### PR TITLE
feat(integrations): generic OData v4 trigger source and receipt-anchored write-backs

### DIFF
--- a/docs/operations/odata.md
+++ b/docs/operations/odata.md
@@ -1,0 +1,184 @@
+# Generic OData v4 system-of-record integration
+
+Operations teams run on business systems of record whose integration surface is
+[OData v4](https://www.odata.org/) — order, purchase, service, and inventory
+objects exposed as entity sets with stable `$metadata` introspection. Bernstein
+integrates with them in two composable halves that share one deterministic
+cursor and anchor every write to the audit chain:
+
+- a **poll trigger source** (`odata_poll`) that turns "a record changed in the
+  system of record" into a normal `TriggerEvent`, and
+- a **receipt-anchored write-back helper** (`odata_writeback`) that writes an
+  outcome back under optimistic concurrency and records a signed receipt.
+
+Neither half assumes anything vendor-specific: the change-timestamp property,
+the key properties, and the auth scheme are all per-connection config, because
+no single convention holds across suites.
+
+## Trigger source: `odata_poll`
+
+### Watermark polling is the baseline
+
+Each poll issues `GET /<EntitySet>?$filter=<ts_prop> gt <watermark>` ordered by
+the timestamp, emits one `TriggerEvent` per changed entity, and advances the
+watermark to the largest timestamp it saw. Because the filter is strictly
+`gt`, an entity at exactly the watermark is excluded on the next poll, so a
+restart never re-emits it. There is no assumed timestamp property name — set
+`timestamp_property` per connection.
+
+Server-driven paging is followed transparently: the source walks every
+`@odata.nextLink` page before returning.
+
+### Delta links are opt-in, never assumed
+
+With `prefer_delta` set, the first poll probes with the
+`Prefer: odata.track-changes` request header. Only if the service actually
+returns an `@odata.deltaLink` does the source switch to delta-token paging;
+subsequent polls follow the stored delta link and surface deletions as
+`delete` events. If the service ignores the header (some view-backed entity
+sets silently omit delta links), the source stays on watermark polling.
+
+Any delta read failure downgrades to watermark polling **without losing the
+cursor** — the watermark is maintained in both modes, so the resume position
+survives the downgrade.
+
+### The cursor is a deterministic, resumable record
+
+| Cursor field | Meaning |
+|---|---|
+| `entity_set` | the set the cursor belongs to |
+| `mode` | `watermark` or `delta` |
+| `watermark` | last-seen maximum change timestamp (always maintained) |
+| `delta_link` | the `@odata.deltaLink` to follow next (delta mode) |
+| `last_page_hash` | `sha256:` of the last result page |
+| `probed` | whether a delta probe was already attempted |
+
+Persist it with `save_cursor(path, cursor)` and reload with
+`load_cursor(path)`. The serialized form is canonical bytes, so two operators
+replaying the same timeline from the same persisted cursor derive byte-identical
+events — no duplicate, no drop. `last_page_hash` lets an auditor prove which
+window of changes produced which tasks.
+
+### Rate handling
+
+- `429` responses are honored: the client sleeps the `Retry-After` value (capped
+  by `max_retry_after_s`) and retries, up to a bounded budget.
+- `rate_limit_min_interval_s` enforces a minimum gap between HTTP calls for
+  vendors that document a fixed per-API minimum.
+
+Both use an injected clock, so tests exercise them with a fake clock and no real
+sleeps.
+
+### Auth
+
+`OdataAuth` supports `bearer`, `api_key`, and `oauth2_client_credentials`, plus
+`none`. Credentials are read from environment variables at call time and are
+never written to a log — auth header values are redacted before any debug line
+is emitted.
+
+## Write-back: `odata_writeback`
+
+`update_entity(connection, key, patch, chain=...)` implements GET-before-PATCH:
+it reads the current entity and its ETag, then sends `If-Match`. It refuses to
+write blindly:
+
+| Situation | Result |
+|---|---|
+| No fresh ETag exposed by the service | `OdataConflict(status=428)` |
+| Stale ETag (concurrent edit landed) | `OdataConflict(status=412)` |
+| Match | PATCH applied, receipt recorded |
+
+Draft-enabled objects are supported through `draft_flow` and
+`draft_activate_action`: the helper creates a draft, patches it under its ETag,
+then POSTs the bound activate action.
+
+### Every write-back emits a receipt
+
+A successful write-back appends an `odata.writeback_receipt` event to the HMAC
+audit chain, binding:
+
+| Field | Binds |
+|---|---|
+| `connection` | the connection label |
+| `entity_set` / `entity_key` | the record written |
+| `etag_observed` | the concurrency token the PATCH was gated on |
+| `payload_content_hash` | `sha256:` of the canonical sent payload |
+| `http_status` | the status the write returned |
+| `draft_flow` / `activate_action` | draft promotion, when used |
+
+The entity body and any credential are never stored — only identifiers and
+hashes. The returned `WriteBackReceipt` carries the same fields plus the HMAC of
+the anchored event, so the receipt is bound to a specific chain position.
+
+Because the receipt is a chain event, `bernstein audit verify` covers it with no
+new verb: a mutated row breaks the chain at its exact position, and an auditor
+holding the sent body re-hashes it and matches `payload_content_hash`.
+
+## Worked example
+
+Poll an `Orders` entity set, seed a task on each change, write the outcome back,
+and verify the receipt offline.
+
+```python
+from pathlib import Path
+
+from bernstein.core.security.audit_chain import AuditChainStore
+from bernstein.core.trigger_sources.odata_poll import (
+    OdataAuth,
+    OdataConnection,
+    OdataPollSource,
+    load_cursor,
+    save_cursor,
+)
+from bernstein.core.trackers.odata_writeback import update_entity
+
+connection = OdataConnection(
+    service_root="https://erp.example.com/odata/v4/svc",
+    entity_set="Orders",
+    timestamp_property="LastChangeDateTime",
+    key_properties=("OrderID",),
+    prefer_delta=True,              # probe for delta; fall back to watermark
+    rate_limit_min_interval_s=1.0,  # respect a documented per-API minimum
+    auth=OdataAuth(kind="bearer", token_env="ERP_TOKEN"),
+    name="erp_orders",
+)
+
+cursor_path = Path(".sdd/odata/erp_orders.cursor.json")
+source = OdataPollSource(connection)
+
+# 1. Poll -> one TriggerEvent per changed order.
+result = source.poll(load_cursor(cursor_path))
+for event in result.events:
+    seed_task_from(event)         # your normal trigger -> task path
+
+# 2. Persist the advanced cursor so a restart resumes byte-identically.
+save_cursor(cursor_path, result.cursor)
+
+# 3. Write an outcome back under optimistic concurrency, recording a receipt.
+chain = AuditChainStore(Path(".sdd/audit"))
+receipt = update_entity(
+    connection,
+    {"OrderID": 4711},
+    {"ProcessingStatus": "Reviewed"},
+    chain=chain,
+)
+print(receipt.payload_content_hash, receipt.http_status)
+```
+
+Verify the write-back offline — no new verb:
+
+```bash
+bernstein audit verify --hmac-only
+```
+
+The command exits non-zero if any `odata.writeback_receipt` row was altered
+after the fact.
+
+## Notes
+
+- No new external dependencies: the integration is built on the HTTP client and
+  audit chain the repo already ships.
+- The full protocol surface (server-driven paging, delta links behind the
+  `Prefer` header, ETags, `412`/`428`, `429` + `Retry-After`, draft-activate) is
+  covered by an in-process fake OData service in `tests/unit/odata/`, driven
+  with an injected clock and no network.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -219,6 +219,7 @@ nav:
           - GitHub Projects: trackers/github-projects.md
           - Plane: trackers/plane.md
           - ServiceNow: trackers/servicenow.md
+          - OData (system of record): operations/odata.md
           - Webhooks: trackers/webhooks.md
       - Git hosting & CI:
           - GitHub Action: integrations/github-action.md

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -802,6 +802,18 @@ EVENT_TRIGGER_RECEIPT_REFUSED = "trigger.receipt.refused"
 EVENT_STATUS_PROOF_EMITTED = "status.proof.emitted"
 
 
+#: Issue #2886 -- emitted for every generic OData v4 system-of-record write-back.
+#: A write-back is not a fire-and-forget HTTP call: the event binds ``{connection,
+#: entity set, key predicate, ETag observed before the PATCH, content hash of the
+#: sent payload, HTTP status, draft-flow flag}`` into the HMAC chain, so an
+#: auditor can prove offline -- with ``bernstein audit verify`` and no new verb --
+#: that a given change to a given record was made against a specific concurrency
+#: token, and can re-hash the sent body and match it against the recorded payload
+#: hash. Only identifiers and hashes are recorded; the entity body and any
+#: credential are never stored.
+EVENT_ODATA_WRITEBACK = "odata.writeback_receipt"
+
+
 # ---------------------------------------------------------------------------
 # AuditChainStore
 # ---------------------------------------------------------------------------
@@ -2983,6 +2995,66 @@ def record_status_proof(
             "producing_event_digest": producing_event_digest,
             "proof_digest": proof_digest,
         },
+    )
+
+
+def record_odata_writeback(
+    *,
+    chain: AuditChainStore,
+    connection_name: str,
+    entity_set: str,
+    entity_key: str,
+    etag_observed: str,
+    payload_content_hash: str,
+    http_status: int,
+    draft_flow: bool = False,
+    activate_action: str = "",
+    actor: str = "odata_writeback",
+) -> AuditEvent:
+    """Append an ``odata.writeback_receipt`` event into *chain* (#2886).
+
+    Anchors one OData system-of-record write-back in the HMAC chain. The event
+    binds the concurrency token the PATCH was gated on (``etag_observed``) and
+    the content hash of the sent payload, so an auditor holding the sent body
+    re-hashes it and matches ``payload_content_hash`` on this row, and confirms
+    from the chain alone -- via ``bernstein audit verify`` with no new verb --
+    that the change targeted the recorded entity against that specific ETag. A
+    mutated row breaks the HMAC chain at its exact position.
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        connection_name: Stable connection label.
+        entity_set: The OData entity set written to.
+        entity_key: Canonical key predicate inner text (e.g. ``id=1``).
+        etag_observed: The ``If-Match`` ETag the PATCH was gated on; empty only
+            for a draft-flow create whose activation carries no prior ETag.
+        payload_content_hash: ``sha256:`` digest of the canonical sent payload.
+        http_status: The HTTP status the write returned.
+        draft_flow: Whether the write went through a draft-activate flow.
+        activate_action: The bound activate action name (draft flow only).
+        actor: Recorded actor; defaults to ``"odata_writeback"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded in
+        its details payload.
+    """
+    details: dict[str, Any] = {
+        "connection": connection_name,
+        "entity_set": entity_set,
+        "entity_key": entity_key,
+        "etag_observed": etag_observed,
+        "payload_content_hash": payload_content_hash,
+        "http_status": http_status,
+        "draft_flow": draft_flow,
+    }
+    if activate_action:
+        details["activate_action"] = activate_action
+    return chain.log_with_prev_digest(
+        event_type=EVENT_ODATA_WRITEBACK,
+        actor=actor,
+        resource_type="odata_entity",
+        resource_id=f"{entity_set}({entity_key})",
+        details=details,
     )
 
 
