### PR TITLE
fix(cli): repair the operator-surface defects found in 3.8.2 testing

### DIFF
--- a/docs/cluster/deployment-patterns.md
+++ b/docs/cluster/deployment-patterns.md
@@ -72,6 +72,27 @@ flags.
 That's it. No tunnel, no overlay. The network is trusted; mTLS makes it
 auditable.
 
+### Running workers in containers
+
+A `bernstein worker` container does not serve the task-server HTTP port, so the
+image's default `HEALTHCHECK` (which probes `http://127.0.0.1:8052/health`)
+never succeeds and the container reports `(unhealthy)` forever. Disable it for
+worker-only containers:
+
+```bash
+docker run --health-cmd=NONE \
+    ghcr.io/sipyourdrink-ltd/bernstein \
+    worker --server https://central.internal:8052 --roles backend
+```
+
+In compose, set `healthcheck: { disable: true }` on the worker service.
+
+The image runs as `USER bernstein` (uid 1000). On macOS a bind-mounted host
+workspace is owned by your host uid, which the in-container user cannot write,
+so mounts fail with permission errors. Add `user: "0:0"` (compose) or
+`--user 0:0` (`docker run`) to the worker service on macOS, or use a named
+volume instead of a bind mount.
+
 ---
 
 ## Pattern 2 - Cloudflare Tunnel

