### PR TITLE
fix(audit): let query read the same segments verify does

### DIFF
--- a/src/bernstein/core/security/audit.py
+++ b/src/bernstein/core/security/audit.py
@@ -737,6 +737,7 @@ class AuditLog:
         actor: str | None = None,
         since: str | None = None,
         until: str | None = None,
+        include_archived: bool = False,
     ) -> list[AuditEvent]:
         """Filter audit events by type, actor, and/or time range.
 
@@ -745,16 +746,42 @@ class AuditLog:
             actor: If set, only return events from this actor.
             since: ISO 8601 lower bound (inclusive).
             until: ISO 8601 upper bound (inclusive).
+            include_archived: Also read archived ``*.jsonl.gz`` segments,
+                replayed in chronological order *before* the live files, the
+                same way :meth:`verify` walks them (#1835). Default False
+                keeps the hot path reading only live segments.
+
+                Callers that reason about *linkage* between events - rather
+                than about individual events - need this. After retention an
+                event's predecessor commonly lives in an archived segment, so
+                a live-only read makes an intact chain look broken. Reading
+                archives costs a decompress per segment, so it belongs on the
+                paths that need completeness, not on every query.
 
         Returns:
             List of matching AuditEvent instances (chronological order).
+
+        Raises:
+            UnicodeDecodeError: When a segment is not valid UTF-8. Invalid
+                bytes are evidence - of a truncated write, corruption, or
+                tampering - and ``verify`` hashes the raw bytes, so silently
+                substituting replacement characters here would return records
+                that do not match what is on disk.
         """
         results: list[AuditEvent] = []
-        log_files = sorted(self._audit_dir.glob(_JSONL_GLOB))
+        sources: list[bytes | None] = []
+        if include_archived:
+            discarded: list[str] = []
+            sources.extend(_read_archived_segment(gz, discarded) for gz in _archived_segment_paths(self._audit_dir))
+        sources.extend(path.read_bytes() for path in sorted(self._audit_dir.glob(_JSONL_GLOB)))
 
-        for log_path in log_files:
-            for raw in log_path.read_text().splitlines():
-                raw = raw.strip()
+        for blob in sources:
+            if blob is None:
+                # Unreadable archive segment (corrupt gzip). ``verify`` reports
+                # it with a named error; a query simply has nothing to yield.
+                continue
+            for raw_line in blob.decode("utf-8").splitlines():
+                raw = raw_line.strip()
                 if not raw:
                     continue
                 try:

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -870,13 +870,20 @@ class AuditChainStore:
         actor: str | None = None,
         since: str | None = None,
         until: str | None = None,
+        include_archived: bool = False,
     ) -> list[AuditEvent]:
-        """Delegate to the underlying :class:`AuditLog`."""
+        """Delegate to the underlying :class:`AuditLog`.
+
+        ``include_archived`` also replays archived ``*.jsonl.gz`` segments, so
+        a caller reasoning about linkage across the retention boundary sees
+        the same events :meth:`verify` does.
+        """
         return self._log.query(
             event_type=event_type,
             actor=actor,
             since=since,
             until=until,
+            include_archived=include_archived,
         )
 
     def verify(self) -> tuple[bool, list[str]]:

--- a/src/bernstein/core/workflows/recipe_registry.py
+++ b/src/bernstein/core/workflows/recipe_registry.py
@@ -419,8 +419,13 @@ class RecipeRegistry:
 
     # -- projection ---------------------------------------------------------
 
-    def _lifecycle_events(self) -> list[dict[str, Any]]:
-        """Return every recipe-lifecycle chain event in chain order."""
+    def _lifecycle_events(self, *, include_archived: bool = False) -> list[dict[str, Any]]:
+        """Return every recipe-lifecycle chain event in chain order.
+
+        ``include_archived`` widens the read to archived segments. The
+        projection reasons about *linkage* between receipts, so after audit
+        retention a live-only read can make an intact lineage look broken.
+        """
         from bernstein.core.security.audit_chain import (
             EVENT_RECIPE_PAUSE,
             EVENT_RECIPE_REGISTER,
@@ -439,7 +444,7 @@ class RecipeRegistry:
         }
         out: list[dict[str, Any]] = []
         for event_type in sorted(wanted):
