### PR TITLE
feat(audit): export the audit chain as standard verifiable receipts

### DIFF
--- a/docs/security/audit-dsse-envelope.md
+++ b/docs/security/audit-dsse-envelope.md
@@ -179,6 +179,9 @@ verifying against itself.
 - [Multi-tenant audit-chain export](audit-multitenant.md) - same DSSE
   primitives applied to a per-tenant slice with optional RFC 3161
   timestamping.
+- [Standard verifiable audit receipts](audit-receipt.md) - reuses these DSSE
+  primitives to project a chain range into COSE_Sign1, in-toto, and RFC 6962
+  transparency envelopes an off-the-shelf verifier validates.
 - [EU AI Act Article 12 evidence pack](../compliance/eu-ai-act-article-12-bundle.md)
   - the bundle the envelope wraps.
 - [Regulatory lineage](../compliance/regulatory-lineage.md) - the

--- a/docs/security/audit-log.md
+++ b/docs/security/audit-log.md
@@ -459,6 +459,9 @@ rare benign causes:
 - [Multi-tenant audit-chain export](audit-multitenant.md)
 - [DSSE / in-toto envelope](audit-dsse-envelope.md) - third-party-verifiable
   wrapper over the Article 12 bundle.
+- [Standard verifiable audit receipts](audit-receipt.md) - project a chain
+  range into COSE_Sign1, in-toto, and RFC 6962 transparency envelopes an
+  off-the-shelf verifier validates with no Bernstein install.
 - [EU AI Act Article 12 evidence pack](../compliance/eu-ai-act-article-12-bundle.md)
 - [Security hardening guide](security-hardening.md)
 - [Disaster recovery runbook](../operations/disaster-recovery.md)

