### PR TITLE
refactor: centralize artifact constants and type wire payloads

### DIFF
--- a/src/bernstein/core/defaults.py
+++ b/src/bernstein/core/defaults.py
@@ -61,6 +61,18 @@ CLI monitors (``status``/``recap``/``checkpoint``) and the TUI poller can
 authenticate to the local server without inheriting the launcher env. The
 token *value* must never be logged (see #2762 / #2763)."""
 
+JOURNAL_EVENT_ARTIFACT_POSTED: Final[str] = "artifact_posted"
+"""Journal event emitted when a worker posts a task artifact."""
+
+ARTIFACT_TYPE_REPORT: Final[str] = "report"
+ARTIFACT_TYPE_TABLE: Final[str] = "table"
+ARTIFACT_TYPE_LINK: Final[str] = "link"
+ARTIFACT_TYPES: Final[frozenset[str]] = frozenset({ARTIFACT_TYPE_REPORT, ARTIFACT_TYPE_TABLE, ARTIFACT_TYPE_LINK})
+"""Artifact types accepted by the worker posting boundary."""
+
+LINK_KINDS: Final[frozenset[str]] = frozenset({"preview", "dashboard", "document"})
+"""Declared kinds accepted for link artifacts."""
+
 COPILOT_CLAUDE_TIER_MODELS: Final[frozenset[str]] = frozenset({"opus", "sonnet", "haiku"})
 """Claude cascade tier names that are not valid Copilot model ids; any that reach
 the Copilot adapter are remapped to ``COPILOT_DEFAULT_MODEL``."""

--- a/src/bernstein/core/evidence/run_artifacts.py
+++ b/src/bernstein/core/evidence/run_artifacts.py
@@ -34,8 +34,16 @@ import re
 import threading
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast
 
+from bernstein.core.defaults import (
+    ARTIFACT_TYPE_LINK,
+    ARTIFACT_TYPE_REPORT,
+    ARTIFACT_TYPE_TABLE,
+    ARTIFACT_TYPES,
+    JOURNAL_EVENT_ARTIFACT_POSTED,
+    LINK_KINDS,
+)
 from bernstein.core.evidence.bundle import DEFAULT_MAX_BLOB_BYTES, EvidenceStore
 from bernstein.core.lineage.spine import LineageSpine, content_hash_of
 
@@ -66,20 +74,6 @@ def _post_lock(task_id: str, key: str) -> threading.Lock:
             _post_locks[ident] = lock
         return lock
 
-
-#: The journal event type for a posted artifact. Kept in lockstep with
-#: :data:`bernstein.core.replay.progress.EVENT_ARTIFACT_POSTED` (progress must
-#: prove it ignores this row).
-JOURNAL_EVENT_ARTIFACT_POSTED = "artifact_posted"
-
-#: The three artifact types a worker may post.
-ARTIFACT_TYPE_REPORT = "report"
-ARTIFACT_TYPE_TABLE = "table"
-ARTIFACT_TYPE_LINK = "link"
-ARTIFACT_TYPES: frozenset[str] = frozenset({ARTIFACT_TYPE_REPORT, ARTIFACT_TYPE_TABLE, ARTIFACT_TYPE_LINK})
-
-#: The declared kinds a ``link`` artifact may carry.
-LINK_KINDS: frozenset[str] = frozenset({"preview", "dashboard", "document"})
 
 #: Artifact key alphabet: a single safe path-ish segment, no leading dot, no
 #: separators, so it can be embedded in a spine artifact path unescaped.
@@ -114,6 +108,48 @@ class ArtifactTooLargeError(ArtifactError):
 
 class ArtifactClaimError(ArtifactError):
     """A caller tried to post against a task whose claim it does not hold."""
+
+
+class ReportArtifactContent(TypedDict):
+    """Canonical wire payload for a markdown report artifact."""
+
+    type: Literal["report"]
+    body: str
+
+
+class TableArtifactContent(TypedDict):
+    """Canonical wire payload for a table artifact."""
+
+    type: Literal["table"]
+    columns: list[str]
+    rows: list[list[str]]
+
+
+class LinkArtifactContent(TypedDict):
+    """Canonical wire payload for a link artifact."""
+
+    type: Literal["link"]
+    url: str
+    kind: str
+
+
+type ArtifactContent = ReportArtifactContent | TableArtifactContent | LinkArtifactContent
+
+
+class RunArtifactRecordDict(TypedDict):
+    """JSON representation shared by artifact API, SSE, and CLI boundaries."""
+
+    task_id: str
+    key: str
+    artifact_type: str
+    content_hash: str
+    version: int
+    prev_version_hash: str
+    spine_entry_hash: str
+    journal_index: int
+    journal_event_hash: str
+    link_kind: str
+    size: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -165,18 +201,24 @@ class ArtifactPayload:
             raise ArtifactValidationError(f"link kind {kind!r} is not one of {sorted(LINK_KINDS)}")
         return ArtifactPayload(artifact_type=ARTIFACT_TYPE_LINK, url=url, link_kind=kind)
 
-    def to_content_dict(self) -> dict[str, Any]:
+    def to_content_dict(self) -> ArtifactContent:
         """Return the type-specific fields that define the artifact content."""
         if self.artifact_type == ARTIFACT_TYPE_REPORT:
-            return {"type": ARTIFACT_TYPE_REPORT, "body": self.body}
+            return cast(ReportArtifactContent, {"type": ARTIFACT_TYPE_REPORT, "body": self.body})
         if self.artifact_type == ARTIFACT_TYPE_TABLE:
-            return {
-                "type": ARTIFACT_TYPE_TABLE,
-                "columns": list(self.columns),
-                "rows": [list(r) for r in self.rows],
-            }
+            return cast(
+                TableArtifactContent,
+                {
+                    "type": ARTIFACT_TYPE_TABLE,
+                    "columns": list(self.columns),
+                    "rows": [list(r) for r in self.rows],
+                },
+            )
         if self.artifact_type == ARTIFACT_TYPE_LINK:
-            return {"type": ARTIFACT_TYPE_LINK, "url": self.url, "kind": self.link_kind}
+            return cast(
+                LinkArtifactContent,
+                {"type": ARTIFACT_TYPE_LINK, "url": self.url, "kind": self.link_kind},
+            )
         raise ArtifactValidationError(f"unknown artifact type {self.artifact_type!r}")
 
     def canonical_bytes(self) -> bytes:
@@ -216,7 +258,7 @@ class RunArtifactRecord:
     link_kind: str = ""
     size: int = 0
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self) -> RunArtifactRecordDict:
         """Return the JSON body served by the API / SSE / CLI."""
         return {
             "task_id": self.task_id,
@@ -685,12 +727,14 @@ __all__ = [
     "JOURNAL_EVENT_ARTIFACT_POSTED",
     "LINK_KINDS",
     "ArtifactClaimError",
+    "ArtifactContent",
     "ArtifactError",
     "ArtifactPayload",
     "ArtifactTooLargeError",
     "ArtifactValidationError",
     "ArtifactVerifyResult",
     "RunArtifactRecord",
+    "RunArtifactRecordDict",
     "latest_versions",
     "live_artifact_content_hashes",
     "post_run_artifact",

--- a/src/bernstein/core/replay/progress.py
+++ b/src/bernstein/core/replay/progress.py
@@ -28,6 +28,8 @@ import json
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.defaults import JOURNAL_EVENT_ARTIFACT_POSTED as EVENT_ARTIFACT_POSTED
+
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
     from pathlib import Path
@@ -39,10 +41,9 @@ PROGRESS_SCHEMA_VERSION = 1
 # ---------------------------------------------------------------------------
 # Journal event wire strings the fold recognises.
 #
-# These are stable wire contracts owned by other modules; they are duplicated
-# here (rather than imported) to keep this projection a lightweight, pure
-# module with no heavy import graph. ``tests/unit/test_run_progress.py`` asserts
-# each equals its source-of-truth constant, so drift is caught at test time.
+# These are stable wire contracts owned by other modules. The artifact event
+# comes from the central defaults module; tests assert the remaining local
+# names equal their source-of-truth constants so drift is caught.
 # ---------------------------------------------------------------------------
 
 #: A worker checkpoint row, from ``checkpoint_retry.JOURNAL_EVENT_CHECKPOINT``.
@@ -54,9 +55,8 @@ EVENT_DIFF_CAPTURED = "task_diff_captured"
 #: A gate/review decision, from ``review_board.EVENT_TASK_REVIEW_DECISION``.
 EVENT_REVIEW_DECISION = "task_review_decision"
 
-#: The agent-posted artifact row. Named here **only** so the fold can prove it
-#: is ignored -- posting artifacts must never move progress (#2553 AC4).
-EVENT_ARTIFACT_POSTED = "artifact_posted"
+#: The imported agent-posted artifact row is named here only so the fold can
+#: prove it is ignored -- posting artifacts must never move progress (#2553 AC4).
 
 #: Work-ledger phases considered terminal. Once a task reaches one, its run is
 #: over: the vector's ``terminal`` flag latches True.

--- a/src/bernstein/core/routes/task_artifacts.py
+++ b/src/bernstein/core/routes/task_artifacts.py
@@ -25,6 +25,7 @@ from bernstein.core.evidence.run_artifacts import (
     ArtifactPayload,
     ArtifactTooLargeError,
     ArtifactValidationError,
+    RunArtifactRecordDict,
     post_run_artifact,
     read_artifact_rows,
     verify_run_artifacts,
@@ -271,7 +272,7 @@ def build_progress_response(sdd_dir: Path, task_id: str, *, run_id: str = "") ->
 def _artifact_to_response(
     request: Request | None,
     task_id: str,
-    record: dict[str, Any],
+    record: RunArtifactRecordDict,
     *,
     verified: bool,
     reason: str,


### PR DESCRIPTION
## What

Centralize the artifact event/type/link-kind constants and add explicit `TypedDict` contracts for artifact payloads and records.

## Why

Artifact wire values were repeated across recording, progress projection, and API rendering, while generic dictionaries obscured the boundary contract. This implements #2660 without changing journal, audit, lineage, or receipt behavior.

## How

- define the shared constants in `core/defaults.py`
- type report, table, link, and run-record dictionaries in `run_artifacts.py`
- consume the shared event constant and typed record at the two existing boundaries

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright src/` passes (CI)
- [x] `uv run python scripts/run_tests.py -x` passes (CI test shards)
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)

- [x] User-visible README section updated (N/A: internal contract refactor)
- [x] `docs/operations/<area>.md` updated (N/A)
- [x] `docs/api/` schema regenerated if a public surface changed (N/A)
- [x] `uv run bernstein agents-md sync` run (N/A: no new module)
- [x] Tests cover the documented behaviour

## Verification

- `uv run pytest tests/unit/test_run_artifacts.py tests/unit/test_run_progress.py tests/unit/test_task_artifacts_routes.py -q` (62 passed)
- `uv run lint-imports` (3 contracts kept)
- all required GitHub CI checks pass

Closes #2660