### PR TITLE
fix(cluster): remote completion reporting, dead-worker redispatch, and adapter/model propagation

### DIFF
--- a/docs/operations/cluster-mode.md
+++ b/docs/operations/cluster-mode.md
@@ -94,6 +94,7 @@ Common flags (`worker_cmd.py:371-430`):
 | `--roles a,b,c`            | backend,qa,security,frontend | Roles this worker accepts.                                |
 | `--label k=v`              | (repeat)           | Free-form labels for affinity routing.                                 |
 | `--adapter NAME`           | auto-detect        | Which CLI agent to invoke (`claude`, `codex`, ...).                    |
+| `--model NAME`             | adapter default    | Default model for tasks with no explicit `model`. Non-Claude adapters fall back to their own discovered default. |
 | `--poll-interval SECONDS`  | 10                 | Task poll cadence.                                                     |
 | `--poll-interval-ms MS`    | none               | Override poll cadence in milliseconds.                                 |
 | `--heartbeat-interval-ms`  | 15000              | Heartbeat cadence.                                                     |

--- a/src/bernstein/cli/commands/worker_cmd.py
+++ b/src/bernstein/cli/commands/worker_cmd.py
@@ -101,6 +101,11 @@ class WorkerLoop:
         self._workdir = workdir or Path.cwd()
         self._running = False
         self._active_tasks: dict[str, int] = {}  # task_id -> pid
+        # Terminal outcomes reaped from finished agents, drained to the server
+        # by _report_finished. (task_id, ok, detail). Worker-side reporting is
+        # authoritative and does not depend on the in-agent completion curl
+        # (#2808): without it a finished agent leaves its task CLAIMED forever.
+        self._pending_reports: list[tuple[str, bool, str]] = []
         self._wake = CapacityWake()
 
     def _headers(self) -> dict[str, str]:
@@ -192,23 +197,41 @@ class WorkerLoop:
     def _reap_finished(self) -> bool:
         """Remove tasks whose agent process has exited.
 
+        Each reaped task is queued as a terminal outcome (success/failure from
+        the agent exit code) for _report_finished to post to the server, so a
+        finished agent transitions its task instead of leaving it CLAIMED
+        (#2808). Success/failure is derived from the exit code: a clean exit
+        (0) completes the task; a non-zero exit or signal kill fails it.
+
         Returns:
             ``True`` if at least one task was reaped (a slot became available).
         """
         from bernstein.core.platform_compat import process_alive
 
-        finished: list[str] = []
-        for task_id, pid in self._active_tasks.items():
+        finished: list[tuple[str, bool, str]] = []
+        for task_id, pid in list(self._active_tasks.items()):
+            exited = False
+            ok = True
+            detail = "worker reaped agent process (exit status unavailable)"
             try:
-                os.waitpid(pid, os.WNOHANG)
+                reaped_pid, status = os.waitpid(pid, os.WNOHANG)
             except ChildProcessError:
-                finished.append(task_id)
-                continue
-            # Check if process is still alive
-            if not process_alive(pid):
-                finished.append(task_id)
-        for task_id in finished:
+                # Already reaped elsewhere; the exit status is gone. Treat as a
+                # completion and let server-side verification have the final say.
+                exited = True
+            else:
+                if reaped_pid == pid:
+                    exited = True
+                    exit_code = os.waitstatus_to_exitcode(status)
+                    ok = exit_code == 0
+                    detail = f"agent exited with code {exit_code}"
+                elif not process_alive(pid):
+                    exited = True
+            if exited:
+                finished.append((task_id, ok, detail))
+        for task_id, ok, detail in finished:
             del self._active_tasks[task_id]
+            self._pending_reports.append((task_id, ok, detail))
         if finished:
             self._wake.signal_capacity()
         return bool(finished)
@@ -306,6 +329,23 @@ class WorkerLoop:
             )
         except httpx.HTTPError as exc:
             logger.warning("Failed to report failure for %s: %s", task_id, exc)
+
+    def _report_finished(self, client: httpx.Client) -> None:
+        """Post queued terminal outcomes for reaped agents to the server.
+
+        This is what drives a remotely executed task to a terminal state: the
+        in-agent completion curl may never fire (crash, kill, wrong URL), so
+        the worker reports completion/failure itself (#2808). A task already
+        terminal server-side simply no-ops the redundant report.
+        """
+        if not self._pending_reports:
+            return
+        pending, self._pending_reports = self._pending_reports, []
+        for task_id, ok, detail in pending:
+            if ok:
+                self._complete_task(client, task_id, detail)
+            else:
+                self._fail_task(client, task_id, detail)
 
     def _spawn_agent(self, task: dict) -> int | None:
         """Spawn a CLI agent process to work on a task. Returns PID or None."""
@@ -446,9 +486,17 @@ class WorkerLoop:
                 if self.available_slots > 0:
                     self._claim_available_tasks(client)
 
+                # Drive reaped agents to a terminal state on the server. Reading
+                # available_slots above already reaped finished agents into the
+                # pending queue.
+                self._report_finished(client)
+
                 if self._wake.wait(timeout_s=poll_s) == WakeReason.ABORT:
                     break
 
+            # Flush any outcomes reaped in the final cycle before leaving.
+            self._reap_finished()
+            self._report_finished(client)
             self._unregister(client, node_id)
 
         console.print("[bold]Worker stopped.[/bold]")

--- a/src/bernstein/cli/commands/worker_cmd.py
+++ b/src/bernstein/cli/commands/worker_cmd.py
@@ -294,11 +294,17 @@ class WorkerLoop:
             logger.warning("Heartbeat error: %s", exc)
         return True  # Don't re-register on transient errors
 
