### PR TITLE
fix(sandbox): validate fork-race --out before dispatching candidates

### DIFF
--- a/src/bernstein/cli/commands/sandbox_cmd.py
+++ b/src/bernstein/cli/commands/sandbox_cmd.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -252,6 +253,21 @@ def fork_race_cmd(
         raise click.ClickException(f"invalid base snapshot digest {base_digest!r}: {exc}") from exc
     if not base_present:
         raise click.ClickException(f"base snapshot digest not found in CAS ({cas_dir}): {base_digest}")
+    # Validate the --out destination is writable *before* any side-effectful
+    # state, mirroring the base-digest guard above: an unwritable or invalid
+    # --out must fail cleanly here, before a signing key is minted, the audit
+    # directory is created, or a (possibly-paid) candidate is booted - so the
+    # whole race is never run only to have its result discarded at write time.
+    out_parent = out_path.parent
+    if not out_parent.is_dir():
+        raise click.ClickException(f"cannot write receipt: --out parent directory does not exist: {out_parent}")
+    try:
+        # An actual write probe (not just os.access) so a 0o000 directory is
+        # caught the same way the real write would fail.
+        with tempfile.NamedTemporaryFile(dir=out_parent, prefix=".fork-race-out-probe-"):
+            pass
+    except OSError as exc:
+        raise click.ClickException(f"cannot write receipt to {out_path}: destination not writable: {exc}") from exc
     signing_key = load_or_create_signing_key(key_path)
     audit_log = AuditLog(audit_dir)
 

--- a/tests/unit/sandbox/test_sandbox_cli.py
+++ b/tests/unit/sandbox/test_sandbox_cli.py
@@ -59,6 +59,102 @@ def test_fork_race_absent_base_fails_cleanly_without_minting_key(tmp_path: Path)
     assert not key_minted
 
 
+def _seed_present_base(cas_dir: Path) -> str:
+    """Materialise a real base snapshot in ``cas_dir`` and return its digest.
+
+    Uses the fake microVM monitor so the CAS ends up with a genuinely
+    *present* base. That lets the ``--out`` preflight tests below use a valid
+    ``--base``: without the preflight, a present base makes the command proceed
+    to mint a signing key and create the audit dir *before* it ever tries to
+    write the receipt, so those side effects are the discriminator.
+    """
+    import asyncio
+
+    from bernstein.core.persistence.cas_store import CASStore
+    from bernstein.core.sandbox.backends._vmmonitor import FakeMonitor
+    from bernstein.core.sandbox.backends.microvm import MicroVMSandboxBackend
+    from bernstein.core.sandbox.manifest import FileEntry, WorkspaceManifest
+
+    async def _seed() -> str:
+        cas = CASStore(cas_dir)
+        backend = MicroVMSandboxBackend(monitor_factory=lambda root: FakeMonitor(root=root), cas=cas)
+        session = await backend.create(
+            WorkspaceManifest(root="/workspace", files=(FileEntry(path="b.txt", content=b"BASE"),)),
+        )
+        base = await session.snapshot()
+        await backend.destroy(session)
+        return base
+
+    return asyncio.run(_seed())
+
+
+def _invoke_fork_race_out(base: str, out_path: Path, tmp_path: Path) -> tuple[int, str, bool, bool]:
+    cas_dir = tmp_path / "cas"
+    key_path = tmp_path / "keys" / "selection.key"
+    audit_dir = tmp_path / "audit"
+    result = CliRunner().invoke(
+        sandbox_group,
+        [
+            "fork-race",
+            "--base",
+            base,
+            "--cmd",
+            "true",
+            "--out",
+            str(out_path),
+            "--cas-dir",
+            str(cas_dir),
+            "--key",
+            str(key_path),
+            "--audit-dir",
+            str(audit_dir),
+        ],
+    )
+    return result.exit_code, (result.output or ""), key_path.exists(), audit_dir.exists()
+
+
+def test_fork_race_out_nonexistent_parent_fails_before_dispatch(tmp_path: Path) -> None:
+    """AC4 (#2707): a ``--out`` whose parent directory does not exist must fail
+    cleanly *before* any candidate is dispatched - even with a valid, present
+    ``--base``. No signing key minted, no audit dir created, no receipt written,
+    no raw traceback."""
+    base = _seed_present_base(tmp_path / "cas")
+    out_path = tmp_path / "nonexistent-dir" / "receipt.json"  # parent missing
+
+    exit_code, output, key_minted, audit_created = _invoke_fork_race_out(base, out_path, tmp_path)
+
+    assert exit_code == 1, output
+    assert "Traceback" not in output  # diagnosable ClickException, not a crash
+    assert "parent directory does not exist" in output
+    assert not key_minted, "no signing key may be minted for a doomed --out"
+    assert not audit_created, "no audit dir may be created for a doomed --out"
+    assert not out_path.exists()
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32" or os.geteuid() == 0,
+    reason="chmod-based unwritability is a no-op on Windows and for root",
+)
+def test_fork_race_out_unwritable_parent_fails_before_dispatch(tmp_path: Path) -> None:
+    """AC4 (#2707): a ``--out`` whose parent exists but is not writable (0o000)
+    must also fail before dispatch, with no side effects."""
+    base = _seed_present_base(tmp_path / "cas")
+    locked = tmp_path / "locked"
+    locked.mkdir()
+    locked.chmod(0o000)
+    out_path = locked / "receipt.json"
+    try:
+        exit_code, output, key_minted, audit_created = _invoke_fork_race_out(base, out_path, tmp_path)
+    finally:
+        locked.chmod(0o755)  # let tmp cleanup remove it
+
+    assert exit_code == 1, output
+    assert "Traceback" not in output
+    assert "not writable" in output.lower()
+    assert not key_minted, "no signing key may be minted for a doomed --out"
+    assert not audit_created, "no audit dir may be created for a doomed --out"
+
+
 @pytest.mark.asyncio
 async def test_receipt_verify_distinguishes_ok_tampered_absent(tmp_path: Path) -> None:
     """`receipt verify` gives three different answers: OK (0), tampered (1), and


### PR DESCRIPTION
## What

`bernstein sandbox fork-race --out` was validated only *after* the entire race had executed, at `write_receipt()` time. An unwritable or invalid `--out` (a nonexistent parent directory, or an unwritable one) was therefore discovered only once every candidate had already run - all of that work done and then discarded at the point of writing.

This mirrors the existing early base-digest guard: before minting the Ed25519 signing key, creating the audit directory, or booting any candidate, `fork_race_cmd` now probes the `--out` parent directory for writability. A missing parent dir or a `0o000` dir fails as a clean `ClickException` (exit 1, no traceback) with zero side effects.

## Why

An operator who typos `--out` (or points it at a read-only location) currently pays for the full, possibly-expensive candidate race and gets nothing back. Validating the destination up front turns a late, wasteful failure into an immediate, diagnosable one - and guarantees no signing key is minted and no audit entry appended for a doomed run.

## How

- `fork_race_cmd`: additive preflight right after the base-digest guard and before the signing key is minted. Parent-dir existence check plus an actual write probe (`tempfile.NamedTemporaryFile(dir=parent)`), so a `0o000` directory is caught exactly as the real write would fail. The post-race `write_receipt(out_path, receipt)` is unchanged.

## Tests (TDD)

- `test_fork_race_out_nonexistent_parent_fails_before_dispatch` - present, valid `--base` + missing `--out` parent -> exit 1, clean message, **no signing key minted, no audit dir created, no receipt written, no traceback**.
- `test_fork_race_out_unwritable_parent_fails_before_dispatch` - same invariant for a `0o000` parent (skipped on Windows/root, matching the existing chmod-based tests).

Both use a genuinely CAS-present base so that, without the preflight, the command proceeds to mint a key and create the audit dir before it ever tries to write - which is the discriminator. Revert-check confirmed: deleting the preflight turns both tests red. Full `tests/unit/sandbox/test_sandbox_cli.py` (24 tests) passes; ruff lint + format clean.

## Scope

Closes #2707 (AC4 - the last unmet acceptance criterion). This was the final child of epic #2708; merging it closes that epic. Diff is minimal and localized to `fork_race_cmd`'s preflight.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `fork-race` command now validates that the output location exists and is writable before starting work.
  * Invalid output paths fail quickly with a clear error instead of producing a traceback.
  * Prevented unnecessary files and security artifacts from being created when the output destination is invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->