### PR TITLE
feat(cache): cache policy engine with composable keys, drift expiry, claim dedup, transitive eviction

### DIFF
--- a/docs/concepts/action-cache.md
+++ b/docs/concepts/action-cache.md
@@ -73,11 +73,22 @@ Metrics:
 - Replay is byte-comparison strict. A different timestamp in a
   recorded log is a "drift" finding even if functionally equivalent.
 
+## Cache policy engine
+
+`derive_key` here is input-only and intentionally survives Bernstein code
+changes. When a task declares a `cache_policy` on its spec, its cache decisions
+route through the shared [cache policy engine](cache-policy.md): keys are
+composed over an ingredient recipe that also folds in the model version, adapter
+version, base worktree commit, and tool schema hash; staleness becomes a pure
+drift verdict over repo state; and eviction is transitive over `served_from`
+lineage edges. Tasks with no declared policy behave exactly as described above.
+
 ## Related
 
 - Source: `src/bernstein/core/persistence/action_cache.py`
 - Layered on: `src/bernstein/core/persistence/fingerprint.py` (memo
   store)
+- Policy engine: `src/bernstein/core/persistence/cache_policy.py`
 - CLI: `src/bernstein/cli/commands/cache_cmd.py`,
   `replay_filter_cmd.py`
 - PR #999

--- a/docs/concepts/cache-policy.md
+++ b/docs/concepts/cache-policy.md
@@ -1,0 +1,155 @@
+# Cache policy engine
+
+Bernstein carries three result caches - fingerprint memoization
+(`core/persistence/fingerprint.py`), the action cache
+(`core/persistence/action_cache.py`), and the semantic response cache
+(`core/knowledge/semantic_cache.py`). Each historically hard-coded its own key
+recipe with no shared vocabulary, and none captured the model version, adapter
+version, base worktree commit, or tool schema hash. The only staleness signal
+was the wall clock. A cached agent output could therefore survive a model
+upgrade, an adapter bump, a tool-schema change, or a diff that touched files
+which have since changed - and a wrong hit injects a stale artifact into a run
+that then completes with a proof-of-done receipt built on bad input.
+
+The **cache policy engine** defines what a cache decision *means* at the cache
+boundary: which changes count as relevant (keys), when an entry is stale
+(expiry), how two fleet workers avoid duplicating expensive work (dedup), and
+how a bad value is revoked together with everything derived from it (eviction).
+Its user-visible artifacts are lineage records, signed receipts, and
+audit-chain events rather than ad hoc store rows.
+
+A task opts in by declaring a `cache_policy` on its spec. A task that declares
+none runs byte-identically to the pre-policy spawn path.
+
+## Composable key recipes
+
+A `CachePolicy` (`core/persistence/cache_policy.py`) names an ordered set of
+optional key ingredients on top of five **mandatory** ingredients that are
+always folded in:
+
+| Mandatory ingredient | Source |
+| --- | --- |
+| `model_id` | adapter contract |
+| `model_version` | adapter contract |
+| `adapter_version` | adapter contract |
+| `base_commit` | `git_basic.rev_parse_head` |
+| `tool_schema_hash` | the task's declared tool surface |
+
+The optional ingredients are `task_inputs`, `producer_code`, and
+`run_parameters`. `compose_recipe` lists the mandatory ingredients first, then
+the policy's declared optional ones, hashing each value to a `sha256:` anchor;
+`compose_key` is the `sha256` of the canonical recipe. Any change to a mandatory
+ingredient - or a declared optional one - alters the recipe and therefore the
+key, so a cached output never survives a model, adapter, repo-base, or
+tool-surface change the policy accounts for. The policy hash is folded into the
+recipe, so two policies over identical inputs still produce distinct keys.
+
+```json
+{
+  "ingredients": ["task_inputs"],
+  "expiry_mode": "both",
+  "drift_window": 3,
+  "ttl_seconds": 604800,
+  "verified_only": true,
+  "world_facing": false,
+  "store_scope": "backend"
+}
+```
+
+Inspect a policy file and its hash:
+
+```bash
+bernstein cache policy --file policy.json
+```
+
+## Drift-based expiry (a pure verdict, not a clock race)
+
+`evaluate_freshness(entry, policy, repo_state)` returns a `FreshnessVerdict`
+that is a **pure function** of `(entry, policy, repo_state)`. It reads no clock,
+no filesystem outside the injected repo state, and no network. An entry is fresh
+while:
+
+1. every file its recorded diff touched still hashes to the recorded content
+   hash, and
+2. its base commit is an ancestor within `drift_window` commits of the current
+   head.
+
+Two operators who assemble the same repo state compute the byte-identical
+verdict JSON (a `fresh`/`stale` boolean plus a machine-readable reason token)
+instead of racing a clock. A wall-clock TTL remains only as a declared backstop
+for `world_facing` tasks (web research, external API state) and is honoured only
+through an injected timestamp.
+
+## Hits are spine entries
+
+Every policy cache hit emits a `served_from` entry on the always-on
+`LineageSpine` (`record_served_from` in
+`core/persistence/cache_served_from.py`), at the same write boundary where every
+artifact write is intercepted. Because the spine is Merkle-chained and
+HMAC-tagged, a run that served steps from cache replays to the identical spine
+head; suppressing or mutating any single `served_from` entry fails spine
+verification, so a hidden or forged cache hit is falsification-evident rather
+than merely unlogged.
+
+## Fleet dedup as a claim, not a lock
+
+When two fleet workers resolve the same cache key, cache-key contention routes
+through the atomic claim primitive (`CacheKeyArbiter` in
+`core/persistence/cache_dedup.py`, backed by `core/tasks/claim.py`). Exactly one
+worker wins the spawn; every loser receives a signed `DuplicateOfReceipt`
+binding it to the winner's key and claim position and completes by a lineage
+edge to the winner's verified output rather than blocking on an hours-long run.
+If the winner fails, the claim releases deterministically and the next contender
+proceeds. The receipt verifies offline: mutating the winner reference, the cache
+key, or the claim position breaks the HMAC and `verify_duplicate_receipt` names
+the mismatching field.
+
+## Surgical, transitive eviction
+
+```bash
+bernstein cache evict <key> --reason pr_reverted
+```
+
+Eviction tombstones the key and walks the `served_from` ledger transitively,
+tombstoning every entry reachable over `served_from` edges
+(`core/persistence/cache_eviction.py`). It prints the recall set of consuming
+runs, emits a `cache.eviction` audit-chain event, and writes a recall report
+under `.sdd/caching/policy/`. A tombstoned key is a hard miss forever - it can
+never serve again, even when its drift verdict is fresh.
+
+## Refresh for one run
+
+```bash
+bernstein run <plan> --refresh-cache
+```
+
+`--refresh-cache` exports `BERNSTEIN_REFRESH_CACHE=1`; the cache boundary treats
+every policy lookup as a miss for that run and repopulates with the fresh
+outputs. Tasks with no declared policy are unaffected.
+
+## Audit-chain events
+
+Every hit, miss, dedup claim, and eviction is an audit-chain event carrying the
+policy hash and recipe hash (`record_cache_hit`, `record_cache_miss`,
+`record_cache_dedup_claim`, `record_cache_eviction` in
+`core/security/audit_chain.py`), so the fact that a cache decision was taken
+under a named policy is itself chain-attested. Only hashes, identifiers, and the
+decision are recorded - never prompt or output payloads.
+
+## Determinism and verifiability
+
+* **Determinism.** Policy JSON, recipes, composed keys, freshness verdicts, and
+  recall sets are all canonical JSON (sorted keys, minimal separators, UTF-8),
+  so two byte-identical inputs produce byte-identical bytes and hashes across
+  processes and platforms. The freshness verdict reads no clock, filesystem, or
+  network.
+* **Verifiability.** Hits are Merkle-chained spine entries, dedup edges are
+  HMAC-signed receipts, and evictions are audit-chain events - each
+  independently checkable offline rather than trusted.
+
+## Relationship to `#2519`
+
+`#2519` seals which cache strategy a dispatch decision assumed into the dispatch
+receipt; this engine defines what a cache policy means at the cache boundary
+(keys, expiry, dedup, eviction). A natural follow-up folds the resolved recipe
+hash into the knob selection there.

--- a/docs/concepts/fingerprint-memoization.md
+++ b/docs/concepts/fingerprint-memoization.md
@@ -76,7 +76,18 @@ Metrics exposed on `/metrics`:
 - The decorator does not replace `semantic_cache.py` - that's a
   vector cache for semantic-similarity lookup, a different concern.
 
+## Cache policy engine
+
+The `MemoStore` here is the single backing store the [cache policy
+engine](cache-policy.md) composes over. A task that declares a `cache_policy`
+gets a key composed from an ordered ingredient recipe (mandatory model version,
+adapter version, base worktree commit, and tool schema hash, plus declared
+optional ingredients), a pure drift-based freshness verdict over repo state, and
+transitive eviction over `served_from` lineage edges - all on top of this same
+content-addressed store.
+
 ## Related
 
 - Source: `src/bernstein/core/persistence/fingerprint.py`
+- Policy engine: `src/bernstein/core/persistence/cache_policy.py`
 - PR #995

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -503,6 +503,7 @@ nav:
           - Feature contract: concepts/feature-contract.md
           - Schema validation retry: concepts/schema-validation-retry.md
           - Action cache and replay: concepts/action-cache.md
+          - Cache policy engine: concepts/cache-policy.md
           - Discrete phase pipeline: concepts/phase-pipeline.md
           - Spec-as-test loop: concepts/spec-as-test.md
           - Abstracted code review: concepts/abstracted-code-review.md

--- a/src/bernstein/cli/commands/cache_cmd.py
+++ b/src/bernstein/cli/commands/cache_cmd.py
@@ -15,6 +15,13 @@ from bernstein.core.persistence.action_cache import (
     ActionRecord,
     open_cache,
 )
+from bernstein.core.persistence.cache_eviction import (
+    cache_dir,
+    open_ledger,
+    open_tombstones,
+    write_recall_report,
+)
+from bernstein.core.persistence.cache_policy import CachePolicy
 from bernstein.core.semantic_cache import ResponseCacheManager, SemanticCacheEntry
 
 
@@ -154,6 +161,99 @@ def clear_cache_entries(workdir: Path, unverified_only: bool, yes: bool) -> None
 
     removed = ResponseCacheManager(workdir.resolve()).clear(unverified_only=unverified_only)
     console.print(f"[green]Removed {removed} response-cache entr{'y' if removed == 1 else 'ies'}.[/green]")
+
+
+# ---------------------------------------------------------------------------
+# Cache-policy engine: surgical transitive eviction + policy inspection (#2551).
+# ---------------------------------------------------------------------------
+
+
+@cache_group.command("evict")
+@click.argument("key")
+@click.option("--reason", required=True, help="Machine-readable revocation reason (e.g. 'pr_reverted').")
+@click.option(
+    "--workdir",
+    type=click.Path(path_type=Path, file_okay=False),
+    default=Path(),
+    show_default=True,
+    help="Project root containing .sdd/caching/policy/.",
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Output the recall set as JSON.")
+def evict_cache_key(key: str, reason: str, workdir: Path, as_json: bool) -> None:
+    """Surgically evict a cache KEY and everything derived from it.
+
+    \b
+    Tombstones the key and every entry reachable over ``served_from`` lineage
+    edges, prints the recall set of consuming runs, emits a ``cache.eviction``
+    audit-chain event, and writes a recall report under
+    ``.sdd/caching/policy/``. A tombstoned key can never serve again, even when
+    its drift verdict is fresh.
+    """
+    root = workdir.resolve()
+    ledger = open_ledger(root)
+    tombstones = open_tombstones(root)
+    recall = tombstones.evict(key, reason, ledger=ledger, ts=int(time.time()))
+
+    report_path = cache_dir(root) / f"recall-{key[:16]}.json"
+    write_recall_report(report_path, recall)
+
+    # Chain-attest the eviction. Best-effort: a missing audit key must not fail
+    # the operator's revocation, which is already durable in the tombstone log.
+    try:
+        from bernstein.core.security.audit import load_or_create_audit_key
+        from bernstein.core.security.audit_chain import AuditChainStore, record_cache_eviction
+
+        chain = AuditChainStore(root / ".sdd" / "audit", key=load_or_create_audit_key())
+        record_cache_eviction(
+            chain=chain,
+            cache_key=key,
+            reason=reason,
+            tombstoned_count=len(recall.tombstoned),
+            recall_count=len(recall.consumers),
+        )
+    except Exception as exc:  # eviction durability must not depend on the audit key
+        console.print(f"[yellow]warning: eviction not chain-attested ({exc}); tombstone still applied[/yellow]")
+
+    if as_json:
+        click.echo(json.dumps(recall.to_dict(), indent=2))
+        return
+
+    consumers = ", ".join(recall.consumers) or "(none)"
+    console.print(f"[green]Evicted {len(recall.tombstoned)} key(s) for reason '{reason}'.[/green]")
+    console.print(f"[bold]Root key:[/bold] {key}")
+    console.print(f"[bold]Tombstoned:[/bold] {', '.join(recall.tombstoned) or '(none)'}")
+    console.print(f"[bold]Recall set ({len(recall.consumers)} run(s)):[/bold] {consumers}")
+    console.print(f"[dim]Recall report: {report_path}[/dim]")
+
+
+@cache_group.command("policy")
+@click.option(
+    "--file",
+    "policy_file",
+    type=click.Path(path_type=Path, dir_okay=False, exists=True),
+    required=True,
+    help="JSON file declaring a CachePolicy.",
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Output the resolved policy as JSON.")
+def show_cache_policy(policy_file: Path, as_json: bool) -> None:
+    """Resolve a cache policy file and print its canonical form and hash.
+
+    \b
+    Loads the JSON policy declaration, validates it, and prints the canonical
+    policy plus its ``sha256`` policy hash - the value bound into every cache
+    hit, miss, dedup, and eviction audit event for tasks under this policy.
+    """
+    policy = CachePolicy.from_dict(json.loads(policy_file.read_text(encoding="utf-8")))
+    if as_json:
+        click.echo(json.dumps({"policy": policy.to_dict(), "policy_hash": policy.policy_hash()}, indent=2))
+        return
+    console.print(f"[bold]Policy hash:[/bold] {policy.policy_hash()}")
+    console.print(f"[bold]Ingredients:[/bold] {', '.join(policy.ingredients) or '(mandatory only)'}")
+    console.print(f"[bold]Expiry mode:[/bold] {policy.expiry_mode} (drift window={policy.drift_window})")
+    console.print(f"[bold]TTL seconds:[/bold] {policy.ttl_seconds}")
+    console.print(f"[bold]Verified only:[/bold] {policy.verified_only}")
+    console.print(f"[bold]World facing:[/bold] {policy.world_facing}")
+    console.print(f"[bold]Store scope:[/bold] {policy.store_scope}")
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -857,6 +857,8 @@ def cli(
         max_blast_radius=None,
         # Bot-added: drift autofix (regen_contract_drift.py)
         attach=(),
+        # Bot-added: drift autofix (regen_contract_drift.py)
+        refresh_cache=False,
     )
 
 

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -1212,6 +1212,18 @@ def exec_restart() -> None:
         "Capable adapters: claude, gemini."
     ),
 )
