### PR TITLE
chore(release): v3.8.3

### DIFF
--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bernstein",
-  "version": "3.8.2",
+  "version": "3.8.3",
   "description": "Multi-agent orchestration for CLI coding agents. Spawn parallel agents, verify their work, and merge results.",
   "author": {
     "name": "chernistry",

--- a/docs/release-notes/v3.8.3.md
+++ b/docs/release-notes/v3.8.3.md
@@ -1,0 +1,44 @@
+# v3.8.3
+
+A bug-fix release. Most of this wave came out of running the published wheel end to end with a free local model, which surfaced a chain of "green status, no artifact" defects across adapter selection, run verification, and the observability surface. Nothing here changes a public API; upgrade in place.
+
+## Adapter selection and routing
+
+- Startup adapter detection now covers the full adapter registry and states when an explicit adapter is pinned instead of claiming auto-routing (#2779).
+- An explicit adapter selection is no longer overridden by model-name inference: a route id like `openai/gpt-oss-20b:free` under a pinned qwen run no longer hijacks the spawn to another adapter (#2776).
+- Adapter selection in the seed file and `--cli` now validates against the live registry rather than three separate stale allowlists, so every registered adapter is actually selectable (#2826).
+- The qwen adapter stops passing a flag qwen-code removed, which broke spawns whenever a Tavily key was set (#2766); zero-config spawn works for adapters that pick the model server-side (#2753).
+
+## Run verification and correctness
+
+- `path_exists` completion signals are verified against the operator checkout, not the agent's ephemeral worktree, so a gitignored or unmerged file no longer reports the task done with nothing delivered (#2778).
+- Running on the repository default branch now fails fast with an actionable message and reports the run as unhealthy, instead of discarding every agent's work and printing a clean summary (#2780).
+- The scheduled dependency scan no longer audits the orchestrator's own tool venv or injects dozens of foreign upgrade tasks into a scoped run; it is scoped to the target repo's declared manifests, skips its own first tick, and can be turned off (#2825).
+- The recovery watchdog now launches from a runnable module, so it actually starts from the published wheel instead of failing silently (#2824).
+- `bernstein demo` completes its mock tasks, exits nonzero when they all fail, reports a consistent count, points at a real follow-up command, and cleans up its own processes (#2828).
+- A merge-back that fails for a non-conflict reason no longer force-deletes the branch holding an agent's only committed copy: the work is preserved to a graveyard ref, the failure is logged at error level, and the task is failed under a bounded retry budget instead of looping (#2832).
+
+## Observability
+
+- Live OTLP bridge: the run journal's signed, chain-anchored span projection now streams to any stock OpenTelemetry collector, live during a run and via `bernstein telemetry export-otel` backfill, so orchestrator spans appear in existing tracing stacks with deterministic ids (#2771).
+- `bernstein telemetry verify-span` proves a single exported span against the run journal and audit chain: it recomputes the span id from the referenced journal entry and checks the chain anchor, rejecting any span that does not recompute (#2827).
+
+## Security
+
+- The webhook secret is no longer written to logs (#2775).
+- The identity grant secret is no longer persisted in clear text; the stored reference is a salted hash, and existing chains stay verifiable (#2777).
+- `pyasn1` is bumped to 0.6.4 to clear CVE-2026-59885 and CVE-2026-59886 (#2821).
+
+## CLI and configuration
+
+- The CLI status, cost, and recap probes resolve the effective server port instead of a hardcoded default, so a run started on a non-default port is reachable (#2819).
+- A detached run now persists its auth token to a 0600 file so out-of-process `status`, `cost`, and `recap` can authenticate; a rejected credential is now reported distinctly from an unreachable server (#2830). The browser-dashboard case is tracked separately.
+- Startup cost lines use the submitted task count (#2752); the first spawn outcome is surfaced before a non-interactive run exits (#2754); unknown top-level seed keys warn with a nearest-match suggestion (#2755); the seed parser accepts `role_model_policy.<role>.endpoint` and drops unread top-level sections from shipped seed files (#2759, #2757); evolution stops warning about locked files in non-source workspaces (#2750).
+
+## Packaging
+
+- The published container image is runnable by default: its entry command no longer points at a removed command, and a foreground `serve` mode lets the image host a coordinator node (#2829). Multi-arch (arm64) images are tracked separately.
+
+## Thanks
+
+Thanks to Sanjay Santhanam, Sai Raj Kasam, and anay for external contributions in this release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "3.8.2"
+version = "3.8.3"
 description = "Deterministic, verifiable orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40+ more): reproducible parallel runs in git worktrees, always-on lineage and replay journal, opt-in HMAC-chained audit log, air-gap install profile."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/server.json
+++ b/server.json
@@ -6,19 +6,19 @@
     "url": "https://github.com/sipyourdrink-ltd/bernstein",
     "source": "github"
   },
-  "version": "3.8.2",
+  "version": "3.8.3",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "bernstein",
-      "version": "3.8.2",
+      "version": "3.8.3",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/sipyourdrink-ltd/bernstein:3.8.2",
+      "identifier": "ghcr.io/sipyourdrink-ltd/bernstein:3.8.3",
       "transport": {
         "type": "stdio"
       }

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "3.8.2"
+version = "3.8.3"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
Release v3.8.3. Bumps the version, refreshes the lockfile and distribution manifests, and adds the release notes.

This is a bug-fix release: adapter selection now validates against the live registry, several run-verification defects are closed (path_exists against the operator tree, default-branch fail-fast, dependency-scan scoping, the recovery watchdog, merge-back work preservation), the live OTLP bridge and verify-span land on the observability side, two secrets stop leaking, and the container image is runnable and multi-arch. See docs/release-notes/v3.8.3.md.