### PR TITLE
chore(release): v3.7.0

### DIFF
--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bernstein",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "Multi-agent orchestration for CLI coding agents. Spawn parallel agents, verify their work, and merge results.",
   "author": {
     "name": "chernistry",

--- a/docs/release-notes/v3.7.0.md
+++ b/docs/release-notes/v3.7.0.md
@@ -1,0 +1,48 @@
+# v3.7.0
+
+Released 2026-07-17.
+
+## Theme
+
+v3.7.0 opens the orchestrator beyond coding agents and turns its determinism and audit chain into standard, independently verifiable receipts. The through-line: any agent, any artifact, and every result provable offline.
+
+## Highlights
+
+### Verifiable receipts, in standard formats
+
+- **Export the audit chain as standard verifiable receipts (#2617).** Projects an HMAC audit-chain range into COSE_Sign1, in-toto attestation, and a transparency-log-style signed receipt, each re-verifiable offline by a standard verifier with zero Bernstein imports. Tampering with a chain entry breaks the receipt exactly as it breaks the chain.
+- **Per-goal SLA contracts (#2618).** Signed violation receipts, lineage-anchored freshness, and ledger-projected error budgets: a breach is a signed, offline-verifiable receipt, not just a log line.
+
+### Universalization: non-coding agents as first-class
+
+- **Browser and computer-use adapter (#2621).** A new adapter family fronts autonomous browser and computer-use agents. Every action is a content-addressed lineage anchor; the action sequence replays deterministically and a divergence surfaces as a hash mismatch at the exact action index.
+- **Research activity worker (#2630).** Non-coding research runs land as artifacts whose every citation is an offline-resolvable lineage anchor, so a report reconstructs from the chain alone.
+
+### Durable, resilient execution
+
+- **Durable task suspend and resume (#2616).** A task waiting on a human or external event parks with an attested receipt that releases the seat, sandbox, and budget envelope; resume reconstructs byte-identically from the receipt.
+- **Cache policy engine (#2625).** Composable content-addressed key recipes, repo-drift expiry, claim-based fleet dedup with a signed duplicate-of receipt, and lineage-propagated eviction. Two operators derive byte-identical cache keys and verdicts.
+- **Lineage-attested failure receipts in recovery (#2628).** An `on_fail` recovery task now carries a lineage-attested failure receipt, so why-it-failed and what-recovered are a single verifiable edge.
+
+### Fleet and deployment
+
+- **Named sandbox pools (#2547).** Chain-projected pool manifests, governed overrides with capability and egress ceilings, and signed worker enrolment. Two hosts holding the same manifest compute a byte-identical effective-manifest hash; a widening override is refused with a chained receipt and no sandbox is created.
+- **Sovereign deployment profile (#2629).** A signed residency posture attestation anchored in the audit chain; posture drift at spawn is a signed, offline-verifiable refusal rather than a silent misconfiguration.
+- **Mission timeline and signed daily digests (#2510).** A mission screen backed by signed daily progress digests, each a verifiable projection of the day's chain.
+
+## Security
+
+Hardening from coordinated disclosure (all fixed and merged):
+
+- **Memory provenance on the spawned-agent prompt path (#2624).** The cross-adapter memory-poisoning invariant is now enforced where the spawned-agent prompt is built, not only in the opt-in query path.
+- **Sandbox scope enforcement (#2622).** `scope_enforcement` is no longer auto-relaxed for a sandbox backend that cannot demonstrate a task-scoped mount.
+- **Newsletter endpoint (bernstein.run).** `POST /api/notify` now returns a uniform response regardless of prior subscription state, closing a subscriber-membership oracle.
+
+The disclosure policy was also corrected (#2623, #2627, #2634): the prior SECURITY.md advertised a paid bug bounty with no budget behind it. It is replaced with an honest recognition-only coordinated-disclosure policy, and the sovereign profile now attests egress truthfully at spawn time.
+
+## Acknowledgments
+
+Thanks to the researchers who reported the issues above through coordinated disclosure:
+
+- **Dmitriy Filatov (Malder)** (https://github.com/Malder-coder) for the memory-provenance and sandbox scope-enforcement reports.
+- **Gaurav Popalghat** (https://www.linkedin.com/in/noobx/) for the newsletter subscriber-enumeration report.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "3.6.0"
+version = "3.7.0"
 description = "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more): HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/server.json
+++ b/server.json
@@ -6,19 +6,19 @@
     "url": "https://github.com/sipyourdrink-ltd/bernstein",
     "source": "github"
   },
-  "version": "3.6.0",
+  "version": "3.7.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "bernstein",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/sipyourdrink-ltd/bernstein:3.6.0",
+      "identifier": "ghcr.io/sipyourdrink-ltd/bernstein:3.7.0",
       "transport": {
         "type": "stdio"
       }

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
Release v3.7.0: version bump, uv.lock, distribution manifests (server.json, .plugin/plugin.json), and release notes. Assembles the features merged since v3.6.0. Remaining in-flight features moved to v3.8.0; a hardening sweep is tracked under v3.7.1.

## Summary by Sourcery

Release version 3.7.0 with updated distribution manifests and documentation for the new release.

New Features:
- Add distribution manifests for server and plugin packaging, aligning shipped artifacts with the 3.7.0 release.

Enhancements:
- Update project metadata and lockfile to reflect the 3.7.0 release state.

Documentation:
- Add v3.7.0 release notes documenting new capabilities, security hardening, and deployment changes.