### PR TITLE
docs(security): measure HMAC-chain default cost and record the migration decision

### DIFF
--- a/docs/decisions/010-audit-chain-default-cost.md
+++ b/docs/decisions/010-audit-chain-default-cost.md
@@ -1,0 +1,237 @@
+# ADR-010: Audit-Chain Default - Cost Measurement and Migration Path
+
+**Status**: Accepted
+**Date**: 2026-07-24
+**Context**: Bernstein audit log (`src/bernstein/core/security/audit.py`), issue #2690
+
+---
+
+## Problem
+
+The lineage spine and the replay journal are always on. The HMAC-chained audit
+log is not: it is enabled by `--audit`, `BERNSTEIN_AUDIT=1`, or a compliance
+preset (`src/bernstein/core/orchestration/orchestrator.py`, the audit-enable
+branch around line 814). An operator who never passes `--audit` gets
+reproducible runs and a lineage record, but no tamper-evident chain, and the gap
+only becomes visible when someone asks for one after the fact.
+
+Making the chain on-by-default is defensible, but it must not be an unmeasured
+guess. Before changing the default we need three things: the cost of enabling
+the chain, a check that nothing depends on its absence, and a migration path
+that never reports a chain-less workspace as tampered.
+
+---
+
+## Measurement
+
+A hermetic micro-benchmark drives `AuditLog` directly - no network, no
+orchestrator, no real adapters - with a fixed key and synthetic
+scheduling-decision payloads: `scripts/bench_audit_chain.py`. Reproduce with:
+
+```
+uv run python scripts/bench_audit_chain.py
+```
+
+**Append** compares a real `AuditLog.log` (`chain-on`) against the same
+canonical row written straight to a JSONL file with no `prev_hmac`/`hmac` and no
+chain-tail recovery (`plain-append`). The gap is the marginal cost attributable
+to the chain, on top of a line an audit-logging run would write anyway.
+**Verify** measures a full `verify()`, a cold `scan_verified()`, and a warm
+(cursor) `scan_verified()` re-scan after one more append.
+
+Representative figures (Python 3.14, macOS, a loaded dev host - wall-clock
+numbers are host-dependent; the ratios and byte counts are not):
+
+### Append latency (per event)
+
+| entry size | chain-on mean | chain-on p95 | plain-append mean | chain marginal |
+|---|--:|--:|--:|--:|
+| small  |  ~80 us |  ~98 us | ~31 us | +~49 us |
+| medium |  ~81 us |  ~97 us | ~33 us | +~48 us |
+| large  |  ~94 us | ~113 us | ~36 us | +~57 us |
+
+### Bytes written per entry
+
+| entry size | chain-on | plain-append | chain overhead |
+|---|--:|--:|--:|
+| small  |  376 B |  219 B | **+157 B** |
+| medium |  502 B |  345 B | **+157 B** |
+| large  | 1603 B | 1446 B | **+157 B** |
+
+### Verify / scan throughput
+
+| events | segments | verify (events/s) | cold scan (events/s) | warm-cursor tail |
+|--:|--:|--:|--:|--:|
+|  1000 |  1 | ~72,000 | ~56,000 |  ~99 us |
+| 10000 |  1 | ~74,000 | ~56,000 |  ~94 us |
+|  9000 | 30 | ~75,000 | ~55,000 | ~367 us |
+|  9000 | 90 | ~75,000 | ~54,000 | ~947 us |
+
+### Reading the numbers
+
+- **Append cost is negligible per decision.** The chain adds roughly 50 us on
+  top of a plain log write. A deterministic orchestrator emits scheduling and
+  lifecycle events at human-review timescales, not in a tight loop; even at
+  hundreds of decisions per second the chain is well under a millisecond of
+  aggregate overhead.
+- **Byte overhead is constant, not proportional.** The chain adds a fixed
+  **+157 B/entry** - the two 64-hex chain fields (`prev_hmac` + `hmac`) plus
+  their JSON framing - regardless of payload size. Growth of the chain file is
+  dominated by the payload an operator chose to log, not by the chain. A run
+  that emits 10,000 audit events pays about 1.5 MB for tamper-evidence.
+- **Verify is linear and fast.** ~72-75k events/s, flat across total events and
+  segment count. A full offline verify of a day's chain is sub-second.
+- **Warm re-verification is cheap but scales with segment count.** A cursor scan
+  re-reads only appended bytes, but still stats every segment: ~99 us at one
+  segment rises to ~950 us at 90. In practice a single run writes one live
+  segment and retention caps live segments at 90 days, so this is bounded; it is
+  recorded as a follow-up below.
+
+---
+
+## What breaks if it is on by default
+
+A targeted review of the audit test surface (the full suite is not run here by
+policy):
+
+- **No golden snapshot or replay fixture depends on the chain being absent.**
+  The snapshot test (`tests/snapshot/test_audit_jsonl_snapshot.py`) pins the
+  on-disk format when the chain is present; nothing asserts `.sdd/audit` is
+  missing or that `AuditLog` is unconstructed by default.
+- **No orchestrator-level test asserts audit-off-by-default** (`_audit_log is
+  None` / `_audit_mode` is unset). The default lives only in the enable branch.
+- The one real behavioral change of flipping the default is operational, not a
+  test breakage: every run would create `.sdd/audit/` and generate an audit key
+  on first boot. That is the surface the migration path below manages.
+
+Confirmation step before any flip: run the audit and orchestrator test layers
+with the default flipped, behind the flag, in CI - not a claim to make from a
+static scan alone.
+
+---
+
+## Decision
+
+**Keep the chain opt-in in this release. Adopt on-by-default as the target once
+the migration steps below are in place. This PR lands the measurement, the
+migration-safety invariant (locked by tests), and this record; it does not flip
+the default.**
+
+The measurement removes cost as an objection: append overhead is sub-millisecond
+and byte overhead is a constant 157 B/entry. The reason not to flip the default
+inside a measurement change is scope and operational rollout (key generation on
+existing installs), not performance. The flip is a small, separate follow-up
+that changes only default resolution and adds a louder first-run notice.
+
+Of the three outcomes the issue admits - default-on, default-on above a run
+size, stay opt-in with a louder prompt - a run-size threshold is rejected: the
+per-decision cost does not vary enough with run length to justify a threshold,
+and a threshold would make "is this run audited?" depend on a size heuristic
+that is itself hard to audit.
+
+---
+
+## Migration path to on-by-default
+
+### Enable-surface precedence (env / config)
+
+Target resolution order, highest precedence first:
+
+1. Explicit opt-out - `--no-audit` / `BERNSTEIN_AUDIT=0` (to be added with the
+   flip). An operator who turns it off is never overridden by the default.
+2. Explicit opt-in - `--audit` / `BERNSTEIN_AUDIT=1` (the `--audit` flag sets the
+   env var; see `src/bernstein/cli/run_bootstrap.py`).
+3. Compliance preset - `audit_logging` on a preset selected via `--compliance`
+   / `BERNSTEIN_COMPLIANCE`. A preset may force the chain on; it does not force
+   it off against an explicit opt-in.
+4. The default - opt-in today, opt-out (on) after the flip.
+
+An explicit env var or flag always wins over the default. This keeps the flip a
+one-line change to step 4 plus the new opt-out at step 1.
+
+### Key-path precedence
+
+The HMAC key lives outside `.sdd/` so a log-writer cannot read or rotate it.
+Resolution (from `_default_audit_key_path`):
+
+1. `BERNSTEIN_AUDIT_KEY_PATH` (explicit override).
+2. `$XDG_STATE_HOME/bernstein/audit.key`.
+3. `~/.local/state/bernstein/audit.key` (XDG default).
+
+On first default-on boot the key is generated with mode `0600` if absent; on
+later boots the existing permissions are enforced (a group- or world-readable
+key is a hard error).
+
+### Existing-install behavior (the invariant to get right)
+
+A workspace that predates the chain has no `.sdd/audit` segments. Enabling the
+chain must not report it as tampered - the append-only chain gives an operator
+no way to repair a bogus record after the fact. The existing code already
+satisfies this, and it is now locked by `tests/unit/test_audit_chain_migration.py`:
+
+- An absent or empty audit dir recovers the chain tail from **genesis**, not a
+  bogus tail; `verify()` over it returns `(True, [])`.
+- The **first** chained run anchors its first event to genesis; that run, and a
+  fresh reader process, both verify clean.
+- Sibling `.sdd/` state (lineage spine, runtime files) is ignored: `verify()`
+  reads only the audit dir's own `*.jsonl` / `*.jsonl.gz` segments, so
+  pre-existing state cannot be mistaken for chain history.
+
+Net: turning the chain on for the first time starts a fresh chain from genesis
+in that workspace. There is nothing to compare the past against, and the
+verifier does not pretend otherwise.
+
+### Rollback
+
+Rollback is a config change, not a data migration. Setting `BERNSTEIN_AUDIT=0`
+(or `--no-audit`, or dropping the compliance preset) returns to opt-in. The
+segments already written stay valid and independently verifiable; nothing is
+deleted. Re-enabling later resumes the **same** chain, because chain recovery
+walks the existing segments (live, then archived) to find the tip. Because the
+chain is append-only and keyed outside the audit dir, neither disabling nor
+re-enabling rewrites history.
+
+---
+
+## Consequences
+
+### Benefits
+
+- The default-on decision is now backed by numbers, not intuition.
+- The migration-safety invariant is locked by tests, so a future flip cannot
+  silently regress a chain-less workspace into a false tamper report.
+- The benchmark is reproducible and hermetic, so the cost can be re-measured on
+  any host or after any change to the append/verify path.
+
+### Costs
+
+- The chain remains opt-in for now; operators who do not pass `--audit` still
+  get no tamper-evidence until the follow-up flip.
+- The benchmark's wall-clock figures are host-dependent and must be re-run to
+  compare across machines; only the ratios and byte counts transfer.
+
+---
+
+## Follow-ups (recorded, not done here)
+
+1. **Flip the default to on**, adding the `--no-audit` / `BERNSTEIN_AUDIT=0`
+   opt-out and a louder first-run notice, once the CI confirmation step above
+   passes. Small, isolated change to default resolution.
+2. **Collapse the double canonical serialization in `AuditLog.log`.** The append
+   path serializes the pre-HMAC entry (to compute the HMAC) and again with the
+   HMAC field added (to write the line) - two `json.dumps(sort_keys=True)` per
+   append, part of the ~50 us marginal. Collapsing to one requires splicing the
+   `hmac` field into an already-serialized string at its sorted position, which
+   risks the byte-exact on-disk format the tamper-evidence and snapshot tests
+   depend on. Deferred as higher-risk than its payoff.
+3. **Bound the warm-cursor scan at O(appended), not O(segments).** A warm
+   `scan_verified` still stats every segment each call, so incremental
+   re-verification cost grows with segment count (~99 us at 1 segment, ~950 us
+   at 90). Candidate: skip the re-stat of segments already marked `complete`.
+
+### Done in this change
+
+- `AuditLog.log` now derives the event timestamp and the daily-file name from a
+  single `datetime.now` reading rather than two - one fewer clock read per
+  append, and it closes a latent UTC-midnight straddle where an event could be
+  filed under a day that disagreed with its own timestamp.

