### PR TITLE
feat(planning): thread lineage-attested failure receipts into on_fail recovery tasks

### DIFF
--- a/docs/lineage.md
+++ b/docs/lineage.md
@@ -161,6 +161,59 @@ make -C examples/lineage demo-eu-mfg
 | `bernstein lineage gate` reports "missing trailing newline" | The final record was truncated or its terminating `\n` was stripped/flipped at EOF (e.g. an editor that drops the trailing newline, or a partial write). | Restore the full log from a trusted copy; a truncated final record is tamper-evidence. |
 | Genesis entry shows up with `parent_hashes: []` | First-time write of a file that existed before lineage was enabled. | Expected - see ADR-009 §11 on bootstrap. |
 
+## on_fail recovery receipts
+
+When a workflow DSL DAG routes control to a recovery node because an upstream
+node failed under a guard (the `fix-bugs` depends-on `run-tests` with
+`condition: "status == 'failed'"` pattern), the recovery task carries a
+**lineage-attested failure receipt** rather than a bare description.
+
+The receipt is the recovery task's primary artefact. It captures the failure
+the run already observed:
+
+| Field | Source |
+|---|---|
+| `source_status` | The failing task's terminal status. |
+| `condition_context` | The guard evaluation context (`status` / `result` / `output`). |
+| `gate_report` | The failing task's quality gate findings. |
+| `journal_tail` | The tail of the run's Merkle event journal, filtered to the failing task and stripped of wall-clock envelope. |
+
+The canonical, sorted-key serialization is content-addressed. Recording it on
+the run's lineage spine returns a Merkle-chained, HMAC-tagged entry hash, which
+is stamped on the recovery task (`metadata.recovery_receipt_hash`) and injected
+into the recovery agent's prompt. The recovery agent continues from the
+captured failure instead of rediscovering it.
+
+Because the receipt bytes are the spine entry's content, the anchored entry
+binds cryptographically to the exact failure summary. Verify that a recovery
+task's receipt resolves to a valid spine entry:
+
+```bash
+# Resolve the embedded receipt hash against the run's spine.
+bernstein lineage verify <run_id> --receipt-hash sha256:<entry-hash>
+
+# Also content-address the receipt artefact against the anchored entry.
+bernstein lineage verify <run_id> \
+  --receipt-hash sha256:<entry-hash> \
+  --receipt-file .sdd/lineage/receipts/<content-hash>.json
+```
+
+Exit codes: `0` the receipt resolves on an intact chain (and, with
+`--receipt-file`, its content matches the anchored entry); `2` it does not.
+
+Guarantees:
+
+- **Determinism.** Two runs over identical fixtures produce a byte-identical
+  receipt content hash and an identical spine entry hash.
+- **Tamper evidence.** Mutating any receipt field changes the content hash, so
+  it no longer matches the anchored entry; rewriting the spine row to cover it
+  up breaks the HMAC chain, which needs a key an editor does not have.
+- **Isolation.** The receipt's `artifact_path` stays repo-relative
+  (`.sdd/lineage/receipts/<content-hash>.json`).
+
+See [on_fail recovery receipts (workflow DSL)](workflows/on-fail-recovery-receipts.md)
+for the DAG authoring side.
+
 ## Key rotation
 
 Each lineage entry signs the key id (`agent_card_kid`) it was produced under, and the gate verifies the signature against the Agent Card for that exact `(agent_id, kid)` pair - not against whatever card currently sits at the agent id. This keeps historical entries verifiable after an agent rotates its key.

--- a/docs/workflows/on-fail-recovery-receipts.md
+++ b/docs/workflows/on-fail-recovery-receipts.md
@@ -1,0 +1,80 @@
+# on_fail recovery receipts
+
+**When an upstream node fails and my DAG routes to a recovery node, what does
+the recovery agent start from?**
+
+The workflow DSL lets a recovery node depend on an upstream node under a guard:
+
+```yaml
+nodes:
+  run-tests:
+    phase: verify
+    role: qa
+    depends_on: [build]
+
+  fix-bugs:
+    phase: implement
+    role: backend
+    depends_on:
+      - source: run-tests
+        condition: "status == 'failed'"
+    retry:
+      max_attempts: 3
+      until: "status == 'done'"
+```
+
+When `run-tests` fails, `DAGExecutor` routes control to `fix-bugs`. The recovery
+task it creates carries a **lineage-attested failure receipt** built from the
+failure the run already captured, so the recovery agent continues from it
+instead of re-deriving the diagnosis.
+
+---
+
+## What the receipt contains
+
+| Field | Meaning |
+|---|---|
+| `failing_node_id` | The upstream node that failed (`run-tests`). |
+| `recovery_node_id` | The recovery node (`fix-bugs`). |
+| `source_status` | The failing task's terminal status. |
+| `condition_context` | The guard evaluation context (`status` / `result` / `output`). |
+| `gate_report` | The failing task's quality gate findings. |
+| `journal_tail` | The tail of the run journal, filtered to the failing task, wall-clock stripped. |
+
+The recovery task's prompt is prepended with a markdown preamble rendered from
+the receipt (the same `orchestrator._context_recovery` channel that
+context-degradation eviction uses), so the failing status, gate findings, and
+journal tail reach the recovery agent directly.
+
+## How it is anchored
+
+The receipt is serialized canonically (sorted keys, minimal separators) and
+recorded on the run's lineage spine. The spine returns a Merkle-chained,
+HMAC-tagged entry hash, stamped on the recovery task metadata:
+
+| Metadata key | Value |
+|---|---|
+| `recovery_receipt_hash` | The spine entry hash (present only when a spine is supplied). |
+| `recovery_receipt_content_hash` | The receipt's content hash. |
+| `recovery_failing_node` | The failing node id. |
+
+Because the receipt bytes are the recorded content, the anchored entry binds to
+the exact failure summary. A reviewer can prove offline which upstream failure a
+recovery task was spawned to fix:
+
+```bash
+bernstein lineage verify <run_id> --receipt-hash sha256:<entry-hash>
+```
+
+See [Lineage - on_fail recovery receipts](../lineage.md#on_fail-recovery-receipts)
+for verification detail and guarantees.
+
+## Behaviour notes
+
+- **No source, no receipt.** `create_task(node_id)` without a failing source
+  task is byte-identical to a plain node instantiation - root and unconditional
+  nodes are unchanged.
+- **Guard routing is unchanged.** The receipt rides alongside the existing edge
+  resolution; it does not alter which nodes become ready.
+- **Determinism.** Two runs over identical fixtures produce a byte-identical
+  receipt content hash and an identical spine entry hash.

--- a/src/bernstein/cli/commands/lineage_verify_cmd.py
+++ b/src/bernstein/cli/commands/lineage_verify_cmd.py
@@ -53,13 +53,39 @@ def _spine_dir(workdir: str) -> Path:
     default=None,
     help="Customer Ed25519 public key (legacy chain only; re-verifies every customer_signature).",
 )
-def lineage_verify_cmd(run_id: str, workdir: str, public_key_path: str | None) -> None:
+@click.option(
+    "--receipt-hash",
+    "receipt_hash",
+    default=None,
+    help="Recovery receipt spine entry hash to resolve against the run's spine (issue #2557).",
+)
+@click.option(
+    "--receipt-file",
+    "receipt_file",
+    type=click.Path(dir_okay=False, exists=True),
+    default=None,
+    help="Recovery receipt artifact JSON; content-addresses it against the anchored entry.",
+)
+def lineage_verify_cmd(
+    run_id: str,
+    workdir: str,
+    public_key_path: str | None,
+    receipt_hash: str | None,
+    receipt_file: str | None,
+) -> None:
     """Verify the lineage spine for *run_id*.
+
+    With ``--receipt-hash`` (optionally ``--receipt-file``) it instead confirms
+    a recovery task's embedded failure-receipt hash resolves to a valid,
+    Merkle-chained, HMAC-tagged spine entry.
 
     Exit codes: 0 = OK, 1 = no entries / bad input, 2 = tamper detected.
     """
     lineage_root = _spine_dir(workdir)
     spine_path = lineage_root / run_id / "spine.jsonl"
