### PR TITLE
fix(config): validate adapter selection against the live registry instead of stale allowlists

### DIFF
--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -36,7 +36,7 @@ Bernstein ships a large surface of CLI commands registered in `cli/main.py`. Thi
 | `--auto-approve` | off | Skip confirmation prompt before execution. |
 | `--approval {auto\|review\|pr}` | auto | Approval gate: merge immediately / pause for review / open GitHub PR. |
 | `--merge {pr\|direct}` | pr | Merge strategy: open a PR, or push directly to main. |
-| `--cli {claude\|codex\|gemini\|qwen\|auto}` | none | Force a specific agent (overrides auto-detection). |
+| `--cli NAME` | none | Force a specific agent: any adapter from `bernstein adapters list`, or `auto` (overrides auto-detection). |
 | `--model NAME` | none | Force a specific model (e.g. `opus`, `sonnet`, `o3`). |
 | `--workflow {governed}` | none | Activate governed workflow mode. |
 | `-v, --verbose` | off | Show debug-level output. |
@@ -101,7 +101,7 @@ The full flag list is large (28 flags inherited from the root group and re-expos
 | `PLAN_FILE` | none | A YAML plan to execute. Optional. |
 | `--budget USD` | 0.0 | Cost cap. 0 = unlimited. |
 | `--max-cost-usd N` | unset | Hard cap on cumulative routed model spend; aborts the run when crossed. Sets `BERNSTEIN_MAX_COST_USD`. |
-| `--cli` | auto | Force agent (claude/codex/gemini/qwen/auto). |
+| `--cli` | auto | Force agent: any registered adapter name (see `bernstein adapters list`) or `auto`. |
 | `--model` | none | Force a specific model. |
 | `--approval {auto\|review\|pr}` | auto | Approval gate. |
 | `--merge {pr\|direct}` | pr | Merge strategy. |

--- a/src/bernstein/adapters/registry.py
+++ b/src/bernstein/adapters/registry.py
@@ -269,6 +269,35 @@ def iter_adapter_specs() -> Iterator[tuple[str, type[CLIAdapter] | CLIAdapter]]:
         yield name, _ADAPTERS[name]
 
 
+#: Registry names that are not user-selectable coding agents. ``mock`` is the
+#: test-only stub adapter (zero-API-key demos, fixtures, and the conformance
+#: harness): it lives in the registry so ``bernstein adapters list`` and the
+#: conformance suite can see it, but it is never a real target an operator
+#: pins a run to. Excluded from :func:`selectable_adapter_names` so selection
+#: surfaces reject it while enumeration surfaces still show it.
+_NON_AGENT_STUBS: frozenset[str] = frozenset({"mock"})
+
+
+def selectable_adapter_names() -> frozenset[str]:
+    """Return the adapter registry names an operator may select for a run.
+
+    The set is the live adapter registry - the same source
+    :func:`iter_adapter_specs` and ``bernstein adapters list`` enumerate -
+    minus the non-agent stubs in :data:`_NON_AGENT_STUBS`. It is the single
+    source of truth the seed ``cli:`` allowlist and every ``--cli``
+    ``click.Choice`` derive from, so a newly registered adapter becomes
+    selectable on every surface at once instead of being rejected by a
+    stale hardcoded list (issue #2781).
+
+    The ``auto`` sentinel (auto-detection, not a registered adapter) is not
+    included; callers that accept it add it themselves.
+
+    Returns:
+        Frozen set of selectable adapter registry names.
+    """
+    return frozenset(name for name, _ in iter_adapter_specs() if name not in _NON_AGENT_STUBS)
+
+
 def _register_provider_alias(alias: str, adapter_name: str) -> None:
     """Register a single provider-name alias into the provider alias table.
 

--- a/src/bernstein/cli/commands/session_cmd.py
+++ b/src/bernstein/cli/commands/session_cmd.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 import click
 
-from bernstein.cli.helpers import console
+from bernstein.cli.helpers import adapter_cli_choice, console
 from bernstein.core.run_session import RunSession, sessions_dir_for
 
 
@@ -96,7 +96,7 @@ def session_show(session_id: str) -> None:
 @click.option(
     "--cli",
     default=None,
-    type=click.Choice(["auto", "claude", "codex", "gemini", "aider", "qwen"], case_sensitive=False),
+    type=adapter_cli_choice(),
     help="Force specific CLI agent (overrides session default).",
 )
 @click.option(

--- a/src/bernstein/cli/helpers.py
+++ b/src/bernstein/cli/helpers.py
@@ -72,6 +72,25 @@ console = Console()
 # ---------------------------------------------------------------------------
 
 
+def adapter_cli_choice() -> click.Choice[str]:
+    """Build the ``--cli`` option type from the live adapter registry.
+
+    Returns a :class:`click.Choice` whose options are every selectable
+    adapter (:func:`bernstein.adapters.registry.selectable_adapter_names`)
+    plus the ``auto`` auto-detection sentinel, so ``--cli`` accepts any
+    registered adapter instead of a stale hardcoded subset (issue #2781).
+    The adapters package is imported lazily here so importing this helper
+    module does not pull it in.
+
+    Returns:
+        A case-insensitive ``click.Choice`` over the selectable adapter
+        names plus ``"auto"``.
+    """
+    from bernstein.adapters.registry import selectable_adapter_names
+
+    return click.Choice(sorted({*selectable_adapter_names(), "auto"}), case_sensitive=False)
+
+
 def print_banner() -> None:
     console.print(f"[blue]{BANNER}[/blue]")
 

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -272,6 +272,7 @@ from bernstein.cli.helpers import (
     SDD_PID_WATCHDOG,
     SERVER_URL,
     STATUS_COLORS,
+    adapter_cli_choice,
     auth_headers,
     console,
     find_seed_file,
@@ -615,7 +616,7 @@ def _validate_evolve_mode(evolve: bool, budget: float, max_cycles: int, yes: boo
 @click.option(
     "--cli",
     "cli_override",
-    type=click.Choice(["claude", "codex", "gemini", "qwen", "auto"]),
+    type=adapter_cli_choice(),
     default=None,
     help="Force a specific agent (overrides auto-detection).",
 )

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -21,6 +21,7 @@ from bernstein.cli.first_run_guard import handle_first_run_exception
 from bernstein.cli.helpers import (
     SDD_DIRS,
     SERVER_URL,
+    adapter_cli_choice,
     auth_headers,
     console,
     find_seed_file,
@@ -1170,7 +1171,7 @@ def exec_restart() -> None:
 @click.option(
     "--cli",
     default=None,
-    type=click.Choice(["auto", "claude", "codex", "gemini", "aider", "qwen"], case_sensitive=False),
+    type=adapter_cli_choice(),
     help="Force specific CLI agent (overrides auto-detection and config file).",
 )
 @click.option(

--- a/src/bernstein/core/config/seed.py
+++ b/src/bernstein/core/config/seed.py
@@ -45,7 +45,6 @@ from bernstein.core.config.seed_parser import (  # noqa: F401
     _BUDGET_RE,
     _DEFAULT_RATE_LIMIT_PATHS,
     _ENV_REF_RE,
-    _VALID_CLIS,
     _WEBHOOK_EVENT_ALIASES,
     _expand_env_value,
     _normalize_webhook_event,
@@ -66,6 +65,7 @@ from bernstein.core.config.seed_parser import (  # noqa: F401
     _parse_team,
     _parse_tenants,
     parse_seed,
+    valid_cli_selections,
 )
 from bernstein.core.models import (
     Complexity,

--- a/src/bernstein/core/config/seed_config.py
+++ b/src/bernstein/core/config/seed_config.py
@@ -384,7 +384,11 @@ class SeedConfig:
     team: Literal["auto"] | list[str] = "auto"
     team_manifest: str | None = None
     team_manifest_digest: str | None = None
-    cli: Literal["claude", "codex", "gemini", "qwen", "auto"] = "auto"
+    # Any selectable adapter registry name (see
+    # ``bernstein.adapters.registry.selectable_adapter_names``) or the
+    # ``auto`` auto-detection sentinel; validated in ``_parse_cli`` against
+    # the live registry rather than a hardcoded subset (issue #2781).
+    cli: str = "auto"
     max_agents: int = 6
     model: str | None = None
     constraints: tuple[str, ...] = ()

--- a/src/bernstein/core/config/seed_parser.py
+++ b/src/bernstein/core/config/seed_parser.py
@@ -68,7 +68,9 @@ type _StrObjDict = dict[str, object]
 
 _BUDGET_RE = re.compile(r"^\$(\d+(?:\.\d+)?)$")
 _ENV_REF_RE = re.compile(r"^\$\{([A-Z0-9_]+)\}$")
-_VALID_CLIS = frozenset({"claude", "codex", "gemini", "qwen", "opencode", "aider", "auto"})
+# The ``cli:`` auto-detection sentinel: accepted alongside every selectable
+# adapter but not itself a registered adapter (see ``valid_cli_selections``).
+_AUTO_CLI = "auto"
 _ALLOWED_WEBHOOK_EVENTS = frozenset(
     {
         "run.started",
@@ -1867,11 +1869,32 @@ def _parse_cost_envelopes(data: dict[str, object]) -> dict[str, dict[str, Any]]:
     return out
 
 
-def _parse_cli(data: dict[str, object]) -> Literal["claude", "codex", "gemini", "qwen", "auto"]:
-    cli_raw: object = data.get("cli", "auto")
-    if cli_raw not in _VALID_CLIS:
-        raise SeedError(f"cli must be one of {sorted(_VALID_CLIS)}, got: {cli_raw!r}")
-    return cast("Literal['claude', 'codex', 'gemini', 'qwen', 'auto']", cli_raw)
+def valid_cli_selections() -> frozenset[str]:
+    """Return the set of values accepted by ``cli:`` in a seed file.
+
+    The set is the live selectable adapter registry
+    (:func:`bernstein.adapters.registry.selectable_adapter_names`) plus the
+    ``auto`` auto-detection sentinel. The adapters package is imported on
+    demand here so importing the seed parser never pulls it in (matching the
+    lazy-import discipline the rest of this module follows), and a newly
+    registered adapter is accepted by ``cli:`` without editing a hardcoded
+    list (issue #2781).
+
+    Returns:
+        Frozen set of accepted ``cli:`` values: every selectable adapter
+        registry name plus ``"auto"``.
+    """
+    from bernstein.adapters.registry import selectable_adapter_names
+
+    return selectable_adapter_names() | {_AUTO_CLI}
+
+
+def _parse_cli(data: dict[str, object]) -> str:
+    cli_raw: object = data.get("cli", _AUTO_CLI)
+    valid = valid_cli_selections()
+    if not isinstance(cli_raw, str) or cli_raw not in valid:
+        raise SeedError(f"cli must be one of {sorted(valid)}, got: {cli_raw!r}")
+    return cli_raw
 
 
 def _parse_max_agents(data: dict[str, object]) -> int:

--- a/tests/unit/test_adapter_selection_allowlists.py
+++ b/tests/unit/test_adapter_selection_allowlists.py
@@ -1,0 +1,89 @@
+"""Adapter selection must track the live registry, not stale allowlists.
+
+Regression cover for issue #2781. The seed ``cli:`` allowlist and every
+``--cli`` ``click.Choice`` derive from
+:func:`bernstein.adapters.registry.selectable_adapter_names`, so a newly
+registered adapter is selectable on every surface at once and the four
+selection surfaces (seed allowlist, main-group ``--cli``, ``run`` ``--cli``,
+``session replay`` ``--cli``) cannot drift apart from the registry.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+import pytest
+from bernstein.core.seed import SeedError, parse_seed, valid_cli_selections
+
+from bernstein.adapters.registry import iter_adapter_specs, selectable_adapter_names
+
+_AUTO = "auto"
+
+# Names the pre-#2781 hardcoded lists accepted; all must stay selectable so the
+# fix only widens the allowlist and never drops a previously valid selection.
+_HISTORICALLY_ALLOWED = frozenset({"claude", "codex", "gemini", "qwen", "opencode", "aider", _AUTO})
+
+
+def _registry_names() -> set[str]:
+    """Every registry adapter name, the source ``bernstein adapters list`` uses."""
+    return {name for name, _ in iter_adapter_specs()}
+
+
+def _cli_choice_values(command: click.Command) -> set[str]:
+    """Return the ``--cli`` option's choice set for a Click command."""
+    for param in command.params:
+        if "--cli" in getattr(param, "opts", ()):
+            param_type = param.type
+            assert isinstance(param_type, click.Choice), f"--cli on {command.name!r} is not a click.Choice"
+            return {str(choice) for choice in param_type.choices}
+    raise AssertionError(f"command {command.name!r} has no --cli option")
+
+
+def test_selectable_names_are_registry_minus_stubs() -> None:
+    """Selectable set is the whole registry except the non-agent ``mock`` stub."""
+    selectable = selectable_adapter_names()
+    registry = _registry_names()
+    assert "mock" not in selectable, "the test-only mock stub must not be selectable"
+    assert selectable == registry - {"mock"}
+
+
+def test_historically_allowed_names_stay_selectable() -> None:
+    """The pre-fix allowlist is a subset of the new allowlist (no regression)."""
+    assert (selectable_adapter_names() | {_AUTO}) >= _HISTORICALLY_ALLOWED
+
+
+def test_seed_allowlist_matches_registry() -> None:
+    """The seed ``cli:`` allowlist is exactly the selectable registry plus ``auto``."""
+    assert valid_cli_selections() == selectable_adapter_names() | {_AUTO}
+
+
+def test_every_cli_choice_matches_the_seed_allowlist() -> None:
+    """The seed allowlist and all three ``--cli`` choices agree with each other."""
+    from bernstein.cli.commands.session_cmd import session_group
+    from bernstein.cli.main import cli
+
+    expected = valid_cli_selections()
+    run_command = cli.commands["run"]
+    replay_command = session_group.commands["replay"]
+
+    assert _cli_choice_values(cli) == expected, "main-group --cli drifted from the registry"
+    assert _cli_choice_values(run_command) == expected, "run --cli drifted from the registry"
+    assert _cli_choice_values(replay_command) == expected, "session replay --cli drifted from the registry"
+
+
+@pytest.mark.parametrize("cli_name", ["cloudflare", "agy", "kimi", "droid"])
+def test_seed_accepts_registered_adapter(tmp_path: Path, cli_name: str) -> None:
+    """A registry-backed adapter parses via ``cli:`` (the issue #2781 repro)."""
+    seed = tmp_path / "bernstein.yaml"
+    seed.write_text(f'goal: "x"\ncli: {cli_name}\nmodel: m\n')
+    config = parse_seed(seed)
+    assert config.cli == cli_name
+
+
+def test_seed_still_rejects_unregistered_adapter(tmp_path: Path) -> None:
+    """A name that is not a registered adapter is still a parse error."""
+    seed = tmp_path / "bernstein.yaml"
+    seed.write_text('goal: "x"\ncli: chatgpt\n')
+    with pytest.raises(SeedError, match="cli must be one of"):
+        parse_seed(seed)


### PR DESCRIPTION
## What

Adapter selection now validates against the live adapter registry (the same source `bernstein adapters list` enumerates) instead of hardcoded allowlists that had fallen out of sync with it.

Before, four independent hardcoded lists gated which adapters a user could select, all smaller than the 48-entry registry:

- `seed_parser._VALID_CLIS` (7 names) gated `cli:` in `bernstein.yaml`
- the main-group `--cli` choice (5 names)
- the `run` `--cli` choice (6 names)
- the `session replay` `--cli` choice (6 names)

A registered adapter absent from a list could not be chosen, so `cli: cloudflare` (and roughly 40 other registered adapters) failed to parse and `--cli cloudflare` was rejected, contradicting both the registry and the docs.

## Why

Adapters are registered and documented as selectable (for example `docs/cloudflare/cloudflare-adapters.md` instructs `cli: cloudflare`), yet the selection surfaces rejected them. Repro on the base branch:

```
printf 'goal: "x"\ncli: cloudflare\nmodel: m\n' > bernstein.yaml
bernstein run --seed ./bernstein.yaml
# -> Cannot parse seed file. Reason: cli must be one of [...], got: 'cloudflare'
```

## How

Add `selectable_adapter_names()` to `bernstein.adapters.registry` as the single source of truth: every registry name minus the non-agent stubs (`mock`). The seed parser (`valid_cli_selections()`) and a shared `adapter_cli_choice()` CLI helper both derive their allowlist from it, and all three `--cli` options plus the seed `cli:` allowlist now use those. A newly registered adapter becomes selectable on every surface at once.

- The seed parser and the CLI helper import the adapters package lazily, so importing them does not pull it in.
- `SeedConfig.cli` widens from a 5-value `Literal` to `str`.
- Previously valid names stay valid (the allowlist only widens); an unregistered name (e.g. `chatgpt`) still fails to parse.
- `docs/reference/cli-reference.md` no longer enumerates the stale short list; `docs/workflows/per-step-routing.md` already described the registry-backed behaviour.

Test: `tests/unit/test_adapter_selection_allowlists.py` asserts the seed allowlist, all three `--cli` choices, and the registry agree (drift guard), that `mock` is excluded while the historically-allowed names stay selectable, and that `cli: cloudflare|agy|kimi|droid` parse while `cli: chatgpt` is still rejected.

```
$ uv run pytest tests/unit/test_adapter_selection_allowlists.py -q
9 passed
```

Closes #2781
