### PR TITLE
fix(core): verify path_exists completion signals against the operator tree, not the ephemeral worktree

### DIFF
--- a/docs/operations/TROUBLESHOOTING.md
+++ b/docs/operations/TROUBLESHOOTING.md
@@ -568,6 +568,37 @@ find . -name "*<basename-without-extension>*"
 
 ---
 
+## 22. Task Fails Verification with "pointed inside an ephemeral agent worktree" or a Gitignore Cause
+
+**Symptom:** A task the agent reported as complete fails janitor verification
+with a `path_exists` detail like `signal path '...' pointed inside an
+ephemeral agent worktree; repo-relative path '...' does not exist in the
+operator checkout`, possibly followed by `matches gitignore rule [...]`. See
+issue [#2760](https://github.com/sipyourdrink-ltd/bernstein/issues/2760).
+
+**Cause:** Filesystem completion signals (`path_exists`, `glob_exists`,
+`file_contains`) are verified against the operator checkout, not the agent's
+worktree. Agent worktrees (`.sdd/worktrees/<session>/`,
+`.sdd/runtime/worktrees/<session>/`) are deleted after the run, so a file
+that exists only there was never delivered. Signals whose path points inside
+a worktree are translated to their repo-relative form and checked against
+the merged result. The most common delivery failure is a `.gitignore` rule
+matching the deliverable: the git-based merge-back stages only tracked-able
+files, so an ignored artifact silently never leaves the worktree. Previously
+this reported done/HEALTHY with zero deliverable in the checkout; now it
+fails verification with the cause named.
+
+**Resolution:**
+- If the detail names a gitignore rule, either write the deliverable to a
+  non-ignored path or amend the ignore rule, then rerun.
+- If no gitignore rule is named, the artifact was not merged back at all -
+  check `merge_preflight` lines in `.sdd/runtime/*.log` for a refused or
+  conflicted merge (see also issue #2756).
+- Verify delivery manually: the path in the detail message is repo-relative;
+  check it exists in your checkout after the run.
+
+---
+
 ## Quick Reference: Exit Codes
 
 | Exit code | Meaning | Likely cause |

--- a/src/bernstein/core/quality/janitor.py
+++ b/src/bernstein/core/quality/janitor.py
@@ -266,14 +266,19 @@ def verify_task(task: Task, workdir: Path) -> tuple[bool, list[str]]:
         workdir: Project root for path resolution.
 
     Returns:
-        Tuple of (all_passed, list_of_failed_signal_descriptions).
-        If no signals defined, returns (True, []).
+        Tuple of (all_passed, list_of_failed_signal_descriptions). Failed
+        descriptions carry the evaluation detail so actionable causes (e.g.
+        a gitignore-excluded deliverable the merge-back never staged) reach
+        retry/fail surfaces. If no signals defined, returns (True, []).
     """
     failed: list[str] = []
     for signal in task.completion_signals:
-        passed, _detail = evaluate_signal(signal, workdir)
+        passed, detail = evaluate_signal(signal, workdir)
         if not passed:
-            failed.append(f"{signal.type}: {signal.value}")
+            desc = f"{signal.type}: {signal.value}"
+            if detail:
+                desc = f"{desc} ({detail})"
+            failed.append(desc)
     all_passed = len(failed) == 0
     return all_passed, failed
 
@@ -1042,6 +1047,159 @@ def _resolve(path_str: str, workdir: Path) -> Path:
     return workdir / p
 
 
+# --- issue #2760: worktree-internal signal paths ---
+#
+# Agent worktrees live under ``<workdir>/.sdd/worktrees/<session>/`` (legacy)
+# or ``<workdir>/.sdd/runtime/worktrees/<session>/`` and are deleted after the
+# run. A filesystem signal whose path points inside one of them (managers
+# routinely emit the path the agent reported, which is worktree-absolute) only
+# proves the agent wrote the file at some instant -- not that the git-based
+# merge-back delivered it to the operator checkout. If the file is
+# gitignore-excluded, merge-back stages nothing, the worktree is deleted, and
+# a naive check would still report done/HEALTHY with zero deliverable.
+#
+# Fix: translate any worktree-internal signal path to its repo-relative form
+# and verify THAT against the checkout the janitor was pointed at. Existence
+# only inside a worktree never counts as delivered; glob and fuzzy fallbacks
+# likewise never match worktree-internal files.
+
+_WORKTREE_BASE_MARKERS: tuple[tuple[str, ...], ...] = (
+    (".sdd", "runtime", "worktrees"),
+    (".sdd", "worktrees"),
+)
+
+
+def _split_worktree_path(path_str: str) -> str | None:
+    """Return the repo-relative remainder of a worktree-internal path.
+
+    Recognizes both worktree layouts (``.sdd/worktrees/<session>/...`` and
+    ``.sdd/runtime/worktrees/<session>/...``) anywhere in the path, so
+    absolute and repo-relative signal values both translate.
+
+    Args:
+        path_str: Raw signal path.
+
+    Returns:
+        The path relative to the worktree root (i.e. relative to the repo),
+        or None when the path does not point inside a worktree or has no
+        remainder after the session directory.
+    """
+    parts = Path(path_str).parts
+    for i, part in enumerate(parts):
+        if part != ".sdd":
+            continue
+        for marker in _WORKTREE_BASE_MARKERS:
+            if tuple(parts[i : i + len(marker)]) == marker:
+                remainder = parts[i + len(marker) + 1 :]
+                if remainder:
+                    return str(Path(*remainder))
+    return None
+
+
+def _translate_worktree_signal_path(path_str: str, workdir: Path) -> tuple[str, bool]:
+    """Translate a worktree-internal signal path to its repo-relative form.
+
+    Args:
+        path_str: Raw signal path.
+        workdir: Checkout the signal is being verified against.
+
+    Returns:
+        Tuple of (path to verify, translated). When ``translated`` is True
+        the returned path is repo-relative and must be resolved against
+        *workdir*; otherwise ``path_str`` is returned unchanged.
+    """
+    remainder = _split_worktree_path(path_str)
+    if remainder is None:
+        return path_str, False
+    logger.warning(
+        "janitor: signal path %r points inside an ephemeral agent worktree; "
+        "verifying repo-relative path %r against %s instead -- existence only "
+        "in a worktree does not count as delivered",
+        path_str,
+        remainder,
+        workdir,
+    )
+    return remainder, True
+
+
+def _is_worktree_internal(path: Path, workdir: Path) -> bool:
+    """True when *path* is inside one of *workdir*'s agent worktree bases."""
+    return any(path.is_relative_to(workdir.joinpath(*marker)) for marker in _WORKTREE_BASE_MARKERS)
+
+
+def _gitignore_exclusion(path_str: str, workdir: Path) -> str | None:
+    """Return the gitignore rule excluding *path_str* from git, if any.
+
+    Args:
+        path_str: Path to test, relative to *workdir* or absolute inside it.
+        workdir: Repository root to run ``git check-ignore`` in.
+
+    Returns:
+        The matching rule as ``<source>:<line>:<pattern>``, or None when the
+        path is not ignored, lies outside *workdir*, or git is unavailable.
+    """
+    candidate = Path(path_str)
+    if candidate.is_absolute():
+        try:
+            candidate = candidate.relative_to(workdir)
+        except ValueError:
+            return None
+    try:
+        result = subprocess.run(
+            ["git", "check-ignore", "--verbose", "--", str(candidate)],
+            cwd=workdir,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.debug("janitor: git check-ignore failed for %r in %s: %s", path_str, workdir, exc)
+        return None
+    if result.returncode != 0:
+        return None
+    lines = result.stdout.strip().splitlines()
+    if not lines:
+        return None
+    # Output format: <source>:<linenum>:<pattern>\t<pathname>
+    return lines[0].split("\t", 1)[0]
+
+
+def _path_miss_detail(path_str: str, workdir: Path, worktree_original: str | None) -> str:
+    """Build the failure detail for a path_exists miss.
+
+    Keeps the bare ``"not found"`` wire format for the ordinary case; adds
+    an actionable cause when the signal path pointed inside an ephemeral
+    worktree and/or the deliverable is excluded by a gitignore rule (so the
+    git-based merge-back never staged it).
+
+    Args:
+        path_str: The path that was actually verified (post-translation).
+        workdir: Checkout the path was verified against.
+        worktree_original: The raw signal value when it pointed inside a
+            worktree, else None.
+
+    Returns:
+        Human-readable failure detail.
+    """
+    rule = _gitignore_exclusion(path_str, workdir)
+    if rule is None and worktree_original is None:
+        return "not found"
+    fragments: list[str] = []
+    if worktree_original is not None:
+        fragments.append(
+            f"signal path {worktree_original!r} pointed inside an ephemeral agent worktree; "
+            f"repo-relative path {path_str!r} does not exist in the operator checkout"
+        )
+    else:
+        fragments.append(f"{path_str!r} does not exist in the operator checkout")
+    if rule is not None:
+        fragments.append(
+            f"the path matches gitignore rule [{rule}], so the git-based merge-back never "
+            "stages it; write the deliverable to a non-ignored path or amend the ignore rule"
+        )
+    return "not found: " + "; ".join(fragments)
+
+
 _GLOB_CHARS = frozenset("*?[")
 
 
@@ -1095,11 +1253,24 @@ def _check_path_exists(path_str: str, workdir: Path) -> tuple[bool, str]:
          fires, a WARNING log names the literal miss, the pattern, and the
          path that satisfied the check.
 
+    Delivery contract (issue #2760): a signal path pointing inside an
+    ephemeral agent worktree is first translated to its repo-relative form
+    (:func:`_translate_worktree_signal_path`) and verified against
+    ``workdir``; glob and fuzzy fallbacks never match worktree-internal
+    files. Existence only in a worktree is not delivery -- the worktree is
+    deleted after the run.
+
     Returns:
         (passed, detail). ``detail`` is "exists"/"not found" for the
         literal case (unchanged wire format) and a longer message
-        identifying the matched path when a glob or fuzzy match passed.
+        identifying the matched path when a glob or fuzzy match passed,
+        or naming the delivery failure cause (worktree-only path,
+        gitignore exclusion) when that is determinable on a miss.
     """
+    original = path_str
+    path_str, translated = _translate_worktree_signal_path(path_str, workdir)
+    worktree_original = original if translated else None
+
     has_glob_syntax = any(c in _GLOB_CHARS for c in path_str)
 
     # Literal-first: a literal path always wins, even when it contains a glob
@@ -1112,9 +1283,12 @@ def _check_path_exists(path_str: str, workdir: Path) -> tuple[bool, str]:
 
     if has_glob_syntax:
         # Literal miss AND the criterion contains explicit glob syntax: honor
-        # it as a glob pattern (opt-in per-check by construction).
+        # it as a glob pattern (opt-in per-check by construction). Matches
+        # inside an agent worktree are excluded -- they are not deliveries.
         glob_pattern = str(workdir / path_str)
-        glob_matches = sorted(globmod.glob(glob_pattern, recursive=True))
+        glob_matches = sorted(
+            m for m in globmod.glob(glob_pattern, recursive=True) if not _is_worktree_internal(Path(m), workdir)
+        )
         if glob_matches:
             matched = glob_matches[0]
             logger.info(
@@ -1128,10 +1302,10 @@ def _check_path_exists(path_str: str, workdir: Path) -> tuple[bool, str]:
             path_str,
             workdir,
         )
-        return False, "not found"
+        return False, _path_miss_detail(path_str, workdir, worktree_original)
 
     if not _fuzzy_paths_enabled():
-        return False, "not found"
+        return False, _path_miss_detail(path_str, workdir, worktree_original)
 
     # Opt-in fuzzy basename fallback. Split the basename on the FIRST dot,
     # not the last: multi-part suffixes like ".test.ts" / ".spec.tsx" are
@@ -1149,10 +1323,12 @@ def _check_path_exists(path_str: str, workdir: Path) -> tuple[bool, str]:
             "janitor path_exists: literal miss for %r and no basename to fuzzy-match",
             path_str,
         )
-        return False, "not found"
+        return False, _path_miss_detail(path_str, workdir, worktree_original)
     fuzzy_pattern = f"**/{stem}*{suffix}" if suffix else f"**/{stem}*"
     full_fuzzy_pattern = str(workdir / fuzzy_pattern)
-    fuzzy_matches = sorted(globmod.glob(full_fuzzy_pattern, recursive=True))
+    fuzzy_matches = sorted(
+        m for m in globmod.glob(full_fuzzy_pattern, recursive=True) if not _is_worktree_internal(Path(m), workdir)
+    )
     if fuzzy_matches:
         matched = fuzzy_matches[0]
         logger.warning(
@@ -1170,13 +1346,19 @@ def _check_path_exists(path_str: str, workdir: Path) -> tuple[bool, str]:
         path_str,
         fuzzy_pattern,
     )
-    return False, "not found"
+    return False, _path_miss_detail(path_str, workdir, worktree_original)
 
 
 def _check_glob_exists(pattern: str, workdir: Path) -> bool:
-    """Check if at least one file matches the glob pattern."""
+    """Check if at least one file matches the glob pattern.
+
+    Worktree-internal signal patterns are translated to their repo-relative
+    form and matches inside an agent worktree are excluded (issue #2760):
+    the worktree is deleted after the run, so files there are not deliveries.
+    """
+    pattern, _ = _translate_worktree_signal_path(pattern, workdir)
     full_pattern = str(workdir / pattern)
-    matches = globmod.glob(full_pattern, recursive=True)
+    matches = [m for m in globmod.glob(full_pattern, recursive=True) if not _is_worktree_internal(Path(m), workdir)]
     return len(matches) > 0
 
 
@@ -1425,7 +1607,10 @@ def _check_file_contains(spec: str, workdir: Path) -> bool:
     if len(parts) != 2:
         return False
     path_str, needle = parts
-    target = _resolve(path_str.strip(), workdir)
+    # Worktree-internal paths verify the delivered copy, not the ephemeral
+    # worktree one (issue #2760, same contract as _check_path_exists).
+    path_str, _ = _translate_worktree_signal_path(path_str.strip(), workdir)
+    target = _resolve(path_str, workdir)
     if not target.is_file():
         return False
     try:

--- a/tests/unit/test_janitor.py
+++ b/tests/unit/test_janitor.py
@@ -259,6 +259,166 @@ class TestPathExistsGlobAndFuzzy:
         assert "glob pattern matched" in detail
 
 
+class TestWorktreeSignalDelivery:
+    """Issue #2760: filesystem completion signals that point inside an
+    ephemeral agent worktree (``.sdd/worktrees/<session>/`` or
+    ``.sdd/runtime/worktrees/<session>/``) must be translated to their
+    repo-relative form and verified against the operator checkout.
+    Existence only in the worktree proves the agent wrote the file at
+    some instant, not that merge-back delivered it -- the worktree is
+    deleted after the run."""
+
+    _SESSION = "manager-e2760abc"
+
+    def _write_worktree_file(self, tmp_path: Path, rel: str, *, runtime_layout: bool = False) -> Path:
+        """Create *rel* inside a fake agent worktree and return its path."""
+        base = (".sdd", "runtime", "worktrees") if runtime_layout else (".sdd", "worktrees")
+        target = tmp_path.joinpath(*base, self._SESSION, rel)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("deliverable\n")
+        return target
+
+    def test_worktree_only_file_fails_relative_signal(self, tmp_path: Path) -> None:
+        """The exact #2760 shape: the file exists ONLY in the worktree."""
+        self._write_worktree_file(tmp_path, "hello.txt")
+
+        signal = CompletionSignal(type="path_exists", value=f".sdd/worktrees/{self._SESSION}/hello.txt")
+        passed, detail = evaluate_signal(signal, tmp_path)
+        assert passed is False
+        assert "worktree" in detail
+        assert "hello.txt" in detail
+
+    def test_worktree_only_file_fails_absolute_signal(self, tmp_path: Path) -> None:
+        worktree_file = self._write_worktree_file(tmp_path, "hello.txt")
+
+        signal = CompletionSignal(type="path_exists", value=str(worktree_file))
+        passed, detail = evaluate_signal(signal, tmp_path)
+        assert passed is False
+        assert "worktree" in detail
+
+    def test_merged_file_passes(self, tmp_path: Path) -> None:
+        """After merge-back delivered the file, the translated check passes."""
+        self._write_worktree_file(tmp_path, "hello.txt")
+        (tmp_path / "hello.txt").write_text("deliverable\n")
+
+        signal = CompletionSignal(type="path_exists", value=f".sdd/worktrees/{self._SESSION}/hello.txt")
+        passed, detail = evaluate_signal(signal, tmp_path)
+        assert passed is True
+        assert detail == "exists"
+
+    def test_merged_file_passes_after_worktree_deleted(self, tmp_path: Path) -> None:
+        """Delivered artifact verifies even when the worktree is already gone."""
+        (tmp_path / "hello.txt").write_text("deliverable\n")
+
+        signal = CompletionSignal(type="path_exists", value=f".sdd/worktrees/{self._SESSION}/hello.txt")
+        passed, _ = evaluate_signal(signal, tmp_path)
+        assert passed is True
+
+    def test_runtime_worktree_layout_also_translated(self, tmp_path: Path) -> None:
+        self._write_worktree_file(tmp_path, "hello.txt", runtime_layout=True)
+
+        rel = f".sdd/runtime/worktrees/{self._SESSION}/hello.txt"
+        signal = CompletionSignal(type="path_exists", value=rel)
+        passed, detail = evaluate_signal(signal, tmp_path)
+        assert passed is False
+        assert "worktree" in detail
+
+    def test_nested_deliverable_keeps_subdirectories(self, tmp_path: Path) -> None:
+        self._write_worktree_file(tmp_path, "docs/report.md")
+        delivered = tmp_path / "docs" / "report.md"
+        delivered.parent.mkdir(parents=True)
+        delivered.write_text("deliverable\n")
+
+        rel = f".sdd/worktrees/{self._SESSION}/docs/report.md"
+        signal = CompletionSignal(type="path_exists", value=rel)
+        passed, _ = evaluate_signal(signal, tmp_path)
+        assert passed is True
+
+    def test_gitignored_deliverable_names_cause(self, tmp_path: Path) -> None:
+        """A miss whose path matches a .gitignore rule must say WHY the
+        merge-back never delivered it."""
+        _run_git(["init", "-q"], tmp_path)
+        (tmp_path / ".gitignore").write_text("hello.txt\n")
+        self._write_worktree_file(tmp_path, "hello.txt")
+
+        signal = CompletionSignal(type="path_exists", value=f".sdd/worktrees/{self._SESSION}/hello.txt")
+        passed, detail = evaluate_signal(signal, tmp_path)
+        assert passed is False
+        assert "gitignore" in detail
+        assert "merge-back" in detail
+        assert ".gitignore:1:hello.txt" in detail
+
+    def test_plain_miss_detail_unchanged(self, tmp_path: Path) -> None:
+        """A miss outside any worktree keeps the original wire format."""
+        signal = CompletionSignal(type="path_exists", value="missing.txt")
+        passed, detail = evaluate_signal(signal, tmp_path)
+        assert passed is False
+        assert detail == "not found"
+
+    def test_non_worktree_sdd_path_not_translated(self, tmp_path: Path) -> None:
+        """Other .sdd paths (backlog, metrics, ...) are untouched."""
+        target = tmp_path / ".sdd" / "backlog" / "open" / "t.yaml"
+        target.parent.mkdir(parents=True)
+        target.write_text("x")
+
+        signal = CompletionSignal(type="path_exists", value=".sdd/backlog/open/t.yaml")
+        passed, _ = evaluate_signal(signal, tmp_path)
+        assert passed is True
+
+    def test_glob_fallback_ignores_worktree_matches(self, tmp_path: Path) -> None:
+        """A path_exists glob must not be satisfied by worktree-internal files."""
+        self._write_worktree_file(tmp_path, "hello.txt")
+
+        signal = CompletionSignal(type="path_exists", value="**/hello.txt")
+        passed, _ = evaluate_signal(signal, tmp_path)
+        assert passed is False
+
+    def test_fuzzy_fallback_ignores_worktree_matches(self, tmp_path: Path) -> None:
+        self._write_worktree_file(tmp_path, "hello-final.txt")
+
+        signal = CompletionSignal(type="path_exists", value="hello.txt")
+        with patch.dict("os.environ", {"BERNSTEIN_JANITOR_FUZZY_PATHS": "1"}):
+            passed, _ = evaluate_signal(signal, tmp_path)
+        assert passed is False
+
+    def test_glob_exists_signal_ignores_worktree_matches(self, tmp_path: Path) -> None:
+        self._write_worktree_file(tmp_path, "hello.txt")
+
+        signal = CompletionSignal(type="glob_exists", value="**/hello.txt")
+        passed, _ = evaluate_signal(signal, tmp_path)
+        assert passed is False
+
+    def test_file_contains_checks_operator_copy(self, tmp_path: Path) -> None:
+        self._write_worktree_file(tmp_path, "hello.txt")
+
+        value = f".sdd/worktrees/{self._SESSION}/hello.txt :: deliverable"
+        signal = CompletionSignal(type="file_contains", value=value)
+        passed, _ = evaluate_signal(signal, tmp_path)
+        assert passed is False
+
+        (tmp_path / "hello.txt").write_text("deliverable\n")
+        passed, _ = evaluate_signal(signal, tmp_path)
+        assert passed is True
+
+    def test_verify_task_failure_carries_actionable_detail(self, tmp_path: Path) -> None:
+        """The failed-signal description surfaced to retry/fail paths names
+        the worktree cause, not just the raw signal value."""
+        self._write_worktree_file(tmp_path, "hello.txt")
+        task = _make_task(
+            signals=[
+                CompletionSignal(
+                    type="path_exists",
+                    value=f".sdd/worktrees/{self._SESSION}/hello.txt",
+                )
+            ]
+        )
+
+        passed, failed = verify_task(task, tmp_path)
+        assert passed is False
+        assert len(failed) == 1
+        assert "worktree" in failed[0]
+
+
 # --- glob_exists ---
 
 


### PR DESCRIPTION
## What

The janitor now verifies filesystem completion signals (`path_exists`, `glob_exists`, `file_contains`) against the operator checkout instead of trusting paths that point inside an ephemeral agent worktree. Worktree-internal signal paths are translated to their repo-relative form before evaluation, glob and fuzzy fallbacks no longer match worktree-internal files, and a miss caused by a `.gitignore` rule fails with a detail naming the rule and the merge-back consequence.

## Why

A task could be marked done (and the run reported HEALTHY) when its deliverable existed only in the agent's worktree. Managers routinely emit `completion_signals` with the path the agent reported, which is worktree-absolute (`.../.sdd/worktrees/manager-<id>/hello.txt`). `path_exists` on that path proves the agent wrote the file at some instant, not that it was delivered: if the file matches a `.gitignore` rule, the git-based merge-back never stages it, the worktree is deleted, and the operator checkout ends the run with zero deliverable while the receipt attests a file that no longer exists anywhere.

## How

Ordering context, and why the fix lands at signal-evaluation time: merge-back and janitor verification are not strictly ordered. On the dominant alive-exit path, `refresh_agent_states` detects the dead agent and merges the worktree branch (`_save_partial_work` -> `reap_completed_agent`) before `process_completed_tasks` runs the janitor later in the same tick, so the janitor already evaluates the post-merge operator tree. On the orphan path (`handle_orphaned_task`) and the in-tick live-session path, verification can run before merge-back while the worktree still exists on disk under `<workdir>/.sdd/worktrees/` - which is exactly how the false pass fired. Enforcing the operator-tree contract inside the janitor's signal evaluators is the smallest point that is correct under both orderings: when verification runs after merge-back it checks the merged result, and when it runs before, a worktree-only file can no longer count as delivered (matching how a repo-relative signal already behaves there, with the existing reopen budget handling the transient case). No reordering of janitor vs merge, no new synchronization.

Mechanism in `src/bernstein/core/quality/janitor.py`:

- `_split_worktree_path` / `_translate_worktree_signal_path`: recognize both worktree layouts (`.sdd/worktrees/<session>/`, `.sdd/runtime/worktrees/<session>/`) anywhere in a signal path (absolute or relative) and return the repo-relative remainder, logged at WARNING when translation fires.
- `_check_path_exists`: translates first, then runs the unchanged literal/glob/fuzzy ladder against the checkout; glob and fuzzy matches inside a worktree base are filtered out.
- `_gitignore_exclusion` + `_path_miss_detail`: on a miss, `git check-ignore --verbose` names the excluding rule; the failure detail states that merge-back never stages ignored files and what to do about it. Plain misses keep the exact `"not found"` wire format.
- `_check_glob_exists` and `_check_file_contains` follow the same contract.
- `verify_task` now carries the evaluation detail into failed-signal descriptions so the actionable cause reaches retry/fail surfaces and fix-task bodies.

Tests (`tests/unit/test_janitor.py`, `TestWorktreeSignalDelivery`, 15 cases): worktree-only file fails for relative and absolute signal shapes and for both worktree layouts; properly merged file passes (including after the worktree is deleted); gitignored deliverable fails naming the rule; glob/fuzzy/glob_exists fallbacks ignore worktree matches; `file_contains` checks the delivered copy; non-worktree `.sdd` paths and plain-miss details are unchanged; `verify_task` failure descriptions carry the cause.

Docs: new TROUBLESHOOTING entry (#22) describing the failure detail and resolution.

Closes #2760
