### PR TITLE
fix(security): stop persisting the identity grant secret in clear text

### DIFF
--- a/src/bernstein/core/identity/grants.py
+++ b/src/bernstein/core/identity/grants.py
@@ -46,8 +46,9 @@ One JSONL line per record under ``<root>/grants/<run_id>.jsonl``::
       "kind": "grant_issued",           # issued | exchanged | revoked | refused
       "grant_id": "...",
       "task_id": "t-42",
-      "secret_name": "sha256:<hex>",    # digest only -- the raw backend
-                                         # secret/key name is never persisted
+      "secret_name": "scrypt:<salt>:<hex>",  # salted hash only -- the raw
+                                             # backend secret/key name is
+                                             # never persisted
       "audience": "api.anthropic.com",
       "expiry": 1730000900,             # epoch seconds; 0 == no explicit expiry
       "capability_ceiling": ["read"],   # sorted, canonical
@@ -67,6 +68,7 @@ from __future__ import annotations
 import hashlib
 import hmac as _hmac
 import json
+import secrets as _secrets
 import time
 import uuid
 from dataclasses import dataclass, field
@@ -91,8 +93,10 @@ __all__ = [
     "default_ledger",
     "digest_secret_name",
     "find_active_grant",
+    "hash_secret_name",
     "install_grant_signer",
     "render_report",
+    "secret_name_matches",
     "verify_grant_chain",
     "verify_grant_signature",
 ]
@@ -164,17 +168,84 @@ def _compute_hmac(key: bytes, prev_hmac: str, body: dict[str, Any]) -> str:
     return _hmac.new(key, payload.encode(), hashlib.sha256).hexdigest()
 
 
-def digest_secret_name(secret_name: str) -> str:
-    """Return a ``sha256:<hex>`` reference for ``secret_name``, safe to persist.
+#: Salted-reference format written to new records. ``sha256:`` (unsalted) is
+#: the legacy format older releases wrote; it is still matched on read so
+#: pre-existing chains stay usable, but it is never written anymore.
+_SALTED_PREFIX: Final[str] = "scrypt:"
+_LEGACY_PREFIX: Final[str] = "sha256:"
+
+_SALT_BYTES: Final[int] = 16
+#: RFC 7914 interactive-use parameters (16 MiB, well under OpenSSL's default
+#: 32 MiB maxmem). Grants are minted once per task spawn, so the cost budget
+#: is per-spawn, not per-request.
+_SCRYPT_N: Final[int] = 2**14
+_SCRYPT_R: Final[int] = 8
+_SCRYPT_P: Final[int] = 1
+_SCRYPT_DKLEN: Final[int] = 32
+
+
+def _scrypt_hex(secret_name: str, salt: bytes) -> str:
+    """Return the hex scrypt derivation of ``secret_name`` under ``salt``."""
+    return hashlib.scrypt(
+        secret_name.encode("utf-8"),
+        salt=salt,
+        n=_SCRYPT_N,
+        r=_SCRYPT_R,
+        p=_SCRYPT_P,
+        dklen=_SCRYPT_DKLEN,
+    ).hex()
+
+
+def hash_secret_name(secret_name: str) -> str:
+    """Return a salted ``scrypt:<salt-hex>:<hash-hex>`` reference safe to persist.
 
     The backing-store secret name (e.g. an env var or Vault path) is never
