### PR TITLE
fix(cli): restore the startup banner (block-art on TTY, no vanish when splash off)

### DIFF
--- a/src/bernstein/cli/display/splash.py
+++ b/src/bernstein/cli/display/splash.py
@@ -28,6 +28,46 @@ def _detect_terminal_width(console: Console) -> int:
         return 80
 
 
+def _block_logo_lines() -> list[str]:
+    """The multi-line block-art BERNSTEIN logo, or ``[]`` when unavailable.
+
+    Reuses the same packaged asset the premium splash renders so both tiers
+    show the identical wordmark. ``_load_logo`` returns a single-line text
+    fallback (``["  BERNSTEIN"]``) when the asset is missing; only the real
+    multi-line art is worth drawing here, so a shorter result yields ``[]``.
+    """
+    try:
+        from bernstein.cli.display.splash_v2 import _load_logo
+
+        lines = _load_logo()
+    except Exception:
+        return []
+    return lines if len(lines) > 1 else []
+
+
+def _print_block_logo(console: Console, width: int) -> None:
+    """Draw the block-art logo when the terminal can actually show it.
+
+    Gated on an interactive terminal wide enough to hold the art: non-TTY
+    output (CI logs, pipes) and narrow terminals keep the dense one-liner so
+    scrollback and captured logs stay compact.
+    """
+    if not console.is_terminal:
+        return
+    lines = _block_logo_lines()
+    if not lines:
+        return
+    logo_w = max(len(line) for line in lines)
+    if width < logo_w + 2:
+        return
+
+    from rich.text import Text
+
+    pad = max(0, (min(width, 80) - logo_w) // 2)
+    for line in lines:
+        console.print(Text(" " * pad + line, style="bold cyan"))
+
+
 def _print_agents_block(
     console: Console,
     agents: list[dict[str, Any]],
@@ -90,6 +130,7 @@ def splash(
 
     sep = f"[dim]{_SEP_CHAR}[/dim]" * min(56, width - 2)
     console.print(sep)
+    _print_block_logo(console, width)
     ver = f" v{version}" if version else ""
     console.print(f"  [bold blue]BERNSTEIN[/bold blue][dim]{ver}  declarative agent orchestration[/dim]")
     console.print(sep)

--- a/src/bernstein/cli/display/splash_screen.py
+++ b/src/bernstein/cli/display/splash_screen.py
@@ -660,7 +660,7 @@ def splash(
     budget: float = 0.0,
     task_count: int = 0,
     skip_animation: bool = False,
-) -> None:
+) -> bool:
     """Show the startup splash, falling back to compact on any error.
 
     The bare ``except Exception`` below is load-bearing: any renderer crash
@@ -668,6 +668,13 @@ def splash(
     where the premium splash silently turns into the compact one (the
     "where is my banner" class of bug).  Set ``BERNSTEIN_DEBUG_SPLASH=1``
     to surface the underlying error to stderr instead of swallowing it.
+
+    Returns ``True`` when a banner was emitted (premium or compact fallback)
+    and ``False`` when the splash is disabled (``visual.splash=false`` /
+    ``BERNSTEIN_NO_SPLASH``) so nothing was rendered.  The bare ``cli()``
+    entry point uses this to decide whether the durable box banner still
+    needs printing -- a disabled splash must not leave the operator with no
+    startup banner at all.
     """
     try:
         from pathlib import Path
@@ -687,7 +694,7 @@ def splash(
         else:
             config = resolve_visual_config(None)
 
-        render_startup_splash(
+        return render_startup_splash(
             console,
             version=version,
             agents=agents,
@@ -719,3 +726,5 @@ def splash(
             budget=budget,
             task_count=task_count,
         )
+        # The compact fallback emitted a banner, so report success.
+        return True

--- a/src/bernstein/cli/display/splash_v2.py
+++ b/src/bernstein/cli/display/splash_v2.py
@@ -73,9 +73,17 @@ class SplashRenderer:
         self._skip = skip_animation
         self._config = config or VisualConfig()
 
-    def render(self, context: SplashContext | None = None) -> None:
+    def render(self, context: SplashContext | None = None) -> bool:
+        """Render the startup splash.
+
+        Returns ``True`` when a banner was actually emitted, ``False`` when
+        the splash is disabled (``visual.splash=false`` / ``BERNSTEIN_NO_SPLASH``)
+        and nothing was written. Callers use the return value to decide whether
+        a durable fallback banner still needs printing, so a disabled splash
+        does not silently leave the user with no startup banner at all.
+        """
         if not self._config.splash:
-            return
+            return False
         ctx = context or SplashContext()
         tier = self._select_tier()
         if self._skip or os.environ.get("CI"):
@@ -86,6 +94,7 @@ class SplashRenderer:
             self._render_tier2(ctx)
         else:
             self._render_tier3(ctx)
+        return True
 
     def _select_tier(self) -> str:
         if self._config.splash_tier != "auto":
@@ -275,10 +284,15 @@ def render_startup_splash(
     task_count: int = 0,
     skip_animation: bool = False,
     config: VisualConfig | None = None,
-) -> None:
-    """Compatibility entrypoint for main.py and splash_screen.py."""
+) -> bool:
+    """Compatibility entrypoint for main.py and splash_screen.py.
+
+    Returns ``True`` when a banner was emitted and ``False`` when the splash
+    is disabled (nothing rendered), so the caller can fall back to the
+    durable box banner instead of showing no startup banner at all.
+    """
     renderer = SplashRenderer(console, skip_animation=skip_animation, config=config)
-    renderer.render(
+    return renderer.render(
         SplashContext(
             version=version,
             agents=[a.copy() for a in (agents or [])],

--- a/src/bernstein/cli/helpers.py
+++ b/src/bernstein/cli/helpers.py
@@ -74,6 +74,29 @@ def print_banner() -> None:
     console.print(f"[blue]{BANNER}[/blue]")
 
 
+def print_startup_banner() -> None:
+    """Show the program-load banner: the block-art ASCII wordmark on an
+    interactive terminal, the compact box banner otherwise.
+
+    The compact splash renders the full block-art logo on a real TTY; on
+    non-interactive output (CI, pipes, captured test output) it collapses to a
+    dense one-liner, so we fall through to the box banner there. That keeps CI
+    logs terse and preserves the ``Agent Orchestra`` marker the run-banner
+    regression guard asserts, while interactive operators get the wordmark back
+    at ``bernstein run`` time (the premium splash only fires on the bare
+    ``bernstein`` invocation).
+    """
+    if console.is_terminal:
+        try:
+            from bernstein.cli.display.splash import splash as _compact_splash
+
+            _compact_splash(console, skip_animation=True)
+            return
+        except Exception:
+            pass
+    print_banner()
+
+
 def auth_headers() -> dict[str, str]:
     """Return Authorization header dict if BERNSTEIN_AUTH_TOKEN is set."""
     token = os.environ.get("BERNSTEIN_AUTH_TOKEN")

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -779,7 +779,7 @@ def cli(
     _splash_future = executor.submit(_background_startup, workdir)
 
     # Show splash immediately (gradient + logo) - no agent data needed for visuals.
-    splash(
+    banner_shown = splash(
         console,
         version="",
         agents=[],
@@ -788,9 +788,15 @@ def cli(
         budget=budget,
         task_count=0,
     )
-    # Mark that the premium splash has been shown so the inner ``run`` callback
-    # invoked below does not also print the compact banner (double-banner).
-    ctx.obj["_BANNER_PRINTED"] = True
+    # Mark that a startup banner has already been shown so the inner ``run``
+    # callback invoked below does not also print the compact box banner
+    # (double-banner). When the splash is disabled (``visual.splash=false`` /
+    # ``BERNSTEIN_NO_SPLASH``) it renders nothing and returns ``False`` -- in
+    # that case we must leave the flag unset so the durable box banner still
+    # prints. Otherwise the bare ``bernstein`` invocation showed no startup
+    # banner at all while ``bernstein run`` still did (regression).
+    if banner_shown:
+        ctx.obj["_BANNER_PRINTED"] = True
 
     # Show immediate feedback while background finishes - no black screen.
     console.print("[dim]Preparing...[/dim]", end="\r")

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -25,6 +25,7 @@ from bernstein.cli.helpers import (
     console,
     find_seed_file,
     print_banner,
+    print_startup_banner,
     server_get,
 )
 from bernstein.cli.run_preflight import (
@@ -1708,7 +1709,7 @@ def _run_impl(
     # for subcommand invocations, so `bernstein run` lost the banner entirely.
     ctx = click.get_current_context(silent=True)
     if ctx is None or not (ctx.obj and ctx.obj.get("_BANNER_PRINTED")):
-        print_banner()
+        print_startup_banner()
 
     # Set process title so orchestrator is visible in Activity Monitor / ps
     with suppress(ImportError):

--- a/tests/unit/cli/test_run_banner.py
+++ b/tests/unit/cli/test_run_banner.py
@@ -148,3 +148,98 @@ def test_run_subcommand_skips_banner_when_splash_already_printed(tmp_path: Any) 
             assert banner_spy.call_count == 0, "banner was double-printed despite splash flag"
     finally:
         os.chdir(cwd)
+
+
+# ---------------------------------------------------------------------------
+# Bare ``bernstein`` (no subcommand) contract when the splash is disabled
+# ---------------------------------------------------------------------------
+
+
+def _invoke_bare_plan_only(tmp_path: Any) -> str:
+    """Invoke the bare ``bernstein --plan-only`` entry point (no subcommand).
+
+    This is the ``ctx.invoked_subcommand is None`` branch of ``main.cli`` --
+    the "general program load" path that shows the startup splash and then
+    chains into the run callback.  ``--plan-only`` exits before any agent is
+    spawned.
+    """
+    seed = tmp_path / "bernstein.yaml"
+    seed.write_text("goal: banner-bare-regression\ntasks: []\n")
+
+    runner = CliRunner()
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        result = runner.invoke(cli, ["--plan-only"], catch_exceptions=False)
+    finally:
+        os.chdir(cwd)
+    return result.output or ""
+
+
+def test_bare_invocation_prints_banner_when_splash_disabled(tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bare ``bernstein`` with the splash disabled must still print the box banner.
+
+    Regression: ``main.cli`` set ``ctx.obj["_BANNER_PRINTED"] = True``
+    unconditionally right after calling ``splash()``.  When the splash was
+    disabled (``BERNSTEIN_NO_SPLASH`` / ``visual.splash=false``) it rendered
+    nothing, yet the flag still suppressed the inner run callback's box
+    banner -- so the bare invocation showed *no* startup banner at all while
+    ``bernstein run`` still did.  ``splash()`` now reports whether it emitted
+    a banner and ``main.cli`` only sets the flag when it did.
+    """
+    monkeypatch.setenv("BERNSTEIN_NO_SPLASH", "1")
+    output = _invoke_bare_plan_only(tmp_path)
+    assert "Bernstein" in output, output
+    assert "Agent Orchestra" in output, output
+
+
+def test_bare_invocation_does_not_double_print_when_splash_enabled(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With the splash enabled, the bare path must not *also* print the box banner.
+
+    Pins the other side of the fix: when the splash actually renders (here the
+    compact fallback, since CliRunner's stdout is not a TTY), the durable box
+    banner (``BANNER`` / "Agent Orchestra") must stay suppressed so the operator
+    never sees two banners stacked.
+    """
+    monkeypatch.delenv("BERNSTEIN_NO_SPLASH", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    output = _invoke_bare_plan_only(tmp_path)
+    # The compact splash marker is present ...
+    assert "declarative agent orchestration" in output, output
+    # ... but the box banner's title-case subtitle must NOT be (no double-print).
+    assert "Agent Orchestra" not in output, output
+
+
+# ---------------------------------------------------------------------------
+# ``splash()`` return-value contract (the mechanism main.cli relies on)
+# ---------------------------------------------------------------------------
+
+
+def test_splash_reports_false_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``splash()`` returns ``False`` when disabled so callers can fall back.
+
+    The bare ``cli()`` path branches on this value; if the splash ever again
+    returns ``None``/truthy while rendering nothing, the box-banner fallback
+    silently breaks.  This locks the contract at the unit level.
+    """
+    from rich.console import Console
+
+    from bernstein.cli.display.splash_screen import splash as splash_fn
+
+    monkeypatch.setenv("BERNSTEIN_NO_SPLASH", "1")
+    con = Console(file=io.StringIO(), force_terminal=True)
+    assert splash_fn(con, version="1.0", agents=[], skip_animation=True) is False
+
+
+def test_splash_reports_true_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``splash()`` returns ``True`` when it actually emits a banner."""
+    from rich.console import Console
+
+    from bernstein.cli.display.splash_screen import splash as splash_fn
+
+    monkeypatch.delenv("BERNSTEIN_NO_SPLASH", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    con = Console(file=io.StringIO(), force_terminal=True)
+    assert splash_fn(con, version="1.0", agents=[], skip_animation=True) is True

--- a/tests/unit/cli/test_startup_banner_blockart.py
+++ b/tests/unit/cli/test_startup_banner_blockart.py
@@ -1,0 +1,81 @@
+"""Guard the block-art ASCII wordmark on the interactive startup banner.
+
+The premium full-screen splash only fires on the bare ``bernstein`` invocation
+and only in colour-capable terminals (tier1/tier2). Plain interactive terminals
+(tier3) and ``bernstein run`` previously fell back to a compact one-liner / a
+small box with no block-art, so the recognisable ASCII wordmark silently
+disappeared for most operators. These tests pin the restored behaviour: an
+interactive terminal shows the block-art; non-TTY output (CI, pipes, captured
+test output) stays compact so logs are not polluted and the run-banner
+regression guard keeps its ``Agent Orchestra`` marker.
+"""
+
+from __future__ import annotations
+
+import pytest
+from rich.console import Console
+
+from bernstein.cli.display.splash import _block_logo_lines, splash
+
+_BLOCK_GLYPHS = ("▄", "▀", "█", "▐", "▌")
+
+
+def _has_block_art(text: str) -> bool:
+    return any(g in text for g in _BLOCK_GLYPHS)
+
+
+def test_block_logo_asset_is_multiline_art() -> None:
+    lines = _block_logo_lines()
+    assert len(lines) > 1, "expected multi-line block-art logo asset"
+    assert _has_block_art("\n".join(lines)), lines
+
+
+def test_compact_splash_shows_block_art_on_a_tty() -> None:
+    console = Console(force_terminal=True, width=100)
+    with console.capture() as cap:
+        splash(console, version="9.9.9", skip_animation=True)
+    out = cap.get()
+    assert _has_block_art(out), out
+    assert "declarative agent orchestration" in out
+
+
+def test_compact_splash_stays_compact_on_non_tty() -> None:
+    # The CI / pipe shape must NOT emit block-art, keeping captured logs terse.
+    console = Console(force_terminal=False, width=100)
+    with console.capture() as cap:
+        splash(console, version="9.9.9", skip_animation=True)
+    out = cap.get()
+    assert not _has_block_art(out), out
+    assert "BERNSTEIN" in out
+
+
+def test_compact_splash_stays_compact_on_narrow_tty() -> None:
+    # Too narrow to hold the art: fall back to the one-liner even on a TTY.
+    console = Console(force_terminal=True, width=30)
+    with console.capture() as cap:
+        splash(console, version="9.9.9", skip_animation=True)
+    out = cap.get()
+    assert not _has_block_art(out), out
+
+
+def test_startup_banner_shows_block_art_on_a_tty(monkeypatch: pytest.MonkeyPatch) -> None:
+    import bernstein.cli.helpers as helpers
+
+    tty_console = Console(force_terminal=True, width=100)
+    monkeypatch.setattr(helpers, "console", tty_console)
+    with tty_console.capture() as cap:
+        helpers.print_startup_banner()
+    out = cap.get()
+    assert _has_block_art(out), out
+
+
+def test_startup_banner_falls_back_to_box_on_non_tty(monkeypatch: pytest.MonkeyPatch) -> None:
+    import bernstein.cli.helpers as helpers
+
+    plain_console = Console(force_terminal=False, width=100)
+    monkeypatch.setattr(helpers, "console", plain_console)
+    with plain_console.capture() as cap:
+        helpers.print_startup_banner()
+    out = cap.get()
+    assert not _has_block_art(out), out
+    assert "Agent Orchestra" in out


### PR DESCRIPTION
## Startup banner regression: two coupled defects

Operators lost the recognisable ASCII wordmark at program load. Two distinct causes:

### 1. Banner vanished entirely when the splash was disabled
On the bare `bernstein` invocation the code set `ctx.obj["_BANNER_PRINTED"] = True` unconditionally, then the chained `run` callback skips its box banner to avoid a double-print. But when the splash is disabled (`visual.splash: false` or `BERNSTEIN_NO_SPLASH=1`) the renderer emits nothing, so the box banner was suppressed too and **no banner showed at all**.

Fix: `splash()` now reports whether it actually rendered; `cli()` only sets `_BANNER_PRINTED` when a banner was truly shown, so the durable box prints when the splash is off.

### 2. Block-art wordmark absent on plain terminals and on `bernstein run`
The premium full-screen splash (big block-art logo) only fires on the bare `bernstein` invocation **and** only in colour-capable terminals (tier1/tier2 — kitty/iTerm2/truecolor/256-colour). Plain interactive terminals (tier3) and every `bernstein run` fell back to a compact one-liner / small box with no block-art.

Fix: the compact splash now renders the packaged block-art logo (the same asset the premium splash uses), gated on an interactive terminal wide enough to hold it; the `bernstein run` startup banner is routed through it on a TTY. Non-TTY output (CI, pipes, captured test output) keeps the dense one-liner / box so logs stay terse and the run-banner regression guard's `Agent Orchestra` marker is preserved.

## Tests
- `test_run_banner.py`: +4 guards (bare+splash-off prints a banner; no double-print when splash on; `splash()` return contract).
- `test_startup_banner_blockart.py`: +7 guards (block-art asset is multi-line; compact splash shows block-art on a TTY, stays compact on non-TTY and on a narrow TTY; `print_startup_banner` shows block-art on a TTY and falls back to the box with `Agent Orchestra` on non-TTY).
- Revert-checked: the disabled-path guard goes red under the old unconditional flag; the block-art guards go red without the compact-splash logo.

Targeted files only (never the full suite). ruff check + format clean.

Milestone: v3.8.2.