### PR TITLE
fix(adapters): declare computer_use in adapters-independent import contract

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -53,6 +53,7 @@ modules =
     bernstein.adapters.codex
     bernstein.adapters.cody
     bernstein.adapters.composio
+    bernstein.adapters.computer_use
     bernstein.adapters.continue_dev
     bernstein.adapters.copilot
     bernstein.adapters.cursor


### PR DESCRIPTION
Fixes red main (run 29583372693, shard 4 on 3.12 + 3.13): the computer-use adapter is registered but was absent from the `.importlinter` adapters-independent contract, so `test_importlinter_contracts` failed on `contracted_modules == _registered_adapter_modules()`. Adds the missing module. Test passes locally.

## Summary by Sourcery

Update importlinter configuration to include the computer_use adapter module in the adapters-independent contract so registered adapters match contracted modules.

Bug Fixes:
- Fix failing importlinter contract test by adding the missing computer_use adapter module to the adapters-independent contract.

Build:
- Adjust importlinter configuration to keep adapter registration in sync with contract definitions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal module validation settings to include computer-use adapters in independence checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->