### PR TITLE
fix(core): explicit adapter selection must not be overridden by model-name substring inference

### DIFF
--- a/src/bernstein/cli/commands/worker_cmd.py
+++ b/src/bernstein/cli/commands/worker_cmd.py
@@ -84,6 +84,10 @@ class WorkerLoop:
         self._pool_hash = pool_hash
         self._enrolment_keyid: str | None = None
         self._adapter_name = adapter or _detect_worker_adapter()
+        # An adapter passed explicitly to the worker is an operator pin and
+        # must not be overridden by model-name inference at spawn time
+        # (#2751); an auto-detected adapter is not a pin.
+        self._adapter_pinned = adapter is not None
         # Prefer explicit PollConfig; fall back to legacy poll_interval (seconds).
         if poll_config is not None:
             self._poll_config = poll_config
@@ -323,6 +327,7 @@ class WorkerLoop:
                 adapter=adapter,
                 templates_dir=get_templates_dir(self._workdir) / "roles",
                 workdir=self._workdir,
+                adapter_pinned=self._adapter_pinned,
             )
             # Spawned agents reach the central server through the standard
             # env vars. Adapters launch agents with an allowlist-filtered

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -1247,8 +1247,15 @@ class AgentSpawner:
         default_model: str | None = None,
         provider_availability: dict[str, Any] | None = None,
         availability_prober: Callable[[ChainElement], ProbeResult] | None = None,
+        adapter_pinned: bool = False,
     ) -> None:
         self._enable_caching = enable_caching
+        # True when the run-level adapter was explicitly selected by the
+        # operator (--adapter flag, BERNSTEIN_ADAPTER env var, or a non-"auto"
+        # seed ``cli`` value) rather than defaulted by auto mode. An explicit
+        # pin must never be overridden by model-name substring inference --
+        # see :meth:`_infer_adapter_name_for_provider` (#2751).
+        self._adapter_pinned = adapter_pinned
         # Run-level model (e.g. from ``bernstein run --model``), threaded in by
         # the orchestrator from the CLI flag / seed config. Used to coerce
         # Claude tier names (opus/sonnet/haiku) emitted by the heuristic
@@ -2089,13 +2096,47 @@ class AgentSpawner:
         ``self._adapter.name()`` -- the currently-active adapter -- exactly
         as before, so Claude-only / unrecognized-provider operators are
         unaffected.
