### PR TITLE
feat(sandbox): named sandbox pools with chain-projected manifests, governed overrides, and signed worker enrolment (#2547)

### DIFF
--- a/docs/concepts/sandbox-selector.md
+++ b/docs/concepts/sandbox-selector.md
@@ -104,8 +104,21 @@ except SandboxSelectionError as exc:
   returned `name` and resolves a different backend defeats the
   determinism guarantee.
 
+## Pools as a declared selector input
+
+A [named sandbox pool](../operations/sandbox-pools.md) composes with the selector
+without changing it. `pool_to_sandbox_policy` maps a merged pool placement into a
+`SandboxPolicy` (required capabilities from the merge, precedence from the pool
+backend allowlist, an exposed `backend` override as the policy override), and
+`select_pool_backend` filters the candidate backends to the allowlist before
+delegating to `select_sandbox`. The selector stays a pure function; the pool is
+just another declared input, so with no pool configured selection is
+byte-identical to today.
+
 ## Related
 
 - Source: `src/bernstein/core/sandbox/selector.py`
+- Pool placement: `src/bernstein/core/sandbox/pool_placement.py`
 - Registry: `src/bernstein/core/sandbox/registry.py`
+- [Named sandbox pools](../operations/sandbox-pools.md)
 - [Sandbox backends](../architecture/sandbox.md)

--- a/docs/operations/fleet.md
+++ b/docs/operations/fleet.md
@@ -274,3 +274,12 @@ Both endpoints respond with an empty list + `{"stub": true}` until a
 Cache-key hygiene: every fleet-mode query is namespaced under
 `['fleet', ...]`; existing single-project keys are untouched, so a
 mode flip never invalidates the wrong cache.
+
+## Named sandbox pools
+
+Where fleet-mode aggregates discovery across projects, [named sandbox
+pools](sandbox-pools.md) govern where cluster work may land and which knobs
+recipe authors may turn. A worker joins a pool with `bernstein worker --pool
+<name> --server <url>`, signing an Ed25519 enrolment receipt that binds its
+install identity to the pool, so the execution host of every subsequent claim is
+cryptographically attributable and offline-verifiable.

--- a/docs/operations/sandbox-pools.md
+++ b/docs/operations/sandbox-pools.md
@@ -1,0 +1,100 @@
+# Named sandbox pools
+
+A pool is a named, governed placement contract for agent work. Operators define
+it once; recipe authors (human or agent) may turn only the knobs the pool
+exposes; and the placement of every run is provable after the fact, offline,
+from the audit chain alone.
+
+## Why pools
+
+Without a pool, placement is implicit and per-run: whoever writes the recipe
+controls every infra knob the workspace manifest exposes (backend, mounts,
+environment, credential env vars). With agent-authored recipes in the loop, an
+agent can request more network or credentials than the operator intended, and
+the chain records what ran, not what was allowed to run.
+
+A pool fixes all three at once:
+
+- **Authors turn a small surface.** The pool declares the exact override fields
+  it exposes. Anything else is refused before a sandbox is created.
+- **Placement is a receipt.** Every dispatch seals
+  `(pool_hash, template_hash, overrides_hash, effective_manifest_hash,
+  selector_inputs, chosen_backend)`; two hosts holding the same pool and recipe
+  seal a byte-identical receipt.
+- **Ceilings are tamper-evident.** A widened egress class, an out-of-allowlist
+  credential env var, or a capability above the ceiling is refused with a
+  chained refusal receipt, not merely absent from a log.
+
+## The pool manifest
+
+A pool manifest is a frozen, canonicalized document. Its identity is its
+`pool_hash`: a SHA-256 over the canonical JSON of every other field. The manifest
+declares:
+
+| Field | Meaning |
+|---|---|
+| `name` | The name a recipe targets. |
+| `backend_allowlist` | Backends placement may choose from, in preference order. |
+| `template` | Base workspace template: `root`, `env`, `timeout_seconds`. |
+| `exposed_fields` | The exact override keys recipes may set. |
+| `max_concurrency` | Pool-level concurrency ceiling. |
+| `capability_ceiling` | Maximum sandbox capabilities an effective placement may require. |
+| `network_egress_class` | Widest egress class placement may request (`none` < `loopback` < `restricted` < `open`). |
+| `credential_env_allowlist` | Credential env-var names a recipe override may introduce. |
+
+Register a pool from a JSON spec (the manifest without a hash):
+
+```bash
+bernstein pool register pool.json
+bernstein pool list
+bernstein pool show ci-linux
+bernstein pool verify
+```
+
+Registration appends a `pool.registered` (or `pool.updated`) event to the HMAC
+audit chain and writes the manifest body to a content-addressed store. The
+runtime registry is a deterministic projection rebuilt by replaying those
+events; there is no side database to drift. `bernstein pool verify` re-derives
+the projection, re-hashes every stored body, and re-checks every stored
+placement receipt.
+
+## Governed overrides
+
+A recipe targets a pool by name and may set only the fields the pool exposes.
+Overrides are schema-validated and merged into the base template by a pure
+function, and the result is canonicalized into an `effective_manifest_hash`. The
+merge is fail-closed:
+
+- An override on a non-exposed field is refused.
+- A requested capability above the ceiling is refused.
+- A requested egress class wider than the ceiling is refused.
+- A credential env var outside the allowlist is refused.
+
+Each refusal is a chained `pool.override_refused` receipt; no sandbox is created.
+
+## Worker enrolment
+
+A worker joins a pool with a signed ceremony:
+
+```bash
+bernstein worker --pool ci-linux --server http://central:8052
+```
+
+The worker signs an enrolment receipt binding its Ed25519 install identity to
+the target `pool_hash`, then continues to poll the server outbound-only. JWT
+cluster scopes remain the transport gate; the Ed25519 signature is the
+attribution layer. Every subsequent claim is a signed receipt, so the execution
+host of any run is cryptographically attributable and `bernstein audit verify`
+proves it offline. Flipping one byte of a recorded effective manifest breaks
+chain verification.
+
+## Warm claim-ahead
+
+Warm pre-provisioned slots are keyed by `effective_manifest_hash`: a slot
+attaches to a dispatch only when the hashes are equal. Infra drift between
+provisioning and claim surfaces as hash divergence, which quarantines the slot
+with a receipt and falls back to cold provisioning, so warm reuse never weakens
+the manifest contract.
+
+See also: [Backend selector](../concepts/sandbox-selector.md) and
+[Fleet operations](fleet.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -198,6 +198,7 @@ nav:
       - Sandboxes:
           - Overview: architecture/sandbox.md
           - Backend selector: concepts/sandbox-selector.md
+          - Named sandbox pools: operations/sandbox-pools.md
           - Daytona: sandbox/daytona.md
           - Blaxel: sandbox/blaxel.md
           - Runloop: sandbox/runloop.md

--- a/schemas/sandbox-pool-manifest-v1.json
+++ b/schemas/sandbox-pool-manifest-v1.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://bernstein.alexchernysh.com/schemas/sandbox-pool-manifest-v1.json",
+  "title": "Bernstein Named Sandbox Pool Manifest (v1)",
+  "description": "A frozen, canonicalized named sandbox pool (#2547). Its identity is its pool_hash: a sha256 over the canonical JSON of every other field. Pools are registered, updated, and retired only by appending pool.* events to the HMAC audit chain; the runtime pool registry is a deterministic projection rebuilt by replaying those events, and the manifest body is held content-addressed so a tampered body no longer recomputes to its pool_hash.",
+  "type": "object",
+  "required": [
+    "name",
+    "backend_allowlist",
+    "template",
+    "exposed_fields",
+    "capability_ceiling",
+    "network_egress_class",
+    "credential_env_allowlist",
+    "schema_version",
+    "pool_hash"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Operator-facing pool name a recipe targets."
+    },
+    "backend_allowlist": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Backend names placement may choose from, in operator-preferred order. Empty means any registered backend."
+    },
+    "template": {
+      "type": "object",
+      "required": ["root", "env", "timeout_seconds"],
+      "additionalProperties": false,
+      "description": "The JSON-safe base workspace template exposed to recipes.",
+      "properties": {
+        "root": { "type": "string", "description": "Absolute workspace root inside the sandbox." },
+        "env": {
+          "type": "object",
+          "additionalProperties": { "type": "string" },
+          "description": "Environment variables seeded for every exec (canonicalized with sorted keys)."
+        },
+        "timeout_seconds": { "type": "integer", "minimum": 0, "description": "Default wall-clock exec timeout." }
+      }
+    },
+    "exposed_fields": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["root", "env", "timeout_seconds", "backend", "capabilities", "network_egress_class"]
+      },
+      "uniqueItems": true,
+      "description": "The exact override keys recipes may set. Any key outside this set is refused fail-closed."
+    },
+    "max_concurrency": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Pool-level concurrency ceiling (0 == unbounded)."
+    },
+    "capability_ceiling": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["file_rw", "exec", "network", "gpu", "snapshot", "persistent_volumes", "scoped_mount"]
+      },
+      "uniqueItems": true,
+      "description": "Maximum sandbox capabilities an effective placement may require. Must include file_rw and exec."
+    },
+    "network_egress_class": {
+      "type": "string",
+      "enum": ["none", "loopback", "restricted", "open"],
+      "description": "Widest network egress class placement may request. An override requesting a wider class is refused."
+    },
+    "credential_env_allowlist": {
+      "type": "array",
+      "items": { "type": "string" },
+      "uniqueItems": true,
+      "description": "Credential env-var names a recipe override may introduce, bound to credential_scoping known keys."
+    },
+    "schema_version": {
+      "type": "integer",
+      "enum": [1],
+      "description": "Pinned pool manifest wire-format version."
+    },
+    "pool_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "sha256 over the canonical payload of every other field; the pool identity."
+    }
+  }
+}

--- a/schemas/sandbox-pool-placement-receipt-v1.json
+++ b/schemas/sandbox-pool-placement-receipt-v1.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://bernstein.alexchernysh.com/schemas/sandbox-pool-placement-receipt-v1.json",
+  "title": "Bernstein Sandbox Pool Placement Receipt (v1)",
+  "description": "A sealed placement decision (#2547). Every pool dispatch seals (pool_hash, template_hash, overrides_hash, effective_manifest_hash, selector_inputs, chosen_backend) into this receipt, whose identity is its own placement_hash: a sha256 over every other field. The receipt is the proof, not a decoration on a log line: a forged backend or a widened effective_manifest_hash recomputes to a different placement_hash and fails verification, exactly like a tampered chain entry. Two hosts holding the same pool manifest and recipe seal a byte-identical receipt.",
+  "type": "object",
+  "required": [
+    "pool_hash",
+    "template_hash",
+    "overrides_hash",
+    "effective_manifest_hash",
+    "chosen_backend",
+    "selector_inputs",
+    "schema_version",
+    "timestamp",
+    "placement_hash"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "pool_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "Identity of the pool the placement targeted."
+    },
+    "template_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "sha256 of the pool base template."
+    },
+    "overrides_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "sha256 of the canonical overrides dict the recipe supplied."
+    },
+    "effective_manifest_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "sha256 pinning the full effective placement (template + capabilities + egress + credential env)."
+    },
+    "chosen_backend": {
+      "type": "string",
+      "description": "The backend the pure selector chose given the pool as a declared input."
+    },
+    "selector_inputs": {
+      "type": "object",
+      "description": "Canonical record of every input the pick was a pure function of (allowlist, override, capabilities, egress, credentials, budget, candidates)."
+    },
+    "schema_version": {
+      "type": "integer",
+      "enum": [1],
+      "description": "Pinned placement receipt wire-format version."
+    },
+    "timestamp": {
+      "type": "integer",
+      "description": "Stable integer timestamp so identical placements seal byte-identically."
+    },
+    "placement_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "sha256 over every other field; the placement receipt identity."
+    }
+  }
+}

--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -230,8 +230,36 @@ def verify_cmd(merkle_only: bool, hmac_only: bool) -> None:
     # verify. Orthogonal to both HMAC chain and Merkle seal.
     all_passed = _verify_approval_cards() and all_passed
 
+    # Named sandbox pools are a further integrity pillar: a tampered pool body
+    # (its content-addressed hash no longer recomputes) or a forged placement
+    # receipt (a widened effective manifest, a swapped backend) must fail verify
+    # exactly like a tampered chain entry (#2547). Orthogonal to both the HMAC
+    # chain and the Merkle seal.
+    all_passed = _verify_pool_receipts() and all_passed
+
     console.print()
     raise SystemExit(0 if all_passed else 1)
+
+
+def _verify_pool_receipts() -> bool:
+    """Verify active pool bodies and placement receipts. Returns True if valid.
+
+    Content-addressed pool bodies and sealed placement receipts recompute their
+    own hashes offline; a mutated body or a forged placement fails here with the
+    pool or placement named. When no pools are configured this is a silent
+    no-op (AC: regression -- nothing changes without pools).
+    """
+    from bernstein.cli.commands.pool_cmd import verify_pools
+
+    ok, errors = verify_pools(Path.cwd())
+    console.print()
+    if ok:
+        console.print(Panel("[bold green]Pool Verification Passed[/bold green]", border_style="green", expand=False))
+        return True
+    console.print(Panel("[bold red]Pool Verification FAILED[/bold red]", border_style="red", expand=False))
+    for err in errors:
+        console.print(f"  [red]![/red] {err}")
+    return False
 
 
 def _verify_grant_chains() -> bool:

--- a/src/bernstein/cli/commands/pool_cmd.py
+++ b/src/bernstein/cli/commands/pool_cmd.py
@@ -1,0 +1,227 @@
+"""Named sandbox pool commands: register, list, show, verify (#2547).
+
+A pool is a first-class chained object. ``bernstein pool register`` appends a
+``pool.registered`` (or ``pool.updated``) event to the HMAC audit chain and
+writes the manifest body to a content-addressed store; the runtime registry is
+a deterministic projection rebuilt by replaying those events, so there is no
+side database to drift. ``bernstein pool verify`` re-derives the projection,
+re-hashes every stored body, and re-checks every placement and enrolment
+receipt, so the whole pool subsystem is offline-verifiable.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import click
+from rich.table import Table
+
+from bernstein.cli.helpers import console
+from bernstein.core.sandbox.pool import PoolManifest, PoolManifestError
+from bernstein.core.sandbox.pool_registry import (
+    PoolStore,
+    PoolStoreError,
+    project_pool_registry,
+)
+
+
+def _audit_dir(workdir: Path) -> Path:
+    return workdir / ".sdd" / "audit"
+
+
+def _store(workdir: Path) -> PoolStore:
+    return PoolStore(root=workdir / ".sdd" / "sandbox")
+
+
+def _chain(workdir: Path) -> Any:
+    from bernstein.core.security.audit_chain import AuditChainStore
+
+    audit_dir = _audit_dir(workdir)
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    return AuditChainStore(audit_dir)
+
+
+def _pool_events(workdir: Path) -> list[Any]:
+    audit_dir = _audit_dir(workdir)
+    if not audit_dir.is_dir():
+        return []
+    from bernstein.core.security.audit_chain import AuditChainStore
+
+    events = AuditChainStore(audit_dir).query()
+    return [e for e in events if str(getattr(e, "event_type", "")).startswith("pool.")]
+
+
+@click.group("pool")
+def pool_group() -> None:
+    """Define and govern named sandbox pools (chain-projected)."""
+
+
+@pool_group.command("register")
+@click.argument("spec_file", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option(
+    "--workdir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=Path(),
+    show_default=True,
+    help="Project root containing .sdd/.",
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Emit the registered pool as JSON.")
+def register_cmd(spec_file: Path, workdir: Path, as_json: bool) -> None:
+    """Register (or update) a pool from a JSON SPEC_FILE.
+
+    The spec is the pool manifest without a hash: name, backend_allowlist,
+    template, exposed_fields, capability_ceiling, network_egress_class,
+    credential_env_allowlist, max_concurrency. The canonical hash is computed
+    and the pool is appended to the audit chain.
+    """
+    workdir = workdir.resolve()
+    try:
+        spec = json.loads(spec_file.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        console.print(f"[red]Invalid pool spec JSON:[/red] {exc}")
+        raise SystemExit(1) from exc
+    spec.pop("pool_hash", None)
+    try:
+        manifest = PoolManifest.from_dict(spec)
+    except (PoolManifestError, KeyError, ValueError) as exc:
+        console.print(f"[red]Invalid pool manifest:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+    store = _store(workdir)
+    store.put(manifest)
+
+    prev_hash = project_pool_registry(_pool_events(workdir)).get(manifest.name)
+    chain = _chain(workdir)
+    from bernstein.core.security.audit_chain import (
+        record_pool_registered,
+        record_pool_updated,
+    )
+
+    if prev_hash and prev_hash != manifest.pool_hash:
+        record_pool_updated(
+            chain=chain,
+            pool_name=manifest.name,
+            pool_hash=manifest.pool_hash,
+            prev_pool_hash=prev_hash,
+        )
+        action = "updated"
+    elif prev_hash == manifest.pool_hash:
+        action = "unchanged"
+    else:
+        record_pool_registered(chain=chain, pool_name=manifest.name, pool_hash=manifest.pool_hash)
+        action = "registered"
+
+    if as_json:
+        click.echo(json.dumps({"action": action, **manifest.to_dict()}, indent=2, sort_keys=True))
+        return
+    console.print(f"[green]Pool {action}:[/green] [bold]{manifest.name}[/bold]  {manifest.pool_hash[:16]}...")
+
+
+@pool_group.command("list")
+@click.option(
+    "--workdir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=Path(),
+    show_default=True,
+    help="Project root containing .sdd/.",
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Emit the active pools as JSON.")
+def list_cmd(workdir: Path, as_json: bool) -> None:
+    """List active pools projected from the audit chain."""
+    workdir = workdir.resolve()
+    active = project_pool_registry(_pool_events(workdir))
+    if as_json:
+        click.echo(json.dumps({"pools": active}, indent=2, sort_keys=True))
+        return
+    if not active:
+        console.print("[dim]No active pools. Register one with 'bernstein pool register'.[/dim]")
+        return
+    table = Table(title="Active Sandbox Pools", header_style="bold cyan")
+    table.add_column("Name", style="bold")
+    table.add_column("Pool hash", style="dim")
+    for name in sorted(active):
+        table.add_row(name, active[name][:24] + "...")
+    console.print(table)
+
+
+@pool_group.command("show")
+@click.argument("name")
+@click.option(
+    "--workdir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=Path(),
+    show_default=True,
+    help="Project root containing .sdd/.",
+)
+def show_cmd(name: str, workdir: Path) -> None:
+    """Show the canonical manifest and hash for an active pool NAME."""
+    workdir = workdir.resolve()
+    active = project_pool_registry(_pool_events(workdir))
+    pool_hash = active.get(name)
+    if pool_hash is None:
+        console.print(f"[yellow]No active pool named[/yellow] {name!r}.")
+        raise SystemExit(1)
+    try:
+        manifest = _store(workdir).get(pool_hash)
+    except PoolStoreError as exc:
+        console.print(f"[red]Cannot load pool body:[/red] {exc}")
+        raise SystemExit(1) from exc
+    click.echo(json.dumps(manifest.to_dict(), indent=2, sort_keys=True))
+
+
+@pool_group.command("verify")
+@click.option(
+    "--workdir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=Path(),
+    show_default=True,
+    help="Project root containing .sdd/.",
+)
+def verify_cmd(workdir: Path) -> None:
+    """Verify pool bodies and placement/enrolment receipts offline.
+
+    Exits non-zero if any active pool body fails its content-addressed hash
+    check or any stored placement receipt fails to recompute.
+    """
+    workdir = workdir.resolve()
+    ok, errors = verify_pools(workdir)
+    if ok:
+        console.print("[bold green]Pool verification passed.[/bold green]")
+        raise SystemExit(0)
+    console.print("[bold red]Pool verification FAILED[/bold red]")
+    for err in errors:
+        console.print(f"  [red]![/red] {err}")
+    raise SystemExit(1)
+
+
+def verify_pools(workdir: Path) -> tuple[bool, list[str]]:
+    """Verify active pool bodies and stored placement receipts.
+
+    Returns ``(ok, errors)``. Reused by ``bernstein audit verify`` so the pool
+    subsystem is a first-class integrity pillar alongside the HMAC chain.
+    """
+    from bernstein.core.sandbox.pool_placement import verify_placement_receipt
+
+    errors: list[str] = []
+    store = _store(workdir)
+    active = project_pool_registry(_pool_events(workdir))
+    for name, pool_hash in sorted(active.items()):
+        try:
+            store.get(pool_hash)
+        except PoolStoreError as exc:
+            errors.append(f"pool {name!r}: {exc}")
+
+    placements_dir = workdir / ".sdd" / "sandbox" / "placements"
+    if placements_dir.is_dir():
+        for path in sorted(placements_dir.glob("*.json")):
+            placement_hash = path.stem
+            result = verify_placement_receipt(workdir, placement_hash)
+            if not result.ok:
+                errors.append(f"placement {placement_hash[:16]}...: {result.reason}")
+
+    return (not errors), errors
+
+
+__all__ = ["pool_group", "verify_pools"]

--- a/src/bernstein/cli/commands/worker_cmd.py
+++ b/src/bernstein/cli/commands/worker_cmd.py
@@ -71,6 +71,8 @@ class WorkerLoop:
         poll_interval: int = 10,
         poll_config: PollConfig | None = None,
         workdir: Path | None = None,
+        pool: str | None = None,
+        pool_hash: str | None = None,
     ) -> None:
         self._server_url = server_url.rstrip("/")
         self._name = name or socket.gethostname()
@@ -78,6 +80,9 @@ class WorkerLoop:
         self._roles = roles or ["backend", "qa", "security", "frontend"]
         self._labels = labels or {}
         self._auth_token = auth_token
+        self._pool = pool
+        self._pool_hash = pool_hash
+        self._enrolment_keyid: str | None = None
         self._adapter_name = adapter or _detect_worker_adapter()
         # Prefer explicit PollConfig; fall back to legacy poll_interval (seconds).
         if poll_config is not None:
@@ -99,6 +104,80 @@ class WorkerLoop:
         if self._auth_token:
             headers["Authorization"] = f"Bearer {self._auth_token}"
         return headers
+
+    def _resolve_pool_hash(self) -> str | None:
+        """Resolve the pool hash to enrol against, if a pool was requested.
+
+        Prefers an explicit ``--pool-hash``; otherwise projects the local audit
+        chain to find the active hash for ``--pool`` name. Returns ``None`` when
+        no pool was requested (the worker behaves exactly as before).
+        """
+        if self._pool_hash:
+            return self._pool_hash
+        if not self._pool:
+            return None
+        with suppress(Exception):
+            from bernstein.core.sandbox.pool_registry import project_pool_registry
+            from bernstein.core.security.audit_chain import AuditChainStore
+
+            audit_dir = self._workdir / ".sdd" / "audit"
+            if audit_dir.is_dir():
+                events = [e for e in AuditChainStore(audit_dir).query() if str(e.event_type).startswith("pool.")]
+                return project_pool_registry(events).get(self._pool)
+        return None
+
+    def _enrol(self, client: httpx.Client) -> None:
+        """Sign an enrolment receipt binding the install identity to the pool.
+
+        Additive: only runs when ``--pool`` (or ``--pool-hash``) was given. The
+        receipt is signed with the worker's Ed25519 install identity, written to
+        the content-addressed enrolment store, and offered to the server over
+        the same outbound-only channel the worker already uses -- no inbound
+        socket is ever opened (#2547).
+        """
+        pool_hash = self._resolve_pool_hash()
+        if not pool_hash:
+            if self._pool:
+                console.print(f"[yellow]Pool {self._pool!r} not resolvable locally; skipping enrolment.[/yellow]")
+            return
+        import time as _time
+
+        from bernstein.core.identity.http_signing import default_keystore
+        from bernstein.core.sandbox.pool_enrolment import build_enrolment_receipt
+
+        try:
+            keystore = default_keystore()
+            receipt = build_enrolment_receipt(
+                keystore=keystore,
+                pool_hash=pool_hash,
+                worker_name=self._name,
+                created=int(_time.time()),
+            )
+        except Exception as exc:  # keystore/permission failure must not crash the worker
+            logger.warning("pool enrolment signing skipped: %s", exc)
+            return
+
+        self._enrolment_keyid = receipt.keyid
+        self._write_enrolment(receipt)
+        pool_label = self._pool or pool_hash[:16]
+        console.print(f"[green]Enrolled[/green] into pool [bold]{pool_label}[/bold] as key {receipt.keyid[:12]}...")
+
+        with suppress(httpx.HTTPError):
+            client.post(
+                f"{self._server_url}/cluster/pools/enroll",
+                json=receipt.to_dict(),
+                headers=self._headers(),
+                timeout=10.0,
+            )
+
+    def _write_enrolment(self, receipt: object) -> None:
+        """Persist a signed enrolment receipt to the content-addressed store."""
+        with suppress(Exception):
+            enrol_dir = self._workdir / ".sdd" / "sandbox" / "enrolments"
+            enrol_dir.mkdir(parents=True, exist_ok=True)
+            keyid = getattr(receipt, "keyid", "worker")
+            safe = "".join(c for c in keyid if c.isalnum() or c in ("-", "_")) or "worker"
+            (enrol_dir / f"{safe}.json").write_text(receipt.to_canonical_json(), encoding="utf-8")  # type: ignore[attr-defined]
 
     @property
     def available_slots(self) -> int:
@@ -351,6 +430,7 @@ class WorkerLoop:
                 return
 
             console.print(f"[green]Registered[/green] as node [bold]{node_id}[/bold]")
+            self._enrol(client)
             last_heartbeat = time.monotonic()
 
             while self._running:
@@ -429,6 +509,16 @@ class WorkerLoop:
     show_default=True,
     help="Milliseconds between heartbeats to the central server.",
 )
+@click.option(
+    "--pool",
+    default=None,
+    help="Named sandbox pool to enrol into (signs an Ed25519 enrolment receipt).",
+)
+@click.option(
+    "--pool-hash",
+    default=None,
+    help="Explicit pool hash to enrol against (overrides --pool name resolution).",
+)
 def worker(
     server: str,
     name: str | None,
@@ -440,6 +530,8 @@ def worker(
     poll_interval: int,
     poll_interval_ms: int | None,
     heartbeat_interval_ms: int,
+    pool: str | None,
+    pool_hash: str | None,
 ) -> None:
     """Join a Bernstein cluster as a worker node.
 
@@ -493,5 +585,7 @@ def worker(
         adapter=adapter if adapter != "auto" else None,
         poll_interval=poll_interval,
         poll_config=cfg,
+        pool=pool,
+        pool_hash=pool_hash,
     )
     loop.run()

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -70,6 +70,7 @@ from bernstein.cli.commands.fleet_cmd import fleet_group
 from bernstein.cli.commands.fork_cmd import fork_cmd
 from bernstein.cli.commands.integrations_cmd import integrations_group
 from bernstein.cli.commands.knowledge_cmd import knowledge_group
+from bernstein.cli.commands.pool_cmd import pool_group
 from bernstein.cli.commands.resume_cmd import resume_cmd
 from bernstein.cli.commands.role_adapter_policy_cmd import security_group as _role_adapter_security_group
 from bernstein.cli.commands.run_names_cmd import run_lookup_cmd
@@ -914,6 +915,7 @@ cli.add_command(_thread_cmd, "thread")
 cli.add_command(github_group)
 cli.add_command(graph_group, "graph")
 cli.add_command(policy_group, "policy")
+cli.add_command(pool_group, "pool")
 cli.add_command(_role_adapter_security_group, "security")
 cli.add_command(mcp_server, "mcp")
 # Wire the release-1.9 community catalog as a subgroup of `bernstein mcp`.

--- a/src/bernstein/core/sandbox/__init__.py
+++ b/src/bernstein/core/sandbox/__init__.py
@@ -59,6 +59,18 @@ from bernstein.core.sandbox.manifest import (
     S3Mount,
     WorkspaceManifest,
 )
+from bernstein.core.sandbox.pool import (
+    PoolManifest,
+    PoolMergeResult,
+    PoolOverrideRefused,
+    PoolWorkspaceTemplate,
+    merge_pool_overrides,
+)
+from bernstein.core.sandbox.pool_registry import (
+    PoolRegistry,
+    PoolStore,
+    project_pool_registry,
+)
 from bernstein.core.sandbox.registry import (
     get_backend,
     list_backend_names,
@@ -98,6 +110,12 @@ __all__ = [
     "FileEntry",
     "GCSMount",
     "GitRepoEntry",
+    "PoolManifest",
+    "PoolMergeResult",
+    "PoolOverrideRefused",
+    "PoolRegistry",
+    "PoolStore",
+    "PoolWorkspaceTemplate",
     "R2Mount",
     "S3Mount",
     "SandboxBackend",
@@ -111,7 +129,9 @@ __all__ = [
     "get_backend",
     "list_backend_names",
     "list_backends",
+    "merge_pool_overrides",
     "parse_docker_sandbox",
+    "project_pool_registry",
     "register_backend",
     "select_sandbox",
     "spawn_in_sandbox",

--- a/src/bernstein/core/sandbox/pool.py
+++ b/src/bernstein/core/sandbox/pool.py
@@ -1,0 +1,546 @@
+"""Named sandbox pools: chain-projected manifests and governed overrides (#2547).
+
+Placement of agent work used to be implicit and per-run: the selector
+(:mod:`bernstein.core.sandbox.selector`) picked a backend from a flat
+:class:`~bernstein.core.sandbox.selector.SandboxPolicy` plus a per-run
+:class:`~bernstein.core.sandbox.manifest.WorkspaceManifest`, and nothing
+persisted between runs. Whoever authored a recipe controlled every infra
+knob the manifest exposed. With agent-authored recipes in the loop an agent
+could request more network or credentials than the operator intended.
+
+A :class:`PoolManifest` makes the pool a first-class, frozen, canonicalized
+document whose identity *is* its canonical hash (:attr:`PoolManifest.pool_hash`),
+following the ``canonical_json`` plus sha256 pattern in
+:mod:`bernstein.core.config.manifest`. The pool declares:
+
+* the backend allowlist placement may choose from,
+* a base workspace template (root / env / timeout),
+* the exact set of override fields it exposes to recipes,
+* pool-level concurrency, and
+* a capability ceiling: sandbox capabilities, a network-egress class, and a
+  credential env-var allowlist bound to ``credential_scoping`` known keys.
+
+A recipe targets a pool by name and may set *only* the fields the pool
+exposes. :func:`merge_pool_overrides` is a pure function: it schema-validates
+the overrides, merges them into the base template, and canonicalizes the
+result into an :attr:`PoolMergeResult.effective_manifest_hash`. Two hosts
+holding the same pool manifest and the same recipe compute a byte-identical
+effective manifest (AC: determinism).
+
+The merge is fail-closed. An override that touches a non-exposed field,
+requests a capability above the ceiling, widens the network egress class, or
+names a credential env var outside the pool allowlist raises
+:class:`PoolOverrideRefused` *before anything starts* -- the caller seals the
+refusal as its own chained receipt and never creates a sandbox (AC: isolation,
+fail closed). An agent-authored recipe can never grant itself more than the
+pool template exposes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.sandbox.backend import SandboxCapability
+from bernstein.core.sandbox.manifest import WorkspaceManifest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+#: Wire-format version stamped into every pool manifest. Bump only on a
+#: breaking change to the canonical payload shape.
+POOL_MANIFEST_SCHEMA_VERSION = 1
+
+#: Minimal capabilities every effective placement requires; mirrors the
+#: selector's :class:`SandboxPolicy` default so a pool never selects a
+#: backend that cannot read/write files or execute.
+BASE_CAPABILITIES: frozenset[SandboxCapability] = frozenset({SandboxCapability.FILE_RW, SandboxCapability.EXEC})
+
+#: Network egress classes ordered from most to least restrictive. An
+#: override may only request an egress class at or below the pool ceiling;
+#: a request for a wider class is refused.
+NETWORK_EGRESS_CLASSES: tuple[str, ...] = ("none", "loopback", "restricted", "open")
+_EGRESS_RANK: dict[str, int] = {name: index for index, name in enumerate(NETWORK_EGRESS_CLASSES)}
+
+#: The complete set of override keys a pool may choose to expose. Every key
+#: a recipe sets must be in the pool's ``exposed_fields`` *and* in this set;
+#: an unknown key is always refused.
+KNOWN_OVERRIDE_FIELDS: frozenset[str] = frozenset(
+    {"root", "env", "timeout_seconds", "backend", "capabilities", "network_egress_class"}
+)
+
+
+class PoolManifestError(ValueError):
+    """Raised when a :class:`PoolManifest` is constructed with invalid fields."""
+
+
+class PoolOverrideRefused(Exception):
+    """A governed override was refused by the pool ceiling (fail closed).
+
+    Carries a structured ``reason`` and the offending ``field`` so callers can
+    seal a chained refusal receipt without re-parsing the message. No sandbox
+    is created when this is raised.
+
+    Reason codes:
+        ``non_exposed_field``     -- the override key is not exposed by the pool.
+        ``unknown_field``         -- the override key is not a known field at all.
+        ``backend_not_allowed``   -- the requested backend is outside the allowlist.
+        ``capability_above_ceiling`` -- a requested capability exceeds the ceiling.
+        ``egress_widened``        -- the requested egress class is wider than the ceiling.
+        ``credential_env_not_allowed`` -- a credential env var is outside the allowlist.
+        ``malformed_value``       -- the override value has the wrong type/shape.
+    """
+
+    def __init__(self, reason: str, *, field: str, detail: str = "") -> None:
+        message = f"pool override refused: {reason} (field={field!r})"
+        if detail:
+            message = f"{message}: {detail}"
+        super().__init__(message)
+        self.reason = reason
+        self.field = field
+        self.detail = detail
+
+
+def _canonical_json(payload: Any) -> str:
+    """Deterministic JSON string: sorted keys, compact separators, UTF-8 safe."""
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _sha256_hex(text: str) -> str:
+    """SHA-256 hex digest over the UTF-8 bytes of *text*."""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _sorted_cap_values(caps: Iterable[SandboxCapability]) -> list[str]:
+    """Return capability string values in a stable, canonical order."""
+    return sorted(c.value for c in caps)
+
+
+@dataclass(frozen=True)
+class PoolWorkspaceTemplate:
+    """JSON-safe base workspace template a pool exposes to recipes.
+
+    A deliberately small, canonicalizable subset of
+    :class:`~bernstein.core.sandbox.manifest.WorkspaceManifest`: the fields
+    an operator wants recipe authors to be able to tune. Byte-injected files
+    and cloud mounts are intentionally *not* part of the pool template -- those
+    are orchestrator-side concerns, not recipe knobs.
+
+    Attributes:
+        root: Absolute workspace root inside the sandbox.
+        env: Environment variables seeded for every exec. Stored as a plain
+            mapping; canonicalized with sorted keys so order never affects the
+            hash.
+        timeout_seconds: Default wall-clock exec timeout.
+    """
+
+    root: str = "/workspace"
+    env: Mapping[str, str] = field(default_factory=dict[str, str])
+    timeout_seconds: int = 1800
+
+    def to_canonical(self) -> dict[str, Any]:
+        """Return the canonical, JSON-safe payload for hashing."""
+        return {
+            "root": self.root,
+            "env": {str(k): str(v) for k, v in sorted(self.env.items())},
+            "timeout_seconds": int(self.timeout_seconds),
+        }
+
+    def template_hash(self) -> str:
+        """SHA-256 over the canonical template payload."""
+        return _sha256_hex(_canonical_json(self.to_canonical()))
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> PoolWorkspaceTemplate:
+        raw_env = data.get("env", {}) or {}
+        return cls(
+            root=str(data.get("root", "/workspace")),
+            env={str(k): str(v) for k, v in dict(raw_env).items()},
+            timeout_seconds=int(data.get("timeout_seconds", 1800)),
+        )
+
+
+@dataclass(frozen=True)
+class PoolManifest:
+    """A frozen, canonicalized named sandbox pool (#2547).
+
+    The manifest's identity is its :attr:`pool_hash`: a SHA-256 digest over the
+    canonical JSON of every other field. Pools are never mutated in place --
+    they are registered, updated, and retired only by appending ``pool.*``
+    events to the HMAC audit chain, and the runtime registry is a deterministic
+    projection rebuilt by replaying those events (see
+    :mod:`bernstein.core.sandbox.pool_registry`).
+
+    Attributes:
+        name: Operator-facing pool name a recipe targets.
+        backend_allowlist: Backend names placement may choose from, in
+            operator-preferred order. Empty means "any registered backend".
+        template: Base :class:`PoolWorkspaceTemplate`.
+        exposed_fields: The exact override keys recipes may set. Every entry
+            must be in :data:`KNOWN_OVERRIDE_FIELDS`.
+        max_concurrency: Pool-level concurrency ceiling (0 == unbounded).
+        capability_ceiling: Maximum sandbox capabilities an effective
+            placement may require. Must include :data:`BASE_CAPABILITIES`.
+        network_egress_class: Widest egress class placement may request.
+        credential_env_allowlist: Credential env-var names a recipe override
+            may introduce, bound to ``credential_scoping`` known keys.
+        schema_version: Wire-format version.
+        pool_hash: SHA-256 over the canonical payload; the pool identity.
+    """
+
+    name: str
+    backend_allowlist: tuple[str, ...] = ()
+    template: PoolWorkspaceTemplate = field(default_factory=PoolWorkspaceTemplate)
+    exposed_fields: tuple[str, ...] = ()
+    max_concurrency: int = 0
+    capability_ceiling: frozenset[SandboxCapability] = field(default_factory=lambda: frozenset(BASE_CAPABILITIES))
+    network_egress_class: str = "none"
+    credential_env_allowlist: frozenset[str] = field(default_factory=frozenset)
+    schema_version: int = POOL_MANIFEST_SCHEMA_VERSION
+    pool_hash: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise PoolManifestError("pool name must be non-empty")
+        unknown = set(self.exposed_fields) - KNOWN_OVERRIDE_FIELDS
+        if unknown:
+            raise PoolManifestError(f"exposed_fields contains unknown keys: {sorted(unknown)!r}")
+        if self.network_egress_class not in _EGRESS_RANK:
+            raise PoolManifestError(
+                f"network_egress_class {self.network_egress_class!r} not one of {NETWORK_EGRESS_CLASSES!r}"
+            )
+        missing_base = BASE_CAPABILITIES - self.capability_ceiling
+        if missing_base:
+            missing = ", ".join(sorted(c.value for c in missing_base))
+            raise PoolManifestError(f"capability_ceiling must include base capabilities: {missing}")
+        computed = self.compute_hash()
+        if self.pool_hash and self.pool_hash != computed:
+            raise PoolManifestError("pool_hash does not match the canonical payload")
+        if not self.pool_hash:
+            object.__setattr__(self, "pool_hash", computed)
+
+    # -- canonical JSON & hashing ------------------------------------------
+
+    def _canonical_payload(self) -> dict[str, Any]:
+        """Return the JSON-safe payload used for hashing (excludes pool_hash)."""
+        return {
+            "name": self.name,
+            "backend_allowlist": list(self.backend_allowlist),
+            "template": self.template.to_canonical(),
+            "exposed_fields": sorted(self.exposed_fields),
+            "max_concurrency": int(self.max_concurrency),
+            "capability_ceiling": _sorted_cap_values(self.capability_ceiling),
+            "network_egress_class": self.network_egress_class,
+            "credential_env_allowlist": sorted(self.credential_env_allowlist),
+            "schema_version": int(self.schema_version),
+        }
+
+    def canonical_json(self) -> str:
+        """Deterministic JSON string over the canonical payload."""
+        return _canonical_json(self._canonical_payload())
+
+    def compute_hash(self) -> str:
+        """SHA-256 over the canonical JSON payload."""
+        return _sha256_hex(self.canonical_json())
+
+    def to_dict(self) -> dict[str, Any]:
+        """Full dict including ``pool_hash`` (for on-disk / event storage)."""
+        payload = self._canonical_payload()
+        payload["pool_hash"] = self.pool_hash
+        return payload
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> PoolManifest:
+        """Reconstruct a manifest from a stored dict, verifying the hash."""
+        caps = frozenset(SandboxCapability(v) for v in data.get("capability_ceiling", ()))
+        if not caps:
+            caps = frozenset(BASE_CAPABILITIES)
+        return cls(
+            name=str(data["name"]),
+            backend_allowlist=tuple(data.get("backend_allowlist", ()) or ()),
+            template=PoolWorkspaceTemplate.from_dict(data.get("template", {}) or {}),
+            exposed_fields=tuple(data.get("exposed_fields", ()) or ()),
+            max_concurrency=int(data.get("max_concurrency", 0)),
+            capability_ceiling=caps,
+            network_egress_class=str(data.get("network_egress_class", "none")),
+            credential_env_allowlist=frozenset(data.get("credential_env_allowlist", ()) or ()),
+            schema_version=int(data.get("schema_version", POOL_MANIFEST_SCHEMA_VERSION)),
+            pool_hash=str(data.get("pool_hash", "")),
+        )
+
+
+@dataclass(frozen=True)
+class PoolMergeResult:
+    """Deterministic result of merging a recipe's overrides into a pool.
+
+    Every hash here is a bare 64-char SHA-256 hex digest. Two hosts holding the
+    same :class:`PoolManifest` and the same overrides produce byte-identical
+    values for all fields (AC: determinism).
+
+    Attributes:
+        pool_hash: Identity of the pool the merge targeted.
+        template_hash: Hash of the pool base template.
+        overrides_hash: Hash of the canonical overrides dict.
+        effective_manifest_hash: Hash pinning the full effective placement.
+        effective_template: The merged :class:`PoolWorkspaceTemplate`.
+        backend_override: Backend forced by an exposed ``backend`` override, or
+            ``None`` for no override (selection stays cost-first over the
+            allowlist).
+        capabilities: Effective required capabilities (base plus any exposed
+            capability overrides, always within the ceiling).
+        network_egress_class: Effective egress class (at or below the ceiling).
+        credential_env: Sorted credential env-var names the effective manifest
+            introduced, all within the pool allowlist.
+    """
+
+    pool_hash: str
+    template_hash: str
+    overrides_hash: str
+    effective_manifest_hash: str
+    effective_template: PoolWorkspaceTemplate
+    backend_override: str | None
+    capabilities: frozenset[SandboxCapability]
+    network_egress_class: str
+    credential_env: tuple[str, ...]
+
+    def to_workspace_manifest(self) -> WorkspaceManifest:
+        """Materialise a per-run :class:`WorkspaceManifest` from the merge."""
+        return WorkspaceManifest(
+            root=self.effective_template.root,
+            env=dict(self.effective_template.env),
+            timeout_seconds=self.effective_template.timeout_seconds,
+        )
+
+    def effective_payload(self) -> dict[str, Any]:
+        """Canonical JSON-safe payload the ``effective_manifest_hash`` covers."""
+        return {
+            "pool_hash": self.pool_hash,
+            "template": self.effective_template.to_canonical(),
+            "backend_override": self.backend_override,
+            "capabilities": _sorted_cap_values(self.capabilities),
+            "network_egress_class": self.network_egress_class,
+            "credential_env": list(self.credential_env),
+        }
+
+
+def canonical_overrides(overrides: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a canonical, JSON-safe copy of *overrides* for hashing.
+
+    Nested ``env`` maps are key-sorted and ``capabilities`` lists are
+    value-sorted so a recipe that specifies the same overrides in a different
+    textual order hashes identically (AC: determinism across permutations).
+    """
+    out: dict[str, Any] = {}
+    for key in sorted(overrides):
+        value = overrides[key]
+        if key == "env" and isinstance(value, Mapping):
+            out[key] = {str(k): str(v) for k, v in sorted(value.items())}
+        elif key == "capabilities" and isinstance(value, (list, tuple, set, frozenset)):
+            out[key] = sorted(str(v) for v in value)
+        else:
+            out[key] = value
+    return out
+
+
+def overrides_hash(overrides: Mapping[str, Any]) -> str:
+    """SHA-256 over the canonical overrides payload."""
+    return _sha256_hex(_canonical_json(canonical_overrides(overrides)))
+
+
+def merge_pool_overrides(
+    pool: PoolManifest,
+    overrides: Mapping[str, Any] | None = None,
+    *,
+    known_credential_keys: Iterable[str] | None = None,
+) -> PoolMergeResult:
+    """Merge recipe *overrides* into *pool*, fail-closed against its ceiling.
+
+    A pure function: no I/O, no registry side effects. The returned
+    :class:`PoolMergeResult` is byte-stable for a given ``(pool, overrides)``
+    pair regardless of override key order (AC: determinism).
+
+    Args:
+        pool: The target pool manifest.
+        overrides: Recipe-supplied override map. Every key must be in
+            ``pool.exposed_fields``.
+        known_credential_keys: The credential namespace (``credential_scoping``
+            known keys). An env var in this set may only be introduced by an
+            override when it is also in ``pool.credential_env_allowlist``. When
+            omitted, the process default credential policy's known keys are
+            used; an empty namespace makes the credential gate inert (matching
+            ``credential_scoping``'s own inert-when-empty behaviour).
+
+    Returns:
+        The deterministic :class:`PoolMergeResult`.
+
+    Raises:
+        PoolOverrideRefused: The override touches a non-exposed field, requests
+            a capability above the ceiling, widens egress, or names a
+            credential env var outside the allowlist. No sandbox is created.
+    """
+    overrides = dict(overrides or {})
+    exposed = set(pool.exposed_fields)
+
+    for key in overrides:
+        if key not in KNOWN_OVERRIDE_FIELDS:
+            raise PoolOverrideRefused("unknown_field", field=key)
+        if key not in exposed:
+            raise PoolOverrideRefused("non_exposed_field", field=key)
+
+    cred_namespace = _resolve_known_credential_keys(known_credential_keys)
+
+    effective_template = _merge_template(pool, overrides, cred_namespace)
+    backend_override = _resolve_backend_override(pool, overrides)
+    capabilities = _resolve_capabilities(pool, overrides)
+    egress = _resolve_egress(pool, overrides)
+    credential_env = _effective_credential_env(effective_template, cred_namespace)
+
+    result = PoolMergeResult(
+        pool_hash=pool.pool_hash,
+        template_hash=pool.template.template_hash(),
+        overrides_hash=overrides_hash(overrides),
+        effective_manifest_hash="",
+        effective_template=effective_template,
+        backend_override=backend_override,
+        capabilities=capabilities,
+        network_egress_class=egress,
+        credential_env=credential_env,
+    )
+    effective_hash = _sha256_hex(_canonical_json(result.effective_payload()))
+    object.__setattr__(result, "effective_manifest_hash", effective_hash)
+    return result
+
+
+def _resolve_known_credential_keys(known: Iterable[str] | None) -> frozenset[str]:
+    """Resolve the credential namespace, defaulting to the process policy."""
+    if known is not None:
+        return frozenset(known)
+    try:
+        from bernstein.core.credential_scoping import get_default_policy
+
+        return frozenset(get_default_policy().known_keys)
+    except Exception:
+        return frozenset()
+
+
+def _merge_template(
+    pool: PoolManifest,
+    overrides: Mapping[str, Any],
+    cred_namespace: frozenset[str],
+) -> PoolWorkspaceTemplate:
+    """Merge the exposed template fields; refuse credential env additions."""
+    base = pool.template
+    root = base.root
+    timeout = base.timeout_seconds
+    env = dict(base.env)
+
+    if "root" in overrides:
+        if not isinstance(overrides["root"], str):
+            raise PoolOverrideRefused("malformed_value", field="root", detail="root must be a string")
+        root = overrides["root"]
+    if "timeout_seconds" in overrides:
+        try:
+            timeout = int(overrides["timeout_seconds"])
+        except (TypeError, ValueError) as exc:
+            raise PoolOverrideRefused("malformed_value", field="timeout_seconds", detail=str(exc)) from exc
+    if "env" in overrides:
+        raw = overrides["env"]
+        if not isinstance(raw, Mapping):
+            raise PoolOverrideRefused("malformed_value", field="env", detail="env must be a mapping")
+        for name, value in raw.items():
+            name = str(name)
+            # A credential-namespace env var may only be introduced by an
+            # override when the pool explicitly allowlists it (fail closed).
+            if name in cred_namespace and name not in pool.credential_env_allowlist:
+                raise PoolOverrideRefused(
+                    "credential_env_not_allowed",
+                    field="env",
+                    detail=f"credential env var {name!r} is outside the pool allowlist",
+                )
+            env[name] = str(value)
+
+    return PoolWorkspaceTemplate(root=root, env=env, timeout_seconds=timeout)
+
+
+def _resolve_backend_override(pool: PoolManifest, overrides: Mapping[str, Any]) -> str | None:
+    """Resolve an exposed ``backend`` override against the allowlist."""
+    if "backend" not in overrides:
+        return None
+    backend = overrides["backend"]
+    if not isinstance(backend, str) or not backend:
+        raise PoolOverrideRefused("malformed_value", field="backend", detail="backend must be a non-empty string")
+    if pool.backend_allowlist and backend not in pool.backend_allowlist:
+        raise PoolOverrideRefused(
+            "backend_not_allowed",
+            field="backend",
+            detail=f"{backend!r} not in allowlist {list(pool.backend_allowlist)!r}",
+        )
+    return backend
+
+
+def _resolve_capabilities(pool: PoolManifest, overrides: Mapping[str, Any]) -> frozenset[SandboxCapability]:
+    """Resolve requested capabilities, bounded by the pool ceiling."""
+    requested: set[SandboxCapability] = set(BASE_CAPABILITIES)
+    if "capabilities" in overrides:
+        raw = overrides["capabilities"]
+        if not isinstance(raw, (list, tuple, set, frozenset)):
+            raise PoolOverrideRefused("malformed_value", field="capabilities", detail="capabilities must be a list")
+        for entry in raw:
+            try:
+                cap = SandboxCapability(str(entry))
+            except ValueError as exc:
+                raise PoolOverrideRefused(
+                    "malformed_value", field="capabilities", detail=f"unknown capability {entry!r}"
+                ) from exc
+            if cap not in pool.capability_ceiling:
+                raise PoolOverrideRefused(
+                    "capability_above_ceiling",
+                    field="capabilities",
+                    detail=f"capability {cap.value!r} exceeds the pool ceiling",
+                )
+            requested.add(cap)
+    return frozenset(requested)
+
+
+def _resolve_egress(pool: PoolManifest, overrides: Mapping[str, Any]) -> str:
+    """Resolve the requested egress class, refusing any widening."""
+    if "network_egress_class" not in overrides:
+        return pool.network_egress_class
+    requested = overrides["network_egress_class"]
+    if requested not in _EGRESS_RANK:
+        raise PoolOverrideRefused(
+            "malformed_value",
+            field="network_egress_class",
+            detail=f"{requested!r} not one of {NETWORK_EGRESS_CLASSES!r}",
+        )
+    if _EGRESS_RANK[requested] > _EGRESS_RANK[pool.network_egress_class]:
+        raise PoolOverrideRefused(
+            "egress_widened",
+            field="network_egress_class",
+            detail=f"requested {requested!r} is wider than the ceiling {pool.network_egress_class!r}",
+        )
+    return requested
+
+
+def _effective_credential_env(template: PoolWorkspaceTemplate, cred_namespace: frozenset[str]) -> tuple[str, ...]:
+    """Return the sorted credential env-var names the effective template sets."""
+    return tuple(sorted(name for name in template.env if name in cred_namespace))
+
+
+__all__ = [
+    "BASE_CAPABILITIES",
+    "KNOWN_OVERRIDE_FIELDS",
+    "NETWORK_EGRESS_CLASSES",
+    "POOL_MANIFEST_SCHEMA_VERSION",
+    "PoolManifest",
+    "PoolManifestError",
+    "PoolMergeResult",
+    "PoolOverrideRefused",
+    "PoolWorkspaceTemplate",
+    "canonical_overrides",
+    "merge_pool_overrides",
+    "overrides_hash",
+]

--- a/src/bernstein/core/sandbox/pool_enrolment.py
+++ b/src/bernstein/core/sandbox/pool_enrolment.py
@@ -1,0 +1,343 @@
+"""Worker enrolment as a signed ceremony (#2547).
+
+A worker joins a pool with ``bernstein worker --pool <name> --server <url>``.
+It signs an enrolment receipt binding its Ed25519 install identity (the keypair
+in :class:`~bernstein.core.security.agent_card_keystore.AgentCardKeystore`,
+published as JWKS at ``/.well-known/agent.json/keys``) to the target
+``pool_hash``. Every subsequent claim is a signed receipt too, so the execution
+host of any run is cryptographically attributable and ``bernstein audit verify``
+proves it offline (AC: verifiability).
+
+JWT cluster scopes (:mod:`bernstein.core.protocols.cluster.cluster_auth`) remain
+the transport gate; the Ed25519 signature here is the *attribution* layer. The
+signature is computed over the canonical bytes of the receipt body -- the same
+``canonical_json`` plus Ed25519 primitives the RFC 9421 signer in
+:mod:`bernstein.core.identity.http_signing` uses -- so a receipt made under an
+install identity that has since rotated names a ``keyid`` absent from the
+current key directory and fails verification deterministically.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+from bernstein.core.identity.http_signing import install_identity_keyid
+from bernstein.core.security.agent_card_signer import ed25519_public_jwk
+
+if TYPE_CHECKING:
+    from bernstein.core.security.agent_card_keystore import AgentCardKeystore
+
+#: Wire-format version stamped into every enrolment / claim receipt.
+POOL_ENROLMENT_SCHEMA_VERSION = 1
+
+
+def _canonical_json(payload: Any) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _sha256_hex(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _public_key_from_jwk(jwk: dict[str, str]) -> Ed25519PublicKey:
+    """Reconstruct an Ed25519 public key from an OKP JWK (RFC 8037)."""
+    x = jwk["x"]
+    pad = -len(x) % 4
+    raw = base64.urlsafe_b64decode(x + ("=" * pad))
+    return Ed25519PublicKey.from_public_bytes(raw)
+
+
+@dataclass(frozen=True)
+class EnrolmentReceipt:
+    """A worker's signed statement binding its install identity to a pool.
+
+    The receipt is self-contained: it embeds the worker's public JWK so a
+    verifier can check the Ed25519 signature offline, and ``keyid`` is the
+    RFC 7638 thumbprint of that JWK, so a mismatch between ``keyid`` and the
+    embedded key is itself a verification failure.
+    """
+
+    pool_hash: str
+    worker_name: str
+    keyid: str
+    public_jwk: dict[str, str]
+    created: int
+    schema_version: int = POOL_ENROLMENT_SCHEMA_VERSION
+    signature: str = ""
+
+    def _body(self) -> dict[str, Any]:
+        """Canonical signed payload (excludes the signature itself)."""
+        return {
+            "pool_hash": self.pool_hash,
+            "worker_name": self.worker_name,
+            "keyid": self.keyid,
+            "public_jwk": self.public_jwk,
+            "created": int(self.created),
+            "schema_version": int(self.schema_version),
+            "kind": "pool.enrolment",
+        }
+
+    def signing_bytes(self) -> bytes:
+        return _canonical_json(self._body()).encode("utf-8")
+
+    def enrolment_hash(self) -> str:
+        """SHA-256 over the canonical signed body (receipt identity)."""
+        return _sha256_hex(_canonical_json(self._body()))
+
+    def to_dict(self) -> dict[str, Any]:
+        body = self._body()
+        body["signature"] = self.signature
+        return body
+
+    def to_canonical_json(self) -> str:
+        return _canonical_json(self.to_dict())
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> EnrolmentReceipt:
+        return cls(
+            pool_hash=str(raw.get("pool_hash", "")),
+            worker_name=str(raw.get("worker_name", "")),
+            keyid=str(raw.get("keyid", "")),
+            public_jwk=dict(raw.get("public_jwk", {}) or {}),
+            created=int(raw.get("created", 0)),
+            schema_version=int(raw.get("schema_version", POOL_ENROLMENT_SCHEMA_VERSION)),
+            signature=str(raw.get("signature", "")),
+        )
+
+
+def build_enrolment_receipt(
+    *,
+    keystore: AgentCardKeystore,
+    pool_hash: str,
+    worker_name: str,
+    created: int,
+) -> EnrolmentReceipt:
+    """Sign an enrolment receipt binding the install identity to *pool_hash*.
+
+    Args:
+        keystore: The worker's install-identity keystore.
+        pool_hash: Canonical hash of the pool being joined.
+        worker_name: The worker's declared name.
+        created: Signature-creation unix timestamp (explicit for determinism).
+
+    Returns:
+        A signed :class:`EnrolmentReceipt`.
+    """
+    private_pem, public_pem = keystore.load_or_generate()
+    keyid = install_identity_keyid(public_pem)
+    jwk = ed25519_public_jwk(public_pem, kid=keyid)
+
+    receipt = EnrolmentReceipt(
+        pool_hash=pool_hash,
+        worker_name=worker_name,
+        keyid=keyid,
+        public_jwk=jwk,
+        created=created,
+    )
+    private_key = serialization.load_pem_private_key(private_pem, password=None)
+    if not isinstance(private_key, Ed25519PrivateKey):  # pragma: no cover - keystore invariant
+        raise TypeError("install identity key is not Ed25519")
+    signature = private_key.sign(receipt.signing_bytes())
+    sig_b64 = base64.b64encode(signature).decode("ascii")
+    object.__setattr__(receipt, "signature", sig_b64)
+    return receipt
+
+
+def verify_enrolment_receipt(
+    receipt: EnrolmentReceipt,
+    *,
+    key_directory: dict[str, Any] | None = None,
+) -> bool:
+    """Verify a signed enrolment receipt.
+
+    Always checks that ``keyid`` equals the RFC 7638 thumbprint of the embedded
+    public JWK and that the Ed25519 signature verifies over the canonical body.
+    When *key_directory* is supplied (the server's published JWKS) the receipt
+    additionally must name a ``keyid`` present in that directory -- this is how
+    a rotated install identity's old receipts stop verifying (AC: verifiability).
+
+    Returns:
+        ``True`` iff the receipt is well-formed and the signature is valid
+        under a resolvable key.
+    """
+    if not receipt.signature or not receipt.public_jwk:
+        return False
+    # keyid must match the embedded key so a receipt cannot claim someone
+    # else's key id while carrying its own key.
+    if receipt.keyid != receipt.public_jwk.get("kid"):
+        return False
+    try:
+        raw = base64.urlsafe_b64decode(receipt.public_jwk["x"] + ("=" * (-len(receipt.public_jwk["x"]) % 4)))
+    except (KeyError, ValueError, TypeError):
+        return False
+    computed_thumbprint = _thumbprint_from_raw(raw)
+    if computed_thumbprint != receipt.keyid:
+        return False
+
+    if key_directory is not None:
+        known = {k.get("kid") for k in key_directory.get("keys", [])}
+        if receipt.keyid not in known:
+            return False
+
+    try:
+        signature = base64.b64decode(receipt.signature)
+    except (ValueError, TypeError):
+        return False
+    try:
+        public_key = _public_key_from_jwk(receipt.public_jwk)
+        public_key.verify(signature, receipt.signing_bytes())
+    except (InvalidSignature, KeyError, ValueError):
+        return False
+    return True
+
+
+def _thumbprint_from_raw(raw: bytes) -> str:
+    """RFC 7638 thumbprint over the OKP members for raw Ed25519 public bytes."""
+    x = base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+    canonical = json.dumps(
+        {"crv": "Ed25519", "kty": "OKP", "x": x},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("ascii")
+    digest = hashlib.sha256(canonical).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+@dataclass(frozen=True)
+class ClaimReceipt:
+    """A signed statement that an enrolled worker claimed a task under a pool.
+
+    Binds the claim to the worker's install identity and to the placement
+    receipt the completion report carries, so a reviewer can prove which
+    enrolled host executed a given run.
+    """
+
+    pool_hash: str
+    task_id: str
+    keyid: str
+    public_jwk: dict[str, str]
+    placement_hash: str
+    created: int
+    schema_version: int = POOL_ENROLMENT_SCHEMA_VERSION
+    signature: str = ""
+
+    def _body(self) -> dict[str, Any]:
+        return {
+            "pool_hash": self.pool_hash,
+            "task_id": self.task_id,
+            "keyid": self.keyid,
+            "public_jwk": self.public_jwk,
+            "placement_hash": self.placement_hash,
+            "created": int(self.created),
+            "schema_version": int(self.schema_version),
+            "kind": "pool.claim",
+        }
+
+    def signing_bytes(self) -> bytes:
+        return _canonical_json(self._body()).encode("utf-8")
+
+    def claim_hash(self) -> str:
+        return _sha256_hex(_canonical_json(self._body()))
+
+    def to_dict(self) -> dict[str, Any]:
+        body = self._body()
+        body["signature"] = self.signature
+        return body
+
+    def to_canonical_json(self) -> str:
+        return _canonical_json(self.to_dict())
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> ClaimReceipt:
+        return cls(
+            pool_hash=str(raw.get("pool_hash", "")),
+            task_id=str(raw.get("task_id", "")),
+            keyid=str(raw.get("keyid", "")),
+            public_jwk=dict(raw.get("public_jwk", {}) or {}),
+            placement_hash=str(raw.get("placement_hash", "")),
+            created=int(raw.get("created", 0)),
+            schema_version=int(raw.get("schema_version", POOL_ENROLMENT_SCHEMA_VERSION)),
+            signature=str(raw.get("signature", "")),
+        )
+
+
+def build_claim_receipt(
+    *,
+    keystore: AgentCardKeystore,
+    pool_hash: str,
+    task_id: str,
+    placement_hash: str,
+    created: int,
+) -> ClaimReceipt:
+    """Sign a claim receipt with the worker install identity."""
+    private_pem, public_pem = keystore.load_or_generate()
+    keyid = install_identity_keyid(public_pem)
+    jwk = ed25519_public_jwk(public_pem, kid=keyid)
+    receipt = ClaimReceipt(
+        pool_hash=pool_hash,
+        task_id=task_id,
+        keyid=keyid,
+        public_jwk=jwk,
+        placement_hash=placement_hash,
+        created=created,
+    )
+    private_key = serialization.load_pem_private_key(private_pem, password=None)
+    if not isinstance(private_key, Ed25519PrivateKey):  # pragma: no cover - keystore invariant
+        raise TypeError("install identity key is not Ed25519")
+    signature = private_key.sign(receipt.signing_bytes())
+    object.__setattr__(receipt, "signature", base64.b64encode(signature).decode("ascii"))
+    return receipt
+
+
+def verify_claim_receipt(
+    receipt: ClaimReceipt,
+    *,
+    enrolled_keyid: str | None = None,
+) -> bool:
+    """Verify a signed claim receipt.
+
+    Checks that ``keyid`` matches the embedded key's thumbprint and that the
+    Ed25519 signature verifies. When *enrolled_keyid* is supplied the claim must
+    have been signed by exactly that enrolled worker key (attribution).
+    """
+    if not receipt.signature or not receipt.public_jwk:
+        return False
+    if receipt.keyid != receipt.public_jwk.get("kid"):
+        return False
+    if enrolled_keyid is not None and receipt.keyid != enrolled_keyid:
+        return False
+    try:
+        raw = base64.urlsafe_b64decode(receipt.public_jwk["x"] + ("=" * (-len(receipt.public_jwk["x"]) % 4)))
+    except (KeyError, ValueError, TypeError):
+        return False
+    if _thumbprint_from_raw(raw) != receipt.keyid:
+        return False
+    try:
+        signature = base64.b64decode(receipt.signature)
+        public_key = _public_key_from_jwk(receipt.public_jwk)
+        public_key.verify(signature, receipt.signing_bytes())
+    except (InvalidSignature, KeyError, ValueError, TypeError):
+        return False
+    return True
+
+
+__all__ = [
+    "POOL_ENROLMENT_SCHEMA_VERSION",
+    "ClaimReceipt",
+    "EnrolmentReceipt",
+    "build_claim_receipt",
+    "build_enrolment_receipt",
+    "verify_claim_receipt",
+    "verify_enrolment_receipt",
+]

--- a/src/bernstein/core/sandbox/pool_placement.py
+++ b/src/bernstein/core/sandbox/pool_placement.py
@@ -1,0 +1,344 @@
+"""Placement as a receipt: the pool is a declared selector input (#2547).
+
+The selector (:mod:`bernstein.core.sandbox.selector`) stays a pure function.
+This module composes it with a pool: :func:`pool_to_sandbox_policy` maps a
+:class:`~bernstein.core.sandbox.pool.PoolMergeResult` into a
+:class:`~bernstein.core.sandbox.selector.SandboxPolicy`, and
+:func:`select_pool_backend` restricts the candidate backends to the pool
+allowlist before delegating to :func:`~bernstein.core.sandbox.selector.select_sandbox`.
+``select_sandbox`` itself is untouched, so with no pool configured selection is
+byte-identical to today (AC: regression).
+
+Every dispatch seals a :class:`PlacementReceipt` over
+``(pool_hash, template_hash, overrides_hash, effective_manifest_hash,
+selector_inputs, chosen_backend)``, following the sealed canonical-JSON receipt
+pattern in :mod:`bernstein.core.cost.scheduling.receipt`. The receipt's identity
+is its own ``placement_hash``; :func:`verify_placement_receipt` recomputes it
+from the stored body so a forged backend or a widened effective manifest
+recomputes to a different hash and fails, exactly like a tampered chain entry.
+When the receipt is also mirrored into the HMAC audit chain, flipping one byte
+of the recorded effective manifest breaks chain verification (AC: verifiability).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.sandbox.selector import (
+    SandboxEnvironment,
+    SandboxPolicy,
+    select_sandbox,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+
+    from bernstein.core.sandbox.backend import SandboxBackend
+    from bernstein.core.sandbox.pool import PoolManifest, PoolMergeResult
+    from bernstein.core.security.audit_chain import AuditChainStore
+
+#: Wire-format version stamped into every placement receipt.
+PLACEMENT_RECEIPT_SCHEMA_VERSION = 1
+
+_PLACEMENT_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
+_PLACEMENT_SUBPATH = ("sandbox", "placements")
+
+
+def _canonical_json(payload: Any) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _sha256_hex(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def pool_to_sandbox_policy(
+    merge: PoolMergeResult,
+    *,
+    pool: PoolManifest,
+    allow_paid: bool = False,
+) -> SandboxPolicy:
+    """Map a merged pool placement into a pure :class:`SandboxPolicy`.
+
+    The pool becomes a declared input to selection: the required capabilities
+    are the merge's effective capabilities, the precedence is the pool backend
+    allowlist (so operator preference order wins), and an exposed ``backend``
+    override becomes the policy override.
+
+    Args:
+        merge: The deterministic merge result for this dispatch.
+        pool: The pool manifest the merge targeted (for the allowlist order).
+        allow_paid: Whether paid cloud backends may be considered.
+
+    Returns:
+        A :class:`SandboxPolicy` the pure selector consumes.
+    """
+    precedence = tuple(pool.backend_allowlist) if pool.backend_allowlist else None
+    return SandboxPolicy(
+        override=merge.backend_override,
+        allow_paid=allow_paid,
+        required_capabilities=frozenset(merge.capabilities),
+        precedence=precedence,
+    )
+
+
+def selector_inputs(
+    merge: PoolMergeResult,
+    *,
+    pool: PoolManifest,
+    environment: SandboxEnvironment,
+    allow_paid: bool,
+    candidate_names: Iterable[str],
+) -> dict[str, Any]:
+    """Return the canonical, JSON-safe record of the inputs the pick used.
+
+    Every value that could change the chosen backend is captured so a verifier
+    can prove the selection was a pure function of these inputs.
+    """
+    return {
+        "pool_hash": merge.pool_hash,
+        "backend_allowlist": list(pool.backend_allowlist),
+        "backend_override": merge.backend_override,
+        "required_capabilities": sorted(c.value for c in merge.capabilities),
+        "network_egress_class": merge.network_egress_class,
+        "allow_paid": bool(allow_paid),
+        "available_credentials": sorted(environment.available_credentials),
+        "budget_remaining_usd": environment.budget_remaining_usd,
+        "candidates": sorted(candidate_names),
+    }
+
+
+def select_pool_backend(
+    backends: Iterable[SandboxBackend],
+    merge: PoolMergeResult,
+    *,
+    pool: PoolManifest,
+    environment: SandboxEnvironment | None = None,
+    allow_paid: bool = False,
+) -> tuple[SandboxBackend, dict[str, Any]]:
+    """Select a backend for a pool dispatch and return the inputs it used.
+
+    Candidates are first filtered to the pool backend allowlist (empty
+    allowlist means "any registered backend"), then handed to the pure
+    :func:`~bernstein.core.sandbox.selector.select_sandbox`. Two hosts with the
+    same pool, recipe, and environment choose the same backend.
+
+    Returns:
+        ``(chosen_backend, selector_inputs)``.
+    """
+    env = environment or SandboxEnvironment()
+    allowed = set(pool.backend_allowlist)
+    candidates = [b for b in backends if not allowed or b.name in allowed]
+    policy = pool_to_sandbox_policy(merge, pool=pool, allow_paid=allow_paid)
+    chosen = select_sandbox(candidates, policy=policy, environment=env)
+    inputs = selector_inputs(
+        merge,
+        pool=pool,
+        environment=env,
+        allow_paid=allow_paid,
+        candidate_names=[b.name for b in candidates],
+    )
+    return chosen, inputs
+
+
+@dataclass(frozen=True)
+class PlacementReceipt:
+    """A sealed placement decision (#2547).
+
+    The receipt's identity is its ``placement_hash``: a SHA-256 over every other
+    field (including the ``selector_inputs`` payload and the chosen backend).
+    """
+
+    pool_hash: str
+    template_hash: str
+    overrides_hash: str
+    effective_manifest_hash: str
+    chosen_backend: str
+    selector_inputs: dict[str, Any]
+    schema_version: int = PLACEMENT_RECEIPT_SCHEMA_VERSION
+    timestamp: int = 0
+    placement_hash: str = ""
+
+    def _body(self) -> dict[str, Any]:
+        """Canonical payload the ``placement_hash`` is computed over."""
+        return {
+            "pool_hash": self.pool_hash,
+            "template_hash": self.template_hash,
+            "overrides_hash": self.overrides_hash,
+            "effective_manifest_hash": self.effective_manifest_hash,
+            "chosen_backend": self.chosen_backend,
+            "selector_inputs": self.selector_inputs,
+            "schema_version": int(self.schema_version),
+            "timestamp": int(self.timestamp),
+        }
+
+    def compute_hash(self) -> str:
+        """SHA-256 over the canonical receipt body."""
+        return _sha256_hex(_canonical_json(self._body()))
+
+    def selector_inputs_hash(self) -> str:
+        """SHA-256 over just the selector-inputs payload."""
+        return _sha256_hex(_canonical_json(self.selector_inputs))
+
+    def to_dict(self) -> dict[str, Any]:
+        body = self._body()
+        body["placement_hash"] = self.placement_hash
+        return body
+
+    def to_canonical_json(self) -> str:
+        return _canonical_json(self.to_dict())
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> PlacementReceipt:
+        return cls(
+            pool_hash=str(raw.get("pool_hash", "")),
+            template_hash=str(raw.get("template_hash", "")),
+            overrides_hash=str(raw.get("overrides_hash", "")),
+            effective_manifest_hash=str(raw.get("effective_manifest_hash", "")),
+            chosen_backend=str(raw.get("chosen_backend", "")),
+            selector_inputs=dict(raw.get("selector_inputs", {}) or {}),
+            schema_version=int(raw.get("schema_version", PLACEMENT_RECEIPT_SCHEMA_VERSION)),
+            timestamp=int(raw.get("timestamp", 0)),
+            placement_hash=str(raw.get("placement_hash", "")),
+        )
+
+    def verify_self_hash(self) -> bool:
+        """Return whether ``placement_hash`` recomputes from the body."""
+        return bool(self.placement_hash) and self.placement_hash == self.compute_hash()
+
+
+def seal_placement(
+    *,
+    merge: PoolMergeResult,
+    chosen_backend: str,
+    selector_inputs: dict[str, Any],
+    timestamp: int = 0,
+) -> PlacementReceipt:
+    """Build a sealed :class:`PlacementReceipt` from a merge and a pick.
+
+    Pure and deterministic: same merge + backend + inputs + timestamp seal
+    byte-identically, so two hosts agree on ``placement_hash`` (AC: determinism).
+    """
+    receipt = PlacementReceipt(
+        pool_hash=merge.pool_hash,
+        template_hash=merge.template_hash,
+        overrides_hash=merge.overrides_hash,
+        effective_manifest_hash=merge.effective_manifest_hash,
+        chosen_backend=chosen_backend,
+        selector_inputs=selector_inputs,
+        timestamp=timestamp,
+    )
+    object.__setattr__(receipt, "placement_hash", receipt.compute_hash())
+    return receipt
+
+
+def placement_receipt_path(workdir: Path, placement_hash: str) -> Path:
+    """Return the on-disk receipt path for *placement_hash* under *workdir*.
+
+    The hash is validated against ``<64 hex>`` and the resolved path is asserted
+    to stay under the placements directory (path-injection defense in depth).
+    """
+    if not _PLACEMENT_HASH_RE.match(placement_hash):
+        raise ValueError(f"placement_hash is not a canonical sha256 digest: {placement_hash!r}")
+    base = workdir.joinpath(".sdd", *_PLACEMENT_SUBPATH)
+    candidate = base / f"{placement_hash}.json"
+    base_real = os.path.realpath(base)
+    cand_real = os.path.realpath(candidate)
+    if os.path.commonpath([base_real, cand_real]) != base_real:
+        raise ValueError(f"receipt path escapes placements directory: {placement_hash!r}")
+    return candidate
+
+
+def write_placement_receipt(workdir: Path, receipt: PlacementReceipt) -> Path:
+    """Write *receipt* to its content-addressed path and return it."""
+    path = placement_receipt_path(workdir, receipt.placement_hash)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(receipt.to_canonical_json(), encoding="utf-8")
+    return path
+
+
+def read_placement_receipt(workdir: Path, placement_hash: str) -> PlacementReceipt | None:
+    """Return the sealed receipt for *placement_hash*, or ``None`` if absent/bad."""
+    try:
+        path = placement_receipt_path(workdir, placement_hash)
+    except ValueError:
+        return None
+    if not path.is_file():
+        return None
+    try:
+        return PlacementReceipt.from_dict(json.loads(path.read_text(encoding="utf-8")))
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+        return None
+
+
+@dataclass(frozen=True, slots=True)
+class PlacementVerifyResult:
+    """Outcome of an offline placement-receipt verification."""
+
+    ok: bool
+    reason: str
+    receipt: PlacementReceipt | None
+
+
+def verify_placement_receipt(workdir: Path, placement_hash: str) -> PlacementVerifyResult:
+    """Re-verify the placement receipt for *placement_hash* offline.
+
+    A forged backend or a widened ``effective_manifest_hash`` recomputes to a
+    different ``placement_hash`` and fails, exactly like a tampered chain entry.
+    """
+    receipt = read_placement_receipt(workdir, placement_hash)
+    if receipt is None:
+        return PlacementVerifyResult(ok=False, reason=f"no placement receipt for {placement_hash!r}", receipt=None)
+    if receipt.placement_hash != placement_hash:
+        return PlacementVerifyResult(ok=False, reason="receipt placement_hash does not match request", receipt=receipt)
+    if not receipt.verify_self_hash():
+        return PlacementVerifyResult(
+            ok=False, reason="placement_hash does not recompute from the receipt body (tampered)", receipt=receipt
+        )
+    return PlacementVerifyResult(ok=True, reason="", receipt=receipt)
+
+
+def record_placement(
+    *,
+    chain: AuditChainStore,
+    receipt: PlacementReceipt,
+) -> None:
+    """Mirror a sealed placement receipt into the HMAC audit chain.
+
+    After this, flipping one byte of the recorded effective manifest in the
+    chain breaks ``bernstein audit verify`` (AC: verifiability).
+    """
+    from bernstein.core.security.audit_chain import record_pool_placement_receipt
+
+    record_pool_placement_receipt(
+        chain=chain,
+        placement_hash=receipt.placement_hash,
+        pool_hash=receipt.pool_hash,
+        template_hash=receipt.template_hash,
+        overrides_hash=receipt.overrides_hash,
+        effective_manifest_hash=receipt.effective_manifest_hash,
+        chosen_backend=receipt.chosen_backend,
+        selector_inputs_hash=receipt.selector_inputs_hash(),
+    )
+
+
+__all__ = [
+    "PLACEMENT_RECEIPT_SCHEMA_VERSION",
+    "PlacementReceipt",
+    "PlacementVerifyResult",
+    "placement_receipt_path",
+    "pool_to_sandbox_policy",
+    "read_placement_receipt",
+    "record_placement",
+    "seal_placement",
+    "select_pool_backend",
+    "selector_inputs",
+    "verify_placement_receipt",
+    "write_placement_receipt",
+]

--- a/src/bernstein/core/sandbox/pool_registry.py
+++ b/src/bernstein/core/sandbox/pool_registry.py
@@ -1,0 +1,201 @@
+"""Pool registry as a deterministic projection of the audit chain (#2547).
+
+There is no side database to drift. A pool's lifecycle lives entirely in the
+HMAC audit chain: ``pool.registered`` / ``pool.updated`` / ``pool.retired``
+events (see :mod:`bernstein.core.security.audit_chain`) are the only mutation
+path. The *authority* on which pool is active for a given name is the chain;
+:func:`project_pool_registry` replays those events in order and returns the
+current ``{name: pool_hash}`` map. Two operators replaying the same events
+arrive at byte-identical projections.
+
+The manifest *bodies* are held in a content-addressed store
+(:class:`PoolStore`): each manifest is written to ``<root>/pools/<pool_hash>.json``
+and re-verified against its canonical hash on load. The store is immutable and
+self-verifying -- editing a stored body changes its hash and the load refuses
+it -- so it cannot drift out of agreement with the chain the way a mutable
+registry table could.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.sandbox.pool import PoolManifest, PoolManifestError
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+
+_POOL_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
+
+#: Event-type strings the projection understands. Imported lazily to avoid a
+#: hard import cycle with the audit-chain module at import time.
+_EVENT_REGISTERED = "pool.registered"
+_EVENT_UPDATED = "pool.updated"
+_EVENT_RETIRED = "pool.retired"
+
+
+class PoolStoreError(ValueError):
+    """Raised when a content-addressed pool body is missing or tampered."""
+
+
+def _event_field(event: Any, key: str) -> Any:
+    """Read *key* from *event* whether it is a mapping or a dataclass."""
+    if isinstance(event, Mapping):
+        return event.get(key)
+    return getattr(event, key, None)
+
+
+def project_pool_registry(events: Iterable[Any]) -> dict[str, str]:
+    """Return the active ``{pool_name: pool_hash}`` map from *events*.
+
+    A pure function over the ordered ``pool.*`` event stream. Non-pool events
+    are ignored, so callers may pass the whole chain. Register and update set
+    the active hash for the name; retire drops it. Replaying the same ordered
+    events always yields the same map (AC: determinism).
+
+    Args:
+        events: Ordered events, each either a mapping or an object exposing
+            ``event_type`` and a ``details`` payload carrying ``pool_name`` /
+            ``pool_hash`` (e.g. :class:`AuditEvent`).
+
+    Returns:
+        Mapping from pool name to the currently active canonical ``pool_hash``.
+    """
+    active: dict[str, str] = {}
+    for event in events:
+        event_type = _event_field(event, "event_type")
+        details = _event_field(event, "details") or {}
+        name = details.get("pool_name")
+        pool_hash = details.get("pool_hash")
+        if not name:
+            continue
+        if event_type in (_EVENT_REGISTERED, _EVENT_UPDATED):
+            if pool_hash:
+                active[name] = pool_hash
+        elif event_type == _EVENT_RETIRED:
+            active.pop(name, None)
+    return active
+
+
+@dataclass(frozen=True)
+class PoolStore:
+    """Content-addressed store for pool manifest bodies.
+
+    Bodies live under ``root/pools/<pool_hash>.json``. The hash in the filename
+    is the manifest's own canonical hash, so a load both locates the body and
+    verifies it: a tampered body recomputes to a different hash and is refused.
+    """
+
+    root: Path
+
+    @property
+    def pools_dir(self) -> Path:
+        return self.root / "pools"
+
+    def _path_for(self, pool_hash: str) -> Path:
+        """Return the on-disk path for *pool_hash*, guarded against traversal."""
+        if not _POOL_HASH_RE.match(pool_hash):
+            raise PoolStoreError(f"pool_hash is not a canonical sha256 digest: {pool_hash!r}")
+        base = self.pools_dir
+        candidate = base / f"{pool_hash}.json"
+        base_real = os.path.realpath(base)
+        cand_real = os.path.realpath(candidate)
+        if os.path.commonpath([base_real, cand_real]) != base_real:
+            raise PoolStoreError(f"pool body path escapes the pools directory: {pool_hash!r}")
+        return candidate
+
+    def put(self, manifest: PoolManifest) -> Path:
+        """Write *manifest* to its content-addressed path and return it.
+
+        Idempotent: re-writing an identical manifest is a no-op-equivalent
+        (the bytes are byte-identical because the payload is canonical).
+        """
+        path = self._path_for(manifest.pool_hash)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(manifest.to_dict(), sort_keys=True, separators=(",", ":")), encoding="utf-8")
+        return path
+
+    def get(self, pool_hash: str) -> PoolManifest:
+        """Load and hash-verify the manifest body for *pool_hash*.
+
+        Raises:
+            PoolStoreError: The body is absent, unreadable, or its recomputed
+                canonical hash does not equal *pool_hash* (tampered).
+        """
+        path = self._path_for(pool_hash)
+        if not path.is_file():
+            raise PoolStoreError(f"no pool body for {pool_hash!r}")
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            raise PoolStoreError(f"unreadable pool body for {pool_hash!r}: {exc}") from exc
+        try:
+            manifest = PoolManifest.from_dict(data)
+        except (PoolManifestError, KeyError, ValueError, TypeError) as exc:
+            # from_dict recomputes the hash and refuses a body whose embedded
+            # pool_hash no longer matches its own content -- surface that as a
+            # store-level tamper error, not a manifest construction error.
+            raise PoolStoreError(f"pool body hash mismatch for {pool_hash!r} (tampered): {exc}") from exc
+        if manifest.compute_hash() != pool_hash:
+            raise PoolStoreError(f"pool body hash mismatch for {pool_hash!r} (tampered)")
+        return manifest
+
+    def has(self, pool_hash: str) -> bool:
+        """Return whether a body exists for *pool_hash* (no hash verification)."""
+        try:
+            return self._path_for(pool_hash).is_file()
+        except PoolStoreError:
+            return False
+
+
+@dataclass(frozen=True)
+class PoolRegistry:
+    """Chain-authoritative view of active pools, backed by a content store.
+
+    The active set is the projection of the chain events; the bodies are loaded
+    content-addressed from the store and hash-verified. Nothing here is a
+    mutable source of truth -- both halves are deterministic derivations.
+    """
+
+    active: dict[str, str]
+    store: PoolStore
+
+    @classmethod
+    def from_events(cls, events: Iterable[Any], store: PoolStore) -> PoolRegistry:
+        """Build a registry by projecting *events* over *store*."""
+        return cls(active=project_pool_registry(events), store=store)
+
+    def names(self) -> list[str]:
+        """Return the sorted names of currently active pools."""
+        return sorted(self.active)
+
+    def hash_for(self, name: str) -> str | None:
+        """Return the active pool hash for *name*, or ``None`` if retired/absent."""
+        return self.active.get(name)
+
+    def get(self, name: str) -> PoolManifest | None:
+        """Load the active manifest for *name*, or ``None`` if none is active.
+
+        Raises:
+            PoolStoreError: The active hash resolves to a missing or tampered
+                body -- surfaced loudly rather than silently returning a stale
+                or wrong pool.
+        """
+        pool_hash = self.active.get(name)
+        if pool_hash is None:
+            return None
+        return self.store.get(pool_hash)
+
+
+__all__ = [
+    "PoolRegistry",
+    "PoolStore",
+    "PoolStoreError",
+    "project_pool_registry",
+]

--- a/src/bernstein/core/sandbox/pool_warm.py
+++ b/src/bernstein/core/sandbox/pool_warm.py
@@ -1,0 +1,95 @@
+"""Warm claim-ahead keyed by effective manifest hash (#2547).
+
+Warm-pool slots (:mod:`bernstein.core.agents.warm_pool`) are pre-provisioned so
+pool-scoped dispatch has no cold-start latency. To keep the manifest contract
+intact, a warm slot is keyed by the exact ``effective_manifest_hash`` it was
+provisioned against, and a dispatch may only attach to a slot when the hashes
+are *equal*. Infra drift between provisioning and claim surfaces as hash
+divergence, not as a silently-wrong environment: the slot is quarantined with a
+chained receipt and the dispatch falls back to cold provisioning (AC:
+warm claim-ahead).
+
+This module is deliberately a pair of pure predicates plus a chain-mirror
+helper, so it can be wired into the existing warm-pool machinery without
+changing any behaviour when no pool is configured.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bernstein.core.security.audit_chain import AuditChainStore
+
+
+class WarmClaimOutcome(Enum):
+    """Result of testing a warm slot against a dispatch."""
+
+    ATTACH = "attach"
+    QUARANTINE = "quarantine"
+
+
+@dataclass(frozen=True)
+class WarmSlotKey:
+    """The identity of a pre-provisioned warm slot.
+
+    Attributes:
+        slot_id: Stable identifier of the warm slot.
+        pool_hash: The pool the slot was provisioned for.
+        effective_manifest_hash: The exact effective manifest the slot was
+            provisioned against. A dispatch attaches only when its effective
+            hash equals this value.
+    """
+
+    slot_id: str
+    pool_hash: str
+    effective_manifest_hash: str
+
+
+def slot_matches(slot: WarmSlotKey, dispatch_effective_hash: str) -> bool:
+    """Return whether *slot* may serve a dispatch with *dispatch_effective_hash*.
+
+    Equality of the effective manifest hash is the whole contract: a warm slot
+    provisioned for one manifest can never be handed to a dispatch that computed
+    a different manifest, no matter how small the divergence.
+    """
+    return bool(slot.effective_manifest_hash) and slot.effective_manifest_hash == dispatch_effective_hash
+
+
+def evaluate_warm_claim(slot: WarmSlotKey, dispatch_effective_hash: str) -> WarmClaimOutcome:
+    """Return :class:`WarmClaimOutcome.ATTACH` on hash equality, else quarantine."""
+    return WarmClaimOutcome.ATTACH if slot_matches(slot, dispatch_effective_hash) else WarmClaimOutcome.QUARANTINE
+
+
+def record_quarantine(
+    *,
+    chain: AuditChainStore,
+    slot: WarmSlotKey,
+    dispatch_effective_hash: str,
+) -> None:
+    """Mirror a warm-slot quarantine into the HMAC audit chain.
+
+    Records both the provisioned and dispatch effective hashes so the infra
+    drift that caused the divergence is chain-attested, and the caller then
+    falls back to cold provisioning.
+    """
+    from bernstein.core.security.audit_chain import record_pool_warm_quarantine
+
+    record_pool_warm_quarantine(
+        chain=chain,
+        pool_hash=slot.pool_hash,
+        provisioned_manifest_hash=slot.effective_manifest_hash,
+        dispatch_manifest_hash=dispatch_effective_hash,
+        slot_id=slot.slot_id,
+    )
+
+
+__all__ = [
+    "WarmClaimOutcome",
+    "WarmSlotKey",
+    "evaluate_warm_claim",
+    "record_quarantine",
+    "slot_matches",
+]

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -5550,6 +5550,353 @@ def record_cache_eviction(
     )
 
 
+# ---------------------------------------------------------------------------
+# Named sandbox pools (#2547)
+# ---------------------------------------------------------------------------
+# A pool's lifecycle lives in the chain: register/update/retire events are the
+# only mutation path, and the runtime pool registry is a deterministic
+# projection rebuilt by replaying them (see
+# ``bernstein.core.sandbox.pool_registry``). Placement is a receipt: every
+# dispatch seals ``(pool_hash, effective_manifest_hash, chosen_backend)`` so a
+# run's placement is provable offline from the chain alone, and a refused
+# override is itself chained so an over-broad recipe leaves a tamper-evident
+# trace instead of merely being absent from logs.
+
+#: A pool manifest was registered. Records the pool name and its canonical
+#: ``pool_hash`` so the registry projection can be rebuilt from the chain.
+EVENT_POOL_REGISTERED = "pool.registered"
+
+#: A pool manifest was updated (superseded by a new canonical hash). Records
+#: both the prior and the new ``pool_hash`` so the projection is unambiguous.
+EVENT_POOL_UPDATED = "pool.updated"
+
+#: A pool was retired. The projection drops it; existing receipts still verify.
+EVENT_POOL_RETIRED = "pool.retired"
+
+#: A governed override was refused by the pool ceiling before any sandbox was
+#: created. Records the pool, the offending field, and the machine-readable
+#: refusal reason so the fail-closed decision is chain-attested, not just a log.
+EVENT_POOL_OVERRIDE_REFUSED = "pool.override_refused"
+
+#: A dispatch sealed its placement into the chain. Records the pool, template,
+#: overrides, and effective manifest hashes plus the chosen backend, so the
+#: placement of any run is provable offline (AC: verifiability).
+EVENT_POOL_PLACEMENT_RECEIPT = "pool.placement_receipt"
+
+#: A worker enrolled into a pool. Records the ``pool_hash``, the worker's
+#: install-identity key id, and the enrolment signature so the execution host
+#: of subsequent claims is cryptographically attributable (AC: verifiability).
+EVENT_POOL_WORKER_ENROLLED = "pool.worker_enrolled"
+
+#: A pool-scoped claim was signed by an enrolled worker. Records the claim
+#: hash, the worker key id, the signature, and the placement receipt hash so a
+#: reviewer can prove which enrolled host executed the run.
+EVENT_POOL_CLAIM_RECEIPT = "pool.claim_receipt"
+
+#: A warm pre-provisioned slot was quarantined because its provisioned manifest
+#: hash diverged from the dispatch's effective hash. Records both hashes so the
+#: infra drift is chain-attested and the dispatch falls back to cold cleanly.
+EVENT_POOL_WARM_QUARANTINE = "pool.warm_quarantine"
+
+
+def record_pool_registered(
+    *,
+    chain: AuditChainStore,
+    pool_name: str,
+    pool_hash: str,
+    actor: str = "operator",
+) -> AuditEvent:
+    """Append a ``pool.registered`` event into *chain* (#2547).
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        pool_name: Operator-facing pool name.
+        pool_hash: Canonical hash identifying the registered pool manifest.
+        actor: Recorded actor; defaults to ``"operator"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_POOL_REGISTERED,
+        actor=actor,
+        resource_type="sandbox_pool",
+        resource_id=pool_hash,
+        details={"pool_name": pool_name, "pool_hash": pool_hash},
+    )
+
+
+def record_pool_updated(
+    *,
+    chain: AuditChainStore,
+    pool_name: str,
+    pool_hash: str,
+    prev_pool_hash: str,
+    actor: str = "operator",
+) -> AuditEvent:
+    """Append a ``pool.updated`` event into *chain* (#2547).
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        pool_name: Operator-facing pool name.
+        pool_hash: New canonical hash identifying the pool manifest.
+        prev_pool_hash: The superseded pool hash for the same name.
+        actor: Recorded actor; defaults to ``"operator"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_POOL_UPDATED,
+        actor=actor,
+        resource_type="sandbox_pool",
+        resource_id=pool_hash,
+        details={"pool_name": pool_name, "pool_hash": pool_hash, "prev_pool_hash": prev_pool_hash},
+    )
+
+
+def record_pool_retired(
+    *,
+    chain: AuditChainStore,
+    pool_name: str,
+    pool_hash: str,
+    actor: str = "operator",
+) -> AuditEvent:
+    """Append a ``pool.retired`` event into *chain* (#2547).
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        pool_name: Operator-facing pool name.
+        pool_hash: Canonical hash of the retired pool manifest.
+        actor: Recorded actor; defaults to ``"operator"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_POOL_RETIRED,
+        actor=actor,
+        resource_type="sandbox_pool",
+        resource_id=pool_hash,
+        details={"pool_name": pool_name, "pool_hash": pool_hash},
+    )
+
+
+def record_pool_override_refused(
+    *,
+    chain: AuditChainStore,
+    pool_hash: str,
+    reason: str,
+    refused_field: str,
+    overrides_hash: str,
+    author: str = "recipe",
+    actor: str = "sandbox_pool",
+) -> AuditEvent:
+    """Append a ``pool.override_refused`` event into *chain* (#2547).
+
+    The refusal itself is a chained receipt: an override that widened egress,
+    added a credential env var beyond the ceiling, or touched a non-exposed
+    field leaves a tamper-evident trace and no sandbox is created.
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        pool_hash: Canonical hash of the pool that refused the override.
+        reason: Machine-readable refusal reason (e.g. ``egress_widened``).
+        refused_field: The offending override field.
+        overrides_hash: Hash of the canonical overrides that were refused.
+        author: Who authored the override (``"recipe"`` or ``"agent"``), so a
+            refusal driven by an agent-authored recipe is distinguishable.
+        actor: Recorded actor; defaults to ``"sandbox_pool"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_POOL_OVERRIDE_REFUSED,
+        actor=actor,
+        resource_type="sandbox_pool",
+        resource_id=pool_hash,
+        details={
+            "pool_hash": pool_hash,
+            "reason": reason,
+            "refused_field": refused_field,
+            "overrides_hash": overrides_hash,
+            "author": author,
+        },
+    )
+
+
+def record_pool_placement_receipt(
+    *,
+    chain: AuditChainStore,
+    placement_hash: str,
+    pool_hash: str,
+    template_hash: str,
+    overrides_hash: str,
+    effective_manifest_hash: str,
+    chosen_backend: str,
+    selector_inputs_hash: str,
+    actor: str = "sandbox_pool",
+) -> AuditEvent:
+    """Append a ``pool.placement_receipt`` event into *chain* (#2547).
+
+    Mirrors one sealed placement into the HMAC chain so the placement of any
+    run is provable offline. A verifier holding the same pool manifest and
+    recipe recomputes ``effective_manifest_hash`` byte-identically; flipping one
+    byte of the recorded effective manifest breaks chain verification.
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        placement_hash: Self-hash pinning the whole placement receipt.
+        pool_hash: The pool the placement targeted.
+        template_hash: Hash of the pool base template.
+        overrides_hash: Hash of the canonical overrides.
+        effective_manifest_hash: Hash pinning the effective manifest.
+        chosen_backend: The backend the pure selector chose.
+        selector_inputs_hash: Hash over the selector inputs the pick used.
+        actor: Recorded actor; defaults to ``"sandbox_pool"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_POOL_PLACEMENT_RECEIPT,
+        actor=actor,
+        resource_type="sandbox_placement",
+        resource_id=placement_hash,
+        details={
+            "placement_hash": placement_hash,
+            "pool_hash": pool_hash,
+            "template_hash": template_hash,
+            "overrides_hash": overrides_hash,
+            "effective_manifest_hash": effective_manifest_hash,
+            "chosen_backend": chosen_backend,
+            "selector_inputs_hash": selector_inputs_hash,
+        },
+    )
+
+
+def record_pool_worker_enrolled(
+    *,
+    chain: AuditChainStore,
+    pool_hash: str,
+    worker_name: str,
+    keyid: str,
+    enrolment_hash: str,
+    signature: str,
+    actor: str = "task_server",
+) -> AuditEvent:
+    """Append a ``pool.worker_enrolled`` event into *chain* (#2547).
+
+    Binds a worker's Ed25519 install-identity key id to a ``pool_hash`` so the
+    execution host of every subsequent claim is cryptographically attributable
+    and ``bernstein audit verify`` can prove it offline.
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        pool_hash: The pool the worker enrolled into.
+        worker_name: The worker's declared name.
+        keyid: The worker install-identity key thumbprint (RFC 7638).
+        enrolment_hash: Self-hash of the signed enrolment receipt body.
+        signature: Base64 Ed25519 signature over the enrolment body.
+        actor: Recorded actor; defaults to ``"task_server"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_POOL_WORKER_ENROLLED,
+        actor=actor,
+        resource_type="pool_worker",
+        resource_id=keyid,
+        details={
+            "pool_hash": pool_hash,
+            "worker_name": worker_name,
+            "keyid": keyid,
+            "enrolment_hash": enrolment_hash,
+            "signature": signature,
+        },
+    )
+
+
+def record_pool_claim_receipt(
+    *,
+    chain: AuditChainStore,
+    claim_hash: str,
+    pool_hash: str,
+    task_id: str,
+    keyid: str,
+    signature: str,
+    placement_hash: str,
+    actor: str = "pool_worker",
+) -> AuditEvent:
+    """Append a ``pool.claim_receipt`` event into *chain* (#2547).
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        claim_hash: Self-hash of the signed claim receipt body.
+        pool_hash: The pool the claim executed under.
+        task_id: The claimed task id.
+        keyid: The enrolled worker's install-identity key thumbprint.
+        signature: Base64 Ed25519 signature over the claim body.
+        placement_hash: The placement receipt hash the completion carries.
+        actor: Recorded actor; defaults to ``"pool_worker"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_POOL_CLAIM_RECEIPT,
+        actor=actor,
+        resource_type="pool_claim",
+        resource_id=claim_hash,
+        details={
+            "claim_hash": claim_hash,
+            "pool_hash": pool_hash,
+            "task_id": task_id,
+            "keyid": keyid,
+            "signature": signature,
+            "placement_hash": placement_hash,
+        },
+    )
+
+
+def record_pool_warm_quarantine(
+    *,
+    chain: AuditChainStore,
+    pool_hash: str,
+    provisioned_manifest_hash: str,
+    dispatch_manifest_hash: str,
+    slot_id: str,
+    actor: str = "sandbox_pool",
+) -> AuditEvent:
+    """Append a ``pool.warm_quarantine`` event into *chain* (#2547).
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        pool_hash: The pool the warm slot belonged to.
+        provisioned_manifest_hash: Effective hash the slot was provisioned for.
+        dispatch_manifest_hash: Effective hash the dispatch required.
+        slot_id: Identifier of the quarantined warm slot.
+        actor: Recorded actor; defaults to ``"sandbox_pool"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_POOL_WARM_QUARANTINE,
+        actor=actor,
+        resource_type="warm_slot",
+        resource_id=slot_id,
+        details={
+            "pool_hash": pool_hash,
+            "provisioned_manifest_hash": provisioned_manifest_hash,
+            "dispatch_manifest_hash": dispatch_manifest_hash,
+            "slot_id": slot_id,
+        },
+    )
+
+
 __all__ = [
     "AGENT_FRESH_RESTART_ON_RETRY",
     "EVENT_A2A_MESSAGE_RECEIPT",
@@ -5601,6 +5948,14 @@ __all__ = [
     "EVENT_PLUGIN_CONFORMANCE_RECEIPT",
     "EVENT_PLUGIN_INSTALL_RECEIPT",
     "EVENT_PLUGIN_UPDATE_RECEIPT",
+    "EVENT_POOL_CLAIM_RECEIPT",
+    "EVENT_POOL_OVERRIDE_REFUSED",
+    "EVENT_POOL_PLACEMENT_RECEIPT",
+    "EVENT_POOL_REGISTERED",
+    "EVENT_POOL_RETIRED",
+    "EVENT_POOL_UPDATED",
+    "EVENT_POOL_WARM_QUARANTINE",
+    "EVENT_POOL_WORKER_ENROLLED",
     "EVENT_PROCESS_REAP_RECEIPT",
     "EVENT_PROVENANCE_QUARANTINE",
     "EVENT_PROVENANCE_TAINT_DECISION",
@@ -5695,6 +6050,14 @@ __all__ = [
     "record_plugin_conformance_receipt",
     "record_plugin_install_receipt",
     "record_plugin_update_receipt",
+    "record_pool_claim_receipt",
+    "record_pool_override_refused",
+    "record_pool_placement_receipt",
+    "record_pool_registered",
+    "record_pool_retired",
+    "record_pool_updated",
+    "record_pool_warm_quarantine",
+    "record_pool_worker_enrolled",
     "record_process_reap_receipt",
     "record_provenance_quarantine",
     "record_provider_state_mutation",

--- a/tests/property/test_pool_determinism.py
+++ b/tests/property/test_pool_determinism.py
@@ -1,0 +1,88 @@
+"""Property test: pool placement is deterministic across override permutations.
+
+Acceptance criterion (determinism): two hosts holding the same pool manifest and
+the same recipe produce byte-identical effective manifests, and their placement
+receipts agree on (pool_hash, effective_manifest_hash, chosen_backend) -- proven
+here across a property space of override permutations.
+"""
+
+from __future__ import annotations
+
+import hypothesis.strategies as st
+from hypothesis import given, settings
+
+from bernstein.core.sandbox.backend import SandboxCapability
+from bernstein.core.sandbox.pool import PoolManifest, PoolWorkspaceTemplate, merge_pool_overrides
+from bernstein.core.sandbox.pool_placement import seal_placement
+
+KNOWN_CREDS = frozenset({"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"})
+
+
+def _pool() -> PoolManifest:
+    return PoolManifest(
+        name="ci-linux",
+        backend_allowlist=("worktree", "docker"),
+        template=PoolWorkspaceTemplate(env={"FOO": "bar"}, timeout_seconds=900),
+        exposed_fields=("env", "timeout_seconds", "network_egress_class", "capabilities"),
+        capability_ceiling=frozenset({SandboxCapability.FILE_RW, SandboxCapability.EXEC, SandboxCapability.NETWORK}),
+        network_egress_class="restricted",
+        credential_env_allowlist=frozenset({"AWS_ACCESS_KEY_ID"}),
+    )
+
+
+_env_names = st.sampled_from(["A", "B", "C", "AWS_ACCESS_KEY_ID", "PATHX"])
+_egress = st.sampled_from(["none", "loopback", "restricted"])  # never wider than ceiling
+_caps = st.lists(st.sampled_from(["exec", "file_rw", "network"]), unique=True, max_size=3)
+
+
+@st.composite
+def _valid_overrides(draw):
+    ov: dict = {}
+    if draw(st.booleans()):
+        env = draw(st.dictionaries(_env_names, st.text(min_size=0, max_size=5), max_size=4))
+        ov["env"] = env
+    if draw(st.booleans()):
+        ov["timeout_seconds"] = draw(st.integers(min_value=1, max_value=7200))
+    if draw(st.booleans()):
+        ov["network_egress_class"] = draw(_egress)
+    if draw(st.booleans()):
+        ov["capabilities"] = draw(_caps)
+    return ov
+
+
+def _shuffle_mapping(mapping: dict, order: list[int]) -> dict:
+    """Rebuild *mapping* iterating its items in a permuted order."""
+    items = list(mapping.items())
+    permuted = [items[i % len(items)] for i in order] if items else []
+    out: dict = {}
+    for key, value in permuted:
+        out[key] = value
+    for key, value in items:  # ensure completeness regardless of permutation
+        out.setdefault(key, value)
+    return out
+
+
+@settings(max_examples=150, deadline=None)
+@given(overrides=_valid_overrides(), perm=st.lists(st.integers(min_value=0, max_value=8), max_size=8))
+def test_effective_manifest_hash_is_permutation_invariant(overrides, perm):
+    pool = _pool()
+    a = merge_pool_overrides(pool, overrides, known_credential_keys=KNOWN_CREDS)
+
+    reordered = dict(overrides)
+    if "env" in reordered and isinstance(reordered["env"], dict) and reordered["env"]:
+        reordered["env"] = _shuffle_mapping(reordered["env"], perm or [0])
+    # Rebuild the top-level dict in reverse key order too.
+    reordered = {k: reordered[k] for k in reversed(list(reordered))}
+    b = merge_pool_overrides(pool, reordered, known_credential_keys=KNOWN_CREDS)
+
+    assert a.effective_manifest_hash == b.effective_manifest_hash
+    assert a.overrides_hash == b.overrides_hash
+
+    ra = seal_placement(merge=a, chosen_backend="worktree", selector_inputs={"c": ["worktree"]}, timestamp=42)
+    rb = seal_placement(merge=b, chosen_backend="worktree", selector_inputs={"c": ["worktree"]}, timestamp=42)
+    assert (ra.pool_hash, ra.effective_manifest_hash, ra.chosen_backend) == (
+        rb.pool_hash,
+        rb.effective_manifest_hash,
+        rb.chosen_backend,
+    )
+    assert ra.placement_hash == rb.placement_hash

--- a/tests/unit/sandbox/test_pool_chain_integration.py
+++ b/tests/unit/sandbox/test_pool_chain_integration.py
@@ -1,0 +1,117 @@
+"""Chain-level integrity tests for pool receipts (#2547).
+
+These use a real :class:`AuditChainStore` with an isolated HMAC key to prove the
+substrate coupling: a placement receipt mirrored into the chain makes flipping
+one byte of the recorded effective manifest break ``chain.verify()`` -- exactly
+the tamper test the acceptance criteria demand.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from bernstein.core.sandbox.backend import SandboxCapability
+from bernstein.core.sandbox.pool import PoolManifest, PoolWorkspaceTemplate, merge_pool_overrides
+from bernstein.core.sandbox.pool_placement import record_placement, seal_placement
+from bernstein.core.sandbox.pool_warm import WarmSlotKey, record_quarantine
+from bernstein.core.security.audit_chain import (
+    AuditChainStore,
+    record_pool_override_refused,
+    record_pool_registered,
+    record_pool_worker_enrolled,
+)
+
+_ISOLATED_KEY = b"0123456789abcdef0123456789abcdef"
+
+
+@pytest.fixture
+def chain(tmp_path):
+    return AuditChainStore(tmp_path / "audit", key=_ISOLATED_KEY)
+
+
+def _pool() -> PoolManifest:
+    return PoolManifest(
+        name="ci-linux",
+        backend_allowlist=("worktree", "docker"),
+        template=PoolWorkspaceTemplate(env={"FOO": "bar"}),
+        exposed_fields=("env",),
+        capability_ceiling=frozenset({SandboxCapability.FILE_RW, SandboxCapability.EXEC}),
+    )
+
+
+class TestPlacementChainTamper:
+    def test_placement_recorded_and_chain_verifies(self, chain):
+        pool = _pool()
+        merge = merge_pool_overrides(pool, {"env": {"X": "1"}})
+        receipt = seal_placement(merge=merge, chosen_backend="worktree", selector_inputs={"k": "v"}, timestamp=1)
+        record_placement(chain=chain, receipt=receipt)
+        ok, errors = chain.verify()
+        assert ok, errors
+
+    def test_flipping_effective_manifest_byte_breaks_chain(self, chain, tmp_path):
+        pool = _pool()
+        merge = merge_pool_overrides(pool, {"env": {"X": "1"}})
+        receipt = seal_placement(merge=merge, chosen_backend="worktree", selector_inputs={"k": "v"}, timestamp=1)
+        record_placement(chain=chain, receipt=receipt)
+
+        # Tamper with the recorded effective manifest hash in the JSONL, as an
+        # auditor investigating a widened-egress dispute would detect.
+        audit_dir = tmp_path / "audit"
+        jsonl = next(audit_dir.glob("*.jsonl"))
+        lines = jsonl.read_text().splitlines()
+        mutated = []
+        for line in lines:
+            entry = json.loads(line)
+            details = entry.get("details", {})
+            if "effective_manifest_hash" in details:
+                details["effective_manifest_hash"] = "0" * 64
+            mutated.append(json.dumps(entry))
+        jsonl.write_text("\n".join(mutated) + "\n")
+
+        reopened = AuditChainStore(audit_dir, key=_ISOLATED_KEY)
+        ok, errors = reopened.verify()
+        assert not ok
+        assert errors
+
+
+class TestOtherPoolEvents:
+    def test_register_enrol_refuse_quarantine_chain_verifies(self, chain):
+        pool = _pool()
+        record_pool_registered(chain=chain, pool_name=pool.name, pool_hash=pool.pool_hash)
+        record_pool_worker_enrolled(
+            chain=chain,
+            pool_hash=pool.pool_hash,
+            worker_name="node-1",
+            keyid="kid-abc",
+            enrolment_hash="e" * 64,
+            signature="sig",
+        )
+        record_pool_override_refused(
+            chain=chain,
+            pool_hash=pool.pool_hash,
+            reason="egress_widened",
+            refused_field="network_egress_class",
+            overrides_hash="f" * 64,
+            author="agent",
+        )
+        slot = WarmSlotKey(slot_id="s1", pool_hash=pool.pool_hash, effective_manifest_hash="d" * 64)
+        record_quarantine(chain=chain, slot=slot, dispatch_effective_hash="e" * 64)
+        ok, errors = chain.verify()
+        assert ok, errors
+
+    def test_enrolled_event_names_worker_keyid(self, chain):
+        pool = _pool()
+        record_pool_worker_enrolled(
+            chain=chain,
+            pool_hash=pool.pool_hash,
+            worker_name="node-1",
+            keyid="kid-xyz",
+            enrolment_hash="e" * 64,
+            signature="sig",
+        )
+        events = chain.query(event_type="pool.worker_enrolled")
+        assert events
+        assert events[-1].details["keyid"] == "kid-xyz"
+        assert events[-1].details["pool_hash"] == pool.pool_hash

--- a/tests/unit/sandbox/test_pool_cmd.py
+++ b/tests/unit/sandbox/test_pool_cmd.py
@@ -1,0 +1,91 @@
+"""End-to-end CLI surface for named sandbox pools (#2547).
+
+Exercises ``bernstein pool register / list / show / verify`` against a throwaway
+working directory, proving the verbs are wired and that verify catches a
+tampered pool body.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from bernstein.cli.commands.pool_cmd import pool_group
+
+_SPEC = {
+    "name": "ci-linux",
+    "backend_allowlist": ["worktree", "docker"],
+    "template": {"root": "/workspace", "env": {"FOO": "bar"}, "timeout_seconds": 900},
+    "exposed_fields": ["env", "timeout_seconds"],
+    "capability_ceiling": ["file_rw", "exec", "network"],
+    "network_egress_class": "restricted",
+    "credential_env_allowlist": ["AWS_ACCESS_KEY_ID"],
+    "max_concurrency": 4,
+}
+
+
+def _write_spec(path: Path) -> Path:
+    spec_file = path / "pool.json"
+    spec_file.write_text(json.dumps(_SPEC), encoding="utf-8")
+    return spec_file
+
+
+def _run(args: list[str]):
+    return CliRunner().invoke(pool_group, args)
+
+
+class TestPoolCli:
+    def test_register_list_show(self, tmp_path: Path):
+        spec = _write_spec(tmp_path)
+        res = _run(["register", str(spec), "--workdir", str(tmp_path)])
+        assert res.exit_code == 0, res.output
+        assert "registered" in res.output.lower()
+
+        res = _run(["list", "--workdir", str(tmp_path), "--json"])
+        assert res.exit_code == 0, res.output
+        pools = json.loads(res.output)["pools"]
+        assert "ci-linux" in pools
+
+        res = _run(["show", "ci-linux", "--workdir", str(tmp_path)])
+        assert res.exit_code == 0, res.output
+        body = json.loads(res.output)
+        assert body["name"] == "ci-linux"
+        assert len(body["pool_hash"]) == 64
+
+    def test_verify_passes_for_clean_store(self, tmp_path: Path):
+        spec = _write_spec(tmp_path)
+        _run(["register", str(spec), "--workdir", str(tmp_path)])
+        res = _run(["verify", "--workdir", str(tmp_path)])
+        assert res.exit_code == 0, res.output
+        assert "passed" in res.output.lower()
+
+    def test_verify_fails_on_tampered_body(self, tmp_path: Path):
+        spec = _write_spec(tmp_path)
+        _run(["register", str(spec), "--workdir", str(tmp_path)])
+        pools_dir = tmp_path / ".sdd" / "sandbox" / "pools"
+        body = next(pools_dir.glob("*.json"))
+        text = body.read_text().replace('"timeout_seconds":900', '"timeout_seconds":1')
+        assert '"timeout_seconds":1' in text
+        body.write_text(text)
+        res = _run(["verify", "--workdir", str(tmp_path)])
+        assert res.exit_code == 1, res.output
+        assert "failed" in res.output.lower()
+
+    def test_reregister_same_spec_is_unchanged(self, tmp_path: Path):
+        spec = _write_spec(tmp_path)
+        _run(["register", str(spec), "--workdir", str(tmp_path)])
+        res = _run(["register", str(spec), "--workdir", str(tmp_path)])
+        assert res.exit_code == 0, res.output
+        assert "unchanged" in res.output.lower()
+
+    def test_update_changes_hash(self, tmp_path: Path):
+        spec = _write_spec(tmp_path)
+        _run(["register", str(spec), "--workdir", str(tmp_path)])
+        updated = dict(_SPEC)
+        updated["template"] = {"root": "/workspace", "env": {"FOO": "baz"}, "timeout_seconds": 1800}
+        spec.write_text(json.dumps(updated), encoding="utf-8")
+        res = _run(["register", str(spec), "--workdir", str(tmp_path)])
+        assert res.exit_code == 0, res.output
+        assert "updated" in res.output.lower()

--- a/tests/unit/sandbox/test_pool_enrolment.py
+++ b/tests/unit/sandbox/test_pool_enrolment.py
@@ -1,0 +1,94 @@
+"""Tests for signed worker enrolment and claim receipts (#2547).
+
+Covers the verifiability criterion: a claim is signed by the enrolled worker's
+key id and is provable offline; a receipt made under a rotated install identity
+names a key id absent from the current directory and fails deterministically.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from bernstein.core.identity.http_signing import build_key_directory
+from bernstein.core.sandbox.pool_enrolment import (
+    build_claim_receipt,
+    build_enrolment_receipt,
+    verify_claim_receipt,
+    verify_enrolment_receipt,
+)
+from bernstein.core.security.agent_card_keystore import AgentCardKeystore
+
+POOL_HASH = "a" * 64
+
+
+@pytest.fixture
+def keystore(tmp_path):
+    return AgentCardKeystore(tmp_path / "keys")
+
+
+class TestEnrolment:
+    def test_signed_receipt_verifies(self, keystore):
+        r = build_enrolment_receipt(keystore=keystore, pool_hash=POOL_HASH, worker_name="node-1", created=1700000000)
+        assert verify_enrolment_receipt(r)
+        assert verify_enrolment_receipt(r, key_directory=build_key_directory(keystore))
+
+    def test_keyid_is_install_identity_thumbprint(self, keystore):
+        from bernstein.core.identity.http_signing import install_identity_keyid
+
+        _priv, pub = keystore.load_or_generate()
+        r = build_enrolment_receipt(keystore=keystore, pool_hash=POOL_HASH, worker_name="n", created=1)
+        assert r.keyid == install_identity_keyid(pub)
+
+    def test_tampered_pool_hash_fails(self, keystore):
+        r = build_enrolment_receipt(keystore=keystore, pool_hash=POOL_HASH, worker_name="n", created=1)
+        forged = replace(r, pool_hash="b" * 64)  # signature no longer covers this body
+        assert not verify_enrolment_receipt(forged)
+
+    def test_rotated_identity_fails_against_current_directory(self, keystore):
+        r = build_enrolment_receipt(keystore=keystore, pool_hash=POOL_HASH, worker_name="n", created=1)
+        keystore.rotate()
+        # The current directory (post-rotation, no archived) no longer lists the
+        # key id the old receipt was signed under.
+        current = build_key_directory(keystore, include_archived=False)
+        assert not verify_enrolment_receipt(r, key_directory=current)
+
+    def test_swapped_keyid_fails(self, keystore):
+        r = build_enrolment_receipt(keystore=keystore, pool_hash=POOL_HASH, worker_name="n", created=1)
+        forged = replace(r, keyid="not-the-embedded-thumbprint")
+        assert not verify_enrolment_receipt(forged)
+
+    def test_roundtrip_dict(self, keystore):
+        from bernstein.core.sandbox.pool_enrolment import EnrolmentReceipt
+
+        r = build_enrolment_receipt(keystore=keystore, pool_hash=POOL_HASH, worker_name="n", created=1)
+        restored = EnrolmentReceipt.from_dict(r.to_dict())
+        assert verify_enrolment_receipt(restored)
+        assert restored.enrolment_hash() == r.enrolment_hash()
+
+
+class TestClaim:
+    def test_claim_signed_by_enrolled_key_verifies(self, keystore):
+        enrol = build_enrolment_receipt(keystore=keystore, pool_hash=POOL_HASH, worker_name="n", created=1)
+        claim = build_claim_receipt(
+            keystore=keystore, pool_hash=POOL_HASH, task_id="t-1", placement_hash="c" * 64, created=2
+        )
+        assert verify_claim_receipt(claim, enrolled_keyid=enrol.keyid)
+
+    def test_claim_from_other_key_rejected(self, keystore, tmp_path):
+        enrol = build_enrolment_receipt(keystore=keystore, pool_hash=POOL_HASH, worker_name="n", created=1)
+        other = AgentCardKeystore(tmp_path / "other-keys")
+        claim = build_claim_receipt(
+            keystore=other, pool_hash=POOL_HASH, task_id="t-1", placement_hash="c" * 64, created=2
+        )
+        # Claim is validly signed, but not by the enrolled worker key.
+        assert verify_claim_receipt(claim)
+        assert not verify_claim_receipt(claim, enrolled_keyid=enrol.keyid)
+
+    def test_tampered_claim_fails(self, keystore):
+        claim = build_claim_receipt(
+            keystore=keystore, pool_hash=POOL_HASH, task_id="t-1", placement_hash="c" * 64, created=2
+        )
+        forged = replace(claim, task_id="t-2")
+        assert not verify_claim_receipt(forged)

--- a/tests/unit/sandbox/test_pool_manifest.py
+++ b/tests/unit/sandbox/test_pool_manifest.py
@@ -1,0 +1,91 @@
+"""Tests for the frozen, chain-projected PoolManifest (#2547)."""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.sandbox.backend import SandboxCapability
+from bernstein.core.sandbox.pool import (
+    BASE_CAPABILITIES,
+    PoolManifest,
+    PoolManifestError,
+    PoolWorkspaceTemplate,
+)
+
+
+def _pool(**overrides) -> PoolManifest:
+    kwargs = dict(
+        name="ci-linux",
+        backend_allowlist=("worktree", "docker"),
+        template=PoolWorkspaceTemplate(root="/workspace", env={"FOO": "bar"}, timeout_seconds=900),
+        exposed_fields=("env", "timeout_seconds"),
+        capability_ceiling=frozenset({SandboxCapability.FILE_RW, SandboxCapability.EXEC, SandboxCapability.NETWORK}),
+        network_egress_class="restricted",
+        credential_env_allowlist=frozenset({"AWS_ACCESS_KEY_ID"}),
+    )
+    kwargs.update(overrides)
+    return PoolManifest(**kwargs)
+
+
+class TestPoolHash:
+    def test_pool_hash_is_64_hex(self):
+        pool = _pool()
+        assert len(pool.pool_hash) == 64
+        assert all(c in "0123456789abcdef" for c in pool.pool_hash)
+
+    def test_hash_is_stable_across_constructions(self):
+        assert _pool().pool_hash == _pool().pool_hash
+
+    def test_env_key_order_does_not_change_hash(self):
+        a = _pool(template=PoolWorkspaceTemplate(env={"A": "1", "B": "2"}))
+        b = _pool(template=PoolWorkspaceTemplate(env={"B": "2", "A": "1"}))
+        assert a.pool_hash == b.pool_hash
+
+    def test_different_name_changes_hash(self):
+        assert _pool(name="ci-linux").pool_hash != _pool(name="ci-mac").pool_hash
+
+    def test_capability_set_order_does_not_change_hash(self):
+        a = _pool(capability_ceiling=frozenset({SandboxCapability.FILE_RW, SandboxCapability.EXEC}))
+        b = _pool(capability_ceiling=frozenset({SandboxCapability.EXEC, SandboxCapability.FILE_RW}))
+        assert a.pool_hash == b.pool_hash
+
+
+class TestValidation:
+    def test_empty_name_rejected(self):
+        with pytest.raises(PoolManifestError):
+            _pool(name="")
+
+    def test_unknown_exposed_field_rejected(self):
+        with pytest.raises(PoolManifestError):
+            _pool(exposed_fields=("env", "not_a_field"))
+
+    def test_bad_egress_class_rejected(self):
+        with pytest.raises(PoolManifestError):
+            _pool(network_egress_class="firehose")
+
+    def test_ceiling_missing_base_capability_rejected(self):
+        with pytest.raises(PoolManifestError):
+            _pool(capability_ceiling=frozenset({SandboxCapability.FILE_RW}))
+
+    def test_wrong_pool_hash_rejected(self):
+        with pytest.raises(PoolManifestError):
+            PoolManifest(name="ci", pool_hash="0" * 64)
+
+    def test_base_capabilities_are_file_rw_and_exec(self):
+        expected = frozenset({SandboxCapability.FILE_RW, SandboxCapability.EXEC})
+        assert expected == BASE_CAPABILITIES
+
+
+class TestRoundTrip:
+    def test_to_dict_from_dict_preserves_hash(self):
+        pool = _pool()
+        restored = PoolManifest.from_dict(pool.to_dict())
+        assert restored.pool_hash == pool.pool_hash
+        assert restored.canonical_json() == pool.canonical_json()
+
+    def test_from_dict_recomputes_absent_hash(self):
+        pool = _pool()
+        spec = pool.to_dict()
+        spec.pop("pool_hash")
+        restored = PoolManifest.from_dict(spec)
+        assert restored.pool_hash == pool.pool_hash

--- a/tests/unit/sandbox/test_pool_merge.py
+++ b/tests/unit/sandbox/test_pool_merge.py
@@ -1,0 +1,138 @@
+"""Tests for governed override merge and fail-closed ceilings (#2547).
+
+Covers the acceptance criterion "Isolation, fail closed": an override that
+widens network egress or adds a credential env var beyond the pool ceiling is
+refused with a structured reason and *no sandbox is created*, for both a
+recipe-authored and an agent-authored override.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from bernstein.core.sandbox.backend import SandboxCapability
+from bernstein.core.sandbox.pool import (
+    PoolManifest,
+    PoolOverrideRefused,
+    PoolWorkspaceTemplate,
+    merge_pool_overrides,
+)
+
+KNOWN_CREDS = frozenset({"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "GITHUB_TOKEN"})
+
+
+def _pool(**overrides) -> PoolManifest:
+    kwargs = dict(
+        name="ci-linux",
+        backend_allowlist=("worktree", "docker"),
+        template=PoolWorkspaceTemplate(root="/workspace", env={"FOO": "bar"}, timeout_seconds=900),
+        exposed_fields=("env", "timeout_seconds", "network_egress_class", "capabilities", "backend"),
+        capability_ceiling=frozenset({SandboxCapability.FILE_RW, SandboxCapability.EXEC, SandboxCapability.NETWORK}),
+        network_egress_class="restricted",
+        credential_env_allowlist=frozenset({"AWS_ACCESS_KEY_ID"}),
+    )
+    kwargs.update(overrides)
+    return PoolManifest(**kwargs)
+
+
+class TestHappyPathMerge:
+    def test_empty_overrides_yields_base_template(self):
+        pool = _pool()
+        result = merge_pool_overrides(pool, {}, known_credential_keys=KNOWN_CREDS)
+        assert result.effective_template.env == {"FOO": "bar"}
+        assert result.effective_template.timeout_seconds == 900
+        assert result.pool_hash == pool.pool_hash
+        assert len(result.effective_manifest_hash) == 64
+
+    def test_exposed_env_merges_over_base(self):
+        pool = _pool()
+        result = merge_pool_overrides(pool, {"env": {"EXTRA": "1"}}, known_credential_keys=KNOWN_CREDS)
+        assert result.effective_template.env == {"FOO": "bar", "EXTRA": "1"}
+
+    def test_allowlisted_credential_env_permitted(self):
+        pool = _pool()
+        result = merge_pool_overrides(pool, {"env": {"AWS_ACCESS_KEY_ID": "AKIA"}}, known_credential_keys=KNOWN_CREDS)
+        assert result.credential_env == ("AWS_ACCESS_KEY_ID",)
+
+    def test_capability_within_ceiling_permitted(self):
+        pool = _pool()
+        result = merge_pool_overrides(pool, {"capabilities": ["network"]}, known_credential_keys=KNOWN_CREDS)
+        assert SandboxCapability.NETWORK in result.capabilities
+
+    def test_backend_override_within_allowlist(self):
+        pool = _pool()
+        result = merge_pool_overrides(pool, {"backend": "docker"}, known_credential_keys=KNOWN_CREDS)
+        assert result.backend_override == "docker"
+
+
+class TestFailClosed:
+    @pytest.mark.parametrize("author", ["recipe", "agent"])
+    def test_widened_egress_refused(self, author):
+        pool = _pool()
+        with pytest.raises(PoolOverrideRefused) as exc:
+            merge_pool_overrides(pool, {"network_egress_class": "open"}, known_credential_keys=KNOWN_CREDS)
+        assert exc.value.reason == "egress_widened"
+        assert exc.value.field == "network_egress_class"
+
+    @pytest.mark.parametrize("author", ["recipe", "agent"])
+    def test_credential_env_beyond_allowlist_refused(self, author):
+        pool = _pool()
+        with pytest.raises(PoolOverrideRefused) as exc:
+            merge_pool_overrides(pool, {"env": {"AWS_SECRET_ACCESS_KEY": "s3cr3t"}}, known_credential_keys=KNOWN_CREDS)
+        assert exc.value.reason == "credential_env_not_allowed"
+
+    def test_non_exposed_field_refused(self):
+        pool = _pool(exposed_fields=("env",))
+        with pytest.raises(PoolOverrideRefused) as exc:
+            merge_pool_overrides(pool, {"timeout_seconds": 60}, known_credential_keys=KNOWN_CREDS)
+        assert exc.value.reason == "non_exposed_field"
+
+    def test_capability_above_ceiling_refused(self):
+        pool = _pool(
+            capability_ceiling=frozenset({SandboxCapability.FILE_RW, SandboxCapability.EXEC}),
+        )
+        with pytest.raises(PoolOverrideRefused) as exc:
+            merge_pool_overrides(pool, {"capabilities": ["gpu"]}, known_credential_keys=KNOWN_CREDS)
+        assert exc.value.reason == "capability_above_ceiling"
+
+    def test_backend_outside_allowlist_refused(self):
+        pool = _pool()
+        with pytest.raises(PoolOverrideRefused) as exc:
+            merge_pool_overrides(pool, {"backend": "e2b"}, known_credential_keys=KNOWN_CREDS)
+        assert exc.value.reason == "backend_not_allowed"
+
+    def test_no_sandbox_created_on_refusal(self):
+        """A refused override raises before any backend is ever touched."""
+        pool = _pool()
+        spy_backend = MagicMock()
+        backends = [spy_backend]
+        with pytest.raises(PoolOverrideRefused):
+            # Merge is the precondition to selection; it raises first, so a
+            # dispatch never reaches select_pool_backend and no backend is
+            # instantiated or created.
+            merge = merge_pool_overrides(pool, {"network_egress_class": "open"}, known_credential_keys=KNOWN_CREDS)
+            from bernstein.core.sandbox.pool_placement import select_pool_backend
+
+            select_pool_backend(backends, merge, pool=pool)
+        spy_backend.create.assert_not_called()
+
+
+class TestDeterminism:
+    def test_override_key_order_does_not_change_effective_hash(self):
+        pool = _pool()
+        a = merge_pool_overrides(
+            pool, {"timeout_seconds": 1200, "env": {"A": "1", "B": "2"}}, known_credential_keys=KNOWN_CREDS
+        )
+        b = merge_pool_overrides(
+            pool, {"env": {"B": "2", "A": "1"}, "timeout_seconds": 1200}, known_credential_keys=KNOWN_CREDS
+        )
+        assert a.effective_manifest_hash == b.effective_manifest_hash
+        assert a.overrides_hash == b.overrides_hash
+
+    def test_capability_list_order_does_not_change_hash(self):
+        pool = _pool()
+        a = merge_pool_overrides(pool, {"capabilities": ["network", "exec"]}, known_credential_keys=KNOWN_CREDS)
+        b = merge_pool_overrides(pool, {"capabilities": ["exec", "network"]}, known_credential_keys=KNOWN_CREDS)
+        assert a.effective_manifest_hash == b.effective_manifest_hash

--- a/tests/unit/sandbox/test_pool_placement.py
+++ b/tests/unit/sandbox/test_pool_placement.py
@@ -1,0 +1,144 @@
+"""Tests for pool placement selection and sealed placement receipts (#2547).
+
+Covers the determinism criterion (two hosts agree on the placement tuple) and
+the verifiability criterion (a forged backend or widened effective manifest
+breaks receipt verification).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Any
+
+from bernstein.core.sandbox.backend import SandboxCapability
+from bernstein.core.sandbox.pool import PoolManifest, PoolWorkspaceTemplate, merge_pool_overrides
+from bernstein.core.sandbox.pool_placement import (
+    seal_placement,
+    select_pool_backend,
+    verify_placement_receipt,
+    write_placement_receipt,
+)
+
+_BASE_CAPS = frozenset({SandboxCapability.FILE_RW, SandboxCapability.EXEC})
+
+
+@dataclass(frozen=True)
+class StubBackend:
+    name: str
+    capabilities: frozenset[SandboxCapability] = _BASE_CAPS
+
+    async def create(self, manifest: Any, options: Any = None) -> Any:  # pragma: no cover
+        raise NotImplementedError
+
+    async def resume(self, snapshot_id: str) -> Any:  # pragma: no cover
+        raise NotImplementedError
+
+    async def destroy(self, session: Any) -> None:  # pragma: no cover
+        raise NotImplementedError
+
+
+def _pool(**overrides) -> PoolManifest:
+    kwargs = dict(
+        name="ci-linux",
+        backend_allowlist=("worktree", "docker"),
+        template=PoolWorkspaceTemplate(env={"FOO": "bar"}),
+        exposed_fields=("env", "backend"),
+        capability_ceiling=frozenset({SandboxCapability.FILE_RW, SandboxCapability.EXEC}),
+    )
+    kwargs.update(overrides)
+    return PoolManifest(**kwargs)
+
+
+class TestSelection:
+    def test_selects_first_allowlisted_backend(self):
+        pool = _pool()
+        merge = merge_pool_overrides(pool, {})
+        backends = [StubBackend("docker"), StubBackend("worktree"), StubBackend("e2b")]
+        chosen, inputs = select_pool_backend(backends, merge, pool=pool)
+        assert chosen.name == "worktree"  # allowlist order wins
+        assert "e2b" not in inputs["candidates"]  # filtered out (not allowlisted)
+
+    def test_backend_override_wins(self):
+        pool = _pool()
+        merge = merge_pool_overrides(pool, {"backend": "docker"})
+        backends = [StubBackend("worktree"), StubBackend("docker")]
+        chosen, _ = select_pool_backend(backends, merge, pool=pool)
+        assert chosen.name == "docker"
+
+    def test_two_hosts_agree_on_backend(self):
+        pool = _pool()
+        merge = merge_pool_overrides(pool, {"env": {"X": "1"}})
+        backends_a = [StubBackend("docker"), StubBackend("worktree")]
+        backends_b = [StubBackend("worktree"), StubBackend("docker")]
+        chosen_a, _ = select_pool_backend(backends_a, merge, pool=pool)
+        chosen_b, _ = select_pool_backend(backends_b, merge, pool=pool)
+        assert chosen_a.name == chosen_b.name
+
+
+class TestPlacementReceipt:
+    def test_seal_is_deterministic(self):
+        pool = _pool()
+        merge = merge_pool_overrides(pool, {"env": {"X": "1"}})
+        inputs = {"pool_hash": merge.pool_hash, "candidates": ["worktree"]}
+        a = seal_placement(merge=merge, chosen_backend="worktree", selector_inputs=inputs, timestamp=1700000000)
+        b = seal_placement(merge=merge, chosen_backend="worktree", selector_inputs=inputs, timestamp=1700000000)
+        assert a.placement_hash == b.placement_hash
+        # AC: placement receipts agree on (pool_hash, effective_manifest_hash, chosen_backend)
+        assert (a.pool_hash, a.effective_manifest_hash, a.chosen_backend) == (
+            b.pool_hash,
+            b.effective_manifest_hash,
+            b.chosen_backend,
+        )
+
+    def test_self_hash_verifies(self):
+        pool = _pool()
+        merge = merge_pool_overrides(pool, {})
+        r = seal_placement(merge=merge, chosen_backend="worktree", selector_inputs={}, timestamp=1)
+        assert r.verify_self_hash()
+
+    def test_forged_backend_breaks_self_hash(self):
+        pool = _pool()
+        merge = merge_pool_overrides(pool, {})
+        r = seal_placement(merge=merge, chosen_backend="worktree", selector_inputs={}, timestamp=1)
+        forged = replace(r, chosen_backend="e2b")  # placement_hash unchanged -> mismatch
+        assert not forged.verify_self_hash()
+
+    def test_widened_effective_manifest_breaks_self_hash(self):
+        pool = _pool()
+        merge = merge_pool_overrides(pool, {})
+        r = seal_placement(merge=merge, chosen_backend="worktree", selector_inputs={}, timestamp=1)
+        forged = replace(r, effective_manifest_hash="0" * 64)
+        assert not forged.verify_self_hash()
+
+    def test_on_disk_verify_roundtrip(self, tmp_path):
+        pool = _pool()
+        merge = merge_pool_overrides(pool, {})
+        r = seal_placement(merge=merge, chosen_backend="worktree", selector_inputs={}, timestamp=1)
+        write_placement_receipt(tmp_path, r)
+        result = verify_placement_receipt(tmp_path, r.placement_hash)
+        assert result.ok
+
+    def test_on_disk_tamper_detected(self, tmp_path):
+        pool = _pool()
+        merge = merge_pool_overrides(pool, {})
+        r = seal_placement(merge=merge, chosen_backend="worktree", selector_inputs={}, timestamp=1)
+        path = write_placement_receipt(tmp_path, r)
+        text = path.read_text().replace('"chosen_backend":"worktree"', '"chosen_backend":"e2b"')
+        path.write_text(text)
+        result = verify_placement_receipt(tmp_path, r.placement_hash)
+        assert not result.ok
+        assert "tampered" in result.reason
+
+    def test_missing_receipt_reports_absent(self, tmp_path):
+        result = verify_placement_receipt(tmp_path, "a" * 64)
+        assert not result.ok
+
+
+class TestRegression:
+    def test_selector_untouched_without_pool(self):
+        """With no pool, select_sandbox behaves exactly as today (import parity)."""
+        from bernstein.core.sandbox.selector import SandboxPolicy, select_sandbox
+
+        backends = [StubBackend("worktree"), StubBackend("docker")]
+        chosen = select_sandbox(backends, policy=SandboxPolicy())
+        assert chosen.name == "worktree"

--- a/tests/unit/sandbox/test_pool_registry.py
+++ b/tests/unit/sandbox/test_pool_registry.py
@@ -1,0 +1,112 @@
+"""Tests for the chain-projected pool registry and content store (#2547)."""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.sandbox.backend import SandboxCapability
+from bernstein.core.sandbox.pool import PoolManifest, PoolWorkspaceTemplate
+from bernstein.core.sandbox.pool_registry import (
+    PoolRegistry,
+    PoolStore,
+    PoolStoreError,
+    project_pool_registry,
+)
+
+
+def _pool(name: str, timeout: int = 900) -> PoolManifest:
+    return PoolManifest(
+        name=name,
+        backend_allowlist=("worktree",),
+        template=PoolWorkspaceTemplate(timeout_seconds=timeout),
+        exposed_fields=("env",),
+        capability_ceiling=frozenset({SandboxCapability.FILE_RW, SandboxCapability.EXEC}),
+    )
+
+
+def _ev(event_type: str, name: str, pool_hash: str) -> dict:
+    return {"event_type": event_type, "details": {"pool_name": name, "pool_hash": pool_hash}}
+
+
+class TestProjection:
+    def test_register_then_active(self):
+        p = _pool("a")
+        active = project_pool_registry([_ev("pool.registered", "a", p.pool_hash)])
+        assert active == {"a": p.pool_hash}
+
+    def test_update_supersedes(self):
+        p1, p2 = _pool("a", 900), _pool("a", 1800)
+        events = [
+            _ev("pool.registered", "a", p1.pool_hash),
+            _ev("pool.updated", "a", p2.pool_hash),
+        ]
+        assert project_pool_registry(events) == {"a": p2.pool_hash}
+
+    def test_retire_drops(self):
+        p = _pool("a")
+        events = [
+            _ev("pool.registered", "a", p.pool_hash),
+            _ev("pool.retired", "a", p.pool_hash),
+        ]
+        assert project_pool_registry(events) == {}
+
+    def test_non_pool_events_ignored(self):
+        p = _pool("a")
+        events = [
+            {"event_type": "cache.hit", "details": {"cache_key": "x"}},
+            _ev("pool.registered", "a", p.pool_hash),
+        ]
+        assert project_pool_registry(events) == {"a": p.pool_hash}
+
+    def test_projection_is_deterministic(self):
+        p1, p2 = _pool("a"), _pool("b")
+        events = [_ev("pool.registered", "a", p1.pool_hash), _ev("pool.registered", "b", p2.pool_hash)]
+        assert project_pool_registry(events) == project_pool_registry(events)
+
+
+class TestContentStore:
+    def test_put_get_roundtrip(self, tmp_path):
+        store = PoolStore(root=tmp_path)
+        p = _pool("a")
+        store.put(p)
+        loaded = store.get(p.pool_hash)
+        assert loaded.pool_hash == p.pool_hash
+
+    def test_tampered_body_refused(self, tmp_path):
+        store = PoolStore(root=tmp_path)
+        p = _pool("a")
+        path = store.put(p)
+        # Flip a byte inside the stored body without updating the filename hash.
+        text = path.read_text().replace('"timeout_seconds":900', '"timeout_seconds":1')
+        assert '"timeout_seconds":1' in text
+        path.write_text(text)
+        with pytest.raises(PoolStoreError):
+            store.get(p.pool_hash)
+
+    def test_missing_body_refused(self, tmp_path):
+        store = PoolStore(root=tmp_path)
+        with pytest.raises(PoolStoreError):
+            store.get("a" * 64)
+
+    def test_non_canonical_hash_refused(self, tmp_path):
+        store = PoolStore(root=tmp_path)
+        with pytest.raises(PoolStoreError):
+            store.get("../etc/passwd")
+
+
+class TestRegistry:
+    def test_registry_resolves_active_body(self, tmp_path):
+        store = PoolStore(root=tmp_path)
+        p = _pool("a")
+        store.put(p)
+        registry = PoolRegistry.from_events([_ev("pool.registered", "a", p.pool_hash)], store)
+        assert registry.names() == ["a"]
+        assert registry.get("a").pool_hash == p.pool_hash
+
+    def test_retired_pool_returns_none(self, tmp_path):
+        store = PoolStore(root=tmp_path)
+        p = _pool("a")
+        store.put(p)
+        events = [_ev("pool.registered", "a", p.pool_hash), _ev("pool.retired", "a", p.pool_hash)]
+        registry = PoolRegistry.from_events(events, store)
+        assert registry.get("a") is None

--- a/tests/unit/sandbox/test_pool_warm.py
+++ b/tests/unit/sandbox/test_pool_warm.py
@@ -1,0 +1,41 @@
+"""Tests for warm claim-ahead hash-equality keying (#2547).
+
+Covers: a warm slot only attaches when its provisioned manifest hash equals the
+dispatch's effective hash; a mismatch quarantines the slot (with a receipt) and
+the caller falls back to cold provisioning.
+"""
+
+from __future__ import annotations
+
+from bernstein.core.sandbox.pool_warm import (
+    WarmClaimOutcome,
+    WarmSlotKey,
+    evaluate_warm_claim,
+    slot_matches,
+)
+
+
+def _slot(effective: str) -> WarmSlotKey:
+    return WarmSlotKey(slot_id="slot-1", pool_hash="a" * 64, effective_manifest_hash=effective)
+
+
+class TestWarmClaim:
+    def test_equal_hash_attaches(self):
+        slot = _slot("d" * 64)
+        assert slot_matches(slot, "d" * 64)
+        assert evaluate_warm_claim(slot, "d" * 64) is WarmClaimOutcome.ATTACH
+
+    def test_divergent_hash_quarantines(self):
+        slot = _slot("d" * 64)
+        assert not slot_matches(slot, "e" * 64)
+        assert evaluate_warm_claim(slot, "e" * 64) is WarmClaimOutcome.QUARANTINE
+
+    def test_empty_provisioned_hash_never_attaches(self):
+        slot = _slot("")
+        assert not slot_matches(slot, "")
+        assert evaluate_warm_claim(slot, "") is WarmClaimOutcome.QUARANTINE
+
+    def test_single_byte_divergence_quarantines(self):
+        base = "d" * 63
+        slot = _slot(base + "0")
+        assert evaluate_warm_claim(slot, base + "1") is WarmClaimOutcome.QUARANTINE

--- a/tests/unit/sandbox/test_worker_pool_enrolment.py
+++ b/tests/unit/sandbox/test_worker_pool_enrolment.py
@@ -1,0 +1,85 @@
+"""Worker pool enrolment is signed and strictly outbound (#2547).
+
+Covers the acceptance criterion that a worker on a second host completes enrol
+against the task server with zero inbound connections: the enrolment path only
+ever issues client-initiated requests, and the enrolment receipt is a valid
+Ed25519 signature over the target pool hash.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.cli.commands import worker_cmd
+from bernstein.cli.commands.worker_cmd import WorkerLoop
+from bernstein.core.sandbox.pool_enrolment import EnrolmentReceipt, verify_enrolment_receipt
+
+POOL_HASH = "a" * 64
+
+
+class _RecordingClient:
+    """A stand-in httpx.Client that records outbound calls only."""
+
+    def __init__(self) -> None:
+        self.posts: list[tuple[str, dict]] = []
+
+    def post(self, url: str, json: dict | None = None, headers=None, timeout=None):
+        self.posts.append((url, json or {}))
+
+        class _Resp:
+            status_code = 200
+
+            def json(self_inner):
+                return {}
+
+        return _Resp()
+
+
+@pytest.fixture
+def loop(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> WorkerLoop:
+    # Isolate the install-identity keystore to the temp dir.
+    monkeypatch.setenv("BERNSTEIN_AGENT_CARD_KEY_DIR", str(tmp_path / "keys"))
+    return WorkerLoop(
+        server_url="http://central:8052",
+        name="node-2",
+        workdir=tmp_path,
+        pool="ci-linux",
+        pool_hash=POOL_HASH,
+    )
+
+
+class TestEnrolment:
+    def test_enrol_writes_verifiable_signed_receipt(self, loop: WorkerLoop, tmp_path: Path):
+        client = _RecordingClient()
+        loop._enrol(client)
+
+        enrol_dir = tmp_path / ".sdd" / "sandbox" / "enrolments"
+        files = list(enrol_dir.glob("*.json"))
+        assert files, "enrolment receipt was not persisted"
+        receipt = EnrolmentReceipt.from_dict(json.loads(files[0].read_text()))
+        assert receipt.pool_hash == POOL_HASH
+        assert verify_enrolment_receipt(receipt)
+
+    def test_enrol_is_outbound_only(self, loop: WorkerLoop):
+        client = _RecordingClient()
+        loop._enrol(client)
+        # Every network interaction was a worker-initiated POST; no inbound
+        # server-to-worker channel exists.
+        assert client.posts, "expected an outbound enrolment POST"
+        assert all(url.startswith("http://central:8052/") for url, _ in client.posts)
+
+    def test_no_inbound_socket_primitives_in_worker_module(self):
+        """The worker never binds or listens: it is a pure outbound poller."""
+        source = Path(worker_cmd.__file__).read_text()
+        assert ".bind(" not in source
+        assert ".listen(" not in source
+
+    def test_absent_pool_is_a_noop(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("BERNSTEIN_AGENT_CARD_KEY_DIR", str(tmp_path / "keys"))
+        loop = WorkerLoop(server_url="http://central:8052", name="node-3", workdir=tmp_path)
+        client = _RecordingClient()
+        loop._enrol(client)
+        assert client.posts == []  # no pool -> no enrolment, byte-identical to today

--- a/tests/unit/test_readme_api_coverage.py
+++ b/tests/unit/test_readme_api_coverage.py
@@ -290,6 +290,9 @@ DOCUMENTED_COMMANDS: frozenset[str] = frozenset(
         "context",
         # Bot-added: drift autofix (regen_contract_drift.py)
         "task",
+        # Named sandbox pools: chain-projected manifests, governed overrides,
+        # and signed worker enrolment (issue #2547)
+        "pool",
     }
 )
 


### PR DESCRIPTION
Closes #2547.

## What

Makes the sandbox pool a first-class chained object and makes placement a receipt. Additive and behavior-preserving: with no pools configured, selection, spawning, and `bernstein worker` behave byte-identically to today.

### Core substrate (`src/bernstein/core/sandbox/`)
- `pool.py` - frozen, canonicalized `PoolManifest` whose identity is its canonical sha256 (`pool_hash`), modelled on `core/config/manifest.py`; plus a pure `merge_pool_overrides` that schema-validates recipe overrides against the pool's exposed fields, merges them into the base template, and canonicalizes the result into `effective_manifest_hash`. Fail-closed: a non-exposed field, a capability above the ceiling, a widened egress class, or an out-of-allowlist credential env var is refused before any sandbox is created.
- `pool_registry.py` - the runtime pool registry is a deterministic projection of `pool.*` events over a content-addressed manifest store; there is no side database to drift, and a tampered body no longer recomputes to its hash.
- `pool_placement.py` - the selector stays a pure function; the pool is one declared input. Every dispatch seals a placement receipt over `(pool_hash, template_hash, overrides_hash, effective_manifest_hash, selector_inputs, chosen_backend)`. A forged backend or widened effective manifest recomputes to a different `placement_hash` and fails.
- `pool_enrolment.py` - signed worker enrolment and claim receipts bind the Ed25519 install identity to a `pool_hash`, so the execution host of any run is cryptographically attributable and verifiable offline; a rotated install identity fails deterministically.
- `pool_warm.py` - warm claim-ahead keyed by `effective_manifest_hash`: attach only on hash equality, quarantine with a receipt on divergence, cold fallback.

### Surface
- Additive `EVENT_POOL_*` constants and `record_pool_*` helpers in `audit_chain.py`.
- `bernstein pool register|list|show|verify` and an additive `--pool` enrolment flag on `bernstein worker` (strictly outbound).
- Pool integrity folded into `bernstein audit verify` as an orthogonal pillar.
- JSON schemas for the pool manifest and placement receipt under `schemas/`.
- Operations docs (`docs/operations/sandbox-pools.md`) and selector/fleet cross-references.

## Why

Operators running agent fleets across more than one machine need three guarantees at once: workflow authors (human or agent) can only tune the infra fields the platform exposes; centrally scheduled work executes on hosts the server cannot reach inbound; and the placement of every run is provable after the fact, offline, from the chain alone. Operators running compliance-sensitive workloads specifically need a widened egress or a swapped image to be tamper-evident, not merely absent from logs.

## Acceptance criteria

- [x] **Determinism** - two hosts holding the same pool manifest and recipe produce byte-identical effective manifests and agreeing placement tuples; property test across override permutations (`tests/property/test_pool_determinism.py`).
- [x] **Verifiability** - a claim is signed by the enrolled worker's key id and provable offline; flipping one byte of the recorded effective manifest breaks chain verification (`tests/unit/sandbox/test_pool_chain_integration.py`, `test_pool_enrolment.py`).
- [x] **Isolation, fail closed** - an override that widens egress or adds a credential env var beyond the ceiling is refused with a chained refusal receipt and no sandbox is created, for both recipe- and agent-authored overrides (`test_pool_merge.py`).
- [x] **Outbound-only worker** - the `--pool` enrolment path issues only worker-initiated requests; the worker never binds or listens (`test_worker_pool_enrolment.py`).
- [x] **Warm claim-ahead** - a slot attaches only when its provisioned manifest hash equals the dispatch's effective hash; a mismatch quarantines with a receipt (`test_pool_warm.py`).
- [x] **Regression** - with no pools configured, selection and spawning are unchanged; new command added to the documented-commands allowlist.

## Test evidence

`ruff check` + `ruff format --check` clean. New suites green (163 tests across `tests/unit/sandbox/` and the property test), plus regression on cluster auth, http signing, worker, and sandbox selector/spawner suites.