### PR TITLE
fix(test): drop release-please.yml from the release-entrypoint guard

### DIFF
--- a/tests/unit/test_release_entrypoint_docs.py
+++ b/tests/unit/test_release_entrypoint_docs.py
@@ -19,7 +19,6 @@ RELEASE_ENTRYPOINTS: dict[str, tuple[str, ...]] = {
     "auto-release.yml": ("workflow_call",),
     "publish.yml": ("push",),
     "release-major-minor.yml": ("workflow_dispatch",),
-    "release-please.yml": ("workflow_dispatch",),
     "reconcile-release.yml": ("schedule", "workflow_dispatch"),
     "publish-docker.yml": ("release", "workflow_dispatch"),
     "publish-homebrew.yml": ("release", "workflow_dispatch"),


### PR DESCRIPTION
## Fixes red main

`test_release_entrypoint_doc_references_actual_workflows` fails on main (shard 4): `.github/workflows/release-please.yml no longer exists`.

#2724 (quick-wins CI consolidation) deleted `release-please.yml` - a dead, dispatch-only release path superseded by `auto-release.yml` + `publish.yml` - and removed its row from `docs/operations/release.md`, but left it in the `RELEASE_ENTRYPOINTS` map in this test, which asserts every listed workflow still exists on disk.

Its own CI was green because the guard ran against a base that still had the file; the deletion only reddens main after merge. This is the green-PR-plus-green-PR-equals-red-main pattern the merge queue (CI redesign task H) eliminates.

## Fix
Drop the stale `release-please.yml` entry so the guard matches the shipped release surface. Verified: guard test passes, no orphaned row in release.md, no other test hardcodes the file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated release documentation validation expectations to reflect the current set of checked workflows.
  * Removed validation for the deprecated release workflow entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->