### PR TITLE
fix(cache): contain key paths, make claim and eviction atomic

### DIFF
--- a/src/bernstein/cli/commands/cache_cmd.py
+++ b/src/bernstein/cli/commands/cache_cmd.py
@@ -16,12 +16,12 @@ from bernstein.core.persistence.action_cache import (
     open_cache,
 )
 from bernstein.core.persistence.cache_eviction import (
-    cache_dir,
     open_ledger,
     open_tombstones,
+    recall_report_path,
     write_recall_report,
 )
-from bernstein.core.persistence.cache_policy import CachePolicy
+from bernstein.core.persistence.cache_policy import CachePolicy, UnsafeCacheKeyError
 from bernstein.core.semantic_cache import ResponseCacheManager, SemanticCacheEntry
 
 
@@ -188,13 +188,22 @@ def evict_cache_key(key: str, reason: str, workdir: Path, as_json: bool) -> None
     audit-chain event, and writes a recall report under
     ``.sdd/caching/policy/``. A tombstoned key can never serve again, even when
     its drift verdict is fresh.
+
+    KEY must be a single cache key, not a path: a value that would address a
+    file outside ``.sdd/caching/policy/`` is refused before anything is written.
     """
     root = workdir.resolve()
+    # Resolve the report path first: an unsafe key is refused before the
+    # tombstone journal, the audit chain, or the filesystem is touched.
+    try:
+        report_path = recall_report_path(root, key)
+    except UnsafeCacheKeyError as exc:
+        console.print(f"[red]Refusing to evict: {exc}[/red]")
+        raise SystemExit(2) from exc
+
     ledger = open_ledger(root)
     tombstones = open_tombstones(root)
     recall = tombstones.evict(key, reason, ledger=ledger, ts=int(time.time()))
-
-    report_path = cache_dir(root) / f"recall-{key[:16]}.json"
     write_recall_report(report_path, recall)
 
     # Chain-attest the eviction. Best-effort: a missing audit key must not fail

--- a/src/bernstein/core/persistence/cache_dedup.py
+++ b/src/bernstein/core/persistence/cache_dedup.py
@@ -5,14 +5,21 @@ same cache key, only one should pay for the minutes-to-hours agent run. A naive
 in-process lock cannot dedup across hosts, and a losing worker that *blocks* on
 an hours-long run wastes a seat.
 
-This routes cache-key contention through the same atomic claim primitive the
-task backlog uses (:func:`bernstein.core.tasks.claim.claim_next_entry`): the
+This routes cache-key contention through the same atomic claim protocol the
+task backlog uses (:func:`bernstein.core.tasks.claim.backlog_transaction`): the
 cache key becomes a single-row backlog, the first worker to flip it to
 ``in_progress`` wins the spawn, and every loser receives a signed
 :class:`DuplicateOfReceipt` binding it to the winner's key and claim position.
 The loser does not block; it completes by a lineage edge to the winner's
 verified output. If the winner never records a verified output the claim can be
 released and re-contended deterministically.
+
+Row creation, the claim flip, the winner read, and the release all happen
+inside one held claim lock. Creating the row outside the lock would let a
+second contender's create overwrite a claim the first contender had already
+been granted, and releasing outside the lock would let a stale reopen clobber a
+concurrent claim; both windows are closed by running the whole read-modify-save
+cycle as a single transaction.
 
 Verifiability (issue #2551 AC3): a :class:`DuplicateOfReceipt` is HMAC-signed
 over its canonical body with the audit-chain key, so it verifies offline; any
@@ -29,11 +36,15 @@ import threading
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.persistence.cache_policy import (
+    resolve_cached_path,
+    validate_cache_key,
+)
 from bernstein.core.tasks.claim import (
     Backlog,
     BacklogEntry,
     ClaimFilter,
-    claim_next_entry,
+    backlog_transaction,
 )
 
 if TYPE_CHECKING:
@@ -41,6 +52,9 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 _RECEIPT_VERSION = 1
+
+#: Status a released row returns to, matching the claim primitive's vocabulary.
+_OPEN_STATUS = "open"
 
 
 def _canonical_bytes(value: Any) -> bytes:
@@ -197,19 +211,36 @@ class ClaimOutcome:
     winner: str
 
 
-class CacheKeyArbiter:
-    """Serialise spawns for one cache key through the atomic claim primitive.
+def arbiter_backlog_path(base_dir: Path, cache_key: str) -> Path:
+    """Return the contended-key backlog path for ``cache_key`` under ``base_dir``.
 
-    The arbiter is backed by a single-row backlog file named after the cache
-    key. ``claim_next_entry`` flips the row to ``in_progress`` atomically under
-    a cross-process file lock, so exactly one worker among N contenders wins,
-    even across hosts sharing the backlog directory. A killed winner's claim is
-    released by :meth:`release` and the next contender proceeds.
+    The arbiter's backlog file is named after the cache key, so the key is
+    validated as a single path component and the composed path is proven to
+    resolve inside ``base_dir`` before it is handed back.
+
+    Raises:
+        UnsafeCacheKeyError: When ``cache_key`` is not a safe path component or
+            the composed path would escape ``base_dir``.
+    """
+    return resolve_cached_path(base_dir, f"{validate_cache_key(cache_key)}.json")
+
+
+class CacheKeyArbiter:
+    """Serialise spawns for one cache key through the atomic claim protocol.
+
+    The arbiter is backed by a single-row backlog file addressed by the cache
+    key (see :func:`arbiter_backlog_path`). Row creation, the flip to
+    ``in_progress``, the winner read, and the release each run inside one held
+    claim lock - the same cross-thread and cross-process lock the task backlog
+    claims under - so exactly one worker among N contenders wins even when all
+    of them arrive before the backlog exists, and even across hosts sharing the
+    backlog directory. A killed winner's claim is released by :meth:`release`
+    and the next contender proceeds.
     """
 
     def __init__(self, backlog_path: Path, cache_key: str) -> None:
         self._path = backlog_path
-        self._cache_key = cache_key
+        self._cache_key = validate_cache_key(cache_key)
         self._contenders = 0
         self._counter_lock = threading.Lock()
 
@@ -217,9 +248,26 @@ class CacheKeyArbiter:
     def cache_key(self) -> str:
         return self._cache_key
 
+    def _row(self, backlog: Backlog) -> BacklogEntry | None:
+        """Return this key's row in ``backlog``, or ``None`` when absent."""
+        for entry in backlog.entries:
+            if entry.id == self._cache_key:
+                return entry
+        return None
+
     def _ensure_backlog(self) -> None:
