### PR TITLE
chore(ci): ratchet coverage baseline up to 81.6%

### DIFF
--- a/.coverage-baseline.json
+++ b/.coverage-baseline.json
@@ -1,5 +1,5 @@
 {
   "diff_coverage_floor_percent": 85,
-  "total_coverage_percent": 81.54,
-  "updated_at": "2026-07-22T09:44:03+00:00"
+  "total_coverage_percent": 81.6,
+  "updated_at": "2026-07-23T15:04:48+00:00"
 }


### PR DESCRIPTION
Total line coverage rose on `main`, so the monotonic ratchet
bumped the committed high-water mark in `.coverage-baseline.json`
to **81.6%**.

From here, any later push whose total coverage falls below this
mark is flagged by the LEVEL 2 ratchet. The gate stays advisory
until promoted; see `docs/operations/coverage-ratchet.md`.

Generated by `.github/workflows/coverage-ratchet.yml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the recorded test coverage baseline to 81.6%.
  * Maintained the required 85% minimum coverage for changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->