### PR TITLE
fix(adapters): wire capability-profile selection recording into the spawn dispatch path

### DIFF
--- a/docs/adapters/capability_profiles.md
+++ b/docs/adapters/capability_profiles.md
@@ -143,10 +143,9 @@ reconstructing the same refusal derive the same identifier.
 ## Anchoring the routing decision
 
 `route_and_record(requirements, audit_chain=chain, run_id=...)` is the
-seam the deterministic scheduler calls to route a task by declared
-capability. It wraps `select_profile_for` so the decision leaves a
-replay-verifiable trace in the HMAC audit chain instead of being an
-unobservable side effect of dispatch:
+seam that turns an adapter selection into a replay-verifiable record. It
+wraps `select_profile_for` so the decision leaves a trace in the HMAC
+audit chain instead of being an unobservable side effect of dispatch:
 
 - **On a match** it appends an `adapter.capability_selection` event
   carrying the chosen adapter and the content-addressed profile hash it
@@ -172,6 +171,47 @@ profile = route_and_record(
 exactly as `select_profile_for` does, so a dry-run capability probe stays
 chain-free. The chain module is imported lazily, only when a chain is
 supplied, so the adapter module's load-time import surface stays lean.
+
+## At dispatch
+
+The spawn path invokes the seam once the adapter for a spawn is resolved,
+in `AgentSpawner._record_adapter_capability_selection`. It runs alongside
+the security-floor preflight, before the adapter receives any task
+context:
+
+- For an adapter that ships a profile, the profile hash it presents is
+  anchored as an `adapter.capability_selection` event, so replay detects
+  a changed declaration as a hash divergence named by the adapter.
+- When the task declares capability requirements the routed adapter
+  cannot meet, the refusal receipt is anchored and the spawn is refused -
+  a hard stop like a floor refusal, never an alternate-adapter failover.
+
+An adapter with **no** profile (the common `claude` / `codex` / `gemini`
+path, served by the generic fallback) is a no-op: nothing is anchored and
+the spawn proceeds unchanged.
+
+### Declaring task requirements
+
+A task declares what it needs from whichever adapter runs it through the
+`capability:` namespace of its `requires` list (the capability-addressing
+field on the task spec). Tokens outside that namespace are skill
+addressing and are ignored, so a task that declares no capability
+requirement routes exactly as before:
+
+```yaml
+requires:
+  - python                       # skill addressing - ignored here
+  - capability:mcp_client        # needs an MCP-client adapter
+  - capability:sandbox=container # needs container isolation or stronger
+  - capability:max_parallel_workers=4
+```
+
+`capability_requirements_from_tokens` parses those tokens into a
+`TaskCapabilityRequirements`. A boolean axis takes no value; `sandbox`
+takes a tier name; `max_parallel_workers` takes an integer. A mistyped
+axis raises `ProfileValidationError` rather than passing silently, so an
+unenforceable requirement fails loud instead of routing a task to an
+adapter that does not support it.
 
 ## Adding an agent as a profile
 

--- a/docs/adapters/capability_profiles.md
+++ b/docs/adapters/capability_profiles.md
@@ -140,6 +140,39 @@ The receipt hash is deterministic for a given
 `(requirements, candidates, unmet)` triple, so two operators
 reconstructing the same refusal derive the same identifier.
 
+## Anchoring the routing decision
+
+`route_and_record(requirements, audit_chain=chain, run_id=...)` is the
+seam the deterministic scheduler calls to route a task by declared
+capability. It wraps `select_profile_for` so the decision leaves a
+replay-verifiable trace in the HMAC audit chain instead of being an
+unobservable side effect of dispatch:
+
+- **On a match** it appends an `adapter.capability_selection` event
+  carrying the chosen adapter and the content-addressed profile hash it
+  presented. Replay recomputes that hash, so a declaration that changed
+  between two runs surfaces as a hash divergence named by the adapter.
+- **On a mismatch** it appends an `adapter.capability_refusal` event -
+  the refusal receipt's hash, the unmet axes, and every candidate with
+  the profile hash it presented - *before* the `CapabilityMismatchError`
+  propagates. The refusal is a signed, chain-anchored record an operator
+  can hand to a postmortem, never a silent fallback to a weaker adapter.
+
+```python
+from bernstein.adapters.capability_profile import route_and_record
+
+profile = route_and_record(
+    TaskCapabilityRequirements(mcp_client=True),
+    audit_chain=chain,
+    run_id=run_id,
+)
+```
+
+`audit_chain` is optional: with no chain the call selects (or refuses)
+exactly as `select_profile_for` does, so a dry-run capability probe stays
+chain-free. The chain module is imported lazily, only when a chain is
+supplied, so the adapter module's load-time import surface stays lean.
+
 ## Adding an agent as a profile
 
 1. Add an `AdapterCapabilityProfile` to `_PROFILE_LIST` in

--- a/src/bernstein/adapters/capability_profile.py
+++ b/src/bernstein/adapters/capability_profile.py
@@ -40,10 +40,13 @@ Profiles come in two shapes, distinguished by
     Migration to the factory is therefore incremental and opt-in - an
     existing adapter gains a profile without changing how it spawns.
 
-Import note: this module deliberately depends only on
+Import note: at module load this depends only on
 :mod:`bernstein.adapters.base`, :mod:`bernstein.adapters._contract` and
 :mod:`bernstein.adapters.env_isolation`. It imports no sibling adapter,
 so the ``adapters-independent`` import-linter contract holds.
+:func:`route_and_record` imports the audit-chain recorder lazily, inside
+the function and only when a chain is supplied, so the module's load-time
+surface stays lean the way the conformance canary keeps its own.
 """
 
 from __future__ import annotations
@@ -636,6 +639,81 @@ def select_profile_for(
     )
 
 
+def route_and_record(
+    requirements: TaskCapabilityRequirements,
+    *,
+    profiles: Iterable[AdapterCapabilityProfile] | None = None,
+    audit_chain: Any | None = None,
+    run_id: str = "",
+) -> AdapterCapabilityProfile:
+    """Select an adapter for a task and anchor the decision in the audit chain.
+
+    Wraps :func:`select_profile_for` so a routing decision leaves a
+    replay-verifiable trace instead of being an unobservable side effect of
+    dispatch. This is the seam the deterministic scheduler calls to route a
+    task by declared capability:
+
+    * On a match, the selected profile's content address is recorded, so replay
+      recomputes it and detects a changed declaration as a hash divergence
+      named by the adapter (profile drift becomes tamper-evident).
+    * On a mismatch, the content-addressed refusal receipt is anchored into the
+      HMAC chain *before* the :class:`CapabilityMismatchError` propagates, so
+      the refusal is a signed record rather than a silent fallback to a weaker
+      adapter.
+
+    Recording is opt-in: when ``audit_chain`` is ``None`` the function selects
+    (or refuses) exactly as :func:`select_profile_for` does, without touching a
+    chain. This keeps the function usable in contexts that have no chain -- for
+    example a dry-run capability probe -- and keeps this module's import surface
+    lean, since the chain module is imported lazily only when a chain is
+    supplied, the same way the conformance canary records its receipts.
+
+    Args:
+        requirements: What the task needs from whichever adapter runs it.
+        profiles: Candidate profiles. Defaults to the shipped catalogue,
+            enumerated in sorted name order for deterministic selection.
+        audit_chain: An ``AuditChainStore`` accepting the selection or refusal
+            record, or ``None`` to skip recording. Typed loosely to avoid a
+            module-level dependency on :mod:`bernstein.core.security`.
+        run_id: The run the routing decision is made for, recorded on the
+            anchored event.
+
+    Returns:
+        The first profile satisfying ``requirements``.
+
+    Raises:
+        CapabilityMismatchError: No candidate satisfies the task. The refusal
+            receipt it carries is anchored into ``audit_chain`` first when a
+            chain was supplied.
+    """
+    try:
+        selected = select_profile_for(requirements, profiles=profiles)
+    except CapabilityMismatchError as exc:
+        if audit_chain is not None:
+            from bernstein.core.security.audit_chain import record_capability_refusal
+
+            record_capability_refusal(
+                chain=audit_chain,
+                run_id=run_id,
+                receipt_hash=exc.receipt.receipt_hash,
+                requirements=exc.receipt.requirements,
+                candidates=[list(pair) for pair in exc.receipt.candidates],
+                unmet=list(exc.receipt.unmet),
+            )
+        raise
+    if audit_chain is not None:
+        from bernstein.core.security.audit_chain import record_capability_selection
+
+        record_capability_selection(
+            chain=audit_chain,
+            run_id=run_id,
+            adapter=selected.name,
+            profile_hash=selected.profile_hash,
+            requirements=requirements.to_canonical_dict(),
+        )
+    return selected
+
+
 # ---------------------------------------------------------------------------
 # Profile-to-contract cross-check
 # ---------------------------------------------------------------------------
@@ -1149,6 +1227,7 @@ __all__ = [
     "profile_built_adapter_classes",
     "profile_contract_discrepancies",
     "profile_hash_for",
+    "route_and_record",
     "sandbox_rank",
     "select_profile_for",
     "unmet_requirements",

--- a/src/bernstein/adapters/capability_profile.py
+++ b/src/bernstein/adapters/capability_profile.py
@@ -639,6 +639,77 @@ def select_profile_for(
     )
 
 
+#: Namespace on a task's capability-addressing list that declares an
+#: adapter-capability requirement, as opposed to a skill address. A token
+#: outside this namespace (``"python"``, ``"testing"``) is skill addressing and
+#: is left to whatever consumes those; only ``capability:`` tokens shape the
+#: :class:`TaskCapabilityRequirements` the dispatch path checks a routed
+#: adapter's profile against.
+CAPABILITY_TOKEN_PREFIX = "capability:"
+
+
+def capability_requirements_from_tokens(
+    tokens: Iterable[str],
+) -> TaskCapabilityRequirements:
+    """Parse capability-addressing tokens into a requirement set.
+
+    Reads the ``capability:`` namespace of a task's capability-addressing list
+    (``Task.requires``) so a declared task need becomes the
+    :class:`TaskCapabilityRequirements` the dispatch path checks the routed
+    adapter's profile against. Tokens without the prefix are skill addressing
+    and are skipped, so a task that declares no capability requirement yields
+    the empty set every profile satisfies -- existing tasks route unchanged.
+
+    Grammar of the parsed suffix:
+
+    * ``capability:<axis>`` sets a boolean axis (``mcp_client``, ``vision``,
+      ``computer_use``, ...).
+    * ``capability:sandbox=<tier>`` requires at least that sandbox tier.
+    * ``capability:max_parallel_workers=<n>`` requires at least *n* workers.
+
+    Args:
+        tokens: The task's capability-addressing entries.
+
+    Returns:
+        The requirement set the tokens declare.
+
+    Raises:
+        ProfileValidationError: An axis is not a requestable requirement axis,
+            a boolean axis carries a value, or a value is malformed. Failing
+            loud keeps a mistyped requirement from silently passing an adapter
+            that does not support it -- the drift
+            :func:`_assert_capability_axes_are_requestable` guards at import,
+            applied here to the declaration side.
+    """
+    fields: dict[str, Any] = {}
+    for raw in tokens:
+        token = raw.strip()
+        if not token.startswith(CAPABILITY_TOKEN_PREFIX):
+            continue
+        axis, sep, value = token[len(CAPABILITY_TOKEN_PREFIX) :].partition("=")
+        axis = axis.strip()
+        value = value.strip()
+        if axis in BOOLEAN_CAPABILITIES:
+            if sep:
+                raise ProfileValidationError(f"boolean capability {axis!r} takes no value (got {value!r})")
+            fields[axis] = True
+        elif axis == "sandbox":
+            try:
+                fields["sandbox"] = SandboxTier(value)
+            except ValueError:
+                tiers = ", ".join(tier.value for tier in SandboxTier)
+                raise ProfileValidationError(f"unknown sandbox tier {value!r}; expected one of {tiers}") from None
+        elif axis == "max_parallel_workers":
+            try:
+                fields["max_parallel_workers"] = int(value)
+            except ValueError:
+                raise ProfileValidationError(f"max_parallel_workers requires an integer (got {value!r})") from None
+        else:
+            requestable = ", ".join(sorted(TaskCapabilityRequirements.__dataclass_fields__))
+            raise ProfileValidationError(f"unknown capability axis {axis!r}; requestable axes: {requestable}")
+    return TaskCapabilityRequirements(**fields)
+
+
 def route_and_record(
     requirements: TaskCapabilityRequirements,
     *,
@@ -650,8 +721,10 @@ def route_and_record(
 
     Wraps :func:`select_profile_for` so a routing decision leaves a
     replay-verifiable trace instead of being an unobservable side effect of
-    dispatch. This is the seam the deterministic scheduler calls to route a
-    task by declared capability:
+    dispatch. This is the seam the spawn dispatch path
+    (:meth:`bernstein.core.agents.spawner_core.AgentSpawner.
+    _record_adapter_capability_selection`) calls once an adapter is resolved,
+    to anchor the profile it presented and refuse a task it cannot serve:
 
     * On a match, the selected profile's content address is recorded, so replay
       recomputes it and detects a changed declaration as a hash divergence
@@ -1206,6 +1279,7 @@ def profile_hash_for(name: str) -> str | None:
 
 __all__ = [
     "BOOLEAN_CAPABILITIES",
+    "CAPABILITY_TOKEN_PREFIX",
     "PROFILES",
     "AdapterCapabilityProfile",
     "CapabilityMismatchError",
@@ -1221,6 +1295,7 @@ __all__ = [
     "assert_profile_backed_by_contract",
     "build_adapter_class_from_profile",
     "build_adapter_from_profile",
+    "capability_requirements_from_tokens",
     "get_profile",
     "iter_profiles",
     "profile_binary_for",

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -2835,6 +2835,72 @@ class AgentSpawner:
                 verdict.advisory_id,
             )
 
+    def _record_adapter_capability_selection(self, adapter_name: str, tasks: list[Task]) -> None:
+        """Anchor the capability profile the routed adapter presents (#2663).
+
+        Capability-aware routing has to leave a replay-verifiable trace at the
+        dispatch boundary, or a changed adapter declaration is an unexplained
+        behaviour change rather than a named hash divergence. For an adapter
+        that ships a capability profile this records the content-addressed
+        ``profile_hash`` it presents at dispatch, so replay recomputes it and
+        detects profile drift as a divergence named by the adapter (AC3).
+
+        When the task declares capability requirements -- ``capability:`` tokens
+        on ``Task.requires`` -- the routed adapter's profile is checked against
+        them. If the profile cannot satisfy the task, a signed refusal receipt
+        is anchored and :exc:`CapabilityMismatchError` propagates, so routing
+        refuses rather than silently spawning a weaker adapter (AC2). Like the
+        security-floor preflight this runs outside the inner spawn ``try``, so
+        the refusal is a hard stop and never an alternate-adapter failover.
+
+        Untracked adapters (no profile) are a no-op, so the common
+        claude / codex / gemini path -- served by the generic fallback -- pays
+        nothing. Recording failures other than the deliberate refusal are logged
+        and swallowed: anchoring the selection must never break a spawn tick.
+
+        Args:
+            adapter_name: The adapter the spawn resolved to.
+            tasks: The task batch this spawn serves; their ``requires`` lists
+                supply the declared capability requirements.
+
+        Raises:
+            CapabilityMismatchError: The routed adapter's profile cannot satisfy
+                a declared task requirement. The refusal receipt is anchored
+                first. Not a ``SpawnError``, so the per-provider failover loop
+                never swallows it into an alternate-adapter retry.
+            ProfileValidationError: A ``capability:`` token is malformed; a
+                mistyped requirement fails loud rather than passing silently.
+        """
+        from bernstein.adapters.capability_profile import (
+            PROFILES,
+            CapabilityMismatchError,
+            capability_requirements_from_tokens,
+            route_and_record,
+        )
+
+        profile = PROFILES.get(adapter_name)
+        if profile is None:
+            return  # untracked adapter: the generic fallback owns it, nothing to anchor
+
+        tokens = [tok for task in tasks for tok in getattr(task, "requires", ())]
+        requirements = capability_requirements_from_tokens(tokens)
+        run_id = tasks[0].id if tasks else ""
+        try:
+            from bernstein.core.security.audit_chain import AuditChainStore
+
+            chain = AuditChainStore(self._workdir / ".sdd" / "audit")
+            route_and_record(requirements, profiles=[profile], audit_chain=chain, run_id=run_id)
+        except CapabilityMismatchError:
+            # AC2: the refusal receipt is already anchored inside route_and_record;
+            # re-raise so routing refuses rather than falling back.
+            raise
+        except Exception as exc:
+            logger.warning(
+                "capability routing: recording failed for %s: %s",
+                adapter_name,
+                type(exc).__name__,
+            )
+
     def _preflight_posture_drift(self) -> None:
         """Refuse a spawn when the sovereign posture drifted or is non-compliant (#2518).
 
@@ -3845,6 +3911,14 @@ class AgentSpawner:
                     # refusal raises out of the spawn (hard stop) instead of
                     # falling through to alternate-provider failover.
                     self._preflight_adapter_security_floor(adapter_name)
+
+                    # Capability-aware routing (#2663): anchor the profile hash
+                    # the resolved adapter presents at dispatch so replay detects
+                    # profile drift, and refuse with a signed receipt when the
+                    # task's declared capability requirements outrun that profile.
+                    # Same placement rationale as the floor preflight above: a
+                    # refusal is a hard stop, not an alternate-adapter failover.
+                    self._record_adapter_capability_selection(adapter_name, tasks)
 
                     # Per-attempt config so a failover to a different
                     # adapter never inherits another adapter's extras.

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -414,6 +414,22 @@ EVENT_PLUGIN_CONFORMANCE_RECEIPT = "plugin.conformance_receipt"
 #: rather than living only in a CI log.
 EVENT_ADAPTER_CANARY_RECEIPT = "adapter.canary_receipt"
 
+#: Issue #2663 -- emitted when capability-aware routing selects an adapter for a
+#: task. The event binds the chosen adapter, the content-addressed capability
+#: profile it presented at dispatch, and the task requirements it satisfied.
+#: Recording the presented ``profile_hash`` makes profile drift replay-visible:
+#: a declaration that changes between two runs shows up as a hash divergence
+#: named by the adapter rather than as unexplained behaviour change.
+EVENT_ADAPTER_CAPABILITY_SELECTION = "adapter.capability_selection"
+
+#: Issue #2663 -- emitted when capability-aware routing refuses a task because
+#: no candidate adapter's declared profile satisfied its requirements. The event
+#: anchors the content-addressed refusal receipt (its hash, the unmet axes, and
+#: every candidate considered with the profile hash it presented) into the HMAC
+#: chain, so a routing refusal is a signed, reconstructable record rather than a
+#: silent fallback to a weaker adapter.
+EVENT_ADAPTER_CAPABILITY_REFUSAL = "adapter.capability_refusal"
+
 #: Issue #2367 -- emitted when the orchestrator forcibly reaps an agent
 #: process tree.  The event records which platform mechanism delivered the
 #: stop (POSIX process-group signalling or Windows process-tree
@@ -3835,6 +3851,105 @@ def record_adapter_canary_receipt(
     )
 
 
+def record_capability_selection(
+    *,
+    chain: AuditChainStore,
+    run_id: str,
+    adapter: str,
+    profile_hash: str,
+    requirements: dict[str, Any],
+    actor: str = "capability_router",
+) -> AuditEvent:
+    """Append an ``adapter.capability_selection`` event into *chain* (#2663).
+
+    Mirrors one capability-aware routing decision into the HMAC chain: the
+    adapter chosen for a task and the content-addressed capability profile it
+    presented at dispatch. The recorded ``profile_hash`` is a pure function of
+    the adapter's declaration, so a verifier replaying the run recomputes it and
+    detects a changed declaration as a hash divergence named by the adapter --
+    profile drift becomes tamper-evident rather than an unexplained behaviour
+    change. Only names, hashes, and the task's declared requirements are
+    recorded; never a prompt or a spawn command.
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        run_id: The run the routing decision was made for.
+        adapter: Registry key of the selected adapter.
+        profile_hash: Content address of the capability profile the adapter
+            presented (its :attr:`profile_hash`).
+        requirements: Canonical form of the task requirements the profile
+            satisfied.
+        actor: Recorded actor; defaults to ``"capability_router"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded in
+        its details payload.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_ADAPTER_CAPABILITY_SELECTION,
+        actor=actor,
+        resource_type="adapter_capability_selection",
+        resource_id=adapter,
+        details={
+            "run_id": run_id,
+            "adapter": adapter,
+            "profile_hash": profile_hash,
+            "requirements": dict(sorted(requirements.items())),
+        },
+    )
+
+
+def record_capability_refusal(
+    *,
+    chain: AuditChainStore,
+    run_id: str,
+    receipt_hash: str,
+    requirements: dict[str, Any],
+    candidates: list[list[str]],
+    unmet: list[str],
+    actor: str = "capability_router",
+) -> AuditEvent:
+    """Append an ``adapter.capability_refusal`` event into *chain* (#2663).
+
+    Anchors one capability-aware routing refusal: no candidate adapter's
+    declared profile satisfied the task, so routing refuses rather than falling
+    back to a weaker adapter. The event mirrors the content-addressed refusal
+    receipt -- its hash, the union of unmet axes, and every candidate considered
+    paired with the profile hash it presented -- into the HMAC chain. A verifier
+    holding the receipt can recompute its hash and check it against the chain,
+    so the refusal is a signed, reconstructable record an operator can hand to a
+    postmortem rather than a decision that left no trace.
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        run_id: The run the refusal was raised for.
+        receipt_hash: Content address of the
+            :class:`~bernstein.adapters.capability_profile.CapabilityRefusalReceipt`.
+        requirements: Canonical form of the task requirements that went unmet.
+        candidates: ``[adapter name, profile hash]`` pairs considered, in the
+            order they were offered.
+        unmet: Sorted union of every unmet capability axis across candidates.
+        actor: Recorded actor; defaults to ``"capability_router"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded in
+        its details payload.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_ADAPTER_CAPABILITY_REFUSAL,
+        actor=actor,
+        resource_type="adapter_capability_refusal",
+        resource_id=receipt_hash,
+        details={
+            "run_id": run_id,
+            "receipt_hash": receipt_hash,
+            "requirements": dict(sorted(requirements.items())),
+            "candidates": [list(pair) for pair in candidates],
+            "unmet": list(unmet),
+        },
+    )
+
+
 def record_adapter_spawn_preflight_receipt(
     *,
     chain: AuditChainStore,
@@ -6870,6 +6985,8 @@ __all__ = [
     "EVENT_A2A_MESSAGE_RECEIPT",
     "EVENT_ACTIVITY_RESULT",
     "EVENT_ADAPTER_CANARY_RECEIPT",
+    "EVENT_ADAPTER_CAPABILITY_REFUSAL",
+    "EVENT_ADAPTER_CAPABILITY_SELECTION",
     "EVENT_ADAPTER_FLOOR_UPDATE",
     "EVENT_ADAPTER_SPAWN_PREFLIGHT",
     "EVENT_ADAPTER_VERSION_POSTURE",
@@ -7003,6 +7120,8 @@ __all__ = [
     "record_cache_eviction",
     "record_cache_hit",
     "record_cache_miss",
+    "record_capability_refusal",
+    "record_capability_selection",
     "record_checkpoint_retry",
     "record_computer_use_action",
     "record_context_capsule",

--- a/tests/unit/adapters/test_capability_profile.py
+++ b/tests/unit/adapters/test_capability_profile.py
@@ -47,6 +47,7 @@ from bernstein.adapters.capability_profile import (
     UnknownProfileError,
     build_adapter_class_from_profile,
     build_adapter_from_profile,
+    capability_requirements_from_tokens,
     get_profile,
     profile_built_adapter_classes,
     profile_contract_discrepancies,
@@ -686,3 +687,61 @@ class TestRouteAndRecord:
         )
         assert chain.query(event_type=EVENT_ADAPTER_CAPABILITY_REFUSAL) == []  # type: ignore[attr-defined]
         assert len(chain.query(event_type=EVENT_ADAPTER_CAPABILITY_SELECTION)) == 1  # type: ignore[attr-defined]
+
+
+class TestCapabilityRequirementsFromTokens:
+    """Parse a task's capability-addressing tokens into requirements.
+
+    ``Task.requires`` is a capability-addressing list. The ``capability:``
+    namespace of that list is what the dispatch path checks a routed adapter's
+    profile against, so the parser is the bridge from a declared task need to a
+    :class:`TaskCapabilityRequirements`. Non-``capability:`` tokens are skill
+    addressing and are ignored, so an existing task declares no requirement and
+    is satisfied by every profile.
+    """
+
+    def test_no_tokens_yields_empty_requirements(self) -> None:
+        assert capability_requirements_from_tokens([]) == TaskCapabilityRequirements()
+
+    def test_skill_tokens_are_ignored(self) -> None:
+        # The pre-existing capability-addressing vocabulary (skills) must not
+        # accidentally become adapter-capability requirements.
+        assert capability_requirements_from_tokens(["python", "testing"]) == TaskCapabilityRequirements()
+
+    def test_boolean_axis_token_sets_the_axis(self) -> None:
+        reqs = capability_requirements_from_tokens(["capability:mcp_client"])
+        assert reqs == TaskCapabilityRequirements(mcp_client=True)
+
+    def test_multiple_axes_union(self) -> None:
+        reqs = capability_requirements_from_tokens(["capability:vision", "python", "capability:mcp_server"])
+        assert reqs == TaskCapabilityRequirements(vision=True, mcp_server=True)
+
+    def test_sandbox_tier_token(self) -> None:
+        reqs = capability_requirements_from_tokens(["capability:sandbox=container"])
+        assert reqs == TaskCapabilityRequirements(sandbox=SandboxTier.CONTAINER)
+
+    def test_max_parallel_workers_token(self) -> None:
+        reqs = capability_requirements_from_tokens(["capability:max_parallel_workers=4"])
+        assert reqs == TaskCapabilityRequirements(max_parallel_workers=4)
+
+    def test_whitespace_is_tolerated(self) -> None:
+        reqs = capability_requirements_from_tokens(["  capability:vision  "])
+        assert reqs == TaskCapabilityRequirements(vision=True)
+
+    def test_unknown_axis_fails_loud(self) -> None:
+        # A mistyped requirement must surface, not silently pass an adapter that
+        # does not support it -- the same drift the import-time axis check guards.
+        with pytest.raises(ProfileValidationError):
+            capability_requirements_from_tokens(["capability:teleportation"])
+
+    def test_boolean_axis_with_value_is_refused(self) -> None:
+        with pytest.raises(ProfileValidationError):
+            capability_requirements_from_tokens(["capability:vision=true"])
+
+    def test_bad_sandbox_tier_is_refused(self) -> None:
+        with pytest.raises(ProfileValidationError):
+            capability_requirements_from_tokens(["capability:sandbox=moon"])
+
+    def test_non_integer_worker_count_is_refused(self) -> None:
+        with pytest.raises(ProfileValidationError):
+            capability_requirements_from_tokens(["capability:max_parallel_workers=lots"])

--- a/tests/unit/adapters/test_capability_profile.py
+++ b/tests/unit/adapters/test_capability_profile.py
@@ -50,6 +50,7 @@ from bernstein.adapters.capability_profile import (
     get_profile,
     profile_built_adapter_classes,
     profile_contract_discrepancies,
+    route_and_record,
     select_profile_for,
     unmet_requirements,
 )
@@ -567,3 +568,121 @@ class TestProfileContractVerification:
         )
         discrepancies = profile_contract_discrepancies(overreaching, spec)
         assert any("TOTALLY_INVENTED_SECRET" in reason for reason in discrepancies), discrepancies
+
+
+# ---------------------------------------------------------------------------
+# Capability-aware routing is anchored in the audit chain
+# ---------------------------------------------------------------------------
+
+
+def _audit_chain(tmp_path: Path) -> object:
+    """A hermetic HMAC audit-chain store for the routing tests."""
+    from bernstein.core.security.audit_chain import AuditChainStore
+
+    return AuditChainStore(tmp_path / "audit", key=b"k" * 32)
+
+
+class TestRouteAndRecord:
+    """Routing decisions leave a signed, replay-verifiable trace.
+
+    ``route_and_record`` wraps ``select_profile_for`` so that a match anchors
+    the presented profile hash and a mismatch anchors the refusal receipt --
+    the substrate coupling that makes adapter selection replay-verifiable
+    rather than an unobservable side effect of dispatch.
+    """
+
+    def test_match_returns_the_selected_profile(self, tmp_path: Path) -> None:
+        profile = _minimal_profile(mcp_client=True)
+        chain = _audit_chain(tmp_path)
+        selected = route_and_record(
+            TaskCapabilityRequirements(mcp_client=True),
+            profiles=(profile,),
+            audit_chain=chain,
+            run_id="run-1",
+        )
+        assert selected is profile
+
+    def test_match_records_the_presented_profile_hash(self, tmp_path: Path) -> None:
+        from bernstein.core.security.audit_chain import EVENT_ADAPTER_CAPABILITY_SELECTION
+
+        profile = _minimal_profile(mcp_client=True)
+        chain = _audit_chain(tmp_path)
+        route_and_record(
+            TaskCapabilityRequirements(mcp_client=True),
+            profiles=(profile,),
+            audit_chain=chain,
+            run_id="run-1",
+        )
+        events = chain.query(event_type=EVENT_ADAPTER_CAPABILITY_SELECTION)  # type: ignore[attr-defined]
+        assert len(events) == 1
+        # The hash the chain records is the profile's own content address, so
+        # replay detects a changed declaration as a divergence named here.
+        assert events[0].details["profile_hash"] == profile.profile_hash
+        assert events[0].details["adapter"] == profile.name
+        assert events[0].details["run_id"] == "run-1"
+        assert chain.verify()[0]  # type: ignore[attr-defined]
+
+    def test_mismatch_reraises_rather_than_falling_back(self, tmp_path: Path) -> None:
+        profile = _minimal_profile(vision=False)
+        chain = _audit_chain(tmp_path)
+        with pytest.raises(CapabilityMismatchError):
+            route_and_record(
+                TaskCapabilityRequirements(vision=True),
+                profiles=(profile,),
+                audit_chain=chain,
+                run_id="run-1",
+            )
+
+    def test_mismatch_records_the_refusal_receipt(self, tmp_path: Path) -> None:
+        from bernstein.core.security.audit_chain import EVENT_ADAPTER_CAPABILITY_REFUSAL
+
+        profile = _minimal_profile(vision=False)
+        chain = _audit_chain(tmp_path)
+        with pytest.raises(CapabilityMismatchError) as excinfo:
+            route_and_record(
+                TaskCapabilityRequirements(vision=True),
+                profiles=(profile,),
+                audit_chain=chain,
+                run_id="run-1",
+            )
+        events = chain.query(event_type=EVENT_ADAPTER_CAPABILITY_REFUSAL)  # type: ignore[attr-defined]
+        assert len(events) == 1
+        assert events[0].details["receipt_hash"] == excinfo.value.receipt.receipt_hash
+        assert events[0].details["unmet"] == ["vision"]
+        assert events[0].details["candidates"] == [[profile.name, profile.profile_hash]]
+        assert chain.verify()[0]  # type: ignore[attr-defined]
+
+    def test_no_chain_still_selects_without_recording(self, tmp_path: Path) -> None:
+        """A chainless call keeps working: recording is opt-in, not required."""
+        profile = _minimal_profile(mcp_client=True)
+        selected = route_and_record(
+            TaskCapabilityRequirements(mcp_client=True),
+            profiles=(profile,),
+        )
+        assert selected is profile
+
+    def test_no_chain_still_refuses(self) -> None:
+        profile = _minimal_profile(vision=False)
+        with pytest.raises(CapabilityMismatchError):
+            route_and_record(
+                TaskCapabilityRequirements(vision=True),
+                profiles=(profile,),
+            )
+
+    def test_match_records_nothing_on_refusal_channel(self, tmp_path: Path) -> None:
+        """A satisfied route must not emit a refusal event, and vice versa."""
+        from bernstein.core.security.audit_chain import (
+            EVENT_ADAPTER_CAPABILITY_REFUSAL,
+            EVENT_ADAPTER_CAPABILITY_SELECTION,
+        )
+
+        profile = _minimal_profile(mcp_client=True)
+        chain = _audit_chain(tmp_path)
+        route_and_record(
+            TaskCapabilityRequirements(mcp_client=True),
+            profiles=(profile,),
+            audit_chain=chain,
+            run_id="run-1",
+        )
+        assert chain.query(event_type=EVENT_ADAPTER_CAPABILITY_REFUSAL) == []  # type: ignore[attr-defined]
+        assert len(chain.query(event_type=EVENT_ADAPTER_CAPABILITY_SELECTION)) == 1  # type: ignore[attr-defined]

--- a/tests/unit/test_audit_chain_capability_profile.py
+++ b/tests/unit/test_audit_chain_capability_profile.py
@@ -1,0 +1,99 @@
+"""Tests for the additive capability-routing audit-chain helpers (issue #2663).
+
+Capability-aware adapter selection produces two decisions worth proving from
+the chain alone:
+
+* the content-addressed capability profile an adapter presented when it was
+  chosen to run a task, so replay detects a changed declaration as a hash
+  divergence named by the adapter (``adapter.capability_selection``);
+* the content-addressed refusal receipt emitted when no candidate satisfied a
+  task, so a routing refusal is a signed record rather than a silent fallback
+  (``adapter.capability_refusal``).
+
+Both events embed the previous chain digest and record only names and hashes --
+never a prompt or a spawn command.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from bernstein.core.security.audit_chain import (
+    EVENT_ADAPTER_CAPABILITY_REFUSAL,
+    EVENT_ADAPTER_CAPABILITY_SELECTION,
+    AuditChainStore,
+    record_capability_refusal,
+    record_capability_selection,
+)
+
+
+def _store(tmp_path: Path) -> AuditChainStore:
+    return AuditChainStore(tmp_path / "audit", key=b"k" * 32)
+
+
+def test_record_capability_selection_appends_chained_event(tmp_path: Path) -> None:
+    chain = _store(tmp_path)
+    event = record_capability_selection(
+        chain=chain,
+        run_id="run-1",
+        adapter="pydantic_ai",
+        profile_hash="ab" * 32,
+        requirements={"mcp_client": True, "sandbox": "process"},
+    )
+    assert event.event_type == EVENT_ADAPTER_CAPABILITY_SELECTION
+    assert event.resource_id == "pydantic_ai"
+    assert "prev_chain_digest" in event.details
+    assert event.details["run_id"] == "run-1"
+    assert event.details["adapter"] == "pydantic_ai"
+    assert event.details["profile_hash"] == "ab" * 32
+    assert event.details["requirements"] == {"mcp_client": True, "sandbox": "process"}
+    ok, errors = chain.verify()
+    assert ok, errors
+
+
+def test_record_capability_refusal_appends_chained_event(tmp_path: Path) -> None:
+    chain = _store(tmp_path)
+    event = record_capability_refusal(
+        chain=chain,
+        run_id="run-1",
+        receipt_hash="cd" * 32,
+        requirements={"vision": True},
+        candidates=[["droid", "11" * 32], ["kimi", "22" * 32]],
+        unmet=["vision"],
+    )
+    assert event.event_type == EVENT_ADAPTER_CAPABILITY_REFUSAL
+    # The refusal is addressed by the receipt hash: the identity of the artefact.
+    assert event.resource_id == "cd" * 32
+    assert "prev_chain_digest" in event.details
+    assert event.details["run_id"] == "run-1"
+    assert event.details["receipt_hash"] == "cd" * 32
+    assert event.details["requirements"] == {"vision": True}
+    assert event.details["candidates"] == [["droid", "11" * 32], ["kimi", "22" * 32]]
+    assert event.details["unmet"] == ["vision"]
+    ok, errors = chain.verify()
+    assert ok, errors
+
+
+def test_capability_events_chain_together(tmp_path: Path) -> None:
+    """A refusal followed by a selection stays a single verifiable chain."""
+    chain = _store(tmp_path)
+    first = record_capability_refusal(
+        chain=chain,
+        run_id="run-1",
+        receipt_hash="cd" * 32,
+        requirements={"vision": True},
+        candidates=[["droid", "11" * 32]],
+        unmet=["vision"],
+    )
+    second = record_capability_selection(
+        chain=chain,
+        run_id="run-1",
+        adapter="droid",
+        profile_hash="11" * 32,
+        requirements={},
+    )
+    # The second event chains onto the first: its embedded predecessor is not
+    # the genesis digest the first embedded.
+    assert second.details["prev_chain_digest"] != first.details["prev_chain_digest"]
+    ok, errors = chain.verify()
+    assert ok, errors

--- a/tests/unit/test_spawner_capability_routing.py
+++ b/tests/unit/test_spawner_capability_routing.py
@@ -1,0 +1,116 @@
+"""Dispatch-path tests for capability-aware routing (issue #2663).
+
+The audit-chain primitives and the ``route_and_record`` seam are proven in
+``tests/unit/adapters/test_capability_profile.py`` in isolation. These tests
+prove the missing half: that the *spawn dispatch path* invokes the seam, so a
+profile hash is anchored at dispatch (AC3) and a task whose declared capability
+requirements outrun the routed adapter is refused with a signed receipt rather
+than silently spawned on a weaker adapter (AC2).
+
+The hook is exercised directly on a real :class:`AgentSpawner` so the test
+asserts the chain the production dispatch path writes, not a stand-in. The
+audit key is isolated to ``tmp_path`` by the autouse ``_isolate_audit_key``
+conftest fixture, so the chain is hermetic.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from bernstein.core.models import Task
+from bernstein.core.spawner import AgentSpawner
+
+from bernstein.adapters.capability_profile import CapabilityMismatchError
+from bernstein.core.security.audit_chain import (
+    EVENT_ADAPTER_CAPABILITY_REFUSAL,
+    EVENT_ADAPTER_CAPABILITY_SELECTION,
+    AuditChainStore,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from unittest.mock import MagicMock
+
+
+def _spawner(tmp_path: Path, adapter: MagicMock) -> AgentSpawner:
+    templates_dir = tmp_path / "templates" / "roles"
+    templates_dir.mkdir(parents=True, exist_ok=True)
+    return AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False, default_model="mock-model")
+
+
+def _task(*, requires: list[str] | None = None) -> Task:
+    return Task(
+        id="T-cap-1",
+        title="Capability routing task",
+        description="Exercise dispatch-time capability routing.",
+        role="backend",
+        requires=requires or [],
+    )
+
+
+def _chain(tmp_path: Path) -> AuditChainStore:
+    # Same audit dir the spawner hook writes to; the isolated key is loaded
+    # from the conftest-set BERNSTEIN_AUDIT_KEY_PATH, so a re-open reads it.
+    return AuditChainStore(tmp_path / ".sdd" / "audit")
+
+
+class TestDispatchRecordsPresentedProfileHash:
+    """AC3: the hash a profiled adapter presents at dispatch is anchored."""
+
+    def test_profiled_selection_is_recorded_at_dispatch(self, tmp_path: Path, mock_adapter_factory) -> None:
+        from bernstein.adapters.capability_profile import PROFILES
+
+        spawner = _spawner(tmp_path, mock_adapter_factory())
+        spawner._record_adapter_capability_selection("opencode", [_task()])
+
+        events = _chain(tmp_path).query(event_type=EVENT_ADAPTER_CAPABILITY_SELECTION)
+        assert len(events) == 1
+        # The recorded hash is the routed adapter's own content address.
+        assert events[0].details["profile_hash"] == PROFILES["opencode"].profile_hash
+        assert events[0].details["adapter"] == "opencode"
+        assert events[0].details["run_id"] == "T-cap-1"
+        # No refusal on a satisfied route.
+        assert _chain(tmp_path).query(event_type=EVENT_ADAPTER_CAPABILITY_REFUSAL) == []
+
+    def test_met_declared_requirement_records_selection(self, tmp_path: Path, mock_adapter_factory) -> None:
+        # goose declares mcp_client=True, so a task requiring it is satisfied.
+        spawner = _spawner(tmp_path, mock_adapter_factory())
+        spawner._record_adapter_capability_selection("goose", [_task(requires=["capability:mcp_client"])])
+        assert len(_chain(tmp_path).query(event_type=EVENT_ADAPTER_CAPABILITY_SELECTION)) == 1
+        assert _chain(tmp_path).query(event_type=EVENT_ADAPTER_CAPABILITY_REFUSAL) == []
+
+    def test_unprofiled_adapter_is_a_noop(self, tmp_path: Path, mock_adapter_factory) -> None:
+        # The common claude/codex/gemini path carries no profile: the generic
+        # fallback owns it, and nothing capability-related is anchored.
+        spawner = _spawner(tmp_path, mock_adapter_factory())
+        spawner._record_adapter_capability_selection("claude", [_task()])
+        assert _chain(tmp_path).query(event_type=EVENT_ADAPTER_CAPABILITY_SELECTION) == []
+        assert _chain(tmp_path).query(event_type=EVENT_ADAPTER_CAPABILITY_REFUSAL) == []
+
+
+class TestDispatchRefusesOnCapabilityMismatch:
+    """AC2: an unmet declared requirement is a signed refusal, not a fallback."""
+
+    def test_mismatch_raises_and_anchors_refusal(self, tmp_path: Path, mock_adapter_factory) -> None:
+        # opencode declares vision=False; a task requiring vision cannot route
+        # to it, so the dispatch path refuses before any spawn.
+        adapter = mock_adapter_factory()
+        spawner = _spawner(tmp_path, adapter)
+        with pytest.raises(CapabilityMismatchError):
+            spawner._record_adapter_capability_selection("opencode", [_task(requires=["capability:vision"])])
+
+        refusals = _chain(tmp_path).query(event_type=EVENT_ADAPTER_CAPABILITY_REFUSAL)
+        assert len(refusals) == 1
+        assert refusals[0].details["unmet"] == ["vision"]
+        # No selection is recorded for a refused route (no silent fallback).
+        assert _chain(tmp_path).query(event_type=EVENT_ADAPTER_CAPABILITY_SELECTION) == []
+        # The refusal is a hard stop: the adapter is never spawned.
+        adapter.spawn.assert_not_called()
+
+    def test_malformed_declaration_fails_loud(self, tmp_path: Path, mock_adapter_factory) -> None:
+        from bernstein.adapters.capability_profile import ProfileValidationError
+
+        spawner = _spawner(tmp_path, mock_adapter_factory())
+        with pytest.raises(ProfileValidationError):
+            spawner._record_adapter_capability_selection("opencode", [_task(requires=["capability:teleportation"])])


### PR DESCRIPTION
## What
The declarative capability-profile seam existed but was dead code: `route_and_record` / `record_capability_selection` / `record_capability_refusal` shipped with zero callers in `src/`, so no profile hash was ever recorded at dispatch and no refusal was ever emitted in production.

Fixes #2663

## How
- `AgentSpawner` records the presented profile hash at the spawn dispatch boundary (right after the security-floor preflight, same hard-stop rationale): selection is anchored via `route_and_record`, so replay detects profile drift between dispatch and execution.
- A task declaring a capability requirement that the routed adapter's profile cannot satisfy now refuses at dispatch with a recorded refusal instead of spawning and failing later.

## Verification
- The adversarial review round proved the original gap (grep: zero callers) and drove the rewire; re-verified confirmed with 0 critical findings across 4 review rounds.
- New `test_spawner_capability_routing.py` drives a real spawner against a hermetic tmp_path audit chain; targeted suites green; sentinel clean.