### PR TITLE
feat(orchestration): research activity worker with offline-resolvable citation lineage

### DIFF
--- a/docs/orchestration/research-activity.md
+++ b/docs/orchestration/research-activity.md
@@ -1,0 +1,121 @@
+# Research activities: sourced reports with offline citation lineage
+
+The deterministic scheduler dispatches any agent modality behind one typed
+activity boundary. The research modality produces a **sourced report** whose every
+claim is bound to the exact bytes it was derived from, so the report stays
+checkable offline months after the run, with the network disabled.
+
+A links-in-markdown report cannot offer this: a link still resolves after a page
+is edited, moved, or rewritten, but to different bytes, and no reader can tell. A
+research report here is not prose with links; it is a citation-lineage artifact.
+
+## The citation model
+
+Every claim in a report carries at least one **citation record**:
+
+| Field | Meaning |
+| --- | --- |
+| `claim_id` | The claim the citation supports |
+| `quote` | The exact span quoted from the source page |
+| `source_ref` | Human-facing provenance (the page URL or label) |
+| `page_content_hash` | `sha256:` hash of the fetched page, stored at fetch time |
+
+The load-bearing field is `page_content_hash`. The research worker routes every
+fetch through `ResearchActivity.fetch`, which content-addresses the page bytes
+into the run content store the moment they land. The citation pins that hash, so
+the claim is only satisfiable against the exact bytes it was drawn from.
+
+The report itself is content-addressed: its canonical JSON bytes are stored in the
+content store, and that hash is anchored as the `artifact_hash` of the
+`ActivityResult` dispatched with `ActivityKind.RESEARCH`. The crossing is mirrored
+into the HMAC-chained audit log, which records only hashes, never the report body.
+
+## Boundary refusal: no uncited claims
+
+A report with an **uncited** claim never reaches the journal. The worker validates
+the assembled report before the result is built; a claim with no citation (or a
+citation with an empty quote, a malformed page hash, or a source the worker never
+fetched) is refused with `ActivityRejected` at the boundary.
+
+```python
+from bernstein.core.orchestration.research_worker import (
+    ClaimDraft,
+    ResearchBudget,
+    ResearchWorker,
+    SpanRef,
+)
+
+worker = ResearchWorker(store=store, budget=ResearchBudget(max_fetches=8))
+
+def synthesise(query, fetched):
+    # The opaque, stochastic step (a model in production). It drafts claims and
+    # the spans they quote; the worker binds each span to the fetched page hash.
+    return [
+        ClaimDraft(
+            statement="3.13 ships an optional free-threaded build",
+            spans=(SpanRef(source_ref="https://example/a", quote="free-threaded build"),),
+        ),
+    ]
+
+run = worker.run(
+    query="what changed in 3.13",
+    sources=["https://example/a", "https://example/b"],
+    fetch_fn=fetch_bytes,       # retrieves the exact page bytes
+    synthesise=synthesise,
+)
+dispatch_activity(run.result, stage_id="research-0", journal=journal, chain=chain)
+```
+
+Planning, fetching, budgeting, report assembly, and hashing are a pure function of
+the query, the plan, and the fetched bytes. Two operators with the same inputs
+assemble the byte-identical report and anchor the same `artifact_hash`. Only the
+`synthesise` step is stochastic, and the worker admits nothing it emits unless the
+quoted span resolves to a page the run actually fetched.
+
+## Cost caps
+
+`ResearchBudget` bounds how many sources a run may fetch and how much it may spend.
+The cap is a first-class refusal, checked before every fetch: the worker raises
+`ResearchBudgetExceeded` the moment a fetch would cross it, so a research task
+scheduled next to coding tasks stays inside its budget the same way a coding task
+does. Both modalities anchor into the same run journal through the one
+`dispatch_activity` path.
+
+## Offline verification
+
+`bernstein activity verify <run>` resolves every citation from the content store
+alone. For each claim, in report order, it reattaches each cited page's bytes by
+its pinned hash, re-hashes them to detect an altered source, and confirms the
+quoted span still occurs in them, emitting a per-claim verdict.
+
+```console
+$ bernstein activity verify run-42
+Activity verify run=run-42
+  OK research-0 [research] (evidence reattached, 2 citations resolved)
+    cite OK claim=c1 (1 checked)
+    cite OK claim=c2 (1 checked)
+verified -- every activity reconstructs from the journal.
+```
+
+Alter a single stored source page and verification fails, naming the claim and the
+mismatched hash:
+
+```console
+$ bernstein activity verify run-42
+Activity verify run=run-42
+  MISMATCH research-0 [research] -- claim 'c1' citation failed: cited page content hash mismatch (pinned 'sha256:...', recomputed 'sha256:...')
+    cite FAIL claim=c1 (0 checked) -- claim 'c1' citation failed: cited page content hash mismatch (...)
+    cite OK claim=c2 (1 checked)
+```
+
+Exit codes: `0` verified, `1` no run / no activity, `2` mismatch (tamper). The
+check touches only the content store, so it holds with the network disabled, and
+its output is a pure function of the report and the stored bytes: two verify runs
+over the same completed run produce byte-identical verdicts.
+
+## Why this shape
+
+The report is not "prose plus an audit log". Strip the content store and the
+report stops meaning anything, not merely stops logging: a claim's citation is an
+unresolvable hash without the bytes behind it. The artifact the operator reads is
+itself the verifiable receipt of the exact evidence each claim rests on.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -517,6 +517,7 @@ nav:
           - Orchestrator hardening: concepts/orchestrator-hardening.md
       - Orchestration internals:
           - Task DAG: orchestration/task-dag.md
+          - Research activities: orchestration/research-activity.md
           - Run actor: orchestration/run-actor.md
           - Worker coordination: orchestration/worker-coordination.md
           - Review gate: orchestration/review-gate.md

--- a/src/bernstein/cli/commands/activity_cmd.py
+++ b/src/bernstein/cli/commands/activity_cmd.py
@@ -81,6 +81,7 @@ def activity_verify_cmd(run: str, workdir: str, as_json: bool) -> None:
                     "ok": s.ok,
                     "evidence_reattached": s.evidence_reattached,
                     "signed_receipt_verified": s.signed_receipt_verified,
+                    "claim_verdicts": [cv.to_dict() for cv in s.claim_verdicts],
                     "reason": s.reason,
                 }
                 for s in result.stages
@@ -101,10 +102,16 @@ def activity_verify_cmd(run: str, workdir: str, as_json: bool) -> None:
                         notes.append("evidence reattached")
                     if stage.signed_receipt_verified:
                         notes.append("signed receipt verified")
+                    if stage.claim_verdicts:
+                        notes.append(f"{len(stage.claim_verdicts)} citations resolved")
                     extra = f" ({', '.join(notes)})" if notes else ""
                     console.print(f"  {tag} {stage.stage_id} [{stage.kind}]{extra}")
                 else:
                     console.print(f"  [red]MISMATCH[/red] {stage.stage_id} [{stage.kind}] -- {stage.reason}")
+                for claim in stage.claim_verdicts:
+                    claim_tag = "[green]cite OK[/green]" if claim.ok else "[red]cite FAIL[/red]"
+                    detail = f" -- {claim.reason}" if not claim.ok and claim.reason else ""
+                    console.print(f"    {claim_tag} claim={claim.claim_id} ({claim.citations_checked} checked){detail}")
             if result.ok:
                 console.print("[green]verified[/green] -- every activity reconstructs from the journal.")
 

--- a/src/bernstein/core/orchestration/activity_modalities.py
+++ b/src/bernstein/core/orchestration/activity_modalities.py
@@ -67,6 +67,12 @@ from bernstein.core.orchestration.activity import (
     TerminalState,
     evidence_set_hash,
 )
+from bernstein.core.orchestration.research_report import (
+    ClaimVerdict,
+    ResearchReport,
+    ResearchReportVerdict,
+    verify_research_report,
+)
 from bernstein.core.replay.journal import load_events, verify_journal
 from bernstein.core.skills.catalog.signature import sign_payload, verify_payload
 
@@ -715,6 +721,8 @@ class StageVerdict:
             content store and re-verified against their pinned hashes.
         signed_receipt_verified: Whether a data/ops signed receipt was reattached
             from the store and its plan + input/output signatures re-verified.
