### PR TITLE
fix(events): harden the event feed, triggers, webhooks, and receipts

### DIFF
--- a/docs/events/grammar.md
+++ b/docs/events/grammar.md
@@ -46,14 +46,21 @@ bernstein events verify window.json
 `verify` needs no signing key. It checks the window's internal `prev_hmac`
 linkage against the embedded fence-posts:
 
-- completeness: the first event's `hmac` equals the lower fence-post and the last
-  event's `hmac` equals the upper fence-post, so no event was dropped from either
-  end;
-- order: every event's `prev_hmac` equals its predecessor's `hmac`.
+- completeness: the last event's `hmac` equals the upper fence-post, and either
+  the first event's `hmac` equals the lower fence-post (a bounded slice) or the
+  window is genesis-anchored - its lower fence-post is `null` and the first
+  event's `prev_hmac` must equal the genesis HMAC. A genesis-anchored window
+  therefore cannot silently drop its leading event;
+- order: every event's `prev_hmac` equals its predecessor's `hmac`;
+- identity: no two events share an `hmac`, and no event links to itself
+  (`hmac == prev_hmac`), so a forged cycle cannot pass as a contiguous chain.
 
 Deleting, inserting, or reordering any single event inside the window breaks the
-linkage or moves a fence-post and fails the check. "What happened, in what order"
-settles by chain position, not by timestamps scattered across five files.
+linkage or moves a fence-post and fails the check. The CLI additionally rejects a
+window file that is not a well-formed envelope (missing `from_hmac`/`to_hmac`, or
+whose `events` is not a list of objects), so dropping a fence-post to disable a
+bound is caught at the boundary. "What happened, in what order" settles by chain
+position, not by timestamps scattered across five files.
 
 ## Composable trigger semantics
 
@@ -65,6 +72,9 @@ re-derived from a chain slice alone.
   Example: three gate failures on one adapter version within ten positions.
 - **Absence**: after event A, expect event B within N positions, else a violation
   whose bounds are two named chain positions. This is the negative-proof input.
+  A violation is only asserted once the deadline is *observed* (the slice reaches
+  `A.position + N`); an anchor whose deadline the slice has not yet reached is
+  deferred, so the negative proof is never asserted on an incomplete window.
 - **Sequence**: an ordered pair keyed on lineage descent, not wall-clock order.
   The later event fires only when it provably descends from the earlier one
   through the `related_resource_ids` edges. Two unrelated events in the right
@@ -102,6 +112,11 @@ canonical event fields. The discipline is content-addressing before rendering:
 the raw payload bytes are hashed into the chain first, so a render is always
 reproducible from the recorded bytes, and a render failure emits a diagnostic
 feed event carrying only the payload digest, never the payload.
+
+The `resource_path` must resolve to a non-empty scalar (a string or integer,
+never a bool, object, or array). A non-scalar fails the render with
+`invalid_resource` rather than serialising the payload subtree into
+`resource_id`, so a nested payload can never leak into the feed.
 
 ## Compatibility
 

--- a/src/bernstein/cli/commands/events_cmd.py
+++ b/src/bernstein/cli/commands/events_cmd.py
@@ -116,8 +116,17 @@ def verify_cmd(window_file: str) -> None:
     except json.JSONDecodeError as exc:
         console.print(f"[red]Malformed window file:[/red] {exc}")
         raise SystemExit(1) from None
-    if not isinstance(envelope, dict) or "events" not in envelope:
-        console.print("[red]Window file is not a feed envelope (missing 'events').[/red]")
+    # Boundary validation before offline verification: a well-formed feed
+    # envelope carries both fence-posts and a homogeneous list of event objects.
+    # Rejecting anything else stops a truncation attacker from dropping a
+    # fence-post (which would silently disable that bound's completeness check)
+    # or smuggling non-object entries that from_envelope would otherwise skip.
+    if not isinstance(envelope, dict) or not {"events", "from_hmac", "to_hmac"} <= envelope.keys():
+        console.print("[red]Window file is not a feed envelope (needs 'events', 'from_hmac', 'to_hmac').[/red]")
+        raise SystemExit(1)
+    raw_events = envelope["events"]
+    if not isinstance(raw_events, list) or not all(isinstance(item, dict) for item in raw_events):
+        console.print("[red]Window 'events' must be a list of event objects.[/red]")
         raise SystemExit(1)
 
     window = FeedWindow.from_envelope(cast("dict[str, Any]", envelope))

--- a/src/bernstein/core/events/feed.py
+++ b/src/bernstein/core/events/feed.py
@@ -24,7 +24,7 @@ by timestamps scattered across five files.
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
 from bernstein.core.events.grammar import GENESIS_HMAC, CanonicalEvent, project_entry
@@ -45,7 +45,7 @@ class FeedWindow:
             for an empty window.
     """
 
-    events: list[CanonicalEvent] = field(default_factory=list[CanonicalEvent])
+    events: tuple[CanonicalEvent, ...] = ()
     from_hmac: str | None = None
     to_hmac: str | None = None
 
@@ -91,11 +91,11 @@ class FeedWindow:
         bounds the producer claimed.
         """
         raw_events = cast("list[Any]", envelope.get("events", []))
-        events = [
+        events = tuple(
             CanonicalEvent.from_canonical_dict(cast("dict[str, Any]", item), position=idx)
             for idx, item in enumerate(raw_events)
             if isinstance(item, dict)
-        ]
+        )
         from_hmac = envelope.get("from_hmac")
         to_hmac = envelope.get("to_hmac")
         return cls(
@@ -103,6 +103,20 @@ class FeedWindow:
             from_hmac=str(from_hmac) if isinstance(from_hmac, str) else None,
             to_hmac=str(to_hmac) if isinstance(to_hmac, str) else None,
         )
+
+
+def _lower_fence_post(events: tuple[CanonicalEvent, ...]) -> str | None:
+    """Return the lower fence-post for a projected window.
+
+    A genesis-anchored slice - one whose first event chains from genesis -
+    carries a ``None`` lower fence-post, so :func:`verify_window` enforces
+    ``first.prev_hmac == GENESIS_HMAC`` and front-truncation of the genesis event
+    is detectable. A bounded slice retains its first event's HMAC as the fence-
+    post, so dropping the leading event still trips the lower-bound mismatch.
+    """
+    if not events:
+        return None
+    return None if events[0].prev_hmac == GENESIS_HMAC else events[0].hmac
 
 
 def project_window(slice_result: AuditSliceResult) -> FeedWindow:
@@ -113,12 +127,14 @@ def project_window(slice_result: AuditSliceResult) -> FeedWindow:
             :func:`bernstein.core.security.audit_slice.slice_audit_log`.
 
     Returns:
-        The projected window. Fence-posts are taken from the slice's first and
-        last entry HMACs, so the window carries its own completeness bounds.
+        The projected window. The upper fence-post is the slice's last entry
+        HMAC; the lower fence-post is the first entry HMAC for a bounded slice,
+        or ``None`` when the slice is genesis-anchored, so the window carries its
+        own completeness bounds.
     """
     raw_entries = cast("list[dict[str, Any]]", slice_result.events)
-    events = [project_entry(entry, position=idx) for idx, entry in enumerate(raw_entries)]
-    from_hmac = events[0].hmac if events else None
+    events = tuple(project_entry(entry, position=idx) for idx, entry in enumerate(raw_entries))
+    from_hmac = _lower_fence_post(events)
     to_hmac = events[-1].hmac if events else None
     return FeedWindow(events=events, from_hmac=from_hmac, to_hmac=to_hmac)
 
@@ -129,8 +145,8 @@ def project_entries(entries: list[dict[str, Any]]) -> FeedWindow:
     Convenience for callers that already hold decoded entries (for example the
     live tail on the SSE bus) rather than a slice result.
     """
-    events = [project_entry(entry, position=idx) for idx, entry in enumerate(entries)]
-    from_hmac = events[0].hmac if events else None
+    events = tuple(project_entry(entry, position=idx) for idx, entry in enumerate(entries))
+    from_hmac = _lower_fence_post(events)
     to_hmac = events[-1].hmac if events else None
     return FeedWindow(events=events, from_hmac=from_hmac, to_hmac=to_hmac)
 
