### PR TITLE
fix(cli): make startup cost lines use the submitted task count

### DIFF
--- a/src/bernstein/cli/run_preflight.py
+++ b/src/bernstein/cli/run_preflight.py
@@ -82,7 +82,9 @@ class RunCostEstimate:
     """Preflight cost estimate for a pending run.
 
     Attributes:
-        task_count: Number of tasks the run will spawn.
+        task_count: Number of tasks the run will spawn, or ``None`` when the
+            count is not yet known (inline goal that the manager agent plans
+            after startup). ``low_usd``/``high_usd`` are then per-task rates.
         model: Display label for the model (``"adapter/model"`` or model).
         low_usd: Legacy single-point low estimate (kept for back-compat).
         high_usd: Legacy single-point high estimate (kept for back-compat).
@@ -90,22 +92,29 @@ class RunCostEstimate:
             legacy callers can leave it unset.
     """
 
-    task_count: int
+    task_count: int | None
     model: str
     low_usd: float
     high_usd: float
     band: CostBand | None = None
 
 
-def _estimate_task_count(workdir: Path, plan_file: Path | None, goal: str | None) -> int:
-    """Estimate the number of tasks from plan file or backlog."""
+def _estimate_task_count(workdir: Path, plan_file: Path | None, goal: str | None) -> int | None:
+    """Count tasks from the plan file or the synced backlog.
+
+    Returns:
+        The task count when it is knowable (explicit plan file or non-empty
+        backlog), or ``None`` when planning has not happened yet (inline
+        goal, unreadable plan file, empty backlog). ``None`` means unknown;
+        callers must not substitute a made-up number for display.
+    """
     if plan_file is not None:
         try:
             return max(1, len(load_plan_from_yaml(plan_file)))
         except Exception:
-            return 5
+            return None
     if goal is not None:
-        return 5
+        return None
     count = 0
     for subdir in ("open", "issues"):
         backlog_dir = workdir / ".sdd" / "backlog" / subdir