-    written to a chain record, receipt, report, or log in clear text -- only
-    this deterministic digest is. The digest is stable, so matching a grant
-    by ``(task_id, secret_name)`` still works by comparing digests; the raw
-    name itself is only ever held in memory for the duration of the call that
-    computes this digest. An empty name digests to an empty string so an
-    absent/optional ``secret_name`` stays absent rather than becoming the
-    digest of the empty string.
+    written to a chain record, receipt, report, or log in clear text. Backing
+    names are low-entropy, so an unsalted digest would be reversible with a
+    precomputed dictionary; each call draws a fresh random salt, which also
+    keeps records for the same name from correlating across grants. Matching
+    a grant by ``(task_id, secret_name)`` goes through
+    :func:`secret_name_matches`, which re-derives under the salt carried in
+    the stored value. An empty name maps to an empty string so an
+    absent/optional ``secret_name`` stays absent.
+    """
+    if not secret_name:
+        return ""
+    salt = _secrets.token_bytes(_SALT_BYTES)
+    return f"{_SALTED_PREFIX}{salt.hex()}:{_scrypt_hex(secret_name, salt)}"
+
+
+def secret_name_matches(stored: str, secret_name: str) -> bool:
+    """Return True when ``stored`` is a persisted reference for ``secret_name``.
+
+    Accepts both the salted ``scrypt:<salt>:<hash>`` format new records carry
+    and the legacy unsalted ``sha256:<hex>`` format written by earlier
+    releases, so chains recorded before salting keep matching. Empty matches
+    only empty (an absent name is not a wildcard); anything malformed never
+    matches.
+    """
+    if not stored or not secret_name:
+        return stored == "" and secret_name == ""
+    if stored.startswith(_SALTED_PREFIX):
+        parts = stored.split(":")
+        if len(parts) != 3:
+            return False
+        try:
+            salt = bytes.fromhex(parts[1])
+        except ValueError:
+            return False
+        return _hmac.compare_digest(_scrypt_hex(secret_name, salt), parts[2])
+    if stored.startswith(_LEGACY_PREFIX):
+        return _hmac.compare_digest(digest_secret_name(secret_name), stored)
+    return False
+
+
+def digest_secret_name(secret_name: str) -> str:
+    """Return the legacy unsalted ``sha256:<hex>`` reference for ``secret_name``.
+
+    Kept only so :func:`secret_name_matches` can match records written by
+    releases that predate salting. Never use this for new persistence -- new
+    records go through :func:`hash_secret_name`.
     """
     if not secret_name:
         return ""
@@ -414,16 +485,16 @@ class GrantLedger:
         prev_hmac, record_index = self._tail(run_id)
         ts = int(created if created is not None else time.time())
         # The raw secret_name is used only transiently, right here, to derive
-        # the digest that actually gets signed and persisted; it is never
-        # itself written into `signed` (and therefore never into the chain
-        # record, the receipt, or a rendered report).
+        # the salted reference that actually gets signed and persisted; it is
+        # never itself written into `signed` (and therefore never into the
+        # chain record, the receipt, or a rendered report).
         signed = {
             "run_id": run_id,
             "record_index": record_index,
             "kind": kind,
             "grant_id": grant_id,
             "task_id": task_id,
-            "secret_name": digest_secret_name(secret_name),
+            "secret_name": hash_secret_name(secret_name),
             "audience": audience,
             "expiry": expiry,
             "capability_ceiling": sorted(capability_ceiling),
@@ -721,13 +792,13 @@ def find_active_grant(
     # Index the issued records so we can return the receipt itself.
     issued: dict[str, GrantReceipt] = {r.grant_id: r for r in result.records if r.kind == GRANT_ISSUED}
     best: GrantReceipt | None = None
-    # Records only ever carry the digest (see digest_secret_name), so the
-    # lookup key is digested here too rather than the raw secret name.
-    wanted_secret = digest_secret_name(secret_name)
+    # Records only ever carry a salted reference (see hash_secret_name), so
+    # matching re-derives the requested name under each record's own salt
+    # rather than comparing against a single precomputed digest.
     for grant_id, state in life.items():
         if not state["issued"] or state["revoked"]:
             continue
-        if state["task_id"] != task_id or state["secret_name"] != wanted_secret:
+        if state["task_id"] != task_id or not secret_name_matches(str(state["secret_name"]), secret_name):
             continue
         expiry = int(state["expiry"])
         if expiry and current >= expiry:

--- a/src/bernstein/core/security/secrets_broker.py
+++ b/src/bernstein/core/security/secrets_broker.py
@@ -983,10 +983,11 @@ class SecretsBroker:
 
         if getattr(grant, "task_id", None) != task_id:
             return False, "task_mismatch"
-        # Grant records only ever carry the digest of secret_name (never the
-        # raw backend key/env var name -- see grants.digest_secret_name), so
-        # the comparison digests the requested name the same way.
-        if getattr(grant, "secret_name", None) != _grants.digest_secret_name(secret_name):
+        # Grant records only ever carry a salted reference to secret_name
+        # (never the raw backend key/env var name -- see
+        # grants.hash_secret_name), so the comparison re-derives the requested
+        # name under the salt carried in the record.
+        if not _grants.secret_name_matches(str(getattr(grant, "secret_name", "") or ""), secret_name):
             return False, "secret_mismatch"
         if self._grant_ledger is None:
             return False, "no_ledger"

--- a/tests/unit/identity/test_grants.py
+++ b/tests/unit/identity/test_grants.py
@@ -11,6 +11,7 @@ failure naming the offending record.
 
 from __future__ import annotations
 
+import hashlib
 import json
 
 import pytest
@@ -58,8 +59,8 @@ class TestGrantIssuance:
             capability_ceiling=("read", "list"),
         )
         assert g.task_id == "t-42"
-        # The persisted/returned secret_name is a digest, never the raw name.
-        assert g.secret_name == grants.digest_secret_name("K")
+        # The persisted/returned secret_name is a salted hash, never the raw name.
+        assert grants.secret_name_matches(g.secret_name, "K")
         assert g.secret_name != "K"
         assert g.audience == "vault.internal"
         assert g.expiry == 1_900_000_000
@@ -84,7 +85,7 @@ class TestGrantIssuance:
 
     def test_persisted_record_never_contains_raw_secret_name(self, ledger) -> None:
         """No persisted surface (JSONL entry, receipt, or report) carries the
