### PR TITLE
fix(tests): fix race on heartbeat file reads in TestRunnerHeartbeat

### DIFF
--- a/tests/unit/adapters/test_openai_agents.py
+++ b/tests/unit/adapters/test_openai_agents.py
@@ -1901,19 +1901,37 @@ class TestRunnerRun:
 # ---------------------------------------------------------------------------
 
 
+def _await_heartbeat_payload(hb_file: Path, timeout_s: float = 5.0) -> dict[str, Any]:
+    """Return the first complete heartbeat payload written to *hb_file*.
+
+    The writer uses ``Path.write_text``, which truncates before writing, so
+    the file can exist while still being empty or only partially written.
+    Waiting for mere existence races that window and reads torn content, so
+    poll until the file parses instead.
+    """
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        try:
+            text = hb_file.read_text(encoding="utf-8").strip()
+        except OSError:  # not created yet
+            text = ""
+        if text:
+            try:
+                return json.loads(text)
+            except json.JSONDecodeError:
+                pass  # partial write; retry
+        time.sleep(0.01)
+    raise AssertionError(f"no complete heartbeat payload at {hb_file} within {timeout_s}s")
+
+
 class TestRunnerHeartbeat:
     def test_heartbeat_writes_proxy_shaped_payload(self, tmp_path: Path) -> None:
         hb_dir = tmp_path / ".sdd" / "runtime" / "heartbeats"
         stop_event = _start_heartbeat("hb-sess", hb_dir, interval_s=0.05)
-        hb_file = hb_dir / "hb-sess.json"
         try:
-            deadline = time.monotonic() + 5.0
-            while not hb_file.exists() and time.monotonic() < deadline:
-                time.sleep(0.01)
+            payload = _await_heartbeat_payload(hb_dir / "hb-sess.json")
         finally:
             stop_event.set()
-        assert hb_file.exists()
-        payload = json.loads(hb_file.read_text(encoding="utf-8"))
         # Schema mirrors _start_heartbeat_proxy in spawner_sandbox_session.
         assert set(payload) == {
             "timestamp",
@@ -1932,9 +1950,7 @@ class TestRunnerHeartbeat:
         hb_dir = tmp_path / ".sdd" / "runtime" / "heartbeats"
         stop_event = _start_heartbeat("hb-stop", hb_dir, interval_s=0.05)
         hb_file = hb_dir / "hb-stop.json"
-        deadline = time.monotonic() + 5.0
-        while not hb_file.exists() and time.monotonic() < deadline:
-            time.sleep(0.01)
+        _await_heartbeat_payload(hb_file)
         stop_event.set()
         time.sleep(0.15)
         hb_file.unlink()


### PR DESCRIPTION
The heartbeat tests in `tests/unit/adapters/test_openai_agents.py` waited only for the heartbeat file to exist before parsing it. `_start_heartbeat` writes with `Path.write_text`, which truncates the file and then writes, so there is a window where the file exists while still empty or partially written. Sampling inside that window read an empty string and raised:

```
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

Observed on CI (ubuntu-latest, Python 3.13). It reddens unrelated PRs at random, so it is fixed on its own rather than inside a feature PR.

## Change

Test-only. The wait loop now polls until the file parses rather than until it exists, keeping the existing 5s deadline. Schema assertions are unchanged. `test_heartbeat_stops_after_event_set` gets the same wait, which additionally guarantees a full write iteration completed before the stop event is set.

## Not a production defect

The production readers already tolerate a torn read:

- `AgentSignalManager.read_heartbeat` strips the text, returns `None` on empty, catches the decode error, and has a broad fallback handler.
- `supervisor_aggregator.load_heartbeat` catches `(OSError, JSONDecodeError)` and guards the payload type.
- `HeartbeatMonitor._read_heartbeat` delegates to the above and guards its fallback path.
- The reaper paths (`_probe_liveness_signals`, `_refresh_heartbeat_from_signals`) read mtime only and never parse.

A torn read therefore degrades to "no heartbeat" and never reaps a worker.

## Verification

- 480 runs across two independent 4-worker concurrent stress runs: zero failures.
- Revert-checked: with the writer temporarily emitting an empty payload and then a half payload, the previous test reproduces the CI error exactly and the new test passes. This proves the test tolerates the window rather than being lucky.
- Full file: 156 passed. `ruff check` and `ruff format --check` clean.

## Follow-up (not in this PR)

Both heartbeat writers (`_start_heartbeat`, `_start_heartbeat_proxy`) use non-atomic `write_text`. A temp-file-plus-`os.replace` write would remove the torn-read window at the source. Since every reader is already guarded, that is a latent smell rather than a live defect, and it is deliberately left out to keep this fix reviewable during the release wave.