-        if not self._path.exists():
-            Backlog.write(self._path, [BacklogEntry(id=self._cache_key)])
+        """Create this key's row inside the claim lock, idempotently.
+
+        Never overwrites an existing document: a row that is already present
+        (claimed or not) is left exactly as it is, so a late initialiser cannot
+        reset a claim another contender has already been granted.
+        """
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        with backlog_transaction(self._path) as backlog:
+            if self._row(backlog) is not None:
+                return
+            backlog.entries.append(BacklogEntry(id=self._cache_key))
+            backlog.save()
 
     def contend(self, claimer: str) -> ClaimOutcome:
         """Attempt to claim the cache key for ``claimer``.
@@ -228,16 +276,31 @@ class CacheKeyArbiter:
         ``claim_position=0``. Every later caller finds the row already claimed
         and returns ``won=False`` with a 1-based ``claim_position`` reflecting
         arrival order, plus the winning claimer id.
+
+        Creating the row, testing eligibility, flipping it, and reading back the
+        winner all happen in one transaction, so no contender can observe or
+        overwrite a half-initialised claim.
         """
         self._path.parent.mkdir(parents=True, exist_ok=True)
-        self._ensure_backlog()
         with self._counter_lock:
             self._contenders += 1
             position = self._contenders - 1
-        claimed = claim_next_entry(self._path, claimer_id=claimer, filter=ClaimFilter())
-        if claimed is not None and claimed.id == self._cache_key:
-            return ClaimOutcome(won=True, claimer=claimer, claim_position=0, winner=claimer)
-        winner = self._current_winner()
+        with backlog_transaction(self._path) as backlog:
+            entry = self._row(backlog)
+            created = entry is None
+            if entry is None:
+                entry = BacklogEntry(id=self._cache_key)
+                backlog.entries.append(entry)
+            # The claim predicate is the backlog's own, scoped to this key's row
+            # so a shared backlog directory can never hand the arbiter a foreign
+            # row to claim.
+            if ClaimFilter().allows(entry):
+                entry.claim(claimer)
+                backlog.save()
+                return ClaimOutcome(won=True, claimer=claimer, claim_position=0, winner=claimer)
+            if created:
+                backlog.save()
+            winner = entry.claimer or ""
         return ClaimOutcome(
             won=False,
             claimer=claimer,
@@ -245,32 +308,41 @@ class CacheKeyArbiter:
             winner=winner,
         )
 
-    def _current_winner(self) -> str:
-        backlog = Backlog.load(self._path)
-        for entry in backlog.entries:
-            if entry.id == self._cache_key and entry.claimer is not None:
+    def current_winner(self) -> str:
+        """Return the claimer currently holding this key, or ``""`` when free.
+
+        Read under the claim lock, so the answer is consistent with the claim
+        state rather than a snapshot taken mid-transaction.
+        """
+        with backlog_transaction(self._path) as backlog:
+            entry = self._row(backlog)
+            if entry is not None and entry.claimer is not None:
                 return entry.claimer
         return ""
 
     def release(self) -> None:
         """Release the claim so the next contender can win (winner failed).
 
-        Re-opens the backlog row to ``open`` and clears the claimer, mirroring a
-        deterministic claim release: the successor's next :meth:`contend` wins.
+        Re-opens the backlog row to ``open`` and clears the claimer inside the
+        claim lock, mirroring a deterministic claim release: the successor's
+        next :meth:`contend` wins. Holding the lock across the load and the save
+        means a release can never clobber a claim granted in between.
         """
-        backlog = Backlog.load(self._path)
-        for entry in backlog.entries:
-            if entry.id == self._cache_key:
-                entry.status = "open"
-                entry.claimer = None
-                entry.claimed_at = None
-        backlog.save()
+        with backlog_transaction(self._path) as backlog:
+            entry = self._row(backlog)
+            if entry is None or (entry.claimer is None and entry.status == _OPEN_STATUS):
+                return
+            entry.status = _OPEN_STATUS
+            entry.claimer = None
+            entry.claimed_at = None
+            backlog.save()
 
 
 __all__ = [
     "CacheKeyArbiter",
     "ClaimOutcome",
     "DuplicateOfReceipt",
+    "arbiter_backlog_path",
     "mint_duplicate_receipt",
     "verify_duplicate_receipt",
 ]

--- a/src/bernstein/core/persistence/cache_eviction.py
+++ b/src/bernstein/core/persistence/cache_eviction.py
@@ -21,6 +21,14 @@ over ``served_from`` edges, tombstones every reachable key, and returns the full
 Determinism: the recall set is computed by a breadth-first walk in sorted order,
 so the same ledger + eviction produces the byte-identical recall set and
 tombstone order across processes.
+
+Crash consistency: a transitive revocation is one journal transition, not N
+appends. Every tombstone the walk produces is serialised first, then the whole
+journal is replaced with ``temp + fsync + os.replace`` under the journal lock,
+so a reader observes either the pre-eviction journal or the fully revoked one.
+An eviction interrupted part-way therefore never leaves the served-from graph
+partially revoked, which would otherwise let a derived key keep serving a value
+whose root had already been recalled.
 """
 
 from __future__ import annotations
@@ -30,7 +38,13 @@ from collections import deque
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from bernstein.core.persistence.atomic_write import write_atomic_json
+from bernstein.core.persistence.atomic_write import write_atomic_bytes, write_atomic_json
+from bernstein.core.persistence.cache_policy import (
+    cache_key_slug,
+    resolve_cached_path,
+    validate_cache_key,
+)
+from bernstein.core.persistence.file_locks import cross_process_lock
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
@@ -38,6 +52,16 @@ if TYPE_CHECKING:
 
 _LEDGER_NAME = "served_from.jsonl"
 _TOMBSTONE_NAME = "tombstones.jsonl"
+
+
+def _canonical_row(payload: Mapping[str, Any]) -> str:
+    """Return one canonical JSONL row for ``payload``."""
+    return json.dumps(dict(payload), ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def _lock_path_for(path: Path) -> Path:
+    """Return the sibling advisory lock path guarding ``path``."""
+    return path.with_name(path.name + ".lock")
 
 
 # ---------------------------------------------------------------------------
@@ -94,9 +118,18 @@ class ServedFromLedger:
         return self._path
 
     def record(self, edge: ServedFromEdge) -> None:
-        """Append one served-from edge as a canonical JSONL row."""
+        """Append one served-from edge as a canonical JSONL row.
+
+        The edge's cache key is validated before the row is written, so a key
+        that could never address a cache artefact safely never enters the graph
+        the eviction walk later treats as authoritative.
+
+        Raises:
+            UnsafeCacheKeyError: When ``edge.cache_key`` is not a safe key.
+        """
+        validate_cache_key(edge.cache_key)
+        row = _canonical_row(edge.to_dict())
         self._path.parent.mkdir(parents=True, exist_ok=True)
-        row = json.dumps(edge.to_dict(), ensure_ascii=False, separators=(",", ":"), sort_keys=True)
         with self._path.open("a", encoding="utf-8") as fh:
             fh.write(row + "\n")
 
@@ -212,12 +245,28 @@ class TombstoneStore:
         """Return whether ``key`` has been revoked."""
         return key in self.all()
 
-    def _append(self, tombstones: Iterable[Tombstone]) -> None:
+    def _commit(self, tombstones: Iterable[Tombstone]) -> None:
+        """Persist ``tombstones`` as one all-or-nothing journal transition.
+
+        Every row is serialised before any byte is written, then the journal is
+        rewritten with ``temp + fsync + os.replace`` while the journal lock is
+        held. A failure while serialising leaves the journal untouched; a
+        failure during the write leaves the previous journal in place, because
+        the rename is the only step that publishes the new contents. Either way
+        the revocation is atomic: never a prefix of the reachable set.
+        """
+        rows = [_canonical_row(tombstone.to_dict()) for tombstone in tombstones]
+        if not rows:
+            return
         self._path.parent.mkdir(parents=True, exist_ok=True)
-        with self._path.open("a", encoding="utf-8") as fh:
-            for ts in tombstones:
-                row = json.dumps(ts.to_dict(), ensure_ascii=False, separators=(",", ":"), sort_keys=True)
-                fh.write(row + "\n")
+        # The lock makes the read-modify-replace cycle safe against a concurrent
+        # eviction, which would otherwise lose one writer's rows entirely.
+        with cross_process_lock(_lock_path_for(self._path)):
+            existing = self._path.read_text(encoding="utf-8") if self._path.exists() else ""
+            if existing and not existing.endswith("\n"):
+                existing += "\n"
+            payload = existing + "".join(row + "\n" for row in rows)
+            write_atomic_bytes(self._path, payload.encode("utf-8"))
 
     def evict(
         self,
@@ -239,7 +288,15 @@ class TombstoneStore:
         pure function of ``(key, ledger)`` - the BFS visits neighbours in sorted
         order, so two operators evicting the same key against the same ledger
         produce identical output.
+
+        Crash consistency (issue #2637): the whole reachable set is committed in
+        one journal transition, so an interrupted eviction revokes nothing
+        rather than a prefix of the graph.
+
+        Raises:
+            UnsafeCacheKeyError: When ``key`` is not a safe cache key.
         """
