### PR TITLE
fix(cli): persist effective server port for runtime probes

### DIFF
--- a/src/bernstein/cli/helpers.py
+++ b/src/bernstein/cli/helpers.py
@@ -22,6 +22,7 @@ from bernstein.core.process_utils import is_process_alive as _shared_is_process_
 # ---------------------------------------------------------------------------
 
 SERVER_URL = os.environ.get("BERNSTEIN_SERVER_URL", "http://localhost:8052")
+SDD_SERVER_PORT = ".sdd/runtime/server.port"
 SDD_DIRS = [
     ".sdd",
     ".sdd/backlog",
@@ -105,10 +106,38 @@ def auth_headers() -> dict[str, str]:
     return {}
 
 
+def resolve_server_url(workdir: Path | None = None) -> str:
+    """Resolve the task server URL from env, the active workspace, or default."""
+    configured = os.environ.get("BERNSTEIN_SERVER_URL")
+    if configured:
+        return configured.rstrip("/")
+
+    port_path = (workdir or Path.cwd()) / SDD_SERVER_PORT
+    try:
+        port = int(port_path.read_text().strip())
+        if 1 <= port <= 65535:
+            return f"http://127.0.0.1:{port}"
+    except (OSError, ValueError):
+        pass
+    return "http://127.0.0.1:8052"
+
+
+def persist_server_port(port: int, workdir: Path | None = None) -> Path:
+    """Persist the effective run port for follow-up CLI commands."""
+    if not 1 <= port <= 65535:
+        raise ValueError(f"server port must be between 1 and 65535, got {port}")
+    path = (workdir or Path.cwd()) / SDD_SERVER_PORT
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(".tmp")
+    temporary.write_text(f"{port}\n")
+    temporary.replace(path)
+    return path
+
+
 def server_get(path: str) -> dict[str, Any] | None:
     """GET from the task server.  Returns None if server is unreachable."""
     try:
-        resp = httpx.get(f"{SERVER_URL}{path}", timeout=5.0, headers=auth_headers())
+        resp = httpx.get(f"{resolve_server_url()}{path}", timeout=5.0, headers=auth_headers())
         resp.raise_for_status()
         return resp.json()  # type: ignore[no-any-return]
     except httpx.ConnectError:
@@ -121,7 +150,7 @@ def server_get(path: str) -> dict[str, Any] | None:
 def server_post(path: str, payload: dict[str, Any]) -> dict[str, Any] | None:
     """POST to the task server.  Returns None if server is unreachable."""
     try:
-        resp = httpx.post(f"{SERVER_URL}{path}", json=payload, timeout=5.0, headers=auth_headers())
+        resp = httpx.post(f"{resolve_server_url()}{path}", json=payload, timeout=5.0, headers=auth_headers())
         resp.raise_for_status()
         return resp.json()  # type: ignore[no-any-return]
     except httpx.ConnectError:

--- a/src/bernstein/cli/helpers.py
+++ b/src/bernstein/cli/helpers.py
@@ -8,12 +8,14 @@ import sys
 import time
 from contextlib import suppress
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 from typing import Any
 
 import click
 import httpx
 from rich.console import Console
 
+from bernstein.core.defaults import SDD_SERVER_PORT
 from bernstein.core.platform_compat import kill_process, kill_process_group
 from bernstein.core.process_utils import is_process_alive as _shared_is_process_alive
 
@@ -22,7 +24,6 @@ from bernstein.core.process_utils import is_process_alive as _shared_is_process_
 # ---------------------------------------------------------------------------
 
 SERVER_URL = os.environ.get("BERNSTEIN_SERVER_URL", "http://localhost:8052")
-SDD_SERVER_PORT = ".sdd/runtime/server.port"
 SDD_DIRS = [
     ".sdd",
     ".sdd/backlog",
@@ -128,9 +129,20 @@ def persist_server_port(port: int, workdir: Path | None = None) -> Path:
         raise ValueError(f"server port must be between 1 and 65535, got {port}")
     path = (workdir or Path.cwd()) / SDD_SERVER_PORT
     path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_suffix(".tmp")
-    temporary.write_text(f"{port}\n")
-    temporary.replace(path)
+    with NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=path.parent,
+        prefix=f"{path.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as stream:
+        stream.write(f"{port}\n")
+        temporary = Path(stream.name)
+    try:
+        temporary.replace(path)
+    finally:
+        temporary.unlink(missing_ok=True)
     return path
 
 

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -24,6 +24,7 @@ from bernstein.cli.helpers import (
     auth_headers,
     console,
     find_seed_file,
+    persist_server_port,
     print_banner,
     print_startup_banner,
     server_get,
@@ -1875,6 +1876,7 @@ def _run_impl(
 
     workdir = Path.cwd()
     if not plan_only:
+        persist_server_port(port, workdir)
         estimate = _estimate_run_preview(
             workdir=workdir,
             plan_file=plan_file,

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -1876,7 +1876,6 @@ def _run_impl(
 
     workdir = Path.cwd()
     if not plan_only:
-        persist_server_port(port, workdir)
         estimate = _estimate_run_preview(
             workdir=workdir,
             plan_file=plan_file,
@@ -1928,6 +1927,7 @@ def _run_impl(
                     tasks=tasks,
                     ab_test=ab_test,
                 )
+                persist_server_port(port, workdir)
 
             _finalize_run_output(quiet=quiet)
             return
@@ -2012,6 +2012,7 @@ def _run_impl(
                     cli=cli or "auto",  # Default to "auto" if not specified
                     model=model,
                 )
+                persist_server_port(port, workdir)
         except RuntimeError as exc:
             from bernstein.cli.errors import bootstrap_failed
 
@@ -2049,6 +2050,7 @@ def _run_impl(
                 model=model,
                 worker_role=worker_role,
             )
+            persist_server_port(port, workdir)
     except SeedError as exc:
         from bernstein.cli.errors import seed_parse_error
 

--- a/src/bernstein/core/defaults.py
+++ b/src/bernstein/core/defaults.py
@@ -50,6 +50,9 @@ COPILOT_DEFAULT_MODEL: Final[str] = "auto"
 """Copilot model used when no operator-pinned model reaches the adapter; ``auto``
 lets Copilot's own router pick the best available model."""
 
+SDD_SERVER_PORT: Final[str] = ".sdd/runtime/server.port"
+"""Workspace-relative file containing the active task-server port."""
+
 COPILOT_CLAUDE_TIER_MODELS: Final[frozenset[str]] = frozenset({"opus", "sonnet", "haiku"})
 """Claude cascade tier names that are not valid Copilot model ids; any that reach
 the Copilot adapter are remapped to ``COPILOT_DEFAULT_MODEL``."""

--- a/tests/unit/test_cli_server_url.py
+++ b/tests/unit/test_cli_server_url.py
@@ -1,36 +1,40 @@
 from pathlib import Path
+from unittest.mock import patch
+
+import pytest
 
 from bernstein.cli import helpers
+from bernstein.core.defaults import SDD_SERVER_PORT
 
 
-def test_resolve_server_url_uses_persisted_workspace_port(tmp_path: Path, monkeypatch) -> None:
+def test_resolve_server_url_uses_persisted_workspace_port(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("BERNSTEIN_SERVER_URL", raising=False)
     helpers.persist_server_port(8062, tmp_path)
 
     assert helpers.resolve_server_url(tmp_path) == "http://127.0.0.1:8062"
 
 
-def test_resolve_server_url_env_overrides_persisted_port(tmp_path: Path, monkeypatch) -> None:
+def test_resolve_server_url_env_overrides_persisted_port(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     helpers.persist_server_port(8062, tmp_path)
     monkeypatch.setenv("BERNSTEIN_SERVER_URL", "https://bernstein.example/")
 
     assert helpers.resolve_server_url(tmp_path) == "https://bernstein.example"
 
 
-def test_resolve_server_url_ignores_invalid_runtime_port(tmp_path: Path, monkeypatch) -> None:
+def test_resolve_server_url_ignores_invalid_runtime_port(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("BERNSTEIN_SERVER_URL", raising=False)
-    port_path = tmp_path / helpers.SDD_SERVER_PORT
+    port_path = tmp_path / SDD_SERVER_PORT
     port_path.parent.mkdir(parents=True)
     port_path.write_text("not-a-port\n")
 
     assert helpers.resolve_server_url(tmp_path) == "http://127.0.0.1:8052"
 
 
-def test_server_get_targets_the_persisted_port(tmp_path: Path, monkeypatch) -> None:
+def test_server_get_targets_the_persisted_port(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("BERNSTEIN_SERVER_URL", raising=False)
     helpers.persist_server_port(8062)
-    requested = []
+    requested: list[str] = []
 
     class Response:
         def raise_for_status(self) -> None:
@@ -39,11 +43,42 @@ def test_server_get_targets_the_persisted_port(tmp_path: Path, monkeypatch) -> N
         def json(self) -> dict[str, bool]:
             return {"ok": True}
 
-    def fake_get(url: str, **kwargs):
+    def fake_get(url: str, **kwargs: object) -> Response:
         requested.append(url)
         return Response()
 
-    monkeypatch.setattr(helpers.httpx, "get", fake_get)
-
-    assert helpers.server_get("/status") == {"ok": True}
+    with patch.object(helpers.httpx, "get", fake_get):
+        assert helpers.server_get("/status") == {"ok": True}
     assert requested == ["http://127.0.0.1:8062/status"]
+
+
+def test_server_post_targets_the_persisted_port(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("BERNSTEIN_SERVER_URL", raising=False)
+    monkeypatch.setenv("BERNSTEIN_AUTH_TOKEN", "test-token")
+    helpers.persist_server_port(8062)
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    class Response:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, bool]:
+            return {"ok": True}
+
+    def fake_post(url: str, **kwargs: object) -> Response:
+        calls.append((url, kwargs))
+        return Response()
+
+    with patch.object(helpers.httpx, "post", fake_post):
+        assert helpers.server_post("/tasks", {"name": "demo"}) == {"ok": True}
+    assert calls == [
+        (
+            "http://127.0.0.1:8062/tasks",
+            {
+                "json": {"name": "demo"},
+                "timeout": 5.0,
+                "headers": {"Authorization": "Bearer test-token"},
+            },
+        )
+    ]

--- a/tests/unit/test_cli_server_url.py
+++ b/tests/unit/test_cli_server_url.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+from bernstein.cli import helpers
+
+
+def test_resolve_server_url_uses_persisted_workspace_port(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.delenv("BERNSTEIN_SERVER_URL", raising=False)
+    helpers.persist_server_port(8062, tmp_path)
+
+    assert helpers.resolve_server_url(tmp_path) == "http://127.0.0.1:8062"
+
+
+def test_resolve_server_url_env_overrides_persisted_port(tmp_path: Path, monkeypatch) -> None:
+    helpers.persist_server_port(8062, tmp_path)
+    monkeypatch.setenv("BERNSTEIN_SERVER_URL", "https://bernstein.example/")
+
+    assert helpers.resolve_server_url(tmp_path) == "https://bernstein.example"
+
+
+def test_resolve_server_url_ignores_invalid_runtime_port(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.delenv("BERNSTEIN_SERVER_URL", raising=False)
+    port_path = tmp_path / helpers.SDD_SERVER_PORT
+    port_path.parent.mkdir(parents=True)
+    port_path.write_text("not-a-port\n")
+
+    assert helpers.resolve_server_url(tmp_path) == "http://127.0.0.1:8052"
+
+
+def test_server_get_targets_the_persisted_port(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("BERNSTEIN_SERVER_URL", raising=False)
+    helpers.persist_server_port(8062)
+    requested = []
+
+    class Response:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, bool]:
+            return {"ok": True}
+
+    def fake_get(url: str, **kwargs):
+        requested.append(url)
+        return Response()
+
+    monkeypatch.setattr(helpers.httpx, "get", fake_get)
+
+    assert helpers.server_get("/status") == {"ok": True}
+    assert requested == ["http://127.0.0.1:8062/status"]


### PR DESCRIPTION
## What

Persists the effective runtime server port and resolves CLI probe URLs from that state.

## Why

Health and control probes were fixed to port 8052 even when the runtime was launched on another port.

Closes #2811

## How

Writes the selected port atomically to .sdd/runtime/server.port for real runs. Probe helpers resolve BERNSTEIN_SERVER_URL first, then the persisted port, then the existing 8052 fallback.

## Checklist

- [x] Ruff check passes for all changed files
- [ ] Pyright was not run
- [ ] Full scripts/run_tests.py was not run
- [x] New code has type hints
- [x] Documentation N/A: internal runtime discovery, no public command or configuration change
- [x] Focused tests cover persisted, overridden, invalid, and request-target behavior (4 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI commands now automatically connect to the active workspace’s running server.
  * The selected server port is persisted in the workspace during bootstrap for reuse.
  * Server address customization is supported via `BERNSTEIN_SERVER_URL`.

* **Bug Fixes**
  * Improved reliability by deriving the connection target from the workspace-selected port.
  * Added safe fallback to the default local server when saved port data is missing or invalid.

* **Tests**
  * Expanded unit coverage for URL resolution and request routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->