### PR TITLE
feat(security): attenuated delegation capability tokens for verifiable multi-hop authority

### DIFF
--- a/docs/operations/security-and-identity.md
+++ b/docs/operations/security-and-identity.md
@@ -207,6 +207,65 @@ Backing store: `core/security/agent_identity.py` (`AgentIdentityStore`) under
 (`routes/identities.py:17-27`). Credentials are stored hashed; the API
 strips them before responses (`:82`).
 
+## Delegation capability tokens
+
+When a run fans out, authority fans out with it. A **capability token** makes
+each delegation hop a signed, scope-attenuating grant, so the
+`principal -> orchestrator -> sub-agent` authority chain becomes a single
+offline-verifiable structure. Backing module: `core/security/capability_tokens.py`.
+
+Each token is an Ed25519 **detached JWS** (RFC 7515) over the JCS-canonical
+(RFC 8785) token body, with a token-specific `typ` (`delegation-capability+jws`)
+so a signature minted for an agent card cannot be replayed as a token. The token
+binds both its own `issuer_pubkey` and its delegatee's `subject_pubkey` captured
+at mint time, so **key rotation never invalidates historical tokens**. Signing
+and key resolution reuse `agent_card_signer.py` and `agent_card_keystore.py`.
+
+**Tokens narrow, never grant.** `attenuate(parent, ...)` enforces that a child's
+caveats are a subset of its parent's over every axis:
+
+| Caveat            | Subset rule                                                            |
+| ----------------- | --------------------------------------------------------------------- |
+| `permissions`     | set-subset over the `PERM_*` vocabulary                               |
+| `task_ids`        | allowlist subset (`None` = unconstrained/widest)                     |
+| `path_prefixes`   | POSIX ancestor-or-equal coverage (`/a/b` covers `/a/b/c`, not `/a/bc`) |
+| `not_after`       | expiry no later than the parent                                       |
+| `max_uses`        | no greater than the parent (`None` = unlimited/widest)               |
+| `remaining_depth` | **strictly less** than the parent (the `max_depth` caveat)            |
+
+Widening at any hop is rejected at mint time *and* independently at verify time,
+so a re-signed, structurally-continuous but widened hop still fails from the
+signed bytes alone. Approval-gated actions are deliberately **not** expressible
+as caveats: a token answers "was this sub-agent granted more than its parent
+held?", never "may it perform an action requiring fresh approval?" - that
+escalation stays on the approval-receipt surface.
+
+Every mint anchors a `delegation_minted` event into the HMAC audit chain
+(`audit_chain.py`), whose `token_hash` and embedded `prev_chain_digest`
+cross-reference the token's identity and captured `audit_head` - so
+`bernstein audit verify` also attests the mint happened at a fixed chain
+position. `PermissionDelegator.verify_capability` verifies the offline chain
+first and consults the in-process registry only for liveness (expiry) and
+revocation; existing enum-scope callers keep working via `enum_to_caveats`.
+
+`verify_chain` walks the chain root -> leaf with **no network and no registry**:
+per-hop signature, structural `parent_token_hash` linkage, identity and pubkey
+continuity (the issuer of hop N is the subject of hop N-1), monotonic
+attenuation, and root trust-anchor membership. `to_actor_claims` projects a
+*verified* chain as nested RFC 8693 `act` claims for external IdP tooling and
+refuses an unverified chain.
+
+Verify a chain offline from the CLI:
+
+```
+bernstein delegation verify-token chain.json --trust-anchor principal.pem
+```
+
+It prints per-hop PASS/FAIL plus the resolved authority path and exits non-zero
+on any failing hop. (This is distinct from `bernstein delegation verify <run>`,
+which reconstructs the per-hop HMAC *receipt* chain - the ACT log - in
+`core/identity/delegation.py`.)
+
 ## Install fingerprint (v1.0)
 
 A separate identity surface, off by default, lives at
@@ -361,6 +420,8 @@ Compliance modules in code (`core/security/`):
 | OIDC / SAML / device flow routes   | `src/bernstein/core/routes/auth.py`                                   |
 | Agent identities API               | `src/bernstein/core/routes/identities.py`                             |
 | Agent identity store               | `src/bernstein/core/security/agent_identity.py`                                |
+| Delegation capability tokens       | `src/bernstein/core/security/capability_tokens.py`, `permission_delegation.py` |
+| Delegation verify CLI              | `src/bernstein/cli/commands/delegation_cmd.py`                        |
 | Audit log (HMAC chain)             | `src/bernstein/core/security/audit.py`                                |
 | Audit integrity verifier           | `src/bernstein/core/security/audit_integrity.py`                      |
 | Audit query / search routes        | `src/bernstein/core/routes/audit_log.py`                              |

--- a/src/bernstein/cli/commands/delegation_cmd.py
+++ b/src/bernstein/cli/commands/delegation_cmd.py
@@ -1,11 +1,17 @@
-"""``bernstein delegation`` - verify per-hop delegation receipts for a run.
+"""``bernstein delegation`` - verify delegation chains offline.
 