-    def _claim_task(self, client: httpx.Client, role: str) -> dict | None:
-        """Try to claim the next task for a given role. Returns task dict or None."""
+    def _claim_task(self, client: httpx.Client, role: str, node_id: str | None = None) -> dict | None:
+        """Try to claim the next task for a given role. Returns task dict or None.
+
+        The worker's node id is recorded as the claim owner so the server can
+        release this node's in-flight tasks when it leaves the cluster (#2801).
+        """
+        params = {"claimed_by_session": node_id} if node_id else None
         with suppress(httpx.HTTPError):
             resp = client.get(
                 f"{self._server_url}/tasks/next/{role}",
+                params=params,
                 headers=self._headers(),
                 timeout=10.0,
             )
@@ -420,12 +426,12 @@ class WorkerLoop:
             return None, last_heartbeat
         return new_id, time.monotonic()
 
-    def _claim_available_tasks(self, client: httpx.Client) -> None:
+    def _claim_available_tasks(self, client: httpx.Client, node_id: str | None = None) -> None:
         """Claim tasks for each role while slots remain."""
         for role in self._roles:
             if self.available_slots <= 0:
                 return
-            task = self._claim_task(client, role)
+            task = self._claim_task(client, role, node_id)
             if task is None:
                 continue
             task_id = task.get("id", "unknown")
@@ -484,7 +490,7 @@ class WorkerLoop:
                     continue
 
                 if self.available_slots > 0:
-                    self._claim_available_tasks(client)
+                    self._claim_available_tasks(client, node_id)
 
                 # Drive reaped agents to a terminal state on the server. Reading
                 # available_slots above already reaped finished agents into the

--- a/src/bernstein/cli/commands/worker_cmd.py
+++ b/src/bernstein/cli/commands/worker_cmd.py
@@ -46,6 +46,28 @@ def _detect_worker_adapter() -> str:
     return "claude"
 
 
+def _adapter_model_profile(adapter_name: str) -> tuple[str | None, list[str]]:
+    """Resolve ``(default_model, supported_models)`` for an adapter.
+
+    Consults the local agent-discovery cache -- the same source
+    :func:`_detect_worker_adapter` uses -- so the worker advertises and defaults
+    to the models the adapter it actually runs supports, rather than a fixed
+    Claude tier list (#2804). Returns ``(None, [])`` when the adapter is not
+    locally discoverable, leaving the caller to keep its prior behaviour.
+    """
+    with suppress(Exception):
+        from bernstein.core.agent_discovery import discover_agents_cached
+
+        for agent in discover_agents_cached().agents:
+            if agent.name == adapter_name:
+                default = agent.default_model or None
+                models = list(agent.available_models or [])
+                if default and default not in models:
+                    models = [default, *models]
+                return default, models
+    return None, []
+
+
 class WorkerLoop:
     """Main loop for a worker node: register, heartbeat, claim + execute tasks.
 
@@ -73,6 +95,7 @@ class WorkerLoop:
         workdir: Path | None = None,
         pool: str | None = None,
         pool_hash: str | None = None,
+        model: str | None = None,
     ) -> None:
         self._server_url = server_url.rstrip("/")
         self._name = name or socket.gethostname()
@@ -88,6 +111,13 @@ class WorkerLoop:
         # must not be overridden by model-name inference at spawn time
         # (#2751); an auto-detected adapter is not a pin.
         self._adapter_pinned = adapter is not None
+        self._model = model
+        # Resolve, once, what this node's adapter can run so a task with no
+        # explicit model gets an adapter-appropriate default (rather than a
+        # Claude tier name the adapter would refuse) and the node advertises a
+        # truthful capability list to server-side placement (#2804).
+        self._spawn_default_model = self._resolve_spawn_default_model()
+        self._supported_models = self._resolve_supported_models()
         # Prefer explicit PollConfig; fall back to legacy poll_interval (seconds).
         if poll_config is not None:
             self._poll_config = poll_config
@@ -113,6 +143,46 @@ class WorkerLoop:
         if self._auth_token:
             headers["Authorization"] = f"Bearer {self._auth_token}"
         return headers
+
+    @staticmethod
+    def _is_claude_adapter(adapter_name: str) -> bool:
+        """Whether an adapter serves the Claude tier-name cascade (sonnet/opus/haiku)."""
+        with suppress(Exception):
+            from bernstein.core.bandit_router import BanditRouter
+
+            return bool(BanditRouter.router_applicable(adapter_name))
+        return adapter_name == "claude"
+
+    def _resolve_spawn_default_model(self) -> str | None:
+        """Default model to hand the spawner for tasks that carry none.
+
+        An explicit ``--model`` always wins. Claude-family adapters run the
+        tier-named cascade the planner emits, so no default is forced (leaving
+        the existing routing untouched). Non-Claude adapters get their own
+        discovered default, so an unpinned Claude tier name coerces to a model
+        the adapter can actually run instead of raising ``ModelNotConfiguredError``
+        (#2804).
+        """
+        if self._model:
+            return self._model
+        if self._is_claude_adapter(self._adapter_name):
+            return None
+        default, _models = _adapter_model_profile(self._adapter_name)
+        return default
+
+    def _resolve_supported_models(self) -> list[str]:
+        """Model set this node advertises to server-side placement.
+
+        Claude-family adapters keep advertising the tier names planner-emitted
+        tasks reference. Other adapters advertise the concrete models the local
+        discovery cache reports for them, so a qwen node stops falsely claiming
+        the Claude tiers it would refuse -- the placement filter in
+        ``best_node_for_task`` trusts this list (#2804).
+        """
+        if self._is_claude_adapter(self._adapter_name):
+            return ["sonnet", "opus", "haiku"]
+        _default, models = _adapter_model_profile(self._adapter_name)
+        return models
 
     def _resolve_pool_hash(self) -> str | None:
         """Resolve the pool hash to enrol against, if a pool was requested.
@@ -246,7 +316,7 @@ class WorkerLoop:
                 "available_slots": self.available_slots,
                 "active_agents": len(self._active_tasks),
                 "gpu_available": False,
-                "supported_models": ["sonnet", "opus", "haiku"],
+                "supported_models": self._supported_models,
             },
             "labels": self._labels,
             "cell_ids": [],
@@ -275,7 +345,7 @@ class WorkerLoop:
                 "available_slots": self.available_slots,
                 "active_agents": len(self._active_tasks),
                 "gpu_available": False,
-                "supported_models": ["sonnet", "opus", "haiku"],
+                "supported_models": self._supported_models,
             },
         }
         try:
@@ -362,8 +432,6 @@ class WorkerLoop:
 
         task_id = task.get("id", "unknown")
         title = task.get("title", "")
-        description = task.get("description", "")
-        role = task.get("role", "backend")
 
         logger.info("Spawning agent for task %s: %s", task_id, title[:60])
 
@@ -374,6 +442,10 @@ class WorkerLoop:
                 templates_dir=get_templates_dir(self._workdir) / "roles",
                 workdir=self._workdir,
                 adapter_pinned=self._adapter_pinned,
+                # Adapter-appropriate default so a task carrying no explicit
+                # model coerces to a model the adapter can run instead of a
+                # Claude tier name it would refuse (#2804).
+                default_model=self._spawn_default_model,
             )
             # Spawned agents reach the central server through the standard
             # env vars. Adapters launch agents with an allowlist-filtered
@@ -383,7 +455,11 @@ class WorkerLoop:
             os.environ["BERNSTEIN_SERVER_URL"] = self._server_url
             if self._auth_token:
                 os.environ["BERNSTEIN_AUTH_TOKEN"] = self._auth_token
-            session = spawner.spawn_for_tasks([Task(id=task_id, title=title, description=description, role=role)])
+            # Reconstruct the full Task from the claimed dict so per-step
+            # model / cli / effort / scope / metadata are honoured rather than
+            # discarded (#2804). from_dict coerces enum fields and tolerates
+            # missing optionals.
+            session = spawner.spawn_for_tasks([Task.from_dict(task)])
             if session and session.pid:
                 return session.pid
         except Exception as exc:
@@ -551,6 +627,11 @@ class WorkerLoop:
     help="CLI agent adapter (default: auto-detect).",
 )
 @click.option(
+    "--model",
+    default=None,
+    help="Default model for tasks that carry no explicit model (default: the adapter's own default).",
+)
+@click.option(
     "--poll-interval",
     default=10,
     show_default=True,
@@ -586,6 +667,7 @@ def worker(
     labels: tuple[str, ...],
     token: str | None,
     adapter: str | None,
+    model: str | None,
     poll_interval: int,
     poll_interval_ms: int | None,
     heartbeat_interval_ms: int,
@@ -642,6 +724,7 @@ def worker(
         labels=label_dict,
         auth_token=token,
         adapter=adapter if adapter != "auto" else None,
+        model=model,
         poll_interval=poll_interval,
         poll_config=cfg,
         pool=pool,

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -446,6 +446,21 @@ def _render_signal_check(session_id: str) -> str:
     )
 
 
+def _resolve_task_server_url() -> str:
+    """Resolve the base URL agents use to reach the task server.
+
+    Remote workers export ``BERNSTEIN_SERVER_URL`` into the agent env before
+    spawning (``cli/commands/worker_cmd.py``), and it is allow-listed for
+    agents (``adapters/env_isolation.py``). Reading it here means a completion
+    POST from an agent on a worker node reaches the central server instead of
+    the worker's own loopback, and it also fixes local runs started on a
+    non-default port. Falls back to the historical local default when unset.
+    """
+    import os
+
+    return os.environ.get("BERNSTEIN_SERVER_URL", "http://127.0.0.1:8052").rstrip("/")
+
+
 def _render_auth_section(token_path: Path) -> str:
     """Return authentication instructions to inject into every agent's prompt.
 
@@ -465,6 +480,7 @@ def _render_auth_section(token_path: Path) -> str:
         Markdown block instructing the agent to authenticate all requests.
     """
     absolute = token_path if token_path.is_absolute() else token_path.resolve(strict=False)
+    base = _resolve_task_server_url()
     return (
         "\n## Task Server Authentication\n"
         "Your agent token is stored at this absolute path (do NOT print or "
@@ -506,14 +522,14 @@ def _render_auth_section(token_path: Path) -> str:
         "the command form was correct.\n"
         "Example - creating a subtask (pass the whole line to `run_command` as ONE string):\n"
         "```bash\n"
-        f"curl -sS -w '\\n%{{http_code}}' -X POST http://127.0.0.1:8052/tasks \\\n"
+        f"curl -sS -w '\\n%{{http_code}}' -X POST {base}/tasks \\\n"
         f'  -H "Authorization: Bearer $(cat {absolute})" \\\n'
         '  -H "Content-Type: application/json" \\\n'
         '  -d \'{"title": "...", "role": "backend", "description": "..."}\'\n'
         "```\n"
         "Example - marking a task complete (pass the whole line to `run_command` as ONE string):\n"
         "```bash\n"
-        f"curl -sS -w '\\n%{{http_code}}' -X POST http://127.0.0.1:8052/tasks/<TASK_ID>/complete \\\n"
+        f"curl -sS -w '\\n%{{http_code}}' -X POST {base}/tasks/<TASK_ID>/complete \\\n"
         f'  -H "Authorization: Bearer $(cat {absolute})" \\\n'
         '  -H "Content-Type: application/json" \\\n'
         '  -d \'{"result_summary": "Done"}\'\n'
@@ -735,6 +751,7 @@ def _render_batch_prompt(task: Task) -> str:
     Returns:
         Prompt string starting with ``/batch`` that triggers the batch skill.
     """
+    base = _resolve_task_server_url()
     lines: list[str] = [f"/batch {task.description}"]
     if task.owned_files:
         lines.append(f"\nAffected paths: {', '.join(task.owned_files)}")
@@ -742,7 +759,7 @@ def _render_batch_prompt(task: Task) -> str:
         (
             f"\nTask ID for completion reporting: {task.id}",
             "\nAfter all batch units are complete, run:\n"
-            f"curl -sS -X POST http://127.0.0.1:8052/tasks/{task.id}/complete "
+            f"curl -sS -X POST {base}/tasks/{task.id}/complete "
             f'-H "Content-Type: application/json" '
             f'-d \'{{"result_summary": "Batch complete: {task.title}"}}\'',
         )
@@ -922,9 +939,10 @@ def _render_prompt(
     # agents must retry on transient connection errors (--retry-connrefused).
     # Do NOT use --retry-all-errors: it retries 4xx (e.g. 409 Conflict),
     # causing infinite loops when task state has changed.
+    completion_base = _resolve_task_server_url()
     completion_cmds = "\n".join(
         f"curl -s -w '\\n%{{http_code}}' --retry 3 --retry-delay 2 --retry-connrefused "
-        f"-X POST http://127.0.0.1:8052/tasks/{t.id}/complete "
+        f"-X POST {completion_base}/tasks/{t.id}/complete "
         f'-H "Content-Type: application/json" '
         f'-d \'{{"result_summary": "Completed: {t.title}"}}\''
         for t in tasks

--- a/src/bernstein/core/routes/task_cluster.py
+++ b/src/bernstein/core/routes/task_cluster.py
@@ -119,6 +119,10 @@ def unregister_node(node_id: str, request: Request) -> Response:
     node_registry = _get_node_registry(request)
     if not node_registry.unregister(node_id):
         raise HTTPException(status_code=404, detail=f"Node '{node_id}' not found")
+    # Release the departed node's in-flight claims so a surviving worker can
+    # pick them up. Covers the graceful-leave path (docker stop / drain);
+    # the timeout path is handled by the node reaper (#2801).
+    _get_store(request).reopen_tasks_for_node(node_id)
     return Response(status_code=204)
 
 

--- a/src/bernstein/core/server/server_app.py
+++ b/src/bernstein/core/server/server_app.py
@@ -636,11 +636,18 @@ async def _reaper_loop(store: TaskStore, interval_s: float = 30.0) -> None:
         store.mark_stale_dead()
 
 
-async def _node_reaper_loop(node_reg: NodeRegistry, interval_s: float = 15.0) -> None:
-    """Periodically mark stale cluster nodes as offline."""
+async def _node_reaper_loop(node_reg: NodeRegistry, store: TaskStore, interval_s: float = 15.0) -> None:
+    """Periodically mark stale cluster nodes offline and release their claims.
+
+    A node that stops heartbeating is transitioned ONLINE -> OFFLINE, and any
+    tasks it had claimed are re-queued to OPEN so a surviving worker can pick
+    them up. Without the task release a crashed worker's claims would stay
+    CLAIMED forever with no live agent (#2801).
+    """
     while True:
         await asyncio.sleep(interval_s)
-        node_reg.mark_stale()
+        for node in node_reg.mark_stale():
+            store.reopen_tasks_for_node(node.id)
 
 
 async def _sse_heartbeat_loop(bus: SSEBus, interval_s: float = 15.0) -> None:
@@ -989,12 +996,19 @@ def create_app(
         reaper = asyncio.create_task(_reaper_loop(store))
         # Launch SSE heartbeat loop
         sse_heartbeat = asyncio.create_task(_sse_heartbeat_loop(sse_bus))
-        # Launch node-stale reaper if cluster mode is on
-        node_reaper: asyncio.Task[None] | None = None
-        if effective_cluster.enabled:
-            node_reaper = asyncio.create_task(
-                _node_reaper_loop(node_registry, interval_s=effective_cluster.node_heartbeat_interval_s)
+        # Launch the node-stale reaper whenever the /cluster/nodes routes are
+        # mounted (always) rather than only when cluster auth is enabled. Node
+        # liveness reaping is not part of the auth layer, and a worker can only
+        # register in the auth-off configuration, so gating the reaper behind
+        # the auth flag meant it never ran in any cluster a worker had joined
+        # (#2801).
+        node_reaper: asyncio.Task[None] = asyncio.create_task(
+            _node_reaper_loop(
+                node_registry,
+                store,
+                interval_s=effective_cluster.node_heartbeat_interval_s,
             )
+        )
         yield
         # Shutdown
         reaper.cancel()

--- a/src/bernstein/core/tasks/task_store_core.py
+++ b/src/bernstein/core/tasks/task_store_core.py
@@ -513,6 +513,59 @@ class TaskStore:
             logger.info("recover_stale_claimed_tasks: reset %d task(s) to open after restart", reset_count)
         return reset_count
 
+    def reopen_tasks_for_node(self, node_id: str) -> int:
+        """Reset a departed cluster node's in-flight tasks back to OPEN.
+
+        A cluster worker claims through ``/tasks/next`` with its node id
+        recorded as the claim owner (``claimed_by_session``). When that node
+        leaves -- by heartbeat timeout (crash) or graceful unregister -- its
+        CLAIMED/IN_PROGRESS tasks would otherwise stay claimed forever with no
+        live agent, and no reaper would ever release them (#2801). This
+        re-queues exactly that node's tasks so a surviving worker can pick them
+        up.
+
+        Mirrors :meth:`recover_stale_claimed_tasks` but scoped to one node.
+        The method performs no ``await``, so it runs atomically with respect to
+        concurrent claims in the single-threaded async server loop and is safe
+        to call from both the async node reaper and the sync unregister route.
+
+        Args:
+            node_id: Owning node id whose claims should be released.
+
+        Returns:
+            Number of tasks reset to open.
+        """
+        if not node_id:
+            return 0
+        reset_count = 0
+        reset_tasks: list[Task] = []
+        for stale_status in (TaskStatus.CLAIMED, TaskStatus.IN_PROGRESS):
+            for task in list(self._by_status.get(stale_status, {}).values()):
+                if task.claimed_by_session != node_id:
+                    continue
+                self._index_remove(task)
+                transition_task(
+                    task,
+                    TaskStatus.OPEN,
+                    actor="task_store",
+                    reason="recover_node_departed",
+                )
+                task.claimed_at = None
+                task.claimed_by_session = None
+                task.version += 1
+                self._index_add(task)
+                reset_tasks.append(task)
+                reset_count += 1
+        if reset_count:
+            for task in reset_tasks:
+                self._append_jsonl_sync(self._task_to_record(task))
+            logger.info(
+                "reopen_tasks_for_node: reset %d task(s) for departed node %s",
+                reset_count,
+                sanitize_log(node_id),
+            )
+        return reset_count
+
     def _append_jsonl_sync(self, record: TaskRecord) -> None:
         """Synchronously append a record to the JSONL log.
 

--- a/tests/unit/test_cluster_node_task_recovery.py
+++ b/tests/unit/test_cluster_node_task_recovery.py
@@ -1,0 +1,202 @@
+"""Regression tests for dead-worker detection and claim recovery (#2801).
+
+When a cluster worker leaves -- by heartbeat timeout (crash) or graceful
+unregister -- the tasks it had claimed must return to OPEN so a surviving
+worker can pick them up, and the node reaper must run in the joinable
+(cluster-auth-off) configuration, not only when cluster mode is enabled.
+"""
+
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest import mock
+
+import pytest
+from bernstein.core.cluster import NodeRegistry
+from bernstein.core.models import ClusterConfig, NodeInfo, NodeStatus
+
+from bernstein.cli.commands.worker_cmd import WorkerLoop
+from bernstein.core.routes.task_cluster import unregister_node
+from bernstein.core.server.server_app import _node_reaper_loop
+from bernstein.core.tasks.models import TaskStatus
+from bernstein.core.tasks.task_store_core import TaskStore
+
+
+def _req(**overrides: Any) -> Any:
+    base: dict[str, Any] = {
+        "title": "T",
+        "description": "D",
+        "role": "backend",
+        "priority": 2,
+        "scope": "medium",
+        "complexity": "medium",
+        "estimated_minutes": 30,
+        "depends_on": [],
+        "owned_files": [],
+        "cell_id": None,
+        "task_type": "standard",
+        "upgrade_details": None,
+        "model": None,
+        "effort": None,
+        "batch_eligible": False,
+        "completion_signals": [],
+        "slack_context": None,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _store(tmp_path: Path) -> TaskStore:
+    return TaskStore(tmp_path / "runtime" / "tasks.jsonl", archive_path=tmp_path / "archive" / "tasks.jsonl")
+
+
+# ---------------------------------------------------------------------------
+# TaskStore.reopen_tasks_for_node
+# ---------------------------------------------------------------------------
+
+
+class TestReopenTasksForNode:
+    @pytest.mark.anyio
+    async def test_releases_only_the_departed_nodes_claims(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        await store.create(_req(title="one"))
+        await store.create(_req(title="two"))
+        # Claim order is by (priority, task_id), so key off the returned tasks
+        # rather than assuming which named task each node received.
+        claimed_a = await store.claim_next("backend", claimed_by_session="node-A")
+        claimed_b = await store.claim_next("backend", claimed_by_session="node-B")
+        assert claimed_a is not None
+        assert claimed_b is not None
+
+        released = store.reopen_tasks_for_node("node-A")
+
+        assert released == 1
+        assert store.get_task(claimed_a.id).status is TaskStatus.OPEN
+        assert store.get_task(claimed_a.id).claimed_by_session is None
+        # Node B's task is untouched.
+        assert store.get_task(claimed_b.id).status is TaskStatus.CLAIMED
+        assert store.get_task(claimed_b.id).claimed_by_session == "node-B"
+
+    @pytest.mark.anyio
+    async def test_noop_for_unknown_or_empty_node(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        await store.create(_req())
+        await store.claim_next("backend", claimed_by_session="node-A")
+        assert store.reopen_tasks_for_node("node-Z") == 0
+        assert store.reopen_tasks_for_node("") == 0
+
+    @pytest.mark.anyio
+    async def test_release_survives_jsonl_replay(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        task = await store.create(_req())
+        await store.claim_next("backend", claimed_by_session="node-A")
+        await store.flush_buffer()
+
+        assert store.reopen_tasks_for_node("node-A") == 1
+
+        fresh = _store(tmp_path)
+        fresh.replay_jsonl()
+        replayed = fresh.get_task(task.id)
+        assert replayed is not None
+        assert replayed.status is TaskStatus.OPEN
+
+
+# ---------------------------------------------------------------------------
+# Node reaper loop: detect stale node AND release its claims
+# ---------------------------------------------------------------------------
+
+
+class TestNodeReaperLoop:
+    @pytest.mark.anyio
+    async def test_stale_node_marked_offline_and_claims_released(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        store = _store(tmp_path)
+        task = await store.create(_req())
+
+        registry = NodeRegistry(ClusterConfig(enabled=False, node_timeout_s=1))
+        node = registry.register(NodeInfo(name="worker-1", url="http://w1:8052"))
+        await store.claim_next("backend", claimed_by_session=node.id)
+        node.last_heartbeat = time.time() - 999  # definitely stale
+
+        # Run exactly one reaper iteration, then cancel.
+        calls = 0
+
+        async def _fake_sleep(_seconds: float) -> None:
+            nonlocal calls
+            calls += 1
+            if calls > 1:
+                raise asyncio.CancelledError
+
+        monkeypatch.setattr(asyncio, "sleep", _fake_sleep)
+        with pytest.raises(asyncio.CancelledError):
+            await _node_reaper_loop(registry, store, interval_s=0.0)
+
+        assert registry.get(node.id) is not None
+        assert registry.get(node.id).status is NodeStatus.OFFLINE
+        assert store.get_task(task.id).status is TaskStatus.OPEN
+
+
+# ---------------------------------------------------------------------------
+# Unregister route: graceful leave releases claims
+# ---------------------------------------------------------------------------
+
+
+class TestUnregisterReleasesClaims:
+    @pytest.mark.anyio
+    async def test_graceful_unregister_reopens_node_tasks(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        task = await store.create(_req())
+        registry = NodeRegistry(ClusterConfig(enabled=False))
+        node = registry.register(NodeInfo(name="worker-1", url="http://w1:8052"))
+        await store.claim_next("backend", claimed_by_session=node.id)
+
+        request = SimpleNamespace(
+            app=SimpleNamespace(
+                state=SimpleNamespace(
+                    cluster_authenticator=None,
+                    node_registry=registry,
+                    store=store,
+                )
+            ),
+            headers={},
+        )
+
+        response = unregister_node(node.id, request)  # type: ignore[arg-type]
+
+        assert response.status_code == 204
+        assert registry.get(node.id) is None
+        assert store.get_task(task.id).status is TaskStatus.OPEN
+
+
+# ---------------------------------------------------------------------------
+# Worker records its node id as the claim owner
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerClaimStampsNode:
+    def test_claim_task_sends_node_id_as_claim_owner(self, tmp_path: Path) -> None:
+        loop = WorkerLoop(server_url="http://central:8052", name="w", adapter="claude", workdir=tmp_path)
+        client = mock.MagicMock()
+        client.get.return_value = mock.MagicMock(status_code=200, json=lambda: {"id": "t-1"})
+
+        loop._claim_task(client, "backend", "node-42")
+
+        _args, kwargs = client.get.call_args
+        assert kwargs["params"] == {"claimed_by_session": "node-42"}
+
+    def test_claim_task_without_node_id_sends_no_params(self, tmp_path: Path) -> None:
+        loop = WorkerLoop(server_url="http://central:8052", name="w", adapter="claude", workdir=tmp_path)
+        client = mock.MagicMock()
+        client.get.return_value = mock.MagicMock(status_code=200, json=lambda: {"id": "t-1"})
+
+        loop._claim_task(client, "backend")
+
+        _args, kwargs = client.get.call_args
+        assert kwargs["params"] is None

--- a/tests/unit/test_spawner_server_url.py
+++ b/tests/unit/test_spawner_server_url.py
@@ -1,0 +1,76 @@
+"""Regression tests for server-URL templating in the agent prompt builders (#2808).
+
+The completion/subtask curl commands embedded in every agent prompt must derive
+their base URL from ``BERNSTEIN_SERVER_URL`` (the value a remote worker exports
+before spawning) rather than a hardcoded ``http://127.0.0.1:8052``. Without this
+an agent on a worker node POSTs completion to its own loopback, where nothing
+listens, and the task can never be marked done. The same literal also breaks a
+local run started on a non-default port.
+"""
+
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from bernstein.core.models import Task
+
+from bernstein.core.agents.spawner_core import (
+    _render_auth_section,
+    _render_batch_prompt,
+    _render_prompt,
+    _resolve_task_server_url,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_LOCAL_DEFAULT = "http://127.0.0.1:8052"
+
+
+def _task() -> Task:
+    return Task(id="T-1", title="Do the thing", description="Body.", role="backend")
+
+
+class TestResolveTaskServerUrl:
+    def test_defaults_to_local_when_env_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("BERNSTEIN_SERVER_URL", raising=False)
+        assert _resolve_task_server_url() == _LOCAL_DEFAULT
+
+    def test_reads_env_and_strips_trailing_slash(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_SERVER_URL", "http://central:9000/")
+        assert _resolve_task_server_url() == "http://central:9000"
+
+
+class TestRenderPromptServerUrl:
+    def test_completion_url_uses_server_env(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_SERVER_URL", "http://central:9000")
+        prompt = _render_prompt([_task()], tmp_path, tmp_path)
+        assert "http://central:9000/tasks/T-1/complete" in prompt
+        assert _LOCAL_DEFAULT not in prompt
+
+    def test_completion_url_defaults_to_local_when_env_unset(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("BERNSTEIN_SERVER_URL", raising=False)
+        prompt = _render_prompt([_task()], tmp_path, tmp_path)
+        assert f"{_LOCAL_DEFAULT}/tasks/T-1/complete" in prompt
+
+
+class TestRenderBatchPromptServerUrl:
+    def test_completion_url_uses_server_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_SERVER_URL", "http://central:9000")
+        prompt = _render_batch_prompt(_task())
+        assert "http://central:9000/tasks/T-1/complete" in prompt
+        assert _LOCAL_DEFAULT not in prompt
+
+
+class TestRenderAuthSectionServerUrl:
+    def test_curl_examples_use_server_env(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_SERVER_URL", "http://central:9000")
+        section = _render_auth_section(tmp_path / "token")
+        assert "POST http://central:9000/tasks" in section
+        assert "http://central:9000/tasks/<TASK_ID>/complete" in section
+        assert _LOCAL_DEFAULT not in section

--- a/tests/unit/test_worker_cmd_model.py
+++ b/tests/unit/test_worker_cmd_model.py
@@ -1,0 +1,126 @@
+"""Regression tests for worker model/adapter propagation (#2804).
+
+A worker started with a non-Claude adapter (e.g. --adapter qwen) used to:
+- discard the claimed task's model / cli / effort / scope / metadata, rebuilding
+  a stripped Task(id, title, description, role);
+- construct its spawner with no default_model, so an unpinned Claude tier name
+  from the role config raised ModelNotConfiguredError on every task;
+- advertise a hardcoded ["sonnet", "opus", "haiku"] capability list unrelated to
+  the adapter it actually runs.
+"""
+
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest import mock
+
+import pytest
+from bernstein.core.models import AgentSession
+
+from bernstein.cli.commands import worker_cmd
+from bernstein.cli.commands.worker_cmd import WorkerLoop
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+RICH_TASK = {
+    "id": "task-77",
+    "title": "Do the thing",
+    "description": "Body.",
+    "role": "backend",
+    "model": "qwen-max",
+    "cli": "qwen",
+    "effort": "high",
+    "scope": "large",
+    "complexity": "high",
+    "priority": 1,
+    "metadata": {"foo": "bar"},
+}
+
+_QWEN_PROFILE = ("qwen-max", ["qwen-max", "qwen-plus", "qwen-turbo"])
+
+
+def _patch_qwen_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(worker_cmd, "_adapter_model_profile", lambda name: _QWEN_PROFILE)
+
+
+def _spawn_patches() -> tuple[mock._patch, mock._patch]:
+    return (
+        mock.patch("bernstein.adapters.registry.get_adapter", return_value=mock.MagicMock()),
+        mock.patch("bernstein.core.agents.spawner.AgentSpawner", autospec=True),
+    )
+
+
+class TestSpawnCarriesTaskFields:
+    def test_spawn_builds_task_from_full_dict(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_qwen_profile(monkeypatch)
+        loop = WorkerLoop(server_url="http://central:8052", adapter="qwen", workdir=tmp_path)
+        session = AgentSession(id="qwen-1", role="backend", pid=1234)
+        get_adapter_patch, spawner_patch = _spawn_patches()
+        with get_adapter_patch, spawner_patch as spawner_cls:
+            spawner_cls.return_value.spawn_for_tasks.return_value = session
+            loop._spawn_agent(RICH_TASK)
+
+        (tasks,) = spawner_cls.return_value.spawn_for_tasks.call_args.args
+        task = tasks[0]
+        assert task.id == "task-77"
+        assert task.model == "qwen-max"
+        assert task.cli == "qwen"
+        assert task.effort == "high"
+        assert task.scope.value == "large"
+        assert task.complexity.value == "high"
+        assert task.priority == 1
+        assert task.metadata == {"foo": "bar"}
+
+
+class TestSpawnDefaultModel:
+    def test_non_claude_default_from_discovery(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_qwen_profile(monkeypatch)
+        loop = WorkerLoop(server_url="http://central:8052", adapter="qwen", workdir=tmp_path)
+        assert loop._spawn_default_model == "qwen-max"
+
+    def test_model_flag_overrides_discovery(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_qwen_profile(monkeypatch)
+        loop = WorkerLoop(server_url="http://central:8052", adapter="qwen", model="MiniMax-M3", workdir=tmp_path)
+        assert loop._spawn_default_model == "MiniMax-M3"
+
+    def test_claude_default_is_left_unset(self, tmp_path: Path) -> None:
+        loop = WorkerLoop(server_url="http://central:8052", adapter="claude", workdir=tmp_path)
+        assert loop._spawn_default_model is None
+
+    def test_spawn_passes_default_model_to_spawner(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_qwen_profile(monkeypatch)
+        loop = WorkerLoop(server_url="http://central:8052", adapter="qwen", workdir=tmp_path)
+        session = AgentSession(id="qwen-1", role="backend", pid=1234)
+        get_adapter_patch, spawner_patch = _spawn_patches()
+        with get_adapter_patch, spawner_patch as spawner_cls:
+            spawner_cls.return_value.spawn_for_tasks.return_value = session
+            loop._spawn_agent(dict(RICH_TASK, model=None))
+
+        assert spawner_cls.call_args.kwargs["default_model"] == "qwen-max"
+
+
+class TestSupportedModelsAdvertised:
+    def test_claude_advertises_tier_names(self, tmp_path: Path) -> None:
+        loop = WorkerLoop(server_url="http://central:8052", adapter="claude", workdir=tmp_path)
+        assert loop._supported_models == ["sonnet", "opus", "haiku"]
+
+    def test_non_claude_advertises_discovered_models(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_qwen_profile(monkeypatch)
+        loop = WorkerLoop(server_url="http://central:8052", adapter="qwen", workdir=tmp_path)
+        assert loop._supported_models == ["qwen-max", "qwen-plus", "qwen-turbo"]
+        assert "sonnet" not in loop._supported_models
+
+    def test_register_payload_uses_supported_models(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_qwen_profile(monkeypatch)
+        loop = WorkerLoop(server_url="http://central:8052", adapter="qwen", workdir=tmp_path)
+        client = mock.MagicMock()
+        client.post.return_value = mock.MagicMock(status_code=201, json=lambda: {"id": "n1"})
+
+        node_id = loop._register(client)
+
+        assert node_id == "n1"
+        payload = client.post.call_args.kwargs["json"]
+        assert payload["capacity"]["supported_models"] == ["qwen-max", "qwen-plus", "qwen-turbo"]

--- a/tests/unit/test_worker_cmd_reporting.py
+++ b/tests/unit/test_worker_cmd_reporting.py
@@ -1,0 +1,124 @@
+"""Regression tests for worker-side terminal-state reporting (#2808).
+
+Before this fix, ``WorkerLoop._complete_task`` / ``_fail_task`` had zero call
+sites: a worker reaped a finished agent's PID (freeing the slot) but never told
+the server, so a remotely executed task stayed CLAIMED forever regardless of
+whether the in-agent completion curl fired. ``_reap_finished`` now records a
+terminal outcome per reaped agent (success/failure from the exit code) and
+``_report_finished`` drains those to ``/complete`` / ``/fail``.
+"""
+
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest import mock
+
+import pytest
+
+from bernstein.cli.commands import worker_cmd
+from bernstein.cli.commands.worker_cmd import WorkerLoop
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _make_loop(tmp_path: Path) -> WorkerLoop:
+    return WorkerLoop(
+        server_url="http://central:8052",
+        name="test-node",
+        auth_token="secret-token",
+        adapter="claude",
+        workdir=tmp_path,
+    )
+
+
+class TestReapEnqueuesTerminalOutcome:
+    def test_clean_exit_enqueues_completion(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        loop = _make_loop(tmp_path)
+        loop._active_tasks = {"task-1": 111}
+        monkeypatch.setattr(worker_cmd.os, "waitpid", lambda pid, flags: (pid, 0))
+        monkeypatch.setattr(worker_cmd.os, "waitstatus_to_exitcode", lambda status: 0)
+
+        assert loop._reap_finished() is True
+        assert loop._active_tasks == {}
+        assert loop._pending_reports == [("task-1", True, "agent exited with code 0")]
+
+    def test_nonzero_exit_enqueues_failure(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        loop = _make_loop(tmp_path)
+        loop._active_tasks = {"task-2": 222}
+        monkeypatch.setattr(worker_cmd.os, "waitpid", lambda pid, flags: (pid, 3 << 8))
+        monkeypatch.setattr(worker_cmd.os, "waitstatus_to_exitcode", lambda status: 3)
+
+        assert loop._reap_finished() is True
+        assert loop._pending_reports == [("task-2", False, "agent exited with code 3")]
+
+    def test_signal_kill_enqueues_failure(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        loop = _make_loop(tmp_path)
+        loop._active_tasks = {"task-3": 333}
+        monkeypatch.setattr(worker_cmd.os, "waitpid", lambda pid, flags: (pid, 9))
+        monkeypatch.setattr(worker_cmd.os, "waitstatus_to_exitcode", lambda status: -9)
+
+        assert loop._reap_finished() is True
+        assert loop._pending_reports == [("task-3", False, "agent exited with code -9")]
+
+    def test_still_running_agent_is_not_reaped(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        loop = _make_loop(tmp_path)
+        loop._active_tasks = {"task-4": 444}
+        monkeypatch.setattr(worker_cmd.os, "waitpid", lambda pid, flags: (0, 0))
+        monkeypatch.setattr(
+            "bernstein.core.platform_compat.process_alive",
+            lambda pid: True,
+        )
+
+        assert loop._reap_finished() is False
+        assert loop._active_tasks == {"task-4": 444}
+        assert loop._pending_reports == []
+
+    def test_already_reaped_child_enqueues_completion(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        loop = _make_loop(tmp_path)
+        loop._active_tasks = {"task-5": 555}
+
+        def _raise(pid: int, flags: int) -> tuple[int, int]:
+            raise ChildProcessError
+
+        monkeypatch.setattr(worker_cmd.os, "waitpid", _raise)
+
+        assert loop._reap_finished() is True
+        assert loop._pending_reports == [("task-5", True, "worker reaped agent process (exit status unavailable)")]
+
+
+class TestReportFinished:
+    def test_drains_queue_to_complete_and_fail(self, tmp_path: Path) -> None:
+        loop = _make_loop(tmp_path)
+        loop._pending_reports = [("t-ok", True, "done"), ("t-bad", False, "boom")]
+        client = mock.MagicMock()
+
+        loop._report_finished(client)
+
+        posted = {call.args[0]: call.kwargs.get("json") for call in client.post.call_args_list}
+        assert posted["http://central:8052/tasks/t-ok/complete"] == {"result_summary": "done"}
+        assert posted["http://central:8052/tasks/t-bad/fail"] == {"reason": "boom"}
+        # The queue is drained so a later cycle does not double-report.
+        assert loop._pending_reports == []
+
+    def test_noop_when_queue_empty(self, tmp_path: Path) -> None:
+        loop = _make_loop(tmp_path)
+        client = mock.MagicMock()
+        loop._report_finished(client)
+        client.post.assert_not_called()
+
+    def test_reap_then_report_drives_completion(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """End-to-end: a reaped clean exit reaches the server's /complete route."""
+        loop = _make_loop(tmp_path)
+        loop._active_tasks = {"task-9": 999}
+        monkeypatch.setattr(worker_cmd.os, "waitpid", lambda pid, flags: (pid, 0))
+        monkeypatch.setattr(worker_cmd.os, "waitstatus_to_exitcode", lambda status: 0)
+        client = mock.MagicMock()
+
+        loop._reap_finished()
+        loop._report_finished(client)
+
+        (call,) = client.post.call_args_list
+        assert call.args[0] == "http://central:8052/tasks/task-9/complete"


### PR DESCRIPTION
## What
Three cluster worker/coordinator loop fixes for milestone v3.8.4, one commit per issue.

Fixes #2808
Fixes #2801
Fixes #2804

## Per issue
- **#2808 remote completion structurally impossible**: prompt builders interpolated a hardcoded `http://127.0.0.1:8052` completion URL, and the worker loop never reported terminal state. A module-level resolver now reads `BERNSTEIN_SERVER_URL` (localhost stays the fallback) across all four curl sites, and `_reap_finished` derives and reports a terminal outcome per reaped process.
- **#2801 dead workers never detected**: the node reaper only started behind a gate that never fired in practice. It now starts unconditionally with the `/cluster/nodes` routes, receives the TaskStore, and the worker records its node id as the claim owner — so reaping a dead node requeues its claimed tasks.
- **#2804 worker discards task model/adapter**: the worker rebuilt tasks lossily and refused non-Claude adapters. `_spawn_agent` now reconstructs the full `Task` via `Task.from_dict` (per-step model/cli/effort/scope/metadata honored), and a new `--model` worker flag plus an adapter-model profile resolve sensible defaults for non-Claude adapters.

## Verification
- All three defects reproduced on origin/main before fixing (TDD, red evidence kept).
- Targeted runs green: spawn/token/batch set 29 passed; node-reaper set 55 passed; server lifespan 122 passed; worker/cluster CLI set 65 passed.
- Import sentinel: 37815 collected, no errors.