### PR TITLE
feat(missions): mission timeline screen and signed daily progress digests (#2510)

### DIFF
--- a/docs/operations/mission-timeline.md
+++ b/docs/operations/mission-timeline.md
@@ -1,0 +1,79 @@
+# Mission timeline and signed daily progress digests
+
+A **mission** is a multi-day goal decomposed into ordered phases, each with a
+verification gate and a budget envelope. Mission status is never stored: it is a
+pure deterministic projection over the mission's work-ledger chain plus the
+evidence bundles its phase receipts reference (see the
+[work ledger](work-ledger.md) and the review board's projection discipline).
+
+Two surfaces render that projection so operators do not have to reverse-engineer
+overnight progress from task lists and logs.
+
+## Mission timeline screen
+
+The web UI route `Missions` renders the deterministic mission projection:
+
+- **Phase lanes** with per-phase state (`pending` / `active` / `passed` /
+  `halted` / `unverified`), gate verdict, and per-phase envelope burn.
+- **Provenance on every element.** Each phase links to the gate receipt hash it
+  advanced by and to the sealed evidence bundle each gate task verified. No
+  element renders without a receipt-, ledger-, or evidence-backed origin.
+- **Status hash.** The screen shows the `mission_status_hash` so two operators
+  can confirm they are looking at the same folded state.
+- **Unverified banner.** When the work-ledger chain no longer recomputes (a
+  tampered entry) or a referenced evidence bundle no longer matches the hash its
+  receipt bound, the screen switches to an explicit unverified banner instead of
+  best-effort rendering.
+
+The read-only projection routes back this screen:
+
+| Route | Returns |
+| --- | --- |
+| `GET /missions` | mission ids with a ledger, newest first |
+| `GET /missions/{mission_id}` | the projection receipt: canonical status, `mission_status_hash`, `ledger_verified`, `evidence_verified` |
+| `GET /missions/{mission_id}/digest?fire_time=<epoch>` | the canonical digest for a fire instant, its `digest_hash` / `receipt_id`, and the verbatim chat message |
+| `GET /missions/{mission_id}/evidence/{task_id}` | the sealed evidence bundle behind a phase gate |
+
+The server holds no mission-side state; the same ledger bytes serve the same
+`mission_status_hash` from any host.
+
+## Signed daily progress digest
+
+A recurring fire computes a canonical **digest** from the mission projection at a
+fire instant: phases advanced, gates passed or failed, spend per envelope, and
+blockers. The digest is a pure fold of `(mission projection, fire time)`, so two
+operators holding byte-identical ledgers, folding at the same `fire_time`, derive
+byte-identical digest bytes and the same `digest_hash`. A missed fire recomputes
+to the identical digest after a restart.
+
+The digest is not a status message with a hash bolted on: the posted chat message
+is the verbatim projection of the digest, the `digest_hash` is embedded in the
+message and recorded in the HMAC audit chain as a `mission.digest_receipt`, and a
+verifier recomputes the digest from the ledger to prove the posted message matches
+the chain-attested receipt. An edited or truncated message is detected as a
+mismatch; a tampered receipt fails chain verification at its exact position.
+
+Delivery is idempotent on the digest receipt id (a pure function of
+`mission_id`, `fire_time`, and `digest_hash`): a restart between fire computation
+and chat delivery does not double-post. Delivery travels only over the common
+chat bridge `send_message` path, so it works uniformly across the Slack, Discord,
+and Telegram drivers.
+
+### CLI
+
+```bash
+# Print the canonical digest for a fire instant (read-only, no chain write).
+bernstein mission digest show <mission_id> --fire-time <epoch>
+
+# Record the digest receipt and post it to chat, idempotent per fire.
+bernstein mission digest send <mission_id> --fire-time <epoch> \
+    --platform slack --thread <channel>
+
+# Recompute the digest from the ledger and prove a posted message matches it.
+bernstein mission digest verify <mission_id> --fire-time <epoch> \
+    --message posted-message.txt
+```
+
+`verify` exits non-zero when the posted message does not match the
+ledger-recomputed digest, when the audit chain does not verify, or when no chain
+receipt binds the recomputed `digest_hash`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -293,6 +293,7 @@ nav:
           - Doctor: operations/doctor.md
           - Holds: operations/HOLDS.md
           - Review board: operations/review-board.md
+          - Mission timeline and digests: operations/mission-timeline.md
           - Work ledger: operations/work-ledger.md
           - Decision log: operations/decision-log.md
           - Intent capsules: operations/intent-capsules.md

--- a/src/bernstein/cli/commands/mission_cmd.py
+++ b/src/bernstein/cli/commands/mission_cmd.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
 
@@ -35,6 +36,10 @@ from bernstein.core.orchestration.missions import (
     project_mission_from_ledger,
 )
 from bernstein.core.persistence.work_ledger import LedgerError, LedgerReader, WorkLedger
+
+if TYPE_CHECKING:
+    from bernstein.core.chat.bridge import BridgeProtocol
+    from bernstein.core.orchestration.mission_digest import MissionDigest
 
 # Exit codes shared across the group so operators (and the dashboard) can
 # branch on the specific failure mode.
@@ -302,6 +307,268 @@ def mission_resume_cmd(mission_id: str, workdir: Path | None, output_json: bool)
             f"[green]Resumed mission[/green] {mission_id} from {projection.entry_count} ledger entries "
             f"(status {projection.status_hash[:16]}...)"
         )
+
+
+# ---------------------------------------------------------------------------
+# digest: signed daily progress digest (#2510)
+# ---------------------------------------------------------------------------
+
+
+_FIRE_TIME_OPTION = click.option(
+    "--fire-time",
+    type=int,
+    required=True,
+    help="Integer Unix epoch of the canonical fire instant.",
+)
+
+
+def _build_digest(workdir: Path | None, mission_id: str, fire_time: int) -> tuple[MissionProjection, MissionDigest]:
+    from bernstein.core.orchestration.mission_digest import build_mission_digest
+
+    projection = project_mission_from_ledger(
+        sdd_dir=_sdd_dir(workdir), workdir=_workdir(workdir), mission_id=mission_id
+    )
+    return projection, build_mission_digest(projection, fire_time=fire_time)
+
+
+def _build_bridge(platform: str, token: str) -> BridgeProtocol:
+    """Construct a chat driver for *platform*, mirroring ``chat serve`` conventions.
+
+    Overridable in tests to inject an in-memory bridge without touching the
+    network. Slack additionally needs its Socket Mode app token via
+    ``BERNSTEIN_SLACK_APP_TOKEN``.
+    """
+    import os
+
+    if platform == "slack":
+        from bernstein.core.chat.drivers.slack import SlackBridge
+
+        app_token = os.environ.get("BERNSTEIN_SLACK_APP_TOKEN", "")
+        if not app_token:
+            raise click.UsageError(
+                "Slack requires the Socket Mode app token in $BERNSTEIN_SLACK_APP_TOKEN (plus the bot token)."
+            )
+        return SlackBridge(token=token, app_token=app_token)
+    if platform == "discord":
+        from bernstein.core.chat.drivers.discord import DiscordBridge
+
+        return DiscordBridge(token=token)
+    if platform == "telegram":
+        from bernstein.core.chat.drivers.telegram import TelegramBridge
+
+        return TelegramBridge(token=token)
+    raise click.UsageError(f"unsupported platform {platform!r}: expected slack, discord, or telegram")
+
+
+@mission_group.group("digest")
+def digest_group() -> None:
+    """Signed daily progress digests: show, send, verify."""
+
+
+@digest_group.command("show")
+@click.argument("mission_id")
+@_FIRE_TIME_OPTION
+@_WORKDIR_OPTION
+@_JSON_OPTION
+def mission_digest_show_cmd(mission_id: str, fire_time: int, workdir: Path | None, output_json: bool) -> None:
+    """Compute and print the canonical digest for a fire instant (read-only).
+
+    The digest is a pure fold over the ledger at ``fire_time``; it writes
+    nothing to the chain. Two operators with the same ledger print the same
+    ``digest_hash``.
+
+    \b
+    Exit codes:
+        0  digest computed
+        1  no mission ledger for this id
+    """
+    from bernstein.core.orchestration.mission_digest import render_digest_message
+
+    _require_mission(workdir, mission_id)
+    _projection, digest = _build_digest(workdir, mission_id, fire_time)
+    message = render_digest_message(digest)
+    if output_json:
+        payload = {
+            **digest.to_dict(),
+            "digest_hash": digest.digest_hash(),
+            "receipt_id": digest.receipt_id(),
+            "message": message,
+        }
+        console.print_json(json.dumps(payload))
+    else:
+        console.print(message)
+
+
+@digest_group.command("send")
+@click.argument("mission_id")
+@_FIRE_TIME_OPTION
+@click.option("--platform", type=click.Choice(["slack", "discord", "telegram"]), required=True)
+@click.option("--thread", "thread_id", required=True, help="Chat thread / channel to post the digest to.")
+@click.option("--token", default="", help="Bot token (falls back to the platform's env var).")
+@click.option("--recurrence", default="", help="Canonical recurrence rule the fire was produced by.")
+@_WORKDIR_OPTION
+@_JSON_OPTION
+def mission_digest_send_cmd(
+    mission_id: str,
+    fire_time: int,
+    platform: str,
+    thread_id: str,
+    token: str,
+    recurrence: str,
+    workdir: Path | None,
+    output_json: bool,
+) -> None:
+    """Record a digest receipt and post it to chat, idempotent per fire.
+
+    Delivery is keyed on the digest receipt id, so re-running the same fire
+    (including after a restart) records nothing new and posts nothing.
+
+    \b
+    Exit codes:
+        0  digest posted, or already delivered (idempotent no-op)
+        1  no mission ledger for this id
+    """
+    import asyncio
+
+    from bernstein.core.orchestration.mission_digest_delivery import run_digest_fire
+    from bernstein.core.security.audit_chain import AuditChainStore
+
+    _require_mission(workdir, mission_id)
+    resolved_token = token or _platform_token(platform)
+    bridge = _build_bridge(platform, resolved_token)
+    chain = AuditChainStore(_sdd_dir(workdir) / "audit")
+
+    result = asyncio.run(
+        run_digest_fire(
+            sdd_dir=_sdd_dir(workdir),
+            workdir=_workdir(workdir),
+            mission_id=mission_id,
+            fire_time=fire_time,
+            chain=chain,
+            bridge=bridge,
+            thread_id=thread_id,
+            recurrence=recurrence,
+        )
+    )
+    outcome = result.outcome
+    if output_json:
+        console.print_json(
+            json.dumps(
+                {
+                    "mission_id": mission_id,
+                    "digest_hash": result.digest.digest_hash(),
+                    "receipt_id": outcome.receipt_id,
+                    "posted": outcome.posted,
+                    "message_id": outcome.message_id,
+                    "reason": outcome.reason,
+                    "recorded_receipt": result.recorded_receipt,
+                    "fire_graph_hash": result.fire_graph_hash,
+                }
+            )
+        )
+    elif outcome.posted:
+        console.print(
+            f"[green]Digest posted[/green] to {platform}:{thread_id} "
+            f"(digest {result.digest.digest_hash()[:16]}..., receipt {outcome.receipt_id})"
+        )
+    else:
+        console.print(f"[yellow]Digest already delivered[/yellow] (receipt {outcome.receipt_id}); no double-post.")
+
+
+def _platform_token(platform: str) -> str:
+    import os
+
+    env = {
+        "slack": "BERNSTEIN_SLACK_BOT_TOKEN",
+        "discord": "BERNSTEIN_DISCORD_TOKEN",
+        "telegram": "BERNSTEIN_TELEGRAM_TOKEN",
+    }[platform]
+    token = os.environ.get(env, "")
+    if not token:
+        raise click.UsageError(f"{platform} requires a bot token via --token or ${env}.")
+    return token
+
+
+@digest_group.command("verify")
+@click.argument("mission_id")
+@_FIRE_TIME_OPTION
+@click.option(
+    "--message",
+    "message_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    required=True,
+    help="Path to the posted chat message text to verify against the ledger.",
+)
+@_WORKDIR_OPTION
+@_JSON_OPTION
+def mission_digest_verify_cmd(
+    mission_id: str,
+    fire_time: int,
+    message_path: Path,
+    workdir: Path | None,
+    output_json: bool,
+) -> None:
+    """Recompute the digest from the ledger and prove a posted message matches.
+
+    Recomputes the canonical digest at ``fire_time`` from the ledger, then
+    checks the posted message equals the digest's verbatim projection. An
+    edited or truncated message is detected as a mismatch. When an audit chain
+    is present the recorded digest receipt is cross-checked too: the chain must
+    verify and carry a receipt binding this exact ``digest_hash``.
+
+    \b
+    Exit codes:
+        0  the posted message matches the ledger-recomputed digest
+        1  no mission ledger for this id
+        2  mismatch (edited / truncated message, or a torn receipt)
+    """
+    from bernstein.core.orchestration.mission_digest import verify_message_matches
+    from bernstein.core.security.audit_chain import EVENT_MISSION_DIGEST_RECEIPT, AuditChainStore
+
+    _require_mission(workdir, mission_id)
+    _projection, digest = _build_digest(workdir, mission_id, fire_time)
+    posted = message_path.read_text(encoding="utf-8")
+    result = verify_message_matches(posted, digest)
+
+    # Optional receipt-side proof: the chain must verify and carry the receipt.
+    audit_dir = _sdd_dir(workdir) / "audit"
+    chain_verified: bool | None = None
+    receipt_present: bool | None = None
+    if audit_dir.exists():
+        chain = AuditChainStore(audit_dir)
+        chain_verified = chain.verify()[0]
+        events = chain.query(event_type=EVENT_MISSION_DIGEST_RECEIPT)
+        receipt_present = any(e.details.get("digest_hash") == digest.digest_hash() for e in events)
+
+    ok = result.matches and (chain_verified is not False) and (receipt_present is not False)
+    if output_json:
+        console.print_json(
+            json.dumps(
+                {
+                    "mission_id": mission_id,
+                    "ok": ok,
+                    "message_matches": result.matches,
+                    "reason": result.reason,
+                    "digest_hash": digest.digest_hash(),
+                    "receipt_id": digest.receipt_id(),
+                    "chain_verified": chain_verified,
+                    "receipt_present": receipt_present,
+                }
+            )
+        )
+    elif ok:
+        console.print(
+            f"[green]Digest verified:[/green] posted message matches the ledger-recomputed digest "
+            f"{digest.digest_hash()[:16]}..."
+        )
+    else:
+        console.print(f"[red]Digest verification failed for {mission_id!r}:[/red] {result.reason}")
+        if chain_verified is False:
+            console.print("  [red]-[/red] the audit chain does not verify (a receipt was tampered with)")
+        if receipt_present is False:
+            console.print("  [red]-[/red] no chain receipt binds this digest hash")
+    if not ok:
+        raise SystemExit(EXIT_VERIFY_FAILED)
 
 
 __all__ = [

--- a/src/bernstein/core/orchestration/mission_digest.py
+++ b/src/bernstein/core/orchestration/mission_digest.py
@@ -1,0 +1,476 @@
+"""Signed daily progress digest: a mission projection folded to a chat receipt (#2510).
+
+A multi-day mission runs mostly while nobody is watching. The morning question
+is "what moved, what verified, what did it cost, what is blocked"; answering it
+today means opening the dashboard and mentally diffing against yesterday. A
+digest that is merely generated text would create a new problem -- a status
+message nobody can check against what actually ran -- so the digest carries the
+same guarantees as the run itself.
+
+The load-bearing property mirrors the mission projection
+(:mod:`bernstein.core.orchestration.missions`): the digest is a **pure
+deterministic projection** of ``(MissionProjection, fire_time)``. Because the
+projection is itself a pure fold over the work-ledger chain, the digest is a
+pure fold over the ledger too:
+
+* **Determinism** -- :func:`build_mission_digest` reads no wall clock and no
+  host state. Two operators holding byte-identical ledgers, folding at the same
+  ``fire_time``, derive byte-identical :meth:`MissionDigest.canonical_bytes`
+  and the same :meth:`MissionDigest.digest_hash`. A missed fire recomputes to
+  the identical digest after a restart.
+* **Verifiability** -- the posted chat message is the verbatim projection of
+  the digest (:func:`render_digest_message`), and the digest hash is embedded in
+  the message and recorded in the HMAC audit chain
+  (:func:`bernstein.core.security.audit_chain.record_mission_digest_receipt`).
+  :func:`verify_message_matches` recomputes the digest from the ledger and the
+  rendered message from the digest, so an edited or truncated chat message is
+  detected as a mismatch, and a tampered receipt fails chain verification at its
+  exact position.
+* **Idempotency** -- delivery is keyed on the digest receipt id
+  (:meth:`MissionDigest.receipt_id`), a pure function of
+  ``(mission_id, fire_time, digest_hash)``. A restart between fire computation
+  and chat delivery does not double-post: :class:`DigestDeliveryLedger` records
+  the delivered receipt id durably, and a re-fire of the same instant is a
+  no-op.
+
+Strip the ledger, the audit chain, and the deterministic fold, and the digest
+collapses to unverifiable prose. The digest is not "a status message plus a
+hash": it is the audit chain in the shape of a morning summary. What the
+operator reads is exactly what a verifier recomputes.
+
+Related work: the mission timeline UI (#2510) renders the same projection over
+the web surface; the deterministic fire projection
+(:mod:`bernstein.core.orchestration.schedule_projection`) anchors the recurring
+fire that computes the digest.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.orchestration.missions import (
+    MISSION_UNVERIFIED,
+    PHASE_ACTIVE,
+    PHASE_HALTED,
+    PHASE_PASSED,
+    PHASE_PENDING,
+    PHASE_UNVERIFIED,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+    from bernstein.core.orchestration.missions import MissionProjection, MissionStatus
+    from bernstein.core.security.audit_chain import AuditChainStore, AuditEvent
+
+#: Digest document schema version. Bump on any change to the canonical digest
+#: shape (the byte-identity witness across hosts). Bumping changes every
+#: ``digest_hash`` and is the single source of truth for when the deterministic
+#: contract is allowed to evolve.
+MISSION_DIGEST_SCHEMA_VERSION = 1
+
+#: Prefix of the deterministic digest receipt id (the delivery idempotency key).
+_RECEIPT_ID_PREFIX = "missiondigest-"
+
+
+# ---------------------------------------------------------------------------
+# Canonical helpers (identical discipline to missions.py so the two cannot drift)
+# ---------------------------------------------------------------------------
+
+
+def _canonical_bytes(payload: Mapping[str, Any]) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Digest document
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PhaseDigest:
+    """The digest projection of one phase: progress plus its provenance handle.
+
+    Every field is derived from the mission projection. ``receipt_hash`` and
+    ``evidence_bundle_hashes`` are the provenance the timeline and the digest
+    element link back to, so no line of the digest renders without a chain- or
+    ledger-backed origin.
+    """
+
+    phase_id: str
+    name: str
+    state: str
+    envelope: str
+    budget_usd: float
+    spend_usd: float
+    gate_passed: bool
+    receipt_hash: str
+    ledger_seq: int
+    evidence_bundle_hashes: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "phase_id": self.phase_id,
+            "name": self.name,
+            "state": self.state,
+            "envelope": self.envelope,
+            "budget_usd": self.budget_usd,
+            "spend_usd": self.spend_usd,
+            "gate_passed": self.gate_passed,
+            "receipt_hash": self.receipt_hash,
+            "ledger_seq": self.ledger_seq,
+            "evidence_bundle_hashes": list(self.evidence_bundle_hashes),
+        }
+
+
+@dataclass(frozen=True)
+class EnvelopeSpend:
+    """Per-envelope spend rollup, summed across phases that share an envelope."""
+
+    envelope: str
+    spend_usd: float
+    budget_usd: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "envelope": self.envelope,
+            "spend_usd": self.spend_usd,
+            "budget_usd": self.budget_usd,
+        }
+
+
+@dataclass(frozen=True)
+class Blocker:
+    """A phase that is holding the mission back (halted or unverified)."""
+
+    phase_id: str
+    state: str
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"phase_id": self.phase_id, "state": self.state, "reason": self.reason}
+
+
+@dataclass(frozen=True)
+class MissionDigest:
+    """The canonical, byte-stable daily progress digest of a mission.
+
+    A pure function of ``(MissionProjection, fire_time)``. Two hosts with the
+    same ledger and the same ``fire_time`` derive identical
+    :meth:`canonical_bytes` and :meth:`digest_hash`.
+    """
+
+    schema_version: int
+    mission_id: str
+    fire_time: int
+    mission_status_hash: str
+    spec_hash: str
+    goal_digest: str
+    overall: str
+    ledger_head: str
+    ledger_verified: bool
+    evidence_verified: bool
+    entry_count: int
+    phases: tuple[PhaseDigest, ...]
+    phases_passed: int
+    phases_active: int
+    phases_pending: int
+    phases_unverified: int
+    gates_passed: int
+    gates_failed: int
+    envelope_spend: tuple[EnvelopeSpend, ...]
+    total_spend_usd: float
+    blockers: tuple[Blocker, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "mission_id": self.mission_id,
+            "fire_time": self.fire_time,
+            "mission_status_hash": self.mission_status_hash,
+            "spec_hash": self.spec_hash,
+            "goal_digest": self.goal_digest,
+            "overall": self.overall,
+            "ledger_head": self.ledger_head,
+            "ledger_verified": self.ledger_verified,
+            "evidence_verified": self.evidence_verified,
+            "entry_count": self.entry_count,
+            "phases": [phase.to_dict() for phase in self.phases],
+            "phases_passed": self.phases_passed,
+            "phases_active": self.phases_active,
+            "phases_pending": self.phases_pending,
+            "phases_unverified": self.phases_unverified,
+            "gates_passed": self.gates_passed,
+            "gates_failed": self.gates_failed,
+            "envelope_spend": [row.to_dict() for row in self.envelope_spend],
+            "total_spend_usd": self.total_spend_usd,
+            "blockers": [blocker.to_dict() for blocker in self.blockers],
+        }
+
+    def canonical_bytes(self) -> bytes:
+        """Return the canonical UTF-8 JSON bytes the digest hash signs."""
+        return _canonical_bytes(self.to_dict())
+
+    def digest_hash(self) -> str:
+        """Return the SHA-256 hex digest of the canonical digest bytes."""
+        return _sha256_hex(self.canonical_bytes())
+
+    def receipt_id(self) -> str:
+        """Return the deterministic digest receipt id (delivery idempotency key).
+
+        A pure function of ``(mission_id, fire_time, digest_hash)``: the same
+        ledger state folded at the same fire instant yields the same id on any
+        host and after any restart, so delivery keyed on it never double-posts
+        and a missed fire recomputes to the identical key.
+        """
+        seed = f"{self.mission_id}|{self.fire_time}|{self.digest_hash()}".encode()
+        return _RECEIPT_ID_PREFIX + _sha256_hex(seed)[:24]
+
+
+# ---------------------------------------------------------------------------
+# Pure build: mission projection + fire time -> canonical digest
+# ---------------------------------------------------------------------------
+
+
+def _phase_digests(status: MissionStatus) -> tuple[PhaseDigest, ...]:
+    return tuple(
+        PhaseDigest(
+            phase_id=phase.phase_id,
+            name=phase.name,
+            state=phase.state,
+            envelope=phase.envelope,
+            budget_usd=phase.budget_usd,
+            spend_usd=phase.spend_usd,
+            gate_passed=phase.gate_passed,
+            receipt_hash=phase.receipt_hash,
+            ledger_seq=phase.ledger_seq,
+            evidence_bundle_hashes=phase.evidence_bundle_hashes,
+        )
+        for phase in status.phases
+    )
+
+
+def _envelope_spend(phases: Sequence[PhaseDigest]) -> tuple[EnvelopeSpend, ...]:
+    """Roll spend up by envelope, summed across phases sharing an envelope.
+
+    Ordered by envelope name so the canonical bytes are order-independent.
+    """
+    spend: dict[str, float] = {}
+    budget: dict[str, float] = {}
+    for phase in phases:
+        spend[phase.envelope] = spend.get(phase.envelope, 0.0) + phase.spend_usd
+        budget[phase.envelope] = budget.get(phase.envelope, 0.0) + phase.budget_usd
+    return tuple(EnvelopeSpend(envelope=env, spend_usd=spend[env], budget_usd=budget[env]) for env in sorted(spend))
+
+
+def _blockers(phases: Sequence[PhaseDigest]) -> tuple[Blocker, ...]:
+    out: list[Blocker] = []
+    for phase in phases:
+        if phase.state == PHASE_HALTED:
+            out.append(Blocker(phase_id=phase.phase_id, state=phase.state, reason="halted"))
+        elif phase.state == PHASE_UNVERIFIED:
+            out.append(Blocker(phase_id=phase.phase_id, state=phase.state, reason="evidence_unverified"))
+    return tuple(out)
+
+
+def build_mission_digest(projection: MissionProjection, *, fire_time: int) -> MissionDigest:
+    """Fold a mission projection at *fire_time* into a canonical digest.
+
+    PURE function: no wall clock, no filesystem, no host state. The only inputs
+    are the projection (itself a pure fold over the ledger) and the integer
+    fire instant, so two hosts holding byte-identical ledgers derive identical
+    :meth:`MissionDigest.canonical_bytes` and :meth:`MissionDigest.digest_hash`.
+
+    Args:
+        projection: The mission projection to summarise (see
+            :func:`bernstein.core.orchestration.missions.project_mission_from_ledger`).
+        fire_time: Unix epoch (integer seconds) of the canonical fire instant.
+            An ``int`` is required so sub-second drift cannot fork two
+            operators' digests (mirrors the schedule-fire float guard).
+
+    Returns:
+        A canonical :class:`MissionDigest`.
+
+    Raises:
+        TypeError: When ``fire_time`` is not an ``int``.
+    """
+    if not isinstance(fire_time, int) or isinstance(fire_time, bool):  # pyright: ignore[reportUnnecessaryIsInstance]
+        raise TypeError("fire_time must be an integer epoch second; floats permit cross-host drift")
+
+    status = projection.status
+    phases = _phase_digests(status)
+
+    phases_passed = sum(1 for p in phases if p.state == PHASE_PASSED)
+    phases_active = sum(1 for p in phases if p.state == PHASE_ACTIVE)
+    phases_pending = sum(1 for p in phases if p.state == PHASE_PENDING)
+    phases_unverified = sum(1 for p in phases if p.state == PHASE_UNVERIFIED)
+    gates_passed = sum(1 for p in phases if p.gate_passed)
+    gates_failed = sum(1 for p in phases if p.state == PHASE_HALTED)
+    total_spend = round(sum(p.spend_usd for p in phases), 6)
+
+    return MissionDigest(
+        schema_version=MISSION_DIGEST_SCHEMA_VERSION,
+        mission_id=status.mission_id,
+        fire_time=fire_time,
+        mission_status_hash=projection.status_hash,
+        spec_hash=status.spec_hash,
+        goal_digest=status.goal_digest,
+        overall=status.overall,
+        ledger_head=projection.ledger_head,
+        ledger_verified=projection.ledger_verified,
+        evidence_verified=projection.evidence_verified,
+        entry_count=projection.entry_count,
+        phases=phases,
+        phases_passed=phases_passed,
+        phases_active=phases_active,
+        phases_pending=phases_pending,
+        phases_unverified=phases_unverified,
+        gates_passed=gates_passed,
+        gates_failed=gates_failed,
+        envelope_spend=_envelope_spend(phases),
+        total_spend_usd=total_spend,
+        blockers=_blockers(phases),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Deterministic chat rendering (the message is the verbatim digest projection)
+# ---------------------------------------------------------------------------
+
+
+def render_digest_message(digest: MissionDigest) -> str:
+    """Render the digest into the exact chat message text, deterministically.
+
+    The message is a pure function of the digest, so what an operator reads is
+    exactly what :func:`verify_message_matches` recomputes. The digest hash and
+    receipt id are embedded so a recipient (or a bot) can recompute the digest
+    from the ledger and prove the message was not edited or truncated.
+    """
+    d = digest
+    trusted = d.ledger_verified and d.evidence_verified and d.overall != MISSION_UNVERIFIED
+    verified = "verified" if trusted else "UNVERIFIED"
+    lines: list[str] = [
+        f"Mission {d.mission_id} - daily progress digest",
+        f"overall: {d.overall} ({verified})",
+        f"phases: {d.phases_passed} passed, {d.phases_active} active, "
+        f"{d.phases_pending} pending, {d.phases_unverified} unverified",
+        f"gates: {d.gates_passed} passed, {d.gates_failed} failed",
+        f"spend: ${d.total_spend_usd:.2f} across {len(d.envelope_spend)} envelope(s)",
+    ]
+    for row in d.envelope_spend:
+        budget = f"/${row.budget_usd:.2f}" if row.budget_usd else ""
+        lines.append(f"  - {row.envelope}: ${row.spend_usd:.2f}{budget}")
+    if d.blockers:
+        lines.append(f"blockers: {len(d.blockers)}")
+        for blocker in d.blockers:
+            lines.append(f"  - {blocker.phase_id}: {blocker.reason}")
+    else:
+        lines.append("blockers: none")
+    lines.append(f"mission_status_hash: {d.mission_status_hash}")
+    lines.append(f"digest_hash: {d.digest_hash()}")
+    lines.append(f"receipt_id: {d.receipt_id()}")
+    return "\n".join(lines)
+
+
+@dataclass(frozen=True)
+class DigestVerification:
+    """Outcome of verifying a posted chat message against a recomputed digest."""
+
+    matches: bool
+    reason: str
+    digest_hash: str
+    receipt_id: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "matches": self.matches,
+            "reason": self.reason,
+            "digest_hash": self.digest_hash,
+            "receipt_id": self.receipt_id,
+        }
+
+
+def verify_message_matches(posted_text: str, digest: MissionDigest) -> DigestVerification:
+    """Verify a posted chat message equals the digest's verbatim projection.
+
+    Recomputes the canonical message from *digest* (which a caller recomputes
+    from the ledger) and compares it byte for byte against *posted_text*. Any
+    edit or truncation of the posted message surfaces as ``matches=False`` with
+    a reason. This is the message-side half of the proof; the receipt-side half
+    is chain verification of the recorded digest receipt.
+    """
+    expected = render_digest_message(digest)
+    digest_hash = digest.digest_hash()
+    receipt_id = digest.receipt_id()
+    if posted_text == expected:
+        return DigestVerification(matches=True, reason="ok", digest_hash=digest_hash, receipt_id=receipt_id)
+    if digest_hash not in posted_text:
+        reason = "digest_hash absent from posted message (edited or truncated)"
+    elif len(posted_text) != len(expected):
+        reason = "posted message length differs from digest projection (edited or truncated)"
+    else:
+        reason = "posted message body differs from digest projection (edited)"
+    return DigestVerification(matches=False, reason=reason, digest_hash=digest_hash, receipt_id=receipt_id)
+
+
+# ---------------------------------------------------------------------------
+# Chain anchoring: record the digest receipt into the HMAC audit chain
+# ---------------------------------------------------------------------------
+
+
+def record_digest_receipt(
+    chain: AuditChainStore,
+    digest: MissionDigest,
+    *,
+    schedule_id: str = "",
+    recurrence: str = "",
+    fire_graph_hash: str = "",
+    journal_entry_hash: str = "",
+) -> AuditEvent:
+    """Anchor *digest* into the HMAC audit chain as a mission digest receipt.
+
+    Thin wrapper over
+    :func:`bernstein.core.security.audit_chain.record_mission_digest_receipt`
+    that unpacks the digest's identity fields. Only hashes, counts, and the
+    envelope spend are recorded -- never goal text or task payloads.
+    """
+    from bernstein.core.security.audit_chain import record_mission_digest_receipt
+
+    return record_mission_digest_receipt(
+        chain=chain,
+        mission_id=digest.mission_id,
+        fire_time=digest.fire_time,
+        digest_hash=digest.digest_hash(),
+        receipt_id=digest.receipt_id(),
+        mission_status_hash=digest.mission_status_hash,
+        ledger_head=digest.ledger_head,
+        phases_passed=digest.phases_passed,
+        gates_passed=digest.gates_passed,
+        gates_failed=digest.gates_failed,
+        total_spend_usd=digest.total_spend_usd,
+        schedule_id=schedule_id,
+        recurrence=recurrence,
+        fire_graph_hash=fire_graph_hash,
+        journal_entry_hash=journal_entry_hash,
+    )
+
+
+__all__ = [
+    "MISSION_DIGEST_SCHEMA_VERSION",
+    "Blocker",
+    "DigestVerification",
+    "EnvelopeSpend",
+    "MissionDigest",
+    "PhaseDigest",
+    "build_mission_digest",
+    "record_digest_receipt",
+    "render_digest_message",
+    "verify_message_matches",
+]

--- a/src/bernstein/core/orchestration/mission_digest_delivery.py
+++ b/src/bernstein/core/orchestration/mission_digest_delivery.py
@@ -1,0 +1,288 @@
+"""Idempotent, chain-anchored delivery of a mission digest to chat (#2510).
+
+The recurring mission digest fire computes a canonical digest
+(:mod:`bernstein.core.orchestration.mission_digest`), anchors it in the HMAC
+audit chain, and posts it to a chat platform through the common bridge protocol
+(:class:`bernstein.core.chat.bridge.BridgeProtocol`). Two properties are
+load-bearing:
+
+* **Deterministic fire projection** -- the fire is anchored on a
+  :func:`bernstein.core.orchestration.schedule_projection.project` graph hash
+  keyed by ``(mission_id, fire_time, mission_status_hash)``, so two operators
+  provably fired the byte-identical digest for the byte-identical fire instant.
+* **Idempotent delivery** -- delivery is keyed on the digest receipt id, a pure
+  function of ``(mission_id, fire_time, digest_hash)``. :class:`DigestDeliveryLedger`
+  records the delivered receipt id durably (append-only, fsynced), so a restart
+  between fire computation and chat delivery does not double-post: a re-fire of
+  the same instant recomputes the identical digest and receipt id, sees it
+  already delivered, and is a no-op. A genuinely missed fire (never delivered)
+  is recomputable to the identical digest after restart and delivered exactly
+  once.
+
+The digest travels only over :meth:`BridgeProtocol.send_message`, so delivery
+works uniformly across every shipped driver (Slack, Discord, Telegram) with no
+driver-specific code path.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from bernstein.core.orchestration.mission_digest import (
+    build_mission_digest,
+    record_digest_receipt,
+    render_digest_message,
+)
+from bernstein.core.orchestration.missions import project_mission_from_ledger
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.chat.bridge import BridgeProtocol
+    from bernstein.core.orchestration.mission_digest import MissionDigest
+    from bernstein.core.security.audit_chain import AuditChainStore
+
+
+def digest_deliveries_dir(sdd_dir: Path) -> Path:
+    """Return the per-install digest-delivery ledger directory."""
+    return sdd_dir / "runtime" / "mission_digests"
+
+
+def digest_fire_graph_hash(
+    *,
+    mission_id: str,
+    fire_time: int,
+    mission_status_hash: str,
+    recurrence: str = "",
+) -> str:
+    """Return the deterministic schedule-fire graph hash for a digest fire.
+
+    A thin, pure use of the shipped schedule-fire projection: the digest fire is
+    a recurring goal whose ``last_state`` is the mission status hash, so two
+    operators with the same mission state at the same instant land on the same
+    ``graph_hash``. Bound into the digest receipt, it proves the digest was
+    fired under the byte-identical schedule definition.
+    """
+    from bernstein.core.orchestration.schedule_projection import project
+
+    result = project(
+        schedule_id=f"mission-digest:{mission_id}",
+        fire_time=fire_time,
+        last_state={"mission_status_hash": mission_status_hash},
+        goal=f"mission digest {mission_id}",
+        recurrence=recurrence,
+    )
+    return result.graph_hash
+
+
+@dataclass(frozen=True)
+class DeliveryOutcome:
+    """Result of a (possibly idempotent no-op) digest delivery."""
+
+    receipt_id: str
+    digest_hash: str
+    posted: bool
+    message_id: str
+    reason: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "receipt_id": self.receipt_id,
+            "digest_hash": self.digest_hash,
+            "posted": self.posted,
+            "message_id": self.message_id,
+            "reason": self.reason,
+        }
+
+
+class DigestDeliveryLedger:
+    """Durable append-only record of delivered digest receipt ids.
+
+    One JSONL file per mission under ``<sdd>/runtime/mission_digests/``. The
+    delivered set is the idempotency substrate: a receipt id present here has
+    already been posted, so a re-fire (including after a restart) is a no-op.
+    Reads scan the file fresh each call so a ledger constructed after a restart
+    sees every prior delivery.
+    """
+
+    __slots__ = ("_path",)
+
+    def __init__(self, sdd_dir: Path, mission_id: str) -> None:
+        self._path = digest_deliveries_dir(sdd_dir) / f"{mission_id}.jsonl"
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def delivered(self, receipt_id: str) -> bool:
+        """Return ``True`` when *receipt_id* was already delivered."""
+        return receipt_id in self._delivered_ids()
+
+    def _delivered_ids(self) -> set[str]:
+        if not self._path.exists():
+            return set()
+        out: set[str] = set()
+        with self._path.open(encoding="utf-8") as fh:
+            for raw in fh:
+                stripped = raw.strip()
+                if not stripped:
+                    continue
+                try:
+                    row = json.loads(stripped)
+                except json.JSONDecodeError:
+                    # Torn tail from a crash mid-write; prior rows stay valid.
+                    continue
+                receipt_id = row.get("receipt_id")
+                if isinstance(receipt_id, str):
+                    out.add(receipt_id)
+        return out
+
+    def mark_delivered(self, receipt_id: str, *, digest_hash: str, message_id: str, fire_time: int) -> None:
+        """Durably record that *receipt_id* was delivered (append + fsync)."""
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        row = {
+            "receipt_id": receipt_id,
+            "digest_hash": digest_hash,
+            "message_id": message_id,
+            "fire_time": fire_time,
+        }
+        line = json.dumps(row, sort_keys=True, separators=(",", ":")) + "\n"
+        fd = os.open(self._path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+        try:
+            os.write(fd, line.encode("utf-8"))
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+
+
+async def deliver_digest(
+    *,
+    bridge: BridgeProtocol,
+    thread_id: str,
+    digest: MissionDigest,
+    ledger: DigestDeliveryLedger,
+) -> DeliveryOutcome:
+    """Post *digest* to *thread_id* through *bridge*, idempotent on receipt id.
+
+    If the digest's receipt id is already recorded in *ledger*, this is a no-op
+    (``posted=False``) -- the guarantee a restart relies on. Otherwise the
+    verbatim digest projection is sent through the common bridge send path and
+    the receipt id is durably recorded before returning.
+    """
+    receipt_id = digest.receipt_id()
+    digest_hash = digest.digest_hash()
+    if ledger.delivered(receipt_id):
+        return DeliveryOutcome(
+            receipt_id=receipt_id,
+            digest_hash=digest_hash,
+            posted=False,
+            message_id="",
+            reason="already_delivered",
+        )
+    text = render_digest_message(digest)
+    message_id = await bridge.send_message(thread_id, text)
+    ledger.mark_delivered(receipt_id, digest_hash=digest_hash, message_id=message_id, fire_time=digest.fire_time)
+    return DeliveryOutcome(
+        receipt_id=receipt_id,
+        digest_hash=digest_hash,
+        posted=True,
+        message_id=message_id,
+        reason="posted",
+    )
+
+
+@dataclass(frozen=True)
+class DigestFireResult:
+    """The full outcome of one mission digest fire."""
+
+    digest: MissionDigest
+    outcome: DeliveryOutcome
+    recorded_receipt: bool
+    fire_graph_hash: str
+
+
+async def run_digest_fire(
+    *,
+    sdd_dir: Path,
+    workdir: Path,
+    mission_id: str,
+    fire_time: int,
+    chain: AuditChainStore,
+    bridge: BridgeProtocol,
+    thread_id: str,
+    recurrence: str = "",
+) -> DigestFireResult:
+    """Compute, anchor, and deliver a mission digest for one fire instant.
+
+    The whole fire is gated on the durable delivery ledger keyed by the digest
+    receipt id, so a re-fire of an already-delivered instant records nothing new
+    and posts nothing -- delivery and the chain receipt are both idempotent. The
+    digest is a pure fold over the ledger at ``fire_time``, so a missed fire
+    recomputes to the identical digest and receipt id after a restart.
+
+    Args:
+        sdd_dir: The install ``.sdd`` directory.
+        workdir: The project root (for evidence bundle recomputation).
+        mission_id: The mission to summarise.
+        fire_time: Integer Unix epoch of the canonical fire instant.
+        chain: The HMAC audit chain to anchor the digest receipt in.
+        bridge: The chat driver to post through (common bridge protocol).
+        thread_id: The chat thread / channel to post to.
+        recurrence: Canonical recurrence rule of the fire, when any.
+
+    Returns:
+        A :class:`DigestFireResult`.
+    """
+    projection = project_mission_from_ledger(sdd_dir=sdd_dir, workdir=workdir, mission_id=mission_id)
+    digest = build_mission_digest(projection, fire_time=fire_time)
+    ledger = DigestDeliveryLedger(sdd_dir, mission_id)
+
+    fire_graph = digest_fire_graph_hash(
+        mission_id=mission_id,
+        fire_time=fire_time,
+        mission_status_hash=digest.mission_status_hash,
+        recurrence=recurrence,
+    )
+
+    if ledger.delivered(digest.receipt_id()):
+        return DigestFireResult(
+            digest=digest,
+            outcome=DeliveryOutcome(
+                receipt_id=digest.receipt_id(),
+                digest_hash=digest.digest_hash(),
+                posted=False,
+                message_id="",
+                reason="already_delivered",
+            ),
+            recorded_receipt=False,
+            fire_graph_hash=fire_graph,
+        )
+
+    record_digest_receipt(
+        chain,
+        digest,
+        schedule_id=f"mission-digest:{mission_id}",
+        recurrence=recurrence,
+        fire_graph_hash=fire_graph,
+    )
+    outcome = await deliver_digest(bridge=bridge, thread_id=thread_id, digest=digest, ledger=ledger)
+    return DigestFireResult(
+        digest=digest,
+        outcome=outcome,
+        recorded_receipt=True,
+        fire_graph_hash=fire_graph,
+    )
+
+
+__all__ = [
+    "DeliveryOutcome",
+    "DigestDeliveryLedger",
+    "DigestFireResult",
+    "deliver_digest",
+    "digest_deliveries_dir",
+    "digest_fire_graph_hash",
+    "run_digest_fire",
+]

--- a/src/bernstein/core/orchestration/missions.py
+++ b/src/bernstein/core/orchestration/missions.py
@@ -627,6 +627,33 @@ def mission_ledger_dir(sdd_dir: Path, mission_id: str) -> Path:
     return run_ledger_dir(sdd_dir, mission_id)
 
 
+def list_missions(sdd_dir: Path) -> list[str]:
+    """Return mission ids under *sdd_dir* that declare a mission, newest first.
+
+    Missions and plain run ledgers share the ledger root; a directory is a
+    mission only when its ledger's first entry is a ``mission.defined``
+    transition. "Newest first" is by directory name (descending): mission ids
+    embed their creation ordering, and name order is a stable property of the
+    on-disk layout rather than of mtimes, which a copy can rewrite.
+    """
+    from bernstein.core.persistence.work_ledger import default_ledger_root
+
+    root = default_ledger_root(sdd_dir)
+    if not root.is_dir():
+        return []
+    found: list[str] = []
+    for entry in root.iterdir():
+        if not entry.is_dir():
+            continue
+        reader = LedgerReader(entry)
+        if not reader.exists():
+            continue
+        first = next(iter(reader.entries()), None)
+        if first is not None and first.kind == KIND_MISSION_DEFINED:
+            found.append(entry.name)
+    return sorted(found, reverse=True)
+
+
 def gather_evidence_hashes(workdir: Path, task_ids: Iterable[str]) -> dict[str, str]:
     """Recompute the content address of each task's sealed evidence bundle.
 
@@ -946,6 +973,7 @@ __all__ = [
     "enter_phase",
     "gather_evidence_hashes",
     "halt_phase",
+    "list_missions",
     "mission_ledger_dir",
     "pass_phase",
     "phase_envelope_key",

--- a/src/bernstein/core/routes/missions.py
+++ b/src/bernstein/core/routes/missions.py
@@ -1,0 +1,164 @@
+"""Mission timeline routes: an outcome-level view projected from the ledger (#2510).
+
+Task-level surfaces (tasks, fleet, approvals, costs, audit) are covered, but a
+multi-day mission has no outcome-level view. These endpoints put the mission
+projection -- phase lanes, gate receipts, per-phase envelope burn, and the daily
+progress digest -- on one web surface while keeping the mission a pure
+projection: the server folds the mission's work-ledger chain on every request
+and the client renders whatever the fold returns. There is no mission-side state
+anywhere, exactly like the review-board routes
+(:mod:`bernstein.core.routes.review_board`).
+
+* ``GET /missions`` -- mission ids with a ledger, newest first.
+* ``GET /missions/{mission_id}`` -- the mission projection receipt: canonical
+  status plus ``mission_status_hash``, ``ledger_head``, ``ledger_verified`` and
+  ``evidence_verified`` so two operators can confirm they are looking at the
+  same state. When chain verification fails the payload carries
+  ``ledger_verified=false`` and ``overall=unverified`` so the screen switches to
+  an explicit unverified banner rather than best-effort rendering.
+* ``GET /missions/{mission_id}/digest?fire_time=<epoch>`` -- the canonical daily
+  progress digest for a fire instant, its ``digest_hash`` / ``receipt_id``, and
+  the verbatim chat message the digest projects to. Read-only: it recomputes the
+  digest from the ledger and never writes to the chain.
+* ``GET /missions/{mission_id}/evidence/{task_id}`` -- the sealed evidence bundle
+  a phase gate verified, for the provenance link behind a timeline element.
+
+Bearer auth: the task server's auth middleware covers every read route here
+(none is registered as a public path). Every route is read-only; a mission
+mutation lives only in the work ledger, never here.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Final
+
+from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi.responses import JSONResponse
+
+from bernstein.core.evidence.bundle import read_evidence_bundle
+from bernstein.core.orchestration.mission_digest import build_mission_digest, render_digest_message
+from bernstein.core.orchestration.missions import (
+    LedgerReader,
+    list_missions,
+    mission_ledger_dir,
+    project_mission_from_ledger,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+#: Mission ids are directory names under the ledger root; reject anything that
+#: could carry a path separator, a NUL, or HTML-active characters before the
+#: value touches the filesystem or the page (mirrors the ledger's id alphabet).
+_MISSION_ID_RE: Final[re.Pattern[str]] = re.compile(r"^[A-Za-z0-9_.\-]{1,64}$")
+
+#: Task ids referenced by a phase gate; slug-shaped, defense in depth.
+_TASK_ID_RE: Final[re.Pattern[str]] = re.compile(r"^[A-Za-z0-9_.\-]{1,128}$")
+
+
+def _resolve_workdir(request: Request) -> Path:
+    """Locate the project root from app state (mirrors the review-board routes)."""
+    workdir = getattr(request.app.state, "workdir", None)
+    if isinstance(workdir, Path):
+        return workdir
+    sdd_dir = getattr(request.app.state, "sdd_dir", None)
+    if isinstance(sdd_dir, Path) and sdd_dir.name == ".sdd":
+        return sdd_dir.parent
+    return Path.cwd()
+
+
+def _validate_mission_id(mission_id: str) -> str:
+    if not _MISSION_ID_RE.fullmatch(mission_id):
+        raise HTTPException(status_code=400, detail="invalid mission id")
+    return mission_id
+
+
+def _validate_task_id(task_id: str) -> str:
+    if not _TASK_ID_RE.fullmatch(task_id):
+        raise HTTPException(status_code=400, detail="invalid task id")
+    return task_id
+
+
+def _require_mission(sdd_dir: Path, mission_id: str) -> None:
+    if not LedgerReader(mission_ledger_dir(sdd_dir, mission_id)).exists():
+        raise HTTPException(status_code=404, detail=f"no mission ledger for: {mission_id}")
+
+
+@router.get("/missions")
+def missions_list(request: Request) -> JSONResponse:
+    """List mission ids that have a ledger to project, newest first."""
+    sdd_dir = _resolve_workdir(request) / ".sdd"
+    return JSONResponse({"missions": list_missions(sdd_dir)})
+
+
+@router.get("/missions/{mission_id}")
+def mission_projection(mission_id: str, request: Request) -> JSONResponse:
+    """Serve the mission projection receipt for ``mission_id``.
+
+    The response is a deterministic function of the mission's ledger file: the
+    same ledger bytes serve the same ``status`` and ``mission_status_hash`` from
+    any server, so two operators cross-check byte for byte.
+    ``ledger_verified=false`` (with ``overall=unverified``) marks a chain that no
+    longer recomputes -- the timeline still renders, but the screen must show the
+    unverified banner instead of trusting the state.
+    """
+    mission_id = _validate_mission_id(mission_id)
+    workdir = _resolve_workdir(request)
+    sdd_dir = workdir / ".sdd"
+    _require_mission(sdd_dir, mission_id)
+    projection = project_mission_from_ledger(sdd_dir=sdd_dir, workdir=workdir, mission_id=mission_id)
+    return JSONResponse(projection.to_dict())
+
+
+@router.get("/missions/{mission_id}/digest")
+def mission_digest(
+    mission_id: str,
+    request: Request,
+    fire_time: int = Query(..., description="Integer Unix epoch of the canonical fire instant."),
+) -> JSONResponse:
+    """Serve the canonical daily progress digest for a fire instant.
+
+    Read-only: the digest is recomputed from the ledger as a pure fold, so the
+    endpoint never writes to the chain. The payload carries the ``digest_hash``,
+    the ``receipt_id`` (the per-fire delivery idempotency key), and the verbatim
+    ``message`` the digest projects to -- the exact bytes a chat delivery posts,
+    so a caller can cross-check a posted message against this projection.
+    """
+    mission_id = _validate_mission_id(mission_id)
+    if not isinstance(fire_time, int) or fire_time < 0:
+        raise HTTPException(status_code=400, detail="fire_time must be a non-negative integer epoch")
+    workdir = _resolve_workdir(request)
+    sdd_dir = workdir / ".sdd"
+    _require_mission(sdd_dir, mission_id)
+    projection = project_mission_from_ledger(sdd_dir=sdd_dir, workdir=workdir, mission_id=mission_id)
+    digest = build_mission_digest(projection, fire_time=fire_time)
+    payload = digest.to_dict()
+    payload["digest_hash"] = digest.digest_hash()
+    payload["receipt_id"] = digest.receipt_id()
+    payload["message"] = render_digest_message(digest)
+    return JSONResponse(payload)
+
+
+@router.get("/missions/{mission_id}/evidence/{task_id}")
+def mission_evidence(mission_id: str, task_id: str, request: Request) -> JSONResponse:
+    """Serve the sealed evidence bundle behind a timeline element's provenance link.
+
+    ``bundle_hash`` is recomputed from the canonical binding bytes on every read,
+    so the drawer always shows the bundle's current identity -- and a bundle that
+    no longer matches the hash a phase receipt bound projects that phase as
+    unverified in the mission projection above.
+    """
+    mission_id = _validate_mission_id(mission_id)
+    task_id = _validate_task_id(task_id)
+    workdir = _resolve_workdir(request)
+    _require_mission(workdir / ".sdd", mission_id)
+    bundle = read_evidence_bundle(workdir, task_id)
+    if bundle is None:
+        raise HTTPException(status_code=404, detail=f"no evidence bundle for task: {task_id}")
+    payload = bundle.to_dict()
+    payload["bundle_hash"] = bundle.bundle_hash()
+    return JSONResponse(payload)

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -704,6 +704,23 @@ EVENT_CONTEXT_CAPSULE = "context.capsule"
 #: never goal text or task payloads.
 EVENT_MISSION_PHASE_RECEIPT = "mission.phase_receipt"
 
+#: Issue #2510 -- emitted once per recurring mission digest fire. A mission
+#: digest is a pure deterministic projection of the mission state at a fire
+#: instant (see :mod:`bernstein.core.orchestration.mission_digest`); this event
+#: anchors that projection in the HMAC chain by recording ``{mission_id,
+#: fire_time, digest_hash, receipt_id, mission_status_hash, ledger_head,
+#: phases_passed, gates_passed, gates_failed, total_spend_usd, schedule_id,
+#: recurrence, fire_graph_hash, journal_entry_hash}`` plus the previous chain
+#: digest. The posted chat message embeds ``digest_hash``, so a recipient
+#: recomputes the digest from the ledger and proves the message matches the
+#: chain-attested receipt; a tampered receipt fails chain verification at its
+#: exact position. ``receipt_id`` is the per-fire delivery idempotency key, a
+#: pure function of ``(mission_id, fire_time, digest_hash)``, so a restart
+#: between fire computation and delivery does not double-post. Only identifiers,
+#: hashes, counts, and the spend are recorded -- never goal text or task
+#: payloads.
+EVENT_MISSION_DIGEST_RECEIPT = "mission.digest_receipt"
+
 #: Issue #2549 -- emitted whenever a per-goal SLA contract is evaluated against
 #: chain evidence inside a supervisor tick and found breached. A breach is a
 #: signed, offline-verifiable violation receipt (see
@@ -4869,6 +4886,85 @@ def record_mission_phase_receipt(
     )
 
 
+def record_mission_digest_receipt(
+    *,
+    chain: AuditChainStore,
+    mission_id: str,
+    fire_time: int,
+    digest_hash: str,
+    receipt_id: str,
+    mission_status_hash: str,
+    ledger_head: str,
+    phases_passed: int,
+    gates_passed: int,
+    gates_failed: int,
+    total_spend_usd: float,
+    schedule_id: str = "",
+    recurrence: str = "",
+    fire_graph_hash: str = "",
+    journal_entry_hash: str = "",
+    actor: str = "mission_digest",
+) -> AuditEvent:
+    """Append a ``mission.digest_receipt`` event into *chain* (#2510).
+
+    Anchors one recurring mission-digest fire in the HMAC chain. The digest is
+    a pure deterministic projection of the mission state at ``fire_time`` (see
+    :mod:`bernstein.core.orchestration.mission_digest`); ``digest_hash`` is the
+    hash of its canonical bytes, embedded in the posted chat message so a
+    recipient recomputes the digest from the ledger and proves the message
+    matches this chain-attested receipt. ``receipt_id`` is the per-fire delivery
+    idempotency key, a pure function of ``(mission_id, fire_time, digest_hash)``.
+    Only identifiers, hashes, counts, and the spend are recorded -- never goal
+    text or task payloads.
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        mission_id: The mission the digest summarises.
+        fire_time: Integer Unix epoch of the canonical fire instant.
+        digest_hash: Hex hash of the canonical digest bytes.
+        receipt_id: Deterministic per-fire delivery idempotency key.
+        mission_status_hash: The mission projection's status hash at fire time.
+        ledger_head: The work-ledger head the projection folded to.
+        phases_passed: Count of phases the digest reports as passed.
+        gates_passed: Count of phases whose verification gate passed.
+        gates_failed: Count of phases halted (gate failed / envelope exhausted).
+        total_spend_usd: Total spend across all envelopes at fire time.
+        schedule_id: The recurring schedule that fired the digest, when any.
+        recurrence: Canonical recurrence rule of the fire, when any.
+        fire_graph_hash: The deterministic schedule-fire projection hash the
+            digest fire was anchored on, when any.
+        journal_entry_hash: The lineage-spine / ledger entry hash the digest
+            was sealed against, when any.
+        actor: Recorded actor; defaults to ``"mission_digest"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded in
+        its details payload.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_MISSION_DIGEST_RECEIPT,
+        actor=actor,
+        resource_type="mission_digest",
+        resource_id=receipt_id,
+        details={
+            "mission_id": mission_id,
+            "fire_time": fire_time,
+            "digest_hash": digest_hash,
+            "receipt_id": receipt_id,
+            "mission_status_hash": mission_status_hash,
+            "ledger_head": ledger_head,
+            "phases_passed": phases_passed,
+            "gates_passed": gates_passed,
+            "gates_failed": gates_failed,
+            "total_spend_usd": total_spend_usd,
+            "schedule_id": schedule_id,
+            "recurrence": recurrence,
+            "fire_graph_hash": fire_graph_hash,
+            "journal_entry_hash": journal_entry_hash,
+        },
+    )
+
+
 # ---------------------------------------------------------------------------
 # Eventing v2 (#2548): fire receipts, automation actions, absence proofs, and
 # webhook payload anchors. These are the chain records the events package writes
@@ -5595,6 +5691,7 @@ __all__ = [
     "EVENT_MCP_STATELESS_CALL",
     "EVENT_MCP_TASK_HANDLE",
     "EVENT_MEMORY_WRITE",
+    "EVENT_MISSION_DIGEST_RECEIPT",
     "EVENT_MISSION_PHASE_RECEIPT",
     "EVENT_MULTIMODAL_ATTACH",
     "EVENT_OTEL_PROJECTION",
@@ -5689,6 +5786,7 @@ __all__ = [
     "record_mcp_stateless_call",
     "record_mcp_task_handle",
     "record_memory_write",
+    "record_mission_digest_receipt",
     "record_mission_phase_receipt",
     "record_multimodal_attach",
     "record_otel_projection",

--- a/src/bernstein/core/server/server_app.py
+++ b/src/bernstein/core/server/server_app.py
@@ -1294,6 +1294,7 @@ def create_app(
     from bernstein.core.routes.hooks import router as hooks_router
     from bernstein.core.routes.identities import router as identities_router
     from bernstein.core.routes.mcp_bot_tools import router as mcp_bot_tools_router
+    from bernstein.core.routes.missions import router as missions_router
     from bernstein.core.routes.orchestrator_holds import router as orchestrator_holds_router
     from bernstein.core.routes.paginated_tasks import router as paginated_tasks_router
     from bernstein.core.routes.plans import router as plans_router
@@ -1371,6 +1372,7 @@ def create_app(
         session_peek_router,
         orchestrator_holds_router,
         review_board_router,
+        missions_router,
     ]
 
     # Fresh per-app router: including route groups mutates the target router,

--- a/src/bernstein/core/server/sse_events.py
+++ b/src/bernstein/core/server/sse_events.py
@@ -29,6 +29,7 @@ class SSEEventType(StrEnum):
     MERGE_COMPLETED = "merge.completed"
     RUN_STARTED = "run.started"
     RUN_COMPLETED = "run.completed"
+    MISSION_UPDATED = "mission.updated"
     HEARTBEAT = "heartbeat"
 
 
@@ -228,6 +229,33 @@ class SSEEvent:
             event=SSEEventType.RUN_COMPLETED,
             data={
                 "run_id": run_id,
+            }
+            | extra,
+        )
+
+    @classmethod
+    def mission_updated(cls, mission_id: str, status_hash: str, overall: str = "", **extra: Any) -> SSEEvent:
+        """Create a mission_updated event for the timeline screen (#2510).
+
+        Carries the mission's canonical ``status_hash`` so a client can refresh
+        its projection only when the folded state actually changed, and confirm
+        it is rendering the same state two operators would agree on.
+
+        Args:
+            mission_id: Mission identifier.
+            status_hash: The mission projection's canonical status hash.
+            overall: Overall mission state (``active`` / ``complete`` / ...).
+            **extra: Additional payload fields.
+
+        Returns:
+            SSEEvent instance.
+        """
+        return cls(
+            event=SSEEventType.MISSION_UPDATED,
+            data={
+                "mission_id": mission_id,
+                "status_hash": status_hash,
+                "overall": overall,
             }
             | extra,
         )

--- a/tests/unit/orchestration/test_mission_digest.py
+++ b/tests/unit/orchestration/test_mission_digest.py
@@ -1,0 +1,465 @@
+"""Signed daily progress digest tests (#2510).
+
+The digest is a pure deterministic projection of the mission state at a fire
+instant, anchored in the HMAC audit chain and posted to chat as its verbatim
+projection. Each test maps to an acceptance criterion from the issue:
+
+* Determinism -- two hosts holding byte-identical ledgers, folding at the same
+  fire time, derive byte-identical digest bytes, the same digest hash, and the
+  exact receipt id (golden test).
+* Verifiability -- the posted chat message embeds the digest hash; verification
+  detects an edited or truncated message as a mismatch.
+* Idempotency -- delivery is idempotent on the digest receipt id; a restart
+  between fire computation and delivery does not double-post, and a missed fire
+  recomputes to the identical digest after restart.
+* Cross-driver -- delivery works on all three shipped chat drivers through the
+  common bridge protocol.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from bernstein.core.chat.bridge import BridgeProtocol
+from bernstein.core.evidence.bundle import (
+    EvidenceProducer,
+    ProducerOutcome,
+    build_evidence_bundle,
+    load_or_create_evidence_identity,
+)
+from bernstein.core.orchestration.mission_digest import (
+    build_mission_digest,
+    record_digest_receipt,
+    render_digest_message,
+    verify_message_matches,
+)
+from bernstein.core.orchestration.mission_digest_delivery import (
+    DigestDeliveryLedger,
+    deliver_digest,
+    run_digest_fire,
+)
+from bernstein.core.orchestration.missions import (
+    MissionSpec,
+    PhaseSpec,
+    define_mission,
+    enter_phase,
+    gather_evidence_hashes,
+    halt_phase,
+    mission_ledger_dir,
+    pass_phase,
+    project_mission_from_ledger,
+)
+from bernstein.core.persistence.work_ledger import WorkLedger
+from bernstein.core.security.audit_chain import EVENT_MISSION_DIGEST_RECEIPT, AuditChainStore
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_KEY = b"0" * 32
+_FIRE = 1_700_000_000
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: build a real two-phase mission ledger with sealed evidence
+# ---------------------------------------------------------------------------
+
+
+def _spec() -> MissionSpec:
+    return MissionSpec(
+        mission_id="m-1",
+        goal="ship the multi-day migration",
+        phases=(
+            PhaseSpec(phase_id="p1", name="prepare", gate=("task-a",), envelope="mission-m-1-p1", budget_usd=40.0),
+            PhaseSpec(phase_id="p2", name="migrate", gate=("task-b",), envelope="mission-m-1-p2", budget_usd=25.0),
+        ),
+    )
+
+
+def _seal_evidence(workdir: Path, task_id: str, *, timestamp: int = 1000) -> str:
+    priv, pub = load_or_create_evidence_identity(workdir / ".sdd" / "identity")
+    outcome = ProducerOutcome(
+        producer=EvidenceProducer(name="tests", kind="test", command=("run",), required=True),
+        exit_code=0,
+        output=f"ok {task_id}\n".encode(),
+    )
+    bundle = build_evidence_bundle(
+        workdir=workdir,
+        lineage_root=workdir / ".sdd" / "lineage",
+        hmac_key=_KEY,
+        private_key_pem=priv,
+        public_key_pem=pub,
+        task_id=task_id,
+        outcomes=(outcome,),
+        timestamp=timestamp,
+    )
+    return bundle.bundle_hash()
+
+
+def _build_full_mission(sdd_dir: Path, workdir: Path) -> MissionSpec:
+    spec = _spec()
+    ledger = WorkLedger.open(mission_ledger_dir(sdd_dir, spec.mission_id))
+    define_mission(ledger=ledger, spec=spec)
+    _seal_evidence(workdir, "task-a")
+    enter_phase(ledger=ledger, mission_id=spec.mission_id, phase_id="p1")
+    ev = gather_evidence_hashes(workdir, ("task-a",))
+    pass_phase(ledger=ledger, spec=spec, phase_id="p1", evidence_hashes=ev, spend_usd=12.0)
+    _seal_evidence(workdir, "task-b")
+    enter_phase(ledger=ledger, mission_id=spec.mission_id, phase_id="p2")
+    ev = gather_evidence_hashes(workdir, ("task-b",))
+    pass_phase(ledger=ledger, spec=spec, phase_id="p2", evidence_hashes=ev, spend_usd=9.0)
+    ledger.close()
+    return spec
+
+
+def _build_halted_mission(sdd_dir: Path, workdir: Path) -> MissionSpec:
+    """Phase 1 passes; phase 2 is halted (envelope exhausted) -> a blocker."""
+    spec = _spec()
+    ledger = WorkLedger.open(mission_ledger_dir(sdd_dir, spec.mission_id))
+    define_mission(ledger=ledger, spec=spec)
+    _seal_evidence(workdir, "task-a")
+    enter_phase(ledger=ledger, mission_id=spec.mission_id, phase_id="p1")
+    ev = gather_evidence_hashes(workdir, ("task-a",))
+    pass_phase(ledger=ledger, spec=spec, phase_id="p1", evidence_hashes=ev, spend_usd=12.0)
+    enter_phase(ledger=ledger, mission_id=spec.mission_id, phase_id="p2")
+    halt_phase(ledger=ledger, spec=spec, phase_id="p2", spend_usd=25.0, reason="envelope_exhausted")
+    ledger.close()
+    return spec
+
+
+# ---------------------------------------------------------------------------
+# Spy bridge + fake drivers
+# ---------------------------------------------------------------------------
+
+
+class _SpyBridge(BridgeProtocol):
+    """Minimal in-memory bridge that records every posted message."""
+
+    platform = "spy"
+
+    def __init__(self) -> None:
+        self.sent: list[tuple[str, str]] = []
+        self._counter = 0
+
+    async def start(self) -> None:  # pragma: no cover - unused
+        return None
+
+    async def stop(self) -> None:  # pragma: no cover - unused
+        return None
+
+    async def send_message(self, thread_id: str, text: str) -> str:
+        self._counter += 1
+        self.sent.append((thread_id, text))
+        return f"msg-{self._counter}"
+
+    async def edit_message(self, thread_id: str, message_id: str, text: str) -> None:  # pragma: no cover - unused
+        return None
+
+    async def push_approval(self, approval: Any) -> str:  # pragma: no cover - unused
+        return "approval-1"
+
+    def on_command(self, name: str, handler: Any) -> None:  # pragma: no cover - unused
+        return None
+
+    def on_button(self, handler: Any) -> None:  # pragma: no cover - unused
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Determinism (AC: byte-identical digest across hosts + golden hash)
+# ---------------------------------------------------------------------------
+
+
+def test_two_hosts_compute_identical_digest_bytes(tmp_path: Path) -> None:
+    host_a, host_b = tmp_path / "a", tmp_path / "b"
+    host_a.mkdir()
+    host_b.mkdir()
+    _build_full_mission(host_a / ".sdd", host_a)
+    _build_full_mission(host_b / ".sdd", host_b)
+
+    proj_a = project_mission_from_ledger(sdd_dir=host_a / ".sdd", workdir=host_a, mission_id="m-1")
+    proj_b = project_mission_from_ledger(sdd_dir=host_b / ".sdd", workdir=host_b, mission_id="m-1")
+    digest_a = build_mission_digest(proj_a, fire_time=_FIRE)
+    digest_b = build_mission_digest(proj_b, fire_time=_FIRE)
+
+    assert digest_a.canonical_bytes() == digest_b.canonical_bytes()
+    assert digest_a.digest_hash() == digest_b.digest_hash()
+    assert digest_a.receipt_id() == digest_b.receipt_id()
+
+
+def test_digest_hash_is_pinned_for_the_canonical_fixture(tmp_path: Path) -> None:
+    """Golden: a fixed ledger + fire time produces a pinned digest hash."""
+    _build_full_mission(tmp_path / ".sdd", tmp_path)
+    proj = project_mission_from_ledger(sdd_dir=tmp_path / ".sdd", workdir=tmp_path, mission_id="m-1")
+    digest = build_mission_digest(proj, fire_time=_FIRE)
+
+    assert digest.overall == "complete"
+    assert digest.phases_passed == 2
+    assert digest.gates_passed == 2
+    assert digest.total_spend_usd == pytest.approx(21.0)
+    # Pinned digest hash + receipt id. Regenerate deliberately if the digest
+    # schema changes; a silent drift means the digest is no longer byte-stable.
+    assert digest.digest_hash() == _PINNED_DIGEST_HASH
+    assert digest.receipt_id() == _PINNED_RECEIPT_ID
+
+
+#: Pinned digest hash / receipt id for the canonical fixture at ``_FIRE``.
+_PINNED_DIGEST_HASH = "d218525c116432fae204159dadd8a7c05f0d88c785b495121ead82d461e3cdea"
+_PINNED_RECEIPT_ID = "missiondigest-0961e849772a90747e0e1ed6"
+
+
+def test_fire_time_must_be_int(tmp_path: Path) -> None:
+    _build_full_mission(tmp_path / ".sdd", tmp_path)
+    proj = project_mission_from_ledger(sdd_dir=tmp_path / ".sdd", workdir=tmp_path, mission_id="m-1")
+    with pytest.raises(TypeError, match="integer epoch"):
+        build_mission_digest(proj, fire_time=float(_FIRE))  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="integer epoch"):
+        build_mission_digest(proj, fire_time=True)  # type: ignore[arg-type]
+
+
+def test_envelope_spend_and_blockers_for_halted_mission(tmp_path: Path) -> None:
+    _build_halted_mission(tmp_path / ".sdd", tmp_path)
+    proj = project_mission_from_ledger(sdd_dir=tmp_path / ".sdd", workdir=tmp_path, mission_id="m-1")
+    digest = build_mission_digest(proj, fire_time=_FIRE)
+
+    assert digest.overall == "halted"
+    assert digest.gates_failed == 1
+    assert [b.phase_id for b in digest.blockers] == ["p2"]
+    assert digest.blockers[0].reason == "halted"
+    envs = {row.envelope: row.spend_usd for row in digest.envelope_spend}
+    assert envs == {"mission-m-1-p1": pytest.approx(12.0), "mission-m-1-p2": pytest.approx(25.0)}
+
+
+# ---------------------------------------------------------------------------
+# Verifiability (AC: posted message embeds hash; edit/truncation detected)
+# ---------------------------------------------------------------------------
+
+
+def test_message_embeds_hashes_and_verifies(tmp_path: Path) -> None:
+    _build_full_mission(tmp_path / ".sdd", tmp_path)
+    proj = project_mission_from_ledger(sdd_dir=tmp_path / ".sdd", workdir=tmp_path, mission_id="m-1")
+    digest = build_mission_digest(proj, fire_time=_FIRE)
+    text = render_digest_message(digest)
+
+    assert digest.digest_hash() in text
+    assert digest.mission_status_hash in text
+    assert digest.receipt_id() in text
+    result = verify_message_matches(text, digest)
+    assert result.matches is True
+    assert result.reason == "ok"
+
+
+def test_edited_message_is_detected_as_mismatch(tmp_path: Path) -> None:
+    _build_full_mission(tmp_path / ".sdd", tmp_path)
+    proj = project_mission_from_ledger(sdd_dir=tmp_path / ".sdd", workdir=tmp_path, mission_id="m-1")
+    digest = build_mission_digest(proj, fire_time=_FIRE)
+    text = render_digest_message(digest)
+
+    # An edit that keeps the length but flips a spend figure.
+    edited = text.replace("$21.00", "$99.00")
+    assert edited != text
+    result = verify_message_matches(edited, digest)
+    assert result.matches is False
+
+
+def test_truncated_message_is_detected_as_mismatch(tmp_path: Path) -> None:
+    _build_full_mission(tmp_path / ".sdd", tmp_path)
+    proj = project_mission_from_ledger(sdd_dir=tmp_path / ".sdd", workdir=tmp_path, mission_id="m-1")
+    digest = build_mission_digest(proj, fire_time=_FIRE)
+    text = render_digest_message(digest)
+
+    truncated = text[: len(text) // 2]
+    result = verify_message_matches(truncated, digest)
+    assert result.matches is False
+    assert "truncated" in result.reason
+
+
+# ---------------------------------------------------------------------------
+# Chain anchoring (AC: receipt recorded + chain verifies)
+# ---------------------------------------------------------------------------
+
+
+def test_digest_receipt_records_and_chain_verifies(tmp_path: Path) -> None:
+    _build_full_mission(tmp_path / ".sdd", tmp_path)
+    proj = project_mission_from_ledger(sdd_dir=tmp_path / ".sdd", workdir=tmp_path, mission_id="m-1")
+    digest = build_mission_digest(proj, fire_time=_FIRE)
+    chain = AuditChainStore(tmp_path / "audit")
+
+    event = record_digest_receipt(chain, digest, schedule_id="mission-digest:m-1")
+    assert event.event_type == EVENT_MISSION_DIGEST_RECEIPT
+    assert event.details["digest_hash"] == digest.digest_hash()
+    assert event.details["receipt_id"] == digest.receipt_id()
+    assert event.details["mission_status_hash"] == digest.mission_status_hash
+    assert "prev_chain_digest" in event.details
+
+    ok, errors = chain.verify()
+    assert ok, errors
+
+
+# ---------------------------------------------------------------------------
+# Idempotent delivery + restart (AC: no double-post; missed fire recomputes)
+# ---------------------------------------------------------------------------
+
+
+def test_delivery_is_idempotent_on_receipt_id(tmp_path: Path) -> None:
+    sdd_dir = tmp_path / ".sdd"
+    _build_full_mission(sdd_dir, tmp_path)
+    proj = project_mission_from_ledger(sdd_dir=sdd_dir, workdir=tmp_path, mission_id="m-1")
+    digest = build_mission_digest(proj, fire_time=_FIRE)
+    bridge = _SpyBridge()
+    ledger = DigestDeliveryLedger(sdd_dir, "m-1")
+
+    first = asyncio.run(deliver_digest(bridge=bridge, thread_id="chan", digest=digest, ledger=ledger))
+    second = asyncio.run(deliver_digest(bridge=bridge, thread_id="chan", digest=digest, ledger=ledger))
+
+    assert first.posted is True
+    assert second.posted is False
+    assert second.reason == "already_delivered"
+    assert len(bridge.sent) == 1  # exactly one post
+
+
+def test_restart_does_not_double_post(tmp_path: Path) -> None:
+    """A fresh delivery ledger over the same file still sees the prior post."""
+    sdd_dir = tmp_path / ".sdd"
+    _build_full_mission(sdd_dir, tmp_path)
+    proj = project_mission_from_ledger(sdd_dir=sdd_dir, workdir=tmp_path, mission_id="m-1")
+    digest = build_mission_digest(proj, fire_time=_FIRE)
+    bridge = _SpyBridge()
+
+    asyncio.run(deliver_digest(bridge=bridge, thread_id="chan", digest=digest, ledger=DigestDeliveryLedger(sdd_dir, "m-1")))
+    # Simulate a restart: brand-new ledger instance reads the durable file.
+    outcome = asyncio.run(
+        deliver_digest(bridge=bridge, thread_id="chan", digest=digest, ledger=DigestDeliveryLedger(sdd_dir, "m-1"))
+    )
+    assert outcome.posted is False
+    assert len(bridge.sent) == 1
+
+
+def test_run_digest_fire_is_idempotent_and_records_one_receipt(tmp_path: Path) -> None:
+    sdd_dir = tmp_path / ".sdd"
+    _build_full_mission(sdd_dir, tmp_path)
+    chain = AuditChainStore(tmp_path / "audit")
+    bridge = _SpyBridge()
+
+    def _fire() -> Any:
+        return asyncio.run(
+            run_digest_fire(
+                sdd_dir=sdd_dir,
+                workdir=tmp_path,
+                mission_id="m-1",
+                fire_time=_FIRE,
+                chain=chain,
+                bridge=bridge,
+                thread_id="chan",
+            )
+        )
+
+    first = _fire()
+    second = _fire()
+
+    assert first.outcome.posted is True
+    assert first.recorded_receipt is True
+    assert second.outcome.posted is False
+    assert second.recorded_receipt is False
+    assert len(bridge.sent) == 1
+    # Exactly one digest receipt in the chain despite two fires.
+    receipts = chain.query(event_type=EVENT_MISSION_DIGEST_RECEIPT)
+    assert len(receipts) == 1
+    assert receipts[0].details["fire_graph_hash"] == first.fire_graph_hash
+    ok, errors = chain.verify()
+    assert ok, errors
+
+
+def test_missed_fire_recomputes_to_identical_digest(tmp_path: Path) -> None:
+    """A fire computed, then recomputed after 'restart', is byte-identical."""
+    sdd_dir = tmp_path / ".sdd"
+    _build_full_mission(sdd_dir, tmp_path)
+
+    proj1 = project_mission_from_ledger(sdd_dir=sdd_dir, workdir=tmp_path, mission_id="m-1")
+    digest1 = build_mission_digest(proj1, fire_time=_FIRE)
+    # Restart: reproject from the same on-disk ledger and rebuild the digest.
+    proj2 = project_mission_from_ledger(sdd_dir=sdd_dir, workdir=tmp_path, mission_id="m-1")
+    digest2 = build_mission_digest(proj2, fire_time=_FIRE)
+
+    assert digest1.canonical_bytes() == digest2.canonical_bytes()
+    assert digest1.receipt_id() == digest2.receipt_id()
+
+
+# ---------------------------------------------------------------------------
+# Cross-driver delivery (AC: all three shipped drivers via common bridge)
+# ---------------------------------------------------------------------------
+
+
+def _make_slack(monkeypatch: pytest.MonkeyPatch, captured: list[str]) -> BridgeProtocol:
+    from bernstein.core.chat.drivers.slack import SlackBridge
+
+    bridge = SlackBridge(token="xoxb-test", app_token="xapp-test")
+
+    class _FakeWeb:
+        async def chat_postMessage(self, *, channel: str, text: str, metadata: Any) -> dict[str, str]:
+            captured.append(text)
+            return {"ts": "1.1"}
+
+    monkeypatch.setattr(bridge, "_require_web", lambda: _FakeWeb())
+    return bridge
+
+
+def _make_discord(monkeypatch: pytest.MonkeyPatch, captured: list[str]) -> BridgeProtocol:
+    from bernstein.core.chat.drivers.discord import DiscordBridge
+
+    bridge = DiscordBridge(token="discord-test")
+
+    class _FakeChannel:
+        async def send(self, text: str) -> Any:
+            captured.append(text)
+            return type("Sent", (), {"id": 42})()
+
+    async def _resolve(_thread_id: str) -> Any:
+        return _FakeChannel()
+
+    monkeypatch.setattr(bridge, "_resolve_channel", _resolve)
+    monkeypatch.setattr(bridge, "_build_signed_envelope", lambda _text: {})
+    return bridge
+
+
+def _make_telegram(monkeypatch: pytest.MonkeyPatch, captured: list[str]) -> BridgeProtocol:
+    from bernstein.core.chat.drivers.telegram import TelegramBridge
+
+    bridge = TelegramBridge(token="telegram-test")
+
+    class _FakeBot:
+        async def send_message(self, *, chat_id: Any, text: str) -> Any:
+            captured.append(text)
+            return type("Sent", (), {"message_id": 7})()
+
+    class _FakeApp:
+        bot = _FakeBot()
+
+    monkeypatch.setattr(bridge, "_require_app", lambda: _FakeApp())
+    return bridge
+
+
+@pytest.mark.parametrize("factory", [_make_slack, _make_discord, _make_telegram])
+def test_delivery_works_on_all_three_drivers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    factory: Any,
+) -> None:
+    sdd_dir = tmp_path / ".sdd"
+    _build_full_mission(sdd_dir, tmp_path)
+    proj = project_mission_from_ledger(sdd_dir=sdd_dir, workdir=tmp_path, mission_id="m-1")
+    digest = build_mission_digest(proj, fire_time=_FIRE)
+
+    captured: list[str] = []
+    bridge = factory(monkeypatch, captured)
+    ledger = DigestDeliveryLedger(sdd_dir, "m-1")
+
+    outcome = asyncio.run(deliver_digest(bridge=bridge, thread_id="chan", digest=digest, ledger=ledger))
+
+    assert outcome.posted is True
+    assert len(captured) == 1
+    # The exact digest projection (with the embedded hash) reached the wire.
+    assert captured[0] == render_digest_message(digest)
+    assert digest.digest_hash() in captured[0]

--- a/tests/unit/orchestration/test_mission_digest.py
+++ b/tests/unit/orchestration/test_mission_digest.py
@@ -328,7 +328,9 @@ def test_restart_does_not_double_post(tmp_path: Path) -> None:
     digest = build_mission_digest(proj, fire_time=_FIRE)
     bridge = _SpyBridge()
 
-    asyncio.run(deliver_digest(bridge=bridge, thread_id="chan", digest=digest, ledger=DigestDeliveryLedger(sdd_dir, "m-1")))
+    asyncio.run(
+        deliver_digest(bridge=bridge, thread_id="chan", digest=digest, ledger=DigestDeliveryLedger(sdd_dir, "m-1"))
+    )
     # Simulate a restart: brand-new ledger instance reads the durable file.
     outcome = asyncio.run(
         deliver_digest(bridge=bridge, thread_id="chan", digest=digest, ledger=DigestDeliveryLedger(sdd_dir, "m-1"))

--- a/tests/unit/test_audit_chain_mission_digest.py
+++ b/tests/unit/test_audit_chain_mission_digest.py
@@ -1,0 +1,75 @@
+"""Mission digest receipt audit-chain event tests (#2510).
+
+The mission digest receipt anchors one recurring digest fire (the digest hash,
+the mission status hash, counts, and spend) into the HMAC-chained audit log, so
+a posted digest is provable offline: a recipient recomputes the digest from the
+ledger and confirms it matches the chain-attested receipt, and a tampered
+receipt fails chain verification at its exact position.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from bernstein.core.security.audit_chain import (
+    EVENT_MISSION_DIGEST_RECEIPT,
+    AuditChainStore,
+    record_mission_digest_receipt,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _record(chain: AuditChainStore) -> None:
+    record_mission_digest_receipt(
+        chain=chain,
+        mission_id="m-1",
+        fire_time=1_700_000_000,
+        digest_hash="a" * 64,
+        receipt_id="missiondigest-abc123",
+        mission_status_hash="b" * 64,
+        ledger_head="c" * 64,
+        phases_passed=2,
+        gates_passed=2,
+        gates_failed=0,
+        total_spend_usd=21.0,
+        schedule_id="mission-digest:m-1",
+        recurrence="cron:0 8 * * *",
+        fire_graph_hash="d" * 64,
+    )
+
+
+def test_record_mission_digest_receipt_chains_and_verifies(tmp_path: Path) -> None:
+    chain = AuditChainStore(tmp_path / "audit")
+    _record(chain)
+    events = chain.query(event_type=EVENT_MISSION_DIGEST_RECEIPT)
+    assert len(events) == 1
+    details = events[0].details
+    assert details["mission_id"] == "m-1"
+    assert details["digest_hash"] == "a" * 64
+    assert details["receipt_id"] == "missiondigest-abc123"
+    assert details["total_spend_usd"] == 21.0
+    assert details["fire_graph_hash"] == "d" * 64
+    assert "prev_chain_digest" in details
+
+    ok, errors = chain.verify()
+    assert ok, errors
+
+
+def test_tampered_digest_receipt_fails_verification_at_position(tmp_path: Path) -> None:
+    audit_dir = tmp_path / "audit"
+    chain = AuditChainStore(audit_dir)
+    _record(chain)
+    assert chain.verify()[0] is True
+
+    # Tamper: flip the recorded digest hash in the on-disk chain entry.
+    (log_file,) = list(audit_dir.glob("*.jsonl"))
+    raw = log_file.read_text(encoding="utf-8")
+    tampered = raw.replace("a" * 64, "e" * 64)
+    assert tampered != raw
+    log_file.write_text(tampered, encoding="utf-8")
+
+    ok, errors = AuditChainStore(audit_dir).verify()
+    assert ok is False
+    assert errors

--- a/tests/unit/test_mission_digest_cmd.py
+++ b/tests/unit/test_mission_digest_cmd.py
@@ -1,0 +1,195 @@
+"""CLI tests for ``bernstein mission digest`` (#2510).
+
+Covers show / send / verify end to end against a real mission ledger. The send
+path is idempotent per fire; verify recomputes the digest from the ledger and
+proves a posted message matches, detecting an edited message as a mismatch.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from click.testing import CliRunner
+
+import bernstein.cli.commands.mission_cmd as mission_cmd
+from bernstein.cli.commands.mission_cmd import mission_group
+from bernstein.core.chat.bridge import BridgeProtocol
+from bernstein.core.evidence.bundle import (
+    EvidenceProducer,
+    ProducerOutcome,
+    build_evidence_bundle,
+    load_or_create_evidence_identity,
+)
+from bernstein.core.orchestration.missions import (
+    MissionSpec,
+    PhaseSpec,
+    define_mission,
+    enter_phase,
+    gather_evidence_hashes,
+    mission_ledger_dir,
+    pass_phase,
+)
+from bernstein.core.persistence.work_ledger import WorkLedger
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_KEY = b"0" * 32
+_FIRE = "1700000000"
+
+
+class _SpyBridge(BridgeProtocol):
+    platform = "spy"
+
+    def __init__(self) -> None:
+        self.sent: list[tuple[str, str]] = []
+
+    async def start(self) -> None:  # pragma: no cover
+        return None
+
+    async def stop(self) -> None:  # pragma: no cover
+        return None
+
+    async def send_message(self, thread_id: str, text: str) -> str:
+        self.sent.append((thread_id, text))
+        return f"msg-{len(self.sent)}"
+
+    async def edit_message(self, thread_id: str, message_id: str, text: str) -> None:  # pragma: no cover
+        return None
+
+    async def push_approval(self, approval: Any) -> str:  # pragma: no cover
+        return "a"
+
+    def on_command(self, name: str, handler: Any) -> None:  # pragma: no cover
+        return None
+
+    def on_button(self, handler: Any) -> None:  # pragma: no cover
+        return None
+
+
+def _seal_evidence(workdir: Path, task_id: str) -> None:
+    priv, pub = load_or_create_evidence_identity(workdir / ".sdd" / "identity")
+    outcome = ProducerOutcome(
+        producer=EvidenceProducer(name="tests", kind="test", command=("run",), required=True),
+        exit_code=0,
+        output=f"ok {task_id}\n".encode(),
+    )
+    build_evidence_bundle(
+        workdir=workdir,
+        lineage_root=workdir / ".sdd" / "lineage",
+        hmac_key=_KEY,
+        private_key_pem=priv,
+        public_key_pem=pub,
+        task_id=task_id,
+        outcomes=(outcome,),
+        timestamp=1000,
+    )
+
+
+def _build_mission(workdir: Path) -> None:
+    sdd_dir = workdir / ".sdd"
+    spec = MissionSpec(
+        mission_id="m-cli",
+        goal="cli mission",
+        phases=(PhaseSpec(phase_id="p1", name="prepare", gate=("task-a",), envelope="mission-m-cli-p1", budget_usd=30.0),),
+    )
+    ledger = WorkLedger.open(mission_ledger_dir(sdd_dir, spec.mission_id))
+    define_mission(ledger=ledger, spec=spec)
+    _seal_evidence(workdir, "task-a")
+    enter_phase(ledger=ledger, mission_id=spec.mission_id, phase_id="p1")
+    pass_phase(
+        ledger=ledger,
+        spec=spec,
+        phase_id="p1",
+        evidence_hashes=gather_evidence_hashes(workdir, ("task-a",)),
+        spend_usd=10.0,
+    )
+    ledger.close()
+
+
+def test_digest_show_json(tmp_path: Path) -> None:
+    _build_mission(tmp_path)
+    runner = CliRunner()
+    res = runner.invoke(mission_group, ["digest", "show", "m-cli", "--fire-time", _FIRE, "--workdir", str(tmp_path), "--json"])
+    assert res.exit_code == 0, res.output
+    body = json.loads(res.output)
+    assert body["mission_id"] == "m-cli"
+    assert body["digest_hash"]
+    assert body["digest_hash"] in body["message"]
+    assert body["receipt_id"].startswith("missiondigest-")
+
+
+def test_digest_send_is_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _build_mission(tmp_path)
+    spy = _SpyBridge()
+    monkeypatch.setattr(mission_cmd, "_build_bridge", lambda platform, token: spy)
+    runner = CliRunner()
+
+    args = [
+        "digest", "send", "m-cli",
+        "--fire-time", _FIRE,
+        "--platform", "slack",
+        "--thread", "C123",
+        "--token", "xoxb-test",
+        "--workdir", str(tmp_path),
+        "--json",
+    ]
+    first = runner.invoke(mission_group, args)
+    assert first.exit_code == 0, first.output
+    assert json.loads(first.output)["posted"] is True
+
+    second = runner.invoke(mission_group, args)
+    assert second.exit_code == 0, second.output
+    body = json.loads(second.output)
+    assert body["posted"] is False
+    assert body["reason"] == "already_delivered"
+
+    assert len(spy.sent) == 1  # no double-post across two fires
+
+
+def test_digest_verify_matches_then_detects_edit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _build_mission(tmp_path)
+    spy = _SpyBridge()
+    monkeypatch.setattr(mission_cmd, "_build_bridge", lambda platform, token: spy)
+    runner = CliRunner()
+
+    send = runner.invoke(
+        mission_group,
+        [
+            "digest", "send", "m-cli",
+            "--fire-time", _FIRE,
+            "--platform", "telegram",
+            "--thread", "42",
+            "--token", "tg-test",
+            "--workdir", str(tmp_path),
+            "--json",
+        ],
+    )
+    assert send.exit_code == 0, send.output
+    posted_text = spy.sent[0][1]
+
+    # Genuine posted message verifies (message-side + receipt-side proof).
+    msg_ok = tmp_path / "posted_ok.txt"
+    msg_ok.write_text(posted_text, encoding="utf-8")
+    ok = runner.invoke(
+        mission_group,
+        ["digest", "verify", "m-cli", "--fire-time", _FIRE, "--message", str(msg_ok), "--workdir", str(tmp_path), "--json"],
+    )
+    assert ok.exit_code == 0, ok.output
+    report = json.loads(ok.output)
+    assert report["ok"] is True
+    assert report["message_matches"] is True
+    assert report["chain_verified"] is True
+    assert report["receipt_present"] is True
+
+    # An edited message is detected as a mismatch (exit 2).
+    msg_bad = tmp_path / "posted_bad.txt"
+    msg_bad.write_text(posted_text.replace("$10.00", "$88.00"), encoding="utf-8")
+    bad = runner.invoke(
+        mission_group,
+        ["digest", "verify", "m-cli", "--fire-time", _FIRE, "--message", str(msg_bad), "--workdir", str(tmp_path), "--json"],
+    )
+    assert bad.exit_code == 2, bad.output
+    assert json.loads(bad.output)["message_matches"] is False

--- a/tests/unit/test_mission_digest_cmd.py
+++ b/tests/unit/test_mission_digest_cmd.py
@@ -93,7 +93,9 @@ def _build_mission(workdir: Path) -> None:
     spec = MissionSpec(
         mission_id="m-cli",
         goal="cli mission",
-        phases=(PhaseSpec(phase_id="p1", name="prepare", gate=("task-a",), envelope="mission-m-cli-p1", budget_usd=30.0),),
+        phases=(
+            PhaseSpec(phase_id="p1", name="prepare", gate=("task-a",), envelope="mission-m-cli-p1", budget_usd=30.0),
+        ),
     )
     ledger = WorkLedger.open(mission_ledger_dir(sdd_dir, spec.mission_id))
     define_mission(ledger=ledger, spec=spec)
@@ -112,7 +114,9 @@ def _build_mission(workdir: Path) -> None:
 def test_digest_show_json(tmp_path: Path) -> None:
     _build_mission(tmp_path)
     runner = CliRunner()
-    res = runner.invoke(mission_group, ["digest", "show", "m-cli", "--fire-time", _FIRE, "--workdir", str(tmp_path), "--json"])
+    res = runner.invoke(
+        mission_group, ["digest", "show", "m-cli", "--fire-time", _FIRE, "--workdir", str(tmp_path), "--json"]
+    )
     assert res.exit_code == 0, res.output
     body = json.loads(res.output)
     assert body["mission_id"] == "m-cli"
@@ -128,12 +132,19 @@ def test_digest_send_is_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     runner = CliRunner()
 
     args = [
-        "digest", "send", "m-cli",
-        "--fire-time", _FIRE,
-        "--platform", "slack",
-        "--thread", "C123",
-        "--token", "xoxb-test",
-        "--workdir", str(tmp_path),
+        "digest",
+        "send",
+        "m-cli",
+        "--fire-time",
+        _FIRE,
+        "--platform",
+        "slack",
+        "--thread",
+        "C123",
+        "--token",
+        "xoxb-test",
+        "--workdir",
+        str(tmp_path),
         "--json",
     ]
     first = runner.invoke(mission_group, args)
@@ -158,12 +169,19 @@ def test_digest_verify_matches_then_detects_edit(tmp_path: Path, monkeypatch: py
     send = runner.invoke(
         mission_group,
         [
-            "digest", "send", "m-cli",
-            "--fire-time", _FIRE,
-            "--platform", "telegram",
-            "--thread", "42",
-            "--token", "tg-test",
-            "--workdir", str(tmp_path),
+            "digest",
+            "send",
+            "m-cli",
+            "--fire-time",
+            _FIRE,
+            "--platform",
+            "telegram",
+            "--thread",
+            "42",
+            "--token",
+            "tg-test",
+            "--workdir",
+            str(tmp_path),
             "--json",
         ],
     )
@@ -175,7 +193,18 @@ def test_digest_verify_matches_then_detects_edit(tmp_path: Path, monkeypatch: py
     msg_ok.write_text(posted_text, encoding="utf-8")
     ok = runner.invoke(
         mission_group,
-        ["digest", "verify", "m-cli", "--fire-time", _FIRE, "--message", str(msg_ok), "--workdir", str(tmp_path), "--json"],
+        [
+            "digest",
+            "verify",
+            "m-cli",
+            "--fire-time",
+            _FIRE,
+            "--message",
+            str(msg_ok),
+            "--workdir",
+            str(tmp_path),
+            "--json",
+        ],
     )
     assert ok.exit_code == 0, ok.output
     report = json.loads(ok.output)
@@ -189,7 +218,18 @@ def test_digest_verify_matches_then_detects_edit(tmp_path: Path, monkeypatch: py
     msg_bad.write_text(posted_text.replace("$10.00", "$88.00"), encoding="utf-8")
     bad = runner.invoke(
         mission_group,
-        ["digest", "verify", "m-cli", "--fire-time", _FIRE, "--message", str(msg_bad), "--workdir", str(tmp_path), "--json"],
+        [
+            "digest",
+            "verify",
+            "m-cli",
+            "--fire-time",
+            _FIRE,
+            "--message",
+            str(msg_bad),
+            "--workdir",
+            str(tmp_path),
+            "--json",
+        ],
     )
     assert bad.exit_code == 2, bad.output
     assert json.loads(bad.output)["message_matches"] is False

--- a/tests/unit/test_missions_route.py
+++ b/tests/unit/test_missions_route.py
@@ -1,0 +1,210 @@
+"""Unit tests for the mission timeline API routes (#2510).
+
+The endpoints are a read-only projection surface over the mission's work-ledger
+chain: no mission-side state, no writes. When chain verification fails the
+projection payload marks the mission unverified so the screen switches to an
+explicit unverified banner instead of best-effort rendering.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from bernstein.core.evidence.bundle import (
+    EvidenceProducer,
+    ProducerOutcome,
+    build_evidence_bundle,
+    load_or_create_evidence_identity,
+)
+from bernstein.core.orchestration.mission_digest import build_mission_digest, render_digest_message
+from bernstein.core.orchestration.missions import (
+    MissionSpec,
+    PhaseSpec,
+    define_mission,
+    enter_phase,
+    gather_evidence_hashes,
+    mission_ledger_dir,
+    pass_phase,
+    project_mission_from_ledger,
+)
+from bernstein.core.persistence.work_ledger import WorkLedger
+from bernstein.core.routes.missions import router
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_KEY = b"0" * 32
+_FIRE = 1_700_000_000
+
+
+def _make_app(workdir: Path) -> FastAPI:
+    app = FastAPI()
+    app.state.workdir = workdir
+    app.state.sdd_dir = workdir / ".sdd"
+    app.include_router(router)
+    return app
+
+
+def _seal_evidence(workdir: Path, task_id: str) -> None:
+    priv, pub = load_or_create_evidence_identity(workdir / ".sdd" / "identity")
+    outcome = ProducerOutcome(
+        producer=EvidenceProducer(name="tests", kind="test", command=("run",), required=True),
+        exit_code=0,
+        output=f"ok {task_id}\n".encode(),
+    )
+    build_evidence_bundle(
+        workdir=workdir,
+        lineage_root=workdir / ".sdd" / "lineage",
+        hmac_key=_KEY,
+        private_key_pem=priv,
+        public_key_pem=pub,
+        task_id=task_id,
+        outcomes=(outcome,),
+        timestamp=1000,
+    )
+
+
+def _build_mission(workdir: Path) -> MissionSpec:
+    sdd_dir = workdir / ".sdd"
+    spec = MissionSpec(
+        mission_id="m-1",
+        goal="ship the migration",
+        phases=(
+            PhaseSpec(phase_id="p1", name="prepare", gate=("task-a",), envelope="mission-m-1-p1", budget_usd=40.0),
+            PhaseSpec(phase_id="p2", name="migrate", gate=("task-b",), envelope="mission-m-1-p2", budget_usd=25.0),
+        ),
+    )
+    ledger = WorkLedger.open(mission_ledger_dir(sdd_dir, spec.mission_id))
+    define_mission(ledger=ledger, spec=spec)
+    _seal_evidence(workdir, "task-a")
+    enter_phase(ledger=ledger, mission_id=spec.mission_id, phase_id="p1")
+    pass_phase(
+        ledger=ledger,
+        spec=spec,
+        phase_id="p1",
+        evidence_hashes=gather_evidence_hashes(workdir, ("task-a",)),
+        spend_usd=12.0,
+    )
+    ledger.close()
+    return spec
+
+
+# ---------------------------------------------------------------------------
+# Listing + projection
+# ---------------------------------------------------------------------------
+
+
+def test_list_missions_empty(tmp_path: Path) -> None:
+    client = TestClient(_make_app(tmp_path))
+    response = client.get("/missions")
+    assert response.status_code == 200
+    assert response.json() == {"missions": []}
+
+
+def test_list_missions_returns_ledger_backed_missions(tmp_path: Path) -> None:
+    _build_mission(tmp_path)
+    client = TestClient(_make_app(tmp_path))
+    response = client.get("/missions")
+    assert response.status_code == 200
+    assert response.json() == {"missions": ["m-1"]}
+
+
+def test_projection_endpoint_folds_ledger(tmp_path: Path) -> None:
+    _build_mission(tmp_path)
+    client = TestClient(_make_app(tmp_path))
+
+    response = client.get("/missions/m-1")
+    assert response.status_code == 200
+    body = response.json()
+
+    expected = project_mission_from_ledger(sdd_dir=tmp_path / ".sdd", workdir=tmp_path, mission_id="m-1")
+    assert body["mission_status_hash"] == expected.status_hash
+    assert body["ledger_verified"] is True
+    assert body["status"]["overall"] == "active"
+    # Every phase carries its provenance handles (receipt hash + evidence).
+    phases = body["status"]["phases"]
+    assert phases[0]["receipt_hash"]
+    assert phases[0]["evidence_bundle_hashes"]
+
+
+def test_unknown_mission_is_404(tmp_path: Path) -> None:
+    client = TestClient(_make_app(tmp_path))
+    assert client.get("/missions/does-not-exist").status_code == 404
+
+
+def test_invalid_mission_id_is_400(tmp_path: Path) -> None:
+    client = TestClient(_make_app(tmp_path))
+    assert client.get("/missions/../etc").status_code in (400, 404)
+
+
+# ---------------------------------------------------------------------------
+# Unverified banner: a tampered ledger flips the projection to unverified
+# ---------------------------------------------------------------------------
+
+
+def test_tampered_ledger_projects_unverified(tmp_path: Path) -> None:
+    _build_mission(tmp_path)
+    bucket = mission_ledger_dir(tmp_path / ".sdd", "m-1") / "000000.jsonl"
+    raw = bucket.read_text(encoding="utf-8")
+    # Flip a spend figure inside a chained entry: the recomputed hash no longer
+    # matches, so the chain does not verify.
+    tampered = raw.replace('"spend_usd":12.0', '"spend_usd":999.0')
+    assert tampered != raw
+    bucket.write_text(tampered, encoding="utf-8")
+
+    client = TestClient(_make_app(tmp_path))
+    body = client.get("/missions/m-1").json()
+    assert body["ledger_verified"] is False
+    assert body["status"]["overall"] == "unverified"
+
+
+# ---------------------------------------------------------------------------
+# Digest endpoint: read-only recompute matching the pure fold
+# ---------------------------------------------------------------------------
+
+
+def test_digest_endpoint_matches_pure_fold(tmp_path: Path) -> None:
+    _build_mission(tmp_path)
+    client = TestClient(_make_app(tmp_path))
+
+    response = client.get("/missions/m-1/digest", params={"fire_time": _FIRE})
+    assert response.status_code == 200
+    body = response.json()
+
+    proj = project_mission_from_ledger(sdd_dir=tmp_path / ".sdd", workdir=tmp_path, mission_id="m-1")
+    digest = build_mission_digest(proj, fire_time=_FIRE)
+    assert body["digest_hash"] == digest.digest_hash()
+    assert body["receipt_id"] == digest.receipt_id()
+    assert body["message"] == render_digest_message(digest)
+    assert digest.digest_hash() in body["message"]
+
+
+def test_digest_endpoint_requires_fire_time(tmp_path: Path) -> None:
+    _build_mission(tmp_path)
+    client = TestClient(_make_app(tmp_path))
+    # Missing fire_time -> 422 (FastAPI query validation).
+    assert client.get("/missions/m-1/digest").status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Evidence provenance link
+# ---------------------------------------------------------------------------
+
+
+def test_evidence_endpoint_serves_bundle(tmp_path: Path) -> None:
+    _build_mission(tmp_path)
+    client = TestClient(_make_app(tmp_path))
+    response = client.get("/missions/m-1/evidence/task-a")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["bundle_hash"]
+    assert body["gate_passed"] is True
+
+
+def test_evidence_endpoint_404_for_missing_bundle(tmp_path: Path) -> None:
+    _build_mission(tmp_path)
+    client = TestClient(_make_app(tmp_path))
+    assert client.get("/missions/m-1/evidence/task-z").status_code == 404

--- a/tests/unit/test_sse_events.py
+++ b/tests/unit/test_sse_events.py
@@ -10,8 +10,8 @@ from bernstein.core.server.sse_events import SSEEvent, SSEEventType
 
 
 class TestSSEEventType:
-    def test_has_14_members(self) -> None:
-        assert len(SSEEventType) == 14
+    def test_has_15_members(self) -> None:
+        assert len(SSEEventType) == 15
 
     def test_event_type_values_are_dotted(self) -> None:
         for member in SSEEventType:
@@ -34,10 +34,19 @@ class TestSSEEventType:
             "MERGE_COMPLETED",
             "RUN_STARTED",
             "RUN_COMPLETED",
+            "MISSION_UPDATED",
             "HEARTBEAT",
         }
         actual = {m.name for m in SSEEventType}
         assert expected == actual
+
+    def test_mission_updated_factory(self) -> None:
+        evt = SSEEvent.mission_updated("m-1", status_hash="abc", overall="active")
+        assert evt.event == SSEEventType.MISSION_UPDATED
+        assert evt.data["mission_id"] == "m-1"
+        assert evt.data["status_hash"] == "abc"
+        assert evt.data["overall"] == "active"
+        assert json.loads(evt.to_sse().split("data: ", 1)[1].split("\n", 1)[0])["mission_id"] == "m-1"
 
 
 class TestSSEEvent:

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -21,6 +21,7 @@ import Approvals from './routes/Approvals';
 import Audit from './routes/Audit';
 import Costs from './routes/Costs';
 import Fleet from './routes/Fleet';
+import Missions from './routes/Missions';
 import Settings from './routes/Settings';
 
 // ── QueryClient ────────────────────────────────────────────────────────────
@@ -54,6 +55,7 @@ const ROUTE_TITLES: Record<string, string> = {
   '/approvals': 'Approvals',
   '/audit': 'Audit',
   '/costs': 'Costs',
+  '/missions': 'Missions',
   '/fleet': 'Fleet',
   '/settings': 'Settings',
 };
@@ -206,6 +208,7 @@ export default function App() {
                 <Route path="/approvals" element={<Approvals />} />
                 <Route path="/audit" element={<Audit />} />
                 <Route path="/costs" element={<Costs />} />
+                <Route path="/missions" element={<Missions />} />
                 {/* Fleet + Settings live in topbar / user-menu but stay deep-linkable. */}
                 <Route path="/fleet" element={<Fleet />} />
                 <Route path="/settings" element={<Settings />} />

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -17,6 +17,7 @@ import {
   Settings as SettingsIcon,
   ShieldCheck,
   Sun,
+  Target,
   User,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -33,6 +34,7 @@ const NAV = [
   { to: '/approvals', label: 'Approvals', icon: ShieldCheck, key: 'approvals' as const },
   { to: '/audit', label: 'Audit', icon: ScrollText, key: 'audit' as const },
   { to: '/costs', label: 'Costs', icon: DollarSign, key: 'costs' as const },
+  { to: '/missions', label: 'Missions', icon: Target, key: 'missions' as const },
   { to: '/fleet', label: 'Fleet', icon: Network, key: 'fleet' as const },
   { to: '/settings', label: 'Settings', icon: SettingsIcon, key: 'settings' as const },
 ] as const;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -190,3 +190,79 @@ export interface SteerReceipt {
 export function steerTask(taskId: string, command: SteerCommand): Promise<SteerReceipt> {
   return apiPost<SteerReceipt>(`/tasks/${encodeURIComponent(taskId)}/steer`, command);
 }
+
+// ── Mission timeline (#2510) ────────────────────────────────────────────────
+// Outcome-level view over a multi-day mission. The server folds the mission's
+// work-ledger chain on every request; the client renders whatever the fold
+// returns. Every element carries the receipt / evidence handle it was derived
+// from, and `ledger_verified === false` flips the screen to an unverified
+// banner. Mirrors `MissionProjection.to_dict()` /
+// `MissionStatus.to_dict()` in
+// `src/bernstein/core/orchestration/missions.py` and the routes in
+// `src/bernstein/core/routes/missions.py`.
+
+export type PhaseState =
+  | 'pending'
+  | 'active'
+  | 'passed'
+  | 'halted'
+  | 'unverified';
+
+export type MissionOverall =
+  | 'pending'
+  | 'active'
+  | 'complete'
+  | 'halted'
+  | 'unverified';
+
+export interface MissionPhaseStatus {
+  phase_id: string;
+  name: string;
+  state: PhaseState | string;
+  gate: string[];
+  gate_passed: boolean;
+  evidence_bundle_hashes: string[];
+  envelope: string;
+  budget_usd: number;
+  spend_usd: number;
+  receipt_hash: string;
+  ledger_seq: number;
+}
+
+export interface MissionStatus {
+  schema_version: number;
+  mission_id: string;
+  goal_digest: string;
+  spec_hash: string;
+  phases: MissionPhaseStatus[];
+  active_phase: string;
+  overall: MissionOverall | string;
+}
+
+export interface MissionProjection {
+  mission_id: string;
+  status: MissionStatus;
+  mission_status_hash: string;
+  ledger_head: string;
+  ledger_verified: boolean;
+  evidence_verified: boolean;
+  entry_count: number;
+}
+
+/** List mission ids that have a ledger to project, newest first. */
+export async function listMissions(): Promise<string[]> {
+  const body = await apiGet<{ missions: string[] }>('/missions');
+  return body.missions ?? [];
+}
+
+/** Fetch the projection receipt (canonical status + status hash) for a mission. */
+export function getMission(missionId: string): Promise<MissionProjection> {
+  return apiGet<MissionProjection>(`/missions/${encodeURIComponent(missionId)}`);
+}
+
+/** Build the provenance link for a phase gate's evidence bundle. */
+export function missionEvidenceUrl(missionId: string, taskId: string): string {
+  return buildUrl(
+    `/missions/${encodeURIComponent(missionId)}/evidence/${encodeURIComponent(taskId)}`,
+  );
+}

--- a/web/src/routes/Missions.tsx
+++ b/web/src/routes/Missions.tsx
@@ -1,0 +1,320 @@
+// Mission timeline screen (#2510) - the outcome-level view over a multi-day run.
+//
+// Task-level surfaces (tasks, fleet, approvals, costs, audit) are covered, but a
+// multi-day mission had no timeline showing phases, gate verdicts, envelope burn,
+// and evidence. This screen renders the deterministic mission projection served
+// by `/api/v1/missions/*` (see `src/bernstein/core/routes/missions.py`):
+//
+//   * phase lanes with per-phase state, gate receipt, and envelope burn;
+//   * every element links to the receipt / evidence bundle it was derived from -
+//     no element renders without provenance;
+//   * the `mission_status_hash` is shown so two operators can confirm they are
+//     looking at the same state;
+//   * when chain verification fails (`ledger_verified === false`) the screen
+//     switches to an explicit unverified banner instead of best-effort
+//     rendering.
+//
+// The projection is a pure fold over the mission's work-ledger chain: the server
+// holds no mission-side state, so the same ledger bytes render the same screen
+// from any host.
+
+import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  CircleDashed,
+  FileCheck2,
+  Flag,
+  ShieldAlert,
+  Target,
+} from 'lucide-react';
+
+import {
+  getMission,
+  listMissions,
+  missionEvidenceUrl,
+  type MissionPhaseStatus,
+  type MissionProjection,
+} from '@/lib/api';
+import { formatUSD } from '@/lib/format';
+import { EmptyState, ErrorState, LoadingState, Pill, SectionLabel } from '@/lib/states';
+import { cn } from '@/lib/utils';
+
+// ── Phase-state visuals ──────────────────────────────────────────────────────
+
+type PillKind = 'default' | 'accent' | 'success' | 'warning' | 'danger' | 'ghost';
+
+const PHASE_PILL: Record<string, PillKind> = {
+  passed: 'success',
+  active: 'accent',
+  pending: 'ghost',
+  halted: 'danger',
+  unverified: 'warning',
+};
+
+function phaseIcon(state: string) {
+  switch (state) {
+    case 'passed':
+      return <CheckCircle2 className="h-4 w-4 text-[var(--success,#16a34a)]" aria-hidden />;
+    case 'active':
+      return <Target className="h-4 w-4 text-primary" aria-hidden />;
+    case 'halted':
+      return <Flag className="h-4 w-4 text-destructive" aria-hidden />;
+    case 'unverified':
+      return <ShieldAlert className="h-4 w-4 text-[var(--warning,#d97706)]" aria-hidden />;
+    default:
+      return <CircleDashed className="h-4 w-4 text-muted-foreground" aria-hidden />;
+  }
+}
+
+function burnPct(phase: MissionPhaseStatus): number {
+  if (!phase.budget_usd) return 0;
+  return Math.min(100, Math.round((phase.spend_usd / phase.budget_usd) * 100));
+}
+
+// ── Provenance handle: a short hash that links to its origin ─────────────────
+
+function shortHash(s: string, head = 10): string {
+  if (!s) return '';
+  const bare = s.startsWith('sha256:') ? s.slice(7) : s;
+  return bare.length > head ? `${bare.slice(0, head)}...` : bare;
+}
+
+// ── Phase lane ───────────────────────────────────────────────────────────────
+
+function PhaseLane({
+  missionId,
+  phase,
+  index,
+}: {
+  missionId: string;
+  phase: MissionPhaseStatus;
+  index: number;
+}) {
+  const pct = burnPct(phase);
+  return (
+    <li className="relative flex gap-3">
+      {/* Rail + node */}
+      <div className="flex flex-col items-center">
+        <span className="flex h-7 w-7 items-center justify-center rounded-full border border-border bg-card">
+          {phaseIcon(phase.state)}
+        </span>
+        <span className="mt-1 w-px flex-1 bg-border-subtle" aria-hidden />
+      </div>
+
+      <div className="mb-4 flex-1 rounded-md border border-border-subtle bg-surface-raised/40 p-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <span className="font-mono text-[11px] text-meta-foreground">#{index + 1}</span>
+            <span className="text-body-md text-foreground">{phase.name || phase.phase_id}</span>
+            <Pill kind={PHASE_PILL[phase.state] ?? 'default'}>{phase.state}</Pill>
+          </div>
+          <div className="font-mono text-[11px] text-muted-foreground">
+            {formatUSD(phase.spend_usd)} / {phase.budget_usd ? formatUSD(phase.budget_usd) : 'unlimited'}
+          </div>
+        </div>
+
+        {/* Envelope burn */}
+        <div className="mt-2">
+          <div className="flex items-center justify-between text-[11px] text-meta-foreground">
+            <span className="font-mono">{phase.envelope}</span>
+            <span>{phase.budget_usd ? `${pct}%` : ''}</span>
+          </div>
+          <div className="mt-1 h-1.5 overflow-hidden rounded-full bg-muted/60">
+            <div
+              className={cn(
+                'h-full rounded-full',
+                pct >= 100 ? 'bg-destructive' : pct >= 80 ? 'bg-[var(--warning,#d97706)]' : 'bg-primary',
+              )}
+              style={{ width: `${phase.budget_usd ? pct : 0}%` }}
+            />
+          </div>
+        </div>
+
+        {/* Provenance: gate receipt + evidence bundle links. No element without provenance. */}
+        <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px]">
+          <span className="text-meta-foreground">
+            gate: {phase.gate_passed ? 'passed' : phase.state === 'halted' ? 'failed' : 'pending'}
+            {phase.gate.length ? ` (${phase.gate.length} task${phase.gate.length === 1 ? '' : 's'})` : ''}
+          </span>
+          {phase.receipt_hash ? (
+            <span className="font-mono text-muted-foreground" title={phase.receipt_hash}>
+              receipt {shortHash(phase.receipt_hash)}
+            </span>
+          ) : (
+            <span className="text-meta-foreground">no receipt yet</span>
+          )}
+          {phase.gate.map((taskId) => (
+            <a
+              key={taskId}
+              href={missionEvidenceUrl(missionId, taskId)}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 text-primary hover:underline"
+              title={`Evidence bundle for ${taskId}`}
+            >
+              <FileCheck2 className="h-3 w-3" aria-hidden />
+              {taskId}
+            </a>
+          ))}
+        </div>
+      </div>
+    </li>
+  );
+}
+
+// ── Verification banner ──────────────────────────────────────────────────────
+
+function UnverifiedBanner({ projection }: { projection: MissionProjection }) {
+  const chainTorn = !projection.ledger_verified;
+  return (
+    <div
+      role="alert"
+      className="flex items-start gap-3 rounded-md border border-destructive/50 bg-destructive/10 p-4"
+    >
+      <ShieldAlert className="mt-0.5 h-5 w-5 text-destructive" aria-hidden />
+      <div>
+        <div className="text-body-md text-foreground">Unverified state - not safe to trust</div>
+        <p className="mt-1 text-body text-muted-foreground">
+          {chainTorn
+            ? 'The mission work-ledger chain no longer recomputes: a ledger entry was tampered with. '
+            : 'A referenced evidence bundle no longer matches the hash its phase receipt bound. '}
+          The timeline below is rendered from the projection, but every claim is unverified until the
+          chain and evidence verify again.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+// ── Mission detail (timeline) ────────────────────────────────────────────────
+
+function MissionDetail({ missionId }: { missionId: string }) {
+  const q = useQuery({
+    queryKey: ['missions', 'projection', missionId],
+    queryFn: () => getMission(missionId),
+    refetchInterval: 15_000,
+  });
+
+  if (q.isLoading) return <LoadingState rows={4} label="Projecting mission from the ledger" />;
+  if (q.isError) {
+    return (
+      <ErrorState
+        title="Could not project mission"
+        message={(q.error as Error).message}
+        retry={() => void q.refetch()}
+      />
+    );
+  }
+
+  const projection = q.data!;
+  const status = projection.status;
+  const unverified = !projection.ledger_verified || !projection.evidence_verified || status.overall === 'unverified';
+
+  return (
+    <div className="space-y-4">
+      {unverified && <UnverifiedBanner projection={projection} />}
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <h2 className="text-h3 text-foreground">{status.mission_id}</h2>
+          <Pill kind={unverified ? 'warning' : status.overall === 'complete' ? 'success' : 'accent'} strong>
+            {status.overall}
+          </Pill>
+        </div>
+        <div className="flex items-center gap-2 text-[11px] text-meta-foreground">
+          {unverified ? (
+            <AlertTriangle className="h-3.5 w-3.5 text-destructive" aria-hidden />
+          ) : (
+            <CheckCircle2 className="h-3.5 w-3.5 text-[var(--success,#16a34a)]" aria-hidden />
+          )}
+          <span>{projection.entry_count} ledger entries</span>
+        </div>
+      </div>
+
+      {/* The status hash two operators must agree on. */}
+      <div className="rounded-md border border-border-subtle bg-card px-3 py-2">
+        <div className="text-meta uppercase text-meta-foreground">mission_status_hash</div>
+        <div className="mt-0.5 select-all break-all font-mono text-[12px] text-foreground">
+          {projection.mission_status_hash}
+        </div>
+      </div>
+
+      <div>
+        <SectionLabel>Phase timeline</SectionLabel>
+        <ol className="mt-3">
+          {status.phases.map((phase, i) => (
+            <PhaseLane key={phase.phase_id} missionId={missionId} phase={phase} index={i} />
+          ))}
+        </ol>
+        {status.phases.length === 0 && (
+          <p className="text-body text-muted-foreground">This mission declares no phases yet.</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Screen ───────────────────────────────────────────────────────────────────
+
+export default function Missions() {
+  const listQ = useQuery({
+    queryKey: ['missions', 'list'],
+    queryFn: listMissions,
+    refetchInterval: 30_000,
+  });
+
+  const missions = useMemo(() => listQ.data ?? [], [listQ.data]);
+  const [selected, setSelected] = useState<string | null>(null);
+  const active = selected ?? missions[0] ?? null;
+
+  return (
+    <div className="p-4 md:p-6">
+      <div className="mb-4">
+        <h1 className="text-h2 text-foreground">Missions</h1>
+        <p className="mt-1 text-body text-muted-foreground">
+          Outcome-level timeline for multi-day runs. Every phase, gate verdict, and dollar of envelope burn is a
+          projection of the mission ledger - the same verified state everyone who opens this screen sees.
+        </p>
+      </div>
+
+      {listQ.isLoading ? (
+        <LoadingState rows={6} label="Loading missions" />
+      ) : listQ.isError ? (
+        <ErrorState message={(listQ.error as Error).message} retry={() => void listQ.refetch()} />
+      ) : missions.length === 0 ? (
+        <EmptyState
+          icon={<Target className="h-6 w-6" />}
+          title="No missions yet"
+          description="Define a multi-day mission with `bernstein mission define <spec.json>`. Its timeline appears here once the ledger has a mission.defined transition."
+        />
+      ) : (
+        <div className="grid gap-6 lg:grid-cols-[240px_1fr]">
+          {/* Mission list */}
+          <nav aria-label="Missions" className="space-y-1">
+            {missions.map((id) => (
+              <button
+                key={id}
+                type="button"
+                onClick={() => setSelected(id)}
+                className={cn(
+                  'flex w-full items-center gap-2 rounded-md border px-3 py-2 text-left text-body-md transition-colors',
+                  id === active
+                    ? 'border-primary bg-primary/10 text-foreground'
+                    : 'border-border-subtle bg-card text-muted-foreground hover:bg-secondary',
+                )}
+              >
+                <Flag className="h-3.5 w-3.5 shrink-0" aria-hidden />
+                <span className="truncate font-mono text-[12px]">{id}</span>
+              </button>
+            ))}
+          </nav>
+
+          {/* Timeline */}
+          <section>{active && <MissionDetail missionId={active} />}</section>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #2510.

Task-level surfaces are covered, but a multi-day mission had no outcome-level view and no push channel summarizing overnight progress. This adds two surfaces over the existing mission projection (#2509), both keeping the run's guarantees.

## Signed daily progress digest
- **Determinism.** The canonical digest document is a pure fold of `(mission projection, fire time)`. Two hosts with byte-identical ledgers, folding at the same `fire_time`, derive byte-identical digest bytes and the same `digest_hash` (golden test pins both hash and receipt id). A missed fire recomputes to the identical digest after a restart.
- **Verifiability.** The posted chat message is the verbatim projection of the digest; the `digest_hash` is embedded in the message and recorded in the HMAC audit chain as `mission.digest_receipt`. `verify` recomputes the digest from the ledger and detects an edited or truncated message as a mismatch; a tampered receipt fails chain verification at its exact position.
- **Idempotency.** Delivery is keyed on the digest receipt id (a pure function of `mission_id`, `fire_time`, `digest_hash`), recorded in a durable append-only ledger, so a restart between fire computation and chat delivery does not double-post.
- **Cross-driver.** Delivery travels only over the common chat bridge `send_message` path; a parametrized test proves it works on the Slack, Discord, and Telegram drivers.

## Mission timeline screen
- Read-only projection routes following the review-board conventions: `GET /missions`, `/missions/{id}`, `/missions/{id}/digest?fire_time=`, `/missions/{id}/evidence/{task_id}`, plus a `mission.updated` SSE event type.
- Web route `Missions` renders phase lanes, gate receipts, per-phase envelope burn, and evidence links; displays the `mission_status_hash`; switches to an explicit unverified banner when chain verification fails (tested with a tampered ledger fixture). Every element links to the receipt or evidence bundle it was derived from.

## CLI
`bernstein mission digest show / send / verify`.

## Acceptance criteria
- [x] Determinism: byte-identical digest bytes + exact recorded hash on a second host (golden test).
- [x] Verifiability: posted message embeds the hash; edit/truncation detected; tampered receipt fails audit at its position.
- [x] Timeline renders only receipt/ledger-backed facts; tampered ledger flips to an explicit unverified state.
- [x] Observability: every timeline element links to its receipt / evidence bundle.
- [x] Restart does not double-post; missed fire recomputes to the identical digest.
- [x] Delivery works on all three shipped chat drivers through the common bridge.

## Tests
New: `tests/unit/orchestration/test_mission_digest.py`, `tests/unit/test_audit_chain_mission_digest.py`, `tests/unit/test_missions_route.py`, `tests/unit/test_mission_digest_cmd.py`. Local: ruff clean, `lint-imports` clean, web `tsc -b` clean, relevant suites green.

Additive and behavior-preserving: builds on the merged mission substrate (#2509); no existing behavior changed.