--- a/src/bernstein/cli/commands/status_cmd.py
+++ b/src/bernstein/cli/commands/status_cmd.py
@@ -281,7 +281,11 @@ def _collect_pid_agents(pid_path: Path) -> tuple[list[dict[str, Any]], list[Path
             continue
 
         worker_pid = info.get("worker_pid", 0)
-        alive = is_process_alive(worker_pid) if worker_pid else False
+        child_pid = info.get("child_pid")
+        # Probe the leaf child PID independently: an adapter leaf process can
+        # outlive its worker briefly, and reporting on ``worker_pid`` alone made
+        # ``ps`` go blind to a still-running agent (issue #2800).
+        alive = (bool(worker_pid) and is_process_alive(worker_pid)) or (bool(child_pid) and is_process_alive(child_pid))
         if not alive:
             stale_files.append(pid_file)
             continue
@@ -299,7 +303,7 @@ def _collect_pid_agents(pid_path: Path) -> tuple[list[dict[str, Any]], list[Path
                 "command": info.get("command", "?"),
                 "model": info.get("model", "?"),
                 "worker_pid": worker_pid,
-                "child_pid": info.get("child_pid"),
+                "child_pid": child_pid,
                 "runtime": runtime_str,
                 "started_at": started_at,
             }

--- a/src/bernstein/cli/commands/stop_cmd.py
+++ b/src/bernstein/cli/commands/stop_cmd.py
@@ -669,6 +669,17 @@ def _cleanup_runtime_artifacts() -> None:
             f.unlink(missing_ok=True)
 
 
+def _count_reaped(killed_pids: set[int]) -> int:
+    """Count collected PIDs confirmed terminated after the kill sweep.
+
+    Every collector adds a PID it attempted to ``killed_pids``, including PIDs
+    that were already dead or that resisted SIGKILL. Reporting the raw set size
+    over-states what was actually reaped (issue #2800); count only PIDs that are
+    no longer alive.
+    """
+    return sum(1 for pid in killed_pids if not is_alive(pid))
+
+
 def hard_stop() -> None:
     """Hard stop: SIGKILL everything, best-effort save, return tickets."""
     # 1. Best-effort session save while server is still alive
@@ -722,9 +733,17 @@ def hard_stop() -> None:
     # Remove Bernstein from .claude/mcp.json so stale references are cleaned up
     _unregister_mcp_discovery(Path.cwd())
 
-    total = len(killed_pids)
-    if total:
-        console.print(f"\n[red]Bernstein stopped (hard) - killed {total} process(es).[/red]")
+    reaped = _count_reaped(killed_pids)
+    resisted = len(killed_pids) - reaped
+    if reaped:
+        console.print(f"\n[red]Bernstein stopped (hard) - killed {reaped} process(es).[/red]")
+        if resisted:
+            console.print(f"[yellow]{resisted} process(es) resisted SIGKILL and may still be running.[/yellow]")
+    elif resisted:
+        console.print(
+            f"\n[yellow]Bernstein stop (hard) - {resisted} process(es) resisted SIGKILL "
+            "and may still be running.[/yellow]"
+        )
     else:
         console.print("\n[red]Bernstein stopped (hard) - no processes were running.[/red]")
 

--- a/src/bernstein/cli/commands/worker_cmd.py
+++ b/src/bernstein/cli/commands/worker_cmd.py
@@ -23,7 +23,7 @@ from pathlib import Path
 import click
 import httpx
 
-from bernstein.cli.helpers import console
+from bernstein.cli.helpers import adapter_cli_choice, console
 from bernstein.core.capacity_wake import CapacityWake, WakeReason
 from bernstein.core.poll_config import PollConfig, validate_poll_config
 
@@ -493,7 +493,10 @@ class WorkerLoop:
 @click.option(
     "--adapter",
     default=None,
-    type=click.Choice(["claude", "codex", "gemini", "qwen", "aider", "auto"], case_sensitive=False),
+    # Derived from the live adapter registry (same source as the seed ``cli:``
+    # allowlist and ``run --cli``) so a worker resolves any selectable adapter
+    # instead of a stale hardcoded subset (issue #2807).
+    type=adapter_cli_choice(),
     help="CLI agent adapter (default: auto-detect).",
 )
 @click.option(

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -406,6 +406,7 @@ def print_rich_help() -> None:
                 ("bernstein", "run from bernstein.yaml or backlog"),
                 ("run [dim]plan.yaml[/dim]", "execute a plan file (stages + steps)"),
                 ("init", "initialize project (.sdd/ + bernstein.yaml)"),
+                ("start", "start server + spawn manager, detached (cluster central node)"),
                 ("serve", "run the task server in the foreground (container / node)"),
                 ("stop", "graceful stop (agents save work first)"),
                 ("stop --force", "hard stop (kill immediately)"),
@@ -875,6 +876,7 @@ def cli(
         attach=(),
         # Bot-added: drift autofix (regen_contract_drift.py)
         refresh_cache=False,
+        force_fresh=force_fresh,
     )
 
 

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -82,6 +82,47 @@ def _build_synthetic_plan(goal: str, team: list[str] | None = None) -> tuple[Any
     return plan, tasks
 
 
+def _resolve_goal_and_team(workdir: Path, goal: str | None, seed_file: str | None) -> tuple[str, list[str] | None]:
+    """Resolve the effective goal and team from an inline goal or a seed.
+
+    Shared by ``--plan-only`` and ``--dry-run`` so both preview the same plan
+    from the same source and reject the same seeds. When ``goal`` is given it
+    wins; otherwise the seed file is parsed (``parse_seed``), which enforces the
+    exact validation a real run enforces - so a seed the run would reject (for
+    example an unselectable ``cli:``) is rejected during preview too, instead of
+    being previewed and then crashing at spawn time (issues #2800, #2807).
+
+    Raises:
+        SystemExit: On a missing goal/seed or a seed that fails validation.
+    """
+    if goal is not None:
+        return goal, None
+
+    from bernstein.core.seed import SeedError, parse_seed
+
+    if seed_file is not None:
+        seed_path = Path(seed_file)
+    else:
+        found = find_seed_file()
+        if found is None:
+            from bernstein.cli.errors import no_seed_or_goal
+
+            no_seed_or_goal().print()
+            raise SystemExit(1)
+        seed_path = found
+
+    try:
+        seed = parse_seed(seed_path)
+    except SeedError as exc:
+        from bernstein.cli.errors import seed_parse_error
+
+        seed_parse_error(exc).print()
+        raise SystemExit(1) from exc
+
+    team = list(seed.team) if seed.team != "auto" else None
+    return seed.goal, team
+
+
 def _load_plan_goal(plan_path: Path) -> str:
     """Extract the goal from a saved plan file (JSON or markdown).
 
@@ -626,14 +667,23 @@ def _show_dry_run_plan(
         model_override: Optional model override.
         _cli: Optional CLI override.
     """
-    _ = workdir  # Part of interface
-    _ = seed_file  # Part of interface
-    _ = cli  # Part of interface
+    _ = cli  # Part of interface: --cli is validated by its click.Choice
     from rich.table import Table
 
     console.print("\n[bold]Dry-run mode: no agents will be spawned.[/bold]\n")
 
-    tasks = _load_dry_run_tasks(plan_file)
+    if plan_file is not None:
+        tasks = _load_dry_run_tasks(plan_file)
+    elif goal is not None or seed_file is not None or find_seed_file() is not None:
+        # Synthesize the plan from the seed/goal exactly as --plan-only does, so
+        # a seed preview needs no running task server and a seed the real run
+        # would reject is rejected here too (issues #2800, #2807), instead of
+        # querying a server that --dry-run never started.
+        effective_goal, team = _resolve_goal_and_team(workdir, goal, seed_file)
+        _plan_obj, tasks = _build_synthetic_plan(effective_goal, team)
+    else:
+        # No seed/goal/plan: fall back to previewing a running server's backlog.
+        tasks = _load_dry_run_tasks(None)
 
     if not tasks:
         console.print("[yellow]No tasks to schedule.[/yellow]")
@@ -1323,11 +1373,9 @@ def exec_restart() -> None:
         "GUI-dev mode: force every adapter to ``mock`` and have each spawned "
         "agent sleep for $BERNSTEIN_MOCK_IDLE_MIN_S..MAX_S seconds (defaults: "
         "min=15, max=120) instead of calling an LLM. Zero token spend - used "
-        "to populate the web GUI with live state. NOTE: the orchestrator "
-        "subprocess otherwise defaults to ``--adapter claude``; pin "
-        "``cli: mock`` at the top of bernstein.yaml in your workdir so the "
-        "orchestrator picks the mock backend too. Mutually exclusive with "
-        "--dry-run."
+        "to populate the web GUI with live state. --idle forces the mock "
+        "backend internally (it exports BERNSTEIN_ADAPTER=mock), so no "
+        "bernstein.yaml edit is needed. Mutually exclusive with --dry-run."
     ),
 )
 @click.option(
@@ -1514,6 +1562,13 @@ def exec_restart() -> None:
         "cache policy are unaffected."
     ),
 )
+@click.option(
+    "--fresh",
+    "force_fresh",
+    is_flag=True,
+    default=False,
+    help="Ignore any saved session and start from scratch.",
+)
 def run(
     plan_file: Path | None,
     goal: str | None,
@@ -1558,6 +1613,7 @@ def run(
     max_blast_radius: float | None = None,
     attach: tuple[Path, ...] = (),
     refresh_cache: bool = False,
+    force_fresh: bool = False,
 ) -> None:
     """Parse seed, init workspace, start server, launch agents.
 
@@ -1610,6 +1666,7 @@ def run(
             max_blast_radius=max_blast_radius,
             attach=attach,
             refresh_cache=refresh_cache,
+            force_fresh=force_fresh,
         )
     except (click.UsageError, SystemExit):
         raise
@@ -1662,6 +1719,7 @@ def _run_impl(
     max_blast_radius: float | None,
     attach: tuple[Path, ...] = (),
     refresh_cache: bool = False,
+    force_fresh: bool = False,
 ) -> None:
     """Concrete ``run`` implementation; wrapped by :func:`run` for hinting.
 
@@ -1967,34 +2025,8 @@ def _run_impl(
     # --plan-only: build a synthetic plan, render to markdown, save, and exit
     if plan_only:
         from bernstein.core.plan_builder import PlanBuilder
-        from bernstein.core.seed import SeedError, parse_seed
 
-        effective_goal = goal
-        team: list[str] | None = None
-
-        if effective_goal is None:
-            # Resolve seed file
-            if seed_file is not None:
-                seed_path = Path(seed_file)
-            else:
-                found = find_seed_file()
-                if found is not None:
-                    seed_path = found
-                else:
-                    from bernstein.cli.errors import no_seed_or_goal
-
-                    no_seed_or_goal().print()
-                    raise SystemExit(1)
-            try:
-                seed = parse_seed(seed_path)
-                effective_goal = seed.goal
-                team = list(seed.team) if seed.team != "auto" else None
-            except SeedError as exc:
-                from bernstein.cli.errors import seed_parse_error
-
-                seed_parse_error(exc).print()
-                raise SystemExit(1) from exc
-
+        effective_goal, team = _resolve_goal_and_team(workdir, goal, seed_file)
         plan_obj, tasks = _build_synthetic_plan(effective_goal, team)
         builder = PlanBuilder(plan_obj, tasks)
         md = builder.render_to_markdown()
@@ -2030,6 +2062,7 @@ def _run_impl(
                     cells=cells,
                     cli=cli or "auto",  # Default to "auto" if not specified
                     model=model,
+                    force_fresh=force_fresh,
                 )
                 persist_server_port(port, workdir)
         except RuntimeError as exc:
@@ -2068,6 +2101,7 @@ def _run_impl(
                 cli=cli,
                 model=model,
                 worker_role=worker_role,
+                force_fresh=force_fresh,
             )
             persist_server_port(port, workdir)
     except SeedError as exc:

--- a/src/bernstein/core/orchestration/bootstrap.py
+++ b/src/bernstein/core/orchestration/bootstrap.py
@@ -175,9 +175,23 @@ def _register_mcp_discovery(workdir: Path) -> None:
             existing = {}
 
     servers = dict(existing.get("mcpServers", {}))  # type: ignore[arg-type]
+    desired_args = ["-m", "bernstein.mcp.server"]
+
+    # Self-heal only when the entry is missing or stale. The bernstein entry is
+    # identified by its ``args``; ``command`` is ``sys.executable``, which is
+    # machine-specific and differs between the host that committed a tracked
+    # mcp.json and the host running the wheel. Rewriting on that difference
+    # dirties the operator working tree on every run (issue #2800), so when an
+    # entry with the same args already exists we leave the file untouched and
+    # only its (machine-specific) command may differ.
+    current = servers.get("bernstein")
+    if isinstance(current, dict) and current.get("args") == desired_args:
+        logger.debug("Bernstein MCP server already registered in %s; skipping rewrite", mcp_path)
+        return
+
     servers["bernstein"] = {
         "command": sys.executable,
-        "args": ["-m", "bernstein.mcp.server"],
+        "args": desired_args,
     }
     existing["mcpServers"] = servers
     mcp_path.write_text(_json.dumps(existing, indent=2) + "\n")

--- a/src/bernstein/core/routes/status_dashboard.py
+++ b/src/bernstein/core/routes/status_dashboard.py
@@ -299,6 +299,25 @@ def _status_task_items(tasks: list[Task], now: float) -> list[dict[str, Any]]:
     return items
 
 
+def _agent_model_label(agent: Any) -> str:
+    """Return the agent's real spawn model for dashboard display.
+
+    Reads the model from the agent's ``model_config`` (attribute- or
+    dict-shaped), then the agent's own ``model`` field. When none is known it
+    falls back to the provider or a neutral ``"unknown"`` - never a hardcoded
+    ``"sonnet"``, which mislabels non-Claude agents (issue #2800).
+    """
+    mc = getattr(agent, "model_config", None)
+    model = getattr(mc, "model", None)
+    if model is None and isinstance(mc, dict):
+        model = mc.get("model")
+    if model is None:
+        model = getattr(agent, "model", None)
+    if model:
+        return str(model)
+    return str(getattr(agent, "provider", None) or "unknown")
+
+
 def _status_agent_items(
     store: TaskStore,
     agent_snapshots: dict[str, dict[str, Any]],
@@ -310,7 +329,7 @@ def _status_agent_items(
     live_agents = list(store.agents.values())
     for agent in live_agents:
         snapshot = agent_snapshots.get(agent.id, {})
-        model_name = agent.model_config.model if hasattr(agent.model_config, "model") else "sonnet"
+        model_name = _agent_model_label(agent)
         role_alive_count = max(1, len([candidate for candidate in live_agents if candidate.role == agent.role]))
         estimated_cost = total_cost_by_role.get(agent.role, 0.0) / role_alive_count
         items.append(
@@ -1044,7 +1063,7 @@ def _build_single_agent_detail(
 ) -> dict[str, Any]:
     """Build a single agent detail dict for the dashboard data endpoint."""
     runtime_s = int(now - a.spawn_ts)
-    model_name = a.model_config.model if hasattr(a.model_config, "model") else "sonnet"
+    model_name = _agent_model_label(a)
     context_window_tokens = int(getattr(a, "context_window_tokens", 0) or snapshot.get("context_window_tokens", 0) or 0)
     context_utilization_pct = float(
         getattr(a, "context_utilization_pct", 0.0) or snapshot.get("context_utilization_pct", 0.0) or 0.0

--- a/tests/unit/test_dashboard_model_label.py
+++ b/tests/unit/test_dashboard_model_label.py
@@ -1,0 +1,34 @@
+"""Dashboard agent rows label the real spawn model, not a Claude default.
+
+The dashboard used a hardcoded ``"sonnet"`` fallback when an agent's
+``model_config`` carried no ``model`` attribute, so a non-Claude agent showed
+``sonnet`` (issue #2800). ``_agent_model_label`` derives the real model from the
+route/model_config and falls back to a neutral label instead.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from bernstein.core.routes.status_dashboard import _agent_model_label
+
+
+def test_label_uses_model_config_model() -> None:
+    agent = SimpleNamespace(model_config=SimpleNamespace(model="qwen2.5-coder"))
+    assert _agent_model_label(agent) == "qwen2.5-coder"
+
+
+def test_label_reads_dict_shaped_model_config() -> None:
+    agent = SimpleNamespace(model_config={"model": "gpt-5-codex"})
+    assert _agent_model_label(agent) == "gpt-5-codex"
+
+
+def test_label_falls_back_to_neutral_not_sonnet() -> None:
+    """When no model is known the label is neutral, never a Claude default."""
+    agent = SimpleNamespace(model_config=object(), provider=None)
+    assert _agent_model_label(agent) != "sonnet"
+
+
+def test_label_uses_provider_when_model_missing() -> None:
+    agent = SimpleNamespace(model_config=object(), provider="ollama")
+    assert _agent_model_label(agent) == "ollama"

--- a/tests/unit/test_dry_run.py
+++ b/tests/unit/test_dry_run.py
@@ -28,47 +28,32 @@ class TestDryRun:
         # Should not error on flag parsing
         assert result.exit_code == 0
 
-    def test_dry_run_shows_table(self) -> None:
-        """Test dry-run displays scheduling table."""
-        # Mock the HTTP response
-        mock_tasks = [
-            {
-                "id": "task-1",
-                "title": "Test task 1",
-                "description": "Test",
-                "role": "backend",
-                "priority": 2,
-                "status": "open",
-                "estimated_minutes": 30,
-            }
-        ]
+    def test_dry_run_shows_table(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Dry-run synthesizes a scheduling table from a seed without a server."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "bernstein.yaml").write_text("goal: Build a widget\n")
 
-        with patch("httpx.get") as mock_get:
-            mock_response = MagicMock()
-            mock_response.json.return_value = mock_tasks
-            mock_response.raise_for_status.return_value = None
-            mock_get.return_value = mock_response
+        # A seed preview must never contact the task server.
+        def _boom(*_a: object, **_k: object) -> None:
+            raise AssertionError("dry-run must not query the task server for a seed")
 
-            with patch("bernstein.core.router.route_task") as mock_route:
-                from bernstein.core.models import ModelConfig
+        monkeypatch.setattr("httpx.get", _boom)
 
-                mock_route.return_value = ModelConfig(model="sonnet", effort="high")
+        from bernstein.cli.run_cmd import _show_dry_run_plan
 
-                # Import after mocking
-                from bernstein.cli.run_cmd import _show_dry_run_plan
+        # Should not raise
+        _show_dry_run_plan(
+            workdir=tmp_path,
+            plan_file=None,
+            goal=None,
+            seed_file=None,
+            model_override=None,
+            cli=None,
+        )
 
-                # Should not raise
-                _show_dry_run_plan(
-                    workdir=Path.cwd(),
-                    plan_file=None,
-                    goal=None,
-                    seed_file=None,
-                    model_override=None,
-                    cli=None,
-                )
-
-    def test_dry_run_no_tasks(self) -> None:
-        """Test dry-run with no open tasks."""
+    def test_dry_run_no_tasks(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With no seed/goal/plan, dry-run falls back to previewing the server backlog."""
+        monkeypatch.chdir(tmp_path)  # seedless dir -> server-backlog fallback
         with patch("httpx.get") as mock_get:
             mock_response = MagicMock()
             mock_response.json.return_value = []
@@ -79,7 +64,7 @@ class TestDryRun:
 
             # Should not raise
             _show_dry_run_plan(
-                workdir=Path.cwd(),
+                workdir=tmp_path,
                 plan_file=None,
                 goal=None,
                 seed_file=None,
@@ -87,10 +72,11 @@ class TestDryRun:
                 cli=None,
             )
 
-    def test_dry_run_server_not_running(self) -> None:
-        """Test dry-run when server is not running."""
+    def test_dry_run_server_not_running(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The server-backlog fallback still exits cleanly when no server is running."""
         import httpx
 
+        monkeypatch.chdir(tmp_path)  # seedless dir -> server-backlog fallback
         with patch("httpx.get") as mock_get:
             mock_get.side_effect = httpx.ConnectError("Connection refused")
 
@@ -98,7 +84,7 @@ class TestDryRun:
 
             with pytest.raises(SystemExit) as exc_info:
                 _show_dry_run_plan(
-                    workdir=Path.cwd(),
+                    workdir=tmp_path,
                     plan_file=None,
                     goal=None,
                     seed_file=None,

--- a/tests/unit/test_dry_run_seed_preview.py
+++ b/tests/unit/test_dry_run_seed_preview.py
@@ -1,0 +1,69 @@
+"""``run --dry-run`` on a seed previews the plan and validates like a real run.
+
+Before this fix ``_show_dry_run_plan`` ignored the seed and fetched tasks from a
+task server that ``--dry-run`` never started, so a seed preview printed nothing
+and failed with a "Task server not running" error (issue #2800). It also
+accepted seeds a real run rejects, because it never called ``parse_seed``
+(issue #2807). These tests pin the seed-synth path and the shared validation.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from typing import Any
+
+import pytest
+from rich.console import Console
+
+from bernstein.cli import run_bootstrap
+
+
+def _patched_console(monkeypatch: Any) -> io.StringIO:
+    buf = io.StringIO()
+    monkeypatch.setattr(run_bootstrap, "console", Console(file=buf, force_terminal=False, width=200))
+    return buf
+
+
+def test_dry_run_previews_seed_without_server(monkeypatch: Any, tmp_path: Path) -> None:
+    """A valid seed renders a scheduling plan with no running task server."""
+    seed = tmp_path / "bernstein.yaml"
+    seed.write_text("goal: Build a widget\n")
+
+    # Any attempt to reach the task server would be a bug: fail loudly if hit.
+    def _boom(*_a: Any, **_k: Any) -> None:
+        raise AssertionError("dry-run must not query the task server for a seed")
+
+    monkeypatch.setattr(run_bootstrap.httpx, "get", _boom)
+    buf = _patched_console(monkeypatch)
+
+    run_bootstrap._show_dry_run_plan(
+        workdir=tmp_path,
+        plan_file=None,
+        goal=None,
+        seed_file=str(seed),
+        model_override=None,
+        cli=None,
+    )
+
+    output = buf.getvalue()
+    assert "Task server not running" not in output
+    assert "Dry-Run Scheduling Plan" in output
+    assert "manager" in output
+
+
+def test_dry_run_rejects_unselectable_cli_seed(monkeypatch: Any, tmp_path: Path) -> None:
+    """A seed a real run rejects (unselectable ``cli:``) is rejected here too."""
+    seed = tmp_path / "bernstein.yaml"
+    seed.write_text("goal: Build a widget\ncli: mock\n")
+    _patched_console(monkeypatch)
+
+    with pytest.raises(SystemExit):
+        run_bootstrap._show_dry_run_plan(
+            workdir=tmp_path,
+            plan_file=None,
+            goal=None,
+            seed_file=str(seed),
+            model_override=None,
+            cli=None,
+        )

--- a/tests/unit/test_gui_smoke_findings.py
+++ b/tests/unit/test_gui_smoke_findings.py
@@ -111,15 +111,17 @@ class TestMockIdleEnvValidation:
 
 
 class TestIdleHelpText:
-    """The ``bernstein run --idle`` help text documents the cli pinning caveat.
+    """The ``bernstein run --idle`` help text documents the mock pinning story.
 
-    Regression guard: the smoke run found that operators are confused by
-    ``--idle`` because it does not propagate ``cli=mock`` to the orchestrator
-    subprocess.  The help text must mention the workaround so the doc and
-    behaviour stay in sync.
+    Regression guard: the smoke run found that operators are confused by how
+    ``--idle`` selects the mock backend. Since the fix for the seed-crash
+    instruction, ``--idle`` forces the mock backend internally (it exports
+    ``BERNSTEIN_ADAPTER=mock``) and the help must say so instead of telling
+    operators to hand-edit ``bernstein.yaml`` with a seed that the parser
+    rejects.
     """
 
-    def test_idle_help_mentions_cli_pinning(self) -> None:
+    def test_idle_help_documents_internal_mock_pinning(self) -> None:
         # Read the option declaration directly so we do not require Click
         # to render help (which depends on terminal width).
         path = REPO_ROOT / "src" / "bernstein" / "cli" / "run_bootstrap.py"
@@ -128,10 +130,13 @@ class TestIdleHelpText:
         m = re.search(r'"--idle".*?\)\n', text, flags=re.DOTALL)
         assert m is not None, "did not find --idle option declaration"
         block = m.group(0)
-        assert "cli: mock" in block, (
-            "--idle help must mention pinning ``cli: mock`` so operators are "
-            "warned that the orchestrator subprocess otherwise defaults to "
-            "Claude Code"
+        assert "BERNSTEIN_ADAPTER=mock" in block, (
+            "--idle help must document that the mock backend is forced "
+            "internally via BERNSTEIN_ADAPTER=mock"
+        )
+        assert "cli: mock" not in block, (
+            "--idle help must not resurrect the hand-edit ``cli: mock`` "
+            "instruction; that seed is rejected by the parser"
         )
 
 

--- a/tests/unit/test_hard_stop_count.py
+++ b/tests/unit/test_hard_stop_count.py
@@ -1,0 +1,32 @@
+"""``bernstein stop --force`` reports what it actually reaped (issue #2800).
+
+The hard-stop summary printed ``len(killed_pids)`` - every PID it attempted -
+so PIDs that were already dead or that resisted SIGKILL inflated the count.
+``_count_reaped`` reports only the collected PIDs confirmed terminated.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from bernstein.cli.commands import stop_cmd
+
+
+def test_count_reaped_excludes_survivors(monkeypatch: Any) -> None:
+    """A PID still alive after the sweep is not counted as reaped."""
+    # PIDs 1 and 2 are gone; PID 3 resisted SIGKILL and is still alive.
+    monkeypatch.setattr(stop_cmd, "is_alive", lambda pid: pid == 3)
+
+    assert stop_cmd._count_reaped({1, 2, 3}) == 2
+
+
+def test_count_reaped_all_dead(monkeypatch: Any) -> None:
+    monkeypatch.setattr(stop_cmd, "is_alive", lambda _pid: False)
+
+    assert stop_cmd._count_reaped({10, 11}) == 2
+
+
+def test_count_reaped_none_dead(monkeypatch: Any) -> None:
+    monkeypatch.setattr(stop_cmd, "is_alive", lambda _pid: True)
+
+    assert stop_cmd._count_reaped({10, 11}) == 0

--- a/tests/unit/test_help_lists_start.py
+++ b/tests/unit/test_help_lists_start.py
@@ -1,0 +1,29 @@
+"""``bernstein --help`` lists the documented ``start`` command (issue #2807).
+
+The cluster deployment doc starts the central node with ``bernstein start``, but
+the curated ``--help`` omitted it, so an operator following the doc could not
+discover it. It is registered and invocable; the curated help now surfaces it.
+"""
+
+from __future__ import annotations
+
+import io
+
+from rich.console import Console
+
+from bernstein.cli import main as main_module
+
+
+def test_help_lists_start() -> None:
+    buf = io.StringIO()
+    original = main_module.console
+    main_module.console = Console(file=buf, force_terminal=False, width=200)
+    try:
+        main_module.print_rich_help()
+    finally:
+        main_module.console = original
+
+    output = buf.getvalue()
+    # Distinctive to the curated ``start`` row (avoids matching "quick start"
+    # or the "--fresh ... start clean" option text).
+    assert "spawn manager" in output

--- a/tests/unit/test_idle_help_no_broken_seed_edit.py
+++ b/tests/unit/test_idle_help_no_broken_seed_edit.py
@@ -1,0 +1,31 @@
+"""``run --idle`` help no longer tells the operator to make a crashing seed edit.
+
+The ``--idle`` help instructed pinning ``cli: mock`` in bernstein.yaml, which a
+real run rejects with ``SeedError`` (``mock`` is a non-selectable stub). ``--idle``
+already forces the mock backend internally, so the instruction was both
+unnecessary and actively broken (issue #2807).
+"""
+
+from __future__ import annotations
+
+import click
+
+from bernstein.cli.run_bootstrap import run
+
+
+def _idle_help() -> str:
+    for param in run.params:
+        if param.name == "idle" and isinstance(param, click.Option):
+            return param.help or ""
+    raise AssertionError("--idle option not found on run")
+
+
+def test_idle_help_drops_cli_mock_instruction() -> None:
+    help_text = _idle_help()
+    assert "cli: mock" not in help_text
+    assert "pin" not in help_text.lower()
+
+
+def test_idle_help_states_mock_is_forced_internally() -> None:
+    help_text = _idle_help().lower()
+    assert "internal" in help_text or "no bernstein.yaml edit" in help_text

--- a/tests/unit/test_mcp_discovery.py
+++ b/tests/unit/test_mcp_discovery.py
@@ -61,6 +61,38 @@ def test_register_tolerates_corrupt_existing_file(tmp_path: Path) -> None:
     assert "bernstein" in data["mcpServers"]
 
 
+def test_register_skips_rewrite_when_command_only_differs(tmp_path: Path) -> None:
+    """A tracked mcp.json committed on another machine is not rewritten (issue #2800).
+
+    The bernstein entry is identified by its ``args``. When an entry with the
+    same args already exists, only its machine-specific ``command`` could
+    differ, so register must leave the file byte-for-byte unchanged instead of
+    dirtying a tracked working tree on every run.
+    """
+    mcp_path = tmp_path / ".claude" / "mcp.json"
+    mcp_path.parent.mkdir(parents=True)
+    committed = {
+        "mcpServers": {"bernstein": {"command": "/other/machine/python", "args": ["-m", "bernstein.mcp.server"]}}
+    }
+    original_text = json.dumps(committed, indent=2) + "\n"
+    mcp_path.write_text(original_text)
+
+    _register_mcp_discovery(tmp_path)
+
+    assert mcp_path.read_text() == original_text
+
+
+def test_register_is_idempotent_on_second_run(tmp_path: Path) -> None:
+    """Two consecutive registers on the same machine leave the file unchanged."""
+    _register_mcp_discovery(tmp_path)
+    mcp_path = tmp_path / ".claude" / "mcp.json"
+    first = mcp_path.read_text()
+
+    _register_mcp_discovery(tmp_path)
+
+    assert mcp_path.read_text() == first
+
+
 def test_unregister_removes_bernstein_entry(tmp_path: Path) -> None:
     """unregister removes only the bernstein entry, leaving others intact."""
     mcp_path = tmp_path / ".claude" / "mcp.json"

--- a/tests/unit/test_ps_child_liveness.py
+++ b/tests/unit/test_ps_child_liveness.py
@@ -1,0 +1,64 @@
+"""``bernstein ps`` sees an agent whose worker died but whose child is alive.
+
+``_collect_pid_agents`` keyed liveness solely on ``worker_pid`` and deleted the
+PID file when that PID was gone, so an adapter leaf process still running under
+a dead worker was reported as no agent at all (issue #2800). Liveness now also
+probes ``child_pid`` and keeps the file while any tracked PID is alive.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from bernstein.cli.commands import status_cmd
+
+
+def _write_pid(pid_path: Path, name: str, **fields: Any) -> Path:
+    pid_path.mkdir(parents=True, exist_ok=True)
+    record = {"session": name, "role": "backend", "started_at": time.time()}
+    record.update(fields)
+    f = pid_path / f"{name}.json"
+    f.write_text(json.dumps(record), encoding="utf-8")
+    return f
+
+
+def test_child_alive_keeps_agent(tmp_path: Path, monkeypatch: Any) -> None:
+    """Worker dead but child alive -> agent is still reported, file not stale."""
+    pid_path = tmp_path / "pids"
+    f = _write_pid(pid_path, "s1", worker_pid=111, child_pid=222)
+
+    monkeypatch.setattr(status_cmd, "is_process_alive", lambda pid: pid == 222)
+
+    agents, stale = status_cmd._collect_pid_agents(pid_path)
+
+    assert [a["session"] for a in agents] == ["s1"]
+    assert f not in stale
+
+
+def test_worker_and_child_dead_is_stale(tmp_path: Path, monkeypatch: Any) -> None:
+    """Both PIDs dead -> agent dropped and its file marked stale."""
+    pid_path = tmp_path / "pids"
+    f = _write_pid(pid_path, "s2", worker_pid=111, child_pid=222)
+
+    monkeypatch.setattr(status_cmd, "is_process_alive", lambda pid: False)
+
+    agents, stale = status_cmd._collect_pid_agents(pid_path)
+
+    assert agents == []
+    assert f in stale
+
+
+def test_worker_alive_reports_agent(tmp_path: Path, monkeypatch: Any) -> None:
+    """Existing behaviour preserved: a live worker is reported."""
+    pid_path = tmp_path / "pids"
+    _write_pid(pid_path, "s3", worker_pid=111, child_pid=222)
+
+    monkeypatch.setattr(status_cmd, "is_process_alive", lambda pid: pid == 111)
+
+    agents, stale = status_cmd._collect_pid_agents(pid_path)
+
+    assert [a["session"] for a in agents] == ["s3"]
+    assert stale == []

--- a/tests/unit/test_run_fresh_flag.py
+++ b/tests/unit/test_run_fresh_flag.py
@@ -1,0 +1,45 @@
+"""``bernstein run --fresh`` parity with the top-level help (issue #2800).
+
+Top-level help advertises ``--fresh`` (``ignore saved session, start clean``),
+but the ``run`` subcommand did not define it, so ``bernstein run --fresh``
+failed with ``No such option``. These tests pin that the flag is accepted on
+the ``run`` path and threaded through to the bootstrap ``force_fresh`` handling.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from click.testing import CliRunner
+
+from bernstein.cli import run_bootstrap
+
+
+def test_run_accepts_and_threads_fresh(monkeypatch: Any) -> None:
+    """``run --fresh`` parses and threads ``force_fresh=True`` into the impl."""
+    captured: dict[str, Any] = {}
+
+    def fake_impl(**kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(run_bootstrap, "_run_impl", fake_impl)
+
+    result = CliRunner().invoke(run_bootstrap.run, ["--fresh", "--goal", "hello", "--auto-approve"])
+
+    assert result.exit_code == 0, result.output
+    assert captured["force_fresh"] is True
+
+
+def test_run_fresh_defaults_false(monkeypatch: Any) -> None:
+    """Without ``--fresh`` the run defaults to resuming (``force_fresh=False``)."""
+    captured: dict[str, Any] = {}
+
+    def fake_impl(**kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(run_bootstrap, "_run_impl", fake_impl)
+
+    result = CliRunner().invoke(run_bootstrap.run, ["--goal", "hello", "--auto-approve"])
+
+    assert result.exit_code == 0, result.output
+    assert captured["force_fresh"] is False

--- a/tests/unit/test_worker_adapter_allowlist.py
+++ b/tests/unit/test_worker_adapter_allowlist.py
@@ -1,0 +1,31 @@
+"""``bernstein worker --adapter`` agrees with the seed and ``run --cli`` (issue #2807).
+
+The worker's adapter allowlist was a stale hardcoded subset, so a cluster
+worker could not run adapters (e.g. ``opencode``) that the seed ``cli:`` key and
+``run --cli`` accept. All three now derive from ``selectable_adapter_names`` via
+``adapter_cli_choice`` so a given adapter resolves identically everywhere.
+"""
+
+from __future__ import annotations
+
+import click
+
+from bernstein.cli.commands.worker_cmd import worker
+from bernstein.cli.run_bootstrap import run
+
+
+def _choices(cmd: click.Command, opt_name: str) -> set[str]:
+    for param in cmd.params:
+        if param.name == opt_name and isinstance(param.type, click.Choice):
+            return set(param.type.choices)
+    raise AssertionError(f"{opt_name} choice option not found on {cmd.name}")
+
+
+def test_worker_adapter_matches_run_cli() -> None:
+    assert _choices(worker, "adapter") == _choices(run, "cli")
+
+
+def test_worker_adapter_includes_registered_adapter_rejects_mock() -> None:
+    choices = _choices(worker, "adapter")
+    assert "opencode" in choices  # previously missing from the worker subset
+    assert "mock" not in choices  # non-agent stub, rejected everywhere


### PR DESCRIPTION
## What
Fixes the defect sub-items of the two UX grab-bag issues from milestone v3.8.4 (two commits). Every sub-item was triaged individually; the four that turned out to be behavior changes or new wiring rather than defects are parked in the follow-up #2874 so the patch stays a patch.

Fixes #2800
Fixes #2807

## Sub-defect status
**#2800** — mcp.json churn on every run: fixed (skip byte-identical rewrite); `--fresh` missing on `run`: fixed; `stop --force` over-reporting reaped processes: fixed (reports only confirmed-terminated PIDs); `ps` blind to a live leaf with a pid file: fixed (`child_pid` probe); empty dry-run preview: fixed; sonnet mislabel in dashboard: fixed. Deferred to #2874: capacity denominator wiring, full killpg reap, post-hard-stop live scan.
**#2807** — `worker --adapter` stale hardcoded allowlist rejecting registered adapters: fixed (derives from `selectable_adapter_names()` like `run --cli`); `--idle` help instructing a crashing seed: fixed; dry-run validation asymmetry: fixed (same `parse_seed` path as real runs); `start` missing from `--help`: fixed; docker worker health + macOS user note: documented. Already fixed on main (verified, no change): locked-file warnings in non-bernstein repos, conduct/start doc mismatch. Deferred to #2874: cluster topology command (new surface).

## Verification
- TDD per sub-defect; 10 touched test files green (64 passed in the regression set; 19 in the worker/adapter set).
- Three tests in `test_dry_run.py` asserting the removed server-fetch behavior were retargeted to the new hermetic seed-synth contract, preserving the server-backlog fallback for the no-seed case.
- Import sentinel: 37807 collected, no errors; ruff check/format clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `bernstein run --fresh` option.
  * Dry runs can now preview seed-based plans without contacting a task server.
  * Added the `start` command to CLI help.
  * Worker adapter choices now reflect available adapters automatically.

* **Bug Fixes**
  * Improved process detection, hard-stop reporting, and dashboard model labels.
  * Prevented unnecessary MCP configuration rewrites.

* **Documentation**
  * Added guidance for running workers in containers, including health checks and macOS permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->