### PR TITLE
fix(tests): stop cross-test leaks of the hermetic-network guard and network posture env

### DIFF
--- a/src/bernstein/core/security/socket_guard.py
+++ b/src/bernstein/core/security/socket_guard.py
@@ -27,6 +27,12 @@ Design notes:
   and the IPv6 4-tuple form ``(host, port, flowinfo, scopeid)``.
 * The guard is idempotent: ``install_runtime_socket_guard()`` can
   be called many times; only the first call patches the global.
+* Install and uninstall key off the *identity* of the callable on
+  the class, not off a bookkeeping flag. Bernstein is not the only
+  thing that may patch ``socket.socket.connect``, and a flag that
+  outlives the patch it describes would otherwise let uninstall
+  write a dead wrapper into the process -- or let install report an
+  egress boundary it never put in place.
 """
 
 from __future__ import annotations
@@ -51,6 +57,7 @@ logger = logging.getLogger(__name__)
 
 _INSTALLED_FLAG: Final[str] = "_bernstein_socket_guard_installed"
 _ORIGINAL_FLAG: Final[str] = "_bernstein_socket_guard_original_connect"
+_GUARD_FLAG: Final[str] = "_bernstein_socket_guard_active_connect"
 
 __all__ = [
     "ENV_PROFILE_MODE",
@@ -132,6 +139,32 @@ def _make_guarded_connect(original: Any) -> Any:
     return _guarded_connect
 
 
+def _guard_is_live(sock_cls: type[socket.socket]) -> bool:
+    """Return True iff *our* guard is the callable currently on the class.
+
+    The ``_INSTALLED_FLAG`` alone is not enough. Bernstein is not the only
+    thing that patches ``socket.socket.connect``: a test harness, tracer, or
+    sandbox shim may swap in its own wrapper and restore its predecessor when
+    its scope ends. If the guard was installed while such a shim was live and
+    was not uninstalled before the shim went away, the flags describe an
+    installation that no longer exists and ``_ORIGINAL_FLAG`` holds a callable
+    nothing references any more. Acting on the flags then writes that dead
+    wrapper onto the class process-wide. Compare identities instead.
+    """
+    if not getattr(sock_cls, _INSTALLED_FLAG, False):
+        return False
+    guard = getattr(sock_cls, _GUARD_FLAG, None)
+    return guard is not None and sock_cls.connect is guard
+
+
+def _clear_guard_state(sock_cls: type[socket.socket]) -> None:
+    """Drop the bookkeeping without touching ``connect``."""
+    setattr(sock_cls, _INSTALLED_FLAG, False)
+    for flag in (_ORIGINAL_FLAG, _GUARD_FLAG):
+        with contextlib.suppress(AttributeError):
+            delattr(sock_cls, flag)
+
+
 def install_runtime_socket_guard(*, force: bool = False) -> bool:
     """Install the process-wide runtime egress hook.
 
@@ -155,16 +188,24 @@ def install_runtime_socket_guard(*, force: bool = False) -> bool:
     if not force and not is_airgap_profile():
         return False
     sock_cls = socket.socket
-    if getattr(sock_cls, _INSTALLED_FLAG, False) and not force:
+    live = _guard_is_live(sock_cls)
+    if live and not force:
         return True
-    if force and getattr(sock_cls, _INSTALLED_FLAG, False):
+    if live:
         # Restore first so we close over the truly original connect,
         # not over the previous guard.
-        original = getattr(sock_cls, _ORIGINAL_FLAG, sock_cls.connect)
-        sock_cls.connect = original  # type: ignore[method-assign]
+        sock_cls.connect = getattr(sock_cls, _ORIGINAL_FLAG, sock_cls.connect)  # type: ignore[method-assign]
+    # Every other state -- never installed, or flags left over from an
+    # installation another patcher has since displaced -- is rebuilt from the
+    # live ``connect`` below, and the stale original is dropped rather than
+    # restored. The displaced case must not short-circuit as "already
+    # installed": reporting an egress boundary that is not actually patched in
+    # is the one failure mode an airgap run cannot tolerate.
     original_connect = sock_cls.connect
