### PR TITLE
fix(config): emit internal-llm preflight notice once per process

### DIFF
--- a/src/bernstein/core/config/seed_config.py
+++ b/src/bernstein/core/config/seed_config.py
@@ -22,14 +22,29 @@ from bernstein.core.models import (
 
 logger = logging.getLogger(__name__)
 
+#: Preflight hints already surfaced this process, so repeated seed parses
+#: (bootstrap, ``create_app`` CORS read, the app-startup seed reload) do not
+#: re-log the same notice. ``bernstein gui serve`` parses the seed twice, which
+#: used to print the internal-LLM notice twice; dedupe on the hint text.
+_emitted_internal_llm_hints: set[str] = set()
+
+
+def reset_internal_llm_preflight_cache() -> None:
+    """Clear the per-process preflight-dedup memory (test helper)."""
+    _emitted_internal_llm_hints.clear()
+
 
 def check_internal_llm_preflight(provider: str) -> str | None:
-    """Return a migration hint if ``provider`` needs env vars that are missing.
+    """Return a heads-up if ``provider`` needs env vars that are missing.
 
-    a fresh clone with ``internal_llm_provider: openrouter_free``
-    but no ``OPENROUTER_API_KEY_FREE`` / ``OPENROUTER_API_KEY_PAID`` crashes
-    on the first LLM call. Callers (seed parser, orchestrator bootstrap) can
-    invoke this to emit the hint early and suggest switching to ``'none'``.
+    A fresh clone with ``internal_llm_provider: openrouter_free`` but no
+    ``OPENROUTER_API_KEY_FREE`` / ``OPENROUTER_API_KEY_PAID`` cannot reach the
+    internal model, so evolution and auto_decompose stay unavailable. Callers
+    (seed parser, orchestrator bootstrap) can invoke this to surface the notice
+    early and suggest switching to ``'none'``.
+
+    This function is pure -- it never logs. Use
+    :func:`warn_internal_llm_preflight_once` for the deduped emission.
 
     Args:
         provider: The configured ``internal_llm_provider`` value.
@@ -41,13 +56,32 @@ def check_internal_llm_preflight(provider: str) -> str | None:
         os.environ.get("OPENROUTER_API_KEY_FREE") or os.environ.get("OPENROUTER_API_KEY_PAID")
     ):
         return (
-            "internal_llm_provider='openrouter_free' requires "
-            "OPENROUTER_API_KEY_FREE or OPENROUTER_API_KEY_PAID in the "
-            "environment. Either export one of those variables or set "
-            "'internal_llm_provider: none' in bernstein.yaml to disable "
-            "evolution and auto_decompose gracefully."
+            "internal_llm_provider is set to 'openrouter_free' but neither "
+            "OPENROUTER_API_KEY_FREE nor OPENROUTER_API_KEY_PAID is set. "
+            "Evolution and auto_decompose stay disabled until you export one "
+            "of those keys, or set 'internal_llm_provider: none' in "
+            "bernstein.yaml to run without them."
         )
     return None
+
+
+def warn_internal_llm_preflight_once(provider: str) -> str | None:
+    """Log the internal-LLM preflight notice at most once per process.
+
+    The seed is parsed several times per process, and each ``SeedConfig``
+    construction used to log the notice -- so ``bernstein gui serve`` emitted
+    it twice (once when ``create_app`` reads CORS, once during the
+    app-startup seed reload). Dedupe on the hint text so the operator sees it
+    at most once. Returns the hint (whether or not it was newly logged) so
+    callers can still react to it.
+    """
+    hint = check_internal_llm_preflight(provider)
+    if hint is None:
+        return None
+    if hint not in _emitted_internal_llm_hints:
+        _emitted_internal_llm_hints.add(hint)
+        logger.warning("preflight: %s", hint)
+    return hint
 
 
 if TYPE_CHECKING:
@@ -421,7 +455,5 @@ class SeedConfig:
     mcp_signing_mode: Literal["warn", "strict", "off"] = "warn"
 
     def __post_init__(self) -> None:
-        """Emit preflight warnings for provider/env mismatches."""
-        hint = check_internal_llm_preflight(self.internal_llm_provider)
-        if hint is not None:
-            logger.warning(" preflight: %s", hint)
+        """Emit preflight warnings for provider/env mismatches (once/process)."""
+        warn_internal_llm_preflight_once(self.internal_llm_provider)

