### PR TITLE
fix(deps): raise pypdf floor to 6.14.2 to clear the Trivy HIGH CVE gate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,7 +164,10 @@ dev = [
     "diff-cover>=9.0",  # Per-PR diff coverage gate
     # PDF re-parse for tests that assert reportlab-emitted Article 12
     # PDFs are well-formed (tests/unit/compliance/test_article12.py).
-    "pypdf>=4.0",
+    # Floor raised to the patched release for CVE-2026-59935 (fixed
+    # 6.14.2) and CVE-2026-59936 (fixed 6.14.1): crafted-PDF inline-image
+    # denial of service.
+    "pypdf>=6.14.2",
     # Resource-leak / RSS / fd-count probes for the TC-C stress suite
     # (tests/stress/*). Pure-Python wrappers around platform APIs, MIT-
     # licensed, no native compile required. Tests degrade gracefully when
@@ -799,8 +802,9 @@ dev = [
     "syrupy>=4.6",
     "diff-cover>=9.0",
     # PDF re-parse for Article 12 evidence tests (mirror of
-    # [project.optional-dependencies].dev).
-    "pypdf>=4.0",
+    # [project.optional-dependencies].dev).  Floor raised to the patched
+    # release for CVE-2026-59935 / CVE-2026-59936 (crafted-PDF DoS).
+    "pypdf>=6.14.2",
     # Resource-leak probes for the TC-C stress suite (mirror of
     # [project.optional-dependencies].dev).  Optional at runtime - the
     # stress suite ``importorskip``s when missing.

--- a/uv.lock
+++ b/uv.lock
@@ -505,7 +505,7 @@ requires-dist = [
     { name = "psutil", marker = "extra == 'dev'", specifier = ">=5.9" },
     { name = "pydantic-settings", specifier = ">=2.13.1" },
     { name = "pyfiglet", specifier = ">=1.0" },
-    { name = "pypdf", marker = "extra == 'dev'", specifier = ">=4.0" },
+    { name = "pypdf", marker = "extra == 'dev'", specifier = ">=6.14.2" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0" },
@@ -553,7 +553,7 @@ dev = [
     { name = "mutmut", specifier = ">=3.5,<4" },
     { name = "pip-audit", specifier = ">=2.7" },
     { name = "psutil", specifier = ">=5.9" },
-    { name = "pypdf", specifier = ">=4.0" },
+    { name = "pypdf", specifier = ">=6.14.2" },
     { name = "pyright", specifier = ">=1.1" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
@@ -3575,11 +3575,11 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-version = "6.13.3"
+version = "6.14.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/17/18/9947cc201af9ccf76720fd3347bf4f70eb882ce3fcf4cb05f7443e4cf871/pypdf-6.13.3.tar.gz", hash = "sha256:f3cb822769725f1bac658c406cfc9460399043f3750c2d3e4650e0a85eacabd7", size = 6484063, upload-time = "2026-06-17T15:22:00.898Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/72/7dfd5ff1c9c37de97a731701f51af091325f123d9d4270361c9c69e4431f/pypdf-6.14.2.tar.gz", hash = "sha256:7873f502fe4385e79539b21d872392dc0c4e3714327c15881cbc7fbfd1f95b25", size = 6491182, upload-time = "2026-06-23T14:18:30.859Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/56/2967e621598987905fb8cdfadd8f8de6b5c68c9351f0523c4df8409f28f1/pypdf-6.13.3-py3-none-any.whl", hash = "sha256:c6e3f86afb625791510b02ad5480e94b63970bb957df75d44657c282ecc52224", size = 347288, upload-time = "2026-06-17T15:21:59.512Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e6/136aa8993a2ae7214e0b0ef2edaa0d2e08d1d4e4982635b08a835ff31ec8/pypdf-6.14.2-py3-none-any.whl", hash = "sha256:3f07891af76dc002657e04993ab9b4de81de29f9013b9761d0b7968bff12e946", size = 349514, upload-time = "2026-06-23T14:18:28.867Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Raises the `pypdf` floor from `>=4.0` to `>=6.14.2` in both dev dependency blocks in `pyproject.toml`, pinning past the crafted-PDF inline-image DoS advisories (CVE-2026-59935 fixed in 6.14.2, CVE-2026-59936 fixed in 6.14.1).

Constraining the floor in `pyproject.toml` keeps the patched version from being re-resolved away on the next lockfile update, which a lockfile-only bump does not guarantee.

Supersedes the lockfile-only bump in #2862.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the development tooling requirement for `pypdf` to version 6.14.2 or later.
  * Adds security hardening to better protect against denial-of-service risks from specially crafted PDF files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->