### PR TITLE
feat(telemetry): add verify-span to prove an exported OTLP span against the journal and chain

### DIFF
--- a/docs/observability/otlp-export.md
+++ b/docs/observability/otlp-export.md
@@ -85,21 +85,39 @@ OTLP/JSON and records nothing.
 
 ## Verifying an exported span
 
-The offline projection tooling remains the verification surface:
+Copy a span out of your tracing UI (its id plus attributes, as JSON) and
+prove it against the run journal and the audit chain:
+
+```bash
+bernstein telemetry verify-span --run <run_id> --span span.json   # from a file
+pbpaste | bernstein telemetry verify-span --run <run_id> --span -  # from stdin
+```
+
+`--span` accepts a file path, or `-` / `@-` to read the span JSON from
+stdin. The span JSON may be the OTLP/JSON object your collector emits
+(`spanId` plus an `attributes` list, exactly what `export-otel --dry-run`
+prints), so a round-trip through the wire stays checkable.
+
+The command recomputes the span's identity with the *same* derivation the
+export bridge used and prints one verdict:
+
+- **genuine** (exit 0) - the span id recomputes from the
+  `bernstein.journal.entry_hash` it carries, that entry exists in the run's
+  journal, and `bernstein.audit.anchor` derives the trace id recorded by the
+  run's `otel.projection` audit event.
+- **forged** (exit 1) - the span id does not recompute, the referenced entry
+  is absent from the journal, or the anchor does not match the chain. A real
+  rejection is a hard failure, never a warning.
+- **unverifiable** (exit 1) - the run's journal is absent, or the run was
+  never anchored into the audit chain, so the span cannot be proven either
+  way.
+
+The offline projection tooling remains available for the whole-run surface:
 
 ```bash
 bernstein trace project <run_id>            # signed projection.otel.json + audit event
 bernstein trace verify-projection <run_id>  # recompute ids from the journal, check signature
 ```
-
-A span in your tracing UI is genuine iff its span id recomputes from the
-`bernstein.journal.entry_hash` it carries and that hash exists in the run's
-journal chain. The verifier derives the trace id from
-`bernstein.audit.anchor`, matches the `otel.projection` event by trace and
-run id, and checks that event's final journal head. A dedicated
-`bernstein telemetry verify-span` subcommand that
-performs this proof from a pasted span JSON lands in the follow-up phase of
-issue #2526.
 
 ## Relationship to the raw GenAI exporter
 

--- a/src/bernstein/cli/commands/telemetry_cmd.py
+++ b/src/bernstein/cli/commands/telemetry_cmd.py
@@ -489,6 +489,119 @@ def telemetry_export_otel(
     )
 
 
