### PR TITLE
fix(evolution): silence locked-file warnings in non-source workspaces

### DIFF
--- a/src/bernstein/evolution/invariants.py
+++ b/src/bernstein/evolution/invariants.py
@@ -43,8 +43,19 @@ def _sha256(path: Path) -> str:
     return h.hexdigest()
 
 
+# Missing-file warnings already emitted this process, keyed by absolute path.
+# Startup verifies the lockfile and then rewrites it, hashing the same tree
+# twice; each missing file should be reported once, not once per pass.
+_warned_missing: set[str] = set()
+
+
 def compute_invariants(repo_root: Path) -> dict[str, str]:
     """Compute SHA256 hashes for all locked files.
+
+    Missing files are only warned about when ``repo_root`` contains a
+    bernstein source tree: a workspace that never had the locked files is
+    normal and stays quiet. Deletion after locking is still reported by
+    :func:`verify_invariants` as a MISSING violation.
 
     Args:
         repo_root: Repository root directory.
@@ -53,11 +64,13 @@ def compute_invariants(repo_root: Path) -> dict[str, str]:
         Dict mapping relative file path to SHA256 hex digest.
     """
     hashes: dict[str, str] = {}
+    source_tree = (repo_root / "src" / "bernstein").is_dir()
     for rel_path in LOCKED_FILES:
         full_path = repo_root / rel_path
         if full_path.exists():
             hashes[rel_path] = _sha256(full_path)
-        else:
+        elif source_tree and str(full_path) not in _warned_missing:
+            _warned_missing.add(str(full_path))
             logger.warning("Locked file not found: %s", rel_path)
     return hashes
 

--- a/tests/unit/test_invariants.py
+++ b/tests/unit/test_invariants.py
@@ -1,11 +1,15 @@
 """Tests for InvariantsGuard."""
 
+import logging
+
 from bernstein.evolution.invariants import (
     check_proposal_targets,
     compute_invariants,
     verify_invariants,
     write_lockfile,
 )
+
+_LOGGER_NAME = "bernstein.evolution.invariants"
 
 
 class TestComputeInvariants:
@@ -49,6 +53,52 @@ class TestVerifyInvariants:
         ok, _violations = verify_invariants(tmp_path)
         assert ok
         assert (tmp_path / ".sdd" / "invariants.lock").exists()
+
+
+class TestWorkspaceNoise:
+    """Locked-file warnings must not fire in workspaces that never had the files."""
+
+    def test_compute_is_silent_in_non_source_workspace(self, tmp_path, caplog):
+        """A workspace without a bernstein source tree gets zero warnings."""
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            compute_invariants(tmp_path)
+        assert not [r for r in caplog.records if "Locked file" in r.getMessage()]
+
+    def test_run_shaped_check_is_silent_in_empty_workspace(self, tmp_path, caplog):
+        """The bootstrap invariants check emits zero Locked-file warnings in an empty workspace."""
+        from bernstein.core.orchestration.bootstrap import _check_safety_invariants
+
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            _check_safety_invariants(tmp_path)
+        assert not [r for r in caplog.records if "Locked file" in r.getMessage()]
+        # The baseline lockfile is still written for later verification.
+        assert (tmp_path / ".sdd" / "invariants.lock").exists()
+
+    def test_deleted_after_lock_still_warns(self, tmp_path, caplog):
+        """A file that WAS locked and then vanished is still reported."""
+        src = tmp_path / "src" / "bernstein" / "core" / "quality"
+        src.mkdir(parents=True)
+        janitor = src / "janitor.py"
+        janitor.write_text("# original")
+        write_lockfile(tmp_path)
+        janitor.unlink()
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            ok, violations = verify_invariants(tmp_path)
+        assert not ok
+        assert any(v == "MISSING: src/bernstein/core/quality/janitor.py" for v in violations)
+        assert any(r.levelno >= logging.ERROR for r in caplog.records)
+
+    def test_missing_warning_fires_once_per_process_in_source_tree(self, tmp_path, caplog):
+        """A partial source tree warns once per missing file, not once per pass."""
+        src = tmp_path / "src" / "bernstein" / "core" / "quality"
+        src.mkdir(parents=True)
+        (src / "janitor.py").write_text("# janitor code")
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            compute_invariants(tmp_path)
+            compute_invariants(tmp_path)
+        warned = [r.getMessage() for r in caplog.records if "Locked file not found" in r.getMessage()]
+        assert len(warned) == len(set(warned))
+        assert warned  # missing files in a source tree are still surfaced
 
 
 class TestCheckProposalTargets:


### PR DESCRIPTION
Fixes #2747

## Problem

Every `bernstein run` in a workspace that does not contain the bernstein source tree printed six warnings, twice:

```
Locked file not found: src/bernstein/core/quality/janitor.py
Locked file not found: src/bernstein/core/server/server_app.py
...
```

`compute_invariants` warned for every entry of `LOCKED_FILES` missing from disk. In a user workspace those files never existed, so the warnings were pure noise. Startup verifies the lockfile and then rewrites it, hashing the tree twice, which doubled the emission.

## Fix

In `src/bernstein/evolution/invariants.py`:

- Warn about a missing locked file only when the workspace contains a bernstein source tree (`src/bernstein/` directory). A workspace that never had the files stays quiet.
- Deduplicate the warning per file per process, so the verify-then-rewrite startup sequence reports each missing file at most once.

The safety property is unchanged: a file that WAS locked and later deleted is still reported by `verify_invariants` as a `MISSING` violation and fails verification. Lockfile writing behaviour is unchanged.

## Tests

- `tests/unit/test_invariants.py::TestWorkspaceNoise` (new):
  - compute pass in a non-source workspace emits zero Locked-file warnings
  - run-shaped `_check_safety_invariants` on an empty workspace emits zero Locked-file warnings and still writes the baseline lockfile
  - a locked file that existed and was deleted still fails verification with a `MISSING` violation and an error log
  - a partial source tree warns once per missing file across repeated passes
- Revert-checked: the three new noise tests fail on the previous implementation and pass with the fix.
- `tests/unit/test_invariants.py`, `tests/unit/test_bootstrap.py`, `tests/unit/test_evolution.py` all pass; ruff check and format clean.

## Merge-order note

Touches only `src/bernstein/evolution/invariants.py` and its test file. No overlap with the pending v3.8.2 PRs #2739, #2740, #2741, #2742.