+
+    if receipt_hash is not None:
+        _verify_receipt(run_id, lineage_root, spine_path, receipt_hash, receipt_file)
 
     if spine_path.exists():
         spine = LineageSpine(lineage_root, run_id=run_id, hmac_key=_load_hmac_key())
@@ -85,6 +111,40 @@ def lineage_verify_cmd(run_id: str, workdir: str, public_key_path: str | None) -
         raise SystemExit(1)
 
     _verify_legacy(run_id, workdir, public_key_path, lineage_root)
+
+
+def _verify_receipt(
+    run_id: str,
+    lineage_root: Path,
+    spine_path: Path,
+    receipt_hash: str,
+    receipt_file: str | None,
+) -> None:
+    """Resolve a recovery receipt hash against the run's spine (issue #2557).
+
+    Exit codes: 0 = receipt resolves on an intact chain, 2 = it does not.
+    """
+    from bernstein.core.planning.recovery_receipt import resolve_receipt_on_spine
+
+    if not spine_path.exists():
+        console.print()
+        console.print(f"[red]No spine for run[/red] {run_id} -- cannot resolve receipt {receipt_hash}.")
+        raise SystemExit(2)
+
+    spine = LineageSpine(lineage_root, run_id=run_id, hmac_key=_load_hmac_key())
+    content = Path(receipt_file).read_bytes() if receipt_file is not None else None
+    resolution = resolve_receipt_on_spine(spine, entry_hash=receipt_hash, receipt_content=content)
+
+    console.print()
+    console.print(f"[bold]Recovery receipt[/bold] run={run_id} entry={receipt_hash[:16]}")
+    if resolution.ok:
+        detail = "content matches anchored entry" if content is not None else "chain-anchored"
+        console.print(f"[green]OK[/green] -- receipt resolves to a valid spine entry ({detail}).")
+        raise SystemExit(0)
+    console.print(f"[red]RECEIPT VERIFICATION FAILED[/red] -- {len(resolution.errors)} error(s):")
+    for err in resolution.errors[:50]:
+        console.print(f"  - {err}")
+    raise SystemExit(2)
 
 
 def _verify_legacy(run_id: str, workdir: str, public_key_path: str | None, lineage_root: Path) -> None:

--- a/src/bernstein/core/planning/recovery_receipt.py
+++ b/src/bernstein/core/planning/recovery_receipt.py
@@ -1,0 +1,466 @@
+"""RecoveryReceipt - lineage-attested failure receipts for on_fail recovery.
+
+Issue #2557. The workflow DSL (:mod:`bernstein.core.planning.workflow_dsl`)
+routes control back to a recovery node when an upstream node fails under a
+guard, but ``DAGExecutor.create_task`` historically built the recovery Task
+from the node's static description alone. The failing upstream Task never
+reached the recovery agent, so it started blind and re-derived the failure
+from scratch.
+
+This module makes the recovery task's primary artifact a content-addressed,
+spine-anchored failure receipt. The receipt captures the failure the run
+already observed - the failing node's terminal status, its condition context,
+the tail of the run's Merkle event journal filtered to that task, and its
+quality gate report - in a canonical, sorted-key serialization.
+
+Substrate coupling (the artifact IS the proof):
+
+* **Content addressing.** :meth:`RecoveryReceipt.content_hash` is a pure
+  function of the receipt payload. Two runs over identical fixtures produce a
+  byte-identical receipt and therefore a byte-identical content hash.
+* **Lineage anchoring.** :func:`record_receipt_on_spine` records the canonical
+  bytes on the run's :class:`~bernstein.core.lineage.spine.LineageSpine`,
+  which returns a Merkle-chained, HMAC-tagged entry hash. That entry hash is
+  the recovery task's provenance identity.
+* **Tamper evidence.** :func:`resolve_receipt_on_spine` recomputes the content
+  hash from the receipt bytes and checks it against the anchored entry, then
+  re-verifies the whole spine chain. Mutating any receipt field breaks the
+  content-hash match; forging the spine's stored content hash to cover it up
+  breaks the HMAC chain, which has no key an editor can reproduce.
+
+Strip the spine and the feature collapses to a bare re-spawn: the recovery
+task can no longer prove which failure it recovers, and the content-addressed
+handoff disappears. The receipt is not a log line bolted onto a re-spawn; it
+is the re-spawn's reason, in verifiable form.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from bernstein.core.lineage.spine import LineageSpine
+    from bernstein.core.quality.quality_gates import QualityGatesResult
+
+#: Version stamped into every receipt payload. Bump only on a wire-format
+#: change so a verifier can reject unknown receipt shapes.
+RECOVERY_RECEIPT_VERSION = 1
+
+#: Repo-relative directory the content-addressed receipt artifacts live under.
+#: Kept repo-relative and POSIX so ``LineageSpine._reject_unsafe_artifact_path``
+#: accepts it.
+RECEIPT_ARTIFACT_DIR = ".sdd/lineage/receipts"
+
+#: Journal envelope fields that vary across runs even when execution is
+#: identical (wall-clock plus derived chain fields). Excluded from the receipt
+#: so timing never leaks into the content hash, mirroring the journal's own
+#: ``_NON_DETERMINISTIC_FIELDS`` policy (issue #2293).
+_NON_DETERMINISTIC_JOURNAL_FIELDS = frozenset({"ts", "elapsed_s", "index", "prev_hash", "payload_hash", "event_hash"})
+
+#: Default number of trailing journal events retained in a receipt.
+DEFAULT_JOURNAL_TAIL = 20
+
+
+def _canonical_bytes(payload: dict[str, Any]) -> bytes:
+    """Return canonical JSON bytes (sorted keys, minimal separators, UTF-8)."""
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+        default=str,
+    ).encode("utf-8")
+
+
+def _project_journal_event(event: dict[str, Any]) -> dict[str, Any]:
+    """Drop non-deterministic envelope fields from a journal event."""
+    return {k: v for k, v in event.items() if k not in _NON_DETERMINISTIC_JOURNAL_FIELDS}
+
+
+def journal_tail_for_task(
+    events: Iterable[dict[str, Any]],
+    *,
+    task_id: str,
+    limit: int = DEFAULT_JOURNAL_TAIL,
+) -> tuple[dict[str, Any], ...]:
+    """Return the bounded, timing-stripped journal tail for one task.
+
+    Filters ``events`` to those whose ``task_id`` matches, keeps only the last
+    ``limit`` in append order, and strips the wall-clock envelope so the slice
+    is a deterministic projection of the failing task's decision trail.
+
+    Args:
+        events: Journal events in append order (e.g. from ``load_events``).
+        task_id: The failing task id to filter on.
+        limit: Maximum number of trailing events to retain (non-positive
+            means keep none).
+
+    Returns:
+        A tuple of projected events, oldest first.
+    """
+    if limit <= 0:
+        return ()
+    matched = [_project_journal_event(e) for e in events if e.get("task_id") == task_id]
+    return tuple(matched[-limit:])
+
+
+def gate_report_findings(report: QualityGatesResult | None) -> tuple[dict[str, Any], ...]:
+    """Return a deterministic, ordered projection of a gate report.
+
+    Each finding carries the gate name, its pass/block flags, its status, and a
+    bounded detail string. The order matches the report's run order so the
+    projection is stable across runs.
+
+    Args:
+        report: The failing task's quality gate result, or ``None``.
+
+    Returns:
+        A tuple of per-gate finding dicts (empty when ``report`` is ``None``).
+    """
+    if report is None:
+        return ()
+    findings: list[dict[str, Any]] = []
+    for check in report.gate_results:
+        findings.append(
+            {
+                "gate": check.gate,
+                "passed": bool(check.passed),
+                "blocked": bool(check.blocked),
+                "status": check.status,
+                "detail": (check.detail or "")[:2000],
+            }
+        )
+    return tuple(findings)
+
+
+@dataclass(frozen=True, slots=True)
+class RecoveryReceipt:
+    """A content-addressed, lineage-attestable failure receipt.
+
+    The receipt is the recovery task's primary artifact. Every field is a pure
+    function of the failure the run already captured, so the canonical
+    serialization is byte-identical across two runs over identical fixtures.
+
+    ``spine_entry_hash`` is set after the receipt is anchored; it is excluded
+    from :meth:`canonical_payload` (it is derived from that payload, so
+    including it would be circular) and from equality/content hashing.
+
+    Attributes:
+        failing_node_id: DAG node id of the failing upstream node.
+        recovery_node_id: DAG node id of the recovery node being instantiated.
+        source_status: Terminal status value of the failing task.
+        condition_context: The failing task's condition context
+            (``status`` / ``result`` / ``output``) as built by
+            ``build_condition_context``.
+        gate_report: Ordered per-gate findings from the failing task's quality
+            gate report.
+        journal_tail: Bounded, timing-stripped tail of the run journal filtered
+            to the failing task.
+        spine_entry_hash: Merkle-chained spine entry hash once anchored, else
+            ``None``. Not part of the content-addressed payload.
+    """
+
+    failing_node_id: str
+    recovery_node_id: str
+    source_status: str
+    condition_context: dict[str, Any]
+    gate_report: tuple[dict[str, Any], ...] = ()
+    journal_tail: tuple[dict[str, Any], ...] = ()
+    v: int = RECOVERY_RECEIPT_VERSION
+    spine_entry_hash: str | None = field(default=None, compare=False)
+
+    def canonical_payload(self) -> dict[str, Any]:
+        """Return the content-addressed payload (excludes the spine hash)."""
+        return {
+            "v": self.v,
+            "failing_node_id": self.failing_node_id,
+            "recovery_node_id": self.recovery_node_id,
+            "source_status": self.source_status,
+            "condition_context": self.condition_context,
+            "gate_report": [dict(g) for g in self.gate_report],
+            "journal_tail": [dict(e) for e in self.journal_tail],
+        }
+
+    def canonical_bytes(self) -> bytes:
+        """Return the canonical JSON bytes hashed for content addressing."""
+        return _canonical_bytes(self.canonical_payload())
+
+    def content_hash(self) -> str:
+        """Return the ``sha256:``-prefixed digest of the canonical bytes."""
+        return "sha256:" + hashlib.sha256(self.canonical_bytes()).hexdigest()
+
+    def artifact_path(self) -> str:
+        """Return the content-addressed, repo-relative receipt artifact path."""
+        digest = self.content_hash().split(":", 1)[1]
+        return f"{RECEIPT_ARTIFACT_DIR}/{digest}.json"
+
+    def with_entry_hash(self, entry_hash: str) -> RecoveryReceipt:
+        """Return a copy carrying the anchored spine entry hash."""
+        return RecoveryReceipt(
+            failing_node_id=self.failing_node_id,
+            recovery_node_id=self.recovery_node_id,
+            source_status=self.source_status,
+            condition_context=self.condition_context,
+            gate_report=self.gate_report,
+            journal_tail=self.journal_tail,
+            v=self.v,
+            spine_entry_hash=entry_hash,
+        )
+
+    def render_preamble(self) -> str:
+        """Render the markdown recovery-context preamble for the agent prompt.
+
+        Mirrors the recovery-context block ``evict_degraded_sessions`` stashes
+        on ``orchestrator._context_recovery``: a markdown section the
+        replacement agent's prompt prepends. It leads with the lineage-attested
+        failure summary and its spine entry hash so the recovery agent
+        continues from the captured failure instead of rediscovering it.
+        """
+        lines: list[str] = [
+            "## Recovery context (lineage-attested failure receipt)",
+            "",
+            f"You are the recovery task for failing node `{self.failing_node_id}` "
+            f"(recovery node `{self.recovery_node_id}`).",
+            f"The upstream task terminated with status **{self.source_status}**. "
+            "Continue from this captured failure; do not re-derive it.",
+            "",
+        ]
+        if self.spine_entry_hash:
+            lines.append(f"- Lineage spine entry: `{self.spine_entry_hash}`")
+        lines.append(f"- Receipt content hash: `{self.content_hash()}`")
+        lines.append("")
+
+        result = str(self.condition_context.get("result", "") or "")
+        if result:
+            lines.append("### Failing task result")
+            lines.append(result[:2000])
+            lines.append("")
+
+        failed = [g for g in self.gate_report if not g.get("passed")]
+        if failed:
+            lines.append("### Gate findings")
+            for g in failed:
+                marker = "blocking" if g.get("blocked") else "non-blocking"
+                detail = str(g.get("detail", "") or "").strip()
+                suffix = f": {detail}" if detail else ""
+                lines.append(f"- `{g.get('gate')}` ({marker}){suffix}")
+            lines.append("")
+
+        if self.journal_tail:
+            lines.append("### Journal tail")
+            for event in self.journal_tail:
+                lines.append(f"- `{event.get('event', '')}`")
+            lines.append("")
+
+        return "\n".join(lines).rstrip() + "\n"
+
+
+def build_receipt(
+    *,
+    failing_node_id: str,
+    recovery_node_id: str,
+    source_status: str,
+    condition_context: dict[str, Any],
+    source_task_id: str,
+    journal_events: Iterable[dict[str, Any]] | None = None,
+    gate_report: QualityGatesResult | None = None,
+    journal_tail_limit: int = DEFAULT_JOURNAL_TAIL,
+) -> RecoveryReceipt:
+    """Assemble a :class:`RecoveryReceipt` from the captured failure inputs.
+
+    Args:
+        failing_node_id: DAG node id of the failing upstream node.
+        recovery_node_id: DAG node id of the recovery node.
+        source_status: Terminal status value of the failing task.
+        condition_context: The failing task's condition context.
+        source_task_id: The failing task's instance id (used to filter the
+            journal tail).
+        journal_events: Optional run journal events in append order.
+        gate_report: Optional quality gate report for the failing task.
+        journal_tail_limit: Maximum number of trailing journal events to keep.
+
+    Returns:
+        An unanchored :class:`RecoveryReceipt` (``spine_entry_hash`` is
+        ``None``).
+    """
+    tail = (
+        journal_tail_for_task(journal_events, task_id=source_task_id, limit=journal_tail_limit)
+        if journal_events is not None
+        else ()
+    )
+    return RecoveryReceipt(
+        failing_node_id=failing_node_id,
+        recovery_node_id=recovery_node_id,
+        source_status=source_status,
+        condition_context=dict(condition_context),
+        gate_report=gate_report_findings(gate_report),
+        journal_tail=tail,
+    )
+
+
+def record_receipt_on_spine(
+    receipt: RecoveryReceipt,
+    *,
+    spine: LineageSpine,
+    actor: str = "dag-executor",
+    model: str = "",
+    timestamp: int = 0,
+) -> str:
+    """Anchor a receipt on the run's lineage spine and return its entry hash.
+
+    The canonical receipt bytes are the recorded content, so the spine entry's
+    ``content_hash`` binds the anchored entry to the exact receipt payload. The
+    ``step_id`` and ``artifact_path`` are pure functions of node identity and
+    content, so two runs over identical fixtures against a fresh spine produce
+    an identical entry hash (issue #2557 AC3).
+
+    Args:
+        receipt: The receipt to anchor.
+        spine: The run's lineage spine.
+        actor: Producing actor recorded on the spine entry.
+        model: Optional model string recorded for provenance.
+        timestamp: Stable integer timestamp; defaults to ``0`` so identical
+            fixtures replay byte-identically.
+
+    Returns:
+        The Merkle-chained spine entry hash.
+    """
+    return spine.record(
+        artifact_path=receipt.artifact_path(),
+        content=receipt.canonical_bytes(),
+        actor=actor,
+        step_id=recovery_step_id(receipt),
+        model=model,
+        timestamp=timestamp,
+    )
+
+
+def recovery_step_id(receipt: RecoveryReceipt) -> str:
+    """Return the deterministic spine ``step_id`` for a receipt.
+
+    Derived from node identity rather than the recovery task's instance id
+    (which carries a per-run uuid), so the spine entry hash is a stable
+    function of the failure being recovered.
+    """
+    return f"recovery-receipt:{receipt.failing_node_id}->{receipt.recovery_node_id}"
+
+
+@dataclass(frozen=True, slots=True)
+class ReceiptResolution:
+    """Outcome of resolving a recovery receipt hash against a spine.
+
+    Attributes:
+        resolved: The entry hash was found on the spine.
+        chain_ok: The whole spine chain re-verified cleanly.
+        content_match: ``True`` / ``False`` when receipt content was supplied
+            and compared against the anchored entry, else ``None``.
+        errors: Human-readable failure explanations.
+    """
+
+    resolved: bool
+    chain_ok: bool
+    content_match: bool | None = None
+    errors: list[str] = field(default_factory=list[str])
+
+    @property
+    def ok(self) -> bool:
+        """True only when the entry resolves, the chain is intact, and (when
+        checked) the receipt content matches the anchored entry."""
+        return self.resolved and self.chain_ok and self.content_match is not False
+
+
+def resolve_receipt_on_spine(
+    spine: LineageSpine,
+    *,
+    entry_hash: str,
+    receipt_content: bytes | None = None,
+) -> ReceiptResolution:
+    """Confirm a recovery receipt hash resolves to a valid spine entry.
+
+    Walks the spine for ``entry_hash``, re-verifies the whole Merkle+HMAC
+    chain, and - when ``receipt_content`` is supplied - checks the content
+    address binds the anchored entry to the exact receipt bytes.
+
+    Args:
+        spine: The run's lineage spine.
+        entry_hash: The spine entry hash embedded in the recovery task.
+        receipt_content: Optional receipt bytes to content-address against the
+            anchored entry's ``content_hash``.
+
+    Returns:
+        A :class:`ReceiptResolution`.
+    """
+    from bernstein.core.lineage.spine import content_hash_of
+
+    errors: list[str] = []
+
+    verify = spine.verify()
+    chain_ok = verify.ok
+    if not chain_ok:
+        errors.extend(verify.errors or ["spine chain verification failed"])
+
+    matched = next((e for e in spine.iter_entries() if e.entry_hash == entry_hash), None)
+    resolved = matched is not None
+    if not resolved:
+        errors.append(f"receipt entry hash not found on spine: {entry_hash}")
+
+    content_match: bool | None = None
+    if receipt_content is not None and matched is not None:
+        recomputed = content_hash_of(receipt_content)
+        content_match = recomputed == matched.content_hash
+        if not content_match:
+            errors.append(f"receipt content hash mismatch: computed {recomputed} != anchored {matched.content_hash}")
+
+    return ReceiptResolution(
+        resolved=resolved,
+        chain_ok=chain_ok,
+        content_match=content_match,
+        errors=errors,
+    )
+
+
+def verify_receipt(spine: LineageSpine, receipt: RecoveryReceipt) -> ReceiptResolution:
+    """Resolve an anchored receipt against its spine using its own bytes.
+
+    Convenience wrapper: uses ``receipt.spine_entry_hash`` and
+    ``receipt.canonical_bytes()`` so a holder of the receipt object can verify
+    it end to end in one call.
+
+    Raises:
+        ValueError: The receipt has no anchored spine entry hash.
+    """
+    if not receipt.spine_entry_hash:
+        raise ValueError("receipt has no spine_entry_hash; anchor it first")
+    return resolve_receipt_on_spine(
+        spine,
+        entry_hash=receipt.spine_entry_hash,
+        receipt_content=receipt.canonical_bytes(),
+    )
+
+
+__all__ = [
+    "DEFAULT_JOURNAL_TAIL",
+    "RECEIPT_ARTIFACT_DIR",
+    "RECOVERY_RECEIPT_VERSION",
+    "ReceiptResolution",
+    "RecoveryReceipt",
+    "build_receipt",
+    "gate_report_findings",
+    "journal_tail_for_task",
+    "record_receipt_on_spine",
+    "recovery_step_id",
+    "resolve_receipt_on_spine",
+    "verify_receipt",
+]
+
+# Metadata keys the DAG executor stamps on a recovery Task so downstream
+# consumers (prompt injection, the lineage verify CLI) can recover the anchor
+# without re-reading the spine.
+RECEIPT_HASH_METADATA_KEY = "recovery_receipt_hash"
+RECEIPT_CONTENT_HASH_METADATA_KEY = "recovery_receipt_content_hash"
+RECEIPT_FAILING_NODE_METADATA_KEY = "recovery_failing_node"

--- a/src/bernstein/core/planning/workflow_dsl.py
+++ b/src/bernstein/core/planning/workflow_dsl.py
@@ -80,10 +80,15 @@ import yaml
 
 from bernstein.core.knowledge.task_graph import EdgeType
 from bernstein.core.models import Scope, Task, TaskStatus
+from bernstein.core.planning.recovery_receipt import DEFAULT_JOURNAL_TAIL
 from bernstein.core.planning.workflow import WorkflowDefinition, WorkflowPhase
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from bernstein.core.lineage.spine import LineageSpine
+    from bernstein.core.quality.quality_gates import QualityGatesResult
+    from bernstein.core.replay.journal import EventJournal
 
 logger = logging.getLogger(__name__)
 
@@ -967,11 +972,53 @@ class DAGExecutor:
         """Increment the retry counter for a node."""
         self._retry_counts[node_id] = self._retry_counts.get(node_id, 0) + 1
 
-    def create_task(self, node_id: str) -> Task:
+    def create_task(
+        self,
+        node_id: str,
+        *,
+        source_task: Task | None = None,
+        source_edge: DAGEdge | None = None,
+        spine: LineageSpine | None = None,
+        journal: EventJournal | None = None,
+        gate_report: QualityGatesResult | None = None,
+        recovery_store: dict[str, str] | None = None,
+        actor: str = "dag-executor",
+        model: str = "",
+        timestamp: int = 0,
+        journal_tail_limit: int = DEFAULT_JOURNAL_TAIL,
+    ) -> Task:
         """Create a Task from a DAG node template.
+
+        When ``source_task`` is supplied (an ``on_fail`` recovery hop), the
+        created Task carries a lineage-attested failure receipt built from the
+        failing task's condition context, the tail of the run journal filtered
+        to that task, and its quality gate report. The receipt is the recovery
+        task's primary artifact: it is anchored on the run's lineage spine (when
+        ``spine`` is given) and injected into the recovery agent's prompt
+        through ``recovery_store`` (the same channel ``evict_degraded_sessions``
+        populates). When ``source_task`` is ``None`` the output is byte-identical
+        to a bare node instantiation - root and unconditional nodes are
+        unchanged.
 
         Args:
             node_id: The DAG node ID to instantiate.
+            source_task: The failing upstream Task, when this is a recovery hop.
+            source_edge: The resolved failing edge; its ``source`` names the
+                failing node. Falls back to ``source_task.id`` when omitted.
+            spine: The run's lineage spine; when given, the receipt is anchored
+                and its entry hash is stamped on the Task metadata.
+            journal: The run's event journal; its tail (filtered to the failing
+                task) is folded into the receipt.
+            gate_report: The failing task's quality gate report.
+            recovery_store: The ``orchestrator._context_recovery`` channel; when
+                given, the rendered receipt preamble is stored keyed by the new
+                Task id.
+            actor: Actor recorded on the spine entry.
+            model: Model string recorded on the spine entry.
+            timestamp: Stable integer timestamp for the spine entry (default 0
+                so identical fixtures replay byte-identically).
+            journal_tail_limit: Maximum number of trailing journal events kept
+                in the receipt.
 
         Returns:
             A new Task ready for scheduling.
