### PR TITLE
fix(orchestrator): honor explicit adapter over seed cli in --idle mode

### DIFF
--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -5238,6 +5238,35 @@ def _collect_smtp_targets(seed: Any, targets: list[NotificationTarget]) -> None:
     )
 
 
+def _resolve_spawner_adapter_name(
+    explicit_adapter: str | None,
+    seed_cli: str | None,
+) -> str | None:
+    """Resolve the orchestrator's adapter with explicit-override precedence.
+
+    An adapter supplied out-of-band -- the ``--adapter`` flag or the
+    ``BERNSTEIN_ADAPTER`` env var, both surfaced here as ``explicit_adapter``
+    -- always wins over the seed's ``cli`` field. The seed value is only a
+    fallback for when no adapter was passed explicitly.
+
+    This mirrors the run-model precedence (``args.model or seed.model``) and
+    is load-bearing for ``bernstein run --idle``: that mode exports
+    ``BERNSTEIN_ADAPTER=mock`` precisely so the orchestrator never spawns real
+    Claude agents (and burns tokens / 401s) when the resolved
+    ``bernstein.yaml`` leaves ``cli`` at its ``auto`` default. Letting the
+    seed's ``cli`` clobber an explicit adapter silently defeats that contract.
+
+    Returns ``None`` only when neither source configured an adapter, which the
+    caller treats as a fatal misconfiguration (Bernstein never defaults to
+    Claude).
+    """
+    explicit = (explicit_adapter or "").strip()
+    if explicit:
+        return explicit
+    seed_value = (seed_cli or "").strip()
+    return seed_value or None
+
+
 if __name__ == "__main__":
     import argparse
     import sys
@@ -5387,7 +5416,14 @@ if __name__ == "__main__":
             )
             try:
                 seed = parse_seed(seed_path)
