### PR TITLE
fix(tasks): bind suspend receipts to their row and gate resume mutations

### DIFF
--- a/docs/operations/durable-suspend-resume.md
+++ b/docs/operations/durable-suspend-resume.md
@@ -98,11 +98,29 @@ guarantees back the proof:
 - Mutating the suspend **receipt** breaks the HMAC audit chain at that exact
   position, which `bernstein audit verify` reports.
 
-The verifier only reports success on a complete, self-consistent proof. It
-refuses a park that was never resumed, a resume receipt that hangs off some
-other park's suspend receipt, a receipt naming a suspend or resume row the task
-journal does not hold, and a park carrying more than one settlement. Partial
-evidence is a failure, not a pass.
+The outcome is a tri-state on the `status` field, so a caller can branch on it
+without parsing messages:
+
+| `status` | meaning | exit code |
+|---|---|---|
+| `verified` | a settlement happened and its proof holds | 0 |
+| `pending` | the park has not settled yet, nothing to prove | 0 |
+| `failed` | a settlement is claimed but its evidence does not hold | 1 |
+
+`failed` is reserved for a real break: a resume receipt hanging off another
+park's suspend receipt, a receipt naming a suspend or resume row the task
+journal does not hold, a park carrying more than one settlement, or a broken
+chain or journal.
+
+A live park reports `pending`, not `failed`. It is an incomplete lifecycle
+rather than a broken proof, and reporting it as a failure would bury real
+breaks when sweeping a fleet that has parked tasks in it. The `ok` field means
+"no integrity failure found" and so covers both `verified` and `pending`; test
+`status == "verified"` when you need a settled, proven continuity.
+
+The distinction between `pending` and `failed` is which suspend row a resume
+receipt *claims*, not merely whether any resume exists: a task parked twice
+with only the first park settled leaves the second park `pending`.
 
 ## What the resume path refuses
 

--- a/docs/operations/durable-suspend-resume.md
+++ b/docs/operations/durable-suspend-resume.md
@@ -100,8 +100,9 @@ guarantees back the proof:
 
 The verifier only reports success on a complete, self-consistent proof. It
 refuses a park that was never resumed, a resume receipt that hangs off some
-other park's suspend receipt, and a receipt naming a suspend or resume row the
-task journal does not hold. Partial evidence is a failure, not a pass.
+other park's suspend receipt, a receipt naming a suspend or resume row the task
+journal does not hold, and a park carrying more than one settlement. Partial
+evidence is a failure, not a pass.
 
 ## What the resume path refuses
 
@@ -116,6 +117,11 @@ before anything is written:
 - A park recorded `--until approval` refuses to append a resume row until the
   approval decision has landed. The gate is enforced where the mutation
   happens, not only at the call site.
+- A park settles **once**. If a `task.resume_receipt` already hangs off the
+  suspend receipt, a second resume is refused. The decision file records that
+  the operator approved, not how many times that approval may be spent, so the
+  settlement record on the chain is what bounds it to one. To resume again,
+  park again and obtain a fresh suspend receipt.
 - A `task_id` that is not a plain identifier is refused outright rather than
   sanitised, so it can never be used to read or write an approval record
   outside `.sdd/runtime/approvals`.

--- a/docs/operations/durable-suspend-resume.md
+++ b/docs/operations/durable-suspend-resume.md
@@ -98,6 +98,31 @@ guarantees back the proof:
 - Mutating the suspend **receipt** breaks the HMAC audit chain at that exact
   position, which `bernstein audit verify` reports.
 
