### PR TITLE
fix(security): harden payment mandates and consent receipts

### DIFF
--- a/docs/operations/spending-mandates.md
+++ b/docs/operations/spending-mandates.md
@@ -30,7 +30,11 @@ Module: `src/bernstein/core/protocols/payments/mandates.py`. CLI group:
   authorize the byte-identical action set. No LLM in the loop.
 - **Spend caps** - the cost ledger (`.sdd/cost/ledger.jsonl`) is the single
   enforcement point. A settlement whose cumulative task spend plus amount would
-  breach the intent's cap is refused.
+  breach the intent's cap is refused. The cap is enforced on the amount the
+  receipt binds: the cart amount and the settlement reference amount must
+  agree, so a cart cannot pass a small amount through the cap while the receipt
+  settles a larger one. A negative amount is refused outright rather than
+  clamped to `0`, so it cannot slip past the cap or mask real spend.
 - **Revocation** - `bernstein mandate revoke <mandate_hash>` appends a signed
   entry to `.sdd/mandates/revocations.jsonl` rather than mutating anything.
   Subsequent actions under the mandate are refused while the original stays
@@ -49,6 +53,12 @@ the mandate lineage spine (`run_id="mandates"`), and mirrors it into the
 HMAC-chained audit log (`mandate.consent_receipt`). Exit code `1` means the
 settlement was refused (cap breach, revocation, or a signature / intent-binding
 gate).
+
+The lineage-spine anchor is the source of truth; the audit-chain mirror is a
+best-effort second write. If the mirror fails, `emit` and `revoke` still exit
+`0` (the receipt / revocation is already committed) and print a distinct
+`WARNING` naming the mandate hash and the failure reason, rather than raising a
+traceback over an already-committed artefact.
 
 ## On-disk layout
 

--- a/src/bernstein/cli/commands/mandate_cmd.py
+++ b/src/bernstein/cli/commands/mandate_cmd.py
@@ -123,16 +123,27 @@ def mandate_emit_cmd(intent_file: str, cart_file: str, settlement_file: str, wor
         console.print(f"[red]REFUSED[/red] -- {exc}")
         raise SystemExit(1) from exc
 
+    # The receipt is already anchored in the lineage spine above. The audit-
+    # chain mirror is a best-effort second write; a failure here must not raise
+    # post-anchor and orphan the operator with a traceback over a committed
+    # receipt. Warn distinctly (naming the mandate hash) and continue.
     chain = AuditChainStore(_audit_dir(root), key=key)
-    record_mandate_consent_receipt(
-        chain=chain,
-        mandate_hash=receipt.mandate_hash,
-        intent_hash=receipt.intent_hash,
-        authorized_tool_calls_hash=receipt.authorized_tool_calls_hash,
-        settlement_ref_hash=_settlement_ref_hash(settlement),
-        journal_entry_hash=receipt.journal_entry_hash,
-        task_id=receipt.task_id,
-    )
+    try:
+        record_mandate_consent_receipt(
+            chain=chain,
+            mandate_hash=receipt.mandate_hash,
+            intent_hash=receipt.intent_hash,
+            authorized_tool_calls_hash=receipt.authorized_tool_calls_hash,
+            settlement_ref_hash=_settlement_ref_hash(settlement),
+            journal_entry_hash=receipt.journal_entry_hash,
+            task_id=receipt.task_id,
+        )
+    except Exception as exc:  # best-effort mirror: never mask the anchored receipt
+        console.print(
+            f"[yellow]WARNING[/yellow] -- consent receipt anchored but audit-chain mirror "
+            f"failed for {receipt.mandate_hash}: {exc}",
+            soft_wrap=True,
+        )
 
     console.print()
     console.print("[bold]Mandate emit[/bold]")
@@ -220,8 +231,19 @@ def mandate_revoke_cmd(mandate_hash: str, reason: str, workdir: str) -> None:
         reason=reason,
         timestamp=int(time.time()),
     )
+    # The revocation is already committed to the append-only ledger above. The
+    # audit-chain mirror is a best-effort second write; a failure here must not
+    # raise after the revocation is persisted. Warn distinctly (naming the
+    # mandate hash) and continue.
     chain = AuditChainStore(_audit_dir(root), key=key)
