### PR TITLE
feat(tasks): typed artifact contract for non-coding agents (slice 1)

### DIFF
--- a/docs/operations/artifacts.md
+++ b/docs/operations/artifacts.md
@@ -1,0 +1,114 @@
+# Artifact contract (non-coding tasks)
+
+Audience: operators and reviewers who need to prove a non-coding task
+produced a specific report, dataset, action log, or ops result - with the
+same guarantees a code diff gets.
+
+## Overview
+
+A coding task's output is a diff. A non-coding task's output is a **report**,
+a **dataset**, an **action log**, or an **ops result**. The artifact contract
+gives every such output one canonical, byte-stable form and records it as a
+signed, content-addressed lineage entry.
+
+The recorded entry **is** the artifact: strip lineage, signing, or the
+canonical form and there is only an unattested blob no operator can prove the
+agent produced.
+
+## Artifact kinds
+
+| Kind | Canonical form |
+|------|----------------|
+| `code_diff` | Normalised UTF-8 text (the default; uses the git-diff path, not the artifact sink) |
+| `report` | Normalised UTF-8 text |
+| `dataset` | Canonical JSONL - one JCS-canonical JSON object per line, `\n`-separated |
+| `action_log` | Canonical JSONL (as `dataset`) |
+| `ops_result` | A single JCS-canonical JSON object |
+
+A task declares its kind through an `ArtifactSpec` on the task. Absent a spec,
+a task is `code_diff` and behaves exactly as before.
+
+## Canonicalisation rules (shared core)
+
+Every kind routes through one core so two kinds can never disagree:
+
+- **Stable key ordering** - JSON objects serialise with sorted keys.
+- **Fixed UTF-8** - no ASCII escaping, no BOM.
+- **Normalised newlines** - CRLF and lone CR fold to `\n`.
+- **Reject, don't repair** - text that is not NFC-normalised is *rejected*,
+  not silently normalised, so two byte-different inputs can never both pass as
+  "the same" artifact. NaN / Infinity are rejected in JSON kinds.
+
+The artifact's identity is `content_hash = sha256(canonical_bytes)`.
+
+## Determinism
+
+The signed lineage entry for an artifact is a deterministic projection of
+`(task_id, kind, artifact)`: the tool-call id, span id, and timestamp are
+derived from the task, not the wall clock. Two operators who run the same task
+with the same inputs produce:
+
+- the **byte-identical `content_hash`**, and
+- the **identical signed lineage-entry hash** (the completion receipt).
+
+A one-byte change to the input changes both.
+
+## Verification criteria
+
+A task's `ArtifactSpec` may declare typed criteria evaluated against the
+artifact bytes (in addition to the six filesystem/test completion signals):
+
+| Criterion | Checks |
+|-----------|--------|
+| `hash_stable` | Re-derives the canonical hash and compares it to an expected `sha256:...` |
+| `schema_valid` | Validates the artifact's JSON document against a declared JSON Schema (JSONL kinds validate each row) |
+| `criteria_match` | Evaluates a closed predicate set (`exists` / `eq` / `ne` / `contains` / `gt` / `ge` / `lt` / `le`) over the JSON document |
+
+Each has a closed evaluator; none executes artifact-supplied code.
+
+## `bernstein artifact verify`
+
+```
+bernstein artifact verify <task_id> [--workdir .] [--output-json]
+```
+
+The command:
+
+1. Re-derives the canonical hash from the stored artifact bytes and confirms
+   it matches the receipt - a post-hoc byte alteration of the blob fails here.
+2. Ties the blob to the signed lineage entry named by the receipt - a removed
+   entry or a swapped hash fails here.
+3. Runs the lineage gate: every entry's Ed25519 signature verifies, the
+   operator HMAC chain is intact, and no `parent_hash` dangles.
+
+Exit codes: `0` = verified, `2` = tampered / missing / unverifiable.
+
+The operator HMAC secret is read from `$BERNSTEIN_OPERATOR_SECRET`, falling
+back to the audit key. When no secret is available the HMAC leg is skipped;
+the Ed25519 signature and parent-chain checks still run.
+
+### On-disk layout
+
+```
+.sdd/
+  lineage/log.jsonl                # signed, HMAC-chained lineage log
+  lineage/signatures/…             # detached JWS sidecars
+  agents/<agent-id>/card.json      # Agent Cards (public keys)
+  artifacts/<task_id>/artifact.bin # canonical artifact bytes (content sink)
+  artifacts/<task_id>/receipt.json # pointer to the signed entry (re-checked on verify)
+```
+
+## Source
+
+- `src/bernstein/core/tasks/artifacts.py` - kinds, canonicalisers, criteria.
+- `src/bernstein/core/lineage/artifact_record.py` - record + verify.
+- `src/bernstein/core/lineage/entry.py` - the widened, still-closed
+  `ARTEFACT_KINDS`.
+- the `artifact` group in `src/bernstein/cli/commands/artifact_cmd.py`.
+
+## Scope
+
+This is the typed contract layer. Wiring the artifact path into the adapter
+`output_mode` axis, skipping worktree allocation for artifact-mode tasks, and
+the `commit_completion` branch are a separate follow-up; a coding task stays on
+the git-diff path and is unchanged.

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -84,4 +84,12 @@ keeping it healthy, cheap, secure, and auditable.
 
     [:octicons-arrow-right-24: Compliance overview](compliance.md)
 
+- :material-file-sign:{ .lg .middle } **Artifacts**
+
+    ---
+
+    Signed, content-addressed non-coding artifacts and `artifact verify`.
+
+    [:octicons-arrow-right-24: Artifact contract](artifacts.md)
+
 </div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -405,6 +405,7 @@ nav:
           - Lineage export: compliance/lineage-export.md
           - Lineage v1 (user reference): lineage.md
           - Lineage v2: operations/lineage-v2.md
+          - Artifact contract: operations/artifacts.md
           - Lineage conflict resolution: lineage/conflict-resolution.md
           - Tracker audit: lineage/tracker-audit.md
           - A2A message receipts: operations/a2a-message-receipts.md

