### PR TITLE
feat(cli): operator-surface follow-ups from the 3.8.2 UX sweep

### DIFF
--- a/docs/operations/cluster-mode.md
+++ b/docs/operations/cluster-mode.md
@@ -228,6 +228,34 @@ without crashing (`worker_cmd.py:230-258`); the task is left unclaimed.
 
 ## Observability for cluster health
 
+### Topology at a glance: `bernstein cluster status` / `nodes`
+
+Two CLI subcommands render the registry without hand-rolling `curl`:
+
+```console
+$ bernstein cluster status
+Cluster  topology=star  nodes=2/3 online
+capacity: 4 active / 8 free / 18 total slots
+                              Cluster Nodes
+ Node ID       Name    Status   Adapter   Heartbeat   Claimed   Slots
+ node-alpha    alpha   online   codex     4s                2     4/6
+ node-bravo    bravo   online   claude    11s               2     4/6
+ node-charlie  charlie offline  gemini    never             0     6/6
+
+$ bernstein cluster nodes            # node table only
+$ bernstein cluster nodes --json-output
+```
+
+- **Heartbeat** is the age since the node's last heartbeat (`never` for a
+  persisted-but-not-yet-rejoined node).
+- **Claimed** is the node's self-reported `active_agents` - the tasks it has
+  claimed and is actively running.
+- **Adapter** comes from the node's advertised `adapter` label (workers set it
+  from their configured adapter; `-` when unset).
+- Both accept `--server-url` (default `BERNSTEIN_SERVER_URL`) and
+  `--json-output`. They read the endpoints below, so a stopped server prints a
+  clear "cannot connect" hint instead of a stack trace.
+
 Endpoints relevant to cluster operations:
 
 - `GET /cluster/nodes[?status=online|cordoned|draining|offline]` - full

