### PR TITLE
fix(tests): drop retired Sonar/GlitchTip refs from hygiene tests

### DIFF
--- a/tests/unit/test_sonar_final_style_hygiene.py
+++ b/tests/unit/test_sonar_final_style_hygiene.py
@@ -43,14 +43,6 @@ def test_telegram_command_dispatch_uses_list_constructor_for_copy() -> None:
     assert "[p for p in text.split()]" not in source
 
 
-def test_pluggy_camel_case_hook_names_have_scoped_sonar_suppression() -> None:
-    """External camelCase lifecycle hooks are suppressed only for the bridge file."""
-    source = _read_source("sonar-project.properties")
-
-    assert "sonar.issue.ignore.multicriteria.e19.ruleKey=python:S116" in source
-    assert "sonar.issue.ignore.multicriteria.e19.resourceKey=src/bernstein/core/lifecycle/pluggy_bridge.py" in source
-
-
 def test_ranked_candidate_default_factory_uses_literal_constructor() -> None:
     """Empty dict defaults should use literal constructor syntax."""
     source = _read_source("src/bernstein/core/orchestration/multi_criteria_rank.py")

--- a/tests/unit/test_sonar_regex_concision.py
+++ b/tests/unit/test_sonar_regex_concision.py
@@ -11,7 +11,6 @@ from bernstein.core.persistence.action_cache import redact_secrets
 from bernstein.core.quality.pr_review_aggregator import _normalise_tokens as aggregate_tokens
 from bernstein.core.quality.review_consensus import _normalise_tokens as consensus_tokens
 from bernstein.core.tasks.backlog_parser import _STORY_ID, _TASK_ID
-from bernstein.eval.incident_synthesizer import _safe_tag
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TRACKED_FILES = (
@@ -22,7 +21,6 @@ TRACKED_FILES = (
     Path("src/bernstein/core/quality/pr_review_aggregator.py"),
     Path("src/bernstein/core/quality/review_consensus.py"),
     Path("src/bernstein/core/tasks/backlog_parser.py"),
-    Path("src/bernstein/eval/incident_synthesizer.py"),
 )
 OLD_REGEX_FRAGMENTS = (
     "[A-Za-z0-9]",
@@ -80,5 +78,3 @@ def test_regex_behavior_is_preserved_for_representative_inputs() -> None:
     assert _TASK_ID.match("Tabc") is None
     assert _STORY_ID.match("US123-alpha") is not None
     assert _STORY_ID.match("USabc") is None
-
-    assert _safe_tag("ValueError: bad/path") == "valueerror_bad_path"


### PR DESCRIPTION
## What
Fix two rule-named `test_sonar_*.py` hygiene tests broken by #2859 (observability retirement).

## Why
#2859 deleted `sonar-project.properties` and the GlitchTip-specific `_safe_tag` helper. A collection ImportError in `test_sonar_regex_concision.py` masked a second `FileNotFoundError` in `test_sonar_final_style_hygiene.py`; both fail on current main.

## How
- `test_sonar_regex_concision.py`: drop the `_safe_tag` import, its assertion, and the `incident_synthesizer.py` TRACKED_FILES entry (the file has no old-form regex fragments left).
- `test_sonar_final_style_hygiene.py`: remove the now-moot `test_pluggy_camel_case_hook_names_have_scoped_sonar_suppression` (it asserted a rule in the deleted Sonar config). The five src-style hygiene assertions are unchanged.
- Full `tests/unit/test_sonar_*.py` suite: 31 passed.

Refs #2857.

## Summary by Sourcery

Update unit hygiene tests to reflect retirement of Sonar configuration and related observability utilities.

Tests:
- Remove Sonar-specific suppression assertion from final style hygiene tests now that sonar-project.properties is gone.
- Drop retired incident synthesizer references and assertions from regex concision tests, keeping coverage to currently tracked files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed outdated checks for scoped Sonar suppression configuration.
  * Simplified regex-concision coverage by removing obsolete incident-synthesis and tag-normalization checks.
  * Retained validation for active regex, token, redaction, aggregation, and identifier behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->