### PR TITLE
fix(registry): keep the MCP server.json description inside the 100-char cap

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.sipyourdrink-ltd/bernstein",
-  "description": "Deterministic, verifiable orchestration for CLI coding agents - reproducible parallel runs, signed audit trail, air-gap friendly. 40+ adapters (Claude Code, Codex, Gemini CLI, and more).",
+  "description": "Deterministic, verifiable orchestration for CLI coding agents. 40+ adapters, air-gap friendly.",
   "repository": {
     "url": "https://github.com/sipyourdrink-ltd/bernstein",
     "source": "github"

--- a/tests/unit/test_distribution_manifests.py
+++ b/tests/unit/test_distribution_manifests.py
@@ -25,6 +25,10 @@ from pathlib import Path
 _REPO = Path(__file__).resolve().parents[2]
 
 
+#: The MCP registry rejects a longer ``description`` with a 422 at publish time.
+_REGISTRY_DESCRIPTION_MAX = 100
+
+
 def _pyproject_version() -> str:
     with (_REPO / "pyproject.toml").open("rb") as fh:
         return tomllib.load(fh)["project"]["version"]
@@ -41,6 +45,24 @@ def test_server_json_version_matches_pyproject() -> None:
     # the version rides in the identifier tag instead.
     assert "version" not in packages["oci"]
     assert packages["oci"]["identifier"] == f"ghcr.io/sipyourdrink-ltd/bernstein:{version}"
+
+
+def test_server_json_description_fits_the_registry_limit() -> None:
+    """The MCP registry caps ``description`` at 100 characters.
+
+    It enforces this at publish time with a 422, which lands *after* the tag
+    and the PyPI upload have already gone out - so the listing silently stays
+    on the previous version while every other artifact ships. A description
+    edit that overruns is invisible until then; this pins it at commit time
+    instead.
+    """
+    data = json.loads((_REPO / "server.json").read_text(encoding="utf-8"))
+    description = data["description"]
+    assert len(description) <= _REGISTRY_DESCRIPTION_MAX, (
+        f"server.json description is {len(description)} characters; the MCP registry "
+        f"rejects anything over {_REGISTRY_DESCRIPTION_MAX} with a 422 during publish. "
+        f"Shorten it: {description!r}"
+    )
 
 
 def test_plugin_manifest_version_and_paths() -> None:


### PR DESCRIPTION
## What broke

The v3.7.1 publish run failed its `Publish MCP registry listing` job:

```
422 Unprocessable Entity
"expected length <= 100", location: body.description
```

`server.json`'s description had grown to 186 characters during the description-unification pass. The MCP registry caps it at 100.

## Why it was invisible until publish

The cap is enforced by the registry at publish time, and publish runs *after* the tag is cut and the wheel is on PyPI. So the release reported success, the package and image shipped, and the registry listing quietly stayed on the previous version. Nothing in CI looks at the length.

## Changes

- `server.json` description shortened to 94 characters, keeping the load-bearing claims: deterministic, verifiable, 40+ adapters, air-gap.
- A test asserting the cap, so an overrun fails at commit time rather than after a release has half-shipped.

Revert-checked: restoring the 186-character description fails the new test.

The generator (`scripts/gen_distribution_manifests.py`) only rewrites version fields, so the description stays hand-maintained; the test is what holds the invariant.

## Summary by Sourcery

Enforce the MCP registry description length limit for the server manifest and fix the existing overlong description.

Bug Fixes:
- Shorten server.json description so MCP registry accepts the manifest within its 100-character cap.

Tests:
- Add a unit test that ensures server.json's description length does not exceed the MCP registry's 100-character limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the service description to highlight deterministic, verifiable orchestration, 40+ adapters, and air-gap-friendly operation.
  * Shortened the description to comply with the MCP registry’s 100-character limit.

* **Tests**
  * Added validation to ensure the service description remains within the registry’s character limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->