### PR TITLE
fix(mcp): harden stateless/gateway/client audit ordering

### DIFF
--- a/src/bernstein/core/protocols/mcp/mcp_client.py
+++ b/src/bernstein/core/protocols/mcp/mcp_client.py
@@ -251,6 +251,14 @@ class StreamedToolCall:
         return self._cancel_event.is_set()
 
 
+#: Methods a stateless server anchors into the audit chain. The client
+#: advances its anchor-specific call index only for these so the baggage
+#: ``mcp.call_index`` claim matches the server's journal allocation: a
+#: non-anchored request (``initialize``, ``tools/list``, notifications) must
+#: not consume an audit ordinal, or the chained call_index sequence would gap.
+_ANCHOR_ELIGIBLE_METHODS = frozenset({"tools/call"})
+
+
 class MCPClientSession:
     """Active client connection to a remote MCP server.
 
@@ -293,7 +301,13 @@ class MCPClientSession:
         # index, so no wire value depends on process-local randomness.
         self._run_root_hash = run_root_hash or self._derive_default_run_root(config)
         self._client_capabilities: dict[str, Any] = dict(client_capabilities or {})
+        # Per-message counter seeding the span id (every message gets a
+        # distinct span). Separate from the anchor-specific index below.
         self._call_index: int = 0
+        # Ordered position among audit-anchored calls, carried in baggage as
+        # ``mcp.call_index``. Advances only for anchor-eligible methods so the
+        # claim stays contiguous with the server's journal allocation (AC5).
+        self._anchor_call_index: int = 0
         # Hardening state (issue #1673).
         self._manifest_digest: str = ""
         self._degraded: bool = False
@@ -562,14 +576,32 @@ class MCPClientSession:
 
         An ``input_required`` result is not an error: the server's
         ``requestState`` echo and prompt surface on the metadata so the
-        caller can resume the call (issue #2506).
+        caller can resume the call (issue #2506). The echo must itself be a
+        present, decodable ``requestState`` -- a resume built on a missing or
+        corrupt state can never complete, so it is treated as a schema
+        violation rather than surfaced as a resumable prompt.
 
         Raises:
             MCPSchemaViolation: When the ``content`` block is structurally
-                malformed. The server is marked degraded before the error
-                propagates.
+                malformed, or an ``input_required`` result omits a decodable
+                ``requestState``. The server is marked degraded before the
+                error propagates.
         """
         if result.get("type") == "input_required":
+            raw_state = result.get("requestState")
+            if not isinstance(raw_state, str) or not raw_state:
+                self.mark_degraded(f"tools/call for '{tool_name}' returned input_required without a requestState")
+                raise MCPSchemaViolation(
+                    f"Server '{self._config.name}' returned an input_required result without a requestState "
+                    f"for tool '{tool_name}'"
+                )
+            try:
+                decode_request_state(raw_state)
+            except ValueError as exc:
+                self.mark_degraded(f"tools/call for '{tool_name}' returned an undecodable requestState")
+                raise MCPSchemaViolation(
+                    f"Server '{self._config.name}' returned an undecodable requestState for tool '{tool_name}'"
+                ) from exc
             prompt = str(result.get("prompt", ""))
             return ToolCallResult(
                 content=prompt,
@@ -579,7 +611,7 @@ class MCPClientSession:
                     "tool": tool_name,
                     "input_required": True,
                     "prompt": prompt,
-                    "request_state": str(result.get("requestState", "")),
+                    "request_state": raw_state,
                 },
             )
         content_parts = result.get("content", [])
@@ -772,11 +804,15 @@ class MCPClientSession:
         logger.info("Closed MCP session with server '%s'", self._config.name)
 
     def _next_request_meta(self, method: str, params: dict[str, Any] | None) -> dict[str, Any]:
-        """Build the per-request ``_meta`` and advance the ordered call index.
+        """Build the per-request ``_meta`` and advance the ordered indices.
 
