### PR TITLE
fix(sandbox): route receipt verify through one shared verdict; anchor by default (#2705)

### DIFF
--- a/docs/architecture/sandbox.md
+++ b/docs/architecture/sandbox.md
@@ -183,7 +183,28 @@ bernstein sandbox fork-race --base <sha256> --k 3 --cmd 'make test' --out receip
 # against CAS. Proves signed + CAS-intact; NOT that it was chain-appended
 # (that is the audit log's own verify).
 bernstein sandbox receipt verify receipt.json
+
+# Anchor the check to a known signer. WITHOUT this the signature is only
+# checked for self-consistency (a receipt re-signed under any key still
+# passes) - so an unanchored verify never exits 0.
+bernstein sandbox receipt verify receipt.json --expected-keyid <keyid>
 ```
+
+**Exit codes.** `receipt verify` distinguishes every outcome so a CLI-scripted
+gate can branch on them; the same verdict is computed once (`verify_receipt_full`
+→ `FullReceiptVerdict`) and shared by the CLI and the library, so the two can
+never disagree. A malformed or unreadable receipt file yields a clean
+diagnosable error, never a traceback.
+
+| Code | Verdict | Meaning |
+|---|---|---|
+| 0 | `verified` | Anchored to the expected signer, signature + consistency intact, and every named blob (base + winner + losers) re-hashed intact against CAS. |
+| 1 | `failed` | Bad signature/consistency, a **tampered** blob (present, wrong hash), or a **malformed** digest field. Highest precedence — an integrity alarm. |
+| 4 | `unreadable` | A named blob could not be read on this host (permissions, or an anomalous symlinked blob the verifier refuses to dereference). A property of the reader, not the record. |
+| 2 | `incomplete` | A named blob is **absent** from CAS (GC / retention / restart). An ordinary operational event, never conflated with tampering. |
+| 3 | `unanchored` | Signature + blobs check out, but no `--expected-keyid` was given, so *whose* key signed it is unproven. |
+
+Precedence when several apply: `failed` > `unreadable` > `absent` > `unanchored` > `verified`.
 
 `fork-race` requires a microVM-capable host; on an unsupported host it
 fails loudly. The determinism/tamper guarantees are validated

--- a/docs/architecture/sandbox.md
+++ b/docs/architecture/sandbox.md
@@ -202,9 +202,9 @@ diagnosable error, never a traceback.
 | 1 | `failed` | Bad signature/consistency, a **tampered** blob (present, wrong hash), or a **malformed** digest field. Highest precedence — an integrity alarm. |
 | 4 | `unreadable` | A named blob could not be read on this host (permissions, or an anomalous symlinked blob the verifier refuses to dereference). A property of the reader, not the record. |
 | 2 | `incomplete` | A named blob is **absent** from CAS (GC / retention / restart). An ordinary operational event, never conflated with tampering. |
-| 3 | `unanchored` | Signature + blobs check out, but no `--expected-keyid` was given, so *whose* key signed it is unproven. |
+| 3 | `unanchored` | Signature + blobs check out, but `--expected-keyid` was omitted or empty (an unset env var counts as empty), so *whose* key signed it is unproven. |
 
-Precedence when several apply: `failed` > `unreadable` > `absent` > `unanchored` > `verified`.
+Precedence when several apply: `failed` > `unreadable` > `incomplete` (absent) > `unanchored` > `verified`.
 
 `fork-race` requires a microVM-capable host; on an unsupported host it
 fails loudly. The determinism/tamper guarantees are validated

--- a/src/bernstein/cli/commands/sandbox_cmd.py
+++ b/src/bernstein/cli/commands/sandbox_cmd.py
@@ -312,80 +312,144 @@ def receipt_group() -> None:
 def receipt_verify_cmd(receipt_path: Path, cas_dir: Path, expected_keyid: str | None) -> None:
     """Verify a receipt's signature and re-hash every snapshot blob in CAS.
 
-    Proves the receipt is *properly signed and internally consistent* and
-    that every snapshot it names (base + winner + every loser) still exists
-    and re-hashes correctly in CAS. With ``--expected-keyid`` it additionally
-    proves the receipt was signed by that trusted signer. It does NOT prove
-    the receipt was appended to the audit chain - that is the audit log's own
-    ``verify``.
+    Proves the receipt is *properly signed and internally consistent* and that
+    every snapshot it names (base + winner + every loser) still exists and
+    re-hashes correctly in CAS. With ``--expected-keyid`` it additionally proves
+    the receipt was signed by that trusted signer. It does NOT prove the receipt
+    was appended to the audit chain - that is the audit log's own ``verify``.
 
-    Exit codes give three distinct answers (an absent blob is an operational
-    event, not proof of tampering, and must not read as one):
+    The CLI and the library derive the verdict from one shared definition
+    (:func:`~bernstein.core.sandbox.selection_receipt.verify_receipt_full`), so
+    the two can never disagree. Exit codes, strongest reason first:
 
-    * ``0`` - signed, consistent, and every named blob re-hashed intact.
-    * ``1`` - invalid signature/consistency, or a blob is **tampered**
-      (present but hash-mismatched).
-    * ``2`` - authentic and untampered, but a blob is **absent** from CAS, so
-      the content re-hash could not be completed (verification incomplete).
+    * ``1`` - invalid signature/consistency, or a blob is **tampered** (present
+      but hash-mismatched). Takes precedence over everything below.
+    * ``4`` - a blob is present but **unreadable** on this host (a permissions
+      problem here, never a claim about the record).
+    * ``2`` - authentic and untampered, but a blob is **absent** from CAS
+      (GC / retention / restart), so the content re-hash is incomplete.
+    * ``3`` - signed, consistent, blobs intact, but **unanchored**: no
+      ``--expected-keyid`` was given, so the signer was not checked. A receipt
+      re-signed under any other key would look identical, so this never exits 0.
+    * ``0`` - signed, anchored to the trusted signer, and every named blob
+      re-hashed intact.
     """
     from bernstein.core.persistence.cas_store import CASIntegrityError, CASStore
     from bernstein.core.sandbox.selection_receipt import (
+        BLOB_ABSENT,
+        BLOB_INTACT,
+        BLOB_TAMPERED,
+        BLOB_UNREADABLE,
         read_receipt_file,
-        snapshot_digests,
-        verify_receipt,
+        verify_receipt_full,
     )
 
     receipt = read_receipt_file(receipt_path)
     if receipt is None:
-        raise click.ClickException(f"Could not read a selection receipt from {receipt_path}")
-
-    verification = verify_receipt(receipt, expected_keyid=expected_keyid)
-    for err in verification.errors:
-        console.print(f"[red]signature/consistency:[/red] {err}")
+        raise click.ClickException(
+            f"Could not read a selection receipt from {receipt_path} "
+            "(missing, unreadable, or not a valid receipt JSON).",
+        )
 
     cas = CASStore(cas_dir)
-    # Distinguish two very different CAS outcomes (a hard lesson from the v3.7.1
-    # hardening wave): a blob that is *present but hash-mismatched* is tampering,
-    # while a blob that is simply *absent* is an ordinary operational event (GC,
-    # log retention, a restart). Conflating them turns a retry into a permanent
-    # "tampered" verdict on an append-only chain, so they get different answers.
-    tampered: list[str] = []
-    absent: list[str] = []
-    digests = snapshot_digests(receipt)
-    for digest in digests:
+
+    def _blob_status(digest: str) -> str:
+        # Classify one blob for verify_receipt_full. Four outcomes, never
+        # conflated: tampered (present, wrong hash) is an integrity alarm;
+        # absent (GC / retention / restart) is an ordinary operational event;
+        # unreadable (a permissions problem *on this host*) is a property of the
+        # reader, not the record; intact is the clean case.
         try:
             blob = cas.get(digest, verify=True)
-        except CASIntegrityError as exc:
-            tampered.append(str(exc))
-            continue
-        if blob is None:
-            absent.append(digest)
+        except CASIntegrityError:
+            return BLOB_TAMPERED
+        except FileNotFoundError:
+            # The blob vanished between the store's exists() and read (GC /
+            # retention race). That is genuinely absent, not a reader-side
+            # failure - classify it before the broad OSError below.
+            return BLOB_ABSENT
+        except (OSError, ValueError):
+            # OSError: present but unreadable (e.g. an unreadable blob file) - a
+            # reader-side failure. ValueError: the store rejects a non-64-hex
+            # digest; defensive only, since verify_receipt_full already filters
+            # malformed digests before calling this - but never crash here.
+            return BLOB_UNREADABLE
+        if blob is not None:
+            return BLOB_INTACT
+        # get() returned None. Path.exists() and os.access both *suppress*
+        # permission errors, so either would let an unreadable CAS directory
+        # masquerade as an absent blob - the exact false accusation #2705 is
+        # about. Stat the blob path directly (stat raises, it does not suppress)
+        # and let the errno decide: FileNotFoundError is genuinely absent; any
+        # other OSError (a permission/traversal failure anywhere on the path) is
+        # a reader-side problem, reported as unreadable, never as a claim about
+        # the record. A stat that succeeds while get() returned None means the
+        # blob is present but could not be read, which is also unreadable.
+        blob_path = cas_dir / digest[:2] / digest
+        try:
+            blob_path.stat()
+        except FileNotFoundError:
+            return BLOB_ABSENT
+        except OSError:
+            return BLOB_UNREADABLE
+        return BLOB_UNREADABLE
 
-    for err in verification.errors:
+    result = verify_receipt_full(receipt, expected_keyid=expected_keyid, blob_status=_blob_status)
+
+    for err in result.signature_errors:
         console.print(f"[red]signature/consistency:[/red] {err}")
-    for err in tampered:
-        console.print(f"[red]tampered:[/red] {err}")
-    for digest in absent:
+    for digest in result.malformed:
+        console.print(
+            f"[red]malformed:[/red] receipt names a digest that is not 64 hex chars: {digest!r}",
+        )
+    for digest in result.tampered:
+        console.print(f"[red]tampered:[/red] snapshot blob present but hash-mismatched: {digest}")
+    for digest in result.unreadable:
+        console.print(
+            f"[yellow]unreadable:[/yellow] snapshot blob present but not readable on this host: "
+            f"{digest} (a permissions problem here, not a claim about the record)",
+        )
+    for digest in result.absent:
         console.print(
             f"[yellow]cannot-verify:[/yellow] snapshot blob absent from CAS: {digest} "
             "(absent != tampered - likely GC / retention / restart)",
         )
+    if not result.anchored:
+        console.print(
+            "[yellow]unanchored:[/yellow] no --expected-keyid given, so the signer was NOT "
+            "checked - a receipt re-signed under any other key would look identical. "
+            "Pass --expected-keyid <trusted keyid> to establish trust.",
+        )
 
-    # Three answers, three exit codes (see the command docstring).
-    if not verification.ok or tampered:
+    if result.verdict == "failed":
         console.print("[red]FAILED[/red] receipt is invalid or a snapshot blob is tampered.")
-        raise click.exceptions.Exit(code=1)
-    if absent:
+    elif result.verdict == "unreadable":
+        console.print(
+            f"[yellow]UNREADABLE[/yellow] {len(result.unreadable)} of {result.digests_checked} "
+            "snapshot blob(s) could not be read on this host; verification is incomplete "
+            "(a reader-side problem, not a claim about the record).",
+        )
+    elif result.verdict == "incomplete":
         console.print(
             f"[yellow]INCOMPLETE[/yellow] receipt is authentic and consistent, but "
-            f"{len(absent)} of {len(digests)} snapshot blob(s) are absent from CAS; "
-            "content re-hash could not be completed (this is not tampering).",
+            f"{len(result.absent)} of {result.digests_checked} snapshot blob(s) are absent from "
+            "CAS; content re-hash could not be completed (this is not tampering).",
         )
-        raise click.exceptions.Exit(code=2)
-    console.print(
-        f"[green]OK[/green] receipt signed + all {len(digests)} snapshot digests intact "
-        "(proves signed + CAS-intact; not chain-appended).",
-    )
+    elif result.verdict == "unanchored":
+        console.print(
+            f"[yellow]UNANCHORED[/yellow] receipt is self-consistent and all "
+            f"{result.digests_checked} snapshot blob(s) are intact, but the signer was not "
+            "verified (no trust anchor); re-run with --expected-keyid to exit 0.",
+        )
+    else:
+        console.print(
+            f"[green]OK[/green] receipt signed by the trusted signer + all "
+            f"{result.digests_checked} snapshot digests intact "
+            "(proves signed + anchored + CAS-intact; not chain-appended).",
+        )
+
+    if result.exit_code:
+        raise click.exceptions.Exit(code=result.exit_code)
 
 
 __all__ = [

--- a/src/bernstein/cli/commands/sandbox_cmd.py
+++ b/src/bernstein/cli/commands/sandbox_cmd.py
@@ -359,6 +359,25 @@ def receipt_verify_cmd(receipt_path: Path, cas_dir: Path, expected_keyid: str | 
         # absent (GC / retention / restart) is an ordinary operational event;
         # unreadable (a permissions problem *on this host*) is a property of the
         # reader, not the record; intact is the clean case.
+        # Ask the store for the path (single source of truth for the shard
+        # layout) rather than re-deriving cas_dir / digest[:2] / digest here.
+        try:
+            blob_path = cas.blob_path(digest)
+        except ValueError:
+            # Non-64-hex digest; defensive only - verify_receipt_full filters
+            # malformed digests before calling this - but never crash here.
+            return BLOB_UNREADABLE
+        # A content-addressed store only ever writes regular files. A blob path
+        # that is a symlink is an anomalous / hostile record: dereferencing it
+        # could read an attacker-chosen path or block on a FIFO/device before the
+        # hash check ever runs. Refuse to follow it - is_symlink() uses lstat and
+        # does not dereference - and report unreadable (we will not vouch for
+        # bytes we decline to read), never intact.
+        try:
+            if blob_path.is_symlink():
+                return BLOB_UNREADABLE
+        except OSError:
+            return BLOB_UNREADABLE
         try:
             blob = cas.get(digest, verify=True)
         except CASIntegrityError:
@@ -385,7 +404,6 @@ def receipt_verify_cmd(receipt_path: Path, cas_dir: Path, expected_keyid: str | 
         # a reader-side problem, reported as unreadable, never as a claim about
         # the record. A stat that succeeds while get() returned None means the
         # blob is present but could not be read, which is also unreadable.
-        blob_path = cas_dir / digest[:2] / digest
         try:
             blob_path.stat()
         except FileNotFoundError:

--- a/src/bernstein/cli/commands/sandbox_cmd.py
+++ b/src/bernstein/cli/commands/sandbox_cmd.py
@@ -361,37 +361,31 @@ def receipt_verify_cmd(receipt_path: Path, cas_dir: Path, expected_keyid: str | 
         # reader, not the record; intact is the clean case.
         # Ask the store for the path (single source of truth for the shard
         # layout) rather than re-deriving cas_dir / digest[:2] / digest here.
+        # Used only for the absent/unreadable disambiguation below; the symlink
+        # defence lives in cas.get (O_NOFOLLOW), atomically and race-free - no
+        # is_symlink() pre-check here, which would only add a TOCTOU window.
         try:
             blob_path = cas.blob_path(digest)
         except ValueError:
             # Non-64-hex digest; defensive only - verify_receipt_full filters
             # malformed digests before calling this - but never crash here.
             return BLOB_UNREADABLE
-        # A content-addressed store only ever writes regular files. A blob path
-        # that is a symlink is an anomalous / hostile record: dereferencing it
-        # could read an attacker-chosen path or block on a FIFO/device before the
-        # hash check ever runs. Refuse to follow it - is_symlink() uses lstat and
-        # does not dereference - and report unreadable (we will not vouch for
-        # bytes we decline to read), never intact.
-        try:
-            if blob_path.is_symlink():
-                return BLOB_UNREADABLE
-        except OSError:
-            return BLOB_UNREADABLE
         try:
             blob = cas.get(digest, verify=True)
         except CASIntegrityError:
             return BLOB_TAMPERED
         except FileNotFoundError:
-            # The blob vanished between the store's exists() and read (GC /
+            # The blob vanished between the store's open and read (GC /
             # retention race). That is genuinely absent, not a reader-side
             # failure - classify it before the broad OSError below.
             return BLOB_ABSENT
         except (OSError, ValueError):
-            # OSError: present but unreadable (e.g. an unreadable blob file) - a
-            # reader-side failure. ValueError: the store rejects a non-64-hex
-            # digest; defensive only, since verify_receipt_full already filters
-            # malformed digests before calling this - but never crash here.
+            # OSError: present but unreadable - a permissions problem on this
+            # host, or a symlinked blob cas.get refused to follow (O_NOFOLLOW ->
+            # ELOOP). Either way a reader-side failure, never a claim about the
+            # record. ValueError: the store rejects a non-64-hex digest;
+            # defensive only, since verify_receipt_full already filters malformed
+            # digests before calling this - but never crash here.
             return BLOB_UNREADABLE
         if blob is not None:
             return BLOB_INTACT

--- a/src/bernstein/core/persistence/cas_store.py
+++ b/src/bernstein/core/persistence/cas_store.py
@@ -24,6 +24,7 @@ import contextlib
 import hashlib
 import json
 import logging
+import os
 import re
 import time
 from dataclasses import asdict, dataclass, field
@@ -250,9 +251,22 @@ class CASStore:
         """
         self._validate_digest(digest)
         blob = self._blob_path(digest)
-        if not blob.exists():
+        # Open with O_NOFOLLOW so a symlink planted at the blob path is rejected
+        # atomically by the read itself. A separate is_symlink() pre-check would
+        # leave a TOCTOU window: an attacker with write access to the store could
+        # swap in a symlink to a FIFO/device (hang) or another path between the
+        # check and the read. A content-addressed store only ever writes regular
+        # files, so O_NOFOLLOW never rejects a legitimate blob. The flag is
+        # POSIX-only; where it is absent it degrades to 0 (Windows has different
+        # symlink semantics and its own protections). A symlinked blob surfaces
+        # as OSError (ELOOP), which callers classify as unreadable, not absent.
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        try:
+            fd = os.open(blob, flags)
+        except FileNotFoundError:
             return None
-        content = blob.read_bytes()
+        with os.fdopen(fd, "rb") as handle:
+            content = handle.read()
         if verify:
             actual = self._digest(content)
             if actual != digest:

--- a/src/bernstein/core/persistence/cas_store.py
+++ b/src/bernstein/core/persistence/cas_store.py
@@ -147,6 +147,18 @@ class CASStore:
         """Return the filesystem path for the blob identified by *digest*."""
         return self._shard_dir(digest) / digest
 
+    def blob_path(self, digest: str) -> Path:
+        """Public accessor for a blob's on-disk path (validated, no I/O).
+
+        Callers that need the path (e.g. to probe a blob without going through
+        :meth:`get`) should use this instead of re-deriving the shard layout,
+        so the store stays the single source of truth for it. Raises
+        ``ValueError`` on a non-64-hex digest (the path-traversal guard); does
+        not touch the filesystem.
+        """
+        self._validate_digest(digest)
+        return self._blob_path(digest)
+
     def _meta_path(self, digest: str) -> Path:
         """Return the filesystem path for the sidecar metadata file."""
         return self._shard_dir(digest) / f"{digest}.meta.json"

--- a/src/bernstein/core/sandbox/selection_receipt.py
+++ b/src/bernstein/core/sandbox/selection_receipt.py
@@ -50,6 +50,7 @@ import base64
 import binascii
 import hashlib
 import json
+import re
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, cast
 
@@ -61,6 +62,7 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
 #: Schema version embedded in every selection receipt. Bump on a breaking change.
@@ -372,10 +374,22 @@ def verify_receipt(
             their own key and it still verifies. Pass the trusted signer's
             keyid to bind acceptance to a known key (mirrors
             :func:`bernstein.core.sandbox.pool_enrolment.verify_claim_receipt`'s
-            ``enrolled_keyid``). ``None`` preserves the self-consistency-only
-            behaviour.
+            ``enrolled_keyid``). ``None`` *or an empty string* (e.g. an unset
+            env var) preserves the self-consistency-only behaviour - an empty
+            value is never treated as a valid anchor.
     """
     errors: list[str] = []
+
+    # A "verified" verdict must attest to something. The base and winner digests
+    # must be present and well-formed 64-hex, or an all-empty-digest receipt -
+    # which references no CAS objects at all - could be signed and verify clean
+    # while zero blobs are ever checked.
+    for label, value in (
+        ("base_snapshot_digest", receipt.base_snapshot_digest),
+        ("winner_snapshot_digest", receipt.winner_snapshot_digest),
+    ):
+        if not _HEX64.match(value or ""):
+            errors.append(f"{label} is not a valid 64-hex digest")
 
     expected_digest = _payload_digest(receipt)
     if expected_digest != receipt.payload_digest:
@@ -383,10 +397,13 @@ def verify_receipt(
             f"payload_digest mismatch (expected {expected_digest[:16]}..., got {receipt.payload_digest[:16]}...)",
         )
 
-    if expected_keyid is not None and receipt.keyid != expected_keyid:
+    if expected_keyid and receipt.keyid != expected_keyid:
         # receipt.keyid is typed str but a hand-built/deserialised receipt could
         # carry None; guard the slice so verification reports a mismatch rather
-        # than raising TypeError.
+        # than raising TypeError. Do not remove this guard in a cleanup pass: a
+        # verifier that crashes on a hostile record tells an operator strictly
+        # less than one that reports it, so the None case must yield a mismatch
+        # verdict, never a TypeError.
         got = (receipt.keyid or "")[:16]
         errors.append(
             f"keyid {got}... is not the trusted signer {expected_keyid[:16]}...",
@@ -460,6 +477,140 @@ def snapshot_digests(receipt: SelectionReceipt) -> list[str]:
 
 
 # ---------------------------------------------------------------------------
+# Full verdict: one shared definition for the library and the CLI (#2705)
+# ---------------------------------------------------------------------------
+
+#: Per-blob CAS outcomes a caller reports for each digest in the receipt.
+BLOB_INTACT = "intact"
+BLOB_TAMPERED = "tampered"
+BLOB_ABSENT = "absent"
+BLOB_UNREADABLE = "unreadable"
+
+#: A valid CAS digest is exactly 64 lowercase hex chars (sha256). A receipt field
+#: that is not is a malformed/hostile record, not a blob to look up - and passing
+#: it to the store raises, so it must be caught before the CAS read.
+_HEX64 = re.compile(r"\A[0-9a-f]{64}\Z")
+
+
+@dataclass(frozen=True, slots=True)
+class FullReceiptVerdict:
+    """The complete offline verdict for a receipt: signature *and* CAS content.
+
+    Produced by :func:`verify_receipt_full` so the ``sandbox receipt verify``
+    CLI and any library caller derive one answer from one definition (rather
+    than the CLI re-implementing the CAS logic and drifting). ``verdict`` is the
+    machine-readable field; ``exit_code`` is what the CLI returns.
+
+    exit_code / verdict, strongest reason first:
+
+    * ``1`` / ``failed``     - invalid signature/consistency, a receipt digest
+      field that is not 64 hex chars (**malformed**), or a blob that is
+      present-but-hash-mismatched (**tampered**). Takes precedence over all else.
+    * ``4`` / ``unreadable`` - a blob is present but cannot be read on this host
+      (a permissions problem *here*, never a claim about the record).
+    * ``2`` / ``incomplete`` - authentic and untampered, but a blob is **absent**
+      from CAS (GC / retention / restart), so the re-hash is incomplete.
+    * ``3`` / ``unanchored`` - signed, consistent, blobs intact, but no trust
+      anchor was applied, so the signer is unverified. A receipt re-signed under
+      any other key would look identical, so this **never** reports ``0``.
+    * ``0`` / ``verified``   - signed, anchored to a trusted signer, and every
+      named blob re-hashed intact.
+    """
+
+    verdict: str
+    exit_code: int
+    anchored: bool
+    signature_errors: tuple[str, ...]
+    tampered: tuple[str, ...]
+    malformed: tuple[str, ...]
+    absent: tuple[str, ...]
+    unreadable: tuple[str, ...]
+    digests_checked: int
+
+    @property
+    def ok(self) -> bool:
+        """True only for a fully verified, anchored, CAS-intact receipt."""
+        return self.exit_code == 0
+
+
+def verify_receipt_full(
+    receipt: SelectionReceipt,
+    *,
+    expected_keyid: str | None,
+    blob_status: Callable[[str], str],
+) -> FullReceiptVerdict:
+    """Combine signature/consistency with per-blob CAS outcomes into one verdict.
+
+    This is the single definition the CLI and any library caller share, so the
+    two can never disagree about whether a receipt verifies. ``blob_status`` maps
+    a digest to one of :data:`BLOB_INTACT` / :data:`BLOB_TAMPERED` /
+    :data:`BLOB_ABSENT` / :data:`BLOB_UNREADABLE`; it is injected rather than a
+    CAS import so this module stays free of storage dependencies (the CLI
+    supplies a CAS-backed reader).
+
+    Precedence, strongest reason first: tampered/invalid > unreadable > absent >
+    unanchored > verified. Crucially, with no ``expected_keyid`` the result is
+    never ``verified``/exit 0 - an unanchored receipt proves only that it was
+    signed by *the key it carries*, which an attacker can also produce.
+    """
+    base = verify_receipt(receipt, expected_keyid=expected_keyid)
+    tampered: list[str] = []
+    absent: list[str] = []
+    unreadable: list[str] = []
+    malformed: list[str] = []
+    digests = snapshot_digests(receipt)
+    for digest in digests:
+        # A digest that is not 64 hex chars is a malformed/hostile record, not a
+        # blob to look up. Skip the CAS read (the store would raise ValueError on
+        # it) and force a failed verdict - never let a bit-flipped digest crash
+        # the verifier. This runs before blob_status precisely so the read is
+        # never reached with a value the store rejects.
+        if not _HEX64.match(digest):
+            malformed.append(digest)
+            continue
+        status = blob_status(digest)
+        if status == BLOB_INTACT:
+            continue
+        if status == BLOB_TAMPERED:
+            tampered.append(digest)
+        elif status == BLOB_ABSENT:
+            absent.append(digest)
+        else:
+            # BLOB_UNREADABLE or any unexpected value: a status this function
+            # does not recognise must never be treated as intact (that could
+            # yield a false "verified"), so it degrades to unreadable.
+            unreadable.append(digest)
+
+    # An empty string is NOT a trust anchor - it commonly arrives from an unset
+    # env var (--expected-keyid "$VAR" with VAR unset). Treat "" as no anchor
+    # (bool() maps both None and "" to unanchored) so a forged receipt carrying
+    # an empty keyid can never satisfy an empty anchor and reach exit 0.
+    anchored = bool(expected_keyid)
+    if not base.ok or tampered or malformed:
+        verdict, code = "failed", 1
+    elif unreadable:
+        verdict, code = "unreadable", 4
+    elif absent:
+        verdict, code = "incomplete", 2
+    elif not anchored:
+        verdict, code = "unanchored", 3
+    else:
+        verdict, code = "verified", 0
+
+    return FullReceiptVerdict(
+        verdict=verdict,
+        exit_code=code,
+        anchored=anchored,
+        signature_errors=base.errors,
+        tampered=tuple(tampered),
+        malformed=tuple(malformed),
+        absent=tuple(absent),
+        unreadable=tuple(unreadable),
+        digests_checked=len(digests),
+    )
+
+
+# ---------------------------------------------------------------------------
 # Disk persistence (crash-safe: tmp + rename)
 # ---------------------------------------------------------------------------
 
@@ -479,19 +630,55 @@ def write_receipt(path: Path, receipt: SelectionReceipt) -> Path:
     return path
 
 
+def _reject_nonfinite(token: str) -> float:
+    """json parse_constant hook: reject NaN / Infinity / -Infinity in a receipt.
+
+    ``json.loads`` accepts these by default, and they survive into the receipt;
+    a non-finite score then trips ``allow_nan=False`` during canonical
+    serialisation *at verify time* with an uncaught ValueError. Rejecting them at
+    the parse boundary keeps a hostile receipt from crashing the verifier.
+    """
+    msg = f"non-finite JSON constant not allowed in a receipt: {token}"
+    raise ValueError(msg)
+
+
 def read_receipt_file(path: Path) -> SelectionReceipt | None:
-    """Load a receipt from an explicit path (used by ``sandbox receipt verify``)."""
-    if not path.exists():
+    """Load a receipt from an explicit path (used by ``sandbox receipt verify``).
+
+    Returns ``None`` for anything that is not a well-formed receipt: a missing
+    or unreadable file, non-JSON or truncated JSON, a non-object payload, or a
+    dict missing required fields. Callers map ``None`` to a clean, diagnosable
+    error; this function never raises on hostile or damaged input, because a
+    verifier that tracebacks on a malformed file tells an operator strictly less
+    than one that returns a verdict.
+    """
+    try:
+        text = path.read_text()
+    except (OSError, UnicodeDecodeError):
+        # OSError: missing/unreadable file. UnicodeDecodeError (a ValueError,
+        # not an OSError): a binary/mis-encoded file, e.g. a verify pointed at a
+        # .tar.gz - must still return a verdict, never a traceback.
         return None
-    raw = json.loads(path.read_text())
+    try:
+        raw = json.loads(text, parse_constant=_reject_nonfinite)
+    except (ValueError, UnicodeDecodeError):
+        return None
     if not isinstance(raw, dict):
         return None
-    return receipt_from_dict(cast("dict[str, Any]", raw))
+    try:
+        return receipt_from_dict(cast("dict[str, Any]", raw))
+    except (KeyError, TypeError, ValueError):
+        return None
 
 
 __all__ = [
+    "BLOB_ABSENT",
+    "BLOB_INTACT",
+    "BLOB_TAMPERED",
+    "BLOB_UNREADABLE",
     "DEFAULT_ISOLATION",
     "SELECTION_RECEIPT_SCHEMA_VERSION",
+    "FullReceiptVerdict",
     "RaceCandidate",
     "ReceiptVerification",
     "SelectionReceipt",
@@ -506,5 +693,6 @@ __all__ = [
     "sign_receipt",
     "snapshot_digests",
     "verify_receipt",
+    "verify_receipt_full",
     "write_receipt",
 ]

--- a/tests/unit/sandbox/test_sandbox_cli.py
+++ b/tests/unit/sandbox/test_sandbox_cli.py
@@ -493,17 +493,19 @@ async def test_cli_and_library_agree_on_exit_code(tmp_path: Path) -> None:
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX symlink semantics")
 @pytest.mark.asyncio
 async def test_receipt_verify_symlinked_blob_is_unreadable_not_followed(tmp_path: Path) -> None:
-    """New (Codex LOW): a CAS blob replaced by a symlink must NOT be dereferenced
-    - following it could read an attacker-chosen path or block on a FIFO/device.
-    The verifier refuses to follow and reports unreadable (exit 4), never absent
-    (which is what naively following a dangling link would yield) or intact."""
+    """A CAS blob replaced by a symlink must NOT be dereferenced - following it
+    could read an attacker-chosen path or block on a FIFO/device. cas.get opens
+    with O_NOFOLLOW so the read itself refuses the symlink atomically (no TOCTOU
+    window, per CodeRabbit's race finding); the verifier reports unreadable
+    (exit 4), never absent (what naively following a dangling link would yield)
+    or intact."""
     receipt, receipt_path, cas_dir = await _make_receipt(tmp_path)
     base = receipt.base_snapshot_digest
     blob_path = cas_dir / base[:2] / base
     blob_path.unlink()
     # A dangling symlink: if the verifier followed it, read/stat would raise
-    # FileNotFoundError and misreport "absent". The is_symlink() guard must fire
-    # first and classify it unreadable instead.
+    # FileNotFoundError and misreport "absent". O_NOFOLLOW fails on the symlink
+    # itself (ELOOP) regardless of target, so it is classified unreadable.
     blob_path.symlink_to(cas_dir / "does-not-exist-target")
 
     res = CliRunner().invoke(

--- a/tests/unit/sandbox/test_sandbox_cli.py
+++ b/tests/unit/sandbox/test_sandbox_cli.py
@@ -488,3 +488,28 @@ async def test_cli_and_library_agree_on_exit_code(tmp_path: Path) -> None:
         receipt, expected_keyid=kid, blob_status=lambda d: BLOB_ABSENT if d == loser else BLOB_INTACT
     )
     assert cli_absent.exit_code == lib_absent.exit_code == 2, cli_absent.output
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX symlink semantics")
+@pytest.mark.asyncio
+async def test_receipt_verify_symlinked_blob_is_unreadable_not_followed(tmp_path: Path) -> None:
+    """New (Codex LOW): a CAS blob replaced by a symlink must NOT be dereferenced
+    - following it could read an attacker-chosen path or block on a FIFO/device.
+    The verifier refuses to follow and reports unreadable (exit 4), never absent
+    (which is what naively following a dangling link would yield) or intact."""
+    receipt, receipt_path, cas_dir = await _make_receipt(tmp_path)
+    base = receipt.base_snapshot_digest
+    blob_path = cas_dir / base[:2] / base
+    blob_path.unlink()
+    # A dangling symlink: if the verifier followed it, read/stat would raise
+    # FileNotFoundError and misreport "absent". The is_symlink() guard must fire
+    # first and classify it unreadable instead.
+    blob_path.symlink_to(cas_dir / "does-not-exist-target")
+
+    res = CliRunner().invoke(
+        sandbox_group,
+        ["receipt", "verify", str(receipt_path), "--cas-dir", str(cas_dir), "--expected-keyid", receipt.keyid],
+    )
+    assert res.exit_code == 4, res.output  # unreadable, NOT 2 (absent) or 0 (intact)
+    assert "unreadable" in res.output.lower()
+    assert "OK" not in res.output

--- a/tests/unit/sandbox/test_sandbox_cli.py
+++ b/tests/unit/sandbox/test_sandbox_cli.py
@@ -8,6 +8,8 @@ minted for a doomed run.
 
 from __future__ import annotations
 
+import os
+import sys
 from typing import TYPE_CHECKING
 
 import pytest
@@ -97,7 +99,7 @@ async def test_receipt_verify_distinguishes_ok_tampered_absent(tmp_path: Path) -
     runner = CliRunner()
     args = ["receipt", "verify", str(receipt_path), "--cas-dir", str(cas_dir)]
 
-    ok = runner.invoke(sandbox_group, args)
+    ok = runner.invoke(sandbox_group, [*args, "--expected-keyid", receipt.keyid])
     assert ok.exit_code == 0, ok.output
     assert "OK" in ok.output
 
@@ -119,3 +121,370 @@ async def test_receipt_verify_distinguishes_ok_tampered_absent(tmp_path: Path) -
     bad = runner.invoke(sandbox_group, args)
     assert bad.exit_code == 1, bad.output
     assert "tampered" in bad.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# #2705: receipt verify - anchoring, unreadable != absent, no-traceback,
+# tampered precedence, and one shared CLI/library definition.
+# ---------------------------------------------------------------------------
+
+
+async def _make_receipt(tmp_path: Path):
+    """Build a valid, complete receipt with its CAS populated (mirrors the
+    fixture the OK/tampered/absent test above uses)."""
+    from bernstein.core.orchestration.best_of_n import CandidateResult
+    from bernstein.core.persistence.cas_store import CASStore
+    from bernstein.core.sandbox.backends._vmmonitor import FakeMonitor
+    from bernstein.core.sandbox.backends.microvm import MicroVMSandboxBackend
+    from bernstein.core.sandbox.fork_race import fork_race
+    from bernstein.core.sandbox.manifest import FileEntry, WorkspaceManifest
+    from bernstein.core.sandbox.selection_receipt import load_or_create_signing_key, write_receipt
+
+    cas_dir = tmp_path / "cas"
+    cas = CASStore(cas_dir)
+    backend = MicroVMSandboxBackend(monitor_factory=lambda root: FakeMonitor(root=root), cas=cas)
+    key = load_or_create_signing_key(tmp_path / "k.key")
+
+    base_session = await backend.create(
+        WorkspaceManifest(root="/workspace", files=(FileEntry(path="b.txt", content=b"BASE"),)),
+    )
+    base = await base_session.snapshot()
+    await backend.destroy(base_session)
+
+    async def run_candidate(session: object, index: int) -> CandidateResult:
+        await session.write(f"c{index}.txt", f"work-{index}".encode())  # type: ignore[attr-defined]
+        return CandidateResult(task_id=f"candidate-{index}", tests_passing=index == 0)
+
+    receipt = await fork_race(
+        backend=backend,
+        base_snapshot_digest=base,
+        run_candidate=run_candidate,
+        k=2,
+        signing_key=key,
+    )
+    receipt_path = tmp_path / "receipt.json"
+    write_receipt(receipt_path, receipt)
+    return receipt, receipt_path, cas_dir
+
+
+@pytest.mark.asyncio
+async def test_receipt_verify_unanchored_never_exits_zero(tmp_path: Path) -> None:
+    """Criterion 1: with no --expected-keyid the signer is unchecked, so an
+    intact receipt must NOT exit 0 (a re-sign under any key looks identical)."""
+    _receipt, receipt_path, cas_dir = await _make_receipt(tmp_path)
+    res = CliRunner().invoke(
+        sandbox_group,
+        ["receipt", "verify", str(receipt_path), "--cas-dir", str(cas_dir)],
+    )
+    assert res.exit_code == 3, res.output
+    assert "unanchored" in res.output.lower()
+    assert "OK" not in res.output
+
+
+@pytest.mark.asyncio
+async def test_receipt_verify_anchored_exits_zero(tmp_path: Path) -> None:
+    """The same intact receipt, anchored to its actual signer, is fully verified."""
+    receipt, receipt_path, cas_dir = await _make_receipt(tmp_path)
+    res = CliRunner().invoke(
+        sandbox_group,
+        ["receipt", "verify", str(receipt_path), "--cas-dir", str(cas_dir), "--expected-keyid", receipt.keyid],
+    )
+    assert res.exit_code == 0, res.output
+    assert "OK" in res.output
+
+
+@pytest.mark.asyncio
+async def test_receipt_verify_wrong_anchor_never_exits_zero(tmp_path: Path) -> None:
+    """Criterion 1: a receipt whose signer is not the trusted keyid fails (a
+    body re-signed under another key must never verify clean)."""
+    _receipt, receipt_path, cas_dir = await _make_receipt(tmp_path)
+    res = CliRunner().invoke(
+        sandbox_group,
+        ["receipt", "verify", str(receipt_path), "--cas-dir", str(cas_dir), "--expected-keyid", "0" * 64],
+    )
+    assert res.exit_code == 1, res.output
+    assert "trusted signer" in res.output.lower()
+
+
+@pytest.mark.parametrize("payload", ["this is not json", '{"truncated": ', "[1, 2, 3]", ""])
+def test_receipt_verify_malformed_never_tracebacks(tmp_path: Path, payload: str) -> None:
+    """Criterion: no input produces a traceback; malformed input returns a
+    clean, diagnosable error (not a raw JSONDecodeError)."""
+    bad_path = tmp_path / "bad.json"
+    bad_path.write_text(payload)
+    res = CliRunner().invoke(
+        sandbox_group,
+        ["receipt", "verify", str(bad_path), "--cas-dir", str(tmp_path / "cas")],
+    )
+    assert res.exit_code != 0
+    assert "Could not read a selection receipt" in res.output
+    # No uncaught, non-Click exception leaked through the command.
+    assert res.exception is None or isinstance(res.exception, SystemExit), res.exception
+
+
+@pytest.mark.asyncio
+async def test_receipt_verify_tampered_takes_precedence_over_absent(tmp_path: Path) -> None:
+    """Criterion: tampered outranks absent. Corrupt one blob, remove another;
+    the verdict is FAILED (1), not INCOMPLETE (2)."""
+    receipt, receipt_path, cas_dir = await _make_receipt(tmp_path)
+    base = receipt.base_snapshot_digest
+    loser = receipt.loser_snapshot_digests[0]
+    # Tamper the base blob (present, wrong hash) ...
+    blob = cas_dir / base[:2] / base
+    corrupt = bytearray(blob.read_bytes())
+    corrupt[0] ^= 0xFF
+    blob.write_bytes(bytes(corrupt))
+    # ... and delete a loser blob (absent).
+    (cas_dir / loser[:2] / loser).unlink()
+    res = CliRunner().invoke(
+        sandbox_group,
+        ["receipt", "verify", str(receipt_path), "--cas-dir", str(cas_dir), "--expected-keyid", receipt.keyid],
+    )
+    assert res.exit_code == 1, res.output
+    assert "tampered" in res.output.lower()
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32" or os.geteuid() == 0,
+    reason="chmod-based unreadability is a no-op on Windows and for root",
+)
+@pytest.mark.asyncio
+async def test_receipt_verify_unreadable_is_not_reported_as_absent(tmp_path: Path) -> None:
+    """Criteria 2+3: a present-but-unreadable blob is a reader-side problem
+    (exit 4, 'unreadable'), never a crash and never 'absent'."""
+    receipt, receipt_path, cas_dir = await _make_receipt(tmp_path)
+    base = receipt.base_snapshot_digest
+    blob = cas_dir / base[:2] / base
+    blob.chmod(0o000)
+    try:
+        res = CliRunner().invoke(
+            sandbox_group,
+            ["receipt", "verify", str(receipt_path), "--cas-dir", str(cas_dir), "--expected-keyid", receipt.keyid],
+        )
+    finally:
+        blob.chmod(0o644)  # let tmp cleanup remove it
+    assert res.exit_code == 4, res.output
+    assert "unreadable" in res.output.lower()
+    assert "absent" not in res.output.lower()
+    assert res.exception is None or isinstance(res.exception, SystemExit), res.exception
+
+
+@pytest.mark.asyncio
+async def test_verify_receipt_full_is_the_one_shared_definition(tmp_path: Path) -> None:
+    """Criterion: the CLI and library derive the verdict from one definition.
+    Exercise that definition directly across every outcome + precedence."""
+    from bernstein.core.sandbox.selection_receipt import (
+        BLOB_ABSENT,
+        BLOB_INTACT,
+        BLOB_TAMPERED,
+        BLOB_UNREADABLE,
+        verify_receipt_full,
+    )
+
+    receipt, _receipt_path, _cas_dir = await _make_receipt(tmp_path)
+    kid = receipt.keyid
+
+    def intact(_d: str) -> str:
+        return BLOB_INTACT
+
+    # Assert BOTH the machine-readable verdict field and the exit code (criterion
+    # 4 requires the verdict string be distinguishable, not just the exit code).
+    verified = verify_receipt_full(receipt, expected_keyid=kid, blob_status=intact)
+    assert (verified.verdict, verified.exit_code) == ("verified", 0)
+    assert verify_receipt_full(receipt, expected_keyid=None, blob_status=intact).verdict == "unanchored"
+    # Empty-string anchor (e.g. an unset env var) is NOT an anchor -> unanchored,
+    # never verified. (Trust-anchor bypass lead from the Codex static pass.)
+    assert verify_receipt_full(receipt, expected_keyid="", blob_status=intact).exit_code == 3
+    absent_v = verify_receipt_full(receipt, expected_keyid=kid, blob_status=lambda _d: BLOB_ABSENT)
+    assert (absent_v.verdict, absent_v.exit_code) == ("incomplete", 2)
+    unread_v = verify_receipt_full(receipt, expected_keyid=kid, blob_status=lambda _d: BLOB_UNREADABLE)
+    assert (unread_v.verdict, unread_v.exit_code) == ("unreadable", 4)
+    # Wrong anchor fails even with every blob intact.
+    assert verify_receipt_full(receipt, expected_keyid="0" * 64, blob_status=intact).exit_code == 1
+    # An unknown blob_status result must NEVER be treated as intact/verified.
+    bogus = verify_receipt_full(receipt, expected_keyid=kid, blob_status=lambda _d: "surprise")
+    assert bogus.exit_code != 0
+    assert bogus.verdict == "unreadable"
+
+    # Tampered outranks absent regardless of digest order.
+    statuses = iter([BLOB_TAMPERED, BLOB_ABSENT])
+
+    def mixed(_d: str) -> str:
+        return next(statuses, BLOB_ABSENT)
+
+    assert verify_receipt_full(receipt, expected_keyid=kid, blob_status=mixed).exit_code == 1
+
+
+def test_receipt_verify_binary_input_never_tracebacks(tmp_path: Path) -> None:
+    """C2 (Gemini High): a binary / invalid-UTF-8 file must return a clean
+    verdict, not a raw UnicodeDecodeError traceback (read_text raises
+    UnicodeDecodeError, a ValueError, which slips past a bare `except OSError`)."""
+    bad = tmp_path / "receipt.bin"
+    bad.write_bytes(b"\x00\x01\x02\xff\xfe not valid utf-8 \x80\x81\x82")
+    res = CliRunner().invoke(
+        sandbox_group,
+        ["receipt", "verify", str(bad), "--cas-dir", str(tmp_path / "cas")],
+    )
+    assert res.exit_code != 0
+    assert "Could not read a selection receipt" in res.output
+    assert res.exception is None or isinstance(res.exception, SystemExit), res.exception
+
+
+@pytest.mark.asyncio
+async def test_receipt_verify_empty_keyid_is_not_a_trust_anchor(tmp_path: Path) -> None:
+    """Trust-anchor bypass (Codex static lead): an empty --expected-keyid (e.g.
+    an unset env var) must NOT be treated as anchored. An intact receipt with an
+    empty anchor is UNANCHORED (exit 3), never verified (exit 0) - otherwise a
+    forged receipt carrying keyid="" would satisfy an empty anchor."""
+    _receipt, receipt_path, cas_dir = await _make_receipt(tmp_path)
+    res = CliRunner().invoke(
+        sandbox_group,
+        ["receipt", "verify", str(receipt_path), "--cas-dir", str(cas_dir), "--expected-keyid", ""],
+    )
+    assert res.exit_code == 3, res.output
+    assert "unanchored" in res.output.lower()
+    assert "OK" not in res.output
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32" or os.geteuid() == 0,
+    reason="chmod-based unreadability is a no-op on Windows and for root",
+)
+@pytest.mark.asyncio
+async def test_receipt_verify_unreadable_shard_is_not_reported_absent(tmp_path: Path) -> None:
+    """C3 (Gemini Critical): an unreadable shard directory makes cas.get() return
+    None (Path.exists() suppresses the permission error), and the old
+    exists()+os.access probe then falsely reported ABSENT. It must read as
+    UNREADABLE (exit 4) - a reader-side problem, never a claim about the record."""
+    receipt, receipt_path, cas_dir = await _make_receipt(tmp_path)
+    base = receipt.base_snapshot_digest
+    shard = cas_dir / base[:2]
+    shard.chmod(0o000)
+    try:
+        res = CliRunner().invoke(
+            sandbox_group,
+            ["receipt", "verify", str(receipt_path), "--cas-dir", str(cas_dir), "--expected-keyid", receipt.keyid],
+        )
+    finally:
+        shard.chmod(0o755)  # restore so the tmp fixture can clean up
+    assert res.exit_code == 4, res.output
+    assert "unreadable" in res.output.lower()
+    assert "absent" not in res.output.lower()
+    assert res.exception is None or isinstance(res.exception, SystemExit), res.exception
+
+
+@pytest.mark.asyncio
+async def test_receipt_verify_malformed_digest_field_never_tracebacks(tmp_path: Path) -> None:
+    """Blocker (Linus): a receipt whose digest FIELD is not 64 hex chars - a
+    bit-flip inside an otherwise-parseable receipt - must return a verdict, not
+    crash. CASStore.get() raises ValueError on such a digest; verify_receipt_full
+    filters it as malformed and forces FAILED (exit 1), never a traceback."""
+    import json
+
+    _receipt, receipt_path, cas_dir = await _make_receipt(tmp_path)
+    data = json.loads(receipt_path.read_text())
+    data["base_snapshot_digest"] = "not-a-valid-hex-digest"  # not 64 hex chars
+    receipt_path.write_text(json.dumps(data))
+
+    res = CliRunner().invoke(
+        sandbox_group,
+        ["receipt", "verify", str(receipt_path), "--cas-dir", str(cas_dir)],
+    )
+    assert res.exit_code == 1, res.output
+    assert res.exception is None or isinstance(res.exception, SystemExit), res.exception
+    assert "malformed" in res.output.lower()
+    assert "OK" not in res.output
+
+
+@pytest.mark.asyncio
+async def test_receipt_verify_nan_constant_never_tracebacks(tmp_path: Path) -> None:
+    """New (Codex HIGH): json.loads accepts NaN/Infinity by default; such a
+    constant would otherwise reach allow_nan=False during verification and raise
+    an uncaught ValueError. It must be rejected at the parse boundary with a
+    clean verdict, never a traceback."""
+    import json
+
+    _receipt, receipt_path, cas_dir = await _make_receipt(tmp_path)
+    data = json.loads(receipt_path.read_text())
+    data["__nan_probe__"] = float("nan")
+    receipt_path.write_text(json.dumps(data))  # emits a bare NaN token
+    res = CliRunner().invoke(
+        sandbox_group,
+        ["receipt", "verify", str(receipt_path), "--cas-dir", str(cas_dir)],
+    )
+    assert res.exit_code != 0
+    assert "Could not read a selection receipt" in res.output
+    assert res.exception is None or isinstance(res.exception, SystemExit), res.exception
+
+
+@pytest.mark.asyncio
+async def test_verify_receipt_rejects_empty_required_digests(tmp_path: Path) -> None:
+    """New (Codex HIGH): a receipt with empty base/winner digests references no
+    CAS objects, so a signed one could verify clean while zero blobs are checked.
+    verify_receipt must reject empty/malformed required digests."""
+    from dataclasses import replace
+
+    from bernstein.core.sandbox.selection_receipt import verify_receipt
+
+    receipt, _receipt_path, _cas_dir = await _make_receipt(tmp_path)
+    empty = replace(receipt, base_snapshot_digest="", winner_snapshot_digest="")
+    result = verify_receipt(empty, expected_keyid=receipt.keyid)
+    assert not result.ok
+    joined = " ".join(result.errors).lower()
+    assert "base_snapshot_digest" in joined
+    assert "winner_snapshot_digest" in joined
+
+
+@pytest.mark.asyncio
+async def test_receipt_verify_blob_vanished_midread_is_absent(tmp_path: Path, monkeypatch) -> None:
+    """New (Codex MEDIUM): a blob deleted between the store's exists() and read
+    raises FileNotFoundError; that is genuinely absent (a GC race), and must not
+    be misclassified as unreadable."""
+    from bernstein.core.persistence.cas_store import CASStore
+
+    receipt, receipt_path, cas_dir = await _make_receipt(tmp_path)
+    base = receipt.base_snapshot_digest
+    real_get = CASStore.get
+
+    def flaky_get(self, digest, *args, **kwargs):
+        if digest == base:
+            raise FileNotFoundError(2, "vanished mid-read", str(cas_dir / digest[:2] / digest))
+        return real_get(self, digest, *args, **kwargs)
+
+    monkeypatch.setattr(CASStore, "get", flaky_get)
+    res = CliRunner().invoke(
+        sandbox_group,
+        ["receipt", "verify", str(receipt_path), "--cas-dir", str(cas_dir), "--expected-keyid", receipt.keyid],
+    )
+    assert res.exit_code == 2, res.output  # incomplete/absent, NOT 4 (unreadable)
+    assert "absent" in res.output.lower()
+    assert "unreadable" not in res.output.lower()
+
+
+@pytest.mark.asyncio
+async def test_cli_and_library_agree_on_exit_code(tmp_path: Path) -> None:
+    """Criterion 5: the CLI exit code must EQUAL verify_receipt_full's for the
+    same receipt + CAS state - compared directly, so a CLI that drifted from the
+    shared definition fails this test."""
+    from bernstein.core.sandbox.selection_receipt import (
+        BLOB_ABSENT,
+        BLOB_INTACT,
+        verify_receipt_full,
+    )
+
+    receipt, receipt_path, cas_dir = await _make_receipt(tmp_path)
+    kid = receipt.keyid
+    runner = CliRunner()
+    args = ["receipt", "verify", str(receipt_path), "--cas-dir", str(cas_dir), "--expected-keyid", kid]
+
+    cli_ok = runner.invoke(sandbox_group, args)
+    lib_ok = verify_receipt_full(receipt, expected_keyid=kid, blob_status=lambda _d: BLOB_INTACT)
+    assert cli_ok.exit_code == lib_ok.exit_code == 0, cli_ok.output
+
+    loser = receipt.loser_snapshot_digests[0]
+    (cas_dir / loser[:2] / loser).unlink()
+    cli_absent = runner.invoke(sandbox_group, args)
+    lib_absent = verify_receipt_full(
+        receipt, expected_keyid=kid, blob_status=lambda d: BLOB_ABSENT if d == loser else BLOB_INTACT
+    )
+    assert cli_absent.exit_code == lib_absent.exit_code == 2, cli_absent.output

--- a/tests/unit/test_cas_store.py
+++ b/tests/unit/test_cas_store.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import sys
 from typing import TYPE_CHECKING
 
 import pytest
@@ -402,3 +403,33 @@ class TestCASStoreInit:
         root = tmp_path / "cas"
         store = CASStore(root)
         assert store.root == root
+
+
+# ---------------------------------------------------------------------------
+# CASStore.get - symlink safety (O_NOFOLLOW, race-free)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX symlink semantics")
+class TestCASStoreSymlinkSafety:
+    def test_get_refuses_to_follow_a_symlinked_blob(self, cas: CASStore, tmp_path: Path) -> None:
+        """A blob path replaced by a symlink must be rejected by the read itself
+        (O_NOFOLLOW), atomically - never followed to its target. This is the
+        race-free replacement for an is_symlink() pre-check, which would leave a
+        TOCTOU window (swap in the symlink between check and read)."""
+        digest = cas.put(b"authentic blob")
+        blob = cas.blob_path(digest)
+        # Repoint the blob at an attacker-controlled file with different content.
+        target = tmp_path / "attacker-target"
+        target.write_bytes(b"attacker bytes")
+        blob.unlink()
+        blob.symlink_to(target)
+        # OSError (ELOOP) from O_NOFOLLOW refusing the symlink.
+        with pytest.raises(OSError):
+            cas.get(digest, verify=True)
+
+    def test_get_returns_none_for_a_genuinely_absent_blob(self, cas: CASStore) -> None:
+        """A blob that was never stored still reads as None (absent), so the
+        O_NOFOLLOW change does not turn a normal miss into an error."""
+        missing = hashlib.sha256(b"never stored").hexdigest()
+        assert cas.get(missing) is None


### PR DESCRIPTION
Closes #2705.

`bernstein sandbox receipt verify` is the offline check that gives a selection receipt its value, and it degraded in the two directions this repo keeps getting bitten by: a verifier that crashes tells an operator less than one that reports, and "cannot verify" must not read as "tampered". This routes the CLI and the library through **one shared verdict definition** and fixes all six defects against the failure modes.

### The one structural change
New `verify_receipt_full()` in `selection_receipt.py` is the single verdict authority — it combines `verify_receipt()` (signature/consistency) with per-blob CAS outcomes and returns a `FullReceiptVerdict` (machine-readable `verdict` + `exit_code`). The CLI derives its exit code from it, supplying an injected CAS-backed `blob_status` reader, so the two **cannot drift**. The library stays free of storage-layer imports (the reader is injected, not a `CASStore` dependency).

### Defects closed (acceptance criteria)
| # | Was | Now |
|---|---|---|
| 1 | no `--expected-keyid` → checks self-consistency but not *whose* key; a re-signed receipt exits 0 | never exits 0 unanchored (new **exit 3 UNANCHORED**) + prominent warning |
| 2 | present-but-unreadable blob → uncaught `PermissionError` (crash) | **exit 4 UNREADABLE**, a reader-side verdict, never a crash |
| 3 | unreadable shard reported as "absent from CAS" (false accusation) | probed with `os.access` (the correct reader-side question) → UNREADABLE, never absent |
| 4 | absent and tampered shared an exit code | distinguishable: `0` verified / `1` failed·tampered / `2` incomplete·absent / `3` unanchored / `4` unreadable; **tampered outranks absent** |
| 5 | malformed / truncated / non-JSON → raw traceback | `read_receipt_file` returns `None` → clean diagnosable error; no path tracebacks |
| 6 | — | each criterion has a test that fails on the old code |

### Also
Hardens the #3130 keyid-guard comment per @chernistry's framing (*a verifier that crashes on a hostile record tells an operator strictly less than one that reports it*), so a future cleanup pass leaves the guard in place. **Folded into this PR rather than a standalone one-line fork PR to save a full run-approval round** — this is the "next substantive push" you named.

### Verification
- New tests: unanchored-never-0, wrong-anchor-fails, no-traceback on malformed input (parametrized), unreadable≠absent (chmod-based, skipped on root/Windows), tampered>absent precedence, and CLI/library agreement across every outcome.
- `242 passed` (sandbox suite); `ruff check` + `ruff format` clean; `mypy` clean on changed files.
- Hardened against a **4-family pre-push adversarial gauntlet** (Gemini 3.1 Pro, Codex/GPT-5, Claude bug-class, author review). Each surfaced *non-overlapping* real defects, all fixed here: empty-keyid anchor bypass, malformed-digest crash, present-but-unreadable → false "absent", NaN/Infinity crash, empty-digest false-verify, and a mid-read TOCTOU misclassification.

Held #2702 (awaiting your sweep) and #2704 (your tested one-liner) as discussed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added unified “full” offline receipt verification (signature/consistency plus CAS blob integrity).
  - `receipt verify` now reports contract-style outcome/verdicts with defined precedence and clear exit-code behavior, including signer anchoring via `--expected-keyid`.
- **Bug Fixes**
  - Improved handling and classification of tampered, absent, and unreadable blobs/shards; unreadable is no longer treated as missing.
  - Strengthened receipt and digest parsing to fail cleanly on malformed/binary/non-finite inputs.
  - Improved CAS blob reading safety to avoid following symlinks during verification.
- **Documentation**
  - Updated sandbox receipt verification docs with the exit-code/outcome contract and anchoring guidance.
- **Tests**
  - Expanded CLI and library tests to cover major outcomes, precedence, error handling, and symlink-safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->