### PR TITLE
fix(cli): persist the run auth token so out-of-process CLI monitors and the dashboard can authenticate

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -15,6 +15,7 @@ alwaysApply: false
 | `dataclass_helpers.py`      | Helpers for preserving dataclass instance types through updates |
 | `defaults.py`               | Centralized default values for the Bernstein orchestrator |
 | `instrumentation.py`        | Wave-3 per-agent instrumentation: LLM calls, tool calls, and conversation history |
+| `run_auth_token.py`         | Persist and read the auto-generated run Bearer token (issue #2794) |
 | `streaming_merge.py`        | Streaming task results for long-running agents (incremental merge) |
 | `admission/`                | Named resource pools with lease-backed admission (#2544) |
 | `agents/`                   | agents sub-package |

--- a/.goosehints
+++ b/.goosehints
@@ -16,6 +16,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `dataclass_helpers.py`      | Helpers for preserving dataclass instance types through updates |
 | `defaults.py`               | Centralized default values for the Bernstein orchestrator |
 | `instrumentation.py`        | Wave-3 per-agent instrumentation: LLM calls, tool calls, and conversation history |
+| `run_auth_token.py`         | Persist and read the auto-generated run Bearer token (issue #2794) |
 | `streaming_merge.py`        | Streaming task results for long-running agents (incremental merge) |
 | `admission/`                | Named resource pools with lease-backed admission (#2544) |
 | `agents/`                   | agents sub-package |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `dataclass_helpers.py`      | Helpers for preserving dataclass instance types through updates |
 | `defaults.py`               | Centralized default values for the Bernstein orchestrator |
 | `instrumentation.py`        | Wave-3 per-agent instrumentation: LLM calls, tool calls, and conversation history |
+| `run_auth_token.py`         | Persist and read the auto-generated run Bearer token (issue #2794) |
 | `streaming_merge.py`        | Streaming task results for long-running agents (incremental merge) |
 | `admission/`                | Named resource pools with lease-backed admission (#2544) |
 | `agents/`                   | agents sub-package |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `dataclass_helpers.py`      | Helpers for preserving dataclass instance types through updates |
 | `defaults.py`               | Centralized default values for the Bernstein orchestrator |
 | `instrumentation.py`        | Wave-3 per-agent instrumentation: LLM calls, tool calls, and conversation history |
+| `run_auth_token.py`         | Persist and read the auto-generated run Bearer token (issue #2794) |
 | `streaming_merge.py`        | Streaming task results for long-running agents (incremental merge) |
 | `admission/`                | Named resource pools with lease-backed admission (#2544) |
 | `agents/`                   | agents sub-package |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -16,6 +16,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `dataclass_helpers.py`      | Helpers for preserving dataclass instance types through updates |
 | `defaults.py`               | Centralized default values for the Bernstein orchestrator |
 | `instrumentation.py`        | Wave-3 per-agent instrumentation: LLM calls, tool calls, and conversation history |
+| `run_auth_token.py`         | Persist and read the auto-generated run Bearer token (issue #2794) |
 | `streaming_merge.py`        | Streaming task results for long-running agents (incremental merge) |
 | `admission/`                | Named resource pools with lease-backed admission (#2544) |
 | `agents/`                   | agents sub-package |

--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -27,6 +27,7 @@ import httpx
 
 from bernstein.cli.helpers import (
     SERVER_URL,
+    ServerAuthError,
     console,
     find_seed_file,
     print_banner,
@@ -1197,7 +1198,13 @@ def recap(archive: str, as_json: bool) -> None:
 
     Reads the task archive and prints a summary of what happened.
     """
-    data = server_get("/recap")
+    try:
+        data = server_get("/recap", raise_on_auth_error=True)
+    except ServerAuthError:
+        from bernstein.cli.errors import server_rejected_credentials
+
+        server_rejected_credentials().print()
+        raise SystemExit(1) from None
     if data is None:
         from bernstein.cli.errors import server_unreachable
 

--- a/src/bernstein/cli/commands/checkpoint_cmd.py
+++ b/src/bernstein/cli/commands/checkpoint_cmd.py
@@ -10,7 +10,7 @@ import click
 from rich.panel import Panel
 from rich.table import Table
 
-from bernstein.cli.helpers import console, server_get
+from bernstein.cli.helpers import console, require_server_reachable, server_get
 from bernstein.core.session import CheckpointState, save_checkpoint
 
 
@@ -56,9 +56,7 @@ def checkpoint_cmd(goal: str | None) -> None:
       bernstein checkpoint --goal X  # attach a goal label
     """
     # 1. Query task server
-    if server_get("/status") is None:
-        console.print("[red]Cannot reach task server.[/red] Is Bernstein running? Run [bold]bernstein[/bold] to start.")
-        raise SystemExit(1)
+    require_server_reachable()
 
     completed_ids = _fetch_task_ids("done")
     in_flight_ids = _fetch_task_ids("claimed") + _fetch_task_ids("in_progress")

--- a/src/bernstein/cli/commands/status_cmd.py
+++ b/src/bernstein/cli/commands/status_cmd.py
@@ -13,6 +13,7 @@ from typing import Any, cast
 import click
 
 from bernstein.cli.helpers import (
+    ServerAuthError,
     console,
     is_json,
     is_process_alive,
@@ -168,7 +169,17 @@ def status(as_json: bool, no_color: bool, view_mode: str | None) -> None:
     """
     from bernstein.core.view_mode import ViewMode, get_view_config, load_view_mode
 
-    data = server_get("/status")
+    try:
+        data = server_get("/status", raise_on_auth_error=True)
+    except ServerAuthError:
+        if as_json or is_json():
+            print_json({"error": "Server is running but rejected credentials"})
+        else:
+            console.print(
+                "[red]Server is running but rejected credentials.[/red] "
+                "Run [bold]bernstein[/bold] in this workspace, or set BERNSTEIN_AUTH_TOKEN to match the server."
+            )
+        raise SystemExit(1) from None
     if data is None:
         if as_json or is_json():
             print_json({"error": "Cannot reach task server"})

--- a/src/bernstein/cli/commands/wrap_up_cmd.py
+++ b/src/bernstein/cli/commands/wrap_up_cmd.py
@@ -13,7 +13,7 @@ import click
 from rich.panel import Panel
 from rich.table import Table
 
-from bernstein.cli.helpers import console, server_get
+from bernstein.cli.helpers import console, require_server_reachable, server_get
 from bernstein.core.session import WrapUpBrief, save_wrapup
 
 
@@ -223,9 +223,7 @@ def wrap_up(do_stop: bool, timeout: int) -> None:
     workdir = Path.cwd()
 
     # 1. Check server reachability
-    if server_get("/status") is None:
-        console.print("[red]Cannot reach task server.[/red] Is Bernstein running? Run [bold]bernstein[/bold] to start.")
-        raise SystemExit(1)
+    require_server_reachable()
 
     # 2. Gather tasks
     done_tasks = _fetch_tasks_by_status("done")

--- a/src/bernstein/cli/dashboard_polling.py
+++ b/src/bernstein/cli/dashboard_polling.py
@@ -29,15 +29,20 @@ _SPARK_CHARS = "▁▂▃▄▅▆▇█"
 
 
 def _auth_headers() -> dict[str, str]:
-    """Return Authorization header when ``BERNSTEIN_AUTH_TOKEN`` is set.
+    """Return the Authorization header for dashboard polling.
 
-    The TUI runs inside the main Bernstein process, so it inherits the
+    The TUI usually runs inside the main Bernstein process, so it inherits the
     token that ``_resolve_auth_token`` stashes into ``os.environ`` during
-    bootstrap (see ``core.server.server_launch``). Without this header the
-    SSO middleware rejects every request with 401, leaving the Tasks
-    panel empty.
+    bootstrap (see ``core.server.server_launch``). When it runs out-of-process
+    it falls back to the persisted run token file under ``.sdd/runtime``
+    (issue #2794). Without this header the SSO middleware rejects every
+    request with 401, leaving the Tasks panel empty.
     """
     token = os.environ.get("BERNSTEIN_AUTH_TOKEN")
+    if not token:
+        from bernstein.core.run_auth_token import read_run_auth_token
+
+        token = read_run_auth_token(Path.cwd())
     if token:
         return {"Authorization": f"Bearer {token}"}
     return {}

--- a/src/bernstein/cli/helpers.py
+++ b/src/bernstein/cli/helpers.py
@@ -118,9 +118,29 @@ def print_startup_banner() -> None:
     print_banner()
 
 
-def auth_headers() -> dict[str, str]:
-    """Return Authorization header dict if BERNSTEIN_AUTH_TOKEN is set."""
+def auth_headers(workdir: Path | None = None) -> dict[str, str]:
+    """Return the Authorization header dict for talking to the local server.
+
+    Resolution order (issue #2794):
+
+    1. The ``BERNSTEIN_AUTH_TOKEN`` env var, when the caller inherited it.
+    2. The persisted run token file under ``.sdd/runtime`` (written by the
+       launcher when it auto-generates a token), so a monitor invoked from a
+       shell that never inherited the launcher env still authenticates.
+
+    Args:
+        workdir: Workspace to resolve the token file against. Defaults to the
+            current working directory - the workspace the monitor runs in.
+
+    Returns:
+        ``{"Authorization": "Bearer <token>"}`` when a token is found, else an
+        empty dict.
+    """
     token = os.environ.get("BERNSTEIN_AUTH_TOKEN")
+    if not token:
+        from bernstein.core.run_auth_token import read_run_auth_token
+
+        token = read_run_auth_token(workdir or Path.cwd())
     if token:
         return {"Authorization": f"Bearer {token}"}
     return {}
@@ -165,30 +185,97 @@ def persist_server_port(port: int, workdir: Path | None = None) -> Path:
     return path
 
 
-def server_get(path: str) -> dict[str, Any] | None:
-    """GET from the task server.  Returns None if server is unreachable."""
+class ServerAuthError(Exception):
+    """The task server is reachable but rejected the request's credentials.
+
+    Raised by :func:`server_get` / :func:`server_post` (opt-in via
+    ``raise_on_auth_error``) when the server answers ``401``/``403``. It lets a
+    monitor command distinguish "server up, bad creds" from "server
+    unreachable" and print a credentials-specific diagnostic instead of the
+    misleading "Is Bernstein running?" (issue #2794).
+    """
+
+    def __init__(self, status_code: int) -> None:
+        self.status_code = status_code
+        super().__init__(f"server rejected credentials (HTTP {status_code})")
+
+
+def server_get(path: str, *, raise_on_auth_error: bool = False) -> dict[str, Any] | None:
+    """GET from the task server.  Returns None if server is unreachable.
+
+    Args:
+        path: Request path appended to the resolved server URL.
+        raise_on_auth_error: When ``True``, a ``401``/``403`` from a reachable
+            server raises :class:`ServerAuthError` instead of returning
+            ``None``, so callers can report a credentials problem distinctly
+            from an unreachable server. Defaults to ``False`` to preserve the
+            ``None``-on-any-error contract existing callers rely on.
+    """
     try:
         resp = httpx.get(f"{resolve_server_url()}{path}", timeout=5.0, headers=auth_headers())
         resp.raise_for_status()
         return resp.json()  # type: ignore[no-any-return]
     except httpx.ConnectError:
         return None
+    except httpx.HTTPStatusError as exc:
+        if raise_on_auth_error and exc.response.status_code in (401, 403):
+            raise ServerAuthError(exc.response.status_code) from exc
+        console.print(f"[red]Server error:[/red] {exc}")
+        return None
     except Exception as exc:
         console.print(f"[red]Server error:[/red] {exc}")
         return None
 
 
-def server_post(path: str, payload: dict[str, Any]) -> dict[str, Any] | None:
-    """POST to the task server.  Returns None if server is unreachable."""
+def server_post(path: str, payload: dict[str, Any], *, raise_on_auth_error: bool = False) -> dict[str, Any] | None:
+    """POST to the task server.  Returns None if server is unreachable.
+
+    Args:
+        path: Request path appended to the resolved server URL.
+        payload: JSON body to send.
+        raise_on_auth_error: When ``True``, a ``401``/``403`` from a reachable
+            server raises :class:`ServerAuthError` instead of returning
+            ``None``. Defaults to ``False`` to preserve the existing contract.
+    """
     try:
         resp = httpx.post(f"{resolve_server_url()}{path}", json=payload, timeout=5.0, headers=auth_headers())
         resp.raise_for_status()
         return resp.json()  # type: ignore[no-any-return]
     except httpx.ConnectError:
         return None
+    except httpx.HTTPStatusError as exc:
+        if raise_on_auth_error and exc.response.status_code in (401, 403):
+            raise ServerAuthError(exc.response.status_code) from exc
+        console.print(f"[red]Server error:[/red] {exc}")
+        return None
     except Exception as exc:
         console.print(f"[red]Server error:[/red] {exc}")
         return None
+
+
+def require_server_reachable() -> None:
+    """Gate a monitor command behind a usable ``/status`` probe.
+
+    Distinguishes an unreachable server from one that is up but rejecting the
+    caller's credentials (issue #2794), printing the matching diagnostic and
+    exiting with status ``1`` in either failure case. Returns normally when the
+    server answers ``/status`` successfully.
+
+    Raises:
+        SystemExit: With code ``1`` when the server is unreachable or rejects
+            the request's credentials.
+    """
+    try:
+        reachable = server_get("/status", raise_on_auth_error=True)
+    except ServerAuthError:
+        console.print(
+            "[red]Server is running but rejected credentials.[/red] "
+            "Run [bold]bernstein[/bold] in this workspace, or set BERNSTEIN_AUTH_TOKEN to match the server."
+        )
+        raise SystemExit(1) from None
+    if reachable is None:
+        console.print("[red]Cannot reach task server.[/red] Is Bernstein running? Run [bold]bernstein[/bold] to start.")
+        raise SystemExit(1)
 
 
 def read_pid(path: str) -> int | None:

--- a/src/bernstein/cli/utils/errors.py
+++ b/src/bernstein/cli/utils/errors.py
@@ -100,6 +100,20 @@ def server_unreachable() -> BernsteinError:
     )
 
 
+def server_rejected_credentials() -> BernsteinError:
+    """Return a BernsteinError when the server is up but rejects credentials.
+
+    Distinct from :func:`server_unreachable` so a ``401`` does not misreport a
+    running server as down (issue #2794).
+    """
+    return BernsteinError(
+        what="The Bernstein task server rejected the request's credentials",
+        why="The server is running but the client presented no matching auth token",
+        fix="Run monitor commands from the run's workspace, or set BERNSTEIN_AUTH_TOKEN to match the server",
+        exit_code=ExitCode.AUTH,
+    )
+
+
 def no_seed_or_goal() -> BernsteinError:
     """Return a BernsteinError when neither seed file nor goal is provided."""
     return BernsteinError(

--- a/src/bernstein/core/defaults.py
+++ b/src/bernstein/core/defaults.py
@@ -53,6 +53,14 @@ lets Copilot's own router pick the best available model."""
 SDD_SERVER_PORT: Final[str] = ".sdd/runtime/server.port"
 """Workspace-relative file containing the active task-server port."""
 
+SDD_AUTH_TOKEN: Final[str] = ".sdd/runtime/auth.token"
+"""Workspace-relative ``0600`` file holding the active run's Bearer token.
+
+Written on startup when the launcher auto-generates a token so out-of-process
+CLI monitors (``status``/``recap``/``checkpoint``) and the TUI poller can
+authenticate to the local server without inheriting the launcher env. The
+token *value* must never be logged (see #2762 / #2763)."""
+
 COPILOT_CLAUDE_TIER_MODELS: Final[frozenset[str]] = frozenset({"opus", "sonnet", "haiku"})
 """Claude cascade tier names that are not valid Copilot model ids; any that reach
 the Copilot adapter are remapped to ``COPILOT_DEFAULT_MODEL``."""

--- a/src/bernstein/core/orchestration/bootstrap.py
+++ b/src/bernstein/core/orchestration/bootstrap.py
@@ -598,7 +598,7 @@ def bootstrap_from_seed(
 
     # Resolve cluster-aware settings
     bind_host = "0.0.0.0" if remote else _resolve_bind_host()
-    auth_token = _resolve_auth_token()
+    auth_token = _resolve_auth_token(workdir)
     server_url = _resolve_server_url(port)
 
     # ── Compact bootstrap: all steps on one screen ──
@@ -1287,7 +1287,7 @@ def _bootstrap_from_goal_impl(
     _register_ci_parsers()
 
     bind_host = _resolve_bind_host()
-    auth_token = _resolve_auth_token()
+    auth_token = _resolve_auth_token(workdir)
     server_url = _resolve_server_url(port)
 
     with Status(f"[bold]Starting task server on {bind_host}:{port}...[/bold]", console=console):

--- a/src/bernstein/core/run_auth_token.py
+++ b/src/bernstein/core/run_auth_token.py
@@ -1,0 +1,106 @@
+"""Persist and read the auto-generated run Bearer token (issue #2794).
+
+When the launcher starts a server without an operator-configured
+``BERNSTEIN_AUTH_TOKEN`` it auto-generates an ephemeral token. Historically
+that token lived only in the launcher process environment, so any CLI monitor
+invoked from a *different* shell (``status``/``recap``/``checkpoint``) or the
+TUI poller could not authenticate and the server answered ``401`` - which the
+client misreported as "server unreachable".
+
+This module gives the token a workspace-local home: a ``0600`` file under
+``.sdd/runtime`` that the launcher writes and out-of-process clients read as a
+fallback. The file is created with restrictive permissions *from the start*
+(never widen-then-narrow) following the same pattern as
+:func:`bernstein.core.security.audit.load_or_create_audit_key`, and the token
+value is never logged (see #2762 / #2763).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+from pathlib import Path
+
+from bernstein.core.defaults import SDD_AUTH_TOKEN
+
+logger = logging.getLogger(__name__)
+
+_TOKEN_FILE_MODE = 0o600
+
+
+def run_auth_token_path(workdir: Path) -> Path:
+    """Return the token file path for *workdir*.
+
+    Args:
+        workdir: Project root that owns the ``.sdd`` workspace.
+
+    Returns:
+        The workspace-relative ``.sdd/runtime/auth.token`` path resolved
+        against *workdir*.
+    """
+    return workdir / SDD_AUTH_TOKEN
+
+
+def persist_run_auth_token(workdir: Path, token: str) -> Path | None:
+    """Write *token* to the run token file with ``0600`` permissions.
+
+    The file is created restrictive-from-the-start via a temporary sibling
+    opened with ``O_WRONLY|O_CREAT|O_EXCL`` and mode ``0600``, then atomically
+    renamed over the target. This never exposes a widened-permission window
+    and never leaves readers observing a half-written token. A fresh token
+    supersedes any previous session's file. The token value is never logged.
+
+    Args:
+        workdir: Project root that owns the ``.sdd`` workspace.
+        token: The Bearer token to persist.
+
+    Returns:
+        The path written, or ``None`` if persistence failed (best-effort:
+        the launcher still keeps the token in its own environment).
+    """
+    target = run_auth_token_path(workdir)
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        logger.warning("could not create runtime dir for auth token: %s", exc)
+        return None
+
+    tmp = target.with_name(f"{target.name}.{os.getpid()}.tmp")
+    try:
+        fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_EXCL, _TOKEN_FILE_MODE)
+    except OSError as exc:
+        logger.warning("could not create auth token file: %s", exc)
+        return None
+    try:
+        os.write(fd, token.encode("utf-8"))
+    finally:
+        os.close(fd)
+    try:
+        os.replace(str(tmp), str(target))
+    except OSError as exc:
+        logger.warning("could not finalize auth token file: %s", exc)
+        with contextlib.suppress(OSError):
+            os.unlink(str(tmp))
+        return None
+    return target
+
+
+def read_run_auth_token(workdir: Path | None = None) -> str | None:
+    """Read the persisted run token, if present.
+
+    Args:
+        workdir: Project root to resolve the token file against. Defaults to
+            the current working directory - the workspace a CLI monitor runs
+            in.
+
+    Returns:
+        The stripped token string, or ``None`` when the file is absent,
+        empty, or unreadable.
+    """
+    path = run_auth_token_path(workdir if workdir is not None else Path.cwd())
+    try:
+        token = path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    return token or None

--- a/src/bernstein/core/server/server_launch.py
+++ b/src/bernstein/core/server/server_launch.py
@@ -133,14 +133,19 @@ def ensure_sdd(workdir: Path, *, model: str | None = None) -> bool:
             f"# Bernstein workspace config\nserver_port: 8052\nmax_workers: 4\n{model_line}default_effort: max\n"
         )
 
-    # .gitignore for runtime dir - ensure session.json is always listed.
+    # .gitignore for runtime dir - ensure secret/state files are always
+    # listed. ``auth.token`` holds the run's Bearer credential (issue #2794)
+    # and must never be committed (secret-at-rest, #2762).
     gi_path = workdir / ".sdd" / "runtime" / ".gitignore"
+    _runtime_gitignore_required = ("*.pid", "*.log", "tasks.jsonl", "session.json", "auth.token")
     if not gi_path.exists():
-        gi_path.write_text("*.pid\n*.log\ntasks.jsonl\nsession.json\n")
+        gi_path.write_text("\n".join(_runtime_gitignore_required) + "\n")
     else:
         existing = gi_path.read_text()
-        if "session.json" not in existing:
-            gi_path.write_text(existing.rstrip("\n") + "\nsession.json\n")
+        existing_lines = {line.strip() for line in existing.splitlines()}
+        missing = [entry for entry in _runtime_gitignore_required if entry not in existing_lines]
+        if missing:
+            gi_path.write_text(existing.rstrip("\n") + "\n" + "\n".join(missing) + "\n")
 
     # Apply any pending on-disk state migrations on load. On a fresh install
     # this stamps the latest schema version; on an existing install it walks
@@ -623,7 +628,7 @@ def _resolve_bind_host() -> str:
     return os.environ.get("BERNSTEIN_BIND_HOST", "127.0.0.1")
 
 
-def _resolve_auth_token() -> str | None:
+def _resolve_auth_token(workdir: Path | None = None) -> str | None:
     """Resolve the Bearer token used by bootstrap to talk to its own server.
 
     Precedence:
@@ -631,9 +636,21 @@ def _resolve_auth_token() -> str | None:
         2. Ephemeral auto-generated token when auth is enabled but no token is
            set and no opt-out is active. The generated token is written into
            ``os.environ`` so both the server subprocess (which inherits env in
-           ``_start_server``) and the bootstrap client see the same value.
+           ``_start_server``) and the bootstrap client see the same value, and
+           - when *workdir* is given - also persisted to a ``0600`` file under
+           ``.sdd/runtime`` so out-of-process CLI monitors (``status`` /
+           ``recap`` / ``checkpoint``) and the TUI poller can authenticate
+           without inheriting the launcher env (issue #2794).
         3. ``None`` when ``BERNSTEIN_AUTH_DISABLED=1`` - the middleware
            short-circuits in that mode so no header is required.
+
+    Args:
+        workdir: Project root whose ``.sdd/runtime`` receives the persisted
+            token file. When ``None`` the token is kept in the environment
+            only (back-compat with callers that cannot supply a workspace).
+
+    Returns:
+        The resolved Bearer token, or ``None`` when auth is disabled.
     """
     existing = os.environ.get("BERNSTEIN_AUTH_TOKEN")
     if existing:
@@ -646,9 +663,19 @@ def _resolve_auth_token() -> str | None:
 
     token = secrets.token_urlsafe(32)
     os.environ["BERNSTEIN_AUTH_TOKEN"] = token
+    persisted = False
+    if workdir is not None:
+        from bernstein.core.run_auth_token import persist_run_auth_token
+
+        # Best-effort: the token also lives in os.environ, so a persistence
+        # failure never blocks the run - it only degrades out-of-process
+        # monitor auth back to the pre-#2794 behaviour.
+        persisted = persist_run_auth_token(workdir, token) is not None
+    where = "persisted 0600 to .sdd/runtime for local CLI monitors" if persisted else "kept in this process env only"
     logger.info(
-        "Auto-generated BERNSTEIN_AUTH_TOKEN for this session (not persisted; "
+        "Auto-generated BERNSTEIN_AUTH_TOKEN for this session (%s; "
         "set BERNSTEIN_AUTH_TOKEN to pin or BERNSTEIN_AUTH_DISABLED=1 to opt out).",
+        where,
     )
     return token
 

--- a/tests/unit/test_issue_2794_detached_auth.py
+++ b/tests/unit/test_issue_2794_detached_auth.py
@@ -1,0 +1,217 @@
+"""Regression tests for issue #2794.
+
+A detached run auto-generates a Bearer token that historically lived only in
+the launcher process environment. Out-of-process CLI monitors then hit ``401``
+and misreported it as "server unreachable". These tests pin the fix:
+
+* the launcher persists the auto-generated token to a ``0600`` file under
+  ``.sdd/runtime``;
+* :func:`bernstein.cli.helpers.auth_headers` falls back to that file when the
+  caller's env has no ``BERNSTEIN_AUTH_TOKEN``;
+* ``server_get`` distinguishes a ``401`` (server up, bad creds) from an
+  unreachable server, so monitor commands print distinct diagnostics.
+"""
+
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from bernstein.cli import helpers
+from bernstein.core.defaults import SDD_AUTH_TOKEN
+from bernstein.core.run_auth_token import (
+    persist_run_auth_token,
+    read_run_auth_token,
+    run_auth_token_path,
+)
+
+
+def test_persist_run_auth_token_creates_0600_file(tmp_path: Path) -> None:
+    written = persist_run_auth_token(tmp_path, "s3cr3t-token")
+
+    assert written == run_auth_token_path(tmp_path)
+    assert written is not None
+    mode = stat.S_IMODE(written.stat().st_mode)
+    assert mode == 0o600, f"expected 0600, got {oct(mode)}"
+    assert written.read_text(encoding="utf-8") == "s3cr3t-token"
+
+
+def test_persist_then_read_round_trips(tmp_path: Path) -> None:
+    persist_run_auth_token(tmp_path, "round-trip-token")
+    assert read_run_auth_token(tmp_path) == "round-trip-token"
+
+
+def test_read_run_auth_token_missing_returns_none(tmp_path: Path) -> None:
+    assert read_run_auth_token(tmp_path) is None
+
+
+def test_ensure_sdd_gitignores_auth_token(tmp_path: Path) -> None:
+    """The token file must be git-ignored so the secret never lands in a commit (#2762)."""
+    from bernstein.core.server_launch import ensure_sdd
+
+    ensure_sdd(tmp_path)
+    gi = (tmp_path / ".sdd" / "runtime" / ".gitignore").read_text(encoding="utf-8")
+    assert "auth.token" in gi
+
+
+def test_ensure_sdd_appends_auth_token_to_existing_gitignore(tmp_path: Path) -> None:
+    from bernstein.core.server_launch import ensure_sdd
+
+    runtime = tmp_path / ".sdd" / "runtime"
+    runtime.mkdir(parents=True)
+    (runtime / ".gitignore").write_text("session.json\n", encoding="utf-8")
+
+    ensure_sdd(tmp_path)
+    gi = (runtime / ".gitignore").read_text(encoding="utf-8")
+    assert "auth.token" in gi
+    assert "session.json" in gi
+
+
+def test_persist_overwrites_previous_session_token(tmp_path: Path) -> None:
+    persist_run_auth_token(tmp_path, "old-token")
+    persist_run_auth_token(tmp_path, "new-token")
+    assert read_run_auth_token(tmp_path) == "new-token"
+    assert stat.S_IMODE(run_auth_token_path(tmp_path).stat().st_mode) == 0o600
+
+
+def test_auth_headers_falls_back_to_token_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A fresh shell with no env token still authenticates via the on-disk token."""
+    monkeypatch.delenv("BERNSTEIN_AUTH_TOKEN", raising=False)
+    monkeypatch.chdir(tmp_path)
+    persist_run_auth_token(tmp_path, "file-token")
+
+    assert helpers.auth_headers() == {"Authorization": "Bearer file-token"}
+
+
+def test_auth_headers_env_wins_over_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("BERNSTEIN_AUTH_TOKEN", "env-token")
+    persist_run_auth_token(tmp_path, "file-token")
+
+    assert helpers.auth_headers() == {"Authorization": "Bearer env-token"}
+
+
+def test_auth_headers_none_when_no_token(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BERNSTEIN_AUTH_TOKEN", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    assert helpers.auth_headers() == {}
+
+
+def _make_401_response() -> httpx.Response:
+    request = httpx.Request("GET", "http://127.0.0.1:8052/status")
+    return httpx.Response(401, request=request, json={"detail": "Missing or invalid Authorization header"})
+
+
+def test_server_get_raises_server_auth_error_on_401(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("BERNSTEIN_SERVER_URL", raising=False)
+    monkeypatch.delenv("BERNSTEIN_AUTH_TOKEN", raising=False)
+
+    def fake_get(url: str, **kwargs: object) -> httpx.Response:
+        return _make_401_response()
+
+    with patch.object(helpers.httpx, "get", fake_get), pytest.raises(helpers.ServerAuthError):
+        helpers.server_get("/status", raise_on_auth_error=True)
+
+
+def test_server_get_returns_none_on_unreachable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("BERNSTEIN_SERVER_URL", raising=False)
+
+    def fake_get(url: str, **kwargs: object) -> httpx.Response:
+        raise httpx.ConnectError("connection refused")
+
+    with patch.object(helpers.httpx, "get", fake_get):
+        assert helpers.server_get("/status", raise_on_auth_error=True) is None
+
+
+def test_server_get_401_without_optin_stays_none(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Back-compat: the 69 existing callers must keep receiving ``None`` on 401."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("BERNSTEIN_SERVER_URL", raising=False)
+
+    def fake_get(url: str, **kwargs: object) -> httpx.Response:
+        return _make_401_response()
+
+    with patch.object(helpers.httpx, "get", fake_get):
+        assert helpers.server_get("/status") is None
+
+
+def test_resolve_auth_token_persists_to_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BERNSTEIN_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("BERNSTEIN_AUTH_DISABLED", raising=False)
+
+    from bernstein.core.server_launch import _resolve_auth_token
+
+    token = _resolve_auth_token(tmp_path)
+
+    assert token is not None
+    token_file = tmp_path / SDD_AUTH_TOKEN
+    assert token_file.read_text(encoding="utf-8") == token
+    assert stat.S_IMODE(token_file.stat().st_mode) == 0o600
+    # And still exported to env for the in-process server + client.
+    import os
+
+    assert os.environ.get("BERNSTEIN_AUTH_TOKEN") == token
+
+
+def test_status_command_distinguishes_401_from_unreachable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 401 prints a credentials-specific message, not "Is Bernstein running?"."""
+    from click.testing import CliRunner
+
+    from bernstein.cli.commands import status_cmd
+
+    runner = CliRunner()
+
+    def raise_auth(path: str, **kwargs: object) -> None:
+        raise helpers.ServerAuthError(401)
+
+    with patch.object(status_cmd, "server_get", raise_auth):
+        auth_result = runner.invoke(status_cmd.status, [])
+
+    def return_none(path: str, **kwargs: object) -> None:
+        return None
+
+    with patch.object(status_cmd, "server_get", return_none):
+        unreachable_result = runner.invoke(status_cmd.status, [])
+
+    assert auth_result.exit_code == 1
+    assert unreachable_result.exit_code == 1
+    combined_auth = auth_result.output.lower()
+    combined_unreachable = unreachable_result.output.lower()
+    assert "credential" in combined_auth or "rejected" in combined_auth
+    assert "is bernstein running" not in combined_auth
+    assert "is bernstein running" in combined_unreachable
+
+
+def test_recap_command_distinguishes_401_from_unreachable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``bernstein recap`` reports a 401 distinctly from an unreachable server."""
+    from click.testing import CliRunner
+
+    from bernstein.cli.commands import advanced_cmd
+
+    runner = CliRunner()
+
+    def raise_auth(path: str, **kwargs: object) -> None:
+        raise helpers.ServerAuthError(401)
+
+    with patch.object(advanced_cmd, "server_get", raise_auth):
+        auth_result = runner.invoke(advanced_cmd.recap, [])
+
+    def return_none(path: str, **kwargs: object) -> None:
+        return None
+
+    with patch.object(advanced_cmd, "server_get", return_none):
+        unreachable_result = runner.invoke(advanced_cmd.recap, [])
+
+    assert auth_result.exit_code != 0
+    assert unreachable_result.exit_code != 0
+    assert "credential" in auth_result.output.lower() or "rejected" in auth_result.output.lower()
+    assert "credential" not in unreachable_result.output.lower()


### PR DESCRIPTION
## What

A detached run auto-generates a Bearer token but previously kept it only in the launcher process environment. Any monitor invoked from a different shell (`status`, `recap`, `checkpoint`) and the TUI dashboard poller then received a `401`, which the client misreported as `Cannot reach task server. Is Bernstein running?` even though the server was up and answering.

This PR gives the token a workspace-local home and teaches the clients to use it, and it distinguishes a `401` from an unreachable server.

- Persist the auto-generated token to a `0600` file at `.sdd/runtime/auth.token`, created restrictive-from-the-start via `O_CREAT|O_EXCL` and atomically renamed into place (same create-restrictive pattern as `load_or_create_audit_key`). The token value is never logged, and the runtime `.gitignore` now lists `auth.token` so the secret is never committed.
- `auth_headers` (CLI) and the TUI dashboard poller fall back to reading that file when `BERNSTEIN_AUTH_TOKEN` is not in the caller env, so monitors authenticate from any workspace shell.
- `server_get` / `server_post` gain an opt-in `raise_on_auth_error` flag that raises `ServerAuthError` on a reachable-but-`401`/`403` server. `status`, `recap`, and `checkpoint` now print a credentials-specific message instead of the misleading "server down" one. The default `None`-on-any-error contract is unchanged for the other ~65 callers.

## Why

- The documented monitor commands were unusable from any shell other than the exact launcher process, and the error actively misdirected operators to restart a server that was already running and merely rejecting an absent credential.
- In the detached-run flow the launcher process exits, taking the only copy of the token with it; an on-disk `0600` token file survives so follow-up commands still authenticate.
- The token file must not reintroduce the secret-at-rest / secret-in-log problems tracked in #2762 / #2763, hence the `0600`-from-the-start create, the `.gitignore` entry, and never logging the value.

## How (including the test)

New regression test `tests/unit/test_issue_2794_detached_auth.py`:

- `test_auth_headers_falls_back_to_token_file` - a shell with no env token still authenticates via the on-disk token (acceptance a).
- `test_auth_headers_env_wins_over_file` - env token keeps precedence.
- `test_persist_run_auth_token_creates_0600_file` / `test_persist_overwrites_previous_session_token` - the file is `0600` and a fresh token supersedes a prior session's.
- `test_ensure_sdd_gitignores_auth_token` / `..._appends_...` - the secret is git-ignored on fresh and existing workspaces.
- `test_server_get_raises_server_auth_error_on_401` vs `test_server_get_returns_none_on_unreachable` - `401` and unreachable are distinct; `test_server_get_401_without_optin_stays_none` pins the unchanged default contract.
- `test_resolve_auth_token_persists_to_workspace` - the launcher writes the `0600` token file and still exports to env.
- `test_status_command_distinguishes_401_from_unreachable` / `test_recap_command_...` - a `401` yields a credentials message, not "Is Bernstein running?".

```
uv run pytest tests/unit/test_issue_2794_detached_auth.py -q
# pre-fix:  5 failed, 7 passed (fallback/persist/401-message not yet implemented)
# post-fix: 15 passed
```

Also green: `test_server_launch.py`, `test_cli_server_url.py`, `test_bootstrap.py`, `test_recap.py`, `test_env_isolation.py`, `test_auth_middleware_defaults.py`, `test_status_cmd_openclaw_bridge.py`, `test_operator_surface_imports.py`. `ruff check` + `ruff format --check` clean on all touched files; `pyright` clean on the new module.

## Scope / what remains

This fixes the out-of-process monitor lockout (issue Symptom A) - the minimal safe delta the issue endorses. It does not yet fix the browser dashboard entry (issue Symptom B): opening the URL printed by `bernstein dashboard` still lands on a bare `401` in the default auto-token configuration. That fix touches the `SSOAuthMiddleware` / `DashboardAuthMiddleware` ordering (or requires serving a GET login page), and the pass-through posture it depends on (`resolve_dashboard_posture`) is only enforced in the `bernstein gui` serve path, not the main `bernstein run` path - so broadly exempting `/dashboard` from the global auth layer would expose dashboard data on non-loopback binds. It is deferred to a follow-up with its own review rather than bundled into this monitor-auth fix.

Addresses #2794.
