### PR TITLE
fix(security): redact the webhook secret from route logging

### DIFF
--- a/src/bernstein/core/routes/webhooks.py
+++ b/src/bernstein/core/routes/webhooks.py
@@ -96,11 +96,13 @@ def _verify_generic_webhook_secret(request: Request, body: bytes) -> tuple[JSONR
 
     configured_secret = os.environ.get(_GENERIC_WEBHOOK_SECRET_ENV, "")
     if not configured_secret:
+        # Fully literal message, matching the GitHub/GitLab handlers: no
+        # binding flows into the logging call, so no secret-shaped value
+        # can ever reach a persisted log sink (#2763).
         logger.error(
-            "Rejecting POST /webhook: %s is not configured. "
-            "Set the env var to enable the endpoint; unsigned "
+            "Rejecting POST /webhook: BERNSTEIN_WEBHOOK_SECRET is not "
+            "configured. Set the env var to enable the endpoint; unsigned "
             "webhooks are not accepted.",
-            _GENERIC_WEBHOOK_SECRET_ENV,
         )
         return (
             JSONResponse(

--- a/tests/unit/test_generic_webhook.py
+++ b/tests/unit/test_generic_webhook.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import time
 from pathlib import Path
 
@@ -392,3 +393,59 @@ async def test_gitlab_webhook_rejects_stale_timestamp_when_supplied(
         },
     )
     assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# #2763: the webhook secret never reaches a log record
+# ---------------------------------------------------------------------------
+
+_WEBHOOKS_LOGGER = "bernstein.core.routes.webhooks"
+
+
+@pytest.mark.anyio
+async def test_unconfigured_webhook_refusal_log_interpolates_nothing(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The 503 refusal log is fully literal - no value flows into the call.
+
+    A logging call that interpolates a secret-shaped binding can leak it
+    into persisted log sinks; keeping the refusal message literal makes
+    that impossible by construction.
+    """
+    monkeypatch.delenv("BERNSTEIN_WEBHOOK_SECRET", raising=False)
+    body = json.dumps(_WEBHOOK_PAYLOAD).encode()
+    with caplog.at_level(logging.ERROR, logger=_WEBHOOKS_LOGGER):
+        resp = await client.post("/webhook", content=body, headers={"content-type": "application/json"})
+    assert resp.status_code == 503
+    refusals = [r for r in caplog.records if r.name == _WEBHOOKS_LOGGER]
+    assert refusals, "expected the unconfigured-endpoint refusal to be logged"
+    for record in refusals:
+        assert not record.args, "refusal log must not interpolate any value"
+
+
+@pytest.mark.anyio
+async def test_webhook_secret_absent_from_all_log_records(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """No record captured while handling POST /webhook contains the secret.
+
+    Exercises the accepted, forged-signature, and unsigned paths and then
+    checks every captured record - message and interpolation args alike -
+    for the raw secret value.
+    """
+    monkeypatch.setenv("BERNSTEIN_WEBHOOK_SECRET", _WEBHOOK_SECRET)
+    body = json.dumps(_WEBHOOK_PAYLOAD).encode()
+    with caplog.at_level(logging.DEBUG):
+        accepted = await client.post("/webhook", content=body, headers=_signed(body))
+        forged = await client.post("/webhook", content=body, headers=_signed(body, secret="wrong-secret"))
+        unsigned = await client.post("/webhook", content=body, headers={"content-type": "application/json"})
+    assert accepted.status_code == 201
+    assert forged.status_code == 401
+    assert unsigned.status_code == 401
+    for record in caplog.records:
+        assert _WEBHOOK_SECRET not in record.getMessage()
+        assert _WEBHOOK_SECRET not in repr(record.args)


### PR DESCRIPTION
## What

Stop the generic webhook route from interpolating the secret env binding into its refusal log. The unconfigured-endpoint message in `_verify_generic_webhook_secret` is now fully literal, matching the GitHub and GitLab handlers in the same module, and new caplog tests pin the secret out of every log record the route emits.

## Why

CodeQL high alert 3135 (py/clear-text-logging-sensitive-data) flags src/bernstein/core/routes/webhooks.py line 103: a secret-shaped binding flows into a `logger.error` call, so log sinks that persist records can end up holding secret-tagged data. Operators shipping route logs to external sinks need a guarantee that nothing secret-shaped ever reaches a record.

## How

Inline the env var name as a literal in the refusal message so no argument flows into the logging call - the same idiom the GitHub (`GITHUB_WEBHOOK_SECRET`) and GitLab (`GITLAB_WEBHOOK_TOKEN`) handlers already use. A sweep of the module and its helpers found no other logging call that receives a secret-derived value.

Tests (tests/unit/test_generic_webhook.py):
- `test_unconfigured_webhook_refusal_log_interpolates_nothing` triggers the 503 path and asserts the refusal record carries no interpolation args (fails before the fix).
- `test_webhook_secret_absent_from_all_log_records` exercises the accepted, forged-signature, and unsigned paths at DEBUG capture and asserts the raw secret value is absent from every captured record's message and args.

Closes #2763

## Summary by Sourcery

Ensure generic webhook route logging never includes secret values, aligning its refusal message with other webhook handlers and guarding against sensitive data leaking into logs.

Bug Fixes:
- Prevent the generic webhook endpoint from interpolating the webhook secret into its refusal error log when the secret is not configured.

Tests:
- Add caplog-based tests that confirm the unconfigured webhook refusal log is fully literal and that the webhook secret never appears in any log record emitted during POST /webhook handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook security logging to prevent configured secrets or environment-derived values from appearing in application logs.
  * Preserved existing webhook rejection behavior and responses when authentication is unavailable or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->