@@ -113,7 +122,7 @@ def _estimate_task_count(workdir: Path, plan_file: Path | None, goal: str | None
             count += len(list(backlog_dir.glob("*.md")))
             count += len(list(backlog_dir.glob("*.yaml")))
             count += len(list(backlog_dir.glob("*.yml")))
-    return max(1, count)
+    return count if count > 0 else None
 
 
 def _resolve_model_and_cli(
@@ -207,6 +216,9 @@ def _estimate_run_preview(
         Cost estimate using the best available task count and model hint.
     """
     est_task_count = _estimate_task_count(workdir, plan_file, goal)
+    # Unknown count: compute a per-task rate (count of 1) but keep
+    # ``task_count=None`` so display code says "unknown" instead of a number.
+    billable_count = est_task_count if est_task_count is not None else 1
     est_model, est_cli, est_role = _resolve_model_and_cli(seed_file, model_override)
 
     if est_cli in _FREE_ADAPTERS:
@@ -221,12 +233,12 @@ def _estimate_run_preview(
             model=est_model,
         )
     else:
-        low_usd, high_usd = estimate_run_cost(est_task_count, est_model)
+        low_usd, high_usd = estimate_run_cost(billable_count, est_model)
         band = compute_band(
             role=est_role,
             adapter=est_cli,
             model=est_model,
-            task_count=est_task_count,
+            task_count=billable_count,
             metrics_dir=workdir / ".sdd" / "metrics",
         )
     display_model = f"{est_cli}/{est_model}" if est_cli != "claude" else est_model
@@ -270,19 +282,22 @@ def _emit_preflight_runtime_warnings(
     disk_usage_gb = directory_size_bytes(sdd_dir) / (1024**3)
     band = estimate.band
     if not quiet:
+        # Only print a count that came from the plan/backlog; when the count
+        # is unknown (planning happens after startup) say so explicitly
+        # instead of substituting a made-up number.
+        if estimate.task_count is not None:
+            basis = f"based on {estimate.task_count} task(s) at {estimate.model} pricing"
+        else:
+            basis = f"per task at {estimate.model} pricing, task count not yet planned"
         if band is not None:
             console.print(f"[bold yellow]{format_band(band)}[/bold yellow]")
             samples_note = (
                 f"{band.samples} historical sample(s)" if not band.cold_start else "no history yet - using heuristic"
             )
-            console.print(
-                f"[dim]based on {estimate.task_count} task(s) at {estimate.model} pricing, {samples_note}[/dim]"
-            )
+            console.print(f"[dim]{basis}, {samples_note}[/dim]")
         else:
             console.print(
-                "[bold yellow]Estimated cost:[/bold yellow] "
-                f"${estimate.low_usd:.2f}-${estimate.high_usd:.2f} "
-                f"based on {estimate.task_count} task(s) at {estimate.model} pricing"
+                f"[bold yellow]Estimated cost:[/bold yellow] ${estimate.low_usd:.2f}-${estimate.high_usd:.2f} {basis}"
             )
         if disk_usage_gb >= 1.0:
             console.print(

--- a/src/bernstein/core/orchestration/bootstrap.py
+++ b/src/bernstein/core/orchestration/bootstrap.py
@@ -494,6 +494,36 @@ def _sync_and_plan_tasks(
     return backlog_count, manager_task_id, prior_session
 
 
+def _describe_cost_estimate(backlog_count: int, model: str | None) -> str:
+    """Build the startup cost-estimate fragment from the synced task count.
+
+    ``backlog_count`` is the number of tasks actually submitted to the task
+    server (backlog sync or plan-file post), so the printed count can never
+    disagree with the run's real task list. When it is zero the manager
+    agent has not planned yet: the count is unknown, so a per-task rate is
+    shown and no count is printed.
+
+    Args:
+        backlog_count: Tasks synced/posted to the server; 0 means planning
+            is deferred to the manager agent.
+        model: Configured model name, or ``None``/empty when unset.
+
+    Returns:
+        Plain-text fragment for the startup cost line.
+    """
+    from bernstein.core.cost import estimate_run_cost
+
+    if backlog_count > 0:
+        if model:
+            low, high = estimate_run_cost(backlog_count, model)
+            return f"~${low:.2f}-${high:.2f} ({backlog_count} task(s), {model})"
+        return f"unknown (no model configured, {backlog_count} task(s))"
+    if model:
+        low, high = estimate_run_cost(1, model)
+        return f"~${low:.2f}-${high:.2f} per task ({model}, task count pending planning)"
+    return "unknown (no model configured, task count pending planning)"
+
+
 def _record_team_manifest_lineage(seed: SeedConfig, workdir: Path) -> None:
     """Anchor a run's team manifest in the audit chain (issue #2248, AC3).
 
@@ -663,16 +693,9 @@ def bootstrap_from_seed(
         worker_role=worker_role,
     )
 
-    # Cost estimate (single compact line)
-    from bernstein.core.cost import estimate_run_cost
-
-    est_count = backlog_count if backlog_count > 0 else 5
-    est_model = seed.model
-    if est_model:
-        low, high = estimate_run_cost(est_count, est_model)
-        console.print(f"  [dim]cost[/dim]    ~${low:.2f}-${high:.2f} ({est_count} tasks, {est_model})")
-    else:
-        console.print(f"  [dim]cost[/dim]    unknown (no model configured, {est_count} tasks)")
+    # Cost estimate (single compact line). Derived from the synced task
+    # count so it can never disagree with the submitted backlog.
+    console.print(f"  [dim]cost[/dim]    {_describe_cost_estimate(backlog_count, seed.model)}")
 
     # 5. Start spawner + watchdog
     # Propagate the resolved adapter (e.g. ``mock`` from ``--idle``) explicitly so
@@ -1235,20 +1258,9 @@ def _bootstrap_from_goal_impl(
         icons=_icons,
     )
 
-    # Cost estimation - show before spawning agents
-    from bernstein.core.cost import estimate_run_cost
-
-    est_task_count = backlog_count if backlog_count > 0 else 5  # default estimate for manager-planned
-    if model:
-        low, high = estimate_run_cost(est_task_count, model)
-        console.print(
-            f"[bold yellow]Cost estimate:[/bold yellow] ${low:.2f}-${high:.2f} "
-            f"({est_task_count} task(s), {model} model)"
-        )
-    else:
-        console.print(
-            f"[bold yellow]Cost estimate:[/bold yellow] unknown - no model configured ({est_task_count} task(s))"
-        )
+    # Cost estimation - show before spawning agents. Derived from the synced
+    # task count so it can never disagree with the submitted backlog.
+    console.print(f"[bold yellow]Cost estimate:[/bold yellow] {_describe_cost_estimate(backlog_count, model)}")
 
     cell_label = f"{cells} cells" if cells > 1 else "single cell"
     # Propagate the resolved cli adapter explicitly so the orchestrator

--- a/tests/unit/test_startup_task_count_consistency.py
+++ b/tests/unit/test_startup_task_count_consistency.py
@@ -1,0 +1,152 @@
+"""Startup cost lines must not invent task counts.
+
+Regression tests for issue #2748: one startup screen showed three different
+task counts because two emitters substituted a hardcoded placeholder (5)
+when the real count was not yet known.
+
+Contract pinned here:
+
+* The preflight cost line only prints a count when it comes from the plan
+  file or the synced backlog, and that count is the one displayed.
+* When the count is unknown (inline goal before planning, unreadable plan,
+  empty backlog), the line says so and shows a per-task rate; it never
+  prints a fabricated count.
+* The bootstrap cost line derives its count from the synced/submitted
+  backlog count and never falls back to a hardcoded number.
+"""
+
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+import inspect
+import re
+from pathlib import Path
+from unittest.mock import patch
+
+import bernstein.core.orchestration.bootstrap as bootstrap_mod
+from bernstein.cli.run_preflight import (
+    _emit_preflight_runtime_warnings,
+    _estimate_run_preview,
+    _estimate_task_count,
+    console,
+)
+from bernstein.core.orchestration.bootstrap import _describe_cost_estimate
+
+_COUNT_RE = re.compile(r"\d+\s+task")
+
+
+# ---------------------------------------------------------------------------
+# _estimate_task_count: unknown means None, never a placeholder
+# ---------------------------------------------------------------------------
+
+
+def test_goal_only_task_count_is_unknown(tmp_path: Path) -> None:
+    """An inline goal has no plan yet - the count must be unknown, not 5."""
+    assert _estimate_task_count(tmp_path, None, "ship a feature") is None
+
+
+def test_unreadable_plan_task_count_is_unknown(tmp_path: Path) -> None:
+    plan_file = tmp_path / "plan.yaml"
+    plan_file.write_text("name: Demo\n", encoding="utf-8")
+    with patch("bernstein.cli.run_preflight.load_plan_from_yaml", side_effect=ValueError("bad plan")):
+        assert _estimate_task_count(tmp_path, plan_file, None) is None
+
+
+def test_empty_backlog_task_count_is_unknown(tmp_path: Path) -> None:
+    assert _estimate_task_count(tmp_path, None, None) is None
+
+
+def test_plan_file_task_count_is_the_plan_count(tmp_path: Path) -> None:
+    plan_file = tmp_path / "plan.yaml"
+    plan_file.write_text("name: Demo\n", encoding="utf-8")
+    with patch("bernstein.cli.run_preflight.load_plan_from_yaml", return_value=[object(), object(), object()]):
+        assert _estimate_task_count(tmp_path, plan_file, None) == 3
+
+
+# ---------------------------------------------------------------------------
+# Preflight cost line
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_cost_line_count_matches_plan_count(tmp_path: Path) -> None:
+    """The printed count is exactly the plan count - no other number."""
+    plan_file = tmp_path / "plan.yaml"
+    plan_file.write_text("name: Demo\n", encoding="utf-8")
+    with patch("bernstein.cli.run_preflight.load_plan_from_yaml", return_value=[object(), object(), object()]):
+        estimate = _estimate_run_preview(
+            workdir=tmp_path,
+            plan_file=plan_file,
+            goal=None,
+            seed_file=None,
+            model_override="sonnet",
+        )
+    assert estimate.task_count == 3
+
+    with console.capture() as cap:
+        _emit_preflight_runtime_warnings(
+            workdir=tmp_path,
+            estimate=estimate,
+            auto_approve=True,
+            quiet=False,
+        )
+    out = cap.get()
+    counts = _COUNT_RE.findall(out)
+    assert counts, f"expected a task count in output: {out!r}"
+    assert all(c.split()[0] == "3" for c in counts), out
+
+
+def test_preflight_cost_line_says_unknown_instead_of_inventing(tmp_path: Path) -> None:
+    """Goal-only run: no count is printed, the line says it is not planned yet."""
+    estimate = _estimate_run_preview(
+        workdir=tmp_path,
+        plan_file=None,
+        goal="ship a feature",
+        seed_file=None,
+        model_override="sonnet",
+    )
+    assert estimate.task_count is None
+
+    with console.capture() as cap:
+        _emit_preflight_runtime_warnings(
+            workdir=tmp_path,
+            estimate=estimate,
+            auto_approve=True,
+            quiet=False,
+        )
+    out = cap.get()
+    assert not _COUNT_RE.search(out), f"no count should be printed when unknown: {out!r}"
+    assert "not yet planned" in out
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap cost line
+# ---------------------------------------------------------------------------
+
+
+def test_bootstrap_cost_uses_submitted_count() -> None:
+    text = _describe_cost_estimate(3, "sonnet")
+    assert "3 task(s)" in text
+    assert "5" not in text.split("$")[0]  # no stray placeholder before the price
+    counts = _COUNT_RE.findall(text)
+    assert all(c.split()[0] == "3" for c in counts), text
+
+
+def test_bootstrap_cost_unknown_count_without_model() -> None:
+    text = _describe_cost_estimate(0, None)
+    assert "no model configured" in text
+    assert "pending planning" in text
+    assert not _COUNT_RE.search(text), text
+
+
+def test_bootstrap_cost_unknown_count_with_model_shows_per_task_rate() -> None:
+    text = _describe_cost_estimate(0, "sonnet")
+    assert "per task" in text
+    assert "pending planning" in text
+    assert not _COUNT_RE.search(text), text
+
+
+def test_bootstrap_has_no_hardcoded_placeholder_count() -> None:
+    """The `backlog_count if backlog_count > 0 else 5` pattern must not return."""
+    source = inspect.getsource(bootstrap_mod)
+    assert "else 5" not in source

--- a/tests/unit/test_startup_task_count_consistency.py
+++ b/tests/unit/test_startup_task_count_consistency.py
@@ -31,7 +31,6 @@ from bernstein.cli.run_preflight import (
     _estimate_task_count,
     console,
 )
-from bernstein.core.orchestration.bootstrap import _describe_cost_estimate
 
 _COUNT_RE = re.compile(r"\d+\s+task")
 
@@ -125,7 +124,7 @@ def test_preflight_cost_line_says_unknown_instead_of_inventing(tmp_path: Path) -
 
 
 def test_bootstrap_cost_uses_submitted_count() -> None:
-    text = _describe_cost_estimate(3, "sonnet")
+    text = bootstrap_mod._describe_cost_estimate(3, "sonnet")
     assert "3 task(s)" in text
     assert "5" not in text.split("$")[0]  # no stray placeholder before the price
     counts = _COUNT_RE.findall(text)
@@ -133,14 +132,14 @@ def test_bootstrap_cost_uses_submitted_count() -> None:
 
 
 def test_bootstrap_cost_unknown_count_without_model() -> None:
-    text = _describe_cost_estimate(0, None)
+    text = bootstrap_mod._describe_cost_estimate(0, None)
     assert "no model configured" in text
     assert "pending planning" in text
     assert not _COUNT_RE.search(text), text
 
 
 def test_bootstrap_cost_unknown_count_with_model_shows_per_task_rate() -> None:
-    text = _describe_cost_estimate(0, "sonnet")
+    text = bootstrap_mod._describe_cost_estimate(0, "sonnet")
     assert "per task" in text
     assert "pending planning" in text
     assert not _COUNT_RE.search(text), text


### PR DESCRIPTION
Fixes #2748

## Problem

One startup screen of a goal-only run showed three contradictory task counts:

- preflight: `based on 1 task(s) at sonnet pricing`
- bootstrap cost line: `cost unknown (no model configured, 5 tasks)`
- plan summary: `Total tasks: 1`

The `5` was a hardcoded fallback used whenever the real count was not yet known, presented as if it were a real count.

## Change

- `src/bernstein/cli/run_preflight.py`: `_estimate_task_count` now returns `None` when the count is unknowable (inline goal before planning, unreadable plan file, empty backlog) instead of a hardcoded 5 or 1. The preflight cost line only prints a count when it came from the plan file or backlog; otherwise it shows a per-task rate and states the count is not yet planned.
- `src/bernstein/core/orchestration/bootstrap.py`: both startup cost lines now derive from a shared `_describe_cost_estimate(backlog_count, model)` helper fed by the synced/submitted task count, so the printed count can never disagree with the run's real task list. When the backlog is empty (manager agent plans after startup) the line shows a per-task rate and `task count pending planning` instead of a fabricated count.

## Tests

New `tests/unit/test_startup_task_count_consistency.py` (10 tests) pins:

- unknown counts are reported as unknown, never as a placeholder number
- the printed count always equals the plan/backlog count
- the `else 5` fallback cannot silently return (source scan)

TDD: tests confirmed failing against the previous code, passing after the fix, and failing again on revert. `tests/unit/test_run_cmd_track_b.py` and bootstrap unit tests pass; ruff check/format clean; pyright error count on touched files unchanged vs main.

## Notes

No overlap with the pending v3.8.2 PRs (#2739, #2740, #2741, #2742); this change touches `run_preflight.py` and `core/orchestration/bootstrap.py` only, none of which appear in those diffs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cost estimates no longer display invented task counts when planning is incomplete or unavailable.
  * Startup and preflight messages now clearly indicate when task planning is pending.
  * Known task counts are consistently reflected in cost estimates and warnings.
  * Per-task pricing is shown when the total task count cannot yet be determined.

* **Tests**
  * Added regression coverage to verify accurate task-count and cost messaging across startup and preflight scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->