+def _read_span_source(source: str) -> str:
+    """Return the raw span JSON text from a file path or stdin.
+
+    ``-`` or ``@-`` reads stdin; a leading ``@`` names a file (curl-style);
+    anything else is treated as a file path.
+    """
+    if source in {"-", "@-"}:
+        return click.get_text_stream("stdin").read()
+    from bernstein.core.security.sanitize import sanitize_log
+
+    path = source[1:] if source.startswith("@") else source
+    try:
+        return Path(path).read_text(encoding="utf-8")
+    except OSError as exc:
+        raise click.ClickException(f"cannot read span file: {sanitize_log(str(exc))}") from exc
+
+
+def _single_exported_span(payload: Any) -> Any:
+    """Unwrap a one-element JSON array so operators can paste either shape."""
+    if isinstance(payload, list):
+        if len(payload) == 1:
+            return payload[0]
+        raise click.ClickException(f"expected a single exported span, got a JSON array of {len(payload)}")
+    return payload
+
+
+def _render_span_verdict(result: Any, *, run_id: str, journal_path: Path) -> list[str]:
+    """Render the human-facing verdict lines for a span verification."""
+    if result.ok:
+        return [
+            "VERDICT: genuine",
+            f"  span {result.span_id} recomputes from journal entry_hash {result.entry_hash} (index {result.index})",
+            f"  anchor {result.anchor} resolves to otel.projection trace {result.chain_trace_id}",
+            f"  run {run_id} journal {journal_path}",
+        ]
+    label = "unverifiable" if result.unverifiable else "forged"
+    return [f"VERDICT: {label}", f"  reason: {result.reason}"]
+
+
+@telemetry_group.command("verify-span")
+@click.option("--run", "run_id", required=True, help="Run id whose journal and audit chain prove the span.")
+@click.option(
+    "--workdir",
+    "-w",
+    type=click.Path(file_okay=False, exists=True),
+    default=".",
+    show_default=True,
+    help="Project root containing .sdd/.",
+)
+@click.option(
+    "--span",
+    "span_source",
+    required=True,
+    metavar="PATH|@-",
+    help="Exported OTLP span JSON: a file path, or '-' / '@-' to read from stdin.",
+)
+@click.pass_context
+def telemetry_verify_span(ctx: click.Context, run_id: str, workdir: str, span_source: str) -> None:
+    """Prove an exported OTLP span against the run journal and chain (#2526).
+
+    Reads a single OTLP span (its id plus attributes, as JSON copied out of a
+    tracing pipeline) and recomputes its identity: the span id must derive
+    from the ``bernstein.journal.entry_hash`` it carries -- using the same
+    derivation the export bridge used -- that entry must exist in ``--run``'s
+    journal, and the ``bernstein.audit.anchor`` must resolve to the run's
+    ``otel.projection`` audit event. A span whose id does not recompute, or
+    whose anchor mismatches, is rejected as a forgery.
+
+    Exit codes: 0 = genuine, 1 = forged / unverifiable / bad input.
+    """
+    from bernstein.core.observability.otel_bridge import (
+        SpanParseError,
+        parse_exported_span,
+        verify_exported_span,
+    )
+    from bernstein.core.replay.journal import JournalPathError, load_events, run_journal_path
+    from bernstein.core.security.audit import load_or_create_audit_key
+    from bernstein.core.security.audit_chain import EVENT_OTEL_PROJECTION, AuditChainStore
+    from bernstein.core.security.sanitize import sanitize_log
+
+    raw = _read_span_source(span_source)
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise click.ClickException(f"span is not valid JSON: {sanitize_log(str(exc))}") from exc
+    payload = _single_exported_span(payload)
+    try:
+        span = parse_exported_span(payload)
+    except SpanParseError as exc:
+        raise click.ClickException(sanitize_log(str(exc))) from exc
+
+    root = Path(workdir).resolve()
+    try:
+        journal_path = run_journal_path(root / ".sdd", run_id)
+    except JournalPathError as exc:
+        raise click.ClickException(sanitize_log(str(exc))) from exc
+    events = load_events(journal_path)
+
+    projections: list[dict[str, Any]] = []
+    try:
+        chain = AuditChainStore(root / ".sdd" / "audit", key=load_or_create_audit_key())
+        projections = [event.details for event in chain.query(event_type=EVENT_OTEL_PROJECTION)]
+    except Exception as exc:
+        # A missing or unreadable chain leaves ``projections`` empty, so the
+        # verdict is "unverifiable" (never a silent pass) -- report and continue.
+        click.echo(f"warning: could not read audit chain: {sanitize_log(str(exc))}", err=True)
+
+    result = verify_exported_span(span, events, projections, run_id=run_id)
+    for line in _render_span_verdict(result, run_id=run_id, journal_path=journal_path):
+        click.echo(line)
+    ctx.exit(0 if result.ok else 1)
+
+
 @telemetry_group.command("tail")
 @click.option(
     "-n",
@@ -551,4 +664,5 @@ __all__ = [
     "telemetry_probe",
     "telemetry_status",
     "telemetry_tail",
+    "telemetry_verify_span",
 ]

--- a/src/bernstein/core/observability/otel_bridge.py
+++ b/src/bernstein/core/observability/otel_bridge.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from bernstein.core.observability.otel_projection import (
@@ -85,11 +86,16 @@ __all__ = [
     "JournalOTLPBridge",
     "LiveJournalSpanStream",
     "OTLPExportError",
+    "ParsedExportedSpan",
+    "SpanParseError",
+    "SpanVerification",
     "attach_live_export",
     "build_bridge_from_env",
+    "parse_exported_span",
     "projection_to_otlp_json_spans",
     "projection_to_readable_spans",
     "record_projection_audit_event",
+    "verify_exported_span",
 ]
 
 
@@ -732,4 +738,258 @@ def record_projection_audit_event(
         trace_id=signed.trace_id,
         span_count=len(signed.spans),
         projection_sha256=hashlib.sha256(canonical_projection_bytes(signed)).hexdigest(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Span verification (#2526 Phase 3)
+# ---------------------------------------------------------------------------
+
+
+class SpanParseError(ValueError):
+    """Raised when pasted span JSON is not a recognisable OTLP span."""
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedExportedSpan:
+    """The identity-bearing fields lifted from an exported OTLP span.
+
+    Attributes:
+        span_id: Lower-case hex span id (``spanId``).
+        trace_id: Lower-case hex trace id, or ``""`` when absent.
+        parent_span_id: Lower-case hex parent span id, or ``""``.
+        entry_hash: The ``bernstein.journal.entry_hash`` attribute.
+        anchor: The ``bernstein.audit.anchor`` attribute.
+        run_id: The ``bernstein.run.id`` attribute, or ``""``.
+        index: The ``bernstein.journal.index`` attribute, or ``-1``.
+        attributes: The flattened attribute map.
+    """
+
+    span_id: str
+    trace_id: str
+    parent_span_id: str
+    entry_hash: str
+    anchor: str
+    run_id: str
+    index: int
+    attributes: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class SpanVerification:
+    """Outcome of :func:`verify_exported_span`.
+
+    ``ok`` is the accept/reject verdict. When ``ok`` is ``False`` and
+    ``unverifiable`` is set the span could not be proven either way (no
+    journal, or the run was never anchored into the audit chain); otherwise
+    the span is a positive forgery. Both non-ok outcomes are nonzero exits on
+    the CLI -- a real rejection is never softened into a pass.
+    """
+
+    ok: bool
+    reason: str
+    unverifiable: bool = False
+    span_id: str = ""
+    entry_hash: str = ""
+    anchor: str = ""
+    trace_id: str = ""
+    index: int = -1
+    chain_trace_id: str = ""
+
+
+def _otlp_scalar(value: Any) -> Any:
+    """Unwrap an OTLP ``AnyValue`` dict to its scalar, or pass a plain value through."""
+    if isinstance(value, dict):
+        for key in ("stringValue", "intValue", "boolValue", "doubleValue"):
+            if key in value:
+                return value[key]
+        return ""
+    return value
+
+
+def _flatten_attributes(raw: Any) -> dict[str, Any]:
+    """Return a flat ``{name: scalar}`` map from either attribute shape.
+
+    Accepts both the OTLP/JSON list form (``[{"key": k, "value": {...}}]`` -- what a
+    stock collector emits) and a plain object (``{k: v}`` -- what an operator may
+    hand-simplify), so a span copied from any pipeline parses.
+    """
+    out: dict[str, Any] = {}
+    if isinstance(raw, list):
+        for item in raw:
+            if isinstance(item, dict) and "key" in item:
+                out[str(item["key"])] = _otlp_scalar(item.get("value"))
+    elif isinstance(raw, dict):
+        for key, value in raw.items():
+            out[str(key)] = _otlp_scalar(value)
+    return out
+
+
+def _hex(value: Any) -> str:
+    """Normalise a hex id/hash for comparison (hex is case-insensitive)."""
+    return str(value if value is not None else "").strip().lower()
+
+
+def parse_exported_span(payload: Any) -> ParsedExportedSpan:
+    """Lift the identity-bearing fields from a pasted OTLP span.
+
+    Args:
+        payload: A single decoded OTLP span object (camelCase ``spanId`` or
+            snake ``span_id``; attributes in either OTLP/JSON list form or a
+            flat object).
+
+    Returns:
+        The parsed span.
+
+    Raises:
+        SpanParseError: When ``payload`` is not an object or carries no span id.
+    """
+    if not isinstance(payload, dict):
+        raise SpanParseError("exported span must be a JSON object")
+    span_id = _hex(payload.get("spanId") or payload.get("span_id"))
+    if not span_id:
+        raise SpanParseError("exported span carries no spanId")
+    attributes = _flatten_attributes(payload.get("attributes"))
+    index_raw = attributes.get(ATTR_JOURNAL_INDEX)
+    try:
+        index = int(str(index_raw)) if index_raw is not None else -1
+    except (TypeError, ValueError):
+        index = -1
+    return ParsedExportedSpan(
+        span_id=span_id,
+        trace_id=_hex(payload.get("traceId") or payload.get("trace_id")),
+        parent_span_id=_hex(payload.get("parentSpanId") or payload.get("parent_span_id")),
+        entry_hash=_hex(attributes.get(ATTR_JOURNAL_ENTRY_HASH)),
+        anchor=_hex(attributes.get(ATTR_AUDIT_ANCHOR)),
+        run_id=str(attributes.get(ATTR_RUN_ID, "")).strip(),
+        index=index,
+        attributes=attributes,
+    )
+
+
+def _forged(reason: str, span: ParsedExportedSpan) -> SpanVerification:
+    return SpanVerification(
+        ok=False,
+        reason=reason,
+        unverifiable=False,
+        span_id=span.span_id,
+        entry_hash=span.entry_hash,
+        anchor=span.anchor,
+    )
+
+
+def _unverifiable(reason: str, span: ParsedExportedSpan) -> SpanVerification:
+    return SpanVerification(
+        ok=False,
+        reason=reason,
+        unverifiable=True,
+        span_id=span.span_id,
+        entry_hash=span.entry_hash,
+        anchor=span.anchor,
+    )
+
+
+def verify_exported_span(
+    span: ParsedExportedSpan,
+    events: Sequence[dict[str, Any]],
+    projections: Sequence[Mapping[str, Any]],
+    *,
+    run_id: str,
+) -> SpanVerification:
+    """Prove one exported span against the journal and the audit chain.
+
+    Re-derives the span id from the ``bernstein.journal.entry_hash`` the span
+    carries with :func:`otel_projection.derive_span_id` -- the *same* function
+    the export bridge used, so the verify path can never drift from the
+    producing path -- confirms that entry exists in ``run_id``'s journal, and
+    checks the ``bernstein.audit.anchor`` resolves through
+    :func:`otel_projection.derive_trace_id` to the run's ``otel.projection``
+    audit event.
+
+    Args:
+        span: The parsed exported span (see :func:`parse_exported_span`).
+        events: The run's journal rows in append order.
+        projections: The ``details`` payloads of the run's ``otel.projection``
+            audit events (each carrying ``run_id`` / ``trace_id`` /
+            ``journal_head``).
+        run_id: The run whose journal and chain the span is checked against.
+
+    Returns:
+        The verdict. ``ok`` is the accept/reject decision; a rejection with
+        ``unverifiable`` set means the span could not be proven either way (no
+        journal, or the export was never anchored), never that it passed.
+    """
+    if span.run_id and span.run_id != run_id:
+        return _forged(
+            f"span carries {ATTR_RUN_ID}={span.run_id!r} but was checked against run {run_id!r}",
+            span,
+        )
+    if not events:
+        return _unverifiable(
+            f"no event journal for run {run_id!r}; span identity cannot be recomputed",
+            span,
+        )
+
+    index_by_hash = {str(row.get("event_hash", "")): i for i, row in enumerate(events) if row.get("event_hash")}
+    root_hash = str(events[0].get("event_hash", ""))
+
+    if not span.entry_hash:
+        return _forged(f"span carries no {ATTR_JOURNAL_ENTRY_HASH}; it is unbindable to the journal", span)
+    if span.entry_hash not in index_by_hash:
+        return _forged(
+            f"{ATTR_JOURNAL_ENTRY_HASH} {span.entry_hash} is absent from run {run_id!r}'s journal",
+            span,
+        )
+
+    expected_span_id = derive_span_id(span.entry_hash)
+    if span.span_id != expected_span_id:
+        return _forged(
+            f"span id {span.span_id} does not recompute from entry_hash {span.entry_hash} "
+            f"(expected {expected_span_id})",
+            span,
+        )
+
+    if not span.anchor:
+        return _forged(f"span carries no {ATTR_AUDIT_ANCHOR}; its trace is unanchored", span)
+    if span.anchor != root_hash:
+        return _forged(
+            f"{ATTR_AUDIT_ANCHOR} {span.anchor} does not match run {run_id!r}'s journal head {root_hash}",
+            span,
+        )
+
+    expected_trace = derive_trace_id(span.anchor)
+    if span.trace_id and span.trace_id != expected_trace:
+        return _forged(
+            f"traceId {span.trace_id} does not derive from the anchor (expected {expected_trace})",
+            span,
+        )
+
+    run_projections = [p for p in projections if str(p.get("run_id", "")) == run_id]
+    if not run_projections:
+        return _unverifiable(
+            f"no otel.projection audit event for run {run_id!r}; the export was never anchored into the chain",
+            span,
+        )
+    matching = [p for p in run_projections if _hex(p.get("trace_id")) == expected_trace]
+    if not matching:
+        return _forged(
+            f"anchor-derived trace {expected_trace} matches no otel.projection audit event for run {run_id!r}",
+            span,
+        )
+    journal_head = str(events[-1].get("event_hash", ""))
+    if not any(str(p.get("journal_head", "")) == journal_head for p in matching):
+        return _forged(
+            f"otel.projection audit event for trace {expected_trace} anchors a different journal head",
+            span,
+        )
+
+    return SpanVerification(
+        ok=True,
+        reason="span id recomputes from the journal entry and its anchor matches the audit chain",
+        span_id=span.span_id,
+        entry_hash=span.entry_hash,
+        anchor=span.anchor,
+        trace_id=expected_trace,
+        index=index_by_hash[span.entry_hash],
+        chain_trace_id=expected_trace,
     )

--- a/tests/unit/test_telemetry_verify_span_cmd.py
+++ b/tests/unit/test_telemetry_verify_span_cmd.py
@@ -1,0 +1,240 @@
+"""Tests for ``bernstein telemetry verify-span`` (#2526, Phase 3).
+
+``verify-span`` proves an exported OTLP span against the run journal and the
+audit chain: the span id must recompute from the ``bernstein.journal.entry_hash``
+it carries (the same derivation the export bridge used), that entry must exist
+in the run's journal, and the ``bernstein.audit.anchor`` must resolve to the
+run's ``otel.projection`` audit event. A genuine exported span is accepted
+(exit 0); a span whose id does not recompute or whose anchor mismatches is
+rejected as a forgery (exit 1). Nothing here touches the network.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.telemetry_cmd import telemetry_group
+from bernstein.core.observability.otel_bridge import (
+    parse_exported_span,
+    projection_to_otlp_json_spans,
+    record_projection_audit_event,
+    verify_exported_span,
+)
+from bernstein.core.observability.otel_projection import (
+    derive_span_id,
+    project_spans,
+    sign_projection,
+)
+from bernstein.core.replay.journal import EventJournal, load_events, run_journal_path
+from bernstein.core.security.audit_dsse import keyid_from_public_key
+from bernstein.core.security.install_key import load_or_create_install_key, signing_key_path
+
+_RUN_ID = "run-1"
+
+
+@pytest.fixture
+def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A workspace with a recorded run journal and isolated keys."""
+    monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(tmp_path / "audit.key"))
+    monkeypatch.setenv("BERNSTEIN_CREDENTIAL_SIGNING_KEY", str(tmp_path / "install.key"))
+    monkeypatch.delenv("BERNSTEIN_OTEL_ENDPOINT", raising=False)
+
+    journal = EventJournal(_RUN_ID, tmp_path / ".sdd")
+    journal.record("run_started", goal="ship")
+    journal.record("agent_spawned", agent_id="a1")
+    journal.record("task_claimed", task_id="t1")
+    journal.record("task_completed", task_id="t1")
+    journal.record("agent_reaped", agent_id="a1")
+    journal.record("run_completed", ok=True)
+    return tmp_path
+
+
+def _exported_spans(project_root: Path, *, record_audit: bool = True) -> list[dict[str, Any]]:
+    """Produce the run's genuine exported OTLP/JSON spans.
+
+    Optionally records the ``otel.projection`` audit event so the exported
+    spans' anchor resolves to the chain (the state after a real export).
+    """
+    events = load_events(run_journal_path(project_root / ".sdd", _RUN_ID))
+    key = load_or_create_install_key(signing_key_path(project_root))
+    projection = project_spans(events, run_id=_RUN_ID, keyid=keyid_from_public_key(key.public_key()))
+    signed = sign_projection(projection, signing_key=key)
+    if record_audit:
+        record_projection_audit_event(
+            workdir=project_root,
+            journal_path=run_journal_path(project_root / ".sdd", _RUN_ID),
+            run_id=_RUN_ID,
+        )
+    return projection_to_otlp_json_spans(signed, events)
+
+
+def _set_attr(span: dict[str, Any], key: str, value: str) -> dict[str, Any]:
+    """Return a deep copy of ``span`` with attribute ``key`` set to ``value``."""
+    mutated = json.loads(json.dumps(span))
+    for item in mutated["attributes"]:
+        if item["key"] == key:
+            item["value"] = {"stringValue": value}
+    return mutated
+
+
+def _write(tmp: Path, span: dict[str, Any]) -> Path:
+    path = tmp / "span.json"
+    path.write_text(json.dumps(span), encoding="utf-8")
+    return path
+
+
+def _invoke(args: list[str], **kwargs: Any) -> Any:
+    return CliRunner().invoke(telemetry_group, args, **kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# Genuine spans are accepted                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_genuine_root_span_verifies_exit_zero(project: Path) -> None:
+    spans = _exported_spans(project)
+    span_file = _write(project, spans[0])  # invoke_workflow root
+    result = _invoke(["verify-span", "--run", _RUN_ID, "-w", str(project), "--span", str(span_file)])
+    assert result.exit_code == 0, result.output
+    assert "genuine" in result.output.lower()
+
+
+def test_genuine_leaf_span_verifies_exit_zero(project: Path) -> None:
+    spans = _exported_spans(project)
+    span_file = _write(project, spans[2])  # a non-root execute_tool span
+    result = _invoke(["verify-span", "--run", _RUN_ID, "-w", str(project), "--span", str(span_file)])
+    assert result.exit_code == 0, result.output
+    assert "genuine" in result.output.lower()
+
+
+def test_genuine_span_from_stdin(project: Path) -> None:
+    spans = _exported_spans(project)
+    result = _invoke(
+        ["verify-span", "--run", _RUN_ID, "-w", str(project), "--span", "@-"],
+        input=json.dumps(spans[0]),
+    )
+    assert result.exit_code == 0, result.output
+    assert "genuine" in result.output.lower()
+
+
+# --------------------------------------------------------------------------- #
+# Forgeries are rejected (hard fail, nonzero)                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_tampered_span_id_rejected(project: Path) -> None:
+    spans = _exported_spans(project)
+    forged = json.loads(json.dumps(spans[0]))
+    forged["spanId"] = "0000000000000000"  # id no longer recomputes from entry_hash
+    span_file = _write(project, forged)
+    result = _invoke(["verify-span", "--run", _RUN_ID, "-w", str(project), "--span", str(span_file)])
+    assert result.exit_code == 1
+    assert "forged" in result.output.lower()
+    assert "recompute" in result.output.lower()
+
+
+def test_tampered_entry_hash_rejected(project: Path) -> None:
+    spans = _exported_spans(project)
+    forged = _set_attr(spans[0], "bernstein.journal.entry_hash", "de" * 32)
+    span_file = _write(project, forged)
+    result = _invoke(["verify-span", "--run", _RUN_ID, "-w", str(project), "--span", str(span_file)])
+    assert result.exit_code == 1
+    assert "forged" in result.output.lower()
+
+
+def test_wrong_anchor_rejected(project: Path) -> None:
+    spans = _exported_spans(project)
+    forged = _set_attr(spans[0], "bernstein.audit.anchor", "ab" * 32)
+    span_file = _write(project, forged)
+    result = _invoke(["verify-span", "--run", _RUN_ID, "-w", str(project), "--span", str(span_file)])
+    assert result.exit_code == 1
+    assert "forged" in result.output.lower()
+    assert "anchor" in result.output.lower()
+
+
+def test_run_id_mismatch_rejected(project: Path) -> None:
+    spans = _exported_spans(project)
+    forged = _set_attr(spans[0], "bernstein.run.id", "some-other-run")
+    span_file = _write(project, forged)
+    result = _invoke(["verify-span", "--run", _RUN_ID, "-w", str(project), "--span", str(span_file)])
+    assert result.exit_code == 1
+    assert "forged" in result.output.lower()
+
+
+# --------------------------------------------------------------------------- #
+# Unverifiable (never anchored) is nonzero and distinct from forgery           #
+# --------------------------------------------------------------------------- #
+
+
+def test_unanchored_span_is_unverifiable(project: Path) -> None:
+    spans = _exported_spans(project, record_audit=False)  # no otel.projection event
+    span_file = _write(project, spans[0])
+    result = _invoke(["verify-span", "--run", _RUN_ID, "-w", str(project), "--span", str(span_file)])
+    assert result.exit_code == 1
+    assert "unverifiable" in result.output.lower()
+
+
+def test_missing_journal_is_unverifiable(project: Path) -> None:
+    spans = _exported_spans(project)
+    # Drop the run-id attribute so the run cross-check does not fire; the point
+    # here is that a run whose journal is absent cannot be proven either way.
+    stripped = json.loads(json.dumps(spans[0]))
+    stripped["attributes"] = [a for a in stripped["attributes"] if a["key"] != "bernstein.run.id"]
+    span_file = _write(project, stripped)
+    result = _invoke(["verify-span", "--run", "gone-run", "-w", str(project), "--span", str(span_file)])
+    assert result.exit_code == 1
+    assert "unverifiable" in result.output.lower()
+
+
+def test_bad_json_errors(project: Path) -> None:
+    span_file = project / "bad.json"
+    span_file.write_text("{not json", encoding="utf-8")
+    result = _invoke(["verify-span", "--run", _RUN_ID, "-w", str(project), "--span", str(span_file)])
+    assert result.exit_code == 1
+    assert "json" in result.output.lower()
+
+
+# --------------------------------------------------------------------------- #
+# Determinism                                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_verdict_is_deterministic(project: Path) -> None:
+    spans = _exported_spans(project)
+    span_file = _write(project, spans[0])
+    first = _invoke(["verify-span", "--run", _RUN_ID, "-w", str(project), "--span", str(span_file)])
+    second = _invoke(["verify-span", "--run", _RUN_ID, "-w", str(project), "--span", str(span_file)])
+    assert first.exit_code == 0
+    assert first.output == second.output
+
+
+# --------------------------------------------------------------------------- #
+# Pure-function surface (no CLI, reuses the shared derivation)                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_verify_exported_span_recompute_uses_shared_derivation(project: Path) -> None:
+    spans = _exported_spans(project)
+    events = load_events(run_journal_path(project / ".sdd", _RUN_ID))
+    projections = [
+        {
+            "run_id": _RUN_ID,
+            "trace_id": spans[0]["traceId"],
+            "journal_head": str(events[-1]["event_hash"]),
+        }
+    ]
+
+    genuine = verify_exported_span(parse_exported_span(spans[0]), events, projections, run_id=_RUN_ID)
+    assert genuine.ok is True
+
+    forged = json.loads(json.dumps(spans[0]))
+    forged["spanId"] = derive_span_id("not-a-real-entry-hash")  # a valid-shaped but wrong id
+    verdict = verify_exported_span(parse_exported_span(forged), events, projections, run_id=_RUN_ID)
+    assert verdict.ok is False
+    assert verdict.unverifiable is False


### PR DESCRIPTION
## What

Adds `bernstein telemetry verify-span --run <run_id> --span <path|@->`. It takes a single exported OTLP span (its id plus attributes, as JSON copied out of a tracing pipeline) and proves it against the run journal and the audit chain, printing one verdict:

- **genuine** (exit 0) - the span id recomputes from the `bernstein.journal.entry_hash` it carries, that entry exists in the run's journal, and `bernstein.audit.anchor` derives the trace id recorded by the run's `otel.projection` audit event.
- **forged** (exit 1) - the span id does not recompute, the referenced entry is absent from the journal, or the anchor does not match the chain.
- **unverifiable** (exit 1) - the run's journal is absent, or the export was never anchored into the chain, so the span cannot be proven either way.

`--span` reads a file path, or `-` / `@-` for stdin. Attributes parse from both the OTLP/JSON list form a stock collector emits and a flat object, so a span pasted from any pipeline is checkable.

## Why

Phases 1+2 (#2771) made the OTLP wire path a transport for the deterministic, journal-anchored span projection, but the operator-facing proof was still limited to the whole-run offline surface (`trace verify-projection`). An operator triaging a run in their own tracing UI needs to prove a *single* span they are looking at without reconstructing the whole projection. This closes that gap: any span in the stack becomes checkable evidence against the run journal rather than unverifiable telemetry.

## How

- `otel_bridge.verify_exported_span` (pure, unit-tested) performs the proof. It **reuses the export bridge's own derivation** (`otel_projection.derive_span_id` / `derive_trace_id`) instead of re-implementing the hash math, so the producing and checking paths cannot drift.
- Checks, in order: run-id cross-check -> journal present -> `entry_hash` in journal -> `derive_span_id(entry_hash) == spanId` -> `anchor == journal root head` -> optional `traceId` consistency -> a run `otel.projection` audit event whose `trace_id == derive_trace_id(anchor)` and whose `journal_head` matches the loaded journal.
- Thin CLI wrapper in `telemetry_cmd.py` alongside `export-otel`, matching its option style (`--run` / `-w` / `--span`). A real rejection is a hard nonzero exit, never softened into a pass.
- `parse_exported_span` tolerates camelCase/snake ids and both attribute shapes.

### Tests

`tests/unit/test_telemetry_verify_span_cmd.py` (12 tests, TDD - failing first):

- genuine root span, genuine leaf span, and stdin input all verify exit 0;
- tampered span id, tampered `entry_hash`, wrong `anchor`, and run-id mismatch each rejected exit 1 as forged;
- unanchored span (no `otel.projection` event) and missing journal reported unverifiable exit 1;
- malformed JSON errors cleanly;
- deterministic verdict (identical output across runs);
- pure-function coverage of `verify_exported_span` using the shared derivation.

Existing Phase-1/2 suites (`test_otel_bridge`, `test_telemetry_export_otel_cmd`, `test_otel_projection`, `test_audit_chain_otel_projection`) stay green. `ruff check` / `ruff format --check` clean; `mypy` clean on the touched files.

### Docs

`docs/observability/otlp-export.md` "Verifying an exported span" now documents the real command (it previously flagged it as a follow-up).

Phase 3 of #2526