+
+        When the run-level adapter is an explicit operator pin
+        (``adapter_pinned=True``: the ``--adapter`` flag, the
+        ``BERNSTEIN_ADAPTER`` env var, or a non-``auto`` seed ``cli`` value),
+        the model string is never consulted (#2751). Without this guard, an
+        aggregator route id such as ``openai/gpt-oss-20b:free`` substring-
+        matches the ``openai`` alias and hijacks a qwen-pinned spawn to the
+        codex adapter. A per-spawn provider selection (task ``cli:`` or
+        ``role_model_policy.<role>.provider``) is a more specific explicit
+        choice and still wins over the pin, but it is resolved against the
+        provider text alone; if it resolves to nothing, the pinned adapter
+        is used. Model-name inference applies only when nothing is pinned
+        anywhere.
         """
         logger.debug(
-            "_infer_adapter_name_for_provider: provider_name=%r model=%r current_adapter=%r",
+            "_infer_adapter_name_for_provider: provider_name=%r model=%r current_adapter=%r adapter_pinned=%r",
             provider_name,
             model,
             self._adapter.name(),
+            self._adapter_pinned,
         )
+        if self._adapter_pinned:
+            resolved = adapter_name_for_provider(provider_name, "") if provider_name else None
+            if resolved is not None:
+                logger.info(
+                    "_infer_adapter_name_for_provider: per-spawn provider_name=%r -> adapter=%r "
+                    "(overrides run-level pin %r)",
+                    provider_name,
+                    resolved,
+                    self._adapter.name(),
+                )
+                return resolved
+            pinned = self._adapter.name()
+            logger.info(
+                "_infer_adapter_name_for_provider: run-level adapter pin %r wins; "
+                "model-name inference skipped for provider_name=%r model=%r",
+                pinned,
+                provider_name,
+                model,
+            )
+            return pinned
         resolved = adapter_name_for_provider(provider_name, model)
         if resolved is not None:
             logger.info(

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -5832,6 +5832,12 @@ if __name__ == "__main__":
             sandbox_options={"image": _container_image} if _docker_sandbox_backend is not None else None,
             sandbox_server_port=args.port,
             default_model=run_model,
+            # Explicit adapter selection (--adapter / BERNSTEIN_ADAPTER / a
+            # non-"auto" seed cli) must never be overridden by model-name
+            # inference at spawn time (#2751). "auto" is the only unpinned
+            # state - adapter_name is guaranteed non-empty by the fatal
+            # check above.
+            adapter_pinned=adapter_name != "auto",
         )
         run_config_budget_usd: float | None = None
         dry_run = False

--- a/tests/unit/test_adapter_inference.py
+++ b/tests/unit/test_adapter_inference.py
@@ -37,6 +37,20 @@ def _make_spawner(tmp_path: Path) -> AgentSpawner:
     return AgentSpawner(adapter, templates_dir, tmp_path)
 
 
+def _make_pinned_spawner(tmp_path: Path, adapter_name: str) -> AgentSpawner:
+    """Spawner whose run-level adapter is an explicit operator pin.
+
+    Mirrors the orchestrator construction path for ``--adapter`` /
+    ``BERNSTEIN_ADAPTER`` / a non-``auto`` seed ``cli`` value, all of which
+    set ``adapter_pinned=True`` on the spawner.
+    """
+    adapter = MagicMock()
+    adapter.name.return_value = adapter_name
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir(parents=True, exist_ok=True)
+    return AgentSpawner(adapter, templates_dir, tmp_path, adapter_pinned=True)
+
+
 def test_openai_agents_provider_routes_to_openai_agents_adapter(tmp_path: Path) -> None:
     """provider='openai_agents' must not be swallowed by the 'openai' check."""
     spawner = _make_spawner(tmp_path)
@@ -87,6 +101,43 @@ def test_registry_gpt_oss_excluded_from_gpt_alias() -> None:
     'gpt' alias match when the model text contains 'gpt-oss'."""
     assert registry.adapter_name_for_provider(None, "gpt-oss:20b") != "codex"
     assert registry.adapter_name_for_provider(None, "gpt-5.5") == "codex"
+
+
+def test_pinned_adapter_wins_over_model_namespace_substring(tmp_path: Path) -> None:
+    """Regression (#2751): an explicit adapter pin must never be hijacked by
+    model-name substring inference. With the run pinned to qwen and no
+    per-spawn provider (task cli 'auto'), an OpenRouter route id like
+    'openai/gpt-oss-20b:free' used to substring-match the 'openai' alias and
+    misroute the spawn to codex."""
+    spawner = _make_pinned_spawner(tmp_path, "qwen")
+    result = spawner._infer_adapter_name_for_provider(None, "openai/gpt-oss-20b:free")
+    assert result == "qwen"
+
+
+def test_pinned_adapter_explicit_provider_still_wins_over_pin(tmp_path: Path) -> None:
+    """A per-spawn provider selection (task `cli:` / role_model_policy
+    provider) is more specific than the run-level pin and must still resolve
+    to its own adapter via exact alias lookup."""
+    spawner = _make_pinned_spawner(tmp_path, "qwen")
+    result = spawner._infer_adapter_name_for_provider("codex", "openai/gpt-oss-20b:free")
+    assert result == "codex"
+
+
+def test_pinned_adapter_provider_lookup_never_consults_model_text(tmp_path: Path) -> None:
+    """Under a pin, an unrecognized per-spawn provider must fall back to the
+    pinned adapter - never to an adapter substring-inferred from the model
+    string."""
+    spawner = _make_pinned_spawner(tmp_path, "qwen")
+    result = spawner._infer_adapter_name_for_provider("totally-unknown-provider", "openai/gpt-oss-20b:free")
+    assert result == "qwen"
+
+
+def test_unpinned_model_name_inference_is_unchanged(tmp_path: Path) -> None:
+    """When nothing is pinned anywhere (adapter_pinned defaults to False),
+    model-name inference keeps working exactly as before."""
+    spawner = _make_spawner(tmp_path)
+    assert spawner._infer_adapter_name_for_provider(None, "gpt-5.5") == "codex"
+    assert spawner._infer_adapter_name_for_provider(None, "qwen3-coder") == "qwen"
 
 
 def test_unrecognized_provider_falls_back_to_current_adapter(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

Adds an `adapter_pinned` flag to `AgentSpawner` and makes `_infer_adapter_name_for_provider` honor it: when the run-level adapter was explicitly selected (`--adapter`, `BERNSTEIN_ADAPTER`, or a non-`auto` seed `cli` value), the model string is never consulted for adapter inference. A per-spawn provider selection (task `cli:` or `role_model_policy.<role>.provider`) is more specific than the run pin and still wins, resolved against the provider text alone; anything unresolved falls back to the pinned adapter. When nothing is pinned anywhere, inference behavior is byte-identical to before.

## Why

With `BERNSTEIN_ADAPTER=qwen` and a task whose `cli` is `auto`, the spawner ran adapter inference with `provider_name=None`, and the registry's substring fallback matched the `openai` alias inside the model id `openai/gpt-oss-20b:free` (an OpenRouter route namespace, not a provider selector). The spawn was hijacked to the codex adapter and failed with `error: unexpected argument '--session-id' found`. An explicit adapter pin must always take precedence over model-name inference - same precedence rule as #2741, applied to the model-name inference path.

## How

- `spawner_core.AgentSpawner` gains `adapter_pinned: bool = False`; `_infer_adapter_name_for_provider` short-circuits under a pin: exact/alias lookup on `provider_name` only (model text withheld), else the pinned adapter name. All spawn-path call sites (spawn loop, sampling gates, tier-coercion) go through this one method, so they inherit the guard.
- The orchestrator `__main__` passes `adapter_pinned=adapter_name != "auto"`; the worker loop passes `adapter_pinned` when its adapter argument was supplied explicitly rather than auto-detected.
- Regression tests in `tests/unit/test_adapter_inference.py` reproduce the exact hijack (pin qwen + model `openai/gpt-oss-20b:free` -> asserts qwen), cover per-spawn provider precedence over the pin, assert the model text is never consulted under a pin, and pin the unpinned inference path to its previous behavior.

Closes #2751