+@click.option(
+    "--refresh-cache",
+    "refresh_cache",
+    is_flag=True,
+    default=False,
+    help=(
+        "Cache policy bypass (issue #2551): ignore every policy cache hit for "
+        "this run, then repopulate the cache with the fresh outputs. Exports "
+        "BERNSTEIN_REFRESH_CACHE=1 for the orchestrator; tasks with no declared "
+        "cache policy are unaffected."
+    ),
+)
 def run(
     plan_file: Path | None,
     goal: str | None,
@@ -1255,6 +1267,7 @@ def run(
     criterion_profile: str | None = None,
     max_blast_radius: float | None = None,
     attach: tuple[Path, ...] = (),
+    refresh_cache: bool = False,
 ) -> None:
     """Parse seed, init workspace, start server, launch agents.
 
@@ -1306,6 +1319,7 @@ def run(
             criterion_profile=criterion_profile,
             max_blast_radius=max_blast_radius,
             attach=attach,
+            refresh_cache=refresh_cache,
         )
     except (click.UsageError, SystemExit):
         raise
@@ -1357,6 +1371,7 @@ def _run_impl(
     criterion_profile: str | None,
     max_blast_radius: float | None,
     attach: tuple[Path, ...] = (),
+    refresh_cache: bool = False,
 ) -> None:
     """Concrete ``run`` implementation; wrapped by :func:`run` for hinting.
 
@@ -1469,6 +1484,12 @@ def _run_impl(
         except (RetryBudgetError, ValueError) as exc:
             raise click.UsageError(f"invalid --retry-budget value: {exc}") from exc
         os.environ["BERNSTEIN_RETRY_BUDGET_SPEC"] = retry_budget_spec
+    # Issue #2551: --refresh-cache bypasses policy cache hits for this run and
+    # repopulates. Exported so the orchestrator's cache boundary reads it via
+    # ``bernstein.core.persistence.cache_policy.refresh_requested``. Tasks with
+    # no declared policy are unaffected.
+    if refresh_cache:
+        os.environ["BERNSTEIN_REFRESH_CACHE"] = "1"
     # Print the startup banner unless the parent ``cli()`` group already
     # rendered the premium splash for this invocation. Regressed by commit
     # 1e5c13013 ("fix: ... double banner ..."), which mistakenly removed the

--- a/src/bernstein/core/persistence/cache_dedup.py
+++ b/src/bernstein/core/persistence/cache_dedup.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import hashlib
 import hmac as _hmac
 import json
+import threading
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -210,6 +211,7 @@ class CacheKeyArbiter:
         self._path = backlog_path
         self._cache_key = cache_key
         self._contenders = 0
+        self._counter_lock = threading.Lock()
 
     @property
     def cache_key(self) -> str:
@@ -229,7 +231,9 @@ class CacheKeyArbiter:
         """
         self._path.parent.mkdir(parents=True, exist_ok=True)
         self._ensure_backlog()
-        self._contenders += 1
+        with self._counter_lock:
+            self._contenders += 1
+            position = self._contenders - 1
         claimed = claim_next_entry(self._path, claimer_id=claimer, filter=ClaimFilter())
         if claimed is not None and claimed.id == self._cache_key:
             return ClaimOutcome(won=True, claimer=claimer, claim_position=0, winner=claimer)
@@ -237,7 +241,7 @@ class CacheKeyArbiter:
         return ClaimOutcome(
             won=False,
             claimer=claimer,
-            claim_position=self._contenders - 1,
+            claim_position=position,
             winner=winner,
         )
 

--- a/src/bernstein/core/persistence/cache_dedup.py
+++ b/src/bernstein/core/persistence/cache_dedup.py
@@ -1,0 +1,272 @@
+"""Claim-based fleet dedup for cache-key contention.
+
+When two fleet workers pick up semantically identical goals that resolve to the
+same cache key, only one should pay for the minutes-to-hours agent run. A naive
+in-process lock cannot dedup across hosts, and a losing worker that *blocks* on
+an hours-long run wastes a seat.
+
+This routes cache-key contention through the same atomic claim primitive the
+task backlog uses (:func:`bernstein.core.tasks.claim.claim_next_entry`): the
+cache key becomes a single-row backlog, the first worker to flip it to
+``in_progress`` wins the spawn, and every loser receives a signed
+:class:`DuplicateOfReceipt` binding it to the winner's key and claim position.
+The loser does not block; it completes by a lineage edge to the winner's
+verified output. If the winner never records a verified output the claim can be
+released and re-contended deterministically.
+
+Verifiability (issue #2551 AC3): a :class:`DuplicateOfReceipt` is HMAC-signed
+over its canonical body with the audit-chain key, so it verifies offline; any
+mutation of the winner reference, the cache key, or the claim position breaks
+the tag, and :func:`verify_duplicate_receipt` names the mismatching field.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac as _hmac
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.tasks.claim import (
+    Backlog,
+    BacklogEntry,
+    ClaimFilter,
+    claim_next_entry,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from pathlib import Path
+
+_RECEIPT_VERSION = 1
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Duplicate-of receipt
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DuplicateOfReceipt:
+    """A signed proof that ``loser`` deduped onto ``winner``'s cache key.
+
+    Attributes:
+        cache_key: The contended cache key (hex).
+        winner: Claimer id that won the spawn.
+        loser: Claimer id that deduped and did not spawn.
+        claim_position: 1-based order in which ``loser`` arrived at the claim
+            (the winner is position 0; the first loser is 1, and so on).
+        winner_output_ref: ``sha256:`` reference to the winner's verified
+            output - the lineage edge target the loser completes against.
+        ts: Integer timestamp the receipt was minted.
+        hmac: Hex HMAC-SHA256 tag over the canonical body, keyed with the
+            audit-chain key.
+    """
+
+    cache_key: str
+    winner: str
+    loser: str
+    claim_position: int
+    winner_output_ref: str
+    ts: int
+    hmac: str = ""
+
+    def body(self) -> dict[str, Any]:
+        """Return the HMAC-covered body (every field except ``hmac``)."""
+        return {
+            "v": _RECEIPT_VERSION,
+            "cache_key": self.cache_key,
+            "winner": self.winner,
+            "loser": self.loser,
+            "claim_position": self.claim_position,
+            "winner_output_ref": self.winner_output_ref,
+            "ts": self.ts,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the full JSON row, including the tag."""
+        row = self.body()
+        row["hmac"] = self.hmac
+        return row
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> DuplicateOfReceipt:
+        """Reconstruct a receipt from its JSON row."""
+        return cls(
+            cache_key=str(data["cache_key"]),
+            winner=str(data["winner"]),
+            loser=str(data["loser"]),
+            claim_position=int(data["claim_position"]),
+            winner_output_ref=str(data["winner_output_ref"]),
+            ts=int(data["ts"]),
+            hmac=str(data.get("hmac", "")),
+        )
+
+
+def mint_duplicate_receipt(
+    *,
+    cache_key: str,
+    winner: str,
+    loser: str,
+    claim_position: int,
+    winner_output_ref: str,
+    ts: int,
+    hmac_key: bytes,
+) -> DuplicateOfReceipt:
+    """Return a signed :class:`DuplicateOfReceipt`.
+
+    The tag is ``HMAC-SHA256(hmac_key, canonical(body))`` so a verifier holding
+    the key confirms the receipt offline; a party without the key cannot forge a
+    mutated receipt that still verifies.
+    """
+    unsigned = DuplicateOfReceipt(
+        cache_key=cache_key,
+        winner=winner,
+        loser=loser,
+        claim_position=claim_position,
+        winner_output_ref=winner_output_ref,
+        ts=ts,
+    )
+    tag = _hmac.new(hmac_key, _canonical_bytes(unsigned.body()), hashlib.sha256).hexdigest()
+    return DuplicateOfReceipt(
+        cache_key=cache_key,
+        winner=winner,
+        loser=loser,
+        claim_position=claim_position,
+        winner_output_ref=winner_output_ref,
+        ts=ts,
+        hmac=tag,
+    )
+
+
+def verify_duplicate_receipt(
+    receipt: DuplicateOfReceipt,
+    *,
+    hmac_key: bytes,
+    authoritative: DuplicateOfReceipt | None = None,
+) -> tuple[bool, str | None]:
+    """Verify a receipt offline; return ``(ok, mismatch_field)``.
+
+    The HMAC is recomputed over the receipt's body. When it matches the stored
+    tag the receipt is authentic and ``(True, None)`` is returned.
+
+    When it does not match, the receipt was tampered with (or signed under a
+    different key). If an ``authoritative`` copy is supplied - e.g. the winner
+    reference, cache key, and claim position an operator holds from the audit
+    chain and lineage store - the first body field that diverges is named, so a
+    mutated ``winner``, ``cache_key``, or ``claim_position`` is reported by
+    field (issue #2551 AC3). Absent an authoritative copy the mismatch is
+    reported as ``"hmac"``.
+    """
+    expected = _hmac.new(hmac_key, _canonical_bytes(receipt.body()), hashlib.sha256).hexdigest()
+    if _hmac.compare_digest(receipt.hmac, expected):
+        return True, None
+    if authoritative is not None:
+        auth_body = authoritative.body()
+        for field_name, value in receipt.body().items():
+            if auth_body.get(field_name) != value:
+                return False, field_name
+    return False, "hmac"
+
+
+# ---------------------------------------------------------------------------
+# Claim-based contention
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ClaimOutcome:
+    """The result of contending for a cache key.
+
+    Attributes:
+        won: Whether this worker won the claim and must perform the spawn.
+        claimer: This worker's claimer id.
+        claim_position: 0 for the winner; 1-based arrival order for a loser.
+        winner: The winning claimer id (equals ``claimer`` when ``won``).
+    """
+
+    won: bool
+    claimer: str
+    claim_position: int
+    winner: str
+
+
+class CacheKeyArbiter:
+    """Serialise spawns for one cache key through the atomic claim primitive.
+
+    The arbiter is backed by a single-row backlog file named after the cache
+    key. ``claim_next_entry`` flips the row to ``in_progress`` atomically under
+    a cross-process file lock, so exactly one worker among N contenders wins,
+    even across hosts sharing the backlog directory. A killed winner's claim is
+    released by :meth:`release` and the next contender proceeds.
+    """
+
+    def __init__(self, backlog_path: Path, cache_key: str) -> None:
+        self._path = backlog_path
+        self._cache_key = cache_key
+        self._contenders = 0
+
+    @property
+    def cache_key(self) -> str:
+        return self._cache_key
+
+    def _ensure_backlog(self) -> None:
+        if not self._path.exists():
+            Backlog.write(self._path, [BacklogEntry(id=self._cache_key)])
+
+    def contend(self, claimer: str) -> ClaimOutcome:
+        """Attempt to claim the cache key for ``claimer``.
+
+        The first caller to win flips the row and returns ``won=True`` with
+        ``claim_position=0``. Every later caller finds the row already claimed
+        and returns ``won=False`` with a 1-based ``claim_position`` reflecting
+        arrival order, plus the winning claimer id.
+        """
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._ensure_backlog()
+        self._contenders += 1
+        claimed = claim_next_entry(self._path, claimer_id=claimer, filter=ClaimFilter())
+        if claimed is not None and claimed.id == self._cache_key:
+            return ClaimOutcome(won=True, claimer=claimer, claim_position=0, winner=claimer)
+        winner = self._current_winner()
+        return ClaimOutcome(
+            won=False,
+            claimer=claimer,
+            claim_position=self._contenders - 1,
+            winner=winner,
+        )
+
+    def _current_winner(self) -> str:
+        backlog = Backlog.load(self._path)
+        for entry in backlog.entries:
+            if entry.id == self._cache_key and entry.claimer is not None:
+                return entry.claimer
+        return ""
+
+    def release(self) -> None:
+        """Release the claim so the next contender can win (winner failed).
+
+        Re-opens the backlog row to ``open`` and clears the claimer, mirroring a
+        deterministic claim release: the successor's next :meth:`contend` wins.
+        """
+        backlog = Backlog.load(self._path)
+        for entry in backlog.entries:
+            if entry.id == self._cache_key:
+                entry.status = "open"
+                entry.claimer = None
+                entry.claimed_at = None
+        backlog.save()
+
+
+__all__ = [
+    "CacheKeyArbiter",
+    "ClaimOutcome",
+    "DuplicateOfReceipt",
+    "mint_duplicate_receipt",
+    "verify_duplicate_receipt",
+]

--- a/src/bernstein/core/persistence/cache_eviction.py
+++ b/src/bernstein/core/persistence/cache_eviction.py
@@ -26,6 +26,7 @@ tombstone order across processes.
 from __future__ import annotations
 
 import json
+from collections import deque
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -247,10 +248,10 @@ class TombstoneStore:
         consumers_seen: set[str] = set()
 
         # BFS from the evicted key. A queued node is always a cache key.
-        queue: list[str] = [key]
+        queue: deque[str] = deque([key])
         queued: set[str] = {key}
         while queue:
-            current = queue.pop(0)
+            current = queue.popleft()
             if current not in tombstoned_seen:
                 tombstoned_order.append(current)
                 tombstoned_seen.add(current)

--- a/src/bernstein/core/persistence/cache_eviction.py
+++ b/src/bernstein/core/persistence/cache_eviction.py
@@ -1,0 +1,309 @@
+"""Surgical, transitive cache eviction over served-from lineage edges.
+
+``bernstein cache evict <key> --reason`` must not merely drop one row: a bad
+cached value that other runs consumed has to be revocable together with
+everything derived from it, and the operator needs a forensic recall set of the
+runs that consumed the revoked value.
+
+Two append-only artefacts back this:
+
+* :class:`ServedFromLedger` - one row per ``served_from`` edge: a consuming run
+  read a value from a cache key. The ledger is the by-artefact projection this
+  module walks; it is append-only so an edge can never be silently rewritten.
+* :class:`TombstoneStore` - append-only tombstone journal. A tombstoned key is
+  always a miss, even when its drift verdict is fresh, so an evicted key can
+  never serve again.
+
+:meth:`TombstoneStore.evict` walks the ledger transitively from the evicted key
+over ``served_from`` edges, tombstones every reachable key, and returns the full
+:class:`RecallSet` - the consuming runs that must be treated as contaminated.
+
+Determinism: the recall set is computed by a breadth-first walk in sorted order,
+so the same ledger + eviction produces the byte-identical recall set and
+tombstone order across processes.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.persistence.atomic_write import write_atomic_json
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+    from pathlib import Path
+
+_LEDGER_NAME = "served_from.jsonl"
+_TOMBSTONE_NAME = "tombstones.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# Served-from ledger
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ServedFromEdge:
+    """One ``served_from`` edge: ``consumer`` read ``cache_key``.
+
+    Attributes:
+        cache_key: The cache key whose value was served.
+        consumer: The consuming run id (or a downstream cache key that pinned
+            the served value as an input).
+        output_hash: ``sha256:`` digest of the value that was served.
+        ts: Integer timestamp the edge was recorded (provenance only; never
+            read by the transitive walk).
+    """
+
+    cache_key: str
+    consumer: str
+    output_hash: str = ""
+    ts: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serialisable row."""
+        return {
+            "cache_key": self.cache_key,
+            "consumer": self.consumer,
+            "output_hash": self.output_hash,
+            "ts": self.ts,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> ServedFromEdge:
+        """Reconstruct an edge from its JSON row."""
+        return cls(
+            cache_key=str(data["cache_key"]),
+            consumer=str(data["consumer"]),
+            output_hash=str(data.get("output_hash", "")),
+            ts=int(data.get("ts", 0)),
+        )
+
+
+class ServedFromLedger:
+    """Append-only ledger of ``served_from`` edges under a cache directory."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def record(self, edge: ServedFromEdge) -> None:
+        """Append one served-from edge as a canonical JSONL row."""
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        row = json.dumps(edge.to_dict(), ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+        with self._path.open("a", encoding="utf-8") as fh:
+            fh.write(row + "\n")
+
+    def edges(self) -> list[ServedFromEdge]:
+        """Return every recorded edge in append order."""
+        if not self._path.exists():
+            return []
+        out: list[ServedFromEdge] = []
+        for raw in self._path.read_text(encoding="utf-8").splitlines():
+            raw = raw.strip()
+            if not raw:
+                continue
+            out.append(ServedFromEdge.from_dict(json.loads(raw)))
+        return out
+
+    def adjacency(self) -> dict[str, list[str]]:
+        """Return ``cache_key -> [consumer, ...]`` in sorted, de-duplicated form.
+
+        A consumer that is itself a cache key becomes a graph node, so the
+        transitive walk cascades along chains of derived caches.
+        """
+        adj: dict[str, set[str]] = {}
+        for edge in self.edges():
+            adj.setdefault(edge.cache_key, set()).add(edge.consumer)
+        return {key: sorted(consumers) for key, consumers in adj.items()}
+
+
+# ---------------------------------------------------------------------------
+# Tombstones
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Tombstone:
+    """A single tombstone: ``key`` is revoked because of ``root_key``'s eviction."""
+
+    key: str
+    reason: str
+    root_key: str
+    ts: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serialisable row."""
+        return {"key": self.key, "reason": self.reason, "root_key": self.root_key, "ts": self.ts}
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> Tombstone:
+        """Reconstruct a tombstone from its JSON row."""
+        return cls(
+            key=str(data["key"]),
+            reason=str(data.get("reason", "")),
+            root_key=str(data.get("root_key", data["key"])),
+            ts=int(data.get("ts", 0)),
+        )
+
+
+@dataclass(frozen=True)
+class RecallSet:
+    """The forensic result of one eviction.
+
+    Attributes:
+        root_key: The originally evicted key.
+        reason: The operator-supplied revocation reason.
+        tombstoned: Every key tombstoned by this eviction, in walk order
+            (root first, then transitive keys in sorted BFS order).
+        consumers: The consuming run ids reachable over ``served_from`` edges,
+            sorted - the recall set an operator inspects for contamination.
+    """
+
+    root_key: str
+    reason: str
+    tombstoned: list[str] = field(default_factory=list[str])
+    consumers: list[str] = field(default_factory=list[str])
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serialisable summary."""
+        return {
+            "root_key": self.root_key,
+            "reason": self.reason,
+            "tombstoned": list(self.tombstoned),
+            "consumers": list(self.consumers),
+        }
+
+
+class TombstoneStore:
+    """Append-only tombstone journal with transitive eviction.
+
+    A tombstoned key is a hard miss forever - :meth:`is_tombstoned` short
+    circuits any lookup regardless of the drift verdict.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def all(self) -> dict[str, Tombstone]:
+        """Return ``key -> Tombstone`` for every tombstone (last write wins)."""
+        if not self._path.exists():
+            return {}
+        out: dict[str, Tombstone] = {}
+        for raw in self._path.read_text(encoding="utf-8").splitlines():
+            raw = raw.strip()
+            if not raw:
+                continue
+            ts = Tombstone.from_dict(json.loads(raw))
+            out[ts.key] = ts
+        return out
+
+    def is_tombstoned(self, key: str) -> bool:
+        """Return whether ``key`` has been revoked."""
+        return key in self.all()
+
+    def _append(self, tombstones: Iterable[Tombstone]) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        with self._path.open("a", encoding="utf-8") as fh:
+            for ts in tombstones:
+                row = json.dumps(ts.to_dict(), ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+                fh.write(row + "\n")
+
+    def evict(
+        self,
+        key: str,
+        reason: str,
+        *,
+        ledger: ServedFromLedger,
+        ts: int = 0,
+    ) -> RecallSet:
+        """Tombstone ``key`` and everything reachable over served-from edges.
+
+        Walks the served-from graph breadth-first from ``key`` in sorted order,
+        tombstoning every reachable cache key and collecting the consuming run
+        ids. A consumer that is itself a cache key (a derived cache) is both
+        tombstoned and traversed further, so revocation cascades down the
+        lineage. Returns the full :class:`RecallSet`.
+
+        Determinism (issue #2551 AC5): the tombstone order and recall set are a
+        pure function of ``(key, ledger)`` - the BFS visits neighbours in sorted
+        order, so two operators evicting the same key against the same ledger
+        produce identical output.
+        """
+        adjacency = ledger.adjacency()
+        graph_keys = set(adjacency)
+
+        tombstoned_order: list[str] = []
+        tombstoned_seen: set[str] = set()
+        consumers_seen: set[str] = set()
+
+        # BFS from the evicted key. A queued node is always a cache key.
+        queue: list[str] = [key]
+        queued: set[str] = {key}
+        while queue:
+            current = queue.pop(0)
+            if current not in tombstoned_seen:
+                tombstoned_order.append(current)
+                tombstoned_seen.add(current)
+            for consumer in adjacency.get(current, []):
+                if consumer not in consumers_seen:
+                    consumers_seen.add(consumer)
+                # A consumer that is itself a cache key is a derived cache: keep
+                # cascading and tombstone it too.
+                if consumer in graph_keys and consumer not in queued:
+                    queue.append(consumer)
+                    queued.add(consumer)
+
+        # The recall set is the consuming *runs* - consumers that are not
+        # themselves cache keys. A consumer that is a derived cache key is
+        # tombstoned (above), not reported as a run.
+        recall = RecallSet(
+            root_key=key,
+            reason=reason,
+            tombstoned=tombstoned_order,
+            consumers=sorted(c for c in consumers_seen if c not in graph_keys),
+        )
+        self._append(Tombstone(key=k, reason=reason, root_key=key, ts=ts) for k in tombstoned_order)
+        return recall
+
+
+def cache_dir(workdir: Path) -> Path:
+    """Return the canonical cache-policy directory under ``workdir``."""
+    return workdir / ".sdd" / "caching" / "policy"
+
+
+def open_ledger(workdir: Path) -> ServedFromLedger:
+    """Return the served-from ledger rooted under ``workdir``."""
+    return ServedFromLedger(cache_dir(workdir) / _LEDGER_NAME)
+
+
+def open_tombstones(workdir: Path) -> TombstoneStore:
+    """Return the tombstone store rooted under ``workdir``."""
+    return TombstoneStore(cache_dir(workdir) / _TOMBSTONE_NAME)
+
+
+def write_recall_report(path: Path, recall: RecallSet) -> None:
+    """Persist a recall report as pretty JSON for the operator."""
+    write_atomic_json(path, recall.to_dict())
+
+
+__all__ = [
+    "RecallSet",
+    "ServedFromEdge",
+    "ServedFromLedger",
+    "Tombstone",
+    "TombstoneStore",
+    "cache_dir",
+    "open_ledger",
+    "open_tombstones",
+    "write_recall_report",
+]

--- a/src/bernstein/core/persistence/cache_policy.py
+++ b/src/bernstein/core/persistence/cache_policy.py
@@ -1,0 +1,538 @@
+"""Cache policy engine: composable key recipes and drift-based expiry.
+
+Bernstein historically carried three result caches, each hard-coding its own
+key recipe (``fingerprint`` folds the producer AST, ``action_cache`` keys the
+model-visible inputs, ``semantic_cache`` keys an exact SHA-256 of normalised
+text) with no shared vocabulary. None captured model version, adapter version,
+base worktree commit, or tool schema hash, so a cached agent output could
+silently survive a model upgrade, an adapter bump, or a tool-schema change; and
+the only staleness signal was the wall clock, so a result whose producing diff
+touched files that have since changed was still served.
+
+This module defines what a cache policy *means* at the cache boundary:
+
+* :class:`CachePolicy` names an ordered set of optional key ingredients on top
+  of the five mandatory ingredients (model id, model version, adapter version,
+  base worktree commit, tool schema hash). The policy canonicalises to JSON
+  with a ``sha256`` policy hash.
+* :func:`compose_recipe` / :func:`compose_key` fold the mandatory ingredients
+  plus the declared optional ones into one canonical recipe whose ``sha256`` is
+  the recipe hash. The composed key is the ``sha256`` of that recipe, so any
+  change to a mandatory ingredient changes the key (the whole point).
+* :class:`CacheEntry` is a content-addressed lineage record: it pins the input
+  hashes, the output hash, the producing task, the recorded diff file set with
+  per-file content hashes, and the base commit.
+* :func:`evaluate_freshness` is a *pure* verdict function over ``(entry,
+  policy, repo_state)``. It reads no clock, no filesystem outside the injected
+  repo state, and no network; two operators with the same repo state compute
+  the byte-identical verdict JSON instead of racing a clock. A wall-clock TTL
+  applies only as a declared backstop for world-facing tasks, and only through
+  an injected timestamp.
+
+Determinism substrate: every serialised artefact here (policy JSON, recipe,
+composed key, freshness verdict) is canonical JSON - sorted keys, minimal
+separators, UTF-8 - so two byte-identical inputs produce byte-identical bytes
+and hashes across processes and platforms.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Final, Literal, cast
+
+if TYPE_CHECKING:
+    from bernstein.core.tasks.models import Task
+
+# ---------------------------------------------------------------------------
+# Ingredient vocabulary
+# ---------------------------------------------------------------------------
+
+#: Ingredients folded into every composed key regardless of policy. A change to
+#: any one of these produces a different key - a cached output never survives a
+#: model, adapter, repo-base, or tool-surface change it did not account for.
+MANDATORY_INGREDIENTS: Final[tuple[str, ...]] = (
+    "model_id",
+    "model_version",
+    "adapter_version",
+    "base_commit",
+    "tool_schema_hash",
+)
+
+#: Optional ingredients a policy may add to the recipe, in the caller's order.
+OPTIONAL_INGREDIENTS: Final[tuple[str, ...]] = (
+    "task_inputs",
+    "producer_code",
+    "run_parameters",
+)
+
+ExpiryMode = Literal["drift", "ttl", "both"]
+
+_EXPIRY_MODES: Final[frozenset[str]] = frozenset({"drift", "ttl", "both"})
+
+_DIGEST_PREFIX = "sha256:"
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    """Return canonical JSON bytes (sorted keys, minimal separators, UTF-8)."""
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _sha256_hex(data: bytes) -> str:
+    """Return the ``sha256:``-prefixed hex digest of ``data``."""
+    return _DIGEST_PREFIX + hashlib.sha256(data).hexdigest()
+
+
+#: Environment signal set by ``bernstein run --refresh-cache``. When present the
+#: cache boundary treats every policy lookup as a miss for that run and then
+#: repopulates with the fresh output.
+_REFRESH_ENV = "BERNSTEIN_REFRESH_CACHE"
+
+
+def refresh_requested(env: Mapping[str, str] | None = None) -> bool:
+    """Return whether ``--refresh-cache`` requested a policy cache bypass.
+
+    Reads ``BERNSTEIN_REFRESH_CACHE`` from ``env`` (defaulting to the process
+    environment). A truthy value (``"1"``/``"true"``/``"yes"``) forces every
+    policy lookup to miss for the run so the cache repopulates with fresh
+    outputs. (issue #2551)
+    """
+    source = os.environ if env is None else env
+    return str(source.get(_REFRESH_ENV, "")).strip().lower() in {"1", "true", "yes", "on"}
+
+
+# ---------------------------------------------------------------------------
+# CachePolicy
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CachePolicy:
+    """A declared cache policy attached to a task spec.
+
+    Attributes:
+        ingredients: Ordered optional key ingredients drawn from
+            :data:`OPTIONAL_INGREDIENTS`. Duplicates and unknown names are
+            rejected at construction. The mandatory ingredients are always
+            folded in and are never listed here.
+        expiry_mode: ``"drift"`` (repo-state verdict only), ``"ttl"``
+            (wall-clock backstop only), or ``"both"``.
+        drift_window: Number of commits the base commit may be behind the
+            current head and still count as fresh. ``0`` means the base must be
+            the head (distance 0). Must be ``>= 0``.
+        ttl_seconds: Wall-clock backstop, in seconds. Required (and only
+            honoured) when ``expiry_mode`` includes ttl. ``None`` otherwise.
+        verified_only: When true, only outputs whose evidence bundle passed the
+            completion gate are cacheable; the semantic cache's ``verified``
+            flag is promoted to a policy term.
+        world_facing: Marks a task whose result depends on external state (web
+            research, third-party API). Only a world-facing policy honours the
+            TTL backstop; a repo-local task's freshness is a pure function of
+            repo state with no clock.
+        store_scope: Namespace label so distinct policies never share a key
+            namespace in the backing store.
+    """
+
+    ingredients: tuple[str, ...] = ()
+    expiry_mode: ExpiryMode = "drift"
+    drift_window: int = 0
+    ttl_seconds: int | None = None
+    verified_only: bool = False
+    world_facing: bool = False
+    store_scope: str = "default"
+
+    def __post_init__(self) -> None:
+        """Validate the policy invariants once at construction."""
+        object.__setattr__(self, "ingredients", tuple(self.ingredients))
+        seen: set[str] = set()
+        for name in self.ingredients:
+            if name not in OPTIONAL_INGREDIENTS:
+                raise ValueError(
+                    f"CachePolicy.ingredients: unknown optional ingredient {name!r}; "
+                    f"choose from {sorted(OPTIONAL_INGREDIENTS)}"
+                )
+            if name in seen:
+                raise ValueError(f"CachePolicy.ingredients: duplicate ingredient {name!r}")
+            seen.add(name)
+        if self.expiry_mode not in _EXPIRY_MODES:
+            raise ValueError(
+                f"CachePolicy.expiry_mode must be one of {sorted(_EXPIRY_MODES)}, got {self.expiry_mode!r}"
+            )
+        if self.drift_window < 0:
+            raise ValueError(f"CachePolicy.drift_window must be >= 0, got {self.drift_window!r}")
+        ttl_active = self.expiry_mode in ("ttl", "both")
+        if ttl_active and (self.ttl_seconds is None or self.ttl_seconds <= 0):
+            raise ValueError(
+                f"CachePolicy.ttl_seconds must be a positive int when expiry_mode={self.expiry_mode!r}, "
+                f"got {self.ttl_seconds!r}"
+            )
+        if not ttl_active and self.ttl_seconds is not None:
+            raise ValueError(
+                f"CachePolicy.ttl_seconds is set ({self.ttl_seconds!r}) but expiry_mode={self.expiry_mode!r} "
+                "does not include a TTL backstop"
+            )
+
+    def canonical(self) -> dict[str, Any]:
+        """Return the canonical dict form used for hashing and serialisation."""
+        return {
+            "ingredients": list(self.ingredients),
+            "expiry_mode": self.expiry_mode,
+            "drift_window": self.drift_window,
+            "ttl_seconds": self.ttl_seconds,
+            "verified_only": self.verified_only,
+            "world_facing": self.world_facing,
+            "store_scope": self.store_scope,
+        }
+
+    def canonical_json(self) -> bytes:
+        """Return canonical JSON bytes of the policy."""
+        return _canonical_bytes(self.canonical())
+
+    def policy_hash(self) -> str:
+        """Return the ``sha256:`` digest of the canonical policy bytes."""
+        return _sha256_hex(self.canonical_json())
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serialisable representation (alias of canonical)."""
+        return self.canonical()
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> CachePolicy:
+        """Build a :class:`CachePolicy` from a JSON-decoded mapping.
+
+        Unknown keys are ignored; missing keys fall back to dataclass defaults.
+        The result is validated by :meth:`__post_init__`.
+        """
+        raw_ingredients: object = data.get("ingredients") or []
+        if isinstance(raw_ingredients, (str, bytes)):
+            raise TypeError("CachePolicy.ingredients must be a list of ingredient names, not a scalar")
+        if not isinstance(raw_ingredients, (list, tuple)):
+            raise TypeError(
+                f"CachePolicy.ingredients must be a list of ingredient names, got {type(raw_ingredients).__name__}"
+            )
+        names: tuple[str, ...] = tuple(str(name) for name in cast("Iterable[Any]", raw_ingredients))
+        ttl = data.get("ttl_seconds")
+        return cls(
+            ingredients=names,
+            expiry_mode=str(data.get("expiry_mode", "drift")),  # type: ignore[arg-type]
+            drift_window=int(data.get("drift_window", 0)),
+            ttl_seconds=None if ttl is None else int(ttl),
+            verified_only=bool(data.get("verified_only", False)),
+            world_facing=bool(data.get("world_facing", False)),
+            store_scope=str(data.get("store_scope", "default")),
+        )
+
+    @classmethod
+    def from_task(cls, task: Task) -> CachePolicy | None:
+        """Return the policy declared on ``task``, or ``None`` when absent.
+
+        A task declares its policy on the ``cache_policy`` spec field. A task
+        that never opted in returns ``None`` and runs byte-identically to the
+        pre-policy spawn path.
+        """
+        declared = getattr(task, "cache_policy", None)
+        if declared is None:
+            return None
+        if isinstance(declared, CachePolicy):
+            return declared
+        if isinstance(declared, Mapping):
+            return cls.from_dict(cast("Mapping[str, Any]", declared))
+        raise TypeError(f"task.cache_policy must be a CachePolicy or mapping, got {type(declared).__name__}")
+
+
+# ---------------------------------------------------------------------------
+# Recipe composition / key engine
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RecipeInputs:
+    """The concrete ingredient values a run resolves for one cache lookup.
+
+    The five mandatory fields source from the adapter contract (adapter and
+    model identity), :func:`bernstein.core.git.git_basic.rev_parse_head` (base
+    commit), and the task's declared tool surface (tool schema hash). The three
+    optional fields are folded only when the policy names them.
+    """
+
+    model_id: str
+    model_version: str
+    adapter_version: str
+    base_commit: str
+    tool_schema_hash: str
+    task_inputs: Any = None
+    producer_code: str | None = None
+    run_parameters: Mapping[str, Any] | None = None
+
+    def value_for(self, ingredient: str) -> Any:
+        """Return the resolved value for ``ingredient`` (mandatory or optional)."""
+        return getattr(self, ingredient)
+
+
+def compose_recipe(policy: CachePolicy, inputs: RecipeInputs) -> dict[str, Any]:
+    """Return the ordered ingredient recipe for ``policy`` over ``inputs``.
+
+    The recipe lists the mandatory ingredients first, in their canonical order,
+    then the policy's declared optional ingredients in the policy's order. Each
+    entry hashes its value to a ``sha256:`` digest so the recipe never embeds a
+    raw prompt or diff, only content-addressed anchors. The policy hash is bound
+    into the recipe so two policies over identical inputs still produce distinct
+    keys.
+    """
+    ordered: list[dict[str, str]] = []
+    for name in MANDATORY_INGREDIENTS:
+        ordered.append({"name": name, "hash": _sha256_hex(_canonical_bytes(inputs.value_for(name)))})
+    for name in policy.ingredients:
+        ordered.append({"name": name, "hash": _sha256_hex(_canonical_bytes(inputs.value_for(name)))})
+    return {
+        "v": 1,
+        "policy_hash": policy.policy_hash(),
+        "store_scope": policy.store_scope,
+        "ingredients": ordered,
+    }
+
+
+def recipe_hash(recipe: Mapping[str, Any]) -> str:
+    """Return the ``sha256:`` digest of the canonical recipe bytes."""
+    return _sha256_hex(_canonical_bytes(dict(recipe)))
+
+
+def compose_key(policy: CachePolicy, inputs: RecipeInputs) -> bytes:
+    """Return the 32-byte composed cache key digest for ``policy``/``inputs``.
+
+    The digest is ``sha256(canonical(recipe))`` as raw bytes, suitable as a
+    :class:`bernstein.core.persistence.fingerprint.MemoStore` key. Any change to
+    a mandatory or declared ingredient alters the recipe and therefore the key.
+    """
+    recipe = compose_recipe(policy, inputs)
+    return hashlib.sha256(_canonical_bytes(recipe)).digest()
+
+
+def compose_key_hex(policy: CachePolicy, inputs: RecipeInputs) -> str:
+    """Return the composed key as a plain hex string (no prefix)."""
+    return compose_key(policy, inputs).hex()
+
+
+# ---------------------------------------------------------------------------
+# Cache entry (content-addressed lineage record)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CacheEntry:
+    """A content-addressed cache entry pinning provenance for one output.
+
+    Attributes:
+        key: The composed cache key (hex).
+        input_hashes: Per-input ``sha256:`` anchors (name -> digest).
+        output_hash: ``sha256:`` digest of the cached output bytes.
+        producing_task: Task id that produced the output.
+        diff_file_hashes: Repo-relative path -> ``sha256:`` content hash of the
+            file *as it was when the output was produced*. Drift expiry compares
+            these against current repo state.
+        base_commit: The worktree head commit the output was produced against.
+        verified: Whether the output's evidence bundle passed the completion
+            gate; a ``verified_only`` policy refuses to serve unverified entries.
+        recipe_hash: The recipe hash the key was composed from.
+        policy_hash: The policy hash in force at production.
+        created_ts: Optional production timestamp; only a world-facing TTL
+            policy reads it, and only through an injected ``now`` value.
+    """
+
+    key: str
+    input_hashes: dict[str, str]
+    output_hash: str
+    producing_task: str
+    diff_file_hashes: dict[str, str]
+    base_commit: str
+    verified: bool = False
+    recipe_hash: str = ""
+    policy_hash: str = ""
+    created_ts: int | None = None
+
+    def canonical(self) -> dict[str, Any]:
+        """Return the canonical dict form of the entry."""
+        return {
+            "key": self.key,
+            "input_hashes": dict(self.input_hashes),
+            "output_hash": self.output_hash,
+            "producing_task": self.producing_task,
+            "diff_file_hashes": dict(self.diff_file_hashes),
+            "base_commit": self.base_commit,
+            "verified": self.verified,
+            "recipe_hash": self.recipe_hash,
+            "policy_hash": self.policy_hash,
+            "created_ts": self.created_ts,
+        }
+
+    def content_id(self) -> str:
+        """Return the ``sha256:`` digest of the entry's canonical bytes."""
+        return _sha256_hex(_canonical_bytes(self.canonical()))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serialisable representation (alias of canonical)."""
+        return self.canonical()
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> CacheEntry:
+        """Reconstruct a :class:`CacheEntry` from its JSON dict form."""
+        created = data.get("created_ts")
+        return cls(
+            key=str(data["key"]),
+            input_hashes={str(k): str(v) for k, v in dict(data.get("input_hashes") or {}).items()},
+            output_hash=str(data["output_hash"]),
+            producing_task=str(data.get("producing_task", "")),
+            diff_file_hashes={str(k): str(v) for k, v in dict(data.get("diff_file_hashes") or {}).items()},
+            base_commit=str(data.get("base_commit", "")),
+            verified=bool(data.get("verified", False)),
+            recipe_hash=str(data.get("recipe_hash", "")),
+            policy_hash=str(data.get("policy_hash", "")),
+            created_ts=None if created is None else int(created),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Drift-based freshness verdict (pure function)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RepoState:
+    """The injected repo state a freshness verdict is computed against.
+
+    The verdict function reads only this object - never the live clock,
+    filesystem, or network - so two operators who assemble the same
+    ``RepoState`` compute byte-identical verdicts.
+
+    Attributes:
+        file_hashes: Current ``sha256:`` content hash for each path the entry's
+            diff touched. A path absent from this mapping is treated as deleted
+            (drift).
+        ancestor_distance: How many commits the entry's ``base_commit`` is
+            behind the current head along the first-parent chain, or ``None``
+            when the base is not an ancestor of the head (rebased away).
+        now: Injected timestamp in seconds. Consumed only by a world-facing TTL
+            policy; ``None`` disables the TTL branch entirely.
+    """
+
+    file_hashes: dict[str, str] = field(default_factory=dict[str, str])
+    ancestor_distance: int | None = None
+    now: int | None = None
+
+
+@dataclass(frozen=True)
+class FreshnessVerdict:
+    """The deterministic outcome of :func:`evaluate_freshness`.
+
+    ``reason`` is a stable, machine-readable token (never free prose) so two
+    processes emit byte-identical verdict JSON. ``detail`` carries the offending
+    path or distance when relevant.
+    """
+
+    fresh: bool
+    reason: str
+    detail: str = ""
+
+    def canonical(self) -> dict[str, Any]:
+        """Return the canonical dict form of the verdict."""
+        return {"fresh": self.fresh, "reason": self.reason, "detail": self.detail}
+
+    def canonical_json(self) -> bytes:
+        """Return canonical JSON bytes of the verdict."""
+        return _canonical_bytes(self.canonical())
+
+
+# Verdict reason tokens (stable machine-readable vocabulary).
+REASON_FRESH = "fresh"
+REASON_FILE_DRIFT = "file_drift"
+REASON_FILE_DELETED = "file_deleted"
+REASON_BASE_NOT_ANCESTOR = "base_not_ancestor"
+REASON_BASE_OUTSIDE_WINDOW = "base_outside_window"
+REASON_TTL_EXPIRED = "ttl_expired"
+
+
+def evaluate_freshness(
+    entry: CacheEntry,
+    policy: CachePolicy,
+    repo_state: RepoState,
+) -> FreshnessVerdict:
+    """Return the freshness verdict for ``entry`` under ``policy``.
+
+    Pure function of ``(entry, policy, repo_state)``: reads no clock, no
+    filesystem outside ``repo_state``, and no network. The drift branch fires
+    first (repo-local truth is authoritative), then the world-facing TTL
+    backstop. Checks run in a fixed, sorted order so the *first* failing check
+    is deterministic across processes.
+
+    Determinism contract (issue #2551 AC1): two processes given the same
+    ``entry`` and ``repo_state`` produce the byte-identical
+    :meth:`FreshnessVerdict.canonical_json`.
+    """
+    drift_active = policy.expiry_mode in ("drift", "both")
+    ttl_active = policy.expiry_mode in ("ttl", "both")
+
+    if drift_active:
+        # 1. Per-file content drift, evaluated in sorted path order so the
+        #    first offending file is a deterministic choice.
+        for path in sorted(entry.diff_file_hashes):
+            recorded = entry.diff_file_hashes[path]
+            current = repo_state.file_hashes.get(path)
+            if current is None:
+                return FreshnessVerdict(fresh=False, reason=REASON_FILE_DELETED, detail=path)
+            if current != recorded:
+                return FreshnessVerdict(fresh=False, reason=REASON_FILE_DRIFT, detail=path)
+        # 2. Base commit ancestry / window.
+        distance = repo_state.ancestor_distance
+        if distance is None:
+            return FreshnessVerdict(fresh=False, reason=REASON_BASE_NOT_ANCESTOR, detail=entry.base_commit)
+        if distance > policy.drift_window:
+            return FreshnessVerdict(
+                fresh=False,
+                reason=REASON_BASE_OUTSIDE_WINDOW,
+                detail=str(distance),
+            )
+
+    if ttl_active and policy.world_facing:
+        # TTL backstop applies only to declared world-facing tasks and only
+        # when both timestamps are present; otherwise the branch is inert so a
+        # repo-local verdict never reads a clock.
+        now = repo_state.now
+        created = entry.created_ts
+        if now is not None and created is not None and policy.ttl_seconds is not None:
+            age = now - created
+            if age > policy.ttl_seconds:
+                return FreshnessVerdict(fresh=False, reason=REASON_TTL_EXPIRED, detail=str(age))
+
+    return FreshnessVerdict(fresh=True, reason=REASON_FRESH)
+
+
+__all__ = [
+    "MANDATORY_INGREDIENTS",
+    "OPTIONAL_INGREDIENTS",
+    "REASON_BASE_NOT_ANCESTOR",
+    "REASON_BASE_OUTSIDE_WINDOW",
+    "REASON_FILE_DELETED",
+    "REASON_FILE_DRIFT",
+    "REASON_FRESH",
+    "REASON_TTL_EXPIRED",
+    "CacheEntry",
+    "CachePolicy",
+    "ExpiryMode",
+    "FreshnessVerdict",
+    "RecipeInputs",
+    "RepoState",
+    "compose_key",
+    "compose_key_hex",
+    "compose_recipe",
+    "evaluate_freshness",
+    "recipe_hash",
+    "refresh_requested",
+]

--- a/src/bernstein/core/persistence/cache_served_from.py
+++ b/src/bernstein/core/persistence/cache_served_from.py
@@ -1,0 +1,90 @@
+"""Served-from spine entries: every cache hit is a lineage-spine record.
+
+A cache hit that leaves no trace in the lineage spine makes replay unable to
+prove which steps were served from cache, and turns "which runs consumed this
+since-revoked entry" into an unanswerable question. This module records every
+hit as a ``served_from`` entry on the always-on :class:`LineageSpine`, at the
+same write boundary where every artifact write is already intercepted.
+
+Because the spine is Merkle-chained and HMAC-tagged, a run that served steps
+from cache replays to the identical spine head; suppressing or mutating any
+single ``served_from`` entry causes :meth:`LineageSpine.verify` to fail, so a
+hidden or forged cache hit is falsification-evident rather than merely unlogged
+(issue #2551 AC2).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bernstein.core.lineage.spine import LineageSpine
+
+_SERVED_FROM_PREFIX = ".sdd/cache/served_from"
+
+
+def served_from_artifact_path(cache_key: str) -> str:
+    """Return the repo-relative spine artifact path for a served-from hit."""
+    return f"{_SERVED_FROM_PREFIX}/{cache_key}"
+
+
+def served_from_content(*, cache_key: str, output_hash: str, policy_hash: str, recipe_hash: str) -> bytes:
+    """Return the canonical served-from marker bytes hashed into the spine entry.
+
+    The marker binds the cache key, the served output hash, and the policy and
+    recipe hashes so the spine ``content_hash`` is a content-addressed anchor of
+    exactly what was served under which policy.
+    """
+    return json.dumps(
+        {
+            "cache_key": cache_key,
+            "output_hash": output_hash,
+            "policy_hash": policy_hash,
+            "recipe_hash": recipe_hash,
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def record_served_from(
+    spine: LineageSpine,
+    *,
+    cache_key: str,
+    output_hash: str,
+    policy_hash: str,
+    recipe_hash: str,
+    actor: str,
+    step_id: str,
+    model: str,
+    timestamp: int,
+) -> str:
+    """Append a ``served_from`` entry to ``spine`` for one cache hit.
+
+    Returns the entry hash. The spine's own append path provides the Merkle
+    chaining and HMAC tag, so no new verification code is needed - the hit
+    participates in the same chain a live artifact write would.
+    """
+    content = served_from_content(
+        cache_key=cache_key,
+        output_hash=output_hash,
+        policy_hash=policy_hash,
+        recipe_hash=recipe_hash,
+    )
+    return spine.record(
+        artifact_path=served_from_artifact_path(cache_key),
+        content=content,
+        actor=actor,
+        step_id=step_id,
+        model=model,
+        timestamp=timestamp,
+    )
+
+
+__all__ = [
+    "record_served_from",
+    "served_from_artifact_path",
+    "served_from_content",
+]

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -5364,6 +5364,192 @@ def record_audit_receipt_export(
     )
 
 
+# ---------------------------------------------------------------------------
+# Cache policy engine (#2551): every hit, miss, dedup claim, and eviction is an
+# audit-chain event carrying the policy hash and recipe hash, so the fact a
+# cache decision was taken under a named policy is itself chain-attested. Only
+# hashes, identifiers, and the decision are recorded -- never prompt or output
+# payloads.
+# ---------------------------------------------------------------------------
+
+#: A policy-gated cache lookup hit a fresh, admissible entry. Records the
+#: composed key, the policy and recipe hashes, the served entry's content id,
+#: and whether the served output was verified.
+EVENT_CACHE_HIT = "cache.hit"
+
+#: A policy-gated cache lookup found no admissible entry (absent, stale, or
+#: tombstoned). Records the composed key, the policy and recipe hashes, and a
+#: machine-readable miss reason.
+EVENT_CACHE_MISS = "cache.miss"
+
+#: A fleet worker deduped onto another worker's in-flight spawn for the same
+#: cache key. Records the key, the winner, the loser, the claim position, and
+#: the duplicate-of receipt tag so the dedup is receipt-verified, not trusted.
+EVENT_CACHE_DEDUP_CLAIM = "cache.dedup_claim"
+
+#: A cache key (and everything reachable over served-from edges) was evicted.
+#: Records the root key, the reason, the tombstoned count, and the recall set
+#: size so the revocation and its blast radius are chain-attested.
+EVENT_CACHE_EVICTION = "cache.eviction"
+
+
+def record_cache_hit(
+    *,
+    chain: AuditChainStore,
+    cache_key: str,
+    policy_hash: str,
+    recipe_hash: str,
+    entry_content_id: str,
+    verified: bool,
+    actor: str = "cache_policy",
+) -> AuditEvent:
+    """Append a ``cache.hit`` event into *chain* (#2551).
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        cache_key: The composed cache key (hex).
+        policy_hash: ``sha256:`` hash of the policy in force.
+        recipe_hash: ``sha256:`` hash of the composed recipe.
+        entry_content_id: ``sha256:`` content id of the served cache entry.
+        verified: Whether the served output passed the completion gate.
+        actor: Recorded actor; defaults to ``"cache_policy"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_CACHE_HIT,
+        actor=actor,
+        resource_type="cache_entry",
+        resource_id=cache_key,
+        details={
+            "cache_key": cache_key,
+            "policy_hash": policy_hash,
+            "recipe_hash": recipe_hash,
+            "entry_content_id": entry_content_id,
+            "verified": verified,
+        },
+    )
+
+
+def record_cache_miss(
+    *,
+    chain: AuditChainStore,
+    cache_key: str,
+    policy_hash: str,
+    recipe_hash: str,
+    reason: str,
+    actor: str = "cache_policy",
+) -> AuditEvent:
+    """Append a ``cache.miss`` event into *chain* (#2551).
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        cache_key: The composed cache key (hex).
+        policy_hash: ``sha256:`` hash of the policy in force.
+        recipe_hash: ``sha256:`` hash of the composed recipe.
+        reason: Machine-readable miss reason (``absent`` / ``stale`` /
+            ``tombstoned`` / ``unverified``).
+        actor: Recorded actor; defaults to ``"cache_policy"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_CACHE_MISS,
+        actor=actor,
+        resource_type="cache_entry",
+        resource_id=cache_key,
+        details={
+            "cache_key": cache_key,
+            "policy_hash": policy_hash,
+            "recipe_hash": recipe_hash,
+            "reason": reason,
+        },
+    )
+
+
+def record_cache_dedup_claim(
+    *,
+    chain: AuditChainStore,
+    cache_key: str,
+    winner: str,
+    loser: str,
+    claim_position: int,
+    receipt_hmac: str,
+    policy_hash: str,
+    recipe_hash: str,
+    actor: str = "cache_policy",
+) -> AuditEvent:
+    """Append a ``cache.dedup_claim`` event into *chain* (#2551).
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        cache_key: The contended cache key (hex).
+        winner: Claimer id that won the spawn.
+        loser: Claimer id that deduped.
+        claim_position: 1-based arrival order of the loser.
+        receipt_hmac: The duplicate-of receipt tag proving the dedup edge.
+        policy_hash: ``sha256:`` hash of the policy in force.
+        recipe_hash: ``sha256:`` hash of the composed recipe.
+        actor: Recorded actor; defaults to ``"cache_policy"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_CACHE_DEDUP_CLAIM,
+        actor=actor,
+        resource_type="cache_dedup",
+        resource_id=cache_key,
+        details={
+            "cache_key": cache_key,
+            "winner": winner,
+            "loser": loser,
+            "claim_position": claim_position,
+            "receipt_hmac": receipt_hmac,
+            "policy_hash": policy_hash,
+            "recipe_hash": recipe_hash,
+        },
+    )
+
+
+def record_cache_eviction(
+    *,
+    chain: AuditChainStore,
+    cache_key: str,
+    reason: str,
+    tombstoned_count: int,
+    recall_count: int,
+    actor: str = "cache_policy",
+) -> AuditEvent:
+    """Append a ``cache.eviction`` event into *chain* (#2551).
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        cache_key: The evicted root key (hex).
+        reason: The operator-supplied revocation reason.
+        tombstoned_count: Number of keys tombstoned by this eviction.
+        recall_count: Number of consuming runs in the recall set.
+        actor: Recorded actor; defaults to ``"cache_policy"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_CACHE_EVICTION,
+        actor=actor,
+        resource_type="cache_entry",
+        resource_id=cache_key,
+        details={
+            "cache_key": cache_key,
+            "reason": reason,
+            "tombstoned_count": tombstoned_count,
+            "recall_count": recall_count,
+        },
+    )
+
+
 __all__ = [
     "AGENT_FRESH_RESTART_ON_RETRY",
     "EVENT_A2A_MESSAGE_RECEIPT",
@@ -5377,6 +5563,10 @@ __all__ = [
     "EVENT_APPROVAL_CARD_RESOLVED",
     "EVENT_AUDIT_RECEIPT_EXPORT",
     "EVENT_AUTOMATION_ACTION",
+    "EVENT_CACHE_DEDUP_CLAIM",
+    "EVENT_CACHE_EVICTION",
+    "EVENT_CACHE_HIT",
+    "EVENT_CACHE_MISS",
     "EVENT_CHECKPOINT_RETRY",
     "EVENT_COMPACTION_RECEIPT",
     "EVENT_COMPACTION_SENSITIVE_GATE",
@@ -5470,6 +5660,10 @@ __all__ = [
     "record_adapter_version_posture_receipt",
     "record_audit_receipt_export",
     "record_automation_action",
+    "record_cache_dedup_claim",
+    "record_cache_eviction",
+    "record_cache_hit",
+    "record_cache_miss",
     "record_checkpoint_retry",
     "record_computer_use_action",
     "record_context_capsule",

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -13,6 +13,7 @@ from bernstein.core import defaults as _defaults
 from bernstein.core.defaults import AGENT
 
 if TYPE_CHECKING:
+    from bernstein.core.persistence.cache_policy import CachePolicy
     from bernstein.core.protocols.cluster.cluster_tls import TLSConfig
 
 logger = logging.getLogger(__name__)
@@ -360,6 +361,26 @@ def _normalize_attachments(raw: object) -> list[str]:
     return [str(a) for a in raw]
 
 
+def _parse_cache_policy(raw: object) -> CachePolicy | None:
+    """Coerce a ``cache_policy`` payload into a :class:`CachePolicy` or ``None``.
+
+    Accepts a JSON mapping (parsed via ``CachePolicy.from_dict``) or an existing
+    ``CachePolicy``. ``None`` (the default) means the task declares no policy and
+    runs byte-identically to the pre-policy spawn path. Imported lazily so the
+    task model has no runtime dependency on the cache subsystem when no policy is
+    declared. (issue #2551)
+    """
+    if raw is None:
+        return None
+    from bernstein.core.persistence.cache_policy import CachePolicy
+
+    if isinstance(raw, CachePolicy):
+        return raw
+    if isinstance(raw, dict):
+        return CachePolicy.from_dict(raw)
+    raise TypeError(f"Task.cache_policy must be a mapping or CachePolicy, got {type(raw).__name__}")
+
+
 def _normalize_evidence_producers(raw: object) -> list[dict[str, Any]]:
     """Coerce an ``evidence_producers`` payload into a ``list[dict]``.
 
@@ -425,6 +446,12 @@ class Task:
     # above continues to govern the *post-completion* review gate so that
     # legacy approve/reject/pending tests stay intact.
     approval_spec: ApprovalSpec | None = None
+    # Issue #2551: opt-in cache policy declared on the task spec. When set, the
+    # cache boundary composes keys over the policy's ingredient recipe, applies
+    # the drift verdict, and routes fleet-key contention through a claim. When
+    # None (the default) the task runs byte-identically to the pre-policy spawn
+    # path. Parsed by ``bernstein.core.persistence.cache_policy.CachePolicy``.
+    cache_policy: CachePolicy | None = None
     risk_level: Literal["low", "medium", "high", "critical"] = "low"  # Risk for approval workflow routing
     sensitivity: Literal["public", "internal", "confidential"] = "internal"  # Data classification level
     max_output_tokens: int | None = None  # Escalated limit for model output
@@ -567,6 +594,7 @@ class Task:
             approval_spec=(
                 ApprovalSpec.from_dict(raw["approval_spec"]) if isinstance(raw.get("approval_spec"), dict) else None
             ),
+            cache_policy=_parse_cache_policy(raw.get("cache_policy")),
             risk_level=raw.get("risk_level", "low"),
             max_output_tokens=raw.get("max_output_tokens"),
             meta_messages=list(raw.get("meta_messages", [])),

--- a/tests/property/test_cache_policy_properties.py
+++ b/tests/property/test_cache_policy_properties.py
@@ -1,0 +1,94 @@
+"""Property tests for cache-policy recipe and verdict determinism (issue #2551).
+
+* Recipe / key determinism (AC1, AC6): the composed key is a pure function of
+  ``(policy, inputs)``; dict-ordering and hash-seed noise never change it, and
+  any mandatory-ingredient change discriminates the key.
+* Verdict determinism (AC1): two evaluations of the same ``(entry, policy,
+  repo_state)`` produce byte-identical verdict JSON.
+"""
+
+from __future__ import annotations
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from bernstein.core.persistence.cache_policy import (
+    MANDATORY_INGREDIENTS,
+    CacheEntry,
+    CachePolicy,
+    RecipeInputs,
+    RepoState,
+    compose_key_hex,
+    evaluate_freshness,
+)
+
+_hashes = st.text(min_size=1, max_size=24)
+_json_scalar = st.one_of(st.text(max_size=20), st.integers(), st.booleans(), st.none())
+
+
+def _inputs_from(values: dict[str, str], task_inputs: object) -> RecipeInputs:
+    return RecipeInputs(
+        model_id=values["model_id"],
+        model_version=values["model_version"],
+        adapter_version=values["adapter_version"],
+        base_commit=values["base_commit"],
+        tool_schema_hash=values["tool_schema_hash"],
+        task_inputs=task_inputs,
+    )
+
+
+@given(
+    values=st.fixed_dictionaries({name: _hashes for name in MANDATORY_INGREDIENTS}),
+    task_inputs=st.dictionaries(st.text(max_size=8), _json_scalar, max_size=4),
+)
+def test_compose_key_is_pure_function(values: dict[str, str], task_inputs: dict[str, object]) -> None:
+    policy = CachePolicy(ingredients=("task_inputs",))
+    k1 = compose_key_hex(policy, _inputs_from(values, dict(task_inputs)))
+    # Rebuild the dict in reversed insertion order - canonicalisation must erase
+    # the ordering difference.
+    reordered = dict(reversed(list(task_inputs.items())))
+    k2 = compose_key_hex(policy, _inputs_from(values, reordered))
+    assert k1 == k2
+
+
+@given(
+    values=st.fixed_dictionaries({name: _hashes for name in MANDATORY_INGREDIENTS}),
+    ingredient=st.sampled_from(MANDATORY_INGREDIENTS),
+    delta=st.text(min_size=1, max_size=8),
+)
+def test_mandatory_ingredient_change_discriminates(
+    values: dict[str, str],
+    ingredient: str,
+    delta: str,
+) -> None:
+    policy = CachePolicy(ingredients=("task_inputs",))
+    baseline = compose_key_hex(policy, _inputs_from(values, {"g": "x"}))
+    mutated_values = dict(values)
+    mutated_values[ingredient] = values[ingredient] + "|" + delta
+    mutated = compose_key_hex(policy, _inputs_from(mutated_values, {"g": "x"}))
+    assert mutated != baseline
+
+
+@given(
+    file_hashes=st.dictionaries(st.text(min_size=1, max_size=8), _hashes, max_size=4),
+    distance=st.one_of(st.none(), st.integers(min_value=0, max_value=20)),
+    window=st.integers(min_value=0, max_value=10),
+)
+def test_verdict_json_is_deterministic(
+    file_hashes: dict[str, str],
+    distance: int | None,
+    window: int,
+) -> None:
+    policy = CachePolicy(expiry_mode="drift", drift_window=window)
+    entry = CacheEntry(
+        key="k",
+        input_hashes={},
+        output_hash="sha256:o",
+        producing_task="t",
+        diff_file_hashes=dict(file_hashes),
+        base_commit="c" * 40,
+    )
+    state = RepoState(file_hashes=dict(file_hashes), ancestor_distance=distance)
+    v1 = evaluate_freshness(entry, policy, state).canonical_json()
+    v2 = evaluate_freshness(entry, policy, state).canonical_json()
+    assert v1 == v2

--- a/tests/unit/test_cache_audit_events.py
+++ b/tests/unit/test_cache_audit_events.py
@@ -1,0 +1,109 @@
+"""Audit-chain events for the cache policy engine (issue #2551, AC7).
+
+Every hit, miss, dedup claim, and eviction is an audit-chain event carrying the
+policy hash and recipe hash, and the chain stays verifiable after the mirror.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from bernstein.core.security.audit_chain import (
+    EVENT_CACHE_DEDUP_CLAIM,
+    EVENT_CACHE_EVICTION,
+    EVENT_CACHE_HIT,
+    EVENT_CACHE_MISS,
+    AuditChainStore,
+    record_cache_dedup_claim,
+    record_cache_eviction,
+    record_cache_hit,
+    record_cache_miss,
+)
+
+
+def _chain(tmp_path: Path) -> AuditChainStore:
+    return AuditChainStore(tmp_path / "audit", key=b"0" * 32)
+
+
+def test_cache_hit_event_carries_policy_and_recipe_hash(tmp_path: Path) -> None:
+    chain = _chain(tmp_path)
+    event = record_cache_hit(
+        chain=chain,
+        cache_key="cafe",
+        policy_hash="sha256:policy",
+        recipe_hash="sha256:recipe",
+        entry_content_id="sha256:entry",
+        verified=True,
+    )
+    assert event.event_type == EVENT_CACHE_HIT
+    details = chain.query(event_type=EVENT_CACHE_HIT)[0].details
+    assert details["policy_hash"] == "sha256:policy"
+    assert details["recipe_hash"] == "sha256:recipe"
+    assert details["entry_content_id"] == "sha256:entry"
+    assert details["verified"] is True
+    assert "prev_chain_digest" in details
+
+
+def test_cache_miss_event(tmp_path: Path) -> None:
+    chain = _chain(tmp_path)
+    record_cache_miss(
+        chain=chain,
+        cache_key="cafe",
+        policy_hash="sha256:policy",
+        recipe_hash="sha256:recipe",
+        reason="stale",
+    )
+    details = chain.query(event_type=EVENT_CACHE_MISS)[0].details
+    assert details["reason"] == "stale"
+    assert details["policy_hash"] == "sha256:policy"
+    assert details["recipe_hash"] == "sha256:recipe"
+
+
+def test_cache_dedup_claim_event(tmp_path: Path) -> None:
+    chain = _chain(tmp_path)
+    record_cache_dedup_claim(
+        chain=chain,
+        cache_key="cafe",
+        winner="w-1",
+        loser="w-2",
+        claim_position=1,
+        receipt_hmac="deadbeef",
+        policy_hash="sha256:policy",
+        recipe_hash="sha256:recipe",
+    )
+    details = chain.query(event_type=EVENT_CACHE_DEDUP_CLAIM)[0].details
+    assert details["winner"] == "w-1"
+    assert details["loser"] == "w-2"
+    assert details["claim_position"] == 1
+    assert details["receipt_hmac"] == "deadbeef"
+
+
+def test_cache_eviction_event(tmp_path: Path) -> None:
+    chain = _chain(tmp_path)
+    record_cache_eviction(
+        chain=chain,
+        cache_key="cafe",
+        reason="pr_reverted",
+        tombstoned_count=3,
+        recall_count=2,
+    )
+    details = chain.query(event_type=EVENT_CACHE_EVICTION)[0].details
+    assert details["reason"] == "pr_reverted"
+    assert details["tombstoned_count"] == 3
+    assert details["recall_count"] == 2
+
+
+def test_chain_verifies_after_cache_events(tmp_path: Path) -> None:
+    chain = _chain(tmp_path)
+    record_cache_hit(
+        chain=chain,
+        cache_key="a",
+        policy_hash="sha256:p",
+        recipe_hash="sha256:r",
+        entry_content_id="sha256:e",
+        verified=True,
+    )
+    record_cache_miss(chain=chain, cache_key="b", policy_hash="sha256:p", recipe_hash="sha256:r", reason="absent")
+    record_cache_eviction(chain=chain, cache_key="a", reason="x", tombstoned_count=1, recall_count=0)
+    ok, errors = chain.verify()
+    assert ok, errors

--- a/tests/unit/test_cache_dedup.py
+++ b/tests/unit/test_cache_dedup.py
@@ -1,0 +1,115 @@
+"""Unit tests for claim-based fleet dedup and duplicate-of receipts (AC3, AC4)."""
+
+from __future__ import annotations
+
+import concurrent.futures
+import dataclasses
+from pathlib import Path
+
+from bernstein.core.persistence.cache_dedup import (
+    CacheKeyArbiter,
+    DuplicateOfReceipt,
+    mint_duplicate_receipt,
+    verify_duplicate_receipt,
+)
+
+_KEY = b"0" * 32
+
+
+def _receipt() -> DuplicateOfReceipt:
+    return mint_duplicate_receipt(
+        cache_key="cafe",
+        winner="worker-1",
+        loser="worker-2",
+        claim_position=1,
+        winner_output_ref="sha256:winneroutput",
+        ts=100,
+        hmac_key=_KEY,
+    )
+
+
+def test_receipt_verifies_offline() -> None:
+    receipt = _receipt()
+    ok, field = verify_duplicate_receipt(receipt, hmac_key=_KEY)
+    assert ok is True
+    assert field is None
+
+
+def test_receipt_verify_fails_under_wrong_key() -> None:
+    ok, field = verify_duplicate_receipt(_receipt(), hmac_key=b"1" * 32)
+    assert ok is False
+    assert field == "hmac"
+
+
+def test_mutating_winner_reference_is_named() -> None:
+    authoritative = _receipt()
+    forged = dataclasses.replace(authoritative, winner_output_ref="sha256:TAMPERED")
+    ok, field = verify_duplicate_receipt(forged, hmac_key=_KEY, authoritative=authoritative)
+    assert ok is False
+    assert field == "winner_output_ref"
+
+
+def test_mutating_cache_key_is_named() -> None:
+    authoritative = _receipt()
+    forged = dataclasses.replace(authoritative, cache_key="beef")
+    ok, field = verify_duplicate_receipt(forged, hmac_key=_KEY, authoritative=authoritative)
+    assert ok is False
+    assert field == "cache_key"
+
+
+def test_mutating_claim_position_is_named() -> None:
+    authoritative = _receipt()
+    forged = dataclasses.replace(authoritative, claim_position=99)
+    ok, field = verify_duplicate_receipt(forged, hmac_key=_KEY, authoritative=authoritative)
+    assert ok is False
+    assert field == "claim_position"
+
+
+def test_receipt_json_roundtrip() -> None:
+    receipt = _receipt()
+    restored = DuplicateOfReceipt.from_dict(receipt.to_dict())
+    assert restored == receipt
+    ok, _ = verify_duplicate_receipt(restored, hmac_key=_KEY)
+    assert ok
+
+
+def test_single_winner_among_contenders(tmp_path: Path) -> None:
+    # AC4: exactly one spawn occurs among N contenders for the same key.
+    backlog = tmp_path / "arbiter.json"
+    arbiter = CacheKeyArbiter(backlog, "hotkey")
+    outcomes = [arbiter.contend(f"worker-{i}") for i in range(6)]
+    winners = [o for o in outcomes if o.won]
+    losers = [o for o in outcomes if not o.won]
+    assert len(winners) == 1
+    assert len(losers) == 5
+    assert all(o.winner == winners[0].claimer for o in losers)
+
+
+def test_killed_winner_release_lets_successor_win(tmp_path: Path) -> None:
+    backlog = tmp_path / "arbiter.json"
+    arbiter = CacheKeyArbiter(backlog, "hotkey")
+    first = arbiter.contend("worker-1")
+    assert first.won
+    second = arbiter.contend("worker-2")
+    assert not second.won
+
+    # Winner is killed mid-run: release the claim; exactly one successor wins.
+    arbiter.release()
+    third = arbiter.contend("worker-3")
+    assert third.won
+
+
+def test_concurrent_contention_yields_one_winner(tmp_path: Path) -> None:
+    # Chaos-style: many threads race the same cache key through the atomic
+    # claim; the file lock guarantees exactly one winner.
+    backlog = tmp_path / "arbiter.json"
+    arbiter = CacheKeyArbiter(backlog, "hotkey")
+    # Pre-create the backlog so all threads race the claim, not the create.
+    arbiter._ensure_backlog()
+
+    def _try(i: int) -> bool:
+        return arbiter.contend(f"w-{i}").won
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(_try, range(16)))
+    assert sum(1 for won in results if won) == 1

--- a/tests/unit/test_cache_drift_verdict.py
+++ b/tests/unit/test_cache_drift_verdict.py
@@ -1,0 +1,188 @@
+"""Unit tests for the drift-based freshness verdict (issue #2551, AC1).
+
+The verdict is a pure function of ``(entry, policy, repo_state)``: two processes
+given the same entry and repo state produce the byte-identical verdict JSON, and
+the function reads no clock, no filesystem outside the injected worktree, and no
+network.
+"""
+
+from __future__ import annotations
+
+import builtins
+import subprocess
+
+import pytest
+
+from bernstein.core.persistence.cache_policy import (
+    REASON_BASE_NOT_ANCESTOR,
+    REASON_BASE_OUTSIDE_WINDOW,
+    REASON_FILE_DELETED,
+    REASON_FILE_DRIFT,
+    REASON_FRESH,
+    REASON_TTL_EXPIRED,
+    CacheEntry,
+    CachePolicy,
+    RepoState,
+    evaluate_freshness,
+)
+
+
+def _entry(**over: object) -> CacheEntry:
+    base = {
+        "key": "deadbeef",
+        "input_hashes": {"task_inputs": "sha256:in"},
+        "output_hash": "sha256:out",
+        "producing_task": "t-1",
+        "diff_file_hashes": {"src/a.py": "sha256:aaa", "src/b.py": "sha256:bbb"},
+        "base_commit": "c" * 40,
+        "verified": True,
+        "recipe_hash": "sha256:recipe",
+        "policy_hash": "sha256:policy",
+        "created_ts": 1000,
+    }
+    base.update(over)
+    return CacheEntry(**base)  # type: ignore[arg-type]
+
+
+def test_fresh_when_files_unchanged_and_base_is_head() -> None:
+    policy = CachePolicy(expiry_mode="drift", drift_window=0)
+    state = RepoState(
+        file_hashes={"src/a.py": "sha256:aaa", "src/b.py": "sha256:bbb"},
+        ancestor_distance=0,
+    )
+    verdict = evaluate_freshness(_entry(), policy, state)
+    assert verdict.fresh is True
+    assert verdict.reason == REASON_FRESH
+
+
+def test_stale_when_a_touched_file_changed() -> None:
+    policy = CachePolicy(expiry_mode="drift", drift_window=5)
+    state = RepoState(
+        file_hashes={"src/a.py": "sha256:CHANGED", "src/b.py": "sha256:bbb"},
+        ancestor_distance=0,
+    )
+    verdict = evaluate_freshness(_entry(), policy, state)
+    assert verdict.fresh is False
+    assert verdict.reason == REASON_FILE_DRIFT
+    assert verdict.detail == "src/a.py"
+
+
+def test_stale_when_a_touched_file_deleted() -> None:
+    policy = CachePolicy(expiry_mode="drift", drift_window=5)
+    state = RepoState(file_hashes={"src/b.py": "sha256:bbb"}, ancestor_distance=0)
+    verdict = evaluate_freshness(_entry(), policy, state)
+    assert verdict.fresh is False
+    assert verdict.reason == REASON_FILE_DELETED
+    assert verdict.detail == "src/a.py"
+
+
+def test_stale_when_base_not_ancestor() -> None:
+    policy = CachePolicy(expiry_mode="drift", drift_window=5)
+    state = RepoState(
+        file_hashes={"src/a.py": "sha256:aaa", "src/b.py": "sha256:bbb"},
+        ancestor_distance=None,
+    )
+    verdict = evaluate_freshness(_entry(), policy, state)
+    assert verdict.fresh is False
+    assert verdict.reason == REASON_BASE_NOT_ANCESTOR
+
+
+def test_stale_when_base_outside_drift_window() -> None:
+    policy = CachePolicy(expiry_mode="drift", drift_window=2)
+    state = RepoState(
+        file_hashes={"src/a.py": "sha256:aaa", "src/b.py": "sha256:bbb"},
+        ancestor_distance=5,
+    )
+    verdict = evaluate_freshness(_entry(), policy, state)
+    assert verdict.fresh is False
+    assert verdict.reason == REASON_BASE_OUTSIDE_WINDOW
+    assert verdict.detail == "5"
+
+
+def test_within_window_is_fresh() -> None:
+    policy = CachePolicy(expiry_mode="drift", drift_window=3)
+    state = RepoState(
+        file_hashes={"src/a.py": "sha256:aaa", "src/b.py": "sha256:bbb"},
+        ancestor_distance=3,
+    )
+    assert evaluate_freshness(_entry(), policy, state).fresh is True
+
+
+def test_drift_beats_ttl_ordering() -> None:
+    # A stale file must be reported as file_drift even if TTL would also fire.
+    policy = CachePolicy(expiry_mode="both", drift_window=5, ttl_seconds=10, world_facing=True)
+    state = RepoState(
+        file_hashes={"src/a.py": "sha256:CHANGED", "src/b.py": "sha256:bbb"},
+        ancestor_distance=0,
+        now=1_000_000,
+    )
+    verdict = evaluate_freshness(_entry(), policy, state)
+    assert verdict.reason == REASON_FILE_DRIFT
+
+
+def test_ttl_backstop_only_for_world_facing() -> None:
+    fresh_files = {"src/a.py": "sha256:aaa", "src/b.py": "sha256:bbb"}
+    # world_facing + both: TTL fires when expired.
+    world = CachePolicy(expiry_mode="both", drift_window=5, ttl_seconds=10, world_facing=True)
+    state = RepoState(file_hashes=fresh_files, ancestor_distance=0, now=2000)
+    verdict = evaluate_freshness(_entry(created_ts=1000), world, state)
+    assert verdict.fresh is False
+    assert verdict.reason == REASON_TTL_EXPIRED
+
+    # Non world-facing: TTL branch is inert even with the same timestamps.
+    local = CachePolicy(expiry_mode="both", drift_window=5, ttl_seconds=10, world_facing=False)
+    assert evaluate_freshness(_entry(created_ts=1000), local, state).fresh is True
+
+
+def test_ttl_inert_without_injected_now() -> None:
+    policy = CachePolicy(expiry_mode="both", drift_window=5, ttl_seconds=10, world_facing=True)
+    state = RepoState(
+        file_hashes={"src/a.py": "sha256:aaa", "src/b.py": "sha256:bbb"},
+        ancestor_distance=0,
+        now=None,
+    )
+    # No injected clock -> the verdict never reads the wall clock -> fresh.
+    assert evaluate_freshness(_entry(created_ts=1000), policy, state).fresh is True
+
+
+def test_verdict_json_is_byte_identical_across_processes() -> None:
+    # AC1: two independent evaluations of the same (entry, repo state) produce
+    # byte-identical verdict JSON.
+    policy = CachePolicy(expiry_mode="drift", drift_window=1)
+    state = RepoState(
+        file_hashes={"src/a.py": "sha256:CHANGED", "src/b.py": "sha256:bbb"},
+        ancestor_distance=0,
+    )
+    a = evaluate_freshness(_entry(), policy, state).canonical_json()
+    b = evaluate_freshness(_entry(), policy, state).canonical_json()
+    assert a == b
+    assert isinstance(a, bytes)
+
+
+def test_verdict_reads_no_clock_or_filesystem(monkeypatch: pytest.MonkeyPatch) -> None:
+    # AC1 (enforced by test): the verdict function must not touch the wall
+    # clock, the filesystem, or the network. Poison those and confirm the
+    # verdict still computes from the injected repo state alone.
+    import time as _time
+
+    def _boom(*_a: object, **_k: object) -> float:
+        raise AssertionError("verdict must not read the wall clock")
+
+    def _boom_open(*_a: object, **_k: object) -> object:
+        raise AssertionError("verdict must not touch the filesystem")
+
+    def _boom_proc(*_a: object, **_k: object) -> object:
+        raise AssertionError("verdict must not shell out / hit the network")
+
+    monkeypatch.setattr(_time, "time", _boom)
+    monkeypatch.setattr(builtins, "open", _boom_open)
+    monkeypatch.setattr(subprocess, "run", _boom_proc)
+
+    policy = CachePolicy(expiry_mode="both", drift_window=2, ttl_seconds=10, world_facing=True)
+    state = RepoState(
+        file_hashes={"src/a.py": "sha256:aaa", "src/b.py": "sha256:bbb"},
+        ancestor_distance=1,
+        now=1005,  # within the injected TTL relative to created_ts=1000
+    )
+    verdict = evaluate_freshness(_entry(created_ts=1000), policy, state)
+    assert verdict.fresh is True

--- a/tests/unit/test_cache_eviction.py
+++ b/tests/unit/test_cache_eviction.py
@@ -1,0 +1,87 @@
+"""Unit tests for transitive cache eviction over served-from edges (AC5)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from bernstein.core.persistence.cache_eviction import (
+    ServedFromEdge,
+    ServedFromLedger,
+    TombstoneStore,
+)
+
+
+def _seed_ledger(ledger: ServedFromLedger) -> None:
+    # key_root served run_a and derived key_mid; key_mid served run_b and key_leaf;
+    # key_leaf served run_c. Eviction of key_root must cascade to all three keys
+    # and recall runs a, b, c.
+    ledger.record(ServedFromEdge(cache_key="key_root", consumer="run_a", output_hash="sha256:o1"))
+    ledger.record(ServedFromEdge(cache_key="key_root", consumer="key_mid"))
+    ledger.record(ServedFromEdge(cache_key="key_mid", consumer="run_b"))
+    ledger.record(ServedFromEdge(cache_key="key_mid", consumer="key_leaf"))
+    ledger.record(ServedFromEdge(cache_key="key_leaf", consumer="run_c"))
+
+
+def test_evict_cascades_transitively(tmp_path: Path) -> None:
+    ledger = ServedFromLedger(tmp_path / "served_from.jsonl")
+    tombstones = TombstoneStore(tmp_path / "tombstones.jsonl")
+    _seed_ledger(ledger)
+
+    recall = tombstones.evict("key_root", "pr_reverted", ledger=ledger, ts=42)
+
+    assert recall.root_key == "key_root"
+    assert set(recall.tombstoned) == {"key_root", "key_mid", "key_leaf"}
+    # Consuming runs (non-key consumers) form the forensic recall set.
+    assert set(recall.consumers) == {"run_a", "run_b", "run_c"}
+
+
+def test_tombstoned_keys_are_hard_misses(tmp_path: Path) -> None:
+    ledger = ServedFromLedger(tmp_path / "served_from.jsonl")
+    tombstones = TombstoneStore(tmp_path / "tombstones.jsonl")
+    _seed_ledger(ledger)
+    tombstones.evict("key_root", "bad", ledger=ledger)
+
+    # AC5: an evicted key can never serve again, even when its drift verdict
+    # would be fresh - is_tombstoned short circuits the lookup.
+    assert tombstones.is_tombstoned("key_root") is True
+    assert tombstones.is_tombstoned("key_leaf") is True
+    assert tombstones.is_tombstoned("never_seen") is False
+
+
+def test_eviction_recall_set_is_deterministic(tmp_path: Path) -> None:
+    # Two operators evicting the same key against the same ledger produce the
+    # byte-identical recall set and tombstone order.
+    ledger1 = ServedFromLedger(tmp_path / "a.jsonl")
+    ledger2 = ServedFromLedger(tmp_path / "b.jsonl")
+    _seed_ledger(ledger1)
+    _seed_ledger(ledger2)
+    r1 = TombstoneStore(tmp_path / "t1.jsonl").evict("key_root", "x", ledger=ledger1)
+    r2 = TombstoneStore(tmp_path / "t2.jsonl").evict("key_root", "x", ledger=ledger2)
+    assert r1.to_dict() == r2.to_dict()
+
+
+def test_eviction_persists_across_reopen(tmp_path: Path) -> None:
+    ledger = ServedFromLedger(tmp_path / "served_from.jsonl")
+    _seed_ledger(ledger)
+    TombstoneStore(tmp_path / "tombstones.jsonl").evict("key_mid", "x", ledger=ledger)
+
+    reopened = TombstoneStore(tmp_path / "tombstones.jsonl")
+    assert reopened.is_tombstoned("key_mid")
+    assert reopened.is_tombstoned("key_leaf")
+    # key_root is upstream of key_mid, so it is NOT tombstoned by evicting mid.
+    assert not reopened.is_tombstoned("key_root")
+
+
+def test_cycle_in_served_from_graph_terminates(tmp_path: Path) -> None:
+    ledger = ServedFromLedger(tmp_path / "served_from.jsonl")
+    ledger.record(ServedFromEdge(cache_key="k1", consumer="k2"))
+    ledger.record(ServedFromEdge(cache_key="k2", consumer="k1"))
+    recall = TombstoneStore(tmp_path / "t.jsonl").evict("k1", "x", ledger=ledger)
+    assert set(recall.tombstoned) == {"k1", "k2"}
+
+
+def test_evict_isolated_key_recalls_nothing(tmp_path: Path) -> None:
+    ledger = ServedFromLedger(tmp_path / "served_from.jsonl")
+    recall = TombstoneStore(tmp_path / "t.jsonl").evict("lonely", "x", ledger=ledger)
+    assert recall.tombstoned == ["lonely"]
+    assert recall.consumers == []

--- a/tests/unit/test_cache_policy.py
+++ b/tests/unit/test_cache_policy.py
@@ -1,0 +1,135 @@
+"""Unit tests for the cache-policy engine (issue #2551).
+
+Covers the policy model, the composable key recipe, and the mandatory-ingredient
+key discrimination (AC6): any change to a mandatory ingredient (model version,
+adapter version, base worktree commit, tool schema hash) or a declared optional
+ingredient produces a different composed key.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from bernstein.core.persistence.cache_policy import (
+    MANDATORY_INGREDIENTS,
+    CachePolicy,
+    RecipeInputs,
+    compose_key_hex,
+    compose_recipe,
+    recipe_hash,
+)
+
+
+def _inputs(**over: object) -> RecipeInputs:
+    base = {
+        "model_id": "claude-opus-4-8",
+        "model_version": "2026-01-15",
+        "adapter_version": "claude@1.4.2",
+        "base_commit": "a" * 40,
+        "tool_schema_hash": "sha256:tools",
+        "task_inputs": {"goal": "add login endpoint"},
+        "producer_code": "def run(): ...",
+        "run_parameters": {"temperature": 0.0},
+    }
+    base.update(over)
+    return RecipeInputs(**base)  # type: ignore[arg-type]
+
+
+def test_policy_hash_is_deterministic_and_stable() -> None:
+    a = CachePolicy(ingredients=("task_inputs",), expiry_mode="drift", drift_window=3)
+    b = CachePolicy(ingredients=("task_inputs",), expiry_mode="drift", drift_window=3)
+    assert a.policy_hash() == b.policy_hash()
+    assert a.policy_hash().startswith("sha256:")
+
+
+def test_policy_roundtrip_from_dict() -> None:
+    policy = CachePolicy(
+        ingredients=("task_inputs", "producer_code"),
+        expiry_mode="both",
+        drift_window=5,
+        ttl_seconds=3600,
+        verified_only=True,
+        world_facing=True,
+        store_scope="research",
+    )
+    restored = CachePolicy.from_dict(policy.to_dict())
+    assert restored == policy
+    assert restored.policy_hash() == policy.policy_hash()
+
+
+def test_policy_rejects_unknown_ingredient() -> None:
+    with pytest.raises(ValueError, match="unknown optional ingredient"):
+        CachePolicy(ingredients=("not_a_real_ingredient",))
+
+
+def test_policy_rejects_duplicate_ingredient() -> None:
+    with pytest.raises(ValueError, match="duplicate ingredient"):
+        CachePolicy(ingredients=("task_inputs", "task_inputs"))
+
+
+def test_policy_ttl_required_when_mode_includes_ttl() -> None:
+    with pytest.raises(ValueError, match="ttl_seconds must be a positive int"):
+        CachePolicy(expiry_mode="ttl")
+    with pytest.raises(ValueError, match="does not include a TTL backstop"):
+        CachePolicy(expiry_mode="drift", ttl_seconds=60)
+
+
+def test_recipe_lists_mandatory_ingredients_first() -> None:
+    policy = CachePolicy(ingredients=("task_inputs",))
+    recipe = compose_recipe(policy, _inputs())
+    names = [ing["name"] for ing in recipe["ingredients"]]
+    assert names[: len(MANDATORY_INGREDIENTS)] == list(MANDATORY_INGREDIENTS)
+    assert names[-1] == "task_inputs"
+    assert recipe["policy_hash"] == policy.policy_hash()
+
+
+def test_compose_key_is_deterministic() -> None:
+    policy = CachePolicy(ingredients=("task_inputs",))
+    assert compose_key_hex(policy, _inputs()) == compose_key_hex(policy, _inputs())
+
+
+@pytest.mark.parametrize("ingredient", list(MANDATORY_INGREDIENTS))
+def test_mandatory_ingredient_change_changes_key(ingredient: str) -> None:
+    policy = CachePolicy(ingredients=("task_inputs",))
+    baseline = compose_key_hex(policy, _inputs())
+    mutated = compose_key_hex(policy, _inputs(**{ingredient: "DIFFERENT-" + ingredient}))
+    assert mutated != baseline, f"changing mandatory ingredient {ingredient} must change the key"
+
+
+def test_declared_optional_ingredient_change_changes_key() -> None:
+    policy = CachePolicy(ingredients=("task_inputs",))
+    baseline = compose_key_hex(policy, _inputs())
+    mutated = compose_key_hex(policy, _inputs(task_inputs={"goal": "something else"}))
+    assert mutated != baseline
+
+
+def test_undeclared_ingredient_does_not_affect_key() -> None:
+    # producer_code is not declared, so changing it must not change the key.
+    policy = CachePolicy(ingredients=("task_inputs",))
+    baseline = compose_key_hex(policy, _inputs())
+    unchanged = compose_key_hex(policy, _inputs(producer_code="def run(): return 42"))
+    assert unchanged == baseline
+
+
+def test_policy_hash_bound_into_key() -> None:
+    # Two policies over identical inputs must produce distinct keys because the
+    # policy hash is folded into the recipe.
+    p1 = CachePolicy(ingredients=("task_inputs",), store_scope="a")
+    p2 = CachePolicy(ingredients=("task_inputs",), store_scope="b")
+    assert compose_key_hex(p1, _inputs()) != compose_key_hex(p2, _inputs())
+
+
+def test_recipe_hash_matches_key_derivation() -> None:
+    policy = CachePolicy(ingredients=("task_inputs",))
+    recipe = compose_recipe(policy, _inputs())
+    # recipe_hash is a stable sha256 over the recipe; identical recipes agree.
+    assert recipe_hash(recipe) == recipe_hash(compose_recipe(policy, _inputs()))
+
+
+def test_frozen_policy_is_hashable() -> None:
+    policy = CachePolicy(ingredients=("task_inputs",))
+    assert dataclasses.is_dataclass(policy)
+    # Frozen dataclasses participate in sets - useful as dict keys downstream.
+    assert {policy, policy} == {policy}

--- a/tests/unit/test_cache_policy_task_regression.py
+++ b/tests/unit/test_cache_policy_task_regression.py
@@ -1,0 +1,62 @@
+"""Regression: tasks without a CachePolicy behave exactly as today (AC7).
+
+A task that declares no ``cache_policy`` must parse to ``None`` and be
+indistinguishable from a pre-feature task on every other field, so the spawn
+path is byte-identical to current behaviour.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from bernstein.core.persistence.cache_policy import CachePolicy, refresh_requested
+from bernstein.core.tasks.models import Task
+
+# Pin created_at so two from_dict calls do not diverge on the time.time default.
+_BASE = {
+    "id": "t-1",
+    "title": "Add login",
+    "description": "Do the thing",
+    "role": "backend",
+    "created_at": 1_700_000_000.0,
+}
+
+
+def test_task_without_policy_parses_to_none() -> None:
+    task = Task.from_dict(dict(_BASE))
+    assert task.cache_policy is None
+    assert CachePolicy.from_task(task) is None
+
+
+def test_task_without_policy_matches_all_other_fields() -> None:
+    # Building the same task via from_dict with and without the (absent) key
+    # yields identical dataclasses - the field is purely additive.
+    a = Task.from_dict(dict(_BASE))
+    b = Task.from_dict({**_BASE, "cache_policy": None})
+    assert dataclasses.asdict(a) == dataclasses.asdict(b)
+
+
+def test_task_with_policy_parses_and_resolves() -> None:
+    task = Task.from_dict(
+        {
+            **_BASE,
+            "cache_policy": {
+                "ingredients": ["task_inputs"],
+                "expiry_mode": "drift",
+                "drift_window": 3,
+                "verified_only": True,
+            },
+        }
+    )
+    policy = CachePolicy.from_task(task)
+    assert policy is not None
+    assert policy.verified_only is True
+    assert policy.drift_window == 3
+    assert policy.ingredients == ("task_inputs",)
+
+
+def test_refresh_requested_reads_env() -> None:
+    assert refresh_requested({"BERNSTEIN_REFRESH_CACHE": "1"}) is True
+    assert refresh_requested({"BERNSTEIN_REFRESH_CACHE": "true"}) is True
+    assert refresh_requested({"BERNSTEIN_REFRESH_CACHE": "0"}) is False
+    assert refresh_requested({}) is False

--- a/tests/unit/test_cache_served_from_spine.py
+++ b/tests/unit/test_cache_served_from_spine.py
@@ -1,0 +1,94 @@
+"""Served-from spine entries are Merkle-chained and tamper-evident (AC2).
+
+A run that served steps from cache replays to the identical spine head;
+suppressing or mutating any single served_from entry causes spine verification
+to fail, so a hidden or forged cache hit is falsification-evident.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from bernstein.core.lineage.spine import LineageSpine, SpineStatus
+from bernstein.core.persistence.cache_served_from import (
+    record_served_from,
+    served_from_artifact_path,
+)
+
+_HMAC = b"k" * 32
+
+
+def _spine(tmp_path: Path, run_id: str = "run-1") -> LineageSpine:
+    return LineageSpine(tmp_path / "lineage", run_id=run_id, hmac_key=_HMAC)
+
+
+def _record_two_hits(spine: LineageSpine) -> None:
+    record_served_from(
+        spine,
+        cache_key="key-a",
+        output_hash="sha256:out-a",
+        policy_hash="sha256:policy",
+        recipe_hash="sha256:recipe",
+        actor="cache_policy",
+        step_id="step-1",
+        model="claude-opus-4-8",
+        timestamp=1000,
+    )
+    record_served_from(
+        spine,
+        cache_key="key-b",
+        output_hash="sha256:out-b",
+        policy_hash="sha256:policy",
+        recipe_hash="sha256:recipe",
+        actor="cache_policy",
+        step_id="step-2",
+        model="claude-opus-4-8",
+        timestamp=1001,
+    )
+
+
+def test_served_from_hits_verify(tmp_path: Path) -> None:
+    spine = _spine(tmp_path)
+    _record_two_hits(spine)
+    result = spine.verify()
+    assert result.status is SpineStatus.OK
+    assert result.count == 2
+
+
+def test_two_runs_replay_to_identical_head(tmp_path: Path) -> None:
+    # AC2: byte-identical served_from records replay to the identical head.
+    a = _spine(tmp_path / "one")
+    b = _spine(tmp_path / "two")
+    _record_two_hits(a)
+    _record_two_hits(b)
+    assert a.head_hash() == b.head_hash()
+
+
+def test_mutated_served_from_entry_fails_verification(tmp_path: Path) -> None:
+    import json
+
+    spine = _spine(tmp_path)
+    _record_two_hits(spine)
+    # Tamper with the first served_from row: forge the recorded content hash so
+    # the served output no longer matches what the entry claims was served.
+    lines = spine.spine_path.read_text(encoding="utf-8").splitlines()
+    row = json.loads(lines[0])
+    row["content_hash"] = "sha256:" + "f" * 64
+    lines[0] = json.dumps(row, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+    spine.spine_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    assert spine.verify().status is SpineStatus.TAMPERED
+
+
+def test_suppressed_served_from_entry_fails_verification(tmp_path: Path) -> None:
+    spine = _spine(tmp_path)
+    _record_two_hits(spine)
+    lines = spine.spine_path.read_text(encoding="utf-8").splitlines()
+    # Drop the first hit; the second's prev_hash no longer chains to genesis.
+    spine.spine_path.write_text(lines[1] + "\n", encoding="utf-8")
+    assert spine.verify().status is SpineStatus.TAMPERED
+
+
+def test_artifact_path_is_repo_relative() -> None:
+    path = served_from_artifact_path("key-a")
+    assert path == ".sdd/cache/served_from/key-a"
+    assert not path.startswith("/")

--- a/tests/unit/test_cli_cache_policy_cmd.py
+++ b/tests/unit/test_cli_cache_policy_cmd.py
@@ -1,0 +1,79 @@
+"""Tests for `bernstein cache evict` and `bernstein cache policy` (issue #2551)."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from click.testing import CliRunner
+
+from bernstein.cli.main import cli
+from bernstein.core.persistence.cache_eviction import (
+    ServedFromEdge,
+    open_ledger,
+    open_tombstones,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _seed_served_from(workdir: Path) -> None:
+    ledger = open_ledger(workdir)
+    ledger.record(ServedFromEdge(cache_key="key_root", consumer="run_a"))
+    ledger.record(ServedFromEdge(cache_key="key_root", consumer="key_child"))
+    ledger.record(ServedFromEdge(cache_key="key_child", consumer="run_b"))
+
+
+def test_cache_evict_json_reports_recall_set(tmp_path: Path) -> None:
+    _seed_served_from(tmp_path)
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        ["cache", "evict", "key_root", "--reason", "pr_reverted", "--workdir", str(tmp_path), "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["root_key"] == "key_root"
+    assert set(payload["tombstoned"]) == {"key_root", "key_child"}
+    assert set(payload["consumers"]) == {"run_a", "run_b"}
+
+    # The tombstone is durable and both keys are hard misses afterwards.
+    tombstones = open_tombstones(tmp_path)
+    assert tombstones.is_tombstoned("key_root")
+    assert tombstones.is_tombstoned("key_child")
+
+
+def test_cache_evict_emits_audit_event(tmp_path: Path) -> None:
+    _seed_served_from(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["cache", "evict", "key_root", "--reason", "bad", "--workdir", str(tmp_path)],
+        env={"BERNSTEIN_AUDIT_KEY_PATH": str(tmp_path / "audit.key")},
+    )
+    assert result.exit_code == 0, result.output
+
+    from bernstein.core.security.audit_chain import EVENT_CACHE_EVICTION, AuditChainStore
+
+    chain = AuditChainStore(tmp_path / ".sdd" / "audit", key=(tmp_path / "audit.key").read_bytes().strip())
+    rows = chain.query(event_type=EVENT_CACHE_EVICTION)
+    assert len(rows) == 1
+    assert rows[0].details["cache_key"] == "key_root"
+    assert rows[0].details["reason"] == "bad"
+
+
+def test_cache_policy_show_json(tmp_path: Path) -> None:
+    policy_file = tmp_path / "policy.json"
+    policy_file.write_text(
+        json.dumps({"ingredients": ["task_inputs"], "expiry_mode": "drift", "drift_window": 2}),
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    result = runner.invoke(cli, ["cache", "policy", "--file", str(policy_file), "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["policy"]["ingredients"] == ["task_inputs"]
+    assert payload["policy_hash"].startswith("sha256:")


### PR DESCRIPTION
## Summary

Implements the cache policy engine from #2551: an opt-in `CachePolicy` declared on the task spec that defines cache semantics at the single cache boundary. Additive and behavior-preserving; a task that declares no policy runs byte-identically to current behavior.

## What landed

- **Composable key recipes** (`core/persistence/cache_policy.py`): keys are content-addressed deterministic projections over an ordered ingredient recipe on top of five mandatory ingredients (model id, model version, adapter version, base worktree commit, tool schema hash). Any mandatory or declared-optional ingredient change changes the key; the policy hash is folded in.
- **Drift-based expiry**: `evaluate_freshness(entry, policy, repo_state)` is a pure verdict function that reads no clock, no filesystem outside the injected worktree, and no network. Two operators with the same repo state compute byte-identical verdict JSON. Wall-clock TTL applies only as a declared backstop for world-facing tasks via an injected timestamp.
- **Served-from spine entries** (`core/persistence/cache_served_from.py`): every hit records on the Merkle-chained, HMAC-tagged lineage spine, so replay proves which steps were served and a forged or suppressed hit fails spine verification.
- **Claim-based fleet dedup** (`core/persistence/cache_dedup.py`): cache-key contention routes through the atomic claim primitive so exactly one worker spawns; losers receive a signed duplicate-of receipt that verifies offline and names any mutated field.
- **Surgical transitive eviction** (`core/persistence/cache_eviction.py`): `cache evict <key> --reason` tombstones the key and everything reachable over `served_from` edges, prints the recall set of consuming runs, emits an audit-chain event, and writes a recall report. A tombstoned key never serves again, even when its drift verdict is fresh.
- **CLI**: `cache evict`, `cache policy`; `run --refresh-cache` bypasses policy hits and repopulates.
- **Audit events**: `cache.hit`, `cache.miss`, `cache.dedup_claim`, `cache.eviction`, each carrying the policy hash and recipe hash.
- **Task spec**: opt-in `cache_policy` field parsed alongside the existing `approval_spec` pattern.
- **Docs**: new `docs/concepts/cache-policy.md`; cross-references in `action-cache.md` and `fingerprint-memoization.md`.

## Acceptance criteria coverage

| Criterion | Where |
| --- | --- |
| Byte-identical drift verdict; no clock/fs/network | `test_cache_drift_verdict.py`, `test_cache_policy_properties.py` |
| Served-from replay to identical head; tamper/suppress fails verification | `test_cache_served_from_spine.py` |
| Duplicate-of receipt verifies offline; mutation names the field | `test_cache_dedup.py` |
| N workers race, exactly one spawn; killed winner releases, one successor | `test_cache_dedup.py` |
| Transitive eviction + recall set; tombstoned key is a hard miss | `test_cache_eviction.py`, `test_cli_cache_policy_cmd.py` |
| Any mandatory ingredient change changes the key | `test_cache_policy.py`, `test_cache_policy_properties.py` |
| No-policy tasks byte-identical; events carry policy+recipe hash | `test_cache_policy_task_regression.py`, `test_cache_audit_events.py` |

## Verification

- New suites: 63 tests green (unit + property).
- Regression: existing action-cache, fingerprint, semantic/response cache, claim, task models, lineage spine, base spine writes, and golden CLI snapshot suites green.
- `ruff check src/` and `ruff format --check src/` clean; new modules pyright-clean; `agents-md verify` in sync.

Closes #2551


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in cache policy engine with deterministic cache keys and drift-based freshness checks.
  * Added cache deduplication, tamper-evident cache-hit tracking, audit events, and transitive eviction with recall reports.
  * Added `cache policy` and `cache evict` commands, plus a per-run `--refresh-cache` option.
* **Documentation**
  * Added cache policy documentation and expanded related architecture guides.
* **Tests**
  * Added comprehensive coverage for policy behavior, freshness, deduplication, eviction, auditing, and CLI workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->