-        The span id is derived from the call's content hash and its ordered
-        index, the trace id from the run root, so two replays of the same
-        call sequence emit byte-identical ``_meta`` (issue #2506).
+        The span id is derived from the call's content hash and its per-message
+        index, the trace id from the run root, so two replays of the same call
+        sequence emit byte-identical ``_meta`` (issue #2506). The baggage
+        ``mcp.call_index`` carries a separate anchor-specific index that
+        advances only for anchor-eligible methods, so the claim it presents to
+        a server matches that server's journal allocation and the anchored
+        call_index sequence stays contiguous (AC5).
         """
         canonical = json.dumps(
             {"method": method, "params": params or {}},
@@ -791,8 +827,11 @@ class MCPClientSession:
             run_root_hash=self._run_root_hash,
             call_index=self._call_index,
             client_capabilities=self._client_capabilities,
+            anchor_index=self._anchor_call_index,
         )
         self._call_index += 1
+        if method in _ANCHOR_ELIGIBLE_METHODS:
+            self._anchor_call_index += 1
         return meta
 
     async def _send_jsonrpc(self, method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:

--- a/src/bernstein/core/protocols/mcp/mcp_gateway.py
+++ b/src/bernstein/core/protocols/mcp/mcp_gateway.py
@@ -24,14 +24,16 @@ WAL output:  {result, error, latency_ms}
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import json
+import logging
 import sys
 import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from bernstein.core.protocols.mcp.stateless_core import anchor_stateless_call, request_span_id
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -340,13 +342,18 @@ class MCPGateway:
         """
         if self._journal is None:
             return
-        with contextlib.suppress(Exception):
+        try:
             anchor_stateless_call(
                 journal=self._journal,
                 method=method,
                 params=params,
                 chain=self._audit_chain,
             )
+        except Exception:
+            # Anchoring stays non-fatal -- a missing anchor is visible to a
+            # verifier as a call-index gap -- but the failure is surfaced in
+            # the log rather than silently swallowed (AC4).
+            logger.exception("Failed to anchor proxied mcp.stateless_call for %s", method)
 
     # ------------------------------------------------------------------
     # Transport runners

--- a/src/bernstein/core/protocols/mcp/stateless_core.py
+++ b/src/bernstein/core/protocols/mcp/stateless_core.py
@@ -182,6 +182,7 @@ def build_request_meta(
     run_root_hash: str,
     call_index: int,
     client_capabilities: Mapping[str, Any],
+    anchor_index: int | None = None,
 ) -> dict[str, Any]:
     """Build the per-request ``_meta`` for a stateless MCP call.
 
@@ -198,9 +199,15 @@ def build_request_meta(
             span-id seed.
         run_root_hash: The run's root hash (the journal genesis / first
             entry hash); the trace-id seed shared across the run.
-        call_index: 0-based ordered index of this call within the run.
+        call_index: 0-based ordered index of this message within the run;
+            seeds the span id so every message gets a distinct span.
         client_capabilities: The client capability map to advertise per
             request in place of the removed handshake.
+        anchor_index: 0-based position of this call within the audit-anchored
+            sequence, carried in baggage as ``mcp.call_index`` so a server can
+            verify its own journal allocation against the claim. Defaults to
+            ``call_index`` for callers that do not distinguish anchored calls
+            from other messages.
 
     Returns:
         A ``_meta`` dict with ``client.capabilities``, ``traceparent``,
@@ -208,7 +215,8 @@ def build_request_meta(
     """
     trace_id = derive_trace_id(run_root_hash=run_root_hash)
     span_id = derive_span_id(params_content_hash=params_content_hash, call_index=call_index)
-    baggage = f"mcp.method={method},mcp.call_index={call_index}"
+    baggage_index = call_index if anchor_index is None else anchor_index
+    baggage = f"mcp.method={method},mcp.call_index={baggage_index}"
     return {
         "client": {"capabilities": dict(client_capabilities)},
         "traceparent": format_traceparent(trace_id=trace_id, span_id=span_id),
@@ -538,16 +546,38 @@ def _meta_of(params: Mapping[str, Any]) -> Mapping[str, Any]:
     return meta if isinstance(meta, Mapping) else {}
 
 
-def _ids_from_traceparent(meta: Mapping[str, Any]) -> tuple[str, str]:
-    """Return ``(trace_id, span_id)`` parsed from ``_meta.traceparent``.
+_TRACE_HEX = frozenset("0123456789abcdef")
 
-    Returns empty strings when the header is absent or malformed, so the
-    caller can fall back to server-side content derivation.
+
+def _is_trace_hex(value: str, length: int) -> bool:
+    """Return whether ``value`` is exactly ``length`` lowercase hex chars."""
+    return len(value) == length and all(char in _TRACE_HEX for char in value)
+
+
+def _ids_from_traceparent(meta: Mapping[str, Any]) -> tuple[str, str]:
+    """Return ``(trace_id, span_id)`` parsed from a *validated* ``traceparent``.
+
+    ``_meta.traceparent`` is untrusted client input that is later persisted as
+    audit identity, so it is validated against the W3C Trace Context shape
+    before it is returned: four dash-separated fields, a 2-hex-char version
+    that is not the reserved ``ff``, a 32-hex-char trace id, a 16-hex-char span
+    id (both lowercase hex, neither all-zero), and 2-hex-char flags. Any
+    deviation returns empty strings so the caller falls back to server-side
+    content derivation instead of anchoring an attacker-chosen identity.
     """
     parts = str(meta.get("traceparent", "")).split("-")
-    if len(parts) == 4 and parts[1] and parts[2]:
-        return parts[1], parts[2]
-    return "", ""
+    if len(parts) != 4:
+        return "", ""
+    version, trace_id, span_id, flags = parts
+    if not _is_trace_hex(version, 2) or version == "ff":
+        return "", ""
+    if not _is_trace_hex(trace_id, 32) or trace_id == "0" * 32:
+        return "", ""
+    if not _is_trace_hex(span_id, 16) or span_id == "0" * 16:
+        return "", ""
+    if not _is_trace_hex(flags, 2):
+        return "", ""
+    return trace_id, span_id
 
 
 def _call_index_from_baggage(meta: Mapping[str, Any]) -> int | None:
@@ -601,10 +631,13 @@ def anchor_stateless_call(
     content-derived ids to the journal head. A verifier reconstructs the full
     call ordering of a run from chain entries alone (issue #2506).
 
-    Identity resolution prefers the ids the client derived into ``_meta``;
-    a request without ``_meta`` gets server-side derivation from the call
-    content and the count of previously anchored calls, which is a projection
-    of chain state rather than session state.
+    The trace / span identity prefers the ids the client derived into
+    ``_meta``; a request without them gets server-side derivation from the
+    call content. Ordering, however, is never taken on the client's word: the
+    call index is allocated from the journal (the count of previously anchored
+    calls) and the ``_meta.baggage`` value is treated as a *claim* only -- a
+    claim that disagrees with the allocation is rejected, so a client cannot
+    dictate its position in the audit ordering.
 
     Args:
         journal: The run journal receiving the ordered entry.
@@ -615,15 +648,27 @@ def anchor_stateless_call(
 
     Returns:
         The projected :class:`StatelessCallRecord`.
+
+    Raises:
+        ValueError: When the client's ``mcp.call_index`` baggage claims an
+            index that does not match the journal-allocated index.
     """
     from bernstein.core.replay.journal import load_events
     from bernstein.core.security.audit_chain import record_mcp_stateless_call
 
     meta = _meta_of(params)
     trace_id, span_id = _ids_from_traceparent(meta)
-    call_index = _call_index_from_baggage(meta)
-    if call_index is None:
-        call_index = sum(1 for row in load_events(journal.path) if row.get("event") == JOURNAL_EVENT_MCP_CALL)
+    # Allocate the next ordinal from the journal, never from the client. The
+    # baggage index is only a claim: a mismatch is rejected so the anchored
+    # call_index sequence stays contiguous and attacker-independent (AC1).
+    claimed_index = _call_index_from_baggage(meta)
+    call_index = sum(1 for row in load_events(journal.path) if row.get("event") == JOURNAL_EVENT_MCP_CALL)
+    if claimed_index is not None and claimed_index != call_index:
+        msg = (
+            f"mcp.call_index claim {claimed_index} does not match the allocated "
+            f"journal index {call_index} for run {journal.run_id!r}"
+        )
+        raise ValueError(msg)
     if not span_id:
         content_hash = hashlib.sha256(
             json.dumps(

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -941,6 +941,42 @@ class AuditChainStore:
         """Delegate to the underlying :class:`AuditLog`."""
         return self._log.verify()
 
+    def verify_and_query(
+        self,
+        *,
+        event_type: str | None = None,
+        actor: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        resource_id: str | None = None,
+        include_archived: bool = False,
+    ) -> tuple[bool, list[str], list[AuditEvent]]:
+        """Verify the chain and project matching events from one snapshot.
+
+        :meth:`verify` and :meth:`query` are otherwise two independent reads: a
+        concurrent append landing between them lets a caller act on a
+        projection the verification never covered (a verify/query TOCTOU).
+        Holding the append lock across both reads pins a single snapshot -- the
+        events returned are exactly the events that were verified -- because
+        chained appends acquire the same lock before touching the log.
+
+        Returns:
+            ``(ok, errors, events)``: the verification verdict and its per-entry
+            errors alongside the events matching the filters, all read under
+            one lock.
+        """
+        with self._append_lock:
+            ok, errors = self._log.verify()
+            events = self._log.query(
+                event_type=event_type,
+                actor=actor,
+                since=since,
+                until=until,
+                resource_id=resource_id,
+                include_archived=include_archived,
+            )
+        return ok, errors, events
+
 
 # ---------------------------------------------------------------------------
 # Event recording helpers (additive)
@@ -1991,11 +2027,13 @@ def reconstruct_mcp_call_order(*, chain: AuditChainStore, run_id: str) -> list[d
     """Rebuild a run's ordered MCP call sequence purely from chain entries.
 
     With the protocol session stores deleted (issue #2506) the audit chain is
-    the only authority on MCP call ordering. The chain is verified first, so
-    a tampered ``mcp.stateless_call`` entry fails at exactly that entry (the
-    underlying verifier names the file and line); the surviving entries are
-    then projected into their recorded ``call_index`` order and the sequence
-    is checked for gaps and duplicates.
+    the only authority on MCP call ordering. Verification and projection read
+    one locked snapshot, so a tampered ``mcp.stateless_call`` entry fails at
+    exactly that entry (the underlying verifier names the file and line) and
+    the projected events are exactly the events that were verified -- a
+    concurrent append cannot slip between the two reads; the surviving entries
+    are then projected into their recorded ``call_index`` order and the
+    sequence is checked for gaps and duplicates.
 
     Args:
         chain: The audit chain store holding the run's entries.
@@ -2010,16 +2048,12 @@ def reconstruct_mcp_call_order(*, chain: AuditChainStore, run_id: str) -> list[d
             verifier's per-entry errors) or when the recorded ``call_index``
             sequence has a gap or duplicate.
     """
-    ok, errors = chain.verify()
+    ok, errors, events = chain.verify_and_query(event_type=EVENT_MCP_STATELESS_CALL)
     if not ok:
         msg = "audit chain verification failed: " + "; ".join(errors)
         raise ValueError(msg)
 
-    details = [
-        event.details
-        for event in chain.query(event_type=EVENT_MCP_STATELESS_CALL)
-        if str(event.details.get("run_id", "")) == run_id
-    ]
+    details = [event.details for event in events if str(event.details.get("run_id", "")) == run_id]
     ordered = sorted(details, key=lambda d: int(d.get("call_index", -1)))
     indexes = [int(d.get("call_index", -1)) for d in ordered]
     if indexes != list(range(len(indexes))):

--- a/src/bernstein/mcp/remote_transport.py
+++ b/src/bernstein/mcp/remote_transport.py
@@ -403,6 +403,13 @@ class StreamableHTTPTransport:
         audit_chain: AuditChainStore | None = None,
         today: Callable[[], date] | None = None,
     ) -> None:
+        # An audit chain with no journal to anchor against would silently
+        # disable the auditing the caller asked for: every served call would
+        # take the ``journal is None`` early return and never reach the chain.
+        # Fail fast so a misconfigured transport cannot look audited (AC3).
+        if audit_chain is not None and journal is None:
+            msg = "audit_chain requires a journal; a chain without a journal silently disables anchoring"
+            raise ValueError(msg)
         self._config = config
         self._server_url = server_url
         self._journal = journal

--- a/tests/unit/protocols/mcp/test_stateless_core.py
+++ b/tests/unit/protocols/mcp/test_stateless_core.py
@@ -23,6 +23,7 @@ from bernstein.core.protocols.mcp.stateless_core import (
     CacheReference,
     InputRequiredResult,
     StatelessCallRecord,
+    _ids_from_traceparent,
     build_request_meta,
     compat_shim_active,
     decode_request_state,
@@ -127,6 +128,41 @@ class TestRequestMeta:
     def test_format_traceparent_shape(self) -> None:
         tp = format_traceparent(trace_id="a" * 32, span_id="b" * 16)
         assert tp == f"00-{'a' * 32}-{'b' * 16}-01"
+
+
+class TestTraceparentValidation:
+    """AC2: an untrusted ``traceparent`` is validated before its ids become
+    audit identity; anything off-shape falls back to content derivation."""
+
+    def _valid(self) -> str:
+        return f"00-{'a' * 32}-{'b' * 16}-01"
+
+    def test_valid_traceparent_returns_ids(self) -> None:
+        assert _ids_from_traceparent({"traceparent": self._valid()}) == ("a" * 32, "b" * 16)
+
+    def test_absent_traceparent_returns_empty(self) -> None:
+        assert _ids_from_traceparent({}) == ("", "")
+
+    @pytest.mark.parametrize(
+        "traceparent",
+        [
+            "00-" + "a" * 32 + "-" + "b" * 16,  # only three fields
+            "00-" + "a" * 32 + "-" + "b" * 16 + "-01-extra",  # five fields
+            "ff-" + "a" * 32 + "-" + "b" * 16 + "-01",  # reserved version ff
+            "0-" + "a" * 32 + "-" + "b" * 16 + "-01",  # 1-char version
+            "00-" + "a" * 31 + "-" + "b" * 16 + "-01",  # short trace id
+            "00-" + "a" * 33 + "-" + "b" * 16 + "-01",  # long trace id
+            "00-" + "a" * 32 + "-" + "b" * 15 + "-01",  # short span id
+            "00-" + "0" * 32 + "-" + "b" * 16 + "-01",  # all-zero trace id
+            "00-" + "a" * 32 + "-" + "0" * 16 + "-01",  # all-zero span id
+            "00-" + "g" * 32 + "-" + "b" * 16 + "-01",  # non-hex trace id
+            "00-" + "A" * 32 + "-" + "b" * 16 + "-01",  # uppercase (non-canonical)
+            "00-" + "a" * 32 + "-" + "b" * 16 + "-0",  # 1-char flags
+            "00-" + "a" * 32 + "-" + "b" * 16 + "-zz",  # non-hex flags
+        ],
+    )
+    def test_malformed_traceparent_returns_empty(self, traceparent: str) -> None:
+        assert _ids_from_traceparent({"traceparent": traceparent}) == ("", "")
 
 
 class TestRequestState:

--- a/tests/unit/protocols/mcp/test_stateless_migration.py
+++ b/tests/unit/protocols/mcp/test_stateless_migration.py
@@ -29,6 +29,7 @@ import pytest
 
 from bernstein.core.protocols.mcp.mcp_client import (
     MCPClientSession,
+    MCPSchemaViolation,
     RemoteServerConfig,
     RemoteTool,
 )
@@ -198,6 +199,42 @@ class TestClientStatelessMeta:
         spans = [p["json"]["params"]["_meta"]["traceparent"].split("-")[2] for p in client.posted]
         assert spans[0] != spans[1]
 
+    @pytest.mark.anyio
+    async def test_baggage_call_index_only_advances_for_anchored_calls(self) -> None:
+        """AC5: the baggage ``mcp.call_index`` advances only for anchor-eligible
+        calls, so its claim matches a server's per-tools/call journal
+        allocation rather than counting every message."""
+
+        def _baggage_index(posted: dict[str, Any]) -> int:
+            baggage = posted["json"]["params"]["_meta"]["baggage"]
+            for item in baggage.split(","):
+                key, _, value = item.partition("=")
+                if key == "mcp.call_index":
+                    return int(value)
+            raise AssertionError(f"no mcp.call_index in baggage: {baggage!r}")
+
+        client = _RecordingClient(
+            [
+                _jsonrpc_response({"tools": [{"name": "echo", "inputSchema": {}}]}),
+                _jsonrpc_response({"content": [{"type": "text", "text": "a"}]}, request_id=2),
+                _jsonrpc_response({"content": [{"type": "text", "text": "b"}]}, request_id=3),
+            ]
+        )
+        session = MCPClientSession(_config())
+        session._initialized = True
+        with patch("bernstein.core.protocols.mcp.mcp_client.httpx.AsyncClient", return_value=client):
+            await session.list_tools()  # tools/list -- not anchor-eligible
+            await session.call_tool("echo", {"input": "1"})  # first anchored call
+            await session.call_tool("echo", {"input": "2"})  # second anchored call
+
+        methods = [p["json"]["params"].get("name") or p["json"]["method"] for p in client.posted]
+        assert methods[0] == "tools/list"
+        # The non-anchored tools/list does not consume an audit ordinal, and the
+        # two tools/call requests claim a contiguous 0, 1.
+        assert _baggage_index(client.posted[0]) == 0
+        assert _baggage_index(client.posted[1]) == 0
+        assert _baggage_index(client.posted[2]) == 1
+
 
 class TestClientInputRequiredRetry:
     @pytest.mark.anyio
@@ -249,6 +286,37 @@ class TestClientInputRequiredRetry:
         session._tools = [RemoteTool(name="fetch", description="", server_name="test-server")]
         with pytest.raises(ValueError, match="requestState"):
             await session.call_tool("fetch", {}, request_state="@@@not-base64@@@")
+
+    @pytest.mark.anyio
+    async def test_input_required_without_request_state_is_rejected(self) -> None:
+        """AC7: an ``input_required`` result with no ``requestState`` cannot be
+        resumed, so it is a schema violation and marks the server degraded."""
+        client = _RecordingClient([_jsonrpc_response({"type": "input_required", "prompt": "need host"})])
+        session = MCPClientSession(_config())
+        session._initialized = True
+        session._tools = [RemoteTool(name="fetch", description="", server_name="test-server")]
+        with (
+            patch("bernstein.core.protocols.mcp.mcp_client.httpx.AsyncClient", return_value=client),
+            pytest.raises(MCPSchemaViolation, match="requestState"),
+        ):
+            await session.call_tool("fetch", {})
+        assert session.is_degraded
+
+    @pytest.mark.anyio
+    async def test_input_required_with_undecodable_request_state_is_rejected(self) -> None:
+        """AC7: an ``input_required`` result whose ``requestState`` will not
+        decode is rejected rather than surfaced as a resumable prompt."""
+        wire = {"type": "input_required", "prompt": "need host", "requestState": "@@@not-base64@@@"}
+        client = _RecordingClient([_jsonrpc_response(wire)])
+        session = MCPClientSession(_config())
+        session._initialized = True
+        session._tools = [RemoteTool(name="fetch", description="", server_name="test-server")]
+        with (
+            patch("bernstein.core.protocols.mcp.mcp_client.httpx.AsyncClient", return_value=client),
+            pytest.raises(MCPSchemaViolation, match="requestState"),
+        ):
+            await session.call_tool("fetch", {})
+        assert session.is_degraded
 
 
 # ---------------------------------------------------------------------------
@@ -374,9 +442,12 @@ class TestServedCallAnchoring:
     async def test_meta_carried_ids_are_anchored_verbatim(self, tmp_path: Path) -> None:
         chain = AuditChainStore(tmp_path / "audit", key=b"k" * 32)
         transport = _transport(tmp_path, chain=chain)
+        # The claimed call index matches the journal-allocated index (0 for the
+        # first served call), so the client-derived trace / span ids are
+        # anchored verbatim.
         meta = {
             "traceparent": f"00-{'a' * 32}-{'b' * 16}-01",
-            "baggage": "mcp.method=tools/call,mcp.call_index=7",
+            "baggage": "mcp.method=tools/call,mcp.call_index=0",
         }
         await transport.handle_request(
             "POST",
@@ -387,7 +458,56 @@ class TestServedCallAnchoring:
         event = chain.query(event_type=EVENT_MCP_STATELESS_CALL)[0]
         assert event.details["trace_id"] == "a" * 32
         assert event.details["span_id"] == "b" * 16
-        assert event.details["call_index"] == 7
+        assert event.details["call_index"] == 0
+
+
+class TestCallIndexAllocation:
+    """AC1: the audit call index is allocated from the journal, and the client
+    baggage is only a claim that must match the allocation."""
+
+    @staticmethod
+    def _claim_params(index: int) -> dict[str, Any]:
+        return {
+            "name": "echo",
+            "arguments": {},
+            "_meta": {"baggage": f"mcp.method=tools/call,mcp.call_index={index}"},
+        }
+
+    def test_absent_and_matching_claims_allocate_contiguously(self, tmp_path: Path) -> None:
+        chain = AuditChainStore(tmp_path / "audit", key=b"k" * 32)
+        journal = EventJournal("run-alloc", tmp_path / "journal")
+        # No baggage -> allocated 0.
+        anchor_stateless_call(
+            journal=journal, method="tools/call", params={"name": "echo", "arguments": {}}, chain=chain
+        )
+        # Baggage claims the correct next index (1) -> accepted.
+        anchor_stateless_call(journal=journal, method="tools/call", params=self._claim_params(1), chain=chain)
+        calls = reconstruct_mcp_call_order(chain=chain, run_id="run-alloc")
+        assert [c["call_index"] for c in calls] == [0, 1]
+
+    def test_mismatching_claim_is_rejected(self, tmp_path: Path) -> None:
+        journal = EventJournal("run-alloc", tmp_path / "journal")
+        # The first call's allocated index is 0; a claim of 7 is a lie.
+        with pytest.raises(ValueError, match="call_index claim 7"):
+            anchor_stateless_call(journal=journal, method="tools/call", params=self._claim_params(7), chain=None)
+        # The rejected call left no journal entry behind.
+        assert [r for r in load_events(journal.path) if r["event"] == "mcp.stateless_call"] == []
+
+    @pytest.mark.anyio
+    async def test_transport_survives_mismatched_claim_without_anchoring(self, tmp_path: Path) -> None:
+        chain = AuditChainStore(tmp_path / "audit", key=b"k" * 32)
+        transport = _transport(tmp_path, chain=chain)
+        meta = {"baggage": "mcp.method=tools/call,mcp.call_index=7"}
+        status, _, _ = await transport.handle_request(
+            "POST",
+            "/mcp",
+            {},
+            _request("tools/call", {"name": "bernstein_health", "arguments": {}, "_meta": meta}),
+        )
+        # Serving stays up (anchoring is non-fatal) but the lying claim is not
+        # anchored -- the gap is visible to a verifier.
+        assert status == 200
+        assert chain.query(event_type=EVENT_MCP_STATELESS_CALL) == []
 
 
 class TestChainReconstruction:
@@ -441,6 +561,36 @@ class TestChainReconstruction:
             )
         with pytest.raises(ValueError, match="call_index"):
             reconstruct_mcp_call_order(chain=chain, run_id="run-2506")
+
+    def test_verify_and_query_reads_one_locked_snapshot(self, tmp_path: Path) -> None:
+        """AC6: verify() and query() run under one lock, so the projected
+        events are exactly the events that were verified (no TOCTOU gap)."""
+        chain = self._seed(tmp_path)
+        ok, errors, events = chain.verify_and_query(event_type=EVENT_MCP_STATELESS_CALL)
+        assert ok, errors
+        # Same projection a plain query would return, but read atomically with
+        # the verification verdict.
+        assert [e.details["call_index"] for e in events] == [0, 1, 2]
+        assert events == chain.query(event_type=EVENT_MCP_STATELESS_CALL)
+
+    def test_verify_and_query_holds_the_append_lock(self, tmp_path: Path) -> None:
+        """AC6: an append cannot interleave between the verify and the query --
+        the operation holds the store's append lock across both reads, so a
+        concurrent ``log_with_prev_digest`` would block."""
+        chain = self._seed(tmp_path)
+        observed: dict[str, bool] = {}
+        real_verify = chain._log.verify
+
+        def _spy_verify() -> tuple[bool, list[str]]:
+            observed["locked_during_verify"] = chain._append_lock.locked()
+            return real_verify()
+
+        chain._log.verify = _spy_verify  # type: ignore[method-assign]
+        ok, _, _ = chain.verify_and_query(event_type=EVENT_MCP_STATELESS_CALL)
+        assert ok
+        assert observed["locked_during_verify"] is True
+        # The lock is released once the operation returns.
+        assert not chain._append_lock.locked()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_mcp_gateway.py
+++ b/tests/unit/test_mcp_gateway.py
@@ -416,3 +416,33 @@ class TestGatewayMetricsRoute:
         assert "tools/call:read_file" in data["metrics"]
         assert data["metrics"]["tools/call:read_file"]["total_calls"] == 3
         assert data["metrics"]["tools/call:read_file"]["error_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# TestProxiedCallAnchoring
+# ---------------------------------------------------------------------------
+
+
+class TestProxiedCallAnchoring:
+    """AC4: a proxied-call anchoring failure is logged, not silently swallowed,
+    while staying non-fatal to the proxy path."""
+
+    def test_anchor_failure_is_logged_not_suppressed(self, tmp_path: Any, caplog: pytest.LogCaptureFixture) -> None:
+        import logging
+        from pathlib import Path
+
+        from bernstein.core.replay.journal import EventJournal
+
+        journal = EventJournal("gw-anchor", Path(tmp_path) / "journal")
+        gateway = MCPGateway(upstream_cmd=[], wal_writer=_make_wal_writer(tmp_path), journal=journal)
+
+        boom = RuntimeError("audit volume full")
+        target = "bernstein.core.protocols.mcp.mcp_gateway.anchor_stateless_call"
+        with (
+            patch(target, side_effect=boom),
+            caplog.at_level(logging.ERROR, logger="bernstein.core.protocols.mcp.mcp_gateway"),
+        ):
+            # Non-fatal: the failing anchor must not propagate out of the proxy.
+            gateway._anchor_proxied_call("tools/call", {"name": "echo", "arguments": {}})
+
+        assert "Failed to anchor proxied mcp.stateless_call" in caplog.text

--- a/tests/unit/test_mcp_remote_transport.py
+++ b/tests/unit/test_mcp_remote_transport.py
@@ -94,6 +94,40 @@ def _matches_cancelled_error(node: ast.expr | None) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Audit wiring tests
+# ---------------------------------------------------------------------------
+
+
+class TestAuditWiring:
+    """AC3: an audit chain with no journal would silently disable anchoring, so
+    it is refused at construction rather than looking audited but recording
+    nothing."""
+
+    def test_audit_chain_without_journal_refused(self, config: RemoteMCPConfig, tmp_path) -> None:
+        from bernstein.core.security.audit_chain import AuditChainStore
+
+        chain = AuditChainStore(tmp_path / "audit", key=b"k" * 32)
+        with pytest.raises(ValueError, match="audit_chain requires a journal"):
+            StreamableHTTPTransport(config=config, audit_chain=chain)
+
+    def test_audit_chain_with_journal_accepted(self, config: RemoteMCPConfig, tmp_path) -> None:
+        from bernstein.core.replay.journal import EventJournal
+        from bernstein.core.security.audit_chain import AuditChainStore
+
+        chain = AuditChainStore(tmp_path / "audit", key=b"k" * 32)
+        journal = EventJournal("run-audit", tmp_path / "journal")
+        transport = StreamableHTTPTransport(config=config, journal=journal, audit_chain=chain)
+        assert transport._audit_chain is chain
+
+    def test_journal_without_chain_accepted(self, config: RemoteMCPConfig, tmp_path) -> None:
+        from bernstein.core.replay.journal import EventJournal
+
+        journal = EventJournal("run-audit", tmp_path / "journal")
+        transport = StreamableHTTPTransport(config=config, journal=journal)
+        assert transport._journal is journal
+
+
+# ---------------------------------------------------------------------------
 # RemoteMCPConfig tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What
All 7 acceptance criteria were genuine, unshipped gaps on origin/main; each is now hardened with a TDD regression test. Two commits on fix/m8w2-harden-mcp-audit: (1) call-index allocation + traceparent validation + input_required validation + verify/query TOCTOU (items 1,2,5,6,7); (2) audit-wiring fail-fast + gateway anchoring log (items 3,4). Commits split on file boundaries (non-interactive add cannot split a single file across commits; mcp_client and test_stateless_migration each carry multiple items). Both commits are bisectable-green.

Fixes #2647

## Checklist outcome
7 fixed / 0 already shipped on main (verified, no change) / 0 recorded out-of-scope.

- **1. Client-supplied call_index accepted as authoritative (stateless_core.py anchor_stateless_call)** — fixed: anchor_stateless_call now allocates the call index from the journal (count of prior mcp.stateless_call entries) and treats _meta.baggage mcp.call_index as a cla
- **2. W3C traceparent accepted without validation (stateless_core.py _ids_from_traceparent)** — fixed: _ids_from_traceparent now validates 4 fields, 2-hex non-reserved version (rejects ff), 32/16 lowercase-hex trace/span with all-zero rejection, and 2-hex flags; 
- **3. audit_chain accepted without journal silently disables auditing (remote_transport.py __init__)** — fixed: StreamableHTTPTransport.__init__ raises ValueError when audit_chain is provided without journal, before storing either. src/bernstein/mcp/remote_transport.py ~l
- **4. Proxied-call audit anchoring failures silently suppressed (mcp_gateway.py _anchor_proxied_call)** — fixed: Replaced contextlib.suppress(Exception) with try/except calling logger.exception (new module logger added; unused contextlib import removed) while keeping ancho
- **5. Audit anchoring covers a different message set than the client call-index counter (mcp_client.py _next_requ** — fixed: Added a separate _anchor_call_index that advances only for anchor-eligible methods (_ANCHOR_ELIGIBLE_METHODS = tools/call), carried in baggage via build_request
- **6. Audit-log verify() and query() are two independent reads (TOCTOU) (audit_chain.py reconstruct_mcp_call_orde** — fixed: Added AuditChainStore.verify_and_query that runs verify()+query() under the store's _append_lock (the same lock chained appends acquire), returning (ok, errors,
- **7. input_required responses accepted without validating requestState (mcp_client.py _parse_tool_result)** — fixed: The input_required branch now requires requestState to be a present non-empty string that decode_request_state accepts; otherwise mark_degraded + raise MCPSchem

## Verification
Adversarial review round: **confirmed, 0 critical findings** (red-on-main proven for the substantive items).
Touched test files (all green, final run 174 passed): tests/unit/protocols/mcp/test_stateless_core.py (added TestTraceparentValidation), tests/unit/protocols/mcp/test_stateless_migration.py (added TestCallIndexAllocation, test_baggage_call_index_only_advances_for_anchored_calls, two input_required tests, two verify_and_query tests; updated test_meta_carried_ids_are_anchored_verbatim), tests/unit/test_mcp_remote_transport.py (added TestAuditWiring), tests/unit/test_mcp_gateway.py (added TestProxiedCallAnchoring). Ran RED-then-GREEN via source-only git stash. NEVER ran the full suite (RAM constr
