### PR TITLE
fix(core): harden process reap, platform compat, and worktree isolation

### DIFF
--- a/src/bernstein/core/config/platform_compat.py
+++ b/src/bernstein/core/config/platform_compat.py
@@ -420,17 +420,20 @@ def reap_process_group(
     if not kill_process_group(pgid, signal.SIGTERM):
         return _receipt(delivered=False, escalated=False)
 
-    # Poll for graceful exit.  Using the lead PID as a liveness proxy is
-    # safe because it is guaranteed to be the session leader (start_new_session=True).
+    # Poll for graceful exit.  Probe the whole process *group* rather than the
+    # lead PID: the session leader can reap while a child it spawned keeps the
+    # group alive, and a lead-PID-only check (``process_alive``) would then
+    # declare the group dead the moment the leader exits and skip the SIGKILL
+    # escalation the surviving tree still needs (issue #2643).
     deadline = time.monotonic() + grace_seconds
     while time.monotonic() < deadline:
-        if not process_alive(pgid):
+        if not process_group_alive(pgid):
             return _receipt(delivered=True, escalated=False)
         time.sleep(poll_interval)
 
-    # Still alive after grace period - escalate.
+    # Group still alive after grace period - escalate.
     escalated = False
-    if process_alive(pgid):
+    if process_group_alive(pgid):
         logger.warning(
             "Process group %d did not exit within %.1fs of SIGTERM; sending SIGKILL",
             pgid,
@@ -467,6 +470,45 @@ def process_alive(pid: int) -> bool:
 
     # Windows: use ctypes kernel32 calls
     return _win_process_alive(pid)
+
+
+def process_group_alive(pgid: int) -> bool:
+    """Check whether *any* member of a process group is still running.
+
+    On POSIX, probes the whole group with ``os.killpg(pgid, 0)`` (signal 0 =
+    existence check): a surviving child keeps the group alive even after the
+    group leader (the lead PID) has already been reaped.  :func:`process_alive`
+    only tracks the lead PID, so a reap path that used it as the liveness proxy
+    would report the group dead the moment the leader exits and skip the
+    SIGKILL escalation the surviving children still need (issue #2643).
+
+    On Windows there are no POSIX process groups, so this falls back to the
+    lead-PID liveness check; the Windows reap path terminates the whole tree
+    via a Job Object / ``taskkill /T`` keyed on that PID.
+
+    Args:
+        pgid: Process group ID (on Unix) or lead PID (on Windows).
+
+    Returns:
+        True if the group (POSIX) or the lead process (Windows) is running.
+    """
+    if pgid <= 0:
+        return False
+
+    if IS_WINDOWS:
+        return process_alive(pgid)
+
+    try:
+        os.killpg(pgid, 0)
+    except ProcessLookupError:
+        # ESRCH: the group has no members left.
+        return False
+    except PermissionError:
+        # EPERM: a process exists but we may not signal it - the group is alive.
+        return True
+    except OSError:
+        return False
+    return True
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/core/git/worktree_isolation.py
+++ b/src/bernstein/core/git/worktree_isolation.py
@@ -24,13 +24,23 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _resolve_link_target(path: Path) -> Path:
+def _resolve_link_target(path: Path) -> Path | None:
     """Resolve a link (symlink or junction) to its target path.
 
     Isolated in a helper so tests can exercise the junction branches on
     platforms where junctions cannot be created.
+
+    ``Path.resolve()`` can raise ``OSError`` (``ELOOP`` on a symlink cycle, or
+    a permission error) or ``RuntimeError`` (an infinite loop the resolver
+    detects itself).  A link the isolation checker cannot resolve is treated
+    fail-closed: this returns ``None`` and the callers record a violation so
+    the spawn aborts through ``create()``'s cleanup path instead of letting a
+    raw filesystem error escape and leak the worktree + lock (issue #2643).
     """
-    return path.resolve()
+    try:
+        return path.resolve()
+    except (OSError, RuntimeError):
+        return None
 
 
 class WorktreeIsolationError(Exception):
@@ -82,6 +92,11 @@ def check_sdd_not_shared(worktree_path: Path, repo_root: Path) -> list[str]:
 
     if is_filesystem_link(sdd_path):
         link_target = _resolve_link_target(sdd_path)
+        if link_target is None:
+            # Fail-closed: an unresolvable .sdd/ link cannot be proven local,
+            # so treat it as a violation and let create() clean up (#2643).
+            violations.append(f".sdd/ is a link that could not be resolved (cannot verify isolation): {sdd_path}")
+            return violations
         parent_sdd = repo_root / ".sdd"
         if link_target == parent_sdd.resolve() or str(link_target).startswith(str(parent_sdd.resolve())):
             violations.append(f".sdd/ is a symlink to parent repo state: {sdd_path} -> {link_target}")
@@ -128,6 +143,11 @@ def check_symlinks_read_only(
             continue
 
         link_target = _resolve_link_target(entry)
+        if link_target is None:
+            # Fail-closed: a symlink whose target cannot be resolved cannot be
+            # cleared of pointing into parent state, so record it (#2643).
+            violations.append(f"Symlink '{rel_name}' could not be resolved (cannot verify isolation): {entry}")
+            continue
         # Symlinks pointing into the parent repo's mutable state dirs are dangerous
         mutable_dirs = (".sdd", ".git")
         for mutable in mutable_dirs:

--- a/tests/unit/test_platform_compat.py
+++ b/tests/unit/test_platform_compat.py
@@ -154,7 +154,7 @@ class TestKillProcessGroupGraceful:
                 return_value=True,
             ) as mock_kpg,
             patch(
-                "bernstein.core.config.platform_compat.process_alive",
+                "bernstein.core.config.platform_compat.process_group_alive",
                 side_effect=_alive,
             ),
         ):
@@ -168,8 +168,8 @@ class TestKillProcessGroupGraceful:
         """If the group never exits, a force-kill must follow the grace period.
 
         No platform skip: the escalation path is fully mocked at the
-        ``kill_process_group`` / ``process_alive`` boundary, so it runs on
-        the Windows lane too. The force tier is the POSIX ``SIGKILL`` where
+        ``kill_process_group`` / ``process_group_alive`` boundary, so it runs
+        on the Windows lane too. The force tier is the POSIX ``SIGKILL`` where
         importable and the numeric ``9`` fallback on Windows (where
         ``signal.SIGKILL`` does not exist) - keyed off the platform so the
         assertion holds on both.
@@ -181,7 +181,7 @@ class TestKillProcessGroupGraceful:
                 return_value=True,
             ) as mock_kpg,
             patch(
-                "bernstein.core.config.platform_compat.process_alive",
+                "bernstein.core.config.platform_compat.process_group_alive",
                 return_value=True,
             ),
         ):

--- a/tests/unit/test_platform_process_tree.py
+++ b/tests/unit/test_platform_process_tree.py
@@ -25,6 +25,7 @@ from bernstein.core.platform_compat import (
     ProcessReapReceipt,
     WindowsJobObject,
     kill_process_group_graceful,
+    process_group_alive,
     process_group_popen_kwargs,
     reap_process_group,
 )
@@ -91,7 +92,7 @@ class TestReapProcessGroup:
         alive = iter([True, False])
         with (
             patch(f"{_PC}.kill_process_group", return_value=True) as mock_kpg,
-            patch(f"{_PC}.process_alive", side_effect=lambda _pid: next(alive, False)),
+            patch(f"{_PC}.process_group_alive", side_effect=lambda _pid: next(alive, False)),
         ):
             receipt = reap_process_group(12345, grace_seconds=1.0, poll_interval=0.01)
         assert receipt.delivered is True
@@ -101,7 +102,7 @@ class TestReapProcessGroup:
     def test_escalation_receipt(self) -> None:
         with (
             patch(f"{_PC}.kill_process_group", return_value=True) as mock_kpg,
-            patch(f"{_PC}.process_alive", return_value=True),
+            patch(f"{_PC}.process_group_alive", return_value=True),
         ):
             receipt = reap_process_group(12345, grace_seconds=0.05, poll_interval=0.01)
         assert receipt.delivered is True
@@ -109,6 +110,33 @@ class TestReapProcessGroup:
         assert mock_kpg.call_count == 2
         # First TERM, then the platform force-kill signal.
         assert mock_kpg.call_args_list[0].args == (12345, signal.SIGTERM)
+
+    def test_escalates_when_group_alive_after_leader_reaped(self) -> None:
+        """Leader reaped but a surviving child keeps the group alive.
+
+        A session leader can exit while a child it spawned survives; the
+        process group is still alive (``os.killpg(pgid, 0)`` succeeds) even
+        though the lead PID is gone.  The reap must probe the whole group and
+        escalate to SIGKILL rather than declaring the group dead off the lead
+        PID and leaking the surviving tree (issue #2643).
+        """
+
+        def _killpg(_pgid: int, _sig: int) -> None:
+            # Signal 0 is the group-liveness probe: the group is still alive.
+            # SIGTERM/SIGKILL deliveries "succeed" (no raise) too.
+            return None
+
+        with (
+            patch(f"{_PC}.os.killpg", side_effect=_killpg) as mock_killpg,
+            # Lead PID is already reaped; a lead-PID-only check stops here.
+            patch(f"{_PC}.process_alive", return_value=False),
+        ):
+            receipt = reap_process_group(4321, grace_seconds=0.05, poll_interval=0.01)
+
+        assert receipt.delivered is True
+        assert receipt.escalated is True
+        forced = [c for c in mock_killpg.call_args_list if c.args[1] in (signal.SIGKILL, 9)]
+        assert forced, "expected a SIGKILL escalation delivered to the surviving group"
 
     def test_receipt_details_projection(self) -> None:
         """to_details() is a deterministic dict projection of the receipt."""
@@ -157,9 +185,47 @@ class TestReapProcessGroup:
         alive = iter([False])
         with (
             patch(f"{_PC}.kill_process_group", return_value=True),
-            patch(f"{_PC}.process_alive", side_effect=lambda _pid: next(alive, False)),
+            patch(f"{_PC}.process_group_alive", side_effect=lambda _pid: next(alive, False)),
         ):
             assert kill_process_group_graceful(12345, grace_seconds=0.1, poll_interval=0.01) is True
+
+
+# ---------------------------------------------------------------------------
+# process_group_alive
+# ---------------------------------------------------------------------------
+
+
+class TestProcessGroupAlive:
+    def test_nonpositive_pgid_is_dead(self) -> None:
+        assert process_group_alive(0) is False
+        assert process_group_alive(-1) is False
+
+    def test_group_alive_when_killpg_succeeds(self) -> None:
+        with patch(f"{_PC}.os.killpg", return_value=None) as mock_killpg:
+            assert process_group_alive(4321) is True
+        mock_killpg.assert_called_once_with(4321, 0)
+
+    def test_group_dead_on_esrch(self) -> None:
+        # ProcessLookupError is the ESRCH mapping: no members left in the group.
+        with patch(f"{_PC}.os.killpg", side_effect=ProcessLookupError):
+            assert process_group_alive(4321) is False
+
+    def test_group_alive_on_eperm(self) -> None:
+        # PermissionError (EPERM) means a process exists we may not signal.
+        with patch(f"{_PC}.os.killpg", side_effect=PermissionError):
+            assert process_group_alive(4321) is True
+
+    def test_generic_oserror_is_dead(self) -> None:
+        with patch(f"{_PC}.os.killpg", side_effect=OSError):
+            assert process_group_alive(4321) is False
+
+    def test_windows_falls_back_to_pid_check(self) -> None:
+        with (
+            patch(f"{_PC}.IS_WINDOWS", True),
+            patch(f"{_PC}.process_alive", return_value=True) as mock_alive,
+        ):
+            assert process_group_alive(4321) is True
+        mock_alive.assert_called_once_with(4321)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_worktree_isolation.py
+++ b/tests/unit/test_worktree_isolation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 from bernstein.core.worktree_isolation import (
@@ -192,3 +193,72 @@ class TestJunctionDetection:
         (worktree_path / "src").mkdir()
         result = validate_worktree_isolation(worktree_path, repo_root)
         assert result.passed
+
+
+# ---------------------------------------------------------------------------
+# Unresolvable links (fail-closed)
+# ---------------------------------------------------------------------------
+
+
+class TestUnresolvableLink:
+    """``Path.resolve()`` can raise (``ELOOP`` symlink cycle, permission error,
+    or a resolver-detected ``RuntimeError``).  ``_resolve_link_target`` must
+    swallow those and return ``None`` so callers record a violation and the
+    spawn aborts through ``create()``'s cleanup path, instead of letting a raw
+    filesystem error escape and leak the worktree + lock (issue #2643).
+    """
+
+    def test_resolve_link_target_returns_none_on_oserror(self) -> None:
+        import bernstein.core.git.worktree_isolation as wi
+
+        fake = MagicMock()
+        fake.resolve.side_effect = OSError("[Errno 62] Too many levels of symbolic links")
+        assert wi._resolve_link_target(fake) is None
+
+    def test_resolve_link_target_returns_none_on_runtime_error(self) -> None:
+        import bernstein.core.git.worktree_isolation as wi
+
+        fake = MagicMock()
+        fake.resolve.side_effect = RuntimeError("Symlink loop")
+        assert wi._resolve_link_target(fake) is None
+
+    def test_resolve_link_target_passes_through_resolved_path(self, tmp_path: Path) -> None:
+        import bernstein.core.git.worktree_isolation as wi
+
+        real = tmp_path / "real"
+        real.mkdir()
+        assert wi._resolve_link_target(real) == real.resolve()
+
+    def test_unresolvable_sdd_link_recorded_as_violation(
+        self,
+        worktree_path: Path,
+        repo_root: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import bernstein.core.git.worktree_isolation as wi
+
+        sdd = worktree_path / ".sdd"
+        sdd.mkdir()
+        monkeypatch.setattr(wi, "is_filesystem_link", lambda p: Path(p) == sdd)
+        monkeypatch.setattr(wi, "_resolve_link_target", lambda _p: None)
+
+        violations = check_sdd_not_shared(worktree_path, repo_root)
+        assert len(violations) == 1
+        assert "could not be resolved" in violations[0].lower()
+
+    def test_unresolvable_symlink_entry_recorded_as_violation(
+        self,
+        worktree_path: Path,
+        repo_root: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import bernstein.core.git.worktree_isolation as wi
+
+        entry = worktree_path / "state"
+        entry.mkdir()
+        monkeypatch.setattr(wi, "is_filesystem_link", lambda p: Path(p) == entry)
+        monkeypatch.setattr(wi, "_resolve_link_target", lambda _p: None)
+
+        violations = check_symlinks_read_only(worktree_path, repo_root)
+        assert len(violations) == 1
+        assert "could not be resolved" in violations[0].lower()


### PR DESCRIPTION
## What
Issue #2643 has 3 acceptance items. Item 1 (audit-chain fork on concurrent reap emissions) was already shipped on main via the cross-process append lock (#2791/#2879) — reported stale with evidence, no code change. Items 2 and 3 were genuine gaps and are now fixed with TDD regressions: (2) reap escalation now probes whole-process-group liveness via os.killpg(pgid,0) instead of the lead PID, so a surviving child after leader exit still gets SIGKILL; (3) _resolve_link_target now catches (OSError, RuntimeError) and returns None, and the isolation callers record a fail-closed violation so an unresolvable link aborts the spawn through create()'s cleanup path instead of escaping as a raw exception. Two commits pushed; no PR opened. The killpg full-tree reap on stop --force and post-hard-stop live scan (deferred to #2874) were left untouched per triage guidance.

Fixes #2643

## Checklist outcome
2 fixed / 1 already shipped on main (verified, no change) / 0 recorded out-of-scope.

- **Concurrent process-reap emissions fork the HMAC audit chain (spawner_core.py:232)** — already-hardened: AuditLog.log() (src/bernstein/core/security/audit.py:873) wraps tail-recovery + append in _chain_append_lock() (audit.py:333), a per-audit-dir fcntl.flock(LOCK_
- **SIGKILL escalation skipped when group leader exits but children survive (platform_compat.py:427)** — fixed: reap_process_group polled and gated escalation on process_alive(pgid) (lead PID only). Added process_group_alive(pgid) in src/bernstein/core/config/platform_com
- **Unguarded path.resolve() in isolation check leaks worktree + lock (worktree_isolation.py:33)** — fixed: _resolve_link_target now returns Path | None, catching (OSError, RuntimeError) around path.resolve() (ELOOP symlink cycle / permission error / resolver loop). c

## Verification
Adversarial review round: **confirmed, 0 critical findings** (red-on-main proven for the substantive items).
Final green (touched files):
- tests/unit/test_platform_process_tree.py -> 28 passed
- tests/unit/test_platform_compat.py + test_platform_win_process_branch.py + test_platform_process_tree.py -> 121 passed
- tests/unit/test_worktree_isolation.py + test_worktree_isolation_windows.py -> 28 passed
- Combined touched (test_platform_process_tree.py + test_platform_compat.py + test_worktree_isolation.py) -> 120 passed
Item 1 evidence: test_audit_adversarial.py -k Concurrent + test_audit_chain_process_reap.py -> 2 passed.
Collection sentinel: uv run pytest tests/unit --co -q -> 37849 tests collected 