--- a/src/bernstein/cli/commands/artifact_cmd.py
+++ b/src/bernstein/cli/commands/artifact_cmd.py
@@ -1,0 +1,120 @@
+"""``bernstein artifact verify``: prove a non-coding artifact (issue #2608).
+
+A non-coding task's output (report / dataset / action log / ops result) is
+recorded as a signed, content-addressed lineage entry. ``artifact verify``
+re-derives the canonical hash from the stored bytes, ties it to the signed
+entry, and runs the lineage gate (Ed25519 signature + operator HMAC chain +
+parent integrity). It fails - non-zero exit - on any post-hoc byte alteration
+of the artifact or a removed lineage entry, so "the agent produced this exact
+artifact" is a cryptographic check, not a trust exercise.
+
+    bernstein artifact verify <task_id>
+
+This is the singular ``artifact`` group; the plural ``artifacts`` group lists
+agent-posted, journal-anchored task artifacts (issue #2553) and is unrelated.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import click
+
+from bernstein.cli.helpers import console
+
+
+@click.group("artifact")
+def artifact_group() -> None:
+    """Verify a task's signed, content-addressed artifact.
+
+    \b
+      bernstein artifact verify <task_id>
+    """
+
+
+@artifact_group.command("verify")
+@click.argument("task_id")
+@click.option(
+    "--workdir",
+    "-w",
+    type=click.Path(file_okay=False, exists=True, path_type=Path),
+    default=".",
+    show_default=True,
+    help="Project root containing .sdd/.",
+)
+@click.option(
+    "--operator-secret-env",
+    default="BERNSTEIN_OPERATOR_SECRET",
+    show_default=True,
+    help="Env var holding the operator HMAC secret. Falls back to the audit key.",
+)
+@click.option("--output-json", is_flag=True, help="Emit a JSON verdict instead of human text.")
+def artifact_verify_cmd(task_id: str, workdir: Path, operator_secret_env: str, output_json: bool) -> None:
+    """Re-derive TASK_ID's canonical hash and verify its signed lineage record.
+
+    Exit codes: 0 = verified, 2 = tampered / missing / unverifiable.
+    """
+    import json
+    import sys
+
+    from bernstein.core.lineage.artifact_record import ARTIFACT_SINK_RELPATH, verify_artifact
+
+    sdd = workdir.resolve() / ".sdd"
+    sink_root = workdir.resolve() / ARTIFACT_SINK_RELPATH
+    log_path = sdd / "lineage" / "log.jsonl"
+    cards_dir = sdd / "agents"
+
+    operator_secret = _resolve_operator_secret(operator_secret_env)
+
+    result = verify_artifact(
+        task_id=task_id,
+        sink_root=sink_root,
+        log_path=log_path,
+        cards_dir=cards_dir,
+        operator_secret=operator_secret,
+    )
+
+    if output_json:
+        click.echo(
+            json.dumps(
+                {
+                    "task_id": result.task_id,
+                    "ok": result.ok,
+                    "content_hash": result.content_hash,
+                    "entry_hash": result.entry_hash,
+                    "failures": result.failures,
+                }
+            )
+        )
+    elif result.ok:
+        console.print(f"[green]VERIFIED[/green] task={task_id}")
+        console.print(f"  content_hash  {result.content_hash}")
+        console.print(f"  entry_hash    {result.entry_hash}")
+    else:
+        console.print(f"[red]TAMPERED[/red] task={task_id}")
+        for failure in result.failures:
+            console.print(f"  - {failure}")
+
+    if not result.ok:
+        sys.exit(2)
+
+
+def _resolve_operator_secret(env_var: str) -> bytes | None:
+    """Resolve the operator HMAC secret: env var first, then the audit key.
+
+    Returns ``None`` only when neither source yields a key, in which case the
+    HMAC leg of verification is skipped (signature + chain are still enforced).
+    """
+    secret = os.environ.get(env_var)
+    if secret:
+        return secret.encode("utf-8")
+    try:
+        from bernstein.core.security.audit import load_or_create_audit_key
+
+        return load_or_create_audit_key()
+    except Exception:  # pragma: no cover - defensive: never block verification on key IO
+        return None
+
+
+__all__ = ["artifact_group"]

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -1310,6 +1310,11 @@ from bernstein.cli.commands.artifacts_cmd import artifacts_group  # noqa: E402
 
 cli.add_command(artifacts_group, "artifacts")
 
+# Verify a non-coding task's signed, content-addressed artifact (#2608).
+from bernstein.cli.commands.artifact_cmd import artifact_group  # noqa: E402
+
+cli.add_command(artifact_group, "artifact")
+
 # In-process verification gate driven by worker hooks: blocks a failing
 # completion or an out-of-scope write in-session, sealing gate receipts (#2360).
 from bernstein.cli.commands.hook_gate_cmd import hook_gate_group  # noqa: E402

--- a/src/bernstein/core/lineage/artifact_record.py
+++ b/src/bernstein/core/lineage/artifact_record.py
@@ -190,9 +190,7 @@ def record_artifact(
     task_dir = sink_root / task_id
     task_dir.mkdir(parents=True, exist_ok=True)
     (task_dir / _BLOB_NAME).write_bytes(canonical)
-    (task_dir / _RECEIPT_NAME).write_text(
-        json.dumps(receipt.to_dict(), sort_keys=True, indent=2), encoding="utf-8"
-    )
+    (task_dir / _RECEIPT_NAME).write_text(json.dumps(receipt.to_dict(), sort_keys=True, indent=2), encoding="utf-8")
     return receipt
 
 
@@ -243,9 +241,7 @@ def verify_artifact(
         stored = blob_path.read_bytes()
         rederived = content_hash(stored)
         if rederived != receipt.content_hash:
-            failures.append(
-                f"stored bytes altered: re-derived {rederived} != receipt {receipt.content_hash}"
-            )
+            failures.append(f"stored bytes altered: re-derived {rederived} != receipt {receipt.content_hash}")
 
     matched = None
     for entry, _jws in _read_log(log_path):
@@ -255,9 +251,7 @@ def verify_artifact(
     if matched is None:
         failures.append(f"lineage entry {receipt.entry_hash} for the artifact is missing from the log")
     elif rederived is not None and matched.content_hash != rederived:
-        failures.append(
-            f"recorded content_hash {matched.content_hash} != stored bytes {rederived}"
-        )
+        failures.append(f"recorded content_hash {matched.content_hash} != stored bytes {rederived}")
 
     gate_result = check(log_path, cards_dir, operator_secret=operator_secret)
     if not gate_result.ok:

--- a/src/bernstein/core/lineage/artifact_record.py
+++ b/src/bernstein/core/lineage/artifact_record.py
@@ -1,0 +1,300 @@
+"""Record and verify a non-coding artifact as a signed lineage entry (#2608).
+
+Slice 1 gives a non-coding task's output the same guarantees a code diff gets:
+the artifact's canonical bytes are recorded through :class:`LineageRecorder`,
+so the entry carries an HMAC envelope + Ed25519 detached-JWS signature, and its
+identity is ``content_hash = sha256(canonical_bytes)``. The recorded, signed
+entry *is* the artifact - strip lineage/signing/canonicalisation and there is
+only an unattested blob no operator can prove the agent produced.
+
+The write side (:func:`record_artifact`) is a thin wrapper over
+``record_write``: it canonicalises the raw artifact under its
+:class:`ArtifactKind`, records it, and persists the canonical bytes plus a
+small receipt to a content sink so the verifier can re-derive the hash. The
+entry is a *deterministic projection* of ``(task_id, kind, artifact)``: the
+tool-call id, span id, and timestamp are derived from the task, so two
+operators with equal inputs produce a byte-identical signed entry.
+
+The read side (:func:`verify_artifact`) re-derives the canonical hash from the
+stored bytes, ties it to the signed entry, and runs the lineage gate
+(signature + HMAC chain + parent integrity). It fails on any post-hoc byte
+alteration or a removed entry.
+
+This module intentionally does not touch the adapter ``output_mode`` axis,
+worktree allocation, or the ``commit_completion`` branch - those are slice 2.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.lineage.entry import entry_hash
+from bernstein.core.lineage.gate import check
+from bernstein.core.tasks.artifacts import (
+    ArtifactKind,
+    CanonicalisationError,
+    canonicalise_artifact,
+    content_hash,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.lineage.identity import AgentCard
+    from bernstein.core.lineage.recorder import LineageRecorder
+
+#: Logical, repo-relative POSIX prefix under which artifact entries are anchored
+#: in the lineage log. The physical sink root is supplied separately so tests
+#: and operators can point it anywhere while the *entry* path stays stable.
+ARTIFACT_SINK_RELPATH = ".sdd/artifacts"
+
+_BLOB_NAME = "artifact.bin"
+_RECEIPT_NAME = "receipt.json"
+
+
+def artifact_entry_path(task_id: str) -> str:
+    """Return the repo-relative lineage path an artifact for ``task_id`` anchors at."""
+    return f"{ARTIFACT_SINK_RELPATH}/{task_id}/{_BLOB_NAME}"
+
+
+def _artifact_tool_call_id(task_id: str) -> str:
+    return f"artifact:{task_id}"
+
+
+def _artifact_span_id(task_id: str, kind: str) -> str:
+    return hashlib.sha256(f"artifact:{task_id}:{kind}".encode()).hexdigest()[:16]
+
+
+@dataclass(frozen=True)
+class ArtifactReceipt:
+    """The completion receipt for an artifact-mode task.
+
+    The receipt is *not* the trust anchor - the signed lineage entry is. It is
+    a pointer that lets the verifier find the entry and the stored bytes and
+    re-derive the hash; every field is re-checked against the signed log.
+    """
+
+    task_id: str
+    kind: str
+    content_hash: str
+    entry_hash: str
+    artefact_path: str
+    agent_id: str
+    agent_card_kid: str
+    ts_ns: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "task_id": self.task_id,
+            "kind": self.kind,
+            "content_hash": self.content_hash,
+            "entry_hash": self.entry_hash,
+            "artefact_path": self.artefact_path,
+            "agent_id": self.agent_id,
+            "agent_card_kid": self.agent_card_kid,
+            "ts_ns": self.ts_ns,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ArtifactReceipt:
+        return cls(
+            task_id=str(data["task_id"]),
+            kind=str(data["kind"]),
+            content_hash=str(data["content_hash"]),
+            entry_hash=str(data["entry_hash"]),
+            artefact_path=str(data["artefact_path"]),
+            agent_id=str(data["agent_id"]),
+            agent_card_kid=str(data["agent_card_kid"]),
+            ts_ns=int(data["ts_ns"]),
+        )
+
+
+@dataclass(frozen=True)
+class ArtifactVerifyResult:
+    """Outcome of :func:`verify_artifact`. ``ok`` is True iff ``failures`` is empty."""
+
+    task_id: str
+    ok: bool
+    failures: list[str]
+    content_hash: str | None
+    entry_hash: str | None
+
+
+def record_artifact(
+    *,
+    recorder: LineageRecorder,
+    sink_root: Path,
+    task_id: str,
+    kind: ArtifactKind | str,
+    artifact: Any,
+    agent_id: str,
+    agent_card: AgentCard,
+    private_key_pem: str,
+    ts_ns: int = 0,
+) -> ArtifactReceipt:
+    """Canonicalise, record, and persist a non-coding artifact.
+
+    Returns the :class:`ArtifactReceipt` whose ``entry_hash`` is the completion
+    receipt for the task (the signed lineage-entry hash, not a git SHA).
+
+    Args:
+        recorder: The lineage recorder to append the signed entry through.
+        sink_root: Physical directory the canonical bytes + receipt are written
+            under (``<sink_root>/<task_id>/``).
+        task_id: The task the artifact completes.
+        kind: The artifact's :class:`ArtifactKind`; ``code_diff`` is rejected -
+            it belongs on the git-diff path, not the artifact sink.
+        artifact: The raw produced artifact (str / bytes / list / mapping).
+        agent_id, agent_card, private_key_pem: Signing identity.
+        ts_ns: Logical entry timestamp. Fixed (default ``0``) so the signed
+            entry is a deterministic projection of the inputs.
+
+    Raises:
+        ValueError: When ``kind`` is ``code_diff``.
+        CanonicalisationError: When ``artifact`` does not fit the kind's rule.
+    """
+    k = ArtifactKind(kind)
+    if k is ArtifactKind.CODE_DIFF:
+        raise ValueError("code_diff artifacts use the git-diff path, not the artifact sink")
+
+    canonical = canonicalise_artifact(k, artifact)
+    chash = content_hash(canonical)
+    artefact_path = artifact_entry_path(task_id)
+
+    eh = recorder.record_write(
+        artefact_path=artefact_path,
+        new_content=canonical,
+        agent_id=agent_id,
+        agent_card=agent_card,
+        private_key_pem=private_key_pem,
+        tool_call_id=_artifact_tool_call_id(task_id),
+        span_id=_artifact_span_id(task_id, k.value),
+        artefact_kind=k.value,
+        ts_ns=ts_ns,
+    )
+
+    receipt = ArtifactReceipt(
+        task_id=task_id,
+        kind=k.value,
+        content_hash=chash,
+        entry_hash=eh,
+        artefact_path=artefact_path,
+        agent_id=agent_id,
+        agent_card_kid=agent_card.kid,
+        ts_ns=ts_ns,
+    )
+
+    task_dir = sink_root / task_id
+    task_dir.mkdir(parents=True, exist_ok=True)
+    (task_dir / _BLOB_NAME).write_bytes(canonical)
+    (task_dir / _RECEIPT_NAME).write_text(
+        json.dumps(receipt.to_dict(), sort_keys=True, indent=2), encoding="utf-8"
+    )
+    return receipt
+
+
+def load_receipt(sink_root: Path, task_id: str) -> ArtifactReceipt | None:
+    """Return the persisted receipt for ``task_id``, or ``None`` when absent."""
+    receipt_path = sink_root / task_id / _RECEIPT_NAME
+    if not receipt_path.exists():
+        return None
+    return ArtifactReceipt.from_dict(json.loads(receipt_path.read_text(encoding="utf-8")))
+
+
+def verify_artifact(
+    *,
+    task_id: str,
+    sink_root: Path,
+    log_path: Path,
+    cards_dir: Path,
+    operator_secret: bytes | None,
+) -> ArtifactVerifyResult:
+    """Verify a recorded artifact end to end.
+
+    The checks, in order:
+
+    1. **Re-derive the canonical hash** from the stored bytes and confirm it
+       matches the receipt - a post-hoc byte alteration of the blob fails here.
+    2. **Tie the blob to the signed entry**: the entry named by the receipt
+       must exist in the log and its recorded ``content_hash`` must equal the
+       re-derived hash - a removed entry or a swapped hash fails here.
+    3. **Lineage gate**: every entry's Ed25519 signature verifies, the operator
+       HMAC chain is intact, and no ``parent_hash`` dangles - a tampered log
+       line or a removed anchor fails here. When ``operator_secret`` is ``None``
+       the HMAC leg is skipped (signature + chain still enforced), matching the
+       lineage gate's own optional-secret semantics.
+
+    Returns an :class:`ArtifactVerifyResult`; ``ok`` is True only when every
+    check passes.
+    """
+    failures: list[str] = []
+    receipt = load_receipt(sink_root, task_id)
+    if receipt is None:
+        return ArtifactVerifyResult(task_id, False, [f"no artifact receipt for task {task_id!r}"], None, None)
+
+    blob_path = sink_root / task_id / _BLOB_NAME
+    rederived: str | None = None
+    if not blob_path.exists():
+        failures.append("stored artifact bytes are missing")
+    else:
+        stored = blob_path.read_bytes()
+        rederived = content_hash(stored)
+        if rederived != receipt.content_hash:
+            failures.append(
+                f"stored bytes altered: re-derived {rederived} != receipt {receipt.content_hash}"
+            )
+
+    matched = None
+    for entry, _jws in _read_log(log_path):
+        if entry.artefact_path == receipt.artefact_path and entry_hash(entry) == receipt.entry_hash:
+            matched = entry
+            break
+    if matched is None:
+        failures.append(f"lineage entry {receipt.entry_hash} for the artifact is missing from the log")
+    elif rederived is not None and matched.content_hash != rederived:
+        failures.append(
+            f"recorded content_hash {matched.content_hash} != stored bytes {rederived}"
+        )
+
+    gate_result = check(log_path, cards_dir, operator_secret=operator_secret)
+    if not gate_result.ok:
+        failures.extend(gate_result.failures)
+
+    return ArtifactVerifyResult(task_id, not failures, failures, rederived, receipt.entry_hash)
+
+
+def _read_log(log_path: Path) -> Any:
+    """Yield ``(entry, jws)`` over a lineage log rooted at ``log_path``.
+
+    A thin adapter over :class:`LineageStore` so the verifier reads through the
+    same reconstruction path the recorder wrote through - the store re-derives
+    signatures from the sidecar tree keyed by entry hash.
+    """
+    from bernstein.core.lineage.store import LineageStore
+
+    store = LineageStore(log_path.parent)
+    return store.read_log()
+
+
+def canonicalise_for_kind(kind: ArtifactKind | str, artifact: Any) -> bytes:
+    """Public re-export so the CLI can re-derive bytes without importing tasks.
+
+    Raises :class:`CanonicalisationError` on a shape/policy violation.
+    """
+    return canonicalise_artifact(kind, artifact)
+
+
+__all__ = [
+    "ARTIFACT_SINK_RELPATH",
+    "ArtifactReceipt",
+    "ArtifactVerifyResult",
+    "CanonicalisationError",
+    "artifact_entry_path",
+    "canonicalise_for_kind",
+    "load_receipt",
+    "record_artifact",
+    "verify_artifact",
+]

--- a/src/bernstein/core/lineage/entry.py
+++ b/src/bernstein/core/lineage/entry.py
@@ -14,7 +14,25 @@ from dataclasses import asdict, dataclass
 
 LINEAGE_ENTRY_VERSION = 1
 
-ARTEFACT_KINDS: frozenset[str] = frozenset({"file", "sdd-runtime", "mcp-result", "config", "tool-result"})
+# Closed set of recordable artefact kinds. The coding path records file writes
+# as ``file``; the non-coding artifact contract (issue #2608) adds the four
+# activity-worker output kinds (``report`` / ``dataset`` / ``action_log`` /
+# ``ops_result``) so a non-coding artifact can be a first-class signed lineage
+# record. The set stays closed - membership only widens and an unknown kind
+# still raises in :meth:`LineageEntry.__post_init__`.
+ARTEFACT_KINDS: frozenset[str] = frozenset(
+    {
+        "file",
+        "sdd-runtime",
+        "mcp-result",
+        "config",
+        "tool-result",
+        "report",
+        "dataset",
+        "action_log",
+        "ops_result",
+    }
+)
 
 #: Provenance trust classes recordable on an entry (issue #2513). ``None`` on
 #: an entry means "no trust class recorded" and is dropped from the canonical

--- a/src/bernstein/core/lineage/recorder.py
+++ b/src/bernstein/core/lineage/recorder.py
@@ -94,6 +94,7 @@ class LineageRecorder:
         artefact_kind: str = "file",
         trust_class: str | None = None,
         extra_parents: list[str] | None = None,
+        ts_ns: int | None = None,
     ) -> str:
         """Record a single artefact write. Returns the entry hash.
 
@@ -114,6 +115,12 @@ class LineageRecorder:
                 top of the artefact's own tip. This is the cross-artefact
                 lineage edge that anchors a derived artefact (or a quarantine
                 extraction) back to the tainted source it was produced from.
+            ts_ns: Optional deterministic entry timestamp (nanoseconds). When
+                ``None`` (the default, and every existing caller) the wall
+                clock is stamped, preserving byte-identical behaviour. Artifact
+                -mode callers pass a logical timestamp so two operators with
+                equal inputs produce a byte-identical signed entry - the
+                deterministic projection of ``(task, inputs)`` (issue #2608).
 
         Raises:
             ValueError: When ``artefact_path`` is absolute or contains a
@@ -138,7 +145,7 @@ class LineageRecorder:
                 if ph not in parent_hashes:
                     parent_hashes.append(ph)
 
-        ts_ns = time.time_ns()
+        entry_ts_ns = time.time_ns() if ts_ns is None else int(ts_ns)
 
         # Build the entry with an empty ``operator_hmac`` field, compute the
         # canonical HMAC over its JCS bytes, then materialise the final
@@ -157,7 +164,7 @@ class LineageRecorder:
             agent_card_kid=agent_card.kid,
             tool_call_id=tool_call_id,
             span_id=span_id,
-            ts_ns=ts_ns,
+            ts_ns=entry_ts_ns,
             operator_hmac="",
             trust_class=trust_class,
         )
@@ -173,7 +180,7 @@ class LineageRecorder:
             agent_card_kid=agent_card.kid,
             tool_call_id=tool_call_id,
             span_id=span_id,
-            ts_ns=ts_ns,
+            ts_ns=entry_ts_ns,
             operator_hmac=operator_hmac,
             trust_class=trust_class,
         )

--- a/src/bernstein/core/quality/janitor.py
+++ b/src/bernstein/core/quality/janitor.py
@@ -90,7 +90,18 @@ _ATTRIBUTION_MAX_COMMITS = 50
 # trivially satisfy). A passing signal of one of these types lets the janitor
 # accept a task whose diff is not attributable (empty-diff warn path) instead
 # of hard-rejecting it.
-_NONTRIVIAL_SIGNAL_TYPES = frozenset({"test_passes", "file_contains", "llm_review", "llm_judge"})
+# The artifact-mode criteria (issue #2608) verify the produced artifact's
+# canonical bytes against a declared contract, so a passing one is strong
+# evidence real work happened - on par with a passing test.
+_NONTRIVIAL_SIGNAL_TYPES = frozenset(
+    {"test_passes", "file_contains", "llm_review", "llm_judge", "schema_valid", "criteria_match", "hash_stable"}
+)
+
+# Completion-signal types that operate on an artifact's canonical bytes rather
+# than the filesystem (issue #2608). The filesystem-oriented
+# :func:`evaluate_signal` defers these to :func:`evaluate_artifact_signals`,
+# which has the produced artifact in scope.
+_ARTIFACT_SIGNAL_TYPES = frozenset({"schema_valid", "criteria_match", "hash_stable"})
 
 
 def _has_nontrivial_passing_signal(task: Task, signal_results: list[tuple[str, bool, str]]) -> bool:
@@ -255,7 +266,40 @@ def evaluate_signal(signal: CompletionSignal, workdir: Path) -> tuple[bool, str]
         case "llm_judge":
             # llm_judge requires async evaluation - use judge_task() instead.
             return False, "llm_judge requires async evaluation via judge_task()"
+        case "schema_valid" | "criteria_match" | "hash_stable":
+            # Artifact-mode criteria operate on the produced artifact's canonical
+            # bytes, not the filesystem. They are dispatched by
+            # evaluate_artifact_signals() once the artifact is in scope; the
+            # filesystem path recognises them (so they are never "unknown") but
+            # cannot evaluate them here.
+            return False, f"{signal.type} requires artifact-mode evaluation via evaluate_artifact_signals()"
     return False, f"unknown signal type: {signal.type}"
+
+
+def evaluate_artifact_signals(task: Task, artifact: object) -> list[tuple[str, bool, str]]:
+    """Evaluate a task's artifact-mode completion signals against ``artifact``.
+
+    ``artifact`` is the raw produced artifact (str / bytes / list / mapping);
+    it is canonicalised under the task's declared
+    :attr:`~bernstein.core.tasks.models.Task.artifact_spec` kind and each
+    ``schema_valid`` / ``criteria_match`` / ``hash_stable`` signal is evaluated
+    by its closed evaluator in :mod:`bernstein.core.tasks.artifacts`.
+
+    Returns a list of ``(description, passed, detail)`` tuples in the same shape
+    as :func:`_collect_signal_results`. Filesystem-oriented signals on the task
+    are ignored here (they are evaluated by :func:`verify_task`).
+    """
+    from bernstein.core.tasks.artifacts import evaluate_criterion
+
+    kind = task.artifact_spec.kind
+    results: list[tuple[str, bool, str]] = []
+    for signal in task.completion_signals:
+        if signal.type not in _ARTIFACT_SIGNAL_TYPES:
+            continue
+        desc = f"{signal.type}: {signal.value}"
+        passed, detail = evaluate_criterion(signal.type, signal.value, artifact=artifact, kind=kind)
+        results.append((desc, passed, detail))
+    return results
 
 
 def verify_task(task: Task, workdir: Path) -> tuple[bool, list[str]]:
@@ -273,6 +317,11 @@ def verify_task(task: Task, workdir: Path) -> tuple[bool, list[str]]:
     """
     failed: list[str] = []
     for signal in task.completion_signals:
+        # Artifact-mode criteria are verified against the produced artifact by
+        # evaluate_artifact_signals(), not against the filesystem, so the
+        # filesystem verify path skips them rather than spuriously failing.
+        if signal.type in _ARTIFACT_SIGNAL_TYPES:
+            continue
         passed, detail = evaluate_signal(signal, workdir)
         if not passed:
             desc = f"{signal.type}: {signal.value}"
@@ -300,6 +349,8 @@ def _collect_signal_results(
     for signal in task.completion_signals:
         if signal.type == "llm_judge":
             continue  # Evaluated async in run_janitor via judge_task()
+        if signal.type in _ARTIFACT_SIGNAL_TYPES:
+            continue  # Evaluated against the artifact via evaluate_artifact_signals()
         desc = f"{signal.type}: {signal.value}"
         passed, detail = evaluate_signal(signal, workdir)
         results.append((desc, passed, detail))

--- a/src/bernstein/core/tasks/artifacts.py
+++ b/src/bernstein/core/tasks/artifacts.py
@@ -1,0 +1,417 @@
+"""Artifact contract: kinds, canonical serialisation, and typed criteria (#2608).
+
+Slice 1 of the generalised task/artifact contract. A non-coding agent produces
+a *report*, a *dataset*, an *action log*, or an *ops result* instead of a code
+diff. Each such artifact needs a single, byte-stable canonical form so its
+``content_hash`` is a deterministic content-addressed identity: two operators
+with equal inputs must produce byte-identical bytes, hence the same hash, hence
+the same signed lineage entry.
+
+Every canonicaliser routes through one shared core (stable key ordering, fixed
+UTF-8, ``\\n`` newlines):
+
+* text kinds (``code_diff`` / ``report``) normalise newlines to ``\\n`` and
+  *reject* non-NFC input rather than repairing it - the same reject-don't-repair
+  policy the other canonical cores in the codebase apply;
+* JSONL kinds (``dataset`` / ``action_log``) emit one JCS-canonical JSON object
+  per line, ``\\n``-separated;
+* the JSON-object kind (``ops_result``) emits a single JCS-canonical object.
+
+This module deliberately has no dependency on the task model or the lineage
+store so it can be imported from both sides without a cycle.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac as _hmac
+import json
+import operator
+import unicodedata
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any, Literal
+
+
+class ArtifactKind(StrEnum):
+    """Closed set of artifact kinds a task can declare it produces."""
+
+    CODE_DIFF = "code_diff"
+    REPORT = "report"
+    DATASET = "dataset"
+    ACTION_LOG = "action_log"
+    OPS_RESULT = "ops_result"
+
+
+#: Kinds whose canonical form is normalised UTF-8 *text*.
+_TEXT_KINDS: frozenset[ArtifactKind] = frozenset({ArtifactKind.CODE_DIFF, ArtifactKind.REPORT})
+#: Kinds whose canonical form is JSONL - one JCS object per line, ``\n``-joined.
+_JSONL_KINDS: frozenset[ArtifactKind] = frozenset({ArtifactKind.DATASET, ArtifactKind.ACTION_LOG})
+#: Kinds whose canonical form is a single JCS-canonical JSON object.
+_JSON_OBJECT_KINDS: frozenset[ArtifactKind] = frozenset({ArtifactKind.OPS_RESULT})
+
+#: The three typed criteria that operate on artifact bytes (issue #2608).
+ARTIFACT_CRITERION_TYPES: frozenset[str] = frozenset({"schema_valid", "criteria_match", "hash_stable"})
+
+#: Closed set of predicate operators the ``criteria_match`` evaluator accepts.
+_ALLOWED_OPS: frozenset[str] = frozenset({"exists", "eq", "ne", "contains", "gt", "ge", "lt", "le"})
+
+
+class CanonicalisationError(ValueError):
+    """Raised when an artifact cannot be canonicalised under its kind's rule."""
+
+
+# ---------------------------------------------------------------------------
+# Shared canonical core
+# ---------------------------------------------------------------------------
+
+
+def _canonical_json_bytes(obj: Any) -> bytes:
+    """Shared JSON canonical core: sorted keys, minimal separators, UTF-8.
+
+    ``allow_nan=False`` rejects NaN / Infinity, which have no canonical JSON
+    form. Every JSON-shaped kind routes through this single serialiser so two
+    kinds can never disagree on key ordering or separators.
+    """
+    try:
+        return json.dumps(
+            obj,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise CanonicalisationError(f"value is not canonical-JSON serialisable: {exc}") from exc
+
+
+def _normalise_newlines(text: str) -> str:
+    """Fold CRLF and a lone CR to ``\\n``. Part of the shared text core."""
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def _canonical_text_bytes(text: str) -> bytes:
+    """Shared text canonical core: normalise newlines, require NFC, encode UTF-8.
+
+    Non-NFC text is *rejected*, not repaired, so a caller can never silently
+    ship two byte-different inputs that render the same. Newline normalisation
+    runs first; it only touches ASCII control bytes and so never changes NFC
+    status.
+    """
+    normalised = _normalise_newlines(text)
+    if not unicodedata.is_normalized("NFC", normalised):
+        raise CanonicalisationError("text artifact is not NFC-normalised (reject-don't-repair policy)")
+    return normalised.encode("utf-8")
+
+
+def _coerce_text(raw: Any) -> str:
+    if isinstance(raw, str):
+        return raw
+    if isinstance(raw, bytes):
+        try:
+            return raw.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise CanonicalisationError(f"text artifact bytes are not valid UTF-8: {exc}") from exc
+    raise CanonicalisationError(f"text artifact must be str or bytes, got {type(raw).__name__}")
+
+
+def _coerce_rows(raw: Any) -> list[Any]:
+    if isinstance(raw, (str, bytes, dict)):
+        raise CanonicalisationError("JSONL artifact must be a sequence of JSON objects, not a scalar or mapping")
+    try:
+        return list(raw)
+    except TypeError as exc:
+        raise CanonicalisationError(f"JSONL artifact must be an iterable of rows: {exc}") from exc
+
+
+# ---------------------------------------------------------------------------
+# Per-kind canonicalisers + content hash
+# ---------------------------------------------------------------------------
+
+
+def canonicalise_artifact(kind: ArtifactKind | str, raw: Any) -> bytes:
+    """Return the canonical bytes for ``raw`` under ``kind``'s rule.
+
+    Raises :class:`CanonicalisationError` when the input does not fit the
+    kind's shape or violates the reject-don't-repair policy.
+    """
+    k = ArtifactKind(kind)
+    if k in _TEXT_KINDS:
+        return _canonical_text_bytes(_coerce_text(raw))
+    if k in _JSONL_KINDS:
+        rows = _coerce_rows(raw)
+        return b"\n".join(_canonical_json_bytes(row) for row in rows)
+    if k in _JSON_OBJECT_KINDS:
+        return _canonical_json_bytes(raw)
+    raise CanonicalisationError(f"no canonicaliser registered for kind {k!r}")
+
+
+def content_hash(canonical_bytes: bytes) -> str:
+    """Return the ``sha256:`` content hash of already-canonical bytes."""
+    return "sha256:" + hashlib.sha256(canonical_bytes).hexdigest()
+
+
+def artifact_content_hash(kind: ArtifactKind | str, raw: Any) -> str:
+    """Canonicalise ``raw`` under ``kind`` and return its content hash."""
+    return content_hash(canonicalise_artifact(kind, raw))
+
+
+def _parse_json_document(kind: ArtifactKind, canonical_bytes: bytes) -> Any:
+    """Parse canonical artifact bytes back into a JSON document for criteria.
+
+    JSONL kinds parse to a ``list`` of row objects; the JSON-object kind parses
+    to the object. Text kinds have no JSON document and raise.
+    """
+    if kind in _JSONL_KINDS:
+        if not canonical_bytes:
+            return []
+        return [json.loads(line) for line in canonical_bytes.split(b"\n")]
+    if kind in _JSON_OBJECT_KINDS:
+        return json.loads(canonical_bytes)
+    raise CanonicalisationError(f"kind {kind.value!r} has no JSON document form")
+
+
+# ---------------------------------------------------------------------------
+# Typed criterion evaluators (closed set, never execute artifact-supplied code)
+# ---------------------------------------------------------------------------
+
+
+def evaluate_criterion(
+    criterion_type: str,
+    criterion_value: str,
+    *,
+    artifact: Any,
+    kind: ArtifactKind | str,
+) -> tuple[bool, str]:
+    """Evaluate one typed artifact criterion against ``artifact``.
+
+    * ``hash_stable`` - re-canonicalise ``artifact`` and compare its content
+      hash to ``criterion_value`` (an expected ``sha256:...`` string).
+    * ``schema_valid`` - validate the artifact's JSON document against the JSON
+      Schema in ``criterion_value``; JSONL kinds validate each row.
+    * ``criteria_match`` - evaluate a closed predicate set (JSON in
+      ``criterion_value``) over the artifact's JSON document.
+
+    Returns ``(passed, detail)``. An unknown criterion type returns
+    ``(False, ...)`` rather than raising so a caller can evaluate a mixed list
+    without a guard at every call site.
+    """
+    k = ArtifactKind(kind)
+    if criterion_type == "hash_stable":
+        expected = criterion_value.strip()
+        try:
+            actual = artifact_content_hash(k, artifact)
+        except CanonicalisationError as exc:
+            return False, f"artifact does not canonicalise: {exc}"
+        ok = _hmac.compare_digest(actual, expected)
+        return ok, ("hash stable" if ok else f"hash drift: expected {expected}, got {actual}")
+    if criterion_type == "schema_valid":
+        return _eval_schema_valid(k, artifact, criterion_value)
+    if criterion_type == "criteria_match":
+        return _eval_criteria_match(k, artifact, criterion_value)
+    return False, f"not an artifact criterion type: {criterion_type!r}"
+
+
+def _json_document_for(kind: ArtifactKind, artifact: Any) -> Any:
+    """Canonicalise ``artifact`` under ``kind`` and parse its JSON document.
+
+    Raises :class:`CanonicalisationError` for text kinds (no JSON document) or
+    when the artifact does not canonicalise under the kind's rule.
+    """
+    canonical = canonicalise_artifact(kind, artifact)
+    return _parse_json_document(kind, canonical)
+
+
+def _eval_schema_valid(kind: ArtifactKind, artifact: Any, schema_text: str) -> tuple[bool, str]:
+    import jsonschema
+
+    try:
+        schema = json.loads(schema_text)
+    except json.JSONDecodeError as exc:
+        return False, f"schema is not valid JSON: {exc}"
+    try:
+        doc = _json_document_for(kind, artifact)
+    except CanonicalisationError as exc:
+        return False, f"artifact has no JSON document to validate: {exc}"
+    try:
+        validator = jsonschema.Draft202012Validator(schema)
+    except jsonschema.exceptions.SchemaError as exc:
+        return False, f"schema is not a valid JSON Schema: {exc.message}"
+    if kind in _JSONL_KINDS:
+        for i, row in enumerate(doc):
+            errors = sorted(validator.iter_errors(row), key=lambda e: list(e.path))
+            if errors:
+                return False, f"row {i} fails schema: {errors[0].message}"
+        return True, f"all {len(doc)} row(s) valid"
+    errors = sorted(validator.iter_errors(doc), key=lambda e: list(e.path))
+    if errors:
+        return False, f"artifact fails schema: {errors[0].message}"
+    return True, "schema valid"
+
+
+def _eval_criteria_match(kind: ArtifactKind, artifact: Any, preds_text: str) -> tuple[bool, str]:
+    try:
+        preds = json.loads(preds_text)
+    except json.JSONDecodeError as exc:
+        return False, f"criteria set is not valid JSON: {exc}"
+    if not isinstance(preds, list):
+        return False, "criteria set must be a JSON list of predicates"
+    try:
+        doc = _json_document_for(kind, artifact)
+    except CanonicalisationError as exc:
+        return False, f"artifact has no JSON document to match: {exc}"
+    for i, pred in enumerate(preds):
+        if not isinstance(pred, dict):
+            return False, f"predicate {i} must be a mapping"
+        op = pred.get("op")
+        if op not in _ALLOWED_OPS:
+            return False, f"predicate {i} has unknown op {op!r}"
+        path = str(pred.get("path", ""))
+        found, actual = _resolve_path(doc, path)
+        ok, detail = _apply_op(str(op), found, actual, pred.get("value"))
+        if not ok:
+            return False, f"predicate {i} ({op} {path!r}) failed: {detail}"
+    return True, f"all {len(preds)} predicate(s) matched"
+
+
+def _resolve_path(doc: Any, path: str) -> tuple[bool, Any]:
+    """Resolve a dotted path (dict keys, list indices) into ``doc``.
+
+    Returns ``(found, value)``; ``found`` is ``False`` when any segment does
+    not resolve. An empty path resolves to the document itself.
+    """
+    if path == "":
+        return True, doc
+    cur = doc
+    for seg in path.split("."):
+        if isinstance(cur, dict):
+            if seg not in cur:
+                return False, None
+            cur = cur[seg]
+        elif isinstance(cur, list):
+            try:
+                idx = int(seg)
+            except ValueError:
+                return False, None
+            if idx < 0 or idx >= len(cur):
+                return False, None
+            cur = cur[idx]
+        else:
+            return False, None
+    return True, cur
+
+
+def _apply_op(op: str, found: bool, actual: Any, expected: Any) -> tuple[bool, str]:
+    if op == "exists":
+        want = True if expected is None else bool(expected)
+        return (found == want), f"exists={found}"
+    if not found:
+        return False, "path not found"
+    if op == "eq":
+        return actual == expected, f"{actual!r} == {expected!r}"
+    if op == "ne":
+        return actual != expected, f"{actual!r} != {expected!r}"
+    if op == "contains":
+        try:
+            return (expected in actual), f"{expected!r} in {actual!r}"
+        except TypeError:
+            return False, "value is not a container"
+    # Numeric comparisons; reject bool (a bool is an int subclass) and non-numbers.
+    if isinstance(actual, bool) or isinstance(expected, bool):
+        return False, "numeric comparison on a boolean"
+    if not isinstance(actual, (int, float)) or not isinstance(expected, (int, float)):
+        return False, "numeric comparison on a non-number"
+    cmp = {"gt": operator.gt, "ge": operator.ge, "lt": operator.lt, "le": operator.le}[op]
+    return cmp(actual, expected), f"{actual!r} {op} {expected!r}"
+
+
+# ---------------------------------------------------------------------------
+# Typed spec dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ArtifactCriterion:
+    """One typed verification criterion evaluated against artifact bytes.
+
+    Mirrors the ``{type, value}`` shape of :class:`CompletionSignal` but is
+    closed to the three artifact criterion types so an :class:`ArtifactSpec`
+    never carries a filesystem-oriented signal.
+    """
+
+    type: Literal["schema_valid", "criteria_match", "hash_stable"]
+    value: str
+
+    def __post_init__(self) -> None:
+        if self.type not in ARTIFACT_CRITERION_TYPES:
+            raise ValueError(f"unknown artifact criterion type: {self.type!r}")
+
+    def to_dict(self) -> dict[str, str]:
+        return {"type": self.type, "value": self.value}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ArtifactCriterion:
+        return cls(type=str(data["type"]), value=str(data["value"]))  # type: ignore[arg-type]
+
+    def evaluate(self, *, artifact: Any, kind: ArtifactKind | str) -> tuple[bool, str]:
+        """Evaluate this criterion against ``artifact`` under ``kind``."""
+        return evaluate_criterion(self.type, self.value, artifact=artifact, kind=kind)
+
+
+@dataclass(frozen=True)
+class ArtifactSpec:
+    """Declared artifact contract for a task: kind, canonicalisation, criteria.
+
+    Defaults to ``code_diff`` so an existing coding task that carries no spec is
+    unchanged. ``canonicalisation`` names the serialisation rule; an empty
+    string means "the kind's default rule" (see :attr:`canonical_rule`).
+    """
+
+    kind: ArtifactKind = ArtifactKind.CODE_DIFF
+    canonicalisation: str = ""
+    criteria: tuple[ArtifactCriterion, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.kind, ArtifactKind):
+            object.__setattr__(self, "kind", ArtifactKind(self.kind))
+        if not isinstance(self.criteria, tuple):
+            object.__setattr__(self, "criteria", tuple(self.criteria))
+
+    @property
+    def canonical_rule(self) -> str:
+        """The effective canonicalisation rule id (falls back to the kind)."""
+        return self.canonicalisation or self.kind.value
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind.value,
+            "canonicalisation": self.canonicalisation,
+            "criteria": [c.to_dict() for c in self.criteria],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ArtifactSpec:
+        criteria = tuple(ArtifactCriterion.from_dict(c) for c in data.get("criteria", []) if isinstance(c, dict))
+        return cls(
+            kind=ArtifactKind(str(data.get("kind", ArtifactKind.CODE_DIFF.value))),
+            canonicalisation=str(data.get("canonicalisation", "")),
+            criteria=criteria,
+        )
+
+    @classmethod
+    def default(cls) -> ArtifactSpec:
+        """Return the default ``code_diff`` spec (the coding-task contract)."""
+        return cls()
+
+
+__all__ = [
+    "ARTIFACT_CRITERION_TYPES",
+    "ArtifactCriterion",
+    "ArtifactKind",
+    "ArtifactSpec",
+    "CanonicalisationError",
+    "artifact_content_hash",
+    "canonicalise_artifact",
+    "content_hash",
+    "evaluate_criterion",
+]

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -259,10 +259,30 @@ class UpgradeProposalDetails:
 
 @dataclass(frozen=True)
 class CompletionSignal:
-    """Janitor signal for automatic task verification."""
+    """Janitor signal for automatic task verification.
 
-    type: Literal["path_exists", "glob_exists", "test_passes", "file_contains", "llm_review", "llm_judge"]
-    value: str  # path, glob pattern, test command, search string, or review instruction
+    The first six types verify against the filesystem or a test command (the
+    coding path). The last three (issue #2608) operate on an artifact's
+    canonical bytes instead: ``schema_valid`` validates the artifact against a
+    declared JSON Schema, ``criteria_match`` evaluates a closed predicate set,
+    and ``hash_stable`` re-derives the canonical content hash. Their closed
+    evaluators live in :mod:`bernstein.core.tasks.artifacts`; the janitor
+    dispatches them via :func:`bernstein.core.quality.janitor.evaluate_artifact_signals`
+    when the produced artifact is in scope.
+    """
+
+    type: Literal[
+        "path_exists",
+        "glob_exists",
+        "test_passes",
+        "file_contains",
+        "llm_review",
+        "llm_judge",
+        "schema_valid",
+        "criteria_match",
+        "hash_stable",
+    ]
+    value: str  # path, glob pattern, test command, search string, review instruction, or criterion payload
 
 
 @dataclass(frozen=True)

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 import logging
 import time
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from enum import Enum, StrEnum
 from typing import TYPE_CHECKING, Any, Literal
 
 from bernstein.core import defaults as _defaults
 from bernstein.core.defaults import AGENT
+from bernstein.core.tasks.artifacts import ArtifactSpec
 
 if TYPE_CHECKING:
     from bernstein.core.persistence.cache_policy import CachePolicy
@@ -422,6 +423,12 @@ class Task:
     depends_on: list[str] = field(default_factory=list[str])
     parent_task_id: str | None = None
     completion_signals: list[CompletionSignal] = field(default_factory=list[CompletionSignal])
+    # Issue #2608: the typed artifact contract this task produces. Declares the
+    # expected ArtifactKind, its canonicalisation rule, and typed verification
+    # criteria over the artifact bytes. Defaults to ``code_diff`` so an existing
+    # coding task is unchanged (the git-diff path). Round-trips through
+    # ``Task.to_dict`` / ``Task.from_dict``.
+    artifact_spec: ArtifactSpec = field(default_factory=ArtifactSpec)
     owned_files: list[str] = field(default_factory=list[str])
     assigned_agent: str | None = None
     result_summary: str | None = None
@@ -522,6 +529,80 @@ class Task:
     # bypassing all scope/complexity-derived math. None = auto-compute as before.
     max_turns: int | None = None
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise a Task into a JSON-safe mapping that ``from_dict`` reads back.
+
+        The mapping mirrors every field :meth:`from_dict` consumes, so
+        ``Task.from_dict(task.to_dict())`` reconstructs the task faithfully
+        (including the :class:`ArtifactSpec`). Enums serialise to their string
+        values and nested specs to their own ``to_dict`` form.
+        """
+        return {
+            "id": self.id,
+            "title": self.title,
+            "description": self.description,
+            "role": self.role,
+            "priority": self.priority,
+            "scope": self.scope.value,
+            "complexity": self.complexity.value,
+            "estimated_minutes": self.estimated_minutes,
+            "status": self.status.value,
+            "task_type": self.task_type.value,
+            "upgrade_details": (asdict(self.upgrade_details) if self.upgrade_details is not None else None),
+            "depends_on": list(self.depends_on),
+            "parent_task_id": self.parent_task_id,
+            "completion_signals": [{"type": s.type, "value": s.value} for s in self.completion_signals],
+            "artifact_spec": self.artifact_spec.to_dict(),
+            "owned_files": list(self.owned_files),
+            "assigned_agent": self.assigned_agent,
+            "result_summary": self.result_summary,
+            "tenant_id": self.tenant_id,
+            "cell_id": self.cell_id,
+            "repo": self.repo,
+            "depends_on_repo": self.depends_on_repo,
+            "model": self.model,
+            "effort": self.effort,
+            "cli": self.cli,
+            "mcp_servers": list(self.mcp_servers),
+            "metadata": dict(self.metadata),
+            "batch_eligible": self.batch_eligible,
+            "eu_ai_act_risk": self.eu_ai_act_risk,
+            "approval_required": self.approval_required,
+            "approval_spec": (self.approval_spec.to_dict() if self.approval_spec is not None else None),
+            "cache_policy": (self.cache_policy.to_dict() if self.cache_policy is not None else None),
+            "risk_level": self.risk_level,
+            "max_output_tokens": self.max_output_tokens,
+            "meta_messages": list(self.meta_messages),
+            "created_at": self.created_at,
+            "claimed_at": self.claimed_at,
+            "completed_at": self.completed_at,
+            "closed_at": self.closed_at,
+            "deadline": self.deadline,
+            "progress_log": list(self.progress_log),
+            "version": self.version,
+            "claimed_by_session": self.claimed_by_session,
+            "parent_session_id": self.parent_session_id,
+            "execution_mode": self.execution_mode,
+            "verification_count": self.verification_count,
+            "flagged_unverified": self.flagged_unverified,
+            "retry_count": self.retry_count,
+            "max_retries": self.max_retries,
+            "retry_delay_s": self.retry_delay_s,
+            "terminal_reason": self.terminal_reason,
+            "subtask_wait_started_at": self.subtask_wait_started_at,
+            "parent_context": self.parent_context,
+            "requires": list(self.requires),
+            "tags": list(self.tags),
+            "best_of_n": self.best_of_n,
+            "refinement_rounds": self.refinement_rounds,
+            "agent_restart_between_retries": self.agent_restart_between_retries,
+            "parallel_safe": self.parallel_safe,
+            "story_id": self.story_id,
+            "attachments": list(self.attachments),
+            "evidence_producers": [dict(p) for p in self.evidence_producers],
+            "max_turns": self.max_turns,
+        }
+
     @classmethod
     def from_dict(cls, raw: dict[str, Any]) -> Task:
         """Deserialise a server JSON response into a Task.
@@ -545,6 +626,18 @@ class Task:
                 signals.append(CompletionSignal(type=sig["type"], value=sig["value"]))
             except (KeyError, TypeError):
                 logger.warning("Invalid completion_signal entry: %r", sig)
+
+        raw_spec = raw.get("artifact_spec")
+        if isinstance(raw_spec, ArtifactSpec):
+            artifact_spec = raw_spec
+        elif isinstance(raw_spec, dict):
+            try:
+                artifact_spec = ArtifactSpec.from_dict(raw_spec)
+            except (KeyError, TypeError, ValueError):
+                logger.warning("Invalid artifact_spec entry: %r - defaulting to code_diff", raw_spec)
+                artifact_spec = ArtifactSpec()
+        else:
+            artifact_spec = ArtifactSpec()
 
         upgrade_details: UpgradeProposalDetails | None = None
         raw_upgrade = raw.get("upgrade_details")
@@ -576,6 +669,7 @@ class Task:
             depends_on=raw.get("depends_on", []),
             parent_task_id=raw.get("parent_task_id"),
             completion_signals=signals,
+            artifact_spec=artifact_spec,
             owned_files=raw.get("owned_files", []),
             assigned_agent=raw.get("assigned_agent"),
             result_summary=raw.get("result_summary"),

--- a/tests/property/test_artifact_canon_properties.py
+++ b/tests/property/test_artifact_canon_properties.py
@@ -1,0 +1,86 @@
+"""Property tests for artifact canonicalisation (issue #2608).
+
+The artifact ``content_hash`` is the deterministic content-addressed identity a
+non-coding task projects onto a signed lineage entry. These properties defend
+the invariants that make that identity trustworthy:
+
+* **Cross-run byte identity** - canonicalising the same input twice, from
+  independently constructed values, yields byte-identical bytes (hence an
+  identical ``content_hash``). This is the determinism heart of the contract.
+
+* **Key-order independence** - a JSON object canonicalises to the same bytes
+  regardless of the insertion order of its keys, so two operators who build the
+  same object differently still converge.
+
+* **Idempotent canonical form** - feeding already-canonical text back through
+  the text canonicaliser is a fixed point (newlines already ``\\n``, already
+  NFC), so re-canonicalisation never drifts.
+
+Budgets are small so the file completes well under ~10 s on a hosted runner.
+"""
+
+from __future__ import annotations
+
+import json
+import unicodedata
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from bernstein.core.tasks.artifacts import (
+    ArtifactKind,
+    artifact_content_hash,
+    canonicalise_artifact,
+)
+
+# JSON scalars that survive a canonical round-trip unchanged (no NaN/Inf; those
+# are rejected by design; no floats, whose repr is interpreter-stable but noisy
+# for this property).
+_json_scalars = st.one_of(
+    st.integers(min_value=-(10**9), max_value=10**9),
+    st.booleans(),
+    st.none(),
+    st.text(max_size=40),
+)
+_json_objects = st.dictionaries(st.text(min_size=1, max_size=12), _json_scalars, max_size=6)
+
+
+@settings(max_examples=150)
+@given(st.lists(_json_objects, max_size=8))
+def test_jsonl_cross_run_byte_identity(rows: list[dict[str, object]]) -> None:
+    # Independently reconstruct the rows so no shared object identity leaks in.
+    a = canonicalise_artifact(ArtifactKind.DATASET, rows)
+    b = canonicalise_artifact(ArtifactKind.DATASET, [dict(r) for r in rows])
+    assert a == b
+    assert artifact_content_hash(ArtifactKind.DATASET, rows) == artifact_content_hash(
+        ArtifactKind.DATASET, [dict(r) for r in rows]
+    )
+
+
+@settings(max_examples=150)
+@given(_json_objects)
+def test_ops_result_is_key_order_independent(obj: dict[str, object]) -> None:
+    shuffled = dict(reversed(list(obj.items())))
+    assert canonicalise_artifact(ArtifactKind.OPS_RESULT, obj) == canonicalise_artifact(
+        ArtifactKind.OPS_RESULT, shuffled
+    )
+
+
+@settings(max_examples=150)
+@given(st.text(max_size=200))
+def test_text_canonical_form_is_a_fixed_point(text: str) -> None:
+    # Restrict to NFC inputs; non-NFC is rejected by policy, not normalised.
+    nfc = unicodedata.normalize("NFC", text)
+    once = canonicalise_artifact(ArtifactKind.REPORT, nfc)
+    # The canonical bytes decode to already-canonical text; re-canonicalising is
+    # a fixed point (newlines already folded, already NFC).
+    twice = canonicalise_artifact(ArtifactKind.REPORT, once.decode("utf-8"))
+    assert once == twice
+
+
+@settings(max_examples=100)
+@given(st.lists(_json_objects, min_size=1, max_size=6))
+def test_jsonl_lines_each_parse_back_to_a_row(rows: list[dict[str, object]]) -> None:
+    canon = canonicalise_artifact(ArtifactKind.DATASET, rows)
+    parsed = [json.loads(line) for line in canon.split(b"\n")]
+    assert parsed == rows

--- a/tests/unit/cli/test_artifact_verify_cmd.py
+++ b/tests/unit/cli/test_artifact_verify_cmd.py
@@ -1,0 +1,96 @@
+"""Tests for the ``bernstein artifact verify`` CLI (issue #2608)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from bernstein.cli.main import cli
+from bernstein.core.lineage.artifact_record import record_artifact
+from bernstein.core.lineage.identity import AgentCard, generate_keypair
+from bernstein.core.lineage.recorder import LineageRecorder
+from bernstein.core.lineage.store import LineageStore
+from bernstein.core.tasks.artifacts import ArtifactKind
+
+# The CLI encodes the operator secret as UTF-8, so the key must be printable.
+_SECRET = "s" * 64
+
+
+def _seed_artifact(workdir: Path, task_id: str, artifact: object) -> None:
+    """Record an artifact into ``workdir``'s .sdd layout the way the CLI reads it."""
+    sdd = workdir / ".sdd"
+    priv_pem, pub_pem = generate_keypair()
+    card = AgentCard(agent_id="agent:worker", kid="key-001", public_key_pem=pub_pem)
+    record_artifact(
+        recorder=LineageRecorder(store=LineageStore(sdd / "lineage"), operator_hmac_key=_SECRET.encode("utf-8")),
+        sink_root=sdd / "artifacts",
+        task_id=task_id,
+        kind=ArtifactKind.OPS_RESULT,
+        artifact=artifact,
+        agent_id=card.agent_id,
+        agent_card=card,
+        private_key_pem=priv_pem,
+    )
+    card_dir = sdd / "agents" / card.agent_id
+    card_dir.mkdir(parents=True, exist_ok=True)
+    (card_dir / "card.json").write_text(
+        json.dumps({"agent_id": card.agent_id, "kid": card.kid, "public_key_pem": card.public_key_pem}),
+        encoding="utf-8",
+    )
+
+
+def test_verify_ok_exit_zero(tmp_path: Path) -> None:
+    _seed_artifact(tmp_path, "T-1", {"status": "ok", "changed": 2})
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["artifact", "verify", "T-1", "--workdir", str(tmp_path)],
+        env={"BERNSTEIN_OPERATOR_SECRET": _SECRET},
+    )
+    assert result.exit_code == 0, result.output
+    assert "VERIFIED" in result.output
+
+
+def test_verify_json_verdict(tmp_path: Path) -> None:
+    _seed_artifact(tmp_path, "T-2", {"status": "ok"})
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["artifact", "verify", "T-2", "--workdir", str(tmp_path), "--output-json"],
+        env={"BERNSTEIN_OPERATOR_SECRET": _SECRET},
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["ok"] is True
+    assert payload["entry_hash"].startswith("sha256:")
+
+
+def test_verify_fails_on_tampered_blob_exit_two(tmp_path: Path) -> None:
+    _seed_artifact(tmp_path, "T-3", {"status": "ok"})
+    blob = tmp_path / ".sdd" / "artifacts" / "T-3" / "artifact.bin"
+    data = bytearray(blob.read_bytes())
+    data[-1] ^= 0x10
+    blob.write_bytes(bytes(data))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["artifact", "verify", "T-3", "--workdir", str(tmp_path)],
+        env={"BERNSTEIN_OPERATOR_SECRET": _SECRET},
+    )
+    assert result.exit_code == 2, result.output
+    assert "TAMPERED" in result.output
+
+
+def test_verify_missing_artifact_exit_two(tmp_path: Path) -> None:
+    (tmp_path / ".sdd").mkdir()
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["artifact", "verify", "ghost", "--workdir", str(tmp_path)],
+        env={"BERNSTEIN_OPERATOR_SECRET": _SECRET},
+    )
+    assert result.exit_code == 2, result.output
+    assert "TAMPERED" in result.output