-Each run authorizes a ``principal -> orchestrator -> sub-agent`` chain, one
-HMAC-chained receipt per hop (see
-:mod:`bernstein.core.identity.delegation`). ``delegation verify <run>``
-reconstructs that chain offline and confirms it is intact - which principal
-authorized which sub-agent action - exiting non-zero on any tamper, deleted
-hop, or missing chain (issue #2305 AC4).
+Two distinct surfaces:
+
+* ``delegation verify <run>`` reconstructs the per-hop HMAC *receipt* chain for
+  a run (the ACT log: which principal authorized which sub-agent action, see
+  :mod:`bernstein.core.identity.delegation`), exiting non-zero on any tamper,
+  deleted hop, or missing chain (issue #2305 AC4).
+* ``delegation verify-token <token-file>`` verifies a signed *authority* token
+  chain (see :mod:`bernstein.core.security.capability_tokens`): per-hop
+  signature, structural linkage, identity/pubkey continuity, monotonic
+  attenuation, and root trust-anchor membership - fully offline, no network and
+  no registry - printing pass/fail per hop and exiting non-zero on any failing
+  hop (issue #2611).
 """
 
 from __future__ import annotations
@@ -27,6 +33,7 @@ def delegation_group() -> None:
     Examples:
       bernstein delegation verify run-42
       bernstein delegation verify run-42 --json
+      bernstein delegation verify-token chain.json --trust-anchor principal.pem
     """
 
 
@@ -80,3 +87,94 @@ def verify_cmd(run: str, root: Path | None, as_json: bool) -> None:
         console.print(f"[red]  {err}[/red]")
     console.print("[red]delegation chain verification failed[/red]")
     raise SystemExit(1)
+
+
+@delegation_group.command("verify-token")
+@click.argument(
+    "token_file",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.option(
+    "--trust-anchor",
+    "trust_anchor_files",
+    multiple=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="Trusted root-issuer public-key PEM (repeatable). Defaults to the local agent-card keystore public key.",
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Emit machine-readable JSON.")
+def verify_token_cmd(token_file: Path, trust_anchor_files: tuple[Path, ...], as_json: bool) -> None:
+    """Verify a signed capability-token chain in TOKEN_FILE, fully offline.
+
+    Prints per-hop pass/fail and the resolved principal -> ... -> leaf authority
+    path. Exits 0 only when every hop verifies (signature, linkage, continuity,
+    attenuation, and a trusted root); 1 on any failing hop, an empty chain, or an
+    unreadable token file.
+    """
+    from bernstein.core.security import capability_tokens as ct
+
+    try:
+        chain = ct.CapabilityChain.from_json(token_file.read_text(encoding="utf-8"))
+    except (ValueError, KeyError, json.JSONDecodeError) as exc:
+        console.print(f"[red]unreadable token file:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+    anchors: set[str] = {p.read_text(encoding="utf-8") for p in trust_anchor_files}
+    if not anchors:
+        anchors = _keystore_trust_anchors()
+
+    result = ct.verify_chain(chain, trust_anchors=anchors)
+
+    if as_json:
+        payload = {
+            "valid": result.valid,
+            "principal_path": result.principal_path,
+            "hops": [
+                {
+                    "hop_index": h.hop_index,
+                    "issuer": h.issuer_identity_id,
+                    "subject": h.subject_identity_id,
+                    "ok": h.ok,
+                    "errors": h.errors,
+                }
+                for h in result.hops
+            ],
+        }
+        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+        raise SystemExit(0 if result.valid else 1)
+
+    if not result.hops:
+        console.print("[red]empty token chain[/red]")
+        raise SystemExit(1)
+
+    for hop in result.hops:
+        marker = "[green]PASS[/green]" if hop.ok else "[red]FAIL[/red]"
+        console.print(f"  hop {hop.hop_index}: {hop.issuer_identity_id} -> {hop.subject_identity_id}  {marker}")
+        for err in hop.errors:
+            console.print(f"[red]      {err}[/red]")
+
+    console.print(f"[dim]authority path:[/dim] {' -> '.join(result.principal_path)}")
+    if result.valid:
+        console.print(f"[green]capability chain verified[/green] ({len(result.hops)} hop(s))")
+        raise SystemExit(0)
+    console.print("[red]capability chain verification failed[/red]")
+    raise SystemExit(1)
+
+
+def _keystore_trust_anchors() -> set[str]:
+    """Return the local agent-card keystore public key as the default anchor set.
+
+    The root issuer of a locally-minted chain is the install identity, so the
+    keystore's current public key is the natural default trust anchor. Returns an
+    empty set when no keystore is available - the root-anchor check then fails
+    loudly rather than trusting an unknown root.
+    """
+    try:
+        from bernstein.core.security.agent_card_keystore import AgentCardKeystore
+
+        _priv, public_pem = AgentCardKeystore().load_or_generate()
+    except Exception:
+        # A missing / unreadable keystore is non-fatal: fall back to an empty
+        # anchor set so the root-anchor check fails loudly rather than trusting
+        # an unknown root.
+        return set()
+    return {public_pem.decode("ascii")}

--- a/src/bernstein/core/security/agent_card_signer.py
+++ b/src/bernstein/core/security/agent_card_signer.py
@@ -42,6 +42,7 @@ __all__ = [
     "ed25519_public_jwk",
     "generate_ed25519_keypair",
     "sign_agent_card",
+    "sign_detached_jws_over_canonical",
     "verify_agent_card",
     "verify_detached_jws_over_canonical",
 ]
@@ -353,6 +354,50 @@ def ed25519_pem_from_jwk(jwk: dict[str, Any]) -> bytes:
         serialization.Encoding.PEM,
         serialization.PublicFormat.SubjectPublicKeyInfo,
     )
+
+
+def sign_detached_jws_over_canonical(
+    canonical_body: bytes,
+    private_key_pem: bytes,
+    *,
+    typ: str,
+    kid: str,
+) -> str:
+    """Sign pre-canonicalised body bytes as a detached JWS (RFC 7515 §A.5).
+
+    The symmetric emit counterpart to :func:`verify_detached_jws_over_canonical`:
+    both compute the signing input as ``base64url(header).base64url(canonical_body)``
+    and leave the compact JWS payload segment empty. Any JWS surface that needs a
+    body-independent signature (agent cards, capability tokens, ...) can reuse this
+    instead of hand-rolling the base64url framing.
+
+    Args:
+        canonical_body: The JCS-canonical body bytes to attest to. The caller is
+            responsible for canonicalization (e.g. via :func:`canonicalize_jcs`);
+            the same bytes must be presented to the verifier.
+        private_key_pem: PEM-encoded PKCS#8 Ed25519 private key, as produced by
+            :func:`generate_ed25519_keypair`.
+        typ: The JWS ``typ`` header value binding the signature to its context
+            (e.g. ``delegation-capability+jws``) so a signature minted for one
+            surface cannot be replayed as another.
+        kid: Key identifier stamped into the protected header.
+
+    Returns:
+        Compact detached JWS string ``base64url(header)..base64url(signature)``.
+    """
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    private_key = serialization.load_pem_private_key(private_key_pem, password=None)
+    if not isinstance(private_key, Ed25519PrivateKey):
+        msg = "sign_detached_jws_over_canonical requires an Ed25519 (EdDSA) private key"
+        raise ValueError(msg)
+    header = {"alg": "EdDSA", "typ": typ, "kid": kid}
+    header_b64 = _b64url(canonicalize_jcs(header))
+    body_b64 = _b64url(canonical_body)
+    signing_input = f"{header_b64}.{body_b64}".encode("ascii")
+    sig_b64 = _b64url(private_key.sign(signing_input))
+    return f"{header_b64}..{sig_b64}"
 
 
 def verify_detached_jws_over_canonical(

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -6566,6 +6566,63 @@ EVENT_POOL_CLAIM_RECEIPT = "pool.claim_receipt"
 #: infra drift is chain-attested and the dispatch falls back to cold cleanly.
 EVENT_POOL_WARM_QUARANTINE = "pool.warm_quarantine"
 
+#: Issue #2611 -- emitted once per attenuated delegation capability-token mint
+#: (see :mod:`bernstein.core.security.capability_tokens`). The event mirrors the
+#: token's ``{token_hash, issuer_identity_id, subject_identity_id,
+#: parent_token_hash, remaining_depth}`` into the HMAC chain and embeds the prior
+#: chain digest, so the token's ``audit_head`` (the tip captured at mint) and the
+#: event's ``prev_chain_digest`` cross-reference each other. A verifier can prove,
+#: from the chain alone, that a specific authority token was minted at a specific
+#: point in history without the record exposing the token's caveats or signature.
+EVENT_DELEGATION_MINTED = "delegation_minted"
+
+
+def record_delegation_minted(
+    *,
+    chain: AuditChainStore,
+    token_hash: str,
+    issuer_identity_id: str,
+    subject_identity_id: str,
+    parent_token_hash: str,
+    remaining_depth: int,
+    actor: str = "delegation_minter",
+) -> AuditEvent:
+    """Append a ``delegation_minted`` event into *chain* (#2611).
+
+    Anchors one attenuated capability-token mint in the HMAC chain. The embedded
+    ``prev_chain_digest`` equals the tip the token captured as its ``audit_head``,
+    and ``token_hash`` is the JCS hash of the token body, so the chain and the
+    token cross-reference each other: a verifier holding both can prove the token
+    was minted at this exact chain position. Only identifiers, the parent hash,
+    and the remaining delegation depth are recorded -- never caveats or key
+    material.
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        token_hash: JCS hash of the minted token body (its identity).
+        issuer_identity_id: Identity that issued (signed) the token.
+        subject_identity_id: Identity the token was delegated to.
+        parent_token_hash: Hash of the parent token (genesis for a root mint).
+        remaining_depth: The token's ``max_depth`` caveat after this hop.
+        actor: Recorded actor; defaults to ``"delegation_minter"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_DELEGATION_MINTED,
+        actor=actor,
+        resource_type="capability_token",
+        resource_id=token_hash,
+        details={
+            "token_hash": token_hash,
+            "issuer_identity_id": issuer_identity_id,
+            "subject_identity_id": subject_identity_id,
+            "parent_token_hash": parent_token_hash,
+            "remaining_depth": remaining_depth,
+        },
+    )
+
 
 def record_pool_registered(
     *,
@@ -6891,6 +6948,7 @@ __all__ = [
     "EVENT_COST_DISPATCH_RECEIPT",
     "EVENT_COST_PROFILE_REPORT",
     "EVENT_DASHBOARD_TOKEN_GRANT",
+    "EVENT_DELEGATION_MINTED",
     "EVENT_ENDPOINT_CERTIFICATION",
     "EVENT_ESCALATION_RECEIPT",
     "EVENT_EVAL_AB_COMPARISON",
@@ -7010,6 +7068,7 @@ __all__ = [
     "record_cost_dispatch_receipt",
     "record_cost_profile_report",
     "record_dashboard_token_grant",
+    "record_delegation_minted",
     "record_endpoint_certification",
     "record_escalation_receipt",
     "record_eval_ab_comparison",

--- a/src/bernstein/core/security/capability_tokens.py
+++ b/src/bernstein/core/security/capability_tokens.py
@@ -1,0 +1,760 @@
+"""Attenuated delegation capability tokens for verifiable multi-hop authority.
+
+When a run fans out, authority fans out with it. This module makes each
+delegation hop a **signed, scope-attenuating capability token** so the
+``principal -> orchestrator -> sub-agent`` authority chain becomes a single
+offline-verifiable structure: an auditor asking "who authorized this sub-agent
+to write these files, and was that authority ever broader than the human
+granted?" gets a cryptographic answer from the token bytes alone, with no live
+coordinator, no registry, and no network.
+
+AUTHORITY tokens vs. the ACT log
+--------------------------------
+This module records *authority* - the scoped, signed grant that flows down a
+delegation chain. It is deliberately distinct from
+:mod:`bernstein.core.identity.delegation`, which records per-hop HMAC
+*receipts* (the ACT log: which principal authorized which sub-agent action for
+a run). Receipts may later reference token hashes, but the two surfaces are not
+coupled here.
+
+Wire format
+-----------
+Each :class:`CapabilityToken` is signed with a **detached JWS** (RFC 7515 §A.5)
+over the **JCS-canonical** (RFC 8785) token body, using the shared Ed25519
+primitives in :mod:`bernstein.core.security.agent_card_signer`. The JWS carries
+a token-specific ``typ`` header (``delegation-capability+jws``) so a signature
+minted for an agent card cannot be replayed as a token, and vice versa. The
+token binds its own ``issuer_pubkey`` and its delegatee's ``subject_pubkey``,
+so verification checks against the key captured *at mint time* - **key rotation
+never invalidates historical tokens**.
+
+Attenuation (tokens narrow, they never grant)
+---------------------------------------------
+:func:`attenuate` mints a child token and enforces that the child's caveats are
+a **subset** of the parent's over every axis:
+
+* ``permissions`` - set-subset over the ``PERM_*`` vocabulary.
+* ``task_ids`` - allowlist subset (``None`` means unconstrained/widest).
+* ``path_prefixes`` - POSIX-normalized prefix coverage; a child prefix is
+  covered iff some parent prefix is an ancestor-or-equal of it (so ``/a/b``
+  covers ``/a/b/c`` and ``/a/b`` but never ``/a/bc``).
+* ``not_after`` - expiry no later than the parent.
+* ``max_uses`` - no greater than the parent (``None`` means unlimited/widest).
+* ``remaining_depth`` - **strictly less** than the parent (the ``max_depth``
+  caveat). A chain cannot grow past the depth its root authorized; a hop whose
+  depth is not strictly below its parent's is rejected at mint *and* at verify.
+
+Widening at any hop is rejected at mint time (:class:`AttenuationError`) and is
+independently caught at verify time (:func:`verify_chain`), so a re-signed,
+structurally-continuous but widened hop still fails from the signed bytes alone.
+
+Two-tier boundary
+------------------
+Tokens express only *narrowing*. They cannot **widen** authority and they
+cannot express **approval-gated actions** (an action that must route through a
+human/approval step). Approval-gated escalation is intentionally *not*
+representable as a caveat: the approval-receipt surface stays the escalation
+path. A capability token answers "was this sub-agent ever granted more than its
+parent held?"; it never answers "may this sub-agent perform an action that
+requires fresh approval?" - that second question belongs to the approval
+receipts, by design.
+
+RFC 8693 projection
+-------------------
+:func:`to_actor_claims` renders a *verified* chain as nested RFC 8693 ``act``
+claims (``{"sub": ..., "act": {"sub": ..., "act": {...}}}``) so standard IdP
+tooling can consume the delegation path without understanding this token
+format. The projection refuses an unverified chain.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import posixpath
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.agents.agent_identity import (
+    PERM_AGENTS_READ,
+    PERM_AGENTS_SPAWN,
+    PERM_CONFIG_READ,
+    PERM_FILES_READ,
+    PERM_FILES_WRITE,
+    PERM_STATUS_READ,
+    PERM_TASKS_CLAIM,
+    PERM_TASKS_READ,
+    PERM_TASKS_WRITE,
+    PERM_TESTS_RUN,
+)
+from bernstein.core.security.agent_card_signer import (
+    canonicalize_jcs,
+    sign_detached_jws_over_canonical,
+    verify_detached_jws_over_canonical,
+)
+
+if TYPE_CHECKING:
+    from bernstein.core.security.audit import AuditEvent
+    from bernstein.core.security.audit_chain import AuditChainStore
+
+__all__ = [
+    "GENESIS_PARENT",
+    "TOKEN_TYP",
+    "AttenuationError",
+    "CapabilityChain",
+    "CapabilityToken",
+    "Caveats",
+    "ChainVerification",
+    "HopVerification",
+    "TokenVerificationError",
+    "attenuate",
+    "caveats_for_scope",
+    "mint_root",
+    "scope_permissions",
+    "sign_token",
+    "to_actor_claims",
+    "verify_chain",
+]
+
+#: JWS ``typ`` header binding a signature to the capability-token context. A
+#: signature minted with any other ``typ`` (an agent card, a lineage record)
+#: will not verify as a token, and vice versa.
+TOKEN_TYP: str = "delegation-capability+jws"
+
+#: Parent-hash sentinel for a root token (the genesis of a chain). Matches the
+#: 64-hex-zero anchor convention used by the audit and delegation-receipt chains.
+GENESIS_PARENT: str = "0" * 64
+
+
+class AttenuationError(ValueError):
+    """A child token attempted to widen (not narrow) its parent's authority."""
+
+
+class TokenVerificationError(ValueError):
+    """An operation required a verified chain but verification failed."""
+
+
+# ---------------------------------------------------------------------------
+# Enum -> caveat mapping (back-compat bridge for scope-based callers)
+# ---------------------------------------------------------------------------
+
+#: Cumulative permission sets for the legacy ``DelegationScope`` enum, expressed
+#: over the ``PERM_*`` vocabulary. ``read`` < ``write`` < ``execute`` < ``full``
+#: so a token minted for a narrower scope is a strict subset of a wider one -
+#: the enum hierarchy maps onto capability-token subset attenuation unchanged.
+_SCOPE_READ: frozenset[str] = frozenset(
+    {PERM_TASKS_READ, PERM_FILES_READ, PERM_STATUS_READ, PERM_AGENTS_READ, PERM_CONFIG_READ}
+)
+_SCOPE_WRITE: frozenset[str] = _SCOPE_READ | {PERM_TASKS_WRITE, PERM_FILES_WRITE, PERM_TASKS_CLAIM}
+_SCOPE_EXECUTE: frozenset[str] = _SCOPE_WRITE | {PERM_TESTS_RUN, PERM_AGENTS_SPAWN}
+_SCOPE_FULL: frozenset[str] = _SCOPE_EXECUTE
+
+_SCOPE_PERMISSIONS: dict[str, frozenset[str]] = {
+    "read": _SCOPE_READ,
+    "write": _SCOPE_WRITE,
+    "execute": _SCOPE_EXECUTE,
+    "full": _SCOPE_FULL,
+}
+
+
+def scope_permissions(scope: str) -> frozenset[str]:
+    """Return the ``PERM_*`` set a legacy ``DelegationScope`` enum maps onto."""
+    return _SCOPE_PERMISSIONS.get(scope, _SCOPE_READ)
+
+
+def caveats_for_scope(
+    scope: str,
+    *,
+    remaining_depth: int,
+    not_after: float,
+    task_ids: set[str] | frozenset[str] | None = None,
+    path_prefixes: set[str] | frozenset[str] | None = None,
+    max_uses: int | None = None,
+    extra_permissions: set[str] | frozenset[str] | None = None,
+) -> Caveats:
+    """Build a :class:`Caveats` from a legacy scope enum (enum -> caveat bridge).
+
+    Existing ``permission_delegation`` callers speak the coarse
+    ``read``/``write``/``execute``/``full`` enum; this renders that scope as the
+    explicit caveat set the signed path enforces, so those callers keep working.
+    """
+    perms = set(scope_permissions(scope))
+    if extra_permissions:
+        perms |= set(extra_permissions)
+    return Caveats(
+        permissions=frozenset(perms),
+        remaining_depth=remaining_depth,
+        not_after=not_after,
+        task_ids=frozenset(task_ids) if task_ids is not None else None,
+        path_prefixes=(frozenset(_normalize_path(p) for p in path_prefixes) if path_prefixes is not None else None),
+        max_uses=max_uses,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Path-prefix subset semantics (POSIX-normalized ancestor-or-equal coverage)
+# ---------------------------------------------------------------------------
+
+
+def _normalize_path(path: str) -> str:
+    """Return the POSIX-normalized form of *path* (collapse ``.``/``..``/``//``)."""
+    return posixpath.normpath(path)
+
+
+def _path_covered_by(child: str, parent: str) -> bool:
+    """Return True iff *parent* is an ancestor-or-equal of *child* (POSIX).
+
+    Coverage is component-wise, not string-prefix: ``/a/b`` covers ``/a/b`` and
+    ``/a/b/c`` but not ``/a/bc``. Both operands are normalized first, so
+    ``/a/./b`` and ``/a/b/`` compare equal to ``/a/b``.
+    """
+    c = _normalize_path(child)
+    p = _normalize_path(parent)
+    if p == c:
+        return True
+    boundary = p if p.endswith("/") else p + "/"
+    return c.startswith(boundary)
+
+
+def _allowlist_narrows(child: frozenset[str] | None, parent: frozenset[str] | None) -> bool:
+    """Subset for allowlists where ``None`` is the universal (widest) set."""
+    if parent is None:
+        return True
+    if child is None:
+        return False
+    return child <= parent
+
+
+def _prefixes_narrow(child: frozenset[str] | None, parent: frozenset[str] | None) -> bool:
+    """Every child prefix must be covered by some parent prefix (``None`` = all)."""
+    if parent is None:
+        return True
+    if child is None:
+        return False
+    return all(any(_path_covered_by(c, p) for p in parent) for c in child)
+
+
+def _uses_narrows(child: int | None, parent: int | None) -> bool:
+    """``max_uses`` subset where ``None`` means unlimited (widest)."""
+    if parent is None:
+        return True
+    if child is None:
+        return False
+    return child <= parent
+
+
+# ---------------------------------------------------------------------------
+# Caveats
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Caveats:
+    """The scope-narrowing predicates a capability token carries.
+
+    A child token's caveats must be a subset of its parent's over every field
+    (see :meth:`is_narrowing_of`). ``task_ids`` and ``path_prefixes`` use
+    ``None`` to mean *unconstrained* (the widest possible value); ``max_uses``
+    uses ``None`` to mean *unlimited*.
+    """
+
+    permissions: frozenset[str]
+    remaining_depth: int
+    not_after: float
+    task_ids: frozenset[str] | None = None
+    path_prefixes: frozenset[str] | None = None
+    max_uses: int | None = None
+
+    def is_narrowing_of(self, parent: Caveats) -> bool:
+        """Return True iff ``self`` narrows (is a subset of) ``parent``.
+
+        Enforces set-subset over permissions and task-ids, ancestor-or-equal
+        prefix coverage, ``not_after <=``, ``max_uses <=``, and the
+        ``max_depth`` rule ``0 <= remaining_depth < parent.remaining_depth``.
+        """
+        if not self.permissions <= parent.permissions:
+            return False
+        if not _allowlist_narrows(self.task_ids, parent.task_ids):
+            return False
+        if not _prefixes_narrow(self.path_prefixes, parent.path_prefixes):
+            return False
+        if self.not_after > parent.not_after:
+            return False
+        if not _uses_narrows(self.max_uses, parent.max_uses):
+            return False
+        return 0 <= self.remaining_depth < parent.remaining_depth
+
+    def to_body(self) -> dict[str, Any]:
+        """Return a JSON/JCS-ready dict (sets rendered as sorted lists)."""
+        return {
+            "permissions": sorted(self.permissions),
+            "remaining_depth": self.remaining_depth,
+            "not_after": self.not_after,
+            "task_ids": sorted(self.task_ids) if self.task_ids is not None else None,
+            "path_prefixes": sorted(self.path_prefixes) if self.path_prefixes is not None else None,
+            "max_uses": self.max_uses,
+        }
+
+    @classmethod
+    def from_body(cls, body: dict[str, Any]) -> Caveats:
+        """Inverse of :meth:`to_body`."""
+        task_ids = body.get("task_ids")
+        prefixes = body.get("path_prefixes")
+        return cls(
+            permissions=frozenset(body["permissions"]),
+            remaining_depth=int(body["remaining_depth"]),
+            not_after=float(body["not_after"]),
+            task_ids=frozenset(task_ids) if task_ids is not None else None,
+            path_prefixes=frozenset(prefixes) if prefixes is not None else None,
+            max_uses=body.get("max_uses"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# CapabilityToken
+# ---------------------------------------------------------------------------
+
+
+def _spki_pem(private_key_pem: bytes) -> str:
+    """Return the SPKI-PEM public key text derived from an Ed25519 private PEM."""
+    from cryptography.hazmat.primitives import serialization
+
+    priv = serialization.load_pem_private_key(private_key_pem, password=None)
+    return (
+        priv.public_key()
+        .public_bytes(serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo)
+        .decode("ascii")
+    )
+
+
+def _raw_pub(pem: str | bytes) -> bytes:
+    """Return the raw 32-byte Ed25519 public key for a SPKI-PEM (for comparison).
+
+    Comparing the raw key bytes rather than PEM text makes continuity and
+    trust-anchor checks insensitive to PEM whitespace/line-ending differences.
+    Returns ``b""`` for input that is not a loadable Ed25519 public key.
+    """
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+    data = pem.encode("ascii") if isinstance(pem, str) else pem
+    try:
+        key = serialization.load_pem_public_key(data)
+    except (ValueError, TypeError):
+        return b""
+    if not isinstance(key, Ed25519PublicKey):
+        return b""
+    return key.public_bytes(serialization.Encoding.Raw, serialization.PublicFormat.Raw)
+
+
+@dataclass(frozen=True)
+class CapabilityToken:
+    """One signed, scope-attenuating hop of a delegation authority chain."""
+
+    token_id: str
+    issuer_identity_id: str
+    issuer_pubkey: str  # SPKI-PEM text of the delegating identity's Ed25519 key
+    subject_identity_id: str
+    subject_pubkey: str  # SPKI-PEM text of the delegatee's Ed25519 key
+    caveats: Caveats
+    parent_token_hash: str
+    audit_head: str
+    granted_at: float
+    jws: str  # detached JWS (RFC 7515 §A.5) over canonicalize_jcs(self.body())
+
+    def body(self) -> dict[str, Any]:
+        """Return the signed token body (every field except ``jws``).
+
+        This exact dict is JCS-canonicalized to form the JWS signing input and
+        the token hash, so any change to a signed field breaks both.
+        """
+        return {
+            "audit_head": self.audit_head,
+            "caveats": self.caveats.to_body(),
+            "granted_at": self.granted_at,
+            "issuer_identity_id": self.issuer_identity_id,
+            "issuer_pubkey": self.issuer_pubkey,
+            "parent_token_hash": self.parent_token_hash,
+            "subject_identity_id": self.subject_identity_id,
+            "subject_pubkey": self.subject_pubkey,
+            "token_id": self.token_id,
+        }
+
+    def token_hash(self) -> str:
+        """Return the SHA-256 of the JCS-canonical body (this token's identity)."""
+        return hashlib.sha256(canonicalize_jcs(self.body())).hexdigest()
+
+    def verify_signature(self) -> bool:
+        """Return True iff the detached JWS verifies against ``issuer_pubkey``."""
+        return verify_detached_jws_over_canonical(
+            canonicalize_jcs(self.body()),
+            self.jws,
+            self.issuer_pubkey.encode("ascii"),
+            expected_typ=TOKEN_TYP,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable dict (signed body plus the ``jws``)."""
+        return {**self.body(), "jws": self.jws}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CapabilityToken:
+        """Inverse of :meth:`to_dict`."""
+        return cls(
+            token_id=data["token_id"],
+            issuer_identity_id=data["issuer_identity_id"],
+            issuer_pubkey=data["issuer_pubkey"],
+            subject_identity_id=data["subject_identity_id"],
+            subject_pubkey=data["subject_pubkey"],
+            caveats=Caveats.from_body(data["caveats"]),
+            parent_token_hash=data["parent_token_hash"],
+            audit_head=data["audit_head"],
+            granted_at=float(data["granted_at"]),
+            jws=data["jws"],
+        )
+
+
+@dataclass(frozen=True)
+class CapabilityChain:
+    """An ordered delegation chain, root first, leaf last."""
+
+    tokens: tuple[CapabilityToken, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"tokens": [t.to_dict() for t in self.tokens]}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CapabilityChain:
+        return cls(tokens=tuple(CapabilityToken.from_dict(t) for t in data["tokens"]))
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), sort_keys=True, indent=2)
+
+    @classmethod
+    def from_json(cls, blob: str) -> CapabilityChain:
+        return cls.from_dict(json.loads(blob))
+
+
+# ---------------------------------------------------------------------------
+# Minting
+# ---------------------------------------------------------------------------
+
+
+def sign_token(
+    *,
+    token_id: str,
+    issuer_identity_id: str,
+    issuer_private_key: bytes,
+    subject_identity_id: str,
+    subject_pubkey: bytes | str,
+    caveats: Caveats,
+    parent_token_hash: str,
+    audit_head: str,
+    granted_at: float,
+) -> CapabilityToken:
+    """Sign a token body with ``issuer_private_key`` (no attenuation check).
+
+    Low-level constructor: :func:`mint_root` and :func:`attenuate` layer the
+    trust-anchor and subset rules on top. Exposed so tests can forge a
+    validly-signed-but-widened hop and prove :func:`verify_chain` rejects it on
+    attenuation alone.
+    """
+    issuer_pubkey = _spki_pem(issuer_private_key)
+    subject_pem = subject_pubkey.decode("ascii") if isinstance(subject_pubkey, bytes) else subject_pubkey
+    token = CapabilityToken(
+        token_id=token_id,
+        issuer_identity_id=issuer_identity_id,
+        issuer_pubkey=issuer_pubkey,
+        subject_identity_id=subject_identity_id,
+        subject_pubkey=subject_pem,
+        caveats=caveats,
+        parent_token_hash=parent_token_hash,
+        audit_head=audit_head,
+        granted_at=granted_at,
+        jws="",
+    )
+    jws = sign_detached_jws_over_canonical(
+        canonicalize_jcs(token.body()),
+        issuer_private_key,
+        typ=TOKEN_TYP,
+        kid=issuer_identity_id,
+    )
+    from dataclasses import replace
+
+    return replace(token, jws=jws)
+
+
+def _anchor_and_head(
+    audit_chain: AuditChainStore | None,
+    default_head: str,
+) -> str:
+    """Return the audit head to bind into a mint (the chain tip, or default)."""
+    if audit_chain is None:
+        return default_head
+    return audit_chain.prev_chain_digest
+
+
+def _record_mint(audit_chain: AuditChainStore | None, token: CapabilityToken) -> AuditEvent | None:
+    """Emit a ``delegation_minted`` event cross-referencing the token, if wired."""
+    if audit_chain is None:
+        return None
+    from bernstein.core.security.audit_chain import record_delegation_minted
+
+    return record_delegation_minted(
+        chain=audit_chain,
+        token_hash=token.token_hash(),
+        issuer_identity_id=token.issuer_identity_id,
+        subject_identity_id=token.subject_identity_id,
+        parent_token_hash=token.parent_token_hash,
+        remaining_depth=token.caveats.remaining_depth,
+    )
+
+
+def mint_root(
+    *,
+    issuer_identity_id: str,
+    issuer_private_key: bytes,
+    subject_identity_id: str,
+    subject_pubkey: bytes | str,
+    caveats: Caveats,
+    audit_head: str = GENESIS_PARENT,
+    granted_at: float | None = None,
+    token_id: str | None = None,
+    audit_chain: AuditChainStore | None = None,
+) -> CapabilityToken:
+    """Mint a root capability token (the principal's grant to the orchestrator).
+
+    The root's issuer is the human principal's install identity; a verifier only
+    accepts a chain whose root ``issuer_pubkey`` is a configured trust anchor.
+
+    When ``audit_chain`` is supplied, the mint is anchored: ``audit_head`` is
+    bound to the chain tip captured before the mint and a ``delegation_minted``
+    audit event is emitted whose ``token_hash`` and ``prev_chain_digest``
+    cross-reference this token.
+    """
+    head = _anchor_and_head(audit_chain, audit_head)
+    token = sign_token(
+        token_id=token_id or uuid.uuid4().hex,
+        issuer_identity_id=issuer_identity_id,
+        issuer_private_key=issuer_private_key,
+        subject_identity_id=subject_identity_id,
+        subject_pubkey=subject_pubkey,
+        caveats=caveats,
+        parent_token_hash=GENESIS_PARENT,
+        audit_head=head,
+        granted_at=granted_at if granted_at is not None else time.time(),
+    )
+    _record_mint(audit_chain, token)
+    return token
+
+
+def attenuate(
+    parent: CapabilityToken,
+    *,
+    issuer_private_key: bytes,
+    subject_identity_id: str,
+    subject_pubkey: bytes | str,
+    caveats: Caveats,
+    audit_head: str | None = None,
+    granted_at: float | None = None,
+    token_id: str | None = None,
+    audit_chain: AuditChainStore | None = None,
+) -> CapabilityToken:
+    """Mint a child token that narrows ``parent`` (tokens narrow, never grant).
+
+    The child's issuer *is* the parent's subject: ``issuer_private_key`` must
+    correspond to ``parent.subject_pubkey`` (the party that was delegated to now
+    delegates onward). Widening on any caveat axis - including a
+    ``remaining_depth`` that is not strictly below the parent's - raises
+    :class:`AttenuationError`.
+    """
+    if _raw_pub(_spki_pem(issuer_private_key)) != _raw_pub(parent.subject_pubkey):
+        raise AttenuationError(
+            "issuer_private_key does not match the parent token's subject_pubkey; "
+            "only the delegatee of the parent hop may attenuate onward"
+        )
+    if not caveats.is_narrowing_of(parent.caveats):
+        raise AttenuationError(
+            "child caveats widen the parent (permissions, task_ids, path_prefixes, "
+            "expiry, max_uses, or remaining_depth); tokens may only narrow"
+        )
+    head = _anchor_and_head(audit_chain, audit_head if audit_head is not None else parent.audit_head)
+    token = sign_token(
+        token_id=token_id or uuid.uuid4().hex,
+        issuer_identity_id=parent.subject_identity_id,
+        issuer_private_key=issuer_private_key,
+        subject_identity_id=subject_identity_id,
+        subject_pubkey=subject_pubkey,
+        caveats=caveats,
+        parent_token_hash=parent.token_hash(),
+        audit_head=head,
+        granted_at=granted_at if granted_at is not None else time.time(),
+    )
+    _record_mint(audit_chain, token)
+    return token
+
+
+# ---------------------------------------------------------------------------
+# Offline chain verification
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class HopVerification:
+    """Per-hop verdict from :func:`verify_chain`."""
+
+    hop_index: int
+    issuer_identity_id: str
+    subject_identity_id: str
+    ok: bool
+    errors: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ChainVerification:
+    """The result of walking a chain offline."""
+
+    valid: bool
+    hops: list[HopVerification] = field(default_factory=list)
+    principal_path: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+
+def verify_chain(
+    chain: CapabilityChain,
+    *,
+    trust_anchors: set[str],
+    audit_chain: AuditChainStore | None = None,
+) -> ChainVerification:
+    """Verify a delegation chain offline and return the resolved authority path.
+
+    Walks the chain root -> leaf, checking at every hop: the detached JWS
+    against the hop's captured ``issuer_pubkey``; structural linkage
+    (``parent_token_hash`` equals the preceding hop's computed hash); identity
+    and pubkey continuity (the issuer of hop N is the subject of hop N-1); and
+    monotonic attenuation (each hop's caveats narrow its parent's). The root's
+    ``issuer_pubkey`` must be one of ``trust_anchors`` (the principal's install
+    identity).
+
+    No network and no live registry are consulted. When ``audit_chain`` is
+    supplied, each hop's ``audit_head`` is additionally checked to be an ancestor
+    of the current head with a matching ``delegation_minted`` event - but the
+    signature/attenuation verdict never depends on it, so tamper detection holds
+    with the registry and audit log unavailable.
+    """
+    anchor_raws = {_raw_pub(a) for a in trust_anchors}
+    anchor_raws.discard(b"")
+
+    hops: list[HopVerification] = []
+    errors: list[str] = []
+    prev_hash = GENESIS_PARENT
+    prev_subject_id: str | None = None
+    prev_subject_pubkey: str | None = None
+    prev_caveats: Caveats | None = None
+
+    tokens = chain.tokens
+    if not tokens:
+        return ChainVerification(valid=False, hops=[], principal_path=[], errors=["empty chain"])
+
+    audit_events = None
+    if audit_chain is not None:
+        from bernstein.core.security.audit_chain import EVENT_DELEGATION_MINTED
+
+        audit_events = audit_chain.query(event_type=EVENT_DELEGATION_MINTED)
+
+    for index, token in enumerate(tokens):
+        hop_errors: list[str] = []
+
+        if not token.verify_signature():
+            hop_errors.append("signature invalid: JWS does not verify against issuer_pubkey")
+
+        if token.parent_token_hash != prev_hash:
+            hop_errors.append("parent hash mismatch: token does not chain onto the preceding hop")
+
+        if index == 0:
+            if _raw_pub(token.issuer_pubkey) not in anchor_raws:
+                hop_errors.append("root issuer_pubkey is not a configured trust anchor")
+        else:
+            if token.issuer_identity_id != prev_subject_id:
+                hop_errors.append("identity discontinuity: issuer is not the subject of the hop above")
+            if prev_subject_pubkey is None or _raw_pub(token.issuer_pubkey) != _raw_pub(prev_subject_pubkey):
+                hop_errors.append("pubkey discontinuity: issuer_pubkey is not the subject_pubkey above")
+            if prev_caveats is not None and not token.caveats.is_narrowing_of(prev_caveats):
+                hop_errors.append("attenuation violated: caveats widen the parent (tokens may only narrow)")
+
+        if audit_events is not None and not _audit_head_matches(token, audit_events):
+            hop_errors.append("audit anchor missing: no delegation_minted event cross-references this token")
+
+        hops.append(
+            HopVerification(
+                hop_index=index,
+                issuer_identity_id=token.issuer_identity_id,
+                subject_identity_id=token.subject_identity_id,
+                ok=not hop_errors,
+                errors=hop_errors,
+            )
+        )
+
+        prev_hash = token.token_hash()
+        prev_subject_id = token.subject_identity_id
+        prev_subject_pubkey = token.subject_pubkey
+        prev_caveats = token.caveats
+
+    principal_path = [tokens[0].issuer_identity_id] + [t.subject_identity_id for t in tokens]
+    valid = all(hop.ok for hop in hops)
+    return ChainVerification(valid=valid, hops=hops, principal_path=principal_path, errors=errors)
+
+
+def _audit_head_matches(token: CapabilityToken, events: list[AuditEvent]) -> bool:
+    """Return True iff a ``delegation_minted`` event cross-references *token*.
+
+    The event's ``token_hash`` must equal the token's hash and its embedded
+    ``prev_chain_digest`` must equal the token's ``audit_head`` - the two-way
+    cross-reference minted by :func:`_record_mint`.
+    """
+    want_hash = token.token_hash()
+    for event in events:
+        details = event.details
+        if details.get("token_hash") == want_hash and details.get("prev_chain_digest") == token.audit_head:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# RFC 8693 actor-claims projection
+# ---------------------------------------------------------------------------
+
+
+def to_actor_claims(chain: CapabilityChain, *, trust_anchors: set[str]) -> dict[str, Any]:
+    """Render a *verified* chain as nested RFC 8693 ``act`` claims.
+
+    The outermost ``sub`` is the principal (the root issuer, the ultimate
+    authority); each nested ``act`` descends through the actors that were
+    delegated to, ending at the leaf subject. External IdP tooling can consume
+    the delegation path without understanding the token format.
+
+    Raises:
+        TokenVerificationError: If the chain does not verify. The projection
+            only speaks for an authority path it has cryptographically checked.
+    """
+    result = verify_chain(chain, trust_anchors=trust_anchors)
+    if not result.valid:
+        raise TokenVerificationError(
+            "refusing to project an unverified chain as actor claims: " + "; ".join(_flatten_errors(result))
+        )
+
+    # principal_path is [principal, actor1, actor2, ..., leaf]; nest outward-in.
+    path = result.principal_path
+    claim: dict[str, Any] = {"sub": path[-1]}
+    for sub in reversed(path[:-1]):
+        claim = {"sub": sub, "act": claim}
+    return claim
+
+
+def _flatten_errors(result: ChainVerification) -> list[str]:
+    out = list(result.errors)
+    for hop in result.hops:
+        out.extend(f"hop {hop.hop_index}: {e}" for e in hop.errors)
+    return out

--- a/src/bernstein/core/security/permission_delegation.py
+++ b/src/bernstein/core/security/permission_delegation.py
@@ -1,4 +1,18 @@
-"""Permission delegation from coordinator to workers."""
+"""Permission delegation from coordinator to workers.
+
+Two surfaces live here:
+
+* The legacy in-memory :class:`DelegationToken` / :class:`PermissionDelegator`
+  registry - an unsigned, coarse-scope grant checked against the coordinator's
+  own process state. Existing callers keep using it unchanged.
+* An additive bridge onto the signed, scope-attenuating capability tokens in
+  :mod:`bernstein.core.security.capability_tokens`. :func:`enum_to_caveats`
+  maps the ``read``/``write``/``execute``/``full`` enum onto the ``PERM_*``
+  caveat vocabulary, :meth:`PermissionDelegator.mint_capability` mints a signed
+  token from that scope, and :meth:`PermissionDelegator.verify_capability`
+  verifies **offline chain first** (no network, no registry) and only then
+  consults the in-process registry for *liveness* (expiry) and *revocation*.
+"""
 
 from __future__ import annotations
 
@@ -6,12 +20,46 @@ import hashlib
 import logging
 import time
 from dataclasses import asdict, dataclass, field
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
+
+from bernstein.core.security import capability_tokens as _cap
+
+if TYPE_CHECKING:
+    from bernstein.core.security.audit_chain import AuditChainStore
+    from bernstein.core.security.capability_tokens import CapabilityChain, CapabilityToken, Caveats
 
 logger = logging.getLogger(__name__)
 
 
 DelegationScope = Literal["read", "write", "execute", "full"]
+
+
+def enum_to_caveats(
+    scope: DelegationScope,
+    *,
+    remaining_depth: int,
+    not_after: float,
+    task_ids: set[str] | frozenset[str] | None = None,
+    path_prefixes: set[str] | frozenset[str] | None = None,
+    max_uses: int | None = None,
+    extra_permissions: set[str] | frozenset[str] | None = None,
+) -> Caveats:
+    """Map a legacy delegation scope enum onto capability-token caveats.
+
+    The enum hierarchy ``read`` < ``write`` < ``execute`` < ``full`` maps onto
+    cumulative ``PERM_*`` sets, so a token minted for a narrower scope is a
+    strict subset of a wider one - the enum ordering becomes capability-token
+    subset attenuation with no behavioural change for existing callers.
+    """
+    return _cap.caveats_for_scope(
+        scope,
+        remaining_depth=remaining_depth,
+        not_after=not_after,
+        task_ids=task_ids,
+        path_prefixes=path_prefixes,
+        max_uses=max_uses,
+        extra_permissions=extra_permissions,
+    )
 
 
 @dataclass
@@ -92,6 +140,11 @@ class PermissionDelegator:
         self._max_uses = max_uses_per_token
         self._tokens: dict[str, DelegationToken] = {}
         self._approvals: dict[str, dict[str, Any]] = {}
+        # Signed-capability liveness registry: token hashes seen at mint, and
+        # the subset that has been revoked. The registry is a *cache* consulted
+        # only after the offline chain check - never the sole source of truth.
+        self._capabilities: dict[str, CapabilityToken] = {}
+        self._revoked_capabilities: set[str] = set()
 
     def register_approval(
         self,
@@ -339,6 +392,120 @@ class PermissionDelegator:
             Short hash string.
         """
         return hashlib.sha256(token_id.encode()).hexdigest()[:8]
+
+    # ------------------------------------------------------------------
+    # Signed capability-token bridge (issue #2611)
+    # ------------------------------------------------------------------
+
+    def mint_capability(
+        self,
+        *,
+        issuer_identity_id: str,
+        issuer_private_key: bytes,
+        subject_identity_id: str,
+        subject_pubkey: bytes | str,
+        scope: DelegationScope,
+        remaining_depth: int,
+        ttl_seconds: float | None = None,
+        task_ids: set[str] | frozenset[str] | None = None,
+        path_prefixes: set[str] | frozenset[str] | None = None,
+        max_uses: int | None = None,
+        parent: CapabilityToken | None = None,
+        audit_chain: AuditChainStore | None = None,
+    ) -> CapabilityToken:
+        """Mint a signed capability token from a legacy scope enum.
+
+        When ``parent`` is ``None`` a root token is minted (the principal's
+        grant); otherwise the token attenuates ``parent`` and its enum-derived
+        caveats must be a subset of the parent's or the mint raises
+        :class:`~bernstein.core.security.capability_tokens.AttenuationError`.
+        The minted token is registered for liveness so :meth:`verify_capability`
+        can later report revocation.
+        """
+        ttl = ttl_seconds if ttl_seconds is not None else self._default_ttl
+        not_after = time.time() + ttl
+        if parent is not None:
+            # A child never outlives its parent. Clamping (rather than raising)
+            # keeps the common "same TTL" attenuation ergonomic: an absolute
+            # expiry computed a few microseconds after the parent's would
+            # otherwise read as a widening and be rejected.
+            not_after = min(not_after, parent.caveats.not_after)
+        caveats = enum_to_caveats(
+            scope,
+            remaining_depth=remaining_depth,
+            not_after=not_after,
+            task_ids=task_ids,
+            path_prefixes=path_prefixes,
+            max_uses=max_uses if max_uses is not None else self._max_uses,
+        )
+        if parent is None:
+            token = _cap.mint_root(
+                issuer_identity_id=issuer_identity_id,
+                issuer_private_key=issuer_private_key,
+                subject_identity_id=subject_identity_id,
+                subject_pubkey=subject_pubkey,
+                caveats=caveats,
+                audit_chain=audit_chain,
+            )
+        else:
+            token = _cap.attenuate(
+                parent,
+                issuer_private_key=issuer_private_key,
+                subject_identity_id=subject_identity_id,
+                subject_pubkey=subject_pubkey,
+                caveats=caveats,
+                audit_chain=audit_chain,
+            )
+        self._capabilities[token.token_hash()] = token
+        return token
+
+    def verify_capability(
+        self,
+        chain: CapabilityChain,
+        required_permission: str,
+        *,
+        trust_anchors: set[str],
+        audit_chain: AuditChainStore | None = None,
+    ) -> bool:
+        """Verify a capability chain grants ``required_permission`` (dual path).
+
+        Offline first: the chain must pass
+        :func:`~bernstein.core.security.capability_tokens.verify_chain` (per-hop
+        signature, structural linkage, identity/pubkey continuity, monotonic
+        attenuation, trusted root) with no network and no registry, and the leaf
+        must actually carry the permission. Only then is the in-process registry
+        consulted for *liveness* (no hop expired) and *revocation* (no hop
+        revoked). A tampered or widened chain is rejected before the registry is
+        ever touched, so authority never depends on a live coordinator.
+        """
+        result = _cap.verify_chain(chain, trust_anchors=trust_anchors, audit_chain=audit_chain)
+        if not result.valid:
+            return False
+        if not chain.tokens:
+            return False
+        leaf = chain.tokens[-1]
+        if required_permission not in leaf.caveats.permissions:
+            return False
+        # Registry liveness/revocation (cache-only, never the source of truth).
+        now = time.time()
+        for token in chain.tokens:
+            if token.token_hash() in self._revoked_capabilities:
+                return False
+            if token.caveats.not_after <= now:
+                return False
+        return True
+
+    def revoke_capability(self, token_hash: str) -> None:
+        """Revoke a capability token by its JCS hash (liveness only).
+
+        Revocation is registry state, not a property of the signed bytes: the
+        chain still verifies offline, but :meth:`verify_capability` refuses a
+        chain containing a revoked hop.
+        """
+        self._revoked_capabilities.add(token_hash)
+        # ``token_hash`` is a content hash, not a credential.
+        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
+        logger.info("Revoked capability token %s", token_hash[:8])
 
 
 def should_delegate(

--- a/tests/property/test_capability_caveat_subset.py
+++ b/tests/property/test_capability_caveat_subset.py
@@ -12,7 +12,7 @@ sub-agent could self-escalate. Two relations are property-tested here:
 
 from __future__ import annotations
 
-from hypothesis import assume, given, settings
+from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from bernstein.core.security import capability_tokens as ct

--- a/tests/property/test_capability_caveat_subset.py
+++ b/tests/property/test_capability_caveat_subset.py
@@ -1,0 +1,165 @@
+"""Property tests for capability-token caveat subset semantics (issue #2611).
+
+The soundness of attenuation rests on the caveat subset relation being exact:
+if a child could ever widen its parent and still be accepted, a compromised
+sub-agent could self-escalate. Two relations are property-tested here:
+
+1. POSIX path-prefix coverage (``_path_covered_by``): reflexive, antisymmetric
+   up to normalization, and immune to ``/a/bc`` vs ``/a/b`` prefix confusion.
+2. The mint-time subset gate: :func:`attenuate` succeeds for a randomized
+   ``(parent, child)`` caveat pair iff ``child.is_narrowing_of(parent)``.
+"""
+
+from __future__ import annotations
+
+from hypothesis import assume, given, settings
+from hypothesis import strategies as st
+
+from bernstein.core.security import capability_tokens as ct
+from bernstein.core.security.agent_card_signer import generate_ed25519_keypair
+
+# Fixed keypairs so each hypothesis example signs without regenerating keys and
+# the attenuate signer-continuity check (issuer key == parent.subject_pubkey)
+# always holds - keeping the test focused on the subset relation, not crypto.
+_PRINCIPAL_PRIV, _PRINCIPAL_PUB = generate_ed25519_keypair()
+_ORCH_PRIV, _ORCH_PUB = generate_ed25519_keypair()
+_LEAF_PRIV, _LEAF_PUB = generate_ed25519_keypair()
+
+_PERM_VOCAB = sorted(
+    {
+        "tasks:read",
+        "tasks:write",
+        "tasks:claim",
+        "files:read",
+        "files:write",
+        "tests:run",
+        "status:read",
+        "agents:spawn",
+    }
+)
+
+_NOW = 1_800_000_000.0
+
+# ---------------------------------------------------------------------------
+# Path-prefix coverage relation
+# ---------------------------------------------------------------------------
+
+_COMPONENT = st.text(st.characters(min_codepoint=ord("a"), max_codepoint=ord("z")), min_size=1, max_size=4)
+
+
+@st.composite
+def _abs_paths(draw: st.DrawFn) -> str:
+    comps = draw(st.lists(_COMPONENT, min_size=1, max_size=4))
+    return "/" + "/".join(comps)
+
+
+@given(path=_abs_paths())
+def test_path_coverage_is_reflexive(path: str) -> None:
+    """Every path is an ancestor-or-equal of itself."""
+    assert ct._path_covered_by(path, path)
+
+
+@given(a=_abs_paths(), b=_abs_paths())
+def test_path_coverage_antisymmetric_up_to_normalization(a: str, b: str) -> None:
+    """Mutual coverage implies the paths normalize to the same thing."""
+    if ct._path_covered_by(a, b) and ct._path_covered_by(b, a):
+        assert ct._normalize_path(a) == ct._normalize_path(b)
+
+
+@given(parent=_abs_paths(), suffix=_COMPONENT)
+def test_path_coverage_rejects_component_boundary_confusion(parent: str, suffix: str) -> None:
+    """``/a/b`` must not cover ``/a/bX`` - coverage is component-wise.
+
+    A true child (``parent/suffix``) is covered; a sibling formed by extending
+    the last component (``parent`` + ``suffix``, no separator) is not.
+    """
+    child = parent + "/" + suffix
+    sibling = parent + suffix  # shares the string prefix but crosses no '/'
+    assert ct._path_covered_by(child, parent)
+    assert not ct._path_covered_by(sibling, parent)
+
+
+@given(parent=_abs_paths())
+def test_root_covers_everything(parent: str) -> None:
+    """The filesystem root ``/`` is an ancestor-or-equal of any absolute path."""
+    assert ct._path_covered_by(parent, "/")
+
+
+# ---------------------------------------------------------------------------
+# Randomized caveats and the mint-time subset gate
+# ---------------------------------------------------------------------------
+
+
+@st.composite
+def _caveats(draw: st.DrawFn, *, min_depth: int, max_depth: int) -> ct.Caveats:
+    permissions = frozenset(draw(st.lists(st.sampled_from(_PERM_VOCAB), max_size=len(_PERM_VOCAB), unique=True)))
+    task_ids = draw(
+        st.one_of(
+            st.none(),
+            st.lists(st.sampled_from(["t1", "t2", "t3", "t4"]), max_size=4, unique=True).map(frozenset),
+        )
+    )
+    path_prefixes = draw(
+        st.one_of(
+            st.none(),
+            st.lists(st.sampled_from(["/repo", "/repo/src", "/repo/tests", "/tmp"]), max_size=3, unique=True).map(
+                frozenset
+            ),
+        )
+    )
+    not_after = draw(st.sampled_from([_NOW + 100, _NOW + 200, _NOW + 300]))
+    max_uses = draw(st.one_of(st.none(), st.integers(min_value=1, max_value=10)))
+    remaining_depth = draw(st.integers(min_value=min_depth, max_value=max_depth))
+    return ct.Caveats(
+        permissions=permissions,
+        remaining_depth=remaining_depth,
+        not_after=not_after,
+        task_ids=task_ids,
+        path_prefixes=path_prefixes,
+        max_uses=max_uses,
+    )
+
+
+@settings(deadline=None, max_examples=250)
+@given(
+    parent=_caveats(min_depth=0, max_depth=5),
+    child=_caveats(min_depth=-1, max_depth=6),
+)
+def test_attenuate_succeeds_iff_child_narrows_parent(parent: ct.Caveats, child: ct.Caveats) -> None:
+    """The mint gate accepts a child iff its caveats are a subset of the parent."""
+    root = ct.mint_root(
+        issuer_identity_id="principal",
+        issuer_private_key=_PRINCIPAL_PRIV,
+        subject_identity_id="orchestrator",
+        subject_pubkey=_ORCH_PUB,
+        caveats=parent,
+    )
+    expected = child.is_narrowing_of(parent)
+    try:
+        ct.attenuate(
+            root,
+            issuer_private_key=_ORCH_PRIV,
+            subject_identity_id="leaf",
+            subject_pubkey=_LEAF_PUB,
+            caveats=child,
+        )
+        minted = True
+    except ct.AttenuationError:
+        minted = False
+    assert minted == expected
+
+
+@settings(deadline=None, max_examples=100)
+@given(parent=_caveats(min_depth=1, max_depth=5))
+def test_narrowing_relation_is_reflexive_except_depth(parent: ct.Caveats) -> None:
+    """A caveat set narrows itself on every axis except the strict-depth rule.
+
+    ``is_narrowing_of`` requires ``remaining_depth`` strictly below the parent,
+    so a set never narrows an identical copy, but a copy with depth reduced by
+    one does.
+    """
+    assert not parent.is_narrowing_of(parent)
+    import dataclasses
+
+    one_deeper = dataclasses.replace(parent, remaining_depth=parent.remaining_depth - 1)
+    assert one_deeper.is_narrowing_of(parent)

--- a/tests/unit/test_capability_token_audit_anchor.py
+++ b/tests/unit/test_capability_token_audit_anchor.py
@@ -1,0 +1,142 @@
+"""``delegation_minted`` audit anchoring for capability tokens (issue #2611, AC5).
+
+Each mint emits a ``delegation_minted`` HMAC-chained audit event whose
+``token_hash`` and embedded ``prev_chain_digest`` cross-reference the token's
+identity and captured ``audit_head`` - verifiable by ``bernstein audit verify``
+(``AuditChainStore.verify``). ``verify_chain`` can optionally consult the same
+chain to confirm the anchor without ever depending on it for tamper detection.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from bernstein.core.security import capability_tokens as ct
+from bernstein.core.security.agent_card_signer import generate_ed25519_keypair
+from bernstein.core.security.audit_chain import EVENT_DELEGATION_MINTED, AuditChainStore
+
+_NOW = 1_800_000_000.0
+
+
+def _caveats(perms: set[str], depth: int) -> ct.Caveats:
+    return ct.Caveats(permissions=frozenset(perms), remaining_depth=depth, not_after=_NOW + 3600)
+
+
+def _chain(tmp_path: Path) -> AuditChainStore:
+    # Explicit random key -> no dependency on the install key file.
+    return AuditChainStore(tmp_path / "audit", key=os.urandom(32))
+
+
+def test_mint_emits_cross_referencing_delegation_minted_event(tmp_path: Path) -> None:
+    chain = _chain(tmp_path)
+    p_priv, p_pub = generate_ed25519_keypair()
+    _o_priv, o_pub = generate_ed25519_keypair()
+
+    head_before = chain.prev_chain_digest
+    root = ct.mint_root(
+        issuer_identity_id="principal",
+        issuer_private_key=p_priv,
+        subject_identity_id="orchestrator",
+        subject_pubkey=o_pub,
+        caveats=_caveats({"files:read", "files:write"}, depth=3),
+        audit_chain=chain,
+    )
+
+    # audit_head is bound to the tip captured before the mint.
+    assert root.audit_head == head_before
+
+    events = chain.query(event_type=EVENT_DELEGATION_MINTED)
+    assert len(events) == 1
+    details = events[0].details
+    # Two-way cross-reference: token -> event (token_hash) and event -> token
+    # (prev_chain_digest == the token's captured audit_head).
+    assert details["token_hash"] == root.token_hash()
+    assert details["prev_chain_digest"] == root.audit_head
+    assert details["issuer_identity_id"] == "principal"
+    assert details["subject_identity_id"] == "orchestrator"
+
+
+def test_audit_chain_verifies_after_mints(tmp_path: Path) -> None:
+    chain = _chain(tmp_path)
+    p_priv, p_pub = generate_ed25519_keypair()
+    o_priv, o_pub = generate_ed25519_keypair()
+    _s_priv, s_pub = generate_ed25519_keypair()
+
+    root = ct.mint_root(
+        issuer_identity_id="principal",
+        issuer_private_key=p_priv,
+        subject_identity_id="orchestrator",
+        subject_pubkey=o_pub,
+        caveats=_caveats({"files:read", "files:write"}, depth=3),
+        audit_chain=chain,
+    )
+    ct.attenuate(
+        root,
+        issuer_private_key=o_priv,
+        subject_identity_id="sub-agent",
+        subject_pubkey=s_pub,
+        caveats=_caveats({"files:read"}, depth=2),
+        audit_chain=chain,
+    )
+
+    # bernstein audit verify equivalent: the HMAC chain is intact.
+    ok, errors = chain.verify()
+    assert ok, errors
+    assert len(chain.query(event_type=EVENT_DELEGATION_MINTED)) == 2
+
+
+def test_verify_chain_with_audit_confirms_anchor(tmp_path: Path) -> None:
+    chain = _chain(tmp_path)
+    p_priv, p_pub = generate_ed25519_keypair()
+    o_priv, o_pub = generate_ed25519_keypair()
+    _s_priv, s_pub = generate_ed25519_keypair()
+
+    root = ct.mint_root(
+        issuer_identity_id="principal",
+        issuer_private_key=p_priv,
+        subject_identity_id="orchestrator",
+        subject_pubkey=o_pub,
+        caveats=_caveats({"files:read", "files:write"}, depth=3),
+        audit_chain=chain,
+    )
+    hop1 = ct.attenuate(
+        root,
+        issuer_private_key=o_priv,
+        subject_identity_id="sub-agent",
+        subject_pubkey=s_pub,
+        caveats=_caveats({"files:read"}, depth=2),
+        audit_chain=chain,
+    )
+    cap_chain = ct.CapabilityChain(tokens=(root, hop1))
+
+    anchors = {p_pub.decode()}
+    result = ct.verify_chain(cap_chain, trust_anchors=anchors, audit_chain=chain)
+    assert result.valid
+    assert all(hop.ok for hop in result.hops)
+
+
+def test_verify_chain_flags_missing_audit_anchor(tmp_path: Path) -> None:
+    """A token never anchored fails the optional audit check (but the crypto
+    verdict is unaffected when no audit chain is supplied)."""
+    anchor_chain = _chain(tmp_path / "a")
+    p_priv, p_pub = generate_ed25519_keypair()
+    _o_priv, o_pub = generate_ed25519_keypair()
+
+    # Mint WITHOUT anchoring into anchor_chain.
+    root = ct.mint_root(
+        issuer_identity_id="principal",
+        issuer_private_key=p_priv,
+        subject_identity_id="orchestrator",
+        subject_pubkey=o_pub,
+        caveats=_caveats({"files:read"}, depth=2),
+    )
+    cap_chain = ct.CapabilityChain(tokens=(root,))
+    anchors = {p_pub.decode()}
+
+    # Pure crypto path: valid.
+    assert ct.verify_chain(cap_chain, trust_anchors=anchors).valid
+    # With an audit chain that has no matching event: anchor check fails.
+    result = ct.verify_chain(cap_chain, trust_anchors=anchors, audit_chain=anchor_chain)
+    assert not result.valid
+    assert any("audit anchor" in e for e in result.hops[0].errors)

--- a/tests/unit/test_capability_token_audit_anchor.py
+++ b/tests/unit/test_capability_token_audit_anchor.py
@@ -30,7 +30,7 @@ def _chain(tmp_path: Path) -> AuditChainStore:
 
 def test_mint_emits_cross_referencing_delegation_minted_event(tmp_path: Path) -> None:
     chain = _chain(tmp_path)
-    p_priv, p_pub = generate_ed25519_keypair()
+    p_priv, _p_pub = generate_ed25519_keypair()
     _o_priv, o_pub = generate_ed25519_keypair()
 
     head_before = chain.prev_chain_digest
@@ -59,7 +59,7 @@ def test_mint_emits_cross_referencing_delegation_minted_event(tmp_path: Path) ->
 
 def test_audit_chain_verifies_after_mints(tmp_path: Path) -> None:
     chain = _chain(tmp_path)
-    p_priv, p_pub = generate_ed25519_keypair()
+    p_priv, _p_pub = generate_ed25519_keypair()
     o_priv, o_pub = generate_ed25519_keypair()
     _s_priv, s_pub = generate_ed25519_keypair()
 

--- a/tests/unit/test_capability_tokens.py
+++ b/tests/unit/test_capability_tokens.py
@@ -1,0 +1,475 @@
+"""Unit tests for attenuated delegation capability tokens (issue #2611).
+
+Covers the crypto core: mint, subset attenuation, offline chain verification,
+the three-way tamper test (JWS byte flip, widened caveat rewrite, issuer-pubkey
+swap) with no registry, the ``max_depth`` monotonic caveat, the RFC 8693
+``to_actor_claims`` projection, and the ``delegation_minted`` audit anchor.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from bernstein.core.security import capability_tokens as ct
+from bernstein.core.security.agent_card_signer import (
+    canonicalize_jcs,
+    generate_ed25519_keypair,
+    sign_detached_jws_over_canonical,
+)
+
+#: Fixed reference time so caveats minted across a chain share an identical
+#: ``not_after`` (equal expiry is narrowing; a later re-computed one would widen).
+_NOW: float = 1_800_000_000.0
+
+
+def _kp() -> tuple[bytes, bytes]:
+    """Fresh (private_pem, public_pem) Ed25519 keypair."""
+    return generate_ed25519_keypair()
+
+
+def _caveats(
+    *,
+    permissions: set[str] | None = None,
+    remaining_depth: int = 3,
+    not_after: float | None = None,
+    task_ids: set[str] | None = None,
+    path_prefixes: set[str] | None = None,
+    max_uses: int | None = None,
+) -> ct.Caveats:
+    return ct.Caveats(
+        permissions=frozenset(permissions or {"files:read", "files:write", "tasks:read"}),
+        remaining_depth=remaining_depth,
+        not_after=not_after if not_after is not None else _NOW + 3600,
+        task_ids=frozenset(task_ids) if task_ids is not None else None,
+        path_prefixes=frozenset(path_prefixes) if path_prefixes is not None else None,
+        max_uses=max_uses,
+    )
+
+
+def _three_hop() -> tuple[ct.CapabilityChain, dict[str, bytes], list[bytes]]:
+    """Build a valid principal -> orchestrator -> sub-agent -> leaf chain.
+
+    Returns the chain, a map of private keys by role, and the trust anchors
+    (the principal's public key).
+    """
+    p_priv, p_pub = _kp()
+    o_priv, o_pub = _kp()
+    s_priv, s_pub = _kp()
+    l_priv, l_pub = _kp()
+
+    root = ct.mint_root(
+        issuer_identity_id="principal",
+        issuer_private_key=p_priv,
+        subject_identity_id="orchestrator",
+        subject_pubkey=o_pub,
+        caveats=_caveats(remaining_depth=3),
+    )
+    hop1 = ct.attenuate(
+        root,
+        issuer_private_key=o_priv,
+        subject_identity_id="sub-agent",
+        subject_pubkey=s_pub,
+        caveats=_caveats(permissions={"files:read", "tasks:read"}, remaining_depth=2),
+    )
+    hop2 = ct.attenuate(
+        hop1,
+        issuer_private_key=s_priv,
+        subject_identity_id="leaf",
+        subject_pubkey=l_pub,
+        caveats=_caveats(permissions={"files:read"}, remaining_depth=1),
+    )
+    chain = ct.CapabilityChain(tokens=(root, hop1, hop2))
+    privs = {"principal": p_priv, "orchestrator": o_priv, "sub-agent": s_priv, "leaf": l_priv}
+    return chain, privs, [p_pub]
+
+
+# ---------------------------------------------------------------------------
+# AC1 - mint produces a detached JWS over the JCS body
+# ---------------------------------------------------------------------------
+
+
+def test_mint_root_populates_signed_fields() -> None:
+    p_priv, _p_pub = _kp()
+    _o_priv, o_pub = _kp()
+    tok = ct.mint_root(
+        issuer_identity_id="principal",
+        issuer_private_key=p_priv,
+        subject_identity_id="orchestrator",
+        subject_pubkey=o_pub,
+        caveats=_caveats(),
+    )
+    assert tok.issuer_pubkey  # derived from private key
+    assert tok.subject_identity_id == "orchestrator"
+    assert tok.caveats.permissions
+    assert tok.parent_token_hash == ct.GENESIS_PARENT
+    assert tok.audit_head  # populated (genesis by default)
+    # Detached JWS: header..signature with the token typ.
+    assert tok.jws.count(".") == 2
+    _header_b64, payload_b64, _sig = tok.jws.split(".")
+    assert payload_b64 == ""  # detached
+    assert tok.verify_signature()
+
+
+def test_mint_root_jws_carries_token_typ() -> None:
+    import base64
+    import json
+
+    p_priv, _ = _kp()
+    _o_priv, o_pub = _kp()
+    tok = ct.mint_root(
+        issuer_identity_id="principal",
+        issuer_private_key=p_priv,
+        subject_identity_id="orchestrator",
+        subject_pubkey=o_pub,
+        caveats=_caveats(),
+    )
+    header_b64 = tok.jws.split(".")[0]
+    pad = "=" * (-len(header_b64) % 4)
+    header = json.loads(base64.urlsafe_b64decode(header_b64 + pad))
+    assert header["typ"] == ct.TOKEN_TYP == "delegation-capability+jws"
+    assert header["alg"] == "EdDSA"
+
+
+# ---------------------------------------------------------------------------
+# AC2 - attenuate enforces subset semantics
+# ---------------------------------------------------------------------------
+
+
+def test_attenuate_narrows_ok() -> None:
+    chain, _privs, _anchors = _three_hop()
+    assert len(chain.tokens) == 3
+
+
+def test_attenuate_rejects_widened_permission() -> None:
+    p_priv, _ = _kp()
+    o_priv, o_pub = _kp()
+    _s_priv, s_pub = _kp()
+    root = ct.mint_root(
+        issuer_identity_id="principal",
+        issuer_private_key=p_priv,
+        subject_identity_id="orchestrator",
+        subject_pubkey=o_pub,
+        caveats=_caveats(permissions={"files:read"}, remaining_depth=3),
+    )
+    with pytest.raises(ct.AttenuationError):
+        ct.attenuate(
+            root,
+            issuer_private_key=o_priv,
+            subject_identity_id="sub-agent",
+            subject_pubkey=s_pub,
+            caveats=_caveats(permissions={"files:read", "files:write"}, remaining_depth=2),
+        )
+
+
+def test_attenuate_rejects_wrong_signer_key() -> None:
+    p_priv, _ = _kp()
+    _o_priv, o_pub = _kp()
+    wrong_priv, _ = _kp()
+    _s_priv, s_pub = _kp()
+    root = ct.mint_root(
+        issuer_identity_id="principal",
+        issuer_private_key=p_priv,
+        subject_identity_id="orchestrator",
+        subject_pubkey=o_pub,
+        caveats=_caveats(remaining_depth=3),
+    )
+    # A key that is not the subject of the parent must not be able to attenuate.
+    with pytest.raises(ct.AttenuationError):
+        ct.attenuate(
+            root,
+            issuer_private_key=wrong_priv,
+            subject_identity_id="sub-agent",
+            subject_pubkey=s_pub,
+            caveats=_caveats(remaining_depth=2),
+        )
+
+
+def test_attenuate_rejects_expiry_extension_and_max_uses_growth() -> None:
+    p_priv, _ = _kp()
+    o_priv, o_pub = _kp()
+    _s_priv, s_pub = _kp()
+    now = time.time()
+    root = ct.mint_root(
+        issuer_identity_id="principal",
+        issuer_private_key=p_priv,
+        subject_identity_id="orchestrator",
+        subject_pubkey=o_pub,
+        caveats=_caveats(remaining_depth=3, not_after=now + 100, max_uses=5),
+    )
+    with pytest.raises(ct.AttenuationError):
+        ct.attenuate(
+            root,
+            issuer_private_key=o_priv,
+            subject_identity_id="sub-agent",
+            subject_pubkey=s_pub,
+            caveats=_caveats(remaining_depth=2, not_after=now + 200, max_uses=5),
+        )
+    with pytest.raises(ct.AttenuationError):
+        ct.attenuate(
+            root,
+            issuer_private_key=o_priv,
+            subject_identity_id="sub-agent",
+            subject_pubkey=s_pub,
+            caveats=_caveats(remaining_depth=2, not_after=now + 100, max_uses=10),
+        )
+
+
+# ---------------------------------------------------------------------------
+# max_depth caveat (design addition 1)
+# ---------------------------------------------------------------------------
+
+
+def test_attenuate_requires_strictly_decreasing_depth() -> None:
+    p_priv, _ = _kp()
+    o_priv, o_pub = _kp()
+    _s_priv, s_pub = _kp()
+    root = ct.mint_root(
+        issuer_identity_id="principal",
+        issuer_private_key=p_priv,
+        subject_identity_id="orchestrator",
+        subject_pubkey=o_pub,
+        caveats=_caveats(remaining_depth=2),
+    )
+    # Equal depth is not narrowing.
+    with pytest.raises(ct.AttenuationError):
+        ct.attenuate(
+            root,
+            issuer_private_key=o_priv,
+            subject_identity_id="sub-agent",
+            subject_pubkey=s_pub,
+            caveats=_caveats(remaining_depth=2),
+        )
+
+
+def test_chain_deeper_than_root_authorized_fails_mint() -> None:
+    p_priv, _ = _kp()
+    o_priv, o_pub = _kp()
+    s_priv, s_pub = _kp()
+    _l_priv, l_pub = _kp()
+    root = ct.mint_root(
+        issuer_identity_id="principal",
+        issuer_private_key=p_priv,
+        subject_identity_id="orchestrator",
+        subject_pubkey=o_pub,
+        caveats=_caveats(remaining_depth=1),
+    )
+    hop1 = ct.attenuate(
+        root,
+        issuer_private_key=o_priv,
+        subject_identity_id="sub-agent",
+        subject_pubkey=s_pub,
+        caveats=_caveats(remaining_depth=0),
+    )
+    # remaining_depth is now 0; one more hop would need depth < 0 -> reject.
+    with pytest.raises(ct.AttenuationError):
+        ct.attenuate(
+            hop1,
+            issuer_private_key=s_priv,
+            subject_identity_id="leaf",
+            subject_pubkey=l_pub,
+            caveats=_caveats(remaining_depth=-1),
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC3 - offline verify_chain returns the resolved authority path
+# ---------------------------------------------------------------------------
+
+
+def test_verify_chain_offline_happy_path() -> None:
+    chain, _privs, anchors = _three_hop()
+    result = ct.verify_chain(chain, trust_anchors=set(_pem_set(anchors)))
+    assert result.valid
+    assert result.principal_path == ["principal", "orchestrator", "sub-agent", "leaf"]
+    assert all(hop.ok for hop in result.hops)
+
+
+def test_verify_chain_rejects_untrusted_root() -> None:
+    chain, _privs, _anchors = _three_hop()
+    _other_priv, other_pub = _kp()
+    result = ct.verify_chain(chain, trust_anchors=set(_pem_set([other_pub])))
+    assert not result.valid
+    assert not result.hops[0].ok
+
+
+# ---------------------------------------------------------------------------
+# AC4 - three-way tamper test with the registry unavailable
+# ---------------------------------------------------------------------------
+
+
+def test_tamper_jws_byte_flip_rejected() -> None:
+    chain, _privs, anchors = _three_hop()
+    tokens = list(chain.tokens)
+    victim = tokens[1]
+    # Flip one significant base64url char of the signature segment. The first
+    # char encodes 6 full signature bits (the last char's low bits are padding),
+    # so flipping index 0 is guaranteed to change the decoded signature bytes.
+    header, _payload, sig = victim.jws.split(".")
+    flipped_char = "A" if sig[0] != "A" else "B"
+    bad_jws = f"{header}..{flipped_char}{sig[1:]}"
+    tokens[1] = _replace_jws(victim, bad_jws)
+    tampered = ct.CapabilityChain(tokens=tuple(tokens))
+    result = ct.verify_chain(tampered, trust_anchors=set(_pem_set(anchors)))
+    assert not result.valid
+    assert not result.hops[1].ok
+
+
+def test_tamper_widened_caveat_rejected_from_bytes_only() -> None:
+    """A re-signed, structurally-continuous but widened hop is rejected on
+    attenuation alone, with no registry and no audit log consulted."""
+    chain, privs, anchors = _three_hop()
+    tokens = list(chain.tokens)
+    parent = tokens[0]
+    victim = tokens[1]
+    # Forge a hop signed by the correct issuer key (orchestrator) but whose
+    # caveats widen the parent: add a permission the parent never held.
+    widened = ct.Caveats(
+        permissions=victim.caveats.permissions | {"agents:spawn"},
+        remaining_depth=victim.caveats.remaining_depth,
+        not_after=victim.caveats.not_after,
+        task_ids=victim.caveats.task_ids,
+        path_prefixes=victim.caveats.path_prefixes,
+        max_uses=victim.caveats.max_uses,
+    )
+    forged = ct.sign_token(
+        token_id=victim.token_id,
+        issuer_identity_id=victim.issuer_identity_id,
+        issuer_private_key=privs["orchestrator"],
+        subject_identity_id=victim.subject_identity_id,
+        subject_pubkey=victim.subject_pubkey.encode(),
+        caveats=widened,
+        parent_token_hash=parent.token_hash(),
+        audit_head=victim.audit_head,
+        granted_at=victim.granted_at,
+    )
+    assert forged.verify_signature()  # signature is valid
+    tokens[1] = forged
+    # Re-mint hop2 so its parent hash points to the forged hop1 (structure intact).
+    tokens[2] = ct.attenuate(
+        forged,
+        issuer_private_key=privs["sub-agent"],
+        subject_identity_id="leaf",
+        subject_pubkey=serialization.load_pem_private_key(privs["leaf"], password=None)
+        .public_key()
+        .public_bytes(serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo),
+        caveats=_caveats(permissions={"files:read"}, remaining_depth=0),
+    )
+    tampered = ct.CapabilityChain(tokens=tuple(tokens))
+    # No audit_chain passed: purely from signed token bytes.
+    result = ct.verify_chain(tampered, trust_anchors=set(_pem_set(anchors)))
+    assert not result.valid
+    assert not result.hops[1].ok
+    assert any("widen" in e or "narrow" in e for e in result.hops[1].errors)
+
+
+def test_tamper_issuer_pubkey_swap_rejected() -> None:
+    chain, _privs, anchors = _three_hop()
+    tokens = list(chain.tokens)
+    victim = tokens[1]
+    # Attacker swaps hop1.issuer_pubkey to their own identity and re-signs.
+    atk_priv = Ed25519PrivateKey.generate().private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+    forged = ct.sign_token(
+        token_id=victim.token_id,
+        issuer_identity_id=victim.issuer_identity_id,
+        issuer_private_key=atk_priv,
+        subject_identity_id=victim.subject_identity_id,
+        subject_pubkey=victim.subject_pubkey.encode(),
+        caveats=victim.caveats,
+        parent_token_hash=tokens[0].token_hash(),
+        audit_head=victim.audit_head,
+        granted_at=victim.granted_at,
+    )
+    assert forged.verify_signature()  # self-consistent signature
+    tokens[1] = forged
+    tampered = ct.CapabilityChain(tokens=tuple(tokens))
+    result = ct.verify_chain(tampered, trust_anchors=set(_pem_set(anchors)))
+    assert not result.valid
+    assert not result.hops[1].ok
+    assert any("pubkey" in e or "continu" in e for e in result.hops[1].errors)
+
+
+# ---------------------------------------------------------------------------
+# to_actor_claims (design addition 2)
+# ---------------------------------------------------------------------------
+
+
+def test_to_actor_claims_nested_shape() -> None:
+    chain, _privs, anchors = _three_hop()
+    claims = ct.to_actor_claims(chain, trust_anchors=set(_pem_set(anchors)))
+    assert claims == {
+        "sub": "principal",
+        "act": {
+            "sub": "orchestrator",
+            "act": {
+                "sub": "sub-agent",
+                "act": {"sub": "leaf"},
+            },
+        },
+    }
+
+
+def test_to_actor_claims_refuses_unverified_chain() -> None:
+    chain, _privs, _anchors = _three_hop()
+    _other_priv, other_pub = _kp()
+    with pytest.raises(ct.TokenVerificationError):
+        ct.to_actor_claims(chain, trust_anchors=set(_pem_set([other_pub])))
+
+
+# ---------------------------------------------------------------------------
+# Round-trip serialization
+# ---------------------------------------------------------------------------
+
+
+def test_chain_json_round_trip_verifies() -> None:
+    chain, _privs, anchors = _three_hop()
+    blob = chain.to_json()
+    restored = ct.CapabilityChain.from_json(blob)
+    result = ct.verify_chain(restored, trust_anchors=set(_pem_set(anchors)))
+    assert result.valid
+
+
+def test_token_hash_is_jcs_stable() -> None:
+    chain, _privs, _anchors = _three_hop()
+    tok = chain.tokens[0]
+    again = ct.CapabilityToken.from_dict(tok.to_dict())
+    assert again.token_hash() == tok.token_hash()
+    # Hash equals sha256 of the JCS body.
+    import hashlib
+
+    assert tok.token_hash() == hashlib.sha256(canonicalize_jcs(tok.body())).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _pem_set(pubs: list[bytes]) -> list[str]:
+    return [p.decode() for p in pubs]
+
+
+def _replace_jws(token: ct.CapabilityToken, jws: str) -> ct.CapabilityToken:
+    import dataclasses
+
+    return dataclasses.replace(token, jws=jws)
+
+
+def test_sign_detached_helper_matches_verify() -> None:
+    """The new public sign helper round-trips through the existing verifier."""
+    priv, pub = _kp()
+    body = canonicalize_jcs({"z": 1, "a": [2, 3]})
+    jws = sign_detached_jws_over_canonical(body, priv, typ="x+jws", kid="k1")
+    from bernstein.core.security.agent_card_signer import (
+        verify_detached_jws_over_canonical,
+    )
+
+    assert verify_detached_jws_over_canonical(body, jws, pub, expected_typ="x+jws")
+    assert not verify_detached_jws_over_canonical(body, jws, pub, expected_typ="other+jws")

--- a/tests/unit/test_delegation_verify_token_cmd.py
+++ b/tests/unit/test_delegation_verify_token_cmd.py
@@ -1,0 +1,114 @@
+"""``bernstein delegation verify-token`` CLI (issue #2611, AC6).
+
+The command verifies a signed capability-token chain fully offline, prints
+per-hop pass/fail, and exits non-zero on any failing hop.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from bernstein.cli.commands.delegation_cmd import delegation_group
+from bernstein.core.security import capability_tokens as ct
+from bernstein.core.security.agent_card_signer import generate_ed25519_keypair
+
+_NOW = 1_800_000_000.0
+
+
+def _caveats(perms: set[str], depth: int) -> ct.Caveats:
+    return ct.Caveats(permissions=frozenset(perms), remaining_depth=depth, not_after=_NOW + 3600)
+
+
+def _write_chain(tmp_path: Path) -> tuple[Path, Path]:
+    p_priv, p_pub = generate_ed25519_keypair()
+    o_priv, o_pub = generate_ed25519_keypair()
+    _s_priv, s_pub = generate_ed25519_keypair()
+
+    root = ct.mint_root(
+        issuer_identity_id="principal",
+        issuer_private_key=p_priv,
+        subject_identity_id="orchestrator",
+        subject_pubkey=o_pub,
+        caveats=_caveats({"files:read", "files:write"}, depth=3),
+    )
+    hop1 = ct.attenuate(
+        root,
+        issuer_private_key=o_priv,
+        subject_identity_id="sub-agent",
+        subject_pubkey=s_pub,
+        caveats=_caveats({"files:read"}, depth=2),
+    )
+    chain = ct.CapabilityChain(tokens=(root, hop1))
+
+    token_file = tmp_path / "chain.json"
+    token_file.write_text(chain.to_json(), encoding="utf-8")
+    anchor_file = tmp_path / "principal.pem"
+    anchor_file.write_bytes(p_pub)
+    return token_file, anchor_file
+
+
+def test_verify_token_valid_exits_zero(tmp_path: Path) -> None:
+    token_file, anchor_file = _write_chain(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        delegation_group,
+        ["verify-token", str(token_file), "--trust-anchor", str(anchor_file)],
+    )
+    assert result.exit_code == 0, result.output
+    assert "hop 0: principal -> orchestrator  PASS" in result.output
+    assert "hop 1: orchestrator -> sub-agent  PASS" in result.output
+    assert "capability chain verified" in result.output
+
+
+def test_verify_token_tampered_exits_nonzero(tmp_path: Path) -> None:
+    token_file, anchor_file = _write_chain(tmp_path)
+    chain = ct.CapabilityChain.from_json(token_file.read_text(encoding="utf-8"))
+    tokens = list(chain.tokens)
+    # Corrupt hop 1's signature (first significant base64url char).
+    header, _payload, sig = tokens[1].jws.split(".")
+    flipped = "A" if sig[0] != "A" else "B"
+    tokens[1] = dataclasses.replace(tokens[1], jws=f"{header}..{flipped}{sig[1:]}")
+    token_file.write_text(ct.CapabilityChain(tokens=tuple(tokens)).to_json(), encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        delegation_group,
+        ["verify-token", str(token_file), "--trust-anchor", str(anchor_file)],
+    )
+    assert result.exit_code == 1, result.output
+    assert "hop 1:" in result.output and "FAIL" in result.output
+    assert "capability chain verification failed" in result.output
+
+
+def test_verify_token_untrusted_root_exits_nonzero(tmp_path: Path) -> None:
+    token_file, _anchor_file = _write_chain(tmp_path)
+    _other_priv, other_pub = generate_ed25519_keypair()
+    other_file = tmp_path / "other.pem"
+    other_file.write_bytes(other_pub)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        delegation_group,
+        ["verify-token", str(token_file), "--trust-anchor", str(other_file)],
+    )
+    assert result.exit_code == 1, result.output
+    assert "hop 0:" in result.output and "FAIL" in result.output
+
+
+def test_verify_token_json_output(tmp_path: Path) -> None:
+    token_file, anchor_file = _write_chain(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        delegation_group,
+        ["verify-token", str(token_file), "--trust-anchor", str(anchor_file), "--json"],
+    )
+    assert result.exit_code == 0, result.output
+    import json
+
+    payload = json.loads(result.output)
+    assert payload["valid"] is True
+    assert payload["principal_path"] == ["principal", "orchestrator", "sub-agent"]
+    assert all(hop["ok"] for hop in payload["hops"])

--- a/tests/unit/test_permission_delegation_capability.py
+++ b/tests/unit/test_permission_delegation_capability.py
@@ -1,0 +1,140 @@
+"""Capability-token bridge on ``PermissionDelegator`` (issue #2611, AC7).
+
+The legacy enum-scope delegation surface keeps working unchanged; the additive
+signed path bridges the ``read``/``write``/``execute``/``full`` enum onto
+capability-token caveats and verifies offline-chain-first with the in-process
+registry consulted only for liveness and revocation.
+"""
+
+from __future__ import annotations
+
+import time
+
+from bernstein.core.security import capability_tokens as ct
+from bernstein.core.security.agent_card_signer import generate_ed25519_keypair
+from bernstein.core.security.permission_delegation import (
+    PermissionDelegator,
+    enum_to_caveats,
+)
+
+
+def test_enum_scope_hierarchy_maps_to_nested_caveats() -> None:
+    now = time.time()
+    read = enum_to_caveats("read", remaining_depth=3, not_after=now + 100)
+    write = enum_to_caveats("write", remaining_depth=3, not_after=now + 100)
+    execute = enum_to_caveats("execute", remaining_depth=3, not_after=now + 100)
+    full = enum_to_caveats("full", remaining_depth=3, not_after=now + 100)
+    # read < write < execute <= full over the PERM_* vocabulary.
+    assert read.permissions < write.permissions
+    assert write.permissions < execute.permissions
+    assert execute.permissions <= full.permissions
+    assert "files:read" in read.permissions
+    assert "files:write" in write.permissions and "files:write" not in read.permissions
+    assert "agents:spawn" in execute.permissions
+
+
+def test_legacy_enum_delegation_still_works() -> None:
+    """The pre-existing enum-scope registry path is untouched."""
+    delegator = PermissionDelegator()
+    delegator.register_approval("approval-1", "write", ["read", "write"])
+    token = delegator.create_delegation("approval-1", "coord-1", "worker-1")
+    assert token is not None
+    assert delegator.verify_token(token.token_id, "read") is True
+    assert delegator.verify_token(token.token_id, "delete") is False
+
+
+def _keys() -> tuple[bytes, bytes, bytes, bytes]:
+    p_priv, p_pub = generate_ed25519_keypair()
+    o_priv, o_pub = generate_ed25519_keypair()
+    return p_priv, p_pub, o_priv, o_pub
+
+
+def test_mint_and_verify_capability_offline() -> None:
+    delegator = PermissionDelegator()
+    p_priv, p_pub, o_priv, o_pub = _keys()
+    _s_priv, s_pub = generate_ed25519_keypair()
+
+    root = delegator.mint_capability(
+        issuer_identity_id="principal",
+        issuer_private_key=p_priv,
+        subject_identity_id="orchestrator",
+        subject_pubkey=o_pub,
+        scope="write",
+        remaining_depth=3,
+        ttl_seconds=3600,
+    )
+    child = delegator.mint_capability(
+        issuer_identity_id="orchestrator",
+        issuer_private_key=o_priv,
+        subject_identity_id="sub-agent",
+        subject_pubkey=s_pub,
+        scope="read",
+        remaining_depth=2,
+        ttl_seconds=3600,
+        parent=root,
+    )
+    chain = ct.CapabilityChain(tokens=(root, child))
+    anchors = {p_pub.decode()}
+
+    assert delegator.verify_capability(chain, "files:read", trust_anchors=anchors)
+    # read scope does not carry write / spawn.
+    assert not delegator.verify_capability(chain, "files:write", trust_anchors=anchors)
+    assert not delegator.verify_capability(chain, "agents:spawn", trust_anchors=anchors)
+
+
+def test_verify_capability_rejects_untrusted_root() -> None:
+    delegator = PermissionDelegator()
+    p_priv, _p_pub, _o_priv, o_pub = _keys()
+    root = delegator.mint_capability(
+        issuer_identity_id="principal",
+        issuer_private_key=p_priv,
+        subject_identity_id="orchestrator",
+        subject_pubkey=o_pub,
+        scope="full",
+        remaining_depth=2,
+        ttl_seconds=3600,
+    )
+    chain = ct.CapabilityChain(tokens=(root,))
+    _other_priv, other_pub = generate_ed25519_keypair()
+    assert not delegator.verify_capability(chain, "files:read", trust_anchors={other_pub.decode()})
+
+
+def test_revocation_is_registry_only_liveness() -> None:
+    """A cryptographically-valid chain still fails once a hop is revoked - the
+    dual path consults the registry for liveness after the offline check."""
+    delegator = PermissionDelegator()
+    p_priv, p_pub, _o_priv, o_pub = _keys()
+    root = delegator.mint_capability(
+        issuer_identity_id="principal",
+        issuer_private_key=p_priv,
+        subject_identity_id="orchestrator",
+        subject_pubkey=o_pub,
+        scope="write",
+        remaining_depth=2,
+        ttl_seconds=3600,
+    )
+    chain = ct.CapabilityChain(tokens=(root,))
+    anchors = {p_pub.decode()}
+    assert delegator.verify_capability(chain, "files:read", trust_anchors=anchors)
+
+    delegator.revoke_capability(root.token_hash())
+    assert not delegator.verify_capability(chain, "files:read", trust_anchors=anchors)
+
+
+def test_verify_capability_rejects_expired_leaf() -> None:
+    delegator = PermissionDelegator()
+    p_priv, p_pub, _o_priv, o_pub = _keys()
+    root = delegator.mint_capability(
+        issuer_identity_id="principal",
+        issuer_private_key=p_priv,
+        subject_identity_id="orchestrator",
+        subject_pubkey=o_pub,
+        scope="write",
+        remaining_depth=2,
+        ttl_seconds=-1,  # already expired
+    )
+    chain = ct.CapabilityChain(tokens=(root,))
+    anchors = {p_pub.decode()}
+    # Offline signature/attenuation are valid, but the token is not live.
+    assert ct.verify_chain(chain, trust_anchors=anchors).valid
+    assert not delegator.verify_capability(chain, "files:read", trust_anchors=anchors)

--- a/typos.toml
+++ b/typos.toml
@@ -28,6 +28,7 @@ thr = "thr"          # thr = threshold (scripts/mutmut_critical.py)
 strat = "strat"      # strat = strategy (adapter STRATEGY_MATRIX, test_adapter_wave_2521.py)
 Aktive = "Aktive"    # correct German word for "Active" (i18n.py)
 abd = "abd"          # deterministic 3-byte hash fixture b"abd" (test_computer_use_lineage.py)
+continu = "continu"  # intentional substring match for "continue"/"continuity" in error text (test_capability_tokens.py)
 
 # Technical terms used consistently in the codebase
 unparseable = "unparseable"


### PR DESCRIPTION
## What
Implemented attenuated delegation capability tokens: each delegation hop is a detached-JWS (typ delegation-capability+jws) over the JCS-canonical token body via agent_card_signer, binding issuer_pubkey AND subject_pubkey captured at mint so key rotation never invalidates history. attenuate() enforces subset caveats (permissions set-subset, task-id allowlist, POSIX ancestor-or-equal path-prefix coverage, expiry <=, max_uses <=, strictly-decreasing remaining_depth = the max_depth caveat), rejecting widening at mint AND independently at verify. verify_chain() walks a chain offline (no network, no registry): per-hop signature, structural parent-hash linkage, identity+pubkey continuity, monotonic attenuation, root trust-anchor membership. to_actor_claims() projects a verified chain as nested RFC 8693 act claims and refuses an unverified chain. Mints anchor a delegation_minted HMAC audit event whose token_hash and prev_chain_digest cross-reference the token; PermissionDelegator gains an enum->caveat bridge with an offline-first dual verify path; CLI `bernstein delegation verify-token` veri

Fixes #2611

## Acceptance criteria (10/10 met)
- [x] AC1: CapabilityToken mint produces detached JWS (typ delegation-capability+jws) over JCS body with issuer_pubkey, subject_identity_id, caveats, parent
- [x] AC2: attenuate rejects non-subset children over permissions/task-ids/path-prefixes/expiry/max_uses, proven by property test
- [x] AC3: verify_chain runs offline (no network, no registry) and returns resolved principal->orchestrator->sub-agent path
- [x] AC4: three-way tamper test (JWS byte flip, widened caveat rewrite, issuer-pubkey swap) rejected with registry unavailable; widened case rejected purel
- [x] AC5: each mint emits delegation_minted audit event whose token hash and chain head cross-reference, verifiable by bernstein audit verify
- [x] AC6: bernstein delegation verify-token prints per-hop pass/fail offline and exits non-zero on failure
- [x] AC7: existing permission_delegation enum-scope callers pass unchanged via enum->caveat mapping
- [x] Design addition 1: max_depth caveat - each hop remaining_depth strictly less than parent; chain deeper than root authorized fails mint and verify
- [x] Design addition 2: to_actor_claims() exports verified chain as nested RFC 8693 act claims; refuses unverified chain
- [x] Design addition 3: two-tier boundary - tokens only narrow (widened child raises at mint AND fails verify); approval-gated actions not caveats (documen

## Verification
Adversarial review: **confirmed, 0 critical findings** (empirical criteria re-attacked independently: tamper/determinism/red-on-main).
New: tests/unit/test_capability_tokens.py (mint/attenuate/verify/three-way tamper/max_depth/to_actor_claims/serialization), tests/unit/test_capability_token_audit_anchor.py (AC5 delegation_minted cross-reference + audit verify), tests/unit/test_permission_delegation_capability.py (AC7 enum bridge + dual verify path + revocation/liveness), tests/unit/test_delegation_verify_token_cmd.py (AC6 CLI), tests/property/test_capability_caveat_subset.py (AC2 subset relation + path-prefix coverage propertie


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added signed, offline-verifiable delegation capability tokens with scoped permissions, expiry, usage, task, and path restrictions.
  * Added support for safely narrowing delegated authority across multiple hops.
  * Added `delegation verify-token` CLI command with human-readable and JSON verification results.
  * Added capability revocation and expiration checks for active delegations.
  * Added audit-chain anchoring for delegated capability issuance.

* **Documentation**
  * Documented delegation capability tokens, verification, trust anchors, and CLI usage.

* **Tests**
  * Added comprehensive coverage for token security, attenuation, auditing, verification, and CLI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->