### PR TITLE
feat(sandbox): microVM backend with content-addressed snapshots for deterministic fork-and-race (#2613)

### DIFF
--- a/docs/architecture/sandbox.md
+++ b/docs/architecture/sandbox.md
@@ -95,6 +95,7 @@ work.
 | `docker`   | core     | `FILE_RW`, `EXEC`, `NETWORK`                     | Launches a container per session via the `docker` Python SDK. Needs `pip install bernstein[docker]`. |
 | `e2b`      | `[e2b]` extra | `FILE_RW`, `EXEC`, `NETWORK`, `SNAPSHOT`     | Runs in E2B Firecracker microVMs. Needs `pip install bernstein[e2b]` plus `E2B_API_KEY`. |
 | `modal`    | `[modal]` extra | `FILE_RW`, `EXEC`, `NETWORK`, `SNAPSHOT`, `GPU` | Serverless containers with optional GPU. Needs `pip install bernstein[modal]` plus `MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET`. |
+| `microvm`  | core     | `FILE_RW`, `EXEC`, `NETWORK`, `SNAPSHOT`         | Firecracker microVM per session — isolates kernel / network / PID namespace at a hardware boundary. Snapshots are **content-addressed** (the snapshot id *is* the SHA-256 of the image bytes in CAS). Opt-in: not a free backend, so the heuristic path never auto-selects it; an explicit `sandbox.backend: microvm` on a host without KVM fails loudly rather than degrading isolation. **The VM boot path is experimental (not yet implemented) — see below.** |
 
 ### Trade-offs
 
@@ -112,6 +113,83 @@ work.
   only `modal` exposes GPU today.
 - **Supported exec semantics.** All four backends handle argv-based
   exec with exit-code, stdout, and stderr capture.
+
+## MicroVM backend and deterministic fork-and-race
+
+The `microvm` backend (`src/bernstein/core/sandbox/backends/microvm.py`)
+adds two things the rest of the sandbox layer was missing: a real
+kernel/network/PID boundary, and a snapshot contract strong enough to
+build reproducible, auditable races on.
+
+> **Status: the deterministic core (snapshot / fork-race / signed receipt)
+> is complete and fully tested; the Firecracker VM boot itself is
+> experimental and not yet implemented.** `FirecrackerMonitor` ships the
+> host preflight and the strict no-silent-downgrade contract; the full boot
+> lifecycle (API socket, drives, networking, `InstanceStart`, and an
+> in-guest vsock agent for exec/file-IO) is a tracked follow-up. It cannot
+> be built or validated without a KVM-capable Linux host plus an
+> operator-supplied kernel, rootfs, and guest agent, so `boot()` raises
+> `MicroVMUnavailableError` on every host today rather than pretending. All
+> the guarantees below are exercised host-independently over the
+> `FakeMonitor`.
+
+**Monitor shim.** The backend never talks to a hypervisor directly. It
+drives a `VMMonitor` adapter (`backends/_vmmonitor.py`): a
+`FirecrackerMonitor` (production; strict host preflight for KVM +
+`firecracker` binary + kernel/rootfs) and a `FakeMonitor` (a
+deterministic, host-portable stand-in used by the tests that really
+executes commands and really freezes the workspace — not canned bytes).
+A Cloud Hypervisor variant fits behind the same shim and is deferred.
+
+**Content-addressed snapshots.** `snapshot()` freezes the workspace into a
+*canonicalised image* (a tar with sorted paths, zeroed mtimes/uids,
+normalised modes — deterministic given identical file contents), streams
+it into the CAS store (`.sdd/cas`, see
+[cas-store.md](./cas-store.md)), and returns the **SHA-256 digest** as the
+snapshot id. `resume(digest)` reads the blob back with integrity
+verification on, so a tampered snapshot fails its CAS check
+(`CASIntegrityError`) *before* it can boot. Images are full and
+self-contained, so a resume can never be confused about which base it
+forked from. Memory snapshots are deliberately out of scope: a memory
+image is never byte-reproducible (kernel timers, entropy, page/ASLR
+ordering), which would make the determinism guarantee below impossible.
+
+**Fork-and-race** (`src/bernstein/core/sandbox/fork_race.py`).
+`fork_race()` resumes K candidates from *one* content-addressed base
+digest, runs each to a terminal snapshot, and picks the winner with the
+existing deterministic ranker (`select_winner` → TOPSIS) — **no LLM in the
+selection path**. Determinism is engineered end to end: candidates are
+sorted by `task_id` *before* ranking (float sums are order-sensitive), and
+the pinned ranking profile excludes any wall-clock axis.
+
+**Selection receipt** (`src/bernstein/core/sandbox/selection_receipt.py`).
+The output is a `SelectionReceipt`: canonical JSON, Ed25519-signed, binding
+`{base_snapshot_digest, candidates[{task_id, terminal_snapshot_digest,
+score_vector, isolation}], winner_task_id, winner_snapshot_digest,
+ranker_profile, loser_snapshot_digests[]}`. The signed body carries **no**
+wall-clock, run id, or chain position, so running the same race twice
+produces a **byte-identical** signed receipt. Losing branches are recorded
+as lineage siblings, and the receipt is appended to the HMAC-chained audit
+log in a single serialised call (chain-position binding lives in that
+wrapper entry, not in the receipt body).
+
+**CLI.**
+
+```bash
+# Fork K candidates from a base snapshot; emits a signed receipt.
+bernstein sandbox fork-race --base <sha256> --k 3 --cmd 'make test' --out receipt.json
+
+# Verify a receipt: Ed25519 signature + re-hash base + winner + every loser
+# against CAS. Proves signed + CAS-intact; NOT that it was chain-appended
+# (that is the audit log's own verify).
+bernstein sandbox receipt verify receipt.json
+```
+
+`fork-race` requires a microVM-capable host; on an unsupported host it
+fails loudly. The determinism/tamper guarantees are validated
+host-independently over the `FakeMonitor` (see
+`tests/unit/sandbox/test_fork_race.py`); the real Firecracker boot is
+covered by the KVM-gated `tests/integration/sandbox/test_microvm_firecracker.py`.
 
 ## `plan.yaml` extension
 
@@ -161,8 +239,8 @@ Third-party backends must:
 
 - `SandboxBackend` / `SandboxSession` / `SandboxCapability` /
   `WorkspaceManifest` live in `src/bernstein/core/sandbox/`.
-- Eight first-party backends ship (worktree & docker in core; e2b,
-  modal, daytona, blaxel, runloop, and vercel as optional extras).
+- First-party backends ship in core (worktree, docker, microvm, blaxel,
+  daytona, runloop, vercel); e2b and modal ship as optional extras.
 - `AgentSpawner` accepts an optional `sandbox_session` parameter; when
   `None` it falls back to the direct-worktree path.
 - `bernstein agents sandbox-backends` lists installed backends.

--- a/docs/architecture/sandbox.md
+++ b/docs/architecture/sandbox.md
@@ -11,7 +11,7 @@ This document covers:
 
 - The `SandboxBackend` / `SandboxSession` protocol and the
   `WorkspaceManifest` / `SandboxCapability` value objects
-- The eight first-party backends (`worktree`, `docker`, `e2b`, `modal`, `daytona`, `blaxel`, `runloop`, `vercel`)
+- The nine first-party backends (`worktree`, `docker`, `e2b`, `modal`, `daytona`, `blaxel`, `runloop`, `vercel`, `microvm`)
 - The `bernstein.sandbox_backends` entry-point group for third-party
   backends
 
@@ -109,7 +109,7 @@ work.
   `docker` provides cgroup + namespace isolation but shares the
   kernel; `e2b` runs in a fresh Firecracker microVM per session;
   `modal` runs in dedicated serverless containers.
-- **Capabilities.** `e2b`, `modal`, `daytona`, `runloop`, and `vercel` support snapshot/resume (as does the local `worktree`);
+- **Capabilities.** `e2b`, `modal`, `daytona`, `runloop`, `vercel`, and `microvm` support snapshot/resume (as does the local `worktree`);
   only `modal` exposes GPU today.
 - **Supported exec semantics.** All four backends handle argv-based
   exec with exit-code, stdout, and stderr capture.

--- a/src/bernstein/cli/commands/sandbox_cmd.py
+++ b/src/bernstein/cli/commands/sandbox_cmd.py
@@ -318,6 +318,15 @@ def receipt_verify_cmd(receipt_path: Path, cas_dir: Path, expected_keyid: str | 
     proves the receipt was signed by that trusted signer. It does NOT prove
     the receipt was appended to the audit chain - that is the audit log's own
     ``verify``.
+
+    Exit codes give three distinct answers (an absent blob is an operational
+    event, not proof of tampering, and must not read as one):
+
+    * ``0`` - signed, consistent, and every named blob re-hashed intact.
+    * ``1`` - invalid signature/consistency, or a blob is **tampered**
+      (present but hash-mismatched).
+    * ``2`` - authentic and untampered, but a blob is **absent** from CAS, so
+      the content re-hash could not be completed (verification incomplete).
     """
     from bernstein.core.persistence.cas_store import CASIntegrityError, CASStore
     from bernstein.core.sandbox.selection_receipt import (
@@ -335,26 +344,48 @@ def receipt_verify_cmd(receipt_path: Path, cas_dir: Path, expected_keyid: str | 
         console.print(f"[red]signature/consistency:[/red] {err}")
 
     cas = CASStore(cas_dir)
-    cas_errors: list[str] = []
-    for digest in snapshot_digests(receipt):
+    # Distinguish two very different CAS outcomes (a hard lesson from the v3.7.1
+    # hardening wave): a blob that is *present but hash-mismatched* is tampering,
+    # while a blob that is simply *absent* is an ordinary operational event (GC,
+    # log retention, a restart). Conflating them turns a retry into a permanent
+    # "tampered" verdict on an append-only chain, so they get different answers.
+    tampered: list[str] = []
+    absent: list[str] = []
+    digests = snapshot_digests(receipt)
+    for digest in digests:
         try:
             blob = cas.get(digest, verify=True)
         except CASIntegrityError as exc:
-            cas_errors.append(str(exc))
+            tampered.append(str(exc))
             continue
         if blob is None:
-            cas_errors.append(f"snapshot blob absent from CAS: {digest}")
-    for err in cas_errors:
-        console.print(f"[red]cas:[/red] {err}")
+            absent.append(digest)
 
-    ok = verification.ok and not cas_errors
-    if ok:
+    for err in verification.errors:
+        console.print(f"[red]signature/consistency:[/red] {err}")
+    for err in tampered:
+        console.print(f"[red]tampered:[/red] {err}")
+    for digest in absent:
         console.print(
-            f"[green]OK[/green] receipt signed + all {len(snapshot_digests(receipt))} snapshot digests intact "
-            "(proves signed + CAS-intact; not chain-appended).",
+            f"[yellow]cannot-verify:[/yellow] snapshot blob absent from CAS: {digest} "
+            "(absent != tampered - likely GC / retention / restart)",
         )
-        return
-    raise click.exceptions.Exit(code=1)
+
+    # Three answers, three exit codes (see the command docstring).
+    if not verification.ok or tampered:
+        console.print("[red]FAILED[/red] receipt is invalid or a snapshot blob is tampered.")
+        raise click.exceptions.Exit(code=1)
+    if absent:
+        console.print(
+            f"[yellow]INCOMPLETE[/yellow] receipt is authentic and consistent, but "
+            f"{len(absent)} of {len(digests)} snapshot blob(s) are absent from CAS; "
+            "content re-hash could not be completed (this is not tampering).",
+        )
+        raise click.exceptions.Exit(code=2)
+    console.print(
+        f"[green]OK[/green] receipt signed + all {len(digests)} snapshot digests intact "
+        "(proves signed + CAS-intact; not chain-appended).",
+    )
 
 
 __all__ = [

--- a/src/bernstein/cli/commands/sandbox_cmd.py
+++ b/src/bernstein/cli/commands/sandbox_cmd.py
@@ -31,6 +31,7 @@ from bernstein.core.sandbox.playwright_runner import (
 )
 
 if TYPE_CHECKING:
+    from bernstein.core.sandbox.backend import SandboxSession
     from bernstein.core.sandbox.playwright_runner import PlaywrightRunResult
 
 logger = logging.getLogger(__name__)
@@ -168,4 +169,172 @@ def web_test(
         raise click.exceptions.Exit(code=1)
 
 
-__all__ = ["sandbox_group", "web_test"]
+# ---------------------------------------------------------------------------
+# fork-and-race (#2613)
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_CAS_DIR = Path(".sdd/cas")
+_DEFAULT_SELECTION_KEY = Path(".sdd/keys/selection.key")
+_DEFAULT_AUDIT_DIR = Path(".sdd/audit")
+
+
+@sandbox_group.command("fork-race")
+@click.option("--base", "base_digest", required=True, help="Base snapshot SHA-256 digest to fork every candidate from.")
+@click.option("--k", "k", type=click.IntRange(min=1), default=3, show_default=True, help="Number of candidates.")
+@click.option(
+    "--cmd", "cmd", required=True, help="Shell command run as each candidate (reads $BERNSTEIN_CANDIDATE_INDEX)."
+)
+@click.option(
+    "--out",
+    "out_path",
+    required=True,
+    type=click.Path(dir_okay=False, path_type=Path),
+    help="Where to write the signed receipt JSON.",
+)
+@click.option(
+    "--cas-dir",
+    "cas_dir",
+    default=_DEFAULT_CAS_DIR,
+    type=click.Path(file_okay=False, path_type=Path),
+    show_default=True,
+)
+@click.option(
+    "--key",
+    "key_path",
+    default=_DEFAULT_SELECTION_KEY,
+    type=click.Path(dir_okay=False, path_type=Path),
+    show_default=True,
+    help="Ed25519 signing key (created 0600 on first use).",
+)
+@click.option(
+    "--audit-dir",
+    "audit_dir",
+    default=_DEFAULT_AUDIT_DIR,
+    type=click.Path(file_okay=False, path_type=Path),
+    show_default=True,
+)
+def fork_race_cmd(
+    base_digest: str,
+    k: int,
+    cmd: str,
+    out_path: Path,
+    cas_dir: Path,
+    key_path: Path,
+    audit_dir: Path,
+) -> None:
+    """Fork K microVM candidates from one base snapshot and emit a signed receipt.
+
+    Requires a microVM-capable host (KVM + kernel/rootfs); on an unsupported
+    host it fails loudly rather than degrading isolation.
+    """
+    from bernstein.core.orchestration.best_of_n import CandidateResult
+    from bernstein.core.persistence.cas_store import CASStore
+    from bernstein.core.sandbox.backends._vmmonitor import MicroVMUnavailableError
+    from bernstein.core.sandbox.backends.microvm import MicroVMSandboxBackend
+    from bernstein.core.sandbox.fork_race import fork_race
+    from bernstein.core.sandbox.selection_receipt import (
+        load_or_create_signing_key,
+        write_receipt,
+    )
+    from bernstein.core.security.audit import AuditLog
+
+    cas = CASStore(cas_dir)
+    backend = MicroVMSandboxBackend(cas=cas)
+    signing_key = load_or_create_signing_key(key_path)
+    audit_log = AuditLog(audit_dir)
+
+    async def run_candidate(session: SandboxSession, index: int) -> CandidateResult:
+        result = await session.exec(
+            ["sh", "-lc", cmd],
+            env={"BERNSTEIN_CANDIDATE_INDEX": str(index)},
+        )
+        return CandidateResult(task_id=f"candidate-{index}", tests_passing=result.exit_code == 0)
+
+    try:
+        receipt = asyncio.run(
+            fork_race(
+                backend=backend,
+                base_snapshot_digest=base_digest,
+                run_candidate=run_candidate,
+                k=k,
+                signing_key=signing_key,
+                audit_log=audit_log,
+                audit_lock_path=audit_dir / ".fork_race.lock",
+            ),
+        )
+    except MicroVMUnavailableError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    write_receipt(out_path, receipt)
+    console.print(f"[green]winner:[/green] {receipt.winner_task_id} ({receipt.winner_snapshot_digest[:12]})")
+    console.print(f"[dim]receipt: {out_path}[/dim]")
+
+
+@sandbox_group.group("receipt")
+def receipt_group() -> None:
+    """Inspect and verify fork-race selection receipts."""
+
+
+@receipt_group.command("verify")
+@click.argument("receipt_path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option(
+    "--cas-dir",
+    "cas_dir",
+    default=_DEFAULT_CAS_DIR,
+    type=click.Path(file_okay=False, path_type=Path),
+    show_default=True,
+)
+def receipt_verify_cmd(receipt_path: Path, cas_dir: Path) -> None:
+    """Verify a receipt's signature and re-hash every snapshot blob in CAS.
+
+    Proves the receipt is *properly signed and internally consistent* and
+    that every snapshot it names (base + winner + every loser) still exists
+    and re-hashes correctly in CAS. It does NOT prove the receipt was
+    appended to the audit chain - that is the audit log's own ``verify``.
+    """
+    from bernstein.core.persistence.cas_store import CASIntegrityError, CASStore
+    from bernstein.core.sandbox.selection_receipt import (
+        read_receipt_file,
+        snapshot_digests,
+        verify_receipt,
+    )
+
+    receipt = read_receipt_file(receipt_path)
+    if receipt is None:
+        raise click.ClickException(f"Could not read a selection receipt from {receipt_path}")
+
+    verification = verify_receipt(receipt)
+    for err in verification.errors:
+        console.print(f"[red]signature/consistency:[/red] {err}")
+
+    cas = CASStore(cas_dir)
+    cas_errors: list[str] = []
+    for digest in snapshot_digests(receipt):
+        try:
+            blob = cas.get(digest, verify=True)
+        except CASIntegrityError as exc:
+            cas_errors.append(str(exc))
+            continue
+        if blob is None:
+            cas_errors.append(f"snapshot blob absent from CAS: {digest}")
+    for err in cas_errors:
+        console.print(f"[red]cas:[/red] {err}")
+
+    ok = verification.ok and not cas_errors
+    if ok:
+        console.print(
+            f"[green]OK[/green] receipt signed + all {len(snapshot_digests(receipt))} snapshot digests intact "
+            "(proves signed + CAS-intact; not chain-appended).",
+        )
+        return
+    raise click.exceptions.Exit(code=1)
+
+
+__all__ = [
+    "fork_race_cmd",
+    "receipt_group",
+    "receipt_verify_cmd",
+    "sandbox_group",
+    "web_test",
+]

--- a/src/bernstein/cli/commands/sandbox_cmd.py
+++ b/src/bernstein/cli/commands/sandbox_cmd.py
@@ -241,10 +241,16 @@ def fork_race_cmd(
 
     cas = CASStore(cas_dir)
     # Validate the base digest through CAS *before* any side-effectful state:
-    # a malformed/unknown --base must fail without minting a signing key,
-    # creating the audit directory, or booting a candidate. (Also turns the
-    # otherwise-uncaught KeyError from resume() into a clean CLI error.)
-    if not cas.has(base_digest):
+    # a malformed or unknown --base must fail cleanly without minting a signing
+    # key, creating the audit directory, or booting a candidate. cas.has()
+    # raises ValueError on a non-hex/wrong-length digest and returns False on a
+    # well-formed-but-absent one; both become a clean CLI error here (and this
+    # also turns the otherwise-uncaught KeyError from resume() into one).
+    try:
+        base_present = cas.has(base_digest)
+    except ValueError as exc:
+        raise click.ClickException(f"invalid base snapshot digest {base_digest!r}: {exc}") from exc
+    if not base_present:
         raise click.ClickException(f"base snapshot digest not found in CAS ({cas_dir}): {base_digest}")
     backend = MicroVMSandboxBackend(cas=cas)
     signing_key = load_or_create_signing_key(key_path)

--- a/src/bernstein/cli/commands/sandbox_cmd.py
+++ b/src/bernstein/cli/commands/sandbox_cmd.py
@@ -240,6 +240,12 @@ def fork_race_cmd(
     from bernstein.core.security.audit import AuditLog
 
     cas = CASStore(cas_dir)
+    # Validate the base digest through CAS *before* any side-effectful state:
+    # a malformed/unknown --base must fail without minting a signing key,
+    # creating the audit directory, or booting a candidate. (Also turns the
+    # otherwise-uncaught KeyError from resume() into a clean CLI error.)
+    if not cas.has(base_digest):
+        raise click.ClickException(f"base snapshot digest not found in CAS ({cas_dir}): {base_digest}")
     backend = MicroVMSandboxBackend(cas=cas)
     signing_key = load_or_create_signing_key(key_path)
     audit_log = AuditLog(audit_dir)
@@ -285,13 +291,25 @@ def receipt_group() -> None:
     type=click.Path(file_okay=False, path_type=Path),
     show_default=True,
 )
-def receipt_verify_cmd(receipt_path: Path, cas_dir: Path) -> None:
+@click.option(
+    "--expected-keyid",
+    "expected_keyid",
+    default=None,
+    help=(
+        "Require the receipt to be signed by this trusted keyid (sha256 of the "
+        "signer's DER public key). Without it, any self-consistent receipt "
+        "verifies - including one re-signed under an attacker's own key."
+    ),
+)
+def receipt_verify_cmd(receipt_path: Path, cas_dir: Path, expected_keyid: str | None) -> None:
     """Verify a receipt's signature and re-hash every snapshot blob in CAS.
 
     Proves the receipt is *properly signed and internally consistent* and
     that every snapshot it names (base + winner + every loser) still exists
-    and re-hashes correctly in CAS. It does NOT prove the receipt was
-    appended to the audit chain - that is the audit log's own ``verify``.
+    and re-hashes correctly in CAS. With ``--expected-keyid`` it additionally
+    proves the receipt was signed by that trusted signer. It does NOT prove
+    the receipt was appended to the audit chain - that is the audit log's own
+    ``verify``.
     """
     from bernstein.core.persistence.cas_store import CASIntegrityError, CASStore
     from bernstein.core.sandbox.selection_receipt import (
@@ -304,7 +322,7 @@ def receipt_verify_cmd(receipt_path: Path, cas_dir: Path) -> None:
     if receipt is None:
         raise click.ClickException(f"Could not read a selection receipt from {receipt_path}")
 
-    verification = verify_receipt(receipt)
+    verification = verify_receipt(receipt, expected_keyid=expected_keyid)
     for err in verification.errors:
         console.print(f"[red]signature/consistency:[/red] {err}")
 

--- a/src/bernstein/cli/commands/sandbox_cmd.py
+++ b/src/bernstein/cli/commands/sandbox_cmd.py
@@ -252,7 +252,6 @@ def fork_race_cmd(
         raise click.ClickException(f"invalid base snapshot digest {base_digest!r}: {exc}") from exc
     if not base_present:
         raise click.ClickException(f"base snapshot digest not found in CAS ({cas_dir}): {base_digest}")
-    backend = MicroVMSandboxBackend(cas=cas)
     signing_key = load_or_create_signing_key(key_path)
     audit_log = AuditLog(audit_dir)
 
@@ -264,6 +263,9 @@ def fork_race_cmd(
         return CandidateResult(task_id=f"candidate-{index}", tests_passing=result.exit_code == 0)
 
     try:
+        # Constructed inside the try so any future preflight in the backend
+        # constructor surfaces as a clean ClickException, not a raw traceback.
+        backend = MicroVMSandboxBackend(cas=cas)
         receipt = asyncio.run(
             fork_race(
                 backend=backend,

--- a/src/bernstein/core/sandbox/backends/_vmmonitor.py
+++ b/src/bernstein/core/sandbox/backends/_vmmonitor.py
@@ -1,0 +1,508 @@
+"""MicroVM monitor shim for the ``microvm`` sandbox backend (#2613).
+
+The :class:`MicroVMSandboxBackend` never talks to a hypervisor directly.
+It drives a :class:`VMMonitor` - a small, swappable adapter that owns one
+guest's lifecycle (boot, exec, file I/O, freeze-to-image, restore,
+shutdown). Two monitors ship here:
+
+- :class:`FirecrackerMonitor` - the real adapter. It performs a strict
+  host preflight (KVM device, ``firecracker`` binary, a configured kernel
+  + rootfs) and raises :class:`MicroVMUnavailableError` the moment any
+  precondition is missing. It never silently degrades into a weaker
+  isolation mode - an operator who asked for a hardware boundary gets an
+  error, not a surprise.
+- :class:`FakeMonitor` - a deterministic, host-portable stand-in used by
+  the unit + acceptance tests (mirroring how the Docker backend mocks its
+  daemon). It runs commands as ordinary local subprocesses inside a
+  private temp directory and freezes that directory into a *canonicalised
+  workspace image*. Because it really executes and really captures the
+  resulting filesystem, its snapshots are honest disk images - not canned
+  bytes - so the determinism/tamper acceptance test exercises the actual
+  content-addressing and signing substrate rather than a mock's echo.
+
+Snapshots are **full canonicalised workspace images**, not memory dumps.
+A memory snapshot can never be byte-reproducible (kernel timers, entropy
+pool, page/ASLR ordering), which would make the "same race twice ->
+identical signed receipt" guarantee impossible. A canonicalised tar of the
+guest filesystem (sorted paths, zeroed mtimes/uids, normalised modes) is
+reproducible given identical file contents, and its ``sha256`` *is* the
+snapshot id the CAS store addresses. Full images are self-contained, so
+``resume(digest)`` needs no base and cannot be confused about which base
+it forked from. Disk-*delta* images (smaller, base-relative) are a future
+optimisation tracked separately; correctness does not depend on them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import io
+import os
+import shutil
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+from bernstein.core.sandbox.backend import ExecResult
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+
+class MicroVMUnavailableError(RuntimeError):
+    """Raised when a microVM cannot be provisioned on this host.
+
+    The message enumerates every missing precondition (KVM, binary,
+    kernel image) so the operator can fix the host. Callers must treat
+    this as a hard failure - the microvm backend deliberately does *not*
+    fall back to a weaker isolation mode, because a silent downgrade from
+    a hardware boundary to a bare worktree is exactly the security
+    regression an operator running untrusted code cannot tolerate.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Canonical workspace-image helpers (the content-addressed snapshot format)
+# ---------------------------------------------------------------------------
+
+#: Content-type recorded in CAS metadata for a workspace-image snapshot.
+SNAPSHOT_CONTENT_TYPE = "application/x-bernstein-vm-snapshot+tar"
+
+
+def canonical_workspace_image(root: Path) -> bytes:
+    """Freeze the directory tree at *root* into deterministic tar bytes.
+
+    Determinism is the whole point: two calls over byte-identical file
+    trees must produce byte-identical output so ``sha256`` of the result
+    is a stable content address. To get there we strip every source of
+    run-to-run variance a normal tar would embed:
+
+    - entries are emitted in sorted path order (not readdir order);
+    - mtime is zeroed; uid/gid/uname/gname are zeroed/emptied;
+    - modes are normalised to ``0o755`` for dirs/executables and
+      ``0o644`` otherwise (guest-arbitrary permission bits do not affect
+      the deliverable and would otherwise poison the digest);
+    - the fixed ``USTAR`` format is used so no PAX timestamp headers leak.
+
+    Symlinks are captured as symlinks; special files are skipped (a guest
+    should not be smuggling device nodes into a content-addressed image).
+
+    Args:
+        root: Directory whose contents become the image.
+
+    Returns:
+        Deterministic tar bytes suitable for ``CASStore.put``.
+    """
+    root = root.resolve()
+    entries: list[tuple[str, Path]] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames.sort()
+        base = Path(dirpath)
+        for name in sorted(dirnames):
+            full = base / name
+            arc = full.relative_to(root).as_posix()
+            entries.append((arc, full))
+        for name in sorted(filenames):
+            full = base / name
+            arc = full.relative_to(root).as_posix()
+            entries.append((arc, full))
+    entries.sort(key=lambda pair: pair[0])
+
+    buf = io.BytesIO()
+    # Fixed format + no compression: gzip would embed an mtime and OS byte.
+    with tarfile.open(fileobj=buf, mode="w", format=tarfile.USTAR_FORMAT) as tar:
+        for arc, full in entries:
+            info = tarfile.TarInfo(name=arc)
+            info.mtime = 0
+            info.uid = 0
+            info.gid = 0
+            info.uname = ""
+            info.gname = ""
+            if full.is_symlink():
+                info.type = tarfile.SYMTYPE
+                info.linkname = os.readlink(full)
+                info.mode = 0o777
+                tar.addfile(info)
+            elif full.is_dir():
+                info.type = tarfile.DIRTYPE
+                info.mode = 0o755
+                tar.addfile(info)
+            elif full.is_file():
+                data = full.read_bytes()
+                info.type = tarfile.REGTYPE
+                info.size = len(data)
+                info.mode = 0o755 if os.access(full, os.X_OK) else 0o644
+                tar.addfile(info, io.BytesIO(data))
+            # else: skip fifos/sockets/devices - not part of a deliverable.
+    return buf.getvalue()
+
+
+def extract_workspace_image(image: bytes, root: Path) -> None:
+    """Restore a :func:`canonical_workspace_image` blob into *root*.
+
+    *root* is emptied first so the restored tree equals the image exactly
+    (no stray files leaking in from a reused directory). A snapshot image is
+    guest-derived and therefore untrusted even though its bytes verified
+    against the CAS digest - content-addressing proves *integrity*, not
+    *benignity*. Extraction is hardened against path traversal and link
+    escapes via the stdlib ``data`` filter (see below).
+
+    Args:
+        image: Tar bytes produced by :func:`canonical_workspace_image`.
+        root: Destination directory (created if absent, cleared if present).
+
+    Raises:
+        MicroVMUnavailableError: When a member is unsafe (absolute path,
+            ``..`` traversal, or a sym/hardlink escaping *root*).
+    """
+    root = root.resolve()
+    if root.exists():
+        for child in root.iterdir():
+            if child.is_dir() and not child.is_symlink():
+                shutil.rmtree(child)
+            else:
+                child.unlink()
+    else:
+        root.mkdir(parents=True, exist_ok=True)
+
+    # The stdlib ``data`` filter (PEP 706, py3.12+) does the right
+    # member-by-member checks *at extraction time*: it refuses absolute paths,
+    # ``..`` traversal, and links (symlink OR hardlink) whose target escapes
+    # the destination. That closes the symlink-then-child TOCTOU a name-only
+    # pre-check misses - a hostile ``dir -> ../../outside`` followed by
+    # ``dir/file`` is resolved against the real link at write time and refused.
+    with tarfile.open(fileobj=io.BytesIO(image), mode="r:") as tar:
+        try:
+            tar.extractall(root, filter="data")
+        except tarfile.FilterError as exc:
+            msg = f"Refusing unsafe member in snapshot image: {exc}"
+            raise MicroVMUnavailableError(msg) from exc
+
+
+# ---------------------------------------------------------------------------
+# Monitor protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class VMMonitor(Protocol):
+    """One guest's lifecycle, abstracted away from the hypervisor.
+
+    The backend depends only on this surface, so Firecracker, a future
+    Cloud Hypervisor adapter, and the test :class:`FakeMonitor` are fully
+    interchangeable. All methods are async to match
+    :class:`~bernstein.core.sandbox.backend.SandboxSession`.
+    """
+
+    @property
+    def workdir(self) -> str:
+        """Absolute path of the workspace root inside the guest."""
+        ...
+
+    async def boot(self, *, base_env: Mapping[str, str]) -> None:
+        """Start the guest and prepare an empty workspace root."""
+        ...
+
+    async def exec(
+        self,
+        cmd: list[str],
+        *,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout: int | None = None,
+        stdin: bytes | None = None,
+    ) -> ExecResult:
+        """Run *cmd* inside the guest and capture its result."""
+        ...
+
+    async def read_file(self, path: str) -> bytes:
+        """Read a file from the guest workspace."""
+        ...
+
+    async def write_file(self, path: str, data: bytes, *, mode: int = 0o644) -> None:
+        """Write *data* to *path* in the guest workspace."""
+        ...
+
+    async def ls(self, path: str) -> list[str]:
+        """List directory entry names in the guest workspace, sorted."""
+        ...
+
+    async def freeze_image(self) -> bytes:
+        """Return a canonicalised, content-addressable image of the workspace."""
+        ...
+
+    async def restore_image(self, image: bytes) -> None:
+        """Boot/populate the guest workspace from a frozen image."""
+        ...
+
+    async def shutdown(self) -> None:
+        """Tear the guest down. Idempotent."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# FakeMonitor - deterministic local stand-in used by tests
+# ---------------------------------------------------------------------------
+
+
+class FakeMonitor:
+    """A host-portable, deterministic :class:`VMMonitor` for tests.
+
+    It is *not* a mock that returns canned bytes. It really executes
+    commands (as local subprocesses) inside a private temp directory and
+    really freezes that directory into a canonical image. That honesty is
+    what lets the acceptance test prove determinism of the actual snapshot
+    /CAS/receipt pipeline instead of proving a mock echoes itself.
+
+    The only thing it does *not* provide is the kernel/network/PID
+    hardware boundary - that is :class:`FirecrackerMonitor`'s job and is
+    validated by the KVM-gated integration test. Everything the
+    determinism guarantee depends on lives above the boundary and is fully
+    exercised here.
+    """
+
+    def __init__(self, *, root: str = "/workspace") -> None:
+        self._logical_root = root
+        # Resolve symlinks up front (macOS /var -> /private/var) so the
+        # containment check in _resolve compares like with like; otherwise a
+        # resolved target legitimately under the temp dir looks like an escape.
+        self._host_dir = Path(tempfile.mkdtemp(prefix="bernstein-microvm-fake-")).resolve()
+        self._base_env: dict[str, str] = {}
+        self._closed = False
+
+    @property
+    def workdir(self) -> str:
+        return self._logical_root
+
+    # -- path safety -------------------------------------------------------
+
+    def _resolve(self, path: str) -> Path:
+        """Map a guest path to a host path pinned under the temp dir."""
+        rel = path
+        if os.path.isabs(path):
+            # Treat the logical root as the guest FS root for absolute paths.
+            rel = os.path.relpath(path, self._logical_root)
+        target = (self._host_dir / rel).resolve()
+        if target != self._host_dir and self._host_dir not in target.parents:
+            msg = f"Path {path!r} escapes the guest workspace"
+            raise ValueError(msg)
+        return target
+
+    # -- lifecycle ---------------------------------------------------------
+
+    async def boot(self, *, base_env: Mapping[str, str]) -> None:
+        self._base_env = dict(base_env)
+        self._host_dir.mkdir(parents=True, exist_ok=True)
+
+    async def exec(
+        self,
+        cmd: list[str],
+        *,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout: int | None = None,
+        stdin: bytes | None = None,
+    ) -> ExecResult:
+        run_env = dict(os.environ)
+        run_env.update(self._base_env)
+        if env:
+            run_env.update(env)
+        workdir = self._resolve(cwd) if cwd else self._host_dir
+
+        loop = asyncio.get_running_loop()
+        start = loop.time()
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            cwd=str(workdir),
+            env=run_env,
+            stdin=asyncio.subprocess.PIPE if stdin is not None else None,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(input=stdin),
+                timeout=timeout,
+            )
+        except TimeoutError as exc:
+            proc.kill()
+            await proc.wait()
+            msg = f"Command timed out after {timeout}s: {cmd!r}"
+            raise TimeoutError(msg) from exc
+        duration = loop.time() - start
+        return ExecResult(
+            exit_code=proc.returncode if proc.returncode is not None else -1,
+            stdout=stdout or b"",
+            stderr=stderr or b"",
+            duration_seconds=duration,
+        )
+
+    async def read_file(self, path: str) -> bytes:
+        target = self._resolve(path)
+        if not target.exists():
+            msg = f"No such file in guest: {path}"
+            raise FileNotFoundError(msg)
+        return target.read_bytes()
+
+    async def write_file(self, path: str, data: bytes, *, mode: int = 0o644) -> None:
+        target = self._resolve(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(data)
+        with contextlib.suppress(OSError):
+            target.chmod(mode)
+
+    async def ls(self, path: str) -> list[str]:
+        target = self._resolve(path)
+        if not target.is_dir():
+            msg = f"Not a directory in guest: {path}"
+            raise NotADirectoryError(msg)
+        return sorted(p.name for p in target.iterdir())
+
+    async def freeze_image(self) -> bytes:
+        return canonical_workspace_image(self._host_dir)
+
+    async def restore_image(self, image: bytes) -> None:
+        self._host_dir.mkdir(parents=True, exist_ok=True)
+        extract_workspace_image(image, self._host_dir)
+
+    async def shutdown(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        shutil.rmtree(self._host_dir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# FirecrackerMonitor - the real adapter (strict preflight, no silent degrade)
+# ---------------------------------------------------------------------------
+
+
+class FirecrackerMonitor:
+    """Real microVM monitor driving a Firecracker guest.
+
+    **Experimental - the guest boot path is not yet implemented.** This
+    release ships the host preflight and the strict no-silent-downgrade
+    contract; the full Firecracker lifecycle (API socket -> boot-source ->
+    drives -> network -> ``InstanceStart`` -> in-guest vsock agent for
+    exec/file-IO/snapshot) is a tracked follow-up that requires a
+    KVM-capable Linux host plus an operator-supplied guest kernel, rootfs,
+    and agent - none of which can be provisioned or validated on a host
+    without ``/dev/kvm`` (e.g. macOS or CI runners without nested virt).
+
+    Construction is cheap and never boots a VM. :meth:`preflight` reports
+    the missing host preconditions side-effect-free. :meth:`boot` runs it
+    and, on a supported host, still raises :class:`MicroVMUnavailableError`
+    because the boot lifecycle is unimplemented - it never pretends to have
+    booted, and it never degrades to a weaker isolation mode. The
+    determinism / content-addressing / receipt machinery this backend feeds
+    is validated host-independently over :class:`FakeMonitor`; the real
+    boot is covered by the opt-in KVM-gated integration test once the
+    follow-up lands.
+    """
+
+    #: Env var pointing at a guest kernel image (vmlinux).
+    KERNEL_ENV = "BERNSTEIN_MICROVM_KERNEL"
+    #: Env var pointing at a guest rootfs (ext4) image.
+    ROOTFS_ENV = "BERNSTEIN_MICROVM_ROOTFS"
+
+    def __init__(
+        self,
+        *,
+        root: str = "/workspace",
+        firecracker_bin: str = "firecracker",
+        kernel_image: str | None = None,
+        rootfs_image: str | None = None,
+    ) -> None:
+        self._logical_root = root
+        self._firecracker_bin = firecracker_bin
+        self._kernel_image = kernel_image or os.environ.get(self.KERNEL_ENV)
+        self._rootfs_image = rootfs_image or os.environ.get(self.ROOTFS_ENV)
+
+    @property
+    def workdir(self) -> str:
+        return self._logical_root
+
+    def preflight(self) -> list[str]:
+        """Return the list of missing host preconditions (empty == ready).
+
+        Checks are cheap and side-effect-free so the selector/backend can
+        probe support before committing to a boot.
+        """
+        missing: list[str] = []
+        if sys.platform != "linux":
+            missing.append(f"host OS is {sys.platform!r}, Firecracker requires Linux/KVM")
+        if not Path("/dev/kvm").exists():
+            missing.append("/dev/kvm not present (no hardware virtualization / KVM)")
+        elif not os.access("/dev/kvm", os.R_OK | os.W_OK):
+            missing.append("/dev/kvm is not readable+writable by this user")
+        if shutil.which(self._firecracker_bin) is None:
+            missing.append(f"{self._firecracker_bin!r} binary not found on PATH")
+        if not self._kernel_image or not Path(self._kernel_image).exists():
+            missing.append(f"guest kernel image missing (set ${self.KERNEL_ENV})")
+        if not self._rootfs_image or not Path(self._rootfs_image).exists():
+            missing.append(f"guest rootfs image missing (set ${self.ROOTFS_ENV})")
+        return missing
+
+    def _require_available(self) -> None:
+        missing = self.preflight()
+        if missing:
+            detail = "; ".join(missing)
+            msg = f"MicroVM (Firecracker) unavailable on this host: {detail}"
+            raise MicroVMUnavailableError(msg)
+
+    async def boot(self, *, base_env: Mapping[str, str]) -> None:
+        # Preflight first: on an unsupported host this is where an explicit
+        # microvm request fails loudly (never a silent worktree downgrade).
+        self._require_available()
+        # On a supported host we still refuse: the full Firecracker boot
+        # lifecycle (API socket -> boot-source -> drives -> network ->
+        # InstanceStart -> in-guest vsock agent) is not implemented in this
+        # release. We raise rather than pretend to have booted.
+        raise MicroVMUnavailableError(
+            "Firecracker guest boot is not yet implemented in this release "
+            "(experimental adapter). The deterministic snapshot / fork-race / "
+            "receipt machinery is complete; the VM boot + guest-agent transport "
+            "is a tracked follow-up requiring a KVM host. This build refuses "
+            "rather than silently degrading isolation.",
+        )
+
+    async def exec(self, *args: object, **kwargs: object) -> ExecResult:
+        self._require_available()
+        raise MicroVMUnavailableError("Firecracker guest exec path not provisioned on this host")
+
+    async def read_file(self, path: str) -> bytes:
+        self._require_available()
+        raise MicroVMUnavailableError("Firecracker guest I/O not provisioned on this host")
+
+    async def write_file(self, path: str, data: bytes, *, mode: int = 0o644) -> None:
+        self._require_available()
+        raise MicroVMUnavailableError("Firecracker guest I/O not provisioned on this host")
+
+    async def ls(self, path: str) -> list[str]:
+        self._require_available()
+        raise MicroVMUnavailableError("Firecracker guest I/O not provisioned on this host")
+
+    async def freeze_image(self) -> bytes:
+        self._require_available()
+        raise MicroVMUnavailableError("Firecracker guest snapshot not provisioned on this host")
+
+    async def restore_image(self, image: bytes) -> None:
+        self._require_available()
+        raise MicroVMUnavailableError("Firecracker guest restore not provisioned on this host")
+
+    async def shutdown(self) -> None:
+        # Idempotent: nothing to tear down until the boot lifecycle lands.
+        return
+
+
+__all__ = [
+    "SNAPSHOT_CONTENT_TYPE",
+    "FakeMonitor",
+    "FirecrackerMonitor",
+    "MicroVMUnavailableError",
+    "VMMonitor",
+    "canonical_workspace_image",
+    "extract_workspace_image",
+]

--- a/src/bernstein/core/sandbox/backends/_vmmonitor.py
+++ b/src/bernstein/core/sandbox/backends/_vmmonitor.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import io
+import operator
 import os
 import shutil
 import sys
@@ -133,7 +134,7 @@ def canonical_workspace_image(root: Path) -> bytes:
             full = base / name
             arc = full.relative_to(root).as_posix()
             entries.append((arc, full))
-    entries.sort(key=lambda pair: pair[0])
+    entries.sort(key=operator.itemgetter(0))
 
     buf = io.BytesIO()
     # Fixed format + no compression: gzip would embed an mtime and OS byte.
@@ -322,7 +323,7 @@ class FakeMonitor:
     def _resolve(self, path: str) -> Path:
         """Map a guest path to a host path pinned under the temp dir."""
         rel = path
-        if os.path.isabs(path):
+        if Path(path).is_absolute():
             # Treat the logical root as the guest FS root for absolute paths.
             rel = os.path.relpath(path, self._logical_root)
         target = (self._host_dir / rel).resolve()
@@ -346,7 +347,7 @@ class FakeMonitor:
         timeout: int | None = None,
         stdin: bytes | None = None,
     ) -> ExecResult:
-        run_env = dict(os.environ)
+        run_env = os.environ.copy()
         run_env.update(self._base_env)
         if env:
             run_env.update(env)
@@ -375,8 +376,8 @@ class FakeMonitor:
         duration = loop.time() - start
         return ExecResult(
             exit_code=proc.returncode if proc.returncode is not None else -1,
-            stdout=stdout or b"",
-            stderr=stderr or b"",
+            stdout=stdout,
+            stderr=stderr,
             duration_seconds=duration,
         )
 

--- a/src/bernstein/core/sandbox/backends/_vmmonitor.py
+++ b/src/bernstein/core/sandbox/backends/_vmmonitor.py
@@ -71,6 +71,26 @@ class MicroVMUnavailableError(RuntimeError):
 SNAPSHOT_CONTENT_TYPE = "application/x-bernstein-vm-snapshot+tar"
 
 
+def _tarfile_data_filter_is_patched() -> bool:
+    """Whether this interpreter's tarfile ``data`` filter includes the June-2025 fix.
+
+    The stdlib ``data`` filter (:func:`extract_workspace_image`'s only defence
+    against a hostile image) had a family of extraction-escape bypasses
+    (CVE-2024-12718 / CVE-2025-4138 / CVE-2025-4330 / CVE-2025-4435 /
+    CVE-2025-4517) fixed in CPython 3.12.11, 3.13.4, and every 3.14+ release.
+    On an unpatched build the filter can be circumvented, so relying on it there
+    is a false sense of safety. The project floor is ``>=3.12``, which still
+    admits vulnerable 3.12.0-3.12.10 / 3.13.0-3.13.3 builds - hence this
+    runtime check rather than a project-wide ``requires-python`` bump.
+    """
+    v = sys.version_info
+    if v[:2] == (3, 12):
+        return v >= (3, 12, 11)
+    if v[:2] == (3, 13):
+        return v >= (3, 13, 4)
+    return v >= (3, 14)
+
+
 def canonical_workspace_image(root: Path) -> bytes:
     """Freeze the directory tree at *root* into deterministic tar bytes.
 
@@ -166,6 +186,19 @@ def extract_workspace_image(image: bytes, root: Path) -> None:
                 child.unlink()
     else:
         root.mkdir(parents=True, exist_ok=True)
+
+    # The stdlib ``data`` filter is the *only* thing standing between this
+    # untrusted, guest-derived image and an extraction escape. On a CPython
+    # build predating the CVE-2025-4517-family fix that filter can be bypassed,
+    # so refuse rather than extract behind a defence that does not hold.
+    if not _tarfile_data_filter_is_patched():
+        version = ".".join(str(part) for part in sys.version_info[:3])
+        msg = (
+            f"Refusing to extract an untrusted snapshot image on CPython {version}: "
+            "its tarfile 'data' filter predates the CVE-2025-4517-family fix "
+            "(upgrade to >=3.12.11 / >=3.13.4)."
+        )
+        raise MicroVMUnavailableError(msg)
 
     # The stdlib ``data`` filter (PEP 706, py3.12+) does the right
     # member-by-member checks *at extraction time*: it refuses absolute paths,

--- a/src/bernstein/core/sandbox/backends/_vmmonitor.py
+++ b/src/bernstein/core/sandbox/backends/_vmmonitor.py
@@ -468,7 +468,15 @@ class FirecrackerMonitor:
             "rather than silently degrading isolation.",
         )
 
-    async def exec(self, *args: object, **kwargs: object) -> ExecResult:
+    async def exec(
+        self,
+        cmd: list[str],
+        *,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout: int | None = None,
+        stdin: bytes | None = None,
+    ) -> ExecResult:
         self._require_available()
         raise MicroVMUnavailableError("Firecracker guest exec path not provisioned on this host")
 

--- a/src/bernstein/core/sandbox/backends/_vmmonitor.py
+++ b/src/bernstein/core/sandbox/backends/_vmmonitor.py
@@ -77,7 +77,8 @@ def _tarfile_data_filter_is_patched() -> bool:
     The stdlib ``data`` filter (:func:`extract_workspace_image`'s only defence
     against a hostile image) had a family of extraction-escape bypasses
     (CVE-2024-12718 / CVE-2025-4138 / CVE-2025-4330 / CVE-2025-4435 /
-    CVE-2025-4517) fixed in CPython 3.12.11, 3.13.4, and every 3.14+ release.
+    CVE-2025-4517) fixed in CPython 3.12.11, 3.13.4, and 3.14.0b3 (the 3.14
+    fix did not land until beta 3, so 3.14.0a* / b1 / b2 are still vulnerable).
     On an unpatched build the filter can be circumvented, so relying on it there
     is a false sense of safety. The project floor is ``>=3.12``, which still
     admits vulnerable 3.12.0-3.12.10 / 3.13.0-3.13.3 builds - hence this
@@ -88,7 +89,11 @@ def _tarfile_data_filter_is_patched() -> bool:
         return v >= (3, 12, 11)
     if v[:2] == (3, 13):
         return v >= (3, 13, 4)
-    return v >= (3, 14)
+    if v[:2] == (3, 14):
+        # version_info compares releaselevel lexically (alpha < beta <
+        # candidate < final), so this admits 3.14.0b3+ and every final/rc.
+        return v >= (3, 14, 0, "beta", 3)
+    return v[:2] > (3, 14)
 
 
 def canonical_workspace_image(root: Path) -> bytes:
@@ -178,19 +183,13 @@ def extract_workspace_image(image: bytes, root: Path) -> None:
             ``..`` traversal, or a sym/hardlink escaping *root*).
     """
     root = root.resolve()
-    if root.exists():
-        for child in root.iterdir():
-            if child.is_dir() and not child.is_symlink():
-                shutil.rmtree(child)
-            else:
-                child.unlink()
-    else:
-        root.mkdir(parents=True, exist_ok=True)
 
-    # The stdlib ``data`` filter is the *only* thing standing between this
-    # untrusted, guest-derived image and an extraction escape. On a CPython
-    # build predating the CVE-2025-4517-family fix that filter can be bypassed,
-    # so refuse rather than extract behind a defence that does not hold.
+    # Refuse BEFORE any filesystem mutation. The stdlib ``data`` filter is the
+    # *only* thing standing between this untrusted, guest-derived image and an
+    # extraction escape, and on a CPython build predating the CVE-2025-4517-
+    # family fix it can be bypassed - so refuse rather than extract behind a
+    # defence that does not hold. Checking here (not after clearing *root*)
+    # means a doomed extraction never destroys an already-populated workspace.
     if not _tarfile_data_filter_is_patched():
         version = ".".join(str(part) for part in sys.version_info[:3])
         msg = (
@@ -199,6 +198,15 @@ def extract_workspace_image(image: bytes, root: Path) -> None:
             "(upgrade to >=3.12.11 / >=3.13.4)."
         )
         raise MicroVMUnavailableError(msg)
+
+    if root.exists():
+        for child in root.iterdir():
+            if child.is_dir() and not child.is_symlink():
+                shutil.rmtree(child)
+            else:
+                child.unlink()
+    else:
+        root.mkdir(parents=True, exist_ok=True)
 
     # The stdlib ``data`` filter (PEP 706, py3.12+) does the right
     # member-by-member checks *at extraction time*: it refuses absolute paths,

--- a/src/bernstein/core/sandbox/backends/microvm.py
+++ b/src/bernstein/core/sandbox/backends/microvm.py
@@ -46,7 +46,7 @@ error on an unsupported host instead of a surprise worktree.
 
 from __future__ import annotations
 
-import contextlib
+import logging
 import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -67,6 +67,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
 
     from bernstein.core.sandbox.manifest import WorkspaceManifest
+
+_logger = logging.getLogger(__name__)
 
 #: Default location of the content-addressed store for VM snapshots.
 _DEFAULT_CAS_DIR = Path(".sdd/cas")
@@ -249,8 +251,17 @@ class MicroVMSandboxBackend:
             for entry in manifest.files:
                 await monitor.write_file(entry.path, entry.content, mode=entry.mode)
         except BaseException:
-            with contextlib.suppress(Exception):
+            # Tear the guest down, but never let a cleanup error mask the
+            # original provisioning failure - log it so a genuine leaked guest
+            # (process/socket/tap device) leaves a trace instead of vanishing.
+            try:
                 await monitor.shutdown()
+            except Exception:
+                _logger.warning(
+                    "microVM shutdown failed during create() cleanup; a guest resource may have leaked (session %s)",
+                    session_id,
+                    exc_info=True,
+                )
             raise
 
         session = MicroVMSandboxSession(
@@ -287,8 +298,14 @@ class MicroVMSandboxBackend:
             await monitor.boot(base_env={})
             await monitor.restore_image(image)
         except BaseException:
-            with contextlib.suppress(Exception):
+            try:
                 await monitor.shutdown()
+            except Exception:
+                _logger.warning(
+                    "microVM shutdown failed during resume() cleanup; a guest resource may have leaked (snapshot %s)",
+                    snapshot_id,
+                    exc_info=True,
+                )
             raise
 
         session_id = f"microvm-resume-{snapshot_id[:12]}-{uuid.uuid4().hex[:8]}"

--- a/src/bernstein/core/sandbox/backends/microvm.py
+++ b/src/bernstein/core/sandbox/backends/microvm.py
@@ -227,13 +227,16 @@ class MicroVMSandboxBackend:
         opts = options or {}
         session_id = str(opts.get("session_id") or f"microvm-{uuid.uuid4().hex}")
         monitor = self._monitor_factory(manifest.root)
-        await monitor.boot(base_env=manifest.env)
 
-        # Any post-boot provisioning failure must tear the guest down - a
-        # half-provisioned monitor left running is a resource leak, and a
-        # silently-ignored non-zero git exit would hand back a session over an
-        # invalid repository. BaseException so a cancellation also cleans up.
+        # boot() is inside the guard: a real monitor can allocate a process,
+        # socket, or tap device and then raise partway through boot, and that
+        # partially-started guest must still be torn down. Any post-boot
+        # provisioning failure likewise tears the guest down - a half-
+        # provisioned monitor is a resource leak, and a silently-ignored
+        # non-zero git exit would hand back a session over an invalid
+        # repository. BaseException so a cancellation also cleans up.
         try:
+            await monitor.boot(base_env=manifest.env)
             if manifest.repo is not None:
                 repo = manifest.repo
                 clone = await monitor.exec(
@@ -277,10 +280,11 @@ class MicroVMSandboxBackend:
             raise KeyError(msg)
 
         monitor = self._monitor_factory("/workspace")
-        await monitor.boot(base_env={})
-        # A restore that raises (e.g. an unsafe member in the image) must not
-        # leave the just-booted guest running.
+        # boot() and restore are both inside the guard: a boot that partially
+        # allocates then raises, or a restore that raises (e.g. an unsafe member
+        # in the image), must not leave the guest running.
         try:
+            await monitor.boot(base_env={})
             await monitor.restore_image(image)
         except BaseException:
             with contextlib.suppress(Exception):

--- a/src/bernstein/core/sandbox/backends/microvm.py
+++ b/src/bernstein/core/sandbox/backends/microvm.py
@@ -1,0 +1,268 @@
+"""MicroVM sandbox backend with content-addressed snapshots (#2613).
+
+The ``microvm`` backend is the first sandbox backend that isolates the
+*kernel, network namespace, and process tree* at a hardware boundary,
+not just the filesystem. It implements the existing
+:class:`~bernstein.core.sandbox.backend.SandboxBackend` protocol against a
+swappable :class:`~bernstein.core.sandbox.backends._vmmonitor.VMMonitor`
+(Firecracker in production; a deterministic
+:class:`~bernstein.core.sandbox.backends._vmmonitor.FakeMonitor` under
+test), so every existing adapter works unchanged.
+
+Its distinguishing feature is the snapshot contract. Where other backends
+return a backend-private opaque handle (or raise ``NotImplementedError``),
+:meth:`MicroVMSandboxSession.snapshot` freezes the workspace into a
+*canonicalised image*, streams it into the content-addressed store
+(``.sdd/cas``), and returns the image's **SHA-256 digest** as the snapshot
+id. Two consequences fall out for free:
+
+- ``resume(digest)`` reads the blob back by digest and verifies it before
+  boot, so a tampered snapshot fails its CAS integrity check
+  (:class:`~bernstein.core.persistence.cas_store.CASIntegrityError`)
+  rather than booting corrupt state; and
+- because the id *is* the content hash, two operators with the same base
+  image resume byte-identical workspaces - the property the deterministic
+  fork-and-race primitive (:mod:`bernstein.core.sandbox.fork_race`) builds
+  its reproducible, attributable races on.
+
+Host support (KVM, kernel/rootfs, ``firecracker`` binary) is enforced at
+:meth:`create` time by the monitor's preflight. When it is absent the
+backend raises
+:class:`~bernstein.core.sandbox.backends._vmmonitor.MicroVMUnavailableError`
+- it never silently degrades to a weaker isolation mode. The selector
+therefore honours an explicit ``sandbox.backend: microvm`` with a loud
+error on an unsupported host instead of a surprise worktree.
+
+.. note::
+   **The Firecracker VM boot path is experimental and not yet implemented.**
+   This release ships the deterministic, fully-tested core - content-addressed
+   snapshots, the fork-and-race primitive, and the signed selection receipt -
+   plus the host preflight and no-silent-downgrade contract. The real guest
+   boot + vsock-agent transport (which needs a KVM host and operator-supplied
+   kernel/rootfs/agent, unbuildable on a host without ``/dev/kvm``) is a
+   tracked follow-up. The snapshot/receipt machinery is validated
+   host-independently over the ``FakeMonitor``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.persistence.cas_store import CASStore
+from bernstein.core.sandbox.backend import (
+    ExecResult,
+    SandboxCapability,
+    SandboxSession,
+)
+from bernstein.core.sandbox.backends._vmmonitor import (
+    SNAPSHOT_CONTENT_TYPE,
+    FirecrackerMonitor,
+    VMMonitor,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
+    from bernstein.core.sandbox.manifest import WorkspaceManifest
+
+#: Default location of the content-addressed store for VM snapshots.
+_DEFAULT_CAS_DIR = Path(".sdd/cas")
+
+
+def _default_monitor_factory(root: str) -> VMMonitor:
+    """Production factory: a real Firecracker monitor (preflighted on boot)."""
+    return FirecrackerMonitor(root=root)
+
+
+class MicroVMSandboxSession(SandboxSession):
+    """An active microVM session backed by a :class:`VMMonitor`.
+
+    File and exec I/O delegate straight to the monitor. :meth:`snapshot`
+    is the interesting one: it content-addresses the workspace image into
+    CAS and returns the digest.
+    """
+
+    backend_name = "microvm"
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        monitor: VMMonitor,
+        cas: CASStore,
+    ) -> None:
+        self.session_id = session_id
+        self.workdir = monitor.workdir
+        self._monitor = monitor
+        self._cas = cas
+        self._closed = False
+
+    async def read(self, path: str) -> bytes:
+        return await self._monitor.read_file(path)
+
+    async def write(self, path: str, data: bytes, *, mode: int = 0o644) -> None:
+        await self._monitor.write_file(path, data, mode=mode)
+
+    async def exec(
+        self,
+        cmd: list[str],
+        *,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout: int | None = None,
+        stdin: bytes | None = None,
+    ) -> ExecResult:
+        return await self._monitor.exec(
+            cmd,
+            cwd=cwd,
+            env=env,
+            timeout=timeout,
+            stdin=stdin,
+        )
+
+    async def ls(self, path: str) -> list[str]:
+        return await self._monitor.ls(path)
+
+    async def snapshot(self) -> str:
+        """Freeze the workspace to a content-addressed image; return its digest.
+
+        The digest returned *is* ``sha256`` of the canonical image bytes,
+        so it is a stable content address that :meth:`MicroVMSandboxBackend.resume`
+        can boot from and that the fork-race receipt can pin.
+        """
+        image = await self._monitor.freeze_image()
+        return self._cas.put(
+            image,
+            content_type=SNAPSHOT_CONTENT_TYPE,
+            metadata={"backend": self.backend_name, "session_id": self.session_id},
+        )
+
+    async def shutdown(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        await self._monitor.shutdown()
+
+
+class MicroVMSandboxBackend:
+    """Provisions :class:`MicroVMSandboxSession` instances.
+
+    Args:
+        monitor_factory: Builds one :class:`VMMonitor` per session given
+            the logical workspace root. Defaults to a real
+            :class:`FirecrackerMonitor`; tests inject a
+            :class:`FakeMonitor` factory.
+        cas: Content-addressed store for snapshots. Defaults to a store
+            rooted at ``.sdd/cas``; tests inject a temp-dir store.
+        cas_dir: Convenience alternative to *cas* - the directory to root
+            a fresh :class:`CASStore` at. Ignored when *cas* is given.
+    """
+
+    name = "microvm"
+    capabilities = frozenset(
+        {
+            SandboxCapability.FILE_RW,
+            SandboxCapability.EXEC,
+            SandboxCapability.NETWORK,
+            SandboxCapability.SNAPSHOT,
+        },
+    )
+
+    def __init__(
+        self,
+        *,
+        monitor_factory: Callable[[str], VMMonitor] | None = None,
+        cas: CASStore | None = None,
+        cas_dir: Path | None = None,
+    ) -> None:
+        self._monitor_factory = monitor_factory or _default_monitor_factory
+        self._cas = cas or CASStore(cas_dir or _DEFAULT_CAS_DIR)
+        self._sessions: dict[str, MicroVMSandboxSession] = {}
+
+    @property
+    def cas(self) -> CASStore:
+        """The content-addressed store backing this backend's snapshots."""
+        return self._cas
+
+    async def create(
+        self,
+        manifest: WorkspaceManifest,
+        options: dict[str, Any] | None = None,
+    ) -> MicroVMSandboxSession:
+        """Provision a fresh microVM session from *manifest*.
+
+        Host-side path construction comes only from *manifest* (a
+        host-controlled value object), never from bytes read out of a
+        guest - a restored guest cannot redirect where the backend writes.
+
+        Raises:
+            MicroVMUnavailableError: When the host cannot run a microVM
+                (no KVM, missing binary/kernel/rootfs). The backend refuses
+                rather than degrading to weaker isolation.
+        """
+        opts = options or {}
+        session_id = str(opts.get("session_id") or f"microvm-{uuid.uuid4().hex}")
+        monitor = self._monitor_factory(manifest.root)
+        await monitor.boot(base_env=manifest.env)
+
+        if manifest.repo is not None:
+            repo = manifest.repo
+            await monitor.exec(
+                ["git", "clone", "--no-hardlinks", "--quiet", repo.src_path, "."],
+            )
+            await monitor.exec(["git", "checkout", "--quiet", repo.branch])
+
+        for entry in manifest.files:
+            await monitor.write_file(entry.path, entry.content, mode=entry.mode)
+
+        session = MicroVMSandboxSession(
+            session_id=session_id,
+            monitor=monitor,
+            cas=self._cas,
+        )
+        self._sessions[session_id] = session
+        return session
+
+    async def resume(self, snapshot_id: str) -> MicroVMSandboxSession:
+        """Boot a fresh session from a content-addressed snapshot.
+
+        The blob is read with integrity verification on, so a tampered
+        snapshot raises
+        :class:`~bernstein.core.persistence.cas_store.CASIntegrityError`
+        before any guest state is booted.
+
+        Raises:
+            KeyError: When *snapshot_id* is not present in CAS.
+            CASIntegrityError: When the stored bytes do not hash to
+                *snapshot_id* (tampering / corruption).
+        """
+        image = self._cas.get(snapshot_id, verify=True)
+        if image is None:
+            msg = f"Unknown microvm snapshot digest: {snapshot_id}"
+            raise KeyError(msg)
+
+        monitor = self._monitor_factory("/workspace")
+        await monitor.boot(base_env={})
+        await monitor.restore_image(image)
+
+        session_id = f"microvm-resume-{snapshot_id[:12]}-{uuid.uuid4().hex[:8]}"
+        session = MicroVMSandboxSession(
+            session_id=session_id,
+            monitor=monitor,
+            cas=self._cas,
+        )
+        self._sessions[session_id] = session
+        return session
+
+    async def destroy(self, session: SandboxSession) -> None:
+        """Tear down *session* and drop it from the tracking table."""
+        await session.shutdown()
+        self._sessions.pop(session.session_id, None)
+
+
+__all__ = [
+    "MicroVMSandboxBackend",
+    "MicroVMSandboxSession",
+]

--- a/src/bernstein/core/sandbox/backends/microvm.py
+++ b/src/bernstein/core/sandbox/backends/microvm.py
@@ -46,6 +46,7 @@ error on an unsupported host instead of a surprise worktree.
 
 from __future__ import annotations
 
+import contextlib
 import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -71,9 +72,30 @@ if TYPE_CHECKING:
 _DEFAULT_CAS_DIR = Path(".sdd/cas")
 
 
+class MicroVMProvisioningError(RuntimeError):
+    """Raised when a booted guest cannot be provisioned into a usable state.
+
+    Distinct from
+    :class:`~bernstein.core.sandbox.backends._vmmonitor.MicroVMUnavailableError`
+    (the *host* cannot run a microVM at all): here the guest booted but a
+    provisioning step - a ``git clone``/``checkout`` returning non-zero, a
+    file write failing - left the workspace invalid. The guest is always torn
+    down before this propagates, so a failed :meth:`MicroVMSandboxBackend.create`
+    never leaks a running monitor.
+    """
+
+
 def _default_monitor_factory(root: str) -> VMMonitor:
     """Production factory: a real Firecracker monitor (preflighted on boot)."""
     return FirecrackerMonitor(root=root)
+
+
+def _require_ok(result: ExecResult, what: str, session_id: str) -> None:
+    """Raise :class:`MicroVMProvisioningError` when a provisioning step failed."""
+    if result.exit_code != 0:
+        stderr = result.stderr.decode("utf-8", "replace").strip()
+        msg = f"{what} failed (exit {result.exit_code}) provisioning microVM session {session_id!r}: {stderr}"
+        raise MicroVMProvisioningError(msg)
 
 
 class MicroVMSandboxSession(SandboxSession):
@@ -207,15 +229,26 @@ class MicroVMSandboxBackend:
         monitor = self._monitor_factory(manifest.root)
         await monitor.boot(base_env=manifest.env)
 
-        if manifest.repo is not None:
-            repo = manifest.repo
-            await monitor.exec(
-                ["git", "clone", "--no-hardlinks", "--quiet", repo.src_path, "."],
-            )
-            await monitor.exec(["git", "checkout", "--quiet", repo.branch])
+        # Any post-boot provisioning failure must tear the guest down - a
+        # half-provisioned monitor left running is a resource leak, and a
+        # silently-ignored non-zero git exit would hand back a session over an
+        # invalid repository. BaseException so a cancellation also cleans up.
+        try:
+            if manifest.repo is not None:
+                repo = manifest.repo
+                clone = await monitor.exec(
+                    ["git", "clone", "--no-hardlinks", "--quiet", repo.src_path, "."],
+                )
+                _require_ok(clone, f"git clone {repo.src_path!r}", session_id)
+                checkout = await monitor.exec(["git", "checkout", "--quiet", repo.branch])
+                _require_ok(checkout, f"git checkout {repo.branch!r}", session_id)
 
-        for entry in manifest.files:
-            await monitor.write_file(entry.path, entry.content, mode=entry.mode)
+            for entry in manifest.files:
+                await monitor.write_file(entry.path, entry.content, mode=entry.mode)
+        except BaseException:
+            with contextlib.suppress(Exception):
+                await monitor.shutdown()
+            raise
 
         session = MicroVMSandboxSession(
             session_id=session_id,
@@ -245,7 +278,14 @@ class MicroVMSandboxBackend:
 
         monitor = self._monitor_factory("/workspace")
         await monitor.boot(base_env={})
-        await monitor.restore_image(image)
+        # A restore that raises (e.g. an unsafe member in the image) must not
+        # leave the just-booted guest running.
+        try:
+            await monitor.restore_image(image)
+        except BaseException:
+            with contextlib.suppress(Exception):
+                await monitor.shutdown()
+            raise
 
         session_id = f"microvm-resume-{snapshot_id[:12]}-{uuid.uuid4().hex[:8]}"
         session = MicroVMSandboxSession(
@@ -263,6 +303,7 @@ class MicroVMSandboxBackend:
 
 
 __all__ = [
+    "MicroVMProvisioningError",
     "MicroVMSandboxBackend",
     "MicroVMSandboxSession",
 ]

--- a/src/bernstein/core/sandbox/fork_race.py
+++ b/src/bernstein/core/sandbox/fork_race.py
@@ -57,7 +57,7 @@ from bernstein.core.sandbox.selection_receipt import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable, Iterator
+    from collections.abc import Awaitable, Callable, Iterable, Iterator
     from pathlib import Path
 
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
@@ -156,6 +156,26 @@ def _profile_to_dict(profile: CriterionProfile) -> dict[str, Any]:
     }
 
 
+def _require_unique_task_ids(task_ids: Iterable[str]) -> None:
+    """Reject empty or duplicate candidate task ids.
+
+    ``task_id`` keys both the terminal-digest map and the receipt's candidate
+    map, so a collision would silently drop a candidate's terminal snapshot from
+    the signed receipt (and from ``snapshot_digests`` verification) - the race
+    the receipt attests could then no longer be reconstructed or attributed.
+    """
+    seen: set[str] = set()
+    dupes: set[str] = set()
+    for tid in task_ids:
+        if not tid:
+            raise ValueError("fork_race candidate task_ids must be non-empty")
+        if tid in seen:
+            dupes.add(tid)
+        seen.add(tid)
+    if dupes:
+        raise ValueError(f"fork_race candidate task_ids must be unique; duplicates: {sorted(dupes)}")
+
+
 async def fork_race(
     *,
     backend: ForkRaceBackend,
@@ -238,6 +258,11 @@ async def fork_race(
     # float sums) is identical across runs - not merely before serialising.
     ordered = sorted(outcomes, key=lambda pair: pair[0].task_id)
     results = [result for result, _ in ordered]
+
+    # Task ids must be unique and non-empty: terminal_by_id (and the receipt's
+    # candidate map) key on task_id, so a duplicate would silently collapse a
+    # candidate's terminal snapshot out of the signed attestation.
+    _require_unique_task_ids(result.task_id for result in results)
     terminal_by_id = {result.task_id: digest for result, digest in ordered}
 
     winner = select_winner(results, profile=ranking_profile)

--- a/src/bernstein/core/sandbox/fork_race.py
+++ b/src/bernstein/core/sandbox/fork_race.py
@@ -200,8 +200,19 @@ async def fork_race(
         return result, terminal_digest
 
     # Race the candidates concurrently; the barrier here is intentional -
-    # ranking and the single audit append need the full result set.
-    outcomes = await asyncio.gather(*[_one(i) for i in range(k)])
+    # ranking and the single audit append need the full result set. If any
+    # candidate raises, gather surfaces the first error but leaves its siblings
+    # running in the (persistent) event loop - explicitly cancel and drain them
+    # so no in-flight candidate outlives the race and every _one finally-block
+    # (which destroys its session) still runs.
+    tasks = [asyncio.ensure_future(_one(i)) for i in range(k)]
+    try:
+        outcomes = await asyncio.gather(*tasks)
+    except BaseException:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise
 
     # D2: fix candidate order BEFORE ranking so the TOPSIS matrix (and its
     # float sums) is identical across runs - not merely before serialising.

--- a/src/bernstein/core/sandbox/fork_race.py
+++ b/src/bernstein/core/sandbox/fork_race.py
@@ -1,0 +1,262 @@
+"""Deterministic fork-and-race over one content-addressed base snapshot (#2613).
+
+``best_of_n`` today spawns K candidate workers from *scratch* in separate
+worktrees, so the K attempts never actually start from one identical
+captured state - rerun the race and the base differs, so the winner is not
+attributable to the candidate's work alone. :func:`fork_race` closes that
+gap. It resumes K candidate sessions from the *same* content-addressed
+base snapshot digest, runs each to a terminal snapshot, and selects the
+winner with the existing deterministic ranker
+(:func:`bernstein.core.orchestration.best_of_n.select_winner` backed by
+TOPSIS) - **no LLM in the selection path**. The output is a signed
+:class:`~bernstein.core.sandbox.selection_receipt.SelectionReceipt` that
+reconstructs the whole race offline.
+
+Two determinism disciplines are load-bearing and easy to get wrong:
+
+- **Rank on a wall-clock-free profile.** :data:`DETERMINISTIC_PROFILE`
+  ranks on ``correctness``/``cost``/``reversibility`` only. It deliberately
+  omits the ``latency`` axis, which
+  :func:`best_of_n._to_rank_candidate` would populate from ``runtime_s`` -
+  a host wall-clock measurement that differs every run and could flip the
+  winner on scheduler jitter, breaking the byte-identical-receipt gate.
+- **Fix candidate order before ranking, not just before serialising.**
+  TOPSIS sums over the candidate matrix, and float addition is not
+  associative, so two runs whose candidate submission order differs can
+  produce last-bit-different scores. Candidates are sorted by ``task_id``
+  *before* they reach ``select_winner``, so the ranking input is identical
+  across runs.
+
+The audit append is a single serialised call after all K candidates and
+the ranker have finished (``AuditLog`` has no internal lock; a per-candidate
+fan-out would race ``prev_hmac`` and corrupt the chain). Publication is
+crash-safe: CAS blobs are already stored by ``snapshot()``, then the
+receipt is signed, then the audit entry lands, then the receipt file is
+exposed via tmp+rename - so a crash never leaves a validly-signed but
+unanchored receipt visible.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+from typing import TYPE_CHECKING, Any, Protocol
+
+from bernstein.core.orchestration.best_of_n import CandidateResult, select_winner
+from bernstein.core.orchestration.multi_criteria_rank import (
+    CriterionProfile,
+    build_criterion_profile,
+)
+from bernstein.core.sandbox.selection_receipt import (
+    RaceCandidate,
+    SelectionReceipt,
+    build_selection_receipt,
+    sign_receipt,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable, Iterator
+    from pathlib import Path
+
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    from bernstein.core.sandbox.backend import SandboxSession
+    from bernstein.core.security.audit import AuditLog
+
+#: The deterministic ranking profile fork-race pins. No wall-clock axis:
+#: ``latency`` (which maps from ``runtime_s``) is deliberately excluded so
+#: the winner is a pure function of the candidates' deliverables.
+DETERMINISTIC_PROFILE: CriterionProfile = build_criterion_profile(
+    ["correctness", "cost", "reversibility"],
+)
+
+#: Audit event-type for a completed fork-race selection.
+FORK_RACE_EVENT_TYPE = "sandbox.fork_race"
+
+
+@contextlib.contextmanager
+def _cross_process_audit_lock(lock_path: Path | None) -> Iterator[None]:
+    """Serialise the single audit append across concurrent fork-race *processes*.
+
+    Within one event loop the append is a synchronous ``AuditLog.log`` call
+    that cannot interleave with another coroutine, so the in-process case is
+    already safe. This guards the remaining window: two *separate processes*
+    running a fork-race against the same audit directory, where ``AuditLog``
+    has no lock of its own and both could read the same ``prev_hmac`` and fork
+    the chain. A no-op when *lock_path* is ``None`` or on a platform without
+    ``fcntl`` (e.g. Windows).
+    """
+    if lock_path is None:
+        yield
+        return
+    try:
+        import fcntl
+    except ImportError:
+        yield
+        return
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        with contextlib.suppress(OSError):
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
+class ForkRaceBackend(Protocol):
+    """The slice of a sandbox backend :func:`fork_race` needs.
+
+    Any SNAPSHOT-capable backend whose ``snapshot()`` returns a CAS digest
+    satisfies this; in practice that is
+    :class:`~bernstein.core.sandbox.backends.microvm.MicroVMSandboxBackend`.
+    """
+
+    name: str
+
+    async def resume(self, snapshot_id: str) -> SandboxSession: ...
+
+    async def destroy(self, session: SandboxSession) -> None: ...
+
+
+def _score_vector(result: CandidateResult) -> dict[str, float]:
+    """Project a candidate onto the deterministic axes recorded in the receipt.
+
+    Mirrors :func:`best_of_n._to_rank_candidate` for the wall-clock-free
+    axes only, so the vector stored in the receipt matches what the ranker
+    actually consumed.
+    """
+    correctness = 1.0 if result.tests_passing else 0.0
+    judge = result.judge_score if result.judge_score is not None else correctness
+    correctness = max(0.0, min(1.0, 0.5 * correctness + 0.5 * judge))
+    return {
+        "correctness": correctness,
+        "cost": max(0.0, 1.0 - max(0.0, min(1.0, result.lint_score))),
+        "reversibility": 1.0,
+    }
+
+
+def _profile_to_dict(profile: CriterionProfile) -> dict[str, Any]:
+    return {
+        "method": "topsis",
+        "criteria": [{"name": c.name, "direction": c.direction, "weight": c.weight} for c in profile.criteria],
+    }
+
+
+async def fork_race(
+    *,
+    backend: ForkRaceBackend,
+    base_snapshot_digest: str,
+    run_candidate: Callable[[SandboxSession, int], Awaitable[CandidateResult]],
+    k: int,
+    signing_key: Ed25519PrivateKey,
+    profile: CriterionProfile | None = None,
+    audit_log: AuditLog | None = None,
+    audit_lock_path: Path | None = None,
+    actor: str = "fork_race",
+) -> SelectionReceipt:
+    """Fork K candidates from one base snapshot and return a signed receipt.
+
+    Args:
+        backend: A SNAPSHOT-capable backend whose ``snapshot()`` returns a
+            CAS digest (the microVM backend).
+        base_snapshot_digest: The single content-addressed base every
+            candidate forks from - the anchor that makes the race
+            attributable.
+        run_candidate: Async callback that mutates a resumed session and
+            returns its :class:`CandidateResult` (task_id + deterministic
+            scores). It must not snapshot; fork_race captures the terminal
+            snapshot after it returns.
+        k: Number of candidates (>= 1).
+        signing_key: Ed25519 private key that signs the receipt.
+        profile: Ranking profile. Defaults to :data:`DETERMINISTIC_PROFILE`.
+        audit_log: When provided, the receipt is appended to the HMAC audit
+            chain in exactly one serialised call after ranking.
+        audit_lock_path: Optional lock file guarding the audit append against
+            concurrent fork-race *processes* sharing the audit directory (the
+            in-process append is already atomic). No-op when ``None``.
+        actor: Actor recorded on the audit entry.
+
+    Returns:
+        The signed :class:`SelectionReceipt`.
+
+    Raises:
+        ValueError: When *k* < 1.
+    """
+    if k < 1:
+        raise ValueError(f"fork_race requires k >= 1, got {k}")
+    ranking_profile = profile or DETERMINISTIC_PROFILE
+    pub = signing_key.public_key()
+
+    async def _one(index: int) -> tuple[CandidateResult, str]:
+        session = await backend.resume(base_snapshot_digest)
+        try:
+            result = await run_candidate(session, index)
+            terminal_digest = await session.snapshot()
+        finally:
+            await backend.destroy(session)
+        return result, terminal_digest
+
+    # Race the candidates concurrently; the barrier here is intentional -
+    # ranking and the single audit append need the full result set.
+    outcomes = await asyncio.gather(*[_one(i) for i in range(k)])
+
+    # D2: fix candidate order BEFORE ranking so the TOPSIS matrix (and its
+    # float sums) is identical across runs - not merely before serialising.
+    ordered = sorted(outcomes, key=lambda pair: pair[0].task_id)
+    results = [result for result, _ in ordered]
+    terminal_by_id = {result.task_id: digest for result, digest in ordered}
+
+    winner = select_winner(results, profile=ranking_profile)
+
+    race_candidates = [
+        RaceCandidate(
+            task_id=result.task_id,
+            terminal_snapshot_digest=terminal_by_id[result.task_id],
+            score_vector=_score_vector(result),
+            isolation=backend.name,
+        )
+        for result in results
+    ]
+
+    receipt = build_selection_receipt(
+        base_snapshot_digest=base_snapshot_digest,
+        candidates=race_candidates,
+        winner_task_id=winner.task_id,
+        ranker_profile=_profile_to_dict(ranking_profile),
+        public_key=pub,
+    )
+    signed = sign_receipt(receipt, private_key=signing_key)
+
+    # Single serialised audit append AFTER all candidates + ranking. The
+    # receipt body is chain-position-agnostic; this wrapper entry is what
+    # binds it into the tamper-evident chain (bound by its own prev_hmac).
+    if audit_log is not None:
+        from bernstein.core.sandbox.selection_receipt import receipt_to_dict
+
+        with _cross_process_audit_lock(audit_lock_path):
+            audit_log.log(
+                FORK_RACE_EVENT_TYPE,
+                actor,
+                "sandbox_selection_receipt",
+                signed.payload_digest,
+                {
+                    "base_snapshot_digest": signed.base_snapshot_digest,
+                    "winner_task_id": signed.winner_task_id,
+                    "winner_snapshot_digest": signed.winner_snapshot_digest,
+                    "keyid": signed.keyid,
+                    "receipt": receipt_to_dict(signed),
+                },
+            )
+
+    return signed
+
+
+__all__ = [
+    "DETERMINISTIC_PROFILE",
+    "FORK_RACE_EVENT_TYPE",
+    "ForkRaceBackend",
+    "fork_race",
+]

--- a/src/bernstein/core/sandbox/fork_race.py
+++ b/src/bernstein/core/sandbox/fork_race.py
@@ -247,20 +247,31 @@ async def fork_race(
     if audit_log is not None:
         from bernstein.core.sandbox.selection_receipt import receipt_to_dict
 
-        with _cross_process_audit_lock(audit_lock_path):
-            audit_log.log(
-                FORK_RACE_EVENT_TYPE,
-                actor,
-                "sandbox_selection_receipt",
-                signed.payload_digest,
-                {
-                    "base_snapshot_digest": signed.base_snapshot_digest,
-                    "winner_task_id": signed.winner_task_id,
-                    "winner_snapshot_digest": signed.winner_snapshot_digest,
-                    "keyid": signed.keyid,
-                    "receipt": receipt_to_dict(signed),
-                },
-            )
+        # The cross-process flock can block on contention from another fork-race
+        # process, and audit_log.log does a synchronous file write - both would
+        # stall the caller's event loop (fork_race is a library coroutine that
+        # may be awaited alongside other tasks). Offload the lock+append to a
+        # worker thread. It is still awaited before returning, so the crash-safe
+        # ordering (CAS blobs -> sign -> audit -> receipt file) holds, and lock
+        # and append stay together in one call, so the chain's prev_hmac is
+        # still written under exclusive serialisation.
+        def _append() -> None:
+            with _cross_process_audit_lock(audit_lock_path):
+                audit_log.log(
+                    FORK_RACE_EVENT_TYPE,
+                    actor,
+                    "sandbox_selection_receipt",
+                    signed.payload_digest,
+                    {
+                        "base_snapshot_digest": signed.base_snapshot_digest,
+                        "winner_task_id": signed.winner_task_id,
+                        "winner_snapshot_digest": signed.winner_snapshot_digest,
+                        "keyid": signed.keyid,
+                        "receipt": receipt_to_dict(signed),
+                    },
+                )
+
+        await asyncio.to_thread(_append)
 
     return signed
 

--- a/src/bernstein/core/sandbox/fork_race.py
+++ b/src/bernstein/core/sandbox/fork_race.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import os
+import threading
 from typing import TYPE_CHECKING, Any, Protocol
 
 from bernstein.core.orchestration.best_of_n import CandidateResult, select_winner
@@ -74,16 +75,26 @@ DETERMINISTIC_PROFILE: CriterionProfile = build_criterion_profile(
 #: Audit event-type for a completed fork-race selection.
 FORK_RACE_EVENT_TYPE = "sandbox.fork_race"
 
+#: Serialises concurrent same-process audit appends. ``AuditLog`` has no
+#: internal lock, and offloading the append to ``asyncio.to_thread`` means two
+#: concurrent ``fork_race()`` calls sharing one ``AuditLog`` would run
+#: ``AuditLog.log`` in parallel worker threads - both reading the same
+#: ``prev_hmac`` and forking the chain. The cross-process flock only guards
+#: *separate processes* (and is a no-op when ``audit_lock_path`` is ``None``),
+#: so an in-process lock is also required now that the append runs off-loop.
+_AUDIT_APPEND_LOCK = threading.Lock()
+
 
 @contextlib.contextmanager
 def _cross_process_audit_lock(lock_path: Path | None) -> Iterator[None]:
     """Serialise the single audit append across concurrent fork-race *processes*.
 
-    Within one event loop the append is a synchronous ``AuditLog.log`` call
-    that cannot interleave with another coroutine, so the in-process case is
-    already safe. This guards the remaining window: two *separate processes*
-    running a fork-race against the same audit directory, where ``AuditLog``
-    has no lock of its own and both could read the same ``prev_hmac`` and fork
+    In-process concurrency is handled separately by :data:`_AUDIT_APPEND_LOCK`
+    (needed because the append now runs in a worker thread via
+    ``asyncio.to_thread``). This guards the remaining window: two *separate
+    processes* running a fork-race against the same audit directory, where
+    ``AuditLog`` has no lock of its own and both could read the same
+    ``prev_hmac`` and fork
     the chain. A no-op when *lock_path* is ``None`` or on a platform without
     ``fcntl`` (e.g. Windows).
     """
@@ -195,8 +206,17 @@ async def fork_race(
         try:
             result = await run_candidate(session, index)
             terminal_digest = await session.snapshot()
-        finally:
-            await backend.destroy(session)
+        except BaseException:
+            # Cleanup must never mask the original candidate failure: a destroy()
+            # error on this path is suppressed rather than replacing the in-flight
+            # exception the outer drain re-raises verbatim (so the winner's failure
+            # is never mis-attributed to teardown, including while draining
+            # cancelled siblings).
+            with contextlib.suppress(Exception):
+                await backend.destroy(session)
+            raise
+        # Success path: a destroy() failure here IS the error worth surfacing.
+        await backend.destroy(session)
         return result, terminal_digest
 
     # Race the candidates concurrently; the barrier here is intentional -
@@ -256,7 +276,7 @@ async def fork_race(
         # and append stay together in one call, so the chain's prev_hmac is
         # still written under exclusive serialisation.
         def _append() -> None:
-            with _cross_process_audit_lock(audit_lock_path):
+            with _AUDIT_APPEND_LOCK, _cross_process_audit_lock(audit_lock_path):
                 audit_log.log(
                     FORK_RACE_EVENT_TYPE,
                     actor,

--- a/src/bernstein/core/sandbox/fork_race.py
+++ b/src/bernstein/core/sandbox/fork_race.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import logging
 import os
 import threading
 from typing import TYPE_CHECKING, Any, Protocol
@@ -71,6 +72,8 @@ if TYPE_CHECKING:
 DETERMINISTIC_PROFILE: CriterionProfile = build_criterion_profile(
     ["correctness", "cost", "reversibility"],
 )
+
+_logger = logging.getLogger(__name__)
 
 #: Audit event-type for a completed fork-race selection.
 FORK_RACE_EVENT_TYPE = "sandbox.fork_race"
@@ -227,13 +230,19 @@ async def fork_race(
             result = await run_candidate(session, index)
             terminal_digest = await session.snapshot()
         except BaseException:
-            # Cleanup must never mask the original candidate failure: a destroy()
-            # error on this path is suppressed rather than replacing the in-flight
-            # exception the outer drain re-raises verbatim (so the winner's failure
-            # is never mis-attributed to teardown, including while draining
-            # cancelled siblings).
-            with contextlib.suppress(Exception):
+            # Cleanup must never mask the original candidate failure, so a
+            # destroy() error here does not replace the in-flight exception the
+            # outer drain re-raises verbatim - but log it so a genuine teardown
+            # failure (leaked guest) leaves a trace instead of vanishing.
+            try:
                 await backend.destroy(session)
+            except Exception:
+                _logger.warning(
+                    "candidate session teardown failed during fork_race cleanup; "
+                    "a guest resource may have leaked (candidate index %d)",
+                    index,
+                    exc_info=True,
+                )
             raise
         # Success path: a destroy() failure here IS the error worth surfacing.
         await backend.destroy(session)

--- a/src/bernstein/core/sandbox/registry.py
+++ b/src/bernstein/core/sandbox/registry.py
@@ -150,6 +150,7 @@ class _Registry:
         from bernstein.core.sandbox.backends.blaxel import BlaxelSandboxBackend
         from bernstein.core.sandbox.backends.daytona import DaytonaSandboxBackend
         from bernstein.core.sandbox.backends.docker import DockerSandboxBackend
+        from bernstein.core.sandbox.backends.microvm import MicroVMSandboxBackend
         from bernstein.core.sandbox.backends.runloop import RunloopSandboxBackend
         from bernstein.core.sandbox.backends.vercel import VercelSandboxBackend
         from bernstein.core.sandbox.backends.worktree import WorktreeSandboxBackend
@@ -157,6 +158,7 @@ class _Registry:
         builtins: tuple[tuple[str, type[SandboxBackend]], ...] = (
             ("worktree", WorktreeSandboxBackend),
             ("docker", DockerSandboxBackend),
+            ("microvm", MicroVMSandboxBackend),
             ("blaxel", BlaxelSandboxBackend),
             ("daytona", DaytonaSandboxBackend),
             ("runloop", RunloopSandboxBackend),

--- a/src/bernstein/core/sandbox/selection_receipt.py
+++ b/src/bernstein/core/sandbox/selection_receipt.py
@@ -50,7 +50,7 @@ import base64
 import binascii
 import hashlib
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, cast
 
 from cryptography.exceptions import InvalidSignature
@@ -314,37 +314,16 @@ def build_selection_receipt(
 
 
 def _with_digest(receipt: SelectionReceipt, digest: str) -> SelectionReceipt:
-    return SelectionReceipt(
-        schema_version=receipt.schema_version,
-        base_snapshot_digest=receipt.base_snapshot_digest,
-        candidates=receipt.candidates,
-        winner_task_id=receipt.winner_task_id,
-        winner_snapshot_digest=receipt.winner_snapshot_digest,
-        ranker_profile=receipt.ranker_profile,
-        loser_snapshot_digests=receipt.loser_snapshot_digests,
-        public_key_pem=receipt.public_key_pem,
-        keyid=receipt.keyid,
-        payload_digest=digest,
-        signature_b64=receipt.signature_b64,
-    )
+    # replace() copies every other field verbatim, so a newly-added field can
+    # never be silently dropped from the signing path (the risk of hand-listing
+    # each field in a security-sensitive dataclass).
+    return replace(receipt, payload_digest=digest)
 
 
 def sign_receipt(receipt: SelectionReceipt, *, private_key: Ed25519PrivateKey) -> SelectionReceipt:
     """Attach an Ed25519 signature. Ed25519 is deterministic (RFC 8032)."""
     sig = private_key.sign(canonical_receipt_bytes(receipt))
-    return SelectionReceipt(
-        schema_version=receipt.schema_version,
-        base_snapshot_digest=receipt.base_snapshot_digest,
-        candidates=receipt.candidates,
-        winner_task_id=receipt.winner_task_id,
-        winner_snapshot_digest=receipt.winner_snapshot_digest,
-        ranker_profile=receipt.ranker_profile,
-        loser_snapshot_digests=receipt.loser_snapshot_digests,
-        public_key_pem=receipt.public_key_pem,
-        keyid=receipt.keyid,
-        payload_digest=receipt.payload_digest,
-        signature_b64=base64.b64encode(sig).decode("ascii"),
-    )
+    return replace(receipt, signature_b64=base64.b64encode(sig).decode("ascii"))
 
 
 # ---------------------------------------------------------------------------
@@ -360,7 +339,11 @@ def _candidate_digest_map(receipt: SelectionReceipt) -> dict[str, str]:
     return out
 
 
-def verify_receipt(receipt: SelectionReceipt) -> ReceiptVerification:
+def verify_receipt(
+    receipt: SelectionReceipt,
+    *,
+    expected_keyid: str | None = None,
+) -> ReceiptVerification:
     """Verify a receipt offline using nothing but the receipt itself.
 
     Checks, in order: payload-digest recomputation, winner presence +
@@ -369,6 +352,18 @@ def verify_receipt(receipt: SelectionReceipt) -> ReceiptVerification:
     the signed body trips at least one check. CAS blob existence/integrity
     is intentionally *not* checked here - that needs the store and is the
     ``sandbox receipt verify`` CLI's job.
+
+    Args:
+        receipt: The receipt to verify.
+        expected_keyid: When supplied, the receipt must have been signed by
+            exactly this trusted signer (its ``keyid`` must equal this value).
+            A self-consistent receipt only proves it was signed by *the key it
+            carries*; without this an attacker can re-sign a forged body under
+            their own key and it still verifies. Pass the trusted signer's
+            keyid to bind acceptance to a known key (mirrors
+            :func:`bernstein.core.sandbox.pool_enrolment.verify_claim_receipt`'s
+            ``enrolled_keyid``). ``None`` preserves the self-consistency-only
+            behaviour.
     """
     errors: list[str] = []
 
@@ -376,6 +371,11 @@ def verify_receipt(receipt: SelectionReceipt) -> ReceiptVerification:
     if expected_digest != receipt.payload_digest:
         errors.append(
             f"payload_digest mismatch (expected {expected_digest[:16]}..., got {receipt.payload_digest[:16]}...)",
+        )
+
+    if expected_keyid is not None and receipt.keyid != expected_keyid:
+        errors.append(
+            f"keyid {receipt.keyid[:16]}... is not the trusted signer {expected_keyid[:16]}...",
         )
 
     digest_by_id = _candidate_digest_map(receipt)

--- a/src/bernstein/core/sandbox/selection_receipt.py
+++ b/src/bernstein/core/sandbox/selection_receipt.py
@@ -374,8 +374,12 @@ def verify_receipt(
         )
 
     if expected_keyid is not None and receipt.keyid != expected_keyid:
+        # receipt.keyid is typed str but a hand-built/deserialised receipt could
+        # carry None; guard the slice so verification reports a mismatch rather
+        # than raising TypeError.
+        got = (receipt.keyid or "")[:16]
         errors.append(
-            f"keyid {receipt.keyid[:16]}... is not the trusted signer {expected_keyid[:16]}...",
+            f"keyid {got}... is not the trusted signer {expected_keyid[:16]}...",
         )
 
     digest_by_id = _candidate_digest_map(receipt)

--- a/src/bernstein/core/sandbox/selection_receipt.py
+++ b/src/bernstein/core/sandbox/selection_receipt.py
@@ -99,7 +99,11 @@ class RaceCandidate:
 
     def to_dict(self) -> dict[str, Any]:
         # Sort the score vector's own keys so serialisation is stable even
-        # if the mapping was built in a different insertion order.
+        # if the mapping was built in a different insertion order. The
+        # float() coercion is deliberate (not redundant): it pins the JSON
+        # form to `1.0` regardless of whether an int/np-float was stored, so
+        # the signed payload digest can never depend on the source numeric
+        # type. Removing it would make the receipt digest input-type sensitive.
         return {
             "task_id": self.task_id,
             "terminal_snapshot_digest": self.terminal_snapshot_digest,

--- a/src/bernstein/core/sandbox/selection_receipt.py
+++ b/src/bernstein/core/sandbox/selection_receipt.py
@@ -289,6 +289,12 @@ def build_selection_receipt(
         raise SelectionReceiptError("a selection receipt requires at least one candidate")
 
     ordered = sorted(candidates, key=lambda c: c.task_id)
+    ids = [c.task_id for c in ordered]
+    if not all(ids):
+        raise SelectionReceiptError("every candidate must have a non-empty task_id")
+    if len(set(ids)) != len(ids):
+        dupes = sorted({t for t in ids if ids.count(t) > 1})
+        raise SelectionReceiptError(f"candidate task_ids must be unique; duplicates: {dupes}")
     by_id = {c.task_id: c for c in ordered}
     winner = by_id.get(winner_task_id)
     if winner is None:
@@ -381,6 +387,15 @@ def verify_receipt(
         errors.append(
             f"keyid {got}... is not the trusted signer {expected_keyid[:16]}...",
         )
+
+    # Reject duplicate/empty candidate task_ids: _candidate_digest_map keys on
+    # task_id, so a deserialised receipt with a collision would otherwise pass
+    # loser/winner cross-checks while hiding a candidate's real terminal digest.
+    receipt_ids = [str(c.get("task_id", "")) for c in receipt.candidates]
+    if not all(receipt_ids):
+        errors.append("a candidate has an empty task_id")
+    if len(set(receipt_ids)) != len(receipt_ids):
+        errors.append("candidate task_ids are not unique")
 
     digest_by_id = _candidate_digest_map(receipt)
     if receipt.winner_task_id not in digest_by_id:

--- a/src/bernstein/core/sandbox/selection_receipt.py
+++ b/src/bernstein/core/sandbox/selection_receipt.py
@@ -1,0 +1,487 @@
+"""Signed, offline-verifiable fork-and-race selection receipts (#2613).
+
+The output of a fork-and-race is not a diff and not a log line; it is a
+:class:`SelectionReceipt` - a canonical JSON envelope, Ed25519-signed,
+that binds the whole race together: the one content-addressed base
+snapshot every candidate forked from, each candidate's terminal snapshot
+digest and deterministic score vector, the winner, the losing branches
+recorded as lineage siblings, and the ranker profile that chose the
+winner. It mirrors the receipt discipline of
+:mod:`bernstein.core.orchestration.sla_receipt` (canonical bytes ->
+payload digest -> Ed25519 signature over those bytes, verify reading
+nothing but the receipt) but for the sandbox fork-race surface.
+
+Determinism is a hard requirement, and it drives every design choice
+here. The acceptance gate is: run the same race twice over the same base
+snapshot and the two receipts must be **byte-identical** - same winner
+digest, same ordered loser siblings, both verifying under the same key.
+For that to hold, the signed body must be a *pure function of
+{base, candidate deliverables, ranker profile}* with every source of
+run-to-run variance removed:
+
+- **No wall-clock, no run id, no chain position** in the signed body. A
+  ``runtime_s`` or ``created_at`` or ``run_id`` field would differ every
+  run and break byte-identity (and, if ranked on, could even flip the
+  winner on scheduler jitter). Replay/chain-position binding lives in the
+  audit-log *wrapper* entry, not in the receipt.
+- **Lists are canonically ordered** by ``task_id`` before serialisation.
+  ``json.dumps(sort_keys=True)`` sorts dict keys, not list elements, so an
+  unsorted candidate/loser list built in completion order would serialise
+  differently between two concurrent races.
+- **``allow_nan=False``** so a degenerate score (TOPSIS constant column ->
+  ``0/0``) throws at signing time rather than minting an unparseable
+  "canonical" receipt.
+
+Verification splits honestly into two layers. :func:`verify_receipt` is
+pure - it re-derives the payload digest, cross-checks that
+``winner_snapshot_digest`` and ``loser_snapshot_digests`` agree with the
+candidate list, and checks the Ed25519 signature against the embedded
+public key (whose keyid is bound into the signed body). It proves the
+receipt is *properly signed and internally consistent*. It does **not**
+prove the snapshot blobs still exist and still hash correctly in CAS -
+that requires the store and is the job of ``bernstein sandbox receipt
+verify`` (see :func:`snapshot_digests`), and it does **not** prove the
+receipt was appended to the audit chain (that is the wrapper entry's job).
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+#: Schema version embedded in every selection receipt. Bump on a breaking change.
+SELECTION_RECEIPT_SCHEMA_VERSION = "1.0.0"
+
+#: Isolation tier recorded per candidate (the backend that produced it).
+DEFAULT_ISOLATION = "microvm"
+
+
+class SelectionReceiptError(RuntimeError):
+    """Raised when receipt assembly, IO, or key handling fails."""
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class RaceCandidate:
+    """One candidate's contribution to a fork-race, as recorded in the receipt.
+
+    Attributes:
+        task_id: Stable candidate identifier (also the ranker tie-break key).
+        terminal_snapshot_digest: CAS digest of the candidate's terminal
+            workspace image.
+        score_vector: Deterministic per-axis scores fed to the ranker.
+            Must contain no wall-clock axis (see module docstring).
+        isolation: Isolation tier that produced the candidate.
+    """
+
+    task_id: str
+    terminal_snapshot_digest: str
+    score_vector: dict[str, float]
+    isolation: str = DEFAULT_ISOLATION
+
+    def to_dict(self) -> dict[str, Any]:
+        # Sort the score vector's own keys so serialisation is stable even
+        # if the mapping was built in a different insertion order.
+        return {
+            "task_id": self.task_id,
+            "terminal_snapshot_digest": self.terminal_snapshot_digest,
+            "score_vector": {k: float(self.score_vector[k]) for k in sorted(self.score_vector)},
+            "isolation": self.isolation,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class SelectionReceipt:
+    """A portable, signed envelope describing one fork-and-race outcome.
+
+    The signed payload is canonical JSON (sorted keys, compact
+    separators). Two operators serialising the same envelope - and two
+    runs of the same race - produce byte-identical signing inputs.
+    """
+
+    schema_version: str
+    base_snapshot_digest: str
+    candidates: tuple[dict[str, Any], ...]
+    winner_task_id: str
+    winner_snapshot_digest: str
+    ranker_profile: dict[str, Any]
+    loser_snapshot_digests: tuple[str, ...]
+    public_key_pem: str
+    keyid: str
+    payload_digest: str
+    signature_b64: str = ""
+
+    @property
+    def is_signed(self) -> bool:
+        return bool(self.signature_b64)
+
+
+@dataclass(frozen=True, slots=True)
+class ReceiptVerification:
+    """Outcome of :func:`verify_receipt`."""
+
+    ok: bool
+    errors: tuple[str, ...] = ()
+
+
+# ---------------------------------------------------------------------------
+# Canonical serialisation
+# ---------------------------------------------------------------------------
+
+
+def _canonical_json(payload: dict[str, Any]) -> bytes:
+    # allow_nan=False: a NaN/Inf score is a bug, not a value to sign over.
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _signing_payload_dict(receipt: SelectionReceipt) -> dict[str, Any]:
+    """The dict that gets signed (excludes signature + payload_digest)."""
+    return {
+        "schema_version": receipt.schema_version,
+        "base_snapshot_digest": receipt.base_snapshot_digest,
+        "candidates": list(receipt.candidates),
+        "winner_task_id": receipt.winner_task_id,
+        "winner_snapshot_digest": receipt.winner_snapshot_digest,
+        "ranker_profile": receipt.ranker_profile,
+        "loser_snapshot_digests": list(receipt.loser_snapshot_digests),
+        "public_key_pem": receipt.public_key_pem,
+        "keyid": receipt.keyid,
+    }
+
+
+def canonical_receipt_bytes(receipt: SelectionReceipt) -> bytes:
+    """Return the canonical signing bytes for *receipt*."""
+    return _canonical_json(_signing_payload_dict(receipt))
+
+
+def _payload_digest(receipt: SelectionReceipt) -> str:
+    return hashlib.sha256(canonical_receipt_bytes(receipt)).hexdigest()
+
+
+def receipt_to_dict(receipt: SelectionReceipt) -> dict[str, Any]:
+    """Return the full canonical dict view (for JSON storage)."""
+    payload = _signing_payload_dict(receipt)
+    payload["payload_digest"] = receipt.payload_digest
+    payload["signature_b64"] = receipt.signature_b64
+    return payload
+
+
+def receipt_from_dict(payload: dict[str, Any]) -> SelectionReceipt:
+    """Build a receipt from its canonical dict view."""
+    candidates_raw = payload.get("candidates", [])
+    candidates = tuple(cast("dict[str, Any]", c) for c in candidates_raw if isinstance(c, dict))
+    losers_raw = payload.get("loser_snapshot_digests", [])
+    losers = tuple(str(d) for d in losers_raw)
+    profile_raw = payload.get("ranker_profile", {})
+    profile = cast("dict[str, Any]", profile_raw) if isinstance(profile_raw, dict) else {}
+    return SelectionReceipt(
+        schema_version=str(payload.get("schema_version", "")),
+        base_snapshot_digest=str(payload.get("base_snapshot_digest", "")),
+        candidates=candidates,
+        winner_task_id=str(payload.get("winner_task_id", "")),
+        winner_snapshot_digest=str(payload.get("winner_snapshot_digest", "")),
+        ranker_profile=profile,
+        loser_snapshot_digests=losers,
+        public_key_pem=str(payload.get("public_key_pem", "")),
+        keyid=str(payload.get("keyid", "")),
+        payload_digest=str(payload.get("payload_digest", "")),
+        signature_b64=str(payload.get("signature_b64", "")),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Key helpers
+# ---------------------------------------------------------------------------
+
+
+def keyid_for(public_key: Ed25519PublicKey) -> str:
+    """Return sha256 of the public key's DER bytes (the stable key id)."""
+    der = public_key.public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return hashlib.sha256(der).hexdigest()
+
+
+def _public_pem(public_key: Ed25519PublicKey) -> str:
+    return public_key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode("ascii")
+
+
+def load_or_create_signing_key(key_path: Path) -> Ed25519PrivateKey:
+    """Load an Ed25519 private key from *key_path*, generating one if absent.
+
+    The key is written PEM-encoded (PKCS#8) with owner-only ``0600``
+    permissions on first creation. Reused across runs so a redeployed
+    verifier and both operators sign under the same key - a prerequisite
+    for the byte-identical-receipt guarantee (Ed25519 is deterministic).
+    """
+    if key_path.exists():
+        data = key_path.read_bytes()
+        try:
+            key = serialization.load_pem_private_key(data, password=None)
+        except (ValueError, TypeError) as exc:
+            msg = f"invalid Ed25519 signing key at {key_path}: {exc}"
+            raise SelectionReceiptError(msg) from exc
+        if not isinstance(key, Ed25519PrivateKey):
+            msg = f"signing key at {key_path} is not an Ed25519 key"
+            raise SelectionReceiptError(msg)
+        return key
+
+    key = Ed25519PrivateKey.generate()
+    pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    key_path.parent.mkdir(parents=True, exist_ok=True)
+    key_path.write_bytes(pem)
+    key_path.chmod(0o600)
+    return key
+
+
+# ---------------------------------------------------------------------------
+# Assembly
+# ---------------------------------------------------------------------------
+
+
+def build_selection_receipt(
+    *,
+    base_snapshot_digest: str,
+    candidates: list[RaceCandidate],
+    winner_task_id: str,
+    ranker_profile: dict[str, Any],
+    public_key: Ed25519PublicKey,
+) -> SelectionReceipt:
+    """Assemble an unsigned :class:`SelectionReceipt`.
+
+    Candidates are canonically ordered by ``task_id`` and the loser
+    siblings are derived (never passed in) so the two can never drift.
+    ``winner_snapshot_digest`` is likewise derived from the winning
+    candidate. Raises when the winner is not among the candidates.
+    """
+    if not candidates:
+        raise SelectionReceiptError("a selection receipt requires at least one candidate")
+
+    ordered = sorted(candidates, key=lambda c: c.task_id)
+    by_id = {c.task_id: c for c in ordered}
+    winner = by_id.get(winner_task_id)
+    if winner is None:
+        msg = f"winner_task_id {winner_task_id!r} is not among the candidates"
+        raise SelectionReceiptError(msg)
+
+    loser_digests = tuple(c.terminal_snapshot_digest for c in ordered if c.task_id != winner_task_id)
+
+    base = SelectionReceipt(
+        schema_version=SELECTION_RECEIPT_SCHEMA_VERSION,
+        base_snapshot_digest=base_snapshot_digest,
+        candidates=tuple(c.to_dict() for c in ordered),
+        winner_task_id=winner_task_id,
+        winner_snapshot_digest=winner.terminal_snapshot_digest,
+        ranker_profile=ranker_profile,
+        loser_snapshot_digests=loser_digests,
+        public_key_pem=_public_pem(public_key),
+        keyid=keyid_for(public_key),
+        payload_digest="",
+        signature_b64="",
+    )
+    return _with_digest(base, _payload_digest(base))
+
+
+def _with_digest(receipt: SelectionReceipt, digest: str) -> SelectionReceipt:
+    return SelectionReceipt(
+        schema_version=receipt.schema_version,
+        base_snapshot_digest=receipt.base_snapshot_digest,
+        candidates=receipt.candidates,
+        winner_task_id=receipt.winner_task_id,
+        winner_snapshot_digest=receipt.winner_snapshot_digest,
+        ranker_profile=receipt.ranker_profile,
+        loser_snapshot_digests=receipt.loser_snapshot_digests,
+        public_key_pem=receipt.public_key_pem,
+        keyid=receipt.keyid,
+        payload_digest=digest,
+        signature_b64=receipt.signature_b64,
+    )
+
+
+def sign_receipt(receipt: SelectionReceipt, *, private_key: Ed25519PrivateKey) -> SelectionReceipt:
+    """Attach an Ed25519 signature. Ed25519 is deterministic (RFC 8032)."""
+    sig = private_key.sign(canonical_receipt_bytes(receipt))
+    return SelectionReceipt(
+        schema_version=receipt.schema_version,
+        base_snapshot_digest=receipt.base_snapshot_digest,
+        candidates=receipt.candidates,
+        winner_task_id=receipt.winner_task_id,
+        winner_snapshot_digest=receipt.winner_snapshot_digest,
+        ranker_profile=receipt.ranker_profile,
+        loser_snapshot_digests=receipt.loser_snapshot_digests,
+        public_key_pem=receipt.public_key_pem,
+        keyid=receipt.keyid,
+        payload_digest=receipt.payload_digest,
+        signature_b64=base64.b64encode(sig).decode("ascii"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Verification (pure - reads only the receipt)
+# ---------------------------------------------------------------------------
+
+
+def _candidate_digest_map(receipt: SelectionReceipt) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for cand in receipt.candidates:
+        task_id = str(cand.get("task_id", ""))
+        out[task_id] = str(cand.get("terminal_snapshot_digest", ""))
+    return out
+
+
+def verify_receipt(receipt: SelectionReceipt) -> ReceiptVerification:
+    """Verify a receipt offline using nothing but the receipt itself.
+
+    Checks, in order: payload-digest recomputation, winner presence +
+    winner-digest cross-check, loser-sibling derivation, then the Ed25519
+    signature (with keyid self-consistency). Any single-byte mutation of
+    the signed body trips at least one check. CAS blob existence/integrity
+    is intentionally *not* checked here - that needs the store and is the
+    ``sandbox receipt verify`` CLI's job.
+    """
+    errors: list[str] = []
+
+    expected_digest = _payload_digest(receipt)
+    if expected_digest != receipt.payload_digest:
+        errors.append(
+            f"payload_digest mismatch (expected {expected_digest[:16]}..., got {receipt.payload_digest[:16]}...)",
+        )
+
+    digest_by_id = _candidate_digest_map(receipt)
+    if receipt.winner_task_id not in digest_by_id:
+        errors.append(f"winner_task_id {receipt.winner_task_id!r} is not among the candidates")
+    elif digest_by_id[receipt.winner_task_id] != receipt.winner_snapshot_digest:
+        errors.append("winner_snapshot_digest does not match the winning candidate's terminal digest")
+
+    expected_losers = tuple(
+        digest for task_id, digest in sorted(digest_by_id.items()) if task_id != receipt.winner_task_id
+    )
+    if expected_losers != receipt.loser_snapshot_digests:
+        errors.append("loser_snapshot_digests do not match the non-winning candidates")
+
+    if not receipt.signature_b64:
+        errors.append("receipt is unsigned")
+    else:
+        try:
+            public_key = serialization.load_pem_public_key(receipt.public_key_pem.encode("ascii"))
+        except (ValueError, TypeError) as exc:
+            errors.append(f"embedded public key is unreadable: {exc}")
+            return ReceiptVerification(ok=False, errors=tuple(errors))
+        if not isinstance(public_key, Ed25519PublicKey):
+            errors.append("embedded public key is not an Ed25519 key")
+            return ReceiptVerification(ok=False, errors=tuple(errors))
+        if receipt.keyid and keyid_for(public_key) != receipt.keyid:
+            errors.append("keyid does not match the embedded public key")
+        try:
+            sig = base64.b64decode(receipt.signature_b64)
+        except (ValueError, binascii.Error) as exc:
+            errors.append(f"signature_b64 not valid base64: {exc}")
+            return ReceiptVerification(ok=False, errors=tuple(errors))
+        try:
+            public_key.verify(sig, canonical_receipt_bytes(receipt))
+        except InvalidSignature:
+            errors.append("Ed25519 signature does not verify")
+
+    return ReceiptVerification(ok=not errors, errors=tuple(errors))
+
+
+def snapshot_digests(receipt: SelectionReceipt) -> list[str]:
+    """Every CAS digest a full verifier must re-hash: base + all candidates.
+
+    The winner and every loser are candidates, so ``base + all candidate
+    terminals`` covers base + winner + all losers. Order is deterministic
+    (base first, then candidates in their receipt order). Deduplicated so a
+    candidate that never mutated the base (terminal == base) is checked once.
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+    for digest in (
+        receipt.base_snapshot_digest,
+        *(str(c.get("terminal_snapshot_digest", "")) for c in receipt.candidates),
+    ):
+        if digest and digest not in seen:
+            seen.add(digest)
+            out.append(digest)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Disk persistence (crash-safe: tmp + rename)
+# ---------------------------------------------------------------------------
+
+
+def write_receipt(path: Path, receipt: SelectionReceipt) -> Path:
+    """Persist *receipt* atomically to *path*; return it.
+
+    Uses a tmp-file + rename so a crash never leaves a half-written
+    receipt visible. Callers publish the receipt file only *after* the CAS
+    blobs are stored, the receipt is signed, and the audit append has
+    durably landed (see :mod:`bernstein.core.sandbox.fork_race`).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(receipt_to_dict(receipt), sort_keys=True, indent=2))
+    tmp.replace(path)
+    return path
+
+
+def read_receipt_file(path: Path) -> SelectionReceipt | None:
+    """Load a receipt from an explicit path (used by ``sandbox receipt verify``)."""
+    if not path.exists():
+        return None
+    raw = json.loads(path.read_text())
+    if not isinstance(raw, dict):
+        return None
+    return receipt_from_dict(cast("dict[str, Any]", raw))
+
+
+__all__ = [
+    "DEFAULT_ISOLATION",
+    "SELECTION_RECEIPT_SCHEMA_VERSION",
+    "RaceCandidate",
+    "ReceiptVerification",
+    "SelectionReceipt",
+    "SelectionReceiptError",
+    "build_selection_receipt",
+    "canonical_receipt_bytes",
+    "keyid_for",
+    "load_or_create_signing_key",
+    "read_receipt_file",
+    "receipt_from_dict",
+    "receipt_to_dict",
+    "sign_receipt",
+    "snapshot_digests",
+    "verify_receipt",
+    "write_receipt",
+]

--- a/src/bernstein/core/sandbox/selector.py
+++ b/src/bernstein/core/sandbox/selector.py
@@ -61,6 +61,12 @@ DEFAULT_PRECEDENCE: tuple[str, ...] = (
     "blaxel",
     "runloop",
     "vercel",
+    # microvm is opt-in: it is not a FREE_BACKEND, so the heuristic path
+    # never auto-selects it over worktree/docker. An explicit
+    # ``sandbox.backend: microvm`` override reaches it, and an unsupported
+    # host then fails loudly at create() (MicroVMUnavailableError) rather
+    # than silently degrading to a bare worktree.
+    "microvm",
 )
 
 

--- a/tests/integration/sandbox/test_microvm_firecracker.py
+++ b/tests/integration/sandbox/test_microvm_firecracker.py
@@ -1,0 +1,74 @@
+"""KVM-gated integration tests for the Firecracker microVM monitor (#2613).
+
+These are skipped everywhere the bounty normally runs (macOS, CI without
+``/dev/kvm``). The determinism / CAS / receipt guarantees are proven
+host-independently by the FakeMonitor unit + acceptance suite; this module
+covers only the parts that genuinely need a hypervisor:
+
+- On an unsupported host, the monitor's ``preflight`` reports the missing
+  preconditions and ``boot`` refuses with :class:`MicroVMUnavailableError`
+  (the no-silent-downgrade invariant) - this part runs everywhere.
+- On a fully provisioned KVM host (opt in with
+  ``BERNSTEIN_MICROVM_INTEGRATION=1`` plus a configured kernel/rootfs), the
+  real backend round-trips create/exec/snapshot/resume.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from bernstein.core.sandbox.backends._vmmonitor import (
+    FirecrackerMonitor,
+    MicroVMUnavailableError,
+)
+
+
+def test_preflight_reports_missing_preconditions() -> None:
+    """preflight() is side-effect-free and enumerates what the host lacks."""
+    missing = FirecrackerMonitor().preflight()
+    # On this dev host (no KVM) the list is non-empty; on a KVM host it may
+    # be empty. Either way the call must not raise.
+    assert isinstance(missing, list)
+
+
+@pytest.mark.asyncio
+async def test_boot_refuses_on_unsupported_host() -> None:
+    monitor = FirecrackerMonitor()
+    if not monitor.preflight():
+        pytest.skip("host supports Firecracker; unsupported-host refusal not exercisable")
+    with pytest.raises(MicroVMUnavailableError):
+        await monitor.boot(base_env={})
+
+
+@pytest.mark.skipif(
+    os.environ.get("BERNSTEIN_MICROVM_INTEGRATION") != "1",
+    reason="opt-in Firecracker integration (needs KVM + kernel/rootfs); set BERNSTEIN_MICROVM_INTEGRATION=1",
+)
+@pytest.mark.asyncio
+async def test_real_microvm_roundtrip(tmp_path) -> None:
+    """Full create -> exec -> snapshot -> resume against a real Firecracker guest.
+
+    Requires an operator-provisioned host: KVM, the ``firecracker`` binary,
+    and ``BERNSTEIN_MICROVM_KERNEL`` / ``BERNSTEIN_MICROVM_ROOTFS`` pointing
+    at a guest kernel + rootfs.
+    """
+    from bernstein.core.persistence.cas_store import CASStore
+    from bernstein.core.sandbox.backends.microvm import MicroVMSandboxBackend
+    from bernstein.core.sandbox.manifest import WorkspaceManifest
+
+    backend = MicroVMSandboxBackend(cas=CASStore(tmp_path / "cas"))
+    session = await backend.create(WorkspaceManifest(root="/workspace"))
+    try:
+        await session.write("state.txt", b"captured")
+        digest = await session.snapshot()
+        assert digest
+    finally:
+        await backend.destroy(session)
+
+    resumed = await backend.resume(digest)
+    try:
+        assert await resumed.read("state.txt") == b"captured"
+    finally:
+        await backend.destroy(resumed)

--- a/tests/unit/sandbox/conftest.py
+++ b/tests/unit/sandbox/conftest.py
@@ -22,6 +22,19 @@ import pytest
 from bernstein.core.sandbox.backends import _vmmonitor
 
 
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "raw_tarfile_filter: do not auto-patch _tarfile_data_filter_is_patched "
+        "(for tests exercising the real version-matrix logic)",
+    )
+
+
 @pytest.fixture(autouse=True)
-def _assume_patched_tarfile_filter(monkeypatch: pytest.MonkeyPatch) -> None:
+def _assume_patched_tarfile_filter(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Tests that exercise the real version matrix opt out via the marker;
+    # everything else gets the check pinned to True so round-trip / correctness
+    # tests are independent of the host's CPython patch level.
+    if request.node.get_closest_marker("raw_tarfile_filter"):
+        return
     monkeypatch.setattr(_vmmonitor, "_tarfile_data_filter_is_patched", lambda: True)

--- a/tests/unit/sandbox/conftest.py
+++ b/tests/unit/sandbox/conftest.py
@@ -1,0 +1,27 @@
+"""Shared fixtures for the sandbox unit tests.
+
+The microVM snapshot format is extracted through the stdlib tarfile ``data``
+filter, and :func:`extract_workspace_image` refuses to run on a CPython build
+whose filter predates the CVE-2025-4517-family fix (``<3.12.11`` / ``<3.13.4``).
+That production guard is correct, but it would otherwise make every
+round-trip / correctness test (conformance snapshot-resume, the canonical-image
+round-trip, and every fork-race that resumes from a snapshot) depend on the
+host's CPython *patch* version rather than the ``>=3.12`` the project claims to
+support - a contributor on a stale interpreter would see spurious failures.
+
+The autouse fixture below pins the patch check to ``True`` so these tests
+exercise extraction *logic* independent of host patch level. The dedicated
+negative test (``test_extract_refuses_on_unpatched_cpython``) re-patches it to
+``False`` in its own body, which wins for the duration of that test.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.sandbox.backends import _vmmonitor
+
+
+@pytest.fixture(autouse=True)
+def _assume_patched_tarfile_filter(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_vmmonitor, "_tarfile_data_filter_is_patched", lambda: True)

--- a/tests/unit/sandbox/test_fork_race.py
+++ b/tests/unit/sandbox/test_fork_race.py
@@ -1,0 +1,169 @@
+"""Acceptance + unit tests for the deterministic fork-and-race (#2613).
+
+The headline test is the issue's empirical acceptance gate: run the same
+fork-race twice over one content-addressed base snapshot with the same
+candidate set, and the two signed receipts must be byte-identical and both
+verify under the Ed25519 public key. Then a stored *loser* snapshot blob is
+mutated and the CAS re-hash the verifier performs must fail - proving the
+race result is meaningless once the content-addressing / signing substrate
+is removed.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from bernstein.core.orchestration.best_of_n import CandidateResult
+from bernstein.core.persistence.cas_store import CASIntegrityError, CASStore
+from bernstein.core.sandbox.backends._vmmonitor import FakeMonitor
+from bernstein.core.sandbox.backends.microvm import MicroVMSandboxBackend
+from bernstein.core.sandbox.fork_race import (
+    FORK_RACE_EVENT_TYPE,
+    fork_race,
+)
+from bernstein.core.sandbox.manifest import FileEntry, WorkspaceManifest
+from bernstein.core.sandbox.selection_receipt import (
+    canonical_receipt_bytes,
+    receipt_to_dict,
+    snapshot_digests,
+    verify_receipt,
+)
+from bernstein.core.security.audit import AuditLog
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_AUDIT_KEY = b"unit-test-audit-key-not-a-secret"
+
+
+def _backend(tmp_path: Path) -> MicroVMSandboxBackend:
+    return MicroVMSandboxBackend(
+        monitor_factory=lambda root: FakeMonitor(root=root),
+        cas=CASStore(tmp_path / "cas"),
+    )
+
+
+async def _base_snapshot(backend: MicroVMSandboxBackend) -> str:
+    manifest = WorkspaceManifest(root="/workspace", files=(FileEntry(path="base.txt", content=b"BASE"),))
+    session = await backend.create(manifest)
+    digest = await session.snapshot()
+    await backend.destroy(session)
+    return digest
+
+
+async def _run_candidate(session: object, index: int) -> CandidateResult:
+    """Deterministic per-candidate work: a fixed file + index-derived scores."""
+    await session.write(f"cand{index}.txt", f"work-{index}".encode())  # type: ignore[attr-defined]
+    return CandidateResult(
+        task_id=f"candidate-{index}",
+        tests_passing=(index % 2 == 0),
+        lint_score=max(0.0, 1.0 - 0.1 * index),
+    )
+
+
+@pytest.mark.asyncio
+async def test_fork_race_is_deterministic_and_tamper_evident(tmp_path: Path) -> None:
+    backend = _backend(tmp_path)
+    key = Ed25519PrivateKey.generate()
+    base = await _base_snapshot(backend)
+
+    r1 = await fork_race(backend=backend, base_snapshot_digest=base, run_candidate=_run_candidate, k=3, signing_key=key)
+    r2 = await fork_race(backend=backend, base_snapshot_digest=base, run_candidate=_run_candidate, k=3, signing_key=key)
+
+    # (a) Same race twice -> byte-identical signed receipts, both verifying.
+    assert canonical_receipt_bytes(r1) == canonical_receipt_bytes(r2)
+    assert r1.signature_b64 == r2.signature_b64
+    assert receipt_to_dict(r1) == receipt_to_dict(r2)
+    assert verify_receipt(r1).ok
+    assert verify_receipt(r2).ok
+
+    # (b) Mutate a LOSER blob -> the CAS re-hash (base + all candidates) fails,
+    # proving the verifier does not only check the winner.
+    cas = backend.cas
+    loser_digest = r1.loser_snapshot_digests[0]
+    blob = cas.root / loser_digest[:2] / loser_digest
+    corrupt = bytearray(blob.read_bytes())
+    corrupt[7] ^= 0xFF
+    blob.write_bytes(bytes(corrupt))
+
+    with pytest.raises(CASIntegrityError):
+        for digest in snapshot_digests(r1):
+            cas.get(digest, verify=True)
+
+
+@pytest.mark.asyncio
+async def test_winner_selection_has_no_llm_and_is_stable(tmp_path: Path) -> None:
+    backend = _backend(tmp_path)
+    key = Ed25519PrivateKey.generate()
+    base = await _base_snapshot(backend)
+    receipts = [
+        await fork_race(backend=backend, base_snapshot_digest=base, run_candidate=_run_candidate, k=4, signing_key=key)
+        for _ in range(3)
+    ]
+    winners = {r.winner_task_id for r in receipts}
+    assert len(winners) == 1  # deterministic winner across repeated races
+
+
+@pytest.mark.asyncio
+async def test_fork_race_appends_exactly_one_audit_entry(tmp_path: Path) -> None:
+    backend = _backend(tmp_path)
+    key = Ed25519PrivateKey.generate()
+    base = await _base_snapshot(backend)
+    audit_dir = tmp_path / "audit"
+    audit_log = AuditLog(audit_dir, key=_AUDIT_KEY)
+
+    await fork_race(
+        backend=backend,
+        base_snapshot_digest=base,
+        run_candidate=_run_candidate,
+        k=3,
+        signing_key=key,
+        audit_log=audit_log,
+    )
+
+    entries = [
+        json.loads(line) for path in audit_dir.glob("*.jsonl") for line in path.read_text().splitlines() if line.strip()
+    ]
+    fork_entries = [e for e in entries if e.get("event_type") == FORK_RACE_EVENT_TYPE]
+    assert len(fork_entries) == 1
+    # The chain still verifies after the append.
+    ok, errors = audit_log.verify()
+    assert ok, errors
+
+
+@pytest.mark.asyncio
+async def test_fork_race_rejects_zero_k(tmp_path: Path) -> None:
+    backend = _backend(tmp_path)
+    key = Ed25519PrivateKey.generate()
+    base = await _base_snapshot(backend)
+    with pytest.raises(ValueError, match="k >= 1"):
+        await fork_race(backend=backend, base_snapshot_digest=base, run_candidate=_run_candidate, k=0, signing_key=key)
+
+
+@pytest.mark.asyncio
+async def test_fork_race_audit_lock_path_is_honoured(tmp_path: Path) -> None:
+    """Passing a lock path serialises the append and leaves the chain verifiable."""
+    backend = _backend(tmp_path)
+    key = Ed25519PrivateKey.generate()
+    base = await _base_snapshot(backend)
+    audit_dir = tmp_path / "audit"
+    audit_log = AuditLog(audit_dir, key=_AUDIT_KEY)
+    lock_path = audit_dir / ".fork_race.lock"
+
+    await fork_race(
+        backend=backend,
+        base_snapshot_digest=base,
+        run_candidate=_run_candidate,
+        k=3,
+        signing_key=key,
+        audit_log=audit_log,
+        audit_lock_path=lock_path,
+    )
+
+    ok, errors = audit_log.verify()
+    assert ok, errors
+    assert lock_path.exists()  # the lock file was created and released cleanly

--- a/tests/unit/sandbox/test_fork_race.py
+++ b/tests/unit/sandbox/test_fork_race.py
@@ -199,6 +199,28 @@ async def test_concurrent_fork_races_do_not_fork_audit_chain(tmp_path: Path) -> 
 
 
 @pytest.mark.asyncio
+async def test_fork_race_rejects_duplicate_task_ids(tmp_path: Path) -> None:
+    """Candidates that return a colliding task_id must be rejected, not silently
+    collapsed into one entry in the signed receipt."""
+    backend = _backend(tmp_path)
+    key = Ed25519PrivateKey.generate()
+    base = await _base_snapshot(backend)
+
+    async def dup_candidate(session: object, index: int) -> CandidateResult:
+        await session.write(f"c{index}.txt", f"work-{index}".encode())  # type: ignore[attr-defined]
+        return CandidateResult(task_id="same-id", tests_passing=True)
+
+    with pytest.raises(ValueError, match="unique"):
+        await fork_race(
+            backend=backend,
+            base_snapshot_digest=base,
+            run_candidate=dup_candidate,
+            k=2,
+            signing_key=key,
+        )
+
+
+@pytest.mark.asyncio
 async def test_fork_race_rejects_zero_k(tmp_path: Path) -> None:
     backend = _backend(tmp_path)
     key = Ed25519PrivateKey.generate()

--- a/tests/unit/sandbox/test_fork_race.py
+++ b/tests/unit/sandbox/test_fork_race.py
@@ -11,6 +11,7 @@ is removed.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import TYPE_CHECKING
 
@@ -133,6 +134,68 @@ async def test_fork_race_appends_exactly_one_audit_entry(tmp_path: Path) -> None
     # The chain still verifies after the append.
     ok, errors = audit_log.verify()
     assert ok, errors
+
+
+@pytest.mark.asyncio
+async def test_candidate_failure_is_not_masked_by_destroy_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If a candidate fails AND its session teardown also fails, the ORIGINAL
+    candidate exception must propagate - not the cleanup error."""
+    backend = _backend(tmp_path)
+    key = Ed25519PrivateKey.generate()
+    base = await _base_snapshot(backend)
+
+    async def boom_candidate(session: object, index: int) -> CandidateResult:
+        raise ValueError(f"candidate {index} boom")
+
+    async def boom_destroy(session: object) -> None:
+        raise RuntimeError("destroy boom")
+
+    monkeypatch.setattr(backend, "destroy", boom_destroy)
+
+    with pytest.raises(ValueError, match="candidate .* boom"):
+        await fork_race(
+            backend=backend,
+            base_snapshot_digest=base,
+            run_candidate=boom_candidate,
+            k=2,
+            signing_key=key,
+        )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_fork_races_do_not_fork_audit_chain(tmp_path: Path) -> None:
+    """Concurrent fork_race() calls sharing one AuditLog with no lock path must
+    still serialise their (now off-loop, threaded) appends - the HMAC chain must
+    remain single and verifiable, not forked on a shared prev_hmac."""
+    key = Ed25519PrivateKey.generate()
+    audit_dir = tmp_path / "audit"
+    audit_log = AuditLog(audit_dir, key=_AUDIT_KEY)
+    n = 4
+
+    async def one_race(i: int) -> None:
+        backend = _backend(tmp_path / f"race{i}")
+        base = await _base_snapshot(backend)
+        await fork_race(
+            backend=backend,
+            base_snapshot_digest=base,
+            run_candidate=_run_candidate,
+            k=3,
+            signing_key=key,
+            audit_log=audit_log,  # shared; audit_lock_path deliberately None
+        )
+
+    await asyncio.gather(*(one_race(i) for i in range(n)))
+
+    entries = [
+        json.loads(line) for path in audit_dir.glob("*.jsonl") for line in path.read_text().splitlines() if line.strip()
+    ]
+    fork_entries = [e for e in entries if e.get("event_type") == FORK_RACE_EVENT_TYPE]
+    assert len(fork_entries) == n  # every append landed, none lost to a race
+    ok, errors = audit_log.verify()
+    assert ok, errors  # chain not forked
 
 
 @pytest.mark.asyncio

--- a/tests/unit/sandbox/test_microvm_backend.py
+++ b/tests/unit/sandbox/test_microvm_backend.py
@@ -17,19 +17,22 @@ import pytest
 import pytest_asyncio
 
 from bernstein.core.persistence.cas_store import CASIntegrityError, CASStore
-from bernstein.core.sandbox.backend import SandboxCapability
+from bernstein.core.sandbox.backend import ExecResult, SandboxCapability
 from bernstein.core.sandbox.backends._vmmonitor import (
     FakeMonitor,
     MicroVMUnavailableError,
     canonical_workspace_image,
     extract_workspace_image,
 )
-from bernstein.core.sandbox.backends.microvm import MicroVMSandboxBackend
+from bernstein.core.sandbox.backends.microvm import (
+    MicroVMProvisioningError,
+    MicroVMSandboxBackend,
+)
 from bernstein.core.sandbox.conformance import SandboxBackendConformance
-from bernstein.core.sandbox.manifest import FileEntry, WorkspaceManifest
+from bernstein.core.sandbox.manifest import FileEntry, GitRepoEntry, WorkspaceManifest
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Mapping
     from pathlib import Path
 
 
@@ -52,8 +55,10 @@ class TestMicroVMConformance(SandboxBackendConformance):
         return WorkspaceManifest(root="/workspace", env={"LC_ALL": "C"}, timeout_seconds=60)
 
 
-def test_backend_declares_hardware_boundary_capabilities() -> None:
-    backend = MicroVMSandboxBackend()
+def test_backend_declares_hardware_boundary_capabilities(tmp_path: Path) -> None:
+    # Inject a tmp_path-rooted CAS so the test never creates a repo-local
+    # .sdd/cas directory as a side effect of constructing the backend.
+    backend = MicroVMSandboxBackend(cas=CASStore(tmp_path / "cas"))
     assert backend.capabilities == frozenset(
         {
             SandboxCapability.FILE_RW,
@@ -103,6 +108,80 @@ async def test_resume_unknown_digest_raises(tmp_path: Path) -> None:
     backend = _backend(tmp_path)
     with pytest.raises(KeyError):
         await backend.resume("0" * 64)
+
+
+class _CloneFailsMonitor:
+    """A VMMonitor stub whose ``git clone`` fails, to exercise create() cleanup.
+
+    Structurally satisfies the (runtime-checkable) ``VMMonitor`` protocol; only
+    the methods create() touches are meaningful. Records ``shutdown`` calls so a
+    test can assert the guest is always torn down on a provisioning failure.
+    """
+
+    def __init__(self, root: str) -> None:
+        self._root = root
+        self.shutdown_calls = 0
+
+    @property
+    def workdir(self) -> str:
+        return self._root
+
+    async def boot(self, *, base_env: Mapping[str, str]) -> None:
+        return None
+
+    async def exec(
+        self,
+        cmd: list[str],
+        *,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout: int | None = None,
+        stdin: bytes | None = None,
+    ) -> ExecResult:
+        return ExecResult(exit_code=1, stdout=b"", stderr=b"fatal: repo not found", duration_seconds=0.0)
+
+    async def write_file(self, path: str, data: bytes, *, mode: int = 0o644) -> None:
+        return None
+
+    async def read_file(self, path: str) -> bytes:
+        return b""
+
+    async def ls(self, path: str) -> list[str]:
+        return []
+
+    async def freeze_image(self) -> bytes:
+        return b""
+
+    async def restore_image(self, image: bytes) -> None:
+        return None
+
+    async def shutdown(self) -> None:
+        self.shutdown_calls += 1
+
+
+@pytest.mark.asyncio
+async def test_create_tears_down_guest_when_clone_fails(tmp_path: Path) -> None:
+    """A non-zero ``git clone`` fails loudly and never leaks the booted monitor."""
+    monitors: list[_CloneFailsMonitor] = []
+
+    def factory(root: str) -> _CloneFailsMonitor:
+        monitor = _CloneFailsMonitor(root)
+        monitors.append(monitor)
+        return monitor
+
+    backend = MicroVMSandboxBackend(monitor_factory=factory, cas=CASStore(tmp_path / "cas"))
+    manifest = WorkspaceManifest(
+        root="/workspace",
+        repo=GitRepoEntry(src_path=str(tmp_path / "missing-repo"), branch="main"),
+    )
+
+    with pytest.raises(MicroVMProvisioningError):
+        await backend.create(manifest)
+
+    assert monitors, "monitor factory was never invoked"
+    assert monitors[0].shutdown_calls == 1
+    # A failed create must not register a session in the tracking table.
+    assert backend._sessions == {}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/sandbox/test_microvm_backend.py
+++ b/tests/unit/sandbox/test_microvm_backend.py
@@ -1,0 +1,192 @@
+"""Unit tests for the microVM sandbox backend (#2613).
+
+The backend runs the full :class:`SandboxBackendConformance` suite over a
+:class:`FakeMonitor` (which really executes commands and really freezes the
+workspace, so these are honest exercises of the snapshot pipeline, not mock
+echoes). Backend-specific tests then cover the content-addressed snapshot
+contract: digest determinism, tamper rejection on resume, the strict
+no-silent-downgrade preflight, and path-traversal hardening of the image
+format.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+import pytest_asyncio
+
+from bernstein.core.persistence.cas_store import CASIntegrityError, CASStore
+from bernstein.core.sandbox.backend import SandboxCapability
+from bernstein.core.sandbox.backends._vmmonitor import (
+    FakeMonitor,
+    MicroVMUnavailableError,
+    canonical_workspace_image,
+    extract_workspace_image,
+)
+from bernstein.core.sandbox.backends.microvm import MicroVMSandboxBackend
+from bernstein.core.sandbox.conformance import SandboxBackendConformance
+from bernstein.core.sandbox.manifest import FileEntry, WorkspaceManifest
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+
+def _backend(tmp_path: Path) -> MicroVMSandboxBackend:
+    return MicroVMSandboxBackend(
+        monitor_factory=lambda root: FakeMonitor(root=root),
+        cas=CASStore(tmp_path / "cas"),
+    )
+
+
+class TestMicroVMConformance(SandboxBackendConformance):
+    """Run the full backend conformance suite over the FakeMonitor."""
+
+    @pytest_asyncio.fixture
+    async def backend(self, tmp_path: Path) -> AsyncIterator[MicroVMSandboxBackend]:
+        yield _backend(tmp_path)
+
+    @pytest.fixture
+    def manifest(self) -> WorkspaceManifest:
+        return WorkspaceManifest(root="/workspace", env={"LC_ALL": "C"}, timeout_seconds=60)
+
+
+def test_backend_declares_hardware_boundary_capabilities() -> None:
+    backend = MicroVMSandboxBackend()
+    assert backend.capabilities == frozenset(
+        {
+            SandboxCapability.FILE_RW,
+            SandboxCapability.EXEC,
+            SandboxCapability.NETWORK,
+            SandboxCapability.SNAPSHOT,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_snapshot_digest_is_deterministic(tmp_path: Path) -> None:
+    """Two identical workspaces snapshot to the same content address."""
+    backend = _backend(tmp_path)
+    manifest = WorkspaceManifest(root="/workspace", files=(FileEntry(path="a.txt", content=b"hi"),))
+    s1 = await backend.create(manifest)
+    await s1.write("state.txt", b"same")
+    d1 = await s1.snapshot()
+    s2 = await backend.create(manifest)
+    await s2.write("state.txt", b"same")
+    d2 = await s2.snapshot()
+    assert d1 == d2
+    await backend.destroy(s1)
+    await backend.destroy(s2)
+
+
+@pytest.mark.asyncio
+async def test_resume_rejects_tampered_snapshot(tmp_path: Path) -> None:
+    cas = CASStore(tmp_path / "cas")
+    backend = MicroVMSandboxBackend(monitor_factory=lambda root: FakeMonitor(root=root), cas=cas)
+    session = await backend.create(WorkspaceManifest(root="/workspace"))
+    await session.write("state.txt", b"captured")
+    digest = await session.snapshot()
+    await backend.destroy(session)
+
+    blob = cas.root / digest[:2] / digest
+    corrupt = bytearray(blob.read_bytes())
+    corrupt[5] ^= 0xFF
+    blob.write_bytes(bytes(corrupt))
+
+    with pytest.raises(CASIntegrityError):
+        await backend.resume(digest)
+
+
+@pytest.mark.asyncio
+async def test_resume_unknown_digest_raises(tmp_path: Path) -> None:
+    backend = _backend(tmp_path)
+    with pytest.raises(KeyError):
+        await backend.resume("0" * 64)
+
+
+@pytest.mark.asyncio
+async def test_default_backend_refuses_without_kvm(tmp_path: Path) -> None:
+    """The production backend never silently degrades: it raises on an unsupported host.
+
+    On a KVM host this test's premise does not hold, so it is skipped.
+    """
+    backend = MicroVMSandboxBackend(cas=CASStore(tmp_path / "cas"))
+    from bernstein.core.sandbox.backends._vmmonitor import FirecrackerMonitor
+
+    if not FirecrackerMonitor().preflight():
+        pytest.skip("host actually supports Firecracker; no-downgrade path not exercisable here")
+    with pytest.raises(MicroVMUnavailableError):
+        await backend.create(WorkspaceManifest(root="/workspace"))
+
+
+def test_canonical_image_roundtrip_and_traversal_guard(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    (src / "sub").mkdir(parents=True)
+    (src / "sub" / "f.txt").write_bytes(b"data")
+    (src / "top.txt").write_bytes(b"top")
+    image = canonical_workspace_image(src)
+    # deterministic: same tree -> same bytes
+    assert image == canonical_workspace_image(src)
+
+    dest = tmp_path / "dest"
+    extract_workspace_image(image, dest)
+    assert (dest / "sub" / "f.txt").read_bytes() == b"data"
+    assert (dest / "top.txt").read_bytes() == b"top"
+
+    # A hostile image with a traversal member is rejected.
+    import io
+    import tarfile
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w", format=tarfile.USTAR_FORMAT) as tar:
+        info = tarfile.TarInfo(name="../escape.txt")
+        payload = b"x"
+        info.size = len(payload)
+        tar.addfile(info, io.BytesIO(payload))
+    with pytest.raises(MicroVMUnavailableError):
+        extract_workspace_image(buf.getvalue(), tmp_path / "dest2")
+
+
+def test_extract_rejects_symlink_then_child_traversal(tmp_path: Path) -> None:
+    """A symlink escaping root, followed by a child written through it, is refused.
+
+    This is the TOCTOU a name-only pre-check misses: ``link -> ../../outside``
+    passes a name check, then ``link/pwned`` writes outside root once the link
+    exists. The stdlib ``data`` filter validates links at extraction time.
+    """
+    import io
+    import tarfile
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w", format=tarfile.USTAR_FORMAT) as tar:
+        link = tarfile.TarInfo(name="link")
+        link.type = tarfile.SYMTYPE
+        link.linkname = "../../outside"
+        tar.addfile(link)
+        child = tarfile.TarInfo(name="link/pwned.txt")
+        payload = b"escaped"
+        child.size = len(payload)
+        tar.addfile(child, io.BytesIO(payload))
+
+    with pytest.raises(MicroVMUnavailableError):
+        extract_workspace_image(buf.getvalue(), tmp_path / "dest3")
+    assert not (outside / "pwned.txt").exists()
+
+
+def test_extract_rejects_absolute_symlink(tmp_path: Path) -> None:
+    """A symlink whose target is an absolute path outside root is refused."""
+    import io
+    import tarfile
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w", format=tarfile.USTAR_FORMAT) as tar:
+        link = tarfile.TarInfo(name="evil")
+        link.type = tarfile.SYMTYPE
+        link.linkname = "/etc/passwd"
+        tar.addfile(link)
+
+    with pytest.raises(MicroVMUnavailableError):
+        extract_workspace_image(buf.getvalue(), tmp_path / "dest4")

--- a/tests/unit/sandbox/test_microvm_backend.py
+++ b/tests/unit/sandbox/test_microvm_backend.py
@@ -417,6 +417,30 @@ def test_tarfile_data_filter_version_matrix(
     assert _vmmonitor._tarfile_data_filter_is_patched() is expected
 
 
+def test_snapshot_digest_is_host_home_agnostic(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The canonical image is a pure function of workspace CONTENT - it must not
+    change with host state like ``$HOME``.
+
+    Guards against the v3.7.1-class bug where a receipt hash silently depended on
+    ``$HOME`` through a redaction helper, so an honest ledger verified on one
+    host and failed on another.
+    """
+    src = tmp_path / "src"
+    (src / "sub").mkdir(parents=True)
+    (src / "sub" / "b.txt").write_bytes(b"nested")
+    (src / "a.txt").write_bytes(b"deliverable")
+
+    monkeypatch.setenv("HOME", "/home/alice")
+    monkeypatch.setenv("USER", "alice")
+    image_alice = canonical_workspace_image(src)
+
+    monkeypatch.setenv("HOME", "/home/bob")
+    monkeypatch.setenv("USER", "bob")
+    image_bob = canonical_workspace_image(src)
+
+    assert image_alice == image_bob  # same content -> same bytes -> same digest
+
+
 def test_extract_rejects_absolute_symlink(tmp_path: Path) -> None:
     """A symlink whose target is an absolute path outside root is refused."""
     import io

--- a/tests/unit/sandbox/test_microvm_backend.py
+++ b/tests/unit/sandbox/test_microvm_backend.py
@@ -274,6 +274,56 @@ def test_extract_refuses_on_unpatched_cpython(tmp_path: Path, monkeypatch: pytes
         extract_workspace_image(image, tmp_path / "dest-unpatched")
 
 
+def test_extract_guard_runs_before_clearing_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """On an unpatched interpreter the refusal fires before *root* is emptied.
+
+    A doomed extraction must never destroy an already-populated destination -
+    the guard is checked before any filesystem mutation.
+    """
+    from bernstein.core.sandbox.backends import _vmmonitor
+
+    dest = tmp_path / "populated"
+    dest.mkdir()
+    (dest / "keep.txt").write_bytes(b"precious")
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.txt").write_bytes(b"hi")
+    image = canonical_workspace_image(src)
+
+    monkeypatch.setattr(_vmmonitor, "_tarfile_data_filter_is_patched", lambda: False)
+    with pytest.raises(MicroVMUnavailableError, match="CVE-2025-4517"):
+        extract_workspace_image(image, dest)
+    assert (dest / "keep.txt").read_bytes() == b"precious"
+
+
+@pytest.mark.raw_tarfile_filter
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        ((3, 11, 13, "final", 0), False),  # below the >=3.12 project floor -> refuse
+        ((3, 12, 10, "final", 0), False),
+        ((3, 12, 11, "final", 0), True),
+        ((3, 13, 3, "final", 0), False),
+        ((3, 13, 4, "final", 0), True),
+        ((3, 14, 0, "alpha", 7), False),  # 3.14 fix did not land until b3
+        ((3, 14, 0, "beta", 2), False),
+        ((3, 14, 0, "beta", 3), True),
+        ((3, 14, 0, "final", 0), True),
+        ((3, 15, 0, "final", 0), True),
+    ],
+)
+def test_tarfile_data_filter_version_matrix(
+    monkeypatch: pytest.MonkeyPatch,
+    version: tuple[int | str, ...],
+    expected: bool,
+) -> None:
+    from bernstein.core.sandbox.backends import _vmmonitor
+
+    monkeypatch.setattr(_vmmonitor.sys, "version_info", version)
+    assert _vmmonitor._tarfile_data_filter_is_patched() is expected
+
+
 def test_extract_rejects_absolute_symlink(tmp_path: Path) -> None:
     """A symlink whose target is an absolute path outside root is refused."""
     import io

--- a/tests/unit/sandbox/test_microvm_backend.py
+++ b/tests/unit/sandbox/test_microvm_backend.py
@@ -159,6 +159,99 @@ class _CloneFailsMonitor:
         self.shutdown_calls += 1
 
 
+class _BootFailsMonitor:
+    """A VMMonitor stub that 'allocates' during boot and then raises.
+
+    Mirrors a real monitor that starts a process/socket/tap device and then
+    fails partway through boot - the partially-started guest must still be torn
+    down. Records ``shutdown`` calls.
+    """
+
+    def __init__(self, root: str) -> None:
+        self._root = root
+        self.shutdown_calls = 0
+
+    @property
+    def workdir(self) -> str:
+        return self._root
+
+    async def boot(self, *, base_env: Mapping[str, str]) -> None:
+        raise RuntimeError("boot exploded after allocating")
+
+    async def exec(
+        self,
+        cmd: list[str],
+        *,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout: int | None = None,
+        stdin: bytes | None = None,
+    ) -> ExecResult:
+        raise AssertionError("unreachable: boot failed first")
+
+    async def write_file(self, path: str, data: bytes, *, mode: int = 0o644) -> None:
+        return None
+
+    async def read_file(self, path: str) -> bytes:
+        return b""
+
+    async def ls(self, path: str) -> list[str]:
+        return []
+
+    async def freeze_image(self) -> bytes:
+        return b""
+
+    async def restore_image(self, image: bytes) -> None:
+        return None
+
+    async def shutdown(self) -> None:
+        self.shutdown_calls += 1
+
+
+@pytest.mark.asyncio
+async def test_create_tears_down_guest_when_boot_fails(tmp_path: Path) -> None:
+    """A boot that raises after allocating must be shut down and register no session."""
+    monitors: list[_BootFailsMonitor] = []
+
+    def factory(root: str) -> _BootFailsMonitor:
+        monitor = _BootFailsMonitor(root)
+        monitors.append(monitor)
+        return monitor
+
+    backend = MicroVMSandboxBackend(monitor_factory=factory, cas=CASStore(tmp_path / "cas"))
+    with pytest.raises(RuntimeError, match="boot exploded"):
+        await backend.create(WorkspaceManifest(root="/workspace"))
+
+    assert monitors and monitors[0].shutdown_calls == 1
+    assert backend._sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_resume_tears_down_guest_when_boot_fails(tmp_path: Path) -> None:
+    """resume() likewise tears down a guest whose boot fails after allocating."""
+    cas = CASStore(tmp_path / "cas")
+    # Produce a real snapshot so resume() gets past its CAS lookup.
+    good = MicroVMSandboxBackend(monitor_factory=lambda root: FakeMonitor(root=root), cas=cas)
+    session = await good.create(WorkspaceManifest(root="/workspace"))
+    await session.write("x.txt", b"data")
+    digest = await session.snapshot()
+    await good.destroy(session)
+
+    monitors: list[_BootFailsMonitor] = []
+
+    def factory(root: str) -> _BootFailsMonitor:
+        monitor = _BootFailsMonitor(root)
+        monitors.append(monitor)
+        return monitor
+
+    backend = MicroVMSandboxBackend(monitor_factory=factory, cas=cas)
+    with pytest.raises(RuntimeError, match="boot exploded"):
+        await backend.resume(digest)
+
+    assert monitors and monitors[0].shutdown_calls == 1
+    assert backend._sessions == {}
+
+
 @pytest.mark.asyncio
 async def test_create_tears_down_guest_when_clone_fails(tmp_path: Path) -> None:
     """A non-zero ``git clone`` fails loudly and never leaks the booted monitor."""

--- a/tests/unit/sandbox/test_microvm_backend.py
+++ b/tests/unit/sandbox/test_microvm_backend.py
@@ -255,6 +255,25 @@ def test_extract_rejects_symlink_then_child_traversal(tmp_path: Path) -> None:
     assert not (outside / "pwned.txt").exists()
 
 
+def test_extract_refuses_on_unpatched_cpython(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Extraction is refused when the tarfile 'data' filter predates its CVE fix.
+
+    The ``data`` filter is the only defence for an untrusted guest image, so on
+    a build where it can be bypassed the backend must refuse rather than extract
+    behind a broken guarantee.
+    """
+    from bernstein.core.sandbox.backends import _vmmonitor
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.txt").write_bytes(b"hi")
+    image = canonical_workspace_image(src)
+
+    monkeypatch.setattr(_vmmonitor, "_tarfile_data_filter_is_patched", lambda: False)
+    with pytest.raises(MicroVMUnavailableError, match="CVE-2025-4517"):
+        extract_workspace_image(image, tmp_path / "dest-unpatched")
+
+
 def test_extract_rejects_absolute_symlink(tmp_path: Path) -> None:
     """A symlink whose target is an absolute path outside root is refused."""
     import io

--- a/tests/unit/sandbox/test_sandbox_cli.py
+++ b/tests/unit/sandbox/test_sandbox_cli.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
 from click.testing import CliRunner
 
 from bernstein.cli.commands.sandbox_cmd import sandbox_group
@@ -54,3 +55,67 @@ def test_fork_race_absent_base_fails_cleanly_without_minting_key(tmp_path: Path)
     assert exit_code == 1
     assert "not found in CAS" in output
     assert not key_minted
+
+
+@pytest.mark.asyncio
+async def test_receipt_verify_distinguishes_ok_tampered_absent(tmp_path: Path) -> None:
+    """`receipt verify` gives three different answers: OK (0), tampered (1), and
+    absent/cannot-verify (2). Absent must NOT read as tampering."""
+    from bernstein.core.orchestration.best_of_n import CandidateResult
+    from bernstein.core.persistence.cas_store import CASStore
+    from bernstein.core.sandbox.backends._vmmonitor import FakeMonitor
+    from bernstein.core.sandbox.backends.microvm import MicroVMSandboxBackend
+    from bernstein.core.sandbox.fork_race import fork_race
+    from bernstein.core.sandbox.manifest import FileEntry, WorkspaceManifest
+    from bernstein.core.sandbox.selection_receipt import load_or_create_signing_key, write_receipt
+
+    cas_dir = tmp_path / "cas"
+    cas = CASStore(cas_dir)
+    backend = MicroVMSandboxBackend(monitor_factory=lambda root: FakeMonitor(root=root), cas=cas)
+    key = load_or_create_signing_key(tmp_path / "k.key")
+
+    base_session = await backend.create(
+        WorkspaceManifest(root="/workspace", files=(FileEntry(path="b.txt", content=b"BASE"),)),
+    )
+    base = await base_session.snapshot()
+    await backend.destroy(base_session)
+
+    async def run_candidate(session: object, index: int) -> CandidateResult:
+        await session.write(f"c{index}.txt", f"work-{index}".encode())  # type: ignore[attr-defined]
+        return CandidateResult(task_id=f"candidate-{index}", tests_passing=index == 0)
+
+    receipt = await fork_race(
+        backend=backend,
+        base_snapshot_digest=base,
+        run_candidate=run_candidate,
+        k=2,
+        signing_key=key,
+    )
+    receipt_path = tmp_path / "receipt.json"
+    write_receipt(receipt_path, receipt)
+
+    runner = CliRunner()
+    args = ["receipt", "verify", str(receipt_path), "--cas-dir", str(cas_dir)]
+
+    ok = runner.invoke(sandbox_group, args)
+    assert ok.exit_code == 0, ok.output
+    assert "OK" in ok.output
+
+    # Absent loser blob -> cannot-verify / INCOMPLETE (exit 2), not tampering.
+    loser = receipt.loser_snapshot_digests[0]
+    (cas.root / loser[:2] / loser).unlink()
+    inc = runner.invoke(sandbox_group, args)
+    assert inc.exit_code == 2, inc.output
+    assert "cannot-verify" in inc.output.lower()
+    assert "INCOMPLETE" in inc.output  # verdict is "incomplete", not a hard tamper failure
+    assert "FAILED" not in inc.output
+    assert "tampered:" not in inc.output.lower()  # no per-blob tampered finding line
+
+    # Tampered base blob (present, wrong hash) -> FAILED (exit 1), takes precedence.
+    blob = cas.root / base[:2] / base
+    corrupt = bytearray(blob.read_bytes())
+    corrupt[3] ^= 0xFF
+    blob.write_bytes(bytes(corrupt))
+    bad = runner.invoke(sandbox_group, args)
+    assert bad.exit_code == 1, bad.output
+    assert "tampered" in bad.output.lower()

--- a/tests/unit/sandbox/test_sandbox_cli.py
+++ b/tests/unit/sandbox/test_sandbox_cli.py
@@ -1,0 +1,56 @@
+"""CLI-surface tests for ``bernstein sandbox fork-race`` base validation (#2613).
+
+These pin the guard added in response to review: a malformed *or* absent
+``--base`` must fail as a clean ``ClickException`` (exit 1, no traceback) and,
+critically, *before* any side-effectful state - no Ed25519 signing key is
+minted for a doomed run.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from click.testing import CliRunner
+
+from bernstein.cli.commands.sandbox_cmd import sandbox_group
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _invoke(base: str, tmp_path: Path) -> tuple[int, str, bool]:
+    key_path = tmp_path / "keys" / "selection.key"
+    result = CliRunner().invoke(
+        sandbox_group,
+        [
+            "fork-race",
+            "--base",
+            base,
+            "--cmd",
+            "true",
+            "--out",
+            str(tmp_path / "receipt.json"),
+            "--cas-dir",
+            str(tmp_path / "cas"),
+            "--key",
+            str(key_path),
+            "--audit-dir",
+            str(tmp_path / "audit"),
+        ],
+    )
+    return result.exit_code, (result.output or ""), key_path.exists()
+
+
+def test_fork_race_malformed_base_fails_cleanly_without_minting_key(tmp_path: Path) -> None:
+    exit_code, output, key_minted = _invoke("not-a-hex-digest", tmp_path)
+    assert exit_code == 1
+    assert "invalid base snapshot digest" in output
+    assert not key_minted
+
+
+def test_fork_race_absent_base_fails_cleanly_without_minting_key(tmp_path: Path) -> None:
+    # Well-formed 64-char hex digest that is simply not present in the CAS.
+    exit_code, output, key_minted = _invoke("0" * 64, tmp_path)
+    assert exit_code == 1
+    assert "not found in CAS" in output
+    assert not key_minted

--- a/tests/unit/sandbox/test_selection_receipt.py
+++ b/tests/unit/sandbox/test_selection_receipt.py
@@ -16,6 +16,7 @@ from bernstein.core.sandbox.selection_receipt import (
     SelectionReceiptError,
     build_selection_receipt,
     canonical_receipt_bytes,
+    keyid_for,
     load_or_create_signing_key,
     read_receipt_file,
     receipt_from_dict,
@@ -64,6 +65,26 @@ def test_signed_receipt_verifies() -> None:
     signed = _build_signed(key)
     result = verify_receipt(signed)
     assert result.ok, result.errors
+
+
+def test_verify_receipt_expected_keyid_binds_to_trusted_signer() -> None:
+    """``expected_keyid`` rejects a validly-signed, self-consistent receipt
+    that was signed by anyone other than the named trusted signer."""
+    key = Ed25519PrivateKey.generate()
+    signed = _build_signed(key)
+
+    # The correct trusted keyid still accepts.
+    assert verify_receipt(signed, expected_keyid=signed.keyid).ok
+
+    # A receipt re-signed under a *different* key is self-consistent (its own
+    # keyid matches its own embedded key) yet must be rejected against the
+    # trusted keyid - this is the attack the check closes.
+    attacker = Ed25519PrivateKey.generate()
+    forged = _build_signed(attacker)
+    assert verify_receipt(forged).ok  # self-consistent on its own
+    result = verify_receipt(forged, expected_keyid=keyid_for(key.public_key()))
+    assert not result.ok
+    assert any("trusted signer" in e for e in result.errors)
 
 
 def test_receipt_is_byte_identical_across_builds_with_same_key() -> None:

--- a/tests/unit/sandbox/test_selection_receipt.py
+++ b/tests/unit/sandbox/test_selection_receipt.py
@@ -1,0 +1,163 @@
+"""Unit tests for the fork-race selection receipt (#2613).
+
+These pin the receipt's determinism and offline-verifiability contract:
+canonical bytes are stable, the signed body carries no wall-clock/chain
+field, verify cross-checks the derived winner + loser digests, a single
+mutated byte fails verification, and a NaN score is refused at build time.
+"""
+
+from __future__ import annotations
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from bernstein.core.sandbox.selection_receipt import (
+    RaceCandidate,
+    SelectionReceiptError,
+    build_selection_receipt,
+    canonical_receipt_bytes,
+    load_or_create_signing_key,
+    read_receipt_file,
+    receipt_from_dict,
+    receipt_to_dict,
+    sign_receipt,
+    snapshot_digests,
+    verify_receipt,
+    write_receipt,
+)
+
+_D = "0123456789abcdef" * 4  # a 64-char hex-ish stand-in digest
+
+
+def _cand(task_id: str, digest: str, tests: bool = True) -> RaceCandidate:
+    return RaceCandidate(
+        task_id=task_id,
+        terminal_snapshot_digest=digest,
+        score_vector={"correctness": 1.0 if tests else 0.0, "cost": 0.0, "reversibility": 1.0},
+    )
+
+
+def _build_signed(key: Ed25519PrivateKey):
+    receipt = build_selection_receipt(
+        base_snapshot_digest="a" * 64,
+        candidates=[_cand("candidate-1", "b" * 64), _cand("candidate-0", "c" * 64, tests=False)],
+        winner_task_id="candidate-1",
+        ranker_profile={"method": "topsis", "criteria": []},
+        public_key=key.public_key(),
+    )
+    return sign_receipt(receipt, private_key=key)
+
+
+def test_build_orders_candidates_and_derives_losers() -> None:
+    key = Ed25519PrivateKey.generate()
+    signed = _build_signed(key)
+    # candidates sorted by task_id
+    assert [c["task_id"] for c in signed.candidates] == ["candidate-0", "candidate-1"]
+    # winner digest derived from the winning candidate
+    assert signed.winner_snapshot_digest == "b" * 64
+    # loser is the single non-winner candidate's digest
+    assert signed.loser_snapshot_digests == ("c" * 64,)
+
+
+def test_signed_receipt_verifies() -> None:
+    key = Ed25519PrivateKey.generate()
+    signed = _build_signed(key)
+    result = verify_receipt(signed)
+    assert result.ok, result.errors
+
+
+def test_receipt_is_byte_identical_across_builds_with_same_key() -> None:
+    key = Ed25519PrivateKey.generate()
+    a = _build_signed(key)
+    b = _build_signed(key)
+    assert canonical_receipt_bytes(a) == canonical_receipt_bytes(b)
+    assert a.signature_b64 == b.signature_b64
+    assert receipt_to_dict(a) == receipt_to_dict(b)
+
+
+def test_dict_roundtrip_preserves_verification() -> None:
+    key = Ed25519PrivateKey.generate()
+    signed = _build_signed(key)
+    restored = receipt_from_dict(receipt_to_dict(signed))
+    assert verify_receipt(restored).ok
+
+
+def test_single_byte_mutation_fails_verification() -> None:
+    key = Ed25519PrivateKey.generate()
+    signed = _build_signed(key)
+    tampered = receipt_to_dict(signed)
+    tampered["winner_task_id"] = "candidate-0"  # lie about the winner
+    result = verify_receipt(receipt_from_dict(tampered))
+    assert not result.ok
+
+
+def test_winner_digest_tamper_is_caught() -> None:
+    key = Ed25519PrivateKey.generate()
+    signed = _build_signed(key)
+    tampered = receipt_to_dict(signed)
+    tampered["winner_snapshot_digest"] = "d" * 64
+    result = verify_receipt(receipt_from_dict(tampered))
+    assert not result.ok
+
+
+def test_unsigned_receipt_does_not_verify() -> None:
+    key = Ed25519PrivateKey.generate()
+    receipt = build_selection_receipt(
+        base_snapshot_digest="a" * 64,
+        candidates=[_cand("candidate-0", "b" * 64)],
+        winner_task_id="candidate-0",
+        ranker_profile={},
+        public_key=key.public_key(),
+    )
+    assert not verify_receipt(receipt).ok
+
+
+def test_nan_score_is_refused_at_build() -> None:
+    key = Ed25519PrivateKey.generate()
+    with pytest.raises((ValueError, SelectionReceiptError)):
+        build_selection_receipt(
+            base_snapshot_digest="a" * 64,
+            candidates=[RaceCandidate("candidate-0", "b" * 64, {"correctness": float("nan")})],
+            winner_task_id="candidate-0",
+            ranker_profile={},
+            public_key=key.public_key(),
+        )
+
+
+def test_unknown_winner_is_rejected() -> None:
+    key = Ed25519PrivateKey.generate()
+    with pytest.raises(SelectionReceiptError):
+        build_selection_receipt(
+            base_snapshot_digest="a" * 64,
+            candidates=[_cand("candidate-0", "b" * 64)],
+            winner_task_id="candidate-9",
+            ranker_profile={},
+            public_key=key.public_key(),
+        )
+
+
+def test_snapshot_digests_covers_base_and_all_candidates() -> None:
+    key = Ed25519PrivateKey.generate()
+    signed = _build_signed(key)
+    digs = snapshot_digests(signed)
+    assert "a" * 64 in digs  # base
+    assert "b" * 64 in digs  # winner
+    assert "c" * 64 in digs  # loser
+
+
+def test_write_and_read_roundtrip(tmp_path) -> None:
+    key = Ed25519PrivateKey.generate()
+    signed = _build_signed(key)
+    path = tmp_path / "receipt.json"
+    write_receipt(path, signed)
+    loaded = read_receipt_file(path)
+    assert loaded is not None
+    assert verify_receipt(loaded).ok
+
+
+def test_signing_key_is_created_and_reused(tmp_path) -> None:
+    key_path = tmp_path / "keys" / "selection.key"
+    k1 = load_or_create_signing_key(key_path)
+    k2 = load_or_create_signing_key(key_path)
+    # Same key material reused -> same public bytes.
+    assert k1.public_key().public_bytes_raw() == k2.public_key().public_bytes_raw()

--- a/tests/unit/sandbox/test_selection_receipt.py
+++ b/tests/unit/sandbox/test_selection_receipt.py
@@ -99,6 +99,40 @@ def test_verify_receipt_expected_keyid_tolerates_none_keyid() -> None:
     assert any("trusted signer" in e for e in result.errors)
 
 
+def test_build_rejects_duplicate_or_empty_task_ids() -> None:
+    """Duplicate/empty task_ids would collapse in the candidate map, dropping a
+    candidate's terminal snapshot from the signed receipt - reject at build."""
+    key = Ed25519PrivateKey.generate()
+    with pytest.raises(SelectionReceiptError, match="unique"):
+        build_selection_receipt(
+            base_snapshot_digest="a" * 64,
+            candidates=[_cand("dup", "b" * 64), _cand("dup", "c" * 64)],
+            winner_task_id="dup",
+            ranker_profile={"method": "topsis", "criteria": []},
+            public_key=key.public_key(),
+        )
+    with pytest.raises(SelectionReceiptError, match="non-empty"):
+        build_selection_receipt(
+            base_snapshot_digest="a" * 64,
+            candidates=[_cand("", "b" * 64)],
+            winner_task_id="",
+            ranker_profile={"method": "topsis", "criteria": []},
+            public_key=key.public_key(),
+        )
+
+
+def test_verify_rejects_duplicate_candidate_task_ids() -> None:
+    """A deserialised receipt whose candidate list has a collision must fail
+    verification rather than silently collapsing on the task_id map."""
+    key = Ed25519PrivateKey.generate()
+    signed = _build_signed(key)
+    tampered = receipt_to_dict(signed)
+    tampered["candidates"] = [dict(tampered["candidates"][0]), dict(tampered["candidates"][0])]
+    result = verify_receipt(receipt_from_dict(tampered))
+    assert not result.ok
+    assert any("not unique" in e for e in result.errors)
+
+
 def test_receipt_is_byte_identical_across_builds_with_same_key() -> None:
     key = Ed25519PrivateKey.generate()
     a = _build_signed(key)

--- a/tests/unit/sandbox/test_selection_receipt.py
+++ b/tests/unit/sandbox/test_selection_receipt.py
@@ -87,6 +87,18 @@ def test_verify_receipt_expected_keyid_binds_to_trusted_signer() -> None:
     assert any("trusted signer" in e for e in result.errors)
 
 
+def test_verify_receipt_expected_keyid_tolerates_none_keyid() -> None:
+    """A receipt carrying a ``None`` keyid must report a mismatch, not TypeError."""
+    import dataclasses
+
+    key = Ed25519PrivateKey.generate()
+    signed = _build_signed(key)
+    forged = dataclasses.replace(signed, keyid=None)  # type: ignore[arg-type]
+    result = verify_receipt(forged, expected_keyid="deadbeef")
+    assert not result.ok
+    assert any("trusted signer" in e for e in result.errors)
+
+
 def test_receipt_is_byte_identical_across_builds_with_same_key() -> None:
     key = Ed25519PrivateKey.generate()
     a = _build_signed(key)


### PR DESCRIPTION
## What

Adds a `microvm` sandbox backend, a content-addressed VM snapshot format, and a deterministic **fork-and-race** primitive that emits an **Ed25519-signed selection receipt**, plus `bernstein sandbox fork-race` and `bernstein sandbox receipt verify` CLI commands.

Closes #2613.

## Why

The sandbox layer had two gaps #2613 calls out:

1. **Isolation gap** — every existing backend isolates *files* only; none isolate the kernel / network namespace / PID tree at a hardware boundary.
2. **Determinism gap** — best-of-N spawns K candidates from scratch in separate worktrees, so the "race" never provably starts from one identical captured state and the winner isn't attributable to the candidate's work alone.

## How

- **Content-addressed snapshots.** `snapshot()` freezes the workspace into a canonicalised image (sorted paths, zeroed mtimes/uids, normalised modes — deterministic given identical contents), stores it in the CAS store (`.sdd/cas`), and returns the **SHA-256 digest** as the snapshot id. `resume(digest)` reads the blob back with integrity verification on, so a tampered snapshot fails its CAS check before any state boots.
- **`fork_race()`** resumes K candidates from **one** content-addressed base digest and selects the winner via the existing TOPSIS ranker (`select_winner` / `multi_criteria_rank`) — **no LLM in the selection path**. Ranking is wall-clock-free and candidate order is fixed *before* ranking, so the same race twice produces a **byte-identical** signed receipt.
- **`SelectionReceipt`** — canonical JSON, Ed25519-signed, chain-position-agnostic (no wall-clock / run-id in the signed body). Every loser is recorded as a lineage sibling; the receipt is appended to the HMAC audit chain in exactly one serialised call. `sandbox receipt verify` re-checks the signature and re-hashes **base + winner + every loser** against CAS.
- **Acceptance test** (issue's empirical gate): same race twice → byte-identical receipts verifying under the pubkey; mutating a **loser** blob makes `receipt verify` fail.

### Scope note — Firecracker VM boot is experimental (not yet implemented)

The backend ships the host **preflight** and the strict **no-silent-downgrade** contract: an explicit `sandbox.backend: microvm` on a host without KVM fails loudly with `MicroVMUnavailableError` rather than degrading to a worktree. The full Firecracker boot lifecycle (API socket, drives, networking, `InstanceStart`, and an in-guest vsock agent for exec/file-IO) is a tracked follow-up — it needs a KVM-capable Linux host plus an operator-supplied kernel/rootfs/agent and cannot be built or validated without `/dev/kvm`. The deterministic snapshot / fork-race / receipt machinery — the issue's through-line — is complete and fully tested host-independently over a `FakeMonitor` (which really executes commands and really freezes the workspace, so the tests exercise the real content-addressing/signing substrate, not a mock echo). The real boot is covered by an opt-in, KVM-gated integration test.

## Review

Pre-merge reviewed by an independent security pass on the design and a cross-model adversarial pass on the diff. Two findings were fixed with regression tests: snapshot-restore hardened against symlink-then-child traversal (`extractall(filter="data")`), and a cross-process lock added around the single audit-chain append.

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run ruff format src/` clean
- [x] `uv run pyright src/` passes (new modules: 0 errors)
- [x] `uv run lint-imports` passes (architecture contracts kept)
- [x] `uv run python scripts/run_tests.py -k microvm|selection_receipt|fork_race` passes
- [x] New code has type hints + Google-style docstrings

### Documentation duty

- [x] Architecture / new module: `docs/architecture/sandbox.md` updated and `uv run bernstein agents-md sync` run
- [x] Tests cover the documented behaviour (determinism + tamper acceptance, conformance suite, traversal/lock regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **MicroVM** sandbox backend with deterministic, content-addressed workspace snapshotting and resume.
  * Introduced deterministic **fork-and-race** selection that outputs **Ed25519-signed, offline-verifiable receipts** with audit-chain support.
  * Added CLI support to run `fork-race` and to **verify** receipts (including CAS-integrity checks).
* **Documentation**
  * Updated architecture docs with MicroVM backend details and receipt verification semantics.
* **Bug Fixes**
  * Hardened snapshot archive handling (secure extraction and tamper-resistant digest verification).
* **Tests**
  * Added unit coverage for determinism/verification and MicroVM behavior, plus opt-in Firecracker integration tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- review-bot acknowledgements -->
## Review-bot acknowledgements
<!-- bot-ack: 3609755137 reason=fixed in 1631eb8b - tarfile data-filter matrix now requires CPython 3.14.0b3+ (rejects 3.14 alpha/b1/b2), covered by test_tarfile_data_filter_version_matrix -->
