### PR TITLE
fix(adapters): anchor nightly canary receipts into the HMAC audit chain

### DIFF
--- a/docs/adapters/conformance-canary.md
+++ b/docs/adapters/conformance-canary.md
@@ -33,8 +33,14 @@ surface at the same timestamp produce byte-identical receipts; a
 mutated receipt fails verification
 (`bernstein.adapters.canary.verify_canary_receipt`) exactly like a
 tampered chain entry. Receipt hashes are mirrored into the HMAC audit
-chain (`adapter.canary_receipt` events), so a canary finding is
-reconstructable offline rather than living only in a CI log.
+chain (`adapter.canary_receipt` events) by the nightly entrypoint
+(`scripts/adapter_canary.py`), so a canary finding is reconstructable
+offline rather than living only in a CI log. The chain segment is
+written under the run's `receipts/audit-chain/` directory and uploaded
+with the receipts artifact, so the receipt-to-chain binding survives the
+ephemeral runner: recompute a receipt file's SHA-256 and match it
+against the `receipt_sha256` of the persisted `adapter.canary_receipt`
+entry.
 
 ## Regression handling
 

--- a/scripts/adapter_canary.py
+++ b/scripts/adapter_canary.py
@@ -30,6 +30,7 @@ import json
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "src"))
@@ -40,6 +41,77 @@ from bernstein.adapters.canary import (  # noqa: E402
     LAST_GREEN_JSON_PATH,
     run_matrix,
 )
