### PR TITLE
fix(adapters): make the cloud and Cloudflare adapter surfaces fail honestly

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -108,10 +108,10 @@ alwaysApply: false
 | `cline.py`                  | Cline CLI adapter |
 | `clm.py`                    | CLM sovereign LLM adapter - drives a customer-side CLM gateway |
 | `clm_tls_launcher.py`       | mTLS launcher for the CLM adapter |
-| `cloudflare_agents.py`      | Cloudflare Agents SDK adapter for local wrangler dev or deployed worker trigger |
+| `cloudflare_agents.py`      | Cloudflare Agents SDK adapter (experimental, currently non-functional) |
 | `codebuff.py`               | Codebuff CLI adapter |
 | `codex.py`                  | OpenAI Codex CLI adapter |
-| `codex_cloudflare.py`       | Codex adapter for Cloudflare Sandbox execution |
+| `codex_cloudflare.py`       | Codex adapter for Cloudflare Sandbox execution (experimental, non-functional) |
 | `cody.py`                   | Sourcegraph Cody CLI adapter |
 | `composio.py`               | Composio Agent Orchestrator (``ao``) CLI adapter |
 | `computer_use.py`           | Browser / computer-use adapter family (#2606) |

--- a/.goosehints
+++ b/.goosehints
@@ -109,10 +109,10 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `cline.py`                  | Cline CLI adapter |
 | `clm.py`                    | CLM sovereign LLM adapter - drives a customer-side CLM gateway |
 | `clm_tls_launcher.py`       | mTLS launcher for the CLM adapter |
-| `cloudflare_agents.py`      | Cloudflare Agents SDK adapter for local wrangler dev or deployed worker trigger |
+| `cloudflare_agents.py`      | Cloudflare Agents SDK adapter (experimental, currently non-functional) |
 | `codebuff.py`               | Codebuff CLI adapter |
 | `codex.py`                  | OpenAI Codex CLI adapter |
-| `codex_cloudflare.py`       | Codex adapter for Cloudflare Sandbox execution |
+| `codex_cloudflare.py`       | Codex adapter for Cloudflare Sandbox execution (experimental, non-functional) |
 | `cody.py`                   | Sourcegraph Cody CLI adapter |
 | `composio.py`               | Composio Agent Orchestrator (``ao``) CLI adapter |
 | `computer_use.py`           | Browser / computer-use adapter family (#2606) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,10 +109,10 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `cline.py`                  | Cline CLI adapter |
 | `clm.py`                    | CLM sovereign LLM adapter - drives a customer-side CLM gateway |
 | `clm_tls_launcher.py`       | mTLS launcher for the CLM adapter |
-| `cloudflare_agents.py`      | Cloudflare Agents SDK adapter for local wrangler dev or deployed worker trigger |
+| `cloudflare_agents.py`      | Cloudflare Agents SDK adapter (experimental, currently non-functional) |
 | `codebuff.py`               | Codebuff CLI adapter |
 | `codex.py`                  | OpenAI Codex CLI adapter |
-| `codex_cloudflare.py`       | Codex adapter for Cloudflare Sandbox execution |
+| `codex_cloudflare.py`       | Codex adapter for Cloudflare Sandbox execution (experimental, non-functional) |
 | `cody.py`                   | Sourcegraph Cody CLI adapter |
 | `composio.py`               | Composio Agent Orchestrator (``ao``) CLI adapter |
 | `computer_use.py`           | Browser / computer-use adapter family (#2606) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,10 +109,10 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `cline.py`                  | Cline CLI adapter |
 | `clm.py`                    | CLM sovereign LLM adapter - drives a customer-side CLM gateway |
 | `clm_tls_launcher.py`       | mTLS launcher for the CLM adapter |
-| `cloudflare_agents.py`      | Cloudflare Agents SDK adapter for local wrangler dev or deployed worker trigger |
+| `cloudflare_agents.py`      | Cloudflare Agents SDK adapter (experimental, currently non-functional) |
 | `codebuff.py`               | Codebuff CLI adapter |
 | `codex.py`                  | OpenAI Codex CLI adapter |
-| `codex_cloudflare.py`       | Codex adapter for Cloudflare Sandbox execution |
+| `codex_cloudflare.py`       | Codex adapter for Cloudflare Sandbox execution (experimental, non-functional) |
 | `cody.py`                   | Sourcegraph Cody CLI adapter |
 | `composio.py`               | Composio Agent Orchestrator (``ao``) CLI adapter |
 | `computer_use.py`           | Browser / computer-use adapter family (#2606) |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -109,10 +109,10 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `cline.py`                  | Cline CLI adapter |
 | `clm.py`                    | CLM sovereign LLM adapter - drives a customer-side CLM gateway |
 | `clm_tls_launcher.py`       | mTLS launcher for the CLM adapter |
-| `cloudflare_agents.py`      | Cloudflare Agents SDK adapter for local wrangler dev or deployed worker trigger |
+| `cloudflare_agents.py`      | Cloudflare Agents SDK adapter (experimental, currently non-functional) |
 | `codebuff.py`               | Codebuff CLI adapter |
 | `codex.py`                  | OpenAI Codex CLI adapter |
-| `codex_cloudflare.py`       | Codex adapter for Cloudflare Sandbox execution |
+| `codex_cloudflare.py`       | Codex adapter for Cloudflare Sandbox execution (experimental, non-functional) |
 | `cody.py`                   | Sourcegraph Cody CLI adapter |
 | `composio.py`               | Composio Agent Orchestrator (``ao``) CLI adapter |
 | `computer_use.py`           | Browser / computer-use adapter family (#2606) |

--- a/docs/cloudflare/cloudflare-adapters.md
+++ b/docs/cloudflare/cloudflare-adapters.md
@@ -1,6 +1,6 @@
 # Cloudflare Adapters
 
-Two adapters let you run agents on Cloudflare infrastructure instead of locally: the Cloudflare Agents SDK adapter and the Codex-on-Cloudflare adapter.
+Two adapters were intended to run agents on Cloudflare infrastructure instead of locally: the Cloudflare Agents SDK adapter and the Codex-on-Cloudflare adapter. **Both are experimental and currently non-functional** — see the status notes below before relying on them.
 
 ---
 
@@ -9,32 +9,24 @@ Two adapters let you run agents on Cloudflare infrastructure instead of locally:
 **Module:** `bernstein.adapters.cloudflare_agents`
 **Class:** `CloudflareAgentsAdapter`
 
-Spawns agents via a Cloudflare Workers backend using `npx wrangler dev` locally. The adapter launches a local wrangler dev server that hosts a Cloudflare Agents SDK worker, passing the task prompt and model as Worker variables.
+!!! warning "Experimental — non-functional (issue #2782)"
+    This adapter has no worker-trigger path. It could only start a local
+    `npx wrangler dev` server, which is a long-running dev server that is never
+    sent a request and never signals completion, so every task would run until
+    the timeout watchdog killed it — producing no artifact. Rather than pretend,
+    `spawn()` now refuses immediately with an actionable error.
 
-### Prerequisites
+    To run agents on Cloudflare today, deploy a worker that implements the
+    `/agents/*` HTTP contract and drive it with
+    `bernstein.bridges.cloudflare.CloudflareBridge`, or run agents locally with
+    an adapter such as `claude`, `codex`, `aider`, or `mock`.
 
-- Node.js 18+ and npm
-- `wrangler` installed globally: `npm install -g wrangler`
-- `wrangler login` completed
-- A Cloudflare account with Workers enabled
+### Behaviour
 
-### Environment variables
-
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `CLOUDFLARE_ACCOUNT_ID` or `CF_ACCOUNT_ID` | Yes | Cloudflare account identifier |
-| `CLOUDFLARE_API_TOKEN` or `CF_API_TOKEN` | Yes | API token with Workers permissions |
-| `CLOUDFLARE_API_KEY` | No | Global API key (legacy, prefer token) |
-| `CLOUDFLARE_EMAIL` | No | Account email (only with global key) |
-| `WRANGLER_SEND_METRICS` | No | Control wrangler telemetry |
-
-### How it works
-
-1. The adapter builds a `npx wrangler dev` command with `--var` flags injecting the prompt, model, and session ID.
-2. The command is wrapped with `build_worker_cmd()` for process visibility in `bernstein ps`.
-3. Environment variables are filtered to only forward the Cloudflare-specific keys listed above (via `build_filtered_env()`).
-4. The wrangler dev server runs as a subprocess with stdout/stderr captured to `.sdd/runtime/<session>.log`.
-5. A timeout watchdog monitors the process.
+`CloudflareAgentsAdapter.spawn()` raises `RuntimeError` with a message that
+names issue #2782 and points to the working alternatives above. The
+`cloudflare` registry key still resolves (so `cli: cloudflare` parses), but a
+run routed to it fails fast instead of timing out.
 
 ### Configuration in bernstein.yaml
 
@@ -43,22 +35,6 @@ cli: cloudflare
 ```
 
 The registry key is `cloudflare` (see `bernstein.adapters.registry`); the module name `cloudflare_agents` is not a registered key.
-
-### Spawn parameters
-
-The adapter's `spawn()` method accepts the standard `CLIAdapter` parameters:
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `prompt` | `str` | (required) | Task prompt for the agent |
-| `workdir` | `Path` | (required) | Working directory |
-| `model_config` | `ModelConfig` | (required) | Model and effort config |
-| `session_id` | `str` | (required) | Unique session identifier |
-| `mcp_config` | `dict` | `None` | MCP config (unused by this adapter) |
-| `timeout_seconds` | `int` | `DEFAULT_TIMEOUT_SECONDS` | Process timeout |
-| `task_scope` | `str` | `"medium"` | Task scope for budget caps |
-| `budget_multiplier` | `float` | `1.0` | Retry budget multiplier |
-| `system_addendum` | `str` | `""` | Additional system prompt text |
 
 ---
 

--- a/docs/cloudflare/cloudflare-adapters.md
+++ b/docs/cloudflare/cloudflare-adapters.md
@@ -43,9 +43,26 @@ The registry key is `cloudflare` (see `bernstein.adapters.registry`); the module
 **Module:** `bernstein.adapters.codex_cloudflare`
 **Class:** `CodexCloudflareAdapter`
 
-Runs OpenAI Codex agents inside Cloudflare sandboxes rather than locally. Combines Codex CLI capabilities with Cloudflare's isolated sandbox infrastructure for secure, scalable code execution.
+!!! warning "Experimental — non-functional (issue #2783)"
+    This adapter drove every operation against
+    `https://api.cloudflare.com/client/v4/accounts/{id}/sandbox/...`, a REST
+    route family that **does not exist** — an authenticated request returns
+    HTTP 400 with Cloudflare errors 7000/7003 ("No route for that URI").
+    Cloudflare's real sandbox/container product runs inside a Worker/Durable
+    Object (the `@cloudflare/sandbox` SDK), not a `client/v4` REST surface.
+
+    Because the target API cannot be routed, no operation can run or populate a
+    result. Every public method (`execute`, `get_status`, `cancel`, `get_logs`)
+    now raises `RuntimeError` with an actionable message instead of issuing a
+    doomed request. To run Codex on Cloudflare, drive a deployed worker via
+    `bernstein.bridges.cloudflare.CloudflareBridge`; to run Codex locally, use
+    the `codex` adapter.
 
 ### Configuration
+
+`CodexSandboxConfig` and `CodexSandboxResult` remain importable so callers and
+a future real implementation keep a stable surface, but no method issues a
+request today.
 
 `CodexSandboxConfig` dataclass fields:
 
@@ -61,48 +78,10 @@ Runs OpenAI Codex agents inside Cloudflare sandboxes rather than locally. Combin
 | `network_access` | `str` | `"restricted"` | Network access level |
 | `r2_bucket` | `str` | `"bernstein-workspaces"` | R2 bucket for workspace sync |
 
-### Usage
-
-```python
-from bernstein.adapters.codex_cloudflare import (
-    CodexCloudflareAdapter,
-    CodexSandboxConfig,
-)
-
-adapter = CodexCloudflareAdapter(CodexSandboxConfig(
-    cloudflare_account_id="abc123",
-    cloudflare_api_token="cf_token_...",
-    openai_api_key="sk-...",
-    memory_mb=1024,
-    max_execution_minutes=60,
-))
-
-# Execute a task
-result = await adapter.execute(
-    prompt="Add input validation to all API endpoints",
-    workspace_id="task-123",
-    model="codex-mini",
-    timeout_minutes=45,
-)
-
-print(result.status)                # "completed", "failed", "timeout"
-print(result.files_changed)         # ["src/api/validation.py", ...]
-print(result.execution_time_seconds)
-print(result.stdout)
-```
-
-### Execution lifecycle
-
-1. **Create sandbox** -- provisions a Cloudflare sandbox container with the specified image, memory, CPU, and network settings. Injects `OPENAI_API_KEY`, `WORKSPACE_R2_BUCKET`, and `WORKSPACE_ID` as environment variables.
-2. **Sync workspace** -- the sandbox pulls workspace files from the configured R2 bucket.
-3. **Inject Codex command** -- sends `codex exec --full-auto -m <model> <prompt>` to the sandbox.
-4. **Poll for completion** -- checks sandbox status every 5 seconds until completed, failed, or timeout.
-5. **Collect results** -- fetches stdout/stderr logs from the sandbox.
-6. **Cleanup** -- terminates the sandbox on timeout or error.
-
 ### Result type
 
-`CodexSandboxResult` fields:
+`CodexSandboxResult` fields (populated only once a real sandbox surface is
+implemented):
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -115,27 +94,10 @@ print(result.stdout)
 | `execution_time_seconds` | `float` | Wall-clock execution time |
 | `tokens_used` | `int` | Tokens consumed by Codex |
 
-### Management methods
-
-```python
-# Check status of a running sandbox
-status = await adapter.get_status("sandbox-id")
-
-# Cancel execution
-await adapter.cancel("sandbox-id")
-
-# Get logs
-logs = await adapter.get_logs("sandbox-id")
-```
-
 ---
 
 ## Choosing between adapters
 
-| Criterion | Cloudflare Agents | Codex-on-Cloudflare |
-|-----------|-------------------|---------------------|
-| LLM Provider | Any (via Worker) | OpenAI Codex |
-| Execution location | Local wrangler dev | Remote Cloudflare sandbox |
-| Isolation | Worker process | Full container sandbox |
-| Workspace sync | Manual | Automatic via R2 |
-| Best for | Development, testing | Production, untrusted code |
+Both Cloudflare adapters are experimental and non-functional at present (see the
+status notes above). Run agents locally (`claude`, `codex`, `aider`, `mock`) or
+drive a deployed worker via `bernstein.bridges.cloudflare.CloudflareBridge`.

--- a/docs/cloudflare/cloudflare-cli.md
+++ b/docs/cloudflare/cloudflare-cli.md
@@ -2,7 +2,15 @@
 
 **Module:** `bernstein.cli.commands.cloud_cmd`
 
-The `bernstein cloud` command group manages hosted orchestration on Cloudflare. It provides authentication, remote run management, cost reporting, and worker deployment.
+The `bernstein cloud` command group manages hosted orchestration on Cloudflare. It provides authentication, remote run management, cost reporting, and worker scaffolding/deployment.
+
+!!! warning "Hosted service is experimental"
+    The hosted API at `api.bernstein.run` is experimental and **not currently
+    available** — the host does not resolve in DNS. The `login`, `run`,
+    `status`, `runs`, and `cost` commands target it; when it is unreachable they
+    report a clear "not reachable / not currently available" message and exit
+    non-zero (rather than a traceback). `init` and `deploy` are local and work
+    against your own Cloudflare account.
 
 ---
 
@@ -123,9 +131,35 @@ Output includes total cost, run count, and period.
 
 ---
 
+### `bernstein cloud init`
+
+Scaffold a deployable worker project in the current directory. Writes a
+free-tier `wrangler.toml` and the runnable `src/index.js` entry point its `main`
+names, so `wrangler deploy` resolves without an "entry-point not found" error.
+This works from the published wheel (which does not ship the repo `templates/`
+directory).
+
+```bash
+bernstein cloud init
+
+# Custom worker name / output path
+bernstein cloud init --worker-name my-worker --output deploy/wrangler.toml
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--worker-name` | `"bernstein-agent"` | Cloudflare Worker script name written into `wrangler.toml` |
+| `--output` / `-o` | `"wrangler.toml"` | Output path for `wrangler.toml` (the worker is written to `<dir>/src/index.js`) |
+
+An existing `src/index.js` is left unchanged. The scaffolded `wrangler.toml`
+declares no paid bindings (Queues, KV, Durable Objects, and R2 are commented
+out).
+
+---
+
 ### `bernstein cloud deploy`
 
-Deploy the Bernstein agent Worker to your Cloudflare account.
+Print the command to deploy the Bernstein agent Worker to your Cloudflare account.
 
 ```bash
 bernstein cloud deploy
@@ -139,7 +173,8 @@ bernstein cloud deploy --worker-name my-bernstein-worker
 | `--worker-name` | `"bernstein-agent"` | Cloudflare Worker script name |
 
 !!! note "Manual step"
-    This command prints the wrangler deploy command and points you to the deployment template. Run the printed command to complete deployment.
+    This command prints the `wrangler deploy` command; run it to complete
+    deployment. Scaffold a deployable worker first with `bernstein cloud init`.
 
 ---
 

--- a/docs/cloudflare/cloudflare-overview.md
+++ b/docs/cloudflare/cloudflare-overview.md
@@ -69,7 +69,7 @@ graph TD
 | D1 Analytics | `bernstein.core.cost.d1_analytics` | Usage metering, billing tiers, quota enforcement |
 | Vectorize Cache | `bernstein.core.memory.vectorize_cache` | Semantic cache for LLM responses using vector similarity |
 | MCP Remote Transport | `bernstein.mcp.remote_transport` | Streamable HTTP transport for remote MCP server access |
-| Cloud CLI | `bernstein.cli.commands.cloud_cmd` | `bernstein cloud` subcommands (login, run, status, cost, deploy) |
+| Cloud CLI | `bernstein.cli.commands.cloud_cmd` | `bernstein cloud` subcommands (init, deploy are local; login/run/status/cost target the experimental, currently-unavailable `api.bernstein.run`) |
 
 ---
 

--- a/docs/cloudflare/cloudflare-overview.md
+++ b/docs/cloudflare/cloudflare-overview.md
@@ -64,8 +64,8 @@ graph TD
 | Browser Rendering | `bernstein.bridges.browser_rendering` | Headless browsing, screenshots, scraping, PDF generation |
 | R2 Workspace Sync | `bernstein.bridges.r2_sync` | Content-addressed file sync between local and R2 |
 | Workers AI Provider | `bernstein.core.routing.cloudflare_ai` | Free-tier LLM completions for planning and decomposition |
-| Cloudflare Agents Adapter | `bernstein.adapters.cloudflare_agents` | Spawn agents via `npx wrangler dev` locally |
-| Codex-on-Cloudflare Adapter | `bernstein.adapters.codex_cloudflare` | Run OpenAI Codex inside Cloudflare sandboxes |
+| Cloudflare Agents Adapter | `bernstein.adapters.cloudflare_agents` | Experimental / non-functional — refuses to spawn (issue #2782) |
+| Codex-on-Cloudflare Adapter | `bernstein.adapters.codex_cloudflare` | Experimental / non-functional — targets a nonexistent sandbox API (issue #2783) |
 | D1 Analytics | `bernstein.core.cost.d1_analytics` | Usage metering, billing tiers, quota enforcement |
 | Vectorize Cache | `bernstein.core.memory.vectorize_cache` | Semantic cache for LLM responses using vector similarity |
 | MCP Remote Transport | `bernstein.mcp.remote_transport` | Streamable HTTP transport for remote MCP server access |

--- a/docs/cloudflare/cloudflare-setup.md
+++ b/docs/cloudflare/cloudflare-setup.md
@@ -126,25 +126,30 @@ config = D1Config(
 
 
 
-If you want to run agents on Cloudflare Workers (not just use Workers AI locally), deploy the agent worker:
+If you want to run agents on Cloudflare Workers (not just use Workers AI locally), scaffold and deploy the agent worker. `bernstein cloud init` writes a free-tier `wrangler.toml` and a runnable `src/index.js` entry point (this works from the published wheel, which does not ship the repo `templates/` directory):
 
 ```bash
-# From the Bernstein repo root
-cd templates/bernstein-cloud
+bernstein cloud init                 # writes wrangler.toml + src/index.js
+# set account_id in wrangler.toml, then:
 npx wrangler deploy --name bernstein-agent
 ```
 
-Or use the CLI shortcut:
-
-```bash
-bernstein cloud deploy --worker-name bernstein-agent
-```
+`bernstein cloud deploy --worker-name bernstein-agent` prints the same
+`wrangler deploy` command for reference.
 
 ---
 
 ## 6. Authenticate the Cloud CLI
 
-For the hosted Bernstein Cloud service (api.bernstein.run):
+!!! warning "Hosted service is experimental"
+    The hosted Bernstein Cloud service at `api.bernstein.run` is experimental
+    and **not currently available** (the host does not resolve in DNS). The
+    `bernstein cloud login/run/status/runs/cost` commands target it and will
+    report that the service is not reachable. Everything else in this guide
+    (Workers AI, R2, D1, worker deployment) works against your own Cloudflare
+    account and does not depend on the hosted service.
+
+For the hosted Bernstein Cloud service (when available):
 
 ```bash
 bernstein cloud login --api-key YOUR_KEY

--- a/src/bernstein/adapters/cloudflare_agents.py
+++ b/src/bernstein/adapters/cloudflare_agents.py
@@ -1,10 +1,19 @@
-"""Cloudflare Agents SDK adapter for local wrangler dev or deployed worker trigger."""
+"""Cloudflare Agents SDK adapter (experimental, currently non-functional).
+
+This adapter is a stub: it can only start a local ``npx wrangler dev`` server,
+which is a long-running dev server with no path to trigger the worker or
+collect a result.  Every task routed here would run until the timeout watchdog
+kills it, producing no artifact (issue #2782).  Rather than pretend, ``spawn()``
+refuses immediately with an actionable error.
+
+To run agents on Cloudflare today, deploy a worker that implements the
+``/agents/*`` HTTP contract and drive it with
+``bernstein.bridges.cloudflare.CloudflareBridge``.
+"""
 
 from __future__ import annotations
 
 import logging
-import os
-import subprocess
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -12,33 +21,27 @@ if TYPE_CHECKING:
 
     from bernstein.core.models import ModelConfig
 
-from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
-from bernstein.adapters.env_isolation import build_filtered_env
+from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult
 
 logger = logging.getLogger(__name__)
 
-# Environment variables forwarded to the wrangler/worker subprocess.
-_CF_ENV_KEYS: list[str] = [
-    "CLOUDFLARE_ACCOUNT_ID",
-    "CLOUDFLARE_API_TOKEN",
-    "CLOUDFLARE_API_KEY",
-    "CLOUDFLARE_EMAIL",
-    "CF_ACCOUNT_ID",
-    "CF_API_TOKEN",
-    "WRANGLER_SEND_METRICS",
-]
+_UNAVAILABLE_MSG = (
+    "Cloudflare Agents adapter is experimental and currently non-functional: "
+    "it can only start a local `npx wrangler dev` server, which never triggers "
+    "the worker or returns a result, so every task would time out with no "
+    "artifact (issue #2782). Run agents with a local adapter (e.g. `claude`, "
+    "`codex`, `aider`, or `mock`) instead, or deploy a worker implementing the "
+    "`/agents/*` contract and drive it via "
+    "`bernstein.bridges.cloudflare.CloudflareBridge`."
+)
 
 
 class CloudflareAgentsAdapter(CLIAdapter):
-    """Spawn agents via Cloudflare Workers using ``npx wrangler dev`` locally.
+    """Experimental Cloudflare Agents adapter that refuses to spawn.
 
-    The adapter launches a local wrangler dev server that hosts a Cloudflare
-    Agents SDK worker.  The prompt is passed as a CLI argument to the worker
-    entry-point.
-
-    Required environment variables:
-        CLOUDFLARE_ACCOUNT_ID: Cloudflare account identifier.
-        CLOUDFLARE_API_TOKEN: API token with Workers permissions.
+    The adapter is registered so the ``cloudflare`` CLI selection still
+    resolves, but ``spawn()`` raises a clear error instead of launching a
+    ``npx wrangler dev`` server that can never complete a task (issue #2782).
     """
 
     external_endpoints = (("api.cloudflare.com", 443),)
@@ -57,89 +60,28 @@ class CloudflareAgentsAdapter(CLIAdapter):
         system_addendum: str = "",
         multimodal_context: Any | None = None,
     ) -> SpawnResult:
-        """Launch a Cloudflare Agents worker via ``npx wrangler dev``.
+        """Refuse to spawn: this adapter has no worker-trigger path.
 
         Args:
-            prompt: Task prompt for the agent.
-            workdir: Working directory for the agent process.
-            model_config: Model and effort configuration.
-            session_id: Unique session identifier.
+            prompt: Task prompt for the agent (unused).
+            workdir: Working directory for the agent process (unused).
+            model_config: Model and effort configuration (unused).
+            session_id: Unique session identifier (unused).
             mcp_config: Optional MCP server definitions (unused).
-            timeout_seconds: Process timeout in seconds.
-            task_scope: Task scope for budget caps.
-            budget_multiplier: Retry budget multiplier.
-            system_addendum: System-prompt instructions to inject.
-
-        Returns:
-            SpawnResult with process metadata.
+            timeout_seconds: Process timeout in seconds (unused).
+            task_scope: Task scope for budget caps (unused).
+            budget_multiplier: Retry budget multiplier (unused).
+            system_addendum: System-prompt instructions to inject (unused).
+            multimodal_context: Optional multimodal attachments.
 
         Raises:
-            RuntimeError: If ``npx`` is not found or permission is denied.
-            NetworkPolicyDenied: When the active --allow-network policy denies api.cloudflare.com.
+            CapabilityRefusal: When multimodal attachments are supplied.
+            RuntimeError: Always, because the adapter is non-functional.
         """
+        # Preserve the multimodal-refusal contract shared by every adapter
+        # before reporting that the adapter itself is unavailable.
         self.refuse_multimodal_if_needed(multimodal_context)
-        self.enforce_network_policy()
-        log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
-        log_path.parent.mkdir(parents=True, exist_ok=True)
-
-        account_id = os.environ.get("CLOUDFLARE_ACCOUNT_ID") or os.environ.get("CF_ACCOUNT_ID")
-        api_token = os.environ.get("CLOUDFLARE_API_TOKEN") or os.environ.get("CF_API_TOKEN")
-        if not account_id:
-            logger.warning("CloudflareAgentsAdapter: CLOUDFLARE_ACCOUNT_ID is not set - spawn may fail")
-        if not api_token:
-            logger.warning("CloudflareAgentsAdapter: CLOUDFLARE_API_TOKEN is not set - spawn may fail")
-
-        full_prompt = f"{prompt}\n\n{system_addendum}".strip() if system_addendum else prompt
-
-        cmd = [
-            "npx",
-            "wrangler",
-            "dev",
-            "--var",
-            f"AGENT_PROMPT:{full_prompt}",
-            "--var",
-            f"AGENT_MODEL:{model_config.model}",
-            "--var",
-            f"AGENT_SESSION:{session_id}",
-        ]
-
-        # Wrap with bernstein-worker for process visibility
-        pid_dir = workdir / ".sdd" / "runtime" / "pids"
-        wrapped_cmd = build_worker_cmd(
-            cmd,
-            role=session_id.rsplit("-", 1)[0],
-            session_id=session_id,
-            pid_dir=pid_dir,
-            workdir=workdir,
-            log_path=log_path,
-            model=model_config.model,
-        )
-
-        env = build_filtered_env(_CF_ENV_KEYS)
-        with log_path.open("w") as log_file:
-            try:
-                proc = subprocess.Popen(
-                    wrapped_cmd,
-                    cwd=workdir,
-                    env=env,
-                    stdout=log_file,
-                    stderr=subprocess.STDOUT,
-                    start_new_session=True,
-                    preexec_fn=self._get_preexec_fn(),
-                )
-            except FileNotFoundError as exc:
-                raise RuntimeError(
-                    "npx not found in PATH. Install Node.js and wrangler: npm install -g wrangler"
-                ) from exc
-            except PermissionError as exc:
-                raise RuntimeError(f"Permission denied executing npx wrangler: {exc}") from exc
-
-        self._probe_fast_exit(proc, log_path, provider_name="cloudflare-agents")
-
-        result = SpawnResult(pid=proc.pid, log_path=log_path, proc=proc)
-        if timeout_seconds > 0:
-            result.timeout_timer = self._start_timeout_watchdog(proc.pid, timeout_seconds, session_id)
-        return result
+        raise RuntimeError(_UNAVAILABLE_MSG)
 
     def name(self) -> str:
         """Return the human-readable adapter name."""

--- a/src/bernstein/adapters/codex_cloudflare.py
+++ b/src/bernstein/adapters/codex_cloudflare.py
@@ -1,20 +1,33 @@
-"""Codex adapter for Cloudflare Sandbox execution.
+"""Codex adapter for Cloudflare Sandbox execution (experimental, non-functional).
 
-Spawns OpenAI Codex agents inside Cloudflare sandboxes rather than
-locally, leveraging the same infrastructure that Codex CLI uses
-for cloud execution.
+This adapter targeted ``https://api.cloudflare.com/client/v4/accounts/{id}/sandbox/...``,
+a REST route family that does not exist: an authenticated request returns HTTP
+400 with Cloudflare errors 7000/7003 ("No route for that URI"). Cloudflare's real
+sandbox/container product runs inside a Worker/Durable Object (the
+``@cloudflare/sandbox`` SDK), not a ``client/v4`` REST surface (issue #2783).
+
+Because the target API does not resolve to a route, no operation could ever
+populate a result. Rather than pretend, every public method refuses with an
+actionable error. A future implementation would drive a deployed worker (the
+pattern ``bernstein.bridges.cloudflare.CloudflareBridge`` already uses).
 """
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from dataclasses import dataclass, field
-from typing import Any
-
-import httpx
 
 logger = logging.getLogger(__name__)
+
+_UNAVAILABLE_MSG = (
+    "Codex-on-Cloudflare adapter is experimental and currently non-functional: "
+    "it targets a Cloudflare sandbox REST API "
+    "(client/v4/accounts/{id}/sandbox/...) that does not exist, so no operation "
+    "can run or return a result (issue #2783). Cloudflare's real sandbox product "
+    "runs inside a Worker/Durable Object; drive a deployed worker via "
+    "`bernstein.bridges.cloudflare.CloudflareBridge`, or run Codex locally with "
+    "the `codex` adapter."
+)
 
 
 @dataclass(frozen=True)
@@ -47,21 +60,12 @@ class CodexSandboxResult:
 
 
 class CodexCloudflareAdapter:
-    """Spawn Codex agents in Cloudflare sandboxes.
+    """Experimental Codex-on-Cloudflare adapter that refuses every operation.
 
-    Combines Codex CLI capabilities with Cloudflare's isolated
-    sandbox infrastructure for secure, scalable code execution.
-
-    Usage:
-        adapter = CodexCloudflareAdapter(CodexSandboxConfig(
-            cloudflare_account_id="...",
-            cloudflare_api_token="...",
-            openai_api_key="...",
-        ))
-        result = await adapter.execute(
-            prompt="Add input validation to all API endpoints",
-            workspace_id="task-123",
-        )
+    The adapter's target REST API does not exist, so it cannot create a sandbox,
+    inject a command, poll status, or collect results. Every public method raises
+    a clear ``RuntimeError`` instead of issuing a request that Cloudflare cannot
+    route (issue #2783).
     """
 
     def __init__(self, config: CodexSandboxConfig) -> None:
@@ -80,184 +84,48 @@ class CodexCloudflareAdapter:
         model: str = "codex-mini",
         timeout_minutes: int | None = None,
     ) -> CodexSandboxResult:
-        """Execute Codex in a Cloudflare sandbox.
-
-        1. Creates sandbox instance
-        2. Syncs workspace from R2
-        3. Runs Codex with prompt
-        4. Collects results and modified files
-        5. Syncs changes back to R2
+        """Refuse to execute: the Cloudflare sandbox REST API does not exist.
 
         Args:
-            prompt: The task prompt to send to Codex.
-            workspace_id: Identifier for the workspace to sync from R2.
-            model: The Codex model to use.
-            timeout_minutes: Max execution time; defaults to config value.
-
-        Returns:
-            CodexSandboxResult with execution outcome.
+            prompt: The task prompt (unused).
+            workspace_id: Workspace identifier (unused).
+            model: The Codex model to use (unused).
+            timeout_minutes: Max execution time (unused).
 
         Raises:
-            httpx.HTTPStatusError: If Cloudflare API calls fail.
+            RuntimeError: Always, because the adapter is non-functional.
         """
-        timeout = timeout_minutes or self._config.max_execution_minutes
-        sandbox_id = await self._create_sandbox(workspace_id, timeout)
-        try:
-            await self._inject_codex_command(sandbox_id, prompt, model)
-            return await self._wait_for_completion(sandbox_id, timeout * 60)
-        except Exception:
-            await self._cleanup_sandbox(sandbox_id)
-            raise
+        raise RuntimeError(_UNAVAILABLE_MSG)
 
     async def get_status(self, sandbox_id: str) -> str:
-        """Get current sandbox execution status.
+        """Refuse: the sandbox status route does not exist.
 
         Args:
-            sandbox_id: The sandbox instance identifier.
+            sandbox_id: The sandbox instance identifier (unused).
 
-        Returns:
-            Status string: "running", "completed", "failed", or "timeout".
+        Raises:
+            RuntimeError: Always, because the adapter is non-functional.
         """
-        url = f"https://api.cloudflare.com/client/v4/accounts/{self._config.cloudflare_account_id}/sandbox/{sandbox_id}"
-        async with httpx.AsyncClient(timeout=30) as client:
-            resp = await client.get(url, headers=self._headers())
-            resp.raise_for_status()
-            data = resp.json()
-        return str(data.get("result", {}).get("status", "unknown"))
+        raise RuntimeError(_UNAVAILABLE_MSG)
 
     async def cancel(self, sandbox_id: str) -> None:
-        """Cancel a running Codex sandbox execution.
+        """Refuse: the sandbox cancel route does not exist.
 
         Args:
-            sandbox_id: The sandbox instance identifier.
+            sandbox_id: The sandbox instance identifier (unused).
+
+        Raises:
+            RuntimeError: Always, because the adapter is non-functional.
         """
-        url = f"https://api.cloudflare.com/client/v4/accounts/{self._config.cloudflare_account_id}/sandbox/{sandbox_id}"
-        async with httpx.AsyncClient(timeout=30) as client:
-            resp = await client.delete(url, headers=self._headers())
-            resp.raise_for_status()
-        logger.info("Cancelled sandbox %s", sandbox_id)
+        raise RuntimeError(_UNAVAILABLE_MSG)
 
     async def get_logs(self, sandbox_id: str) -> str:
-        """Get stdout/stderr from sandbox.
+        """Refuse: the sandbox logs route does not exist.
 
         Args:
-            sandbox_id: The sandbox instance identifier.
+            sandbox_id: The sandbox instance identifier (unused).
 
-        Returns:
-            Combined stdout and stderr output.
+        Raises:
+            RuntimeError: Always, because the adapter is non-functional.
         """
-        url = (
-            f"https://api.cloudflare.com/client/v4/accounts/"
-            f"{self._config.cloudflare_account_id}/sandbox/{sandbox_id}/logs"
-        )
-        async with httpx.AsyncClient(timeout=30) as client:
-            resp = await client.get(url, headers=self._headers())
-            resp.raise_for_status()
-            data = resp.json()
-        return str(data.get("result", {}).get("output", ""))
-
-    async def _create_sandbox(self, workspace_id: str, timeout_minutes: int) -> str:
-        """Create a Cloudflare sandbox configured for Codex.
-
-        Args:
-            workspace_id: Workspace identifier for R2 sync.
-            timeout_minutes: Sandbox timeout in minutes.
-
-        Returns:
-            The sandbox instance ID.
-        """
-        url = f"https://api.cloudflare.com/client/v4/accounts/{self._config.cloudflare_account_id}/sandbox"
-        payload: dict[str, Any] = {
-            "image": self._config.sandbox_image,
-            "memory_mb": self._config.memory_mb,
-            "cpu_cores": self._config.cpu_cores,
-            "timeout_seconds": timeout_minutes * 60,
-            "network_access": self._config.network_access,
-            "env": {
-                "OPENAI_API_KEY": self._config.openai_api_key,
-                "WORKSPACE_R2_BUCKET": self._config.r2_bucket,
-                "WORKSPACE_ID": workspace_id,
-            },
-        }
-        async with httpx.AsyncClient(timeout=30) as client:
-            resp = await client.post(url, headers=self._headers(), json=payload)
-            resp.raise_for_status()
-            data = resp.json()
-        sandbox_id = str(data.get("result", {}).get("id", ""))
-        logger.info("Created sandbox %s for workspace %s", sandbox_id, workspace_id)
-        return sandbox_id
-
-    async def _inject_codex_command(self, sandbox_id: str, prompt: str, model: str) -> None:
-        """Send Codex execution command to sandbox.
-
-        Args:
-            sandbox_id: The sandbox instance identifier.
-            prompt: Task prompt for Codex.
-            model: Codex model name.
-        """
-        url = (
-            f"https://api.cloudflare.com/client/v4/accounts/"
-            f"{self._config.cloudflare_account_id}/sandbox/{sandbox_id}/exec"
-        )
-        payload = {
-            "command": "codex",
-            "args": ["exec", "--full-auto", "-m", model, prompt],
-        }
-        async with httpx.AsyncClient(timeout=30) as client:
-            resp = await client.post(url, headers=self._headers(), json=payload)
-            resp.raise_for_status()
-
-    async def _wait_for_completion(self, sandbox_id: str, timeout_seconds: int) -> CodexSandboxResult:
-        """Poll sandbox until execution completes or times out.
-
-        Args:
-            sandbox_id: The sandbox instance identifier.
-            timeout_seconds: Maximum wait time in seconds.
-
-        Returns:
-            CodexSandboxResult with final execution state.
-        """
-        elapsed = 0.0
-        poll_interval = 5.0
-        while elapsed < timeout_seconds:
-            status = await self.get_status(sandbox_id)
-            if status in ("completed", "failed"):
-                logs = await self.get_logs(sandbox_id)
-                return CodexSandboxResult(
-                    sandbox_id=sandbox_id,
-                    status=status,
-                    stdout=logs,
-                    execution_time_seconds=elapsed,
-                )
-            await asyncio.sleep(poll_interval)
-            elapsed += poll_interval
-
-        # Timed out - cancel and return timeout result
-        await self._cleanup_sandbox(sandbox_id)
-        return CodexSandboxResult(
-            sandbox_id=sandbox_id,
-            status="timeout",
-            execution_time_seconds=elapsed,
-        )
-
-    async def _cleanup_sandbox(self, sandbox_id: str) -> None:
-        """Terminate and clean up sandbox resources.
-
-        Args:
-            sandbox_id: The sandbox instance identifier.
-        """
-        try:
-            await self.cancel(sandbox_id)
-        except Exception:
-            logger.warning("Failed to clean up sandbox %s", sandbox_id, exc_info=True)
-
-    def _headers(self) -> dict[str, str]:
-        """Build Cloudflare API request headers.
-
-        Returns:
-            Dictionary with Authorization and Content-Type headers.
-        """
-        return {
-            "Authorization": f"Bearer {self._config.cloudflare_api_token}",
-            "Content-Type": "application/json",
-        }
+        raise RuntimeError(_UNAVAILABLE_MSG)

--- a/src/bernstein/cli/commands/cloud_cmd.py
+++ b/src/bernstein/cli/commands/cloud_cmd.py
@@ -61,8 +61,7 @@ def cloud_login(api_key: str | None, url: str) -> None:
     _save_token(api_key, url)
     click.echo("Authenticated with Bernstein Cloud.")
     click.echo(
-        "Note: the hosted cloud service (api.bernstein.run) is experimental and "
-        "may be unavailable.",
+        "Note: the hosted cloud service (api.bernstein.run) is experimental and may be unavailable.",
         err=True,
     )
 

--- a/src/bernstein/cli/commands/cloud_cmd.py
+++ b/src/bernstein/cli/commands/cloud_cmd.py
@@ -60,6 +60,11 @@ def cloud_login(api_key: str | None, url: str) -> None:
         api_key = click.prompt("Enter your Bernstein Cloud API key", hide_input=True)
     _save_token(api_key, url)
     click.echo("Authenticated with Bernstein Cloud.")
+    click.echo(
+        "Note: the hosted cloud service (api.bernstein.run) is experimental and "
+        "may be unavailable.",
+        err=True,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -195,10 +200,35 @@ compatibility_date = "2024-01-01"
 [vars]
 BERNSTEIN_SERVER_URL = "http://127.0.0.1:8052"
 
-# Add your Cloudflare bindings here:
+# Free-tier compatible by default: no paid bindings are declared. Add your own
+# below as needed. Note that Queues require a Workers Paid plan.
 # [[kv_namespaces]]
 # binding = "TASKS"
 # id = "your-kv-namespace-id"
+"""
+
+# Minimal runnable worker so ``main`` resolves and ``wrangler deploy`` succeeds.
+_WORKER_JS_TEMPLATE = """\
+/**
+ * Minimal Bernstein agent worker.
+ *
+ * Free-tier compatible: a single fetch handler with no paid bindings. Replace
+ * the body with your agent logic. This file is the `main` entry point named in
+ * wrangler.toml, so `wrangler deploy` resolves without an "entry-point not
+ * found" error.
+ */
+export default {
+  async fetch(request, env) {
+    const body = {
+      service: "bernstein-agent",
+      server: env.BERNSTEIN_SERVER_URL ?? "",
+      message: "Bernstein agent worker is running.",
+    };
+    return new Response(JSON.stringify(body), {
+      headers: { "content-type": "application/json" },
+    });
+  },
+};
 """
 
 
@@ -206,10 +236,10 @@ BERNSTEIN_SERVER_URL = "http://127.0.0.1:8052"
 @click.option("--worker-name", default="bernstein-agent", show_default=True, help="Cloudflare Worker name.")
 @click.option("--output", "-o", default="wrangler.toml", show_default=True, help="Output path for wrangler.toml.")
 def cloud_init(worker_name: str, output: str) -> None:
-    """Scaffold wrangler.toml and Cloudflare bindings for cloud deployment.
+    """Scaffold a deployable wrangler.toml and its worker entry point.
 
     \b
-      bernstein cloud init                        # write wrangler.toml
+      bernstein cloud init                        # write wrangler.toml + src/index.js
       bernstein cloud init --output deploy/wrangler.toml
     """
     out_path = Path(output)
@@ -219,7 +249,17 @@ def cloud_init(worker_name: str, output: str) -> None:
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(_WRANGLER_TOML_TEMPLATE.format(worker_name=worker_name), encoding="utf-8")
     click.echo(f"Created {output}")
-    click.echo("Next: edit bindings in wrangler.toml, then run 'bernstein cloud deploy'.")
+
+    # Scaffold the worker named by ``main`` so the toml points at a real file.
+    worker_path = out_path.parent / "src" / "index.js"
+    if worker_path.exists():
+        click.echo(f"{worker_path} already exists; left unchanged.")
+    else:
+        worker_path.parent.mkdir(parents=True, exist_ok=True)
+        worker_path.write_text(_WORKER_JS_TEMPLATE, encoding="utf-8")
+        click.echo(f"Created {worker_path}")
+
+    click.echo("Next: set account_id in wrangler.toml, then deploy with 'npx wrangler deploy'.")
 
 
 # ---------------------------------------------------------------------------
@@ -233,7 +273,7 @@ def cloud_deploy(worker_name: str) -> None:
     """Deploy Bernstein agent Worker to your Cloudflare account."""
     click.echo(f"Deploying {worker_name}...")
     click.echo(f"Run: npx wrangler deploy --name {worker_name}")
-    click.echo("See templates/bernstein-cloud/wrangler.toml for the deployment template.")
+    click.echo("Scaffold a deployable worker first with 'bernstein cloud init'.")
 
 
 # ---------------------------------------------------------------------------
@@ -268,11 +308,23 @@ def _cloud_request(
     token: dict[str, str],
     **kwargs: Any,
 ) -> httpx.Response:
-    """Make authenticated request to Bernstein Cloud API."""
+    """Make an authenticated request to the Bernstein Cloud API.
+
+    Raises:
+        click.ClickException: When the hosted service cannot be reached. The
+            default ``api.bernstein.run`` host does not currently resolve, so a
+            connection failure is reported cleanly instead of as a traceback.
+    """
     url = f"{token['url']}{path}"
     headers = {
         "Authorization": f"Bearer {token['api_key']}",
         "Content-Type": "application/json",
     }
-    with httpx.Client(timeout=30) as client:
-        return client.request(method, url, headers=headers, **kwargs)
+    try:
+        with httpx.Client(timeout=30) as client:
+            return client.request(method, url, headers=headers, **kwargs)
+    except httpx.RequestError as exc:
+        raise click.ClickException(
+            f"Bernstein Cloud hosted service ({token['url']}) is not reachable: {exc}. "
+            "The hosted cloud API is experimental and not currently available."
+        ) from exc

--- a/templates/bernstein-cloud/src/worker.ts
+++ b/templates/bernstein-cloud/src/worker.ts
@@ -1,0 +1,29 @@
+/**
+ * Minimal Bernstein agent worker.
+ *
+ * Free-tier compatible: a single fetch handler with no paid bindings. This file
+ * is the `main` entry point named in wrangler.toml, so `wrangler deploy`
+ * resolves without an "entry-point not found" error. Replace the body with your
+ * agent logic and re-enable bindings in wrangler.toml as needed.
+ */
+
+interface Env {
+  BERNSTEIN_ENV: string;
+  MAX_AGENTS: string;
+  DEFAULT_MODEL: string;
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const body = {
+      service: "bernstein-agent",
+      env: env.BERNSTEIN_ENV ?? "development",
+      max_agents: env.MAX_AGENTS ?? "3",
+      default_model: env.DEFAULT_MODEL ?? "auto",
+      message: "Bernstein agent worker is running.",
+    };
+    return new Response(JSON.stringify(body), {
+      headers: { "content-type": "application/json" },
+    });
+  },
+};

--- a/templates/bernstein-cloud/wrangler.toml
+++ b/templates/bernstein-cloud/wrangler.toml
@@ -3,10 +3,16 @@
 # Usage:
 #   1. Copy this file to your project root
 #   2. Set your account_id below
-#   3. Configure KV namespaces and secrets
-#   4. Deploy: npx wrangler deploy
+#   3. Deploy: npx wrangler deploy
 #
-# See also: bernstein cloud deploy
+# See also: bernstein cloud init (scaffolds this file plus a runnable worker)
+#
+# This template is free-tier compatible by default: it declares only a fetch
+# worker, [vars], and the Workers AI binding, and its `main` points at the
+# src/worker.ts shipped alongside this file. The paid or ID-requiring bindings
+# (KV, Durable Objects, Queues, R2) are commented out below - uncomment and fill
+# in the required values only if your plan and use case need them. Queues in
+# particular require a Workers Paid plan.
 
 name = "bernstein-agent"
 main = "src/worker.ts"
@@ -20,43 +26,40 @@ BERNSTEIN_ENV = "production"
 MAX_AGENTS = "3"
 DEFAULT_MODEL = "auto"
 
-# KV namespace for task state persistence
-[[kv_namespaces]]
-binding = "TASK_STORE"
-id = ""  # Create with: npx wrangler kv namespace create TASK_STORE
-
-# Durable Objects for orchestrator state
-[durable_objects]
-bindings = [
-  { name = "ORCHESTRATOR", class_name = "OrchestratorDO" }
-]
-
-[[migrations]]
-tag = "v1"
-new_classes = ["OrchestratorDO"]
-
-# Queue for async task processing
-[[queues.producers]]
-queue = "bernstein-tasks"
-binding = "TASK_QUEUE"
-
-[[queues.consumers]]
-queue = "bernstein-tasks"
-max_batch_size = 10
-max_batch_timeout = 30
-
-# R2 bucket for artifact storage
-[[r2_buckets]]
-binding = "ARTIFACTS"
-bucket_name = "bernstein-artifacts"
-
-# AI binding for Workers AI model inference
+# AI binding for Workers AI model inference (free tier eligible)
 [ai]
 binding = "AI"
 
-# Rate limiting
-# [unsafe.bindings]
-# - name = "RATE_LIMITER"
-#   type = "ratelimit"
-#   namespace_id = "0"
-#   simple = { limit = 100, period = 60 }
+# ---------------------------------------------------------------------------
+# Optional bindings (disabled by default). Uncomment and set the required IDs.
+# ---------------------------------------------------------------------------
+
+# KV namespace for task state persistence
+# [[kv_namespaces]]
+# binding = "TASK_STORE"
+# id = ""  # Create with: npx wrangler kv namespace create TASK_STORE
+
+# Durable Objects for orchestrator state
+# [durable_objects]
+# bindings = [
+#   { name = "ORCHESTRATOR", class_name = "OrchestratorDO" }
+# ]
+#
+# [[migrations]]
+# tag = "v1"
+# new_classes = ["OrchestratorDO"]
+
+# Queue for async task processing (requires a Workers Paid plan)
+# [[queues.producers]]
+# queue = "bernstein-tasks"
+# binding = "TASK_QUEUE"
+#
+# [[queues.consumers]]
+# queue = "bernstein-tasks"
+# max_batch_size = 10
+# max_batch_timeout = 30
+
+# R2 bucket for artifact storage
+# [[r2_buckets]]
+# binding = "ARTIFACTS"
+# bucket_name = "bernstein-artifacts"

--- a/tests/property/test_adapter_spawn_bughunt.py
+++ b/tests/property/test_adapter_spawn_bughunt.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import inspect
 import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -112,6 +113,8 @@ def _spawn_with_mock(
     """
     popen_mock = _make_popen_mock()
     mod = type(adapter).__module__
+    if not hasattr(sys.modules[mod], "subprocess"):
+        pytest.skip(f"{mod} does not launch a subprocess")
     sdd = workdir / ".sdd" / "runtime"
     sdd.mkdir(parents=True, exist_ok=True)
     (workdir / ".claude").mkdir(parents=True, exist_ok=True)
@@ -262,6 +265,8 @@ def test_spawn_passes_env_and_cwd_no_shell(
     """
     popen_mock = _make_popen_mock()
     mod = type(adapter).__module__
+    if not hasattr(sys.modules[mod], "subprocess"):
+        pytest.skip(f"{mod} does not launch a subprocess")
     (tmp_path / ".sdd" / "runtime").mkdir(parents=True, exist_ok=True)
     (tmp_path / ".claude").mkdir(parents=True, exist_ok=True)
     with (

--- a/tests/unit/test_adapter_consistency.py
+++ b/tests/unit/test_adapter_consistency.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import inspect
 import subprocess
+import sys
 from contextlib import suppress
 from pathlib import Path
 from typing import Any
@@ -137,6 +138,14 @@ class TestAdapterSpawnResult:
     ) -> None:
         popen_mock = _make_popen_mock()
         mod = type(adapter).__module__
+
+        # Adapters that refuse before spawning (e.g. experimental stubs) do not
+        # import subprocess and never return a SpawnResult; skip the process
+        # check for them, mirroring the external-binary skip below.
+        mod_obj = sys.modules[mod]
+        if not hasattr(mod_obj, "subprocess"):
+            pytest.skip(f"{adapter_name} does not launch a subprocess")
+            return
 
         # Create required directories
         sdd = tmp_path / ".sdd" / "runtime"

--- a/tests/unit/test_adapter_contract.py
+++ b/tests/unit/test_adapter_contract.py
@@ -67,13 +67,16 @@ def _discover_registered_names() -> list[str]:
       are set; the contract test mocks Popen but can't satisfy the runtime
       config requirement.  Covered by ``test_adapter_clm.py`` and the
       integration suite under ``tests/integration/adapters/``.
+    - ``cloudflare`` - spawn() refuses with RuntimeError (no worker-trigger
+      path exists; see test_cloudflare_agents_adapter.py which covers the
+      refusal contract), so the Popen-mock contract does not apply.
     - ``q_dev`` - spawn() raises SpawnError unless a ``q login`` cache
       exists on disk; CI runners don't have one and the contract test
       mocks Popen but can't fake an authenticated AWS Builder ID
       session.  Covered by ``test_adapter_q_dev.py`` which monkeypatches
       ``Path.home`` to stand up a fake cache directory.
     """
-    return sorted(n for n in _ADAPTERS if n not in {"mock", "generic", "iac", "clm", "q_dev"})
+    return sorted(n for n in _ADAPTERS if n not in {"mock", "generic", "iac", "clm", "q_dev", "cloudflare"})
 
 
 def _make_factory(name: str) -> Any:

--- a/tests/unit/test_cloud_cmd.py
+++ b/tests/unit/test_cloud_cmd.py
@@ -9,6 +9,7 @@ import stat
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import httpx
 from click.testing import CliRunner
 
 from bernstein.cli.commands import cloud_cmd
@@ -173,6 +174,95 @@ def test_cloud_deploy_shows_instructions() -> None:
     assert result.exit_code == 0
     assert "wrangler deploy" in result.output
     assert "bernstein-agent" in result.output
+
+
+def test_cloud_deploy_does_not_point_at_repo_only_template() -> None:
+    """``cloud deploy`` must not reference the repo-only template path.
+
+    Wheel users have no ``templates/bernstein-cloud/``; the honest pointer is
+    ``bernstein cloud init`` (issue #2784).
+    """
+    runner = CliRunner()
+    result = runner.invoke(cloud_group, ["deploy"])
+    assert result.exit_code == 0
+    assert "templates/bernstein-cloud" not in result.output
+    assert "cloud init" in result.output
+
+
+# ---------------------------------------------------------------------------
+# init - scaffold a runnable, free-tier worker
+# ---------------------------------------------------------------------------
+
+
+def test_cloud_init_scaffolds_runnable_worker(tmp_path: Path) -> None:
+    """``cloud init`` writes a wrangler.toml AND the worker its ``main`` names."""
+    out = tmp_path / "wrangler.toml"
+    runner = CliRunner()
+    result = runner.invoke(cloud_group, ["init", "--output", str(out)])
+    assert result.exit_code == 0
+    assert out.exists()
+
+    toml_text = out.read_text(encoding="utf-8")
+    # main names src/index.js, which must now exist (issue #2784 entry-point bug).
+    assert 'main = "src/index.js"' in toml_text
+    worker = tmp_path / "src" / "index.js"
+    assert worker.exists()
+    assert "fetch" in worker.read_text(encoding="utf-8")
+
+
+def test_cloud_init_default_template_is_free_tier(tmp_path: Path) -> None:
+    """The scaffolded wrangler.toml has no paid bindings by default."""
+    out = tmp_path / "wrangler.toml"
+    runner = CliRunner()
+    result = runner.invoke(cloud_group, ["init", "--output", str(out)])
+    assert result.exit_code == 0
+    toml_text = out.read_text(encoding="utf-8")
+    # Queues are a Workers Paid feature; they must not be active by default.
+    assert "[[queues.producers]]" not in toml_text
+    assert "[[queues.consumers]]" not in toml_text
+
+
+def test_cloud_init_does_not_clobber_existing_worker(tmp_path: Path) -> None:
+    """An existing worker file is left untouched by ``cloud init``."""
+    out = tmp_path / "wrangler.toml"
+    worker = tmp_path / "src" / "index.js"
+    worker.parent.mkdir(parents=True, exist_ok=True)
+    worker.write_text("// custom worker\n", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(cloud_group, ["init", "--output", str(out)])
+    assert result.exit_code == 0
+    assert worker.read_text(encoding="utf-8") == "// custom worker\n"
+
+
+# ---------------------------------------------------------------------------
+# login / hosted-service honesty
+# ---------------------------------------------------------------------------
+
+
+def test_cloud_login_notes_experimental(tmp_path: Path) -> None:
+    """``cloud login`` warns that the hosted service is experimental."""
+    _redirect_token_paths(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cloud_group, ["login", "--api-key", "sk-test-123"])
+    assert result.exit_code == 0
+    assert "Authenticated" in result.output
+    assert "experimental" in result.output.lower()
+
+
+def test_cloud_runs_reports_hosted_service_unavailable(tmp_path: Path) -> None:
+    """A connection failure to the hosted API yields a clean message, not a traceback."""
+    _redirect_token_paths(tmp_path)
+    cloud_cmd._save_token("sk-test", "https://api.bernstein.run")
+
+    failing_client = MagicMock(request=MagicMock(side_effect=httpx.ConnectError("name resolution failed")))
+    runner = CliRunner()
+    with patch.object(cloud_cmd.httpx.Client, "__enter__", return_value=failing_client):
+        result = runner.invoke(cloud_group, ["runs"])
+
+    assert result.exit_code != 0
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+    assert "not reachable" in result.output.lower() or "not currently available" in result.output.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cloudflare_agents_adapter.py
+++ b/tests/unit/test_cloudflare_agents_adapter.py
@@ -1,11 +1,13 @@
-"""Unit tests for CloudflareAgentsAdapter spawn/name/env filtering."""
+"""Unit tests for CloudflareAgentsAdapter.
+
+The adapter is experimental and non-functional (issue #2782): it has no
+worker-trigger path, so ``spawn()`` refuses with a clear error instead of
+launching a ``npx wrangler dev`` server that can never complete a task.
+"""
 
 from __future__ import annotations
 
-import subprocess
-import sys
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock, patch
 
 import pytest
 from bernstein.core.models import ModelConfig
@@ -14,24 +16,6 @@ from bernstein.adapters.cloudflare_agents import CloudflareAgentsAdapter
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _make_popen_mock(pid: int) -> MagicMock:
-    m = MagicMock(spec=subprocess.Popen)
-    m.pid = pid
-    m.wait.return_value = None
-    return m
-
-
-def _inner_cmd(full_cmd: list[str]) -> list[str]:
-    """Extract the actual CLI command after the '--' worker separator."""
-    sep = full_cmd.index("--")
-    return full_cmd[sep + 1 :]
 
 
 # ---------------------------------------------------------------------------
@@ -45,311 +29,84 @@ class TestCloudflareAdapterName:
 
 
 # ---------------------------------------------------------------------------
-# CloudflareAgentsAdapter.spawn() - command construction
+# spawn() refuses: the adapter has no worker-trigger path (issue #2782)
 # ---------------------------------------------------------------------------
 
 
-class TestCloudflareAdapterSpawn:
-    def test_wrapped_with_worker(self, tmp_path: Path) -> None:
+class TestCloudflareSpawnRefuses:
+    def test_spawn_raises_runtime_error(self, tmp_path: Path) -> None:
         adapter = CloudflareAgentsAdapter()
-        proc_mock = _make_popen_mock(pid=100)
-        with patch("bernstein.adapters.cloudflare_agents.subprocess.Popen", return_value=proc_mock) as popen:
-            adapter.spawn(
-                prompt="fix the bug",
-                workdir=tmp_path,
-                model_config=ModelConfig(model="gpt-4o", effort="high"),
-                session_id="cf-s1",
-            )
-        cmd = popen.call_args.args[0]
-        assert cmd[0] == sys.executable
-        assert cmd[1:3] == ["-m", "bernstein.core.orchestration.worker"]
-        inner = _inner_cmd(cmd)
-        assert inner[0] == "npx"
-        assert inner[1] == "wrangler"
-        assert inner[2] == "dev"
-
-    def test_model_passed_as_var(self, tmp_path: Path) -> None:
-        adapter = CloudflareAgentsAdapter()
-        proc_mock = _make_popen_mock(pid=101)
-        with patch("bernstein.adapters.cloudflare_agents.subprocess.Popen", return_value=proc_mock) as popen:
-            adapter.spawn(
-                prompt="hello",
-                workdir=tmp_path,
-                model_config=ModelConfig(model="claude-sonnet-4-20250514", effort="medium"),
-                session_id="cf-s2",
-            )
-        inner = _inner_cmd(popen.call_args.args[0])
-        var_indices = [i for i, v in enumerate(inner) if v == "--var"]
-        model_vars = [inner[i + 1] for i in var_indices if inner[i + 1].startswith("AGENT_MODEL:")]
-        assert len(model_vars) == 1
-        assert model_vars[0] == "AGENT_MODEL:claude-sonnet-4-20250514"
-
-    def test_prompt_passed_as_var(self, tmp_path: Path) -> None:
-        adapter = CloudflareAgentsAdapter()
-        proc_mock = _make_popen_mock(pid=102)
-        with patch("bernstein.adapters.cloudflare_agents.subprocess.Popen", return_value=proc_mock) as popen:
-            adapter.spawn(
-                prompt="my-unique-prompt",
-                workdir=tmp_path,
-                model_config=ModelConfig(model="gpt-4o", effort="high"),
-                session_id="cf-s3",
-            )
-        inner = _inner_cmd(popen.call_args.args[0])
-        var_indices = [i for i, v in enumerate(inner) if v == "--var"]
-        prompt_vars = [inner[i + 1] for i in var_indices if inner[i + 1].startswith("AGENT_PROMPT:")]
-        assert len(prompt_vars) == 1
-        assert "my-unique-prompt" in prompt_vars[0]
-
-    def test_session_id_passed_as_var(self, tmp_path: Path) -> None:
-        adapter = CloudflareAgentsAdapter()
-        proc_mock = _make_popen_mock(pid=103)
-        with patch("bernstein.adapters.cloudflare_agents.subprocess.Popen", return_value=proc_mock) as popen:
+        with pytest.raises(RuntimeError, match="experimental"):
             adapter.spawn(
                 prompt="hello",
                 workdir=tmp_path,
                 model_config=ModelConfig(model="gpt-4o", effort="high"),
-                session_id="cf-s4",
+                session_id="cf-refuse",
             )
-        inner = _inner_cmd(popen.call_args.args[0])
-        var_indices = [i for i, v in enumerate(inner) if v == "--var"]
-        session_vars = [inner[i + 1] for i in var_indices if inner[i + 1].startswith("AGENT_SESSION:")]
-        assert len(session_vars) == 1
-        assert session_vars[0] == "AGENT_SESSION:cf-s4"
 
-    def test_creates_log_dir(self, tmp_path: Path) -> None:
+    def test_refusal_message_is_actionable(self, tmp_path: Path) -> None:
         adapter = CloudflareAgentsAdapter()
-        proc_mock = _make_popen_mock(pid=104)
-        with patch("bernstein.adapters.cloudflare_agents.subprocess.Popen", return_value=proc_mock):
+        with pytest.raises(RuntimeError) as exc:
             adapter.spawn(
                 prompt="hello",
                 workdir=tmp_path,
                 model_config=ModelConfig(model="gpt-4o", effort="high"),
-                session_id="cf-s5",
+                session_id="cf-refuse-2",
             )
-        assert (tmp_path / ".sdd" / "runtime").is_dir()
+        message = str(exc.value)
+        # Names the tracking issue and at least one working alternative.
+        assert "#2782" in message
+        assert "CloudflareBridge" in message
 
-    def test_spawn_result_pid(self, tmp_path: Path) -> None:
+    def test_spawn_does_not_create_runtime_dirs(self, tmp_path: Path) -> None:
+        """Refusal happens before any filesystem side effects."""
         adapter = CloudflareAgentsAdapter()
-        proc_mock = _make_popen_mock(pid=106)
-        with patch("bernstein.adapters.cloudflare_agents.subprocess.Popen", return_value=proc_mock):
-            result = adapter.spawn(
-                prompt="hello",
-                workdir=tmp_path,
-                model_config=ModelConfig(model="gpt-4o", effort="high"),
-                session_id="cf-s6",
-            )
-        assert result.pid == 106
-
-    def test_log_path_uses_session_id(self, tmp_path: Path) -> None:
-        adapter = CloudflareAgentsAdapter()
-        proc_mock = _make_popen_mock(pid=107)
-        with patch("bernstein.adapters.cloudflare_agents.subprocess.Popen", return_value=proc_mock):
-            result = adapter.spawn(
-                prompt="hello",
-                workdir=tmp_path,
-                model_config=ModelConfig(model="gpt-4o", effort="high"),
-                session_id="my-cf-session",
-            )
-        assert result.log_path.name == "my-cf-session.log"
-
-    def test_start_new_session_enabled(self, tmp_path: Path) -> None:
-        adapter = CloudflareAgentsAdapter()
-        proc_mock = _make_popen_mock(pid=108)
-        with patch("bernstein.adapters.cloudflare_agents.subprocess.Popen", return_value=proc_mock) as popen:
+        with pytest.raises(RuntimeError):
             adapter.spawn(
                 prompt="hello",
                 workdir=tmp_path,
                 model_config=ModelConfig(model="gpt-4o", effort="high"),
-                session_id="cf-s8",
+                session_id="cf-refuse-3",
             )
-        kwargs = popen.call_args.kwargs
-        assert kwargs.get("start_new_session") is True
-
-    def test_system_addendum_appended(self, tmp_path: Path) -> None:
-        adapter = CloudflareAgentsAdapter()
-        proc_mock = _make_popen_mock(pid=109)
-        with patch("bernstein.adapters.cloudflare_agents.subprocess.Popen", return_value=proc_mock) as popen:
-            adapter.spawn(
-                prompt="do work",
-                workdir=tmp_path,
-                model_config=ModelConfig(model="gpt-4o", effort="high"),
-                session_id="cf-s9",
-                system_addendum="extra instructions",
-            )
-        inner = _inner_cmd(popen.call_args.args[0])
-        var_indices = [i for i, v in enumerate(inner) if v == "--var"]
-        prompt_vars = [inner[i + 1] for i in var_indices if inner[i + 1].startswith("AGENT_PROMPT:")]
-        assert "do work" in prompt_vars[0]
-        assert "extra instructions" in prompt_vars[0]
+        assert not (tmp_path / ".sdd" / "runtime").exists()
 
 
 # ---------------------------------------------------------------------------
-# spawn() - env isolation
+# Multimodal refusal takes precedence over the unavailable error
 # ---------------------------------------------------------------------------
 
 
-class TestCloudflareEnvIsolation:
-    def test_env_contains_cf_keys(self, tmp_path: Path) -> None:
+class TestCloudflareMultimodalRefusal:
+    def test_multimodal_context_refused_first(self, tmp_path: Path) -> None:
+        from bernstein.core.agents.multimodal import (
+            ModalityType,
+            MultiModalContext,
+            MultiModalInput,
+        )
+        from bernstein.core.agents.multimodal_attestation import CapabilityRefusal
+
         adapter = CloudflareAgentsAdapter()
-        proc_mock = _make_popen_mock(pid=200)
-        with (
-            patch("bernstein.adapters.cloudflare_agents.subprocess.Popen", return_value=proc_mock) as popen,
-            patch.dict(
-                "os.environ",
-                {
-                    "CLOUDFLARE_ACCOUNT_ID": "abc123",
-                    "CLOUDFLARE_API_TOKEN": "tok-secret",
-                    "PATH": "/usr/bin",
-                },
-                clear=True,
+        attachment = tmp_path / "shot.png"
+        attachment.write_bytes(b"fake image")
+        context = MultiModalContext(
+            inputs=(
+                MultiModalInput(
+                    modality=ModalityType.IMAGE,
+                    content_path=attachment,
+                    mime_type="image/png",
+                    description="screenshot",
+                ),
             ),
-        ):
+            primary_modality=ModalityType.IMAGE,
+        )
+        with pytest.raises(CapabilityRefusal):
             adapter.spawn(
                 prompt="hello",
                 workdir=tmp_path,
                 model_config=ModelConfig(model="gpt-4o", effort="high"),
-                session_id="cf-env1",
+                session_id="cf-mm",
+                multimodal_context=context,
             )
-        env = popen.call_args.kwargs.get("env", {})
-        assert "CLOUDFLARE_ACCOUNT_ID" in env
-        assert env["CLOUDFLARE_ACCOUNT_ID"] == "abc123"
-        assert "CLOUDFLARE_API_TOKEN" in env
-
-    def test_env_excludes_unrelated_keys(self, tmp_path: Path) -> None:
-        adapter = CloudflareAgentsAdapter()
-        proc_mock = _make_popen_mock(pid=201)
-        with (
-            patch("bernstein.adapters.cloudflare_agents.subprocess.Popen", return_value=proc_mock) as popen,
-            patch.dict(
-                "os.environ",
-                {
-                    "CLOUDFLARE_API_TOKEN": "tok-secret",
-                    "ANTHROPIC_API_KEY": "ant-secret",
-                    "DATABASE_URL": "postgres://x",
-                    "PATH": "/usr/bin",
-                },
-                clear=True,
-            ),
-        ):
-            adapter.spawn(
-                prompt="hello",
-                workdir=tmp_path,
-                model_config=ModelConfig(model="gpt-4o", effort="high"),
-                session_id="cf-env2",
-            )
-        env = popen.call_args.kwargs.get("env", {})
-        assert "ANTHROPIC_API_KEY" not in env
-        assert "DATABASE_URL" not in env
-
-    def test_env_includes_path(self, tmp_path: Path) -> None:
-        adapter = CloudflareAgentsAdapter()
-        proc_mock = _make_popen_mock(pid=202)
-        with (
-            patch("bernstein.adapters.cloudflare_agents.subprocess.Popen", return_value=proc_mock) as popen,
-            patch.dict("os.environ", {"PATH": "/usr/bin", "CLOUDFLARE_API_TOKEN": "x"}, clear=True),
-        ):
-            adapter.spawn(
-                prompt="hello",
-                workdir=tmp_path,
-                model_config=ModelConfig(model="gpt-4o", effort="high"),
-                session_id="cf-env3",
-            )
-        env = popen.call_args.kwargs.get("env", {})
-        assert "PATH" in env
-
-
-# ---------------------------------------------------------------------------
-# Missing binary / PermissionError
-# ---------------------------------------------------------------------------
-
-
-class TestCloudflareSpawnMissingBinary:
-    def test_file_not_found_raises_runtime_error(self, tmp_path: Path) -> None:
-        adapter = CloudflareAgentsAdapter()
-        with (
-            patch(
-                "bernstein.adapters.cloudflare_agents.subprocess.Popen",
-                side_effect=FileNotFoundError("No such file"),
-            ),
-            pytest.raises(RuntimeError, match="npx not found"),
-        ):
-            adapter.spawn(
-                prompt="hello",
-                workdir=tmp_path,
-                model_config=ModelConfig(model="gpt-4o", effort="high"),
-                session_id="missing",
-            )
-
-    def test_permission_error_raises_runtime_error(self, tmp_path: Path) -> None:
-        adapter = CloudflareAgentsAdapter()
-        with (
-            patch(
-                "bernstein.adapters.cloudflare_agents.subprocess.Popen",
-                side_effect=PermissionError("Permission denied"),
-            ),
-            pytest.raises(RuntimeError, match="[Pp]ermission"),
-        ):
-            adapter.spawn(
-                prompt="hello",
-                workdir=tmp_path,
-                model_config=ModelConfig(model="gpt-4o", effort="high"),
-                session_id="perm-denied",
-            )
-
-
-# ---------------------------------------------------------------------------
-# Warnings and fast-exit
-# ---------------------------------------------------------------------------
-
-
-class TestCloudflareWarningsAndFastExit:
-    def test_warns_when_account_id_missing(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
-        adapter = CloudflareAgentsAdapter()
-        proc_mock = _make_popen_mock(pid=301)
-        with (
-            patch("bernstein.adapters.cloudflare_agents.subprocess.Popen", return_value=proc_mock),
-            patch.dict("os.environ", {"PATH": "/usr/bin"}, clear=True),
-            caplog.at_level("WARNING"),
-        ):
-            adapter.spawn(
-                prompt="hello",
-                workdir=tmp_path,
-                model_config=ModelConfig(model="gpt-4o", effort="high"),
-                session_id="warn-missing-id",
-            )
-        assert "CLOUDFLARE_ACCOUNT_ID is not set" in caplog.text
-
-    def test_warns_when_api_token_missing(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
-        adapter = CloudflareAgentsAdapter()
-        proc_mock = _make_popen_mock(pid=302)
-        with (
-            patch("bernstein.adapters.cloudflare_agents.subprocess.Popen", return_value=proc_mock),
-            patch.dict("os.environ", {"PATH": "/usr/bin"}, clear=True),
-            caplog.at_level("WARNING"),
-        ):
-            adapter.spawn(
-                prompt="hello",
-                workdir=tmp_path,
-                model_config=ModelConfig(model="gpt-4o", effort="high"),
-                session_id="warn-missing-token",
-            )
-        assert "CLOUDFLARE_API_TOKEN is not set" in caplog.text
-
-    def test_fast_exit_rate_limit_raises(self, tmp_path: Path) -> None:
-        adapter = CloudflareAgentsAdapter()
-        proc_mock = _make_popen_mock(pid=303)
-        proc_mock.wait.return_value = 1
-        with (
-            patch("bernstein.adapters.cloudflare_agents.subprocess.Popen", return_value=proc_mock),
-            patch.object(CloudflareAgentsAdapter, "_read_last_lines", return_value=["429 rate limit exceeded"]),
-        ):
-            with pytest.raises(RuntimeError, match="rate-limited"):
-                adapter.spawn(
-                    prompt="hello",
-                    workdir=tmp_path,
-                    model_config=ModelConfig(model="gpt-4o", effort="high"),
-                    session_id="cf-fast-exit",
-                )
 
 
 # ---------------------------------------------------------------------------
@@ -372,6 +129,8 @@ class TestCloudflareRegistry:
 
 class TestCloudflareIsAlive:
     def test_true_when_process_exists(self) -> None:
+        from unittest.mock import patch
+
         adapter = CloudflareAgentsAdapter()
         with patch("bernstein.adapters.base.process_alive", return_value=True) as mock_alive:
             assert adapter.is_alive(1234) is True
@@ -380,6 +139,8 @@ class TestCloudflareIsAlive:
 
 class TestCloudflareKill:
     def test_calls_killpg(self) -> None:
+        from unittest.mock import patch
+
         adapter = CloudflareAgentsAdapter()
         with patch("bernstein.adapters.base.reap_process_group") as mock_killpg:
             adapter.kill(555)

--- a/tests/unit/test_codex_cloudflare.py
+++ b/tests/unit/test_codex_cloudflare.py
@@ -120,9 +120,7 @@ class TestCodexCloudflareAdapterName:
 
 
 def _adapter() -> CodexCloudflareAdapter:
-    return CodexCloudflareAdapter(
-        CodexSandboxConfig(cloudflare_account_id="a", cloudflare_api_token="t")
-    )
+    return CodexCloudflareAdapter(CodexSandboxConfig(cloudflare_account_id="a", cloudflare_api_token="t"))
 
 
 class TestRefusal:

--- a/tests/unit/test_codex_cloudflare.py
+++ b/tests/unit/test_codex_cloudflare.py
@@ -1,10 +1,12 @@
-"""Unit tests for CodexCloudflareAdapter."""
+"""Unit tests for CodexCloudflareAdapter.
+
+The adapter is experimental and non-functional (issue #2783): its target
+Cloudflare sandbox REST API does not exist, so every public operation refuses
+with a clear error instead of issuing a request Cloudflare cannot route.
+"""
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
-
-import httpx
 import pytest
 
 from bernstein.adapters.codex_cloudflare import (
@@ -113,459 +115,41 @@ class TestCodexCloudflareAdapterName:
 
 
 # ---------------------------------------------------------------------------
-# _headers()
+# Refusal: the target Cloudflare sandbox REST API does not exist (issue #2783)
 # ---------------------------------------------------------------------------
 
 
-class TestHeaders:
-    def test_includes_auth_token(self) -> None:
-        cfg = CodexSandboxConfig(cloudflare_api_token="my-token")
-        adapter = CodexCloudflareAdapter(cfg)
-        headers = adapter._headers()
-        assert headers["Authorization"] == "Bearer my-token"
-        assert headers["Content-Type"] == "application/json"
+def _adapter() -> CodexCloudflareAdapter:
+    return CodexCloudflareAdapter(
+        CodexSandboxConfig(cloudflare_account_id="a", cloudflare_api_token="t")
+    )
 
 
-# ---------------------------------------------------------------------------
-# _create_sandbox() - payload validation
-# ---------------------------------------------------------------------------
-
-
-def _mock_post_response(sandbox_id: str = "sb-test") -> httpx.Response:
-    """Build a mock httpx.Response for sandbox creation."""
-    resp = MagicMock(spec=httpx.Response)
-    resp.status_code = 200
-    resp.json.return_value = {"result": {"id": sandbox_id}}
-    resp.raise_for_status = MagicMock()
-    return resp
-
-
-class TestCreateSandbox:
+class TestRefusal:
     @pytest.mark.asyncio
-    async def test_sends_correct_payload(self) -> None:
-        cfg = CodexSandboxConfig(
-            cloudflare_account_id="acct-42",
-            cloudflare_api_token="tok-x",
-            openai_api_key="sk-key",
-            sandbox_image="img:v1",
-            memory_mb=1024,
-            cpu_cores=2.0,
-            network_access="full",
-            r2_bucket="bucket-1",
-        )
-        adapter = CodexCloudflareAdapter(cfg)
-
-        mock_resp = _mock_post_response("sb-created")
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.post.return_value = mock_resp
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-
-        with patch("bernstein.adapters.codex_cloudflare.httpx.AsyncClient", return_value=mock_client):
-            sandbox_id = await adapter._create_sandbox("ws-123", timeout_minutes=10)
-
-        assert sandbox_id == "sb-created"
-        call_kwargs = mock_client.post.call_args
-        payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
-        assert payload["image"] == "img:v1"
-        assert payload["memory_mb"] == 1024
-        assert payload["cpu_cores"] == pytest.approx(2.0)
-        assert payload["timeout_seconds"] == 600
-        assert payload["network_access"] == "full"
-        assert payload["env"]["OPENAI_API_KEY"] == "sk-key"
-        assert payload["env"]["WORKSPACE_R2_BUCKET"] == "bucket-1"
-        assert payload["env"]["WORKSPACE_ID"] == "ws-123"
+    async def test_execute_refuses(self) -> None:
+        with pytest.raises(RuntimeError, match="experimental"):
+            await _adapter().execute("do stuff", "ws-1", model="codex-mini")
 
     @pytest.mark.asyncio
-    async def test_sends_to_correct_url(self) -> None:
-        cfg = CodexSandboxConfig(
-            cloudflare_account_id="acct-99",
-            cloudflare_api_token="tok-z",
-        )
-        adapter = CodexCloudflareAdapter(cfg)
-
-        mock_resp = _mock_post_response()
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.post.return_value = mock_resp
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-
-        with patch("bernstein.adapters.codex_cloudflare.httpx.AsyncClient", return_value=mock_client):
-            await adapter._create_sandbox("ws-1", timeout_minutes=5)
-
-        url = mock_client.post.call_args[0][0]
-        assert "acct-99" in url
-        assert url.endswith("/sandbox")
-
-
-# ---------------------------------------------------------------------------
-# execute() - happy path
-# ---------------------------------------------------------------------------
-
-
-class TestExecute:
-    @pytest.mark.asyncio
-    async def test_execute_happy_path(self) -> None:
-        """execute() creates sandbox, injects command, waits, returns result."""
-        cfg = CodexSandboxConfig(
-            cloudflare_account_id="acct-1",
-            cloudflare_api_token="tok-1",
-            openai_api_key="sk-1",
-        )
-        adapter = CodexCloudflareAdapter(cfg)
-
-        expected_result = CodexSandboxResult(
-            sandbox_id="sb-exec",
-            status="completed",
-            stdout="done",
-            execution_time_seconds=5.0,
-        )
-        with (
-            patch.object(adapter, "_create_sandbox", new_callable=AsyncMock, return_value="sb-exec"),
-            patch.object(adapter, "_inject_codex_command", new_callable=AsyncMock) as mock_inject,
-            patch.object(adapter, "_wait_for_completion", new_callable=AsyncMock, return_value=expected_result),
-        ):
-            result = await adapter.execute("do stuff", "ws-1", model="codex-mini")
-
-        assert result.sandbox_id == "sb-exec"
-        assert result.status == "completed"
-        mock_inject.assert_awaited_once_with("sb-exec", "do stuff", "codex-mini")
+    async def test_get_status_refuses(self) -> None:
+        with pytest.raises(RuntimeError, match="experimental"):
+            await _adapter().get_status("sb-1")
 
     @pytest.mark.asyncio
-    async def test_execute_uses_config_timeout(self) -> None:
-        """execute() defaults to config max_execution_minutes."""
-        cfg = CodexSandboxConfig(
-            cloudflare_account_id="a",
-            cloudflare_api_token="t",
-            max_execution_minutes=15,
-        )
-        adapter = CodexCloudflareAdapter(cfg)
-
-        with (
-            patch.object(adapter, "_create_sandbox", new_callable=AsyncMock, return_value="sb-t"),
-            patch.object(adapter, "_inject_codex_command", new_callable=AsyncMock),
-            patch.object(
-                adapter,
-                "_wait_for_completion",
-                new_callable=AsyncMock,
-                return_value=CodexSandboxResult(sandbox_id="sb-t", status="completed"),
-            ) as mock_wait,
-        ):
-            await adapter.execute("prompt", "ws-1")
-
-        # timeout_minutes=15 => timeout_seconds=900
-        mock_wait.assert_awaited_once_with("sb-t", 900)
+    async def test_cancel_refuses(self) -> None:
+        with pytest.raises(RuntimeError, match="experimental"):
+            await _adapter().cancel("sb-1")
 
     @pytest.mark.asyncio
-    async def test_execute_custom_timeout(self) -> None:
-        """execute() uses explicit timeout_minutes when provided."""
-        cfg = CodexSandboxConfig(
-            cloudflare_account_id="a",
-            cloudflare_api_token="t",
-            max_execution_minutes=30,
-        )
-        adapter = CodexCloudflareAdapter(cfg)
-
-        with (
-            patch.object(adapter, "_create_sandbox", new_callable=AsyncMock, return_value="sb-t2"),
-            patch.object(adapter, "_inject_codex_command", new_callable=AsyncMock),
-            patch.object(
-                adapter,
-                "_wait_for_completion",
-                new_callable=AsyncMock,
-                return_value=CodexSandboxResult(sandbox_id="sb-t2", status="completed"),
-            ) as mock_wait,
-        ):
-            await adapter.execute("prompt", "ws-1", timeout_minutes=5)
-
-        mock_wait.assert_awaited_once_with("sb-t2", 300)
-
-
-# ---------------------------------------------------------------------------
-# execute() - cleanup on failure
-# ---------------------------------------------------------------------------
-
-
-class TestExecuteCleanupOnFailure:
-    @pytest.mark.asyncio
-    async def test_cleanup_called_on_inject_failure(self) -> None:
-        """execute() calls _cleanup_sandbox when _inject_codex_command fails."""
-        cfg = CodexSandboxConfig(
-            cloudflare_account_id="a",
-            cloudflare_api_token="t",
-        )
-        adapter = CodexCloudflareAdapter(cfg)
-
-        with (
-            patch.object(adapter, "_create_sandbox", new_callable=AsyncMock, return_value="sb-fail"),
-            patch.object(
-                adapter,
-                "_inject_codex_command",
-                new_callable=AsyncMock,
-                side_effect=httpx.HTTPStatusError(
-                    "server error",
-                    request=MagicMock(),
-                    response=MagicMock(status_code=500),
-                ),
-            ),
-            patch.object(adapter, "_cleanup_sandbox", new_callable=AsyncMock) as mock_cleanup,
-            pytest.raises(httpx.HTTPStatusError),
-        ):
-            await adapter.execute("prompt", "ws-1")
-
-        mock_cleanup.assert_awaited_once_with("sb-fail")
+    async def test_get_logs_refuses(self) -> None:
+        with pytest.raises(RuntimeError, match="experimental"):
+            await _adapter().get_logs("sb-1")
 
     @pytest.mark.asyncio
-    async def test_cleanup_called_on_wait_failure(self) -> None:
-        """execute() calls _cleanup_sandbox when _wait_for_completion fails."""
-        cfg = CodexSandboxConfig(
-            cloudflare_account_id="a",
-            cloudflare_api_token="t",
-        )
-        adapter = CodexCloudflareAdapter(cfg)
-
-        with (
-            patch.object(adapter, "_create_sandbox", new_callable=AsyncMock, return_value="sb-fail2"),
-            patch.object(adapter, "_inject_codex_command", new_callable=AsyncMock),
-            patch.object(
-                adapter,
-                "_wait_for_completion",
-                new_callable=AsyncMock,
-                side_effect=RuntimeError("poll failed"),
-            ),
-            patch.object(adapter, "_cleanup_sandbox", new_callable=AsyncMock) as mock_cleanup,
-            pytest.raises(RuntimeError, match="poll failed"),
-        ):
-            await adapter.execute("prompt", "ws-1")
-
-        mock_cleanup.assert_awaited_once_with("sb-fail2")
-
-
-# ---------------------------------------------------------------------------
-# get_status()
-# ---------------------------------------------------------------------------
-
-
-class TestGetStatus:
-    @pytest.mark.asyncio
-    async def test_returns_status_string(self) -> None:
-        cfg = CodexSandboxConfig(
-            cloudflare_account_id="acct-s",
-            cloudflare_api_token="tok-s",
-        )
-        adapter = CodexCloudflareAdapter(cfg)
-
-        mock_resp = MagicMock(spec=httpx.Response)
-        mock_resp.json.return_value = {"result": {"status": "running"}}
-        mock_resp.raise_for_status = MagicMock()
-
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.get.return_value = mock_resp
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-
-        with patch("bernstein.adapters.codex_cloudflare.httpx.AsyncClient", return_value=mock_client):
-            status = await adapter.get_status("sb-123")
-
-        assert status == "running"
-
-    @pytest.mark.asyncio
-    async def test_returns_unknown_on_missing_status(self) -> None:
-        cfg = CodexSandboxConfig(
-            cloudflare_account_id="acct-s",
-            cloudflare_api_token="tok-s",
-        )
-        adapter = CodexCloudflareAdapter(cfg)
-
-        mock_resp = MagicMock(spec=httpx.Response)
-        mock_resp.json.return_value = {"result": {}}
-        mock_resp.raise_for_status = MagicMock()
-
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.get.return_value = mock_resp
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-
-        with patch("bernstein.adapters.codex_cloudflare.httpx.AsyncClient", return_value=mock_client):
-            status = await adapter.get_status("sb-empty")
-
-        assert status == "unknown"
-
-
-# ---------------------------------------------------------------------------
-# cancel()
-# ---------------------------------------------------------------------------
-
-
-class TestCancel:
-    @pytest.mark.asyncio
-    async def test_sends_delete_request(self) -> None:
-        cfg = CodexSandboxConfig(
-            cloudflare_account_id="acct-c",
-            cloudflare_api_token="tok-c",
-        )
-        adapter = CodexCloudflareAdapter(cfg)
-
-        mock_resp = MagicMock(spec=httpx.Response)
-        mock_resp.raise_for_status = MagicMock()
-
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.delete.return_value = mock_resp
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-
-        with patch("bernstein.adapters.codex_cloudflare.httpx.AsyncClient", return_value=mock_client):
-            await adapter.cancel("sb-cancel")
-
-        url = mock_client.delete.call_args[0][0]
-        assert "sb-cancel" in url
-        assert "acct-c" in url
-
-
-# ---------------------------------------------------------------------------
-# get_logs()
-# ---------------------------------------------------------------------------
-
-
-class TestGetLogs:
-    @pytest.mark.asyncio
-    async def test_returns_log_output(self) -> None:
-        cfg = CodexSandboxConfig(
-            cloudflare_account_id="acct-l",
-            cloudflare_api_token="tok-l",
-        )
-        adapter = CodexCloudflareAdapter(cfg)
-
-        mock_resp = MagicMock(spec=httpx.Response)
-        mock_resp.json.return_value = {"result": {"output": "hello world\n"}}
-        mock_resp.raise_for_status = MagicMock()
-
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.get.return_value = mock_resp
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-
-        with patch("bernstein.adapters.codex_cloudflare.httpx.AsyncClient", return_value=mock_client):
-            logs = await adapter.get_logs("sb-logs")
-
-        assert logs == "hello world\n"
-
-
-# ---------------------------------------------------------------------------
-# Error handling
-# ---------------------------------------------------------------------------
-
-
-class TestErrorHandling:
-    @pytest.mark.asyncio
-    async def test_create_sandbox_api_failure(self) -> None:
-        """_create_sandbox raises on HTTP error."""
-        cfg = CodexSandboxConfig(
-            cloudflare_account_id="acct-e",
-            cloudflare_api_token="tok-e",
-        )
-        adapter = CodexCloudflareAdapter(cfg)
-
-        mock_resp = MagicMock(spec=httpx.Response)
-        mock_resp.status_code = 401
-        mock_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
-            "Unauthorized",
-            request=MagicMock(),
-            response=mock_resp,
-        )
-
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.post.return_value = mock_resp
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-
-        with (
-            patch("bernstein.adapters.codex_cloudflare.httpx.AsyncClient", return_value=mock_client),
-            pytest.raises(httpx.HTTPStatusError),
-        ):
-            await adapter._create_sandbox("ws-err", timeout_minutes=5)
-
-    @pytest.mark.asyncio
-    async def test_get_status_api_failure(self) -> None:
-        """get_status raises on HTTP error."""
-        cfg = CodexSandboxConfig(
-            cloudflare_account_id="acct-e",
-            cloudflare_api_token="bad-token",
-        )
-        adapter = CodexCloudflareAdapter(cfg)
-
-        mock_resp = MagicMock(spec=httpx.Response)
-        mock_resp.status_code = 403
-        mock_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
-            "Forbidden",
-            request=MagicMock(),
-            response=mock_resp,
-        )
-
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.get.return_value = mock_resp
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-
-        with (
-            patch("bernstein.adapters.codex_cloudflare.httpx.AsyncClient", return_value=mock_client),
-            pytest.raises(httpx.HTTPStatusError),
-        ):
-            await adapter.get_status("sb-err")
-
-    @pytest.mark.asyncio
-    async def test_cleanup_sandbox_swallows_errors(self) -> None:
-        """_cleanup_sandbox does not raise when cancel fails."""
-        cfg = CodexSandboxConfig(
-            cloudflare_account_id="acct-e",
-            cloudflare_api_token="tok-e",
-        )
-        adapter = CodexCloudflareAdapter(cfg)
-
-        with patch.object(
-            adapter,
-            "cancel",
-            new_callable=AsyncMock,
-            side_effect=httpx.HTTPStatusError(
-                "gone",
-                request=MagicMock(),
-                response=MagicMock(status_code=410),
-            ),
-        ):
-            # Should not raise
-            await adapter._cleanup_sandbox("sb-gone")
-
-
-# ---------------------------------------------------------------------------
-# _inject_codex_command()
-# ---------------------------------------------------------------------------
-
-
-class TestInjectCodexCommand:
-    @pytest.mark.asyncio
-    async def test_sends_exec_payload(self) -> None:
-        cfg = CodexSandboxConfig(
-            cloudflare_account_id="acct-i",
-            cloudflare_api_token="tok-i",
-        )
-        adapter = CodexCloudflareAdapter(cfg)
-
-        mock_resp = MagicMock(spec=httpx.Response)
-        mock_resp.raise_for_status = MagicMock()
-
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.post.return_value = mock_resp
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-
-        with patch("bernstein.adapters.codex_cloudflare.httpx.AsyncClient", return_value=mock_client):
-            await adapter._inject_codex_command("sb-inj", "fix bugs", "o3-mini")
-
-        call_kwargs = mock_client.post.call_args
-        url = call_kwargs[0][0]
-        assert "sb-inj/exec" in url
-        payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
-        assert payload["command"] == "codex"
-        assert "fix bugs" in payload["args"]
-        assert "-m" in payload["args"]
-        assert "o3-mini" in payload["args"]
+    async def test_refusal_message_is_actionable(self) -> None:
+        with pytest.raises(RuntimeError) as exc:
+            await _adapter().execute("do stuff", "ws-1")
+        message = str(exc.value)
+        assert "#2783" in message
+        assert "CloudflareBridge" in message

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -137,3 +137,7 @@ capture_output  # noqa
 # TYPE_CHECKING-only import used inside cast("...") string literal,
 # which vulture's AST walker cannot resolve.
 JsonSchemaValidationError  # noqa
+
+# Refusal-stub keyword parameter kept for public API surface stability
+# (codex_cloudflare.execute refuses; callers may still pass the kwarg).
+timeout_minutes  # noqa


### PR DESCRIPTION
## What
Patch-level fixes for the three cloud-surface defects in milestone v3.8.4. No new cloud infrastructure, no paid-tier bindings — broken surfaces now refuse fast with actionable errors, and the genuinely small defects are repaired.

Fixes #2782
Fixes #2783
Fixes #2784

## Per issue
- **#2782 `cloudflare_agents`**: `spawn()` launched `npx wrangler dev` with no worker-trigger path, so every task ran to the timeout watchdog (rc 143) with zero artifacts. It now refuses immediately with a clear error naming working alternatives; the guaranteed-timeout launch path is removed; the registry key still resolves so existing configs keep parsing; docs mark the adapter experimental.
- **#2783 `codex_cloudflare`**: every operation targeted `accounts/{id}/sandbox/...`, a REST route family that does not exist (HTTP 400, errors 7000/7003), so results could never be populated. All four public methods now raise a clear, actionable error; the dead HTTP helpers are removed; config/result dataclasses stay importable; docs drop the fictional lifecycle example.
- **#2784 `bernstein cloud`**: four defects — `cloud init` wrote a wrangler.toml pointing at a never-created entrypoint; `cloud deploy` referenced a template the wheel does not ship; a dead hosted-API hostname surfaced as a raw traceback; the repo template declared paid bindings while docs claimed free tier. `cloud init` now scaffolds a runnable free-tier worker, `cloud deploy` points at `cloud init`, request errors surface as actionable messages, and the template/docs match reality.

## Verification
- TDD per issue (red-run evidence captured before each fix; e.g. the #2783 red run shows `execute()` reaching the network from a unit test before the fix).
- `test_cloudflare_agents_adapter.py` 8 passed; `test_codex_cloudflare.py` 11 passed; shared `test_adapter_consistency.py` 491 passed / 100 skipped.
- Full unit collection sentinel: 37768 tests collected, no errors.