### PR TITLE
Warn on unknown top-level seed keys with nearest-match suggestion

### DIFF
--- a/docs/operations/CONFIG.md
+++ b/docs/operations/CONFIG.md
@@ -22,7 +22,7 @@ All magic numbers, timeouts, and thresholds are centralized in `src/bernstein/co
 `bernstein.yaml` is the main run-time input. Typical keys include:
 
 - `goal`
-- `tasks`
+- `cells` (number of parallel work cells; work is decomposed from `goal`)
 - `workspace`
 - `role_model_policy`
 - `local_endpoints`
@@ -31,17 +31,16 @@ All magic numbers, timeouts, and thresholds are centralized in `src/bernstein/co
 - `network` (IP allowlist)
 - `tuning` (override defaults from `core/defaults.py`)
 
+Unknown top-level keys are ignored but logged: the parser emits a warning
+naming the unrecognised key and, where possible, the closest known key
+(for example `tasks` suggests `cells`). A typo such as `max_agnets` no
+longer silently drops the setting; check the run log if a section seems
+to have no effect.
+
 Minimal example:
 
 ```yaml
 goal: "Implement API auth and integration tests"
-
-tasks:
-  - title: "Add auth middleware"
-    role: backend
-    priority: 1
-    scope: medium
-    complexity: medium
 
 role_model_policy:
   backend:

--- a/src/bernstein/core/config/seed_parser.py
+++ b/src/bernstein/core/config/seed_parser.py
@@ -7,6 +7,7 @@ backward compatibility.
 
 from __future__ import annotations
 
+import difflib
 import ipaddress
 import logging
 import os
@@ -1812,6 +1813,144 @@ def _parse_mcp_signing_mode(data: dict[str, object]) -> Literal["warn", "strict"
     return cast("Literal['warn', 'strict', 'off']", candidate)
 
 
+# Every top-level key ``parse_seed`` consumes, directly or via a helper
+# that receives the whole mapping. Any new ``data.get(...)`` read must be
+# added here; keys outside the known set trigger the unknown-key warning
+# in ``_warn_unknown_top_level_keys`` so a typo or an unsupported section
+# cannot silently drop configuration from the run.
+_PARSED_TOP_LEVEL_KEYS: frozenset[str] = frozenset(
+    {
+        "agent_catalog",
+        "batch",
+        "bridges",
+        "budget",
+        "catalogs",
+        "cells",
+        "cli",
+        "cluster",
+        "compliance",
+        "constraints",
+        "context_files",
+        "cors",
+        "cost",
+        "cost_autopilot",
+        "cost_tags",
+        "dashboard_auth",
+        "deployment_strategy",
+        "formal_verification",
+        "github",
+        "goal",
+        "internal_llm_model",
+        "internal_llm_provider",
+        "judge_model",
+        "judge_provider",
+        "key_rotation",
+        "max_agents",
+        "max_cost_per_agent",
+        "mcp",
+        "mcp_allowlist",
+        "mcp_servers",
+        "metrics",
+        "model",
+        "model_fallback",
+        "model_policy",
+        "network",
+        "notify",
+        "org_policies",
+        "provider_availability",
+        "quality_gates",
+        "rate_limit",
+        "repos",
+        "role_model_policy",
+        "sandbox",
+        "secrets",
+        "session",
+        "smtp",
+        "storage",
+        "team",
+        "team_manifest",
+        "tenants",
+        "test_agent",
+        "tuning",
+        "visual",
+        "webhooks",
+        "workspace",
+        "worktree_setup",
+    }
+)
+
+# Top-level sections consumed by subsystems that read bernstein.yaml
+# directly instead of going through ``parse_seed``. Each entry names its
+# reader so a removed section can be retired from this set alongside it.
+_SECTION_TOP_LEVEL_KEYS: frozenset[str] = frozenset(
+    {
+        "approvals",  # core/approval/gate.py
+        "autofix",  # core/autofix/ladder.py, core/autofix/telemetry_grounded.py
+        "chat",  # core/chat/permissions.py
+        "embedding",  # core/routes/embedding.py
+        "evolve",  # cli/commands/evolve_cmd.py
+        "hooks",  # cli/commands/hooks_cmd.py
+        "keybindings",  # tui/keybinding_config.py
+        "mcp_compositions",  # core/protocols/mcp/mcp_composition.py
+        "mcp_sandbox",  # core/protocols/mcp/mcp_sandbox.py
+        "mouse",  # tui/mouse_support.py
+        "permissions",  # core/security/permission_policy.py
+        "plan",  # core/planning/vertical_slice.py
+        "plugins",  # plugins/manager.py
+        "preview",  # core/preview/command_discovery.py
+        "security",  # core/security/compliance_library.py
+        "tls",  # core/security/compliance_library.py
+        "warm_pool",  # core/agents/warm_pool.py
+    }
+)
+
+# Keys operators plausibly reach for that map to a schema key covering the
+# same intent. Consulted before the fuzzy match because edit distance
+# cannot connect these pairs.
+_TOP_LEVEL_KEY_ALIASES: dict[str, str] = {
+    "tasks": "cells",
+}
+
+
+def _known_top_level_keys() -> frozenset[str]:
+    """Return every top-level bernstein.yaml key a shipped subsystem consumes.
+
+    Unions the keys this parser reads, the sections read out-of-band by
+    other subsystems, and the fields of the Pydantic schema
+    (``BernsteinConfig``) so schema additions never produce false
+    unknown-key warnings here. The schema import is deferred to keep this
+    module's import graph unchanged.
+    """
+    from bernstein.core.config.config_schema import BernsteinConfig
+
+    return _PARSED_TOP_LEVEL_KEYS | _SECTION_TOP_LEVEL_KEYS | frozenset(BernsteinConfig.model_fields)
+
+
+def _warn_unknown_top_level_keys(data: dict[str, object]) -> None:
+    """Warn about top-level keys nothing in the codebase consumes.
+
+    A warning, never an error: existing seeds must keep parsing. The
+    parse result is unaffected; unknown keys stay ignored exactly as
+    before, they are just no longer silent.
+    """
+    known = _known_top_level_keys()
+    unknown = [key for key in data if not (isinstance(key, str) and key in known)]
+    for key in sorted(unknown, key=str):
+        key_text = key if isinstance(key, str) else str(key)
+        suggestion = _TOP_LEVEL_KEY_ALIASES.get(key_text)
+        if suggestion is None:
+            matches = difflib.get_close_matches(key_text, sorted(known), n=1)
+            suggestion = matches[0] if matches else None
+        if suggestion is not None:
+            logger.warning(
+                "Ignoring unknown top-level key %r in seed file; did you mean %r?",
+                key_text,
+                suggestion,
+            )
+        else:
+            logger.warning("Ignoring unknown top-level key %r in seed file.", key_text)
+
+
 def parse_seed(path: Path) -> SeedConfig:
     """Parse a bernstein.yaml seed file into a validated SeedConfig.
 
@@ -1841,6 +1980,8 @@ def parse_seed(path: Path) -> SeedConfig:
         raise SeedError(f"Seed file must be a YAML mapping, got {type(data_raw).__name__}")
 
     data: dict[str, object] = cast("_StrObjDict", data_raw)
+
+    _warn_unknown_top_level_keys(data)
 
     # --- Required fields ---
     goal: object = data.get("goal")

--- a/tests/unit/test_seed.py
+++ b/tests/unit/test_seed.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
@@ -758,3 +759,71 @@ class TestResolveSeedPathWorkdirFallback:
 
         assert resolved.is_absolute()
         assert resolved == (tmp_path / "bernstein.yaml").resolve()
+
+
+# ---------------------------------------------------------------------------
+# parse_seed - unknown top-level keys
+# ---------------------------------------------------------------------------
+
+_SEED_PARSER_LOGGER = "bernstein.core.config.seed_parser"
+
+
+class TestParseSeedUnknownTopLevelKeys:
+    """Unknown top-level keys warn (never fail) and suggest the nearest known key."""
+
+    def test_unknown_key_warns_and_names_it(self, seed_file: Path, caplog: pytest.LogCaptureFixture) -> None:
+        seed_file.write_text('goal: "Test"\nmax_agnets: 3\n')
+
+        with caplog.at_level(logging.WARNING, logger=_SEED_PARSER_LOGGER):
+            cfg = parse_seed(seed_file)
+
+        assert cfg.goal == "Test"
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("max_agnets" in m for m in messages)
+
+    def test_unknown_key_suggests_nearest_match(self, seed_file: Path, caplog: pytest.LogCaptureFixture) -> None:
+        seed_file.write_text('goal: "Test"\nmax_agnets: 3\n')
+
+        with caplog.at_level(logging.WARNING, logger=_SEED_PARSER_LOGGER):
+            parse_seed(seed_file)
+
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("max_agnets" in m and "max_agents" in m for m in messages)
+
+    def test_tasks_key_suggests_cells(self, seed_file: Path, caplog: pytest.LogCaptureFixture) -> None:
+        seed_file.write_text('goal: "Test"\ntasks:\n  - id: t1\n    description: x\n')
+
+        with caplog.at_level(logging.WARNING, logger=_SEED_PARSER_LOGGER):
+            parse_seed(seed_file)
+
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("tasks" in m and "cells" in m for m in messages)
+
+    def test_valid_seed_warns_nothing(self, seed_file: Path, caplog: pytest.LogCaptureFixture) -> None:
+        seed_file.write_text(FULL_YAML)
+
+        with caplog.at_level(logging.WARNING, logger=_SEED_PARSER_LOGGER):
+            parse_seed(seed_file)
+
+        assert not caplog.records
+
+    def test_parse_result_unchanged_by_unknown_key(self, seed_file: Path, caplog: pytest.LogCaptureFixture) -> None:
+        seed_file.write_text(MINIMAL_YAML)
+        baseline = parse_seed(seed_file)
+
+        seed_file.write_text(MINIMAL_YAML + "tasks: [{id: t1, description: x}]\n")
+        with caplog.at_level(logging.WARNING, logger=_SEED_PARSER_LOGGER):
+            with_unknown = parse_seed(seed_file)
+
+        assert with_unknown == baseline
+
+    def test_unknown_key_without_close_match_still_warns(
+        self, seed_file: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        seed_file.write_text('goal: "Test"\nzzqqxx: 1\n')
+
+        with caplog.at_level(logging.WARNING, logger=_SEED_PARSER_LOGGER):
+            parse_seed(seed_file)
+
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("zzqqxx" in m for m in messages)


### PR DESCRIPTION
Fixes #2745

## Problem

The seed parser silently ignored unknown top-level keys. A seed carrying `tasks: [{id: t1, description: x}]` (not part of the schema; work is defined via `cells:` or a bare `goal:`) parsed clean, the key was dropped, and the run silently degraded to goal decomposition. The same applied to any typo (`max_agnets`) or stale section: no signal to the operator.

## Change

- `parse_seed` now checks every top-level key against the union of:
  - the keys the parser itself consumes,
  - the sections other subsystems read from `bernstein.yaml` out-of-band (`chat`, `permissions`, `warm_pool`, `autofix`, `hooks`, `plugins`, and so on, each annotated with its reader),
  - the `BernsteinConfig` Pydantic schema fields, so schema additions never produce false warnings here.
- Unknown keys emit a `logger.warning` naming the key, with a closest-match suggestion via `difflib.get_close_matches`. A small alias map covers semantic near-misses edit distance cannot connect: `tasks` suggests `cells`.
- Warning only, never an error: existing seeds keep parsing and the parse result is byte-for-byte unchanged.
- `docs/operations/CONFIG.md`: removed the stale `tasks:` key and example block (it showed exactly the shape the parser ignores) and documented the warning behaviour.

## Verification

- New tests in `tests/unit/test_seed.py` (`TestParseSeedUnknownTopLevelKeys`): unknown key warns and names it; nearest-match suggestion; `tasks` suggests `cells`; valid seed warns nothing; parse result identical with and without the unknown key; no-close-match key still warns. Revert-checked: 4 warning tests fail without the implementation, full file (90 tests) passes with it.
- All shipped seeds under `templates/` and `examples/` parse warning-free, except two true positives the warning correctly surfaces: `observability:` in the repo's own `bernstein.yaml` and `worker:` in `examples/cluster/tailscale/bernstein.yaml`, neither of which is read by any code. Left as-is here to keep the diff surgical; can be cleaned up separately.
- `ruff check` and `ruff format` clean on touched files.

## Overlap note

No file overlap with the open v3.8.2 PRs (#2739 `gui/cli.py`, #2740 bootstrap/splash, #2741 `orchestrator.py`, #2742 `seed_config.py`). This PR touches `seed_parser.py` only; #2742 touches the sibling `seed_config.py`, different files, no shared hunks.
