### PR TITLE
chore(ci): drop path-filter entries for files that no longer exist

### DIFF
--- a/.github/workflows/auto-heal.yml
+++ b/.github/workflows/auto-heal.yml
@@ -1,9 +1,9 @@
 name: Auto-heal v2
 
 # Self-healing CI workflow, version 2. The v1 workflow (zero-LLM,
-# four repair recipes) is kept under .github/workflows/auto-heal-v1.yml
-# as an emergency fallback (gated behind ``if: false``) so an operator
-# can revert by flipping a single boolean.
+# four repair recipes) has been removed from the tree; recover it from
+# git history (.github/workflows/auto-heal-v1.yml, deleted in #1501)
+# if an emergency fallback is ever needed.
 #
 # v2 splits the heal pipeline into four layers (detection / classification
 # / repair / safety) and wires in Bernstein-native primitives:

--- a/.github/workflows/ci-gate-stub.yml
+++ b/.github/workflows/ci-gate-stub.yml
@@ -71,9 +71,7 @@ on:
       - ".github/FUNDING.yml"
       - ".github/CODEOWNERS"
       - ".github/pull_request_template.md"
-      - ".github/dependabot.yml"
       - ".github/labeler.yml"
-      - ".github/release-drafter.yml"
       - ".github/copilot-instructions.md"
       - ".github/codeql/**"
       # Non-code project files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,7 @@ on:
       - ".github/FUNDING.yml"
       - ".github/CODEOWNERS"
       - ".github/pull_request_template.md"
-      - ".github/dependabot.yml"
       - ".github/labeler.yml"
-      - ".github/release-drafter.yml"
       - ".github/copilot-instructions.md"
       - ".github/codeql/**"
       # Non-code project files
@@ -99,9 +97,7 @@ on:
       - ".github/FUNDING.yml"
       - ".github/CODEOWNERS"
       - ".github/pull_request_template.md"
-      - ".github/dependabot.yml"
       - ".github/labeler.yml"
-      - ".github/release-drafter.yml"
       - ".github/copilot-instructions.md"
       - ".github/codeql/**"
       # Non-code project files

--- a/docs/operations/auto-heal.md
+++ b/docs/operations/auto-heal.md
@@ -136,16 +136,16 @@ jq -r '"\(.ts | localtime) \(.outcome) \(.strategy) \(.cls) \(.rationale)"' \
 
 ### Emergency revert
 
-The frozen v1 workflow lives at `.github/workflows/auto-heal-v1.yml`
-with all jobs gated by `if: false`. To revert, swap the v2 file out of
-the workflows directory and re-enable v1 by replacing the static
-`false` gates with the original guards from git history.
+The v1 workflow file has been removed from the tree (deleted in #1501).
+To revert, recover `.github/workflows/auto-heal-v1.yml` from git history,
+restore its original job guards, and swap the v2 file out of the
+workflows directory.
 
 ## v1 vs v2
 
 | Aspect | v1 | v2 |
 |--------|----|----|
-| Workflow file | `auto-heal.yml` (kept frozen as `auto-heal-v1.yml`) | `auto-heal.yml` |
+| Workflow file | `auto-heal.yml` (removed; recover from git history) | `auto-heal.yml` |
 | Repair strategies | 4 hardcoded recipes | bandit-selected from a growing set |
 | Confidence | Flat safe/heuristic/risky | Numeric Bayesian per-class |
 | Flake handling | None | non-adjacent-failure heuristic |


### PR DESCRIPTION
## What

- Remove `.github/dependabot.yml` and `.github/release-drafter.yml` from the `paths-ignore` blocks in `ci.yml` (push and pull_request triggers) and `ci-gate-stub.yml`. Neither file exists in the repo.
- Fix the header comment in `auto-heal.yml`: it claimed the v1 workflow is kept at `.github/workflows/auto-heal-v1.yml`, but that file was deleted in #1501. The comment now points at git history.

## Notes

- `ci.yml` and `ci-gate-stub.yml` path filters stay in sync, as required for the stub gate to mirror the real workflow.
- `scripts/gen_workflow_topology.py` was re-run; `docs/operations/ci-topology.md` is byte-identical because `paths-ignore` entries are not part of the rendered topology.
- No behavior change: `paths-ignore` entries for nonexistent files never matched anything.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI/CD**
  * Updated automated checks to run for changes to dependency and release configuration.
  * Adjusted required-check coverage for label configuration changes.
* **Documentation**
  * Clarified recovery guidance for the retired auto-heal workflow in emergency scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->