### PR TITLE
fix(orchestration): stop the scheduled dependency scan from injecting foreign tasks and scanning the tool venv

### DIFF
--- a/docs/security/security-hardening.md
+++ b/docs/security/security-hardening.md
@@ -692,6 +692,21 @@ dependency_scan:
     - "ISC"
 ```
 
+#### Scheduled scan scope
+
+The orchestrator's scheduled (weekly) dependency scan is separate from the
+compliance scan above and is **off by default**
+(`OrchestratorConfig.dependency_scan_enabled = False`), so a scoped run is
+never given unrequested remediation tasks. When it is enabled:
+
+- It audits only the dependencies the target repo declares
+  (`requirements*.txt`, `pyproject.toml`, `setup.py`/`setup.cfg`, or a
+  lockfile). A repo with no Python dependency manifest is skipped rather than
+  having the orchestrator's own tool environment audited.
+- The first tick of a fresh run records a baseline instead of firing
+  immediately, so the weekly interval starts from that baseline rather than
+  treating a missing scan state as overdue.
+
 ### Data residency
 
 Restrict agent operations to specific regions in multi-region deployments:

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -338,7 +338,10 @@ class Orchestrator:
         self._tick_count = 0
         self._consecutive_server_failures: int = 0
         self._cached_critical_path_ids: set[str] = set()
-        self._dependency_scanner = DependencyVulnerabilityScanner(workdir)
+        self._dependency_scanner = DependencyVulnerabilityScanner(
+            workdir,
+            enabled=config.dependency_scan_enabled,
+        )
         # Track spawn failures per batch for backoff: task_ids -> (fail_count, last_fail_ts)
         self._spawn_failures: dict[frozenset[str], tuple[int, float]] = {}
         self._spawn_failure_history: dict[frozenset[str], list[Any]] = {}

--- a/src/bernstein/core/quality/dependency_scan.py
+++ b/src/bernstein/core/quality/dependency_scan.py
@@ -180,6 +180,88 @@ def read_latest_dependency_scan(sdd_dir: Path) -> DependencyScanResult | None:
     return DependencyScanResult.from_dict(payload_map)
 
 
+_REQUIREMENTS_GLOB = "requirements*.txt"
+_PROJECT_MARKERS = ("pyproject.toml", "setup.py", "setup.cfg", "Pipfile")
+_LOCKFILES = ("poetry.lock", "uv.lock", "pdm.lock", "Pipfile.lock")
+
+
+@dataclass(frozen=True)
+class DependencyScanTargets:
+    """Python dependency manifests declared by the target repo under work.
+
+    The scheduled scan audits these declared manifests, never the
+    orchestrator's own installed environment. When nothing is declared the
+    scan skips instead of falling back to auditing the active venv.
+    """
+
+    requirements_files: tuple[Path, ...] = ()
+    project_path: Path | None = None
+    has_lockfile: bool = False
+
+    @property
+    def declared(self) -> bool:
+        """Return True when the target repo declares any Python dependencies."""
+        return bool(self.requirements_files) or self.project_path is not None
+
+
+def discover_dependency_scan_targets(workdir: Path) -> DependencyScanTargets:
+    """Discover the Python dependency manifests declared in ``workdir``.
+
+    Args:
+        workdir: The target repository root under work.
+
+    Returns:
+        The discovered manifests. ``DependencyScanTargets.declared`` is False
+        when the repo has no ``requirements*.txt``, project file, or lockfile,
+        which signals the scan to skip rather than audit the active venv.
+    """
+    requirements_files = tuple(sorted((p for p in workdir.glob(_REQUIREMENTS_GLOB) if p.is_file()), key=str))
+    has_project_marker = any((workdir / marker).is_file() for marker in _PROJECT_MARKERS)
+    has_lockfile = any((workdir / lock).is_file() for lock in _LOCKFILES)
+    project_path = workdir if (has_project_marker or has_lockfile) else None
+    return DependencyScanTargets(
+        requirements_files=requirements_files,
+        project_path=project_path,
+        has_lockfile=has_lockfile,
+    )
+
+
+def _targeted_argv(command: DependencyScanCommand, targets: DependencyScanTargets) -> tuple[str, ...] | None:
+    """Return scanner argv aimed at the declared manifests, or None to skip.
+
+    ``pip-audit`` and ``safety`` audit the active Python environment unless an
+    explicit target is supplied, so a command with no derivable target is
+    dropped rather than run against the orchestrator's own venv.
+    """
+    if targets.requirements_files:
+        argv = list(command.argv)
+        for requirement in targets.requirements_files:
+            argv += ["-r", str(requirement)]
+        return tuple(argv)
+    # Only pip-audit can audit a bare project directory (pyproject / lockfile);
+    # safety needs a requirements file, so it is skipped for project-only repos
+    # rather than allowed to fall back to auditing the active environment.
+    if command.name == "pip-audit" and targets.project_path is not None:
+        argv = [*command.argv, str(targets.project_path)]
+        if targets.has_lockfile:
+            argv.append("--locked")
+        return tuple(argv)
+    return None
+
+
+def _build_targeted_commands(
+    base_commands: tuple[DependencyScanCommand, ...],
+    targets: DependencyScanTargets,
+) -> list[DependencyScanCommand]:
+    """Build scanner commands aimed at the target repo's declared manifests."""
+    commands: list[DependencyScanCommand] = []
+    for base in base_commands:
+        argv = _targeted_argv(base, targets)
+        if argv is not None:
+            commands.append(DependencyScanCommand(name=base.name, argv=argv))
+    return commands
+
+
 class DependencyVulnerabilityScanner:
     """Run weekly dependency vulnerability scans and persist their results."""
 
@@ -189,9 +271,11 @@ class DependencyVulnerabilityScanner:
         *,
         interval_s: int = DEFAULT_DEPENDENCY_SCAN_INTERVAL_S,
         timeout_s: int = DEFAULT_DEPENDENCY_SCAN_TIMEOUT_S,
+        enabled: bool = True,
         runner: DependencyCommandRunner | None = None,
     ) -> None:
         self._workdir = workdir
+        self._enabled = enabled
         self._sdd_dir = workdir / ".sdd"
         self._runtime_dir = self._sdd_dir / "runtime"
         self._metrics_dir = self._sdd_dir / "metrics"
@@ -207,10 +291,20 @@ class DependencyVulnerabilityScanner:
         )
 
     def is_due(self, *, now: float | None = None) -> bool:
-        """Return True when the next scheduled scan should run."""
+        """Return True when the next scheduled scan should run.
+
+        A disabled scanner is never due. A fresh workspace with no recorded
+        baseline (``last_scan_at <= 0``) is treated as "no baseline yet", not
+        "overdue", so it does not fire on the first tick; ``run_if_due``
+        records the baseline instead.
+        """
+        if not self._enabled:
+            return False
         last_scan_at = self._read_last_scan_at()
+        if last_scan_at <= 0:
+            return False
         current_time = time.time() if now is None else now
-        return last_scan_at <= 0 or (current_time - last_scan_at) >= self._interval_s
+        return (current_time - last_scan_at) >= self._interval_s
 
     def run_if_due(
         self,
@@ -219,23 +313,41 @@ class DependencyVulnerabilityScanner:
         audit_log: AuditLog | None = None,
         now: float | None = None,
     ) -> DependencyScanResult | None:
-        """Run the dependency scan if its weekly schedule is due."""
+        """Run the dependency scan if enabled and its weekly schedule is due.
+
+        On the first tick of a fresh workspace no scan runs: a baseline
+        ``last_scan_at`` is recorded so the weekly interval applies from then
+        on. This stops a freshly scoped run from being flooded on its first
+        normal tick.
+        """
+        if not self._enabled:
+            return None
         current_time = time.time() if now is None else now
+        if self._read_last_scan_at() <= 0:
+            # No baseline yet: record one and skip this tick.
+            self._write_state(current_time)
+            return None
         if not self.is_due(now=current_time):
             return None
         result = self.run_scan(create_fix_task=create_fix_task, audit_log=audit_log, now=current_time)
         self._write_state(current_time)
         return result
 
-    def _run_scanners(self) -> tuple[list[DependencyVulnerabilityFinding], list[str], list[str], int, int]:
-        """Execute all scanner commands. Returns (findings, errors, scanners_run, successful, unavailable)."""
+    def _run_scanners(
+        self,
+        commands: list[DependencyScanCommand],
+    ) -> tuple[list[DependencyVulnerabilityFinding], list[str], list[str], int, int]:
+        """Execute the given scanner commands.
+
+        Returns ``(findings, errors, scanners_run, successful, unavailable)``.
+        """
         findings: list[DependencyVulnerabilityFinding] = []
         errors: list[str] = []
         scanners_run: list[str] = []
         successful_scanners = 0
         unavailable_scanners = 0
 
-        for command in self._commands:
+        for command in commands:
             execution = self._runner(command, cwd=self._workdir, timeout_s=self._timeout_s)
             if _command_unavailable(command, execution):
                 unavailable_scanners += 1
@@ -279,34 +391,53 @@ class DependencyVulnerabilityScanner:
         audit_log: AuditLog | None = None,
         now: float | None = None,
     ) -> DependencyScanResult:
-        """Run one dependency vulnerability scan immediately."""
+        """Run one dependency vulnerability scan immediately.
+
+        The scan is scoped to the target repo's declared manifests. When the
+        repo declares no Python dependencies the scan is skipped with zero
+        findings, so no remediation tasks are created and the orchestrator's
+        own tool venv is never audited.
+        """
         current_time = time.time() if now is None else now
 
-        findings, errors, scanners_run, successful_scanners, unavailable_scanners = self._run_scanners()
+        targets = discover_dependency_scan_targets(self._workdir)
+        commands = _build_targeted_commands(self._commands, targets)
+        if not commands:
+            # The target repo declares no Python dependencies: skip with zero
+            # findings so no remediation tasks are created and the active
+            # environment (the orchestrator's own tool venv) is never audited.
+            result = DependencyScanResult(
+                scan_id=uuid.uuid4().hex[:12],
+                scanned_at=current_time,
+                status=DependencyScanStatus.SKIPPED,
+                summary="Dependency scan skipped: target repo declares no Python dependency manifest",
+            )
+        else:
+            findings, errors, scanners_run, successful_scanners, unavailable_scanners = self._run_scanners(commands)
+            deduped_findings = _dedupe_findings(findings)
+            created_task_titles: list[str] = []
+            if create_fix_task is not None:
+                created_task_titles = self._create_fix_tasks(deduped_findings, create_fix_task)
 
-        deduped_findings = _dedupe_findings(findings)
-        created_task_titles: list[str] = []
-        if create_fix_task is not None:
-            created_task_titles = self._create_fix_tasks(deduped_findings, create_fix_task)
+            status = _determine_scan_status(
+                findings=deduped_findings,
+                successful_scanners=successful_scanners,
+                unavailable_scanners=unavailable_scanners,
+                total_scanners=len(commands),
+                errors=errors,
+            )
+            summary = _build_summary(status, deduped_findings, scanners_run, errors)
+            result = DependencyScanResult(
+                scan_id=uuid.uuid4().hex[:12],
+                scanned_at=current_time,
+                status=status,
+                summary=summary,
+                findings=tuple(deduped_findings),
+                scanners_run=tuple(scanners_run),
+                errors=tuple(errors),
+                created_task_titles=tuple(created_task_titles),
+            )
 
-        status = _determine_scan_status(
-            findings=deduped_findings,
-            successful_scanners=successful_scanners,
-            unavailable_scanners=unavailable_scanners,
-            total_scanners=len(self._commands),
-            errors=errors,
-        )
-        summary = _build_summary(status, deduped_findings, scanners_run, errors)
-        result = DependencyScanResult(
-            scan_id=uuid.uuid4().hex[:12],
-            scanned_at=current_time,
-            status=status,
-            summary=summary,
-            findings=tuple(deduped_findings),
-            scanners_run=tuple(scanners_run),
-            errors=tuple(errors),
-            created_task_titles=tuple(created_task_titles),
-        )
         self._persist_result(result)
         if audit_log is not None:
             audit_log.log(

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -1408,6 +1408,10 @@ class OrchestratorConfig:
     # Default off; enable once multi-tenant workloads exist.
     fair_scheduling_enabled: bool = False
     cost_autopilot: bool = False  # Wire CostAutopilot when True
+    # Scheduled dependency vulnerability scan. Off by default so a scoped run
+    # is never given unrequested background maintenance tasks; enable only when
+    # the target repo declares Python dependencies that should be audited.
+    dependency_scan_enabled: bool = False
     # Janitor LLM-judge model/provider override, threaded from the seed's
     # ``judge_model``/``judge_provider`` (bernstein.yaml). None = fall back
     # to the janitor's hardcoded JUDGE_MODEL/JUDGE_PROVIDER defaults.

--- a/tests/unit/test_dependency_scan.py
+++ b/tests/unit/test_dependency_scan.py
@@ -12,14 +12,37 @@ from bernstein.core.dependency_scan import (
     DependencyScanResult,
     DependencyScanStatus,
     DependencyVulnerabilityScanner,
+    discover_dependency_scan_targets,
 )
 from httpx import ASGITransport, AsyncClient
 
 from bernstein.cli.status import render_status_plain
 from bernstein.core.server import create_app
+from bernstein.core.tasks.models import OrchestratorConfig
+
+
+def _vulnerable_pip_audit_output(package: str) -> CommandExecution:
+    """A pip-audit payload reporting one vulnerable package."""
+    return CommandExecution(
+        returncode=1,
+        stdout=json.dumps(
+            {
+                "dependencies": [
+                    {
+                        "name": package,
+                        "version": "1.0.0",
+                        "vulns": [{"id": "PYSEC-X", "description": "boom", "fix_versions": ["2.0.0"]}],
+                    }
+                ]
+            }
+        ),
+        stderr="",
+    )
 
 
 def test_dependency_scan_creates_fix_tasks_for_vulnerable_packages(tmp_path: Path) -> None:
+    # The scan only runs when the target repo declares Python dependencies.
+    (tmp_path / "requirements.txt").write_text("jinja2==2.11.0\nurllib3==1.25.0\n", encoding="utf-8")
     outputs = {
         "pip-audit": CommandExecution(
             returncode=1,
@@ -83,18 +106,28 @@ def test_dependency_scan_is_due_after_interval(tmp_path: Path) -> None:
         return CommandExecution(returncode=0, stdout=json.dumps([]), stderr="")
 
     scanner = DependencyVulnerabilityScanner(tmp_path, interval_s=100, runner=runner)
-    assert scanner.is_due(now=1_000.0) is True
+    # Fresh workspace: no baseline recorded yet, so the scan is not due on the
+    # first tick (last_scan_at <= 0 means "no baseline", not "overdue").
+    assert scanner.is_due(now=1_000.0) is False
 
-    scanner.run_if_due(
-        now=1_000.0,
-        create_fix_task=lambda finding: None,
+    # First run_if_due records a baseline and performs no scan.
+    assert (
+        scanner.run_if_due(
+            now=1_000.0,
+            create_fix_task=lambda finding: None,
+        )
+        is None
     )
 
+    # Baseline is now 1_000.0; the interval gate applies from there.
     assert scanner.is_due(now=1_050.0) is False
     assert scanner.is_due(now=1_101.0) is True
 
 
 def test_dependency_scan_records_skipped_when_tools_unavailable(tmp_path: Path) -> None:
+    # A declared manifest is required to reach the scanners at all.
+    (tmp_path / "requirements.txt").write_text("jinja2==2.11.0\n", encoding="utf-8")
+
     def runner(command: DependencyScanCommand, *, cwd: Path, timeout_s: int) -> CommandExecution:
         return CommandExecution(returncode=127, stdout="", stderr=f"{command.name} not installed")
 
@@ -137,3 +170,129 @@ async def test_status_exposes_latest_dependency_scan(tmp_path: Path) -> None:
     assert payload["dependency_scan"]["status"] == "vulnerable"
     plain = render_status_plain(payload)
     assert "Dependency scan: vulnerable" in plain
+
+
+# --- issue #2788: scope the scan to the target repo, not the tool venv -----
+
+
+def test_dependency_scan_skips_when_target_has_no_manifest(tmp_path: Path) -> None:
+    """A target repo with no Python dependency manifest must not be scanned.
+
+    Regression guard for issue #2788: without a manifest the scanners would
+    audit the orchestrator's own tool venv and inject one foreign
+    ``Upgrade vulnerable dependency`` task per installed package.
+    """
+    invoked: list[str] = []
+
+    def runner(command: DependencyScanCommand, *, cwd: Path, timeout_s: int) -> CommandExecution:
+        invoked.append(command.name)
+        return _vulnerable_pip_audit_output("aiohttp")
+
+    created: list[str] = []
+    scanner = DependencyVulnerabilityScanner(tmp_path, runner=runner)
+    result = scanner.run_scan(create_fix_task=lambda finding: created.append(finding.package) or finding.package)
+
+    assert invoked == []  # scanners never executed against the active environment
+    assert created == []  # zero foreign tasks injected
+    assert result.status == DependencyScanStatus.SKIPPED
+    assert result.findings == ()
+
+
+def test_dependency_scan_first_run_records_baseline_without_scanning(tmp_path: Path) -> None:
+    """A fresh workspace records a baseline instead of firing on the first tick."""
+    (tmp_path / "requirements.txt").write_text("jinja2==2.11.0\n", encoding="utf-8")
+    invoked: list[str] = []
+
+    def runner(command: DependencyScanCommand, *, cwd: Path, timeout_s: int) -> CommandExecution:
+        invoked.append(command.name)
+        return _vulnerable_pip_audit_output("jinja2")
+
+    scanner = DependencyVulnerabilityScanner(tmp_path, runner=runner)
+    assert scanner.is_due(now=1_000.0) is False
+
+    result = scanner.run_if_due(now=1_000.0, create_fix_task=lambda finding: finding.package)
+
+    assert result is None  # no scan on the first tick
+    assert invoked == []
+    state = json.loads((tmp_path / ".sdd" / "runtime" / "dependency_scan_state.json").read_text(encoding="utf-8"))
+    assert state["last_scan_at"] == 1_000.0
+
+
+def test_dependency_scan_disabled_flag_skips_scan(tmp_path: Path) -> None:
+    """When the scan is disabled, it never runs and never records state."""
+    (tmp_path / "requirements.txt").write_text("jinja2==2.11.0\n", encoding="utf-8")
+    invoked: list[str] = []
+
+    def runner(command: DependencyScanCommand, *, cwd: Path, timeout_s: int) -> CommandExecution:
+        invoked.append(command.name)
+        return _vulnerable_pip_audit_output("jinja2")
+
+    scanner = DependencyVulnerabilityScanner(tmp_path, enabled=False, runner=runner)
+
+    assert scanner.is_due(now=5_000.0) is False
+    assert scanner.run_if_due(now=5_000.0, create_fix_task=lambda finding: finding.package) is None
+    assert invoked == []
+    assert not (tmp_path / ".sdd" / "runtime" / "dependency_scan_state.json").exists()
+
+
+def test_dependency_scan_targets_declared_requirements_file(tmp_path: Path) -> None:
+    """When a manifest exists, the scanners are pointed at it, not the tool venv."""
+    req = tmp_path / "requirements.txt"
+    req.write_text("jinja2==2.11.0\n", encoding="utf-8")
+    seen_argv: dict[str, tuple[str, ...]] = {}
+
+    def runner(command: DependencyScanCommand, *, cwd: Path, timeout_s: int) -> CommandExecution:
+        seen_argv[command.name] = command.argv
+        return CommandExecution(returncode=0, stdout="[]", stderr="")
+
+    scanner = DependencyVulnerabilityScanner(tmp_path, runner=runner)
+    scanner.run_scan()
+
+    assert "-r" in seen_argv["pip-audit"]
+    assert str(req) in seen_argv["pip-audit"]
+    assert "-r" in seen_argv["safety"]
+    assert str(req) in seen_argv["safety"]
+
+
+def test_dependency_scan_targets_pyproject_project_path(tmp_path: Path) -> None:
+    """A pyproject-only project is audited as a project path (pip-audit), not the env."""
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'demo'\n", encoding="utf-8")
+    seen_argv: dict[str, tuple[str, ...]] = {}
+
+    def runner(command: DependencyScanCommand, *, cwd: Path, timeout_s: int) -> CommandExecution:
+        seen_argv[command.name] = command.argv
+        return CommandExecution(returncode=0, stdout="[]", stderr="")
+
+    scanner = DependencyVulnerabilityScanner(tmp_path, runner=runner)
+    scanner.run_scan()
+
+    # pip-audit can audit a project path; safety (which cannot target a bare
+    # project) must not run against the active environment.
+    assert str(tmp_path) in seen_argv["pip-audit"]
+    assert "safety" not in seen_argv
+
+
+def test_discover_targets_reports_no_declaration_for_empty_repo(tmp_path: Path) -> None:
+    targets = discover_dependency_scan_targets(tmp_path)
+    assert targets.declared is False
+    assert targets.requirements_files == ()
+    assert targets.project_path is None
+
+
+def test_discover_targets_finds_requirements_and_pyproject(tmp_path: Path) -> None:
+    (tmp_path / "requirements.txt").write_text("jinja2\n", encoding="utf-8")
+    (tmp_path / "requirements-dev.txt").write_text("pytest\n", encoding="utf-8")
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'demo'\n", encoding="utf-8")
+    (tmp_path / "uv.lock").write_text("", encoding="utf-8")
+
+    targets = discover_dependency_scan_targets(tmp_path)
+
+    assert targets.declared is True
+    assert (tmp_path / "requirements.txt") in targets.requirements_files
+    assert (tmp_path / "requirements-dev.txt") in targets.requirements_files
+    assert targets.project_path == tmp_path
+    assert targets.has_lockfile is True
+
+
+def test_orchestrator_config_disables_dependency_scan_by_default() -> None:
+    assert OrchestratorConfig().dependency_scan_enabled is False


### PR DESCRIPTION
## What

Stops the scheduled dependency scan from injecting foreign `Upgrade vulnerable dependency: <pkg>` tasks into a scoped run and from auditing the orchestrator's own tool venv instead of the target repo.

Three layered changes in `src/bernstein/core/quality/dependency_scan.py` (plus config wiring):

- **Manifest scoping (root cause).** The scan now discovers the target repo's declared manifests (`requirements*.txt`, `pyproject.toml`, `setup.py`/`setup.cfg`, or a lockfile). A repo that declares no Python dependencies is skipped with zero findings, so no remediation tasks are created and the active environment is never audited. When manifests exist, `pip-audit`/`safety` are pointed at them (`-r <file>`, or a project path for `pip-audit`) rather than the active environment.
- **First-run baseline gate.** `is_due` now treats `last_scan_at <= 0` as "no baseline yet" (not "overdue"). The first tick of a fresh run records a baseline and skips, so the weekly interval starts from that baseline instead of firing immediately.
- **Off-by-default flag.** New `OrchestratorConfig.dependency_scan_enabled` (default `False`) gates the scanner, so a scoped run is never given unrequested background maintenance tasks.

## Why

A run scoped to a single seed goal silently gained ~80 unrelated `fix` tasks with `role: security`, one per package in Bernstein's own tool venv. Two defects combined:

1. The scan fired on the first normal tick because `last_scan_at <= 0` was treated as overdue, so the weekly interval never protected a fresh workspace.
2. `pip-audit --format=json` / `safety check --json` audit the active Python environment (the orchestrator tool venv), not the target repo; passing `cwd=workdir` does not change which environment those tools inspect. A target repo with no manifest was therefore reported using Bernstein's own dependencies.

Those tasks are claimable, so workers would pick them up and try to "upgrade" packages the target project does not depend on, which is unresolvable churn and, on a paid model route, unrequested cost.

## How

Systematic debugging confirmed the exact root cause at three points (`dependency_scan.py` `is_due` interval gate, the untargeted command argv, and the missing gate). TDD: the failing tests were written first and reproduced the bug (foreign tasks injected, first tick firing), then the smallest fix at the root cause made them pass.

Tests in `tests/unit/test_dependency_scan.py`:

- `test_dependency_scan_skips_when_target_has_no_manifest` - no manifest -> scanners never invoked, zero tasks created, status `skipped`.
- `test_dependency_scan_first_run_records_baseline_without_scanning` - fresh workspace records a baseline and does not scan on the first tick.
- `test_dependency_scan_disabled_flag_skips_scan` - disabled scanner never runs and never records state.
- `test_dependency_scan_targets_declared_requirements_file` / `test_dependency_scan_targets_pyproject_project_path` - the scanners are pointed at the declared manifests, not the active environment.
- `test_discover_targets_*` and `test_orchestrator_config_disables_dependency_scan_by_default` - discovery and the off-by-default config default.

Existing tests updated for the corrected semantics (a declared manifest is required to reach the scanners; the first tick records a baseline instead of firing).

`tests/unit/test_dependency_scan.py` + `tests/unit/test_dependency_scan_tasks.py`: 27 passed. `ruff check` / `ruff format --check` clean on touched files; `pyright` on the touched module is unchanged from baseline (6 pre-existing errors rooted in the `bernstein.core.audit` redirect that static analysis cannot resolve). Docs: scheduled-scan scope documented in `docs/security/security-hardening.md`.

Closes #2788
