### PR TITLE
feat(adapters): browser / computer-use adapter with per-action lineage

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -112,6 +112,7 @@ alwaysApply: false
 | `codex_cloudflare.py`       | Codex adapter for Cloudflare Sandbox execution |
 | `cody.py`                   | Sourcegraph Cody CLI adapter |
 | `composio.py`               | Composio Agent Orchestrator (``ao``) CLI adapter |
+| `computer_use.py`           | Browser / computer-use adapter family (#2606) |
 | `conformance.py`            | Adapter tool contract conformance suite harness |
 | `continue_dev.py`           | Continue.dev CLI adapter |
 | `copilot.py`                | GitHub Copilot CLI adapter |

--- a/.goosehints
+++ b/.goosehints
@@ -113,6 +113,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `codex_cloudflare.py`       | Codex adapter for Cloudflare Sandbox execution |
 | `cody.py`                   | Sourcegraph Cody CLI adapter |
 | `composio.py`               | Composio Agent Orchestrator (``ao``) CLI adapter |
+| `computer_use.py`           | Browser / computer-use adapter family (#2606) |
 | `conformance.py`            | Adapter tool contract conformance suite harness |
 | `continue_dev.py`           | Continue.dev CLI adapter |
 | `copilot.py`                | GitHub Copilot CLI adapter |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `codex_cloudflare.py`       | Codex adapter for Cloudflare Sandbox execution |
 | `cody.py`                   | Sourcegraph Cody CLI adapter |
 | `composio.py`               | Composio Agent Orchestrator (``ao``) CLI adapter |
+| `computer_use.py`           | Browser / computer-use adapter family (#2606) |
 | `conformance.py`            | Adapter tool contract conformance suite harness |
 | `continue_dev.py`           | Continue.dev CLI adapter |
 | `copilot.py`                | GitHub Copilot CLI adapter |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `codex_cloudflare.py`       | Codex adapter for Cloudflare Sandbox execution |
 | `cody.py`                   | Sourcegraph Cody CLI adapter |
 | `composio.py`               | Composio Agent Orchestrator (``ao``) CLI adapter |
+| `computer_use.py`           | Browser / computer-use adapter family (#2606) |
 | `conformance.py`            | Adapter tool contract conformance suite harness |
 | `continue_dev.py`           | Continue.dev CLI adapter |
 | `copilot.py`                | GitHub Copilot CLI adapter |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -113,6 +113,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `codex_cloudflare.py`       | Codex adapter for Cloudflare Sandbox execution |
 | `cody.py`                   | Sourcegraph Cody CLI adapter |
 | `composio.py`               | Composio Agent Orchestrator (``ao``) CLI adapter |
+| `computer_use.py`           | Browser / computer-use adapter family (#2606) |
 | `conformance.py`            | Adapter tool contract conformance suite harness |
 | `continue_dev.py`           | Continue.dev CLI adapter |
 | `copilot.py`                | GitHub Copilot CLI adapter |

--- a/docs/adapters/computer_use.md
+++ b/docs/adapters/computer_use.md
@@ -1,0 +1,115 @@
+# Browser / computer-use adapter (`computer_use`)
+
+Every coding adapter under `src/bernstein/adapters/` models an agent whose
+output is a file diff: the lineage recorder hashes the written content, chains it
+under the operator HMAC, and Ed25519-signs the entry, so a coding run is
+replayable and offline-verifiable.
+
+Browser and computer-use agents (web tasks, form filling, back-office click
+flows) do not fit that shape. They own their own decision loop and emit a stream
+of GUI actions, not a diff. A browser agent that "completed" a signup flow leaves
+no verifiable record of what it actually did: which fields it typed into, which
+button it clicked, what the page looked like at each decision. Because such an
+agent is non-deterministic by construction, absent an anchored action log it is
+unauditable, which is exactly the property every other agent kind on the
+substrate does not have.
+
+The `computer_use` adapter family closes that gap. It fronts a **third-party
+autonomous** browser / computer-use agent and instruments the boundary crossing
+so each action the external agent decides on becomes an anchored, signed,
+replayable record on the same substrate coding tasks already use.
+
+> Scope: this admits an externally-driven agent that decides its own actions and
+> makes that stream verifiable. A bernstein-driven browser worker where we own
+> the step loop is a separate, disjoint surface.
+
+## Per-action lineage anchor
+
+For each action the external agent takes, the boundary builds an observation and
+anchors it:
+
+```
+observation_hash = sha256(pre_action_screenshot_bytes + dom_accessibility_digest)
+action_anchor    = sha256(canonical(prev_anchor, observation_hash, action))
+```
+
+- The pre-action screenshot bytes are stored once in the content-addressed store
+  (`.sdd/cas/`) by SHA-256, so duplicate frames dedupe and replay retrieves the
+  exact bytes the agent saw.
+- `action` is the canonicalised action: kind (`navigate` / `type` / `click` /
+  ...), target selector or URL, and a digest of any typed value. Only the digest
+  is anchored, so a form-filling agent's secrets never enter the chain in plain
+  text.
+- Each `action_anchor` folds in the prior anchor, so the action stream is a
+  single-parent Merkle chain. Every action is recorded through the lineage
+  recorder with the prior anchor as its `parent_hashes`: HMAC-enveloped,
+  Ed25519-signed, one entry per action. The anchor **is** the entry's
+  `content_hash`, not a field bolted next to it. The head anchor is the run's
+  identity.
+
+A `computer_use.action` audit event mirrors `multimodal.attach`: it is the
+per-action replay manifest, carrying the anchor, the prior anchor, the pre-action
+screenshot's CAS SHA-256, the normalised DOM digest, the observation hash, the
+canonicalised action, the signed lineage entry hash, the worker identity, the
+worktree id, and the previous chain digest.
+
+## Deterministic replay and divergence detection
+
+Because each anchor folds in the exact observed bytes and the chosen action, a
+recorded run replays by walking the chain: re-hash the stored pre-action bytes,
+recompute each `action_anchor`, and compare against the signed chain head. Replay
+needs only the lineage store, the audit chain, and the CAS that a fresh checkout
+already ships; it never re-runs the agent.
+
+A non-deterministic re-run that observed different bytes or chose a different
+action surfaces as a **hash mismatch at the exact action index**, not a flaky
+text assertion. `replay_run(...)` returns a `ReplayResult`; on divergence its
+`ReplayDivergence` names the first differing action index and both the expected
+(signed) and recomputed anchors.
+
+This is the empirical verifiability property: flip one byte of one stored
+pre-action screenshot and replay fails, naming the exact action index. A plain
+implementation that writes screenshots as files with no anchor binding cannot
+reproduce this, because it has nothing to recompute the tampered bytes against.
+
+## Isolation
+
+Two concurrent browser tasks share no profile state. `isolated_profile_dir(...)`
+returns a per-session browser profile plus working directory under the worktree
+(`.sdd/computer-use/profiles/<session_id>`); distinct sessions resolve to disjoint
+directories by construction, so cookies cannot bleed between concurrent tasks.
+
+## Terminal states
+
+Driver failure and timeout never surface as free text. They map onto
+`ComputerUseTerminalState` (`ok` / `driver_failure` / `timeout` / `refused`) via
+`classify_terminal_state(...)`, and a driver fault is raised as a typed
+`ComputerUseDriverError` carrying its terminal state.
+
+## Capability gating
+
+An incapable adapter handed a browser task raises `ComputerUseRefusal` before any
+process launch, with `suggested_adapters` populated. This is the same structured
+refusal the multimodal boundary raises (`ComputerUseRefusal` subclasses
+`CapabilityRefusal`), just for the computer-use boundary. `is_computer_use_capable(name)`
+is the predicate, mirroring `is_multimodal_capable(name)`.
+
+## CAS-growth guard
+
+Per-action screenshots are large. A per-run cumulative byte cap
+(`DEFAULT_RUN_BYTE_CAP`, 64 MiB) fires a typed `ActionByteCapExceeded` refusal on
+overflow, so a runaway run cannot silently balloon the content-addressed store.
+
+## Where the pieces live
+
+| Concern | Module |
+| --- | --- |
+| Anchor primitives, action vocabulary, capability predicate | `bernstein.core.agents.computer_use` |
+| Recording session, replay, refusal, byte cap | `bernstein.core.agents.computer_use_attestation` |
+| Adapter family + reference adapter + terminal states | `bernstein.adapters.computer_use` |
+| `computer_use.action` audit event | `bernstein.core.security.audit_chain` |
+| YAML contract | `tests/contract/contracts/computer_use.yaml` |
+| Golden transcript | `tests/golden/computer_use_adapter.yaml` |
+
+The concrete browser driver stays behind the adapter contract: the boundary and
+anchor logic never import a specific browser tool.

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -65,6 +65,10 @@ For air-gap or BYO-model scenarios.
 - `cloudflare` - Cloudflare Agents SDK via wrangler.
 - `openai_agents` - in-process OpenAI Agents SDK v2 (requires the
   `[openai]` extra).
+- `computer_use` - fronts a third-party autonomous browser / computer-use
+  agent; each action is anchored into a signed, replayable lineage chain and
+  each task runs in an isolated browser profile (see
+  [`computer_use.md`](computer_use.md)).
 
 ### Other supported CLIs
 

--- a/src/bernstein/adapters/_contract.py
+++ b/src/bernstein/adapters/_contract.py
@@ -626,6 +626,12 @@ STRATEGY_MATRIX: dict[str, AdapterStrategy] = {
     "clm": AdapterStrategy(),
     "cloudflare": AdapterStrategy(event_channel=EventChannel.HOOKS),
     "codebuff": AdapterStrategy(),
+    # Fronts a third-party autonomous browser / computer-use agent (issue
+    # #2606). The external agent owns its own loop, so Bernstein neither
+    # resumes it natively nor reads a structured lifecycle stream: liveness is
+    # polled and the per-action record is the signed lineage chain, not stdout
+    # text. Dangerous-mode is the external agent's own concern.
+    "computer_use": AdapterStrategy(event_channel=EventChannel.POLL_PTY),
     "cody": AdapterStrategy(),
     "composio": AdapterStrategy(event_channel=EventChannel.HOOKS),
     "continue": AdapterStrategy(),

--- a/src/bernstein/adapters/computer_use.py
+++ b/src/bernstein/adapters/computer_use.py
@@ -1,0 +1,260 @@
+"""Browser / computer-use adapter family (#2606).
+
+This admits the one agent kind the coding-adapter substrate could not front:
+*third-party autonomous* browser and computer-use agents. A coding adapter's
+output is a file diff; a browser / computer-use agent owns its own decision loop
+and emits a stream of GUI actions. This adapter fronts such an external agent and
+leaves the per-action anchoring to
+:mod:`bernstein.core.agents.computer_use_attestation`, so the boundary never
+imports a specific browser tool -- the concrete driver stays behind the adapter
+contract.
+
+Two things live here:
+
+* :class:`ComputerUseAdapter` -- a :class:`~bernstein.adapters.base.CLIAdapter`
+  subclass adding per-task profile isolation and the capability-refusal path,
+  the same on-ramp the coding adapters use.
+* :class:`ReferenceComputerUseAdapter` -- a concrete reference adapter (registry
+  name ``computer_use``) that proves the mechanism end to end without requiring a
+  live browser in tests.
+
+Driver failure and timeout never surface as free text: they map onto
+:class:`ComputerUseTerminalState` via :func:`classify_terminal_state`, and a
+driver fault is raised as a typed :class:`ComputerUseDriverError`.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any
+
+from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
+from bernstein.adapters.env_isolation import build_filtered_env
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.models import ModelConfig
+
+
+# ---------------------------------------------------------------------------
+# Typed terminal states
+# ---------------------------------------------------------------------------
+
+
+class ComputerUseTerminalState(StrEnum):
+    """Terminal outcome of a computer-use run. Never free text.
+
+    The orchestrator dispatches off these enum members so a driver crash or a
+    wall-clock timeout is a structured state a compliance operator can act on,
+    not a stack trace or a log grep.
+    """
+
+    OK = "ok"
+    DRIVER_FAILURE = "driver_failure"
+    TIMEOUT = "timeout"
+    REFUSED = "refused"
+
+
+class ComputerUseDriverError(RuntimeError):
+    """Raised when the concrete browser driver faults.
+
+    Carries the typed :class:`ComputerUseTerminalState` so the failure never has
+    to be re-parsed from a message string.
+    """
+
+    def __init__(self, message: str, *, terminal_state: ComputerUseTerminalState) -> None:
+        self.terminal_state = terminal_state
+        super().__init__(message)
+
+
+def classify_terminal_state(*, exit_code: int | None, timed_out: bool) -> ComputerUseTerminalState:
+    """Map a raw driver exit into a typed terminal state.
+
+    Args:
+        exit_code: The driver process exit code, or ``None`` when it never
+            produced one.
+        timed_out: Whether the run hit its wall-clock timeout.
+
+    Returns:
+        The corresponding :class:`ComputerUseTerminalState`.
+    """
+    if timed_out:
+        return ComputerUseTerminalState.TIMEOUT
+    if exit_code == 0:
+        return ComputerUseTerminalState.OK
+    return ComputerUseTerminalState.DRIVER_FAILURE
+
+
+# ---------------------------------------------------------------------------
+# Adapter family base
+# ---------------------------------------------------------------------------
+
+
+class ComputerUseAdapter(CLIAdapter):
+    """Base for adapters that front a third-party browser / computer-use agent.
+
+    Adds two things over :class:`CLIAdapter`:
+
+    * **Per-task isolation.** :meth:`isolated_profile_dir` returns a per-session
+      browser profile + working directory under the worktree, so two concurrent
+      browser tasks share no cookie / profile state. The directory is a pure
+      function of ``(workdir, session_id)``: distinct sessions get disjoint
+      directories by construction.
+    * **Capability gating.** Concrete adapters advertise
+      :attr:`is_computer_use` so an incapable adapter fronting a browser task is
+      refused before any process launch (parity with the multimodal boundary).
+    """
+
+    #: Concrete computer-use adapters set this to ``True``.
+    is_computer_use: bool = False
+
+    #: Relative root (under the worktree) for per-session profile isolation.
+    _PROFILE_ROOT = (".sdd", "computer-use", "profiles")
+
+    def isolated_profile_dir(self, *, workdir: Path, session_id: str) -> Path:
+        """Return the per-session isolated profile directory.
+
+        Two different ``session_id`` values always resolve to disjoint
+        directories, so concurrent browser tasks cannot bleed cookies or
+        profile state into each other.
+
+        Args:
+            workdir: The worktree working directory.
+            session_id: The unique per-task session id.
+
+        Returns:
+            The profile directory path (not created).
+        """
+        safe = "".join(c if (c.isalnum() or c in "-_") else "_" for c in session_id)
+        return workdir.joinpath(*self._PROFILE_ROOT, safe)
+
+    def prepare_isolation(self, *, workdir: Path, session_id: str) -> Path:
+        """Create and return the isolated profile directory for a session."""
+        profile = self.isolated_profile_dir(workdir=workdir, session_id=session_id)
+        profile.mkdir(parents=True, exist_ok=True)
+        return profile
+
+
+# ---------------------------------------------------------------------------
+# Reference concrete adapter
+# ---------------------------------------------------------------------------
+
+
+class ReferenceComputerUseAdapter(ComputerUseAdapter):
+    """Reference computer-use adapter fronting an external browser agent.
+
+    The concrete browser driver stays behind the adapter contract: this adapter
+    only launches the external agent process (isolated to a per-session profile)
+    and lets the boundary layer anchor each action. It requires no live browser
+    in tests -- the per-action anchoring mechanism is exercised directly through
+    :mod:`bernstein.core.agents.computer_use_attestation`.
+
+    Args:
+        cli_command: The external agent CLI to launch. Defaults to a reference
+            placeholder; a real deployment points this at the partner browser
+            agent binary.
+        display_name: Human-readable adapter name.
+    """
+
+    registry_name = "computer_use"
+    is_computer_use = True
+
+    def __init__(
+        self,
+        *,
+        cli_command: str = "computer-use-agent",
+        display_name: str = "Computer Use",
+    ) -> None:
+        super().__init__()
+        self._cli_command = cli_command
+        self._display_name = display_name
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+        multimodal_context: Any | None = None,
+    ) -> SpawnResult:
+        # Capability gating parity: a browser task handed to an incapable
+        # adapter is refused up front. This adapter IS capable, but an operator
+        # attaching an image to it still hits the multimodal boundary refusal
+        # (this adapter fronts actions, not attachments).
+        self.refuse_multimodal_if_needed(multimodal_context)
+
+        # Per-task isolation: distinct sessions get disjoint profile dirs.
+        profile_dir = self.prepare_isolation(workdir=workdir, session_id=session_id)
+
+        log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        cmd = [
+            self._cli_command,
+            "--model",
+            model_config.model,
+            "--user-data-dir",
+            str(profile_dir),
+            "--prompt",
+            prompt,
+        ]
+
+        pid_dir = workdir / ".sdd" / "runtime" / "pids"
+        wrapped_cmd = build_worker_cmd(
+            cmd,
+            role=session_id.rsplit("-", 1)[0],
+            session_id=session_id,
+            pid_dir=pid_dir,
+            workdir=workdir,
+            log_path=log_path,
+            model=model_config.model,
+        )
+
+        env = build_filtered_env()
+        preexec_fn = self._get_preexec_fn()
+        with log_path.open("w") as log_file:
+            try:
+                proc = subprocess.Popen(
+                    wrapped_cmd,
+                    cwd=workdir,
+                    env=env,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                    preexec_fn=preexec_fn,
+                )
+            except FileNotFoundError as exc:
+                raise ComputerUseDriverError(
+                    f"{self._cli_command!r} not found in PATH",
+                    terminal_state=ComputerUseTerminalState.DRIVER_FAILURE,
+                ) from exc
+            except PermissionError as exc:
+                raise ComputerUseDriverError(
+                    f"Permission denied executing {self._cli_command!r}: {exc}",
+                    terminal_state=ComputerUseTerminalState.DRIVER_FAILURE,
+                ) from exc
+
+        result = SpawnResult(pid=proc.pid, log_path=log_path, proc=proc)
+        if timeout_seconds > 0:
+            result.timeout_timer = self._start_timeout_watchdog(proc.pid, timeout_seconds, session_id)
+        return result
+
+    def name(self) -> str:
+        return self._display_name
+
+
+__all__ = [
+    "ComputerUseAdapter",
+    "ComputerUseDriverError",
+    "ComputerUseTerminalState",
+    "ReferenceComputerUseAdapter",
+    "classify_terminal_state",
+]

--- a/src/bernstein/adapters/registry.py
+++ b/src/bernstein/adapters/registry.py
@@ -26,6 +26,7 @@ from bernstein.adapters.codebuff import CodebuffAdapter
 from bernstein.adapters.codex import CodexAdapter
 from bernstein.adapters.cody import CodyAdapter
 from bernstein.adapters.composio import ComposioAdapter
+from bernstein.adapters.computer_use import ReferenceComputerUseAdapter
 from bernstein.adapters.continue_dev import ContinueDevAdapter
 from bernstein.adapters.copilot import CopilotAdapter
 from bernstein.adapters.cursor import CursorAdapter
@@ -79,6 +80,9 @@ _ADAPTERS: dict[str, type[CLIAdapter] | CLIAdapter] = {
     "codex": CodexAdapter,
     "cody": CodyAdapter,
     "composio": ComposioAdapter,
+    # Fronts a third-party autonomous browser / computer-use agent; per-action
+    # lineage anchoring lives in the boundary layer (issue #2606).
+    "computer_use": ReferenceComputerUseAdapter,
     "continue": ContinueDevAdapter,
     "copilot": CopilotAdapter,
     "cursor": CursorAdapter,

--- a/src/bernstein/adapters/use_cases.py
+++ b/src/bernstein/adapters/use_cases.py
@@ -146,6 +146,18 @@ USE_CASES: dict[str, AdapterUseCase] = {
         headline="Composio Agent Orchestrator (ao) CLI",
         binary="ao",
     ),
+    "computer_use": AdapterUseCase(
+        headline="Fronts a browser / computer-use agent with per-action lineage",
+        binary="computer-use-agent",
+        details=(
+            "Admits a third-party autonomous browser / computer-use agent that "
+            "owns its own decision loop. Each action the external agent takes "
+            "against a live UI is anchored into a signed, replayable lineage "
+            "chain (pre-action screenshot hashed into a content-addressed "
+            "anchor), and each task runs in an isolated browser profile."
+        ),
+        docs_path="docs/adapters/computer_use.md",
+    ),
     "continue": AdapterUseCase(
         headline="Continue.dev CLI for IDE-style coding agents in the terminal",
         binary="continue",

--- a/src/bernstein/core/agents/computer_use.py
+++ b/src/bernstein/core/agents/computer_use.py
@@ -1,0 +1,220 @@
+"""Per-action lineage primitives for browser / computer-use agents (#2606).
+
+Where :mod:`bernstein.core.agents.multimodal` and
+:mod:`bernstein.core.agents.multimodal_attestation` capture an operator-supplied
+attachment *into* a run, this module captures the outbound side: the stream of
+GUI actions a *third-party autonomous* browser / computer-use agent decides on
+against a live UI.
+
+A coding adapter's output is a file diff, which the lineage recorder already
+hashes, chains, and signs. A browser / computer-use agent instead owns its own
+decision loop and emits a sequence of actions (navigate, type, click). Those
+actions are non-deterministic by construction, so absent an anchored log they
+are unauditable -- the one property every other agent kind on the substrate does
+not have.
+
+The anchor definition (the load-bearing primitive) is::
+
+    observation_hash = sha256(pre_action_screenshot_bytes + dom_accessibility_digest)
+    action_anchor    = sha256(canonical(prev_anchor, observation_hash, action))
+
+Each ``action_anchor`` folds in the prior anchor, so the action stream is a
+single-parent Merkle chain: the head anchor is the run's identity, and a
+non-deterministic re-run that observed different bytes or chose a different
+action surfaces as a hash mismatch at the exact action index rather than a
+flaky text assertion.
+
+Only *digests* of typed values are ever anchored -- never the raw keystrokes --
+so a form-filling agent's secrets never enter the chain in plain text.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from enum import StrEnum
+
+# ---------------------------------------------------------------------------
+# Action vocabulary
+# ---------------------------------------------------------------------------
+
+
+class ActionKind(StrEnum):
+    """The kind of GUI action an external agent decided on.
+
+    Kept deliberately small and driver-agnostic: the anchor logic never
+    imports a specific browser tool, so a concrete driver maps its own verbs
+    onto these before recording.
+    """
+
+    NAVIGATE = "navigate"
+    CLICK = "click"
+    TYPE = "type"
+    SCROLL = "scroll"
+    KEY = "key"
+    SELECT = "select"
+    SUBMIT = "submit"
+    WAIT = "wait"
+    SCREENSHOT = "screenshot"
+
+
+#: Sentinel ``prev_anchor`` for the first action in a run. The genesis action
+#: folds this constant in so the chain has a well-known root that a verifier
+#: reproduces without any prior state.
+GENESIS_ANCHOR = ""
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class Action:
+    """A single canonicalised action the external agent chose.
+
+    Attributes:
+        kind: The action verb (see :class:`ActionKind`).
+        target: The action target -- a URL, CSS/accessibility selector, or
+            element ref. Free-form but canonicalised into the anchor as-is.
+        value_digest: SHA-256 hex digest of any typed value. The raw value is
+            never stored or anchored, so secrets typed into a form never enter
+            the lineage chain in plain text. Empty for actions that type
+            nothing (click, navigate, scroll).
+    """
+
+    kind: ActionKind
+    target: str = ""
+    value_digest: str = ""
+
+    def to_canonical_dict(self) -> dict[str, str]:
+        """Return the canonical dict folded into the anchor preimage."""
+        return {
+            "kind": str(self.kind),
+            "target": self.target,
+            "value_digest": self.value_digest,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ActionObservation:
+    """The pre-action observation an anchor binds to.
+
+    Attributes:
+        screenshot_sha256: CAS key (SHA-256 hex) of the pre-action screenshot
+            bytes. The bytes themselves live in the content-addressed store.
+        dom_digest: A normalised accessibility/DOM digest (hex). Hashing a
+            normalised accessibility tree rather than raw HTML keeps the digest
+            stable across cosmetically noisy dynamic pages.
+        observation_hash: ``sha256(screenshot_bytes + dom_digest)``. This is the
+            value folded into the action anchor; it binds the anchor to the
+            exact bytes the agent saw before it acted.
+    """
+
+    screenshot_sha256: str
+    dom_digest: str
+    observation_hash: str
+
+
+# ---------------------------------------------------------------------------
+# Digest + anchor helpers
+# ---------------------------------------------------------------------------
+
+
+def digest_typed_value(value: str | bytes) -> str:
+    """Return the SHA-256 hex digest of a typed value.
+
+    Used to anchor *what* an agent typed without ever recording the raw value.
+    """
+    raw = value.encode("utf-8") if isinstance(value, str) else value
+    return hashlib.sha256(raw).hexdigest()
+
+
+def compute_observation_hash(*, screenshot_bytes: bytes, dom_digest: str) -> str:
+    """Return ``sha256(screenshot_bytes + dom_digest)``.
+
+    The two inputs are concatenated in a fixed order (screenshot bytes first,
+    then the UTF-8 bytes of the accessibility digest) so the value is stable
+    and reproducible from the stored bytes on replay.
+    """
+    h = hashlib.sha256()
+    h.update(screenshot_bytes)
+    h.update(dom_digest.encode("utf-8"))
+    return h.hexdigest()
+
+
+def _canonical(body: dict[str, object]) -> bytes:
+    """RFC 8785-style canonical JSON bytes (sorted keys, minimal separators)."""
+    return json.dumps(
+        body,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def action_anchor_preimage(*, prev_anchor: str, observation_hash: str, action: Action) -> bytes:
+    """Return the canonical bytes whose SHA-256 is the action anchor.
+
+    These bytes are also what the lineage recorder hashes into the entry's
+    ``content_hash``, so ``content_hash == "sha256:" + action_anchor`` -- the
+    anchor *is* the signed content hash, not a field bolted next to it.
+    """
+    return _canonical(
+        {
+            "prev_anchor": prev_anchor,
+            "observation_hash": observation_hash,
+            "action": action.to_canonical_dict(),
+        }
+    )
+
+
+def compute_action_anchor(*, prev_anchor: str, observation_hash: str, action: Action) -> str:
+    """Return the action anchor hex digest.
+
+    ``action_anchor = sha256(canonical(prev_anchor, observation_hash, action))``.
+    """
+    return hashlib.sha256(
+        action_anchor_preimage(prev_anchor=prev_anchor, observation_hash=observation_hash, action=action)
+    ).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Adapter capability check
+# ---------------------------------------------------------------------------
+
+#: Registry names of adapters that advertise computer-use capability. Kept as a
+#: frozenset mirroring ``_MULTIMODAL_ADAPTERS`` in
+#: :mod:`bernstein.core.agents.multimodal`.
+_COMPUTER_USE_ADAPTERS: frozenset[str] = frozenset({"computer_use"})
+
+
+def is_computer_use_capable(adapter_name: str) -> bool:
+    """Check whether an adapter can front a browser / computer-use task.
+
+    Mirrors :func:`bernstein.core.agents.multimodal.is_multimodal_capable`: an
+    adapter that is not registered here raises a structured
+    :class:`~bernstein.core.agents.computer_use_attestation.ComputerUseRefusal`
+    before any process launch when handed a browser task.
+
+    Args:
+        adapter_name: The adapter name as used in the adapter registry.
+
+    Returns:
+        ``True`` when the adapter is known to accept computer-use tasks.
+    """
+    return adapter_name.lower() in _COMPUTER_USE_ADAPTERS
+
+
+__all__ = [
+    "GENESIS_ANCHOR",
+    "Action",
+    "ActionKind",
+    "ActionObservation",
+    "action_anchor_preimage",
+    "compute_action_anchor",
+    "compute_observation_hash",
+    "digest_typed_value",
+    "is_computer_use_capable",
+]

--- a/src/bernstein/core/agents/computer_use_attestation.py
+++ b/src/bernstein/core/agents/computer_use_attestation.py
@@ -1,0 +1,525 @@
+"""Per-action anchoring, recording, and replay for computer-use agents (#2606).
+
+This module is the outbound counterpart to
+:mod:`bernstein.core.agents.multimodal_attestation`. Where that module attests
+an operator-supplied ``--attach`` image *into* a run, this one instruments the
+boundary crossing for a *third-party autonomous* browser / computer-use agent so
+each action the external agent decides on becomes an anchored, signed, replayable
+record.
+
+Substrate coupling (the point, not decoration)
+-----------------------------------------------
+Each recorded action touches four substrate pieces, and stripping any one
+collapses the feature rather than merely losing its log:
+
+* :mod:`bernstein.core.persistence.cas_store` -- the pre-action screenshot bytes
+  are stored once by SHA-256 (dedup, byte-exact retrieval on replay).
+* :mod:`bernstein.core.lineage.recorder` / ``store`` -- the action anchor is the
+  entry's ``content_hash`` and its ``parent_hashes`` is the prior anchor, so the
+  action stream is a single-parent, HMAC-enveloped, Ed25519-signed lineage
+  chain. The signed head anchor is the run's identity.
+* :mod:`bernstein.core.security.audit_chain` -- a ``computer_use.action`` event
+  per action is the replay manifest: which CAS blob, which DOM digest, which
+  action produced each anchor.
+
+Replay walks the signed chain, re-hashes the stored bytes, recomputes each
+anchor, and reports the *first* action index whose recomputed anchor diverges
+from the signed value. A one-byte flip in a stored screenshot changes that
+action's observation hash, hence its anchor, hence surfaces as a hash mismatch
+at the exact index -- never a flaky text assertion. A plain-file implementation
+(screenshots on disk with no anchor binding) cannot reproduce this: it has
+nothing to recompute the tampered bytes against.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from bernstein.core.agents.computer_use import (
+    GENESIS_ANCHOR,
+    Action,
+    ActionKind,
+    action_anchor_preimage,
+    compute_action_anchor,
+    compute_observation_hash,
+    is_computer_use_capable,
+)
+from bernstein.core.agents.multimodal_attestation import CapabilityRefusal
+from bernstein.core.security.audit_chain import (
+    EVENT_COMPUTER_USE_ACTION,
+    record_computer_use_action,
+)
+
+if TYPE_CHECKING:
+    from bernstein.core.lineage.identity import AgentCard
+    from bernstein.core.lineage.recorder import LineageRecorder
+    from bernstein.core.lineage.store import LineageStore
+    from bernstein.core.persistence.cas_store import CASStore
+    from bernstein.core.security.audit_chain import AuditChainStore
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Capability gating
+# ---------------------------------------------------------------------------
+
+#: Adapters that advertise ``is_computer_use_capable() == True``. Sorted tuple
+#: so refusal messages are deterministic.
+_CAPABLE_SUGGESTIONS: tuple[str, ...] = ("computer_use",)
+
+
+class ComputerUseRefusal(CapabilityRefusal):
+    """Raised when an incapable adapter is asked to front a browser task.
+
+    Subclasses :class:`~bernstein.core.agents.multimodal_attestation.CapabilityRefusal`
+    so callers that already catch ``CapabilityRefusal`` (the multimodal boundary
+    error) catch this too -- it is the *same structured* refusal, populated with
+    ``suggested_adapters``, just for the computer-use boundary.
+    """
+
+    def __init__(self, adapter_name: str, suggested_adapters: tuple[str, ...]) -> None:
+        # Bypass the multimodal-specific message but keep the same public
+        # attributes (adapter_name / suggested_adapters) so isinstance checks
+        # and structured handling are identical.
+        self.adapter_name = adapter_name
+        self.suggested_adapters = suggested_adapters
+        RuntimeError.__init__(
+            self,
+            f"Adapter {adapter_name!r} cannot front a browser / computer-use task. "
+            f"Suggested capable adapters: {', '.join(suggested_adapters)}.",
+        )
+
+
+def refuse_when_incapable(
+    *,
+    adapter_name: str,
+    action_count: int,
+) -> None:
+    """Raise :class:`ComputerUseRefusal` before any process launch.
+
+    Parity with
+    :func:`bernstein.core.agents.multimodal_attestation.refuse_when_incapable`:
+    an incapable adapter fronting a non-empty browser task is refused up front,
+    with ``suggested_adapters`` naming capable adapters.
+
+    Args:
+        adapter_name: Registry name of the selected adapter (case-insensitive).
+        action_count: Number of browser actions the task will drive. Zero means
+            there is nothing to refuse (no browser work requested).
+
+    Raises:
+        ComputerUseRefusal: When ``action_count > 0`` and the adapter is not
+            computer-use-capable.
+    """
+    if action_count <= 0:
+        return
+    if is_computer_use_capable(adapter_name):
+        return
+    raise ComputerUseRefusal(adapter_name=adapter_name, suggested_adapters=_CAPABLE_SUGGESTIONS)
+
+
+# ---------------------------------------------------------------------------
+# Byte-cap refusal (CAS growth guard)
+# ---------------------------------------------------------------------------
+
+
+class ActionByteCapExceeded(RuntimeError):
+    """Raised when a run's cumulative screenshot bytes exceed the per-run cap.
+
+    Per-action screenshots are large; the cap is a typed refusal on overflow so
+    a runaway run cannot silently balloon the content-addressed store.
+    """
+
+    def __init__(self, run_id: str, cap_bytes: int, would_be_bytes: int) -> None:
+        self.run_id = run_id
+        self.cap_bytes = cap_bytes
+        self.would_be_bytes = would_be_bytes
+        super().__init__(
+            f"Computer-use run {run_id!r} would store {would_be_bytes} screenshot "
+            f"bytes, exceeding the per-run cap of {cap_bytes} bytes."
+        )
+
+
+#: Default per-run cumulative screenshot byte cap (64 MiB). Generous for a
+#: normal click flow; a typed refusal fires past it.
+DEFAULT_RUN_BYTE_CAP = 64 * 1024 * 1024
+
+
+# ---------------------------------------------------------------------------
+# Recorded action
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ActionAnchorRecord:
+    """A single recorded, anchored action.
+
+    Attributes:
+        index: Zero-based position in the run.
+        anchor: The action anchor (hex). Equal to the lineage entry's
+            ``content_hash`` minus the ``sha256:`` prefix.
+        prev_anchor: The prior anchor folded into this one.
+        observation_hash: ``sha256(screenshot_bytes + dom_digest)``.
+        screenshot_sha256: CAS key of the pre-action screenshot bytes.
+        dom_digest: Normalised DOM/accessibility digest.
+        action: The canonicalised action.
+        lineage_entry_hash: The signed lineage entry hash (``sha256:...``).
+    """
+
+    index: int
+    anchor: str
+    prev_anchor: str
+    observation_hash: str
+    screenshot_sha256: str
+    dom_digest: str
+    action: Action
+    lineage_entry_hash: str
+
+
+def _artefact_path(run_id: str, index: int) -> str:
+    """Return the repo-relative lineage artefact path for an action."""
+    return f".sdd/computer-use/{run_id}/action-{index:06d}.json"
+
+
+def _parse_index(artefact_path: str) -> int | None:
+    """Parse the action index out of an artefact path, or ``None``."""
+    stem = artefact_path.rsplit("/", 1)[-1]
+    if not stem.startswith("action-") or not stem.endswith(".json"):
+        return None
+    digits = stem[len("action-") : -len(".json")]
+    return int(digits) if digits.isdigit() else None
+
+
+# ---------------------------------------------------------------------------
+# Recording session
+# ---------------------------------------------------------------------------
+
+
+class ComputerUseSession:
+    """Records the per-action lineage chain for one browser / computer-use run.
+
+    The session owns the running ``prev_anchor`` and action index. Each
+    :meth:`record_action` stores the pre-action bytes in CAS, records one signed
+    lineage entry whose ``content_hash`` is the action anchor and whose
+    ``parent_hashes`` is the prior anchor, and appends the ``computer_use.action``
+    replay-manifest event to the audit chain.
+
+    Args:
+        run_id: Identifier for this run (namespaces the lineage artefact paths).
+        worker_id: Bernstein agent id fronting the external agent.
+        worktree_id: Worktree the run is isolated to.
+        cas: Content-addressed blob store (reused, not re-created).
+        audit_chain: Audit chain store.
+        lineage_recorder: The lineage recorder (holds the operator HMAC key).
+        agent_card: Agent Card carrying the signing public key id.
+        private_key_pem: PEM-encoded Ed25519 private key for the agent.
+        run_byte_cap: Per-run cumulative screenshot byte cap.
+    """
+
+    def __init__(
+        self,
+        *,
+        run_id: str,
+        worker_id: str,
+        worktree_id: str,
+        cas: CASStore,
+        audit_chain: AuditChainStore,
+        lineage_recorder: LineageRecorder,
+        agent_card: AgentCard,
+        private_key_pem: str,
+        run_byte_cap: int = DEFAULT_RUN_BYTE_CAP,
+    ) -> None:
+        self.run_id = run_id
+        self.worker_id = worker_id
+        self.worktree_id = worktree_id
+        self._cas = cas
+        self._audit_chain = audit_chain
+        self._lineage = lineage_recorder
+        self._agent_card = agent_card
+        self._private_key_pem = private_key_pem
+        self._run_byte_cap = run_byte_cap
+        self._prev_anchor = GENESIS_ANCHOR
+        self._index = 0
+        self._bytes_stored = 0
+        self._records: list[ActionAnchorRecord] = []
+
+    @property
+    def head_anchor(self) -> str:
+        """The current head anchor (the run's identity so far)."""
+        return self._prev_anchor
+
+    @property
+    def records(self) -> tuple[ActionAnchorRecord, ...]:
+        """All actions recorded so far, in order."""
+        return tuple(self._records)
+
+    def record_action(
+        self,
+        *,
+        screenshot_bytes: bytes,
+        dom_digest: str,
+        action: Action,
+    ) -> ActionAnchorRecord:
+        """Store the observation, anchor the action, and sign + audit it.
+
+        Args:
+            screenshot_bytes: The exact pre-action screenshot bytes the agent
+                saw before it acted.
+            dom_digest: Normalised DOM/accessibility digest of the same state.
+            action: The canonicalised action the agent chose.
+
+        Returns:
+            The :class:`ActionAnchorRecord` for the recorded action.
+
+        Raises:
+            ActionByteCapExceeded: When storing the bytes would push the run
+                past its cumulative screenshot byte cap.
+        """
+        would_be = self._bytes_stored + len(screenshot_bytes)
+        if would_be > self._run_byte_cap:
+            raise ActionByteCapExceeded(
+                run_id=self.run_id,
+                cap_bytes=self._run_byte_cap,
+                would_be_bytes=would_be,
+            )
+
+        index = self._index
+        prev_anchor = self._prev_anchor
+
+        # 1. Pre-action bytes into CAS (dedup, byte-exact retrieval on replay).
+        screenshot_sha256 = self._cas.put(
+            screenshot_bytes,
+            content_type="image/png",
+            metadata={
+                "kind": "computer_use.pre_action_screenshot",
+                "run_id": self.run_id,
+                "worktree_id": self.worktree_id,
+                "worker_id": self.worker_id,
+                "action_index": index,
+            },
+        )
+        self._bytes_stored = would_be
+
+        # 2. observation_hash binds the anchor to the exact observed bytes.
+        observation_hash = compute_observation_hash(screenshot_bytes=screenshot_bytes, dom_digest=dom_digest)
+
+        # 3. The anchor IS the lineage content: content_hash == "sha256:" + anchor.
+        anchor = compute_action_anchor(prev_anchor=prev_anchor, observation_hash=observation_hash, action=action)
+        preimage = action_anchor_preimage(prev_anchor=prev_anchor, observation_hash=observation_hash, action=action)
+
+        # 4. Signed lineage entry: parent_hashes is the prior anchor (genesis has
+        #    none). A fresh artefact path per action keeps the tip empty so the
+        #    only parent is the anchor we pass, matching the anchor chain 1:1.
+        extra_parents = None if index == 0 else [f"sha256:{prev_anchor}"]
+        span_id = hashlib.sha256(f"{self.run_id}:{index}".encode()).hexdigest()[:16]
+        entry_hash = self._lineage.record_write(
+            artefact_path=_artefact_path(self.run_id, index),
+            new_content=preimage,
+            agent_id=self.worker_id,
+            agent_card=self._agent_card,
+            private_key_pem=self._private_key_pem,
+            tool_call_id=f"{self.run_id}:action:{index}",
+            span_id=span_id,
+            artefact_kind="tool-result",
+            extra_parents=extra_parents,
+        )
+
+        # 5. Replay-manifest event on the audit chain.
+        record_computer_use_action(
+            chain=self._audit_chain,
+            run_id=self.run_id,
+            action_index=index,
+            anchor=anchor,
+            prev_anchor=prev_anchor,
+            observation_hash=observation_hash,
+            screenshot_sha256=screenshot_sha256,
+            dom_digest=dom_digest,
+            action_kind=str(action.kind),
+            action_target=action.target,
+            action_value_digest=action.value_digest,
+            lineage_entry_hash=entry_hash,
+            worker_id=self.worker_id,
+            worktree_id=self.worktree_id,
+        )
+
+        record = ActionAnchorRecord(
+            index=index,
+            anchor=anchor,
+            prev_anchor=prev_anchor,
+            observation_hash=observation_hash,
+            screenshot_sha256=screenshot_sha256,
+            dom_digest=dom_digest,
+            action=action,
+            lineage_entry_hash=entry_hash,
+        )
+        self._records.append(record)
+        self._prev_anchor = anchor
+        self._index += 1
+        return record
+
+
+# ---------------------------------------------------------------------------
+# Replay + divergence detection
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ReplayDivergence:
+    """The first action index whose recomputed anchor diverges from the chain.
+
+    Attributes:
+        action_index: The exact action index at which replay diverged.
+        expected_anchor: The signed anchor recorded in the lineage chain.
+        recomputed_anchor: The anchor recomputed from the stored bytes/action.
+        reason: A short machine-readable reason
+            (``anchor-mismatch`` / ``missing-manifest`` / ``missing-bytes`` /
+            ``missing-lineage``).
+    """
+
+    action_index: int
+    expected_anchor: str
+    recomputed_anchor: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class ReplayResult:
+    """Outcome of replaying a computer-use run.
+
+    Attributes:
+        ok: ``True`` only when every action's recomputed anchor matched the
+            signed chain and the parent linkage held.
+        action_count: Number of signed actions in the run.
+        head_anchor: The recomputed head anchor (the run's identity) when ``ok``.
+        divergence: The first divergence, or ``None`` when ``ok``.
+    """
+
+    ok: bool
+    action_count: int
+    head_anchor: str
+    divergence: ReplayDivergence | None
+
+
+def replay_run(
+    *,
+    run_id: str,
+    store: LineageStore,
+    audit_chain: AuditChainStore,
+    cas: CASStore,
+) -> ReplayResult:
+    """Replay a completed run and detect the first divergent action index.
+
+    Given only the lineage store, the audit chain, and the CAS -- the same three
+    substrate pieces a fresh checkout ships -- this recomputes each action anchor
+    by re-hashing the stored pre-action bytes and comparing against the signed
+    ``content_hash``. It never re-runs the external agent.
+
+    Args:
+        run_id: The run to replay.
+        store: The lineage store holding the signed anchor chain.
+        audit_chain: The audit chain holding the per-action replay manifest.
+        cas: The content-addressed store holding the pre-action screenshots. Read
+            with ``verify=False`` so a tampered blob is detected at the anchor
+            level (naming the index), not masked as a CAS integrity error.
+
+    Returns:
+        A :class:`ReplayResult`. ``ok`` is ``True`` only for a byte-identical
+        replay up to the signed head; otherwise ``divergence`` names the exact
+        first differing action index and both anchors.
+    """
+    prefix = f".sdd/computer-use/{run_id}/action-"
+
+    # 1. Signed anchors from the lineage chain, keyed by action index.
+    signed: dict[int, tuple[str, list[str]]] = {}
+    for entry, _jws in store.read_log():
+        if not entry.artefact_path.startswith(prefix):
+            continue
+        idx = _parse_index(entry.artefact_path)
+        if idx is None:
+            continue
+        anchor_hex = entry.content_hash.split(":", 1)[1] if ":" in entry.content_hash else entry.content_hash
+        signed[idx] = (anchor_hex, list(entry.parent_hashes))
+
+    # 2. Replay manifest from the audit chain, keyed by action index.
+    manifest: dict[int, dict[str, object]] = {}
+    for ev in audit_chain.query(event_type=EVENT_COMPUTER_USE_ACTION):
+        details = ev.details
+        if details.get("run_id") != run_id:
+            continue
+        try:
+            manifest[int(details["action_index"])] = details  # type: ignore[arg-type]
+        except (KeyError, TypeError, ValueError):
+            continue
+
+    # 3. Walk indices in order, recomputing each anchor and checking linkage.
+    prev = GENESIS_ANCHOR
+    head = GENESIS_ANCHOR
+    for idx in sorted(signed):
+        expected_anchor, parents = signed[idx]
+        details = manifest.get(idx)
+        if details is None:
+            return ReplayResult(
+                ok=False,
+                action_count=len(signed),
+                head_anchor=head,
+                divergence=ReplayDivergence(idx, expected_anchor, "", "missing-manifest"),
+            )
+
+        screenshot = cas.get(str(details["screenshot_sha256"]), verify=False)
+        if screenshot is None:
+            return ReplayResult(
+                ok=False,
+                action_count=len(signed),
+                head_anchor=head,
+                divergence=ReplayDivergence(idx, expected_anchor, "", "missing-bytes"),
+            )
+
+        action = Action(
+            kind=ActionKind(str(details["action_kind"])),
+            target=str(details["action_target"]),
+            value_digest=str(details["action_value_digest"]),
+        )
+        observation_hash = compute_observation_hash(
+            screenshot_bytes=screenshot,
+            dom_digest=str(details["dom_digest"]),
+        )
+        recomputed = compute_action_anchor(prev_anchor=prev, observation_hash=observation_hash, action=action)
+
+        if recomputed != expected_anchor:
+            return ReplayResult(
+                ok=False,
+                action_count=len(signed),
+                head_anchor=head,
+                divergence=ReplayDivergence(idx, expected_anchor, recomputed, "anchor-mismatch"),
+            )
+
+        expected_parents = [] if prev == GENESIS_ANCHOR else [f"sha256:{prev}"]
+        if parents != expected_parents:
+            return ReplayResult(
+                ok=False,
+                action_count=len(signed),
+                head_anchor=head,
+                divergence=ReplayDivergence(idx, expected_anchor, recomputed, "parent-mismatch"),
+            )
+
+        prev = recomputed
+        head = recomputed
+
+    return ReplayResult(ok=True, action_count=len(signed), head_anchor=head, divergence=None)
+
+
+__all__ = [
+    "DEFAULT_RUN_BYTE_CAP",
+    "ActionAnchorRecord",
+    "ActionByteCapExceeded",
+    "ComputerUseRefusal",
+    "ComputerUseSession",
+    "ReplayDivergence",
+    "ReplayResult",
+    "refuse_when_incapable",
+    "replay_run",
+]

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -87,6 +87,18 @@ EVENT_COST_PROFILE_REPORT = "cost.profile_report"
 #: artifact byte-identically and check it against the chain.
 EVENT_EVAL_AB_COMPARISON = "eval.ab_comparison"
 
+#: Issue #2606 -- emitted for every action a third-party autonomous browser /
+#: computer-use agent decides on against a live UI. The event is the per-action
+#: replay manifest: it carries the action anchor
+#: (``sha256(prev_anchor, observation_hash, action)``), the prior anchor, the
+#: pre-action screenshot's CAS SHA-256, the normalised DOM/accessibility digest,
+#: the observation hash, the canonicalised action (kind / target / value
+#: digest), the signed lineage entry hash, the worker identity, the worktree
+#: id, and the previous chain digest. Mirrors ``multimodal.attach`` but for the
+#: outbound action stream; a replay walks these events, re-hashes the stored
+#: bytes, recomputes each anchor, and compares against the signed lineage head.
+EVENT_COMPUTER_USE_ACTION = "computer_use.action"
+
 #: Issue #2249 -- emitted once per applied role-template compression
 #: (``bernstein templates compress``). The event carries the full
 #: compression receipt: role, pre/post role-template directory digests,
@@ -887,6 +899,113 @@ def record_multimodal_attach(
         actor=worker_id,
         resource_type="multimodal_attachment",
         resource_id=sha256,
+        details=payload,
+    )
+
+
+@dataclass(frozen=True)
+class ComputerUseActionDetails:
+    """Structured payload for the ``computer_use.action`` event (#2606)."""
+
+    run_id: str
+    action_index: int
+    anchor: str
+    prev_anchor: str
+    observation_hash: str
+    screenshot_sha256: str
+    dom_digest: str
+    action_kind: str
+    action_target: str
+    action_value_digest: str
+    lineage_entry_hash: str
+    worker_id: str
+    worktree_id: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "action_index": self.action_index,
+            "anchor": self.anchor,
+            "prev_anchor": self.prev_anchor,
+            "observation_hash": self.observation_hash,
+            "screenshot_sha256": self.screenshot_sha256,
+            "dom_digest": self.dom_digest,
+            "action_kind": self.action_kind,
+            "action_target": self.action_target,
+            "action_value_digest": self.action_value_digest,
+            "lineage_entry_hash": self.lineage_entry_hash,
+            "worker_id": self.worker_id,
+            "worktree_id": self.worktree_id,
+        }
+
+
+def record_computer_use_action(
+    *,
+    chain: AuditChainStore,
+    run_id: str,
+    action_index: int,
+    anchor: str,
+    prev_anchor: str,
+    observation_hash: str,
+    screenshot_sha256: str,
+    dom_digest: str,
+    action_kind: str,
+    action_target: str,
+    action_value_digest: str,
+    lineage_entry_hash: str,
+    worker_id: str,
+    worktree_id: str,
+) -> AuditEvent:
+    """Append a ``computer_use.action`` event into *chain* (#2606).
+
+    This is the per-action replay manifest for a third-party browser /
+    computer-use agent: it names the CAS blob of the pre-action screenshot, the
+    normalised DOM/accessibility digest, and the canonicalised action, so a
+    replay can re-derive the observation hash and recompute the action anchor
+    without re-running the agent. Mirrors :func:`record_multimodal_attach`.
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        run_id: Identifier of the computer-use run the action belongs to.
+        action_index: Zero-based position of the action in the run.
+        anchor: The action anchor
+            (``sha256(prev_anchor, observation_hash, action)``), lower-case hex.
+        prev_anchor: The prior action's anchor, or the genesis sentinel for the
+            first action.
+        observation_hash: ``sha256(pre_action_screenshot + dom_digest)``.
+        screenshot_sha256: CAS SHA-256 of the pre-action screenshot bytes.
+        dom_digest: Normalised DOM/accessibility digest (hex).
+        action_kind: The action verb (e.g. ``navigate``, ``type``, ``click``).
+        action_target: The action target (URL / selector / element ref).
+        action_value_digest: SHA-256 of any typed value; never the raw value.
+        lineage_entry_hash: The signed lineage entry hash for this action.
+        worker_id: Identifier of the worker fronting the external agent.
+        worktree_id: Worktree the run is isolated to.
+
+    Returns:
+        The recorded :class:`AuditEvent`. The details payload carries every
+        input plus ``prev_chain_digest`` (set to the chain head at write time).
+    """
+    payload = ComputerUseActionDetails(
+        run_id=run_id,
+        action_index=action_index,
+        anchor=anchor,
+        prev_anchor=prev_anchor,
+        observation_hash=observation_hash,
+        screenshot_sha256=screenshot_sha256,
+        dom_digest=dom_digest,
+        action_kind=action_kind,
+        action_target=action_target,
+        action_value_digest=action_value_digest,
+        lineage_entry_hash=lineage_entry_hash,
+        worker_id=worker_id,
+        worktree_id=worktree_id,
+    ).to_dict()
+    return chain.log_with_prev_digest(
+        event_type=EVENT_COMPUTER_USE_ACTION,
+        actor=worker_id,
+        resource_type="computer_use_action",
+        resource_id=anchor,
         details=payload,
     )
 
@@ -4970,6 +5089,7 @@ __all__ = [
     "EVENT_CHECKPOINT_RETRY",
     "EVENT_COMPACTION_RECEIPT",
     "EVENT_COMPACTION_SENSITIVE_GATE",
+    "EVENT_COMPUTER_USE_ACTION",
     "EVENT_CONTEXT_CAPSULE",
     "EVENT_COST_BATCH_ROUTE",
     "EVENT_COST_DISPATCH_RECEIPT",
@@ -5036,6 +5156,7 @@ __all__ = [
     "EVENT_WEBHOOK_PAYLOAD_ANCHOR",
     "EVENT_WORK_LEDGER_ANCHOR",
     "AuditChainStore",
+    "ComputerUseActionDetails",
     "CostProfileReportDetails",
     "EvalAbComparisonDetails",
     "ForkSnapshotDetails",
@@ -5055,6 +5176,7 @@ __all__ = [
     "record_audit_receipt_export",
     "record_automation_action",
     "record_checkpoint_retry",
+    "record_computer_use_action",
     "record_context_capsule",
     "record_cost_batch_route",
     "record_cost_dispatch_receipt",

--- a/tests/contract/contracts/computer_use.yaml
+++ b/tests/contract/contracts/computer_use.yaml
@@ -1,0 +1,27 @@
+# Contract for the reference browser / computer-use adapter (adapter:
+# computer_use, issue #2606).
+#
+# This adapter fronts a third-party autonomous browser / computer-use agent that
+# owns its own decision loop. Bernstein does not drive the step loop here; it
+# launches the external agent, isolates it to a per-task browser profile, and
+# anchors each action the agent takes into a signed lineage chain (the boundary
+# layer lives in bernstein.core.agents.computer_use_attestation). The concrete
+# driver stays behind the adapter contract, so the flag surface below is the
+# reference launcher's, not any specific browser tool's.
+adapter: computer_use
+binary: computer-use-agent
+install:
+  method: none
+  spec: ""
+auth:
+  required_for_help: false
+  required_for_models: false
+  secret_env: ""
+required_flags:
+  - "--model"
+  - "--prompt"
+  - "--user-data-dir"
+required_subcommands: []
+expected_models:
+  command: []
+  required_present: []

--- a/tests/golden/computer_use_adapter.yaml
+++ b/tests/golden/computer_use_adapter.yaml
@@ -1,0 +1,7 @@
+name: computer_use_adapter_spawn
+adapter_class: bernstein.adapters.computer_use.ReferenceComputerUseAdapter
+steps:
+  - prompt: "complete the signup flow on example.test"
+    model: "sonnet"
+    expected_pid: 4242
+    expected_log_suffix: ".log"

--- a/tests/unit/adapters/test_computer_use_adapter.py
+++ b/tests/unit/adapters/test_computer_use_adapter.py
@@ -1,0 +1,218 @@
+"""Browser / computer-use adapter family wiring + isolation (#2606).
+
+Covers:
+* Registration via the registry and dispatch parity with coding adapters.
+* Strategy declaration in ``STRATEGY_MATRIX`` (conformance gate).
+* YAML contract + golden transcript presence.
+* Per-task isolation: two concurrent sessions share no profile state.
+* Typed terminal states for driver failure / timeout.
+* Multimodal-attachment refusal (this adapter fronts actions, not images).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bernstein.adapters._contract import EventChannel, strategy_for
+from bernstein.adapters.base import CLIAdapter, SpawnResult
+from bernstein.adapters.computer_use import (
+    ComputerUseAdapter,
+    ComputerUseDriverError,
+    ComputerUseTerminalState,
+    ReferenceComputerUseAdapter,
+    classify_terminal_state,
+)
+from bernstein.adapters.conformance import assert_strategies_declared
+from bernstein.adapters.registry import get_adapter, iter_adapter_specs
+from bernstein.core.tasks.models import ModelConfig
+
+
+def _popen_mock(pid: int = 4242) -> MagicMock:
+    import subprocess
+
+    m = MagicMock(spec=subprocess.Popen)
+    m.pid = pid
+    m.stdout = MagicMock()
+    return m
+
+
+# ---------------------------------------------------------------------------
+# Registration + conformance
+# ---------------------------------------------------------------------------
+
+
+class TestRegistration:
+    def test_registered_under_computer_use(self) -> None:
+        adapter = get_adapter("computer_use")
+        assert isinstance(adapter, ReferenceComputerUseAdapter)
+        assert isinstance(adapter, ComputerUseAdapter)
+        assert isinstance(adapter, CLIAdapter)
+
+    def test_appears_in_registry_enumeration(self) -> None:
+        names = {name for name, _ in iter_adapter_specs()}
+        assert "computer_use" in names
+
+    def test_strategy_declared(self) -> None:
+        # Missing declaration is a hard conformance failure; this must not raise.
+        assert_strategies_declared()
+
+    def test_strategy_is_poll_pty(self) -> None:
+        # The external agent owns its loop; Bernstein polls for liveness and the
+        # per-action record is the signed lineage chain, not a stdout stream.
+        assert strategy_for("computer_use").event_channel is EventChannel.POLL_PTY
+
+    def test_name_is_string(self) -> None:
+        assert get_adapter("computer_use").name() == "Computer Use"
+
+
+# ---------------------------------------------------------------------------
+# Contract + golden transcript presence
+# ---------------------------------------------------------------------------
+
+
+class TestContractAndGolden:
+    def test_yaml_contract_present(self) -> None:
+        repo_root = Path(__file__).resolve().parents[3]
+        contract = repo_root / "tests" / "contract" / "contracts" / "computer_use.yaml"
+        assert contract.exists(), f"missing YAML contract at {contract}"
+
+    def test_golden_transcript_loads_and_passes(self, tmp_path: Path) -> None:
+        from bernstein.adapters.conformance import ConformanceHarness, load_golden_transcripts
+
+        repo_root = Path(__file__).resolve().parents[3]
+        golden_dir = repo_root / "tests" / "golden"
+        transcripts = [t for t in load_golden_transcripts(golden_dir) if "computer_use" in t.adapter_class]
+        assert transcripts, "computer-use golden transcript not found"
+
+        harness = ConformanceHarness()
+        report = harness.run_all(transcripts, workdir=tmp_path)
+        assert report.passed, report.regressions
+
+
+# ---------------------------------------------------------------------------
+# Spawn + dispatch parity
+# ---------------------------------------------------------------------------
+
+
+class TestSpawn:
+    def test_spawn_returns_spawn_result(self, tmp_path: Path) -> None:
+        adapter = ReferenceComputerUseAdapter()
+        (tmp_path / ".sdd" / "runtime").mkdir(parents=True, exist_ok=True)
+        with patch("bernstein.adapters.computer_use.subprocess.Popen", return_value=_popen_mock()):
+            result = adapter.spawn(
+                prompt="fill the signup form",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="low"),
+                session_id="cu-sess-1",
+                timeout_seconds=0,
+            )
+        assert isinstance(result, SpawnResult)
+        assert result.pid == 4242
+        assert isinstance(result.log_path, Path)
+
+    def test_spawn_refuses_multimodal_attachment(self, tmp_path: Path) -> None:
+        from bernstein.core.agents.multimodal import ModalityType, MultiModalContext, MultiModalInput
+        from bernstein.core.agents.multimodal_attestation import CapabilityRefusal
+
+        adapter = ReferenceComputerUseAdapter()
+        attachment = tmp_path / "shot.png"
+        attachment.write_bytes(b"fake")
+        ctx = MultiModalContext(
+            inputs=(
+                MultiModalInput(
+                    modality=ModalityType.IMAGE,
+                    content_path=attachment,
+                    mime_type="image/png",
+                    description="shot",
+                ),
+            ),
+            primary_modality=ModalityType.IMAGE,
+        )
+        with pytest.raises(CapabilityRefusal):
+            adapter.spawn(
+                prompt="x",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="low"),
+                session_id="cu-sess-2",
+                timeout_seconds=0,
+                multimodal_context=ctx,
+            )
+
+
+# ---------------------------------------------------------------------------
+# AC: isolation -- concurrent browser tasks share no profile state
+# ---------------------------------------------------------------------------
+
+
+class TestIsolation:
+    def test_distinct_sessions_get_disjoint_profile_dirs(self, tmp_path: Path) -> None:
+        adapter = ReferenceComputerUseAdapter()
+        a = adapter.isolated_profile_dir(workdir=tmp_path, session_id="task-a")
+        b = adapter.isolated_profile_dir(workdir=tmp_path, session_id="task-b")
+        assert a != b
+        # Neither is a parent of the other.
+        assert a not in b.parents
+        assert b not in a.parents
+
+    def test_no_cookie_bleed_between_concurrent_tasks(self, tmp_path: Path) -> None:
+        adapter = ReferenceComputerUseAdapter()
+        a = adapter.prepare_isolation(workdir=tmp_path, session_id="task-a")
+        b = adapter.prepare_isolation(workdir=tmp_path, session_id="task-b")
+
+        (a / "cookies.sqlite").write_text("session=aaa")
+        assert not (b / "cookies.sqlite").exists(), "cookie bled into the other task's profile"
+
+    def test_same_session_is_stable(self, tmp_path: Path) -> None:
+        adapter = ReferenceComputerUseAdapter()
+        one = adapter.isolated_profile_dir(workdir=tmp_path, session_id="task-a")
+        two = adapter.isolated_profile_dir(workdir=tmp_path, session_id="task-a")
+        assert one == two
+
+    def test_spawn_creates_isolated_profile(self, tmp_path: Path) -> None:
+        adapter = ReferenceComputerUseAdapter()
+        (tmp_path / ".sdd" / "runtime").mkdir(parents=True, exist_ok=True)
+        with patch("bernstein.adapters.computer_use.subprocess.Popen", return_value=_popen_mock()):
+            adapter.spawn(
+                prompt="x",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="low"),
+                session_id="cu-iso",
+                timeout_seconds=0,
+            )
+        assert adapter.isolated_profile_dir(workdir=tmp_path, session_id="cu-iso").is_dir()
+
+
+# ---------------------------------------------------------------------------
+# AC: typed terminal states, never free text
+# ---------------------------------------------------------------------------
+
+
+class TestTerminalStates:
+    def test_clean_exit_is_ok(self) -> None:
+        assert classify_terminal_state(exit_code=0, timed_out=False) is ComputerUseTerminalState.OK
+
+    def test_nonzero_exit_is_driver_failure(self) -> None:
+        assert classify_terminal_state(exit_code=1, timed_out=False) is ComputerUseTerminalState.DRIVER_FAILURE
+
+    def test_timeout_is_timeout(self) -> None:
+        assert classify_terminal_state(exit_code=None, timed_out=True) is ComputerUseTerminalState.TIMEOUT
+
+    def test_driver_error_carries_typed_state(self, tmp_path: Path) -> None:
+        adapter = ReferenceComputerUseAdapter(cli_command="definitely-not-on-path-xyz")
+        (tmp_path / ".sdd" / "runtime").mkdir(parents=True, exist_ok=True)
+        with patch(
+            "bernstein.adapters.computer_use.subprocess.Popen",
+            side_effect=FileNotFoundError("no such binary"),
+        ):
+            with pytest.raises(ComputerUseDriverError) as exc:
+                adapter.spawn(
+                    prompt="x",
+                    workdir=tmp_path,
+                    model_config=ModelConfig(model="sonnet", effort="low"),
+                    session_id="cu-fail",
+                    timeout_seconds=0,
+                )
+        assert exc.value.terminal_state is ComputerUseTerminalState.DRIVER_FAILURE

--- a/tests/unit/test_computer_use_lineage.py
+++ b/tests/unit/test_computer_use_lineage.py
@@ -1,0 +1,408 @@
+"""Per-action lineage anchoring for browser / computer-use agents (#2606).
+
+Encodes the issue's acceptance criteria as tests:
+
+* Per-action anchoring: each action stores its pre-action screenshot bytes and
+  DOM digest in CAS and records one ``action_anchor`` lineage entry whose
+  ``parent_hashes`` is the prior anchor.
+* Verifiability (empirical SOTA proof): flipping one byte of one stored
+  screenshot makes chain-walk replay fail and name the exact action index and
+  anchor; a plain-file implementation with no anchor binding cannot satisfy the
+  same test.
+* Determinism: replay of a completed run recomputes byte-identical anchors up to
+  the signed head; a divergent re-run surfaces as a hash mismatch at the first
+  differing index, not free text.
+* Capability refusal: an incapable adapter fronting a browser task raises the
+  structured refusal with populated ``suggested_adapters``, before any launch.
+* CAS-growth guard: a per-run byte cap fires a typed refusal.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.agents.computer_use import (
+    GENESIS_ANCHOR,
+    Action,
+    ActionKind,
+    action_anchor_preimage,
+    compute_action_anchor,
+    compute_observation_hash,
+    digest_typed_value,
+    is_computer_use_capable,
+)
+from bernstein.core.agents.computer_use_attestation import (
+    DEFAULT_RUN_BYTE_CAP,
+    ActionByteCapExceeded,
+    ComputerUseRefusal,
+    ComputerUseSession,
+    refuse_when_incapable,
+    replay_run,
+)
+from bernstein.core.agents.multimodal_attestation import CapabilityRefusal
+from bernstein.core.lineage.identity import AgentCard, generate_keypair
+from bernstein.core.lineage.recorder import LineageRecorder
+from bernstein.core.lineage.store import LineageStore
+from bernstein.core.persistence.cas_store import CASStore
+from bernstein.core.security.audit_chain import (
+    EVENT_COMPUTER_USE_ACTION,
+    AuditChainStore,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _session(tmp_path: Path, *, run_id: str = "run-1", worktree_id: str = "wt-a") -> ComputerUseSession:
+    cas = CASStore(tmp_path / "cas")
+    chain = AuditChainStore(audit_dir=tmp_path / "audit", key=b"k" * 32)
+    store = LineageStore(tmp_path / "lineage")
+    recorder = LineageRecorder(store, operator_hmac_key=b"h" * 32)
+    priv, pub = generate_keypair()
+    card = AgentCard(agent_id="agent:cu-worker", kid="kid-cu-1", public_key_pem=pub)
+    return ComputerUseSession(
+        run_id=run_id,
+        worker_id="agent:cu-worker",
+        worktree_id=worktree_id,
+        cas=cas,
+        audit_chain=chain,
+        lineage_recorder=recorder,
+        agent_card=card,
+        private_key_pem=priv,
+    )
+
+
+def _drive_three(session: ComputerUseSession) -> None:
+    """Record a short golden action transcript: navigate, type, click."""
+    session.record_action(
+        screenshot_bytes=b"\x89PNG-home-screen",
+        dom_digest="dom-home",
+        action=Action(kind=ActionKind.NAVIGATE, target="https://example.test/signup"),
+    )
+    session.record_action(
+        screenshot_bytes=b"\x89PNG-form-screen",
+        dom_digest="dom-form",
+        action=Action(kind=ActionKind.TYPE, target="#email", value_digest=digest_typed_value("user@example.test")),
+    )
+    session.record_action(
+        screenshot_bytes=b"\x89PNG-ready-screen",
+        dom_digest="dom-ready",
+        action=Action(kind=ActionKind.CLICK, target="#submit"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Anchor primitives
+# ---------------------------------------------------------------------------
+
+
+class TestAnchorPrimitives:
+    def test_observation_hash_is_deterministic(self) -> None:
+        a = compute_observation_hash(screenshot_bytes=b"abc", dom_digest="d")
+        b = compute_observation_hash(screenshot_bytes=b"abc", dom_digest="d")
+        assert a == b
+        assert len(a) == 64
+
+    def test_observation_hash_changes_with_screenshot_bytes(self) -> None:
+        a = compute_observation_hash(screenshot_bytes=b"abc", dom_digest="d")
+        b = compute_observation_hash(screenshot_bytes=b"abd", dom_digest="d")
+        assert a != b
+
+    def test_observation_hash_changes_with_dom_digest(self) -> None:
+        a = compute_observation_hash(screenshot_bytes=b"abc", dom_digest="d1")
+        b = compute_observation_hash(screenshot_bytes=b"abc", dom_digest="d2")
+        assert a != b
+
+    def test_anchor_folds_in_prev_anchor(self) -> None:
+        obs = compute_observation_hash(screenshot_bytes=b"x", dom_digest="d")
+        act = Action(kind=ActionKind.CLICK, target="#a")
+        first = compute_action_anchor(prev_anchor=GENESIS_ANCHOR, observation_hash=obs, action=act)
+        chained = compute_action_anchor(prev_anchor=first, observation_hash=obs, action=act)
+        assert first != chained
+
+    def test_anchor_is_deterministic(self) -> None:
+        obs = compute_observation_hash(screenshot_bytes=b"x", dom_digest="d")
+        act = Action(kind=ActionKind.TYPE, target="#f", value_digest="deadbeef")
+        one = compute_action_anchor(prev_anchor="p", observation_hash=obs, action=act)
+        two = compute_action_anchor(prev_anchor="p", observation_hash=obs, action=act)
+        assert one == two
+
+    def test_typed_value_digest_never_exposes_raw(self) -> None:
+        secret = "hunter2-super-secret"
+        digest = digest_typed_value(secret)
+        assert secret not in digest
+        assert len(digest) == 64
+
+    def test_preimage_hashes_to_anchor(self) -> None:
+        import hashlib
+
+        obs = compute_observation_hash(screenshot_bytes=b"x", dom_digest="d")
+        act = Action(kind=ActionKind.CLICK, target="#a")
+        preimage = action_anchor_preimage(prev_anchor="p", observation_hash=obs, action=act)
+        anchor = compute_action_anchor(prev_anchor="p", observation_hash=obs, action=act)
+        assert hashlib.sha256(preimage).hexdigest() == anchor
+
+
+# ---------------------------------------------------------------------------
+# AC: per-action anchoring stores bytes in CAS + records lineage entry chained
+# to the prior anchor
+# ---------------------------------------------------------------------------
+
+
+class TestPerActionAnchoring:
+    def test_each_action_stores_screenshot_in_cas(self, tmp_path: Path) -> None:
+        session = _session(tmp_path)
+        _drive_three(session)
+        cas = CASStore(tmp_path / "cas")
+        for record in session.records:
+            blob = cas.get(record.screenshot_sha256)
+            assert blob is not None, f"action {record.index} screenshot missing from CAS"
+
+    def test_lineage_content_hash_equals_anchor(self, tmp_path: Path) -> None:
+        session = _session(tmp_path)
+        _drive_three(session)
+        store = LineageStore(tmp_path / "lineage")
+        by_path = {entry.artefact_path: entry for entry, _ in store.read_log()}
+        for record in session.records:
+            path = f".sdd/computer-use/{session.run_id}/action-{record.index:06d}.json"
+            entry = by_path[path]
+            assert entry.content_hash == f"sha256:{record.anchor}"
+
+    def test_parent_hashes_is_prior_anchor(self, tmp_path: Path) -> None:
+        session = _session(tmp_path)
+        _drive_three(session)
+        store = LineageStore(tmp_path / "lineage")
+        by_path = {entry.artefact_path: entry for entry, _ in store.read_log()}
+
+        recs = session.records
+        genesis = by_path[f".sdd/computer-use/{session.run_id}/action-000000.json"]
+        assert genesis.parent_hashes == []  # genesis has no parent
+
+        for record in recs[1:]:
+            path = f".sdd/computer-use/{session.run_id}/action-{record.index:06d}.json"
+            entry = by_path[path]
+            assert entry.parent_hashes == [f"sha256:{record.prev_anchor}"]
+
+    def test_action_records_audit_event(self, tmp_path: Path) -> None:
+        session = _session(tmp_path)
+        _drive_three(session)
+        chain = AuditChainStore(audit_dir=tmp_path / "audit", key=b"k" * 32)
+        events = chain.query(event_type=EVENT_COMPUTER_USE_ACTION)
+        assert len(events) == 3
+        indices = sorted(int(e.details["action_index"]) for e in events)
+        assert indices == [0, 1, 2]
+
+    def test_audit_chain_verifies_after_actions(self, tmp_path: Path) -> None:
+        session = _session(tmp_path)
+        _drive_three(session)
+        chain = AuditChainStore(audit_dir=tmp_path / "audit", key=b"k" * 32)
+        ok, errors = chain.verify()
+        assert ok, errors
+
+    def test_head_anchor_is_last_action_anchor(self, tmp_path: Path) -> None:
+        session = _session(tmp_path)
+        _drive_three(session)
+        assert session.head_anchor == session.records[-1].anchor
+
+
+# ---------------------------------------------------------------------------
+# AC: determinism -- replay recomputes byte-identical anchors up to the head
+# ---------------------------------------------------------------------------
+
+
+class TestReplayDeterminism:
+    def test_clean_replay_passes(self, tmp_path: Path) -> None:
+        session = _session(tmp_path)
+        _drive_three(session)
+        store = LineageStore(tmp_path / "lineage")
+        chain = AuditChainStore(audit_dir=tmp_path / "audit", key=b"k" * 32)
+        cas = CASStore(tmp_path / "cas")
+
+        result = replay_run(run_id=session.run_id, store=store, audit_chain=chain, cas=cas)
+        assert result.ok
+        assert result.divergence is None
+        assert result.action_count == 3
+        assert result.head_anchor == session.records[-1].anchor
+
+    def test_replay_from_fresh_store_objects(self, tmp_path: Path) -> None:
+        # Determinism: a fresh checkout (new store objects over the same dirs)
+        # recomputes the identical head anchor without re-running the agent.
+        session = _session(tmp_path)
+        _drive_three(session)
+        expected_head = session.head_anchor
+
+        result = replay_run(
+            run_id=session.run_id,
+            store=LineageStore(tmp_path / "lineage"),
+            audit_chain=AuditChainStore(audit_dir=tmp_path / "audit", key=b"k" * 32),
+            cas=CASStore(tmp_path / "cas"),
+        )
+        assert result.ok
+        assert result.head_anchor == expected_head
+
+
+# ---------------------------------------------------------------------------
+# AC: verifiability (empirical SOTA proof) -- one flipped byte fails replay at
+# the exact index; a plain-file implementation cannot detect it
+# ---------------------------------------------------------------------------
+
+
+class TestTamperDetection:
+    def test_flipping_one_screenshot_byte_fails_at_exact_index(self, tmp_path: Path) -> None:
+        session = _session(tmp_path)
+        _drive_three(session)
+        cas = CASStore(tmp_path / "cas")
+
+        target = session.records[1]  # tamper with the second action's screenshot
+        blob_path = cas._blob_path(target.screenshot_sha256)
+        raw = bytearray(blob_path.read_bytes())
+        raw[0] ^= 0x01  # flip exactly one bit of one byte
+        blob_path.write_bytes(bytes(raw))
+
+        result = replay_run(
+            run_id=session.run_id,
+            store=LineageStore(tmp_path / "lineage"),
+            audit_chain=AuditChainStore(audit_dir=tmp_path / "audit", key=b"k" * 32),
+            cas=CASStore(tmp_path / "cas"),
+        )
+        assert not result.ok
+        assert result.divergence is not None
+        assert result.divergence.action_index == 1  # names the exact index
+        assert result.divergence.reason == "anchor-mismatch"
+        assert result.divergence.expected_anchor == target.anchor
+        assert result.divergence.recomputed_anchor != target.anchor
+
+    def test_tampering_a_recorded_action_field_fails_replay(self, tmp_path: Path) -> None:
+        # Flip one field of one recorded action in the audit manifest: replay
+        # recomputes a different anchor and diverges at that index.
+        session = _session(tmp_path)
+        _drive_three(session)
+
+        audit_log = tmp_path / "audit"
+        # The audit chain writes JSONL; rewrite the click target on the last
+        # action and confirm replay refuses (the manifest no longer reproduces
+        # the signed anchor).
+        log_files = list(audit_log.glob("*.jsonl"))
+        assert log_files, "audit log file missing"
+        log_path = log_files[0]
+        lines = log_path.read_text().splitlines()
+        rewritten: list[str] = []
+        for line in lines:
+            obj = json.loads(line)
+            details = obj.get("details", {})
+            if obj.get("event_type") == EVENT_COMPUTER_USE_ACTION and details.get("action_index") == 2:
+                details["action_target"] = "#cancel"  # was "#submit"
+            rewritten.append(json.dumps(obj))
+        log_path.write_text("\n".join(rewritten) + "\n")
+
+        result = replay_run(
+            run_id=session.run_id,
+            store=LineageStore(tmp_path / "lineage"),
+            audit_chain=AuditChainStore(audit_dir=tmp_path / "audit", key=b"k" * 32),
+            cas=CASStore(tmp_path / "cas"),
+        )
+        assert not result.ok
+        assert result.divergence is not None
+        assert result.divergence.action_index == 2
+
+    def test_plain_file_implementation_cannot_detect_tamper(self, tmp_path: Path) -> None:
+        """A plain-file screenshot log with no anchor binding cannot pass the
+        same tamper test -- proving the substrate coupling is load-bearing.
+
+        The naive implementation writes each screenshot to a plain file and a
+        JSON action log next to it, then "replays" by reading the log. It has no
+        content-addressed anchor to recompute, so flipping a byte in a stored
+        screenshot is invisible to it: its replay still reports success. The
+        lineage-anchored implementation, given the identical tamper, fails at the
+        exact index (asserted above).
+        """
+
+        class _PlainFileActionLog:
+            """Screenshots as plain files + a JSON log; no anchor, no CAS, no sig."""
+
+            def __init__(self, root: Path) -> None:
+                self.root = root
+                self.root.mkdir(parents=True, exist_ok=True)
+                self._entries: list[dict[str, str]] = []
+
+            def record(self, *, index: int, screenshot_bytes: bytes, action: dict[str, str]) -> None:
+                shot = self.root / f"action-{index}.png"
+                shot.write_bytes(screenshot_bytes)
+                self._entries.append({"index": str(index), "screenshot": str(shot), **action})
+                (self.root / "log.json").write_text(json.dumps(self._entries))
+
+            def replay_ok(self) -> bool:
+                # No anchor binds the bytes to the log, so "replay" is just:
+                # does the log parse and do the files exist? Tampering with the
+                # file contents cannot be seen here.
+                entries = json.loads((self.root / "log.json").read_text())
+                return all(Path(e["screenshot"]).exists() for e in entries)
+
+        plain = _PlainFileActionLog(tmp_path / "plain")
+        plain.record(index=0, screenshot_bytes=b"shot0", action={"kind": "navigate", "target": "x"})
+        plain.record(index=1, screenshot_bytes=b"shot1", action={"kind": "click", "target": "#a"})
+        assert plain.replay_ok()
+
+        # Same tamper: flip a byte of a stored screenshot.
+        shot = tmp_path / "plain" / "action-1.png"
+        raw = bytearray(shot.read_bytes())
+        raw[0] ^= 0x01
+        shot.write_bytes(bytes(raw))
+
+        # The plain-file implementation is blind to the tamper -- it still passes.
+        assert plain.replay_ok(), "plain-file replay should be unable to detect the tamper"
+
+
+# ---------------------------------------------------------------------------
+# AC: capability refusal before any launch
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilityRefusal:
+    def test_incapable_adapter_refused(self) -> None:
+        with pytest.raises(ComputerUseRefusal) as exc:
+            refuse_when_incapable(adapter_name="aider", action_count=2)
+        assert exc.value.adapter_name == "aider"
+        assert exc.value.suggested_adapters == ("computer_use",)
+
+    def test_refusal_is_a_capability_refusal(self) -> None:
+        # It IS the same structured refusal the multimodal boundary raises.
+        with pytest.raises(CapabilityRefusal):
+            refuse_when_incapable(adapter_name="cursor", action_count=1)
+
+    def test_capable_adapter_not_refused(self) -> None:
+        refuse_when_incapable(adapter_name="computer_use", action_count=5)  # no raise
+
+    def test_zero_actions_never_refused(self) -> None:
+        refuse_when_incapable(adapter_name="aider", action_count=0)  # nothing to front
+
+    def test_capability_predicate(self) -> None:
+        assert is_computer_use_capable("computer_use")
+        assert is_computer_use_capable("COMPUTER_USE")  # case-insensitive
+        assert not is_computer_use_capable("aider")
+
+
+# ---------------------------------------------------------------------------
+# AC: CAS-growth guard -- per-run byte cap fires a typed refusal
+# ---------------------------------------------------------------------------
+
+
+class TestByteCap:
+    def test_default_cap_is_generous(self) -> None:
+        assert DEFAULT_RUN_BYTE_CAP >= 1024 * 1024
+
+    def test_byte_cap_fires_typed_refusal(self, tmp_path: Path) -> None:
+        session = _session(tmp_path)
+        session._run_byte_cap = 10
+        with pytest.raises(ActionByteCapExceeded) as exc:
+            session.record_action(
+                screenshot_bytes=b"this is definitely more than ten bytes",
+                dom_digest="d",
+                action=Action(kind=ActionKind.SCREENSHOT),
+            )
+        assert exc.value.run_id == session.run_id
+        assert exc.value.cap_bytes == 10


### PR DESCRIPTION
Closes #2606.

## Problem

Every coding adapter under `src/bernstein/adapters/` models an agent whose output is a file diff, which the lineage recorder hashes, chains under the operator HMAC, and Ed25519-signs, so a coding run is replayable and offline-verifiable. Browser and computer-use agents (web tasks, form filling, back-office click flows) do not fit that shape: they own their own decision loop and emit a stream of GUI actions, not a diff. Such an agent that "completed" a signup flow leaves no verifiable record of what it did, and because it is non-deterministic by construction it is unauditable absent an anchored action log, which is exactly the property every other agent kind on the substrate does not have.

This admits that last agent class to the same signed-lineage substrate. It is disjoint from the bernstein-driven browser worker (#2523): this fronts an externally-driven agent that decides its own actions and makes that stream verifiable.

## Per-action lineage anchor

For each action the external agent takes:

```
observation_hash = sha256(pre_action_screenshot_bytes + dom_accessibility_digest)
action_anchor    = sha256(canonical(prev_anchor, observation_hash, action))
```

- Pre-action screenshot bytes are stored once in the CAS by SHA-256 (dedup, exact-byte retrieval on replay).
- Only a digest of any typed value is anchored, never the raw keystrokes, so a form-filling agent's secrets never enter the chain.
- Each anchor folds in the prior anchor, so the action stream is a single-parent Merkle chain. Every action is recorded through `LineageRecorder` with the prior anchor as `parent_hashes`, HMAC-enveloped and Ed25519-signed. The anchor **is** the entry's `content_hash`. The head anchor is the run's identity.
- A `computer_use.action` audit event mirrors `multimodal.attach` and carries the per-action replay manifest.

## Deterministic replay + divergence detection

`replay_run(...)` walks the chain using only the lineage store, audit chain, and CAS a fresh checkout ships; it never re-runs the agent. It re-hashes the stored bytes, recomputes each anchor, and compares against the signed head. A divergent re-run surfaces as a hash mismatch at the exact action index (`ReplayDivergence` names the first differing index and both anchors), not a flaky text assertion.

**Empirical verifiability proof (tested):** flipping one byte of one stored pre-action screenshot makes replay fail and name the exact action index; a plain-file implementation with no anchor binding cannot detect the same tamper (`test_plain_file_implementation_cannot_detect_tamper`).

## Also included

- Capability gating: an incapable adapter fronting a browser task raises `ComputerUseRefusal` (a `CapabilityRefusal` subclass) before any launch, with `suggested_adapters` populated, parity with the multimodal boundary.
- Isolation: two concurrent tasks get disjoint per-session browser profile directories (asserted no cookie bleed).
- Typed terminal states: driver failure / timeout map onto `ComputerUseTerminalState`, never free text.
- CAS-growth guard: a per-run byte cap fires a typed `ActionByteCapExceeded`.
- `ComputerUseAdapter` base + `ReferenceComputerUseAdapter` (registry name `computer_use`), `STRATEGY_MATRIX` row, YAML contract, golden transcript, and docs.

## Acceptance criteria

- [x] Adapter registered via the registry, passes its YAML contract and golden transcript, dispatched alongside coding tasks.
- [x] Each action stores pre-action screenshot bytes + DOM digest in CAS and records one `action_anchor` lineage entry whose `parent_hashes` is the prior anchor.
- [x] Verifiability: one flipped byte fails replay and names the exact index/anchor; a plain-file implementation cannot satisfy the same test.
- [x] Determinism: replay from a fresh store recomputes byte-identical anchors up to the signed head; divergence is a hash mismatch at the first differing index.
- [x] Incapable adapter raises `CapabilityRefusal` with populated `suggested_adapters` before any launch.
- [x] Isolation: concurrent tasks share no profile state.
- [x] Driver failure and timeout are typed terminal states.

Additive and behavior-preserving. `ruff check` + `ruff format --check` clean; import-linter contracts kept.