### PR TITLE
chore(ci): ratchet coverage baseline to 81.71%

### DIFF
--- a/.coverage-baseline.json
+++ b/.coverage-baseline.json
@@ -1,5 +1,5 @@
 {
   "diff_coverage_floor_percent": 85,
-  "total_coverage_percent": 81.6,
-  "updated_at": "2026-07-23T15:04:48+00:00"
+  "total_coverage_percent": 81.71,
+  "updated_at": "2026-07-24T09:10:11+00:00"
 }


### PR DESCRIPTION
Ratchets the coverage floor in `.coverage-baseline.json` from 81.6% to 81.71% to lock in gains from recently merged work.

Recreated under user auth to replace #2864, whose GITHUB_TOKEN-authored branch never fired `pull_request` CI and was therefore permanently unmergeable.

## Summary by Sourcery

CI:
- Raise the coverage floor in the coverage baseline configuration from 81.6% to 81.71% to enforce the higher standard in CI.