### PR TITLE
fix(security): sanitize caller-supplied paths before the SLA receipt log sink

### DIFF
--- a/src/bernstein/core/orchestration/sla_receipt.py
+++ b/src/bernstein/core/orchestration/sla_receipt.py
@@ -61,6 +61,7 @@ from bernstein.core.planning.sla_store import (
     compute_contract_id,
     contract_from_dict,
 )
+from bernstein.core.security.sanitize import sanitize_log
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -519,7 +520,7 @@ def read_receipt_file(path: Path) -> SLAViolationReceipt | None:
     try:
         raw = json.loads(path.read_text())
     except (OSError, json.JSONDecodeError) as exc:
-        logger.warning("Could not load SLA receipt %s: %s", path, exc)
+        logger.warning("Could not load SLA receipt %s: %s", sanitize_log(str(path)), exc)
         return None
     if not isinstance(raw, dict):
         return None

--- a/tests/unit/test_sla_receipt_log_sanitization.py
+++ b/tests/unit/test_sla_receipt_log_sanitization.py
@@ -1,0 +1,77 @@
+"""Log-sanitization tests for the SLA receipt file loader (#2696).
+
+``read_receipt_file`` logs a caller-supplied path when a receipt fails to
+load.  The path reaches the loader straight from the operator (via
+``sla verify <file>``) or from a less-trusted caller, so a value carrying
+CR/LF could split the single log line into several and forge additional log
+records (log injection).  The sink-side ``sanitize_log`` wrapper escapes
+CR/LF at the ``logger.*`` call so the record stays one line even when a
+control character reaches it.
+
+These tests assert:
+
+1.  A CR/LF-bearing path is escaped in the emitted log record -- no raw line
+    break survives, so the record cannot forge a second log line.  Removing
+    the escaper from the call site makes this test fail.
+2.  A plain path (no control chars) is logged verbatim -- sanitizing does not
+    change the logged meaning for non-malicious input.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from bernstein.core.orchestration.sla_receipt import read_receipt_file
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+_LOGGER_NAME = "bernstein.core.orchestration.sla_receipt"
+_MSG_PREFIX = "Could not load SLA receipt"
+
+
+def _load_failure_records(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [
+        r.getMessage()
+        for r in caplog.records
+        if r.getMessage().startswith(_MSG_PREFIX)
+    ]
+
+
+def test_crlf_path_is_escaped_in_load_failure_log(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    # A file whose name embeds CR/LF plus a forged-looking log line; invalid
+    # JSON so the load hits the ``except`` branch that logs the path.
+    forged = tmp_path / "receipt\r\nCould not load SLA receipt FORGED.json"
+    forged.write_text("not valid json")
+
+    caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
+    assert read_receipt_file(forged) is None
+
+    records = _load_failure_records(caplog)
+    # Exactly one log record: the injected newline must not split the line.
+    assert len(records) == 1, f"expected one load-failure line, got: {caplog.text}"
+    line = records[0]
+    assert "\r" not in line
+    assert "\n" not in line
+    # The escaped forms are present instead of raw control characters.
+    assert "\\r\\n" in line
+
+
+def test_plain_path_is_logged_verbatim(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    plain = tmp_path / "receipt.json"
+    plain.write_text("not valid json")
+
+    caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
+    assert read_receipt_file(plain) is None
+
+    records = _load_failure_records(caplog)
+    assert len(records) == 1, f"expected one load-failure line, got: {caplog.text}"
+    # A path with no control characters is unchanged by the escaper.
+    assert str(plain) in records[0]


### PR DESCRIPTION
## What
`read_receipt_file` in `sla_receipt.py` interpolated the caller-supplied path straight into `logger.warning`, so a path carrying CR/LF split the record and forged log lines — reachable from `sla verify <file>`.

Fixes #2696

## How
Route the path through the established sink-side `sanitize_log` helper (same pattern as the other orchestration modules). Module audited: this was the only logger call in the file; the exception text is safe by construction (`OSError.__str__` repr-escapes filenames — verified empirically).

## Verification
- Red first: the new test captured the raw CR/LF split with a forged second line; green after the one-line fix.
- `test_sla_receipt_log_sanitization.py` + `test_sla_receipt.py` = 14 passed; ruff clean; sentinel clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security when reporting SLA receipt file parsing failures by escaping control characters in logged file paths.
  * Prevents crafted paths from injecting misleading content into warning logs.

* **Tests**
  * Added coverage for paths containing carriage returns and line feeds.
  * Confirmed ordinary file paths continue to appear unchanged in logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->