### PR TITLE
feat(cluster): signed Merkle-chained claim journal with deterministic projection (phases 1-2)

### DIFF
--- a/docs/orchestration/tracker-pipeline.md
+++ b/docs/orchestration/tracker-pipeline.md
@@ -7,6 +7,7 @@
 | `PipelineConfig` | Typed view over `bernstein.yaml: orchestration.tracker_pipeline`. |
 | `PipelineStage` | One role in the pipeline (claim status, success status, failure status, optional prior-role gate). |
 | `ClaimLedger` | SQLite-backed distributed claim ledger with lease TTL. |
+| `ClaimJournal` + `project_claims` | Opt-in signed, Merkle-chained claim journal; SQLite becomes a deterministic projection of it. |
 | `make_idempotency_key` | Stable `sha256(tracker || ticket_id || role || stage || stage_attempt)`. |
 | `FailurePayload` + `format_failure_comment` | Structured failure taxonomy embedded in a fenced YAML block. |
 | `TrackerPipeline` | Stateless sweep loop binding the above pieces together. |
@@ -76,6 +77,46 @@ next caller picks it up.
 The ledger also enforces `per_role_max_in_flight`: when a role's live
 claim count reaches the ceiling, the loop stops dispatching new claims
 for that role until somebody releases.
+
+## Signed claim journal (opt-in projection)
+
+The SQLite ledger is race-safe only when every claimer shares one
+filesystem. For leaderless coordination the ledger can instead be driven
+by a **signed, append-only, Merkle-chained claim journal** (`ClaimJournal`),
+with the SQLite rows demoted to a deterministic *projection* of that
+journal rather than the source of truth.
+
+The path is **opt-in and off by default**. Existing callers construct
+`ClaimLedger(db_path)` and touch no journal — behaviour is unchanged.
+Passing a journal (`ClaimLedger(db_path, journal=...)`) turns on the
+journal path.
+
+| Piece | What it is |
+|-------|------------|
+| `ClaimReceipt` | One signed entry: `claim` / `release` / `renew` / `expire` / `supersede`, binding `{tracker, ticket_id, role, claimer_id, node_id, lease_expires_at, prev_entry_hash, entry_hash}`. |
+| `ClaimJournal` | Append-only JSONL store. Each receipt chains over the previous head and is Ed25519-signed with the node install identity; each is anchored into the HMAC audit chain (`cluster.claim_journal_receipt`). |
+| `project_claims(receipts)` | Pure fold: the same ordered receipt set yields a byte-identical `ClaimState` and identical head hash on any node. |
+
+**Determinism.** The `entry_hash` is computed with the signature blanked,
+so two nodes signing the same body with different install keys still agree
+on the hash and therefore on the journal head. When more than one live
+claim contends for a key, the claim with the lowest `entry_hash` wins and
+the losers are superseded — a total order independent of wall-clock, node
+identity, or observation order.
+
+**Convergence.** `ClaimJournal.reconcile(...)` appends a chain-anchored
+`claim_superseded` receipt for every loser, naming the winner. Re-running
+once every loser is superseded is a no-op.
+
+**Verify.** `ClaimJournal.verify()` replays the journal offline, checking
+every `prev_entry_hash` link, every recomputed `entry_hash`, and every
+Ed25519 signature; a single flipped byte or a dropped receipt fails at the
+exact entry index.
+
+Deferred (not in this slice): MESH topology wiring in the orchestrator,
+A2A gossip of receipts between machines, fork detection at merge time, and
+the `bernstein cluster claims log | head | verify` CLI. Those land once the
+verified peer-identity surface is in place.
 
 ## Idempotency keys
 

--- a/docs/orchestration/tracker-pipeline.md
+++ b/docs/orchestration/tracker-pipeline.md
@@ -113,6 +113,22 @@ every `prev_entry_hash` link, every recomputed `entry_hash`, and every
 Ed25519 signature; a single flipped byte or a dropped receipt fails at the
 exact entry index.
 
+**Multi-writer safety.** Each append resolves the chain tail and writes the
+new receipt as one critical section under a single exclusive advisory lock
+on the journal file. Two nodes appending to the same journal on a shared
+filesystem are therefore serialised across the read-modify-write of
+`prev_entry_hash`, so concurrent honest claims stay on one linear chain
+instead of forking — a fork that offline `verify()` could not distinguish
+from tampering. Convergence between the concurrent claimants is then the
+ordinary lowest-`entry_hash` rule plus `reconcile(...)`.
+
+**Journal is the source of truth.** On the journal path a granted claim
+mints the signed receipt first and materialises the SQLite row *from that
+receipt* inside the same transaction. If the receipt cannot be written
+(disk or signing error) the transaction is rolled back, so the ledger never
+holds a row without a backing receipt — the projection can always be
+rebuilt from the journal alone.
+
 Deferred (not in this slice): MESH topology wiring in the orchestrator,
 A2A gossip of receipts between machines, fork detection at merge time, and
 the `bernstein cluster claims log | head | verify` CLI. Those land once the

