### PR TITLE
fix(cli): fail fast and report degraded health when a run targets the default branch without an override

### DIFF
--- a/docs/operations/CONFIG.md
+++ b/docs/operations/CONFIG.md
@@ -365,6 +365,14 @@ a `init.defaultBranch` fallback). The refusal is recorded to
 `.sdd/runtime/refused_merges.jsonl` and the merge is reported as failed rather
 than silently landing unreviewed commits on the trunk.
 
+`bernstein run` also checks this **before spawning any agent**: when the
+default branch is checked out and the override below is unset, the run aborts
+immediately instead of letting every agent work and then discarding the
+result at merge time. Modes that never merge back (`--dry-run`,
+`--plan-only`) are unaffected. If a refusal still happens mid-run, it is
+printed in the end-of-run summary and the run health verdict is downgraded to
+UNHEALTHY.
+
 Check out a non-default branch before merging, or opt in explicitly:
 
 ```bash

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -29,6 +29,7 @@ from bernstein.cli.helpers import (
     server_get,
 )
 from bernstein.cli.run_preflight import (
+    _abort_if_default_branch_merge_target,
     _configure_quality_gate_bypass,
     _emit_preflight_runtime_warnings,
     _estimate_run_preview,
@@ -1875,6 +1876,12 @@ def _run_impl(
 
     workdir = Path.cwd()
     if not plan_only:
+        # Fail fast when agent merges would target the repository default
+        # branch (gh-2756): without this every agent does its work and the
+        # spawner merge guard then silently discards it at reap time.
+        # Applies only to modes that merge agent work back -- --dry-run
+        # returned above and --plan-only skips this block.
+        _abort_if_default_branch_merge_target(workdir)
         estimate = _estimate_run_preview(
             workdir=workdir,
             plan_file=plan_file,

--- a/src/bernstein/cli/run_preflight.py
+++ b/src/bernstein/cli/run_preflight.py
@@ -7,9 +7,10 @@ import io
 import logging
 import os
 import sys
+import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import click
 
@@ -25,26 +26,117 @@ from bernstein.core.cost.preflight import CostBand, compute_band, format_band
 from bernstein.core.plan_loader import load_plan_from_yaml
 from bernstein.core.runtime_state import directory_size_bytes
 
+if TYPE_CHECKING:
+    from rich.console import Console
+
 logger = logging.getLogger(__name__)
+
+#: When this module was imported, which is when the CLI process started.
+#: Used to ignore merge-refusal journal entries left over from previous runs
+#: when surfacing refusals in the end-of-run summary.
+_CLI_RUN_EPOCH = time.time()
 
 # ---------------------------------------------------------------------------
 # Post-run summary helper
 # ---------------------------------------------------------------------------
 
 
+def _abort_if_default_branch_merge_target(workdir: Path) -> None:
+    """Abort before any agent spawns when merges would land on the default branch.
+
+    The spawner merge guard (``spawner_merge._run_merge_and_push``) refuses to
+    merge agent work onto the repository's protected default branch. When the
+    run starts with that branch checked out and the override env var unset,
+    every agent would do its work and then have it silently discarded at
+    merge time (gh-2756). Detect that state up front and abort with the
+    remedy instead.
+
+    Only wired into run modes that merge agent work back into the checked-out
+    branch; ``--dry-run`` and ``--plan-only`` never reach this check.
+
+    Args:
+        workdir: Repository root the run would merge agent work into.
+
+    Raises:
+        SystemExit: When the checked-out branch is a protected default branch
+            and ``BERNSTEIN_ALLOW_MERGE_TO_DEFAULT_BRANCH`` is not set.
+    """
+    from bernstein.core.agents.spawner_merge import (
+        ENV_ALLOW_MERGE_TO_DEFAULT_BRANCH,
+        _allow_merge_to_default_branch,
+    )
+    from bernstein.core.git_ops import current_branch, protected_default_branches
+
+    branch = current_branch(workdir)
+    if branch is None:
+        # Detached HEAD or not a git repo: mirror the merge guard, which only
+        # refuses when a named protected branch is checked out.
+        return
+    if branch not in protected_default_branches(workdir):
+        return
+    if _allow_merge_to_default_branch():
+        return
+    console.print(
+        f"[bold red]Refusing to start:[/bold red] the checked-out branch {branch!r} is the "
+        "repository default branch, so every agent's work would be refused by the merge "
+        "guard and discarded instead of merged."
+    )
+    console.print(
+        "Fix: check out a working branch first (git checkout -b <branch>), or set "
+        f"{ENV_ALLOW_MERGE_TO_DEFAULT_BRANCH}=1 to explicitly allow merging to the default branch."
+    )
+    raise SystemExit(1)
+
+
+def _surface_merge_refusals(workdir: Path, *, since_ts: float, console: Console) -> None:
+    """Print a loud warning for agent merges the merge guard refused this run.
+
+    The spawner merge guard refuses to land agent work on the repository's
+    protected default branch and records each refusal to
+    ``.sdd/runtime/refused_merges.jsonl``. Without this warning the refusal
+    is only visible in the spawner log, so the run ends looking clean while
+    the work was discarded (gh-2756).
+
+    Args:
+        workdir: Repository root of the run.
+        since_ts: Only refusals recorded at or after this timestamp are
+            shown, filtering out journal entries from previous runs.
+        console: Console to print the warning to.
+    """
+    from bernstein.core.agents.spawner_merge import ENV_ALLOW_MERGE_TO_DEFAULT_BRANCH
+    from bernstein.core.quality.retrospective import read_merge_refusals
+
+    refusals = read_merge_refusals(workdir / ".sdd" / "runtime", since_ts=since_ts)
+    if not refusals:
+        return
+    branches = sorted({r.branch for r in refusals if r.branch})
+    branch_note = f" onto default branch {', '.join(repr(b) for b in branches)}" if branches else ""
+    console.print(
+        f"[bold red]Merge refused:[/bold red] agent work from {len(refusals)} session(s) was NOT "
+        f"merged{branch_note} and was discarded (details: .sdd/runtime/refused_merges.jsonl)."
+    )
+    console.print(
+        "Check out a working branch first (git checkout -b <branch>), or set "
+        f"{ENV_ALLOW_MERGE_TO_DEFAULT_BRANCH}=1 and re-run."
+    )
+
+
 def _show_run_summary() -> None:
     """Fetch final status from the task server and render a summary.
 
-    Silently returns if the server is unreachable (e.g. already stopped).
+    Silently skips the status table when the server is unreachable (e.g.
+    already stopped). Merge refusals recorded during this run are surfaced
+    even then -- a run whose work was discarded must not end with a clean,
+    silent summary (gh-2756).
     """
     from bernstein.cli.helpers import server_get
 
-    data = server_get("/status")
-    if data is None:
-        return
     force_no_color = not sys.stdout.isatty()
     con = make_console(no_color=force_no_color)
-    render_run_summary_from_dict(data, console=con)
+    data = server_get("/status")
+    if data is not None:
+        render_run_summary_from_dict(data, console=con)
+    _surface_merge_refusals(Path.cwd(), since_ts=_CLI_RUN_EPOCH, console=con)
 
 
 def _drain_completed_backlog_files() -> None:

--- a/src/bernstein/core/quality/retrospective.py
+++ b/src/bernstein/core/quality/retrospective.py
@@ -10,6 +10,7 @@ import json
 import logging
 import time
 from collections import defaultdict
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
@@ -254,7 +255,82 @@ def classify_task_terminator(task: Task) -> str:
     return TERMINATOR_AGENT_COMPLETED
 
 
-def compute_run_health(all_tasks: list[Task], n_unresolved: int = 0) -> tuple[bool, dict[str, int]]:
+#: Journal the spawner merge guard appends one JSON line to for every merge
+#: it refuses (see ``spawner_merge._record_merge_refusal``). Lives in
+#: ``.sdd/runtime/`` next to the retrospective this module writes.
+REFUSED_MERGES_FILENAME = "refused_merges.jsonl"
+
+
+@dataclass(frozen=True)
+class MergeRefusal:
+    """One refused agent-work merge read back from the runtime journal.
+
+    Attributes:
+        session_id: Agent session whose merge was refused.
+        branch: Branch the merge would have landed on.
+        reason: Machine-readable refusal reason recorded by the guard.
+        ts: Unix timestamp when the refusal was recorded.
+    """
+
+    session_id: str
+    branch: str
+    reason: str
+    ts: float
+
+
+def read_merge_refusals(runtime_dir: Path, since_ts: float = 0.0) -> list[MergeRefusal]:
+    """Read merge refusals recorded by the spawner merge guard.
+
+    The guard appends one JSON line per refused merge to
+    ``.sdd/runtime/refused_merges.jsonl``. The journal persists across runs,
+    so callers pass ``since_ts`` (typically the run start) to see only the
+    current run's refusals. Malformed or timestamp-less lines are skipped;
+    a missing or unreadable journal yields an empty list. Never raises.
+
+    Args:
+        runtime_dir: The ``.sdd/runtime`` directory of the run.
+        since_ts: Only entries recorded at or after this Unix timestamp are
+            returned.
+
+    Returns:
+        Refusals recorded at or after ``since_ts``, in journal order.
+    """
+    path = runtime_dir / REFUSED_MERGES_FILENAME
+    refusals: list[MergeRefusal] = []
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return refusals
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            entry = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(entry, dict):
+            continue
+        entry_dict = cast("dict[str, object]", entry)
+        ts = entry_dict.get("ts")
+        if not isinstance(ts, (int, float)) or ts < since_ts:
+            continue
+        refusals.append(
+            MergeRefusal(
+                session_id=str(entry_dict.get("session_id", "")),
+                branch=str(entry_dict.get("branch", "")),
+                reason=str(entry_dict.get("reason", "")),
+                ts=float(ts),
+            )
+        )
+    return refusals
+
+
+def compute_run_health(
+    all_tasks: list[Task],
+    n_unresolved: int = 0,
+    n_refused_merges: int = 0,
+) -> tuple[bool, dict[str, int]]:
     """Compute the run-health verdict and per-terminator-category counts.
 
     Args:
@@ -265,13 +341,19 @@ def compute_run_health(all_tasks: list[Task], n_unresolved: int = 0) -> tuple[bo
             ``collector.complete_task()`` call (see
             ``generate_retrospective``'s reconciliation block). Treated as
             additional non-agent-verified terminations for health purposes.
+        n_refused_merges: Count of agent-work merges the spawner merge guard
+            refused this run (see :func:`read_merge_refusals`). Refused
+            merges discard completed work without producing a failed task,
+            so any refusal forces ``healthy`` to ``False`` -- including for
+            an otherwise-empty 0/0 run (gh-2756).
 
     Returns:
         Tuple of ``(healthy, counts)`` where ``counts`` maps each
         ``TERMINATOR_*`` category to the number of tasks in it.
 
         Hard rule (bug fix): ``healthy`` is ``False`` whenever ANY task
-        has status FAILED, or ``n_unresolved > 0``, or there is at least
+        has status FAILED, or ``n_unresolved > 0``, or
+        ``n_refused_merges > 0``, or there is at least
         one ``TERMINATOR_AUTO_COMPLETED_AFTER_DEATH`` -- regardless of the
         text-pattern classification below. This does not depend on
         ``classify_task_terminator`` finding a forced-kill marker in the
@@ -287,6 +369,13 @@ def compute_run_health(all_tasks: list[Task], n_unresolved: int = 0) -> tuple[bo
     counts: dict[str, int] = defaultdict(int)
     for t in all_tasks:
         counts[classify_task_terminator(t)] += 1
+
+    # Hard rule (gh-2756): a refused merge means completed agent work was
+    # discarded, and the affected task never shows up as FAILED -- checked
+    # before the vacuous-empty return so a 0/0 run with discarded work is
+    # never reported HEALTHY.
+    if n_refused_merges > 0:
+        return False, counts.copy()
 
     total = len(all_tasks) + n_unresolved
     if total == 0:
@@ -306,9 +395,10 @@ def _write_run_health_section(
     lines: list[str],
     all_tasks: list[Task],
     n_unresolved: int = 0,
+    n_refused_merges: int = 0,
 ) -> tuple[bool, dict[str, int]]:
     """Write the Run Health section and return (healthy, counts) for reuse in Recommendations."""
-    healthy, counts = compute_run_health(all_tasks, n_unresolved=n_unresolved)
+    healthy, counts = compute_run_health(all_tasks, n_unresolved=n_unresolved, n_refused_merges=n_refused_merges)
     total = len(all_tasks) + n_unresolved
     agent_completed = counts.get(TERMINATOR_AGENT_COMPLETED, 0)
     watchdog_killed = counts.get(TERMINATOR_WATCHDOG_KILLED, 0)
@@ -322,7 +412,7 @@ def _write_run_health_section(
     logger.info(
         "run health: %d/%d agent-completed, %d watchdog-killed, %d janitor-rejected, "
         "%d timeout-killed, %d other-forced, %d auto-completed-after-death, "
-        "%d agent-reported-failure, %d unresolved-in-metrics -> %s",
+        "%d agent-reported-failure, %d unresolved-in-metrics, %d merges-refused -> %s",
         agent_completed,
         total,
         watchdog_killed,
@@ -332,6 +422,7 @@ def _write_run_health_section(
         auto_completed,
         agent_reported_failure,
         n_unresolved,
+        n_refused_merges,
         verdict,
     )
 
@@ -350,9 +441,20 @@ def _write_run_health_section(
             f"| Auto-completed after agent death | {auto_completed} |",
             f"| Other forced termination | {other_forced} |",
             f"| Unresolved in metrics (started, outcome never reconciled) | {n_unresolved} |",
+            f"| Merge refused by guard (agent work discarded) | {n_refused_merges} |",
             "",
         )
     )
+    if n_refused_merges > 0:
+        lines.extend(
+            (
+                f"- **Warning:** {n_refused_merges} completed merge attempt(s) were refused because "
+                "the run targeted the repository default branch, and the agent work was discarded "
+                "(see .sdd/runtime/refused_merges.jsonl). Check out a working branch or set "
+                "BERNSTEIN_ALLOW_MERGE_TO_DEFAULT_BRANCH=1 before re-running.",
+                "",
+            )
+        )
     if not healthy:
         lines.extend(
             (
@@ -694,6 +796,26 @@ def generate_retrospective(
             unresolved_task_ids,
         )
 
+    # ------------------------------------------------------------------
+    # Refused merges: agent work discarded by the spawner merge guard
+    # ------------------------------------------------------------------
+    #
+    # The merge guard refuses to land agent work on the repository's default
+    # branch and records each refusal to .sdd/runtime/refused_merges.jsonl
+    # (spawner_merge._record_merge_refusal). A refused session produces no
+    # FAILED task -- the run can end 0 done / 0 failed -- so without this the
+    # retrospective reported HEALTHY while every artefact was discarded
+    # (gh-2756). The journal persists across runs; filter to this run.
+    merge_refusals = read_merge_refusals(runtime_dir, since_ts=run_start_ts)
+    n_refused_merges = len(merge_refusals)
+    if n_refused_merges:
+        logger.warning(
+            "retrospective: %d merge(s) of agent work were refused by the merge guard this run "
+            "(branches=%s) -- counting them against run health; see .sdd/runtime/refused_merges.jsonl.",
+            n_refused_merges,
+            sorted({r.branch for r in merge_refusals}),
+        )
+
     n_done = len(done_tasks)
     n_failed = len(failed_tasks) + n_unresolved
     total = len(all_tasks) + n_unresolved
@@ -845,7 +967,12 @@ def generate_retrospective(
     _section(f"- **Wall-clock duration:** {duration_str}")
     _section("")
 
-    run_healthy, terminator_counts = _write_run_health_section(lines, all_tasks, n_unresolved=n_unresolved)
+    run_healthy, terminator_counts = _write_run_health_section(
+        lines,
+        all_tasks,
+        n_unresolved=n_unresolved,
+        n_refused_merges=n_refused_merges,
+    )
 
     _write_failure_analysis(lines, done_tasks, failed_tasks)
     _write_performance_section(lines, task_metrics, all_tasks)

--- a/tests/unit/test_issue_2756_default_branch_surfacing.py
+++ b/tests/unit/test_issue_2756_default_branch_surfacing.py
@@ -1,0 +1,419 @@
+"""Surfacing for default-branch merge refusals (gh-2756).
+
+Running on the repository default branch used to let every agent do its work,
+have the spawner merge guard silently discard the merged result, and still
+end with a clean "Tasks completed 0/0" / HEALTHY summary. Three surfaces fix
+that:
+
+A. CLI preflight aborts before any agent spawns when the run would merge back
+   onto the default branch without the explicit override - but only for run
+   modes that actually merge back (--dry-run and --plan-only stay untouched).
+B. A merge refusal that still happens mid-run is printed in the CLI run
+   summary instead of staying buried in the spawner log.
+C. Run health treats discarded work as a hard UNHEALTHY rule with the reason.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import time
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+from bernstein.core.metrics import MetricsCollector
+from bernstein.core.models import Complexity, Scope, Task, TaskStatus, TaskType
+
+import bernstein.cli.run_bootstrap as run_bootstrap
+from bernstein.cli.run_preflight import (
+    _abort_if_default_branch_merge_target,
+    _show_run_summary,
+    _surface_merge_refusals,
+)
+from bernstein.cli.ui import make_console
+from bernstein.core.quality.retrospective import (
+    compute_run_health,
+    generate_retrospective,
+    read_merge_refusals,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+OVERRIDE_ENV = "BERNSTEIN_ALLOW_MERGE_TO_DEFAULT_BRANCH"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_task(*, id: str = "T-001", status: str = "done") -> Task:
+    return Task(
+        id=id,
+        title="Do something",
+        description="desc",
+        role="backend",
+        scope=Scope.MEDIUM,
+        complexity=Complexity("medium"),
+        status=TaskStatus(status),
+        task_type=TaskType.STANDARD,
+    )
+
+
+def _write_refusal(
+    runtime_dir: Path,
+    *,
+    branch: str = "main",
+    ts: float | None = None,
+    session_id: str = "manager-1",
+) -> None:
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    entry = {
+        "session_id": session_id,
+        "branch": branch,
+        "reason": "target-is-default-branch",
+        "ts": time.time() if ts is None else ts,
+    }
+    with (runtime_dir / "refused_merges.jsonl").open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# A. Preflight guard behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestPreflightDefaultBranchGuard:
+    def test_aborts_on_default_branch_without_override(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv(OVERRIDE_ENV, raising=False)
+        with (
+            patch("bernstein.core.git_ops.current_branch", return_value="main"),
+            patch(
+                "bernstein.core.git_ops.protected_default_branches",
+                return_value=frozenset({"main"}),
+            ),
+        ):
+            with pytest.raises(SystemExit) as excinfo:
+                _abort_if_default_branch_merge_target(tmp_path)
+
+        assert excinfo.value.code == 1
+        out = capsys.readouterr().out
+        # The error must name both remedies: the override env var and the
+        # checkout-a-working-branch alternative.
+        assert OVERRIDE_ENV in out
+        assert "checkout" in out
+        assert "main" in out
+
+    def test_aborts_on_ambiguous_default_when_either_candidate_checked_out(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Mirror the merge guard's fail-closed ambiguity handling."""
+        monkeypatch.delenv(OVERRIDE_ENV, raising=False)
+        with (
+            patch("bernstein.core.git_ops.current_branch", return_value="master"),
+            patch(
+                "bernstein.core.git_ops.protected_default_branches",
+                return_value=frozenset({"main", "master"}),
+            ),
+        ):
+            with pytest.raises(SystemExit):
+                _abort_if_default_branch_merge_target(tmp_path)
+
+    def test_no_abort_on_feature_branch(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(OVERRIDE_ENV, raising=False)
+        with (
+            patch("bernstein.core.git_ops.current_branch", return_value="feat/x"),
+            patch(
+                "bernstein.core.git_ops.protected_default_branches",
+                return_value=frozenset({"main"}),
+            ),
+        ):
+            _abort_if_default_branch_merge_target(tmp_path)
+
+    def test_no_abort_with_override_env(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(OVERRIDE_ENV, "1")
+        with (
+            patch("bernstein.core.git_ops.current_branch", return_value="main"),
+            patch(
+                "bernstein.core.git_ops.protected_default_branches",
+                return_value=frozenset({"main"}),
+            ),
+        ):
+            _abort_if_default_branch_merge_target(tmp_path)
+
+    def test_no_abort_on_detached_head_or_missing_repo(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """current_branch is None on detached HEAD and outside a repo; the
+        merge guard skips both, so preflight must skip them too."""
+        monkeypatch.delenv(OVERRIDE_ENV, raising=False)
+        with patch("bernstein.core.git_ops.current_branch", return_value=None):
+            _abort_if_default_branch_merge_target(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# A (wiring). Merge-back modes hit the guard; no-merge modes never do.
+# ---------------------------------------------------------------------------
+
+
+def _run_impl_kwargs(**overrides: object) -> dict[str, object]:
+    kwargs: dict[str, object] = {
+        "plan_file": None,
+        "goal": "Ship it",
+        "seed_file": None,
+        "port": 8052,
+        "cells": 1,
+        "remote": False,
+        "cli": None,
+        "model": None,
+        "workflow": None,
+        "routing": None,
+        "compliance": None,
+        "container": False,
+        "container_image": None,
+        "two_phase_sandbox": False,
+        "worker_role": None,
+        "plan_only": False,
+        "from_plan": None,
+        "auto_approve": True,
+        "quiet": True,
+        "skip_gate": (),
+        "skip_gate_reason": None,
+        "audit": False,
+        "sandbox": None,
+        "allow_paid": False,
+        "ab_test": False,
+        "dry_run": False,
+        "idle": False,
+        "cprofile": False,
+        "run_profile": None,
+        "allow_network": (),
+        "permission_profile": None,
+        "task_filter": None,
+        "auto_pr": False,
+        "activity_log_path": None,
+        "max_cost_usd": None,
+        "budget_spec": None,
+        "hard_budget_spec": None,
+        "budget_cap": None,
+        "retry_budget_spec": None,
+        "criterion_profile": None,
+        "max_blast_radius": None,
+        "attach": (),
+        "refresh_cache": False,
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
+@contextlib.contextmanager
+def _run_impl_environment() -> object:
+    """Neutralise the environment-touching bootstrap steps of _run_impl."""
+    with contextlib.ExitStack() as stack:
+        for patcher in (
+            patch.object(run_bootstrap, "print_startup_banner"),
+            patch.object(run_bootstrap, "_propagate_env_flags"),
+            patch.object(run_bootstrap, "_sovereign_config_snapshot", return_value=None),
+            patch.object(run_bootstrap, "_install_profile_network_policy"),
+            patch.object(run_bootstrap, "_activate_sovereign_profile"),
+            patch.object(run_bootstrap, "_configure_quality_gate_bypass"),
+        ):
+            stack.enter_context(patcher)
+        yield
+
+
+class TestRunImplGuardWiring:
+    def test_dry_run_never_invokes_default_branch_guard(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        guard = MagicMock()
+        with (
+            _run_impl_environment(),
+            patch.object(run_bootstrap, "_show_dry_run_plan") as show_plan,
+            patch.object(run_bootstrap, "_abort_if_default_branch_merge_target", guard),
+        ):
+            run_bootstrap._run_impl(**_run_impl_kwargs(dry_run=True))  # type: ignore[arg-type]
+
+        show_plan.assert_called_once()
+        guard.assert_not_called()
+
+    def test_plan_only_never_invokes_default_branch_guard(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        guard = MagicMock()
+        with (
+            _run_impl_environment(),
+            patch.object(run_bootstrap, "_abort_if_default_branch_merge_target", guard),
+        ):
+            run_bootstrap._run_impl(**_run_impl_kwargs(plan_only=True))  # type: ignore[arg-type]
+
+        guard.assert_not_called()
+
+    def test_goal_mode_aborts_before_estimate_and_spawn(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        guard = MagicMock(side_effect=SystemExit(1))
+        with (
+            _run_impl_environment(),
+            patch.object(run_bootstrap, "_abort_if_default_branch_merge_target", guard),
+            patch.object(run_bootstrap, "_estimate_run_preview") as estimate,
+            patch("bernstein.core.bootstrap.bootstrap_from_goal") as bootstrap_goal,
+        ):
+            with pytest.raises(SystemExit):
+                run_bootstrap._run_impl(**_run_impl_kwargs())  # type: ignore[arg-type]
+
+        guard.assert_called_once()
+        estimate.assert_not_called()
+        bootstrap_goal.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# B. CLI run summary surfaces refusals
+# ---------------------------------------------------------------------------
+
+
+class TestCliSummarySurfacesRefusals:
+    def test_fresh_refusal_prints_warning_with_both_remedies(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _write_refusal(tmp_path / ".sdd" / "runtime", branch="main")
+        con = make_console(no_color=True)
+
+        _surface_merge_refusals(tmp_path, since_ts=0.0, console=con)
+
+        out = capsys.readouterr().out
+        assert "refused" in out
+        assert "main" in out
+        assert OVERRIDE_ENV in out
+        assert "checkout" in out
+
+    def test_stale_refusals_from_prior_runs_stay_silent(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _write_refusal(tmp_path / ".sdd" / "runtime", ts=time.time() - 3600)
+        con = make_console(no_color=True)
+
+        _surface_merge_refusals(tmp_path, since_ts=time.time() - 60, console=con)
+
+        assert capsys.readouterr().out == ""
+
+    def test_no_journal_stays_silent(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        con = make_console(no_color=True)
+
+        _surface_merge_refusals(tmp_path, since_ts=0.0, console=con)
+
+        assert capsys.readouterr().out == ""
+
+    def test_show_run_summary_surfaces_refusals_even_when_server_gone(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        _write_refusal(tmp_path / ".sdd" / "runtime", branch="main")
+        with patch("bernstein.cli.helpers.server_get", return_value=None):
+            _show_run_summary()
+
+        out = capsys.readouterr().out
+        assert "refused" in out
+        assert OVERRIDE_ENV in out
+
+
+# ---------------------------------------------------------------------------
+# C. Run health downgrade
+# ---------------------------------------------------------------------------
+
+
+class TestRunHealthWithRefusedMerges:
+    def test_zero_task_run_with_refused_merge_is_unhealthy(self) -> None:
+        healthy, counts = compute_run_health([], n_refused_merges=1)
+        assert healthy is False
+        assert counts == {}
+
+    def test_successful_tasks_with_refused_merge_still_unhealthy(self) -> None:
+        tasks = [_make_task(id=f"T-{i}", status="done") for i in range(3)]
+        healthy, _counts = compute_run_health(tasks, n_refused_merges=2)
+        assert healthy is False
+
+    def test_no_refusals_keeps_existing_verdict(self) -> None:
+        tasks = [_make_task(id=f"T-{i}", status="done") for i in range(3)]
+        healthy, _counts = compute_run_health(tasks, n_refused_merges=0)
+        assert healthy is True
+
+    def test_empty_run_without_refusals_stays_vacuously_healthy(self) -> None:
+        healthy, counts = compute_run_health([])
+        assert healthy is True
+        assert counts == {}
+
+
+class TestReadMergeRefusals:
+    def test_reads_entries_and_filters_by_since_ts(self, tmp_path: Path) -> None:
+        now = time.time()
+        _write_refusal(tmp_path, branch="main", ts=now - 3600, session_id="old")
+        _write_refusal(tmp_path, branch="main", ts=now, session_id="fresh")
+
+        refusals = read_merge_refusals(tmp_path, since_ts=now - 60)
+
+        assert len(refusals) == 1
+        assert refusals[0].session_id == "fresh"
+        assert refusals[0].branch == "main"
+        assert refusals[0].reason == "target-is-default-branch"
+
+    def test_missing_journal_returns_empty(self, tmp_path: Path) -> None:
+        assert read_merge_refusals(tmp_path) == []
+
+    def test_malformed_lines_are_skipped(self, tmp_path: Path) -> None:
+        _write_refusal(tmp_path, branch="main", ts=time.time())
+        path = tmp_path / "refused_merges.jsonl"
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write("not json\n")
+            handle.write('["not", "a", "dict"]\n')
+            handle.write('{"session_id": "no-ts", "branch": "main", "reason": "x"}\n')
+
+        refusals = read_merge_refusals(tmp_path)
+
+        assert len(refusals) == 1
+
+
+class TestRetrospectiveReflectsRefusedMerges:
+    def test_fresh_refusal_downgrades_health_and_names_reason(self, tmp_path: Path) -> None:
+        runtime_dir = tmp_path / "runtime"
+        run_start = time.time() - 60
+        _write_refusal(runtime_dir, branch="main")
+        collector = MetricsCollector(metrics_dir=tmp_path / "metrics")
+
+        generate_retrospective(
+            done_tasks=[],
+            failed_tasks=[],
+            collector=collector,
+            runtime_dir=runtime_dir,
+            run_start_ts=run_start,
+        )
+
+        content = (runtime_dir / "retrospective.md").read_text()
+        assert "**Verdict:** UNHEALTHY" in content
+        assert "Merge refused" in content
+        assert "default branch" in content
+
+    def test_stale_refusals_from_prior_runs_keep_health(self, tmp_path: Path) -> None:
+        runtime_dir = tmp_path / "runtime"
+        run_start = time.time() - 60
+        _write_refusal(runtime_dir, branch="main", ts=run_start - 3600)
+        collector = MetricsCollector(metrics_dir=tmp_path / "metrics")
+
+        generate_retrospective(
+            done_tasks=[],
+            failed_tasks=[],
+            collector=collector,
+            runtime_dir=runtime_dir,
+            run_start_ts=run_start,
+        )
+
+        content = (runtime_dir / "retrospective.md").read_text()
+        assert "**Verdict:** HEALTHY" in content


### PR DESCRIPTION
## What

Running `bernstein run` in a repo whose checked-out branch is the default trunk (the fresh `git init` state) now aborts before any agent spawns, with an error naming both remedies (check out a working branch, or set `BERNSTEIN_ALLOW_MERGE_TO_DEFAULT_BRANCH=1`). If a merge refusal still happens mid-run, it is printed in the end-of-run summary and the run health verdict is downgraded to UNHEALTHY with the reason. The merge guard itself is unchanged.

## Why

Previously every agent spawned, did its work in an isolated worktree, and the spawner merge guard then refused the merge-back onto the protected trunk. The worktree was reaped and the artifact lost, while the CLI stayed silent: `Tasks completed 0/0` with run health HEALTHY. The only trace of the real cause was a `Refusing to merge agent work` line buried in the spawner log. A first-time user in a fresh repo got zero output and no actionable message.

## How

- `run_preflight._abort_if_default_branch_merge_target` mirrors the merge guard's exact checks (`current_branch` / `protected_default_branches` / the override env var, including the fail-closed ambiguous-default case) and raises `SystemExit(1)` with the remedy. It is wired into `_run_impl` before the cost estimate, inside the block that only merge-back modes reach - `--dry-run` and `--plan-only` never hit it.
- `read_merge_refusals` reads the guard's `.sdd/runtime/refused_merges.jsonl` journal, filtered by timestamp so entries from previous runs are ignored. `_show_run_summary` surfaces this run's refusals even when the task server is already gone.
- `compute_run_health` gains an `n_refused_merges` hard rule: any refused merge forces UNHEALTHY, including for an otherwise-empty 0/0 run (a refused session produces no FAILED task, so the old logic was vacuously healthy). `generate_retrospective` counts this run's refusals and the Run Health section names the reason and both remedies.
- Tests: preflight abort/skip matrix (default branch, ambiguous default, feature branch, override, detached HEAD), `_run_impl` wiring for `--dry-run` / `--plan-only` (guard never invoked) and goal mode (abort before estimate and spawn), summary surfacing incl. server-gone and stale-journal cases, health downgrade unit and retrospective integration cases. 130 targeted tests pass, including the pre-existing merge-guard and retrospective suites.

Closes #2756