### PR TITLE
chore(release): v3.8.0

### DIFF
--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bernstein",
-  "version": "3.7.1",
+  "version": "3.8.0",
   "description": "Multi-agent orchestration for CLI coding agents. Spawn parallel agents, verify their work, and merge results.",
   "author": {
     "name": "chernistry",

--- a/docs/release-notes/v3.8.0.md
+++ b/docs/release-notes/v3.8.0.md
@@ -1,0 +1,35 @@
+# v3.8.0
+
+Feature release: a microVM sandbox tier, a callable A2A node, a browser activity worker, and a signed automation bridge, landed alongside a large security-hardening pass whose every fix ships with a regression test that fails on the pre-fix code.
+
+## Features
+
+- **MicroVM sandbox backend with content-addressed snapshots (#2701).** A new isolation tier for deterministic fork-and-race: candidate workspaces are canonicalised to a content address, so two operators with the same inputs derive the same snapshot digest. Opt-in via `--sandbox microvm` (#2714); never auto-selected. Contributed by @ecgang.
+- **Callable, discoverable A2A node (#2677).** A signed `/.well-known/agent.json` card, a persisted A2A handler that survives restart, and agent-registry publication. Every inbound delegation returns a signed response receipt.
+- **Browser activity worker with replayable site checks (#2669).** A non-coding activity modality whose site checks are recorded as replayable, lineage-attested artifacts.
+- **Automation bridge (#2670).** Signed trigger receipts and chain-anchored status callbacks, so an external automation firing a goal leaves a verifiable trail.
+- **Declarative adapter capability profiles (#2672).** Each adapter declares a machine-readable capability profile (MCP client/server, sandbox tier, vision, computer-use, parallelism) with a content-addressed profile hash.
+
+## Security and integrity hardening
+
+Each item is a confirmed defect with a regression test that fails on the pre-fix code, several found by cross-model adversarial review of already-merged work.
+
+- **Resume authenticates the suspend receipt before acting (#2725).** The resume/release path authorized off an unauthenticated audit-chain read, so a forged suspend receipt with an invalid HMAC could drive a real resume. It now reads through the authenticated `scan_verified` primitive; a forged receipt is refused.
+- **`sandbox receipt verify` is anchored by default and never conflates absent with tampered (#2713).** One shared verdict definition backs both the CLI and the library; an unanchored receipt never exits 0, an unreadable blob is reported as a reader-side problem rather than as a missing record, and a malformed input returns a verdict instead of a traceback. Contributed by @ecgang.
+- **Snapshot canonicalisation is a pure function of the tree (#2719).** The digest no longer folds in the calling process's execute permission, host symlink targets, or dropped special files, so a snapshot written on one host verifies on another.
+- **Intent-capsule verification derives from signed state (#2674)** and its journal reads route through the shared containment barrier (#2727), so a run journal planted outside the runs root is refused rather than read.
+- **Clearance-gate atomicity, idempotence, and verification hardened (#2678);** **approval-card resolution made terminal, bounded, and verifiable (#2671);** **sovereign attestation made equal to the enforced posture (#2681);** **recipe fires now submit and receipt real work, with lineage, DST, and collision handling hardened (#2673).**
+
+## Fixed
+
+- **Local dashboard auth no longer locks the CLI and browser out of their own task server (#2726).** With dashboard auth configured, `bernstein run` and `bernstein gui serve` returned 401 against the server they had just started. The CLI now authenticates to its own server, and the UI shell plus PWA assets are served without a bearer token while every data route still requires one. External unauthenticated access still returns 401; the posture is unchanged.
+- **Drain-merge subprocess is killed on every exit path, including cancellation (#2718).** A cancelled drain no longer leaves a coding-agent subprocess running against the repository with write access.
+- **Worktree and session-fork creation undo themselves when a post-creation step fails (#2716);** **fork-race teardown is cancellation-resilient and its lifecycle receipts are honest (#2720);** **`fork-race --out` is validated before any candidate is dispatched (#2707).**
+
+## CI and release infrastructure
+
+- **Per-PR CI load cut by shifting full-width validation toward a merge-queue lane (#2724);** review-bot-ack now reports on `merge_group` (#2723); the release chain self-dispatches past the GITHUB_TOKEN handoffs that previously needed two manual dispatches (#2722).
+
+## Code-scanning
+
+The open-alert set was worked to disposition: real defects fixed with regression tests, and canonical-serialisation coercions dismissed as false positives with a documented rationale, because removing them would change hash inputs and break byte-identical replay.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "3.7.1"
+version = "3.8.0"
 description = "Deterministic, verifiable orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40+ more): reproducible parallel runs in git worktrees, always-on lineage and replay journal, opt-in HMAC-chained audit log, air-gap install profile."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/server.json
+++ b/server.json
@@ -6,19 +6,19 @@
     "url": "https://github.com/sipyourdrink-ltd/bernstein",
     "source": "github"
   },
-  "version": "3.7.1",
+  "version": "3.8.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "bernstein",
-      "version": "3.7.1",
+      "version": "3.8.0",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/sipyourdrink-ltd/bernstein:3.7.1",
+      "identifier": "ghcr.io/sipyourdrink-ltd/bernstein:3.8.0",
       "transport": {
         "type": "stdio"
       }

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "3.7.1"
+version = "3.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
Version bump to 3.8.0: pyproject, uv.lock, server.json, plugin.json, plus docs/release-notes/v3.8.0.md.

milestone/7 is at 0 open / 44 closed. main is green. After this merges, the tag is cut on the resulting green-main SHA (auto-release skips bump-only commits, so the tag is manual), and publish.yml + publish-docker.yml run via the tag trigger and the self-dispatch added in #2722.