### PR TITLE
fix(spawner): zero-config spawn for adapters with server-side model selection

### DIFF
--- a/docs/adapters/agy.md
+++ b/docs/adapters/agy.md
@@ -53,6 +53,10 @@ agy -p "<prompt>" --sandbox --dangerously-skip-permissions [--print-timeout <N>s
 
 Model selection is server-side: the CLI exposes no model flag, so
 Bernstein's `model` setting never reaches the argv for this adapter.
+The adapter declares `default` as its model default (the same sentinel
+the conformance canary pins), so a run with no model in the seed config
+resolves a spawnable config: the session records `default` and the
+backend picks the actual model.
 
 Session identifiers: the CLI mints its own conversation ids
 (`--conversation <id>` resumes one). Native resume is not wired yet --

--- a/src/bernstein/adapters/agy.py
+++ b/src/bernstein/adapters/agy.py
@@ -170,6 +170,14 @@ class AgyAdapter(CLIAdapter):
     # to the legacy binary cascade.
     provides = ("agy",)
 
+    # Model selection is server-side: the CLI exposes no model flag, so this
+    # value never reaches the argv (see spawn()). It is the documented
+    # sentinel for "the backend picks the model" - the same value the canary
+    # matrix pins for this adapter - and exists so the spawner's tier-name
+    # guard can resolve a spawnable model config on zero-config runs instead
+    # of refusing to spawn (issue #2743).
+    default_model = "default"
+
     external_endpoints = (("generativelanguage.googleapis.com", 443),)
     # The hosted backend returns HTTP 429 with ``RESOURCE_EXHAUSTED``
     # once per-minute quotas trip; same meter label as the gemini lane.

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -2901,6 +2901,28 @@ class AgentSpawner:
             if preferred_provider:
                 provider_name = preferred_provider
             routing_source = "operator-config" if role_policy.get("model") else "heuristic"
+            # Adapter-aware heuristic (issue #2743): the batch/heuristic
+            # selectors and role templates emit Claude tier names
+            # (opus/sonnet/haiku) with no adapter awareness. When the
+            # run-level adapter is authoritative (no provider redirection)
+            # and no operator pin is in play, resolve the adapter's own
+            # default_model here so the routing decision - and the log line
+            # below - never proposes an unpinned tier name a non-Claude
+            # adapter cannot run. Claude-compatible adapters and non-tier
+            # models pass through byte-identical; a tier name with no
+            # default anywhere still refuses (ModelNotConfiguredError),
+            # same as the downstream guard it front-runs.
+            if routing_source == "heuristic" and provider_name is None:
+                _task_metadata = tasks[0].metadata or {}
+                _model_unpinned = not _task_metadata.get("pinned_model") and (
+                    not tasks[0].model or tasks[0].model in _CLAUDE_TIER_MODELS
+                )
+                if _model_unpinned:
+                    model_config = _coerce_model_for_non_claude_adapter(
+                        model_config,
+                        adapter_name=self._adapter.name(),
+                        adapter_default_model=self._default_model or getattr(self._adapter, "default_model", None),
+                    )
             logger.info(
                 "Router skipped for role=%s (adapter=%s): using %s/%s (source=%s)",
                 tasks[0].role,

--- a/tests/unit/test_adapter_model_default.py
+++ b/tests/unit/test_adapter_model_default.py
@@ -1,0 +1,171 @@
+"""Zero-config model resolution for adapters with server-side model selection.
+
+Issue #2743: a run with a non-Claude default adapter and no model in the seed
+config could never spawn. The heuristic selector proposed a Claude tier name
+("opus"/"sonnet"), and the spawn guard then refused because the adapter had no
+``default_model`` to substitute. Two halves under test here:
+
+1. The routing step itself never proposes an unpinned Claude tier name for a
+   non-Claude adapter - it resolves the adapter's ``default_model`` instead.
+2. The agy adapter declares its documented server-side selection sentinel
+   (``"default"``, same as the canary matrix pin) so zero-config runs resolve
+   a spawnable model config.
+
+The refusal for genuinely nonsensical configs (Claude tier name, non-Claude
+adapter, no default anywhere) must survive unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from bernstein.core.models import ModelConfig
+from bernstein.core.spawner import AgentSpawner
+
+from bernstein.adapters.agy import AgyAdapter
+from bernstein.adapters.base import SpawnResult
+from bernstein.core.agents.spawn_errors import ModelNotConfiguredError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_CLAUDE_TIERS = frozenset({"opus", "sonnet", "haiku"})
+
+
+def _write_manager_role_config(templates_dir: Path) -> None:
+    """Mirror the shipped manager role template (default_model: opus)."""
+    role_dir = templates_dir / "manager"
+    role_dir.mkdir(parents=True, exist_ok=True)
+    (role_dir / "config.yaml").write_text("default_model: opus\ndefault_effort: max\n")
+
+
+class TestHeuristicNeverProposesClaudeTierForNonClaudeAdapter:
+    def test_resolve_routing_substitutes_adapter_default(self, tmp_path: Path, make_task, mock_adapter_factory) -> None:
+        """The router-skip (heuristic) path must not propose an unpinned
+        Claude tier name when the active adapter is not Claude-compatible;
+        it resolves the adapter's own default_model instead."""
+        templates_dir = tmp_path / "templates" / "roles"
+        templates_dir.mkdir(parents=True)
+
+        adapter = mock_adapter_factory(pid=42)
+        adapter.name.return_value = "Antigravity"
+        adapter.default_model = "default"
+
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)
+
+        task = make_task(role="manager")
+        model_config, provider_name, source = spawner._resolve_routing(
+            [task],
+            ModelConfig(model="opus", effort="max"),
+            role_policy={},
+            preferred_provider=None,
+        )
+
+        assert source == "heuristic"
+        assert provider_name is None
+        assert model_config.model not in _CLAUDE_TIERS
+        assert model_config.model == "default"
+        # Effort selection is unrelated to the tier-name substitution.
+        assert model_config.effort == "max"
+
+    def test_resolve_routing_keeps_tier_for_claude_adapter(
+        self, tmp_path: Path, make_task, mock_adapter_factory
+    ) -> None:
+        """Claude-compatible adapters keep the heuristic tier name unchanged."""
+        templates_dir = tmp_path / "templates" / "roles"
+        templates_dir.mkdir(parents=True)
+
+        adapter = mock_adapter_factory(pid=42)
+        adapter.name.return_value = "claude"
+        adapter.default_model = "default"
+
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)
+
+        task = make_task(role="manager")
+        model_config, _provider, source = spawner._resolve_routing(
+            [task],
+            ModelConfig(model="opus", effort="max"),
+            role_policy={},
+            preferred_provider=None,
+        )
+
+        assert source == "heuristic"
+        assert model_config.model == "opus"
+
+    def test_resolve_routing_respects_operator_role_policy_model(
+        self, tmp_path: Path, make_task, mock_adapter_factory
+    ) -> None:
+        """An operator-pinned role_model_policy model is never substituted."""
+        templates_dir = tmp_path / "templates" / "roles"
+        templates_dir.mkdir(parents=True)
+
+        adapter = mock_adapter_factory(pid=42)
+        adapter.name.return_value = "Antigravity"
+        adapter.default_model = "default"
+
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)
+
+        task = make_task(role="manager")
+        model_config, _provider, source = spawner._resolve_routing(
+            [task],
+            ModelConfig(model="gemini-3-pro", effort="high"),
+            role_policy={"model": "gemini-3-pro"},
+            preferred_provider=None,
+        )
+
+        assert source == "operator-config"
+        assert model_config.model == "gemini-3-pro"
+
+    def test_spawn_still_refuses_tier_with_no_default_anywhere(
+        self, tmp_path: Path, make_task, mock_adapter_factory
+    ) -> None:
+        """Guard preservation: a Claude tier name on a non-Claude adapter
+        with no adapter default and no run-level default must still refuse."""
+        templates_dir = tmp_path / "templates" / "roles"
+        _write_manager_role_config(templates_dir)
+
+        adapter = mock_adapter_factory(pid=42)
+        adapter.name.return_value = "qwen"
+        # No default_model attribute on the adapter and no run-level default.
+
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)
+
+        task = make_task(role="manager")
+        with pytest.raises(ModelNotConfiguredError, match="unpinned Claude tier name"):
+            spawner.spawn_for_tasks([task])
+
+
+class TestAgyZeroConfigSpawn:
+    def test_agy_declares_server_side_default_model(self) -> None:
+        """agy's model selection is server-side (no CLI model flag), so the
+        adapter declares the documented sentinel - the same value the canary
+        matrix pins for this adapter."""
+        assert AgyAdapter.default_model == "default"
+
+    def test_agy_zero_config_spawn_resolves_model(self, tmp_path: Path, make_task, monkeypatch) -> None:
+        """A run with BERNSTEIN_ADAPTER=agy and no model in the seed config
+        must spawn: the heuristic proposal (opus from the manager role
+        template) resolves to the adapter's server-side sentinel instead of
+        being refused."""
+        templates_dir = tmp_path / "templates" / "roles"
+        _write_manager_role_config(templates_dir)
+
+        adapter = AgyAdapter()
+        spawn_calls: list[ModelConfig] = []
+
+        def _fake_spawn(*, model_config: ModelConfig, **_kwargs) -> SpawnResult:
+            spawn_calls.append(model_config)
+            return SpawnResult(pid=42, log_path=tmp_path / "agent.log")
+
+        monkeypatch.setattr(adapter, "spawn", _fake_spawn)
+
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)
+
+        task = make_task(role="manager")
+        session = spawner.spawn_for_tasks([task])
+
+        assert session.model_config.model == "default"
+        assert session.model_config.model not in _CLAUDE_TIERS
+        assert spawn_calls, "adapter.spawn was never invoked"
+        assert spawn_calls[0].model == "default"


