### PR TITLE
refactor(security): recognition-only disclosure, drop monetary reward tables

### DIFF
--- a/.github/ISSUE_TEMPLATE/security.md
+++ b/.github/ISSUE_TEMPLATE/security.md
@@ -14,9 +14,8 @@ assignees: []
 
 ## How to report a vulnerability
 
-1. **HackerOne (preferred):** https://hackerone.com/bernstein
-2. **Email:** forte@bernstein.run (PGP key at `/.well-known/security-pgp.asc`)
-3. **GitHub private vulnerability reporting:** the "Report a vulnerability"
+1. **Email (preferred):** forte@bernstein.run (PGP key at `/.well-known/security-pgp.asc`)
+2. **GitHub private vulnerability reporting:** the "Report a vulnerability"
    button on the [Security tab](https://github.com/sipyourdrink-ltd/bernstein/security/advisories/new).
 
 Initial triage acknowledgement: within 72 hours. SLA matrix and the

--- a/src/bernstein/core/security/vuln_disclosure.py
+++ b/src/bernstein/core/security/vuln_disclosure.py
@@ -1,15 +1,16 @@
-"""Automated vulnerability disclosure program with bug bounty integration.
+"""Coordinated vulnerability disclosure with non-monetary recognition.
 
 Provides structured vulnerability report handling, triage workflows,
 coordinated disclosure timelines, and RFC 9116 security.txt generation.
-Integrates with bug bounty platforms (HackerOne, Bugcrowd) for reward
-management and researcher communication.
+Recognition for valid reports is non-monetary - severity maps to a
+recognition tier (acknowledgment, public credit, CVE credit, hall of
+fame) rather than a cash payout.
 
 Usage::
 
     from bernstein.core.security.vuln_disclosure import (
         VulnReport,
-        BountyScope,
+        DisclosureScope,
         VulnerabilityDisclosureManager,
         generate_security_txt,
     )
@@ -62,6 +63,21 @@ class ReportStatus(StrEnum):
     REJECTED = "rejected"
 
 
+class RecognitionTier(StrEnum):
+    """Non-monetary recognition granted for a valid disclosure.
+
+    The project is non-commercial and runs no paid bounty; researchers are
+    recognized through acknowledgment, public credit, CVE credit, and the
+    hall of fame rather than a cash reward.
+    """
+
+    NONE = "none"
+    ACKNOWLEDGMENT = "acknowledgment"
+    PUBLIC_CREDIT = "public-credit"
+    CVE_CREDIT = "cve-credit"
+    HALL_OF_FAME = "hall-of-fame"
+
+
 @dataclass(frozen=True)
 class VulnReport:
     """A vulnerability report submitted by a security researcher.
@@ -90,29 +106,30 @@ class VulnReport:
 
 
 @dataclass(frozen=True)
-class BountyScope:
-    """Scope definition for the bug bounty program.
+class DisclosureScope:
+    """Scope definition for the coordinated disclosure program.
+
+    Recognition is non-monetary: ``recognition`` maps a severity level to a
+    :class:`RecognitionTier` value rather than a cash amount.
 
     Attributes:
         in_scope: Components or endpoints that are in scope.
         out_of_scope: Components explicitly out of scope.
-        rewards: Mapping from severity level to USD reward amount.
+        recognition: Mapping from severity level to recognition tier.
         response_sla_hours: Maximum hours before initial triage response.
-        max_reward: Absolute cap on any single bounty payout.
     """
 
-    in_scope: tuple[str, ...]
+    in_scope: tuple[str, ...] = ()
     out_of_scope: tuple[str, ...] = ()
-    rewards: dict[str, float] = field(
+    recognition: dict[str, str] = field(
         default_factory=lambda: {
-            "low": 100.0,
-            "medium": 500.0,
-            "high": 1500.0,
-            "critical": 5000.0,
+            "low": RecognitionTier.ACKNOWLEDGMENT.value,
+            "medium": RecognitionTier.PUBLIC_CREDIT.value,
+            "high": RecognitionTier.CVE_CREDIT.value,
+            "critical": RecognitionTier.HALL_OF_FAME.value,
         }
     )
     response_sla_hours: int = 48
-    max_reward: float = 10000.0
 
 
 @dataclass(frozen=True)
@@ -157,7 +174,7 @@ def generate_security_txt(
 
     Args:
         contact: Contact URI (e.g. ``mailto:security@example.com`` or
-                 ``https://hackerone.com/example``).
+                 ``https://github.com/example/repo/security/advisories``).
         policy_url: URL to the full security/vulnerability policy.
         expires: Date when this file expires (ISO 8601). Defaults to 1 year.
         encryption: URL pointing to a PGP public key for encrypted reports.
@@ -207,14 +224,20 @@ class VulnerabilityDisclosureManager:
     """Manages the full lifecycle of vulnerability disclosure.
 
     Handles report submission, triage, fix tracking, and coordinated
-    disclosure timelines. Provides reward calculation based on bounty scope.
+    disclosure timelines. Classifies each report into a non-monetary
+    recognition tier based on the disclosure scope.
 
     Usage::
 
         mgr = VulnerabilityDisclosureManager(
-            scope=BountyScope(
+            scope=DisclosureScope(
                 in_scope=("/api/v1/*", "/api/v2/*"),
-                rewards={"low": 100, "medium": 500, "high": 2000, "critical": 10000},
+                recognition={
+                    "low": "acknowledgment",
+                    "medium": "public-credit",
+                    "high": "cve-credit",
+                    "critical": "hall-of-fame",
+                },
             ),
         )
         report_id = mgr.submit_report(report)
@@ -223,21 +246,21 @@ class VulnerabilityDisclosureManager:
 
     def __init__(
         self,
-        scope: BountyScope | None = None,
+        scope: DisclosureScope | None = None,
         *,
         triage_sla_hours: int = 48,
         fix_deadline_days: int = 90,
         disclosure_delay_days: int = 30,
     ) -> None:
-        self._scope = scope or BountyScope()
+        self._scope = scope or DisclosureScope()
         self._reports: dict[str, VulnReport] = {}
         self._triage_sla_hours = triage_sla_hours
         self._fix_deadline_days = fix_deadline_days
         self._disclosure_delay_days = disclosure_delay_days
 
     @property
-    def scope(self) -> BountyScope:
-        """Return the current bounty scope configuration."""
+    def scope(self) -> DisclosureScope:
+        """Return the current disclosure scope configuration."""
         return self._scope
 
     @property
@@ -436,19 +459,20 @@ class VulnerabilityDisclosureManager:
             milestones=milestones,
         )
 
-    # -- Reward calculation ---------------------------------------------------
+    # -- Recognition classification -------------------------------------------
 
-    def calculate_reward(self, report_id: str) -> float:
-        """Calculate the bounty reward for a triaged report.
+    def classify_recognition(self, report_id: str) -> str:
+        """Classify a triaged report into a non-monetary recognition tier.
 
-        Looks up the severity in the bounty scope's reward table.
-        Returns 0.0 if the severity is not in the table.
+        Looks up the severity in the disclosure scope's recognition table.
+        Returns :attr:`RecognitionTier.NONE` (``"none"``) if the severity is
+        not in the table.
 
         Args:
             report_id: Tracking ID of the report.
 
         Returns:
-            The calculated reward amount in USD.
+            The recognition tier value (see :class:`RecognitionTier`).
 
         Raises:
             KeyError: If the report does not exist.
@@ -457,8 +481,7 @@ class VulnerabilityDisclosureManager:
         if report is None:
             raise KeyError(f"Report {report_id!r} not found")
 
-        reward = self._scope.rewards.get(report.severity, 0.0)
-        return min(reward, self._scope.max_reward)
+        return self._scope.recognition.get(report.severity, RecognitionTier.NONE.value)
 
     # -- SLA compliance -------------------------------------------------------
 

--- a/tests/unit/test_vuln_disclosure.py
+++ b/tests/unit/test_vuln_disclosure.py
@@ -1,7 +1,8 @@
 """Tests for bernstein.core.security.vuln_disclosure.
 
 Covers vulnerability report lifecycle, triage, disclosure timelines,
-reward calculation, SLA compliance, and security.txt generation.
+non-monetary recognition classification, SLA compliance, and
+security.txt generation.
 """
 
 from __future__ import annotations
@@ -11,8 +12,9 @@ from datetime import UTC, datetime, timedelta
 import pytest
 
 from bernstein.core.security.vuln_disclosure import (
-    BountyScope,
+    DisclosureScope,
     DisclosureTimeline,
+    RecognitionTier,
     ReportStatus,
     VulnerabilityDisclosureManager,
     VulnReport,
@@ -39,19 +41,23 @@ def sample_report() -> VulnReport:
 
 
 @pytest.fixture
-def sample_scope() -> BountyScope:
-    """Create a sample bounty scope."""
-    return BountyScope(
+def sample_scope() -> DisclosureScope:
+    """Create a sample disclosure scope."""
+    return DisclosureScope(
         in_scope=("/api/v1/*", "/api/v2/*"),
         out_of_scope=("/static/*", "/docs/*"),
-        rewards={"low": 100.0, "medium": 500.0, "high": 1500.0, "critical": 5000.0},
+        recognition={
+            "low": "acknowledgment",
+            "medium": "public-credit",
+            "high": "cve-credit",
+            "critical": "hall-of-fame",
+        },
         response_sla_hours=48,
-        max_reward=10000.0,
     )
 
 
 @pytest.fixture
-def manager(sample_scope: BountyScope) -> VulnerabilityDisclosureManager:
+def manager(sample_scope: DisclosureScope) -> VulnerabilityDisclosureManager:
     """Create a disclosure manager with the sample scope."""
     return VulnerabilityDisclosureManager(
         scope=sample_scope,
@@ -293,20 +299,21 @@ class TestDisclosureTimeline:
 
 
 # ---------------------------------------------------------------------------
-# VulnerabilityDisclosureManager - reward calculation
+# VulnerabilityDisclosureManager - recognition classification
 # ---------------------------------------------------------------------------
 
 
-class TestRewardCalculation:
-    """Tests for bounty reward calculation."""
+class TestRecognitionClassification:
+    """Tests for non-monetary recognition classification."""
 
-    def test_high_severity_reward(self, manager: VulnerabilityDisclosureManager, sample_report: VulnReport) -> None:
+    def test_high_severity_recognition(
+        self, manager: VulnerabilityDisclosureManager, sample_report: VulnReport
+    ) -> None:
         manager.submit_report(sample_report)
         manager.triage_report("VR-001")
-        reward = manager.calculate_reward("VR-001")
-        assert reward == pytest.approx(1500.0)
+        assert manager.classify_recognition("VR-001") == "cve-credit"
 
-    def test_critical_severity_reward(self, manager: VulnerabilityDisclosureManager) -> None:
+    def test_critical_severity_recognition(self, manager: VulnerabilityDisclosureManager) -> None:
         report = VulnReport(
             report_id="VR-CRIT",
             severity="critical",
@@ -316,15 +323,13 @@ class TestRewardCalculation:
         )
         manager.submit_report(report)
         manager.triage_report("VR-CRIT")
-        reward = manager.calculate_reward("VR-CRIT")
-        assert reward == pytest.approx(5000.0)
+        assert manager.classify_recognition("VR-CRIT") == "hall-of-fame"
 
-    def test_unknown_severity_zero_reward(self, manager: VulnerabilityDisclosureManager) -> None:
-        """Severity not in the reward table should return 0."""
-        # Use a scope with no "info" tier
-        scope = BountyScope(
+    def test_unknown_severity_no_recognition(self, manager: VulnerabilityDisclosureManager) -> None:
+        """A severity not in the recognition table maps to 'none'."""
+        scope = DisclosureScope(
             in_scope=("/api/*",),
-            rewards={"high": 1000, "critical": 5000},
+            recognition={"high": "cve-credit", "critical": "hall-of-fame"},
         )
         mgr = VulnerabilityDisclosureManager(scope=scope)
         report = VulnReport(
@@ -336,25 +341,29 @@ class TestRewardCalculation:
         )
         mgr.submit_report(report)
         mgr.triage_report("VR-LOW")
-        assert mgr.calculate_reward("VR-LOW") == pytest.approx(0.0)
+        assert mgr.classify_recognition("VR-LOW") == RecognitionTier.NONE.value
 
-    def test_reward_capped_at_max(self, manager: VulnerabilityDisclosureManager) -> None:
-        scope = BountyScope(
+    def test_custom_recognition_mapping(self, manager: VulnerabilityDisclosureManager) -> None:
+        """A custom recognition mapping is honoured verbatim."""
+        scope = DisclosureScope(
             in_scope=("/api/*",),
-            rewards={"critical": 50000.0},
-            max_reward=10000.0,
+            recognition={"medium": "public-credit"},
         )
         mgr = VulnerabilityDisclosureManager(scope=scope)
         report = VulnReport(
-            report_id="VR-CAP",
-            severity="critical",
-            title="RCE",
-            description="Remote code execution",
+            report_id="VR-MED",
+            severity="medium",
+            title="SSRF",
+            description="Server-side request forgery",
             reporter_email="a@b.com",
         )
         mgr.submit_report(report)
-        mgr.triage_report("VR-CAP")
-        assert mgr.calculate_reward("VR-CAP") == pytest.approx(10000.0)
+        mgr.triage_report("VR-MED")
+        assert mgr.classify_recognition("VR-MED") == "public-credit"
+
+    def test_classify_nonexistent_raises(self, manager: VulnerabilityDisclosureManager) -> None:
+        with pytest.raises(KeyError):
+            manager.classify_recognition("VR-MISSING")
 
 
 # ---------------------------------------------------------------------------
@@ -432,27 +441,48 @@ class TestVulnReport:
 
 
 # ---------------------------------------------------------------------------
-# BountyScope data model
+# DisclosureScope data model
 # ---------------------------------------------------------------------------
 
 
-class TestBountyScope:
-    """Tests for the BountyScope dataclass."""
+class TestDisclosureScope:
+    """Tests for the DisclosureScope dataclass."""
 
-    def test_default_rewards(self) -> None:
-        scope = BountyScope(in_scope=("/api/*",))
-        assert scope.rewards["low"] == pytest.approx(100.0)
-        assert scope.rewards["critical"] == pytest.approx(5000.0)
+    def test_default_recognition(self) -> None:
+        scope = DisclosureScope(in_scope=("/api/*",))
+        assert scope.recognition["low"] == RecognitionTier.ACKNOWLEDGMENT.value
+        assert scope.recognition["critical"] == RecognitionTier.HALL_OF_FAME.value
 
-    def test_custom_rewards(self) -> None:
-        scope = BountyScope(
+    def test_custom_recognition(self) -> None:
+        scope = DisclosureScope(
             in_scope=("/api/*",),
-            rewards={"low": 50.0, "high": 3000.0},
+            recognition={"low": "acknowledgment", "high": "cve-credit"},
         )
-        assert scope.rewards.get("low") == pytest.approx(50.0)
-        assert scope.rewards.get("high") == pytest.approx(3000.0)
+        assert scope.recognition.get("low") == "acknowledgment"
+        assert scope.recognition.get("high") == "cve-credit"
+
+    def test_no_monetary_fields(self) -> None:
+        """The scope carries no dollar-denominated reward fields."""
+        scope = DisclosureScope(in_scope=("/api/*",))
+        assert not hasattr(scope, "rewards")
+        assert not hasattr(scope, "max_reward")
+
+    def test_default_scope_needs_no_targets(self) -> None:
+        """A scope is constructible with no in-scope targets.
+
+        The manager falls back to ``DisclosureScope()`` when no scope is
+        supplied, so an empty in-scope default must be valid.
+        """
+        scope = DisclosureScope()
+        assert scope.in_scope == ()
+        assert scope.recognition["critical"] == RecognitionTier.HALL_OF_FAME.value
+
+    def test_manager_default_scope_is_constructible(self) -> None:
+        """VulnerabilityDisclosureManager() works with no scope argument."""
+        mgr = VulnerabilityDisclosureManager()
+        assert mgr.scope.in_scope == ()
 
     def test_frozen_scope(self) -> None:
-        scope = BountyScope(in_scope=("/api/*",))
+        scope = DisclosureScope(in_scope=("/api/*",))
         with pytest.raises(AttributeError):
-            scope.max_reward = 999999  # type: ignore[misc]
+            scope.response_sla_hours = 999  # type: ignore[misc]


### PR DESCRIPTION
## What

Aligns the two residual monetary-reward artifacts with the recognition-only
security policy already reflected in `SECURITY.md`, so nothing in the repo
implies a paid bug bounty. The project is solo and non-commercial with no
bounty budget.

### `src/bernstein/core/security/vuln_disclosure.py` (+ tests)

- Replace `BountyScope` (USD `rewards` table `{100, 500, 1500, 5000}`,
  `max_reward=10000`) with `DisclosureScope` carrying a non-monetary
  `recognition` mapping.
- New `RecognitionTier` enum: `none / acknowledgment / public-credit /
  cve-credit / hall-of-fame`.
- Replace `calculate_reward()` (returned USD) with `classify_recognition()`
  (returns a recognition tier). No dollar-amount reward tables remain in
  shipped code.
- Fix a latent crash: `VulnerabilityDisclosureManager()` with no scope
  previously raised because `in_scope` had no default; it now defaults to an
  empty tuple. Covered by a new test.

### `.github/ISSUE_TEMPLATE/security.md`

- Drop the HackerOne (bounty-platform) reporting channel so the template
  matches `SECURITY.md`'s actual channels: email + GitHub private advisory.

## Verification

- `pytest tests/unit/test_vuln_disclosure.py` - 40 passed (recognition
  classification covered)
- `ruff check` / `ruff format --check` - clean
- `mypy src/bernstein/core/security/vuln_disclosure.py` - clean

## Docs

`SECURITY.md`, `docs/security/bug-bounty.md`, and the mkdocs nav were already
reframed to recognition-only in a prior change; no further doc updates needed.