### PR TITLE
fix(core): preserve and fail-mark agent work when merge-back fails instead of force-deleting it

### DIFF
--- a/src/bernstein/core/agents/spawner_merge.py
+++ b/src/bernstein/core/agents/spawner_merge.py
@@ -537,10 +537,13 @@ def merge_worktree_branch(
                 ", ".join(result.conflicting_files),
             )
         else:
-            logger.warning("Merge failed for %s: %s", session_id, result.error)
+            # issue #2792: a non-conflict merge-back failure discards committed
+            # work and blocks the task; it is an error-level event, not a soft
+            # warning, so a run that is silently losing output is visible.
+            logger.error("Merge failed for %s: %s", session_id, result.error)
         return result
     except Exception as exc:
-        logger.warning("Merge failed for %s: %s", session_id, exc)
+        logger.error("Merge failed for %s: %s", session_id, exc)
         return MergeResult(success=False, conflicting_files=[], error=str(exc))
 
 

--- a/src/bernstein/core/git/worktree.py
+++ b/src/bernstein/core/git/worktree.py
@@ -437,6 +437,61 @@ def _count_unmerged_commits(repo_root: Path, branch: str, base: str = "main") ->
         return -1 if _branch_exists(repo_root, branch) else 0
 
 
+def _count_orphan_commits(repo_root: Path, branch: str) -> int:
+    """Return how many commits on *branch* are reachable from no other branch.
+
+    These are the commits that ``git branch -D <branch>`` would orphan (make
+    unreachable and gc-eligible). Computed as
+    ``git rev-list <branch> --not --exclude=<branch> --branches --count`` so a
+    branch whose work is already merged into ``main`` *or any other local
+    branch* (the operator may run on a feature branch) reports ``0`` and is
+    safe to delete without preservation - avoiding a false positive on the
+    success path.
+
+    Unlike :func:`_count_unmerged_commits` this does not assume a single
+    ``main`` baseline, which is why it is used by :meth:`WorktreeManager.cleanup`
+    (invoked on every branch delete, including successful merges) rather than
+    only by the startup stale sweep.
+
+    Returns the real count, ``0`` when the branch is gone or reachable
+    elsewhere, and ``-1`` when the branch still exists but the count could not
+    be computed. Callers treat any non-zero result, including ``-1``, as
+    "preserve" so committed work is never silently dropped.
+
+    Args:
+        repo_root: Repository root directory.
+        branch: Branch name to check (e.g. ``agent/<sid>``).
+
+    Returns:
+        Number of orphan commits; ``0`` when nothing is at risk; ``-1`` when
+        the check was inconclusive but the branch exists.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-list", branch, "--not", f"--exclude={branch}", "--branches", "--count"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=_GRAVEYARD_GIT_TIMEOUT_S,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+        logger.debug("orphan rev-list for %s failed: %s", branch, exc)
+        return -1 if _branch_exists(repo_root, branch) else 0
+    if result.returncode != 0:
+        logger.debug("orphan rev-list for %s exited %d: %s", branch, result.returncode, result.stderr.strip())
+        return -1 if _branch_exists(repo_root, branch) else 0
+    raw = result.stdout.strip()
+    if not raw:
+        return 0
+    try:
+        return int(raw)
+    except ValueError:
+        logger.debug("orphan rev-list for %s produced non-integer output: %r", branch, raw)
+        return -1 if _branch_exists(repo_root, branch) else 0
+
+
 def _resolve_ref(repo_root: Path, ref: str) -> str | None:
     """Resolve *ref* to a SHA via ``git rev-parse``; return ``None`` on failure."""
     try:
@@ -891,6 +946,32 @@ class WorktreeManager:
                     "Residual worktree directory could not be removed for %s: %s",
                     session_id,
                     worktree_path,
+                )
+
+        # 1c. Preserve committed-but-unmerged work to the graveyard before the
+        #     force branch delete (issue #2792). The step-0 salvage only
+        #     captures *uncommitted* state, so a worker that committed its work
+        #     and then had its merge-back fail would otherwise lose that commit
+        #     to ``git branch -D``. When the branch still exists and holds
+        #     commits reachable from no other branch, rescue them to
+        #     ``refs/graveyard/<sid>-<ts>`` + a bundle. Gated on the same flag
+        #     as the uncommitted salvage; a merged branch (the success path)
+        #     reports zero orphan commits and is deleted as before.
+        if self._salvage_on_cleanup:
+            try:
+                orphan = _count_orphan_commits(self.repo_root, branch_name)
+                if orphan != 0:
+                    logger.warning(
+                        "Branch %s has %s committed-but-unmerged commit(s); preserving to graveyard before delete",
+                        branch_name,
+                        orphan if orphan > 0 else "an unknown number of",
+                    )
+                    preserve_branch_to_graveyard(self.repo_root, session_id, branch=branch_name)
+            except Exception as exc:  # defensive - never let preservation block cleanup
+                logger.warning(
+                    "Committed-work graveyard preservation crashed for %s (continuing cleanup): %s",
+                    session_id,
+                    exc,
                 )
 
         # 2. Delete the branch

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -2983,10 +2983,14 @@ def _reap_and_cleanup_session(
     skip_merge: bool,
     _completion_data: CompletionData | None,
     cache_diff_lines: int,
-) -> tuple[bool, int]:
+) -> tuple[bool, int, bool]:
     """Reap agent, handle merge, cleanup worktree.
 
