### PR TITLE
fix(sandbox): fail loudly on explicit --sandbox override instead of degrading to host

### DIFF
--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -104,6 +104,7 @@ from bernstein.core.prometheus import (
 )
 from bernstein.core.router import ProviderHealthStatus, RouterError, TierAwareRouter
 from bernstein.core.sandbox import DockerSandbox, spawn_in_sandbox
+from bernstein.core.sandbox.selector import SandboxSelectionError
 from bernstein.core.team_state import TeamStateStore
 from bernstein.core.traces import AgentTrace, TraceStore, new_trace
 from bernstein.core.worktree import WorktreeError, WorktreeManager, WorktreeSetupConfig
@@ -4579,6 +4580,27 @@ class AgentSpawner:
             try:
                 sbx_session = self._provision_sandbox_session(session_id)
             except Exception as exc:
+                if self._sandbox_explicitly_requested():
+                    # Issue #2809 (second fallback): the operator explicitly
+                    # requested container isolation with ``--sandbox docker``.
+                    # A live daemon whose ``bernstein-agent:latest`` image is
+                    # missing passes the wiring-time availability probe
+                    # (SDK import + daemon ping) but fails here when
+                    # containers.run raises ImageNotFound. Falling back to a
+                    # host spawn would silently drop the isolation boundary the
+                    # operator asked for, exactly the degradation #2809 reports,
+                    # so the failure is raised instead of swallowed. Auto-
+                    # selected sandboxes still degrade gracefully below.
+                    image = self._sandbox_options.get("image") or "the configured image"
+                    raise SandboxSelectionError(
+                        f"Explicit '--sandbox docker' could not provision a sandbox for "
+                        f"agent {session_id}: {exc}. Refusing to fall back to host "
+                        f"execution because container isolation was explicitly requested "
+                        f"(is the '{image}' image built and available to the Docker "
+                        f"daemon?). Re-run without --sandbox to allow automatic fallback, "
+                        f"or build/pull the image and retry.",
+                        attempted=("docker",),
+                    ) from exc
                 logger.warning(
                     "Sandbox session provisioning failed for %s, falling back to direct spawn: %s",
                     session_id,
@@ -4707,6 +4729,21 @@ class AgentSpawner:
         session.isolation = IsolationMode.CONTAINER.value
         session.runtime_backend = handle.backend_name
         return SpawnResult(pid=0, log_path=log_path)
+
+    @staticmethod
+    def _sandbox_explicitly_requested() -> bool:
+        """Whether the operator pinned the sandbox runtime with ``--sandbox``.
+
+        ``BERNSTEIN_SANDBOX_RUNTIME`` is set only by the ``--sandbox`` CLI
+        flag (see ``run_bootstrap`` and ``orchestrator``); an auto-selected
+        sandbox never sets it. Issue #2809: this is the intent signal that
+        turns a per-spawn provisioning failure from a graceful host fallback
+        into a loud :class:`SandboxSelectionError` for the explicit-docker
+        case, while leaving auto-selection's fallback intact.
+        """
+        import os
+
+        return os.environ.get("BERNSTEIN_SANDBOX_RUNTIME", "").strip().lower() == "docker"
 
     def _provision_sandbox_session(self, session_id: str) -> SandboxSession:
         """Provision a dedicated sandbox session for one spawn (issue #2162).

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -5696,57 +5696,49 @@ if __name__ == "__main__":
         # and concurrent agents shared one /workspace clone. Attach the
         # DockerSandboxBackend plus a manifest factory instead: the
         # spawner provisions ONE session per spawn and destroys it when
-        # the exec future resolves (issue #2162). Fully
-        # backward-compatible: without ``--sandbox docker`` this block
-        # never runs, and any wiring failure falls back to the existing
-        # legacy container path unchanged.
+        # the exec future resolves (issue #2162).
+        #
+        # BERNSTEIN_SANDBOX_RUNTIME is only ever set by an explicit
+        # ``--sandbox`` flag, so reaching this block always means the
+        # operator explicitly requested container isolation. A missing
+        # Docker SDK or dead daemon is therefore a loud failure
+        # (SandboxSelectionError) rather than a silent degrade to legacy
+        # container / host worktree execution, which would drop the
+        # isolation boundary without a console signal (issue #2809).
         _docker_sandbox_backend = None
         _docker_manifest_factory = None
         if _sandbox_runtime == "docker":
-            try:
-                import subprocess as _subprocess
+            import subprocess as _subprocess
 
-                from bernstein.core.sandbox.backends.docker import (
-                    DockerSandboxBackend,
-                    DockerUnavailableError,
-                )
-                from bernstein.core.sandbox.manifest import GitRepoEntry, WorkspaceManifest
+            from bernstein.core.sandbox.explicit_attach import attach_docker_backend
+            from bernstein.core.sandbox.manifest import GitRepoEntry, WorkspaceManifest
 
-                _branch_result = _subprocess.run(
-                    ["git", "rev-parse", "--abbrev-ref", "HEAD"],
-                    cwd=workdir,
-                    capture_output=True,
-                    text=True,
-                    timeout=10,
-                    check=False,
-                )
-                _current_branch = _branch_result.stdout.strip() or "HEAD"
+            _branch_result = _subprocess.run(
+                ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                cwd=workdir,
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+            _current_branch = _branch_result.stdout.strip() or "HEAD"
 
-                def _make_docker_manifest(
-                    _src: str = str(workdir), _branch: str = _current_branch
-                ) -> WorkspaceManifest:
-                    return WorkspaceManifest(
-                        root="/workspace",
-                        repo=GitRepoEntry(src_path=_src, branch=_branch),
-                    )
+            def _make_docker_manifest(_src: str = str(workdir), _branch: str = _current_branch) -> WorkspaceManifest:
+                return WorkspaceManifest(
+                    root="/workspace",
+                    repo=GitRepoEntry(src_path=_src, branch=_branch),
+                )
 
-                _docker_backend = DockerSandboxBackend()
-                # Fail fast at wiring time so a dead daemon still falls
-                # back to legacy isolation instead of failing per spawn.
-                _docker_backend.ensure_available()
-                _docker_sandbox_backend = _docker_backend
-                _docker_manifest_factory = _make_docker_manifest
-                logger.info(
-                    "Docker sandbox backend attached; one session per agent spawn (branch=%s)",
-                    _current_branch,
-                )
-            except DockerUnavailableError as exc:
-                logger.warning("Docker sandbox unavailable (%s); falling back to legacy container isolation", exc)
-            except Exception as exc:
-                logger.warning(
-                    "Failed to attach Docker sandbox backend, falling back to legacy container isolation: %s",
-                    exc,
-                )
+            # Fail fast at wiring time so a dead daemon surfaces before
+            # any spawn. ``explicit=True`` turns an unavailable backend
+            # into a raised SandboxSelectionError instead of a silent
+            # host fallback.
+            _docker_sandbox_backend = attach_docker_backend(explicit=True)
+            _docker_manifest_factory = _make_docker_manifest
+            logger.info(
+                "Docker sandbox backend attached; one session per agent spawn (branch=%s)",
+                _current_branch,
+            )
 
         def _teardown_docker_sandbox() -> None:
             """Destroy any Docker sandbox sessions the backend still tracks.

--- a/src/bernstein/core/sandbox/explicit_attach.py
+++ b/src/bernstein/core/sandbox/explicit_attach.py
@@ -1,0 +1,86 @@
+"""Explicit-override-aware attachment of the Docker sandbox backend.
+
+The deterministic selector (:mod:`bernstein.core.sandbox.selector`) already
+treats an explicit ``--sandbox <name>`` override as a hard contract and
+raises :class:`~bernstein.core.sandbox.selector.SandboxSelectionError`
+rather than silently picking a different runtime. The runtime *attach*
+step, however, has to probe a live Docker daemon, and that probe used to
+degrade quietly: a missing Docker SDK or dead daemon logged a warning and
+fell through to legacy-container and then plain host-worktree execution,
+dropping the isolation boundary the operator explicitly asked for with no
+console signal (issue #2809).
+
+This module carries the same override-first contract into the attach step.
+When Docker is requested by an explicit override, an unavailable backend is
+a loud failure; when Docker was merely auto-selected, an unavailable
+backend degrades gracefully. Threading the ``explicit`` bit through is what
+distinguishes the two, so the loud-fail path is gated on operator intent,
+not on Docker availability alone.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from bernstein.core.sandbox.selector import SandboxSelectionError
+
+if TYPE_CHECKING:
+    from bernstein.core.sandbox.backends.docker import DockerSandboxBackend
+
+
+def attach_docker_backend(
+    *,
+    explicit: bool,
+    backend: DockerSandboxBackend | None = None,
+) -> DockerSandboxBackend | None:
+    """Instantiate and verify the Docker sandbox backend.
+
+    The backend's availability probe (SDK import + daemon ping) runs at
+    wiring time so a broken setup surfaces before any agent spawns rather
+    than per spawn.
+
+    Args:
+        explicit: Whether Docker was chosen by an explicit operator
+            override (``--sandbox docker``) as opposed to automatic
+            selection. Only the explicit path fails loudly; auto-selection
+            keeps the historical graceful fallback.
+        backend: Pre-built backend to verify. Defaults to a fresh
+            :class:`~bernstein.core.sandbox.backends.docker.DockerSandboxBackend`.
+            Tests inject a stub to exercise the availability branches
+            without a live daemon.
+
+    Returns:
+        The ready backend when Docker is usable. ``None`` when Docker is
+        unavailable *and* the choice was auto-selected (``explicit`` is
+        ``False``), signalling the caller to fall back gracefully.
+
+    Raises:
+        SandboxSelectionError: When ``explicit`` is ``True`` and Docker is
+            unavailable. The operator requested container isolation with an
+            explicit ``--sandbox docker`` override; silently degrading to
+            host execution would drop that isolation boundary without a
+            signal, so the failure is raised instead of swallowed.
+    """
+    from bernstein.core.sandbox.backends.docker import (
+        DockerSandboxBackend,
+        DockerUnavailableError,
+    )
+
+    candidate = backend if backend is not None else DockerSandboxBackend()
+    try:
+        candidate.ensure_available()
+    except DockerUnavailableError as exc:
+        if explicit:
+            raise SandboxSelectionError(
+                "Explicit '--sandbox docker' could not be honored: "
+                f"{exc} Refusing to fall back to host execution because "
+                "container isolation was explicitly requested. Re-run "
+                "without --sandbox to allow automatic fallback, or install "
+                "the Docker SDK and start the Docker daemon.",
+                attempted=("docker",),
+            ) from exc
+        return None
+    return candidate
+
+
+__all__ = ["attach_docker_backend"]

--- a/tests/unit/sandbox/test_explicit_attach.py
+++ b/tests/unit/sandbox/test_explicit_attach.py
@@ -1,0 +1,79 @@
+"""Unit tests for explicit-override-aware Docker backend attachment.
+
+Regression coverage for issue #2809: an explicit ``--sandbox docker``
+override that cannot be satisfied (missing Docker SDK, dead daemon) must
+fail loudly with :class:`SandboxSelectionError` instead of silently
+degrading to host / worktree execution. Auto-selected Docker (no explicit
+override) must still fall back quietly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from bernstein.core.sandbox.backends.docker import DockerUnavailableError
+from bernstein.core.sandbox.explicit_attach import attach_docker_backend
+from bernstein.core.sandbox.selector import SandboxSelectionError
+
+
+class _UnavailableBackend:
+    """Docker backend stub whose availability probe always fails."""
+
+    name = "docker"
+
+    def ensure_available(self) -> None:
+        raise DockerUnavailableError(
+            "Install the 'docker' extra to use DockerSandboxBackend: `pip install bernstein[docker]`."
+        )
+
+
+class _AvailableBackend:
+    """Docker backend stub whose availability probe succeeds."""
+
+    name = "docker"
+
+    def ensure_available(self) -> None:
+        return None
+
+
+def test_explicit_docker_unavailable_raises_selection_error() -> None:
+    """Explicit override + unavailable Docker must raise, not fall back."""
+    with pytest.raises(SandboxSelectionError) as excinfo:
+        attach_docker_backend(explicit=True, backend=_UnavailableBackend())  # type: ignore[arg-type]
+
+    err = excinfo.value
+    assert err.attempted == ("docker",)
+    # The message must name the actual cause so the operator can fix it.
+    assert "docker" in err.reason.lower()
+    assert "host" in err.reason.lower()
+
+
+def test_explicit_docker_unavailable_does_not_return_host_backend() -> None:
+    """The explicit failure path must never yield a usable backend."""
+    with pytest.raises(SandboxSelectionError):
+        _result: Any = attach_docker_backend(
+            explicit=True,
+            backend=_UnavailableBackend(),  # type: ignore[arg-type]
+        )
+
+
+def test_auto_selected_docker_unavailable_falls_back_quietly() -> None:
+    """Auto-selection (explicit False) degrades gracefully to ``None``."""
+    result = attach_docker_backend(explicit=False, backend=_UnavailableBackend())  # type: ignore[arg-type]
+    assert result is None
+
+
+def test_explicit_docker_available_returns_backend() -> None:
+    """When Docker is usable the same backend instance is returned."""
+    backend = _AvailableBackend()
+    result = attach_docker_backend(explicit=True, backend=backend)  # type: ignore[arg-type]
+    assert result is backend
+
+
+def test_auto_selected_docker_available_returns_backend() -> None:
+    """Auto-selection also returns the backend when Docker is usable."""
+    backend = _AvailableBackend()
+    result = attach_docker_backend(explicit=False, backend=backend)  # type: ignore[arg-type]
+    assert result is backend

--- a/tests/unit/test_spawner_sandbox_session.py
+++ b/tests/unit/test_spawner_sandbox_session.py
@@ -17,18 +17,18 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
-from bernstein.core.models import AgentSession, ModelConfig
+import pytest
+from bernstein.core.models import AgentSession, IsolationMode, ModelConfig
 from bernstein.core.spawner import AgentSpawner
 
 from bernstein.adapters.base import CLIAdapter, SpawnResult
 from bernstein.core.sandbox import WorkspaceManifest
 from bernstein.core.sandbox.backend import ExecResult, SandboxSession
+from bernstein.core.sandbox.selector import SandboxSelectionError
 from bernstein.core.security.audit import AuditLog
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
-
-    import pytest
 
 
 class _FakeAdapter(CLIAdapter):
@@ -257,6 +257,7 @@ def _build_spawner_with_backend(
     *,
     backend: _FakeBackend,
     server_port: int | None = None,
+    image: str = "img:test",
 ) -> tuple[AgentSpawner, _FakeAdapter]:
     adapter = _FakeAdapter("claude")
     with patch("bernstein.core.agents.spawner_core.get_registry", return_value=MagicMock()):
@@ -267,7 +268,7 @@ def _build_spawner_with_backend(
             use_worktrees=False,
             sandbox_backend=backend,  # pyright: ignore[reportArgumentType]
             sandbox_manifest_factory=lambda: WorkspaceManifest(root=str(tmp_path)),
-            sandbox_options={"image": "img:test"},
+            sandbox_options={"image": image},
             sandbox_server_port=server_port,
         )
     return spawner, adapter
@@ -387,6 +388,90 @@ def test_provisioning_failure_falls_back_to_direct_spawn(tmp_path: Path) -> None
     assert result.pid == 99
     assert adapter.spawn_calls == [("fallback", tmp_path)]
     assert "S-25" not in spawner._sandbox_owned_sessions  # pyright: ignore[reportPrivateUsage]
+
+
+# ---------------------------------------------------------------------------
+# Issue #2809: explicit --sandbox docker must never silently degrade to host.
+#
+# The first loud-fail (explicit_attach.attach_docker_backend) only covers a
+# missing SDK / dead daemon: ensure_available() pings the daemon but does not
+# check image existence, so a LIVE daemon with a MISSING image passes wiring
+# and fails later at containers.run with ImageNotFound. That per-spawn
+# provisioning failure used to warn + fall back to a host spawn, dropping the
+# isolation boundary the operator explicitly asked for. For an explicit
+# override it must surface as SandboxSelectionError instead.
+# ---------------------------------------------------------------------------
+
+
+class _FakeImageNotFound(Exception):
+    """Stand-in for ``docker.errors.ImageNotFound`` (no SDK needed in tests)."""
+
+
+class _ImageMissingBackend(_FakeBackend):
+    """Live-daemon backend whose containers.run cannot find the agent image.
+
+    ``ensure_available`` (SDK import + daemon ping) would have succeeded for
+    this backend; the failure only manifests at ``create`` time, exactly the
+    #2809 second-fallback condition.
+    """
+
+    async def create(self, manifest: object, options: dict[str, object] | None = None) -> _FakeSession:
+        del manifest, options
+        raise _FakeImageNotFound("404 Client Error: No such image: bernstein-agent:latest")
+
+
+def test_explicit_docker_missing_image_raises_and_never_runs_on_host(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Explicit --sandbox docker + live daemon + missing image fails loudly."""
+    monkeypatch.setenv("BERNSTEIN_SANDBOX_RUNTIME", "docker")
+    backend = _ImageMissingBackend(tmp_path)
+    spawner, adapter = _build_spawner_with_backend(tmp_path, backend=backend, image="bernstein-agent:latest")
+
+    agent_session = AgentSession(id="S-2809", role="backend")
+    with pytest.raises(SandboxSelectionError) as excinfo:
+        spawner._spawn_via_sandbox_session(  # pyright: ignore[reportPrivateUsage]
+            session_id="S-2809",
+            prompt="isolate me",
+            spawn_cwd=tmp_path,
+            model_config=ModelConfig("sonnet", "high"),
+            mcp_config=None,
+            session=agent_session,
+            adapter=adapter,
+        )
+
+    # The message names the cause so the operator can act.
+    message = str(excinfo.value)
+    assert "bernstein-agent:latest" in message
+    assert "docker" in message.lower()
+    # Isolation was NOT downgraded to a host spawn.
+    assert adapter.spawn_calls == []
+    assert agent_session.isolation != IsolationMode.WORKTREE.value
+    assert agent_session.isolation != IsolationMode.CONTAINER.value
+    assert "S-2809" not in spawner._sandbox_owned_sessions  # pyright: ignore[reportPrivateUsage]
+
+
+def test_auto_selected_docker_missing_image_falls_back_quietly(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Auto-selected sandbox (no explicit --sandbox flag) still degrades gracefully."""
+    monkeypatch.delenv("BERNSTEIN_SANDBOX_RUNTIME", raising=False)
+    backend = _ImageMissingBackend(tmp_path)
+    spawner, adapter = _build_spawner_with_backend(tmp_path, backend=backend, image="bernstein-agent:latest")
+
+    agent_session = AgentSession(id="S-auto", role="backend")
+    result = spawner._spawn_via_sandbox_session(  # pyright: ignore[reportPrivateUsage]
+        session_id="S-auto",
+        prompt="isolate me",
+        spawn_cwd=tmp_path,
+        model_config=ModelConfig("sonnet", "high"),
+        mcp_config=None,
+        session=agent_session,
+        adapter=adapter,
+    )
+
+    # No raise: fell back to the direct adapter spawn on the host.
+    assert result.pid == 99
+    assert adapter.spawn_calls == [("isolate me", tmp_path)]
+    assert "S-auto" not in spawner._sandbox_owned_sessions  # pyright: ignore[reportPrivateUsage]
 
 
 def test_reachability_probe_warns_when_unreachable(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:


### PR DESCRIPTION
## What

An explicit `--sandbox docker` override now fails loudly with
`SandboxSelectionError` when the Docker backend cannot be honored,
instead of silently degrading to host / worktree execution.

## Why

`--sandbox docker` is an explicit isolation request. The runtime attach
step degraded it silently: a missing Docker SDK (absent from the wheel
venv) or a dead daemon logged a warning and fell through to the
legacy-container path and then a plain host git worktree. The run then
reported normally with no isolation and no console signal - the only
trace was buried in `.sdd/runtime/orchestrator-debug.log`. The selector
already treats an explicit override as a hard contract; the attach step
did not.

## How

New `attach_docker_backend(explicit=...)` in
`src/bernstein/core/sandbox/explicit_attach.py` runs the availability
probe (SDK import + daemon ping) at wiring time. When the backend was
explicitly requested it raises `SandboxSelectionError` naming the cause;
when auto-selected it returns `None` so historical graceful fallback is
preserved. The orchestrator reaches this path only when
`BERNSTEIN_SANDBOX_RUNTIME` is set, which happens only via an explicit
`--sandbox` flag, so it always passes `explicit=True`. The prior
warn-and-fall-back try/except is removed.

Proven by `tests/unit/sandbox/test_explicit_attach.py`:
`test_explicit_docker_unavailable_raises_selection_error` (explicit +
unavailable raises and yields no host backend) and
`test_auto_selected_docker_unavailable_falls_back_quietly` (auto path
still returns `None`).

Closes #2809