### PR TITLE
chore(observability): daily snapshot + trends refresh

### DIFF
--- a/docs/observability/trends.md
+++ b/docs/observability/trends.md
@@ -1,6 +1,6 @@
 # Observability trends
 
-_Window: 2026-05-22 -> 2026-07-22 (10 day(s); target 30)_
+_Window: 2026-05-22 -> 2026-07-23 (10 day(s); target 30)_
 
 Sparklines are rendered with unicode block characters. Each tick is one daily snapshot from `bernstein doctor observe --json`. Missing days appear as blank ticks.
 
@@ -8,7 +8,7 @@ Sparklines are rendered with unicode block characters. Each tick is one daily sn
 
 | metric | sparkline | first | latest | min | max |
 | --- | --- | ---: | ---: | ---: | ---: |
-| coverage_pct | `▁▇▇▇▇▇▇▇▇█` | 13.50 | 81.90 | 13.50 | 81.90 |
+| coverage_pct | `▁▇▇▇▇▇▇▇▇█` | 13.50 | 82.00 | 13.50 | 82.00 |
 | code_smells | `█        ▂` | 153.00 | 42.00 | 0.00 | 153.00 |
 | bugs | `█         ` | 11.00 | 1.00 | 0.00 | 11.00 |
 | vulnerabilities | `▅      █▂▂` | 2.00 | 1.00 | 0.00 | 3.00 |
@@ -33,7 +33,7 @@ Sparklines are rendered with unicode block characters. Each tick is one daily sn
 
 | metric | sparkline | first | latest | min | max |
 | --- | --- | ---: | ---: | ---: | ---: |
-| open_alerts | ` ▂       █` | 6.00 | 68.00 | 0.00 | 68.00 |
+| open_alerts | ` ▁       █` | 6.00 | 71.00 | 0.00 | 71.00 |
 | critical_alerts | `          ` | 0.00 | 0.00 | 0.00 | 0.00 |
-| high_alerts | `   ▄  ▂ ▁█` | 0.00 | 8.00 | 0.00 | 8.00 |
+| high_alerts | `   ▅  ▂ ▁█` | 0.00 | 6.00 | 0.00 | 6.00 |
 


### PR DESCRIPTION
Automated daily observability snapshot generated by
`docs-observability-snapshot.yml`. Includes today's JSON
snapshot under `docs/_internal/observability/snapshots/` and a
re-rendered `docs/observability/trends.md` covering the
last 30 days.

## Summary by Sourcery

Update observability trends documentation with the latest daily snapshot metrics.

Documentation:
- Refresh docs/observability/trends.md to extend the metrics window by one day and reflect updated coverage and alert statistics.

Chores:
- Regenerate observability snapshot data as part of the daily automated docs refresh.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated observability trends to reflect the latest reporting window through July 23, 2026.
  * Refreshed coverage and code-scanning trend metrics, including current and maximum values.
  * Confirmed that critical code-scanning alerts remain at zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->