--- a/src/bernstein/core/orchestration/tracker_pipeline.py
+++ b/src/bernstein/core/orchestration/tracker_pipeline.py
@@ -60,7 +60,7 @@ import uuid
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from dataclasses import asdict, dataclass, field, replace
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar, Final, Protocol, cast, runtime_checkable
+from typing import IO, TYPE_CHECKING, Any, ClassVar, Final, Protocol, cast, runtime_checkable
 
 from bernstein.core.lineage.tracker_audit import (
     GENESIS_PREV_HASH,
@@ -705,6 +705,9 @@ class ClaimLedger:
         """
         current = float(time.time() if now is None else now)
         expires_at = current + max(1, ttl_seconds)
+        # Populated on the MESH path; the SQLite row below is materialised from
+        # this receipt so the ledger stays a projection of the journal.
+        receipt: ClaimReceipt | None = None
         with self._lock:
             conn = self._connect()
             try:
@@ -740,12 +743,47 @@ class ClaimLedger:
                         claimer_id="",
                         lease_expires_at=0.0,
                     )
+                # MESH path: the journal is the source of truth. Mint the signed
+                # claim receipt FIRST, still inside the open transaction, then
+                # materialise the SQLite row from that receipt and commit both
+                # together. If the append fails (disk / signing), roll the
+                # transaction back so no receipt-less row is ever committed --
+                # the projection derives claim state from receipts only, so a
+                # held row with no receipt would be a phantom holder. STAR
+                # deployments pass no journal and insert from the raw inputs.
+                if self._journal is not None:
+                    try:
+                        receipt = self._journal.append(
+                            kind="claim",
+                            tracker=tracker,
+                            ticket_id=ticket_id,
+                            role=role,
+                            claimer_id=claimer_id,
+                            lease_expires_at=expires_at,
+                            ts_ns=int(current * 1_000_000_000),
+                        )
+                    except BaseException:
+                        with contextlib.suppress(sqlite3.Error):
+                            conn.execute("ROLLBACK")
+                        raise
+                insert_values = (
+                    (tracker, ticket_id, role, claimer_id, expires_at, current)
+                    if receipt is None
+                    else (
+                        receipt.tracker,
+                        receipt.ticket_id,
+                        receipt.role,
+                        receipt.claimer_id,
+                        receipt.lease_expires_at,
+                        current,
+                    )
+                )
                 try:
                     conn.execute(
                         "INSERT OR FAIL INTO claims "
                         "(tracker, ticket_id, role, claimer_id, lease_expires_at, stage_attempt, created_at) "
                         "VALUES (?, ?, ?, ?, ?, 0, ?)",
-                        (tracker, ticket_id, role, claimer_id, expires_at, current),
+                        insert_values,
                     )
                 except sqlite3.IntegrityError:
                     conn.execute("ROLLBACK")
@@ -778,26 +816,12 @@ class ClaimLedger:
                     claimer_id="",
                     lease_expires_at=0.0,
                 )
-            # MESH path: the granted claim is anchored as a signed receipt on
-            # the journal, and the SQLite row above is its materialised
-            # projection (both derive from the same injected ``now`` clock and
-            # claim inputs, so a replay reproduces byte-identical state). STAR
-            # deployments pass no journal and skip this entirely.
-            if self._journal is not None:
-                self._journal.append(
-                    kind="claim",
-                    tracker=tracker,
-                    ticket_id=ticket_id,
-                    role=role,
-                    claimer_id=claimer_id,
-                    lease_expires_at=expires_at,
-                    ts_ns=int(current * 1_000_000_000),
-                )
+        granted_lease = expires_at if receipt is None else receipt.lease_expires_at
         return ClaimOutcome(
             granted=True,
             reason="granted",
             claimer_id=claimer_id,
-            lease_expires_at=expires_at,
+            lease_expires_at=granted_lease,
         )
 
     def live_claims(self, *, now: float | None = None) -> list[dict[str, Any]]:
@@ -998,6 +1022,24 @@ def compute_claim_entry_hash(receipt: ClaimReceipt) -> str:
     return "sha256:" + hashlib.sha256(_claim_signing_bytes(receipt)).hexdigest()
 
 
+def _tail_hash_from_handle(fp: IO[bytes]) -> str:
+    """Return the last receipt's ``entry_hash`` from an open journal handle.
+
+    Reads from the start of ``fp`` so a caller already holding the exclusive
+    append lock can resolve the current chain tail without opening a second
+    descriptor. Keeping the tail read on the *locked* handle is what makes the
+    read-modify-write of ``prev_entry_hash`` a single atomic critical section.
+    """
+    fp.seek(0)
+    last_hash = GENESIS_PREV_HASH
+    for raw in fp:
+        stripped = raw.strip()
+        if not stripped:
+            continue
+        last_hash = json.loads(stripped.decode("utf-8"))["entry_hash"]
+    return last_hash
+
+
 @dataclass(frozen=True, slots=True)
 class ClaimHold:
     """The current holder of one ``(tracker, ticket_id, role)`` claim."""
@@ -1193,32 +1235,43 @@ class ClaimJournal:
             msg = f"unknown claim-receipt kind: {kind!r}"
             raise ValueError(msg)
         with self._lock:
-            prev_hash = self._tail_hash()
-            unsigned = ClaimReceipt(
-                schema_version=CLAIM_JOURNAL_SCHEMA_VERSION,
-                kind=kind,
-                ts_ns=int(ts_ns),
-                tracker=tracker,
-                ticket_id=ticket_id,
-                role=role,
-                claimer_id=claimer_id,
-                node_id=self._node_id if node_id is None else node_id,
-                lease_expires_at=float(lease_expires_at),
-                prev_entry_hash=prev_hash,
-                entry_hash=GENESIS_PREV_HASH,  # placeholder; recomputed below
-                signature={},
-                supersedes=supersedes,
-                winner_claimer_id=winner_claimer_id,
-                winner_entry_hash=winner_entry_hash,
-            )
-            digest = compute_claim_entry_hash(unsigned)
-            signed = replace(unsigned, entry_hash=digest)
-            signature = build_head_signature(digest.split(":", 1)[1], kms_adapter=self._kms)
-            final = replace(signed, signature=signature)
-
-            line = _canonical_bytes(asdict(final)) + b"\n"
             self.path.parent.mkdir(parents=True, exist_ok=True)
-            with self.path.open("ab") as fp, _exclusive_lock(fp):
+            # The tail read and the byte-append are one critical section under
+            # a single exclusive advisory lock. Reading ``prev_entry_hash``
+            # before taking the lock would let two nodes on a shared filesystem
+            # both observe the same tail and mint receipts that both link to it,
+            # forking the linear chain -- a fork offline ``verify()`` cannot
+            # tell apart from tampering. Holding the lock across the read, the
+            # (deterministic, in-memory) Ed25519 signing, and the write keeps
+            # every cross-process append strictly linear. ``a+b`` opens for read
+            # and append; on POSIX an append write always lands at EOF
+            # regardless of the read cursor.
+            with self.path.open("a+b") as fp, _exclusive_lock(fp):
+                prev_hash = _tail_hash_from_handle(fp)
+                unsigned = ClaimReceipt(
+                    schema_version=CLAIM_JOURNAL_SCHEMA_VERSION,
+                    kind=kind,
+                    ts_ns=int(ts_ns),
+                    tracker=tracker,
+                    ticket_id=ticket_id,
+                    role=role,
+                    claimer_id=claimer_id,
+                    node_id=self._node_id if node_id is None else node_id,
+                    lease_expires_at=float(lease_expires_at),
+                    prev_entry_hash=prev_hash,
+                    entry_hash=GENESIS_PREV_HASH,  # placeholder; recomputed below
+                    signature={},
+                    supersedes=supersedes,
+                    winner_claimer_id=winner_claimer_id,
+                    winner_entry_hash=winner_entry_hash,
+                )
+                digest = compute_claim_entry_hash(unsigned)
+                signed = replace(unsigned, entry_hash=digest)
+                signature = build_head_signature(digest.split(":", 1)[1], kms_adapter=self._kms)
+                final = replace(signed, signature=signature)
+
+                line = _canonical_bytes(asdict(final)) + b"\n"
+                fp.seek(0, os.SEEK_END)
                 fp.write(line)
                 fp.flush()
                 os.fsync(fp.fileno())
@@ -1386,17 +1439,15 @@ class ClaimJournal:
     # -- internals ----------------------------------------------------
 
     def _tail_hash(self) -> str:
-        """Return the ``entry_hash`` of the last receipt, or genesis."""
+        """Return the ``entry_hash`` of the last receipt, or genesis.
+
+        A lock-free snapshot read used by :meth:`head`; the append path resolves
+        the tail on its own locked handle via :func:`_tail_hash_from_handle`.
+        """
         if not self.path.exists() or self.path.stat().st_size == 0:
             return GENESIS_PREV_HASH
-        last_hash = GENESIS_PREV_HASH
         with self.path.open("rb") as fp:
-            for raw in fp:
-                stripped = raw.strip()
-                if not stripped:
-                    continue
-                last_hash = json.loads(stripped.decode("utf-8"))["entry_hash"]
-        return last_hash
+            return _tail_hash_from_handle(fp)
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/core/orchestration/tracker_pipeline.py
+++ b/src/bernstein/core/orchestration/tracker_pipeline.py
@@ -50,18 +50,32 @@ from __future__ import annotations
 
 import contextlib
 import hashlib
+import json
 import logging
+import os
 import sqlite3
 import threading
 import time
 import uuid
-from collections.abc import Callable, Iterable, Mapping, Sequence
-from dataclasses import dataclass, field
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
+from dataclasses import asdict, dataclass, field, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Final, Protocol, cast, runtime_checkable
 
+from bernstein.core.lineage.tracker_audit import (
+    GENESIS_PREV_HASH,
+    _canonical_bytes,
+    _exclusive_lock,
+)
+from bernstein.core.security.audit_head_signature import (
+    build_head_signature,
+    verify_head_signature,
+)
+
 if TYPE_CHECKING:
     from bernstein.core.lifecycle.hooks import HookRegistry
+    from bernstein.core.security.audit_chain import AuditChainStore
+    from bernstein.core.security.lineage_kms import KMSAdapter
     from bernstein.core.trackers.contract import (
         AbstractTrackerAdapter,
         Ticket,
@@ -74,13 +88,21 @@ log = logging.getLogger(__name__)
 __all__ = [
     "ALLOWED_FAILURE_CATEGORIES",
     "ALLOWED_FAILURE_NEXT_ACTIONS",
+    "CLAIM_JOURNAL_SCHEMA_VERSION",
+    "CLAIM_RECEIPT_KINDS",
+    "DEFAULT_CLAIM_JOURNAL_RELPATH",
     "DEFAULT_CLAIM_LOCK_TTL_SECONDS",
     "DEFAULT_LEDGER_RELPATH",
     "DEFAULT_PER_ROLE_MAX_IN_FLIGHT",
     "FAILURE_BLOCK_BEGIN",
     "FAILURE_BLOCK_END",
+    "ClaimHold",
+    "ClaimJournal",
+    "ClaimJournalVerifyResult",
     "ClaimLedger",
     "ClaimOutcome",
+    "ClaimReceipt",
+    "ClaimState",
     "DispatchOutcome",
     "FailurePayload",
     "PipelineConfig",
@@ -89,11 +111,14 @@ __all__ = [
     "StageHandoff",
     "TrackerPipeline",
     "TrackerPipelineError",
+    "compute_claim_entry_hash",
+    "default_claim_journal_path",
     "format_failure_comment",
     "format_success_comment",
     "make_idempotency_key",
     "parse_failure_block",
     "parse_success_blocks",
+    "project_claims",
 ]
 
 
@@ -120,6 +145,30 @@ ceiling for that role.
 
 DEFAULT_LEDGER_RELPATH: Final[Path] = Path("state") / "tracker_claims.db"
 """Path under ``.sdd/`` where the SQLite ledger lives by default."""
+
+DEFAULT_CLAIM_JOURNAL_RELPATH: Final[Path] = Path("cluster") / "claim_journal.jsonl"
+"""Path under ``.sdd/`` where the signed MESH claim journal lives by default.
+
+The journal is opt-in: STAR deployments never materialise it. Only the
+leaderless MESH path (issue #2558) constructs a :class:`ClaimJournal` and
+threads it into :class:`ClaimLedger`.
+"""
+
+CLAIM_JOURNAL_SCHEMA_VERSION: Final[int] = 1
+"""On-disk schema version stamped into every :class:`ClaimReceipt`.
+
+Bumping requires a parallel reader for the old version, mirroring the
+tracker-audit stream's versioning contract.
+"""
+
+CLAIM_RECEIPT_KINDS: Final[frozenset[str]] = frozenset(
+    {"claim", "release", "renew", "expire", "supersede"},
+)
+"""The closed set of :class:`ClaimReceipt` kinds.
+
+Exposed as a module constant so downstream tools can introspect the taxonomy
+without reaching into the dataclass internals.
+"""
 
 FAILURE_BLOCK_BEGIN: Final[str] = "```yaml bernstein:failure"
 """Opening fence of the structured failure block embedded in comments."""
@@ -550,15 +599,33 @@ class ClaimLedger:
     _locks: ClassVar[dict[str, threading.RLock]] = {}
     _locks_guard: ClassVar[threading.Lock] = threading.Lock()
 
-    def __init__(self, db_path: Path) -> None:
+    def __init__(self, db_path: Path, *, journal: ClaimJournal | None = None) -> None:
+        """Build a ledger.
+
+        Args:
+            db_path: SQLite file the projection is materialised into.
+            journal: Optional signed :class:`ClaimJournal`. When supplied the
+                ledger runs the leaderless MESH path: every granted claim is
+                first appended as a signed receipt and the SQLite row is
+                materialised from it, so the ledger becomes a projection of the
+                journal rather than the source of truth. When ``None`` (the
+                default) the ledger behaves exactly as the STAR path always
+                has, touching no journal -- existing callers are unaffected.
+        """
         self._db_path = db_path
         self._conn: sqlite3.Connection | None = None
         self._lock = self._lock_for_path(db_path)
+        self._journal = journal
 
     @property
     def db_path(self) -> Path:
         """Filesystem path the ledger persists at."""
         return self._db_path
+
+    @property
+    def journal(self) -> ClaimJournal | None:
+        """The signed claim journal on the MESH path, or ``None`` for STAR."""
+        return self._journal
 
     @classmethod
     def _lock_for_path(cls, db_path: Path) -> threading.RLock:
@@ -711,6 +778,21 @@ class ClaimLedger:
                     claimer_id="",
                     lease_expires_at=0.0,
                 )
+            # MESH path: the granted claim is anchored as a signed receipt on
+            # the journal, and the SQLite row above is its materialised
+            # projection (both derive from the same injected ``now`` clock and
+            # claim inputs, so a replay reproduces byte-identical state). STAR
+            # deployments pass no journal and skip this entirely.
+            if self._journal is not None:
+                self._journal.append(
+                    kind="claim",
+                    tracker=tracker,
+                    ticket_id=ticket_id,
+                    role=role,
+                    claimer_id=claimer_id,
+                    lease_expires_at=expires_at,
+                    ts_ns=int(current * 1_000_000_000),
+                )
         return ClaimOutcome(
             granted=True,
             reason="granted",
@@ -802,6 +884,519 @@ class ClaimLedger:
                 conn.execute("ROLLBACK")
                 raise
             return attempt
+
+
+# ---------------------------------------------------------------------------
+# Claim journal (signed, Merkle-chained) -- leaderless MESH substrate (#2558)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class ClaimReceipt:
+    """One signed, hash-chained entry in a leaderless MESH claim journal.
+
+    A receipt records a single self-claim, release, renewal, expiry, or
+    supersession against ``(tracker, ticket_id, role)``. Receipts chain via
+    ``prev_entry_hash`` / ``entry_hash`` (reusing the tracker-audit
+    canonicalisation) and are Ed25519-signed with the node's install identity
+    through the same head-signature path the A2A message receipts use.
+
+    The ``entry_hash`` is computed with the ``signature`` and ``entry_hash``
+    fields blanked, so it is *signature-independent*: two nodes signing the
+    same body with different install keys agree on the entry hash and therefore
+    on the journal head. That is what lets the pure fold produce byte-identical
+    state across nodes.
+
+    The core binding is ``{tracker, ticket_id, role, claimer_id, node_id,
+    lease_expires_at, prev_entry_hash, entry_hash}``. A ``supersede`` receipt
+    additionally names the losing claim (``supersedes``) and the winner
+    (``winner_claimer_id`` / ``winner_entry_hash``).
+    """
+
+    schema_version: int
+    kind: str
+    ts_ns: int
+    tracker: str
+    ticket_id: str
+    role: str
+    claimer_id: str
+    node_id: str
+    lease_expires_at: float
+    prev_entry_hash: str
+    entry_hash: str
+    signature: dict[str, Any] = field(default_factory=dict)
+    supersedes: str | None = None
+    winner_claimer_id: str | None = None
+    winner_entry_hash: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.kind not in CLAIM_RECEIPT_KINDS:
+            msg = f"unknown claim-receipt kind: {self.kind!r}"
+            raise ValueError(msg)
+        for hash_field, label in (
+            (self.prev_entry_hash, "prev_entry_hash"),
+            (self.entry_hash, "entry_hash"),
+        ):
+            if not hash_field.startswith("sha256:"):
+                msg = f"{label} must start with 'sha256:', got {hash_field!r}"
+                raise ValueError(msg)
+
+    @property
+    def key(self) -> tuple[str, str, str]:
+        """The ``(tracker, ticket_id, role)`` the receipt claims against."""
+        return (self.tracker, self.ticket_id, self.role)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the plain-dict wire form (the on-disk JSONL body)."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> ClaimReceipt:
+        """Rebuild a receipt from a parsed JSON object.
+
+        Validates the receipt shape through the dataclass ``__post_init__``
+        invariants on construction.
+        """
+        supersedes = data.get("supersedes")
+        winner_claimer_id = data.get("winner_claimer_id")
+        winner_entry_hash = data.get("winner_entry_hash")
+        return cls(
+            schema_version=int(data["schema_version"]),
+            kind=str(data["kind"]),
+            ts_ns=int(data["ts_ns"]),
+            tracker=str(data["tracker"]),
+            ticket_id=str(data["ticket_id"]),
+            role=str(data["role"]),
+            claimer_id=str(data["claimer_id"]),
+            node_id=str(data["node_id"]),
+            lease_expires_at=float(data["lease_expires_at"]),
+            prev_entry_hash=str(data["prev_entry_hash"]),
+            entry_hash=str(data["entry_hash"]),
+            signature=dict(data.get("signature") or {}),
+            supersedes=None if supersedes is None else str(supersedes),
+            winner_claimer_id=None if winner_claimer_id is None else str(winner_claimer_id),
+            winner_entry_hash=None if winner_entry_hash is None else str(winner_entry_hash),
+        )
+
+
+def _claim_signing_bytes(receipt: ClaimReceipt) -> bytes:
+    """Return the JCS bytes the entry hash and signature run over.
+
+    Mirrors :func:`bernstein.core.lineage.tracker_audit._signing_payload`: the
+    ``signature`` and ``entry_hash`` fields are blanked so the digest is
+    reproducible from the same body during replay or verification, and so the
+    chain hash never depends on which node signed the receipt.
+    """
+    body = asdict(receipt)
+    body["signature"] = {}
+    body["entry_hash"] = ""
+    return _canonical_bytes(body)
+
+
+def compute_claim_entry_hash(receipt: ClaimReceipt) -> str:
+    """Return the content-addressed ``entry_hash`` for ``receipt``."""
+    return "sha256:" + hashlib.sha256(_claim_signing_bytes(receipt)).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class ClaimHold:
+    """The current holder of one ``(tracker, ticket_id, role)`` claim."""
+
+    tracker: str
+    ticket_id: str
+    role: str
+    claimer_id: str
+    node_id: str
+    lease_expires_at: float
+    entry_hash: str
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return the canonical dict form used by :meth:`ClaimState.canonical_bytes`."""
+        return {
+            "tracker": self.tracker,
+            "ticket_id": self.ticket_id,
+            "role": self.role,
+            "claimer_id": self.claimer_id,
+            "node_id": self.node_id,
+            "lease_expires_at": self.lease_expires_at,
+            "entry_hash": self.entry_hash,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ClaimState:
+    """The projected claim state -- the pure fold of an ordered receipt set.
+
+    ``holds`` maps each claimed key to its single deterministic holder;
+    ``superseded`` is the set of every claim ``entry_hash`` that lost (whether
+    by an explicit ``supersede`` receipt or by the lowest-``entry_hash`` rule);
+    ``head`` is the journal head hash (the ``entry_hash`` of the last receipt).
+
+    Two nodes folding the same ordered receipt set must produce a
+    byte-identical :meth:`canonical_bytes` and an identical ``head``.
+    """
+
+    holds: Mapping[tuple[str, str, str], ClaimHold]
+    superseded: frozenset[str]
+    head: str
+
+    def holder(self, tracker: str, ticket_id: str, role: str) -> ClaimHold | None:
+        """Return the current holder of the key, or ``None`` if unheld."""
+        return self.holds.get((tracker, ticket_id, role))
+
+    def canonical_bytes(self) -> bytes:
+        """Return the deterministic JCS serialisation for byte-comparison."""
+        payload = {
+            "head": self.head,
+            "holds": [self.holds[k].as_dict() for k in sorted(self.holds)],
+            "superseded": sorted(self.superseded),
+        }
+        return _canonical_bytes(payload)
+
+
+def _active_buckets(
+    receipts: Sequence[ClaimReceipt],
+) -> tuple[dict[tuple[str, str, str], dict[str, ClaimHold]], set[str]]:
+    """Fold ``receipts`` into per-key live-claim buckets.
+
+    Returns ``(active, explicitly_superseded)`` where ``active[key]`` maps each
+    still-live claim's ``entry_hash`` to its :class:`ClaimHold`, and
+    ``explicitly_superseded`` is the set of entry hashes removed by an explicit
+    ``supersede`` receipt. Ordering follows the receipt sequence; the
+    lowest-``entry_hash`` winner selection is applied by the callers.
+    """
+    active: dict[tuple[str, str, str], dict[str, ClaimHold]] = {}
+    explicit_superseded: set[str] = set()
+    for receipt in receipts:
+        bucket = active.setdefault(receipt.key, {})
+        if receipt.kind == "claim":
+            bucket[receipt.entry_hash] = ClaimHold(
+                tracker=receipt.tracker,
+                ticket_id=receipt.ticket_id,
+                role=receipt.role,
+                claimer_id=receipt.claimer_id,
+                node_id=receipt.node_id,
+                lease_expires_at=receipt.lease_expires_at,
+                entry_hash=receipt.entry_hash,
+            )
+        elif receipt.kind == "renew":
+            for entry_hash, hold in list(bucket.items()):
+                if hold.claimer_id == receipt.claimer_id and hold.node_id == receipt.node_id:
+                    bucket[entry_hash] = replace(hold, lease_expires_at=receipt.lease_expires_at)
+        elif receipt.kind in ("release", "expire"):
+            for entry_hash, hold in list(bucket.items()):
+                if hold.claimer_id == receipt.claimer_id and hold.node_id == receipt.node_id:
+                    del bucket[entry_hash]
+        elif receipt.kind == "supersede" and receipt.supersedes is not None:
+            bucket.pop(receipt.supersedes, None)
+            explicit_superseded.add(receipt.supersedes)
+    return active, explicit_superseded
+
+
+def project_claims(receipts: Sequence[ClaimReceipt]) -> ClaimState:
+    """Fold an ordered receipt set into a deterministic :class:`ClaimState`.
+
+    Pure and total: given the same ordered receipts, two independently
+    instantiated nodes produce a byte-identical state and an identical head
+    hash. When more than one live claim contends for a key, the claim with the
+    lexicographically-lowest ``entry_hash`` wins and the rest are superseded --
+    a total order that does not depend on wall-clock, node identity, or which
+    node observed which claim first.
+    """
+    active, superseded = _active_buckets(receipts)
+    superseded = set(superseded)
+    holds: dict[tuple[str, str, str], ClaimHold] = {}
+    for key, bucket in active.items():
+        if not bucket:
+            continue
+        winner_entry_hash = min(bucket)
+        holds[key] = bucket[winner_entry_hash]
+        for entry_hash in bucket:
+            if entry_hash != winner_entry_hash:
+                superseded.add(entry_hash)
+    head = receipts[-1].entry_hash if receipts else GENESIS_PREV_HASH
+    return ClaimState(holds=holds, superseded=frozenset(superseded), head=head)
+
+
+@dataclass(frozen=True, slots=True)
+class ClaimJournalVerifyResult:
+    """Outcome of :meth:`ClaimJournal.verify`."""
+
+    ok: bool
+    entry_count: int
+    bad_index: int | None = None
+    failures: list[str] = field(default_factory=list)
+
+
+class ClaimJournal:
+    """Signed, append-only, Merkle-chained journal of claim receipts.
+
+    The journal is the source of truth for leaderless MESH coordination: the
+    SQLite :class:`ClaimLedger` is a projection of it. Each append computes the
+    chain link, signs the entry hash with the node's Ed25519 install identity,
+    writes the JSONL body under an exclusive ``flock`` (so multiple nodes on a
+    shared filesystem never interleave bytes), and -- when an audit chain is
+    supplied -- anchors the receipt's ``entry_hash`` into the HMAC audit chain
+    as a ``cluster.claim_journal_receipt`` event.
+
+    Args:
+        path: JSONL file the receipts are appended to.
+        kms_adapter: The node's Ed25519 signer (its install identity).
+        node_id: The node install identity id recorded on every receipt.
+        chain: Optional :class:`AuditChainStore`; when supplied every receipt
+            is anchored into the HMAC chain.
+    """
+
+    def __init__(
+        self,
+        path: Path,
+        *,
+        kms_adapter: KMSAdapter,
+        node_id: str,
+        chain: AuditChainStore | None = None,
+    ) -> None:
+        self.path: Path = Path(path)
+        self._kms = kms_adapter
+        self._node_id = node_id
+        self._chain = chain
+        self._lock = threading.RLock()
+
+    @property
+    def node_id(self) -> str:
+        """The node install identity id recorded on receipts this journal mints."""
+        return self._node_id
+
+    # -- append -------------------------------------------------------
+
+    def append(
+        self,
+        *,
+        kind: str,
+        tracker: str,
+        ticket_id: str,
+        role: str,
+        claimer_id: str,
+        lease_expires_at: float,
+        ts_ns: int,
+        node_id: str | None = None,
+        supersedes: str | None = None,
+        winner_claimer_id: str | None = None,
+        winner_entry_hash: str | None = None,
+    ) -> ClaimReceipt:
+        """Append one signed receipt and return the materialised entry.
+
+        ``ts_ns`` is an explicit argument rather than an ambient clock read, so
+        a replay with the same inputs reproduces a byte-identical receipt
+        (including its signature -- Ed25519 is deterministic per RFC 8032).
+        """
+        if kind not in CLAIM_RECEIPT_KINDS:
+            msg = f"unknown claim-receipt kind: {kind!r}"
+            raise ValueError(msg)
+        with self._lock:
+            prev_hash = self._tail_hash()
+            unsigned = ClaimReceipt(
+                schema_version=CLAIM_JOURNAL_SCHEMA_VERSION,
+                kind=kind,
+                ts_ns=int(ts_ns),
+                tracker=tracker,
+                ticket_id=ticket_id,
+                role=role,
+                claimer_id=claimer_id,
+                node_id=self._node_id if node_id is None else node_id,
+                lease_expires_at=float(lease_expires_at),
+                prev_entry_hash=prev_hash,
+                entry_hash=GENESIS_PREV_HASH,  # placeholder; recomputed below
+                signature={},
+                supersedes=supersedes,
+                winner_claimer_id=winner_claimer_id,
+                winner_entry_hash=winner_entry_hash,
+            )
+            digest = compute_claim_entry_hash(unsigned)
+            signed = replace(unsigned, entry_hash=digest)
+            signature = build_head_signature(digest.split(":", 1)[1], kms_adapter=self._kms)
+            final = replace(signed, signature=signature)
+
+            line = _canonical_bytes(asdict(final)) + b"\n"
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            with self.path.open("ab") as fp, _exclusive_lock(fp):
+                fp.write(line)
+                fp.flush()
+                os.fsync(fp.fileno())
+            self._anchor(final)
+            return final
+
+    def _anchor(self, receipt: ClaimReceipt) -> None:
+        """Mirror ``receipt`` into the HMAC audit chain when one is configured."""
+        if self._chain is None:
+            return
+        # Imported lazily so the (large) audit_chain module is not pulled in at
+        # tracker_pipeline import time on the STAR path that never anchors.
+        from bernstein.core.security.audit_chain import record_claim_journal_receipt
+
+        record_claim_journal_receipt(
+            chain=self._chain,
+            kind=receipt.kind,
+            tracker=receipt.tracker,
+            ticket_id=receipt.ticket_id,
+            role=receipt.role,
+            claimer_id=receipt.claimer_id,
+            node_id=receipt.node_id,
+            lease_expires_at=receipt.lease_expires_at,
+            prev_entry_hash=receipt.prev_entry_hash,
+            journal_entry_hash=receipt.entry_hash,
+            supersedes=receipt.supersedes,
+            winner_claimer_id=receipt.winner_claimer_id,
+            winner_entry_hash=receipt.winner_entry_hash,
+        )
+
+    # -- read ---------------------------------------------------------
+
+    def read(self) -> list[ClaimReceipt]:
+        """Return every receipt on disk, in insertion order."""
+        return list(self.iter_receipts())
+
+    def iter_receipts(self) -> Iterator[ClaimReceipt]:
+        """Yield each receipt without holding the whole file in memory."""
+        if not self.path.exists():
+            return
+        with self.path.open("rb") as fp:
+            for raw in fp:
+                stripped = raw.strip()
+                if not stripped:
+                    continue
+                yield ClaimReceipt.from_dict(json.loads(stripped.decode("utf-8")))
+
+    def project(self) -> ClaimState:
+        """Return the pure fold of the on-disk receipts."""
+        return project_claims(self.read())
+
+    def head(self) -> str:
+        """Return the journal head hash (last ``entry_hash`` or genesis)."""
+        return self._tail_hash()
+
+    # -- conflict reconciliation --------------------------------------
+
+    def reconcile(self, *, ts_ns: int) -> list[ClaimReceipt]:
+        """Append a ``supersede`` receipt for every deterministic loser.
+
+        Reads the journal, folds it, and for each key with more than one live
+        claim appends a chain-anchored ``claim_superseded`` receipt naming the
+        winner (lowest ``entry_hash``) for every loser that does not already
+        hold one. Returns the receipts appended, in a deterministic order.
+        Idempotent: re-running once every loser is superseded is a no-op.
+        """
+        active, explicit_superseded = _active_buckets(self.read())
+        emitted: list[ClaimReceipt] = []
+        cursor_ts = int(ts_ns)
+        for key in sorted(active):
+            bucket = active[key]
+            if len(bucket) <= 1:
+                continue
+            winner_entry_hash = min(bucket)
+            winner = bucket[winner_entry_hash]
+            for loser_entry_hash in sorted(bucket):
+                if loser_entry_hash == winner_entry_hash or loser_entry_hash in explicit_superseded:
+                    continue
+                loser = bucket[loser_entry_hash]
+                receipt = self.append(
+                    kind="supersede",
+                    tracker=key[0],
+                    ticket_id=key[1],
+                    role=key[2],
+                    claimer_id=loser.claimer_id,
+                    node_id=loser.node_id,
+                    lease_expires_at=0.0,
+                    ts_ns=cursor_ts,
+                    supersedes=loser_entry_hash,
+                    winner_claimer_id=winner.claimer_id,
+                    winner_entry_hash=winner_entry_hash,
+                )
+                emitted.append(receipt)
+                explicit_superseded.add(loser_entry_hash)
+                cursor_ts += 1
+        return emitted
+
+    # -- verify -------------------------------------------------------
+
+    def verify(self, *, trusted_keys: Mapping[str, dict[str, Any]] | None = None) -> ClaimJournalVerifyResult:
+        """Replay the journal offline, checking chain links and signatures.
+
+        Walks every receipt confirming the ``prev_entry_hash`` linkage, the
+        recomputed ``entry_hash`` (tamper detection), and the Ed25519 node
+        signature. A single flipped byte or an inserted / dropped receipt fails
+        at the exact entry index. ``trusted_keys`` optionally pins each node's
+        public-key JWK by ``node_id``; when omitted the embedded key is trusted
+        on first use (the signature still authenticates the bytes against *a*
+        key, catching an unsigned tamper).
+        """
+        if not self.path.exists():
+            return ClaimJournalVerifyResult(ok=True, entry_count=0)
+
+        prev_hash = GENESIS_PREV_HASH
+        ordinal = 0
+        with self.path.open("rb") as fp:
+            for raw in fp:
+                stripped = raw.strip()
+                if not stripped:
+                    continue
+                try:
+                    payload = json.loads(stripped.decode("utf-8"))
+                    receipt = ClaimReceipt.from_dict(payload)
+                except (ValueError, KeyError, json.JSONDecodeError) as exc:
+                    return ClaimJournalVerifyResult(
+                        ok=False,
+                        entry_count=ordinal,
+                        bad_index=ordinal,
+                        failures=[f"entry {ordinal}: schema invalid ({exc})"],
+                    )
+                if receipt.prev_entry_hash != prev_hash:
+                    return ClaimJournalVerifyResult(
+                        ok=False,
+                        entry_count=ordinal,
+                        bad_index=ordinal,
+                        failures=[
+                            f"entry {ordinal}: prev_entry_hash mismatch "
+                            f"(expected {prev_hash}, got {receipt.prev_entry_hash})",
+                        ],
+                    )
+                if compute_claim_entry_hash(receipt) != receipt.entry_hash:
+                    return ClaimJournalVerifyResult(
+                        ok=False,
+                        entry_count=ordinal,
+                        bad_index=ordinal,
+                        failures=[f"entry {ordinal}: entry_hash mismatch (tampered payload)"],
+                    )
+                trusted = None if trusted_keys is None else trusted_keys.get(receipt.node_id)
+                sig_check = verify_head_signature(
+                    receipt.entry_hash.split(":", 1)[1],
+                    receipt.signature,
+                    trusted_public_key_jwk=trusted,
+                )
+                if not sig_check.ok:
+                    return ClaimJournalVerifyResult(
+                        ok=False,
+                        entry_count=ordinal,
+                        bad_index=ordinal,
+                        failures=[f"entry {ordinal}: signature failure ({'; '.join(sig_check.errors)})"],
+                    )
+                prev_hash = receipt.entry_hash
+                ordinal += 1
+        return ClaimJournalVerifyResult(ok=True, entry_count=ordinal)
+
+    # -- internals ----------------------------------------------------
+
+    def _tail_hash(self) -> str:
+        """Return the ``entry_hash`` of the last receipt, or genesis."""
+        if not self.path.exists() or self.path.stat().st_size == 0:
+            return GENESIS_PREV_HASH
+        last_hash = GENESIS_PREV_HASH
+        with self.path.open("rb") as fp:
+            for raw in fp:
+                stripped = raw.strip()
+                if not stripped:
+                    continue
+                last_hash = json.loads(stripped.decode("utf-8"))["entry_hash"]
+        return last_hash
 
 
 # ---------------------------------------------------------------------------
@@ -1250,6 +1845,15 @@ def default_ledger_path(state_root: Path) -> Path:
     Typically ``state_root`` is the project's ``.sdd/`` directory.
     """
     return state_root / DEFAULT_LEDGER_RELPATH
+
+
+def default_claim_journal_path(state_root: Path) -> Path:
+    """Return the conventional MESH claim-journal path under ``state_root``.
+
+    Typically ``state_root`` is the project's ``.sdd/`` directory. Only the
+    leaderless MESH path materialises this file; STAR deployments never do.
+    """
+    return state_root / DEFAULT_CLAIM_JOURNAL_RELPATH
 
 
 def build_pipeline_from_yaml(

--- a/src/bernstein/core/orchestration/tracker_pipeline.py
+++ b/src/bernstein/core/orchestration/tracker_pipeline.py
@@ -154,11 +154,16 @@ leaderless MESH path (issue #2558) constructs a :class:`ClaimJournal` and
 threads it into :class:`ClaimLedger`.
 """
 
-CLAIM_JOURNAL_SCHEMA_VERSION: Final[int] = 1
+CLAIM_JOURNAL_SCHEMA_VERSION: Final[int] = 2
 """On-disk schema version stamped into every :class:`ClaimReceipt`.
 
 Bumping requires a parallel reader for the old version, mirroring the
 tracker-audit stream's versioning contract.
+
+v2 adds the ``superseded_node_id`` / ``superseded_claimer_id`` reference
+fields so a ``supersede`` receipt records the loser's identity as data it
+speaks *about* while its own ``node_id`` / ``claimer_id`` name the
+reconciling node that signs it (issue #2558).
 """
 
 CLAIM_RECEIPT_KINDS: Final[frozenset[str]] = frozenset(
@@ -932,9 +937,18 @@ class ClaimReceipt:
     state across nodes.
 
     The core binding is ``{tracker, ticket_id, role, claimer_id, node_id,
-    lease_expires_at, prev_entry_hash, entry_hash}``. A ``supersede`` receipt
-    additionally names the losing claim (``supersedes``) and the winner
-    (``winner_claimer_id`` / ``winner_entry_hash``).
+    lease_expires_at, prev_entry_hash, entry_hash}``. The ``claimer_id`` /
+    ``node_id`` fields are the receipt's own identity -- *who the receipt is
+    from* -- and they always name the node whose Ed25519 install key signs it.
+    A ``supersede`` receipt is a statement *by* the reconciling node *about* a
+    losing claim, so it is attributed to the reconciler: its ``claimer_id`` /
+    ``node_id`` name the reconciler, and the loser is carried as *referenced
+    data* -- the losing claim's ``entry_hash`` (``supersedes``) plus the
+    loser's identity (``superseded_node_id`` / ``superseded_claimer_id``) --
+    alongside the winner (``winner_claimer_id`` / ``winner_entry_hash``). This
+    keeps the signature and the declared identity in agreement: a verifier that
+    pins each node's public key by ``node_id`` finds every receipt signed by the
+    node it claims to be from.
     """
 
     schema_version: int
@@ -952,6 +966,8 @@ class ClaimReceipt:
     supersedes: str | None = None
     winner_claimer_id: str | None = None
     winner_entry_hash: str | None = None
+    superseded_node_id: str | None = None
+    superseded_claimer_id: str | None = None
 
     def __post_init__(self) -> None:
         if self.kind not in CLAIM_RECEIPT_KINDS:
@@ -984,6 +1000,8 @@ class ClaimReceipt:
         supersedes = data.get("supersedes")
         winner_claimer_id = data.get("winner_claimer_id")
         winner_entry_hash = data.get("winner_entry_hash")
+        superseded_node_id = data.get("superseded_node_id")
+        superseded_claimer_id = data.get("superseded_claimer_id")
         return cls(
             schema_version=int(data["schema_version"]),
             kind=str(data["kind"]),
@@ -1000,6 +1018,8 @@ class ClaimReceipt:
             supersedes=None if supersedes is None else str(supersedes),
             winner_claimer_id=None if winner_claimer_id is None else str(winner_claimer_id),
             winner_entry_hash=None if winner_entry_hash is None else str(winner_entry_hash),
+            superseded_node_id=None if superseded_node_id is None else str(superseded_node_id),
+            superseded_claimer_id=(None if superseded_claimer_id is None else str(superseded_claimer_id)),
         )
 
 
@@ -1224,6 +1244,8 @@ class ClaimJournal:
         supersedes: str | None = None,
         winner_claimer_id: str | None = None,
         winner_entry_hash: str | None = None,
+        superseded_node_id: str | None = None,
+        superseded_claimer_id: str | None = None,
     ) -> ClaimReceipt:
         """Append one signed receipt and return the materialised entry.
 
@@ -1264,6 +1286,8 @@ class ClaimJournal:
                     supersedes=supersedes,
                     winner_claimer_id=winner_claimer_id,
                     winner_entry_hash=winner_entry_hash,
+                    superseded_node_id=superseded_node_id,
+                    superseded_claimer_id=superseded_claimer_id,
                 )
                 digest = compute_claim_entry_hash(unsigned)
                 signed = replace(unsigned, entry_hash=digest)
@@ -1300,6 +1324,8 @@ class ClaimJournal:
             supersedes=receipt.supersedes,
             winner_claimer_id=receipt.winner_claimer_id,
             winner_entry_hash=receipt.winner_entry_hash,
+            superseded_node_id=receipt.superseded_node_id,
+            superseded_claimer_id=receipt.superseded_claimer_id,
         )
 
     # -- read ---------------------------------------------------------
@@ -1337,6 +1363,13 @@ class ClaimJournal:
         winner (lowest ``entry_hash``) for every loser that does not already
         hold one. Returns the receipts appended, in a deterministic order.
         Idempotent: re-running once every loser is superseded is a no-op.
+
+        The receipt is attributed to *this* reconciling node -- its
+        ``claimer_id`` / ``node_id`` name this node, the one whose install key
+        signs the entry -- so the signature and the declared identity agree. The
+        losing claim it speaks about is carried as referenced data: the loser's
+        ``entry_hash`` (``supersedes``) and identity (``superseded_node_id`` /
+        ``superseded_claimer_id``), never the receipt's own identity fields.
         """
         active, explicit_superseded = _active_buckets(self.read())
         emitted: list[ClaimReceipt] = []
@@ -1356,13 +1389,15 @@ class ClaimJournal:
                     tracker=key[0],
                     ticket_id=key[1],
                     role=key[2],
-                    claimer_id=loser.claimer_id,
-                    node_id=loser.node_id,
+                    claimer_id=self._node_id,
+                    node_id=self._node_id,
                     lease_expires_at=0.0,
                     ts_ns=cursor_ts,
                     supersedes=loser_entry_hash,
                     winner_claimer_id=winner.claimer_id,
                     winner_entry_hash=winner_entry_hash,
+                    superseded_node_id=loser.node_id,
+                    superseded_claimer_id=loser.claimer_id,
                 )
                 emitted.append(receipt)
                 explicit_superseded.add(loser_entry_hash)

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -733,6 +733,21 @@ EVENT_MISSION_PHASE_RECEIPT = "mission.phase_receipt"
 #: payloads.
 EVENT_MISSION_DIGEST_RECEIPT = "mission.digest_receipt"
 
+#: Issue #2558 -- emitted once per receipt appended to a leaderless MESH claim
+#: journal (see :class:`bernstein.core.orchestration.tracker_pipeline.ClaimJournal`).
+#: A MESH claim journal is a signed, append-only, Merkle-chained log of every
+#: self-claim, release, renewal, expiry, and supersession; the SQLite
+#: ``ClaimLedger`` is a deterministic projection (fold) of it rather than the
+#: source of truth. This event mirrors ``{kind, tracker, ticket_id, role,
+#: claimer_id, node_id, lease_expires_at, prev_entry_hash, journal_entry_hash,
+#: supersedes, winner_claimer_id, winner_entry_hash}`` into the HMAC chain so a
+#: claim decision -- including a deterministic ``supersede`` naming the winner of
+#: a concurrent double-claim -- is provable offline from the chain alone. The
+#: receipt binding lives in the journal; the projection derives claim state from
+#: receipts only, so a claim without a receipt is by definition not held. Only
+#: identifiers and hashes are recorded -- never ticket or workspace contents.
+EVENT_CLAIM_JOURNAL_RECEIPT = "cluster.claim_journal_receipt"
+
 #: Issue #2549 -- emitted whenever a per-goal SLA contract is evaluated against
 #: chain evidence inside a supervisor tick and found breached. A breach is a
 #: signed, offline-verifiable violation receipt (see
@@ -3608,6 +3623,86 @@ def record_task_claim_receipt(
             "task_version": task_version,
             "claim_path": claim_path,
         },
+    )
+
+
+def record_claim_journal_receipt(
+    *,
+    chain: AuditChainStore,
+    kind: str,
+    tracker: str,
+    ticket_id: str,
+    role: str,
+    claimer_id: str,
+    node_id: str,
+    lease_expires_at: float,
+    prev_entry_hash: str,
+    journal_entry_hash: str,
+    supersedes: str | None = None,
+    winner_claimer_id: str | None = None,
+    winner_entry_hash: str | None = None,
+    actor: str = "claim_journal",
+) -> AuditEvent:
+    """Append a ``cluster.claim_journal_receipt`` event into *chain* (#2558).
+
+    Mirrors one leaderless-MESH claim-journal receipt into the HMAC-chained
+    audit log so an operator can prove, from the chain alone, that a self-claim
+    (or its release / renewal / expiry / supersession) was recorded with the
+    exact identity, lease, and chain position claimed -- without trusting any
+    single node. ``journal_entry_hash`` is the receipt's Merkle ``entry_hash``;
+    a verifier holding the journal recomputes it byte-identically and confirms
+    the anchor. For a ``supersede`` receipt the ``winner_*`` fields name the
+    concurrent claim that won by the deterministic lowest-``entry_hash`` rule.
+    Only identifiers and hashes are recorded -- never ticket or workspace
+    contents.
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        kind: The receipt kind (``claim`` / ``release`` / ``renew`` /
+            ``expire`` / ``supersede``).
+        tracker: Tracker adapter name the claim is scoped to.
+        ticket_id: Tracker-side ticket id.
+        role: Bernstein role lane the claim covers.
+        claimer_id: The claiming worker's identifier (the loser, for a
+            ``supersede`` receipt).
+        node_id: The node install identity the receipt pertains to.
+        lease_expires_at: Unix timestamp the lease expires (``0`` when none).
+        prev_entry_hash: The journal head the receipt chained onto.
+        journal_entry_hash: The receipt's own Merkle ``entry_hash`` (the anchor).
+        supersedes: For a ``supersede`` receipt, the losing claim's
+            ``entry_hash``; ``None`` otherwise.
+        winner_claimer_id: For a ``supersede`` receipt, the winning claimer.
+        winner_entry_hash: For a ``supersede`` receipt, the winning claim's
+            ``entry_hash``.
+        actor: Recorded actor; defaults to ``"claim_journal"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded
+        in its details payload.
+    """
+    details: dict[str, Any] = {
+        "kind": kind,
+        "tracker": tracker,
+        "ticket_id": ticket_id,
+        "role": role,
+        "claimer_id": claimer_id,
+        "node_id": node_id,
+        "lease_expires_at": lease_expires_at,
+        "prev_entry_hash": prev_entry_hash,
+        "journal_entry_hash": journal_entry_hash,
+    }
+    if supersedes is not None:
+        details["supersedes"] = supersedes
+    if winner_claimer_id is not None:
+        details["winner_claimer_id"] = winner_claimer_id
+    if winner_entry_hash is not None:
+        details["winner_entry_hash"] = winner_entry_hash
+    return chain.log_with_prev_digest(
+        event_type=EVENT_CLAIM_JOURNAL_RECEIPT,
+        actor=actor,
+        resource_type="claim_journal_receipt",
+        resource_id=f"{tracker}:{ticket_id}:{role}",
+        details=details,
     )
 
 
@@ -6883,6 +6978,7 @@ __all__ = [
     "EVENT_CACHE_HIT",
     "EVENT_CACHE_MISS",
     "EVENT_CHECKPOINT_RETRY",
+    "EVENT_CLAIM_JOURNAL_RECEIPT",
     "EVENT_COMPACTION_RECEIPT",
     "EVENT_COMPACTION_SENSITIVE_GATE",
     "EVENT_COMPUTER_USE_ACTION",
@@ -7004,6 +7100,7 @@ __all__ = [
     "record_cache_hit",
     "record_cache_miss",
     "record_checkpoint_retry",
+    "record_claim_journal_receipt",
     "record_computer_use_action",
     "record_context_capsule",
     "record_cost_batch_route",

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -3641,6 +3641,8 @@ def record_claim_journal_receipt(
     supersedes: str | None = None,
     winner_claimer_id: str | None = None,
     winner_entry_hash: str | None = None,
+    superseded_node_id: str | None = None,
+    superseded_claimer_id: str | None = None,
     actor: str = "claim_journal",
 ) -> AuditEvent:
     """Append a ``cluster.claim_journal_receipt`` event into *chain* (#2558).
@@ -3663,9 +3665,13 @@ def record_claim_journal_receipt(
         tracker: Tracker adapter name the claim is scoped to.
         ticket_id: Tracker-side ticket id.
         role: Bernstein role lane the claim covers.
-        claimer_id: The claiming worker's identifier (the loser, for a
-            ``supersede`` receipt).
-        node_id: The node install identity the receipt pertains to.
+        claimer_id: The receipt's own claimer identity -- who the receipt is
+            *from*. For a ``supersede`` receipt this is the reconciling node
+            that emitted and signed it, not the loser (the loser is carried in
+            ``superseded_claimer_id`` as referenced data).
+        node_id: The node install identity the receipt is *from* -- the node
+            whose Ed25519 key signs it. For a ``supersede`` receipt this is the
+            reconciling node, not the superseded claim's node.
         lease_expires_at: Unix timestamp the lease expires (``0`` when none).
         prev_entry_hash: The journal head the receipt chained onto.
         journal_entry_hash: The receipt's own Merkle ``entry_hash`` (the anchor).
@@ -3674,6 +3680,11 @@ def record_claim_journal_receipt(
         winner_claimer_id: For a ``supersede`` receipt, the winning claimer.
         winner_entry_hash: For a ``supersede`` receipt, the winning claim's
             ``entry_hash``.
+        superseded_node_id: For a ``supersede`` receipt, the losing claim's
+            node identity, carried as referenced data (what the receipt is
+            *about*); ``None`` otherwise.
+        superseded_claimer_id: For a ``supersede`` receipt, the losing claim's
+            claimer identity, carried as referenced data; ``None`` otherwise.
         actor: Recorded actor; defaults to ``"claim_journal"``.
 
     Returns:
@@ -3697,6 +3708,10 @@ def record_claim_journal_receipt(
         details["winner_claimer_id"] = winner_claimer_id
     if winner_entry_hash is not None:
         details["winner_entry_hash"] = winner_entry_hash
+    if superseded_node_id is not None:
+        details["superseded_node_id"] = superseded_node_id
+    if superseded_claimer_id is not None:
+        details["superseded_claimer_id"] = superseded_claimer_id
     return chain.log_with_prev_digest(
         event_type=EVENT_CLAIM_JOURNAL_RECEIPT,
         actor=actor,

--- a/tests/unit/orchestration/test_claim_journal.py
+++ b/tests/unit/orchestration/test_claim_journal.py
@@ -21,11 +21,19 @@ fails verification at the exact entry index.
 
 from __future__ import annotations
 
+import threading
+import time
+from dataclasses import asdict, replace
 from typing import TYPE_CHECKING
 
 import pytest
 
+from bernstein.core.lineage.tracker_audit import (
+    GENESIS_PREV_HASH,
+    _canonical_bytes,
+)
 from bernstein.core.orchestration.tracker_pipeline import (
+    CLAIM_JOURNAL_SCHEMA_VERSION,
     CLAIM_RECEIPT_KINDS,
     ClaimJournal,
     ClaimLedger,
@@ -38,6 +46,7 @@ from bernstein.core.security.audit_chain import (
     EVENT_CLAIM_JOURNAL_RECEIPT,
     AuditChainStore,
 )
+from bernstein.core.security.audit_head_signature import build_head_signature
 from bernstein.core.security.lineage_kms import FileBasedKMSAdapter
 
 if TYPE_CHECKING:
@@ -385,6 +394,213 @@ def test_reconcile_is_noop_without_conflict(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Concurrent multi-writer safety on a shared journal (the phase 1-2 target)
+# ---------------------------------------------------------------------------
+
+
+def _shared_journal(tmp_path: Path, *, node_id: str, seed: int, chain: AuditChainStore | None = None) -> ClaimJournal:
+    """A journal for ``node_id`` bound to the single shared ``shared.jsonl``."""
+    return ClaimJournal(
+        tmp_path / "shared.jsonl",
+        kms_adapter=_kms(tmp_path, seed=seed, name=f"{node_id}-key"),
+        node_id=node_id,
+        chain=chain,
+    )
+
+
+def test_concurrent_shared_journal_appends_stay_linear(tmp_path: Path) -> None:
+    """Two nodes appending to one shared journal never fork the chain.
+
+    Two :class:`ClaimJournal` instances (distinct install identities, own
+    process-local locks) hammer the same on-disk file from two threads,
+    released together by a barrier so their appends genuinely overlap -- the
+    literal shared-filesystem multi-writer shape phase 1-2 targets. The
+    read-modify-write of ``prev_entry_hash`` must be serialised by the
+    exclusive file lock; if the tail were read outside that lock both writers
+    could link to the same predecessor and fork the linear chain, which
+    offline :meth:`ClaimJournal.verify` cannot tell apart from tampering.
+    """
+    journal_a = _shared_journal(tmp_path, node_id="node-a", seed=1)
+    journal_b = _shared_journal(tmp_path, node_id="node-b", seed=2)
+
+    rounds = 24
+    barrier = threading.Barrier(2)
+
+    def hammer(journal: ClaimJournal, worker: str, base_ticket: int) -> None:
+        for i in range(rounds):
+            barrier.wait()
+            journal.append(
+                kind="claim",
+                tracker="jira",
+                ticket_id=f"T-{base_ticket + i}",
+                role="backend",
+                claimer_id=worker,
+                lease_expires_at=1600.0,
+                ts_ns=1_000_000_000 + i,
+            )
+
+    ta = threading.Thread(target=hammer, args=(journal_a, "worker-a", 0))
+    tb = threading.Thread(target=hammer, args=(journal_b, "worker-b", 1000))
+    ta.start()
+    tb.start()
+    ta.join()
+    tb.join()
+
+    # No fork: every receipt sits on one linear, offline-verifiable chain.
+    result = journal_a.verify()
+    assert result.ok, result.failures
+    assert result.entry_count == 2 * rounds
+
+
+def test_two_nodes_concurrently_claim_same_key_converge(tmp_path: Path) -> None:
+    """Issue criterion 3: two nodes *concurrently* self-claim one key.
+
+    Both nodes race an honest claim for the same ``(tracker, ticket_id,
+    role)`` against the shared journal at the same instant. The chain must
+    stay linear (both claims land, neither forks), the deterministic fold
+    must already resolve a single winner, and ``reconcile`` must emit exactly
+    one chain-anchored ``supersede`` naming that winner.
+    """
+    chain = _chain(tmp_path)
+    journal_a = _shared_journal(tmp_path, node_id="node-a", seed=1, chain=chain)
+    journal_b = _shared_journal(tmp_path, node_id="node-b", seed=2, chain=chain)
+
+    barrier = threading.Barrier(2)
+    minted: dict[str, ClaimReceipt] = {}
+
+    def claim(journal: ClaimJournal, worker: str) -> None:
+        barrier.wait()
+        minted[worker] = journal.append(
+            kind="claim",
+            tracker="jira",
+            ticket_id="T-1",
+            role="backend",
+            claimer_id=worker,
+            lease_expires_at=1600.0,
+            ts_ns=1_000_000_000,
+        )
+
+    ta = threading.Thread(target=claim, args=(journal_a, "worker-a"))
+    tb = threading.Thread(target=claim, args=(journal_b, "worker-b"))
+    ta.start()
+    tb.start()
+    ta.join()
+    tb.join()
+
+    result = journal_a.verify()
+    assert result.ok, result.failures
+    assert result.entry_count == 2
+
+    winner = min(minted.values(), key=lambda r: r.entry_hash)
+    loser = max(minted.values(), key=lambda r: r.entry_hash)
+
+    pre = journal_a.project()
+    hold = pre.holder("jira", "T-1", "backend")
+    assert hold is not None and hold.entry_hash == winner.entry_hash
+    assert loser.entry_hash in pre.superseded
+
+    supersedes = journal_a.reconcile(ts_ns=2_000_000_000)
+    assert len(supersedes) == 1
+    assert supersedes[0].supersedes == loser.entry_hash
+    assert supersedes[0].winner_entry_hash == winner.entry_hash
+    # Convergence survives the extra supersede receipt and stays linear.
+    assert journal_a.verify().ok
+    post = journal_a.project().holder("jira", "T-1", "backend")
+    assert post is not None and post.claimer_id == winner.claimer_id
+
+
+def test_append_resolves_tail_under_the_write_lock(tmp_path: Path) -> None:
+    """The tail read and the byte-append are one lock-guarded critical section.
+
+    Deterministic proof (no scheduling luck): while another writer holds the
+    exclusive lock and commits a fresh entry before releasing, a concurrent
+    append must observe that new entry as its predecessor. If ``append`` read
+    the tail *before* taking the lock it would link to the stale tail and fork
+    the chain. We gate the interleaving with the file lock itself.
+    """
+    fcntl = pytest.importorskip("fcntl")
+
+    journal_a = _shared_journal(tmp_path, node_id="node-a", seed=1)
+    journal_b = _shared_journal(tmp_path, node_id="node-b", seed=2)
+
+    # One committed entry so the tail is a real hash, not genesis.
+    r1 = journal_a.append(
+        kind="claim",
+        tracker="jira",
+        ticket_id="T-1",
+        role="backend",
+        claimer_id="worker-a",
+        lease_expires_at=1600.0,
+        ts_ns=1_000_000_000,
+    )
+
+    started = threading.Event()
+    done = threading.Event()
+    captured: dict[str, ClaimReceipt] = {}
+
+    def append_b() -> None:
+        started.set()
+        captured["b"] = journal_b.append(
+            kind="claim",
+            tracker="jira",
+            ticket_id="T-2",
+            role="backend",
+            claimer_id="worker-b",
+            lease_expires_at=1700.0,
+            ts_ns=1_002_000_000,
+        )
+        done.set()
+
+    holder = (tmp_path / "shared.jsonl").open("a+b")
+    try:
+        fcntl.flock(holder.fileno(), fcntl.LOCK_EX)
+        thread = threading.Thread(target=append_b)
+        thread.start()
+        started.wait(timeout=2.0)
+        # Give B time to reach the lock; a correct append is now blocked
+        # *before* reading the tail, a buggy one has already read tail == r1.
+        time.sleep(0.25)
+
+        # A third node commits an entry (r_mid) while we hold the lock, moving
+        # the true tail forward. Build it with the production helpers so it is a
+        # fully valid, signed, chain-linked receipt.
+        kms_c = _kms(tmp_path, seed=3, name="node-c-key")
+        unsigned = ClaimReceipt(
+            schema_version=CLAIM_JOURNAL_SCHEMA_VERSION,
+            kind="claim",
+            ts_ns=1_001_000_000,
+            tracker="jira",
+            ticket_id="T-9",
+            role="backend",
+            claimer_id="worker-c",
+            node_id="node-c",
+            lease_expires_at=1650.0,
+            prev_entry_hash=r1.entry_hash,
+            entry_hash=GENESIS_PREV_HASH,
+            signature={},
+        )
+        digest = compute_claim_entry_hash(unsigned)
+        signed = replace(unsigned, entry_hash=digest)
+        signature = build_head_signature(digest.split(":", 1)[1], kms_adapter=kms_c)
+        r_mid = replace(signed, signature=signature)
+        holder.write(_canonical_bytes(asdict(r_mid)) + b"\n")
+        holder.flush()
+
+        assert not done.wait(timeout=0.2)  # B is still blocked on the lock
+        fcntl.flock(holder.fileno(), fcntl.LOCK_UN)
+    finally:
+        holder.close()
+
+    assert done.wait(timeout=3.0)
+    thread.join(timeout=3.0)
+
+    # B linked to r_mid (the tail it saw *under* the lock), not the stale r1.
+    assert captured["b"].prev_entry_hash == r_mid.entry_hash
+    # The whole chain -- r1 -> r_mid -> r_b -- stays linear and verifiable.
+    assert journal_a.verify().ok
+
+
+# ---------------------------------------------------------------------------
 # Verifiability / tamper-evidence (offline replay)
 # ---------------------------------------------------------------------------
 
@@ -532,6 +748,60 @@ def test_ledger_journal_replay_is_deterministic(tmp_path: Path) -> None:
     # receipt, entry_hash, and signature.
     assert r1.to_dict() == r2.to_dict()
     assert r1.entry_hash == r2.entry_hash
+
+
+def test_journal_is_source_of_truth_no_receiptless_claim(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A grant that cannot mint a receipt must not leave a held SQLite row.
+
+    The journal is the source of truth and the ledger is its projection: a
+    committed claim row with no backing receipt is a phantom holder the fold
+    can never explain. When the receipt append fails (disk / signing error),
+    ``try_claim`` must roll the SQLite transaction back so the claim is *not*
+    held -- caller-sees-failure and ledger-does-not-hold must agree.
+    """
+    chain = _chain(tmp_path)
+    journal = _journal(tmp_path, chain=chain)
+    ledger = ClaimLedger(tmp_path / "claims.db", journal=journal)
+
+    def boom(*_args: object, **_kwargs: object) -> ClaimReceipt:
+        raise RuntimeError("disk full while signing the claim receipt")
+
+    monkeypatch.setattr(journal, "append", boom)
+    with pytest.raises(RuntimeError, match="disk full"):
+        ledger.try_claim(
+            tracker="jira",
+            ticket_id="T-1",
+            role="backend",
+            claimer_id="worker-a",
+            ttl_seconds=600,
+            per_role_max_in_flight=1,
+            now=1000.0,
+        )
+
+    # No phantom: the ledger holds nothing and no receipt was recorded.
+    assert ledger.live_claims(now=1000.0) == []
+    assert journal.read() == []
+    assert chain.query(event_type=EVENT_CLAIM_JOURNAL_RECEIPT) == []
+
+    # The rollback left the connection usable: an honest claim still lands, and
+    # now the row is backed by exactly one receipt (materialised from it).
+    monkeypatch.undo()
+    outcome = ledger.try_claim(
+        tracker="jira",
+        ticket_id="T-1",
+        role="backend",
+        claimer_id="worker-a",
+        ttl_seconds=600,
+        per_role_max_in_flight=1,
+        now=1000.0,
+    )
+    assert outcome.granted
+    receipts = journal.read()
+    assert len(receipts) == 1
+    live = ledger.live_claims(now=1000.0)
+    assert len(live) == 1
+    assert live[0]["claimer_id"] == receipts[0].claimer_id == "worker-a"
+    assert receipts[0].lease_expires_at == outcome.lease_expires_at
 
 
 def test_reject_unknown_receipt_kind(tmp_path: Path) -> None:

--- a/tests/unit/orchestration/test_claim_journal.py
+++ b/tests/unit/orchestration/test_claim_journal.py
@@ -1,0 +1,548 @@
+"""Unit tests for the signed, Merkle-chained claim journal (issue #2558).
+
+Phases 1-2 of leaderless MESH cluster mode land a signed, append-only
+claim journal beside the SQLite :class:`ClaimLedger`, plus a pure fold
+``project_claims`` that turns an ordered set of receipts into a
+:class:`ClaimState`. The tests below assert the two binding criteria from
+the issue:
+
+* **Determinism** -- two independently instantiated nodes given the same
+  ordered receipt set produce a byte-identical projected ``ClaimState``
+  and an identical journal head hash (serialise both and byte-compare).
+* **Leaderless convergence** -- two nodes concurrently self-claiming the
+  same ``(tracker, ticket_id, role)`` converge on exactly one holder by
+  the deterministic lowest-``entry_hash`` rule, and the loser holds a
+  chain-anchored ``claim_superseded`` receipt naming the winner.
+
+The verifiability / tamper-evidence path (offline replay checking every
+chain link and Ed25519 signature) is exercised too: a single flipped byte
+fails verification at the exact entry index.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bernstein.core.orchestration.tracker_pipeline import (
+    CLAIM_RECEIPT_KINDS,
+    ClaimJournal,
+    ClaimLedger,
+    ClaimReceipt,
+    ClaimState,
+    compute_claim_entry_hash,
+    project_claims,
+)
+from bernstein.core.security.audit_chain import (
+    EVENT_CLAIM_JOURNAL_RECEIPT,
+    AuditChainStore,
+)
+from bernstein.core.security.lineage_kms import FileBasedKMSAdapter
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_HMAC_KEY = b"0" * 32
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _kms(tmp_path: Path, *, seed: int, name: str) -> FileBasedKMSAdapter:
+    """Return a deterministic file-backed Ed25519 signer for one node.
+
+    A distinct ``seed`` models a distinct node install identity, so two
+    nodes sign the same receipt bytes with different keys -- exactly the
+    leaderless shape.
+    """
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    key_path = tmp_path / f"{name}.pem"
+    if not key_path.exists():
+        private_key = Ed25519PrivateKey.from_private_bytes(bytes([seed]) * 32)
+        key_path.write_bytes(
+            private_key.private_bytes(
+                serialization.Encoding.PEM,
+                serialization.PrivateFormat.PKCS8,
+                serialization.NoEncryption(),
+            )
+        )
+    return FileBasedKMSAdapter(key_path, kid=name)
+
+
+def _chain(tmp_path: Path) -> AuditChainStore:
+    return AuditChainStore(tmp_path / "audit", key=_HMAC_KEY)
+
+
+def _journal(
+    tmp_path: Path,
+    *,
+    path_name: str = "claim_journal.jsonl",
+    node_id: str = "node-a",
+    seed: int = 1,
+    chain: AuditChainStore | None = None,
+) -> ClaimJournal:
+    return ClaimJournal(
+        tmp_path / path_name,
+        kms_adapter=_kms(tmp_path, seed=seed, name=f"{node_id}-key"),
+        node_id=node_id,
+        chain=chain,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Receipt hashing
+# ---------------------------------------------------------------------------
+
+
+def test_entry_hash_excludes_signature(tmp_path: Path) -> None:
+    """The chain hash must be signature-independent.
+
+    Two nodes signing the same receipt body with different keys must
+    compute the same ``entry_hash`` -- otherwise the journal head would
+    depend on who signed, breaking the byte-identical-fold guarantee.
+    """
+    journal_a = _journal(tmp_path, node_id="node-a", seed=1)
+    receipt = journal_a.append(
+        kind="claim",
+        tracker="jira",
+        ticket_id="T-1",
+        role="backend",
+        claimer_id="worker-a",
+        lease_expires_at=1600.0,
+        ts_ns=1_000_000_000,
+    )
+    # Recompute over the same body with the signature blanked.
+    assert compute_claim_entry_hash(receipt) == receipt.entry_hash
+    # A receipt with an identical body but a foreign signature block still
+    # hashes to the same entry_hash.
+    from dataclasses import replace
+
+    forged_sig = replace(receipt, signature={"alg": "EdDSA", "signature_b64": "AAAA"})
+    assert compute_claim_entry_hash(forged_sig) == receipt.entry_hash
+
+
+def test_append_chains_prev_entry_hash(tmp_path: Path) -> None:
+    """Each receipt links its predecessor; the head advances."""
+    journal = _journal(tmp_path)
+    r1 = journal.append(
+        kind="claim",
+        tracker="jira",
+        ticket_id="T-1",
+        role="backend",
+        claimer_id="worker-a",
+        lease_expires_at=1600.0,
+        ts_ns=1_000_000_000,
+    )
+    r2 = journal.append(
+        kind="release",
+        tracker="jira",
+        ticket_id="T-1",
+        role="backend",
+        claimer_id="worker-a",
+        lease_expires_at=0.0,
+        ts_ns=1_001_000_000,
+    )
+    assert r1.prev_entry_hash.startswith("sha256:")
+    assert r2.prev_entry_hash == r1.entry_hash
+    assert journal.head() == r2.entry_hash
+    assert set(CLAIM_RECEIPT_KINDS) == {"claim", "release", "renew", "expire", "supersede"}
+
+
+def test_signature_verifies_and_tamper_fails(tmp_path: Path) -> None:
+    """The Ed25519 node signature authenticates the receipt binding."""
+    journal = _journal(tmp_path, node_id="node-a", seed=7)
+    receipt = journal.append(
+        kind="claim",
+        tracker="jira",
+        ticket_id="T-1",
+        role="backend",
+        claimer_id="worker-a",
+        lease_expires_at=1600.0,
+        ts_ns=1_000_000_000,
+    )
+    assert journal.verify().ok
+
+    from dataclasses import replace
+
+    # Flip the claimer without re-signing: entry_hash no longer matches.
+    tampered = replace(receipt, claimer_id="worker-evil")
+    assert compute_claim_entry_hash(tampered) != receipt.entry_hash
+
+
+# ---------------------------------------------------------------------------
+# Determinism (byte-identical fold) -- the heart
+# ---------------------------------------------------------------------------
+
+
+def test_project_claims_is_byte_identical_across_nodes(tmp_path: Path) -> None:
+    """Two nodes folding the same ordered receipts agree byte-for-byte."""
+    journal = _journal(tmp_path)
+    journal.append(
+        kind="claim",
+        tracker="jira",
+        ticket_id="T-1",
+        role="backend",
+        claimer_id="worker-a",
+        lease_expires_at=1600.0,
+        ts_ns=1_000_000_000,
+    )
+    journal.append(
+        kind="claim",
+        tracker="jira",
+        ticket_id="T-2",
+        role="qa",
+        claimer_id="worker-b",
+        lease_expires_at=1700.0,
+        ts_ns=1_001_000_000,
+    )
+    journal.append(
+        kind="release",
+        tracker="jira",
+        ticket_id="T-1",
+        role="backend",
+        claimer_id="worker-a",
+        lease_expires_at=0.0,
+        ts_ns=1_002_000_000,
+    )
+    journal.append(
+        kind="claim",
+        tracker="jira",
+        ticket_id="T-1",
+        role="backend",
+        claimer_id="worker-c",
+        lease_expires_at=1800.0,
+        ts_ns=1_003_000_000,
+    )
+
+    # Node 1 reads the receipts; node 2 receives them over the wire (JSON
+    # round-trip) and reparses -- modelling a gossiped receipt set.
+    receipts_node1 = journal.read()
+    receipts_node2 = [ClaimReceipt.from_dict(r.to_dict()) for r in receipts_node1]
+
+    state1 = project_claims(receipts_node1)
+    state2 = project_claims(receipts_node2)
+
+    # Literal byte-comparison of the canonical serialisation.
+    assert state1.canonical_bytes() == state2.canonical_bytes()
+    assert state1.head == state2.head
+
+    # T-1 ended up with worker-c (T-1's first claim was released), T-2 with
+    # worker-b.
+    hold_t1 = state1.holder("jira", "T-1", "backend")
+    hold_t2 = state1.holder("jira", "T-2", "qa")
+    assert hold_t1 is not None and hold_t1.claimer_id == "worker-c"
+    assert hold_t2 is not None and hold_t2.claimer_id == "worker-b"
+
+
+def test_empty_fold_is_genesis(tmp_path: Path) -> None:
+    state = project_claims([])
+    assert isinstance(state, ClaimState)
+    assert state.head.endswith("0" * 64)
+    assert state.holder("jira", "T-1", "backend") is None
+
+
+# ---------------------------------------------------------------------------
+# Deterministic conflict rule -- lowest entry_hash wins
+# ---------------------------------------------------------------------------
+
+
+def test_lowest_entry_hash_wins_regardless_of_merge_order(tmp_path: Path) -> None:
+    """Two concurrent claims resolve to the same holder in either order.
+
+    Node A and node B each mint an independent claim for the same key. A
+    merge that saw A-then-B and a merge that saw B-then-A must converge on
+    the same winner (lowest ``entry_hash``), even though the journal head
+    hash differs between the two orderings (that divergence is the fork
+    surface deferred to a later phase).
+    """
+    journal_a = _journal(tmp_path, path_name="a.jsonl", node_id="node-a", seed=1)
+    journal_b = _journal(tmp_path, path_name="b.jsonl", node_id="node-b", seed=2)
+    claim_a = journal_a.append(
+        kind="claim",
+        tracker="jira",
+        ticket_id="T-1",
+        role="backend",
+        claimer_id="worker-a",
+        lease_expires_at=1600.0,
+        ts_ns=1_000_000_000,
+    )
+    claim_b = journal_b.append(
+        kind="claim",
+        tracker="jira",
+        ticket_id="T-1",
+        role="backend",
+        claimer_id="worker-b",
+        lease_expires_at=1600.0,
+        ts_ns=1_000_000_000,
+    )
+    assert claim_a.entry_hash != claim_b.entry_hash
+
+    winner = min(claim_a, claim_b, key=lambda r: r.entry_hash)
+    loser = max(claim_a, claim_b, key=lambda r: r.entry_hash)
+
+    state_ab = project_claims([claim_a, claim_b])
+    state_ba = project_claims([claim_b, claim_a])
+
+    hold_ab = state_ab.holder("jira", "T-1", "backend")
+    hold_ba = state_ba.holder("jira", "T-1", "backend")
+    assert hold_ab is not None and hold_ba is not None
+    assert hold_ab.entry_hash == hold_ba.entry_hash == winner.entry_hash
+    assert hold_ab.claimer_id == winner.claimer_id
+    assert loser.entry_hash in state_ab.superseded
+    assert loser.entry_hash in state_ba.superseded
+
+
+# ---------------------------------------------------------------------------
+# Leaderless convergence -- chain-anchored supersede naming the winner
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_emits_chain_anchored_supersede_naming_winner(tmp_path: Path) -> None:
+    """A double-claim converges via a signed, anchored supersede receipt."""
+    chain = _chain(tmp_path)
+    # One shared journal file; two node identities append to it (shared
+    # workspace / shared filesystem -- the phase 1-2 substrate).
+    journal_a = ClaimJournal(
+        tmp_path / "claim_journal.jsonl",
+        kms_adapter=_kms(tmp_path, seed=1, name="node-a-key"),
+        node_id="node-a",
+        chain=chain,
+    )
+    journal_b = ClaimJournal(
+        tmp_path / "claim_journal.jsonl",
+        kms_adapter=_kms(tmp_path, seed=2, name="node-b-key"),
+        node_id="node-b",
+        chain=chain,
+    )
+    claim_a = journal_a.append(
+        kind="claim",
+        tracker="jira",
+        ticket_id="T-1",
+        role="backend",
+        claimer_id="worker-a",
+        lease_expires_at=1600.0,
+        ts_ns=1_000_000_000,
+    )
+    claim_b = journal_b.append(
+        kind="claim",
+        tracker="jira",
+        ticket_id="T-1",
+        role="backend",
+        claimer_id="worker-b",
+        lease_expires_at=1600.0,
+        ts_ns=1_000_100_000,
+    )
+    winner = min(claim_a, claim_b, key=lambda r: r.entry_hash)
+    loser = max(claim_a, claim_b, key=lambda r: r.entry_hash)
+
+    # Before reconciliation both claims are live in the fold.
+    pre = journal_a.project()
+    assert loser.entry_hash in pre.superseded  # fold already resolves the winner
+
+    supersedes = journal_a.reconcile(ts_ns=1_000_200_000)
+    assert len(supersedes) == 1
+    receipt = supersedes[0]
+    assert receipt.kind == "supersede"
+    assert receipt.claimer_id == loser.claimer_id
+    assert receipt.supersedes == loser.entry_hash
+    assert receipt.winner_claimer_id == winner.claimer_id
+    assert receipt.winner_entry_hash == winner.entry_hash
+
+    # The supersede receipt is anchored in the HMAC audit chain.
+    rows = chain.query(event_type=EVENT_CLAIM_JOURNAL_RECEIPT)
+    supersede_rows = [r for r in rows if r.details.get("kind") == "supersede"]
+    assert len(supersede_rows) == 1
+    assert supersede_rows[0].details["journal_entry_hash"] == receipt.entry_hash
+    assert supersede_rows[0].details["winner_claimer_id"] == winner.claimer_id
+    assert "prev_chain_digest" in supersede_rows[0].details
+
+    # Re-folding the journal (now carrying the supersede) leaves one holder,
+    # and re-reconciling is a no-op (idempotent convergence).
+    post = journal_a.project()
+    hold = post.holder("jira", "T-1", "backend")
+    assert hold is not None and hold.claimer_id == winner.claimer_id
+    assert loser.entry_hash in post.superseded
+    assert journal_a.reconcile(ts_ns=1_000_300_000) == []
+
+
+def test_reconcile_is_noop_without_conflict(tmp_path: Path) -> None:
+    journal = _journal(tmp_path, chain=_chain(tmp_path))
+    journal.append(
+        kind="claim",
+        tracker="jira",
+        ticket_id="T-1",
+        role="backend",
+        claimer_id="worker-a",
+        lease_expires_at=1600.0,
+        ts_ns=1_000_000_000,
+    )
+    assert journal.reconcile(ts_ns=1_000_100_000) == []
+
+
+# ---------------------------------------------------------------------------
+# Verifiability / tamper-evidence (offline replay)
+# ---------------------------------------------------------------------------
+
+
+def test_verify_flags_flipped_byte_at_exact_index(tmp_path: Path) -> None:
+    """A single flipped byte fails verification at the offending entry."""
+    journal = _journal(tmp_path)
+    for i in range(3):
+        journal.append(
+            kind="claim",
+            tracker="jira",
+            ticket_id=f"T-{i}",
+            role="backend",
+            claimer_id=f"worker-{i}",
+            lease_expires_at=1600.0 + i,
+            ts_ns=1_000_000_000 + i,
+        )
+    assert journal.verify().ok
+
+    # Corrupt the second on-disk record's claimer_id.
+    lines = journal.path.read_text(encoding="utf-8").splitlines()
+    assert "worker-1" in lines[1]
+    lines[1] = lines[1].replace("worker-1", "worker-X")
+    journal.path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    result = journal.verify()
+    assert not result.ok
+    assert result.bad_index == 1
+    assert result.failures
+
+
+def test_verify_detects_broken_chain_link(tmp_path: Path) -> None:
+    """Dropping a middle receipt breaks the prev_entry_hash linkage."""
+    journal = _journal(tmp_path)
+    for i in range(3):
+        journal.append(
+            kind="claim",
+            tracker="jira",
+            ticket_id=f"T-{i}",
+            role="backend",
+            claimer_id=f"worker-{i}",
+            lease_expires_at=1600.0,
+            ts_ns=1_000_000_000 + i,
+        )
+    lines = journal.path.read_text(encoding="utf-8").splitlines()
+    # Delete the middle entry: entry 2's prev no longer matches entry 0.
+    del lines[1]
+    journal.path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    result = journal.verify()
+    assert not result.ok
+    assert result.bad_index == 1
+
+
+# ---------------------------------------------------------------------------
+# ClaimLedger opt-in journal path (STAR untouched)
+# ---------------------------------------------------------------------------
+
+
+def test_ledger_without_journal_writes_no_receipts(tmp_path: Path) -> None:
+    """The default STAR ledger path must not touch a journal."""
+    ledger = ClaimLedger(tmp_path / "claims.db")
+    assert ledger.journal is None
+    outcome = ledger.try_claim(
+        tracker="jira",
+        ticket_id="T-1",
+        role="backend",
+        claimer_id="worker-a",
+        ttl_seconds=600,
+        per_role_max_in_flight=1,
+        now=1000.0,
+    )
+    assert outcome.granted
+    assert not (tmp_path / "claim_journal.jsonl").exists()
+
+
+def test_ledger_journal_path_appends_receipt_and_materialises_row(tmp_path: Path) -> None:
+    """On the opt-in journal path a grant appends a signed claim receipt."""
+    chain = _chain(tmp_path)
+    journal = _journal(tmp_path, chain=chain)
+    ledger = ClaimLedger(tmp_path / "claims.db", journal=journal)
+    assert ledger.journal is journal
+
+    outcome = ledger.try_claim(
+        tracker="jira",
+        ticket_id="T-1",
+        role="backend",
+        claimer_id="worker-a",
+        ttl_seconds=600,
+        per_role_max_in_flight=1,
+        now=1000.0,
+    )
+    assert outcome.granted
+    assert outcome.lease_expires_at == 1600.0
+
+    receipts = journal.read()
+    assert len(receipts) == 1
+    assert receipts[0].kind == "claim"
+    assert receipts[0].claimer_id == "worker-a"
+    assert receipts[0].lease_expires_at == 1600.0
+
+    # The SQLite projection reflects the same holder.
+    live = ledger.live_claims(now=1000.0)
+    assert len(live) == 1
+    assert live[0]["claimer_id"] == "worker-a"
+
+    # The receipt is anchored in the audit chain.
+    rows = chain.query(event_type=EVENT_CLAIM_JOURNAL_RECEIPT)
+    assert len(rows) == 1
+    assert rows[0].details["kind"] == "claim"
+
+    # The fold over the journal agrees with the SQLite row.
+    hold = journal.project().holder("jira", "T-1", "backend")
+    assert hold is not None and hold.claimer_id == "worker-a"
+
+
+def test_ledger_journal_replay_is_deterministic(tmp_path: Path) -> None:
+    """The injected ``now`` clock makes the claim receipt replay-stable."""
+    journal1 = _journal(tmp_path, path_name="j1.jsonl", node_id="node-a", seed=1)
+    journal2 = _journal(tmp_path, path_name="j2.jsonl", node_id="node-a", seed=1)
+    ledger1 = ClaimLedger(tmp_path / "c1.db", journal=journal1)
+    ledger2 = ClaimLedger(tmp_path / "c2.db", journal=journal2)
+
+    ledger1.try_claim(
+        tracker="jira",
+        ticket_id="T-1",
+        role="backend",
+        claimer_id="worker-a",
+        ttl_seconds=600,
+        per_role_max_in_flight=1,
+        now=1000.0,
+    )
+    ledger2.try_claim(
+        tracker="jira",
+        ticket_id="T-1",
+        role="backend",
+        claimer_id="worker-a",
+        ttl_seconds=600,
+        per_role_max_in_flight=1,
+        now=1000.0,
+    )
+    r1 = journal1.read()[0]
+    r2 = journal2.read()[0]
+    # Same node identity + same injected clock + same inputs -> byte-identical
+    # receipt, entry_hash, and signature.
+    assert r1.to_dict() == r2.to_dict()
+    assert r1.entry_hash == r2.entry_hash
+
+
+def test_reject_unknown_receipt_kind(tmp_path: Path) -> None:
+    journal = _journal(tmp_path)
+    with pytest.raises(ValueError, match="unknown claim-receipt kind"):
+        journal.append(
+            kind="bogus",
+            tracker="jira",
+            ticket_id="T-1",
+            role="backend",
+            claimer_id="worker-a",
+            lease_expires_at=1600.0,
+            ts_ns=1,
+        )

--- a/tests/unit/orchestration/test_claim_journal.py
+++ b/tests/unit/orchestration/test_claim_journal.py
@@ -357,8 +357,14 @@ def test_reconcile_emits_chain_anchored_supersede_naming_winner(tmp_path: Path) 
     assert len(supersedes) == 1
     receipt = supersedes[0]
     assert receipt.kind == "supersede"
-    assert receipt.claimer_id == loser.claimer_id
+    # The supersede is a statement BY the reconciling node (node-a) ABOUT the
+    # loser's claim: its own identity names the reconciler that signs it, the
+    # loser is carried as referenced data.
+    assert receipt.node_id == "node-a"
+    assert receipt.claimer_id == "node-a"
     assert receipt.supersedes == loser.entry_hash
+    assert receipt.superseded_node_id == loser.node_id
+    assert receipt.superseded_claimer_id == loser.claimer_id
     assert receipt.winner_claimer_id == winner.claimer_id
     assert receipt.winner_entry_hash == winner.entry_hash
 
@@ -367,7 +373,9 @@ def test_reconcile_emits_chain_anchored_supersede_naming_winner(tmp_path: Path) 
     supersede_rows = [r for r in rows if r.details.get("kind") == "supersede"]
     assert len(supersede_rows) == 1
     assert supersede_rows[0].details["journal_entry_hash"] == receipt.entry_hash
+    assert supersede_rows[0].details["node_id"] == "node-a"
     assert supersede_rows[0].details["winner_claimer_id"] == winner.claimer_id
+    assert supersede_rows[0].details["superseded_claimer_id"] == loser.claimer_id
     assert "prev_chain_digest" in supersede_rows[0].details
 
     # Re-folding the journal (now carrying the supersede) leaves one holder,
@@ -377,6 +385,82 @@ def test_reconcile_emits_chain_anchored_supersede_naming_winner(tmp_path: Path) 
     assert hold is not None and hold.claimer_id == winner.claimer_id
     assert loser.entry_hash in post.superseded
     assert journal_a.reconcile(ts_ns=1_000_300_000) == []
+
+
+def test_reconcile_supersede_is_attributed_to_its_signing_node(tmp_path: Path) -> None:
+    """A reconcile-emitted supersede must be attributed to the node that signs it.
+
+    A ``claim_superseded`` receipt is a statement *by* the reconciling node
+    *about* the loser's claim -- so the ``node_id`` / ``claimer_id`` identity
+    fields it carries and the Ed25519 signature that seals them must name the
+    same node. If the receipt carried the loser's identity while being signed
+    with the reconciler's install key, a verifier that pins each node's public
+    key by ``node_id`` would reject the entry: the embedded JWK would not match
+    the pinned key for the declared node. Here a *third* node (``node-c``)
+    reconciles a ``node-a`` / ``node-b`` conflict, so the loser is always a
+    different node than the signer -- exposing any mis-attribution unambiguously.
+    """
+    chain = _chain(tmp_path)
+    kms_a = _kms(tmp_path, seed=1, name="node-a-key")
+    kms_b = _kms(tmp_path, seed=2, name="node-b-key")
+    kms_c = _kms(tmp_path, seed=3, name="node-c-key")
+    journal_a = ClaimJournal(tmp_path / "claim_journal.jsonl", kms_adapter=kms_a, node_id="node-a", chain=chain)
+    journal_b = ClaimJournal(tmp_path / "claim_journal.jsonl", kms_adapter=kms_b, node_id="node-b", chain=chain)
+    journal_c = ClaimJournal(tmp_path / "claim_journal.jsonl", kms_adapter=kms_c, node_id="node-c", chain=chain)
+
+    claim_a = journal_a.append(
+        kind="claim",
+        tracker="jira",
+        ticket_id="T-1",
+        role="backend",
+        claimer_id="worker-a",
+        lease_expires_at=1600.0,
+        ts_ns=1_000_000_000,
+    )
+    claim_b = journal_b.append(
+        kind="claim",
+        tracker="jira",
+        ticket_id="T-1",
+        role="backend",
+        claimer_id="worker-b",
+        lease_expires_at=1600.0,
+        ts_ns=1_000_100_000,
+    )
+    winner = min(claim_a, claim_b, key=lambda r: r.entry_hash)
+    loser = max(claim_a, claim_b, key=lambda r: r.entry_hash)
+
+    emitted = journal_c.reconcile(ts_ns=1_000_200_000)
+    assert len(emitted) == 1
+    supersede = emitted[0]
+
+    # The receipt is a statement BY node-c: its own identity fields name node-c,
+    # the actual signer -- never the loser it speaks about.
+    assert supersede.node_id == "node-c"
+    assert supersede.node_id != loser.node_id
+
+    # The embedded signing JWK belongs to node-c, matching the declared node_id:
+    # signature and attribution agree.
+    assert supersede.signature["public_key_jwk"] == kms_c.public_key_jwk()
+
+    # A verifier pinning each node's key by node_id accepts the whole journal:
+    # every receipt's signature matches the identity the receipt claims to be
+    # from. This is the attribution invariant the mis-signed supersede broke.
+    trusted_keys = {
+        "node-a": kms_a.public_key_jwk(),
+        "node-b": kms_b.public_key_jwk(),
+        "node-c": kms_c.public_key_jwk(),
+    }
+    result = journal_c.verify(trusted_keys=trusted_keys)
+    assert result.ok, result.failures
+
+    # The loser's identity survives as *referenced data* (what the receipt is
+    # about), not as the receipt's own identity (who it is from).
+    assert supersede.supersedes == loser.entry_hash
+    assert supersede.superseded_node_id == loser.node_id
+    assert supersede.superseded_claimer_id == loser.claimer_id
+    # The winner naming is unchanged: lowest-entry-hash winner rule intact.
+    assert supersede.winner_entry_hash == winner.entry_hash
+    assert supersede.winner_claimer_id == winner.claimer_id
 
 
 def test_reconcile_is_noop_without_conflict(tmp_path: Path) -> None:


### PR DESCRIPTION
## What
The claim-journal substrate for leaderless coordination — phases 1–2 only: `ClaimJournal` (append-only, hash-chained, Ed25519-signed claim/release/renew/expire/supersede receipts anchored into the audit chain) and the pure `project_claims` fold with the deterministic lowest-`entry_hash` supersede rule. The journal path is opt-in; STAR behavior and existing `ClaimLedger` callers are unchanged. Topology wiring, gossip, and the CLI wait for the verified peer-identity surface.

Part of #2558 (phases 1–2; phases 3–5 follow separately).

## Review journey (three adversarial rounds, all findings fixed)
- Round 1: journal appends were not atomic under two writers (tail hash read outside the flock) and SQLite was still the grant arbiter — both fixed: read-modify-write now inside the lock; the receipt is minted first and the SQLite row materialises from it.
- Round 2: `reconcile` signed the `claim_superseded` receipt with the reconciler's key while attributing it to the loser — a signature/attribution mismatch. Fixed with a new invariant: **every receipt is attributed to the node that signs it**; the losing claim is referenced data (`supersedes` entry hash + `superseded_node_id`/`superseded_claimer_id`), never the receipt's identity. Schema version bumped 1→2. RED test proved the mismatch pre-fix; 19/19 green post-fix.

## Binding criteria
- Byte-identical fold: two nodes over the same ordered receipt set produce byte-compared-identical `ClaimState` and the same head hash.
- Concurrent double-claim converges on one holder by the deterministic rule, loser holds a chain-anchored supersede naming the winner (as referenced data).
- With the journal path off, behavior is unchanged and existing ledger tests stay green.

## Verification
19 passed on the claim-journal suite; sentinel 37,872 collected, 0 errors; ruff/mypy clean on changed files.