### PR TITLE
fix(security): repair audit-chain key split, lineage baggage sealing, seal-only verify, and live replay

### DIFF
--- a/docs/concepts/artifact-lineage.md
+++ b/docs/concepts/artifact-lineage.md
@@ -51,6 +51,17 @@ The chain walks output → producing prompt → input artefact → upstream
 producer recursively. CLI text output prints the most recent producer
 first; `--limit` caps how many records are shown.
 
+### Coverage and the `SEAL_ONLY` verify status
+
+Per-artifact records are captured at the in-process write boundary
+(`record_artifact_write`). CLI adapters (qwen, claude, ...) spawn a
+subprocess that writes files directly on disk; those writes do not cross
+that boundary, so a CLI-adapter run's spine may contain only the
+journal-head seal and no produced-artifact record. `bernstein lineage
+verify` reports that case as the distinct **`SEAL_ONLY`** status with a
+non-zero exit, rather than a clean `OK`, so a chain with no artifact
+provenance is never mistaken for "provenance confirmed".
+
 ## Programmatic access
 
 ```python

--- a/docs/operations/deterministic-replay.md
+++ b/docs/operations/deterministic-replay.md
@@ -10,13 +10,36 @@ path (selected with `BERNSTEIN_REPLAY_RUN_ID`).
 
 | Item | Behaviour |
 |---|---|
+| Coverage | The internal `call_llm` path only (manager reviews, planning, voting, janitor). CLI-adapter subprocess LLM traffic is **not** recorded. |
 | Replay default | Strict / hermetic. A cache miss aborts the run. |
 | On a miss (strict) | Raises `ReplayMissError`; the live model is never called. |
+| No recording (strict) | Activating replay against a run with no `llm_calls.jsonl` raises `ReplayRecordingMissingError` and aborts **before any agent is spawned**. |
 | Escape hatch | `BERNSTEIN_REPLAY_ALLOW_LIVE_MISS=1` -> miss logs a WARNING and falls through to the live model. |
 | Replay key | `(model, prompt, provider, temperature, max_tokens)`. Any drift is a miss, not a hit. |
 | Repeated calls | A key called N times records N responses and replays them **in recorded order**; the Nth call returns the Nth response. |
 | Over-consumption | Requesting a key more times than recorded is a miss (strict: raises; non-strict: returns `None`). |
 | Coverage line | `hits` / `misses` / `strict_violations`; a fully covered replay reports `misses=0`. |
+
+## What replay covers (and what it does not)
+
+Recording and replay wrap the internal native LLM client `call_llm`, which
+serves Bernstein's own features (manager reviews, planning, voting, janitor).
+That client is gated by `internal_llm_provider`, whose default is `none`.
+
+The coding work itself is done by CLI agent subprocesses (qwen, claude, ...)
+that talk to their provider directly and never pass through `call_llm`, so
+their LLM traffic is **not** recorded on any path. On the default
+`internal_llm_provider: none` + CLI-agent setup, a recording run therefore
+writes no `llm_calls.jsonl`.
+
+Because "cannot reach the network" must not be advertised for a path that
+cannot honour it, a **strict** replay whose target run has no recording
+(`cached_count == 0`) now raises `ReplayRecordingMissingError` and exits
+non-zero at activation, before any agent is spawned or any provider is
+contacted - rather than silently running live. To run such a path anyway with
+live fall-through (non-hermetic), set `BERNSTEIN_REPLAY_ALLOW_LIVE_MISS=1`. To
+get a real recording, configure an internal LLM provider and record with
+`BERNSTEIN_DETERMINISTIC_SEED` set.
 
 ## How to record and replay
 

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -790,7 +790,7 @@ deterministic-subset extractor described in
 
 | Subcommand | Purpose |
 |---|---|
-| `verify RUN_ID` | Verify the run's lineage spine: recompute the full Merkle hash chain and every HMAC tag, print the head hash. `--workdir DIR`. Exit 0 = OK, 1 = no entries, 2 = tamper. |
+| `verify RUN_ID` | Verify the run's lineage spine: recompute the full Merkle hash chain and every HMAC tag, print the head hash. `--workdir DIR`. Exit 0 = OK, 1 = no entries / seal-only (chain intact but no produced-artifact provenance), 2 = tamper. |
 | `replay RUN_ID` | Walk the run's spine entries in append order (artifact, actor, step, model, content hash, entry hash). `--workdir DIR`, `--limit N`. Exit 1 on an empty run. |
 
 Every adapter artifact write is recorded, without per-adapter opt-in, as

--- a/src/bernstein/adapters/base.py
+++ b/src/bernstein/adapters/base.py
@@ -1030,6 +1030,39 @@ class CLIAdapter(ABC):
 #: Set to ``0`` / ``false`` / ``no`` / ``off`` to disable recording.
 LINEAGE_ENABLED_ENV = "BERNSTEIN_LINEAGE_ENABLED"
 
+#: W3C ``baggage`` member-key prefixes that mark a member as
+#: orchestrator-controlled. Only members whose key carries one of these
+#: prefixes survive into a sealed lineage entry; ambient members set by an
+#: unrelated launching process (e.g. ``sentry-*`` from an OTEL/Sentry-
+#: instrumented shell) are stripped before the value enters the entry hash or
+#: HMAC body (issue #2787).
+_LINEAGE_BAGGAGE_ALLOW_PREFIXES = ("bernstein-", "bernstein.")
+
+
+def _filter_lineage_baggage(baggage: str | None) -> str | None:
+    """Keep only orchestrator-controlled members of a W3C ``baggage`` value.
+
+    ``baggage`` is a comma-separated list of ``key=value`` members (each value
+    may carry ``;``-delimited properties). Ambient members inherited from an
+    unrelated launching process must never be sealed into the lineage chain
+    (issue #2787), so every member whose key is not orchestrator-controlled is
+    dropped before the value reaches the entry hash and HMAC body.
+
+    Returns:
+        The filtered baggage string, or ``None`` when no member survives.
+    """
+    if not baggage:
+        return None
+    kept: list[str] = []
+    for raw_member in baggage.split(","):
+        member = raw_member.strip()
+        if not member or "=" not in member:
+            continue
+        key = member.split("=", 1)[0].strip().lower()
+        if key.startswith(_LINEAGE_BAGGAGE_ALLOW_PREFIXES):
+            kept.append(member)
+    return ",".join(kept) if kept else None
+
 
 def _lineage_enabled() -> bool:
     """Return whether the lineage spine write boundary is active.
@@ -1087,9 +1120,23 @@ def record_artifact_write(
         return None
     ts = timestamp if timestamp is not None else time.time_ns()
 
+    # ``.lower()`` on the literal keeps the lowercase W3C spelling (OTEL SDKs
+    # export lowercase ``traceparent``) without tripping the capitalised-env
+    # lint rule.
     traceparent = os.environ.get("TRACEPARENT") or os.environ.get("traceparent".lower())
     tracestate = os.environ.get("TRACESTATE") or os.environ.get("tracestate".lower())
-    baggage = os.environ.get("BAGGAGE") or os.environ.get("baggage".lower())
+    raw_baggage = os.environ.get("BAGGAGE") or os.environ.get("baggage".lower())
+
+    # Only orchestrator-controlled trace context is sealed into the chain
+    # (issue #2787). Keep just the allowlisted baggage members; a surviving
+    # bernstein-owned member is the signal that the ambient W3C context was set
+    # by bernstein rather than inherited from an unrelated launching process,
+    # so traceparent/tracestate are recorded only when such a member is present.
+    # Otherwise all three are dropped before they enter the entry hash/HMAC body.
+    baggage = _filter_lineage_baggage(raw_baggage)
+    if baggage is None:
+        traceparent = None
+        tracestate = None
 
     return LineageSpine(lineage_root, run_id=run_id, hmac_key=hmac_key).record(
         artifact_path=artifact_path,

--- a/src/bernstein/adapters/base.py
+++ b/src/bernstein/adapters/base.py
@@ -1019,10 +1019,15 @@ class CLIAdapter(ABC):
 # Lineage spine write boundary (issue #2292)
 # ---------------------------------------------------------------------------
 #
-# The spine is the single always-on Merkle+HMAC lineage store. Every
-# adapter artifact write routes through ``record_artifact_write`` -- the
-# one write boundary -- so provenance is captured with no per-adapter
-# opt-in. ``LineageSpine`` is bound at module scope so tests can patch it.
+# The spine is the single always-on Merkle+HMAC lineage store.
+# ``record_artifact_write`` is the one write boundary for per-artifact
+# provenance: in-process callers (the journal-head seal, schedule-fire
+# records, the MCP tasks extension, checkpoint-retry) route through it.
+# CLI-adapter runs spawn a subprocess (qwen, claude, ...) that writes files
+# directly on disk without crossing this boundary, so those writes are not
+# captured here; ``LineageSpine.verify`` reports a chain that carries only the
+# journal seal as ``SEAL_ONLY`` rather than a clean pass (issue #2789).
+# ``LineageSpine`` is bound at module scope so tests can patch it.
 
 #: Env var that gates the spine write. ``BERNSTEIN_LINEAGE_ENABLED``
 #: defaults to true and is a *hard* gate: when enabled, a failure to
@@ -1092,8 +1097,10 @@ def record_artifact_write(
 ) -> str | None:
     """Record one artifact write into the run's lineage spine.
 
-    This is the single write boundary every adapter routes through. It
-    appends exactly one Merkle-chained, HMAC-tagged entry per call.
+    The single write boundary for per-artifact provenance, used by the
+    in-process callers listed in the module comment above. It appends exactly
+    one Merkle-chained, HMAC-tagged entry per call. CLI-adapter subprocess
+    file writes do not cross this boundary (issue #2789).
 
     Fail-closed gate: when ``BERNSTEIN_LINEAGE_ENABLED`` is truthy (the
     default), any failure inside the spine propagates -- provenance is a

--- a/src/bernstein/cli/commands/lineage_verify_cmd.py
+++ b/src/bernstein/cli/commands/lineage_verify_cmd.py
@@ -79,7 +79,8 @@ def lineage_verify_cmd(
     a recovery task's embedded failure-receipt hash resolves to a valid,
     Merkle-chained, HMAC-tagged spine entry.
 
-    Exit codes: 0 = OK, 1 = no entries / bad input, 2 = tamper detected.
+    Exit codes: 0 = OK, 1 = no entries / seal-only (no artifact provenance) /
+    bad input, 2 = tamper detected.
     """
     lineage_root = _spine_dir(workdir)
     spine_path = lineage_root / run_id / "spine.jsonl"
@@ -97,6 +98,12 @@ def lineage_verify_cmd(
             raise SystemExit(0)
         if result.status is SpineStatus.NO_ENTRIES:
             console.print("[yellow]NO ENTRIES[/yellow] -- run emitted no lineage.")
+            raise SystemExit(1)
+        if result.status is SpineStatus.SEAL_ONLY:
+            console.print(
+                "[yellow]SEAL ONLY[/yellow] -- chain intact but records only the journal-head "
+                "seal; no produced-artifact provenance was captured for this run."
+            )
             raise SystemExit(1)
         console.print(f"[red]TAMPER DETECTED[/red] -- {len(result.errors)} error(s):")
         for err in result.errors[:50]:

--- a/src/bernstein/core/lineage/spine.py
+++ b/src/bernstein/core/lineage/spine.py
@@ -63,6 +63,13 @@ logger = logging.getLogger(__name__)
 #: change; ``verify`` rejects unknown versions.
 SPINE_ENTRY_VERSION = 1
 
+#: ``step_id`` prefix of the internal journal-head seal written at run
+#: finalization (see ``bernstein.core.replay.journal.seal_journal_into_spine``).
+#: An entry with this prefix records the run's own journal file, not a produced
+#: artifact, so ``verify`` treats a chain built only of these as having no
+#: artifact provenance (issue #2789).
+JOURNAL_SEAL_STEP_PREFIX = "replay-journal-head:"
+
 _SPINE_LOG_NAME = "spine.jsonl"
 _SPINE_HEAD_NAME = "spine.head"
 
@@ -234,6 +241,11 @@ class SpineStatus(Enum):
 
     OK = "ok"
     NO_ENTRIES = "no_entries"
+    #: The chain is intact but contains only the internal journal-head seal:
+    #: no produced-artifact provenance was captured (issue #2789). Distinct
+    #: from ``OK`` so a run that recorded no deliverable cannot pass as
+    #: "provenance confirmed".
+    SEAL_ONLY = "seal_only"
     TAMPERED = "tampered"
 
 
@@ -247,11 +259,12 @@ class SpineVerifyResult:
 
     @property
     def ok(self) -> bool:
-        """True only when the chain is intact and non-empty.
+        """True only when the chain is intact and carries artifact provenance.
 
-        An empty run is *not* ``ok`` - AC5 requires a distinct status
-        so ``lineage verify`` cannot pass trivially against a run that
-        emitted nothing.
+        Neither an empty run (``NO_ENTRIES``) nor a chain that holds only the
+        internal journal-head seal (``SEAL_ONLY``, issue #2789) is ``ok``: a
+        distinct status keeps ``lineage verify`` from passing trivially against
+        a run that emitted nothing or recorded no produced artifact.
         """
         return self.status is SpineStatus.OK
 
@@ -539,9 +552,11 @@ class LineageSpine:
         """Recompute the full hash chain and every HMAC tag.
 
         Returns a :class:`SpineVerifyResult`. ``NO_ENTRIES`` is a
-        distinct status: an empty run must not trivially pass (AC5). Any
-        single-byte mutation of any entry - payload byte or HMAC tag -
-        yields ``TAMPERED`` (AC2).
+        distinct status: an empty run must not trivially pass (AC5). A chain
+        whose only entries are the internal journal-head seal carries no
+        produced-artifact provenance and returns the distinct ``SEAL_ONLY``
+        status rather than ``OK`` (issue #2789). Any single-byte mutation of
+        any entry - payload byte or HMAC tag - yields ``TAMPERED`` (AC2).
         """
         if not self.spine_path.exists():
             return SpineVerifyResult(status=SpineStatus.NO_ENTRIES, count=0)
@@ -552,6 +567,9 @@ class LineageSpine:
         errors: list[str] = []
         prev_hash = _GENESIS_HASH
         count = 0
+        # True until an entry that is *not* the internal journal-head seal is
+        # seen; a chain built only of seals has no artifact provenance (#2789).
+        seal_only = True
         for line_no, line in enumerate(raw.split(b"\n"), start=1):
             count += 1
             try:
@@ -606,14 +624,19 @@ class LineageSpine:
             expected_hmac = _compute_hmac(self._hmac_key, body)
             if not _hmac.compare_digest(str(row["hmac"]), expected_hmac):
                 errors.append(f"line {line_no}: hmac mismatch")
+            if not str(row["step_id"]).startswith(JOURNAL_SEAL_STEP_PREFIX):
+                seal_only = False
             prev_hash = str(row["entry_hash"])
 
         if errors:
             return SpineVerifyResult(status=SpineStatus.TAMPERED, count=count, errors=errors)
+        if seal_only:
+            return SpineVerifyResult(status=SpineStatus.SEAL_ONLY, count=count)
         return SpineVerifyResult(status=SpineStatus.OK, count=count)
 
 
 __all__ = [
+    "JOURNAL_SEAL_STEP_PREFIX",
     "SPINE_ENTRY_VERSION",
     "LineageSpine",
     "SpineEntry",

--- a/src/bernstein/core/orchestration/deterministic.py
+++ b/src/bernstein/core/orchestration/deterministic.py
@@ -109,6 +109,36 @@ class ReplayMissError(RuntimeError):
         )
 
 
+class ReplayRecordingMissingError(RuntimeError):
+    """Raised when strict replay is activated against a run with no recording.
+
+    Extends the :class:`ReplayMissError` contract from the per-call site to the
+    whole-run activation boundary (issue #2790). On the CLI-adapter path
+    (``internal_llm_provider: none`` + a CLI agent) ``call_llm`` never runs, so
+    no ``llm_calls.jsonl`` is written and a replay store loads zero cached
+    responses. Activating replay against such a run would fall through to a live
+    run - real agent subprocesses, real network calls - while the operator
+    believes replay is hermetic. Callers raise this before any agent is spawned
+    so a strict replay refuses loudly instead of degrading to live.
+
+    Attributes:
+        run_dir: The run directory whose recording is absent or empty.
+    """
+
+    def __init__(self, run_dir: Path) -> None:
+        self.run_dir = run_dir
+        super().__init__(
+            f"Deterministic replay requested but no recording exists at "
+            f"{run_dir / 'llm_calls.jsonl'}. Strict/hermetic replay refuses to run "
+            "live. This run recorded no LLM calls - the CLI-adapter path "
+            "(internal_llm_provider 'none' + a CLI agent) does not record, so it "
+            "cannot be replayed hermetically. To run anyway with live fall-through "
+            f"(non-hermetic), set {ALLOW_LIVE_MISS_ENV}=1; to produce a recording, "
+            "re-run with BERNSTEIN_DETERMINISTIC_SEED set and an internal LLM "
+            "provider configured.",
+        )
+
+
 def _prompt_key(
     prompt: str,
     model: str,
@@ -393,11 +423,41 @@ def set_active_store(store: DeterministicStore | None) -> None:
     _active_store = store
 
 
+def open_replay_store(run_dir: Path, *, strict: bool) -> DeterministicStore:
+    """Open a replay store for ``run_dir``, refusing a strict miss.
+
+    A strict/hermetic replay must never fall through to a live model or a live
+    agent spawn (issue #2790). When ``strict`` is set and the run recorded no
+    LLM calls (absent or empty ``llm_calls.jsonl`` -> ``cached_count == 0``),
+    raise :class:`ReplayRecordingMissingError` so the caller aborts before
+    spawning any agent, mirroring the :class:`ReplayMissError` contract enforced
+    per-call inside ``call_llm``. Non-strict replay (live-miss allowed) opens
+    the store even when empty, preserving the record-extend workflow.
+
+    Args:
+        run_dir: The run directory (``{sdd_dir}/runs/{run_id}``) to replay.
+        strict: Whether replay is hermetic (refuse on miss).
+
+    Returns:
+        The replay store when a recording is present, or when non-strict.
+
+    Raises:
+        ReplayRecordingMissingError: Strict replay with no recording.
+    """
+    store = DeterministicStore(run_dir, replay=True, strict=strict)
+    if strict and store.cached_count == 0:
+        raise ReplayRecordingMissingError(run_dir)
+    return store
+
+
 def load_replay_store(run_id: str, sdd_dir: Path) -> DeterministicStore:
     """Create a DeterministicStore in replay mode for the given run.
 
     Replay is hermetic (strict) unless :data:`ALLOW_LIVE_MISS_ENV` is set, in
-    which case misses fall through to the live provider with a warning.
+    which case misses fall through to the live provider with a warning. A strict
+    replay against a run with no recording refuses via
+    :class:`ReplayRecordingMissingError` rather than degrading to a live run
+    (issue #2790).
 
     Args:
         run_id: Run ID whose ``llm_calls.jsonl`` should be replayed.
@@ -405,6 +465,9 @@ def load_replay_store(run_id: str, sdd_dir: Path) -> DeterministicStore:
 
     Returns:
         Store loaded with cached responses from the specified run.
+
+    Raises:
+        ReplayRecordingMissingError: Strict replay with no recording.
     """
     run_dir = sdd_dir / "runs" / run_id
-    return DeterministicStore(run_dir, replay=True, strict=not allow_live_miss())
+    return open_replay_store(run_dir, strict=not allow_live_miss())

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -5382,8 +5382,9 @@ if __name__ == "__main__":
     _sdd_dir = workdir / ".sdd"
     if _replay_run_id:
         from bernstein.core.orchestration.deterministic import (
-            DeterministicStore,
+            ReplayRecordingMissingError,
             allow_live_miss,
+            open_replay_store,
             set_active_store,
         )
 
@@ -5392,11 +5393,19 @@ if __name__ == "__main__":
         # opt-in BERNSTEIN_REPLAY_ALLOW_LIVE_MISS flag restores live
         # fall-through (logged per miss) for record-extend workflows.
         _strict_replay = not allow_live_miss()
-        _det_store = DeterministicStore(
-            _sdd_dir / "runs" / _replay_run_id,
-            replay=True,
-            strict=_strict_replay,
-        )
+        # Refuse a strict replay against a run with no recording before any
+        # agent is spawned or any network call is made (issue #2790). The
+        # CLI-adapter path never records, so cached_count == 0 there; without
+        # this guard replay silently degrades to a full live run.
+        try:
+            _det_store = open_replay_store(
+                _sdd_dir / "runs" / _replay_run_id,
+                strict=_strict_replay,
+            )
+        except ReplayRecordingMissingError as exc:
+            logger.error("FATAL: %s", exc)
+            print(f"[FATAL] {exc}", file=sys.stderr, flush=True)
+            sys.exit(1)
         set_active_store(_det_store)
         logger.info(
             "Deterministic replay mode (%s): loaded %d cached LLM responses from run %s",

--- a/src/bernstein/core/replay/journal.py
+++ b/src/bernstein/core/replay/journal.py
@@ -577,6 +577,7 @@ def seal_journal_into_spine(
         journal is empty.
     """
     from bernstein.adapters.base import record_artifact_write
+    from bernstein.core.lineage.spine import JOURNAL_SEAL_STEP_PREFIX
 
     head = journal.head()
     if not head:
@@ -590,7 +591,7 @@ def seal_journal_into_spine(
         artifact_path=artifact_path,
         content=content,
         actor=actor,
-        step_id=f"replay-journal-head:{head}",
+        step_id=f"{JOURNAL_SEAL_STEP_PREFIX}{head}",
         model=model,
         lineage_root=lineage_root,
         run_id=journal.run_id,

--- a/src/bernstein/core/security/audit.py
+++ b/src/bernstein/core/security/audit.py
@@ -30,7 +30,15 @@ import sys
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+if sys.platform == "win32":
+    fcntl = None  # type: ignore[assignment]
+else:
+    import fcntl  # type: ignore[no-redef]
 
 _JSONL_GLOB = "*.jsonl"
 
@@ -319,6 +327,47 @@ def _compute_hmac(key: bytes, prev_hmac: str, entry: dict[str, Any]) -> str:
     """Compute HMAC-SHA256 over the previous HMAC concatenated with the canonical JSON payload."""
     payload = prev_hmac + json.dumps(entry, sort_keys=True)
     return _hmac.new(key, payload.encode(), hashlib.sha256).hexdigest()
+
+
+@contextlib.contextmanager
+def _chain_append_lock(audit_dir: Path) -> Iterator[None]:
+    """Serialise daily-log appends across processes via ``flock(LOCK_EX)``.
+
+    The task server, the spawner, the orchestrator, and CLI commands are
+    separate processes that append to the same ``.sdd/audit/<day>.jsonl``.
+    In-process ``threading.Lock``s only serialise threads within one process;
+    without an OS-level lock two processes recover the same chain tail in
+    ``AuditLog.__init__`` and each append a record embedding the same stale
+    ``prev_hmac``, forking the HMAC chain and breaking ``verify()`` for the
+    whole daily log (issue #2791).
+
+    A single stable lock file per audit dir serialises across day rollovers
+    (a writer that has rolled to the next day still contends with one still on
+    the previous day). Falls back to a no-op on platforms without ``fcntl``
+    (Windows); the in-process locks callers may hold remain the only ordering
+    there, matching how the lineage spine degrades.
+    """
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    if fcntl is None:  # pragma: no cover - Windows path
+        yield
+        return
+    lock_path = audit_dir / ".chain.lock"
+    fd = os.open(str(lock_path), os.O_WRONLY | os.O_CREAT, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        with contextlib.suppress(OSError):
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
+def _path_size(path: Path) -> int:
+    """Return ``path`` size in bytes, or ``-1`` when it does not exist."""
+    try:
+        return path.stat().st_size
+    except OSError:
+        return -1
 
 
 def _split_jsonl_bytes(raw_bytes: bytes) -> list[bytes]:
@@ -749,6 +798,12 @@ class AuditLog:
         else:
             self._key = load_or_create_audit_key(key_path)
         self._prev_hmac = self._recover_chain_tail()
+        # Tracks the day file and its byte length after this instance's last
+        # append, so ``log`` can skip re-reading the tail from disk when no
+        # other writer has touched the file since (issue #2791). ``None`` /
+        # ``-1`` force a re-sync on the first append.
+        self._synced_path: Path | None = None
+        self._synced_size = -1
 
     # -- chain recovery -----------------------------------------------------
 
@@ -815,43 +870,56 @@ class AuditLog:
         Returns:
             The newly created AuditEvent with computed HMAC.
         """
-        ts = datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-        entry_dict: dict[str, Any] = {
-            "timestamp": ts,
-            "event_type": event_type,
-            "actor": actor,
-            "resource_type": resource_type,
-            "resource_id": resource_id,
-            "details": details or {},
-            "prev_hmac": self._prev_hmac,
-        }
-        computed_hmac = _compute_hmac(self._key, self._prev_hmac, entry_dict)
+        with _chain_append_lock(self._audit_dir):
+            ts = datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+            day = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+            log_path = self._audit_dir / f"{day}.jsonl"
 
-        event = AuditEvent(
-            timestamp=ts,
-            event_type=event_type,
-            actor=actor,
-            resource_type=resource_type,
-            resource_id=resource_id,
-            details=details or {},
-            prev_hmac=self._prev_hmac,
-            hmac=computed_hmac,
-        )
+            # Re-sync the chain tail from disk under the cross-process lock so a
+            # concurrent writer's appended head is chained onto rather than a
+            # stale tail captured at construction (issue #2791). Fast path: when
+            # the current day file is byte-length-identical to what our own last
+            # append left it at, no other process has appended and the cached
+            # head still stands, so the re-read (a full-file scan) is skipped.
+            if log_path != self._synced_path or _path_size(log_path) != self._synced_size:
+                self._prev_hmac = self._recover_chain_tail()
 
-        entry_dict["hmac"] = computed_hmac
-        day = datetime.now(tz=UTC).strftime("%Y-%m-%d")
-        log_path = self._audit_dir / f"{day}.jsonl"
+            entry_dict: dict[str, Any] = {
+                "timestamp": ts,
+                "event_type": event_type,
+                "actor": actor,
+                "resource_type": resource_type,
+                "resource_id": resource_id,
+                "details": details or {},
+                "prev_hmac": self._prev_hmac,
+            }
+            computed_hmac = _compute_hmac(self._key, self._prev_hmac, entry_dict)
 
-        # ``newline=""`` disables Python's universal-newline translation so
-        # the literal ``\n`` we append survives byte-for-byte on Windows
-        # (where text mode would otherwise rewrite it to ``\r\n``). The
-        # verifier reads bytes and re-canonicalises against ``\n``-only
-        # frames; without this the ``\r`` stays inside each split line and
-        # the byte-equality tamper check trips.
-        with log_path.open("a", encoding="utf-8", newline="") as fh:
-            fh.write(json.dumps(entry_dict, sort_keys=True) + "\n")
+            event = AuditEvent(
+                timestamp=ts,
+                event_type=event_type,
+                actor=actor,
+                resource_type=resource_type,
+                resource_id=resource_id,
+                details=details or {},
+                prev_hmac=self._prev_hmac,
+                hmac=computed_hmac,
+            )
 
-        self._prev_hmac = computed_hmac
+            entry_dict["hmac"] = computed_hmac
+
+            # ``newline=""`` disables Python's universal-newline translation so
+            # the literal ``\n`` we append survives byte-for-byte on Windows
+            # (where text mode would otherwise rewrite it to ``\r\n``). The
+            # verifier reads bytes and re-canonicalises against ``\n``-only
+            # frames; without this the ``\r`` stays inside each split line and
+            # the byte-equality tamper check trips.
+            with log_path.open("a", encoding="utf-8", newline="") as fh:
+                fh.write(json.dumps(entry_dict, sort_keys=True) + "\n")
+
+            self._prev_hmac = computed_hmac
+            self._synced_path = log_path
+            self._synced_size = _path_size(log_path)
         return event
 
     # -- verify -------------------------------------------------------------

--- a/src/bernstein/core/server/dashboard_tokens.py
+++ b/src/bernstein/core/server/dashboard_tokens.py
@@ -46,15 +46,15 @@ import hmac as _hmac
 import ipaddress
 import json
 import logging
-import os
 import secrets
 from dataclasses import dataclass
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 from bernstein.core.security.governance import RoleBindings, decide_access
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from bernstein.core.security.audit_chain import AuditChainStore
     from bernstein.core.security.governance import GovernanceDecision
 
@@ -102,20 +102,27 @@ def _canonical_bytes(payload: dict[str, Any]) -> bytes:
 def resolve_dashboard_hmac_key(sdd_dir: Path) -> bytes:
     """Resolve the HMAC key the dashboard auth surface signs with.
 
-    Mirrors the task server's key resolution exactly (env override first,
-    then the workspace key file), so the CLI, the serve entry points, and
-    the server middleware all sign and verify against the same key.
+    Defers to the single canonical resolver :func:`load_or_create_audit_key`
+    so every audit-chain writer on one workspace signs with one key: the task
+    server / dashboard, the spawner, and ``bernstein audit verify`` all resolve
+    the same file (``$BERNSTEIN_AUDIT_KEY_PATH`` when set, else the XDG state
+    key). Previously this returned the workspace ``.sdd/keys/audit.key`` while
+    the verifier and spawner used the XDG key, so entries written by the task
+    server into ``.sdd/audit/<day>.jsonl`` failed verification by construction
+    (issue #2791).
+
+    ``sdd_dir`` is retained for signature compatibility; the resolved key no
+    longer lives under it.
 
     Args:
-        sdd_dir: The workspace ``.sdd`` directory.
+        sdd_dir: The workspace ``.sdd`` directory (unused; kept for callers).
 
     Returns:
         The raw key bytes.
     """
     from bernstein.core.security.audit import load_or_create_audit_key
 
-    override = os.environ.get("BERNSTEIN_AUDIT_KEY_PATH", "")
-    return load_or_create_audit_key(Path(override) if override else sdd_dir / "keys" / "audit.key")
+    return load_or_create_audit_key()
 
 
 def dashboard_role_bindings(hmac_key: bytes) -> RoleBindings:

--- a/tests/unit/test_audit_chain_crossprocess.py
+++ b/tests/unit/test_audit_chain_crossprocess.py
@@ -1,0 +1,99 @@
+"""Cross-process audit-chain integrity (issue #2791).
+
+Two independent defects broke ``bernstein audit verify`` on a log written
+entirely by the product on one machine:
+
+1. The task server / dashboard signed audit-chain entries with a different
+   HMAC key than the verifier and spawner (workspace key vs XDG key).
+2. Appends to the shared daily log had no cross-process lock, so two
+   processes recovered the same chain tail and wrote sibling records.
+
+These tests pin both fixes: the two key resolvers agree when no key-path
+override is set, and N concurrent processes appending to one daily log
+produce a chain that ``verify()`` accepts.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.security.audit import (
+    AuditLog,
+    load_or_create_audit_key,
+)
+from bernstein.core.server.dashboard_tokens import resolve_dashboard_hmac_key
+
+_KEY = b"cross-process-test-key-0123456789"
+
+
+@pytest.mark.audit_key_real
+def test_key_resolvers_agree_without_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """resolve_dashboard_hmac_key and load_or_create_audit_key agree (#2791).
+
+    With no ``BERNSTEIN_AUDIT_KEY_PATH`` override, the dashboard/task-server
+    resolver and the verifier/spawner resolver must return the same key from
+    the same file. Before the fix they diverged: the dashboard resolver used
+    the workspace ``.sdd/keys/audit.key`` while the verifier used the XDG
+    state key.
+    """
+    monkeypatch.delenv("BERNSTEIN_AUDIT_KEY_PATH", raising=False)
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "xdg"))
+
+    sdd_dir = tmp_path / ".sdd"
+    sdd_dir.mkdir(parents=True)
+
+    dashboard_key = resolve_dashboard_hmac_key(sdd_dir)
+    verifier_key = load_or_create_audit_key()
+
+    assert dashboard_key == verifier_key
+    # The dashboard resolver must not mint a separate workspace key file.
+    assert not (sdd_dir / "keys" / "audit.key").exists()
+
+
+def _append_worker(audit_dir_str: str, key: bytes, count: int, barrier: object) -> None:
+    """Append ``count`` events to the shared daily log from a child process."""
+    from bernstein.core.security.audit import AuditLog
+
+    log = AuditLog(Path(audit_dir_str), key=key)
+    barrier.wait()  # type: ignore[attr-defined]
+    for i in range(count):
+        log.log("concurrent.event", "worker", "res", f"id-{i}")
+
+
+def test_concurrent_process_appends_verify(tmp_path: Path) -> None:
+    """N processes appending M events each yield a chain verify() accepts (#2791).
+
+    Without a cross-process lock, every worker recovers the same tail at
+    construction and appends a sibling record, forking the HMAC chain.
+    """
+    audit_dir = tmp_path / "audit"
+    audit_dir.mkdir()
+
+    n_procs = 4
+    m_events = 20
+
+    ctx = mp.get_context("fork")
+    barrier = ctx.Barrier(n_procs)
+    procs = [
+        ctx.Process(target=_append_worker, args=(str(audit_dir), _KEY, m_events, barrier))
+        for _ in range(n_procs)
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=30)
+        assert p.exitcode == 0
+
+    valid, errors = AuditLog(audit_dir, key=_KEY).verify()
+    assert valid, f"chain forked under concurrent appends: {errors[:5]}"
+
+    total_lines = sum(
+        len([ln for ln in path.read_bytes().split(b"\n") if ln])
+        for path in audit_dir.glob("*.jsonl")
+    )
+    assert total_lines == n_procs * m_events

--- a/tests/unit/test_audit_chain_crossprocess.py
+++ b/tests/unit/test_audit_chain_crossprocess.py
@@ -30,9 +30,7 @@ _KEY = b"cross-process-test-key-0123456789"
 
 
 @pytest.mark.audit_key_real
-def test_key_resolvers_agree_without_override(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_key_resolvers_agree_without_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """resolve_dashboard_hmac_key and load_or_create_audit_key agree (#2791).
 
     With no ``BERNSTEIN_AUDIT_KEY_PATH`` override, the dashboard/task-server
@@ -79,10 +77,7 @@ def test_concurrent_process_appends_verify(tmp_path: Path) -> None:
 
     ctx = mp.get_context("fork")
     barrier = ctx.Barrier(n_procs)
-    procs = [
-        ctx.Process(target=_append_worker, args=(str(audit_dir), _KEY, m_events, barrier))
-        for _ in range(n_procs)
-    ]
+    procs = [ctx.Process(target=_append_worker, args=(str(audit_dir), _KEY, m_events, barrier)) for _ in range(n_procs)]
     for p in procs:
         p.start()
     for p in procs:
@@ -92,8 +87,5 @@ def test_concurrent_process_appends_verify(tmp_path: Path) -> None:
     valid, errors = AuditLog(audit_dir, key=_KEY).verify()
     assert valid, f"chain forked under concurrent appends: {errors[:5]}"
 
-    total_lines = sum(
-        len([ln for ln in path.read_bytes().split(b"\n") if ln])
-        for path in audit_dir.glob("*.jsonl")
-    )
+    total_lines = sum(len([ln for ln in path.read_bytes().split(b"\n") if ln]) for path in audit_dir.glob("*.jsonl"))
     assert total_lines == n_procs * m_events

--- a/tests/unit/test_journal_spine_seal.py
+++ b/tests/unit/test_journal_spine_seal.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from bernstein.core.lineage.spine import LineageSpine
+from bernstein.core.lineage.spine import LineageSpine, SpineStatus
 from bernstein.core.replay.journal import EventJournal, seal_journal_into_spine
 
 
@@ -40,7 +40,12 @@ def test_journal_head_appears_in_spine_root(tmp_path: Path) -> None:
     # pin the run's replay identity against its provenance chain.
     assert head in seal.step_id
     assert seal.artifact_path.endswith("journal.jsonl")
-    assert spine.verify().ok
+    # The chain is cryptographically intact, but it records only the journal
+    # seal and no produced-artifact provenance, so verify reports SEAL_ONLY
+    # rather than a clean OK (issue #2789).
+    result = spine.verify()
+    assert result.status is SpineStatus.SEAL_ONLY
+    assert not result.ok
 
 
 def test_seal_is_noop_when_lineage_disabled(monkeypatch, tmp_path: Path) -> None:

--- a/tests/unit/test_lineage_baggage_filter.py
+++ b/tests/unit/test_lineage_baggage_filter.py
@@ -58,9 +58,7 @@ def test_foreign_baggage_is_not_sealed(tmp_path: Path, monkeypatch: pytest.Monke
     assert spine.verify().status is SpineStatus.OK
 
 
-def test_bernstein_baggage_survives_and_foreign_stripped(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_bernstein_baggage_survives_and_foreign_stripped(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Orchestrator-controlled members are kept; foreign members are dropped."""
     monkeypatch.setenv("BERNSTEIN_LINEAGE_ENABLED", "1")
     monkeypatch.setenv("BAGGAGE", f"bernstein-run=r1,{_SENTRY_BAGGAGE}")
@@ -80,9 +78,7 @@ def test_bernstein_baggage_survives_and_foreign_stripped(
     assert spine.verify().status is SpineStatus.OK
 
 
-def test_ambient_traceparent_dropped_without_bernstein_baggage(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_ambient_traceparent_dropped_without_bernstein_baggage(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """traceparent/tracestate are dropped when no bernstein baggage is present."""
     monkeypatch.setenv("BERNSTEIN_LINEAGE_ENABLED", "1")
     monkeypatch.delenv("BAGGAGE", raising=False)

--- a/tests/unit/test_lineage_baggage_filter.py
+++ b/tests/unit/test_lineage_baggage_filter.py
@@ -1,0 +1,98 @@
+"""Ambient host trace context must not be sealed into the lineage chain (#2787).
+
+``record_artifact_write`` reads the W3C ``BAGGAGE`` / ``TRACEPARENT`` /
+``TRACESTATE`` environment variables and folds them into the HMAC-covered
+lineage entry. Ambient values inherited from an unrelated launching process
+(e.g. a Sentry/OTEL-instrumented shell) must be stripped before they enter the
+entry hash or HMAC body; only orchestrator-controlled baggage members survive.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.adapters.base import record_artifact_write
+from bernstein.core.lineage.spine import LineageSpine, SpineStatus
+
+_KEY = b"k" * 32
+_SENTRY_BAGGAGE = (
+    "sentry-environment=production,sentry-release=host-app@1.2.3,"
+    "sentry-public_key=deadbeef,sentry-trace_id=abc123,sentry-org_id=42"
+)
+
+
+def _record(root: Path, run_id: str) -> LineageSpine:
+    record_artifact_write(
+        artifact_path="src/out.py",
+        content=b"print('hi')\n",
+        actor="agent:test",
+        step_id="tc-1",
+        model="claude",
+        lineage_root=root,
+        run_id=run_id,
+        hmac_key=_KEY,
+        timestamp=1,
+    )
+    return LineageSpine(root, run_id=run_id, hmac_key=_KEY)
+
+
+def test_foreign_baggage_is_not_sealed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ambient sentry-* baggage never reaches the spine entry or its pre-image."""
+    monkeypatch.setenv("BERNSTEIN_LINEAGE_ENABLED", "1")
+    monkeypatch.setenv("BAGGAGE", _SENTRY_BAGGAGE)
+    monkeypatch.delenv("TRACEPARENT", raising=False)
+    monkeypatch.delenv("TRACESTATE", raising=False)
+
+    root = tmp_path / "lineage"
+    spine = _record(root, "run-foreign")
+    entries = list(spine.iter_entries())
+    assert len(entries) == 1
+    assert entries[0].baggage is None
+
+    # The foreign identifiers must be absent from the raw persisted bytes,
+    # which are exactly the HMAC/hash pre-image material.
+    raw = (root / "run-foreign" / "spine.jsonl").read_bytes()
+    assert b"sentry-" not in raw
+    assert spine.verify().status is SpineStatus.OK
+
+
+def test_bernstein_baggage_survives_and_foreign_stripped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Orchestrator-controlled members are kept; foreign members are dropped."""
+    monkeypatch.setenv("BERNSTEIN_LINEAGE_ENABLED", "1")
+    monkeypatch.setenv("BAGGAGE", f"bernstein-run=r1,{_SENTRY_BAGGAGE}")
+    monkeypatch.setenv("TRACEPARENT", "00-abc-123-01")
+    monkeypatch.setenv("TRACESTATE", "vendor=1")
+
+    root = tmp_path / "lineage"
+    spine = _record(root, "run-mixed")
+    entry = next(iter(spine.iter_entries()))
+    assert entry.baggage == "bernstein-run=r1"
+    # A bernstein-owned baggage member proves the trace context is ours, so
+    # traceparent/tracestate are recorded.
+    assert entry.traceparent == "00-abc-123-01"
+    assert entry.tracestate == "vendor=1"
+    raw = (root / "run-mixed" / "spine.jsonl").read_bytes()
+    assert b"sentry-" not in raw
+    assert spine.verify().status is SpineStatus.OK
+
+
+def test_ambient_traceparent_dropped_without_bernstein_baggage(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """traceparent/tracestate are dropped when no bernstein baggage is present."""
+    monkeypatch.setenv("BERNSTEIN_LINEAGE_ENABLED", "1")
+    monkeypatch.delenv("BAGGAGE", raising=False)
+    monkeypatch.setenv("TRACEPARENT", "00-foreignhost-999-01")
+    monkeypatch.setenv("TRACESTATE", "sentry=1")
+
+    root = tmp_path / "lineage"
+    spine = _record(root, "run-ambient-tp")
+    entry = next(iter(spine.iter_entries()))
+    assert entry.traceparent is None
+    assert entry.tracestate is None
+    raw = (root / "run-ambient-tp" / "spine.jsonl").read_bytes()
+    assert b"foreignhost" not in raw

--- a/tests/unit/test_lineage_seal_only_verify.py
+++ b/tests/unit/test_lineage_seal_only_verify.py
@@ -23,9 +23,7 @@ def _seal_only_spine(tmp_path: Path) -> LineageSpine:
     journal = EventJournal(run_id="run-seal-only", sdd_dir=sdd_dir)
     journal.record("run_started", run_id="run-seal-only")
     journal.record("run_completed", run_id="run-seal-only")
-    seal_journal_into_spine(
-        journal, lineage_root=lineage_root, hmac_key=_KEY, actor="orchestrator"
-    )
+    seal_journal_into_spine(journal, lineage_root=lineage_root, hmac_key=_KEY, actor="orchestrator")
     return LineageSpine(lineage_root, run_id="run-seal-only", hmac_key=_KEY)
 
 

--- a/tests/unit/test_lineage_seal_only_verify.py
+++ b/tests/unit/test_lineage_seal_only_verify.py
@@ -1,0 +1,58 @@
+"""verify() must not report a clean pass over a seal-only chain (#2789).
+
+On the CLI-adapter path the only spine write is the journal-head seal, whose
+recorded artifact is the run's own journal file, not any produced deliverable.
+A chain that contains only that internal self-reference has no artifact
+provenance, so ``verify`` must return a distinct non-OK status rather than the
+``OK -- chain intact`` an auditor reads as "provenance confirmed".
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from bernstein.core.lineage.spine import LineageSpine, SpineStatus
+from bernstein.core.replay.journal import EventJournal, seal_journal_into_spine
+
+_KEY = b"k" * 32
+
+
+def _seal_only_spine(tmp_path: Path) -> LineageSpine:
+    sdd_dir = tmp_path / ".sdd"
+    lineage_root = sdd_dir / "lineage"
+    journal = EventJournal(run_id="run-seal-only", sdd_dir=sdd_dir)
+    journal.record("run_started", run_id="run-seal-only")
+    journal.record("run_completed", run_id="run-seal-only")
+    seal_journal_into_spine(
+        journal, lineage_root=lineage_root, hmac_key=_KEY, actor="orchestrator"
+    )
+    return LineageSpine(lineage_root, run_id="run-seal-only", hmac_key=_KEY)
+
+
+def test_seal_only_chain_is_not_ok(tmp_path: Path, monkeypatch) -> None:
+    """A chain whose only entry is the journal seal reports SEAL_ONLY, not OK."""
+    monkeypatch.setenv("BERNSTEIN_LINEAGE_ENABLED", "1")
+    spine = _seal_only_spine(tmp_path)
+    result = spine.verify()
+    assert result.status is SpineStatus.SEAL_ONLY
+    assert not result.ok
+    # The chain is still cryptographically intact - this is not tampering.
+    assert result.count == 1
+
+
+def test_chain_with_artifact_entry_is_ok(tmp_path: Path, monkeypatch) -> None:
+    """Adding a real produced-artifact entry restores an OK verify."""
+    monkeypatch.setenv("BERNSTEIN_LINEAGE_ENABLED", "1")
+    spine = _seal_only_spine(tmp_path)
+    # A genuine artifact-provenance entry (not a journal seal).
+    spine.record(
+        artifact_path="src/produced.py",
+        content=b"print('hi')\n",
+        actor="agent:test",
+        step_id="tc-1",
+        model="claude",
+        timestamp=1,
+    )
+    result = spine.verify()
+    assert result.status is SpineStatus.OK
+    assert result.ok

--- a/tests/unit/test_mcp_tasks.py
+++ b/tests/unit/test_mcp_tasks.py
@@ -237,10 +237,13 @@ async def test_bernstein_run_with_client_supports_tasks(mock_client: AsyncMock) 
 
 @pytest.mark.asyncio
 async def test_trace_context_propagation_to_lineage(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Only orchestrator-controlled trace context is sealed (issue #2787): a
+    # bernstein-prefixed baggage member survives and marks the context as ours,
+    # so traceparent/tracestate are recorded alongside it.
     monkeypatch.setenv("BERNSTEIN_LINEAGE_ENABLED", "1")
     monkeypatch.setenv("TRACEPARENT", "00-abc-123-01")
     monkeypatch.setenv("TRACESTATE", "state-abc")
-    monkeypatch.setenv("BAGGAGE", "bag-abc")
+    monkeypatch.setenv("BAGGAGE", "bernstein-task=t1")
 
     root = tmp_path / "lineage"
     h = record_artifact_write(
@@ -261,7 +264,7 @@ async def test_trace_context_propagation_to_lineage(tmp_path: Path, monkeypatch:
     assert len(entries) == 1
     assert entries[0].traceparent == "00-abc-123-01"
     assert entries[0].tracestate == "state-abc"
-    assert entries[0].baggage == "bag-abc"
+    assert entries[0].baggage == "bernstein-task=t1"
 
     result = spine.verify()
     assert result.status is SpineStatus.OK

--- a/tests/unit/test_replay_refuse_on_miss.py
+++ b/tests/unit/test_replay_refuse_on_miss.py
@@ -1,0 +1,54 @@
+"""Strict replay must refuse when the target run has no recording (#2790).
+
+On the CLI-adapter path (``internal_llm_provider: none`` + a CLI agent) the
+internal ``call_llm`` never runs, so no ``llm_calls.jsonl`` is written.
+Activating replay against such a run must abort loudly before any agent is
+spawned or any network call is made, instead of silently degrading to a live
+run. ``open_replay_store`` is the activation-point guard that mirrors the
+``ReplayMissError`` contract for the whole-run boundary.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.orchestration.deterministic import (
+    ReplayRecordingMissingError,
+    open_replay_store,
+)
+
+
+def test_strict_replay_refuses_when_recording_absent(tmp_path: Path) -> None:
+    """Strict replay against a run with no llm_calls.jsonl raises, naming the file."""
+    run_dir = tmp_path / "runs" / "run-no-recording"
+    run_dir.mkdir(parents=True)
+
+    with pytest.raises(ReplayRecordingMissingError) as excinfo:
+        open_replay_store(run_dir, strict=True)
+
+    assert str(run_dir / "llm_calls.jsonl") in str(excinfo.value)
+
+
+def test_non_strict_replay_allows_missing_recording(tmp_path: Path) -> None:
+    """With live-miss allowed (non-strict), a missing recording does not abort."""
+    run_dir = tmp_path / "runs" / "run-no-recording"
+    run_dir.mkdir(parents=True)
+
+    store = open_replay_store(run_dir, strict=False)
+    assert store.cached_count == 0
+
+
+def test_strict_replay_accepts_present_recording(tmp_path: Path) -> None:
+    """A run with a non-empty recording opens normally under strict replay."""
+    run_dir = tmp_path / "runs" / "run-with-recording"
+    run_dir.mkdir(parents=True)
+    (run_dir / "llm_calls.jsonl").write_text(
+        json.dumps({"key": "k1", "response": "hello"}) + "\n",
+        encoding="utf-8",
+    )
+
+    store = open_replay_store(run_dir, strict=True)
+    assert store.cached_count == 1


### PR DESCRIPTION
## What
Four verifiability-core fixes for milestone v3.8.4, one commit per issue. Existing chains keep verifying; two existing tests were updated to the corrected behavior.

Fixes #2791
Fixes #2787
Fixes #2789
Fixes #2790

## Per issue
- **#2791 audit HMAC key split + append race**: the task server resolved the chain HMAC key to the workspace `.sdd/keys/audit.key` while the spawner and `bernstein audit verify` used the XDG state key — both wrote the same daily log, so verification failed on mixed segments. The dashboard resolver now delegates to the single canonical `load_or_create_audit_key()` (env override still wins), and `AuditLog.log()` holds a per-audit-dir `fcntl` lock across tail-recovery + append, with a stat-based fast path that re-reads the on-disk tail only when another writer appended.
- **#2787 ambient BAGGAGE sealed into the chain**: `record_artifact_write` folded raw `BAGGAGE`/`TRACEPARENT`/`TRACESTATE` env vars into the entry hash, so foreign Sentry/OTEL context from the launching shell changed lineage hashes. Baggage members are now filtered to orchestrator-owned keys before hashing, and trace context is recorded only when an orchestrator-owned member marks it as ours.
- **#2789 seal-only spine passes verify**: on CLI-adapter runs the only spine entry is the journal seal, yet `verify()` returned OK — an intact chain with zero artifact provenance. New `SpineStatus.SEAL_ONLY`: `ok` stays false, `bernstein lineage verify` prints a distinct message and exits non-zero; chains with real artifact entries still verify OK.
- **#2790 replay silently running live**: the replay-activation handler built the store and proceeded even with zero recordings, so `BERNSTEIN_REPLAY_RUN_ID` on a CLI-adapter run executed live without a recording. New `open_replay_store(strict=...)` raises `ReplayRecordingMissingError` at the whole-run boundary; the orchestrator exits fatally before spawning any agent.

## Verification
- TDD per issue with red-run evidence captured before each fix.
- Targeted batches green: key/lock tests, lineage filter tests (3), spine/lineage batch (43), replay batch (52 incl. deterministic-store and replay suites).
- Import sentinel: 37796 tests collected, no errors. ruff clean on all touched files. Docs updated in the same commits.