### PR TITLE
fix(cost): record real token usage for qwen CLI-adapter runs

### DIFF
--- a/src/bernstein/adapters/qwen.py
+++ b/src/bernstein/adapters/qwen.py
@@ -129,7 +129,14 @@ class QwenAdapter(CLIAdapter):
         # in qwen-code (the unified form; the older ``-y`` / ``--yolo`` spellings
         # are no longer shown in ``qwen --help``). ``--approval-mode`` is the
         # stable flag the adapter contract verifies against the CLI help.
-        cmd: list[str] = ["qwen", "--approval-mode", "yolo"]
+        # ``--output-format stream-json`` makes qwen-code emit line-delimited
+        # JSON whose ``stats.models[<route>].tokens`` breakdown and per-call
+        # ``usage`` blocks carry the provider's own token accounting. The
+        # completion path recovers those counts from the session log so
+        # ``bernstein cost`` shows real ``Tokens In`` / ``Tokens Out`` for
+        # CLI-adapter runs instead of ``0`` / ``0`` (issue #2797). Streaming
+        # is preserved: records arrive line by line rather than buffered.
+        cmd: list[str] = ["qwen", "--approval-mode", "yolo", "--output-format", "stream-json"]
 
         # Map abstract/alias names to real Qwen API model IDs.
         # Always pass --model explicitly to avoid relying on settings.json.

