### PR TITLE
fix(admission): harden the admission engine, ledger, tags, and verifier

### DIFF
--- a/src/bernstein/cli/commands/limits_cmd.py
+++ b/src/bernstein/cli/commands/limits_cmd.py
@@ -24,7 +24,7 @@ from rich.table import Table
 
 from bernstein.cli.helpers import console
 from bernstein.core.admission.engine import AdmissionEngine
-from bernstein.core.admission.models import Posture
+from bernstein.core.admission.models import Posture, canonical_name
 from bernstein.core.persistence.work_ledger import LedgerError
 
 EXIT_OK = 0
@@ -197,10 +197,20 @@ def queue_pause_cmd(name: str, resume: bool, workdir: Path | None, output_json: 
     """Pause (or resume) a named queue."""
     engine = _engine(workdir)
     state = engine.state()
-    spec = state.queues.get(name)
-    priority = spec.priority if spec is not None else 0
+    # Canonicalize the name so a mis-cased argument resolves to the same queue,
+    # and refuse an unknown queue instead of conjuring a phantom one (with its
+    # priority silently reset to 0).
     try:
-        entry_hash = engine.set_queue(name, priority=priority, paused=not resume)
+        canonical = canonical_name(name)
+    except ValueError as exc:
+        console.print(f"[red]Queue update failed:[/red] {exc}")
+        raise SystemExit(EXIT_ERROR) from None
+    spec = state.queues.get(canonical)
+    if spec is None:
+        console.print(f"[red]Queue update failed:[/red] no such queue {name!r}")
+        raise SystemExit(EXIT_ERROR) from None
+    try:
+        entry_hash = engine.set_queue(canonical, priority=spec.priority, paused=not resume)
     except (ValueError, LedgerError) as exc:
         console.print(f"[red]Queue update failed:[/red] {exc}")
         raise SystemExit(EXIT_ERROR) from None

--- a/src/bernstein/core/admission/engine.py
+++ b/src/bernstein/core/admission/engine.py
@@ -35,13 +35,16 @@ from bernstein.core.admission.ledger import (
     open_admission_reader,
 )
 from bernstein.core.admission.models import Posture, canonical_name
-from bernstein.core.admission.projection import AdmissionState
+from bernstein.core.admission.projection import (
+    AdmissionState,
+    advise_over_gates,
+    enforce_gate_refusal,
+)
 from bernstein.core.admission.receipts import (
     WaiverReceipt,
     assemble_waiver_receipt,
     sign_receipt,
 )
-from bernstein.core.admission.tags import tags_admissible
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -100,12 +103,20 @@ class AdmissionEngine:
     audit_dir: Path | None = None
 
     def __post_init__(self) -> None:
-        if not self.private_key_pem or not self.public_key_pem:
+        # Reject a partial keypair: filling in the missing half from a freshly
+        # generated pair would mint a signing key whose public half does not
+        # match the supplied one (or vice versa), producing receipts no verifier
+        # can validate. Supply both PEMs, or neither.
+        if bool(self.private_key_pem) != bool(self.public_key_pem):
+            msg = (
+                "AdmissionEngine requires both private_key_pem and public_key_pem or neither; "
+                "a partial keypair would mismatch signing and verification"
+            )
+            raise ValueError(msg)
+        if not self.private_key_pem and not self.public_key_pem:
             from bernstein.core.skills.catalog.signature import generate_signer_keypair
 
-            priv, pub = generate_signer_keypair()
-            self.private_key_pem = self.private_key_pem or priv
-            self.public_key_pem = self.public_key_pem or pub
+            self.private_key_pem, self.public_key_pem = generate_signer_keypair()
 
     @classmethod
     def for_workdir(cls, workdir: Path, *, ledger_id: str = DEFAULT_ADMISSION_ID) -> AdmissionEngine:
@@ -206,9 +217,11 @@ class AdmissionEngine:
         """
         state = self.state()
         pool_name = canonical_name(pool) if pool else ""
-        declared = tuple(canonical_name(t) for t in tags)
+        # De-duplicate declared tags so a grant that names the same tag twice
+        # consumes at most one unit of that tag's concurrency limit.
+        declared = tuple(sorted({canonical_name(t) for t in tags}))
 
-        over_limit, refusal = self._evaluate(state, pool_name, declared)
+        over_limit, refusal, over_gates = self._evaluate(state, pool_name, declared)
         if refusal is not None:
             return AdmissionDecision(admitted=False, reason=refusal)
 
@@ -234,9 +247,13 @@ class AdmissionEngine:
 
         waiver: WaiverReceipt | None = None
         if over_limit:
+            # Name the gate(s) actually exceeded under ADVISE, not whichever
+            # gate happened to be present. A pool-under-capacity grant that is
+            # over-limit only because of a tag records the tag, not the pool.
+            resource = ",".join(over_gates)
             waiver = self._record_waiver(
-                gate=pool_name or (declared[0] if declared else "tag"),
-                resource=pool_name or ",".join(declared),
+                gate=resource,
+                resource=resource,
                 task_id=task_id,
                 worker_id=worker_id,
                 granted_ts=now,
@@ -248,37 +265,39 @@ class AdmissionEngine:
         """Return the current admission-ledger head hash."""
         return self.state().head_hash
 
-    def _evaluate(self, state: AdmissionState, pool_name: str, declared: tuple[str, ...]) -> tuple[bool, str | None]:
-        """Return ``(over_limit, refusal_reason)`` for a candidate grant.
+    def _evaluate(
+        self, state: AdmissionState, pool_name: str, declared: tuple[str, ...]
+    ) -> tuple[bool, str | None, tuple[str, ...]]:
+        """Return ``(over_limit, refusal_reason, over_gates)`` for a candidate.
 
         ``refusal_reason`` is ``None`` when the grant is admissible (possibly
-        over-limit under ADVISE).
+        over-limit under ADVISE); ``over_gates`` names the ADVISE gate(s) the
+        grant passes over-limit and is empty unless ``over_limit`` is ``True``.
+        The gate definitions are shared with the verifier so a decision and its
+        later re-verification read one predicate.
         """
-        over_limit = False
-        # Pool capacity gate.
-        if pool_name:
-            spec = state.pools.get(pool_name)
-            if spec is not None and spec.posture is not Posture.OFF and state.pool_occupancy(pool_name) >= spec.slots:
-                if spec.posture is Posture.ENFORCE:
-                    return False, f"pool {pool_name!r} at capacity ({spec.slots})"
-                over_limit = True
-        # Tag concurrency gate (AND-of-all declared tags).
-        if declared:
-            occupancy = state.tag_occupancy()
-            enforce_limits = {
-                tag: spec.limit for tag, spec in state.tag_limits.items() if spec.posture is Posture.ENFORCE
-            }
-            if not tags_admissible(declared, occupancy, enforce_limits):
-                return False, "declared tag(s) at capacity"
-            advise_limits = {
-                tag: spec.limit for tag, spec in state.tag_limits.items() if spec.posture is Posture.ADVISE
-            }
-            if not tags_admissible(declared, occupancy, advise_limits):
-                over_limit = True
-        return over_limit, None
+        refusal = enforce_gate_refusal(state, pool_name, declared)
+        if refusal is not None:
+            return False, refusal, ()
+        over_gates = advise_over_gates(state, pool_name, declared)
+        return bool(over_gates), None, over_gates
 
     def renew(self, grant_id: str, now: int) -> str:
-        """Renew a grant's lease (piggybacked on the heartbeat signal)."""
+        """Renew a grant's lease (piggybacked on the heartbeat signal).
+
+        Rejects a renewal for an unknown/released grant or one whose lease has
+        already expired at *now*: a late heartbeat must not revive a dead lease
+        (the projection ignores such a row too, so this is a fail-fast guard).
+        """
+        grant = self.state().active_grants.get(grant_id)
+        if grant is None:
+            msg = f"cannot renew unknown or released grant {grant_id[:16]}..."
+            raise ValueError(msg)
+        if grant.effective_expiry and now >= grant.effective_expiry:
+            msg = (
+                f"cannot renew grant {grant_id[:16]}...: lease already expired at {grant.effective_expiry} (now {now})"
+            )
+            raise ValueError(msg)
         return self._append(kind=KIND_RENEW, payload={"grant": grant_id, "ts": now})
 
     def release(self, grant_id: str, now: int) -> str:
@@ -330,24 +349,28 @@ class AdmissionEngine:
         references the expiry row via ``slot_freed_by``.
         """
         state = self.state()
-        outcomes: list[ExpiryOutcome] = []
-        for grant in state.expired_grants(now):
-            expire_hash = self._append(
-                kind=KIND_EXPIRE,
-                task_id=grant.task_id,
-                payload={"grant": grant.grant_id, "ts": now},
-            )
-            receipt = self._assemble_expiry_receipt(grant, state, prev_chain_digest=expire_hash)
-            retry_decision = self._resume_decision(grant)
-            outcomes.append(
-                ExpiryOutcome(
-                    grant=grant,
-                    expire_hash=expire_hash,
-                    receipt=receipt,
-                    retry_decision=retry_decision,
-                )
-            )
-        return outcomes
+        return [self._expire_grant(grant, state, now) for grant in state.expired_grants(now)]
+
+    def _expire_grant(self, grant: Grant, state: AdmissionState, now: int) -> ExpiryOutcome:
+        """Run one lease-expiry lifecycle: expire row, signed receipt, resume.
+
+        The single per-grant expiry path shared by the deterministic sweep and
+        by quarantine, so a quarantined worker goes through the identical
+        receipt/checkpoint-retry lifecycle instead of a silent slot recycle.
+        """
+        expire_hash = self._append(
+            kind=KIND_EXPIRE,
+            task_id=grant.task_id,
+            payload={"grant": grant.grant_id, "ts": now},
+        )
+        receipt = self._assemble_expiry_receipt(grant, state, prev_chain_digest=expire_hash)
+        retry_decision = self._resume_decision(grant)
+        return ExpiryOutcome(
+            grant=grant,
+            expire_hash=expire_hash,
+            receipt=receipt,
+            retry_decision=retry_decision,
+        )
 
     def _assemble_expiry_receipt(self, grant: Grant, state: AdmissionState, *, prev_chain_digest: str) -> Any:
         """Build a signed escalation receipt in the supervisor-receipt shape."""
@@ -445,8 +468,21 @@ class AdmissionEngine:
         affected.sort(key=lambda g: (g.granted_ts, g.grant_id))
         checkpointed: list[dict[str, str]] = []
         for grant in affected:
-            self._append(kind=KIND_EXPIRE, task_id=grant.task_id, payload={"grant": grant.grant_id, "ts": now})
-            checkpointed.append({"grant_id": grant.grant_id, "task_id": grant.task_id, "worker_id": grant.worker_id})
+            # Run the same expiry lifecycle as ``sweep_expired`` -- an expire
+            # row plus a signed escalation receipt -- and only record the worker
+            # as checkpointed once that lifecycle has been persisted, so the
+            # manifest's ``checkpointed`` label is backed by an actual receipt
+            # anchored in the chain rather than a bare relabel.
+            outcome = self._expire_grant(grant, state, now)
+            checkpointed.append(
+                {
+                    "expire_hash": outcome.expire_hash,
+                    "grant_id": grant.grant_id,
+                    "receipt_digest": outcome.receipt.payload_digest,
+                    "task_id": grant.task_id,
+                    "worker_id": grant.worker_id,
+                }
+            )
 
         manifest = {
             "checkpointed": checkpointed,
@@ -519,7 +555,15 @@ class AdmissionEngine:
 
 
 def _install_keypair() -> tuple[str, str]:
-    """Return the install agent-card keypair PEM, generating on first use."""
+    """Return the install agent-card keypair PEM, generating on first use.
+
+    Falls back to an ephemeral identity only when the keystore itself is
+    *unavailable* (its module or crypto dependency will not import). Every other
+    failure -- unsafe key permissions, a corrupt keystore, an I/O error -- is a
+    security signal: it propagates instead of silently substituting a fresh,
+    unpinnable keypair that would break every verifier pinned to the stable
+    install identity.
+    """
     try:
         from bernstein.core.security.agent_card_keystore import (
             DEFAULT_KEY_DIR,
@@ -527,11 +571,11 @@ def _install_keypair() -> tuple[str, str]:
         )
 
         private_pem, public_pem = AgentCardKeystore(DEFAULT_KEY_DIR).load_or_generate()
-        return private_pem.decode("ascii"), public_pem.decode("ascii")
-    except Exception:  # pragma: no cover - keystore unavailable
+    except ImportError:  # pragma: no cover - keystore dependency unavailable
         from bernstein.core.skills.catalog.signature import generate_signer_keypair
 
         return generate_signer_keypair()
+    return private_pem.decode("ascii"), public_pem.decode("ascii")
 
 
 def _keyid(public_key_pem: str) -> str:

--- a/src/bernstein/core/admission/projection.py
+++ b/src/bernstein/core/admission/projection.py
@@ -35,25 +35,29 @@ from bernstein.core.admission.ledger import (
 from bernstein.core.admission.models import (
     Grant,
     PoolSpec,
+    Posture,
     QueueSpec,
     RateLimitSpec,
     TagLimitSpec,
 )
 from bernstein.core.admission.rate_limit import effective_rate_limit
+from bernstein.core.admission.tags import tags_admissible
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from bernstein.core.persistence.work_ledger import LedgerEntry
 
-__all__ = ["AdmissionState", "GrantInterval"]
+__all__ = ["AdmissionState", "GrantInterval", "advise_over_gates", "enforce_gate_refusal"]
 
 
 @dataclass(frozen=True, slots=True)
 class GrantInterval:
     """A grant's holding interval, retained for offline slot forensics.
 
-    ``end_ts == 0`` means the grant is still held at the chain head.
+    An empty ``end_kind`` means the grant is still held at the chain head.
+    ``end_ts`` alone cannot signal openness: a release or expiry at logical
+    time ``0`` is a real close whose ``end_ts`` is legitimately ``0``.
     """
 
     grant_id: str
@@ -69,7 +73,9 @@ class GrantInterval:
         """Return ``True`` when the grant was held at logical time *at_ts*."""
         if at_ts < self.start_ts:
             return False
-        return self.end_ts == 0 or at_ts < self.end_ts
+        # Openness is keyed on ``end_kind`` (empty == open), not ``end_ts``:
+        # a close at logical time 0 has ``end_ts == 0`` yet is not open.
+        return self.end_kind == "" or at_ts < self.end_ts
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -190,14 +196,23 @@ class AdmissionState:
         """
         state = cls()
         for entry in entries:
-            state.head_hash = entry.entry_hash
-            state.entries += 1
-            handler = _HANDLERS.get(entry.kind)
-            if handler is None:
-                state.unknown_kinds += 1
-                continue
-            handler(state, entry)
+            state.apply(entry)
         return state
+
+    def apply(self, entry: LedgerEntry) -> None:
+        """Fold one ledger row into the state, in chain order.
+
+        The single fold step behind :meth:`from_rows`; exposed so a verifier
+        can interleave a soundness check between rows while projecting the
+        exact same state the engine would read.
+        """
+        self.head_hash = entry.entry_hash
+        self.entries += 1
+        handler = _HANDLERS.get(entry.kind)
+        if handler is None:
+            self.unknown_kinds += 1
+            return
+        handler(self, entry)
 
 
 # ---------------------------------------------------------------------------
@@ -266,7 +281,9 @@ def _close_interval(state: AdmissionState, grant_id: str, end_ts: int, end_kind:
     """Close the open holding interval for *grant_id*, if any."""
     for idx in range(len(state.grant_history) - 1, -1, -1):
         interval = state.grant_history[idx]
-        if interval.grant_id == grant_id and interval.end_ts == 0:
+        # Openness is keyed on ``end_kind`` (empty == open): a prior close at
+        # logical time 0 leaves ``end_ts == 0`` yet must not be reopened.
+        if interval.grant_id == grant_id and interval.end_kind == "":
             state.grant_history[idx] = dataclasses.replace(interval, end_ts=end_ts, end_kind=end_kind)
             return
 
@@ -282,8 +299,14 @@ def _handle_renew(state: AdmissionState, entry: LedgerEntry) -> None:
     grant_id = str(entry.payload.get("grant", ""))
     ts = int(entry.payload.get("ts", 0))
     grant = state.active_grants.get(grant_id)
-    if grant is not None:
-        state.active_grants[grant_id] = dataclasses.replace(grant, renewed_ts=ts)
+    if grant is None:
+        return
+    # A renew at or after the lease expiry cannot revive a dead lease. Enforced
+    # in the projection (not only the engine) so a forged or replayed late-renew
+    # row is ignored deterministically on every replay.
+    if grant.effective_expiry and ts >= grant.effective_expiry:
+        return
+    state.active_grants[grant_id] = dataclasses.replace(grant, renewed_ts=ts)
 
 
 def _handle_expire(state: AdmissionState, entry: LedgerEntry) -> None:
@@ -318,3 +341,52 @@ _HANDLERS = {
     KIND_WAIVE: _handle_waive,
     KIND_QUARANTINE: _handle_quarantine,
 }
+
+
+# ---------------------------------------------------------------------------
+# Admission predicate (shared by the engine's decision and the verifier's
+# soundness replay, so both read one gate definition, never two)
+# ---------------------------------------------------------------------------
+
+
+def enforce_gate_refusal(state: AdmissionState, pool_name: str, declared: tuple[str, ...]) -> str | None:
+    """Return the ENFORCE-gate refusal for a candidate grant, or ``None``.
+
+    Only ENFORCE gates refuse; ADVISE and OFF never do. The engine calls this
+    to decide admission; the verifier calls it against the state projected from
+    the rows *before* a chain grant to prove the projection would have issued
+    that grant. One predicate, two callers -- a forged grant that skips a full
+    ENFORCE pool or a maxed ENFORCE tag is caught because the verifier replays
+    the identical gate the engine applied.
+    """
+    if pool_name:
+        spec = state.pools.get(pool_name)
+        if spec is not None and spec.posture is Posture.ENFORCE and state.pool_occupancy(pool_name) >= spec.slots:
+            return f"pool {pool_name!r} at capacity ({spec.slots})"
+    if declared:
+        occupancy = state.tag_occupancy()
+        enforce_limits = {tag: spec.limit for tag, spec in state.tag_limits.items() if spec.posture is Posture.ENFORCE}
+        if not tags_admissible(declared, occupancy, enforce_limits):
+            return "declared tag(s) at capacity"
+    return None
+
+
+def advise_over_gates(state: AdmissionState, pool_name: str, declared: tuple[str, ...]) -> tuple[str, ...]:
+    """Return the ADVISE gates a candidate grant would pass over-limit.
+
+    Sorted, de-duplicated resource names (pool and/or tags) whose ADVISE limit
+    the grant exceeds. Empty when the grant is within every gate. This is the
+    exact set that justifies an ``over_limit`` grant and its waiver receipt, so
+    the engine names the right gate and the verifier can confirm an
+    ``over_limit`` flag is backed by a genuinely exceeded ADVISE gate.
+    """
+    over: list[str] = []
+    if pool_name:
+        spec = state.pools.get(pool_name)
+        if spec is not None and spec.posture is Posture.ADVISE and state.pool_occupancy(pool_name) >= spec.slots:
+            over.append(pool_name)
+    if declared:
+        occupancy = state.tag_occupancy()
+        advise_limits = {tag: spec.limit for tag, spec in state.tag_limits.items() if spec.posture is Posture.ADVISE}
+        over.extend(tag for tag in declared if tag in advise_limits and occupancy.get(tag, 0) >= advise_limits[tag])
+    return tuple(sorted(set(over)))

--- a/src/bernstein/core/admission/tags.py
+++ b/src/bernstein/core/admission/tags.py
@@ -19,6 +19,7 @@ nothing about the diff.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import PurePosixPath
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -51,9 +52,19 @@ class TagContract:
     forbidden_prefixes: tuple[str, ...] = ()
 
     def violations_for(self, changed_paths: Iterable[str]) -> tuple[str, ...]:
-        """Return the changed paths that break this contract."""
+        """Return the changed paths that break this contract.
+
+        A path that is absolute or contains any ``..`` component is always a
+        violation: prefix checks alone would let ``docs/../src/x`` sail past a
+        ``docs/`` allow-prefix and produce a false-conformant signed receipt.
+        Such a path is flagged before any prefix comparison.
+        """
         offenders: list[str] = []
         for path in changed_paths:
+            pure = PurePosixPath(path)
+            if pure.is_absolute() or ".." in pure.parts:
+                offenders.append(path)
+                continue
             norm = path.lstrip("./")
             if any(norm.startswith(bad) for bad in self.forbidden_prefixes):
                 offenders.append(path)

--- a/src/bernstein/core/admission/verify.py
+++ b/src/bernstein/core/admission/verify.py
@@ -8,10 +8,12 @@ Two independent checks compose:
    (:meth:`~bernstein.core.persistence.work_ledger.LedgerReader.verify`), which
    recomputes every entry hash and names the exact position of a mutated
    payload or a swapped pair (a reorder breaks the ``prev_hash`` linkage).
-2. **Admission soundness** -- replay the chain and, at each grant row under an
-   ENFORCE pool, assert a slot was actually free. A forged grant injected past
-   capacity is a grant the projection would not have issued, and is reported at
-   its exact position.
+2. **Admission soundness** -- project the chain and, at each grant row, replay
+   the same ENFORCE predicate the engine admitted it with (pool capacity *and*
+   tag limits), reading the state before the grant. A forged grant injected
+   past any ENFORCE gate -- or one that references an undeclared pool, or
+   carries an unbacked ``over_limit`` flag -- is a grant the projection would
+   not have issued, and is reported at its exact position.
 
 The verifier is offline: it needs only the ledger bytes. "Who held pool P at
 time T" is then answerable from the verified projection alone.
@@ -22,16 +24,15 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
-from bernstein.core.admission.ledger import (
-    KIND_EXPIRE,
-    KIND_GRANT,
-    KIND_POOL_CHANGED,
-    KIND_RELEASE,
+from bernstein.core.admission.ledger import KIND_GRANT
+from bernstein.core.admission.projection import (
+    AdmissionState,
+    advise_over_gates,
+    enforce_gate_refusal,
 )
-from bernstein.core.admission.models import PoolSpec, Posture
 
 if TYPE_CHECKING:
-    from bernstein.core.persistence.work_ledger import LedgerReader
+    from bernstein.core.persistence.work_ledger import LedgerEntry, LedgerReader
 
 __all__ = ["AdmissionVerification", "verify_admission_ledger"]
 
@@ -54,40 +55,19 @@ def verify_admission_ledger(reader: LedgerReader) -> AdmissionVerification:
     chain = reader.verify()
     errors: list[str] = list(chain.errors)
 
-    # Admission soundness: replay grant/release/expire under ENFORCE pools and
-    # flag any grant issued past capacity. One pass; the grant->pool map is
-    # built as grants are seen (a grant always precedes its release/expire).
-    pools: dict[str, PoolSpec] = {}
-    occupancy: dict[str, int] = {}
-    grant_pool: dict[str, str] = {}
+    # Admission soundness: project the chain row by row and, at each grant,
+    # replay the *same* ENFORCE predicate the engine used to admit it, reading
+    # the state projected from the rows before the grant. The projection tracks
+    # held grants by id, so a repeated terminal row is idempotent (it cannot
+    # under-count occupancy) and occupancy/limits reflect exactly what admission
+    # saw. Every ENFORCE gate is replayed -- pool capacity and tag limits --
+    # never only pool capacity, and the attacker-controlled over_limit flag can
+    # neither buy an exemption nor stand unbacked by an exceeded ADVISE gate.
+    state = AdmissionState()
     for index, entry in enumerate(reader.entries()):
-        kind = entry.kind
-        if kind == KIND_POOL_CHANGED:
-            spec = PoolSpec.from_dict(entry.payload)
-            pools[spec.name] = spec
-        elif kind == KIND_GRANT:
-            pool = str(entry.payload.get("pool", ""))
-            over_limit = bool(entry.payload.get("over_limit", False))
-            spec = pools.get(pool)
-            if (
-                pool
-                and spec is not None
-                and spec.posture is Posture.ENFORCE
-                and not over_limit
-                and occupancy.get(pool, 0) >= spec.slots
-            ):
-                errors.append(
-                    f"entry {index} (grant {entry.entry_hash[:16]}...): "
-                    f"pool {pool!r} was at capacity ({spec.slots}); "
-                    f"the projection would not have issued this grant"
-                )
-            if pool:
-                grant_pool[entry.entry_hash] = pool
-                occupancy[pool] = occupancy.get(pool, 0) + 1
-        elif kind in (KIND_RELEASE, KIND_EXPIRE):
-            pool = grant_pool.get(str(entry.payload.get("grant", "")), "")
-            if pool:
-                occupancy[pool] = max(0, occupancy.get(pool, 0) - 1)
+        if entry.kind == KIND_GRANT:
+            _check_grant_admissible(state, entry, index, errors)
+        state.apply(entry)
 
     return AdmissionVerification(
         ok=not errors,
@@ -95,3 +75,32 @@ def verify_admission_ledger(reader: LedgerReader) -> AdmissionVerification:
         entries=chain.entries,
         errors=tuple(errors),
     )
+
+
+def _check_grant_admissible(state: AdmissionState, entry: LedgerEntry, index: int, errors: list[str]) -> None:
+    """Append an error for a grant the projection would not have issued."""
+    payload = entry.payload
+    pool = str(payload.get("pool", ""))
+    declared = tuple(sorted({str(t) for t in payload.get("tags", []) if isinstance(t, str)}))
+    over_limit = bool(payload.get("over_limit", False))
+    prefix = f"entry {index} (grant {entry.entry_hash[:16]}...):"
+
+    # A grant can only hold a slot in a declared pool. An undeclared pool means
+    # the projection never sized the class, so it would not have issued this.
+    if pool and pool not in state.pools:
+        errors.append(f"{prefix} references undeclared pool {pool!r}; the projection would not have issued this grant")
+        return
+
+    refusal = enforce_gate_refusal(state, pool, declared)
+    if refusal is not None:
+        errors.append(f"{prefix} {refusal}; the projection would not have issued this grant")
+        return
+
+    # over_limit is only legitimate when an ADVISE gate is genuinely exceeded.
+    # A grant that carries the flag without any over-limit ADVISE gate is a
+    # forged waiver flag (the classic attempt to slip past an ENFORCE gate).
+    if over_limit and not advise_over_gates(state, pool, declared):
+        errors.append(
+            f"{prefix} carries over_limit=True but no ADVISE gate was over limit; "
+            f"the projection would not have set this flag"
+        )

--- a/tests/unit/test_admission.py
+++ b/tests/unit/test_admission.py
@@ -120,7 +120,11 @@ def test_randomized_interleavings_project_identically(tmp_path_factory: pytest.T
         elif op == "release" and state.active_grants:
             eng.release(sorted(state.active_grants)[arg % len(state.active_grants)], now=clock)
         elif op == "renew" and state.active_grants:
-            eng.renew(sorted(state.active_grants)[arg % len(state.active_grants)], now=clock)
+            gid = sorted(state.active_grants)[arg % len(state.active_grants)]
+            # A late heartbeat can no longer revive an expired lease; only renew
+            # a still-live grant (the engine rejects the rest).
+            if not state.active_grants[gid].is_expired(clock):
+                eng.renew(gid, now=clock)
         elif op == "sweep":
             eng.sweep_expired(now=clock + 10)
 
@@ -239,10 +243,10 @@ def test_lease_expiry_emits_signed_receipt_resume_and_references_expiry(tmp_path
 def test_a_renewed_lease_does_not_expire(tmp_path: Path) -> None:
     eng = _engine(tmp_path)
     eng.set_pool("p", 1)
-    grant = eng.request_grant(pool="p", task_id="T1", worker_id="w1", now=100, ttl_s=50)
-    eng.renew(grant.grant_id, now=180)  # heartbeat renewal
-    assert eng.sweep_expired(now=200) == []  # 180 + 50 = 230 > 200
-    assert eng.sweep_expired(now=240) != []  # now past the renewed expiry
+    grant = eng.request_grant(pool="p", task_id="T1", worker_id="w1", now=100, ttl_s=50)  # expiry 150
+    eng.renew(grant.grant_id, now=140)  # heartbeat renewal before expiry -> new expiry 190
+    assert eng.sweep_expired(now=180) == []  # 140 + 50 = 190 > 180
+    assert eng.sweep_expired(now=200) != []  # now past the renewed expiry
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_admission_hardening.py
+++ b/tests/unit/test_admission_hardening.py
@@ -1,0 +1,382 @@
+"""Admission engine / ledger / tags / verifier hardening (#2650).
+
+One regression test per acceptance criterion. These lock in the security and
+integrity fixes over the pool/lease-based admission subsystem: the verifier
+must replay the full ENFORCE predicate (not just pool capacity), the install
+identity must not silently fail open, path/tag inputs must reject traversal,
+and lease/renew/waiver semantics must be exact.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.admission import (
+    AdmissionEngine,
+    AdmissionState,
+    Posture,
+    verify_admission_ledger,
+)
+from bernstein.core.admission.ledger import (
+    KIND_GRANT,
+    KIND_RELEASE,
+    open_admission_ledger,
+    open_admission_reader,
+)
+
+
+def _fixed_keypair() -> tuple[str, str]:
+    from bernstein.core.skills.catalog.signature import generate_signer_keypair
+
+    return generate_signer_keypair()
+
+
+def _engine(tmp_path: Path, **kw) -> AdmissionEngine:
+    sdd = tmp_path / ".sdd"
+    sdd.mkdir(parents=True, exist_ok=True)
+    priv, pub = _fixed_keypair()
+    return AdmissionEngine(sdd_dir=sdd, private_key_pem=priv, public_key_pem=pub, **kw)
+
+
+def _forge_grant(
+    eng: AdmissionEngine,
+    *,
+    task_id: str,
+    pool: str,
+    worker_id: str,
+    ts: int,
+    tags: tuple[str, ...] = (),
+    over_limit: bool = False,
+) -> str:
+    """Append a raw, hash-valid grant row the engine would never have issued."""
+    ledger = open_admission_ledger(eng.sdd_dir)
+    entry = ledger.append(
+        kind=KIND_GRANT,
+        task_id=task_id,
+        payload={
+            "over_limit": over_limit,
+            "pool": pool,
+            "slot_freed_by": "",
+            "tags": list(tags),
+            "task_id": task_id,
+            "ttl_s": 0,
+            "ts": ts,
+            "worker_id": worker_id,
+        },
+    )
+    ledger.close()
+    return entry.entry_hash
+
+
+# ---------------------------------------------------------------------------
+# Item 1: install-identity keystore failure must not fail open
+# ---------------------------------------------------------------------------
+
+
+def test_install_keypair_propagates_keystore_permission_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    from bernstein.core.admission import engine as engine_mod
+    from bernstein.core.security import agent_card_keystore as ks
+
+    def unsafe_perms(_self: object) -> tuple[bytes, bytes]:
+        raise PermissionError("agent-card private key has unsafe permissions")
+
+    monkeypatch.setattr(ks.AgentCardKeystore, "load_or_generate", unsafe_perms)
+    # A real keystore failure is a security signal: it must propagate, not be
+    # papered over with an unpinnable ephemeral identity.
+    with pytest.raises(PermissionError):
+        engine_mod._install_keypair()
+
+
+def test_install_keypair_falls_back_only_when_keystore_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    from bernstein.core.admission import engine as engine_mod
+    from bernstein.core.security import agent_card_keystore as ks
+
+    def unavailable(_self: object) -> tuple[bytes, bytes]:
+        raise ImportError("keystore dependency not installed")
+
+    monkeypatch.setattr(ks.AgentCardKeystore, "load_or_generate", unavailable)
+    priv, pub = engine_mod._install_keypair()
+    assert "PRIVATE KEY" in priv
+    assert "PUBLIC KEY" in pub
+
+
+# ---------------------------------------------------------------------------
+# Item 2: a partial keypair must be rejected (never mixed with a generated one)
+# ---------------------------------------------------------------------------
+
+
+def test_partial_keypair_is_rejected(tmp_path: Path) -> None:
+    sdd = tmp_path / ".sdd"
+    sdd.mkdir(parents=True, exist_ok=True)
+    priv, pub = _fixed_keypair()
+    with pytest.raises(ValueError, match="both|partial|neither"):
+        AdmissionEngine(sdd_dir=sdd, private_key_pem=priv, public_key_pem="")
+    with pytest.raises(ValueError, match="both|partial|neither"):
+        AdmissionEngine(sdd_dir=sdd, private_key_pem="", public_key_pem=pub)
+
+
+def test_absent_keypair_generates_a_matched_pair(tmp_path: Path) -> None:
+    sdd = tmp_path / ".sdd"
+    sdd.mkdir(parents=True, exist_ok=True)
+    eng = AdmissionEngine(sdd_dir=sdd)
+    assert eng.private_key_pem and eng.public_key_pem
+    # The generated pair must actually match: a signed receipt verifies.
+    from bernstein.core.admission.receipts import verify_receipt
+
+    seal = eng.seal_tag_conformance(
+        task_id="T1", worker_id="w1", declared_tags=("docs-only",), changed_paths=("docs/x.md",)
+    )
+    ok, reason = verify_receipt(seal, public_key_pem=eng.public_key_pem)
+    assert ok, reason
+
+
+# ---------------------------------------------------------------------------
+# Item 3: verifier soundness is not bypassable
+# ---------------------------------------------------------------------------
+
+
+def test_forged_over_limit_flag_cannot_bypass_full_enforce_pool(tmp_path: Path) -> None:
+    eng = _engine(tmp_path)
+    eng.set_pool("p", 1)
+    eng.request_grant(pool="p", task_id="a", worker_id="w1", now=1)  # pool now full
+    _forge_grant(eng, task_id="b", pool="p", worker_id="w2", ts=2, over_limit=True)
+    result = verify_admission_ledger(open_admission_reader(eng.sdd_dir))
+    assert result.ok is False
+    assert any("capacity" in e for e in result.errors)
+
+
+def test_grant_on_undeclared_pool_fails_verification(tmp_path: Path) -> None:
+    eng = _engine(tmp_path)
+    eng.set_pool("p", 1)
+    _forge_grant(eng, task_id="x", pool="ghost", worker_id="w", ts=1)
+    result = verify_admission_ledger(open_admission_reader(eng.sdd_dir))
+    assert result.ok is False
+    assert any("ghost" in e for e in result.errors)
+
+
+def test_repeated_terminal_row_cannot_undercount_occupancy(tmp_path: Path) -> None:
+    eng = _engine(tmp_path)
+    eng.set_pool("p", 1)
+    a = eng.request_grant(pool="p", task_id="a", worker_id="w1", now=1).grant_id
+    eng.release(a, now=2)
+    eng.request_grant(pool="p", task_id="b", worker_id="w2", now=3)  # legit: reuses the freed slot
+    # Forge a duplicate release of the already-released grant, then a grant that
+    # would only pass if the extra release wrongly freed a second slot.
+    ledger = open_admission_ledger(eng.sdd_dir)
+    ledger.append(kind=KIND_RELEASE, payload={"grant": a, "ts": 4})
+    ledger.close()
+    _forge_grant(eng, task_id="c", pool="p", worker_id="w3", ts=5)
+    result = verify_admission_ledger(open_admission_reader(eng.sdd_dir))
+    assert result.ok is False
+    assert any("capacity" in e for e in result.errors)
+
+
+def test_enforce_pool_with_advise_tag_over_limit_still_verifies(tmp_path: Path) -> None:
+    # Regression guard: a legitimate over_limit grant (ENFORCE pool under
+    # capacity, ADVISE tag over its limit) must NOT be flagged as forged.
+    eng = _engine(tmp_path)
+    eng.set_pool("p", 5)
+    eng.set_tag_limit("t", 1, posture=Posture.ADVISE)
+    eng.request_grant(pool="p", task_id="a", worker_id="w1", now=1, tags=("t",))
+    dec = eng.request_grant(pool="p", task_id="b", worker_id="w2", now=2, tags=("t",))
+    assert dec.over_limit is True
+    result = eng.verify()
+    assert result.ok is True, result.errors
+
+
+# ---------------------------------------------------------------------------
+# Item 4: verifier replays the ENFORCE tag gate, not only pool capacity
+# ---------------------------------------------------------------------------
+
+
+def test_verifier_replays_enforce_tag_gate(tmp_path: Path) -> None:
+    eng = _engine(tmp_path)
+    eng.set_tag_limit("lock", 1)  # ENFORCE, limit 1
+    eng.request_grant(pool="", task_id="a", worker_id="w1", now=1, tags=("lock",))
+    _forge_grant(eng, task_id="b", pool="", worker_id="w2", ts=2, tags=("lock",))
+    result = verify_admission_ledger(open_admission_reader(eng.sdd_dir))
+    assert result.ok is False
+    assert any("tag" in e for e in result.errors)
+
+
+# ---------------------------------------------------------------------------
+# Item 5: `limits queue pause` on unknown / mis-cased name
+# ---------------------------------------------------------------------------
+
+
+def test_queue_pause_unknown_name_fails_and_creates_no_queue(tmp_path: Path) -> None:
+    from click.testing import CliRunner
+
+    from bernstein.cli.commands.limits_cmd import limits_group
+
+    runner = CliRunner()
+    result = runner.invoke(limits_group, ["queue", "pause", "ghost", "--workdir", str(tmp_path)])
+    assert result.exit_code == 1
+    # No phantom queue was appended to the ledger.
+    eng = AdmissionEngine.for_workdir(tmp_path.resolve())
+    assert "ghost" not in eng.state().queues
+
+
+def test_queue_pause_mis_cased_name_preserves_priority(tmp_path: Path) -> None:
+    from click.testing import CliRunner
+
+    from bernstein.cli.commands.limits_cmd import limits_group
+
+    runner = CliRunner()
+    created = runner.invoke(limits_group, ["queue", "create", "build", "--priority", "5", "--workdir", str(tmp_path)])
+    assert created.exit_code == 0
+    paused = runner.invoke(limits_group, ["queue", "pause", "BUILD", "--workdir", str(tmp_path)])
+    assert paused.exit_code == 0
+    spec = AdmissionEngine.for_workdir(tmp_path.resolve()).state().queues["build"]
+    assert spec.paused is True
+    assert spec.priority == 5  # priority preserved, not reset to 0
+
+
+# ---------------------------------------------------------------------------
+# Item 6: tag-conformance path check rejects `..` traversal and absolute paths
+# ---------------------------------------------------------------------------
+
+
+def test_docs_only_dotdot_escape_is_a_violation() -> None:
+    from bernstein.core.admission.tags import check_conformance
+
+    assert check_conformance(("docs-only",), ("docs/../src/evil.py",))
+    assert check_conformance(("docs-only",), ("/etc/passwd",))
+    # A clean docs path is still conformant.
+    assert check_conformance(("docs-only",), ("docs/guide.md",)) == ()
+
+
+def test_no_src_dotdot_escape_is_a_violation() -> None:
+    from bernstein.core.admission.tags import check_conformance
+
+    # A path that dodges the ``src/`` prefix via traversal must still be flagged.
+    assert check_conformance(("no-src",), ("build/../src/secret.py",))
+
+
+# ---------------------------------------------------------------------------
+# Item 7: ledger_id path traversal is rejected (already hardened via containment)
+# ---------------------------------------------------------------------------
+
+
+def test_ledger_id_traversal_is_rejected(tmp_path: Path) -> None:
+    from bernstein.core.admission.ledger import admission_ledger_dir
+    from bernstein.core.security.path_containment import PathContainmentError
+
+    for evil in ("../evil", "..", "a/b", "/abs"):
+        with pytest.raises((PathContainmentError, ValueError)):
+            admission_ledger_dir(tmp_path, evil)
+
+
+# ---------------------------------------------------------------------------
+# Item 8: quarantine runs the full expiry receipt lifecycle per grant
+# ---------------------------------------------------------------------------
+
+
+def test_quarantine_runs_full_expiry_lifecycle_per_grant(tmp_path: Path) -> None:
+    eng = _engine(tmp_path)
+    eng.set_tag_limit("lock", 3)
+    eng.request_grant(pool="", task_id="a", worker_id="w1", now=1, tags=("lock",))
+    eng.request_grant(pool="", task_id="b", worker_id="w2", now=2, tags=("lock",))
+    result = eng.quarantine(target_kind="tag", target="lock", now=10, queued_tasks=("c",))
+
+    for entry in result.manifest["checkpointed"]:
+        assert entry["expire_hash"]  # a real expire row was appended
+        assert entry["receipt_digest"]  # a signed escalation receipt was assembled
+    # The grants are actually released, not merely relabelled.
+    assert eng.state().tag_occupancy().get("lock", 0) == 0
+    # Determinism preserved: replay reproduces the identical manifest.
+    replayed = AdmissionState.from_rows(open_admission_reader(eng.sdd_dir).entries()).quarantines[0]
+    assert replayed["checkpointed"] == result.manifest["checkpointed"]
+
+
+# ---------------------------------------------------------------------------
+# Item 9: waiver receipt names the exact violated gate
+# ---------------------------------------------------------------------------
+
+
+def test_waiver_names_the_tag_gate_not_the_pool(tmp_path: Path) -> None:
+    eng = _engine(tmp_path)
+    eng.set_pool("p", 5)  # ENFORCE, roomy -> the pool is not the exceeded gate
+    eng.set_tag_limit("lock", 1, posture=Posture.ADVISE)
+    eng.request_grant(pool="p", task_id="a", worker_id="w1", now=1, tags=("lock",))
+    dec = eng.request_grant(pool="p", task_id="b", worker_id="w2", now=2, tags=("lock",))
+    assert dec.over_limit is True
+    assert dec.waiver is not None
+    assert dec.waiver.gate == "lock"
+    assert dec.waiver.resource == "lock"
+
+
+def test_waiver_names_the_pool_gate_for_pool_over_limit(tmp_path: Path) -> None:
+    eng = _engine(tmp_path)
+    eng.set_pool("soft", 1, posture=Posture.ADVISE)
+    eng.request_grant(pool="soft", task_id="a", worker_id="w1", now=1)
+    dec = eng.request_grant(pool="soft", task_id="b", worker_id="w2", now=2)
+    assert dec.over_limit is True
+    assert dec.waiver is not None
+    assert dec.waiver.gate == "soft"
+    assert dec.waiver.resource == "soft"
+
+
+# ---------------------------------------------------------------------------
+# Item 10: declared tags are de-duplicated (one grant = at most one unit)
+# ---------------------------------------------------------------------------
+
+
+def test_declared_tags_are_deduplicated(tmp_path: Path) -> None:
+    eng = _engine(tmp_path)
+    eng.set_tag_limit("lock", 2)  # ENFORCE, limit 2
+    eng.request_grant(pool="", task_id="a", worker_id="w1", now=1, tags=("lock", "lock"))
+    assert eng.state().tag_occupancy().get("lock") == 1
+    # A second grant is still admissible (the duplicate did not eat two units).
+    dec = eng.request_grant(pool="", task_id="b", worker_id="w2", now=2, tags=("lock",))
+    assert dec.admitted is True
+
+
+# ---------------------------------------------------------------------------
+# Item 11: a late heartbeat cannot revive an already-expired lease
+# ---------------------------------------------------------------------------
+
+
+def test_late_renew_is_rejected(tmp_path: Path) -> None:
+    eng = _engine(tmp_path)
+    eng.set_pool("p", 1)
+    g = eng.request_grant(pool="p", task_id="T1", worker_id="w1", now=100, ttl_s=50)  # expiry 150
+    with pytest.raises(ValueError):
+        eng.renew(g.grant_id, now=200)  # 200 >= 150
+    # The lease is still expired; a sweep still expires it.
+    assert eng.sweep_expired(now=201) != []
+
+
+def test_forged_late_renew_row_does_not_revive_in_projection(tmp_path: Path) -> None:
+    from bernstein.core.admission.ledger import KIND_RENEW
+
+    eng = _engine(tmp_path)
+    eng.set_pool("p", 1)
+    g = eng.request_grant(pool="p", task_id="T1", worker_id="w1", now=100, ttl_s=50).grant_id  # expiry 150
+    # Forge a renew row past the lease expiry directly into the chain.
+    ledger = open_admission_ledger(eng.sdd_dir)
+    ledger.append(kind=KIND_RENEW, payload={"grant": g, "ts": 200})
+    ledger.close()
+    # The projection must ignore the late renew: the lease stays expired at 150.
+    state = eng.state()
+    assert state.expired_grants(160) != []
+
+
+# ---------------------------------------------------------------------------
+# Item 12: an open interval is detected by end_kind, not end_ts == 0
+# ---------------------------------------------------------------------------
+
+
+def test_release_at_logical_time_zero_closes_the_interval(tmp_path: Path) -> None:
+    eng = _engine(tmp_path)
+    eng.set_pool("p", 1)
+    g = eng.request_grant(pool="p", task_id="a", worker_id="w1", now=0, ttl_s=0).grant_id
+    eng.release(g, now=0)  # released at logical time 0
+    state = AdmissionState.from_rows(open_admission_reader(eng.sdd_dir).entries())
+    # The interval is closed: nobody holds the pool at (or after) time 0.
+    assert state.who_held("p", 0) == []
+    interval = state.grant_history[0]
+    assert interval.end_kind == "release"
+    assert interval.covers(0) is False


### PR DESCRIPTION
## What
Bounded hardening sweep of the pool/lease-based admission subsystem. 11 of 12 checklist items were genuine gaps and are fixed with a regression test each; item 7 (ledger_id path traversal) was already shipped via contained_path and got a lock-in test. Core lever: the engine and verifier now share one ENFORCE admission predicate (projection.enforce_gate_refusal / advise_over_gates), so verification replays the exact gate the engine admitted with. All work is on fix/m8w2-harden-admission (pushed, no PR). No pyproject/uv.lock/workflow files touched.

Fixes #2650

## Checklist outcome
11 fixed / 1 already shipped on main (verified, no change) / 0 recorded out-of-scope.

- **engine.py:531 install-identity keystore failure fails open to ephemeral keypair** — fixed: _install_keypair now catches only ImportError (keystore/crypto dependency unavailable); PermissionError (unsafe key perms) and every other operational failure p
- **engine.py:103 partial keypair produces a mismatched signing/verification pair** — fixed: __post_init__ raises ValueError when bool(priv) != bool(pub); generates only when both absent, assigning both from the generated pair. Tests: test_partial_keypa
- **verify.py:72 admission verifier soundness check is bypassable (over_limit flag, unknown pool, repeated termina** — fixed: Verifier projects the chain row-by-row and checks each grant against enforce_gate_refusal using state before the grant. Held grants tracked by id via AdmissionS
- **verify.py:63 verifier replays only pool capacity, never ENFORCE tag/rate/queue gates** — fixed: Extracted the projection admission predicate (enforce_gate_refusal in projection.py) shared by engine._evaluate and the verifier, so pool capacity AND ENFORCE t
- **limits_cmd.py:201 queue pause on unknown/mis-cased name creates a phantom queue and resets priority** — fixed: queue_pause_cmd canonicalizes the name, looks up state.queues.get(canonical_name(name)), and exits EXIT_ERROR when None instead of defaulting priority to 0 and 
- **tags.py:57 tag-conformance path check ignores '..' traversal** — fixed: violations_for parses each path with PurePosixPath and flags absolute paths or any '..' component as a violation before prefix checks, closing the docs/../src/x
- **ledger.py:91 ledger_id path traversal in admission ledger path composition** — already-hardened: admission_ledger_dir already routes ledger_id through contained_path (allowlist SAFE_SEGMENT_RE + realpath containment), which is strictly stronger than the sug
- **engine.py:447 quarantine labels workers checkpointed without creating any checkpoint** — fixed: Extracted _expire_grant (expire row + signed escalation receipt + resume decision) shared by sweep_expired and quarantine; quarantine runs it per affected grant
- **engine.py:238 over-limit waiver receipt misidentifies which gate was exceeded** — fixed: _evaluate now returns the specific over-limit ADVISE gate(s) (advise_over_gates); the waiver's gate/resource name those exact resources, so a pool-under-capacit
- **engine.py:209 declared tags are not de-duplicated** — fixed: declared = tuple(sorted({canonical_name(t) for t in tags})) so each tag contributes at most one unit of its concurrency limit. Test: test_declared_tags_are_dedu
- **engine.py:280 late heartbeat revives an already-expired lease** — fixed: renew raises ValueError when the grant is unknown/released or now >= grant.effective_expiry; the projection's _handle_renew independently ignores a renew at/aft
- **projection.py:72 open grant interval detected by end_ts == 0 misclassifies a release at logical time 0** — fixed: GrantInterval.covers and _close_interval now key openness on end_kind (empty == open) rather than end_ts == 0, so a release/expire at logical time 0 correctly c

## Verification
Adversarial review round: **confirmed, 0 critical findings** (red-on-main proven for the substantive items).
RED baseline captured before fixes: 16 failed / 5 passed on the new hardening file (the 5 that passed = item 7 already-hardened lock-in test + the two false-positive guard tests + the two already-shipped behaviours). GREEN after fixes: test_admission_hardening.py 21 passed; test_admission.py 16 passed (37 total). uv run ruff check (touched files) All checks passed; uv run ruff format applied. mypy: no new errors in the admission package or in the queue_pause change (the two limits_cmd.py:258-259 errors are pre-existing in limits_status_cmd, outside the diff). Import sentinel OK (engine/project
