### PR TITLE
fix(cluster): one credential clears both worker-join auth layers, and tokenless joins fail fast

### DIFF
--- a/docs/cluster/deployment-patterns.md
+++ b/docs/cluster/deployment-patterns.md
@@ -20,6 +20,40 @@ Pick one based on where the workers live relative to the central node.
 
 ---
 
+## Authentication
+
+Cluster mode enables bearer auth on the central server's API, so a worker
+must present a token to register, heartbeat, and pull tasks. **One token
+covers all three** - the same value the central node accepts for its API also
+authenticates node join.
+
+Set the token on the central node with either of:
+
+- `BERNSTEIN_AUTH_TOKEN` - the API bearer token, or
+- `BERNSTEIN_CLUSTER_AUTH_SECRET` - a dedicated cluster secret.
+
+Pass the **same value** to each worker with `--token` (or export
+`BERNSTEIN_AUTH_TOKEN` in the worker's environment). Copy it to the worker
+host out of band (scp, your secrets manager, etc.).
+
+If you start the central node with `bernstein run --remote` and set neither,
+a token is auto-generated and written, mode `0600`, to
+`.sdd/runtime/auth.token`; read it from there and distribute it. The startup
+log names that path but never prints the value.
+
+Read-only status checks need the token too:
+
+```bash
+curl -H "Authorization: Bearer $BERNSTEIN_AUTH_TOKEN" \
+    http://central:8052/cluster/status
+```
+
+A worker that omits the token, or presents one the central node does not
+accept, now fails fast with an actionable error instead of retrying the same
+rejected request every 5 s.
+
+---
+
 ## Pattern 1 - Same-VPC mTLS
 
 Both the central server and the workers run inside one trusted network
@@ -36,8 +70,10 @@ bernstein cluster bootstrap-ca \
     --out-dir ~/.bernstein/cluster \
     --server-san central.internal
 
-# Bind to all interfaces so workers can reach it.
-BERNSTEIN_BIND_HOST=0.0.0.0 bernstein start
+# Set the shared worker token (any strong random value) and enable cluster
+# mode, then bind to all interfaces so workers can reach it.
+export BERNSTEIN_AUTH_TOKEN="$(openssl rand -hex 32)"
+BERNSTEIN_BIND_HOST=0.0.0.0 BERNSTEIN_CLUSTER_ENABLED=1 bernstein start
 ```
 
 > **Containers:** `bernstein start` detaches the task server and returns, so
@@ -60,9 +96,11 @@ server key into `ClusterConfig.tls` as shown in
 ```bash
 # On each worker
 # (ca.crt + node.crt + node.key copied out-of-band into ~/.bernstein/cluster/)
+# --token is the same value set as BERNSTEIN_AUTH_TOKEN on the central node.
 bernstein worker \
     --server https://central.internal:8052 \
-    --roles backend
+    --roles backend \
+    --token "$BERNSTEIN_AUTH_TOKEN"
 ```
 
 The worker's CA, node cert, and node key are wired through
@@ -140,10 +178,12 @@ public hostname like any HTTPS server.
 
 ```bash
 # On the worker (laptop, separate cloud, build runner)
+# --token is the value the central node sets as BERNSTEIN_CLUSTER_AUTH_SECRET,
+# copied to this host out of band.
 bernstein worker \
     --server https://central.bernstein.example.com \
     --roles backend \
-    --token "$BERNSTEIN_AUTH_TOKEN"
+    --token "$BERNSTEIN_CLUSTER_AUTH_SECRET"
 ```
 
 If you put Cloudflare Access in front of the hostname, set:
@@ -175,10 +215,16 @@ End-to-end:
    for their service token, run `bernstein worker --server
    https://central.bernstein.example.com --roles backend`. They never
    touch your VPN.
-4. **Verify.** On the central node, the `GET /cluster/status` snapshot lists the
-   contractor's worker as `ONLINE`. Revoking the service token in
-   Cloudflare immediately blocks them at the edge - Bernstein doesn't
-   need to know.
+4. **Verify.** The cluster status snapshot lists the contractor's worker as
+   `ONLINE`. The endpoint requires the bearer token:
+
+   ```bash
+   curl -H "Authorization: Bearer $BERNSTEIN_CLUSTER_AUTH_SECRET" \
+       https://central.bernstein.example.com/cluster/status
+   ```
+
+   Revoking the service token in Cloudflare immediately blocks them at the
+   edge - Bernstein doesn't need to know.
 
 For a regulated workload, layer mTLS underneath the tunnel so the
 encryption is end-to-end and the application can verify the worker's
@@ -252,10 +298,12 @@ tailscale status | grep bernstein-central
 # On the worker
 sudo tailscale up --authkey="$TS_AUTHKEY_WORKER" --advertise-tags=tag:bernstein-worker
 
+# --token is the value the central node sets as BERNSTEIN_CLUSTER_AUTH_SECRET,
+# copied to this host out of band.
 bernstein worker \
     --server http://bernstein-central.tailXXXXX.ts.net:8052 \
     --roles backend \
-    --token "$BERNSTEIN_AUTH_TOKEN"
+    --token "$BERNSTEIN_CLUSTER_AUTH_SECRET"
 ```
 
 The traffic stays inside the tailnet; the URL is `http://` because the

--- a/src/bernstein/cli/commands/worker_cmd.py
+++ b/src/bernstein/cli/commands/worker_cmd.py
@@ -1,13 +1,17 @@
 """Worker command: join a Bernstein cluster as a remote worker node.
 
 Usage:
-  bernstein worker --server http://central:8052
-  bernstein worker --server http://central:8052 --name gpu-node-1 --slots 8
   bernstein worker --server http://central:8052 --token SECRET
+  bernstein worker --server http://central:8052 --token SECRET --name gpu-node-1 --slots 8
 
 The worker registers itself with the central task server, starts a
 heartbeat loop, and polls for tasks to execute locally via the CLI
 agent adapter.
+
+Cluster mode enables bearer auth on the central server, so ``--token`` (or the
+``BERNSTEIN_AUTH_TOKEN`` env var) is required: pass the value the central node
+was started with (``BERNSTEIN_AUTH_TOKEN`` or ``BERNSTEIN_CLUSTER_AUTH_SECRET``).
+When the central auto-generates one it is written to ``.sdd/runtime/auth.token``.
 """
 
 from __future__ import annotations
@@ -239,10 +243,37 @@ class WorkerLoop:
                 node_id = resp.json().get("id")
                 logger.info("Registered as node %s with %s", node_id, self._server_url)
                 return node_id
+            if resp.status_code in (401, 403):
+                # An auth rejection is a credential/config error, not a
+                # transient fault: re-sending the same header every 5s never
+                # succeeds and hides the real cause (#2805 / #2802). Abort.
+                self._fail_fast_auth(resp.status_code)
+                return None
             logger.warning("Registration failed: %d %s", resp.status_code, resp.text[:200])
         except httpx.HTTPError as exc:
             logger.warning("Registration error: %s", exc)
         return None
+
+    def _fail_fast_auth(self, status_code: int) -> None:
+        """Stop the worker on an unrecoverable registration auth rejection.
+
+        Prints an actionable message naming the credential the central server
+        requires and where to obtain it, then aborts the run loop instead of
+        retrying a request that cannot succeed.
+        """
+        console.print(
+            f"[red]Registration rejected ({status_code}):[/red] the central server "
+            "requires a bearer token this worker did not present (or presented an "
+            "unaccepted one)."
+        )
+        console.print(
+            "  Pass it with [bold]--token[/bold] or the [bold]BERNSTEIN_AUTH_TOKEN[/bold] env var. "
+            "When the central node auto-generates a token it writes it to "
+            "[bold].sdd/runtime/auth.token[/bold]; copy that value to this worker.\n"
+            "  In cluster mode the same token must equal BERNSTEIN_CLUSTER_AUTH_SECRET if one is set."
+        )
+        self._running = False
+        self._wake.signal_abort()
 
     def _heartbeat(self, client: httpx.Client, node_id: str) -> bool:
         """Send heartbeat with updated capacity. Returns True on success."""
@@ -351,6 +382,10 @@ class WorkerLoop:
             node_id = self._register(client)
             if node_id is not None:
                 break
+            if not self._running:
+                # Fail-fast path (e.g. auth rejection) already aborted the
+                # loop; do not print a misleading retry notice.
+                return None
             console.print("[yellow]Registration failed, retrying in 5s...[/yellow]")
             if self._wake.wait(timeout_s=5.0) == WakeReason.ABORT:
                 return None
@@ -546,12 +581,16 @@ def worker(
     work across multiple machines.
 
     \b
+    Cluster mode requires a bearer token: pass --token (or set
+    BERNSTEIN_AUTH_TOKEN) to the value the central node was started with.
+
+    \b
     Examples:
-      bernstein worker --server http://central:8052
-      bernstein worker --server http://central:8052 --name gpu-box --slots 8
-      bernstein worker --server http://central:8052 --label gpu=true
-      bernstein worker --server http://central:8052 --poll-interval-ms 2000
-      BERNSTEIN_SERVER_URL=http://central:8052 bernstein worker
+      bernstein worker --server http://central:8052 --token SECRET
+      bernstein worker --server http://central:8052 --token SECRET --name gpu-box --slots 8
+      bernstein worker --server http://central:8052 --token SECRET --label gpu=true
+      bernstein worker --server http://central:8052 --token SECRET --poll-interval-ms 2000
+      BERNSTEIN_SERVER_URL=http://central:8052 BERNSTEIN_AUTH_TOKEN=SECRET bernstein worker
     """
     from bernstein.core.poll_config import PollConfigValidationError, validate_poll_config
 

--- a/src/bernstein/core/protocols/cluster/cluster_auth.py
+++ b/src/bernstein/core/protocols/cluster/cluster_auth.py
@@ -7,6 +7,7 @@ are verified on every registration and heartbeat request.
 
 from __future__ import annotations
 
+import hmac
 import logging
 import time
 from dataclasses import dataclass
@@ -48,16 +49,22 @@ class ClusterAuthConfig:
     """Configuration for cluster JWT authentication.
 
     Attributes:
-        secret: Shared secret for JWT signing.
+        secret: Shared secret for JWT signing. Also accepted verbatim as a
+            worker bearer credential (see ``verify_request``).
         token_expiry_hours: How long node tokens remain valid.
         require_auth: Whether authentication is mandatory.
         allowed_scopes: Set of scopes that grant registration access.
+        shared_secrets: Additional raw bearer values accepted as a full-scope
+            worker credential (e.g. the operator's API bearer token when it
+            differs from ``secret``). Lets one credential satisfy both the
+            outer API middleware and the inner cluster layer (issue #2805).
     """
 
     secret: str
     token_expiry_hours: int = 24
     require_auth: bool = True
     allowed_scopes: tuple[str, ...] = (SCOPE_NODE_REGISTER, SCOPE_NODE_HEARTBEAT, SCOPE_NODE_ADMIN)
+    shared_secrets: tuple[str, ...] = ()
 
 
 class ClusterAuthenticator:
@@ -152,6 +159,24 @@ class ClusterAuthenticator:
         if token in self._revoked_tokens:
             _record_admission_failure("invalid_token")
             raise ClusterAuthError("Token has been revoked")
+
+        # Shared-secret path: a worker may present the raw cluster secret (or
+        # the operator's API bearer token) instead of a minted node JWT. This
+        # is the single worker-join credential story (#2805): the same token
+        # the outer API middleware accepts also authenticates node
+        # registration and heartbeat, so no separate JWT issuance surface is
+        # needed. Constant-time compared against every configured secret; a
+        # match grants the full node scope set.
+        for candidate in (self._config.secret, *self._config.shared_secrets):
+            if candidate and hmac.compare_digest(token, candidate):
+                now = time.time()
+                return JWTPayload(
+                    session_id="cluster-shared-secret",
+                    user_id=None,
+                    issued_at=now,
+                    expires_at=now + self._config.token_expiry_hours * 3600,
+                    scopes=list(self._config.allowed_scopes),
+                )
 
         payload = self._jwt.verify_token(token)
         if payload is None:

--- a/src/bernstein/core/security/auth_middleware.py
+++ b/src/bernstein/core/security/auth_middleware.py
@@ -405,11 +405,17 @@ class SSOAuthMiddleware(BaseHTTPMiddleware):
         agent_identity_store: AgentIdentityStore | None = None,
         auth_disabled: bool | None = None,
         expected_resource: _ExpectedResourceConfig = None,
+        cluster_secret: str | None = None,
     ) -> None:
         super().__init__(app)
         self._auth_service = auth_service
         self._legacy_token = legacy_token
         self._agent_identity_store = agent_identity_store
+        # The cluster shared secret is accepted as a worker credential so a
+        # single token clears both this outer layer and the inner cluster
+        # route layer (#2805). It is barred from operator-only endpoints
+        # below, mirroring the agent-identity restriction.
+        self._cluster_secret = cluster_secret or None
         # Resolve opt-out from explicit arg > env var. Config-based opt-out
         # should be passed in via ``auth_disabled=True`` from the factory.
         resolved_disabled = bool(auth_disabled) or auth_disabled_via_opt_out()
@@ -442,6 +448,8 @@ class SSOAuthMiddleware(BaseHTTPMiddleware):
         if self._auth_service is not None:
             return True
         if self._legacy_token:
+            return True
+        if self._cluster_secret:
             return True
         if self._agent_identity_store is not None:
             return True
@@ -533,6 +541,32 @@ class SSOAuthMiddleware(BaseHTTPMiddleware):
                 # Legacy tokens get operator-level access
                 request.state.user = None  # type: ignore[attr-defined]
                 request.state.auth_claims = {"legacy": True}  # type: ignore[attr-defined]
+                response = await call_next(request)
+                return response
+
+        # Strategy 3b: Cluster shared secret. A cluster worker presents the
+        # cluster secret to register, heartbeat, and pull tasks; it must clear
+        # this outer layer as well as the inner cluster route layer (#2805).
+        # Accepted like the legacy operator token but - like agent tokens -
+        # barred from operator-only (admin:manage) endpoints so it cannot
+        # shut down or reconfigure the server.
+        if self._cluster_secret:
+            import hmac
+
+            if hmac.compare_digest(token, self._cluster_secret):
+                if (
+                    request.method not in _READ_METHODS
+                    and _get_required_permission(path, request.method) == _PERM_ADMIN_MANAGE
+                ):
+                    return JSONResponse(
+                        status_code=403,
+                        content={
+                            "detail": "Cluster credential cannot access operator-only endpoints",
+                            "required_permission": _PERM_ADMIN_MANAGE,
+                        },
+                    )
+                request.state.user = None  # type: ignore[attr-defined]
+                request.state.auth_claims = {"cluster": True}  # type: ignore[attr-defined]
                 response = await call_next(request)
                 return response
 

--- a/src/bernstein/core/server/server_app.py
+++ b/src/bernstein/core/server/server_app.py
@@ -945,15 +945,13 @@ def create_app(
         _nodes_persist = _runtime_dir / "nodes.json"
     node_registry = NodeRegistry(effective_cluster, persist_path=_nodes_persist)
 
-    # Cluster JWT authentication
+    # Cluster JWT authentication. Constructed below, once the API legacy
+    # token is resolved, so the outer middleware and the inner cluster layer
+    # can share one worker-join credential (#2805).
     from bernstein.core.cluster_auth import ClusterAuthConfig, ClusterAuthenticator
 
     _cluster_auth_secret = effective_cluster.auth_token or ""
     cluster_authenticator: ClusterAuthenticator | None = None
-    if effective_cluster.enabled and _cluster_auth_secret:
-        cluster_authenticator = ClusterAuthenticator(
-            ClusterAuthConfig(secret=_cluster_auth_secret, require_auth=True),
-        )
 
     store = TaskStore(jsonl_path, metrics_jsonl_path=metrics_jsonl_path)
     sse_bus = SSEBus()
@@ -967,6 +965,23 @@ def create_app(
     auth_enabled = auth_config.enabled or auth_config.oidc.enabled or auth_config.saml.enabled
     auth_service = AuthService(auth_config, AuthStore(sdd_dir)) if auth_enabled else None
     legacy_auth_token = effective_token or auth_config.legacy_token or None
+
+    # Wire the cluster authenticator with a single worker-join credential
+    # story (#2805): a worker presenting either the cluster secret or the
+    # operator API bearer token authenticates node registration/heartbeat.
+    # The outer SSOAuthMiddleware already accepts the legacy API token on
+    # every path, so teaching the inner cluster layer to accept it too means
+    # one token clears both layers even when a distinct
+    # BERNSTEIN_CLUSTER_AUTH_SECRET is configured.
+    if effective_cluster.enabled and _cluster_auth_secret:
+        _extra_cluster_secrets = tuple(s for s in (legacy_auth_token,) if s and s != _cluster_auth_secret)
+        cluster_authenticator = ClusterAuthenticator(
+            ClusterAuthConfig(
+                secret=_cluster_auth_secret,
+                require_auth=True,
+                shared_secrets=_extra_cluster_secrets,
+            ),
+        )
 
     def _reload_seed_config() -> dict[str, Any]:
         """Reload and persist bernstein.yaml metadata without restarting."""
@@ -1107,6 +1122,10 @@ def create_app(
     # Empty string disables the check (legacy behaviour).
     expected_resource = auth_config.expected_resource or None
 
+    # In cluster mode the worker credential (the cluster secret) must clear
+    # the outer middleware too, not only the inner cluster route layer (#2805).
+    _mw_cluster_secret = _cluster_auth_secret if (effective_cluster.enabled and _cluster_auth_secret) else None
+
     application.add_middleware(
         SSOAuthMiddleware,
         auth_service=auth_service,
@@ -1114,6 +1133,7 @@ def create_app(
         agent_identity_store=_agent_identity_store,
         auth_disabled=auth_disabled_flag,
         expected_resource=expected_resource,
+        cluster_secret=_mw_cluster_secret,
     )
 
     # Dashboard auth (#2366) - scoped sessions / tokens for the /dashboard

--- a/tests/unit/test_cluster_worker_join_auth.py
+++ b/tests/unit/test_cluster_worker_join_auth.py
@@ -1,0 +1,240 @@
+"""Worker-join auth coherence across the two cluster auth layers.
+
+Regression coverage for the cluster worker-join credential story:
+
+* A cluster-enabled server exposes ``/cluster/*`` behind two independent
+  auth layers - the outer :class:`SSOAuthMiddleware` and the inner
+  :class:`ClusterAuthenticator`. A single worker credential must satisfy
+  both, otherwise no worker can register (issue #2805).
+* The worker must fail fast on an auth rejection instead of retrying a
+  doomed request every 5 s forever (issues #2805 / #2802).
+
+The tests intentionally exercise the real ``create_app`` wiring so the two
+layers are verified together, not in isolation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from bernstein.core.cluster_auth import (
+    SCOPE_NODE_HEARTBEAT,
+    SCOPE_NODE_REGISTER,
+    ClusterAuthConfig,
+    ClusterAuthenticator,
+    ClusterAuthError,
+)
+from bernstein.core.models import ClusterConfig
+from fastapi.testclient import TestClient
+
+from bernstein.core.server import create_app
+
+_SECRET = "cluster-shared-secret-value"  # NOSONAR - test fixture, not a real credential
+
+_NODE_PAYLOAD = {
+    "name": "worker-1",
+    "url": "",
+    "capacity": {
+        "max_agents": 4,
+        "available_slots": 4,
+        "active_agents": 0,
+        "gpu_available": False,
+        "supported_models": ["sonnet", "opus", "haiku"],
+    },
+    "labels": {},
+    "cell_ids": [],
+}
+
+
+# ---------------------------------------------------------------------------
+# Inner layer: ClusterAuthenticator accepts the raw shared secret
+# ---------------------------------------------------------------------------
+
+
+class TestSharedSecretAcceptance:
+    """The inner authenticator must accept the raw cluster secret."""
+
+    def test_raw_secret_is_accepted(self) -> None:
+        auth = ClusterAuthenticator(ClusterAuthConfig(secret=_SECRET))
+        payload = auth.verify_request(f"Bearer {_SECRET}", SCOPE_NODE_REGISTER)
+        assert SCOPE_NODE_REGISTER in payload.scopes
+        assert SCOPE_NODE_HEARTBEAT in payload.scopes
+
+    def test_raw_secret_covers_heartbeat_scope(self) -> None:
+        auth = ClusterAuthenticator(ClusterAuthConfig(secret=_SECRET))
+        payload = auth.verify_request(f"Bearer {_SECRET}", SCOPE_NODE_HEARTBEAT)
+        assert SCOPE_NODE_HEARTBEAT in payload.scopes
+
+    def test_wrong_raw_secret_is_rejected(self) -> None:
+        auth = ClusterAuthenticator(ClusterAuthConfig(secret=_SECRET))
+        with pytest.raises(ClusterAuthError):
+            auth.verify_request("Bearer not-the-secret", SCOPE_NODE_REGISTER)
+
+    def test_extra_shared_secret_is_accepted(self) -> None:
+        # The operator's legacy bearer token, distinct from the cluster
+        # secret, is accepted so a split config still has one worker token.
+        auth = ClusterAuthenticator(ClusterAuthConfig(secret=_SECRET, shared_secrets=("operator-legacy-token",)))
+        payload = auth.verify_request("Bearer operator-legacy-token", SCOPE_NODE_REGISTER)
+        assert SCOPE_NODE_REGISTER in payload.scopes
+
+    def test_issued_jwt_still_accepted(self) -> None:
+        # The pre-existing JWT issuance path must keep working.
+        auth = ClusterAuthenticator(ClusterAuthConfig(secret=_SECRET))
+        token = auth.issue_node_token("node-1")
+        payload = auth.verify_request(f"Bearer {token}", SCOPE_NODE_REGISTER)
+        assert payload.user_id == "node-1"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: both auth layers accept one worker credential
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.auth_enabled
+class TestWorkerJoinEndToEnd:
+    """A single worker credential must pass outer middleware + cluster route."""
+
+    def _client(self, tmp_path: Path, *, cluster_secret: str, api_token: str) -> TestClient:
+        app = create_app(
+            jsonl_path=tmp_path / "tasks.jsonl",
+            auth_token=api_token,
+            cluster_config=ClusterConfig(enabled=True, auth_token=cluster_secret),
+        )
+        return TestClient(app)
+
+    def test_single_secret_join_succeeds(self, tmp_path: Path) -> None:
+        """Common config: cluster secret == API token. Worker uses that token."""
+        client = self._client(tmp_path, cluster_secret=_SECRET, api_token=_SECRET)
+        headers = {"Authorization": f"Bearer {_SECRET}"}
+
+        resp = client.post("/cluster/nodes", json=_NODE_PAYLOAD, headers=headers)
+        assert resp.status_code == 201, resp.text
+        node_id = resp.json()["id"]
+
+        hb = client.post(
+            f"/cluster/nodes/{node_id}/heartbeat",
+            json={"capacity": None},
+            headers=headers,
+        )
+        assert hb.status_code == 200, hb.text
+
+        status = client.get("/cluster/status", headers=headers)
+        assert status.status_code == 200, status.text
+        assert status.json()["total_nodes"] >= 1
+
+    def test_join_without_token_is_rejected(self, tmp_path: Path) -> None:
+        client = self._client(tmp_path, cluster_secret=_SECRET, api_token=_SECRET)
+        resp = client.post("/cluster/nodes", json=_NODE_PAYLOAD)
+        assert resp.status_code == 401
+
+    def test_join_with_wrong_token_is_rejected(self, tmp_path: Path) -> None:
+        client = self._client(tmp_path, cluster_secret=_SECRET, api_token=_SECRET)
+        resp = client.post(
+            "/cluster/nodes",
+            json=_NODE_PAYLOAD,
+            headers={"Authorization": "Bearer wrong-token"},
+        )
+        assert resp.status_code == 401
+
+    def test_split_config_operator_token_joins(self, tmp_path: Path) -> None:
+        """Split config: distinct cluster secret + API token.
+
+        The operator's API token is a universal worker credential - it passes
+        the outer middleware (legacy) and the cluster route layer (extra
+        shared secret).
+        """
+        client = self._client(tmp_path, cluster_secret="distinct-cluster-secret", api_token=_SECRET)
+        headers = {"Authorization": f"Bearer {_SECRET}"}
+        resp = client.post("/cluster/nodes", json=_NODE_PAYLOAD, headers=headers)
+        assert resp.status_code == 201, resp.text
+
+    def test_split_config_cluster_secret_joins_and_pulls(self, tmp_path: Path) -> None:
+        """Split config: the CLUSTER SECRET is also a universal worker token.
+
+        It clears the outer middleware and the inner cluster route, and it
+        authenticates task pull (a non-cluster path) - which proves the two
+        layers no longer accept disjoint credentials (#2805).
+        """
+        cluster_secret = "cluster-only-secret"  # NOSONAR - test fixture
+        client = self._client(tmp_path, cluster_secret=cluster_secret, api_token=_SECRET)
+        headers = {"Authorization": f"Bearer {cluster_secret}"}
+
+        resp = client.post("/cluster/nodes", json=_NODE_PAYLOAD, headers=headers)
+        assert resp.status_code == 201, resp.text
+
+        # Task pull is a non-cluster route; the same credential must authenticate
+        # it. No open tasks -> 404, but crucially NOT 401/403.
+        pull = client.get("/tasks/next/backend", headers=headers)
+        assert pull.status_code not in (401, 403), pull.text
+
+    def test_cluster_secret_barred_from_operator_endpoint(self, tmp_path: Path) -> None:
+        """The cluster secret must not reach operator-only endpoints."""
+        cluster_secret = "cluster-only-secret"  # NOSONAR - test fixture
+        client = self._client(tmp_path, cluster_secret=cluster_secret, api_token=_SECRET)
+        resp = client.post(
+            "/shutdown",
+            json={},
+            headers={"Authorization": f"Bearer {cluster_secret}"},
+        )
+        assert resp.status_code == 403, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Worker fail-fast on auth rejection
+# ---------------------------------------------------------------------------
+
+
+class _FakeResp:
+    def __init__(self, status_code: int, *, text: str = "", payload: dict | None = None) -> None:
+        self.status_code = status_code
+        self.text = text
+        self._payload = payload or {}
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class _FakeClient:
+    def __init__(self, resp: _FakeResp) -> None:
+        self._resp = resp
+        self.calls = 0
+
+    def post(self, *_a: object, **_k: object) -> _FakeResp:
+        self.calls += 1
+        return self._resp
+
+
+class TestWorkerFailFast:
+    """Worker must not loop forever on a 401/403."""
+
+    def _loop(self):  # type: ignore[no-untyped-def]
+        from bernstein.cli.commands.worker_cmd import WorkerLoop
+
+        # Explicit adapter avoids slow, non-hermetic agent auto-detection.
+        loop = WorkerLoop(server_url="http://central:8052", auth_token="whatever", adapter="claude")
+        loop._running = True
+        return loop
+
+    def test_register_retry_stops_on_401(self) -> None:
+        loop = self._loop()
+        client = _FakeClient(_FakeResp(401, text='{"detail":"Invalid or expired token"}'))
+        node_id = loop._register_with_retry(client)  # type: ignore[arg-type]
+        assert node_id is None
+        assert loop._running is False
+        assert client.calls == 1  # fail-fast: no silent retry loop
+
+    def test_register_retry_stops_on_403(self) -> None:
+        loop = self._loop()
+        client = _FakeClient(_FakeResp(403, text='{"detail":"forbidden"}'))
+        node_id = loop._register_with_retry(client)  # type: ignore[arg-type]
+        assert node_id is None
+        assert loop._running is False
+        assert client.calls == 1
+
+    def test_register_succeeds_on_201(self) -> None:
+        loop = self._loop()
+        client = _FakeClient(_FakeResp(201, payload={"id": "node-xyz"}))
+        node_id = loop._register_with_retry(client)  # type: ignore[arg-type]
+        assert node_id == "node-xyz"
+        assert loop._running is True


### PR DESCRIPTION
## What
Cluster worker registration was structurally impossible: two auth layers accepted disjoint credentials, and a misconfigured worker retried silently forever. One coherent commit fixes the join surface end to end.

Fixes #2805
Fixes #2802

## Details
- **#2805 disjoint auth layers**: the outer middleware accepted an SSO/agent JWT or the legacy bearer token, while the inner `ClusterAuthenticator` demanded its own JWT that nothing issued. `verify_request` now accepts a raw bearer that constant-time-matches the cluster secret (or a configured shared secret) and synthesizes a full-scope payload — the JWT path is preserved; the app now constructs the authenticator after config resolution so both layers see the same secrets.
- **#2802 silent 401 loop + unsurfaced token**: the worker treated 401 like a transient error and retried every 5s forever, and the auto-generated bearer token was never shown to the operator. 401/403 are now fatal with an actionable message naming `--token` / `BERNSTEIN_AUTH_TOKEN` and the `.sdd/runtime/auth.token` path; transient/5xx errors still retry; the cluster deployment doc now documents the real join flow.

## Verification
- TDD with red evidence; consolidated touched-area run 114 passed (incl. `test_auth_middleware_defaults.py`, `test_auth_middleware_resource_indicator.py` — 84 passed).
- Import sentinel: 37800 collected, no errors; ruff check/format clean.