--- a/src/bernstein/core/cost/cli_adapter_usage.py
+++ b/src/bernstein/core/cost/cli_adapter_usage.py
@@ -1,0 +1,314 @@
+"""Per-call token-usage capture for plain CLI-adapter runs (issue #2797).
+
+The openai_agents runner and the Claude Code wrapper each write a per-session
+``.tokens`` sidecar *during* a run, which the completion path recovers via
+:func:`bernstein.core.agents.agent_lifecycle._read_runner_cost_usd`. Plain CLI
+adapters (qwen and friends) wrote no such sidecar and captured no usage, so
+``bernstein cost`` reported ``Tokens In 0`` / ``Tokens Out 0`` for runs that
+made real model calls - the whole usage view was blank on a free route, where
+the ``$0`` dollar total is legitimately zero and token counts are the only
+usage signal.
+
+This module gives the CLI-adapter path its own usage source. The qwen adapter
+requests ``--output-format stream-json``, whose session log carries the
+provider's own token accounting (``stats.models[<route>].tokens`` and per-call
+``usage`` blocks). :func:`capture_cli_adapter_usage` parses that log and writes
+the same ``{"ts", "in", "out"}`` sidecar the recovery path already consumes, so
+no downstream accounting code has to change to see real counts.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Token-count key spellings seen across qwen-code output surfaces. The
+# authoritative ``stats.models[<route>].tokens`` breakdown uses
+# ``prompt``/``completion``; per-call ``usage`` blocks use
+# ``input_tokens``/``output_tokens`` (and a few provider-native aliases). We
+# accept all of them so capture stays robust across model routes rather than
+# pinned to one route's field names.
+_INPUT_KEYS: tuple[str, ...] = (
+    "prompt",
+    "input_tokens",
+    "prompt_tokens",
+    "input",
+    "promptTokenCount",
+    "inputTokens",
+)
+_OUTPUT_KEYS: tuple[str, ...] = (
+    "completion",
+    "output_tokens",
+    "completion_tokens",
+    "output",
+    "candidatesTokenCount",
+    "outputTokens",
+)
+
+
+def _as_dict(value: Any) -> dict[str, Any] | None:
+    """Return ``value`` as a ``dict[str, Any]`` when it is a mapping, else None."""
+    return cast("dict[str, Any]", value) if isinstance(value, dict) else None
+
+
+def _coerce_int(value: Any) -> int:
+    """Return ``value`` as a non-negative int, or ``0`` when not coercible."""
+    try:
+        result = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return result if result > 0 else 0
+
+
+def _extract_in_out(usage: dict[str, Any]) -> tuple[int, int]:
+    """Extract ``(input, output)`` token counts from a usage/tokens dict."""
+    tokens_in = 0
+    tokens_out = 0
+    for key in _INPUT_KEYS:
+        if key in usage:
+            tokens_in = _coerce_int(usage[key])
+            break
+    for key in _OUTPUT_KEYS:
+        if key in usage:
+            tokens_out = _coerce_int(usage[key])
+            break
+    return tokens_in, tokens_out
+
+
+def _records_from_text(text: str) -> list[dict[str, Any]]:
+    """Parse stream-json (line-delimited) or a single buffered JSON object.
+
+    ``--output-format stream-json`` emits one JSON object per line;
+    ``--output-format json`` emits a single buffered object (or array). Both
+    are handled: whole-text parse first, then a per-line fallback.
+    """
+    text = text.strip()
+    if not text:
+        return []
+    whole: Any = None
+    try:
+        whole = json.loads(text)
+    except ValueError:
+        whole = None
+    if isinstance(whole, dict):
+        return [cast("dict[str, Any]", whole)]
+    if isinstance(whole, list):
+        return [d for d in (_as_dict(rec) for rec in cast("list[Any]", whole)) if d is not None]
+
+    records: list[dict[str, Any]] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            parsed: Any = json.loads(line)
+        except ValueError:
+            continue
+        rec = _as_dict(parsed)
+        if rec is not None:
+            records.append(rec)
+    return records
+
+
+def _models_tokens(models: dict[str, Any]) -> tuple[int, int, str]:
+    """Sum ``tokens`` across a ``models`` map; return (in, out, first model)."""
+    tokens_in = 0
+    tokens_out = 0
+    model = ""
+    for name, entry in models.items():
+        if not model and name:
+            model = name
+        entry_dict = _as_dict(entry)
+        if entry_dict is not None:
+            tokens = _as_dict(entry_dict.get("tokens"))
+            if tokens is not None:
+                call_in, call_out = _extract_in_out(tokens)
+                tokens_in += call_in
+                tokens_out += call_out
+    return tokens_in, tokens_out, model
+
+
+def _record_model(rec: dict[str, Any]) -> str:
+    """Best-effort model/route id from a stream-json record."""
+    model = rec.get("model")
+    if isinstance(model, str) and model:
+        return model
+    message = _as_dict(rec.get("message"))
+    if message is not None:
+        inner = message.get("model")
+        if isinstance(inner, str) and inner:
+            return inner
+    return ""
+
+
+def _record_usage(rec: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the ``usage`` dict on a record or its nested message."""
+    usage = _as_dict(rec.get("usage"))
+    if usage is not None:
+        return usage
+    message = _as_dict(rec.get("message"))
+    if message is not None:
+        return _as_dict(message.get("usage"))
+    return None
+
+
+def parse_stream_json_usage(text: str) -> tuple[int, int, str]:
+    """Parse qwen-code stream-json output into ``(in, out, model)`` tokens.
+
+    Precedence, most authoritative first, so counts are never double-summed:
+
+    1. ``stats.models`` / ``metrics.models`` - the provider's own cumulative
+       per-session breakdown (``tokens.prompt`` / ``tokens.completion``).
+    2. The terminal ``result`` message's cumulative ``usage`` block.
+    3. The sum of per-call ``usage`` blocks on ``assistant`` messages.
+
+    Args:
+        text: Raw session-log text (line-delimited stream-json, or a single
+            buffered JSON object/array).
+
+    Returns:
+        ``(input_tokens, output_tokens, model)``. All zero / empty when the
+        text carries no recognisable usage.
+    """
+    records = _records_from_text(text)
+    if not records:
+        return 0, 0, ""
+
+    fallback_model = ""
+    for rec in records:
+        fallback_model = _record_model(rec)
+        if fallback_model:
+            break
+
+    # 1. Authoritative provider breakdown.
+    for rec in records:
+        for container_key in ("stats", "metrics"):
+            container = _as_dict(rec.get(container_key))
+            if container is None:
+                continue
+            models = _as_dict(container.get("models"))
+            if models:
+                tokens_in, tokens_out, model = _models_tokens(models)
+                if tokens_in > 0 or tokens_out > 0:
+                    return tokens_in, tokens_out, model or fallback_model
+
+    # 2. Terminal result usage (cumulative for the session).
+    for rec in records:
+        if rec.get("type") == "result":
+            usage = _record_usage(rec)
+            if usage is not None:
+                tokens_in, tokens_out = _extract_in_out(usage)
+                if tokens_in > 0 or tokens_out > 0:
+                    return tokens_in, tokens_out, _record_model(rec) or fallback_model
+
+    # 3. Sum per-call assistant usage.
+    total_in = 0
+    total_out = 0
+    model = ""
+    for rec in records:
+        if rec.get("type") != "assistant":
+            continue
+        usage = _record_usage(rec)
+        if usage is None:
+            continue
+        call_in, call_out = _extract_in_out(usage)
+        total_in += call_in
+        total_out += call_out
+        if not model:
+            model = _record_model(rec)
+    if total_in > 0 or total_out > 0:
+        return total_in, total_out, model or fallback_model
+
+    return 0, 0, fallback_model
+
+
+def _resolve_session_log(workdir: Path, session_id: str) -> Path | None:
+    """Resolve the on-disk session log for ``session_id``.
+
+    Mirrors the candidate order of
+    :meth:`bernstein.core.agents.agent_log_aggregator.AgentLogAggregator._resolve_log_path`
+    so worktree-isolated runs (where the adapter wrote its log inside a
+    per-task worktree) are found alongside the non-isolated root layout.
+    """
+    candidates = (
+        workdir / ".sdd" / "runtime" / f"{session_id}.log",
+        workdir / ".sdd" / "logs" / f"{session_id}.log",
+        workdir / ".sdd" / "worktrees" / session_id / ".sdd" / "runtime" / f"{session_id}.log",
+        workdir / ".sdd" / "worktrees" / session_id / ".sdd" / "logs" / f"{session_id}.log",
+    )
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def capture_cli_adapter_usage(
+    workdir: Path,
+    session_id: str,
+    log_path: Path | None = None,
+) -> tuple[int, int, str]:
+    """Recover CLI-adapter token usage and materialise the recovery sidecar.
+
+    Parses the adapter's structured session log and, when it carries real
+    token counts, appends a ``{"ts", "in", "out"}`` record to the
+    orchestrator-root ``.sdd/runtime/<session_id>.tokens`` sidecar - the exact
+    file
+    :func:`bernstein.core.agents.agent_lifecycle._read_runner_cost_usd` reads
+    at task completion. No-op when a sidecar already exists (the openai_agents
+    runner or the Claude wrapper wrote one during the run) so counts are never
+    double-recorded.
+
+    Args:
+        workdir: Orchestrator root working directory. The sidecar is written
+            under ``workdir/.sdd/runtime`` regardless of worktree isolation,
+            so the completion-time recovery keyed off the same root finds it.
+        session_id: Agent session id - the sidecar/log stem.
+        log_path: Explicit session-log path (e.g. ``session.log_path``). When
+            absent or missing, the workdir candidate layout is searched.
+
+    Returns:
+        ``(input_tokens, output_tokens, model)`` parsed from the log. All zero
+        / empty when there is no sidecar to write (already present, log
+        missing, or no usage found).
+    """
+    if not session_id:
+        return 0, 0, ""
+
+    sidecar_path = workdir / ".sdd" / "runtime" / f"{session_id}.tokens"
+    try:
+        if sidecar_path.exists() and sidecar_path.stat().st_size > 0:
+            # A runner/wrapper already recorded usage during the run.
+            return 0, 0, ""
+    except OSError:
+        pass
+
+    resolved = log_path if (log_path is not None and log_path.exists()) else _resolve_session_log(workdir, session_id)
+    if resolved is None:
+        return 0, 0, ""
+    try:
+        text = resolved.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return 0, 0, ""
+
+    tokens_in, tokens_out, model = parse_stream_json_usage(text)
+    if tokens_in <= 0 and tokens_out <= 0:
+        return 0, 0, model
+
+    try:
+        sidecar_path.parent.mkdir(parents=True, exist_ok=True)
+        record = json.dumps({"ts": time.time(), "in": tokens_in, "out": tokens_out})
+        with sidecar_path.open("a", encoding="utf-8") as fh:
+            fh.write(record + "\n")
+    except OSError as exc:
+        # "tokens" here is the usage-count sidecar file, not a credential.
+        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
+        logger.warning("failed to write CLI-adapter tokens sidecar %s: %s", sidecar_path, exc)
+
+    return tokens_in, tokens_out, model

