### PR TITLE
fix(cli): make the mock demo succeed, exit nonzero on total failure, and clean up its processes

### DIFF
--- a/src/bernstein/adapters/mock.py
+++ b/src/bernstein/adapters/mock.py
@@ -56,6 +56,14 @@ class MockAgentAdapter(CLIAdapter):
     pre-scripted bug fixes to the demo project and exits successfully.
     """
 
+    # Default model when no operator-pinned model reaches this adapter. Read by
+    # the spawner to substitute Claude cascade tier names (opus/sonnet/haiku)
+    # for this non-Claude adapter. Without it the spawn-time model gate refuses
+    # to spawn a Claude tier on the mock adapter, so ``bernstein demo`` fails
+    # every task (issue #2799). The mock ignores the model at runtime; the name
+    # only has to be a non-Claude-tier placeholder the gate can coerce to.
+    default_model = "mock"
+
     def spawn(
         self,
         *,

--- a/src/bernstein/cli/run_confirm.py
+++ b/src/bernstein/cli/run_confirm.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import time
 from contextlib import suppress
 from dataclasses import dataclass
@@ -15,7 +16,6 @@ from bernstein.cli.helpers import (
     SDD_DIRS,
     auth_headers,
     console,
-    is_alive,
     print_banner,
     server_get,
 )
@@ -312,7 +312,7 @@ def detect_available_adapter() -> str | None:
 
 
 def setup_demo_project(project_dir: Path, adapter: str) -> None:
-    """Copy demo template files and seed three backlog tasks.
+    """Copy demo template files, seed the backlog, and init a git repo.
 
     Args:
         project_dir: Destination directory (should be empty / temp dir).
@@ -404,24 +404,87 @@ def setup_demo_project(project_dir: Path, adapter: str) -> None:
     )
     (project_dir / ".sdd" / "runtime" / ".gitignore").write_text("*.pid\n*.log\ntasks.jsonl\n")
 
-    # Seed the three backlog tasks
+    # Seed the backlog tasks
     backlog_open = project_dir / ".sdd" / "backlog" / "open"
     for task in DEMO_TASKS:
         (backlog_open / task["filename"]).write_text(task["content"])
 
+    # Keep bernstein's runtime state (including per-agent worktrees under
+    # .sdd/worktrees/) out of git; the project files are what agents fix.
+    if not (project_dir / ".gitignore").exists():
+        (project_dir / ".gitignore").write_text(".sdd/\n__pycache__/\n*.pyc\n")
+
+    # Agent spawns run in per-task git worktrees (isolation is always on), which
+    # require a git repository with a HEAD commit. The demo project is a
+    # throwaway temp dir, so initialise it here (issue #2799).
+    _git_init_demo_repo(project_dir)
+
+
+def _git_init_demo_repo(project_dir: Path) -> None:
+    """Initialize the demo project as a git repo with an initial commit.
+
+    Uses a repo-local identity so the demo never depends on - or mutates - the
+    operator's global git config. Best-effort: if git is unavailable the demo
+    degrades to the same spawn failure it had before rather than crashing setup.
+
+    Args:
+        project_dir: Demo project root to initialise.
+    """
+    import subprocess
+
+    def _git(*args: str) -> None:
+        subprocess.run(["git", *args], cwd=str(project_dir), check=True, capture_output=True)
+
+    with suppress(OSError, subprocess.CalledProcessError):
+        _git("init", "-b", "main")
+        _git("config", "user.email", "demo@bernstein.local")
+        _git("config", "user.name", "Bernstein Demo")
+        _git("config", "commit.gpgsign", "false")
+        _git("add", "-A")
+        _git("commit", "-m", "Bernstein demo: Flask app with intentional bugs")
+
+
+def _process_group_of(pid: int) -> int:
+    """Return ``pid``'s process-group id, falling back to the pid itself.
+
+    On POSIX the demo's server, spawner and watchdog are session leaders
+    (``start_new_session=True``), so their pgid equals their pid; ``os.getpgid``
+    still resolves the real group for any child pid. On platforms without
+    ``getpgid`` (Windows) the pid doubles as the group handle that
+    :func:`reap_process_group` consumes.
+
+    Args:
+        pid: Process id to resolve a group for.
+
+    Returns:
+        The process-group id, or ``pid`` when it cannot be resolved.
+    """
+    getpgid = getattr(os, "getpgid", None)
+    if getpgid is None:
+        return pid
+    try:
+        return int(getpgid(pid))
+    except OSError:
+        return pid
+
 
 def _stop_demo_processes(project_dir: Path) -> None:
-    """Terminate server, spawner and watchdog started in project_dir.
+    """Reap the demo server, spawner, watchdog and their child processes.
+
+    Each tracked process is launched in its own session
+    (``start_new_session=True``), so the tracked pid leads a process group. A
+    lone SIGTERM to the leader leaves the orchestrator's mock-agent children
+    alive (issue #2799). This reaps the whole group with the standard
+    SIGTERM -> poll -> SIGKILL escalation and confirms the leader is gone
+    before removing its pid file.
 
     Args:
         project_dir: Demo project root whose .sdd/runtime/ holds PID files.
     """
