### PR TITLE
feat(observability): close the GenAI-semconv gaps in the OTLP span bridge

### DIFF
--- a/docs/observability/otlp-export.md
+++ b/docs/observability/otlp-export.md
@@ -50,6 +50,14 @@ completion Bernstein records an `otel.projection` audit event binding the
 exported trace - its trace id, span count, and the SHA-256 of the signed
 canonical span set - to the audit chain.
 
+The gRPC exporter is an optional extra. A configured endpoint with the
+package missing would silently drop every span, so `bernstein doctor`
+carries an **OTel export** advisory: it PASSes when the endpoint is unset
+(export off, local tracing active) or when the endpoint is set and the
+extra is importable, and WARNs when `BERNSTEIN_OTEL_ENDPOINT` is set but
+`opentelemetry-exporter-otlp-proto-grpc` is not installed (fix:
+`pip install 'bernstein[otel]'`). The advisory never fails the doctor run.
+
 ### Example collector config
 
 ```yaml

--- a/src/bernstein/cli/commands/doctor_cmd.py
+++ b/src/bernstein/cli/commands/doctor_cmd.py
@@ -637,6 +637,63 @@ def check_spiffe_workload_api() -> dict[str, Any]:
     }
 
 
+def _otlp_exporter_extra_available() -> bool:
+    """Return True when the optional OTLP/gRPC span-exporter extra is importable.
+
+    Mirrors the import the live bridge performs
+    (:meth:`observability.otel_bridge.JournalOTLPBridge._build_otlp_exporter`):
+    a configured endpoint is useless without
+    ``opentelemetry-exporter-otlp-proto-grpc``. Wrapped as a module-level
+    indirection so tests can stub extra presence without uninstalling the SDK.
+    """
+    import importlib.util
+
+    return importlib.util.find_spec("opentelemetry.exporter.otlp.proto.grpc.trace_exporter") is not None
+
+
+def check_otel_export_advisory() -> dict[str, Any]:
+    """Advise on the live OTLP export path when an endpoint is configured (#2526).
+
+    Live export is off by default: with ``BERNSTEIN_OTEL_ENDPOINT`` unset the
+    journal-anchored span projection stays local (``.sdd/traces/``) and nothing
+    is broken, so this reports an informational PASS. With an endpoint
+    configured the optional ``opentelemetry-exporter-otlp-proto-grpc`` package
+    must be importable or every span is silently dropped on the wire path; a
+    configured endpoint with the extra missing is surfaced as a WARN. Advisory
+    only -- it never blocks.
+    """
+    from bernstein.core.observability.otlp_exporter import OTEL_ENDPOINT_ENV
+
+    name = "OTel export"
+    endpoint = os.environ.get(OTEL_ENDPOINT_ENV, "").strip()
+    if not endpoint:
+        return {
+            "name": name,
+            "status": _CHECK_PASS,
+            "detail": f"off ({OTEL_ENDPOINT_ENV} unset); local JSONL tracing active",
+            "fix": "",
+        }
+    if not _otlp_exporter_extra_available():
+        return {
+            "name": name,
+            "status": _CHECK_WARN,
+            "detail": (
+                f"{OTEL_ENDPOINT_ENV} set but opentelemetry-exporter-otlp-proto-grpc "
+                "is missing; journal-anchored spans will not export"
+            ),
+            "fix": "pip install 'bernstein[otel]'",
+        }
+    return {
+        "name": name,
+        "status": _CHECK_PASS,
+        "detail": (
+            f"{OTEL_ENDPOINT_ENV} set and opentelemetry-exporter-otlp-proto-grpc present; "
+            "journal-anchored spans will export"
+        ),
+        "fix": "",
+    }
+
+
 def check_sdd_workspace() -> dict[str, Any]:
     """Check for .sdd/ workspace structure."""
     workdir = Path.cwd()
@@ -870,6 +927,7 @@ def run_all_checks() -> list[dict[str, Any]]:
             check_sdd_workspace(),
             check_schedule_supervisor(),
             check_spiffe_workload_api(),
+            check_otel_export_advisory(),
         )
     )
     return checks

--- a/src/bernstein/cli/commands/status_cmd.py
+++ b/src/bernstein/cli/commands/status_cmd.py
@@ -619,6 +619,28 @@ def _doctor_check_eval_gate_power(checks: list[dict[str, Any]], workdir: Path) -
     _add_check(checks, advisory["name"], True, detail, fix)
 
 
+def _doctor_check_otel_export(checks: list[dict[str, Any]]) -> None:
+    """Surface the live OTLP export advisory (#2526, Phase 4).
+
+    Advisory only: with ``BERNSTEIN_OTEL_ENDPOINT`` set but the optional
+    ``opentelemetry-exporter-otlp-proto-grpc`` extra missing, every
+    journal-anchored span is silently dropped on the wire path. This warns the
+    operator without failing the doctor run (the ci-tools/last-green pattern:
+    WARN rows stay ``ok`` and prefix the detail).
+    """
+    from bernstein.cli.commands.doctor_cmd import check_otel_export_advisory
+
+    row = check_otel_export_advisory()
+    warn = row["status"] == "WARN"
+    _add_check(
+        checks,
+        row["name"],
+        True,
+        f"WARNING: {row['detail']}" if warn else row["detail"],
+        row["fix"],
+    )
+
+
 def _doctor_check_python(checks: list[dict[str, Any]]) -> bool:
     """Check Python version. Returns True if version is adequate."""
     major, minor = sys.version_info.major, sys.version_info.minor
@@ -1099,6 +1121,7 @@ def doctor(as_json: bool, auto_fix: bool) -> None:
     _doctor_check_compliance(checks, workdir)
     _doctor_check_schedule_supervisor(checks, workdir)
     _doctor_check_eval_gate_power(checks, workdir)
+    _doctor_check_otel_export(checks)
 
     if auto_fix:
         _doctor_auto_fix(checks, stale_pid_paths, workdir, fixed, manual_needed)

--- a/tests/unit/test_doctor_otel_export.py
+++ b/tests/unit/test_doctor_otel_export.py
@@ -1,0 +1,56 @@
+"""Doctor advisory for the live OTLP export path (#2526, Phase 4).
+
+Export is off by default: with ``BERNSTEIN_OTEL_ENDPOINT`` unset the check is
+an informational PASS (the local JSONL tracing path is active and nothing is
+broken). With an endpoint configured the check confirms the optional
+``opentelemetry-exporter-otlp-proto-grpc`` extra is importable -- PASS when it
+is, WARN when it is missing, because a configured endpoint with no exporter
+package silently drops every span. The advisory never fails the doctor run.
+"""
+
+from __future__ import annotations
+
+from bernstein.cli.commands import doctor_cmd, status_cmd
+
+
+class TestOtelExportDoctorCheck:
+    def test_endpoint_unset_is_informational_pass(self, monkeypatch) -> None:
+        monkeypatch.delenv("BERNSTEIN_OTEL_ENDPOINT", raising=False)
+        result = doctor_cmd.check_otel_export_advisory()
+        assert result["name"] == "OTel export"
+        assert result["status"] == "PASS"
+        assert result["fix"] == ""
+
+    def test_endpoint_set_extra_present_passes(self, monkeypatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_OTEL_ENDPOINT", "http://otel-collector:4317")
+        monkeypatch.setattr(doctor_cmd, "_otlp_exporter_extra_available", lambda: True)
+        result = doctor_cmd.check_otel_export_advisory()
+        assert result["status"] == "PASS"
+
+    def test_endpoint_set_extra_missing_warns(self, monkeypatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_OTEL_ENDPOINT", "http://otel-collector:4317")
+        monkeypatch.setattr(doctor_cmd, "_otlp_exporter_extra_available", lambda: False)
+        result = doctor_cmd.check_otel_export_advisory()
+        assert result["status"] == "WARN"
+        assert "bernstein[otel]" in result["fix"]
+
+    def test_blank_endpoint_is_treated_as_unset(self, monkeypatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_OTEL_ENDPOINT", "   ")
+        # A blank endpoint means export is off; the missing extra is irrelevant.
+        monkeypatch.setattr(doctor_cmd, "_otlp_exporter_extra_available", lambda: False)
+        result = doctor_cmd.check_otel_export_advisory()
+        assert result["status"] == "PASS"
+
+    def test_check_is_wired_into_run_all_checks(self) -> None:
+        names = {c["name"] for c in doctor_cmd.run_all_checks()}
+        assert "OTel export" in names
+
+    def test_check_is_wired_into_status_doctor(self, monkeypatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_OTEL_ENDPOINT", "http://otel-collector:4317")
+        monkeypatch.setattr(doctor_cmd, "_otlp_exporter_extra_available", lambda: False)
+        checks: list[dict[str, object]] = []
+        status_cmd._doctor_check_otel_export(checks)
+        row = next(c for c in checks if c["name"] == "OTel export")
+        # Advisory only: never fails the doctor run, but the WARN detail stays visible.
+        assert row["ok"] is True
+        assert "WARNING" in str(row["detail"])


### PR DESCRIPTION
## What
Full triage of #2526 (stream chain-anchored GenAI spans over OTLP). Cross-checked every checklist item and acceptance criterion against main. Phases 1-3 and most of Phase 4 already shipped (via #2771 bridge/lifecycle/export-otel backfill and #2827 verify-span, plus the collector example config and docs). The ONE genuine gap was the Phase 4 doctor advisory: a configured BERNSTEIN_OTEL_ENDPOINT with the optional opentelemetry-exporter-otlp-proto-grpc extra missing silently dropped every span with no operator-visible signal. Closed that gap with a TDD "OTel export" doctor advisory. The issue checkboxes for Phase 3 and Phase 4 are stale (unchecked) but the code shipped; only the doctor advisory was actually absent.

Fixes #2526

## Checklist outcome
1 fixed / 11 already shipped on main (verified, no change) / 0 recorded out-of-scope.

- **Phase 1: bridge module mapping ProjectedSpan to OTLP spans with id/attribute preservation + in-memory-receiver** — already-hardened: src/bernstein/core/observability/otel_bridge.py (JournalOTLPBridge, projection_to_readable_spans, _readable_span builds an explicit journal-derived SpanContext,
- **Phase 2: run-lifecycle wiring (incremental flush on journal append) + `bernstein telemetry export-otel --run <** — already-hardened: IncrementalSpanProjector + LiveJournalSpanStream + attach_live_export in otel_bridge.py; wired at orchestrator.py:606. Backfill command telemetry_cmd.py:telemet
- **Phase 3: `bernstein telemetry verify-span` recomputing span identity from journal entry hash and checking chai** — already-hardened: telemetry_cmd.py:telemetry_verify_span + otel_bridge.py verify_exported_span/parse_exported_span; forgery rejected, exit codes 0/1 (genuine/forged|unverifiable)
- **Phase 4: doctor advisory when endpoint configured but optional exporter package missing** — fixed: NEW. Added check_otel_export_advisory() + _otlp_exporter_extra_available() in doctor_cmd.py, _doctor_check_otel_export() wired into the `bernstein doctor` comma
- **Phase 4: collector example config** — already-hardened: deploy/otel-collector/otel-collector-config.yaml (plus deploy/grafana/dashboards/bernstein-otel.json and an inline example in docs).
- **Phase 4: docs** — already-hardened: docs/observability/otlp-export.md and docs/sdd/otel-journal-bridge.md exist. Extended otlp-export.md with the new doctor-advisory preflight note (docs duty for 
- **AC: endpoint-configured run exports spans a stock collector ingests, GenAI layers (workflow/agent/tool/chat) i** — already-hardened: EVENT_TO_OPERATION maps journal events to invoke_workflow/invoke_agent/execute_tool/chat; bridge exports full parent tree. otel_projection.py + otel_bridge.py.
- **AC: every span carries bernstein.journal.entry_hash + audit-chain anchor; verify-span accepts genuine, rejects** — already-hardened: ATTR_JOURNAL_ENTRY_HASH + ATTR_AUDIT_ANCHOR (bernstein.audit.anchor) stamped on every wire span; verify_exported_span recomputes derive_span_id and matches the 
- **AC: determinism on live path (two replays => byte-identical trace/span id trees)** — already-hardened: Ids derived from journal entry hashes; timestamps from journal ts (out of hash chain). Gating property test incremental==batch project_spans in tests/property/t
- **AC: span ids are a deterministic projection of the step_hash chain (no LLM/wall-clock leak); full invoke_agent** — already-hardened: derive_span_id/derive_trace_id are pure hashes; parent state machine emits workflow/agent/tool/chat intermediate spans.
- **AC: default off (no endpoint => zero exporter init + zero network; test asserts)** — already-hardened: build_bridge_from_env returns None before importing any exporter class when BERNSTEIN_OTEL_ENDPOINT is unset; asserted in tests/unit/test_otel_bridge.py.
- **AC: offline projection artifact + otel.projection audit event remain byte-compatible** — already-hardened: Bridge only consumes project_spans output; canonical_projection_bytes / _signing_payload_dict untouched; record_projection_audit_event reuses the same signing p

## Verification
Adversarial review round: **confirmed, 0 critical findings** (red-on-main proven for the substantive items).
TDD red (before fix): `uv run pytest tests/unit/test_doctor_otel_export.py -q` => 6 failed (AttributeError: module doctor_cmd has no attribute _otlp_exporter_extra_available / check_otel_export_advisory). Green (after fix): 6 passed. Touched files re-run: test_doctor_otel_export.py + test_doctor_cmd.py + test_doctor.py + test_doctor_spiffe.py => 34 passed. Property: tests/property/test_doctor_properties.py => 10 passed. Collection sentinel: tests/unit --co -q => 37843 collected. No full-suite run performed (per constraints).