--- a/tests/unit/lineage/test_artifact_record.py
+++ b/tests/unit/lineage/test_artifact_record.py
@@ -1,0 +1,252 @@
+"""Artifact recording + verification: the determinism/tamper heart (#2608).
+
+These are the empirical criteria the design directive calls the heart of the
+slice:
+
+* a same-input double run produces a byte-identical ``content_hash`` *and* an
+  identical signed lineage-entry hash - the artifact is a deterministic
+  content-addressed record, not merely a logged blob;
+* a one-byte input mutation changes the hash;
+* ``verify_artifact`` fails on a post-hoc byte alteration of the blob, on a
+  tampered log entry, and on a removed entry - so without lineage + signing
+  there is no verifiable proof the agent produced the claimed result.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.lineage.artifact_record import (
+    ArtifactReceipt,
+    artifact_entry_path,
+    load_receipt,
+    record_artifact,
+    verify_artifact,
+)
+from bernstein.core.lineage.identity import AgentCard, generate_keypair
+from bernstein.core.lineage.recorder import LineageRecorder
+from bernstein.core.lineage.store import LineageStore
+from bernstein.core.tasks.artifacts import ArtifactKind
+
+_HMAC_KEY = b"k" * 64
+
+
+@pytest.fixture
+def identity() -> tuple[AgentCard, str]:
+    # A fixed keypair stands in for "the same operator identity" across runs.
+    priv_pem, pub_pem = generate_keypair()
+    card = AgentCard(agent_id="agent:report-worker", kid="key-artifact-001", public_key_pem=pub_pem)
+    return card, priv_pem
+
+
+def _recorder(root: Path) -> LineageRecorder:
+    return LineageRecorder(store=LineageStore(root / "lineage"), operator_hmac_key=_HMAC_KEY)
+
+
+def _write_card(cards_dir: Path, card: AgentCard) -> None:
+    card_dir = cards_dir / card.agent_id
+    card_dir.mkdir(parents=True, exist_ok=True)
+    (card_dir / "card.json").write_text(
+        json.dumps({"agent_id": card.agent_id, "kid": card.kid, "public_key_pem": card.public_key_pem}),
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Determinism: same input -> byte-identical content_hash AND entry_hash
+# ---------------------------------------------------------------------------
+
+
+def test_same_input_double_run_is_byte_identical(tmp_path: Path, identity: tuple[AgentCard, str]) -> None:
+    card, priv = identity
+    rows = [{"id": 2, "name": "b"}, {"id": 1, "name": "a"}]
+
+    r1 = record_artifact(
+        recorder=_recorder(tmp_path / "run-a"),
+        sink_root=tmp_path / "run-a" / "artifacts",
+        task_id="T-1",
+        kind=ArtifactKind.DATASET,
+        artifact=rows,
+        agent_id=card.agent_id,
+        agent_card=card,
+        private_key_pem=priv,
+    )
+    r2 = record_artifact(
+        recorder=_recorder(tmp_path / "run-b"),
+        sink_root=tmp_path / "run-b" / "artifacts",
+        task_id="T-1",
+        kind=ArtifactKind.DATASET,
+        artifact=[dict(r) for r in rows],
+        agent_id=card.agent_id,
+        agent_card=card,
+        private_key_pem=priv,
+    )
+
+    assert r1.content_hash == r2.content_hash
+    # The completion receipt IS the signed lineage-entry hash: identical across
+    # two independent runs with equal inputs (a deterministic projection).
+    assert r1.entry_hash == r2.entry_hash
+
+
+def test_one_byte_input_mutation_changes_the_hash(tmp_path: Path, identity: tuple[AgentCard, str]) -> None:
+    card, priv = identity
+
+    def _record(root: str, artifact: object) -> ArtifactReceipt:
+        return record_artifact(
+            recorder=_recorder(tmp_path / root),
+            sink_root=tmp_path / root / "artifacts",
+            task_id="T-2",
+            kind=ArtifactKind.REPORT,
+            artifact=artifact,
+            agent_id=card.agent_id,
+            agent_card=card,
+            private_key_pem=priv,
+        )
+
+    base = _record("base", "the quick brown fox\n")
+    mutated = _record("mut", "the quick brown frx\n")
+    assert base.content_hash != mutated.content_hash
+    assert base.entry_hash != mutated.entry_hash
+
+
+# ---------------------------------------------------------------------------
+# verify_artifact happy path + tamper detection
+# ---------------------------------------------------------------------------
+
+
+def _record_and_paths(tmp_path: Path, card: AgentCard, priv: str, artifact: object) -> tuple[Path, Path, Path]:
+    sink_root = tmp_path / "artifacts"
+    log_root = tmp_path / "lineage"
+    cards_dir = tmp_path / "cards"
+    record_artifact(
+        recorder=LineageRecorder(store=LineageStore(log_root), operator_hmac_key=_HMAC_KEY),
+        sink_root=sink_root,
+        task_id="T-9",
+        kind=ArtifactKind.OPS_RESULT,
+        artifact=artifact,
+        agent_id=card.agent_id,
+        agent_card=card,
+        private_key_pem=priv,
+    )
+    _write_card(cards_dir, card)
+    return sink_root, log_root / "log.jsonl", cards_dir
+
+
+def test_verify_passes_for_untampered_artifact(tmp_path: Path, identity: tuple[AgentCard, str]) -> None:
+    card, priv = identity
+    sink_root, log_path, cards_dir = _record_and_paths(tmp_path, card, priv, {"status": "ok", "changed": 3})
+
+    result = verify_artifact(
+        task_id="T-9", sink_root=sink_root, log_path=log_path, cards_dir=cards_dir, operator_secret=_HMAC_KEY
+    )
+    assert result.ok, result.failures
+    assert result.content_hash is not None
+    assert result.entry_hash is not None
+
+
+def test_verify_fails_on_byte_alteration_of_blob(tmp_path: Path, identity: tuple[AgentCard, str]) -> None:
+    card, priv = identity
+    sink_root, log_path, cards_dir = _record_and_paths(tmp_path, card, priv, {"status": "ok"})
+
+    # Flip a byte in the stored canonical bytes after the fact.
+    blob = sink_root / "T-9" / "artifact.bin"
+    tampered = bytearray(blob.read_bytes())
+    tampered[-2] ^= 0x20
+    blob.write_bytes(bytes(tampered))
+
+    result = verify_artifact(
+        task_id="T-9", sink_root=sink_root, log_path=log_path, cards_dir=cards_dir, operator_secret=_HMAC_KEY
+    )
+    assert not result.ok
+    assert any("altered" in f or "content_hash" in f for f in result.failures)
+
+
+def test_verify_fails_on_tampered_log_entry(tmp_path: Path, identity: tuple[AgentCard, str]) -> None:
+    card, priv = identity
+    sink_root, log_path, cards_dir = _record_and_paths(tmp_path, card, priv, {"status": "ok"})
+
+    # Rewrite the recorded content_hash in the log line to a plausible-looking
+    # but forged value. The signature + HMAC no longer verify, and the entry
+    # the receipt points at is gone.
+    line = json.loads(log_path.read_text().strip())
+    line["content_hash"] = "sha256:" + "0" * 64
+    log_path.write_text(json.dumps(line, separators=(",", ":"), sort_keys=True) + "\n", encoding="utf-8")
+
+    result = verify_artifact(
+        task_id="T-9", sink_root=sink_root, log_path=log_path, cards_dir=cards_dir, operator_secret=_HMAC_KEY
+    )
+    assert not result.ok
+    assert result.failures
+
+
+def test_verify_fails_on_removed_entry(tmp_path: Path, identity: tuple[AgentCard, str]) -> None:
+    card, priv = identity
+    sink_root, log_path, cards_dir = _record_and_paths(tmp_path, card, priv, {"status": "ok"})
+
+    # Remove the entry entirely (an empty log => the receipt's entry is gone).
+    log_path.write_text("", encoding="utf-8")
+
+    result = verify_artifact(
+        task_id="T-9", sink_root=sink_root, log_path=log_path, cards_dir=cards_dir, operator_secret=_HMAC_KEY
+    )
+    assert not result.ok
+    assert any("missing from the log" in f for f in result.failures)
+
+
+def test_verify_fails_when_receipt_absent(tmp_path: Path) -> None:
+    result = verify_artifact(
+        task_id="nope",
+        sink_root=tmp_path / "artifacts",
+        log_path=tmp_path / "lineage" / "log.jsonl",
+        cards_dir=tmp_path / "cards",
+        operator_secret=_HMAC_KEY,
+    )
+    assert not result.ok
+    assert any("no artifact receipt" in f for f in result.failures)
+
+
+# ---------------------------------------------------------------------------
+# Receipt + helpers
+# ---------------------------------------------------------------------------
+
+
+def test_receipt_round_trip() -> None:
+    receipt = ArtifactReceipt(
+        task_id="T",
+        kind="report",
+        content_hash="sha256:aa",
+        entry_hash="sha256:bb",
+        artefact_path=artifact_entry_path("T"),
+        agent_id="agent:x",
+        agent_card_kid="k1",
+        ts_ns=0,
+    )
+    assert ArtifactReceipt.from_dict(receipt.to_dict()) == receipt
+
+
+def test_load_receipt_returns_none_when_absent(tmp_path: Path) -> None:
+    assert load_receipt(tmp_path, "missing") is None
+
+
+def test_record_artifact_rejects_code_diff(tmp_path: Path, identity: tuple[AgentCard, str]) -> None:
+    card, priv = identity
+    with pytest.raises(ValueError, match="git-diff path"):
+        record_artifact(
+            recorder=_recorder(tmp_path),
+            sink_root=tmp_path / "artifacts",
+            task_id="T",
+            kind=ArtifactKind.CODE_DIFF,
+            artifact="@@ diff @@\n",
+            agent_id=card.agent_id,
+            agent_card=card,
+            private_key_pem=priv,
+        )
+
+
+def test_artifact_entry_path_is_repo_relative() -> None:
+    p = artifact_entry_path("T-42")
+    assert p == ".sdd/artifacts/T-42/artifact.bin"
+    assert not p.startswith("/")

--- a/tests/unit/lineage/test_entry.py
+++ b/tests/unit/lineage/test_entry.py
@@ -91,5 +91,21 @@ def test_accepts_all_artefact_kinds():
         LineageEntry(**_kwargs(artefact_kind=kind))
 
 
+def test_accepts_widened_non_coding_kinds():
+    # Issue #2608: the non-coding artifact kinds must be recordable.
+    for kind in ("report", "dataset", "action_log", "ops_result"):
+        assert kind in ARTEFACT_KINDS
+        entry = LineageEntry(**_kwargs(artefact_kind=kind))
+        assert entry.artefact_kind == kind
+
+
+def test_widening_keeps_the_set_closed():
+    # A kind outside the closed set (including the coding-path ``code_diff``,
+    # which is recorded as a ``file`` write, not its own lineage kind) raises.
+    for bogus in ("code_diff", "screenshot", "unknown"):
+        with pytest.raises(ValueError, match="unknown artefact_kind"):
+            LineageEntry(**_kwargs(artefact_kind=bogus))
+
+
 def test_version_constant():
     assert LINEAGE_ENTRY_VERSION == 1

--- a/tests/unit/tasks/test_artifact_contract.py
+++ b/tests/unit/tasks/test_artifact_contract.py
@@ -1,0 +1,292 @@
+"""Artifact contract slice 1: kinds, canonical serialisation, typed criteria.
+
+Covers :mod:`bernstein.core.tasks.artifacts`:
+
+* the ``ArtifactKind`` closed set;
+* the one-shared-core canonicalisers (text / JSONL / JSON-object) and their
+  reject-don't-repair NFC + newline-normalisation policy;
+* ``content_hash`` and the cross-run byte-identity property that makes the
+  hash a deterministic content-addressed identity;
+* the three closed criterion evaluators (``hash_stable`` / ``schema_valid`` /
+  ``criteria_match``);
+* ``ArtifactSpec`` / ``ArtifactCriterion`` round-trips.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import unicodedata
+
+import pytest
+
+from bernstein.core.tasks.artifacts import (
+    ArtifactCriterion,
+    ArtifactKind,
+    ArtifactSpec,
+    CanonicalisationError,
+    artifact_content_hash,
+    canonicalise_artifact,
+    content_hash,
+    evaluate_criterion,
+)
+
+# ---------------------------------------------------------------------------
+# ArtifactKind closed set
+# ---------------------------------------------------------------------------
+
+
+def test_artifact_kind_membership() -> None:
+    assert {k.value for k in ArtifactKind} == {
+        "code_diff",
+        "report",
+        "dataset",
+        "action_log",
+        "ops_result",
+    }
+
+
+def test_artifact_kind_coerces_from_str() -> None:
+    assert ArtifactKind("report") is ArtifactKind.REPORT
+
+
+# ---------------------------------------------------------------------------
+# Text canonical core (report / code_diff)
+# ---------------------------------------------------------------------------
+
+
+def test_report_text_is_utf8_with_normalised_newlines() -> None:
+    raw = "line1\r\nline2\rline3\n"
+    canon = canonicalise_artifact(ArtifactKind.REPORT, raw)
+    assert canon == b"line1\nline2\nline3\n"
+
+
+def test_code_diff_shares_the_text_core() -> None:
+    raw = "@@ -1 +1 @@\r\n-old\r\n+new\r\n"
+    assert canonicalise_artifact(ArtifactKind.CODE_DIFF, raw) == b"@@ -1 +1 @@\n-old\n+new\n"
+
+
+def test_text_bytes_input_is_decoded_utf8() -> None:
+    assert canonicalise_artifact(ArtifactKind.REPORT, "café".encode()) == "café".encode()
+
+
+def test_text_rejects_non_nfc_rather_than_repairing() -> None:
+    # "e" + combining acute accent is NFD, not NFC.
+    nfd = "café"
+    assert not unicodedata.is_normalized("NFC", nfd)
+    with pytest.raises(CanonicalisationError, match="NFC"):
+        canonicalise_artifact(ArtifactKind.REPORT, nfd)
+
+
+def test_text_rejects_invalid_utf8_bytes() -> None:
+    with pytest.raises(CanonicalisationError, match="UTF-8"):
+        canonicalise_artifact(ArtifactKind.REPORT, b"\xff\xfe")
+
+
+# ---------------------------------------------------------------------------
+# JSONL canonical core (dataset / action_log)
+# ---------------------------------------------------------------------------
+
+
+def test_dataset_is_canonical_jsonl_one_object_per_line() -> None:
+    rows = [{"b": 2, "a": 1}, {"z": 26, "y": 25}]
+    canon = canonicalise_artifact(ArtifactKind.DATASET, rows)
+    assert canon == b'{"a":1,"b":2}\n{"y":25,"z":26}'
+
+
+def test_action_log_key_order_is_stable_regardless_of_input_order() -> None:
+    a = canonicalise_artifact(ArtifactKind.ACTION_LOG, [{"x": 1, "m": 2, "a": 3}])
+    b = canonicalise_artifact(ArtifactKind.ACTION_LOG, [{"a": 3, "x": 1, "m": 2}])
+    assert a == b == b'{"a":3,"m":2,"x":1}'
+
+
+def test_empty_dataset_is_empty_bytes() -> None:
+    assert canonicalise_artifact(ArtifactKind.DATASET, []) == b""
+
+
+def test_dataset_rejects_scalar_and_mapping() -> None:
+    with pytest.raises(CanonicalisationError):
+        canonicalise_artifact(ArtifactKind.DATASET, {"not": "a list"})
+    with pytest.raises(CanonicalisationError):
+        canonicalise_artifact(ArtifactKind.DATASET, "scalar")
+
+
+def test_jsonl_rejects_nan() -> None:
+    with pytest.raises(CanonicalisationError):
+        canonicalise_artifact(ArtifactKind.DATASET, [{"v": float("nan")}])
+
+
+# ---------------------------------------------------------------------------
+# JSON-object canonical core (ops_result)
+# ---------------------------------------------------------------------------
+
+
+def test_ops_result_is_single_canonical_object() -> None:
+    canon = canonicalise_artifact(ArtifactKind.OPS_RESULT, {"status": "ok", "changed": 3, "applied": True})
+    assert canon == b'{"applied":true,"changed":3,"status":"ok"}'
+
+
+# ---------------------------------------------------------------------------
+# content_hash + cross-run byte identity (determinism heart)
+# ---------------------------------------------------------------------------
+
+
+def test_content_hash_is_sha256_of_canonical_bytes() -> None:
+    canon = canonicalise_artifact(ArtifactKind.REPORT, "hello\n")
+    assert content_hash(canon) == "sha256:" + hashlib.sha256(canon).hexdigest()
+
+
+def test_same_input_double_run_is_byte_identical() -> None:
+    rows = [{"id": 2, "name": "b"}, {"id": 1, "name": "a"}]
+    first = artifact_content_hash(ArtifactKind.DATASET, rows)
+    second = artifact_content_hash(ArtifactKind.DATASET, [dict(r) for r in rows])
+    assert first == second
+
+
+def test_one_byte_mutation_changes_the_hash() -> None:
+    base = artifact_content_hash(ArtifactKind.REPORT, "the quick brown fox\n")
+    mutated = artifact_content_hash(ArtifactKind.REPORT, "the quick brown frx\n")
+    assert base != mutated
+
+
+# ---------------------------------------------------------------------------
+# hash_stable criterion
+# ---------------------------------------------------------------------------
+
+
+def test_hash_stable_passes_on_matching_hash() -> None:
+    rows = [{"a": 1}]
+    expected = artifact_content_hash(ArtifactKind.DATASET, rows)
+    ok, _ = evaluate_criterion("hash_stable", expected, artifact=rows, kind=ArtifactKind.DATASET)
+    assert ok
+
+
+def test_hash_stable_fails_on_drifted_input() -> None:
+    expected = artifact_content_hash(ArtifactKind.DATASET, [{"a": 1}])
+    ok, detail = evaluate_criterion("hash_stable", expected, artifact=[{"a": 2}], kind=ArtifactKind.DATASET)
+    assert not ok
+    assert "drift" in detail
+
+
+# ---------------------------------------------------------------------------
+# schema_valid criterion
+# ---------------------------------------------------------------------------
+
+
+def test_schema_valid_passes_for_conforming_rows() -> None:
+    schema = json.dumps({"type": "object", "required": ["id"], "properties": {"id": {"type": "integer"}}})
+    rows = [{"id": 1}, {"id": 2}]
+    ok, _ = evaluate_criterion("schema_valid", schema, artifact=rows, kind=ArtifactKind.DATASET)
+    assert ok
+
+
+def test_schema_valid_fails_for_nonconforming_row() -> None:
+    schema = json.dumps({"type": "object", "required": ["id"], "properties": {"id": {"type": "integer"}}})
+    rows = [{"id": 1}, {"name": "no id"}]
+    ok, detail = evaluate_criterion("schema_valid", schema, artifact=rows, kind=ArtifactKind.DATASET)
+    assert not ok
+    assert "row 1" in detail
+
+
+def test_schema_valid_on_ops_result_object() -> None:
+    schema = json.dumps({"type": "object", "required": ["status"]})
+    ok, _ = evaluate_criterion("schema_valid", schema, artifact={"status": "ok"}, kind=ArtifactKind.OPS_RESULT)
+    assert ok
+
+
+def test_schema_valid_fails_on_text_kind_without_json_document() -> None:
+    schema = json.dumps({"type": "object"})
+    ok, detail = evaluate_criterion("schema_valid", schema, artifact="prose", kind=ArtifactKind.REPORT)
+    assert not ok
+    assert "JSON document" in detail
+
+
+# ---------------------------------------------------------------------------
+# criteria_match criterion
+# ---------------------------------------------------------------------------
+
+
+def test_criteria_match_predicate_set_passes() -> None:
+    preds = json.dumps(
+        [
+            {"path": "status", "op": "eq", "value": "ok"},
+            {"path": "changed", "op": "gt", "value": 0},
+            {"path": "detail", "op": "exists"},
+        ]
+    )
+    art = {"status": "ok", "changed": 3, "detail": "x"}
+    ok, _ = evaluate_criterion("criteria_match", preds, artifact=art, kind=ArtifactKind.OPS_RESULT)
+    assert ok
+
+
+def test_criteria_match_fails_and_names_predicate() -> None:
+    preds = json.dumps([{"path": "status", "op": "eq", "value": "ok"}])
+    ok, detail = evaluate_criterion("criteria_match", preds, artifact={"status": "error"}, kind=ArtifactKind.OPS_RESULT)
+    assert not ok
+    assert "predicate 0" in detail
+
+
+def test_criteria_match_rejects_unknown_op() -> None:
+    preds = json.dumps([{"path": "x", "op": "regex", "value": ".*"}])
+    ok, detail = evaluate_criterion("criteria_match", preds, artifact={"x": 1}, kind=ArtifactKind.OPS_RESULT)
+    assert not ok
+    assert "unknown op" in detail
+
+
+def test_criteria_match_indexes_into_jsonl_rows() -> None:
+    preds = json.dumps([{"path": "0.id", "op": "eq", "value": 7}])
+    ok, _ = evaluate_criterion("criteria_match", preds, artifact=[{"id": 7}], kind=ArtifactKind.DATASET)
+    assert ok
+
+
+def test_unknown_criterion_type_returns_false() -> None:
+    ok, detail = evaluate_criterion("bogus", "x", artifact={"a": 1}, kind=ArtifactKind.OPS_RESULT)
+    assert not ok
+    assert "criterion type" in detail
+
+
+# ---------------------------------------------------------------------------
+# ArtifactCriterion + ArtifactSpec round-trips
+# ---------------------------------------------------------------------------
+
+
+def test_artifact_criterion_round_trip() -> None:
+    crit = ArtifactCriterion(type="hash_stable", value="sha256:abc")
+    assert ArtifactCriterion.from_dict(crit.to_dict()) == crit
+
+
+def test_artifact_criterion_rejects_unknown_type() -> None:
+    with pytest.raises(ValueError, match="criterion type"):
+        ArtifactCriterion(type="path_exists", value="x")  # type: ignore[arg-type]
+
+
+def test_artifact_spec_default_is_code_diff() -> None:
+    spec = ArtifactSpec()
+    assert spec.kind is ArtifactKind.CODE_DIFF
+    assert spec.canonical_rule == "code_diff"
+    assert spec.criteria == ()
+
+
+def test_artifact_spec_round_trip_with_criteria() -> None:
+    spec = ArtifactSpec(
+        kind=ArtifactKind.DATASET,
+        canonicalisation="",
+        criteria=(
+            ArtifactCriterion(type="hash_stable", value="sha256:deadbeef"),
+            ArtifactCriterion(type="schema_valid", value='{"type":"object"}'),
+        ),
+    )
+    restored = ArtifactSpec.from_dict(spec.to_dict())
+    assert restored == spec
+    assert restored.canonical_rule == "dataset"
+
+
+def test_artifact_spec_from_dict_coerces_kind_string() -> None:
+    spec = ArtifactSpec.from_dict({"kind": "action_log"})
+    assert spec.kind is ArtifactKind.ACTION_LOG
+    assert spec.criteria == ()
+
+
+def test_artifact_spec_constructor_coerces_kind_string() -> None:
+    spec = ArtifactSpec(kind="report")  # type: ignore[arg-type]
+    assert spec.kind is ArtifactKind.REPORT