@@ -6919,6 +6991,7 @@ __all__ = [
     "EVENT_MISSION_DIGEST_RECEIPT",
     "EVENT_MISSION_PHASE_RECEIPT",
     "EVENT_MULTIMODAL_ATTACH",
+    "EVENT_ODATA_WRITEBACK",
     "EVENT_OTEL_PROJECTION",
     "EVENT_PLUGIN_CONFORMANCE_RECEIPT",
     "EVENT_PLUGIN_INSTALL_RECEIPT",
@@ -7037,6 +7110,7 @@ __all__ = [
     "record_mission_digest_receipt",
     "record_mission_phase_receipt",
     "record_multimodal_attach",
+    "record_odata_writeback",
     "record_otel_projection",
     "record_plugin_conformance_receipt",
     "record_plugin_install_receipt",

--- a/src/bernstein/core/trackers/odata_writeback.py
+++ b/src/bernstein/core/trackers/odata_writeback.py
@@ -1,0 +1,240 @@
+"""Receipt-anchored OData v4 write-back helper.
+
+A write-back to a system of record is not a fire-and-forget HTTP call; it is a
+provable act. :func:`update_entity` implements the GET-before-PATCH pattern with
+``If-Match`` optimistic concurrency, surfaces ``412`` / ``428`` as typed
+conflicts (never a blind retry that could clobber a concurrent human edit), and
+emits a receipt bound into the HMAC audit chain: ``{connection, entity set, key
+predicate, ETag observed, payload content-hash, HTTP status}``. Because the
+receipt is anchored as an ``odata.writeback_receipt`` event, ``bernstein audit
+verify`` covers it with no new verb -- a tampered row breaks the chain, and an
+auditor holding the sent body re-hashes it and matches the recorded payload
+hash.
+
+Draft-enabled objects (create-draft -> patch -> bound activate action) are
+supported through the connection's ``draft_flow`` flag and activate-action name,
+because several suites gate writes behind draft promotion.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.security.audit_chain import record_odata_writeback
+from bernstein.core.trigger_sources.odata_poll import (
+    OdataConflict,
+    OdataError,
+    OdataHttpClient,
+    build_key_predicate,
+    discover_keys,
+    key_signature,
+)
+
+if TYPE_CHECKING:
+    from bernstein.core.security.audit_chain import AuditChainStore
+    from bernstein.core.trigger_sources.odata_poll import Clock, OdataConnection
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "WriteBackReceipt",
+    "canonical_payload_hash",
+    "update_entity",
+]
+
+
+@dataclass(frozen=True)
+class WriteBackReceipt:
+    """Content-addressable proof of one OData write-back.
+
+    Attributes:
+        connection: Connection label.
+        entity_set: Entity set written to.
+        entity_key: Canonical key predicate inner text (e.g. ``id=1``).
+        etag_observed: The ``If-Match`` ETag the PATCH was gated on.
+        payload_content_hash: ``sha256:`` digest of the canonical sent payload.
+        http_status: HTTP status returned by the write.
+        audit_event_hmac: HMAC of the anchored ``odata.writeback_receipt`` event
+            -- the chain position the receipt is bound to.
+        draft_flow: Whether the write went through a draft-activate flow.
+        activate_action: The bound activate action name (draft flow only).
+    """
+
+    connection: str
+    entity_set: str
+    entity_key: str
+    etag_observed: str
+    payload_content_hash: str
+    http_status: int
+    audit_event_hmac: str
+    draft_flow: bool = False
+    activate_action: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serialisable mapping (stable field order)."""
+        return {
+            "connection": self.connection,
+            "entity_set": self.entity_set,
+            "entity_key": self.entity_key,
+            "etag_observed": self.etag_observed,
+            "payload_content_hash": self.payload_content_hash,
+            "http_status": self.http_status,
+            "audit_event_hmac": self.audit_event_hmac,
+            "draft_flow": self.draft_flow,
+            "activate_action": self.activate_action,
+        }
+
+    def receipt_hash(self) -> str:
+        """Return the content-addressed identifier for this receipt."""
+        body = json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":")).encode("utf-8")
+        return "sha256:" + hashlib.sha256(body).hexdigest()
+
+
+def canonical_payload_hash(patch: dict[str, Any]) -> str:
+    """Return the ``sha256:`` content hash of ``patch`` (canonical JSON).
+
+    The canonical form is sorted-key, compact-separator JSON, so the same
+    payload always produces the same hash and an auditor can recompute it from
+    the sent body independently.
+    """
+    body = json.dumps(patch, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return "sha256:" + hashlib.sha256(body).hexdigest()
+
+
+def update_entity(
+    connection: OdataConnection,
+    key: dict[str, Any],
+    patch: dict[str, Any],
+    *,
+    chain: AuditChainStore,
+    http_client: OdataHttpClient | None = None,
+    clock: Clock | None = None,
+    actor: str = "odata_writeback",
+) -> WriteBackReceipt:
+    """Write ``patch`` back to an OData entity and anchor a signed receipt.
+
+    Non-draft path: GET the current entity + ETag, then ``If-Match`` PATCH.
+    A missing ETag raises :class:`OdataConflict` (428) before any blind write;
+    a stale ETag surfaces the service's ``412`` as :class:`OdataConflict`.
+
+    Draft path (``connection.draft_flow``): create a draft, PATCH it under its
+    ETag, then POST the bound activate action.
+
+    Args:
+        connection: The OData connection.
+        key: Key property -> value mapping identifying the entity (ignored for
+            the create step of a draft flow).
+        patch: The field changes to write.
+        chain: Audit chain the write-back receipt is anchored into.
+        http_client: Optional pre-built client (tests inject one bound to the
+            in-process fake).
+        clock: Optional injected clock for rate-limit waits.
+        actor: Recorded audit actor.
+
+    Returns:
+        A :class:`WriteBackReceipt` bound to the recorded audit event.
+
+    Raises:
+        OdataConflict: On a 412 (stale ETag) or 428 (missing precondition).
+        OdataError: On any other HTTP failure.
+    """
+    client = http_client or OdataHttpClient(connection, clock=clock)
+    payload_hash = canonical_payload_hash(patch)
+
+    if connection.draft_flow:
+        return _draft_update(connection, patch, client=client, chain=chain, payload_hash=payload_hash, actor=actor)
+
+    predicate = build_key_predicate(connection.entity_set, key)
+    entity_key = key_signature(key)
+
+    _entity, etag = client.get_entity(predicate)
+    if not etag:
+        # No fresh concurrency token: refuse before writing so a concurrent
+        # human edit is never clobbered. This is the 428 path.
+        raise OdataConflict(f"no fresh ETag for {predicate}; refusing blind write", status=428)
+
+    status, _body, _new_etag = client.patch_entity(predicate, patch, if_match=etag)
+
+    event = record_odata_writeback(
+        chain=chain,
+        connection_name=connection.name,
+        entity_set=connection.entity_set,
+        entity_key=entity_key,
+        etag_observed=etag,
+        payload_content_hash=payload_hash,
+        http_status=status,
+        actor=actor,
+    )
+    return WriteBackReceipt(
+        connection=connection.name,
+        entity_set=connection.entity_set,
+        entity_key=entity_key,
+        etag_observed=etag,
+        payload_content_hash=payload_hash,
+        http_status=status,
+        audit_event_hmac=event.hmac,
+    )
+
+
+def _draft_update(
+    connection: OdataConnection,
+    patch: dict[str, Any],
+    *,
+    client: OdataHttpClient,
+    chain: AuditChainStore,
+    payload_hash: str,
+    actor: str,
+) -> WriteBackReceipt:
+    """Create-draft -> patch -> activate, then anchor a signed receipt."""
+    activate_action = connection.draft_activate_action
+    if not activate_action:
+        raise OdataError("draft_flow requires draft_activate_action to be configured")
+
+    key_names = tuple(connection.key_properties) or discover_keys(connection, client)
+
+    # 1. Create the draft.
+    _status_c, draft_body, draft_etag = client.post(connection.entity_set, {})
+    if draft_body is None:
+        raise OdataError("draft create returned no body")
+    draft_key = {name: draft_body.get(name) for name in key_names}
+    draft_predicate = build_key_predicate(connection.entity_set, draft_key)
+    if not draft_etag:
+        raise OdataConflict(f"draft {draft_predicate} exposed no ETag", status=428)
+
+    # 2. Patch the draft under its ETag.
+    client.patch_entity(draft_predicate, patch, if_match=draft_etag)
+
+    # 3. Activate the draft via the bound action.
+    status_a, active_body, _active_etag = client.post(f"{draft_predicate}/{activate_action}")
+    active_key = draft_key
+    if active_body is not None:
+        active_key = {name: active_body.get(name, draft_key.get(name)) for name in key_names}
+    entity_key = key_signature(active_key)
+
+    event = record_odata_writeback(
+        chain=chain,
+        connection_name=connection.name,
+        entity_set=connection.entity_set,
+        entity_key=entity_key,
+        etag_observed=draft_etag,
+        payload_content_hash=payload_hash,
+        http_status=status_a,
+        draft_flow=True,
+        activate_action=activate_action,
+        actor=actor,
+    )
+    return WriteBackReceipt(
+        connection=connection.name,
+        entity_set=connection.entity_set,
+        entity_key=entity_key,
+        etag_observed=draft_etag,
+        payload_content_hash=payload_hash,
+        http_status=status_a,
+        audit_event_hmac=event.hmac,
+        draft_flow=True,
+        activate_action=activate_action,
+    )

--- a/src/bernstein/core/trigger_sources/odata_poll.py
+++ b/src/bernstein/core/trigger_sources/odata_poll.py
@@ -1,0 +1,804 @@
+"""Generic OData v4 poll trigger source (watermark + opt-in delta).
+
+Operations teams run on business systems of record whose integration surface
+is OData v4. This module turns "a record changed in the system of record" into
+the orchestrator's normal :class:`TriggerEvent` flow, so a changed order /
+purchase / service object can seed a task through the same pipeline every other
+trigger source uses.
+
+Two polling modes share one deterministic cursor:
+
+* **Watermark polling is the baseline.** Each poll queries
+  ``$filter=<ts_prop> gt <watermark>`` ordered by the timestamp, emits one
+  :class:`TriggerEvent` per changed entity, and advances the watermark. There
+  is no assumption of a standard timestamp property name -- it is per-connection
+  config, because none exists across vendors.
+* **Delta links are an opt-in optimization, never assumed.** With
+  ``prefer_delta`` set, the first poll probes with ``Prefer:
+  odata.track-changes``; only if the service actually returns
+  ``@odata.deltaLink`` does the source switch to delta-token paging. Any delta
+  failure downgrades to watermark polling *without losing the cursor* -- the
+  maintained watermark carries the resume position across the downgrade.
+
+The cursor is a deterministic, content-addressable record so a restarted
+operator resumes byte-identically: the same fake timeline replayed against the
+same persisted cursor yields the same events with no duplicate and no drop.
+
+Auth (OAuth2 client-credentials, static bearer, or API-key headers) is resolved
+through environment variables and is never written to a log; header values for
+the auth headers are redacted before any debug line is emitted.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import time
+from dataclasses import dataclass, field, replace
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, Literal, Protocol
+
+from bernstein.core.tasks.models import TriggerEvent
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+try:  # pragma: no cover - dep declared in pyproject
+    import httpx
+except ImportError:  # pragma: no cover
+    httpx = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "Clock",
+    "OdataAuth",
+    "OdataAuthError",
+    "OdataConflict",
+    "OdataConnection",
+    "OdataCursor",
+    "OdataError",
+    "OdataHttpClient",
+    "OdataPollSource",
+    "PollResult",
+    "RateLimited",
+    "RealClock",
+    "build_key_predicate",
+    "discover_keys",
+    "load_cursor",
+    "save_cursor",
+]
+
+# Header names whose values must never be logged.
+_SENSITIVE_HEADER_PREFIXES = ("authorization", "x-api-key", "api-key", "apikey", "cookie")
+
+_METADATA_KEY_RE = re.compile(
+    r'<EntityType\s+Name="(?P<name>[^"]+)".*?<Key>(?P<keys>.*?)</Key>',
+    re.DOTALL,
+)
+_PROPERTY_REF_RE = re.compile(r'<PropertyRef\s+Name="(?P<name>[^"]+)"')
+
+
+# ---------------------------------------------------------------------------
+# Clock
+# ---------------------------------------------------------------------------
+
+
+class Clock(Protocol):
+    """Injected clock so rate-limit waits are testable without real sleeps."""
+
+    def now(self) -> float:
+        """Return a monotonic-ish timestamp in seconds."""
+        ...
+
+    def sleep(self, seconds: float) -> None:
+        """Block for ``seconds`` (a no-op for non-positive values)."""
+        ...
+
+
+class RealClock:
+    """Production clock backed by :mod:`time`."""
+
+    def now(self) -> float:
+        return time.monotonic()
+
+    def sleep(self, seconds: float) -> None:
+        if seconds > 0:
+            time.sleep(seconds)
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class OdataError(Exception):
+    """Base class for OData integration errors."""
+
+
+class OdataAuthError(OdataError):
+    """Raised when credentials are missing or the service rejects them."""
+
+
+class RateLimited(OdataError):
+    """Raised when 429s persist beyond the retry budget."""
+
+    def __init__(self, message: str, retry_after: float | None = None) -> None:
+        super().__init__(message)
+        self.retry_after = retry_after
+
+
+class OdataConflict(OdataError):
+    """Raised on an optimistic-concurrency conflict (412 / 428).
+
+    ``status`` distinguishes ``412`` (a stale ``If-Match`` precondition) from
+    ``428`` (a required precondition was absent). Neither is retried blindly so
+    a concurrent human edit is never clobbered.
+    """
+
+    def __init__(self, message: str, status: int) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class OdataAuth:
+    """Auth configuration for an OData connection. Secrets stay in env vars.
+
+    Attributes:
+        kind: ``"none"``, ``"bearer"``, ``"api_key"``, or
+            ``"oauth2_client_credentials"``.
+        token_env: Env var holding the bearer / API-key secret.
+        header_name: Header to place the credential in (default
+            ``Authorization``).
+        header_prefix: Prefix for a bearer credential (default ``"Bearer "``).
+        token_url: OAuth2 token endpoint (client-credentials grant).
+        client_id_env / client_secret_env: Env vars for the OAuth2 client.
+        scope: Optional OAuth2 scope string.
+    """
+
+    kind: Literal["none", "bearer", "api_key", "oauth2_client_credentials"] = "none"
+    token_env: str = ""
+    header_name: str = "Authorization"
+    header_prefix: str = "Bearer "
+    token_url: str = ""
+    client_id_env: str = ""
+    client_secret_env: str = ""
+    scope: str = ""
+
+
+@dataclass(frozen=True)
+class OdataConnection:
+    """A single OData v4 connection.
+
+    Attributes:
+        service_root: Service root URL (e.g. ``https://host/odata/v4/svc``).
+        entity_set: Entity-set name to poll / write back.
+        timestamp_property: Change-timestamp property used by watermark polling.
+            Per-connection because no standard name exists across vendors.
+        key_properties: Key property name(s). When empty they are derived from
+            ``$metadata`` via :func:`discover_keys`.
+        filter: Optional extra ``$filter`` clause ANDed with the watermark
+            predicate.
+        start_watermark: Initial watermark for a fresh cursor.
+        page_size: ``$top`` page hint (0 = server default; paging still follows
+            ``@odata.nextLink``).
+        poll_interval_s: Advisory minimum seconds between polls (the scheduler
+            owns cadence; recorded here for operators).
+        rate_limit_min_interval_s: Minimum seconds between HTTP calls.
+        prefer_delta: Opt into probing for ``@odata.deltaLink``.
+        auth: Auth configuration.
+        draft_flow: Whether writes go through a draft-activate flow.
+        draft_activate_action: Bound-action name that activates a draft.
+        max_retry_after_s: Cap on an honored ``Retry-After`` value.
+        name: Stable connection label used in event source / metadata.
+    """
+
+    service_root: str
+    entity_set: str
+    timestamp_property: str = ""
+    key_properties: tuple[str, ...] = ()
+    filter: str = ""
+    start_watermark: str = "1970-01-01T00:00:00Z"
+    page_size: int = 0
+    poll_interval_s: float = 60.0
+    rate_limit_min_interval_s: float = 0.0
+    prefer_delta: bool = False
+    auth: OdataAuth = field(default_factory=OdataAuth)
+    draft_flow: bool = False
+    draft_activate_action: str = ""
+    max_retry_after_s: float = 300.0
+    name: str = "odata"
+
+
+# ---------------------------------------------------------------------------
+# Cursor
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class OdataCursor:
+    """Deterministic, chain-anchorable poll cursor.
+
+    Attributes:
+        entity_set: Entity set the cursor belongs to.
+        mode: ``"watermark"`` or ``"delta"``.
+        watermark: Last-seen maximum change timestamp; always maintained, even
+            in delta mode, so a delta downgrade never loses the resume point.
+        delta_link: The ``@odata.deltaLink`` to follow next (delta mode only).
+        last_page_hash: ``sha256:`` digest of the last result page, so an
+            auditor can prove which window of changes produced which tasks.
+        probed: Whether a delta probe has already been attempted (so a
+            watermark-only service is not re-probed every poll).
+    """
+
+    entity_set: str
+    mode: Literal["watermark", "delta"]
+    watermark: str
+    delta_link: str = ""
+    last_page_hash: str = ""
+    probed: bool = False
+
+    @classmethod
+    def initial(cls, connection: OdataConnection) -> OdataCursor:
+        """Return a fresh watermark cursor for ``connection``."""
+        return cls(
+            entity_set=connection.entity_set,
+            mode="watermark",
+            watermark=connection.start_watermark,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serialisable mapping (stable field order)."""
+        return {
+            "entity_set": self.entity_set,
+            "mode": self.mode,
+            "watermark": self.watermark,
+            "delta_link": self.delta_link,
+            "last_page_hash": self.last_page_hash,
+            "probed": self.probed,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> OdataCursor:
+        """Rebuild a cursor from :meth:`to_dict` output."""
+        return cls(
+            entity_set=str(data["entity_set"]),
+            mode="delta" if data.get("mode") == "delta" else "watermark",
+            watermark=str(data["watermark"]),
+            delta_link=str(data.get("delta_link", "")),
+            last_page_hash=str(data.get("last_page_hash", "")),
+            probed=bool(data.get("probed", False)),
+        )
+
+    def content_hash(self) -> str:
+        """Return the content-addressed identifier for this cursor."""
+        return "sha256:" + hashlib.sha256(_canonical_bytes(self.to_dict())).hexdigest()
+
+
+def save_cursor(path: Path, cursor: OdataCursor) -> None:
+    """Persist ``cursor`` to ``path`` as canonical bytes (byte-stable)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(_canonical_bytes(cursor.to_dict()) + b"\n")
+
+
+def load_cursor(path: Path) -> OdataCursor | None:
+    """Load a cursor from ``path``; return ``None`` when the file is absent."""
+    if not path.exists():
+        return None
+    return OdataCursor.from_dict(json.loads(path.read_bytes().decode("utf-8")))
+
+
+# ---------------------------------------------------------------------------
+# HTTP client
+# ---------------------------------------------------------------------------
+
+
+class OdataHttpClient:
+    """Thin OData HTTP client: auth, paging, 429/Retry-After, throttle.
+
+    Args:
+        connection: The connection this client serves.
+        http_client: Optional pre-built ``httpx.Client`` (tests inject one bound
+            to the in-process fake). When omitted, one is built against
+            ``connection.service_root``.
+        clock: Injected clock; defaults to :class:`RealClock`.
+        max_429_retries: Retry budget for 429 responses.
+        token_fetcher: Optional override for OAuth2 token acquisition (tests).
+    """
+
+    def __init__(
+        self,
+        connection: OdataConnection,
+        *,
+        http_client: Any | None = None,
+        clock: Clock | None = None,
+        max_429_retries: int = 5,
+        token_fetcher: Callable[[OdataAuth], str] | None = None,
+    ) -> None:
+        if http_client is None and httpx is None:  # pragma: no cover - dep present
+            msg = "httpx is required for OdataHttpClient"
+            raise RuntimeError(msg)
+        self._conn = connection
+        self._client: Any = http_client or httpx.Client(base_url=connection.service_root, timeout=30.0)
+        self._owns_client = http_client is None
+        self._clock: Clock = clock or RealClock()
+        self._max_429_retries = max_429_retries
+        self._token_fetcher = token_fetcher
+        self._last_call_at: float | None = None
+        self._oauth_token: str | None = None
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def close(self) -> None:
+        """Release the HTTP client if this instance owns it."""
+        if self._owns_client:
+            try:
+                self._client.close()
+            except Exception:  # pragma: no cover - best effort
+                logger.debug("ignoring error while closing httpx client", exc_info=True)
+
+    # -- auth --------------------------------------------------------------
+
+    def auth_headers(self) -> dict[str, str]:
+        """Return the auth headers for this connection (never logged raw)."""
+        auth = self._conn.auth
+        if auth.kind == "none":
+            return {}
+        if auth.kind == "bearer":
+            return {auth.header_name: f"{auth.header_prefix}{_require_env(auth.token_env)}"}
+        if auth.kind == "api_key":
+            return {auth.header_name: _require_env(auth.token_env)}
+        if auth.kind == "oauth2_client_credentials":
+            token = self._resolve_oauth_token(auth)
+            return {auth.header_name: f"{auth.header_prefix}{token}"}
+        raise OdataAuthError(f"unsupported auth kind: {auth.kind!r}")  # pragma: no cover - guarded by Literal
+
+    def _resolve_oauth_token(self, auth: OdataAuth) -> str:
+        if self._oauth_token is not None:
+            return self._oauth_token
+        if self._token_fetcher is not None:
+            self._oauth_token = self._token_fetcher(auth)
+            return self._oauth_token
+        client_id = _require_env(auth.client_id_env)
+        client_secret = _require_env(auth.client_secret_env)
+        form: dict[str, str] = {
+            "grant_type": "client_credentials",
+            "client_id": client_id,
+            "client_secret": client_secret,
+        }
+        if auth.scope:
+            form["scope"] = auth.scope
+        resp = self._client.post(auth.token_url, data=form, headers={"Accept": "application/json"})
+        if resp.status_code >= 400:
+            raise OdataAuthError(f"OAuth2 token endpoint returned {resp.status_code}")
+        token = resp.json().get("access_token")
+        if not token:
+            raise OdataAuthError("OAuth2 token response missing access_token")
+        self._oauth_token = str(token)
+        return self._oauth_token
+
+    @staticmethod
+    def sanitize_headers(headers: dict[str, str]) -> dict[str, str]:
+        """Return a copy of ``headers`` with sensitive values redacted."""
+        redacted: dict[str, str] = {}
+        for name, value in headers.items():
+            if name.lower().startswith(_SENSITIVE_HEADER_PREFIXES):
+                redacted[name] = "***"
+            else:
+                redacted[name] = value
+        return redacted
+
+    # -- request pipeline --------------------------------------------------
+
+    def _throttle(self) -> None:
+        interval = self._conn.rate_limit_min_interval_s
+        if interval <= 0:
+            self._last_call_at = self._clock.now()
+            return
+        now = self._clock.now()
+        if self._last_call_at is not None:
+            wait = interval - (now - self._last_call_at)
+            if wait > 0:
+                self._clock.sleep(wait)
+        self._last_call_at = self._clock.now()
+
+    def _request(
+        self,
+        method: str,
+        url: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json_body: dict[str, Any] | None = None,
+        form_body: dict[str, str] | None = None,
+        if_match: str | None = None,
+        prefer: str | None = None,
+    ) -> Any:
+        headers: dict[str, str] = {"Accept": "application/json"}
+        headers.update(self.auth_headers())
+        if json_body is not None:
+            headers["Content-Type"] = "application/json"
+        if if_match is not None:
+            headers["If-Match"] = if_match
+        if prefer is not None:
+            headers["Prefer"] = prefer
+
+        attempt = 0
+        while True:
+            self._throttle()
+            try:
+                resp = self._client.request(
+                    method,
+                    url,
+                    params=params,
+                    json=json_body,
+                    data=form_body,
+                    headers=headers,
+                )
+            except Exception as exc:  # pragma: no cover - transport failure
+                logger.warning("OData transport error: %s %s", method, url)
+                raise OdataError(f"OData transport error: {exc}") from exc
+
+            status = getattr(resp, "status_code", 0)
+            logger.debug("OData %s %s -> %s headers=%s", method, url, status, self.sanitize_headers(headers))
+
+            if status == 429:
+                retry_after = _parse_retry_after(resp)
+                if attempt < self._max_429_retries:
+                    wait = retry_after if retry_after is not None else self._conn.rate_limit_min_interval_s
+                    wait = min(wait, self._conn.max_retry_after_s)
+                    if wait > 0:
+                        self._clock.sleep(wait)
+                    attempt += 1
+                    continue
+                raise RateLimited(f"OData rate-limited after {attempt} retries", retry_after)
+            return resp
+
+    # -- typed operations --------------------------------------------------
+
+    def get_metadata(self) -> str:
+        """Return the raw ``$metadata`` CSDL document."""
+        resp = self._request("GET", f"{self._conn.service_root.rstrip('/')}/$metadata")
+        if getattr(resp, "status_code", 0) >= 400:
+            raise OdataError(f"metadata request failed: {resp.status_code}")
+        return str(resp.text)
+
+    def get_json(self, url: str, *, params: dict[str, Any] | None = None, prefer: str | None = None) -> Any:
+        """GET ``url`` and return the parsed JSON body (raises on >= 400)."""
+        resp = self._request("GET", url, params=params, prefer=prefer)
+        status = getattr(resp, "status_code", 0)
+        if status >= 400:
+            raise OdataError(f"OData GET {url} failed: {status}")
+        return resp.json()
+
+    def get_entity(self, predicate: str) -> tuple[dict[str, Any], str | None]:
+        """GET a single entity by ``<EntitySet>(<key>)`` predicate + ETag."""
+        url = f"{self._conn.service_root.rstrip('/')}/{predicate}"
+        resp = self._request("GET", url)
+        status = getattr(resp, "status_code", 0)
+        if status == 404:
+            raise OdataError(f"entity not found: {predicate}")
+        if status >= 400:
+            raise OdataError(f"OData GET {predicate} failed: {status}")
+        body = resp.json()
+        return body, _etag_of(resp, body)
+
+    def patch_entity(
+        self,
+        predicate: str,
+        patch: dict[str, Any],
+        *,
+        if_match: str | None,
+    ) -> tuple[int, dict[str, Any] | None, str | None]:
+        """PATCH an entity; surface 412 / 428 as :class:`OdataConflict`."""
+        url = f"{self._conn.service_root.rstrip('/')}/{predicate}"
+        resp = self._request("PATCH", url, json_body=patch, if_match=if_match)
+        status = getattr(resp, "status_code", 0)
+        if status == 412:
+            raise OdataConflict("If-Match precondition failed (ETag stale)", status=412)
+        if status == 428:
+            raise OdataConflict("If-Match precondition required", status=428)
+        if status >= 400:
+            raise OdataError(f"OData PATCH {predicate} failed: {status}")
+        body = resp.json() if getattr(resp, "content", b"") else None
+        return status, body, _etag_of(resp, body)
+
+    def post(
+        self,
+        predicate: str,
+        json_body: dict[str, Any] | None = None,
+    ) -> tuple[int, dict[str, Any] | None, str | None]:
+        """POST to ``<EntitySet>`` (create) or a bound action path."""
+        url = f"{self._conn.service_root.rstrip('/')}/{predicate}"
+        resp = self._request("POST", url, json_body=json_body if json_body is not None else {})
+        status = getattr(resp, "status_code", 0)
+        if status >= 400:
+            raise OdataError(f"OData POST {predicate} failed: {status}")
+        body = resp.json() if getattr(resp, "content", b"") else None
+        return status, body, _etag_of(resp, body)
+
+
+# ---------------------------------------------------------------------------
+# Key discovery + predicate building
+# ---------------------------------------------------------------------------
+
+
+def discover_keys(connection: OdataConnection, client: OdataHttpClient) -> tuple[str, ...]:
+    """Return the key property names for ``connection.entity_set``.
+
+    Uses ``connection.key_properties`` when configured; otherwise parses
+    ``$metadata`` for the entity type's ``<Key>`` property refs.
+    """
+    if connection.key_properties:
+        return tuple(connection.key_properties)
+    metadata = client.get_metadata()
+    for match in _METADATA_KEY_RE.finditer(metadata):
+        if match.group("name") == connection.entity_set:
+            refs = tuple(m.group("name") for m in _PROPERTY_REF_RE.finditer(match.group("keys")))
+            if refs:
+                return refs
+    raise OdataError(f"could not derive key properties for entity set {connection.entity_set!r}")
+
+
+def build_key_predicate(entity_set: str, key: dict[str, Any]) -> str:
+    """Build an OData key predicate, e.g. ``Widgets(1)`` or ``Widgets(a=1,b='x')``.
+
+    A single key renders as a bare literal; a composite key renders as
+    ``name=value`` pairs in sorted order for determinism.
+    """
+    if not key:
+        raise OdataError("key predicate requires at least one key property")
+    if len(key) == 1:
+        (only_value,) = key.values()
+        return f"{entity_set}({_key_literal(only_value)})"
+    parts = ",".join(f"{name}={_key_literal(key[name])}" for name in sorted(key))
+    return f"{entity_set}({parts})"
+
+
+def key_signature(key: dict[str, Any]) -> str:
+    """Return the inner key text (without the entity-set wrapper), sorted."""
+    if len(key) == 1:
+        (name,) = key
+        return f"{name}={_key_literal(key[name])}"
+    return ",".join(f"{name}={_key_literal(key[name])}" for name in sorted(key))
+
+
+# ---------------------------------------------------------------------------
+# Poll source
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PollResult:
+    """Outcome of one poll: emitted events plus the advanced cursor."""
+
+    events: tuple[TriggerEvent, ...]
+    cursor: OdataCursor
+
+
+class OdataPollSource:
+    """Poll an OData entity set and normalise changes into TriggerEvents."""
+
+    def __init__(self, connection: OdataConnection, *, http_client: OdataHttpClient | None = None) -> None:
+        self._conn = connection
+        self._client = http_client or OdataHttpClient(connection)
+        self._keys: tuple[str, ...] | None = tuple(connection.key_properties) or None
+
+    # -- TriggerSource protocol -------------------------------------------
+
+    def normalize(self, raw_event: dict[str, Any]) -> TriggerEvent:
+        """Convert one OData entity into a normalised TriggerEvent."""
+        return self._to_event(raw_event, change_kind="upsert")
+
+    # -- polling ----------------------------------------------------------
+
+    def poll(self, cursor: OdataCursor | None) -> PollResult:
+        """Run one poll cycle and return emitted events + the next cursor."""
+        cursor = cursor or OdataCursor.initial(self._conn)
+
+        if cursor.mode == "delta" and cursor.delta_link:
+            try:
+                return self._poll_delta(cursor)
+            except OdataError as exc:
+                # Fall back to watermark polling WITHOUT losing the cursor: the
+                # maintained watermark is the resume position. Do not re-probe
+                # this cycle (probed stays True so we do not thrash).
+                logger.info("OData delta read failed (%s); falling back to watermark polling", exc)
+                cursor = replace(cursor, mode="watermark", delta_link="")
+                return self._poll_watermark(cursor, allow_probe=False)
+
+        allow_probe = self._conn.prefer_delta and not cursor.probed
+        return self._poll_watermark(cursor, allow_probe=allow_probe)
+
+    def _poll_watermark(self, cursor: OdataCursor, *, allow_probe: bool) -> PollResult:
+        prefer = "odata.track-changes" if allow_probe else None
+        entities, delta_link = self._drain(self._first_watermark_url(cursor), prefer=prefer)
+
+        events = tuple(self._to_event(e, change_kind="upsert") for e in entities if "@removed" not in e)
+        new_watermark = self._advance_watermark(cursor.watermark, entities)
+        page_hash = _hash_entities(entities)
+
+        if allow_probe and delta_link:
+            next_cursor = OdataCursor(
+                entity_set=self._conn.entity_set,
+                mode="delta",
+                watermark=new_watermark,
+                delta_link=delta_link,
+                last_page_hash=page_hash,
+                probed=True,
+            )
+        else:
+            next_cursor = OdataCursor(
+                entity_set=self._conn.entity_set,
+                mode="watermark",
+                watermark=new_watermark,
+                last_page_hash=page_hash,
+                probed=cursor.probed or allow_probe,
+            )
+        return PollResult(events=events, cursor=next_cursor)
+
+    def _poll_delta(self, cursor: OdataCursor) -> PollResult:
+        entities, delta_link = self._drain(cursor.delta_link, prefer=None)
+        if not delta_link:
+            # A delta read that returns no fresh deltaLink is treated as a delta
+            # failure so the caller falls back to watermark polling.
+            raise OdataError("delta response did not include @odata.deltaLink")
+
+        events: list[TriggerEvent] = []
+        new_watermark = cursor.watermark
+        for entity in entities:
+            if "@removed" in entity:
+                events.append(self._to_event(entity, change_kind="delete"))
+                continue
+            events.append(self._to_event(entity, change_kind="upsert"))
+            new_watermark = _max_str(new_watermark, str(entity.get(self._conn.timestamp_property, "")))
+
+        return PollResult(
+            events=tuple(events),
+            cursor=OdataCursor(
+                entity_set=self._conn.entity_set,
+                mode="delta",
+                watermark=new_watermark,
+                delta_link=delta_link,
+                last_page_hash=_hash_entities(entities),
+                probed=True,
+            ),
+        )
+
+    # -- helpers ----------------------------------------------------------
+
+    def _first_watermark_url(self, cursor: OdataCursor) -> str:
+        root = self._conn.service_root.rstrip("/")
+        ts = self._conn.timestamp_property
+        clauses = [f"{ts} gt {cursor.watermark}"]
+        if self._conn.filter:
+            clauses.append(f"({self._conn.filter})")
+        params: list[str] = [
+            f"$filter={' and '.join(clauses)}",
+            f"$orderby={ts} asc",
+        ]
+        if self._conn.page_size > 0:
+            params.append(f"$top={self._conn.page_size}")
+        return f"{root}/{self._conn.entity_set}?{'&'.join(params)}"
+
+    def _drain(self, url: str, *, prefer: str | None) -> tuple[list[dict[str, Any]], str]:
+        """Follow ``@odata.nextLink`` pages; return all rows + final deltaLink."""
+        collected: list[dict[str, Any]] = []
+        delta_link = ""
+        next_url: str | None = url
+        while next_url:
+            body = self._client.get_json(next_url, prefer=prefer)
+            collected.extend(body.get("value", []))
+            delta_link = body.get("@odata.deltaLink", delta_link)
+            next_url = body.get("@odata.nextLink")
+            # Prefer is only meaningful on the initial request of a sequence.
+            prefer = None
+        return collected, delta_link
+
+    def _advance_watermark(self, current: str, entities: list[dict[str, Any]]) -> str:
+        ts = self._conn.timestamp_property
+        watermark = current
+        for entity in entities:
+            if "@removed" in entity:
+                continue
+            watermark = _max_str(watermark, str(entity.get(ts, "")))
+        return watermark
+
+    def _key_dict(self, entity: dict[str, Any]) -> dict[str, Any]:
+        return {name: entity.get(name) for name in self._key_names()}
+
+    def _key_names(self) -> tuple[str, ...]:
+        if self._keys is None:
+            self._keys = discover_keys(self._conn, self._client)
+        return self._keys
+
+    def _to_event(self, entity: dict[str, Any], *, change_kind: str) -> TriggerEvent:
+        key = self._key_dict(entity)
+        predicate_inner = key_signature(key)
+        ts_value = str(entity.get(self._conn.timestamp_property, ""))
+        return TriggerEvent(
+            source=f"odata:{self._conn.name}",
+            timestamp=_parse_ts(ts_value),
+            raw_payload=dict(entity),
+            message=f"{self._conn.entity_set} {predicate_inner} {change_kind}"[:500],
+            metadata={
+                "source_type": "odata_poll",
+                "connection": self._conn.name,
+                "entity_set": self._conn.entity_set,
+                "entity_key": predicate_inner,
+                "change_kind": change_kind,
+                "watermark": ts_value,
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# Module helpers
+# ---------------------------------------------------------------------------
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name, "") if name else ""
+    if not value:
+        raise OdataAuthError(f"required credential env var {name!r} is not set")
+    return value
+
+
+def _key_literal(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    return f"'{value}'"
+
+
+def _canonical_bytes(payload: dict[str, Any]) -> bytes:
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def _hash_entities(entities: list[dict[str, Any]]) -> str:
+    return "sha256:" + hashlib.sha256(_canonical_bytes({"value": entities})).hexdigest()
+
+
+def _max_str(current: str, candidate: str) -> str:
+    if not candidate:
+        return current
+    return candidate if candidate > current else current
+
+
+def _parse_ts(value: str) -> float:
+    if not value:
+        return 0.0
+    text = value.replace("Z", "+00:00") if value.endswith("Z") else value
+    try:
+        return datetime.fromisoformat(text).timestamp()
+    except ValueError:
+        return 0.0
+
+
+def _parse_retry_after(response: Any) -> float | None:
+    headers = getattr(response, "headers", {}) or {}
+    raw = headers.get("Retry-After") if hasattr(headers, "get") else None
+    if raw is None:
+        return None
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def _etag_of(response: Any, body: dict[str, Any] | None) -> str | None:
+    if isinstance(body, dict) and body.get("@odata.etag"):
+        return str(body["@odata.etag"])
+    headers = getattr(response, "headers", {}) or {}
+    etag = headers.get("ETag") if hasattr(headers, "get") else None
+    return str(etag) if etag else None

--- a/tests/unit/odata/__init__.py
+++ b/tests/unit/odata/__init__.py
@@ -1,0 +1,1 @@
+"""Hermetic OData v4 test harness for the odata_poll / odata_writeback suites."""

--- a/tests/unit/odata/fake_service.py
+++ b/tests/unit/odata/fake_service.py
@@ -1,0 +1,444 @@
+"""In-process fake OData v4 service for hermetic integration tests.
+
+The fake is a Starlette ASGI app driven through ``httpx.ASGITransport`` so no
+socket, port, or real clock is involved. It models the slice of the OData v4
+protocol the ``odata_poll`` trigger source and the ``odata_writeback`` helper
+exercise:
+
+* ``GET /$metadata`` -- a minimal CSDL XML document whose ``EntityType`` names
+  the key property, so ``discover_keys`` has something real to parse.
+* ``GET /<EntitySet>`` -- a collection page with ``$filter=<ts> gt <watermark>``
+  support, ``$orderby``, and server-driven paging via ``@odata.nextLink``
+  (opaque ``$skiptoken``).
+* ``Prefer: odata.track-changes`` -- when delta tracking is enabled the final
+  page carries ``@odata.deltaLink`` and the response sets
+  ``Preference-Applied``; otherwise the header is ignored (the real-world
+  fallback the source must tolerate).
+* ``GET /<EntitySet>?$deltatoken=...`` -- changed entities since the token plus
+  a fresh ``@odata.deltaLink``; deletions surface as ``@removed`` tombstones.
+* ``GET /<EntitySet>(<key>)`` -- a single entity with ``@odata.etag`` and an
+  ``ETag`` header.
+* ``PATCH /<EntitySet>(<key>)`` -- ``If-Match`` enforced: missing precondition
+  is ``428``, a stale precondition is ``412``, a match applies the patch and
+  bumps the ETag.
+* Draft-activate flow -- ``POST`` a draft, ``PATCH`` the draft, ``POST`` the
+  bound activate action to promote it to an active entity.
+* A configurable ``429 + Retry-After`` throttle plan.
+
+Every request is appended to :attr:`FakeODataService.calls` so tests can assert
+on inter-call spacing, ``Prefer`` negotiation, and ``If-Match`` values without
+reaching into the transport.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from dataclasses import dataclass, field
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse, PlainTextResponse, Response
+from starlette.routing import Route
+
+BASE_URL = "http://odata.test"
+
+_KEY_PREDICATE_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)\((.*)\)$")
+
+
+@dataclass
+class FakeClock:
+    """Deterministic clock: ``sleep`` advances virtual time and is recorded.
+
+    Satisfies the ``Clock`` protocol the OData HTTP client depends on, so the
+    rate-limit and ``Retry-After`` paths are exercised without any real sleep.
+    """
+
+    _t: float = 0.0
+    sleeps: list[float] = field(default_factory=list)
+
+    def now(self) -> float:
+        return self._t
+
+    def sleep(self, seconds: float) -> None:
+        if seconds > 0:
+            self.sleeps.append(seconds)
+            self._t += seconds
+
+
+@dataclass
+class CallRecord:
+    """One recorded HTTP call against the fake."""
+
+    method: str
+    path: str
+    query: str
+    prefer: str
+    if_match: str | None
+
+
+@dataclass
+class _Entity:
+    """Server-side entity row with change bookkeeping."""
+
+    key: int
+    fields: dict[str, Any]
+    version: int
+    seq: int
+
+
+@dataclass
+class FakeODataService:
+    """Configurable in-process OData v4 service.
+
+    Args:
+        entity_set: Entity-set name served at ``/<entity_set>``.
+        key_property: Single integer key property name.
+        timestamp_property: Change-timestamp property used by watermark polling.
+        page_size: Server-driven page size for collection reads.
+        delta_enabled: Whether ``Prefer: odata.track-changes`` yields a delta
+            link. When ``False`` the header is accepted but ignored.
+        activate_action: Bound-action name used by the draft-activate flow.
+    """
+
+    entity_set: str = "Widgets"
+    key_property: str = "id"
+    timestamp_property: str = "modified"
+    page_size: int = 2
+    delta_enabled: bool = True
+    activate_action: str = "Activate"
+
+    _entities: dict[int, _Entity] = field(default_factory=dict)
+    _deleted: dict[int, int] = field(default_factory=dict)
+    _drafts: dict[int, _Entity] = field(default_factory=dict)
+    _change_seq: int = 0
+    _draft_seq: int = 0
+    calls: list[CallRecord] = field(default_factory=list)
+    # Throttle plan: number of leading requests to reject with 429 + Retry-After.
+    throttle_first_n: int = 0
+    throttle_retry_after: int = 10
+    _throttled: int = 0
+    # When True, delta-token reads fail (models a view-backed set that silently
+    # drops delta support), forcing the client to fall back to watermark polling.
+    delta_broken: bool = False
+    # When True, a single-entity GET bumps the entity version right after it is
+    # served, so a following PATCH with the just-read ETag hits a 412 (models a
+    # concurrent human edit landing between GET and PATCH).
+    bump_on_entity_get: bool = False
+    # When False, single-entity reads omit the ETag (models a service that does
+    # not surface concurrency tokens), so a write-back has no fresh ETag -> 428.
+    expose_etag: bool = True
+
+    # -- seeding / mutation (test-facing) ----------------------------------
+
+    def seed(self, key: int, *, timestamp: str, **fields: Any) -> None:
+        """Insert or replace an entity, advancing its change sequence."""
+        self._change_seq += 1
+        row = self._entities.get(key)
+        version = (row.version + 1) if row is not None else 1
+        payload = {self.key_property: key, self.timestamp_property: timestamp, **fields}
+        self._entities[key] = _Entity(key=key, fields=payload, version=version, seq=self._change_seq)
+        self._deleted.pop(key, None)
+
+    def delete(self, key: int) -> None:
+        """Delete an entity, recording a delta tombstone."""
+        self._change_seq += 1
+        self._entities.pop(key, None)
+        self._deleted[key] = self._change_seq
+
+    # -- transport ---------------------------------------------------------
+
+    def client(self) -> httpx.Client:
+        """Return a sync ``httpx.Client`` bound to this ASGI app (no sockets).
+
+        The transport bridges each sync request into the real Starlette ASGI
+        app via a short-lived event loop, so the fake stays a genuine ASGI
+        application while remaining drivable by the synchronous production
+        HTTP client (whose ``httpx`` build ships an async-only
+        ``ASGITransport``).
+        """
+        app = self.app()
+        return httpx.Client(transport=httpx.MockTransport(lambda req: _asgi_roundtrip(app, req)), base_url=BASE_URL)
+
+    def app(self) -> Starlette:
+        """Build the Starlette app dispatching every OData route."""
+        return Starlette(routes=[Route("/{full_path:path}", self._dispatch, methods=["GET", "PATCH", "POST"])])
+
+    # -- dispatch ----------------------------------------------------------
+
+    async def _dispatch(self, request: Request) -> Response:
+        full_path = request.path_params["full_path"]
+        prefer = request.headers.get("prefer", "")
+        if_match = request.headers.get("if-match")
+        self.calls.append(
+            CallRecord(
+                method=request.method,
+                path=full_path,
+                query=request.url.query,
+                prefer=prefer,
+                if_match=if_match,
+            )
+        )
+
+        throttled = self._maybe_throttle()
+        if throttled is not None:
+            return throttled
+
+        if full_path == "$metadata":
+            return self._metadata_response()
+
+        predicate = _KEY_PREDICATE_RE.match(full_path)
+        if predicate is not None:
+            name, inner = predicate.group(1), predicate.group(2)
+            if name != self.entity_set:
+                return _error(404, "unknown entity set")
+            return await self._entity_route(request, inner, if_match)
+
+        # Bound-action call: ``<EntitySet>(<key>)/<Action>``.
+        action = re.match(rf"^{re.escape(self.entity_set)}\((.*)\)/(.+)$", full_path)
+        if action is not None:
+            return self._activate_draft(action.group(1), action.group(2))
+
+        if full_path == self.entity_set:
+            if request.method == "POST":
+                body = await _json_body(request)
+                return self._create_draft(body)
+            return self._collection_response(request, prefer)
+
+        return _error(404, f"no route for {full_path!r}")
+
+    def _maybe_throttle(self) -> Response | None:
+        if self._throttled < self.throttle_first_n:
+            self._throttled += 1
+            return Response(
+                content=b'{"error":{"code":"429","message":"Too Many Requests"}}',
+                status_code=429,
+                media_type="application/json",
+                headers={"Retry-After": str(self.throttle_retry_after)},
+            )
+        return None
+
+    # -- collection --------------------------------------------------------
+
+    def _collection_response(self, request: Request, prefer: str) -> Response:
+        params = dict(request.query_params)
+        delta_token = params.get("$deltatoken")
+        if delta_token is not None:
+            if self.delta_broken:
+                return _error(400, "delta tracking not supported for this entity set")
+            return self._delta_page(int(delta_token))
+
+        track_changes = "odata.track-changes" in prefer and self.delta_enabled
+        rows = self._watermark_rows(params.get("$filter", ""))
+        skiptoken = params.get("$skiptoken")
+        start = int(skiptoken) if skiptoken is not None else 0
+        page = rows[start : start + self.page_size]
+        next_start = start + self.page_size
+
+        body: dict[str, Any] = {
+            "@odata.context": f"{BASE_URL}/$metadata#{self.entity_set}",
+            "value": [self._as_wire(r) for r in page],
+        }
+        headers: dict[str, str] = {}
+        if next_start < len(rows):
+            body["@odata.nextLink"] = f"{BASE_URL}/{self.entity_set}?$skiptoken={next_start}"
+        elif track_changes:
+            body["@odata.deltaLink"] = f"{BASE_URL}/{self.entity_set}?$deltatoken={self._change_seq}"
+            headers["Preference-Applied"] = "odata.track-changes"
+        return JSONResponse(body, headers=headers)
+
+    def _watermark_rows(self, filter_expr: str) -> list[_Entity]:
+        rows = list(self._entities.values())
+        match = re.search(r"(\w+)\s+gt\s+(\S+)", filter_expr)
+        if match is not None:
+            prop, raw = match.group(1), match.group(2)
+            watermark = raw.strip("'")
+            rows = [r for r in rows if str(r.fields.get(prop, "")) > watermark]
+        rows.sort(key=lambda r: (str(r.fields.get(self.timestamp_property, "")), r.key))
+        return rows
+
+    def _delta_page(self, token: int) -> Response:
+        changed = [r for r in self._entities.values() if r.seq > token]
+        changed.sort(key=lambda r: r.seq)
+        removed = sorted((k for k, s in self._deleted.items() if s > token))
+        value: list[dict[str, Any]] = [self._as_wire(r) for r in changed]
+        for key in removed:
+            value.append({"@removed": {"reason": "deleted"}, self.key_property: key})
+        body = {
+            "@odata.context": f"{BASE_URL}/$metadata#{self.entity_set}/$delta",
+            "value": value,
+            "@odata.deltaLink": f"{BASE_URL}/{self.entity_set}?$deltatoken={self._change_seq}",
+        }
+        return JSONResponse(body)
+
+    # -- single entity -----------------------------------------------------
+
+    async def _entity_route(self, request: Request, inner: str, if_match: str | None) -> Response:
+        key = self._parse_key(inner)
+        if key is None:
+            return _error(400, "unparseable key")
+        if request.method == "GET":
+            row = self._entities.get(key) or self._drafts.get(key)
+            if row is None:
+                return _error(404, "not found")
+            response = self._entity_response(row, with_etag=self.expose_etag)
+            if self.bump_on_entity_get and key in self._entities:
+                # A concurrent edit lands right after the read: bump the version.
+                self._change_seq += 1
+                row.version += 1
+                row.seq = self._change_seq
+            return response
+        if request.method == "PATCH":
+            return await self._patch_entity(request, key, if_match)
+        return _error(405, "method not allowed")
+
+    async def _patch_entity(self, request: Request, key: int, if_match: str | None) -> Response:
+        row = self._entities.get(key) or self._drafts.get(key)
+        if row is None:
+            return _error(404, "not found")
+        if if_match is None:
+            return _error(428, "precondition required")
+        if if_match != _etag(row):
+            return _error(412, "precondition failed")
+        patch = await _json_body(request)
+        self._change_seq += 1
+        row.fields.update({k: v for k, v in patch.items() if not k.startswith("@")})
+        row.version += 1
+        row.seq = self._change_seq
+        return self._entity_response(row)
+
+    # -- draft flow --------------------------------------------------------
+
+    def _create_draft(self, body: dict[str, Any]) -> Response:
+        self._draft_seq += 1
+        draft_key = 100_000 + self._draft_seq
+        payload = {k: v for k, v in body.items() if not k.startswith("@")}
+        payload[self.key_property] = draft_key
+        row = _Entity(key=draft_key, fields=payload, version=1, seq=0)
+        self._drafts[draft_key] = row
+        return self._entity_response(row, status=201)
+
+    def _activate_draft(self, inner: str, action: str) -> Response:
+        if action != self.activate_action:
+            return _error(404, f"unknown action {action!r}")
+        key = self._parse_key(inner)
+        draft = self._drafts.pop(key, None) if key is not None else None
+        if draft is None:
+            return _error(404, "no such draft")
+        self._change_seq += 1
+        draft.seq = self._change_seq
+        self._entities[draft.key] = draft
+        return self._entity_response(draft)
+
+    # -- rendering ---------------------------------------------------------
+
+    def _entity_response(self, row: _Entity, *, status: int = 200, with_etag: bool = True) -> Response:
+        headers = {"ETag": _etag(row)} if with_etag else {}
+        return JSONResponse(self._as_wire(row, with_etag=with_etag), status_code=status, headers=headers)
+
+    def _as_wire(self, row: _Entity, *, with_etag: bool = True) -> dict[str, Any]:
+        if with_etag:
+            return {"@odata.etag": _etag(row), **row.fields}
+        return dict(row.fields)
+
+    def _metadata_response(self) -> Response:
+        xml = (
+            '<?xml version="1.0" encoding="utf-8"?>'
+            '<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">'
+            "<edmx:DataServices>"
+            '<Schema Namespace="Fake" xmlns="http://docs.oasis-open.org/odata/ns/edm">'
+            f'<EntityType Name="{self.entity_set}">'
+            f'<Key><PropertyRef Name="{self.key_property}"/></Key>'
+            f'<Property Name="{self.key_property}" Type="Edm.Int32" Nullable="false"/>'
+            f'<Property Name="{self.timestamp_property}" Type="Edm.DateTimeOffset"/>'
+            '<Property Name="name" Type="Edm.String"/>'
+            "</EntityType>"
+            f'<EntityContainer Name="Container"><EntitySet Name="{self.entity_set}" '
+            f'EntityType="Fake.{self.entity_set}"/></EntityContainer>'
+            "</Schema></edmx:DataServices></edmx:Edmx>"
+        )
+        return PlainTextResponse(xml, media_type="application/xml")
+
+    # -- helpers -----------------------------------------------------------
+
+    def _parse_key(self, inner: str) -> int | None:
+        token = inner.strip()
+        if "=" in token:  # keyed form ``id=1``
+            token = token.split("=", 1)[1].strip()
+        token = token.strip("'")
+        try:
+            return int(token)
+        except ValueError:
+            return None
+
+
+def _etag(row: _Entity) -> str:
+    return f'W/"{row.version}"'
+
+
+def _error(status: int, message: str) -> Response:
+    return JSONResponse({"error": {"code": str(status), "message": message}}, status_code=status)
+
+
+async def _json_body(request: Request) -> dict[str, Any]:
+    raw = await request.body()
+    if not raw:
+        return {}
+    import json
+
+    parsed = json.loads(raw.decode("utf-8"))
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def split_delta_token(delta_link: str) -> str:
+    """Return the ``$deltatoken`` value embedded in a delta link (test helper)."""
+    query = parse_qs(urlparse(delta_link).query)
+    return query.get("$deltatoken", [""])[0]
+
+
+def _asgi_roundtrip(app: Starlette, request: httpx.Request) -> httpx.Response:
+    """Drive one sync request through the ASGI *app* and return the response."""
+    return asyncio.run(_call_asgi(app, request))
+
+
+async def _call_asgi(app: Starlette, request: httpx.Request) -> httpx.Response:
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "http_version": "1.1",
+        "method": request.method,
+        "scheme": request.url.scheme,
+        "path": request.url.path,
+        "raw_path": request.url.path.encode("utf-8"),
+        "query_string": request.url.query.encode("utf-8") if isinstance(request.url.query, str) else request.url.query,
+        "root_path": "",
+        "headers": [(key.lower().encode("latin-1"), value.encode("latin-1")) for key, value in request.headers.items()],
+        "server": (request.url.host, request.url.port or 80),
+        "client": ("testclient", 50000),
+    }
+    body = request.content
+    pending: list[dict[str, Any]] = [{"type": "http.request", "body": body, "more_body": False}]
+    captured: list[dict[str, Any]] = []
+
+    async def receive() -> dict[str, Any]:
+        return pending.pop(0) if pending else {"type": "http.disconnect"}
+
+    async def send(message: dict[str, Any]) -> None:
+        captured.append(message)
+
+    await app(scope, receive, send)
+
+    status = 500
+    raw_headers: list[tuple[bytes, bytes]] = []
+    out = b""
+    for message in captured:
+        if message["type"] == "http.response.start":
+            status = message["status"]
+            raw_headers = message.get("headers", [])
+        elif message["type"] == "http.response.body":
+            out += message.get("body", b"")
+    headers = [(key.decode("latin-1"), value.decode("latin-1")) for key, value in raw_headers]
+    return httpx.Response(status_code=status, headers=headers, content=out, request=request)

--- a/tests/unit/odata/test_fake_service.py
+++ b/tests/unit/odata/test_fake_service.py
@@ -1,0 +1,131 @@
+"""Trust tests for the hermetic fake OData service.
+
+These pin the fake's behaviour so the ``odata_poll`` / ``odata_writeback`` suites
+can rely on it as ground truth.
+"""
+
+from __future__ import annotations
+
+from tests.unit.odata.fake_service import BASE_URL, FakeODataService, split_delta_token
+
+
+def _svc() -> FakeODataService:
+    svc = FakeODataService(page_size=2)
+    svc.seed(1, timestamp="2026-01-01T00:00:01Z", name="alpha")
+    svc.seed(2, timestamp="2026-01-01T00:00:02Z", name="beta")
+    svc.seed(3, timestamp="2026-01-01T00:00:03Z", name="gamma")
+    return svc
+
+
+def test_metadata_names_the_key() -> None:
+    svc = _svc()
+    with svc.client() as client:
+        resp = client.get("/$metadata")
+    assert resp.status_code == 200
+    assert '<PropertyRef Name="id"/>' in resp.text
+    assert 'Name="Widgets"' in resp.text
+
+
+def test_collection_paging_follows_next_link() -> None:
+    svc = _svc()
+    seen: list[int] = []
+    with svc.client() as client:
+        url = f"{BASE_URL}/Widgets?$orderby=modified"
+        while url:
+            body = client.get(url).json()
+            seen.extend(row["id"] for row in body["value"])
+            url = body.get("@odata.nextLink", "")
+    assert seen == [1, 2, 3]
+
+
+def test_watermark_filter_excludes_old_rows() -> None:
+    svc = _svc()
+    with svc.client() as client:
+        body = client.get(f"{BASE_URL}/Widgets?$filter=modified gt 2026-01-01T00:00:02Z").json()
+    assert [row["id"] for row in body["value"]] == [3]
+
+
+def test_delta_link_only_with_prefer_and_enabled() -> None:
+    svc = _svc()
+    with svc.client() as client:
+        # Walk to the last page carrying the Prefer header.
+        url = f"{BASE_URL}/Widgets"
+        body = client.get(url, headers={"Prefer": "odata.track-changes"}).json()
+        while "@odata.nextLink" in body:
+            body = client.get(body["@odata.nextLink"], headers={"Prefer": "odata.track-changes"}).json()
+    assert "@odata.deltaLink" in body
+
+
+def test_delta_disabled_service_never_returns_delta_link() -> None:
+    svc = FakeODataService(page_size=10, delta_enabled=False)
+    svc.seed(1, timestamp="2026-01-01T00:00:01Z", name="alpha")
+    with svc.client() as client:
+        body = client.get(f"{BASE_URL}/Widgets", headers={"Prefer": "odata.track-changes"}).json()
+    assert "@odata.deltaLink" not in body
+
+
+def test_delta_page_reports_changes_and_tombstones() -> None:
+    svc = FakeODataService(page_size=10)
+    svc.seed(1, timestamp="2026-01-01T00:00:01Z", name="alpha")
+    with svc.client() as client:
+        body = client.get(f"{BASE_URL}/Widgets", headers={"Prefer": "odata.track-changes"}).json()
+        token = split_delta_token(body["@odata.deltaLink"])
+        svc.seed(2, timestamp="2026-01-01T00:00:05Z", name="beta")
+        svc.delete(1)
+        delta = client.get(f"{BASE_URL}/Widgets?$deltatoken={token}").json()
+    ids_added = [row["id"] for row in delta["value"] if "@removed" not in row]
+    ids_removed = [row["id"] for row in delta["value"] if "@removed" in row]
+    assert ids_added == [2]
+    assert ids_removed == [1]
+
+
+def test_patch_requires_if_match_428() -> None:
+    svc = _svc()
+    with svc.client() as client:
+        resp = client.patch(f"{BASE_URL}/Widgets(1)", json={"name": "renamed"})
+    assert resp.status_code == 428
+
+
+def test_patch_stale_etag_412() -> None:
+    svc = _svc()
+    with svc.client() as client:
+        etag = client.get(f"{BASE_URL}/Widgets(1)").json()["@odata.etag"]
+        # A concurrent edit bumps the server etag.
+        svc.seed(1, timestamp="2026-01-01T00:00:09Z", name="concurrent")
+        resp = client.patch(f"{BASE_URL}/Widgets(1)", json={"name": "renamed"}, headers={"If-Match": etag})
+    assert resp.status_code == 412
+
+
+def test_patch_match_applies_and_bumps_etag() -> None:
+    svc = _svc()
+    with svc.client() as client:
+        etag = client.get(f"{BASE_URL}/Widgets(1)").json()["@odata.etag"]
+        resp = client.patch(f"{BASE_URL}/Widgets(1)", json={"name": "renamed"}, headers={"If-Match": etag})
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "renamed"
+    assert resp.json()["@odata.etag"] != etag
+
+
+def test_draft_activate_flow() -> None:
+    svc = _svc()
+    with svc.client() as client:
+        draft = client.post(f"{BASE_URL}/Widgets", json={"name": "draft"}).json()
+        draft_key = draft["id"]
+        etag = draft["@odata.etag"]
+        client.patch(f"{BASE_URL}/Widgets({draft_key})", json={"name": "draft-edited"}, headers={"If-Match": etag})
+        activated = client.post(f"{BASE_URL}/Widgets({draft_key})/Activate").json()
+    assert activated["name"] == "draft-edited"
+    with svc.client() as client:
+        # The activated entity is now readable in the active set.
+        assert client.get(f"{BASE_URL}/Widgets({draft_key})").status_code == 200
+
+
+def test_throttle_plan_emits_429_then_recovers() -> None:
+    svc = FakeODataService(page_size=10, throttle_first_n=1, throttle_retry_after=7)
+    svc.seed(1, timestamp="2026-01-01T00:00:01Z", name="alpha")
+    with svc.client() as client:
+        first = client.get(f"{BASE_URL}/Widgets")
+        second = client.get(f"{BASE_URL}/Widgets")
+    assert first.status_code == 429
+    assert first.headers["Retry-After"] == "7"
+    assert second.status_code == 200

--- a/tests/unit/odata/test_odata_poll.py
+++ b/tests/unit/odata/test_odata_poll.py
@@ -1,0 +1,247 @@
+"""Tests for :mod:`bernstein.core.trigger_sources.odata_poll`.
+
+Covers acceptance criteria 1 (watermark loop + byte-identical restart replay),
+2 (delta probe / fallback), 4 (429 + min-interval), and 5 (log sanitisation)
+from issue #2886, driven entirely against the hermetic fake service.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from bernstein.core.trigger_sources.odata_poll import (
+    OdataAuth,
+    OdataConnection,
+    OdataCursor,
+    OdataHttpClient,
+    OdataPollSource,
+    discover_keys,
+    load_cursor,
+    save_cursor,
+)
+from tests.unit.odata.fake_service import FakeClock, FakeODataService
+
+
+def _connection(**overrides: object) -> OdataConnection:
+    base: dict[str, object] = {
+        "service_root": "http://odata.test",
+        "entity_set": "Widgets",
+        "timestamp_property": "modified",
+        "key_properties": ("id",),
+        "name": "erp",
+    }
+    base.update(overrides)
+    return OdataConnection(**base)  # type: ignore[arg-type]
+
+
+def _source(svc: FakeODataService, *, clock: FakeClock | None = None, **conn: object) -> OdataPollSource:
+    client = OdataHttpClient(_connection(**conn), http_client=svc.client(), clock=clock)
+    return OdataPollSource(_connection(**conn), http_client=client)
+
+
+# ---------------------------------------------------------------------------
+# metadata / key discovery
+# ---------------------------------------------------------------------------
+
+
+def test_discover_keys_from_metadata() -> None:
+    svc = FakeODataService()
+    client = OdataHttpClient(_connection(key_properties=()), http_client=svc.client())
+    assert discover_keys(_connection(key_properties=()), client) == ("id",)
+
+
+# ---------------------------------------------------------------------------
+# AC1 -- watermark loop + deterministic restart replay
+# ---------------------------------------------------------------------------
+
+
+def test_watermark_emits_ordered_events_and_advances_cursor() -> None:
+    svc = FakeODataService(page_size=2)
+    svc.seed(1, timestamp="2026-01-01T00:00:01Z", name="alpha")
+    svc.seed(2, timestamp="2026-01-01T00:00:02Z", name="beta")
+    svc.seed(3, timestamp="2026-01-01T00:00:03Z", name="gamma")
+
+    source = _source(svc)
+    result = source.poll(None)
+
+    assert [e.metadata["entity_key"] for e in result.events] == ["id=1", "id=2", "id=3"]
+    assert [e.raw_payload["name"] for e in result.events] == ["alpha", "beta", "gamma"]
+    assert result.cursor.mode == "watermark"
+    assert result.cursor.watermark == "2026-01-01T00:00:03Z"
+
+
+def test_watermark_second_poll_only_returns_new_rows() -> None:
+    svc = FakeODataService(page_size=10)
+    svc.seed(1, timestamp="2026-01-01T00:00:01Z", name="alpha")
+
+    source = _source(svc)
+    first = source.poll(None)
+    assert len(first.events) == 1
+
+    svc.seed(2, timestamp="2026-01-01T00:00:05Z", name="beta")
+    second = source.poll(first.cursor)
+    assert [e.raw_payload["id"] for e in second.events] == [2]
+    assert second.cursor.watermark == "2026-01-01T00:00:05Z"
+
+
+def test_restart_from_persisted_cursor_no_dup_or_drop(tmp_path: object) -> None:
+    import pathlib
+
+    cursor_path = pathlib.Path(str(tmp_path)) / "cursor.json"
+    svc = FakeODataService(page_size=1)
+    svc.seed(1, timestamp="2026-01-01T00:00:01Z", name="alpha")
+    svc.seed(2, timestamp="2026-01-01T00:00:02Z", name="beta")
+
+    source = _source(svc)
+    first = source.poll(None)
+    save_cursor(cursor_path, first.cursor)
+
+    # New process: reload the cursor and add a change.
+    svc.seed(3, timestamp="2026-01-01T00:00:03Z", name="gamma")
+    resumed = load_cursor(cursor_path)
+    assert resumed == first.cursor
+
+    source2 = _source(svc)
+    second = source2.poll(resumed)
+    ids = [e.raw_payload["id"] for e in second.events]
+    assert ids == [3]  # no duplicate of 1/2, no drop of 3
+
+
+def test_replay_is_byte_identical(tmp_path: object) -> None:
+    import pathlib
+
+    def run() -> tuple[list[dict[str, object]], OdataCursor]:
+        svc = FakeODataService(page_size=2)
+        svc.seed(1, timestamp="2026-01-01T00:00:01Z", name="alpha")
+        svc.seed(2, timestamp="2026-01-01T00:00:02Z", name="beta")
+        src = _source(svc)
+        res = src.poll(None)
+        payloads = [dict(e.raw_payload) for e in res.events]
+        return payloads, res.cursor
+
+    payloads_a, cursor_a = run()
+    payloads_b, cursor_b = run()
+    assert payloads_a == payloads_b
+    assert cursor_a == cursor_b
+    # And the persisted cursor form is byte-identical.
+    p1 = pathlib.Path(str(tmp_path)) / "a.json"
+    p2 = pathlib.Path(str(tmp_path)) / "b.json"
+    save_cursor(p1, cursor_a)
+    save_cursor(p2, cursor_b)
+    assert p1.read_bytes() == p2.read_bytes()
+
+
+# ---------------------------------------------------------------------------
+# AC2 -- delta probe / fallback
+# ---------------------------------------------------------------------------
+
+
+def test_delta_mode_activates_only_when_probe_returns_delta_link() -> None:
+    svc = FakeODataService(page_size=10, delta_enabled=True)
+    svc.seed(1, timestamp="2026-01-01T00:00:01Z", name="alpha")
+
+    source = _source(svc, prefer_delta=True)
+    first = source.poll(None)
+    assert first.cursor.mode == "delta"
+    assert first.cursor.delta_link
+
+    # A subsequent change is delivered through the delta link.
+    svc.seed(2, timestamp="2026-01-01T00:00:05Z", name="beta")
+    svc.delete(1)
+    second = source.poll(first.cursor)
+    kinds = {e.metadata["entity_key"]: e.metadata["change_kind"] for e in second.events}
+    assert kinds == {"id=2": "upsert", "id=1": "delete"}
+    assert second.cursor.mode == "delta"
+
+
+def test_prefer_delta_but_service_omits_link_stays_watermark() -> None:
+    svc = FakeODataService(page_size=10, delta_enabled=False)
+    svc.seed(1, timestamp="2026-01-01T00:00:01Z", name="alpha")
+
+    source = _source(svc, prefer_delta=True)
+    first = source.poll(None)
+    assert first.cursor.mode == "watermark"
+
+
+def test_delta_failure_falls_back_to_watermark_without_losing_cursor() -> None:
+    svc = FakeODataService(page_size=10, delta_enabled=True)
+    svc.seed(1, timestamp="2026-01-01T00:00:01Z", name="alpha")
+
+    source = _source(svc, prefer_delta=True)
+    first = source.poll(None)
+    assert first.cursor.mode == "delta"
+    assert first.cursor.watermark == "2026-01-01T00:00:01Z"
+
+    # The entity set silently drops delta support; the next delta read fails.
+    svc.delta_broken = True
+    svc.seed(2, timestamp="2026-01-01T00:00:05Z", name="beta")
+    second = source.poll(first.cursor)
+
+    assert second.cursor.mode == "watermark"  # downgraded
+    assert [e.raw_payload["id"] for e in second.events] == [2]  # served via watermark
+    assert second.cursor.watermark == "2026-01-01T00:00:05Z"  # position preserved + advanced
+
+
+# ---------------------------------------------------------------------------
+# AC4 -- 429 + Retry-After + minimum inter-call interval (fake clock)
+# ---------------------------------------------------------------------------
+
+
+def test_retry_after_honoured_with_fake_clock() -> None:
+    svc = FakeODataService(page_size=10, throttle_first_n=1, throttle_retry_after=10)
+    svc.seed(1, timestamp="2026-01-01T00:00:01Z", name="alpha")
+    clock = FakeClock()
+
+    source = _source(svc, clock=clock)
+    result = source.poll(None)
+
+    assert [e.raw_payload["id"] for e in result.events] == [1]
+    assert 10 in clock.sleeps  # the Retry-After was slept off, not ignored
+
+
+def test_minimum_inter_call_interval_honoured() -> None:
+    svc = FakeODataService(page_size=1)
+    svc.seed(1, timestamp="2026-01-01T00:00:01Z", name="alpha")
+    svc.seed(2, timestamp="2026-01-01T00:00:02Z", name="beta")
+    clock = FakeClock()
+
+    # page_size=1 forces a nextLink follow, i.e. two HTTP calls in one poll.
+    source = _source(svc, clock=clock, rate_limit_min_interval_s=5.0)
+    source.poll(None)
+
+    assert 5 in clock.sleeps
+
+
+# ---------------------------------------------------------------------------
+# AC5 -- credentials never appear in logs
+# ---------------------------------------------------------------------------
+
+
+def test_bearer_token_never_logged(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    monkeypatch.setenv("ODATA_TOKEN", "supersecret-bearer-value")
+    svc = FakeODataService(page_size=10)
+    svc.seed(1, timestamp="2026-01-01T00:00:01Z", name="alpha")
+    auth = OdataAuth(kind="bearer", token_env="ODATA_TOKEN")
+
+    caplog.set_level(logging.DEBUG, logger="bernstein.core.trigger_sources.odata_poll")
+    source = _source(svc, auth=auth)
+    # Also drive an error path (unknown entity) to exercise error logging.
+    source.poll(None)
+    with pytest.raises(Exception):  # noqa: B017 - any OData error is fine here
+        _source(svc, entity_set="Missing").poll(None)
+
+    assert "supersecret-bearer-value" not in caplog.text
+
+
+def test_auth_header_is_sent_but_redacted(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ODATA_TOKEN", "supersecret-bearer-value")
+    svc = FakeODataService(page_size=10)
+    svc.seed(1, timestamp="2026-01-01T00:00:01Z", name="alpha")
+    auth = OdataAuth(kind="bearer", token_env="ODATA_TOKEN")
+    client = OdataHttpClient(_connection(auth=auth), http_client=svc.client())
+    headers = client.auth_headers()
+    assert headers["Authorization"] == "Bearer supersecret-bearer-value"
+    # The sanitiser must hide it.
+    assert client.sanitize_headers(headers)["Authorization"] == "***"

--- a/tests/unit/odata/test_odata_writeback.py
+++ b/tests/unit/odata/test_odata_writeback.py
@@ -1,0 +1,210 @@
+"""Tests for :mod:`bernstein.core.trackers.odata_writeback`.
+
+Covers acceptance criterion 3 from issue #2886: typed 412 / 428 conflicts, a
+successful write-back that emits an audit event + lineage receipt whose payload
+hash matches the sent body, and offline verifiability via ``bernstein audit
+verify``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import pathlib
+
+import pytest
+
+from bernstein.core.security.audit_chain import EVENT_ODATA_WRITEBACK, AuditChainStore
+from bernstein.core.trackers.odata_writeback import (
+    WriteBackReceipt,
+    canonical_payload_hash,
+    update_entity,
+)
+from bernstein.core.trigger_sources.odata_poll import (
+    OdataConflict,
+    OdataConnection,
+    OdataHttpClient,
+)
+from tests.unit.odata.fake_service import FakeODataService
+
+
+def _connection(**overrides: object) -> OdataConnection:
+    base: dict[str, object] = {
+        "service_root": "http://odata.test",
+        "entity_set": "Widgets",
+        "timestamp_property": "modified",
+        "key_properties": ("id",),
+        "name": "erp",
+    }
+    base.update(overrides)
+    return OdataConnection(**base)  # type: ignore[arg-type]
+
+
+def _chain(tmp_path: pathlib.Path) -> AuditChainStore:
+    return AuditChainStore(tmp_path / "audit")
+
+
+def _seeded() -> FakeODataService:
+    svc = FakeODataService(page_size=10)
+    svc.seed(1, timestamp="2026-01-01T00:00:01Z", name="alpha")
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# Independent payload-hash reference
+# ---------------------------------------------------------------------------
+
+
+def _reference_hash(patch: dict[str, object]) -> str:
+    body = json.dumps(patch, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return "sha256:" + hashlib.sha256(body).hexdigest()
+
+
+def test_canonical_payload_hash_matches_independent_sha256() -> None:
+    patch = {"name": "renamed", "priority": 3}
+    assert canonical_payload_hash(patch) == _reference_hash(patch)
+
+
+# ---------------------------------------------------------------------------
+# AC3 -- successful write-back emits a receipt-anchored audit event
+# ---------------------------------------------------------------------------
+
+
+def test_successful_writeback_emits_receipt_and_audit_event(tmp_path: pathlib.Path) -> None:
+    svc = _seeded()
+    conn = _connection()
+    client = OdataHttpClient(conn, http_client=svc.client())
+    chain = _chain(tmp_path)
+    patch = {"name": "renamed"}
+
+    receipt = update_entity(conn, {"id": 1}, patch, chain=chain, http_client=client)
+
+    assert isinstance(receipt, WriteBackReceipt)
+    assert receipt.entity_set == "Widgets"
+    assert receipt.entity_key == "id=1"
+    assert receipt.http_status == 200
+    assert receipt.etag_observed == 'W/"1"'
+    assert receipt.payload_content_hash == _reference_hash(patch)
+
+    events = chain.query(event_type=EVENT_ODATA_WRITEBACK)
+    assert len(events) == 1
+    details = events[0].details
+    assert details["entity_set"] == "Widgets"
+    assert details["entity_key"] == "id=1"
+    assert details["etag_observed"] == 'W/"1"'
+    assert details["payload_content_hash"] == _reference_hash(patch)
+    assert details["http_status"] == 200
+    # The receipt is bound to the recorded chain event.
+    assert receipt.audit_event_hmac == events[0].hmac
+
+
+def test_writeback_audit_event_verifies_offline(tmp_path: pathlib.Path) -> None:
+    svc = _seeded()
+    conn = _connection()
+    client = OdataHttpClient(conn, http_client=svc.client())
+    chain = _chain(tmp_path)
+
+    update_entity(conn, {"id": 1}, {"name": "renamed"}, chain=chain, http_client=client)
+
+    ok, errors = chain.verify()
+    assert ok, errors
+
+
+def test_writeback_verifies_through_audit_verify_cli(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``bernstein audit verify`` covers the write-back receipt with no new verb."""
+    from pathlib import Path
+
+    from click.testing import CliRunner
+
+    from bernstein.cli.commands.audit_cmd import audit_group
+
+    monkeypatch.chdir(tmp_path)
+    svc = _seeded()
+    conn = _connection()
+    client = OdataHttpClient(conn, http_client=svc.client())
+    chain = AuditChainStore(Path(".sdd/audit"))
+    update_entity(conn, {"id": 1}, {"name": "renamed"}, chain=chain, http_client=client)
+
+    ok_run = CliRunner().invoke(audit_group, ["verify", "--hmac-only"])
+    assert ok_run.exit_code == 0, ok_run.output
+
+    # Tamper the recorded event and re-run: the CLI must now exit non-zero.
+    log = next(iter(sorted(Path(".sdd/audit").glob("*.jsonl"))))
+    log.write_text(log.read_text().replace('"entity_key": "id=1"', '"entity_key": "id=9"'))
+    bad_run = CliRunner().invoke(audit_group, ["verify", "--hmac-only"])
+    assert bad_run.exit_code != 0, bad_run.output
+
+
+def test_writeback_tamper_breaks_chain(tmp_path: pathlib.Path) -> None:
+    svc = _seeded()
+    conn = _connection()
+    client = OdataHttpClient(conn, http_client=svc.client())
+    chain = _chain(tmp_path)
+    update_entity(conn, {"id": 1}, {"name": "renamed"}, chain=chain, http_client=client)
+
+    # The raw payload is never stored -- only its content hash. Tamper the
+    # recorded entity key (a field bound into the HMAC): verify must fail.
+    audit_files = list((tmp_path / "audit").glob("*.jsonl"))
+    assert audit_files
+    log = audit_files[0]
+    text = log.read_text()
+    assert '"entity_key": "id=1"' in text
+    log.write_text(text.replace('"entity_key": "id=1"', '"entity_key": "id=9"'))
+
+    ok, _errors = chain.verify()
+    assert not ok
+
+
+# ---------------------------------------------------------------------------
+# AC3 -- typed conflicts (412 + 428)
+# ---------------------------------------------------------------------------
+
+
+def test_stale_etag_raises_412_conflict(tmp_path: pathlib.Path) -> None:
+    svc = _seeded()
+    svc.bump_on_entity_get = True  # concurrent edit between GET and PATCH
+    conn = _connection()
+    client = OdataHttpClient(conn, http_client=svc.client())
+    chain = _chain(tmp_path)
+
+    with pytest.raises(OdataConflict) as excinfo:
+        update_entity(conn, {"id": 1}, {"name": "renamed"}, chain=chain, http_client=client)
+    assert excinfo.value.status == 412
+    # No success event is recorded for a conflict.
+    assert chain.query(event_type=EVENT_ODATA_WRITEBACK) == []
+
+
+def test_missing_etag_raises_428_conflict(tmp_path: pathlib.Path) -> None:
+    svc = _seeded()
+    svc.expose_etag = False  # service does not surface an ETag for the entity
+    conn = _connection()
+    client = OdataHttpClient(conn, http_client=svc.client())
+    chain = _chain(tmp_path)
+
+    with pytest.raises(OdataConflict) as excinfo:
+        update_entity(conn, {"id": 1}, {"name": "renamed"}, chain=chain, http_client=client)
+    assert excinfo.value.status == 428
+    assert chain.query(event_type=EVENT_ODATA_WRITEBACK) == []
+
+
+# ---------------------------------------------------------------------------
+# AC3 -- draft-activate flow
+# ---------------------------------------------------------------------------
+
+
+def test_draft_flow_creates_patches_activates(tmp_path: pathlib.Path) -> None:
+    svc = FakeODataService(page_size=10, activate_action="Activate")
+    conn = _connection(draft_flow=True, draft_activate_action="Activate")
+    client = OdataHttpClient(conn, http_client=svc.client())
+    chain = _chain(tmp_path)
+
+    patch = {"name": "drafted"}
+    receipt = update_entity(conn, {"id": 0}, patch, chain=chain, http_client=client)
+
+    assert receipt.draft_flow is True
+    assert receipt.http_status == 200
+    assert receipt.payload_content_hash == _reference_hash(patch)
+    events = chain.query(event_type=EVENT_ODATA_WRITEBACK)
+    assert len(events) == 1
+    assert events[0].details["draft_flow"] is True
+    assert events[0].details["activate_action"] == "Activate"


### PR DESCRIPTION
## What
Implemented a generic OData v4 system-of-record integration in two composable halves plus a hermetic fake service. (1) src/bernstein/core/trigger_sources/odata_poll.py: watermark polling baseline (`$filter=<ts> gt <watermark>`, server-driven `@odata.nextLink` paging, one TriggerEvent per changed entity, strict-gt watermark advance), opt-in delta via `Prefer: odata.track-changes` that only activates when the service returns `@odata.deltaLink` and falls back to watermark on any delta failure without losing the deterministic, content-addressable cursor; 429+Retry-After and a configurable minimum inter-call interval honored via an injected clock; bearer/api-key/OAuth2 client-credentials auth resolved from env and redacted in logs. (2) src/bernstein/core/trackers/odata_writeback.py: GET-before-PATCH `update_entity` with `If-Match`, typed OdataConflict for 412 (stale ETag) and 428 (missing precondition), draft-activate flow, and a WriteBackReceipt bound to a new HMAC-chain audit event. (3) audit_chain.py: additive EVENT_ODATA_WRITEBACK + record_odata_writeback so `bernstein audit verify` c

Fixes #2886

## Acceptance criteria (6/8 met)
- [x] AC1: hermetic fake drives watermark loop -> ordered TriggerEvents -> cursor advances -> restart resumes from persisted cursor with no dup/drop (byte-i
- [x] AC2: delta mode activates only when probe returns @odata.deltaLink; any delta failure falls back to watermark without losing the cursor
- [x] AC3: write-back without fresh ETag fails typed conflict (412+428 both covered); success emits audit event + lineage receipt whose payload hash matches
- [x] AC4: 429 + Retry-After and configured minimum inter-call interval both honored (fake clock, no sleeps)
- [x] AC5: credentials never appear in logs (log-sanitisation test)
- [x] AC6: docs page shipped in the same branch
- [ ] Plan step: register in the trigger-source registry — *deferred*
- [ ] Plan steps 5-6: CLI connection-config surface + config-schema/seed-parser keys — *deferred*

## Verification
Adversarial review rounds complete; empirical criteria independently re-attacked (tamper, determinism byte-compare, auth rejection, red-on-main).
uv run pytest tests/unit/odata/ -v -> 31 passed, 1 warning. Files: tests/unit/odata/test_fake_service.py (11 trust tests for the fake), test_odata_poll.py (12: AC1/AC2/AC4/AC5), test_odata_writeback.py (8: AC3). Also ran tests/unit/test_audit_chain_activity_result.py and tests/unit/trigger_sources/test_webhook_node_audit_chain.py after editing audit_chain.py -> all pass (37 passed combined). Collection sentinel `uv run pytest tests/unit --co -q` 
