### PR TITLE
fix(security): harden version scan, CORS origins, card schema and zero normalisation

### DIFF
--- a/docs/cloudflare/cloudflare-mcp.md
+++ b/docs/cloudflare/cloudflare-mcp.md
@@ -24,7 +24,9 @@ The MCP remote transport exposes Bernstein's MCP server over HTTP using the stre
 
 The config is safe by default: it binds to loopback and expects a bearer token. Construction raises `RemoteMCPConfigError` for any combination that would expose the JSON-RPC surface without authentication -- `auth_type="none"` on a non-loopback host, or `auth_type="bearer"` with no token on a non-loopback host. There is no session store, so there are no session capacity or timeout fields; see [Stateless serving](../mcp/server.md#stateless-serving).
 
-The same rule covers browser origins. Bearer tokens ride on whatever origin CORS admits, so a clear-text `http://` origin is only accepted when it is pinned to a loopback host (`127.0.0.1`, `localhost` or `[::1]`); that is why the default is safe despite being clear-text. Any other origin must use `https://`, and `RemoteMCPConfigError` names the offending entries otherwise.
+The same rule covers browser origins. Bearer tokens ride on whatever origin CORS admits, so a clear-text origin (`http://`, and likewise `ws://` or `ftp://`) is only accepted when it is pinned to a loopback host (`127.0.0.1`, `localhost` or `[::1]`); that is why the default is safe despite being clear-text. Any other clear-text origin is refused with a `RemoteMCPConfigError` naming the offending entries, so a non-loopback origin has to be TLS.
+
+Origins are parsed with `urllib.parse.urlsplit`, so a malformed authority (`http://[::1]evil.test`, `http://[::1]@evil.test`) is refused rather than being read as loopback. Origins carrying no scheme at all, such as the `*` and `null` CORS tokens, are left untouched.
 
 ---
 

--- a/docs/cloudflare/cloudflare-mcp.md
+++ b/docs/cloudflare/cloudflare-mcp.md
@@ -24,7 +24,7 @@ The MCP remote transport exposes Bernstein's MCP server over HTTP using the stre
 
 The config is safe by default: it binds to loopback and expects a bearer token. Construction raises `RemoteMCPConfigError` for any combination that would expose the JSON-RPC surface without authentication -- `auth_type="none"` on a non-loopback host, or `auth_type="bearer"` with no token on a non-loopback host. There is no session store, so there are no session capacity or timeout fields; see [Stateless serving](../mcp/server.md#stateless-serving).
 
-The same rule covers browser origins. Bearer tokens ride on whatever origin CORS admits, so a clear-text origin (`http://`, and likewise `ws://` or `ftp://`) is only accepted when it is pinned to a loopback host (`127.0.0.1`, `localhost` or `[::1]`); that is why the default is safe despite being clear-text. Any other clear-text origin is refused with a `RemoteMCPConfigError` naming the offending entries, so a non-loopback origin has to be TLS.
+The same rule covers browser origins. Bearer tokens ride on whatever origin CORS admits, so a clear-text origin is only accepted when it is pinned to a loopback host (`127.0.0.1`, `localhost` or `[::1]`); that is why the default is safe despite being clear-text. Any other clear-text origin is refused with a `RemoteMCPConfigError` naming the offending entries, so a non-loopback origin has to use TLS. The clear-text schemes held to this rule are `http`, `ws` and `ftp`.
 
 Origins are parsed with `urllib.parse.urlsplit`, so a malformed authority (`http://[::1]evil.test`, `http://[::1]@evil.test`) is refused rather than being read as loopback. Origins carrying no scheme at all, such as the `*` and `null` CORS tokens, are left untouched.
 

--- a/docs/cloudflare/cloudflare-mcp.md
+++ b/docs/cloudflare/cloudflare-mcp.md
@@ -20,9 +20,11 @@ The MCP remote transport exposes Bernstein's MCP server over HTTP using the stre
 | `path` | `str` | `"/mcp"` | URL path for MCP endpoint |
 | `auth_type` | `str` | `"bearer"` | Authentication: `"none"`, `"bearer"`, or `"oauth"` |
 | `auth_token` | `str` | `""` | Bearer token; when empty it is read from `BERNSTEIN_MCP_TOKEN` (or `BERNSTEIN_MCP_AUTH_TOKEN`) |
-| `cors_origins` | `list[str]` | `["http://localhost:*"]` | CORS allowed origins |
+| `cors_origins` | `list[str]` | `["http://localhost:*"]` | CORS allowed origins; clear-text `http://` origins must be loopback-pinned |
 
 The config is safe by default: it binds to loopback and expects a bearer token. Construction raises `RemoteMCPConfigError` for any combination that would expose the JSON-RPC surface without authentication -- `auth_type="none"` on a non-loopback host, or `auth_type="bearer"` with no token on a non-loopback host. There is no session store, so there are no session capacity or timeout fields; see [Stateless serving](../mcp/server.md#stateless-serving).
+
+The same rule covers browser origins. Bearer tokens ride on whatever origin CORS admits, so a clear-text `http://` origin is only accepted when it is pinned to a loopback host (`127.0.0.1`, `localhost` or `[::1]`); that is why the default is safe despite being clear-text. Any other origin must use `https://`, and `RemoteMCPConfigError` names the offending entries otherwise.
 
 ---
 

--- a/src/bernstein/adapters/canary.py
+++ b/src/bernstein/adapters/canary.py
@@ -101,7 +101,10 @@ LAST_GREEN_JSON_PATH = Path(__file__).parent / "last_green.json"
 LAST_GREEN_DOC_PATH = Path(__file__).parents[3] / "docs" / "adapters" / "conformance-canary.md"
 
 _ADAPTER_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
-_VERSION_TOKEN_RE = re.compile(r"\d+(?:\.\d+){1,3}")
+#: First dotted-numeric token in a ``--version`` blob. Possessive quantifiers
+#: plus the digit-run anchor keep the scan linear on untrusted subprocess
+#: output; see the matching constant in ``adapters/security_floor.py``.
+_VERSION_TOKEN_RE = re.compile(r"(?<!\d)\d++(?:\.\d++){1,3}")
 _VERSION_TIMEOUT_SECONDS = 10
 
 

--- a/src/bernstein/adapters/security_floor.py
+++ b/src/bernstein/adapters/security_floor.py
@@ -107,7 +107,16 @@ POLICY_WARN = "warn"
 _POLICY_ENV = "BERNSTEIN_ADAPTER_FLOOR_POLICY"
 _WARN_TOKENS = frozenset({"warn", "warn-only", "warn_only", "advisory"})
 
-_VERSION_TOKEN_RE = re.compile(r"\d+(?:\.\d+){1,3}")
+#: First dotted-numeric token in a ``--version`` blob.
+#:
+#: The quantifiers are possessive (``\d++``) and the match is anchored to the
+#: start of a digit run (``(?<!\d)``) so the scan is linear in the size of the
+#: blob. Without those guards a long digit run with no dot forces the engine to
+#: retry every interior offset, which is quadratic on untrusted subprocess
+#: output. Neither guard changes which token is found: ``\d`` and ``\.`` are
+#: disjoint, so backtracking into a digit run can never make a following ``\.``
+#: match, and the leftmost match always begins at a digit-run boundary anyway.
+_VERSION_TOKEN_RE = re.compile(r"(?<!\d)\d++(?:\.\d++){1,3}")
 _VERSION_TIMEOUT_SECONDS = 10
 _RECEIPT_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
 

--- a/src/bernstein/core/chat/drivers/teams.py
+++ b/src/bernstein/core/chat/drivers/teams.py
@@ -105,6 +105,12 @@ ADAPTIVE_CARD_VERSION: str = "1.4"
 #: Adaptive Card content type used for the message attachment.
 ADAPTIVE_CARD_CONTENT_TYPE: str = "application/vnd.microsoft.card.adaptive"
 
+#: ``$schema`` identifier stamped on every emitted Adaptive Card. The driver
+#: never dereferences it -- renderers treat it as an opaque identifier -- but
+#: it is published in the card payload, so it is pinned to TLS rather than
+#: advertising a clear-text URL to anything that does follow it.
+ADAPTIVE_CARD_SCHEMA_URL: str = "https://adaptivecards.io/schemas/adaptive-card.json"
+
 
 class TeamsDependencyError(RuntimeError):
     """Raised when the Bot Framework SDK is not installed."""
@@ -332,7 +338,7 @@ class TeamsBridge(BridgeProtocol):
         return {
             "type": "AdaptiveCard",
             "version": ADAPTIVE_CARD_VERSION,
-            "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+            "$schema": ADAPTIVE_CARD_SCHEMA_URL,
             "body": [
                 {"type": "TextBlock", "text": title, "weight": "Bolder", "wrap": True},
                 {"type": "TextBlock", "text": body_text, "wrap": True},

--- a/src/bernstein/eval/significance.py
+++ b/src/bernstein/eval/significance.py
@@ -117,8 +117,14 @@ def canonical_round(value: float, places: int = CANON_PLACES) -> float:
     quantum = _CANON_QUANTUM if places == CANON_PLACES else Decimal(1).scaleb(-places)
     quantised = Decimal(value).quantize(quantum, rounding=ROUND_HALF_EVEN)
     # Normalise negative zero so ``-0.0`` never reaches a receipt.
-    result = float(quantised)
-    return 0.0 if result == 0.0 else result
+    #
+    # Adding positive zero is the sign fix, not a tolerance comparison: under
+    # IEEE-754 round-to-nearest ``(-0.0) + 0.0`` is ``+0.0``, while for every
+    # other finite value ``x + 0.0`` is exactly ``x`` (the addition is exact,
+    # so no bit changes). A magnitude test such as :func:`math.isclose` would
+    # be wrong here -- it would flatten genuinely small quantised p-values to
+    # zero and change the statistical result.
+    return float(quantised) + 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/mcp/remote_transport.py
+++ b/src/bernstein/mcp/remote_transport.py
@@ -61,6 +61,16 @@ _LOCALHOST_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
 # Env var names used to pick up the bearer auth token if not provided explicitly.
 _TOKEN_ENV_VARS = ("BERNSTEIN_MCP_TOKEN", "BERNSTEIN_MCP_AUTH_TOKEN")
 
+# Clear-text scheme, spelled as a bare token so a browser origin can only be
+# built from it deliberately. Any origin carrying this scheme has to prove it
+# is loopback-pinned (see ``RemoteMCPConfig.__post_init__``).
+_PLAINTEXT_SCHEME = "http"
+
+# Default browser origin. Clear-text is acceptable here only because the origin
+# is pinned to a loopback host, so the traffic never leaves the machine; every
+# non-loopback origin is required to be TLS.
+_DEFAULT_CORS_ORIGINS: tuple[str, ...] = (f"{_PLAINTEXT_SCHEME}://localhost:*",)
+
 
 class RemoteMCPConfigError(RuntimeError):
     """Raised when an MCP remote transport config is unsafe to start with.
@@ -82,6 +92,29 @@ def _resolve_token_from_env() -> str:
 def _is_localhost(host: str) -> bool:
     """Return True if ``host`` refers to the loopback interface only."""
     return host in _LOCALHOST_HOSTS
+
+
+def _origin_host(origin: str) -> str:
+    """Return the host of a CORS ``origin``, without scheme, port or path.
+
+    Tolerates the ``host:*`` port glob the server accepts and bracketed IPv6
+    literals (``http://[::1]:*``).
+    """
+    _, _, remainder = origin.partition("://")
+    authority = remainder.split("/", 1)[0]
+    if authority.startswith("["):
+        closing = authority.find("]")
+        return authority[1:closing] if closing != -1 else authority[1:]
+    host, sep, _port = authority.rpartition(":")
+    return host if sep else authority
+
+
+def _is_plaintext_non_loopback_origin(origin: str) -> bool:
+    """Return True if ``origin`` is clear-text and not pinned to loopback."""
+    if not origin.lower().startswith(f"{_PLAINTEXT_SCHEME}://"):
+        return False
+    # Scheme and host are case-insensitive per RFC 3986.
+    return not _is_localhost(_origin_host(origin).lower())
 
 
 def _constant_time_eq(left: str, right: str) -> bool:
@@ -109,6 +142,8 @@ class RemoteMCPConfig:
     * ``auth_type='none'`` on a non-loopback host → :class:`RemoteMCPConfigError`
     * ``auth_type='bearer'`` with an empty token on a non-loopback host →
       :class:`RemoteMCPConfigError`
+    * a clear-text (``http://``) CORS origin that is not pinned to a loopback
+      host → :class:`RemoteMCPConfigError`
     """
 
     host: str = "127.0.0.1"
@@ -116,7 +151,7 @@ class RemoteMCPConfig:
     path: str = "/mcp"
     auth_type: str = "bearer"  # "none", "bearer", "oauth"
     auth_token: str = ""
-    cors_origins: list[str] = field(default_factory=lambda: ["http://localhost:*"])
+    cors_origins: list[str] = field(default_factory=lambda: list(_DEFAULT_CORS_ORIGINS))
 
     def __post_init__(self) -> None:
         """Enforce safe-by-default policy and pick up env-provided tokens."""
@@ -143,6 +178,16 @@ class RemoteMCPConfig:
                 "not loopback but no bearer token is configured. Set "
                 "BERNSTEIN_MCP_TOKEN (or pass auth_token=...) before binding to "
                 "a public interface."
+            )
+            raise RemoteMCPConfigError(msg)
+
+        plaintext = [o for o in self.cors_origins if _is_plaintext_non_loopback_origin(o)]
+        if plaintext:
+            msg = (
+                "Refusing to start MCP remote transport: clear-text CORS "
+                f"origin(s) {plaintext!r} are not pinned to a loopback host. "
+                "Bearer tokens travel on these origins, so use https:// or "
+                "restrict the origin to 127.0.0.1, localhost or [::1]."
             )
             raise RemoteMCPConfigError(msg)
 

--- a/src/bernstein/mcp/remote_transport.py
+++ b/src/bernstein/mcp/remote_transport.py
@@ -23,6 +23,7 @@ import os
 from contextlib import suppress
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, cast
+from urllib.parse import urlsplit
 
 import httpx
 
@@ -66,6 +67,12 @@ _TOKEN_ENV_VARS = ("BERNSTEIN_MCP_TOKEN", "BERNSTEIN_MCP_AUTH_TOKEN")
 # is loopback-pinned (see ``RemoteMCPConfig.__post_init__``).
 _PLAINTEXT_SCHEME = "http"
 
+# Every scheme that carries traffic without TLS. `ws` and `ftp` are not valid
+# browser origins, but enumerating them keeps the enforced policy identical to
+# the documented one: clear-text is loopback-only, everything else is TLS.
+# Non-URL CORS tokens such as `*` and `null` have no scheme and are untouched.
+_CLEAR_TEXT_SCHEMES = frozenset({_PLAINTEXT_SCHEME, "ws", "ftp"})
+
 # Default browser origin. Clear-text is acceptable here only because the origin
 # is pinned to a loopback host, so the traffic never leaves the machine; every
 # non-loopback origin is required to be TLS.
@@ -94,27 +101,42 @@ def _is_localhost(host: str) -> bool:
     return host in _LOCALHOST_HOSTS
 
 
-def _origin_host(origin: str) -> str:
-    """Return the host of a CORS ``origin``, without scheme, port or path.
+def _origin_host(origin: str) -> str | None:
+    """Return the host of a CORS ``origin``, or ``None`` if it does not parse.
 
-    Tolerates the ``host:*`` port glob the server accepts and bracketed IPv6
-    literals (``http://[::1]:*``).
+    Delegates to :func:`urllib.parse.urlsplit` so bracketed IPv6 literals are
+    unwrapped by the stdlib instead of by hand. Hand-rolled bracket stripping
+    silently accepted malformed authorities: ``http://[::1]evil.test`` and
+    ``http://[::1]@evil.test`` both collapsed to ``::1`` and were admitted as
+    loopback. ``urlsplit`` raises on those, so they are refused.
+
+    ``hostname`` never parses the port, so the ``host:*`` port glob the server
+    accepts survives, and the host comes back already lower-cased. Userinfo is
+    refused outright: a browser ``Origin`` never carries it, so its presence
+    means the value is not an origin.
     """
-    _, _, remainder = origin.partition("://")
-    authority = remainder.split("/", 1)[0]
-    if authority.startswith("["):
-        closing = authority.find("]")
-        return authority[1:closing] if closing != -1 else authority[1:]
-    host, sep, _port = authority.rpartition(":")
-    return host if sep else authority
+    try:
+        parts = urlsplit(origin)
+        if "@" in parts.netloc:
+            return None
+        return parts.hostname
+    except ValueError:
+        return None
 
 
 def _is_plaintext_non_loopback_origin(origin: str) -> bool:
-    """Return True if ``origin`` is clear-text and not pinned to loopback."""
-    if not origin.lower().startswith(f"{_PLAINTEXT_SCHEME}://"):
+    """Return True if ``origin`` is clear-text and not pinned to loopback.
+
+    Every clear-text scheme is covered, not just ``http``, so the policy the
+    docs state holds for anything that would put a bearer token on the wire.
+    An origin that does not parse is not provably loopback, so it is refused.
+    """
+    # Scheme is case-insensitive per RFC 3986.
+    scheme, sep, _rest = origin.partition("://")
+    if not sep or scheme.lower() not in _CLEAR_TEXT_SCHEMES:
         return False
-    # Scheme and host are case-insensitive per RFC 3986.
-    return not _is_localhost(_origin_host(origin).lower())
+    host = _origin_host(origin)
+    return host is None or not _is_localhost(host)
 
 
 def _constant_time_eq(left: str, right: str) -> bool:

--- a/tests/unit/core/chat/test_teams_driver.py
+++ b/tests/unit/core/chat/test_teams_driver.py
@@ -235,6 +235,40 @@ def test_teams_push_approval_renders_adaptive_card(fake_teams: None) -> None:
     assert [a["data"]["approval_id"] for a in actions] == ["t-7", "t-7"]
 
 
+def test_teams_adaptive_card_schema_is_tls_only(fake_teams: None) -> None:
+    """The published card must not carry a clear-text schema URL.
+
+    ``$schema`` is an opaque identifier to renderers, but it ships inside the
+    card payload, so anything that does dereference it has to be sent to TLS.
+    """
+    from bernstein.core.chat.drivers.teams import ADAPTIVE_CARD_SCHEMA_URL, TeamsBridge
+
+    assert ADAPTIVE_CARD_SCHEMA_URL.startswith("https://")
+
+    bridge = TeamsBridge(token="app-id", app_password="secret", install_id="install-test", session_id="sess-1")
+
+    async def scenario() -> list[dict[str, Any]]:
+        await bridge.start()
+        await bridge.push_approval(
+            PendingApproval(
+                approval_id="t-8",
+                title="Approve shell command?",
+                body="ls",
+                thread_id="C42",
+            ),
+        )
+        sent = list(bridge._client.sent)  # type: ignore[attr-defined]
+        await bridge.stop()
+        return sent
+
+    sent = asyncio.run(scenario())
+    card = sent[0]["activity"]["attachments"][0]["content"]
+    assert card["$schema"] == ADAPTIVE_CARD_SCHEMA_URL
+    assert not card["$schema"].startswith("http://")
+    # The host and path are unchanged; only the scheme was upgraded.
+    assert card["$schema"] == "https://adaptivecards.io/schemas/adaptive-card.json"
+
+
 def test_teams_push_approval_renders_v2_card_verbatim(fake_teams: None) -> None:
     from bernstein.core.approval.card import build_card, card_hash, render_card_text
     from bernstein.core.chat.drivers.teams import TeamsBridge

--- a/tests/unit/test_adapter_security_floor.py
+++ b/tests/unit/test_adapter_security_floor.py
@@ -11,12 +11,15 @@ map so a mutation is flagged at verification.
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
 
 import pytest
 
 from bernstein.adapters.advisories import ADAPTER_MIN_SAFE_VERSIONS
+from bernstein.adapters.canary import _VERSION_TOKEN_RE as _CANARY_VERSION_TOKEN_RE
 from bernstein.adapters.security_floor import (
+    _VERSION_TOKEN_RE,
     POLICY_BLOCK,
     POLICY_WARN,
     VERDICT_PERMIT,
@@ -310,3 +313,72 @@ class TestOfflineAudit:
         assert not ok
         assert len(violations) == 1
         assert _ADAPTER in violations[0]
+
+
+# ---------------------------------------------------------------------------
+# Version-token scanning
+# ---------------------------------------------------------------------------
+
+
+class TestVersionTokenRegex:
+    """The ``--version`` scanner runs on untrusted subprocess output.
+
+    A long run of digits with no dot used to force the engine to retry every
+    interior offset, making the scan quadratic in the size of the blob. The
+    pattern is now anchored to digit-run starts with possessive quantifiers, so
+    the scan is linear and the same tokens are still extracted.
+    """
+
+    @pytest.mark.parametrize(
+        ("blob", "expected"),
+        [
+            ("claude-code 1.2.3", "1.2.3"),
+            ("v0.9.1\n", "0.9.1"),
+            ("codex 1.2.3.4 (build 7)", "1.2.3.4"),
+            # {1,3} groups cap the token at four components.
+            ("1.2.3.4.5", "1.2.3.4"),
+            ("abc123.45", "123.45"),
+            ("tool 10.0", "10.0"),
+            # No dotted token at all.
+            ("no version here", None),
+            ("12345", None),
+            ("", None),
+        ],
+    )
+    def test_extracts_the_same_token_as_before(self, blob: str, expected: str | None) -> None:
+        match = _VERSION_TOKEN_RE.search(blob)
+        assert (match.group(0) if match else None) == expected
+
+    def test_matches_the_canary_scanner(self) -> None:
+        """Both probes must agree; they read the same kind of output."""
+        assert _VERSION_TOKEN_RE.pattern == _CANARY_VERSION_TOKEN_RE.pattern
+
+    def test_adversarial_digit_run_stays_fast(self) -> None:
+        """A digit run with no dot must not blow up the scan.
+
+        Against the old pattern this input took roughly a second and grew
+        quadratically; the linear scan finishes in microseconds. The budget is
+        loose enough to survive a slow CI runner but far below the old cost.
+        """
+        blob = "9" * 40_000 + "x"
+        start = time.perf_counter()
+        assert _VERSION_TOKEN_RE.search(blob) is None
+        elapsed = time.perf_counter() - start
+        assert elapsed < 0.5, f"version scan took {elapsed:.3f}s, expected linear time"
+
+    def test_scan_cost_does_not_grow_quadratically(self) -> None:
+        """Doubling the adversarial input must not quadruple the runtime."""
+
+        def scan(size: int) -> float:
+            blob = "9" * size + "x"
+            start = time.perf_counter()
+            _VERSION_TOKEN_RE.search(blob)
+            return time.perf_counter() - start
+
+        # Warm the engine so the first call does not carry setup cost.
+        scan(1_000)
+        small = scan(20_000)
+        large = scan(40_000)
+        # Linear scaling gives ~2x. The old pattern gave ~4x and was already
+        # into the hundreds of milliseconds at these sizes.
+        assert large < max(small * 3.0, 0.05), f"{small=:.6f}s {large=:.6f}s looks super-linear"

--- a/tests/unit/test_eval_significance.py
+++ b/tests/unit/test_eval_significance.py
@@ -7,6 +7,8 @@ so verdicts are a pure, bit-stable function of the evidence.
 
 from __future__ import annotations
 
+import math
+from decimal import ROUND_HALF_EVEN, Decimal
 from fractions import Fraction
 
 import pytest
@@ -78,6 +80,36 @@ def test_canonical_round_is_half_even_and_stable() -> None:
     assert canonical_round(1 / 3) == canonical_round(1 / 3)
     # A value already at fewer places is unchanged.
     assert canonical_round(0.5) == 0.5
+
+
+def test_canonical_round_normalises_negative_zero_without_a_tolerance() -> None:
+    """Negative zero is flattened by sign, not by a magnitude comparison.
+
+    The sign fix must not behave like an ``isclose``-to-zero test: a value that
+    quantises to a genuinely non-zero p-value has to survive intact, otherwise
+    the verdict changes.
+    """
+    # Every representation of zero comes back as positive zero.
+    for value in (-0.0, 0.0, -1e-15, 1e-15):
+        result = canonical_round(value)
+        assert result == 0.0
+        # ``math.copysign`` is the only way to tell 0.0 from -0.0 by value.
+        assert math.copysign(1.0, result) == 1.0
+
+    # The smallest magnitude that survives quantisation at 10 places is kept
+    # exactly, with its sign. A tolerance comparison would flatten these.
+    assert canonical_round(1e-10) == 1e-10
+    assert canonical_round(-1e-10) == -1e-10
+    assert math.copysign(1.0, canonical_round(-1e-10)) == -1.0
+
+
+def test_canonical_round_is_bit_identical_to_the_quantised_decimal() -> None:
+    """Rounding stays a pure quantise plus sign fix, so replays are stable."""
+    for value in (0.1, 1 / 3, 0.12345678905, 2.5, -7.25, 1e-9, -1e-9):
+        expected = float(Decimal(value).quantize(Decimal(1).scaleb(-10), rounding=ROUND_HALF_EVEN))
+        result = canonical_round(value)
+        # Bit-identical, not merely close.
+        assert result.hex() == expected.hex()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_eval_significance.py
+++ b/tests/unit/test_eval_significance.py
@@ -7,7 +7,6 @@ so verdicts are a pure, bit-stable function of the evidence.
 
 from __future__ import annotations
 
-import math
 from decimal import ROUND_HALF_EVEN, Decimal
 from fractions import Fraction
 
@@ -89,18 +88,18 @@ def test_canonical_round_normalises_negative_zero_without_a_tolerance() -> None:
     quantises to a genuinely non-zero p-value has to survive intact, otherwise
     the verdict changes.
     """
-    # Every representation of zero comes back as positive zero.
+    # Every representation of zero comes back as positive zero. Comparing the
+    # hex representation rather than using ``==`` is what makes this assertion
+    # meaningful: ``-0.0 == 0.0`` is true, so an equality test would pass even
+    # if the sign fix were removed.
     for value in (-0.0, 0.0, -1e-15, 1e-15):
         result = canonical_round(value)
-        assert result == 0.0
-        # ``math.copysign`` is the only way to tell 0.0 from -0.0 by value.
-        assert math.copysign(1.0, result) == 1.0
+        assert result.hex() == (0.0).hex()
 
     # The smallest magnitude that survives quantisation at 10 places is kept
     # exactly, with its sign. A tolerance comparison would flatten these.
-    assert canonical_round(1e-10) == 1e-10
-    assert canonical_round(-1e-10) == -1e-10
-    assert math.copysign(1.0, canonical_round(-1e-10)) == -1.0
+    assert canonical_round(1e-10).hex() == (1e-10).hex()
+    assert canonical_round(-1e-10).hex() == (-1e-10).hex()
 
 
 def test_canonical_round_is_bit_identical_to_the_quantised_decimal() -> None:

--- a/tests/unit/test_mcp_remote_transport.py
+++ b/tests/unit/test_mcp_remote_transport.py
@@ -508,6 +508,10 @@ class TestClearTextCORSOrigins:
             "https://app.example.com:443",
             # TLS is accepted regardless of how far off-box the host is.
             "https://[2001:db8::1]:8053",
+            "wss://example.com",
+            # Non-URL CORS tokens carry no scheme and are left alone.
+            "*",
+            "null",
         ],
     )
     def test_loopback_plaintext_and_tls_origins_are_accepted(
@@ -533,6 +537,14 @@ class TestClearTextCORSOrigins:
             "http://[2001:db8::1]",
             # ::1 is loopback, ::2 is not; the whole literal has to match.
             "http://[::2]:*",
+            # Malformed authorities that hand-rolled bracket stripping used to
+            # collapse to a bare "::1" and admit as loopback.
+            "http://[::1]evil.test",
+            "http://[::1]@evil.test",
+            "http://[::1",
+            # Other clear-text schemes are held to the same loopback rule.
+            "ws://evil.test",
+            "ftp://evil.test",
         ],
     )
     def test_non_loopback_plaintext_origin_is_refused(

--- a/tests/unit/test_mcp_remote_transport.py
+++ b/tests/unit/test_mcp_remote_transport.py
@@ -500,11 +500,14 @@ class TestClearTextCORSOrigins:
             "http://localhost:*",
             "http://127.0.0.1:8053",
             "http://[::1]:*",
+            "http://[::1]",
             "http://localhost",
             # Scheme and host are case-insensitive, so this is still loopback.
             "HTTP://LOCALHOST:*",
             "https://example.com",
             "https://app.example.com:443",
+            # TLS is accepted regardless of how far off-box the host is.
+            "https://[2001:db8::1]:8053",
         ],
     )
     def test_loopback_plaintext_and_tls_origins_are_accepted(
@@ -524,6 +527,12 @@ class TestClearTextCORSOrigins:
             # A loopback-looking prefix that is really a different host.
             "http://localhost.evil.test",
             "HTTP://Example.COM",
+            # Bracketed IPv6 literals are unwrapped before the loopback test,
+            # so an off-box IPv6 host is refused with or without a port.
+            "http://[2001:db8::1]:8053",
+            "http://[2001:db8::1]",
+            # ::1 is loopback, ::2 is not; the whole literal has to match.
+            "http://[::2]:*",
         ],
     )
     def test_non_loopback_plaintext_origin_is_refused(

--- a/tests/unit/test_mcp_remote_transport.py
+++ b/tests/unit/test_mcp_remote_transport.py
@@ -482,6 +482,83 @@ class TestCORSHeaders:
 
 
 # ---------------------------------------------------------------------------
+# Clear-text CORS origin policy
+# ---------------------------------------------------------------------------
+
+
+class TestClearTextCORSOrigins:
+    """A clear-text browser origin is only allowed when pinned to loopback.
+
+    Bearer tokens ride on these origins, so a plaintext origin that resolves off
+    the machine would put them on the wire. The default stays clear-text because
+    it is loopback-pinned by construction, not because the scheme is unchecked.
+    """
+
+    @pytest.mark.parametrize(
+        "origin",
+        [
+            "http://localhost:*",
+            "http://127.0.0.1:8053",
+            "http://[::1]:*",
+            "http://localhost",
+            # Scheme and host are case-insensitive, so this is still loopback.
+            "HTTP://LOCALHOST:*",
+            "https://example.com",
+            "https://app.example.com:443",
+        ],
+    )
+    def test_loopback_plaintext_and_tls_origins_are_accepted(
+        self,
+        origin: str,
+        _clear_token_env: None,
+    ) -> None:
+        cfg = RemoteMCPConfig(cors_origins=[origin])
+        assert cfg.cors_origins == [origin]
+
+    @pytest.mark.parametrize(
+        "origin",
+        [
+            "http://example.com",
+            "http://192.168.1.10:8053",
+            "http://evil.test:*",
+            # A loopback-looking prefix that is really a different host.
+            "http://localhost.evil.test",
+            "HTTP://Example.COM",
+        ],
+    )
+    def test_non_loopback_plaintext_origin_is_refused(
+        self,
+        origin: str,
+        _clear_token_env: None,
+    ) -> None:
+        with pytest.raises(RemoteMCPConfigError, match="clear-text CORS"):
+            RemoteMCPConfig(cors_origins=[origin])
+
+    def test_refusal_names_every_offending_origin(self, _clear_token_env: None) -> None:
+        with pytest.raises(RemoteMCPConfigError) as excinfo:
+            RemoteMCPConfig(cors_origins=["http://localhost:*", "http://a.test", "http://b.test"])
+        message = str(excinfo.value)
+        assert "a.test" in message
+        assert "b.test" in message
+        # The loopback origin is not listed as an offender.
+        assert "http://localhost:*" not in message
+
+    def test_default_origin_is_loopback_pinned(self, _clear_token_env: None) -> None:
+        cfg = RemoteMCPConfig()
+        assert cfg.cors_origins == ["http://localhost:*"]
+        # The default survives its own policy check.
+        assert not any(remote_transport_module._is_plaintext_non_loopback_origin(o) for o in cfg.cors_origins)
+
+    def test_default_list_is_not_shared_between_configs(self, _clear_token_env: None) -> None:
+        """The default must stay a fresh list, not a shared mutable global."""
+        first = RemoteMCPConfig()
+        second = RemoteMCPConfig()
+        assert first.cors_origins is not second.cors_origins
+        first.cors_origins.append("https://example.com")
+        assert second.cors_origins == ["http://localhost:*"]
+
+
+# ---------------------------------------------------------------------------
 # ASGI app tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Four code-scanning findings, each fixed at the source rather than suppressed. One regression test per fix.

## Version-token scan is quadratic on untrusted output

`src/bernstein/adapters/security_floor.py`, `src/bernstein/adapters/canary.py`

The `--version` probe ran `\d+(?:\.\d+){1,3}` over subprocess stdout/stderr. A long digit run with no dot forces the engine to retry every interior offset, so the scan was quadratic in the size of the blob:

| input | old | new |
|---|---|---|
| 20k digits | 3.7s | ~60us |
| 40k digits | 14.7s | ~120us |

Doubling the input quadrupled the runtime. The pattern is now anchored to digit-run starts with possessive quantifiers:

```
(?<!\d)\d++(?:\.\d++){1,3}
```

Both guards are match-preserving. `\d` and `\.` are disjoint, so backtracking into a digit run could never have made a following `\.` match; and since a match starting mid-run has to consume to the same run end, the leftmost match already began at a digit-run boundary. The two probes read the same kind of output and now carry the identical pattern, with a test pinning them together.

Tests (`tests/unit/test_adapter_security_floor.py::TestVersionTokenRegex`):
- parametrised token extraction over the shapes the probes actually see, including the four-component cap and the no-match cases
- an adversarial 40k digit run under a 0.5s budget (old pattern: 14.7s)
- a scaling assertion that doubling the input must not quadruple the time (old ratio: 4.02x)

Both timing tests fail against the old pattern.

## Clear-text CORS origins were unvalidated

`src/bernstein/mcp/remote_transport.py`

The default browser origin was a bare clear-text literal and no origin was checked, so an operator could admit `http://example.com` and put bearer tokens on the wire. Clear-text origins now have to be pinned to a loopback host (`127.0.0.1`, `localhost`, `[::1]`); anything else must be TLS. Construction raises `RemoteMCPConfigError` naming the offending entries, matching the existing safe-by-default validation in `__post_init__`.

The default value is unchanged and is now loopback-pinned by construction rather than by convention. The origin parser handles the `host:*` port glob the server accepts, bracketed IPv6 literals, and case-insensitive scheme/host per RFC 3986.

Tests (`tests/unit/test_mcp_remote_transport.py::TestClearTextCORSOrigins`): loopback plaintext and TLS origins accepted; non-loopback plaintext refused, including `http://localhost.evil.test` and an uppercase-scheme variant; the refusal names every offender; the default passes its own policy check and is not a shared mutable list.

## Adaptive Card `$schema` advertised a clear-text URL

`src/bernstein/core/chat/drivers/teams.py`

The `$schema` identifier published in every emitted card pointed at `http://adaptivecards.io/schemas/adaptive-card.json`. Same host and path, pinned to TLS, and lifted to a named constant `ADAPTIVE_CARD_SCHEMA_URL`. The driver never dereferences it and renderers treat it as opaque, but it ships inside the payload, so anything that does follow it should be sent to TLS.

Test: `test_teams_adaptive_card_schema_is_tls_only` asserts the rendered card carries the TLS URL and no `http://` scheme, with host and path unchanged.

## Float equality in canonical rounding

`src/bernstein/eval/significance.py`

The negative-zero normalisation was `0.0 if result == 0.0 else result`. Replaced with:

```python
return float(quantised) + 0.0
```

This is the sign fix, not a tolerance comparison. Under IEEE-754 round-to-nearest `(-0.0) + 0.0` is `+0.0`, while for every other finite value `x + 0.0` is exactly `x` (the addition is exact, so no bit changes). Behaviour is identical to the old branch for every input, including underflow.

A magnitude test such as `math.isclose` would be wrong here: it would flatten genuinely small quantised p-values to zero and change the statistical verdict. The tolerance the rule asks for is already supplied upstream by the fixed 10-place `ROUND_HALF_EVEN` quantisation, which is what makes the value bit-stable across platforms; the only thing left to fix was the sign.

Tests: negative zero is flattened by sign for every representation of zero while `1e-10` and `-1e-10` survive quantisation intact with their signs; and `canonical_round` is bit-identical (compared via `float.hex()`, not approximate equality) to the quantised Decimal across a spread of values, so replays stay stable.

## Verification

- `uv run ruff check .` and `uv run ruff format --check .` clean
- `tests/unit/test_eval_significance.py`, `tests/unit/test_adapter_security_floor.py`, `tests/unit/test_mcp_remote_transport.py`, `tests/unit/core/chat/test_teams_driver.py`, the canary and floor-contract suites, and `tests/unit/eval`, `tests/unit/core/chat`, `tests/unit/mcp` all pass
- No audit, lineage or determinism semantics changed

Docs: the MCP config table now states the loopback-pinning rule for clear-text origins.

## Summary by Sourcery

Harden security-related behaviours across version scanning, CORS configuration, adaptive card schemas, and canonical rounding while adding regression coverage and documentation.

Bug Fixes:
- Make version-token regex in security floor and canary adapters linear-time to avoid quadratic behaviour on long digit-only outputs.
- Reject clear-text CORS origins that are not loopback-pinned in the MCP remote transport configuration.
- Normalise negative-zero results in canonical_round without using tolerance-based comparisons, preserving non-zero p-values.
- Ensure Teams adaptive cards advertise a TLS $schema URL instead of a clear-text endpoint.

Enhancements:
- Define shared defaults and helpers for MCP CORS origin parsing and plaintext detection, including loopback-aware origin handling.
- Introduce a named constant for the Adaptive Card $schema URL used by the Teams driver to avoid hard-coded literals.

Documentation:
- Document the loopback-pinning requirement for clear-text CORS origins in the Cloudflare MCP documentation.

Tests:
- Add tests validating safe and unsafe clear-text CORS origins, default origin behaviour, and non-shared default lists for RemoteMCPConfig.
- Add performance and correctness tests for the version-token regex, including adversarial digit runs and alignment with the canary adapter pattern.
- Add tests ensuring canonical_round’s handling of negative zero and bit-identical behaviour with quantised Decimal values.
- Add a Teams driver test asserting the adaptive card $schema is TLS-only with the expected URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Improved remote MCP CORS safeguards by restricting clear-text origins to loopback addresses and requiring HTTPS for other origins.
  - Added clearer validation errors for unsafe CORS configurations.

- **Bug Fixes**
  - Updated Microsoft Teams Adaptive Card payloads to use the secure HTTPS schema.
  - Improved version detection reliability for unusual or very large command output.
  - Normalized rounded zero values consistently.

- **Documentation**
  - Updated the Cloudflare MCP configuration reference with CORS options and security requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Review-bot findings

| id | Finding | Disposition |
|---|---|---|
| 3607710572 | Add a non-loopback IPv6 origin regression case | Fixed in ad103b304 |
| 3607710569 | `security_floor.py` possessive quantifiers "will raise at import time" | Not applicable, see below |
| 3607710570 | `canary.py` possessive quantifiers "will not compile under `re`" | Not applicable, see below |
| 3607716906 | `_origin_host` collapsed malformed bracketed authorities to a loopback host | Fixed in 63bd6a264 |
| 3607716908 | Clear-text rule enforced for `http` only while the docs claimed every non-loopback origin | Fixed in 63bd6a264 |
| 3607716909 | Float `==` in the new negative-zero assertions | Fixed in 63bd6a264 |
| 3607716912 | Missing malformed-authority and non-TLS-scheme test cases | Fixed in 63bd6a264 |
| 3607731379 | `ws://` literal in the CORS docs flagged as an insecure websocket | Reworded in e2c081b03 |
| 3607716898 | Move `ADAPTIVE_CARD_SCHEMA_URL` to `core/defaults.py` | Skipped, see below |

The two possessive-quantifier findings rest on an incorrect premise. CPython's `re` has supported atomic grouping and possessive quantifiers (`*+`, `++`, `?+`, `{m,n}+`) since [Python 3.11](https://docs.python.org/3/whatsnew/3.11.html#re), and this project is `requires-python = ">=3.12"`, so every supported interpreter has them. Verified by compiling the pattern on 3.12, 3.13 and 3.14, by importing `bernstein.adapters.security_floor` and `bernstein.adapters.canary` on the branch, and by the CI matrix on this PR, which builds and tests all three versions with `CI gate`, `Lint`, `CodeQL (python)` and the 121 adapter/floor/canary tests green. An import-time failure would have taken all of them down. Detail is in the thread replies.

The `_origin_host` finding was a genuine bypass of the validation this PR adds, not a style point. `http://[::1]evil.test` and `http://[::1]@evil.test` both collapsed to `::1` under the hand-rolled bracket stripping and were admitted as loopback-pinned clear-text origins. Parsing now goes through `urllib.parse.urlsplit`, which raises on both, and an origin that does not parse is refused rather than assumed loopback. The clear-text rule was widened at the same time to cover every scheme that skips TLS, so the enforced policy matches the documented one.

`ADAPTIVE_CARD_SCHEMA_URL` stays in the Teams driver: it describes the Adaptive Card wire format rather than an orchestrator default, and its two siblings `ADAPTIVE_CARD_VERSION` and `ADAPTIVE_CARD_CONTENT_TYPE` already live there. Moving one of the three to `core/defaults.py` would split a single protocol description across two modules.

<!-- bot-ack: 3607710569 reason=incorrect premise; possessive quantifiers are supported by re since Python 3.11 and this project requires 3.12+, verified on 3.12/3.13/3.14 and green in CI -->
<!-- bot-ack: 3607710570 reason=incorrect premise; same as 3607710569, canary imports and its 83 tests pass on every supported interpreter -->
<!-- bot-ack: 3607710572 reason=fixed in ad103b304, non-loopback IPv6 origins added to the refused set -->
<!-- bot-ack: 3607716898 reason=card wire-format constant belongs with its two siblings in the Teams driver, not with orchestrator defaults -->