-    record_mandate_revocation(chain=chain, mandate_hash=entry.mandate_hash, reason=entry.reason)
+    try:
+        record_mandate_revocation(chain=chain, mandate_hash=entry.mandate_hash, reason=entry.reason)
+    except Exception as exc:  # best-effort mirror: never mask the committed revocation
+        console.print(
+            f"[yellow]WARNING[/yellow] -- revocation committed but audit-chain mirror "
+            f"failed for {entry.mandate_hash}: {exc}",
+            soft_wrap=True,
+        )
 
     console.print()
     console.print(f"[bold]Mandate revoke[/bold] hash={mandate_hash[:24]}")

--- a/src/bernstein/core/protocols/payments/mandates.py
+++ b/src/bernstein/core/protocols/payments/mandates.py
@@ -621,7 +621,7 @@ def emit_consent_receipt(
     if set(cart.tool_calls) - set(authorized):
         raise MandateRefused("cart proposes tool calls the intent does not authorize")
 
-    _enforce_spend_cap(intent=intent, cart=cart, ledger=ledger)
+    _enforce_spend_cap(intent=intent, cart=cart, settlement_ref=settlement_ref, ledger=ledger)
 
     receipt = ConsentReceipt(
         mandate_hash=cart.mandate_hash(),
@@ -666,21 +666,42 @@ def _enforce_spend_cap(
     *,
     intent: IntentMandate,
     cart: CartMandate,
+    settlement_ref: SettlementRef,
     ledger: SpendLedger | None,
 ) -> None:
-    """Refuse the settlement when it would breach the intent's spend cap.
+    """Refuse the settlement when its amount is unsound or breaches the cap.
 
     The cost ledger is the single enforcement point: cumulative task spend
     (from the ledger's ``task`` rollup) plus this cart's amount must not
     exceed ``spend_cap_usd``. A cap of ``0`` permits no spend.
+
+    Two amount invariants gate the cap check so the value enforced is the
+    value the receipt binds:
+
+    * The cart amount and the settlement reference amount must agree. The cap
+      is enforced on the cart amount, but the receipt binds ``settlement_ref``;
+      if the two could diverge, a cart could pass a small amount through the
+      cap while the receipt settled a larger one.
+    * A negative amount is refused outright rather than clamped to ``0``. A
+      clamped negative would slip past the cap and could mask real spend from
+      the ledger rollup.
     """
+    if cart.amount_usd < 0 or settlement_ref.amount_usd < 0:
+        raise MandateRefused(
+            f"negative settlement amount refused: cart ${cart.amount_usd:.4f}, "
+            f"settlement ${settlement_ref.amount_usd:.4f}"
+        )
+    if cart.amount_usd != settlement_ref.amount_usd:
+        raise MandateRefused(
+            f"cart amount ${cart.amount_usd:.4f} does not match settlement amount ${settlement_ref.amount_usd:.4f}"
+        )
     cap = intent.spend_cap_usd
     if cap < 0:
         cap = 0.0
     prior = 0.0
     if ledger is not None:
         prior = ledger.totals_by("task").get(intent.task_id or "unknown", 0.0)
-    projected = prior + max(0.0, cart.amount_usd)
+    projected = prior + cart.amount_usd
     if projected > cap:
         raise MandateRefused(
             f"spend cap breach: task spend ${prior:.4f} + settlement ${cart.amount_usd:.4f} exceeds cap ${cap:.4f}"

--- a/tests/unit/test_mandate_cmd.py
+++ b/tests/unit/test_mandate_cmd.py
@@ -108,3 +108,88 @@ def test_revoke_then_verify_fails(project: Path) -> None:
     )
     assert verify.exit_code == 2, verify.output
     assert "revoked" in verify.output
+
+
+# ----------------------------------------- audit-chain mirror guards (#2641)
+
+
+def test_emit_warns_when_audit_mirror_fails(project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # The receipt is anchored in the lineage spine before the audit-chain
+    # mirror is written. A mirror-write failure must not raise post-anchor:
+    # the receipt is already committed. Emit a distinct WARNING naming the
+    # mandate hash and exit 0.
+    import bernstein.core.security.audit_chain as audit_chain
+
+    i_path, c_path, s_path, mandate_hash = _write_inputs(project)
+
+    def _boom(**_: object) -> None:
+        raise RuntimeError("audit chain unavailable")
+
+    monkeypatch.setattr(audit_chain, "record_mandate_consent_receipt", _boom)
+
+    emit = CliRunner().invoke(
+        mandate_group,
+        [
+            "emit",
+            "--intent",
+            str(i_path),
+            "--cart",
+            str(c_path),
+            "--settlement",
+            str(s_path),
+            "--no-sign",
+            "--workdir",
+            str(project),
+        ],
+    )
+    assert emit.exit_code == 0, emit.output
+    flat = emit.output.replace("\n", "")
+    assert "WARNING" in flat
+    assert mandate_hash in flat
+    # The receipt was still anchored despite the mirror failure.
+    assert "consent receipt anchored" in emit.output
+
+
+def test_revoke_warns_when_audit_mirror_fails(project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Revocation is committed to the append-only ledger before the audit-chain
+    # mirror. A mirror-write failure must not raise after the revocation is
+    # already persisted: warn distinctly (naming the mandate hash) and exit 0.
+    import bernstein.core.security.audit_chain as audit_chain
+    from bernstein.core.protocols.payments.mandates import revocation_path
+
+    i_path, c_path, s_path, mandate_hash = _write_inputs(project)
+    runner = CliRunner()
+    emit = runner.invoke(
+        mandate_group,
+        [
+            "emit",
+            "--intent",
+            str(i_path),
+            "--cart",
+            str(c_path),
+            "--settlement",
+            str(s_path),
+            "--no-sign",
+            "--workdir",
+            str(project),
+        ],
+    )
+    assert emit.exit_code == 0, emit.output
+
+    def _boom(**_: object) -> None:
+        raise RuntimeError("audit chain unavailable")
+
+    monkeypatch.setattr(audit_chain, "record_mandate_revocation", _boom)
+
+    revoke = runner.invoke(
+        mandate_group,
+        ["revoke", mandate_hash, "--reason", "budget change", "--workdir", str(project)],
+    )
+    assert revoke.exit_code == 0, revoke.output
+    flat = revoke.output.replace("\n", "")
+    assert "WARNING" in flat
+    assert mandate_hash in flat
+    # The revocation was committed to the append-only ledger despite the failure.
+    ledger = revocation_path(project)
+    assert ledger.is_file()
+    assert mandate_hash in ledger.read_text(encoding="utf-8")

--- a/tests/unit/test_payment_mandates.py
+++ b/tests/unit/test_payment_mandates.py
@@ -262,6 +262,72 @@ def test_spend_cap_within_bound_allowed(tmp_path: Path) -> None:
     assert receipt.journal_entry_hash
 
 
+# ------------------------------------------------- AC4 hardening (issue #2641)
+
+
+def test_emit_refuses_settlement_amount_mismatch(tmp_path: Path) -> None:
+    # The cap is enforced on the cart amount, but the receipt binds the
+    # settlement reference's own amount. If the two can diverge, a cart passes
+    # a small amount through the cap while the receipt settles a larger one.
+    # Require them to agree so the checked value is the value bound.
+    intent, cart = _signed_pair(_KEY, cap=10.0, amount=5.0)
+    with pytest.raises(MandateRefused, match="does not match settlement"):
+        emit_consent_receipt(
+            workdir=tmp_path,
+            lineage_root=tmp_path / ".sdd" / "lineage",
+            hmac_key=_KEY,
+            intent=intent,
+            cart=cart,
+            settlement_ref=_settlement(amount=50.0),
+            now=1000,
+        )
+
+
+def test_emit_refuses_negative_amount(tmp_path: Path) -> None:
+    # A negative amount was previously clamped to 0, so it slipped past the cap
+    # and could mask real spend from the ledger rollup. Refuse it outright.
+    intent, cart = _signed_pair(_KEY, cap=10.0, amount=-1.0)
+    with pytest.raises(MandateRefused, match="negative settlement amount"):
+        emit_consent_receipt(
+            workdir=tmp_path,
+            lineage_root=tmp_path / ".sdd" / "lineage",
+            hmac_key=_KEY,
+            intent=intent,
+            cart=cart,
+            settlement_ref=_settlement(amount=-1.0),
+            now=1000,
+        )
+
+
+def test_verify_tolerates_legacy_amount_mismatch(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Backward compatibility: a receipt anchored before the emit-time amount
+    # guard existed (cart amount != settlement amount) must still verify. The
+    # guard lives on emit only; verify never checks the amount, so an
+    # already-signed receipt stays valid.
+    import bernstein.core.protocols.payments.mandates as mandates_mod
+
+    intent, cart = _signed_pair(_KEY, cap=100.0, amount=5.0)
+    monkeypatch.setattr(mandates_mod, "_enforce_spend_cap", lambda **_: None)
+    receipt = emit_consent_receipt(
+        workdir=tmp_path,
+        lineage_root=tmp_path / ".sdd" / "lineage",
+        hmac_key=_KEY,
+        intent=intent,
+        cart=cart,
+        settlement_ref=_settlement(amount=50.0),
+        now=1000,
+    )
+    result = verify_consent_receipt(
+        workdir=tmp_path,
+        lineage_root=tmp_path / ".sdd" / "lineage",
+        hmac_key=_KEY,
+        mandate_hash=receipt.mandate_hash,
+        intent=intent,
+        cart=cart,
+    )
+    assert result.ok, result.reason
+
+
 # --------------------------------------------------------------------------- AC5
 
 


### PR DESCRIPTION
## What
Hardened the payment-mandate surface (src/bernstein/core/protocols/payments/mandates.py + src/bernstein/cli/commands/mandate_cmd.py) per all 3 acceptance criteria. All 3 were genuine gaps on current main (staleness cross-checked). TDD each: red captured, implemented, green. Backward compatibility preserved — verification path untouched, so receipts/mandates signed before this change still verify. 3 conventional commits (Refs #2641, no closing keywords), pushed. No PR opened. No workflow/pyproject/uv.lock touched.

Fixes #2641

## Items
- **AC1 (security): spend cap enforced on cart amount while receipt binds an independent, unchecked sett** — fixed: _enforce_spend_cap now takes settlement_ref: rejects cart.amount_usd<0 or settlement_ref.amount_usd<0 with MandateRefused (no more max(0.0,...) clamp)
- **AC2 (data-integrity): consent-receipt audit-chain mirror unguarded; receipt anchored without matchin** — fixed: record_mandate_consent_receipt wrapped in try/except; on failure prints a distinct WARNING including receipt.mandate_hash and the failure reason (soft
- **AC3 (data-integrity): revocation persisted before an unguarded audit-chain mirror write (mandate_cmd** — fixed: record_mandate_revocation wrapped in try/except; on failure prints a distinct WARNING including entry.mandate_hash and exits 0 since the signed revoca

## Verification
Adversarial review: **confirmed, 0 critical**. Backward compatibility of already-signed artefacts verified (a token/mandate/receipt signed before this change still verifies).
TDD red then green, targeted files only (never full suite). RED (unmodified source): `uv run pytest tests/unit/test_payment_mandates.py -k "settlement_amount_mismatch or negative_amount or legacy_amount_mismatch"` -> 2 failed (DID NOT RAISE MandateRefused), 1 passed (legacy backward-compat guard). `... test_mandate_cmd.py -k audit_mirror` -> 2 failed (assert 1==0, exit_code from unguarded RuntimeError). GREEN (final): `uv run pytest tests/unit/te


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stricter spending-cap validation by rejecting negative amounts and mismatches between cart and settlement amounts.
  * Mandate emit and revoke operations now complete successfully when audit-log mirroring fails, while displaying a warning with the mandate hash and failure reason.

* **Documentation**
  * Clarified spending-cap enforcement, negative amount handling, and audit-log mirror failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->