### PR TITLE
fix(core): unstick heartbeat-dead agents, stop opening a locked-out dashboard, enforce the manager write boundary

### DIFF
--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -205,6 +205,33 @@ def dashboard(port: int, no_open: bool) -> None:
         )
         sys.exit(1)
 
+    # Probe /dashboard exactly as a browser would (no Authorization header). A
+    # detached run gates every non-public route behind an auto-generated Bearer
+    # token that a plain browser navigation cannot supply, so opening the URL
+    # would dead-end on a raw 401 JSON body. Guide the operator to a surface
+    # that authenticates on its own instead of launching a broken page (#2794).
+    try:
+        probe = httpx.get(url, timeout=2.0)
+        browser_reachable = probe.status_code != 401
+    except httpx.HTTPError:
+        # Probe failure is inconclusive; fall through to the normal open path
+        # rather than blocking on a transient error.
+        browser_reachable = True
+
+    if not browser_reachable:
+        from bernstein.core.defaults import SDD_AUTH_TOKEN
+
+        console.print(
+            "[yellow]The web dashboard requires authentication a browser cannot supply on its own.[/yellow]\n"
+            "This run auto-generated a Bearer token, so a plain browser navigation to the dashboard is "
+            "rejected with 401.\n"
+            "Use the terminal dashboard instead: [cyan]bernstein live[/cyan] (or [cyan]bernstein status[/cyan]), "
+            "which authenticate automatically from this workspace.\n"
+            f"The run token lives in [cyan]{SDD_AUTH_TOKEN}[/cyan] if you front the server with your own "
+            "authenticating proxy."
+        )
+        sys.exit(1)
+
     console.print(f"[green]Dashboard:[/green] [link={url}]{url}[/link]")
     if not no_open:
         webbrowser.open(url)

--- a/src/bernstein/core/agents/agent_signals.py
+++ b/src/bernstein/core/agents/agent_signals.py
@@ -81,27 +81,48 @@ class AgentSignalManager:
     # SHUTDOWN
     # ------------------------------------------------------------------
 
-    def write_shutdown(self, session_id: str, reason: str, task_title: str) -> None:
+    def write_shutdown(self, session_id: str, reason: str, task_title: str) -> bool:
         """Write a SHUTDOWN signal file telling the agent to save and exit.
+
+        Idempotent per stall episode: if a SHUTDOWN file already exists for
+        this session with the same *reason*, the file is not rewritten and no
+        log line is emitted. Without this guard the stale-heartbeat monitor
+        re-emitted (and re-logged) the identical ``no_heartbeat`` SHUTDOWN on
+        every tick, filling the logs with hundreds of identical lines while the
+        agent was never actually reaped (issue #2796). A new episode after
+        :meth:`clear_signals` re-emits normally.
 
         Args:
             session_id: The agent's session ID.
             reason: Human-readable reason for the shutdown.
             task_title: Title of the task the agent is working on.
+
+        Returns:
+            True if the signal was newly written, False if an identical
+            SHUTDOWN for this reason was already present (deduplicated).
         """
         signal_dir = self._signals_dir / session_id
-        signal_dir.mkdir(parents=True, exist_ok=True)
+        shutdown_file = signal_dir / "SHUTDOWN"
+        reason_line = f"Reason: {reason}\n"
+        try:
+            existing = shutdown_file.read_text(encoding="utf-8")
+        except OSError:
+            existing = ""
+        if reason_line in existing:
+            return False
 
+        signal_dir.mkdir(parents=True, exist_ok=True)
         content = (
             f"# SHUTDOWN - Save and exit\n"
-            f"Reason: {reason}\n"
+            f"{reason_line}"
             f"You have 30 seconds to:\n"
             f'1. Save all current work (git add + commit "[WIP] {task_title}")\n'
             f"2. Report partial progress to task server\n"
             f"3. Exit cleanly\n"
         )
-        (signal_dir / "SHUTDOWN").write_text(content, encoding="utf-8")
+        shutdown_file.write_text(content, encoding="utf-8")
         logger.info("SHUTDOWN signal written for agent %s (reason: %s)", session_id, reason)
+        return True
 
     # ------------------------------------------------------------------
     # HEARTBEAT

--- a/src/bernstein/core/agents/heartbeat.py
+++ b/src/bernstein/core/agents/heartbeat.py
@@ -16,6 +16,11 @@ from typing import Any, cast
 
 from bernstein.core.agents.agent_log_aggregator import AgentLogAggregator, AgentLogSummary
 from bernstein.core.agents.agent_signals import AgentSignalManager
+from bernstein.core.agents.heartbeat_escalation import (
+    EscalationThresholds,
+    EscalationTier,
+    HeartbeatEscalationLadder,
+)
 from bernstein.core.defaults import AGENT
 from bernstein.core.models import AgentHeartbeat, ProgressSnapshot, Task
 
@@ -331,17 +336,86 @@ def _session_task_title(session: Any) -> str:
     return ", ".join(session.task_ids) if session.task_ids else "unknown task"
 
 
+def _heartbeat_escalation_ladder(
+    orch: Any,
+    sigterm_threshold: float,
+    kill_threshold: float,
+) -> HeartbeatEscalationLadder:
+    """Return the orchestrator's heartbeat escalation ladder, creating it once.
+
+    Only the SIGTERM and SIGKILL tiers are active; the WARN/SIGUSR1 nudge tiers
+    are disabled so a stuck agent is escalated straight to a graceful then a
+    forced termination (a SIGUSR1 to a Node-based CLI adapter would start its
+    debugger, not nudge it). The ladder is stored on the orchestrator so its
+    per-tier idempotency persists across monitor ticks - without that a SIGKILL
+    (and its log line) would be re-emitted every tick.
+    """
+    ladder = getattr(orch, "_heartbeat_escalation_ladder", None)
+    if not isinstance(ladder, HeartbeatEscalationLadder):
+        ladder = HeartbeatEscalationLadder(
+            EscalationThresholds(
+                warn_s=0.0,
+                sigusr1_s=0.0,
+                sigterm_s=sigterm_threshold,
+                sigkill_s=kill_threshold,
+            )
+        )
+        with contextlib.suppress(Exception):
+            orch._heartbeat_escalation_ladder = ladder
+    return ladder
+
+
+def _terminate_stuck_agent(orch: Any, session: Any, age: float) -> None:
+    """Reap the backgrounded heartbeat loop of an agent being force-killed.
+
+    The escalation ladder has already sent SIGKILL to the agent process; its
+    death is picked up by ``refresh_agent_states`` on the next tick, which
+    requeues the orphaned task and frees the slot. This just tears down the
+    session's own backgrounded heartbeat shell loop so it does not outlive the
+    reaped agent (issue #2796).
+    """
+    logger.warning(
+        "Heartbeat-kill: agent %s heartbeat frozen for %.0fs - force-terminating stuck process",
+        session.id,
+        age,
+    )
+    _reap_session_heartbeat_loop(orch, session, reason="no_heartbeat_kill")
+
+
 def _escalate_heartbeat(
-    signal_mgr: AgentSignalManager,
+    orch: Any,
     session: Any,
     age: float,
     elapsed: float,
     shutdown_threshold: float,
     wakeup_threshold: float,
     shutdown_reason: str,
+    kill_threshold: float,
 ) -> None:
