### PR TITLE
fix(cli): surface first spawn outcome before non-interactive run exits

### DIFF
--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -119,6 +119,17 @@ when cumulative routed spend crosses the threshold. Precedence is
 `BERNSTEIN_MAX_COST_USD` > `run_config.json` > `seed.budget_usd`
 > default (0 = unlimited). Non-positive values normalise to 0.
 
+**Non-interactive output (pipes, CI).** When stdout is not a terminal the
+CLI detaches after bootstrap instead of opening the dashboard. Before
+exiting it waits up to ~10 seconds for the first spawn outcome:
+
+- If the first spawn attempt was refused or errored before any work
+  started, the failure reason is printed and the command exits `1`.
+  Details: `bernstein status` or `.sdd/runtime/retrospective.md`.
+- Otherwise the summary is followed by an explicit detach notice; the run
+  continues in the background and the command exits `0`. Check progress
+  with `bernstein status`.
+
 #### `bernstein stop`
 
 Graceful or force stop.

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -1029,6 +1029,80 @@ def _wait_for_run_completion(
     return last_status
 
 
+#: How long the exiting CLI waits for the first spawn outcome (roughly one
+#: spawner tick plus slack) before detaching without a verdict.
+_FIRST_SPAWN_WAIT_S = 10.0
+#: Delay between first-spawn outcome polls.
+_FIRST_SPAWN_POLL_S = 0.5
+#: Consecutive unreachable-server polls before giving up early.
+_FIRST_SPAWN_MAX_UNREACHABLE = 3
+#: Failed tasks older than this are attributed to a previous run and ignored.
+_FIRST_SPAWN_FRESHNESS_S = 300.0
+
+
+def _await_first_spawn_outcome(
+    *,
+    timeout_s: float = _FIRST_SPAWN_WAIT_S,
+    poll_interval_s: float = _FIRST_SPAWN_POLL_S,
+) -> tuple[str, str | None]:
+    """Briefly poll the task server for the outcome of the first agent spawn.
+
+    The CLI detaches right after bootstrap, so a spawn refusal in the
+    background orchestrator would otherwise never reach the terminal and
+    ``bernstein run`` would exit 0 with an empty summary (gh-2744).
+
+    A failed task counts only when its failure reason is a spawn failure and
+    it completed recently; failed tasks reloaded from a previous run are
+    ignored.  Transient spawn failures are given the rest of the window to
+    recover before being reported.
+
+    Args:
+        timeout_s: Maximum total time to wait for a verdict.
+        poll_interval_s: Delay between polls.
+
+    Returns:
+        ``("spawned", None)`` once at least one agent is live,
+        ``("refused", reason)`` when the first spawn attempt failed before
+        any agent did work, or ``("unknown", None)`` when no verdict arrived
+        within ``timeout_s`` (including an unreachable server).
+    """
+    deadline = time.time() + timeout_s
+    transient_reason: str | None = None
+    unreachable_polls = 0
+    while True:
+        health = server_get("/health")
+        if not isinstance(health, dict):
+            unreachable_polls += 1
+            if unreachable_polls >= _FIRST_SPAWN_MAX_UNREACHABLE:
+                return "unknown", None
+        else:
+            unreachable_polls = 0
+            if int(health.get("agent_count", 0) or 0) > 0:
+                return "spawned", None
+            failed_page: Any = server_get("/tasks?status=failed&limit=50")
+            entries = failed_page.get("tasks", []) if isinstance(failed_page, dict) else []
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    continue
+                reason = str(entry.get("result_summary") or "")
+                if not reason.startswith("Spawn failed"):
+                    continue
+                completed_at = float(entry.get("completed_at") or 0.0)
+                if completed_at < time.time() - _FIRST_SPAWN_FRESHNESS_S:
+                    continue
+                if "(transient" in reason:
+                    # A retry may still succeed - keep polling until deadline.
+                    transient_reason = reason
+                    continue
+                return "refused", reason
+        if time.time() >= deadline:
+            break
+        time.sleep(poll_interval_s)
+    if transient_reason is not None:
+        return "refused", transient_reason
+    return "unknown", None
+
+
 def exec_restart() -> None:
     """Re-exec the current process as ``bernstein run`` (full stack restart).
 

--- a/src/bernstein/cli/run_preflight.py
+++ b/src/bernstein/cli/run_preflight.py
@@ -410,7 +410,19 @@ def _finalize_run_output(*, quiet: bool) -> None:
             # TTY but Textual not supported -- use Rich fallback (TUI-003)
             _try_fallback_display()
         else:
+            # Non-interactive output detaches from the run immediately, so a
+            # spawn refusal in the background orchestrator would never reach
+            # the terminal (gh-2744).  Wait briefly for the first spawn
+            # outcome and surface a refusal as a non-zero exit.
+            from bernstein.cli.run_bootstrap import _await_first_spawn_outcome
+
+            outcome, reason = _await_first_spawn_outcome()
             _show_run_summary()
+            if outcome == "refused":
+                console.print(f"[red]Run failed before any work started:[/red] {reason}")
+                console.print("Details: run 'bernstein status' or read .sdd/runtime/retrospective.md")
+                raise SystemExit(1)
+            console.print("Run continues in the background (check: bernstein status).")
     finally:
         _drain_completed_backlog_files()
 

--- a/tests/unit/test_detached_run_visibility.py
+++ b/tests/unit/test_detached_run_visibility.py
@@ -1,0 +1,217 @@
+"""Regression tests for issue gh-2744.
+
+Non-interactive ``bernstein run`` detaches right after bootstrap.  When the
+detached spawner refused the very first spawn (for example a model that no
+adapter accepts), the CLI printed an empty summary and exited 0 - the refusal
+reason never reached the terminal.
+
+Two layers are covered:
+
+1. ``_await_first_spawn_outcome`` - the bounded poll that classifies the
+   first spawn outcome from the task server (``/health`` agent count plus
+   failed-task reasons).
+
+2. ``_finalize_run_output`` (non-TTY branch) - a refused first spawn must
+   print the reason and exit non-zero; a healthy first spawn must print an
+   explicit detach notice and keep the current exit-0 behaviour.
+"""
+
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+import time
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bernstein.cli.run_bootstrap import _await_first_spawn_outcome
+
+REFUSAL_REASON = (
+    "Spawn failed permanently (model_not_configured): Refusing to spawn "
+    "with a nonsensical model - configure role_model_policy or an adapter default."
+)
+
+
+def _server_get_factory(
+    health: dict[str, Any] | None,
+    failed_tasks: list[dict[str, Any]] | None,
+) -> Any:
+    """Build a ``server_get`` stub serving /health and /tasks?status=failed."""
+
+    def _server_get(path: str) -> Any:
+        if path.startswith("/health"):
+            return health
+        if path.startswith("/tasks?status=failed"):
+            if failed_tasks is None:
+                return None
+            return {"tasks": failed_tasks, "total": len(failed_tasks), "limit": 50, "offset": 0}
+        return None
+
+    return _server_get
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: outcome classification
+# ---------------------------------------------------------------------------
+
+
+class TestAwaitFirstSpawnOutcome:
+    def test_permanent_spawn_failure_is_refused_with_reason(self) -> None:
+        """A non-transient spawn failure surfaces immediately with its reason."""
+        stub = _server_get_factory(
+            health={"agent_count": 0},
+            failed_tasks=[
+                {
+                    "id": "t1",
+                    "status": "failed",
+                    "result_summary": REFUSAL_REASON,
+                    "completed_at": time.time(),
+                }
+            ],
+        )
+        with patch("bernstein.cli.run_bootstrap.server_get", side_effect=stub):
+            outcome, reason = _await_first_spawn_outcome(timeout_s=1.0, poll_interval_s=0.01)
+        assert outcome == "refused"
+        assert reason == REFUSAL_REASON
+
+    def test_live_agent_short_circuits_to_spawned(self) -> None:
+        stub = _server_get_factory(health={"agent_count": 2}, failed_tasks=[])
+        with patch("bernstein.cli.run_bootstrap.server_get", side_effect=stub):
+            outcome, reason = _await_first_spawn_outcome(timeout_s=1.0, poll_interval_s=0.01)
+        assert outcome == "spawned"
+        assert reason is None
+
+    def test_unreachable_server_returns_unknown_quickly(self) -> None:
+        """No server means no verdict - bail out well before the timeout."""
+        with patch("bernstein.cli.run_bootstrap.server_get", return_value=None):
+            start = time.monotonic()
+            outcome, reason = _await_first_spawn_outcome(timeout_s=30.0, poll_interval_s=0.01)
+            elapsed = time.monotonic() - start
+        assert outcome == "unknown"
+        assert reason is None
+        assert elapsed < 5.0
+
+    def test_transient_failure_escalates_only_at_deadline(self) -> None:
+        """A transient first failure gets the retry window before we give up."""
+        transient = "Spawn failed (transient, attempt 1): adapter busy"
+        stub = _server_get_factory(
+            health={"agent_count": 0},
+            failed_tasks=[
+                {
+                    "id": "t1",
+                    "status": "failed",
+                    "result_summary": transient,
+                    "completed_at": time.time(),
+                }
+            ],
+        )
+        with patch("bernstein.cli.run_bootstrap.server_get", side_effect=stub):
+            outcome, reason = _await_first_spawn_outcome(timeout_s=0.05, poll_interval_s=0.01)
+        assert outcome == "refused"
+        assert reason == transient
+
+    def test_stale_failed_task_from_prior_run_is_ignored(self) -> None:
+        """Failed tasks reloaded from a previous run must not fail this one."""
+        stub = _server_get_factory(
+            health={"agent_count": 0},
+            failed_tasks=[
+                {
+                    "id": "t-old",
+                    "status": "failed",
+                    "result_summary": REFUSAL_REASON,
+                    "completed_at": time.time() - 3600.0,
+                }
+            ],
+        )
+        with patch("bernstein.cli.run_bootstrap.server_get", side_effect=stub):
+            outcome, _reason = _await_first_spawn_outcome(timeout_s=0.05, poll_interval_s=0.01)
+        assert outcome == "unknown"
+
+    def test_non_spawn_failure_reasons_are_ignored(self) -> None:
+        """Only spawn failures count as refused-before-any-work."""
+        stub = _server_get_factory(
+            health={"agent_count": 0},
+            failed_tasks=[
+                {
+                    "id": "t1",
+                    "status": "failed",
+                    "result_summary": "verification failed: tests red",
+                    "completed_at": time.time(),
+                }
+            ],
+        )
+        with patch("bernstein.cli.run_bootstrap.server_get", side_effect=stub):
+            outcome, _reason = _await_first_spawn_outcome(timeout_s=0.05, poll_interval_s=0.01)
+        assert outcome == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: non-TTY exit path
+# ---------------------------------------------------------------------------
+
+_NON_TTY_CAPS = MagicMock(supports_textual=False, is_tty=False)
+
+
+class TestFinalizeRunOutputNonTty:
+    def test_refused_first_spawn_prints_reason_and_exits_nonzero(self, capsys: pytest.CaptureFixture[str]) -> None:
+        from bernstein.cli.run_preflight import _finalize_run_output
+
+        with (
+            patch("bernstein.cli.terminal_caps.detect_capabilities", return_value=_NON_TTY_CAPS),
+            patch(
+                "bernstein.cli.run_bootstrap._await_first_spawn_outcome",
+                return_value=("refused", REFUSAL_REASON),
+            ),
+            patch("bernstein.cli.run_preflight._show_run_summary") as show_summary,
+            patch("bernstein.cli.run_preflight._drain_completed_backlog_files") as drain,
+        ):
+            with pytest.raises(SystemExit) as excinfo:
+                _finalize_run_output(quiet=False)
+
+        assert excinfo.value.code == 1
+        out = capsys.readouterr().out
+        assert "Run failed before any work started" in out
+        assert "nonsensical" in out
+        assert "bernstein status" in out
+        assert "retrospective.md" in out
+        show_summary.assert_called_once()
+        # Cleanup must still run despite the non-zero exit.
+        drain.assert_called_once()
+
+    def test_healthy_first_spawn_prints_detach_notice(self, capsys: pytest.CaptureFixture[str]) -> None:
+        from bernstein.cli.run_preflight import _finalize_run_output
+
+        with (
+            patch("bernstein.cli.terminal_caps.detect_capabilities", return_value=_NON_TTY_CAPS),
+            patch(
+                "bernstein.cli.run_bootstrap._await_first_spawn_outcome",
+                return_value=("spawned", None),
+            ),
+            patch("bernstein.cli.run_preflight._show_run_summary") as show_summary,
+            patch("bernstein.cli.run_preflight._drain_completed_backlog_files"),
+        ):
+            _finalize_run_output(quiet=False)
+
+        out = capsys.readouterr().out
+        assert "continues in the background" in out
+        assert "bernstein status" in out
+        show_summary.assert_called_once()
+
+    def test_unknown_outcome_keeps_exit_zero_with_detach_notice(self, capsys: pytest.CaptureFixture[str]) -> None:
+        from bernstein.cli.run_preflight import _finalize_run_output
+
+        with (
+            patch("bernstein.cli.terminal_caps.detect_capabilities", return_value=_NON_TTY_CAPS),
+            patch(
+                "bernstein.cli.run_bootstrap._await_first_spawn_outcome",
+                return_value=("unknown", None),
+            ),
+            patch("bernstein.cli.run_preflight._show_run_summary"),
+            patch("bernstein.cli.run_preflight._drain_completed_backlog_files"),
+        ):
+            _finalize_run_output(quiet=False)
+
+        out = capsys.readouterr().out
+        assert "continues in the background" in out


### PR DESCRIPTION
Fixes #2744

## Problem

Non-interactive `bernstein run` (stdout not a TTY) detaches right after bootstrap. When the detached spawner refused the very first spawn (observed live: "Refusing to spawn with a nonsensical model", retries exhausted, task quarantined, retrospective UNHEALTHY), the CLI printed an empty summary (Total tasks: 1 / Done: 0 / Elapsed: 0s) and exited 0 within a second. Nothing reached the terminal.

## Fix

Minimal change on the non-TTY exit path, keeping the detach model as is:

- `src/bernstein/cli/run_bootstrap.py`: new `_await_first_spawn_outcome()` next to `_wait_for_run_completion()`. Polls the server for up to 10 seconds (0.5 s interval): a live agent on `/health` means the first spawn succeeded; a failed task whose reason starts with "Spawn failed" means it was refused. Transient spawn failures get the rest of the window to recover before being reported. Failed tasks older than 5 minutes are ignored so records reloaded from a previous run cannot fail a fresh one. An unreachable server bails out after 3 consecutive misses with no verdict.
- `src/bernstein/cli/run_preflight.py`: the non-TTY branch of `_finalize_run_output()` now consults that outcome. Refused before any work: print the refusal reason plus pointers (`bernstein status`, `.sdd/runtime/retrospective.md`) and exit 1. Otherwise: keep current behaviour and print an explicit one-line detach notice. The `claimed/` drain still runs on the non-zero exit path (try/finally preserved).
- `docs/reference/cli-reference.md`: documented the non-interactive behaviour under `bernstein run`.

Interactive TTY paths (Textual dashboard, Rich fallback) and `--quiet` are unchanged.

## Tests

`tests/unit/test_detached_run_visibility.py` (new, 9 tests):

- refused first spawn: reason reaches stdout, exit code 1, backlog drain still runs
- healthy first spawn: detach notice printed, exit stays 0
- no verdict / unreachable server: exit stays 0, quick bail-out
- transient failure escalates only at the deadline; stale and non-spawn failures are ignored

TDD: tests confirmed red before the implementation and red again on a revert check. Neighbouring suites pass: test_run_summary_issue_953, test_tui_fallback, test_run_cmd_track_b, test_max_cost_usd_flag, test_cli_run_sandbox, test_sovereign_spawn_gate, test_sovereign_hardening, test_cost_cmd_by_role.

## Merge-order note

`run_bootstrap.py` is also touched by open PR #2740 (startup banner call around line 1710). This PR's only hunk in that file is at line ~1031 (after `_wait_for_run_completion`), so the hunks do not overlap, but both PRs edit the same file; whichever merges second needs a routine rebase.
