### PR TITLE
fix(daemon): launch the recovery watchdog via a runnable module so it starts from the wheel

### DIFF
--- a/src/bernstein/cli/commands/stop_cmd.py
+++ b/src/bernstein/cli/commands/stop_cmd.py
@@ -538,7 +538,9 @@ def _classify_and_kill_process(
         _kill_agent_pid(snapshot.pid, f"orphan-{snapshot.pid}", killed)
         return
 
-    is_watchdog = "bernstein.core.bootstrap" in command and "--watchdog" in command
+    # Matches the launcher argv in ``_start_watchdog`` (issue #2795): the watchdog
+    # runs as ``python -m bernstein.core.orchestration.bootstrap --watchdog``.
+    is_watchdog = "bernstein.core.orchestration.bootstrap" in command and "--watchdog" in command
     is_orchestrator = "bernstein.core.orchestrator" in command
     is_server = "uvicorn bernstein.core.server:app" in command
 

--- a/src/bernstein/core/orchestration/bootstrap.py
+++ b/src/bernstein/core/orchestration/bootstrap.py
@@ -747,6 +747,39 @@ def bootstrap_from_seed(
     return result
 
 
+_WATCHDOG_MODULE = "bernstein.core.orchestration.bootstrap"
+"""Runnable module for the ``python -m`` watchdog launch (issue #2795).
+
+Must resolve to a real code object under ``runpy``. The historical
+``bernstein.core.bootstrap`` name is a compatibility redirect alias whose loader
+returns no code object, so launching it via ``-m`` fails with "No code object
+available" and the watchdog never starts. This module carries the
+``if __name__ == "__main__":`` watchdog entrypoint.
+"""
+
+_WATCHDOG_LAUNCH_GRACE_S: float = 0.5
+"""Seconds to wait for the watchdog to prove it survived launch (issue #2795)."""
+
+
+def _read_watchdog_log_tail(log_path: Path, *, max_chars: int = 500) -> str:
+    """Return the tail of ``watchdog.log`` for a failed-launch error message.
+
+    Args:
+        log_path: Path to the watchdog log sink.
+        max_chars: Cap on returned characters, taken from the end of the file.
+
+    Returns:
+        The trailing log content, or a placeholder when it is empty or unreadable.
+    """
+    try:
+        text = log_path.read_text(errors="replace").strip()
+    except OSError:
+        return "<unavailable>"
+    if not text:
+        return "<empty>"
+    return text[-max_chars:]
+
+
 def _start_watchdog(
     workdir: Path,
     port: int,
@@ -777,7 +810,11 @@ def _start_watchdog(
     argv = [
         sys.executable,
         "-m",
-        "bernstein.core.bootstrap",
+        # Must be a module ``runpy`` can execute. ``bernstein.core.bootstrap`` is
+        # only a compatibility redirect alias whose loader returns no code object,
+        # so ``python -m`` on it raises "No code object available" and the
+        # watchdog never starts; target the real runnable module (issue #2795).
+        _WATCHDOG_MODULE,
         "--watchdog",
         "--port",
         str(port),
@@ -800,6 +837,27 @@ def _start_watchdog(
     )
     log_fh.close()
     pid_path.write_text(str(proc.pid))
+
+    # Confirm the watchdog survived launch. A module-name or import failure makes
+    # the child exit within milliseconds; without this check the failure is
+    # silent -- one line in watchdog.log plus a dead pid file -- while the run
+    # reports itself healthy despite having lost its crash/stall recovery layer
+    # (issue #2795).
+    try:
+        returncode = proc.wait(timeout=_WATCHDOG_LAUNCH_GRACE_S)
+    except subprocess.TimeoutExpired:
+        return proc.pid  # still running after the grace window -> launched OK
+
+    log_tail = _read_watchdog_log_tail(log_path)
+    logger.error(
+        "Recovery watchdog exited immediately (code %s); this run has no crash or stall recovery. watchdog.log: %s",
+        returncode,
+        log_tail,
+    )
+    console.print(
+        f"[bold red]Recovery watchdog failed to start (exit {returncode}); "
+        f"this run has no automatic crash or stall recovery.[/bold red]"
+    )
     return proc.pid
 
 

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 import sys
 import types
 from contextlib import ExitStack
@@ -16,7 +17,7 @@ from bernstein.core.models import Complexity, Scope, Task
 from bernstein.core.seed import SeedConfig
 from bernstein.core.server_launch import BootstrapResult
 
-from bernstein.core.orchestration.bootstrap import _post_plan_tasks
+from bernstein.core.orchestration.bootstrap import _post_plan_tasks, _start_watchdog
 
 
 class _CompletedFuture:
@@ -293,3 +294,100 @@ def test_post_plan_tasks_sends_no_header_when_auth_disabled() -> None:
         )
 
     assert captured["auth"] is None
+
+
+class _FakeWatchdogProc:
+    """Minimal ``subprocess.Popen`` stand-in for ``_start_watchdog`` tests."""
+
+    def __init__(self, pid: int = 4242, *, exit_code: int | None = None) -> None:
+        self.pid = pid
+        self._exit_code = exit_code
+
+    def wait(self, timeout: float | None = None) -> int:
+        """Mirror ``Popen.wait``: raise ``TimeoutExpired`` while still running."""
+        if self._exit_code is None:
+            raise subprocess.TimeoutExpired(cmd="watchdog", timeout=timeout or 0.0)
+        return self._exit_code
+
+    def poll(self) -> int | None:
+        return self._exit_code
+
+
+def test_start_watchdog_launches_a_runpy_runnable_module(tmp_path: Path) -> None:
+    """The watchdog launcher must target a module ``runpy`` can execute.
+
+    Regression guard for issue #2795: the launcher spawned
+    ``python -m bernstein.core.bootstrap``, but that name is a compatibility
+    redirect alias whose loader returns no code object, so ``runpy`` raised
+    "No code object available for bernstein.core.bootstrap" and the watchdog
+    died on arrival. Run the exact ``python -m <module>`` the launcher targets
+    in a fresh interpreter (the alias is unimported there, as in a real wheel
+    launch) and assert it loads. ``--watchdog`` is deliberately omitted so the
+    module exits instead of entering the monitor loop; the "No code object"
+    failure is raised at load time, before argument parsing, so its absence is
+    what the guard checks -- a future rename or redirect cannot silently rebreak
+    the launch.
+    """
+    (tmp_path / ".sdd" / "runtime").mkdir(parents=True)
+    captured: dict[str, list[str]] = {}
+
+    def _fake_popen(argv: list[str], **_kwargs: Any) -> _FakeWatchdogProc:
+        captured["argv"] = argv
+        return _FakeWatchdogProc()
+
+    with (
+        patch("bernstein.core.orchestration.bootstrap.subprocess.Popen", _fake_popen),
+        patch("bernstein.core.orchestration.bootstrap.console") as mock_console,
+        patch("bernstein.core.orchestration.bootstrap.logger") as mock_logger,
+    ):
+        _start_watchdog(tmp_path, 8052)
+
+    argv = captured["argv"]
+    module_name = argv[argv.index("-m") + 1]
+
+    result = subprocess.run(
+        [sys.executable, "-m", module_name],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        cwd=tmp_path,
+        check=False,
+    )
+    output = result.stdout + result.stderr
+    assert "No code object available" not in output, (
+        f"python -m {module_name} is not runpy-runnable (#2795): {output.strip()}"
+    )
+    assert result.returncode == 0, f"python -m {module_name} exited {result.returncode}: {output.strip()}"
+
+    # A healthy launch stays quiet: no operator-facing failure is surfaced.
+    mock_logger.error.assert_not_called()
+    mock_console.print.assert_not_called()
+
+
+def test_start_watchdog_surfaces_a_dead_on_arrival_watchdog(tmp_path: Path) -> None:
+    """A watchdog that exits immediately is surfaced, not swallowed.
+
+    Regression guard for issue #2795: a broken launch left one line in
+    ``watchdog.log`` and a dead pid file while the run reported itself healthy.
+    The launcher must detect the immediate exit and raise the alarm at an
+    operator-visible level (error log plus console), not only inside the log
+    file that nobody reads.
+    """
+    (tmp_path / ".sdd" / "runtime").mkdir(parents=True)
+
+    def _fake_popen(argv: list[str], *, stdout: Any = None, **_kwargs: Any) -> _FakeWatchdogProc:
+        del argv
+        # Model the real child: it writes its failure to the log sink and exits.
+        if stdout is not None:
+            stdout.write("No code object available for bernstein.core.bootstrap\n")
+        return _FakeWatchdogProc(exit_code=1)
+
+    with (
+        patch("bernstein.core.orchestration.bootstrap.subprocess.Popen", _fake_popen),
+        patch("bernstein.core.orchestration.bootstrap.console") as mock_console,
+        patch("bernstein.core.orchestration.bootstrap.logger") as mock_logger,
+    ):
+        _start_watchdog(tmp_path, 8052)
+
+    assert mock_logger.error.called, "dead-on-arrival watchdog must log an operator-visible error"
+    assert mock_console.print.called, "dead-on-arrival watchdog must be surfaced to the console"

--- a/tests/unit/test_cli_stop.py
+++ b/tests/unit/test_cli_stop.py
@@ -291,7 +291,7 @@ class TestHardStopFallbacks:
                 pid=11,
                 ppid=1,
                 pgid=11,
-                command="/usr/bin/python -m bernstein.core.bootstrap --watchdog --port 8052",
+                command="/usr/bin/python -m bernstein.core.orchestration.bootstrap --watchdog --port 8052",
             ),
             stop_cmd_module._ProcessSnapshot(  # pyright: ignore[reportPrivateUsage]
                 pid=12,
@@ -309,7 +309,7 @@ class TestHardStopFallbacks:
                 pid=14,
                 ppid=1,
                 pgid=14,
-                command="/usr/bin/python -m bernstein.core.bootstrap --watchdog --port 8052",
+                command="/usr/bin/python -m bernstein.core.orchestration.bootstrap --watchdog --port 8052",
             ),
         ]
 


### PR DESCRIPTION
## What

The recovery watchdog was launched as `python -m bernstein.core.bootstrap`.
That name is not a real module: it is a compatibility redirect alias
(`_REDIRECT_MAP["bootstrap"]` in `src/bernstein/core/__init__.py`) served by a
loader whose `get_code()` returns `None`. `import bernstein.core.bootstrap`
works, but `python -m` goes through `runpy`, which calls `loader.get_code()` and
raises `No code object available for bernstein.core.bootstrap`. The watchdog
died on arrival: one error line in `.sdd/runtime/watchdog.log`, a dead pid in
`.sdd/runtime/watchdog.pid`, and a run that still reported itself healthy.

This PR points the launcher at the real runnable module, keeps the stop-side
cleanup in step, and makes an immediate launch failure loud instead of silent.

## Why

The watchdog is the layer that restarts a dead task server or spawner. With it
dead on arrival, a detached run has no supervision of its own supervisors: any
stall or crash goes unrecovered, and the failure is invisible. The root cause is
a fixed module-name mismatch, so it reproduces on every install form (it was
observed on the published 3.8.2 wheel), not a transient error.

## How

- **Launcher** (`src/bernstein/core/orchestration/bootstrap.py`): the watchdog
  argv now targets `bernstein.core.orchestration.bootstrap`, the module that
  actually carries the `if __name__ == "__main__":` watchdog entrypoint, so
  `runpy` loads a real code object. Verified `python -m
  bernstein.core.orchestration.bootstrap` loads (exit 0) while `python -m
  bernstein.core.bootstrap` exits 1 with the reported error.
- **Loud failure**: after `Popen`, the launcher waits a short grace window; if
  the child has already exited it logs at `error` level and prints a red console
  line naming the failure, instead of leaving the operator to discover an empty
  log. A healthy launch stays quiet.
- **Stop matcher** (`src/bernstein/cli/commands/stop_cmd.py`): the command-string
  classifier that identifies the watchdog process is updated to the new module
  name so `stop`/cleanup still finds and reaps it. The new substring does not
  false-match the spawner command.
- **Regression test** (`tests/unit/test_bootstrap.py`):
  `test_start_watchdog_launches_a_runpy_runnable_module` captures the exact argv
  the launcher builds, then runs `python -m <that-module>` in a fresh interpreter
  (where the alias is unimported, as in a real wheel launch) and asserts it loads
  without `No code object available`. A future rename or redirect that rebreaks
  the launch fails this test.
  `test_start_watchdog_surfaces_a_dead_on_arrival_watchdog` asserts a child that
  exits immediately is surfaced via the error log and the console.

The failing-first check: before the fix, both new tests fail (the runnability
test on the `No code object available` string; the surfacing test because the
launcher never inspected the child). After the fix, the touched test files pass
(29 passed), with `ruff check`/`ruff format --check` clean on all touched files.

Closes #2795


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved watchdog startup compatibility when launched as a Python module.
  - Detects watchdog processes more reliably during stop operations.
  - Reports watchdog startup failures with clear console messages, exit status, and recent log details.
  - Helps prevent silent loss of crash and stall recovery when the watchdog exits immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->