### PR TITLE
chore: add .mailmap to canonicalize contributor identity

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,12 @@
+# .mailmap - canonical contributor identity map.
+#
+# Resolves author, committer, and co-author records to a single canonical
+# identity per contributor in `git shortlog`, `git blame --use-mailmap`, and
+# the GitHub contributors graph, so identity variants committed from different
+# machines do not fragment attribution. This maps display only; it does not
+# rewrite history.
+#
+# Format: Canonical Name <canonical-email> <other-email>
+# See `git help shortlog` (MAPPING AUTHORS) and `git help check-mailmap`.
+
+chernistry <73943355+chernistry@users.noreply.github.com> <alex.chernysh@aporianetworks.com>


### PR DESCRIPTION
## What
Add a `.mailmap` so author, committer, and co-author records resolve to a single canonical identity per contributor.

## Why
Identity variants committed from different machines fragment attribution across several buckets for the same person in `git shortlog`, `git blame --use-mailmap`, and the GitHub contributors graph. A `.mailmap` canonicalizes them.

## How
Standard git `.mailmap` (see `git help check-mailmap`). Display-only: no history rewrite, no force-push, no SHA changes.

## Summary by Sourcery

Chores:
- Introduce project-level .mailmap configuration to normalize author and committer identity variants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved contributor attribution consistency across repository history and reporting tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->