+        validate_cache_key(key)
         adjacency = ledger.adjacency()
         graph_keys = set(adjacency)
 
@@ -273,7 +330,7 @@ class TombstoneStore:
             tombstoned=tombstoned_order,
             consumers=sorted(c for c in consumers_seen if c not in graph_keys),
         )
-        self._append(Tombstone(key=k, reason=reason, root_key=key, ts=ts) for k in tombstoned_order)
+        self._commit(Tombstone(key=k, reason=reason, root_key=key, ts=ts) for k in tombstoned_order)
         return recall
 
 
@@ -292,6 +349,20 @@ def open_tombstones(workdir: Path) -> TombstoneStore:
     return TombstoneStore(cache_dir(workdir) / _TOMBSTONE_NAME)
 
 
+def recall_report_path(workdir: Path, key: str) -> Path:
+    """Return the recall-report path for ``key``, contained in the cache dir.
+
+    The key is validated as a single path component and the composed path is
+    resolved and proven to live inside :func:`cache_dir`, so an operator-supplied
+    key can never steer the report onto a file outside the cache directory.
+
+    Raises:
+        UnsafeCacheKeyError: When ``key`` is not a safe cache key or the
+            composed path would escape the cache directory.
+    """
+    return resolve_cached_path(cache_dir(workdir), f"recall-{cache_key_slug(key)}.json")
+
+
 def write_recall_report(path: Path, recall: RecallSet) -> None:
     """Persist a recall report as pretty JSON for the operator."""
     write_atomic_json(path, recall.to_dict())
@@ -306,5 +377,6 @@ __all__ = [
     "cache_dir",
     "open_ledger",
     "open_tombstones",
+    "recall_report_path",
     "write_recall_report",
 ]

--- a/src/bernstein/core/persistence/cache_eviction.py
+++ b/src/bernstein/core/persistence/cache_eviction.py
@@ -5,14 +5,16 @@ cached value that other runs consumed has to be revocable together with
 everything derived from it, and the operator needs a forensic recall set of the
 runs that consumed the revoked value.
 
-Two append-only artefacts back this:
+Two journals back this:
 
 * :class:`ServedFromLedger` - one row per ``served_from`` edge: a consuming run
   read a value from a cache key. The ledger is the by-artefact projection this
   module walks; it is append-only so an edge can never be silently rewritten.
-* :class:`TombstoneStore` - append-only tombstone journal. A tombstoned key is
-  always a miss, even when its drift verdict is fresh, so an evicted key can
-  never serve again.
+* :class:`TombstoneStore` - tombstone journal. A tombstoned key is always a
+  miss, even when its drift verdict is fresh, so an evicted key can never serve
+  again. Rows are only ever added, but a revocation rewrites the journal whole
+  under its lock rather than appending row by row, so that the whole reachable
+  set lands in one atomic transition (see below).
 
 :meth:`TombstoneStore.evict` walks the ledger transitively from the evicted key
 over ``served_from`` edges, tombstones every reachable key, and returns the full
@@ -215,10 +217,18 @@ class RecallSet:
 
 
 class TombstoneStore:
-    """Append-only tombstone journal with transitive eviction.
+    """Tombstone journal with crash-consistent transitive eviction.
 
     A tombstoned key is a hard miss forever - :meth:`is_tombstoned` short
     circuits any lookup regardless of the drift verdict.
+
+    The journal only ever grows - no code path removes or edits a row - but it
+    is not written by appending. Each revocation rewrites the file whole, prior
+    rows plus the new ones, via ``temp + fsync + os.replace`` under the journal
+    lock, so an interrupted eviction cannot publish a prefix of the reachable
+    set. The trade is deliberate: a rewrite could in principle drop history that
+    a pure append could not, so the rewrite is confined to :meth:`_commit`,
+    which never filters or reorders the rows it read.
     """
 
     def __init__(self, path: Path) -> None:

--- a/src/bernstein/core/persistence/cache_policy.py
+++ b/src/bernstein/core/persistence/cache_policy.py
@@ -401,14 +401,19 @@ def cache_key_slug(key: str, *, length: int = 16) -> str:
 def resolve_cached_path(base: Path, name: str) -> Path:
     """Return ``base/name`` resolved, proven to live strictly inside ``base``.
 
