### PR TITLE
fix(security): lineage verify fails closed on a missing audit key instead of reporting tamper

### DIFF
--- a/docs/concepts/artifact-lineage.md
+++ b/docs/concepts/artifact-lineage.md
@@ -62,6 +62,26 @@ verify` reports that case as the distinct **`SEAL_ONLY`** status with a
 non-zero exit, rather than a clean `OK`, so a chain with no artifact
 provenance is never mistaken for "provenance confirmed".
 
+### The audit key is required (verify never mints one)
+
+Each spine entry is HMAC-tagged with the install's audit key. `verify` only
+reads the chain, so it loads that key **read-only** and never creates one: a
+freshly minted key cannot authenticate an existing chain, so every tag would
+fail and a plain missing-key setup error would be misreported as tamper. When
+no key is found, `verify` fails closed with a clear "key missing" message and
+exits `3` (distinct from `2` = tamper).
+
+The key is resolved from `$BERNSTEIN_AUDIT_KEY_PATH` or the XDG state path. An
+auditor verifying a handed-over evidence package points `--key-path` at the key
+the chain was written under:
+
+```bash
+bernstein lineage verify <run_id> --key-path ./handover/audit.key
+```
+
+Exit codes: `0` OK, `1` no entries / seal-only, `2` tamper detected,
+`3` cannot verify (audit key missing).
+
 ## Programmatic access
 
 ```python