--- a/scripts/bench_audit_chain.py
+++ b/scripts/bench_audit_chain.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+"""Micro-benchmark: the cost of the HMAC-chained audit log (issue #2690).
+
+The lineage spine and the replay journal are always on; the HMAC-chained audit
+log is opt-in (``--audit`` / ``BERNSTEIN_AUDIT=1`` / a compliance preset). This
+script measures what enabling it costs per scheduling decision so the
+default-on decision rests on numbers rather than a guess.
+
+It is hermetic and reproducible:
+
+* No network, no real adapters, no orchestrator - only :class:`AuditLog`.
+* A fixed HMAC key and fixed synthetic payloads, so re-running on the same host
+  reproduces the same distribution (wall-clock figures vary with the machine).
+* All I/O lands in a caller-supplied directory (a ``tmp_path`` under test, a
+  ``TemporaryDirectory`` from :func:`main`); nothing touches the real
+  ``.sdd/audit`` tree or the user's audit key.
+
+Two questions, two comparisons:
+
+* **Append.** ``chain_on`` is a real :meth:`AuditLog.log`. ``plain_append`` is
+  the same canonical row written straight to a JSONL file with no ``prev_hmac``
+  / ``hmac`` and no chain-tail recovery. The gap between them is the marginal
+  cost attributable to the chain itself, on top of a line you would write
+  anyway; ``chain_on`` alone is the absolute per-decision cost versus today's
+  default of writing nothing.
+* **Verify.** Full-chain :meth:`AuditLog.verify` and cold
+  :meth:`AuditLog.scan_verified` walk every byte; a warm cursor scan re-reads
+  only what was appended since. Reported as events/second so the number scales
+  to any run length.
+
+Run it directly to print a Markdown report and a JSON blob::
+
+    uv run python scripts/bench_audit_chain.py
+    uv run python scripts/bench_audit_chain.py --json-only > bench.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+import tempfile
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from bernstein.core.audit import AuditLog
+
+#: Fixed key so the benchmark never mints or reads a real audit key.
+BENCH_KEY = b"benchmark-key-2690-deterministic"
+
+#: A representative scheduling-decision event type and actor.
+_EVENT_TYPE = "schedule.decision"
+_ACTOR = "orchestrator"
+_RESOURCE_TYPE = "task"
+
+
+def make_details(size: str) -> dict[str, Any]:
+    """Return a synthetic ``details`` payload of a given realistic size.
+
+    The three sizes bracket what real scheduling and lifecycle events carry:
+
+    * ``small`` - a bare transition (a handful of scalar fields).
+    * ``medium`` - a scheduling decision with the chosen agent, model, and a
+      short reason string.
+    * ``large`` - a decision that embeds a truncated tool result or diff
+      summary, the upper end of what lands in the chain.
+    """
+    if size == "small":
+        return {"from": "queued", "to": "running", "attempt": 1}
+    if size == "medium":
+        return {
+            "from": "queued",
+            "to": "running",
+            "attempt": 1,
+            "agent": "backend-3",
+            "model": "claude-sonnet",
+            "reason": "highest-priority ready task on an idle worker",
+            "queue_depth": 12,
+        }
+    if size == "large":
+        return {
+            "from": "review",
+            "to": "done",
+            "attempt": 2,
+            "agent": "backend-3",
+            "model": "claude-sonnet",
+            "reason": "quality gate passed on retry",
+            "queue_depth": 12,
+            "tool_result_head": "x" * 800,
+            "changed_files": [f"src/pkg/module_{i}.py" for i in range(12)],
+        }
+    raise ValueError(f"unknown size {size!r}")
+
+
+def _summarize(latencies_ns: list[int]) -> dict[str, float]:
+    """Reduce raw per-op nanosecond timings to microsecond summary stats."""
+    micros = sorted(v / 1000.0 for v in latencies_ns)
+    n = len(micros)
+    p95 = micros[min(n - 1, round(0.95 * (n - 1)))]
+    return {
+        "n": float(n),
+        "mean_us": statistics.fmean(micros),
+        "median_us": statistics.median(micros),
+        "p95_us": p95,
+        "min_us": micros[0],
+        "max_us": micros[-1],
+    }
+
+
+@dataclass
+class AppendResult:
+    """Append-latency and on-disk-size figures for one entry size."""
+
+    size: str
+    chain_on: dict[str, float]
+    plain_append: dict[str, float]
+    chain_on_bytes_per_entry: float
+    plain_bytes_per_entry: float
+
+    @property
+    def marginal_mean_us(self) -> float:
+        """Mean per-append cost attributable to the chain, in microseconds."""
+        return self.chain_on["mean_us"] - self.plain_append["mean_us"]
+
+    @property
+    def chain_byte_overhead(self) -> float:
+        """Extra bytes per entry the chain adds over a plain row."""
+        return self.chain_on_bytes_per_entry - self.plain_bytes_per_entry
+
+
+@dataclass
+class VerifyResult:
+    """Verify / scan throughput for one (events, segments) point."""
+
+    events: int
+    segments: int
+    verify_events_per_s: float
+    scan_cold_events_per_s: float
+    scan_warm_tail_us: float
+
+
+@dataclass
+class BenchReport:
+    """Full benchmark output: append + verify tables plus provenance."""
+
+    append: list[AppendResult] = field(default_factory=list)
+    verify: list[VerifyResult] = field(default_factory=list)
+    meta: dict[str, Any] = field(default_factory=dict)
+
+
+def bench_append(
+    workdir: Path,
+    size: str,
+    *,
+    n: int = 2000,
+    warmup: int = 200,
+) -> AppendResult:
+    """Measure per-append latency and bytes/entry for chain-on vs plain-append.
+
+    ``chain_on`` drives a real :class:`AuditLog`; ``plain_append`` writes the
+    same canonical field set minus the two chain fields to an ordinary JSONL
+    file, isolating the marginal cost of the HMAC chain from the file write
+    every logged decision pays regardless.
+    """
+    details = make_details(size)
+
+    # --- chain on: real AuditLog.log ---
+    on_dir = workdir / f"on-{size}"
+    log = AuditLog(on_dir, key=BENCH_KEY)
+    for _ in range(warmup):
+        log.log(_EVENT_TYPE, _ACTOR, _RESOURCE_TYPE, "warmup", details)
+    on_lat: list[int] = []
+    for i in range(n):
+        start = time.perf_counter_ns()
+        log.log(_EVENT_TYPE, _ACTOR, _RESOURCE_TYPE, f"task-{i}", details)
+        on_lat.append(time.perf_counter_ns() - start)
+    on_bytes = sum(p.stat().st_size for p in on_dir.glob("*.jsonl"))
+    on_rows = warmup + n
+    chain_on_bytes_per_entry = on_bytes / on_rows
+
+    # --- chain off: plain canonical JSONL append, no HMAC, no recovery ---
+    off_dir = workdir / f"off-{size}"
+    off_dir.mkdir(parents=True, exist_ok=True)
+    off_path = off_dir / "plain.jsonl"
+    ts = datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+    def _row(resource_id: str) -> str:
+        entry = {
+            "timestamp": ts,
+            "event_type": _EVENT_TYPE,
+            "actor": _ACTOR,
+            "resource_type": _RESOURCE_TYPE,
+            "resource_id": resource_id,
+            "details": details,
+        }
+        return json.dumps(entry, sort_keys=True) + "\n"
+
+    for _ in range(warmup):
+        with off_path.open("a", encoding="utf-8", newline="") as fh:
+            fh.write(_row("warmup"))
+    off_lat: list[int] = []
+    for i in range(n):
+        row = _row(f"task-{i}")
+        start = time.perf_counter_ns()
+        with off_path.open("a", encoding="utf-8", newline="") as fh:
+            fh.write(row)
+        off_lat.append(time.perf_counter_ns() - start)
+    off_bytes = off_path.stat().st_size
+    plain_bytes_per_entry = off_bytes / (warmup + n)
+
+    return AppendResult(
+        size=size,
+        chain_on=_summarize(on_lat),
+        plain_append=_summarize(off_lat),
+        chain_on_bytes_per_entry=chain_on_bytes_per_entry,
+        plain_bytes_per_entry=plain_bytes_per_entry,
+    )
+
+
+def build_segmented_chain(audit_dir: Path, *, events: int, segments: int) -> None:
+    """Materialise one continuous HMAC chain split across ``segments`` files.
+
+    Events are produced through the real :meth:`AuditLog.log` so every byte is
+    identical to production output, then the single day's rows are partitioned
+    into dated ``<YYYY-MM-DD>.jsonl`` files whose names sort in chain order.
+    :meth:`AuditLog.verify` walks live files in sorted order, so the resulting
+    multi-segment layout is a genuine cross-file chain - the same construction
+    the audit test-suite uses to exercise the archive boundary.
+    """
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    log = AuditLog(audit_dir, key=BENCH_KEY)
+    details = make_details("medium")
+    for i in range(events):
+        log.log(_EVENT_TYPE, _ACTOR, _RESOURCE_TYPE, f"task-{i}", details)
+
+    live = list(audit_dir.glob("*.jsonl"))
+    if len(live) != 1:  # pragma: no cover - single-run invariant
+        raise RuntimeError(f"expected one live file, found {[p.name for p in live]}")
+    source = live[0]
+    lines = source.read_text(encoding="utf-8").splitlines()
+    source.unlink()
+
+    # Even partition, remainder folded into the last segment.
+    per = max(1, events // segments)
+    base_day = datetime(2020, 1, 1, tzinfo=UTC)
+    start = 0
+    for seg in range(segments):
+        end = events if seg == segments - 1 else min(events, start + per)
+        chunk = lines[start:end]
+        if not chunk:
+            break
+        day = (base_day + timedelta(days=seg)).strftime("%Y-%m-%d")
+        (audit_dir / f"{day}.jsonl").write_text("\n".join(chunk) + "\n", encoding="utf-8")
+        start = end
+
+
+def _best_seconds(fn: Any, reps: int = 5) -> float:
+    """Return the fastest wall-clock time over ``reps`` calls, in seconds."""
+    best = float("inf")
+    for _ in range(reps):
+        start = time.perf_counter()
+        fn()
+        best = min(best, time.perf_counter() - start)
+    return best
+
+
+def bench_verify(workdir: Path, *, events: int, segments: int) -> VerifyResult:
+    """Measure full-verify, cold-scan, and warm-cursor-scan cost of a chain."""
+    audit_dir = workdir / f"verify-{events}-{segments}"
+    build_segmented_chain(audit_dir, events=events, segments=segments)
+
+    def _do_verify() -> None:
+        ok, errors = AuditLog(audit_dir, key=BENCH_KEY).verify()
+        if not ok:  # pragma: no cover - benchmark sanity guard
+            raise RuntimeError(f"benchmark chain failed to verify: {errors[:3]}")
+
+    verify_s = _best_seconds(_do_verify)
+
+    def _do_cold_scan() -> None:
+        result = AuditLog(audit_dir, key=BENCH_KEY).scan_verified()
+        if not result.ok:  # pragma: no cover - benchmark sanity guard
+            raise RuntimeError(f"benchmark chain failed to scan: {result.errors[:3]}")
+
+    scan_cold_s = _best_seconds(_do_cold_scan)
+
+    # Warm cursor: authenticate the whole chain once, append a single event,
+    # then re-scan from the cursor - the live hot-path cost of an authenticated
+    # read after one more decision.
+    reader = AuditLog(audit_dir, key=BENCH_KEY)
+    cursor = reader.scan_verified().cursor
+    writer = AuditLog(audit_dir, key=BENCH_KEY)
+    warm_samples: list[int] = []
+    for i in range(20):
+        writer.log(_EVENT_TYPE, _ACTOR, _RESOURCE_TYPE, f"warm-{i}", make_details("medium"))
+        start = time.perf_counter_ns()
+        res = reader.scan_verified(cursor)
+        warm_samples.append(time.perf_counter_ns() - start)
+        cursor = res.cursor
+
+    return VerifyResult(
+        events=events,
+        segments=segments,
+        verify_events_per_s=events / verify_s if verify_s > 0 else 0.0,
+        scan_cold_events_per_s=events / scan_cold_s if scan_cold_s > 0 else 0.0,
+        scan_warm_tail_us=statistics.median(warm_samples) / 1000.0,
+    )
+
+
+def run_benchmark(
+    workdir: Path,
+    *,
+    append_n: int = 2000,
+    sizes: tuple[str, ...] = ("small", "medium", "large"),
+    verify_points: tuple[tuple[int, int], ...] = (
+        (1000, 1),
+        (10000, 1),
+        (9000, 30),
+        (9000, 90),
+    ),
+) -> BenchReport:
+    """Run the full append + verify matrix into ``workdir`` and return results."""
+    report = BenchReport()
+    for size in sizes:
+        report.append.append(bench_append(workdir, size, n=append_n))
+    for events, segments in verify_points:
+        report.verify.append(bench_verify(workdir, events=events, segments=segments))
+    report.meta = {
+        "issue": 2690,
+        "append_n": append_n,
+        "python": sys.version.split()[0],
+        "platform": sys.platform,
+        "generated_at": datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "note": (
+            "Wall-clock figures are host-dependent; ratios (chain-on vs "
+            "plain-append) and bytes/entry are stable across hosts."
+        ),
+    }
+    return report
+
+
+def render_markdown(report: BenchReport) -> str:
+    """Render a :class:`BenchReport` as a Markdown report."""
+    lines: list[str] = []
+    lines.append("### Append latency (per event)\n")
+    lines.append("| entry size | chain-on mean | chain-on p95 | plain-append mean | chain marginal mean |")
+    lines.append("|---|--:|--:|--:|--:|")
+    for r in report.append:
+        lines.append(
+            f"| {r.size} | {r.chain_on['mean_us']:.2f} us | {r.chain_on['p95_us']:.2f} us "
+            f"| {r.plain_append['mean_us']:.2f} us | {r.marginal_mean_us:+.2f} us |"
+        )
+    lines.append("\n### Bytes written per entry\n")
+    lines.append("| entry size | chain-on | plain-append | chain overhead |")
+    lines.append("|---|--:|--:|--:|")
+    for r in report.append:
+        lines.append(
+            f"| {r.size} | {r.chain_on_bytes_per_entry:.0f} B | {r.plain_bytes_per_entry:.0f} B "
+            f"| {r.chain_byte_overhead:+.0f} B |"
+        )
+    lines.append("\n### Verify / scan throughput\n")
+    lines.append("| events | segments | verify (events/s) | cold scan (events/s) | warm-cursor tail |")
+    lines.append("|--:|--:|--:|--:|--:|")
+    for v in report.verify:
+        lines.append(
+            f"| {v.events} | {v.segments} | {v.verify_events_per_s:,.0f} "
+            f"| {v.scan_cold_events_per_s:,.0f} | {v.scan_warm_tail_us:.1f} us |"
+        )
+    lines.append("")
+    lines.append(
+        f"_Generated {report.meta.get('generated_at', '?')} "
+        f"on Python {report.meta.get('python', '?')} / {report.meta.get('platform', '?')}. "
+        f"{report.meta.get('note', '')}_"
+    )
+    return "\n".join(lines)
+
+
+def _report_to_dict(report: BenchReport) -> dict[str, Any]:
+    return {
+        "append": [asdict(r) for r in report.append],
+        "verify": [asdict(v) for v in report.verify],
+        "meta": report.meta,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--append-n", type=int, default=2000, help="appends measured per entry size")
+    parser.add_argument("--json-only", action="store_true", help="emit only the JSON blob")
+    args = parser.parse_args(argv)
+
+    with tempfile.TemporaryDirectory(prefix="bench-audit-2690-") as tmp:
+        report = run_benchmark(Path(tmp), append_n=args.append_n)
+
+    if args.json_only:
+        print(json.dumps(_report_to_dict(report), indent=2))
+    else:
+        print(render_markdown(report))
+        print("\n<details><summary>raw json</summary>\n")
+        print("```json")
+        print(json.dumps(_report_to_dict(report), indent=2))
+        print("```\n</details>")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(main())

--- a/src/bernstein/core/security/audit.py
+++ b/src/bernstein/core/security/audit.py
@@ -871,8 +871,14 @@ class AuditLog:
             The newly created AuditEvent with computed HMAC.
         """
         with _chain_append_lock(self._audit_dir):