-    Containment is asserted on the *resolved* paths, so a symlinked base
-    directory or a name that survives component validation but still escapes
-    (for example through an intermediate symlink) is refused rather than
-    written to.
+    ``base`` is canonicalised first, so a base directory that is itself a
+    symlink is *followed*, not refused: containment is then asserted against
+    that canonical target. What the check refuses is a ``name`` that resolves
+    outside the canonical base - including the case where ``base/name`` is a
+    symlink pointing elsewhere, since the candidate is resolved too.
+
+    Callers pass a ``name`` built from an already validated key, so it carries
+    no separators; this resolution step is the second, independent barrier
+    rather than the primary one.
 
     Raises:
         UnsafeCacheKeyError: When the resolved candidate is not strictly inside
-            the resolved base directory.
+            the canonical base directory.
     """
     resolved_base = Path(base).resolve()
     candidate = (resolved_base / name).resolve()

--- a/src/bernstein/core/persistence/cache_policy.py
+++ b/src/bernstein/core/persistence/cache_policy.py
@@ -40,8 +40,10 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final, Literal, cast
 
 if TYPE_CHECKING:
@@ -322,6 +324,100 @@ def compose_key_hex(policy: CachePolicy, inputs: RecipeInputs) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Key safety: a cache key is a key, never a path
+# ---------------------------------------------------------------------------
+
+#: Upper bound on a cache key's length. A composed key is 64 hex characters;
+#: the ceiling leaves room for operator-facing labels without admitting a value
+#: long enough to blow a filesystem name limit.
+MAX_CACHE_KEY_LENGTH: Final[int] = 128
+
+#: A cache key must be a single, self-contained path component: it starts with
+#: an alphanumeric character and continues with alphanumerics, dot, underscore,
+#: or hyphen. This admits every key :func:`compose_key_hex` produces and every
+#: operator-facing label, while excluding separators, traversal segments,
+#: leading dots, leading dashes, control characters, and whitespace.
+_SAFE_CACHE_KEY_RE: Final[re.Pattern[str]] = re.compile(r"\A[0-9A-Za-z][0-9A-Za-z._-]*\Z")
+
+_PATH_SEPARATORS: Final[tuple[str, ...]] = ("/", "\\")
+
+
+class UnsafeCacheKeyError(ValueError):
+    """Typed refusal: a cache key cannot be used to address a cache artefact.
+
+    Raised before any filesystem work happens, so a refused key never creates,
+    truncates, or overwrites a file. ``key`` and ``reason`` are exposed as
+    attributes so a caller can render an operator-facing message without
+    re-parsing the string form.
+    """
+
+    def __init__(self, key: str, reason: str) -> None:
+        self.key = key
+        self.reason = reason
+        super().__init__(f"unsafe cache key {key!r}: {reason}")
+
+
+def validate_cache_key(key: str) -> str:
+    """Return ``key`` unchanged when it is safe to use as a path component.
+
+    A cache key reaches the cache boundary from a composed recipe, a served-from
+    ledger row, or an operator's ``bernstein cache evict <key>`` argument. The
+    last of those is untrusted input, so the key is validated here rather than
+    interpolated into a path and hoped for.
+
+    Raises:
+        UnsafeCacheKeyError: When the key is empty, over
+            :data:`MAX_CACHE_KEY_LENGTH`, contains a path separator, a NUL, or
+            any character outside ``[0-9A-Za-z._-]``, or begins with a
+            character that would make it a traversal segment or a hidden file.
+    """
+    if not key:
+        raise UnsafeCacheKeyError(key, "is empty")
+    if len(key) > MAX_CACHE_KEY_LENGTH:
+        raise UnsafeCacheKeyError(key, f"is longer than {MAX_CACHE_KEY_LENGTH} characters")
+    if "\x00" in key:
+        raise UnsafeCacheKeyError(key, "contains a NUL byte")
+    if any(sep in key for sep in _PATH_SEPARATORS):
+        raise UnsafeCacheKeyError(key, "contains a path separator")
+    if key in (os.curdir, os.pardir):
+        raise UnsafeCacheKeyError(key, "is a relative path segment")
+    if not _SAFE_CACHE_KEY_RE.match(key):
+        raise UnsafeCacheKeyError(key, "must start with an alphanumeric and contain only [0-9A-Za-z._-]")
+    return key
+
+
+def cache_key_slug(key: str, *, length: int = 16) -> str:
+    """Return a short, filesystem-safe label for ``key``.
+
+    The key is validated first, so the truncation operates on a value already
+    known to be a single safe path component; a prefix of such a value is
+    itself a safe path component.
+    """
+    if length <= 0:
+        raise ValueError(f"cache_key_slug: length must be positive, got {length!r}")
+    return validate_cache_key(key)[:length]
+
+
+def resolve_cached_path(base: Path, name: str) -> Path:
+    """Return ``base/name`` resolved, proven to live strictly inside ``base``.
+
+    Containment is asserted on the *resolved* paths, so a symlinked base
+    directory or a name that survives component validation but still escapes
+    (for example through an intermediate symlink) is refused rather than
+    written to.
+
+    Raises:
+        UnsafeCacheKeyError: When the resolved candidate is not strictly inside
+            the resolved base directory.
+    """
+    resolved_base = Path(base).resolve()
+    candidate = (resolved_base / name).resolve()
+    if resolved_base not in candidate.parents:
+        raise UnsafeCacheKeyError(name, f"resolves outside the cache directory {resolved_base}")
+    return candidate
+
+
+# ---------------------------------------------------------------------------
 # Cache entry (content-addressed lineage record)
 # ---------------------------------------------------------------------------
 
@@ -516,6 +612,7 @@ def evaluate_freshness(
 
 __all__ = [
     "MANDATORY_INGREDIENTS",
+    "MAX_CACHE_KEY_LENGTH",
     "OPTIONAL_INGREDIENTS",
     "REASON_BASE_NOT_ANCESTOR",
     "REASON_BASE_OUTSIDE_WINDOW",
@@ -529,10 +626,14 @@ __all__ = [
     "FreshnessVerdict",
     "RecipeInputs",
     "RepoState",
+    "UnsafeCacheKeyError",
+    "cache_key_slug",
     "compose_key",
     "compose_key_hex",
     "compose_recipe",
     "evaluate_freshness",
     "recipe_hash",
     "refresh_requested",
+    "resolve_cached_path",
+    "validate_cache_key",
 ]

--- a/src/bernstein/core/persistence/cache_served_from.py
+++ b/src/bernstein/core/persistence/cache_served_from.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING
 
+from bernstein.core.persistence.cache_policy import validate_cache_key
+
 if TYPE_CHECKING:
     from bernstein.core.lineage.spine import LineageSpine
 
@@ -25,8 +27,16 @@ _SERVED_FROM_PREFIX = ".sdd/cache/served_from"
 
 
 def served_from_artifact_path(cache_key: str) -> str:
-    """Return the repo-relative spine artifact path for a served-from hit."""
-    return f"{_SERVED_FROM_PREFIX}/{cache_key}"
+    """Return the repo-relative spine artifact path for a served-from hit.
+
+    The key becomes the final path component, so it is validated first: a key
+    carrying separators or traversal segments would otherwise let a spine entry
+    claim an artifact path outside the served-from namespace.
+
+    Raises:
+        UnsafeCacheKeyError: When ``cache_key`` is not a safe cache key.
+    """
+    return f"{_SERVED_FROM_PREFIX}/{validate_cache_key(cache_key)}"
 
 
 def served_from_content(*, cache_key: str, output_hash: str, policy_hash: str, recipe_hash: str) -> bytes:

--- a/src/bernstein/core/tasks/claim.py
+++ b/src/bernstein/core/tasks/claim.py
@@ -308,6 +308,33 @@ class Backlog:
         write_atomic_json(self.path, [entry.to_dict() for entry in self.entries])
 
 
+@contextmanager
+def backlog_transaction(backlog_path: Path) -> Generator[Backlog, None, None]:
+    """Hold the claim lock for *backlog_path* and yield the loaded backlog.
+
+    This is the same cross-thread plus cross-process lock
+    :func:`claim_next_entry` takes, exposed so a caller that must create a row
+    before claiming it, or reopen a row after a failed run, performs that work
+    inside the claim protocol instead of in an unlocked read-modify-write
+    window. Mutations are persisted by calling :meth:`Backlog.save` before the
+    block exits; the lock is held for the whole block, so the load, the
+    mutation, and the save are one atomic step against every other claimer.
+
+    A missing backlog file yields an empty :class:`Backlog`, so create-if-absent
+    and claim collapse into a single transaction rather than a check-then-act
+    pair that two contenders can interleave.
+
+    Args:
+        backlog_path: Path to the JSON backlog document.
+
+    Yields:
+        The backlog loaded under the lock.
+    """
+    backlog = Backlog(path=backlog_path)
+    with _backlog_lock(backlog.lock_path):
+        yield Backlog.load(backlog_path)
+
+
 def claim_next_entry(
     backlog_path: Path,
     claimer_id: str,
@@ -350,6 +377,7 @@ __all__ = [
     "Backlog",
     "BacklogEntry",
     "ClaimFilter",
+    "backlog_transaction",
     "claim_next",
     "claim_next_entry",
 ]

--- a/tests/unit/test_cache_hardening.py
+++ b/tests/unit/test_cache_hardening.py
@@ -104,6 +104,30 @@ def test_resolve_cached_path_refuses_escape(tmp_path: Path) -> None:
         resolve_cached_path(tmp_path / "cache", "../../escaped.json")
 
 
+def test_resolve_cached_path_follows_a_symlinked_base(tmp_path: Path) -> None:
+    """A symlinked base is canonicalised and followed, not refused."""
+    real = tmp_path / "real"
+    real.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(real)
+
+    resolved = resolve_cached_path(link, "recall-key_root.json")
+
+    assert resolved == real.resolve() / "recall-key_root.json"
+
+
+def test_resolve_cached_path_refuses_a_name_symlinked_out_of_base(tmp_path: Path) -> None:
+    """A report name that is itself a symlink pointing outside is refused."""
+    base = tmp_path / "cache"
+    base.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (base / "recall-key_root.json").symlink_to(outside / "stolen.json")
+
+    with pytest.raises(UnsafeCacheKeyError):
+        resolve_cached_path(base, "recall-key_root.json")
+
+
 def test_recall_report_path_is_contained(tmp_path: Path) -> None:
     report = recall_report_path(tmp_path, "key_root")
     assert cache_dir(tmp_path).resolve() in report.parents
@@ -159,10 +183,35 @@ def test_cli_evict_refuses_traversal_key_and_writes_nothing(tmp_path: Path) -> N
     )
 
     assert result.exit_code != 0
-    # The pre-hardening path builder resolved to <workdir>/pwne.json - outside
-    # the policy cache directory it was supposed to stay in.
-    assert not (workdir / "pwne.json").exists()
-    assert not any(workdir.glob("*.json"))
+    # The pre-hardening builder composed
+    # <workdir>/.sdd/caching/policy/recall-../../../../pwne.json, whose
+    # components normalise to <workdir>/.sdd/pwne.json - three levels above the
+    # policy cache directory it was supposed to stay in. Assert on that exact
+    # target, and recursively, so the check cannot pass by looking in the wrong
+    # directory.
+    assert not (workdir / ".sdd" / "pwne.json").exists()
+    assert list(workdir.rglob("*.json")) == []
+    # The refusal precedes every filesystem effect, so the run leaves no trace
+    # at all: no report, no tombstone journal, no audit chain.
+    assert list(workdir.rglob("*")) == []
+
+
+def test_cli_evict_writes_the_report_inside_the_cache_dir(tmp_path: Path) -> None:
+    """Positive control: a safe key still gets its report, and it stays contained."""
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+    open_ledger(workdir).record(ServedFromEdge(cache_key="key_root", consumer="run_a"))
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        ["cache", "evict", "key_root", "--reason", "pr_reverted", "--workdir", str(workdir)],
+    )
+
+    assert result.exit_code == 0, result.output
+    reports = list(cache_dir(workdir).glob("recall-*.json"))
+    assert len(reports) == 1
+    assert cache_dir(workdir).resolve() in reports[0].resolve().parents
 
 
 # ---------------------------------------------------------------------------
@@ -243,34 +292,6 @@ def test_concurrent_cold_start_yields_exactly_one_winner(tmp_path: Path) -> None
         results = list(pool.map(_try, range(workers)))
 
     assert sum(1 for won in results if won) == 1
-
-
-def test_release_and_contend_race_yields_one_owner(tmp_path: Path) -> None:
-    """A release racing fresh contenders never leaves two owners of the key."""
-    backlog_path = tmp_path / "arbiter.json"
-    arbiter = CacheKeyArbiter(backlog_path, "hotkey")
-    assert arbiter.contend("worker-0").won
-
-    barrier = threading.Barrier(9)
-
-    def _release(_: int) -> bool:
-        barrier.wait(timeout=10)
-        arbiter.release()
-        return False
-
-    def _contend(index: int) -> bool:
-        barrier.wait(timeout=10)
-        return CacheKeyArbiter(backlog_path, "hotkey").contend(f"w-{index}").won
-
-    with concurrent.futures.ThreadPoolExecutor(max_workers=9) as pool:
-        futures = [pool.submit(_release, 0), *[pool.submit(_contend, i) for i in range(8)]]
-        results = [f.result(timeout=30) for f in futures]
-
-    # At most one contender wins the re-opened claim, and the persisted row has
-    # exactly one owner (or none, when the release lands last).
-    assert sum(1 for won in results if won) <= 1
-    rows = [e for e in Backlog.load(backlog_path).entries if e.id == "hotkey"]
-    assert len(rows) == 1
 
 
 def test_contend_preserves_outcome_semantics(tmp_path: Path) -> None:

--- a/tests/unit/test_cache_hardening.py
+++ b/tests/unit/test_cache_hardening.py
@@ -1,0 +1,418 @@
+"""Hardening regressions for the cache policy engine (issue #2637).
+
+Three properties are pinned here:
+
+* **Path containment.** A cache key is a key, not a path. Any key that would
+  address a file outside the cache directory is refused with a typed error
+  before a single byte is written.
+* **Claim atomicity.** Creating the arbiter row and releasing a claim both
+  happen inside the claim protocol, so no contender observes a half-initialised
+  row and no release clobbers a concurrent claim.
+* **Crash-consistent eviction.** A transitive revocation lands as one
+  all-or-nothing journal transition; an interrupted eviction never leaves the
+  served-from graph partially revoked.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import threading
+from typing import TYPE_CHECKING
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.main import cli
+from bernstein.core.persistence.cache_dedup import (
+    CacheKeyArbiter,
+    arbiter_backlog_path,
+)
+from bernstein.core.persistence.cache_eviction import (
+    ServedFromEdge,
+    ServedFromLedger,
+    Tombstone,
+    TombstoneStore,
+    cache_dir,
+    open_ledger,
+    open_tombstones,
+    recall_report_path,
+)
+from bernstein.core.persistence.cache_policy import (
+    UnsafeCacheKeyError,
+    resolve_cached_path,
+    validate_cache_key,
+)
+from bernstein.core.persistence.cache_served_from import served_from_artifact_path
+from bernstein.core.tasks.claim import Backlog, backlog_transaction
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Path containment
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "",
+        ".",
+        "..",
+        "../escape",
+        "../../../../pwned",
+        "sub/../../x",
+        "a/b",
+        "a\\b",
+        "/absolute",
+        "C:\\windows",
+        "-leading-dash",
+        ".hidden",
+        "key with space",
+        "key\nwith-newline",
+        "nul\x00byte",
+        "x" * 129,
+    ],
+)
+def test_unsafe_cache_key_is_refused(key: str) -> None:
+    with pytest.raises(UnsafeCacheKeyError):
+        validate_cache_key(key)
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "a",
+        "key_root",
+        "key-a",
+        "key.child",
+        "deadbeef" * 8,
+    ],
+)
+def test_safe_cache_key_is_accepted(key: str) -> None:
+    assert validate_cache_key(key) == key
+
+
+def test_resolve_cached_path_stays_inside_base(tmp_path: Path) -> None:
+    resolved = resolve_cached_path(tmp_path / "cache", "recall-key_root.json")
+    assert (tmp_path / "cache").resolve() in resolved.parents
+
+
+def test_resolve_cached_path_refuses_escape(tmp_path: Path) -> None:
+    with pytest.raises(UnsafeCacheKeyError):
+        resolve_cached_path(tmp_path / "cache", "../../escaped.json")
+
+
+def test_recall_report_path_is_contained(tmp_path: Path) -> None:
+    report = recall_report_path(tmp_path, "key_root")
+    assert cache_dir(tmp_path).resolve() in report.parents
+
+
+def test_recall_report_path_refuses_traversal_key(tmp_path: Path) -> None:
+    with pytest.raises(UnsafeCacheKeyError):
+        recall_report_path(tmp_path, "../../../../pwned")
+
+
+def test_evict_refuses_traversal_key(tmp_path: Path) -> None:
+    store = TombstoneStore(tmp_path / "tombstones.jsonl")
+    ledger = ServedFromLedger(tmp_path / "served_from.jsonl")
+    with pytest.raises(UnsafeCacheKeyError):
+        store.evict("../../../../pwned", "bad", ledger=ledger)
+
+
+def test_served_from_ledger_refuses_traversal_key(tmp_path: Path) -> None:
+    ledger = ServedFromLedger(tmp_path / "served_from.jsonl")
+    with pytest.raises(UnsafeCacheKeyError):
+        ledger.record(ServedFromEdge(cache_key="../../escape", consumer="run_a"))
+    assert not (tmp_path / "served_from.jsonl").exists()
+
+
+def test_served_from_artifact_path_refuses_traversal_key() -> None:
+    with pytest.raises(UnsafeCacheKeyError):
+        served_from_artifact_path("../../../../etc/passwd")
+
+
+def test_arbiter_backlog_path_is_contained(tmp_path: Path) -> None:
+    path = arbiter_backlog_path(tmp_path, "key_root")
+    assert tmp_path.resolve() in path.parents
+
+
+def test_arbiter_backlog_path_refuses_traversal_key(tmp_path: Path) -> None:
+    with pytest.raises(UnsafeCacheKeyError):
+        arbiter_backlog_path(tmp_path, "../../../../pwned")
+
+
+def test_arbiter_refuses_traversal_key(tmp_path: Path) -> None:
+    with pytest.raises(UnsafeCacheKeyError):
+        CacheKeyArbiter(tmp_path / "arbiter.json", "../../escape")
+
+
+def test_cli_evict_refuses_traversal_key_and_writes_nothing(tmp_path: Path) -> None:
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        ["cache", "evict", "../../../../pwned", "--reason", "bad", "--workdir", str(workdir)],
+    )
+
+    assert result.exit_code != 0
+    # The pre-hardening path builder resolved to <workdir>/pwne.json - outside
+    # the policy cache directory it was supposed to stay in.
+    assert not (workdir / "pwne.json").exists()
+    assert not any(workdir.glob("*.json"))
+
+
+# ---------------------------------------------------------------------------
+# Claim atomicity
+# ---------------------------------------------------------------------------
+
+
+def test_contend_initialises_inside_the_claim_lock(tmp_path: Path) -> None:
+    """The arbiter row is created under the claim lock, not before it.
+
+    While another party holds the claim lock the backlog must not appear on
+    disk: a row created outside the lock is the window in which a second
+    contender can overwrite a claim that has already been granted.
+    """
+    backlog_path = tmp_path / "arbiter.json"
+    arbiter = CacheKeyArbiter(backlog_path, "hotkey")
+    started = threading.Event()
+    done = threading.Event()
+
+    def _contend() -> None:
+        started.set()
+        arbiter.contend("worker-1")
+        done.set()
+
+    worker = threading.Thread(target=_contend)
+    with backlog_transaction(backlog_path):
+        worker.start()
+        started.wait(timeout=5)
+        # Give the contender a chance to run its initialisation half.
+        done.wait(timeout=0.5)
+        assert not backlog_path.exists(), "backlog initialised outside the claim lock"
+    worker.join(timeout=10)
+    assert not worker.is_alive()
+    assert backlog_path.exists()
+
+
+def test_release_runs_inside_the_claim_lock(tmp_path: Path) -> None:
+    """Releasing a claim waits for the claim lock instead of racing it."""
+    backlog_path = tmp_path / "arbiter.json"
+    arbiter = CacheKeyArbiter(backlog_path, "hotkey")
+    assert arbiter.contend("worker-1").won
+
+    released = threading.Event()
+
+    def _release() -> None:
+        arbiter.release()
+        released.set()
+
+    worker = threading.Thread(target=_release)
+    with backlog_transaction(backlog_path):
+        worker.start()
+        released.wait(timeout=0.5)
+        row = next(e for e in Backlog.load(backlog_path).entries if e.id == "hotkey")
+        assert row.claimer == "worker-1", "release mutated the row outside the claim lock"
+    worker.join(timeout=10)
+    assert not worker.is_alive()
+    row = next(e for e in Backlog.load(backlog_path).entries if e.id == "hotkey")
+    assert row.claimer is None
+    assert row.status == "open"
+
+
+def test_concurrent_cold_start_yields_exactly_one_winner(tmp_path: Path) -> None:
+    """N contenders racing an *uninitialised* backlog still produce one winner.
+
+    Each contender gets its own arbiter instance, so no in-process state can
+    serialise the create-then-claim window; only the claim protocol can.
+    """
+    backlog_path = tmp_path / "arbiter.json"
+    workers = 16
+    arbiters = [CacheKeyArbiter(backlog_path, "hotkey") for _ in range(workers)]
+    barrier = threading.Barrier(workers)
+
+    def _try(index: int) -> bool:
+        barrier.wait(timeout=10)
+        return arbiters[index].contend(f"w-{index}").won
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+        results = list(pool.map(_try, range(workers)))
+
+    assert sum(1 for won in results if won) == 1
+
+
+def test_release_and_contend_race_yields_one_owner(tmp_path: Path) -> None:
+    """A release racing fresh contenders never leaves two owners of the key."""
+    backlog_path = tmp_path / "arbiter.json"
+    arbiter = CacheKeyArbiter(backlog_path, "hotkey")
+    assert arbiter.contend("worker-0").won
+
+    barrier = threading.Barrier(9)
+
+    def _release(_: int) -> bool:
+        barrier.wait(timeout=10)
+        arbiter.release()
+        return False
+
+    def _contend(index: int) -> bool:
+        barrier.wait(timeout=10)
+        return CacheKeyArbiter(backlog_path, "hotkey").contend(f"w-{index}").won
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=9) as pool:
+        futures = [pool.submit(_release, 0), *[pool.submit(_contend, i) for i in range(8)]]
+        results = [f.result(timeout=30) for f in futures]
+
+    # At most one contender wins the re-opened claim, and the persisted row has
+    # exactly one owner (or none, when the release lands last).
+    assert sum(1 for won in results if won) <= 1
+    rows = [e for e in Backlog.load(backlog_path).entries if e.id == "hotkey"]
+    assert len(rows) == 1
+
+
+def test_contend_preserves_outcome_semantics(tmp_path: Path) -> None:
+    """Winner/loser positions and the winner reference are unchanged."""
+    backlog_path = tmp_path / "arbiter.json"
+    arbiter = CacheKeyArbiter(backlog_path, "hotkey")
+    outcomes = [arbiter.contend(f"worker-{i}") for i in range(4)]
+
+    assert outcomes[0].won is True
+    assert outcomes[0].claim_position == 0
+    assert outcomes[0].winner == "worker-0"
+    for index, outcome in enumerate(outcomes[1:], start=1):
+        assert outcome.won is False
+        assert outcome.claim_position == index
+        assert outcome.winner == "worker-0"
+
+
+def test_current_winner_tracks_claim_state(tmp_path: Path) -> None:
+    """The winner query is consistent with the claim before and after release."""
+    backlog_path = tmp_path / "arbiter.json"
+    arbiter = CacheKeyArbiter(backlog_path, "hotkey")
+    assert arbiter.current_winner() == ""
+    arbiter.contend("worker-1")
+    assert arbiter.current_winner() == "worker-1"
+    arbiter.release()
+    assert arbiter.current_winner() == ""
+
+
+# ---------------------------------------------------------------------------
+# Crash-consistent transitive eviction
+# ---------------------------------------------------------------------------
+
+
+def _seed_chain(workdir: Path) -> ServedFromLedger:
+    ledger = open_ledger(workdir)
+    ledger.record(ServedFromEdge(cache_key="key_root", consumer="run_a"))
+    ledger.record(ServedFromEdge(cache_key="key_root", consumer="key_child"))
+    ledger.record(ServedFromEdge(cache_key="key_child", consumer="run_b"))
+    ledger.record(ServedFromEdge(cache_key="key_child", consumer="key_grand"))
+    ledger.record(ServedFromEdge(cache_key="key_grand", consumer="run_c"))
+    return ledger
+
+
+def test_interrupted_eviction_leaves_no_partial_revocation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A crash part-way through a transitive eviction revokes nothing.
+
+    The served-from graph must never be observed half-revoked: either every
+    reachable key carries a tombstone or none of them does.
+    """
+    ledger = _seed_chain(tmp_path)
+    store = open_tombstones(tmp_path)
+
+    calls = {"n": 0}
+    original = Tombstone.to_dict
+
+    def _flaky(self: Tombstone) -> dict[str, object]:
+        calls["n"] += 1
+        if calls["n"] > 1:
+            raise RuntimeError("crash mid-eviction")
+        return original(self)
+
+    monkeypatch.setattr(Tombstone, "to_dict", _flaky)
+
+    with pytest.raises(RuntimeError):
+        store.evict("key_root", "bad", ledger=ledger, ts=7)
+
+    monkeypatch.undo()
+    assert store.all() == {}, "eviction left the served-from graph partially revoked"
+
+
+def test_interrupted_eviction_preserves_prior_tombstones(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An interrupted eviction does not damage tombstones written earlier."""
+    ledger = _seed_chain(tmp_path)
+    store = open_tombstones(tmp_path)
+    store.evict("key_grand", "earlier", ledger=ledger, ts=1)
+    before = store.all()
+    assert set(before) == {"key_grand"}
+
+    calls = {"n": 0}
+    original = Tombstone.to_dict
+
+    def _flaky(self: Tombstone) -> dict[str, object]:
+        calls["n"] += 1
+        if calls["n"] > 1:
+            raise RuntimeError("crash mid-eviction")
+        return original(self)
+
+    monkeypatch.setattr(Tombstone, "to_dict", _flaky)
+    with pytest.raises(RuntimeError):
+        store.evict("key_root", "bad", ledger=ledger, ts=2)
+    monkeypatch.undo()
+
+    assert store.all().keys() == before.keys()
+
+
+def test_transitive_eviction_is_all_or_nothing(tmp_path: Path) -> None:
+    """A completed eviction revokes the whole reachable set in one transition."""
+    ledger = _seed_chain(tmp_path)
+    store = open_tombstones(tmp_path)
+    recall = store.evict("key_root", "pr_reverted", ledger=ledger, ts=5)
+
+    assert recall.tombstoned == ["key_root", "key_child", "key_grand"]
+    assert recall.consumers == ["run_a", "run_b", "run_c"]
+    assert set(store.all()) == {"key_root", "key_child", "key_grand"}
+
+
+def test_concurrent_evictions_preserve_every_tombstone(tmp_path: Path) -> None:
+    """Parallel evictions serialise; no revocation is lost to a lost update."""
+    ledger = open_ledger(tmp_path)
+    keys = [f"key_{i:02d}" for i in range(12)]
+    for key in keys:
+        ledger.record(ServedFromEdge(cache_key=key, consumer=f"run_{key}"))
+    store = open_tombstones(tmp_path)
+    barrier = threading.Barrier(len(keys))
+
+    def _evict(key: str) -> None:
+        barrier.wait(timeout=10)
+        store.evict(key, "bulk", ledger=ledger, ts=3)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(keys)) as pool:
+        list(pool.map(_evict, keys))
+
+    assert set(store.all()) == set(keys)
+
+
+def test_eviction_verdict_is_deterministic(tmp_path: Path) -> None:
+    """Two operators evicting the same key produce identical recall sets."""
+    left = tmp_path / "left"
+    right = tmp_path / "right"
+    recalls = [
+        TombstoneStore(root / "tombstones.jsonl").evict(
+            "key_root",
+            "pr_reverted",
+            ledger=_seed_chain(root),
+            ts=11,
+        )
+        for root in (left, right)
+    ]
+    assert recalls[0].to_dict() == recalls[1].to_dict()


