### PR TITLE
ci(docker): build multi-arch amd64 and arm64 images

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -90,6 +90,9 @@ jobs:
             type=semver,pattern={{major}},value=${{ steps.ref.outputs.ref }}
             type=raw,value=latest,enable=${{ !contains(steps.ref.outputs.version, '-') }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
@@ -98,6 +101,7 @@ jobs:
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## What
Builds and pushes the container image for both linux/amd64 and linux/arm64, so `docker pull` resolves a matching manifest on Apple Silicon and other arm64 hosts instead of failing with "no matching manifest for linux/arm64/v8".

## How
Adds a `docker/setup-qemu-action` step (arm64 emulation on the amd64 runner) and `platforms: linux/amd64,linux/arm64` on the existing `docker/build-push-action` step in publish-docker.yml. Regenerated docs/operations/ci-topology.md in the same commit (required for any workflow change).

## Why
Completes the image fix started in #2829 (which fixed the default command and added a foreground serve mode). Since publish-docker.yml is dispatched at release time, the v3.8.3 image itself ships multi-arch.

Closes #2803.