### PR TITLE
feat(interop): inbound A2A server surface - callable, discoverable, chain-anchored

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable project changes are tracked here (code + docs).
 
 ## [Unreleased]
 
+### Added
+
+- A2A JSON-RPC server surface: one instance can be called into as a
+  discoverable node. The signed agent card is served at both
+  `/.well-known/agent-card.json` and `/.well-known/agent.json`; a JSON-RPC 2.0
+  endpoint (`/a2a/v1`) dispatches `message/send`, `tasks/get`, and
+  `message/stream` (SSE); auth is a card-declared API key plus OAuth2
+  client-credentials, rejected per spec, with the caller anchored in the audit
+  chain; and a completed task returns an artifact whose parts carry a lineage
+  receipt the caller verifies offline with `bernstein a2a verify`. Off by
+  default behind `BERNSTEIN_A2A_SERVER_ENABLED`. See
+  [`docs/operations/a2a-server.md`](operations/a2a-server.md). Refs #2609.
+
 ## [3.5.0] - 2026-07-16
 
 Hardens audit identity across MCP protocol change and replay detection of provider-side context rewrites, plus a security dependency bump and CI reliability work. Full notes: [`docs/release-notes/v3.5.0.md`](release-notes/v3.5.0.md).

--- a/docs/operations/a2a-server.md
+++ b/docs/operations/a2a-server.md
@@ -1,0 +1,166 @@
+# A2A JSON-RPC server surface
+
+Bernstein already speaks [A2A v1.0](https://a2a-protocol.org/) as a client, an
+emitter, and a federation peer. This surface makes one instance a **callable,
+discoverable node** other agents and apps can delegate work *into*: a signed
+agent card is its identity, a JSON-RPC 2.0 binding is how it is called, and
+every completed task comes back with a lineage receipt the caller verifies
+offline.
+
+It is **off by default.** Nothing below is reachable, and the agent card
+advertises none of it, until you set `BERNSTEIN_A2A_SERVER_ENABLED=1`.
+
+## What it gives you
+
+| Capability | Detail |
+|---|---|
+| Discovery at both well-known paths | The signed card is served identically at `/.well-known/agent-card.json` (A2A v1.0 canonical) and `/.well-known/agent.json` (legacy), so a client built for either name resolves it. |
+| JSON-RPC 2.0 binding | One endpoint, `POST /a2a/v1`, dispatches `message/send`, `tasks/get`, and `message/stream` (SSE). |
+| Degrade-gracefully polling | A client with no streaming and no artifact support still reaches every result by polling `tasks/get`. |
+| Card-declared auth | Two schemes, both in the card: a static **API key** and an **OAuth2 client-credentials** grant. |
+| Verifiable answers | A completed task returns an `Artifact` whose parts carry the result text **and** a lineage-receipt reference, so the caller proves the answer offline with `bernstein a2a verify`. |
+| Audited callers | The authenticated caller is anchored in the audit chain on every accepted task. |
+
+## Enable it
+
+```bash
+export BERNSTEIN_A2A_SERVER_ENABLED=1
+
+# Static API keys: caller_id=key, comma-separated.
+export BERNSTEIN_A2A_API_KEYS="partner-a=<key-a>,partner-b=<key-b>"
+
+# OAuth2 client-credentials clients: client_id=client_secret, comma-separated.
+export BERNSTEIN_A2A_OAUTH_CLIENTS="app-x=<secret-x>"
+
+# Optional: pin the token-signing secret (else one is derived from the client
+# set so a restart keeps validating previously issued tokens).
+export BERNSTEIN_A2A_OAUTH_SIGNING_SECRET="<random-secret>"
+
+# Optional: the public base URL advertised in the card.
+export BERNSTEIN_PUBLIC_BASE_URL="https://node.example"
+```
+
+The JSON-RPC endpoints run their own auth, so they are exempt from the server's
+bearer middleware — a call with no A2A credentials is still rejected per spec.
+
+## Discovery and offline card verification
+
+```bash
+curl -s https://node.example/.well-known/agent-card.json
+```
+
+The card is JCS-canonical (RFC 8785) with a detached JWS (RFC 7515) whose key
+is published at `/.well-known/agent.json/keys`. When the surface is on, the card
+also carries:
+
+- `supportedInterfaces` including `"JSONRPC"` and an `additionalInterfaces`
+  entry pointing at `/a2a/v1`; and
+- `securitySchemes` for `a2a-api-key` (apiKey, header `X-API-Key`) and
+  `a2a-oauth2` (oauth2 clientCredentials, with the token URL).
+
+The embedded `capabilityCard` verifies offline with
+`verify_capability_card()`; a byte-tampered card fails.
+
+## Authentication
+
+### API key
+
+```
+POST /a2a/v1
+X-API-Key: <key-a>
+```
+
+### OAuth2 client-credentials
+
+```bash
+curl -s -X POST https://node.example/a2a/v1/oauth/token \
+  -d grant_type=client_credentials \
+  -d client_id=app-x -d client_secret=<secret-x>
+# -> {"access_token": "...", "token_type": "Bearer", "expires_in": 3600}
+```
+
+```
+POST /a2a/v1
+Authorization: Bearer <access_token>
+```
+
+Rejections follow the spec: a missing or invalid credential gets `401` with an
+RFC 6750 `WWW-Authenticate` challenge; a bad client secret at the token
+endpoint gets an OAuth2 §5.2 `invalid_client` body. Tokens are stateless
+(self-describing, HMAC-tagged), so they survive a restart and are validated
+offline on every call.
+
+## Calling the node
+
+`message/send` — submit work; returns an A2A `Task`:
+
+```json
+{"jsonrpc":"2.0","id":1,"method":"message/send",
+ "params":{"message":{"role":"user","parts":[{"kind":"text","text":"review the auth module"}],"messageId":"m1"}}}
+```
+
+`tasks/get` — poll to completion:
+
+```json
+{"jsonrpc":"2.0","id":2,"method":"tasks/get","params":{"id":"<taskId>"}}
+```
+
+When the task completes, the result carries an artifact:
+
+```json
+{"artifacts":[{"artifactId":"<taskId>-result","name":"result",
+  "parts":[
+    {"kind":"text","text":"<result summary>"},
+    {"kind":"data","data":{
+       "attested":{"taskId":"<taskId>","result":"<result summary>"},
+       "lineageReceipt":{"entry_hash":"...","content_hash":"sha256:...","operator_hmac":"...","head_signature":{...},"kid":"..."}
+    }}
+  ]}]}
+```
+
+`message/stream` — the same accepted task and a status snapshot over SSE
+(`text/event-stream`); terminal results still come from `tasks/get`.
+
+## Task-state mapping
+
+| A2A state | Bernstein status |
+|---|---|
+| `submitted` | `open` / `planned` |
+| `working` | `claimed` / `in_progress` / `waiting_for_subtasks` |
+| `input-required` | `blocked` (needs more from the caller) |
+| `auth-required` | `blocked` (needs downstream credentials) |
+| `completed` | `done` / `closed` |
+| `failed` | `failed` / `refused` / `abandoned` |
+| `canceled` | `cancelled` |
+
+## Verify an answer offline
+
+The `data` part carries the receipt and the exact bytes it attests. Extract
+them and run the shipped verifier — no access to the node required:
+
+```bash
+bernstein a2a verify --receipt receipt.json --response attested.json
+```
+
+- `attested.json` — the `parts[].data.attested` object.
+- `receipt.json` — the `parts[].data.lineageReceipt` object.
+
+Verification recomputes the content hash and checks the head signature over the
+binding digest against the audit chain head. Tamper one byte of the answer and
+it is rejected; strip the receipt and the answer is *unverifiable*, not merely
+unlogged. Pass `--trusted-jwk` to pin the signing key and establish provenance
+against the operator's published key rather than trust-on-first-use.
+
+## Publish for discovery
+
+`bernstein a2a publish --endpoint https://node.example/a2a` projects the node's
+signed capability card into agent-registry manifests (A2A card + MCP registry),
+each carrying a verifiable publisher fingerprint, so peers discover the node by
+verifiable capability rather than by an opaque URL. The AGNTCY ADS / OASF
+descriptor surface is a separate follow-up.
+
+## Related
+
+- [Signed A2A message receipts](a2a-message-receipts.md)
+- [A2A interop (peer cards)](../interop/a2a.md)
+- [A2A architecture](../architecture/a2a.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -407,6 +407,7 @@ nav:
           - Lineage conflict resolution: lineage/conflict-resolution.md
           - Tracker audit: lineage/tracker-audit.md
           - A2A message receipts: operations/a2a-message-receipts.md
+          - A2A JSON-RPC server surface: operations/a2a-server.md
   - Reference:
       - reference/index.md
       - CLI:

--- a/src/bernstein/core/protocols/a2a/a2a.py
+++ b/src/bernstein/core/protocols/a2a/a2a.py
@@ -63,11 +63,19 @@ _A2A_STATE_SCHEMA_VERSION: int = 1
 
 
 class A2ATaskStatus(Enum):
-    """A2A protocol task states, mapped to Bernstein TaskStatus."""
+    """A2A protocol task states, mapped to Bernstein TaskStatus.
+
+    ``INPUT_REQUIRED`` and ``AUTH_REQUIRED`` are the two wait states a
+    callable node must be able to express to a peer (#2609): the first when
+    the node needs more input from the caller, the second when the node needs
+    the caller to authenticate to a downstream resource before it can
+    proceed. Both project onto a locally ``blocked`` task.
+    """
 
     SUBMITTED = "submitted"
     WORKING = "working"
     INPUT_REQUIRED = "input-required"
+    AUTH_REQUIRED = "auth-required"
     COMPLETED = "completed"
     FAILED = "failed"
     CANCELED = "canceled"
@@ -108,6 +116,7 @@ _A2A_TO_BERNSTEIN: dict[A2ATaskStatus, str] = {
     A2ATaskStatus.SUBMITTED: "open",
     A2ATaskStatus.WORKING: "in_progress",
     A2ATaskStatus.INPUT_REQUIRED: "blocked",
+    A2ATaskStatus.AUTH_REQUIRED: "blocked",
     A2ATaskStatus.COMPLETED: "done",
     A2ATaskStatus.FAILED: "failed",
     A2ATaskStatus.CANCELED: "cancelled",

--- a/src/bernstein/core/protocols/a2a/jsonrpc.py
+++ b/src/bernstein/core/protocols/a2a/jsonrpc.py
@@ -1,0 +1,267 @@
+"""JSON-RPC 2.0 + A2A projection helpers for the inbound server surface (#2609).
+
+The binding design directive fixes the wire binding as JSON-RPC 2.0 (with SSE
+for ``message/stream``). This module holds the framework-agnostic core so the
+FastAPI route in :mod:`bernstein.core.routes.a2a_jsonrpc` is a thin adapter:
+
+* request parsing and the ``result`` / ``error`` envelopes (JSON-RPC 2.0);
+* extracting the caller's text from an A2A ``Message``;
+* projecting a Bernstein task's status onto an A2A ``Task`` state; and
+* building the completed-task ``Artifact`` whose ``Part`` list carries a
+  lineage-receipt reference plus the exact payload that receipt attests.
+
+The last point is the callable-node's whole reason for existing: a peer that
+cannot take streaming or artifacts still reaches the same completed ``Task``
+by polling ``tasks/get``, and the ``Artifact`` it receives contains both the
+receipt and the bytes the receipt covers, so it verifies the answer offline.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+__all__ = [
+    "JSONRPC_INTERNAL_ERROR",
+    "JSONRPC_INVALID_PARAMS",
+    "JSONRPC_INVALID_REQUEST",
+    "JSONRPC_METHOD_NOT_FOUND",
+    "JSONRPC_PARSE_ERROR",
+    "JSONRPCError",
+    "JSONRPCRequest",
+    "a2a_state_for_bernstein",
+    "build_completed_artifact",
+    "build_task_object",
+    "extract_message_text",
+    "jsonrpc_error_response",
+    "jsonrpc_result_response",
+    "parse_jsonrpc_request",
+]
+
+# JSON-RPC 2.0 reserved error codes (§5.1).
+JSONRPC_PARSE_ERROR = -32700
+JSONRPC_INVALID_REQUEST = -32600
+JSONRPC_METHOD_NOT_FOUND = -32601
+JSONRPC_INVALID_PARAMS = -32602
+JSONRPC_INTERNAL_ERROR = -32603
+
+
+class JSONRPCError(Exception):
+    """A JSON-RPC error to project into an ``error`` envelope.
+
+    Attributes:
+        code: JSON-RPC error code.
+        message: Human-readable summary.
+        data: Optional structured detail.
+    """
+
+    def __init__(self, code: int, message: str, *, data: Any = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.data = data
+
+
+@dataclass(frozen=True, slots=True)
+class JSONRPCRequest:
+    """A parsed, validated JSON-RPC 2.0 request object.
+
+    Attributes:
+        id: The request id echoed on the response. May be ``None`` for
+            notifications, though the A2A methods here always carry one.
+        method: The invoked method name (e.g. ``message/send``).
+        params: The params object (always a dict; positional params are
+            rejected because every A2A method takes named params).
+    """
+
+    id: Any
+    method: str
+    params: dict[str, Any]
+
+
+def parse_jsonrpc_request(body: Any) -> JSONRPCRequest:
+    """Validate a decoded JSON body as a JSON-RPC 2.0 request.
+
+    Args:
+        body: The already-JSON-decoded request body.
+
+    Returns:
+        A :class:`JSONRPCRequest`.
+
+    Raises:
+        JSONRPCError: With :data:`JSONRPC_INVALID_REQUEST` when the body is not
+            a conformant request object.
+    """
+    if not isinstance(body, dict):
+        raise JSONRPCError(JSONRPC_INVALID_REQUEST, "request must be a JSON object")
+    if body.get("jsonrpc") != "2.0":
+        raise JSONRPCError(JSONRPC_INVALID_REQUEST, "jsonrpc version must be exactly '2.0'")
+    method = body.get("method")
+    if not isinstance(method, str) or not method:
+        raise JSONRPCError(JSONRPC_INVALID_REQUEST, "method must be a non-empty string")
+    params = body.get("params", {})
+    if params is None:
+        params = {}
+    if not isinstance(params, dict):
+        # A2A methods all take named params; positional lists are refused so a
+        # malformed call fails at the boundary rather than deep in a handler.
+        raise JSONRPCError(JSONRPC_INVALID_PARAMS, "params must be an object")
+    return JSONRPCRequest(id=body.get("id"), method=method, params=params)
+
+
+def jsonrpc_result_response(request_id: Any, result: Any) -> dict[str, Any]:
+    """Return a JSON-RPC 2.0 success envelope."""
+    return {"jsonrpc": "2.0", "id": request_id, "result": result}
+
+
+def jsonrpc_error_response(request_id: Any, code: int, message: str, *, data: Any = None) -> dict[str, Any]:
+    """Return a JSON-RPC 2.0 error envelope."""
+    error: dict[str, Any] = {"code": code, "message": message}
+    if data is not None:
+        error["data"] = data
+    return {"jsonrpc": "2.0", "id": request_id, "error": error}
+
+
+# ---------------------------------------------------------------------------
+# A2A message extraction
+# ---------------------------------------------------------------------------
+
+
+def extract_message_text(params: dict[str, Any]) -> str:
+    """Return the concatenated text of an A2A ``message/send`` message.
+
+    A2A messages carry a ``parts`` array; this joins every ``text`` part in
+    order and ignores non-text parts (file / data). An empty result is a
+    protocol error - there is nothing to act on.
+
+    Raises:
+        JSONRPCError: :data:`JSONRPC_INVALID_PARAMS` when no message or no
+            usable text is present.
+    """
+    message = params.get("message")
+    if not isinstance(message, dict):
+        raise JSONRPCError(JSONRPC_INVALID_PARAMS, "params.message is required")
+    parts = message.get("parts")
+    if not isinstance(parts, list):
+        raise JSONRPCError(JSONRPC_INVALID_PARAMS, "params.message.parts must be an array")
+    chunks: list[str] = []
+    for part in parts:
+        if isinstance(part, dict) and part.get("kind") == "text":
+            text = part.get("text")
+            if isinstance(text, str):
+                chunks.append(text)
+    joined = "".join(chunks)
+    if not joined.strip():
+        raise JSONRPCError(JSONRPC_INVALID_PARAMS, "message carries no text part")
+    return joined
+
+
+# ---------------------------------------------------------------------------
+# A2A task projection
+# ---------------------------------------------------------------------------
+
+#: Bernstein task status -> A2A task state. Mirrors ``_BERNSTEIN_TO_A2A`` in
+#: :mod:`bernstein.core.protocols.a2a.a2a` but yields the A2A *string* the wire
+#: expects, and covers the states an inbound task can reach.
+_BERNSTEIN_TO_A2A_STATE: dict[str, str] = {
+    "planned": "submitted",
+    "open": "submitted",
+    "claimed": "working",
+    "in_progress": "working",
+    "waiting_for_subtasks": "working",
+    "blocked": "input-required",
+    "blocked_by_abandon": "input-required",
+    "pending_approval": "input-required",
+    "suspended": "input-required",
+    "done": "completed",
+    "closed": "completed",
+    "failed": "failed",
+    "refused": "failed",
+    "abandoned": "failed",
+    "orphaned": "failed",
+    "cancelled": "canceled",
+}
+
+
+def a2a_state_for_bernstein(status: str) -> str:
+    """Return the A2A task-state string for a Bernstein task status.
+
+    Unknown statuses degrade to ``submitted`` rather than raising: a caller
+    polling ``tasks/get`` should keep polling, not receive a terminal error
+    for a status this projection has not enumerated.
+    """
+    return _BERNSTEIN_TO_A2A_STATE.get(status, "submitted")
+
+
+def build_task_object(
+    *,
+    task_id: str,
+    context_id: str,
+    state: str,
+    timestamp: str,
+    artifacts: list[dict[str, Any]] | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build an A2A ``Task`` object for a JSON-RPC result.
+
+    Args:
+        task_id: The A2A task id (echoed to the caller for ``tasks/get``).
+        context_id: The A2A context id grouping related tasks.
+        state: A2A task state string (see :func:`a2a_state_for_bernstein`).
+        timestamp: ISO-8601 status timestamp.
+        artifacts: Completed-task artifacts, when any.
+        metadata: Free-form metadata (used to carry the acceptance receipt).
+    """
+    task: dict[str, Any] = {
+        "id": task_id,
+        "contextId": context_id,
+        "kind": "task",
+        "status": {"state": state, "timestamp": timestamp},
+        "artifacts": artifacts or [],
+        "history": [],
+    }
+    if metadata:
+        task["metadata"] = metadata
+    return task
+
+
+def attested_completion_payload(*, task_id: str, result: str) -> dict[str, Any]:
+    """Return the exact object a completion receipt attests to.
+
+    Kept tiny and explicit so a peer reconstructs it byte-for-byte from the
+    artifact and verifies the receipt offline: it is the ``content_hash``
+    pre-image, nothing more.
+    """
+    return {"taskId": task_id, "result": result}
+
+
+def build_completed_artifact(
+    *,
+    task_id: str,
+    result: str,
+    receipt: dict[str, Any],
+) -> dict[str, Any]:
+    """Build the completed-task ``Artifact`` carrying a receipt reference.
+
+    The artifact has two parts:
+
+    * a ``text`` part with the human-readable result, for any client; and
+    * a ``data`` part carrying ``{attested, lineageReceipt}`` - the payload
+      the receipt covers and the receipt itself - so a client that cannot take
+      artifacts still gets everything it needs to verify the answer offline via
+      ``bernstein a2a verify``.
+    """
+    return {
+        "artifactId": f"{task_id}-result",
+        "name": "result",
+        "parts": [
+            {"kind": "text", "text": result},
+            {
+                "kind": "data",
+                "data": {
+                    "attested": attested_completion_payload(task_id=task_id, result=result),
+                    "lineageReceipt": receipt,
+                },
+            },
+        ],
+    }

--- a/src/bernstein/core/protocols/a2a/receipt.py
+++ b/src/bernstein/core/protocols/a2a/receipt.py
@@ -14,14 +14,18 @@ receipt, and a public key.
 Scope of the claim
 ------------------
 A receipt attests the exact response bytes the node recorded *at the moment
-it was issued*. On the inbound send path that moment is acceptance: the
-response is the acceptance record (the task this node took in and chained),
-not the eventual completed result. So a receipt proves "this is the answer
-this node recorded for this task", not "this task has finished". Re-attesting
-the completed result when the task terminates, and serving that receipt from
-the read path, is tracked as a follow-up on #2609. The mechanism below is
-independent of which response dict it is handed, so it carries over unchanged
-when the completion-time response is the one recorded.
+it was issued*. The mechanism is independent of which response dict it is
+handed, so the same issuer serves both moments a task is attestable:
+
+* **Acceptance** - the REST ``POST /a2a/tasks/send`` path and the JSON-RPC
+  ``message/send`` path attest the acceptance record (the task this node took
+  in and chained). That receipt proves "this is the request this node
+  recorded", not "this task has finished".
+* **Completion** - the JSON-RPC ``tasks/get`` path, once the underlying task is
+  done, re-attests the completed result and serves that receipt inside the
+  completed task's artifact (see :mod:`bernstein.core.routes.a2a_jsonrpc`). The
+  completion receipt is minted once and reused on later polls, so reads do not
+  grow the chain.
 
 Two independent claims, deliberately kept apart
 -----------------------------------------------
@@ -352,6 +356,7 @@ class A2AReceiptIssuer:
         response: dict[str, Any],
         step_id: str = "",
         timestamp: int | None = None,
+        caller: str = "",
     ) -> A2ATaskReceipt:
         """Record ``response`` on the spine and return its receipt.
 
@@ -363,6 +368,12 @@ class A2AReceiptIssuer:
                 the current time in nanoseconds. Passing an explicit value
                 makes the whole projection deterministic, which is what the
                 determinism tests rely on.
+            caller: Authenticated A2A caller id (#2609). When supplied it is
+                folded into the chain entry's ``actor`` so the accepted task is
+                attributable to the identity that called; the caller is part of
+                the signed binding, so it cannot be altered after the fact.
+                Two identical calls from the same caller still project
+                byte-identical receipts.
 
         Returns:
             The :class:`A2ATaskReceipt` to attach to the response.
@@ -377,11 +388,14 @@ class A2AReceiptIssuer:
         content = canonical_response_bytes(response)
         artefact_path = receipt_artefact_path(task_id)
         ts = time.time_ns() if timestamp is None else timestamp
+        # Attribute the chain entry to the authenticated caller when known, so
+        # the audit chain answers "who delegated this?" without a side channel.
+        actor = f"{self._actor}:{caller}" if caller else self._actor
 
         entry = self._spine.record_entry(
             artifact_path=artefact_path,
             content=content,
-            actor=self._actor,
+            actor=actor,
             step_id=step_id or f"a2a:{task_id}",
             model=self._model,
             timestamp=ts,

--- a/src/bernstein/core/protocols/a2a/server_auth.py
+++ b/src/bernstein/core/protocols/a2a/server_auth.py
@@ -1,0 +1,337 @@
+"""Inbound auth for the A2A JSON-RPC server surface (#2609).
+
+A callable node advertises two auth schemes in its agent card and enforces
+them on every JSON-RPC call:
+
+* **API key** - a static per-caller secret sent as ``X-API-Key``. The header
+  value maps to a named caller so the accepting path can anchor *who* called
+  in the audit chain.
+* **OAuth2 client-credentials** - a machine-to-machine grant. A client
+  exchanges ``client_id`` / ``client_secret`` at the token endpoint for a
+  short-lived bearer token; the node validates the token offline on each call.
+
+Both mechanisms are declared in the card's ``securitySchemes`` so a peer
+negotiates them before sending work, and rejections follow the wire shapes
+the A2A spec inherits (HTTP 401 with an RFC 6750 ``WWW-Authenticate``
+challenge; OAuth2 §5.2 ``invalid_client`` at the token endpoint).
+
+Stateless by construction
+-------------------------
+Issued tokens carry their own claims and an HMAC tag; the node verifies them
+without a session store, so tokens survive a restart and two processes behind
+one config validate each other's tokens. When the operator does not pin a
+signing secret, one is *derived deterministically* from the configured client
+set, so a rebuilt authenticator - or a restarted process - validates tokens it
+issued before. The secret never leaves the process and is never advertised.
+
+This module is transport-agnostic: it takes a header mapping and returns an
+:class:`AuthenticatedCaller` (or raises :class:`A2AAuthError`), which the
+FastAPI route in :mod:`bernstein.core.routes.a2a_jsonrpc` translates to a
+response. Keeping it pure makes the reject-per-spec behaviour unit-testable
+without standing up a server.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import hmac
+import json
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+__all__ = [
+    "A2A_API_KEY_HEADER",
+    "A2AAuthError",
+    "A2AServerAuth",
+    "AuthenticatedCaller",
+    "IssuedToken",
+]
+
+#: Header carrying the static API key. Named in the advertised card scheme so
+#: a peer knows exactly where to place it.
+A2A_API_KEY_HEADER = "X-API-Key"
+
+#: Environment configuration.
+_API_KEYS_ENV = "BERNSTEIN_A2A_API_KEYS"
+_OAUTH_CLIENTS_ENV = "BERNSTEIN_A2A_OAUTH_CLIENTS"
+_SIGNING_SECRET_ENV = "BERNSTEIN_A2A_OAUTH_SIGNING_SECRET"
+
+#: Client-credentials token lifetime (seconds).
+_TOKEN_TTL_SECONDS = 3600
+
+#: Scheme ids advertised in the card. Stable so a cached card keeps resolving.
+_API_KEY_SCHEME_ID = "a2a-api-key"
+_OAUTH2_SCHEME_ID = "a2a-oauth2"
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(text: str) -> bytes:
+    pad = "=" * (-len(text) % 4)
+    return base64.urlsafe_b64decode(text + pad)
+
+
+@dataclass(frozen=True, slots=True)
+class AuthenticatedCaller:
+    """The identity behind an authenticated A2A request.
+
+    Attributes:
+        caller_id: Stable name of the caller - the API-key owner or the OAuth2
+            ``client_id``. Recorded in the audit chain on the accepting path.
+        scheme: ``"apiKey"`` or ``"oauth2"``.
+    """
+
+    caller_id: str
+    scheme: str
+
+
+@dataclass(frozen=True, slots=True)
+class IssuedToken:
+    """A client-credentials access token, shaped as an OAuth2 token response."""
+
+    access_token: str
+    token_type: str
+    expires_in: int
+
+    def to_response(self) -> dict[str, Any]:
+        """Return the RFC 6749 §5.1 token-endpoint success body."""
+        return {
+            "access_token": self.access_token,
+            "token_type": self.token_type,
+            "expires_in": self.expires_in,
+        }
+
+
+class A2AAuthError(Exception):
+    """A rejected A2A request, carrying the wire shape of the rejection.
+
+    Attributes:
+        status_code: HTTP status the route should return (401 for the RPC
+            surface, 400 for the token endpoint).
+        error: OAuth2 error code (e.g. ``invalid_client``, ``invalid_token``).
+        headers: Extra response headers, notably ``WWW-Authenticate``.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int = 401,
+        error: str = "invalid_token",
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+        self.error = error
+        self.headers = headers or {}
+
+
+def _parse_pairs(raw: str) -> dict[str, str]:
+    """Parse ``a=1, b=2`` into a mapping, tolerating whitespace and blanks."""
+    pairs: dict[str, str] = {}
+    for chunk in raw.split(","):
+        chunk = chunk.strip()
+        if not chunk or "=" not in chunk:
+            continue
+        name, _, value = chunk.partition("=")
+        name = name.strip()
+        value = value.strip()
+        if name and value:
+            pairs[name] = value
+    return pairs
+
+
+@dataclass
+class A2AServerAuth:
+    """Authenticator for the inbound A2A server surface.
+
+    Args:
+        api_keys: ``caller_id -> api_key`` map. A request presenting a known
+            key authenticates as the mapped caller.
+        oauth_clients: ``client_id -> client_secret`` map for the
+            client-credentials grant.
+        signing_secret: HMAC key for issued tokens. When empty, a deterministic
+            secret is derived from ``oauth_clients`` so a rebuilt authenticator
+            validates previously issued tokens.
+    """
+
+    api_keys: dict[str, str] = field(default_factory=dict)
+    oauth_clients: dict[str, str] = field(default_factory=dict)
+    signing_secret: bytes = b""
+
+    def __post_init__(self) -> None:
+        if not self.signing_secret:
+            self.signing_secret = self._derive_secret(self.oauth_clients)
+
+    @staticmethod
+    def _derive_secret(oauth_clients: dict[str, str]) -> bytes:
+        """Derive a stable HMAC key from the client set.
+
+        Deterministic so a restart or a second process behind the same config
+        validates tokens issued earlier, without persisting a secret. The
+        client secrets are already private, so folding them into the key adds
+        no new exposure and binds token validity to the configured clients.
+        """
+        material = "\x00".join(f"{cid}={sec}" for cid, sec in sorted(oauth_clients.items()))
+        return hashlib.sha256(b"bernstein-a2a-oauth\x00" + material.encode("utf-8")).digest()
+
+    @property
+    def is_configured(self) -> bool:
+        """Return ``True`` when at least one credential is configured."""
+        return bool(self.api_keys or self.oauth_clients)
+
+    # -- Classmethod constructor -----------------------------------------
+
+    @classmethod
+    def from_env(cls) -> A2AServerAuth:
+        """Build an authenticator from ``BERNSTEIN_A2A_*`` environment vars."""
+        api_keys = _parse_pairs(os.environ.get(_API_KEYS_ENV, ""))
+        oauth_clients = _parse_pairs(os.environ.get(_OAUTH_CLIENTS_ENV, ""))
+        secret_raw = os.environ.get(_SIGNING_SECRET_ENV, "").strip()
+        signing_secret = secret_raw.encode("utf-8") if secret_raw else b""
+        return cls(api_keys=api_keys, oauth_clients=oauth_clients, signing_secret=signing_secret)
+
+    # -- Request authentication ------------------------------------------
+
+    def authenticate(self, headers: dict[str, str], *, now: float | None = None) -> AuthenticatedCaller:
+        """Authenticate a request from its headers, or raise.
+
+        Header lookups are case-insensitive. The API key is checked first
+        (cheapest), then the bearer token. A request that presents neither is
+        rejected with an RFC 6750 challenge naming both accepted schemes.
+
+        Raises:
+            A2AAuthError: On missing or invalid credentials.
+        """
+        lower = {k.lower(): v for k, v in headers.items()}
+
+        api_key = lower.get(A2A_API_KEY_HEADER.lower())
+        if api_key is not None:
+            caller = self._match_api_key(api_key)
+            if caller is None:
+                raise A2AAuthError("invalid API key", status_code=401, headers=self._challenge())
+            return AuthenticatedCaller(caller_id=caller, scheme="apiKey")
+
+        auth_header = lower.get("authorization", "")
+        if auth_header.startswith("Bearer "):
+            token = auth_header[len("Bearer ") :].strip()
+            return self._verify_token(token, now=self._resolve_now(now))
+
+        raise A2AAuthError(
+            "missing credentials: present an X-API-Key header or an OAuth2 bearer token",
+            status_code=401,
+            error="invalid_request",
+            headers=self._challenge(),
+        )
+
+    def _match_api_key(self, presented: str) -> str | None:
+        """Return the caller id for a presented key, in constant time."""
+        for caller_id, key in self.api_keys.items():
+            if hmac.compare_digest(key, presented):
+                return caller_id
+        return None
+
+    # -- Client-credentials grant ----------------------------------------
+
+    def issue_client_credentials_token(
+        self,
+        *,
+        client_id: str,
+        client_secret: str,
+        now: float | None = None,
+    ) -> IssuedToken:
+        """Issue a bearer token for a valid client, or raise ``invalid_client``.
+
+        The token is a self-describing ``<payload>.<mac>`` string: the payload
+        names the client and an absolute expiry, and the MAC binds both to the
+        node's signing secret. Verification is offline and stateless.
+        """
+        expected = self.oauth_clients.get(client_id)
+        if expected is None or not hmac.compare_digest(expected, client_secret):
+            raise A2AAuthError(
+                "unknown client or bad secret",
+                status_code=401,
+                error="invalid_client",
+                headers={"WWW-Authenticate": 'Basic realm="a2a"'},
+            )
+        issued = int(self._resolve_now(now))
+        payload = {"sub": client_id, "exp": issued + _TOKEN_TTL_SECONDS, "iat": issued}
+        access_token = self._encode_token(payload)
+        return IssuedToken(access_token=access_token, token_type="Bearer", expires_in=_TOKEN_TTL_SECONDS)
+
+    def _encode_token(self, payload: dict[str, Any]) -> str:
+        payload_bytes = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        payload_seg = _b64url(payload_bytes)
+        mac = hmac.new(self.signing_secret, payload_seg.encode("ascii"), hashlib.sha256).digest()
+        return f"{payload_seg}.{_b64url(mac)}"
+
+    def _verify_token(self, token: str, *, now: float) -> AuthenticatedCaller:
+        parts = token.split(".")
+        if len(parts) != 2:
+            raise A2AAuthError("malformed bearer token", status_code=401, headers=self._challenge())
+        payload_seg, mac_seg = parts
+        expected_mac = hmac.new(self.signing_secret, payload_seg.encode("ascii"), hashlib.sha256).digest()
+        try:
+            presented_mac = _b64url_decode(mac_seg)
+        except (ValueError, binascii.Error):
+            raise A2AAuthError("malformed bearer token", status_code=401, headers=self._challenge()) from None
+        if not hmac.compare_digest(expected_mac, presented_mac):
+            raise A2AAuthError("bad token signature", status_code=401, headers=self._challenge())
+        try:
+            payload = json.loads(_b64url_decode(payload_seg))
+        except (ValueError, binascii.Error):
+            raise A2AAuthError("malformed bearer token", status_code=401, headers=self._challenge()) from None
+        if not isinstance(payload, dict):
+            raise A2AAuthError("malformed bearer token", status_code=401, headers=self._challenge())
+        exp = payload.get("exp")
+        if not isinstance(exp, (int, float)) or now > exp:
+            raise A2AAuthError("token expired", status_code=401, headers=self._challenge())
+        client_id = payload.get("sub")
+        if not isinstance(client_id, str) or client_id not in self.oauth_clients:
+            raise A2AAuthError("token subject is not a known client", status_code=401, headers=self._challenge())
+        return AuthenticatedCaller(caller_id=client_id, scheme="oauth2")
+
+    @staticmethod
+    def _resolve_now(now: float | None) -> float:
+        return time.time() if now is None else now
+
+    @staticmethod
+    def _challenge() -> dict[str, str]:
+        """RFC 6750 challenge naming the two accepted schemes."""
+        return {"WWW-Authenticate": 'Bearer realm="a2a", error="invalid_token"'}
+
+    # -- Card advertisement ----------------------------------------------
+
+    def security_schemes(self, *, token_url: str) -> list[dict[str, Any]]:
+        """Return the A2A card ``securitySchemes`` entries for both mechanisms.
+
+        Args:
+            token_url: Absolute URL of the client-credentials token endpoint.
+        """
+        return [
+            {
+                "id": _API_KEY_SCHEME_ID,
+                "type": "apiKey",
+                "in": "header",
+                "name": A2A_API_KEY_HEADER,
+                "description": "Static per-caller API key.",
+            },
+            {
+                "id": _OAUTH2_SCHEME_ID,
+                "type": "oauth2",
+                "description": "OAuth2 client-credentials grant for machine callers.",
+                "flows": {
+                    "clientCredentials": {
+                        "tokenUrl": token_url,
+                        "scopes": {},
+                    }
+                },
+            },
+        ]

--- a/src/bernstein/core/routes/a2a_jsonrpc.py
+++ b/src/bernstein/core/routes/a2a_jsonrpc.py
@@ -1,0 +1,460 @@
+"""A2A JSON-RPC 2.0 server surface - the callable, discoverable node (#2609).
+
+This is the inbound *server* binding the design directive fixes: JSON-RPC 2.0
+over HTTP, with SSE for ``message/stream``, guarded by two card-declared auth
+schemes (API key + OAuth2 client-credentials). It complements the client and
+federation code that already ships under ``core/protocols/a2a`` and the
+REST-shaped ``/a2a/tasks/*`` routes.
+
+Design constraints honoured here (all from the binding directive):
+
+* **JSON-RPC first.** One endpoint (:data:`A2A_JSONRPC_PATH`) dispatches
+  ``message/send``, ``tasks/get``, and ``message/stream``.
+* **Degrade gracefully.** A client with neither streaming nor artifacts still
+  reaches every result by polling ``tasks/get``; the completed task returns an
+  ``Artifact`` whose parts carry the result text *and* a lineage-receipt
+  reference, so the answer verifies offline.
+* **Auth, rejected per spec.** Missing / invalid credentials get an HTTP 401
+  with an RFC 6750 ``WWW-Authenticate`` challenge; the token endpoint returns
+  OAuth2 §5.2 error bodies. The authenticated caller is anchored in the audit
+  chain via the receipt issuer.
+* **Off by default.** The whole surface is gated behind
+  ``BERNSTEIN_A2A_SERVER_ENABLED``; when unset the endpoints answer ``404`` and
+  the agent card advertises none of this, so the default deployment is
+  unchanged.
+
+The heavy lifting lives in pure modules (:mod:`..protocols.a2a.jsonrpc`,
+:mod:`..protocols.a2a.server_auth`); this router is the thin ASGI adapter.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, Final
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from bernstein.core.difficulty_estimator import estimate_difficulty, minutes_for_level
+from bernstein.core.protocols.a2a.jsonrpc import (
+    JSONRPC_INTERNAL_ERROR,
+    JSONRPC_INVALID_PARAMS,
+    JSONRPC_METHOD_NOT_FOUND,
+    JSONRPC_PARSE_ERROR,
+    JSONRPCError,
+    a2a_state_for_bernstein,
+    attested_completion_payload,
+    build_completed_artifact,
+    build_task_object,
+    extract_message_text,
+    jsonrpc_error_response,
+    jsonrpc_result_response,
+    parse_jsonrpc_request,
+)
+from bernstein.core.protocols.a2a.server_auth import A2AAuthError, A2AServerAuth
+
+if TYPE_CHECKING:
+    from bernstein.core.protocols.a2a.a2a import A2AHandler
+    from bernstein.core.protocols.a2a.receipt import A2AReceiptIssuer
+    from bernstein.core.server import TaskStore
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+#: JSON-RPC 2.0 endpoint. Advertised as the node's A2A ``url`` when enabled.
+A2A_JSONRPC_PATH: Final[str] = "/a2a/v1"
+
+#: OAuth2 client-credentials token endpoint (advertised in the card scheme).
+A2A_TOKEN_PATH: Final[str] = "/a2a/v1/oauth/token"
+
+#: Env flag gating the whole surface. Off unless explicitly truthy.
+_ENABLE_ENV_VAR: Final[str] = "BERNSTEIN_A2A_SERVER_ENABLED"
+_TRUTHY: Final[frozenset[str]] = frozenset({"1", "true", "yes", "on"})
+
+#: Handler key suffix for the completion receipt, kept distinct from the
+#: acceptance receipt stored under the bare task id.
+_COMPLETED_RECEIPT_SUFFIX: Final[str] = "::completed"
+
+
+def a2a_server_enabled() -> bool:
+    """Return whether the inbound A2A JSON-RPC surface is enabled.
+
+    Read live from the environment so the flag, the card advertisement, and
+    the route all agree within a single process without a restart.
+    """
+    return os.environ.get(_ENABLE_ENV_VAR, "").strip().lower() in _TRUTHY
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _context_id(task_id: str) -> str:
+    """Return the A2A context id for a task - deterministic from the id.
+
+    A2A groups related tasks under a ``contextId``. We assign one per task so
+    ``tasks/get`` reproduces it without persisting extra state.
+    """
+    return f"ctx-{task_id}"
+
+
+def _get_store(request: Request) -> TaskStore:
+    return request.app.state.store  # type: ignore[no-any-return]
+
+
+def _get_handler(request: Request) -> A2AHandler:
+    return request.app.state.a2a_handler  # type: ignore[no-any-return]
+
+
+def _get_issuer(request: Request) -> A2AReceiptIssuer | None:
+    return getattr(request.app.state, "a2a_receipt_issuer", None)
+
+
+def _get_auth(request: Request) -> A2AServerAuth:
+    """Return the request-scoped authenticator.
+
+    Rebuilt from the environment per request: the config is a handful of
+    strings and the OAuth signing secret is derived deterministically, so a
+    fresh instance validates tokens an earlier one issued.
+    """
+    cached = getattr(request.app.state, "a2a_server_auth", None)
+    if cached is not None:
+        return cached  # type: ignore[no-any-return]
+    return A2AServerAuth.from_env()
+
+
+# ---------------------------------------------------------------------------
+# Auth helpers
+# ---------------------------------------------------------------------------
+
+
+def _auth_error_response(exc: A2AAuthError) -> JSONResponse:
+    """Render an :class:`A2AAuthError` as an HTTP response with its headers."""
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"error": exc.error, "error_description": exc.message},
+        headers=exc.headers,
+    )
+
+
+# ---------------------------------------------------------------------------
+# OAuth2 client-credentials token endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.post(A2A_TOKEN_PATH, include_in_schema=False)
+async def a2a_oauth_token(request: Request) -> JSONResponse:
+    """Issue an OAuth2 client-credentials access token.
+
+    Accepts ``client_id`` / ``client_secret`` from a form body or an HTTP
+    Basic ``Authorization`` header (RFC 6749 §2.3.1). Returns the RFC 6749
+    §5.1 token response, or a §5.2 error body on failure.
+    """
+    if not a2a_server_enabled():
+        return JSONResponse(status_code=404, content={"detail": "A2A server surface is disabled"})
+
+    auth = _get_auth(request)
+    form: dict[str, str] = {}
+    try:
+        raw_form = await request.form()
+        form = {k: str(v) for k, v in raw_form.items()}
+    except Exception:  # pragma: no cover - defensive: malformed multipart
+        form = {}
+
+    grant_type = form.get("grant_type", "")
+    if grant_type != "client_credentials":
+        return JSONResponse(
+            status_code=400,
+            content={"error": "unsupported_grant_type", "error_description": "only client_credentials is supported"},
+        )
+
+    client_id, client_secret = _extract_client_credentials(request, form)
+    if not client_id or not client_secret:
+        return JSONResponse(
+            status_code=400,
+            content={"error": "invalid_request", "error_description": "client_id and client_secret are required"},
+        )
+
+    try:
+        token = auth.issue_client_credentials_token(client_id=client_id, client_secret=client_secret)
+    except A2AAuthError as exc:
+        return _auth_error_response(exc)
+
+    return JSONResponse(
+        status_code=200,
+        content=token.to_response(),
+        headers={"Cache-Control": "no-store", "Pragma": "no-cache"},
+    )
+
+
+def _extract_client_credentials(request: Request, form: dict[str, str]) -> tuple[str, str]:
+    """Return ``(client_id, client_secret)`` from Basic auth or the form."""
+    import base64
+    import binascii
+
+    header = request.headers.get("authorization", "")
+    if header.startswith("Basic "):
+        try:
+            decoded = base64.b64decode(header[len("Basic ") :].strip()).decode("utf-8")
+            client_id, _, client_secret = decoded.partition(":")
+            if client_id:
+                return client_id, client_secret
+        except (ValueError, binascii.Error, UnicodeDecodeError):
+            pass
+    return form.get("client_id", ""), form.get("client_secret", "")
+
+
+# ---------------------------------------------------------------------------
+# JSON-RPC endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.post(A2A_JSONRPC_PATH, include_in_schema=False)
+async def a2a_jsonrpc(request: Request) -> Any:
+    """Dispatch a single A2A JSON-RPC 2.0 request.
+
+    Auth is enforced before parsing so an unauthenticated caller cannot probe
+    method behaviour. ``message/stream`` returns an SSE stream; the other
+    methods return a JSON-RPC envelope.
+    """
+    if not a2a_server_enabled():
+        return JSONResponse(status_code=404, content={"detail": "A2A server surface is disabled"})
+
+    # 1. Authenticate (transport-level, per the A2A spec).
+    try:
+        caller = _get_auth(request).authenticate(dict(request.headers))
+    except A2AAuthError as exc:
+        return _auth_error_response(exc)
+
+    # 2. Parse the JSON body into a JSON-RPC request.
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse(
+            status_code=200,
+            content=jsonrpc_error_response(None, JSONRPC_PARSE_ERROR, "request body is not valid JSON"),
+        )
+    try:
+        rpc = parse_jsonrpc_request(body)
+    except JSONRPCError as exc:
+        return JSONResponse(status_code=200, content=jsonrpc_error_response(None, exc.code, exc.message))
+
+    # 3. Dispatch.
+    if rpc.method == "message/stream":
+        return _stream_message(request, rpc.id, rpc.params, caller_id=caller.caller_id)
+
+    try:
+        if rpc.method == "message/send":
+            result = await _handle_message_send(request, rpc.params, caller_id=caller.caller_id)
+        elif rpc.method == "tasks/get":
+            result = _handle_tasks_get(request, rpc.params)
+        else:
+            return JSONResponse(
+                status_code=200,
+                content=jsonrpc_error_response(rpc.id, JSONRPC_METHOD_NOT_FOUND, f"unknown method '{rpc.method}'"),
+            )
+    except JSONRPCError as exc:
+        return JSONResponse(status_code=200, content=jsonrpc_error_response(rpc.id, exc.code, exc.message))
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("A2A JSON-RPC %s failed: %s", rpc.method, exc)
+        return JSONResponse(
+            status_code=200,
+            content=jsonrpc_error_response(rpc.id, JSONRPC_INTERNAL_ERROR, "internal error handling the request"),
+        )
+
+    return JSONResponse(status_code=200, content=jsonrpc_result_response(rpc.id, result))
+
+
+# ---------------------------------------------------------------------------
+# Method handlers
+# ---------------------------------------------------------------------------
+
+
+async def _handle_message_send(request: Request, params: dict[str, Any], *, caller_id: str) -> dict[str, Any]:
+    """Accept an A2A message, create a task, and return the accepted ``Task``.
+
+    The acceptance is anchored in the audit chain (with the caller) and the
+    receipt rides in the task metadata, so even the acceptance is verifiable.
+    The task's eventual completed result is reached by polling ``tasks/get``.
+    """
+    text = extract_message_text(params)
+    role = str(params.get("role") or (params.get("message") or {}).get("role") or "backend")
+    if role not in {"backend", "frontend", "qa", "security", "devops", "docs", "manager"}:
+        role = "backend"
+
+    handler = _get_handler(request)
+    store = _get_store(request)
+
+    a2a_task = handler.create_task(sender=caller_id or "a2a-caller", message=text, role=role)
+    from bernstein.core.server import TaskCreate
+    from bernstein.core.tenanting import request_tenant_id
+
+    bernstein_task = await store.create(
+        TaskCreate(
+            title=f"[A2A] {text[:80]}",
+            description=text,
+            role=role,
+            tenant_id=request_tenant_id(request),
+            estimated_minutes=minutes_for_level(estimate_difficulty(text).level),
+        )
+    )
+    handler.link_bernstein_task(a2a_task.id, bernstein_task.id)
+
+    state = a2a_state_for_bernstein(bernstein_task.status.value)
+    metadata = _attest_acceptance(request, a2a_task_id=a2a_task.id, text=text, caller_id=caller_id)
+    return build_task_object(
+        task_id=a2a_task.id,
+        context_id=_context_id(a2a_task.id),
+        state=state,
+        timestamp=_now_iso(),
+        metadata=metadata,
+    )
+
+
+def _attest_acceptance(request: Request, *, a2a_task_id: str, text: str, caller_id: str) -> dict[str, Any]:
+    """Mint and persist the acceptance receipt, returning task metadata.
+
+    Returns a metadata dict carrying the authenticated caller and, when the
+    node can attest, the receipt plus the exact payload it covers. An
+    unattested node still answers; the missing receipt is the signal.
+    """
+    metadata: dict[str, Any] = {"a2a": {"caller": caller_id or "anonymous"}}
+    issuer = _get_issuer(request)
+    if issuer is None:
+        return metadata
+    attested = {"taskId": a2a_task_id, "message": text}
+    try:
+        receipt = issuer.issue(task_id=a2a_task_id, response=attested, caller=caller_id)
+    except (OSError, ValueError) as exc:
+        logger.warning("could not mint A2A acceptance receipt for %s: %s", a2a_task_id, exc)
+        return metadata
+    payload = receipt.to_dict()
+    _get_handler(request).attach_receipt(a2a_task_id, payload)
+    metadata["lineageReceipt"] = payload
+    metadata["attested"] = attested
+    return metadata
+
+
+def _handle_tasks_get(request: Request, params: dict[str, Any]) -> dict[str, Any]:
+    """Return the current A2A ``Task`` for a task id, projecting Bernstein state.
+
+    When the underlying task is done, the returned task carries an ``Artifact``
+    whose parts hold the result text and a lineage-receipt reference. The
+    completion receipt is minted once and reused on later polls, so repeated
+    reads do not grow the audit chain.
+    """
+    task_id = params.get("id")
+    if not isinstance(task_id, str) or not task_id:
+        raise JSONRPCError(JSONRPC_INVALID_PARAMS, "params.id is required")
+
+    handler = _get_handler(request)
+    store = _get_store(request)
+    a2a_task = handler.get_task(task_id)
+    if a2a_task is None:
+        # A2A surfaces an unknown task as an error, not a 404 - the transport
+        # stays JSON-RPC. -32001 is a server-defined "task not found".
+        raise JSONRPCError(-32001, f"task '{task_id}' not found")
+
+    bernstein_status = "open"
+    result_summary = ""
+    if a2a_task.bernstein_task_id is not None:
+        bt = store.get_task(a2a_task.bernstein_task_id)
+        if bt is not None:
+            bernstein_status = bt.status.value
+            handler.sync_status(a2a_task.id, bernstein_status)
+            result_summary = bt.result_summary or ""
+
+    state = a2a_state_for_bernstein(bernstein_status)
+    artifacts: list[dict[str, Any]] = []
+    if state == "completed":
+        receipt = _completion_receipt(request, a2a_task_id=task_id, result=result_summary)
+        artifacts.append(build_completed_artifact(task_id=task_id, result=result_summary, receipt=receipt))
+
+    return build_task_object(
+        task_id=task_id,
+        context_id=_context_id(task_id),
+        state=state,
+        timestamp=_now_iso(),
+        artifacts=artifacts,
+    )
+
+
+def _completion_receipt(request: Request, *, a2a_task_id: str, result: str) -> dict[str, Any]:
+    """Return the completion receipt, minting it once and caching it.
+
+    The receipt attests the exact ``{taskId, result}`` payload the artifact
+    carries, so a peer reconstructs it and verifies offline. Minted lazily on
+    the first poll that observes completion and reused thereafter.
+    """
+    handler = _get_handler(request)
+    key = f"{a2a_task_id}{_COMPLETED_RECEIPT_SUFFIX}"
+    stored = handler.get_receipt(key)
+    if stored is not None:
+        return stored
+
+    issuer = _get_issuer(request)
+    if issuer is None:
+        return {}
+    attested = attested_completion_payload(task_id=a2a_task_id, result=result)
+    try:
+        receipt = issuer.issue(task_id=a2a_task_id, response=attested)
+    except (OSError, ValueError) as exc:
+        logger.warning("could not mint A2A completion receipt for %s: %s", a2a_task_id, exc)
+        return {}
+    payload = receipt.to_dict()
+    handler.attach_receipt(key, payload)
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# message/stream (SSE)
+# ---------------------------------------------------------------------------
+
+
+def _stream_message(request: Request, request_id: Any, params: dict[str, Any], *, caller_id: str) -> StreamingResponse:
+    """Stream task updates over SSE for ``message/stream``.
+
+    A2A clients that support streaming receive the accepted task and a status
+    snapshot as ``data:`` events. Terminal completion (and the receipt-bearing
+    artifact) is delivered through ``tasks/get`` polling, which every client
+    must support - streaming is an accelerator, not the only path.
+    """
+    import json as _json
+
+    def _sse(envelope: dict[str, Any]) -> str:
+        return f"data: {_json.dumps(envelope)}\n\n"
+
+    async def _events() -> Any:
+        try:
+            accepted = await _handle_message_send(request, params, caller_id=caller_id)
+        except JSONRPCError as exc:
+            yield _sse(jsonrpc_error_response(request_id, exc.code, exc.message))
+            return
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("A2A message/stream failed: %s", exc)
+            yield _sse(jsonrpc_error_response(request_id, JSONRPC_INTERNAL_ERROR, "internal error"))
+            return
+
+        # First event: the accepted task.
+        yield _sse(jsonrpc_result_response(request_id, accepted))
+
+        # Second event: a status snapshot the client can act on, marked final
+        # so a streaming client knows to fall back to tasks/get for the result.
+        snapshot = _handle_tasks_get(request, {"id": accepted["id"]})
+        status_update = {
+            "taskId": accepted["id"],
+            "contextId": accepted["contextId"],
+            "kind": "status-update",
+            "status": snapshot["status"],
+            "final": snapshot["status"]["state"] in {"completed", "failed", "canceled"},
+        }
+        yield _sse(jsonrpc_result_response(request_id, status_update))
+
+    return StreamingResponse(
+        _events(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-store", "X-Accel-Buffering": "no"},
+    )

--- a/src/bernstein/core/routes/a2a_jsonrpc.py
+++ b/src/bernstein/core/routes/a2a_jsonrpc.py
@@ -161,7 +161,7 @@ async def a2a_oauth_token(request: Request) -> JSONResponse:
     try:
         raw_form = await request.form()
         form = {k: str(v) for k, v in raw_form.items()}
-    except Exception:  # pragma: no cover - defensive: malformed multipart
+    except Exception:  # pragma: no cover  # intentional-broad-except: malformed multipart is best-effort
         form = {}
 
     grant_type = form.get("grant_type", "")
@@ -232,7 +232,7 @@ async def a2a_jsonrpc(request: Request) -> Any:
     # 2. Parse the JSON body into a JSON-RPC request.
     try:
         body = await request.json()
-    except Exception:
+    except Exception:  # intentional-broad-except: malformed JSON body returns a JSON-RPC parse error
         return JSONResponse(
             status_code=200,
             content=jsonrpc_error_response(None, JSONRPC_PARSE_ERROR, "request body is not valid JSON"),
@@ -258,7 +258,7 @@ async def a2a_jsonrpc(request: Request) -> Any:
             )
     except JSONRPCError as exc:
         return JSONResponse(status_code=200, content=jsonrpc_error_response(rpc.id, exc.code, exc.message))
-    except Exception as exc:  # pragma: no cover - defensive
+    except Exception as exc:  # pragma: no cover  # intentional-broad-except: dispatch failure -> JSON-RPC error
         logger.warning("A2A JSON-RPC %s failed: %s", rpc.method, exc)
         return JSONResponse(
             status_code=200,
@@ -433,7 +433,7 @@ def _stream_message(request: Request, request_id: Any, params: dict[str, Any], *
         except JSONRPCError as exc:
             yield _sse(jsonrpc_error_response(request_id, exc.code, exc.message))
             return
-        except Exception as exc:  # pragma: no cover - defensive
+        except Exception as exc:  # pragma: no cover  # intentional-broad-except: stream failure -> JSON-RPC error
             logger.warning("A2A message/stream failed: %s", exc)
             yield _sse(jsonrpc_error_response(request_id, JSONRPC_INTERNAL_ERROR, "internal error"))
             return

--- a/src/bernstein/core/routes/well_known.py
+++ b/src/bernstein/core/routes/well_known.py
@@ -374,7 +374,45 @@ def _agent_card_body(base_url: str = _DEFAULT_BASE_URL, *, tenant_id: str = DEFA
     }
     if tenant_id != DEFAULT_TENANT_ID:
         body["tenantId"] = tenant_id
+    _apply_a2a_server_surface(body, base_url)
     return body
+
+
+def _apply_a2a_server_surface(body: dict[str, Any], base_url: str) -> None:
+    """Declare the inbound A2A JSON-RPC binding + auth in the card, if enabled.
+
+    Off by default: when ``BERNSTEIN_A2A_SERVER_ENABLED`` is unset the card is
+    byte-identical to the historical one, so existing verifiers and cached
+    cards are undisturbed. When enabled, the card advertises
+
+    * the JSON-RPC 2.0 interface (transport + endpoint URL) as an additional
+      interface, and ``JSONRPC`` in ``supportedInterfaces``; and
+    * the two callable-node auth schemes - a static API key and an OAuth2
+      client-credentials grant with its token URL -
+
+    so a peer negotiates the binding and credentials before sending a task.
+    """
+    # Local import keeps the route module (which imports FastAPI + task server
+    # helpers) out of this module's import graph unless the surface is on.
+    from bernstein.core.protocols.a2a.server_auth import A2AServerAuth
+    from bernstein.core.routes.a2a_jsonrpc import (
+        A2A_JSONRPC_PATH,
+        A2A_TOKEN_PATH,
+        a2a_server_enabled,
+    )
+
+    if not a2a_server_enabled():
+        return
+
+    rpc_url = f"{base_url.rstrip('/')}{A2A_JSONRPC_PATH}"
+    token_url = f"{base_url.rstrip('/')}{A2A_TOKEN_PATH}"
+
+    interfaces = body["supportedInterfaces"]
+    if "JSONRPC" not in interfaces:
+        interfaces.append("JSONRPC")
+    body["additionalInterfaces"] = [{"url": rpc_url, "transport": "JSONRPC"}]
+
+    body["securitySchemes"] = body["securitySchemes"] + A2AServerAuth.from_env().security_schemes(token_url=token_url)
 
 
 def _sign_canonical_body(canonical_body: bytes, private_pem: bytes, *, kid: str) -> str:
@@ -563,16 +601,11 @@ def _render_llms_txt() -> str:
 # ---------------------------------------------------------------------------
 
 
-@router.get("/.well-known/agent.json", include_in_schema=False)
-def agent_json(request: Request) -> Response:
-    """Return the A2A v1.0 signed agent card for this task server.
+def _serve_agent_card(request: Request) -> Response:
+    """Render the signed A2A v1.0 card as a JCS-canonical JSON response.
 
-    Body bytes are JCS-canonical (RFC 8785) so verifiers can recompute the
-    JWS signing input bit-perfect after stripping the ``signatures`` array.
-    Cache for an hour - the card body changes only when the server config
-    or the orchestrator's signing key rotates. A ``?tenant=`` query parameter
-    (or ``x-tenant-id`` header) selects a tenant-scoped identity; a
-    multi-tenant host serves a distinct signed card per tenant.
+    Shared by ``/.well-known/agent.json`` and ``/.well-known/agent-card.json``
+    so both paths return byte-identical, identically-signed bytes.
     """
     tenant_id = _resolve_tenant(request)
     payload = _agent_card_payload(_resolve_base_url(), tenant_id=tenant_id)
@@ -586,6 +619,32 @@ def agent_json(request: Request) -> Response:
         media_type="application/json",
         headers=headers,
     )
+
+
+@router.get("/.well-known/agent.json", include_in_schema=False)
+def agent_json(request: Request) -> Response:
+    """Return the A2A v1.0 signed agent card for this task server.
+
+    Body bytes are JCS-canonical (RFC 8785) so verifiers can recompute the
+    JWS signing input bit-perfect after stripping the ``signatures`` array.
+    Cache for an hour - the card body changes only when the server config
+    or the orchestrator's signing key rotates. A ``?tenant=`` query parameter
+    (or ``x-tenant-id`` header) selects a tenant-scoped identity; a
+    multi-tenant host serves a distinct signed card per tenant.
+    """
+    return _serve_agent_card(request)
+
+
+@router.get("/.well-known/agent-card.json", include_in_schema=False)
+def agent_card_json(request: Request) -> Response:
+    """Serve the signed card at the A2A v1.0 canonical well-known path (#2609).
+
+    A2A v1.0 canonicalised ``/.well-known/agent-card.json``, but at least one
+    major shipped client still fetches the legacy ``/.well-known/agent.json``.
+    Both paths return identical bytes with the same signature, so a peer
+    discovers and verifies the node whichever name it was built to fetch.
+    """
+    return _serve_agent_card(request)
 
 
 @router.get("/.well-known/agent.json/keys", include_in_schema=False)

--- a/src/bernstein/core/security/auth_middleware.py
+++ b/src/bernstein/core/security/auth_middleware.py
@@ -94,12 +94,23 @@ AUTH_PUBLIC_PATHS = frozenset(
         "/alive",
         # Agent / protocol discovery
         "/.well-known/agent.json",
+        # A2A v1.0 canonical discovery path (#2609): served identical to
+        # ``/.well-known/agent.json`` so shipped clients that fetch either the
+        # v1.0 name or the legacy name both resolve the signed card.
+        "/.well-known/agent-card.json",
         "/.well-known/agent.json/keys",
         "/.well-known/http-message-signatures-directory",
         "/.well-known/acp.json",
         "/.well-known/mcp-tools",
         "/llms.txt",
         "/acp/v0/agents",
+        # A2A JSON-RPC server surface (#2609). These endpoints run their OWN
+        # auth (card-declared API key + OAuth2 client-credentials) and reject
+        # unauthenticated calls per spec, so the server-wide bearer check must
+        # let them reach the handler. When the surface is disabled (the
+        # default) the handler answers 404, exposing nothing.
+        "/a2a/v1",
+        "/a2a/v1/oauth/token",
         # Auth flow endpoints (must be public for login to work)
         "/auth/login",
         "/auth/oidc/callback",

--- a/src/bernstein/core/server/server_app.py
+++ b/src/bernstein/core/server/server_app.py
@@ -1250,6 +1250,13 @@ def create_app(
     # ``None`` when key material or the lineage root is unavailable, in which
     # case responses are served unattested rather than not at all.
     application.state.a2a_receipt_issuer = build_receipt_issuer(sdd_dir)  # type: ignore[attr-defined]
+    # Inbound A2A JSON-RPC auth (#2609): API key + OAuth2 client-credentials,
+    # both declared in the agent card. Built from ``BERNSTEIN_A2A_*`` env at
+    # app creation; the JSON-RPC surface is inert unless
+    # ``BERNSTEIN_A2A_SERVER_ENABLED`` is set, so this stays dormant by default.
+    from bernstein.core.protocols.a2a.server_auth import A2AServerAuth
+
+    application.state.a2a_server_auth = A2AServerAuth.from_env()  # type: ignore[attr-defined]
     application.state.acp_handler = acp_handler  # type: ignore[attr-defined]
     application.state.node_registry = node_registry  # type: ignore[attr-defined]
     application.state.cluster_authenticator = cluster_authenticator  # type: ignore[attr-defined]
@@ -1325,6 +1332,7 @@ def create_app(
 
     # WEB-011: Paginated task search - must precede tasks_router so /tasks/search
     # is matched before /tasks/{task_id}.
+    from bernstein.core.routes.a2a_jsonrpc import router as a2a_jsonrpc_router
     from bernstein.core.routes.acp import router as acp_router
     from bernstein.core.routes.agent_comparison import router as agent_comparison_router
     from bernstein.core.routes.api_v1 import build_router as build_api_v1_router
@@ -1424,6 +1432,7 @@ def create_app(
         orchestrator_holds_router,
         review_board_router,
         missions_router,
+        a2a_jsonrpc_router,
     ]
 
     # Fresh per-app router: including route groups mutates the target router,

--- a/src/bernstein/core/server/server_middleware.py
+++ b/src/bernstein/core/server/server_middleware.py
@@ -36,11 +36,16 @@ _PUBLIC_PATHS = frozenset(
         "/ready",
         "/alive",
         "/.well-known/agent.json",
+        "/.well-known/agent-card.json",
         "/.well-known/agent.json/keys",
         "/.well-known/http-message-signatures-directory",
         "/.well-known/acp.json",
         "/.well-known/mcp-tools",
         "/acp/v0/agents",
+        # A2A JSON-RPC surface - handlers enforce their own card-declared auth
+        # (#2609). Disabled by default (handler returns 404 when off).
+        "/a2a/v1",
+        "/a2a/v1/oauth/token",
         "/docs",
         "/redoc",
         "/openapi.json",

--- a/tests/unit/test_a2a_jsonrpc_protocol.py
+++ b/tests/unit/test_a2a_jsonrpc_protocol.py
@@ -1,0 +1,190 @@
+"""Pure JSON-RPC 2.0 + A2A projection helpers for the server surface (#2609).
+
+These cover the framework-agnostic core: request parsing, error/result
+envelopes, A2A ``Message``/``Task`` projection, and the completed-task
+artifact that carries a lineage receipt reference. No HTTP here - the route
+module wires these into FastAPI.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.protocols.a2a.jsonrpc import (
+    JSONRPC_INVALID_PARAMS,
+    JSONRPC_INVALID_REQUEST,
+    JSONRPC_METHOD_NOT_FOUND,
+    JSONRPC_PARSE_ERROR,
+    JSONRPCError,
+    a2a_state_for_bernstein,
+    build_completed_artifact,
+    build_task_object,
+    extract_message_text,
+    jsonrpc_error_response,
+    jsonrpc_result_response,
+    parse_jsonrpc_request,
+)
+
+# ---------------------------------------------------------------------------
+# Request parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_valid_request() -> None:
+    req = parse_jsonrpc_request({"jsonrpc": "2.0", "id": 7, "method": "message/send", "params": {"x": 1}})
+    assert req.id == 7
+    assert req.method == "message/send"
+    assert req.params == {"x": 1}
+
+
+def test_missing_jsonrpc_version_is_invalid_request() -> None:
+    with pytest.raises(JSONRPCError) as exc:
+        parse_jsonrpc_request({"id": 1, "method": "message/send"})
+    assert exc.value.code == JSONRPC_INVALID_REQUEST
+
+
+def test_wrong_jsonrpc_version_is_invalid_request() -> None:
+    with pytest.raises(JSONRPCError) as exc:
+        parse_jsonrpc_request({"jsonrpc": "1.0", "id": 1, "method": "m"})
+    assert exc.value.code == JSONRPC_INVALID_REQUEST
+
+
+def test_missing_method_is_invalid_request() -> None:
+    with pytest.raises(JSONRPCError) as exc:
+        parse_jsonrpc_request({"jsonrpc": "2.0", "id": 1})
+    assert exc.value.code == JSONRPC_INVALID_REQUEST
+
+
+def test_non_object_body_is_invalid_request() -> None:
+    with pytest.raises(JSONRPCError) as exc:
+        parse_jsonrpc_request([1, 2, 3])  # type: ignore[arg-type]
+    assert exc.value.code == JSONRPC_INVALID_REQUEST
+
+
+def test_params_default_to_empty_object() -> None:
+    req = parse_jsonrpc_request({"jsonrpc": "2.0", "id": 1, "method": "tasks/get"})
+    assert req.params == {}
+
+
+# ---------------------------------------------------------------------------
+# Envelopes
+# ---------------------------------------------------------------------------
+
+
+def test_result_envelope_shape() -> None:
+    env = jsonrpc_result_response(7, {"ok": True})
+    assert env == {"jsonrpc": "2.0", "id": 7, "result": {"ok": True}}
+
+
+def test_error_envelope_shape() -> None:
+    env = jsonrpc_error_response(7, JSONRPC_METHOD_NOT_FOUND, "no such method")
+    assert env["jsonrpc"] == "2.0"
+    assert env["id"] == 7
+    assert env["error"]["code"] == JSONRPC_METHOD_NOT_FOUND
+    assert env["error"]["message"] == "no such method"
+    assert "result" not in env
+
+
+def test_error_constants_match_spec() -> None:
+    assert JSONRPC_PARSE_ERROR == -32700
+    assert JSONRPC_INVALID_REQUEST == -32600
+    assert JSONRPC_METHOD_NOT_FOUND == -32601
+    assert JSONRPC_INVALID_PARAMS == -32602
+
+
+# ---------------------------------------------------------------------------
+# A2A message extraction
+# ---------------------------------------------------------------------------
+
+
+def test_extract_text_from_parts() -> None:
+    params = {
+        "message": {
+            "role": "user",
+            "parts": [
+                {"kind": "text", "text": "review "},
+                {"kind": "text", "text": "the auth module"},
+            ],
+            "messageId": "m1",
+        }
+    }
+    assert extract_message_text(params) == "review the auth module"
+
+
+def test_extract_text_ignores_non_text_parts() -> None:
+    params = {
+        "message": {
+            "parts": [
+                {"kind": "text", "text": "hello"},
+                {"kind": "data", "data": {"k": "v"}},
+            ]
+        }
+    }
+    assert extract_message_text(params) == "hello"
+
+
+def test_missing_message_raises_invalid_params() -> None:
+    with pytest.raises(JSONRPCError) as exc:
+        extract_message_text({})
+    assert exc.value.code == JSONRPC_INVALID_PARAMS
+
+
+def test_message_with_no_text_raises_invalid_params() -> None:
+    with pytest.raises(JSONRPCError) as exc:
+        extract_message_text({"message": {"parts": [{"kind": "data", "data": {}}]}})
+    assert exc.value.code == JSONRPC_INVALID_PARAMS
+
+
+# ---------------------------------------------------------------------------
+# A2A task projection
+# ---------------------------------------------------------------------------
+
+
+def test_state_projection_maps_done_to_completed() -> None:
+    assert a2a_state_for_bernstein("done") == "completed"
+    assert a2a_state_for_bernstein("open") == "submitted"
+    assert a2a_state_for_bernstein("in_progress") == "working"
+    assert a2a_state_for_bernstein("blocked") == "input-required"
+    assert a2a_state_for_bernstein("failed") == "failed"
+
+
+def test_build_task_object_shape() -> None:
+    task = build_task_object(
+        task_id="abc123",
+        context_id="ctx1",
+        state="submitted",
+        timestamp="2026-07-24T00:00:00Z",
+    )
+    assert task["id"] == "abc123"
+    assert task["contextId"] == "ctx1"
+    assert task["kind"] == "task"
+    assert task["status"]["state"] == "submitted"
+    assert task["status"]["timestamp"] == "2026-07-24T00:00:00Z"
+
+
+def test_completed_artifact_carries_receipt_and_attested_payload() -> None:
+    receipt = {"entry_hash": "e", "content_hash": "sha256:c", "kid": "k", "head_signature": {}}
+    artifact = build_completed_artifact(
+        task_id="abc123",
+        result="all tests pass",
+        receipt=receipt,
+    )
+    assert artifact["artifactId"] == "abc123-result"
+    kinds = [p["kind"] for p in artifact["parts"]]
+    assert "text" in kinds
+    assert "data" in kinds
+    text_part = next(p for p in artifact["parts"] if p["kind"] == "text")
+    assert text_part["text"] == "all tests pass"
+    data_part = next(p for p in artifact["parts"] if p["kind"] == "data")
+    assert data_part["data"]["lineageReceipt"] == receipt
+    # The attested payload is exactly what the receipt's content_hash covers,
+    # so a peer reconstructs it from the artifact and verifies offline.
+    assert data_part["data"]["attested"] == {"taskId": "abc123", "result": "all tests pass"}
+
+
+def test_attested_payload_is_stable_for_the_same_inputs() -> None:
+    a = build_completed_artifact(task_id="t", result="r", receipt={})
+    b = build_completed_artifact(task_id="t", result="r", receipt={})
+    da = next(p for p in a["parts"] if p["kind"] == "data")["data"]["attested"]
+    db = next(p for p in b["parts"] if p["kind"] == "data")["data"]["attested"]
+    assert da == db

--- a/tests/unit/test_a2a_jsonrpc_route.py
+++ b/tests/unit/test_a2a_jsonrpc_route.py
@@ -1,0 +1,386 @@
+"""End-to-end A2A JSON-RPC server surface over the real ASGI app (#2609).
+
+The binding design directive's acceptance addition, exercised here with an
+independent JSON-RPC speaker (not the server's own client code):
+
+    an off-the-shelf A2A client discovers the card at both well-known paths,
+    sends ``message/send``, polls ``tasks/get`` to completion, and receives an
+    artifact whose lineage receipt verifies offline.
+
+Plus the surrounding guarantees: the surface is off by default, both auth
+schemes are enforced and rejected per spec, and the card advertises the
+JSON-RPC binding and both schemes only when enabled.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from bernstein.core.interop.a2a_card import SignedCapabilityCard, verify_capability_card
+from bernstein.core.protocols.a2a.receipt import A2ATaskReceipt, verify_task_receipt
+from bernstein.core.server import create_app
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture()
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.fixture()
+def enabled_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Enable the surface and configure both auth schemes, hermetically."""
+    monkeypatch.setenv("BERNSTEIN_A2A_SERVER_ENABLED", "1")
+    monkeypatch.setenv("BERNSTEIN_A2A_API_KEYS", "alice=key-alice")
+    monkeypatch.setenv("BERNSTEIN_A2A_OAUTH_CLIENTS", "client-x=secret-x")
+    monkeypatch.setenv("BERNSTEIN_A2A_OAUTH_SIGNING_SECRET", "unit-signing-secret")
+    # Isolate the agent-card keystore so the test never touches a real one.
+    monkeypatch.setenv("BERNSTEIN_AGENT_CARD_KEY_DIR", str(tmp_path / "keys"))
+    from bernstein.core.routes import well_known
+
+    well_known._reset_signing_keypair_for_tests(tmp_path / "keys")
+
+
+@pytest.fixture()
+def app(tmp_path: Path, enabled_env: None):  # type: ignore[no-untyped-def]
+    # ``enabled_env`` must run first so ``create_app`` reads the A2A auth
+    # config (built once at app creation) with the env already in place.
+    return create_app(jsonl_path=tmp_path / ".sdd" / "runtime" / "tasks.jsonl")
+
+
+@pytest.fixture()
+async def client(app) -> AsyncClient:  # type: ignore[no-untyped-def]
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# Minimal, independent A2A JSON-RPC client (not the server's own code)
+# ---------------------------------------------------------------------------
+
+
+class _A2AClient:
+    """A tiny off-the-shelf-style JSON-RPC 2.0 A2A speaker."""
+
+    def __init__(self, http: AsyncClient, *, api_key: str | None = None, bearer: str | None = None) -> None:
+        self._http = http
+        self._id = 0
+        self._headers: dict[str, str] = {}
+        if api_key is not None:
+            self._headers["X-API-Key"] = api_key
+        if bearer is not None:
+            self._headers["Authorization"] = f"Bearer {bearer}"
+
+    async def call(self, method: str, params: dict[str, Any]) -> Any:
+        self._id += 1
+        return await self._http.post(
+            "/a2a/v1",
+            headers=self._headers,
+            json={"jsonrpc": "2.0", "id": self._id, "method": method, "params": params},
+        )
+
+    @staticmethod
+    def text_message(text: str) -> dict[str, Any]:
+        return {"message": {"role": "user", "parts": [{"kind": "text", "text": text}], "messageId": "m-1"}}
+
+
+async def _drive_to_completion(app, a2a_task_id: str, result: str) -> None:
+    """Act as the worker: complete the Bernstein task behind the A2A task.
+
+    Walks the legal lifecycle (open -> claimed -> done) the store enforces,
+    standing in for the agent that would normally run the task.
+    """
+    handler = app.state.a2a_handler
+    bernstein_task_id = handler.get_task(a2a_task_id).bernstein_task_id
+    await app.state.store.claim_by_id(bernstein_task_id)
+    await app.state.store.complete(bernstein_task_id, result)
+
+
+# ---------------------------------------------------------------------------
+# Off-by-default
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_surface_is_off_by_default(client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BERNSTEIN_A2A_SERVER_ENABLED", raising=False)
+    resp = await client.post(
+        "/a2a/v1",
+        headers={"X-API-Key": "anything"},
+        json={"jsonrpc": "2.0", "id": 1, "method": "message/send", "params": {}},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_card_does_not_advertise_the_surface_when_disabled(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("BERNSTEIN_A2A_SERVER_ENABLED", raising=False)
+    monkeypatch.setenv("BERNSTEIN_AGENT_CARD_KEY_DIR", str(tmp_path / "k"))
+    from bernstein.core.routes import well_known
+
+    well_known._reset_signing_keypair_for_tests(tmp_path / "k")
+    card = (await client.get("/.well-known/agent-card.json")).json()
+    assert "JSONRPC" not in card["supportedInterfaces"]
+    assert "additionalInterfaces" not in card
+
+
+# ---------------------------------------------------------------------------
+# Discovery: card at both paths, advertising the binding + schemes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_card_served_identically_at_both_well_known_paths(client: AsyncClient, enabled_env: None) -> None:
+    legacy = await client.get("/.well-known/agent.json")
+    canonical = await client.get("/.well-known/agent-card.json")
+    assert legacy.status_code == canonical.status_code == 200
+    assert legacy.content == canonical.content, "both paths must serve byte-identical signed bytes"
+
+
+@pytest.mark.anyio
+async def test_discovered_card_verifies_offline(client: AsyncClient, enabled_env: None) -> None:
+    card = (await client.get("/.well-known/agent-card.json")).json()
+    signed = SignedCapabilityCard.from_dict(card["capabilityCard"])
+    assert verify_capability_card(signed) is True
+
+
+@pytest.mark.anyio
+async def test_tampered_card_fails_offline_verification(client: AsyncClient, enabled_env: None) -> None:
+    card = (await client.get("/.well-known/agent-card.json")).json()
+    signed = SignedCapabilityCard.from_dict(card["capabilityCard"])
+    tampered = SignedCapabilityCard.from_dict(card["capabilityCard"])
+    object.__setattr__(tampered.card, "name", signed.card.name + "-evil")
+    assert verify_capability_card(tampered) is False
+
+
+@pytest.mark.anyio
+async def test_card_advertises_jsonrpc_binding_and_both_schemes(client: AsyncClient, enabled_env: None) -> None:
+    card = (await client.get("/.well-known/agent-card.json")).json()
+    assert "JSONRPC" in card["supportedInterfaces"]
+    jsonrpc = [i for i in card["additionalInterfaces"] if i["transport"] == "JSONRPC"]
+    assert jsonrpc and jsonrpc[0]["url"].endswith("/a2a/v1")
+    scheme_types = {s["type"] for s in card["securitySchemes"]}
+    assert "apiKey" in scheme_types
+    assert "oauth2" in scheme_types
+
+
+# ---------------------------------------------------------------------------
+# Auth: rejections per spec
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_unauthenticated_call_is_rejected_with_a_challenge(client: AsyncClient, enabled_env: None) -> None:
+    resp = await client.post("/a2a/v1", json={"jsonrpc": "2.0", "id": 1, "method": "tasks/get", "params": {"id": "x"}})
+    assert resp.status_code == 401
+    assert "www-authenticate" in {k.lower() for k in resp.headers}
+
+
+@pytest.mark.anyio
+async def test_bad_api_key_is_rejected(client: AsyncClient, enabled_env: None) -> None:
+    c = _A2AClient(client, api_key="wrong")
+    resp = await c.call("tasks/get", {"id": "x"})
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# OAuth2 client-credentials token flow
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_oauth_token_endpoint_issues_a_usable_bearer(client: AsyncClient, enabled_env: None) -> None:
+    token_resp = await client.post(
+        "/a2a/v1/oauth/token",
+        data={"grant_type": "client_credentials", "client_id": "client-x", "client_secret": "secret-x"},
+    )
+    assert token_resp.status_code == 200
+    token = token_resp.json()["access_token"]
+
+    c = _A2AClient(client, bearer=token)
+    send = await c.call("message/send", _A2AClient.text_message("do the thing"))
+    assert send.status_code == 200
+    assert send.json()["result"]["kind"] == "task"
+
+
+@pytest.mark.anyio
+async def test_oauth_token_endpoint_rejects_bad_secret(client: AsyncClient, enabled_env: None) -> None:
+    resp = await client.post(
+        "/a2a/v1/oauth/token",
+        data={"grant_type": "client_credentials", "client_id": "client-x", "client_secret": "nope"},
+    )
+    assert resp.status_code == 401
+    assert resp.json()["error"] == "invalid_client"
+
+
+# ---------------------------------------------------------------------------
+# The headline AC: send -> poll -> completed artifact -> verify offline
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_send_poll_complete_artifact_verifies_offline(client: AsyncClient, app, enabled_env: None) -> None:  # type: ignore[no-untyped-def]
+    c = _A2AClient(client, api_key="key-alice")
+
+    # 1. message/send returns an accepted task.
+    send = await c.call("message/send", _A2AClient.text_message("review the auth module"))
+    assert send.status_code == 200
+    task = send.json()["result"]
+    assert task["kind"] == "task"
+    assert task["status"]["state"] == "submitted"
+    task_id = task["id"]
+
+    # 2. tasks/get before completion still works (degrade-gracefully polling).
+    poll = (await c.call("tasks/get", {"id": task_id})).json()["result"]
+    assert poll["status"]["state"] in {"submitted", "working"}
+    assert poll["artifacts"] == []
+
+    # 3. The worker completes the underlying task.
+    await _drive_to_completion(app, task_id, "all 42 tests pass")
+
+    # 4. tasks/get now returns the completed task with a receipt-bearing artifact.
+    done = (await c.call("tasks/get", {"id": task_id})).json()["result"]
+    assert done["status"]["state"] == "completed"
+    assert len(done["artifacts"]) == 1
+    artifact = done["artifacts"][0]
+    text_part = next(p for p in artifact["parts"] if p["kind"] == "text")
+    assert text_part["text"] == "all 42 tests pass"
+
+    # 5. Offline verification: the artifact carries the receipt and the exact
+    #    bytes it attests, so the client proves the answer without the node.
+    data = next(p for p in artifact["parts"] if p["kind"] == "data")["data"]
+    receipt = A2ATaskReceipt.from_dict(data["lineageReceipt"])
+    assert verify_task_receipt(receipt, response=data["attested"]).ok
+
+
+@pytest.mark.anyio
+async def test_tampered_completion_artifact_fails_verification(client: AsyncClient, app, enabled_env: None) -> None:  # type: ignore[no-untyped-def]
+    """EMPIRICAL: rewriting one byte of the answer is caught by the caller."""
+    c = _A2AClient(client, api_key="key-alice")
+    task_id = (await c.call("message/send", _A2AClient.text_message("m"))).json()["result"]["id"]
+    await _drive_to_completion(app, task_id, "the answer")
+
+    done = (await c.call("tasks/get", {"id": task_id})).json()["result"]
+    data = next(p for p in done["artifacts"][0]["parts"] if p["kind"] == "data")["data"]
+    receipt = A2ATaskReceipt.from_dict(data["lineageReceipt"])
+
+    tampered = dict(data["attested"])
+    tampered["result"] = "the answer."  # one byte added
+    result = verify_task_receipt(receipt, response=tampered)
+    assert not result.ok
+    assert any("content_hash" in e for e in result.errors)
+
+
+@pytest.mark.anyio
+async def test_completion_receipt_is_stable_across_polls(client: AsyncClient, app, enabled_env: None) -> None:  # type: ignore[no-untyped-def]
+    """Re-polling a completed task does not grow the audit chain."""
+    c = _A2AClient(client, api_key="key-alice")
+    task_id = (await c.call("message/send", _A2AClient.text_message("m"))).json()["result"]["id"]
+    await _drive_to_completion(app, task_id, "the answer")
+
+    first = (await c.call("tasks/get", {"id": task_id})).json()["result"]
+    second = (await c.call("tasks/get", {"id": task_id})).json()["result"]
+    r1 = next(p for p in first["artifacts"][0]["parts"] if p["kind"] == "data")["data"]["lineageReceipt"]
+    r2 = next(p for p in second["artifacts"][0]["parts"] if p["kind"] == "data")["data"]["lineageReceipt"]
+    assert r1["entry_hash"] == r2["entry_hash"]
+
+
+@pytest.mark.anyio
+async def test_authenticated_caller_is_anchored_in_the_audit_chain(client: AsyncClient, app, enabled_env: None) -> None:  # type: ignore[no-untyped-def]
+    c = _A2AClient(client, api_key="key-alice")
+    task_id = (await c.call("message/send", _A2AClient.text_message("m"))).json()["result"]["id"]
+    # The acceptance receipt names the caller via the chain entry the issuer
+    # wrote; the handler kept its copy of that receipt.
+    stored = app.state.a2a_handler.get_receipt(task_id)
+    assert stored is not None
+    # The caller rode into the chain: the metadata echoes it and the receipt
+    # attests the accepted request.
+    result = verify_task_receipt(
+        A2ATaskReceipt.from_dict(stored),
+        response={"taskId": task_id, "message": "m"},
+    )
+    assert result.ok
+
+
+# ---------------------------------------------------------------------------
+# JSON-RPC error handling + method dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_unknown_method_returns_method_not_found(client: AsyncClient, enabled_env: None) -> None:
+    c = _A2AClient(client, api_key="key-alice")
+    resp = await c.call("tasks/nonexistent", {})
+    assert resp.status_code == 200
+    assert resp.json()["error"]["code"] == -32601
+
+
+@pytest.mark.anyio
+async def test_tasks_get_unknown_task_is_a_jsonrpc_error(client: AsyncClient, enabled_env: None) -> None:
+    c = _A2AClient(client, api_key="key-alice")
+    resp = await c.call("tasks/get", {"id": "does-not-exist"})
+    assert resp.status_code == 200
+    assert "error" in resp.json()
+
+
+@pytest.mark.anyio
+async def test_completion_artifact_verifies_and_tamper_rejected_via_cli(
+    client: AsyncClient, app, enabled_env: None, tmp_path: Path
+) -> None:  # type: ignore[no-untyped-def]
+    """EMPIRICAL: the shipped ``bernstein a2a verify`` CLI accepts the real
+    artifact and rejects a one-byte tamper - the same tool a peer would run.
+    """
+    from click.testing import CliRunner
+
+    from bernstein.cli.commands.a2a_cmd import a2a_group
+
+    c = _A2AClient(client, api_key="key-alice")
+    task_id = (await c.call("message/send", _A2AClient.text_message("m"))).json()["result"]["id"]
+    await _drive_to_completion(app, task_id, "the answer")
+    done = (await c.call("tasks/get", {"id": task_id})).json()["result"]
+    data = next(p for p in done["artifacts"][0]["parts"] if p["kind"] == "data")["data"]
+
+    receipt_file = tmp_path / "receipt.json"
+    response_file = tmp_path / "response.json"
+    receipt_file.write_text(json.dumps(data["lineageReceipt"]), encoding="utf-8")
+    response_file.write_text(json.dumps(data["attested"]), encoding="utf-8")
+
+    runner = CliRunner()
+    ok = runner.invoke(a2a_group, ["verify", "--receipt", str(receipt_file), "--response", str(response_file)])
+    assert ok.exit_code == 0, ok.output
+
+    tampered = dict(data["attested"])
+    tampered["result"] = "the answer."
+    response_file.write_text(json.dumps(tampered), encoding="utf-8")
+    bad = runner.invoke(a2a_group, ["verify", "--receipt", str(receipt_file), "--response", str(response_file)])
+    assert bad.exit_code == 1
+
+
+@pytest.mark.anyio
+async def test_message_stream_returns_sse(client: AsyncClient, enabled_env: None) -> None:
+    resp = await client.post(
+        "/a2a/v1",
+        headers={"X-API-Key": "key-alice", "Accept": "text/event-stream"},
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "message/stream",
+            "params": _A2AClient.text_message("stream me"),
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/event-stream")
+    # The first SSE event is the accepted task.
+    body = resp.text
+    first = next(line for line in body.splitlines() if line.startswith("data: "))
+    event = json.loads(first[len("data: ") :])
+    assert event["result"]["kind"] == "task"

--- a/tests/unit/test_a2a_jsonrpc_states.py
+++ b/tests/unit/test_a2a_jsonrpc_states.py
@@ -1,0 +1,41 @@
+"""A2A task-state mapping covers ``input-required`` and ``auth-required`` (#2609).
+
+The binding design directive requires the A2A protocol states to map onto
+Bernstein task states, explicitly including the two states a callable node
+must be able to express: ``input-required`` (the node needs more from the
+caller) and ``auth-required`` (the node needs the caller to authenticate to a
+downstream resource before it can proceed).
+"""
+
+from __future__ import annotations
+
+from bernstein.core.protocols.a2a.a2a import (
+    A2AHandler,
+    A2ATaskStatus,
+)
+
+
+def test_auth_required_state_exists() -> None:
+    assert A2ATaskStatus.AUTH_REQUIRED.value == "auth-required"
+
+
+def test_input_required_state_exists() -> None:
+    assert A2ATaskStatus.INPUT_REQUIRED.value == "input-required"
+
+
+def test_auth_required_maps_to_a_bernstein_blocked_state() -> None:
+    # ``auth-required`` is a wait state: the node cannot progress until the
+    # caller supplies downstream credentials, which is a blocked task locally.
+    assert A2AHandler.bernstein_status_for(A2ATaskStatus.AUTH_REQUIRED) == "blocked"
+
+
+def test_input_required_maps_to_blocked() -> None:
+    assert A2AHandler.bernstein_status_for(A2ATaskStatus.INPUT_REQUIRED) == "blocked"
+
+
+def test_every_a2a_state_has_a_bernstein_mapping() -> None:
+    # A missing entry silently degrades to "open"; assert the table is total
+    # so a newly added state fails loudly here instead of mis-projecting.
+    for state in A2ATaskStatus:
+        mapped = A2AHandler.bernstein_status_for(state)
+        assert mapped, f"{state} has no Bernstein mapping"

--- a/tests/unit/test_a2a_receipt_caller.py
+++ b/tests/unit/test_a2a_receipt_caller.py
@@ -1,0 +1,86 @@
+"""The receipt issuer anchors the authenticated caller in the audit chain (#2609).
+
+The binding directive requires that every accepted task record the
+authenticated caller in the audit chain. The receipt issuer already appends
+the response to the Merkle-chained lineage spine; passing the caller records
+it on that same chain entry, so an auditor can attribute the accepted work to
+the identity that called - and two identical calls from the same caller still
+project byte-identical receipts (determinism).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from bernstein.core.lineage.spine import LineageSpine
+from bernstein.core.protocols.a2a.receipt import A2AReceiptIssuer
+from bernstein.core.security.lineage_kms import FileBasedKMSAdapter
+
+
+def _fixed_key(tmp_path: Path) -> Path:
+    """Write a fixed-seed Ed25519 key so signatures are byte-stable.
+
+    Determinism of the *projection* is what the AC asserts; a random per-run
+    key would make the signature diverge for reasons unrelated to the caller.
+    Pinning the key isolates the property under test - two identical calls
+    from the same caller and the same node key are byte-identical.
+    """
+    key_path = tmp_path / "head.pem"
+    if not key_path.exists():
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+        private_key = Ed25519PrivateKey.from_private_bytes(b"\x02" * 32)
+        key_path.parent.mkdir(parents=True, exist_ok=True)
+        key_path.write_bytes(
+            private_key.private_bytes(
+                serialization.Encoding.PEM,
+                serialization.PrivateFormat.PKCS8,
+                serialization.NoEncryption(),
+            )
+        )
+    return key_path
+
+
+def _issuer(tmp_path: Path, run_id: str) -> A2AReceiptIssuer:
+    return A2AReceiptIssuer(
+        spine=LineageSpine(tmp_path / "lineage", run_id=run_id, hmac_key=b"unit-key"),
+        kid="test-kid",
+        kms_adapter=FileBasedKMSAdapter(_fixed_key(tmp_path.parent / "shared-key"), kid="test-kid"),
+    )
+
+
+def test_caller_is_recorded_on_the_chain_entry(tmp_path: Path) -> None:
+    issuer = _issuer(tmp_path, "run-caller")
+    issuer.issue(
+        task_id="t1",
+        response={"message": "m"},
+        caller="alice",
+        timestamp=1000,
+    )
+    # The spine entry's actor names the authenticated caller.
+    spine = LineageSpine(tmp_path / "lineage", run_id="run-caller", hmac_key=b"unit-key")
+    entries = list(spine.iter_entries())
+    assert entries
+    assert "alice" in entries[-1].actor
+
+
+def test_same_caller_and_state_yields_byte_identical_receipts(tmp_path: Path) -> None:
+    a = _issuer(tmp_path / "a", "r").issue(task_id="t1", response={"message": "m"}, caller="alice", timestamp=1000)
+    b = _issuer(tmp_path / "b", "r").issue(task_id="t1", response={"message": "m"}, caller="alice", timestamp=1000)
+    assert a.to_dict() == b.to_dict()
+
+
+def test_different_caller_changes_the_receipt(tmp_path: Path) -> None:
+    a = _issuer(tmp_path / "a", "r").issue(task_id="t1", response={"message": "m"}, caller="alice", timestamp=1000)
+    b = _issuer(tmp_path / "b", "r").issue(task_id="t1", response={"message": "m"}, caller="bob", timestamp=1000)
+    assert a.entry_hash != b.entry_hash
+
+
+def test_default_caller_keeps_the_historical_actor(tmp_path: Path) -> None:
+    """Omitting the caller preserves the pre-existing receipt bytes."""
+    issuer = _issuer(tmp_path, "run-default")
+    issuer.issue(task_id="t1", response={"message": "m"}, timestamp=1000)
+    spine = LineageSpine(tmp_path / "lineage", run_id="run-default", hmac_key=b"unit-key")
+    entries = list(spine.iter_entries())
+    assert entries[-1].actor == "a2a-server"

--- a/tests/unit/test_a2a_server_auth.py
+++ b/tests/unit/test_a2a_server_auth.py
@@ -1,0 +1,182 @@
+"""API-key + OAuth2 client-credentials auth for the A2A server surface (#2609).
+
+The binding design directive requires the callable node to accept two auth
+schemes declared in its agent card - a static API key and an OAuth2
+client-credentials grant - to reject missing or invalid credentials per the
+A2A spec, and to name the authenticated caller so the accepting path can
+anchor it in the audit chain.
+
+These tests exercise the pure authenticator: no HTTP, stdlib crypto only.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.protocols.a2a.server_auth import (
+    A2AAuthError,
+    A2AServerAuth,
+)
+
+
+def _auth() -> A2AServerAuth:
+    return A2AServerAuth(
+        api_keys={"alice": "key-alice", "bob": "key-bob"},
+        oauth_clients={"client-x": "secret-x"},
+        signing_secret=b"unit-test-secret",
+    )
+
+
+# ---------------------------------------------------------------------------
+# API key
+# ---------------------------------------------------------------------------
+
+
+def test_valid_api_key_authenticates_the_named_caller() -> None:
+    caller = _auth().authenticate({"x-api-key": "key-alice"})
+    assert caller.caller_id == "alice"
+    assert caller.scheme == "apiKey"
+
+
+def test_unknown_api_key_is_rejected() -> None:
+    with pytest.raises(A2AAuthError) as exc:
+        _auth().authenticate({"x-api-key": "not-a-key"})
+    assert exc.value.status_code == 401
+
+
+def test_missing_credentials_are_rejected_with_a_challenge() -> None:
+    with pytest.raises(A2AAuthError) as exc:
+        _auth().authenticate({})
+    assert exc.value.status_code == 401
+    # RFC 6750: an unauthenticated request gets a WWW-Authenticate challenge.
+    assert "www-authenticate" in {k.lower() for k in exc.value.headers}
+
+
+# ---------------------------------------------------------------------------
+# OAuth2 client-credentials
+# ---------------------------------------------------------------------------
+
+
+def test_client_credentials_grant_issues_a_bearer_token() -> None:
+    auth = _auth()
+    token = auth.issue_client_credentials_token(
+        client_id="client-x",
+        client_secret="secret-x",
+        now=1000.0,
+    )
+    assert token.token_type == "Bearer"
+    assert token.expires_in > 0
+    assert token.access_token
+
+
+def test_bad_client_secret_is_refused() -> None:
+    with pytest.raises(A2AAuthError) as exc:
+        _auth().issue_client_credentials_token(
+            client_id="client-x",
+            client_secret="wrong",
+            now=1000.0,
+        )
+    # OAuth2 §5.2 invalid_client.
+    assert exc.value.error == "invalid_client"
+
+
+def test_issued_token_authenticates_the_client_as_caller() -> None:
+    auth = _auth()
+    token = auth.issue_client_credentials_token(
+        client_id="client-x",
+        client_secret="secret-x",
+        now=1000.0,
+    )
+    caller = auth.authenticate(
+        {"authorization": f"Bearer {token.access_token}"},
+        now=1000.0,
+    )
+    assert caller.caller_id == "client-x"
+    assert caller.scheme == "oauth2"
+
+
+def test_expired_token_is_rejected() -> None:
+    auth = _auth()
+    token = auth.issue_client_credentials_token(
+        client_id="client-x",
+        client_secret="secret-x",
+        now=1000.0,
+    )
+    with pytest.raises(A2AAuthError) as exc:
+        auth.authenticate(
+            {"authorization": f"Bearer {token.access_token}"},
+            now=1000.0 + token.expires_in + 1,
+        )
+    assert exc.value.status_code == 401
+
+
+def test_tampered_token_is_rejected() -> None:
+    auth = _auth()
+    token = auth.issue_client_credentials_token(
+        client_id="client-x",
+        client_secret="secret-x",
+        now=1000.0,
+    )
+    forged = token.access_token[:-4] + ("AAAA" if not token.access_token.endswith("AAAA") else "BBBB")
+    with pytest.raises(A2AAuthError):
+        auth.authenticate({"authorization": f"Bearer {forged}"}, now=1000.0)
+
+
+def test_token_signed_by_a_different_secret_is_rejected() -> None:
+    issuer = _auth()
+    token = issuer.issue_client_credentials_token(
+        client_id="client-x",
+        client_secret="secret-x",
+        now=1000.0,
+    )
+    other = A2AServerAuth(
+        api_keys={},
+        oauth_clients={"client-x": "secret-x"},
+        signing_secret=b"a-different-secret",
+    )
+    with pytest.raises(A2AAuthError):
+        other.authenticate({"authorization": f"Bearer {token.access_token}"}, now=1000.0)
+
+
+# ---------------------------------------------------------------------------
+# Card advertisement
+# ---------------------------------------------------------------------------
+
+
+def test_security_schemes_declare_both_mechanisms() -> None:
+    schemes = _auth().security_schemes(token_url="https://node.example/a2a/v1/oauth/token")
+    by_id = {s["id"]: s for s in schemes}
+    assert by_id["a2a-api-key"]["type"] == "apiKey"
+    assert by_id["a2a-api-key"]["in"] == "header"
+    assert by_id["a2a-api-key"]["name"].lower() == "x-api-key"
+    oauth = by_id["a2a-oauth2"]
+    assert oauth["type"] == "oauth2"
+    cc = oauth["flows"]["clientCredentials"]
+    assert cc["tokenUrl"] == "https://node.example/a2a/v1/oauth/token"
+
+
+# ---------------------------------------------------------------------------
+# Config from environment
+# ---------------------------------------------------------------------------
+
+
+def test_from_env_parses_api_keys_and_oauth_clients(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BERNSTEIN_A2A_API_KEYS", "alice=key-alice, bob=key-bob")
+    monkeypatch.setenv("BERNSTEIN_A2A_OAUTH_CLIENTS", "client-x=secret-x")
+    monkeypatch.delenv("BERNSTEIN_A2A_OAUTH_SIGNING_SECRET", raising=False)
+    auth = A2AServerAuth.from_env()
+    assert auth.authenticate({"x-api-key": "key-alice"}).caller_id == "alice"
+    # Signing secret is derived deterministically from the client set when
+    # unset, so a rebuilt authenticator validates the same tokens.
+    token = auth.issue_client_credentials_token(client_id="client-x", client_secret="secret-x", now=5.0)
+    rebuilt = A2AServerAuth.from_env()
+    assert rebuilt.authenticate({"authorization": f"Bearer {token.access_token}"}, now=5.0).caller_id == "client-x"
+
+
+def test_from_env_with_no_config_authenticates_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BERNSTEIN_A2A_API_KEYS", raising=False)
+    monkeypatch.delenv("BERNSTEIN_A2A_OAUTH_CLIENTS", raising=False)
+    auth = A2AServerAuth.from_env()
+    assert not auth.is_configured
+    with pytest.raises(A2AAuthError):
+        auth.authenticate({"x-api-key": "anything"})


### PR DESCRIPTION
## What
Shipped the inbound A2A JSON-RPC 2.0 SERVER surface making a Bernstein instance a callable, discoverable node, behind config flag BERNSTEIN_A2A_SERVER_ENABLED (default OFF). #2677 had already shipped the signed card, persisted A2AHandler, receipts, and registry publish (A2A card + MCP registry); this branch adds the callable core the latest maintainer comment binds: (1) signed card served identically at BOTH /.well-known/agent-card.json and /.well-known/agent.json; (2) POST /a2a/v1 JSON-RPC dispatch of message/send, tasks/get, message/stream (SSE); (3) every result reachable via tasks/get polling; (4) API-key + OAuth2 client-credentials auth declared in the card, rejected per spec, caller anchored in the audit chain; (5) A2A state mapping incl. input-required + new auth-required; (6) completed tasks return artifact Parts carrying a lineage-receipt reference that verifies offline. Pure logic lives in two hermetically-tested modules (jsonrpc.py, server_auth.py); the route is a thin ASGI adapter. AGNTCY ADS/OASF registry surface remains a follow-up (already deferred by the maintainer to

Part of #2609 (registry publication follows).

> Registry publication is the recorded follow-up; this PR ships the callable core (card at both well-known paths, message/send, tasks/get, SSE stream, auth, chain anchoring) behind a default-OFF flag.

## Acceptance criteria (10/11 met)
- [x] Signed card served at both well-known paths, verifies offline, tamper fails
- [x] JSON-RPC 2.0 binding: message/send, tasks/get, message/stream (SSE)
- [x] Every result retrievable via tasks/get polling (no streaming/artifacts needed)
- [x] Auth = API key + OAuth2 client-credentials in card; rejected per spec; caller in audit chain
- [x] A2A states mapped incl. input-required and auth-required
- [x] Completed tasks return artifact Parts carrying lineage receipt references; verify offline; tamper rejected
- [x] Deterministic projection: identical task + state -> byte-identical receipts
- [x] Off by default behind a config flag, wired into the FastAPI task server
- [ ] Registry publication across A2A card / MCP registry / AGNTCY ADS-OASF — *partially-met*
- [x] Handler state survives restart (inbound task + receipt recoverable)
- [x] Docs, CLI registration, quality gates green

## Verification
Adversarial review rounds complete; empirical criteria independently re-attacked (tamper, determinism byte-compare, auth rejection, red-on-main).
Added 5 hermetic test files (in-process ASGI via httpx ASGITransport; stdlib crypto; no network): test_a2a_jsonrpc_states.py (5), test_a2a_server_auth.py (12), test_a2a_jsonrpc_protocol.py (17), test_a2a_receipt_caller.py (4), test_a2a_jsonrpc_route.py (18). All 56 pass. Broader affected set of 191 tests passes. Followed the repo's global rule: never ran the full suite; only targeted files plus the allowed `--co` collection sentinel.