### PR DESCRIPTION
Closes #2637

Three integrity gaps in the cache policy engine, each with a regression test written before the fix.

## Path containment

A cache key reached the filesystem as a raw path component. `bernstein cache evict ../../../../pwned` resolved its recall report to `<workdir>/.sdd/pwne.json`, outside the `.sdd/caching/policy/` directory it was supposed to stay in.

- `validate_cache_key` accepts a single self-contained path component (`[0-9A-Za-z][0-9A-Za-z._-]*`, max 128 chars) and refuses separators, traversal segments, NULs, control characters, leading dots, and leading dashes.
- `resolve_cached_path` resolves the composed path and asserts strict containment inside the cache base directory, so an intermediate symlink cannot escape either.
- Refusal is a typed `UnsafeCacheKeyError` raised before any filesystem work, so a refused key never creates, truncates, or overwrites a file.
- Applied at every boundary where a key becomes a path: the recall report, the served-from ledger write, the spine artifact path, and the arbiter backlog. The CLI refuses with exit code 2 before touching the tombstone journal or the audit chain.

## Claim atomicity

`CacheKeyArbiter` created its backlog row outside the claim lock. Two contenders arriving before the backlog existed could each create it, the second overwriting a claim the first had already been granted. Measured on the pre-fix code: a 16-thread cold-start race produced two or three winners in 9 of 20 runs, meaning duplicate spawns of a minutes-to-hours agent run. `release` had the same shape, mutating the row in an unlocked read-modify-write that could clobber a concurrent claim.