+from bernstein.core.security.audit_chain import AuditChainStore  # noqa: E402
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from bernstein.adapters.canary import CanaryTarget, MatrixRunResult
+
+
+def run_nightly_canary(
+    targets: tuple[CanaryTarget, ...],
+    *,
+    out_dir: Path,
+    generated_at: str,
+    update_docs: bool = False,
+    which: Callable[[str], str | None] | None = None,
+    contracts_dir: Path | None = None,
+    audit_key: bytes | None = None,
+    audit_key_path: Path | None = None,
+) -> MatrixRunResult:
+    """Run the canary matrix with every receipt anchored into the HMAC chain.
+
+    This is the nightly entrypoint's core: it constructs the run's
+    :class:`AuditChainStore` and threads it through :func:`run_matrix` so
+    each sealed receipt hash is mirrored into the HMAC audit chain (the
+    ``adapter.canary_receipt`` event), making the docstring/docs claim
+    true for the automated path -- not only when a chain is passed by an
+    in-run caller.
+
+    Durability: the chain's JSONL segments are written under
+    ``<out_dir>/receipts/audit-chain`` so the existing "Upload receipts"
+    workflow step captures them as an artifact. The receipt->chain
+    binding therefore survives the ephemeral CI runner with no workflow
+    change: a verifier holding a receipt file can recompute its hash and
+    match it against a persisted chain entry offline.
+
+    Args:
+        targets: The canary matrix targets to probe.
+        out_dir: Run scratch directory for receipts, state, and the
+            audit-chain segment.
+        generated_at: Deterministic UTC timestamp stamped into every
+            receipt (drives the content-addressed receipt identity).
+        update_docs: When true, write the packaged last-green projection
+            (JSON + docs table) in place; otherwise keep it scratch-local.
+        which: Optional binary resolver override (hermetic tests).
+        contracts_dir: Optional contracts directory override (hermetic
+            tests).
+        audit_key: Optional raw HMAC key. When omitted the store loads or
+            creates a key via the canonical resolver.
+        audit_key_path: Optional HMAC key file path override.
+
+    Returns:
+        The :class:`MatrixRunResult` produced by :func:`run_matrix`.
+    """
+    audit_chain = AuditChainStore(
+        audit_dir=out_dir / "receipts" / "audit-chain",
+        key=audit_key,
+        key_path=audit_key_path,
+    )
+    return run_matrix(
+        targets,
+        receipts_dir=out_dir / "receipts",
+        state_path=out_dir / "state.json",
+        # --update-docs writes the packaged projection in place (the
+        # workflow commits it via PR); otherwise keep the run scratch-local.
+        last_green_path=LAST_GREEN_JSON_PATH if update_docs else out_dir / "last_green.json",
+        docs_path=LAST_GREEN_DOC_PATH if update_docs else None,
+        generated_at=generated_at,
+        which=which,
+        contracts_dir=contracts_dir,
+        audit_chain=audit_chain,
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -76,15 +148,11 @@ def main(argv: list[str] | None = None) -> int:
     out_dir.mkdir(parents=True, exist_ok=True)
     generated_at = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    result = run_matrix(
+    result = run_nightly_canary(
         targets,
-        receipts_dir=out_dir / "receipts",
-        state_path=out_dir / "state.json",
-        # --update-docs writes the packaged projection in place (the
-        # workflow commits it via PR); otherwise keep the run scratch-local.
-        last_green_path=LAST_GREEN_JSON_PATH if args.update_docs else out_dir / "last_green.json",
-        docs_path=LAST_GREEN_DOC_PATH if args.update_docs else None,
+        out_dir=out_dir,
         generated_at=generated_at,
+        update_docs=args.update_docs,
     )
 
     issues_path = out_dir / "issues_to_open.json"

--- a/tests/unit/test_adapter_canary.py
+++ b/tests/unit/test_adapter_canary.py
@@ -18,10 +18,12 @@ same regression never opens two.
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 import stat
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -54,9 +56,30 @@ from bernstein.adapters.canary import (
 )
 
 if TYPE_CHECKING:
-    from pathlib import Path
+    from types import ModuleType
 
 _GENERATED_AT = "2026-07-11T00:00:00Z"
+
+_ADAPTER_CANARY_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "adapter_canary.py"
+
+
+def _load_adapter_canary_script() -> ModuleType:
+    """Import ``scripts/adapter_canary.py`` as a module by file path.
+
+    The nightly entrypoint lives outside the importable package, so it is
+    loaded via an explicit spec. The module is cached in ``sys.modules``
+    under a private name so repeated loads are cheap.
+    """
+    mod_name = "_adapter_canary_script_under_test"
+    cached = sys.modules.get(mod_name)
+    if cached is not None:
+        return cached
+    spec = importlib.util.spec_from_file_location(mod_name, _ADAPTER_CANARY_SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 def _outcome(
@@ -518,6 +541,100 @@ class TestAuditChainMirror:
         assert details["verdict"] == "fail"
         assert details["receipt_sha256"] == "ab" * 32
         assert "prev_chain_digest" in details
+
+
+# ---------------------------------------------------------------------------
+# Nightly entrypoint anchors receipts into the HMAC audit chain (#2843)
+# ---------------------------------------------------------------------------
+
+
+class TestNightlyAnchorsReceipts:
+    """The nightly path must anchor every receipt into the HMAC chain.
+
+    ``scripts/adapter_canary.py`` is the only caller that drives the
+    canary in CI. If it does not pass an ``AuditChainStore`` to
+    ``run_matrix`` the receipts are self-hashed but never anchored, so
+    the docstring/docs claim (receipt hashes mirrored into the HMAC
+    audit chain) is false for the automated path.
+    """
+
+    def test_nightly_run_anchors_every_receipt_and_verifies(self, tmp_path: Path) -> None:
+        from bernstein.core.security.audit_chain import (
+            EVENT_ADAPTER_CANARY_RECEIPT,
+            AuditChainStore,
+        )
+
+        script = _load_adapter_canary_script()
+
+        bin_dir = tmp_path / "bin"
+        good = _write_stub_cli(bin_dir, "agy", version="1.4.0", help_text="usage: agy -p --output-format")
+        bad = _write_stub_cli(bin_dir, "claude", version="2.0.0", help_text="usage: claude -p")
+        contracts = tmp_path / "contracts"
+        _write_contract(contracts, "agy", ["-p", "--output-format"], binary=good)
+        _write_contract(contracts, "claude", ["-p", "--output-format"], binary=bad)
+        stubs = {"agy": str(good), "claude": str(bad)}
+
+        def which(name: str) -> str | None:
+            return stubs.get(name)
+
+        targets = (
+            CanaryTarget(adapter="agy", binary="agy", model="default"),
+            CanaryTarget(adapter="claude", binary="claude", model="default"),
+        )
+
+        out_dir = tmp_path / "adapter-canary"
+        key = b"K" * 32
+        result = script.run_nightly_canary(
+            targets,
+            out_dir=out_dir,
+            generated_at=_GENERATED_AT,
+            which=which,
+            contracts_dir=contracts,
+            audit_key=key,
+        )
+        assert len(result.receipt_paths) == 2
+
+        # The chain segment must be persisted under the receipts directory
+        # so the existing "Upload receipts" artifact step captures it.
+        chain_dir = out_dir / "receipts" / "audit-chain"
+        assert chain_dir.is_dir()
+
+        # Reopen the persisted chain with the same key and verify integrity.
+        chain = AuditChainStore(chain_dir, key=key)
+        ok, errors = chain.verify()
+        assert ok, errors
+
+        anchored = {row.details["receipt_sha256"] for row in chain.query(event_type=EVENT_ADAPTER_CANARY_RECEIPT)}
+        assert len(anchored) == 2
+
+        # REAL recompute: every sealed receipt file's content hash must be
+        # present as an anchor in the persisted chain.
+        for receipt_path in result.receipt_paths:
+            doc = json.loads(receipt_path.read_text(encoding="utf-8"))
+            assert verify_canary_receipt(doc)
+            recomputed = receipt_sha256(doc["receipt"])
+            assert recomputed in anchored
+
+    def test_main_wires_audit_chain_into_run_matrix(self, tmp_path: Path) -> None:
+        """The CLI ``main`` must route through the anchoring helper."""
+        script = _load_adapter_canary_script()
+
+        captured: dict[str, object] = {}
+
+        def fake_run_nightly(targets: object, **kwargs: object) -> object:
+            captured["kwargs"] = kwargs
+            from bernstein.adapters.canary import MatrixRunResult
+
+            return MatrixRunResult()
+
+        with patch.object(script, "run_nightly_canary", side_effect=fake_run_nightly):
+            rc = script.main(["--adapter", "agy", "--out-dir", str(tmp_path / "out")])
+
+        assert rc == 0
+        kwargs = captured["kwargs"]
+        assert isinstance(kwargs, dict)
+        assert "out_dir" in kwargs
+        assert "generated_at" in kwargs
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

The nightly adapter conformance canary now anchors every sealed receipt into the HMAC audit chain, and the anchor is persisted durably so it can be verified after the ephemeral CI runner exits.

## Why

`scripts/adapter_canary.py` drove `run_matrix()` without an `audit_chain=` argument, so it defaulted to `None`, the `if audit_chain is not None:` guard never fired, and `record_adapter_canary_receipt` was never called. Every nightly receipt carried a `receipt_sha256` self-hash but was never bound into the signed chain, so an operator could not verify a nightly receipt against the chain -- exactly the property the canary docstring (`src/bernstein/adapters/canary.py`) and `docs/adapters/conformance-canary.md` advertise. The documented guarantee and the automated behavior now match.

## How

- Extracted `run_nightly_canary()` in `scripts/adapter_canary.py`: it constructs the run's `AuditChainStore` and threads it through `run_matrix(..., audit_chain=<store>)`, so each receipt hash is mirrored into the chain as an `adapter.canary_receipt` event. `main()` routes through this helper.
- The chain JSONL segment is written under the run's `receipts/audit-chain/` directory, which the existing "Upload receipts" workflow step already uploads as an artifact. The receipt-to-chain binding survives the runner with no workflow YAML change.
- Determinism preserved: receipt hashing still keys off the caller-supplied `generated_at`, and the chain entry payload is unchanged.
- Docs updated to state where the persisted chain segment lives and how to recompute-and-match a receipt offline.

Test that proves it: `tests/unit/test_adapter_canary.py::TestNightlyAnchorsReceipts::test_nightly_run_anchors_every_receipt_and_verifies` drives the nightly entrypoint end to end with hermetic stub binaries, reopens the persisted chain, asserts `chain.verify()` passes, and recomputes each receipt file's SHA-256 to confirm it is present as an anchor in the chain. `test_main_wires_audit_chain_into_run_matrix` locks the `main` -> helper wiring.

Closes #2843

## Summary by Sourcery

Anchor nightly adapter conformance canary receipts into the HMAC audit chain and ensure the persisted chain segment can be verified offline.

New Features:
- Introduce a dedicated run_nightly_canary entrypoint that runs the adapter canary matrix with receipts anchored into an HMAC audit chain and persisted under the receipts directory.

Enhancements:
- Route the adapter canary CLI main function through the new nightly helper to consistently wire an AuditChainStore into matrix runs.
- Document where the nightly audit-chain segment is stored and how to recompute and match receipt hashes against persisted chain entries for offline verification.

Tests:
- Add end-to-end tests that drive the nightly entrypoint with stub binaries, verify the persisted audit chain, and confirm every sealed receipt hash is anchored.
- Add a test ensuring the CLI main function calls the nightly helper and passes the expected arguments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nightly canary results now include audit-chain records that link each receipt to its SHA-256 hash.
  * Persisted audit-chain data is included with receipt artifacts for offline verification.
  * Added integrity checks to confirm receipt anchors and audit-chain consistency.

* **Documentation**
  * Expanded canary documentation with details on reconstructing and verifying receipt history offline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->