### PR TITLE
fix(server): drop stale re-export that broke importing core.server.server

### DIFF
--- a/src/bernstein/core/server/__init__.py
+++ b/src/bernstein/core/server/__init__.py
@@ -12,18 +12,33 @@ from bernstein.core.server.server_models import *  # noqa: F403
 
 
 def __getattr__(name: str) -> _Any:
-    """Lazy fallback for attributes not eagerly exported."""
+    """Lazy fallback for attributes not eagerly exported.
+
+    A module in the fallback chain that fails to import must not decide the
+    answer for an unrelated attribute: the remaining modules are still
+    consulted, and a genuine miss still raises ``AttributeError`` rather than
+    leaking that module's ``ImportError``. The failures are named in the final
+    message so a broken module stays visible instead of being swallowed.
+    """
     import importlib
 
+    unimportable: list[str] = []
     for mod_name in (
         "bernstein.core.server.server_app",
         "bernstein.core.server.server_models",
         "bernstein.core.server.server_middleware",
         "bernstein.core.server.server",
     ):
-        mod = importlib.import_module(mod_name)
+        try:
+            mod = importlib.import_module(mod_name)
+        except ImportError as exc:
+            unimportable.append(f"{mod_name} ({exc})")
+            continue
         try:
             return getattr(mod, name)
         except AttributeError:
             continue
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    if unimportable:
+        msg += "; these fallback modules could not be imported: " + ", ".join(unimportable)
+    raise AttributeError(msg)

--- a/src/bernstein/core/server/server.py
+++ b/src/bernstein/core/server/server.py
@@ -30,7 +30,6 @@ from bernstein.core.server.server_app import node_to_response as node_to_respons
 from bernstein.core.server.server_app import notify_agent_status as notify_agent_status
 from bernstein.core.server.server_app import read_log_tail as read_log_tail
 from bernstein.core.server.server_app import task_to_response as task_to_response
-from bernstein.core.server.server_middleware import _PUBLIC_PATH_PREFIXES as _PUBLIC_PATH_PREFIXES
 from bernstein.core.server.server_middleware import _PUBLIC_PATHS as _PUBLIC_PATHS
 from bernstein.core.server.server_middleware import _WRITE_METHODS as _WRITE_METHODS
 

--- a/tests/unit/test_server_import_regression.py
+++ b/tests/unit/test_server_import_regression.py
@@ -1,0 +1,75 @@
+"""Import-time regression tests for the ``bernstein.core.server`` package.
+
+These guard against two coupled failure modes surfaced when a re-export in
+``server.py`` referenced a symbol that ``server_middleware.py`` had stopped
+defining:
+
+* ``import bernstein.core.server.server`` raised ``ImportError`` outright
+  (the stale ``_PUBLIC_PATH_PREFIXES`` re-export);
+* ``from bernstein.core.server import <submodule>`` (e.g. ``server_launch``)
+  failed *in isolation* because the package ``__getattr__`` fallback loop
+  imports ``bernstein.core.server.server`` and only caught ``AttributeError``,
+  leaking the unrelated ``ImportError`` for any attribute miss.
+
+The subprocess tests use a *fresh* interpreter on purpose: once a module is
+cached in ``sys.modules`` a repeated ``import`` is a no-op and would mask the
+regression. Only a cold import re-executes ``server.py`` top-to-bottom.
+"""
+
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = str(Path(__file__).resolve().parents[2] / "src")
+
+
+def _import_in_fresh_interpreter(statement: str) -> subprocess.CompletedProcess[str]:
+    """Run *statement* in a cold interpreter and return the completed process."""
+    script = f"import sys; sys.path.insert(0, {_SRC!r})\n{statement}\nprint('ok')"
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_import_server_module_in_fresh_interpreter() -> None:
+    proc = _import_in_fresh_interpreter("import bernstein.core.server.server")
+    assert proc.returncode == 0, "import bernstein.core.server.server failed:\n" + proc.stderr
+    assert proc.stdout.strip() == "ok"
+
+
+def test_from_server_import_submodule_in_fresh_interpreter() -> None:
+    proc = _import_in_fresh_interpreter("from bernstein.core.server import server_launch")
+    assert proc.returncode == 0, "from bernstein.core.server import server_launch failed:\n" + proc.stderr
+    assert proc.stdout.strip() == "ok"
+
+
+def test_getattr_tolerates_broken_fallback_module(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A broken fallback module must not corrupt unrelated attribute lookups.
+
+    If any module in the ``__getattr__`` fallback loop fails to import, an
+    attribute that is genuinely absent everywhere must still raise
+    ``AttributeError`` - never leak the fallback module's ``ImportError``.
+    """
+    import bernstein.core.server as srv
+
+    real_import_module = importlib.import_module
+
+    def _fake_import_module(name: str, *args: object, **kwargs: object) -> object:
+        if name == "bernstein.core.server.server":
+            raise ImportError("simulated broken fallback")
+        return real_import_module(name, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(importlib, "import_module", _fake_import_module)
+
+    with pytest.raises(AttributeError):
+        _ = srv.this_attribute_does_not_exist_anywhere


### PR DESCRIPTION
## What

`import bernstein.core.server.server` raises `ImportError` on `main` today:

```
ImportError: cannot import name '_PUBLIC_PATH_PREFIXES' from
'bernstein.core.server.server_middleware'
```

`server.py` re-exported that symbol, but `server_middleware.py` stopped defining it when the unauthenticated bypass paths were removed. The re-export was left behind and has no remaining users anywhere in the tree.

## Why it was not noticed

The package `__getattr__` fallback masks it. Any attribute miss on `bernstein.core.server` walks a list of modules and imports each one; because `importlib.import_module` sat outside the `try`, the broken module aborted the walk. Importing the package still worked, so nothing in CI exercised the direct module import.

That masking is the more interesting half of this. One module failing to import decided the answer for unrelated attribute lookups, and it reported an `ImportError` about a different module rather than the truthful "no such attribute".

## Changes

- Remove the dead re-export in `server.py`.
- `__getattr__` now imports each fallback module inside the `try`, so a module that fails to import no longer stops the remaining ones from being consulted, and a genuine miss raises `AttributeError` as it should. The names of any modules that failed to import are appended to the `AttributeError` message, so a broken module stays visible instead of being silently skipped.
- Add a cold-import regression guard covering both failure modes.

The tests run in a fresh interpreter deliberately: once a module is cached in `sys.modules`, a repeated import is a no-op and would mask exactly this regression.

## Verification

- 3 new tests pass; 30 tests pass across the touched server surface.
- Revert-checked, both directions:
  - restoring the re-export fails `test_import_server_module_in_fresh_interpreter`
  - restoring the original `__getattr__` fails `test_getattr_tolerates_broken_fallback_module`
- `ruff check` and `ruff format --check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server module loading for more reliable imports and startup behavior.
  * Preserved backward-compatible attribute access when optional components cannot be loaded.
  * Missing server attributes now produce clearer diagnostic errors instead of obscuring the underlying issue.
* **Tests**
  * Added regression coverage for fresh server imports, submodule access, and fallback behavior when components are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->