@@ -989,7 +1036,7 @@ class DAGExecutor:
             if edge.condition is None and edge.edge_type in {EdgeType.BLOCKS, EdgeType.VALIDATES}
         ]
 
-        return Task(
+        task = Task(
             id=task_id,
             title=node.description or f"DAG node: {node.id}",
             description=node.description,
@@ -1001,6 +1048,84 @@ class DAGExecutor:
             depends_on=dep_ids,
             created_at=time.time(),
         )
+
+        if source_task is None:
+            # Byte-identical to the historical behaviour: no receipt, no
+            # metadata mutation (metadata stays its default empty dict).
+            return task
+
+        self._attach_recovery_receipt(
+            task,
+            node=node,
+            source_task=source_task,
+            source_edge=source_edge,
+            spine=spine,
+            journal=journal,
+            gate_report=gate_report,
+            recovery_store=recovery_store,
+            actor=actor,
+            model=model,
+            timestamp=timestamp,
+            journal_tail_limit=journal_tail_limit,
+        )
+        return task
+
+    def _attach_recovery_receipt(
+        self,
+        task: Task,
+        *,
+        node: DAGNode,
+        source_task: Task,
+        source_edge: DAGEdge | None,
+        spine: LineageSpine | None,
+        journal: EventJournal | None,
+        gate_report: QualityGatesResult | None,
+        recovery_store: dict[str, str] | None,
+        actor: str,
+        model: str,
+        timestamp: int,
+        journal_tail_limit: int,
+    ) -> None:
+        """Build, anchor, and inject a failure receipt for a recovery Task."""
+        from bernstein.core.planning.recovery_receipt import (
+            RECEIPT_CONTENT_HASH_METADATA_KEY,
+            RECEIPT_FAILING_NODE_METADATA_KEY,
+            RECEIPT_HASH_METADATA_KEY,
+            build_receipt,
+            record_receipt_on_spine,
+        )
+        from bernstein.core.replay.journal import load_events
+
+        failing_node_id = source_edge.source if source_edge is not None else source_task.id
+        journal_events = load_events(journal.path) if journal is not None else None
+
+        receipt = build_receipt(
+            failing_node_id=failing_node_id,
+            recovery_node_id=node.id,
+            source_status=source_task.status.value,
+            condition_context=build_condition_context(source_task),
+            source_task_id=source_task.id,
+            journal_events=journal_events,
+            gate_report=gate_report,
+            journal_tail_limit=journal_tail_limit,
+        )
+
+        task.metadata[RECEIPT_CONTENT_HASH_METADATA_KEY] = receipt.content_hash()
+        task.metadata[RECEIPT_FAILING_NODE_METADATA_KEY] = failing_node_id
+
+        if spine is not None:
+            entry_hash = record_receipt_on_spine(
+                receipt,
+                spine=spine,
+                actor=actor,
+                model=model,
+                timestamp=timestamp,
+            )
+            receipt = receipt.with_entry_hash(entry_hash)
+            task.metadata[RECEIPT_HASH_METADATA_KEY] = entry_hash
+
+        if recovery_store is not None:
+            recovery_store[task.id] = receipt.render_preamble()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/lineage/test_spine_cli.py
+++ b/tests/unit/lineage/test_spine_cli.py
@@ -102,3 +102,98 @@ def test_replay_empty_run(tmp_path: Path, monkeypatch) -> None:
     result = _run(["replay", "empty", "--workdir", str(tmp_path)])
     assert result.exit_code != 0
     assert "no entries" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# Recovery receipt resolution (issue #2557)
+# ---------------------------------------------------------------------------
+
+
+def _seed_receipt(workdir: Path, run_id: str) -> tuple[str, bytes]:
+    """Anchor one recovery receipt and return (entry_hash, receipt_bytes)."""
+    from bernstein.core.planning.recovery_receipt import RecoveryReceipt, record_receipt_on_spine
+
+    root = workdir / ".sdd" / "lineage"
+    spine = LineageSpine(root, run_id=run_id, hmac_key=_KEY)
+    receipt = RecoveryReceipt(
+        failing_node_id="run-tests",
+        recovery_node_id="fix-bugs",
+        source_status="failed",
+        condition_context={"status": "failed", "result": "3 failing", "output": {}},
+    )
+    entry_hash = record_receipt_on_spine(receipt, spine=spine, timestamp=0)
+    return entry_hash, receipt.canonical_bytes()
+
+
+def test_verify_receipt_hash_resolves(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(tmp_path / "audit.key"))
+    key_file = tmp_path / "audit.key"
+    key_file.write_bytes(_KEY)
+    key_file.chmod(0o600)
+    entry_hash, _ = _seed_receipt(tmp_path, "run-1")
+
+    result = _run(["verify", "run-1", "--workdir", str(tmp_path), "--receipt-hash", entry_hash])
+    assert result.exit_code == 0, result.output
+    assert "receipt resolves" in result.output.lower()
+
+
+def test_verify_receipt_content_match(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(tmp_path / "audit.key"))
+    key_file = tmp_path / "audit.key"
+    key_file.write_bytes(_KEY)
+    key_file.chmod(0o600)
+    entry_hash, receipt_bytes = _seed_receipt(tmp_path, "run-1")
+    receipt_path = tmp_path / "receipt.json"
+    receipt_path.write_bytes(receipt_bytes)
+
+    result = _run(
+        [
+            "verify",
+            "run-1",
+            "--workdir",
+            str(tmp_path),
+            "--receipt-hash",
+            entry_hash,
+            "--receipt-file",
+            str(receipt_path),
+        ]
+    )
+    assert result.exit_code == 0, result.output
+    assert "content matches" in result.output.lower()
+
+
+def test_verify_receipt_tampered_content_fails(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(tmp_path / "audit.key"))
+    key_file = tmp_path / "audit.key"
+    key_file.write_bytes(_KEY)
+    key_file.chmod(0o600)
+    entry_hash, _ = _seed_receipt(tmp_path, "run-1")
+    forged = tmp_path / "forged.json"
+    forged.write_bytes(b'{"tampered": true}')
+
+    result = _run(
+        [
+            "verify",
+            "run-1",
+            "--workdir",
+            str(tmp_path),
+            "--receipt-hash",
+            entry_hash,
+            "--receipt-file",
+            str(forged),
+        ]
+    )
+    assert result.exit_code == 2
+    assert "receipt verification failed" in result.output.lower()
+
+
+def test_verify_receipt_missing_hash_fails(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(tmp_path / "audit.key"))
+    key_file = tmp_path / "audit.key"
+    key_file.write_bytes(_KEY)
+    key_file.chmod(0o600)
+    _seed_receipt(tmp_path, "run-1")
+
+    result = _run(["verify", "run-1", "--workdir", str(tmp_path), "--receipt-hash", "sha256:deadbeef"])
+    assert result.exit_code == 2
+    assert "failed" in result.output.lower()

--- a/tests/unit/test_recovery_receipt.py
+++ b/tests/unit/test_recovery_receipt.py
@@ -1,0 +1,302 @@
+"""Tests for lineage-attested on_fail recovery receipts (issue #2557).
+
+These tests pin the issue's acceptance criteria for the failure-receipt
+handoff:
+
+* Correctness - the recovery task's prompt carries the failing status, gate
+  findings, and journal tail (not merely routed control).
+* Verifiability - the receipt is anchored on the run's ``LineageSpine`` and the
+  returned entry hash resolves to a valid Merkle-chained, HMAC-tagged entry.
+* Determinism - two runs over identical fixtures produce a byte-identical
+  receipt content hash and an identical spine entry hash.
+* Tamper evidence - mutating any receipt field breaks the content-address bind
+  to the spine, and forging the spine row to cover it up breaks the HMAC chain.
+* Isolation - the receipt's ``artifact_path`` stays repo-relative and is
+  accepted by ``_reject_unsafe_artifact_path``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+from bernstein.core.models import Task, TaskStatus
+
+from bernstein.core.lineage.spine import (
+    LineageSpine,
+    SpineStatus,
+    _reject_unsafe_artifact_path,
+    content_hash_of,
+)
+from bernstein.core.planning.recovery_receipt import (
+    RECOVERY_RECEIPT_VERSION,
+    RecoveryReceipt,
+    build_receipt,
+    gate_report_findings,
+    journal_tail_for_task,
+    record_receipt_on_spine,
+    recovery_step_id,
+    resolve_receipt_on_spine,
+    verify_receipt,
+)
+from bernstein.core.quality.quality_gates import QualityGateCheckResult, QualityGatesResult
+from bernstein.core.replay.journal import EventJournal
+
+_KEY = b"k" * 32
+
+
+# ---------------------------------------------------------------------------
+# Fixtures - deterministic failure inputs
+# ---------------------------------------------------------------------------
+
+
+def _failing_task(task_id: str = "run-tests-fixed") -> Task:
+    return Task(
+        id=task_id,
+        title="run tests",
+        description="run the test suite",
+        role="qa",
+        status=TaskStatus.FAILED,
+        result_summary='{"status": "failed", "failed": 3, "suite": "unit"}',
+    )
+
+
+def _gate_report(task_id: str = "run-tests-fixed") -> QualityGatesResult:
+    return QualityGatesResult(
+        task_id=task_id,
+        passed=False,
+        gate_results=[
+            QualityGateCheckResult(gate="lint", passed=True, blocked=False, detail="clean", status="pass"),
+            QualityGateCheckResult(
+                gate="tests", passed=False, blocked=True, detail="3 failing in test_math", status="fail"
+            ),
+        ],
+    )
+
+
+def _journal(tmp_path: Path, run_id: str, task_id: str = "run-tests-fixed") -> EventJournal:
+    journal = EventJournal(run_id=run_id, sdd_dir=tmp_path / ".sdd")
+    journal.record("task_claimed", task_id=task_id, agent_id="A-1")
+    journal.record("gate_failed", task_id=task_id, gate="tests")
+    journal.record("task_failed", task_id=task_id, reason="tests")
+    journal.record("unrelated", task_id="other-task", note="noise")
+    return journal
+
+
+def _make_spine(tmp_path: Path, run_id: str = "run-1") -> LineageSpine:
+    return LineageSpine(tmp_path / ".sdd" / "lineage", run_id=run_id, hmac_key=_KEY)
+
+
+def _build_fixture_receipt(tmp_path: Path, run_id: str = "run-1") -> RecoveryReceipt:
+    task = _failing_task()
+    journal = _journal(tmp_path, run_id)
+    from bernstein.core.replay.journal import load_events
+
+    return build_receipt(
+        failing_node_id="run-tests",
+        recovery_node_id="fix-bugs",
+        source_status=task.status.value,
+        condition_context={
+            "status": task.status.value,
+            "result": task.result_summary or "",
+            "output": {"status": "failed", "failed": 3, "suite": "unit"},
+        },
+        source_task_id=task.id,
+        journal_events=load_events(journal.path),
+        gate_report=_gate_report(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Journal tail projection
+# ---------------------------------------------------------------------------
+
+
+class TestJournalTail:
+    def test_filters_to_task_and_strips_envelope(self, tmp_path: Path) -> None:
+        from bernstein.core.replay.journal import load_events
+
+        journal = _journal(tmp_path, "run-jt")
+        tail = journal_tail_for_task(load_events(journal.path), task_id="run-tests-fixed", limit=10)
+
+        assert [e["event"] for e in tail] == ["task_claimed", "gate_failed", "task_failed"]
+        # Envelope + derived chain fields are excluded so timing never leaks.
+        for event in tail:
+            assert "ts" not in event
+            assert "elapsed_s" not in event
+            assert "event_hash" not in event
+            assert "prev_hash" not in event
+
+    def test_bounded_tail(self, tmp_path: Path) -> None:
+        from bernstein.core.replay.journal import load_events
+
+        journal = _journal(tmp_path, "run-jt2")
+        tail = journal_tail_for_task(load_events(journal.path), task_id="run-tests-fixed", limit=1)
+        assert len(tail) == 1
+        assert tail[0]["event"] == "task_failed"
+
+    def test_zero_limit_yields_nothing(self, tmp_path: Path) -> None:
+        from bernstein.core.replay.journal import load_events
+
+        journal = _journal(tmp_path, "run-jt3")
+        assert journal_tail_for_task(load_events(journal.path), task_id="run-tests-fixed", limit=0) == ()
+
+
+class TestGateFindings:
+    def test_projects_each_gate(self) -> None:
+        findings = gate_report_findings(_gate_report())
+        assert [f["gate"] for f in findings] == ["lint", "tests"]
+        assert findings[1] == {
+            "gate": "tests",
+            "passed": False,
+            "blocked": True,
+            "status": "fail",
+            "detail": "3 failing in test_math",
+        }
+
+    def test_none_report(self) -> None:
+        assert gate_report_findings(None) == ()
+
+
+# ---------------------------------------------------------------------------
+# Content addressing + determinism (AC3)
+# ---------------------------------------------------------------------------
+
+
+class TestDeterminism:
+    def test_receipt_content_hash_byte_identical_across_runs(self, tmp_path: Path) -> None:
+        r1 = _build_fixture_receipt(tmp_path / "a", "run-1")
+        r2 = _build_fixture_receipt(tmp_path / "b", "run-1")
+        assert r1.canonical_bytes() == r2.canonical_bytes()
+        assert r1.content_hash() == r2.content_hash()
+
+    def test_spine_entry_hash_identical_across_runs(self, tmp_path: Path) -> None:
+        r1 = _build_fixture_receipt(tmp_path / "a", "run-1")
+        r2 = _build_fixture_receipt(tmp_path / "b", "run-1")
+        spine1 = _make_spine(tmp_path / "s1")
+        spine2 = _make_spine(tmp_path / "s2")
+        h1 = record_receipt_on_spine(r1, spine=spine1, actor="dag-executor", model="claude", timestamp=0)
+        h2 = record_receipt_on_spine(r2, spine=spine2, actor="dag-executor", model="claude", timestamp=0)
+        assert h1 == h2
+
+    def test_step_id_is_node_derived_not_uuid(self, tmp_path: Path) -> None:
+        receipt = _build_fixture_receipt(tmp_path, "run-1")
+        assert recovery_step_id(receipt) == "recovery-receipt:run-tests->fix-bugs"
+
+
+# ---------------------------------------------------------------------------
+# Verifiability (AC2)
+# ---------------------------------------------------------------------------
+
+
+class TestVerifiability:
+    def test_receipt_hash_resolves_on_spine(self, tmp_path: Path) -> None:
+        receipt = _build_fixture_receipt(tmp_path, "run-1")
+        spine = _make_spine(tmp_path / "s")
+        entry_hash = record_receipt_on_spine(receipt, spine=spine, timestamp=0)
+        anchored = receipt.with_entry_hash(entry_hash)
+
+        resolution = verify_receipt(spine, anchored)
+        assert resolution.ok
+        assert resolution.resolved
+        assert resolution.chain_ok
+        assert resolution.content_match is True
+
+    def test_resolution_reports_missing_hash(self, tmp_path: Path) -> None:
+        receipt = _build_fixture_receipt(tmp_path, "run-1")
+        spine = _make_spine(tmp_path / "s")
+        record_receipt_on_spine(receipt, spine=spine, timestamp=0)
+
+        resolution = resolve_receipt_on_spine(spine, entry_hash="sha256:deadbeef")
+        assert not resolution.ok
+        assert not resolution.resolved
+        assert any("not found" in e for e in resolution.errors)
+
+
+# ---------------------------------------------------------------------------
+# Tamper evidence (AC4)
+# ---------------------------------------------------------------------------
+
+
+class TestTamperEvidence:
+    def test_mutating_a_field_breaks_content_bind(self, tmp_path: Path) -> None:
+        receipt = _build_fixture_receipt(tmp_path, "run-1")
+        spine = _make_spine(tmp_path / "s")
+        entry_hash = record_receipt_on_spine(receipt, spine=spine, timestamp=0)
+
+        # Mutate any field -> canonical bytes change -> content hash no longer
+        # matches the anchored entry's content_hash.
+        tampered = dataclasses.replace(receipt, source_status="done")
+        resolution = resolve_receipt_on_spine(spine, entry_hash=entry_hash, receipt_content=tampered.canonical_bytes())
+        assert resolution.resolved  # entry still exists
+        assert resolution.content_match is False
+        assert not resolution.ok
+
+    def test_covering_the_spine_row_breaks_hmac_chain(self, tmp_path: Path) -> None:
+        receipt = _build_fixture_receipt(tmp_path, "run-1")
+        spine = _make_spine(tmp_path / "s")
+        record_receipt_on_spine(receipt, spine=spine, timestamp=0)
+
+        # An attacker rewrites the anchored content_hash to match a mutated
+        # receipt. Without the HMAC key the row's tag no longer verifies.
+        raw = spine.spine_path.read_text(encoding="utf-8")
+        tampered = raw.replace(receipt.content_hash(), content_hash_of(b"forged"))
+        assert tampered != raw
+        spine.spine_path.write_text(tampered, encoding="utf-8")
+
+        assert spine.verify().status is SpineStatus.TAMPERED
+
+    def test_each_receipt_field_changes_the_content_hash(self, tmp_path: Path) -> None:
+        receipt = _build_fixture_receipt(tmp_path, "run-1")
+        base = receipt.content_hash()
+        mutations = [
+            {"failing_node_id": "other"},
+            {"recovery_node_id": "other"},
+            {"source_status": "done"},
+            {"condition_context": {"status": "done"}},
+            {"gate_report": ()},
+            {"journal_tail": ()},
+            {"v": RECOVERY_RECEIPT_VERSION + 1},
+        ]
+        for mutation in mutations:
+            mutated = dataclasses.replace(receipt, **mutation)
+            assert mutated.content_hash() != base, f"mutation did not change hash: {mutation}"
+
+    def test_spine_entry_hash_excluded_from_content_address(self, tmp_path: Path) -> None:
+        receipt = _build_fixture_receipt(tmp_path, "run-1")
+        anchored = receipt.with_entry_hash("sha256:whatever")
+        # The derived entry hash must not feed back into the content address.
+        assert anchored.content_hash() == receipt.content_hash()
+        assert anchored.canonical_bytes() == receipt.canonical_bytes()
+
+
+# ---------------------------------------------------------------------------
+# Isolation (AC6)
+# ---------------------------------------------------------------------------
+
+
+class TestIsolation:
+    def test_artifact_path_is_repo_relative_and_accepted(self, tmp_path: Path) -> None:
+        receipt = _build_fixture_receipt(tmp_path, "run-1")
+        path = receipt.artifact_path()
+        assert not path.startswith("/")
+        assert ".." not in path.split("/")
+        assert path.startswith(".sdd/lineage/receipts/")
+        # Does not raise.
+        _reject_unsafe_artifact_path(path)
+
+
+# ---------------------------------------------------------------------------
+# Preamble rendering (AC1 helper)
+# ---------------------------------------------------------------------------
+
+
+class TestPreamble:
+    def test_preamble_carries_status_gates_and_journal(self, tmp_path: Path) -> None:
+        receipt = _build_fixture_receipt(tmp_path, "run-1").with_entry_hash("sha256:abc123")
+        preamble = receipt.render_preamble()
+        assert "failed" in preamble
+        assert "sha256:abc123" in preamble
+        assert "tests" in preamble  # failing gate
+        assert "task_failed" in preamble  # journal tail event
+        assert receipt.content_hash() in preamble

--- a/tests/unit/test_workflow_dsl.py
+++ b/tests/unit/test_workflow_dsl.py
@@ -887,6 +887,138 @@ class TestCreateTask:
 
 
 # ===========================================================================
+# on_fail recovery receipts (issue #2557)
+# ===========================================================================
+
+
+def _recovery_dag() -> WorkflowDAG:
+    """DAG whose ``fix-bugs`` recovery node depends on failing ``run-tests``."""
+    return WorkflowDAG(
+        definition=WorkflowDefinition(
+            name="ci",
+            phases=(
+                WorkflowPhase(name="verify"),
+                WorkflowPhase(name="implement"),
+            ),
+        ),
+        nodes=(
+            DAGNode(id="run-tests", phase="verify", role="qa"),
+            DAGNode(id="fix-bugs", phase="implement", role="backend", description="Fix the failing tests"),
+        ),
+        edges=(
+            DAGEdge(
+                source="run-tests",
+                target="fix-bugs",
+                condition=ConditionExpr(raw="status == 'failed'"),
+            ),
+        ),
+    )
+
+
+class TestRecoveryReceiptCreateTask:
+    def test_source_none_is_byte_identical_to_legacy(self) -> None:
+        """AC5: ``create_task(node_id)`` without a source task is unchanged."""
+        executor = DAGExecutor(_recovery_dag())
+        plain = executor.create_task("fix-bugs")
+        explicit = executor.create_task("fix-bugs", source_task=None)
+
+        # Metadata is untouched (default empty dict) on the no-source path.
+        assert plain.metadata == {}
+        assert explicit.metadata == {}
+
+        # Every field except the per-call uuid id and wall-clock created_at.
+        import dataclasses
+
+        norm_a = dataclasses.replace(plain, id="X", created_at=0.0)
+        norm_b = dataclasses.replace(explicit, id="X", created_at=0.0)
+        assert norm_a == norm_b
+
+    def test_recovery_task_prompt_has_failure_context(self, tmp_path: Path) -> None:
+        """AC1: the recovery task's injected prompt carries status, gates, tail."""
+        from bernstein.core.lineage.spine import LineageSpine
+        from bernstein.core.quality.quality_gates import QualityGateCheckResult, QualityGatesResult
+        from bernstein.core.replay.journal import EventJournal
+
+        executor = DAGExecutor(_recovery_dag())
+        source = _task("run-tests-fixed", role="qa", status=TaskStatus.FAILED, result_summary='{"status": "failed"}')
+        edge = executor.dag.edges[0]
+        journal = EventJournal(run_id="run-1", sdd_dir=tmp_path / ".sdd")
+        journal.record("task_failed", task_id="run-tests-fixed", reason="tests")
+        gate_report = QualityGatesResult(
+            task_id="run-tests-fixed",
+            passed=False,
+            gate_results=[QualityGateCheckResult(gate="tests", passed=False, blocked=True, detail="3 failing")],
+        )
+        spine = LineageSpine(tmp_path / ".sdd" / "lineage", run_id="run-1", hmac_key=b"k" * 32)
+        recovery_store: dict[str, str] = {}
+
+        task = executor.create_task(
+            "fix-bugs",
+            source_task=source,
+            source_edge=edge,
+            spine=spine,
+            journal=journal,
+            gate_report=gate_report,
+            recovery_store=recovery_store,
+            timestamp=0,
+        )
+
+        assert task.id in recovery_store
+        preamble = recovery_store[task.id]
+        assert "failed" in preamble  # failing status
+        assert "tests" in preamble  # gate finding
+        assert "task_failed" in preamble  # journal tail
+        # The spine entry hash is stamped on metadata and injected into the prompt.
+        entry_hash = task.metadata["recovery_receipt_hash"]
+        assert entry_hash in preamble
+        assert task.metadata["recovery_failing_node"] == "run-tests"
+
+    def test_recovery_receipt_hash_resolves_on_spine(self, tmp_path: Path) -> None:
+        """AC2: the stamped entry hash resolves to a valid spine entry."""
+        from bernstein.core.lineage.spine import LineageSpine
+        from bernstein.core.planning.recovery_receipt import resolve_receipt_on_spine
+
+        executor = DAGExecutor(_recovery_dag())
+        source = _task("run-tests-fixed", role="qa", status=TaskStatus.FAILED, result_summary='{"status": "failed"}')
+        spine = LineageSpine(tmp_path / ".sdd" / "lineage", run_id="run-1", hmac_key=b"k" * 32)
+
+        task = executor.create_task(
+            "fix-bugs",
+            source_task=source,
+            source_edge=executor.dag.edges[0],
+            spine=spine,
+            timestamp=0,
+        )
+        entry_hash = task.metadata["recovery_receipt_hash"]
+        resolution = resolve_receipt_on_spine(spine, entry_hash=entry_hash)
+        assert resolution.ok
+
+    def test_receipt_built_without_spine_still_stamps_content_hash(self) -> None:
+        """No spine: the content hash is stamped, no entry hash, no crash."""
+        executor = DAGExecutor(_recovery_dag())
+        source = _task("run-tests-fixed", role="qa", status=TaskStatus.FAILED, result_summary='{"status": "failed"}')
+        recovery_store: dict[str, str] = {}
+        task = executor.create_task(
+            "fix-bugs",
+            source_task=source,
+            source_edge=executor.dag.edges[0],
+            recovery_store=recovery_store,
+        )
+        assert task.metadata["recovery_receipt_content_hash"].startswith("sha256:")
+        assert "recovery_receipt_hash" not in task.metadata
+        assert task.id in recovery_store
+
+    def test_guard_routing_unchanged(self) -> None:
+        """The receipt path does not alter edge resolution or readiness."""
+        executor = DAGExecutor(_recovery_dag())
+        failed = {"run-tests": _task("run-tests-x", status=TaskStatus.FAILED, result_summary='{"status": "failed"}')}
+        assert "fix-bugs" in executor.ready_nodes(failed)
+
+        done = {"run-tests": _task("run-tests-x", status=TaskStatus.DONE, result_summary='{"status": "done"}')}
+        assert "fix-bugs" not in executor.ready_nodes(done)
+
+
+# ===========================================================================
 # WorkflowDAG tests
 # ===========================================================================
 


### PR DESCRIPTION
## Summary

Closes #2557.

The workflow DSL routes control to a recovery node when an upstream node fails
under a guard, but `DAGExecutor.create_task` built the recovery Task from the
node's static description alone. The failing task's context never reached the
recovery agent, so it started blind and re-derived the failure the run had
already captured.

This threads a **lineage-attested failure receipt** through the on_fail path.
The recovery task's primary artifact is now a content-addressed, spine-anchored
receipt, not a bare description.

## What changed

- **New `RecoveryReceipt`** (`src/bernstein/core/planning/recovery_receipt.py`)
  capturing the failing node id, recovery node id, terminal status, condition
  context, a bounded and timing-stripped journal tail filtered to the failing
  task, and the gate report findings. Canonical sorted-key serialization gives
  a byte-stable content hash.
- **Extended `DAGExecutor.create_task`** with keyword-only `source_task`,
  `source_edge`, `spine`, `journal`, `gate_report`, `recovery_store`, and
  timing args. When a failing source task is supplied it builds the receipt,
  anchors it on the run's `LineageSpine` (returning a Merkle-chained,
  HMAC-tagged entry hash), stamps the hash on the task metadata, and injects
  the rendered preamble into the existing `_context_recovery` channel keyed by
  the recovery task id (the same plumbing context-degradation eviction uses).
  With `source_task=None` the output is byte-identical to before.
