### PR TITLE
fix(cli): expose the microvm backend through --sandbox

### DIFF
--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -213,6 +213,10 @@ SANDBOX_CHOICES: tuple[str, ...] = (
     "blaxel",
     "runloop",
     "vercel",
+    # Opt-in, never auto-selected: mirrors its trailing position in
+    # DEFAULT_PRECEDENCE, and it is deliberately absent from
+    # SANDBOX_FREE_CHOICES so only an explicit flag reaches it.
+    "microvm",
 )
 
 


### PR DESCRIPTION
Main is red on shard 3: `test_sandbox_choices_cover_full_selector_precedence` fails because the selector's DEFAULT_PRECEDENCE gained `microvm` while `SANDBOX_CHOICES` did not. The backend was selectable via config override but invisible to `--sandbox`.

One-line fix plus a comment pinning the placement: trailing, opt-in, absent from SANDBOX_FREE_CHOICES so the heuristic path never auto-selects it.

The guard test that caught this is the pre-existing one; no new test is needed - it fails on main and passes here.

Closes #2711

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for explicitly selecting the microVM sandbox backend with the `--sandbox microvm` option.
  * The microVM backend remains opt-in and is not selected automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->