-                adapter_name = getattr(seed, "cli", adapter_name)
+                # An explicit --adapter / BERNSTEIN_ADAPTER wins over the
+                # seed's ``cli`` (which defaults to ``auto``); the seed value
+                # is only a fallback. Without this, ``bernstein run --idle``
+                # (which exports BERNSTEIN_ADAPTER=mock) is silently overridden
+                # by the seed default and spawns real Claude agents.
+                adapter_name = _resolve_spawner_adapter_name(
+                    args.adapter, getattr(seed, "cli", None)
+                )
                 _seed_role_model_policy = getattr(seed, "role_model_policy", None)
                 if not _seed_role_model_policy:
                     print(

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -5421,9 +5421,7 @@ if __name__ == "__main__":
                 # is only a fallback. Without this, ``bernstein run --idle``
                 # (which exports BERNSTEIN_ADAPTER=mock) is silently overridden
                 # by the seed default and spawns real Claude agents.
-                adapter_name = _resolve_spawner_adapter_name(
-                    args.adapter, getattr(seed, "cli", None)
-                )
+                adapter_name = _resolve_spawner_adapter_name(args.adapter, getattr(seed, "cli", None))
                 _seed_role_model_policy = getattr(seed, "role_model_policy", None)
                 if not _seed_role_model_policy:
                     print(

--- a/tests/unit/test_orchestrator_idle_adapter.py
+++ b/tests/unit/test_orchestrator_idle_adapter.py
@@ -1,0 +1,45 @@
+"""Adapter-resolution precedence for the orchestrator __main__ launch path.
+
+Regression coverage for the ``bernstein run --idle`` contract: the launcher
+exports ``BERNSTEIN_ADAPTER=mock`` (and passes ``--adapter mock``) so the
+orchestrator subprocess never spawns real Claude agents. That contract broke
+because the orchestrator overrode the explicit adapter with the seed's ``cli``
+field, which defaults to ``auto`` -> Claude, whenever a ``bernstein.yaml`` was
+present (i.e. always).
+"""
+
+from __future__ import annotations
+
+from bernstein.core.orchestration.orchestrator import _resolve_spawner_adapter_name
+
+
+def test_explicit_adapter_wins_over_seed_cli_auto_default() -> None:
+    """--idle exports BERNSTEIN_ADAPTER=mock; the seed's ``auto`` must not win.
+
+    This is the exact failure: a plain ``bernstein.yaml`` leaves ``cli`` at
+    ``auto``. If ``auto`` overrides the explicit ``mock`` the orchestrator
+    spawns real Claude agents (401 / token burn) despite ``--idle``.
+    """
+    assert _resolve_spawner_adapter_name("mock", "auto") == "mock"
+
+
+def test_explicit_adapter_wins_over_configured_seed_cli() -> None:
+    """An explicit ``--adapter``/env choice beats even a non-default seed cli."""
+    assert _resolve_spawner_adapter_name("claude", "codex") == "claude"
+
+
+def test_seed_cli_used_when_no_explicit_adapter() -> None:
+    """Normal runs (no --adapter, no env) still honour the seed's cli."""
+    assert _resolve_spawner_adapter_name(None, "codex") == "codex"
+    assert _resolve_spawner_adapter_name("", "auto") == "auto"
+
+
+def test_no_adapter_configured_returns_none() -> None:
+    """Neither source configured -> None (caller treats as fatal misconfig)."""
+    assert _resolve_spawner_adapter_name(None, None) is None
+    assert _resolve_spawner_adapter_name("", "") is None
+
+
+def test_whitespace_only_values_are_ignored() -> None:
+    """Blank/whitespace explicit adapter falls back to the seed cli."""
+    assert _resolve_spawner_adapter_name("   ", "codex") == "codex"


### PR DESCRIPTION
## Problem

`bernstein run --idle` promises "every agent will be spawned via the mock
adapter ... Zero LLM spend". The launcher (`_start_spawner`) already exports
`BERNSTEIN_ADAPTER=mock` and passes `--adapter mock` to the orchestrator
subprocess for exactly this reason.

But the orchestrator `__main__` block then did:

```python
adapter_name = args.adapter                       # "mock" (from --idle)
seed = parse_seed(seed_path)
adapter_name = getattr(seed, "cli", adapter_name) # clobbered back to seed.cli
```

`SeedConfig.cli` defaults to `auto`, so any workdir with a `bernstein.yaml`
(i.e. every real run) overrode the explicit `mock` adapter. `--idle` then
spawned real agents against the configured provider, which failed
authentication (`401 Invalid authentication credentials`). Repeated failures
drove the adapter health monitor to 100% and it disabled the adapter, so
every subsequent spawn failed with "Adapter ... is disabled by health
monitor" and all tasks ended `failed`.

Observed end to end against a playground seed under `--idle`:
`tasks_completed: 0, tasks_failed: 5`, `SPAWNER-DEBUG ... adapter=ClaudeCodeAdapter`.

## Fix

Resolve the orchestrator adapter with explicit-override precedence, mirroring
the run-model rule already used one screen down (`args.model or seed.model`):
an explicit `--adapter` flag / `BERNSTEIN_ADAPTER` env wins; the seed `cli` is
only a fallback. Extracted into a pure, unit-tested helper
`_resolve_spawner_adapter_name`.

After the fix, the same run reports the orchestrator constructing a
`MockAgentAdapter`, mock agents complete (`idle: completed`, exit 0),
`tasks_completed: 4/5`, `quality_score 1.0`, `total_cost_usd 0`, and no
authentication failures.

## Tests

`tests/unit/test_orchestrator_idle_adapter.py` covers:
- explicit `mock` wins over seed `auto` (the `--idle` case)
- explicit choice wins over a configured non-default seed cli
- seed cli still used when no explicit adapter is set (normal runs preserved)
- neither source set -> `None` (fatal-misconfig path preserved)
- whitespace-only explicit value falls back to seed cli

Verified the tests fail against the pre-fix behaviour and pass after.
Existing `test_zero_config`, `test_bootstrap`, `test_role_adapter_policy`,
`test_seed` remain green.
