### PR TITLE
fix(security): truthful egress attestation and spawn-time compliance for the sovereign profile

### DIFF
--- a/docs/compliance/eu-residency-customer-setup.md
+++ b/docs/compliance/eu-residency-customer-setup.md
@@ -85,9 +85,18 @@ sovereign:
   enabled: true
   regions: [eu-central, eu-west]
   enforce_strict: true
+  # Egress is deny-all by default. To reach a self-hosted EU model server,
+  # list it here (host / host:port / CIDR) -- NOT via --allow-network -- so the
+  # runtime network policy and the signed attestation come from the same config
+  # and cannot diverge. Every entry must be self-hosted or EU-region.
+  allowed_egress: ["10.0.0.5:11434"]
 storage:
   backend: memory        # local sink only; a remote backend is drift
 ```
+
+Under `--profile sovereign`, `--allow-network` is rejected: egress is declared
+in config so a deny-all attestation can never coexist with a runtime that
+quietly allows a destination.
 
 Verify the posture at any time:
 

--- a/src/bernstein/cli/commands/doctor_sovereign_cmd.py
+++ b/src/bernstein/cli/commands/doctor_sovereign_cmd.py
@@ -55,11 +55,15 @@ def _simulated_sovereign_env() -> Iterator[bool]:
     prior_sovereign = os.environ.get(ENV_SOVEREIGN_MODE)
     activated = False
     if (prior_sovereign or "").strip().lower() not in {"1", "true", "sovereign"}:
+        # A real ``bernstein run --profile sovereign`` always installs the
+        # airgap deny-all baseline, so the simulation overrides BOTH the profile
+        # mode and the network policy unconditionally (not only when unset) --
+        # otherwise a stale ``BERNSTEIN_NETWORK_POLICY`` from a prior session
+        # would make the deny-all check report a state the real run would not
+        # produce. The caller's values are restored in the ``finally`` block.
         os.environ[ENV_SOVEREIGN_MODE] = "1"
-        if (prior_profile or "").strip().lower() != PROFILE_AIRGAP:
-            os.environ[ENV_PROFILE_MODE] = PROFILE_AIRGAP
-        if prior_policy is None:
-            os.environ[ENV_NETWORK_POLICY] = "none"
+        os.environ[ENV_PROFILE_MODE] = PROFILE_AIRGAP
+        os.environ[ENV_NETWORK_POLICY] = "none"
         activated = True
     try:
         yield activated

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -403,6 +403,38 @@ def _install_network_policy(
         install_runtime_socket_guard()
 
 
+def _install_profile_network_policy(*, run_profile: str | None, allow_network: tuple[str, ...], workdir: Path) -> None:
+    """Install the egress policy, sourcing sovereign egress from config (#2518).
+
+    Under ``--profile sovereign`` the egress allow-list comes from
+    ``bernstein.yaml`` (``sovereign.allowed_egress``), not ``--allow-network``,
+    so the runtime network policy and the signed posture attestation are
+    computed from the same config and cannot diverge (a deny-all attestation
+    can never coexist with a runtime that quietly allows a destination).
+    Everything else keeps the existing ``--allow-network`` behaviour.
+
+    Raises:
+        click.UsageError: When ``--allow-network`` is combined with
+            ``--profile sovereign``.
+    """
+    if (run_profile or "").strip().lower() == "sovereign":
+        from bernstein.core.security.deployment_profile import (
+            load_config_snapshot,
+            sovereign_egress_allowlist,
+        )
+
+        if allow_network:
+            raise click.UsageError(
+                "--allow-network is not accepted under --profile sovereign. Declare egress "
+                "destinations in bernstein.yaml under sovereign.allowed_egress so the runtime "
+                "network policy and the signed posture attestation stay in sync."
+            )
+        egress = sovereign_egress_allowlist(load_config_snapshot(workdir))
+        _install_network_policy(run_profile=run_profile, allow_network=egress)
+    else:
+        _install_network_policy(run_profile=run_profile, allow_network=allow_network)
+
+
 def _activate_sovereign_profile(*, run_profile: str | None, workdir: Path) -> None:
     """Attest the sovereign residency posture at run start (issue #2518).
 
@@ -1591,7 +1623,7 @@ def _run_impl(
         max_blast_radius=max_blast_radius,
     )
 
-    _install_network_policy(run_profile=run_profile, allow_network=allow_network)
+    _install_profile_network_policy(run_profile=run_profile, allow_network=allow_network, workdir=Path.cwd())
     _activate_sovereign_profile(run_profile=run_profile, workdir=Path.cwd())
 
     _configure_quality_gate_bypass(

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -2776,22 +2776,24 @@ class AgentSpawner:
             )
 
     def _preflight_posture_drift(self) -> None:
-        """Refuse a spawn when the sovereign posture drifted from attestation (#2518).
+        """Refuse a spawn when the sovereign posture drifted or is non-compliant (#2518).
 
         No-op unless the run activated ``--profile sovereign``. When active,
         recomputes the effective residency posture from the live workspace
-        config and compares its canonical hash to the attested hash. On any
-        divergence -- a cloud storage sink added, a catalog re-enabled, a role
-        repointed at a non-certified endpoint -- this signs and anchors a drift
-        record naming the exact diverging keys, then refuses the spawn. The
-        signed drift record re-verifies under ``bernstein audit verify``, so the
-        divergence is caught at spawn time and evidenced on the chain rather
-        than surfacing at audit time.
+        config and compares its canonical hash to the attested hash, and
+        re-checks live compliance -- storage locality, offline catalog, strict
+        EU residency, and endpoint certification against the on-disk receipts.
+        A spawn is refused on hash drift (a cloud storage sink added, a catalog
+        re-enabled, a role repointed) *or* a live violation (an endpoint whose
+        certification receipt was revoked without a config change, which leaves
+        the posture hash unchanged). The signed refusal record re-verifies under
+        ``bernstein audit verify``, so the divergence is caught at spawn time and
+        evidenced on the chain rather than surfacing at audit time.
 
         Raises:
-            PostureDriftRefusal: On posture drift (or a missing attestation).
-                Deliberately not a ``SpawnError`` so the per-provider failover
-                loop never retries it -- a drift refusal is a hard stop.
+            PostureDriftRefusal: On drift, a live violation, or a missing
+                attestation. Deliberately not a ``SpawnError`` so the
+                per-provider failover loop never retries it -- a hard stop.
         """
         from bernstein.core.security.network_policy import is_sovereign_profile
 
@@ -2810,7 +2812,7 @@ class AgentSpawner:
 
         snapshot = load_config_snapshot(self._workdir)
         evaluation = evaluate_posture_drift(workdir=self._workdir, config_snapshot=snapshot)
-        if not evaluation.drifted:
+        if not evaluation.should_refuse:
             return
 
         chain = AuditChainStore(self._workdir / ".sdd" / "audit")
@@ -2820,17 +2822,19 @@ class AgentSpawner:
             timestamp=int(_time.time()),
             chain=chain,
         )
-        diverging = ", ".join(evaluation.diverging_keys) or "(attestation missing)"
+        diverging = ", ".join(evaluation.diverging_keys) or "(none)"
+        violations = "; ".join(evaluation.violations) or "(none)"
         logger.error(
-            "spawn refused: sovereign posture drift - diverging_keys=[%s] attested=%s observed=%s",
+            "spawn refused: sovereign posture - diverging_keys=[%s] violations=[%s] attested=%s observed=%s",
             diverging,
+            violations,
             evaluation.attested_hash or "<none>",
             evaluation.observed_hash,
         )
         raise PostureDriftRefusal(
-            f"sovereign posture drift: {evaluation.reason}. Diverging keys: {diverging}. "
-            "Re-activate the profile (bernstein run --profile sovereign) after restoring the "
-            "intended posture, or inspect it with 'bernstein doctor sovereign'.",
+            f"sovereign posture refusal: {evaluation.reason}. Diverging keys: {diverging}. "
+            f"Violations: {violations}. Re-activate the profile (bernstein run --profile sovereign) "
+            "after restoring the intended posture, or inspect it with 'bernstein doctor sovereign'.",
             record=record,
             record_sha256=record_sha256,
         )
@@ -4093,6 +4097,12 @@ class AgentSpawner:
         """
         if not tasks:
             raise ValueError("Cannot resume with empty task list")
+
+        # Sovereign posture drift gate (#2518): the resume path goes straight to
+        # the adapter without ``_spawn_for_tasks_internal``, so it must apply the
+        # same gate or a sovereign run could resume an agent after the posture
+        # drifted. A hard stop (``PostureDriftRefusal``), same as the main path.
+        self._preflight_posture_drift()
 
         # Build resume context prefix
         files_list = "\n".join(f"  - {f}" for f in changed_files) if changed_files else "  (none)"

--- a/src/bernstein/core/config/config_schema.py
+++ b/src/bernstein/core/config/config_schema.py
@@ -338,6 +338,16 @@ class SovereignProfileSchema(BaseModel):
         default=True,
         description="When true, a residency region outside the pinned set halts the run.",
     )
+    allowed_egress: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Egress allow-list under --profile sovereign, as host / host:port / CIDR tokens "
+            "(e.g. a self-hosted EU model server on 10.0.0.5:11434). Empty means deny-all. "
+            "Declared here (not via --allow-network) so the runtime policy and the signed "
+            "posture attestation are sourced from the same config and cannot diverge. Every "
+            "entry must resolve to a self-hosted / EU-region destination."
+        ),
+    )
 
 
 class SessionSchema(BaseModel):

--- a/src/bernstein/core/distribution/doctor_sovereign.py
+++ b/src/bernstein/core/distribution/doctor_sovereign.py
@@ -42,7 +42,7 @@ from bernstein.core.security.network_policy import ENV_SOVEREIGN_MODE
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from bernstein.core.security.deployment_profile import EffectivePolicy
+    from bernstein.core.security.deployment_profile import DriftEvaluation, EffectivePolicy
 
 
 @dataclass(frozen=True)
@@ -169,9 +169,8 @@ def check_endpoints_certified(policy: EffectivePolicy, workdir: Path) -> Check:
     )
 
 
-def check_posture_attested(workdir: Path, policy: EffectivePolicy) -> Check:
+def check_posture_attested(policy: EffectivePolicy, evaluation: DriftEvaluation) -> Check:
     """Verify the posture is attested and the live posture has not drifted."""
-    evaluation = evaluate_posture_drift(workdir=workdir, config_snapshot=load_config_snapshot(workdir))
     if not evaluation.attested_hash:
         return Check(
             name="posture attested (no drift)",
@@ -214,7 +213,7 @@ def run_sovereign_checks(workdir: Path | None = None) -> SovereignReport:
         check_catalog_offline(policy),
         check_residency_strict_eu(policy),
         check_endpoints_certified(policy, cwd),
-        check_posture_attested(cwd, policy),
+        check_posture_attested(policy, evaluation),
         check_audit_chain_hmac(cwd),
     ]
     return SovereignReport.from_checks(

--- a/src/bernstein/core/security/deployment_profile.py
+++ b/src/bernstein/core/security/deployment_profile.py
@@ -69,6 +69,7 @@ __all__ = [
     "SovereignVerifyResult",
     "attestation_path",
     "build_posture_attestation",
+    "endpoint_certification_violations",
     "evaluate_posture_drift",
     "is_local_or_eu_host",
     "load_config_snapshot",
@@ -76,6 +77,7 @@ __all__ = [
     "read_posture_attestation",
     "record_and_sign_drift",
     "resolve_effective_policy",
+    "sovereign_egress_allowlist",
     "verify_sovereign_attestations",
 ]
 
@@ -148,6 +150,32 @@ def is_local_or_eu_host(base_url: str) -> bool:
     return ip.is_loopback or ip.is_private
 
 
+def _egress_token_is_local(token: str) -> bool:
+    """Return True iff an ``--allow-network`` token targets a local / EU host.
+
+    Handles the three token shapes the network policy accepts: a CIDR
+    (``10.0.0.0/8``), a bare host or ``host:port``, and bracketed IPv6. ``none``
+    is vacuously local (deny-all); ``any`` is never local (opens all egress).
+    """
+    tok = token.strip().lower()
+    if not tok or tok == "none":
+        return True
+    if tok == "any":
+        return False
+    if "/" in tok:
+        try:
+            net = ipaddress.ip_network(tok, strict=False)
+        except ValueError:
+            return False
+        return net.is_loopback or net.is_private
+    host = tok
+    if tok.startswith("[") and "]" in tok:  # [::1] or [2001:db8::1]:443
+        host = tok[1 : tok.index("]")]
+    elif tok.count(":") == 1:  # host:port (single colon => not bare IPv6)
+        host = tok.rsplit(":", 1)[0]
+    return is_local_or_eu_host(host)
+
+
 # ---------------------------------------------------------------------------
 # Effective policy (the posture identity)
 # ---------------------------------------------------------------------------
@@ -167,6 +195,7 @@ class EffectivePolicy:
     profile: str
     schema_version: int
     network_egress: str
+    egress_allowlist: tuple[str, ...]
     catalog_mode: str
     compliance_pack: str
     storage_backend: str
@@ -181,6 +210,7 @@ class EffectivePolicy:
             "profile": self.profile,
             "schema_version": self.schema_version,
             "network_egress": self.network_egress,
+            "egress_allowlist": list(self.egress_allowlist),
             "catalog_mode": self.catalog_mode,
             "compliance_pack": self.compliance_pack,
             "storage_backend": self.storage_backend,
@@ -204,8 +234,16 @@ class EffectivePolicy:
         :func:`endpoint_certification_violations`.
         """
         problems: list[str] = []
-        if self.network_egress != _PINNED_NETWORK_EGRESS:
-            problems.append(f"network egress is {self.network_egress!r}, sovereign requires deny-all")
+        # Egress may be deny-all, or an allow-list of self-hosted / EU-region
+        # destinations (a residency deployment must reach its own model server
+        # on an RFC-1918 address). A public destination in the allow-list is a
+        # violation; the allow-list itself is attested so the claim is truthful.
+        for token in self.egress_allowlist:
+            if not _egress_token_is_local(token):
+                problems.append(
+                    f"egress allow-list entry {token!r} is neither self-hosted nor EU-region; "
+                    "sovereign permits only local / EU-region egress destinations"
+                )
         if self.catalog_mode != _PINNED_CATALOG_MODE:
             problems.append(f"catalog mode is {self.catalog_mode!r}, sovereign requires offline")
         if self.storage_backend not in LOCAL_STORAGE_BACKENDS:
@@ -300,6 +338,26 @@ def _project_residency(config: Mapping[str, Any]) -> tuple[bool, tuple[str, ...]
     return enforce_strict, regions
 
 
+def sovereign_egress_allowlist(config_snapshot: Mapping[str, Any] | None) -> tuple[str, ...]:
+    """Return the sorted, de-duplicated ``sovereign.allowed_egress`` tokens.
+
+    This is the single source of truth for sovereign egress: the runtime
+    network policy is installed from it and the effective policy attests it, so
+    the attested ``network_egress`` can never claim deny-all while the runtime
+    allows a destination. ``--allow-network`` is rejected under sovereign
+    precisely so the CLI and the attested config cannot diverge.
+    """
+    config: Mapping[str, Any] = config_snapshot or {}
+    block = config.get("sovereign")
+    if not isinstance(block, Mapping):
+        return ()
+    raw = block.get("allowed_egress")
+    if not isinstance(raw, Sequence) or isinstance(raw, (str, bytes)):
+        return ()
+    tokens = {str(t).strip() for t in raw if str(t).strip()}
+    return tuple(sorted(tokens))
+
+
 def resolve_effective_policy(profile_name: str, config_snapshot: Mapping[str, Any] | None) -> EffectivePolicy:
     """Resolve the canonical effective policy for *profile_name* (pure function).
 
@@ -320,10 +378,12 @@ def resolve_effective_policy(profile_name: str, config_snapshot: Mapping[str, An
     if isinstance(storage, Mapping):
         storage_backend = str(storage.get("backend", "memory"))
     enforce_strict, regions = _project_residency(config)
+    egress = sovereign_egress_allowlist(config)
     return EffectivePolicy(
         profile=profile_name,
         schema_version=EFFECTIVE_POLICY_SCHEMA_VERSION,
-        network_egress=_PINNED_NETWORK_EGRESS,
+        network_egress=_PINNED_NETWORK_EGRESS if not egress else "allow-list",
+        egress_allowlist=egress,
         catalog_mode=_PINNED_CATALOG_MODE,
         compliance_pack=_PINNED_COMPLIANCE_PACK,
         storage_backend=storage_backend,
@@ -558,7 +618,14 @@ class PostureDriftRefusal(RuntimeError):
 
 @dataclass(frozen=True, slots=True)
 class DriftEvaluation:
-    """Outcome of comparing the live posture against the attestation."""
+    """Outcome of comparing the live posture against the attestation.
+
+    ``drifted`` is hash divergence from the attestation. ``violations`` is the
+    set of live compliance failures (config-only *and* endpoint-certification):
+    these are checked every spawn so a receipt revoked or deleted *without* a
+    config change -- which leaves the posture hash unchanged -- is still caught.
+    A spawn is refused when :attr:`should_refuse` is True.
+    """
 
     drifted: bool
     reason: str
@@ -566,6 +633,12 @@ class DriftEvaluation:
     observed_hash: str
     diverging_keys: tuple[str, ...]
     observed_policy: EffectivePolicy
+    violations: tuple[str, ...] = ()
+
+    @property
+    def should_refuse(self) -> bool:
+        """True iff the spawn must be refused (hash drift or a live violation)."""
+        return self.drifted or bool(self.violations)
 
 
 def _diverging_keys(attested: Mapping[str, Any], observed: Mapping[str, Any]) -> tuple[str, ...]:
@@ -576,10 +649,14 @@ def _diverging_keys(attested: Mapping[str, Any], observed: Mapping[str, Any]) ->
 def evaluate_posture_drift(*, workdir: Path, config_snapshot: Mapping[str, Any] | None) -> DriftEvaluation:
     """Recompute the live posture and compare it to the stored attestation.
 
-    An absent attestation is itself drift (the posture was never attested).
+    An absent attestation is itself drift (the posture was never attested). Live
+    compliance is re-checked every call -- including endpoint certification
+    against the on-disk receipts -- so a revoked or deleted receipt is caught
+    even when the config (and therefore the posture hash) is unchanged.
     """
     observed = resolve_effective_policy(SOVEREIGN_PROFILE, config_snapshot)
     observed_hash = observed.posture_hash()
+    violations = tuple(observed.violations()) + tuple(endpoint_certification_violations(observed, workdir=workdir))
     attestation = read_posture_attestation(workdir)
     if attestation is None:
         return DriftEvaluation(
@@ -589,15 +666,17 @@ def evaluate_posture_drift(*, workdir: Path, config_snapshot: Mapping[str, Any] 
             observed_hash=observed_hash,
             diverging_keys=(),
             observed_policy=observed,
+            violations=violations,
         )
     if attestation.posture_hash == observed_hash:
         return DriftEvaluation(
             drifted=False,
-            reason="",
+            reason="" if not violations else f"live posture violates the sovereign profile: {'; '.join(violations)}",
             attested_hash=attestation.posture_hash,
             observed_hash=observed_hash,
             diverging_keys=(),
             observed_policy=observed,
+            violations=violations,
         )
     diverging = _diverging_keys(attestation.effective_policy, observed.to_canonical_document())
     return DriftEvaluation(
@@ -607,6 +686,7 @@ def evaluate_posture_drift(*, workdir: Path, config_snapshot: Mapping[str, Any] 
         observed_hash=observed_hash,
         diverging_keys=diverging,
         observed_policy=observed,
+        violations=violations,
     )
 
 
@@ -634,6 +714,7 @@ def record_and_sign_drift(
         "attested_hash": evaluation.attested_hash,
         "observed_hash": evaluation.observed_hash,
         "diverging_keys": list(evaluation.diverging_keys),
+        "violations": list(evaluation.violations),
         "effective_policy": evaluation.observed_policy.to_canonical_document(),
         "timestamp": timestamp,
     }
@@ -740,7 +821,14 @@ def _verify_one_record(
             errors.append(f"{kind} {subject}: recorded hash {recorded} does not match recomputed {recomputed}")
     if kind == _RECORD_KIND_DRIFT:
         diverging = body.get("diverging_keys")
-        if not isinstance(diverging, list) or not diverging:
-            errors.append(f"{kind} {subject}: drift record names no diverging keys")
-        if body.get("attested_hash") == body.get("observed_hash"):
+        raw_violations = body.get("violations")
+        has_diverging = isinstance(diverging, list) and bool(diverging)
+        has_violations = isinstance(raw_violations, list) and bool(raw_violations)
+        # A drift record must name a reason to refuse: either hash-drift keys or
+        # live compliance violations (a receipt revoked without a config change).
+        if not has_diverging and not has_violations:
+            errors.append(f"{kind} {subject}: drift record names no diverging keys or violations")
+        # Hash drift implies the attested and observed hashes must differ; a
+        # violation-only refusal legitimately keeps them equal.
+        if has_diverging and body.get("attested_hash") == body.get("observed_hash"):
             errors.append(f"{kind} {subject}: drift record's attested and observed hashes agree")

--- a/tests/unit/test_deployment_profile.py
+++ b/tests/unit/test_deployment_profile.py
@@ -71,6 +71,7 @@ def test_effective_policy_pins_profile_constants(tmp_path: Path) -> None:
     policy = resolve_effective_policy(SOVEREIGN_PROFILE, load_config_snapshot(tmp_path))
     doc = policy.to_canonical_document()
     assert doc["network_egress"] == "deny-all"
+    assert doc["egress_allowlist"] == []
     assert doc["catalog_mode"] == "offline"
     assert doc["compliance_pack"] == "regulated"
     assert doc["storage_backend"] == "memory"
@@ -256,6 +257,30 @@ def test_config_edit_after_attestation_drifts_and_names_key(tmp_path: Path) -> N
     assert result.attestation_count == 1
 
 
+def test_non_certified_endpoint_refuses_without_hash_drift(tmp_path: Path) -> None:
+    """AC4: a gated endpoint with no receipt refuses even when the hash is unchanged."""
+    # A gated role points at a local endpoint (host-compliant) but has no
+    # certification receipt on disk. The posture hash reflects only the config,
+    # so it does not "drift", yet the spawn gate must still refuse.
+    _write_config(
+        tmp_path,
+        "goal: x\nrole_model_policy:\n  developer:\n    base_url: http://10.0.0.5:11434/v1\n    model: m\n",
+    )
+    policy = resolve_effective_policy(SOVEREIGN_PROFILE, load_config_snapshot(tmp_path))
+    build_posture_attestation(workdir=tmp_path, policy=policy, timestamp=1, chain=AuditChainStore(_audit_dir(tmp_path)))
+    ev = evaluate_posture_drift(workdir=tmp_path, config_snapshot=load_config_snapshot(tmp_path))
+    assert ev.drifted is False  # config unchanged -> hash matches
+    assert ev.should_refuse is True  # but a gated endpoint lacks certification
+    assert any("certification" in v for v in ev.violations)
+
+    # The violation-only refusal record signs + anchors + re-verifies.
+    record, _ = record_and_sign_drift(
+        workdir=tmp_path, evaluation=ev, timestamp=2, chain=AuditChainStore(_audit_dir(tmp_path))
+    )
+    assert record["violations"]
+    assert verify_sovereign_attestations(_audit_dir(tmp_path)).ok is True
+
+
 def test_drift_record_is_anchored_in_chain(tmp_path: Path) -> None:
     _write_config(tmp_path, _CLEAN_CONFIG)
     policy = resolve_effective_policy(SOVEREIGN_PROFILE, load_config_snapshot(tmp_path))
@@ -343,6 +368,7 @@ def test_effective_policy_document_round_trips() -> None:
         profile="sovereign",
         schema_version=1,
         network_egress="deny-all",
+        egress_allowlist=(),
         catalog_mode="offline",
         compliance_pack="regulated",
         storage_backend="memory",
@@ -353,3 +379,45 @@ def test_effective_policy_document_round_trips() -> None:
     )
     doc = policy.to_canonical_document()
     assert json.loads(json.dumps(doc)) == doc
+
+
+# ---------------------------------------------------------------------------
+# Egress allow-list truthfulness (deny-all attestation must match runtime)
+# ---------------------------------------------------------------------------
+
+
+def test_deny_all_egress_by_default(tmp_path: Path) -> None:
+    _write_config(tmp_path, _CLEAN_CONFIG)
+    policy = resolve_effective_policy(SOVEREIGN_PROFILE, load_config_snapshot(tmp_path))
+    doc = policy.to_canonical_document()
+    assert doc["network_egress"] == "deny-all"
+    assert doc["egress_allowlist"] == []
+
+
+def test_local_egress_allowlist_is_compliant_and_attested(tmp_path: Path) -> None:
+    _write_config(
+        tmp_path,
+        "goal: x\nsovereign:\n  enabled: true\n  allowed_egress: ['10.0.0.5:11434', 'vllm.internal:8000']\n",
+    )
+    policy = resolve_effective_policy(SOVEREIGN_PROFILE, load_config_snapshot(tmp_path))
+    doc = policy.to_canonical_document()
+    assert doc["network_egress"] == "allow-list"
+    assert doc["egress_allowlist"] == ["10.0.0.5:11434", "vllm.internal:8000"]
+    assert policy.violations() == []
+
+
+def test_public_egress_allowlist_is_a_violation(tmp_path: Path) -> None:
+    _write_config(
+        tmp_path,
+        "goal: x\nsovereign:\n  enabled: true\n  allowed_egress: ['api.openai.com:443']\n",
+    )
+    policy = resolve_effective_policy(SOVEREIGN_PROFILE, load_config_snapshot(tmp_path))
+    assert any("egress" in p for p in policy.violations())
+
+
+def test_egress_allowlist_changes_posture_hash(tmp_path: Path) -> None:
+    _write_config(tmp_path, _CLEAN_CONFIG)
+    base = resolve_effective_policy(SOVEREIGN_PROFILE, load_config_snapshot(tmp_path)).posture_hash()
+    _write_config(tmp_path, "goal: x\nsovereign:\n  enabled: true\n  allowed_egress: ['10.0.0.5:11434']\n")
+    changed = resolve_effective_policy(SOVEREIGN_PROFILE, load_config_snapshot(tmp_path)).posture_hash()
+    assert base != changed

--- a/tests/unit/test_sovereign_spawn_gate.py
+++ b/tests/unit/test_sovereign_spawn_gate.py
@@ -77,11 +77,70 @@ def test_gate_refuses_when_never_attested(tmp_path: Path, monkeypatch: pytest.Mo
         _preflight(tmp_path)
 
 
+def test_gate_refuses_on_revoked_certification_without_config_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AC4: a gated endpoint with no receipt is refused even when the hash matches."""
+    monkeypatch.setenv(ENV_SOVEREIGN_MODE, "1")
+    (tmp_path / ".sdd" / "audit").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "bernstein.yaml").write_text(
+        "goal: x\nrole_model_policy:\n  developer:\n    base_url: http://10.0.0.5:11434/v1\n    model: m\n",
+        encoding="utf-8",
+    )
+    policy = resolve_effective_policy(SOVEREIGN_PROFILE, load_config_snapshot(tmp_path))
+    build_posture_attestation(
+        workdir=tmp_path, policy=policy, timestamp=1, chain=AuditChainStore(tmp_path / ".sdd" / "audit")
+    )
+    with pytest.raises(PostureDriftRefusal) as excinfo:
+        _preflight(tmp_path)
+    assert excinfo.value.record["violations"]
+
+
 def test_drift_refusal_is_not_a_spawn_error() -> None:
     """A drift refusal must be a hard stop, not swallowed by provider failover."""
     from bernstein.adapters.base import SpawnError
 
     assert not issubclass(PostureDriftRefusal, SpawnError)
+
+
+def test_resume_path_invokes_the_gate() -> None:
+    """AC (bypass): spawn_for_resume must run the same drift gate as the main path."""
+    import inspect
+
+    source = inspect.getsource(AgentSpawner.spawn_for_resume)
+    assert "_preflight_posture_drift" in source
+
+
+def test_sovereign_rejects_cli_allow_network(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """--allow-network is rejected under sovereign so egress is config-sourced only."""
+    import click
+
+    from bernstein.cli.run_bootstrap import _install_profile_network_policy
+
+    for var in ("BERNSTEIN_PROFILE_MODE", "BERNSTEIN_NETWORK_POLICY", ENV_SOVEREIGN_MODE):
+        monkeypatch.delenv(var, raising=False)
+    with pytest.raises(click.UsageError, match="allowed_egress"):
+        _install_profile_network_policy(run_profile="sovereign", allow_network=("10.0.0.5:11434",), workdir=tmp_path)
+
+
+def test_sovereign_egress_sourced_from_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sovereign installs the deny-all-or-allowlist policy from config, then restores."""
+    from bernstein.cli.run_bootstrap import _install_profile_network_policy
+    from bernstein.core.security.network_policy import ENV_NETWORK_POLICY, ENV_PROFILE_MODE, policy_from_env
+    from bernstein.core.security.socket_guard import uninstall_runtime_socket_guard
+
+    for var in (ENV_PROFILE_MODE, ENV_NETWORK_POLICY, ENV_SOVEREIGN_MODE):
+        monkeypatch.delenv(var, raising=False)
+    (tmp_path / "bernstein.yaml").write_text(
+        "goal: x\nsovereign:\n  enabled: true\n  allowed_egress: ['10.0.0.5:11434']\n", encoding="utf-8"
+    )
+    try:
+        _install_profile_network_policy(run_profile="sovereign", allow_network=(), workdir=tmp_path)
+        assert is_sovereign_profile() is True
+        assert policy_from_env().is_allowed("10.0.0.5", 11434) is True
+        assert policy_from_env().is_allowed("api.openai.com", 443) is False
+    finally:
+        uninstall_runtime_socket_guard()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #2629 (sovereign deployment profile). Addresses correctness findings surfaced in review of that PR before they can mislead a residency-constrained operator's audit.

## Changes

- **Truthful egress attestation.** The effective policy now projects an explicit egress allow-list from `bernstein.yaml` (`sovereign.allowed_egress`) instead of always signing `network_egress: deny-all`. Under `--profile sovereign`, `--allow-network` is rejected so the runtime network policy and the signed attestation are sourced from the same config and cannot diverge. A self-hosted EU model server on an RFC-1918 address is reachable and attested; a public egress destination is a violation.
- **Spawn-time compliance enforcement.** The drift gate now refuses on live compliance violations (storage locality, offline catalog, strict EU residency, and endpoint certification against the on-disk receipts), not only on posture-hash drift. A certification receipt revoked or deleted without a config change — which leaves the posture hash unchanged — is now caught at spawn time; the signed refusal record carries the violations and re-verifies under `bernstein audit verify`.
- **Resume-path gate.** `spawn_for_resume` now runs the same drift gate, closing a bypass where a sovereign run could resume an agent after posture drift.
- **doctor sovereign.** The network-policy simulation overrides profile mode and network policy symmetrically so a stale env var cannot skew the report; the posture evaluation is computed once and threaded through.

## Tests

Extends the sovereign suites with the egress allow-list projection and truthfulness, the violation-only spawn refusal (AC4 revocation gap), the resume-path gate, and the `--allow-network` rejection. ruff clean; `bernstein agents-md verify` in sync; 54 sovereign tests green plus the existing airgap / audit-verify / config-schema suites.