-            for ev in chain.query(event_type=event_type):
+            for ev in chain.query(event_type=event_type, include_archived=include_archived):
                 out.append(
                     {
                         "event_type": ev.event_type,
@@ -466,6 +471,17 @@ class RecipeRegistry:
         )
 
         events = [ev for ev in self._lifecycle_events() if str(ev["details"].get("name", "")) == name]
+        if events and not _lineage_is_complete(events):
+            # A receipt names a predecessor the live segments cannot produce.
+            # Before treating that as a broken lineage, look where ``verify``
+            # looks: it has replayed archived segments since #1835, so after
+            # retention the missing predecessor is usually simply archived.
+            # Only paid when the linkage is actually incomplete.
+            widened = [
+                ev for ev in self._lifecycle_events(include_archived=True) if str(ev["details"].get("name", "")) == name
+            ]
+            if len(widened) > len(events):
+                events = widened
         # Order the name's receipts by their per-name lineage linkage: each
         # receipt names the hmac of its predecessor, so a linked list rebuild
         # is order-independent of how query() grouped them.
@@ -798,6 +814,27 @@ class RecipeRegistry:
             concurrency_cap=int(body.get("concurrency_cap", 1)),
             pins=pins,
         )
+
+
+def _lineage_is_complete(events: list[dict[str, Any]]) -> bool:
+    """Return whether every receipt is reachable from the genesis link.
+
+    False means at least one receipt names a predecessor that is not in
+    *events* - normally because the segment holding it has been archived out
+    of the default query window.
+    """
+    by_prev: dict[str, dict[str, Any]] = {}
+    for ev in events:
+        by_prev.setdefault(str(ev["details"].get("prev_receipt_digest", "")), ev)
+    reached: set[str] = set()
+    cursor = ""
+    while cursor in by_prev:
+        hmac = str(by_prev[cursor]["hmac"])
+        if hmac in reached:
+            break
+        reached.add(hmac)
+        cursor = hmac
+    return len(reached) == len(events)
 
 
 def _order_by_lineage(events: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/tests/unit/test_audit_query_archived_segments.py
+++ b/tests/unit/test_audit_query_archived_segments.py
@@ -1,0 +1,138 @@
+"""``query`` can read the same segments ``verify`` does (#1835 follow-up).
+
+``verify`` has replayed archived ``*.jsonl.gz`` segments since #1835, but
+``query`` reads only live ``*.jsonl``. Any caller reasoning about *linkage*
+between events therefore disagrees with the verifier once retention archives
+an early segment: the chain is intact, yet the predecessor an event names is
+simply not in the window the caller read.
+
+The recipe definition lineage is one such caller, and the visible symptom is
+``recipes history --verify`` reporting a broken link for a recipe that is
+entirely healthy.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bernstein.core.security.audit import AuditLog, RetentionPolicy
+from bernstein.core.security.audit_chain import AuditChainStore
+from bernstein.core.workflows.recipe_registry import RecipePins, RecipeRegistry
+from bernstein.core.workflows.recipe_spec import load_recipe_spec_from_text
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_KEY = b"0" * 32
+_V1 = 'name: nightly\ndescription: d\nversion: "1.0.0"\nnodes:\n  - id: n\n    command: "echo a"\n'
+_V2 = 'name: nightly\ndescription: d\nversion: "2.0.0"\nnodes:\n  - id: n\n    command: "echo b"\n'
+
+
+def _registry(sdd: Path) -> RecipeRegistry:
+    sdd.mkdir(parents=True, exist_ok=True)
+    return RecipeRegistry(
+        sdd,
+        chain=AuditChainStore(sdd / "audit", key=_KEY),
+        hmac_key=_KEY,
+        lineage_key=_KEY,
+    )
+
+
+def _register_then_archive_genesis(sdd: Path) -> None:
+    """Register v1, age its segment, register v2, run ordinary retention."""
+    audit = sdd / "audit"
+    _registry(sdd).register(spec=load_recipe_spec_from_text(_V1), pins=RecipePins(git_commit="c1"))
+    sorted(audit.glob("*.jsonl"))[0].rename(audit / "2020-01-01.jsonl")
+    _registry(sdd).register(spec=load_recipe_spec_from_text(_V2), pins=RecipePins(git_commit="c2"))
+    AuditLog(audit_dir=audit, key=_KEY).archive(RetentionPolicy())
+
+
+class TestQueryReadsArchivedSegments:
+    def test_archived_events_are_invisible_by_default(self, tmp_path: Path) -> None:
+        """The default window is unchanged: live segments only."""
+        sdd = tmp_path / ".sdd"
+        _register_then_archive_genesis(sdd)
+        log = AuditLog(audit_dir=sdd / "audit", key=_KEY)
+        assert len(log.query(event_type="recipe.register")) == 0
+
+    def test_include_archived_sees_them(self, tmp_path: Path) -> None:
+        sdd = tmp_path / ".sdd"
+        _register_then_archive_genesis(sdd)
+        log = AuditLog(audit_dir=sdd / "audit", key=_KEY)
+        assert len(log.query(event_type="recipe.register", include_archived=True)) == 1
+
+    def test_archived_events_come_before_live_ones(self, tmp_path: Path) -> None:
+        """Chronological order across the retention boundary, as verify walks it."""
+        sdd = tmp_path / ".sdd"
+        _register_then_archive_genesis(sdd)
+        log = AuditLog(audit_dir=sdd / "audit", key=_KEY)
+        events = log.query(include_archived=True)
+        assert [e.event_type for e in events] == ["recipe.register", "recipe.supersede"]
+
+
+class TestLineageSurvivesRetention:
+    def test_an_archived_genesis_no_longer_reads_as_a_broken_link(self, tmp_path: Path) -> None:
+        """The reported defect: a healthy recipe accused of a broken lineage."""
+        sdd = tmp_path / ".sdd"
+        _register_then_archive_genesis(sdd)
+        registry = _registry(sdd)
+
+        chain_ok, _errors = registry._get_chain().verify()
+        assert chain_ok, "precondition: the chain is intact, only a segment was archived"
+
+        ok, errors = registry.verify_history("nightly")
+        assert ok is True, f"an archived-but-intact lineage must verify: {errors}"
+        assert len(registry.history("nightly")) == 2, "both receipts re-walked, including the archived one"
+        assert registry.live_hash("nightly")
+
+    def test_a_recipe_with_no_archived_history_is_unaffected(self, tmp_path: Path) -> None:
+        sdd = tmp_path / ".sdd"
+        registry = _registry(sdd)
+        registry.register(spec=load_recipe_spec_from_text(_V1), pins=RecipePins(git_commit="c1"))
+        ok, errors = registry.verify_history("nightly")
+        assert ok is True, errors
+
+
+class TestInvalidUtf8StaysLoud:
+    """Invalid bytes are evidence, and ``verify`` hashes the raw bytes.
+
+    Substituting replacement characters would make ``query`` return a
+    clean-looking record that does not match what is on disk - the projection
+    and the verifier would then disagree about what the log says.
+    """
+
+    @staticmethod
+    def _corrupt_a_string_value(audit: Path) -> None:
+        segment = sorted(audit.glob("*.jsonl"))[0]
+        raw = segment.read_bytes()
+        corrupted = raw.replace(b'"nightly"', b'"night\xffy"')
+        assert corrupted != raw, "fixture did not corrupt anything"
+        segment.write_bytes(corrupted)
+
+    def test_live_segment_with_invalid_utf8_raises(self, tmp_path: Path) -> None:
+        sdd = tmp_path / ".sdd"
+        sdd.mkdir(parents=True)
+        _registry(sdd).register(spec=load_recipe_spec_from_text(_V1), pins=RecipePins(git_commit="c1"))
+        self._corrupt_a_string_value(sdd / "audit")
+
+        log = AuditLog(audit_dir=sdd / "audit", key=_KEY)
+        with pytest.raises(UnicodeDecodeError):
+            log.query(event_type="recipe.register")
+
+    def test_archived_segment_with_invalid_utf8_raises(self, tmp_path: Path) -> None:
+        sdd = tmp_path / ".sdd"
+        sdd.mkdir(parents=True)
+        audit = sdd / "audit"
+        _registry(sdd).register(spec=load_recipe_spec_from_text(_V1), pins=RecipePins(git_commit="c1"))
+        self._corrupt_a_string_value(audit)
+        sorted(audit.glob("*.jsonl"))[0].rename(audit / "2020-01-01.jsonl")
+        AuditLog(audit_dir=audit, key=_KEY).archive(RetentionPolicy())
+
+        log = AuditLog(audit_dir=audit, key=_KEY)
+        # Live-only read sees nothing and must not raise...
+        assert log.query(event_type="recipe.register") == []
+        # ...but reading the archive applies the same strict rule.
+        with pytest.raises(UnicodeDecodeError):
+            log.query(event_type="recipe.register", include_archived=True)


### PR DESCRIPTION
## The defect

`verify()` has replayed archived `*.jsonl.gz` segments since #1835. `query()` reads only live `*.jsonl`. Any caller that reasons about *linkage between events* — rather than about individual events — therefore disagrees with the verifier once retention archives an early segment.

The recipe definition lineage is such a caller. After ordinary 90-day retention archives a recipe's genesis registration:

```
chain.verify()                 -> True      (the chain is intact)
recipes history --verify       -> "broken definition-lineage link for 'nightly':
                                   receipt expected prev (genesis) but names 45e96a2a..."
```

Nothing is broken. The operator is told something is wrong with data that is fine, by routine housekeeping they were supposed to do. This reproduces on `main` today with retention enabled.

## The fix

- `AuditLog.query` and `AuditChainStore.query` gain `include_archived`, replaying archived segments in chronological order *before* the live files, exactly as `verify` walks them. Default `False`, so the hot path is unchanged and no existing caller changes behaviour.
- The recipe lineage projection widens to archived segments **only when the linkage is incomplete**, so a healthy projection pays nothing.

No new mechanism, no schema change, no new command.

## On the decode

Segments are now read as bytes so the live and archive paths share one loop. The decode is deliberately **strict** — `blob.decode("utf-8")` with no error handler.

Invalid UTF-8 in a segment is evidence: of a truncated write, corruption, or tampering. `verify` hashes the raw bytes. Substituting replacement characters would let `query` return a clean-looking record that does not match what is on disk, so the projection and the verifier would disagree about what the log *says* — the same class of asymmetry this PR exists to remove, one layer down.

Measured, injecting `0xFF` into a JSON string value:

| | `query()` | `verify()` |
|---|---|---|
| `main` | raises `UnicodeDecodeError` | raises `UnicodeDecodeError` |
| lenient decode (rejected) | **returns `note='cl�an'`** | raises |
| this PR | raises `UnicodeDecodeError` | raises `UnicodeDecodeError` |

Behaviour on live segments is identical to `main`; the same rule now applies to archived ones. Pinned by `TestInvalidUtf8StaysLoud`.

## Tests

`tests/unit/test_audit_query_archived_segments.py` — 7 tests: the default window is unchanged, `include_archived` sees archived events, ordering is chronological across the boundary, an archived genesis no longer reads as a broken link, a recipe with no archived history is unaffected, and invalid UTF-8 raises on both live and archived paths.

Each was confirmed to **fail** with its production change reverted: archive-aware projection → 1 failure; `include_archived` → 4; strict decode → 2.

148 tests pass across the audit, recipe, and schedule suites. `ruff check` and `ruff format --check` clean.

## Adjacent, not fixed here

`verify()` raises an uncaught `UnicodeDecodeError` on a segment containing invalid UTF-8, rather than returning `(False, errors)`. Its docstring claims it stays "a total function over a possibly-damaged archive directory", which that case contradicts. This is pre-existing on `main` and unrelated to the asymmetry fixed here, so it is reported rather than bundled — happy to open it separately.

Split out of #2673, which stays a draft for v3.8.0.
