### PR TITLE
fix(cost): harden cost-scheduling receipts and the price table

### DIFF
--- a/docs/operations/cost-aware-scheduling.md
+++ b/docs/operations/cost-aware-scheduling.md
@@ -35,10 +35,13 @@ cost_policy:
 ```
 
 Rates are schema-validated non-negative; a negative rate fails at load time
-rather than corrupting every downstream budget decision. `bernstein doctor`
-prints a staleness advisory when the shipped table's `as_of` date is older than
-the staleness window (default 90 days), a reminder that provider rates drift
-between releases.
+rather than corrupting every downstream budget decision. A partial override that
+names only `input`/`output` inherits the base row's `cache_read`/`cache_write`
+rather than zeroing them, so re-rating a model's list price never silently
+understates its cache spend; name a cache rate explicitly (including `0.0`) to
+change it. `bernstein doctor` prints a staleness advisory when the shipped
+table's `as_of` date is older than the staleness window (default 90 days), a
+reminder that provider rates drift between releases.
 
 ## USD ceilings and the halt receipt
 

--- a/src/bernstein/core/config/config_schema.py
+++ b/src/bernstein/core/config/config_schema.py
@@ -468,8 +468,12 @@ class ModelPriceSchema(BaseModel):
 
     input: float = Field(..., ge=0, description="USD per 1M input tokens.")
     output: float = Field(..., ge=0, description="USD per 1M output tokens.")
-    cache_read: float = Field(default=0.0, ge=0, description="USD per 1M cache-read tokens.")
-    cache_write: float = Field(default=0.0, ge=0, description="USD per 1M cache-write tokens.")
+    cache_read: float | None = Field(
+        default=None, ge=0, description="USD per 1M cache-read tokens; omitted inherits the base rate."
+    )
+    cache_write: float | None = Field(
+        default=None, ge=0, description="USD per 1M cache-write tokens; omitted inherits the base rate."
+    )
 
 
 class PricingSchema(BaseModel):

--- a/src/bernstein/core/cost/scheduling/dispatch_gate.py
+++ b/src/bernstein/core/cost/scheduling/dispatch_gate.py
@@ -88,11 +88,13 @@ def _pricing_models(pricing: Any) -> dict[str, dict[str, Any]]:
         elif isinstance(price, dict):
             row = dict(price)
         else:
+            # A missing cache rate is left as None ("inherit the base rate"),
+            # never forced to 0.0, so a partial override cannot zero cache pricing.
             row = {
                 "input": getattr(price, "input", 0.0),
                 "output": getattr(price, "output", 0.0),
-                "cache_read": getattr(price, "cache_read", 0.0),
-                "cache_write": getattr(price, "cache_write", 0.0),
+                "cache_read": getattr(price, "cache_read", None),
+                "cache_write": getattr(price, "cache_write", None),
             }
         rows[str(key)] = row
     return rows

--- a/src/bernstein/core/cost/scheduling/price_table.py
+++ b/src/bernstein/core/cost/scheduling/price_table.py
@@ -134,8 +134,15 @@ class PriceTable:
         return PricedCall(model=model, cost_usd=0.0, priced=False)
 
 
-def _coerce_rates(raw: Mapping[str, Any], *, key: str) -> ModelPrice:
+def _coerce_rates(raw: Mapping[str, Any], *, key: str, base: ModelPrice | None = None) -> ModelPrice:
     """Validate one config rate row into a :class:`ModelPrice`.
+
+    An omitted (absent or ``None``) optional cache rate inherits *base* rather
+    than collapsing to ``0.0``: a partial override that names only
+    ``input``/``output`` must not silently zero a model's cache pricing and
+    understate cache-heavy spend. An explicit ``0`` is still honoured. When
+    *base* is ``None`` (a brand-new model with no shipped row) an omitted cache
+    rate defaults to ``0.0`` as before.
 
     Raises:
         ValueError: A rate is missing, non-numeric, or negative. A negative
@@ -143,24 +150,27 @@ def _coerce_rates(raw: Mapping[str, Any], *, key: str) -> ModelPrice:
             corrupt every downstream budget decision.
     """
 
-    def _rate(field: str, *, required: bool) -> float:
-        if field not in raw:
+    def _rate(field: str, *, required: bool, inherited: float) -> float:
+        value = raw.get(field)
+        if value is None:  # absent, or an explicit null meaning "inherit"
             if required:
                 raise ValueError(f"price for model {key!r} is missing required rate {field!r}")
-            return 0.0
+            return inherited
         try:
-            value = float(raw[field])
+            num = float(value)
         except (TypeError, ValueError) as exc:
-            raise ValueError(f"price for model {key!r} has non-numeric rate {field!r}: {raw[field]!r}") from exc
-        if value < 0:
-            raise ValueError(f"price for model {key!r} has negative rate {field!r}={value}")
-        return value
+            raise ValueError(f"price for model {key!r} has non-numeric rate {field!r}: {value!r}") from exc
+        if num < 0:
+            raise ValueError(f"price for model {key!r} has negative rate {field!r}={num}")
+        return num
 
+    base_read = base.cache_read_usd_per_1m if base is not None else 0.0
+    base_write = base.cache_write_usd_per_1m if base is not None else 0.0
     return ModelPrice(
-        input_usd_per_1m=_rate("input", required=True),
-        output_usd_per_1m=_rate("output", required=True),
-        cache_read_usd_per_1m=_rate("cache_read", required=False),
-        cache_write_usd_per_1m=_rate("cache_write", required=False),
+        input_usd_per_1m=_rate("input", required=True, inherited=0.0),
+        output_usd_per_1m=_rate("output", required=True, inherited=0.0),
+        cache_read_usd_per_1m=_rate("cache_read", required=False, inherited=base_read),
+        cache_write_usd_per_1m=_rate("cache_write", required=False, inherited=base_write),
     )
 
 
@@ -212,7 +222,9 @@ def load_price_table(
         return base_table
     merged: dict[str, ModelPrice] = base_table.models.copy()
     for key, raw in models.items():
-        merged[key] = _coerce_rates(raw, key=key)
+        # Thread the base row so an omitted cache rate inherits the shipped
+        # value instead of collapsing to 0.0 (partial-override understatement).
+        merged[key] = _coerce_rates(raw, key=key, base=base_table.models.get(key))
     return PriceTable(
         models=merged,
         as_of=as_of or base_table.as_of,

--- a/src/bernstein/core/cost/scheduling/receipt.py
+++ b/src/bernstein/core/cost/scheduling/receipt.py
@@ -58,14 +58,22 @@ def dispatch_receipt_path(workdir: Path, decision_hash: str) -> Path:
     caller-influenced hash can never escape the receipt store (CodeQL
     path-injection defense in depth).
 
+    The filename is the bare hex digest (the ``sha256:`` prefix is stripped):
+    a colon is an invalid path character on Windows, so a ``sha256:...``
+    filename would make the write fail and silently lose the receipt. The full
+    canonical hash is preserved inside the receipt body (``decision_hash``).
+
     Raises:
         ValueError: The decision hash is not a canonical ``sha256:`` digest,
             or the resolved path escapes the dispatch directory.
     """
     if not _DECISION_HASH_RE.match(decision_hash):
         raise ValueError(f"decision_hash is not a canonical sha256 digest: {decision_hash!r}")
+    # The regex guarantees exactly one ``sha256:`` prefix over 64 hex chars, so
+    # the suffix is a portable, filesystem-safe filename on every platform.
+    hex_digest = decision_hash.split(":", 1)[1]
     base = workdir.joinpath(*_DISPATCH_SUBPATH)
-    candidate = base / f"{decision_hash}.json"
+    candidate = base / f"{hex_digest}.json"
     base_real = os.path.realpath(base)
     cand_real = os.path.realpath(candidate)
     if os.path.commonpath([base_real, cand_real]) != base_real:
@@ -136,6 +144,13 @@ def build_dispatch_receipt(
     Returns:
         The sealed :class:`DispatchReceipt` with its ``journal_entry_hash``.
     """
+    # Idempotent: a decision already sealed for this hash is returned unchanged.
+    # Re-sealing on every tick would append a duplicate spine entry and a
+    # duplicate audit-chain event, orphaning the prior anchor.
+    existing = read_dispatch_receipt(workdir, decision.decision_hash)
+    if existing is not None:
+        return existing
+
     content = decision.canonical_bytes()
     spine = LineageSpine(lineage_root, run_id=DISPATCH_RUN_ID, hmac_key=hmac_key)
     artifact_path = "/".join((*_DISPATCH_SUBPATH, f"{decision.decision_hash}.json"))

--- a/tests/unit/cost/test_cost_scheduling.py
+++ b/tests/unit/cost/test_cost_scheduling.py
@@ -58,11 +58,14 @@ from bernstein.core.cost.scheduling.price_table import (
     price_table_staleness,
 )
 from bernstein.core.cost.scheduling.receipt import (
+    DISPATCH_RUN_ID,
     build_dispatch_receipt,
+    dispatch_receipt_path,
     read_dispatch_receipt,
     verify_dispatch_receipt,
 )
 from bernstein.core.cost.spend_ledger import LedgerEntry
+from bernstein.core.lineage.spine import LineageSpine
 from bernstein.core.security.audit_chain import (
     EVENT_COST_DISPATCH_RECEIPT,
     AuditChainStore,
@@ -159,6 +162,64 @@ def test_load_price_table_from_config_overrides_defaults_and_validates() -> None
 def test_load_price_table_rejects_negative_rate() -> None:
     with pytest.raises(ValueError, match="negative"):
         load_price_table({"bad": {"input": -1.0, "output": 2.0}})
+
+
+def test_load_price_table_partial_override_inherits_base_cache_rate() -> None:
+    # An override that names only input/output must NOT zero the base model's
+    # cache rates: that would silently understate cache-heavy spend.
+    base = PriceTable(
+        models={
+            "m": ModelPrice(
+                input_usd_per_1m=3.0,
+                output_usd_per_1m=15.0,
+                cache_read_usd_per_1m=0.30,
+                cache_write_usd_per_1m=3.75,
+            )
+        },
+        as_of="2026-05-05",
+        revision=1,
+    )
+    table = load_price_table({"m": {"input": 2.0, "output": 10.0}}, base=base, revision=2)
+    price = table.models["m"]
+    assert price.input_usd_per_1m == pytest.approx(2.0)
+    assert price.output_usd_per_1m == pytest.approx(10.0)
+    # Cache rates inherited from the base row, not collapsed to 0.
+    assert price.cache_read_usd_per_1m == pytest.approx(0.30)
+    assert price.cache_write_usd_per_1m == pytest.approx(3.75)
+
+
+def test_load_price_table_explicit_zero_cache_is_honored() -> None:
+    # An operator can still deliberately zero a cache rate by naming it.
+    base = PriceTable(
+        models={"m": ModelPrice(3.0, 15.0, cache_read_usd_per_1m=0.30, cache_write_usd_per_1m=3.75)},
+        as_of="2026-05-05",
+        revision=1,
+    )
+    table = load_price_table({"m": {"input": 2.0, "output": 10.0, "cache_read": 0.0}}, base=base)
+    assert table.models["m"].cache_read_usd_per_1m == 0.0
+    # Unnamed cache_write still inherits.
+    assert table.models["m"].cache_write_usd_per_1m == pytest.approx(3.75)
+
+
+def test_config_partial_pricing_override_inherits_default_cache_rate() -> None:
+    # End-to-end through the config schema: omitting cache rates in a config
+    # override inherits the shipped default rather than collapsing to 0.
+    from bernstein.core.config.config_schema import (
+        CostPolicySchema,
+        ModelPriceSchema,
+        PricingSchema,
+    )
+    from bernstein.core.cost.scheduling.dispatch_gate import resolve_price_table
+
+    # sonnet ships with a non-zero cache_read in the default table.
+    default_cache_read = DEFAULT_PRICE_TABLE.models["sonnet"].cache_read_usd_per_1m
+    assert default_cache_read > 0
+    # The schema now leaves an omitted cache rate as None (meaning "inherit").
+    assert ModelPriceSchema(input=1.0, output=2.0).cache_read is None
+    policy = CostPolicySchema(pricing=PricingSchema(models={"sonnet": ModelPriceSchema(input=1.0, output=2.0)}))
+    table = resolve_price_table(policy)
+    assert table.models["sonnet"].input_usd_per_1m == pytest.approx(1.0)
+    assert table.models["sonnet"].cache_read_usd_per_1m == pytest.approx(default_cache_read)
 
 
 def test_price_table_staleness_advisory_fires_past_window() -> None:
@@ -339,7 +400,7 @@ def test_dispatch_receipt_tamper_is_detected(tmp_path: Path) -> None:
     stored = read_dispatch_receipt(workdir, decision.decision_hash)
     assert stored is not None
     # Tamper with the on-disk receipt: forge an admit.
-    path = workdir / ".sdd" / "cost" / "dispatch" / f"{decision.decision_hash}.json"
+    path = dispatch_receipt_path(workdir, decision.decision_hash)
     forged = json.loads(path.read_text(encoding="utf-8"))
     forged["admit"] = True
     forged["projected_overrun_usd"] = 0.0
@@ -348,6 +409,84 @@ def test_dispatch_receipt_tamper_is_detected(tmp_path: Path) -> None:
         workdir=workdir, lineage_root=lineage_root, hmac_key=_KEY, decision_hash=decision.decision_hash
     )
     assert result.ok is False
+
+
+def test_dispatch_receipt_filename_strips_sha256_prefix(tmp_path: Path) -> None:
+    # A ':' is an invalid path character on Windows: a colon-bearing filename
+    # would silently lose every receipt. The on-disk name must be the bare hex
+    # digest, while the canonical hash still lives inside the receipt body.
+    day = _day_key(1_762_000_000.0)
+    entries = [_entry(task_id="t1", run_id="r1", cost_usd=9.9, ts=1_762_000_000.0)]
+    caps = CostCaps(per_run_usd=10.0)
+    candidate = DispatchCandidate(
+        task_id="t1", run_id="r1", model="sonnet", projected_cost_usd=1.0, day_key=day, pool="api"
+    )
+    decision = decide_dispatch(candidate=candidate, entries=entries, caps=caps, price_table_hash="sha256:pt")
+    workdir = tmp_path / "proj"
+    build_dispatch_receipt(
+        decision=decision,
+        workdir=workdir,
+        lineage_root=workdir / ".sdd" / "lineage",
+        hmac_key=_KEY,
+        timestamp=1_762_000_001,
+    )
+    path = dispatch_receipt_path(workdir, decision.decision_hash)
+    hex_digest = decision.decision_hash.split(":", 1)[1]
+    assert ":" not in path.name
+    assert path.name == f"{hex_digest}.json"
+    assert path.is_file()
+    # The canonical hash is preserved inside the receipt body.
+    body = json.loads(path.read_text(encoding="utf-8"))
+    assert body["decision_hash"] == decision.decision_hash
+    # And the reader round-trips it.
+    stored = read_dispatch_receipt(workdir, decision.decision_hash)
+    assert stored is not None
+    assert stored.decision.decision_hash == decision.decision_hash
+
+
+def test_build_dispatch_receipt_is_idempotent(tmp_path: Path) -> None:
+    # Re-sealing the same decision (e.g. on every tick) must not append
+    # duplicate spine / audit-chain entries and orphan the prior anchor: the
+    # second call returns the already-sealed receipt unchanged.
+    day = _day_key(1_762_000_000.0)
+    entries = [_entry(task_id="t1", run_id="r1", cost_usd=9.9, ts=1_762_000_000.0)]
+    caps = CostCaps(per_run_usd=10.0)
+    candidate = DispatchCandidate(
+        task_id="t1", run_id="r1", model="sonnet", projected_cost_usd=1.0, day_key=day, pool="api"
+    )
+    decision = decide_dispatch(candidate=candidate, entries=entries, caps=caps, price_table_hash="sha256:pt")
+    workdir = tmp_path / "proj"
+    lineage_root = workdir / ".sdd" / "lineage"
+    chain = AuditChainStore(workdir / ".sdd" / "audit", key=_KEY)
+    first = build_dispatch_receipt(
+        decision=decision,
+        workdir=workdir,
+        lineage_root=lineage_root,
+        hmac_key=_KEY,
+        timestamp=1_762_000_001,
+        chain=chain,
+    )
+    second = build_dispatch_receipt(
+        decision=decision,
+        workdir=workdir,
+        lineage_root=lineage_root,
+        hmac_key=_KEY,
+        timestamp=1_762_000_999,  # a later tick must not re-anchor
+        chain=chain,
+    )
+    # Same anchor, original timestamp preserved -- no re-seal.
+    assert second.journal_entry_hash == first.journal_entry_hash
+    assert second.timestamp == first.timestamp == 1_762_000_001
+    # Exactly one audit-chain event and one spine entry.
+    events = chain.query(event_type=EVENT_COST_DISPATCH_RECEIPT)
+    assert len(events) == 1
+    spine = LineageSpine(lineage_root, run_id=DISPATCH_RUN_ID, hmac_key=_KEY)
+    assert len(list(spine.iter_entries())) == 1
+    # Still offline-verifiable.
+    result = verify_dispatch_receipt(
+        workdir=workdir, lineage_root=lineage_root, hmac_key=_KEY, decision_hash=decision.decision_hash
+    )
+    assert result.ok is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cost/test_cost_scheduling_cli.py
+++ b/tests/unit/cost/test_cost_scheduling_cli.py
@@ -17,7 +17,7 @@ from click.testing import CliRunner
 
 from bernstein.cli.commands.cost import cost_cmd
 from bernstein.core.cost.scheduling.policy import CostCaps, DispatchCandidate, decide_dispatch
-from bernstein.core.cost.scheduling.receipt import build_dispatch_receipt
+from bernstein.core.cost.scheduling.receipt import build_dispatch_receipt, dispatch_receipt_path
 from bernstein.core.cost.spend_ledger import LedgerEntry
 
 _KEY = b"0" * 32
@@ -133,7 +133,7 @@ def test_verify_roundtrip_and_tamper(tmp_path: Path, monkeypatch: pytest.MonkeyP
     assert json.loads(ok.output)["ok"] is True
 
     # Tamper the on-disk receipt: forge an admit.
-    path = workdir / ".sdd" / "cost" / "dispatch" / f"{decision.decision_hash}.json"
+    path = dispatch_receipt_path(workdir, decision.decision_hash)
     forged = json.loads(path.read_text(encoding="utf-8"))
     forged["admit"] = True
     path.write_text(json.dumps(forged), encoding="utf-8")

--- a/tests/unit/cost/test_dispatch_knob_matrix.py
+++ b/tests/unit/cost/test_dispatch_knob_matrix.py
@@ -63,6 +63,7 @@ from bernstein.core.cost.scheduling.policy import (
 )
 from bernstein.core.cost.scheduling.receipt import (
     build_dispatch_receipt,
+    dispatch_receipt_path,
     verify_dispatch_receipt,
 )
 from bernstein.core.cost.spend_ledger import LedgerEntry
@@ -314,7 +315,7 @@ def test_sealed_knob_receipt_verifies_offline(tmp_path: Path) -> None:
     )
     assert result.ok is True
     # The sealed selection is on the receipt.
-    payload = json.loads((workdir / ".sdd" / "cost" / "dispatch" / f"{decision_hash}.json").read_text(encoding="utf-8"))
+    payload = json.loads(dispatch_receipt_path(workdir, decision_hash).read_text(encoding="utf-8"))
     assert payload["knob_selection"]["lane"] in {LANE_INTERACTIVE, LANE_BATCH}
     assert payload["knob_selection"]["selection_hash"] == selection.selection_hash
 
@@ -335,7 +336,7 @@ def test_tampering_any_knob_field_fails_verification_naming_it(
         candidate=_candidate(batch_eligible=True, adapter="claude"), matrix=DEFAULT_KNOB_MATRIX
     )
     workdir, lineage_root, decision_hash = _seal_receipt(tmp_path, selection=selection)
-    path = workdir / ".sdd" / "cost" / "dispatch" / f"{decision_hash}.json"
+    path = dispatch_receipt_path(workdir, decision_hash)
     forged = json.loads(path.read_text(encoding="utf-8"))
     assert forged["knob_selection"][field_name] != tampered_value
     forged["knob_selection"][field_name] = tampered_value


### PR DESCRIPTION
## What
All three acceptance-criteria items were genuine, unshipped gaps on origin/main (verified by reading the code first). Fixed each with a TDD regression test. Item 1: dispatch_receipt_path now strips the 'sha256:' prefix so the on-disk filename is the bare hex digest (a colon is an invalid Windows path char that silently lost receipts); the full canonical hash stays in the receipt body. Item 2: ModelPriceSchema cache fields are now Optional (None=inherit) and _coerce_rates/load_price_table thread the base row so a partial override naming only input/output inherits the base cache_read/cache_write instead of collapsing them to 0.0; explicit 0.0 is still honoured. Item 3: build_dispatch_receipt is now idempotent (returns the already-sealed receipt when one exists) so re-seals on repeat ticks no longer append duplicate spine + audit-chain entries. No new float money surfaces added to signed receipts; audit-chain/lineage verification semantics preserved (verify_dispatch_receipt still passes). One commit; pushed; no PR opened.

Fixes #2644

## Checklist outcome
3 fixed / 0 already shipped on main (verified, no change) / 0 recorded out-of-scope.

- **Receipt filename embeds sha256: colon — invalid path on Windows, receipts silently lost (receipt.py:68)** — fixed: dispatch_receipt_path validates the canonical sha256 hash then derives the filename from the hex digest (decision_hash.split(':',1)[1]) -> '<64hex>.json'; the f
- **Partial price override silently zeroes a model's cache pricing, understating spend (price_table.py:215)** — fixed: config_schema.ModelPriceSchema.cache_read/cache_write are now `float | None = Field(default=None, ge=0)` (omitted => None => inherit). price_table._coerce_rates
- **build_dispatch_receipt not idempotent — re-seal on every tick orphans prior audit events (receipt.py:140)** — fixed: Added a guard at the top of build_dispatch_receipt: existing = read_dispatch_receipt(workdir, decision.decision_hash); if existing is not None: return existing 

## Verification
Adversarial review round: **confirmed, 0 critical findings** (red-on-main proven for the substantive items).
Touched test files, all green (81 passed together): tests/unit/cost/test_cost_scheduling.py, tests/unit/cost/test_dispatch_knob_matrix.py, tests/unit/cost/test_cost_scheduling_cli.py, tests/unit/cost/test_cost_dispatch_gate.py. Cost-dispatch orchestrator tests: uv run pytest tests/unit/test_orchestrator.py -k "cost or dispatch_halt or fail_open or zero_cap" -> 9 passed. RED baseline captured before the fixes (5 new tests failed). Import/collection sentinel: uv run pytest tests/unit --co -q -> 37842 tests collected, no import errors. ruff check clean on all touched files; ruff format clean; myp
