### PR TITLE
chore(typos): allowlist COSE and in-toto receipt-export terms

### DIFF
--- a/typos.toml
+++ b/typos.toml
@@ -13,6 +13,10 @@ extend-ignore-re = [
 ]
 
 [default.extend-words]
+abd = "abd"          # hex/hash fixture fragment (test_computer_use_lineage)
+cose = "cose"        # COSE_Sign1 (RFC 9052) receipt-export term
+COSE = "COSE"        # COSE_Sign1 (RFC 9052) receipt-export term
+intoto = "intoto"    # in-toto attestation format identifier
 # Variable names and abbreviations in code
 ba = "ba"            # ba_table = Budget & Approval table (manifest_cmd.py)
 nd = "nd"            # nd = number of diffs (benchmarks/run_benchmark.py)


### PR DESCRIPTION
Green the advisory Spelling check on main: the v3.7.0 release notes reference COSE_Sign1 (RFC 9052) and in-toto, which typos flags. Allowlist the domain terms.

## Summary by Sourcery

Chores:
- Update typos configuration to recognize COSE_Sign1 and in-toto domain-specific terminology as valid words.