-    """Send SHUTDOWN or WAKEUP signal based on heartbeat staleness."""
+    """Escalate a stale heartbeat: WAKEUP -> SHUTDOWN -> terminal kill.
+
+    A heartbeat that never advances past its spawn-time value must not loop the
+    same SHUTDOWN signal forever. Once the age crosses ``kill_threshold`` the
+    process is force-killed (SIGTERM then SIGKILL via the escalation ladder) so
+    it is reaped and the slot frees (issue #2796). ``write_shutdown`` is itself
+    idempotent per episode, so the soft SHUTDOWN below is emitted at most once.
+    """
+    signal_mgr = orch._signal_mgr
     task_title = _session_task_title(session)
+
+    ladder = _heartbeat_escalation_ladder(orch, shutdown_threshold, kill_threshold)
+    if age < shutdown_threshold:
+        # Healthy again (or never stale): drop any prior escalation state so a
+        # later stall episode re-escalates from the start.
+        ladder.reset_agent(session.id)
+    else:
+        action = ladder.check_and_escalate(session.id, age, pid=session.pid)
+        if action is not None and action.tier >= EscalationTier.SIGKILL:
+            _terminate_stuck_agent(orch, session, age)
+            if session.pid is None or not action.action_taken:
+                with contextlib.suppress(Exception):
+                    orch._spawner.kill(session)
+
     if age >= shutdown_threshold:
         with contextlib.suppress(OSError):
             signal_mgr.write_shutdown(session.id, reason=shutdown_reason, task_title=task_title)
@@ -367,13 +441,14 @@ def _check_stale_agents_simple(orch: Any) -> None:
         age = now - hb.timestamp
         elapsed = now - session.spawn_ts
         _escalate_heartbeat(
-            orch._signal_mgr,
+            orch,
             session,
             age,
             elapsed,
             AGENT.escalation_sigterm_s,
             AGENT.escalation_warn_s,
             "no_heartbeat_120s",
+            AGENT.escalation_sigkill_s,
         )
 
 
@@ -390,6 +465,11 @@ def check_stale_agents(orch: Any) -> None:
 
     timeout_s = float(getattr(config, "heartbeat_timeout_s", AGENT.heartbeat_stale_s))
     wakeup_after_s = max(timeout_s / 2.0, AGENT.escalation_warn_s)
+    # Terminal (SIGKILL) threshold sits a fixed grace past the SHUTDOWN
+    # threshold so the configured heartbeat timeout is honoured while still
+    # forcing a kill on a heartbeat that never advances (issue #2796).
+    kill_grace_s = max(AGENT.escalation_sigkill_s - AGENT.escalation_sigterm_s, 1.0)
+    kill_after_s = timeout_s + kill_grace_s
     monitor = HeartbeatMonitor(workdir, timeout_s=timeout_s)
     for session in orch._agents.values():
         if session.status == "dead":
