### PR TITLE
feat(replay): deterministic replay-debugging surface with time-travel path diff

### DIFF
--- a/docs/operations/replay.md
+++ b/docs/operations/replay.md
@@ -14,8 +14,27 @@ portable, offline-verifiable receipts of the chain.
 | `bernstein replay publish <agent_id> -o RECEIPT --opt-in` | Redacted receipt; only path that ever writes outside `.sdd/runtime/` |
 | `bernstein replay verify <RECEIPT> [--head HEX]` | Offline verifier |
 | `bernstein replay diff-journal <A> <B>` | Surface the precise field that differs between two chains |
+| `bernstein replay debug <RUN>` | Forensic single-chain walk; refuse a tampered chain and localise the divergent step; emit an offline-verifiable debug receipt |
+| `bernstein replay debug <LEFT> <RIGHT>` | Two-run time-travel path diff; content-addressed, byte-identical artifact |
+| `bernstein replay debug <RUN> --fork-from <n>` | Fork-and-reproduce a worktree anchored at parent step N |
 
 Privacy default is local-only. `publish` is opt-in.
+
+## Two debugging jobs: exploratory vs forensic
+
+Replay debugging answers two different questions; do not confuse them.
+
+| Job | Question | How | Surface |
+|---|---|---|---|
+| **Exploratory what-if** | "What changes if I re-run this?" | Re-execute the task (optionally against recorded fixtures or a different model) and compare the *new* output | `bernstein replay <run_id>` (run-trace replay), `bernstein replay <task_id> --model ...` |
+| **Forensic reconstruction** | "Where exactly did this run diverge, and can I prove it?" | Freeze the recorded chain; recompute hashes; never re-execute anything | `bernstein replay debug ...` (this section) |
+
+`replay debug` is **forensic**. It re-executes nothing. Its deliverable is
+a **debug receipt** that verifies offline via `bernstein replay verify` and
+that is meaningless once the Merkle chain it anchors on is stripped or
+corrupted. A non-deterministic divergence is surfaced as a hash mismatch at
+the exact diverging step - not as a "flaky, re-ran it" signature - so a
+flaky run becomes a reproducible bug report.
 
 ## Journal layout
 
@@ -106,6 +125,79 @@ of forks forms a tree rather than a flat list.
 When `--from-step` is omitted the command falls back to the pre-#1799
 session-level fork semantics. The two paths share a single
 implementation in `bernstein.core.sessions.fork.fork_session`.
+
+## Replay debug (forensic time-travel)
+
+`bernstein replay debug` composes the record, journal, diff, and fork
+primitives into one operator-facing debugger. It is a projection of the
+chain that already exists on disk - no new hashing scheme, no new storage.
+The core lives in `bernstein.core.replay.debug`.
+
+### Single-run walk
+
+```
+bernstein replay debug <RUN> [--json] [--full] [--limit N] [--sign KEY]
+```
+
+1. Verifies the chain head via `JournalReader.verify` **before** any output.
+2. If the chain does not verify, it is **refused** (non-zero exit). The
+   command still localises the first divergent step by streaming
+   `walk_and_verify` from `JournalReader` (it never materialises the whole
+   journal), reporting `HashMismatch(seq, expected_hash, actual_hash,
+   first_divergent_field)`:
+   - a `prev_hash` linkage break names `prev_hash` (attributed via
+     `journal_diff.diff_steps`);
+   - a bare digest tamper (the row's fields no longer hash to its stored
+     `step_hash`) names `step_hash`.
+   Only the first divergent step is reported, so the signal is a single
+   named step, not a cascade of downstream breaks.
+3. On a healthy chain it writes a **debug receipt** via
+   `journal_export.export_receipt` to `.sdd/runtime/receipts/<run>.debug.tar`
+   and prints the head hash and a bounded step projection (`--full` lifts
+   the default cap; `--limit N` sets it). `--sign KEY` signs the receipt
+   with an `Ed25519FileKeySigner`.
+
+The debug receipt IS the deliverable: `bernstein replay verify <receipt>`
+accepts it offline, and stripping or corrupting the bundled chain (or its
+recorded head) makes verification fail - the debugger's output is
+meaningless without the audit chain, not merely unlogged.
+
+### Two-run path diff
+
+```
+bernstein replay debug <LEFT> <RIGHT> [--json] [--jump-to-failure]
+```
+
+Reuses `journal_diff.diff_journals` to find the first divergence, then emits
+an ordered side-by-side of the canonical six fields from seq 0 up to and
+including the divergence, with the diverging fields marked. The artifact is
+**content-addressed**: its `diff_hash` is a SHA-256 over the sorted-key JSON
+of the diff body (chain content only, never a filesystem path), written to
+`.sdd/runtime/debug/<left>__<right>.pathdiff.json`. Two operators on the
+same journals - or the same operator twice - produce the byte-identical
+artifact and the same `diff_hash`.
+
+`--jump-to-failure` positions the output at the diverging seq; it is a
+presentation flag and does not perturb the content-addressed artifact.
+
+### Fork-and-reproduce
+
+```
+bernstein replay debug <RUN> --fork-from <n>
+```
+
+Calls `fork_session(..., from_step=n)` to materialise a sibling worktree
+seeded with the parent journal prefix `[0..n]`, so the fork's first new step
+chains onto the parent `step_hash` at seq `n`. The debug output records that
+`parent_step_hash` as the reproduction anchor. An out-of-range `n` fails
+fast with no side effects on disk (no dangling worktree or branch).
+
+### Privacy
+
+`replay debug` is local-only by default: the receipt and the path-diff
+artifact are written under `.sdd/runtime/`. It has no publish path. Should a
+receipt ever be published, it routes through the same `RedactionPolicy` as
+`replay publish`.
 
 ## Receipt format
 

--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -1940,6 +1940,34 @@ def _replay_from_step(*, run_id: str, sdd_dir: str, from_step: int, as_json: boo
     default=None,
     help="Rebuild deterministic run state by walking the journal to step N.",
 )