--- a/docs/operations/commands.md
+++ b/docs/operations/commands.md
@@ -45,6 +45,8 @@ For session monitoring commands (`live`, `dashboard`, `status`, `ps`, `cost`, `d
 | `bernstein identity show` / `decode` / `verify` / `disable` | Operator-side helpers for the install-rev fingerprint embedded in shared yaml/trace/role-prompt artefacts. |
 | `bernstein security role-adapter-policy` | Inspects and edits the per-role adapter allow-list (deny-list enforcement at spawn time). |
 | `bernstein run-lookup NAME` | Resolve a memorable run name back to its run UUID; exits non-zero when the name is malformed or unknown. Example: `bernstein run-lookup brave-otter-1234`. |
+| `bernstein stop [--force]` | Graceful drain (soft stop) by default. `--force`/`--hard` SIGKILLs everything immediately, then reaps whole process groups so a re-parented grandchild (disowned heartbeat/curl loops) dies with its leader; the summary counts only PIDs confirmed terminated. |
+| `bernstein cluster status` / `bernstein cluster nodes` | Render the node registry as a table (id, adapter, heartbeat age, claimed tasks). `status` adds the topology summary line. Both take `--json-output` and `--server-url`. See [cluster-mode.md](cluster-mode.md). |
 
 ## Monitoring
 
@@ -52,7 +54,7 @@ For session monitoring commands (`live`, `dashboard`, `status`, `ps`, `cost`, `d
 bernstein live       # TUI dashboard
 bernstein dashboard  # web dashboard
 bernstein status     # task summary
-bernstein ps         # running agents
+bernstein ps         # running agents (PID files + a live process-table cross-check, so it still lists survivors after stop --force removed the PID files)
 bernstein cost       # spend by model/task
 bernstein doctor     # pre-flight checks
 bernstein recap      # post-run summary

--- a/src/bernstein/cli/commands/cluster_cmd.py
+++ b/src/bernstein/cli/commands/cluster_cmd.py
@@ -1,18 +1,21 @@
-"""``bernstein cluster``: cluster lifecycle helpers (mTLS bootstrap, etc.)."""
+"""``bernstein cluster``: cluster lifecycle helpers (mTLS bootstrap, topology)."""
 
 from __future__ import annotations
 
 import datetime
 import os
+import time
 from pathlib import Path
+from typing import Any
 
 import click
+import httpx
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
 
-from bernstein.cli.helpers import console
+from bernstein.cli.helpers import SERVER_URL, auth_headers, console, is_json, print_json
 
 DEFAULT_CLUSTER_DIR = Path.home() / ".bernstein" / "cluster"
 KEY_SIZE = 4096
@@ -259,3 +262,134 @@ def bootstrap_ca(
         "[yellow]Warning:[/yellow] this is a self-signed CA suitable for internal clusters only. "
         "For production, use your own CA / step-ca / cert-manager."
     )
+
+
+# ---------------------------------------------------------------------------
+# cluster status / nodes - topology visibility (issue #2874)
+# ---------------------------------------------------------------------------
+
+
+def _format_heartbeat_age(last_heartbeat: float, now: float) -> str:
+    """Render heartbeat staleness as a compact age string.
+
+    ``never`` when the node has not heartbeated (persisted-but-offline nodes
+    load with ``last_heartbeat == 0``); otherwise seconds/minutes/hours since
+    the last heartbeat was received.
+    """
+    if not last_heartbeat or last_heartbeat <= 0:
+        return "never"
+    age = max(0, int(now - last_heartbeat))
+    if age < 60:
+        return f"{age}s"
+    if age < 3600:
+        return f"{age // 60}m {age % 60}s"
+    hours, remainder = divmod(age, 3600)
+    return f"{hours}h {remainder // 60}m"
+
+
+def _node_display_fields(node: dict[str, Any], now: float) -> dict[str, str]:
+    """Project a cluster-status node dict into rendered table cells.
+
+    ``claimed`` is the node's self-reported ``active_agents`` - the count of
+    tasks it has claimed and is actively running (see the worker heartbeat).
+    ``adapter`` comes from the node's advertised labels, falling back to ``-``.
+    """
+    capacity = node.get("capacity", {}) or {}
+    labels = node.get("labels", {}) or {}
+    try:
+        last_heartbeat = float(node.get("last_heartbeat") or 0.0)
+    except (TypeError, ValueError):
+        last_heartbeat = 0.0
+    return {
+        "id": str(node.get("id", "")),
+        "name": str(node.get("name", "")) or "-",
+        "status": str(node.get("status", "")),
+        "adapter": str(labels.get("adapter") or "-"),
+        "heartbeat": _format_heartbeat_age(last_heartbeat, now),
+        "claimed": str(int(capacity.get("active_agents", 0) or 0)),
+        "slots": f"{int(capacity.get('available_slots', 0) or 0)}/{int(capacity.get('max_agents', 0) or 0)}",
+    }
+
+
+def _fetch_cluster_status(server_url: str) -> dict[str, Any]:
+    """Fetch the cluster status summary from the running task server."""
+    try:
+        resp = httpx.get(f"{server_url}/cluster/status", timeout=5.0, headers=auth_headers())
+        resp.raise_for_status()
+    except httpx.ConnectError:
+        console.print("[red]Cannot connect to task server.[/red]")
+        console.print(f"[dim]Is it running at {server_url}?[/dim]")
+        raise SystemExit(1) from None
+    except httpx.HTTPStatusError as exc:
+        console.print(f"[red]Server error:[/red] {exc.response.status_code}")
+        raise SystemExit(1) from None
+    data = resp.json()
+    if not isinstance(data, dict):
+        console.print("[red]Unexpected response format from server.[/red]")
+        raise SystemExit(1)
+    return data
+
+
+def _render_nodes_table(nodes: list[dict[str, Any]], now: float) -> None:
+    """Render the registered-node table, or a hint when the registry is empty."""
+    if not nodes:
+        console.print("[dim]No nodes registered.[/dim]")
+        return
+    from rich.table import Table
+
+    table = Table(title="Cluster Nodes", show_lines=False, header_style="bold cyan")
+    table.add_column("Node ID", style="dim", min_width=12)
+    table.add_column("Name", min_width=8)
+    table.add_column("Status", min_width=8)
+    table.add_column("Adapter", min_width=8)
+    table.add_column("Heartbeat", justify="right")
+    table.add_column("Claimed", justify="right")
+    table.add_column("Slots", justify="right")
+    for node in nodes:
+        fields = _node_display_fields(node, now)
+        status = fields["status"]
+        status_style = "green" if status == "online" else "yellow" if status != "offline" else "dim"
+        table.add_row(
+            fields["id"],
+            fields["name"],
+            f"[{status_style}]{status}[/{status_style}]",
+            fields["adapter"],
+            fields["heartbeat"],
+            fields["claimed"],
+            fields["slots"],
+        )
+    console.print(table)
+
+
+@cluster_group.command("nodes")
+@click.option("--json-output", "as_json", is_flag=True, help="Output as JSON instead of a table.")
+@click.option("--server-url", "server_url", default=None, help="Central server URL (default: BERNSTEIN_SERVER_URL).")
+def cluster_nodes(as_json: bool, server_url: str | None) -> None:
+    """List registered cluster nodes with heartbeat age and claimed-task counts."""
+    data = _fetch_cluster_status(server_url or SERVER_URL)
+    nodes = data.get("nodes", []) if isinstance(data.get("nodes"), list) else []
+    if as_json or is_json():
+        print_json(nodes)
+        return
+    _render_nodes_table(nodes, time.time())
+
+
+@cluster_group.command("status")
+@click.option("--json-output", "as_json", is_flag=True, help="Output as JSON instead of a table.")
+@click.option("--server-url", "server_url", default=None, help="Central server URL (default: BERNSTEIN_SERVER_URL).")
+def cluster_status_cmd(as_json: bool, server_url: str | None) -> None:
+    """Show cluster topology: online/offline counts and the node table."""
+    data = _fetch_cluster_status(server_url or SERVER_URL)
+    if as_json or is_json():
+        print_json(data)
+        return
+    console.print(
+        f"[bold]Cluster[/bold]  topology={data.get('topology', '?')}  "
+        f"nodes={data.get('online_nodes', 0)}/{data.get('total_nodes', 0)} online"
+    )
+    console.print(
+        f"[dim]capacity: {data.get('active_agents', 0)} active / "
+        f"{data.get('available_slots', 0)} free / {data.get('total_capacity', 0)} total slots[/dim]"
+    )
+    nodes = data.get("nodes", []) if isinstance(data.get("nodes"), list) else []
+    _render_nodes_table(nodes, time.time())

--- a/src/bernstein/cli/commands/status_cmd.py
+++ b/src/bernstein/cli/commands/status_cmd.py
@@ -24,6 +24,7 @@ from bernstein.cli.helpers import (
 from bernstein.cli.status import collect_rate_limit_snapshots, render_status
 from bernstein.cli.ui import make_console
 from bernstein.core.agent_discovery import AgentCapabilities, DiscoveryResult, discover_agents_cached
+from bernstein.core.process_utils import list_command_lines, process_cwd
 from bernstein.tui.worker_badges import format_worker_badge, get_badge_for_worker
 
 logger = logging.getLogger(__name__)
@@ -312,6 +313,85 @@ def _collect_pid_agents(pid_path: Path) -> tuple[list[dict[str, Any]], list[Path
     return agents, stale_files
 
 
+def _ps_scan_workdir(pid_path: Path) -> Path:
+    """Resolve the project root for the live scan from the PID directory.
+
+    ``ps`` matches processes by their absolute ``.sdd`` path prefixes, so the
+    scan needs the absolute project root. The default PID directory is
+    ``<project>/.sdd/runtime/pids``; when the layout matches we walk up to the
+    project root, otherwise we fall back to the current working directory.
+    """
+    resolved = pid_path.resolve()
+    if resolved.name == "pids" and resolved.parent.name == "runtime" and resolved.parent.parent.name == ".sdd":
+        return resolved.parent.parent.parent
+    return Path.cwd()
+
+
+def _classify_live_process(
+    pid: int, command: str, workdir: Path, worktree_prefix: str, heartbeat_prefix: str
+) -> str | None:
+    """Return the role of a repo-owned process, or ``None`` when unrelated.
+
+    Agents are matched by worktree/heartbeat path markers alone; the
+    orchestrator, server, and watchdog must additionally run with a cwd inside
+    this project so a sibling checkout's server is never attributed here.
+    """
+    if worktree_prefix in command or heartbeat_prefix in command:
+        return "agent"
+    is_watchdog = "bernstein.core.orchestration.bootstrap" in command and "--watchdog" in command
+    is_spawner = "bernstein.core.orchestrator" in command
+    is_server = "uvicorn bernstein.core.server:app" in command
+    if not (is_watchdog or is_spawner or is_server):
+        return None
+    if process_cwd(pid) != workdir:
+        return None
+    if is_watchdog:
+        return "watchdog"
+    if is_spawner:
+        return "spawner"
+    return "server"
+
+
+def _scan_live_agent_rows(workdir: Path, known_pids: set[int]) -> list[dict[str, Any]]:
+    """Cross-check the OS process table for live repo-owned processes.
+
+    PID files are the primary source, but ``hard_stop`` deletes them; this scan
+    keeps ``ps`` honest by surfacing the orchestrator, server, watchdog, and
+    agent processes that are still alive after the files are gone (#2874). PIDs
+    already covered by a PID-file row are skipped. Each candidate's liveness is
+    re-probed so a process that exited between the ``ps`` snapshot and now is
+    dropped rather than reported as a phantom.
+    """
+    worktree_prefix = str(workdir / ".sdd" / "worktrees")
+    heartbeat_prefix = str(workdir / ".sdd" / "runtime" / "heartbeats")
+    self_pid = os.getpid()
+    seen = set(known_pids)
+    rows: list[dict[str, Any]] = []
+    for pid, command in list_command_lines():
+        if pid in seen or pid == self_pid:
+            continue
+        role = _classify_live_process(pid, command, workdir, worktree_prefix, heartbeat_prefix)
+        if role is None:
+            continue
+        # Race guard: the pid was in the ps snapshot but may have exited since.
+        if not is_process_alive(pid):
+            continue
+        seen.add(pid)
+        rows.append(
+            {
+                "session": f"{role}:{pid}",
+                "role": role,
+                "command": "-",
+                "model": "-",
+                "worker_pid": pid,
+                "child_pid": None,
+                "runtime": "-",
+                "source": "scan",
+            }
+        )
+    return rows
+
+
 @click.command("ps")
 @click.option("--json-output", "as_json", is_flag=True, help="Output as JSON instead of table.")
 @click.option("--pid-dir", default=".sdd/runtime/pids", help="PID metadata directory.")
@@ -333,6 +413,17 @@ def ps_cmd(as_json: bool, pid_dir: str) -> None:
             agents.append(remote)
 
     _decorate_agent_rows(agents)
+
+    # Live process-table cross-check: surface repo-owned processes that outlived
+    # their PID files (e.g. after ``bernstein stop --force``) so ``ps`` never
+    # goes blind while the orchestrator or an agent is still running (#2874).
+    known_pids: set[int] = set()
+    for agent in agents:
+        for key in ("worker_pid", "child_pid"):
+            value = agent.get(key)
+            if isinstance(value, int) and value > 0:
+                known_pids.add(value)
+    agents.extend(_scan_live_agent_rows(_ps_scan_workdir(pid_path), known_pids))
 
     from bernstein.core.agents.spawn_supervisor import get_supervisor
 

--- a/src/bernstein/cli/commands/stop_cmd.py
+++ b/src/bernstein/cli/commands/stop_cmd.py
@@ -12,7 +12,10 @@ import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 import click
 
@@ -529,19 +532,23 @@ def _list_process_snapshots_unix() -> list[_ProcessSnapshot]:
     return snapshots
 
 
-def _classify_and_kill_process(
+def _classify_repo_process(
     snapshot: Any,
     workdir: Path,
     heartbeat_prefix: str,
     worktree_prefix: str,
-    killed: set[int],
-) -> None:
-    """Classify a process snapshot and kill it if it belongs to this repo."""
+) -> tuple[str, str] | None:
+    """Return ``(kind, label)`` for a repo-owned process, else ``None``.
+
+    ``kind`` is ``"agent"`` for orphaned worktree/heartbeat processes (matched
+    purely by command-line marker, no cwd probe) or ``"infra"`` for the
+    orchestrator/server/watchdog - which must additionally run with a cwd
+    inside this project, so a sibling checkout's server is never touched.
+    """
     command = snapshot.command
 
     if heartbeat_prefix in command or worktree_prefix in command:
-        _kill_agent_pid(snapshot.pid, f"orphan-{snapshot.pid}", killed)
-        return
+        return "agent", f"orphan-{snapshot.pid}"
 
     # Matches the launcher argv in ``_start_watchdog`` (issue #2795): the watchdog
     # runs as ``python -m bernstein.core.orchestration.bootstrap --watchdog``.
@@ -550,17 +557,84 @@ def _classify_and_kill_process(
     is_server = "uvicorn bernstein.core.server:app" in command
 
     if not (is_watchdog or is_orchestrator or is_server):
-        return
+        return None
 
     if process_cwd(snapshot.pid) != workdir:
-        return
+        return None
 
     if is_watchdog:
-        _kill_named_pid(snapshot.pid, "Watchdog", killed)
-    elif is_orchestrator:
-        _kill_named_pid(snapshot.pid, "Spawner", killed)
+        return "infra", "Watchdog"
+    if is_orchestrator:
+        return "infra", "Spawner"
+    return "infra", _LABEL_TASK_SERVER
+
+
+def _classify_and_kill_process(
+    snapshot: Any,
+    workdir: Path,
+    heartbeat_prefix: str,
+    worktree_prefix: str,
+    killed: set[int],
+) -> None:
+    """Classify a process snapshot and kill it if it belongs to this repo."""
+    classified = _classify_repo_process(snapshot, workdir, heartbeat_prefix, worktree_prefix)
+    if classified is None:
+        return
+    kind, label = classified
+    if kind == "agent":
+        _kill_agent_pid(snapshot.pid, label, killed)
     else:
-        _kill_named_pid(snapshot.pid, _LABEL_TASK_SERVER, killed)
+        _kill_named_pid(snapshot.pid, label, killed)
+
+
+def _reap_process_group(pgid: int, killed: set[int], member_pids: Iterable[int] = ()) -> None:
+    """SIGKILL an entire process group, guarding against pgid reuse.
+
+    Never signals ``pgid <= 0`` (which would broadcast to the caller's whole
+    session/group) or the caller's own group. Only groups whose *leader* we
+    positively identified as repo-owned reach here. ``member_pids`` are recorded
+    in *killed* so the post-sweep summary counts only PIDs later confirmed
+    terminated (see :func:`_count_reaped`) rather than every PID we signalled.
+    """
+    if not hasattr(os, "killpg"):
+        return
+    my_pgid = os.getpgrp() if hasattr(os, "getpgrp") else -1
+    if pgid <= 0 or pgid == my_pgid:
+        return
+    with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+        # pgid anchors on a leader we already classified as ours (Sonar S4828).
+        os.killpg(pgid, signal.SIGKILL)  # NOSONAR python:S4828
+    for pid in member_pids:
+        if pid > 0:
+            killed.add(pid)
+
+
+def _reap_repo_process_groups(killed: set[int]) -> None:
+    """Reap surviving process *groups* owned by this repo (issue #2874).
+
+    Per-PID kills miss a grandchild a worker re-parented into its own process
+    group (e.g. a disowned ``while true; curl`` heartbeat loop). This sweep
+    ``os.killpg``s each group whose *leader* (``pid == pgid``) we positively
+    identify as repo-owned, so a detached grandchild dies with its group.
+    Anchoring only on a group leader keeps the target reuse-safe: the pgid
+    cannot have been recycled by an unrelated group while its original leader
+    is still present in the same scan.
+    """
+    if sys.platform == "win32" or not hasattr(os, "killpg"):
+        return
+    workdir = Path.cwd()
+    heartbeat_prefix = str(workdir / ".sdd" / "runtime" / "heartbeats")
+    worktree_prefix = str(workdir / ".sdd" / "worktrees")
+    snapshots = _list_process_snapshots()
+    members: dict[int, list[int]] = {}
+    for snapshot in snapshots:
+        members.setdefault(snapshot.pgid, []).append(snapshot.pid)
+    for snapshot in snapshots:
+        if snapshot.pid != snapshot.pgid:
+            continue  # anchor only on the group leader (reuse-safe)
+        if _classify_repo_process(snapshot, workdir, heartbeat_prefix, worktree_prefix) is None:
+            continue
+        _reap_process_group(snapshot.pgid, killed, members.get(snapshot.pgid, ()))
 
 
 def _collect_repo_processes(killed: set[int]) -> None:
@@ -706,6 +780,9 @@ def hard_stop() -> None:
     _collect_pids_from_agents_json(killed_pids)
     _collect_pids_from_metadata(killed_pids)
     _collect_repo_processes(killed_pids)
+    # Reap whole process groups so a grandchild re-parented into its own group
+    # (disowned heartbeat/curl loops) dies with its leader (#2874).
+    _reap_repo_process_groups(killed_pids)
 
     # 4. Verification sweep - re-scan and retry anything still alive
     time.sleep(0.1)

--- a/src/bernstein/cli/commands/worker_cmd.py
+++ b/src/bernstein/cli/commands/worker_cmd.py
@@ -111,6 +111,10 @@ class WorkerLoop:
         self._pool_hash = pool_hash
         self._enrolment_keyid: str | None = None
         self._adapter_name = adapter or _detect_worker_adapter()
+        # Advertise the adapter as a node label so the cluster topology view
+        # (``bernstein cluster nodes``) can show which agent backend each node
+        # runs (#2874). An operator-supplied ``adapter`` label still wins.
+        self._labels.setdefault("adapter", self._adapter_name)
         # An adapter passed explicitly to the worker is an operator pin and
         # must not be overridden by model-name inference at spawn time
         # (#2751); an auto-detected adapter is not a pin.

--- a/src/bernstein/core/config/home.py
+++ b/src/bernstein/core/config/home.py
@@ -57,7 +57,7 @@ effort: max
 model: null
 """
 
-ConfigSource = Literal["session", "project", "context", "global", "default"]
+ConfigSource = Literal["seed", "session", "project", "context", "global", "default"]
 
 
 class ConfigProvenanceLayer(TypedDict):
@@ -92,8 +92,11 @@ _ALLOWED_SOURCE_POLICIES: dict[str, tuple[ConfigSource, ...]] = {
     # Security-sensitive keys must not be set via session/env overrides alone.
     # A named operating context (#2550) is an audit-chained, attested source
     # that sits between project and global, so it joins the allowlist.
-    "budget": ("project", "context", "global", "default"),
-    "max_agents": ("project", "context", "global", "default"),
+    # The run seed (``bernstein.yaml``, the committed run manifest) is the
+    # value the orchestrator actually enforces at runtime, so it is a
+    # legitimate source on par with the project layer (#2874).
+    "budget": ("seed", "project", "context", "global", "default"),
+    "max_agents": ("seed", "project", "context", "global", "default"),
 }
 
 
@@ -401,20 +404,33 @@ def resolve_config(
     home: BernsteinHome,
     project_dir: Path,
     session_overrides: Mapping[str, object] | None = None,
+    seed_overrides: Mapping[str, object] | None = None,
+    seed_overrides_path: str | None = None,
 ) -> ConfigResolution:
     """Resolve the effective value for *key* across all config layers.
 
     Precedence (highest first):
-    1. Session-only overrides (environment or caller-provided)
-    2. ``<project>/.sdd/config.yaml``
-    3. ``~/.bernstein/config.yaml``
-    4. Built-in defaults
+    1. Run seed overrides (``bernstein.yaml``, the value the orchestrator
+       actually enforces at runtime - see ``seed_overrides``)
+    2. Session-only overrides (environment or caller-provided)
+    3. ``<project>/.sdd/config.yaml``
+    4. ``~/.bernstein/config.yaml``
+    5. Built-in defaults
 
     Args:
         key: Config key to look up.
         home: BernsteinHome instance (global config).
         project_dir: Project root for loading ``.sdd/config.yaml``.
         session_overrides: Optional session-only overrides.
+        seed_overrides: Optional run-seed effective values. The seed
+            (``bernstein.yaml``) is not read by the low-level file resolver,
+            yet it is the value the orchestrator caps concurrency and spend
+            with. Threading it here as the top-precedence ``seed`` layer keeps
+            surfaces such as the dashboard capacity denominator honest for
+            seed-configured runs (#2874). A key absent from this mapping is
+            resolved exactly as before.
+        seed_overrides_path: Filesystem path recorded on the injected ``seed``
+            layer (the resolved seed file), or ``None`` when unknown.
 
     Returns:
         Typed mapping with the effective ``value``, winning ``source``, and the
@@ -426,6 +442,16 @@ def resolve_config(
     combined_session_overrides = _session_overrides_from_env() | dict(session_overrides or {})
 
     layers: list[ConfigProvenanceLayer] = []
+    if seed_overrides is not None and key in seed_overrides:
+        value = _coerce_config_value(key, seed_overrides[key])
+        layers.append(
+            {
+                "source": "seed",
+                "value": value,
+                "redacted_value": _redact_config_value(key, value),
+                "path": seed_overrides_path,
+            }
+        )
     if key in combined_session_overrides:
         value = _coerce_config_value(key, combined_session_overrides[key])
         layers.append(
@@ -491,8 +517,15 @@ def resolve_config_bundle(
     project_dir: Path,
     keys: tuple[str, ...] | None = None,
     session_overrides: Mapping[str, object] | None = None,
+    seed_overrides: Mapping[str, object] | None = None,
+    seed_overrides_path: str | None = None,
 ) -> dict[str, ConfigResolution]:
-    """Resolve a stable bundle of config keys with provenance."""
+    """Resolve a stable bundle of config keys with provenance.
+
+    ``seed_overrides`` threads the run seed's effective values (see
+    :func:`resolve_config`) so the bundle reflects what the orchestrator
+    actually enforces for seed-configured runs (#2874).
+    """
     target_keys = keys or tuple(sorted(_DEFAULTS))
     return {
         key: resolve_config(
@@ -500,6 +533,8 @@ def resolve_config_bundle(
             home=home,
             project_dir=project_dir,
             session_overrides=session_overrides,
+            seed_overrides=seed_overrides,
+            seed_overrides_path=seed_overrides_path,
         )
         for key in target_keys
     }

--- a/src/bernstein/core/orchestration/process_utils.py
+++ b/src/bernstein/core/orchestration/process_utils.py
@@ -50,6 +50,42 @@ def is_process_alive(pid: int) -> bool:
     return not (state is not None and state.startswith("Z"))
 
 
+def list_command_lines() -> list[tuple[int, str]]:
+    """Best-effort ``(pid, command)`` snapshot of local processes.
+
+    Returns an empty list on Windows (no ``ps``) or when the probe fails, so
+    callers degrade to whatever other signal they have. Used as a live
+    cross-check so process-visibility surfaces can still report running
+    processes after their PID files were deleted (issue #2874).
+    """
+    if IS_WINDOWS:
+        return []
+    try:
+        result = subprocess.run(
+            ["ps", "-ax", "-o", "pid=,command="],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    if result.returncode != 0:
+        return []
+    out: list[tuple[int, str]] = []
+    for raw in result.stdout.splitlines():
+        parts = raw.strip().split(maxsplit=1)
+        if len(parts) != 2:
+            continue
+        try:
+            out.append((int(parts[0]), parts[1]))
+        except ValueError:
+            continue
+    return out
+
+
 def process_cwd(pid: int) -> Path | None:
     """Return the current working directory for *pid* when available."""
     if pid <= 0:

--- a/src/bernstein/core/routes/status_dashboard.py
+++ b/src/bernstein/core/routes/status_dashboard.py
@@ -180,6 +180,32 @@ def _safe_call(label: str, fn: Any, default: Any) -> Any:
         return default
 
 
+def _seed_config_overrides(
+    request: Request, config_state: dict[str, Any] | None
+) -> tuple[dict[str, object], str | None]:
+    """Extract the run seed's effective config values for provenance threading.
+
+    Returns ``(overrides, seed_path)`` where *overrides* maps config keys to
+    the values the server's loaded seed (``app.state.seed_config``) enforces.
+    Empty when no seed is loaded, so the resolver falls back to the file-based
+    chain byte-for-byte as before (#2874). ``budget`` is only threaded when the
+    seed actually sets it (``budget_usd is not None``); an unset seed budget
+    must not shadow a project/global budget layer.
+    """
+    seed_config = getattr(request.app.state, "seed_config", None)
+    if seed_config is None:
+        return {}, None
+    overrides: dict[str, object] = {}
+    max_agents = getattr(seed_config, "max_agents", None)
+    if isinstance(max_agents, int):
+        overrides["max_agents"] = max_agents
+    budget_usd = getattr(seed_config, "budget_usd", None)
+    if budget_usd is not None:
+        overrides["budget"] = budget_usd
+    seed_path = config_state.get("seed_path") if config_state else None
+    return overrides, seed_path if isinstance(seed_path, str) else None
+
+
 def _runtime_summary(request: Request, store: TaskStore) -> dict[str, Any]:
     """Build runtime operational metadata for status and TUI consumers.
 
@@ -213,6 +239,13 @@ def _runtime_summary(request: Request, store: TaskStore) -> dict[str, Any]:
         disk_usage_bytes = _safe_call("disk_usage_bytes", lambda: directory_size_bytes(sdd_dir), 0)
         config_state = _safe_call("config_state", lambda: read_config_state(sdd_dir), None)
 
+    # The run seed (``bernstein.yaml``) is the value the orchestrator caps
+    # concurrency and spend with, but the file resolver only reads
+    # ``.sdd/config.yaml``. Thread the seed the server loaded at bootstrap so
+    # the dashboard capacity denominator is honest for seed-configured runs
+    # (#2874) rather than falling back to the built-in default of 6.
+    seed_overrides, seed_overrides_path = _seed_config_overrides(request, config_state)
+
     _runtime_cache = {
         "git_branch": _safe_call("git_branch", lambda: current_git_branch(workdir), ""),
         "restart_count": restart_count,
@@ -231,6 +264,8 @@ def _runtime_summary(request: Request, store: TaskStore) -> dict[str, Any]:
                 home=BernsteinHome.default(),
                 project_dir=workdir,
                 keys=_STATUS_CONFIG_KEYS,
+                seed_overrides=seed_overrides or None,
+                seed_overrides_path=seed_overrides_path,
             ),
             {},
         ),

--- a/tests/unit/cli/test_cluster_status_cmd.py
+++ b/tests/unit/cli/test_cluster_status_cmd.py
@@ -1,0 +1,179 @@
+"""``bernstein cluster status`` / ``nodes`` topology view (issue #2874).
+
+A first-class operator surface for the node registry: which nodes are
+registered, how stale their heartbeats are, and how many tasks each is
+working. The commands query the running server's ``/cluster/status`` endpoint
+and render a node table (id, adapter, heartbeat age, claimed tasks).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+from click.testing import CliRunner
+
+from bernstein.cli.commands import cluster_cmd
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict[str, Any], status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("error", request=httpx.Request("GET", "http://x"), response=self)  # type: ignore[arg-type]
+
+
+_STATUS_PAYLOAD: dict[str, Any] = {
+    "topology": "star",
+    "total_nodes": 2,
+    "online_nodes": 1,
+    "offline_nodes": 1,
+    "total_capacity": 6,
+    "available_slots": 4,
+    "active_agents": 2,
+    "nodes": [
+        {
+            "id": "node-alpha",
+            "name": "alpha",
+            "url": "",
+            "status": "online",
+            "capacity": {
+                "max_agents": 6,
+                "available_slots": 4,
+                "active_agents": 2,
+                "gpu_available": False,
+                "supported_models": ["sonnet"],
+            },
+            "last_heartbeat": 0.0,  # overwritten per-test relative to now
+            "registered_at": 0.0,
+            "labels": {"adapter": "codex"},
+            "cell_ids": [],
+        },
+        {
+            "id": "node-bravo",
+            "name": "bravo",
+            "url": "",
+            "status": "offline",
+            "capacity": {
+                "max_agents": 6,
+                "available_slots": 6,
+                "active_agents": 0,
+                "gpu_available": False,
+                "supported_models": ["opus"],
+            },
+            "last_heartbeat": 0.0,
+            "registered_at": 0.0,
+            "labels": {},
+            "cell_ids": [],
+        },
+    ],
+}
+
+
+class TestFormatHeartbeatAge:
+    def test_never(self) -> None:
+        assert cluster_cmd._format_heartbeat_age(0.0, now=1000.0) == "never"
+
+    def test_seconds(self) -> None:
+        assert cluster_cmd._format_heartbeat_age(990.0, now=1000.0) == "10s"
+
+    def test_minutes(self) -> None:
+        assert cluster_cmd._format_heartbeat_age(880.0, now=1000.0) == "2m 0s"
+
+    def test_hours(self) -> None:
+        assert cluster_cmd._format_heartbeat_age(0.0 + 100.0, now=100.0 + 3 * 3600 + 120) == "3h 2m"
+
+
+class TestNodeDisplayFields:
+    def test_adapter_and_claimed_from_registry(self) -> None:
+        node = {**_STATUS_PAYLOAD["nodes"][0], "last_heartbeat": 1000.0}
+        fields = cluster_cmd._node_display_fields(node, now=1005.0)
+        assert fields["id"] == "node-alpha"
+        assert fields["adapter"] == "codex"
+        assert fields["claimed"] == "2"
+        assert fields["slots"] == "4/6"
+        assert fields["heartbeat"] == "5s"
+
+    def test_missing_adapter_label_shows_dash(self) -> None:
+        # An offline node that never heartbeated renders "never".
+        node = _STATUS_PAYLOAD["nodes"][1]
+        fields = cluster_cmd._node_display_fields(node, now=1000.0)
+        assert fields["adapter"] == "-"
+        assert fields["claimed"] == "0"
+        assert fields["heartbeat"] == "never"
+
+
+def _patch_fetch(monkeypatch: Any, payload: dict[str, Any]) -> None:
+    def _fake_get(url: str, **_kwargs: Any) -> _FakeResponse:
+        assert url.endswith("/cluster/status")
+        return _FakeResponse(payload)
+
+    monkeypatch.setattr(cluster_cmd.httpx, "get", _fake_get)
+
+
+class TestClusterNodesCommand:
+    def test_renders_node_table(self, monkeypatch: Any) -> None:
+        _patch_fetch(monkeypatch, _STATUS_PAYLOAD)
+        result = CliRunner().invoke(cluster_cmd.cluster_group, ["nodes"])
+        assert result.exit_code == 0, result.output
+        assert "node-alpha" in result.output
+        assert "codex" in result.output
+        # Claimed-task count (active_agents) surfaces.
+        assert "2" in result.output
+
+    def test_json_output_lists_nodes(self, monkeypatch: Any) -> None:
+        _patch_fetch(monkeypatch, _STATUS_PAYLOAD)
+        result = CliRunner().invoke(cluster_cmd.cluster_group, ["nodes", "--json-output"])
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert [n["id"] for n in parsed] == ["node-alpha", "node-bravo"]
+
+    def test_empty_registry_message(self, monkeypatch: Any) -> None:
+        empty = {**_STATUS_PAYLOAD, "nodes": [], "total_nodes": 0, "online_nodes": 0}
+        _patch_fetch(monkeypatch, empty)
+        result = CliRunner().invoke(cluster_cmd.cluster_group, ["nodes"])
+        assert result.exit_code == 0, result.output
+        assert "No nodes registered" in result.output
+
+
+class TestClusterStatusCommand:
+    def test_renders_summary_and_nodes(self, monkeypatch: Any) -> None:
+        _patch_fetch(monkeypatch, _STATUS_PAYLOAD)
+        result = CliRunner().invoke(cluster_cmd.cluster_group, ["status"])
+        assert result.exit_code == 0, result.output
+        assert "star" in result.output
+        assert "node-alpha" in result.output
+
+    def test_connect_error_exits_nonzero(self, monkeypatch: Any) -> None:
+        def _boom(url: str, **_kwargs: Any) -> _FakeResponse:
+            raise httpx.ConnectError("refused")
+
+        monkeypatch.setattr(cluster_cmd.httpx, "get", _boom)
+        result = CliRunner().invoke(cluster_cmd.cluster_group, ["status"])
+        assert result.exit_code == 1
+        assert "Cannot connect" in result.output
+
+
+class TestWorkerAdvertisesAdapterLabel:
+    def test_adapter_label_defaulted_from_adapter_name(self) -> None:
+        from bernstein.cli.commands.worker_cmd import WorkerLoop
+
+        worker = WorkerLoop(server_url="http://localhost:8052", adapter="codex")
+        assert worker._labels.get("adapter") == "codex"
+
+    def test_explicit_adapter_label_wins(self) -> None:
+        from bernstein.cli.commands.worker_cmd import WorkerLoop
+
+        worker = WorkerLoop(
+            server_url="http://localhost:8052",
+            adapter="codex",
+            labels={"adapter": "operator-pinned"},
+        )
+        assert worker._labels["adapter"] == "operator-pinned"

--- a/tests/unit/test_dashboard_capacity_denominator.py
+++ b/tests/unit/test_dashboard_capacity_denominator.py
@@ -1,0 +1,120 @@
+"""Dashboard capacity denominator equals the run's effective ``max_agents``.
+
+``status_dashboard`` builds ``config_provenance`` from ``resolve_config_bundle``,
+whose project layer only reads ``.sdd/config.yaml``. A run configured by a seed
+(``bernstein.yaml``) with a non-default ``max_agents`` therefore fell back to the
+built-in default of 6, so the ``Agents active/max`` denominator lied about the
+run's real capacity. The server now threads the seed it loaded at bootstrap into
+the provenance chain as the top-precedence ``seed`` layer (issue #2874).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from bernstein.core.home import BernsteinHome, resolve_config, resolve_config_bundle
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+import bernstein.core.routes.status_dashboard as status_routes
+from bernstein.core.server import create_app
+
+
+class TestSeedProvenanceLayer:
+    """``resolve_config`` injects the seed value as the winning layer."""
+
+    def test_seed_override_becomes_winning_source(self, tmp_path: Path) -> None:
+        home = BernsteinHome(tmp_path / ".bernstein")
+        sdd_config = tmp_path / ".sdd" / "config.yaml"
+        sdd_config.parent.mkdir(parents=True, exist_ok=True)
+        sdd_config.write_text("max_agents: 8\n", encoding="utf-8")
+
+        resolved = resolve_config(
+            "max_agents",
+            home=home,
+            project_dir=tmp_path,
+            seed_overrides={"max_agents": 3},
+            seed_overrides_path=str(tmp_path / "bernstein.yaml"),
+        )
+
+        assert resolved["value"] == 3
+        assert resolved["source"] == "seed"
+        # The seed layer sits above the project layer in the chain.
+        chain_sources = [layer["source"] for layer in resolved["source_chain"]]
+        assert chain_sources[0] == "seed"
+        assert "project" in chain_sources
+        assert resolved["source_chain"][0]["path"] == str(tmp_path / "bernstein.yaml")
+
+    def test_key_absent_from_seed_is_unchanged(self, tmp_path: Path) -> None:
+        home = BernsteinHome(tmp_path / ".bernstein")
+        bundle = resolve_config_bundle(
+            home=home,
+            project_dir=tmp_path,
+            keys=("cli", "max_agents"),
+            seed_overrides={"max_agents": 4},
+        )
+        # ``cli`` is not in the seed overrides, so no seed layer appears for it.
+        assert [layer["source"] for layer in bundle["cli"]["source_chain"]] == ["default"]
+        assert bundle["max_agents"]["value"] == 4
+        assert bundle["max_agents"]["source"] == "seed"
+
+
+def _make_app(tmp_path: Path) -> FastAPI:
+    jsonl_path = tmp_path / ".sdd" / "runtime" / "tasks.jsonl"
+    jsonl_path.parent.mkdir(parents=True, exist_ok=True)
+    return create_app(jsonl_path=jsonl_path)
+
+
+@pytest.mark.anyio
+async def test_seed_max_agents_reaches_config_provenance(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-default seed ``max_agents`` reaches the dashboard denominator."""
+    monkeypatch.setattr(status_routes, "_runtime_cache", {})
+    monkeypatch.setattr(status_routes, "_runtime_cache_ts", 0.0)
+    home_dir = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home_dir))
+
+    app = _make_app(tmp_path)
+    app_state = cast(Any, app.state)
+    app_state.workdir = tmp_path
+    # The server loads the seed at bootstrap; simulate that carried value.
+    app_state.seed_config = SimpleNamespace(max_agents=3, budget_usd=None)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="https://test") as client:
+        response = await client.get("/status")
+
+    assert response.status_code == 200
+    body = response.json()
+    provenance = body["runtime"]["config_provenance"]
+    assert provenance["max_agents"]["value"] == 3
+    assert provenance["max_agents"]["source"] == "seed"
+    # The summary denominator the TUI header binds to also updates.
+    assert body["summary"]["max_agents"] == 3
+
+
+@pytest.mark.anyio
+async def test_no_seed_falls_back_to_file_chain(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no seed loaded, provenance is the unchanged file-based chain."""
+    monkeypatch.setattr(status_routes, "_runtime_cache", {})
+    monkeypatch.setattr(status_routes, "_runtime_cache_ts", 0.0)
+    home_dir = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home_dir))
+
+    app = _make_app(tmp_path)
+    app_state = cast(Any, app.state)
+    app_state.workdir = tmp_path
+    app_state.seed_config = None
+    sdd_config = tmp_path / ".sdd" / "config.yaml"
+    sdd_config.parent.mkdir(parents=True, exist_ok=True)
+    sdd_config.write_text("max_agents: 8\n", encoding="utf-8")
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="https://test") as client:
+        response = await client.get("/status")
+
+    provenance = response.json()["runtime"]["config_provenance"]
+    assert provenance["max_agents"]["value"] == 8
+    assert provenance["max_agents"]["source"] == "project"

--- a/tests/unit/test_hard_stop_group_reap.py
+++ b/tests/unit/test_hard_stop_group_reap.py
@@ -1,0 +1,161 @@
+"""``bernstein stop --force`` reaps surviving process *groups* (issue #2874).
+
+Individual-PID SIGKILLs miss a grandchild a worker re-parented into its own
+process group (e.g. a disowned ``while true; curl`` heartbeat loop). The hard
+stop now anchors on each repo-owned group *leader* and ``os.killpg``s the whole
+group, while still counting only PIDs confirmed terminated.
+
+The tests spawn tiny real process groups in a scratch dir - no orchestrator
+processes, no PID files - so the pgid-reuse guard and the whole-group kill are
+exercised against real kernel process groups.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bernstein.cli.commands import stop_cmd
+
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="POSIX process groups")
+
+# A leader that forks a grandchild into its own group, prints the grandchild
+# PID, then blocks. ``start_new_session=True`` makes the leader a new session +
+# group leader, so ``pid == pgid``.
+_LEADER_SRC = (
+    "import os,sys,subprocess,time;"
+    "c=subprocess.Popen([sys.executable,'-c','import time;time.sleep(120)']);"
+    "print(c.pid, flush=True);"
+    "time.sleep(120)"
+)
+
+
+def _alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _wait_dead(pid: int, timeout: float = 6.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not _alive(pid):
+            return True
+        time.sleep(0.05)
+    return not _alive(pid)
+
+
+def _spawn_group(extra_arg: str | None = None) -> tuple[subprocess.Popen[str], int, int]:
+    """Return ``(popen, leader_pid, grandchild_pid)`` for a fresh group."""
+    argv = [sys.executable, "-c", _LEADER_SRC]
+    if extra_arg is not None:
+        argv.append(extra_arg)
+    proc = subprocess.Popen(argv, start_new_session=True, stdout=subprocess.PIPE, text=True)
+    assert proc.stdout is not None
+    grandchild = int(proc.stdout.readline().strip())
+    # Leader is its own group leader.
+    assert os.getpgid(proc.pid) == proc.pid
+    return proc, proc.pid, grandchild
+
+
+def _hard_cleanup(proc: subprocess.Popen[str], leader: int, grandchild: int) -> None:
+    for target in (leader, grandchild):
+        with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+            os.killpg(target, 9)
+        with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+            os.kill(target, 9)
+    with contextlib.suppress(subprocess.TimeoutExpired):
+        proc.wait(timeout=3)
+
+
+class TestReapProcessGroup:
+    def test_kills_whole_group(self) -> None:
+        proc, leader, grandchild = _spawn_group()
+        try:
+            killed: set[int] = set()
+            stop_cmd._reap_process_group(leader, killed, member_pids=(leader, grandchild))
+
+            # The leader is a direct child of the test, so reap the zombie via
+            # wait(): a negative return code confirms it was signal-killed.
+            assert proc.wait(timeout=6) < 0, "group leader survived killpg"
+            assert _wait_dead(grandchild), "group grandchild survived killpg"
+            # Members are recorded so ``_count_reaped`` can confirm them.
+            assert {leader, grandchild} <= killed
+        finally:
+            _hard_cleanup(proc, leader, grandchild)
+
+    def test_guards_skip_own_and_invalid_groups(self, monkeypatch: Any) -> None:
+        """Never signal pgid <= 0 or the caller's own group (reuse safety)."""
+        signalled: list[int] = []
+        monkeypatch.setattr(os, "killpg", lambda pgid, _sig: signalled.append(pgid))
+
+        killed: set[int] = set()
+        stop_cmd._reap_process_group(os.getpgrp(), killed, member_pids=(123,))
+        stop_cmd._reap_process_group(0, killed, member_pids=(123,))
+        stop_cmd._reap_process_group(-1, killed, member_pids=(123,))
+
+        assert signalled == []
+        assert killed == set()
+
+
+class TestReapRepoProcessGroups:
+    def test_only_repo_owned_group_is_reaped(self, tmp_path: Path, monkeypatch: Any) -> None:
+        monkeypatch.chdir(tmp_path)
+        worktree_prefix = str(tmp_path / ".sdd" / "worktrees")
+
+        ours_proc, ours_leader, ours_grandchild = _spawn_group()
+        other_proc, other_leader, other_grandchild = _spawn_group()
+        try:
+            snapshots = [
+                stop_cmd._ProcessSnapshot(
+                    pid=ours_leader,
+                    ppid=1,
+                    pgid=ours_leader,
+                    command=f"{sys.executable} worker --worktree {worktree_prefix}/task-1",
+                ),
+                stop_cmd._ProcessSnapshot(
+                    pid=ours_grandchild,
+                    ppid=ours_leader,
+                    pgid=ours_leader,
+                    command=f"{sys.executable} -c heartbeat-loop",
+                ),
+                stop_cmd._ProcessSnapshot(
+                    pid=other_leader,
+                    ppid=1,
+                    pgid=other_leader,
+                    command=f"{sys.executable} -c unrelated-sleeper",
+                ),
+                stop_cmd._ProcessSnapshot(
+                    pid=other_grandchild,
+                    ppid=other_leader,
+                    pgid=other_leader,
+                    command=f"{sys.executable} -c unrelated-child",
+                ),
+            ]
+            monkeypatch.setattr(stop_cmd, "_list_process_snapshots", lambda: snapshots)
+
+            killed: set[int] = set()
+            stop_cmd._reap_repo_process_groups(killed)
+
+            # ours_leader is a direct child of the test; wait() reaps the zombie
+            # and its negative return code confirms the group kill.
+            assert ours_proc.wait(timeout=6) < 0, "repo-owned leader survived"
+            assert _wait_dead(ours_grandchild), "repo-owned grandchild survived"
+            # The unrelated group must be left alone (no pgid-reuse collateral).
+            assert _alive(other_leader), "unrelated group was wrongly reaped"
+            assert {ours_leader, ours_grandchild} <= killed
+            assert other_leader not in killed
+        finally:
+            _hard_cleanup(ours_proc, ours_leader, ours_grandchild)
+            _hard_cleanup(other_proc, other_leader, other_grandchild)

--- a/tests/unit/test_ps_live_scan.py
+++ b/tests/unit/test_ps_live_scan.py
@@ -1,0 +1,90 @@
+"""``bernstein ps`` cross-checks a live process scan (issue #2874).
+
+``hard_stop`` deletes ``.sdd/runtime/pids/*.json``. Before this change ``ps``
+read only those PID files, so once they were gone it reported "No running
+agents" even while the orchestrator, server, or a re-parented agent was still
+alive. ``ps`` now also scans the OS process table for repo-owned processes and
+surfaces the live ones, guarding against the race where a PID exits between the
+scan and the liveness re-check.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from bernstein.cli.commands import status_cmd
+
+
+class TestScanLiveAgentRows:
+    def test_reports_infra_and_agents_without_pid_files(self, tmp_path: Path, monkeypatch: Any) -> None:
+        worktree_prefix = str(tmp_path / ".sdd" / "worktrees")
+        lines = [
+            (100, "python -m uvicorn bernstein.core.server:app --port 8052"),
+            (101, "python -m bernstein.core.orchestrator --port 8052 --cells 1"),
+            (102, "python -m bernstein.core.orchestration.bootstrap --watchdog --port 8052"),
+            (103, f"python worker --worktree {worktree_prefix}/task-7"),
+            (104, "python -c import time; time.sleep(9)"),  # unrelated
+        ]
+        monkeypatch.setattr(status_cmd, "list_command_lines", lambda: lines)
+        # Infra processes require cwd==workdir; the agent (104) is unrelated.
+        monkeypatch.setattr(status_cmd, "process_cwd", lambda _pid: tmp_path)
+        monkeypatch.setattr(status_cmd, "is_process_alive", lambda _pid: True)
+
+        rows = status_cmd._scan_live_agent_rows(tmp_path, set())
+        by_pid = {r["worker_pid"]: r for r in rows}
+
+        assert set(by_pid) == {100, 101, 102, 103}
+        assert by_pid[100]["role"] == "server"
+        assert by_pid[101]["role"] == "spawner"
+        assert by_pid[102]["role"] == "watchdog"
+        assert by_pid[103]["role"] == "agent"
+        assert all(r["source"] == "scan" for r in rows)
+
+    def test_skips_known_pids(self, tmp_path: Path, monkeypatch: Any) -> None:
+        lines = [(200, "python -m uvicorn bernstein.core.server:app --port 8052")]
+        monkeypatch.setattr(status_cmd, "list_command_lines", lambda: lines)
+        monkeypatch.setattr(status_cmd, "process_cwd", lambda _pid: tmp_path)
+        monkeypatch.setattr(status_cmd, "is_process_alive", lambda _pid: True)
+
+        rows = status_cmd._scan_live_agent_rows(tmp_path, {200})
+        assert rows == []
+
+    def test_race_pid_dies_mid_scan_is_dropped(self, tmp_path: Path, monkeypatch: Any) -> None:
+        worktree_prefix = str(tmp_path / ".sdd" / "worktrees")
+        lines = [(300, f"python worker --worktree {worktree_prefix}/task-1")]
+        monkeypatch.setattr(status_cmd, "list_command_lines", lambda: lines)
+        monkeypatch.setattr(status_cmd, "process_cwd", lambda _pid: tmp_path)
+        # The pid appeared in the ps snapshot but has since exited.
+        monkeypatch.setattr(status_cmd, "is_process_alive", lambda _pid: False)
+
+        assert status_cmd._scan_live_agent_rows(tmp_path, set()) == []
+
+    def test_infra_outside_workdir_is_ignored(self, tmp_path: Path, monkeypatch: Any) -> None:
+        """A server from a sibling checkout must not be attributed to us."""
+        lines = [(400, "python -m uvicorn bernstein.core.server:app --port 8052")]
+        monkeypatch.setattr(status_cmd, "list_command_lines", lambda: lines)
+        monkeypatch.setattr(status_cmd, "process_cwd", lambda _pid: tmp_path / "other")
+        monkeypatch.setattr(status_cmd, "is_process_alive", lambda _pid: True)
+
+        assert status_cmd._scan_live_agent_rows(tmp_path, set()) == []
+
+
+class TestPsCommandLiveScan:
+    def test_ps_shows_scanned_agent_when_pid_files_gone(self, tmp_path: Path, monkeypatch: Any) -> None:
+        """End-to-end: no PID files, but a live server surfaces in ``ps``."""
+        from click.testing import CliRunner
+
+        monkeypatch.chdir(tmp_path)
+        pid_dir = tmp_path / ".sdd" / "runtime" / "pids"
+        pid_dir.mkdir(parents=True)
+
+        lines = [(500, "python -m uvicorn bernstein.core.server:app --port 8052")]
+        monkeypatch.setattr(status_cmd, "list_command_lines", lambda: lines)
+        monkeypatch.setattr(status_cmd, "process_cwd", lambda _pid: tmp_path)
+        monkeypatch.setattr(status_cmd, "is_process_alive", lambda _pid: True)
+
+        result = CliRunner().invoke(status_cmd.ps_cmd, ["--json-output", "--pid-dir", str(pid_dir)])
+        assert result.exit_code == 0, result.output
+        assert "500" in result.output
+        assert "server" in result.output


### PR DESCRIPTION
## What
All four operator-surface follow-ups were genuine gaps (staleness cross-check confirmed none shipped) and are now implemented with TDD. Item 1: threaded the run seed's effective max_agents into the dashboard config_provenance as a new top-precedence "seed" source. Item 2: stop --force now reaps whole process groups via os.killpg, anchored on live repo-owned group leaders (pgid-reuse safe), still counting only confirmed-terminated PIDs. Item 3: bernstein ps cross-checks a live OS process scan with a race-safe liveness re-probe so it still lists survivors after the PID files are deleted. Item 4: new bernstein cluster status / nodes CLI renders the node registry (id, adapter, heartbeat age, claimed tasks); workers now advertise their adapter as a node label. 4 commits, pushed, no PR opened.

Fixes #2874

## Checklist outcome
4 fixed / 0 already shipped on main (verified, no change) / 0 recorded out-of-scope.

- **Dashboard capacity denominator equals the run's effective max_agents for seed-configured runs (regression test** — fixed: Added seed_overrides/seed_overrides_path to resolve_config + resolve_config_bundle (src/bernstein/core/config/home.py), injecting a new top-precedence 'seed' Co
- **stop --force reaps surviving process groups and still reports only confirmed-terminated PIDs** — fixed: Added _reap_process_group + _reap_repo_process_groups to src/bernstein/cli/commands/stop_cmd.py, wired into hard_stop after the per-PID passes. Anchors os.killp
- **ps reports live orchestrator/agent processes even after hard_stop removed the pid files** — fixed: Added list_command_lines to src/bernstein/core/orchestration/process_utils.py and _scan_live_agent_rows + _classify_live_process + _ps_scan_workdir to status_cm
- **bernstein cluster status lists registered nodes with heartbeat age and claimed-task counts** — fixed: Added cluster status / nodes subcommands to src/bernstein/cli/commands/cluster_cmd.py (query GET /cluster/status, render id/name/status/adapter/heartbeat-age/cl

## Verification
Adversarial review round: **confirmed, 0 critical findings** (red-on-main proven for the substantive items).
TDD red-then-green for each item. Final targeted runs (no full suite per host RAM rule): 4 new test files -> 25 passed (test_dashboard_capacity_denominator.py, test_hard_stop_group_reap.py, test_ps_live_scan.py, tests/unit/cli/test_cluster_status_cmd.py). Touched + adjacent regression set (incl. test_cli_stop.py, test_hard_stop_count.py, test_ps_child_liveness.py, test_status_cmd_openclaw_bridge.py, cli/test_cluster_cmd.py, test_config_provenance.py, test_server_track_b.py) -> 84 passed. Worker suite (test_*worker*.py) -> 213 passed (adapter-label change safe). ruff format+check clean on all t
