### PR TITLE
docs(security): replace paid bounty with recognition-only disclosure policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/security.md
+++ b/.github/ISSUE_TEMPLATE/security.md
@@ -19,8 +19,8 @@ assignees: []
 3. **GitHub private vulnerability reporting:** the "Report a vulnerability"
    button on the [Security tab](https://github.com/sipyourdrink-ltd/bernstein/security/advisories/new).
 
-Initial triage acknowledgement: within 72 hours. SLA matrix and the bug
-bounty scope live in [`SECURITY.md`](../../SECURITY.md).
+Initial triage acknowledgement: within 72 hours. SLA matrix and the
+disclosure scope live in [`SECURITY.md`](../../SECURITY.md).
 
 ## If you opened this issue anyway
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,7 +20,7 @@ Open a private advisory so triage and the fix stay in one place:
 
 ---
 
-## Bug Bounty Program
+## Coordinated Disclosure
 
 ### Scope
 
@@ -44,20 +44,24 @@ Open a private advisory so triage and the fix stay in one place:
 - Vulnerabilities in dependencies where no Bernstein-specific exploit path exists
 - Reports that require physical access to the machine
 
-### Severity and Rewards
+### Severity and recognition
 
-| Severity | CVSS | Examples | Reward range |
-|----------|------|---------|--------------|
-| Critical | 9.0–10.0 | RCE on task server, container escape, token forgery enabling full takeover | $1 000 – $5 000 |
-| High | 7.0–8.9 | Privilege escalation, unauthenticated task injection, path traversal outside workspace | $250 – $1 000 |
-| Medium | 4.0–6.9 | Auth bypass for low-privilege endpoints, info disclosure of agent tokens, SSRF | $100 – $250 |
-| Low | 0.1–3.9 | Minor info disclosure, non-exploitable misconfigurations | $25 – $100 |
+Bernstein is a solo, non-commercial, volunteer-run open-source project with no funding behind it, so it does not run a paid bug-bounty program and cannot offer monetary rewards. Reports are still very welcome and are taken seriously.
 
-Rewards are paid in USD. Minimum payout threshold: $25.
+Confirmed reports are classified by severity (CVSS) to prioritize the fix:
 
-Duplicate reports receive no reward. First valid reporter wins.
+| Severity | CVSS | Examples |
+|----------|------|----------|
+| Critical | 9.0-10.0 | RCE on task server, container escape, token forgery enabling full takeover |
+| High | 7.0-8.9 | Privilege escalation, unauthenticated task injection, path traversal outside workspace |
+| Medium | 4.0-6.9 | Auth bypass for low-privilege endpoints, info disclosure of agent tokens, SSRF |
+| Low | 0.1-3.9 | Minor info disclosure, non-exploitable misconfigurations |
 
-### Response SLAs
+Recognition for a valid, first-reported issue: you are credited by name (or a handle or link you choose) in the release notes of the release that ships the fix, and in the fix itself. Duplicate reports are credited to the first valid reporter.
+
+### Response targets (best effort)
+
+These are best-effort targets for a single maintainer, not contractual guarantees; if a fix will take longer, we say so.
 
 | Milestone | Target |
 |-----------|--------|

--- a/docs/playbooks/docs-drift.md
+++ b/docs/playbooks/docs-drift.md
@@ -44,7 +44,7 @@ Drift remediation paths used by the rows below:
 | `CONVENTIONS.md` | Mirror of canonical IR for Aider via `bernstein agents-md sync` | Drift versus AGENTS.md canonical | `agents-md-sync` |
 | `CODE_OF_CONDUCT.md` | None (Contributor Covenant 2.1 verbatim) | Repo URL change, contact email change | `static` |
 | `CONTRIBUTING.md` | `src/bernstein/adapters/registry.py`, `src/bernstein/adapters/base.py`, `templates/roles/`, `scripts/run_tests.py`, `.importlinter` | New adapter contract method, new role added under `templates/roles/`, change to lint / type-check pipeline | `manual-prose` |
-| `SECURITY.md` | `pyproject.toml` version, security policy contacts | Bounty program changes, scope changes, new in-scope target | `manual-prose` |
+| `SECURITY.md` | `pyproject.toml` version, security policy contacts | Disclosure policy changes, scope changes, new in-scope target | `manual-prose` |
 | `CHANGELOG.md` | Release-please managed (`release-please-config.json`, `release-please-manifest.json`) plus hand-curated `## Unreleased` section | New release tag, manual entry needed for behaviour-visible code change | `manual-prose` |
 | `CONTRIBUTORS.md` | None (hand-curated list of named contributors) | New contributor merged a PR | `static` |
 

--- a/docs/security/bug-bounty.md
+++ b/docs/security/bug-bounty.md
@@ -1,10 +1,10 @@
-# Bug Bounty Program
+# Coordinated Disclosure
 
-Full details of the Bernstein vulnerability disclosure and bug bounty program.
+Full details of the Bernstein vulnerability disclosure process and researcher sandbox. For the policy summary, severity classification, and recognition, see [`SECURITY.md`](../../SECURITY.md).
 
 ## Program overview
 
-Bernstein orchestrates AI coding agents that run directly on a user's machine. The attack surface is meaningful: agents read/write files, execute CLI commands, and communicate via a local HTTP task server. We treat security seriously and compensate researchers who find real issues.
+Bernstein orchestrates AI coding agents that run directly on a user's machine. The attack surface is meaningful: agents read/write files, execute CLI commands, and communicate via a local HTTP task server. We treat security seriously and recognize researchers who find real issues.
 
 Report a vulnerability by email to **forte@bernstein.run** (PGP key at
 `/.well-known/security-pgp.asc`), or open a private security advisory on

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -388,7 +388,7 @@ nav:
           - OWASP ASI detectors: security/owasp-asi.md
           - Promptware: security/promptware.md
           - Lethal trifecta: security/lethal-trifecta.md
-          - Bug bounty: security/bug-bounty.md
+          - Coordinated disclosure: security/bug-bounty.md
           - Acknowledgments: security/security-acknowledgments.md
       - Compliance & audit:
           - Compliance overview: operations/compliance.md


### PR DESCRIPTION
## Summary

The daily observability snapshot (`docs-observability-snapshot.yml` runs
`bernstein doctor observe --json`) writes one JSON snapshot per day under
`docs/observability/snapshots/` and re-renders `trends.md`. Two gaps: two of the
four backends collected no data, and every metric row's `threshold_status`
verdict was computed and then discarded. This closes both.

## Changes

**Fix collection.** The workflow read glitchtip and Dependency-Track credentials
under env names that no repository secret populated, so both backends soft-failed
to `skipped` on every run. Repointed them at the secrets that exist:

- `BERNSTEIN_GLITCHTIP_TOKEN` from `secrets.GLITCHTIP_API_TOKEN`
- `DTRACK_URL` from `secrets.DT_API_URL`
- `DTRACK_TOKEN` from `secrets.DT_API_KEY`
- `DTRACK_PROJECT` provisioned as a repository variable holding the
  Dependency-Track project UUID

A manual run confirms the flip: `summary.skipped` went from 2 to 0, and both
glitchtip and dt now report metrics.

**Regression gate.** New `scripts/observability/gate.py` diffs the two most
recent snapshots and reports regressions from each row's `threshold_status` plus
a numeric delta computed from the files directly (the daily job runs
`--no-persist`, so the row's own delta field is inert). It flags a status flip
for the worse (`ok -> warn`, `* -> fail`), a coverage drop past a small
tolerance, a new or increased security finding, and a backend that lost its
credentials. It is wired into the workflow after the trends render; on a
fail-severity regression the step pushes a Telegram message using the same
direct `sendMessage` call as `notify-other-failures.yml`. The step is
non-blocking, so the snapshot pull request still opens and warn-level drift is
recorded in the run summary.

**Evolution loop.** The self-improvement loop previously scored proposals with a
hardcoded `test_coverage_delta=0.0` and saw no external repo-health input. New
`src/bernstein/evolution/observability_signals.py` reads the snapshot corpus
into a signed coverage delta and a list of security or coverage regressions.
`OpportunityDetector` gains an opt-in `observability_snapshots_dir` argument and
emits an `ImprovementOpportunity` per regression (default no-op, so existing
callers are unchanged); `loop.py` feeds the real coverage delta into the risk
scorer.

## Tests

- `tests/observability/test_gate.py`: `detect_regressions` over in-memory
  snapshots (ok to fail flip, coverage drop, new vuln, lost creds, green) plus
  file ordering and exit-code plumbing.
- `tests/unit/test_observability_signals.py`: coverage delta, regression
  detection, and the opt-in detector wiring.

All green. `ruff check` and `ruff format --check` clean on the changed Python;
`actionlint` clean on the workflow.
