### PR TITLE
fix(security): harden path containment in the work ledger and replay journal

### DIFF
--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -1699,8 +1699,14 @@ def _replay_find_run_dirs(runs_dir: Path) -> list[Path]:
     """Return sorted list of run directories that contain replay logs."""
     if not runs_dir.exists():
         return []
+    from bernstein.core.replay.journal import contained_run_journal
+
+    def _has_journal(d: Path) -> bool:
+        journal = contained_run_journal(runs_dir, d.name, _REPLAY_JSONL)
+        return journal is not None and journal.exists()
+
     return sorted(
-        (d for d in runs_dir.iterdir() if d.is_dir() and (d / _REPLAY_JSONL).exists()),
+        (d for d in runs_dir.iterdir() if d.is_dir() and _has_journal(d)),
         key=lambda d: d.name,
         reverse=True,
     )
@@ -1724,8 +1730,12 @@ def _replay_list_runs(runs_dir: Path) -> None:
     table.add_column("SHA")
     table.add_column("Events", justify="right")
     table.add_column("Size", justify="right")
+    from bernstein.core.replay.journal import contained_run_journal
+
     for d in run_dirs:
-        replay_file = d / _REPLAY_JSONL
+        replay_file = contained_run_journal(runs_dir, d.name, _REPLAY_JSONL)
+        if replay_file is None:
+            continue
         event_count = sum(1 for line in replay_file.read_text().splitlines() if line.strip())
         size_kb = replay_file.stat().st_size / 1024
         metadata = read_session_replay_metadata(d)

--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -1443,9 +1443,9 @@ _OTEL_PROJECTION_SUFFIX = ".otel.json"
 
 
 def _journal_path_for_run(root: Path, run_id: str) -> Path:
-    from bernstein.core.replay.journal import JOURNAL_FILENAME
+    from bernstein.core.replay.journal import run_journal_path
 
-    return root / ".sdd" / "runs" / run_id / JOURNAL_FILENAME
+    return run_journal_path(root / ".sdd", run_id)
 
 
 def _projection_dest(root: Path, run_id: str) -> Path:
@@ -1752,8 +1752,19 @@ def _replay_resolve_latest(runs_dir: Path) -> str:
 
 
 def _should_use_run_replay(run_id: str, runs_dir: Path) -> bool:
-    """Return whether replay should use the legacy run-event mode."""
-    return run_id in {"list", "latest"} or (runs_dir / run_id / _REPLAY_JSONL).exists()
+    """Return whether replay should use the legacy run-event mode.
+
+    A run id that escapes ``runs_dir`` is reported as absent rather than
+    probed, so the traversal never reaches the filesystem.
+    """
+    from bernstein.core.security.path_containment import PathContainmentError, contained_path
+
+    if run_id in {"list", "latest"}:
+        return True
+    try:
+        return contained_path(runs_dir, run_id, _REPLAY_JSONL, label="run id").exists()
+    except PathContainmentError:
+        return False
 
 
 def _wait_for_replay_completion(
@@ -1839,7 +1850,7 @@ def _replay_run_impl(
     if run_id == "latest":
         run_id = _replay_resolve_latest(runs_dir)
 
-    replay_path = runs_dir / run_id / _REPLAY_JSONL
+    replay_path = _resolve_journal_path(run_id, runs_dir)
     if not replay_path.exists():
         console.print(f"[red]Replay log not found:[/red] {replay_path}")
         console.print("[dim]Use 'bernstein replay list' to see available runs.[/dim]")
@@ -1948,10 +1959,15 @@ def _replay_run_impl(
 
 
 def _resolve_journal_path(run_id: str, runs_dir: Path) -> Path:
-    """Resolve a run id (or ``latest``) to its canonical journal path."""
+    """Resolve a run id (or ``latest``) to its canonical journal path.
+
+    Contained under ``runs_dir``: the id reaches here straight from argv.
+    """
+    from bernstein.core.security.path_containment import contained_path
+
     if run_id == "latest":
         run_id = _replay_resolve_latest(runs_dir)
-    return runs_dir / run_id / _REPLAY_JSONL
+    return contained_path(runs_dir, run_id, _REPLAY_JSONL, label="run id")
 
 
 def _replay_verify_journal(*, run_id: str, sdd_dir: str, as_json: bool) -> None:

--- a/src/bernstein/cli/commands/replay_filter_cmd.py
+++ b/src/bernstein/cli/commands/replay_filter_cmd.py
@@ -132,6 +132,20 @@ def _replay_filter_find_run_dirs(runs_dir: Path, replay_jsonl: str) -> list[Path
     )
 
 
+def _run_journal_exists(runs_dir: Path, run_id: str, filename: str) -> bool:
+    """Return whether a *contained* run journal exists for ``run_id``.
+
+    A run id that escapes ``runs_dir`` is reported as absent rather than
+    probed, so the traversal never reaches the filesystem.
+    """
+    from bernstein.core.security.path_containment import PathContainmentError, contained_path
+
+    try:
+        return contained_path(runs_dir, run_id, filename, label="run id").exists()
+    except PathContainmentError:
+        return False
+
+
 def _replay_filter_list_runs(runs_dir: Path, replay_jsonl: str) -> None:
     """List available replay runs."""
     run_dirs = _replay_filter_find_run_dirs(runs_dir, replay_jsonl)
@@ -202,6 +216,7 @@ def replay_filter_cmd(
       bernstein replay latest --limit 20 --event-type task_completed
     """
 
+    from bernstein.core.security.path_containment import contained_path
     from bernstein.core.traces import TraceStore, build_replay_task_request
 
     sdd_path = Path(sdd_dir)
@@ -211,7 +226,7 @@ def replay_filter_cmd(
     _REPLAY_JSONL = "journal.jsonl"
 
     has_filters = any([filter_str, event_type, agent, search])
-    is_run_replay = run_id in {"list", "latest"} or (runs_dir / run_id / _REPLAY_JSONL).exists()
+    is_run_replay = run_id in {"list", "latest"} or _run_journal_exists(runs_dir, run_id, _REPLAY_JSONL)
     is_task_trace = not is_run_replay and not has_filters
 
     if is_task_trace:
@@ -225,7 +240,7 @@ def replay_filter_cmd(
     if run_id == "latest":
         run_id = _replay_filter_resolve_latest(runs_dir, _REPLAY_JSONL)
 
-    replay_path = runs_dir / run_id / _REPLAY_JSONL
+    replay_path = contained_path(runs_dir, run_id, _REPLAY_JSONL, label="run id")
     if not replay_path.exists():
         console.print(f"[red]Replay log not found:[/red] {replay_path}")
         raise SystemExit(1)

--- a/src/bernstein/cli/commands/thread_cmd.py
+++ b/src/bernstein/cli/commands/thread_cmd.py
@@ -16,7 +16,7 @@ from pathlib import Path
 import click
 
 from bernstein.cli.helpers import console
-from bernstein.core.replay.journal import JOURNAL_FILENAME
+from bernstein.core.replay.journal import JournalPathError, run_journal_path
 from bernstein.core.replay.thread_projection import verify_thread_against_journal
 
 
@@ -32,7 +32,17 @@ def thread_verify(*, run_id: str, sdd_dir: Path, as_json: bool) -> int:
         ``0`` when the projected thread equals the journal, ``1`` on a
         divergence, ``2`` when the run journal is missing.
     """
-    journal_path = sdd_dir / "runs" / run_id / JOURNAL_FILENAME
+    try:
+        journal_path = run_journal_path(sdd_dir, run_id)
+    except JournalPathError as exc:
+        # This command's whole purpose is proving the streamed thread equals
+        # the executed journal, so it must never report a pass on a journal
+        # that is not ours. Treated as the documented missing-journal case.
+        if as_json:
+            console.print_json(json.dumps({"ok": False, "run_id": run_id, "error": f"invalid run id: {exc}"}))
+        else:
+            console.print(f"[red]Invalid run id[/red] {run_id}: {exc}")
+        return 2
     if not journal_path.exists():
         if as_json:
             console.print_json(json.dumps({"ok": False, "run_id": run_id, "error": "run journal not found"}))

--- a/src/bernstein/core/admission/ledger.py
+++ b/src/bernstein/core/admission/ledger.py
@@ -24,6 +24,7 @@ from bernstein.core.persistence.work_ledger import (
     LedgerReader,
     WorkLedger,
 )
+from bernstein.core.security.path_containment import contained_path
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -87,8 +88,18 @@ ADMISSION_KINDS: frozenset[str] = frozenset(
 
 
 def admission_ledger_dir(sdd_dir: Path, ledger_id: str = DEFAULT_ADMISSION_ID) -> Path:
-    """Return the on-disk directory backing an admission ledger."""
-    return sdd_dir / "runtime" / "admission" / ledger_id
+    """Return the on-disk directory backing an admission ledger.
+
+    ``ledger_id`` names a directory, so it goes through the containment
+    barrier: it must be a single safe path segment and the resolved
+    directory must stay under the admission root. Callers build their
+    reader or writer from the returned (checked) path.
+
+    Raises:
+        PathContainmentError: ``ledger_id`` is not a safe path segment, or
+            the resolved directory escapes the admission root.
+    """
+    return contained_path(sdd_dir / "runtime" / "admission", ledger_id, label="admission ledger id")
 
 
 def open_admission_ledger(sdd_dir: Path, ledger_id: str = DEFAULT_ADMISSION_ID) -> WorkLedger:

--- a/src/bernstein/core/agents/context_capsule.py
+++ b/src/bernstein/core/agents/context_capsule.py
@@ -434,7 +434,12 @@ def verify_context_capsule(
     ``ok`` is True only when every check holds. A verifier holding only the
     journal, the chain, and the capsule record can run this end to end.
     """
-    from bernstein.core.replay.journal import load_events, verify_journal
+    from bernstein.core.replay.journal import (
+        JournalPathError,
+        load_events,
+        run_journal_path,
+        verify_journal,
+    )
     from bernstein.core.security.audit_chain import EVENT_CONTEXT_CAPSULE
 
     signed = read_capsule_record(sdd_dir, task_id)
@@ -483,7 +488,16 @@ def verify_context_capsule(
             capsule=capsule,
         )
 
-    journal_path = sdd_dir / "runs" / capsule.run_id / "journal.jsonl"
+    try:
+        journal_path = run_journal_path(sdd_dir, capsule.run_id)
+    except JournalPathError as exc:
+        return ContextVerifyResult(
+            ok=False,
+            reason=f"invalid run id: {exc}",
+            signature_ok=True,
+            chain_ok=True,
+            capsule=capsule,
+        )
     if not journal_path.exists():
         return ContextVerifyResult(
             ok=False,

--- a/src/bernstein/core/evidence/run_artifacts.py
+++ b/src/bernstein/core/evidence/run_artifacts.py
@@ -551,7 +551,7 @@ def _verify_one_artifact(
 
 def verify_all_run_artifacts(workdir: Path, *, hmac_key: bytes) -> list[ArtifactVerifyResult]:
     """Verify every task's artifacts under ``workdir/.sdd`` (for ``audit verify``)."""
-    from bernstein.core.replay.journal import verify_journal
+    from bernstein.core.replay.journal import contained_run_journal, verify_journal
 
     sdd_dir = workdir / ".sdd"
     runs_root = sdd_dir / "runs"
@@ -559,8 +559,8 @@ def verify_all_run_artifacts(workdir: Path, *, hmac_key: bytes) -> list[Artifact
         return []
     results: list[ArtifactVerifyResult] = []
     for run_dir in sorted(p for p in runs_root.iterdir() if p.is_dir()):
-        journal_path = run_dir / "journal.jsonl"
-        if not journal_path.is_file():
+        journal_path = contained_run_journal(runs_root, run_dir.name)
+        if journal_path is None or not journal_path.is_file():
             continue
         task_id = _task_id_from_rows(journal_path)
         if task_id is not None:
@@ -607,12 +607,12 @@ def live_artifact_content_hashes(sdd_dir: Path) -> set[str]:
     runs_root = sdd_dir / "runs"
     if not runs_root.is_dir():
         return set()
-    from bernstein.core.replay.journal import load_events
+    from bernstein.core.replay.journal import contained_run_journal, load_events
 
     live: set[str] = set()
     for run_dir in runs_root.iterdir():
-        journal_path = run_dir / "journal.jsonl"
-        if not journal_path.is_file():
+        journal_path = contained_run_journal(runs_root, run_dir.name)
+        if journal_path is None or not journal_path.is_file():
             continue
         for row in load_events(journal_path):
             if str(row.get("event", "")) == JOURNAL_EVENT_ARTIFACT_POSTED:

--- a/src/bernstein/core/evidence/run_artifacts.py
+++ b/src/bernstein/core/evidence/run_artifacts.py
@@ -37,6 +37,7 @@ from typing import TYPE_CHECKING, Any
 
 from bernstein.core.evidence.bundle import DEFAULT_MAX_BLOB_BYTES, EvidenceStore
 from bernstein.core.lineage.spine import LineageSpine, content_hash_of
+from bernstein.core.security.path_containment import contained_path
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -266,7 +267,18 @@ def _validate_ids(task_id: str, key: str) -> None:
 
 
 def _artifact_journal_path(sdd_dir: Path, task_id: str) -> Path:
-    return sdd_dir / "runs" / _task_run_id(task_id) / "journal.jsonl"
+    """Return the task journal path, proven to sit under ``<sdd>/runs``.
+
+    ``task_id`` arrives from the dashboard API, so the derived run id goes
+    through the containment barrier and the *returned* value is the
+    normalised, checked path. Readers open that value rather than the raw
+    join, so a crafted id (or a symlinked run directory) cannot address a
+    journal outside the runs root.
+
+    Raises:
+        PathContainmentError: The derived run id escapes the runs root.
+    """
+    return contained_path(sdd_dir / "runs", _task_run_id(task_id), "journal.jsonl", label="task run id")
 
 
 def _row_to_record(row: dict[str, Any]) -> RunArtifactRecord:

--- a/src/bernstein/core/evidence/run_artifacts.py
+++ b/src/bernstein/core/evidence/run_artifacts.py
@@ -37,7 +37,6 @@ from typing import TYPE_CHECKING, Any
 
 from bernstein.core.evidence.bundle import DEFAULT_MAX_BLOB_BYTES, EvidenceStore
 from bernstein.core.lineage.spine import LineageSpine, content_hash_of
-from bernstein.core.security.path_containment import contained_path
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -278,7 +277,9 @@ def _artifact_journal_path(sdd_dir: Path, task_id: str) -> Path:
     Raises:
         PathContainmentError: The derived run id escapes the runs root.
     """
-    return contained_path(sdd_dir / "runs", _task_run_id(task_id), "journal.jsonl", label="task run id")
+    from bernstein.core.tasks.checkpoint_retry import task_journal_path
+
+    return task_journal_path(sdd_dir, task_id)
 
 
 def _row_to_record(row: dict[str, Any]) -> RunArtifactRecord:

--- a/src/bernstein/core/evidence/run_artifacts.py
+++ b/src/bernstein/core/evidence/run_artifacts.py
@@ -306,10 +306,20 @@ def read_artifact_rows(sdd_dir: Path, task_id: str, *, verify: bool = True) -> l
         task_id: The task whose artifacts to read.
         verify: When True (default), a task journal that fails Merkle
             verification yields no records (fail-closed).
+
+    A task id too long to name a file reads as empty, matching the
+    "no journal" case: ``_TASK_ID_RE`` accepts 256 characters and
+    ``task_run_id`` adds a prefix, so the derived component can exceed
+    ``NAME_MAX``. A *containment* failure is deliberately not caught - a
+    traversal or symlink escape must surface, never read as empty.
     """
     from bernstein.core.replay.journal import load_events, verify_journal
+    from bernstein.core.security.path_containment import PathTooLongError
 
-    path = _artifact_journal_path(sdd_dir, task_id)
+    try:
+        path = _artifact_journal_path(sdd_dir, task_id)
+    except PathTooLongError:
+        return []
     if not path.is_file():
         return []
     if verify and not verify_journal(path).ok:

--- a/src/bernstein/core/orchestration/activity_modalities.py
+++ b/src/bernstein/core/orchestration/activity_modalities.py
@@ -73,7 +73,7 @@ from bernstein.core.orchestration.research_report import (
     ResearchReportVerdict,
     verify_research_report,
 )
-from bernstein.core.replay.journal import load_events, verify_journal
+from bernstein.core.replay.journal import JournalPathError, load_events, run_journal_path, verify_journal
 from bernstein.core.skills.catalog.signature import sign_payload, verify_payload
 
 if TYPE_CHECKING:
@@ -782,7 +782,18 @@ def verify_run_activities(
         An :class:`ActivityVerifyResult`. ``found`` is ``False`` when no journal
         or no activity entry exists.
     """
-    journal_path = sdd_dir / "runs" / run_id / "journal.jsonl"
+    try:
+        journal_path = run_journal_path(sdd_dir, run_id)
+    except JournalPathError as exc:
+        # A run id that escapes the runs root names no run of ours; report it
+        # as absent rather than verifying a journal outside the tree.
+        return ActivityVerifyResult(
+            run_id=run_id,
+            found=False,
+            ok=False,
+            chain_ok=False,
+            reason=f"invalid run id: {exc}",
+        )
     if not journal_path.exists():
         return ActivityVerifyResult(
             run_id=run_id,

--- a/src/bernstein/core/orchestration/escalation.py
+++ b/src/bernstein/core/orchestration/escalation.py
@@ -51,7 +51,7 @@ from bernstein.core.orchestration.supervisor_receipt import (
     recommend_action,
 )
 from bernstein.core.replay.fork import SNAPSHOT_EVENT
-from bernstein.core.replay.journal import JOURNAL_FILENAME, load_events, verify_journal
+from bernstein.core.replay.journal import load_events, run_journal_path, verify_journal
 from bernstein.core.skills.catalog.signature import sign_payload, verify_payload
 
 if TYPE_CHECKING:
@@ -182,7 +182,8 @@ class ForkRef:
 
 
 def _journal_path(sdd_dir: Path, run_id: str) -> Path:
-    return sdd_dir / "runs" / run_id / JOURNAL_FILENAME
+    """Return the run journal path via the shared containment barrier."""
+    return run_journal_path(sdd_dir, run_id)
 
 
 def _resolve_fork_ref(events: list[dict[str, Any]], run_id: str, fork_step: int) -> ForkRef:

--- a/src/bernstein/core/orchestration/schedule_fire_record.py
+++ b/src/bernstein/core/orchestration/schedule_fire_record.py
@@ -34,7 +34,7 @@ from bernstein.core.orchestration.schedule_projection import (
     project,
     project_schedule_fire,
 )
-from bernstein.core.replay.journal import EventJournal, load_events
+from bernstein.core.replay.journal import EventJournal, contained_run_journal, load_events
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -261,7 +261,10 @@ def load_fire_records(sdd_dir: Path) -> list[dict[str, Any]]:
         return []
     rows: list[dict[str, Any]] = []
     for run_dir in sorted(runs_root.glob("sched-fire-*")):
-        for event in load_events(run_dir / "journal.jsonl"):
+        journal_path = contained_run_journal(runs_root, run_dir.name)
+        if journal_path is None:
+            continue
+        for event in load_events(journal_path):
             if event.get("event") == JOURNAL_EVENT:
                 rows.append(event)
     rows.sort(key=lambda r: (int(r.get("fire_time", 0)), str(r.get("schedule_id", ""))))

--- a/src/bernstein/core/persistence/work_ledger.py
+++ b/src/bernstein/core/persistence/work_ledger.py
@@ -76,6 +76,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from bernstein.core.persistence.journal import GENESIS_HASH
+from bernstein.core.security.path_containment import contained_path
 from bernstein.core.security.redactor import redact_text
 
 if TYPE_CHECKING:
@@ -143,6 +144,22 @@ _TASK_ID_RE = re.compile(r"^[A-Za-z0-9_.-]{0,64}$")
 
 class LedgerError(RuntimeError):
     """Raised for unrecoverable ledger read/write/verify errors."""
+
+
+def _contained_bucket_path(ledger_dir: Path) -> Path:
+    """Return the bucket file path, proven to sit inside *ledger_dir*.
+
+    Path-injection barrier (py/path-injection) for the reader and writer
+    below. The bucket filename is a constant, but the *directory* is
+    caller-supplied, and a bucket file that is itself a symlink would
+    otherwise let a read or an append land outside the ledger directory.
+    The returned value is the normalised, containment-checked path, and it
+    is the only path the filesystem sinks are built from.
+
+    Raises:
+        PathContainmentError: The bucket resolves outside *ledger_dir*.
+    """
+    return contained_path(ledger_dir, _DEFAULT_BUCKET, label="ledger bucket")
 
 
 # ---------------------------------------------------------------------------
@@ -485,7 +502,7 @@ class WorkLedger:
 
     def __init__(self, ledger_dir: Path) -> None:
         self._dir = ledger_dir
-        self._bucket_path = ledger_dir / _DEFAULT_BUCKET
+        self._bucket_path = _contained_bucket_path(ledger_dir)
         self._lock = threading.Lock()
         self._tip_hash = GENESIS_HASH
         self._seq = 0
@@ -636,7 +653,7 @@ class LedgerReader:
 
     def __init__(self, ledger_dir: Path) -> None:
         self._dir = ledger_dir
-        self._bucket_path = ledger_dir / _DEFAULT_BUCKET
+        self._bucket_path = _contained_bucket_path(ledger_dir)
 
     @property
     def ledger_dir(self) -> Path:
@@ -959,8 +976,28 @@ def default_ledger_root(sdd_dir: Path) -> Path:
 
 
 def run_ledger_dir(sdd_dir: Path, run_id: str) -> Path:
-    """Return the per-run ledger directory under the default root."""
-    return default_ledger_root(sdd_dir) / run_id
+    """Return the per-run ledger directory under the default root.
+
+    ``run_id`` reaches this function from the dashboard API, the MCP
+    surface, and the CLI, and it names a directory. It therefore goes
+    through the containment barrier: the id must be a single safe path
+    segment and the resolved directory must stay under the ledger root.
+    The *returned* value is the checked path, so readers and writers built
+    from it cannot address a ledger outside the root - including through a
+    symlinked run directory.
+
+    Args:
+        sdd_dir: The install's ``.sdd`` directory.
+        run_id: Run (or mission) identifier naming the ledger directory.
+
+    Returns:
+        The containment-checked per-run ledger directory.
+
+    Raises:
+        PathContainmentError: ``run_id`` is not a safe path segment, or the
+            resolved directory escapes the ledger root.
+    """
+    return contained_path(default_ledger_root(sdd_dir), run_id, label="run id")
 
 
 __all__ = [

--- a/src/bernstein/core/persistence/work_ledger.py
+++ b/src/bernstein/core/persistence/work_ledger.py
@@ -458,8 +458,17 @@ def validated_canonical_lines(ledger_dir: Path) -> tuple[list[str], str]:
     bytes the chain verified over: a torn trailing line from a crash is
     excluded (matching writer recovery), while interior corruption raises
     :class:`LedgerError` so a broken chain is never exported.
+
+    The bucket goes through the same containment barrier the reader and the
+    writer use. This is the third constructor of the identical path and it
+    runs *before* the guarded reader in ``anchor_ledger``, so without the
+    barrier a symlinked bucket would have its bytes read into the anchor and
+    its head hash derived from them before anything refused.
+
+    Raises:
+        PathContainmentError: The bucket resolves outside *ledger_dir*.
     """
-    bucket_path = ledger_dir / _DEFAULT_BUCKET
+    bucket_path = _contained_bucket_path(ledger_dir)
     if not bucket_path.exists():
         return [], GENESIS_HASH
     tip_hash, validated = _walk_validated_lines(bucket_path)

--- a/src/bernstein/core/replay/fork.py
+++ b/src/bernstein/core/replay/fork.py
@@ -36,7 +36,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from bernstein.core.git.git_basic import run_git
-from bernstein.core.replay.journal import EventJournal, load_events
+from bernstein.core.replay.journal import EventJournal, JournalPathError, load_events, run_journal_path
 from bernstein.core.sandbox.snapshot import (
     SnapshotError,
     resume_worktree_snapshot,
@@ -166,7 +166,10 @@ def fork_run(
             (its sha no longer matches the journal), or the checkout
             fails.
     """
-    journal_path = sdd_dir / "runs" / run_id / "journal.jsonl"
+    try:
+        journal_path = run_journal_path(sdd_dir, run_id)
+    except JournalPathError as exc:
+        raise ForkError(f"cannot fork run {run_id!r}: {exc}") from exc
     if not journal_path.exists():
         raise ForkError(f"no journal for run {run_id!r} (looked at {journal_path})")
 

--- a/src/bernstein/core/replay/journal.py
+++ b/src/bernstein/core/replay/journal.py
@@ -45,10 +45,23 @@ import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.security.path_containment import PathContainmentError, contained_path
+
 if TYPE_CHECKING:
     from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+
+class JournalPathError(PathContainmentError):
+    """Raised for a run id that cannot safely name a journal directory.
+
+    Subclasses :class:`ValueError` (through
+    :class:`~bernstein.core.security.path_containment.PathContainmentError`)
+    so callers that already handle a bad run id with ``except ValueError``
+    keep working unchanged.
+    """
+
 
 #: Name of the canonical per-run event journal inside ``.sdd/runs/<id>/``.
 JOURNAL_FILENAME = "journal.jsonl"
@@ -68,17 +81,19 @@ _GENESIS_HASH = ""
 
 #: A run_id names exactly one journal directory and must be a single safe path
 #: segment. This mirrors ``run_service.paths.validate_run_id``: an anchored
-#: allowlist match then a return of the checked value, the shape CodeQL credits
-#: as a path-injection barrier. The journal path is derived only from the value
-#: :func:`_validated_run_id` returns, so no attacker-controlled character reaches
-#: the filesystem sinks below.
+#: allowlist match then a return of the checked value.
 _RUN_ID_RE = re.compile(r"^[A-Za-z0-9_.-]{1,64}$")
 
 
 def _validated_run_id(run_id: str) -> str:
-    """Return *run_id* unchanged when it is a safe path segment, else raise."""
-    if not _RUN_ID_RE.match(run_id):
-        raise ValueError(f"unsafe run_id for journal path: {run_id!r}")
+    """Return *run_id* unchanged when it is a safe path segment, else raise.
+
+    Raises:
+        JournalPathError: The id is ``.``, ``..``, or falls outside the
+            allowlisted alphabet.
+    """
+    if run_id in {".", ".."} or not _RUN_ID_RE.match(run_id):
+        raise JournalPathError(f"unsafe run_id for journal path: {run_id!r}")
     return run_id
 
 
@@ -156,21 +171,17 @@ class EventJournal:
         self._run_id = run_id
         self._runs_root = sdd_dir / "runs"
         # Path-injection barrier (py/path-injection). A run_id names one journal
-        # directory and must be a single safe path segment. ``.``/``..`` pass the
-        # id alphabet but are the current/parent directory, so reject them first;
-        # then ``_validated_run_id`` -- an anchored allowlist match that returns
-        # the checked value, mirroring run_service.paths.validate_run_id -- is the
-        # sanitizer the filesystem sinks below are built from. The path is derived
-        # only from the value that flows out of that barrier.
-        if run_id in {".", ".."}:
-            raise ValueError(f"unsafe run_id for journal path: {run_id!r}")
+        # directory and must be a single safe path segment, so it goes through
+        # the allowlist first and the runs-root containment check second. The
+        # journal path is the value ``contained_path`` returns -- the normalised,
+        # containment-checked path -- never the raw join, so every filesystem
+        # sink below is built from a location proven to sit under the runs root
+        # even when the run directory is a symlink pointing elsewhere.
         safe_run_id = _validated_run_id(run_id)
-        self._path = self._runs_root / safe_run_id / JOURNAL_FILENAME
-        # Defence in depth: refuse a resolved path that still escapes the runs
-        # root, e.g. through a symlinked run directory.
-        runs_root_real = os.path.realpath(self._runs_root)
-        if os.path.commonpath((runs_root_real, os.path.realpath(self._path))) != runs_root_real:
-            raise ValueError(f"run_id escapes the journal runs root: {run_id!r}")
+        try:
+            self._path = contained_path(self._runs_root, safe_run_id, JOURNAL_FILENAME, label="run id")
+        except PathContainmentError as exc:
+            raise JournalPathError(f"run_id escapes the journal runs root: {run_id!r}") from exc
         self._path.parent.mkdir(parents=True, exist_ok=True)
         self._lock = threading.Lock()
         self._index = 0
@@ -550,6 +561,7 @@ __all__ = [
     "JOURNAL_FILENAME",
     "RETENTION_ENV_VAR",
     "EventJournal",
+    "JournalPathError",
     "JournalVerifyResult",
     "compute_event_hash",
     "load_events",

--- a/src/bernstein/core/replay/journal.py
+++ b/src/bernstein/core/replay/journal.py
@@ -97,6 +97,36 @@ def _validated_run_id(run_id: str) -> str:
     return run_id
 
 
+def run_journal_path(sdd_dir: Path, run_id: str) -> Path:
+    """Return the run's journal path, contained under ``<sdd>/runs``.
+
+    Every reader of a run journal must derive its path here rather than
+    rebuilding ``<sdd>/runs/<run_id>/journal.jsonl`` by hand, so that a
+    crafted run id cannot address a journal outside the runs root and a
+    symlinked run directory cannot redirect the read. This is the run-level
+    twin of ``checkpoint_retry.task_journal_path``.
+
+    ``verify_journal`` is not a substitute: it is an unkeyed Merkle
+    recompute, so a journal planted outside the tree verifies cleanly.
+
+    Args:
+        sdd_dir: The project ``.sdd`` directory.
+        run_id: The run whose journal to locate.
+
+    Returns:
+        The containment-checked journal path.
+
+    Raises:
+        JournalPathError: The run id is not a safe path segment, or the
+            resolved journal escapes the runs root.
+    """
+    safe_run_id = _validated_run_id(run_id)
+    try:
+        return contained_path(sdd_dir / "runs", safe_run_id, JOURNAL_FILENAME, label="run id")
+    except PathContainmentError as exc:
+        raise JournalPathError(f"run_id escapes the journal runs root: {run_id!r}") from exc
+
+
 def _payload_hash(event_type: str, payload: dict[str, Any]) -> str:
     """Return the SHA-256 of the canonical, timing-excluded payload.
 
@@ -171,17 +201,13 @@ class EventJournal:
         self._run_id = run_id
         self._runs_root = sdd_dir / "runs"
         # Path-injection barrier (py/path-injection). A run_id names one journal
-        # directory and must be a single safe path segment, so it goes through
-        # the allowlist first and the runs-root containment check second. The
-        # journal path is the value ``contained_path`` returns -- the normalised,
-        # containment-checked path -- never the raw join, so every filesystem
-        # sink below is built from a location proven to sit under the runs root
-        # even when the run directory is a symlink pointing elsewhere.
-        safe_run_id = _validated_run_id(run_id)
-        try:
-            self._path = contained_path(self._runs_root, safe_run_id, JOURNAL_FILENAME, label="run id")
-        except PathContainmentError as exc:
-            raise JournalPathError(f"run_id escapes the journal runs root: {run_id!r}") from exc
+        # directory and must be a single safe path segment. The writer shares
+        # ``run_journal_path`` with every run-journal reader, so there is one
+        # definition of where a run journal lives and one barrier guarding it:
+        # the path is the normalised, containment-checked value, never the raw
+        # join, so every filesystem sink below is built from a location proven
+        # to sit under the runs root even when the run directory is a symlink.
+        self._path = run_journal_path(sdd_dir, run_id)
         self._path.parent.mkdir(parents=True, exist_ok=True)
         self._lock = threading.Lock()
         self._index = 0

--- a/src/bernstein/core/replay/journal.py
+++ b/src/bernstein/core/replay/journal.py
@@ -127,6 +127,39 @@ def run_journal_path(sdd_dir: Path, run_id: str) -> Path:
         raise JournalPathError(f"run_id escapes the journal runs root: {run_id!r}") from exc
 
 
+def contained_run_journal(runs_root: Path, entry_name: str, filename: str = JOURNAL_FILENAME) -> Path | None:
+    """Return the journal path for an iterated run directory, or ``None``.
+
+    For the sweep case: the caller obtained *entry_name* by iterating
+    *runs_root*, so it cannot carry ``..`` or a separator. That covers only
+    half the threat. A directory entry with a perfectly ordinary name can be
+    a **symlink** pointing outside the runs root - the name is innocent, the
+    target is not - and iteration says nothing about what the entry resolves
+    to. Containment is what closes that half, so sweeps re-derive through
+    the same barrier as targeted lookups.
+
+    Returns ``None`` for an entry that escapes, so a sweep skips it and
+    keeps going rather than aborting the whole pass over one bad entry.
+
+    Args:
+        runs_root: The directory being iterated.
+        entry_name: A directory entry name from that iteration.
+        filename: Journal filename to append.
+
+    Returns:
+        The contained journal path, or ``None`` when the entry escapes.
+    """
+    try:
+        return contained_path(runs_root, entry_name, filename, label="run directory")
+    except PathContainmentError:
+        logger.warning(
+            "skipping run directory %r: it resolves outside %s",
+            entry_name,
+            runs_root,
+        )
+        return None
+
+
 def _payload_hash(event_type: str, payload: dict[str, Any]) -> str:
     """Return the SHA-256 of the canonical, timing-excluded payload.
 
@@ -590,6 +623,7 @@ __all__ = [
     "JournalPathError",
     "JournalVerifyResult",
     "compute_event_hash",
+    "contained_run_journal",
     "load_events",
     "rebuild_state",
     "record_dispatch_knob_selection",

--- a/src/bernstein/core/replay/progress.py
+++ b/src/bernstein/core/replay/progress.py
@@ -266,9 +266,15 @@ def project_task_progress(sdd_dir: Path, task_id: str, *, run_id: str = "") -> P
 def _load_task_journal_rows(sdd_dir: Path, task_id: str) -> list[dict[str, Any]]:
     """Return the task journal rows, or ``[]`` when absent or tampered."""
     from bernstein.core.replay.journal import load_events, verify_journal
+    from bernstein.core.security.path_containment import PathTooLongError
     from bernstein.core.tasks.checkpoint_retry import task_journal_path
 
-    path = task_journal_path(sdd_dir, task_id)
+    try:
+        path = task_journal_path(sdd_dir, task_id)
+    except PathTooLongError:
+        # Cannot name a file here, so there is no journal to read. A
+        # containment failure is not caught: an escape must surface.
+        return []
     if not path.is_file():
         return []
     # Fail-closed: a journal whose Merkle chain does not verify is not a

--- a/src/bernstein/core/replay/progress.py
+++ b/src/bernstein/core/replay/progress.py
@@ -266,9 +266,9 @@ def project_task_progress(sdd_dir: Path, task_id: str, *, run_id: str = "") -> P
 def _load_task_journal_rows(sdd_dir: Path, task_id: str) -> list[dict[str, Any]]:
     """Return the task journal rows, or ``[]`` when absent or tampered."""
     from bernstein.core.replay.journal import load_events, verify_journal
-    from bernstein.core.tasks.checkpoint_retry import task_run_id
+    from bernstein.core.tasks.checkpoint_retry import task_journal_path
 
-    path = sdd_dir / "runs" / task_run_id(task_id) / "journal.jsonl"
+    path = task_journal_path(sdd_dir, task_id)
     if not path.is_file():
         return []
     # Fail-closed: a journal whose Merkle chain does not verify is not a

--- a/src/bernstein/core/replay/review_board.py
+++ b/src/bernstein/core/replay/review_board.py
@@ -60,7 +60,9 @@ from typing import TYPE_CHECKING, Any, cast
 
 from bernstein.core.replay.journal import (
     JOURNAL_FILENAME,
+    JournalPathError,
     load_events,
+    run_journal_path,
     verify_journal,
 )
 
@@ -337,7 +339,14 @@ def project_run(sdd_dir: Path, run_id: str) -> BoardProjection | None:
         A :class:`BoardProjection`, or ``None`` when no journal exists for
         ``run_id``.
     """
-    journal_path = sdd_dir / "runs" / run_id / JOURNAL_FILENAME
+    try:
+        journal_path = run_journal_path(sdd_dir, run_id)
+    except JournalPathError:
+        # A run id that escapes the runs root names no run of ours, which is
+        # the documented "no projection" case. Never project a journal that
+        # is not ours: verify_journal is an unkeyed recompute and a planted
+        # chain satisfies it.
+        return None
     if not journal_path.is_file():
         return None
     events = load_events(journal_path)

--- a/src/bernstein/core/replay/review_board.py
+++ b/src/bernstein/core/replay/review_board.py
@@ -59,8 +59,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
 from bernstein.core.replay.journal import (
-    JOURNAL_FILENAME,
     JournalPathError,
+    contained_run_journal,
     load_events,
     run_journal_path,
     verify_journal,
@@ -373,7 +373,13 @@ def list_board_runs(sdd_dir: Path) -> list[str]:
     runs_root = sdd_dir / "runs"
     if not runs_root.is_dir():
         return []
-    run_ids = [entry.name for entry in runs_root.iterdir() if entry.is_dir() and (entry / JOURNAL_FILENAME).is_file()]
+    run_ids = [
+        entry.name
+        for entry in runs_root.iterdir()
+        if entry.is_dir()
+        and (journal := contained_run_journal(runs_root, entry.name)) is not None
+        and journal.is_file()
+    ]
     return sorted(run_ids, reverse=True)
 
 

--- a/src/bernstein/core/run_service/verify.py
+++ b/src/bernstein/core/run_service/verify.py
@@ -25,6 +25,7 @@ from bernstein.core.run_service.receipts import (
     TRANSITION_SUBMITTED,
 )
 from bernstein.core.security.audit_chain import EVENT_RUN_LIFECYCLE, AuditChainStore
+from bernstein.core.security.path_containment import PathContainmentError
 
 
 @dataclass(frozen=True)
@@ -72,13 +73,24 @@ def verify_run(root: Path, run_id: str) -> RunVerification:
     if not audit_ok:
         errors.extend(f"audit: {e}" for e in audit_errors)
 
-    reader = LedgerReader(run_ledger_dir(sdd, run_id))
-    ledger_result = reader.verify()
-    ledger_ok = ledger_result.ok
-    if not ledger_ok:
-        errors.extend(f"ledger: {e}" for e in ledger_result.errors)
+    # A verifier reports; it does not raise. An unusable run id is a ledger
+    # finding like any other, so it is recorded and the remaining pillars
+    # still get reported. Raising here would discard the audit-chain result
+    # computed just above -- the tamper finding would be lost to an
+    # unrelated identifier check, which is strictly worse than not checking.
+    reader: LedgerReader | None = None
+    try:
+        reader = LedgerReader(run_ledger_dir(sdd, run_id))
+    except PathContainmentError as exc:
+        ledger_ok = False
+        errors.append(f"ledger: unusable run id: {exc}")
+    else:
+        ledger_result = reader.verify()
+        ledger_ok = ledger_result.ok
+        if not ledger_ok:
+            errors.extend(f"ledger: {e}" for e in ledger_result.errors)
 
-    hashes = [entry.entry_hash for entry in reader.entries()] if ledger_ok else []
+    hashes = [entry.entry_hash for entry in reader.entries()] if (reader is not None and ledger_ok) else []
 
     receipts = [e for e in chain.query(event_type=EVENT_RUN_LIFECYCLE) if e.details.get("run_id") == run_id]
     receipts_seen = len(receipts)

--- a/src/bernstein/core/security/intent_capsule.py
+++ b/src/bernstein/core/security/intent_capsule.py
@@ -802,7 +802,12 @@ def verify_intent_conformance(
     conformant. A drifted-but-untampered run returns ``ok=False`` with
     ``conformant=False`` and a divergence-naming reason.
     """
-    from bernstein.core.replay.journal import load_events, verify_journal
+    from bernstein.core.replay.journal import (
+        JournalPathError,
+        load_events,
+        run_journal_path,
+        verify_journal,
+    )
     from bernstein.core.security.audit_chain import EVENT_INTENT_CAPSULE
 
     capsule, run_id = read_capsule_binding(sdd_dir, task_id)
@@ -839,7 +844,16 @@ def verify_intent_conformance(
             run_id=run_id,
         )
 
-    journal_path = sdd_dir / "runs" / run_id / "journal.jsonl"
+    try:
+        journal_path = run_journal_path(sdd_dir, run_id)
+    except JournalPathError as exc:
+        return IntentVerifyResult(
+            ok=False,
+            conformant=False,
+            reason=f"invalid run id: {exc}",
+            capsule=capsule,
+            run_id=run_id,
+        )
     if not journal_path.exists():
         return IntentVerifyResult(
             ok=False,

--- a/src/bernstein/core/security/path_containment.py
+++ b/src/bernstein/core/security/path_containment.py
@@ -101,16 +101,22 @@ def contained_path(base: Path | str, *segments: str, label: str = "identifier") 
     for segment in segments:
         validate_path_segment(segment, label=label)
     base_real = os.path.realpath(base)
+    # ``os.path.join(x, "")`` appends the separator without doubling it on a
+    # drive root such as ``C:\``, so the prefix test below stays correct for
+    # every base. The trailing separator is what stops a sibling directory
+    # like ``<base>-evil`` from passing a bare prefix comparison.
+    base_prefix = os.path.join(base_real, "")
     # ``realpath`` resolves symlinks and normalises ``..`` even for a path
-    # that does not exist yet, so the containment test below sees exactly
-    # the location a later open() would reach. Every segment is a plain
-    # name, so a contained result is always a strict descendant of the
-    # base: a single prefix test is the whole check, and ``+ os.sep``
-    # stops a sibling like ``<base>-evil`` from passing it.
+    # that does not exist yet, so the containment test sees exactly the
+    # location a later open() would reach. Every segment is a plain name, so
+    # a contained result is always a strict descendant of the base and a
+    # single prefix test is the whole check.
     candidate = os.path.realpath(os.path.join(base_real, *segments))
-    if not candidate.startswith(base_real + os.sep):
+    if not candidate.startswith(base_prefix):
+        # The base is deliberately left out of the message: these errors can
+        # surface to an API caller, and the absolute layout is not theirs.
         joined = "/".join(segments)
-        msg = f"{label} {joined!r} resolves outside {base_real}"
+        msg = f"{label} {joined!r} resolves outside its base directory"
         raise PathContainmentError(msg)
     return Path(candidate)
 

--- a/src/bernstein/core/security/path_containment.py
+++ b/src/bernstein/core/security/path_containment.py
@@ -80,7 +80,9 @@ def contained_path(base: Path | str, *segments: str, label: str = "identifier") 
         base: The intended containing directory. Trusted by configuration;
             it need not exist yet.
         *segments: Path segments to append, each checked by
-            :func:`validate_path_segment`.
+            :func:`validate_path_segment`. At least one is required - the
+            result must be a strict descendant of *base*, never *base*
+            itself.
         label: Noun used in error messages (e.g. ``"mission id"``).
 
     Returns:
@@ -89,18 +91,24 @@ def contained_path(base: Path | str, *segments: str, label: str = "identifier") 
         to be inside *base*.
 
     Raises:
-        PathContainmentError: If a segment is unsafe, or if the resolved
-            candidate falls outside the resolved base (for example via a
-            symlinked child).
+        PathContainmentError: If no segment is given, if a segment is
+            unsafe, or if the resolved candidate falls outside the
+            resolved base (for example via a symlinked child).
     """
+    if not segments:
+        msg = f"contained_path requires at least one {label} segment"
+        raise PathContainmentError(msg)
     for segment in segments:
         validate_path_segment(segment, label=label)
     base_real = os.path.realpath(base)
     # ``realpath`` resolves symlinks and normalises ``..`` even for a path
     # that does not exist yet, so the containment test below sees exactly
-    # the location a later open() would reach.
+    # the location a later open() would reach. Every segment is a plain
+    # name, so a contained result is always a strict descendant of the
+    # base: a single prefix test is the whole check, and ``+ os.sep``
+    # stops a sibling like ``<base>-evil`` from passing it.
     candidate = os.path.realpath(os.path.join(base_real, *segments))
-    if candidate != base_real and not candidate.startswith(base_real + os.sep):
+    if not candidate.startswith(base_real + os.sep):
         joined = "/".join(segments)
         msg = f"{label} {joined!r} resolves outside {base_real}"
         raise PathContainmentError(msg)

--- a/src/bernstein/core/security/path_containment.py
+++ b/src/bernstein/core/security/path_containment.py
@@ -1,0 +1,115 @@
+"""Filesystem containment barrier for externally-influenced identifiers.
+
+Run ids, task ids, ledger ids, and mission ids reach the process from the
+dashboard API, the MCP surface, and the CLI, and several of them name a
+directory or a file under ``.sdd``. Joining such an identifier onto a base
+directory without a barrier lets ``..`` segments, an absolute path, or a
+symlinked child address files outside the tree the caller intended
+(``py/path-injection``).
+
+This module is the single place that turns "an identifier the caller does
+not control" into "a path proven to live under a base directory". Both
+halves of the barrier are load-bearing and neither is sufficient alone:
+
+1. **Allowlist.** Every segment must match :data:`SAFE_SEGMENT_RE` and must
+   not be ``.`` or ``..``. This rejects separators, traversal, NUL bytes,
+   and absolute paths before any filesystem call happens.
+2. **Realpath containment.** The joined candidate is normalised with
+   :func:`os.path.realpath` (which follows symlinks) and required to stay
+   under the normalised base. This catches the case the allowlist cannot:
+   a well-named child that is itself a symlink pointing out of the tree.
+
+:func:`contained_path` returns the *normalised, checked* path, and callers
+build their filesystem access from that return value rather than from the
+raw join, so no unchecked string survives to reach a filesystem sink.
+
+The base directory is trusted by configuration (it is derived from the
+install's ``.sdd`` root, never from request data); the identifier is not.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+#: A safe path segment: the git-ref-safe alphabet the persistence layer
+#: already uses for run, worktree, task, and ledger ids. Anchored on both
+#: ends, so a separator or a traversal sequence cannot match. The 255-byte
+#: cap is the ``NAME_MAX`` every supported filesystem enforces anyway, so
+#: it turns a later ``ENAMETOOLONG`` into a typed error rather than taking
+#: away a name that used to work.
+SAFE_SEGMENT_RE = re.compile(r"^[A-Za-z0-9_.-]{1,255}$")
+
+#: Segments that match the alphabet but name the current/parent directory.
+_RESERVED_SEGMENTS = frozenset({".", ".."})
+
+
+class PathContainmentError(ValueError):
+    """Raised for an unsafe path segment or a path that escapes its base.
+
+    Subclasses :class:`ValueError` so existing callers that already guard
+    identifier handling with ``except ValueError`` keep working.
+    """
+
+
+def validate_path_segment(segment: str, *, label: str = "identifier") -> str:
+    """Return *segment* unchanged when it is a safe single path segment.
+
+    Args:
+        segment: The externally-influenced identifier to check.
+        label: Noun used in the error message (e.g. ``"run id"``).
+
+    Returns:
+        The segment, unchanged, when it is safe.
+
+    Raises:
+        PathContainmentError: If the segment is empty, is ``.`` or ``..``,
+            or contains anything outside :data:`SAFE_SEGMENT_RE`.
+    """
+    if segment in _RESERVED_SEGMENTS or not SAFE_SEGMENT_RE.match(segment):
+        msg = f"unsafe {label} {segment!r}: must match {SAFE_SEGMENT_RE.pattern} and must not be '.' or '..'"
+        raise PathContainmentError(msg)
+    return segment
+
+
+def contained_path(base: Path | str, *segments: str, label: str = "identifier") -> Path:
+    """Join *segments* under *base* and prove the result stays inside it.
+
+    Args:
+        base: The intended containing directory. Trusted by configuration;
+            it need not exist yet.
+        *segments: Path segments to append, each checked by
+            :func:`validate_path_segment`.
+        label: Noun used in error messages (e.g. ``"mission id"``).
+
+    Returns:
+        The normalised, containment-checked path. Callers must use this
+        return value for filesystem access - it is the only value proven
+        to be inside *base*.
+
+    Raises:
+        PathContainmentError: If a segment is unsafe, or if the resolved
+            candidate falls outside the resolved base (for example via a
+            symlinked child).
+    """
+    for segment in segments:
+        validate_path_segment(segment, label=label)
+    base_real = os.path.realpath(base)
+    # ``realpath`` resolves symlinks and normalises ``..`` even for a path
+    # that does not exist yet, so the containment test below sees exactly
+    # the location a later open() would reach.
+    candidate = os.path.realpath(os.path.join(base_real, *segments))
+    if candidate != base_real and not candidate.startswith(base_real + os.sep):
+        joined = "/".join(segments)
+        msg = f"{label} {joined!r} resolves outside {base_real}"
+        raise PathContainmentError(msg)
+    return Path(candidate)
+
+
+__all__ = [
+    "SAFE_SEGMENT_RE",
+    "PathContainmentError",
+    "contained_path",
+    "validate_path_segment",
+]

--- a/src/bernstein/core/security/path_containment.py
+++ b/src/bernstein/core/security/path_containment.py
@@ -34,12 +34,23 @@ import re
 from pathlib import Path
 
 #: A safe path segment: the git-ref-safe alphabet the persistence layer
-#: already uses for run, worktree, task, and ledger ids. Anchored on both
-#: ends, so a separator or a traversal sequence cannot match. The 255-byte
-#: cap is the ``NAME_MAX`` every supported filesystem enforces anyway, so
-#: it turns a later ``ENAMETOOLONG`` into a typed error rather than taking
-#: away a name that used to work.
-SAFE_SEGMENT_RE = re.compile(r"^[A-Za-z0-9_.-]{1,255}$")
+#: already uses for run, worktree, task, and ledger ids.
+#:
+#: The length bound is a sanity limit, not the security control - containment
+#: below is. It is deliberately above the repo-wide 256-character task id
+#: convention (``_TASK_ID_RE``, the MCP tool schemas) plus room for a derived
+#: prefix such as ``task-``, so an identifier this codebase already blesses
+#: never trips it. A segment past the filesystem's ``NAME_MAX`` still
+#: normalises and contains correctly, and the read degrades to "not found"
+#: the same way it did before this barrier existed, rather than raising.
+#:
+#: The tail anchor is ``\Z``, not ``$``: in Python ``$`` also matches just
+#: before a trailing newline, so ``$`` would accept ``"..\n"`` - which the
+#: reserved-segment check below does not catch, since it is not equal to
+#: ``".."``. Containment would still hold (a newline is a literal character,
+#: not a parent reference), but the id would carry a control character into
+#: a directory name and into operator-facing log and ledger listings.
+SAFE_SEGMENT_RE = re.compile(r"^[A-Za-z0-9_.-]{1,512}\Z")
 
 #: Segments that match the alphabet but name the current/parent directory.
 _RESERVED_SEGMENTS = frozenset({".", ".."})

--- a/src/bernstein/core/security/path_containment.py
+++ b/src/bernstein/core/security/path_containment.py
@@ -36,13 +36,9 @@ from pathlib import Path
 #: A safe path segment: the git-ref-safe alphabet the persistence layer
 #: already uses for run, worktree, task, and ledger ids.
 #:
-#: The length bound is a sanity limit, not the security control - containment
-#: below is. It is deliberately above the repo-wide 256-character task id
-#: convention (``_TASK_ID_RE``, the MCP tool schemas) plus room for a derived
-#: prefix such as ``task-``, so an identifier this codebase already blesses
-#: never trips it. A segment past the filesystem's ``NAME_MAX`` still
-#: normalises and contains correctly, and the read degrades to "not found"
-#: the same way it did before this barrier existed, rather than raising.
+#: Length is deliberately NOT bounded here. :data:`MAX_SEGMENT_BYTES` owns it,
+#: measured in encoded bytes, because ``NAME_MAX`` is a byte limit and a
+#: character count would let a multi-byte name through.
 #:
 #: The tail anchor is ``\Z``, not ``$``: in Python ``$`` also matches just
 #: before a trailing newline, so ``$`` would accept ``"..\n"`` - which the
@@ -50,10 +46,19 @@ from pathlib import Path
 #: ``".."``. Containment would still hold (a newline is a literal character,
 #: not a parent reference), but the id would carry a control character into
 #: a directory name and into operator-facing log and ledger listings.
-SAFE_SEGMENT_RE = re.compile(r"^[A-Za-z0-9_.-]{1,512}\Z")
+SAFE_SEGMENT_RE = re.compile(r"^[A-Za-z0-9_.-]+\Z")
 
 #: Segments that match the alphabet but name the current/parent directory.
 _RESERVED_SEGMENTS = frozenset({".", ".."})
+
+
+#: Longest single path component, in encoded bytes. ``NAME_MAX`` is 255 on
+#: every filesystem this project supports.
+MAX_SEGMENT_BYTES = 255
+
+#: Longest composed path, in encoded bytes. ``PATH_MAX`` is 4096 on Linux;
+#: a legal-length segment under an already-deep base can still exceed it.
+MAX_PATH_BYTES = 4096
 
 
 class PathContainmentError(ValueError):
@@ -61,6 +66,23 @@ class PathContainmentError(ValueError):
 
     Subclasses :class:`ValueError` so existing callers that already guard
     identifier handling with ``except ValueError`` keep working.
+    """
+
+
+class PathTooLongError(PathContainmentError):
+    """Raised when an identifier cannot name a file on this filesystem.
+
+    Distinct from its parent on purpose. A containment violation (traversal,
+    or a symlinked child pointing out of the tree) is an attack signal and
+    must never be swallowed - readers let it propagate. An over-long name is
+    a *capacity* failure: the identifier is contained, it simply cannot exist
+    on disk, which is indistinguishable from "no such journal". Readers that
+    already degrade to an empty result for a missing file may catch this one,
+    and only this one.
+
+    Without the bound the filesystem raises ``OSError(ENAMETOOLONG)`` at
+    ``open()`` instead, which escapes the ``ValueError`` hierarchy every
+    caller guards on and turns a rejected identifier into a crash.
     """
 
 
@@ -77,10 +99,19 @@ def validate_path_segment(segment: str, *, label: str = "identifier") -> str:
     Raises:
         PathContainmentError: If the segment is empty, is ``.`` or ``..``,
             or contains anything outside :data:`SAFE_SEGMENT_RE`.
+        PathTooLongError: If the segment exceeds :data:`MAX_SEGMENT_BYTES`
+            once encoded.
     """
     if segment in _RESERVED_SEGMENTS or not SAFE_SEGMENT_RE.match(segment):
         msg = f"unsafe {label} {segment!r}: must match {SAFE_SEGMENT_RE.pattern} and must not be '.' or '..'"
         raise PathContainmentError(msg)
+    # Measured in encoded bytes, not characters: NAME_MAX is a byte limit, so
+    # a character count would let a multi-byte name through and hand the
+    # filesystem a component it cannot store.
+    encoded = len(segment.encode("utf-8", errors="surrogatepass"))
+    if encoded > MAX_SEGMENT_BYTES:
+        msg = f"{label} is {encoded} bytes, over the {MAX_SEGMENT_BYTES}-byte filesystem limit for one path component"
+        raise PathTooLongError(msg)
     return segment
 
 
@@ -105,6 +136,8 @@ def contained_path(base: Path | str, *segments: str, label: str = "identifier") 
         PathContainmentError: If no segment is given, if a segment is
             unsafe, or if the resolved candidate falls outside the
             resolved base (for example via a symlinked child).
+        PathTooLongError: If a segment, or the composed path, exceeds what
+            the filesystem can represent.
     """
     if not segments:
         msg = f"contained_path requires at least one {label} segment"
@@ -129,12 +162,23 @@ def contained_path(base: Path | str, *segments: str, label: str = "identifier") 
         joined = "/".join(segments)
         msg = f"{label} {joined!r} resolves outside its base directory"
         raise PathContainmentError(msg)
+    # A legal-length segment under an already-deep base can still exceed
+    # PATH_MAX, which would surface as OSError(ENAMETOOLONG) at open() -
+    # outside the ValueError hierarchy callers guard on. Checked after
+    # containment so an escape attempt is never reported as a length problem.
+    encoded_path = len(candidate.encode("utf-8", errors="surrogatepass"))
+    if encoded_path > MAX_PATH_BYTES:
+        msg = f"path for {label} is {encoded_path} bytes, over the {MAX_PATH_BYTES}-byte filesystem limit"
+        raise PathTooLongError(msg)
     return Path(candidate)
 
 
 __all__ = [
+    "MAX_PATH_BYTES",
+    "MAX_SEGMENT_BYTES",
     "SAFE_SEGMENT_RE",
     "PathContainmentError",
+    "PathTooLongError",
     "contained_path",
     "validate_path_segment",
 ]

--- a/src/bernstein/core/tasks/checkpoint_retry.py
+++ b/src/bernstein/core/tasks/checkpoint_retry.py
@@ -50,7 +50,7 @@ from bernstein.adapters._contract import (
     CheckpointRetryCapability,
     checkpoint_retry_capability,
 )
-from bernstein.core.replay.journal import EventJournal, load_events, verify_journal
+from bernstein.core.replay.journal import JOURNAL_FILENAME, EventJournal, load_events, verify_journal
 
 if TYPE_CHECKING:
     from bernstein.core.security.audit_chain import AuditChainStore
@@ -151,6 +151,26 @@ def task_run_id(task_id: str) -> str:
     """
     safe = _RUN_ID_SAFE_RE.sub("-", task_id) or "unknown"
     return f"task-{safe}"
+
+
+def task_journal_path(sdd_dir: Path, task_id: str) -> Path:
+    """Return the task's event-journal path, contained under ``<sdd>/runs``.
+
+    Every reader of a task journal must derive its path here rather than
+    rebuilding ``<sdd>/runs/<task_run_id>/journal.jsonl`` by hand. The
+    identifier is slugified by :func:`task_run_id`, which blocks traversal,
+    but only the containment barrier catches a run directory that is a
+    symlink out of the runs root - the case that would otherwise let a
+    planted, self-consistent journal be read as if it were ours.
+    ``verify_journal`` cannot catch that: it is an unkeyed Merkle recompute,
+    so whoever plants the symlink can also satisfy it.
+
+    Raises:
+        PathContainmentError: The derived run id escapes the runs root.
+    """
+    from bernstein.core.security.path_containment import contained_path
+
+    return contained_path(sdd_dir / "runs", task_run_id(task_id), JOURNAL_FILENAME, label="task run id")
 
 
 def workspace_hash(worktree: Path) -> str:
@@ -295,7 +315,7 @@ def latest_checkpoint(sdd_dir: Path, task_id: str) -> CheckpointRef | None:
     restarts cold. A tampered checkpoint reference can therefore never fuel
     a warm resume.
     """
-    path = sdd_dir / "runs" / task_run_id(task_id) / "journal.jsonl"
+    path = task_journal_path(sdd_dir, task_id)
     if not path.exists():
         return None
     result = verify_journal(path)

--- a/src/bernstein/core/tasks/checkpoint_retry.py
+++ b/src/bernstein/core/tasks/checkpoint_retry.py
@@ -314,8 +314,18 @@ def latest_checkpoint(sdd_dir: Path, task_id: str) -> CheckpointRef | None:
     absence of any checkpoint row all return ``None`` -- the caller then
     restarts cold. A tampered checkpoint reference can therefore never fuel
     a warm resume.
+
+    A task id too long to name a file is treated as "no checkpoint" (cold
+    restart), the same as a missing journal. A containment failure is not
+    caught: a run directory that escapes the runs root must surface rather
+    than silently degrade to a cold start.
     """
-    path = task_journal_path(sdd_dir, task_id)
+    from bernstein.core.security.path_containment import PathTooLongError
+
+    try:
+        path = task_journal_path(sdd_dir, task_id)
+    except PathTooLongError:
+        return None
     if not path.exists():
         return None
     result = verify_journal(path)

--- a/src/bernstein/core/tasks/suspension.py
+++ b/src/bernstein/core/tasks/suspension.py
@@ -189,7 +189,10 @@ class SuspendRow:
 
 
 def _journal_path(sdd_dir: Path, task_id: str) -> Path:
-    return sdd_dir / "runs" / task_run_id(task_id) / "journal.jsonl"
+    """Return the task journal path via the shared containment barrier."""
+    from bernstein.core.tasks.checkpoint_retry import task_journal_path
+
+    return task_journal_path(sdd_dir, task_id)
 
 
 def record_task_suspension_row(

--- a/src/bernstein/mcp/server.py
+++ b/src/bernstein/mcp/server.py
@@ -160,13 +160,13 @@ def _register_health_tool(mcp: FastMCP[None]) -> None:
 def _get_journal_head(task_id: str) -> str:
     from pathlib import Path
 
-    from bernstein.core.replay.journal import EventJournal
+    from bernstein.core.replay.journal import EventJournal, run_journal_path
     from bernstein.core.tasks.checkpoint_retry import task_run_id
 
     run_id = task_run_id(task_id)
     sdd_dir = Path.cwd() / ".sdd"
     try:
-        journal_path = sdd_dir / "runs" / run_id / "journal.jsonl"
+        journal_path = run_journal_path(sdd_dir, run_id)
         if journal_path.exists():
             journal = EventJournal.resume(run_id, sdd_dir)
             return journal.head()
@@ -476,18 +476,20 @@ def _register_task_handle_tool(mcp: FastMCP[None]) -> None:
             return _validation_error_response(err)
         try:
             from bernstein.core.protocols.mcp.tasks_extension import RunHandle
-            from bernstein.core.replay.journal import JOURNAL_FILENAME, load_events
+            from bernstein.core.replay.journal import (
+                JournalPathError,
+                load_events,
+                run_journal_path,
+            )
 
             base = Path(workdir).resolve()
-            runs_root = (base / ".sdd" / "runs").resolve()
-            journal_path = (runs_root / run_id / JOURNAL_FILENAME).resolve()
-            # Realpath-containment check (CodeQL): a crafted run_id must not
-            # escape the runs root via ``..`` or an absolute path. A plain run
-            # id resolves to ``<runs_root>/<run_id>/journal.jsonl``; anything
-            # else is refused.
-            if journal_path.parent.parent != runs_root:
+            # Shared barrier rather than a local containment check, so this
+            # surface cannot drift from the rest of the run-journal readers.
+            try:
+                journal_path = run_journal_path(base / ".sdd", run_id)
+            except JournalPathError as exc:
                 return _error_response(
-                    ValueError("run_id escapes the runs directory"),
+                    exc,
                     hint="run_id must be a plain run identifier",
                 )
             events = load_events(journal_path)

--- a/tests/unit/test_context_capsule.py
+++ b/tests/unit/test_context_capsule.py
@@ -247,3 +247,33 @@ def test_any_field_change_changes_hash(field_name: str) -> None:
     base = _capsule()
     changed = replace(base, **{field_name: "CHANGED"})
     assert base.capsule_hash() != changed.capsule_hash()
+
+
+def test_verify_refuses_a_run_journal_planted_outside_the_runs_root(tmp_path: Path) -> None:
+    """The capsule verifier must not re-derive from a journal outside the tree.
+
+    Pins the routing of ``verify_context_capsule`` through the shared
+    containment barrier. The planted journal's Merkle chain is intact - it
+    is written by the real writer - so ``verify_journal`` cannot tell it
+    apart from ours; only containment can. Reverting the routing to a raw
+    join makes this verify a planted journal and fails the test.
+    """
+    import pytest
+
+    sdd = tmp_path / ".sdd"
+    capsule = _capsule()
+    _seal(sdd, capsule)
+
+    run_dir = sdd / "runs" / "run-1"
+    outside = tmp_path / "outside_runs"
+    run_dir.rename(outside)
+    try:
+        run_dir.symlink_to(outside, target_is_directory=True)
+    except OSError:  # pragma: no cover - platform dependent
+        pytest.skip("cannot create symlinks on this platform")
+
+    result = verify_context_capsule(sdd_dir=sdd, chain=_chain(sdd), task_id="task-1")
+
+    # Unrouted, this journal reads cleanly and the capsule verifies ok.
+    assert not result.ok
+    assert "invalid run id" in result.reason

--- a/tests/unit/test_intent_capsule.py
+++ b/tests/unit/test_intent_capsule.py
@@ -490,3 +490,46 @@ def test_capsule_store_roundtrip(tmp_path: Path) -> None:
     loaded = read_capsule(_sdd(tmp_path), _TASK_ID)
     assert loaded is not None
     assert loaded.to_dict() == cap.to_dict()
+
+
+def test_verify_refuses_a_run_journal_planted_outside_the_runs_root(tmp_path: Path) -> None:
+    """The conformance verifier must not read a journal outside ``<sdd>/runs``.
+
+    Pins the routing of ``verify_intent_conformance`` through the shared
+    containment barrier. The journal's own Merkle chain is intact here - it
+    is written by the real writer - so ``verify_journal`` cannot tell it
+    apart from ours; only containment can. Reverting the routing to a raw
+    join makes this verify a planted journal and fails the test.
+    """
+    import pytest
+
+    chain = _chain(tmp_path)
+    cap, _ = approve_and_capsule(
+        chain=chain,
+        sdd_dir=_sdd(tmp_path),
+        plan=_plan(),
+        task_id=_TASK_ID,
+        run_id=_RUN_ID,
+        allowed_action_classes=["fs.read", "fs.write", "git.commit"],
+        file_scope_globs=["src/pricing/**"],
+        permitted_adapters=["claude"],
+        egress_classes=[],
+        expiry_ts=1_700_100_000,
+    )
+    journal = _build_run_journal(tmp_path, capsule_h=capsule_hash(cap), drift=False)
+
+    # Move the whole run directory out of the runs root and symlink to it.
+    run_dir = journal.path.parent
+    outside = tmp_path / "outside_runs"
+    run_dir.rename(outside)
+    try:
+        run_dir.symlink_to(outside, target_is_directory=True)
+    except OSError:  # pragma: no cover - platform dependent
+        pytest.skip("cannot create symlinks on this platform")
+
+    result = verify_intent_conformance(sdd_dir=_sdd(tmp_path), chain=_chain(tmp_path), task_id=_TASK_ID)
+
+    # Unrouted, this journal reads cleanly and reports ok/conformant.
+    assert not result.ok
+    assert not result.conformant
+    assert "invalid run id" in result.reason

--- a/tests/unit/test_path_containment.py
+++ b/tests/unit/test_path_containment.py
@@ -247,7 +247,7 @@ def test_run_ledger_dir_refuses_symlink_escape(tmp_path: Path) -> None:
     root = default_ledger_root(tmp_path)
     outside = tmp_path / "outside"
     outside.mkdir()
-    (root / "run-evil").symlink_to(outside, target_is_directory=True)
+    _symlink_or_skip(root / "run-evil", outside)
 
     with pytest.raises(PathContainmentError):
         run_ledger_dir(tmp_path, "run-evil")

--- a/tests/unit/test_path_containment.py
+++ b/tests/unit/test_path_containment.py
@@ -9,6 +9,10 @@ nothing on disk outside the intended base, while an ordinary identifier
 still round-trips unchanged.
 """
 
+# The task journal path helper is module-private but is the exact barrier
+# under test, so it is exercised directly rather than through a caller.
+# pyright: reportPrivateUsage=false
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/tests/unit/test_path_containment.py
+++ b/tests/unit/test_path_containment.py
@@ -31,7 +31,10 @@ from bernstein.core.persistence.work_ledger import (
 )
 from bernstein.core.replay.journal import EventJournal, JournalPathError
 from bernstein.core.security.path_containment import (
+    MAX_PATH_BYTES,
+    MAX_SEGMENT_BYTES,
     PathContainmentError,
+    PathTooLongError,
     contained_path,
     validate_path_segment,
 )
@@ -79,23 +82,52 @@ def test_validate_path_segment_refuses_unsafe_ids(bad_id: str) -> None:
         validate_path_segment(bad_id, label="run id")
 
 
-@pytest.mark.parametrize(
-    "good_id",
-    ["run-1", "run_1", "task-T.1", "a", "fleet", "A" * 255, f"task-{'T' * 256}"],
-)
+@pytest.mark.parametrize("good_id", ["run-1", "run_1", "task-T.1", "a", "fleet", "A" * 255])
 def test_validate_path_segment_accepts_ordinary_ids(good_id: str) -> None:
-    """A plain identifier passes through unchanged.
-
-    The last case is a task run id derived from the longest task id
-    ``_TASK_ID_RE`` accepts; the segment bound must stay clear of it.
-    """
+    """A plain identifier passes through unchanged."""
     assert validate_path_segment(good_id) == good_id
 
 
-def test_validate_path_segment_refuses_absurdly_long_id() -> None:
-    """The sanity bound still rejects a segment nothing legitimate produces."""
+def test_validate_path_segment_refuses_segment_over_name_max() -> None:
+    """A component past NAME_MAX is a typed error, never an OSError.
+
+    Without this the filesystem raises ``OSError(ENAMETOOLONG)`` at open(),
+    which escapes the ``ValueError`` hierarchy every caller guards on and
+    turns a rejected identifier into a crash. Linux raises; macOS returns
+    False from ``is_file()``, so only the bound makes this deterministic
+    across platforms.
+    """
+    with pytest.raises(PathTooLongError):
+        validate_path_segment("A" * (MAX_SEGMENT_BYTES + 1))
+
+
+def test_segment_length_is_measured_in_bytes_not_characters() -> None:
+    """NAME_MAX is a byte limit, so a multi-byte name must not slip past.
+
+    The alphabet rejects non-ASCII anyway, so this pins the bound itself
+    rather than relying on the allowlist to be the only gate.
+    """
+    from bernstein.core.security.path_containment import MAX_SEGMENT_BYTES as limit
+
+    two_byte = "é"  # one char, two bytes encoded
+    assert len(two_byte) < len(two_byte.encode("utf-8"))
     with pytest.raises(PathContainmentError):
-        validate_path_segment("A" * 513)
+        validate_path_segment(two_byte * limit)
+
+
+def test_contained_path_refuses_path_over_path_max(tmp_path: Path) -> None:
+    """A legal-length segment under a deep base can still exceed PATH_MAX."""
+    deep = tmp_path
+    while len(str(deep).encode()) < MAX_PATH_BYTES:
+        deep = deep / ("d" * 200)
+    with pytest.raises(PathTooLongError):
+        contained_path(deep, "run-1")
+
+
+def test_path_too_long_is_a_containment_error_and_value_error() -> None:
+    """The capacity error stays inside the documented exception hierarchy."""
+    assert issubclass(PathTooLongError, PathContainmentError)
+    assert issubclass(PathTooLongError, ValueError)
 
 
 def test_contained_path_joins_under_base(tmp_path: Path) -> None:
@@ -401,6 +433,76 @@ def test_validated_canonical_lines_round_trips(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Run-journal readers (the run-level twin of the task-journal family)
+# ---------------------------------------------------------------------------
+
+
+def _plant_journal_outside_runs_root(tmp_path: Path) -> tuple[Path, str]:
+    """Build a verifying journal outside ``<sdd>/runs`` and return a hop to it.
+
+    The returned id is a relative traversal, the shape an operator can pass
+    on the CLI. The planted chain is written by the real writer, so
+    ``verify_journal`` recomputes it cleanly: only containment tells it
+    apart from one of ours.
+    """
+    sdd_dir = tmp_path / ".sdd"
+    (sdd_dir / "runs").mkdir(parents=True)
+    other = tmp_path / "other_sdd"
+    other.mkdir()
+    planted = EventJournal("legit", other)
+    planted.record("activity.result", stage="s1")
+    return sdd_dir, "../../other_sdd/runs/legit"
+
+
+def test_run_journal_path_refuses_traversal(tmp_path: Path) -> None:
+    """The shared run-journal helper refuses a traversal id."""
+    from bernstein.core.replay.journal import JournalPathError, run_journal_path
+
+    sdd_dir, hostile = _plant_journal_outside_runs_root(tmp_path)
+    with pytest.raises(JournalPathError):
+        run_journal_path(sdd_dir, hostile)
+
+
+def test_verify_run_activities_refuses_traversal_run_id(tmp_path: Path) -> None:
+    """The activity verifier must not verify a journal outside the tree.
+
+    Before routing, this returned ``found=True chain_ok=True`` for a journal
+    read entirely outside the runs root, while ``EventJournal`` refused the
+    byte-identical id.
+    """
+    from bernstein.core.orchestration.activity_modalities import verify_run_activities
+
+    sdd_dir, hostile = _plant_journal_outside_runs_root(tmp_path)
+    result = verify_run_activities(sdd_dir, run_id=hostile)
+    assert result.found is False
+    assert result.ok is False
+
+
+def test_fork_run_refuses_traversal_run_id(tmp_path: Path) -> None:
+    """Forking cannot seed a child run from a journal outside the tree.
+
+    Matched on the containment branch specifically: an unrouted ``fork_run``
+    also raises ``ForkError`` here, but only after reading the outside
+    journal and failing to find a snapshot in it. A bare ``raises`` would
+    pass either way and prove nothing.
+    """
+    from bernstein.core.replay.fork import ForkError, fork_run
+
+    sdd_dir, hostile = _plant_journal_outside_runs_root(tmp_path)
+    with pytest.raises(ForkError, match="cannot fork run"):
+        fork_run(sdd_dir, hostile, from_step=0, repo_root=tmp_path)
+
+
+def test_event_journal_still_refuses_the_same_id(tmp_path: Path) -> None:
+    """The writer and the readers now agree on what a run id may name."""
+    from bernstein.core.replay.journal import JournalPathError
+
+    sdd_dir, hostile = _plant_journal_outside_runs_root(tmp_path)
+    with pytest.raises(JournalPathError):
+        EventJournal(hostile, sdd_dir)
+
+
+# ---------------------------------------------------------------------------
 # Allowlist edge cases
 # ---------------------------------------------------------------------------
 
@@ -419,9 +521,10 @@ def test_validate_path_segment_refuses_trailing_newline(bad_id: str) -> None:
 def test_long_task_id_reads_empty_rather_than_raising(tmp_path: Path) -> None:
     """An id the module's own validator blesses must not blow up a read.
 
-    ``_TASK_ID_RE`` accepts 256 characters, and ``task_run_id`` prefixes
-    ``task-``. The segment bound must stay clear of that, so the read
-    degrades to "no journal" exactly as it did before the barrier.
+    ``_TASK_ID_RE`` accepts 256 characters and ``task_run_id`` prefixes
+    ``task-``, so the derived component exceeds NAME_MAX. That is a capacity
+    failure, not an attack: the read degrades to "no journal" exactly as a
+    missing file would, instead of raising ENAMETOOLONG out of the barrier.
     """
     from bernstein.core.evidence.run_artifacts import _validate_ids, read_artifact_rows
 
@@ -431,6 +534,41 @@ def test_long_task_id_reads_empty_rather_than_raising(tmp_path: Path) -> None:
     _validate_ids(task_id, "k")
 
     assert read_artifact_rows(sdd_dir, task_id) == []
+
+
+def test_long_task_id_degrades_across_the_routed_readers(tmp_path: Path) -> None:
+    """No routed reader turns an over-long id into a crash."""
+    from bernstein.core.replay import progress
+    from bernstein.core.tasks import checkpoint_retry
+
+    sdd_dir = tmp_path / ".sdd"
+    (sdd_dir / "runs").mkdir(parents=True)
+    task_id = "T" * 256
+
+    assert progress._load_task_journal_rows(sdd_dir, task_id) == []
+    assert checkpoint_retry.latest_checkpoint(sdd_dir, task_id) is None
+
+
+def test_containment_failure_is_never_swallowed_as_too_long(tmp_path: Path) -> None:
+    """Readers degrade on capacity, never on a containment violation.
+
+    The two failure modes share a base class, so this pins that the readers
+    catch only the narrow one - a symlink escape must still surface.
+    """
+    from bernstein.core.evidence.run_artifacts import read_artifact_rows
+    from bernstein.core.replay import progress
+    from bernstein.core.tasks import checkpoint_retry
+
+    sdd_dir, _ = _plant_symlinked_task_journal(tmp_path)
+
+    for call in (
+        lambda: read_artifact_rows(sdd_dir, "T-1"),
+        lambda: progress._load_task_journal_rows(sdd_dir, "T-1"),
+        lambda: checkpoint_retry.latest_checkpoint(sdd_dir, "T-1"),
+    ):
+        with pytest.raises(PathContainmentError) as caught:
+            call()
+        assert not isinstance(caught.value, PathTooLongError)
 
 
 def test_no_stray_writes_outside_base(tmp_path: Path) -> None:

--- a/tests/unit/test_path_containment.py
+++ b/tests/unit/test_path_containment.py
@@ -1,0 +1,293 @@
+"""Path-containment regression tests for identifier-derived filesystem paths.
+
+Run ids, task ids, mission ids, and ledger ids arrive from the dashboard
+API, the MCP surface, and the CLI, and each of them names a directory or a
+file under ``.sdd``. These tests pin the barrier at every site that turns
+such an identifier into a path: a traversal-shaped, absolute, or
+symlink-escaping identifier is refused with a typed error and leaves
+nothing on disk outside the intended base, while an ordinary identifier
+still round-trips unchanged.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.admission.ledger import admission_ledger_dir
+from bernstein.core.evidence.run_artifacts import _artifact_journal_path
+from bernstein.core.persistence.work_ledger import (
+    KIND_RUN_OPEN,
+    LedgerReader,
+    WorkLedger,
+    default_ledger_root,
+    run_ledger_dir,
+)
+from bernstein.core.replay.journal import EventJournal, JournalPathError
+from bernstein.core.security.path_containment import (
+    PathContainmentError,
+    contained_path,
+    validate_path_segment,
+)
+
+#: Identifiers that must never be accepted as a single path segment.
+HOSTILE_IDS = [
+    "..",
+    ".",
+    "../escape",
+    "../../etc",
+    "a/../../b",
+    "sub/dir",
+    "/etc/passwd",
+    "/absolute",
+    "",
+    "with space",
+    "semi;colon",
+    "null\x00byte",
+    "back\\slash",
+]
+
+
+# ---------------------------------------------------------------------------
+# The barrier itself
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad_id", HOSTILE_IDS)
+def test_validate_path_segment_refuses_unsafe_ids(bad_id: str) -> None:
+    """Every traversal or separator shape is refused with the typed error."""
+    with pytest.raises(PathContainmentError):
+        validate_path_segment(bad_id, label="run id")
+
+
+@pytest.mark.parametrize("good_id", ["run-1", "run_1", "task-T.1", "a", "fleet", "A" * 255])
+def test_validate_path_segment_accepts_ordinary_ids(good_id: str) -> None:
+    """A plain identifier passes through unchanged."""
+    assert validate_path_segment(good_id) == good_id
+
+
+def test_validate_path_segment_refuses_overlong_id() -> None:
+    """A name past NAME_MAX is refused as a typed error, not an OSError."""
+    with pytest.raises(PathContainmentError):
+        validate_path_segment("A" * 256)
+
+
+def test_contained_path_joins_under_base(tmp_path: Path) -> None:
+    """An ordinary id resolves to the expected child of the base."""
+    resolved = contained_path(tmp_path, "run-1", "journal.jsonl")
+    assert resolved == tmp_path / "run-1" / "journal.jsonl"
+
+
+@pytest.mark.parametrize("bad_id", HOSTILE_IDS)
+def test_contained_path_refuses_unsafe_ids(tmp_path: Path, bad_id: str) -> None:
+    """A hostile id never produces a path outside the base."""
+    with pytest.raises(PathContainmentError):
+        contained_path(tmp_path, bad_id)
+
+
+def test_contained_path_refuses_symlink_escape(tmp_path: Path) -> None:
+    """A well-named child that symlinks out of the base is refused.
+
+    This is the case the identifier allowlist cannot catch on its own: the
+    segment is a perfectly ordinary name, but following it leaves the tree.
+    """
+    base = tmp_path / "base"
+    base.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (base / "escape").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(PathContainmentError):
+        contained_path(base, "escape")
+
+
+def test_contained_path_allows_symlink_inside_base(tmp_path: Path) -> None:
+    """A symlink that stays inside the base is fine - containment, not a ban."""
+    base = tmp_path / "base"
+    (base / "real").mkdir(parents=True)
+    (base / "link").symlink_to(base / "real", target_is_directory=True)
+
+    assert contained_path(base, "link") == (base / "real").resolve()
+
+
+# ---------------------------------------------------------------------------
+# EventJournal (replay journal path)
+# ---------------------------------------------------------------------------
+
+
+def test_event_journal_round_trips_ordinary_run_id(tmp_path: Path) -> None:
+    """The on-disk layout for a legitimate run id is unchanged."""
+    journal = EventJournal(run_id="run-1", sdd_dir=tmp_path)
+    journal.record("task_claimed", task_id="T-1")
+
+    assert journal.path == tmp_path / "runs" / "run-1" / "journal.jsonl"
+    assert journal.path.is_file()
+    assert journal.event_count() == 1
+    assert journal.verify().ok
+
+
+@pytest.mark.parametrize("bad_id", ["..", ".", "../escape", "sub/dir", "/etc/passwd", ""])
+def test_event_journal_refuses_traversal_run_id(tmp_path: Path, bad_id: str) -> None:
+    """A traversal run id is refused and writes nothing outside the runs root."""
+    sdd_dir = tmp_path / ".sdd"
+    sdd_dir.mkdir()
+
+    with pytest.raises(JournalPathError):
+        EventJournal(run_id=bad_id, sdd_dir=sdd_dir)
+
+    assert list(tmp_path.iterdir()) == [sdd_dir]
+    assert not any(sdd_dir.rglob("journal.jsonl"))
+
+
+def test_event_journal_path_error_is_a_value_error(tmp_path: Path) -> None:
+    """Callers that guard on ValueError keep catching a bad run id."""
+    with pytest.raises(ValueError, match="unsafe run_id"):
+        EventJournal(run_id="../escape", sdd_dir=tmp_path)
+
+
+def test_event_journal_refuses_symlinked_run_dir(tmp_path: Path) -> None:
+    """A run directory symlinked out of the runs root is refused."""
+    sdd_dir = tmp_path / ".sdd"
+    runs_root = sdd_dir / "runs"
+    runs_root.mkdir(parents=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (runs_root / "run-evil").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(JournalPathError):
+        EventJournal(run_id="run-evil", sdd_dir=sdd_dir)
+
+    assert list(outside.iterdir()) == []
+
+
+# ---------------------------------------------------------------------------
+# Task artifact journal path
+# ---------------------------------------------------------------------------
+
+
+def test_artifact_journal_path_round_trips(tmp_path: Path) -> None:
+    """A normal task id maps to the same journal path as before."""
+    assert _artifact_journal_path(tmp_path, "T-1") == tmp_path / "runs" / "task-T-1" / "journal.jsonl"
+
+
+@pytest.mark.parametrize("bad_id", ["../../etc/passwd", "/etc/passwd", "a/../../b"])
+def test_artifact_journal_path_neutralises_traversal(tmp_path: Path, bad_id: str) -> None:
+    """A traversal task id is slugified and stays under the runs root."""
+    resolved = _artifact_journal_path(tmp_path, bad_id)
+    assert resolved.is_relative_to((tmp_path / "runs").resolve())
+
+
+def test_artifact_journal_path_refuses_symlinked_run_dir(tmp_path: Path) -> None:
+    """A symlinked task run directory is refused rather than followed."""
+    runs_root = tmp_path / "runs"
+    runs_root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (runs_root / "task-T-1").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(PathContainmentError):
+        _artifact_journal_path(tmp_path, "T-1")
+
+
+# ---------------------------------------------------------------------------
+# Work ledger directories and buckets
+# ---------------------------------------------------------------------------
+
+
+def test_run_ledger_dir_round_trips(tmp_path: Path) -> None:
+    """A legitimate run id keeps the documented ledger layout."""
+    assert run_ledger_dir(tmp_path, "run-a") == tmp_path / "runtime" / "ledger" / "run-a"
+
+
+@pytest.mark.parametrize("bad_id", HOSTILE_IDS)
+def test_run_ledger_dir_refuses_unsafe_run_id(tmp_path: Path, bad_id: str) -> None:
+    """A hostile run (or mission) id never escapes the ledger root."""
+    with pytest.raises(PathContainmentError):
+        run_ledger_dir(tmp_path, bad_id)
+
+
+def test_run_ledger_dir_refuses_symlink_escape(tmp_path: Path) -> None:
+    """A ledger directory symlinked out of the root is refused."""
+    root = default_ledger_root(tmp_path)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (root / "run-evil").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(PathContainmentError):
+        run_ledger_dir(tmp_path, "run-evil")
+
+    assert list(outside.iterdir()) == []
+
+
+def test_ledger_round_trips_through_reader(tmp_path: Path) -> None:
+    """Writer and reader agree on the bucket for an ordinary ledger dir."""
+    ledger_dir = run_ledger_dir(tmp_path, "run-a")
+    ledger = WorkLedger.open(ledger_dir)
+    ledger.append(kind=KIND_RUN_OPEN, payload={"goal": "ship it"})
+    ledger.close()
+
+    reader = LedgerReader(ledger_dir)
+    assert reader.exists()
+    assert reader.bucket_path == ledger_dir / "000000.jsonl"
+    assert [entry.kind for entry in reader.entries()] == [KIND_RUN_OPEN]
+    assert reader.verify().ok
+
+
+def test_ledger_reader_refuses_symlinked_bucket(tmp_path: Path) -> None:
+    """A bucket file symlinked out of the ledger directory is refused.
+
+    Without the barrier a reader would follow the link and disclose the
+    target file's bytes as if they were ledger rows.
+    """
+    ledger_dir = tmp_path / "ledger"
+    ledger_dir.mkdir()
+    secret = tmp_path / "secret.jsonl"
+    secret.write_text("{}\n", encoding="utf-8")
+    (ledger_dir / "000000.jsonl").symlink_to(secret)
+
+    with pytest.raises(PathContainmentError):
+        LedgerReader(ledger_dir)
+
+    with pytest.raises(PathContainmentError):
+        WorkLedger.open(ledger_dir)
+
+    assert secret.read_text(encoding="utf-8") == "{}\n"
+
+
+# ---------------------------------------------------------------------------
+# Admission ledger directory
+# ---------------------------------------------------------------------------
+
+
+def test_admission_ledger_dir_round_trips(tmp_path: Path) -> None:
+    """The default admission ledger keeps its documented location."""
+    assert admission_ledger_dir(tmp_path) == tmp_path / "runtime" / "admission" / "fleet"
+
+
+@pytest.mark.parametrize("bad_id", HOSTILE_IDS)
+def test_admission_ledger_dir_refuses_unsafe_id(tmp_path: Path, bad_id: str) -> None:
+    """A hostile ledger id never escapes the admission root."""
+    with pytest.raises(PathContainmentError):
+        admission_ledger_dir(tmp_path, bad_id)
+
+
+def test_no_stray_writes_outside_base(tmp_path: Path) -> None:
+    """A refused identifier creates nothing outside the intended base.
+
+    ``default_ledger_root`` legitimately creates its own root on first use;
+    what must never appear is a directory named after the hostile id, or
+    anything at all beside the ``.sdd`` tree.
+    """
+    sdd_dir = tmp_path / ".sdd"
+    sdd_dir.mkdir()
+
+    for bad_id in HOSTILE_IDS:
+        with pytest.raises(PathContainmentError):
+            run_ledger_dir(sdd_dir, bad_id)
+        with pytest.raises(PathContainmentError):
+            admission_ledger_dir(sdd_dir, bad_id)
+
+    assert [p.name for p in tmp_path.iterdir()] == [".sdd"]
+    created = sorted(str(p.relative_to(sdd_dir)) for p in sdd_dir.rglob("*"))
+    assert created == ["runtime", str(Path("runtime") / "ledger")]

--- a/tests/unit/test_path_containment.py
+++ b/tests/unit/test_path_containment.py
@@ -53,6 +53,19 @@ HOSTILE_IDS = [
 ]
 
 
+def _symlink_or_skip(link: Path, target: Path, *, directory: bool = True) -> None:
+    """Create *link* pointing at *target*, or skip where that is not allowed.
+
+    Unprivileged Windows runners cannot create symlinks, and the symlink
+    leg of these tests is the only part that needs one; the allowlist leg
+    still runs everywhere.
+    """
+    try:
+        link.symlink_to(target, target_is_directory=directory)
+    except OSError:  # pragma: no cover - platform dependent
+        pytest.skip("cannot create symlinks on this platform")
+
+
 # ---------------------------------------------------------------------------
 # The barrier itself
 # ---------------------------------------------------------------------------
@@ -80,7 +93,7 @@ def test_validate_path_segment_refuses_overlong_id() -> None:
 def test_contained_path_joins_under_base(tmp_path: Path) -> None:
     """An ordinary id resolves to the expected child of the base."""
     resolved = contained_path(tmp_path, "run-1", "journal.jsonl")
-    assert resolved == tmp_path / "run-1" / "journal.jsonl"
+    assert resolved == (tmp_path / "run-1" / "journal.jsonl").resolve()
 
 
 @pytest.mark.parametrize("bad_id", HOSTILE_IDS)
@@ -100,7 +113,7 @@ def test_contained_path_refuses_symlink_escape(tmp_path: Path) -> None:
     base.mkdir()
     outside = tmp_path / "outside"
     outside.mkdir()
-    (base / "escape").symlink_to(outside, target_is_directory=True)
+    _symlink_or_skip(base / "escape", outside)
 
     with pytest.raises(PathContainmentError):
         contained_path(base, "escape")
@@ -118,7 +131,7 @@ def test_contained_path_refuses_sibling_prefix(tmp_path: Path) -> None:
     base.mkdir()
     sibling = tmp_path / "base-evil"
     sibling.mkdir()
-    (base / "link").symlink_to(sibling, target_is_directory=True)
+    _symlink_or_skip(base / "link", sibling)
 
     with pytest.raises(PathContainmentError):
         contained_path(base, "link")
@@ -128,7 +141,7 @@ def test_contained_path_allows_symlink_inside_base(tmp_path: Path) -> None:
     """A symlink that stays inside the base is fine - containment, not a ban."""
     base = tmp_path / "base"
     (base / "real").mkdir(parents=True)
-    (base / "link").symlink_to(base / "real", target_is_directory=True)
+    _symlink_or_skip(base / "link", base / "real")
 
     assert contained_path(base, "link") == (base / "real").resolve()
 
@@ -143,7 +156,7 @@ def test_event_journal_round_trips_ordinary_run_id(tmp_path: Path) -> None:
     journal = EventJournal(run_id="run-1", sdd_dir=tmp_path)
     journal.record("task_claimed", task_id="T-1")
 
-    assert journal.path == tmp_path / "runs" / "run-1" / "journal.jsonl"
+    assert journal.path == (tmp_path / "runs" / "run-1" / "journal.jsonl").resolve()
     assert journal.path.is_file()
     assert journal.event_count() == 1
     assert journal.verify().ok
@@ -175,7 +188,7 @@ def test_event_journal_refuses_symlinked_run_dir(tmp_path: Path) -> None:
     runs_root.mkdir(parents=True)
     outside = tmp_path / "outside"
     outside.mkdir()
-    (runs_root / "run-evil").symlink_to(outside, target_is_directory=True)
+    _symlink_or_skip(runs_root / "run-evil", outside)
 
     with pytest.raises(JournalPathError):
         EventJournal(run_id="run-evil", sdd_dir=sdd_dir)
@@ -190,7 +203,7 @@ def test_event_journal_refuses_symlinked_run_dir(tmp_path: Path) -> None:
 
 def test_artifact_journal_path_round_trips(tmp_path: Path) -> None:
     """A normal task id maps to the same journal path as before."""
-    assert _artifact_journal_path(tmp_path, "T-1") == tmp_path / "runs" / "task-T-1" / "journal.jsonl"
+    assert _artifact_journal_path(tmp_path, "T-1") == (tmp_path / "runs" / "task-T-1" / "journal.jsonl").resolve()
 
 
 @pytest.mark.parametrize("bad_id", ["../../etc/passwd", "/etc/passwd", "a/../../b"])
@@ -206,7 +219,7 @@ def test_artifact_journal_path_refuses_symlinked_run_dir(tmp_path: Path) -> None
     runs_root.mkdir()
     outside = tmp_path / "outside"
     outside.mkdir()
-    (runs_root / "task-T-1").symlink_to(outside, target_is_directory=True)
+    _symlink_or_skip(runs_root / "task-T-1", outside)
 
     with pytest.raises(PathContainmentError):
         _artifact_journal_path(tmp_path, "T-1")
@@ -219,7 +232,7 @@ def test_artifact_journal_path_refuses_symlinked_run_dir(tmp_path: Path) -> None
 
 def test_run_ledger_dir_round_trips(tmp_path: Path) -> None:
     """A legitimate run id keeps the documented ledger layout."""
-    assert run_ledger_dir(tmp_path, "run-a") == tmp_path / "runtime" / "ledger" / "run-a"
+    assert run_ledger_dir(tmp_path, "run-a") == (tmp_path / "runtime" / "ledger" / "run-a").resolve()
 
 
 @pytest.mark.parametrize("bad_id", HOSTILE_IDS)
@@ -266,7 +279,7 @@ def test_ledger_reader_refuses_symlinked_bucket(tmp_path: Path) -> None:
     ledger_dir.mkdir()
     secret = tmp_path / "secret.jsonl"
     secret.write_text("{}\n", encoding="utf-8")
-    (ledger_dir / "000000.jsonl").symlink_to(secret)
+    _symlink_or_skip(ledger_dir / "000000.jsonl", secret, directory=False)
 
     with pytest.raises(PathContainmentError):
         LedgerReader(ledger_dir)
@@ -284,7 +297,7 @@ def test_ledger_reader_refuses_symlinked_bucket(tmp_path: Path) -> None:
 
 def test_admission_ledger_dir_round_trips(tmp_path: Path) -> None:
     """The default admission ledger keeps its documented location."""
-    assert admission_ledger_dir(tmp_path) == tmp_path / "runtime" / "admission" / "fleet"
+    assert admission_ledger_dir(tmp_path) == (tmp_path / "runtime" / "admission" / "fleet").resolve()
 
 
 @pytest.mark.parametrize("bad_id", HOSTILE_IDS)

--- a/tests/unit/test_path_containment.py
+++ b/tests/unit/test_path_containment.py
@@ -642,41 +642,51 @@ def _source_files() -> list[Path]:
     return sorted(src.rglob("*.py"))
 
 
-#: Sites that join a runs-root path from a name obtained by iterating the
-#: directory itself. The name comes from the filesystem, never from a caller,
-#: so there is no external identifier to contain. Each entry must stay
-#: justified; adding to this list is how a reviewer sees the exception.
-_ITERATION_DERIVED_ALLOWLIST = {
-    "core/evidence/run_artifacts.py",
-    "core/orchestration/schedule_fire_record.py",
-    "core/replay/review_board.py",
-    "cli/commands/advanced_cmd.py",
-}
+#: Helpers that ARE the barrier, so a journal filename on their own lines is
+#: the routed construction rather than a bypass of it.
+_BARRIER_CALLS = (
+    "contained_path(",
+    "run_journal_path(",
+    "task_journal_path(",
+    "contained_run_journal(",
+)
 
 
 def test_no_unrouted_journal_path_construction() -> None:
-    """No source file may build a journal path by hand.
+    """No source file may build a journal path outside the barrier.
 
     The escape this PR closes is reachable from any raw
-    ``<base> / <run_id> / journal.jsonl`` join, so the guarantee is only as
+    ``<base> / <name> / journal.jsonl`` join, so the guarantee is only as
     good as the claim that no such join remains. This asserts that claim
     mechanically instead of trusting a hand-kept list: a new unrouted reader
     fails here the moment it is added.
+
+    There is deliberately no allowlist. Sites that obtain the directory name
+    by iterating the runs root are covered too: iteration proves the name is
+    a single innocent component, but an entry with an ordinary name can
+    still be a symlink pointing outside the root, and only resolution
+    catches that. An exemption here would cover exactly the half of the
+    threat iteration already handles.
     """
-    pattern = re.compile(
-        r"/\s*(?:run_id|task_id|_task_run_id\(|task_run_id\()[^\n]*?/\s*(?:JOURNAL_FILENAME|\"journal\.jsonl\"|_REPLAY_JSONL)"
-    )
+    # The word boundary goes INSIDE each alternative: a trailing \b after
+    # the quoted literal can never match, because the pattern ends on a
+    # quote and \b there demands a following word character. That hole made
+    # every `x / "journal.jsonl"` form invisible to this scan.
+    pattern = re.compile(r"/\s*(?:JOURNAL_FILENAME\b|\"journal\.jsonl\"|_REPLAY_JSONL\b)")
     offenders: list[str] = []
     for path in _source_files():
         rel = path.relative_to(path.parents[1]).as_posix()
         for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
-            if pattern.search(line) and rel not in _ITERATION_DERIVED_ALLOWLIST:
-                offenders.append(f"{rel}:{lineno}: {line.strip()}")
+            if not pattern.search(line):
+                continue
+            if any(call in line for call in _BARRIER_CALLS):
+                continue
+            offenders.append(f"{rel}:{lineno}: {line.strip()}")
 
     assert not offenders, (
-        "these sites build a journal path from an identifier without the "
-        "containment barrier; route them through run_journal_path / "
-        "task_journal_path / contained_path:\n  " + "\n  ".join(offenders)
+        "these sites build a journal path without the containment barrier; "
+        "route them through run_journal_path / task_journal_path / "
+        "contained_run_journal / contained_path:\n  " + "\n  ".join(offenders)
     )
 
 
@@ -781,3 +791,49 @@ def test_verify_run_reports_an_unusable_run_id_without_losing_the_audit_finding(
     assert result.ledger_ok is False
     assert any("unusable run id" in e for e in result.errors)
     assert result.ok is False
+
+
+# ---------------------------------------------------------------------------
+# Sweeps: iteration gives an innocent NAME, not an innocent TARGET
+# ---------------------------------------------------------------------------
+
+
+def test_sweeps_skip_a_symlinked_run_directory_with_an_innocent_name(tmp_path: Path) -> None:
+    """A run directory whose name is ordinary but which points outside is skipped.
+
+    Iterating the runs root proves the entry name is a single component with
+    no ``..`` and no separator. It proves nothing about what the entry
+    resolves to. This plants a directory called ``run-ok`` - an entirely
+    legitimate name - that is a symlink to a tree outside the runs root, and
+    asserts every sweeping reader declines to read through it.
+    """
+    from bernstein.cli.commands.advanced_cmd import _replay_find_run_dirs
+    from bernstein.core.evidence.run_artifacts import live_artifact_content_hashes
+    from bernstein.core.replay.review_board import list_board_runs
+
+    sdd_dir = tmp_path / ".sdd"
+    runs_root = sdd_dir / "runs"
+    runs_root.mkdir(parents=True)
+
+    # A genuine run inside the root, so the sweeps have real work to do.
+    honest = EventJournal("run-honest", sdd_dir)
+    honest.record("tool.call", tool="Read")
+
+    # A planted run outside the root, reachable only through the symlink.
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    planted = EventJournal("planted", elsewhere)
+    planted.record("artifact_posted", task_id="T-1", key="k", content_hash="sha256:evil")
+    _symlink_or_skip(runs_root / "run-ok", planted.path.parent)
+
+    assert (runs_root / "run-ok").is_dir(), "symlink should look like an ordinary run dir"
+    assert (runs_root / "run-ok" / "journal.jsonl").is_file(), "and its journal should look readable"
+
+    assert "run-ok" not in list_board_runs(sdd_dir)
+    assert "run-honest" in list_board_runs(sdd_dir)
+
+    assert "sha256:evil" not in live_artifact_content_hashes(sdd_dir)
+
+    replay_dirs = {d.name for d in _replay_find_run_dirs(runs_root)}
+    assert "run-ok" not in replay_dirs
+    assert "run-honest" in replay_dirs

--- a/tests/unit/test_path_containment.py
+++ b/tests/unit/test_path_containment.py
@@ -15,7 +15,9 @@ still round-trips unchanged.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -86,6 +88,39 @@ def test_validate_path_segment_refuses_unsafe_ids(bad_id: str) -> None:
 def test_validate_path_segment_accepts_ordinary_ids(good_id: str) -> None:
     """A plain identifier passes through unchanged."""
     assert validate_path_segment(good_id) == good_id
+
+
+def test_max_segment_bytes_matches_posix_name_max() -> None:
+    """The bound must be NAME_MAX, not merely "some large number".
+
+    Widening it silently reintroduces the ENAMETOOLONG crash this bound was
+    added to stop, so the value itself is the contract, not just the
+    presence of a check.
+    """
+    assert MAX_SEGMENT_BYTES == 255
+
+
+def test_segment_at_name_max_is_accepted_and_one_over_is_refused() -> None:
+    """Pins the exact boundary, so widening or narrowing the bound fails."""
+    assert validate_path_segment("A" * MAX_SEGMENT_BYTES) == "A" * MAX_SEGMENT_BYTES
+    with pytest.raises(PathTooLongError):
+        validate_path_segment("A" * (MAX_SEGMENT_BYTES + 1))
+
+
+def test_derived_task_run_id_over_name_max_is_refused_by_the_bound() -> None:
+    """The real derivation that motivated the bound trips it deterministically.
+
+    ``_TASK_ID_RE`` accepts 256 characters and ``task_run_id`` adds a
+    ``task-`` prefix, giving a 261-byte component. This asserts the barrier
+    itself rejects it rather than relying on a filesystem probe, which
+    returns False on macOS but raises ENAMETOOLONG on Linux.
+    """
+    from bernstein.core.tasks.checkpoint_retry import task_run_id
+
+    segment = task_run_id("T" * 256)
+    assert len(segment.encode()) > MAX_SEGMENT_BYTES
+    with pytest.raises(PathTooLongError):
+        validate_path_segment(segment)
 
 
 def test_validate_path_segment_refuses_segment_over_name_max() -> None:
@@ -590,3 +625,159 @@ def test_no_stray_writes_outside_base(tmp_path: Path) -> None:
     assert [p.name for p in tmp_path.iterdir()] == [".sdd"]
     created = sorted(str(p.relative_to(sdd_dir)) for p in sdd_dir.rglob("*"))
     assert created == ["runtime", str(Path("runtime") / "ledger")]
+
+
+# ---------------------------------------------------------------------------
+# Sink closure: the set of journal readers must stay routed
+# ---------------------------------------------------------------------------
+#
+# The barrier tests above prove the barrier works. These prove the ROUTING:
+# that every reader actually goes through it. Without them a new call site
+# can join a journal path by hand and silently reopen the escape, which is
+# exactly what happened twice on this branch.
+
+
+def _source_files() -> list[Path]:
+    src = Path(__file__).resolve().parents[2] / "src" / "bernstein"
+    return sorted(src.rglob("*.py"))
+
+
+#: Sites that join a runs-root path from a name obtained by iterating the
+#: directory itself. The name comes from the filesystem, never from a caller,
+#: so there is no external identifier to contain. Each entry must stay
+#: justified; adding to this list is how a reviewer sees the exception.
+_ITERATION_DERIVED_ALLOWLIST = {
+    "core/evidence/run_artifacts.py",
+    "core/orchestration/schedule_fire_record.py",
+    "core/replay/review_board.py",
+    "cli/commands/advanced_cmd.py",
+}
+
+
+def test_no_unrouted_journal_path_construction() -> None:
+    """No source file may build a journal path by hand.
+
+    The escape this PR closes is reachable from any raw
+    ``<base> / <run_id> / journal.jsonl`` join, so the guarantee is only as
+    good as the claim that no such join remains. This asserts that claim
+    mechanically instead of trusting a hand-kept list: a new unrouted reader
+    fails here the moment it is added.
+    """
+    pattern = re.compile(
+        r"/\s*(?:run_id|task_id|_task_run_id\(|task_run_id\()[^\n]*?/\s*(?:JOURNAL_FILENAME|\"journal\.jsonl\"|_REPLAY_JSONL)"
+    )
+    offenders: list[str] = []
+    for path in _source_files():
+        rel = path.relative_to(path.parents[1]).as_posix()
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if pattern.search(line) and rel not in _ITERATION_DERIVED_ALLOWLIST:
+                offenders.append(f"{rel}:{lineno}: {line.strip()}")
+
+    assert not offenders, (
+        "these sites build a journal path from an identifier without the "
+        "containment barrier; route them through run_journal_path / "
+        "task_journal_path / contained_path:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_every_run_journal_reader_refuses_a_planted_journal(tmp_path: Path) -> None:
+    """Enumerate the run-journal readers; each must refuse a planted journal.
+
+    One planted symlink, every reader. A reader that starts following it
+    again fails here even if its own dedicated test is removed.
+    """
+    from bernstein.cli.commands import thread_cmd
+    from bernstein.core.orchestration import escalation
+    from bernstein.core.orchestration.activity_modalities import verify_run_activities
+    from bernstein.core.replay import review_board
+    from bernstein.core.replay.fork import ForkError, fork_run
+    from bernstein.core.replay.journal import run_journal_path
+
+    sdd_dir = tmp_path / ".sdd"
+    runs_root = sdd_dir / "runs"
+    runs_root.mkdir(parents=True)
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    planted = EventJournal("planted", elsewhere)
+    planted.record("activity.result", stage="s1")
+    _symlink_or_skip(runs_root / "planted", planted.path.parent)
+    assert planted.path.is_file()
+
+    # Each entry: (name, call, predicate that the planted journal was refused).
+    checks: list[tuple[str, Any]] = [
+        ("run_journal_path", lambda: run_journal_path(sdd_dir, "planted")),
+        ("escalation._journal_path", lambda: escalation._journal_path(sdd_dir, "planted")),
+        ("review_board.project_run", lambda: review_board.project_run(sdd_dir, "planted")),
+        ("thread_cmd.thread_verify", lambda: thread_cmd.thread_verify(run_id="planted", sdd_dir=sdd_dir, as_json=True)),
+        ("verify_run_activities", lambda: verify_run_activities(sdd_dir, run_id="planted")),
+        ("fork_run", lambda: fork_run(sdd_dir, "planted", from_step=0, repo_root=tmp_path)),
+    ]
+
+    followed: list[str] = []
+    for name, call in checks:
+        try:
+            result = call()
+        except (PathContainmentError, ForkError):
+            continue
+        # A reader may report rather than raise, but it must not report a
+        # pass or hand back a projection built from the planted journal.
+        if name == "review_board.project_run" and result is None:
+            continue
+        if name == "thread_cmd.thread_verify" and result != 0:
+            continue
+        if name == "verify_run_activities" and not result.found:
+            continue
+        followed.append(f"{name} -> {result!r}")
+
+    assert not followed, "these readers followed a journal planted outside the runs root:\n  " + "\n  ".join(followed)
+
+
+# ---------------------------------------------------------------------------
+# A verifier reports; it does not raise
+# ---------------------------------------------------------------------------
+
+
+def _tampered_audit_chain(root: Path) -> None:
+    """Build a real audit chain under *root* and tamper one record in place."""
+    from bernstein.core.security.audit_chain import AuditChainStore
+
+    audit_dir = root / ".sdd" / "audit"
+    audit_dir.mkdir(parents=True)
+    chain = AuditChainStore(audit_dir)
+    for transition in ("submitted", "done"):
+        chain.log(
+            event_type="run.lifecycle",
+            resource_type="run",
+            resource_id="r",
+            details={"run_id": "r", "transition": transition},
+            actor="tester",
+        )
+    log_file = sorted(audit_dir.glob("*.jsonl"))[0]
+    lines = log_file.read_text(encoding="utf-8").splitlines()
+    lines[1] = lines[1].replace("done", "TAMPERED")
+    log_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+@pytest.mark.parametrize("bad_run_id", ["r:1", "..", "", "../escape"])
+def test_verify_run_reports_an_unusable_run_id_without_losing_the_audit_finding(
+    tmp_path: Path,
+    bad_run_id: str,
+) -> None:
+    """An identifier check must not destroy a computed audit-tamper finding.
+
+    ``verify_run`` verifies the audit chain first and the ledger second. If
+    the ledger step raises on a bad run id, the tamper finding it already
+    computed is thrown away and the operator gets a traceback instead of the
+    verdict - strictly worse than not having checked at all.
+    """
+    from bernstein.core.run_service.verify import verify_run
+
+    _tampered_audit_chain(tmp_path)
+
+    result = verify_run(tmp_path, bad_run_id)
+
+    assert result.audit_ok is False, "the audit-tamper finding must survive"
+    assert any(e.startswith("audit:") for e in result.errors)
+    assert result.ledger_ok is False
+    assert any("unusable run id" in e for e in result.errors)
+    assert result.ok is False

--- a/tests/unit/test_path_containment.py
+++ b/tests/unit/test_path_containment.py
@@ -106,6 +106,24 @@ def test_contained_path_refuses_symlink_escape(tmp_path: Path) -> None:
         contained_path(base, "escape")
 
 
+def test_contained_path_requires_a_segment(tmp_path: Path) -> None:
+    """The result must be a strict descendant, so a bare base is refused."""
+    with pytest.raises(PathContainmentError):
+        contained_path(tmp_path)
+
+
+def test_contained_path_refuses_sibling_prefix(tmp_path: Path) -> None:
+    """A sibling sharing the base's name prefix must not pass containment."""
+    base = tmp_path / "base"
+    base.mkdir()
+    sibling = tmp_path / "base-evil"
+    sibling.mkdir()
+    (base / "link").symlink_to(sibling, target_is_directory=True)
+
+    with pytest.raises(PathContainmentError):
+        contained_path(base, "link")
+
+
 def test_contained_path_allows_symlink_inside_base(tmp_path: Path) -> None:
     """A symlink that stays inside the base is fine - containment, not a ban."""
     base = tmp_path / "base"

--- a/tests/unit/test_path_containment.py
+++ b/tests/unit/test_path_containment.py
@@ -27,6 +27,7 @@ from bernstein.core.persistence.work_ledger import (
     WorkLedger,
     default_ledger_root,
     run_ledger_dir,
+    validated_canonical_lines,
 )
 from bernstein.core.replay.journal import EventJournal, JournalPathError
 from bernstein.core.security.path_containment import (
@@ -78,16 +79,23 @@ def test_validate_path_segment_refuses_unsafe_ids(bad_id: str) -> None:
         validate_path_segment(bad_id, label="run id")
 
 
-@pytest.mark.parametrize("good_id", ["run-1", "run_1", "task-T.1", "a", "fleet", "A" * 255])
+@pytest.mark.parametrize(
+    "good_id",
+    ["run-1", "run_1", "task-T.1", "a", "fleet", "A" * 255, f"task-{'T' * 256}"],
+)
 def test_validate_path_segment_accepts_ordinary_ids(good_id: str) -> None:
-    """A plain identifier passes through unchanged."""
+    """A plain identifier passes through unchanged.
+
+    The last case is a task run id derived from the longest task id
+    ``_TASK_ID_RE`` accepts; the segment bound must stay clear of it.
+    """
     assert validate_path_segment(good_id) == good_id
 
 
-def test_validate_path_segment_refuses_overlong_id() -> None:
-    """A name past NAME_MAX is refused as a typed error, not an OSError."""
+def test_validate_path_segment_refuses_absurdly_long_id() -> None:
+    """The sanity bound still rejects a segment nothing legitimate produces."""
     with pytest.raises(PathContainmentError):
-        validate_path_segment("A" * 256)
+        validate_path_segment("A" * 513)
 
 
 def test_contained_path_joins_under_base(tmp_path: Path) -> None:
@@ -206,13 +214,6 @@ def test_artifact_journal_path_round_trips(tmp_path: Path) -> None:
     assert _artifact_journal_path(tmp_path, "T-1") == (tmp_path / "runs" / "task-T-1" / "journal.jsonl").resolve()
 
 
-@pytest.mark.parametrize("bad_id", ["../../etc/passwd", "/etc/passwd", "a/../../b"])
-def test_artifact_journal_path_neutralises_traversal(tmp_path: Path, bad_id: str) -> None:
-    """A traversal task id is slugified and stays under the runs root."""
-    resolved = _artifact_journal_path(tmp_path, bad_id)
-    assert resolved.is_relative_to((tmp_path / "runs").resolve())
-
-
 def test_artifact_journal_path_refuses_symlinked_run_dir(tmp_path: Path) -> None:
     """A symlinked task run directory is refused rather than followed."""
     runs_root = tmp_path / "runs"
@@ -305,6 +306,131 @@ def test_admission_ledger_dir_refuses_unsafe_id(tmp_path: Path, bad_id: str) -> 
     """A hostile ledger id never escapes the admission root."""
     with pytest.raises(PathContainmentError):
         admission_ledger_dir(tmp_path, bad_id)
+
+
+# ---------------------------------------------------------------------------
+# Every reader of a task journal, not just the artifact one
+# ---------------------------------------------------------------------------
+
+
+def _plant_symlinked_task_journal(tmp_path: Path) -> tuple[Path, Path]:
+    """Point ``<sdd>/runs/task-T-1`` at an attacker-controlled journal.
+
+    The planted chain is built with the real writer, so it verifies: a
+    ``verify_journal`` recompute is unkeyed, and whoever can plant the
+    symlink can also plant a self-consistent journal. Only containment
+    distinguishes it from ours.
+    """
+    sdd_dir = tmp_path / ".sdd"
+    runs_root = sdd_dir / "runs"
+    runs_root.mkdir(parents=True)
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    planted = EventJournal("planted", elsewhere)
+    planted.record("checkpoint_recorded", task_id="T-1", checkpoint_id="cp-evil")
+    _symlink_or_skip(runs_root / "task-T-1", planted.path.parent)
+    return sdd_dir, planted.path
+
+
+def test_task_journal_path_refuses_symlinked_run_dir(tmp_path: Path) -> None:
+    """The shared helper every task-journal reader uses is contained."""
+    from bernstein.core.tasks.checkpoint_retry import task_journal_path
+
+    sdd_dir, _ = _plant_symlinked_task_journal(tmp_path)
+    with pytest.raises(PathContainmentError):
+        task_journal_path(sdd_dir, "T-1")
+
+
+def test_progress_rows_refuse_symlinked_run_dir(tmp_path: Path) -> None:
+    """The dashboard progress projection cannot read a planted journal."""
+    from bernstein.core.replay import progress
+
+    sdd_dir, _ = _plant_symlinked_task_journal(tmp_path)
+    with pytest.raises(PathContainmentError):
+        progress._load_task_journal_rows(sdd_dir, "T-1")
+
+
+def test_latest_checkpoint_refuses_symlinked_run_dir(tmp_path: Path) -> None:
+    """A planted checkpoint journal cannot fuel a warm resume."""
+    from bernstein.core.tasks import checkpoint_retry
+
+    sdd_dir, _ = _plant_symlinked_task_journal(tmp_path)
+    with pytest.raises(PathContainmentError):
+        checkpoint_retry.latest_checkpoint(sdd_dir, "T-1")
+
+
+def test_suspension_journal_path_refuses_symlinked_run_dir(tmp_path: Path) -> None:
+    """The suspension row reader resolves through the same barrier."""
+    from bernstein.core.tasks import suspension
+
+    sdd_dir, _ = _plant_symlinked_task_journal(tmp_path)
+    with pytest.raises(PathContainmentError):
+        suspension._journal_path(sdd_dir, "T-1")
+
+
+def test_validated_canonical_lines_refuses_symlinked_bucket(tmp_path: Path) -> None:
+    """The git-anchor export must not read a foreign file's bytes.
+
+    ``validated_canonical_lines`` runs before the guarded reader in
+    ``anchor_ledger``, so an unguarded read here would derive the anchored
+    head hash from the symlink target.
+    """
+    real = tmp_path / "real"
+    ledger = WorkLedger.open(real)
+    ledger.append(kind=KIND_RUN_OPEN, payload={"goal": "private"})
+    ledger.close()
+
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    _symlink_or_skip(victim / "000000.jsonl", real / "000000.jsonl", directory=False)
+
+    with pytest.raises(PathContainmentError):
+        validated_canonical_lines(victim)
+
+
+def test_validated_canonical_lines_round_trips(tmp_path: Path) -> None:
+    """An ordinary ledger still exports its validated lines and head."""
+    ledger_dir = run_ledger_dir(tmp_path, "run-a")
+    ledger = WorkLedger.open(ledger_dir)
+    entry = ledger.append(kind=KIND_RUN_OPEN, payload={"goal": "ship it"})
+    ledger.close()
+
+    lines, head = validated_canonical_lines(ledger_dir)
+    assert len(lines) == 1
+    assert head == entry.entry_hash
+
+
+# ---------------------------------------------------------------------------
+# Allowlist edge cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad_id", ["..\n", ".\n", "run-1\n"])
+def test_validate_path_segment_refuses_trailing_newline(bad_id: str) -> None:
+    """``$`` would accept a trailing newline; the allowlist anchors on ``\\Z``.
+
+    ``"..\\n"`` is the sharp case: it is not equal to ``".."``, so the
+    reserved-segment guard does not catch it either.
+    """
+    with pytest.raises(PathContainmentError):
+        validate_path_segment(bad_id)
+
+
+def test_long_task_id_reads_empty_rather_than_raising(tmp_path: Path) -> None:
+    """An id the module's own validator blesses must not blow up a read.
+
+    ``_TASK_ID_RE`` accepts 256 characters, and ``task_run_id`` prefixes
+    ``task-``. The segment bound must stay clear of that, so the read
+    degrades to "no journal" exactly as it did before the barrier.
+    """
+    from bernstein.core.evidence.run_artifacts import _validate_ids, read_artifact_rows
+
+    sdd_dir = tmp_path / ".sdd"
+    (sdd_dir / "runs").mkdir(parents=True)
+    task_id = "T" * 256
+    _validate_ids(task_id, "k")
+
+    assert read_artifact_rows(sdd_dir, task_id) == []
 
 
 def test_no_stray_writes_outside_base(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

Run ids, task ids, mission ids, and ledger ids reach the process from the dashboard API, the MCP surface, and the CLI, and each of them names a directory or a file under `.sdd`. Several sites joined such an identifier onto a base directory with no barrier, so a crafted id could address a ledger or a journal outside the tree the caller intended.

This adds one containment barrier and routes every construction of the two affected paths through it. It closes 9 HIGH `py/path-injection` code-scanning alerts (#3028-#3032, #3056-#3059).

## Approach

New `src/bernstein/core/security/path_containment.py` is the single place that turns an externally-influenced identifier into a path. Both halves are load-bearing:

1. **Allowlist.** Every segment must match `^[A-Za-z0-9_.-]{1,512}\Z` and must not be `.` or `..`, so separators, traversal, NUL bytes, and absolute paths are rejected before any filesystem call. The tail anchor is `\Z` rather than `$`, because `$` also matches before a trailing newline and would let `"..\n"` through.
2. **Realpath containment.** The joined candidate is normalised with `os.path.realpath` and required to stay under the normalised base, which catches what the allowlist cannot: a well-named child that is itself a symlink pointing out of the tree.

`contained_path` returns the normalised, checked path, and callers build their filesystem access from that return value rather than the raw join. That is the part the previous journal code was missing: it computed a containment check but then kept using the unchecked join.

The length bound is a sanity limit, not the security control. It sits clear of the repo-wide 256-character task id convention so an identifier this codebase already blesses never trips it; a segment past the filesystem's `NAME_MAX` still contains correctly and the read degrades to "not found" as it did before.

## Sites routed through the barrier

| Site | Barrier |
|---|---|
| `run_ledger_dir` | run/mission id contained under the ledger root |
| `admission_ledger_dir` | ledger id contained under the admission root |
| `WorkLedger.__init__`, `LedgerReader.__init__` | bucket file contained inside the ledger directory |
| `validated_canonical_lines` | same bucket, on the git-ref anchoring export path |
| `EventJournal.__init__` | run id contained under `<sdd>/runs`; `self._path` is now the checked value |
| `checkpoint_retry.task_journal_path` | one contained helper for the task journal |
| `run_artifacts`, `progress`, `latest_checkpoint`, `suspension` | all four task-journal readers derive from that helper |
| `replay.journal.run_journal_path` | one contained helper for the run journal |
| `verify_run_activities`, `fork_run`, `intent_capsule`, `context_capsule` | all four run-journal readers derive from that helper |

`mission_ledger_dir` delegates to `run_ledger_dir`, so it is covered too.

Two of these were added after review: `validated_canonical_lines` runs *before* the guarded reader in `anchor_ledger`, so an unguarded read there fed the anchored head hash from a symlink target; and three task-journal readers rebuilt the path verbatim, leaving the symlink escape reachable on the warm-resume checkpoint read. `verify_journal` does not cover that case, since it is an unkeyed Merkle recompute that whoever plants the symlink can also satisfy.

## Behaviour

Unchanged for legitimate identifiers. The on-disk layout, file naming, audit chain, lineage, and replay semantics are untouched: an ordinary id resolves to exactly the path it did before, and byte-identical replay still holds.

Failures raise `PathContainmentError`, which subclasses `ValueError` so existing callers that guard bad ids with `except ValueError` keep working unchanged. `JournalPathError` narrows it for the journal.

## Tests

`tests/unit/test_path_containment.py` covers, at each site:

- a traversal (`..`, `../escape`, `a/../../b`), separator, absolute, or trailing-newline identifier is refused with the typed error;
- a symlink-escaping child is refused at every reader and at the export surface, and a symlink that stays inside the base is still allowed;
- a refused identifier writes nothing outside the intended base;
- an ordinary identifier still round-trips, including a full ledger write/read/verify cycle and a journal record/verify cycle;
- a 256-character task id still reads as empty rather than raising.

Every test here was checked by reverting the corresponding production line and confirming it fails.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added safeguards to prevent unsafe identifiers, path traversal, and symlink escapes when accessing journals, ledgers, and artifacts.
  * Invalid run IDs now produce clear errors or safe verification failures instead of accessing unintended files.

* **Bug Fixes**
  * Replay, verification, progress, checkpoint, and suspension workflows now handle invalid or overlong identifiers safely.
  * Verification preserves audit findings even when ledger paths are unusable.

* **Tests**
  * Added comprehensive coverage for containment, symlink protection, path limits, and safe failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->