### PR DESCRIPTION
Fixes #2743

## Problem

A zero-config run with a non-Claude default adapter (for example `BERNSTEIN_ADAPTER=agy` with no model in the seed config) could never spawn. The spawner log shows the sequence:

```
Router skipped for role=manager (adapter=Antigravity): using opus/max (source=heuristic)
Spawn failed: Model 'opus' is an unpinned Claude tier name but adapter 'Antigravity' is not Claude-compatible and has no default_model configured. Refusing to spawn
```

The heuristic selector proposed a Claude tier name with no adapter awareness, and the spawn guard then refused because the agy adapter declared no `default_model`. The task retried, exhausted its retries, and was quarantined.

## Fix

Two halves:

1. **Adapter-aware heuristic** (`src/bernstein/core/agents/spawner_core.py`): the router-skip (heuristic) path in `_resolve_routing` now resolves the adapter's own `default_model` before proposing a model, so an unpinned Claude tier name never reaches a non-Claude adapter's routing decision (or the routing log line). Operator pins are untouched: `role_model_policy` models, `metadata["pinned_model"]` task models, non-tier task models, and provider redirection all bypass the substitution. A tier name with no default anywhere still refuses with `ModelNotConfiguredError`, same as before.

2. **agy declares its server-side default** (`src/bernstein/adapters/agy.py`): the CLI exposes no model flag (model selection is server-side), so the adapter now declares `default_model = "default"`, the documented sentinel the conformance canary matrix already pins for this adapter. The value never reaches the argv; it exists so the spawn guard can resolve a spawnable config on zero-config runs.

