### PR TITLE
fix(cli): validate the seed in --dry-run and warn on unparseable backlog files

### DIFF
--- a/docs/operations/task_format.md
+++ b/docs/operations/task_format.md
@@ -15,6 +15,21 @@ for the DAG walker and CLI.
 Both fields are persisted on the `Task` dataclass and round-trip through
 `Task.from_dict`.
 
+## Required backlog file format
+
+Files under `.sdd/backlog/open/` (and `.sdd/backlog/issues/`) must be one of
+two shapes so the orchestrator can extract a title and route the task:
+
+1. **YAML frontmatter** - a `---` delimited block at the top of the file
+   (see [YAML frontmatter](#yaml-frontmatter-ticket-format-v1) below).
+2. **Markdown fields** - a `# ` heading for the title plus optional
+   `**Role:**` / `**Priority:**` / `**Scope:**` / `**Complexity:**` lines.
+
+A file that is neither (for example a plain YAML file with no `---` block and
+no `# ` heading) cannot be parsed as a ticket. It is skipped rather than
+spawned, and `bernstein --dry-run` prints a warning naming the file so the
+gap is visible instead of silent.
+
 ## YAML frontmatter (Ticket Format v1)
 
 ```yaml

--- a/src/bernstein/cli/helpers.py
+++ b/src/bernstein/cli/helpers.py
@@ -396,6 +396,15 @@ def print_dry_run_table(workdir: Path) -> None:
         bt = parse_backlog_file(backlog_file)
         if bt is not None:
             tasks.append(bt)
+        else:
+            # A backlog file that is not the expected frontmatter/markdown
+            # format (e.g. plain YAML with no `---` block and no `# ` title)
+            # would otherwise be silently skipped (issue #2785). Surface it so
+            # the operator can see the ticket will not be picked up.
+            console.print(
+                f"[yellow]Warning:[/yellow] {backlog_file.name} could not be parsed as a backlog ticket "
+                "(expected YAML frontmatter delimited by '---' or a Markdown '# ' title); skipping."
+            )
 
     console.print("\n[bold cyan][DRY RUN] Planned task spawns:[/bold cyan]")
 

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -809,6 +809,12 @@ def cli(
     executor.shutdown(wait=False)
 
     if dry_run:
+        # Validate the seed with the same rules the real run uses before
+        # rendering the preview, so --dry-run cannot report success on a
+        # seed the run would reject (issue #2785).
+        from bernstein.cli.run_preflight import validate_seed_or_exit
+
+        validate_seed_or_exit(str(seed_path) if seed_path else None)
         print_dry_run_table(workdir)
         return
 

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -39,6 +39,7 @@ from bernstein.cli.run_preflight import (
     _make_profile_ctx,
     _quiet_bootstrap_console,
     _show_run_summary,
+    validate_seed_or_exit,
 )
 from bernstein.core.cost import estimate_run_cost
 from bernstein.core.manager_parsing import _resolve_depends_on  # pyright: ignore[reportPrivateUsage]
@@ -1884,12 +1885,22 @@ def _run_impl(
         # Applies only to modes that merge agent work back -- --dry-run
         # returned above and --plan-only skips this block.
         _abort_if_default_branch_merge_target(workdir)
+        # Validate the seed before estimating cost (issue #2785): a seed the
+        # run would reject must not first print an estimate "at sonnet
+        # pricing", and the estimate must reflect the validated seed's
+        # effective default model rather than the sonnet fallback. Only seed
+        # mode is validated here; inline-goal, --plan-file and --from-plan
+        # runs carry no seed to validate at this point.
+        validated_seed = None
+        if goal is None and plan_file is None and from_plan is None:
+            validated_seed = validate_seed_or_exit(seed_file)
         estimate = _estimate_run_preview(
             workdir=workdir,
             plan_file=plan_file,
             goal=goal,
             seed_file=seed_file,
             model_override=model,
+            seed=validated_seed,
         )
         _emit_preflight_runtime_warnings(
             workdir=workdir,

--- a/src/bernstein/cli/run_preflight.py
+++ b/src/bernstein/cli/run_preflight.py
@@ -29,7 +29,46 @@ from bernstein.core.runtime_state import directory_size_bytes
 if TYPE_CHECKING:
     from rich.console import Console
 
+    from bernstein.core.config.seed import SeedConfig
+
 logger = logging.getLogger(__name__)
+
+
+def validate_seed_or_exit(seed_file: str | None) -> SeedConfig | None:
+    """Parse and validate the seed file with the same rules the real run uses.
+
+    Resolves the seed path (falling back to :func:`find_seed_file` when
+    ``seed_file`` is ``None``) and parses it through
+    :func:`bernstein.core.seed.parse_seed` -- the single shared validation
+    boundary. A :class:`~bernstein.core.seed.SeedError` is surfaced as the
+    same structured CLI error the real run raises and aborts the process, so
+    ``--dry-run`` can no longer report success on a seed the run would reject
+    (issue #2785).
+
+    Args:
+        seed_file: Explicit seed path, or ``None`` to auto-discover one.
+
+    Returns:
+        The parsed :class:`SeedConfig` when a seed file exists and validates,
+        or ``None`` when no seed file is present (inline-goal and empty-backlog
+        modes validate elsewhere).
+
+    Raises:
+        SystemExit: When the seed file exists but fails validation.
+    """
+    from bernstein.core.config.seed import SeedError, parse_seed
+
+    seed_path = Path(seed_file) if seed_file is not None else find_seed_file()
+    if seed_path is None or not seed_path.exists():
+        return None
+    try:
+        return parse_seed(seed_path)
+    except SeedError as exc:
+        from bernstein.cli.utils.errors import seed_parse_error
+
+        seed_parse_error(exc).print()
+        raise SystemExit(1) from exc
+
 
 #: When this module was imported, which is when the CLI process started.
 #: Used to ignore merge-refusal journal entries left over from previous runs
@@ -220,8 +259,19 @@ def _estimate_task_count(workdir: Path, plan_file: Path | None, goal: str | None
 def _resolve_model_and_cli(
     seed_file: str | None,
     model_override: str | None,
+    seed: SeedConfig | None = None,
 ) -> tuple[str, str, str]:
     """Resolve model, CLI adapter, and dominant role from seed or defaults.
+
+    Args:
+        seed_file: Explicit seed path, or ``None`` to auto-discover one.
+        model_override: Explicit ``--model`` override; short-circuits seed
+            inspection when set.
+        seed: A seed already parsed by the shared validation boundary
+            (:func:`validate_seed_or_exit`). When supplied it is used
+            directly, so the estimate reflects the seed's effective default
+            model instead of falling back to the sonnet heuristic on a
+            re-parse failure (issue #2785).
 
     Returns:
         Tuple of ``(model, cli, role)``. ``role`` defaults to ``"backend"``
@@ -233,15 +283,20 @@ def _resolve_model_and_cli(
     if model_override is not None:
         return est_model, est_cli, est_role
 
-    seed_path = Path(seed_file) if seed_file is not None else find_seed_file()
-    if seed_path is None or not seed_path.exists():
-        return est_model, est_cli, est_role
+    if seed is None:
+        seed_path = Path(seed_file) if seed_file is not None else find_seed_file()
+        if seed_path is None or not seed_path.exists():
+            return est_model, est_cli, est_role
+        try:
+            from bernstein.core.config.seed import parse_seed
+
+            seed = parse_seed(seed_path)
+        except Exception:
+            return "sonnet", est_cli, est_role
 
     try:
         from bernstein.core.cost.cost import _model_cost
-        from bernstein.core.seed import parse_seed
 
-        seed = parse_seed(seed_path)
         if seed.model:
             est_model = seed.model
         if seed.role_model_policy:
@@ -287,6 +342,7 @@ def _estimate_run_preview(
     goal: str | None,
     seed_file: str | None,
     model_override: str | None,
+    seed: SeedConfig | None = None,
 ) -> RunCostEstimate:
     """Estimate run cost before bootstrapping the orchestrator.
 
@@ -303,6 +359,9 @@ def _estimate_run_preview(
         goal: Optional inline goal.
         seed_file: Optional seed path override.
         model_override: Optional CLI ``--model`` override.
+        seed: Seed already parsed by the shared validation boundary. When
+            supplied, the estimate reflects the seed's effective default
+            model rather than re-parsing (issue #2785).
 
     Returns:
         Cost estimate using the best available task count and model hint.
@@ -311,7 +370,7 @@ def _estimate_run_preview(
     # Unknown count: compute a per-task rate (count of 1) but keep
     # ``task_count=None`` so display code says "unknown" instead of a number.
     billable_count = est_task_count if est_task_count is not None else 1
-    est_model, est_cli, est_role = _resolve_model_and_cli(seed_file, model_override)
+    est_model, est_cli, est_role = _resolve_model_and_cli(seed_file, model_override, seed=seed)
 
     if est_cli in _FREE_ADAPTERS:
         low_usd, high_usd = 0.0, 0.0

--- a/tests/unit/test_issue_2785_dryrun_seed_validation.py
+++ b/tests/unit/test_issue_2785_dryrun_seed_validation.py
@@ -1,0 +1,154 @@
+"""Regression tests for issue #2785.
+
+Three related validation gaps in the ``bernstein --dry-run`` path:
+
+1. ``--dry-run`` skipped seed validation, so a seed the real run rejects
+   (e.g. an unsupported ``cli:`` value) printed "No open tasks found in
+   backlog" and exited 0 instead of raising the same parse error.
+2. A backlog file that is not the expected frontmatter/markdown format
+   (e.g. plain YAML) was silently skipped with no warning.
+3. The preflight cost estimator resolved the model by swallowing seed
+   parse errors and falling back to sonnet, so it could print an estimate
+   "at sonnet pricing" for a seed the run would reject or run under a
+   different default model.
+"""
+
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pytest
+from rich.console import Console
+
+from bernstein.cli import helpers
+from bernstein.cli.run_preflight import _resolve_model_and_cli, validate_seed_or_exit
+
+
+def _write_seed(path: Path, body: str) -> Path:
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Gap 1: --dry-run must validate the seed the same way run does.
+# ---------------------------------------------------------------------------
+
+
+def test_validate_seed_or_exit_rejects_unsupported_cli(tmp_path: Path) -> None:
+    """A seed with an unsupported ``cli:`` value raises the same error as run."""
+    seed = _write_seed(tmp_path / "bernstein.yaml", 'goal: "ship it"\ncli: definitely-not-a-real-adapter\n')
+    with pytest.raises(SystemExit) as exc_info:
+        validate_seed_or_exit(str(seed))
+    assert exc_info.value.code != 0
+
+
+def test_validate_seed_or_exit_accepts_valid_seed(tmp_path: Path) -> None:
+    """A valid seed parses and is returned for downstream reuse."""
+    seed = _write_seed(tmp_path / "bernstein.yaml", 'goal: "ship it"\ncli: claude\nmodel: opus\n')
+    result = validate_seed_or_exit(str(seed))
+    assert result is not None
+    assert result.model == "opus"
+
+
+def test_validate_seed_or_exit_none_when_no_seed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """No seed file present is a no-op (inline goal / empty backlog modes)."""
+    monkeypatch.chdir(tmp_path)
+    assert validate_seed_or_exit(None) is None
+
+
+def test_dry_run_flag_validates_bad_seed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``bernstein --dry-run`` on a rejected seed exits non-zero, not 'No open tasks'."""
+    from click.testing import CliRunner
+
+    import bernstein.cli.main as main_mod
+
+    _write_seed(tmp_path / "bernstein.yaml", 'goal: "ship it"\ncli: definitely-not-a-real-adapter\n')
+
+    # Keep the heavy startup path out of the unit test.
+    monkeypatch.setattr(main_mod, "_background_startup", lambda _workdir: {"agents": [], "task_count": 0})
+    import bernstein.cli.splash_screen as splash_mod
+
+    monkeypatch.setattr(splash_mod, "splash", lambda *a, **k: False)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path) as fs:
+        _write_seed(Path(fs) / "bernstein.yaml", 'goal: "ship it"\ncli: definitely-not-a-real-adapter\n')
+        result = runner.invoke(main_mod.cli, ["--dry-run"])
+
+    assert result.exit_code != 0
+    assert "No open tasks found" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# Gap 2: an unparseable backlog file must emit a visible warning.
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_table_warns_on_unparseable_backlog_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A plain-YAML file (no frontmatter, no ``# `` title) is warned about, not skipped."""
+    open_dir = tmp_path / ".sdd" / "backlog" / "open"
+    open_dir.mkdir(parents=True)
+    # Valid frontmatter ticket so the table still renders.
+    (open_dir / "001-ok.md").write_text(
+        "---\ntitle: Valid ticket\nrole: backend\npriority: 2\nscope: small\ncomplexity: low\n---\n# Valid ticket\n",
+        encoding="utf-8",
+    )
+    # Plain YAML with no frontmatter delimiters and no markdown title.
+    (open_dir / "002-plain.yaml").write_text("title: Plain yaml\nrole: backend\npriority: 2\n", encoding="utf-8")
+
+    buf = io.StringIO()
+    fake_console = Console(file=buf, width=200, force_terminal=False, record=False)
+    monkeypatch.setattr(helpers, "console", fake_console)
+
+    helpers.print_dry_run_table(tmp_path)
+
+    output = buf.getvalue()
+    assert "002-plain.yaml" in output, output
+    assert "could not be parsed" in output.lower() or "warning" in output.lower(), output
+
+
+# ---------------------------------------------------------------------------
+# Gap 3: the estimate must reflect the effective default model, not sonnet.
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_model_and_cli_honors_passed_validated_seed(tmp_path: Path) -> None:
+    """When a validated seed is supplied, its default model wins over sonnet."""
+    from bernstein.core.seed import parse_seed
+
+    seed_path = _write_seed(tmp_path / "bernstein.yaml", 'goal: "ship it"\ncli: claude\nmodel: opus\n')
+    seed = parse_seed(seed_path)
+    model, cli, _role = _resolve_model_and_cli(None, None, seed=seed)
+    assert model == "opus"
+    assert cli == "claude"
+
+
+def test_run_validates_seed_before_printing_estimate(tmp_path: Path) -> None:
+    """The run path rejects a bad seed before printing any cost estimate."""
+    from click.testing import CliRunner
+
+    from bernstein.cli.run_cmd import run
+
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path) as fs:
+        _write_seed(Path(fs) / "bernstein.yaml", 'goal: "ship it"\ncli: definitely-not-a-real-adapter\n')
+        result = runner.invoke(run, ["--auto-approve"])
+
+    assert result.exit_code != 0
+    # The seed is rejected before the preflight estimate, so no "pricing"
+    # line for the sonnet fallback is printed.
+    assert "pricing" not in result.output.lower()
+
+
+def test_resolve_model_and_cli_passed_seed_does_not_reparse(tmp_path: Path) -> None:
+    """A supplied seed is used directly, so a missing file does not fall back to sonnet."""
+    from bernstein.core.seed import parse_seed
+
+    seed_path = _write_seed(tmp_path / "bernstein.yaml", 'goal: "ship it"\nmodel: haiku\n')
+    seed = parse_seed(seed_path)
+    seed_path.unlink()  # file gone; only the in-memory seed remains
+    model, _cli, _role = _resolve_model_and_cli(str(seed_path), None, seed=seed)
+    assert model == "haiku"


### PR DESCRIPTION
## What

Close three related validation gaps in the `bernstein --dry-run` path (issue #2785):

1. `--dry-run` now validates the seed with the same rules `run` uses. A seed the real run rejects (e.g. an unsupported `cli:` value) raises the same parse error instead of printing "No open tasks found in backlog" and exiting 0.
2. A backlog file that is not the expected frontmatter/markdown format (e.g. plain YAML) now emits a visible warning naming the file instead of being silently skipped. The required backlog file format is documented in `docs/operations/task_format.md`.
3. The preflight cost estimator now runs after seed validation and honors the seed's effective default model, so it no longer prints an estimate "at sonnet pricing" for a seed the run will not use or would reject.

## Why

`--dry-run` is how a user checks a configuration before spending anything, so it must catch the same errors the real run would, and unparseable backlog files must be visible rather than silently skipped.

## How

- New shared helper `validate_seed_or_exit` in `run_preflight.py` parses the seed through the single existing validation boundary (`parse_seed`) and surfaces a `SeedError` as the same structured CLI error the run raises. Both the `--dry-run` flag path (`main.py`) and the run preflight (`run_bootstrap.py`) call it; no validation logic is duplicated.
- The run preflight validates the seed before `_estimate_run_preview` and threads the validated seed through `_resolve_model_and_cli`, so the estimate reflects the effective default model and never falls back to sonnet on a parse failure.
- `print_dry_run_table` warns on any backlog file that cannot be parsed.

Proven by `tests/unit/test_issue_2785_dryrun_seed_validation.py` (8 tests: seed validation reuse, `--dry-run` rejecting a bad seed, unparseable-file warning, validate-before-estimate ordering, and model resolution honoring the validated seed).

Closes #2785