+    guard = _make_guarded_connect(original_connect)
     setattr(sock_cls, _ORIGINAL_FLAG, original_connect)
-    sock_cls.connect = _make_guarded_connect(original_connect)  # type: ignore[method-assign]
+    setattr(sock_cls, _GUARD_FLAG, guard)
+    sock_cls.connect = guard  # type: ignore[method-assign]
     setattr(sock_cls, _INSTALLED_FLAG, True)
     return True
 
@@ -172,25 +213,30 @@ def install_runtime_socket_guard(*, force: bool = False) -> bool:
 def uninstall_runtime_socket_guard() -> bool:
     """Restore the original ``socket.socket.connect`` (test helper).
 
-    Returns True iff the guard was previously installed and has been
-    successfully removed.
+    Safe to call unconditionally, including when another patcher has taken
+    over ``connect`` since the guard was installed. In that case the stashed
+    original is stale -- putting it back would swap a dead wrapper into the
+    process and silently displace the live patch -- so the bookkeeping is
+    dropped and ``connect`` is left exactly as found.
+
+    Returns True iff the guard was actually the callable on the class and has
+    been replaced by the original it captured.
     """
     sock_cls = socket.socket
     if not getattr(sock_cls, _INSTALLED_FLAG, False):
         return False
     original = getattr(sock_cls, _ORIGINAL_FLAG, None)
-    if original is None:
+    live = _guard_is_live(sock_cls)
+    _clear_guard_state(sock_cls)
+    if not live or original is None:
         return False
     sock_cls.connect = original  # type: ignore[method-assign]
-    setattr(sock_cls, _INSTALLED_FLAG, False)
-    with contextlib.suppress(AttributeError):
-        delattr(sock_cls, _ORIGINAL_FLAG)
     return True
 
 
 def is_runtime_socket_guard_installed() -> bool:
     """Return True iff the guard is currently patched into ``socket.socket``."""