+@click.option(
+    "--fork-from",
+    "fork_from",
+    type=int,
+    default=None,
+    help="replay debug: fork-and-reproduce a worktree anchored at parent step N.",
+)
+@click.option(
+    "--jump-to-failure",
+    "jump_to_failure",
+    is_flag=True,
+    default=False,
+    help="replay debug: position output at the diverging seq.",
+)
+@click.option(
+    "--sign",
+    "sign_key",
+    type=click.Path(dir_okay=False),
+    default=None,
+    help="replay debug: Ed25519 key path to sign the debug receipt.",
+)
+@click.option(
+    "--full",
+    "full",
+    is_flag=True,
+    default=False,
+    help="replay debug: emit the unbounded step projection (default is capped).",
+)
 def replay_cmd(
     run_id: tuple[str, ...],
     sdd_dir: str,
@@ -1949,6 +1977,10 @@ def replay_cmd(
     extra_context: str | None,
     verify: bool,
     from_step: int | None,
+    fork_from: int | None,
+    jump_to_failure: bool,
+    sign_key: str | None,
+    full: bool,
 ) -> None:
     """Replay a past orchestration run step-by-step.
 
@@ -1973,6 +2005,9 @@ def replay_cmd(
       bernstein replay publish <AGENT_ID> -o RECEIPT  # redacted publish (#1799)
       bernstein replay verify <RECEIPT>           # offline verifier (#1799)
       bernstein replay diff-journal A B           # per-step divergence finder
+      bernstein replay debug <RUN>                # forensic single-chain walk (#2605)
+      bernstein replay debug <LEFT> <RIGHT>       # two-run time-travel path diff
+      bernstein replay debug <RUN> --fork-from N  # fork-and-reproduce at step N
     """
     # ``nargs=-1`` lets us implement the pseudo-subcommand ``diff`` without
     # converting ``replay`` to a full :class:`click.Group` (which would
@@ -1980,6 +2015,18 @@ def replay_cmd(
     args = list(run_id)
     if args and args[0] == "diff":
         _replay_diff_dispatch(args[1:], sdd_dir=sdd_dir, as_json=as_json)
+        return
+    if args and args[0] == "debug":
+        _replay_debug_dispatch(
+            args[1:],
+            sdd_dir=sdd_dir,
+            as_json=as_json,
+            fork_from=fork_from,
+            jump_to_failure=jump_to_failure,
+            sign_key=sign_key,
+            full=full,
+            limit=limit,
+        )
         return
     if args and args[0] in {"export", "publish", "verify", "diff-journal"}:
         _replay_journal_dispatch(args, sdd_dir=sdd_dir, as_json=as_json)
@@ -2030,6 +2077,39 @@ def replay_cmd(
         model=model,
         extra_context=extra_context,
     )
+
+
+def _replay_debug_dispatch(
+    args: list[str],
+    *,
+    sdd_dir: str,
+    as_json: bool,
+    fork_from: int | None,
+    jump_to_failure: bool,
+    sign_key: str | None,
+    full: bool,
+    limit: int | None,
+) -> None:
+    """Dispatch ``bernstein replay debug`` (#2605).
+
+    Forensic time-travel debugger over the per-step journal. Local-only by
+    default under ``.sdd/runtime/``; it never re-executes anything.
+    """
+    from bernstein.cli.commands.replay_cmd import replay_debug
+
+    rc = replay_debug(
+        args,
+        Path(sdd_dir),
+        as_json=as_json,
+        fork_from=fork_from,
+        jump_to_failure=jump_to_failure,
+        sign_key_path=Path(sign_key) if sign_key else None,
+        full=full,
+        limit=limit,
+        repo_root=Path.cwd(),
+    )
+    if rc != 0:
+        raise SystemExit(rc)
 
 
 def _replay_journal_dispatch(

--- a/src/bernstein/cli/commands/replay_cmd.py
+++ b/src/bernstein/cli/commands/replay_cmd.py
@@ -1,14 +1,17 @@
-"""CLI helpers for the per-step replay surface (#1799).
+"""CLI helpers for the per-step replay surface (#1799, #2605).
 
 The top-level ``bernstein replay`` command is implemented in
 ``advanced_cmd.py`` as a ``nargs=-1`` pseudo-group so the legacy
 ``bernstein replay <run_id>`` shape keeps working. This module hosts
-the *new* verbs added by #1799:
+the *new* verbs added by #1799 and #2605:
 
 * ``bernstein replay <agent_id>`` (interactive view + chain verification)
 * ``bernstein replay export <agent_id>`` (portable, offline-verifiable receipt)
 * ``bernstein replay publish <agent_id>`` (explicit opt-in, redacted receipt)
 * ``bernstein replay verify <receipt_path>`` (offline verifier helper)
+* ``bernstein replay debug <run>`` / ``<left> <right>`` (forensic time-travel
+  debugger: recompute-mismatch localization, two-run path diff, ``--fork-from``
+  reproduction, offline-verifiable debug receipt)
 
 The dispatch functions are called from the existing ``replay`` command
 in ``advanced_cmd.py``; keeping them in a separate module makes them
@@ -19,7 +22,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from bernstein.core.persistence.journal import (
     JournalReader,
@@ -41,6 +44,11 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+#: Default cap on the number of projection rows rendered by ``replay debug``.
+#: Matches the ``limit`` pattern in :func:`replay_agent_view`; ``--full``
+#: lifts the cap for an unbounded projection.
+_DEFAULT_DEBUG_LIMIT = 200
 
 
 def _resolve_agent_dir(sdd_dir: Path, agent_id: str) -> Path:
@@ -326,8 +334,362 @@ def replay_diff_journals(
     return 1
 
 
+# ---------------------------------------------------------------------------
+# replay debug - forensic time-travel debugger (#2605)
+# ---------------------------------------------------------------------------
+
+
+def replay_debug(
+    args: list[str],
+    sdd_dir: Path,
+    *,
+    as_json: bool = False,
+    fork_from: int | None = None,
+    jump_to_failure: bool = False,
+    sign_key_path: Path | None = None,
+    full: bool = False,
+    limit: int | None = None,
+    repo_root: Path | None = None,
+) -> int:
+    """Dispatch the forensic ``replay debug`` verb. Returns the exit code.
+
+    ``[run]`` runs the single-chain walk (optionally forking with
+    ``fork_from``); ``[left, right]`` runs the two-run path diff. The surface
+    is forensic: it freezes the recorded chain and proves where it diverged;
+    it never re-executes anything. The debug receipt is the deliverable and
+    verifies offline via the ``replay verify`` path.
+    """
+    from bernstein.cli.helpers import console
+
+    if len(args) == 1:
+        return _debug_single_run(
+            args[0],
+            sdd_dir,
+            as_json=as_json,
+            fork_from=fork_from,
+            jump_to_failure=jump_to_failure,
+            sign_key_path=sign_key_path,
+            full=full,
+            limit=limit,
+            repo_root=repo_root,
+        )
+    if len(args) == 2:
+        if fork_from is not None:
+            console.print("[red]--fork-from applies to single-run debug only.[/red]")
+            return 2
+        return _debug_two_run(
+            args[0],
+            args[1],
+            sdd_dir,
+            as_json=as_json,
+            jump_to_failure=jump_to_failure,
+            full=full,
+            limit=limit,
+        )
+
+    console.print(
+        "[red]Usage:[/red] bernstein replay debug <RUN> [--fork-from N] [--sign KEY] "
+        "OR bernstein replay debug <LEFT> <RIGHT>"
+    )
+    return 2
+
+
+def _load_signer(sign_key_path: Path | None):  # type: ignore[no-untyped-def]
+    """Return an ``Ed25519FileKeySigner`` for *sign_key_path*, or ``None``.
+
+    Reuses the same signer the export path uses so a signed debug receipt is
+    indistinguishable from a signed export receipt. Raises the signer's own
+    ``LineageSignerError`` on a bad key so the caller can fail fast.
+    """
+    if sign_key_path is None:
+        return None
+    from bernstein.core.persistence.lineage_signer import Ed25519FileKeySigner
+
+    return Ed25519FileKeySigner.from_path(sign_key_path)
+
+
+def _debug_single_run(
+    run: str,
+    sdd_dir: Path,
+    *,
+    as_json: bool,
+    fork_from: int | None,
+    jump_to_failure: bool,
+    sign_key_path: Path | None,
+    full: bool,
+    limit: int | None,
+    repo_root: Path | None,
+) -> int:
+    """Single-chain forensic walk + optional fork + debug receipt."""
+    from bernstein.cli.helpers import console
+    from bernstein.core.replay.debug import walk_and_verify
+
+    agent_dir = _resolve_agent_dir(sdd_dir, run)
+    if not agent_dir.exists():
+        console.print(f"[red]No journal for run[/red] {run} (looked at {agent_dir})")
+        return 2
+
+    reader = JournalReader(agent_dir)
+    head_entry = reader.head()
+    if head_entry is None:
+        console.print(f"[yellow]Journal for {run} is empty.[/yellow]")
+        return 0
+
+    # AC1: verify the chain head before emitting any success output; a tampered
+    # chain is refused (non-zero exit). AC2: the refusal still localises the
+    # first divergent step so a flaky re-run becomes a reproducible bug report.
+    verification = reader.verify(expected_head=head_entry.step_hash)
+    if not verification.ok:
+        mismatch = next(iter(walk_and_verify(reader)), None)
+        return _emit_single_run_tamper(
+            run,
+            mismatch,
+            verification.errors,
+            as_json=as_json,
+            jump_to_failure=jump_to_failure,
+        )
+
+    # Healthy chain: optional fork-and-reproduce, then the debug receipt.
+    fork_info: dict[str, Any] | None = None
+    if fork_from is not None:
+        fork_info = _debug_fork(run, from_step=fork_from, repo_root=repo_root)
+        if fork_info is None:
+            return 1
+
+    try:
+        signer = _load_signer(sign_key_path)
+    except Exception as exc:
+        console.print(f"[red]Cannot load signing key:[/red] {exc}")
+        return 1
+
+    receipt_path = sdd_dir / "runtime" / "receipts" / f"{run}.debug.tar"
+    try:
+        result = export_receipt(agent_dir, receipt_path, agent_id=run, signer=signer)
+    except ReceiptError as exc:
+        console.print(f"[red]Debug receipt export failed:[/red] {exc}")
+        return 1
+
+    return _emit_single_run_ok(
+        run,
+        reader,
+        verification,
+        result,
+        fork_info,
+        as_json=as_json,
+        jump_to_failure=jump_to_failure,
+        full=full,
+        limit=limit,
+    )
+
+
+def _emit_single_run_tamper(
+    run: str,
+    mismatch: Any,
+    errors: list[str],
+    *,
+    as_json: bool,
+    jump_to_failure: bool,
+) -> int:
+    """Report the localised tamper and refuse the chain (exit 1)."""
+    from bernstein.cli.helpers import console
+
+    payload: dict[str, Any] = {
+        "mode": "single-run",
+        "run": run,
+        "verified": False,
+        "errors": errors,
+    }
+    if mismatch is not None:
+        payload["seq"] = mismatch.seq
+        payload["first_divergent_field"] = mismatch.first_divergent_field
+        payload["expected_hash"] = mismatch.expected_hash
+        payload["actual_hash"] = mismatch.actual_hash
+    if jump_to_failure:
+        payload["jump_to_seq"] = mismatch.seq if mismatch is not None else None
+
+    if as_json:
+        console.print_json(json.dumps(payload, default=str))
+        return 1
+
+    console.print(f"[red]Chain refused for {run}: tampered / does not verify.[/red]")
+    if mismatch is not None:
+        console.print(
+            f"[yellow]Divergence at step {mismatch.seq}[/yellow] (field: [bold]{mismatch.first_divergent_field}[/bold])"
+        )
+        console.print(f"[dim]expected:[/dim] {mismatch.expected_hash}")
+        console.print(f"[dim]actual:  [/dim] {mismatch.actual_hash}")
+    for err in errors:
+        console.print(f"  - {err}")
+    return 1
+
+
+def _emit_single_run_ok(
+    run: str,
+    reader: JournalReader,
+    verification: Any,
+    result: Any,
+    fork_info: dict[str, Any] | None,
+    *,
+    as_json: bool,
+    jump_to_failure: bool,
+    full: bool,
+    limit: int | None,
+) -> int:
+    """Emit the healthy-chain debug receipt + bounded step projection."""
+    from bernstein.cli.helpers import console
+
+    cap = None if full else (limit if limit is not None else _DEFAULT_DEBUG_LIMIT)
+    projection: list[dict[str, Any]] = []
+    for entry in reader.entries():
+        if cap is not None and len(projection) >= cap:
+            break
+        tool_name = ""
+        if isinstance(entry.tool_call, dict):
+            tool_name = str(entry.tool_call.get("name", ""))
+        projection.append(
+            {
+                "seq": entry.seq,
+                "step_hash": entry.step_hash,
+                "prev_hash": entry.prev_hash,
+                "model": entry.model,
+                "tool_call": tool_name,
+            }
+        )
+
+    payload: dict[str, Any] = {
+        "mode": "single-run",
+        "run": run,
+        "verified": True,
+        "head_hash": verification.head_hash,
+        "steps": verification.steps,
+        "receipt": {
+            "path": str(result.path),
+            "head_hash": result.head_hash,
+            "steps": result.steps,
+            "signed": result.signed,
+        },
+        "projection": projection,
+    }
+    if fork_info is not None:
+        payload["fork"] = fork_info
+    if jump_to_failure:
+        # A healthy chain has no failure to jump to.
+        payload["jump_to_seq"] = None
+
+    if as_json:
+        console.print_json(json.dumps(payload, default=str))
+        return 0
+
+    console.print(f"[bold]Replay debug for[/bold] [cyan]{run}[/cyan]")
+    console.print(f"[dim]head_hash:[/dim] [bold]{verification.head_hash}[/bold]")
+    console.print(f"[dim]steps:[/dim] {verification.steps}")
+    console.print(f"[green]Debug receipt[/green] -> {result.path} (signed={result.signed})")
+    console.print("[dim]Verify offline with:[/dim] bernstein replay verify " + str(result.path))
+    if fork_info is not None:
+        console.print(
+            f"[cyan]Forked[/cyan] at step {fork_info['from_step']} -> "
+            f"{fork_info['fork_worktree']} (anchor {fork_info['parent_step_hash'][:16]}...)"
+        )
+    return 0
+
+
+def _debug_fork(run: str, *, from_step: int, repo_root: Path | None) -> dict[str, Any] | None:
+    """Fork-and-reproduce at ``from_step`` via ``fork_session``.
+
+    ``fork_session`` fails fast on an out-of-range seq with no side effects
+    on disk, so a bad step never leaves a dangling worktree. Returns the fork
+    lineage (recording ``parent_step_hash`` as the reproduction anchor), or
+    ``None`` on failure.
+    """
+    from bernstein.cli.helpers import console
+    from bernstein.core.sessions.fork import SessionForkError, fork_session
+
+    try:
+        fork = fork_session(parent_session_id=run, repo_root=repo_root, from_step=from_step)
+    except SessionForkError as exc:
+        console.print(f"[red]Fork failed:[/red] {exc}")
+        return None
+
+    return {
+        "from_step": fork.from_step,
+        "parent_step_hash": fork.parent_step_hash,
+        "fork_session_id": fork.fork_session_id,
+        "fork_branch": fork.fork_branch,
+        "fork_worktree": str(fork.fork_worktree),
+    }
+
+
+def _debug_two_run(
+    left: str,
+    right: str,
+    sdd_dir: Path,
+    *,
+    as_json: bool,
+    jump_to_failure: bool,
+    full: bool,
+    limit: int | None,
+) -> int:
+    """Two-run time-travel path diff; writes a content-addressed artifact."""
+    from bernstein.cli.helpers import console
+    from bernstein.core.replay.debug import two_run_path_diff
+
+    left_dir = _resolve_agent_dir(sdd_dir, left)
+    right_dir = _resolve_agent_dir(sdd_dir, right)
+    if not left_dir.exists() or not right_dir.exists():
+        console.print("[red]One or both journals are missing.[/red]")
+        return 2
+
+    path_diff = two_run_path_diff(left_dir, right_dir)
+
+    # The content-addressed artifact is the source of truth: canonical bytes,
+    # chain content only, so two invocations (or two operators) match exactly.
+    artifact = path_diff.to_dict()
+    artifact_bytes = (json.dumps(artifact, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+    artifact_dir = sdd_dir / "runtime" / "debug"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    artifact_path = artifact_dir / f"{left}__{right}.pathdiff.json"
+    artifact_path.write_bytes(artifact_bytes)
+
+    # Presentation extras (display cap, jump anchor) live outside the
+    # content-addressed body so they never perturb ``diff_hash``.
+    cap = None if full else (limit if limit is not None else _DEFAULT_DEBUG_LIMIT)
+    display_steps = path_diff.steps if cap is None else path_diff.steps[:cap]
+    envelope: dict[str, Any] = {
+        "mode": "two-run",
+        "left": left,
+        "right": right,
+        "artifact_path": str(artifact_path),
+        "diff_hash": path_diff.diff_hash,
+        "diverged": path_diff.diverged,
+        "divergence": artifact["divergence"],
+        "steps": display_steps,
+    }
+    if jump_to_failure:
+        envelope["jump_to_seq"] = path_diff.divergence.seq if path_diff.divergence is not None else None
+
+    if as_json:
+        console.print_json(json.dumps(envelope, default=str))
+        return 1 if path_diff.diverged else 0
+
+    if not path_diff.diverged:
+        console.print("[green]No divergence; chains match end-to-end.[/green]")
+        console.print(f"[dim]diff artifact:[/dim] {artifact_path} ({path_diff.diff_hash[:16]}...)")
+        return 0
+
+    divergence = path_diff.divergence
+    assert divergence is not None  # diverged implies a divergence
+    console.print(f"[yellow]Divergence at step {divergence.seq}[/yellow]: {divergence.reason}")
+    for name in divergence.fields_changed:
+        console.print(f"  [bold]{name}[/bold]:")
+        console.print(f"    left:  {divergence.left_values.get(name)!r}")
+        console.print(f"    right: {divergence.right_values.get(name)!r}")
+    console.print(f"[dim]diff artifact:[/dim] {artifact_path} ([bold]{path_diff.diff_hash}[/bold])")
+    return 1
+
+
 __all__ = [
     "replay_agent_view",
+    "replay_debug",
     "replay_diff_journals",
     "replay_export",
     "replay_publish",

--- a/src/bernstein/core/replay/debug.py
+++ b/src/bernstein/core/replay/debug.py
@@ -259,13 +259,14 @@ def two_run_path_diff(left_dir: Path, right_dir: Path) -> PathDiff:
     steps: list[dict[str, Any]] = []
     for seq in range(max_seq + 1):
         diverged_here = divergence is not None and seq == divergence.seq
+        fields_changed = sorted(divergence.fields_changed) if divergence is not None and diverged_here else []
         steps.append(
             {
                 "seq": seq,
                 "left": left_window.get(seq),
                 "right": right_window.get(seq),
                 "diverged": diverged_here,
-                "fields_changed": sorted(divergence.fields_changed) if diverged_here else [],
+                "fields_changed": fields_changed,
             }
         )
 
@@ -274,9 +275,7 @@ def two_run_path_diff(left_dir: Path, right_dir: Path) -> PathDiff:
         "divergence": _divergence_to_dict(divergence),
         "steps": steps,
     }
-    diff_hash = hashlib.sha256(
-        json.dumps(body, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    ).hexdigest()
+    diff_hash = hashlib.sha256(json.dumps(body, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
 
     return PathDiff(
         diverged=divergence is not None,

--- a/src/bernstein/core/replay/debug.py
+++ b/src/bernstein/core/replay/debug.py
@@ -1,0 +1,294 @@
+"""Deterministic replay-debugging projection (#2605).
+
+This module is the *forensic* half of replay debugging. It freezes the
+recorded Merkle step chain and proves where a single run was tampered or
+where two runs diverged; it never re-executes anything. (The exploratory
+what-if surface - re-run and see what changes - is a distinct concern; see
+``docs/operations/replay.md``.)
+
+Two projections, both built on the single chain primitive
+(``journal.compute_step_hash``) and the single field-attribution primitive
+(``journal_diff.diff_steps``) so there is no second hashing or diffing
+scheme to drift against :meth:`JournalReader.verify`:
+
+* :func:`walk_and_verify` streams a :class:`HashMismatch` for every step
+  whose recomputed ``step_hash`` or chain linkage disagrees with the stored
+  value. It reads the journal one entry at a time from
+  :class:`JournalReader` and never materialises the whole chain, so the
+  first divergent step in a large journal is localised without loading it
+  all - take ``next(walk_and_verify(reader), None)`` to stop at the first.
+
+* :func:`two_run_path_diff` builds an ordered, content-addressed
+  side-by-side projection of two chains up to and including the first
+  divergence found by :func:`journal_diff.diff_journals`. The artifact
+  carries its own SHA-256 over the sorted-key JSON body (chain content
+  only, never a filesystem path), so two operators on the same journals
+  produce the byte-identical diff artifact.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.persistence.journal import (
+    GENESIS_HASH,
+    JournalReader,
+    compute_step_hash,
+)
+from bernstein.core.persistence.journal_diff import (
+    StepDivergence,
+    diff_journals,
+    diff_steps,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+#: Canonical six fields projected side-by-side in a two-run path diff. These
+#: are the human-legible payload fields; ``effort`` folds into the hash but is
+#: surfaced via ``fields_changed`` when it is what diverged.
+_PROJECTED_FIELDS = (
+    "prev_hash",
+    "input_hash",
+    "model",
+    "prompt",
+    "tool_call",
+    "tool_result",
+)
+
+
+# ---------------------------------------------------------------------------
+# Single-run recompute-mismatch
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class HashMismatch:
+    """A step whose stored digest or chain linkage does not verify.
+
+    Attributes:
+        seq: Zero-based index of the divergent step.
+        expected_hash: The hash the chain expects at this position - the
+            value recomputed from the row's canonical fields for a digest
+            mismatch, or the previous step's stored ``step_hash`` for a
+            ``prev_hash`` break.
+        actual_hash: The value stored on disk (the tampered/inconsistent
+            digest, or the row's stored ``prev_hash`` for a linkage break).
+        first_divergent_field: Name of the first canonical field that
+            diverged, attributed via :func:`journal_diff.diff_steps`.
+            ``"prev_hash"`` for a chain-linkage break; ``"step_hash"`` when
+            the row's fields no longer hash to its stored digest.
+    """
+
+    seq: int
+    expected_hash: str
+    actual_hash: str
+    first_divergent_field: str
+
+
+def _recompute_step_hash(row: dict[str, Any]) -> str:
+    """Recompute a row's ``step_hash`` from its canonical fields."""
+    return compute_step_hash(
+        prev_hash=str(row.get("prev_hash", "")),
+        input_hash=str(row.get("input_hash", "")),
+        model=row.get("model"),
+        prompt=row.get("prompt"),
+        tool_call=row.get("tool_call"),
+        tool_result=row.get("tool_result"),
+        # Legacy rows lack ``effort`` (get -> None), matching the pre-effort
+        # payload so old chains recompute unchanged.
+        effort=row.get("effort"),
+    )
+
+
+def _first_divergent_field(row: dict[str, Any], expected_prev_hash: str) -> str:
+    """Attribute the first divergent field of a mismatched step.
+
+    Compares the recorded row against the row the chain *expected* at this
+    position - identical fields except ``prev_hash``, which is pinned to the
+    walk's expected value. :func:`diff_steps` names ``prev_hash`` when the
+    linkage broke; when it finds no canonical-field difference the mismatch
+    is a bare digest tamper, so the divergent field is the ``step_hash``
+    itself.
+    """
+    reference = dict(row)
+    reference["prev_hash"] = expected_prev_hash
+    divergence = diff_steps(reference, row)
+    if divergence is not None:
+        return divergence.fields_changed[0]
+    return "step_hash"
+
+
+def walk_and_verify(reader: JournalReader) -> Iterator[HashMismatch]:
+    """Yield a :class:`HashMismatch` for every non-verifying step, in order.
+
+    Streams entries from *reader* one at a time and recomputes each
+    ``step_hash`` from the canonical six-field payload, comparing to the
+    stored value and checking ``prev_hash`` linkage against the previous
+    step's stored digest. A ``prev_hash`` break is reported in preference to
+    a co-located digest mismatch. Yields nothing for an intact chain.
+
+    The generator never materialises the whole journal, so a caller that
+    only needs the first divergent step (``next(walk_and_verify(reader),
+    None)``) stops reading as soon as it is found.
+    """
+    prev_hash = GENESIS_HASH
+    for entry in reader.entries():
+        row = entry.to_dict()
+        stored_prev = str(row.get("prev_hash", ""))
+        stored_hash = str(row.get("step_hash", ""))
+
+        if stored_prev != prev_hash:
+            # Chain linkage broke: the row does not chain onto the previous
+            # step's stored digest. Attribute the field via diff_steps.
+            yield HashMismatch(
+                seq=entry.seq,
+                expected_hash=prev_hash,
+                actual_hash=stored_prev,
+                first_divergent_field=_first_divergent_field(row, prev_hash),
+            )
+        else:
+            recomputed = _recompute_step_hash(row)
+            if recomputed != stored_hash:
+                yield HashMismatch(
+                    seq=entry.seq,
+                    expected_hash=recomputed,
+                    actual_hash=stored_hash,
+                    first_divergent_field=_first_divergent_field(row, prev_hash),
+                )
+
+        # Continue from the on-disk digest (mirrors JournalReader.verify) so a
+        # tampered digest surfaces as a downstream prev_hash break rather than
+        # silently re-anchoring the walk.
+        prev_hash = stored_hash
+
+
+# ---------------------------------------------------------------------------
+# Two-run time-travel path diff
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PathDiff:
+    """Ordered, content-addressed side-by-side of two chains to divergence.
+
+    Attributes:
+        diverged: ``True`` when the two chains disagree.
+        divergence: The first :class:`StepDivergence` from
+            :func:`diff_journals`, or ``None`` when the chains match.
+        steps: Per-seq side-by-side of the canonical six fields, ordered
+            from seq 0 up to and including the divergence (or the full
+            paired length when the chains match). Each entry is
+            ``{"seq", "left", "right", "diverged", "fields_changed"}`` where
+            ``left`` / ``right`` are ``None`` when that chain has no step at
+            the seq (length mismatch).
+        diff_hash: SHA-256 hex over the sorted-key JSON of the diff *body*
+            (``diverged`` + ``divergence`` + ``steps``) - chain content only,
+            never a filesystem path - so the artifact is byte-identical for
+            any two operators holding the same journals.
+    """
+
+    diverged: bool
+    divergence: StepDivergence | None
+    steps: list[dict[str, Any]] = field(default_factory=list)
+    diff_hash: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the JSON-friendly artifact (``diff_hash`` + body)."""
+        return {
+            "diff_hash": self.diff_hash,
+            "diverged": self.diverged,
+            "divergence": _divergence_to_dict(self.divergence),
+            "steps": self.steps,
+        }
+
+
+def _divergence_to_dict(divergence: StepDivergence | None) -> dict[str, Any] | None:
+    """Serialise a :class:`StepDivergence` deterministically (or ``None``)."""
+    if divergence is None:
+        return None
+    return {
+        "seq": divergence.seq,
+        "fields_changed": sorted(divergence.fields_changed),
+        "left_values": divergence.left_values,
+        "right_values": divergence.right_values,
+        "reason": divergence.reason,
+    }
+
+
+def _project(row: dict[str, Any]) -> dict[str, Any]:
+    """Project a journal row onto the canonical six fields."""
+    return {name: row.get(name) for name in _PROJECTED_FIELDS}
+
+
+def _collect_window(reader: JournalReader, upto_seq: int | None) -> dict[int, dict[str, Any]]:
+    """Stream entries ``[0..upto_seq]`` (or all) as ``{seq: projected_row}``.
+
+    Reads one entry at a time and stops past ``upto_seq`` so a long journal
+    is not fully materialised when the divergence is early.
+    """
+    window: dict[int, dict[str, Any]] = {}
+    for entry in reader.entries():
+        if upto_seq is not None and entry.seq > upto_seq:
+            break
+        window[entry.seq] = _project(entry.to_dict())
+    return window
+
+
+def two_run_path_diff(left_dir: Path, right_dir: Path) -> PathDiff:
+    """Build the content-addressed path diff between two agent journals.
+
+    Reuses :func:`diff_journals` for the first-divergence locator, then emits
+    the ordered side-by-side projection up to and including that divergence.
+    When the chains match, the projection spans the full paired length.
+    """
+    divergence = diff_journals(left_dir, right_dir)
+    upto = divergence.seq if divergence is not None else None
+
+    left_window = _collect_window(JournalReader(left_dir), upto)
+    right_window = _collect_window(JournalReader(right_dir), upto)
+
+    max_seq = -1
+    for seq in (*left_window.keys(), *right_window.keys()):
+        max_seq = max(max_seq, seq)
+
+    steps: list[dict[str, Any]] = []
+    for seq in range(max_seq + 1):
+        diverged_here = divergence is not None and seq == divergence.seq
+        steps.append(
+            {
+                "seq": seq,
+                "left": left_window.get(seq),
+                "right": right_window.get(seq),
+                "diverged": diverged_here,
+                "fields_changed": sorted(divergence.fields_changed) if diverged_here else [],
+            }
+        )
+
+    body = {
+        "diverged": divergence is not None,
+        "divergence": _divergence_to_dict(divergence),
+        "steps": steps,
+    }
+    diff_hash = hashlib.sha256(
+        json.dumps(body, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+    return PathDiff(
+        diverged=divergence is not None,
+        divergence=divergence,
+        steps=steps,
+        diff_hash=diff_hash,
+    )
+
+
+__all__ = [
+    "HashMismatch",
+    "PathDiff",
+    "two_run_path_diff",
+    "walk_and_verify",
+]

--- a/tests/unit/test_replay_debug.py
+++ b/tests/unit/test_replay_debug.py
@@ -218,9 +218,7 @@ class TestTwoRunPathDiff:
         left, right = _two_runs_diverging_at(tmp_path, seq=2)
         diff = two_run_path_diff(left, right)
         body = {"diverged": diff.diverged, "divergence": diff.to_dict()["divergence"], "steps": diff.steps}
-        recomputed = hashlib.sha256(
-            json.dumps(body, sort_keys=True, separators=(",", ":")).encode("utf-8")
-        ).hexdigest()
+        recomputed = hashlib.sha256(json.dumps(body, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
         assert diff.diff_hash == recomputed
 
     def test_length_mismatch_surfaces_as_divergence(self, tmp_path: Path) -> None:

--- a/tests/unit/test_replay_debug.py
+++ b/tests/unit/test_replay_debug.py
@@ -1,0 +1,262 @@
+"""Tests for the deterministic replay-debugging projection (#2605).
+
+The debug surface is *forensic*: it freezes the recorded chain and proves
+where a single run was tampered or where two runs diverged. It never
+re-executes anything. These tests pin the empirical contract:
+
+* single-run recompute-mismatch localization (streaming, first divergent
+  step, named field);
+* two-run divergence localization driven by ``diff_journals``;
+* byte-identical, content-addressed two-run path diff across repeated
+  invocations and across journal directory locations.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+
+from bernstein.core.persistence.journal import (
+    Journal,
+    JournalReader,
+    compute_step_hash,
+)
+from bernstein.core.replay.debug import (
+    HashMismatch,
+    PathDiff,
+    two_run_path_diff,
+    walk_and_verify,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _populate(agent_dir: Path, n: int = 4, *, model: str = "m1") -> list[str]:
+    """Write an ``n``-step journal and return the per-step head hashes."""
+    journal = Journal.open(agent_dir)
+    heads: list[str] = []
+    for i in range(n):
+        entry = journal.append(
+            input_hash=f"a{i}",
+            model=model,
+            prompt=f"step {i}",
+            tool_call={"name": "noop", "args": {"i": i}},
+            tool_result={"ok": True, "n": i},
+        )
+        heads.append(entry.step_hash)
+    journal.close()
+    return heads
+
+
+def _tamper_stored_step_hash(agent_dir: Path, seq: int) -> None:
+    """Rewrite the stored ``step_hash`` of row *seq* to a bogus value.
+
+    Leaves every canonical field intact, so the row's fields still hash to
+    the original value: the divergence is a bare digest tamper.
+    """
+    bucket = agent_dir / "000000.jsonl"
+    lines = bucket.read_text(encoding="utf-8").splitlines()
+    row = json.loads(lines[seq])
+    row["step_hash"] = "f" * 64
+    lines[seq] = json.dumps(row, sort_keys=True, separators=(",", ":"))
+    bucket.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _tamper_field_keep_prev(agent_dir: Path, seq: int) -> None:
+    """Rewrite the ``prev_hash`` of row *seq* to break chain linkage."""
+    bucket = agent_dir / "000000.jsonl"
+    lines = bucket.read_text(encoding="utf-8").splitlines()
+    row = json.loads(lines[seq])
+    row["prev_hash"] = "e" * 64
+    lines[seq] = json.dumps(row, sort_keys=True, separators=(",", ":"))
+    bucket.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# walk_and_verify - single-run recompute-mismatch localization
+# ---------------------------------------------------------------------------
+
+
+class TestWalkAndVerify:
+    def test_clean_chain_yields_no_mismatch(self, tmp_path: Path) -> None:
+        agent = tmp_path / "agent-1"
+        _populate(agent, 4)
+        reader = JournalReader(agent)
+        assert list(walk_and_verify(reader)) == []
+
+    def test_is_a_generator_that_streams(self, tmp_path: Path) -> None:
+        agent = tmp_path / "agent-1"
+        _populate(agent, 4)
+        reader = JournalReader(agent)
+        # It must be lazy: taking the first result cannot require walking the
+        # whole chain into memory first.
+        assert inspect.isgenerator(walk_and_verify(reader))
+
+    def test_localizes_tampered_step_hash_to_exact_seq(self, tmp_path: Path) -> None:
+        agent = tmp_path / "agent-1"
+        _populate(agent, 4)
+        _tamper_stored_step_hash(agent, seq=2)
+
+        reader = JournalReader(agent)
+        first = next(iter(walk_and_verify(reader)), None)
+        assert first is not None
+        assert isinstance(first, HashMismatch)
+        # First divergence is the tampered digest at seq 2, not the downstream
+        # prev_hash break it induces at seq 3.
+        assert first.seq == 2
+        assert first.first_divergent_field == "step_hash"
+        assert first.actual_hash == "f" * 64
+        # The expected hash is what the intact fields hash to.
+        assert first.expected_hash != first.actual_hash
+
+    def test_localizes_prev_hash_break_and_names_prev_hash(self, tmp_path: Path) -> None:
+        agent = tmp_path / "agent-1"
+        _populate(agent, 4)
+        _tamper_field_keep_prev(agent, seq=1)
+
+        reader = JournalReader(agent)
+        first = next(iter(walk_and_verify(reader)), None)
+        assert first is not None
+        assert first.seq == 1
+        assert first.first_divergent_field == "prev_hash"
+
+    def test_first_mismatch_is_the_earliest_step(self, tmp_path: Path) -> None:
+        agent = tmp_path / "agent-1"
+        _populate(agent, 5)
+        # Tamper two steps; the earliest must be the first yielded.
+        _tamper_stored_step_hash(agent, seq=3)
+        _tamper_stored_step_hash(agent, seq=1)
+
+        reader = JournalReader(agent)
+        first = next(iter(walk_and_verify(reader)), None)
+        assert first is not None
+        assert first.seq == 1
+
+
+# ---------------------------------------------------------------------------
+# two_run_path_diff - divergence localization + determinism
+# ---------------------------------------------------------------------------
+
+
+def _two_runs_diverging_at(tmp_path: Path, seq: int) -> tuple[Path, Path]:
+    """Build two 4-step journals that differ only at ``tool_result`` at *seq*."""
+    left = tmp_path / "left"
+    right = tmp_path / "right"
+    jl = Journal.open(left)
+    jr = Journal.open(right)
+    for i in range(4):
+        jl.append(
+            input_hash=f"a{i}",
+            model="m1",
+            prompt=f"step {i}",
+            tool_call={"name": "noop"},
+            tool_result={"ok": True, "n": i},
+        )
+        # right diverges only at `seq`: a non-deterministic tool_result.
+        jr.append(
+            input_hash=f"a{i}",
+            model="m1",
+            prompt=f"step {i}",
+            tool_call={"name": "noop"},
+            tool_result={"ok": True, "n": i if i != seq else 999},
+        )
+    jl.close()
+    jr.close()
+    return left, right
+
+
+class TestTwoRunPathDiff:
+    def test_localizes_divergence_field_and_seq(self, tmp_path: Path) -> None:
+        left, right = _two_runs_diverging_at(tmp_path, seq=2)
+        diff = two_run_path_diff(left, right)
+        assert isinstance(diff, PathDiff)
+        assert diff.diverged is True
+        assert diff.divergence is not None
+        assert diff.divergence.seq == 2
+        assert "tool_result" in diff.divergence.fields_changed
+        # The projection runs up to and including the divergence.
+        seqs = [s["seq"] for s in diff.steps]
+        assert seqs == [0, 1, 2]
+        assert diff.steps[-1]["diverged"] is True
+        assert "tool_result" in diff.steps[-1]["fields_changed"]
+
+    def test_identical_chains_no_divergence(self, tmp_path: Path) -> None:
+        left = tmp_path / "left"
+        right = tmp_path / "right"
+        _populate(left, 3)
+        _populate(right, 3)
+        diff = two_run_path_diff(left, right)
+        assert diff.diverged is False
+        assert diff.divergence is None
+        # A stable content address even when nothing diverges.
+        assert len(diff.diff_hash) == 64
+
+    def test_content_addressed_diff_is_byte_identical_across_invocations(self, tmp_path: Path) -> None:
+        left, right = _two_runs_diverging_at(tmp_path, seq=1)
+        a = two_run_path_diff(left, right)
+        b = two_run_path_diff(left, right)
+        assert a.diff_hash == b.diff_hash
+        assert json.dumps(a.to_dict(), sort_keys=True) == json.dumps(b.to_dict(), sort_keys=True)
+
+    def test_diff_hash_is_over_content_not_paths(self, tmp_path: Path) -> None:
+        # Two operators with the same journals in different directories must
+        # get the byte-identical diff artifact.
+        left, right = _two_runs_diverging_at(tmp_path, seq=2)
+        diff_a = two_run_path_diff(left, right)
+
+        # Re-create the same chains under different directory names.
+        left2, right2 = _two_runs_diverging_at(tmp_path / "op2", seq=2)
+        diff_b = two_run_path_diff(left2, right2)
+        assert diff_a.diff_hash == diff_b.diff_hash
+
+    def test_diff_hash_matches_recomputed_sha256_of_body(self, tmp_path: Path) -> None:
+        import hashlib
+
+        left, right = _two_runs_diverging_at(tmp_path, seq=2)
+        diff = two_run_path_diff(left, right)
+        body = {"diverged": diff.diverged, "divergence": diff.to_dict()["divergence"], "steps": diff.steps}
+        recomputed = hashlib.sha256(
+            json.dumps(body, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+        assert diff.diff_hash == recomputed
+
+    def test_length_mismatch_surfaces_as_divergence(self, tmp_path: Path) -> None:
+        left = tmp_path / "left"
+        right = tmp_path / "right"
+        _populate(left, 3)
+        _populate(right, 2)
+        diff = two_run_path_diff(left, right)
+        assert diff.diverged is True
+        assert diff.divergence is not None
+        assert diff.divergence.seq == 2
+        # The side-by-side marks the shorter side as absent at the missing seq.
+        last = diff.steps[-1]
+        assert last["seq"] == 2
+        assert last["right"] is None
+        assert last["left"] is not None
+
+
+def test_projection_recovers_stored_hashes_from_disk(tmp_path: Path) -> None:
+    """The side-by-side projects the exact canonical fields the writer wrote."""
+    left, right = _two_runs_diverging_at(tmp_path, seq=1)
+    diff = two_run_path_diff(left, right)
+    left_reader = JournalReader(left)
+    left_entries = {e.seq: e for e in left_reader.entries()}
+    for step in diff.steps:
+        entry = left_entries[step["seq"]]
+        assert step["left"]["prompt"] == entry.prompt
+        assert step["left"]["model"] == entry.model
+        # prev_hash chains onto the stored value, so a verifier can re-derive
+        # the step hash from the projection alone.
+        expected = compute_step_hash(
+            prev_hash=step["left"]["prev_hash"],
+            input_hash=step["left"]["input_hash"],
+            model=step["left"]["model"],
+            prompt=step["left"]["prompt"],
+            tool_call=step["left"]["tool_call"],
+            tool_result=step["left"]["tool_result"],
+        )
+        assert expected == entry.step_hash

--- a/tests/unit/test_replay_debug_cli.py
+++ b/tests/unit/test_replay_debug_cli.py
@@ -1,0 +1,374 @@
+"""Tests for the ``bernstein replay debug`` CLI dispatch (#2605).
+
+These exercise :func:`bernstein.cli.commands.replay_cmd.replay_debug`
+directly (exit codes + on-disk artifacts) and, for the fork-anchoring and
+tamper-refusal acceptance criteria, drive the full pieces the command wires
+together. The forensic contract:
+
+* a tampered chain is refused before any success artifact and the mismatch
+  is localised to the exact seq;
+* the debug receipt is offline-verifiable via ``replay verify`` and fails
+  when the chain is stripped or corrupted;
+* the two-run path-diff artifact is byte-identical across invocations;
+* ``--fork-from`` anchors the fork to the parent ``step_hash`` at seq N.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from bernstein.cli.commands.replay_cmd import replay_debug, replay_verify
+from bernstein.core.persistence.journal import Journal, JournalReader
+from bernstein.core.persistence.lineage_signer import Ed25519FileKeySigner
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+def _populate(sdd_dir: Path, run: str, n: int = 4) -> str:
+    journal_dir = sdd_dir / "runtime" / "journal" / run
+    journal = Journal.open(journal_dir)
+    head = ""
+    for i in range(n):
+        entry = journal.append(
+            input_hash=f"a{i}",
+            model="m1",
+            prompt=f"step {i}",
+            tool_call={"name": "noop"},
+            tool_result={"ok": True, "n": i},
+        )
+        head = entry.step_hash
+    journal.close()
+    return head
+
+
+def _tamper_stored_step_hash(sdd_dir: Path, run: str, seq: int) -> None:
+    bucket = sdd_dir / "runtime" / "journal" / run / "000000.jsonl"
+    lines = bucket.read_text(encoding="utf-8").splitlines()
+    row = json.loads(lines[seq])
+    row["step_hash"] = "f" * 64
+    lines[seq] = json.dumps(row, sort_keys=True, separators=(",", ":"))
+    bucket.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _two_runs_diverging_at(sdd_dir: Path, seq: int) -> tuple[str, str]:
+    left, right = "run-left", "run-right"
+    jl = Journal.open(sdd_dir / "runtime" / "journal" / left)
+    jr = Journal.open(sdd_dir / "runtime" / "journal" / right)
+    for i in range(4):
+        jl.append(input_hash=f"a{i}", model="m1", prompt=f"p{i}", tool_result={"n": i})
+        jr.append(input_hash=f"a{i}", model="m1", prompt=f"p{i}", tool_result={"n": i if i != seq else 999})
+    jl.close()
+    jr.close()
+    return left, right
+
+
+# ---------------------------------------------------------------------------
+# AC1 + AC2: tamper refusal before output, single-step localization
+# ---------------------------------------------------------------------------
+
+
+class TestSingleRun:
+    def test_clean_chain_emits_verifiable_receipt(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        sdd = tmp_path / ".sdd"
+        head = _populate(sdd, "run-1", 4)
+        rc = replay_debug(["run-1"], sdd, as_json=True)
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["verified"] is True
+        assert payload["head_hash"] == head
+        receipt_path = Path(payload["receipt"]["path"])
+        assert receipt_path.exists()
+        # AC6: the debug receipt verifies offline via the replay verify path.
+        assert replay_verify(receipt_path, expected_head=head, public_key_path=None) == 0
+
+    def test_tampered_chain_refused_before_output_and_localized(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        sdd = tmp_path / ".sdd"
+        _populate(sdd, "run-1", 4)
+        _tamper_stored_step_hash(sdd, "run-1", seq=2)
+
+        rc = replay_debug(["run-1"], sdd, as_json=True)
+        assert rc == 1  # refused, non-zero exit
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["verified"] is False
+        # Localised to exactly seq 2, naming the divergent field.
+        assert payload["seq"] == 2
+        assert payload["first_divergent_field"] == "step_hash"
+        # No success receipt is emitted for a tampered chain.
+        assert "receipt" not in payload
+        assert not (sdd / "runtime" / "receipts" / "run-1.debug.tar").exists()
+
+    def test_missing_journal_returns_2(self, tmp_path: Path) -> None:
+        assert replay_debug(["nope"], tmp_path / ".sdd", as_json=True) == 2
+
+
+# ---------------------------------------------------------------------------
+# AC6: receipt fails verification once the chain is stripped / corrupted
+# ---------------------------------------------------------------------------
+
+
+class TestReceiptForensics:
+    def test_receipt_fails_when_chain_stripped(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        sdd = tmp_path / ".sdd"
+        _populate(sdd, "run-1", 3)
+        rc = replay_debug(["run-1"], sdd, as_json=True)
+        assert rc == 0
+        receipt_path = Path(json.loads(capsys.readouterr().out)["receipt"]["path"])
+
+        # Strip the journal member: the receipt is meaningless without the chain.
+        stripped = tmp_path / "stripped.tar"
+        with tarfile.open(receipt_path, "r") as src, tarfile.open(stripped, "w") as dst:
+            for member in src.getmembers():
+                if member.name.startswith("journal/"):
+                    continue
+                fileobj = src.extractfile(member)
+                dst.addfile(member, fileobj)
+        assert replay_verify(stripped, expected_head=None, public_key_path=None) == 1
+
+    def test_receipt_fails_when_chain_corrupted(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        sdd = tmp_path / ".sdd"
+        head = _populate(sdd, "run-1", 3)
+        rc = replay_debug(["run-1"], sdd, as_json=True)
+        assert rc == 0
+        receipt_path = Path(json.loads(capsys.readouterr().out)["receipt"]["path"])
+
+        extract = tmp_path / "x"
+        with tarfile.open(receipt_path) as tar:
+            tar.extractall(extract, filter="data")
+        bucket = next(extract.rglob("*.jsonl"))
+        lines = bucket.read_text(encoding="utf-8").splitlines()
+        row = json.loads(lines[0])
+        row["prompt"] = "EVIL"
+        lines[0] = json.dumps(row, sort_keys=True, separators=(",", ":"))
+        bucket.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        repacked = tmp_path / "repacked.tar"
+        with tarfile.open(repacked, "w") as tar:
+            for item in sorted(extract.rglob("*")):
+                tar.add(item, arcname=item.relative_to(extract))
+        assert replay_verify(repacked, expected_head=head, public_key_path=None) == 1
+
+    def test_sign_passthrough_signs_and_verifies_with_public_key(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+        key = Ed25519PrivateKey.generate()
+        key_path = tmp_path / "sign.key"
+        key_path.write_bytes(
+            key.private_bytes(
+                encoding=serialization.Encoding.Raw,
+                format=serialization.PrivateFormat.Raw,
+                encryption_algorithm=serialization.NoEncryption(),
+            )
+        )
+        pub_path = tmp_path / "sign.pub"
+        pub_path.write_bytes(
+            key.public_key().public_bytes(
+                encoding=serialization.Encoding.Raw,
+                format=serialization.PublicFormat.Raw,
+            )
+        )
+
+        sdd = tmp_path / ".sdd"
+        head = _populate(sdd, "run-1", 2)
+        rc = replay_debug(["run-1"], sdd, as_json=True, sign_key_path=key_path)
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["receipt"]["signed"] is True
+        receipt_path = Path(payload["receipt"]["path"])
+        # Signed receipt verifies with the public key.
+        assert replay_verify(receipt_path, expected_head=head, public_key_path=pub_path) == 0
+        # And is rejected when a signature is present but no verifier is given.
+        assert replay_verify(receipt_path, expected_head=head, public_key_path=None) == 1
+
+    def test_load_signer_is_reused_from_lineage_signer(self, tmp_path: Path) -> None:
+        # Guard against a divergent signer implementation: debug must sign with
+        # the same Ed25519FileKeySigner the export path uses.
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+        key = Ed25519PrivateKey.generate()
+        key_path = tmp_path / "k"
+        key_path.write_bytes(
+            key.private_bytes(
+                encoding=serialization.Encoding.Raw,
+                format=serialization.PrivateFormat.Raw,
+                encryption_algorithm=serialization.NoEncryption(),
+            )
+        )
+        signer = Ed25519FileKeySigner.from_path(key_path)
+        assert signer.sign(b"x")
+
+
+# ---------------------------------------------------------------------------
+# AC3 + AC4: two-run divergence + byte-identical content-addressed artifact
+# ---------------------------------------------------------------------------
+
+
+class TestTwoRun:
+    def test_two_run_divergence_localized(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        sdd = tmp_path / ".sdd"
+        left, right = _two_runs_diverging_at(sdd, seq=2)
+        rc = replay_debug([left, right], sdd, as_json=True)
+        assert rc == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["diverged"] is True
+        assert payload["divergence"]["seq"] == 2
+        assert "tool_result" in payload["divergence"]["fields_changed"]
+
+    def test_path_diff_artifact_byte_identical_across_invocations(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        sdd = tmp_path / ".sdd"
+        left, right = _two_runs_diverging_at(sdd, seq=1)
+
+        rc1 = replay_debug([left, right], sdd, as_json=True)
+        payload1 = json.loads(capsys.readouterr().out)
+        artifact_path = Path(payload1["artifact_path"])
+        first_bytes = artifact_path.read_bytes()
+        first_hash = payload1["diff_hash"]
+
+        rc2 = replay_debug([left, right], sdd, as_json=True)
+        payload2 = json.loads(capsys.readouterr().out)
+        second_bytes = Path(payload2["artifact_path"]).read_bytes()
+
+        assert rc1 == rc2 == 1
+        assert first_bytes == second_bytes
+        assert first_hash == payload2["diff_hash"]
+
+    def test_identical_runs_exit_zero(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        sdd = tmp_path / ".sdd"
+        _populate(sdd, "run-a", 3)
+        _populate(sdd, "run-b", 3)
+        rc = replay_debug(["run-a", "run-b"], sdd, as_json=True)
+        assert rc == 0
+        assert json.loads(capsys.readouterr().out)["diverged"] is False
+
+    def test_jump_to_failure_positions_output_without_changing_artifact(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        sdd = tmp_path / ".sdd"
+        left, right = _two_runs_diverging_at(sdd, seq=2)
+
+        replay_debug([left, right], sdd, as_json=True)
+        base = json.loads(capsys.readouterr().out)
+
+        replay_debug([left, right], sdd, as_json=True, jump_to_failure=True)
+        jumped = json.loads(capsys.readouterr().out)
+
+        assert jumped["jump_to_seq"] == 2
+        # The presentation flag must not perturb the content-addressed artifact.
+        assert jumped["diff_hash"] == base["diff_hash"]
+
+
+# ---------------------------------------------------------------------------
+# AC5: --fork-from anchors to the parent step_hash at seq N
+# ---------------------------------------------------------------------------
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(root, "init", "-q", "-b", "main")
+    _git(root, "config", "user.email", "test@example.com")
+    _git(root, "config", "user.name", "Test")
+    (root / "README.md").write_text("# repo\n", encoding="utf-8")
+    _git(root, "add", "README.md")
+    _git(root, "commit", "-q", "-m", "initial")
+    return root
+
+
+def _parent_with_journal(repo: Path) -> tuple[str, list[str]]:
+    from bernstein.core.orchestration.run_session import RunSession, sessions_dir_for
+
+    sdir = sessions_dir_for(repo)
+    sdir.mkdir(parents=True, exist_ok=True)
+    session = RunSession.create(goal="build", run_seed=42)
+    session.tasks = [{"id": "t-1", "role": "backend", "title": "x", "status": "in_progress"}]
+    session.save(sdir)
+
+    journal_dir = repo / ".sdd" / "runtime" / "journal" / session.session_id
+    journal = Journal.open(journal_dir)
+    heads: list[str] = []
+    for i in range(4):
+        entry = journal.append(input_hash=f"a{i}", model="m1", prompt=f"s{i}", tool_result={"n": i})
+        heads.append(entry.step_hash)
+    journal.close()
+    return session.session_id, heads
+
+
+class TestForkFrom:
+    def test_fork_from_step_anchors_parent_step_hash(self, repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        run, heads = _parent_with_journal(repo)
+        sdd = repo / ".sdd"
+
+        rc = replay_debug([run], sdd, as_json=True, fork_from=2, repo_root=repo)
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["fork"]["from_step"] == 2
+        # The reproduction anchor is the parent step hash at seq 2.
+        assert payload["fork"]["parent_step_hash"] == heads[2]
+
+        # And the seeded fork journal head equals that parent step hash.
+        fork_worktree = Path(payload["fork"]["fork_worktree"])
+        fork_sid = payload["fork"]["fork_session_id"]
+        fork_journal = fork_worktree / ".sdd" / "runtime" / "journal" / fork_sid
+        reader = JournalReader(fork_journal)
+        entries = list(reader.entries())
+        assert [e.seq for e in entries] == [0, 1, 2]
+        assert entries[-1].step_hash == heads[2]
+
+    def test_fork_from_out_of_range_fails_fast(self, repo: Path) -> None:
+        run, _heads = _parent_with_journal(repo)
+        sdd = repo / ".sdd"
+        rc = replay_debug([run], sdd, as_json=True, fork_from=99, repo_root=repo)
+        assert rc == 1
+        # No fork worktree was created.
+        worktrees = repo / ".sdd" / "worktrees"
+        assert not worktrees.exists() or not any(worktrees.iterdir())
+
+
+# ---------------------------------------------------------------------------
+# End-to-end wiring through the ``bernstein replay`` pseudo-group
+# ---------------------------------------------------------------------------
+
+
+class TestCliWiring:
+    def test_replay_debug_single_run_via_group(self, tmp_path: Path) -> None:
+        from bernstein.cli.advanced_cmd import replay_cmd
+        from click.testing import CliRunner
+
+        sdd = tmp_path / ".sdd"
+        _populate(sdd, "run-1", 3)
+        runner = CliRunner()
+        result = runner.invoke(replay_cmd, ["debug", "run-1", "--sdd-dir", str(sdd), "--as-json"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["verified"] is True
+        assert payload["mode"] == "single-run"
+
+    def test_replay_debug_two_run_divergence_via_group_exits_nonzero(self, tmp_path: Path) -> None:
+        from bernstein.cli.advanced_cmd import replay_cmd
+        from click.testing import CliRunner
+
+        sdd = tmp_path / ".sdd"
+        left, right = _two_runs_diverging_at(sdd, seq=1)
+        runner = CliRunner()
+        result = runner.invoke(replay_cmd, ["debug", left, right, "--sdd-dir", str(sdd), "--as-json"])
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.output)
+        assert payload["divergence"]["seq"] == 1


### PR DESCRIPTION
## What
Implemented the deterministic replay-debugging surface (#2605) as a forensic projection over the existing Merkle step chain — no new hashing or storage. Added bernstein/core/replay/debug.py (HashMismatch, streaming walk_and_verify, content-addressed two_run_path_diff), wired a `replay debug` verb through the replay pseudo-group in replay_cmd.py/advanced_cmd.py with --fork-from, --jump-to-failure, --sign, --full/--limit and --json, and documented the exploratory-vs-forensic distinction in docs/operations/replay.md. The debug receipt is a journal_export.export_receipt tarball that verifies offline via `replay verify`. 6 new commits pushed; no PR opened.

Fixes #2605

## Acceptance criteria (6/6 met)
- [x] AC1: replay debug <run> verifies chain head via JournalReader.verify before any output and refuses a tampered chain (non-zero exit)
- [x] AC2: single tampered step_hash at N reported as a hash mismatch localized to exactly seq N, naming the first divergent canonical field, no other step
- [x] AC3: two runs diverging only at N surface the divergence at seq N with the field name, driven by diff_journals
- [x] AC4: two-run path diff twice produces a byte-identical content-addressed diff artifact (same SHA256)
- [x] AC5: --fork-from N produces a fork worktree whose seeded journal head equals the parent step_hash at seq N, and the debug output records parent_step_h
- [x] AC6: primary output is a debug receipt that replay verify accepts offline; stripping or corrupting the chain (or its recorded head) makes it fail veri

## Verification
Adversarial review: **confirmed, 0 critical findings** (empirical criteria re-attacked independently: tamper/determinism/red-on-main).
uv run pytest tests/unit/test_replay_debug.py tests/unit/test_replay_debug_cli.py -q => 27 passed. Broader: 76 new+adjacent passed, 6 fork-integration passed. Only targeted test files were run (never the full suite); collection-only sentinel used once.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added forensic replay debugging with single-run verification, two-run comparisons, and fork-from-step analysis.
  * Added options to jump to failures, display full output, and sign debug receipts.
  * Added tamper detection with localized divergence reporting and offline-verifiable receipts.
  * Added deterministic, content-addressed path-diff artifacts for comparing runs.

* **Documentation**
  * Added usage guidance, debugging modes, privacy behavior, and artifact locations for replay debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->