### PR TITLE
test(security): invert the concurrent-writer expectation now that appends are locked

### DIFF
--- a/tests/unit/test_audit_adversarial.py
+++ b/tests/unit/test_audit_adversarial.py
@@ -407,15 +407,16 @@ class TestConcurrentWriters:
         # POSIX O_APPEND guarantees data atomicity for sub-PIPE_BUF writes.
         assert total == 10, f"expected 10 records, got {total}"
 
-    def test_concurrent_chain_break_is_detected(self, tmp_path: Path) -> None:
-        """Without a file lock, two interleaved writers MUST break the chain.
+    def test_concurrent_writers_keep_the_chain_intact(self, tmp_path: Path) -> None:
+        """With the append lock, two interleaved writers keep one valid chain.
 
-        Both processes load ``_prev_hmac = GENESIS`` on their fresh AuditLog
-        instances. Synchronized via a barrier, they then race-write against the
-        same cached prev_hmac → ``verify()`` reports HMAC mismatches.
-
-        If a future fix adds inter-process locking with proper prev_hmac
-        re-read on each append, this assertion flips and guards the lock.
+        ``AuditLog.log()`` holds a per-audit-dir ``fcntl`` lock across
+        tail-recovery and append, re-reading the on-disk tail when another
+        writer appended, so barrier-synchronized racing processes serialize
+        into a single verifiable chain. This inverts the pre-lock expectation
+        this test used to document (racing writers breaking the chain) and
+        now guards the lock itself: if it starts failing, the cross-process
+        append lock has regressed.
         """
         audit_dir = tmp_path / "audit"
         audit_dir.mkdir()
@@ -430,15 +431,11 @@ class TestConcurrentWriters:
 
         log = AuditLog(audit_dir, key=_TEST_KEY)
         valid, errors = log.verify()
-        # Without inter-process locking, the chain must be detected as broken.
-        # Note: this test documents the current limitation - a future fix
-        # that adds proper locking would flip this assertion.
-        assert valid is False, (
-            "Concurrent writers without a file lock should produce a broken "
-            "chain that verify() detects. If this assertion flips, a lock "
-            "has been added (good!) - invert this expectation."
+        assert valid is True, (
+            "Concurrent writers must serialize through the cross-process "
+            f"append lock into one verifiable chain; verify() errors: {errors}"
         )
-        assert errors, "broken chain should produce at least one error"
+        assert errors == [], "an intact chain must produce no verify errors"
 
 
 # -- 8. Wrong-key tamper attempt -------------------------------------------


### PR DESCRIPTION
## What
Un-reds main after the audit-lineage merge: `test_audit_adversarial.py::TestConcurrentWriters` asserted that two barrier-synchronized writers racing the same audit log MUST break the chain — explicitly documenting the pre-lock limitation, with its own failure message instructing: *"If this assertion flips, a lock has been added (good!) — invert this expectation."*

The cross-process append lock landed on main with the audit HMAC key unification, so the assertion flipped exactly as predicted (main shard 4, both Pythons). This inverts the test so it now guards the lock: concurrent writers must serialize into one verifiable chain with zero verify errors.

## Verification
- `tests/unit/test_audit_adversarial.py` green locally post-inversion (includes the real two-process barrier race).
- Test-only change; no source touched.