The retry-escalation guard in `task_lifecycle.py` needs no change: for a non-Claude adapter it already falls back to the pinned or prior task model, and with the two fixes above a zero-config retry re-resolves to the adapter default instead of being refused.

## Tests

New `tests/unit/test_adapter_model_default.py`:

- routing never proposes an unpinned Claude tier for a non-Claude adapter (substitutes the adapter default)
- Claude-compatible adapters keep tier names unchanged
- operator `role_model_policy` model pins are never substituted
- guard preservation: tier name + non-Claude adapter + no default anywhere still refuses
- `AgyAdapter.default_model == "default"`
- end-to-end: agy zero-config spawn resolves and passes `default` to the adapter (reproduces the quarantine scenario from the issue)

Revert-checked: with the source changes reverted, the three new behavioural tests fail with the exact refusal from the issue; re-applied, all pass.

Regression suites run green: `test_spawner.py`, `test_model_coercion.py`, `test_adapter_agy.py`, `test_per_step_routing.py`, `test_model_routing.py`, `test_spawner_failures.py`, `test_spawner_provider_availability.py`, `test_task_lifecycle.py`, `test_zero_config.py`, `test_crash_recovery.py` (317 passed total).

## Docs

`docs/adapters/agy.md` model-selection section updated to document the `default` sentinel and the zero-config behaviour.

No overlap with the in-flight v3.8.2 PRs (#2739, #2740, #2741, #2742); this change touches `spawner_core.py`, `agy.py`, the agy docs page, and a new test file only.
