### PR TITLE
chore(release): v3.8.1

### DIFF
--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bernstein",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "Multi-agent orchestration for CLI coding agents. Spawn parallel agents, verify their work, and merge results.",
   "author": {
     "name": "chernistry",

--- a/docs/release-notes/v3.8.1.md
+++ b/docs/release-notes/v3.8.1.md
@@ -1,0 +1,12 @@
+# v3.8.1
+
+Patch release: two operator-facing fixes to the local dashboard and a missing runtime dependency, both surfaced by an end-to-end run of the released 3.8.0 build.
+
+## Fixed
+
+- **`bernstein doctor` no longer crashes on a clean install (#2735).** `doctor` (and its adapter last-green, security-floor, and advisory checks) import `packaging.version` at runtime, but `packaging` was only present transitively via dev tooling and was never a declared runtime dependency, so a `uv tool install bernstein` shipped without it and `doctor` raised `ModuleNotFoundError: No module named 'packaging'`. `packaging` is now a direct runtime dependency, with a contract test that fails if any runtime module imports it while it is undeclared.
+- **The local dashboard no longer locks the operator out (#2736).** Running `bernstein gui serve` on loopback with dashboard auth configured loaded the UI shell but returned 401 on every data panel, because the local serve path never handed the browser a credential and the bundled SPA wrote the onboarding token to a different localStorage key than the API layer read. The local serve path now seeds a token for the loopback browser, and the shipped SPA bundle was rebuilt so the write and read keys agree. External unauthenticated access still returns 401; the auth posture is unchanged.
+
+## Build
+
+- The bundled web UI could not be rebuilt: an earlier dependency bump moved it to Tailwind v4 while the stylesheet and PostCSS config stayed on the v3 form, so `npm run build` failed. Tailwind is pinned back to the version the configuration targets, and the regenerated bundle ships with this release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "3.8.0"
+version = "3.8.1"
 description = "Deterministic, verifiable orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40+ more): reproducible parallel runs in git worktrees, always-on lineage and replay journal, opt-in HMAC-chained audit log, air-gap install profile."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/server.json
+++ b/server.json
@@ -6,19 +6,19 @@
     "url": "https://github.com/sipyourdrink-ltd/bernstein",
     "source": "github"
   },
-  "version": "3.8.0",
+  "version": "3.8.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "bernstein",
-      "version": "3.8.0",
+      "version": "3.8.1",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/sipyourdrink-ltd/bernstein:3.8.0",
+      "identifier": "ghcr.io/sipyourdrink-ltd/bernstein:3.8.1",
       "transport": {
         "type": "stdio"
       }

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "3.8.0"
+version = "3.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
Patch release delivering the two operator-facing fixes found by an e2e of the 3.8.0 build:
- #2735 packaging runtime dependency (bernstein doctor crash)
- #2736 local dashboard auth + SPA rebuild (gui serve 401 lockout)

Bumps pyproject + uv.lock + server.json + plugin.json, adds docs/release-notes/v3.8.1.md. After merge: tag on green main (auto-release skips bump-only), publish.yml + publish-docker.yml via the tag + #2722 self-dispatch.