--- a/src/bernstein/core/cost/cost.py
+++ b/src/bernstein/core/cost/cost.py
@@ -788,10 +788,31 @@ def compute_savings_vs_opus(records: list[dict[str, Any]]) -> float:
     return savings
 
 
+def _record_is_completed(rec: dict[str, Any]) -> bool:
+    """Return whether a task record counts as a completed task.
+
+    Reconciles with ``bernstein cost``'s ``_count_task_status`` so the manual-
+    savings figure and the ``Tasks: N completed`` line are computed from the
+    same completion-aware view (issue #2797): an explicit ``status`` wins, and
+    only when no status was recorded does a nonzero ``cost_usd`` stand in as
+    "this task did real work". A free-route run that recorded neither a
+    ``done`` status nor any spend is therefore not counted, so no savings
+    figure is claimed for ``0`` completed tasks.
+    """
+    status = str(rec.get("status", "") or "").strip().lower()
+    if status:
+        return status == "done"
+    return float(rec.get("cost_usd", 0.0) or 0.0) > 0.0
+
+
 def compute_savings_vs_manual(records: list[dict[str, Any]], hourly_rate: float = 100.0) -> dict[str, float]:
     """Estimate savings vs manual coding.
 
-    Calculates: estimated_manual_hours * hourly_rate - api_cost.
+    Calculates: estimated_manual_hours * hourly_rate - api_cost. Manual hours
+    are summed only over completed task records (see
+    :func:`_record_is_completed`) so the savings figure reconciles with the
+    completed-task count instead of claiming hours for tasks that never
+    completed.
 
     Args:
         records: Task metric records from tasks.jsonl.
@@ -804,6 +825,8 @@ def compute_savings_vs_manual(records: list[dict[str, Any]], hourly_rate: float 
     api_cost = 0.0
     for rec in records:
         api_cost += float(rec.get("cost_usd", 0.0) or 0.0)
+        if not _record_is_completed(rec):
+            continue
         # Check if explicitly recorded, otherwise estimate based on scope
         recorded_hours = float(rec.get("estimated_manual_hours", 0.0) or 0.0)
         if recorded_hours <= 0:

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -3346,7 +3346,23 @@ def _record_completion_metrics(
             dead_model,
         )
     if sidecar_session is not None:
+        from pathlib import Path as _CliPath
+
         from bernstein.core.agents.agent_lifecycle import _read_runner_cost_usd
+        from bernstein.core.cost.cli_adapter_usage import capture_cli_adapter_usage
+
+        # Issue #2797: plain CLI adapters (qwen etc.) write no .tokens sidecar
+        # during the run, so recover per-call usage from the adapter's
+        # structured session log and materialise the sidecar the recovery
+        # below already consumes. No-op when a sidecar already exists
+        # (openai_agents / Claude wrapper wrote one) so counts are never
+        # double-recorded. Also yields the model/route id for attribution.
+        _cli_session_log = getattr(session, "log_path", "") or ""
+        _cli_in, _cli_out, _cli_model = capture_cli_adapter_usage(
+            orch._workdir,
+            str(getattr(sidecar_session, "id", "") or ""),
+            _CliPath(_cli_session_log) if _cli_session_log else None,
+        )
 
         sidecar_cost, sidecar_in, sidecar_out = _read_runner_cost_usd(orch._workdir, sidecar_session, task.id)
         if sidecar_cost > cost_usd or (cost_usd <= 0.0 and (sidecar_in > 0 or sidecar_out > 0)):
@@ -3363,6 +3379,10 @@ def _record_completion_metrics(
                 task_m.tokens_prompt = sidecar_in
                 task_m.tokens_completion = sidecar_out
                 task_m.tokens_used = sidecar_in + sidecar_out
+        # Attribute the model/route where the CLI log knows it but the record
+        # does not (dead-session completions record model=None -> "unknown").
+        if _cli_model and task_m is not None and not (task_m.model or "").strip():
+            task_m.model = _cli_model
     logger.info(
         "completion_cost_source: task_id=%s agent_id=%s source=%s cost_usd=%.6f tokens_prompt=%d tokens_completion=%d",
         task.id,
@@ -3541,7 +3561,13 @@ def _record_evolution_completion(
                 duration_seconds=round(duration, 2),
                 cost_usd=cost_usd,
                 janitor_passed=janitor_passed,
-                model=session.model_config.model if session else None,
+                # Fall back to the record's model when the session is gone
+                # (dead-session completions) so a known CLI-adapter route id,
+                # recovered from the session log in _record_completion_metrics,
+                # is attributed instead of writing model=None -> "unknown"
+                # (issue #2797).
+                model=(session.model_config.model if session else None)
+                or (str(getattr(task_m, "model", "") or "") or None if task_m else None),
                 provider=session.provider if session else None,
                 # task_m was reconciled with the runner's .tokens sidecar in
                 # _record_completion_metrics, so these carry the real token

--- a/tests/contract/contracts/qwen.yaml
+++ b/tests/contract/contracts/qwen.yaml
@@ -1,8 +1,10 @@
 # Contract for the Qwen CLI (adapter: qwen).
 #
 # Always-passed surface from src/bernstein/adapters/qwen.py::_build_command:
-# ``qwen --approval-mode yolo --model <resolved> [--auth-type openai] [--web-search-default tavily]``.
-# ``--approval-mode yolo`` and ``--model`` are always passed. Only ``--model``
+# ``qwen --approval-mode yolo --output-format stream-json --model <resolved> [--auth-type openai]``.
+# ``--approval-mode yolo``, ``--output-format stream-json`` and ``--model`` are
+# always passed (stream-json makes qwen emit the token accounting the cost path
+# recovers, issue #2797). Only ``--model``
 # is in ``required_flags`` because ``qwen --help`` does not enumerate the
 # approval-mode flag at the top level (in any spelling: -y / --yolo /
 # --approval-mode), so it cannot be drift-checked via help text; it is the

--- a/tests/unit/test_adapter_qwen.py
+++ b/tests/unit/test_adapter_qwen.py
@@ -116,6 +116,27 @@ class TestQwenAdapterSpawn:
         assert "-y" not in inner
         assert "--yolo" not in inner
 
+    def test_stream_json_output_format_present(self, tmp_path: Path) -> None:
+        # Issue #2797: the adapter requests structured stream-json output so
+        # the completion path can recover real per-call token usage from the
+        # session log.
+        adapter = QwenAdapter()
+        proc_mock = _make_popen_mock(pid=112)
+        settings = _default_settings()
+        with (
+            patch("bernstein.adapters.qwen.subprocess.Popen", return_value=proc_mock) as popen,
+            patch("bernstein.adapters.qwen.LLMSettings", return_value=settings),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="qwen-max", effort="high"),
+                session_id="qwen-sjson",
+            )
+        inner = _inner_cmd(popen.call_args.args[0])
+        assert "--output-format" in inner
+        assert inner[inner.index("--output-format") + 1] == "stream-json"
+
     def test_prompt_appended_last(self, tmp_path: Path) -> None:
         adapter = QwenAdapter()
         proc_mock = _make_popen_mock(pid=103)

--- a/tests/unit/test_cli_adapter_usage.py
+++ b/tests/unit/test_cli_adapter_usage.py
@@ -1,0 +1,213 @@
+"""Unit tests for CLI-adapter token-usage capture (issue #2797).
+
+Plain CLI adapters (qwen and friends) write no ``.tokens`` sidecar during a
+run, so ``bernstein cost`` reported ``Tokens In 0`` / ``Tokens Out 0`` for
+runs that made real model calls. These tests pin the parse-and-capture path
+that gives the CLI-adapter route its own usage source, plus the downstream
+recovery that turns the captured sidecar into nonzero cost-table token
+counts. No network calls: the qwen usage payloads are representative
+captures of ``qwen --output-format stream-json`` output.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from bernstein.core.cost.cli_adapter_usage import (
+    capture_cli_adapter_usage,
+    parse_stream_json_usage,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# A representative ``qwen --output-format stream-json`` session log for a
+# free route. Line-delimited JSON: a session_start, one assistant message
+# with per-call usage, and a terminal result carrying the authoritative
+# cumulative ``stats.models[<route>].tokens`` breakdown.
+_QWEN_STREAM_JSON_LOG = "\n".join(
+    [
+        json.dumps(
+            {
+                "type": "system",
+                "subtype": "session_start",
+                "session_id": "s1",
+                "model": "cohere/north-mini-code:free",
+            }
+        ),
+        json.dumps(
+            {
+                "type": "assistant",
+                "session_id": "s1",
+                "message": {
+                    "role": "assistant",
+                    "model": "cohere/north-mini-code:free",
+                    "content": [{"type": "text", "text": "Editing files..."}],
+                    "usage": {"input_tokens": 1200, "output_tokens": 340},
+                },
+            }
+        ),
+        json.dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "session_id": "s1",
+                "is_error": False,
+                "duration_ms": 1234,
+                "result": "done",
+                "usage": {"input_tokens": 5120, "output_tokens": 880},
+                "stats": {
+                    "models": {
+                        "cohere/north-mini-code:free": {
+                            "api": {"total_requests": 3, "total_errors": 0},
+                            "tokens": {
+                                "prompt": 5120,
+                                "completion": 880,
+                                "total": 6000,
+                                "cached": 1000,
+                                "thoughts": 0,
+                            },
+                        }
+                    }
+                },
+            }
+        ),
+    ]
+)
+
+
+class TestParseStreamJsonUsage:
+    """parse_stream_json_usage extracts real in/out tokens and model."""
+
+    def test_prefers_authoritative_stats_tokens(self) -> None:
+        tokens_in, tokens_out, model = parse_stream_json_usage(_QWEN_STREAM_JSON_LOG)
+        assert tokens_in == 5120
+        assert tokens_out == 880
+        assert model == "cohere/north-mini-code:free"
+
+    def test_falls_back_to_result_usage_without_stats(self) -> None:
+        log = "\n".join(
+            [
+                json.dumps({"type": "system", "subtype": "session_start", "model": "qwen3-coder-plus"}),
+                json.dumps(
+                    {
+                        "type": "result",
+                        "subtype": "success",
+                        "usage": {"input_tokens": 900, "output_tokens": 120},
+                    }
+                ),
+            ]
+        )
+        tokens_in, tokens_out, model = parse_stream_json_usage(log)
+        assert tokens_in == 900
+        assert tokens_out == 120
+        assert model == "qwen3-coder-plus"
+
+    def test_sums_assistant_usage_without_result_or_stats(self) -> None:
+        log = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {"model": "qwen3-coder-plus", "usage": {"input_tokens": 100, "output_tokens": 20}},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {"model": "qwen3-coder-plus", "usage": {"input_tokens": 300, "output_tokens": 40}},
+                    }
+                ),
+            ]
+        )
+        tokens_in, tokens_out, model = parse_stream_json_usage(log)
+        assert tokens_in == 400
+        assert tokens_out == 60
+        assert model == "qwen3-coder-plus"
+
+    def test_single_object_output_format(self) -> None:
+        # ``--output-format json`` returns one buffered object with stats.
+        blob = json.dumps(
+            {
+                "response": "done",
+                "stats": {"models": {"qwen3-coder-plus": {"tokens": {"prompt": 42, "completion": 7}}}},
+            }
+        )
+        tokens_in, tokens_out, model = parse_stream_json_usage(blob)
+        assert tokens_in == 42
+        assert tokens_out == 7
+        assert model == "qwen3-coder-plus"
+
+    def test_empty_and_nonjson_log_returns_zeros(self) -> None:
+        assert parse_stream_json_usage("") == (0, 0, "")
+        assert parse_stream_json_usage("not json at all\njust text\n") == (0, 0, "")
+
+
+class TestCaptureCliAdapterUsage:
+    """capture_cli_adapter_usage materialises the recovery sidecar."""
+
+    def _write_log(self, workdir: Path, session_id: str, text: str) -> Path:
+        log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text(text, encoding="utf-8")
+        return log_path
+
+    def test_writes_sidecar_from_qwen_log(self, tmp_path: Path) -> None:
+        self._write_log(tmp_path, "s1", _QWEN_STREAM_JSON_LOG)
+        tokens_in, tokens_out, model = capture_cli_adapter_usage(tmp_path, "s1")
+        assert (tokens_in, tokens_out, model) == (5120, 880, "cohere/north-mini-code:free")
+
+        sidecar = tmp_path / ".sdd" / "runtime" / "s1.tokens"
+        assert sidecar.exists()
+        rec = json.loads(sidecar.read_text(encoding="utf-8").strip())
+        assert rec["in"] == 5120
+        assert rec["out"] == 880
+
+    def test_noop_when_sidecar_already_present(self, tmp_path: Path) -> None:
+        # openai_agents / Claude wrapper already wrote a sidecar during the
+        # run - capture must not double-count on top of it.
+        self._write_log(tmp_path, "s1", _QWEN_STREAM_JSON_LOG)
+        sidecar = tmp_path / ".sdd" / "runtime" / "s1.tokens"
+        sidecar.write_text(json.dumps({"ts": 1.0, "in": 10, "out": 2}) + "\n", encoding="utf-8")
+
+        result = capture_cli_adapter_usage(tmp_path, "s1")
+        assert result == (0, 0, "")
+        # Sidecar left untouched (single record).
+        assert len(sidecar.read_text(encoding="utf-8").strip().splitlines()) == 1
+
+    def test_noop_when_log_missing(self, tmp_path: Path) -> None:
+        assert capture_cli_adapter_usage(tmp_path, "missing") == (0, 0, "")
+        assert not (tmp_path / ".sdd" / "runtime" / "missing.tokens").exists()
+
+    def test_explicit_log_path_wins(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "custom" / "qwen.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text(_QWEN_STREAM_JSON_LOG, encoding="utf-8")
+        tokens_in, tokens_out, _ = capture_cli_adapter_usage(tmp_path, "s1", log_path)
+        assert tokens_in == 5120
+        assert tokens_out == 880
+
+
+class TestSidecarFeedsCostRecovery:
+    """The captured sidecar becomes nonzero cost-table token counts."""
+
+    def test_recovery_reads_nonzero_tokens_zero_usd_for_free_route(self, tmp_path: Path) -> None:
+        from types import SimpleNamespace
+
+        from bernstein.core.agents.agent_lifecycle import _read_runner_cost_usd
+
+        log_path = tmp_path / ".sdd" / "runtime" / "s1.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text(_QWEN_STREAM_JSON_LOG, encoding="utf-8")
+        capture_cli_adapter_usage(tmp_path, "s1")
+
+        session = SimpleNamespace(
+            id="s1",
+            model_config=SimpleNamespace(model="cohere/north-mini-code:free"),
+        )
+        cost_usd, tokens_in, tokens_out = _read_runner_cost_usd(tmp_path, session, "task-1")
+        # Free route: dollars legitimately zero, tokens must be real.
+        assert cost_usd == 0.0
+        assert tokens_in == 5120
+        assert tokens_out == 880

--- a/tests/unit/test_cost_engine.py
+++ b/tests/unit/test_cost_engine.py
@@ -723,3 +723,34 @@ class TestComputeSavingsVsManual:
         assert res["manual_cost_usd"] == pytest.approx(750.0)
         assert res["api_cost_usd"] == pytest.approx(4.0)
         assert res["savings_usd"] == pytest.approx(746.0)
+
+    def test_no_savings_when_no_task_completed(self) -> None:
+        # Issue #2797: a free-route run records real token usage but no
+        # ``status`` and ``$0`` cost, so nothing is "completed". The savings
+        # figure must reconcile with that instead of claiming manual hours
+        # for tasks that never completed.
+        from bernstein.core.cost import compute_savings_vs_manual
+
+        records = [
+            {"cost_usd": 0.0, "tokens_prompt": 5120, "tokens_completion": 880, "scope": "large"},
+            {"cost_usd": 0.0, "tokens_prompt": 1200, "tokens_completion": 340, "scope": "medium"},
+        ]
+        res = compute_savings_vs_manual(records)
+        assert res["manual_hours"] == pytest.approx(0.0)
+        assert res["savings_usd"] == pytest.approx(0.0)
+
+    def test_counts_only_done_status_records(self) -> None:
+        # Explicit status wins over the cost>0 fallback: a failed task with
+        # real spend must not contribute manual-savings hours.
+        from bernstein.core.cost import compute_savings_vs_manual
+
+        records = [
+            {"cost_usd": 0.0, "status": "done", "scope": "medium"},  # 1.5 hr
+            {"cost_usd": 2.0, "status": "failed", "scope": "large"},  # excluded
+        ]
+        res = compute_savings_vs_manual(records)
+        assert res["manual_hours"] == pytest.approx(1.5)
+        # Manual cost = 1.5 hr * $100 = $150; api_cost still sums real spend
+        # across all records (including the failed one) = $2.0.
+        assert res["api_cost_usd"] == pytest.approx(2.0)
+        assert res["savings_usd"] == pytest.approx(148.0)


### PR DESCRIPTION
## What

qwen (and other plain CLI adapters) reported `Tokens In 0` / `Tokens Out 0` in `bernstein cost` for runs that made real model calls. The `$0.0000` dollar total for a zero-priced free route (`cohere/north-mini-code:free`) is correct and is left unchanged; only the token counters and the model attribution were wrong.

## Why

Token capture depended entirely on either the openai_agents runner or the Claude Code wrapper writing a per-session `.tokens` sidecar during the run. The completion-time recovery (`_read_runner_cost_usd`) reads that sidecar; plain CLI adapters wrote none, so it recovered `0/0` and the cost table's `Tokens In` / `Tokens Out` columns (fed from `tokens_prompt` / `tokens_completion` on the task record) stayed zero. On a free route, where dollars are legitimately `$0`, the token columns were the only usage signal - so the whole usage view was blank. Some rows also showed model `unknown` on dead-session completions that record `model=None`.

## How

- The qwen adapter spawns with `--output-format stream-json`, whose session log carries the provider's own token accounting (`stats.models[<route>].tokens` and per-call `usage` blocks). Streaming is preserved (records arrive line by line).
- New module `src/bernstein/core/cost/cli_adapter_usage.py` parses that log and materialises the same `{"ts","in","out"}` sidecar the recovery path already consumes. It is a no-op when a sidecar already exists (runner / Claude wrapper wrote one), so counts are never double-recorded.
- Completion wiring (`_record_completion_metrics`) recovers the counts before pricing - USD stays `$0.0000` for a zero-priced free route - and attributes the model/route id from the log when the record would otherwise be `unknown`.
- Summary reconciliation: `compute_savings_vs_manual` now sums manual hours only over completed task records (same completion-aware rule as the task-status count), so a run with `0` completed tasks prints no savings figure.

Proven by `tests/unit/test_cli_adapter_usage.py` - in particular `TestSidecarFeedsCostRecovery::test_recovery_reads_nonzero_tokens_zero_usd_for_free_route` asserts nonzero in/out tokens with `$0` USD on the free route - plus the qwen `--output-format stream-json` flag test and the `compute_savings_vs_manual` reconciliation tests in `test_cost_engine.py`. No network calls; the qwen usage payloads are representative stream-json captures.

Note: the "Manual Coding Savings vs 0 completed" mismatch overlaps the known task-count family (#2748); this PR scopes the savings line to the completion-aware view and keeps the zero-token defect on the CLI-adapter path as the core fix.

Closes #2797