### PR TITLE
feat(tasks): figure grounding for report artifacts

### DIFF
--- a/docs/operations/artifacts.md
+++ b/docs/operations/artifacts.md
@@ -63,6 +63,7 @@ artifact bytes (in addition to the six filesystem/test completion signals):
 | `hash_stable` | Re-derives the canonical hash and compares it to an expected `sha256:...` |
 | `schema_valid` | Validates the artifact's JSON document against a declared JSON Schema (JSONL kinds validate each row) |
 | `criteria_match` | Evaluates a closed predicate set (`exists` / `eq` / `ne` / `contains` / `gt` / `ge` / `lt` / `le`) over the JSON document |
+| `figures_grounded` | On a report bundle, requires every declared figure's anchor to resolve to a verifying lineage record and every material number in the body to be declared (see [Figure grounding](#figure-grounding-report-artifacts)) |
 
 Each has a closed evaluator; none executes artifact-supplied code.
 
@@ -98,17 +99,111 @@ the Ed25519 signature and parent-chain checks still run.
   artifacts/<task_id>/receipt.json # pointer to the signed entry (re-checked on verify)
 ```
 
+## Figure grounding (report artifacts)
+
+A schema-valid report can still be **fabricated**: every number in the prose
+can come from the model, and `schema_valid` / `criteria_match` / `hash_stable`
+only prove the artifact's *shape*, never its *claims*. Figure grounding closes
+that gap for `report`-kind artifacts: every material number must trace to an
+anchored source, or the task does not complete.
+
+### The `figures.json` sidecar
+
+A grounded report is recorded as a **bundle** - the prose body plus a
+`figures.json` sidecar - serialised as one canonical JSON object
+(`{"body": ..., "figures": [...]}`). The sidecar is therefore *inside* the
+artifact's own `content_hash`: editing a figure value after completion changes
+the hash (the same hash-stability machinery above), so a figure cannot be
+altered without breaking the signed record.
+
+Each figure declares:
+
+| Field | Meaning |
+|-------|---------|
+| `value` | The number as written (e.g. `"1,234"`, `"$4.5M"`, `"12.5"`) |
+| `unit` | Its unit (`"users"`, `"%"`, `"GB"`, ...) |
+| `label` | A human-readable name for the figure |
+| `anchor` | `{kind, ref}` - the lineage record that grounds it |
+
+Anchor kinds available today: `attachment` and `artifact` (both a `sha256:`
+content hash of a signed lineage record). `receipt` (a query-receipt id) is a
+reserved plug point - the resolver registry accepts it so the receipt kind lands
+without reworking this contract.
+
+### The `figures_grounded` completion signal
+
+A closed evaluator (no network) that runs two checks:
+
+1. **Anchors resolve.** Every declared figure's anchor must resolve to a
+   lineage record that verifies - Ed25519 signature (kid-bound), operator HMAC
+   (when a secret is available), and chain anchoring (its parents are present).
+   A tampered or missing target record fails the figure.
+2. **Every material number is declared.** A unit- and locale-aware tokenizer
+   scans the body; every *material* number (quantity, currency amount,
+   percentage, count) must appear in the sidecar. The failure names each
+   unanchored number with its line and column.
+
+The false-positive policy is pinned by an extensible vector suite
+(`tests/unit/tasks/data/figure_tokenizer_vectors.json`):
+
+| Exempt (no anchor demanded) | Material (anchor demanded) |
+|-----------------------------|----------------------------|
+| Section numbers (`§3.2`, `Section 4`, `Figure 2`) | Currency (`$1,234.56`, `€49`, `$4.5M`, `USD 2,000`) |
+| ISO dates (`2026-07-24`, `2026-07-24T09:30`) and bare years | Percentages (`12.5%`, `30 percent`) |
+| Versions (`v3.9.0`, `1.2.3`) | Quantities (`3.2 GB`, `250 ms`) |
+| Allowlisted patterns (policy regexes, e.g. `24/7`) | Counts (`1,234`, `5000`, decimals) and ranges (`10-20%`) |
+| Identifier-glued numbers (`P99`, `IPv4`) | |
+| Bare integers below the materiality floor (default 1000) | |
+
+Tune the policy with `TokenizerPolicy` (`materiality_min`, `units`, `allowlist`).
+
+### Failure semantics: strict by default, `warn` per task
+
+An unanchored figure is a **completion failure**, not a warning - the same
+posture as an unverifiable artifact hash. The signal's `value` sets the
+severity:
+
+| `value` | Behaviour |
+|---------|-----------|
+| `""` / `"strict"` (default) | An ungrounded figure fails completion |
+| `"warn"` | Downgrade: the failure is reported with a `WARN:` prefix but does not block completion (exploratory work) |
+
+`bernstein artifact verify` is the audit tool and is always strict: it renders
+a per-figure provenance line and exits non-zero on any failing figure,
+regardless of the task's severity.
+
+### `artifact verify` output
+
+For a grounded report, `artifact verify <task_id>` adds a figures section:
+
+```
+VERIFIED task=RPT-1
+  content_hash  sha256:…
+  entry_hash    sha256:…
+  figures:
+    OK migrated users (1,234) - traces to artifact sha256:9f2c1a…, recorded at chain position 3
+```
+
+A failing figure renders `UNANCHORED <number> (<category>) at line L, col C`
+and the command exits `2`.
+
 ## Source
 
 - `src/bernstein/core/tasks/artifacts.py` - kinds, canonicalisers, criteria.
-- `src/bernstein/core/lineage/artifact_record.py` - record + verify.
+- `src/bernstein/core/tasks/figures.py` - figure tokenizer, `figures.json`
+  sidecar, report bundle, and the pure `figures_grounded` evaluator.
+- `src/bernstein/core/lineage/figure_grounding.py` - the lineage-wired anchor
+  resolver (attachment / artifact today, receipt plug point) and
+  `verify_report_figures`.
+- `src/bernstein/core/lineage/artifact_record.py` - record + verify (records a
+  report bundle; the figures verdict is part of `verify_artifact`).
 - `src/bernstein/core/lineage/entry.py` - the widened, still-closed
   `ARTEFACT_KINDS`.
 - the `artifact` group in `src/bernstein/cli/commands/artifact_cmd.py`.
 
 ## Scope
 
-This is the typed contract layer. Wiring the artifact path into the adapter
-`output_mode` axis, skipping worktree allocation for artifact-mode tasks, and
-the `commit_completion` branch are a separate follow-up; a coding task stays on
-the git-diff path and is unchanged.
+This is the typed contract layer plus figure grounding for report artifacts.
+Wiring the artifact path into the adapter `output_mode` axis, skipping worktree
+allocation for artifact-mode tasks, and the `commit_completion` branch are a
+separate follow-up; a coding task stays on the git-diff path and is unchanged.

--- a/src/bernstein/cli/commands/artifact_cmd.py
+++ b/src/bernstein/cli/commands/artifact_cmd.py
@@ -76,28 +76,57 @@ def artifact_verify_cmd(task_id: str, workdir: Path, operator_secret_env: str, o
     )
 
     if output_json:
-        click.echo(
-            json.dumps(
-                {
-                    "task_id": result.task_id,
-                    "ok": result.ok,
-                    "content_hash": result.content_hash,
-                    "entry_hash": result.entry_hash,
-                    "failures": result.failures,
-                }
-            )
-        )
+        click.echo(json.dumps(_json_verdict(result)))
     elif result.ok:
         console.print(f"[green]VERIFIED[/green] task={task_id}")
         console.print(f"  content_hash  {result.content_hash}")
         console.print(f"  entry_hash    {result.entry_hash}")
+        _render_figures(result)
     else:
         console.print(f"[red]TAMPERED[/red] task={task_id}")
         for failure in result.failures:
             console.print(f"  - {failure}")
+        _render_figures(result)
 
     if not result.ok:
         sys.exit(2)
+
+
+def _json_verdict(result: object) -> dict:
+    """Assemble the JSON verdict, including the per-figure provenance section."""
+    payload = {
+        "task_id": result.task_id,  # type: ignore[attr-defined]
+        "ok": result.ok,  # type: ignore[attr-defined]
+        "content_hash": result.content_hash,  # type: ignore[attr-defined]
+        "entry_hash": result.entry_hash,  # type: ignore[attr-defined]
+        "failures": result.failures,  # type: ignore[attr-defined]
+    }
+    figures = getattr(result, "figures", None)
+    if figures is not None:
+        payload["figures"] = {
+            "ok": figures.ok,
+            "provenances": [
+                {"label": p.label, "value": p.value, "ok": p.ok, "statement": p.statement} for p in figures.provenances
+            ],
+            "unanchored": [
+                {"surface": u.surface, "category": u.category, "line": u.line, "col": u.col} for u in figures.unanchored
+            ],
+        }
+    return payload
+
+
+def _render_figures(result: object) -> None:
+    """Render the per-figure provenance statement below the verdict (issue #2888)."""
+    figures = getattr(result, "figures", None)
+    if figures is None or not figures.has_figures:
+        return
+    console.print("  figures:")
+    for p in figures.provenances:
+        marker = "[green]OK[/green]" if p.ok else "[red]FAIL[/red]"
+        label = p.label or p.value
+        console.print(f"    {marker} {label} ({p.value}) - {p.statement}")
+    for u in figures.unanchored:
+        console.print(f"    [red]UNANCHORED[/red] {u.surface} ({u.category}) at line {u.line}, col {u.col}")
 
 
 def _resolve_operator_secret(env_var: str) -> bytes | None:

--- a/src/bernstein/core/lineage/artifact_record.py
+++ b/src/bernstein/core/lineage/artifact_record.py
@@ -39,12 +39,18 @@ from bernstein.core.tasks.artifacts import (
     canonicalise_artifact,
     content_hash,
 )
+from bernstein.core.tasks.figures import (
+    ReportBundle,
+    canonicalise_report_bundle,
+    is_report_bundle,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     from bernstein.core.lineage.identity import AgentCard
     from bernstein.core.lineage.recorder import LineageRecorder
+    from bernstein.core.tasks.figures import FiguresVerdict, TokenizerPolicy
 
 #: Logical, repo-relative POSIX prefix under which artifact entries are anchored
 #: in the lineage log. The physical sink root is supplied separately so tests
@@ -114,13 +120,20 @@ class ArtifactReceipt:
 
 @dataclass(frozen=True)
 class ArtifactVerifyResult:
-    """Outcome of :func:`verify_artifact`. ``ok`` is True iff ``failures`` is empty."""
+    """Outcome of :func:`verify_artifact`. ``ok`` is True iff ``failures`` is empty.
+
+    ``figures`` is populated only when the stored bytes are a report bundle with
+    a ``figures.json`` sidecar (issue #2888): it carries the per-figure
+    provenance statements and any unanchored numbers. A failing figure verdict
+    contributes to ``failures`` and flips ``ok``.
+    """
 
     task_id: str
     ok: bool
     failures: list[str]
     content_hash: str | None
     entry_hash: str | None
+    figures: FiguresVerdict | None = None
 
 
 def record_artifact(
@@ -160,7 +173,15 @@ def record_artifact(
     if k is ArtifactKind.CODE_DIFF:
         raise ValueError("code_diff artifacts use the git-diff path, not the artifact sink")
 
-    canonical = canonicalise_artifact(k, artifact)
+    # A report with a figures sidecar is recorded as a single canonical bundle
+    # (body + figures.json) so the sidecar is inside the artifact content_hash
+    # (issue #2888). Any other artifact routes through its kind's canonicaliser.
+    if isinstance(artifact, ReportBundle):
+        if k is not ArtifactKind.REPORT:
+            raise ValueError(f"a ReportBundle must be recorded as a report kind, not {k.value!r}")
+        canonical = canonicalise_report_bundle(artifact)
+    else:
+        canonical = canonicalise_artifact(k, artifact)
     chash = content_hash(canonical)
     artefact_path = artifact_entry_path(task_id)
 
@@ -209,6 +230,7 @@ def verify_artifact(
     log_path: Path,
     cards_dir: Path,
     operator_secret: bytes | None,
+    policy: TokenizerPolicy | None = None,
 ) -> ArtifactVerifyResult:
     """Verify a recorded artifact end to end.
 
@@ -224,6 +246,10 @@ def verify_artifact(
        line or a removed anchor fails here. When ``operator_secret`` is ``None``
        the HMAC leg is skipped (signature + chain still enforced), matching the
        lineage gate's own optional-secret semantics.
+    4. **Figure grounding** (issue #2888): when the stored bytes are a report
+       bundle with a ``figures.json`` sidecar, every declared figure's anchor
+       must resolve to a verifying lineage record and every material number in
+       the body must be declared. Any failing figure is a verification failure.
 
     Returns an :class:`ArtifactVerifyResult`; ``ok`` is True only when every
     check passes.
@@ -235,6 +261,7 @@ def verify_artifact(
 
     blob_path = sink_root / task_id / _BLOB_NAME
     rederived: str | None = None
+    stored: bytes | None = None
     if not blob_path.exists():
         failures.append("stored artifact bytes are missing")
     else:
@@ -257,7 +284,37 @@ def verify_artifact(
     if not gate_result.ok:
         failures.extend(gate_result.failures)
 
-    return ArtifactVerifyResult(task_id, not failures, failures, rederived, receipt.entry_hash)
+    figures = _figures_verdict(stored, log_path, cards_dir, operator_secret, policy)
+    if figures is not None and not figures.ok:
+        failures.extend(figures.failures)
+
+    return ArtifactVerifyResult(task_id, not failures, failures, rederived, receipt.entry_hash, figures)
+
+
+def _figures_verdict(
+    stored: bytes | None,
+    log_path: Path,
+    cards_dir: Path,
+    operator_secret: bytes | None,
+    policy: TokenizerPolicy | None,
+) -> FiguresVerdict | None:
+    """Run figure grounding when ``stored`` is a report bundle; else ``None``.
+
+    ``artifact verify`` is the audit tool, so grounding here is unconditional
+    (strict): the per-task ``warn`` downgrade is a *completion* concept, not a
+    verification one - a verifier always reports a failing figure.
+    """
+    if stored is None or not is_report_bundle(stored):
+        return None
+    from bernstein.core.lineage.figure_grounding import verify_report_figures
+
+    return verify_report_figures(
+        canonical_bytes=stored,
+        log_path=log_path,
+        cards_dir=cards_dir,
+        operator_secret=operator_secret,
+        policy=policy,
+    )
 
 
 def _read_log(log_path: Path) -> Any:

--- a/src/bernstein/core/lineage/figure_grounding.py
+++ b/src/bernstein/core/lineage/figure_grounding.py
@@ -1,0 +1,171 @@
+"""Resolve report-figure anchors against the signed lineage log (issue #2888).
+
+The pure ``figures_grounded`` evaluator in :mod:`bernstein.core.tasks.figures`
+takes an *injected* anchor resolver so the tokenizer and sidecar can be tested
+without any lineage state. This module supplies the real resolver: it reads the
+signed, HMAC-chained lineage log and, for each anchor, finds the lineage record
+whose ``content_hash`` (attachment / artifact) matches the anchor's ref and
+verifies that record end to end - Ed25519 signature (kid-bound), operator HMAC
+(when a secret is available), and chain anchoring (its parents are present).
+
+A figure is only as good as its receipt: a tampered or missing target record
+makes the anchor fail, so a fabricated figure whose anchor points at nothing -
+or at an altered record - can never pass.
+
+The resolver dispatches by anchor kind through a small registry. The
+``receipt`` kind (issue #2887, the query-receipt subsystem) is a declared plug
+point: registering its resolver is a one-line addition once receipts exist, and
+nothing else here changes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from bernstein.core.lineage.entry import canonicalise, compute_operator_hmac, entry_hash
+from bernstein.core.lineage.gate import _load_cards
+from bernstein.core.lineage.identity import jws_header_kid, verify_detached
+from bernstein.core.tasks.figures import (
+    AnchorResolution,
+    FigureAnchor,
+    FiguresVerdict,
+    TokenizerPolicy,
+    evaluate_figures_grounded_bytes,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from bernstein.core.lineage.entry import LineageEntry
+    from bernstein.core.lineage.identity import AgentCard
+
+
+def _short(content_hash: str) -> str:
+    stem = content_hash.split(":", 1)[1] if ":" in content_hash else content_hash
+    return "sha256:" + stem[:12]
+
+
+@dataclass
+class LineageAnchorResolver:
+    """Resolve figure anchors against a signed lineage log on disk.
+
+    The log is read once at construction; each anchor resolution is then a
+    dictionary lookup by ``content_hash`` plus a per-record cryptographic
+    verification, so a report with many figures pays one log read.
+    """
+
+    log_path: Path
+    cards_dir: Path
+    operator_secret: bytes | None = None
+
+    _by_hash: dict[str, list[tuple[LineageEntry, str, int]]] = field(init=False, default_factory=dict)
+    _hashes: set[str] = field(init=False, default_factory=set)
+    _cards: dict[tuple[str, str], AgentCard] = field(init=False, default_factory=dict)
+    _resolvers: dict[str, Callable[[str], AnchorResolution]] = field(init=False, default_factory=dict)
+
+    def __post_init__(self) -> None:
+        from bernstein.core.lineage.store import LineageStore
+
+        store = LineageStore(self.log_path.parent)
+        for idx, (entry, jws) in enumerate(store.read_log(), start=1):
+            self._by_hash.setdefault(entry.content_hash, []).append((entry, jws, idx))
+            self._hashes.add(entry_hash(entry))
+        self._cards, _ = _load_cards(self.cards_dir)
+        # Anchor-kind registry. attachment and artifact both address a lineage
+        # record by content hash; receipt is the reserved plug point (#2887).
+        self._resolvers = {
+            "attachment": lambda ref: self._resolve_by_content_hash("attachment", ref),
+            "artifact": lambda ref: self._resolve_by_content_hash("artifact", ref),
+            "receipt": self._resolve_receipt,
+        }
+
+    def register(self, kind: str, resolver: Callable[[str], AnchorResolution]) -> None:
+        """Register (or override) a resolver for an anchor kind.
+
+        The receipt-id resolver (issue #2887) plugs in here without touching the
+        evaluator or the verify path.
+        """
+        self._resolvers[kind] = resolver
+
+    def resolve(self, anchor: FigureAnchor) -> AnchorResolution:
+        resolver = self._resolvers.get(anchor.kind)
+        if resolver is None:
+            return AnchorResolution(ok=False, statement=f"no resolver for anchor kind {anchor.kind!r}")
+        return resolver(anchor.ref)
+
+    # -- per-kind resolvers --------------------------------------------------
+
+    def _resolve_by_content_hash(self, kind: str, ref: str) -> AnchorResolution:
+        candidates = self._by_hash.get(ref)
+        if not candidates:
+            return AnchorResolution(ok=False, statement=f"anchor {ref} resolves to no lineage record")
+        # A content hash can appear on more than one record; the anchor is
+        # grounded if any matching record verifies.
+        reasons: list[str] = []
+        for entry, jws, idx in candidates:
+            ok, reason = self._verify_record(entry, jws)
+            if ok:
+                return AnchorResolution(
+                    ok=True,
+                    statement=f"traces to {kind} {_short(ref)}, recorded at chain position {idx}",
+                )
+            reasons.append(reason)
+        return AnchorResolution(ok=False, statement=f"anchor {ref} record does not verify: {reasons[0]}")
+
+    def _resolve_receipt(self, ref: str) -> AnchorResolution:
+        # Plug point for the query-receipt subsystem (issue #2887). Until it
+        # lands, a receipt anchor cannot be resolved; fail closed with a clear
+        # reason rather than silently accepting an ungrounded figure.
+        return AnchorResolution(
+            ok=False,
+            statement=f"receipt anchor {ref!r} requires the query-receipt subsystem (issue #2887), not available",
+        )
+
+    # -- record verification -------------------------------------------------
+
+    def _verify_record(self, entry: LineageEntry, jws: str) -> tuple[bool, str]:
+        """Verify one record's signature, HMAC, and chain anchoring."""
+        eh = entry_hash(entry)
+        card = self._cards.get((entry.agent_id, entry.agent_card_kid))
+        if card is None:
+            return False, f"no agent card for (agent_id={entry.agent_id!r}, kid={entry.agent_card_kid!r})"
+        if not jws:
+            return False, f"missing signature sidecar for entry {eh}"
+        if jws_header_kid(jws) != entry.agent_card_kid:
+            return False, f"kid binding mismatch on entry {eh}"
+        if not verify_detached(canonicalise(entry), jws, card):
+            return False, f"invalid signature on entry {eh}"
+        if self.operator_secret is not None:
+            import hmac as _hmac
+
+            expected = compute_operator_hmac(entry, self.operator_secret)
+            if not _hmac.compare_digest(expected, entry.operator_hmac):
+                return False, f"HMAC mismatch on entry {eh}"
+        for ph in entry.parent_hashes:
+            if ph not in self._hashes:
+                return False, f"dangling parent_hash {ph} on entry {eh}"
+        return True, ""
+
+
+def verify_report_figures(
+    *,
+    canonical_bytes: bytes,
+    log_path: Path,
+    cards_dir: Path,
+    operator_secret: bytes | None,
+    policy: TokenizerPolicy | None = None,
+) -> FiguresVerdict:
+    """Run ``figures_grounded`` on report-bundle bytes against the lineage log.
+
+    ``canonical_bytes`` are the stored canonical artifact bytes (a report
+    bundle). Raises :class:`bernstein.core.tasks.artifacts.CanonicalisationError`
+    when the bytes are not a report bundle - callers that may see a plain report
+    should guard with :func:`bernstein.core.tasks.figures.is_report_bundle`.
+    """
+    resolver = LineageAnchorResolver(log_path=log_path, cards_dir=cards_dir, operator_secret=operator_secret)
+    return evaluate_figures_grounded_bytes(canonical_bytes, resolve_anchor=resolver.resolve, policy=policy)
+
+
+__all__ = ["LineageAnchorResolver", "verify_report_figures"]

--- a/src/bernstein/core/quality/janitor.py
+++ b/src/bernstein/core/quality/janitor.py
@@ -94,14 +94,25 @@ _ATTRIBUTION_MAX_COMMITS = 50
 # canonical bytes against a declared contract, so a passing one is strong
 # evidence real work happened - on par with a passing test.
 _NONTRIVIAL_SIGNAL_TYPES = frozenset(
-    {"test_passes", "file_contains", "llm_review", "llm_judge", "schema_valid", "criteria_match", "hash_stable"}
+    {
+        "test_passes",
+        "file_contains",
+        "llm_review",
+        "llm_judge",
+        "schema_valid",
+        "criteria_match",
+        "hash_stable",
+        # A grounded report proves the figures trace to signed sources - strong
+        # evidence of real work, on par with a passing test (issue #2888).
+        "figures_grounded",
+    }
 )
 
 # Completion-signal types that operate on an artifact's canonical bytes rather
-# than the filesystem (issue #2608). The filesystem-oriented
+# than the filesystem (issue #2608, #2888). The filesystem-oriented
 # :func:`evaluate_signal` defers these to :func:`evaluate_artifact_signals`,
 # which has the produced artifact in scope.
-_ARTIFACT_SIGNAL_TYPES = frozenset({"schema_valid", "criteria_match", "hash_stable"})
+_ARTIFACT_SIGNAL_TYPES = frozenset({"schema_valid", "criteria_match", "hash_stable", "figures_grounded"})
 
 
 def _has_nontrivial_passing_signal(task: Task, signal_results: list[tuple[str, bool, str]]) -> bool:
@@ -266,24 +277,37 @@ def evaluate_signal(signal: CompletionSignal, workdir: Path) -> tuple[bool, str]
         case "llm_judge":
             # llm_judge requires async evaluation - use judge_task() instead.
             return False, "llm_judge requires async evaluation via judge_task()"
-        case "schema_valid" | "criteria_match" | "hash_stable":
+        case "schema_valid" | "criteria_match" | "hash_stable" | "figures_grounded":
             # Artifact-mode criteria operate on the produced artifact's canonical
-            # bytes, not the filesystem. They are dispatched by
-            # evaluate_artifact_signals() once the artifact is in scope; the
-            # filesystem path recognises them (so they are never "unknown") but
-            # cannot evaluate them here.
+            # bytes (and, for figures_grounded, on lineage reads), not the
+            # filesystem. They are dispatched by evaluate_artifact_signals() once
+            # the artifact is in scope; the filesystem path recognises them (so
+            # they are never "unknown") but cannot evaluate them here.
             return False, f"{signal.type} requires artifact-mode evaluation via evaluate_artifact_signals()"
     return False, f"unknown signal type: {signal.type}"
 
 
-def evaluate_artifact_signals(task: Task, artifact: object) -> list[tuple[str, bool, str]]:
+def evaluate_artifact_signals(
+    task: Task,
+    artifact: object,
+    *,
+    lineage_root: Path | None = None,
+    operator_secret: bytes | None = None,
+) -> list[tuple[str, bool, str]]:
     """Evaluate a task's artifact-mode completion signals against ``artifact``.
 
-    ``artifact`` is the raw produced artifact (str / bytes / list / mapping);
+    ``artifact`` is the raw produced artifact (str / bytes / list / mapping, or
+    a :class:`~bernstein.core.tasks.figures.ReportBundle` for a figures report);
     it is canonicalised under the task's declared
     :attr:`~bernstein.core.tasks.models.Task.artifact_spec` kind and each
     ``schema_valid`` / ``criteria_match`` / ``hash_stable`` signal is evaluated
     by its closed evaluator in :mod:`bernstein.core.tasks.artifacts`.
+
+    ``figures_grounded`` (issue #2888) additionally resolves each declared
+    figure's anchor against the signed lineage log rooted at ``lineage_root``
+    (the project root containing ``.sdd/``). A ``warn``-severity signal
+    downgrades a grounding failure to a passing result whose detail is prefixed
+    ``WARN:`` so completion is not blocked; the default severity is ``strict``.
 
     Returns a list of ``(description, passed, detail)`` tuples in the same shape
     as :func:`_collect_signal_results`. Filesystem-oriented signals on the task
@@ -297,9 +321,90 @@ def evaluate_artifact_signals(task: Task, artifact: object) -> list[tuple[str, b
         if signal.type not in _ARTIFACT_SIGNAL_TYPES:
             continue
         desc = f"{signal.type}: {signal.value}"
-        passed, detail = evaluate_criterion(signal.type, signal.value, artifact=artifact, kind=kind)
+        if signal.type == "figures_grounded":
+            passed, detail = _evaluate_figures_grounded_signal(
+                artifact, signal.value, lineage_root=lineage_root, operator_secret=operator_secret
+            )
+        else:
+            passed, detail = evaluate_criterion(signal.type, signal.value, artifact=artifact, kind=kind)
         results.append((desc, passed, detail))
     return results
+
+
+def _parse_figures_severity(value: str) -> str:
+    """Return ``"strict"`` or ``"warn"`` for a ``figures_grounded`` signal value.
+
+    An empty value and any unrecognised value fall closed to ``strict`` - the
+    default posture is that an unanchored figure fails completion. Only an
+    explicit ``warn`` (bare or as ``{"severity": "warn"}``) downgrades.
+    """
+    text = (value or "").strip()
+    if not text:
+        return "strict"
+    lowered = text.lower()
+    if lowered in ("strict", "warn"):
+        return lowered
+    if text.startswith("{"):
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError:
+            return "strict"
+        sev = str(payload.get("severity", "strict")).lower()
+        return "warn" if sev == "warn" else "strict"
+    return "strict"
+
+
+def _apply_figures_severity(severity: str, passed: bool, detail: str) -> tuple[bool, str]:
+    """Downgrade a grounding failure to a passing ``WARN:`` when severity is warn."""
+    if not passed and severity == "warn":
+        return True, f"WARN: {detail}"
+    return passed, detail
+
+
+def _evaluate_figures_grounded_signal(
+    artifact: object,
+    value: str,
+    *,
+    lineage_root: Path | None,
+    operator_secret: bytes | None,
+) -> tuple[bool, str]:
+    """Evaluate ``figures_grounded`` on a report bundle against the lineage log."""
+    from bernstein.core.tasks.figures import (
+        CanonicalisationError,
+        ReportBundle,
+        evaluate_figures_grounded,
+        parse_report_bundle,
+    )
+
+    severity = _parse_figures_severity(value)
+
+    if isinstance(artifact, ReportBundle):
+        bundle = artifact
+    elif isinstance(artifact, (bytes, bytearray)):
+        try:
+            bundle = parse_report_bundle(bytes(artifact))
+        except CanonicalisationError as exc:
+            return _apply_figures_severity(severity, False, f"artifact is not a report bundle: {exc}")
+    else:
+        return _apply_figures_severity(
+            severity, False, "figures_grounded requires a report bundle artifact (body + figures.json)"
+        )
+
+    if lineage_root is None:
+        return _apply_figures_severity(severity, False, "no lineage root available to resolve figure anchors")
+
+    from bernstein.core.lineage.figure_grounding import LineageAnchorResolver
+
+    sdd = Path(lineage_root) / ".sdd"
+    resolver = LineageAnchorResolver(
+        log_path=sdd / "lineage" / "log.jsonl",
+        cards_dir=sdd / "agents",
+        operator_secret=operator_secret,
+    )
+    verdict = evaluate_figures_grounded(bundle, resolve_anchor=resolver.resolve)
+    if verdict.ok:
+        return True, f"{len(verdict.provenances)} figure(s) grounded"
+    return _apply_figures_severity(severity, False, "; ".join(verdict.failures))
 
 
 def verify_task(task: Task, workdir: Path) -> tuple[bool, list[str]]:

--- a/src/bernstein/core/tasks/figures.py
+++ b/src/bernstein/core/tasks/figures.py
@@ -1,0 +1,634 @@
+"""Figure grounding for report artifacts (issue #2888).
+
+A schema-valid report can still be *fabricated*: every number in the prose can
+come from the model's imagination and the completion path will accept it. This
+module closes that gap. A report-kind artifact declares its figures in a
+machine-checkable sidecar (``figures.json``) that lives *inside* the canonical
+artifact bytes, so a figure value is covered by the artifact's own
+``content_hash``. Each figure binds ``{value, unit, label, anchor}`` where the
+anchor is a lineage-record reference. The ``figures_grounded`` evaluator then
+enforces the binding:
+
+* every declared figure's anchor must resolve to a lineage record that verifies
+  (signature + chain anchor); and
+* every *material* numeric token in the report body must appear in the sidecar.
+
+The tokenizer that decides which numbers are material is the false-positive
+surface: section numbers, ISO dates, versions, and allowlisted patterns are
+exempt; quantities, currency amounts, percentages, and counts demand an anchor.
+Its policy is pinned by an extensible vector suite.
+
+This module is deliberately free of any lineage/store import: anchor resolution
+is *injected* as a callable so the tokenizer, the sidecar, and the pure
+evaluator can be exercised hermetically. The lineage-wired resolver lives in
+:mod:`bernstein.core.lineage.figure_grounding`.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from bernstein.core.tasks.artifacts import (
+    CanonicalisationError,
+    _canonical_json_bytes,
+    _normalise_newlines,
+)
+
+# ---------------------------------------------------------------------------
+# Tokenizer policy
+# ---------------------------------------------------------------------------
+
+#: Measurement units that mark a preceding number as a *quantity* (material).
+#: Deliberately excludes ambiguous counted nouns ("users", "steps", "requests")
+#: - those stay counts governed by the materiality threshold so "3 steps" does
+#: not spuriously demand an anchor.
+_DEFAULT_UNITS: frozenset[str] = frozenset(
+    {
+        # bytes
+        "B",
+        "KB",
+        "MB",
+        "GB",
+        "TB",
+        "PB",
+        "KiB",
+        "MiB",
+        "GiB",
+        "TiB",
+        # time
+        "ns",
+        "us",
+        "µs",
+        "ms",
+        "s",
+        "sec",
+        "secs",
+        "min",
+        "mins",
+        "h",
+        "hr",
+        "hrs",
+        "d",
+        # frequency / rate
+        "Hz",
+        "kHz",
+        "MHz",
+        "GHz",
+        "rps",
+        "qps",
+        "bps",
+        "kbps",
+        "Mbps",
+        "Gbps",
+        # mass / length
+        "mg",
+        "g",
+        "kg",
+        "t",
+        "mm",
+        "cm",
+        "m",
+        "km",
+        # misc
+        "px",
+        "dpi",
+        "fps",
+        "W",
+        "kW",
+        "kWh",
+        "V",
+        "A",
+    }
+)
+
+#: Structural markers that make a following number a section/figure reference.
+_SECTION_MARKERS = ("Section", "Sec", "Chapter", "Ch", "Appendix", "Figure", "Fig", "Table", "Step", "Item", "Note")
+
+#: Default materiality floor for *bare* integers (no grouping, decimal, unit,
+#: currency, or percent): a bare integer strictly below this is treated as an
+#: incidental count and stays exempt. Grouped, decimal, unit, currency, and
+#: percentage numbers are always material regardless of this floor.
+_DEFAULT_MATERIALITY_MIN = 1000
+
+
+@dataclass(frozen=True)
+class TokenizerPolicy:
+    """Extensible policy pinning the figure tokenizer's false-positive rules."""
+
+    materiality_min: int = _DEFAULT_MATERIALITY_MIN
+    units: frozenset[str] = _DEFAULT_UNITS
+    allowlist: tuple[str, ...] = ()
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TokenizerPolicy:
+        units = data.get("units")
+        return cls(
+            materiality_min=int(data.get("materiality_min", _DEFAULT_MATERIALITY_MIN)),
+            units=frozenset(units) if units else _DEFAULT_UNITS,
+            allowlist=tuple(data.get("allowlist", ())),
+        )
+
+
+DEFAULT_POLICY = TokenizerPolicy()
+
+
+# ---------------------------------------------------------------------------
+# Numeric token
+# ---------------------------------------------------------------------------
+
+#: Material categories demand a grounding anchor.
+MATERIAL_CATEGORIES: frozenset[str] = frozenset({"currency", "percentage", "quantity", "count", "range"})
+#: Exempt categories never demand an anchor.
+EXEMPT_CATEGORIES: frozenset[str] = frozenset({"date", "version", "section", "allowlisted", "below_threshold"})
+
+
+@dataclass(frozen=True)
+class NumericToken:
+    """One numeric token found in a report body, classified by the policy."""
+
+    surface: str
+    numeric_key: str
+    category: str
+    material: bool
+    start: int
+    end: int
+    line: int
+    col: int
+    numeric_keys: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.numeric_keys:
+            object.__setattr__(self, "numeric_keys", (self.numeric_key,))
+
+
+# ---------------------------------------------------------------------------
+# Numeric key normalisation
+# ---------------------------------------------------------------------------
+
+_NUM_CORE = r"\d{1,3}(?:,\d{3})+(?:\.\d+)?|\d+(?:\.\d+)?"
+_NUM_CORE_RE = re.compile(_NUM_CORE)
+_MULTIPLIERS = "KMBT"
+
+
+def numeric_key_of(value: str) -> str:
+    """Return a canonical numeric key for ``value`` for cross-form matching.
+
+    Strips grouping separators and a leading currency/label, folds trailing
+    zeros on a single-decimal number, and appends a normalised magnitude
+    suffix (K/M/B/T) when present, so ``"$1,234.00"``, ``"1234"`` and a figure
+    declared as ``"1,234"`` all reduce to the same key, and ``"$4.5M"`` reduces
+    to ``"4.5M"``.
+    """
+    m = _NUM_CORE_RE.search(value)
+    if not m:
+        return value.strip()
+    core = m.group(0).replace(",", "")
+    if core.count(".") == 1:
+        core = core.rstrip("0").rstrip(".")
+    suffix = ""
+    tail = value[m.end() : m.end() + 1]
+    if tail.upper() in _MULTIPLIERS:
+        after = value[m.end() + 1 : m.end() + 2]
+        if not after.isalnum():
+            suffix = tail.upper()
+    return core + suffix
+
+
+# ---------------------------------------------------------------------------
+# Exempt-span and material-span detection
+# ---------------------------------------------------------------------------
+
+_DATE_RE = re.compile(r"\b\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}(?::\d{2})?)?\b")
+_VERSION_RE = re.compile(r"\bv\d+(?:\.\d+)+\b|\b\d+\.\d+\.\d+\b")
+_SECTION_RE = re.compile(
+    r"(?:§\s*|\b(?:" + "|".join(_SECTION_MARKERS) + r")\.?\s+)\d+(?:\.\d+)*",
+)
+
+
+def _line_col(text: str, pos: int) -> tuple[int, int]:
+    prefix = text[:pos]
+    line = prefix.count("\n") + 1
+    col = pos - (prefix.rfind("\n") + 1) + 1
+    return line, col
+
+
+def _overlaps(start: int, end: int, occupied: list[tuple[int, int]]) -> bool:
+    return any(start < oe and os < end for os, oe in occupied)
+
+
+def _units_alt(policy: TokenizerPolicy) -> str:
+    # Longest-first so "Mbps" wins over "m"; escape for safety.
+    return "|".join(re.escape(u) for u in sorted(policy.units, key=len, reverse=True))
+
+
+def _range_re(policy: TokenizerPolicy) -> re.Pattern[str]:
+    suffix = rf"%|\s?percent\b|\s(?:{_units_alt(policy)})\b"
+    # The character class intentionally admits ASCII hyphen, en dash, and em
+    # dash as range connectors (e.g. "10-20%" written with any of the three).
+    return re.compile(rf"(?P<lo>{_NUM_CORE})\s*[-–—]\s*(?P<hi>{_NUM_CORE})(?:{suffix})")  # noqa: RUF001
+
+
+def _classify_number(
+    text: str,
+    m: re.Match[str],
+    policy: TokenizerPolicy,
+) -> NumericToken:
+    """Classify a bare number match into a material/exempt category."""
+    num_start, num_end = m.start(), m.end()
+    core = m.group(0)
+
+    # Currency prefix: adjacent symbol, or an ISO code within a short window.
+    cur_start = num_start
+    prefix = text[max(0, num_start - 5) : num_start]
+    has_currency = False
+    if num_start > 0 and text[num_start - 1] in "$€£¥":
+        has_currency = True
+        cur_start = num_start - 1
+    else:
+        code = re.search(r"(USD|EUR|GBP|JPY|CHF|CAD|AUD)\s?$", prefix)
+        if code:
+            has_currency = True
+            cur_start = num_start - (len(prefix) - code.start())
+
+    # Magnitude suffix (K/M/B/T) directly after the number.
+    end = num_end
+    tail = text[num_end : num_end + 1]
+    if tail.upper() in _MULTIPLIERS and not text[num_end + 1 : num_end + 2].isalnum():
+        end = num_end + 1
+
+    # Percent.
+    has_percent = False
+    pm = re.match(r"%|\s?percent\b", text[end:])
+    if pm:
+        has_percent = True
+        end = end + pm.end()
+
+    # Unit word.
+    unit_hit = False
+    if not has_percent:
+        um = re.match(rf"\s(?P<u>{_units_alt(policy)})\b", text[end:])
+        if um:
+            unit_hit = True
+            end = end + um.end()
+
+    surface = text[cur_start:end]
+    numeric_key = numeric_key_of(text[num_start:end])
+    line, col = _line_col(text, cur_start)
+
+    if has_currency:
+        category = "currency"
+    elif has_percent:
+        category = "percentage"
+    elif unit_hit:
+        category = "quantity"
+    else:
+        category = _classify_bare(core, policy)
+
+    material = category in MATERIAL_CATEGORIES
+    return NumericToken(surface, numeric_key, category, material, cur_start, end, line, col)
+
+
+def _classify_bare(core: str, policy: TokenizerPolicy) -> str:
+    """Classify a bare number (no currency/percent/unit) as count or exempt."""
+    if "," in core or "." in core:
+        # Grouped or decimal: a measured count, always material.
+        return "count"
+    try:
+        magnitude = int(core)
+    except ValueError:  # pragma: no cover - core is always digits here
+        return "below_threshold"
+    # A bare four-digit year reads as a date, not a measured count. Exempting it
+    # keeps "in 2026 we shipped" from spuriously demanding an anchor; a genuine
+    # large count is almost always grouped ("2,026") or out of the year range.
+    if len(core) == 4 and 1900 <= magnitude <= 2999:
+        return "date"
+    return "count" if magnitude >= policy.materiality_min else "below_threshold"
+
+
+def tokenize_numbers(text: str, policy: TokenizerPolicy | None = None) -> list[NumericToken]:
+    """Return the ordered numeric tokens in ``text`` classified by ``policy``.
+
+    Exempt spans (allowlist, ISO date, version, section reference) are detected
+    first and their character ranges suppress overlapping bare-number matches,
+    so ``§3.2`` yields one exempt section token, not two decimals. Material
+    ranges (``10-20%``) are detected before bare numbers so both endpoints
+    collapse into a single range token.
+    """
+    policy = policy or DEFAULT_POLICY
+    tokens: list[NumericToken] = []
+    occupied: list[tuple[int, int]] = []
+
+    def _emit_span(start: int, end: int, category: str) -> None:
+        line, col = _line_col(text, start)
+        surface = text[start:end]
+        tokens.append(NumericToken(surface, numeric_key_of(surface), category, False, start, end, line, col))
+        occupied.append((start, end))
+
+    # 1. Exempt spans, in precedence order.
+    for pattern in policy.allowlist:
+        for m in re.finditer(pattern, text):
+            if not _overlaps(m.start(), m.end(), occupied):
+                _emit_span(m.start(), m.end(), "allowlisted")
+    for m in _DATE_RE.finditer(text):
+        if not _overlaps(m.start(), m.end(), occupied):
+            _emit_span(m.start(), m.end(), "date")
+    for m in _VERSION_RE.finditer(text):
+        if not _overlaps(m.start(), m.end(), occupied):
+            _emit_span(m.start(), m.end(), "version")
+    for m in _SECTION_RE.finditer(text):
+        if not _overlaps(m.start(), m.end(), occupied):
+            _emit_span(m.start(), m.end(), "section")
+
+    # 2. Material ranges (before bare numbers so endpoints do not split).
+    for m in _range_re(policy).finditer(text):
+        if _overlaps(m.start(), m.end(), occupied):
+            continue
+        line, col = _line_col(text, m.start())
+        lo = numeric_key_of(m.group("lo"))
+        hi = numeric_key_of(m.group("hi"))
+        surface = text[m.start() : m.end()]
+        tokens.append(NumericToken(surface, lo, "range", True, m.start(), m.end(), line, col, numeric_keys=(lo, hi)))
+        occupied.append((m.start(), m.end()))
+
+    # 3. Bare numbers.
+    for m in _NUM_CORE_RE.finditer(text):
+        if _overlaps(m.start(), m.end(), occupied):
+            continue
+        # A number glued to a preceding letter is part of an identifier
+        # ("P99", "IPv4", "H2"), not a standalone figure - skip it entirely.
+        if m.start() > 0 and text[m.start() - 1].isalpha():
+            continue
+        tok = _classify_number(text, m, policy)
+        tokens.append(tok)
+        occupied.append((tok.start, tok.end))
+
+    tokens.sort(key=lambda t: t.start)
+    return tokens
+
+
+# ---------------------------------------------------------------------------
+# Figure sidecar + report bundle
+# ---------------------------------------------------------------------------
+
+#: Anchor kinds available today. ``receipt`` is reserved for the query-receipt
+#: work (issue #2887): the resolver registry accepts it as a plug point so a
+#: receipt-id anchor kind lands without reworking this contract.
+ANCHOR_KINDS: frozenset[str] = frozenset({"attachment", "artifact", "receipt"})
+#: Anchor kinds whose ``ref`` is a ``sha256:`` content hash.
+_HASH_ANCHOR_KINDS: frozenset[str] = frozenset({"attachment", "artifact"})
+
+
+@dataclass(frozen=True)
+class FigureAnchor:
+    """A reference from a figure to the lineage record that grounds it."""
+
+    kind: str
+    ref: str
+
+    def __post_init__(self) -> None:
+        if self.kind not in ANCHOR_KINDS:
+            raise ValueError(f"unknown figure anchor kind: {self.kind!r}")
+        if not self.ref:
+            raise ValueError("figure anchor ref must be non-empty")
+        if self.kind in _HASH_ANCHOR_KINDS and not self.ref.startswith("sha256:"):
+            raise ValueError(f"{self.kind} anchor ref must be a 'sha256:' content hash, got {self.ref!r}")
+
+    def to_dict(self) -> dict[str, str]:
+        return {"kind": self.kind, "ref": self.ref}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> FigureAnchor:
+        return cls(kind=str(data["kind"]), ref=str(data["ref"]))
+
+
+@dataclass(frozen=True)
+class Figure:
+    """One declared figure: a material number and its grounding anchor."""
+
+    value: str
+    unit: str
+    label: str
+    anchor: FigureAnchor
+
+    @property
+    def numeric_key(self) -> str:
+        return numeric_key_of(self.value)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"value": self.value, "unit": self.unit, "label": self.label, "anchor": self.anchor.to_dict()}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Figure:
+        return cls(
+            value=str(data["value"]),
+            unit=str(data.get("unit", "")),
+            label=str(data.get("label", "")),
+            anchor=FigureAnchor.from_dict(data["anchor"]),
+        )
+
+
+@dataclass(frozen=True)
+class ReportBundle:
+    """A report body plus its ``figures.json`` sidecar, hashed as one unit.
+
+    The canonical bytes are a single JCS object ``{"body": ..., "figures":
+    [...]}`` so the sidecar is *inside* the artifact's ``content_hash``: editing
+    a figure value after completion changes the hash.
+    """
+
+    body: str
+    figures: tuple[Figure, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.figures, tuple):
+            object.__setattr__(self, "figures", tuple(self.figures))
+
+    def to_canonical_obj(self) -> dict[str, Any]:
+        normalised = _normalise_newlines(self.body)
+        if not unicodedata.is_normalized("NFC", normalised):
+            raise CanonicalisationError("report body is not NFC-normalised (reject-don't-repair policy)")
+        return {"body": normalised, "figures": [f.to_dict() for f in self.figures]}
+
+    @classmethod
+    def from_canonical_obj(cls, obj: dict[str, Any]) -> ReportBundle:
+        figures = tuple(Figure.from_dict(f) for f in obj.get("figures", []))
+        return cls(body=str(obj.get("body", "")), figures=figures)
+
+
+def canonicalise_report_bundle(bundle: ReportBundle) -> bytes:
+    """Return the canonical bytes for a report bundle (body + sidecar).
+
+    Raises :class:`CanonicalisationError` when the body is not NFC-normalised.
+    """
+    return _canonical_json_bytes(bundle.to_canonical_obj())
+
+
+def parse_report_bundle(canonical_bytes: bytes) -> ReportBundle:
+    """Parse canonical report-bundle bytes back into a :class:`ReportBundle`.
+
+    Raises :class:`CanonicalisationError` when the bytes are not a report
+    bundle (a plain report kind, a dataset, etc. - callers that may see either
+    should catch this to skip figure grounding).
+    """
+    import json
+
+    try:
+        obj = json.loads(canonical_bytes)
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise CanonicalisationError(f"not a report bundle: {exc}") from exc
+    if not isinstance(obj, dict) or "body" not in obj or "figures" not in obj:
+        raise CanonicalisationError("not a report bundle: missing body/figures keys")
+    return ReportBundle.from_canonical_obj(obj)
+
+
+def is_report_bundle(canonical_bytes: bytes) -> bool:
+    """Return True iff ``canonical_bytes`` parse as a figures report bundle."""
+    try:
+        parse_report_bundle(canonical_bytes)
+    except CanonicalisationError:
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# figures_grounded evaluator (pure; anchor resolution injected)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AnchorResolution:
+    """Result of resolving one figure anchor against the lineage log."""
+
+    ok: bool
+    statement: str
+
+
+@dataclass(frozen=True)
+class FigureProvenance:
+    """Per-figure provenance line for the operator-facing verdict."""
+
+    label: str
+    value: str
+    anchor: FigureAnchor
+    ok: bool
+    statement: str
+
+
+@dataclass(frozen=True)
+class UnanchoredNumber:
+    """A material number in the body with no matching sidecar figure."""
+
+    surface: str
+    numeric_key: str
+    category: str
+    line: int
+    col: int
+
+
+@dataclass(frozen=True)
+class FiguresVerdict:
+    """Outcome of ``figures_grounded``. ``ok`` iff no figure or number fails."""
+
+    ok: bool
+    has_figures: bool
+    provenances: tuple[FigureProvenance, ...]
+    unanchored: tuple[UnanchoredNumber, ...]
+    failures: tuple[str, ...]
+
+
+#: An injected anchor resolver: given an anchor, return whether it resolves to a
+#: verifying lineage record and a human-readable provenance statement.
+AnchorResolver = Callable[[FigureAnchor], AnchorResolution]
+
+
+def evaluate_figures_grounded(
+    bundle: ReportBundle,
+    *,
+    resolve_anchor: AnchorResolver,
+    policy: TokenizerPolicy | None = None,
+) -> FiguresVerdict:
+    """Evaluate the ``figures_grounded`` contract on a parsed report bundle.
+
+    Two closed checks, no network:
+
+    1. Every declared figure's anchor must resolve to a verifying lineage
+       record (``resolve_anchor`` is the injected, lineage-wired resolver).
+    2. Every *material* numeric token in the body must appear in the sidecar.
+
+    The failure list names each failing figure and each unanchored number with
+    its location, so the exact gap is fixable.
+    """
+    policy = policy or DEFAULT_POLICY
+    failures: list[str] = []
+
+    provenances: list[FigureProvenance] = []
+    for fig in bundle.figures:
+        res = resolve_anchor(fig.anchor)
+        provenances.append(FigureProvenance(fig.label, fig.value, fig.anchor, res.ok, res.statement))
+        if not res.ok:
+            label = fig.label or fig.value
+            failures.append(f"figure {label!r} (value {fig.value}) is not grounded: {res.statement}")
+
+    declared: set[str] = set()
+    for fig in bundle.figures:
+        declared.add(fig.numeric_key)
+
+    unanchored: list[UnanchoredNumber] = []
+    for tok in tokenize_numbers(bundle.body, policy):
+        if not tok.material:
+            continue
+        if any(k in declared for k in tok.numeric_keys):
+            continue
+        unanchored.append(UnanchoredNumber(tok.surface, tok.numeric_key, tok.category, tok.line, tok.col))
+        failures.append(
+            f"unanchored {tok.category} {tok.surface!r} at line {tok.line}, col {tok.col} "
+            f"is not declared in figures.json"
+        )
+
+    return FiguresVerdict(
+        ok=not failures,
+        has_figures=bool(bundle.figures),
+        provenances=tuple(provenances),
+        unanchored=tuple(unanchored),
+        failures=tuple(failures),
+    )
+
+
+def evaluate_figures_grounded_bytes(
+    canonical_bytes: bytes,
+    *,
+    resolve_anchor: AnchorResolver,
+    policy: TokenizerPolicy | None = None,
+) -> FiguresVerdict:
+    """Parse ``canonical_bytes`` as a report bundle and evaluate grounding."""
+    bundle = parse_report_bundle(canonical_bytes)
+    return evaluate_figures_grounded(bundle, resolve_anchor=resolve_anchor, policy=policy)
+
+
+__all__ = [
+    "ANCHOR_KINDS",
+    "DEFAULT_POLICY",
+    "EXEMPT_CATEGORIES",
+    "MATERIAL_CATEGORIES",
+    "AnchorResolution",
+    "AnchorResolver",
+    "Figure",
+    "FigureAnchor",
+    "FigureProvenance",
+    "FiguresVerdict",
+    "NumericToken",
+    "ReportBundle",
+    "TokenizerPolicy",
+    "UnanchoredNumber",
+    "canonicalise_report_bundle",
+    "evaluate_figures_grounded",
+    "evaluate_figures_grounded_bytes",
+    "is_report_bundle",
+    "numeric_key_of",
+    "parse_report_bundle",
+    "tokenize_numbers",
+]

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -262,13 +262,19 @@ class CompletionSignal:
     """Janitor signal for automatic task verification.
 
     The first six types verify against the filesystem or a test command (the
-    coding path). The last three (issue #2608) operate on an artifact's
+    coding path). The next three (issue #2608) operate on an artifact's
     canonical bytes instead: ``schema_valid`` validates the artifact against a
     declared JSON Schema, ``criteria_match`` evaluates a closed predicate set,
     and ``hash_stable`` re-derives the canonical content hash. Their closed
     evaluators live in :mod:`bernstein.core.tasks.artifacts`; the janitor
     dispatches them via :func:`bernstein.core.quality.janitor.evaluate_artifact_signals`
     when the produced artifact is in scope.
+
+    ``figures_grounded`` (issue #2888) is the tenth type: on a report bundle it
+    requires every declared figure's anchor to resolve to a verifying lineage
+    record and every material number in the body to be declared in the sidecar.
+    Its ``value`` is the severity - ``""``/``"strict"`` (an unanchored figure
+    fails completion) or ``"warn"`` (downgrade for exploratory work).
     """
 
     type: Literal[
@@ -281,8 +287,9 @@ class CompletionSignal:
         "schema_valid",
         "criteria_match",
         "hash_stable",
+        "figures_grounded",
     ]
-    value: str  # path, glob pattern, test command, search string, review instruction, or criterion payload
+    value: str  # path, glob pattern, test command, search string, review instruction, criterion payload, or severity
 
 
 @dataclass(frozen=True)

--- a/tests/unit/cli/test_artifact_verify_cmd.py
+++ b/tests/unit/cli/test_artifact_verify_cmd.py
@@ -94,3 +94,87 @@ def test_verify_missing_artifact_exit_two(tmp_path: Path) -> None:
     )
     assert result.exit_code == 2, result.output
     assert "TAMPERED" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Figure grounding (issue #2888): per-figure provenance in the verdict
+# ---------------------------------------------------------------------------
+
+
+def _seed_report(workdir: Path, task_id: str, body: str) -> None:
+    """Record a source dataset + a report bundle anchoring to it, CLI-readable."""
+    from bernstein.core.tasks.figures import Figure, FigureAnchor, ReportBundle
+
+    sdd = workdir / ".sdd"
+    priv_pem, pub_pem = generate_keypair()
+    card = AgentCard(agent_id="agent:worker", kid="key-001", public_key_pem=pub_pem)
+    rec = LineageRecorder(store=LineageStore(sdd / "lineage"), operator_hmac_key=_SECRET.encode("utf-8"))
+    src = record_artifact(
+        recorder=rec,
+        sink_root=sdd / "artifacts",
+        task_id="SRC",
+        kind=ArtifactKind.DATASET,
+        artifact=[{"users": 1234}],
+        agent_id=card.agent_id,
+        agent_card=card,
+        private_key_pem=priv_pem,
+    )
+    figs = (Figure("1,234", "users", "migrated users", FigureAnchor("artifact", src.content_hash)),)
+    record_artifact(
+        recorder=rec,
+        sink_root=sdd / "artifacts",
+        task_id=task_id,
+        kind=ArtifactKind.REPORT,
+        artifact=ReportBundle(body=body, figures=figs),
+        agent_id=card.agent_id,
+        agent_card=card,
+        private_key_pem=priv_pem,
+    )
+    card_dir = sdd / "agents" / card.agent_id
+    card_dir.mkdir(parents=True, exist_ok=True)
+    (card_dir / "card.json").write_text(
+        json.dumps({"agent_id": card.agent_id, "kid": card.kid, "public_key_pem": card.public_key_pem}),
+        encoding="utf-8",
+    )
+
+
+def test_verify_renders_figure_provenance(tmp_path: Path) -> None:
+    _seed_report(tmp_path, "RPT", "We migrated 1,234 users.\n")
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["artifact", "verify", "RPT", "--workdir", str(tmp_path)],
+        env={"BERNSTEIN_OPERATOR_SECRET": _SECRET},
+    )
+    assert result.exit_code == 0, result.output
+    assert "figures:" in result.output
+    assert "migrated users" in result.output
+    assert "traces to artifact sha256:" in result.output
+
+
+def test_verify_exits_nonzero_on_unanchored_figure(tmp_path: Path) -> None:
+    # The body cites 9.9% with no sidecar figure - a failing figure.
+    _seed_report(tmp_path, "RPT2", "We migrated 1,234 users at 9.9% cost.\n")
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["artifact", "verify", "RPT2", "--workdir", str(tmp_path)],
+        env={"BERNSTEIN_OPERATOR_SECRET": _SECRET},
+    )
+    assert result.exit_code == 2, result.output
+    assert "UNANCHORED" in result.output
+    assert "9.9%" in result.output
+
+
+def test_verify_figures_json_section(tmp_path: Path) -> None:
+    _seed_report(tmp_path, "RPT3", "We migrated 1,234 users.\n")
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["artifact", "verify", "RPT3", "--workdir", str(tmp_path), "--output-json"],
+        env={"BERNSTEIN_OPERATOR_SECRET": _SECRET},
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["figures"]["ok"] is True
+    assert payload["figures"]["provenances"][0]["ok"] is True

--- a/tests/unit/lineage/test_figure_grounding.py
+++ b/tests/unit/lineage/test_figure_grounding.py
@@ -1,0 +1,239 @@
+"""Figure anchors resolve against the signed lineage log (issue #2888).
+
+A figure is only as good as its receipt. These tests wire real lineage records
+as anchor targets and prove:
+
+* a figure anchored to a verifying record resolves with a provenance statement;
+* an anchor to a *missing* record fails (the fabricated-figure case);
+* an anchor to a *tampered* record fails at the signature (AC2 tamper test);
+* the reserved ``receipt`` anchor kind (issue #2887) fails closed until wired.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.lineage.artifact_record import record_artifact
+from bernstein.core.lineage.figure_grounding import LineageAnchorResolver, verify_report_figures
+from bernstein.core.lineage.identity import AgentCard, generate_keypair
+from bernstein.core.lineage.recorder import LineageRecorder
+from bernstein.core.lineage.store import LineageStore
+from bernstein.core.tasks.artifacts import ArtifactKind
+from bernstein.core.tasks.figures import (
+    Figure,
+    FigureAnchor,
+    ReportBundle,
+    canonicalise_report_bundle,
+)
+
+_HMAC = b"k" * 64
+
+
+@pytest.fixture
+def identity() -> tuple[AgentCard, str]:
+    priv, pub = generate_keypair()
+    return AgentCard(agent_id="agent:analyst", kid="key-fig-001", public_key_pem=pub), priv
+
+
+def _write_card(cards_dir: Path, card: AgentCard) -> None:
+    d = cards_dir / card.agent_id
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "card.json").write_text(
+        json.dumps({"agent_id": card.agent_id, "kid": card.kid, "public_key_pem": card.public_key_pem}),
+        encoding="utf-8",
+    )
+
+
+def _seed_source(tmp_path: Path, card: AgentCard, priv: str, rows: object) -> tuple[str, Path, Path]:
+    """Record a source dataset artifact; return (its content_hash, log_path, cards_dir)."""
+    log_root = tmp_path / "lineage"
+    cards_dir = tmp_path / "cards"
+    receipt = record_artifact(
+        recorder=LineageRecorder(store=LineageStore(log_root), operator_hmac_key=_HMAC),
+        sink_root=tmp_path / "artifacts",
+        task_id="SRC-1",
+        kind=ArtifactKind.DATASET,
+        artifact=rows,
+        agent_id=card.agent_id,
+        agent_card=card,
+        private_key_pem=priv,
+    )
+    _write_card(cards_dir, card)
+    return receipt.content_hash, log_root / "log.jsonl", cards_dir
+
+
+def _report(body: str, anchor_ref: str, value: str = "1,234") -> bytes:
+    fig = Figure(value=value, unit="users", label="migrated users", anchor=FigureAnchor("artifact", anchor_ref))
+    return canonicalise_report_bundle(ReportBundle(body=body, figures=(fig,)))
+
+
+def test_figure_anchored_to_verifying_record_resolves(tmp_path: Path, identity: tuple[AgentCard, str]) -> None:
+    card, priv = identity
+    src_hash, log_path, cards_dir = _seed_source(tmp_path, card, priv, [{"id": 1}, {"id": 2}])
+
+    verdict = verify_report_figures(
+        canonical_bytes=_report("We migrated 1,234 users.\n", src_hash),
+        log_path=log_path,
+        cards_dir=cards_dir,
+        operator_secret=_HMAC,
+    )
+    assert verdict.ok, verdict.failures
+    assert verdict.provenances[0].ok
+    assert "traces to artifact sha256:" in verdict.provenances[0].statement
+    assert "chain position" in verdict.provenances[0].statement
+
+
+def test_anchor_to_missing_record_fails(tmp_path: Path, identity: tuple[AgentCard, str]) -> None:
+    card, priv = identity
+    _src_hash, log_path, cards_dir = _seed_source(tmp_path, card, priv, [{"id": 1}])
+    ghost = "sha256:" + "0" * 64
+
+    verdict = verify_report_figures(
+        canonical_bytes=_report("We migrated 1,234 users.\n", ghost),
+        log_path=log_path,
+        cards_dir=cards_dir,
+        operator_secret=_HMAC,
+    )
+    assert not verdict.ok
+    assert any("resolves to no lineage record" in f for f in verdict.failures)
+
+
+def test_anchor_to_tampered_record_fails_at_signature(tmp_path: Path, identity: tuple[AgentCard, str]) -> None:
+    """AC2: mutating the anchored record makes the figure fail verification."""
+    card, priv = identity
+    src_hash, log_path, cards_dir = _seed_source(tmp_path, card, priv, [{"id": 1}])
+
+    # Tamper a non-content_hash field (ts_ns) on the source record. The content
+    # hash still matches the anchor, so the record is *found*, but its signature
+    # no longer verifies over the altered canonical bytes.
+    line = json.loads(log_path.read_text().strip())
+    line["ts_ns"] = line["ts_ns"] + 1
+    log_path.write_text(json.dumps(line, separators=(",", ":"), sort_keys=True) + "\n", encoding="utf-8")
+
+    verdict = verify_report_figures(
+        canonical_bytes=_report("We migrated 1,234 users.\n", src_hash),
+        log_path=log_path,
+        cards_dir=cards_dir,
+        operator_secret=_HMAC,
+    )
+    assert not verdict.ok
+    assert any("does not verify" in f for f in verdict.failures)
+
+
+def test_anchor_hmac_mismatch_fails(tmp_path: Path, identity: tuple[AgentCard, str]) -> None:
+    card, priv = identity
+    src_hash, log_path, cards_dir = _seed_source(tmp_path, card, priv, [{"id": 1}])
+
+    resolver = LineageAnchorResolver(log_path=log_path, cards_dir=cards_dir, operator_secret=b"wrong-secret" * 4)
+    res = resolver.resolve(FigureAnchor("artifact", src_hash))
+    assert not res.ok
+    assert "does not verify" in res.statement
+
+
+def test_receipt_anchor_kind_is_a_plug_point(tmp_path: Path, identity: tuple[AgentCard, str]) -> None:
+    card, priv = identity
+    _src, log_path, cards_dir = _seed_source(tmp_path, card, priv, [{"id": 1}])
+
+    resolver = LineageAnchorResolver(log_path=log_path, cards_dir=cards_dir, operator_secret=_HMAC)
+    res = resolver.resolve(FigureAnchor("receipt", "rcpt-abc"))
+    assert not res.ok
+    assert "2887" in res.statement
+
+    # A registered resolver plugs in without touching the evaluator.
+    from bernstein.core.tasks.figures import AnchorResolution
+
+    resolver.register("receipt", lambda ref: AnchorResolution(True, f"traces to receipt {ref}, recorded"))
+    res2 = resolver.resolve(FigureAnchor("receipt", "rcpt-abc"))
+    assert res2.ok
+    assert "traces to receipt rcpt-abc" in res2.statement
+
+
+# ---------------------------------------------------------------------------
+# End to end: record a report bundle, then verify it through verify_artifact
+# ---------------------------------------------------------------------------
+
+
+def _seed_report_and_source(
+    tmp_path: Path, card: AgentCard, priv: str, body: str, unanchored_ok: bool = True
+) -> tuple[str, str]:
+    """Record a source dataset + a report bundle anchoring to it into one .sdd.
+
+    Returns (report_task_id, source_content_hash).
+    """
+    from bernstein.core.lineage.artifact_record import record_artifact
+
+    sdd = tmp_path / ".sdd"
+    store = LineageStore(sdd / "lineage")
+    rec = LineageRecorder(store=store, operator_hmac_key=_HMAC)
+    src = record_artifact(
+        recorder=rec,
+        sink_root=sdd / "artifacts",
+        task_id="SRC-1",
+        kind=ArtifactKind.DATASET,
+        artifact=[{"users": 1234}],
+        agent_id=card.agent_id,
+        agent_card=card,
+        private_key_pem=priv,
+    )
+    figs = (Figure("1,234", "users", "migrated users", FigureAnchor("artifact", src.content_hash)),)
+    record_artifact(
+        recorder=rec,
+        sink_root=sdd / "artifacts",
+        task_id="RPT-1",
+        kind=ArtifactKind.REPORT,
+        artifact=ReportBundle(body=body, figures=figs),
+        agent_id=card.agent_id,
+        agent_card=card,
+        private_key_pem=priv,
+    )
+    _write_card(sdd / "agents", card)
+    return "RPT-1", src.content_hash
+
+
+def _verify(tmp_path: Path, task_id: str):
+    from bernstein.core.lineage.artifact_record import verify_artifact
+
+    sdd = tmp_path / ".sdd"
+    return verify_artifact(
+        task_id=task_id,
+        sink_root=sdd / "artifacts",
+        log_path=sdd / "lineage" / "log.jsonl",
+        cards_dir=sdd / "agents",
+        operator_secret=_HMAC,
+    )
+
+
+def test_verify_artifact_reports_grounded_report(tmp_path: Path, identity: tuple[AgentCard, str]) -> None:
+    card, priv = identity
+    task_id, _ = _seed_report_and_source(tmp_path, card, priv, "We migrated 1,234 users.\n")
+    result = _verify(tmp_path, task_id)
+    assert result.ok, result.failures
+    assert result.figures is not None
+    assert result.figures.has_figures
+    assert result.figures.provenances[0].ok
+
+
+def test_verify_artifact_fails_on_unanchored_number(tmp_path: Path, identity: tuple[AgentCard, str]) -> None:
+    card, priv = identity
+    # The body cites 9.9% but the sidecar only declares 1,234 users.
+    task_id, _ = _seed_report_and_source(tmp_path, card, priv, "We migrated 1,234 users at 9.9% cost.\n")
+    result = _verify(tmp_path, task_id)
+    assert not result.ok
+    assert result.figures is not None
+    assert any("9.9%" in f for f in result.figures.failures)
+
+
+def test_verify_artifact_fails_when_figure_edited_in_blob(tmp_path: Path, identity: tuple[AgentCard, str]) -> None:
+    card, priv = identity
+    task_id, _ = _seed_report_and_source(tmp_path, card, priv, "We migrated 1,234 users.\n")
+    # Editing the stored figure value breaks the content hash (AC4) and the
+    # edited figure value no longer matches the body's material number.
+    blob = tmp_path / ".sdd" / "artifacts" / task_id / "artifact.bin"
+    blob.write_bytes(blob.read_bytes().replace(b'"1,234"', b'"9,999"'))
+    result = _verify(tmp_path, task_id)
+    assert not result.ok
+    # Content-hash re-derivation fails, and the body number is now unanchored.
+    assert any("altered" in f for f in result.failures)

--- a/tests/unit/tasks/data/figure_tokenizer_vectors.json
+++ b/tests/unit/tasks/data/figure_tokenizer_vectors.json
@@ -1,0 +1,208 @@
+{
+  "_comment": [
+    "Figure-tokenizer classification vectors (issue #2888).",
+    "This file pins the false-positive policy of the report figure tokenizer:",
+    "which numeric tokens are MATERIAL (demand a grounding anchor) and which are",
+    "EXEMPT (section numbers, ISO dates, versions, allowlisted patterns, and",
+    "below-threshold incidental counts).",
+    "",
+    "Extend the suite by appending a case to `cases`. Each case is a report",
+    "snippet plus the ordered list of numeric tokens the tokenizer must emit,",
+    "each with its surface string, whether it is material, and its category.",
+    "`category` is one of: currency, percentage, quantity, count, range (all",
+    "material) or date, version, section, allowlisted, below_threshold (all",
+    "exempt). The test asserts the emitted (surface, material, category) triples",
+    "equal `expect` in order, so a policy regression fails loudly here.",
+    "",
+    "`policy` overrides the tokenizer defaults for the whole suite; today only",
+    "`materiality_min` (bare integers strictly below this are incidental/exempt)",
+    "and `allowlist` (extra exempt regexes) are honoured."
+  ],
+  "policy": {
+    "materiality_min": 1000,
+    "allowlist": [
+      "\\b\\d{1,2}/\\d{1,2}\\b"
+    ]
+  },
+  "cases": [
+    {
+      "id": "currency-dollar-grouped-decimal",
+      "text": "Quarterly revenue was $1,234.56 across the segment.",
+      "expect": [
+        {"surface": "$1,234.56", "material": true, "category": "currency"}
+      ]
+    },
+    {
+      "id": "currency-euro-plain",
+      "text": "The licence costs €49 per seat.",
+      "expect": [
+        {"surface": "€49", "material": true, "category": "currency"}
+      ]
+    },
+    {
+      "id": "currency-magnitude-suffix",
+      "text": "Total addressable spend is $4.5M this year.",
+      "expect": [
+        {"surface": "$4.5M", "material": true, "category": "currency"}
+      ]
+    },
+    {
+      "id": "currency-iso-code",
+      "text": "Settlement of USD 2,000 cleared overnight.",
+      "expect": [
+        {"surface": "USD 2,000", "material": true, "category": "currency"}
+      ]
+    },
+    {
+      "id": "percentage-decimal",
+      "text": "Error rate rose to 12.5% after the change.",
+      "expect": [
+        {"surface": "12.5%", "material": true, "category": "percentage"}
+      ]
+    },
+    {
+      "id": "percentage-word",
+      "text": "Coverage improved by 30 percent overall.",
+      "expect": [
+        {"surface": "30 percent", "material": true, "category": "percentage"}
+      ]
+    },
+    {
+      "id": "quantity-unit-decimal",
+      "text": "The dump was 3.2 GB when compressed.",
+      "expect": [
+        {"surface": "3.2 GB", "material": true, "category": "quantity"}
+      ]
+    },
+    {
+      "id": "quantity-latency-unit",
+      "text": "P99 latency held at 250 ms under load.",
+      "expect": [
+        {"surface": "250 ms", "material": true, "category": "quantity"}
+      ]
+    },
+    {
+      "id": "count-grouped-noun",
+      "text": "We migrated 1,234 users without incident.",
+      "expect": [
+        {"surface": "1,234", "material": true, "category": "count"}
+      ]
+    },
+    {
+      "id": "count-large-bare",
+      "text": "The batch processed 5000 records overnight.",
+      "expect": [
+        {"surface": "5000", "material": true, "category": "count"}
+      ]
+    },
+    {
+      "id": "count-decimal-bare",
+      "text": "The mean depth was 4.7 across the sample.",
+      "expect": [
+        {"surface": "4.7", "material": true, "category": "count"}
+      ]
+    },
+    {
+      "id": "range-percentage",
+      "text": "Throughput improved 10-20% depending on shard.",
+      "expect": [
+        {"surface": "10-20%", "material": true, "category": "range"}
+      ]
+    },
+    {
+      "id": "iso-date-exempt",
+      "text": "The incident opened on 2026-07-24 and closed same day.",
+      "expect": [
+        {"surface": "2026-07-24", "material": false, "category": "date"}
+      ]
+    },
+    {
+      "id": "iso-datetime-exempt",
+      "text": "Snapshot taken at 2026-07-24T09:30 by the collector.",
+      "expect": [
+        {"surface": "2026-07-24T09:30", "material": false, "category": "date"}
+      ]
+    },
+    {
+      "id": "version-v-prefixed-exempt",
+      "text": "Shipped in v3.9.0 of the orchestrator.",
+      "expect": [
+        {"surface": "v3.9.0", "material": false, "category": "version"}
+      ]
+    },
+    {
+      "id": "version-semver-exempt",
+      "text": "The pin moved to 1.2.3 last week.",
+      "expect": [
+        {"surface": "1.2.3", "material": false, "category": "version"}
+      ]
+    },
+    {
+      "id": "section-symbol-exempt",
+      "text": "See §3.2 for the canonicalisation rule.",
+      "expect": [
+        {"surface": "§3.2", "material": false, "category": "section"}
+      ]
+    },
+    {
+      "id": "section-word-exempt",
+      "text": "Section 4 covers the failure semantics.",
+      "expect": [
+        {"surface": "Section 4", "material": false, "category": "section"}
+      ]
+    },
+    {
+      "id": "section-figure-ref-exempt",
+      "text": "Figure 2 shows the chain projection.",
+      "expect": [
+        {"surface": "Figure 2", "material": false, "category": "section"}
+      ]
+    },
+    {
+      "id": "below-threshold-incidental",
+      "text": "There are 3 steps and 2 options in the flow.",
+      "expect": [
+        {"surface": "3", "material": false, "category": "below_threshold"},
+        {"surface": "2", "material": false, "category": "below_threshold"}
+      ]
+    },
+    {
+      "id": "allowlisted-fraction-pattern",
+      "text": "The rota runs 24/7 during the freeze.",
+      "expect": [
+        {"surface": "24/7", "material": false, "category": "allowlisted"}
+      ]
+    },
+    {
+      "id": "mixed-material-and-exempt",
+      "text": "Per §2, the 2026-07-24 run moved $1,000 across 1,500 accounts at 9.9%.",
+      "expect": [
+        {"surface": "§2", "material": false, "category": "section"},
+        {"surface": "2026-07-24", "material": false, "category": "date"},
+        {"surface": "$1,000", "material": true, "category": "currency"},
+        {"surface": "1,500", "material": true, "category": "count"},
+        {"surface": "9.9%", "material": true, "category": "percentage"}
+      ]
+    },
+    {
+      "id": "identifier-glued-number-skipped",
+      "text": "P99 latency held at 250 ms under load.",
+      "expect": [
+        {"surface": "250 ms", "material": true, "category": "quantity"}
+      ]
+    },
+    {
+      "id": "bare-year-exempt",
+      "text": "In 2026 the orchestrator moved 5000 records.",
+      "expect": [
+        {"surface": "2026", "material": false, "category": "date"},
+        {"surface": "5000", "material": true, "category": "count"}
+      ]
+    },
+    {
+      "id": "no-numbers",
+      "text": "The report contains only prose and no figures at all.",
+      "expect": []
+    }
+  ]
+}

--- a/tests/unit/tasks/test_figure_tokenizer.py
+++ b/tests/unit/tasks/test_figure_tokenizer.py
@@ -1,0 +1,85 @@
+"""Figure tokenizer: the false-positive policy surface (issue #2888).
+
+The tokenizer classifies every numeric token in a report body as *material*
+(demands a grounding anchor) or *exempt* (section numbers, ISO dates, versions,
+allowlisted patterns, incidental below-threshold counts). The policy is pinned
+by an extensible vector file so a classification regression fails loudly.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.tasks.figures import TokenizerPolicy, tokenize_numbers
+
+_VECTORS = Path(__file__).parent / "data" / "figure_tokenizer_vectors.json"
+
+
+def _load_vectors() -> tuple[TokenizerPolicy, list[dict]]:
+    data = json.loads(_VECTORS.read_text(encoding="utf-8"))
+    policy = TokenizerPolicy.from_dict(data.get("policy", {}))
+    return policy, data["cases"]
+
+
+_POLICY, _CASES = _load_vectors()
+
+
+@pytest.mark.parametrize("case", _CASES, ids=[c["id"] for c in _CASES])
+def test_tokenizer_vector(case: dict) -> None:
+    tokens = tokenize_numbers(case["text"], _POLICY)
+    got = [{"surface": t.surface, "material": t.material, "category": t.category} for t in tokens]
+    assert got == case["expect"], f"case {case['id']!r}: {got} != {case['expect']}"
+
+
+def test_material_categories_demand_anchors() -> None:
+    """AC3: quantities, currency, percentages, and counts are material."""
+    materials = {
+        "$5": "currency",
+        "12%": "percentage",
+        "3.2 GB": "quantity",
+        "1,234": "count",
+    }
+    for text, category in materials.items():
+        tokens = tokenize_numbers(f"value {text} here", _POLICY)
+        material = [t for t in tokens if t.material]
+        assert material, f"{text!r} should yield a material token"
+        assert material[0].category == category
+
+
+def test_exempt_categories_do_not_demand_anchors() -> None:
+    """AC3: section numbers, ISO dates, versions, allowlist stay exempt."""
+    for text in ("§3.2", "Section 7", "2026-01-02", "v1.2.3", "9.8.7"):
+        tokens = tokenize_numbers(f"ref {text} end", _POLICY)
+        assert all(not t.material for t in tokens), f"{text!r} produced a material token"
+
+
+def test_token_carries_location() -> None:
+    tokens = tokenize_numbers("line one\nrevenue was $1,000 here", _POLICY)
+    material = [t for t in tokens if t.material]
+    assert len(material) == 1
+    tok = material[0]
+    assert tok.line == 2
+    assert tok.col >= 1
+    # The numeric core is exposed for value matching against a sidecar.
+    assert tok.numeric_key == "1000"
+
+
+def test_materiality_threshold_is_configurable() -> None:
+    # With a low threshold, a bare small integer becomes material.
+    low = TokenizerPolicy(materiality_min=1)
+    tokens = tokenize_numbers("there are 7 shards", low)
+    material = [t for t in tokens if t.material]
+    assert len(material) == 1
+    assert material[0].category == "count"
+
+
+def test_numeric_key_normalises_grouping_and_trailing_zeros() -> None:
+    from bernstein.core.tasks.figures import numeric_key_of
+
+    assert numeric_key_of("1,234.00") == "1234"
+    assert numeric_key_of("12.50") == "12.5"
+    assert numeric_key_of("$1,000") == "1000"
+    assert numeric_key_of("9.9%") == "9.9"

--- a/tests/unit/tasks/test_models_serialization.py
+++ b/tests/unit/tasks/test_models_serialization.py
@@ -96,6 +96,24 @@ def test_task_from_dict_skips_malformed_completion_signal() -> None:
     assert task.completion_signals[0].value == "out.txt"
 
 
+def test_task_round_trips_figures_grounded_signal() -> None:
+    """Issue #2888: the figures_grounded signal type survives to_dict/from_dict."""
+    task = Task.from_dict(
+        {
+            "id": "x",
+            "title": "T",
+            "description": "D",
+            "role": "backend",
+            "completion_signals": [{"type": "figures_grounded", "value": "warn"}],
+        }
+    )
+    assert task.completion_signals[0].type == "figures_grounded"
+    assert task.completion_signals[0].value == "warn"
+    restored = Task.from_dict(task.to_dict())
+    assert restored.completion_signals[0].type == "figures_grounded"
+    assert restored.completion_signals[0].value == "warn"
+
+
 def test_task_from_dict_best_of_n_coercion() -> None:
     task = Task.from_dict({"id": "x", "title": "T", "description": "D", "role": "backend", "best_of_n": "3"})
     assert task.best_of_n == 3

--- a/tests/unit/tasks/test_report_bundle.py
+++ b/tests/unit/tasks/test_report_bundle.py
@@ -1,0 +1,165 @@
+"""Report bundle + figures_grounded pure evaluator (issue #2888).
+
+The bundle carries the report body and its ``figures.json`` sidecar inside one
+canonical byte string, so editing a figure changes the artifact ``content_hash``
+(AC4). The pure evaluator resolves anchors through an injected callable and
+names each unanchored figure with its location (AC1), independent of lineage.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.tasks.artifacts import CanonicalisationError, content_hash
+from bernstein.core.tasks.figures import (
+    AnchorResolution,
+    Figure,
+    FigureAnchor,
+    ReportBundle,
+    canonicalise_report_bundle,
+    evaluate_figures_grounded,
+    is_report_bundle,
+    parse_report_bundle,
+)
+
+
+def _anchor(ref: str = "sha256:" + "a" * 64) -> FigureAnchor:
+    return FigureAnchor(kind="artifact", ref=ref)
+
+
+def _bundle(body: str, figures: tuple[Figure, ...]) -> ReportBundle:
+    return ReportBundle(body=body, figures=figures)
+
+
+# ---------------------------------------------------------------------------
+# Anchor validation
+# ---------------------------------------------------------------------------
+
+
+def test_anchor_rejects_unknown_kind() -> None:
+    with pytest.raises(ValueError, match="unknown figure anchor kind"):
+        FigureAnchor(kind="telepathy", ref="sha256:" + "a" * 64)
+
+
+def test_hash_anchor_requires_sha256_ref() -> None:
+    with pytest.raises(ValueError, match="content hash"):
+        FigureAnchor(kind="attachment", ref="not-a-hash")
+
+
+def test_receipt_anchor_accepts_opaque_ref() -> None:
+    # The receipt anchor kind (issue #2887) plugs in without a hash constraint.
+    a = FigureAnchor(kind="receipt", ref="rcpt-2f8c")
+    assert a.ref == "rcpt-2f8c"
+
+
+# ---------------------------------------------------------------------------
+# Canonicalisation + parse + content_hash covers the sidecar (AC4)
+# ---------------------------------------------------------------------------
+
+
+def test_bundle_round_trips_through_canonical_bytes() -> None:
+    fig = Figure(value="1,234", unit="users", label="migrated users", anchor=_anchor())
+    bundle = _bundle("We migrated 1,234 users.\n", (fig,))
+    parsed = parse_report_bundle(canonicalise_report_bundle(bundle))
+    assert parsed.body == "We migrated 1,234 users.\n"
+    assert parsed.figures[0].value == "1,234"
+    assert parsed.figures[0].anchor.ref == fig.anchor.ref
+
+
+def test_editing_a_figure_value_changes_content_hash() -> None:
+    fig = Figure(value="1,234", unit="users", label="migrated", anchor=_anchor())
+    base = _bundle("We migrated 1,234 users.\n", (fig,))
+    edited = _bundle(
+        "We migrated 1,234 users.\n",
+        (Figure(value="9,999", unit="users", label="migrated", anchor=_anchor()),),
+    )
+    h_base = content_hash(canonicalise_report_bundle(base))
+    h_edited = content_hash(canonicalise_report_bundle(edited))
+    assert h_base != h_edited
+
+
+def test_editing_an_anchor_changes_content_hash() -> None:
+    body = "We migrated 1,234 users.\n"
+    base = _bundle(body, (Figure("1,234", "users", "m", _anchor("sha256:" + "a" * 64)),))
+    moved = _bundle(body, (Figure("1,234", "users", "m", _anchor("sha256:" + "b" * 64)),))
+    assert content_hash(canonicalise_report_bundle(base)) != content_hash(canonicalise_report_bundle(moved))
+
+
+def test_canonical_bytes_are_deterministic() -> None:
+    fig = Figure("1,234", "users", "m", _anchor())
+    b1 = canonicalise_report_bundle(_bundle("body 1,234\n", (fig,)))
+    b2 = canonicalise_report_bundle(_bundle("body 1,234\n", (Figure("1,234", "users", "m", _anchor()),)))
+    assert b1 == b2
+
+
+def test_bundle_body_must_be_nfc() -> None:
+    # A decomposed 'é' (e + combining acute) is rejected, not repaired.
+    with pytest.raises(CanonicalisationError, match="NFC"):
+        canonicalise_report_bundle(_bundle("café 1,234\n", (Figure("1,234", "", "", _anchor()),)))
+
+
+def test_plain_report_text_is_not_a_bundle() -> None:
+    assert is_report_bundle(b"just prose, no bundle") is False
+    assert is_report_bundle(b'{"body":"x","figures":[]}') is True
+
+
+# ---------------------------------------------------------------------------
+# figures_grounded pure evaluation
+# ---------------------------------------------------------------------------
+
+
+def _all_ok(_a: FigureAnchor) -> AnchorResolution:
+    return AnchorResolution(ok=True, statement="traces to artifact sha256:aaaa, recorded at chain position 1")
+
+
+def _all_broken(_a: FigureAnchor) -> AnchorResolution:
+    return AnchorResolution(ok=False, statement="resolves to no verifying lineage record")
+
+
+def test_fully_grounded_report_passes() -> None:
+    fig = Figure("1,234", "users", "migrated users", _anchor())
+    bundle = _bundle(
+        "We migrated 1,234 users at 9.9% cost.\n",
+        (
+            fig,
+            Figure("9.9", "%", "cost ratio", _anchor("sha256:" + "c" * 64)),
+        ),
+    )
+    verdict = evaluate_figures_grounded(bundle, resolve_anchor=_all_ok)
+    assert verdict.ok, verdict.failures
+    assert verdict.has_figures
+    assert len(verdict.provenances) == 2
+    assert all(p.ok for p in verdict.provenances)
+
+
+def test_removing_one_anchor_fails_naming_that_figure_and_location() -> None:
+    # Same report, but the 9.9% figure is no longer declared in the sidecar.
+    bundle = _bundle(
+        "We migrated 1,234 users at 9.9% cost.\n",
+        (Figure("1,234", "users", "migrated users", _anchor()),),
+    )
+    verdict = evaluate_figures_grounded(bundle, resolve_anchor=_all_ok)
+    assert not verdict.ok
+    assert len(verdict.unanchored) == 1
+    un = verdict.unanchored[0]
+    assert un.surface == "9.9%"
+    assert un.category == "percentage"
+    assert un.line == 1
+    # The failure names the exact number and its location.
+    assert any("9.9%" in f and "line 1" in f for f in verdict.failures)
+
+
+def test_figure_with_unresolvable_anchor_fails_naming_the_figure() -> None:
+    fig = Figure("1,234", "users", "migrated users", _anchor())
+    bundle = _bundle("We migrated 1,234 users.\n", (fig,))
+    verdict = evaluate_figures_grounded(bundle, resolve_anchor=_all_broken)
+    assert not verdict.ok
+    assert any("migrated users" in f and "not grounded" in f for f in verdict.failures)
+    assert verdict.provenances[0].ok is False
+
+
+def test_report_with_no_figures_and_no_material_numbers_passes() -> None:
+    bundle = _bundle("Section 4 has 3 steps, per §2.\n", ())
+    verdict = evaluate_figures_grounded(bundle, resolve_anchor=_all_broken)
+    assert verdict.ok
+    assert verdict.has_figures is False

--- a/tests/unit/test_janitor.py
+++ b/tests/unit/test_janitor.py
@@ -1670,3 +1670,97 @@ class TestArtifactSignals:
         task = _make_task(signals=[CompletionSignal(type="path_exists", value="README.md")])
         task.artifact_spec = ArtifactSpec(kind=ArtifactKind.REPORT)
         assert evaluate_artifact_signals(task, "prose\n") == []
+
+
+class TestFiguresGroundedSignal:
+    """Issue #2888: the figures_grounded completion signal and its severity."""
+
+    _HMAC = b"k" * 64
+
+    def _seed(self, tmp_path: Path, body: str, declare_9_9: bool = False):
+        """Record a source dataset into tmp_path/.sdd; return a report ReportBundle."""
+        import json as _json
+
+        from bernstein.core.lineage.artifact_record import record_artifact
+        from bernstein.core.lineage.identity import AgentCard, generate_keypair
+        from bernstein.core.lineage.recorder import LineageRecorder
+        from bernstein.core.lineage.store import LineageStore
+        from bernstein.core.tasks.artifacts import ArtifactKind
+        from bernstein.core.tasks.figures import Figure, FigureAnchor, ReportBundle
+
+        sdd = tmp_path / ".sdd"
+        priv, pub = generate_keypair()
+        card = AgentCard(agent_id="agent:analyst", kid="key-fg", public_key_pem=pub)
+        rec = LineageRecorder(store=LineageStore(sdd / "lineage"), operator_hmac_key=self._HMAC)
+        src = record_artifact(
+            recorder=rec,
+            sink_root=sdd / "artifacts",
+            task_id="SRC",
+            kind=ArtifactKind.DATASET,
+            artifact=[{"users": 1234}],
+            agent_id=card.agent_id,
+            agent_card=card,
+            private_key_pem=priv,
+        )
+        card_dir = sdd / "agents" / card.agent_id
+        card_dir.mkdir(parents=True, exist_ok=True)
+        (card_dir / "card.json").write_text(
+            _json.dumps({"agent_id": card.agent_id, "kid": card.kid, "public_key_pem": card.public_key_pem}),
+            encoding="utf-8",
+        )
+        figs = [Figure("1,234", "users", "migrated users", FigureAnchor("artifact", src.content_hash))]
+        if declare_9_9:
+            figs.append(Figure("9.9", "%", "cost ratio", FigureAnchor("artifact", src.content_hash)))
+        return ReportBundle(body=body, figures=tuple(figs))
+
+    def _task(self, value: str = ""):
+        from bernstein.core.tasks.artifacts import ArtifactKind, ArtifactSpec
+
+        task = _make_task(signals=[CompletionSignal(type="figures_grounded", value=value)])
+        task.artifact_spec = ArtifactSpec(kind=ArtifactKind.REPORT)
+        return task
+
+    def test_grounded_report_passes(self, tmp_path: Path) -> None:
+        from bernstein.core.quality.janitor import evaluate_artifact_signals
+
+        bundle = self._seed(tmp_path, "We migrated 1,234 users.\n")
+        results = evaluate_artifact_signals(self._task(), bundle, lineage_root=tmp_path)
+        assert len(results) == 1
+        _desc, passed, detail = results[0]
+        assert passed is True, detail
+        assert "grounded" in detail
+
+    def test_strict_unanchored_number_fails(self, tmp_path: Path) -> None:
+        from bernstein.core.quality.janitor import evaluate_artifact_signals
+
+        bundle = self._seed(tmp_path, "We migrated 1,234 users at 9.9% cost.\n")
+        results = evaluate_artifact_signals(self._task(value="strict"), bundle, lineage_root=tmp_path)
+        _desc, passed, detail = results[0]
+        assert passed is False
+        assert "9.9%" in detail
+
+    def test_warn_downgrades_failure_to_pass(self, tmp_path: Path) -> None:
+        from bernstein.core.quality.janitor import evaluate_artifact_signals
+
+        bundle = self._seed(tmp_path, "We migrated 1,234 users at 9.9% cost.\n")
+        results = evaluate_artifact_signals(self._task(value="warn"), bundle, lineage_root=tmp_path)
+        _desc, passed, detail = results[0]
+        assert passed is True
+        assert detail.startswith("WARN:")
+        assert "9.9%" in detail
+
+    def test_default_severity_is_strict(self, tmp_path: Path) -> None:
+        from bernstein.core.quality.janitor import evaluate_artifact_signals
+
+        bundle = self._seed(tmp_path, "We migrated 1,234 users at 9.9% cost.\n")
+        results = evaluate_artifact_signals(self._task(value=""), bundle, lineage_root=tmp_path)
+        _desc, passed, _detail = results[0]
+        assert passed is False
+
+    def test_non_bundle_artifact_reports_clearly(self, tmp_path: Path) -> None:
+        from bernstein.core.quality.janitor import evaluate_artifact_signals
+
+        results = evaluate_artifact_signals(self._task(value="strict"), "just prose", lineage_root=tmp_path)
+        _desc, passed, detail = results[0]
+        assert passed is False
+        assert "report bundle" in detail


### PR DESCRIPTION
## What
Every material number in a report-kind artifact must trace to an anchored source, or the task does not complete. Builds directly on the #2608 slice-1 artifact contract.

Fixes #2888

> **Stacked on #2903** (`fix/m8w3-artifact-contract`, the #2608 slice-1 base). This PR targets that branch; retarget to `main` once #2903 merges. The diff shown here is figure-grounding only.

## How
- A report bundle is one canonical JCS object `{body, figures}`; the figures sidecar is inside the artifact's own `content_hash`, so editing a figure value changes the hash by construction.
- A closed `figures_grounded` completion signal (10th signal type): every declared figure's anchor must resolve to a verifying lineage record, and every material numeric token in the body must appear in the sidecar; failure names each unanchored figure and its location.
- The tokenizer's false-positive policy is pinned by a 25-case vector file: currency/percentage/quantity/count/range demand anchors; ISO dates, versions, section numbers, below-threshold counts, and an allowlist are exempt.
- `bernstein artifact verify` renders a per-figure provenance section and exits non-zero on any failing figure.
- Strict by default for report artifacts; per-task `warn` downgrade available.
- The `receipt` anchor kind (#2887) is a registered plug-point that fails closed until that resolver lands — no rework needed, no dependency taken.

## Verification
274 passed across the new and adjacent suites; collection sentinel 37,972 (+60), 0 errors; ruff clean; the two new modules mypy-clean. Empirical criteria independently covered: tamper (missing/tampered/HMAC-mismatch anchor), sidecar-in-bytes hash change, tokenizer vector categories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added figure grounding for report artifacts, validating declared figures against verifiable lineage records.
  * Reports now require all material numbers in the body to be declared in the figures sidecar.
  * Enhanced `artifact verify` output with per-figure provenance in both human-readable and JSON modes.
  * Added `figures_grounded` completion checks with strict and warning severity behavior.
* **Bug Fixes**
  * Verification fails with clear diagnostics (including unanchored/mismatched figures) and non-zero exit on any failing figure.
* **Documentation**
  * Documented report figure sidecar format, grounding rules, and verification semantics.
* **Tests**
  * Added unit and CLI coverage for figure grounding, tokenizer policy, and output rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->