### PR TITLE
fix(core): stop auto-completing unverified exits, cap retry storms, and resume open work after stop

### DIFF
--- a/src/bernstein/cli/commands/stop_cmd.py
+++ b/src/bernstein/cli/commands/stop_cmd.py
@@ -198,11 +198,16 @@ def save_session_on_stop(workdir: Path) -> None:
             task_list: list[dict[str, Any]] = []
         done_ids = [t["id"] for t in task_list if t.get("status") == "done"]
         pending_ids = [t["id"] for t in task_list if t.get("status") in ("claimed", "in_progress")]
+        # Persist still-open tasks too (issue #2798): they were dropped
+        # entirely before, so a resumed run had no record of the work queued
+        # when the operator stopped it and could self-declare complete.
+        open_ids = [t["id"] for t in task_list if t.get("status") == "open"]
         state = SessionState(
             saved_at=time.time(),
             goal="",
             completed_task_ids=done_ids,
             pending_task_ids=pending_ids,
+            open_task_ids=open_ids,
             cost_spent=0.0,
         )
         save_session(workdir, state)

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -1551,6 +1551,17 @@ def exec_restart() -> None:
     ),
 )
 @click.option(
+    "--fresh",
+    "force_fresh",
+    is_flag=True,
+    default=False,
+    help=(
+        "Ignore any saved session (.sdd/runtime/session.json) and start from "
+        "scratch instead of resuming. Use after a stopped run to force a full "
+        "re-plan rather than resuming the prior session (issue #2798)."
+    ),
+)
+@click.option(
     "--refresh-cache",
     "refresh_cache",
     is_flag=True,
@@ -2003,6 +2014,7 @@ def _run_impl(
                     model=model,
                     tasks=tasks,
                     ab_test=ab_test,
+                    force_fresh=force_fresh,
                 )
                 persist_server_port(port, workdir)
 

--- a/src/bernstein/core/agents/agent_lifecycle.py
+++ b/src/bernstein/core/agents/agent_lifecycle.py
@@ -1746,40 +1746,59 @@ def _handle_orphan_no_signals(
         )
         return _try_auto_complete(orch, task_id, base, summary, log_msg, session=session, start_ts=start_ts)
     if clean_exit:
-        # A very short-lived "successful" agent that changed nothing is a
-        # defect signal, not health: run-9 attempt-7's manager exited 0
-        # after ~3s with zero tools and zero child tasks, and the
-        # auto-complete below made the run self-declare healthy.
-        # _probe_fast_exit() always runs for a clean exit and returns the
-        # full structured diagnostic (exit code, manifest path, log tail) -
-        # logged at ERROR when suspicious - instead of the bare
-        # WARNING-and-move-on this used to be.
-        # The probe's structured diagnostic is logged internally (ERROR when
-        # suspicious); the auto-complete summary text is left unchanged so
-        # existing consumers of the completion message are unaffected -
-        # operators get the diagnostic from the log, not a mutated summary.
+        # A clean exit (code 0) with an empty diff and no completion signals is
+        # only a genuine "no changes needed" completion when the agent actually
+        # ran long enough to have done the work. _probe_fast_exit() flags a
+        # *suspicious* fast exit (runtime below _FAST_EXIT_THRESHOLD_S): the
+        # agent likely never started real work (no tools, immediate exit) or its
+        # tracked process exited in a way that merely looked clean while the
+        # deliverable was never merged. Marking such a task ``done`` records a
+        # deliverable that exists in no ref and makes the run self-declare
+        # healthy (issues #2810, #2806); it also races an in-flight merge/verify
+        # step that may still land the real diff a moment later. Fail/unverify a
+        # suspicious fast clean exit instead of auto-completing it, so the run
+        # surfaces UNHEALTHY and the lineage can retry or reach the DLQ.
         _probe_result = _probe_fast_exit(orch, session, task_id)
-        summary = (
-            f"Auto-completed (no changes needed): agent {session.id} "
-            f"exited cleanly with empty diff (exit code 0, no signals to verify)"
-        )
-        log_msg = (
-            f"Orphaned task {task_id} auto-completed (no changes needed, clean exit) after agent {session.id} died"
-        )
-        _result = _try_auto_complete(orch, task_id, base, summary, log_msg, session=session, start_ts=start_ts)
-        if _probe_result.get("suspicious"):
-            logger.warning(
-                "SUSPICIOUS auto-complete: agent %s auto-completed task %s after only %.1fs "
-                "clean exit with no files modified, no commits, and no completion signals - "
-                "this is a defect signal, not health. See preserved logs under "
-                ".sdd/runtime/agent_logs/%s/ for the full transcript (manifest=%s).",
-                session.id,
-                task_id,
-                _probe_result.get("runtime_s"),
-                session.id,
-                _probe_result.get("manifest_path") or "<none preserved>",
+        if not _probe_result.get("suspicious"):
+            # Long-lived clean exit: the agent had time to do real work and
+            # decided nothing needed changing. Record that as a completion.
+            summary = (
+                f"Auto-completed (no changes needed): agent {session.id} "
+                f"exited cleanly with empty diff (exit code 0, no signals to verify)"
             )
-        return _result
+            log_msg = (
+                f"Orphaned task {task_id} auto-completed (no changes needed, clean exit) "
+                f"after agent {session.id} died"
+            )
+            return _try_auto_complete(orch, task_id, base, summary, log_msg, session=session, start_ts=start_ts)
+
+        logger.warning(
+            "SUSPICIOUS clean exit: agent %s exited cleanly (exit code 0) after only %.1fs "
+            "with no files modified, no commits, and no completion signals -- NOT "
+            "auto-completing task %s; failing it as unverified. A fast empty clean exit is a "
+            "defect signal, not health. See preserved logs under .sdd/runtime/agent_logs/%s/ "
+            "for the full transcript (manifest=%s).",
+            session.id,
+            _probe_result.get("runtime_s"),
+            task_id,
+            session.id,
+            _probe_result.get("manifest_path") or "<none preserved>",
+        )
+        try:
+            retry_or_fail_task(
+                task_id,
+                f"Agent {session.id} exited cleanly but produced no verified deliverable "
+                f"(empty diff, no commits, no completion signals)",
+                client=orch._client,
+                server_url=base,
+                max_task_retries=orch._config.max_task_retries,
+                retried_task_ids=orch._retried_task_ids,
+                workdir=getattr(orch, "_workdir", None),
+                **_retry_escalation_context(orch),
+            )
+        except httpx.HTTPError as exc:
+            logger.error("Failed to retry/fail unverified clean-exit task %s: %s", task_id, exc)
+        return False, "clean_exit_unverified"
 
     # Before declaring "died without output", check every liveness signal --
     # a double-forked/re-exec'd runner's tracked PID can exit in seconds while

--- a/src/bernstein/core/agents/agent_lifecycle.py
+++ b/src/bernstein/core/agents/agent_lifecycle.py
@@ -1767,8 +1767,7 @@ def _handle_orphan_no_signals(
                 f"exited cleanly with empty diff (exit code 0, no signals to verify)"
             )
             log_msg = (
-                f"Orphaned task {task_id} auto-completed (no changes needed, clean exit) "
-                f"after agent {session.id} died"
+                f"Orphaned task {task_id} auto-completed (no changes needed, clean exit) after agent {session.id} died"
             )
             return _try_auto_complete(orch, task_id, base, summary, log_msg, session=session, start_ts=start_ts)
 

--- a/src/bernstein/core/orchestration/bootstrap.py
+++ b/src/bernstein/core/orchestration/bootstrap.py
@@ -480,11 +480,20 @@ def _sync_and_plan_tasks(
     )
 
     manager_task_id = ""
-    if prior_session is not None:
+    # Resume reconcile (#2798): only short-circuit planning when the prior
+    # session actually finished its queued work. A session stopped mid-flight
+    # (open/pending tasks that the wiped runtime queue no longer holds) must
+    # NOT resume as "done previously" -- that let the run self-declare complete
+    # with the deliverable unproduced and the queued work silently dropped.
+    # Fall through to work the backlog or re-plan the goal instead.
+    if prior_session is not None and not prior_session.has_unfinished_work():
         console.print(f"  [dim]resume[/dim]  {len(prior_session.completed_task_ids)} done previously")
     elif backlog_count > 0:
-        console.print(f"  [dim]tasks[/dim]   {backlog_count} from backlog")
+        _suffix = " (resuming interrupted run)" if prior_session is not None else ""
+        console.print(f"  [dim]tasks[/dim]   {backlog_count} from backlog{_suffix}")
     else:
+        if prior_session is not None:
+            console.print("  [dim]replan[/dim]  interrupted run had unfinished work; re-planning the goal")
         if worker_role:
             manager_task_id = _inject_worker_task(
                 seed,
@@ -1126,7 +1135,11 @@ def _goal_sync_and_plan(
         )
 
     manager_task_id = ""
-    if prior_session is not None:
+    # Resume reconcile (#2798): only short-circuit when the prior session
+    # finished its queued work. A run stopped mid-flight (open/pending tasks the
+    # wiped runtime queue no longer holds) must re-plan rather than resume as
+    # complete with the deliverable unproduced.
+    if prior_session is not None and not prior_session.has_unfinished_work():
         completed_count = len(prior_session.completed_task_ids)
         console.print(
             f"[bold cyan]Resuming from previous session[/bold cyan] "
@@ -1142,6 +1155,11 @@ def _goal_sync_and_plan(
             + ")"
         )
     else:
+        if prior_session is not None:
+            console.print(
+                f"[green]{icons.arrow_right}[/green] Previous run was interrupted with unfinished "
+                "work - re-planning the goal"
+            )
         with Status("[bold]Creating planning task...[/bold]", console=console):
             manager_task_id = _inject_manager_task(
                 seed,

--- a/src/bernstein/core/orchestration/orchestrator_cleanup.py
+++ b/src/bernstein/core/orchestration/orchestrator_cleanup.py
@@ -137,16 +137,25 @@ def save_session_state(orch: Any) -> None:
 
         done_ids: list[str] = [str(t["id"]) for t in task_list if t.get("status") == "done"]
         pending_ids: list[str] = [str(t["id"]) for t in task_list if t.get("status") in ("claimed", "in_progress")]
+        # Capture still-open tasks too (issue #2798): dropping them made a
+        # resumed run look finished when it had been paused mid-flight.
+        open_ids: list[str] = [str(t["id"]) for t in task_list if t.get("status") == "open"]
 
         state = SessionState(
             saved_at=time.time(),
             goal="",
             completed_task_ids=done_ids,
             pending_task_ids=pending_ids,
+            open_task_ids=open_ids,
             cost_spent=orch._cost_tracker.spent_usd,
         )
         save_session(orch._workdir, state)
-        logger.info("Session state saved (%d done, %d pending)", len(done_ids), len(pending_ids))
+        logger.info(
+            "Session state saved (%d done, %d pending, %d open)",
+            len(done_ids),
+            len(pending_ids),
+            len(open_ids),
+        )
     except Exception:
         logger.debug("Failed to save session state (best-effort)", exc_info=True)
 

--- a/src/bernstein/core/persistence/session.py
+++ b/src/bernstein/core/persistence/session.py
@@ -41,6 +41,11 @@ class SessionState:
         goal: The goal or description for this run.
         completed_task_ids: Task IDs that finished successfully this run.
         pending_task_ids: Task IDs that were claimed or in-progress when stopped.
+        open_task_ids: Task IDs that were still ``open`` (queued but not yet
+            claimed) when stopped. Persisted so a resumed run can tell it was
+            paused mid-flight rather than finished (issue #2798); dropping them
+            let a resume declare the run complete with the deliverable
+            unproduced.
         cost_spent: Cumulative USD cost accumulated this run.
     """
 
@@ -48,7 +53,18 @@ class SessionState:
     goal: str = ""
     completed_task_ids: list[str] = field(default_factory=list[str])
     pending_task_ids: list[str] = field(default_factory=list[str])
+    open_task_ids: list[str] = field(default_factory=list[str])
     cost_spent: float = 0.0
+
+    def has_unfinished_work(self) -> bool:
+        """Return True if the run was stopped with work still queued.
+
+        Open or pending (claimed/in-progress) tasks at stop time mean the run
+        was paused mid-flight. A resume must not treat such a session as a
+        completed run (issue #2798) -- there is still work to do even though
+        the runtime task queue was cleared on the next start.
+        """
+        return bool(self.open_task_ids or self.pending_task_ids)
 
     def is_stale(self, stale_minutes: int = DEFAULT_STALE_MINUTES) -> bool:
         """Return True if this session is too old to resume.
@@ -85,6 +101,7 @@ class SessionState:
             goal=str(data.get("goal", "")),
             completed_task_ids=list(data.get("completed_task_ids", [])),  # type: ignore[arg-type]
             pending_task_ids=list(data.get("pending_task_ids", [])),  # type: ignore[arg-type]
+            open_task_ids=list(data.get("open_task_ids", [])),  # type: ignore[arg-type]
             cost_spent=float(data.get("cost_spent", 0.0)),  # type: ignore[arg-type]
         )
 

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -514,7 +514,15 @@ def maybe_retry_task(
     # in the title until they complete, but the counter they report is the
     # typed field - never the regex match.
     retry_count = task.retry_count
-    effective_max = min(task.max_retries, max_task_retries) if max_task_retries > 0 else task.max_retries
+    # Apply the same _MAX_REGULAR_TASK_RETRIES hard ceiling that
+    # retry_or_fail_task uses (issue #2806). The two retry paths -- this
+    # tick-loop path and the reap path -- must agree on the cap; otherwise a
+    # structurally-dead lineage that the reap path would dead-letter keeps
+    # getting retried here, exceeding the intended ceiling.
+    if max_task_retries > 0:
+        effective_max = min(task.max_retries, max_task_retries, _MAX_REGULAR_TASK_RETRIES)
+    else:
+        effective_max = min(task.max_retries, _MAX_REGULAR_TASK_RETRIES)
 
     if retry_count >= effective_max:
         quarantine.record_failure(task.title, "Max retries exhausted")
@@ -1778,6 +1786,32 @@ def _clear_claim_conflict_state(orch: Any, task_id: str) -> None:
         state.pop(task_id, None)
 
 
+def _lineage_id(task: Task) -> str:
+    """Return the task's lineage id: ``metadata["original_task_id"]`` or its id.
+
+    Every retry created by ``maybe_retry_task`` / ``retry_or_fail_task`` stamps
+    ``metadata["original_task_id"]`` with the lineage root, so grouping by this
+    value keeps a task and all its retries under one stable key even though each
+    retry has a fresh task id.
+    """
+    metadata = task.metadata
+    if isinstance(metadata, dict):
+        original = metadata.get("original_task_id")
+        if isinstance(original, str) and original:
+            return original
+    return task.id
+
+
+def _batch_lineage_key(batch: list[Task]) -> frozenset[str]:
+    """Lineage-stable spawn-backoff key for a batch (issue #2806).
+
+    Keyed on each task's lineage id rather than its ephemeral task id so the
+    spawn-failure counter and exponential backoff accumulate across retries
+    instead of resetting every time a retry mints a new id.
+    """
+    return frozenset(_lineage_id(t) for t in batch)
+
+
 def claim_and_spawn_batches(
     orch: Any,  # Orchestrator instance (avoids circular import)
     batches: list[list[Task]],
@@ -1961,8 +1995,15 @@ def claim_and_spawn_batches(
                 )
                 continue
 
-        # Check spawn backoff: skip batches that recently failed
-        batch_key = frozenset(t.id for t in batch)
+        # Check spawn backoff: skip batches that recently failed.
+        # Key on the task *lineage* (metadata["original_task_id"], falling back
+        # to the task id) rather than the current attempt's ids: a retry mints a
+        # brand-new task id, so an id-keyed backoff resets fail_count to 0 on
+        # every attempt and the _MAX_SPAWN_FAILURES ceiling never accumulates
+        # against a repeating spawn failure (issue #2806). Keying on the lineage
+        # makes the consecutive-failure counter and exponential backoff
+        # accumulate across retries so a structurally-dead spawn fails fast.
+        batch_key = _batch_lineage_key(batch)
         fail_count, last_fail_ts = orch._spawn_failures.get(batch_key, (0, 0.0))
         failure_history = spawn_failure_history.get(batch_key, [])
         # Exponential backoff: base * 2^(failures-1), capped at max

--- a/tests/unit/agents/test_agent_lifecycle_helpers.py
+++ b/tests/unit/agents/test_agent_lifecycle_helpers.py
@@ -416,31 +416,45 @@ def _orphan_orch(tmp_path: Path) -> SimpleNamespace:
         _workdir=tmp_path,
         _client=MagicMock(),
         _spawner=SimpleNamespace(get_worktree_path=lambda sid: None),
+        _config=SimpleNamespace(max_task_retries=3),
+        _retried_task_ids=set(),
     )
 
 
-def test_short_lived_clean_exit_auto_complete_warns(
+def test_suspicious_clean_exit_is_failed_not_auto_completed(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A <60s 'no changes needed' auto-complete emits a defect-signal WARNING."""
+    """A <60s clean exit with an empty diff and no signals must NOT be marked done.
+
+    Regression for #2810 / #2806: a fast clean exit was auto-completed to
+    ``done`` even though no deliverable was produced (and the run then
+    self-declared healthy). Such a task must route to fail/unverified.
+    """
     import logging
     import time as _time
 
     import bernstein.core.agents.agent_lifecycle as al
 
     monkeypatch.setattr(al, "collect_completion_data", lambda workdir, session: {"files_modified": []})
-    monkeypatch.setattr(al, "complete_task", lambda client, base, task_id, summary: None)
+    completed: list[str] = []
+    monkeypatch.setattr(al, "complete_task", lambda client, base, task_id, summary: completed.append(task_id))
+    failed: list[tuple[str, str]] = []
+    monkeypatch.setattr(al, "retry_or_fail_task", lambda task_id, reason, **kw: failed.append((task_id, reason)))
+
     session = _session(exit_code=0)
     session.spawn_ts = _time.time() - 3.0
     with caplog.at_level(logging.WARNING):
         success, error_type = al._handle_orphan_no_signals(
             _orphan_orch(tmp_path), MagicMock(), "T-1", session, "http://srv", _time.time()
         )
-    assert success is True
-    assert error_type is None
-    warning = next(r for r in caplog.records if "SUSPICIOUS auto-complete" in r.message)
+    # Task is NOT completed; it is failed/unverified instead.
+    assert success is False
+    assert error_type == "clean_exit_unverified"
+    assert completed == []
+    assert failed and failed[0][0] == "T-1"
+    warning = next(r for r in caplog.records if "SUSPICIOUS clean exit" in r.message)
     assert "A-1" in warning.message
     assert "agent_logs" in warning.message
 

--- a/tests/unit/test_agent_lifecycle.py
+++ b/tests/unit/test_agent_lifecycle.py
@@ -227,8 +227,16 @@ def test_orphaned_task_completes_on_git_commits(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_orphaned_task_completes_on_clean_exit(tmp_path: Path) -> None:
-    """Task is auto-completed when agent exited with code 0."""
+def test_orphaned_task_completes_on_long_lived_clean_exit(tmp_path: Path) -> None:
+    """A long-lived agent that exits cleanly with an empty diff is a genuine
+    "no changes needed" completion and is auto-completed.
+
+    The distinction from a suspicious fast exit is runtime: an agent that ran
+    well past the fast-exit threshold before exiting 0 had time to do real
+    work and decide nothing was needed.
+    """
+    import time as _time
+
     task = _make_task()
     task.status = TaskStatus.CLAIMED
     session = AgentSession(
@@ -238,6 +246,7 @@ def test_orphaned_task_completes_on_clean_exit(tmp_path: Path) -> None:
         model_config=ModelConfig("sonnet", "high"),
         task_ids=[task.id],
         exit_code=0,  # Clean exit
+        spawn_ts=_time.time() - 300.0,  # long-lived -> not a suspicious fast exit
     )
     orch = _make_orch_no_ratelimit(tmp_path)
 
@@ -257,6 +266,39 @@ def test_orphaned_task_completes_on_clean_exit(tmp_path: Path) -> None:
         f"exited cleanly with empty diff (exit code 0, no signals to verify)",
     )
     mock_retry.assert_not_called()
+
+
+def test_orphaned_task_fails_on_suspicious_fast_clean_exit(tmp_path: Path) -> None:
+    """A short-lived clean exit with an empty diff must NOT be marked done.
+
+    Regression for #2810 / #2806: a fast clean exit (below the fast-exit
+    threshold) with no files, no commits, and no completion signals is a
+    defect signal, not a real completion. It must route to fail/unverified
+    so the run surfaces UNHEALTHY instead of self-declaring healthy with a
+    deliverable that exists in no ref.
+    """
+    task = _make_task()
+    task.status = TaskStatus.CLAIMED
+    session = AgentSession(
+        id="sess-fast",
+        role="backend",
+        provider="claude",
+        model_config=ModelConfig("sonnet", "high"),
+        task_ids=[task.id],
+        exit_code=0,  # Clean exit, but fresh spawn_ts -> suspicious fast exit
+    )
+    orch = _make_orch_no_ratelimit(tmp_path)
+
+    with (
+        patch("bernstein.core.agents.agent_lifecycle.collect_completion_data", return_value={"files_modified": []}),
+        patch("bernstein.core.agents.agent_lifecycle._has_git_commits_on_branch", return_value=False),
+        patch("bernstein.core.agents.agent_lifecycle.complete_task") as mock_complete,
+        patch("bernstein.core.agents.agent_lifecycle.retry_or_fail_task") as mock_retry,
+    ):
+        handle_orphaned_task(orch, task.id, session, {"claimed": [task], "open": [], "in_progress": [], "done": []})
+
+    mock_complete.assert_not_called()
+    mock_retry.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
+import time
 import types
 from contextlib import ExitStack
 from pathlib import Path
@@ -152,6 +153,112 @@ def test_bootstrap_from_seed_skips_manager_when_backlog_tasks_exist(
         stack.enter_context(patch("bernstein.core.orchestration.bootstrap.supervised_server", return_value=111))
         stack.enter_context(patch("bernstein.core.orchestration.bootstrap._wait_for_server", return_value=True))
         stack.enter_context(patch("bernstein.core.session.check_resume_session", return_value=None))
+        stack.enter_context(patch("bernstein.core.sync.sync_backlog_to_server", return_value=sync_result))
+        mock_inject = stack.enter_context(patch("bernstein.core.orchestration.bootstrap._inject_manager_task"))
+        stack.enter_context(patch("bernstein.core.cost.cost.estimate_run_cost", return_value=(1.0, 2.0)))
+        stack.enter_context(patch("bernstein.core.orchestration.bootstrap._start_spawner", return_value=222))
+        stack.enter_context(patch("bernstein.core.orchestration.bootstrap._start_watchdog", return_value=333))
+        result = bootstrap_from_seed(tmp_path / "bernstein.yaml", tmp_path)
+
+    assert result.manager_task_id == ""
+    mock_inject.assert_not_called()
+
+
+def test_bootstrap_from_seed_replans_when_prior_session_has_unfinished_work(
+    tmp_path: Path,
+    invariants_module: types.ModuleType,
+) -> None:
+    """A resumed session stopped mid-flight re-plans instead of short-circuiting.
+
+    Regression for #2798: a prior session with open/pending tasks (the run was
+    paused, not finished) used to short-circuit planning and let the run
+    self-declare complete with no deliverable. It must inject a manager task to
+    re-plan the goal instead.
+    """
+    from bernstein.core.session import SessionState
+
+    prior = SessionState(
+        saved_at=time.time(),
+        goal="Ship the parser",
+        completed_task_ids=["T-done"],
+        open_task_ids=["T-open"],  # unfinished work queued when stopped
+    )
+    sync_result = SimpleNamespace(created=[], skipped=[])  # empty backlog
+
+    with ExitStack() as stack:
+        stack.enter_context(patch.dict(sys.modules, {"bernstein.evolution.invariants": invariants_module}))
+        stack.enter_context(patch("bernstein.core.orchestration.bootstrap.console", MagicMock()))
+        stack.enter_context(
+            patch("bernstein.core.orchestration.bootstrap.concurrent.futures.ThreadPoolExecutor", _Executor)
+        )
+        stack.enter_context(patch("bernstein.core.orchestration.bootstrap.parse_seed", return_value=_seed()))
+        stack.enter_context(patch("bernstein.core.orchestration.bootstrap.preflight_checks"))
+        stack.enter_context(patch("bernstein.core.orchestration.bootstrap.ensure_sdd"))
+        stack.enter_context(patch("bernstein.core.orchestration.bootstrap._clean_stale_runtime"))
+        stack.enter_context(patch("bernstein.core.orchestration.bootstrap._discover_catalog"))
+        stack.enter_context(patch("bernstein.core.orchestration.bootstrap._build_codebase_index"))
+        stack.enter_context(
+            patch("bernstein.core.orchestration.bootstrap._resolve_bind_host", return_value="127.0.0.1")
+        )
+        stack.enter_context(patch("bernstein.core.orchestration.bootstrap._resolve_auth_token", return_value=None))
+        stack.enter_context(
+            patch("bernstein.core.orchestration.bootstrap._resolve_server_url", return_value="http://server")
+        )
+        stack.enter_context(patch("bernstein.core.orchestration.bootstrap.supervised_server", return_value=111))
+        stack.enter_context(patch("bernstein.core.orchestration.bootstrap._wait_for_server", return_value=True))
+        stack.enter_context(patch("bernstein.core.session.check_resume_session", return_value=prior))
+        stack.enter_context(patch("bernstein.core.sync.sync_backlog_to_server", return_value=sync_result))
+        mock_inject = stack.enter_context(
+            patch("bernstein.core.orchestration.bootstrap._inject_manager_task", return_value="mgr-1")
+        )
+        stack.enter_context(patch("bernstein.core.cost.cost.estimate_run_cost", return_value=(1.0, 2.0)))
+        stack.enter_context(patch("bernstein.core.orchestration.bootstrap._start_spawner", return_value=222))
+        stack.enter_context(patch("bernstein.core.orchestration.bootstrap._start_watchdog", return_value=333))
+        result = bootstrap_from_seed(tmp_path / "bernstein.yaml", tmp_path)
+
+    # The interrupted run re-plans: a manager task is injected rather than the
+    # empty manager_task_id a bare "done previously" resume would leave.
+    assert result.manager_task_id == "mgr-1"
+    mock_inject.assert_called_once()
+
+
+def test_bootstrap_from_seed_resumes_when_prior_session_finished(
+    tmp_path: Path,
+    invariants_module: types.ModuleType,
+) -> None:
+    """A prior session that finished its queued work still short-circuits planning."""
+    from bernstein.core.session import SessionState
+
+    prior = SessionState(
+        saved_at=time.time(),
+        goal="Ship the parser",
+        completed_task_ids=["T-done-1", "T-done-2"],
+        # no open / pending -> the run finished its queued work
+    )
+    sync_result = SimpleNamespace(created=[], skipped=[])
+
+    with ExitStack() as stack:
+        stack.enter_context(patch.dict(sys.modules, {"bernstein.evolution.invariants": invariants_module}))
+        stack.enter_context(patch("bernstein.core.orchestration.bootstrap.console", MagicMock()))
+        stack.enter_context(
+            patch("bernstein.core.orchestration.bootstrap.concurrent.futures.ThreadPoolExecutor", _Executor)
+        )
+        stack.enter_context(patch("bernstein.core.orchestration.bootstrap.parse_seed", return_value=_seed()))
+        stack.enter_context(patch("bernstein.core.orchestration.bootstrap.preflight_checks"))
+        stack.enter_context(patch("bernstein.core.orchestration.bootstrap.ensure_sdd"))
+        stack.enter_context(patch("bernstein.core.orchestration.bootstrap._clean_stale_runtime"))
+        stack.enter_context(patch("bernstein.core.orchestration.bootstrap._discover_catalog"))
+        stack.enter_context(patch("bernstein.core.orchestration.bootstrap._build_codebase_index"))
+        stack.enter_context(
+            patch("bernstein.core.orchestration.bootstrap._resolve_bind_host", return_value="127.0.0.1")
+        )
+        stack.enter_context(patch("bernstein.core.orchestration.bootstrap._resolve_auth_token", return_value=None))
+        stack.enter_context(
+            patch("bernstein.core.orchestration.bootstrap._resolve_server_url", return_value="http://server")
+        )
+        stack.enter_context(patch("bernstein.core.orchestration.bootstrap.supervised_server", return_value=111))
+        stack.enter_context(patch("bernstein.core.orchestration.bootstrap._wait_for_server", return_value=True))
+        stack.enter_context(patch("bernstein.core.session.check_resume_session", return_value=prior))
         stack.enter_context(patch("bernstein.core.sync.sync_backlog_to_server", return_value=sync_result))
         mock_inject = stack.enter_context(patch("bernstein.core.orchestration.bootstrap._inject_manager_task"))
         stack.enter_context(patch("bernstein.core.cost.cost.estimate_run_cost", return_value=(1.0, 2.0)))

--- a/tests/unit/test_gui_smoke_findings.py
+++ b/tests/unit/test_gui_smoke_findings.py
@@ -131,8 +131,7 @@ class TestIdleHelpText:
         assert m is not None, "did not find --idle option declaration"
         block = m.group(0)
         assert "BERNSTEIN_ADAPTER=mock" in block, (
-            "--idle help must document that the mock backend is forced "
-            "internally via BERNSTEIN_ADAPTER=mock"
+            "--idle help must document that the mock backend is forced internally via BERNSTEIN_ADAPTER=mock"
         )
         assert "cli: mock" not in block, (
             "--idle help must not resurrect the hand-edit ``cli: mock`` "

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -4250,6 +4250,11 @@ class TestShutdownFinalOnQuiescenceSelfStop:
             task_ids=[task_id],
             status="working",
             exit_code=0,  # clean exit -> "auto-completed, no changes needed" path
+            # Long-lived so this is a genuine "no changes needed" clean exit,
+            # not the suspicious fast exit that is now failed/unverified
+            # (#2810/#2806). The auto-complete-after-death -> UNHEALTHY /
+            # self-stop mechanics under test are the same either way.
+            spawn_ts=time.time() - 300.0,
         )
         orch._agents["manager-e7bfd5e6"] = session
 
@@ -4306,6 +4311,9 @@ class TestShutdownFinalOnQuiescenceSelfStop:
             task_ids=[task_id],
             status="working",
             exit_code=0,
+            # Long-lived clean exit -> genuine auto-complete path (see the
+            # sibling test above); the suspicious fast exit is failed/unverified.
+            spawn_ts=time.time() - 300.0,
         )
 
         orch.tick()

--- a/tests/unit/test_retry_consolidation.py
+++ b/tests/unit/test_retry_consolidation.py
@@ -151,6 +151,41 @@ def test_maybe_retry_dlq_fires_from_typed_field():
     assert recorded_title == task.title
 
 
+def test_maybe_retry_enforces_hard_ceiling_matching_retry_or_fail():
+    """`maybe_retry_task` must apply the same `_MAX_REGULAR_TASK_RETRIES=2`
+    hard ceiling that `retry_or_fail_task` already enforces.
+
+    Regression for #2806: the tick-loop retry path (`maybe_retry_task`) and
+    the reap path (`retry_or_fail_task`) disagreed on the cap. A task at
+    retry_count=2 with a higher `max_retries`/`max_task_retries` was refused
+    by the reap path but still retried by the tick path, so a
+    structurally-dead lineage could exceed the intended ceiling.
+    """
+    from bernstein.core.task_lifecycle import _MAX_REGULAR_TASK_RETRIES
+
+    assert _MAX_REGULAR_TASK_RETRIES == 2
+    # retry_count already at the hard ceiling, but task.max_retries (3) and
+    # max_task_retries (3) would both otherwise permit another attempt.
+    task = _build_task(retry_count=2, max_retries=3)
+    client, posted = _capture_client()
+    quarantine = MagicMock()
+
+    created = maybe_retry_task(
+        task,
+        retried_task_ids=set(),
+        max_task_retries=3,
+        client=client,
+        server_url="http://server",
+        quarantine=quarantine,
+        workdir=None,
+        session_id=None,
+    )
+
+    assert created is False
+    assert posted == []
+    quarantine.record_failure.assert_called_once()
+
+
 def test_maybe_retry_ignores_legacy_title_prefix_when_typed_field_disagrees():
     """Legacy ``[RETRY N]`` prefix must not raise the counter."""
     task = _build_task(

--- a/tests/unit/test_session_resume.py
+++ b/tests/unit/test_session_resume.py
@@ -70,6 +70,46 @@ def test_session_state_roundtrip_without_pending() -> None:
     assert restored.pending_task_ids == []
 
 
+def test_session_state_roundtrip_includes_open_task_ids() -> None:
+    """Open tasks queued when the run was stopped must survive a round-trip.
+
+    Regression for #2798: open tasks were dropped entirely on stop, so a
+    resumed run had no record of the work still queued when it was paused.
+    """
+    original = SessionState(
+        saved_at=12345.0,
+        goal="Build auth",
+        completed_task_ids=["T-001"],
+        pending_task_ids=["T-002"],
+        open_task_ids=["T-003", "T-004"],
+        cost_spent=1.25,
+    )
+    restored = SessionState.from_dict(original.to_dict())
+    assert restored.open_task_ids == ["T-003", "T-004"]
+
+
+def test_session_state_roundtrip_without_open_task_ids() -> None:
+    """Backward compat: sessions saved before open_task_ids existed still load."""
+    data = {
+        "saved_at": 12345.0,
+        "goal": "old format",
+        "completed_task_ids": ["T-001"],
+        "pending_task_ids": ["T-002"],
+        "cost_spent": 0.5,
+    }
+    restored = SessionState.from_dict(data)
+    assert restored.open_task_ids == []
+
+
+def test_session_state_has_unfinished_work() -> None:
+    """A stopped session with open or pending tasks reports unfinished work."""
+    assert SessionState(saved_at=1.0, open_task_ids=["T-open"]).has_unfinished_work()
+    assert SessionState(saved_at=1.0, pending_task_ids=["T-wip"]).has_unfinished_work()
+    # Only completed tasks -> the run finished its queued work.
+    assert not SessionState(saved_at=1.0, completed_task_ids=["T-done"]).has_unfinished_work()
+    assert not SessionState(saved_at=1.0).has_unfinished_work()
+
+
 # ---------------------------------------------------------------------------
 # save_session / load_session / discard_session
 # ---------------------------------------------------------------------------
@@ -244,6 +284,9 @@ def test_orchestrator_save_session_state(tmp_path: Path) -> None:
     data = json.loads(session_file.read_text())
     assert sorted(data["completed_task_ids"]) == ["T-done-1", "T-done-2"]
     assert sorted(data["pending_task_ids"]) == ["T-claimed", "T-wip"]
+    # #2798: open tasks queued at stop must be persisted, not dropped, so the
+    # next start can tell the run was paused mid-flight.
+    assert data["open_task_ids"] == ["T-open"]
 
 
 def test_orchestrator_save_session_state_server_down(tmp_path: Path) -> None:

--- a/tests/unit/test_task_lifecycle.py
+++ b/tests/unit/test_task_lifecycle.py
@@ -211,6 +211,41 @@ def test_claim_and_spawn_batches_aborts_on_claim_transport_error(tmp_path: Path,
     assert result.errors == ["claim:T-net: server down"]
 
 
+def test_spawn_backoff_keyed_on_lineage_not_ephemeral_retry_id(tmp_path: Path, make_task: Any) -> None:
+    """A retry inherits its lineage's spawn backoff instead of resetting it.
+
+    Regression for #2806: the spawn-failure backoff was keyed on the current
+    attempt's task ids, so every retry (a fresh id) started fail_count back at
+    0 and the ``_MAX_SPAWN_FAILURES`` ceiling never accumulated against a
+    repeating spawn failure. Keying on the lineage
+    (``metadata["original_task_id"]``) makes a retry respect the backoff the
+    original lineage already accrued.
+    """
+    import time as _time
+
+    orch = _claim_orch(tmp_path)
+
+    # The lineage root "T-orig" already failed to spawn twice and its most
+    # recent failure is fresh, so the lineage is in active backoff.
+    lineage_key = frozenset(["T-orig"])
+    orch._spawn_failures[lineage_key] = (2, _time.time())
+
+    # A retry of that lineage arrives with a brand-new task id but carries the
+    # same original_task_id in its metadata.
+    retry = make_task(id="T-retry-1", role="backend")
+    retry.metadata = {"original_task_id": "T-orig"}
+    result = TickResult()
+
+    claim_and_spawn_batches(orch, [[retry]], alive_count=0, assigned_task_ids=set(), done_ids=set(), result=result)
+
+    # The retry is skipped by the inherited backoff: no claim, no spawn. Before
+    # the fix the id-keyed backoff missed the lineage entry and the retry was
+    # claimed/spawned immediately.
+    orch._client.post.assert_not_called()
+    orch._spawner.spawn_for_tasks.assert_not_called()
+    assert result.spawned == []
+
+
 def test_claim_and_spawn_batches_auto_decomposes_large_task_before_claim(tmp_path: Path, make_task: Any) -> None:
     """claim_and_spawn_batches creates a planner task instead of claiming a decomposable large task."""
     orch = _claim_orch(tmp_path)


### PR DESCRIPTION
## What
Three task-lifecycle fixes for milestone v3.8.4, one commit per issue. Together they close the path where a run declares success with no deliverable.

Fixes #2810
Fixes #2806
Fixes #2798

## Per issue
- **#2810 clean exit misclassified**: auto-complete-after-death now gates on the fast-exit probe's `suspicious` flag. A long-lived clean exit still auto-completes; a suspicious fast clean exit routes to `retry_or_fail_task` and surfaces as `clean_exit_unverified` instead of "done" with an empty diff.
- **#2806 uncapped retry storm**: backoff and fail-counts are now keyed on the retried lineage (`original_task_id`), so a structurally-dead spawn terminates within the existing cap instead of ballooning a 5-step plan into ~97 task records; `maybe_retry_task` respects the regular-retry cap.
- **#2798 resume-after-stop false completion**: `SessionState` now persists open task ids on both stop paths and exposes `has_unfinished_work()`; bootstrap short-circuits to "done previously" only when the prior session actually finished — a stopped session with open work re-plans instead of idling into a false complete.

## Verification
- All three reproduced on origin/main before fixing (TDD, red evidence kept).
- Targeted runs green: lifecycle/retry/session/bootstrap set 145 passed; `test_orchestrator.py` 226 passed; scheduling 57; task lifecycle 45; resume/stop set 55.
- Import sentinel: 37796 collected, no errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session recovery now preserves open tasks, improving interrupted-run resumption.
  * The `--fresh` option clearly indicates that it ignores saved sessions and triggers a full re-plan.

* **Bug Fixes**
  * Interrupted runs are now re-planned instead of incorrectly treated as completed.
  * Suspicious fast agent exits are retried or failed rather than automatically completed.
  * Task retry limits and spawn backoff now behave consistently across retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->