### PR TITLE
fix(config): drop unread top-level sections from shipped seed files

### DIFF
--- a/bernstein.yaml
+++ b/bernstein.yaml
@@ -41,15 +41,15 @@ context_files:
 - CLAUDE.md
 agency:
   path: ${BERNSTEIN_AGENCY_PATH:-./external/agency-agents}  # replace with your agency-agents clone path
-# OTLP exporter with OpenTelemetry GenAI semantic conventions.
-# Spans are emitted only when ``endpoint`` is set (or the BERNSTEIN_OTEL_ENDPOINT
-# env var is exported); otherwise Bernstein keeps writing local JSONL traces.
-# Install the optional extras with: pip install 'bernstein[otel]'.
-observability:
-  otlp:
-    endpoint: ${BERNSTEIN_OTEL_ENDPOINT:-}        # e.g. http://otel-collector:4317
-    service_name: ${BERNSTEIN_OTEL_SERVICE_NAME:-bernstein}
-    insecure: true                                # skip TLS verify on local collectors
+
+# OTLP export (OpenTelemetry GenAI semantic conventions) is configured
+# through environment variables, not a seed section:
+#   BERNSTEIN_OTEL_ENDPOINT      OTLP/gRPC collector URL, e.g. http://otel-collector:4317.
+#                                Unset -> spans are disabled and Bernstein keeps
+#                                writing local JSONL traces under .sdd/traces/.
+#   BERNSTEIN_OTEL_SERVICE_NAME  service.name resource attribute (default: bernstein).
+# Install the exporter extras with: pip install 'bernstein[otel]'.
+# TLS verification is skipped for local collectors by default.
 
 # Autofix daemon - escalation ladder for self-driving CI repair.
 # The ladder is feature-flagged off until three PRs run clean; flip

--- a/examples/cluster/tailscale/bernstein.yaml
+++ b/examples/cluster/tailscale/bernstein.yaml
@@ -29,12 +29,7 @@ cluster:
   # application-level identity for audit (see docs/cluster/mtls-setup.md).
   tls: null
 
-worker:
-  role: backend
-  capacity:
-    max_agents: 4
-    gpu_available: false
-    supported_models: ["sonnet"]
-  labels:
-    deployment: tailscale-overlay
-    region: contractor-laptop
+# The worker's role is passed on the command line (`--role backend`, shown
+# above), and its capacity and labels are advertised to the central server
+# when the worker registers. None of that is read from this seed file, so
+# there is no `worker:` section here.


### PR DESCRIPTION
## What

Two shipped `bernstein.yaml` files carried top-level sections that no code reads. Once the parser warns on unknown top-level keys, both files emit "unknown top-level key" warnings on every parse.

| File | Dead section | Fix |
|------|--------------|-----|
| `bernstein.yaml` (repo) | `observability:` (otlp endpoint/service_name/insecure) | delete block, document the real mechanism |
| `examples/cluster/tailscale/bernstein.yaml` | `worker:` (role/capacity/labels) | delete block, note where those settings come from |

## Why each section is dead

**`observability:`** - the OTLP exporter (`src/bernstein/core/observability/otlp_exporter.py`) is configured entirely from environment variables via `OTLPExporterConfig.from_env`:
- `BERNSTEIN_OTEL_ENDPOINT` - OTLP/gRPC collector URL; unset means spans are disabled and the local JSONL trace writer stays the default.
- `BERNSTEIN_OTEL_SERVICE_NAME` - `service.name` resource attribute (default `bernstein`).

Nothing reads a top-level `observability` key (not the seed parser, not the config schema, not the `tuning:` override path). The block was documentation dressed up as config. It is replaced with a comment that documents the env-var mechanism, so operators keep the guidance without a section the parser ignores.

**`worker:`** - cluster configuration lives under `cluster:`, which the seed parser reads via `_parse_cluster`. A worker's role is passed on the command line (`--role backend`, already shown in the file's header comment), and its capacity and labels are advertised to the central server at registration time (`ClusterState.register`), not loaded from the seed file. The section is removed and replaced with a short comment explaining where role, capacity, and labels actually come from.

## Verification

Parsed both edited files with `bernstein.core.seed.parse_seed` at WARNING log level:
- `bernstein.yaml`: parses cleanly, **zero** unknown top-level-key warnings.
- `examples/cluster/tailscale/bernstein.yaml`: **zero** unknown top-level-key warnings; still raises the expected `SeedError` for the missing `goal` (the example intentionally has no goal).

As a control, the pre-edit files produced exactly the two warnings this change removes (`observability`, `worker`).

No Python changed; both edits are YAML-only.