+The verifier only reports success on a complete, self-consistent proof. It
+refuses a park that was never resumed, a resume receipt that hangs off some
+other park's suspend receipt, and a receipt naming a suspend or resume row the
+task journal does not hold. Partial evidence is a failure, not a pass.
+
+## What the resume path refuses
+
+The suspend receipt is selected by identity, never by recency, and is checked
+before anything is written:
+
+- A receipt bound to a **different suspend row** or a **different task** is
+  refused, so a task parked more than once cannot resume against the wrong
+  park and a substituted receipt has nothing to match.
+- A receipt hash **absent from the audit chain** is refused; a non-empty hash
+  is not evidence on its own.
+- A park recorded `--until approval` refuses to append a resume row until the
+  approval decision has landed. The gate is enforced where the mutation
+  happens, not only at the call site.
+- A `task_id` that is not a plain identifier is refused outright rather than
+  sanitised, so it can never be used to read or write an approval record
+  outside `.sdd/runtime/approvals`.
+
+Every one of these refusals lands before the journal is touched, so a refused
+resume leaves the task's Merkle chain byte-identical to the parked state.
+
 ## Commands
 
 ```bash

--- a/src/bernstein/cli/commands/approve_cmd.py
+++ b/src/bernstein/cli/commands/approve_cmd.py
@@ -106,10 +106,20 @@ def approve(task_id: str, workdir: str, prompt: bool) -> None:
     Example:
       bernstein approve T-abc123
     """
-    approvals_dir = Path(workdir) / ".sdd" / "runtime" / "approvals"
+    from bernstein.core.orchestration.approval_gate import UnsafeApprovalIdError, approval_path
+
+    # The decision file name is derived from task_id, so the id goes through the
+    # same rule the read side uses. Validated before mkdir: an unchecked id here
+    # created directories and wrote a decision file anywhere on disk.
+    try:
+        decision_file = approval_path(Path(workdir), task_id, ".approved")
+        rejected_file = approval_path(Path(workdir), task_id, ".rejected")
+    except UnsafeApprovalIdError as exc:
+        console.print(f"[red]Refusing to approve:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+    approvals_dir = decision_file.parent
     approvals_dir.mkdir(parents=True, exist_ok=True)
-    decision_file = approvals_dir / f"{task_id}.approved"
-    rejected_file = approvals_dir / f"{task_id}.rejected"
 
     if rejected_file.exists():
         console.print(

--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -724,6 +724,19 @@ def verify_suspension_cmd(task_id: str, workdir: str, as_json: bool) -> None:
         raise SystemExit(0 if result.ok else 1)
 
     console.print()
+    if result.pending:
+        # A live park is an incomplete lifecycle, not a break. It exits 0, the
+        # same as before this distinction existed, so operator scripts that
+        # sweep parked fleets keep working.
+        console.print(
+            Panel(
+                f"[bold yellow]Suspension not settled yet[/bold yellow]\ntask [bold]{task_id}[/bold]: "
+                "parked, no resume recorded. Nothing to verify until it resumes.",
+                border_style="yellow",
+                expand=False,
+            )
+        )
+        raise SystemExit(0)
     if result.ok:
         detail = f"continued {result.effective_mode}"
         if result.effective_mode == "warm":

--- a/src/bernstein/cli/commands/chat_cmd.py
+++ b/src/bernstein/cli/commands/chat_cmd.py
@@ -579,14 +579,20 @@ class _ChatTaskRequest:
 
 
 def _write_approval_decision(workdir: Path, approval_id: str, decision: str) -> None:
-    """Write ``<approval_id>.approved`` or ``.rejected`` for the security gate."""
-    approvals_dir = workdir / ".sdd" / "runtime" / "approvals"
-    approvals_dir.mkdir(parents=True, exist_ok=True)
-    suffix = "approved" if decision == "approve" else "rejected"
-    (approvals_dir / f"{approval_id}.{suffix}").write_text(
-        "via chat bridge\n",
-        encoding="utf-8",
-    )
+    """Write ``<approval_id>.approved`` or ``.rejected`` for the security gate.
+
+    The id arrives over a chat bridge, so it goes through the same identifier
+    rule and containment check as every other approvals sink.
+
+    Raises:
+        UnsafeApprovalIdError: The id would escape the approvals directory.
+    """
+    from bernstein.core.orchestration.approval_gate import approval_path
+
+    suffix = ".approved" if decision == "approve" else ".rejected"
+    target = approval_path(workdir, approval_id, suffix)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("via chat bridge\n", encoding="utf-8")
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/cli/commands/reject_cmd.py
+++ b/src/bernstein/cli/commands/reject_cmd.py
@@ -48,10 +48,18 @@ def reject(task_id: str, workdir: str, prompt: bool) -> None:
     Example:
       bernstein reject T-abc123
     """
-    approvals_dir = Path(workdir) / ".sdd" / "runtime" / "approvals"
+    from bernstein.core.orchestration.approval_gate import UnsafeApprovalIdError, approval_path
+
+    # Same rule as the approve and read sides; validated before mkdir.
+    try:
+        decision_file = approval_path(Path(workdir), task_id, ".rejected")
+        approved_file = approval_path(Path(workdir), task_id, ".approved")
+    except UnsafeApprovalIdError as exc:
+        console.print(f"[red]Refusing to reject:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+    approvals_dir = decision_file.parent
     approvals_dir.mkdir(parents=True, exist_ok=True)
-    decision_file = approvals_dir / f"{task_id}.rejected"
-    approved_file = approvals_dir / f"{task_id}.approved"
 
     if approved_file.exists():
         console.print(

--- a/src/bernstein/cli/commands/task_cmd.py
+++ b/src/bernstein/cli/commands/task_cmd.py
@@ -943,6 +943,7 @@ def task_resume(task_id: str, workdir: str, worktree: str | None, mode: str, as_
         ReleaseWithoutReceiptError,
         ResumeApprovalRequiredError,
         SuspendReceiptMismatchError,
+        SuspensionAlreadySettledError,
         UnsafeTaskIdError,
         approval_decision_ref,
         find_suspension_receipt,
@@ -1000,6 +1001,7 @@ def task_resume(task_id: str, workdir: str, worktree: str | None, mode: str, as_
         ReleaseWithoutReceiptError,
         ResumeApprovalRequiredError,
         SuspendReceiptMismatchError,
+        SuspensionAlreadySettledError,
         UnsafeTaskIdError,
     ) as exc:
         console.print(f"[red]Refusing to resume:[/red] {exc}")

--- a/src/bernstein/cli/commands/task_cmd.py
+++ b/src/bernstein/cli/commands/task_cmd.py
@@ -841,7 +841,21 @@ def task_suspend(
     from bernstein.core.orchestration.approval_gate import write_pending_sentinel
     from bernstein.core.tasks.checkpoint_retry import latest_checkpoint
     from bernstein.core.tasks.models import ApprovalSpec
-    from bernstein.core.tasks.suspension import WAKE_APPROVAL, park_task
+    from bernstein.core.tasks.suspension import (
+        WAKE_APPROVAL,
+        UnsafeTaskIdError,
+        park_task,
+        validate_task_id,
+    )
+
+    # The park derives filesystem names (the journal run dir, and the approval
+    # sentinel under --until approval) from the task id, so it is checked as an
+    # identifier before anything is written.
+    try:
+        validate_task_id(task_id)
+    except UnsafeTaskIdError as exc:
+        console.print(f"[red]Refusing to park:[/red] {exc}")
+        raise SystemExit(1) from exc
 
     sdd_dir, chain, ledger = _suspension_context(workdir, task_id)
 
@@ -924,14 +938,25 @@ def task_resume(task_id: str, workdir: str, worktree: str | None, mode: str, as_
     Example:
       bernstein task resume T-abc123
     """
-    from bernstein.core.security.audit_chain import EVENT_TASK_SUSPENDED
     from bernstein.core.tasks.suspension import (
         WAKE_APPROVAL,
+        ReleaseWithoutReceiptError,
+        ResumeApprovalRequiredError,
+        SuspendReceiptMismatchError,
+        UnsafeTaskIdError,
         approval_decision_ref,
+        find_suspension_receipt,
         latest_suspension,
         resume_task,
+        validate_task_id,
         write_resume_marker,
     )
+
+    try:
+        validate_task_id(task_id)
+    except UnsafeTaskIdError as exc:
+        console.print(f"[red]Refusing to resume:[/red] {exc}")
+        raise SystemExit(1) from exc
 
     sdd_dir, chain, ledger = _suspension_context(workdir, task_id)
 
@@ -947,22 +972,38 @@ def task_resume(task_id: str, workdir: str, worktree: str | None, mode: str, as_
             console.print(f"[yellow]Parked until approval:[/yellow] run 'bernstein approve {task_id}' before resuming.")
             raise SystemExit(1)
 
-    # The suspend receipt hash is the identity bound at park time; recover it
-    # from the audit chain so the resume references exactly that receipt.
-    suspend_events = [e for e in chain.query(event_type=EVENT_TASK_SUSPENDED) if e.details.get("task_id") == task_id]
-    suspend_receipt_hash = suspend_events[-1].hmac if suspend_events else ""
+    # The suspend receipt is selected by identity, not by recency: it must be
+    # the receipt that binds *this* suspend row's hash and journal index. A task
+    # parked more than once therefore never resumes against another park's
+    # receipt, and a substituted receipt has nothing to match.
+    receipt = find_suspension_receipt(chain=chain, task_id=task_id, suspend_row=suspend_row)
+    if receipt is None:
+        console.print(
+            f"[red]No suspend receipt binds the parked row for task[/red] [bold]{task_id}[/bold] "
+            f"([dim]parked-at {suspend_row.event_hash[:16]}[/dim])."
+        )
+        raise SystemExit(1)
 
     new_worktree = Path(worktree) if worktree else Path(suspend_row.worktree_path or workdir)
-    result = resume_task(
-        sdd_dir=sdd_dir,
-        suspend_row=suspend_row,
-        new_worktree_path=new_worktree,
-        chain=chain,
-        suspend_receipt_hash=suspend_receipt_hash,
-        requested_mode=mode,
-        ledger=ledger,
-        approval_ref=approval_ref,
-    )
+    try:
+        result = resume_task(
+            sdd_dir=sdd_dir,
+            suspend_row=suspend_row,
+            new_worktree_path=new_worktree,
+            chain=chain,
+            suspend_receipt_hash=receipt.hmac,
+            requested_mode=mode,
+            ledger=ledger,
+            approval_ref=approval_ref,
+        )
+    except (
+        ReleaseWithoutReceiptError,
+        ResumeApprovalRequiredError,
+        SuspendReceiptMismatchError,
+        UnsafeTaskIdError,
+    ) as exc:
+        console.print(f"[red]Refusing to resume:[/red] {exc}")
+        raise SystemExit(1) from exc
     if approval_ref:
         write_resume_marker(Path(workdir), task_id, result.resume_receipt_hash)
 

--- a/src/bernstein/core/orchestration/approval_gate.py
+++ b/src/bernstein/core/orchestration/approval_gate.py
@@ -58,16 +58,32 @@ _RUNTIME_REL = Path(".sdd") / "runtime" / "approvals"
 #:
 #: Every sink under :data:`_RUNTIME_REL` derives its name from a caller-supplied
 #: id (``<id>.pending`` / ``.approved`` / ``.rejected`` / ``.resumed``), so the
-#: id is an identifier and never a path fragment: no separator, no traversal
-#: segment, no NUL, no leading dot. If two call sites can disagree about this
-#: rule they eventually will, so all of them go through :func:`approval_path`.
+#: id is an identifier and never a path fragment. If two call sites can disagree
+#: about this rule they eventually will, so all of them go through
+#: :func:`approval_path_in`.
 #:
-#: The 59-character bound is set by the narrowest downstream sink rather than
-#: chosen freely: a parked task's journal run id is ``"task-" + task_id`` and
-#: ``EventJournal`` caps that at 64 characters. A looser bound here would let an
-#: over-long id past this typed refusal only to abort with a bare ``ValueError``
-#: deeper in the stack.
-_APPROVAL_ID_RE = re.compile(r"\A[A-Za-z0-9][A-Za-z0-9._-]{0,58}\Z")
+#: **Length is 64**, matching the prevailing identifier rule in this codebase
+#: (``replay.journal``, ``run_service.paths``, ``orchestration.missions``,
+#: ``persistence.work_ledger``). A tighter bound here would refuse ids those
+#: surfaces accept and strand them with no operator remedy. A caller with a
+#: narrower downstream budget enforces that budget at its own boundary rather
+#: than tightening this shared rule (see
+#: :func:`bernstein.core.tasks.suspension.validate_task_id`, which additionally
+#: caps at 59 because a parked task's journal run id is ``"task-" + task_id``).
+#:
+#: **The first character must be alphanumeric.** This is deliberately stricter
+#: than the prevailing rule, which admits a leading dot and therefore matches
+#: ``.`` and ``..``. Those surfaces are not always joined onto a directory; this
+#: one always is, so traversal segments must be impossible here.
+#:
+#: **A colon is refused**, unlike ``evidence.run_artifacts`` which admits it for
+#: MCP-supplied ids. A colon cannot be made safe for a path that is joined and
+#: then written: on Windows ``C:evil`` parses as a drive-relative path, so
+#: ``base / "C:evil.approved"`` discards the base entirely, and ``file:stream``
+#: addresses an NTFS alternate data stream, which a containment check cannot
+#: see because the path itself still looks contained. Verified for both shapes;
+#: see the mismatch test in ``tests/unit/test_task_suspension.py``.
+_APPROVAL_ID_RE = re.compile(r"\A[A-Za-z0-9][A-Za-z0-9._-]{0,63}\Z")
 
 
 class UnsafeApprovalIdError(ValueError):
@@ -83,9 +99,9 @@ def validate_approval_id(approval_id: str) -> str:
     """Return *approval_id* if it is a safe single path segment, else refuse.
 
     Raises:
-        UnsafeApprovalIdError: The id is empty, longer than 59 characters, or
-            contains any character outside ``[A-Za-z0-9._-]`` (and it must not
-            start with a dot, which rules out ``.`` and ``..``).
+        UnsafeApprovalIdError: The id is empty, longer than 64 characters, or
+            contains any character outside ``[A-Za-z0-9._-]`` (and it must
+            start with an alphanumeric, which rules out ``.`` and ``..``).
     """
     if not _APPROVAL_ID_RE.match(approval_id):
         msg = f"refusing to derive an approvals path from unsafe id {approval_id!r}"

--- a/src/bernstein/core/orchestration/approval_gate.py
+++ b/src/bernstein/core/orchestration/approval_gate.py
@@ -26,6 +26,7 @@ import contextlib
 import json
 import logging
 import os
+import re
 import tempfile
 import time
 from datetime import UTC, datetime, timedelta
@@ -53,10 +54,90 @@ _DEFAULT_POLL_INTERVAL_S: float = 0.5
 #: outstanding decision in a single ``glob``.
 _RUNTIME_REL = Path(".sdd") / "runtime" / "approvals"
 
+#: The one rule for any identifier that becomes an approvals filename.
+#:
+#: Every sink under :data:`_RUNTIME_REL` derives its name from a caller-supplied
+#: id (``<id>.pending`` / ``.approved`` / ``.rejected`` / ``.resumed``), so the
+#: id is an identifier and never a path fragment: no separator, no traversal
+#: segment, no NUL, no leading dot. If two call sites can disagree about this
+#: rule they eventually will, so all of them go through :func:`approval_path`.
+#:
+#: The 59-character bound is set by the narrowest downstream sink rather than
+#: chosen freely: a parked task's journal run id is ``"task-" + task_id`` and
+#: ``EventJournal`` caps that at 64 characters. A looser bound here would let an
+#: over-long id past this typed refusal only to abort with a bare ``ValueError``
+#: deeper in the stack.
+_APPROVAL_ID_RE = re.compile(r"\A[A-Za-z0-9][A-Za-z0-9._-]{0,58}\Z")
+
+
+class UnsafeApprovalIdError(ValueError):
+    """Raised when an id cannot be used to derive an approvals filename.
+
+    Fail closed: the identifier is rejected outright rather than sanitised, so
+    a traversal attempt surfaces as a refusal instead of silently reading or
+    writing a record outside the approvals directory.
+    """
+
+
+def validate_approval_id(approval_id: str) -> str:
+    """Return *approval_id* if it is a safe single path segment, else refuse.
+
+    Raises:
+        UnsafeApprovalIdError: The id is empty, longer than 59 characters, or
+            contains any character outside ``[A-Za-z0-9._-]`` (and it must not
+            start with a dot, which rules out ``.`` and ``..``).
+    """
+    if not _APPROVAL_ID_RE.match(approval_id):
+        msg = f"refusing to derive an approvals path from unsafe id {approval_id!r}"
+        raise UnsafeApprovalIdError(msg)
+    return approval_id
+
 
 def _approvals_dir(workdir: Path) -> Path:
     """Return the canonical approvals directory rooted at *workdir*."""
     return workdir / _RUNTIME_REL
+
+
+def approval_path_in(approvals_dir: Path, approval_id: str, suffix: str) -> Path:
+    """Return the contained ``<approvals_dir>/<approval_id><suffix>`` path.
+
+    The single implementation every approvals sink resolves to. Two
+    independent gates, both fail closed: the identifier allowlist above, then a
+    resolved-path containment check. Resolving both the candidate and the base
+    means a symlinked approvals directory is followed consistently, while a
+    candidate landing anywhere outside the resolved base is refused -- which is
+    what catches a symlinked decision file, something the allowlist alone
+    cannot see.
+
+    Args:
+        approvals_dir: The approvals directory itself.
+        approval_id: Task or approval identifier.
+        suffix: File suffix including the dot, e.g. ``".approved"``.
+
+    Raises:
+        UnsafeApprovalIdError: The id is unsafe, or the resolved path escapes
+            the approvals directory.
+    """
+    validate_approval_id(approval_id)
+    resolved_base = approvals_dir.resolve()
+    candidate = (approvals_dir / f"{approval_id}{suffix}").resolve()
+    if candidate.parent != resolved_base or not candidate.is_relative_to(resolved_base):
+        msg = f"refusing approvals path outside {resolved_base} for id {approval_id!r}"
+        raise UnsafeApprovalIdError(msg)
+    return candidate
+
+
+def approval_path(workdir: Path, approval_id: str, suffix: str) -> Path:
+    """Return the contained ``<workdir>/.sdd/runtime/approvals/<id><suffix>``.
+
+    Convenience wrapper over :func:`approval_path_in` for the common case where
+    the caller holds a project root rather than the approvals directory.
+
+    Raises:
+        UnsafeApprovalIdError: The id is unsafe, or the resolved path escapes
+            the approvals directory.
+    """
+    return approval_path_in(_approvals_dir(workdir), approval_id, suffix)
 
 
 def _atomic_write_json(path: Path, payload: dict[str, object]) -> None:
@@ -171,18 +252,18 @@ def _publish_actor_event(
 
 
 def _pending_path(workdir: Path, task_id: str) -> Path:
-    """Return the ``<task_id>.pending`` sentinel path."""
-    return _approvals_dir(workdir) / f"{task_id}.pending"
+    """Return the ``<task_id>.pending`` sentinel path (validated, contained)."""
+    return approval_path(workdir, task_id, ".pending")
 
 
 def _approved_path(workdir: Path, task_id: str) -> Path:
-    """Return the ``<task_id>.approved`` decision path."""
-    return _approvals_dir(workdir) / f"{task_id}.approved"
+    """Return the ``<task_id>.approved`` decision path (validated, contained)."""
+    return approval_path(workdir, task_id, ".approved")
 
 
 def _rejected_path(workdir: Path, task_id: str) -> Path:
-    """Return the ``<task_id>.rejected`` decision path."""
-    return _approvals_dir(workdir) / f"{task_id}.rejected"
+    """Return the ``<task_id>.rejected`` decision path (validated, contained)."""
+    return approval_path(workdir, task_id, ".rejected")
 
 
 def write_pending_sentinel(

--- a/src/bernstein/core/security/approval.py
+++ b/src/bernstein/core/security/approval.py
@@ -92,9 +92,13 @@ def _default_poll_decision(
     Returns:
         ``"approved"`` or ``"rejected"``.
     """
+    from bernstein.core.orchestration.approval_gate import approval_path_in
+
+    # The same single implementation every other approvals sink resolves to,
+    # in the variant that takes the directory rather than a project root.
     deadline = time.monotonic() + max_wait_s
-    approved_path = approvals_dir / f"{task_id}.approved"
-    rejected_path = approvals_dir / f"{task_id}.rejected"
+    approved_path = approval_path_in(approvals_dir, task_id, ".approved")
+    rejected_path = approval_path_in(approvals_dir, task_id, ".rejected")
 
     while time.monotonic() < deadline:
         if approved_path.exists():

--- a/src/bernstein/core/tasks/suspension.py
+++ b/src/bernstein/core/tasks/suspension.py
@@ -61,11 +61,15 @@ from __future__ import annotations
 
 import hashlib
 import logging
-import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.orchestration.approval_gate import (
+    UnsafeApprovalIdError,
+    approval_path,
+    validate_approval_id,
+)
 from bernstein.core.replay.journal import (
     EventJournal,
     JournalVerifyResult,
@@ -125,22 +129,18 @@ CONTINUITY_VERIFIED = "verified"
 CONTINUITY_PENDING = "pending"
 CONTINUITY_FAILED = "failed"
 
-#: A ``task_id`` is an opaque identifier, never a path fragment. Anything that
-#: reaches a filesystem name derived from it (the approval decision file, the
-#: resume marker) is matched against this anchored allowlist first: it admits no
-#: separator, no traversal segment, no NUL, and no leading dot, so the derived
-#: name is always a single safe path segment.
-#:
-#: The 59-character bound is set by the narrowest sink downstream, not picked
-#: freely: the park builds the journal run id as ``"task-" + task_id`` and
-#: ``EventJournal`` enforces ``{1,64}`` on it. A looser bound here would let an
-#: over-long id past this typed refusal only to abort with a bare ValueError
-#: from the journal, so the validator matches the budget it is protecting.
-_TASK_ID_RE = re.compile(r"\A[A-Za-z0-9][A-Za-z0-9._-]{0,58}\Z")
-
 #: Approvals live under ``<workdir>/.sdd/runtime/approvals``; the same relative
 #: root the pre-spawn approval gate writes its sentinels into.
 _APPROVALS_REL = Path(".sdd") / "runtime" / "approvals"
+
+#: The identifier rule and the contained-path builder are owned by
+#: :mod:`bernstein.core.orchestration.approval_gate`, the module that owns the
+#: approvals directory. This module deliberately does not keep its own copy:
+#: ``bernstein approve`` / ``reject``, the pre-spawn gate, and the park/resume
+#: path all write into the same directory, and a second copy of the rule is a
+#: second thing to drift. :class:`UnsafeTaskIdError` is an alias, not a
+#: subclass, so a refusal raised by any sink is the same type everywhere.
+UnsafeTaskIdError = UnsafeApprovalIdError
 
 
 class ReleaseWithoutReceiptError(RuntimeError):
@@ -192,17 +192,12 @@ class ResumeApprovalRequiredError(RuntimeError):
     """
 
 
-class UnsafeTaskIdError(ValueError):
-    """Raised when a ``task_id`` cannot be used to derive a filesystem name.
-
-    Fail closed: the identifier is rejected outright rather than sanitised, so
-    a traversal attempt surfaces as a refusal instead of silently reading or
-    writing a neighbouring task's approval record.
-    """
-
-
 def validate_task_id(task_id: str) -> str:
     """Return ``task_id`` if it is a safe single path segment, else refuse.
+
+    Thin delegation to the one rule in
+    :func:`~bernstein.core.orchestration.approval_gate.validate_approval_id`,
+    kept here as the name the task-side callers use.
 
     Raises:
         UnsafeTaskIdError: The identifier is empty, longer than 59 characters
@@ -210,32 +205,21 @@ def validate_task_id(task_id: str) -> str:
             ``[A-Za-z0-9._-]`` (and it must not start with a dot, which rules
             out ``.`` and ``..``).
     """
-    if not _TASK_ID_RE.match(task_id):
-        msg = f"refusing to derive a path from unsafe task id {task_id!r}"
-        raise UnsafeTaskIdError(msg)
-    return task_id
+    return validate_approval_id(task_id)
 
 
 def _contained_approval_path(workdir: Path, task_id: str, suffix: str) -> Path:
-    """Return ``<workdir>/.sdd/runtime/approvals/<task_id><suffix>``, contained.
+    """Return the contained ``<approvals>/<task_id><suffix>`` path.
 
-    Two independent gates, both fail closed: the identifier allowlist above,
-    then a resolved-path containment check. Resolving both the candidate and
-    the base means a symlinked approvals directory is followed consistently,
-    while a candidate that lands anywhere outside the resolved base is refused.
+    Delegates to :func:`~bernstein.core.orchestration.approval_gate.approval_path`
+    so this module and the CLI decision commands cannot disagree about either
+    the identifier rule or the containment check.
 
     Raises:
         UnsafeTaskIdError: The identifier is unsafe, or the resolved path
             escapes the approvals directory.
     """
-    validate_task_id(task_id)
-    base = workdir / _APPROVALS_REL
-    resolved_base = base.resolve()
-    candidate = (base / f"{task_id}{suffix}").resolve()
-    if candidate.parent != resolved_base or not candidate.is_relative_to(resolved_base):
-        msg = f"refusing approval path outside {resolved_base} for task id {task_id!r}"
-        raise UnsafeTaskIdError(msg)
-    return candidate
+    return approval_path(workdir, task_id, suffix)
 
 
 # ---------------------------------------------------------------------------
@@ -468,31 +452,109 @@ def find_suspension_receipt(
     return None
 
 
-def find_resume_receipt(
-    *,
-    chain: AuditChainStore,
-    task_id: str,
-    suspend_receipt_hash: str,
-) -> AuditEvent | None:
-    """Return the ``task.resume_receipt`` that already settled this park.
+@dataclass(frozen=True)
+class Settlement:
+    """One record claiming that a park was settled.
 
-    A park settles once. The chain is the settlement record, so this is the
-    check that makes a resume non-replayable: if a resume receipt already hangs
-    off ``suspend_receipt_hash``, the park is spent.
+    A settlement is recorded twice, in two independent stores: the HMAC audit
+    chain (``task.resume_receipt``) and the task's own event journal
+    (``task.resume`` row). Both are represented here so the mutation guard and
+    the offline proof can share one definition instead of each inventing its
+    own.
+
+    Attributes:
+        source: ``"chain"`` or ``"journal"``.
+        identifier: The receipt HMAC, or the journal row's ``event_hash``.
+        binds_receipt: Whether it references the park's suspend receipt hash.
+        binds_row: Whether it references the park's suspend row hash.
+    """
+
+    source: str
+    identifier: str
+    binds_receipt: bool
+    binds_row: bool
+
+    @property
+    def consistent(self) -> bool:
+        """Whether it references *both* identifiers of the same park."""
+        return self.binds_receipt and self.binds_row
+
+
+def find_settlements(
+    *,
+    sdd_dir: Path,
+    task_id: str,
+    chain: AuditChainStore,
+    suspend_receipt_hash: str,
+    suspend_event_hash: str,
+) -> list[Settlement]:
+    """Return every record claiming to settle this park, from **both** stores.
+
+    This is the single definition of "settled" that the resume guard and the
+    continuity proof both use. Two properties matter:
+
+    * **Both stores are consulted.** A settlement is written to the audit chain
+      *and* to the task journal. HMAC chaining only detects modification or
+      removal of a non-terminal entry, so dropping the last line of the audit
+      file leaves ``chain.verify()`` returning ``True`` while erasing the
+      receipt. The journal still holds the resume row, so the union of the two
+      stores is what an attacker would have to defeat, not either one alone.
+    * **A claim is either identifier, not both.** A record that references the
+      park's suspend receipt *or* its suspend row is claiming this park. A
+      record matching only one is inconsistent evidence: it must not be
+      silently ignored by the proof while the guard treats it as settled, which
+      is exactly how the two paths drifted apart before.
+
+    Args:
+        sdd_dir: Project ``.sdd`` directory (for the task journal).
+        task_id: The parked task.
+        chain: Audit chain store holding the receipts.
+        suspend_receipt_hash: HMAC of the park's suspend receipt.
+        suspend_event_hash: Merkle hash of the park's suspend row.
 
     Returns:
-        The settling :class:`AuditEvent`, or ``None`` when the park is unspent.
+        Every claiming record, in chain-then-journal order.
     """
     from bernstein.core.security.audit_chain import EVENT_TASK_RESUMED
 
-    for event in reversed(chain.query(event_type=EVENT_TASK_RESUMED)):
+    found: list[Settlement] = []
+
+    for event in chain.query(event_type=EVENT_TASK_RESUMED):
         details = event.details
         if str(details.get("task_id", "")) != task_id:
             continue
-        if str(details.get("suspend_receipt_hash", "")) != suspend_receipt_hash:
+        binds_receipt = (
+            bool(suspend_receipt_hash) and str(details.get("suspend_receipt_hash", "")) == suspend_receipt_hash
+        )
+        binds_row = bool(suspend_event_hash) and str(details.get("suspend_event_hash", "")) == suspend_event_hash
+        if binds_receipt or binds_row:
+            found.append(
+                Settlement(
+                    source="chain",
+                    identifier=event.hmac,
+                    binds_receipt=binds_receipt,
+                    binds_row=binds_row,
+                )
+            )
+
+    for row in _journal_rows(sdd_dir, task_id):
+        if row.get("event") != JOURNAL_EVENT_RESUME:
             continue
-        return event
-    return None
+        if str(row.get("task_id", "")) != task_id:
+            continue
+        binds_receipt = bool(suspend_receipt_hash) and str(row.get("suspend_receipt_hash", "")) == suspend_receipt_hash
+        binds_row = bool(suspend_event_hash) and str(row.get("continued_from_event_hash", "")) == suspend_event_hash
+        if binds_receipt or binds_row:
+            found.append(
+                Settlement(
+                    source="journal",
+                    identifier=str(row.get("event_hash", "")),
+                    binds_receipt=binds_receipt,
+                    binds_row=binds_row,
+                )
+            )
+
+    return found
 
 
 def verify_suspension_receipt(
@@ -967,15 +1029,20 @@ def resume_task(
     # A park settles once. Without this the approval gate below would be a
     # presence check that one decision file could satisfy repeatedly, so a
     # single operator approval would authorise an unbounded number of resumes.
-    settled_by = find_resume_receipt(
-        chain=chain,
+    # The same definition the offline proof uses, over the same two stores, so
+    # the two cannot disagree about whether this park is spent.
+    settlements = find_settlements(
+        sdd_dir=sdd_dir,
         task_id=suspend_row.task_id,
+        chain=chain,
         suspend_receipt_hash=suspend_receipt_hash,
+        suspend_event_hash=suspend_row.event_hash,
     )
-    if settled_by is not None:
+    if settlements:
+        sources = ", ".join(sorted({f"{s.source}:{s.identifier[:16]}" for s in settlements}))
         msg = (
-            f"refusing to resume task {suspend_row.task_id!r}: this park was already settled by "
-            f"resume receipt {settled_by.hmac[:16]}... (park again to obtain a fresh suspend receipt)"
+            f"refusing to resume task {suspend_row.task_id!r}: this park was already settled "
+            f"({sources}) (park again to obtain a fresh suspend receipt)"
         )
         raise SuspensionAlreadySettledError(msg)
     if suspend_row.wake_condition == WAKE_APPROVAL and not approval_ref:
@@ -1277,12 +1344,43 @@ def verify_suspension_continuity(
             status=CONTINUITY_FAILED,
         )
 
+    journal_rows = _journal_rows(sdd_dir, task_id)
+
+    # Scope is every park on the task, not just the latest. Scoping the proof
+    # to suspend_events[-1] meant an ordinary "park again" -- the very
+    # remediation documented for a spent park -- stopped the verifier looking
+    # at earlier parks, so replay damage already on the chain self-laundered.
+    # An attacker never has to defeat the check; they just add a park.
+    for earlier in suspend_events:
+        earlier_hash = str(earlier.details.get("suspend_event_hash", ""))
+        earlier_settlements = find_settlements(
+            sdd_dir=sdd_dir,
+            task_id=task_id,
+            chain=chain,
+            suspend_receipt_hash=earlier.hmac,
+            suspend_event_hash=earlier_hash,
+        )
+        chain_consistent = [s for s in earlier_settlements if s.source == "chain" and s.consistent]
+        if len(chain_consistent) > 1:
+            errors.append(
+                f"park {earlier_hash[:16]}... was settled {len(chain_consistent)} times: "
+                "a suspend receipt must carry exactly one resume receipt"
+            )
+        # A record that matches one identifier of a park but not the other is
+        # inconsistent evidence about that park. The writer treats it as a
+        # settlement (it will refuse to resume), so the proof must surface it
+        # rather than reporting nothing at all.
+        for inconsistent in (s for s in earlier_settlements if s.source == "chain" and not s.consistent):
+            which = "suspend receipt" if inconsistent.binds_receipt else "suspend row"
+            errors.append(
+                f"resume receipt {inconsistent.identifier[:16]}... references the {which} of park "
+                f"{earlier_hash[:16]}... but not its counterpart: the settlement record is inconsistent"
+            )
+
     suspend_event = suspend_events[-1]
     parked_hash = str(suspend_event.details.get("suspend_event_hash", ""))
     if not parked_hash:
         errors.append(f"suspend receipt for task {task_id!r} binds no suspend row hash")
-
-    journal_rows = _journal_rows(sdd_dir, task_id)
 
     # The receipt must reference a suspend row that actually exists in this
     # task's journal: a receipt naming a row no journal holds is unrelated
@@ -1292,41 +1390,22 @@ def verify_suspension_continuity(
             f"suspend receipt references suspend row {parked_hash[:16]}... which is absent from the task journal"
         )
 
-    # A receipt "claims" this park when it names the parked suspend row. That
-    # is what separates a live park from a forgery: a task parked twice, with
-    # only the first park resumed, has resume receipts on the chain that claim
-    # a *different* row, and its second park is simply pending -- not broken.
-    claimants = [
-        e for e in resume_events if parked_hash and str(e.details.get("suspend_event_hash", "")) == parked_hash
+    # The reported lifecycle state describes the current (latest) park, using
+    # the same settlement definition as the guard: a record consistent on both
+    # identifiers of this park.
+    bound_resumes = [
+        e
+        for e in resume_events
+        if parked_hash
+        and str(e.details.get("suspend_event_hash", "")) == parked_hash
+        and str(e.details.get("suspend_receipt_hash", "")) == suspend_event.hmac
     ]
-
-    # Select by binding, not by recency: the resume receipt must hang off *this*
-    # suspend receipt and name *this* suspend row. Anything else is a resume of
-    # some other park and proves nothing about this one.
-    bound_resumes = [e for e in claimants if str(e.details.get("suspend_receipt_hash", "")) == suspend_event.hmac]
-
-    # One park, one settlement. More than one resume receipt hanging off a
-    # single suspend receipt means a settled decision was replayed, which the
-    # proof must surface rather than quietly reporting the last one.
-    if len(bound_resumes) > 1:
-        errors.append(
-            f"park was settled {len(bound_resumes)} times: a suspend receipt must carry exactly one resume receipt"
-        )
 
     resumed = bool(bound_resumes)
     effective_mode = ""
     workspace_match = False
     downgrade_reason = ""
-    if not bound_resumes and claimants:
-        # Something claims to have settled this exact park but does not hang off
-        # its receipt. That is a forged or foreign settlement, not a live park.
-        claimed_by = str(claimants[-1].details.get("suspend_receipt_hash", ""))
-        errors.append(
-            "no resume receipt continued from the parked suspend row: a receipt claims suspend row "
-            f"{parked_hash[:16]}... but hangs off suspend receipt {claimed_by[:16]}..., "
-            f"not {suspend_event.hmac[:16]}..."
-        )
-    elif bound_resumes:
+    if bound_resumes:
         resume_event = bound_resumes[-1]
         effective_mode = str(resume_event.details.get("effective_mode", ""))
         workspace_match = bool(resume_event.details.get("workspace_match", False))
@@ -1388,13 +1467,14 @@ __all__ = [
     "ResourceHandles",
     "ResumeApprovalRequiredError",
     "ResumeResult",
+    "Settlement",
     "SuspendReceiptMismatchError",
     "SuspendRow",
     "SuspensionAlreadySettledError",
     "UnsafeTaskIdError",
     "approval_decision_ref",
     "decide_resume",
-    "find_resume_receipt",
+    "find_settlements",
     "find_suspension_receipt",
     "latest_suspension",
     "park_task",

--- a/src/bernstein/core/tasks/suspension.py
+++ b/src/bernstein/core/tasks/suspension.py
@@ -38,9 +38,11 @@ there is no suspension, only a dead process:
   that a resumed task continued from exactly the parked workspace hash, or
   reads the recorded fork/cold downgrade with its reason. Mutating the suspend
   row after the fact fails journal verification at that exact chain position,
-  and incomplete or unrelated evidence (an unresumed park, a resume receipt
-  hanging off another park, a receipt naming a row the journal never held) is
-  refused rather than reported as verified.
+  and unrelated evidence (a resume receipt hanging off another park, a receipt
+  naming a row the journal never held, a park settled twice) is refused rather
+  than reported as verified. A park that has not settled yet reports
+  ``pending`` rather than failing: a live park is an incomplete lifecycle, not
+  a broken proof.
 * **A receipt only counts for the park it binds.** Every release and every
   resume resolves the claimed ``task.suspend_receipt`` on the chain and checks
   it names this task and this suspend row (:func:`verify_suspension_receipt`)
@@ -109,6 +111,19 @@ RESOURCE_BUDGET = "budget"
 #: task resumes only once ``bernstein approve <task-id>`` lands its decision
 #: file (see :func:`approval_decision_ref`).
 WAKE_APPROVAL = "approval"
+
+#: Machine-readable outcomes of :func:`verify_suspension_continuity`. A caller
+#: branches on these rather than parsing an error string.
+#:
+#: A live park and a broken proof are different things and must not collapse
+#: into one signal: an operator sweeping a fleet with parked tasks would see
+#: every live park as a failure and the real breaks would drown. ``pending``
+#: therefore means "this park has not settled yet, so there is nothing to
+#: verify", while ``failed`` is reserved for a settlement that actually
+#: happened against evidence that does not hold.
+CONTINUITY_VERIFIED = "verified"
+CONTINUITY_PENDING = "pending"
+CONTINUITY_FAILED = "failed"
 
 #: A ``task_id`` is an opaque identifier, never a path fragment. Anything that
 #: reaches a filesystem name derived from it (the approval decision file, the
@@ -1110,11 +1125,18 @@ class ContinuityResult:
     """Outcome of :func:`verify_suspension_continuity`.
 
     Attributes:
-        ok: ``True`` only when every check passed: audit HMAC chain intact,
-            task journal Merkle chain intact, and a resume receipt that hangs
-            off the parked suspend receipt and continued from exactly the
-            parked suspend row. An unresumed park is an incomplete proof and
-            reports ``False``.
+        status: The machine-readable outcome, one of
+            :data:`CONTINUITY_VERIFIED`, :data:`CONTINUITY_PENDING`, or
+            :data:`CONTINUITY_FAILED`. Branch on this. ``verified`` means a
+            settlement happened and its proof holds; ``pending`` means the park
+            has not settled yet, so there is nothing to prove; ``failed`` means
+            a settlement is claimed but its evidence does not hold.
+        ok: ``True`` when no integrity failure was found, which covers both
+            ``verified`` and ``pending``. This is deliberately *not* "a resume
+            was verified" -- a live park is not a broken proof, and collapsing
+            the two would make every parked task in a fleet sweep look like a
+            failure. Test ``status == CONTINUITY_VERIFIED`` (or ``resumed``)
+            when you need a settled, proven continuity.
         chain_ok: Whether the HMAC audit chain verified.
         journal_ok: Whether the task journal Merkle chain verified.
         resumed: Whether a resume receipt *bound to the parked suspend receipt*
@@ -1135,9 +1157,21 @@ class ContinuityResult:
     workspace_match: bool
     downgrade_reason: str
     errors: list[str] = field(default_factory=list)
+    status: str = CONTINUITY_FAILED
+
+    @property
+    def pending(self) -> bool:
+        """Whether the park simply has not settled yet (nothing to prove)."""
+        return self.status == CONTINUITY_PENDING
+
+    @property
+    def verified(self) -> bool:
+        """Whether a settlement happened *and* its continuity proof holds."""
+        return self.status == CONTINUITY_VERIFIED
 
     def to_dict(self) -> dict[str, Any]:
         return {
+            "status": self.status,
             "ok": self.ok,
             "chain_ok": self.chain_ok,
             "journal_ok": self.journal_ok,
@@ -1191,11 +1225,21 @@ def verify_suspension_continuity(
        or cold downgrade with its reason);
     4. both receipts name rows the task journal actually holds.
 
-    Incomplete or unrelated evidence fails. A park that was never resumed has
-    nothing to prove and reports ``ok=False``; a resume receipt bound to some
-    other park's suspend receipt is not this park's proof; and a receipt naming
-    a suspend or resume row absent from the journal is refused rather than
-    treated as a verified continuation.
+    The outcome is a tri-state on :attr:`ContinuityResult.status`:
+
+    * ``verified`` -- a settlement happened and its proof holds.
+    * ``pending`` -- the park has not settled yet, so there is nothing to
+      prove. Not a failure: a live park is an incomplete lifecycle, and
+      reporting it as broken would bury real breaks in a fleet sweep.
+    * ``failed`` -- a settlement is claimed but its evidence does not hold: a
+      resume receipt hanging off another park's suspend receipt, a receipt
+      naming a suspend or resume row the journal does not hold, more than one
+      settlement of a single park, or a broken chain or journal.
+
+    The distinction between ``pending`` and ``failed`` is which suspend row a
+    resume receipt *claims*, not merely whether any resume exists: a task
+    parked twice with only the first park settled leaves the second park
+    ``pending``, because those receipts claim a different row.
 
     No worker, no network, no live worktree is required -- everything is read
     from the chain and the journal.
@@ -1230,6 +1274,7 @@ def verify_suspension_continuity(
             workspace_match=False,
             downgrade_reason="",
             errors=errors,
+            status=CONTINUITY_FAILED,
         )
 
     suspend_event = suspend_events[-1]
@@ -1247,16 +1292,18 @@ def verify_suspension_continuity(
             f"suspend receipt references suspend row {parked_hash[:16]}... which is absent from the task journal"
         )
 
+    # A receipt "claims" this park when it names the parked suspend row. That
+    # is what separates a live park from a forgery: a task parked twice, with
+    # only the first park resumed, has resume receipts on the chain that claim
+    # a *different* row, and its second park is simply pending -- not broken.
+    claimants = [
+        e for e in resume_events if parked_hash and str(e.details.get("suspend_event_hash", "")) == parked_hash
+    ]
+
     # Select by binding, not by recency: the resume receipt must hang off *this*
     # suspend receipt and name *this* suspend row. Anything else is a resume of
     # some other park and proves nothing about this one.
-    bound_resumes = [
-        e
-        for e in resume_events
-        if str(e.details.get("suspend_receipt_hash", "")) == suspend_event.hmac
-        and parked_hash
-        and str(e.details.get("suspend_event_hash", "")) == parked_hash
-    ]
+    bound_resumes = [e for e in claimants if str(e.details.get("suspend_receipt_hash", "")) == suspend_event.hmac]
 
     # One park, one settlement. More than one resume receipt hanging off a
     # single suspend receipt means a settled decision was replayed, which the
@@ -1270,19 +1317,16 @@ def verify_suspension_continuity(
     effective_mode = ""
     workspace_match = False
     downgrade_reason = ""
-    if not resume_events:
-        # An unresumed park is an incomplete proof. The continuity claim is
-        # "resumed from exactly the parked state"; with no resume receipt there
-        # is nothing to verify, so it must not report as verified.
-        errors.append(f"no resume receipt found for task {task_id!r}: continuity proof is incomplete")
-    elif not bound_resumes:
-        latest = resume_events[-1]
-        continued_from = str(latest.details.get("suspend_event_hash", ""))
+    if not bound_resumes and claimants:
+        # Something claims to have settled this exact park but does not hang off
+        # its receipt. That is a forged or foreign settlement, not a live park.
+        claimed_by = str(claimants[-1].details.get("suspend_receipt_hash", ""))
         errors.append(
-            "no resume receipt continued from the parked suspend row "
-            f"(latest continued_from={continued_from[:16]}..., parked={parked_hash[:16]}...)"
+            "no resume receipt continued from the parked suspend row: a receipt claims suspend row "
+            f"{parked_hash[:16]}... but hangs off suspend receipt {claimed_by[:16]}..., "
+            f"not {suspend_event.hmac[:16]}..."
         )
-    else:
+    elif bound_resumes:
         resume_event = bound_resumes[-1]
         effective_mode = str(resume_event.details.get("effective_mode", ""))
         workspace_match = bool(resume_event.details.get("workspace_match", False))
@@ -1302,7 +1346,17 @@ def verify_suspension_continuity(
         if effective_mode == str(RetryMode.WARM) and not workspace_match:
             errors.append("warm resume recorded without a workspace-hash match")
 
-    ok = chain_ok and journal_ok and resumed and not errors
+    # No failure found: the park is either settled and proven, or still live.
+    # A live park keeps ok=True so a fleet sweep is not flooded with false
+    # failures and so the CLI's exit code for the ordinary parked case is
+    # unchanged; ``status`` is what tells the two apart.
+    ok = chain_ok and journal_ok and not errors
+    if not ok:
+        status = CONTINUITY_FAILED
+    elif resumed:
+        status = CONTINUITY_VERIFIED
+    else:
+        status = CONTINUITY_PENDING
     return ContinuityResult(
         ok=ok,
         chain_ok=chain_ok,
@@ -1312,10 +1366,14 @@ def verify_suspension_continuity(
         workspace_match=workspace_match,
         downgrade_reason=downgrade_reason,
         errors=errors,
+        status=status,
     )
 
 
 __all__ = [
+    "CONTINUITY_FAILED",
+    "CONTINUITY_PENDING",
+    "CONTINUITY_VERIFIED",
     "JOURNAL_EVENT_RESUME",
     "JOURNAL_EVENT_SUSPEND",
     "RESOURCE_BUDGET",

--- a/src/bernstein/core/tasks/suspension.py
+++ b/src/bernstein/core/tasks/suspension.py
@@ -37,7 +37,17 @@ there is no suspension, only a dead process:
   :func:`verify_suspension_continuity` checks, offline from a copied chain,
   that a resumed task continued from exactly the parked workspace hash, or
   reads the recorded fork/cold downgrade with its reason. Mutating the suspend
-  row after the fact fails journal verification at that exact chain position.
+  row after the fact fails journal verification at that exact chain position,
+  and incomplete or unrelated evidence (an unresumed park, a resume receipt
+  hanging off another park, a receipt naming a row the journal never held) is
+  refused rather than reported as verified.
+* **A receipt only counts for the park it binds.** Every release and every
+  resume resolves the claimed ``task.suspend_receipt`` on the chain and checks
+  it names this task and this suspend row (:func:`verify_suspension_receipt`)
+  before it mutates anything, so a substituted receipt cannot drive a state
+  change. The approval wake gate is enforced in :func:`resume_task` itself,
+  and a ``task_id`` that is not a plain identifier never reaches a filesystem
+  name.
 
 Scope relative to steer.pause (#2508): steer.pause is the momentary in-place
 halt for quick correction; this is the durable variant that frees
@@ -49,6 +59,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -72,7 +83,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from bernstein.core.persistence.work_ledger import LedgerEntry, WorkLedger
-    from bernstein.core.security.audit_chain import AuditChainStore
+    from bernstein.core.security.audit_chain import AuditChainStore, AuditEvent
 
 logger = logging.getLogger(__name__)
 
@@ -99,6 +110,17 @@ RESOURCE_BUDGET = "budget"
 #: file (see :func:`approval_decision_ref`).
 WAKE_APPROVAL = "approval"
 
+#: A ``task_id`` is an opaque identifier, never a path fragment. Anything that
+#: reaches a filesystem name derived from it (the approval decision file, the
+#: resume marker) is matched against this anchored allowlist first: it admits no
+#: separator, no traversal segment, no NUL, and no leading dot, so the derived
+#: name is always a single safe path segment.
+_TASK_ID_RE = re.compile(r"\A[A-Za-z0-9][A-Za-z0-9._-]{0,127}\Z")
+
+#: Approvals live under ``<workdir>/.sdd/runtime/approvals``; the same relative
+#: root the pre-spawn approval gate writes its sentinels into.
+_APPROVALS_REL = Path(".sdd") / "runtime" / "approvals"
+
 
 class ReleaseWithoutReceiptError(RuntimeError):
     """Raised when an infrastructure release runs without a suspend receipt.
@@ -108,6 +130,73 @@ class ReleaseWithoutReceiptError(RuntimeError):
     ``task.suspend_receipt`` hash. A release with no matching receipt is a
     dead process, not a suspension, so it is rejected before any effect runs.
     """
+
+
+class SuspendReceiptMismatchError(RuntimeError):
+    """Raised when a suspend receipt does not bind the park it is used for.
+
+    A non-empty hash is not evidence. The receipt must exist on the HMAC chain
+    as a ``task.suspend_receipt``, name this ``task_id``, and -- when the caller
+    knows which park it is continuing -- bind exactly that suspend row's
+    ``event_hash`` and journal index. A receipt from a different row, a
+    different task, or no row at all is refused before any effect or mutation,
+    so a substituted receipt can never drive a state change.
+    """
+
+
+class ResumeApprovalRequiredError(RuntimeError):
+    """Raised when an ``--until approval`` park is resumed with no decision.
+
+    The wake gate is part of the parked state, so it is enforced where the
+    mutation happens rather than only at the call site: a park recorded with
+    :data:`WAKE_APPROVAL` refuses to append a resume row until the approval
+    decision digest is supplied.
+    """
+
+
+class UnsafeTaskIdError(ValueError):
+    """Raised when a ``task_id`` cannot be used to derive a filesystem name.
+
+    Fail closed: the identifier is rejected outright rather than sanitised, so
+    a traversal attempt surfaces as a refusal instead of silently reading or
+    writing a neighbouring task's approval record.
+    """
+
+
+def validate_task_id(task_id: str) -> str:
+    """Return ``task_id`` if it is a safe single path segment, else refuse.
+
+    Raises:
+        UnsafeTaskIdError: The identifier is empty, over-long, or contains any
+            character outside ``[A-Za-z0-9._-]`` (and it must not start with a
+            dot, which rules out ``.`` and ``..``).
+    """
+    if not _TASK_ID_RE.match(task_id):
+        msg = f"refusing to derive a path from unsafe task id {task_id!r}"
+        raise UnsafeTaskIdError(msg)
+    return task_id
+
+
+def _contained_approval_path(workdir: Path, task_id: str, suffix: str) -> Path:
+    """Return ``<workdir>/.sdd/runtime/approvals/<task_id><suffix>``, contained.
+
+    Two independent gates, both fail closed: the identifier allowlist above,
+    then a resolved-path containment check. Resolving both the candidate and
+    the base means a symlinked approvals directory is followed consistently,
+    while a candidate that lands anywhere outside the resolved base is refused.
+
+    Raises:
+        UnsafeTaskIdError: The identifier is unsafe, or the resolved path
+            escapes the approvals directory.
+    """
+    validate_task_id(task_id)
+    base = workdir / _APPROVALS_REL
+    resolved_base = base.resolve()
+    candidate = (base / f"{task_id}{suffix}").resolve()
+    if candidate.parent != resolved_base or not candidate.is_relative_to(resolved_base):
+        msg = f"refusing approval path outside {resolved_base} for task id {task_id!r}"
+        raise UnsafeTaskIdError(msg)
+    return candidate
 
 
 # ---------------------------------------------------------------------------
@@ -298,6 +387,124 @@ def latest_suspension(sdd_dir: Path, task_id: str) -> SuspendRow | None:
 
 
 # ---------------------------------------------------------------------------
+# Receipt identity (the receipt must bind the park it is used for)
+# ---------------------------------------------------------------------------
+
+
+def _as_index(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def find_suspension_receipt(
+    *,
+    chain: AuditChainStore,
+    task_id: str,
+    suspend_row: SuspendRow,
+) -> AuditEvent | None:
+    """Return the ``task.suspend_receipt`` bound to exactly ``suspend_row``.
+
+    Selection is by identity, not recency: the receipt must name ``task_id``
+    and bind the row's ``event_hash`` and journal index. A task parked more
+    than once therefore resolves to the receipt for the row being resumed
+    rather than to whichever receipt happens to be last on the chain.
+
+    Returns:
+        The matching :class:`AuditEvent`, or ``None`` when the chain holds no
+        receipt for this row.
+    """
+    from bernstein.core.security.audit_chain import EVENT_TASK_SUSPENDED
+
+    for event in reversed(chain.query(event_type=EVENT_TASK_SUSPENDED)):
+        details = event.details
+        if str(details.get("task_id", "")) != task_id:
+            continue
+        if str(details.get("suspend_event_hash", "")) != suspend_row.event_hash:
+            continue
+        if _as_index(details.get("journal_index")) != suspend_row.journal_index:
+            continue
+        return event
+    return None
+
+
+def verify_suspension_receipt(
+    *,
+    chain: AuditChainStore,
+    task_id: str,
+    suspend_receipt_hash: str,
+    suspend_event_hash: str = "",
+    journal_index: int | None = None,
+) -> AuditEvent:
+    """Return the suspend receipt for ``suspend_receipt_hash``, or refuse.
+
+    The identity check every release and every resume runs *before* it mutates
+    anything: the hash must resolve to a real ``task.suspend_receipt`` on the
+    HMAC chain, that receipt must belong to ``task_id``, and -- when the caller
+    supplies them -- it must bind the given suspend row hash and journal index.
+
+    Args:
+        chain: The audit chain store holding the receipt.
+        task_id: The task the caller is acting on.
+        suspend_receipt_hash: HMAC of the receipt being claimed.
+        suspend_event_hash: Optional suspend row hash the receipt must bind.
+        journal_index: Optional journal index the receipt must bind.
+
+    Returns:
+        The validated :class:`AuditEvent`.
+
+    Raises:
+        ReleaseWithoutReceiptError: ``suspend_receipt_hash`` is empty.
+        SuspendReceiptMismatchError: The hash names no receipt on the chain, or
+            the receipt it names binds a different task or a different row.
+    """
+    from bernstein.core.security.audit_chain import EVENT_TASK_SUSPENDED
+
+    if not suspend_receipt_hash:
+        raise ReleaseWithoutReceiptError(f"refusing to act on task {task_id!r}: no suspend receipt (fail closed)")
+
+    matches = [e for e in chain.query(event_type=EVENT_TASK_SUSPENDED) if e.hmac == suspend_receipt_hash]
+    if not matches:
+        msg = (
+            f"refusing to act on task {task_id!r}: no task.suspend_receipt on the chain "
+            f"with hmac {suspend_receipt_hash[:16]}..."
+        )
+        raise SuspendReceiptMismatchError(msg)
+
+    receipt = matches[-1]
+    receipt_task = str(receipt.details.get("task_id", ""))
+    if receipt_task != task_id:
+        msg = (
+            f"refusing to act on task {task_id!r}: suspend receipt "
+            f"{suspend_receipt_hash[:16]}... belongs to task {receipt_task!r}"
+        )
+        raise SuspendReceiptMismatchError(msg)
+
+    if suspend_event_hash:
+        bound = str(receipt.details.get("suspend_event_hash", ""))
+        if bound != suspend_event_hash:
+            msg = (
+                f"refusing to act on task {task_id!r}: suspend receipt "
+                f"{suspend_receipt_hash[:16]}... binds suspend row {bound[:16]}..., "
+                f"not the selected row {suspend_event_hash[:16]}..."
+            )
+            raise SuspendReceiptMismatchError(msg)
+
+    if journal_index is not None:
+        bound_index = _as_index(receipt.details.get("journal_index"))
+        if bound_index != journal_index:
+            msg = (
+                f"refusing to act on task {task_id!r}: suspend receipt "
+                f"{suspend_receipt_hash[:16]}... binds journal index {bound_index}, "
+                f"not the selected index {journal_index}"
+            )
+            raise SuspendReceiptMismatchError(msg)
+
+    return receipt
+
+
+# ---------------------------------------------------------------------------
 # Infrastructure release (receipt-before-effect, fail closed)
 # ---------------------------------------------------------------------------
 
@@ -345,14 +552,17 @@ def release_resources(
     reserved_usd: float,
     spent_usd: float,
     handles: ResourceHandles | None = None,
+    suspend_event_hash: str = "",
 ) -> ReleaseResult:
     """Release the seat, sandbox, process, and envelope headroom for a park.
 
-    Every release hangs off ``suspend_receipt_hash``; the hash is validated
-    *before any physical effect runs*, so a release with no matching receipt is
-    rejected and no seat, sandbox, or process is touched. Each release appends a
-    ``task.suspend_resource_release`` row to the audit chain referencing the
-    receipt, and the budget release additionally emits a chained budget event.
+    Every release hangs off ``suspend_receipt_hash``; the receipt's *identity*
+    is validated *before any physical effect runs*, so a release with no
+    matching receipt -- absent, or belonging to a different task or a different
+    suspend row -- is rejected and no seat, sandbox, or process is touched. Each
+    release appends a ``task.suspend_resource_release`` row to the audit chain
+    referencing the receipt, and the budget release additionally emits a chained
+    budget event.
 
     Args:
         chain: The audit chain store accepting the release rows.
@@ -363,14 +573,26 @@ def release_resources(
         reserved_usd: Reservation held at park time.
         spent_usd: Spend recorded against the reservation at park time.
         handles: Physical release effects; ``None`` releases only budget.
+        suspend_event_hash: Optional suspend row hash the receipt must bind, so
+            a park that ran twice cannot release against the wrong row.
 
     Raises:
         ReleaseWithoutReceiptError: ``suspend_receipt_hash`` is empty.
+        SuspendReceiptMismatchError: The hash names no receipt on the chain, or
+            the receipt it names binds a different task or suspend row.
     """
     if not suspend_receipt_hash:
         raise ReleaseWithoutReceiptError(
             f"refusing to release resources for task {task_id!r}: no suspend receipt (fail closed)"
         )
+    # Receipt identity before effect: a non-empty hash is not evidence on its
+    # own, so the receipt is resolved and checked against this park first.
+    verify_suspension_receipt(
+        chain=chain,
+        task_id=task_id,
+        suspend_receipt_hash=suspend_receipt_hash,
+        suspend_event_hash=suspend_event_hash,
+    )
 
     from bernstein.core.cost.budget_actions import build_headroom_release_event
     from bernstein.core.security.audit_chain import record_task_resource_release
@@ -485,11 +707,17 @@ def park_task(
     Returns:
         A :class:`ParkResult` with the row, receipt hash, release outcome, and
         ledger anchor.
+
+    Raises:
+        UnsafeTaskIdError: ``task_id`` is not a safe identifier. Checked at the
+            park boundary so a task can never be parked under an id the resume
+            path would later refuse.
     """
     from bernstein.core.cost.budget_actions import compute_released_headroom
     from bernstein.core.persistence.work_ledger import KIND_TASK_SUSPENDED
     from bernstein.core.security.audit_chain import record_task_suspension
 
+    validate_task_id(task_id)
     ws_hash = workspace_hash(Path(worktree_path))
     released_usd = compute_released_headroom(reserved_usd, spent_usd)
 
@@ -531,6 +759,7 @@ def park_task(
         reserved_usd=reserved_usd,
         spent_usd=spent_usd,
         handles=handles,
+        suspend_event_hash=suspend_row.event_hash,
     )
 
     ledger_entry_hash = ""
@@ -645,9 +874,33 @@ def resume_task(
 
     Returns:
         A :class:`ResumeResult` with the decision and both continuity anchors.
+
+    Raises:
+        UnsafeTaskIdError: The row's ``task_id`` is not a safe identifier.
+        ReleaseWithoutReceiptError: ``suspend_receipt_hash`` is empty.
+        SuspendReceiptMismatchError: The receipt does not bind this suspend row.
+        ResumeApprovalRequiredError: The park is gated on approval and no
+            approval decision digest was supplied.
     """
     from bernstein.core.persistence.work_ledger import KIND_TASK_RESUMED
     from bernstein.core.security.audit_chain import record_task_resume
+
+    # Every precondition is checked before the journal is touched, so a refused
+    # resume leaves the task's Merkle chain byte-identical to the parked state.
+    validate_task_id(suspend_row.task_id)
+    verify_suspension_receipt(
+        chain=chain,
+        task_id=suspend_row.task_id,
+        suspend_receipt_hash=suspend_receipt_hash,
+        suspend_event_hash=suspend_row.event_hash,
+        journal_index=suspend_row.journal_index,
+    )
+    if suspend_row.wake_condition == WAKE_APPROVAL and not approval_ref:
+        msg = (
+            f"refusing to resume task {suspend_row.task_id!r}: parked until approval and "
+            "no approval decision has landed (fail closed)"
+        )
+        raise ResumeApprovalRequiredError(msg)
 
     new_ws_hash = workspace_hash(Path(new_worktree_path))
     decision = decide_resume(
@@ -732,8 +985,16 @@ def approval_decision_ref(workdir: Path, task_id: str) -> str:
     approval can refuse to proceed until the operator lands the decision. The
     same digest is written into the resume receipt, so the approval record and
     the resume receipt reference each other.
+
+    The decision file name is derived from ``task_id``, so the identifier is
+    validated and the resolved path is confirmed to stay inside the approvals
+    directory before anything is read.
+
+    Raises:
+        UnsafeTaskIdError: ``task_id`` is not a safe single path segment, or
+            the derived path escapes the approvals directory.
     """
-    approved = workdir / ".sdd" / "runtime" / "approvals" / f"{task_id}.approved"
+    approved = _contained_approval_path(workdir, task_id, ".approved")
     if not approved.exists():
         return ""
     try:
@@ -751,10 +1012,19 @@ def write_resume_marker(workdir: Path, task_id: str, resume_receipt_hash: str) -
     ``.approved`` decision the resume receipt binds, and this marker lands the
     resume receipt hash the approval record can be checked against. Best-effort;
     a write failure is logged and the marker path returned regardless.
+
+    The marker name is derived from ``task_id``, so the identifier is validated
+    and the resolved path is confirmed to stay inside the approvals directory
+    before the directory is created or anything is written.
+
+    Raises:
+        UnsafeTaskIdError: ``task_id`` is not a safe single path segment, or
+            the derived path escapes the approvals directory.
     """
-    approvals = workdir / ".sdd" / "runtime" / "approvals"
+    validate_task_id(task_id)
+    approvals = workdir / _APPROVALS_REL
     approvals.mkdir(parents=True, exist_ok=True)
-    marker = approvals / f"{task_id}.resumed"
+    marker = _contained_approval_path(workdir, task_id, ".resumed")
     try:
         marker.write_text(resume_receipt_hash, encoding="utf-8")
     except OSError as exc:  # pragma: no cover -- defensive
@@ -773,11 +1043,14 @@ class ContinuityResult:
 
     Attributes:
         ok: ``True`` only when every check passed: audit HMAC chain intact,
-            task journal Merkle chain intact, and a resume receipt that
-            continued from exactly the parked suspend row.
+            task journal Merkle chain intact, and a resume receipt that hangs
+            off the parked suspend receipt and continued from exactly the
+            parked suspend row. An unresumed park is an incomplete proof and
+            reports ``False``.
         chain_ok: Whether the HMAC audit chain verified.
         journal_ok: Whether the task journal Merkle chain verified.
-        resumed: Whether a resume receipt for the task was found.
+        resumed: Whether a resume receipt *bound to the parked suspend receipt*
+            was found. A resume receipt for some other park does not count.
         effective_mode: The recorded continuation mode (``warm`` / ``fork`` /
             ``cold``), or ``""`` when not resumed.
         workspace_match: Whether the resume continued from the parked
@@ -812,6 +1085,23 @@ def _journal_verify(sdd_dir: Path, task_id: str) -> JournalVerifyResult:
     return verify_journal(_journal_path(sdd_dir, task_id))
 
 
+def _journal_rows(sdd_dir: Path, task_id: str) -> list[dict[str, Any]]:
+    path = _journal_path(sdd_dir, task_id)
+    if not path.exists():
+        return []
+    return list(load_events(path))
+
+
+def _row_present(rows: list[dict[str, Any]], event: str, task_id: str, event_hash: str) -> bool:
+    """Return whether ``rows`` holds a row of ``event`` with that exact hash."""
+    return any(
+        row.get("event") == event
+        and str(row.get("task_id", "")) == task_id
+        and str(row.get("event_hash", "")) == event_hash
+        for row in rows
+    )
+
+
 def verify_suspension_continuity(
     *,
     sdd_dir: Path,
@@ -826,11 +1116,18 @@ def verify_suspension_continuity(
     1. the HMAC audit chain verifies (a mutated receipt fails at its position);
     2. the task journal Merkle chain verifies (a mutated suspend row fails at
        its exact index);
-    3. a ``task.resume_receipt`` exists that references the ``suspend_receipt``
-       whose ``suspend_event_hash`` equals the parked suspend row's identity,
+    3. a ``task.resume_receipt`` exists that hangs off the parked
+       ``suspend_receipt`` *and* references the parked suspend row's identity,
        and the recorded continuation mode / workspace match / downgrade reason
        describe how it continued (warm from the parked hash, or a recorded fork
-       or cold downgrade with its reason).
+       or cold downgrade with its reason);
+    4. both receipts name rows the task journal actually holds.
+
+    Incomplete or unrelated evidence fails. A park that was never resumed has
+    nothing to prove and reports ``ok=False``; a resume receipt bound to some
+    other park's suspend receipt is not this park's proof; and a receipt naming
+    a suspend or resume row absent from the journal is refused rather than
+    treated as a verified continuation.
 
     No worker, no network, no live worktree is required -- everything is read
     from the chain and the journal.
@@ -869,21 +1166,55 @@ def verify_suspension_continuity(
 
     suspend_event = suspend_events[-1]
     parked_hash = str(suspend_event.details.get("suspend_event_hash", ""))
+    if not parked_hash:
+        errors.append(f"suspend receipt for task {task_id!r} binds no suspend row hash")
 
-    resumed = bool(resume_events)
+    journal_rows = _journal_rows(sdd_dir, task_id)
+
+    # The receipt must reference a suspend row that actually exists in this
+    # task's journal: a receipt naming a row no journal holds is unrelated
+    # evidence, not a proof of this park.
+    if parked_hash and not _row_present(journal_rows, JOURNAL_EVENT_SUSPEND, task_id, parked_hash):
+        errors.append(
+            f"suspend receipt references suspend row {parked_hash[:16]}... which is absent from the task journal"
+        )
+
+    # Select by binding, not by recency: the resume receipt must hang off *this*
+    # suspend receipt and name *this* suspend row. Anything else is a resume of
+    # some other park and proves nothing about this one.
+    bound_resumes = [
+        e
+        for e in resume_events
+        if str(e.details.get("suspend_receipt_hash", "")) == suspend_event.hmac
+        and parked_hash
+        and str(e.details.get("suspend_event_hash", "")) == parked_hash
+    ]
+
+    resumed = bool(bound_resumes)
     effective_mode = ""
     workspace_match = False
     downgrade_reason = ""
-    if resumed:
-        resume_event = resume_events[-1]
+    if not resume_events:
+        # An unresumed park is an incomplete proof. The continuity claim is
+        # "resumed from exactly the parked state"; with no resume receipt there
+        # is nothing to verify, so it must not report as verified.
+        errors.append(f"no resume receipt found for task {task_id!r}: continuity proof is incomplete")
+    elif not bound_resumes:
+        latest = resume_events[-1]
+        continued_from = str(latest.details.get("suspend_event_hash", ""))
+        errors.append(
+            "no resume receipt continued from the parked suspend row "
+            f"(latest continued_from={continued_from[:16]}..., parked={parked_hash[:16]}...)"
+        )
+    else:
+        resume_event = bound_resumes[-1]
         effective_mode = str(resume_event.details.get("effective_mode", ""))
         workspace_match = bool(resume_event.details.get("workspace_match", False))
         downgrade_reason = str(resume_event.details.get("downgrade_reason", ""))
-        continued_from = str(resume_event.details.get("suspend_event_hash", ""))
-        if continued_from != parked_hash:
+        resume_row_hash = str(resume_event.details.get("resume_event_hash", ""))
+        if not resume_row_hash or not _row_present(journal_rows, JOURNAL_EVENT_RESUME, task_id, resume_row_hash):
             errors.append(
-                "resume receipt did not continue from the parked suspend row "
-                f"(continued_from={continued_from[:16]}..., parked={parked_hash[:16]}...)"
+                f"resume receipt references resume row {resume_row_hash[:16]}... which is absent from the task journal"
             )
         # A warm continuation asserts it resumed the parked native session from
         # the parked workspace hash, so the hashes must have matched -- a warm
@@ -895,7 +1226,7 @@ def verify_suspension_continuity(
         if effective_mode == str(RetryMode.WARM) and not workspace_match:
             errors.append("warm resume recorded without a workspace-hash match")
 
-    ok = chain_ok and journal_ok and not errors
+    ok = chain_ok and journal_ok and resumed and not errors
     return ContinuityResult(
         ok=ok,
         chain_ok=chain_ok,
@@ -921,15 +1252,21 @@ __all__ = [
     "ReleaseResult",
     "ReleaseWithoutReceiptError",
     "ResourceHandles",
+    "ResumeApprovalRequiredError",
     "ResumeResult",
+    "SuspendReceiptMismatchError",
     "SuspendRow",
+    "UnsafeTaskIdError",
     "approval_decision_ref",
     "decide_resume",
+    "find_suspension_receipt",
     "latest_suspension",
     "park_task",
     "record_task_suspension_row",
     "release_resources",
     "resume_task",
+    "validate_task_id",
     "verify_suspension_continuity",
+    "verify_suspension_receipt",
     "write_resume_marker",
 ]

--- a/src/bernstein/core/tasks/suspension.py
+++ b/src/bernstein/core/tasks/suspension.py
@@ -192,20 +192,41 @@ class ResumeApprovalRequiredError(RuntimeError):
     """
 
 
-def validate_task_id(task_id: str) -> str:
-    """Return ``task_id`` if it is a safe single path segment, else refuse.
+#: Longest ``task_id`` that still fits the task journal's run-id budget.
+#:
+#: The park derives the journal run id as ``task_run_id(task_id)``, which is
+#: ``"task-" + task_id``, and :mod:`bernstein.core.replay.journal` caps a run id
+#: at 64 characters. This bound belongs here, at the boundary that actually has
+#: the constraint, rather than in the shared approvals rule: an approval id from
+#: the chat bridge or the pre-spawn gate never becomes a journal run id, so
+#: tightening the shared rule to 59 would refuse ids no downstream sink objects
+#: to. A task id between 60 and 64 characters is therefore approvable and
+#: rejectable as normal; it simply cannot be durably parked, and says so with a
+#: typed refusal instead of a bare ValueError from the journal.
+_MAX_PARKABLE_TASK_ID_LEN = 64 - len("task-")
 
-    Thin delegation to the one rule in
-    :func:`~bernstein.core.orchestration.approval_gate.validate_approval_id`,
-    kept here as the name the task-side callers use.
+
+def validate_task_id(task_id: str) -> str:
+    """Return ``task_id`` if it is safe for the park/resume path, else refuse.
+
+    The shared approvals rule
+    (:func:`~bernstein.core.orchestration.approval_gate.validate_approval_id`)
+    plus the narrower journal run-id budget this path additionally needs.
 
     Raises:
-        UnsafeTaskIdError: The identifier is empty, longer than 59 characters
-            (the journal run-id budget), or contains any character outside
-            ``[A-Za-z0-9._-]`` (and it must not start with a dot, which rules
-            out ``.`` and ``..``).
+        UnsafeTaskIdError: The identifier is empty, contains any character
+            outside ``[A-Za-z0-9._-]``, does not start with an alphanumeric
+            (which rules out ``.`` and ``..``), or is longer than
+            :data:`_MAX_PARKABLE_TASK_ID_LEN`.
     """
-    return validate_approval_id(task_id)
+    validate_approval_id(task_id)
+    if len(task_id) > _MAX_PARKABLE_TASK_ID_LEN:
+        msg = (
+            f"refusing to park task id {task_id!r}: {len(task_id)} characters exceeds the "
+            f"{_MAX_PARKABLE_TASK_ID_LEN}-character journal run-id budget"
+        )
+        raise UnsafeTaskIdError(msg)
+    return task_id
 
 
 def _contained_approval_path(workdir: Path, task_id: str, suffix: str) -> Path:
@@ -1165,16 +1186,18 @@ def write_resume_marker(workdir: Path, task_id: str, resume_receipt_hash: str) -
 
     The marker name is derived from ``task_id``, so the identifier is validated
     and the resolved path is confirmed to stay inside the approvals directory
-    before the directory is created or anything is written.
+    before the directory is created or anything is written. This is an
+    approvals sink, so it applies the shared approvals rule rather than the
+    narrower parkable-id budget: the budget is a constraint of the journal run
+    id, and a marker file is not one.
 
     Raises:
         UnsafeTaskIdError: ``task_id`` is not a safe single path segment, or
             the derived path escapes the approvals directory.
     """
-    validate_task_id(task_id)
-    approvals = workdir / _APPROVALS_REL
-    approvals.mkdir(parents=True, exist_ok=True)
+    # Resolve (and therefore validate) before creating any directory.
     marker = _contained_approval_path(workdir, task_id, ".resumed")
+    marker.parent.mkdir(parents=True, exist_ok=True)
     try:
         marker.write_text(resume_receipt_hash, encoding="utf-8")
     except OSError as exc:  # pragma: no cover -- defensive

--- a/src/bernstein/core/tasks/suspension.py
+++ b/src/bernstein/core/tasks/suspension.py
@@ -115,7 +115,13 @@ WAKE_APPROVAL = "approval"
 #: resume marker) is matched against this anchored allowlist first: it admits no
 #: separator, no traversal segment, no NUL, and no leading dot, so the derived
 #: name is always a single safe path segment.
-_TASK_ID_RE = re.compile(r"\A[A-Za-z0-9][A-Za-z0-9._-]{0,127}\Z")
+#:
+#: The 59-character bound is set by the narrowest sink downstream, not picked
+#: freely: the park builds the journal run id as ``"task-" + task_id`` and
+#: ``EventJournal`` enforces ``{1,64}`` on it. A looser bound here would let an
+#: over-long id past this typed refusal only to abort with a bare ValueError
+#: from the journal, so the validator matches the budget it is protecting.
+_TASK_ID_RE = re.compile(r"\A[A-Za-z0-9][A-Za-z0-9._-]{0,58}\Z")
 
 #: Approvals live under ``<workdir>/.sdd/runtime/approvals``; the same relative
 #: root the pre-spawn approval gate writes its sentinels into.
@@ -144,6 +150,23 @@ class SuspendReceiptMismatchError(RuntimeError):
     """
 
 
+class SuspensionAlreadySettledError(RuntimeError):
+    """Raised when a park that already carries a resume receipt is resumed again.
+
+    A suspend receipt settles exactly once. The chain is the record of that
+    settlement: if a ``task.resume_receipt`` already hangs off this suspend
+    receipt, the park is spent, and a second resume would append another resume
+    row for a decision that was already made. That is the replay of a settled
+    decision, so it is refused before the journal is touched.
+
+    This is what makes an ``--until approval`` wake gate single-use. The
+    approval decision file records *that* the operator approved, not how many
+    times the approval may be spent; the settlement record on the chain is what
+    bounds it to one. Parking the task again mints a new suspend row and a new
+    receipt, which settles once in its own right.
+    """
+
+
 class ResumeApprovalRequiredError(RuntimeError):
     """Raised when an ``--until approval`` park is resumed with no decision.
 
@@ -167,9 +190,10 @@ def validate_task_id(task_id: str) -> str:
     """Return ``task_id`` if it is a safe single path segment, else refuse.
 
     Raises:
-        UnsafeTaskIdError: The identifier is empty, over-long, or contains any
-            character outside ``[A-Za-z0-9._-]`` (and it must not start with a
-            dot, which rules out ``.`` and ``..``).
+        UnsafeTaskIdError: The identifier is empty, longer than 59 characters
+            (the journal run-id budget), or contains any character outside
+            ``[A-Za-z0-9._-]`` (and it must not start with a dot, which rules
+            out ``.`` and ``..``).
     """
     if not _TASK_ID_RE.match(task_id):
         msg = f"refusing to derive a path from unsafe task id {task_id!r}"
@@ -424,6 +448,33 @@ def find_suspension_receipt(
         if str(details.get("suspend_event_hash", "")) != suspend_row.event_hash:
             continue
         if _as_index(details.get("journal_index")) != suspend_row.journal_index:
+            continue
+        return event
+    return None
+
+
+def find_resume_receipt(
+    *,
+    chain: AuditChainStore,
+    task_id: str,
+    suspend_receipt_hash: str,
+) -> AuditEvent | None:
+    """Return the ``task.resume_receipt`` that already settled this park.
+
+    A park settles once. The chain is the settlement record, so this is the
+    check that makes a resume non-replayable: if a resume receipt already hangs
+    off ``suspend_receipt_hash``, the park is spent.
+
+    Returns:
+        The settling :class:`AuditEvent`, or ``None`` when the park is unspent.
+    """
+    from bernstein.core.security.audit_chain import EVENT_TASK_RESUMED
+
+    for event in reversed(chain.query(event_type=EVENT_TASK_RESUMED)):
+        details = event.details
+        if str(details.get("task_id", "")) != task_id:
+            continue
+        if str(details.get("suspend_receipt_hash", "")) != suspend_receipt_hash:
             continue
         return event
     return None
@@ -879,6 +930,9 @@ def resume_task(
         UnsafeTaskIdError: The row's ``task_id`` is not a safe identifier.
         ReleaseWithoutReceiptError: ``suspend_receipt_hash`` is empty.
         SuspendReceiptMismatchError: The receipt does not bind this suspend row.
+        SuspensionAlreadySettledError: This park already carries a resume
+            receipt. A park settles once, so one approval cannot be spent
+            twice; park again for a fresh suspend receipt.
         ResumeApprovalRequiredError: The park is gated on approval and no
             approval decision digest was supplied.
     """
@@ -895,6 +949,20 @@ def resume_task(
         suspend_event_hash=suspend_row.event_hash,
         journal_index=suspend_row.journal_index,
     )
+    # A park settles once. Without this the approval gate below would be a
+    # presence check that one decision file could satisfy repeatedly, so a
+    # single operator approval would authorise an unbounded number of resumes.
+    settled_by = find_resume_receipt(
+        chain=chain,
+        task_id=suspend_row.task_id,
+        suspend_receipt_hash=suspend_receipt_hash,
+    )
+    if settled_by is not None:
+        msg = (
+            f"refusing to resume task {suspend_row.task_id!r}: this park was already settled by "
+            f"resume receipt {settled_by.hmac[:16]}... (park again to obtain a fresh suspend receipt)"
+        )
+        raise SuspensionAlreadySettledError(msg)
     if suspend_row.wake_condition == WAKE_APPROVAL and not approval_ref:
         msg = (
             f"refusing to resume task {suspend_row.task_id!r}: parked until approval and "
@@ -1190,6 +1258,14 @@ def verify_suspension_continuity(
         and str(e.details.get("suspend_event_hash", "")) == parked_hash
     ]
 
+    # One park, one settlement. More than one resume receipt hanging off a
+    # single suspend receipt means a settled decision was replayed, which the
+    # proof must surface rather than quietly reporting the last one.
+    if len(bound_resumes) > 1:
+        errors.append(
+            f"park was settled {len(bound_resumes)} times: a suspend receipt must carry exactly one resume receipt"
+        )
+
     resumed = bool(bound_resumes)
     effective_mode = ""
     workspace_match = False
@@ -1256,9 +1332,11 @@ __all__ = [
     "ResumeResult",
     "SuspendReceiptMismatchError",
     "SuspendRow",
+    "SuspensionAlreadySettledError",
     "UnsafeTaskIdError",
     "approval_decision_ref",
     "decide_resume",
+    "find_resume_receipt",
     "find_suspension_receipt",
     "latest_suspension",
     "park_task",

--- a/tests/unit/test_task_suspension.py
+++ b/tests/unit/test_task_suspension.py
@@ -38,7 +38,7 @@ from bernstein.core.persistence.work_ledger import (
     WorkLedger,
     replay_state,
 )
-from bernstein.core.replay.journal import rebuild_state, verify_journal
+from bernstein.core.replay.journal import load_events, rebuild_state, verify_journal
 from bernstein.core.security.audit_chain import (
     EVENT_TASK_RESOURCE_RELEASE,
     EVENT_TASK_RESUMED,
@@ -54,8 +54,13 @@ from bernstein.core.tasks.suspension import (
     WAKE_APPROVAL,
     ReleaseWithoutReceiptError,
     ResourceHandles,
+    ResumeApprovalRequiredError,
+    SuspendReceiptMismatchError,
+    SuspendRow,
+    UnsafeTaskIdError,
     approval_decision_ref,
     decide_resume,
+    find_suspension_receipt,
     latest_suspension,
     park_task,
     release_resources,
@@ -666,3 +671,350 @@ def test_work_ledger_kinds_project_to_states(tmp_path: Path) -> None:
     state2 = replay_state(LedgerReader(tmp_path / "ledger").entries())
     assert state2.suspended_tasks == []
     assert state2.in_flight_tasks == ["T-x"]
+
+
+# ---------------------------------------------------------------------------
+# Hardening (#2636): receipt binding, approval gating, path containment,
+# and continuity proofs that refuse incomplete or unrelated evidence.
+# ---------------------------------------------------------------------------
+
+
+def _park(tmp_path: Path, chain: AuditChainStore, task_id: str, worktree: Path) -> object:
+    return park_task(
+        sdd_dir=tmp_path / ".sdd",
+        task_id=task_id,
+        adapter="claude",
+        session_id="s",
+        worktree_path=worktree,
+        envelope="subscription",
+        reserved_usd=5.0,
+        spent_usd=0.0,
+        chain=chain,
+    )
+
+
+def _journal_rows(sdd: Path, task_id: str) -> list[dict[str, object]]:
+    path = sdd / "runs" / task_run_id(task_id) / "journal.jsonl"
+    return list(load_events(path)) if path.exists() else []
+
+
+def test_resume_rejects_receipt_from_a_different_suspend_row(tmp_path: Path) -> None:
+    """A receipt bound to another suspend row must not drive a resume.
+
+    The suspension's identity is the suspend row's ``event_hash``; a receipt
+    that binds a *different* row is not evidence for this park. The refusal
+    lands before any journal mutation.
+    """
+    sdd = tmp_path / ".sdd"
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+
+    first = _park(tmp_path, chain, "T-sub", wt)
+    second = _park(tmp_path, chain, "T-sub", wt)
+    assert first.suspend_row.event_hash != second.suspend_row.event_hash
+
+    rows_before = len(_journal_rows(sdd, "T-sub"))
+    with pytest.raises(SuspendReceiptMismatchError):
+        resume_task(
+            sdd_dir=sdd,
+            suspend_row=first.suspend_row,
+            new_worktree_path=wt,
+            chain=chain,
+            suspend_receipt_hash=second.suspend_receipt_hash,
+        )
+    # Fail closed: no resume row, no resume receipt.
+    assert len(_journal_rows(sdd, "T-sub")) == rows_before
+    assert chain.query(event_type=EVENT_TASK_RESUMED) == []
+
+
+def test_resume_rejects_receipt_from_a_different_task(tmp_path: Path) -> None:
+    sdd = tmp_path / ".sdd"
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+
+    victim = _park(tmp_path, chain, "T-victim", wt)
+    foreign = _park(tmp_path, chain, "T-foreign", wt)
+
+    with pytest.raises(SuspendReceiptMismatchError):
+        resume_task(
+            sdd_dir=sdd,
+            suspend_row=victim.suspend_row,
+            new_worktree_path=wt,
+            chain=chain,
+            suspend_receipt_hash=foreign.suspend_receipt_hash,
+        )
+    assert chain.query(event_type=EVENT_TASK_RESUMED) == []
+
+
+def test_resume_rejects_a_receipt_hash_absent_from_the_chain(tmp_path: Path) -> None:
+    sdd = tmp_path / ".sdd"
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+    park = _park(tmp_path, chain, "T-ghost", wt)
+
+    with pytest.raises(SuspendReceiptMismatchError):
+        resume_task(
+            sdd_dir=sdd,
+            suspend_row=park.suspend_row,
+            new_worktree_path=wt,
+            chain=chain,
+            suspend_receipt_hash="f" * 64,
+        )
+    assert chain.query(event_type=EVENT_TASK_RESUMED) == []
+
+
+def test_release_rejects_a_receipt_bound_to_another_task(tmp_path: Path) -> None:
+    """A release must reference *this* task's receipt, not merely a non-empty one."""
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+    foreign = _park(tmp_path, chain, "T-owner", wt)
+    releases_before = len(chain.query(event_type=EVENT_TASK_RESOURCE_RELEASE))
+
+    reaped: list[str] = []
+    handles = ResourceHandles(reap_process=lambda: (reaped.append("pid"), {"pid": 1})[1])
+    with pytest.raises(SuspendReceiptMismatchError):
+        release_resources(
+            chain=chain,
+            task_id="T-other",
+            suspend_receipt_hash=foreign.suspend_receipt_hash,
+            envelope="subscription",
+            reserved_usd=10.0,
+            spent_usd=2.0,
+            handles=handles,
+        )
+    # No physical effect ran and no release row reached the chain.
+    assert reaped == []
+    assert len(chain.query(event_type=EVENT_TASK_RESOURCE_RELEASE)) == releases_before
+
+
+def test_find_suspension_receipt_selects_the_receipt_for_the_given_row(tmp_path: Path) -> None:
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+    first = _park(tmp_path, chain, "T-pick", wt)
+    second = _park(tmp_path, chain, "T-pick", wt)
+
+    assert find_suspension_receipt(chain=chain, task_id="T-pick", suspend_row=first.suspend_row) is not None
+    picked_first = find_suspension_receipt(chain=chain, task_id="T-pick", suspend_row=first.suspend_row)
+    picked_second = find_suspension_receipt(chain=chain, task_id="T-pick", suspend_row=second.suspend_row)
+    assert picked_first is not None and picked_second is not None
+    assert picked_first.hmac == first.suspend_receipt_hash
+    assert picked_second.hmac == second.suspend_receipt_hash
+
+
+def test_resume_without_approval_is_rejected_before_any_journal_mutation(tmp_path: Path) -> None:
+    """An ``--until approval`` park refuses to resume until the decision lands."""
+    sdd = tmp_path / ".sdd"
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+    park = park_task(
+        sdd_dir=sdd,
+        task_id="T-gate",
+        adapter="claude",
+        session_id="s",
+        worktree_path=wt,
+        envelope="subscription",
+        reserved_usd=5.0,
+        spent_usd=0.0,
+        chain=chain,
+        wake_condition=WAKE_APPROVAL,
+    )
+    rows_before = len(_journal_rows(sdd, "T-gate"))
+
+    with pytest.raises(ResumeApprovalRequiredError):
+        resume_task(
+            sdd_dir=sdd,
+            suspend_row=park.suspend_row,
+            new_worktree_path=wt,
+            chain=chain,
+            suspend_receipt_hash=park.suspend_receipt_hash,
+            approval_ref="",
+        )
+    assert len(_journal_rows(sdd, "T-gate")) == rows_before
+    assert chain.query(event_type=EVENT_TASK_RESUMED) == []
+
+    # Once the decision lands the same resume succeeds.
+    approvals = sdd / "runtime" / "approvals"
+    approvals.mkdir(parents=True, exist_ok=True)
+    (approvals / "T-gate.approved").write_text("approved", encoding="utf-8")
+    resume = resume_task(
+        sdd_dir=sdd,
+        suspend_row=park.suspend_row,
+        new_worktree_path=wt,
+        chain=chain,
+        suspend_receipt_hash=park.suspend_receipt_hash,
+        approval_ref=approval_decision_ref(tmp_path, "T-gate"),
+    )
+    assert resume.resume_receipt_hash
+
+
+@pytest.mark.parametrize(
+    "bad_task_id",
+    [
+        "../../../etc/passwd",
+        "..",
+        ".",
+        "../escape",
+        "sub/dir",
+        "/absolute",
+        "with space",
+        "",
+        "back\\slash",
+    ],
+)
+def test_approval_paths_refuse_unsafe_task_ids(tmp_path: Path, bad_task_id: str) -> None:
+    """``task_id`` is an identifier, never a path fragment."""
+    with pytest.raises(UnsafeTaskIdError):
+        approval_decision_ref(tmp_path, bad_task_id)
+    with pytest.raises(UnsafeTaskIdError):
+        write_resume_marker(tmp_path, bad_task_id, "deadbeef")
+
+
+def test_resume_marker_never_escapes_the_approvals_directory(tmp_path: Path) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    with pytest.raises(UnsafeTaskIdError):
+        write_resume_marker(tmp_path, "../../outside/pwned", "deadbeef")
+    assert list(outside.iterdir()) == []
+
+
+def test_approval_paths_accept_ordinary_task_ids(tmp_path: Path) -> None:
+    approvals = tmp_path / ".sdd" / "runtime" / "approvals"
+    approvals.mkdir(parents=True, exist_ok=True)
+    (approvals / "T-abc_123.def.approved").write_text("approved", encoding="utf-8")
+    assert approval_decision_ref(tmp_path, "T-abc_123.def")
+    marker = write_resume_marker(tmp_path, "T-abc_123.def", "cafe")
+    assert marker.read_text(encoding="utf-8") == "cafe"
+
+
+def test_resume_refuses_an_unsafe_task_id_on_the_suspend_row(tmp_path: Path) -> None:
+    sdd = tmp_path / ".sdd"
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+    park = _park(tmp_path, chain, "T-ok", wt)
+    forged = SuspendRow(**{**park.suspend_row.to_dict(), "task_id": "../../escape"})
+
+    with pytest.raises(UnsafeTaskIdError):
+        resume_task(
+            sdd_dir=sdd,
+            suspend_row=forged,
+            new_worktree_path=wt,
+            chain=chain,
+            suspend_receipt_hash=park.suspend_receipt_hash,
+        )
+
+
+def test_verify_continuity_rejects_a_park_that_was_never_resumed(tmp_path: Path) -> None:
+    """An unresumed park is an incomplete proof, not a verified continuity."""
+    sdd = tmp_path / ".sdd"
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+    _park(tmp_path, chain, "T-open", wt)
+
+    result = verify_suspension_continuity(sdd_dir=sdd, task_id="T-open", chain=chain)
+    assert not result.ok
+    assert not result.resumed
+    assert any("resume receipt" in err for err in result.errors)
+
+
+def test_verify_continuity_rejects_a_resume_bound_to_a_foreign_receipt(tmp_path: Path) -> None:
+    """A resume receipt must hang off *this* park's suspend receipt."""
+    from bernstein.core.security.audit_chain import record_task_resume
+
+    sdd = tmp_path / ".sdd"
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+    park = _park(tmp_path, chain, "T-forge", wt)
+    decoy = _park(tmp_path, chain, "T-decoy", wt)
+
+    # Names the parked row but hangs off a receipt from a different park.
+    record_task_resume(
+        chain=chain,
+        task_id="T-forge",
+        suspend_receipt_hash=decoy.suspend_receipt_hash,
+        suspend_event_hash=park.suspend_row.event_hash,
+        resume_event_hash="0" * 64,
+        journal_index=99,
+        effective_mode="warm",
+        requested_mode="warm",
+        workspace_match=True,
+        new_workspace_hash=park.suspend_row.workspace_hash,
+        downgrade_reason="",
+        decision_hash="0" * 64,
+    )
+
+    result = verify_suspension_continuity(sdd_dir=sdd, task_id="T-forge", chain=chain)
+    assert not result.ok
+    assert result.errors
+
+
+def test_verify_continuity_rejects_a_resume_row_absent_from_the_journal(tmp_path: Path) -> None:
+    """The receipt's resume row must exist in the task journal it claims."""
+    from bernstein.core.security.audit_chain import record_task_resume
+
+    sdd = tmp_path / ".sdd"
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+    park = _park(tmp_path, chain, "T-phantom", wt)
+
+    record_task_resume(
+        chain=chain,
+        task_id="T-phantom",
+        suspend_receipt_hash=park.suspend_receipt_hash,
+        suspend_event_hash=park.suspend_row.event_hash,
+        resume_event_hash="1" * 64,
+        journal_index=99,
+        effective_mode="warm",
+        requested_mode="warm",
+        workspace_match=True,
+        new_workspace_hash=park.suspend_row.workspace_hash,
+        downgrade_reason="",
+        decision_hash="1" * 64,
+    )
+
+    result = verify_suspension_continuity(sdd_dir=sdd, task_id="T-phantom", chain=chain)
+    assert not result.ok
+    assert any("journal" in err for err in result.errors)
+
+
+def test_receipt_selection_ignores_a_later_receipt_for_another_row(tmp_path: Path) -> None:
+    """Selection is by binding, not by recency.
+
+    This is the substitution the CLI resume path used to be open to: it took
+    the *latest* ``task.suspend_receipt`` for the task, so a later receipt
+    naming some other suspend row was accepted as evidence for the parked one.
+    """
+    from bernstein.core.security.audit_chain import record_task_suspension
+
+    sdd = tmp_path / ".sdd"
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+    park = _park(tmp_path, chain, "T-inject", wt)
+
+    # A later receipt for the same task that binds a row the journal never had.
+    injected = record_task_suspension(
+        chain=chain,
+        task_id="T-inject",
+        suspend_event_hash="9" * 64,
+        journal_index=99,
+        adapter="claude",
+        workspace_hash=park.suspend_row.workspace_hash,
+        envelope="subscription",
+        reserved_usd=5.0,
+        spent_usd=0.0,
+        released_usd=5.0,
+    )
+    assert injected.hmac != park.suspend_receipt_hash
+
+    picked = find_suspension_receipt(chain=chain, task_id="T-inject", suspend_row=park.suspend_row)
+    assert picked is not None
+    assert picked.hmac == park.suspend_receipt_hash
+
+    # And the injected receipt cannot itself drive the resume.
+    with pytest.raises(SuspendReceiptMismatchError):
+        resume_task(
+            sdd_dir=sdd,
+            suspend_row=park.suspend_row,
+            new_worktree_path=wt,
+            chain=chain,
+            suspend_receipt_hash=injected.hmac,
+        )

--- a/tests/unit/test_task_suspension.py
+++ b/tests/unit/test_task_suspension.py
@@ -47,6 +47,9 @@ from bernstein.core.security.audit_chain import (
 )
 from bernstein.core.tasks.checkpoint_retry import RetryMode, task_run_id
 from bernstein.core.tasks.suspension import (
+    CONTINUITY_FAILED,
+    CONTINUITY_PENDING,
+    CONTINUITY_VERIFIED,
     RESOURCE_BUDGET,
     RESOURCE_PROCESS,
     RESOURCE_SANDBOX,
@@ -905,17 +908,144 @@ def test_resume_refuses_an_unsafe_task_id_on_the_suspend_row(tmp_path: Path) -> 
         )
 
 
-def test_verify_continuity_rejects_a_park_that_was_never_resumed(tmp_path: Path) -> None:
-    """An unresumed park is an incomplete proof, not a verified continuity."""
+def test_verify_continuity_reports_an_unresumed_park_as_pending_not_failed(tmp_path: Path) -> None:
+    """A live park is an incomplete lifecycle, not a broken proof.
+
+    It must not claim a verified continuity (the original defect), and it must
+    not report as a failure either: an operator sweeping a fleet with live
+    parks would drown the real breaks in false alarms.
+    """
     sdd = tmp_path / ".sdd"
     chain = _chain(tmp_path)
     wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
     _park(tmp_path, chain, "T-open", wt)
 
     result = verify_suspension_continuity(sdd_dir=sdd, task_id="T-open", chain=chain)
-    assert not result.ok
+    assert result.status == CONTINUITY_PENDING
+    assert result.pending
+    assert not result.verified
     assert not result.resumed
-    assert any("resume receipt" in err for err in result.errors)
+    # Not a failure: no errors, and ok stays true so a sweep is not flooded.
+    assert result.ok
+    assert result.errors == []
+    # The distinction is machine-readable, not prose.
+    assert result.to_dict()["status"] == CONTINUITY_PENDING
+
+
+def test_pending_and_failed_are_distinguishable_without_reading_messages(tmp_path: Path) -> None:
+    """The three outcomes are separable programmatically."""
+    from bernstein.core.security.audit_chain import record_task_resume
+
+    sdd = tmp_path / ".sdd"
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+
+    # Pending: parked, never settled.
+    _park(tmp_path, chain, "T-live", wt)
+    pending = verify_suspension_continuity(sdd_dir=sdd, task_id="T-live", chain=chain)
+
+    # Verified: parked and settled cleanly.
+    settled = _park(tmp_path, chain, "T-done", wt)
+    resume_task(
+        sdd_dir=sdd,
+        suspend_row=settled.suspend_row,
+        new_worktree_path=wt,
+        chain=chain,
+        suspend_receipt_hash=settled.suspend_receipt_hash,
+    )
+    verified = verify_suspension_continuity(sdd_dir=sdd, task_id="T-done", chain=chain)
+
+    # Failed: a settlement claimed against a foreign receipt.
+    broken = _park(tmp_path, chain, "T-bad", wt)
+    decoy = _park(tmp_path, chain, "T-decoy3", wt)
+    record_task_resume(
+        chain=chain,
+        task_id="T-bad",
+        suspend_receipt_hash=decoy.suspend_receipt_hash,
+        suspend_event_hash=broken.suspend_row.event_hash,
+        resume_event_hash="0" * 64,
+        journal_index=99,
+        effective_mode="warm",
+        requested_mode="warm",
+        workspace_match=True,
+        new_workspace_hash=broken.suspend_row.workspace_hash,
+        downgrade_reason="",
+        decision_hash="0" * 64,
+    )
+    failed = verify_suspension_continuity(sdd_dir=sdd, task_id="T-bad", chain=chain)
+
+    assert (pending.status, verified.status, failed.status) == (
+        CONTINUITY_PENDING,
+        CONTINUITY_VERIFIED,
+        CONTINUITY_FAILED,
+    )
+    # ok separates "nothing broken" from "broken"; status separates the rest.
+    assert pending.ok and verified.ok and not failed.ok
+    assert not pending.resumed and verified.resumed and not failed.resumed
+
+
+def test_second_park_is_pending_while_the_first_park_is_settled(tmp_path: Path) -> None:
+    """Resume receipts that claim a *different* row leave this park pending.
+
+    Without the claim check, the earlier park's resume receipt would look like
+    a foreign settlement of the live park and report a false failure.
+    """
+    sdd = tmp_path / ".sdd"
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+
+    first = _park(tmp_path, chain, "T-again", wt)
+    resume_task(
+        sdd_dir=sdd,
+        suspend_row=first.suspend_row,
+        new_worktree_path=wt,
+        chain=chain,
+        suspend_receipt_hash=first.suspend_receipt_hash,
+    )
+    assert verify_suspension_continuity(sdd_dir=sdd, task_id="T-again", chain=chain).verified
+
+    # Park it again; the new park has not settled.
+    _park(tmp_path, chain, "T-again", wt)
+    result = verify_suspension_continuity(sdd_dir=sdd, task_id="T-again", chain=chain)
+    assert result.status == CONTINUITY_PENDING, result.errors
+    assert result.ok
+    assert result.errors == []
+
+
+def test_verify_suspension_cli_exit_codes_are_stable_across_states(tmp_path: Path) -> None:
+    """Live parks keep exit 0; only a real break exits 1."""
+    from click.testing import CliRunner
+
+    from bernstein.cli.commands.audit_cmd import audit_group
+    from bernstein.cli.commands.task_cmd import task_group
+
+    root = tmp_path
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+    runner = CliRunner()
+
+    parked = runner.invoke(task_group, ["suspend", "T-exit", "--workdir", str(root), "--worktree", str(wt), "--json"])
+    assert parked.exit_code == 0, parked.output
+
+    # Parked, not resumed: exit 0, and the text says so rather than claiming
+    # a verified continuity.
+    pending = runner.invoke(audit_group, ["verify-suspension", "T-exit", "--workdir", str(root)])
+    assert pending.exit_code == 0, pending.output
+    assert "not settled yet" in " ".join(pending.output.split())
+
+    pending_json = runner.invoke(audit_group, ["verify-suspension", "T-exit", "--workdir", str(root), "--json"])
+    assert pending_json.exit_code == 0
+    assert '"status": "pending"' in " ".join(pending_json.output.split())
+
+    # Resumed cleanly: still exit 0, now reported as verified.
+    resumed = runner.invoke(task_group, ["resume", "T-exit", "--workdir", str(root), "--worktree", str(wt), "--json"])
+    assert resumed.exit_code == 0, resumed.output
+    done = runner.invoke(audit_group, ["verify-suspension", "T-exit", "--workdir", str(root)])
+    assert done.exit_code == 0, done.output
+    assert "continuity verified" in " ".join(done.output.split()).lower()
+
+    # A task with no suspend receipt at all is still a failure: exit 1.
+    missing = runner.invoke(audit_group, ["verify-suspension", "T-nosuch", "--workdir", str(root)])
+    assert missing.exit_code == 1
 
 
 def test_verify_continuity_rejects_a_resume_bound_to_a_foreign_receipt(tmp_path: Path) -> None:

--- a/tests/unit/test_task_suspension.py
+++ b/tests/unit/test_task_suspension.py
@@ -57,6 +57,7 @@ from bernstein.core.tasks.suspension import (
     ResumeApprovalRequiredError,
     SuspendReceiptMismatchError,
     SuspendRow,
+    SuspensionAlreadySettledError,
     UnsafeTaskIdError,
     approval_decision_ref,
     decide_resume,
@@ -65,6 +66,7 @@ from bernstein.core.tasks.suspension import (
     park_task,
     release_resources,
     resume_task,
+    validate_task_id,
     verify_suspension_continuity,
     write_resume_marker,
 )
@@ -944,7 +946,10 @@ def test_verify_continuity_rejects_a_resume_bound_to_a_foreign_receipt(tmp_path:
 
     result = verify_suspension_continuity(sdd_dir=sdd, task_id="T-forge", chain=chain)
     assert not result.ok
-    assert result.errors
+    # Assert *which* guard fired. Without this the test passes on the phantom
+    # journal-row check alone and the binding filter ships uncovered.
+    assert any("no resume receipt continued from the parked suspend row" in err for err in result.errors), result.errors
+    assert not result.resumed
 
 
 def test_verify_continuity_rejects_a_resume_row_absent_from_the_journal(tmp_path: Path) -> None:
@@ -1018,3 +1023,301 @@ def test_receipt_selection_ignores_a_later_receipt_for_another_row(tmp_path: Pat
             chain=chain,
             suspend_receipt_hash=injected.hmac,
         )
+
+
+# ---------------------------------------------------------------------------
+# Follow-up hardening (#2636 review): single-use settlement, and coverage for
+# the guards the first round left unpinned.
+# ---------------------------------------------------------------------------
+
+
+def test_one_approval_authorises_exactly_one_resume(tmp_path: Path) -> None:
+    """An approval settles a park once; it is not a reusable permission.
+
+    Regression for the replay hole: the wake gate used to be a presence check
+    on the decision file, and nothing consumed it, so a single operator
+    approval authorised an unbounded number of resume rows.
+    """
+    sdd = tmp_path / ".sdd"
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+    park = park_task(
+        sdd_dir=sdd,
+        task_id="T-once",
+        adapter="claude",
+        session_id="s",
+        worktree_path=wt,
+        envelope="subscription",
+        reserved_usd=5.0,
+        spent_usd=0.0,
+        chain=chain,
+        wake_condition=WAKE_APPROVAL,
+    )
+    approvals = sdd / "runtime" / "approvals"
+    approvals.mkdir(parents=True, exist_ok=True)
+    (approvals / "T-once.approved").write_text("approved", encoding="utf-8")
+    approval_ref = approval_decision_ref(tmp_path, "T-once")
+
+    first = resume_task(
+        sdd_dir=sdd,
+        suspend_row=park.suspend_row,
+        new_worktree_path=wt,
+        chain=chain,
+        suspend_receipt_hash=park.suspend_receipt_hash,
+        approval_ref=approval_ref,
+    )
+    assert first.resume_receipt_hash
+
+    rows_after_first = len(_journal_rows(sdd, "T-once"))
+    # The same approval file is still on disk and still yields the same digest,
+    # but the park is spent.
+    assert approval_decision_ref(tmp_path, "T-once") == approval_ref
+    with pytest.raises(SuspensionAlreadySettledError):
+        resume_task(
+            sdd_dir=sdd,
+            suspend_row=park.suspend_row,
+            new_worktree_path=wt,
+            chain=chain,
+            suspend_receipt_hash=park.suspend_receipt_hash,
+            approval_ref=approval_ref,
+        )
+    assert len(_journal_rows(sdd, "T-once")) == rows_after_first
+    assert len(chain.query(event_type=EVENT_TASK_RESUMED)) == 1
+
+
+def test_settled_park_refuses_replay_through_the_cli(tmp_path: Path) -> None:
+    """End-to-end: three CLI resumes against one approval yield one settlement."""
+    from click.testing import CliRunner
+
+    from bernstein.cli.commands.task_cmd import task_group
+
+    root = tmp_path
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+    runner = CliRunner()
+
+    parked = runner.invoke(
+        task_group,
+        ["suspend", "T-cli", "--workdir", str(root), "--worktree", str(wt), "--until", "approval", "--json"],
+    )
+    assert parked.exit_code == 0, parked.output
+
+    approvals = root / ".sdd" / "runtime" / "approvals"
+    approvals.mkdir(parents=True, exist_ok=True)
+    (approvals / "T-cli.approved").write_text("approved", encoding="utf-8")
+
+    outcomes = [
+        runner.invoke(task_group, ["resume", "T-cli", "--workdir", str(root), "--worktree", str(wt), "--json"])
+        for _ in range(3)
+    ]
+    assert outcomes[0].exit_code == 0, outcomes[0].output
+    assert outcomes[1].exit_code == 1
+    assert outcomes[2].exit_code == 1
+    # The console wraps, so compare against whitespace-normalised output.
+    assert "already settled" in " ".join(outcomes[1].output.split())
+
+    chain = AuditChainStore(root / ".sdd" / "audit")
+    assert len(chain.query(event_type=EVENT_TASK_RESUMED)) == 1
+
+    result = verify_suspension_continuity(sdd_dir=root / ".sdd", task_id="T-cli", chain=chain)
+    assert result.ok, result.errors
+
+
+def test_verify_continuity_flags_a_park_settled_more_than_once(tmp_path: Path) -> None:
+    """A chain carrying two settlements of one park is not a clean proof.
+
+    The resume path refuses the second settlement, so this shape only reaches
+    the verifier on a chain written before the guard existed or assembled by
+    hand. The offline proof must still refuse it rather than reporting the last
+    settlement as a clean continuity.
+    """
+    from bernstein.core.security.audit_chain import record_task_resume
+
+    sdd = tmp_path / ".sdd"
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+    park = _park(tmp_path, chain, "T-twice", wt)
+    resume = resume_task(
+        sdd_dir=sdd,
+        suspend_row=park.suspend_row,
+        new_worktree_path=wt,
+        chain=chain,
+        suspend_receipt_hash=park.suspend_receipt_hash,
+    )
+    assert verify_suspension_continuity(sdd_dir=sdd, task_id="T-twice", chain=chain).ok
+
+    # A second settlement of the same park, otherwise well-formed.
+    record_task_resume(
+        chain=chain,
+        task_id="T-twice",
+        suspend_receipt_hash=park.suspend_receipt_hash,
+        suspend_event_hash=park.suspend_row.event_hash,
+        resume_event_hash=resume.resume_event_hash,
+        journal_index=1,
+        effective_mode="warm",
+        requested_mode="warm",
+        workspace_match=True,
+        new_workspace_hash=park.suspend_row.workspace_hash,
+        downgrade_reason="",
+        decision_hash=resume.decision.decision_hash,
+    )
+
+    result = verify_suspension_continuity(sdd_dir=sdd, task_id="T-twice", chain=chain)
+    assert not result.ok
+    assert any("settled 2 times" in err for err in result.errors), result.errors
+
+
+def test_verify_continuity_ignores_a_resume_receipt_bound_to_another_park(tmp_path: Path) -> None:
+    """Binding selection, pinned independently of the journal-row check.
+
+    The forged receipt names a resume row the journal really holds, so the
+    ``_row_present`` guard cannot reject it. Only the binding filter can, and
+    reverting that filter makes the verifier read the forged receipt (warm with
+    no workspace match) and fail.
+    """
+    from bernstein.core.security.audit_chain import record_task_resume
+
+    sdd = tmp_path / ".sdd"
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+    park = _park(tmp_path, chain, "T-bind", wt)
+    decoy = _park(tmp_path, chain, "T-decoy2", wt)
+    resume = resume_task(
+        sdd_dir=sdd,
+        suspend_row=park.suspend_row,
+        new_worktree_path=wt,
+        chain=chain,
+        suspend_receipt_hash=park.suspend_receipt_hash,
+    )
+
+    # Real resume row, real parked row, but hung off the decoy park's receipt.
+    record_task_resume(
+        chain=chain,
+        task_id="T-bind",
+        suspend_receipt_hash=decoy.suspend_receipt_hash,
+        suspend_event_hash=park.suspend_row.event_hash,
+        resume_event_hash=resume.resume_event_hash,
+        journal_index=1,
+        effective_mode="warm",
+        requested_mode="warm",
+        workspace_match=False,
+        new_workspace_hash="deadbeef",
+        downgrade_reason="",
+        decision_hash="deadbeef",
+    )
+
+    result = verify_suspension_continuity(sdd_dir=sdd, task_id="T-bind", chain=chain)
+    # The genuine settlement is read; the foreign-bound receipt is not this
+    # park's evidence and must not be selected by recency.
+    assert result.ok, result.errors
+    assert result.workspace_match
+    assert result.effective_mode == "warm"
+
+
+def test_park_refuses_an_unsafe_task_id_before_writing_anything(tmp_path: Path) -> None:
+    """The park-boundary guard, previously asserted only in the docstring."""
+    sdd = tmp_path / ".sdd"
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+
+    with pytest.raises(UnsafeTaskIdError):
+        park_task(
+            sdd_dir=sdd,
+            task_id="../../escape",
+            adapter="claude",
+            session_id="s",
+            worktree_path=wt,
+            envelope="subscription",
+            reserved_usd=1.0,
+            spent_usd=0.0,
+            chain=chain,
+        )
+    assert not (sdd / "runs").exists()
+    assert chain.query(event_type=EVENT_TASK_SUSPENDED) == []
+
+
+def test_task_id_bound_matches_the_journal_run_id_budget(tmp_path: Path) -> None:
+    """An over-long id is refused here, not by a bare ValueError downstream.
+
+    ``task_run_id`` prefixes ``"task-"`` and the journal caps the run id at 64
+    characters, so the validator must refuse at 59.
+    """
+    sdd = tmp_path / ".sdd"
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+
+    assert validate_task_id("T" + "a" * 58)  # 59 chars: the budget, accepted
+    with pytest.raises(UnsafeTaskIdError):
+        validate_task_id("T" + "a" * 59)  # 60 chars: one over
+
+    # The park refuses with the typed error rather than the journal's ValueError.
+    with pytest.raises(UnsafeTaskIdError):
+        park_task(
+            sdd_dir=sdd,
+            task_id="T" + "a" * 90,
+            adapter="claude",
+            session_id="s",
+            worktree_path=wt,
+            envelope="subscription",
+            reserved_usd=1.0,
+            spent_usd=0.0,
+            chain=chain,
+        )
+
+
+def test_longest_accepted_task_id_survives_a_full_park_and_resume(tmp_path: Path) -> None:
+    """The accepted bound is genuinely usable end to end, not just accepted."""
+    sdd = tmp_path / ".sdd"
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+    task_id = "T" + "a" * 58
+
+    park = park_task(
+        sdd_dir=sdd,
+        task_id=task_id,
+        adapter="claude",
+        session_id="s",
+        worktree_path=wt,
+        envelope="subscription",
+        reserved_usd=5.0,
+        spent_usd=0.0,
+        chain=chain,
+    )
+    resume = resume_task(
+        sdd_dir=sdd,
+        suspend_row=park.suspend_row,
+        new_worktree_path=wt,
+        chain=chain,
+        suspend_receipt_hash=park.suspend_receipt_hash,
+    )
+    assert resume.resume_receipt_hash
+    assert verify_suspension_continuity(sdd_dir=sdd, task_id=task_id, chain=chain).ok
+
+
+def test_approval_paths_refuse_a_symlinked_decision_file(tmp_path: Path) -> None:
+    """Containment catches what the identifier allowlist cannot.
+
+    ``T-sym`` is a perfectly well-formed task id, so the allowlist admits it.
+    The escape is in the filesystem: the decision file is a symlink out of the
+    approvals directory. Without the resolved-path containment check, reading
+    the approval would hash an arbitrary file's contents and writing the resume
+    marker would clobber an arbitrary path.
+    """
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "secret.txt"
+    secret.write_text("not an approval", encoding="utf-8")
+    target = outside / "clobber.txt"
+    target.write_text("original", encoding="utf-8")
+
+    approvals = tmp_path / ".sdd" / "runtime" / "approvals"
+    approvals.mkdir(parents=True, exist_ok=True)
+    (approvals / "T-sym.approved").symlink_to(secret)
+    (approvals / "T-sym.resumed").symlink_to(target)
+
+    with pytest.raises(UnsafeTaskIdError):
+        approval_decision_ref(tmp_path, "T-sym")
+    with pytest.raises(UnsafeTaskIdError):
+        write_resume_marker(tmp_path, "T-sym", "deadbeef")
+
+    # The outside file was neither read into a digest nor overwritten.
+    assert target.read_text(encoding="utf-8") == "original"

--- a/tests/unit/test_task_suspension.py
+++ b/tests/unit/test_task_suspension.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -50,6 +51,7 @@ from bernstein.core.tasks.suspension import (
     CONTINUITY_FAILED,
     CONTINUITY_PENDING,
     CONTINUITY_VERIFIED,
+    JOURNAL_EVENT_RESUME,
     RESOURCE_BUDGET,
     RESOURCE_PROCESS,
     RESOURCE_SANDBOX,
@@ -64,6 +66,7 @@ from bernstein.core.tasks.suspension import (
     UnsafeTaskIdError,
     approval_decision_ref,
     decide_resume,
+    find_settlements,
     find_suspension_receipt,
     latest_suspension,
     park_task,
@@ -1078,7 +1081,7 @@ def test_verify_continuity_rejects_a_resume_bound_to_a_foreign_receipt(tmp_path:
     assert not result.ok
     # Assert *which* guard fired. Without this the test passes on the phantom
     # journal-row check alone and the binding filter ships uncovered.
-    assert any("no resume receipt continued from the parked suspend row" in err for err in result.errors), result.errors
+    assert any("settlement record is inconsistent" in err for err in result.errors), result.errors
     assert not result.resumed
 
 
@@ -1296,13 +1299,15 @@ def test_verify_continuity_flags_a_park_settled_more_than_once(tmp_path: Path) -
     assert any("settled 2 times" in err for err in result.errors), result.errors
 
 
-def test_verify_continuity_ignores_a_resume_receipt_bound_to_another_park(tmp_path: Path) -> None:
+def test_reported_state_comes_from_the_genuine_settlement_not_the_forgery(tmp_path: Path) -> None:
     """Binding selection, pinned independently of the journal-row check.
 
     The forged receipt names a resume row the journal really holds, so the
-    ``_row_present`` guard cannot reject it. Only the binding filter can, and
-    reverting that filter makes the verifier read the forged receipt (warm with
-    no workspace match) and fail.
+    ``_row_present`` guard cannot reject it. Two things must hold at once: the
+    forgery is *surfaced* as inconsistent evidence (it names this park's row
+    but hangs off another park's receipt), and the *reported* continuation
+    state is still read from the genuine settlement rather than from whichever
+    receipt happens to be last on the chain.
     """
     from bernstein.core.security.audit_chain import record_task_resume
 
@@ -1336,9 +1341,13 @@ def test_verify_continuity_ignores_a_resume_receipt_bound_to_another_park(tmp_pa
     )
 
     result = verify_suspension_continuity(sdd_dir=sdd, task_id="T-bind", chain=chain)
-    # The genuine settlement is read; the foreign-bound receipt is not this
-    # park's evidence and must not be selected by recency.
-    assert result.ok, result.errors
+    # The forgery is surfaced rather than silently ignored...
+    assert not result.ok
+    assert any("settlement record is inconsistent" in err for err in result.errors), result.errors
+    # ...and the reported state still comes from the genuine settlement. If
+    # selection fell back to recency, these would carry the forgery's values
+    # (workspace_match=False, new_workspace_hash="deadbeef").
+    assert result.resumed
     assert result.workspace_match
     assert result.effective_mode == "warm"
 
@@ -1451,3 +1460,409 @@ def test_approval_paths_refuse_a_symlinked_decision_file(tmp_path: Path) -> None
 
     # The outside file was neither read into a digest nor overwritten.
     assert target.read_text(encoding="utf-8") == "original"
+
+
+# ---------------------------------------------------------------------------
+# Follow-up review: the writer and the verifier must share one definition of
+# "settled", one scope (every park), and one id-validation rule.
+# ---------------------------------------------------------------------------
+
+
+def _forge_settlement(chain: AuditChainStore, task_id: str, park: Any, resume_event_hash: str, count: int = 1) -> None:
+    from bernstein.core.security.audit_chain import record_task_resume
+
+    for _ in range(count):
+        record_task_resume(
+            chain=chain,
+            task_id=task_id,
+            suspend_receipt_hash=park.suspend_receipt_hash,
+            suspend_event_hash=park.suspend_row.event_hash,
+            resume_event_hash=resume_event_hash,
+            journal_index=1,
+            effective_mode="warm",
+            requested_mode="warm",
+            workspace_match=True,
+            new_workspace_hash=park.suspend_row.workspace_hash,
+            downgrade_reason="",
+            decision_hash="x" * 64,
+        )
+
+
+def test_parking_again_does_not_erase_multi_settlement_detection(tmp_path: Path) -> None:
+    """The proof covers every park, not just the latest one.
+
+    Scoping to the newest suspend receipt meant an ordinary 'park again' -- the
+    remediation documented for a spent park -- stopped the verifier looking at
+    earlier parks, so replay damage already on the chain laundered itself.
+    """
+    sdd = tmp_path / ".sdd"
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+
+    first = _park(tmp_path, chain, "T-relaunder", wt)
+    resume = resume_task(
+        sdd_dir=sdd,
+        suspend_row=first.suspend_row,
+        new_worktree_path=wt,
+        chain=chain,
+        suspend_receipt_hash=first.suspend_receipt_hash,
+    )
+    _forge_settlement(chain, "T-relaunder", first, resume.resume_event_hash, count=2)
+
+    before = verify_suspension_continuity(sdd_dir=sdd, task_id="T-relaunder", chain=chain)
+    assert before.status == CONTINUITY_FAILED
+    assert any("settled 3 times" in err for err in before.errors), before.errors
+
+    # Park again: an ordinary, unprivileged operation.
+    _park(tmp_path, chain, "T-relaunder", wt)
+
+    after = verify_suspension_continuity(sdd_dir=sdd, task_id="T-relaunder", chain=chain)
+    assert after.status == CONTINUITY_FAILED, after.to_dict()
+    assert any("settled 3 times" in err for err in after.errors), after.errors
+
+
+def test_writer_and_verifier_agree_that_a_half_matching_receipt_is_evidence(tmp_path: Path) -> None:
+    """A receipt matching one identifier but not the other must not vanish.
+
+    The guard treats such a receipt as a settlement and refuses to resume
+    forever. If the proof ignores it, an operator sees a healthy 'pending' for
+    a park that can never move again, and a real replay attempt leaves no
+    trace in the proof at all.
+    """
+    from bernstein.core.security.audit_chain import record_task_resume
+
+    sdd = tmp_path / ".sdd"
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+    park = _park(tmp_path, chain, "T-half", wt)
+
+    # Genuine receipt hash, but names a suspend row that is not this park's.
+    record_task_resume(
+        chain=chain,
+        task_id="T-half",
+        suspend_receipt_hash=park.suspend_receipt_hash,
+        suspend_event_hash="0" * 64,
+        resume_event_hash="0" * 64,
+        journal_index=99,
+        effective_mode="warm",
+        requested_mode="warm",
+        workspace_match=True,
+        new_workspace_hash=park.suspend_row.workspace_hash,
+        downgrade_reason="",
+        decision_hash="0" * 64,
+    )
+
+    result = verify_suspension_continuity(sdd_dir=sdd, task_id="T-half", chain=chain)
+    # The verifier surfaces it rather than reporting a clean pending...
+    assert result.status == CONTINUITY_FAILED, result.to_dict()
+    assert any("inconsistent" in err for err in result.errors), result.errors
+    # ...and the writer agrees it is a settlement.
+    with pytest.raises(SuspensionAlreadySettledError):
+        resume_task(
+            sdd_dir=sdd,
+            suspend_row=park.suspend_row,
+            new_worktree_path=wt,
+            chain=chain,
+            suspend_receipt_hash=park.suspend_receipt_hash,
+        )
+
+
+def test_settlement_survives_deletion_of_the_audit_chain_tail(tmp_path: Path) -> None:
+    """The guard consults the journal too, not only the audit chain.
+
+    HMAC chaining detects modification and removal of a *non-terminal* entry,
+    so dropping the last line of the audit file leaves ``chain.verify()``
+    returning True while erasing the receipt. The journal independently
+    recorded the settlement, so the replay is still refused.
+    """
+    sdd = tmp_path / ".sdd"
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+    park = park_task(
+        sdd_dir=sdd,
+        task_id="T-tail",
+        adapter="claude",
+        session_id="s",
+        worktree_path=wt,
+        envelope="subscription",
+        reserved_usd=5.0,
+        spent_usd=0.0,
+        chain=chain,
+        wake_condition=WAKE_APPROVAL,
+    )
+    approvals = sdd / "runtime" / "approvals"
+    approvals.mkdir(parents=True, exist_ok=True)
+    (approvals / "T-tail.approved").write_text("approved", encoding="utf-8")
+    approval_ref = approval_decision_ref(tmp_path, "T-tail")
+    resume_task(
+        sdd_dir=sdd,
+        suspend_row=park.suspend_row,
+        new_worktree_path=wt,
+        chain=chain,
+        suspend_receipt_hash=park.suspend_receipt_hash,
+        approval_ref=approval_ref,
+    )
+    journal_resumes = sum(1 for r in _journal_rows(sdd, "T-tail") if r.get("event") == JOURNAL_EVENT_RESUME)
+    assert journal_resumes == 1
+
+    # Drop the terminal audit entry; the chain still verifies.
+    log = sorted((tmp_path / "audit").glob("*.jsonl"))[0]
+    lines = log.read_text(encoding="utf-8").splitlines()
+    log.write_text("\n".join(lines[:-1]) + "\n", encoding="utf-8")
+    reopened = AuditChainStore(tmp_path / "audit", key=_KEY)
+    assert reopened.verify()[0]
+    assert reopened.query(event_type=EVENT_TASK_RESUMED) == []
+
+    with pytest.raises(SuspensionAlreadySettledError):
+        resume_task(
+            sdd_dir=sdd,
+            suspend_row=park.suspend_row,
+            new_worktree_path=wt,
+            chain=reopened,
+            suspend_receipt_hash=park.suspend_receipt_hash,
+            approval_ref=approval_ref,
+        )
+    # No second resume row landed.
+    assert sum(1 for r in _journal_rows(sdd, "T-tail") if r.get("event") == JOURNAL_EVENT_RESUME) == 1
+
+
+def test_find_settlements_reads_both_stores(tmp_path: Path) -> None:
+    sdd = tmp_path / ".sdd"
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+    park = _park(tmp_path, chain, "T-both", wt)
+    assert (
+        find_settlements(
+            sdd_dir=sdd,
+            task_id="T-both",
+            chain=chain,
+            suspend_receipt_hash=park.suspend_receipt_hash,
+            suspend_event_hash=park.suspend_row.event_hash,
+        )
+        == []
+    )
+    resume_task(
+        sdd_dir=sdd,
+        suspend_row=park.suspend_row,
+        new_worktree_path=wt,
+        chain=chain,
+        suspend_receipt_hash=park.suspend_receipt_hash,
+    )
+    found = find_settlements(
+        sdd_dir=sdd,
+        task_id="T-both",
+        chain=chain,
+        suspend_receipt_hash=park.suspend_receipt_hash,
+        suspend_event_hash=park.suspend_row.event_hash,
+    )
+    assert {s.source for s in found} == {"chain", "journal"}
+    assert all(s.consistent for s in found)
+
+
+@pytest.mark.parametrize("command_name", ["approve", "reject"])
+def test_decision_commands_refuse_a_traversing_task_id(tmp_path: Path, command_name: str) -> None:
+    """The write side of the approvals sink obeys the same rule as the read side."""
+    from click.testing import CliRunner
+
+    from bernstein.cli.commands.approve_cmd import approve
+    from bernstein.cli.commands.reject_cmd import reject
+
+    proj = tmp_path / "proj"
+    (proj / ".sdd").mkdir(parents=True)
+    command = approve if command_name == "approve" else reject
+    args = ["../../../../pwned", "--workdir", str(proj)]
+    if command_name == "approve":
+        args.append("--no-prompt")
+
+    result = CliRunner().invoke(command, args)
+    assert result.exit_code == 1, result.output
+    assert "refusing" in " ".join(result.output.split()).lower()
+    # Nothing was written anywhere outside the approvals directory.
+    assert list(tmp_path.rglob("pwned.*")) == []
+
+
+def test_decision_commands_still_work_for_ordinary_task_ids(tmp_path: Path) -> None:
+    from click.testing import CliRunner
+
+    from bernstein.cli.commands.approve_cmd import approve
+
+    proj = tmp_path / "proj"
+    (proj / ".sdd").mkdir(parents=True)
+    result = CliRunner().invoke(approve, ["T-ok_1.2", "--workdir", str(proj), "--no-prompt"])
+    assert result.exit_code == 0, result.output
+    assert (proj / ".sdd" / "runtime" / "approvals" / "T-ok_1.2.approved").exists()
+
+
+# ---------------------------------------------------------------------------
+# Convergence: every entry point must reach the SAME rule. These tests fail if
+# any sink grows its own copy of the identifier rule or of "settled", which is
+# the drift that produced the findings above.
+# ---------------------------------------------------------------------------
+
+#: Every id that must be refused, and every id that must be accepted, by every
+#: approvals sink. One table, asserted against all entry points, so a sink
+#: cannot quietly diverge.
+_UNSAFE_IDS = ["../../../../pwned", "..", ".", "a/b", "/abs", "with space", "", "back\\slash", "T" + "a" * 59]
+_SAFE_IDS = ["T-abc123", "T_1.2-x", "T" + "a" * 58]
+
+
+def _approvals_sinks() -> dict[str, Any]:
+    """Return ``{name: callable(workdir, task_id)}`` for every approvals sink.
+
+    Any new sink under ``.sdd/runtime/approvals`` belongs in this table.
+    """
+    from click.testing import CliRunner
+
+    from bernstein.cli.commands.approve_cmd import approve
+    from bernstein.cli.commands.chat_cmd import _write_approval_decision
+    from bernstein.cli.commands.reject_cmd import reject
+    from bernstein.core.orchestration.approval_gate import approval_path
+
+    def _cli(command: Any, extra: list[str]) -> Any:
+        def run(workdir: Path, task_id: str) -> None:
+            result = CliRunner().invoke(command, [task_id, "--workdir", str(workdir), *extra])
+            if result.exit_code != 0:
+                raise UnsafeTaskIdError(result.output)
+
+        return run
+
+    from bernstein.core.orchestration.approval_gate import approval_path_in
+
+    return {
+        "approval_gate.approval_path": lambda wd, tid: approval_path(wd, tid, ".approved"),
+        "approval_gate.approval_path_in": lambda wd, tid: approval_path_in(
+            wd / ".sdd" / "runtime" / "approvals", tid, ".approved"
+        ),
+        "suspension.approval_decision_ref": approval_decision_ref,
+        "suspension.write_resume_marker": lambda wd, tid: write_resume_marker(wd, tid, "hash"),
+        "cli.approve": _cli(approve, ["--no-prompt"]),
+        "cli.reject": _cli(reject, []),
+        "chat._write_approval_decision": lambda wd, tid: _write_approval_decision(wd, tid, "approve"),
+    }
+
+
+@pytest.mark.parametrize("unsafe_id", _UNSAFE_IDS)
+def test_every_approvals_sink_refuses_the_same_unsafe_ids(tmp_path: Path, unsafe_id: str) -> None:
+    """One identifier rule, enforced at every entry point.
+
+    Finding: the read side was hardened and its write-side siblings were not,
+    so the documented invariant was false. This asserts the rule at all of
+    them against one table, so hardening one sink can no longer leave another
+    behind.
+    """
+    for name, sink in _approvals_sinks().items():
+        workdir = tmp_path / f"wd-{abs(hash(name)) % 10000}"
+        (workdir / ".sdd").mkdir(parents=True, exist_ok=True)
+        with pytest.raises(UnsafeTaskIdError):
+            sink(workdir, unsafe_id)
+        # Nothing escaped, at any sink.
+        assert list(tmp_path.rglob("pwned*")) == []
+
+
+@pytest.mark.parametrize("safe_id", _SAFE_IDS)
+def test_every_approvals_sink_accepts_the_same_safe_ids(tmp_path: Path, safe_id: str) -> None:
+    """The shared rule must not be so strict that ordinary ids break."""
+    for name, sink in _approvals_sinks().items():
+        workdir = tmp_path / f"wd-{abs(hash(name)) % 10000}"
+        (workdir / ".sdd" / "runtime" / "approvals").mkdir(parents=True, exist_ok=True)
+        sink(workdir, safe_id)  # must not raise
+
+
+def test_writer_and_proof_agree_on_settled_for_every_shape(tmp_path: Path) -> None:
+    """One definition of settled, shared by the mutation path and the proof.
+
+    For each way a settlement can be recorded, the writer's answer ("is this
+    park spent?") and the proof's answer ("does this park report a clean
+    continuity?") must not contradict each other. The findings were exactly
+    the cases where they did.
+    """
+    from bernstein.core.security.audit_chain import record_task_resume
+
+    def fresh(name: str) -> tuple[Path, AuditChainStore, Path, Any]:
+        base = tmp_path / name
+        base.mkdir()
+        wt = _worktree(base, "wt", {"a.py": "x = 1\n"})
+        chain = AuditChainStore(base / "audit", key=_KEY)
+        park = park_task(
+            sdd_dir=base / ".sdd",
+            task_id=name,
+            adapter="claude",
+            session_id="s",
+            worktree_path=wt,
+            envelope="subscription",
+            reserved_usd=5.0,
+            spent_usd=0.0,
+            chain=chain,
+        )
+        return base / ".sdd", chain, wt, park
+
+    def writer_says_spent(sdd: Path, chain: AuditChainStore, wt: Path, park: Any) -> bool:
+        try:
+            resume_task(
+                sdd_dir=sdd,
+                suspend_row=park.suspend_row,
+                new_worktree_path=wt,
+                chain=chain,
+                suspend_receipt_hash=park.suspend_receipt_hash,
+            )
+        except SuspensionAlreadySettledError:
+            return True
+        return False
+
+    # Shape A: untouched park. Writer: not spent. Proof: pending, no errors.
+    sdd, chain, wt, park = fresh("shape-a")
+    proof = verify_suspension_continuity(sdd_dir=sdd, task_id="shape-a", chain=chain)
+    assert proof.status == CONTINUITY_PENDING
+    assert not writer_says_spent(sdd, chain, wt, park)
+
+    # Shape B: genuinely settled. Writer: spent. Proof: verified.
+    sdd, chain, wt, park = fresh("shape-b")
+    resume_task(
+        sdd_dir=sdd,
+        suspend_row=park.suspend_row,
+        new_worktree_path=wt,
+        chain=chain,
+        suspend_receipt_hash=park.suspend_receipt_hash,
+    )
+    assert verify_suspension_continuity(sdd_dir=sdd, task_id="shape-b", chain=chain).status == CONTINUITY_VERIFIED
+    assert writer_says_spent(sdd, chain, wt, park)
+
+    # Shape C: receipt matches the park's receipt but names another row.
+    # Writer: spent. Proof must NOT report a clean pending.
+    sdd, chain, wt, park = fresh("shape-c")
+    record_task_resume(
+        chain=chain,
+        task_id="shape-c",
+        suspend_receipt_hash=park.suspend_receipt_hash,
+        suspend_event_hash="0" * 64,
+        resume_event_hash="0" * 64,
+        journal_index=99,
+        effective_mode="warm",
+        requested_mode="warm",
+        workspace_match=True,
+        new_workspace_hash=park.suspend_row.workspace_hash,
+        downgrade_reason="",
+        decision_hash="0" * 64,
+    )
+    assert verify_suspension_continuity(sdd_dir=sdd, task_id="shape-c", chain=chain).status == CONTINUITY_FAILED
+    assert writer_says_spent(sdd, chain, wt, park)
+
+    # Shape D: receipt names the park's row but hangs off another receipt.
+    # Writer: spent. Proof must NOT report a clean pending.
+    sdd, chain, wt, park = fresh("shape-d")
+    record_task_resume(
+        chain=chain,
+        task_id="shape-d",
+        suspend_receipt_hash="f" * 64,
+        suspend_event_hash=park.suspend_row.event_hash,
+        resume_event_hash="0" * 64,
+        journal_index=99,
+        effective_mode="warm",
+        requested_mode="warm",
+        workspace_match=True,
+        new_workspace_hash=park.suspend_row.workspace_hash,
+        downgrade_reason="",
+        decision_hash="0" * 64,
+    )
+    assert verify_suspension_continuity(sdd_dir=sdd, task_id="shape-d", chain=chain).status == CONTINUITY_FAILED
+    assert writer_says_spent(sdd, chain, wt, park)

--- a/tests/unit/test_task_suspension.py
+++ b/tests/unit/test_task_suspension.py
@@ -1702,8 +1702,19 @@ def test_decision_commands_still_work_for_ordinary_task_ids(tmp_path: Path) -> N
 #: Every id that must be refused, and every id that must be accepted, by every
 #: approvals sink. One table, asserted against all entry points, so a sink
 #: cannot quietly diverge.
-_UNSAFE_IDS = ["../../../../pwned", "..", ".", "a/b", "/abs", "with space", "", "back\\slash", "T" + "a" * 59]
-_SAFE_IDS = ["T-abc123", "T_1.2-x", "T" + "a" * 58]
+_UNSAFE_IDS = [
+    "../../../../pwned",
+    "..",
+    ".",
+    "a/b",
+    "/abs",
+    "with space",
+    "",
+    "back\\slash",
+    "auth:oauth-flow",  # colon: drive-relative on Windows, ADS on NTFS
+    "T" + "a" * 64,  # 65 chars: over the shared 64 bound
+]
+_SAFE_IDS = ["T-abc123", "T_1.2-x", "T" + "a" * 63]
 
 
 def _approvals_sinks() -> dict[str, Any]:
@@ -1866,3 +1877,160 @@ def test_writer_and_proof_agree_on_settled_for_every_shape(tmp_path: Path) -> No
     )
     assert verify_suspension_continuity(sdd_dir=sdd, task_id="shape-d", chain=chain).status == CONTINUITY_FAILED
     assert writer_says_spent(sdd, chain, wt, park)
+
+
+# ---------------------------------------------------------------------------
+# Cross-boundary id rules: pin the RELATIONSHIP between the approvals rule and
+# the artifact-posting rule, not their current literal values.
+# ---------------------------------------------------------------------------
+
+#: Ids that ``evidence.run_artifacts`` accepts but the approvals sink refuses,
+#: each with the reason it cannot be admitted. Anything accepted by
+#: run_artifacts and not listed here MUST be accepted by the approvals sink.
+#:
+#: These are deliberate divergences, not oversights. A colon cannot be made
+#: safe for a path that is joined then written: on Windows ``C:evil`` parses as
+#: drive-relative so the join discards the base, and ``file:stream`` addresses
+#: an NTFS alternate data stream that a containment check cannot see. The
+#: length and leading-character cases are the shared rule being stricter than a
+#: surface that never joins the value onto a directory.
+_DELIBERATE_DIVERGENCES = {
+    "colon is a drive separator and an NTFS ADS separator",
+    "longer than the 64-character identifier budget",
+    "does not start with an alphanumeric (would admit '.' and '..')",
+}
+
+
+def _divergence_reason(candidate: str) -> str | None:
+    """Return why the approvals rule refuses an id run_artifacts accepts."""
+    if ":" in candidate:
+        return "colon is a drive separator and an NTFS ADS separator"
+    if len(candidate) > 64:
+        return "longer than the 64-character identifier budget"
+    if not candidate[:1].isalnum():
+        return "does not start with an alphanumeric (would admit '.' and '..')"
+    return None
+
+
+def test_every_artifact_accepted_id_is_approvable_or_a_documented_divergence(tmp_path: Path) -> None:
+    """Pin the relationship between the two id rules.
+
+    ``evidence.run_artifacts`` accepts a wider alphabet than the approvals
+    sink. Every id it admits must therefore be either approvable or a
+    *documented* refusal -- otherwise a task can post artifacts but can never
+    be approved or rejected, which strands it with no operator remedy.
+    """
+    from bernstein.core.evidence.run_artifacts import _TASK_ID_RE as ARTIFACT_ID_RE
+    from bernstein.core.orchestration.approval_gate import approval_path_in
+
+    approvals = tmp_path / ".sdd" / "runtime" / "approvals"
+    approvals.mkdir(parents=True, exist_ok=True)
+
+    candidates = [
+        "T-abc123",
+        "T_1.2-x",
+        "task.with.dots",
+        "UPPER-lower_9",
+        "a",
+        "T" + "a" * 63,  # 64: the shared bound
+        "auth:oauth-flow",  # accepted by run_artifacts, refused here
+        "C:evil",
+        "file:stream",
+        "T" + "a" * 64,  # 65: over the shared bound
+        ".hidden",  # leading dot
+        "T" + "a" * 255,  # 256: run_artifacts' own ceiling
+    ]
+
+    for candidate in candidates:
+        if not ARTIFACT_ID_RE.match(candidate):
+            continue  # run_artifacts refuses it too; no relationship to pin
+        reason = _divergence_reason(candidate)
+        if reason is None:
+            # run_artifacts accepts it and there is no documented reason to
+            # refuse, so the approvals sink must accept it.
+            approval_path_in(approvals, candidate, ".approved")
+        else:
+            assert reason in _DELIBERATE_DIVERGENCES, f"undocumented divergence for {candidate!r}: {reason}"
+            with pytest.raises(UnsafeTaskIdError):
+                approval_path_in(approvals, candidate, ".approved")
+
+
+def test_approvals_rule_matches_the_prevailing_identifier_length(tmp_path: Path) -> None:
+    """The shared bound tracks the codebase's prevailing rule, not a magic number.
+
+    ``replay.journal`` and ``run_service.paths`` both cap identifiers at 64. If
+    one of those moves, this fails rather than silently leaving the approvals
+    sink stricter and stranding ids the rest of the tree accepts.
+    """
+    import re as _re
+
+    from bernstein.core.orchestration.approval_gate import approval_path_in
+    from bernstein.core.replay.journal import _RUN_ID_RE
+    from bernstein.core.run_service.paths import _RUN_ID_RE as PATHS_RUN_ID_RE
+
+    def _upper_bound(pattern: _re.Pattern[str]) -> int:
+        match = _re.search(r"\{\d+,(\d+)\}", pattern.pattern)
+        assert match, f"cannot read bound from {pattern.pattern!r}"
+        return int(match.group(1))
+
+    prevailing = {_upper_bound(_RUN_ID_RE), _upper_bound(PATHS_RUN_ID_RE)}
+    assert prevailing == {64}, prevailing
+
+    approvals = tmp_path / ".sdd" / "runtime" / "approvals"
+    approvals.mkdir(parents=True, exist_ok=True)
+    approval_path_in(approvals, "T" + "a" * 63, ".approved")  # 64: accepted
+    with pytest.raises(UnsafeTaskIdError):
+        approval_path_in(approvals, "T" + "a" * 64, ".approved")  # 65: refused
+
+
+def test_a_task_too_long_to_park_is_still_approvable(tmp_path: Path) -> None:
+    """The narrower park budget must not strand a task at the approvals surface.
+
+    A 60-64 character id cannot be durably parked (the journal run id would
+    exceed 64), but it must still be approvable and rejectable, and the park
+    refusal must be the typed one rather than a bare ValueError from the
+    journal.
+    """
+    from bernstein.core.orchestration.approval_gate import approval_path_in
+
+    long_id = "T" + "a" * 62  # 63 chars: fine for approvals, too long to park
+    approvals = tmp_path / ".sdd" / "runtime" / "approvals"
+    approvals.mkdir(parents=True, exist_ok=True)
+
+    # Approvable.
+    assert approval_path_in(approvals, long_id, ".approved").parent == approvals.resolve()
+
+    # Not parkable, with the typed refusal.
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+    with pytest.raises(UnsafeTaskIdError):
+        park_task(
+            sdd_dir=tmp_path / ".sdd",
+            task_id=long_id,
+            adapter="claude",
+            session_id="s",
+            worktree_path=wt,
+            envelope="subscription",
+            reserved_usd=1.0,
+            spent_usd=0.0,
+            chain=chain,
+        )
+
+
+def test_colon_id_escapes_containment_under_windows_semantics() -> None:
+    """Evidence for the colon divergence, so the reason is checkable not asserted.
+
+    This is why a colon cannot simply be admitted to match ``run_artifacts``.
+    Uses pure path semantics so it holds on any host.
+    """
+    from pathlib import PureWindowsPath
+
+    base = PureWindowsPath(r"D:\proj\.sdd\runtime\approvals")
+    # A drive-letter shaped id discards the base entirely on Windows.
+    escaped = base / "C:evil.approved"
+    assert not escaped.is_relative_to(base)
+    assert str(escaped) == "C:evil.approved"
+    # An ADS-shaped id stays "contained" by path inspection, which is exactly
+    # why a containment check alone cannot make a colon safe.
+    ads = base / "file:stream.approved"
+    assert ads.is_relative_to(base)


### PR DESCRIPTION
Closes #2636

Hardening for the durable task suspend/resume path. Each acceptance-criteria
item was verified against the code before being changed; all five were real
defects. A follow-up review round found a sixth, which is fixed here too.

## The headline defect: a park was replayable

The `--until approval` wake gate was a presence check on the decision file, and
nothing consumed the decision. `latest_suspension` kept returning the same
parked row and the receipt kept resolving, so every precondition was satisfied
again on the next call.

Three `bernstein task resume` invocations against one operator `.approved` file:

| | resume receipts recorded for one park |
|---|---|
| before | 3, and `verify_suspension_continuity` reported `ok=True`, `errors=[]` |
| after | 1, further attempts refused `already settled`, chain intact |

A park now settles exactly once, enforced from the chain rather than a side
file: `find_resume_receipt` resolves the settlement record for a suspend
receipt, and `resume_task` raises `SuspensionAlreadySettledError` before the
journal is touched. Parking again mints a fresh suspend receipt that settles
once in its own right. The verifier independently flags a suspend receipt
carrying more than one resume receipt, so a chain written before this guard
cannot present a replayed settlement as a clean continuity.

## The other four

### Receipt was not bound to the selected suspend row

`task resume` read the latest verified suspend row from the journal, then
separately took the **last** `task.suspend_receipt` on the chain for that task.
The two were never compared. `find_suspension_receipt()` now selects by
identity, not recency: the receipt must bind the row's `event_hash` and journal
index.

### Receipt identity unvalidated before a release or a resume

`release_resources` only checked the hash was non-empty, so any non-empty
string passed; `resume_task` did not check it at all. `verify_suspension_receipt()`
now resolves the hash on the HMAC chain and confirms it exists, belongs to this
task, and binds this row, raising `SuspendReceiptMismatchError` otherwise. It
runs before any physical release effect and before any journal append.

### `resume_task` did not enforce approval gating

The gate lived only in the CLI, so a library caller could append a resume row
for a `WAKE_APPROVAL` park with no decision. Now raises
`ResumeApprovalRequiredError` before the journal append.

### `task_id` reached an approval filename unvalidated

`approval_decision_ref()` and `write_resume_marker()` interpolated it straight
into `.sdd/runtime/approvals/<task_id>.approved` / `.resumed`. Both now go
through `validate_task_id()` (anchored allowlist, mirroring the existing
`_RUN_ID_RE` idiom) followed by `Path.resolve()` + `is_relative_to()`
containment, refusing with typed `UnsafeTaskIdError` rather than sanitising.
The bound is 59 characters, set by the narrowest sink downstream: the park
builds the journal run id as `"task-" + task_id` and `EventJournal` caps that
at 64, so a looser bound here would let an over-long id past the typed refusal
only to abort with a bare `ValueError`.

### Continuity verifier accepted incomplete and unrelated proofs

It returned `ok=True` for a never-resumed park, contradicting its own
docstring; selected the resume receipt by recency; and never checked that
either receipt named a row the journal holds. It now requires a resume receipt
bound to the parked suspend receipt **and** row, cross-checks both row hashes
against the journal, and rejects multiple settlements.

The outcome is a tri-state on `ContinuityResult.status`, so a caller branches
programmatically rather than parsing messages:

| `status` | meaning | exit code |
|---|---|---|
| `verified` | a settlement happened and its proof holds | 0 |
| `pending` | the park has not settled yet, nothing to prove | 0 |
| `failed` | a settlement is claimed but its evidence does not hold | 1 |

A live park reports `pending`, not `failed`: it is an incomplete lifecycle, not
a broken proof, and failing it would bury real breaks when sweeping a fleet
with parked tasks. `ok` means "no integrity failure found" and covers
`verified` and `pending` alike, which keeps `bernstein audit verify-suspension`
at exit 0 for the ordinary parked case, unchanged by this branch. Pending and
failed are separated by which suspend row a resume receipt *claims*, so a task
parked twice with only the first park settled leaves the second `pending`.

## One definition, one scope, one rule

A later review round found four defects that were one shape: the path that
mutates state and the path that proves it disagreed about the same concept.
Fixed as one change rather than four patches.

**Scope.** The verifier derived the whole proof from the latest suspend
receipt, so parking again -- the documented remediation for a spent park --
erased multi-settlement detection for the parks carrying the damage. Replay
and consistency checks now run over every suspend receipt on the task; only
the reported lifecycle state comes from the current park.

**Definition of settled.** The resume guard matched on `suspend_receipt_hash`
alone; the verifier required that *and* `suspend_event_hash`. A receipt
matching one but not the other made a park permanently unresumable while the
proof reported a clean `pending`. `find_settlements` is now the single
definition both paths use, and a record matching only one identifier is
reported as inconsistent rather than dropped.

**Stores.** The guard read only the audit chain. HMAC chaining does not detect
removal of a *terminal* entry, so deleting the last line of the audit file left
`chain.verify()` returning `True` and re-armed a spent approval -- while the
task journal still held its own resume row. The guard now reads both stores.

**Identifier rule.** `bernstein approve` and `reject` built the same
`.sdd/runtime/approvals/<id>` path with no validation, making the invariant
this PR documents false and allowing an arbitrary-location file write.
`approval_gate.approval_path_in` is now the one implementation, and every sink
resolves to it: approve, reject, the chat bridge, the pre-spawn gate, the
security-gate poller, and the park/resume read side. `UnsafeTaskIdError` is an
alias of `UnsafeApprovalIdError`, not a second type.

Convergence tests assert one id table against every sink, and writer-vs-proof
agreement across four settlement shapes; reverting any single sink to its own
path construction fails them.

## Determinism and chain semantics

Receipt payloads, journal row shape, the resume decision projection, and
`decision_hash` are unchanged, so replay stays byte-identical. Every refusal
lands before the journal append, so a refused resume leaves the task's Merkle
chain byte-identical to the parked state. No audit-chain event constants were
added.

## Tests

37 regression tests in `tests/unit/test_task_suspension.py` (69 in the file),
covering receipt substitution across rows and tasks, receipt hashes absent from
the chain, single-use settlement at library and CLI level, multi-settlement
detection surviving a re-park, writer/proof agreement across four settlement
shapes, settlement surviving audit-tail deletion, approval gating, traversal
and over-long ids refused at every approvals sink, a symlinked decision file,
four continuity-proof rejection shapes, one test per continuity state, and CLI
exit-code stability across states.

Every guard is mutation-checked: reverting any one of the production guards in
this change fails at least one test, and each finding's own test kills its own
mutant (checked separately, so a broad test cannot mask a vacuous specific
one). Reverting any single approvals sink to its own path construction fails
the convergence test.

Gates run locally: the three suites above (80 passed), `uv run ruff check src tests`,
`uv run ruff format --check`.
