### PR TITLE
fix(adapters): escalate chronic canary skip verdicts and surface stale or absent last-green

### DIFF
--- a/docs/adapters/conformance-canary.md
+++ b/docs/adapters/conformance-canary.md
@@ -49,11 +49,30 @@ reconstructable offline rather than living only in a CI log.
   operator must investigate, rather than genuine per-flag drift. A
   *partial* miss (at least one required token still present) remains a
   real drift `fail`. The `skip` is independent of the process exit code.
+  The skip transcript records the **resolved binary path**, so a
+  shadowed/wrong binary on `PATH` is distinguishable from real drift.
 * Issues are **deduped on the failure fingerprint** (adapter + version +
   failure lines): the same regression never opens two issues, while a
   new upstream version failing fresh reports again.
 * The opened issue carries the failing conformance transcript and the
   receipt hash, so the finding is reproducible from the issue alone.
+
+## Chronic-skip handling
+
+A `skip` is not a conformance break, but an adapter that skips for the
+**same reason on three consecutive runs** is silently unverified -- the
+blind spot the canary exists to close. Such a streak opens a
+distinctly-labeled tracking issue (title: *"Adapter conformance canary
+skip streak"*, never *"regression"*), so a degraded probe becomes visible
+without being conflated with confirmed drift:
+
+* The skip streak counts on its own counter and threshold
+  (`SKIP_ISSUE_THRESHOLD`), independent of the failure path, and is
+  deduped on an (adapter, skip-reason) fingerprint so it opens **one**
+  issue per chronic reason.
+* A `pass` resets the streak; a different skip reason restarts it.
+* A chronic skip never reddens the job -- the workflow stays advisory;
+  escalation-to-issue is the mechanism, not a red cron.
 
 ## Last-green table
 
@@ -62,16 +81,36 @@ is a projection, never a hand-maintained list. Primary adapters without
 a passing receipt (currently `aider`) have no last-green row, so the
 primary-adapter list above and this table diverge until the next green
 canary run for that adapter. Each row names the
-receipt hash prefix that attested it. `bernstein doctor` reads the same
-projection (shipped as `src/bernstein/adapters/last_green.json`) and
-warns when a locally installed agent version is *ahead* of last-green:
-the canary has not verified that release yet, so unattended runs are
-one upstream regression away from failing without warning.
+receipt hash prefix that attested it. A row whose `recorded_at` is older
+than seven days is annotated `(stale)`: the canary refreshes passing rows
+nightly, so a frozen row is no longer evidence the surface still conforms.
+
+`bernstein doctor` reads the same projection (shipped as
+`src/bernstein/adapters/last_green.json`) and, for every locally installed
+matrix adapter, warns when the installed version is *ahead* of last-green
+(the canary has not verified that release yet), when the adapter has **no
+last-green row at all** (installed but never certified -- e.g. `aider`),
+and when its last-green row is **stale**. So an operator sees an absent or
+frozen adapter locally, not only in this table.
+
+### Adapters with no automated last-green
+
+* **`aider`** -- a `--help` that advertises none of its required tokens
+  probes as an inconclusive `skip`, so `aider` earns no last-green row
+  until a green canary run. A chronic skip is now tracked (see
+  *Chronic-skip handling*).
+* **`agy`** (Antigravity) is closed-source with a **manual, no-CI install
+  path** (`install.method: manual`, empty spec in
+  `tests/contract/contracts/agy.yaml`): the CI runner cannot install it,
+  so its last-green row is refreshed only by an operator running the canary
+  locally and can freeze while peer rows refresh nightly. Its row is
+  therefore expected to read `(stale)` on the CI-shipped projection; treat
+  `agy` as an operator-verified local check, not an automation-fresh row.
 
 <!-- last-green:begin -->
 | Adapter | Binary | Last-green version | Verified | Receipt |
 |---|---|---|---|---|
-| agy | `agy` | 1.0.0 | 2026-07-11T05:57:23Z | `006fb946868d` |
+| agy | `agy` | 1.0.0 | 2026-07-11T05:57:23Z (stale) | `006fb946868d` |
 | claude | `claude` | 2.1.217 | 2026-07-22T07:30:14Z | `488c43fbfbc0` |
 | codex | `codex` | 0.145.0 | 2026-07-22T07:30:14Z | `43296bc25996` |
 | copilot | `copilot` | 1.0.73 | 2026-07-22T07:30:14Z | `44eab25c7282` |

--- a/src/bernstein/adapters/canary.py
+++ b/src/bernstein/adapters/canary.py
@@ -37,6 +37,7 @@ import re
 import shutil
 import subprocess
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -54,6 +55,8 @@ __all__ = [
     "LAST_GREEN_DOC_PATH",
     "LAST_GREEN_END",
     "LAST_GREEN_JSON_PATH",
+    "LAST_GREEN_STALE_DAYS",
+    "SKIP_ISSUE_THRESHOLD",
     "CanaryOutcome",
     "CanaryTarget",
     "LastGreenEntry",
@@ -62,7 +65,10 @@ __all__ = [
     "build_canary_receipt",
     "canary_issue_body",
     "canary_issue_title",
+    "canary_skip_issue_body",
+    "canary_skip_issue_title",
     "failure_fingerprint",
+    "last_green_is_stale",
     "load_canary_state",
     "load_last_green",
     "probe_binary_version",
@@ -72,6 +78,7 @@ __all__ = [
     "run_matrix",
     "save_canary_state",
     "save_last_green",
+    "skip_fingerprint",
     "update_last_green",
     "verify_canary_receipt",
     "write_canary_receipt",
@@ -88,6 +95,20 @@ CANARY_GOAL = "Reply with exactly the word BERNSTEIN-CANARY and stop."
 #: Consecutive failures required before the canary proposes an issue.
 #: One upstream flake or a transient install problem never pages anyone.
 FAILURE_ISSUE_THRESHOLD = 2
+
+#: Consecutive same-reason skips required before the canary proposes a
+#: skip-tracking issue. A degraded (``skip``) probe is not a conformance
+#: break, but an adapter that skips for the same reason night after night
+#: is silently unverified -- the blind spot the canary exists to close. The
+#: threshold is higher than :data:`FAILURE_ISSUE_THRESHOLD`: a skip is a
+#: weaker signal than a confirmed drift, so it must persist longer before it
+#: is worth an operator's attention.
+SKIP_ISSUE_THRESHOLD = 3
+
+#: A last-green row older than this many days is flagged stale. The canary
+#: refreshes passing rows nightly, so a row that has not moved in this long
+#: is no longer evidence the installed surface still conforms.
+LAST_GREEN_STALE_DAYS = 7
 
 #: Markers delimiting the generated last-green table inside the docs page.
 LAST_GREEN_BEGIN = "<!-- last-green:begin -->"
@@ -167,6 +188,15 @@ class CanaryOutcome:
             ``None``. Recorded so the last-green guard can reject a below-floor
             version regardless of the conformance verdict.
         refused_below_floor: Whether this outcome is a below-floor refusal.
+        skip_reason: Stable, path-independent reason for a ``skip`` verdict
+            (``None`` for every other verdict). It is the dedupe key for the
+            skip-streak escalation (:func:`skip_fingerprint`): the same
+            degraded reason repeating night after night fingerprints
+            identically, so a chronic skip escalates exactly once. It is
+            deliberately *not* folded into the receipt preimage
+            (:func:`build_canary_receipt`) -- the human-readable reason
+            already rides in ``transcript`` -- so adding it does not perturb
+            any receipt hash.
     """
 
     adapter: str
@@ -179,6 +209,7 @@ class CanaryOutcome:
     transcript: tuple[str, ...] = ()
     security_floor: str | None = None
     refused_below_floor: bool = False
+    skip_reason: str | None = None
 
 
 @dataclass(frozen=True)
@@ -303,7 +334,13 @@ def run_canary_target(
             installed_version=None,
             verdict="skip",
             transcript=tuple(transcript),
+            skip_reason="binary not on PATH",
         )
+
+    # Record which file was actually probed. A shadowed or wrong binary on
+    # PATH produces an inconclusive skip that is indistinguishable from real
+    # drift unless the resolved path is in the receipt (#2842).
+    transcript.append(f"{target.binary} resolved: {binary_resolved}")
 
     installed_version = probe_binary_version(binary_resolved)
     transcript.append(f"{target.binary} --version: {installed_version or 'unknown'}")
@@ -369,6 +406,12 @@ def run_canary_target(
             verdict="pass",
             transcript=tuple(transcript),
         )
+    # The skip reason is the report detail when present (e.g. "probe
+    # inconclusive (...)", "no contract", "binary missing"). It is stable for
+    # a given adapter on a given host, so the same degraded surface repeating
+    # across nights fingerprints identically and the streak escalates exactly
+    # once. The resolved path stays out of the reason (it rides in the
+    # transcript for forensics) so the dedupe key does not churn on paths.
     return CanaryOutcome(
         adapter=target.adapter,
         binary=target.binary,
@@ -377,6 +420,7 @@ def run_canary_target(
         installed_version=installed_version,
         verdict="skip",
         transcript=tuple(transcript),
+        skip_reason=detail or "conformance skip",
     )
 
 
@@ -479,6 +523,24 @@ def failure_fingerprint(outcome: CanaryOutcome) -> str:
     )
 
 
+def skip_fingerprint(outcome: CanaryOutcome) -> str:
+    """Stable dedupe key for one degraded-skip shape.
+
+    Depends on the adapter and the skip reason (not the version or any
+    resolved path): the same degraded reason repeating night after night
+    fingerprints identically, so a chronic skip escalates exactly once,
+    while a different degradation restarts the streak and reports afresh.
+    """
+    return _sha256_hex(
+        _canonical_bytes(
+            {
+                "adapter": outcome.adapter,
+                "skip_reason": outcome.skip_reason or "",
+            }
+        )
+    )
+
+
 def apply_canary_outcome(
     state: dict[str, dict[str, Any]],
     outcome: CanaryOutcome,
@@ -486,42 +548,77 @@ def apply_canary_outcome(
     """Fold one outcome into the canary state; decide whether to report.
 
     State shape (per adapter): ``{"consecutive_failures": int,
-    "last_fingerprint": str, "reported_fingerprint": str}``.
+    "last_fingerprint": str, "reported_fingerprint": str,
+    "consecutive_skips": int, "last_skip_fingerprint": str,
+    "reported_skip_fingerprint": str}``.
 
     Rules:
 
-    * ``pass`` resets the failure counter and clears both fingerprints.
-    * ``skip`` leaves the state untouched (an uninstalled binary is not
-      evidence either way).
-    * ``fail`` counts consecutively *per fingerprint*: a failure that
-      fingerprints differently from the previous one restarts the count
-      at 1, so a churning upstream must fail the same way twice in a row
-      before anything is reported. Reporting triggers only when the
-      counter reaches :data:`FAILURE_ISSUE_THRESHOLD` AND this
-      fingerprint has not been reported yet.
+    * ``pass`` resets both the failure and the skip counters and clears
+      every fingerprint: a green run is positive evidence that supersedes
+      any prior degraded or failing streak.
+    * ``refuse`` (#2515) leaves the state untouched: a below-floor version
+      is an operator-environment issue, not an upstream signal.
+    * ``fail`` counts consecutively *per failure fingerprint*: a failure
+      that fingerprints differently from the previous one restarts the
+      count at 1, so a churning upstream must fail the same way twice in a
+      row before anything is reported. Reporting triggers only when the
+      counter reaches :data:`FAILURE_ISSUE_THRESHOLD` AND this fingerprint
+      has not been reported yet.
+    * ``skip`` counts consecutively *per skip fingerprint*, mirroring the
+      failure path on its own counter and threshold
+      (:data:`SKIP_ISSUE_THRESHOLD`): a degraded probe that repeats for the
+      same reason becomes visible instead of being silently voided, while a
+      one-off skip never pages anyone. The skip counters are independent of
+      the failure counters, so a skip never perturbs the failure path (and
+      vice versa).
 
     Returns:
         ``(new_state, should_open_issue)``. The input mapping is not
-        mutated.
+        mutated. ``should_open_issue`` is set for both a threshold-crossing
+        fail and a threshold-crossing skip; the caller distinguishes them by
+        ``outcome.verdict`` to pick the issue title/body.
     """
     new_state = {name: entry.copy() for name, entry in state.items()}
-    if outcome.verdict in ("skip", "refuse"):
-        # ``skip``: an uninstalled binary is not evidence either way.
-        # ``refuse`` (#2515): a below-floor version is an operator-environment
-        # issue, not an upstream regression, so it never counts toward the
-        # issue-opening threshold. The refusal is still sealed as a receipt by
-        # ``run_matrix``; it just does not page anyone as a conformance break.
+    if outcome.verdict == "refuse":
+        # A below-floor version is an operator-environment issue, not an
+        # upstream regression, so it never counts toward any threshold. The
+        # refusal is still sealed as a receipt by ``run_matrix``.
         return new_state, False
 
     entry = new_state.setdefault(
         outcome.adapter,
-        {"consecutive_failures": 0, "last_fingerprint": "", "reported_fingerprint": ""},
+        {
+            "consecutive_failures": 0,
+            "last_fingerprint": "",
+            "reported_fingerprint": "",
+            "consecutive_skips": 0,
+            "last_skip_fingerprint": "",
+            "reported_skip_fingerprint": "",
+        },
     )
     if outcome.verdict == "pass":
         entry["consecutive_failures"] = 0
         entry["last_fingerprint"] = ""
         entry["reported_fingerprint"] = ""
+        entry["consecutive_skips"] = 0
+        entry["last_skip_fingerprint"] = ""
+        entry["reported_skip_fingerprint"] = ""
         return new_state, False
+
+    if outcome.verdict == "skip":
+        fingerprint = skip_fingerprint(outcome)
+        if entry.get("last_skip_fingerprint") == fingerprint:
+            entry["consecutive_skips"] = int(entry.get("consecutive_skips", 0)) + 1
+        else:
+            entry["consecutive_skips"] = 1
+            entry["last_skip_fingerprint"] = fingerprint
+        should_open = (
+            entry["consecutive_skips"] >= SKIP_ISSUE_THRESHOLD and entry.get("reported_skip_fingerprint") != fingerprint
+        )
+        if should_open:
+            entry["reported_skip_fingerprint"] = fingerprint
+        return new_state, should_open
 
     fingerprint = failure_fingerprint(outcome)
     if entry.get("last_fingerprint") == fingerprint:
@@ -581,6 +678,60 @@ def canary_issue_body(outcome: CanaryOutcome, *, receipt_sha: str) -> str:
     ]
     lines.extend(f"- {failure}" for failure in outcome.failures)
     lines.extend(["", "## Probe transcript", "", "```"])
+    lines.extend(outcome.transcript)
+    lines.extend(
+        [
+            "```",
+            "",
+            f"Receipt: `sha256:{receipt_sha}` (canary run artifact; verify with "
+            "`bernstein.adapters.canary.verify_canary_receipt`).",
+            "",
+            "Last-green reference: docs/adapters/conformance-canary.md.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def canary_skip_issue_title(outcome: CanaryOutcome) -> str:
+    """Deterministic title for a chronic-skip tracking issue.
+
+    Distinct from :func:`canary_issue_title` -- it says "skip", never
+    "regression" -- so a degraded probe is never conflated with a confirmed
+    drift. The workflow's title-based dedupe keeps one open issue per
+    adapter skip streak.
+    """
+    return f"Adapter conformance canary skip streak: {outcome.adapter}"
+
+
+def canary_skip_issue_body(outcome: CanaryOutcome, *, receipt_sha: str) -> str:
+    """Issue body for a chronic skip: the degraded reason plus transcript.
+
+    A ``skip`` is not a confirmed conformance break; it is a probe that
+    could not decide (an uninstalled binary, a broken or wholesale-redesigned
+    ``--help``, a shadowed binary on ``PATH``). A skip that repeats for the
+    same reason past :data:`SKIP_ISSUE_THRESHOLD` nights means the adapter is
+    silently unverified and needs an operator to investigate -- which the
+    transcript (carrying the resolved binary path) makes reproducible.
+    """
+    lines = [
+        f"The nightly adapter conformance canary has recorded `{outcome.adapter}` "
+        f"({outcome.installed_version or 'unknown version'}) as a degraded `skip` for "
+        f"the same reason on {SKIP_ISSUE_THRESHOLD} consecutive runs, so it is "
+        "currently unverified rather than confirmed-passing.",
+        "",
+        "This is not a confirmed conformance regression. A chronic skip usually "
+        "means an uninstalled binary, a broken or wholesale-redesigned `--help`, "
+        "or a shadowed/wrong binary on `PATH`. Investigate using the transcript "
+        "below; the last-green table will not advance until a green run.",
+        "",
+        "## Skip reason",
+        "",
+        f"- {outcome.skip_reason or 'unknown'}",
+        "",
+        "## Probe transcript",
+        "",
+        "```",
+    ]
     lines.extend(outcome.transcript)
     lines.extend(
         [
@@ -690,12 +841,48 @@ def save_last_green(path: Path, entries: dict[str, LastGreenEntry]) -> None:
     tmp.replace(path)
 
 
-def render_last_green_table(entries: dict[str, LastGreenEntry]) -> str:
+def _parse_recorded_at(value: str) -> datetime | None:
+    """Parse a last-green ``recorded_at`` stamp, tolerating a trailing ``Z``.
+
+    Returns ``None`` for an unparseable value (treated as stale by callers:
+    a timestamp that cannot be read cannot be proven fresh).
+    """
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
+
+
+def last_green_is_stale(
+    recorded_at: str,
+    *,
+    now: datetime,
+    max_age_days: int = LAST_GREEN_STALE_DAYS,
+) -> bool:
+    """Return whether a last-green row is older than ``max_age_days``.
+
+    Time is injected (``now``) so the decision is deterministic and testable;
+    the canary passes its run timestamp and the doctor passes ``datetime.now``.
+    An unparseable ``recorded_at`` is treated as stale (fail-visible).
+    """
+    recorded = _parse_recorded_at(recorded_at)
+    if recorded is None:
+        return True
+    return (now - recorded).days > max_age_days
+
+
+def render_last_green_table(entries: dict[str, LastGreenEntry], *, now: datetime | None = None) -> str:
     """Render the per-adapter last-green table as Markdown.
 
     Rows sort by adapter name so regeneration is deterministic; each row
-    names the receipt hash prefix that attested it.
+    names the receipt hash prefix that attested it. A row whose
+    ``recorded_at`` is older than :data:`LAST_GREEN_STALE_DAYS` (as of
+    ``now``) is annotated ``(stale)`` so a frozen row stops reading as
+    automation-fresh. ``now`` is injected for deterministic tests and set to
+    the run timestamp by the canary; it defaults to the current UTC time.
     """
+    current = now if now is not None else datetime.now(UTC)
     lines = [
         "| Adapter | Binary | Last-green version | Verified | Receipt |",
         "|---|---|---|---|---|",
@@ -704,18 +891,22 @@ def render_last_green_table(entries: dict[str, LastGreenEntry]) -> str:
         lines.append("| _none yet_ | - | - | - | - |")
     for name in sorted(entries):
         entry = entries[name]
+        verified = entry.recorded_at
+        if last_green_is_stale(entry.recorded_at, now=current):
+            verified = f"{entry.recorded_at} (stale)"
         lines.append(
-            f"| {entry.adapter} | `{entry.binary}` | {entry.version} "
-            f"| {entry.recorded_at} | `{entry.receipt_sha256[:12]}` |"
+            f"| {entry.adapter} | `{entry.binary}` | {entry.version} | {verified} | `{entry.receipt_sha256[:12]}` |"
         )
     return "\n".join(lines)
 
 
-def write_last_green_doc(doc_path: Path, entries: dict[str, LastGreenEntry]) -> None:
+def write_last_green_doc(doc_path: Path, entries: dict[str, LastGreenEntry], *, now: datetime | None = None) -> None:
     """Regenerate the last-green table between the doc's markers.
 
-    Idempotent: regenerating with the same entries leaves the file
-    byte-identical. Content outside the markers is preserved verbatim.
+    Idempotent for a fixed ``now``: regenerating with the same entries and
+    timestamp leaves the file byte-identical. Content outside the markers is
+    preserved verbatim. ``now`` is threaded into the staleness annotation so
+    the regenerated table is a deterministic function of ``(entries, now)``.
 
     Raises:
         ValueError: If the doc is missing either marker.
@@ -727,7 +918,7 @@ def write_last_green_doc(doc_path: Path, entries: dict[str, LastGreenEntry]) -> 
         raise ValueError(f"{doc_path} is missing the last-green table markers")
     head = text[: begin + len(LAST_GREEN_BEGIN)]
     tail = text[end:]
-    table = render_last_green_table(entries)
+    table = render_last_green_table(entries, now=now)
     doc_path.write_text(f"{head}\n{table}\n{tail}", encoding="utf-8")
 
 
@@ -791,16 +982,29 @@ def run_matrix(
         if outcome.refused_below_floor:
             result.refusals.append(outcome.adapter)
         if should_open:
-            result.issues_to_open.append(
-                {
-                    "title": canary_issue_title(outcome),
-                    "body": canary_issue_body(outcome, receipt_sha=sha),
-                }
-            )
+            # A threshold-crossing skip and a threshold-crossing fail are both
+            # reported here; the verdict picks the distinctly-labeled payload so
+            # a degraded probe is never conflated with a confirmed drift.
+            if outcome.verdict == "skip":
+                result.issues_to_open.append(
+                    {
+                        "title": canary_skip_issue_title(outcome),
+                        "body": canary_skip_issue_body(outcome, receipt_sha=sha),
+                    }
+                )
+            else:
+                result.issues_to_open.append(
+                    {
+                        "title": canary_issue_title(outcome),
+                        "body": canary_issue_body(outcome, receipt_sha=sha),
+                    }
+                )
         last_green = update_last_green(last_green, outcome, receipt_sha=sha, recorded_at=generated_at)
 
     save_canary_state(state_path, state)
     save_last_green(last_green_path, last_green)
     if docs_path is not None:
-        write_last_green_doc(docs_path, last_green)
+        # Evaluate staleness as-of the run timestamp so the regenerated table
+        # is a deterministic function of the run inputs.
+        write_last_green_doc(docs_path, last_green, now=_parse_recorded_at(generated_at))
     return result

--- a/src/bernstein/cli/commands/doctor_cmd.py
+++ b/src/bernstein/cli/commands/doctor_cmd.py
@@ -17,9 +17,12 @@ import socket
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import click
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 from bernstein.cli.helpers import SERVER_URL
 
@@ -272,32 +275,71 @@ def emit_version_posture_receipt(workdir: Path) -> dict[str, Any]:
     return {"receipt": receipt, "receipt_sha256": sha, "entries": entries, "anchored": anchored}
 
 
-def check_canary_last_green() -> list[dict[str, Any]]:
-    """Warn when an installed agent version is ahead of its last-green.
+def check_canary_last_green(*, now: datetime | None = None) -> list[dict[str, Any]]:
+    """Advise on the local adapter posture against the canary last-green.
 
     The nightly adapter conformance canary regenerates a per-adapter
     last-green projection (the newest upstream version whose conformance
-    receipt passed; see ``docs/adapters/conformance-canary.md``). When a
-    locally installed binary is *newer* than last-green, the canary has
-    not yet verified that release against the adapter contract, so
-    unattended runs are one upstream regression away from failing without
-    warning. Rows:
+    receipt passed; see ``docs/adapters/conformance-canary.md``). This check
+    enumerates the *union* of the canary matrix and the last-green rows, so a
+    primary adapter that carries no row still surfaces for a local operator
+    instead of vanishing. For each locally installed adapter binary:
 
-    - PASS when the installed version is at or below last-green,
-    - WARN when it is strictly ahead of last-green,
-    - adapters whose binary is missing, whose version cannot be probed,
-      or which carry no last-green row are omitted so the surface stays
-      quiet.
+    - WARN when it is installed but has no last-green row (never certified),
+    - WARN when the installed version is strictly ahead of last-green,
+    - WARN when its last-green row is older than the staleness window,
+    - PASS when the installed version is at or below a fresh last-green row,
+    - adapters whose binary is missing or whose version cannot be probed are
+      omitted so the surface stays quiet.
+
+    Args:
+        now: Injected clock for the staleness comparison (deterministic
+            tests pass a fixed value); defaults to the current UTC time.
     """
+    from datetime import UTC
+    from datetime import datetime as _datetime
+
     from packaging.version import InvalidVersion, Version
 
-    from bernstein.adapters.canary import load_last_green
+    from bernstein.adapters.canary import (
+        CANARY_MATRIX,
+        LAST_GREEN_STALE_DAYS,
+        last_green_is_stale,
+        load_last_green,
+    )
+
+    current = now if now is not None else _datetime.now(UTC)
+    entries = load_last_green()
+    # Union: every matrix adapter plus any adapter that carries a row, so an
+    # absent primary adapter (e.g. one still in permanent skip) is not silent.
+    binaries: dict[str, str] = {target.adapter: target.binary for target in CANARY_MATRIX}
+    for name, entry in entries.items():
+        binaries.setdefault(name, entry.binary)
 
     results: list[dict[str, Any]] = []
-    for name, entry in sorted(load_last_green().items()):
-        if shutil.which(entry.binary) is None:
+    for name in sorted(binaries):
+        binary = binaries[name]
+        if shutil.which(binary) is None:
             continue  # adapter not installed: nothing to advise on
-        version = _probe_adapter_version(entry.binary)
+        label = f"Adapter last-green: {name}"
+        entry = entries.get(name)
+        if entry is None:
+            # Installed primary adapter with no last-green row: the canary has
+            # never certified it, so unattended runs are unverified with no
+            # signal at all.
+            results.append(
+                {
+                    "name": label,
+                    "status": _CHECK_WARN,
+                    "detail": (
+                        f"{binary} is installed but has no last-green row; the "
+                        "conformance canary has not certified any version of it yet"
+                    ),
+                    "fix": "Check docs/adapters/conformance-canary.md for this adapter's canary status",
+                }
+            )
+            continue
+        version = _probe_adapter_version(binary)
         if version is None:
             continue  # unknown version is already surfaced by advisories
         try:
@@ -305,7 +347,6 @@ def check_canary_last_green() -> list[dict[str, Any]]:
             last_green = Version(entry.version)
         except InvalidVersion:
             continue
-        label = f"Adapter last-green: {name}"
         if installed > last_green:
             results.append(
                 {
@@ -322,15 +363,32 @@ def check_canary_last_green() -> list[dict[str, Any]]:
                     ),
                 }
             )
-        else:
+            continue
+        if last_green_is_stale(entry.recorded_at, now=current):
             results.append(
                 {
                     "name": label,
-                    "status": _CHECK_PASS,
-                    "detail": f"{version} <= last-green {entry.version}",
-                    "fix": "",
+                    "status": _CHECK_WARN,
+                    "detail": (
+                        f"last-green {entry.version} recorded {entry.recorded_at} is stale "
+                        f"(> {LAST_GREEN_STALE_DAYS}d old); the canary has not refreshed "
+                        "this row, so it may no longer reflect a passing surface"
+                    ),
+                    "fix": (
+                        "Check docs/adapters/conformance-canary.md; the nightly "
+                        "canary may not be certifying this adapter"
+                    ),
                 }
             )
+            continue
+        results.append(
+            {
+                "name": label,
+                "status": _CHECK_PASS,
+                "detail": f"{version} <= last-green {entry.version}",
+                "fix": "",
+            }
+        )
     return results
 
 

--- a/tests/unit/test_adapter_canary.py
+++ b/tests/unit/test_adapter_canary.py
@@ -32,12 +32,16 @@ from bernstein.adapters.canary import (
     CANARY_MATRIX,
     CANARY_SCHEMA_VERSION,
     FAILURE_ISSUE_THRESHOLD,
+    LAST_GREEN_STALE_DAYS,
+    SKIP_ISSUE_THRESHOLD,
     CanaryOutcome,
     CanaryTarget,
     apply_canary_outcome,
     build_canary_receipt,
     canary_issue_body,
     canary_issue_title,
+    canary_skip_issue_body,
+    canary_skip_issue_title,
     failure_fingerprint,
     load_canary_state,
     load_last_green,
@@ -47,6 +51,7 @@ from bernstein.adapters.canary import (
     run_matrix,
     save_canary_state,
     save_last_green,
+    skip_fingerprint,
     update_last_green,
     verify_canary_receipt,
     write_canary_receipt,
@@ -65,6 +70,7 @@ def _outcome(
     verdict: str = "fail",
     version: str | None = "1.4.0",
     failures: tuple[str, ...] = ("required flag missing from --help: --output-format",),
+    skip_reason: str | None = None,
 ) -> CanaryOutcome:
     return CanaryOutcome(
         adapter=adapter,
@@ -75,6 +81,7 @@ def _outcome(
         verdict=verdict,
         failures=failures if verdict == "fail" else (),
         transcript=(f"{adapter} --help: probe", "verdict: " + verdict),
+        skip_reason=skip_reason if verdict == "skip" else None,
     )
 
 
@@ -217,6 +224,23 @@ class TestRunCanaryTarget:
         assert outcome.verdict == "skip"
         assert outcome.failures == ()
         assert any("none of" in line for line in outcome.transcript)
+        # The skip carries a stable reason so a chronic skip streak can escalate.
+        assert outcome.skip_reason is not None
+
+    def test_skip_transcript_carries_resolved_binary_path(self, tmp_path: Path) -> None:
+        """The resolved binary path rides into the skip transcript.
+
+        An operator must be able to tell a shadowed/wrong binary on PATH
+        from real drift: the receipt records exactly which file was probed.
+        """
+        bin_dir = tmp_path / "bin"
+        stub = _write_stub_cli(bin_dir, "aider", version="3.13", help_text="aider 3.13 - no advertised surface")
+        contracts = tmp_path / "contracts"
+        _write_contract(contracts, "aider", ["--model", "--message"], binary=stub)
+        target = CanaryTarget(adapter="aider", binary="aider", model="gpt-5-mini")
+        outcome = run_canary_target(target, which=lambda _n: str(stub), contracts_dir=contracts)
+        assert outcome.verdict == "skip"
+        assert any(str(stub) in line for line in outcome.transcript)
 
 
 # ---------------------------------------------------------------------------
@@ -338,6 +362,121 @@ class TestFailureThresholdAndDedupe:
 
 
 # ---------------------------------------------------------------------------
+# Skip-streak escalation
+# ---------------------------------------------------------------------------
+
+
+class TestSkipStreakEscalation:
+    """A chronic same-reason skip must become visible, mirroring fails.
+
+    A degraded (``skip``) probe is not a conformance break, but an adapter
+    that skips for the same reason night after night is silently unverified
+    -- exactly the blind spot the canary exists to close. The skip streak
+    escalates on its own counter and threshold, distinct from the fail path.
+    """
+
+    def _skip(self, *, adapter: str = "aider", reason: str = "probe inconclusive (all_absent)") -> CanaryOutcome:
+        return _outcome(adapter=adapter, verdict="skip", failures=(), version=None, skip_reason=reason)
+
+    def test_single_skip_never_escalates(self) -> None:
+        state, should_open = apply_canary_outcome({}, self._skip())
+        assert should_open is False
+        assert state["aider"]["consecutive_skips"] == 1
+
+    def test_threshold_same_reason_skips_escalate_once(self) -> None:
+        assert SKIP_ISSUE_THRESHOLD >= 3
+        state: dict = {}
+        opens: list[bool] = []
+        for _ in range(SKIP_ISSUE_THRESHOLD):
+            state, should_open = apply_canary_outcome(state, self._skip())
+            opens.append(should_open)
+        # Exactly one escalation, fired on the threshold-crossing night.
+        assert opens.count(True) == 1
+        assert opens[-1] is True
+        assert state["aider"]["consecutive_skips"] == SKIP_ISSUE_THRESHOLD
+        # A further same-reason skip does not re-open (deduped by fingerprint).
+        state, again = apply_canary_outcome(state, self._skip())
+        assert again is False
+
+    def test_new_skip_reason_restarts_the_streak(self) -> None:
+        state: dict = {}
+        for _ in range(SKIP_ISSUE_THRESHOLD):
+            state, _ = apply_canary_outcome(state, self._skip(reason="probe inconclusive (all_absent)"))
+        state, should_open = apply_canary_outcome(state, self._skip(reason="binary not on PATH"))
+        assert should_open is False
+        assert state["aider"]["consecutive_skips"] == 1
+
+    def test_pass_resets_skip_streak(self) -> None:
+        state: dict = {}
+        for _ in range(SKIP_ISSUE_THRESHOLD - 1):
+            state, _ = apply_canary_outcome(state, self._skip())
+        state, _ = apply_canary_outcome(state, _outcome(adapter="aider", verdict="pass", failures=()))
+        assert state["aider"]["consecutive_skips"] == 0
+        # After a reset it takes another full streak to escalate again.
+        opens: list[bool] = []
+        for _ in range(SKIP_ISSUE_THRESHOLD):
+            state, should_open = apply_canary_outcome(state, self._skip())
+            opens.append(should_open)
+        assert opens.count(True) == 1
+
+    def test_refuse_still_never_escalates(self) -> None:
+        refusal = _outcome(adapter="aider", verdict="refuse", failures=(), version="0.1.0")
+        state, should_open = apply_canary_outcome({}, refusal)
+        assert should_open is False
+        assert "consecutive_skips" not in state.get("aider", {})
+
+    def test_skip_streak_does_not_touch_fail_counter(self) -> None:
+        state, _ = apply_canary_outcome({}, _outcome())  # one fail for agy
+        state, _ = apply_canary_outcome(state, self._skip(adapter="agy"))
+        assert state["agy"]["consecutive_failures"] == 1
+
+    def test_skip_fingerprint_depends_on_adapter_and_reason(self) -> None:
+        a = skip_fingerprint(self._skip(adapter="aider", reason="probe inconclusive (all_absent)"))
+        b = skip_fingerprint(self._skip(adapter="aider", reason="binary not on PATH"))
+        c = skip_fingerprint(self._skip(adapter="agy", reason="probe inconclusive (all_absent)"))
+        assert len({a, b, c}) == 3
+
+    def test_skip_issue_title_and_body_are_distinct_from_regression(self) -> None:
+        outcome = self._skip()
+        title = canary_skip_issue_title(outcome)
+        body = canary_skip_issue_body(
+            outcome, receipt_sha=receipt_sha256(build_canary_receipt(outcome, generated_at=_GENERATED_AT))
+        )
+        assert "aider" in title
+        assert "skip" in title.lower()
+        # Must not read as a confirmed drift regression.
+        assert "regression" not in title.lower()
+        assert "probe inconclusive (all_absent)" in body
+
+    def test_run_matrix_escalates_a_chronic_skip(self, tmp_path: Path) -> None:
+        """A workflow-shaped run opens exactly one skip issue at the threshold."""
+        bin_dir = tmp_path / "bin"
+        # A stub whose --help advertises none of the required tokens is an
+        # inconclusive skip (report.py), the aider blind-spot shape.
+        stub = _write_stub_cli(bin_dir, "aider", version="0.86.2", help_text="usage: aider [options]")
+        contracts = tmp_path / "contracts"
+        _write_contract(contracts, "aider", ["--yes-always", "--message"], binary=stub)
+        targets = (CanaryTarget(adapter="aider", binary="aider", model="gpt-5-mini"),)
+        kwargs = {
+            "receipts_dir": tmp_path / "receipts",
+            "state_path": tmp_path / "state.json",
+            "last_green_path": tmp_path / "last_green.json",
+            "docs_path": None,
+            "generated_at": _GENERATED_AT,
+            "which": lambda _n: str(stub),
+            "contracts_dir": contracts,
+        }
+        results = [run_matrix(targets, **kwargs) for _ in range(SKIP_ISSUE_THRESHOLD)]
+        # Never a regression (advisory-green preserved), no fail escalation.
+        assert all(r.regressions == [] for r in results)
+        opened = [issue for r in results for issue in r.issues_to_open]
+        assert len(opened) == 1
+        assert "skip" in opened[0]["title"].lower()
+        # The receipt still records the degraded probe.
+        assert all(o.verdict == "skip" for r in results for o in r.outcomes)
+
+
+# ---------------------------------------------------------------------------
 # Last-green table
 # ---------------------------------------------------------------------------
 
@@ -383,18 +522,38 @@ class TestLastGreen:
         assert "1.4.0" in table
         assert ("cd" * 32)[:12] in table  # receipt anchor visible in docs
 
+    def test_render_table_marks_stale_rows(self) -> None:
+        from datetime import UTC, datetime
+
+        entries = update_last_green(
+            {}, _outcome(verdict="pass", failures=()), receipt_sha="cd" * 32, recorded_at="2026-07-01T00:00:00Z"
+        )
+        # A "now" well past the staleness window flags the row.
+        stale_now = datetime(2026, 7, 1, tzinfo=UTC).replace(day=1 + LAST_GREEN_STALE_DAYS + 5)
+        table = render_last_green_table(entries, now=stale_now)
+        assert "stale" in table.lower()
+        # A "now" inside the window leaves the same row unmarked.
+        fresh_now = datetime(2026, 7, 2, tzinfo=UTC)
+        assert "stale" not in render_last_green_table(entries, now=fresh_now).lower()
+
     def test_write_last_green_doc_is_idempotent(self, tmp_path: Path) -> None:
+        from datetime import UTC, datetime
+
         doc = tmp_path / "conformance-canary.md"
         doc.write_text(
-            "# Canary\n\n<!-- last-green:begin -->\nstale\n<!-- last-green:end -->\ntail\n",
+            "# Canary\n\n<!-- last-green:begin -->\nplaceholder\n<!-- last-green:end -->\ntail\n",
             encoding="utf-8",
         )
         outcome = _outcome(verdict="pass", failures=())
         entries = update_last_green({}, outcome, receipt_sha="ef" * 32, recorded_at=_GENERATED_AT)
-        write_last_green_doc(doc, entries)
+        # A "now" inside the freshness window keeps the fixed row unmarked, so
+        # the regeneration is a deterministic function of (entries, now).
+        now = datetime(2026, 7, 12, tzinfo=UTC)
+        write_last_green_doc(doc, entries, now=now)
         once = doc.read_text(encoding="utf-8")
-        write_last_green_doc(doc, entries)
+        write_last_green_doc(doc, entries, now=now)
         assert doc.read_text(encoding="utf-8") == once
+        assert "placeholder" not in once
         assert "stale" not in once
         assert "1.4.0" in once
         assert once.endswith("tail\n")
@@ -549,19 +708,75 @@ class TestDoctorAheadOfLastGreen:
         assert "1.4.0" in row["detail"]
 
     def test_installed_at_last_green_passes(self) -> None:
+        from datetime import UTC, datetime
+
         from bernstein.cli.commands import doctor_cmd
 
         def fake_which(binary: str) -> str | None:
             return "/usr/local/bin/agy" if binary == "agy" else None
 
+        # Evaluate staleness as-of a "now" inside the freshness window so the
+        # fixed _GENERATED_AT row is not flagged stale here.
+        now = datetime(2026, 7, 12, tzinfo=UTC)
         with (
             patch.object(doctor_cmd.shutil, "which", side_effect=fake_which),
             patch.object(doctor_cmd, "_probe_adapter_version", return_value="1.4.0"),
             patch("bernstein.adapters.canary.load_last_green", return_value=self._entries()),
         ):
-            rows = doctor_cmd.check_canary_last_green()
+            rows = doctor_cmd.check_canary_last_green(now=now)
         assert len(rows) == 1
         assert rows[0]["status"] == "PASS"
+
+    def test_installed_adapter_absent_from_last_green_warns(self) -> None:
+        """An installed matrix adapter with no last-green row surfaces as WARN.
+
+        Closes the "aider absent" blind spot: aider is a primary matrix
+        adapter but carries no last-green row, so it never surfaced for a
+        local operator -- not even as "no data".
+        """
+        from datetime import UTC, datetime
+
+        from bernstein.cli.commands import doctor_cmd
+
+        def fake_which(binary: str) -> str | None:
+            return "/usr/local/bin/aider" if binary == "aider" else None
+
+        now = datetime(2026, 7, 12, tzinfo=UTC)
+        with (
+            patch.object(doctor_cmd.shutil, "which", side_effect=fake_which),
+            patch("bernstein.adapters.canary.load_last_green", return_value=self._entries()),
+        ):
+            rows = doctor_cmd.check_canary_last_green(now=now)
+        aider_rows = [r for r in rows if "aider" in r["name"]]
+        assert len(aider_rows) == 1
+        assert aider_rows[0]["status"] == "WARN"
+        assert "last-green" in aider_rows[0]["detail"].lower()
+
+    def test_stale_last_green_row_warns(self) -> None:
+        """A last-green row older than the staleness window surfaces as WARN.
+
+        Closes the "agy stale" blind spot: agy's row froze weeks ago and
+        read as automation-fresh with no marker.
+        """
+        from datetime import UTC, datetime
+
+        from bernstein.cli.commands import doctor_cmd
+
+        def fake_which(binary: str) -> str | None:
+            return "/usr/local/bin/agy" if binary == "agy" else None
+
+        # _GENERATED_AT is 2026-07-11; evaluate well past the window.
+        now = datetime(2026, 8, 1, tzinfo=UTC)
+        with (
+            patch.object(doctor_cmd.shutil, "which", side_effect=fake_which),
+            patch.object(doctor_cmd, "_probe_adapter_version", return_value="1.4.0"),
+            patch("bernstein.adapters.canary.load_last_green", return_value=self._entries()),
+        ):
+            rows = doctor_cmd.check_canary_last_green(now=now)
+        agy_rows = [r for r in rows if "agy" in r["name"]]
+        assert len(agy_rows) == 1
+        assert agy_rows[0]["status"] == "WARN"
+        assert "stale" in agy_rows[0]["detail"].lower()
 
     def test_missing_binary_omitted(self) -> None:
         from bernstein.cli.commands import doctor_cmd


### PR DESCRIPTION
## What

The adapter conformance canary escalated only `fail` verdicts. A `skip`
returned `(state, False)` with no counter, streak, or threshold, so a
degraded probe was silently voided indefinitely: a primary adapter whose
signal decays to `skip` (aider today) was indistinguishable from a
healthy-but-unprobed one, with no issue, no doctor warning, and no path to
self-correct. This makes the skip signal visible without conflating it with
confirmed drift, and closes the local-operator blind spots for an absent or
frozen last-green row.

## Why

The canary's stated purpose is that "adapter breakage becomes our finding
instead of a user's broken unattended run." For any adapter whose signal
degrades to `skip`, that promise was silently unmet. aider has probed as an
inconclusive `skip` for 8+ nightly runs and carries no last-green row at
all; agy is not CI-installable and its row froze weeks ago with no staleness
marker beside peers that refresh nightly. A wholesale upstream redesign of
aider (all required flags renamed at once) was architecturally
indistinguishable from a probe hiccup and would be swallowed.

## How

- **Skip-streak escalation** (`apply_canary_outcome`): a per-adapter
  consecutive-skip counter mirrors the existing failure path on its own
  counter and threshold (`SKIP_ISSUE_THRESHOLD=3`), deduped on an
  `(adapter, skip-reason)` fingerprint just as fails dedupe on
  `reported_fingerprint`. Crossing opens exactly one distinctly-labeled
  tracking issue (`canary_skip_issue_title` says "skip streak", never
  "regression"); a `pass` resets the streak; a different reason restarts it.
  The fail path is byte-for-byte unchanged. `skip_reason` lives on
  `CanaryOutcome` only (not the receipt preimage), so no receipt hash moves.
- **Staleness** (`render_last_green_table`): rows older than
  `LAST_GREEN_STALE_DAYS=7` are annotated `(stale)`. Time is injected
  (`now`), defaulting to the run timestamp in `run_matrix`, so the table
  stays a deterministic function of its inputs.
- **doctor/status** (`check_canary_last_green`): enumerates the union of
  `CANARY_MATRIX` and `load_last_green()`, warning on an installed adapter
  with no last-green row (aider) and on a stale row (agy), instead of only
  rows that already exist and are installed. Time is injectable.
- **Skip transcript**: `run_canary_target` records the resolved binary path
  so a shadowed/wrong binary on `PATH` is distinguishable from real drift.
- **Docs**: document the aider no-row and agy no-CI-install gaps in
  `docs/adapters/conformance-canary.md`.

The workflow stays advisory by design: a chronic skip escalates to an
issue, it never reddens the cron.

Proven by `tests/unit/test_adapter_canary.py`:
`TestSkipStreakEscalation::test_threshold_same_reason_skips_escalate_once`
(N same-reason skips fire exactly one escalation),
`test_pass_resets_skip_streak`, `test_skip_streak_does_not_touch_fail_counter`
and the untouched `TestFailureThresholdAndDedupe` (fail path unchanged),
`test_run_matrix_escalates_a_chronic_skip` (workflow-shaped run opens one
skip issue and never regresses), `TestLastGreen::test_render_table_marks_stale_rows`,
and `TestDoctorAheadOfLastGreen::test_installed_adapter_absent_from_last_green_warns`
/ `test_stale_last_green_row_warns` / `test_skip_transcript_carries_resolved_binary_path`.

Closes #2842