+    from bernstein.core.config.platform_compat import process_alive, reap_process_group
+
     runtime_dir = project_dir / ".sdd" / "runtime"
-    for pid_filename, _label in (
-        ("watchdog.pid", "Watchdog"),
-        ("spawner.pid", "Spawner"),
-        ("server.pid", "Task server"),
-    ):
+    for pid_filename in ("watchdog.pid", "spawner.pid", "server.pid"):
         pid_file = runtime_dir / pid_filename
         if not pid_file.exists():
             continue
@@ -429,33 +492,58 @@ def _stop_demo_processes(project_dir: Path) -> None:
             pid = int(pid_file.read_text().strip())
         except (ValueError, OSError):
             continue
-        if is_alive(pid):
-            from bernstein.core.platform_compat import kill_process
-
-            kill_process(pid, sig=15)
+        if pid > 0 and process_alive(pid):
+            reap_process_group(_process_group_of(pid), grace_seconds=3.0)
         pid_file.unlink(missing_ok=True)
 
 
-def _print_demo_summary(project_dir: Path, server_url: str, elapsed_secs: float = 0.0) -> None:
-    """Print final demo summary: bugs fixed, files changed, cost, next steps.
+@dataclass(frozen=True)
+class _DemoOutcome:
+    """Task outcome of a demo run, counted against the seeded task set.
+
+    ``total`` is the seeded task count (a single source of truth), not the live
+    server list length, so retries that spawn fresh task ids cannot inflate the
+    denominator (issue #2799). ``done`` is clamped to ``total`` and ``failed`` is
+    the number of seeded bugs left unfixed.
+    """
+
+    done: int
+    failed: int
+    total: int
+    cost_usd: float
+
+    @property
+    def all_fixed(self) -> bool:
+        """Return True only when every seeded task reached ``done``."""
+        return self.total > 0 and self.done >= self.total
+
+
+def _fetch_demo_outcome(server_url: str, *, expected_total: int) -> _DemoOutcome:
+    """Snapshot the demo task outcome from the live server ``/status``.
+
+    Must be called while the task server is still alive - the demo tears it down
+    during cleanup, so a later query would read nothing.
 
     Args:
-        project_dir: Demo project root.
         server_url: Base URL of the demo task server.
-        elapsed_secs: Wall-clock seconds the orchestration took.
-    """
-    from rich.table import Table
+        expected_total: Number of tasks the demo seeded (the reporting
+            denominator).
 
+    Returns:
+        A :class:`_DemoOutcome` whose ``total`` is ``expected_total``, ``done``
+        is the number of done tasks clamped to that total, and ``failed`` is the
+        remaining unfixed count.
+    """
     tasks_data: list[dict[str, Any]] = []
-    total_cost: float = 0.0
+    total_cost = 0.0
     with suppress(Exception):
         resp = httpx.get(f"{server_url}/status", timeout=3.0, headers=auth_headers())
         if resp.status_code == 200:
             payload = resp.json()
             # /status returns tasks as {"count": N, "items": [...]}; tolerate a
             # bare list too. Iterating the dict form would yield its string keys
-            # and crash on ``t.get`` (the historical AttributeError), so unwrap
-            # to the items list and keep only dict rows.
+            # and crash on ``t.get`` (the historical AttributeError, #2075), so
+            # unwrap to the items list and keep only dict rows.
             raw_tasks = payload.get("tasks", [])
             if isinstance(raw_tasks, dict):
                 raw_tasks = raw_tasks.get("items", [])
@@ -463,9 +551,30 @@ def _print_demo_summary(project_dir: Path, server_url: str, elapsed_secs: float 
                 tasks_data = [t for t in raw_tasks if isinstance(t, dict)]
             total_cost = float(payload.get("total_cost_usd", 0.0) or 0.0)
 
-    done = sum(1 for t in tasks_data if t.get("status") == "done")
-    failed = sum(1 for t in tasks_data if t.get("status") == "failed")
-    total = len(tasks_data)
+    # Count done against the seeded set. A failed task spawns a retry task with a
+    # fresh id, so the live list can balloon past the seeded count (banner said
+    # 4, summary said 12). Clamp done to the seeded total and derive "not fixed"
+    # from it so banner, progress and summary never disagree.
+    done = min(sum(1 for t in tasks_data if t.get("status") == "done"), expected_total)
+    failed = max(expected_total - done, 0)
+    return _DemoOutcome(done=done, failed=failed, total=expected_total, cost_usd=total_cost)
+
+
+def _print_demo_summary(project_dir: Path, outcome: _DemoOutcome | None, elapsed_secs: float = 0.0) -> None:
+    """Print final demo summary: bugs fixed, files changed, cost, next steps.
+
+    Args:
+        project_dir: Demo project root.
+        outcome: Task outcome snapshot taken before cleanup, or None when no
+            snapshot was captured (e.g. an interrupted or crashed run).
+        elapsed_secs: Wall-clock seconds the orchestration took.
+    """
+    from rich.table import Table
+
+    done = outcome.done if outcome is not None else 0
+    failed = outcome.failed if outcome is not None else len(DEMO_TASKS)
+    total = outcome.total if outcome is not None else len(DEMO_TASKS)
+    total_cost = outcome.cost_usd if outcome is not None else 0.0
 
     elapsed_str = f"{elapsed_secs:.0f}s" if elapsed_secs > 0 else "\u2014"
 
@@ -489,7 +598,7 @@ def _print_demo_summary(project_dir: Path, server_url: str, elapsed_secs: float 
     # Governance story
     console.print(
         "\n[dim]Every agent decision was logged. "
-        "Run [bold]bernstein audit verify --merkle[/bold] to inspect the audit trail.[/dim]"
+        "Run [bold]bernstein audit verify --merkle-only[/bold] to inspect the audit trail.[/dim]"
     )
 
     # Primary CTA
@@ -634,6 +743,24 @@ def _emit_task_events(
     return done_count, failed_count
 
 
+def _demo_exit_code(outcome: _DemoOutcome | None, *, bootstrap_error: Exception | None) -> int:
+    """Map the demo outcome to a process exit code.
+
+    Args:
+        outcome: Task outcome snapshot, or None when none was captured.
+        bootstrap_error: The bootstrap exception if one was swallowed, else None.
+
+    Returns:
+        0 only when the bootstrap succeeded and every seeded task reached done;
+        1 on any failed task, a missing snapshot, or a crashed bootstrap.
+    """
+    if bootstrap_error is not None:
+        return 1
+    if outcome is None:
+        return 1
+    return 0 if outcome.all_fixed else 1
+
+
 @click.command("demo")
 @click.option(
     "--dry-run",
@@ -655,23 +782,24 @@ def _emit_task_events(
 )
 @click.option(
     "--timeout",
-    default=60,
+    default=120,
     show_default=True,
     help="Maximum seconds to wait for tasks to complete.",
 )
 def demo(dry_run: bool, real: bool, adapter: str | None, timeout: int) -> None:
-    """Zero-config demo: fix 4 bugs in a Flask app in under 60 seconds.
+    """Zero-config demo: fix 4 bugs in a Flask app with mock agents.
 
     \b
     Creates a temp Flask app with 4 intentional bugs, seeds fix tasks,
     then runs agents to resolve them - all while showing live progress.
-    No API key required in mock mode.
+    Each agent runs in its own git worktree, so the demo needs about a
+    minute or two to complete. No API key required in mock mode.
 
     \b
-      bernstein demo              # mock agents (no API key, ~30 seconds)
+      bernstein demo              # mock agents (no API key)
       bernstein demo --real       # real agents (requires API key, ~$0.15)
       bernstein demo --dry-run    # preview the plan without spawning
-      bernstein demo --real --timeout 120
+      bernstein demo --real --timeout 180
     """
     import tempfile
 
@@ -690,10 +818,12 @@ def demo(dry_run: bool, real: bool, adapter: str | None, timeout: int) -> None:
         detected = "mock"
         cost_estimate = "[green]free[/green] (simulated agents, no API calls)"
 
-    # Always print cost estimate before doing anything
+    # Always print cost estimate before doing anything. The task count is driven
+    # off len(DEMO_TASKS) - the same source the summary reports against - so the
+    # banner and summary can never disagree (issue #2799).
     console.print(
         f"\n[bold yellow]Cost estimate:[/bold yellow] "
-        f"{cost_estimate} (4 bug-fix tasks)\n"
+        f"{cost_estimate} ({len(DEMO_TASKS)} bug-fix tasks)\n"
         f"[dim]Adapter: {detected}  |  Mode: {'real' if real else 'demo'}  |  Timeout: {timeout}s[/dim]"
     )
 
@@ -726,38 +856,57 @@ def demo(dry_run: bool, real: bool, adapter: str | None, timeout: int) -> None:
     console.print(f"\n[dim]Creating demo project in {project_dir}\u2026[/dim]")
 
     setup_demo_project(project_dir, detected)
-    console.print("[green]\u2713[/green] Flask app with 4 intentional bugs created")
+    console.print(f"[green]\u2713[/green] Flask app with {len(DEMO_TASKS)} intentional bugs created")
     console.print(
-        "[green]\u2713[/green] 4 bug-fix tasks seeded: "
+        f"[green]\u2713[/green] {len(DEMO_TASKS)} bug-fix tasks seeded: "
         "off-by-one \u00b7 missing import \u00b7 wrong status code \u00b7 broken test"
     )
 
     server_url = f"http://127.0.0.1:{_DEMO_PORT}"
     orchestration_start = time.monotonic()
 
+    outcome: _DemoOutcome | None = None
+    bootstrap_error: Exception | None = None
     try:
-        # Bootstrap: start server + spawner in the demo project dir
+        # Bootstrap: start server + spawner in the demo project dir. The demo's
+        # work is the seeded backlog, so no goal is passed: a seeded goal would
+        # be shadowed by the non-empty backlog and leak the internal precedence
+        # WARNING into this first-run experience (issue #2799).
         console.print("\n[bold]Starting orchestration\u2026[/bold]")
         from bernstein.core.bootstrap import bootstrap_from_goal  # pyright: ignore[reportUnknownVariableType]
 
         bootstrap_from_goal(
-            goal="Fix the four bugs in the demo Flask app.",
+            goal="",
             workdir=project_dir,
             port=_DEMO_PORT,
             cli=detected,
         )
 
         _poll_demo_completion(server_url, orchestration_start + timeout)
-        console.print("[green]\u2713[/green] Orchestration finished")
-
+        # Snapshot the outcome while the server is still alive: cleanup below
+        # tears it down, so a query after that would read an empty list.
+        outcome = _fetch_demo_outcome(server_url, expected_total=len(DEMO_TASKS))
     except KeyboardInterrupt:
         console.print("\n[yellow]Interrupted.[/yellow]")
     except RuntimeError as exc:
         from bernstein.cli.errors import bootstrap_failed
 
         bootstrap_failed(exc).print()
+        bootstrap_error = exc
     finally:
         _stop_demo_processes(project_dir)
 
+    if outcome is not None and outcome.all_fixed:
+        console.print("[green]\u2713[/green] Orchestration finished")
+    else:
+        console.print("[yellow]![/yellow] Orchestration finished with unresolved tasks")
+
     elapsed = time.monotonic() - orchestration_start
-    _print_demo_summary(project_dir, server_url, elapsed_secs=elapsed)
+    _print_demo_summary(project_dir, outcome, elapsed_secs=elapsed)
+
+    # Exit code reflects the result: 0 only when every seeded task succeeded,
+    # nonzero on any failure or a crashed bootstrap, so a wrapper or CI smoke
+    # check cannot read a broken run as green (issue #2799).
+    exit_code = _demo_exit_code(outcome, bootstrap_error=bootstrap_error)
+    if exit_code != 0:
+        raise SystemExit(exit_code)

--- a/src/bernstein/core/orchestration/bootstrap.py
+++ b/src/bernstein/core/orchestration/bootstrap.py
@@ -1166,7 +1166,10 @@ def _bootstrap_from_goal_impl(
         console.print(agents_note)
 
     _icons = get_icons()
-    console.print(f"[green]{_icons.arrow_right}[/green] Goal: [bold]{goal[:80]}[/bold]")
+    # Callers that drive a pre-seeded backlog (e.g. the mock demo) pass no goal
+    # on purpose; don't print an empty "Goal:" line in that case.
+    if goal.strip():
+        console.print(f"[green]{_icons.arrow_right}[/green] Goal: [bold]{goal[:80]}[/bold]")
     try:
         from bernstein.core.complexity_advisor import ComplexityMode, suggest_goal_execution_mode
 

--- a/tests/unit/test_cli_demo.py
+++ b/tests/unit/test_cli_demo.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 from click.testing import CliRunner
 from rich.console import Console
 
+from bernstein.cli import run_confirm
 from bernstein.cli.main import (
     DEMO_TASKS,
     cli,
@@ -16,18 +17,59 @@ from bernstein.cli.main import (
 )
 
 
-def test_demo_summary_handles_status_tasks_dict_shape(tmp_path):
-    """GET /status returns tasks as {"count", "items"}; the summary must not crash.
+def _status_response(payload: dict) -> MagicMock:
+    """Build a fake httpx response returning ``payload`` from ``/status``."""
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = payload
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# _fetch_demo_outcome - one source of truth for the task count (issue #2799)
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_demo_outcome_denominator_is_seeded_count():
+    """Retries balloon the server list; the outcome still reports 4 as total.
+
+    Regression for issue #2799: failed tasks spawn retry tasks with fresh ids,
+    inflating ``/status`` to 12 rows, so a summary that counted the live list
+    printed ``0 / 12`` under a banner that promised 4.
+    """
+    payload = {
+        "total_cost_usd": 0.0,
+        "tasks": {"count": 12, "items": [{"status": "failed", "title": f"t{i}"} for i in range(12)]},
+    }
+    with patch.object(run_confirm.httpx, "get", return_value=_status_response(payload)):
+        outcome = run_confirm._fetch_demo_outcome("http://127.0.0.1:9999", expected_total=4)
+
+    assert outcome.total == 4
+    assert outcome.done == 0
+    assert outcome.failed == 4
+    assert not outcome.all_fixed
+
+
+def test_fetch_demo_outcome_all_done():
+    """Four done tasks yield done=4, failed=0, all_fixed True."""
+    payload = {"total_cost_usd": 0.25, "tasks": [{"status": "done"} for _ in range(4)]}
+    with patch.object(run_confirm.httpx, "get", return_value=_status_response(payload)):
+        outcome = run_confirm._fetch_demo_outcome("http://x", expected_total=4)
+
+    assert outcome.done == 4
+    assert outcome.failed == 0
+    assert outcome.total == 4
+    assert outcome.cost_usd == 0.25
+    assert outcome.all_fixed
+
+
+def test_fetch_demo_outcome_handles_status_tasks_dict_shape():
+    """GET /status returns tasks as {"count", "items"}; parsing must not crash.
 
     Regression for issue #2075: iterating the dict form yielded its string keys
     and raised ``AttributeError: 'str' object has no attribute 'get'``.
     """
-    from bernstein.cli import run_confirm
-
     payload = {
-        "total": 3,
-        "done": 1,
-        "failed": 1,
         "total_cost_usd": 0.5,
         "tasks": {
             "count": 3,
@@ -38,23 +80,142 @@ def test_demo_summary_handles_status_tasks_dict_shape(tmp_path):
             ],
         },
     }
-    resp = MagicMock()
-    resp.status_code = 200
-    resp.json.return_value = payload
+    with patch.object(run_confirm.httpx, "get", return_value=_status_response(payload)):
+        outcome = run_confirm._fetch_demo_outcome("http://127.0.0.1:9999", expected_total=4)
 
+    assert outcome.done == 1
+    assert outcome.cost_usd == 0.5
+
+
+# ---------------------------------------------------------------------------
+# _print_demo_summary - rendering + follow-up hint (issue #2799)
+# ---------------------------------------------------------------------------
+
+
+def _render_summary(outcome, tmp_path) -> str:
+    """Render the demo summary to a string buffer and return the output."""
     buf = io.StringIO()
-    rec_console = Console(file=buf, force_terminal=False, width=100)
-    with (
-        patch.object(run_confirm.httpx, "get", return_value=resp),
-        patch.object(run_confirm, "console", rec_console),
-    ):
-        run_confirm._print_demo_summary(tmp_path, "http://127.0.0.1:9999", elapsed_secs=12.0)
+    rec_console = Console(file=buf, force_terminal=False, width=200)
+    with patch.object(run_confirm, "console", rec_console):
+        run_confirm._print_demo_summary(tmp_path, outcome, elapsed_secs=12.0)
+    return buf.getvalue()
 
-    out = buf.getvalue()
-    # 1 done out of 3 total, rendered without raising.
-    assert "1" in out
-    assert "/ 3" in out
+
+def test_demo_summary_hint_uses_real_flag(tmp_path):
+    """The follow-up hint must name a flag that exists (``--merkle-only``).
+
+    Regression for issue #2799: the summary suggested ``audit verify --merkle``,
+    which errors with "No such option '--merkle'".
+    """
+    outcome = run_confirm._DemoOutcome(done=4, failed=0, total=4, cost_usd=0.0)
+    out = _render_summary(outcome, tmp_path)
+
+    assert "audit verify --merkle-only" in out
+    # No bare/broken --merkle: every occurrence must be the --merkle-only flag.
+    assert out.count("--merkle") == out.count("--merkle-only")
+
+
+def test_demo_summary_renders_consistent_count(tmp_path):
+    """Bugs-fixed row reports done/total against the seeded denominator."""
+    outcome = run_confirm._DemoOutcome(done=1, failed=3, total=4, cost_usd=0.5)
+    out = _render_summary(outcome, tmp_path)
+
+    assert "/ 4" in out
     assert "$0.5000" in out
+
+
+# ---------------------------------------------------------------------------
+# demo command - exit code reflects task outcomes (issue #2799)
+# ---------------------------------------------------------------------------
+
+
+def _invoke_demo_with_outcome(outcome, tmp_path):
+    """Invoke ``bernstein demo`` in mock mode with the heavy seams stubbed.
+
+    The bootstrap, poll, cleanup and outcome fetch are all patched so the
+    command exercises only its own control flow (banner, summary, exit code)
+    against a controlled ``outcome``.
+    """
+    runner = CliRunner()
+    with (
+        patch.object(run_confirm, "setup_demo_project"),
+        patch.object(run_confirm, "_poll_demo_completion"),
+        patch.object(run_confirm, "_stop_demo_processes"),
+        patch.object(run_confirm, "_fetch_demo_outcome", return_value=outcome),
+        patch("bernstein.core.bootstrap.bootstrap_from_goal"),
+        patch("tempfile.mkdtemp", return_value=str(tmp_path)),
+    ):
+        return runner.invoke(cli, ["demo", "--timeout", "1"])
+
+
+def test_demo_exits_nonzero_when_all_tasks_fail(tmp_path):
+    """100% task failure must not report success: exit code is nonzero."""
+    outcome = run_confirm._DemoOutcome(done=0, failed=4, total=4, cost_usd=0.0)
+    result = _invoke_demo_with_outcome(outcome, tmp_path)
+    assert result.exit_code != 0, result.output
+
+
+def test_demo_exits_nonzero_on_partial_failure(tmp_path):
+    """Any failed task exits nonzero, even when some tasks succeeded."""
+    outcome = run_confirm._DemoOutcome(done=3, failed=1, total=4, cost_usd=0.0)
+    result = _invoke_demo_with_outcome(outcome, tmp_path)
+    assert result.exit_code != 0, result.output
+
+
+def test_demo_exits_zero_when_all_tasks_succeed(tmp_path):
+    """Exit code is 0 only when every seeded task reached done."""
+    outcome = run_confirm._DemoOutcome(done=4, failed=0, total=4, cost_usd=0.0)
+    result = _invoke_demo_with_outcome(outcome, tmp_path)
+    assert result.exit_code == 0, result.output
+
+
+def test_demo_exits_nonzero_when_bootstrap_crashes(tmp_path):
+    """A crashed bootstrap must exit nonzero, not be swallowed to exit 0."""
+    runner = CliRunner()
+    with (
+        patch.object(run_confirm, "setup_demo_project"),
+        patch.object(run_confirm, "_poll_demo_completion"),
+        patch.object(run_confirm, "_stop_demo_processes"),
+        patch("bernstein.core.bootstrap.bootstrap_from_goal", side_effect=RuntimeError("boom")),
+        patch("tempfile.mkdtemp", return_value=str(tmp_path)),
+    ):
+        result = runner.invoke(cli, ["demo", "--timeout", "1"])
+    assert result.exit_code != 0, result.output
+
+
+# ---------------------------------------------------------------------------
+# _stop_demo_processes - reap the whole process group (issue #2799)
+# ---------------------------------------------------------------------------
+
+
+def test_stop_demo_processes_reaps_process_group(tmp_path):
+    """A tracked demo process (session leader) is reaped, its pid file removed.
+
+    Regression for issue #2799: a lone SIGTERM to the tracked leader left the
+    orchestrator and its mock-agent children alive after the demo returned.
+    """
+    import subprocess
+    import sys
+    import time
+
+    runtime = tmp_path / ".sdd" / "runtime"
+    runtime.mkdir(parents=True)
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(30)"],
+        start_new_session=True,
+    )
+    (runtime / "server.pid").write_text(str(proc.pid))
+    try:
+        run_confirm._stop_demo_processes(tmp_path)
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline and proc.poll() is None:
+            time.sleep(0.1)
+        assert proc.poll() is not None, "demo process was not reaped"
+        assert not (runtime / "server.pid").exists()
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait()
 
 
 # ---------------------------------------------------------------------------
@@ -126,6 +287,38 @@ def testsetup_demo_project_creates_app_py(tmp_path):
     """app.py should exist in the project root after setup."""
     setup_demo_project(tmp_path, "claude")
     assert (tmp_path / "app.py").exists()
+
+
+def test_setup_demo_project_initializes_git_repo_with_head(tmp_path):
+    """The demo project must be a git repo with a HEAD commit.
+
+    Per-task worktree isolation is always on (orchestrator hardcodes
+    use_worktrees=True), and ``git worktree add`` requires a repository with a
+    valid HEAD. Without this the mock demo failed every task (issue #2799).
+    """
+    import subprocess
+
+    setup_demo_project(tmp_path, "mock")
+
+    assert (tmp_path / ".git").is_dir()
+    head = subprocess.run(
+        ["git", "rev-parse", "--verify", "HEAD"],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+    )
+    assert head.returncode == 0, head.stderr
+
+    tracked = subprocess.run(
+        ["git", "ls-files"],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+    )
+    # The project files are tracked; bernstein runtime state is not, so the
+    # per-agent worktrees under .sdd/worktrees/ never pollute git.
+    assert "app.py" in tracked.stdout
+    assert ".sdd/" not in tracked.stdout
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_mock_adapter.py
+++ b/tests/unit/test_mock_adapter.py
@@ -261,3 +261,39 @@ class TestMockOrchestrator:
 
         task = _run(orch.process_one("qa"))
         assert task is None  # Only 1 QA task
+
+
+# ---------------------------------------------------------------------------
+# Production MockAgentAdapter default_model (issue #2799)
+# ---------------------------------------------------------------------------
+
+
+def test_mock_adapter_declares_non_claude_default_model() -> None:
+    """MockAgentAdapter must declare a non-Claude-tier default_model.
+
+    Regression for issue #2799: the spawn-time model gate refuses to spawn when
+    a Claude cascade tier (opus/sonnet/haiku) reaches a non-Claude adapter that
+    has no default_model, so ``bernstein demo`` failed every task. A declared
+    default lets the gate coerce the tier name instead of refusing.
+    """
+    from bernstein.adapters.mock import MockAgentAdapter
+    from bernstein.core.agents.spawner_warm_pool import _CLAUDE_TIER_MODELS
+
+    assert MockAgentAdapter.default_model
+    assert MockAgentAdapter.default_model not in _CLAUDE_TIER_MODELS
+
+
+def test_mock_default_model_coerces_claude_tier_instead_of_refusing() -> None:
+    """The model gate coerces a Claude tier to the mock default rather than raising."""
+    from bernstein.core.models import ModelConfig
+
+    from bernstein.adapters.mock import MockAgentAdapter
+    from bernstein.core.agents.spawner_warm_pool import _coerce_model_for_non_claude_adapter
+
+    selected = ModelConfig(model="sonnet", effort="high")
+    coerced = _coerce_model_for_non_claude_adapter(
+        selected,
+        adapter_name="mock",
+        adapter_default_model=MockAgentAdapter.default_model,
+    )
+    assert coerced.model == MockAgentAdapter.default_model


### PR DESCRIPTION
## What

`bernstein demo` (mock mode, the no-key first run) failed every task yet printed a green "Orchestration finished" and exited 0. This fixes the five distinct defects on the demo path so the demo actually completes its 4 fixes, reports one honest count, exits with a code that reflects the result, suggests a real command, and leaves nothing running.

Before / after a mock `bernstein demo`:

| | before | after |
|---|---|---|
| Bugs fixed | `0 / 12` | `4 / 4` |
| Exit code | `0` (on 100% failure) | `0` only when all 4 pass; `1` otherwise |
| Shadow-goal WARNING | leaked into output | gone |
| Follow-up hint | `audit verify --merkle` (errors) | `audit verify --merkle-only` |
| Leftover processes | server + orchestrator alive | reaped; port freed |

## Why

- Two blockers stopped the mock adapter from ever completing a task. First, `MockAgentAdapter` declared no `default_model`, so the Claude cascade tier selected for it (`sonnet`) hit the spawn-time model gate (`_coerce_model_for_non_claude_adapter`), which refuses to run a Claude tier on a non-Claude adapter with no default. Second, agent spawns run in per-task git worktrees (the orchestrator hardcodes `use_worktrees=True`), which require a git repo with a HEAD commit, but the temp demo project was never initialised, so `git worktree add` failed for every task.
- Exit 0 on total failure means any wrapper or CI smoke check that shells out to `bernstein demo` reads green on a broken run. The exit code was never tied to the outcome, and the `except RuntimeError` branch swallowed bootstrap crashes to exit 0 too.
- The banner hardcoded `4` while the summary counted the live server task list, which retries inflate to `12` (two sources of truth for one number).
- The demo seeded a backlog and also passed a goal; the non-empty backlog shadows the goal, so bootstrap printed its operator-facing precedence WARNING inside the first-run experience.
- The summary suggested `audit verify --merkle`, which does not exist (the real flag is `--merkle-only`).
- Cleanup sent a single graceful SIGTERM to each tracked leader and returned without waiting or escalating. The orchestrator is a session leader (`start_new_session=True`), so a lone SIGTERM to the leader never reached its mock-agent children; the server and orchestrator stayed alive on the demo port.

## How

- `MockAgentAdapter.default_model = "mock"` (a non-Claude-tier placeholder the mock ignores) so the model gate coerces the tier instead of refusing.
- `setup_demo_project` writes a `.gitignore` for `.sdd/` and initialises the project as a git repo with a repo-local identity and one commit, so worktree isolation can create per-task workspaces without depending on or mutating the operator's global git config.
- `demo` snapshots the outcome (`_fetch_demo_outcome`) while the server is still alive, prints the summary from it, and raises `SystemExit(1)` on any failed task or a crashed bootstrap. `_DemoOutcome` counts `done`/`total` against the seeded set (`len(DEMO_TASKS)`), and the banner lines now derive from the same source, so banner and summary cannot disagree.
- The demo passes no goal (the seeded backlog is the work), and `_bootstrap_from_goal_impl` no longer prints an empty `Goal:` line.
- The follow-up hint uses `--merkle-only`.
- `_stop_demo_processes` reaps the whole process group (`SIGTERM -> poll -> SIGKILL` via `reap_process_group`) and confirms the leader is gone before returning.
- The default `--timeout` rises to 120s so the now-real orchestration reliably finishes all four fixes.

Tests (`tests/unit/test_cli_demo.py`, `tests/unit/test_mock_adapter.py`):

- `test_mock_adapter_declares_non_claude_default_model` and `test_mock_default_model_coerces_claude_tier_instead_of_refusing` prove the gate coerces `sonnet` to the mock default instead of raising.
- `test_setup_demo_project_initializes_git_repo_with_head` asserts the project is a git repo with a valid HEAD and that `.sdd/` is untracked.
- `test_demo_exits_nonzero_when_all_tasks_fail`, `..._on_partial_failure`, `..._when_bootstrap_crashes`, and `test_demo_exits_zero_when_all_tasks_succeed` pin the exit code to the outcome.
- `test_fetch_demo_outcome_denominator_is_seeded_count` proves a 12-row server list still reports `total == 4`.
- `test_demo_summary_hint_uses_real_flag` asserts every `--merkle` occurrence is `--merkle-only`.
- `test_stop_demo_processes_reaps_process_group` spawns a real session-leader child and asserts it is reaped and its pid file removed.

Verified end to end: a real mock `bernstein demo` now ends `Bugs fixed 4 / 4`, exit 0, no shadow WARNING, `--merkle-only` hint, and no leftover processes (port 8055 free).

Closes #2799