@@ -182,6 +198,17 @@ def verify_window(
     # Completeness at the upper bound.
     if to_bound is not None and last.hmac != to_bound:
         errors.append(f"upper fence-post mismatch: window ends at {last.hmac[:16]}, expected {to_bound[:16]}")
+
+    # Identity integrity: no event may reuse another event's HMAC (a duplicated
+    # identity) or link to itself (``hmac == prev_hmac``). Either lets a forged
+    # cycle masquerade as a contiguous, fence-post-consistent chain.
+    seen: set[str] = set()
+    for idx, event in enumerate(window.events):
+        if event.hmac == event.prev_hmac:
+            errors.append(f"self-linked event at position {idx}: hmac equals prev_hmac {event.hmac[:16]}")
+        if event.hmac in seen:
+            errors.append(f"duplicate event hmac at position {idx}: {event.hmac[:16]}")
+        seen.add(event.hmac)
 
     # Order: contiguous prev_hmac linkage across the whole window.
     for idx in range(1, len(window.events)):

--- a/src/bernstein/core/events/receipts.py
+++ b/src/bernstein/core/events/receipts.py
@@ -97,6 +97,11 @@ def build_fire_receipt(
     """
     rendered = render_action(action, triggering_event)
     matched_hmacs = tuple(event.hmac for event in matched_events)
+    if triggering_event.hmac not in matched_hmacs:
+        # The receipt must not authorise an action rendered against an event
+        # outside the matched set: that would let a rule fire on an event it
+        # never actually matched.
+        raise ValueError("triggering event must be among the matched events")
     return FireReceipt(
         rule_hash=rule_hash(rule_spec),
         matched_event_hmacs=matched_hmacs,
@@ -128,9 +133,11 @@ def verify_fire_receipt(
 ) -> tuple[bool, list[str]]:
     """Verify a fire receipt against the rule, action, and the event window.
 
-    Confirms the rule hash, that every matched HMAC is present in the window, and
-    that re-rendering the action from the recorded triggering event reproduces
-    the committed digest byte-for-byte.
+    Confirms the rule hash, that every matched HMAC is present in the window,
+    that the triggering event is itself among the matched events, that the
+    receipt's ``action_kind`` matches what the action re-renders to, and that
+    re-rendering from the recorded triggering event reproduces the committed
+    digest byte-for-byte.
     """
     errors: list[str] = []
     if rule_hash(rule_spec) != receipt.rule_hash:
@@ -141,11 +148,17 @@ def verify_fire_receipt(
             errors.append(f"matched event not present in window: {hmac[:16]}")
 
     triggering_hmac = str(receipt.rendered_action.get("triggering_event_hmac", ""))
+    if triggering_hmac not in receipt.matched_event_hmacs:
+        # A receipt whose action was rendered against an event outside its own
+        # matched set is not a valid fire commitment.
+        errors.append("triggering event not among matched events")
     triggering_event = events_by_hmac.get(triggering_hmac)
     if triggering_event is None:
         errors.append("triggering event not present in window")
     else:
         re_rendered = render_action(action, triggering_event)
+        if re_rendered.kind != receipt.action_kind:
+            errors.append("action kind diverges from receipt")
         if re_rendered.digest != receipt.action_digest:
             errors.append("re-rendered action digest diverges from receipt")
         if re_rendered.to_dict() != receipt.rendered_action:
@@ -238,6 +251,30 @@ class DispatchResult:
     effect_result: Any
 
 
+def _find_completed_action_event(chain: AuditChainStore, *, action_digest: str) -> AuditEvent | None:
+    """Return a prior *completed* automation-action event for ``action_digest``.
+
+    A completed record (``result_status == "dispatched"``) proves the effect
+    already ran to success, so a replay must not run it again.
+    """
+    from bernstein.core.security.audit_chain import EVENT_AUTOMATION_ACTION
+
+    for event in chain.query(event_type=EVENT_AUTOMATION_ACTION, resource_id=action_digest):
+        details = event.details
+        status = str(details.get("result_status", ""))
+        if status == "dispatched" and str(details.get("action_digest", "")) == action_digest:
+            return event
+    return None
+
+
+def _find_fire_receipt_event(chain: AuditChainStore, *, action_digest: str) -> AuditEvent | None:
+    """Return the fire-receipt event that committed to ``action_digest``, if any."""
+    from bernstein.core.security.audit_chain import EVENT_RULE_FIRE_RECEIPT
+
+    events = chain.query(event_type=EVENT_RULE_FIRE_RECEIPT, resource_id=action_digest)
+    return events[0] if events else None
+
+
 def dispatch_action(
     *,
     chain: AuditChainStore,
@@ -246,11 +283,22 @@ def dispatch_action(
     effect: Callable[[RenderedAction], Any],
     actor: str = "events_automation",
 ) -> DispatchResult:
-    """Write the fire receipt, authorise, run the effect, then record the action.
+    """Authorise, commit a fire receipt, run the effect, and record the outcome.
 
-    The ordering is the contract: the receipt lands on the chain *before* the
-    effect runs, and the executed action is itself a chain event referencing the
-    receipt, so the automation is observable in the same feed it reacts to.
+    The chain records leave no audit gap across a failure:
+
+    1. The action is authorised against the receipt (a pure check, no write).
+    2. The fire receipt lands on the chain as the pre-effect commitment.
+    3. An *intent* record (``result_status="pending"``) is written **before** the
+       effect runs, so a crash mid-effect still shows the attempt.
+    4. The effect runs. A success writes a ``dispatched`` outcome; an exception
+       writes a ``failed`` outcome and then re-raises - either way the outcome is
+       on the chain.
+
+    Dispatch is idempotent, keyed on the fire receipt's action digest: if a
+    ``dispatched`` outcome for this exact action already exists, the effect is not
+    run again and the recorded events are returned. This makes a retry after a
+    post-effect record failure safe (the completed effect is not repeated).
 
     Raises:
         ActionRejected: When ``receipt`` does not authorise ``rendered_action``.
@@ -259,6 +307,18 @@ def dispatch_action(
         record_automation_action,
         record_rule_fire_receipt,
     )
+
+    if not authorize_action(receipt, rendered_action):
+        raise ActionRejected(
+            f"action {rendered_action.digest[:16]} is not covered by fire receipt {receipt.action_digest[:16]}"
+        )
+
+    # Idempotent replay: a completed outcome for this action digest means the
+    # effect already succeeded; return the recorded events without re-running it.
+    prior = _find_completed_action_event(chain, action_digest=rendered_action.digest)
+    if prior is not None:
+        fire_event = _find_fire_receipt_event(chain, action_digest=receipt.action_digest) or prior
+        return DispatchResult(fire_receipt_event=fire_event, action_event=prior, effect_result=None)
 
     fire_event = record_rule_fire_receipt(
         chain=chain,
@@ -269,12 +329,32 @@ def dispatch_action(
         actor=actor,
     )
 
-    if not authorize_action(receipt, rendered_action):
-        raise ActionRejected(
-            f"action {rendered_action.digest[:16]} is not covered by fire receipt {receipt.action_digest[:16]}"
-        )
+    # Intent before the effect: closes the pre-effect audit gap.
+    record_automation_action(
+        chain=chain,
+        action_kind=rendered_action.kind,
+        action_digest=rendered_action.digest,
+        fire_receipt_hmac=fire_event.hmac,
+        triggering_event_hmac=rendered_action.triggering_event_hmac,
+        result_status="pending",
+        actor=actor,
+    )
 
-    effect_result = effect(rendered_action)
+    try:
+        effect_result = effect(rendered_action)
+    except Exception:
+        # Record the failure outcome before propagating, so the effect exception
+        # never leaves the chain without an outcome.
+        record_automation_action(
+            chain=chain,
+            action_kind=rendered_action.kind,
+            action_digest=rendered_action.digest,
+            fire_receipt_hmac=fire_event.hmac,
+            triggering_event_hmac=rendered_action.triggering_event_hmac,
+            result_status="failed",
+            actor=actor,
+        )
+        raise
 
     action_event = record_automation_action(
         chain=chain,
@@ -282,6 +362,7 @@ def dispatch_action(
         action_digest=rendered_action.digest,
         fire_receipt_hmac=fire_event.hmac,
         triggering_event_hmac=rendered_action.triggering_event_hmac,
+        result_status="dispatched",
         actor=actor,
     )
     return DispatchResult(fire_receipt_event=fire_event, action_event=action_event, effect_result=effect_result)

--- a/src/bernstein/core/events/state.py
+++ b/src/bernstein/core/events/state.py
@@ -15,16 +15,22 @@ re-derivable from the slice alone.
 
 from __future__ import annotations
 
+import contextlib
 import json
+import os
 import sys
 from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
-if sys.platform == "win32":  # pragma: no cover - Windows fallback
+if sys.platform == "win32":  # pragma: no cover - exercised only on Windows
+    import msvcrt
+
     fcntl = None  # type: ignore[assignment]
 else:
     import fcntl  # type: ignore[no-redef]
+
+    msvcrt = None  # type: ignore[assignment]
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -34,37 +40,87 @@ _EXPECTATIONS_NAME = "expectations.json"
 _LOCK_NAME = ".triggers.lock"
 
 
+class TriggerStateCorruptError(RuntimeError):
+    """Raised when a trigger state file is unreadable or not a JSON object.
+
+    The offending file is preserved (renamed to ``<name>.corrupt``) rather than
+    silently treated as empty and overwritten, so the loss is never hidden and an
+    operator can inspect the damaged bookkeeping.
+    """
+
+
+def _lock_file(fd: Any) -> None:
+    """Take an exclusive, blocking inter-process lock on ``fd``.
+
+    ``flock`` on POSIX, ``msvcrt.locking`` on Windows. When neither primitive is
+    available the store refuses to run rather than yielding an unsynchronised
+    no-op that would silently lose concurrent increments or clobber expectations.
+    """
+    if fcntl is not None:
+        fcntl.flock(fd.fileno(), fcntl.LOCK_EX)
+    elif msvcrt is not None:  # pragma: no cover - Windows only
+        fd.seek(0)
+        msvcrt.locking(fd.fileno(), msvcrt.LK_LOCK, 1)
+    else:  # pragma: no cover - defensive: no lock primitive on this platform
+        raise RuntimeError("no inter-process lock primitive available on this platform")
+
+
+def _unlock_file(fd: Any) -> None:
+    """Release the lock taken by :func:`_lock_file`."""
+    if fcntl is not None:
+        fcntl.flock(fd.fileno(), fcntl.LOCK_UN)
+    elif msvcrt is not None:  # pragma: no cover - Windows only
+        fd.seek(0)
+        msvcrt.locking(fd.fileno(), msvcrt.LK_UNLCK, 1)
+
+
 @contextmanager
 def _exclusive_lock(root: Path) -> Iterator[None]:
-    """Serialise state mutations across processes via ``flock(LOCK_EX)``.
+    """Serialise state mutations across processes with an OS file lock.
 
-    Falls back to a no-op only where ``fcntl`` is unavailable (Windows); on those
-    platforms the caller is responsible for in-process ordering.
+    The lock is exclusive and blocking on every supported platform, so two
+    concurrent workers cannot lose an increment or clobber an expectation. It
+    never degrades to an unsynchronised no-op: a platform without a lock
+    primitive raises instead (see :func:`_lock_file`).
     """
     root.mkdir(parents=True, exist_ok=True)
     lock_path = root / _LOCK_NAME
-    if fcntl is None:  # pragma: no cover - Windows path
-        yield
-        return
-    fd = lock_path.open("a")
+    fd = lock_path.open("a+")
     try:
-        fcntl.flock(fd.fileno(), fcntl.LOCK_EX)
-        yield
-    finally:
+        _lock_file(fd)
         try:
-            fcntl.flock(fd.fileno(), fcntl.LOCK_UN)
+            yield
         finally:
-            fd.close()
+            _unlock_file(fd)
+    finally:
+        fd.close()
+
+
+def _quarantine(path: Path) -> None:
+    """Best-effort: preserve a corrupt state file as ``<name>.corrupt``."""
+    corrupt = path.with_name(path.name + ".corrupt")
+    with contextlib.suppress(OSError):  # preservation is best-effort
+        os.replace(path, corrupt)
 
 
 def _load(path: Path) -> dict[str, Any]:
     if not path.exists():
         return {}
     try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return {}
-    return cast("dict[str, Any]", raw) if isinstance(raw, dict) else {}
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        # Unreadable: propagate rather than overwrite. The file is untouched, so
+        # nothing is lost and the fault surfaces instead of being masked as {}.
+        raise TriggerStateCorruptError(f"cannot read trigger state file {path}") from exc
+    try:
+        raw = json.loads(text)
+    except json.JSONDecodeError as exc:
+        _quarantine(path)
+        raise TriggerStateCorruptError(f"corrupt trigger state file {path} (quarantined)") from exc
+    if not isinstance(raw, dict):
+        _quarantine(path)
+        raise TriggerStateCorruptError(f"trigger state file {path} is not a JSON object (quarantined)")
+    return cast("dict[str, Any]", raw)
 
 
 def _atomic_write(path: Path, data: dict[str, Any]) -> None:
@@ -151,4 +207,4 @@ class TriggerStateStore:
             return {k: cast("dict[str, Any]", v) for k, v in raw.items() if isinstance(v, dict)}
 
 
-__all__ = ["TriggerStateStore"]
+__all__ = ["TriggerStateCorruptError", "TriggerStateStore"]

--- a/src/bernstein/core/events/triggers.py
+++ b/src/bernstein/core/events/triggers.py
@@ -26,7 +26,7 @@ from fnmatch import fnmatchcase
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Sequence
+    from collections.abc import Sequence
 
     from bernstein.core.events.grammar import CanonicalEvent
 
@@ -56,17 +56,16 @@ def _bucket_key(event: CanonicalEvent, dims: Sequence[str]) -> tuple[str, ...]:
 # ---------------------------------------------------------------------------
 
 
-def _build_ancestor_index(events: Iterable[CanonicalEvent]) -> dict[str, set[str]]:
-    """Return ``resource_id -> {immediate ancestor resource ids}`` over a window.
+def _extend_ancestor_index(index: dict[str, set[str]], event: CanonicalEvent) -> None:
+    """Fold one event's lineage edges into an incremental ancestor index.
 
-    Edges are aggregated across every event: an event's
-    ``related_resource_ids`` are the immediate ancestors of its resource.
+    An event's ``related_resource_ids`` are the immediate ancestors of its
+    resource. Accumulating in chain-position order keeps descent checks causal: a
+    descent is decided only against edges introduced by the current or earlier
+    events, never by a relationship a later event will add (which would let a
+    trigger fold consult the future).
     """
-    index: dict[str, set[str]] = {}
-    for event in events:
-        bucket = index.setdefault(event.resource_id, set())
-        bucket.update(event.related_resource_ids)
-    return index
+    index.setdefault(event.resource_id, set()).update(event.related_resource_ids)
 
 
 def resource_descends(
@@ -215,41 +214,74 @@ class AbsenceViolation:
     expect: str
 
 
+@dataclass(slots=True)
+class _OpenAbsence:
+    """An anchor A awaiting its expected B, tracked during a forward scan."""
+
+    anchor: CanonicalEvent
+    upper_position: int
+    last_in_window: CanonicalEvent
+
+
 def evaluate_absence(expectation: AbsenceExpectation, events: Sequence[CanonicalEvent]) -> list[AbsenceViolation]:
     """Emit a violation for every A whose expected B never arrived in-window.
 
-    A violation is asserted only when the observed slice actually covers the
-    window (the slice extends ``within`` positions past A, or ends), so the
-    negative proof is bounded by two chain positions the verifier can check.
+    A violation is asserted only once the deadline is *observed* - the slice
+    contains an event at or beyond ``anchor.position + within`` - so the negative
+    proof is bounded by two chain positions a verifier can check. An anchor whose
+    deadline the slice never reaches is deferred (no violation), because emitting
+    would assert absence the slice cannot yet support.
+
+    The scan is a single forward pass so descent checks (``require_descent``)
+    consult the lineage index only up to the candidate's chain position, never
+    edges a later event introduces.
     """
     if expectation.within <= 0:
         raise ValueError("absence window must be positive")
 
-    ancestor_index = _build_ancestor_index(events)
+    ancestor_index: dict[str, set[str]] = {}
+    open_absences: list[_OpenAbsence] = []
     violations: list[AbsenceViolation] = []
 
-    for idx, anchor in enumerate(events):
-        if not _matches(anchor.label, expectation.after):
-            continue
-        upper_position = anchor.position + expectation.within
-        satisfied = False
-        last_in_window = anchor
-        for candidate in events[idx + 1 :]:
-            if candidate.position > upper_position:
-                break
-            last_in_window = candidate
-            if not _matches(candidate.label, expectation.expect):
+    for event in events:
+        # Accumulate lineage edges in chain-position order before any descent
+        # check, so an anchor's expectation is judged only against edges already
+        # recorded at this point in the chain.
+        _extend_ancestor_index(ancestor_index, event)
+
+        still_open: list[_OpenAbsence] = []
+        for oa in open_absences:
+            if event.position > oa.upper_position:
+                # An event past the deadline proves the window elapsed with no B.
+                violations.append(
+                    AbsenceViolation(
+                        after_hmac=oa.anchor.hmac, to_hmac=oa.last_in_window.hmac, expect=expectation.expect
+                    )
+                )
                 continue
-            if expectation.require_descent and not resource_descends(
-                candidate.resource_id, anchor.resource_id, ancestor_index
-            ):
-                continue
-            satisfied = True
-            break
-        if not satisfied:
-            violations.append(
-                AbsenceViolation(after_hmac=anchor.hmac, to_hmac=last_in_window.hmac, expect=expectation.expect)
+            # ``event`` falls inside the window (anchor.position, upper_position].
+            oa.last_in_window = event
+            satisfied = _matches(event.label, expectation.expect) and (
+                not expectation.require_descent
+                or resource_descends(event.resource_id, oa.anchor.resource_id, ancestor_index)
             )
+            if satisfied:
+                continue  # expectation met -> no violation
+            if event.position >= oa.upper_position:
+                # Deadline observed exactly at the window edge, still unmet.
+                violations.append(
+                    AbsenceViolation(after_hmac=oa.anchor.hmac, to_hmac=event.hmac, expect=expectation.expect)
+                )
+                continue
+            still_open.append(oa)  # deadline not yet observed -> keep waiting
+        open_absences = still_open
+
+        if _matches(event.label, expectation.after):
+            open_absences.append(
+                _OpenAbsence(anchor=event, upper_position=event.position + expectation.within, last_in_window=event)
+            )
+
+    # Anchors whose deadline the slice never observed are deferred (no violation).
     return violations
 
 
@@ -290,12 +322,20 @@ def evaluate_sequence(rule: SequenceRule, events: Sequence[CanonicalEvent]) -> l
     For each B matching ``later``, the earliest A (by chain position) matching
     ``earlier`` from which B descends fires the rule. Two unrelated events in the
     right wall-clock order never fire, because no lineage path connects them.
+
+    The index is accumulated in chain-position order, so B's descent is decided
+    only against edges present at or before B's position - a later event can
+    never retroactively make an earlier pair fire.
     """
-    ancestor_index = _build_ancestor_index(events)
-    earlier_events = [e for e in events if _matches(e.label, rule.earlier)]
+    ancestor_index: dict[str, set[str]] = {}
+    earlier_events: list[CanonicalEvent] = []
     fires: list[SequenceFire] = []
 
     for later in events:
+        # Fold this event's edges in before deciding descent for it.
+        _extend_ancestor_index(ancestor_index, later)
+        if _matches(later.label, rule.earlier):
+            earlier_events.append(later)
         if not _matches(later.label, rule.later):
             continue
         for earlier in earlier_events:

--- a/src/bernstein/core/events/webhook_template.py
+++ b/src/bernstein/core/events/webhook_template.py
@@ -28,6 +28,20 @@ class TemplatePathError(KeyError):
     """Raised internally when a required payload path is absent."""
 
 
+def _is_scalar_resource(value: Any) -> bool:
+    """Return whether ``value`` is a non-empty scalar usable as a resource id.
+
+    Only a non-empty ``str`` or an ``int`` (excluding ``bool``, an ``int``
+    subclass) qualifies. A dict/list would otherwise be ``str()``-ed into
+    ``resource_id`` verbatim, leaking the payload subtree into the feed.
+    """
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, int):
+        return True
+    return isinstance(value, str) and bool(value)
+
+
 def _extract(payload: Any, dot_path: str) -> Any:
     """Resolve a dot-delimited path against a decoded JSON payload.
 
@@ -72,7 +86,7 @@ class WebhookRenderResult:
             failure ever records.
         event: The rendered canonical event mapping on success, else ``None``.
         error_kind: A short machine token on failure (``invalid_json`` /
-            ``missing_resource``), else ``None``.
+            ``missing_resource`` / ``invalid_resource``), else ``None``.
     """
 
     ok: bool
@@ -101,6 +115,11 @@ def render(template: WebhookTemplate, payload_bytes: bytes) -> WebhookRenderResu
         resource_raw = _extract(decoded, template.resource_path)
     except TemplatePathError:
         return WebhookRenderResult(ok=False, payload_digest=digest, error_kind="missing_resource")
+
+    if not _is_scalar_resource(resource_raw):
+        # Never str() a non-scalar into resource_id - that would copy the payload
+        # subtree into the feed. Fail carrying the digest only.
+        return WebhookRenderResult(ok=False, payload_digest=digest, error_kind="invalid_resource")
 
     related: set[str] = set()
     for path in template.related_paths:

--- a/tests/unit/test_events_feed.py
+++ b/tests/unit/test_events_feed.py
@@ -68,8 +68,63 @@ def test_window_embeds_fence_posts(tmp_path: Path) -> None:
     _seed_chain(audit_dir)
     window = project_window(slice_audit_log(audit_dir))
 
-    assert window.from_hmac == window.events[0].hmac
+    # A genesis-anchored full window carries a null lower fence-post, so
+    # verify_window enforces first.prev_hmac == GENESIS and front-truncation of
+    # the genesis event is detectable (#2653).
+    assert window.from_hmac is None
     assert window.to_hmac == window.events[-1].hmac
+
+
+def test_events_stored_as_immutable_tuple(tmp_path: Path) -> None:
+    audit_dir = tmp_path / "audit"
+    _seed_chain(audit_dir)
+    window = project_window(slice_audit_log(audit_dir))
+
+    # A verified window cannot be mutated in place: events is a tuple (#2653).
+    assert isinstance(window.events, tuple)
+
+
+def test_genesis_front_truncation_is_detected(tmp_path: Path) -> None:
+    audit_dir = tmp_path / "audit"
+    _seed_chain(audit_dir)
+    window = project_window(slice_audit_log(audit_dir))
+    assert window.from_hmac is None  # genesis-anchored
+
+    # Drop the genesis event but keep claiming a genesis anchor: the new first
+    # event's prev_hmac is not GENESIS, so verification must reject it (#2653).
+    truncated = dataclasses.replace(window, events=window.events[1:])
+    ok, errors = verify_window(truncated)
+    assert not ok
+    assert any("genesis anchor" in e for e in errors)
+
+
+def test_duplicate_event_hmac_is_rejected(tmp_path: Path) -> None:
+    audit_dir = tmp_path / "audit"
+    _seed_chain(audit_dir)
+    window = project_window(slice_audit_log(audit_dir))
+
+    # Re-inserting an event with an already-seen HMAC must fail verification,
+    # even though its prev_hmac still chains from its predecessor (#2653).
+    dup = dataclasses.replace(window.events[1], position=window.events[1].position)
+    tampered = dataclasses.replace(window, events=(*window.events, dup))
+    ok, errors = verify_window(tampered, expect_from=window.from_hmac, expect_to=window.to_hmac)
+    assert not ok
+    assert any("duplicate event hmac" in e for e in errors)
+
+
+def test_self_linked_event_is_rejected(tmp_path: Path) -> None:
+    audit_dir = tmp_path / "audit"
+    _seed_chain(audit_dir)
+    window = project_window(slice_audit_log(audit_dir))
+
+    # An event whose hmac equals its prev_hmac is a self-link (a forged cycle);
+    # verification must reject it (#2653).
+    first = window.events[0]
+    self_linked = dataclasses.replace(first, prev_hmac=first.hmac)
+    tampered = dataclasses.replace(window, events=(self_linked, *window.events[1:]))
+    ok, errors = verify_window(tampered)
+    assert not ok
+    assert any("self-linked" in e for e in errors)
 
 
 def test_window_verifies_offline_for_completeness_and_order(tmp_path: Path) -> None:
@@ -89,7 +144,7 @@ def test_deleting_an_event_fails_verification(tmp_path: Path) -> None:
     # Drop the middle event but keep the fence-posts: linkage must break.
     tampered = dataclasses.replace(
         window,
-        events=[window.events[0], window.events[1], window.events[3]],
+        events=(window.events[0], window.events[1], window.events[3]),
     )
     ok, errors = verify_window(tampered, expect_from=window.from_hmac, expect_to=window.to_hmac)
     assert not ok
@@ -103,7 +158,7 @@ def test_reordering_an_event_fails_verification(tmp_path: Path) -> None:
 
     reordered = dataclasses.replace(
         window,
-        events=[window.events[0], window.events[2], window.events[1], window.events[3]],
+        events=(window.events[0], window.events[2], window.events[1], window.events[3]),
     )
     ok, _errors = verify_window(reordered, expect_from=window.from_hmac, expect_to=window.to_hmac)
     assert not ok

--- a/tests/unit/test_events_receipts.py
+++ b/tests/unit/test_events_receipts.py
@@ -12,13 +12,17 @@ Covers acceptance criteria:
 
 from __future__ import annotations
 
+import dataclasses
 from pathlib import Path
 
-from bernstein.core.events.actions import ActionSpec, render_action
+import pytest
+
+from bernstein.core.events.actions import ActionSpec, render_action, rule_hash
 from bernstein.core.events.feed import project_window
 from bernstein.core.events.grammar import CanonicalEvent
 from bernstein.core.events.receipts import (
     ActionRejected,
+    FireReceipt,
     build_absence_receipt,
     build_fire_receipt,
     dispatch_action,
@@ -154,8 +158,9 @@ def test_absence_receipt_verifies_and_fails_on_injection(tmp_path: Path) -> None
     )
     window = project_window(slice_audit_log(tmp_path / "audit"))
 
+    # within=2 so the deadline (chain position 2) is observed by the slice.
     violations = evaluate_absence(
-        AbsenceExpectation(after="run.started", expect="run.completed", within=10), window.events
+        AbsenceExpectation(after="run.started", expect="run.completed", within=2), window.events
     )
     assert len(violations) == 1
     receipt = build_absence_receipt(violations[0])
@@ -179,3 +184,129 @@ def test_absence_receipt_verifies_and_fails_on_injection(tmp_path: Path) -> None
     bad_ok, bad_errors = verify_absence_receipt(receipt, tampered_window)
     assert not bad_ok
     assert any("matching event present" in e for e in bad_errors)
+
+
+# ---------------------------------------------------------------------------
+# Fire-receipt binding checks (#2653, item 9)
+# ---------------------------------------------------------------------------
+
+
+def test_build_fire_receipt_requires_triggering_in_matched() -> None:
+    trigger = _event(0, "gate.result", "g")
+    other = _event(1, "gate.result", "h")
+    action = ActionSpec(kind="schedule.pause", params={"schedule_id": "nightly"})
+    # The action is rendered against ``trigger`` but ``trigger`` is not among the
+    # matched events -> the receipt would authorise an unmatched triggering event.
+    with pytest.raises(ValueError):
+        build_fire_receipt(rule_spec=_RULE_SPEC, matched_events=[other], action=action, triggering_event=trigger)
+
+
+def test_verify_fire_receipt_rejects_triggering_not_in_matched() -> None:
+    trigger = _event(0, "gate.result", "g")
+    other = _event(1, "gate.result", "h")
+    action = ActionSpec(kind="schedule.pause", params={"schedule_id": "nightly"})
+    rendered = render_action(action, trigger)
+    # Hand-craft a receipt whose matched set excludes the triggering event.
+    receipt = FireReceipt(
+        rule_hash=rule_hash(_RULE_SPEC),
+        matched_event_hmacs=(other.hmac,),
+        action_kind=rendered.kind,
+        action_digest=rendered.digest,
+        rendered_action=rendered.to_dict(),
+    )
+    events_by_hmac = {trigger.hmac: trigger, other.hmac: other}
+
+    ok, errors = verify_fire_receipt(receipt, rule_spec=_RULE_SPEC, action=action, events_by_hmac=events_by_hmac)
+    assert not ok
+    assert any("triggering event not among matched" in e for e in errors)
+
+
+def test_verify_fire_receipt_rejects_action_kind_mismatch() -> None:
+    trigger = _event(0, "gate.result", "g")
+    action = ActionSpec(kind="schedule.pause", params={"schedule_id": "nightly"})
+    receipt = build_fire_receipt(
+        rule_spec=_RULE_SPEC, matched_events=[trigger], action=action, triggering_event=trigger
+    )
+    # A receipt whose action_kind no longer matches what the action re-renders to.
+    tampered = dataclasses.replace(receipt, action_kind="notify")
+    events_by_hmac = {trigger.hmac: trigger}
+
+    ok, errors = verify_fire_receipt(tampered, rule_spec=_RULE_SPEC, action=action, events_by_hmac=events_by_hmac)
+    assert not ok
+    assert any("action kind diverges" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# Dispatch audit continuity (#2653, item 10)
+# ---------------------------------------------------------------------------
+
+
+def _dispatch_fixture() -> tuple[ActionSpec, CanonicalEvent, FireReceipt, object]:
+    trigger = _event(0, "gate.result", "g")
+    action = ActionSpec(kind="schedule.pause", params={"schedule_id": "nightly"})
+    receipt = build_fire_receipt(
+        rule_spec=_RULE_SPEC, matched_events=[trigger], action=action, triggering_event=trigger
+    )
+    rendered = render_action(action, trigger)
+    return action, trigger, receipt, rendered
+
+
+def test_dispatch_writes_pending_intent_before_effect(tmp_path: Path) -> None:
+    chain = AuditChainStore(tmp_path / "audit", key=b"k" * 32)
+    _action, _trigger, receipt, rendered = _dispatch_fixture()
+
+    saw_pending: list[bool] = []
+
+    def effect(_rendered: object) -> str:
+        pending = [
+            e for e in chain.query(event_type=EVENT_AUTOMATION_ACTION) if e.details.get("result_status") == "pending"
+        ]
+        saw_pending.append(bool(pending))
+        return "paused"
+
+    dispatch_action(chain=chain, receipt=receipt, rendered_action=rendered, effect=effect)  # type: ignore[arg-type]
+    # The intent/pending record is on the chain before the effect runs.
+    assert saw_pending == [True]
+
+
+def test_dispatch_records_failure_outcome_on_effect_exception(tmp_path: Path) -> None:
+    chain = AuditChainStore(tmp_path / "audit", key=b"k" * 32)
+    _action, _trigger, receipt, rendered = _dispatch_fixture()
+
+    def effect(_rendered: object) -> str:
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        dispatch_action(chain=chain, receipt=receipt, rendered_action=rendered, effect=effect)  # type: ignore[arg-type]
+
+    statuses = [e.details.get("result_status") for e in chain.query(event_type=EVENT_AUTOMATION_ACTION)]
+    # No audit gap: an intent and a failure outcome both landed despite the raise.
+    assert "pending" in statuses
+    assert "failed" in statuses
+    ok, errors = chain.verify()
+    assert ok, errors
+
+
+def test_dispatch_is_idempotent_on_replay(tmp_path: Path) -> None:
+    chain = AuditChainStore(tmp_path / "audit", key=b"k" * 32)
+    _action, _trigger, receipt, rendered = _dispatch_fixture()
+
+    calls: list[int] = []
+
+    def effect(_rendered: object) -> str:
+        calls.append(1)
+        return "paused"
+
+    first = dispatch_action(chain=chain, receipt=receipt, rendered_action=rendered, effect=effect)  # type: ignore[arg-type]
+    second = dispatch_action(chain=chain, receipt=receipt, rendered_action=rendered, effect=effect)  # type: ignore[arg-type]
+
+    # The effect ran exactly once; the replay is keyed on the fire receipt.
+    assert calls == [1]
+    assert first.effect_result == "paused"
+    assert second.effect_result is None
+    completed = [
+        e for e in chain.query(event_type=EVENT_AUTOMATION_ACTION) if e.details.get("result_status") == "dispatched"
+    ]
+    assert len(completed) == 1
+    ok, errors = chain.verify()
+    assert ok, errors

--- a/tests/unit/test_events_state_isolation.py
+++ b/tests/unit/test_events_state_isolation.py
@@ -10,7 +10,10 @@ from __future__ import annotations
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
-from bernstein.core.events.state import TriggerStateStore
+import pytest
+
+from bernstein.core.events import state as state_mod
+from bernstein.core.events.state import TriggerStateCorruptError, TriggerStateStore
 
 
 def test_state_lives_under_runtime_triggers(tmp_path: Path) -> None:
@@ -49,3 +52,62 @@ def test_expectations_roundtrip(tmp_path: Path) -> None:
     closed = store.close_expectation("run_1")
     assert closed == {"expect": "run.completed", "after_hmac": "abc"}
     assert store.open_expectations() == {}
+
+
+def test_corrupt_state_file_is_preserved_not_overwritten(tmp_path: Path) -> None:
+    root = tmp_path / ".sdd" / "runtime" / "triggers"
+    root.mkdir(parents=True)
+    counters = root / "counters.json"
+    counters.write_text("{not valid json", encoding="utf-8")
+    store = TriggerStateStore(root)
+
+    with pytest.raises(TriggerStateCorruptError):
+        store.increment("gate.result")
+
+    # Original bytes preserved for inspection; not silently emptied and rewritten.
+    corrupt = root / "counters.json.corrupt"
+    assert corrupt.exists()
+    assert corrupt.read_text(encoding="utf-8") == "{not valid json"
+    assert not counters.exists()
+
+
+def test_non_object_state_file_raises(tmp_path: Path) -> None:
+    root = tmp_path / ".sdd" / "runtime" / "triggers"
+    root.mkdir(parents=True)
+    (root / "expectations.json").write_text("[1, 2, 3]", encoding="utf-8")
+    store = TriggerStateStore(root)
+
+    with pytest.raises(TriggerStateCorruptError):
+        store.open_expectations()
+    assert (root / "expectations.json.corrupt").exists()
+
+
+def test_missing_lock_primitive_refuses_silent_no_op(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # With neither flock nor msvcrt available the store must raise rather than
+    # yield an unsynchronised no-op (the old Windows behaviour).
+    monkeypatch.setattr(state_mod, "fcntl", None, raising=False)
+    monkeypatch.setattr(state_mod, "msvcrt", None, raising=False)
+    store = TriggerStateStore(tmp_path / "triggers")
+
+    with pytest.raises(RuntimeError):
+        store.increment("gate.result")
+
+
+def test_windows_lock_path_uses_msvcrt(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Simulate the Windows branch: fcntl absent, msvcrt present. The lock must be
+    # taken (LK_LOCK) and released (LK_UNLCK), not skipped.
+    modes: list[int] = []
+
+    class _FakeMsvcrt:
+        LK_LOCK = 1
+        LK_UNLCK = 2
+
+        def locking(self, _fileno: int, mode: int, _nbytes: int) -> None:
+            modes.append(mode)
+
+    monkeypatch.setattr(state_mod, "fcntl", None, raising=False)
+    monkeypatch.setattr(state_mod, "msvcrt", _FakeMsvcrt(), raising=False)
+    store = TriggerStateStore(tmp_path / "triggers")
+
+    assert store.increment("gate.result") == 1
+    assert modes == [_FakeMsvcrt.LK_LOCK, _FakeMsvcrt.LK_UNLCK]

--- a/tests/unit/test_events_triggers.py
+++ b/tests/unit/test_events_triggers.py
@@ -126,17 +126,61 @@ def test_sequence_ignores_pure_wall_clock_order() -> None:
     assert evaluate_sequence(rule, events) == []
 
 
+def test_sequence_ignores_future_lineage_edges() -> None:
+    # The B->A edge only appears at position 2, after the "b" event at position 1.
+    # A causal fold must not fire the (A@0, b@1) pair on an edge from the future.
+    events = [
+        _event(0, "task.created", "task_a"),
+        _event(1, "gate.result", "gate_b", related=()),
+        _event(2, "cost.update", "gate_b", related=("task_a",)),
+    ]
+    rule = SequenceRule(earlier="task.created", later="gate.result")
+    # Fixed (causal index): no fire. Bug (merged future edges): one spurious fire.
+    assert evaluate_sequence(rule, events) == []
+
+
 def test_absence_emits_violation_when_expected_never_arrives() -> None:
     events = [
         _event(0, "run.started", "run_1"),
         _event(1, "cost.update", "run_1"),
         _event(2, "cost.update", "run_1"),
     ]
-    expectation = AbsenceExpectation(after="run.started", expect="run.completed", within=5)
+    # within=2 so the deadline (position 2) is actually observed by the slice.
+    expectation = AbsenceExpectation(after="run.started", expect="run.completed", within=2)
     violations = evaluate_absence(expectation, events)
     assert len(violations) == 1
     assert violations[0].after_hmac == "hmac0000"
     assert violations[0].to_hmac == "hmac0002"
+
+
+def test_absence_defers_when_deadline_not_observed() -> None:
+    # The slice ends (position 2) before the absence deadline (position 5) is
+    # reached, so no negative proof can be asserted yet -> defer (#2653).
+    events = [
+        _event(0, "run.started", "run_1"),
+        _event(1, "cost.update", "run_1"),
+        _event(2, "cost.update", "run_1"),
+    ]
+    expectation = AbsenceExpectation(after="run.started", expect="run.completed", within=5)
+    assert evaluate_absence(expectation, events) == []
+
+
+def test_absence_uses_only_causal_lineage_edges() -> None:
+    # B (position 1) has no lineage to anchor A at its own position; a later
+    # event (position 2) introduces the B->A edge. A causal descent check must
+    # NOT let that future edge satisfy the expectation, so the violation stands.
+    events = [
+        _event(0, "a", "A"),
+        _event(1, "b", "B"),
+        _event(2, "b", "B", related=("A",)),
+    ]
+    expectation = AbsenceExpectation(after="a", expect="b", within=1, require_descent=True)
+    violations = evaluate_absence(expectation, events)
+    # Fixed (causal index): B@1 does not descend from A yet -> 1 violation.
+    # Bug (future edges merged): B@1 would descend from A -> 0 violations.
+    assert len(violations) == 1
+    assert violations[0].after_hmac == "hmac0000"
+    assert violations[0].to_hmac == "hmac0001"
 
 
 def test_absence_satisfied_when_expected_arrives() -> None:

--- a/tests/unit/test_events_verify_cmd.py
+++ b/tests/unit/test_events_verify_cmd.py
@@ -1,0 +1,87 @@
+"""``bernstein events verify`` boundary validation (#2653).
+
+The CLI verifier must reject envelopes that a truncation attacker has stripped
+of a fence-post or whose event list is not a homogeneous list of objects, before
+handing them to the offline verifier. Otherwise dropping ``to_hmac`` and
+truncating the tail passes verification unnoticed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from bernstein.cli.commands.events_cmd import events_group
+from bernstein.core.events.feed import project_window
+from bernstein.core.security.audit_chain import AuditChainStore
+from bernstein.core.security.audit_slice import slice_audit_log
+
+
+def _valid_envelope(tmp_path: Path) -> dict[str, object]:
+    audit_dir = tmp_path / "audit"
+    chain = AuditChainStore(audit_dir, key=b"k" * 32)
+    for i in range(3):
+        chain.log_with_prev_digest(
+            event_type="cost.update",
+            actor="orchestrator",
+            resource_type="run",
+            resource_id=f"run_{i}",
+            details={"run_id": f"run_{i}"},
+        )
+    window = project_window(slice_audit_log(audit_dir))
+    return json.loads(window.to_envelope_json())
+
+
+def _write(tmp_path: Path, envelope: object) -> Path:
+    out = tmp_path / "window.json"
+    out.write_text(json.dumps(envelope), encoding="utf-8")
+    return out
+
+
+def test_valid_window_verifies(tmp_path: Path) -> None:
+    path = _write(tmp_path, _valid_envelope(tmp_path))
+    result = CliRunner().invoke(events_group, ["verify", str(path)])
+    assert result.exit_code == 0, result.output
+    assert "verified" in result.output.lower()
+
+
+def test_dropped_to_hmac_with_truncated_tail_is_rejected(tmp_path: Path) -> None:
+    envelope = _valid_envelope(tmp_path)
+    # Attacker drops the upper fence-post and truncates the last event; without
+    # the boundary check the missing to_hmac disables the upper-bound check.
+    envelope["events"] = envelope["events"][:-1]  # type: ignore[index]
+    del envelope["to_hmac"]
+
+    path = _write(tmp_path, envelope)
+    result = CliRunner().invoke(events_group, ["verify", str(path)])
+    assert result.exit_code == 1
+    assert "feed envelope" in result.output.lower()
+
+
+def test_dropped_from_hmac_is_rejected(tmp_path: Path) -> None:
+    envelope = _valid_envelope(tmp_path)
+    del envelope["from_hmac"]
+    path = _write(tmp_path, envelope)
+    result = CliRunner().invoke(events_group, ["verify", str(path)])
+    assert result.exit_code == 1
+
+
+def test_events_not_a_list_is_rejected(tmp_path: Path) -> None:
+    envelope = _valid_envelope(tmp_path)
+    envelope["events"] = {"not": "a list"}
+    path = _write(tmp_path, envelope)
+    result = CliRunner().invoke(events_group, ["verify", str(path)])
+    assert result.exit_code == 1
+    assert "list" in result.output.lower()
+
+
+def test_non_dict_event_entry_is_rejected(tmp_path: Path) -> None:
+    envelope = _valid_envelope(tmp_path)
+    events = list(envelope["events"])  # type: ignore[arg-type]
+    events.append("smuggled-scalar")
+    envelope["events"] = events
+    path = _write(tmp_path, envelope)
+    result = CliRunner().invoke(events_group, ["verify", str(path)])
+    assert result.exit_code == 1

--- a/tests/unit/test_events_webhook_template.py
+++ b/tests/unit/test_events_webhook_template.py
@@ -96,3 +96,30 @@ def test_missing_required_path_fails_with_digest() -> None:
     assert not result.ok
     assert result.error_kind == "missing_resource"
     assert result.payload_digest == content_address(payload)
+
+
+def test_non_scalar_resource_does_not_leak_payload() -> None:
+    # run.id resolves to a nested object; str()-ing it would serialise the whole
+    # subtree (including the secret) into resource_id (#2653).
+    payload = json.dumps({"run": {"id": {"nested": "s3cr3t-value"}}}).encode("utf-8")
+    result = render(_TEMPLATE, payload)
+    assert not result.ok
+    assert result.error_kind == "invalid_resource"
+    assert result.event is None
+    assert result.payload_digest == content_address(payload)
+
+
+def test_boolean_and_empty_resource_are_rejected() -> None:
+    for raw in (True, False, "", [1, 2], None):
+        payload = json.dumps({"run": {"id": raw}}).encode("utf-8")
+        result = render(_TEMPLATE, payload)
+        assert not result.ok, raw
+        assert result.error_kind == "invalid_resource", raw
+
+
+def test_integer_resource_is_accepted() -> None:
+    payload = json.dumps({"run": {"id": 4242}}).encode("utf-8")
+    result = render(_TEMPLATE, payload)
+    assert result.ok
+    assert result.event is not None
+    assert result.event["resource_id"] == "4242"


### PR DESCRIPTION
## What
Bounded hardening sweep of the eventing v2 feed/triggers/webhooks/receipts. All 11 checklist items were genuine gaps against current main (none stale) and are fixed with a regression test each. 6 coherent commits (5 module clusters + docs), TDD red-then-green captured for every item. 59 event tests pass; ruff clean; 0 new mypy errors in touched files; collection sentinel + import sentinel green.

Fixes #2653

## Checklist outcome
11 fixed / 0 already shipped on main (verified, no change) / 0 recorded out-of-scope.

- **1: events verify accepts truncated window when to_hmac dropped (events_cmd.py:119)** — fixed: verify_cmd now requires both from_hmac and to_hmac keys present, events to be a list, and every entry a dict before from_envelope/verify_window. Dropping to_hma
- **2: project_window never marks genesis anchor (feed.py:121)** — fixed: New _lower_fence_post() returns from_hmac=None for genesis-anchored slices (first.prev_hmac==GENESIS_HMAC), retaining the first HMAC only for bounded slices, so
- **3: verify_window does not reject duplicate/self-linked events (feed.py:187)** — fixed: Added an identity-integrity pass tracking seen HMACs; rejects duplicate hmac identities and any event where hmac==prev_hmac. Tests: test_duplicate_event_hmac_is
- **4: webhook render serializes non-scalar resource into resource_id (webhook_template.py:117)** — fixed: New _is_scalar_resource() requires a non-empty scalar (str/int, excluding bool); a dict/list/bool/empty/None now fails with error_kind=invalid_resource carrying
- **5: TriggerStateStore inter-process lock is a silent no-op on Windows (state.py:46)** — fixed: _lock_file/_unlock_file dispatch to fcntl.flock (POSIX) or msvcrt.locking (Windows) and raise RuntimeError where no primitive exists, instead of yielding unsync
- **6: corrupted/unreadable state file silently emptied then overwritten (state.py:65)** — fixed: _load now raises TriggerStateCorruptError on unreadable/non-JSON/non-object content and quarantines the offending file (renamed to <name>.corrupt) instead of re
- **7: lineage index merges future edges (triggers.py:66)** — fixed: Replaced _build_ancestor_index with incremental _extend_ancestor_index; evaluate_sequence and evaluate_absence now accumulate the ancestor index in chain-positi
- **8: evaluate_absence emits violations before deadline observed (triggers.py:249)** — fixed: Rewrote evaluate_absence as a single forward scan that emits a violation only once the deadline is observed (an event at/beyond anchor.position+within); anchors
- **9: verify_fire_receipt omits triggering-event membership and action_kind checks (receipts.py:139)** — fixed: verify_fire_receipt now rejects when triggering_event_hmac is not in matched_event_hmacs and when receipt.action_kind != re_rendered.kind; build_fire_receipt ra
- **10: dispatch_action leaves audit gaps on effect failure and post-effect record failure (receipts.py:277)** — fixed: dispatch_action writes a pending intent record before the effect and a dispatched/failed outcome afterward (failed outcome recorded even when the effect raises,
- **11: FeedWindow frozen but events list stays mutable (feed.py:48)** — fixed: FeedWindow.events is now tuple[CanonicalEvent, ...] (default ()); project_window/project_entries/from_envelope build tuples, so a verified window cannot be muta

## Verification
Adversarial review round: **confirmed, 0 critical findings** (red-on-main proven for the substantive items).
Final targeted run of all 7 event test files: "59 passed, 1 warning in 9.69s" (uv run pytest tests/unit/test_events_feed.py test_events_verify_cmd.py test_events_webhook_template.py test_events_state_isolation.py test_events_triggers.py test_events_receipts.py test_events_compat.py). Import sentinel: imports OK for all 6 touched modules. Collection sentinel (allowed): 37862 tests collected in tests/unit, no collection errors. ruff check: All checks passed; ruff format --check: clean. mypy on the 6 touched files: 0 errors in touched files (the 186 repo-wide errors are pre-existing, all in unrel