-            ts = datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-            day = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+            # One clock reading feeds both the timestamp and the daily-file
+            # name: two readings can straddle a UTC midnight and file an event
+            # under a day that disagrees with its own timestamp, and the append
+            # runs once per scheduling decision, so the second ``now`` is pure
+            # hot-path cost (issue #2690).
+            now = datetime.now(tz=UTC)
+            ts = now.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+            day = now.strftime("%Y-%m-%d")
             log_path = self._audit_dir / f"{day}.jsonl"
 
             # Re-sync the chain tail from disk under the cross-process lock so a

--- a/tests/unit/test_audit_append_hotpath.py
+++ b/tests/unit/test_audit_append_hotpath.py
@@ -1,0 +1,67 @@
+"""Hot-path invariants for :meth:`AuditLog.log`.
+
+The append path runs once per scheduling decision. Two properties matter when
+the HMAC chain is on by default (issue #2690): the per-append work is minimal,
+and the timestamp written into an event agrees with the daily file the event
+lands in. Both follow from deriving ``ts`` and ``day`` from a single
+``datetime.now`` reading rather than two.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import bernstein.core.audit as audit_mod
+from bernstein.core.audit import AuditLog
+
+
+class _FakeInstant:
+    """A frozen ``datetime`` reading with a fixed timestamp/day pair."""
+
+    def __init__(self, ts: str, day: str) -> None:
+        self._ts = ts
+        self._day = day
+
+    def strftime(self, fmt: str) -> str:
+        if fmt == "%Y-%m-%dT%H:%M:%S.%fZ":
+            return self._ts
+        if fmt == "%Y-%m-%d":
+            return self._day
+        raise AssertionError(f"unexpected strftime format {fmt!r}")
+
+
+class _FakeDatetime:
+    """Hands out queued instants so we can straddle a UTC midnight boundary."""
+
+    def __init__(self, instants: list[_FakeInstant]) -> None:
+        self.queue = list(instants)
+
+    def now(self, tz: object = None) -> _FakeInstant:  # noqa: ARG002 - signature parity
+        return self.queue.pop(0)
+
+
+def test_log_derives_ts_and_day_from_single_now(tmp_path: Path, monkeypatch) -> None:
+    """One append consumes exactly one clock reading, so ts and day agree.
+
+    The two instants straddle a UTC midnight: the first is 23:59:59 on day N,
+    the second is 00:00:00 on day N+1. Two ``datetime.now`` calls would stamp
+    the event with day N's time but file it under day N+1, leaving an event
+    whose timestamp disagrees with its containing segment. A single reading
+    keeps them consistent.
+    """
+    before = _FakeInstant("2025-01-01T23:59:59.999999Z", "2025-01-01")
+    after = _FakeInstant("2025-01-02T00:00:00.000000Z", "2025-01-02")
+    fake = _FakeDatetime([before, after])
+    monkeypatch.setattr(audit_mod, "datetime", fake)
+
+    audit_dir = tmp_path / "audit"
+    log = AuditLog(audit_dir, key=b"test-key")
+    event = log.log("schedule.decision", "orchestrator", "task", "t1", {"n": 1})
+
+    # Only the first reading is consumed: the second instant is still queued.
+    assert len(fake.queue) == 1
+    # The event's timestamp date-prefix matches the daily file it landed in.
+    live = list(audit_dir.glob("*.jsonl"))
+    assert len(live) == 1
+    assert live[0].stem == "2025-01-01"
+    assert event.timestamp.startswith("2025-01-01")

--- a/tests/unit/test_audit_append_hotpath.py
+++ b/tests/unit/test_audit_append_hotpath.py
@@ -36,7 +36,7 @@ class _FakeDatetime:
     def __init__(self, instants: list[_FakeInstant]) -> None:
         self.queue = list(instants)
 
-    def now(self, tz: object = None) -> _FakeInstant:  # noqa: ARG002 - signature parity
+    def now(self, tz: object = None) -> _FakeInstant:  # tz kept for signature parity
         return self.queue.pop(0)
 
 

--- a/tests/unit/test_audit_chain_migration.py
+++ b/tests/unit/test_audit_chain_migration.py
@@ -1,0 +1,91 @@
+"""Migration safety for enabling the HMAC audit chain (issue #2690, point 4).
+
+The audit chain is opt-in today. Any move toward on-by-default must never turn
+a workspace that predates the chain into a false tamper report: a workspace
+with no chain has nothing to compare against, and the append-only chain gives
+an operator no way to repair such a record after the fact. These tests lock the
+invariant the migration ADR (ADR-010) depends on - that a chain-less workspace,
+and the first run that starts a chain in it, both verify clean.
+
+They are characterization tests: the behavior already holds. They exist so a
+future default flip cannot regress it silently.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from bernstein.core.audit import (
+    _GENESIS_HMAC,  # pyright: ignore[reportPrivateUsage]
+    AuditLog,
+)
+
+_KEY = b"migration-test-key"
+
+
+def test_pre_chain_workspace_verifies_clean(tmp_path: Path) -> None:
+    """A workspace whose audit dir never existed verifies clean, not tampered."""
+    audit_dir = tmp_path / ".sdd" / "audit"
+    assert not audit_dir.exists()
+
+    log = AuditLog(audit_dir, key=_KEY)
+    # No prior history means the chain resumes from genesis, not a bogus tail.
+    assert log._prev_hmac == _GENESIS_HMAC  # pyright: ignore[reportPrivateUsage]
+
+    ok, errors = log.verify()
+    assert ok is True
+    assert errors == []
+
+
+def test_first_run_starting_a_chain_verifies_clean(tmp_path: Path) -> None:
+    """Enabling the chain and writing the first event does not flag the run.
+
+    The first event anchors to genesis; verifying it, and re-verifying from a
+    fresh reader process, both report clean. This is the exact first-run path a
+    default flip would trigger on an existing install.
+    """
+    audit_dir = tmp_path / ".sdd" / "audit"
+    writer = AuditLog(audit_dir, key=_KEY)
+
+    first = writer.log("schedule.decision", "orchestrator", "task", "t1", {"n": 1})
+    assert first.prev_hmac == _GENESIS_HMAC
+
+    ok, errors = writer.verify()
+    assert ok is True, errors
+
+    # A separate reader (new process) recovers the tail and re-verifies clean.
+    reader = AuditLog(audit_dir, key=_KEY)
+    ok2, errors2 = reader.verify()
+    assert ok2 is True, errors2
+
+
+def test_preexisting_sdd_state_is_not_mistaken_for_chain_history(tmp_path: Path) -> None:
+    """Sibling .sdd state that predates the chain is ignored by the verifier.
+
+    A workspace that predates the chain typically has lineage and runtime state
+    already on disk. Starting the chain must key only off the audit dir's own
+    JSONL segments, never off unrelated files, so their presence cannot make the
+    first chained run look inconsistent.
+    """
+    sdd = tmp_path / ".sdd"
+    (sdd / "lineage").mkdir(parents=True)
+    (sdd / "lineage" / "spine.jsonl").write_text('{"artefact": "x"}\n', encoding="utf-8")
+    (sdd / "runtime").mkdir(parents=True)
+    (sdd / "runtime" / "session.json").write_text('{"pid": 1}\n', encoding="utf-8")
+
+    audit_dir = sdd / "audit"
+    log = AuditLog(audit_dir, key=_KEY)
+    assert log._prev_hmac == _GENESIS_HMAC  # pyright: ignore[reportPrivateUsage]
+
+    log.log("schedule.decision", "orchestrator", "task", "t1")
+    ok, errors = log.verify()
+    assert ok is True, errors
+
+
+def test_empty_audit_dir_scans_verified_clean(tmp_path: Path) -> None:
+    """An authenticated scan of an empty chain yields no events and no error."""
+    audit_dir = tmp_path / ".sdd" / "audit"
+    result = AuditLog(audit_dir, key=_KEY).scan_verified()
+    assert result.ok is True
+    assert result.events == []
+    assert result.errors == []

--- a/tests/unit/test_bench_audit_chain.py
+++ b/tests/unit/test_bench_audit_chain.py
@@ -1,0 +1,106 @@
+"""Hermetic coverage for the audit-chain micro-benchmark (issue #2690).
+
+The benchmark itself is a measurement tool, but its harness must stay correct
+and reproducible: the segmented chain it builds has to be a genuine, verifiable
+HMAC chain, and the append comparison has to actually isolate the chain's
+marginal cost. These tests run the harness with tiny parameters so they are
+fast and add no network or real-adapter dependency.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+from bernstein.core.audit import AuditLog
+
+# The benchmark lives under scripts/, which is not on the test import path
+# (pytest only adds src/). Load it by file path, matching how other tests pull
+# in script modules (e.g. test_format_release_notes_utm.py). The module is
+# registered in sys.modules before execution so its @dataclass decorators can
+# resolve their defining module on Python 3.14.
+_SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "bench_audit_chain.py"
+_spec = importlib.util.spec_from_file_location("_bench_audit_chain", _SCRIPT_PATH)
+assert _spec is not None and _spec.loader is not None
+bench = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = bench
+_spec.loader.exec_module(bench)
+
+BENCH_KEY = bench.BENCH_KEY
+bench_append = bench.bench_append
+bench_verify = bench.bench_verify
+build_segmented_chain = bench.build_segmented_chain
+make_details = bench.make_details
+render_markdown = bench.render_markdown
+run_benchmark = bench.run_benchmark
+
+
+def test_make_details_sizes_are_ordered() -> None:
+    """Payload sizes grow small < medium < large so the axis is meaningful."""
+    import json
+
+    sizes = [len(json.dumps(make_details(s))) for s in ("small", "medium", "large")]
+    assert sizes[0] < sizes[1] < sizes[2]
+
+
+def test_bench_append_isolates_chain_cost(tmp_path: Path) -> None:
+    """chain-on writes the same rows plus a constant HMAC overhead."""
+    result = bench_append(tmp_path, "medium", n=40, warmup=5)
+
+    assert result.chain_on["n"] == 40
+    assert result.plain_append["n"] == 40
+    # The chain adds the two 64-hex chain fields (prev_hmac + hmac) to every
+    # row: a fixed per-entry byte cost independent of payload size.
+    assert result.chain_byte_overhead > 100
+    # chain-on does strictly more work per append than a bare line write.
+    assert result.chain_on_bytes_per_entry > result.plain_bytes_per_entry
+
+
+def test_chain_byte_overhead_is_constant_across_sizes(tmp_path: Path) -> None:
+    """The chain's per-entry byte cost does not depend on payload size."""
+    small = bench_append(tmp_path / "s", "small", n=20, warmup=2)
+    large = bench_append(tmp_path / "l", "large", n=20, warmup=2)
+    assert abs(small.chain_byte_overhead - large.chain_byte_overhead) < 1.0
+
+
+def test_build_segmented_chain_is_a_real_verifiable_chain(tmp_path: Path) -> None:
+    """A segmented chain the harness builds passes a real verify()."""
+    audit_dir = tmp_path / "audit"
+    build_segmented_chain(audit_dir, events=60, segments=3)
+
+    segments = sorted(audit_dir.glob("*.jsonl"))
+    assert len(segments) == 3
+
+    ok, errors = AuditLog(audit_dir, key=BENCH_KEY).verify()
+    assert ok, errors
+
+    # The same chain scans clean and yields every event.
+    result = AuditLog(audit_dir, key=BENCH_KEY).scan_verified()
+    assert result.ok
+    assert len(result.events) == 60
+
+
+def test_bench_verify_reports_positive_throughput(tmp_path: Path) -> None:
+    """The verify harness produces non-zero, well-formed throughput figures."""
+    v = bench_verify(tmp_path, events=200, segments=2)
+    assert v.events == 200
+    assert v.segments == 2
+    assert v.verify_events_per_s > 0
+    assert v.scan_cold_events_per_s > 0
+    assert v.scan_warm_tail_us > 0
+
+
+def test_run_benchmark_renders_without_error(tmp_path: Path) -> None:
+    """The end-to-end harness runs and renders a Markdown report."""
+    report = run_benchmark(
+        tmp_path,
+        append_n=20,
+        sizes=("small",),
+        verify_points=((100, 1),),
+    )
+    assert len(report.append) == 1
+    assert len(report.verify) == 1
+    md = render_markdown(report)
+    assert "Append latency" in md
+    assert "Verify / scan throughput" in md


### PR DESCRIPTION
## What
Repaired the single critical review finding: the pushed branch failed `ruff check`. tests/unit/test_audit_append_hotpath.py:39 carried `# noqa: ARG002 - signature parity`, but ARG002 is not in the enabled ruff rule set, so RUF100 flagged it as an unused noqa directive ("Found 1 error"). Root cause: the fake `now(self, tz=None)` needs the `tz` param for signature parity with the real `datetime.now(tz=UTC)` call in src/bernstein/core/security/audit.py:879, but no lint rule flags an unused method arg (ARG002 disabled), so the suppression was itself dead. Fix: replaced the noqa with a plain explanatory comment ("# tz kept for signature parity") — the same effect as `ruff check --fix`, no behaviour change, on-disk format untouched. Committed as f2dbb415e (style, follow-up commit, not a force-push) and pushed; local == origin. The three minor findings were left as-is: all are non-blocking and already disclosed transparently in ADR-010 (baseline-framing shows absolute chain-on figures alongside marginal; concurrency and scope-2 full-suite confirmation are explicitly out of the issue's scope

Fixes #2690

## Acceptance criteria (3/6 met)
- [x] CRITICAL: pushed HEAD fails ruff check (RUF100 unused noqa at test_audit_append_hotpath.py:39)
- [x] No regression in audit tests after the fix
- [x] Collection sentinel clean
- [ ] Minor: baseline framing (marginal vs absolute chain cost) — *deferred*
- [ ] Minor: concurrency not measured (serial bench only) — *deferred*
- [ ] Minor: scope-2 rests on targeted scan, full suite not run — *deferred*

## Verification
Adversarial review: **confirmed, 0 critical findings** (empirical criteria re-attacked independently: tamper/determinism/red-on-main).
47 passed, 3 snapshots passed (tests/unit/test_audit_append_hotpath.py, test_audit_chain_migration.py, test_bench_audit_chain.py, test_audit.py, test_audit_mode.py, test_audit_chain_crossprocess.py, tests/snapshot/test_audit_jsonl_snapshot.py). Collection sentinel: 37864 tests collected, no errors. ruff check . = All checks passed; ruff format --check = clean.