-        raw secret name in clear text -- only its ``sha256:`` digest.
+        raw secret name in clear text -- only its salted ``scrypt:`` reference.
         """
         raw_secret = "ANTHROPIC_API_KEY_SUPER_SECRET_VALUE"
         g = ledger.issue_grant(
@@ -100,11 +101,11 @@ class TestGrantIssuance:
         # On-disk JSONL (the audit chain entry) never contains the raw name.
         raw_file = ledger.receipt_path("run-1").read_text(encoding="utf-8")
         assert raw_secret not in raw_file
-        assert grants.digest_secret_name(raw_secret) in raw_file
+        assert g.secret_name in raw_file
 
         # Neither does the in-memory receipt returned to the caller, nor its
         # serialized JSONL entry.
-        assert g.secret_name == grants.digest_secret_name(raw_secret)
+        assert grants.secret_name_matches(g.secret_name, raw_secret)
         assert raw_secret not in g.secret_name
         assert raw_secret not in json.dumps(g.to_entry())
 
@@ -112,6 +113,61 @@ class TestGrantIssuance:
         result = grants.verify_grant_chain(root=ledger.root, run_id="run-1", key=b"k" * 32)
         report = grants.render_report(result, run_id="run-1")
         assert raw_secret not in report
+
+
+class TestSecretNameAtRest:
+    """The persisted secret_name reference must not be derivable without the record.
+
+    An unsalted digest of a low-entropy backing name (an env var name or a
+    vault path) is reversible with a precomputed dictionary, so the store must
+    hold a salted derivation instead and comparison must go through the salt
+    held in the record.
+    """
+
+    def test_no_file_written_by_store_contains_raw_or_unsalted_digest(self, ledger) -> None:
+        raw_secret = "VAULT_PATH_TO_PRODUCTION_SIGNING_KEY"
+        unsalted = "sha256:" + hashlib.sha256(raw_secret.encode("utf-8")).hexdigest()
+        g = ledger.issue_grant(
+            run_id="run-1",
+            task_id="t-1",
+            secret_name=raw_secret,
+            audience="aud",
+            expiry=2_000_000_000,
+        )
+        ledger.record_exchange(run_id="run-1", grant_id=g.grant_id, token_id="brn-tok-1")
+        ledger.record_refusal(run_id="run-2", task_id="t-2", secret_name=raw_secret, reason="no_grant")
+        ledger.revoke_grant(run_id="run-1", grant_id=g.grant_id, reason="task-exit", secret_name=raw_secret)
+
+        written = [p for p in ledger.root.rglob("*") if p.is_file()]
+        assert written, "the store wrote no files"
+        for path in written:
+            content = path.read_text(encoding="utf-8")
+            assert raw_secret not in content, f"raw secret name persisted in {path}"
+            assert unsalted not in content, f"dictionary-attackable unsalted digest persisted in {path}"
+
+    def test_stored_reference_is_salted_per_grant(self, ledger) -> None:
+        a = ledger.issue_grant(run_id="run-1", task_id="t-1", secret_name="K", audience="aud", expiry=0)
+        b = ledger.issue_grant(run_id="run-1", task_id="t-2", secret_name="K", audience="aud", expiry=0)
+        # Same backing name, different salts: records must not correlate.
+        assert a.secret_name != b.secret_name
+        assert grants.secret_name_matches(a.secret_name, "K")
+        assert grants.secret_name_matches(b.secret_name, "K")
+
+    def test_secret_name_matches_semantics(self, ledger) -> None:
+        g = ledger.issue_grant(run_id="run-1", task_id="t-1", secret_name="K", audience="aud", expiry=0)
+        assert grants.secret_name_matches(g.secret_name, "K")
+        assert not grants.secret_name_matches(g.secret_name, "J")
+        # Legacy records written before salting carry an unsalted sha256
+        # digest; they must still match so pre-existing chains stay usable.
+        assert grants.secret_name_matches(grants.digest_secret_name("K"), "K")
+        assert not grants.secret_name_matches(grants.digest_secret_name("K"), "J")
+        # Absent names stay absent on both sides.
+        assert grants.secret_name_matches("", "")
+        assert not grants.secret_name_matches("", "K")
+        assert not grants.secret_name_matches(g.secret_name, "")
+        # Garbage stored values never match anything.
+        assert not grants.secret_name_matches("scrypt:zz:zz", "K")
+        assert not grants.secret_name_matches("plaintext-K", "K")
 
 
 class TestOfflineReconstruction:


### PR DESCRIPTION
## What

Grant records under `.sdd/audit/grants/` no longer store a dictionary-attackable reference to the backing secret name. New records carry a per-grant salted scrypt derivation (`scrypt:<salt>:<hash>`), and grant lookups compare by re-deriving the requested name under the salt carried in each record. Records written by earlier releases (`sha256:<hex>`) still match on read, so existing chains stay usable.

## Why

CodeQL high alert 2946 (py/clear-text-storage-sensitive-data) flagged the grant ledger write in `src/bernstein/core/identity/grants.py`. The record stored an unsalted sha256 digest of the backing secret name. Backing names are low-entropy (env var names, vault paths), so an unsalted digest at rest is reversible with a precomputed dictionary, and identical names correlate across records. On the signed-identity surface that undermines the guarantee the module exists to provide: an operator handing a chain slice to a third party leaks which backing credentials the fleet uses.

## How

The stored value is only ever compared (grant lookup and the broker's grant check), never read back, so it is hashed rather than encrypted:

- `hash_secret_name()` writes `scrypt:<salt>:<hash>` with a fresh 16-byte salt per record (RFC 7914 interactive parameters; grants are minted once per task spawn, so the cost is per-spawn).
- `secret_name_matches()` re-derives under the record's salt and compares in constant time; it also accepts the legacy `sha256:` format so pre-existing chains keep matching.
- `find_active_grant()` and the secrets broker's `_verify_grant()` now match through the helper instead of comparing precomputed digests.
- Chain verification semantics are unchanged: HMAC linkage, Ed25519 signature checks, and every tamper/deletion/reorder failure mode report exactly as before (covered by the existing offline-reconstruction tests).
- Regression test creates issue/exchange/refuse/revoke records, walks every file the store wrote, and asserts neither the raw secret name nor its unsalted digest appears; two grants for the same name must store non-correlating references.

Targeted tests: `tests/unit/identity/test_grants.py`, `tests/unit/security/test_secrets_broker_grants.py`, `tests/unit/security/test_broker_grant_config.py`, `tests/unit/identity/spiffe/test_grant_identity.py`, `tests/unit/cli/test_audit_verify_grants.py`, `tests/unit/cli/test_secrets_grants_cli.py` (47 passed).

Closes #2762