### PR TITLE
fix(qwen): stop passing removed web search flag

### DIFF
--- a/src/bernstein/adapters/qwen.py
+++ b/src/bernstein/adapters/qwen.py
@@ -118,8 +118,7 @@ class QwenAdapter(CLIAdapter):
         The Tavily API key is never placed on argv (it would be visible to
         any user with ``ps`` access on the host). It is forwarded to the
         spawned process via the ``TAVILY_API_KEY`` environment variable in
-        :meth:`spawn`. Only the non-sensitive ``--web-search-default``
-        selector is added to argv.
+        :meth:`spawn`.
 
         Args:
             mcp_config: Per-spawn config that may carry ``temperature``/
@@ -139,9 +138,6 @@ class QwenAdapter(CLIAdapter):
 
         if provider != "default":
             cmd.extend(["--auth-type", "openai"])
-
-        if settings.tavily_api_key:
-            cmd.extend(["--web-search-default", "tavily"])
 
         if mcp_config:
             temperature = mcp_config.get("temperature")

--- a/tests/unit/test_adapter_non_claude.py
+++ b/tests/unit/test_adapter_non_claude.py
@@ -479,7 +479,7 @@ class TestQwenAdapterSpawn:
         # is enabled.
         assert "--tavily-api-key" not in inner
         assert "tv-key-xyz" not in inner
-        assert "--web-search-default" in inner
+        assert "--web-search-default" not in inner
         env = popen.call_args.kwargs.get("env", {})
         assert env.get("TAVILY_API_KEY") == "tv-key-xyz"
 

--- a/tests/unit/test_adapter_qwen.py
+++ b/tests/unit/test_adapter_qwen.py
@@ -202,7 +202,7 @@ class TestQwenAdapterSpawn:
         inner = _inner_cmd(popen.call_args.args[0])
         assert inner[inner.index("--model") + 1] == "qwen3.6-plus"
 
-    def test_tavily_flags_when_key_set(self, tmp_path: Path) -> None:
+    def test_tavily_key_does_not_add_removed_cli_flag(self, tmp_path: Path) -> None:
         adapter = QwenAdapter()
         proc_mock = _make_popen_mock(pid=108)
         settings = _default_settings(tavily_api_key="tvly-test")
@@ -217,9 +217,9 @@ class TestQwenAdapterSpawn:
                 session_id="qwen-s9",
             )
         inner = _inner_cmd(popen.call_args.args[0])
-        # The non-sensitive selector flag is still on argv.
-        assert "--web-search-default" in inner
-        assert inner[inner.index("--web-search-default") + 1] == "tavily"
+        # Qwen Code reads the key from the environment; current releases no
+        # longer accept the old selector flag.
+        assert "--web-search-default" not in inner
         # SECURITY: the Tavily key must NEVER reach argv (visible via ps).
         assert "--tavily-api-key" not in inner
         assert "tvly-test" not in inner


### PR DESCRIPTION
Closes #2758

## What

Stop passing Qwen Code's removed `--web-search-default` flag while continuing to forward `TAVILY_API_KEY` through the child environment.

## Why

Current Qwen Code rejects the removed flag, causing every Tavily-enabled spawn to exit before doing any work.

## How

Remove the obsolete argument and update both command-construction regressions. The focused test failed before the source change; both Qwen adapter test files now pass (100 tests).

## Checklist

- [x] `uv run ruff check src/` passes (changed files checked)
- [ ] `uv run pyright src/` passes
- [ ] `uv run python scripts/run_tests.py -x` passes
- [x] New code has type hints (N/A: no new symbols)

### Documentation duty (every PR that touches a feature)

- [x] User-visible README section updated (N/A: internal adapter compatibility fix)
- [x] `docs/operations/<area>.md` updated (N/A)
- [x] `docs/api/` schema regenerated if a public surface changed (N/A)
- [x] `uv run bernstein agents-md sync` run so AGENTS.md, CLAUDE.md, `.goosehints`, `CONVENTIONS.md`, and `.cursor/rules/*.mdc` reflect any new module (N/A: no new module)
- [x] Tests cover the documented behaviour


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Qwen web-search configuration to avoid sending the legacy selector flag in command-line arguments.
  * Continued forwarding the Tavily API key securely through the process environment instead of exposing it in command-line arguments.

* **Tests**
  * Updated validation to confirm the legacy flag and raw API key are absent from command-line arguments while environment forwarding remains supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->