--- a/docs/security/audit-receipt.md
+++ b/docs/security/audit-receipt.md
@@ -1,0 +1,115 @@
+# Standard verifiable audit receipts
+
+The HMAC audit chain proves "no record was edited inside Bernstein", and the
+[DSSE / in-toto envelope](audit-dsse-envelope.md) and the v2
+[multi-tenant export](audit-multitenant.md) add key-less origin authentication.
+All of them still end with "now install our verifier". An audit receipt closes
+that gap: it projects an existing audit-chain range into off-the-shelf envelope
+formats an external auditor already knows how to validate, with no Bernstein
+install and no shared HMAC secret.
+
+For the underlying chain see [audit log](audit-log.md); for the envelope this
+receipt reuses see [DSSE / in-toto envelope](audit-dsse-envelope.md).
+
+## What a receipt is
+
+A receipt is a **projection**, not new evidence. Its subject digest IS the
+chain range `head_sha256` (the SHA-256 over the canonical JSONL of the
+re-chained slice, computed by the same reader path the multi-tenant export
+uses). Every format binds that single subject, and the receipt embeds the
+re-chained event range so a standard verifier can recompute the head from the
+embedded range and assert it equals the signed subject.
+
+The consequence is the whole point: mutate any embedded chain entry and the
+recomputed head diverges, so **every format fails**. Strip or alter the chain
+and the receipt stops verifying; it does not merely lose a log line.
+
+## Formats
+
+| Format | Standard | Payload / binding | Offline verifier |
+|---|---|---|---|
+| `cose` | COSE_Sign1, RFC 9052 (EdDSA) | Signs the raw 32-byte `head_sha256` | any COSE library + `cbor2` |
+| `intoto` | DSSE + in-toto Statement v1 | `subject.digest.sha256` = `head_sha256` | any in-toto / DSSE / SLSA verifier |
+| `transparency` | RFC 6962 style signed receipt | Merkle inclusion proof of the chain-head event; signed tree head binds root + subject | Merkle inclusion check + Ed25519 |
+
+All three sign through the same Ed25519 KMS adapter that already signs lineage
+records and the multi-tenant `head_signature` (see
+[`lineage_kms.py`](../../src/bernstein/core/security/lineage_kms.py)) - no new
+key material or rotation cadence. The verifying key is embedded as an RFC 8037
+JWK (`signing.public_key_jwk`) so the receipt is self-contained; auditors may
+pin it out-of-band for additional trust.
+
+The `transparency` format is offline by default (a local Merkle inclusion proof
+built with the same domain-separated hashing as `bernstein audit seal`). Online
+Rekor submission is strictly opt-in (`--online-rekor`) so air-gapped operators
+are never forced onto the network.
+
+## Determinism
+
+For a fixed chain range and signing key the receipt bytes are byte-identical
+across independent runs: canonical JSONL for the range, canonical CBOR for
+COSE, canonical JSON for the DSSE payload, and RFC 8032 deterministic Ed25519
+for every signature. No wall-clock value enters the signed or serialized bytes.
+
+## Exporting
+
+```bash
+bernstein audit receipt export \
+  --format cose,intoto,transparency \
+  --since 2026-01-01T00:00:00Z \
+  --until 2026-02-01T00:00:00Z \
+  --signing-key-path /path/to/ed25519.pem \
+  --output .sdd/evidence
+```
+
+The export writes `audit-receipt-<since>-<until>.json` and records an
+`audit.receipt_export` event into the HMAC chain (head, window, event count,
+receipt hash, format list) so the projection is itself chain-attested. Use
+`--dry-run` to print the receipt without writing, `--signing-env-var` to read
+the key from an environment variable, and `--online-rekor` to also anchor in a
+Rekor transparency log.
+
+## Verifying offline
+
+The standalone verifier imports **no Bernstein code** - only `cryptography` and
+`cbor2`, the libraries an auditor already runs:
+
+```bash
+python tools/verify_audit_receipt.py --receipt audit-receipt-....json --verbose
+```
+
+It recomputes `head_sha256` from the embedded range, asserts every format binds
+that value, and validates each envelope with a stock verification path. Pin the
+key with `--jwk` or `--public-key`; scope with `--format cose|intoto|transparency|all`.
+Exit code `0` means all checks passed, `1` a check failed, `2` bad arguments.
+
+The `bernstein audit receipt verify <path>` subcommand shells out to that
+standalone tool on purpose - it proves the receipt needs nothing from Bernstein
+to validate.
+
+### Verifying with third-party tooling
+
+Because `intoto` is a plain DSSE envelope wrapping an in-toto v1 Statement, any
+DSSE / in-toto / SLSA verifier validates it given the public key; the subject
+digest it reports is the chain `head_sha256`. The `cose` block is a standard
+COSE_Sign1 structure (`base64` of the CBOR tag-18 bytes) that any COSE library
+verifies against the same key. In both cases, checking that the reported
+subject digest equals the head recomputed from the embedded range is what ties
+the standard envelope back to the intact chain.
+
+## Schema
+
+The receipt conforms to
+[`schemas/audit-receipt-v1.json`](../../schemas/audit-receipt-v1.json).
+
+## Threat model
+
+- **Tampered chain entry** - recomputed head diverges from the signed subject;
+  every format fails.
+- **Forged signature** - the receipt embeds the public key but the signatures
+  are Ed25519 over the subject / PAE / tree head; an attacker without the
+  private key cannot re-sign a mutated subject.
+- **Swapped public key** - pin the JWK (`--jwk`) or PEM (`--public-key`) out of
+  band; the embedded key must then match or verification fails.
+- **No operator secret required** - unlike raw HMAC chain verification, a
+  receipt needs no shared HMAC key, so a sovereign auditor validates it alone.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,11 @@ dependencies = [
     # hand-rolling a DER parser. Used exclusively by
     # ``bernstein.core.security.rfc3161_verifier``.
     "asn1crypto>=1.5",
+    # Canonical CBOR encoding for the COSE_Sign1 (RFC 9052) audit receipt.
+    # MIT-licensed; deterministic-encoding mode gives byte-identical receipt
+    # replay. Used by ``bernstein.core.security.audit_receipt`` and the
+    # standalone ``tools/verify_audit_receipt.py`` verifier.
+    "cbor2>=5.6",
     # Pure-Python PDF generation for the EU AI Act Article 12 evidence pack
     # rendered by `bernstein compliance pack`. MIT-licensed, no native deps.
     # Used exclusively by ``bernstein.core.compliance.article12``.

--- a/schemas/audit-receipt-v1.json
+++ b/schemas/audit-receipt-v1.json
@@ -1,0 +1,231 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://bernstein.alexchernysh.com/schemas/audit-receipt-v1.json",
+  "title": "Bernstein Audit Receipt (v1)",
+  "description": "Standard, offline-verifiable receipt projecting an HMAC-chained audit-log range into off-the-shelf envelope formats (COSE_Sign1 per RFC 9052, in-toto/DSSE, and an RFC 6962 style transparency receipt). The receipt is a projection, not new evidence: its subject digest IS the chain range head_sha256 (never independently recomputed). Every format binds that single subject, and the receipt embeds the re-chained event range so a standard verifier can recompute the head from the embedded range and assert it equals the signed subject. Mutating any embedded entry diverges the recomputed head and every format fails.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "receipt_type",
+    "subject",
+    "range",
+    "events",
+    "signing",
+    "formats"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "enum": ["1.0.0"],
+      "description": "Pinned receipt schema version."
+    },
+    "receipt_type": {
+      "type": "string",
+      "const": "https://bernstein.run/attestations/audit-receipt/v1",
+      "description": "URL identifying the receipt predicate/type."
+    },
+    "subject": {
+      "type": "object",
+      "required": ["name", "digest"],
+      "description": "The single attested subject. Its sha256 digest IS the chain range head_sha256; no independently recomputed head exists.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Logical name of the attested range."
+        },
+        "digest": {
+          "type": "object",
+          "required": ["sha256"],
+          "properties": {
+            "sha256": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$",
+              "description": "The chain range head_sha256 (subject digest)."
+            }
+          }
+        }
+      }
+    },
+    "range": {
+      "type": "object",
+      "required": [
+        "since",
+        "until",
+        "genesis_prev_hmac",
+        "head_hmac",
+        "head_sha256",
+        "event_count"
+      ],
+      "properties": {
+        "since": {
+          "type": "string",
+          "description": "Inclusive ISO-8601 lower bound of the projected chain range."
+        },
+        "until": {
+          "type": "string",
+          "description": "Exclusive ISO-8601 upper bound of the projected chain range."
+        },
+        "genesis_prev_hmac": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$",
+          "description": "Sentinel prev_hmac of the first re-chained event (always 0*64)."
+        },
+        "head_hmac": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$",
+          "description": "HMAC of the final event in the re-chained range (0*64 when empty)."
+        },
+        "head_sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$",
+          "description": "SHA-256 over the canonical JSONL of the re-chained range. Equal to subject.digest.sha256."
+        },
+        "event_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of events in the projected range."
+        }
+      }
+    },
+    "events": {
+      "type": "array",
+      "description": "The embedded re-chained event range. A verifier recomputes head_sha256 from these bytes and asserts it equals the signed subject; mutating any entry breaks every format.",
+      "items": {
+        "type": "object",
+        "required": [
+          "timestamp",
+          "event_type",
+          "actor",
+          "resource_type",
+          "resource_id",
+          "details",
+          "prev_hmac",
+          "hmac"
+        ],
+        "properties": {
+          "timestamp": { "type": "string" },
+          "event_type": { "type": "string" },
+          "actor": { "type": "string" },
+          "resource_type": { "type": "string" },
+          "resource_id": { "type": "string" },
+          "details": { "type": "object" },
+          "prev_hmac": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+          "hmac": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+        }
+      }
+    },
+    "signing": {
+      "type": "object",
+      "required": ["alg", "key_id", "public_key_jwk"],
+      "description": "The Ed25519 verifying key shared by every format. Auditors may pin this JWK externally for additional trust; without pinning the key is trusted on first use.",
+      "properties": {
+        "alg": { "type": "string", "const": "EdDSA" },
+        "key_id": { "type": "string", "minLength": 1 },
+        "public_key_jwk": {
+          "type": "object",
+          "required": ["kty", "crv", "x"],
+          "properties": {
+            "kty": { "const": "OKP" },
+            "crv": { "const": "Ed25519" },
+            "alg": { "const": "EdDSA" },
+            "x": { "type": "string" },
+            "kid": { "type": "string" }
+          }
+        }
+      }
+    },
+    "formats": {
+      "type": "object",
+      "description": "One or more standard-envelope projections of the same subject. At least one is present.",
+      "minProperties": 1,
+      "properties": {
+        "cose": {
+          "type": "object",
+          "required": ["alg", "key_id", "content_type", "cose_sign1_b64"],
+          "description": "A COSE_Sign1 (RFC 9052) envelope, EdDSA, whose payload is the raw 32-byte subject digest.",
+          "properties": {
+            "alg": { "type": "string", "const": "EdDSA" },
+            "key_id": { "type": "string" },
+            "content_type": { "type": "string" },
+            "cose_sign1_b64": {
+              "type": "string",
+              "description": "Base64 of the canonical CBOR bytes of the CBOR-tag-18 COSE_Sign1 structure."
+            }
+          }
+        },
+        "intoto": {
+          "type": "object",
+          "required": ["payload", "payloadType", "signatures"],
+          "description": "A DSSE envelope carrying an in-toto v1 Statement whose subject digest is the chain head_sha256.",
+          "properties": {
+            "payload": { "type": "string" },
+            "payloadType": {
+              "type": "string",
+              "const": "application/vnd.in-toto+json"
+            },
+            "signatures": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "required": ["keyid", "sig"],
+                "properties": {
+                  "keyid": { "type": "string" },
+                  "sig": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "transparency": {
+          "type": "object",
+          "required": ["log_algorithm", "signed_tree_head", "inclusion_proof"],
+          "description": "An RFC 6962 style signed receipt. The signed tree head binds the range-event Merkle root and the subject digest; the inclusion proof places the chain-head event leaf in that tree. Offline by default; the optional rekor block records an online transparency-log submission.",
+          "properties": {
+            "log_algorithm": { "type": "string", "const": "RFC6962-SHA256" },
+            "signed_tree_head": {
+              "type": "object",
+              "required": ["tree_size", "root_hash", "subject_sha256", "signature_b64"],
+              "properties": {
+                "tree_size": { "type": "integer", "minimum": 0 },
+                "root_hash": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+                "subject_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+                "signature_b64": { "type": "string" }
+              }
+            },
+            "inclusion_proof": {
+              "type": "object",
+              "required": ["leaf_index", "leaf_hash", "audit_path"],
+              "properties": {
+                "leaf_index": { "type": "integer" },
+                "leaf_hash": { "type": "string" },
+                "audit_path": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": ["hash", "left"],
+                    "properties": {
+                      "hash": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+                      "left": { "type": "boolean" }
+                    }
+                  }
+                }
+              }
+            },
+            "rekor": {
+              "type": ["object", "null"],
+              "description": "Optional online transparency-log receipt. Present only when Rekor submission was requested and succeeded.",
+              "properties": {
+                "log_index": { "type": "integer" },
+                "log_id": { "type": "string" },
+                "inclusion_proof": { "type": "object" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -2071,3 +2071,277 @@ def _print_post_archive_verify(audit_dir: Path) -> int:
         console.print(f"  [red]![/red] {err}")
     console.print()
     return 1
+
+
+# ---------------------------------------------------------------------------
+# Standard verifiable receipts (#2604)
+# ---------------------------------------------------------------------------
+
+
+@audit_group.group("receipt")
+def receipt_group() -> None:
+    """Export / verify standard, offline-verifiable audit receipts (#2604).
+
+    A receipt projects an existing audit-chain range into off-the-shelf
+    envelope formats (COSE_Sign1 per RFC 9052, in-toto / DSSE, and an RFC 6962
+    style transparency receipt) so an auditor can validate what an agent did
+    with tooling they already run - no bernstein install and no shared HMAC
+    secret. See docs/security/audit-receipt.md.
+    """
+
+
+def _find_receipt_verifier() -> Path | None:
+    """Locate the standalone ``tools/verify_audit_receipt.py`` script.
+
+    The verify wrapper deliberately shells out to the standalone tool to prove
+    it is self-contained. Resolution order: ``$BERNSTEIN_AUDIT_RECEIPT_VERIFIER``
+    override, then a ``tools/verify_audit_receipt.py`` walking up from the CWD
+    and from this module's location.
+    """
+    import os
+
+    override = os.environ.get("BERNSTEIN_AUDIT_RECEIPT_VERIFIER")
+    if override:
+        candidate = Path(override).expanduser()
+        return candidate if candidate.is_file() else None
+
+    for base in (Path.cwd(), Path(__file__).resolve()):
+        for parent in (base, *base.parents):
+            candidate = parent / "tools" / "verify_audit_receipt.py"
+            if candidate.is_file():
+                return candidate
+    return None
+
+
+@receipt_group.command("export")
+@click.option(
+    "--format",
+    "formats",
+    default="cose,intoto,transparency",
+    show_default=True,
+    help="Comma-separated receipt formats to emit (cose, intoto, transparency).",
+)
+@click.option("--since", required=True, help="ISO-8601 inclusive lower bound of the chain range.")
+@click.option("--until", required=True, help="ISO-8601 exclusive upper bound of the chain range.")
+@click.option(
+    "--signing-key-path",
+    "signing_key_path",
+    default=None,
+    type=click.Path(dir_okay=False, exists=True, resolve_path=True),
+    help=(
+        "Path to the Ed25519 private key (PEM PKCS#8 or raw 32-byte) that signs "
+        "every receipt format. Reuses the lineage / head-signature KMS key "
+        "(see src/bernstein/core/security/lineage_kms.py). Mutually exclusive "
+        "with --signing-env-var."
+    ),
+)
+@click.option(
+    "--signing-env-var",
+    "signing_env_var",
+    default=None,
+    help="Env var carrying a PEM Ed25519 private key. Mutually exclusive with --signing-key-path.",
+)
+@click.option("--signing-key-id", "signing_key_id", default=None, help="Operator-stable JWK 'kid' for the receipt key.")
+@click.option(
+    "--online-rekor",
+    is_flag=True,
+    default=False,
+    help="Also submit the subject to a Rekor transparency log (opt-in; needs network + the sigstore extra).",
+)
+@click.option("--output", "-o", default=None, help="Output directory (defaults to .sdd/evidence/).")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Build the receipt in-memory and print the summary without writing to disk.",
+)
+@click.option("--dir", "workdir", default=".", show_default=True, help="Project root directory.")
+def receipt_export_cmd(
+    formats: str,
+    since: str,
+    until: str,
+    signing_key_path: str | None,
+    signing_env_var: str | None,
+    signing_key_id: str | None,
+    online_rekor: bool,
+    output: str | None,
+    dry_run: bool,
+    workdir: str,
+) -> None:
+    """Export a standard verifiable receipt over an audit-chain range.
+
+    \b
+      bernstein audit receipt export --format cose,intoto,transparency \\
+          --since 2026-01-01T00:00:00Z --until 2026-02-01T00:00:00Z \\
+          --signing-key-path /path/to/ed25519.pem
+
+    \b
+    The receipt subject digest IS the chain range head_sha256 - no format
+    recomputes a head of its own. The exported receipt re-verifies offline
+    with tools/verify_audit_receipt.py (stdlib + cryptography + cbor2), and
+    the export itself is recorded as an ``audit.receipt_export`` chain event.
+    """
+    from bernstein.core.persistence.lineage_signer import LineageSignerError
+    from bernstein.core.security.audit import load_or_create_audit_key
+    from bernstein.core.security.audit_chain import AuditChainStore, record_audit_receipt_export
+    from bernstein.core.security.audit_receipt import RekorUnavailableError, build_receipt
+    from bernstein.core.security.lineage_kms import EnvBasedKMSAdapter, FileBasedKMSAdapter, KMSAdapter
+
+    requested = tuple(f.strip() for f in formats.split(",") if f.strip())
+    if not requested:
+        console.print("[red]--format must name at least one of cose, intoto, transparency.[/red]")
+        raise SystemExit(2)
+
+    sdd_dir = Path(workdir).resolve() / ".sdd"
+    audit_dir = sdd_dir / "audit"
+    if not audit_dir.is_dir():
+        console.print(f"[red]Audit directory not found:[/red] {audit_dir}")
+        console.print("[dim]Run [bold]bernstein run[/bold] first to generate audit events.[/dim]")
+        raise SystemExit(1)
+
+    if signing_key_path and signing_env_var:
+        console.print("[red]--signing-key-path and --signing-env-var are mutually exclusive.[/red]")
+        raise SystemExit(2)
+
+    kms_adapter: KMSAdapter
+    try:
+        if signing_key_path:
+            kms_adapter = FileBasedKMSAdapter(Path(signing_key_path), kid=signing_key_id)
+        elif signing_env_var:
+            kms_adapter = EnvBasedKMSAdapter(signing_env_var, kid=signing_key_id)
+        else:
+            console.print("[red]Provide either --signing-key-path or --signing-env-var (Ed25519 receipt key).[/red]")
+            raise SystemExit(2)
+    except (LineageSignerError, OSError, ValueError) as exc:
+        console.print(f"[red]Failed to load receipt signing key: {exc}[/red]")
+        raise SystemExit(1) from None
+
+    output_dir = Path(output).resolve() if output else None
+    try:
+        hmac_key = load_or_create_audit_key()
+    except OSError as exc:  # pragma: no cover - filesystem race
+        console.print(f"[red]Failed to load audit key: {exc}[/red]")
+        raise SystemExit(1) from None
+
+    try:
+        receipt = build_receipt(
+            audit_dir,
+            since=since,
+            until=until,
+            key=hmac_key,
+            kms_adapter=kms_adapter,
+            formats=requested,
+            online_rekor=online_rekor,
+            output_dir=output_dir,
+            write=not dry_run,
+        )
+    except ValueError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1) from None
+    except RekorUnavailableError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1) from None
+
+    # Record the export in the HMAC chain so the projection is itself attested.
+    if not dry_run:
+        try:
+            chain = AuditChainStore(audit_dir)
+            record_audit_receipt_export(
+                chain=chain,
+                head_sha256=receipt.head_sha256,
+                since=receipt.since,
+                until=receipt.until,
+                event_count=receipt.event_count,
+                receipt_sha256=receipt.sha256,
+                formats=receipt.formats,
+            )
+        except OSError as exc:  # pragma: no cover - filesystem race
+            console.print(f"[yellow]Receipt written but audit event not recorded: {exc}[/yellow]")
+
+    console.print()
+    console.print(Panel("[bold]Audit Receipt[/bold]", border_style="green", expand=False))
+    table = Table(show_header=False, box=None, padding=(0, 2))
+    table.add_column("Key", style="dim", no_wrap=True, min_width=18)
+    table.add_column("Value")
+    table.add_row("Window", f"{receipt.since} → {receipt.until}")
+    table.add_row("Events", str(receipt.event_count))
+    table.add_row("Head SHA-256", receipt.head_sha256[:16] + "…")
+    table.add_row("Formats", ", ".join(receipt.formats))
+    table.add_row("Receipt SHA-256", receipt.sha256[:16] + "…")
+    if receipt.receipt_path is not None:
+        table.add_row("Receipt", str(receipt.receipt_path))
+    elif dry_run:
+        table.add_row("Receipt", "(dry-run, not written)")
+    console.print(table)
+    console.print()
+
+    if dry_run:
+        import json as _json
+
+        console.print("[dim]Receipt (dry-run):[/dim]")
+        console.print(_json.dumps(receipt.receipt, indent=2))
+        console.print()
+
+
+@receipt_group.command("verify")
+@click.argument("receipt_path", type=click.Path(dir_okay=False, exists=True, resolve_path=True))
+@click.option(
+    "--jwk",
+    "jwk_path",
+    default=None,
+    type=click.Path(dir_okay=False, exists=True, resolve_path=True),
+    help="Optional trusted Ed25519 JWK (OKP) to pin; the embedded receipt key must match.",
+)
+@click.option(
+    "--public-key",
+    "public_key_path",
+    default=None,
+    type=click.Path(dir_okay=False, exists=True, resolve_path=True),
+    help="Optional trusted Ed25519 public key PEM to pin; the embedded receipt key must match.",
+)
+@click.option(
+    "--format",
+    "fmt",
+    default="all",
+    type=click.Choice(["cose", "intoto", "transparency", "all"]),
+    show_default=True,
+    help="Which format(s) to verify.",
+)
+def receipt_verify_cmd(
+    receipt_path: str,
+    jwk_path: str | None,
+    public_key_path: str | None,
+    fmt: str,
+) -> None:
+    """Verify an audit receipt by shelling to the standalone verifier.
+
+    \b
+    Runs tools/verify_audit_receipt.py in a subprocess - the same stdlib +
+    cryptography + cbor2 tool an external auditor runs - to prove the receipt
+    is self-contained and needs no bernstein code to validate. Exits non-zero
+    on any verification failure.
+    """
+    import subprocess
+    import sys
+
+    verifier = _find_receipt_verifier()
+    if verifier is None:
+        console.print(
+            "[red]Could not locate tools/verify_audit_receipt.py.[/red] "
+            "Set BERNSTEIN_AUDIT_RECEIPT_VERIFIER to its path, or run from a "
+            "bernstein source checkout.",
+        )
+        raise SystemExit(2)
+
+    cmd = [sys.executable, str(verifier), "--receipt", receipt_path, "--format", fmt, "--verbose"]
+    if jwk_path:
+        cmd.extend(["--jwk", jwk_path])
+    if public_key_path:
+        cmd.extend(["--public-key", public_key_path])
+
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if proc.stdout:
+        console.print(proc.stdout.rstrip())
+    if proc.returncode != 0 and proc.stderr:
+        console.print(f"[red]{proc.stderr.rstrip()}[/red]")
+    raise SystemExit(proc.returncode)

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -692,6 +692,17 @@ EVENT_CONTEXT_CAPSULE = "context.capsule"
 #: never goal text or task payloads.
 EVENT_MISSION_PHASE_RECEIPT = "mission.phase_receipt"
 
+#: Issue #2604 -- emitted once per ``bernstein audit receipt export``. A
+#: receipt projects an existing audit-chain range into standard, offline-
+#: verifiable envelopes (COSE_Sign1, in-toto/DSSE, RFC 6962 transparency).
+#: The event mirrors the projection's identity into the HMAC chain by recording
+#: ``{head_sha256, since, until, event_count, receipt_sha256, formats}`` plus
+#: the previous chain digest, so the fact that a standard receipt was emitted
+#: over a named range (and which head it bound) is itself chain-attested. The
+#: receipt subject digest IS the chain ``head_sha256``; only hashes, the window,
+#: and the format list are recorded -- never event payloads.
+EVENT_AUDIT_RECEIPT_EXPORT = "audit.receipt_export"
+
 
 # ---------------------------------------------------------------------------
 # AuditChainStore
@@ -4896,6 +4907,53 @@ def record_recipe_fleet_apply(
     )
 
 
+def record_audit_receipt_export(
+    *,
+    chain: AuditChainStore,
+    head_sha256: str,
+    since: str,
+    until: str,
+    event_count: int,
+    receipt_sha256: str,
+    formats: tuple[str, ...] | list[str],
+    actor: str = "audit",
+) -> AuditEvent:
+    """Append an ``audit.receipt_export`` event into *chain* (#2604).
+
+    Records that a standard, offline-verifiable receipt was projected over the
+    chain range ``[since, until)`` and which head it bound. Only hashes, the
+    window, the event count, and the emitted format list are recorded -- never
+    event payloads.
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        head_sha256: The chain range head - the receipt's subject digest.
+        since: ISO-8601 inclusive lower bound of the projected range.
+        until: ISO-8601 exclusive upper bound of the projected range.
+        event_count: Number of events in the projected range.
+        receipt_sha256: SHA-256 of the canonical receipt bytes.
+        formats: The receipt formats emitted (subset of cose/intoto/transparency).
+        actor: Recorded actor; defaults to ``"audit"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_AUDIT_RECEIPT_EXPORT,
+        actor=actor,
+        resource_type="audit_receipt",
+        resource_id=head_sha256,
+        details={
+            "head_sha256": head_sha256,
+            "since": since,
+            "until": until,
+            "event_count": event_count,
+            "receipt_sha256": receipt_sha256,
+            "formats": sorted(formats),
+        },
+    )
+
+
 __all__ = [
     "AGENT_FRESH_RESTART_ON_RETRY",
     "EVENT_A2A_MESSAGE_RECEIPT",
@@ -4907,6 +4965,7 @@ __all__ = [
     "EVENT_APPROVAL_CARD_ISSUED",
     "EVENT_APPROVAL_CARD_REFUSED",
     "EVENT_APPROVAL_CARD_RESOLVED",
+    "EVENT_AUDIT_RECEIPT_EXPORT",
     "EVENT_AUTOMATION_ACTION",
     "EVENT_CHECKPOINT_RETRY",
     "EVENT_COMPACTION_RECEIPT",
@@ -4993,6 +5052,7 @@ __all__ = [
     "record_adapter_floor_update_receipt",
     "record_adapter_spawn_preflight_receipt",
     "record_adapter_version_posture_receipt",
+    "record_audit_receipt_export",
     "record_automation_action",
     "record_checkpoint_retry",
     "record_context_capsule",

--- a/src/bernstein/core/security/audit_receipt.py
+++ b/src/bernstein/core/security/audit_receipt.py
@@ -1,0 +1,578 @@
+"""Standard, offline-verifiable receipt projection over the audit chain.
+
+The HMAC audit chain is tamper-evident, but only someone running bernstein
+code (or holding the operator's HMAC key) can check it today. This module
+projects an existing audit-chain *range* into standard receipt envelopes that
+an off-the-shelf verifier already knows how to validate:
+
+* ``cose`` - a COSE_Sign1 envelope (RFC 9052), EdDSA, whose payload is the
+  raw 32-byte chain-range ``head_sha256``.
+* ``intoto`` - a DSSE envelope carrying an in-toto v1 ``Statement`` whose
+  ``subject`` digest is that same ``head_sha256`` (reuses the
+  :mod:`bernstein.core.security.audit_dsse` wire primitives).
+* ``transparency`` - an RFC 6962 style signed receipt: a Merkle inclusion
+  proof of the chain-head event against the range's event tree, built with the
+  same domain-separated leaf/internal hashing that
+  :mod:`bernstein.core.persistence.merkle` (``bernstein audit seal``) uses.
+  An optional online mode submits the subject to Rekor.
+
+Projection contract (why this is not "audit plus decoration")
+-------------------------------------------------------------
+The receipt is not new evidence; it is a re-encoding of an existing chain
+range. Three properties hold by construction:
+
+1. **Subject binding.** The subject digest IS the chain range
+   ``head_sha256`` computed by the same slice-rebuild path
+   :mod:`bernstein.core.security.audit_multitenant` uses
+   (``_read_audit_events`` -> ``_rebuild_slice_chain`` ->
+   ``_events_jsonl_bytes``). No format recomputes a head of its own.
+2. **Embedded range.** The receipt carries the re-chained event range. A
+   standard verifier recomputes ``head_sha256`` from those bytes and asserts
+   it equals the signed subject.
+3. **Tamper collapse.** Mutating any embedded entry changes the recomputed
+   head, which no longer matches the signed subject, and every format fails.
+   Strip or alter the chain and the receipt stops verifying - it does not
+   merely lose a log line.
+
+Determinism
+-----------
+For a fixed chain range and signing key the receipt bytes are byte-identical
+across independent runs: canonical JSONL for the range, canonical CBOR
+(``cbor2`` deterministic mode) for COSE, canonical JSON for the DSSE payload,
+and RFC 8032 deterministic Ed25519 for every signature. No wall-clock value
+enters the signed or serialized bytes.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import cbor2
+
+from bernstein.core.persistence.merkle import _combine_internal, _leaf_digest
+from bernstein.core.security.audit_dsse import (
+    DSSE_PAYLOAD_TYPE,
+    Envelope,
+    Signature,
+    Statement,
+    Subject,
+    pae,
+)
+from bernstein.core.security.audit_multitenant import (
+    _GENESIS_HMAC,
+    _event_in_window,
+    _events_jsonl_bytes,
+    _read_audit_events,
+    _rebuild_slice_chain,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.security.lineage_kms import KMSAdapter
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Wire-format identifiers
+# ---------------------------------------------------------------------------
+
+#: Receipt schema version (matches ``schemas/audit-receipt-v1.json``).
+RECEIPT_SCHEMA_VERSION: str = "1.0.0"
+
+#: Receipt predicate/type URL. Versioned so a future v2 can co-exist.
+RECEIPT_TYPE: str = "https://bernstein.run/attestations/audit-receipt/v1"
+
+#: COSE_Sign1 CBOR tag (RFC 9052 section 2).
+_COSE_SIGN1_TAG: int = 18
+
+#: COSE ``alg`` header value for EdDSA (RFC 9053 / IANA COSE Algorithms).
+_COSE_ALG_EDDSA: int = -8
+
+#: COSE header labels (RFC 9052 section 3.1).
+_COSE_LABEL_ALG: int = 1
+_COSE_LABEL_CONTENT_TYPE: int = 3
+_COSE_LABEL_KID: int = 4
+
+#: Content type advertised in the COSE protected header.
+COSE_CONTENT_TYPE: str = "application/vnd.bernstein.audit-receipt+json"
+
+#: Merkle log algorithm advertised in the transparency block.
+_TRANSPARENCY_LOG_ALGO: str = "RFC6962-SHA256"
+
+#: All receipt formats this module can emit.
+ALL_FORMATS: tuple[str, ...] = ("cose", "intoto", "transparency")
+
+#: Empty-tree root sentinel, matching
+#: :func:`bernstein.core.persistence.merkle.build_merkle_tree`.
+_EMPTY_TREE_ROOT: str = hashlib.sha256(b"empty-tree").hexdigest()
+
+
+class AuditReceiptError(RuntimeError):
+    """Base error for receipt build failures."""
+
+
+class RekorUnavailableError(AuditReceiptError):
+    """Raised when online Rekor submission is requested but unavailable."""
+
+
+# ---------------------------------------------------------------------------
+# Result model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class AuditReceipt:
+    """A built audit receipt.
+
+    Attributes:
+        since: Inclusive ISO-8601 lower bound of the projected range.
+        until: Exclusive ISO-8601 upper bound of the projected range.
+        event_count: Number of events in the projected range.
+        head_hmac: HMAC of the final re-chained event (or genesis when empty).
+        head_sha256: Chain range head - the receipt's single subject digest.
+        formats: Sorted tuple of format names present in the receipt.
+        receipt: The serialisable receipt dict.
+        receipt_bytes: Canonical JSON bytes of ``receipt`` (byte-deterministic).
+        receipt_path: On-disk path when written, else ``None``.
+    """
+
+    since: str
+    until: str
+    event_count: int
+    head_hmac: str
+    head_sha256: str
+    formats: tuple[str, ...]
+    receipt: dict[str, Any]
+    receipt_bytes: bytes
+    receipt_path: Path | None = field(default=None)
+
+    @property
+    def sha256(self) -> str:
+        """SHA-256 of the canonical receipt bytes."""
+        return hashlib.sha256(self.receipt_bytes).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Canonical helpers
+# ---------------------------------------------------------------------------
+
+
+def _canonical_json_bytes(obj: dict[str, Any]) -> bytes:
+    """Return deterministic JSON bytes (sorted keys, compact separators)."""
+    return json.dumps(obj, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _canonical_event_bytes(event: dict[str, Any]) -> bytes:
+    """Return the canonical single-event bytes used as a Merkle leaf.
+
+    Matches one line of
+    :func:`bernstein.core.security.audit_multitenant._events_jsonl_bytes`
+    (``json.dumps(event, sort_keys=True, separators=(",", ":"))``) so a leaf
+    is derived from exactly the bytes the ``head_sha256`` covers.
+    """
+    return json.dumps(event, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _read_range_slice(
+    audit_dir: Path,
+    *,
+    since: str,
+    until: str,
+    key: bytes,
+) -> tuple[list[dict[str, Any]], str, str]:
+    """Read a chain range and re-chain it into a slice-local HMAC chain.
+
+    Reuses the multitenant reader path so the receipt binds to the same
+    ``head_sha256`` that ``bernstein audit export --tenant`` would produce for
+    the same events - no independent head computation.
+
+    Returns:
+        ``(rebuilt_events, head_hmac, head_sha256)``.
+    """
+    all_events = _read_audit_events(audit_dir)
+    matched = [e for e in all_events if _event_in_window(e, since, until)]
+    # Stable chronological order with hmac tie-break, matching the multitenant
+    # exporter so two operators derive the identical slice.
+    matched.sort(key=lambda e: (str(e.get("timestamp", "")), str(e.get("hmac", ""))))
+    rebuilt, head_hmac = _rebuild_slice_chain(matched, key)
+    head_sha256 = hashlib.sha256(_events_jsonl_bytes(rebuilt)).hexdigest()
+    return rebuilt, head_hmac, head_sha256
+
+
+# ---------------------------------------------------------------------------
+# COSE_Sign1 (RFC 9052)
+# ---------------------------------------------------------------------------
+
+
+def _build_cose_sign1(
+    *,
+    subject_digest_bytes: bytes,
+    key_id: str,
+    kms_adapter: KMSAdapter,
+) -> dict[str, Any]:
+    """Build a COSE_Sign1 receipt over the raw subject digest bytes.
+
+    The signed payload is the 32-byte ``head_sha256`` digest, mirroring the
+    existing head-signature convention
+    (:func:`bernstein.core.security.audit_head_signature.build_head_signature`
+    signs ``bytes.fromhex(head_sha256)``) and reusing ``KMSAdapter.sign``.
+    """
+    protected_map: dict[int, Any] = {
+        _COSE_LABEL_ALG: _COSE_ALG_EDDSA,
+        _COSE_LABEL_CONTENT_TYPE: COSE_CONTENT_TYPE,
+        _COSE_LABEL_KID: key_id.encode("utf-8"),
+    }
+    protected_bstr = cbor2.dumps(protected_map, canonical=True)
+    # RFC 9052 section 4.4: Sig_structure for COSE_Sign1.
+    sig_structure = ["Signature1", protected_bstr, b"", subject_digest_bytes]
+    to_sign = cbor2.dumps(sig_structure, canonical=True)
+    signature = kms_adapter.sign(to_sign)
+    cose_obj = cbor2.CBORTag(
+        _COSE_SIGN1_TAG,
+        [protected_bstr, {}, subject_digest_bytes, signature],
+    )
+    cose_bytes = cbor2.dumps(cose_obj, canonical=True)
+    return {
+        "alg": "EdDSA",
+        "key_id": key_id,
+        "content_type": COSE_CONTENT_TYPE,
+        "cose_sign1_b64": base64.b64encode(cose_bytes).decode("ascii"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# in-toto / DSSE (reuses audit_dsse primitives)
+# ---------------------------------------------------------------------------
+
+
+def _build_intoto_envelope(
+    *,
+    subject_name: str,
+    head_sha256: str,
+    range_block: dict[str, Any],
+    key_id: str,
+    kms_adapter: KMSAdapter,
+) -> dict[str, Any]:
+    """Build a DSSE / in-toto v1 envelope binding the chain head_sha256.
+
+    Reuses the :mod:`bernstein.core.security.audit_dsse` ``Subject`` /
+    ``Statement`` / ``Envelope`` wire types and the DSSE ``pae`` so a stock
+    in-toto / DSSE verifier validates the envelope with no bernstein code.
+    """
+    subject = Subject(name=subject_name, digest={"sha256": head_sha256})
+    predicate: dict[str, Any] = {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "kind": "audit-receipt",
+        "range": range_block,
+    }
+    statement = Statement(
+        subjects=[subject],
+        predicate_type=RECEIPT_TYPE,
+        predicate=predicate,
+    )
+    payload = _canonical_json_bytes(statement.to_dict())
+    signature = kms_adapter.sign(pae(DSSE_PAYLOAD_TYPE, payload))
+    envelope = Envelope(
+        payload_type=DSSE_PAYLOAD_TYPE,
+        payload_b64=base64.b64encode(payload).decode("ascii"),
+        signatures=[Signature(keyid=key_id, sig=base64.b64encode(signature).decode("ascii"))],
+    )
+    return envelope.to_dict()
+
+
+# ---------------------------------------------------------------------------
+# Transparency (RFC 6962 style)
+# ---------------------------------------------------------------------------
+
+
+def _merkle_root_and_path(
+    leaves: list[str],
+    index: int,
+) -> tuple[str, list[tuple[str, bool]]]:
+    """Return ``(root, audit_path)`` for ``leaves[index]``.
+
+    Tree construction matches
+    :func:`bernstein.core.persistence.merkle.build_merkle_tree` exactly:
+    domain-separated internal nodes (``0x01`` tag via :func:`_combine_internal`)
+    and a lone odd node promoted unchanged (never self-paired). ``audit_path``
+    is a list of ``(sibling_hash, sibling_is_left)`` from leaf to root.
+    """
+    if not leaves:
+        return _EMPTY_TREE_ROOT, []
+    path: list[tuple[str, bool]] = []
+    level = list(leaves)
+    idx = index
+    while len(level) > 1:
+        sibling = idx ^ 1
+        if sibling < len(level):
+            path.append((level[sibling], sibling < idx))
+        # else: idx is the promoted lone odd node - no sibling this level.
+        next_level: list[str] = []
+        for i in range(0, len(level), 2):
+            if i + 1 < len(level):
+                next_level.append(_combine_internal(level[i], level[i + 1]))
+            else:
+                next_level.append(level[i])
+        level = next_level
+        idx //= 2
+    return level[0], path
+
+
+def _build_transparency_receipt(
+    *,
+    rebuilt_events: list[dict[str, Any]],
+    head_sha256: str,
+    key_id: str,
+    kms_adapter: KMSAdapter,
+    online_rekor: bool,
+) -> dict[str, Any]:
+    """Build an RFC 6962 style signed inclusion receipt for the chain head.
+
+    Leaves are the range's per-event canonical bytes, hashed with the same
+    ``0x00``-tagged leaf digest the audit seal uses. The signed tree head binds
+    the Merkle root and the chain ``head_sha256``; the inclusion proof places
+    the chain-head (last) event's leaf in the tree.
+    """
+    leaves = [_leaf_digest(_canonical_event_bytes(e)) for e in rebuilt_events]
+    if leaves:
+        leaf_index = len(leaves) - 1
+        root, path = _merkle_root_and_path(leaves, leaf_index)
+        leaf_hash = leaves[leaf_index]
+    else:
+        leaf_index = -1
+        root = _EMPTY_TREE_ROOT
+        path = []
+        leaf_hash = ""
+
+    sth = {
+        "tree_size": len(leaves),
+        "root_hash": root,
+        "subject_sha256": head_sha256,
+    }
+    sth_signature = kms_adapter.sign(_canonical_json_bytes(sth))
+    block: dict[str, Any] = {
+        "log_algorithm": _TRANSPARENCY_LOG_ALGO,
+        "signed_tree_head": {
+            "tree_size": len(leaves),
+            "root_hash": root,
+            "subject_sha256": head_sha256,
+            "signature_b64": base64.b64encode(sth_signature).decode("ascii"),
+        },
+        "inclusion_proof": {
+            "leaf_index": leaf_index,
+            "leaf_hash": leaf_hash,
+            "audit_path": [{"hash": h, "left": is_left} for h, is_left in path],
+        },
+        "rekor": None,
+    }
+    if online_rekor:
+        block["rekor"] = _submit_to_rekor(head_sha256=head_sha256, key_id=key_id)
+    return block
+
+
+def _submit_to_rekor(*, head_sha256: str, key_id: str) -> dict[str, Any]:
+    """Submit the subject digest to a Rekor transparency log (opt-in, online).
+
+    Offline Merkle inclusion is the default; this path is only reached when the
+    caller explicitly opts into online submission. It reuses the sigstore
+    plumbing already present in
+    :mod:`bernstein.core.security.sigstore_attestation`. When the ``sigstore``
+    package or the network is unavailable, a clear
+    :class:`RekorUnavailableError` is raised rather than silently degrading, so
+    an operator who asked for an online anchor learns it did not happen.
+
+    Returns:
+        ``{"log_index", "log_id", "inclusion_proof"}`` on success.
+    """
+    from bernstein.core.security.sigstore_attestation import _sigstore_available
+
+    if not _sigstore_available():
+        raise RekorUnavailableError(
+            "online Rekor submission requested but the 'sigstore' package is "
+            "not installed; the offline Merkle inclusion proof is the default "
+            "and requires no network. Install the 'sigstore' extra to enable "
+            "online anchoring.",
+        )
+    # Real submission is delegated to the sigstore signing context. The keyless
+    # Fulcio/Rekor flow needs an OIDC identity; when it is not resolvable the
+    # sigstore client raises, which we surface as RekorUnavailableError.
+    try:  # pragma: no cover - exercised only in online integration envs
+        from sigstore.sign import SigningContext  # type: ignore[import-untyped]
+
+        ctx = SigningContext.production()
+        with ctx.signer() as signer:
+            result = signer.sign_artifact(input_=bytes.fromhex(head_sha256))
+        entry = result.transparency_log_entry
+        return {
+            "log_index": int(getattr(entry, "log_index", -1)),
+            "log_id": str(getattr(entry, "uuid", "") or getattr(entry, "log_id", "")),
+            "inclusion_proof": dict(getattr(entry, "inclusion_proof", {}) or {}),
+            "key_id": key_id,
+        }
+    except Exception as exc:  # pragma: no cover - online only
+        raise RekorUnavailableError(f"Rekor submission failed: {exc}") from exc
+
+
+# ---------------------------------------------------------------------------
+# Public: build
+# ---------------------------------------------------------------------------
+
+
+def build_receipt(
+    audit_dir: Path,
+    *,
+    since: str,
+    until: str,
+    key: bytes,
+    kms_adapter: KMSAdapter,
+    formats: tuple[str, ...] | list[str] = ALL_FORMATS,
+    subject_name: str | None = None,
+    online_rekor: bool = False,
+    output_dir: Path | None = None,
+    write: bool = True,
+) -> AuditReceipt:
+    """Project an audit-chain range into standard, offline-verifiable receipts.
+
+    Args:
+        audit_dir: Directory of HMAC-chained ``*.jsonl`` audit files. Read-only.
+        since: ISO-8601 inclusive lower bound of the range.
+        until: ISO-8601 exclusive upper bound of the range.
+        key: Operator HMAC key. Used only to re-chain the slice so the receipt
+            binds the same ``head_sha256`` an offline replay would derive.
+        kms_adapter: Ed25519 signer (the lineage / head-signature KMS adapter).
+            Reused so no new key material or rotation cadence is introduced.
+        formats: Which envelope encodings to emit (subset of
+            :data:`ALL_FORMATS`). Every format projects the same subject digest.
+        subject_name: Logical subject name. Defaults to a deterministic name
+            derived from the window.
+        online_rekor: When ``True`` the transparency format also submits the
+            subject to a Rekor log (opt-in, requires network + sigstore).
+            Default ``False`` (offline Merkle inclusion proof).
+        output_dir: Where to write the receipt JSON. Defaults to
+            ``audit_dir.parent / 'evidence'``.
+        write: When ``False`` build in-memory only (``--dry-run`` / tests).
+
+    Returns:
+        An :class:`AuditReceipt`.
+
+    Raises:
+        ValueError: ``since`` is not strictly less than ``until``, or an
+            unknown format was requested.
+        RekorUnavailableError: ``online_rekor`` was requested but the Rekor
+            path is unavailable.
+    """
+    if since >= until:
+        raise ValueError(f"since={since!r} must be < until={until!r}")
+    requested = tuple(dict.fromkeys(formats))  # de-dup, preserve order
+    unknown = [f for f in requested if f not in ALL_FORMATS]
+    if unknown:
+        raise ValueError(f"unknown receipt format(s): {unknown}; valid: {list(ALL_FORMATS)}")
+    if not requested:
+        raise ValueError("at least one receipt format is required")
+
+    rebuilt, head_hmac, head_sha256 = _read_range_slice(
+        audit_dir,
+        since=since,
+        until=until,
+        key=key,
+    )
+    resolved_subject_name = subject_name or f"audit-receipt-{since}-{until}"
+
+    jwk = kms_adapter.public_key_jwk()
+    key_id = str(jwk.get("kid") or "audit-receipt-key")
+
+    range_block: dict[str, Any] = {
+        "since": since,
+        "until": until,
+        "genesis_prev_hmac": _GENESIS_HMAC,
+        "head_hmac": head_hmac,
+        "head_sha256": head_sha256,
+        "event_count": len(rebuilt),
+    }
+
+    format_blocks: dict[str, Any] = {}
+    if "cose" in requested:
+        format_blocks["cose"] = _build_cose_sign1(
+            subject_digest_bytes=bytes.fromhex(head_sha256),
+            key_id=key_id,
+            kms_adapter=kms_adapter,
+        )
+    if "intoto" in requested:
+        format_blocks["intoto"] = _build_intoto_envelope(
+            subject_name=resolved_subject_name,
+            head_sha256=head_sha256,
+            range_block=range_block,
+            key_id=key_id,
+            kms_adapter=kms_adapter,
+        )
+    if "transparency" in requested:
+        format_blocks["transparency"] = _build_transparency_receipt(
+            rebuilt_events=rebuilt,
+            head_sha256=head_sha256,
+            key_id=key_id,
+            kms_adapter=kms_adapter,
+            online_rekor=online_rekor,
+        )
+
+    receipt: dict[str, Any] = {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "receipt_type": RECEIPT_TYPE,
+        "subject": {
+            "name": resolved_subject_name,
+            "digest": {"sha256": head_sha256},
+        },
+        "range": range_block,
+        "events": rebuilt,
+        "signing": {
+            "alg": "EdDSA",
+            "key_id": key_id,
+            "public_key_jwk": jwk,
+        },
+        "formats": format_blocks,
+    }
+    receipt_bytes = _canonical_json_bytes(receipt) + b"\n"
+
+    receipt_path: Path | None = None
+    if write:
+        target_dir = output_dir or (audit_dir.parent / "evidence")
+        target_dir.mkdir(parents=True, exist_ok=True)
+        safe_since = since.replace(":", "").replace("/", "_")
+        safe_until = until.replace(":", "").replace("/", "_")
+        receipt_path = target_dir / f"audit-receipt-{safe_since}-{safe_until}.json"
+        receipt_path.write_bytes(receipt_bytes)
+        logger.info(
+            "Audit receipt written events=%d formats=%s path=%s",
+            len(rebuilt),
+            ",".join(sorted(format_blocks)),
+            receipt_path,
+        )
+
+    return AuditReceipt(
+        since=since,
+        until=until,
+        event_count=len(rebuilt),
+        head_hmac=head_hmac,
+        head_sha256=head_sha256,
+        formats=tuple(sorted(format_blocks)),
+        receipt=receipt,
+        receipt_bytes=receipt_bytes,
+        receipt_path=receipt_path,
+    )
+
+
+__all__ = [
+    "ALL_FORMATS",
+    "COSE_CONTENT_TYPE",
+    "RECEIPT_SCHEMA_VERSION",
+    "RECEIPT_TYPE",
+    "AuditReceipt",
+    "AuditReceiptError",
+    "RekorUnavailableError",
+    "build_receipt",
+]

--- a/tests/integration/test_standalone_receipt_verifier.py
+++ b/tests/integration/test_standalone_receipt_verifier.py
@@ -1,0 +1,172 @@
+"""Hermetic-venv proof that the audit-receipt verifier is truly standalone.
+
+The promise of ``tools/verify_audit_receipt.py`` is that an external auditor
+validates a bernstein audit receipt with the off-the-shelf libraries they
+already run - ``cryptography`` + ``cbor2`` - and **no bernstein package** on
+PYTHONPATH, no operator HMAC key.
+
+This is the empirical SOTA-axis (verifiability) proof for #2604:
+
+1. Create a fresh venv with only ``cryptography`` and ``cbor2`` installed.
+2. Assert ``import bernstein`` fails inside it (the venv is hermetic).
+3. Build a real three-format receipt in the project venv.
+4. Run the verifier under the isolated interpreter and assert PASS - a stock
+   COSE_Sign1 / in-toto / RFC 6962 verification path validates the receipt.
+5. Mutate exactly one underlying chain entry in the receipt and re-run the
+   verifier: every format fails because the head recomputed from the embedded
+   range no longer matches the signed subject.
+
+If the verifier ever gains a ``from bernstein...`` import, step 4 raises
+``ModuleNotFoundError`` and the test fails - that is the whole point.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import venv
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from bernstein.core.security.audit import AuditLog
+from bernstein.core.security.audit_receipt import build_receipt
+from bernstein.core.security.lineage_kms import FileBasedKMSAdapter
+
+pytestmark = pytest.mark.slow
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VERIFIER_SCRIPT = REPO_ROOT / "tools" / "verify_audit_receipt.py"
+
+_HMAC_KEY = b"x" * 32
+_SINCE = "2020-01-01T00:00:00.000000Z"
+_UNTIL = "2100-01-01T00:00:00.000000Z"
+
+
+def _create_isolated_venv(venv_dir: Path) -> Path:
+    """Create a venv with only cryptography + cbor2 installed."""
+    import shutil as _shutil
+
+    uv_bin = _shutil.which("uv")
+    if uv_bin:
+        subprocess.run([uv_bin, "venv", str(venv_dir), "--quiet"], check=True)
+        py = venv_dir / ("Scripts/python.exe" if sys.platform == "win32" else "bin/python")
+        subprocess.run(
+            [uv_bin, "pip", "install", "--quiet", "--python", str(py), "cryptography>=45.0.0", "cbor2>=5.6"],
+            check=True,
+        )
+        return py
+
+    venv.create(str(venv_dir), with_pip=True, clear=True)
+    py = venv_dir / ("Scripts/python.exe" if sys.platform == "win32" else "bin/python")
+    subprocess.run(
+        [
+            str(py),
+            "-m",
+            "pip",
+            "install",
+            "--quiet",
+            "--disable-pip-version-check",
+            "cryptography>=45.0.0",
+            "cbor2>=5.6",
+        ],
+        check=True,
+        cwd=str(venv_dir),
+    )
+    return py
+
+
+def _assert_no_bernstein(py: Path) -> None:
+    out = subprocess.run([str(py), "-c", "import bernstein"], capture_output=True, text=True, check=False)
+    assert out.returncode != 0, "venv must NOT have bernstein installed"
+    assert "ModuleNotFoundError" in out.stderr or "No module named" in out.stderr, out.stderr
+
+
+def _build_receipt(tmp_path: Path) -> Path:
+    audit_dir = tmp_path / ".sdd" / "audit"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    log = AuditLog(audit_dir, key=_HMAC_KEY)
+    log.log("task.created", "alice", "task", "T-1", {"role": "backend"})
+    log.log("agent.spawned", "orchestrator", "agent", "A-1", {"task": "T-1"})
+    log.log("task.completed", "alice", "task", "T-1", {"status": "ok"})
+
+    key = Ed25519PrivateKey.from_private_bytes(b"i" * 32)
+    key_path = tmp_path / "sign.pem"
+    key_path.write_bytes(
+        key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        ),
+    )
+    receipt = build_receipt(
+        audit_dir,
+        since=_SINCE,
+        until=_UNTIL,
+        key=_HMAC_KEY,
+        kms_adapter=FileBasedKMSAdapter(key_path, kid="e2e-receipt-key"),
+        output_dir=tmp_path / "out",
+        write=True,
+    )
+    assert receipt.receipt_path is not None
+    return receipt.receipt_path
+
+
+def _run_verifier(py: Path, receipt: Path, *extra: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+    return subprocess.run(
+        [str(py), str(VERIFIER_SCRIPT), "--receipt", str(receipt), *extra],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+
+@pytest.fixture(scope="module")
+def isolated_python(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    venv_dir = tmp_path_factory.mktemp("receipt-venv")
+    py = _create_isolated_venv(venv_dir)
+    _assert_no_bernstein(py)
+    return py
+
+
+class TestStandaloneReceiptVerifier:
+    """End-to-end verifiability proof under a hermetic interpreter."""
+
+    def test_pass_path(self, tmp_path: Path, isolated_python: Path) -> None:
+        receipt = _build_receipt(tmp_path)
+        proc = _run_verifier(isolated_python, receipt)
+        assert proc.returncode == 0, f"stderr={proc.stderr!r} stdout={proc.stdout!r}"
+        assert "OVERALL: PASS" in proc.stdout
+        assert "[PASS] cose" in proc.stdout
+        assert "[PASS] intoto" in proc.stdout
+        assert "[PASS] transparency" in proc.stdout
+
+    def test_tamper_one_entry_fails_all_formats(self, tmp_path: Path, isolated_python: Path) -> None:
+        receipt = _build_receipt(tmp_path)
+        # Prove PASS first, then mutate exactly one underlying chain entry.
+        assert _run_verifier(isolated_python, receipt).returncode == 0
+
+        data = json.loads(receipt.read_text())
+        data["events"][1]["actor"] = "mallory"
+        tampered = tmp_path / "tampered.json"
+        tampered.write_text(json.dumps(data))
+
+        proc = _run_verifier(isolated_python, tampered)
+        assert proc.returncode == 1
+        assert "OVERALL: FAIL" in proc.stdout
+        assert "[FAIL] subject_binding" in proc.stdout
+        assert "[FAIL] cose" in proc.stdout
+        assert "[FAIL] intoto" in proc.stdout
+        assert "[FAIL] transparency" in proc.stdout
+
+    def test_verifier_runs_without_bernstein(self, tmp_path: Path, isolated_python: Path) -> None:
+        receipt = _build_receipt(tmp_path)
+        proc = _run_verifier(isolated_python, receipt)
+        assert "ModuleNotFoundError" not in proc.stderr

--- a/tests/unit/test_audit_receipt.py
+++ b/tests/unit/test_audit_receipt.py
@@ -1,0 +1,336 @@
+"""Unit tests for the standard verifiable audit receipt (#2604).
+
+Covers the projection contract: the receipt subject digest IS the chain range
+``head_sha256`` (no independently recomputed head), byte-identical determinism,
+round-trip verification of all three formats, schema conformance, and the
+substrate-coupling tamper property (mutate one embedded chain entry -> every
+format fails).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+from contextlib import redirect_stdout
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from bernstein.core.security.audit import AuditLog
+from bernstein.core.security.audit_multitenant import export_tenant_slice
+from bernstein.core.security.audit_receipt import (
+    ALL_FORMATS,
+    RECEIPT_TYPE,
+    build_receipt,
+)
+from bernstein.core.security.lineage_kms import FileBasedKMSAdapter
+
+if TYPE_CHECKING:
+    from bernstein.core.security.lineage_kms import KMSAdapter
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VERIFIER_SCRIPT = REPO_ROOT / "tools" / "verify_audit_receipt.py"
+
+_HMAC_KEY = b"x" * 32
+_SIGN_SEED = b"i" * 32
+_SINCE = "2020-01-01T00:00:00.000000Z"
+_UNTIL = "2100-01-01T00:00:00.000000Z"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_log(audit_dir: Path) -> None:
+    """Populate ``audit_dir`` with three HMAC-chained events."""
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    log = AuditLog(audit_dir, key=_HMAC_KEY)
+    log.log("task.created", "alice", "task", "T-1", {"role": "backend"})
+    log.log("agent.spawned", "orchestrator", "agent", "A-1", {"task": "T-1"})
+    log.log("task.completed", "alice", "task", "T-1", {"status": "ok"})
+
+
+def _kms(tmp_path: Path) -> KMSAdapter:
+    """Return a deterministic file-backed Ed25519 KMS adapter."""
+    key = Ed25519PrivateKey.from_private_bytes(_SIGN_SEED)
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    key_path = tmp_path / "sign.pem"
+    key_path.write_bytes(
+        key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        ),
+    )
+    return FileBasedKMSAdapter(key_path, kid="test-receipt-key")
+
+
+def _load_verifier() -> Any:
+    """Load the standalone verifier as a module (no bernstein imports in it)."""
+    import sys
+
+    spec = importlib.util.spec_from_file_location("verify_audit_receipt", VERIFIER_SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so dataclasses can resolve the module namespace.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _verify(receipt_path: Path, *args: str) -> tuple[int, str]:
+    """Run the standalone verifier's main() in-process; return (rc, stdout)."""
+    verifier = _load_verifier()
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = verifier.main(["--receipt", str(receipt_path), *args])
+    return rc, buf.getvalue()
+
+
+@pytest.fixture
+def receipt_env(tmp_path: Path) -> dict[str, Any]:
+    """Build a full three-format receipt on disk with a seeded chain."""
+    audit_dir = tmp_path / ".sdd" / "audit"
+    _seed_log(audit_dir)
+    kms = _kms(tmp_path)
+    receipt = build_receipt(
+        audit_dir,
+        since=_SINCE,
+        until=_UNTIL,
+        key=_HMAC_KEY,
+        kms_adapter=kms,
+        output_dir=tmp_path / "out",
+        write=True,
+    )
+    assert receipt.receipt_path is not None
+    return {"receipt": receipt, "audit_dir": audit_dir, "kms": kms, "tmp": tmp_path}
+
+
+# ---------------------------------------------------------------------------
+# Subject binding (AC1): subject digest IS the chain head, not recomputed
+# ---------------------------------------------------------------------------
+
+
+def test_subject_digest_equals_chain_head(receipt_env: dict[str, Any]) -> None:
+    receipt = receipt_env["receipt"]
+    assert receipt.event_count == 3
+    subject_digest = receipt.receipt["subject"]["digest"]["sha256"]
+    assert subject_digest == receipt.head_sha256
+    assert receipt.receipt["range"]["head_sha256"] == receipt.head_sha256
+
+
+def test_head_matches_multitenant_export_for_range(receipt_env: dict[str, Any]) -> None:
+    """AC1: the head is the existing chain head, identical to the tenant export.
+
+    The seeded events carry no tenant id, so they all map to the default tenant.
+    The multitenant exporter over the same window must produce the identical
+    ``head_sha256`` - proving the receipt binds the existing head, not a
+    format-specific recomputation.
+    """
+    export = export_tenant_slice(
+        receipt_env["audit_dir"],
+        "default",
+        since=_SINCE,
+        until=_UNTIL,
+        key=_HMAC_KEY,
+        write=False,
+    )
+    assert export.head_sha256 == receipt_env["receipt"].head_sha256
+
+
+def test_receipt_type_and_formats(receipt_env: dict[str, Any]) -> None:
+    receipt = receipt_env["receipt"]
+    assert receipt.receipt["receipt_type"] == RECEIPT_TYPE
+    assert receipt.formats == tuple(sorted(ALL_FORMATS))
+
+
+# ---------------------------------------------------------------------------
+# Determinism (AC6): byte-identical replay
+# ---------------------------------------------------------------------------
+
+
+def test_byte_identical_replay(tmp_path: Path) -> None:
+    audit_dir = tmp_path / ".sdd" / "audit"
+    _seed_log(audit_dir)
+    kms1 = _kms(tmp_path / "k1")
+    kms2 = _kms(tmp_path / "k2")
+    r1 = build_receipt(audit_dir, since=_SINCE, until=_UNTIL, key=_HMAC_KEY, kms_adapter=kms1, write=False)
+    r2 = build_receipt(audit_dir, since=_SINCE, until=_UNTIL, key=_HMAC_KEY, kms_adapter=kms2, write=False)
+    assert r1.receipt_bytes == r2.receipt_bytes
+    assert r1.sha256 == r2.sha256
+
+
+# ---------------------------------------------------------------------------
+# Round-trip verification (AC2/AC3/AC4)
+# ---------------------------------------------------------------------------
+
+
+def test_verifier_passes_all_formats(receipt_env: dict[str, Any]) -> None:
+    rc, out = _verify(receipt_env["receipt"].receipt_path)
+    assert rc == 0, out
+    assert "OVERALL: PASS" in out
+    assert "[PASS] cose" in out
+    assert "[PASS] intoto" in out
+    assert "[PASS] transparency" in out
+    assert "[PASS] subject_binding" in out
+
+
+@pytest.mark.parametrize("fmt", ["cose", "intoto", "transparency"])
+def test_each_format_verifies_alone(tmp_path: Path, fmt: str) -> None:
+    audit_dir = tmp_path / ".sdd" / "audit"
+    _seed_log(audit_dir)
+    receipt = build_receipt(
+        audit_dir,
+        since=_SINCE,
+        until=_UNTIL,
+        key=_HMAC_KEY,
+        kms_adapter=_kms(tmp_path),
+        formats=(fmt,),
+        output_dir=tmp_path / "out",
+        write=True,
+    )
+    assert receipt.formats == (fmt,)
+    rc, out = _verify(receipt.receipt_path, "--format", fmt)
+    assert rc == 0, out
+    assert f"[PASS] {fmt}" in out
+
+
+def test_verifier_imports_no_bernstein() -> None:
+    """The headline promise: the verifier has no bernstein import."""
+    source = VERIFIER_SCRIPT.read_text(encoding="utf-8")
+    offending = [
+        ln
+        for ln in source.splitlines()
+        if (ln.strip().startswith(("import bernstein", "from bernstein"))) and not ln.lstrip().startswith("#")
+    ]
+    assert not offending, f"verifier imports bernstein: {offending}"
+
+
+def test_pinned_jwk_matches(receipt_env: dict[str, Any]) -> None:
+    receipt = receipt_env["receipt"]
+    jwk_path = receipt_env["tmp"] / "trusted.jwk.json"
+    jwk_path.write_text(json.dumps(receipt.receipt["signing"]["public_key_jwk"]))
+    rc, out = _verify(receipt.receipt_path, "--jwk", str(jwk_path), "--verbose")
+    assert rc == 0, out
+    assert "[PASS] public_key - pinned-jwk" in out
+
+
+def test_pinned_jwk_mismatch_fails(receipt_env: dict[str, Any]) -> None:
+    receipt = receipt_env["receipt"]
+    wrong = {"kty": "OKP", "crv": "Ed25519", "alg": "EdDSA", "x": "A" * 43}
+    jwk_path = receipt_env["tmp"] / "wrong.jwk.json"
+    jwk_path.write_text(json.dumps(wrong))
+    rc, out = _verify(receipt.receipt_path, "--jwk", str(jwk_path))
+    assert rc == 1
+    assert "[FAIL] public_key" in out
+
+
+# ---------------------------------------------------------------------------
+# Tamper property (AC5): mutate one embedded entry -> every format fails
+# ---------------------------------------------------------------------------
+
+
+def test_tamper_one_entry_fails_all_formats(receipt_env: dict[str, Any]) -> None:
+    receipt = receipt_env["receipt"]
+    data = json.loads(receipt.receipt_path.read_text())
+    # Mutate exactly one underlying chain entry inside the embedded range.
+    data["events"][1]["actor"] = "mallory"
+    tampered = receipt_env["tmp"] / "tampered.json"
+    tampered.write_text(json.dumps(data))
+
+    rc, out = _verify(tampered)
+    assert rc == 1
+    assert "OVERALL: FAIL" in out
+    assert "[FAIL] subject_binding" in out
+    assert "[FAIL] cose" in out
+    assert "[FAIL] intoto" in out
+    assert "[FAIL] transparency" in out
+
+
+def test_tamper_details_field_fails(receipt_env: dict[str, Any]) -> None:
+    receipt = receipt_env["receipt"]
+    data = json.loads(receipt.receipt_path.read_text())
+    data["events"][0]["details"]["role"] = "frontend"
+    tampered = receipt_env["tmp"] / "tampered2.json"
+    tampered.write_text(json.dumps(data))
+    rc, out = _verify(tampered)
+    assert rc == 1
+    assert "[FAIL] cose" in out
+    assert "[FAIL] intoto" in out
+    assert "[FAIL] transparency" in out
+
+
+def test_dropped_event_fails(receipt_env: dict[str, Any]) -> None:
+    receipt = receipt_env["receipt"]
+    data = json.loads(receipt.receipt_path.read_text())
+    data["events"] = data["events"][:-1]  # drop the chain-head event
+    tampered = receipt_env["tmp"] / "dropped.json"
+    tampered.write_text(json.dumps(data))
+    rc, out = _verify(tampered)
+    assert rc == 1
+    assert "[FAIL] subject_binding" in out
+
+
+# ---------------------------------------------------------------------------
+# Schema conformance (AC7)
+# ---------------------------------------------------------------------------
+
+
+def test_receipt_validates_against_schema(receipt_env: dict[str, Any]) -> None:
+    import jsonschema
+
+    schema = json.loads((REPO_ROOT / "schemas" / "audit-receipt-v1.json").read_text())
+    jsonschema.validate(receipt_env["receipt"].receipt, schema)
+
+
+def test_empty_range_receipt(tmp_path: Path) -> None:
+    """An empty window still yields a deterministic, verifiable receipt."""
+    audit_dir = tmp_path / ".sdd" / "audit"
+    _seed_log(audit_dir)
+    # A window that excludes every seeded event.
+    receipt = build_receipt(
+        audit_dir,
+        since="2100-01-01T00:00:00.000000Z",
+        until="2100-01-02T00:00:00.000000Z",
+        key=_HMAC_KEY,
+        kms_adapter=_kms(tmp_path),
+        output_dir=tmp_path / "out",
+        write=True,
+    )
+    assert receipt.event_count == 0
+    rc, out = _verify(receipt.receipt_path)
+    assert rc == 0, out
+    assert "OVERALL: PASS" in out
+
+
+# ---------------------------------------------------------------------------
+# Validation errors
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_window_rejected(tmp_path: Path) -> None:
+    audit_dir = tmp_path / ".sdd" / "audit"
+    _seed_log(audit_dir)
+    with pytest.raises(ValueError, match="must be <"):
+        build_receipt(audit_dir, since=_UNTIL, until=_SINCE, key=_HMAC_KEY, kms_adapter=_kms(tmp_path), write=False)
+
+
+def test_unknown_format_rejected(tmp_path: Path) -> None:
+    audit_dir = tmp_path / ".sdd" / "audit"
+    _seed_log(audit_dir)
+    with pytest.raises(ValueError, match="unknown receipt format"):
+        build_receipt(
+            audit_dir,
+            since=_SINCE,
+            until=_UNTIL,
+            key=_HMAC_KEY,
+            kms_adapter=_kms(tmp_path),
+            formats=("cose", "bogus"),
+            write=False,
+        )

--- a/tests/unit/test_audit_receipt_cmd.py
+++ b/tests/unit/test_audit_receipt_cmd.py
@@ -1,0 +1,145 @@
+"""CLI tests for ``bernstein audit receipt export|verify`` (#2604)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from bernstein.cli.commands.audit_cmd import audit_group
+from bernstein.core.security.audit import AuditLog
+
+
+def _write_signing_key(path: Path) -> None:
+    key = Ed25519PrivateKey.from_private_bytes(b"i" * 32)
+    path.write_bytes(
+        key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        ),
+    )
+
+
+def _seed(workdir: Path, key_path: Path) -> None:
+    """Seed a chain under ``workdir/.sdd/audit`` keyed by the audit key file."""
+    key_path.write_bytes(b"y" * 64)
+    key_path.chmod(0o600)
+    audit_dir = workdir / ".sdd" / "audit"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    log = AuditLog(audit_dir, key_path=key_path)
+    log.log("task.created", "alice", "task", "T-1", {"role": "backend"})
+    log.log("task.completed", "alice", "task", "T-1", {"status": "ok"})
+
+
+def test_receipt_export_then_verify(tmp_path: Path, monkeypatch) -> None:
+    workdir = tmp_path / "proj"
+    workdir.mkdir()
+    audit_key = tmp_path / "audit.key"
+    monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(audit_key))
+    _seed(workdir, audit_key)
+
+    sign_key = tmp_path / "sign.pem"
+    _write_signing_key(sign_key)
+    out_dir = tmp_path / "receipts"
+
+    runner = CliRunner()
+    export = runner.invoke(
+        audit_group,
+        [
+            "receipt",
+            "export",
+            "--dir",
+            str(workdir),
+            "--since",
+            "2020-01-01T00:00:00.000000Z",
+            "--until",
+            "2100-01-01T00:00:00.000000Z",
+            "--signing-key-path",
+            str(sign_key),
+            "--output",
+            str(out_dir),
+        ],
+    )
+    assert export.exit_code == 0, export.output
+    assert "Audit Receipt" in export.output
+
+    receipts = list(out_dir.glob("audit-receipt-*.json"))
+    assert len(receipts) == 1
+    receipt = json.loads(receipts[0].read_text())
+    assert set(receipt["formats"]) == {"cose", "intoto", "transparency"}
+
+    # The export recorded an audit.receipt_export chain event.
+    events = AuditLog(workdir / ".sdd" / "audit", key_path=audit_key).query()
+    assert any(e.event_type == "audit.receipt_export" for e in events)
+
+    # verify shells to the standalone tool and passes.
+    verify = runner.invoke(audit_group, ["receipt", "verify", str(receipts[0])])
+    assert verify.exit_code == 0, verify.output
+    assert "OVERALL: PASS" in verify.output
+
+
+def test_receipt_verify_detects_tamper(tmp_path: Path, monkeypatch) -> None:
+    workdir = tmp_path / "proj"
+    workdir.mkdir()
+    audit_key = tmp_path / "audit.key"
+    monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(audit_key))
+    _seed(workdir, audit_key)
+    sign_key = tmp_path / "sign.pem"
+    _write_signing_key(sign_key)
+    out_dir = tmp_path / "receipts"
+
+    runner = CliRunner()
+    runner.invoke(
+        audit_group,
+        [
+            "receipt",
+            "export",
+            "--dir",
+            str(workdir),
+            "--since",
+            "2020-01-01T00:00:00.000000Z",
+            "--until",
+            "2100-01-01T00:00:00.000000Z",
+            "--signing-key-path",
+            str(sign_key),
+            "--output",
+            str(out_dir),
+        ],
+    )
+    receipt_path = next(out_dir.glob("audit-receipt-*.json"))
+    data = json.loads(receipt_path.read_text())
+    data["events"][0]["actor"] = "mallory"
+    receipt_path.write_text(json.dumps(data))
+
+    verify = runner.invoke(audit_group, ["receipt", "verify", str(receipt_path)])
+    assert verify.exit_code == 1
+    assert "OVERALL: FAIL" in verify.output
+
+
+def test_receipt_export_requires_signing_key(tmp_path: Path, monkeypatch) -> None:
+    workdir = tmp_path / "proj"
+    workdir.mkdir()
+    audit_key = tmp_path / "audit.key"
+    monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(audit_key))
+    _seed(workdir, audit_key)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        audit_group,
+        [
+            "receipt",
+            "export",
+            "--dir",
+            str(workdir),
+            "--since",
+            "2020-01-01T00:00:00.000000Z",
+            "--until",
+            "2100-01-01T00:00:00.000000Z",
+        ],
+    )
+    assert result.exit_code == 2
+    assert "signing-key-path" in result.output

--- a/tools/verify_audit_receipt.py
+++ b/tools/verify_audit_receipt.py
@@ -1,0 +1,615 @@
+#!/usr/bin/env python3
+"""Standalone verifier for a bernstein audit receipt.
+
+This script has **zero dependencies on the bernstein package**. Its only
+third-party imports are :mod:`cryptography` and :mod:`cbor2` - both are the
+off-the-shelf libraries an external auditor already runs to check COSE_Sign1
+and CBOR. Everything else is stdlib.
+
+The point of the strict isolation (mirroring ``tools/verify_audit_dsse.py``)
+is auditor reproducibility: a regulator can point their own COSE / in-toto /
+transparency-log tooling at the receipt and get a yes or no without installing
+bernstein and without holding the operator's HMAC key.
+
+What it checks (per format, plus the shared subject binding):
+
+* ``cose``         - COSE_Sign1 (RFC 9052) EdDSA signature over the subject
+                     digest, and payload == recomputed chain head.
+* ``intoto``       - DSSE / in-toto v1 Statement signature, and the statement
+                     subject digest == recomputed chain head.
+* ``transparency`` - RFC 6962 style signed tree head signature, Merkle root
+                     rebuilt from the embedded range, inclusion proof of the
+                     chain-head leaf, and subject binding.
+
+The subject binding is the substrate coupling: the chain ``head_sha256`` is
+recomputed from the receipt's embedded event range and every format is asserted
+to bind that value. Mutate one embedded entry and the recomputed head diverges,
+so every format fails - the receipt is meaningless without the intact chain.
+
+Usage::
+
+    python tools/verify_audit_receipt.py \\
+        --receipt /path/to/audit-receipt.json \\
+        [--jwk /path/to/trusted.jwk.json] \\
+        [--public-key /path/to/ed25519.pub.pem] \\
+        [--format cose|intoto|transparency|all] \\
+        [--verbose]
+
+Exit codes: ``0`` all enabled checks passed, ``1`` a check failed, ``2`` bad
+arguments or unreadable inputs.
+
+By default the verifier trusts the Ed25519 key embedded in the receipt
+(``signing.public_key_jwk``) on first use. Pass ``--jwk`` or ``--public-key``
+to pin an out-of-band key; the embedded key must then match it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import io
+
+# Wire-format constants re-declared from the specs / bernstein receipt module.
+# Any drift is caught by tests/unit/test_audit_receipt.py (in-tree round-trip)
+# and tests/integration/test_standalone_receipt_verifier.py (this script in a
+# hermetic venv). DO NOT import from the bernstein package here.
+DSSE_PAYLOAD_TYPE = "application/vnd.in-toto+json"
+IN_TOTO_STATEMENT_TYPE = "https://in-toto.io/Statement/v1"
+RECEIPT_TYPE = "https://bernstein.run/attestations/audit-receipt/v1"
+COSE_SIGN1_TAG = 18
+COSE_ALG_EDDSA = -8
+COSE_LABEL_ALG = 1
+EMPTY_TREE_ROOT = hashlib.sha256(b"empty-tree").hexdigest()
+VALID_FORMATS = ("cose", "intoto", "transparency")
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CheckResult:
+    """Outcome of a single check."""
+
+    name: str
+    ok: bool
+    detail: str = ""
+
+
+@dataclass
+class VerifyResult:
+    """Aggregate outcome across every requested check."""
+
+    checks: list[CheckResult] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        """True iff every check that ran reported success."""
+        return all(c.ok for c in self.checks)
+
+
+# ---------------------------------------------------------------------------
+# Canonical primitives - re-implemented from the bernstein receipt spec
+# ---------------------------------------------------------------------------
+
+
+def _canonical_json_bytes(obj: Any) -> bytes:
+    """Deterministic JSON bytes (sorted keys, compact separators)."""
+    return json.dumps(obj, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _events_jsonl_bytes(events: list[dict[str, Any]]) -> bytes:
+    """Canonical JSONL for the event range (matches audit_multitenant)."""
+    if not events:
+        return b""
+    parts = [json.dumps(e, sort_keys=True, separators=(",", ":")) for e in events]
+    return ("\n".join(parts) + "\n").encode("utf-8")
+
+
+def recompute_head_sha256(events: list[dict[str, Any]]) -> str:
+    """Recompute the chain range head from the embedded events."""
+    return hashlib.sha256(_events_jsonl_bytes(events)).hexdigest()
+
+
+def _leaf_digest(data: bytes) -> str:
+    """RFC 6962 style leaf hash: ``H(0x00 || data)``."""
+    return hashlib.sha256(b"\x00" + data).hexdigest()
+
+
+def _combine_internal(left: str, right: str) -> str:
+    """RFC 6962 style internal node: ``H(0x01 || left || right)``."""
+    return hashlib.sha256(b"\x01" + left.encode() + right.encode()).hexdigest()
+
+
+def _merkle_root(leaves: list[str]) -> str:
+    """Merkle root over ``leaves`` (lone odd node promoted unchanged)."""
+    if not leaves:
+        return EMPTY_TREE_ROOT
+    level = list(leaves)
+    while len(level) > 1:
+        nxt: list[str] = []
+        for i in range(0, len(level), 2):
+            if i + 1 < len(level):
+                nxt.append(_combine_internal(level[i], level[i + 1]))
+            else:
+                nxt.append(level[i])
+        level = nxt
+    return level[0]
+
+
+def _root_from_inclusion(leaf_hash: str, audit_path: list[dict[str, Any]]) -> str:
+    """Fold an inclusion proof from the leaf up to the root."""
+    node = leaf_hash
+    for step in audit_path:
+        sibling = str(step.get("hash", ""))
+        # ``left`` marks the sibling as the left child, so our node is the right.
+        node = _combine_internal(sibling, node) if step.get("left") else _combine_internal(node, sibling)
+    return node
+
+
+def pae(payload_type: str, payload: bytes) -> bytes:
+    """DSSE Pre-Authentication Encoding."""
+    type_bytes = payload_type.encode("utf-8")
+    return (
+        b"DSSEv1 "
+        + str(len(type_bytes)).encode("ascii")
+        + b" "
+        + type_bytes
+        + b" "
+        + str(len(payload)).encode("ascii")
+        + b" "
+        + payload
+    )
+
+
+# ---------------------------------------------------------------------------
+# Key loading
+# ---------------------------------------------------------------------------
+
+
+def _public_key_from_jwk(jwk: dict[str, Any]) -> Any:
+    """Convert an OKP/Ed25519 JWK into an Ed25519PublicKey (RFC 8037)."""
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+    if jwk.get("kty") != "OKP" or jwk.get("crv") != "Ed25519":
+        msg = f"expected kty=OKP, crv=Ed25519; got {jwk!r}"
+        raise ValueError(msg)
+    x = jwk.get("x")
+    if not isinstance(x, str):
+        msg = "JWK 'x' missing or not a string"
+        raise ValueError(msg)
+    padding = "=" * (-len(x) % 4)
+    raw = base64.urlsafe_b64decode(x + padding)
+    if len(raw) != 32:
+        msg = f"Ed25519 public key must be 32 bytes (got {len(raw)})"
+        raise ValueError(msg)
+    return Ed25519PublicKey.from_public_bytes(raw)
+
+
+def _jwk_x(jwk: dict[str, Any]) -> str:
+    """Return the ``x`` member of a JWK for pinning comparison."""
+    return str(jwk.get("x", ""))
+
+
+def _resolve_public_key(
+    receipt: dict[str, Any],
+    *,
+    pinned_jwk: dict[str, Any] | None,
+    pinned_pem: bytes | None,
+) -> tuple[Any, str]:
+    """Resolve the verifying key, honouring an optional pin.
+
+    Returns ``(public_key, note)``. Raises ``ValueError`` when the embedded
+    key is absent/invalid or does not match a supplied pin.
+    """
+    signing = receipt.get("signing") or {}
+    embedded_jwk = signing.get("public_key_jwk")
+    if not isinstance(embedded_jwk, dict):
+        msg = "receipt.signing.public_key_jwk missing or not an object"
+        raise ValueError(msg)
+
+    if pinned_pem is not None:
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+        key = serialization.load_pem_public_key(pinned_pem)
+        if not isinstance(key, Ed25519PublicKey):
+            msg = f"pinned --public-key is not Ed25519 (got {type(key).__name__})"
+            raise ValueError(msg)
+        # Confirm the embedded JWK matches the pinned PEM.
+        embedded_key = _public_key_from_jwk(embedded_jwk)
+        raw_pin = key.public_bytes(
+            serialization.Encoding.Raw,
+            serialization.PublicFormat.Raw,
+        )
+        raw_emb = embedded_key.public_bytes(
+            serialization.Encoding.Raw,
+            serialization.PublicFormat.Raw,
+        )
+        if raw_pin != raw_emb:
+            msg = "embedded receipt key does not match the pinned --public-key"
+            raise ValueError(msg)
+        return key, "pinned-pem"
+
+    if pinned_jwk is not None:
+        if _jwk_x(pinned_jwk) != _jwk_x(embedded_jwk):
+            msg = "embedded receipt JWK does not match the pinned --jwk"
+            raise ValueError(msg)
+        return _public_key_from_jwk(embedded_jwk), "pinned-jwk"
+
+    return _public_key_from_jwk(embedded_jwk), "trust-on-first-use"
+
+
+# ---------------------------------------------------------------------------
+# Per-format checks
+# ---------------------------------------------------------------------------
+
+
+def verify_subject_binding(receipt: dict[str, Any]) -> tuple[CheckResult, str]:
+    """Recompute head_sha256 from the embedded range; compare to the subject.
+
+    Returns ``(check, recomputed_head)``. The recomputed head is the value
+    every format is asserted to bind.
+    """
+    events = receipt.get("events")
+    if not isinstance(events, list):
+        return CheckResult("subject_binding", ok=False, detail="receipt.events missing or not a list"), ""
+    recomputed = recompute_head_sha256(events)
+    subject_digest = str(((receipt.get("subject") or {}).get("digest") or {}).get("sha256", ""))
+    range_head = str((receipt.get("range") or {}).get("head_sha256", ""))
+    if subject_digest != recomputed:
+        return (
+            CheckResult(
+                "subject_binding",
+                ok=False,
+                detail=(f"recomputed head {recomputed[:16]}… != subject {subject_digest[:16]}… (chain tampered)"),
+            ),
+            recomputed,
+        )
+    if range_head != recomputed:
+        return (
+            CheckResult(
+                "subject_binding",
+                ok=False,
+                detail=f"recomputed head {recomputed[:16]}… != range.head_sha256 {range_head[:16]}…",
+            ),
+            recomputed,
+        )
+    return CheckResult("subject_binding", ok=True, detail=f"head={recomputed[:16]}…"), recomputed
+
+
+def verify_cose(receipt: dict[str, Any], public_key: Any, recomputed_head: str) -> CheckResult:
+    """Verify the COSE_Sign1 signature and its payload binding."""
+    import cbor2
+    from cryptography.exceptions import InvalidSignature
+
+    block = (receipt.get("formats") or {}).get("cose")
+    if not isinstance(block, dict):
+        return CheckResult("cose", ok=False, detail="no cose format block present")
+    b64 = block.get("cose_sign1_b64")
+    if not isinstance(b64, str):
+        return CheckResult("cose", ok=False, detail="cose_sign1_b64 missing")
+    try:
+        cose_bytes = base64.b64decode(b64)
+        obj = cbor2.loads(cose_bytes)
+    except Exception as exc:
+        return CheckResult("cose", ok=False, detail=f"COSE CBOR decode failed: {exc}")
+
+    tag = getattr(obj, "tag", None)
+    value = getattr(obj, "value", None)
+    # The pure-Python cbor2 decoder yields tuples for CBOR arrays; the C
+    # extension yields lists. Accept both.
+    if tag != COSE_SIGN1_TAG or not isinstance(value, (list, tuple)) or len(value) != 4:
+        return CheckResult("cose", ok=False, detail="not a COSE_Sign1 (tag 18, 4-element array)")
+    protected_bstr, _unprotected, payload, signature = value
+
+    try:
+        protected_map = cbor2.loads(protected_bstr) if protected_bstr else {}
+    except Exception as exc:
+        return CheckResult("cose", ok=False, detail=f"protected header decode failed: {exc}")
+    if protected_map.get(COSE_LABEL_ALG) != COSE_ALG_EDDSA:
+        return CheckResult("cose", ok=False, detail=f"unexpected COSE alg: {protected_map.get(COSE_LABEL_ALG)!r}")
+
+    sig_structure = ["Signature1", protected_bstr, b"", payload]
+    to_verify = cbor2.dumps(sig_structure, canonical=True)
+    try:
+        public_key.verify(signature, to_verify)
+    except InvalidSignature:
+        return CheckResult("cose", ok=False, detail="COSE_Sign1 signature does not verify")
+    except Exception as exc:
+        return CheckResult("cose", ok=False, detail=f"COSE verify error: {exc}")
+
+    # Payload binding: the signed payload IS the chain head digest bytes.
+    if not isinstance(payload, (bytes, bytearray)):
+        return CheckResult("cose", ok=False, detail="COSE payload is not a byte string")
+    if bytes(payload).hex() != recomputed_head:
+        return CheckResult(
+            "cose",
+            ok=False,
+            detail=(f"COSE payload {bytes(payload).hex()[:16]}… != recomputed head {recomputed_head[:16]}…"),
+        )
+    return CheckResult("cose", ok=True, detail="COSE_Sign1 EdDSA verified, payload bound to head")
+
+
+def verify_intoto(receipt: dict[str, Any], public_key: Any, recomputed_head: str) -> CheckResult:
+    """Verify the DSSE / in-toto envelope signature and subject binding."""
+    from cryptography.exceptions import InvalidSignature
+
+    env = (receipt.get("formats") or {}).get("intoto")
+    if not isinstance(env, dict):
+        return CheckResult("intoto", ok=False, detail="no intoto format block present")
+    payload_type = env.get("payloadType")
+    payload_b64 = env.get("payload")
+    signatures = env.get("signatures") or []
+    if payload_type != DSSE_PAYLOAD_TYPE:
+        return CheckResult("intoto", ok=False, detail=f"unexpected payloadType {payload_type!r}")
+    if not isinstance(payload_b64, str) or not signatures:
+        return CheckResult("intoto", ok=False, detail="envelope missing payload/signatures")
+    try:
+        payload = base64.b64decode(payload_b64)
+    except Exception as exc:
+        return CheckResult("intoto", ok=False, detail=f"payload base64 decode failed: {exc}")
+
+    pae_bytes = pae(payload_type, payload)
+    verified = False
+    for sig_obj in signatures:
+        if not isinstance(sig_obj, dict):
+            continue
+        try:
+            sig = base64.b64decode(sig_obj.get("sig", ""))
+            public_key.verify(sig, pae_bytes)
+            verified = True
+            break
+        except (InvalidSignature, ValueError, TypeError):
+            continue
+    if not verified:
+        return CheckResult("intoto", ok=False, detail="no DSSE signature verified")
+
+    try:
+        statement = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return CheckResult("intoto", ok=False, detail=f"statement JSON decode failed: {exc}")
+    if statement.get("_type") != IN_TOTO_STATEMENT_TYPE:
+        return CheckResult("intoto", ok=False, detail=f"unexpected statement _type {statement.get('_type')!r}")
+    subjects = statement.get("subject") or []
+    digests = [str((s.get("digest") or {}).get("sha256", "")) for s in subjects if isinstance(s, dict)]
+    if recomputed_head not in digests:
+        return CheckResult(
+            "intoto",
+            ok=False,
+            detail=(f"recomputed head {recomputed_head[:16]}… not in statement subject digests"),
+        )
+    return CheckResult("intoto", ok=True, detail="DSSE/in-toto verified, subject bound to head")
+
+
+def verify_transparency(receipt: dict[str, Any], public_key: Any, recomputed_head: str) -> CheckResult:
+    """Verify the transparency STH signature, Merkle root, and inclusion proof."""
+    from cryptography.exceptions import InvalidSignature
+
+    block = (receipt.get("formats") or {}).get("transparency")
+    if not isinstance(block, dict):
+        return CheckResult("transparency", ok=False, detail="no transparency format block present")
+    sth = block.get("signed_tree_head") or {}
+    proof = block.get("inclusion_proof") or {}
+    root_hash = str(sth.get("root_hash", ""))
+    subject_sha256 = str(sth.get("subject_sha256", ""))
+    tree_size = sth.get("tree_size")
+
+    # 1. STH signature over the canonical signed-tree-head fields.
+    sig_b64 = sth.get("signature_b64")
+    if not isinstance(sig_b64, str):
+        return CheckResult("transparency", ok=False, detail="signed_tree_head.signature_b64 missing")
+    signed = {
+        "tree_size": tree_size,
+        "root_hash": root_hash,
+        "subject_sha256": subject_sha256,
+    }
+    try:
+        public_key.verify(base64.b64decode(sig_b64), _canonical_json_bytes(signed))
+    except InvalidSignature:
+        return CheckResult("transparency", ok=False, detail="signed tree head signature does not verify")
+    except Exception as exc:
+        return CheckResult("transparency", ok=False, detail=f"STH verify error: {exc}")
+
+    # 2. Subject binding.
+    if subject_sha256 != recomputed_head:
+        return CheckResult(
+            "transparency",
+            ok=False,
+            detail=(f"STH subject {subject_sha256[:16]}… != recomputed head {recomputed_head[:16]}…"),
+        )
+
+    # 3. Rebuild the Merkle root from the embedded range and compare.
+    events = receipt.get("events") or []
+    leaves = [_leaf_digest(_canonical_json_bytes(e)) for e in events]
+    if len(leaves) != tree_size:
+        return CheckResult(
+            "transparency",
+            ok=False,
+            detail=f"tree_size {tree_size} != embedded leaf count {len(leaves)}",
+        )
+    rebuilt_root = _merkle_root(leaves)
+    if rebuilt_root != root_hash:
+        return CheckResult(
+            "transparency",
+            ok=False,
+            detail=f"rebuilt Merkle root {rebuilt_root[:16]}… != STH root {root_hash[:16]}… (chain tampered)",
+        )
+
+    # 4. Inclusion proof of the chain-head (last) leaf.
+    if leaves:
+        leaf_index = proof.get("leaf_index")
+        leaf_hash = str(proof.get("leaf_hash", ""))
+        audit_path = proof.get("audit_path") or []
+        if leaf_index != len(leaves) - 1 or leaf_hash != leaves[-1]:
+            return CheckResult("transparency", ok=False, detail="inclusion proof does not target the chain-head leaf")
+        proven_root = _root_from_inclusion(leaf_hash, audit_path)
+        if proven_root != root_hash:
+            return CheckResult(
+                "transparency",
+                ok=False,
+                detail=f"inclusion proof root {proven_root[:16]}… != STH root {root_hash[:16]}…",
+            )
+    return CheckResult("transparency", ok=True, detail="RFC6962 STH signed, root + inclusion proof verified")
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+_VERIFIERS = {
+    "cose": verify_cose,
+    "intoto": verify_intoto,
+    "transparency": verify_transparency,
+}
+
+
+def _print_check(check: CheckResult, *, verbose: bool, stream: io.TextIOBase) -> None:
+    """Emit one PASS/FAIL line."""
+    status = "PASS" if check.ok else "FAIL"
+    line = f"[{status}] {check.name}"
+    if check.detail and (not check.ok or verbose):
+        line += f" - {check.detail}"
+    print(line, file=stream)
+
+
+def run_verify(
+    *,
+    receipt_path: Path,
+    which: str,
+    pinned_jwk: dict[str, Any] | None,
+    pinned_pem: bytes | None,
+    verbose: bool,
+    stream: io.TextIOBase,
+) -> VerifyResult:
+    """Run every enabled check and emit human-readable output."""
+    result = VerifyResult()
+
+    try:
+        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        check = CheckResult("receipt_load", ok=False, detail=str(exc))
+        result.checks.append(check)
+        _print_check(check, verbose=verbose, stream=stream)
+        return result
+
+    try:
+        public_key, note = _resolve_public_key(receipt, pinned_jwk=pinned_jwk, pinned_pem=pinned_pem)
+    except ValueError as exc:
+        check = CheckResult("public_key", ok=False, detail=str(exc))
+        result.checks.append(check)
+        _print_check(check, verbose=verbose, stream=stream)
+        return result
+    key_check = CheckResult("public_key", ok=True, detail=note)
+    result.checks.append(key_check)
+    _print_check(key_check, verbose=verbose, stream=stream)
+
+    binding_check, recomputed_head = verify_subject_binding(receipt)
+    result.checks.append(binding_check)
+    _print_check(binding_check, verbose=verbose, stream=stream)
+
+    present = list((receipt.get("formats") or {}).keys())
+    targets = VALID_FORMATS if which == "all" else (which,)
+    ran_any = False
+    for fmt in targets:
+        if fmt not in present:
+            if which != "all":
+                check = CheckResult(fmt, ok=False, detail="requested format not present in receipt")
+                result.checks.append(check)
+                _print_check(check, verbose=verbose, stream=stream)
+            continue
+        ran_any = True
+        check = _VERIFIERS[fmt](receipt, public_key, recomputed_head)
+        result.checks.append(check)
+        _print_check(check, verbose=verbose, stream=stream)
+
+    if which == "all" and not ran_any:
+        check = CheckResult("formats", ok=False, detail="receipt carries no recognised formats")
+        result.checks.append(check)
+        _print_check(check, verbose=verbose, stream=stream)
+
+    print(f"OVERALL: {'PASS' if result.ok else 'FAIL'}", file=stream)
+    return result
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser."""
+    parser = argparse.ArgumentParser(
+        description="Verify a bernstein audit receipt without importing the bernstein package.",
+    )
+    parser.add_argument("--receipt", required=True, type=Path, help="Path to the audit receipt JSON.")
+    parser.add_argument(
+        "--jwk",
+        type=Path,
+        default=None,
+        help="Optional trusted Ed25519 JWK (OKP) to pin; embedded key must match.",
+    )
+    parser.add_argument(
+        "--public-key",
+        type=Path,
+        default=None,
+        help="Optional trusted Ed25519 public key PEM to pin; embedded key must match.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=[*VALID_FORMATS, "all"],
+        default="all",
+        help="Which format(s) to verify (default: all present).",
+    )
+    parser.add_argument("--verbose", "-v", action="store_true", help="Print PASS-line details.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns 0 pass, 1 fail, 2 bad args."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if not args.receipt.is_file():
+        print(f"ERROR: not a file: {args.receipt}", file=sys.stderr)
+        return 2
+
+    pinned_jwk: dict[str, Any] | None = None
+    if args.jwk is not None:
+        if not args.jwk.is_file():
+            print(f"ERROR: not a file: {args.jwk}", file=sys.stderr)
+            return 2
+        try:
+            pinned_jwk = json.loads(args.jwk.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"ERROR: cannot read --jwk: {exc}", file=sys.stderr)
+            return 2
+        if not isinstance(pinned_jwk, dict):
+            print("ERROR: --jwk must be a JSON object", file=sys.stderr)
+            return 2
+
+    pinned_pem: bytes | None = None
+    if args.public_key is not None:
+        if not args.public_key.is_file():
+            print(f"ERROR: not a file: {args.public_key}", file=sys.stderr)
+            return 2
+        pinned_pem = args.public_key.read_bytes()
+
+    result = run_verify(
+        receipt_path=args.receipt,
+        which=args.format,
+        pinned_jwk=pinned_jwk,
+        pinned_pem=pinned_pem,
+        verbose=args.verbose,
+        stream=sys.stdout,
+    )
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -298,6 +298,7 @@ version = "3.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },
+    { name = "cbor2" },
     { name = "click" },
     { name = "cryptography" },
     { name = "defusedxml" },
@@ -463,6 +464,7 @@ requires-dist = [
     { name = "botbuilder-core", marker = "extra == 'teams'", specifier = ">=4.15" },
     { name = "boto3", marker = "extra == 'r2'", specifier = ">=1.43.6" },
     { name = "boto3", marker = "extra == 's3'", specifier = ">=1.43.6" },
+    { name = "cbor2", specifier = ">=5.6" },
     { name = "click", specifier = ">=8.3.3" },
     { name = "crosshair-tool", marker = "extra == 'dev'", specifier = ">=0.0.95" },
     { name = "cryptography", specifier = ">=45.0.7" },


### PR DESCRIPTION
## Summary

Projects an existing HMAC audit-chain range into off-the-shelf, offline-verifiable receipt envelopes so an external auditor can validate what an agent did with tooling they already run, with no bernstein install and no shared HMAC secret. Closes #2604.

The receipt is a projection, not new evidence: its subject digest IS the chain range `head_sha256`, computed via the same slice-rebuild reader path the multi-tenant export uses (no independently recomputed head). The receipt embeds the re-chained event range, so a standard verifier recomputes the head from the embedded range and asserts it equals the signed subject. Mutating any embedded entry diverges the recomputed head and every format fails. Strip or alter the chain and the receipt stops verifying rather than merely losing a log line.

## What is added

- `src/bernstein/core/security/audit_receipt.py` - the projection layer. Three formats, all binding the single subject and signing through the existing Ed25519 KMS adapter (no new key material or rotation cadence):
  - `cose`: COSE_Sign1 (RFC 9052, EdDSA) over the raw 32-byte head digest.
  - `intoto`: DSSE / in-toto v1 Statement reusing the `audit_dsse` wire primitives.
  - `transparency`: RFC 6962 style signed tree head plus a Merkle inclusion proof of the chain-head event, built with the same domain-separated hashing as `bernstein audit seal`. Offline by default; Rekor submission is opt-in.
- `tools/verify_audit_receipt.py` - standalone verifier importing only `cryptography` + `cbor2` (zero bernstein imports), mirroring `verify_audit_dsse.py`.
- CLI `bernstein audit receipt export|verify`. `verify` shells to the standalone tool to prove self-containment; `export` records an `audit.receipt_export` chain event.
- `schemas/audit-receipt-v1.json` and `docs/security/audit-receipt.md`.
- Pins `cbor2` as a direct dependency.

## Acceptance criteria

- [x] `export --format cose,intoto,transparency` emits a receipt whose subject digest equals the existing chain `head_sha256` (no independently recomputed head).
- [x] `tools/verify_audit_receipt.py` imports no bernstein code and validates the COSE_Sign1 receipt using only `cryptography` + `cbor2`.
- [x] A stock in-toto / DSSE verifier validates the `intoto` receipt with no bernstein code in the loop.
- [x] The `transparency` receipt carries a Merkle inclusion proof of the chain head, verifiable offline; Rekor submission is opt-in.
- [x] Tamper proof: mutating exactly one underlying chain entry makes all three formats fail via the external verifier because the recomputed head no longer matches the signed subject.
- [x] Byte-identical receipt bytes for identical range + key across two independent runs.
- [x] `schemas/audit-receipt-v1.json` published and validated against.

## Verifiability proof (empirical)

`tests/integration/test_standalone_receipt_verifier.py` builds a real three-format receipt, then under an interpreter that has only `cryptography` + `cbor2` installed (no bernstein on PYTHONPATH): validates all three formats (PASS), mutates one chain entry, and re-runs the verifier - every format fails. This is the verifiability axis demonstrated end to end with off-the-shelf tooling.

## Testing

- `uv run ruff check` and `ruff format --check` clean.
- `uv run lint-imports` clean; `bernstein agents-md verify` and distribution-manifest checks in sync.
- New unit + CLI + hermetic-venv integration tests pass; existing audit (DSSE, multitenant, merkle, lineage KMS) suites unaffected.

Docs are updated in the same PR (`docs/security/audit-receipt.md`, cross-referenced from the audit-log and DSSE docs).