@@ -402,13 +482,14 @@ def check_stale_agents(orch: Any) -> None:
 
         elapsed = time.time() - session.spawn_ts
         _escalate_heartbeat(
-            orch._signal_mgr,
+            orch,
             session,
             hb_status.age_seconds,
             elapsed,
             timeout_s,
             wakeup_after_s,
             "no_heartbeat",
+            kill_after_s,
         )
 
 

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -361,6 +361,51 @@ def extract_error_aware_reason(log_text: str, max_chars: int = _FAILURE_REASON_M
     return f"(no error pattern found, showing last {_FAILURE_REASON_FALLBACK_LINES} lines)\n{tail}"[:max_chars]
 
 
+# Roles whose spawn must never run unconfined in the operator checkout.
+# The manager/planning role is told (by prompt) not to write files, but prompt
+# text is not a boundary: an ungated CLI adapter that ignores the rule writes
+# straight into its cwd (issue #2793).
+_WRITE_BOUNDARY_ROLES = frozenset({"manager"})
+
+
+def manager_write_boundary_error(
+    role: str,
+    spawn_cwd: Path,
+    workdir: Path,
+    has_os_sandbox: bool,
+) -> str | None:
+    """Return a refusal message when a planning role would run unconfined.
+
+    A stray write from a manager/planning agent must not land in the operator
+    checkout. A per-session git worktree (``spawn_cwd`` distinct from the
+    operator root) or an OS sandbox both confine writes; either satisfies the
+    boundary. When neither is present the spawn must fail loudly instead of
+    proceeding on prompt-only protection (issue #2793).
+
+    Args:
+        role: The role being spawned.
+        spawn_cwd: The resolved working directory the agent will spawn into.
+        workdir: The operator checkout root.
+        has_os_sandbox: Whether an OS-level sandbox confines the agent.
+
+    Returns:
+        An actionable error string when the spawn must be refused, else None.
+    """
+    if role not in _WRITE_BOUNDARY_ROLES:
+        return None
+    if has_os_sandbox:
+        return None
+    if spawn_cwd.resolve() != workdir.resolve():
+        # Confined to a per-session worktree (or a separate repo checkout).
+        return None
+    return (
+        f"Refusing to spawn a {role!r} agent in the operator checkout with no write "
+        f"boundary: prompt-only protection lets a stray write land untracked in your "
+        f"working tree. Run with worktree isolation (the default) or an OS sandbox "
+        f"(e.g. --sandbox docker). See issue #2793."
+    )
+
+
 def _diagnose_spawn_failure(
     session_id: str,
     spawn_cwd: Path,
@@ -3616,6 +3661,23 @@ class AgentSpawner:
                         f"Cannot create workspace for agent {session_id}: {exc}. "
                         "Fix: run 'bernstein stop' then restart, or delete .sdd/worktrees/ manually"
                     ) from exc
+
+        # Manager/planning write-boundary preflight (#2793). Once the working
+        # directory is resolved, refuse a planning agent that would run directly
+        # in the operator checkout with no OS sandbox: prompt text is not a
+        # boundary, and an ungated CLI adapter that ignores it writes straight
+        # into the operator tree. A per-session worktree or an OS sandbox both
+        # satisfy the boundary, so the default (worktree) flow is unaffected.
+        _boundary_error = manager_write_boundary_error(
+            role,
+            spawn_cwd,
+            self._workdir,
+            has_os_sandbox=(
+                self._sandbox is not None or self._container_mgr is not None or self._sandbox_backend is not None
+            ),
+        )
+        if _boundary_error is not None:
+            raise SpawnError(_boundary_error)
 
         # Install the in-process verification-gate policy for this session so a
         # gate-capable adapter (Claude Code) can refuse a failing completion or

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -13,7 +13,7 @@ import threading
 import time
 import uuid
 from contextlib import suppress
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any, cast
 
 from bernstein.adapters.base import RateLimitError, SpawnError, SpawnResult
@@ -374,13 +374,21 @@ def manager_write_boundary_error(
     workdir: Path,
     has_os_sandbox: bool,
 ) -> str | None:
-    """Return a refusal message when a planning role would run unconfined.
+    """Return a refusal message when a planning role has no isolation at all.
 
-    A stray write from a manager/planning agent must not land in the operator
-    checkout. A per-session git worktree (``spawn_cwd`` distinct from the
-    operator root) or an OS sandbox both confine writes; either satisfies the
-    boundary. When neither is present the spawn must fail loudly instead of
-    proceeding on prompt-only protection (issue #2793).
+    First of two layers for issue #2793. This one is the hard stop for the
+    worst case: a planning agent spawned directly in the operator checkout
+    with neither a per-session worktree nor an OS sandbox. There is then no
+    isolation whatsoever, so the spawn fails loudly instead of proceeding on
+    prompt-only protection.
+
+    A per-session worktree lifts this refusal because it confines the agent's
+    *relative* writes. It is not, however, a full boundary: an ungated CLI
+    adapter can still write an absolute or ``..`` path into the operator
+    checkout, which a worktree cwd does not confine. That residual escape is
+    handled by the second layer -- the reap-time stray-write sweep
+    (:func:`manager_stray_writes` / :func:`quarantine_manager_stray_writes`) --
+    which keeps the operator ``git status`` clean regardless of adapter.
 
     Args:
         role: The role being spawned.
@@ -396,7 +404,8 @@ def manager_write_boundary_error(
     if has_os_sandbox:
         return None
     if spawn_cwd.resolve() != workdir.resolve():
-        # Confined to a per-session worktree (or a separate repo checkout).
+        # A per-session worktree (or a separate repo checkout) confines
+        # relative writes; the reap-time sweep catches absolute/`..` escapes.
         return None
     return (
         f"Refusing to spawn a {role!r} agent in the operator checkout with no write "
@@ -404,6 +413,96 @@ def manager_write_boundary_error(
         f"working tree. Run with worktree isolation (the default) or an OS sandbox "
         f"(e.g. --sandbox docker). See issue #2793."
     )
+
+
+# Operator-checkout subtrees that are never a planning-agent stray write:
+# ``.sdd`` is Bernstein's own runtime state and ``.git`` is VCS metadata.
+_MANAGER_STRAY_IGNORED_TOP = frozenset({".sdd", ".git"})
+
+
+def operator_tree_untracked(workdir: Path) -> frozenset[str]:
+    """Return the untracked paths in the operator checkout (git porcelain).
+
+    Uses ``git status --porcelain --untracked-files=all`` at the operator
+    root so untracked *files* are listed individually (not collapsed to their
+    parent directory). Returns an empty set when the root is not a git repo or
+    git is unavailable, so callers degrade to a no-op rather than failing a
+    spawn or a reap.
+    """
+    from bernstein.core.git.git_basic import run_git
+
+    try:
+        result = run_git(["status", "--porcelain", "--untracked-files=all"], workdir)
+    except Exception:
+        return frozenset()
+    if not result.ok:
+        return frozenset()
+    untracked: set[str] = set()
+    for line in result.stdout.splitlines():
+        # Porcelain v1 marks untracked entries with a leading "?? ".
+        if line.startswith("?? "):
+            untracked.add(line[3:].strip().strip('"'))
+    return frozenset(untracked)
+
+
+def manager_stray_writes(workdir: Path, baseline: frozenset[str]) -> list[str]:
+    """Return operator-tree untracked paths that appeared since ``baseline``.
+
+    A planning agent is contracted to write no files in the operator checkout
+    (it creates tasks via the task server). Any untracked path present now but
+    absent at spawn time is therefore a stray write -- typically an absolute
+    or ``..`` path an ungated adapter wrote past its worktree cwd (issue
+    #2793). Entries under ``.sdd`` or ``.git`` are never counted. Result is
+    sorted for deterministic quarantine ordering.
+    """
+    stray: list[str] = []
+    for rel in sorted(operator_tree_untracked(workdir) - baseline):
+        if not rel:
+            continue
+        if PurePosixPath(rel).parts[0] in _MANAGER_STRAY_IGNORED_TOP:
+            continue
+        stray.append(rel)
+    return stray
+
+
+def quarantine_manager_stray_writes(
+    workdir: Path,
+    session_id: str,
+    stray: list[str],
+) -> Path | None:
+    """Move stray operator-tree writes into a per-session quarantine directory.
+
+    Keeps the operator ``git status`` clean -- unblocking later merge-backs --
+    while preserving the bytes for forensics under
+    ``.sdd/runtime/manager-stray/<session_id>/``. Adapter-agnostic: it acts on
+    whatever landed in the operator tree, regardless of which CLI wrote it.
+    Returns the quarantine directory when anything was moved, else None.
+    """
+    if not stray:
+        return None
+    quarantine = workdir / ".sdd" / "runtime" / "manager-stray" / session_id
+    moved: list[str] = []
+    for rel in stray:
+        src = workdir / rel
+        if not src.exists():
+            continue
+        dest = quarantine / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            shutil.move(str(src), str(dest))
+        except OSError:
+            continue
+        moved.append(rel)
+    if not moved:
+        return None
+    logger.warning(
+        "Quarantined %d stray operator-tree write(s) from planning agent %s to %s (issue #2793): %s",
+        len(moved),
+        session_id,
+        quarantine,
+        ", ".join(moved),
+    )
+    return quarantine
 
 
 def _diagnose_spawn_failure(
@@ -1350,6 +1449,10 @@ class AgentSpawner:
         self._bulletin = bulletin
         self._context_builder = TaskContextBuilder(workdir)
         self._procs: dict[str, subprocess.Popen[bytes] | None] = {}
+        # Per-session baseline of operator-checkout untracked paths, captured
+        # at manager/planning spawn so the reap-time sweep can quarantine any
+        # stray write that escaped the worktree cwd (issue #2793).
+        self._manager_write_baselines: dict[str, frozenset[str]] = {}
         self._shutdown_event: threading.Event | None = None
         self._agent_failure_timestamps: dict[str, float] = {}  # adapter_name -> last failure ts
         self._adapter_health = AdapterHealthMonitor()
@@ -1710,6 +1813,26 @@ class AgentSpawner:
         """Write the finalized trace for a reaped session."""
         finalize_agent_trace(session, self._traces, self._trace_store)
 
+    def _sweep_manager_write_boundary(self, session: AgentSession) -> Path | None:
+        """Quarantine stray operator-tree writes a reaped planning agent made.
+
+        Second write-boundary layer for issue #2793. A per-session worktree
+        confines only the planning agent's relative writes; an ungated CLI
+        adapter can still write an absolute or ``..`` path into the operator
+        checkout despite running in a worktree. Once the agent is reaped,
+        diff the operator checkout's untracked set against the spawn-time
+        baseline and move anything new into a quarantine directory, so a stray
+        write cannot block a later merge-back. Adapter-agnostic and best-effort:
+        it acts on whatever landed in the tree and never raises into reap.
+
+        Returns the quarantine directory when anything was moved, else None.
+        """
+        baseline = self._manager_write_baselines.pop(session.id, None)
+        if baseline is None or session.role not in _WRITE_BOUNDARY_ROLES:
+            return None
+        stray = manager_stray_writes(self._workdir, baseline)
+        return quarantine_manager_stray_writes(self._workdir, session.id, stray)
+
     def reap_completed_agent(
         self,
         session: AgentSession,
@@ -1717,7 +1840,7 @@ class AgentSpawner:
         defer_cleanup: bool = False,
     ) -> MergeResult | None:
         """Terminate and wait on the subprocess for a completed agent."""
-        return _reap_completed_agent(
+        result = _reap_completed_agent(
             session,
             skip_merge=skip_merge,
             defer_cleanup=defer_cleanup,
@@ -1740,6 +1863,11 @@ class AgentSpawner:
             trace_store=self._trace_store,
             merge_queue=self._merge_queue,
         )
+        # Reap-time write-boundary sweep (#2793): keep the operator checkout
+        # clean after a planning agent exits. Best-effort; never fails a reap.
+        with suppress(Exception):
+            self._sweep_manager_write_boundary(session)
+        return result
 
     def update_trace_outcome(self, session_id: str, outcome: str) -> None:
         """Update the stored trace outcome for a session."""
@@ -3678,6 +3806,16 @@ class AgentSpawner:
         )
         if _boundary_error is not None:
             raise SpawnError(_boundary_error)
+
+        # Second write-boundary layer (#2793): a worktree cwd confines only
+        # relative writes, so snapshot the operator checkout's untracked set
+        # before the planning agent runs. Any untracked path that appears by
+        # reap time (an absolute/`..` write an ungated adapter made past its
+        # worktree) is swept in _sweep_manager_write_boundary. Snapshot only
+        # for the write-boundary roles and never let it block a spawn.
+        if role in _WRITE_BOUNDARY_ROLES:
+            with suppress(Exception):
+                self._manager_write_baselines[session_id] = operator_tree_untracked(self._workdir)
 
         # Install the in-process verification-gate policy for this session so a
         # gate-capable adapter (Claude Code) can refuse a failing completion or

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,6 +69,7 @@ _SPAWNER_TMP_REPO_TESTS = {
     "test_evolve_mode.py",
     "test_failure_reduction.py",
     "test_idle_agent_detection.py",
+    "test_manager_write_boundary.py",
     "test_mcp_config.py",
     "test_mcp_manager.py",
     "test_mcp_registry.py",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,7 @@ if TYPE_CHECKING:
 _MAX_RSS_BYTES = 2 * 1024 * 1024 * 1024  # 2 GB
 
 _SPAWNER_TMP_REPO_TESTS = {
+    "test_adapter_model_default.py",
     "test_agent_signals.py",
     "test_approval_gates.py",
     "test_conflict_resolution.py",

--- a/tests/unit/test_adapter_model_default.py
+++ b/tests/unit/test_adapter_model_default.py
@@ -160,7 +160,9 @@ class TestAgyZeroConfigSpawn:
 
         monkeypatch.setattr(adapter, "spawn", _fake_spawn)
 
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)
+        # Worktree isolation is on (the default) so the manager spawn has a real
+        # write boundary; tmp_path is git-initialised by the spawner-repo fixture.
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=True)
 
         task = make_task(role="manager")
         session = spawner.spawn_for_tasks([task])

--- a/tests/unit/test_dashboard_auth_guard.py
+++ b/tests/unit/test_dashboard_auth_guard.py
@@ -1,0 +1,78 @@
+"""Regression tests for `bernstein dashboard` on an auth-gated server (#2794).
+
+A detached run gates every non-public route behind an auto-generated Bearer
+token that a plain browser navigation cannot supply, so ``GET /dashboard``
+answers ``401`` and the printed URL used to dead-end on raw JSON. The command
+must probe the dashboard as a browser would and, when it is auth-gated, guide
+the operator to a working surface instead of launching a broken page.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+from click.testing import CliRunner
+
+from bernstein.cli.commands import advanced_cmd
+
+
+def _response(status_code: int) -> httpx.Response:
+    request = httpx.Request("GET", "http://localhost:8052/probe")
+    return httpx.Response(status_code, request=request, json={"detail": "x"})
+
+
+def _fake_get(dashboard_status: int):
+    def _get(url: str, **kwargs: object) -> httpx.Response:
+        if url.endswith("/health"):
+            return _response(200)
+        if url.endswith("/dashboard"):
+            return _response(dashboard_status)
+        return _response(200)
+
+    return _get
+
+
+def test_dashboard_401_does_not_open_broken_page() -> None:
+    """An auth-gated /dashboard is not launched; the operator is guided instead."""
+    runner = CliRunner()
+    with (
+        patch.object(advanced_cmd.httpx, "get", _fake_get(401)),
+        patch("webbrowser.open") as wb_open,
+    ):
+        result = runner.invoke(advanced_cmd.dashboard, [])
+
+    assert result.exit_code == 1
+    wb_open.assert_not_called()
+    out = result.output.lower()
+    assert "auth" in out or "credential" in out or "token" in out
+    # Points at a surface that actually authenticates.
+    assert "bernstein live" in result.output or "bernstein status" in result.output
+    # No raw 401 JSON body echoed to the operator.
+    assert '{"detail"' not in result.output
+
+
+def test_dashboard_open_when_not_auth_gated() -> None:
+    """When /dashboard is reachable anonymously the browser is opened as before."""
+    runner = CliRunner()
+    with (
+        patch.object(advanced_cmd.httpx, "get", _fake_get(200)),
+        patch("webbrowser.open") as wb_open,
+    ):
+        result = runner.invoke(advanced_cmd.dashboard, [])
+
+    assert result.exit_code == 0
+    wb_open.assert_called_once()
+
+
+def test_dashboard_no_open_flag_still_guards_401() -> None:
+    """--no-open must not suppress the auth guidance on an auth-gated server."""
+    runner = CliRunner()
+    with (
+        patch.object(advanced_cmd.httpx, "get", _fake_get(401)),
+        patch("webbrowser.open") as wb_open,
+    ):
+        result = runner.invoke(advanced_cmd.dashboard, ["--no-open"])
+
+    assert result.exit_code == 1
+    wb_open.assert_not_called()

--- a/tests/unit/test_heartbeat_terminal_escalation.py
+++ b/tests/unit/test_heartbeat_terminal_escalation.py
@@ -1,0 +1,115 @@
+"""Regression tests for supervisor liveness on a frozen heartbeat (issue #2796).
+
+A live agent whose heartbeat file never advances past the spawn-time
+``"starting"`` state must not deadlock the run. The monitor loop must
+escalate a stuck heartbeat to a terminal kill (SIGTERM then SIGKILL) so the
+process is reaped and the slot is freed, instead of rewriting the same
+SHUTDOWN signal every monitor tick forever.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from bernstein.core.heartbeat import check_stale_agents
+from bernstein.core.models import AgentSession, ModelConfig
+
+from bernstein.core.agents.agent_signals import AgentSignalManager
+from bernstein.core.defaults import AGENT
+
+
+def _session(task_id: str, *, pid: int | None = 4321) -> AgentSession:
+    """A live agent session whose heartbeat never advances past spawn."""
+    return AgentSession(
+        id="A-1",
+        role="manager",
+        task_ids=[task_id],
+        status="working",
+        spawn_ts=100.0,
+        pid=pid,
+        model_config=ModelConfig("sonnet", "high"),
+    )
+
+
+def test_write_shutdown_is_idempotent_per_reason(tmp_path) -> None:
+    """write_shutdown emits and logs the same reason at most once per episode."""
+    mgr = AgentSignalManager(tmp_path)
+
+    with patch("bernstein.core.agents.agent_signals.logger") as log:
+        first = mgr.write_shutdown("A-1", reason="no_heartbeat", task_title="T-1")
+        second = mgr.write_shutdown("A-1", reason="no_heartbeat", task_title="T-1")
+        third = mgr.write_shutdown("A-1", reason="no_heartbeat", task_title="T-1")
+
+    assert first is True
+    assert second is False
+    assert third is False
+    # Logged exactly once for the whole stall episode, not once per tick.
+    assert log.info.call_count == 1
+
+    # A new episode (after signals are cleared) re-emits.
+    mgr.clear_signals("A-1")
+    with patch("bernstein.core.agents.agent_signals.logger") as log2:
+        again = mgr.write_shutdown("A-1", reason="no_heartbeat", task_title="T-1")
+    assert again is True
+    assert log2.info.call_count == 1
+
+
+def test_stale_heartbeat_escalates_to_terminal_kill() -> None:
+    """A heartbeat frozen past the SIGKILL threshold force-kills the process."""
+    session = _session("T-1", pid=4321)
+    spawner = MagicMock()
+    orch = SimpleNamespace(
+        _agents={"A-1": session},
+        _signal_mgr=MagicMock(),
+        _spawner=spawner,
+    )
+    # Heartbeat frozen at spawn (timestamp 100); age well past escalation_sigkill_s.
+    orch._signal_mgr.read_heartbeat.return_value = SimpleNamespace(timestamp=100.0)
+    kill_time = 100.0 + AGENT.escalation_sigkill_s + 10.0
+
+    with (
+        patch("bernstein.core.agents.heartbeat.time.time", return_value=kill_time),
+        patch("bernstein.core.platform_compat.kill_process_group") as kpg,
+    ):
+        check_stale_agents(orch)
+
+    # The stuck process is force-killed (SIGKILL) rather than only signalled
+    # via the SHUTDOWN file.
+    assert kpg.called
+
+
+def test_stale_heartbeat_does_not_loop_shutdown_forever() -> None:
+    """Repeated monitor ticks on a frozen heartbeat write SHUTDOWN at most once."""
+    session = _session("T-1", pid=4321)
+    orch = SimpleNamespace(
+        _agents={"A-1": session},
+        _signal_mgr=MagicMock(),
+        _spawner=MagicMock(),
+    )
+    # Age >= shutdown threshold but below the kill threshold: SHUTDOWN territory.
+    frozen_ts = 100.0
+    tick_time = frozen_ts + AGENT.escalation_sigterm_s + 5.0
+    # Real dedup lives in AgentSignalManager.write_shutdown; emulate it on the mock.
+    emitted: set[tuple[str, str]] = set()
+
+    def _dedup_shutdown(session_id: str, reason: str, task_title: str) -> bool:
+        key = (session_id, reason)
+        if key in emitted:
+            return False
+        emitted.add(key)
+        return True
+
+    orch._signal_mgr.write_shutdown.side_effect = _dedup_shutdown
+    orch._signal_mgr.read_heartbeat.return_value = SimpleNamespace(timestamp=frozen_ts)
+
+    with (
+        patch("bernstein.core.agents.heartbeat.time.time", return_value=tick_time),
+        patch("bernstein.core.platform_compat.kill_process_group"),
+    ):
+        for _ in range(5):
+            check_stale_agents(orch)
+
+    # write_shutdown may be invoked each tick, but only the first newly emits;
+    # the deduped set proves at most one SHUTDOWN reaches the agent per episode.
+    assert len(emitted) == 1

--- a/tests/unit/test_heartbeat_terminal_escalation.py
+++ b/tests/unit/test_heartbeat_terminal_escalation.py
@@ -5,18 +5,26 @@ A live agent whose heartbeat file never advances past the spawn-time
 escalate a stuck heartbeat to a terminal kill (SIGTERM then SIGKILL) so the
 process is reaped and the slot is freed, instead of rewriting the same
 SHUTDOWN signal every monitor tick forever.
+
+These tests drive the real production monitor path: ``check_stale_agents``
+runs with a real ``_workdir`` (so it takes the ``HeartbeatMonitor`` branch,
+not the workdir-less ``_check_stale_agents_simple`` fallback) and a real
+``AgentSignalManager`` reading/writing real signal files. The heartbeat is a
+real file on disk; the SHUTDOWN dedup is the real one in
+``AgentSignalManager.write_shutdown``.
 """
 
 from __future__ import annotations
 
+import signal
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from bernstein.core.heartbeat import check_stale_agents
-from bernstein.core.models import AgentSession, ModelConfig
+from bernstein.core.models import AgentHeartbeat, AgentSession, ModelConfig
 
 from bernstein.core.agents.agent_signals import AgentSignalManager
-from bernstein.core.defaults import AGENT
 
 
 def _session(task_id: str, *, pid: int | None = 4321) -> AgentSession:
@@ -29,6 +37,23 @@ def _session(task_id: str, *, pid: int | None = 4321) -> AgentSession:
         spawn_ts=100.0,
         pid=pid,
         model_config=ModelConfig("sonnet", "high"),
+    )
+
+
+def _orch(workdir: Path, *, timeout_s: float) -> SimpleNamespace:
+    """A minimal orchestrator stand-in that routes through the workdir path.
+
+    ``_workdir`` is a real ``Path`` so ``check_stale_agents`` takes the
+    production ``HeartbeatMonitor`` branch (with its ``kill_after_s =
+    heartbeat_timeout_s + kill_grace_s`` threshold math), not the
+    workdir-less ``_check_stale_agents_simple`` fallback.
+    """
+    return SimpleNamespace(
+        _agents={"A-1": _session("T-1")},
+        _signal_mgr=AgentSignalManager(workdir),
+        _spawner=MagicMock(),
+        _workdir=workdir,
+        _config=SimpleNamespace(heartbeat_enabled=True, heartbeat_timeout_s=timeout_s),
     )
 
 
@@ -55,61 +80,57 @@ def test_write_shutdown_is_idempotent_per_reason(tmp_path) -> None:
     assert log2.info.call_count == 1
 
 
-def test_stale_heartbeat_escalates_to_terminal_kill() -> None:
-    """A heartbeat frozen past the SIGKILL threshold force-kills the process."""
-    session = _session("T-1", pid=4321)
-    spawner = MagicMock()
-    orch = SimpleNamespace(
-        _agents={"A-1": session},
-        _signal_mgr=MagicMock(),
-        _spawner=spawner,
-    )
-    # Heartbeat frozen at spawn (timestamp 100); age well past escalation_sigkill_s.
-    orch._signal_mgr.read_heartbeat.return_value = SimpleNamespace(timestamp=100.0)
-    kill_time = 100.0 + AGENT.escalation_sigkill_s + 10.0
+def test_stale_heartbeat_escalates_to_terminal_kill(tmp_path: Path) -> None:
+    """A heartbeat frozen past the production SIGKILL threshold force-kills.
+
+    ``heartbeat_timeout_s`` is 60, so the production kill threshold is
+    ``60 + kill_grace_s (30) = 90``. The frozen age is 100: past the
+    production threshold but *below* the workdir-less fallback's fixed
+    ``escalation_sigkill_s`` (150). A SIGKILL therefore proves the run went
+    through ``check_stale_agents``' production threshold math, not the
+    ``_check_stale_agents_simple`` fallback the previous test exercised.
+    """
+    orch = _orch(tmp_path, timeout_s=60.0)
+    # Heartbeat frozen at t=1000; the monitor tick runs at t=1100 (age 100s).
+    orch._signal_mgr.write_heartbeat("A-1", AgentHeartbeat(timestamp=1000.0, status="starting"))
 
     with (
-        patch("bernstein.core.agents.heartbeat.time.time", return_value=kill_time),
+        patch("bernstein.core.agents.heartbeat.time.time", return_value=1100.0),
         patch("bernstein.core.platform_compat.kill_process_group") as kpg,
     ):
         check_stale_agents(orch)
 
-    # The stuck process is force-killed (SIGKILL) rather than only signalled
-    # via the SHUTDOWN file.
-    assert kpg.called
+    # The stuck process is force-killed (SIGKILL to its pid), not merely
+    # signalled via the SHUTDOWN file.
+    assert kpg.called, "a frozen heartbeat past the kill threshold must be force-killed"
+    kill_args = kpg.call_args.args
+    assert kill_args[0] == 4321
+    assert signal.SIGKILL in kill_args
 
 
-def test_stale_heartbeat_does_not_loop_shutdown_forever() -> None:
-    """Repeated monitor ticks on a frozen heartbeat write SHUTDOWN at most once."""
-    session = _session("T-1", pid=4321)
-    orch = SimpleNamespace(
-        _agents={"A-1": session},
-        _signal_mgr=MagicMock(),
-        _spawner=MagicMock(),
-    )
-    # Age >= shutdown threshold but below the kill threshold: SHUTDOWN territory.
-    frozen_ts = 100.0
-    tick_time = frozen_ts + AGENT.escalation_sigterm_s + 5.0
-    # Real dedup lives in AgentSignalManager.write_shutdown; emulate it on the mock.
-    emitted: set[tuple[str, str]] = set()
+def test_stale_heartbeat_does_not_loop_shutdown_forever(tmp_path: Path) -> None:
+    """Repeated monitor ticks on a frozen heartbeat write SHUTDOWN at most once.
 
-    def _dedup_shutdown(session_id: str, reason: str, task_title: str) -> bool:
-        key = (session_id, reason)
-        if key in emitted:
-            return False
-        emitted.add(key)
-        return True
-
-    orch._signal_mgr.write_shutdown.side_effect = _dedup_shutdown
-    orch._signal_mgr.read_heartbeat.return_value = SimpleNamespace(timestamp=frozen_ts)
+    The dedup under test is the real one in ``AgentSignalManager.write_shutdown``
+    (a real signal directory on disk), reached through the production
+    ``check_stale_agents`` path -- not an emulated ``side_effect`` on a mock.
+    Age 70 sits in SHUTDOWN territory (>= timeout 60) but below the kill
+    threshold (90), so the run stays in the soft-signal tier across ticks.
+    """
+    orch = _orch(tmp_path, timeout_s=60.0)
+    orch._signal_mgr.write_heartbeat("A-1", AgentHeartbeat(timestamp=1000.0, status="starting"))
 
     with (
-        patch("bernstein.core.agents.heartbeat.time.time", return_value=tick_time),
+        patch("bernstein.core.agents.heartbeat.time.time", return_value=1070.0),
         patch("bernstein.core.platform_compat.kill_process_group"),
+        patch("bernstein.core.agents.agent_signals.logger") as log,
     ):
         for _ in range(5):
             check_stale_agents(orch)
 
-    # write_shutdown may be invoked each tick, but only the first newly emits;
-    # the deduped set proves at most one SHUTDOWN reaches the agent per episode.
-    assert len(emitted) == 1
+    # The SHUTDOWN file is written and logged exactly once for the whole
+    # stall episode, not once per tick.
+    assert log.info.call_count == 1
+    shutdown_file = tmp_path / ".sdd" / "runtime" / "signals" / "A-1" / "SHUTDOWN"
+    assert shutdown_file.exists()
+    assert "Reason: no_heartbeat" in shutdown_file.read_text(encoding="utf-8")

--- a/tests/unit/test_manager_write_boundary.py
+++ b/tests/unit/test_manager_write_boundary.py
@@ -1,0 +1,103 @@
+"""Write-boundary preflight for the manager/planning spawn (issue #2793).
+
+A planning agent is told (by prompt) not to write files, but prompt text is not
+a security boundary: an ungated CLI adapter that ignores the rule writes
+straight into whatever cwd it runs in. When the manager would run directly in
+the operator checkout with no OS sandbox, the spawn must fail loudly instead of
+proceeding on prompt-only protection and letting a stray write land untracked
+in the operator working tree. A per-session git worktree (a cwd distinct from
+the operator root) or an OS sandbox both satisfy the boundary.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from bernstein.core.spawner import AgentSpawner
+
+from bernstein.adapters.agy import AgyAdapter
+from bernstein.adapters.base import SpawnError, SpawnResult
+from bernstein.core.agents.spawner_core import manager_write_boundary_error
+
+
+def test_manager_in_operator_tree_without_sandbox_is_refused(tmp_path: Path) -> None:
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+    err = manager_write_boundary_error(
+        role="manager",
+        spawn_cwd=workdir,
+        workdir=workdir,
+        has_os_sandbox=False,
+    )
+    assert err is not None
+    assert "manager" in err
+    assert "worktree" in err.lower() or "sandbox" in err.lower()
+
+
+def test_manager_in_worktree_is_allowed(tmp_path: Path) -> None:
+    workdir = tmp_path / "repo"
+    worktree = tmp_path / "worktrees" / "manager-abc"
+    workdir.mkdir()
+    worktree.mkdir(parents=True)
+    assert (
+        manager_write_boundary_error(
+            role="manager",
+            spawn_cwd=worktree,
+            workdir=workdir,
+            has_os_sandbox=False,
+        )
+        is None
+    )
+
+
+def test_manager_with_os_sandbox_is_allowed(tmp_path: Path) -> None:
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+    assert (
+        manager_write_boundary_error(
+            role="manager",
+            spawn_cwd=workdir,
+            workdir=workdir,
+            has_os_sandbox=True,
+        )
+        is None
+    )
+
+
+def test_non_manager_role_is_not_gated(tmp_path: Path) -> None:
+    """The preflight targets the planning role; workers are gated elsewhere."""
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+    assert (
+        manager_write_boundary_error(
+            role="backend",
+            spawn_cwd=workdir,
+            workdir=workdir,
+            has_os_sandbox=False,
+        )
+        is None
+    )
+
+
+def test_full_spawn_refuses_manager_without_boundary(tmp_path: Path, make_task, monkeypatch) -> None:
+    """A manager spawn with no worktree and no sandbox fails loudly, not silently.
+
+    ``use_worktrees=False`` leaves spawn_cwd at the operator root and no sandbox
+    is configured, so there is no effective write boundary for the CLI adapter.
+    """
+    templates_dir = tmp_path / "templates" / "roles"
+    templates_dir.mkdir(parents=True)
+
+    adapter = AgyAdapter()
+    # adapter.spawn must never be reached: the preflight refuses before launch.
+    monkeypatch.setattr(
+        adapter,
+        "spawn",
+        lambda **_kwargs: SpawnResult(pid=1, log_path=tmp_path / "agent.log"),
+    )
+
+    spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False, default_model="default")
+
+    with pytest.raises(SpawnError, match="operator checkout"):
+        spawner.spawn_for_tasks([make_task(role="manager")])

--- a/tests/unit/test_manager_write_boundary.py
+++ b/tests/unit/test_manager_write_boundary.py
@@ -1,24 +1,42 @@
-"""Write-boundary preflight for the manager/planning spawn (issue #2793).
+"""Write boundary for the manager/planning spawn (issue #2793).
 
 A planning agent is told (by prompt) not to write files, but prompt text is not
 a security boundary: an ungated CLI adapter that ignores the rule writes
-straight into whatever cwd it runs in. When the manager would run directly in
-the operator checkout with no OS sandbox, the spawn must fail loudly instead of
-proceeding on prompt-only protection and letting a stray write land untracked
-in the operator working tree. A per-session git worktree (a cwd distinct from
-the operator root) or an OS sandbox both satisfy the boundary.
+straight into whatever path it targets. Two layers defend the operator tree:
+
+1. Preflight refusal -- the hard stop when there is no isolation at all
+   (manager in the operator checkout, no worktree, no OS sandbox).
+2. Reap-time stray-write sweep -- a per-session worktree confines only the
+   agent's *relative* writes; an absolute/``..`` path still escapes into the
+   operator checkout. The sweep snapshots the operator tree's untracked set at
+   spawn and quarantines anything new once the agent is reaped, so the operator
+   ``git status`` stays clean regardless of which adapter ran.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
+from bernstein.core.models import AgentSession, ModelConfig
 from bernstein.core.spawner import AgentSpawner
 
 from bernstein.adapters.agy import AgyAdapter
-from bernstein.adapters.base import SpawnError, SpawnResult
-from bernstein.core.agents.spawner_core import manager_write_boundary_error
+from bernstein.adapters.base import CLIAdapter, SpawnError, SpawnResult
+from bernstein.core.agents.spawner_core import (
+    manager_stray_writes,
+    manager_write_boundary_error,
+    operator_tree_untracked,
+    quarantine_manager_stray_writes,
+)
+
+
+def _write_manager_role_config(templates_dir: Path) -> None:
+    """Mirror the shipped manager role template (default_model: opus)."""
+    role_dir = templates_dir / "manager"
+    role_dir.mkdir(parents=True, exist_ok=True)
+    (role_dir / "config.yaml").write_text("default_model: opus\ndefault_effort: max\n")
 
 
 def test_manager_in_operator_tree_without_sandbox_is_refused(tmp_path: Path) -> None:
@@ -101,3 +119,112 @@ def test_full_spawn_refuses_manager_without_boundary(tmp_path: Path, make_task, 
 
     with pytest.raises(SpawnError, match="operator checkout"):
         spawner.spawn_for_tasks([make_task(role="manager")])
+
+
+# --- Layer 2: reap-time stray-write sweep (the worktree escape) ------------
+
+
+def test_operator_tree_untracked_lists_new_files(tmp_path: Path) -> None:
+    """The snapshot reports untracked files created in the operator checkout."""
+    assert "hello.txt" not in operator_tree_untracked(tmp_path)
+    (tmp_path / "hello.txt").write_text("x", encoding="utf-8")
+    assert "hello.txt" in operator_tree_untracked(tmp_path)
+
+
+def test_manager_stray_writes_diffs_baseline_and_ignores_runtime(tmp_path: Path) -> None:
+    """Only untracked paths that appeared *after* the baseline count as stray.
+
+    Paths present at baseline (a pre-existing operator scratch file) and the
+    ``.sdd`` runtime subtree are never reported.
+    """
+    (tmp_path / "preexisting.txt").write_text("kept", encoding="utf-8")
+    baseline = operator_tree_untracked(tmp_path)
+
+    (tmp_path / "escaped.txt").write_text("stray", encoding="utf-8")
+    runtime_marker = tmp_path / ".sdd" / "runtime"
+    runtime_marker.mkdir(parents=True, exist_ok=True)
+    (runtime_marker / "state.json").write_text("{}", encoding="utf-8")
+
+    stray = manager_stray_writes(tmp_path, baseline)
+    assert stray == ["escaped.txt"]
+
+
+def test_quarantine_moves_stray_and_cleans_operator_tree(tmp_path: Path) -> None:
+    """Quarantine relocates stray writes and leaves the operator tree clean."""
+    (tmp_path / "escaped.txt").write_text("stray", encoding="utf-8")
+    baseline: frozenset[str] = frozenset()
+
+    stray = manager_stray_writes(tmp_path, baseline)
+    dest = quarantine_manager_stray_writes(tmp_path, "manager-abc", stray)
+
+    assert dest is not None
+    assert not (tmp_path / "escaped.txt").exists()
+    assert "escaped.txt" not in operator_tree_untracked(tmp_path)
+    moved = tmp_path / ".sdd" / "runtime" / "manager-stray" / "manager-abc" / "escaped.txt"
+    assert moved.read_text(encoding="utf-8") == "stray"
+
+
+def test_planning_spawn_out_of_scope_write_is_contained(tmp_path: Path, make_task, monkeypatch) -> None:
+    """A planning agent's out-of-scope write leaves the operator tree unaffected.
+
+    The manager runs in a per-session worktree (the default), but the adapter
+    writes an absolute path into the operator checkout root that the worktree
+    cwd does not confine. The write happens; the reap-time sweep then contains
+    it so the operator ``git status`` is clean (acceptance #1/#2 for #2793).
+    Adapter-agnostic: the sweep acts on whatever landed in the operator tree.
+    """
+    templates_dir = tmp_path / "templates" / "roles"
+    _write_manager_role_config(templates_dir)
+
+    stray = tmp_path / "hello.txt"
+    adapter = AgyAdapter()
+
+    def _fake_spawn(*, model_config: ModelConfig, **_kwargs) -> SpawnResult:
+        # Simulate an ungated CLI adapter writing straight into the operator
+        # checkout root, past its worktree cwd.
+        stray.write_text("stray planning output", encoding="utf-8")
+        return SpawnResult(pid=4321, log_path=tmp_path / "agent.log")
+
+    monkeypatch.setattr(adapter, "spawn", _fake_spawn)
+
+    spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=True, default_model="default")
+
+    session = spawner.spawn_for_tasks([make_task(role="manager")])
+
+    # The out-of-scope write actually happened (defect reproduced).
+    assert stray.exists()
+    assert "hello.txt" in operator_tree_untracked(tmp_path)
+
+    # The reap-time sweep contains it: operator tree clean, bytes preserved.
+    spawner._sweep_manager_write_boundary(session)
+
+    assert not stray.exists()
+    assert "hello.txt" not in operator_tree_untracked(tmp_path)
+    quarantined = tmp_path / ".sdd" / "runtime" / "manager-stray" / session.id / "hello.txt"
+    assert quarantined.read_text(encoding="utf-8") == "stray planning output"
+
+
+def test_reap_invokes_write_boundary_sweep(tmp_path: Path) -> None:
+    """reap_completed_agent runs the sweep so a stray write is contained on reap."""
+    templates_dir = tmp_path / "templates" / "roles"
+    templates_dir.mkdir(parents=True)
+
+    adapter = MagicMock(spec=CLIAdapter)
+    adapter.is_rate_limited.return_value = False
+    spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)
+
+    session = AgentSession(id="manager-xyz", role="manager", model_config=ModelConfig("sonnet", "high"))
+    # Baseline captured at spawn: the operator tree was clean of this write.
+    spawner._manager_write_baselines[session.id] = operator_tree_untracked(tmp_path)
+    spawner._procs[session.id] = MagicMock()
+
+    # A stray write lands in the operator checkout while the agent runs.
+    stray = tmp_path / "escaped.txt"
+    stray.write_text("oops", encoding="utf-8")
+    assert "escaped.txt" in operator_tree_untracked(tmp_path)
+
+    spawner.reap_completed_agent(session, skip_merge=True)
+
+    assert not stray.exists()
+    assert "escaped.txt" not in operator_tree_untracked(tmp_path)
+    assert (tmp_path / ".sdd" / "runtime" / "manager-stray" / session.id / "escaped.txt").exists()


### PR DESCRIPTION
## What
Three independent lifecycle/safety fixes for milestone v3.8.4, one commit per issue.

Fixes #2796
Fixes #2794
Fixes #2793

## Per issue
- **#2796 supervisor deadlock on stuck-at-"starting" heartbeat**: the stale-agent check rewrote the SHUTDOWN signal forever without ever escalating. The heartbeat escalation ladder is now wired into `check_stale_agents`: past the SIGTERM/SIGKILL thresholds the stuck process is force-terminated (ladder SIGKILL, or spawner.kill fallback for pid-less backends), its heartbeat loop is reaped, and the task returns to the queue.
- **#2794 detached run locks out monitors**: symptom A (token never persisted) was verified already fixed on main — no change. Symptom B fixed at patch level: before opening the browser dashboard the CLI probes `GET /dashboard` unauthenticated the way a browser would; on 401 it prints an actionable message (terminal dashboard + token path) instead of launching a broken page.
- **#2793 manager spawn writes into the operator checkout**: new adapter-agnostic write-boundary preflight in `AgentSpawner.spawn` — a manager/planning spawn that would run in the operator checkout root with no OS sandbox is refused with an actionable `SpawnError` instead of relying on prompt-only protection.

## Verification
- TDD per issue with red evidence; heartbeat/stall set 111 passed; detached-auth suite 15 passed; spawner/write-boundary set 182 passed.
- Import sentinel: 37797 collected, no errors; ruff clean on changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dashboard access checks that provide clear authentication and token guidance when browser access is restricted.
  * Added safeguards to prevent planning agents from writing unintended files into the operator checkout.
  * Added automatic quarantine for stray files created by manager or planning agents.
* **Bug Fixes**
  * Improved stale-agent handling with controlled shutdown escalation and force-kill timing.
  * Prevented repeated shutdown signals during the same stalled-agent episode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->