--- a/docs/lineage.md
+++ b/docs/lineage.md
@@ -199,7 +199,10 @@ bernstein lineage verify <run_id> \
 ```
 
 Exit codes: `0` the receipt resolves on an intact chain (and, with
-`--receipt-file`, its content matches the anchored entry); `2` it does not.
+`--receipt-file`, its content matches the anchored entry); `2` it does not;
+`3` the audit key is missing so the chain cannot be verified. Verification
+loads the HMAC key read-only and never mints one -- pass `--key-path` to point
+at the key the chain was written under.
 
 Guarantees:
 

--- a/src/bernstein/cli/commands/lineage_verify_cmd.py
+++ b/src/bernstein/cli/commands/lineage_verify_cmd.py
@@ -26,10 +26,24 @@ from bernstein.cli.helpers import console
 from bernstein.core.lineage.spine import LineageSpine, SpineStatus
 
 
-def _load_hmac_key() -> bytes:
-    from bernstein.core.security.audit import load_or_create_audit_key
+def _load_hmac_key(key_path: Path | None = None) -> bytes:
+    """Load the audit HMAC key read-only for a verify pass.
 
-    return load_or_create_audit_key()
+    ``verify`` only reads the chain, so it must never mint key material.
+    ``load_or_create_audit_key`` would generate a fresh key on a machine that
+    has none -- and that key cannot authenticate a chain written under the real
+    key, so every HMAC tag would fail and a plain missing-key setup error would
+    be misreported as tamper (issue #2639). Load read-only and fail closed with
+    a clear "key missing" error and a distinct exit code instead.
+    """
+    from bernstein.core.security.audit import AuditKeyMissingError, load_audit_key
+
+    try:
+        return load_audit_key(key_path)
+    except AuditKeyMissingError as exc:
+        console.print()
+        console.print(f"[yellow]CANNOT VERIFY[/yellow] -- {exc}")
+        raise SystemExit(3) from exc
 
 
 def _spine_dir(workdir: str) -> Path:
@@ -66,12 +80,21 @@ def _spine_dir(workdir: str) -> Path:
     default=None,
     help="Recovery receipt artifact JSON; content-addresses it against the anchored entry.",
 )
+@click.option(
+    "--key-path",
+    "key_path",
+    type=click.Path(dir_okay=False, exists=True),
+    default=None,
+    help="Audit HMAC key file the chain was written under (read-only; never mints a key). "
+    "Defaults to $BERNSTEIN_AUDIT_KEY_PATH or the XDG state key.",
+)
 def lineage_verify_cmd(
     run_id: str,
     workdir: str,
     public_key_path: str | None,
     receipt_hash: str | None,
     receipt_file: str | None,
+    key_path: str | None,
 ) -> None:
     """Verify the lineage spine for *run_id*.
 
@@ -80,16 +103,17 @@ def lineage_verify_cmd(
     Merkle-chained, HMAC-tagged spine entry.
 
     Exit codes: 0 = OK, 1 = no entries / seal-only (no artifact provenance) /
-    bad input, 2 = tamper detected.
+    bad input, 2 = tamper detected, 3 = cannot verify (audit key missing).
     """
+    key_path_resolved = Path(key_path) if key_path is not None else None
     lineage_root = _spine_dir(workdir)
     spine_path = lineage_root / run_id / "spine.jsonl"
 
     if receipt_hash is not None:
-        _verify_receipt(run_id, lineage_root, spine_path, receipt_hash, receipt_file)
+        _verify_receipt(run_id, lineage_root, spine_path, receipt_hash, receipt_file, key_path_resolved)
 
     if spine_path.exists():
-        spine = LineageSpine(lineage_root, run_id=run_id, hmac_key=_load_hmac_key())
+        spine = LineageSpine(lineage_root, run_id=run_id, hmac_key=_load_hmac_key(key_path_resolved))
         result = spine.verify()
         console.print()
         console.print(f"[bold]Lineage spine[/bold] run={run_id} entries={result.count} head={spine.head_hash()[:16]}")
@@ -126,10 +150,12 @@ def _verify_receipt(
     spine_path: Path,
     receipt_hash: str,
     receipt_file: str | None,
+    key_path: Path | None = None,
 ) -> None:
     """Resolve a recovery receipt hash against the run's spine (issue #2557).
 
-    Exit codes: 0 = receipt resolves on an intact chain, 2 = it does not.
+    Exit codes: 0 = receipt resolves on an intact chain, 2 = it does not,
+    3 = cannot verify (audit key missing).
     """
     from bernstein.core.planning.recovery_receipt import resolve_receipt_on_spine
 
@@ -138,7 +164,7 @@ def _verify_receipt(
         console.print(f"[red]No spine for run[/red] {run_id} -- cannot resolve receipt {receipt_hash}.")
         raise SystemExit(2)
 
-    spine = LineageSpine(lineage_root, run_id=run_id, hmac_key=_load_hmac_key())
+    spine = LineageSpine(lineage_root, run_id=run_id, hmac_key=_load_hmac_key(key_path))
     content = Path(receipt_file).read_bytes() if receipt_file is not None else None
     resolution = resolve_receipt_on_spine(spine, entry_hash=receipt_hash, receipt_content=content)
 

--- a/tests/unit/lineage/test_spine_cli.py
+++ b/tests/unit/lineage/test_spine_cli.py
@@ -197,3 +197,52 @@ def test_verify_receipt_missing_hash_fails(tmp_path: Path, monkeypatch) -> None:
     result = _run(["verify", "run-1", "--workdir", str(tmp_path), "--receipt-hash", "sha256:deadbeef"])
     assert result.exit_code == 2
     assert "failed" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# Read-only key handling (issue #2639): verify must never mint an HMAC key.
+# ---------------------------------------------------------------------------
+
+
+def test_verify_missing_key_fails_closed_not_tamper(tmp_path: Path, monkeypatch) -> None:
+    # No key file exists at the resolved path. A read-only verify must fail
+    # closed with a clear key-missing error rather than minting a fresh key --
+    # a minted key cannot authenticate the existing chain, so every HMAC tag
+    # would fail and the setup error would be misreported as tamper.
+    key_path = tmp_path / "state" / "audit.key"
+    monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(key_path))
+    _seed(tmp_path, "run-1")
+
+    result = _run(["verify", "run-1", "--workdir", str(tmp_path)])
+    assert result.exit_code == 3, result.output
+    assert "tamper" not in result.output.lower()
+    assert "key" in result.output.lower()
+    # The verify path must never create key material.
+    assert not key_path.exists()
+
+
+def test_verify_key_path_option_reads_named_key(tmp_path: Path, monkeypatch) -> None:
+    # The chain was written under a key stored at a non-default location; an
+    # auditor points --key-path at it to verify a handed-over evidence package.
+    monkeypatch.delenv("BERNSTEIN_AUDIT_KEY_PATH", raising=False)
+    key_file = tmp_path / "handover" / "audit.key"
+    key_file.parent.mkdir(parents=True)
+    key_file.write_bytes(_KEY)
+    key_file.chmod(0o600)
+    spine = _seed(tmp_path, "run-1")
+
+    result = _run(["verify", "run-1", "--workdir", str(tmp_path), "--key-path", str(key_file)])
+    assert result.exit_code == 0, result.output
+    assert spine.head_hash()[:16] in result.output
+    assert "OK" in result.output
+
+
+def test_verify_receipt_missing_key_fails_closed(tmp_path: Path, monkeypatch) -> None:
+    key_path = tmp_path / "state" / "audit.key"
+    monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(key_path))
+    entry_hash, _ = _seed_receipt(tmp_path, "run-1")
+
+    result = _run(["verify", "run-1", "--workdir", str(tmp_path), "--receipt-hash", entry_hash])
+    assert result.exit_code == 3, result.output
+    assert "key" in result.output.lower()
+    assert not key_path.exists()


### PR DESCRIPTION
## What
`lineage verify` loaded the HMAC key via `load_or_create_audit_key()`, so on a fresh machine or a handed-over evidence pack it minted a brand-new key, every tag failed, and a setup problem was misreported as TAMPER (exit 2).

Fixes #2639

## How
- `_load_hmac_key()` now uses the read-only `load_audit_key()` and catches `AuditKeyMissingError`: prints a clear CANNOT VERIFY message and fails closed with a distinct exit code 3, mirroring the sibling `intent verify` surface.
- `--key-path` reads a named key for offline verification of transported evidence.
- `SpineStatus.SEAL_ONLY` behavior (landed this week) untouched and covered.

## Verification
- `tests/unit/lineage/test_spine_cli.py` 12 passed (3 new: missing-key fails closed, key-path option, receipt-path missing key); sentinel 37840 collected; red-on-main proven for the misreport case.