- `backlog_transaction` is exported from `core/tasks/claim.py` as the claim protocol's transaction boundary. It holds the same cross-thread and cross-process lock `claim_next_entry` takes and yields the backlog loaded under it.
- Row creation, the eligibility test, the claim flip, the winner read, and the release all run inside one held lock, so create-if-absent and claim are a single transaction rather than a check-then-act pair.
- The claim predicate is `ClaimFilter().allows` scoped to the arbiter's own row, so a shared backlog directory can never hand the arbiter a foreign row to claim.

## Eviction crash consistency

Transitive revocation appended one row per reachable key. An interruption part-way left the served-from graph partially revoked, so a derived key kept serving a value whose root had already been recalled.

- Every tombstone the walk produces is serialised before any byte is written, then the whole journal is replaced with temp + fsync + os.replace while the journal lock is held.
- A failure while serialising leaves the journal untouched; a failure during the write leaves the previous journal in place, because the rename is the only step that publishes new contents. A revocation is one all-or-nothing transition.
- The lock also makes the read-modify-replace cycle safe against a concurrent eviction, which would otherwise lose one writer's rows entirely.

## Determinism and receipt semantics

Unchanged. Key composition, the freshness verdict function, recall-set ordering, and the signed duplicate-of receipt body are all untouched, so two operators still derive byte-identical cache keys, verdicts, recall sets, and receipts. `ClaimOutcome` winner and position semantics are preserved and pinned by a test.

