### PR TITLE
feat(cost): canonical money and text core for tenant showback statements

### DIFF
--- a/docs/cost/showback-canonical.md
+++ b/docs/cost/showback-canonical.md
@@ -1,0 +1,46 @@
+# Canonical money and text for showback statements
+
+Tenant showback statements (#2554) are recomputed independently by two
+parties and compared byte for byte, so every value that enters a statement
+needs exactly one encoding. `bernstein.core.cost.showback_canonical` fixes
+the three ground rules; everything downstream (line-item receipts, rollup
+projections, `bernstein tenant showback` / `verify-statement`) builds on
+them.
+
+## Money: fixed-scale integers
+
+| Rule | Value |
+|---|---|
+| Scale | nano-USD (`1 USD = 10^9`), integer arithmetic only |
+| Rounding | exactly once, at line-item creation (`nano_usd_from_float`), banker's rounding to 1 nano-USD |
+| Totals | integer sums of exact line-item values; aggregation order can never change a digit |
+| In payloads | string-encoded integers (`"250000000"`) so every raw JSON number stays inside the I-JSON safe range |
+| Operator text form | `nano_usd_from_decimal_str` / `nano_usd_to_decimal_str`; rendering always carries nine fractional digits |
+
+Nano rather than micro scale: per-token line items on inexpensive models
+fall below one micro-USD, and a fixed scale must hold the smallest value
+the ledger can attribute without a second rounding step.
+
+## Text: reject, don't repair
+
+Every string key and value in a statement must already be Unicode NFC.
+`require_nfc` rejects anything else instead of normalizing it, because a
+verifier must hash exactly the bytes it was handed, and normalization
+tables move between Unicode versions; rejection semantics are stable, and
+data accepted once stays NFC under later Unicode versions.
+
+## Statement bytes
+
+`canonical_statement_bytes` validates the payload tree (no floats
+anywhere, NFC everywhere, integers inside the I-JSON range) and then
+encodes it with the shared RFC 8785 canonicalizer used for agent-card
+signing. Two writers with the same payload produce identical bytes; the
+statement hash is therefore comparable across machines and languages.
+
+## Cross-language vectors
+
+`tests/fixtures/showback/canonical_vectors.json` carries the parse,
+render, float-bridge, NFC, and statement-hash vectors a non-Python
+implementation must reproduce. Extend the vectors file rather than adding
+cases in test code; `tests/unit/test_showback_canonical.py` binds the file
+to the Python implementation.

--- a/src/bernstein/core/cost/showback_canonical.py
+++ b/src/bernstein/core/cost/showback_canonical.py
@@ -1,0 +1,191 @@
+"""Canonical money and text core for tenant showback statements (#2554).
+
+Showback statements are meant to be recomputed byte-identically by two
+independent parties and verified offline, so every value that enters a
+statement must have exactly one encoding. This module fixes the three
+policies everything downstream builds on:
+
+**Money is a fixed-scale integer.** Amounts are integers of nano-USD
+(1 USD = 10**9 nano-USD). Rounding happens exactly once, when a line item
+is created from the float spend ledger (:func:`nano_usd_from_float`,
+banker's rounding); totals are integer sums of those exact values, so
+aggregation order can never change a digit. Inside statement payloads,
+amounts travel as *string-encoded* integers ("250000000"), keeping every
+number in the payload inside the I-JSON interoperable range.
+
+**Text is rejected, not repaired.** Every string in a statement must
+already be in Unicode NFC (:func:`require_nfc`). Normalizing on behalf of
+the caller would mean the verifier transforms input before hashing it,
+and normalization tables move between Unicode versions for unassigned
+code points; rejection is stable, and data accepted once stays NFC under
+every later Unicode version by the normalization stability policy.
+
+**Floats never reach canonical bytes.** :func:`canonical_statement_bytes`
+walks the payload tree, rejects any ``float``, any non-NFC string, and
+any integer outside the I-JSON safe range, then delegates the encoding to
+the shared RFC 8785 canonicalizer
+(:func:`bernstein.core.security.agent_card_signer.canonicalize_jcs`).
+
+Cross-language test vectors live in
+``tests/fixtures/showback/canonical_vectors.json``; extend the vectors
+file rather than encoding new cases in test code.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+import unicodedata
+from decimal import ROUND_HALF_EVEN, Decimal
+from typing import Any
+
+from bernstein.core.security.agent_card_signer import canonicalize_jcs
+
+__all__ = [
+    "NANO_USD_PER_USD",
+    "CanonicalStatementError",
+    "FloatRejectedError",
+    "MoneyFormatError",
+    "NonCanonicalTextError",
+    "canonical_statement_bytes",
+    "nano_usd_from_decimal_str",
+    "nano_usd_from_float",
+    "nano_usd_to_decimal_str",
+    "require_nfc",
+]
+
+#: Fixed money scale: one USD in nano-USD.
+NANO_USD_PER_USD: int = 10**9
+
+#: JSON numbers outside ``(-2**53, 2**53)`` are not interoperable (RFC 7493
+#: I-JSON); statement payloads must string-encode anything that large.
+_IJSON_MAX_INT: int = 2**53
+
+#: Canonical decimal-string grammar: optional minus, integer part without
+#: leading zeros, optional fraction of at most nine digits. No exponent,
+#: no plus sign, no whitespace, ASCII digits only.
+_MONEY_RE = re.compile(r"-?(?:0|[1-9][0-9]*)(?:\.[0-9]{1,9})?", re.ASCII)
+
+_NANO_QUANTUM = Decimal(1).scaleb(-9)
+
+
+class CanonicalStatementError(ValueError):
+    """A value cannot appear in a canonical showback statement."""
+
+
+class MoneyFormatError(CanonicalStatementError):
+    """A monetary value is not in the canonical fixed-scale form."""
+
+
+class NonCanonicalTextError(CanonicalStatementError):
+    """A string is not in Unicode NFC; the caller must fix its input."""
+
+
+class FloatRejectedError(CanonicalStatementError):
+    """A float reached a statement payload; money must be fixed-scale."""
+
+
+def require_nfc(text: str) -> str:
+    """Return ``text`` unchanged if it is NFC; raise otherwise.
+
+    The value is deliberately never normalized here: a verifier must hash
+    exactly the bytes it was handed, and silent repair would let two
+    parties sign different bytes for the "same" statement.
+    """
+    if not unicodedata.is_normalized("NFC", text):
+        raise NonCanonicalTextError(
+            f"text is not NFC-normalized: {text!r}; normalize at the input boundary before it enters a statement"
+        )
+    return text
+
+
+def nano_usd_from_decimal_str(text: str) -> int:
+    """Parse a canonical decimal USD string into integer nano-USD.
+
+    Accepts at most nine fractional digits and rejects every notation
+    with more than one spelling (exponents, leading zeros, ``+``, ``-0``,
+    bare or trailing dots, whitespace, non-ASCII digits) so a given
+    amount has exactly one accepted text form per fraction length.
+    """
+    if not _MONEY_RE.fullmatch(text):
+        raise MoneyFormatError(f"not a canonical decimal USD amount: {text!r}")
+    negative = text.startswith("-")
+    body = text[1:] if negative else text
+    integer_part, _, fraction = body.partition(".")
+    nanos = int(integer_part) * NANO_USD_PER_USD + int(fraction.ljust(9, "0") or "0")
+    if negative:
+        if nanos == 0:
+            raise MoneyFormatError("negative zero is not a canonical amount")
+        nanos = -nanos
+    return nanos
+
+
+def nano_usd_from_float(cost_usd: float) -> int:
+    """Convert a float ledger amount to nano-USD, rounding exactly once.
+
+    The float is read through its shortest round-trip decimal (``repr``),
+    then quantized to one nano-USD with banker's rounding. This is the
+    single place a showback amount may be rounded; everything downstream
+    works on the exact integer.
+    """
+    if not math.isfinite(cost_usd):
+        raise MoneyFormatError(f"non-finite amount: {cost_usd!r}")
+    quantized = Decimal(repr(cost_usd)).quantize(_NANO_QUANTUM, rounding=ROUND_HALF_EVEN)
+    return int(quantized.scaleb(9))
+
+
+def nano_usd_to_decimal_str(nanos: int) -> str:
+    """Render integer nano-USD in the canonical decimal form.
+
+    Always nine fractional digits: one rule, no trimming ambiguity, and
+    ``nano_usd_from_decimal_str`` round-trips the result exactly.
+    """
+    sign = "-" if nanos < 0 else ""
+    whole, frac = divmod(abs(nanos), NANO_USD_PER_USD)
+    return f"{sign}{whole}.{frac:09d}"
+
+
+def canonical_statement_bytes(payload: Any) -> bytes:
+    """Encode a statement payload as RFC 8785 canonical JSON bytes.
+
+    Validates the whole tree first: floats are rejected outright (money
+    must already be fixed-scale, string-encoded), every string key and
+    value must be NFC, and integers must stay inside the I-JSON safe
+    range. Only a payload that passes untransformed is encoded.
+    """
+    _validate_tree(payload, "$")
+    return canonicalize_jcs(payload)
+
+
+def _validate_tree(value: Any, path: str) -> None:
+    if isinstance(value, bool) or value is None:
+        return
+    if isinstance(value, float):
+        raise FloatRejectedError(
+            f"float at {path}: statement amounts must be string-encoded integer nano-USD, not floats"
+        )
+    if isinstance(value, int):
+        if not -_IJSON_MAX_INT < value < _IJSON_MAX_INT:
+            raise MoneyFormatError(f"integer at {path} exceeds the I-JSON safe range; string-encode it")
+        return
+    if isinstance(value, str):
+        try:
+            require_nfc(value)
+        except NonCanonicalTextError as exc:
+            raise NonCanonicalTextError(f"at {path}: {exc}") from None
+        return
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            _validate_tree(item, f"{path}[{index}]")
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise CanonicalStatementError(f"non-string key at {path}: {key!r}")
+            try:
+                require_nfc(key)
+            except NonCanonicalTextError as exc:
+                raise NonCanonicalTextError(f"key at {path}: {exc}") from None
+            _validate_tree(item, f"{path}.{key}")
+        return
+    raise CanonicalStatementError(f"unsupported type at {path}: {type(value).__name__}")

--- a/tests/fixtures/showback/canonical_vectors.json
+++ b/tests/fixtures/showback/canonical_vectors.json
@@ -1,0 +1,241 @@
+{
+  "schema": "showback-canonical-vectors-v1",
+  "notes": "Cross-language vectors for the tenant showback canonical core. money_parse/money_render cover the operator-facing decimal-string format (nano-USD fixed scale, 9 fractional digits); float_bridge covers the one-time conversion from the float spend ledger (shortest round-trip decimal of the IEEE 754 double, then ROUND_HALF_EVEN to 1e-9); nfc covers the reject-don't-repair text policy; statements bind validated payload trees to RFC 8785 canonical bytes via sha256.",
+  "money_parse": [
+    {
+      "desc": "integer dollars",
+      "input": "3",
+      "nano_usd": 3000000000
+    },
+    {
+      "desc": "typical price fraction",
+      "input": "0.25",
+      "nano_usd": 250000000
+    },
+    {
+      "desc": "full nine fractional digits",
+      "input": "0.000000001",
+      "nano_usd": 1
+    },
+    {
+      "desc": "negative credit line",
+      "input": "-1.5",
+      "nano_usd": -1500000000
+    },
+    {
+      "desc": "zero",
+      "input": "0",
+      "nano_usd": 0
+    },
+    {
+      "desc": "trailing zeros accepted on input",
+      "input": "0.250000000",
+      "nano_usd": 250000000
+    },
+    {
+      "desc": "large amount",
+      "input": "12345678.900000000",
+      "nano_usd": 12345678900000000
+    },
+    {
+      "desc": "reject exponent notation",
+      "input": "1e3",
+      "error": "money-format"
+    },
+    {
+      "desc": "reject tenth fractional digit",
+      "input": "0.0000000001",
+      "error": "money-format"
+    },
+    {
+      "desc": "reject leading zero",
+      "input": "01.5",
+      "error": "money-format"
+    },
+    {
+      "desc": "reject plus sign",
+      "input": "+1",
+      "error": "money-format"
+    },
+    {
+      "desc": "reject negative zero",
+      "input": "-0",
+      "error": "money-format"
+    },
+    {
+      "desc": "reject negative zero with fraction",
+      "input": "-0.000000000",
+      "error": "money-format"
+    },
+    {
+      "desc": "reject bare fraction",
+      "input": ".5",
+      "error": "money-format"
+    },
+    {
+      "desc": "reject trailing dot",
+      "input": "1.",
+      "error": "money-format"
+    },
+    {
+      "desc": "reject whitespace",
+      "input": " 1",
+      "error": "money-format"
+    },
+    {
+      "desc": "reject thousands separator",
+      "input": "1,000",
+      "error": "money-format"
+    },
+    {
+      "desc": "reject empty string",
+      "input": "",
+      "error": "money-format"
+    },
+    {
+      "desc": "reject non-ascii digits",
+      "input": "١",
+      "error": "money-format"
+    }
+  ],
+  "money_render": [
+    {
+      "desc": "zero renders nine digits",
+      "nano_usd": 0,
+      "text": "0.000000000"
+    },
+    {
+      "desc": "one nano-USD",
+      "nano_usd": 1,
+      "text": "0.000000001"
+    },
+    {
+      "desc": "quarter dollar",
+      "nano_usd": 250000000,
+      "text": "0.250000000"
+    },
+    {
+      "desc": "negative credit",
+      "nano_usd": -1500000000,
+      "text": "-1.500000000"
+    },
+    {
+      "desc": "large amount",
+      "nano_usd": 12345678900000000,
+      "text": "12345678.900000000"
+    }
+  ],
+  "float_bridge": [
+    {
+      "desc": "one tenth is exact after shortest round-trip",
+      "cost_usd": 0.1,
+      "nano_usd": 100000000
+    },
+    {
+      "desc": "integer dollars",
+      "cost_usd": 5.0,
+      "nano_usd": 5000000000
+    },
+    {
+      "desc": "sub-nano rounds half-even down to zero",
+      "cost_usd": 5e-10,
+      "nano_usd": 0
+    },
+    {
+      "desc": "tie at 1.5 nano lands on even 2",
+      "cost_usd": 1.5e-09,
+      "nano_usd": 2
+    },
+    {
+      "desc": "tie at 2.5 nano lands on even 2",
+      "cost_usd": 2.5e-09,
+      "nano_usd": 2
+    },
+    {
+      "desc": "typical haiku-call cost",
+      "cost_usd": 2.5e-05,
+      "nano_usd": 25000
+    },
+    {
+      "desc": "negative adjustment",
+      "cost_usd": -0.1,
+      "nano_usd": -100000000
+    }
+  ],
+  "nfc": [
+    {
+      "desc": "ascii passes",
+      "codepoints": "U+0062 U+0075 U+0064 U+0067 U+0065 U+0074",
+      "ok": true
+    },
+    {
+      "desc": "precomposed e-acute passes",
+      "codepoints": "U+00E9",
+      "ok": true
+    },
+    {
+      "desc": "decomposed e plus combining acute is rejected",
+      "codepoints": "U+0065 U+0301"
+    },
+    {
+      "desc": "cyrillic passes",
+      "codepoints": "U+043A U+043E U+043C U+0430 U+043D U+0434 U+0430",
+      "ok": true
+    },
+    {
+      "desc": "singleton angstrom sign is rejected",
+      "codepoints": "U+212B"
+    },
+    {
+      "desc": "hangul jamo sequence is rejected",
+      "codepoints": "U+1100 U+1161"
+    }
+  ],
+  "statements": [
+    {
+      "desc": "minimal statement",
+      "payload": {
+        "schema": "showback-statement-v1",
+        "tenant": "core",
+        "total_nano_usd": "250000000"
+      },
+      "sha256": "008a13385898d3cfc8764582d42b7072e08f4c81fcbcd8066ae97ee9c33d5c0d"
+    },
+    {
+      "desc": "line items in chain order with anchors",
+      "payload": {
+        "schema": "showback-statement-v1",
+        "tenant": "platform",
+        "window": {
+          "from_chain_seq": 100,
+          "to_chain_seq": 220
+        },
+        "line_items": [
+          {
+            "seq": 101,
+            "task_id": "t-001",
+            "nano_usd": "25000",
+            "label": "plan"
+          },
+          {
+            "seq": 140,
+            "task_id": "t-002",
+            "nano_usd": "100000000",
+            "label": "implement"
+          }
+        ],
+        "total_nano_usd": "100025000"
+      },
+      "sha256": "585eebacd614720327a4b3d10554da2114550cca525452a11c26671468eac4aa"
+    },
+    {
+      "desc": "unicode label precomposed",
+      "payload": {
+        "schema": "showback-statement-v1",
+        "tenant": "café",
+        "total_nano_usd": "0"
+      },
+      "sha256": "487d16e5a75ca4433ef06afa0be031496b1b0090613c3f48e3e96b31f59aa440"
+    }
+  ]
+}

--- a/tests/unit/test_showback_canonical.py
+++ b/tests/unit/test_showback_canonical.py
@@ -1,0 +1,145 @@
+"""Tests for the canonical money/text core behind tenant showback statements.
+
+Every case that a cross-language implementation must reproduce lives in
+``tests/fixtures/showback/canonical_vectors.json`` so external fixtures can
+extend the set without touching this file. The tests here bind the vectors
+to the Python implementation and add the Python-only edge cases (exception
+types, float-bridge guards, tree validation).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import unicodedata
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.cost.showback_canonical import (
+    FloatRejectedError,
+    MoneyFormatError,
+    NonCanonicalTextError,
+    canonical_statement_bytes,
+    nano_usd_from_decimal_str,
+    nano_usd_from_float,
+    nano_usd_to_decimal_str,
+    require_nfc,
+)
+
+VECTORS = json.loads(
+    (Path(__file__).resolve().parents[1] / "fixtures" / "showback" / "canonical_vectors.json").read_text(
+        encoding="utf-8"
+    )
+)
+
+
+# ---------------------------------------------------------------------------
+# Money: canonical decimal-string parsing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("case", VECTORS["money_parse"], ids=lambda c: c["desc"])
+def test_money_parse_vectors(case: dict) -> None:
+    if "nano_usd" in case:
+        assert nano_usd_from_decimal_str(case["input"]) == case["nano_usd"]
+    else:
+        with pytest.raises(MoneyFormatError):
+            nano_usd_from_decimal_str(case["input"])
+
+
+@pytest.mark.parametrize("case", VECTORS["money_render"], ids=lambda c: c["desc"])
+def test_money_render_vectors(case: dict) -> None:
+    assert nano_usd_to_decimal_str(case["nano_usd"]) == case["text"]
+
+
+@pytest.mark.parametrize("nano", [0, 1, -1, 250_000_000, -999_999_999, 12_345_678_900_000_000])
+def test_money_render_parse_roundtrip(nano: int) -> None:
+    assert nano_usd_from_decimal_str(nano_usd_to_decimal_str(nano)) == nano
+
+
+# ---------------------------------------------------------------------------
+# Money: bridge from the float ledger
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("case", VECTORS["float_bridge"], ids=lambda c: c["desc"])
+def test_float_bridge_vectors(case: dict) -> None:
+    assert nano_usd_from_float(case["cost_usd"]) == case["nano_usd"]
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_float_bridge_rejects_non_finite(bad: float) -> None:
+    with pytest.raises(MoneyFormatError):
+        nano_usd_from_float(bad)
+
+
+def test_float_bridge_ties_round_half_even() -> None:
+    # 1.5e-9 ties between 1 and 2 nano-USD and must land on the even digit;
+    # 2.5e-9 ties between 2 and 3 and must also land on 2.
+    assert nano_usd_from_float(1.5e-9) == 2
+    assert nano_usd_from_float(2.5e-9) == 2
+
+
+# ---------------------------------------------------------------------------
+# Text: reject-don't-repair NFC policy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("case", VECTORS["nfc"], ids=lambda c: c["desc"])
+def test_nfc_vectors(case: dict) -> None:
+    text = "".join(chr(int(cp[2:], 16)) for cp in case["codepoints"].split())
+    if case.get("ok"):
+        assert require_nfc(text) == text
+    else:
+        with pytest.raises(NonCanonicalTextError):
+            require_nfc(text)
+
+
+def test_require_nfc_never_transforms() -> None:
+    # The accepted value is returned unchanged, not re-normalized: a verifier
+    # must hash exactly the bytes it was handed.
+    composed = unicodedata.normalize("NFC", "café")
+    assert require_nfc(composed) is composed
+
+
+# ---------------------------------------------------------------------------
+# Statements: canonical bytes over a validated tree
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("case", VECTORS["statements"], ids=lambda c: c["desc"])
+def test_statement_vectors(case: dict) -> None:
+    got = canonical_statement_bytes(case["payload"])
+    assert hashlib.sha256(got).hexdigest() == case["sha256"]
+
+
+def test_statement_bytes_independent_of_key_insertion_order() -> None:
+    a = {"tenant": "core", "total_nano_usd": "250000000"}
+    b = {"total_nano_usd": "250000000", "tenant": "core"}
+    assert canonical_statement_bytes(a) == canonical_statement_bytes(b)
+
+
+def test_statement_rejects_float_anywhere() -> None:
+    with pytest.raises(FloatRejectedError):
+        canonical_statement_bytes({"line_items": [{"cost_usd": 0.1}]})
+
+
+def test_statement_rejects_non_nfc_value_and_key() -> None:
+    decomposed = "cafe\u0301"  # 'e' + COMBINING ACUTE ACCENT, i.e. NFD form
+    with pytest.raises(NonCanonicalTextError):
+        canonical_statement_bytes({"label": decomposed})
+    with pytest.raises(NonCanonicalTextError):
+        canonical_statement_bytes({decomposed: "label"})
+
+
+def test_statement_rejects_ints_outside_ijson_range() -> None:
+    with pytest.raises(MoneyFormatError):
+        canonical_statement_bytes({"n": 2**53})
+    with pytest.raises(MoneyFormatError):
+        canonical_statement_bytes({"n": -(2**53)})
+
+
+def test_statement_accepts_bool_none_and_nested_containers() -> None:
+    payload = {"ok": True, "gap": None, "items": [{"n": 1}, {"n": 2}]}
+    assert canonical_statement_bytes(payload) == b'{"gap":null,"items":[{"n":1},{"n":2}],"ok":true}'


### PR DESCRIPTION
## What
Foundation module for the #2554 showback surface: `bernstein.core.cost.showback_canonical`, plus cross-language test vectors and a short operator doc.

Fixes nothing by itself — it pins the three encoding policies every later phase (line-item receipts, rollup projections, `bernstein tenant showback` / `verify-statement`) must agree on, so follow-up PRs can build against a stable core instead of re-litigating encodings:

- **Money = integer nano-USD.** Rounding exactly once at line-item creation (banker's rounding to 1 nano-USD); totals are exact integer sums, so aggregation order can never change a digit; amounts travel through payloads as string-encoded integers, keeping raw JSON numbers inside the I-JSON safe range. Nano rather than micro scale because per-token line items on inexpensive models fall below one micro-USD.
- **Text: reject, don't repair.** Statement strings must already be NFC; `require_nfc` refuses non-NFC input instead of normalizing it — a verifier must hash exactly the bytes it was handed, and normalization tables move between Unicode versions while rejection semantics stay stable.
- **No floats in statements.** `canonical_statement_bytes` validates the whole tree (floats rejected, NFC everywhere, I-JSON-safe integers) before delegating to the existing RFC 8785 canonicalizer from `agent_card_signer`.

## Vectors
`tests/fixtures/showback/canonical_vectors.json` carries parse/render/float-bridge/NFC/statement-hash cases a non-Python implementation must reproduce, and is the extension point for contributed fixtures — add vectors there, not test code.

## Verification
- 56 tests green (`tests/unit/test_showback_canonical.py`), including half-even tie cases and NFC singleton/jamo rejections.
- Statement hashes cross-checked independently (`shasum -a 256` over the hand-written canonical form matches the implementation).
- ruff check/format clean; the new module is mypy-clean; full unit collection sentinel passes.

## Landing note
Hold merge until the v3.8.4 tag lands so the patch release stays bug-fix-only; this is v3.9.0 (#2554) groundwork.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic showback statement encoding for consistent, verifiable results across systems.
  * Added precise nano-USD money handling with standardized rounding and decimal formatting.
  * Added validation for Unicode text, numeric ranges, and unsupported floating-point values.
  * Added canonical JSON output suitable for stable hashing and cross-language compatibility.

* **Tests**
  * Added comprehensive validation for money conversion, text normalization, payload rules, and deterministic serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Follow-up direction (build on this core)

Roadmap slices from #2554 that consume this module, in dependency order — each is a self-contained PR:

- [ ] **Cross-language vectors** — extend `tests/fixtures/showback/canonical_vectors.json` with additional canonicalization cases (unicode edge cases, money boundaries); no Python changes required.
- [ ] **Per-hop scope binding** — scope (or content-addressed scope reference) + parent receipt reference on `DelegationReceipt`, and the child ⊆ parent recomputation in `bernstein delegation verify` (#2554 Phase 2).
- [ ] **Line-item receipts** — `SpendRecord` tenant binding + chain-position reference; amounts converted through `nano_usd_from_float` exactly once at creation (#2554 Phase 4).
- [ ] **Statement projection** — pure function from a chain segment to a canonical statement via `canonical_statement_bytes`, then `bernstein tenant showback` / `verify-statement` on top.

Contributions welcome on any slice — comment on #2554 to claim one.
