### PR TITLE
fix(tests): drop retired sbom-upload.yml from release-entrypoint doc check

### DIFF
--- a/tests/unit/test_release_entrypoint_docs.py
+++ b/tests/unit/test_release_entrypoint_docs.py
@@ -22,7 +22,6 @@ RELEASE_ENTRYPOINTS: dict[str, tuple[str, ...]] = {
     "reconcile-release.yml": ("schedule", "workflow_dispatch"),
     "publish-docker.yml": ("release", "workflow_dispatch"),
     "publish-homebrew.yml": ("release", "workflow_dispatch"),
-    "sbom-upload.yml": ("push", "release"),
 }
 
 


### PR DESCRIPTION
## What
Fix the release-entrypoint doc test broken by #2863 (Dependency-Track retirement).

## Why
#2863 deleted `sbom-upload.yml` (a DT-only upload; release SBOMs come from `sbom.yml`). `test_release_entrypoint_docs.py` still listed it in `RELEASE_ENTRYPOINTS` and asserts existence -> fails on current main (and any `pytest tests/unit` consumer: Test shards, Beartype).

## How
Drop the `sbom-upload.yml` entry from `RELEASE_ENTRYPOINTS`. release.md already references `sbom.yml` instead.

Refs #2857.

## Summary by Sourcery

Bug Fixes:
- Remove the obsolete sbom-upload.yml entry from RELEASE_ENTRYPOINTS so the release-entrypoint documentation test no longer asserts the existence of a deleted workflow file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated release documentation validation to reflect current workflow references.
  * Removed the requirement to document the SBOM upload workflow and its triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->