## Tests

`tests/unit/test_cache_hardening.py`, 43 cases:

- Path containment: key validation table, contained and refused path composition, ledger and spine and arbiter refusals, and a CLI test asserting the traversal target is never written.
- Claim atomicity: deterministic tests that the row is not created and the release does not mutate while another party holds the claim lock, plus a 16-contender cold-start race and a release-versus-contend race.
- Crash consistency: an interrupted eviction revokes nothing and does not damage prior tombstones, a completed eviction revokes the whole reachable set, concurrent evictions lose no rows, and two operators produce identical recall sets.

Verified the tests fail against the pre-fix logic before implementing.

## Gates

`uv run ruff check`, `uv run ruff format --check`, pyright on the changed modules (no new errors), and the cache plus claim unit suites: 154 passed.

## Summary by Sourcery

Harden cache key handling and cache eviction to prevent path escapes, race conditions, and partial revocations.

New Features:
- Introduce reusable helpers for validating cache keys and resolving cache-relative paths, along with a slug utility for recall report filenames.

Bug Fixes:
- Ensure cache key based file paths, including recall reports, backlog files, and served-from artifacts, are strictly contained within their cache directories and reject unsafe keys.
- Make cache key arbitration fully atomic by performing backlog row creation, claim, winner inspection, and release within a shared claim transaction boundary.
- Guarantee cache eviction journal updates are crash-consistent and atomic so transitive revocations either fully apply or leave prior tombstones untouched.
- Prevent the CLI cache eviction command from writing any files when given an unsafe cache key path, exiting with a non-zero status instead.

Enhancements:
- Expose a backlog transaction context manager to share the claim protocol’s locking guarantees with other components.
- Refine cache arbitration and eviction docstrings and comments to document determinism, crash consistency, and safety guarantees.

Tests:
- Add an extensive cache hardening test suite covering path containment, claim atomicity under contention, crash-consistent eviction behavior, and determinism of recall sets.