-    Returns (cache_verified, cache_diff_lines).
+    Returns ``(cache_verified, cache_diff_lines, merge_failed)`` where
+    ``merge_failed`` is True only when a merge-back was attempted and failed
+    for a non-conflict reason (issue #2792). The caller routes that case
+    through the bounded reopen/permanent-fail budget instead of leaving the
+    task on the open queue for uncapped retry.
     """
     merge_result: MergeResult | None = orch._spawner.reap_completed_agent(
         session,
@@ -3026,8 +3030,31 @@ def _reap_and_cleanup_session(
     # and verify it against a detached run. Fail-open: never blocks completion.
     _capture_review_diff(orch, task, session)
 
-    orch._spawner.cleanup_worktree(session.id)
-    return cache_verified, cache_diff_lines
+    # issue #2792: a merge-back that failed for a *non-conflict* reason (an
+    # untracked operator-tree file, the forbidden-path guard, unrelated
+    # histories, a missing branch) leaves the worker's only committed copy on
+    # the agent/<id> branch. ``cleanup_worktree`` force-deletes both the
+    # worktree and that branch, so gating it on merge success preserves the
+    # committed work for inspection or a resolver. Conflicts are handled by
+    # ``_handle_merge_result`` (a resolver task) and a merge that was
+    # intentionally skipped (approval-gate PR path) is not a failure; both
+    # still clean up as before.
+    merge_failed = (
+        not skip_merge and merge_result is not None and not merge_result.success and not merge_result.conflicting_files
+    )
+    if merge_failed:
+        assert merge_result is not None  # narrowed above
+        logger.error(
+            "Merge-back failed for task %s (session %s); preserving worktree and "
+            "branch agent/%s so the committed work is not force-deleted: %s",
+            task.id,
+            session.id,
+            session.id,
+            merge_result.error or "unknown reason",
+        )
+    else:
+        orch._spawner.cleanup_worktree(session.id)
+    return cache_verified, cache_diff_lines, merge_failed
 
 
 def _capture_review_diff(orch: Any, task: Task, session: AgentSession) -> None:
@@ -3116,7 +3143,19 @@ def _handle_merge_result(
     """Handle merge conflicts and return whether merge succeeded."""
     if merge_result is None or merge_result.success:
         return True
-    if not merge_result.conflicting_files or skip_merge:
+    if skip_merge:
+        return False
+    if not merge_result.conflicting_files:
+        # issue #2792: non-conflict merge-back failure (untracked operator-tree
+        # file, forbidden-path guard, unrelated histories, missing branch). The
+        # worker's only committed copy is preserved on agent/<id> by the caller;
+        # surface the failure loudly so a run does not report a healthy state
+        # while work is being held back.
+        orch._post_bulletin(
+            "alert",
+            f"merge-back failed (non-conflict) for task {task.id}: "
+            f"{merge_result.error or 'unknown reason'} - worktree/branch preserved for recovery",
+        )
         return False
     create_conflict_resolution_task(
         task,
@@ -3785,6 +3824,7 @@ def _process_single_completed_task(
     cache_verified = False
     cache_diff_lines = 0
     qg_result: Any = None
+    merge_failed = False
 
     # DEFECT 30 FIX: the alive-exit /complete path runs the janitor+verdict
     # action here. Log at INFO so a silent no-op in the orchestrator tick
@@ -3837,7 +3877,7 @@ def _process_single_completed_task(
         _record_bandit_outcome(orch, task, session, janitor_passed)
 
         skip_merge = _evaluate_approval_gate(orch, task, session, completion_data, janitor_passed)
-        cache_verified, cache_diff_lines = _reap_and_cleanup_session(
+        cache_verified, cache_diff_lines, merge_failed = _reap_and_cleanup_session(
             orch,
             task,
             session,
@@ -3868,7 +3908,16 @@ def _process_single_completed_task(
 
     _record_evolution_completion(orch, task, session, task_m, cost_usd, janitor_passed)
 
-    _apply_janitor_verdict_action(orch, task, janitor_passed)
+    # issue #2792: when the worker's own work passed the janitor but the
+    # merge-back failed for a non-conflict reason, the task must not silently
+    # return to the open queue for uncapped retry. Route it through the same
+    # bounded reopen/permanent-fail budget as a janitor FAIL. A janitor FAIL
+    # takes precedence (it already reopens/fails) so the two paths never both
+    # act on the same completion.
+    if janitor_passed and merge_failed:
+        _apply_merge_failure_action(orch, task)
+    else:
+        _apply_janitor_verdict_action(orch, task, janitor_passed)
 
 
 _JANITOR_REOPEN_MAX_DEFAULT = 2
@@ -3975,6 +4024,89 @@ def _apply_janitor_verdict_action(orch: Any, task: Task, janitor_passed: bool) -
             return
         logger.info(
             "janitor_verdict_action: task=%s verdict=FAIL action=permanent_fail reason=reopen_budget_exhausted",
+            task.id,
+        )
+
+
+def _apply_merge_failure_action(orch: Any, task: Task) -> None:
+    """Route a non-conflict merge-back failure through the bounded retry budget.
+
+    Issue #2792: a merge-back that failed for a non-conflict reason leaves the
+    worker's committed work only on ``agent/<id>`` (preserved by
+    :func:`_reap_and_cleanup_session`) and the task DONE-but-unmerged. Without
+    this the claim is released back to the open queue and the same merge fails
+    on every subsequent worker with no cap. Reopen the task under the same
+    bounded budget as a janitor FAIL (``BERNSTEIN_JANITOR_REOPEN_MAX``, shared
+    ``metadata['janitor_reopen_count']``) and permanently fail it once the
+    budget is spent, so the loop terminates and the failure is visible instead
+    of silently burning workers.
+
+    Args:
+        orch: Orchestrator instance.
+        task: The completed task whose merge-back failed for a non-conflict
+            reason.
+    """
+    server_url: str | None = getattr(orch._config, "server_url", None)
+    if not server_url:
+        logger.error(
+            "merge_failure_action: task=%s action=skip reason=no_server_url",
+            task.id,
+        )
+        return
+
+    max_cycles = _janitor_reopen_max()
+    prior_cycles = int(task.metadata.get("janitor_reopen_count", 0) or 0)
+
+    if prior_cycles < max_cycles:
+        cycle = prior_cycles + 1
+        try:
+            resp = orch._client.post(
+                f"{server_url}/tasks/{task.id}/reopen",
+                json={"reason": f"merge-back failed (non-conflict); bounded retry (reopen cycle {cycle}/{max_cycles})"},
+            )
+            resp.raise_for_status()
+        except Exception as exc:
+            logger.error(
+                "merge_failure_action: task=%s action=reopen cycle=%d/%d FAILED: %s",
+                task.id,
+                cycle,
+                max_cycles,
+                exc,
+            )
+            return
+        # Allow the re-completed task to be verified again on the next
+        # completion instead of being skipped as already-processed.
+        try:
+            orch._processed_done_tasks.pop(task.id, None)
+        except Exception:  # pragma: no cover - defensive, dict-like expected
+            logger.debug("merge_failure_action: could not clear processed marker for %s", task.id)
+        logger.warning(
+            "merge_failure_action: task=%s action=reopen cycle=%d/%d reason=merge_back_failed",
+            task.id,
+            cycle,
+            max_cycles,
+        )
+    else:
+        try:
+            resp = orch._client.post(
+                f"{server_url}/tasks/{task.id}/fail",
+                json={
+                    "reason": (
+                        f"merge_back_failed: non-conflict merge-back failed after "
+                        f"{prior_cycles} reopen cycle(s) (max {max_cycles})"
+                    )
+                },
+            )
+            resp.raise_for_status()
+        except Exception as exc:
+            logger.error(
+                "merge_failure_action: task=%s action=permanent_fail reason=merge_back_failed FAILED: %s",
+                task.id,
+                exc,
+            )
+            return
+        logger.error(
+            "merge_failure_action: task=%s action=permanent_fail reason=merge_back_failed_budget_exhausted",
             task.id,
         )
 

--- a/tests/unit/test_mergeback_failure_2792.py
+++ b/tests/unit/test_mergeback_failure_2792.py
@@ -1,0 +1,306 @@
+"""Regression tests for issue #2792.
+
+A worker that commits its work in a worktree and then hits a *non-conflict*
+merge-back failure (an untracked operator-tree file, the forbidden-path guard,
+unrelated histories, a missing branch) must not have its worktree and
+``agent/<id>`` branch force-deleted, and its task must not be silently returned
+to the open queue for uncapped retry.
+
+These tests pin three behaviours:
+
+* ``_reap_and_cleanup_session`` skips ``cleanup_worktree`` when a merge-back
+  failed (preserving the only committed copy on ``agent/<id>``) and still runs
+  it on merge success.
+* ``_apply_merge_failure_action`` routes the failure through the bounded
+  reopen/permanent-fail budget rather than leaving the task open forever.
+* ``WorktreeManager.cleanup`` preserves committed-but-unmerged work to the
+  graveyard before ``git branch -D`` when cleanup does eventually run.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from bernstein.core.git.git_pr import MergeResult
+from bernstein.core.git.worktree import WorktreeManager
+from bernstein.core.tasks.models import AgentSession, Task, TaskStatus
+from bernstein.core.tasks.task_lifecycle import (
+    _apply_merge_failure_action,
+    _reap_and_cleanup_session,
+)
+
+
+class _FakeResponse:
+    def raise_for_status(self) -> None:
+        return None
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.posts: list[tuple[str, dict[str, Any]]] = []
+
+    def post(self, url: str, json: dict[str, Any] | None = None, **_kwargs: Any) -> _FakeResponse:
+        self.posts.append((url, json or {}))
+        return _FakeResponse()
+
+
+class _FakeSpawner:
+    """Records whether cleanup ran and returns a canned merge result."""
+
+    def __init__(self, merge_result: MergeResult | None) -> None:
+        self._merge_result = merge_result
+        self.cleanup_called = False
+
+    def reap_completed_agent(
+        self,
+        session: AgentSession,
+        *,
+        skip_merge: bool = False,
+        defer_cleanup: bool = False,
+    ) -> MergeResult | None:
+        return self._merge_result
+
+    def get_worktree_path(self, _session_id: str) -> Path | None:
+        return None
+
+    def cleanup_worktree(self, _session_id: str) -> None:
+        self.cleanup_called = True
+
+
+def _make_task() -> Task:
+    return Task(
+        id="task-2792",
+        title="Create hello.txt",
+        description="Write hello world",
+        role="backend",
+        status=TaskStatus.DONE,
+    )
+
+
+def _make_session() -> AgentSession:
+    return AgentSession(
+        id="writer-8f6311cf",
+        role="backend",
+        pid=4242,
+        task_ids=["task-2792"],
+        status="working",
+        exit_code=0,
+    )
+
+
+def _make_orch(spawner: _FakeSpawner, tmp_path: Path) -> SimpleNamespace:
+    return SimpleNamespace(
+        _spawner=spawner,
+        _workdir=tmp_path,
+        _config=SimpleNamespace(ab_test=False),
+        _post_bulletin=lambda *_args, **_kwargs: None,
+    )
+
+
+def test_reap_preserves_worktree_on_nonconflict_merge_failure(tmp_path: Path) -> None:
+    """A non-conflict merge failure must NOT force-delete the worktree/branch."""
+    merge_result = MergeResult(
+        success=False,
+        conflicting_files=[],
+        error="untracked working tree file hello.txt would be overwritten",
+    )
+    spawner = _FakeSpawner(merge_result)
+    orch = _make_orch(spawner, tmp_path)
+
+    _cache_verified, _cache_diff, merge_failed = _reap_and_cleanup_session(
+        orch,
+        _make_task(),
+        _make_session(),
+        None,
+        True,  # janitor_passed - the worker's own work passed
+        False,  # skip_merge
+        None,
+        0,
+    )
+
+    assert merge_failed is True
+    assert spawner.cleanup_called is False, "cleanup_worktree must be gated on merge success so agent/<id> survives"
+
+
+def test_reap_cleans_worktree_on_merge_success(tmp_path: Path) -> None:
+    """On a clean merge, cleanup still runs (no behaviour change)."""
+    merge_result = MergeResult(success=True, conflicting_files=[], merge_diff="ok")
+    spawner = _FakeSpawner(merge_result)
+    orch = _make_orch(spawner, tmp_path)
+
+    _cache_verified, _cache_diff, merge_failed = _reap_and_cleanup_session(
+        orch,
+        _make_task(),
+        _make_session(),
+        None,
+        True,
+        False,
+        None,
+        1,
+    )
+
+    assert merge_failed is False
+    assert spawner.cleanup_called is True
+
+
+def test_reap_cleans_worktree_when_merge_skipped(tmp_path: Path) -> None:
+    """skip_merge (approval-gate PR path) still cleans up - not a merge failure."""
+    spawner = _FakeSpawner(None)
+    orch = _make_orch(spawner, tmp_path)
+
+    _cache_verified, _cache_diff, merge_failed = _reap_and_cleanup_session(
+        orch,
+        _make_task(),
+        _make_session(),
+        None,
+        True,
+        True,  # skip_merge
+        None,
+        0,
+    )
+
+    assert merge_failed is False
+    assert spawner.cleanup_called is True
+
+
+def _make_verdict_orch(client: _FakeClient) -> SimpleNamespace:
+    return SimpleNamespace(
+        _config=SimpleNamespace(server_url="http://127.0.0.1:8052"),
+        _client=client,
+        _processed_done_tasks={"task-2792": None},
+    )
+
+
+def test_merge_failure_reopens_under_bounded_budget(caplog: pytest.LogCaptureFixture) -> None:
+    """First merge-back failure reopens the same task (bounded), not an open-queue drop."""
+    client = _FakeClient()
+    orch = _make_verdict_orch(client)
+    task = _make_task()
+
+    with caplog.at_level(logging.WARNING, logger="bernstein.core.tasks.task_lifecycle"):
+        _apply_merge_failure_action(orch, task)
+
+    assert len(client.posts) == 1
+    url, body = client.posts[0]
+    assert url.endswith("/tasks/task-2792/reopen")
+    assert "merge" in body["reason"].lower()
+    assert "task-2792" not in orch._processed_done_tasks
+    assert "merge_failure_action: task=task-2792 action=reopen cycle=1/2" in caplog.text
+
+
+def test_merge_failure_permanent_fails_when_budget_exhausted(caplog: pytest.LogCaptureFixture) -> None:
+    """Once the reopen budget is spent the task is permanently failed, never re-queued."""
+    client = _FakeClient()
+    orch = _make_verdict_orch(client)
+    task = _make_task()
+    task.metadata["janitor_reopen_count"] = 2  # default budget already spent
+
+    with caplog.at_level(logging.ERROR, logger="bernstein.core.tasks.task_lifecycle"):
+        _apply_merge_failure_action(orch, task)
+
+    assert len(client.posts) == 1
+    url, body = client.posts[0]
+    assert url.endswith("/tasks/task-2792/fail")
+    assert "merge" in body["reason"].lower()
+    assert "merge_failure_action: task=task-2792 action=permanent_fail" in caplog.text
+
+
+# --- committed-but-unmerged graveyard preservation (real git) ---------------
+
+
+def _run(cmd: list[str], cwd: Path) -> None:
+    subprocess.run(cmd, cwd=cwd, check=True, capture_output=True, text=True, encoding="utf-8")
+
+
+@pytest.fixture
+def repo_with_committed_worktree(tmp_path: Path) -> tuple[Path, str]:
+    """Real repo whose ``agent/<id>`` worktree holds a committed, unmerged change."""
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _run(["git", "init", "-b", "main"], repo_root)
+    _run(["git", "config", "user.email", "test@example.com"], repo_root)
+    _run(["git", "config", "user.name", "Test User"], repo_root)
+    _run(["git", "config", "commit.gpgsign", "false"], repo_root)
+    (repo_root / "README.md").write_text("seed\n", encoding="utf-8")
+    _run(["git", "add", "README.md"], repo_root)
+    _run(["git", "commit", "-m", "seed"], repo_root)
+
+    session_id = "committed-session"
+    worktree_path = repo_root / ".sdd" / "worktrees" / session_id
+    worktree_path.parent.mkdir(parents=True, exist_ok=True)
+    _run(["git", "worktree", "add", "-b", f"agent/{session_id}", str(worktree_path)], repo_root)
+    # Commit the work inside the worktree - clean tree, but a commit that is
+    # reachable from no other branch.
+    (worktree_path / "hello.txt").write_text("hello from agent\n", encoding="utf-8")
+    _run(["git", "add", "hello.txt"], worktree_path)
+    _run(["git", "commit", "-m", "add hello.txt"], worktree_path)
+    return repo_root, session_id
+
+
+def test_cleanup_preserves_committed_unmerged_work_to_graveyard(
+    repo_with_committed_worktree: tuple[Path, str],
+) -> None:
+    """cleanup() must graveyard committed-but-unmerged work before branch -D."""
+    repo_root, session_id = repo_with_committed_worktree
+    tip_sha = subprocess.run(
+        ["git", "rev-parse", f"agent/{session_id}"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+    ).stdout.strip()
+
+    mgr = WorktreeManager(repo_root=repo_root, salvage_on_cleanup=True, salvage_push=False)
+    mgr.cleanup(session_id)
+
+    # The agent branch is gone (force-deleted), but the commit survives in the
+    # graveyard ref + bundle.
+    refs = (
+        subprocess.run(
+            ["git", "for-each-ref", "--format=%(refname) %(objectname)", "refs/graveyard/"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            check=True,
+        )
+        .stdout.strip()
+        .splitlines()
+    )
+    assert len(refs) == 1, f"expected one graveyard ref, got {refs!r}"
+    ref_name, ref_sha = refs[0].split()
+    assert ref_name.startswith(f"refs/graveyard/{session_id}-")
+    assert ref_sha == tip_sha, "graveyard ref must point at the committed work"
+
+    bundles = list((repo_root / ".sdd" / "graveyard").glob(f"{session_id}-*.bundle"))
+    assert len(bundles) == 1
+    assert bundles[0].stat().st_size > 0
+
+
+def test_cleanup_merged_branch_creates_no_graveyard(
+    repo_with_committed_worktree: tuple[Path, str],
+) -> None:
+    """When the branch is already merged, cleanup must NOT create graveyard refs."""
+    repo_root, session_id = repo_with_committed_worktree
+    # Merge the agent branch into main so its commit is reachable elsewhere.
+    _run(["git", "merge", "--no-ff", "-m", "merge", f"agent/{session_id}"], repo_root)
+
+    mgr = WorktreeManager(repo_root=repo_root, salvage_on_cleanup=True, salvage_push=False)
+    mgr.cleanup(session_id)
+
+    refs = subprocess.run(
+        ["git", "for-each-ref", "--format=%(refname)", "refs/graveyard/"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+    ).stdout.strip()
+    assert refs == "", f"merged branch must not be graveyarded, got {refs!r}"


### PR DESCRIPTION
## What

Fixes #2792. A worker that committed its work in its worktree and then hit a **non-conflict** merge-back failure (an untracked operator-tree file, the forbidden-path guard, unrelated histories, a missing branch) had its worktree and `agent/<id>` branch force-deleted (the only committed copy), while the task stayed open for uncapped retry, so the same failure repeated on every subsequent worker. It was logged at WARNING only, with `errors=0`.

## Why

Three failures in sequence in the reap-and-cleanup path:

1. `_reap_and_cleanup_session` called `cleanup_worktree` unconditionally, so a failed merge-back still ran `git worktree remove --force` + `git branch -D agent/<id>`, discarding the committed work. The existing salvage step only captures **uncommitted** state, so a committed-but-unmerged worktree was never salvaged.
2. The non-conflict branch of `_handle_merge_result` returned `False` with no task-state change, so the claim was released back to the open queue and re-claimed with no cycle cap.
3. `merge_worktree_branch` logged the failure at WARNING with no bulletin, so a run silently burning workers looked healthy.

## How

- **Gate cleanup on merge success** (`task_lifecycle._reap_and_cleanup_session`): a non-conflict merge-back failure now skips `cleanup_worktree`, preserving the worktree and `agent/<id>` branch that hold the committed work. Conflicts (resolver task) and intentionally-skipped merges (approval-gate PR path) clean up as before.
- **Preserve committed-but-unmerged work** (`WorktreeManager.cleanup`): before the force `git branch -D`, commits reachable from no other branch are rescued to `refs/graveyard/<sid>-<ts>` + a bundle, reusing the existing graveyard machinery. A new `_count_orphan_commits` uses branch reachability (not a single `main` baseline), so a merged branch reports zero on the success path — including feature-branch operation — and no graveyard refs are created for merged work. This also protects the partial-work-save reap path in `agent_lifecycle`.
- **Bounded task-state handling** (`_apply_merge_failure_action`): a non-conflict merge failure now routes through the same bounded reopen/permanent-fail budget as a janitor FAIL (`BERNSTEIN_JANITOR_REOPEN_MAX`, shared `janitor_reopen_count`), so the task cannot re-enter the open queue for uncapped retry and terminates in a failed state once the budget is spent. A janitor FAIL still takes precedence so the two paths never both act on one completion.
- **Surface it**: the non-conflict merge-failure log is raised to error level and an alert bulletin is posted.

### Tests

`tests/unit/test_mergeback_failure_2792.py` (7 tests):

- `_reap_and_cleanup_session` with a non-conflict `MergeResult(success=False, conflicting_files=[])` does **not** call `cleanup_worktree` (branch preserved) and returns `merge_failed=True`; still cleans up on merge success and on `skip_merge`.
- `_apply_merge_failure_action` reopens under the bounded budget on the first failure and permanently fails once the budget is spent (never an uncapped open-queue drop).
- Real-git: `WorktreeManager.cleanup` graveyards a committed-but-unmerged branch (ref + bundle point at the committed tip) and creates **no** graveyard ref for a branch already merged into main.

Pre-fix: the reap/cleanup tests fail (`_apply_merge_failure_action` did not exist; `cleanup_worktree` ran unconditionally; no graveyard for committed work). Post-fix: `7 passed`.

Regression runs (all green): `test_worktree_salvage`, `test_worktree_graveyard`, `test_janitor_reopen`, `test_conflict_resolution`, `test_worktree`, `test_spawner`, `test_chaos`, `test_orchestrator`, `test_task_lifecycle`, `test_review_board_*`, `test_streaming_merge`, `test_drain_merge`, `test_abandon_lifecycle`.