--- a/tests/unit/test_seed_preflight_dedup.py
+++ b/tests/unit/test_seed_preflight_dedup.py
@@ -1,0 +1,77 @@
+"""The internal-LLM preflight notice is emitted at most once per process.
+
+``bernstein gui serve`` parses the seed twice (``create_app`` reads CORS, then
+the app-startup reload), and every ``SeedConfig`` construction used to log the
+same ``internal_llm_provider`` notice -- so operators saw it twice on startup.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from bernstein.core.config.seed_config import (
+    SeedConfig,
+    check_internal_llm_preflight,
+    reset_internal_llm_preflight_cache,
+    warn_internal_llm_preflight_once,
+)
+
+_MODULE = "bernstein.core.config.seed_config"
+
+
+@pytest.fixture(autouse=True)
+def _clear_env_and_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENROUTER_API_KEY_FREE", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY_PAID", raising=False)
+    reset_internal_llm_preflight_cache()
+
+
+def _preflight_warnings(records: list[logging.LogRecord]) -> list[logging.LogRecord]:
+    return [r for r in records if r.name == _MODULE and "preflight" in r.getMessage()]
+
+
+def test_repeated_seed_construction_warns_once(caplog: pytest.LogCaptureFixture) -> None:
+    """Two SeedConfig constructions (the gui-serve shape) -> one warning."""
+    with caplog.at_level(logging.WARNING, logger=_MODULE):
+        SeedConfig(goal="demo", internal_llm_provider="openrouter_free")
+        SeedConfig(goal="demo", internal_llm_provider="openrouter_free")
+    assert len(_preflight_warnings(caplog.records)) == 1
+
+
+def test_warn_once_helper_dedupes(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.WARNING, logger=_MODULE):
+        first = warn_internal_llm_preflight_once("openrouter_free")
+        second = warn_internal_llm_preflight_once("openrouter_free")
+    # Hint text is returned both times so callers can still react...
+    assert first is not None
+    assert second == first
+    # ...but only the first call logs.
+    assert len(_preflight_warnings(caplog.records)) == 1
+
+
+def test_no_warning_when_provider_is_none(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.WARNING, logger=_MODULE):
+        SeedConfig(goal="demo", internal_llm_provider="none")
+    assert _preflight_warnings(caplog.records) == []
+
+
+def test_reset_cache_allows_reemission(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.WARNING, logger=_MODULE):
+        warn_internal_llm_preflight_once("openrouter_free")
+        reset_internal_llm_preflight_cache()
+        warn_internal_llm_preflight_once("openrouter_free")
+    assert len(_preflight_warnings(caplog.records)) == 2
+
+
+def test_message_is_calm_and_actionable() -> None:
+    """Hint states the fact and both remedies without alarmist phrasing."""
+    hint = check_internal_llm_preflight("openrouter_free")
+    assert hint is not None
+    assert "internal_llm_provider: none" in hint
+    assert "OPENROUTER_API_KEY_FREE" in hint
+    # No alarmist verbs.
+    lowered = hint.lower()
+    assert "crash" not in lowered
+    assert "fatal" not in lowered


### PR DESCRIPTION
## Problem

`SeedConfig.__post_init__` logged the `internal_llm_provider` heads-up on
every construction. The seed is parsed several times per process, so
`bernstein gui serve` printed the same notice twice on startup:

1. `create_app()` parses the seed to read CORS config (before uvicorn start).
2. The app-startup seed reload (`_do_reload_seed_config`) parses it again.

Duplicate startup warnings are noise and make the log look alarming.

## Fix

- Dedupe the emission on the hint text via `warn_internal_llm_preflight_once`
  so the notice prints at most once per process, regardless of how many times
  the seed is parsed.
- Keep `check_internal_llm_preflight` pure (it never logs) so callers can read
  the hint without side effects.
- Calm the wording: state the fact and both remedies (export a key, or set
  `internal_llm_provider: none`) without imperative/alarmist phrasing.

## Tests

`tests/unit/test_seed_preflight_dedup.py` covers:
- two `SeedConfig` constructions (the gui-serve shape) -> exactly one warning
- the `warn_..._once` helper dedupes but still returns the hint each call
- no warning when the provider is `none`
- a reset helper re-arms emission (test isolation)
- the message is calm and actionable (no "crash"/"fatal", both remedies present)

Verified the once-per-process test fails against the pre-fix
per-construction logging and passes after. `test_seed`, `test_config_schema`
remain green.