--- a/tests/unit/tasks/test_models_serialization.py
+++ b/tests/unit/tasks/test_models_serialization.py
@@ -18,6 +18,7 @@ from bernstein.core.tasks.models import (
     AgentCostSummary,
     ApprovalSpec,
     ClusterConfig,
+    CompletionSignal,
     ModelCostBreakdown,
     NodeInfo,
     OrchestratorConfig,
@@ -334,3 +335,70 @@ def test_run_cost_report_round_trip_without_projection() -> None:
     restored = RunCostReport.from_dict(report.to_dict())
     assert restored.projection is None
     assert restored.per_agent == []
+
+
+# ---------------------------------------------------------------------------
+# Task.artifact_spec round-trip through Task.to_dict / from_dict (#2608)
+# ---------------------------------------------------------------------------
+
+
+def test_task_defaults_to_code_diff_artifact_spec() -> None:
+    from bernstein.core.tasks.artifacts import ArtifactKind
+
+    task = Task.from_dict({"id": "x", "title": "T", "description": "D", "role": "backend"})
+    assert task.artifact_spec.kind is ArtifactKind.CODE_DIFF
+    assert task.artifact_spec.criteria == ()
+
+
+def test_task_to_dict_from_dict_round_trips_artifact_spec() -> None:
+    from bernstein.core.tasks.artifacts import ArtifactCriterion, ArtifactKind, ArtifactSpec
+
+    spec = ArtifactSpec(
+        kind=ArtifactKind.DATASET,
+        criteria=(ArtifactCriterion(type="hash_stable", value="sha256:abc"),),
+    )
+    task = Task(id="t1", title="Ttl", description="Desc", role="retrieval", artifact_spec=spec)
+    restored = Task.from_dict(task.to_dict())
+    assert restored.artifact_spec == spec
+    assert restored.artifact_spec.kind is ArtifactKind.DATASET
+
+
+def test_task_to_dict_from_dict_round_trips_core_fields() -> None:
+    task = Task(
+        id="t2",
+        title="Title",
+        description="Body",
+        role="backend",
+        priority=1,
+        estimated_minutes=45,
+        depends_on=["a", "b"],
+        owned_files=["src/x.py"],
+        tags=["fast"],
+    )
+    restored = Task.from_dict(task.to_dict())
+    assert restored.id == "t2"
+    assert restored.title == "Title"
+    assert restored.role == "backend"
+    assert restored.priority == 1
+    assert restored.estimated_minutes == 45
+    assert restored.depends_on == ["a", "b"]
+    assert restored.owned_files == ["src/x.py"]
+    assert restored.tags == ["fast"]
+
+
+def test_task_to_dict_is_json_serialisable() -> None:
+    import json
+
+    from bernstein.core.tasks.artifacts import ArtifactKind, ArtifactSpec
+
+    task = Task(
+        id="t3",
+        title="T",
+        description="D",
+        role="backend",
+        completion_signals=[CompletionSignal(type="path_exists", value="README.md")],
+        artifact_spec=ArtifactSpec(kind=ArtifactKind.REPORT),
+    )
+    # Must not raise - every value in the dict is a plain JSON type.
+    payload = json.dumps(task.to_dict())
+    assert '"artifact_spec"' in payload

--- a/tests/unit/test_janitor.py
+++ b/tests/unit/test_janitor.py
@@ -1599,3 +1599,74 @@ class TestEmptyDiffGuardAndAttribution:
 
         assert len(results) == 1
         assert results[0].passed is True
+
+
+class TestArtifactSignals:
+    """Issue #2608: the three artifact-mode criteria and their janitor wiring.
+
+    The filesystem ``evaluate_signal`` recognises the new types (never "unknown
+    signal type") but defers them; ``evaluate_artifact_signals`` evaluates them
+    against the produced artifact using the task's declared kind.
+    """
+
+    def test_evaluate_signal_defers_artifact_types_not_unknown(self, tmp_path: Path) -> None:
+        for sig_type in ("schema_valid", "criteria_match", "hash_stable"):
+            signal = CompletionSignal(type=sig_type, value="x")
+            passed, detail = evaluate_signal(signal, tmp_path)
+            assert passed is False
+            assert "unknown signal type" not in detail
+            assert "artifact-mode" in detail
+
+    def test_hash_stable_signal_passes_on_matching_artifact(self) -> None:
+        from bernstein.core.quality.janitor import evaluate_artifact_signals
+        from bernstein.core.tasks.artifacts import ArtifactKind, ArtifactSpec, artifact_content_hash
+
+        rows = [{"id": 1}, {"id": 2}]
+        digest = artifact_content_hash(ArtifactKind.DATASET, rows)
+        task = _make_task(signals=[CompletionSignal(type="hash_stable", value=digest)])
+        task.artifact_spec = ArtifactSpec(kind=ArtifactKind.DATASET)
+
+        results = evaluate_artifact_signals(task, rows)
+        assert len(results) == 1
+        _desc, passed, _detail = results[0]
+        assert passed is True
+
+    def test_hash_stable_signal_fails_on_mutated_artifact(self) -> None:
+        from bernstein.core.quality.janitor import evaluate_artifact_signals
+        from bernstein.core.tasks.artifacts import ArtifactKind, ArtifactSpec, artifact_content_hash
+
+        digest = artifact_content_hash(ArtifactKind.REPORT, "the report\n")
+        task = _make_task(signals=[CompletionSignal(type="hash_stable", value=digest)])
+        task.artifact_spec = ArtifactSpec(kind=ArtifactKind.REPORT)
+
+        results = evaluate_artifact_signals(task, "a different report\n")
+        _desc, passed, detail = results[0]
+        assert passed is False
+        assert "drift" in detail
+
+    def test_schema_valid_and_criteria_match_signals(self) -> None:
+        import json
+
+        from bernstein.core.quality.janitor import evaluate_artifact_signals
+        from bernstein.core.tasks.artifacts import ArtifactKind, ArtifactSpec
+
+        schema = json.dumps({"type": "object", "required": ["status"]})
+        preds = json.dumps([{"path": "status", "op": "eq", "value": "ok"}])
+        task = _make_task(
+            signals=[
+                CompletionSignal(type="schema_valid", value=schema),
+                CompletionSignal(type="criteria_match", value=preds),
+            ]
+        )
+        task.artifact_spec = ArtifactSpec(kind=ArtifactKind.OPS_RESULT)
+
+        results = evaluate_artifact_signals(task, {"status": "ok"})
+        assert [passed for _d, passed, _det in results] == [True, True]
+
+    def test_evaluate_artifact_signals_ignores_filesystem_signals(self) -> None:
+        from bernstein.core.quality.janitor import evaluate_artifact_signals
+        from bernstein.core.tasks.artifacts import ArtifactKind, ArtifactSpec
+
+        task = _make_task(signals=[CompletionSignal(type="path_exists", value="README.md")])
+        task.artifact_spec = ArtifactSpec(kind=ArtifactKind.REPORT)
+        assert evaluate_artifact_signals(task, "prose\n") == []

--- a/tests/unit/test_sla_receipt_log_sanitization.py
+++ b/tests/unit/test_sla_receipt_log_sanitization.py
@@ -34,16 +34,10 @@ _MSG_PREFIX = "Could not load SLA receipt"
 
 
 def _load_failure_records(caplog: pytest.LogCaptureFixture) -> list[str]:
-    return [
-        r.getMessage()
-        for r in caplog.records
-        if r.getMessage().startswith(_MSG_PREFIX)
-    ]
+    return [r.getMessage() for r in caplog.records if r.getMessage().startswith(_MSG_PREFIX)]
 
 
-def test_crlf_path_is_escaped_in_load_failure_log(
-    tmp_path: Path, caplog: pytest.LogCaptureFixture
-) -> None:
+def test_crlf_path_is_escaped_in_load_failure_log(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
     # A file whose name embeds CR/LF plus a forged-looking log line; invalid
     # JSON so the load hits the ``except`` branch that logs the path.
     forged = tmp_path / "receipt\r\nCould not load SLA receipt FORGED.json"
@@ -62,9 +56,7 @@ def test_crlf_path_is_escaped_in_load_failure_log(
     assert "\\r\\n" in line
 
 
-def test_plain_path_is_logged_verbatim(
-    tmp_path: Path, caplog: pytest.LogCaptureFixture
-) -> None:
+def test_plain_path_is_logged_verbatim(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
     plain = tmp_path / "receipt.json"
     plain.write_text("not valid json")
 


### PR DESCRIPTION
## What
Implemented slice 1 of the generalised task/artifact contract (#2608): the ArtifactKind enum + ArtifactSpec dataclass threaded onto Task with to_dict/from_dict round-trip; widened the closed ARTEFACT_KINDS set; per-kind canonical serialisers over one shared core (stable key ordering, fixed UTF-8, normalised \n, reject-don't-repair NFC for text, canonical JSONL for dataset/action_log, single JCS object for ops_result) with a content_hash helper; three new closed CompletionSignal evaluators (schema_valid/criteria_match/hash_stable) leaving the original six intact; and a `bernstein artifact verify <task_id>` CLI over a record/verify substrate that produces a signed, content-addressed lineage entry (deterministic projection) and fails on byte tamper or removed entry. Slice-2 items (adapter output_mode axis, worktree skip, commit_completion branch) are intentionally not touched. 6 conventional commits pushed; no PR opened.

Part of #2608 (slice 1; the adapter output-mode axis and completion-path branching land as slice 2).

## Acceptance criteria (7/8 met)
- [x] ArtifactKind + ArtifactSpec exist; Task carries optional ArtifactSpec defaulting to code_diff; round-trips through Task.to_dict/from_dict
- [x] ARTEFACT_KINDS admits report/dataset/action_log (+ops_result); each new-kind LineageEntry validates; unknown kind still raises ValueError
- [x] Non-coding task produces a signed, content-addressed lineage entry via LineageRecorder.record_write; receipt is the entry hash, not a git SHA
- [x] Determinism+verifiability (empirical): same-input double run -> byte-identical content_hash AND identical signed lineage-entry hash; one-byte mutation
- [x] Tamper: bernstein artifact verify re-derives canonical hash, verifies Ed25519 signature + HMAC chain, fails on post-hoc byte alteration or removed ent
- [x] CompletionSignal supports schema_valid/criteria_match/hash_stable with closed evaluators; original six unchanged and still pass
- [ ] Adapter output_mode axis declared; every adapter resolves to git_diff; coding completion path unchanged — *deferred*
- [x] Docs updated (docs/operations/artifacts.md for the slice-1 surface); agents-md sync if needed

## Verification
Adversarial review: **confirmed, 0 critical findings** (empirical criteria re-attacked independently: tamper/determinism/red-on-main).
Targeted files only (never the full suite). New/changed test files: tests/unit/tasks/test_artifact_contract.py (33 cases: kinds, canonical cores, NFC reject, JSONL, content_hash, cross-run identity, one-byte mutation, three criterion evaluators, spec round-trips), tests/property/test_artifact_canon_properties.py (4 hypothesis properties: cross-run byte identity, key-order independence, text fixed point, JSONL row round-trip), tests/unit/lineage/test_entry.py (+2 widened/closed-set tests), tests/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for signed, content-addressed artifacts including reports, datasets, action logs, and operational results.
  * Added `bernstein artifact verify` with human-readable and JSON output, tamper detection, and verification status codes.
  * Added artifact validation for canonical formatting, stable hashes, schemas, and configurable criteria.

* **Documentation**
  * Added an artifact contract guide and linked it from the Operations documentation.

* **Bug Fixes**
  * Improved task completion checks to evaluate artifact-based signals correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->