- **Extended `bernstein lineage verify`** with `--receipt-hash` and
  `--receipt-file` to confirm a recovery task's embedded receipt hash resolves
  to a valid spine entry, optionally content-addressing the receipt artifact
  against the anchored entry.
- **Docs**: on_fail receipt flow in `docs/lineage.md` plus a workflow DSL page.

## Design shape

The receipt bytes are the recorded spine content, so the anchored entry binds
cryptographically to the exact failure summary. Strip the spine and the feature
collapses to a bare re-spawn: the recovery task can no longer prove which
failure it recovers and the content-addressed handoff disappears.

## Tests

New `tests/unit/test_recovery_receipt.py` plus additions to
`tests/unit/test_workflow_dsl.py` and `tests/unit/lineage/test_spine_cli.py`:

- Two runs over identical fixtures produce a byte-identical receipt content
  hash and an identical spine entry hash (determinism / byte-identical replay).
- The stamped entry hash resolves to a valid Merkle-chained, HMAC-tagged spine
  entry (verifiability).
- Mutating any receipt field breaks the content-address bind to the spine, and
  rewriting the spine row to cover it up breaks the HMAC chain (tamper
  evidence).
- `create_task(node_id)` without a source task is byte-identical to the prior
  output (no regression on root and unconditional nodes).
- The receipt's `artifact_path` stays repo-relative and is accepted by
  `_reject_unsafe_artifact_path` (isolation).
- Guard routing and edge resolution are unchanged.

## Acceptance criteria

- [x] Recovery task prompt contains the failing status, gate findings, journal tail.
- [x] Receipt recorded on the LineageSpine; `lineage verify` resolves the entry hash.
- [x] Byte-identical receipt content hash and spine entry hash across two runs.
- [x] Mutating any receipt field fails spine verification at that entry.
- [x] `create_task(node_id)` without a source task is unchanged.
- [x] `artifact_path` stays repo-relative.