+        claim_verdicts: Per-claim citation verdicts for a research stage
+            (empty for other modalities), in the report's claim order.
         reason: A short human-readable explanation on failure, else empty.
     """
 
@@ -723,6 +731,7 @@ class StageVerdict:
     ok: bool
     evidence_reattached: bool
     signed_receipt_verified: bool = False
+    claim_verdicts: tuple[ClaimVerdict, ...] = ()
     reason: str = ""
 
 
@@ -841,6 +850,28 @@ def _verify_stage(row: dict[str, Any], *, store: ContentStore | None, chain_ok: 
             reason="journal Merkle chain diverges",
         )
 
+    # Research citation lineage (#2524): resolve every claim's citation against
+    # the store first, so a tampered *cited* page fails naming the claim and the
+    # mismatched hash rather than as an anonymous observation-reattach failure.
+    claim_verdicts: tuple[ClaimVerdict, ...] = ()
+    if store is not None and kind == ActivityKind.RESEARCH.value:
+        research = _verify_research_stage(row, store=store)
+        if research is not None:
+            claim_verdicts = research.claims
+            if not research.ok:
+                reason = research.reason or next(
+                    (c.reason for c in research.claims if not c.ok),
+                    "research report verification failed",
+                )
+                return StageVerdict(
+                    stage_id=stage_id,
+                    kind=kind,
+                    ok=False,
+                    evidence_reattached=False,
+                    claim_verdicts=claim_verdicts,
+                    reason=reason,
+                )
+
     reattached = False
     if store is not None:
         for obs in rebuilt:
@@ -852,6 +883,7 @@ def _verify_stage(row: dict[str, Any], *, store: ContentStore | None, chain_ok: 
                     kind=kind,
                     ok=False,
                     evidence_reattached=False,
+                    claim_verdicts=claim_verdicts,
                     reason=f"evidence bytes missing from store for {obs.ref!r}",
                 )
             recomputed_hash = "sha256:" + _sha256_hex(content)
@@ -861,6 +893,7 @@ def _verify_stage(row: dict[str, Any], *, store: ContentStore | None, chain_ok: 
                     kind=kind,
                     ok=False,
                     evidence_reattached=False,
+                    claim_verdicts=claim_verdicts,
                     reason=f"content hash mismatch reattaching {obs.ref!r}",
                 )
         reattached = bool(rebuilt)
@@ -885,6 +918,7 @@ def _verify_stage(row: dict[str, Any], *, store: ContentStore | None, chain_ok: 
         ok=True,
         evidence_reattached=reattached,
         signed_receipt_verified=receipt_verified,
+        claim_verdicts=claim_verdicts,
     )
 
 
@@ -933,3 +967,54 @@ def _verify_data_ops_stage(row: dict[str, Any], *, store: ContentStore) -> DataO
             reason=f"stored receipt is not valid JSON: {type(exc).__name__}",
         )
     return verify_data_ops_receipt(receipt, store=store)
+
+
+def _verify_research_stage(row: dict[str, Any], *, store: ContentStore) -> ResearchReportVerdict | None:
+    """Reattach and re-resolve a research report's citation lineage (#2524).
+
+    The report's canonical bytes were stored content-addressed under the stage's
+    ``artifact_hash``. This reattaches them by that hash, confirms they still hash
+    to the anchored ``artifact_hash`` (tamper of the report itself), parses the
+    report, and resolves every claim's citation offline against the store --
+    naming the claim and the mismatched hash on any altered source page. Returns
+    ``None`` when no report is stored (a legacy or non-report research row), so
+    the generic evidence check stands alone.
+    """
+    artifact_hash = str(row.get("artifact_hash", ""))
+    digest = artifact_hash.split(":", 1)[-1]
+    # Realpath-contain the store lookup: the hash comes from the journal, so only
+    # a bare sha256 hex digest may address a blob (no path separators).
+    if not _SHA256_HEX.match(digest):
+        return ResearchReportVerdict(
+            ok=False,
+            claims=(),
+            reason=f"malformed artifact_hash for research stage: {artifact_hash!r}",
+        )
+    try:
+        report_bytes = store.get(artifact_hash)
+    except KeyError:
+        return None
+    if "sha256:" + _sha256_hex(report_bytes) != artifact_hash:
+        return ResearchReportVerdict(
+            ok=False,
+            claims=(),
+            reason=f"report bytes do not match anchored artifact_hash {artifact_hash!r}",
+        )
+    try:
+        report = ResearchReport.from_dict(json.loads(report_bytes))
+    except (ValueError, TypeError) as exc:
+        return ResearchReportVerdict(
+            ok=False,
+            claims=(),
+            reason=f"stored report is not valid JSON: {type(exc).__name__}",
+        )
+    # A stored report with no claims is not a valid research artifact; surface it
+    # as one refused claim so the failure is not silently empty.
+    verdict = verify_research_report(report, store=store)
+    if not report.claims and not verdict.claims:
+        return ResearchReportVerdict(
+            ok=False,
+            claims=(ClaimVerdict(claim_id="", ok=False, citations_checked=0, reason="report holds no claims"),),
+            reason=verdict.reason or "report holds no claims",
+        )
+    return verdict

--- a/src/bernstein/core/orchestration/research_report.py
+++ b/src/bernstein/core/orchestration/research_report.py
@@ -1,0 +1,379 @@
+"""Citation-lineage report model for the research modality (issue #2524).
+
+The typed activity boundary already ships a ``RESEARCH`` modality and a
+:class:`~bernstein.core.orchestration.activity_modalities.ResearchActivity` that
+content-addresses every fetched page at fetch time, but a fetched-page store on
+its own is not a *report*. This module is the report: a research report is not
+prose with links, it is a citation-lineage artifact where every claim is bound
+to the exact bytes it was derived from.
+
+The shape is deliberate. A links-in-markdown report degrades the moment a cited
+page is edited, moved, or rewritten -- the link still resolves, but to different
+bytes, and no reader can tell. A citation-lineage report cannot: each
+:class:`CitationRecord` pins the ``sha256:`` content hash of the fetched page
+(the same hash the page was stored under in the run
+:class:`~bernstein.core.orchestration.activity_modalities.ContentStore` at fetch
+time) plus the exact quoted span the claim rests on. Verification is then a pure
+offline function -- re-read the cited bytes by hash, confirm they still hash to
+the pinned value, confirm the quote still occurs in them -- so a claim stays
+checkable months later with the network disabled, and a single altered source
+page fails verification naming the claim and the mismatched hash.
+
+The module owns two halves of that contract:
+
+* :func:`validate_research_report` -- the boundary check. A report whose every
+  claim carries at least one well-formed citation passes; a report with an
+  *uncited* claim (or a citation with an empty quote / a malformed page hash) is
+  refused with :class:`~bernstein.core.orchestration.activity.ActivityRejected`
+  *before* the result is built and dispatched, so it never reaches the journal.
+* :func:`verify_research_report` -- the offline resolver. For every claim it
+  reattaches each cited page's bytes from the content store by hash, re-hashes
+  them to detect tamper, and confirms the quoted span is present, emitting a
+  per-claim :class:`ClaimVerdict`. The verdict order is the report's claim order,
+  so two verify runs over the same report produce byte-identical output.
+
+The report itself is a JSON-serialisable :class:`ResearchReport`; the research
+worker stores its canonical bytes content-addressed and anchors that hash as the
+``artifact_hash`` of the dispatched
+:class:`~bernstein.core.orchestration.activity.ActivityResult`, so
+:func:`~bernstein.core.orchestration.activity_modalities.verify_run_activities`
+reattaches and re-verifies the report from the run's content store alone.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.orchestration.activity import ActivityRejected
+
+if TYPE_CHECKING:
+    from bernstein.core.orchestration.activity_modalities import ContentStore
+
+__all__ = [
+    "CitationRecord",
+    "ClaimVerdict",
+    "ResearchClaim",
+    "ResearchReport",
+    "ResearchReportVerdict",
+    "report_to_canonical_bytes",
+    "validate_research_report",
+    "verify_research_report",
+]
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _content_hash(data: bytes) -> str:
+    """Return the ``sha256:``-prefixed content hash of raw bytes."""
+    return "sha256:" + _sha256_hex(data)
+
+
+@dataclass(frozen=True, slots=True)
+class CitationRecord:
+    """One claim-to-source binding: a quoted span pinned to fetched-page bytes.
+
+    A citation is the atom of report lineage. It names the claim it supports, the
+    exact span quoted from the source, the human-facing provenance reference, and
+    -- the load-bearing field -- the ``sha256:`` content hash of the fetched page
+    as stored in the run content store at fetch time. Verification resolves the
+    hash back to bytes and confirms the quote occurs in them, so the citation is
+    only satisfiable against the exact bytes the claim was derived from.
+
+    Attributes:
+        claim_id: The id of the claim this citation supports.
+        quote: The exact span quoted from the source page (must occur in it).
+        source_ref: Human-facing provenance reference (the page URL / label).
+        page_content_hash: ``sha256:`` hash of the fetched page bytes in the store.
+    """
+
+    claim_id: str
+    quote: str
+    source_ref: str
+    page_content_hash: str
+
+    def to_dict(self) -> dict[str, str]:
+        """Return the JSON projection stored on the report."""
+        return {
+            "claim_id": self.claim_id,
+            "quote": self.quote,
+            "source_ref": self.source_ref,
+            "page_content_hash": self.page_content_hash,
+        }
+
+    @classmethod
+    def from_dict(cls, row: dict[str, Any]) -> CitationRecord:
+        """Rebuild a citation from its report projection."""
+        return cls(
+            claim_id=str(row.get("claim_id", "")),
+            quote=str(row.get("quote", "")),
+            source_ref=str(row.get("source_ref", "")),
+            page_content_hash=str(row.get("page_content_hash", "")),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ResearchClaim:
+    """A single claim in a research report plus its supporting citations.
+
+    A claim is an assertion the report makes. It is only admissible if it carries
+    at least one :class:`CitationRecord` binding it to fetched bytes; the boundary
+    check refuses a report the moment a claim has none.
+
+    Attributes:
+        claim_id: Stable id for the claim (unique within the report).
+        statement: The claim text.
+        citations: The citations supporting the claim (at least one required).
+    """
+
+    claim_id: str
+    statement: str
+    citations: tuple[CitationRecord, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the JSON projection stored on the report."""
+        return {
+            "claim_id": self.claim_id,
+            "statement": self.statement,
+            "citations": [c.to_dict() for c in self.citations],
+        }
+
+    @classmethod
+    def from_dict(cls, row: dict[str, Any]) -> ResearchClaim:
+        """Rebuild a claim from its report projection."""
+        raw_citations = row.get("citations", [])
+        citations = (
+            tuple(CitationRecord.from_dict(c) for c in raw_citations if isinstance(c, dict))
+            if isinstance(raw_citations, list)
+            else ()
+        )
+        return cls(
+            claim_id=str(row.get("claim_id", "")),
+            statement=str(row.get("statement", "")),
+            citations=citations,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ResearchReport:
+    """A sourced research report: the query, a summary, and cited claims.
+
+    The report is the activity's ``artifact``. Its canonical JSON projection is
+    hashed as the ``artifact_hash`` of the dispatched
+    :class:`~bernstein.core.orchestration.activity.ActivityResult` and stored
+    content-addressed, so an offline verifier reattaches and re-verifies it from
+    the run content store by that hash alone.
+
+    Attributes:
+        query: The top-level research question the report answers.
+        claims: The cited claims that make up the report body.
+        summary: A short free-text synthesis (never a substitute for citations).
+    """
+
+    query: str
+    claims: tuple[ResearchClaim, ...] = ()
+    summary: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the JSON artifact projection (hashed as ``artifact_hash``)."""
+        return {
+            "query": self.query,
+            "summary": self.summary,
+            "claims": [c.to_dict() for c in self.claims],
+        }
+
+    @classmethod
+    def from_dict(cls, row: dict[str, Any]) -> ResearchReport:
+        """Rebuild a report from its artifact projection."""
+        raw_claims = row.get("claims", [])
+        claims = (
+            tuple(ResearchClaim.from_dict(c) for c in raw_claims if isinstance(c, dict))
+            if isinstance(raw_claims, list)
+            else ()
+        )
+        return cls(
+            query=str(row.get("query", "")),
+            claims=claims,
+            summary=str(row.get("summary", "")),
+        )
+
+
+def validate_research_report(report: ResearchReport) -> ResearchReport:
+    """Refuse a report with any uncited or malformed claim at the boundary (AC1).
+
+    Enforces every invariant the citation-lineage guarantee rests on:
+
+    * every claim carries a non-empty ``claim_id`` and at least one citation;
+    * every citation names its own claim, quotes a non-empty span, and pins a
+      ``sha256:``-shaped page content hash.
+
+    Raised as :class:`~bernstein.core.orchestration.activity.ActivityRejected` so
+    the research worker's build path refuses the report *before* the
+    :class:`~bernstein.core.orchestration.activity.ActivityResult` is dispatched
+    -- an uncited claim never reaches the journal or the audit chain.
+
+    Args:
+        report: The report to validate.
+
+    Returns:
+        The same report, unchanged, when valid.
+
+    Raises:
+        ActivityRejected: On the first uncited or malformed claim.
+    """
+    seen_ids: set[str] = set()
+    for claim in report.claims:
+        if not claim.claim_id.strip():
+            raise ActivityRejected("research report claim has an empty claim_id")
+        if claim.claim_id in seen_ids:
+            raise ActivityRejected(f"research report has a duplicate claim_id: {claim.claim_id!r}")
+        seen_ids.add(claim.claim_id)
+        if not claim.citations:
+            raise ActivityRejected(
+                f"research report claim {claim.claim_id!r} has no citation "
+                "(every claim must carry at least one citation record)"
+            )
+        for citation in claim.citations:
+            if citation.claim_id != claim.claim_id:
+                raise ActivityRejected(
+                    f"citation on claim {claim.claim_id!r} names a different claim: {citation.claim_id!r}"
+                )
+            if not citation.quote:
+                raise ActivityRejected(f"citation on claim {claim.claim_id!r} has an empty quote span")
+            if not citation.page_content_hash.startswith("sha256:"):
+                raise ActivityRejected(
+                    f"citation on claim {claim.claim_id!r} has a malformed page hash: {citation.page_content_hash!r}"
+                )
+    return report
+
+
+@dataclass(frozen=True, slots=True)
+class ClaimVerdict:
+    """Per-claim outcome of :func:`verify_research_report`.
+
+    Attributes:
+        claim_id: The claim this verdict covers.
+        ok: True only when every citation resolved: bytes present, bytes still
+            hash to the pinned value, and the quoted span occurs in them.
+        citations_checked: The number of citations resolved for the claim.
+        reason: A short explanation naming the claim (and, on tamper, the
+            mismatched hash) when ``ok`` is False, else empty.
+    """
+
+    claim_id: str
+    ok: bool
+    citations_checked: int
+    reason: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the JSON projection surfaced by the CLI."""
+        return {
+            "claim_id": self.claim_id,
+            "ok": self.ok,
+            "citations_checked": self.citations_checked,
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ResearchReportVerdict:
+    """Outcome of resolving every citation in a report offline.
+
+    Attributes:
+        ok: True only when every claim verdict is ``ok``.
+        claims: Per-claim verdicts in the report's claim order (so two verify
+            runs over the same report emit byte-identical output).
+        reason: A short top-level explanation when the report itself is empty.
+    """
+
+    ok: bool
+    claims: tuple[ClaimVerdict, ...] = ()
+    reason: str = ""
+
+
+def _verify_claim(claim: ResearchClaim, *, store: ContentStore) -> ClaimVerdict:
+    """Resolve every citation on one claim against the content store."""
+    if not claim.citations:
+        return ClaimVerdict(
+            claim_id=claim.claim_id,
+            ok=False,
+            citations_checked=0,
+            reason=f"claim {claim.claim_id!r} has no citation",
+        )
+    checked = 0
+    for citation in claim.citations:
+        try:
+            content = store.get(citation.page_content_hash)
+        except KeyError:
+            return ClaimVerdict(
+                claim_id=claim.claim_id,
+                ok=False,
+                citations_checked=checked,
+                reason=(
+                    f"claim {claim.claim_id!r} citation unresolved: "
+                    f"page bytes missing from store for {citation.page_content_hash!r}"
+                ),
+            )
+        recomputed = _content_hash(content)
+        if recomputed != citation.page_content_hash:
+            return ClaimVerdict(
+                claim_id=claim.claim_id,
+                ok=False,
+                citations_checked=checked,
+                reason=(
+                    f"claim {claim.claim_id!r} citation failed: cited page content hash mismatch "
+                    f"(pinned {citation.page_content_hash!r}, recomputed {recomputed!r})"
+                ),
+            )
+        if citation.quote.encode("utf-8") not in content:
+            return ClaimVerdict(
+                claim_id=claim.claim_id,
+                ok=False,
+                citations_checked=checked,
+                reason=(
+                    f"claim {claim.claim_id!r} citation failed: quoted span not found in cited page "
+                    f"{citation.page_content_hash!r}"
+                ),
+            )
+        checked += 1
+    return ClaimVerdict(claim_id=claim.claim_id, ok=True, citations_checked=checked)
+
+
+def verify_research_report(report: ResearchReport, *, store: ContentStore) -> ResearchReportVerdict:
+    """Resolve every citation in *report* offline against the content store (AC2).
+
+    For each claim, in report order, reattach each cited page's bytes from the
+    content-addressed store by its pinned hash, re-hash them to detect an altered
+    source page, and confirm the quoted span still occurs in them. Any failure
+    marks the claim -- and the report -- as not ``ok`` with a reason naming the
+    claim and, on tamper, the mismatched hash. The check touches only the store,
+    so it holds with the network disabled, and its output is a pure function of
+    the report and the stored bytes, so two runs produce identical verdicts.
+
+    Args:
+        report: The report whose citations to resolve.
+        store: The content-addressed store holding the fetched page bytes.
+
+    Returns:
+        A :class:`ResearchReportVerdict`. ``ok`` requires every claim to resolve.
+    """
+    if not report.claims:
+        return ResearchReportVerdict(ok=False, reason="research report holds no claims")
+    verdicts = tuple(_verify_claim(claim, store=store) for claim in report.claims)
+    return ResearchReportVerdict(ok=all(v.ok for v in verdicts), claims=verdicts)
+
+
+def report_to_canonical_bytes(report: ResearchReport) -> bytes:
+    """Return the canonical JSON bytes hashed as the report's ``artifact_hash``.
+
+    Matches the canonicalisation the activity boundary hashes with, so the
+    content hash of these bytes equals the anchored ``artifact_hash`` and the
+    report reattaches from the store by that hash.
+    """
+    return json.dumps(report.to_dict(), ensure_ascii=False, separators=(",", ":"), sort_keys=True, default=str).encode(
+        "utf-8"
+    )

--- a/src/bernstein/core/orchestration/research_worker.py
+++ b/src/bernstein/core/orchestration/research_worker.py
@@ -1,0 +1,331 @@
+"""Research worker: sourced reports with offline-resolvable citation lineage (#2524).
+
+The activity boundary ships a ``RESEARCH`` modality and a
+:class:`~bernstein.core.orchestration.activity_modalities.ResearchActivity` that
+content-addresses fetched pages at fetch time, but no worker turns that substrate
+into a *report*. This module is that worker. It runs the deterministic half of a
+research task -- plan the sources, fetch each one through
+:meth:`ResearchActivity.fetch` so every page is content-addressed as it lands,
+apply the cost cap, and assemble the fetched bytes and the synthesiser's drafts
+into a citation-lineage :class:`~bernstein.core.orchestration.research_report.ResearchReport`
+-- and hands a built
+:class:`~bernstein.core.orchestration.activity.ActivityResult` to the same
+:func:`~bernstein.core.orchestration.activity.dispatch_activity` path a coding
+spawn uses.
+
+The split is what keeps the guarantee deterministic. The *synthesiser* -- the
+stochastic step that reads pages and drafts claims (a model in production) -- is
+injected as an opaque callable; the worker never inspects how it drafts, only
+that every quoted span it emits resolves to a source the worker actually fetched
+and content-addressed. A draft that cites an unfetched source, or a claim with no
+citation, is refused with
+:class:`~bernstein.core.orchestration.activity.ActivityRejected` before the
+result is built, so an uncited claim never reaches the journal. Everything the
+worker itself does -- planning, fetching, budgeting, report assembly, hashing --
+is a pure function of the query, the plan, and the fetched bytes, so two operators
+with the same inputs assemble the byte-identical report and anchor the same
+``artifact_hash``.
+
+Cost caps are a first-class refusal, not advice: :class:`ResearchBudget` bounds
+how many sources a run may fetch, and the worker raises
+:class:`ResearchBudgetExceeded` the moment a fetch would cross the cap -- before
+the fetch happens -- so a research task scheduled next to coding tasks stays
+inside its budget the same way a coding task does.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from bernstein.core.orchestration.activity import (
+    ActivityRejected,
+    ActivityResult,
+    TerminalState,
+)
+from bernstein.core.orchestration.activity_modalities import ContentStore, ResearchActivity
+from bernstein.core.orchestration.research_report import (
+    CitationRecord,
+    ResearchClaim,
+    ResearchReport,
+    report_to_canonical_bytes,
+    validate_research_report,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+__all__ = [
+    "ClaimDraft",
+    "FetchedSource",
+    "ResearchBudget",
+    "ResearchBudgetExceeded",
+    "ResearchPlan",
+    "ResearchRunResult",
+    "ResearchWorker",
+    "SpanRef",
+]
+
+
+class ResearchBudgetExceeded(RuntimeError):
+    """A research run was refused because a fetch would cross its cost cap.
+
+    Raised by :meth:`ResearchWorker.run` *before* the fetch that would exceed the
+    cap, so a budgeted research task never spends past its cap. The message names
+    the cap that was hit.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class ResearchBudget:
+    """The cost cap applied to a research run.
+
+    A run may fetch at most ``max_fetches`` sources, and may spend at most
+    ``max_cost_units`` (each fetch costs ``cost_per_fetch``). The cap is checked
+    before every fetch, so it bounds the work a research task does the same way a
+    coding task's budget bounds its spawns.
+
+    Attributes:
+        max_fetches: Maximum number of source fetches the run may perform.
+        max_cost_units: Maximum total cost the run may spend (defaults to no
+            cost ceiling beyond ``max_fetches``).
+        cost_per_fetch: Cost charged per fetch.
+    """
+
+    max_fetches: int
+    max_cost_units: float = math.inf
+    cost_per_fetch: float = 1.0
+
+    def __post_init__(self) -> None:
+        if self.max_fetches < 0:
+            raise ValueError("max_fetches must be non-negative")
+        if self.cost_per_fetch < 0:
+            raise ValueError("cost_per_fetch must be non-negative")
+
+
+@dataclass(frozen=True, slots=True)
+class ResearchPlan:
+    """The ordered, de-duplicated set of sources a research run will consult.
+
+    Planning is a pure projection of the query and the candidate sources: the
+    plan preserves first-seen order and drops duplicates, so two operators with
+    the same query and candidates derive the identical plan. It carries no live
+    call -- it only decides *which* sources to fetch, not what they say.
+
+    Attributes:
+        query: The top-level research question.
+        sources: The ordered, de-duplicated source references to fetch.
+    """
+
+    query: str
+    sources: tuple[str, ...]
+
+    @classmethod
+    def derive(cls, *, query: str, sources: Sequence[str]) -> ResearchPlan:
+        """Derive a plan from a query and candidate source references."""
+        ordered: list[str] = []
+        seen: set[str] = set()
+        for source in sources:
+            if source not in seen:
+                seen.add(source)
+                ordered.append(source)
+        return cls(query=query, sources=tuple(ordered))
+
+
+@dataclass(frozen=True, slots=True)
+class FetchedSource:
+    """A source fetched and content-addressed during a research run.
+
+    Attributes:
+        source_ref: The source reference (URL / label) fetched.
+        content_hash: The ``sha256:`` hash the page bytes were stored under.
+        content: The exact page bytes fetched.
+    """
+
+    source_ref: str
+    content_hash: str
+    content: bytes
+
+
+@dataclass(frozen=True, slots=True)
+class SpanRef:
+    """A quoted span a synthesised claim rests on, tied to a source reference.
+
+    Attributes:
+        source_ref: The source the span was quoted from (must be one the worker
+            fetched, so the span can be bound to content-addressed bytes).
+        quote: The exact span quoted from that source.
+    """
+
+    source_ref: str
+    quote: str
+
+
+@dataclass(frozen=True, slots=True)
+class ClaimDraft:
+    """One claim the synthesiser drafted, with the spans it quotes.
+
+    The worker turns each span into a :class:`CitationRecord` by resolving its
+    ``source_ref`` to the content hash of the page the worker fetched, so the
+    drafted claim becomes a claim bound to fetched bytes.
+
+    Attributes:
+        statement: The claim text.
+        spans: The quoted spans supporting the claim (at least one required for
+            the claim to survive the boundary check).
+        claim_id: Optional stable id; the worker assigns ``c1``, ``c2`` ... when
+            empty.
+    """
+
+    statement: str
+    spans: tuple[SpanRef, ...] = ()
+    claim_id: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class ResearchRunResult:
+    """The outcome of a completed research run.
+
+    Attributes:
+        report: The assembled citation-lineage report (the activity artifact).
+        result: The built :class:`ActivityResult` ready for
+            :func:`~bernstein.core.orchestration.activity.dispatch_activity`.
+        plan: The plan the run executed.
+        fetched: The sources fetched, in fetch order.
+    """
+
+    report: ResearchReport
+    result: ActivityResult
+    plan: ResearchPlan
+    fetched: tuple[FetchedSource, ...] = field(default_factory=tuple)
+
+
+class ResearchWorker:
+    """Runs the deterministic half of a research task under a cost cap (#2524).
+
+    The worker plans the sources, fetches each through
+    :meth:`ResearchActivity.fetch` (content-addressing every page at fetch time),
+    enforces the :class:`ResearchBudget`, invokes the injected synthesiser to
+    draft claims, and assembles a citation-lineage
+    :class:`~bernstein.core.orchestration.research_report.ResearchReport`. The
+    report's canonical bytes are stored content-addressed under the activity's
+    ``artifact_hash`` so an offline verifier reattaches and re-verifies the report
+    from the run content store alone.
+
+    Args:
+        store: The content-addressed store fetched pages and the report land in.
+        budget: The cost cap the run must stay inside.
+    """
+
+    def __init__(self, *, store: ContentStore, budget: ResearchBudget) -> None:
+        self._store = store
+        self._budget = budget
+
+    def run(
+        self,
+        *,
+        query: str,
+        sources: Sequence[str],
+        fetch_fn: Callable[[str], bytes],
+        synthesise: Callable[[str, tuple[FetchedSource, ...]], Sequence[ClaimDraft]],
+        summary: str = "",
+    ) -> ResearchRunResult:
+        """Plan, fetch, synthesise, and assemble a citation-lineage report.
+
+        Args:
+            query: The top-level research question.
+            sources: Candidate source references to consult (planned in order,
+                de-duplicated).
+            fetch_fn: Retrieves the exact bytes for a source reference. This is
+                the only place the run touches the outside world; every returned
+                blob is content-addressed at fetch time.
+            synthesise: The opaque synthesiser drafting cited claims from the
+                fetched sources.
+            summary: An optional free-text synthesis stored on the report.
+
+        Returns:
+            A :class:`ResearchRunResult` whose ``result`` is ready to dispatch.
+
+        Raises:
+            ResearchBudgetExceeded: When a fetch would cross the cost cap.
+            ActivityRejected: When the synthesiser drafts a claim with no span,
+                or cites a source the worker did not fetch (an uncited claim never
+                reaches the journal).
+        """
+        plan = ResearchPlan.derive(query=query, sources=sources)
+        activity = ResearchActivity(store=self._store)
+
+        fetched: list[FetchedSource] = []
+        by_ref: dict[str, str] = {}
+        spent = 0.0
+        for index, source_ref in enumerate(plan.sources):
+            if index + 1 > self._budget.max_fetches:
+                raise ResearchBudgetExceeded(
+                    f"research run exceeds max_fetches={self._budget.max_fetches} at source {source_ref!r}"
+                )
+            projected = spent + self._budget.cost_per_fetch
+            if projected > self._budget.max_cost_units:
+                raise ResearchBudgetExceeded(
+                    f"research run exceeds max_cost_units={self._budget.max_cost_units} at source {source_ref!r}"
+                )
+            content = fetch_fn(source_ref)
+            observation = activity.fetch(source_ref, content)
+            spent = projected
+            fetched.append(FetchedSource(source_ref=source_ref, content_hash=observation.content_hash, content=content))
+            # Last write wins if a synthesiser later quotes an ambiguous ref; the
+            # content hash still binds the citation to fetched bytes.
+            by_ref[source_ref] = observation.content_hash
+
+        drafts = synthesise(query, tuple(fetched))
+        claims = self._assemble_claims(drafts, by_ref=by_ref)
+        report = ResearchReport(query=query, claims=claims, summary=summary)
+
+        # Boundary refusal (AC1): an uncited or malformed claim is refused here,
+        # before the result is built and dispatched.
+        validate_research_report(report)
+
+        # Store the report's canonical bytes content-addressed so an offline
+        # verifier reattaches it by the anchored artifact_hash.
+        self._store.put(report_to_canonical_bytes(report))
+
+        result = activity.finish(
+            artifact=report.to_dict(),
+            terminal_state=TerminalState.COMPLETED,
+            reason_code="ok",
+        )
+        return ResearchRunResult(report=report, result=result, plan=plan, fetched=tuple(fetched))
+
+    @staticmethod
+    def _assemble_claims(
+        drafts: Sequence[ClaimDraft],
+        *,
+        by_ref: dict[str, str],
+    ) -> tuple[ResearchClaim, ...]:
+        """Bind each drafted span to the content hash of the source it quotes."""
+        claims: list[ResearchClaim] = []
+        for index, draft in enumerate(drafts):
+            claim_id = draft.claim_id.strip() or f"c{index + 1}"
+            if not draft.spans:
+                raise ActivityRejected(
+                    f"synthesiser drafted claim {claim_id!r} with no span "
+                    "(every claim must carry at least one citation record)"
+                )
+            citations: list[CitationRecord] = []
+            for span in draft.spans:
+                content_hash = by_ref.get(span.source_ref)
+                if content_hash is None:
+                    raise ActivityRejected(
+                        f"claim {claim_id!r} cites source {span.source_ref!r} that was not fetched "
+                        "(a citation must bind to a content-addressed page)"
+                    )
+                citations.append(
+                    CitationRecord(
+                        claim_id=claim_id,
+                        quote=span.quote,
+                        source_ref=span.source_ref,
+                        page_content_hash=content_hash,
+                    )
+                )
+            claims.append(ResearchClaim(claim_id=claim_id, statement=draft.statement, citations=tuple(citations)))
+        return tuple(claims)

--- a/tests/unit/test_activity_cmd.py
+++ b/tests/unit/test_activity_cmd.py
@@ -17,6 +17,12 @@ from click.testing import CliRunner
 from bernstein.cli.commands.activity_cmd import activity_group
 from bernstein.core.orchestration.activity import dispatch_activity
 from bernstein.core.orchestration.activity_modalities import ContentStore, ResearchActivity
+from bernstein.core.orchestration.research_worker import (
+    ClaimDraft,
+    ResearchBudget,
+    ResearchWorker,
+    SpanRef,
+)
 from bernstein.core.replay.journal import EventJournal
 
 
@@ -29,6 +35,37 @@ def _seed_run(project: Path, run_id: str = "run-cli-1") -> str:
     result = research.finish(artifact={"summary": "found 2 sources"})
     journal = EventJournal(run_id=run_id, sdd_dir=project / ".sdd")
     dispatch_activity(result, stage_id="research-0", journal=journal)
+    return run_id
+
+
+_REPORT_PAGES = {
+    "https://a": b"<html>Python 3.13 ships an optional free-threaded build.</html>",
+    "https://b": b"<html>Module foo is deprecated and slated for removal.</html>",
+}
+
+
+def _seed_report_run(project: Path, run_id: str = "run-cli-report") -> str:
+    """Seed a citation-lineage research report anchored into RUN's journal."""
+    store = ContentStore(project / ".sdd" / "cas")
+    worker = ResearchWorker(store=store, budget=ResearchBudget(max_fetches=5))
+
+    def synth(query: str, fetched: tuple[object, ...]) -> list[ClaimDraft]:
+        return [
+            ClaimDraft(
+                statement="3.13 has an optional free-threaded build",
+                spans=(SpanRef(source_ref="https://a", quote="optional free-threaded build"),),
+            ),
+            ClaimDraft(
+                statement="foo is deprecated",
+                spans=(SpanRef(source_ref="https://b", quote="deprecated and slated for removal"),),
+            ),
+        ]
+
+    run = worker.run(
+        query="what changed", sources=list(_REPORT_PAGES), fetch_fn=_REPORT_PAGES.__getitem__, synthesise=synth
+    )
+    journal = EventJournal(run_id=run_id, sdd_dir=project / ".sdd")
+    dispatch_activity(run.result, stage_id="research-0", journal=journal)
     return run_id
 
 
@@ -104,3 +141,48 @@ def test_verify_missing_run_exits_nonzero(project: Path) -> None:
     )
     assert result.exit_code == 1, result.output
     assert "no" in result.output.lower()
+
+
+def test_verify_reports_per_claim_citation_verdicts(project: Path) -> None:
+    run_id = _seed_report_run(project)
+    result = CliRunner().invoke(
+        activity_group,
+        ["verify", run_id, "--workdir", str(project), "--json"],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    verdicts = payload["stages"][0]["claim_verdicts"]
+    assert [v["claim_id"] for v in verdicts] == ["c1", "c2"]
+    assert all(v["ok"] for v in verdicts)
+    assert all(v["citations_checked"] == 1 for v in verdicts)
+
+
+def test_verify_text_output_lists_citation_verdicts(project: Path) -> None:
+    run_id = _seed_report_run(project)
+    result = CliRunner().invoke(
+        activity_group,
+        ["verify", run_id, "--workdir", str(project)],
+    )
+    assert result.exit_code == 0, result.output
+    assert "cite OK" in result.output
+    assert "claim=c1" in result.output
+
+
+def test_verify_fails_naming_claim_when_source_altered(project: Path) -> None:
+    run_id = _seed_report_run(project)
+    store = ContentStore(project / ".sdd" / "cas")
+    journal_path = project / ".sdd" / "runs" / run_id / "journal.jsonl"
+    rows = [json.loads(line) for line in journal_path.read_text().splitlines() if line.strip()]
+    cited_hash = rows[0]["observations"][0]["content_hash"]
+    store.force_put(cited_hash, b"<html>rewritten, quote gone</html>")
+
+    result = CliRunner().invoke(
+        activity_group,
+        ["verify", run_id, "--workdir", str(project), "--json"],
+    )
+    assert result.exit_code == 2, result.output
+    payload = json.loads(result.output)
+    assert payload["ok"] is False
+    stage = payload["stages"][0]
+    assert cited_hash in stage["reason"]
+    assert any(not v["ok"] for v in stage["claim_verdicts"])

--- a/tests/unit/test_research_report.py
+++ b/tests/unit/test_research_report.py
@@ -1,0 +1,240 @@
+"""Citation-lineage report model and offline verification (issue #2524).
+
+A research report is a citation-lineage artifact, not prose with links. These
+tests prove the two halves of that contract:
+
+* the boundary check refuses a report with an uncited or malformed claim before
+  it is ever dispatched (AC1); and
+* offline verification resolves every citation from the content store alone,
+  passes on intact bytes, fails naming the claim and the mismatched hash on an
+  altered source page, and is deterministic across runs (AC2 / AC5). A
+  links-in-markdown report carries no page hash and so cannot satisfy this.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.orchestration.activity import ActivityRejected
+from bernstein.core.orchestration.activity_modalities import ContentStore
+from bernstein.core.orchestration.research_report import (
+    CitationRecord,
+    ResearchClaim,
+    ResearchReport,
+    report_to_canonical_bytes,
+    validate_research_report,
+    verify_research_report,
+)
+
+
+def _store_page(store: ContentStore, content: bytes) -> str:
+    return store.put(content)
+
+
+def _report_over(store: ContentStore) -> ResearchReport:
+    """A two-claim report whose citations resolve against *store*."""
+    h1 = _store_page(store, b"<html>Python 3.13 ships an optional free-threaded build.</html>")
+    h2 = _store_page(store, b"<html>Module foo is deprecated and slated for removal.</html>")
+    return ResearchReport(
+        query="what changed",
+        summary="two findings",
+        claims=(
+            ResearchClaim(
+                claim_id="c1",
+                statement="3.13 has an optional free-threaded build",
+                citations=(
+                    CitationRecord(
+                        claim_id="c1",
+                        quote="optional free-threaded build",
+                        source_ref="https://a",
+                        page_content_hash=h1,
+                    ),
+                ),
+            ),
+            ResearchClaim(
+                claim_id="c2",
+                statement="foo is deprecated",
+                citations=(
+                    CitationRecord(
+                        claim_id="c2",
+                        quote="deprecated and slated for removal",
+                        source_ref="https://b",
+                        page_content_hash=h2,
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# boundary check: uncited / malformed claims are refused (AC1)
+# ---------------------------------------------------------------------------
+
+
+def test_valid_report_passes_boundary(tmp_path: Path) -> None:
+    store = ContentStore(tmp_path / "cas")
+    report = _report_over(store)
+    assert validate_research_report(report) is report
+
+
+def test_uncited_claim_is_refused() -> None:
+    report = ResearchReport(
+        query="q",
+        claims=(ResearchClaim(claim_id="c1", statement="unsupported", citations=()),),
+    )
+    with pytest.raises(ActivityRejected, match="no citation"):
+        validate_research_report(report)
+
+
+def test_empty_quote_is_refused() -> None:
+    report = ResearchReport(
+        query="q",
+        claims=(
+            ResearchClaim(
+                claim_id="c1",
+                statement="s",
+                citations=(CitationRecord(claim_id="c1", quote="", source_ref="r", page_content_hash="sha256:aa"),),
+            ),
+        ),
+    )
+    with pytest.raises(ActivityRejected, match="empty quote"):
+        validate_research_report(report)
+
+
+def test_malformed_page_hash_is_refused() -> None:
+    report = ResearchReport(
+        query="q",
+        claims=(
+            ResearchClaim(
+                claim_id="c1",
+                statement="s",
+                citations=(CitationRecord(claim_id="c1", quote="x", source_ref="r", page_content_hash="not-a-hash"),),
+            ),
+        ),
+    )
+    with pytest.raises(ActivityRejected, match="malformed page hash"):
+        validate_research_report(report)
+
+
+def test_citation_naming_wrong_claim_is_refused() -> None:
+    report = ResearchReport(
+        query="q",
+        claims=(
+            ResearchClaim(
+                claim_id="c1",
+                statement="s",
+                citations=(CitationRecord(claim_id="c2", quote="x", source_ref="r", page_content_hash="sha256:aa"),),
+            ),
+        ),
+    )
+    with pytest.raises(ActivityRejected, match="names a different claim"):
+        validate_research_report(report)
+
+
+def test_duplicate_claim_id_is_refused() -> None:
+    cite = CitationRecord(claim_id="c1", quote="x", source_ref="r", page_content_hash="sha256:aa")
+    report = ResearchReport(
+        query="q",
+        claims=(
+            ResearchClaim(claim_id="c1", statement="a", citations=(cite,)),
+            ResearchClaim(claim_id="c1", statement="b", citations=(cite,)),
+        ),
+    )
+    with pytest.raises(ActivityRejected, match="duplicate claim_id"):
+        validate_research_report(report)
+
+
+# ---------------------------------------------------------------------------
+# offline verification: resolve every citation from the store (AC2)
+# ---------------------------------------------------------------------------
+
+
+def test_verify_resolves_every_citation(tmp_path: Path) -> None:
+    store = ContentStore(tmp_path / "cas")
+    report = _report_over(store)
+    verdict = verify_research_report(report, store=store)
+    assert verdict.ok
+    assert [c.claim_id for c in verdict.claims] == ["c1", "c2"]
+    assert all(c.ok for c in verdict.claims)
+    assert all(c.citations_checked == 1 for c in verdict.claims)
+
+
+def test_verify_fails_when_cited_page_altered_naming_claim_and_hash(tmp_path: Path) -> None:
+    store = ContentStore(tmp_path / "cas")
+    report = _report_over(store)
+    tampered_hash = report.claims[0].citations[0].page_content_hash
+    # Alter the stored bytes under the pinned hash: the recomputed hash diverges.
+    store.force_put(tampered_hash, b"<html>rewritten, quote gone</html>")
+
+    verdict = verify_research_report(report, store=store)
+    assert not verdict.ok
+    bad = verdict.claims[0]
+    assert not bad.ok
+    assert bad.claim_id == "c1"
+    assert tampered_hash in bad.reason
+    # The untouched claim still resolves.
+    assert verdict.claims[1].ok
+
+
+def test_verify_fails_when_quote_absent(tmp_path: Path) -> None:
+    store = ContentStore(tmp_path / "cas")
+    page = store.put(b"<html>the page body says something else entirely</html>")
+    report = ResearchReport(
+        query="q",
+        claims=(
+            ResearchClaim(
+                claim_id="c1",
+                statement="s",
+                citations=(
+                    CitationRecord(claim_id="c1", quote="not present here", source_ref="r", page_content_hash=page),
+                ),
+            ),
+        ),
+    )
+    verdict = verify_research_report(report, store=store)
+    assert not verdict.ok
+    assert "quoted span not found" in verdict.claims[0].reason
+
+
+def test_verify_fails_when_page_missing_from_store(tmp_path: Path) -> None:
+    store = ContentStore(tmp_path / "cas")
+    report = ResearchReport(
+        query="q",
+        claims=(
+            ResearchClaim(
+                claim_id="c1",
+                statement="s",
+                citations=(
+                    CitationRecord(claim_id="c1", quote="x", source_ref="r", page_content_hash="sha256:" + "0" * 64),
+                ),
+            ),
+        ),
+    )
+    verdict = verify_research_report(report, store=store)
+    assert not verdict.ok
+    assert "missing from store" in verdict.claims[0].reason
+
+
+def test_verify_is_deterministic_across_runs(tmp_path: Path) -> None:
+    store = ContentStore(tmp_path / "cas")
+    report = _report_over(store)
+    # Tamper one page so a failure verdict is produced (the more interesting case
+    # for determinism), then verify twice.
+    store.force_put(report.claims[1].citations[0].page_content_hash, b"gone")
+    first = verify_research_report(report, store=store)
+    second = verify_research_report(report, store=store)
+    assert [(c.claim_id, c.ok, c.reason, c.citations_checked) for c in first.claims] == [
+        (c.claim_id, c.ok, c.reason, c.citations_checked) for c in second.claims
+    ]
+
+
+def test_report_roundtrips_through_dict(tmp_path: Path) -> None:
+    store = ContentStore(tmp_path / "cas")
+    report = _report_over(store)
+    restored = ResearchReport.from_dict(report.to_dict())
+    assert restored == report
+    # Canonical bytes are stable, so the report reattaches from the store by hash.
+    assert report_to_canonical_bytes(restored) == report_to_canonical_bytes(report)

--- a/tests/unit/test_research_worker.py
+++ b/tests/unit/test_research_worker.py
@@ -1,0 +1,245 @@
+"""Research worker: planning, budgeted fetching, dispatch, offline verify (#2524).
+
+The worker runs the deterministic half of a research task -- plan, fetch through
+:meth:`ResearchActivity.fetch` (content-addressing every page), apply the cost
+cap, assemble a citation-lineage report -- and hands the result to the same
+dispatch path a coding spawn uses. These tests prove the end-to-end guarantee:
+
+* every produced report carries at least one citation per claim; an uncited or
+  unbound claim is refused before dispatch (AC1);
+* the dispatched report is content-addressed, anchored as ``artifact_hash``, and
+  mirrored into the audit chain (AC3);
+* with only the content store, ``verify_run_activities`` resolves every citation
+  and passes; altering a stored source page fails naming the claim (AC2);
+* research runs dispatch next to coding tasks under one journal with cost caps
+  applied (AC4); and two verify runs produce identical verdicts (AC5).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.orchestration.activity import (
+    ActivityKind,
+    ActivityRejected,
+    ActivityResult,
+    Observation,
+    TerminalState,
+    dispatch_activity,
+)
+from bernstein.core.orchestration.activity_modalities import ContentStore, verify_run_activities
+from bernstein.core.orchestration.research_worker import (
+    ClaimDraft,
+    ResearchBudget,
+    ResearchBudgetExceeded,
+    ResearchPlan,
+    ResearchWorker,
+    SpanRef,
+)
+from bernstein.core.replay.journal import EventJournal
+from bernstein.core.security.audit_chain import EVENT_ACTIVITY_RESULT, AuditChainStore
+
+_PAGES = {
+    "https://a": b"<html>Python 3.13 ships an optional free-threaded build.</html>",
+    "https://b": b"<html>Module foo is deprecated and slated for removal.</html>",
+    "https://c": b"<html>The wire format gained a new length prefix field.</html>",
+}
+
+
+def _fetch(url: str) -> bytes:
+    return _PAGES[url]
+
+
+def _synth_two(query: str, fetched: tuple[object, ...]) -> list[ClaimDraft]:
+    return [
+        ClaimDraft(
+            statement="3.13 has an optional free-threaded build",
+            spans=(SpanRef(source_ref="https://a", quote="optional free-threaded build"),),
+        ),
+        ClaimDraft(
+            statement="foo is deprecated",
+            spans=(SpanRef(source_ref="https://b", quote="deprecated and slated for removal"),),
+        ),
+    ]
+
+
+def _worker(tmp_path: Path, *, max_fetches: int = 10, **budget: float) -> ResearchWorker:
+    store = ContentStore(tmp_path / ".sdd" / "cas")
+    return ResearchWorker(store=store, budget=ResearchBudget(max_fetches=max_fetches, **budget))
+
+
+# ---------------------------------------------------------------------------
+# planning + content-addressed fetching
+# ---------------------------------------------------------------------------
+
+
+def test_plan_dedupes_and_preserves_order() -> None:
+    plan = ResearchPlan.derive(query="q", sources=["u1", "u2", "u1", "u3", "u2"])
+    assert plan.sources == ("u1", "u2", "u3")
+
+
+def test_run_content_addresses_each_fetched_page(tmp_path: Path) -> None:
+    worker = _worker(tmp_path)
+    run = worker.run(query="what changed", sources=list(_PAGES), fetch_fn=_fetch, synthesise=_synth_two)
+    # Every claim's citation pins the content hash of the page it was drawn from.
+    for claim in run.report.claims:
+        for citation in claim.citations:
+            assert citation.page_content_hash.startswith("sha256:")
+    assert run.result.kind is ActivityKind.RESEARCH
+    assert run.result.terminal_state is TerminalState.COMPLETED
+
+
+def test_run_refuses_uncited_claim_before_dispatch(tmp_path: Path) -> None:
+    worker = _worker(tmp_path)
+
+    def synth_uncited(query: str, fetched: tuple[object, ...]) -> list[ClaimDraft]:
+        return [ClaimDraft(statement="unsupported", spans=())]
+
+    with pytest.raises(ActivityRejected, match="no span"):
+        worker.run(query="q", sources=["https://a"], fetch_fn=_fetch, synthesise=synth_uncited)
+
+
+def test_run_refuses_claim_citing_unfetched_source(tmp_path: Path) -> None:
+    worker = _worker(tmp_path)
+
+    def synth_bad(query: str, fetched: tuple[object, ...]) -> list[ClaimDraft]:
+        return [ClaimDraft(statement="s", spans=(SpanRef(source_ref="https://never", quote="x"),))]
+
+    with pytest.raises(ActivityRejected, match="was not fetched"):
+        worker.run(query="q", sources=["https://a"], fetch_fn=_fetch, synthesise=synth_bad)
+
+
+# ---------------------------------------------------------------------------
+# cost caps (AC4)
+# ---------------------------------------------------------------------------
+
+
+def test_max_fetches_cap_refuses_before_overspending(tmp_path: Path) -> None:
+    worker = _worker(tmp_path, max_fetches=2)
+    with pytest.raises(ResearchBudgetExceeded, match="max_fetches=2"):
+        worker.run(query="q", sources=list(_PAGES), fetch_fn=_fetch, synthesise=_synth_two)
+
+
+def test_cost_unit_cap_refuses(tmp_path: Path) -> None:
+    worker = _worker(tmp_path, max_fetches=10, max_cost_units=1.5, cost_per_fetch=1.0)
+    with pytest.raises(ResearchBudgetExceeded, match="max_cost_units"):
+        worker.run(query="q", sources=list(_PAGES), fetch_fn=_fetch, synthesise=_synth_two)
+
+
+def test_run_within_budget_succeeds(tmp_path: Path) -> None:
+    worker = _worker(tmp_path, max_fetches=2)
+    run = worker.run(query="q", sources=["https://a", "https://b"], fetch_fn=_fetch, synthesise=_synth_two)
+    assert len(run.fetched) == 2
+
+
+# ---------------------------------------------------------------------------
+# dispatch + audit chain mirror + offline verify (AC2, AC3, AC5)
+# ---------------------------------------------------------------------------
+
+
+def test_report_is_content_addressed_and_verifies_offline(tmp_path: Path) -> None:
+    sdd = tmp_path / ".sdd"
+    store = ContentStore(sdd / "cas")
+    worker = ResearchWorker(store=store, budget=ResearchBudget(max_fetches=5))
+    run = worker.run(query="q", sources=list(_PAGES), fetch_fn=_fetch, synthesise=_synth_two)
+
+    # The report's canonical bytes are stored under the anchored artifact_hash.
+    assert store.get(run.result.artifact_hash)
+
+    journal = EventJournal(run_id="run-r", sdd_dir=sdd)
+    dispatch_activity(run.result, stage_id="research-0", journal=journal)
+
+    # Offline: verification touches only the content store, no network.
+    verified = verify_run_activities(sdd, run_id="run-r", store=store)
+    assert verified.ok
+    stage = verified.stages[0]
+    assert stage.kind == "research"
+    assert stage.evidence_reattached
+    assert [c.claim_id for c in stage.claim_verdicts] == ["c1", "c2"]
+    assert all(c.ok for c in stage.claim_verdicts)
+
+
+def test_dispatch_mirrors_into_audit_chain(tmp_path: Path) -> None:
+    sdd = tmp_path / ".sdd"
+    store = ContentStore(sdd / "cas")
+    worker = ResearchWorker(store=store, budget=ResearchBudget(max_fetches=5))
+    run = worker.run(query="q", sources=["https://a", "https://b"], fetch_fn=_fetch, synthesise=_synth_two)
+
+    chain = AuditChainStore(tmp_path / "audit", key=b"0" * 32)
+    journal = EventJournal(run_id="run-r", sdd_dir=sdd)
+    dispatch_activity(run.result, stage_id="research-0", journal=journal, chain=chain)
+
+    rows = chain.query(event_type=EVENT_ACTIVITY_RESULT)
+    assert len(rows) == 1
+    details = rows[0].details
+    assert details["kind"] == "research"
+    assert details["artifact_hash"] == run.result.artifact_hash
+    # The chain never carries the report body, only its hash.
+    assert "claims" not in details
+
+
+def test_verify_fails_naming_claim_when_source_altered(tmp_path: Path) -> None:
+    sdd = tmp_path / ".sdd"
+    store = ContentStore(sdd / "cas")
+    worker = ResearchWorker(store=store, budget=ResearchBudget(max_fetches=5))
+    run = worker.run(query="q", sources=list(_PAGES), fetch_fn=_fetch, synthesise=_synth_two)
+    journal = EventJournal(run_id="run-r", sdd_dir=sdd)
+    dispatch_activity(run.result, stage_id="research-0", journal=journal)
+
+    tampered_hash = run.report.claims[0].citations[0].page_content_hash
+    store.force_put(tampered_hash, b"<html>rewritten, quote gone</html>")
+
+    verified = verify_run_activities(sdd, run_id="run-r", store=store)
+    assert not verified.ok
+    stage = verified.stages[0]
+    assert not stage.ok
+    # The failure names the claim and the mismatched hash.
+    assert "c1" in stage.reason
+    assert tampered_hash in stage.reason
+    failed = next(c for c in stage.claim_verdicts if not c.ok)
+    assert failed.claim_id == "c1"
+
+
+def test_two_verify_runs_produce_identical_verdicts(tmp_path: Path) -> None:
+    sdd = tmp_path / ".sdd"
+    store = ContentStore(sdd / "cas")
+    worker = ResearchWorker(store=store, budget=ResearchBudget(max_fetches=5))
+    run = worker.run(query="q", sources=list(_PAGES), fetch_fn=_fetch, synthesise=_synth_two)
+    journal = EventJournal(run_id="run-r", sdd_dir=sdd)
+    dispatch_activity(run.result, stage_id="research-0", journal=journal)
+
+    first = verify_run_activities(sdd, run_id="run-r", store=store)
+    second = verify_run_activities(sdd, run_id="run-r", store=store)
+    assert first.ok == second.ok
+    assert [
+        (s.stage_id, s.ok, s.reason, [(c.claim_id, c.ok, c.reason) for c in s.claim_verdicts]) for s in first.stages
+    ] == [(s.stage_id, s.ok, s.reason, [(c.claim_id, c.ok, c.reason) for c in s.claim_verdicts]) for s in second.stages]
+
+
+def test_research_runs_dispatch_next_to_coding_tasks_with_cost_caps(tmp_path: Path) -> None:
+    # A coding activity and a budgeted research activity anchor into the same run
+    # journal through the one deterministic dispatch path (AC4).
+    sdd = tmp_path / ".sdd"
+    store = ContentStore(sdd / "cas")
+    journal = EventJournal(run_id="run-mixed", sdd_dir=sdd)
+
+    coding = ActivityResult.build(
+        kind=ActivityKind.CODING,
+        artifact={"diff": "patch"},
+        observations=(Observation.of(kind="artifact", ref="spec", content=b"spec-bytes"),),
+        terminal_state=TerminalState.COMPLETED,
+        reason_code="ok",
+    )
+    dispatch_activity(coding, stage_id="coding-0", journal=journal)
+
+    worker = ResearchWorker(store=store, budget=ResearchBudget(max_fetches=2))
+    run = worker.run(query="q", sources=["https://a", "https://b"], fetch_fn=_fetch, synthesise=_synth_two)
+    dispatch_activity(run.result, stage_id="research-0", journal=journal)
+
+    verified = verify_run_activities(sdd, run_id="run-mixed", store=store)
+    kinds = {s.stage_id: s.kind for s in verified.stages}
+    assert kinds == {"coding-0": "coding", "research-0": "research"}
+    # The research stage stayed inside its 2-fetch cap.
+    assert len(run.fetched) == 2


### PR DESCRIPTION
Closes #2524.

## Problem
The activity boundary ships a RESEARCH modality and a `ResearchActivity` that content-addresses fetched pages at fetch time, but no worker produces research output: no planner, no multi-source gathering, no report format. Operators who want a sourced report run it outside the boundary and paste in unverifiable text, and a report whose sources have drifted (page edited, moved, rewritten) rots silently.

## What this adds
A research worker whose report is a citation-lineage artifact, not prose with links. Every claim carries at least one citation record (claim id, quoted span, and the `sha256:` content hash of the fetched page stored at fetch time). The report is content-addressed and anchored as the `artifact_hash` of the `ActivityResult` dispatched with `ActivityKind.RESEARCH`, and `bernstein activity verify` resolves every citation offline.

### Phase 1 - citation record model
- `research_report.py`: `CitationRecord` / `ResearchClaim` / `ResearchReport` using the boundary's canonical JSON hashing conventions.
- `validate_research_report` refuses a report with an uncited or malformed claim via the existing `ActivityRejected` path, before the result is built, so it never reaches the journal.

### Phase 2 - worker
- `research_worker.py`: `ResearchWorker` plans sources (pure, de-duplicated), fetches each through `ResearchActivity.fetch` so every page is content-addressed, applies a `ResearchBudget` cost cap, invokes an injected synthesiser (the stochastic step), assembles the report, stores its canonical bytes content-addressed, and dispatches through `dispatch_activity` - the same path coding tasks use - which mirrors the crossing into the audit chain.

### Phase 3 - offline verification
- `verify_run_activities` resolves citation lineage for a research stage: reattach each cited page by hash, re-hash to detect an altered source, confirm the quoted span occurs, emit per-claim verdicts.
- `bernstein activity verify` gains per-claim citation verdicts (text and JSON).

### Phase 4 - scheduling and docs
- Cost caps are enforced as a first-class refusal; a research run dispatches next to coding tasks under one run journal (test coverage).
- `docs/orchestration/research-activity.md`: citation model, boundary refusal, cost caps, offline verify.

## Acceptance criteria
- [x] Every claim carries at least one citation record; an uncited claim is refused at the boundary and never reaches the journal.
- [x] With no network, `activity verify` resolves every citation from the ContentStore and passes; altering one stored source page fails verification naming the claim and the mismatched hash; a links-in-markdown report cannot satisfy this.
- [x] The report artifact is content-addressed, anchored as `artifact_hash`, and mirrored into the audit chain.
- [x] Research runs schedule next to coding tasks under the deterministic dispatch path with cost caps applied.
- [x] Two verify runs over the same completed research run produce identical verdict output.

## SOTA axis proven empirically
Tamper test: `store.force_put` on a cited page makes `verify_run_activities` fail naming the claim (`c1`) and the mismatched hash; determinism test asserts two verify runs emit byte-identical verdicts. See `tests/unit/test_research_report.py` and `tests/unit/test_research_worker.py`.

## Scope boundary
Distinct from #2608 (contract) and #2523 (browser worker). Read-only study of the existing activity boundary / research modality / lineage / citation surfaces. Additive and behavior-preserving: existing modalities and the verify CLI keep their output shape (`claim_verdicts` defaults empty for non-research stages).

## Checks
ruff check + format clean; import-linter contracts kept; typos clean; vulture clean; new and existing activity suites green (`test_research_report`, `test_research_worker`, `test_activity_cmd`, `test_activity_modalities`, `test_activity_data_ops`, `test_activity_boundary`, `test_audit_chain_activity_result`).