-    return bool(getattr(socket.socket, _INSTALLED_FLAG, False))
+    return _guard_is_live(socket.socket)
 
 
 def collect_unmonitored_destinations(allowed_specs: Iterable[str]) -> list[str]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     )
 
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -206,6 +206,43 @@ def _isolate_agent_card_keystore(
     from bernstein.core.routes import well_known as _wk
 
     _wk._reset_signing_keypair_for_tests(key_dir)
+
+
+_NETWORK_POSTURE_ENV_VARS = (
+    "BERNSTEIN_PROFILE_MODE",
+    "BERNSTEIN_NETWORK_POLICY",
+    "BERNSTEIN_SOVEREIGN_MODE",
+)
+
+
+@pytest.fixture(autouse=True)
+def _restore_network_posture_env() -> Iterator[None]:
+    """Put the profile / policy / sovereign env vars back after every test.
+
+    ``install_policy()`` and the sovereign branch of ``_install_network_policy()``
+    write straight to ``os.environ`` on purpose - spawned adapters inherit the
+    posture that way - and there is no uninstall counterpart. Tests that call
+    those installers clean up with a ``monkeypatch.delenv(..., raising=False)``
+    preamble, which looks like it covers the case but does not:
+    ``MonkeyPatch.delitem`` only records an undo entry when the key is already
+    present, so on a clean environment it registers nothing and the values
+    written *afterwards* by the installer survive the test.
+
+    A leaked ``BERNSTEIN_SOVEREIGN_MODE=1`` makes ``is_sovereign_profile()`` true
+    for the rest of the session, which turns the spawner's posture-drift
+    preflight from a no-op into a hard refusal for every later test whose
+    workspace has no attestation. Snapshot and restore here so the trap is
+    closed for any test that touches these vars, however it sets them.
+    """
+    saved = {name: os.environ.get(name) for name in _NETWORK_POSTURE_ENV_VARS}
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/_no_network.py
+++ b/tests/unit/_no_network.py
@@ -134,13 +134,25 @@ def block_network() -> Iterator[None]:
     exiting restores the outer guard rather than re-enabling real egress for
     the remainder of the outer scope. Intended for use by the autouse fixture,
     but usable directly in a ``with`` block for targeted tests.
+
+    The class object is bound once, on entry, and both the patch and the
+    restore go through that binding rather than re-resolving ``socket.socket``.
+    A purity test proving some code path never opens a socket does so by
+    replacing the class in the ``socket`` module namespace
+    (``monkeypatch.setattr(socket, "socket", ...)``), and that replacement can
+    still be live when this context exits - fixture finalizers do not have to
+    unwind in the order that would make re-resolution safe. Re-resolving would
+    then write the saved methods onto the stand-in and strand the guard on the
+    real class for the rest of the session, breaking every later
+    ``allow_network`` test with a failure that points nowhere near the cause.
     """
-    previous_connect = socket.socket.connect
-    previous_connect_ex = socket.socket.connect_ex
-    socket.socket.connect = _guarded_connect  # type: ignore[method-assign]
-    socket.socket.connect_ex = _guarded_connect_ex  # type: ignore[method-assign]
+    sock_cls = socket.socket
+    previous_connect = sock_cls.connect
+    previous_connect_ex = sock_cls.connect_ex
+    sock_cls.connect = _guarded_connect  # type: ignore[method-assign]
+    sock_cls.connect_ex = _guarded_connect_ex  # type: ignore[method-assign]
     try:
         yield
     finally:
-        socket.socket.connect = previous_connect  # type: ignore[method-assign]
-        socket.socket.connect_ex = previous_connect_ex  # type: ignore[method-assign]
+        sock_cls.connect = previous_connect  # type: ignore[method-assign]
+        sock_cls.connect_ex = previous_connect_ex  # type: ignore[method-assign]

--- a/tests/unit/test_no_network_guard.py
+++ b/tests/unit/test_no_network_guard.py
@@ -139,6 +139,43 @@ def test_nested_block_network_keeps_guard_active_after_inner_exit() -> None:
         sock2.close()
 
 
+@pytest.mark.allow_network
+def test_block_network_restores_the_real_class_when_socket_is_rebound() -> None:
+    """A test that swaps ``socket.socket`` out must not strand the guard.
+
+    Purity tests assert a code path never opens a socket by replacing the class
+    in the ``socket`` module namespace with something that raises. While that
+    replacement is live, ``socket.socket`` no longer names the class the guard
+    patched. If the guard resolves the name again on the way out it writes its
+    saved method onto the stand-in and the real class keeps ``_guarded_connect``
+    for the rest of the session -- which then breaks every later
+    ``allow_network`` test, far from the test that caused it.
+
+    ``@pytest.mark.allow_network`` keeps the autouse fixture out of the way so
+    this exercises a bare ``block_network()`` round trip.
+    """
+    real_cls = socket.socket
+    pristine = real_cls.connect
+    pristine_ex = real_cls.connect_ex
+
+    def _stand_in(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("stand-in must never be called")
+
+    try:
+        with block_network():
+            # Sanity: the guard really is installed on the real class.
+            assert real_cls.connect is not pristine
+            socket.socket = _stand_in  # type: ignore[misc]
+    finally:
+        socket.socket = real_cls  # type: ignore[misc]
+
+    assert real_cls.connect is pristine
+    assert real_cls.connect_ex is pristine_ex
+    # The restore must not have landed on the stand-in.
+    assert not hasattr(_stand_in, "connect")
+    assert not hasattr(_stand_in, "connect_ex")
+
+
 @pytest.mark.parametrize(
     "address",
     [

--- a/tests/unit/test_socket_guard_isolation.py
+++ b/tests/unit/test_socket_guard_isolation.py
@@ -1,0 +1,181 @@
+"""The runtime socket guard must never write a stale ``connect`` onto the class.
+
+``install_runtime_socket_guard`` stashes whatever ``socket.socket.connect`` was
+bound to at install time and parks the stash on the class itself, so a later
+``uninstall_runtime_socket_guard`` can put it back. That contract holds only
+while *our* guard is still the callable on the class.
+
+Bernstein is not the only thing that patches ``socket.socket.connect``. The unit
+suite wraps every test in a hermetic-network guard; an operator shell may have a
+tracing or sandbox shim in place. Those patchers restore their own predecessor on
+scope exit. If the airgap guard was installed while such a shim was live and was
+not uninstalled before the shim went away, the class-level stash now points at a
+callable that is no longer anybody's ``connect``. Restoring it -- or trusting the
+"installed" flag and skipping a real install -- silently swaps a dead wrapper into
+the process, and every subsequent connect in that process runs through it.
+
+These tests pin the identity check that makes install/uninstall safe under that
+interleaving.
+"""
+
+from __future__ import annotations
+
+import socket
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from bernstein.core.security.network_policy import (
+    ENV_NETWORK_POLICY,
+    ENV_PROFILE_MODE,
+    PROFILE_AIRGAP,
+)
+from bernstein.core.security.socket_guard import (
+    install_runtime_socket_guard,
+    is_runtime_socket_guard_installed,
+    uninstall_runtime_socket_guard,
+)
+
+_GUARD_ATTRS = (
+    "_bernstein_socket_guard_installed",
+    "_bernstein_socket_guard_original_connect",
+    "_bernstein_socket_guard_active_connect",
+)
+
+_MISSING = object()
+
+
+@pytest.fixture(autouse=True)
+def _restore_socket_state() -> Iterator[None]:
+    """Snapshot every piece of guard state and put it back verbatim.
+
+    These tests deliberately drive the guard into inconsistent states, so the
+    teardown cannot go through ``uninstall_runtime_socket_guard`` -- that is the
+    function under test. Restore the raw attributes instead.
+    """
+    saved_connect = socket.socket.connect
+    saved_attrs = {name: getattr(socket.socket, name, _MISSING) for name in _GUARD_ATTRS}
+    try:
+        yield
+    finally:
+        socket.socket.connect = saved_connect  # type: ignore[method-assign]
+        for name, value in saved_attrs.items():
+            if value is _MISSING:
+                if hasattr(socket.socket, name):
+                    delattr(socket.socket, name)
+            else:
+                setattr(socket.socket, name, value)
+
+
+def _stashed_original() -> Any:
+    """The ``connect`` the guard captured at install time, or ``None``."""
+    return getattr(socket.socket, _GUARD_ATTRS[1], None)
+
+
+def _foreign_patch() -> Any:
+    """A stand-in for another patcher's ``connect`` wrapper."""
+
+    def _connect(self: socket.socket, address: Any, *args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("foreign connect must never be called by these tests")
+
+    return _connect
+
+
+@pytest.fixture
+def _airgap_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_PROFILE_MODE, PROFILE_AIRGAP)
+    monkeypatch.setenv(ENV_NETWORK_POLICY, "none")
+
+
+@pytest.mark.usefixtures("_airgap_env")
+def test_uninstall_after_foreign_patch_withdrawn_leaves_connect_alone() -> None:
+    """A withdrawn foreign patch must not come back via our stash.
+
+    Reproduces the suite-wide leak: a test installs the guard while the
+    hermetic-network wrapper is live and never uninstalls; the wrapper is then
+    withdrawn at teardown. An unrelated later test calls uninstall -- which must
+    not resurrect the withdrawn wrapper as the process-wide ``connect``.
+    """
+    pristine = socket.socket.connect
+    foreign = _foreign_patch()
+
+    socket.socket.connect = foreign  # type: ignore[method-assign]
+    assert install_runtime_socket_guard() is True
+    # The foreign patcher's scope ends and it restores its own predecessor.
+    socket.socket.connect = pristine  # type: ignore[method-assign]
+
+    assert uninstall_runtime_socket_guard() is False
+    assert socket.socket.connect is pristine
+    assert is_runtime_socket_guard_installed() is False
+
+
+@pytest.mark.usefixtures("_airgap_env")
+def test_stale_flags_do_not_block_a_real_install() -> None:
+    """Fail-open guard: stale flags must not make install a silent no-op.
+
+    ``install_runtime_socket_guard`` returning True while ``connect`` is
+    unpatched would leave an airgap run believing it has an egress boundary it
+    does not have.
+    """
+    pristine = socket.socket.connect
+    foreign = _foreign_patch()
+
+    socket.socket.connect = foreign  # type: ignore[method-assign]
+    assert install_runtime_socket_guard() is True
+    socket.socket.connect = pristine  # type: ignore[method-assign]
+
+    assert install_runtime_socket_guard() is True
+    assert socket.socket.connect is not pristine
+    assert is_runtime_socket_guard_installed() is True
+    # The fresh install must close over the live connect, not the withdrawn one.
+    assert _stashed_original() is pristine
+
+
+@pytest.mark.usefixtures("_airgap_env")
+def test_is_installed_reports_false_once_our_guard_is_displaced() -> None:
+    """The reported state must track the class, not a leftover flag."""
+    pristine = socket.socket.connect
+
+    assert install_runtime_socket_guard() is True
+    assert is_runtime_socket_guard_installed() is True
+
+    socket.socket.connect = pristine  # type: ignore[method-assign]
+    assert is_runtime_socket_guard_installed() is False
+
+
+@pytest.mark.usefixtures("_airgap_env")
+def test_force_reinstall_after_displacement_does_not_restore_stale_original() -> None:
+    """``force=True`` re-derives its original from the live class too."""
+    pristine = socket.socket.connect
+    foreign = _foreign_patch()
+
+    socket.socket.connect = foreign  # type: ignore[method-assign]
+    assert install_runtime_socket_guard(force=True) is True
+    socket.socket.connect = pristine  # type: ignore[method-assign]
+
+    assert install_runtime_socket_guard(force=True) is True
+    assert _stashed_original() is pristine
+    assert uninstall_runtime_socket_guard() is True
+    assert socket.socket.connect is pristine
+
+
+@pytest.mark.usefixtures("_airgap_env")
+def test_install_uninstall_round_trip_still_restores() -> None:
+    """The ordinary path is unchanged: uninstall puts the original back."""
+    pristine = socket.socket.connect
+
+    assert install_runtime_socket_guard() is True
+    assert is_runtime_socket_guard_installed() is True
+    assert socket.socket.connect is not pristine
+
+    assert uninstall_runtime_socket_guard() is True
+    assert socket.socket.connect is pristine
+    assert is_runtime_socket_guard_installed() is False
+
+
+def test_uninstall_is_a_noop_when_never_installed() -> None:
+    """No flags, no state change, no lie in the return value."""
+    pristine = socket.socket.connect
+    assert uninstall_runtime_socket_guard() is False
+    assert socket.socket.connect is pristine


### PR DESCRIPTION
## Problem

Three pre-existing order-dependent failures on `main`, reproducible with:

```
uv run pytest tests/unit tests/integration -q -p no:randomly \
  -k "sovereign or airgap or network or socket_guard or doctor or profile"
```

```
FAILED tests/unit/test_no_network_guard.py::test_allow_network_marker_disables_guard
FAILED tests/unit/test_spawner.py::TestSamplingParamsSpawnPath::test_mode_profile_sampling_params_reach_adapter
FAILED tests/unit/test_spawner.py::TestSamplingParamsSpawnPath::test_role_policy_sampling_params_take_precedence_over_mode_profile
FAILED tests/unit/test_spawner.py::TestSamplingParamsSpawnPath::test_mode_profile_max_tokens_reaches_manifest_for_openai_agents_role_with_claude_primary
```

Two unrelated leaks, each invisible when the affected file runs alone.

## 1. Hermetic-network guard stranded on the real socket class

`block_network()` resolved `socket.socket` again on the way out of its context.

`tests/unit/cost/test_dispatch_knob_matrix.py` proves the knob resolver never opens a
socket by replacing the class in the `socket` module namespace with a raising stand-in.
That replacement can still be live when the guard's context exits, since fixture
finalizers do not have to unwind in the order that would make re-resolution safe. The
restore then wrote the saved methods onto the stand-in and left `_guarded_connect` on
the real class for the rest of the session.

Every later test carrying `@pytest.mark.allow_network` hit the unit-test network guard
instead of the OS and failed with `NetworkBlockedError`, far from the test that caused it.

Fix: bind the class once on entry and route both the patch and the restore through that
binding.

Deterministic repro, 6 seconds:

```
uv run pytest tests/unit/cost/test_dispatch_knob_matrix.py \
              tests/unit/test_no_network_guard.py -q -p no:randomly
```

## 2. Network posture env vars leaking between tests

`install_policy()` and the sovereign branch of `_install_network_policy()` write
`BERNSTEIN_PROFILE_MODE` / `BERNSTEIN_NETWORK_POLICY` / `BERNSTEIN_SOVEREIGN_MODE`
straight to `os.environ` on purpose, since spawned adapters inherit the posture that
way, and there is no uninstall counterpart.

Tests that call those installers clean up with a `monkeypatch.delenv(..., raising=False)`
preamble. That looks like it covers the case but does not: `MonkeyPatch.delitem` only
records an undo entry when the key is already present, so on a clean environment it
registers nothing and the values the installer writes afterwards survive the test.

A leaked `BERNSTEIN_SOVEREIGN_MODE=1` makes `is_sovereign_profile()` true for the rest of
the session, which turns the spawner's posture-drift preflight from a no-op into a
`PostureDriftRefusal` for every later test whose workspace has no attestation.

Fix: snapshot and restore the three vars in an autouse fixture, so the trap is closed for
any test that touches them however it sets them.

## 3. Runtime socket guard keyed off callable identity

Independent hardening, found while investigating. Separable: this is the last commit and
can be dropped without affecting the two fixes above.

`install_runtime_socket_guard()` stashes the current `socket.socket.connect` on the class
and tracks the installation with a boolean flag. Nothing tied that flag to the patch it
described, so once another patcher took over `connect` and later withdrew, the flag
outlived the installation and both entry points acted on a stale stash:

- `uninstall_runtime_socket_guard()` restored a callable that was no longer anybody's
  `connect`, writing a dead wrapper into the process and displacing whatever was
  legitimately installed.
- `install_runtime_socket_guard()` short-circuited on the flag and returned `True`
  without patching, so an airgap run could believe it had an egress boundary that was
  never put in place. That is a fail-open on a security control and the more serious of
  the two.

Fix: record the guard callable alongside the stash and compare identities before acting.
`is_runtime_socket_guard_installed()` now reports the state of the class rather than the
leftover flag. Behaviour on the ordinary install/uninstall round trip is unchanged.

## Verification

| Check | Result |
|---|---|
| Original repro command | 1105 passed, 0 failed (was 4 failed) |
| `tests/unit/cost` + `tests/unit/cli` | 764 passed, 1 skipped |
| spawner + guard + airgap + sovereign files | 216 passed |
| `ruff check` + `ruff format --check` | clean |

New regression coverage:

- `tests/unit/test_no_network_guard.py::test_block_network_restores_the_real_class_when_socket_is_rebound`
- `tests/unit/test_socket_guard_isolation.py` (6 tests)

Each fix was confirmed to fail before the change and pass after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved air-gapped network protection when socket behavior is modified by other components.
  * Prevented uninstalling the guard from restoring outdated or unrelated socket patches.
  * Ensured forced reinstallation uses the socket configuration currently in effect.
  * Improved restoration of socket behavior when the socket class is temporarily replaced.

* **Tests**
  * Added coverage for socket guard installation, removal, replacement, and restoration scenarios.
  * Improved test isolation by restoring network-related environment settings between tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->