### PR TITLE
feat(cost): x402 settlement hook for metered MCP gateway calls with chained spend receipts

### DIFF
--- a/docs/operations/spending-mandates.md
+++ b/docs/operations/spending-mandates.md
@@ -58,3 +58,12 @@ gate).
 | `.sdd/mandates/revocations.jsonl` | Append-only signed revocation ledger. |
 | `.sdd/lineage/mandates/spine.jsonl` | The lineage spine anchoring every receipt. |
 | `.sdd/audit/` | The HMAC audit chain carrying the mirrored events. |
+
+## Metered gateway settlement (x402)
+
+The HTTP 402 pay-and-retry reference above becomes an executed flow at the MCP
+gateway: on a 402 from an upstream tool the gateway gates the call against an
+intent, invokes an operator settlement hook, retries, and emits a spend receipt
+that chains the payment to the exact WAL invocation it paid for. That path is
+disabled by default and documented in
+[`x402-settlement.md`](./x402-settlement.md).

--- a/docs/operations/x402-settlement.md
+++ b/docs/operations/x402-settlement.md
@@ -1,0 +1,126 @@
+# x402 settlement for metered MCP gateway calls
+
+When an upstream MCP server answers a proxied tool call with an HTTP **402**
+challenge (the x402 pay-and-retry pattern), the gateway can settle the charge
+under a signed spending mandate and record a **spend receipt** that ties the
+payment to the exact executed invocation it paid for. Bernstein never moves
+money itself: the settlement hook is the single boundary where your own payment
+tooling plugs in.
+
+The path is **disabled by default**. With no active x402 config a 402 surfaces
+as an ordinary tool error - no hook is looked up and no retry is sent.
+
+Module: `src/bernstein/core/protocols/payments/x402.py`. It is the concrete x402
+adapter over the mandate / consent-receipt surface documented in
+[`spending-mandates.md`](./spending-mandates.md).
+
+## What a settlement proves
+
+A spend receipt is not "a payment plus an audit line". Its identity is a
+lineage-spine entry hash, and its bindings recompute offline against two
+independent records:
+
+| Binding | Proves |
+|---|---|
+| WAL invocation record digest | *which executed tool call* the charge paid for |
+| 402 challenge digest | the challenge that was answered |
+| Payment reference | the (opaque, non-secret) settlement id |
+| Retried request digest | the exact request that was replayed after payment |
+| Mandate hash | the spend was inside a signed, capped authority |
+
+A payment claim that does not chain to **both** the WAL invocation record and
+the authorising mandate fails verification. A provider's statement is therefore
+checkable against gateway execution history rather than taken on trust.
+
+## Flow
+
+On a 402 during a proxied `tools/call`, with an active config the gateway:
+
+1. **Gates** the call against the active `IntentMandate` - refusing **fail
+   closed** when no mandate authorizes the tool, the spend cap would be
+   breached, or the amount cannot be determined. A refusal is itself a
+   chain-anchored receipt (`.sdd/x402/refusals/`), so a denial is as provable as
+   a payment.
+2. **Invokes** the settlement hook *only after* the mandate and cap pass. The
+   hook returns a payment reference or declines.
+3. **Retries** the call with the payment reference injected.
+4. **Records** the settled invocation to the WAL and emits a spend receipt
+   binding the five hashes above, flushes the settled amount into the per-server
+   cost meter (so `bernstein cost` rollups include it, tagged with the server
+   name), and mirrors an `x402.settlement` event into the audit chain.
+
+Replay mode serves the recorded settled response **without invoking the hook**,
+so a replay can never double-settle.
+
+## The settlement hook
+
+A hook is any object with a `settle` method (or a plain callable wrapped in
+`CallableSettlementHook`, or an operator command wrapped in
+`CommandSettlementHook`). `amount_usd` is the amount Bernstein authorized from
+the challenge and the mandate - never a value the hook chooses.
+
+Example no-op hook (records intent, never actually pays - useful for a dry run):
+
+```python
+from bernstein.core.protocols.payments.x402 import (
+    CallableSettlementHook,
+    X402Config,
+    X402Challenge,
+)
+
+
+def no_op_settle(challenge: X402Challenge, server: str, tool: str, amount_usd: float) -> str | None:
+    # A real hook would call your payment rail here and return its reference.
+    # This no-op declines every challenge, so nothing is ever settled.
+    return None
+
+
+config = X402Config(enabled=True, hook=CallableSettlementHook(no_op_settle))
+```
+
+To actually settle, return an opaque payment reference string instead of
+`None`. Because the no-op declines, the original 402 surfaces unchanged - a safe
+way to wire the path and watch refusal receipts accumulate before enabling real
+payment.
+
+An operator command hook reads a JSON request on stdin and prints
+`{"payment_ref": "..."}` (or a null / non-zero exit to decline):
+
+```python
+from bernstein.core.protocols.payments.x402 import CommandSettlementHook, X402Config
+
+config = X402Config(enabled=True, hook=CommandSettlementHook(argv=("./settle-x402.sh",)))
+```
+
+Bernstein only reads the opaque `payment_ref` from the hook - never a credential.
+
+## Amounts
+
+x402 challenges carry `maxAmountRequired` in atomic units of an arbitrary asset.
+Converting that to USD needs the asset's decimals and a rate Bernstein does not
+invent. A challenge that includes an explicit `amountUsd` is used directly;
+otherwise supply a `price_resolver` on `X402Config`. When no USD figure can be
+determined the settlement refuses honestly rather than guessing.
+
+## CLI
+
+```
+bernstein gateway settlements                              # list recorded spend receipts
+bernstein mandate verify-settlement <receipt_hash> --intent i.json
+```
+
+`verify-settlement` recomputes the receipt against its spine anchor, the settled
+WAL invocation record, and the authorising consent receipt. Exit codes: `0`
+verified, `1` no receipt / bad input, `2` mismatch (a mutated amount, challenge
+digest, or invocation digest).
+
+## On-disk layout
+
+| Path | Contents |
+|---|---|
+| `.sdd/x402/settlements/<receipt_hash>.json` | The spend receipt binding + its anchor. |
+| `.sdd/x402/refusals/<receipt_hash>.json` | Fail-closed refusal receipts. |
+| `.sdd/lineage/x402-settlements/spine.jsonl` | The lineage spine anchoring every settlement / refusal. |
+| `.sdd/mandates/receipts/<mandate_hash>.json` | The consent receipt each settlement was authorized under. |
+| `.sdd/audit/` | The HMAC audit chain carrying `x402.settlement` / `x402.settlement_refused` events. |
+| `.sdd/cost/ledger.jsonl` | Settled amounts, tagged with the server name alongside metered spend. |

--- a/src/bernstein/cli/commands/gateway_cmd.py
+++ b/src/bernstein/cli/commands/gateway_cmd.py
@@ -166,6 +166,48 @@ def replay_cmd(run_id: str, transport: str, port: int) -> None:
 
 
 # ---------------------------------------------------------------------------
+# gateway settlements
+# ---------------------------------------------------------------------------
+
+
+@gateway_group.command("settlements")
+@click.option(
+    "--workdir",
+    "-w",
+    type=click.Path(file_okay=False, exists=True),
+    default=".",
+    show_default=True,
+    help="Project root containing .sdd/.",
+)
+def settlements_cmd(workdir: str) -> None:
+    """List recorded x402 settlements (issue #2528).
+
+    Each row is a chain-anchored spend receipt binding a settled upstream tool
+    call to the WAL invocation it paid for. Verify one offline with
+    ``bernstein mandate verify-settlement <hash> --intent <file>``.
+    """
+    from bernstein.core.protocols.payments.x402 import iter_spend_receipts
+
+    root = Path(workdir).resolve()
+    receipts = sorted(iter_spend_receipts(root), key=lambda r: (r.timestamp, r.server_name, r.tool_name))
+    if not receipts:
+        console.print("[dim]No x402 settlements recorded.[/dim]")
+        return
+
+    console.print()
+    console.print("[bold]x402 settlements[/bold]")
+    # One receipt per block, values on their own short lines so long hashes are
+    # never truncated and the output stays greppable when piped.
+    for r in receipts:
+        console.print(
+            f"[cyan]{r.receipt_hash()[:20]}[/cyan]  {r.server_name} / {r.tool_name}"
+            f"  ${r.settlement_ref.amount_usd:.4f}  wal_seq={r.wal_invocation_seq}"
+        )
+        console.print(f"  mandate {r.mandate_hash}")
+    console.print(f"[dim]{len(receipts)} settlement(s) under {root}/.sdd/x402/settlements[/dim]")
+
+
+# ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
 

--- a/src/bernstein/cli/commands/mandate_cmd.py
+++ b/src/bernstein/cli/commands/mandate_cmd.py
@@ -226,3 +226,54 @@ def mandate_revoke_cmd(mandate_hash: str, reason: str, workdir: str) -> None:
     console.print()
     console.print(f"[bold]Mandate revoke[/bold] hash={mandate_hash[:24]}")
     console.print("[green]OK[/green] -- signed revocation appended; further actions are refused.")
+
+
+@mandate_group.command("verify-settlement")
+@click.argument("receipt_hash", required=True)
+@click.option("--intent", "intent_file", required=True, type=click.Path(exists=True, dir_okay=False))
+@click.option(
+    "--workdir",
+    "-w",
+    type=click.Path(file_okay=False, exists=True),
+    default=".",
+    show_default=True,
+    help="Project root containing .sdd/.",
+)
+def mandate_verify_settlement_cmd(receipt_hash: str, intent_file: str, workdir: str) -> None:
+    """Prove an x402 spend receipt offline (issue #2528).
+
+    Recomputes the receipt against its spine anchor, the settled WAL invocation
+    record it paid for, and the authorising consent receipt, so a provider's
+    charge is checkable against gateway execution history rather than trusted.
+
+    Exit codes: 0 = verified, 1 = no receipt / bad input, 2 = mismatch.
+    """
+    from bernstein.core.protocols.payments.mandates import IntentMandate
+    from bernstein.core.protocols.payments.x402 import verify_spend_receipt
+
+    root = Path(workdir).resolve()
+    intent = IntentMandate.from_dict(_read_json(intent_file))
+
+    result = verify_spend_receipt(
+        workdir=root,
+        lineage_root=_lineage_root(root),
+        hmac_key=_load_hmac_key(),
+        wal_sdd_dir=root / ".sdd",
+        spend_receipt_hash=receipt_hash,
+        intent=intent,
+    )
+    console.print()
+    console.print(f"[bold]Settlement verify[/bold] hash={receipt_hash[:24]}")
+    if result.ok:
+        assert result.receipt is not None
+        console.print(f"  server           {result.receipt.server_name}")
+        console.print(f"  tool             {result.receipt.tool_name}")
+        console.print(f"  amount_usd       {result.receipt.settlement_ref.amount_usd}")
+        console.print(f"  wal_invocation   {result.receipt.wal_invocation_digest[:24]}")
+        console.print("[green]OK[/green] -- settlement chains to the WAL invocation and the mandate.")
+        raise SystemExit(0)
+    if result.receipt is None:
+        console.print(f"[yellow]NO RECEIPT[/yellow] -- {result.reason}")
+        raise SystemExit(1)
+    console.print(f"[red]MISMATCH[/red] -- {result.reason}")
+    raise SystemExit(2)

--- a/src/bernstein/core/protocols/mcp/mcp_gateway.py
+++ b/src/bernstein/core/protocols/mcp/mcp_gateway.py
@@ -38,9 +38,10 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from bernstein.core.protocols.payments.x402 import X402SettlementCoordinator
     from bernstein.core.replay.journal import EventJournal
     from bernstein.core.security.audit_chain import AuditChainStore
-    from bernstein.core.wal import WALWriter
+    from bernstein.core.wal import WALEntry, WALWriter
 
 
 # ---------------------------------------------------------------------------
@@ -174,6 +175,7 @@ class MCPGateway:
         server_name: str = "unknown",
         journal: EventJournal | None = None,
         audit_chain: AuditChainStore | None = None,
+        settlement: X402SettlementCoordinator | None = None,
     ) -> None:
         self._upstream_cmd = upstream_cmd
         self._wal_writer = wal_writer
@@ -181,6 +183,12 @@ class MCPGateway:
         self._server_name = server_name.strip() or "unknown"
         self._journal = journal
         self._audit_chain = audit_chain
+        # x402 settlement coordinator (issue #2528). ``None`` keeps the gateway
+        # byte-identical to the pre-settlement proxy; a 402 then surfaces as an
+        # ordinary tool error. The coordinator gates against a spending mandate
+        # before any payment. The settlement seam lives on the live-proxy
+        # branch only, so replay can never invoke the hook or double-settle.
+        self._settlement = settlement
         self._metrics: dict[str, ToolMetrics] = {}
         self._proc: asyncio.subprocess.Process | None = None
         self._pending: dict[Any, asyncio.Future[dict[str, Any]]] = {}
@@ -269,11 +277,16 @@ class MCPGateway:
 
     def _record_wal_and_metrics(
         self, method: str, params: dict[str, Any], req_id: Any, response: dict[str, Any], latency_ms: float
-    ) -> None:
-        """Write WAL record and update per-tool metrics."""
+    ) -> WALEntry:
+        """Write WAL record and update per-tool metrics; return the WAL entry.
+
+        The returned entry's ``entry_hash`` is the WAL invocation digest an
+        x402 spend receipt binds (issue #2528), so a settlement is provably
+        tied to the exact recorded call it paid for.
+        """
         tool_name = str(params.get("name", "")) if method == "tools/call" else ""
         has_error = response.get("error") is not None
-        self._wal_writer.append(
+        entry = self._wal_writer.append(
             decision_type="mcp_tool_call",
             inputs={
                 "method": method,
@@ -293,6 +306,7 @@ class MCPGateway:
         if metric_key not in self._metrics:
             self._metrics[metric_key] = ToolMetrics(tool_name=metric_key)
         self._metrics[metric_key].record(latency_ms, error=has_error)
+        return entry
 
     async def handle_jsonrpc(self, message: dict[str, Any]) -> dict[str, Any] | None:
         """Handle one JSON-RPC message, recording to WAL.
@@ -316,6 +330,22 @@ class MCPGateway:
                 await self._send_upstream(message)
             return None
 
+        response, latency_ms = await self._send_request(message, req_id)
+        self._record_wal_and_metrics(method, params, req_id, response, latency_ms)
+        self._anchor_proxied_call(method, params)
+
+        if self._settlement is not None and method == "tools/call":
+            response = await self._maybe_settle(message, params, response)
+
+        return response
+
+    async def _send_request(self, message: dict[str, Any], req_id: Any) -> tuple[dict[str, Any], float]:
+        """Send one JSON-RPC request upstream and await its response.
+
+        Returns the response and the round-trip latency in milliseconds. The
+        pending-future dance is factored out here so the x402 retry (issue
+        #2528) reuses the identical send/await path as the original call.
+        """
         fut: asyncio.Future[dict[str, Any]] = asyncio.get_running_loop().create_future()
         self._pending[req_id] = fut
         t0 = time.monotonic()
@@ -324,12 +354,65 @@ class MCPGateway:
             response: dict[str, Any] = await asyncio.wait_for(asyncio.shield(fut), timeout=30.0)
         finally:
             self._pending.pop(req_id, None)
+        return response, (time.monotonic() - t0) * 1000.0
 
-        latency_ms = (time.monotonic() - t0) * 1000.0
-        self._record_wal_and_metrics(method, params, req_id, response, latency_ms)
-        self._anchor_proxied_call(method, params)
+    async def _maybe_settle(
+        self, message: dict[str, Any], params: dict[str, Any], response: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Run the x402 settlement flow when a proxied call answers with a 402.
 
-        return response
+        Detects an x402 challenge, gates it against the active spending mandate,
+        invokes the operator settlement hook, retries the call with the payment
+        reference, records the retried invocation to the WAL, and emits a
+        chain-anchored spend receipt binding the WAL invocation digest, the
+        challenge, the payment reference, the retried request, and the mandate.
+
+        A non-402 response, a disabled config, or a refused/declined settlement
+        returns the original response unchanged -- so the 402 surfaces as an
+        ordinary tool error and Bernstein never pays outside a mandate.
+        """
+        from bernstein.core.protocols.payments.x402 import (
+            SettlementStatus,
+            build_retry_request,
+            parse_challenge,
+        )
+
+        assert self._settlement is not None
+        challenge = parse_challenge(response)
+        if challenge is None:
+            return response
+
+        tool_name = str(params.get("name", ""))
+        pre = self._settlement.pre_authorize(challenge, server_name=self._server_name, tool_name=tool_name)
+        if pre.status is not SettlementStatus.AUTHORIZED or not pre.payment_ref:
+            # SKIPPED (disabled) or REFUSED (fail closed): the original 402
+            # surfaces as an ordinary tool error; a refusal is already anchored.
+            return response
+
+        retried = build_retry_request(message, pre.payment_ref)
+        retried_id = retried.get("id")
+        retried_params: dict[str, Any] = retried.get("params") or {}
+        settled, latency_ms = await self._send_request(retried, retried_id)
+        wal_entry = self._record_wal_and_metrics("tools/call", retried_params, retried_id, settled, latency_ms)
+        self._anchor_proxied_call("tools/call", retried_params)
+
+        try:
+            self._settlement.record_settlement(
+                challenge,
+                server_name=self._server_name,
+                tool_name=tool_name,
+                payment_ref=pre.payment_ref,
+                amount_usd=pre.amount_usd,
+                retried_request=retried,
+                wal_entry=wal_entry,
+            )
+        except Exception:
+            # A recording failure must not swallow the settled response the
+            # operator already paid for; it surfaces in the log and as a
+            # missing receipt a verifier can detect.
+            logger.exception("x402: failed to record settlement receipt for %s", tool_name)
+
+        return settled
 
     def _anchor_proxied_call(self, method: str, params: dict[str, Any]) -> None:
         """Anchor a proxied call into the run journal and audit chain.

--- a/src/bernstein/core/protocols/payments/x402.py
+++ b/src/bernstein/core/protocols/payments/x402.py
@@ -1,0 +1,1101 @@
+"""x402 settlement hook for metered MCP gateway calls (issue #2528).
+
+When an upstream MCP server answers a proxied tool call with an HTTP 402
+challenge (the x402 pay-and-retry pattern), the gateway has, until now, no
+settlement path: the 402 surfaces as an ordinary tool error and no record ties
+a payment to the exact invocation it paid for. This module is the concrete
+x402 adapter over the AP2 mandate / consent-receipt surface
+(:mod:`bernstein.core.protocols.payments.mandates`). Bernstein never executes a
+payment itself; the settlement hook is the single boundary where the operator's
+own payment tooling plugs in.
+
+Design (the artefact IS the proof)
+----------------------------------
+A settlement is not "a payment plus an audit line". The primary artefact is a
+:class:`SpendReceipt` whose identity is a lineage-spine entry hash and whose
+bindings recompute offline against two independent records:
+
+* the **WAL invocation record** of the exact proxied (retried) tool call --
+  proving *which executed call* the charge paid for; and
+* the **consent receipt** the settlement was authorized under -- proving the
+  spend was inside a signed :class:`IntentMandate` bound
+  (:func:`verify_consent_receipt`).
+
+A payment claim that does not chain to *both* fails :func:`verify_spend_receipt`.
+Mutating the recorded amount, the 402 challenge digest, or the WAL invocation
+digest breaks the recompute -- so a provider statement is checkable against
+gateway execution history rather than taken on trust. Strip the spine, the WAL,
+or the mandate and the receipt loses its meaning, not just its log.
+
+Default off
+-----------
+:class:`X402Config` gates the whole path and defaults to disabled. With no
+active config a 402 surfaces unchanged (no hook lookup, no retry). The gateway
+never double-settles under replay: replay serves the recorded settled response
+without reaching this module (the settlement seam is on the live-proxy branch
+only).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import subprocess
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+from bernstein.core.lineage.spine import LineageSpine, content_hash_of
+from bernstein.core.protocols.payments.mandates import (
+    CartMandate,
+    ConsentReceipt,
+    IntentMandate,
+    SettlementRef,
+    authorized_action_set,
+    emit_consent_receipt,
+    read_consent_receipt,
+    verify_consent_receipt,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+    from pathlib import Path
+
+    from bernstein.core.cost.mcp_server_cost import MCPServerCostMeter
+    from bernstein.core.persistence.wal import WALEntry
+    from bernstein.core.security.audit_chain import AuditChainStore
+
+logger = logging.getLogger(__name__)
+
+#: Version stamped into every spend / refusal receipt preimage. Bump only on a
+#: wire-format change.
+X402_SCHEMA_VERSION = 1
+
+#: Dedicated lineage run under which x402 spend and refusal receipts are
+#: anchored, kept separate from the mandate spine so settlement lineage never
+#: interleaves with consent-receipt lineage.
+X402_SETTLEMENT_RUN_ID = "x402-settlements"
+
+#: Audit-chain event types mirrored for a settled / refused settlement. Only
+#: hashes, the server name, and the (public, non-secret) amount are recorded --
+#: never a payment credential.
+EVENT_X402_SETTLEMENT = "x402.settlement"
+EVENT_X402_SETTLEMENT_REFUSED = "x402.settlement_refused"
+
+#: Reserved params key under which the payment reference is injected into the
+#: retried JSON-RPC request.
+X402_PAYMENT_KEY = "_x402_payment"
+
+_SETTLEMENT_SUBPATH = (".sdd", "x402", "settlements")
+_REFUSAL_SUBPATH = (".sdd", "x402", "refusals")
+
+_MANDATE_ACTOR = "x402_gateway"
+_MANDATE_MODEL = "none"
+
+
+# ---------------------------------------------------------------------------
+# Canonical helpers
+# ---------------------------------------------------------------------------
+
+
+def _canonical_bytes(payload: dict[str, Any]) -> bytes:
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def _sha256(payload: dict[str, Any]) -> str:
+    return "sha256:" + hashlib.sha256(_canonical_bytes(payload)).hexdigest()
+
+
+def settlement_ref_hash(ref: SettlementRef) -> str:
+    """Return the content digest of a :class:`SettlementRef` (audit-chain input)."""
+    return _sha256(ref.to_dict())
+
+
+def _safe_hash_name(receipt_hash: str) -> str:
+    """Return a filesystem-safe basename for a ``sha256:<hex>`` receipt hash."""
+    if not receipt_hash:
+        raise ValueError("empty receipt_hash")
+    if "/" in receipt_hash or "\\" in receipt_hash or "\x00" in receipt_hash:
+        raise ValueError(f"receipt_hash contains an unsafe character: {receipt_hash!r}")
+    return receipt_hash.replace(":", "_")
+
+
+# ---------------------------------------------------------------------------
+# X402Challenge -- parsed 402 challenge
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class X402Challenge:
+    """A parsed HTTP 402 (x402) challenge extracted from a proxied response.
+
+    ``raw`` is the canonical challenge payload the digest is computed over --
+    either the ``x402Version``/``accepts`` object or, when the upstream only
+    signals a bare ``402`` code, the JSON-RPC error object.
+
+    Attributes:
+        raw: The dict the challenge digest is bound to.
+        x402_version: The advertised x402 protocol version (``0`` when absent).
+        accepts: The advertised payment options (may be empty).
+    """
+
+    raw: dict[str, Any]
+    x402_version: int = 0
+    accepts: tuple[dict[str, Any], ...] = ()
+
+    def challenge_hash(self) -> str:
+        """Return the ``sha256:`` digest of the canonical challenge body."""
+        return _sha256(self.raw)
+
+    def _first_accept(self) -> dict[str, Any]:
+        return self.accepts[0] if self.accepts else {}
+
+    def max_amount_required(self) -> str:
+        """Return the advertised ``maxAmountRequired`` atomic string (or ``""``)."""
+        return str(self._first_accept().get("maxAmountRequired", ""))
+
+    def resource(self) -> str:
+        """Return the advertised protected resource identifier (or ``""``)."""
+        return str(self._first_accept().get("resource", ""))
+
+    def scheme(self) -> str:
+        """Return the advertised payment scheme (or ``""``)."""
+        return str(self._first_accept().get("scheme", ""))
+
+    def resolved_amount_usd(self) -> float | None:
+        """Return an explicit USD price when the challenge states one.
+
+        x402 challenges carry ``maxAmountRequired`` in atomic units of an
+        arbitrary asset; converting that to USD needs the asset's decimals and
+        a rate Bernstein does not invent. When the upstream includes an
+        explicit ``amountUsd`` (some servers do) it is used; otherwise the
+        operator must supply a price resolver via :class:`X402Config`. Returns
+        ``None`` when no USD figure can be determined -- settlement then refuses
+        honestly rather than guessing.
+        """
+        raw_amount = self._first_accept().get("amountUsd")
+        if raw_amount is None:
+            return None
+        try:
+            return float(raw_amount)
+        except (TypeError, ValueError):
+            return None
+
+
+def _extract_challenge_payload(response: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the x402 challenge payload carried by *response*, or ``None``.
+
+    Recognises the challenge in an ``error`` object (``code == 402`` or a
+    ``data``/body carrying ``x402Version``/``accepts``) and in a ``result``
+    that wraps an x402 body. An ordinary success or a non-402 error is not a
+    challenge.
+    """
+    error = response.get("error")
+    if isinstance(error, dict):
+        data = error.get("data")
+        if isinstance(data, dict) and _looks_like_x402(data):
+            return data
+        if _http_status(error) == 402 or error.get("code") == 402:
+            return data if isinstance(data, dict) and data else error
+    result = response.get("result")
+    if isinstance(result, dict) and _looks_like_x402(result):
+        return result
+    return None
+
+
+def _looks_like_x402(payload: dict[str, Any]) -> bool:
+    return "x402Version" in payload or "accepts" in payload
+
+
+def _http_status(error: dict[str, Any]) -> int | None:
+    data = error.get("data")
+    if isinstance(data, dict):
+        status = data.get("http_status") or data.get("httpStatus") or data.get("status")
+        if isinstance(status, int):
+            return status
+    return None
+
+
+def parse_challenge(response: dict[str, Any]) -> X402Challenge | None:
+    """Parse a JSON-RPC *response* into an :class:`X402Challenge`, or ``None``.
+
+    ``None`` means "not a 402 challenge" -- the caller returns the response
+    unchanged. Detection is deliberately structural (a 402 code or an x402
+    body); it never performs a network read.
+    """
+    if not isinstance(response, dict):
+        return None
+    payload = _extract_challenge_payload(response)
+    if payload is None:
+        return None
+    accepts_raw = payload.get("accepts")
+    accepts: tuple[dict[str, Any], ...] = (
+        tuple(a for a in accepts_raw if isinstance(a, dict)) if isinstance(accepts_raw, list) else ()
+    )
+    try:
+        version = int(payload.get("x402Version", 0))
+    except (TypeError, ValueError):
+        version = 0
+    return X402Challenge(raw=payload, x402_version=version, accepts=accepts)
+
+
+def build_retry_request(message: dict[str, Any], payment_ref: str) -> dict[str, Any]:
+    """Return a copy of *message* with *payment_ref* injected into its params.
+
+    The payment reference lands under :data:`X402_PAYMENT_KEY` inside the tool
+    arguments so the upstream can settle the retried call. The original message
+    is not mutated -- the retried-request digest binds this exact copy.
+    """
+    retried = json.loads(json.dumps(message))  # deep copy via canonical round-trip
+    params = retried.setdefault("params", {})
+    if not isinstance(params, dict):
+        params = {}
+        retried["params"] = params
+    arguments = params.setdefault("arguments", {})
+    if not isinstance(arguments, dict):
+        arguments = {}
+        params["arguments"] = arguments
+    arguments[X402_PAYMENT_KEY] = {"payment_ref": payment_ref}
+    return retried
+
+
+def retried_request_hash(retried: dict[str, Any]) -> str:
+    """Return the content digest of a retried request payload."""
+    return _sha256(retried)
+
+
+# ---------------------------------------------------------------------------
+# Settlement hook -- the operator's payment boundary
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class SettlementHook(Protocol):
+    """The operator-registered boundary that settles a 402 challenge.
+
+    Bernstein calls :meth:`settle` after it has confirmed the spend is inside a
+    signed mandate and under its cap. The hook executes the operator's own
+    payment and returns an opaque, non-secret payment reference -- or ``None``
+    to decline, which surfaces the original 402 as an ordinary tool error.
+
+    ``amount_usd`` is the amount Bernstein authorized (derived from the
+    challenge / mandate), never a value the hook is free to change.
+    """
+
+    def settle(self, challenge: X402Challenge, *, server_name: str, tool_name: str, amount_usd: float) -> str | None:
+        """Return a payment reference for *challenge*, or ``None`` to decline."""
+        ...
+
+
+@dataclass(frozen=True)
+class CallableSettlementHook:
+    """Adapt a plain callable into a :class:`SettlementHook`."""
+
+    fn: Callable[[X402Challenge, str, str, float], str | None]
+
+    def settle(self, challenge: X402Challenge, *, server_name: str, tool_name: str, amount_usd: float) -> str | None:
+        return self.fn(challenge, server_name, tool_name, amount_usd)
+
+
+@dataclass(frozen=True)
+class CommandSettlementHook:
+    """Settle by invoking an operator command.
+
+    The command receives the challenge, server, tool, and authorized amount as
+    a JSON object on stdin and must print ``{"payment_ref": "..."}`` on stdout
+    to settle, or exit non-zero / print ``{"payment_ref": null}`` to decline.
+    Bernstein never parses a credential out of the command; only the opaque
+    reference is read.
+    """
+
+    argv: tuple[str, ...]
+    timeout_s: float = 30.0
+
+    def settle(self, challenge: X402Challenge, *, server_name: str, tool_name: str, amount_usd: float) -> str | None:
+        request = json.dumps(
+            {
+                "challenge": challenge.raw,
+                "server_name": server_name,
+                "tool_name": tool_name,
+                "amount_usd": amount_usd,
+            }
+        )
+        try:
+            proc = subprocess.run(
+                list(self.argv),
+                input=request,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout_s,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            logger.warning("x402 settlement command failed to run: %s", exc)
+            return None
+        if proc.returncode != 0:
+            logger.warning("x402 settlement command declined (exit %s)", proc.returncode)
+            return None
+        try:
+            parsed = json.loads(proc.stdout or "{}")
+        except json.JSONDecodeError:
+            logger.warning("x402 settlement command produced non-JSON output")
+            return None
+        ref = parsed.get("payment_ref")
+        return str(ref) if ref else None
+
+
+# ---------------------------------------------------------------------------
+# Config gate -- default off
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class X402Config:
+    """The x402 settlement gate. Disabled by default.
+
+    Attributes:
+        enabled: Master switch. When ``False`` the settlement path is inert.
+        hook: The operator settlement boundary. Required for an active config.
+        max_settlement_usd: Optional extra ceiling applied per settlement on
+            top of the mandate cap (``0`` disables the extra guard).
+        price_resolver: Optional operator callback that maps a challenge to a
+            USD amount when the challenge carries no explicit ``amountUsd``.
+    """
+
+    enabled: bool = False
+    hook: SettlementHook | None = None
+    max_settlement_usd: float = 0.0
+    price_resolver: Callable[[X402Challenge], float | None] | None = None
+
+    def is_active(self) -> bool:
+        """Return whether the settlement path should run."""
+        return bool(self.enabled and self.hook is not None)
+
+    def resolve_amount(self, challenge: X402Challenge) -> float | None:
+        """Return the USD amount to authorize for *challenge*, or ``None``."""
+        if self.price_resolver is not None:
+            return self.price_resolver(challenge)
+        return challenge.resolved_amount_usd()
+
+
+# ---------------------------------------------------------------------------
+# SpendReceipt -- the primary settlement artefact
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SpendReceipt:
+    """A settled x402 charge, bound to its WAL invocation and its mandate.
+
+    Attributes:
+        server_name: Upstream MCP server the charge is attributed to.
+        tool_name: Tool call that was settled (the authorized action).
+        wal_run_id: WAL run the settled invocation was recorded in.
+        wal_invocation_seq: Sequence number of the settled invocation record.
+        wal_invocation_digest: ``entry_hash`` of that WAL record -- the exact
+            executed call the charge paid for.
+        mandate_hash: Cart-mandate hash of the authorising consent receipt.
+        intent_hash: Intent-mandate hash the cart was issued under.
+        settlement_ref: The x402 pay-and-retry reference (challenge digest,
+            payment reference, retried-request digest, settled amount).
+        consent_journal_entry_hash: Spine anchor of the consent receipt this
+            settlement was authorized under (cross-link into the mandate spine).
+        task_id: Task the settlement was attributed to.
+        timestamp: Integer timestamp; caller-chosen but stable.
+        journal_entry_hash: This receipt's own spine anchor -- its identity.
+    """
+
+    server_name: str
+    tool_name: str
+    wal_run_id: str
+    wal_invocation_seq: int
+    wal_invocation_digest: str
+    mandate_hash: str
+    intent_hash: str
+    settlement_ref: SettlementRef
+    consent_journal_entry_hash: str
+    task_id: str
+    timestamp: int
+    journal_entry_hash: str = ""
+
+    def _binding(self) -> dict[str, Any]:
+        """Return the anchored binding (everything except the anchor itself)."""
+        return {
+            "v": X402_SCHEMA_VERSION,
+            "server_name": self.server_name,
+            "tool_name": self.tool_name,
+            "wal_run_id": self.wal_run_id,
+            "wal_invocation_seq": self.wal_invocation_seq,
+            "wal_invocation_digest": self.wal_invocation_digest,
+            "mandate_hash": self.mandate_hash,
+            "intent_hash": self.intent_hash,
+            "settlement_ref": self.settlement_ref.to_dict(),
+            "consent_journal_entry_hash": self.consent_journal_entry_hash,
+            "task_id": self.task_id,
+            "timestamp": self.timestamp,
+        }
+
+    def to_canonical_bytes(self) -> bytes:
+        """Serialise the binding to canonical JSON bytes (spine-hashed)."""
+        return _canonical_bytes(self._binding())
+
+    def receipt_hash(self) -> str:
+        """Return the content hash of the binding (the receipt's file id)."""
+        return _sha256(self._binding())
+
+    def to_dict(self) -> dict[str, Any]:
+        return self._binding() | {"journal_entry_hash": self.journal_entry_hash}
+
+    @classmethod
+    def from_bytes(cls, raw: bytes) -> SpendReceipt:
+        row = json.loads(raw)
+        return cls(
+            server_name=str(row["server_name"]),
+            tool_name=str(row["tool_name"]),
+            wal_run_id=str(row["wal_run_id"]),
+            wal_invocation_seq=int(row["wal_invocation_seq"]),
+            wal_invocation_digest=str(row["wal_invocation_digest"]),
+            mandate_hash=str(row["mandate_hash"]),
+            intent_hash=str(row["intent_hash"]),
+            settlement_ref=SettlementRef.from_dict(row["settlement_ref"]),
+            consent_journal_entry_hash=str(row["consent_journal_entry_hash"]),
+            task_id=str(row["task_id"]),
+            timestamp=int(row["timestamp"]),
+            journal_entry_hash=str(row.get("journal_entry_hash", "")),
+        )
+
+
+@dataclass(frozen=True)
+class RefusalReceipt:
+    """A refused settlement, anchored so a denial is as provable as a payment.
+
+    Attributes:
+        server_name: Upstream MCP server the refused charge targeted.
+        tool_name: Tool call that was refused.
+        challenge_hash: Digest of the 402 challenge that was refused.
+        amount_usd: The amount that would have been settled (``0`` when
+            undeterminable).
+        reason: Human-readable, closed-vocabulary refusal reason.
+        mandate_hash: Cart-mandate hash when one applied (``""`` when no
+            mandate authorized the spend at all).
+        task_id: Task the refusal was attributed to.
+        timestamp: Integer timestamp.
+        journal_entry_hash: This receipt's own spine anchor.
+    """
+
+    server_name: str
+    tool_name: str
+    challenge_hash: str
+    amount_usd: float
+    reason: str
+    mandate_hash: str
+    task_id: str
+    timestamp: int
+    journal_entry_hash: str = ""
+
+    def _binding(self) -> dict[str, Any]:
+        return {
+            "v": X402_SCHEMA_VERSION,
+            "kind": "refusal",
+            "server_name": self.server_name,
+            "tool_name": self.tool_name,
+            "challenge_hash": self.challenge_hash,
+            "amount_usd": self.amount_usd,
+            "reason": self.reason,
+            "mandate_hash": self.mandate_hash,
+            "task_id": self.task_id,
+            "timestamp": self.timestamp,
+        }
+
+    def to_canonical_bytes(self) -> bytes:
+        return _canonical_bytes(self._binding())
+
+    def receipt_hash(self) -> str:
+        return _sha256(self._binding())
+
+    def to_dict(self) -> dict[str, Any]:
+        return self._binding() | {"journal_entry_hash": self.journal_entry_hash}
+
+    @classmethod
+    def from_bytes(cls, raw: bytes) -> RefusalReceipt:
+        row = json.loads(raw)
+        return cls(
+            server_name=str(row["server_name"]),
+            tool_name=str(row["tool_name"]),
+            challenge_hash=str(row["challenge_hash"]),
+            amount_usd=float(row.get("amount_usd", 0.0)),
+            reason=str(row["reason"]),
+            mandate_hash=str(row.get("mandate_hash", "")),
+            task_id=str(row["task_id"]),
+            timestamp=int(row["timestamp"]),
+            journal_entry_hash=str(row.get("journal_entry_hash", "")),
+        )
+
+
+# ---------------------------------------------------------------------------
+# On-disk paths
+# ---------------------------------------------------------------------------
+
+
+def spend_receipt_path(workdir: Path, receipt_hash: str) -> Path:
+    """Return the on-disk spend-receipt path for *receipt_hash*."""
+    return workdir.joinpath(*_SETTLEMENT_SUBPATH, f"{_safe_hash_name(receipt_hash)}.json")
+
+
+def refusal_receipt_path(workdir: Path, receipt_hash: str) -> Path:
+    """Return the on-disk refusal-receipt path for *receipt_hash*."""
+    return workdir.joinpath(*_REFUSAL_SUBPATH, f"{_safe_hash_name(receipt_hash)}.json")
+
+
+def read_spend_receipt(workdir: Path, receipt_hash: str) -> SpendReceipt | None:
+    """Return the spend receipt for *receipt_hash* or ``None`` if absent/malformed."""
+    path = spend_receipt_path(workdir, receipt_hash)
+    if not path.is_file():
+        return None
+    try:
+        return SpendReceipt.from_bytes(path.read_bytes())
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+        logger.warning("x402: malformed spend receipt at %s", path)
+        return None
+
+
+def iter_spend_receipts(workdir: Path) -> Iterator[SpendReceipt]:
+    """Yield every recorded spend receipt (unordered)."""
+    root = workdir.joinpath(*_SETTLEMENT_SUBPATH)
+    if not root.is_dir():
+        return
+    for path in sorted(root.glob("*.json")):
+        try:
+            yield SpendReceipt.from_bytes(path.read_bytes())
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+            logger.debug("x402: skipping malformed spend receipt at %s", path)
+            continue
+
+
+# ---------------------------------------------------------------------------
+# Settlement context + coordinator
+# ---------------------------------------------------------------------------
+
+
+class SettlementStatus(Enum):
+    """Outcome of :meth:`X402SettlementCoordinator.pre_authorize`."""
+
+    #: The config is inert -- no hook lookup, no retry (default off, AC1).
+    SKIPPED = "skipped"
+    #: A mandate/cap/hook gate refused; a chain-anchored refusal receipt was
+    #: emitted and the original 402 should surface as an ordinary error (AC2).
+    REFUSED = "refused"
+    #: The spend is authorized; the caller retries and calls
+    #: :meth:`X402SettlementCoordinator.record_settlement`.
+    AUTHORIZED = "authorized"
+
+
+@dataclass(frozen=True)
+class PreAuthResult:
+    """Result of the pre-payment gate."""
+
+    status: SettlementStatus
+    payment_ref: str | None = None
+    amount_usd: float = 0.0
+    reason: str = ""
+    refusal_receipt: RefusalReceipt | None = None
+
+
+@dataclass
+class SettlementContext:
+    """Everything the coordinator needs to gate, settle, and anchor.
+
+    Attributes:
+        config: The x402 gate (may be inert).
+        hmac_key: Audit-chain HMAC key that signs mandates and tags spine
+            entries.
+        workdir: Project root; receipts land under ``.sdd/x402/``.
+        lineage_root: Spine root (``.sdd/lineage``).
+        wal_sdd_dir: The ``.sdd`` dir the WAL lives under (for verification).
+        wal_run_id: WAL run id the proxied calls are recorded in.
+        intent: The active signed intent mandate (``None`` -> fail closed).
+        meter: Optional per-server cost meter to flush settled amounts into.
+        audit_chain: Optional audit chain to mirror settlement events into.
+        now: Clock returning an integer timestamp.
+    """
+
+    config: X402Config
+    hmac_key: bytes
+    workdir: Path
+    lineage_root: Path
+    wal_sdd_dir: Path
+    wal_run_id: str
+    intent: IntentMandate | None = None
+    meter: MCPServerCostMeter | None = None
+    audit_chain: AuditChainStore | None = None
+    now: Callable[[], int] = lambda: 0
+
+    @property
+    def task_id(self) -> str:
+        return self.intent.task_id if self.intent is not None else "unknown"
+
+
+class X402SettlementCoordinator:
+    """Gates, settles, and anchors x402 settlements over the mandate surface.
+
+    The coordinator holds no transport: the caller (the gateway) performs the
+    actual retry between :meth:`pre_authorize` and :meth:`record_settlement`.
+    This keeps every side effect that matters -- the mandate gate, the receipt,
+    the ledger flush -- pure and hermetically testable.
+    """
+
+    def __init__(self, context: SettlementContext) -> None:
+        self._ctx = context
+
+    # -- pre-payment gate ---------------------------------------------------
+
+    def pre_authorize(self, challenge: X402Challenge, *, server_name: str, tool_name: str) -> PreAuthResult:
+        """Gate a 402 challenge against the mandate and invoke the hook.
+
+        Returns :data:`SettlementStatus.SKIPPED` (do nothing) when the config
+        is inert, :data:`SettlementStatus.REFUSED` (fail closed, refusal
+        receipt anchored) when no mandate authorizes the spend / the cap is
+        breached / the hook declines / the amount is undeterminable, and
+        :data:`SettlementStatus.AUTHORIZED` with a payment reference otherwise.
+
+        The hook is never invoked -- and thus no payment is ever executed --
+        until the mandate gate and the spend cap have both passed.
+        """
+        ctx = self._ctx
+        if not ctx.config.is_active():
+            return PreAuthResult(status=SettlementStatus.SKIPPED, reason="x402 disabled")
+
+        amount = ctx.config.resolve_amount(challenge)
+        if amount is None:
+            return self._refuse(challenge, server_name, tool_name, 0.0, "amount undeterminable", "")
+        amount = max(0.0, float(amount))
+
+        intent = ctx.intent
+        if intent is None:
+            return self._refuse(challenge, server_name, tool_name, amount, "no active mandate", "")
+
+        cart = self._build_cart(intent, tool_name, amount)
+        authorized = authorized_action_set(
+            intent=intent,
+            cart=cart,
+            hmac_key=ctx.hmac_key,
+            now=ctx.now(),
+            workdir=ctx.workdir,
+        )
+        if tool_name not in authorized:
+            return self._refuse(
+                challenge, server_name, tool_name, amount, "no matching mandate authorizes this tool call", ""
+            )
+
+        breach = self._cap_breach(intent, amount)
+        if breach is not None:
+            return self._refuse(challenge, server_name, tool_name, amount, breach, cart.mandate_hash())
+
+        if ctx.config.max_settlement_usd > 0 and amount > ctx.config.max_settlement_usd:
+            return self._refuse(
+                challenge, server_name, tool_name, amount, "amount exceeds max_settlement_usd", cart.mandate_hash()
+            )
+
+        assert ctx.config.hook is not None  # is_active() guaranteed a hook
+        payment_ref = ctx.config.hook.settle(challenge, server_name=server_name, tool_name=tool_name, amount_usd=amount)
+        if not payment_ref:
+            return self._refuse(
+                challenge, server_name, tool_name, amount, "settlement hook declined", cart.mandate_hash()
+            )
+
+        return PreAuthResult(status=SettlementStatus.AUTHORIZED, payment_ref=payment_ref, amount_usd=amount)
+
+    # -- post-retry recording ----------------------------------------------
+
+    def record_settlement(
+        self,
+        challenge: X402Challenge,
+        *,
+        server_name: str,
+        tool_name: str,
+        payment_ref: str,
+        amount_usd: float,
+        retried_request: dict[str, Any],
+        wal_entry: WALEntry,
+    ) -> SpendReceipt:
+        """Bind the settled invocation into a chain-anchored spend receipt.
+
+        Reuses the consent-receipt machinery to prove the spend was authorized,
+        then anchors a :class:`SpendReceipt` binding the WAL invocation record
+        digest, the 402 challenge digest, the payment reference, the retried
+        request digest, and the mandate hash. Flushes the settled amount into
+        the per-server cost meter and mirrors a ``x402.settlement`` event into
+        the audit chain.
+        """
+        ctx = self._ctx
+        assert ctx.intent is not None  # AUTHORIZED implies an intent
+        intent = ctx.intent
+        cart = self._build_cart(intent, tool_name, amount_usd)
+        ref = SettlementRef(
+            challenge_hash=challenge.challenge_hash(),
+            payment_ref=payment_ref,
+            retried_request_hash=retried_request_hash(retried_request),
+            amount_usd=amount_usd,
+        )
+        now = ctx.now()
+        # The consent receipt re-gates and enforces the cap; a breach here
+        # raises MandateRefused rather than silently over-spending.
+        consent: ConsentReceipt = emit_consent_receipt(
+            workdir=ctx.workdir,
+            lineage_root=ctx.lineage_root,
+            hmac_key=ctx.hmac_key,
+            intent=intent,
+            cart=cart,
+            settlement_ref=ref,
+            now=now,
+            ledger=ctx.meter.ledger if ctx.meter is not None else None,
+        )
+
+        receipt = SpendReceipt(
+            server_name=server_name,
+            tool_name=tool_name,
+            wal_run_id=ctx.wal_run_id,
+            wal_invocation_seq=wal_entry.seq,
+            wal_invocation_digest=wal_entry.entry_hash,
+            mandate_hash=consent.mandate_hash,
+            intent_hash=consent.intent_hash,
+            settlement_ref=ref,
+            consent_journal_entry_hash=consent.journal_entry_hash,
+            task_id=intent.task_id,
+            timestamp=now,
+        )
+        anchored = self._anchor_spend_receipt(receipt, now)
+        self._flush_ledger(anchored)
+        self._mirror_settlement(anchored)
+        return anchored
+
+    # -- internals ----------------------------------------------------------
+
+    def _build_cart(self, intent: IntentMandate, tool_name: str, amount_usd: float) -> CartMandate:
+        return CartMandate(
+            intent_hash=intent.mandate_hash(),
+            tool_calls=(tool_name,),
+            amount_usd=amount_usd,
+        ).sign(self._ctx.hmac_key)
+
+    def _cap_breach(self, intent: IntentMandate, amount: float) -> str | None:
+        """Return a refusal reason when *amount* would breach the intent cap."""
+        cap = intent.spend_cap_usd if intent.spend_cap_usd > 0 else 0.0
+        prior = 0.0
+        meter = self._ctx.meter
+        if meter is not None and meter.ledger is not None:
+            prior = meter.ledger.totals_by("task").get(intent.task_id or "unknown", 0.0)
+        if prior + max(0.0, amount) > cap:
+            return f"spend cap breach: ${prior:.4f} + ${amount:.4f} exceeds cap ${cap:.4f}"
+        return None
+
+    def _anchor_spend_receipt(self, receipt: SpendReceipt, now: int) -> SpendReceipt:
+        spine = LineageSpine(self._ctx.lineage_root, run_id=X402_SETTLEMENT_RUN_ID, hmac_key=self._ctx.hmac_key)
+        artifact_path = "/".join((*_SETTLEMENT_SUBPATH, f"{_safe_hash_name(receipt.receipt_hash())}.json"))
+        anchor = spine.record(
+            artifact_path=artifact_path,
+            content=receipt.to_canonical_bytes(),
+            actor=_MANDATE_ACTOR,
+            step_id=receipt.receipt_hash(),
+            model=_MANDATE_MODEL,
+            timestamp=now,
+        )
+        anchored = SpendReceipt(
+            server_name=receipt.server_name,
+            tool_name=receipt.tool_name,
+            wal_run_id=receipt.wal_run_id,
+            wal_invocation_seq=receipt.wal_invocation_seq,
+            wal_invocation_digest=receipt.wal_invocation_digest,
+            mandate_hash=receipt.mandate_hash,
+            intent_hash=receipt.intent_hash,
+            settlement_ref=receipt.settlement_ref,
+            consent_journal_entry_hash=receipt.consent_journal_entry_hash,
+            task_id=receipt.task_id,
+            timestamp=receipt.timestamp,
+            journal_entry_hash=anchor,
+        )
+        path = spend_receipt_path(self._ctx.workdir, anchored.receipt_hash())
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(anchored.to_dict(), ensure_ascii=False, separators=(",", ":"), sort_keys=True),
+            encoding="utf-8",
+        )
+        return anchored
+
+    def _flush_ledger(self, receipt: SpendReceipt) -> None:
+        meter = self._ctx.meter
+        if meter is None:
+            return
+        meter.record(
+            task_id=receipt.task_id,
+            server_name=receipt.server_name,
+            tool_name=receipt.tool_name,
+            cost_usd=receipt.settlement_ref.amount_usd,
+        )
+
+    def _mirror_settlement(self, receipt: SpendReceipt) -> None:
+        chain = self._ctx.audit_chain
+        if chain is None:
+            return
+        try:
+            chain.log_with_prev_digest(
+                event_type=EVENT_X402_SETTLEMENT,
+                actor=_MANDATE_ACTOR,
+                resource_type="x402_spend_receipt",
+                resource_id=receipt.receipt_hash(),
+                details={
+                    "server_name": receipt.server_name,
+                    "tool_name": receipt.tool_name,
+                    "mandate_hash": receipt.mandate_hash,
+                    "challenge_hash": receipt.settlement_ref.challenge_hash,
+                    "settlement_ref_hash": settlement_ref_hash(receipt.settlement_ref),
+                    "wal_invocation_digest": receipt.wal_invocation_digest,
+                    "amount_usd": receipt.settlement_ref.amount_usd,
+                    "journal_entry_hash": receipt.journal_entry_hash,
+                    "consent_journal_entry_hash": receipt.consent_journal_entry_hash,
+                },
+            )
+        except Exception:  # pragma: no cover - audit mirror is best-effort
+            logger.exception("x402: failed to mirror settlement into the audit chain")
+
+    def _refuse(
+        self,
+        challenge: X402Challenge,
+        server_name: str,
+        tool_name: str,
+        amount_usd: float,
+        reason: str,
+        mandate_hash: str,
+    ) -> PreAuthResult:
+        receipt = self._anchor_refusal(
+            RefusalReceipt(
+                server_name=server_name,
+                tool_name=tool_name,
+                challenge_hash=challenge.challenge_hash(),
+                amount_usd=amount_usd,
+                reason=reason,
+                mandate_hash=mandate_hash,
+                task_id=self._ctx.task_id,
+                timestamp=self._ctx.now(),
+            )
+        )
+        return PreAuthResult(
+            status=SettlementStatus.REFUSED,
+            reason=reason,
+            refusal_receipt=receipt,
+        )
+
+    def _anchor_refusal(self, receipt: RefusalReceipt) -> RefusalReceipt:
+        spine = LineageSpine(self._ctx.lineage_root, run_id=X402_SETTLEMENT_RUN_ID, hmac_key=self._ctx.hmac_key)
+        artifact_path = "/".join((*_REFUSAL_SUBPATH, f"{_safe_hash_name(receipt.receipt_hash())}.json"))
+        anchor = spine.record(
+            artifact_path=artifact_path,
+            content=receipt.to_canonical_bytes(),
+            actor=_MANDATE_ACTOR,
+            step_id=receipt.receipt_hash(),
+            model=_MANDATE_MODEL,
+            timestamp=receipt.timestamp,
+        )
+        anchored = RefusalReceipt(
+            server_name=receipt.server_name,
+            tool_name=receipt.tool_name,
+            challenge_hash=receipt.challenge_hash,
+            amount_usd=receipt.amount_usd,
+            reason=receipt.reason,
+            mandate_hash=receipt.mandate_hash,
+            task_id=receipt.task_id,
+            timestamp=receipt.timestamp,
+            journal_entry_hash=anchor,
+        )
+        path = refusal_receipt_path(self._ctx.workdir, anchored.receipt_hash())
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(anchored.to_dict(), ensure_ascii=False, separators=(",", ":"), sort_keys=True),
+            encoding="utf-8",
+        )
+        self._mirror_refusal(anchored)
+        return anchored
+
+    def _mirror_refusal(self, receipt: RefusalReceipt) -> None:
+        chain = self._ctx.audit_chain
+        if chain is None:
+            return
+        try:
+            chain.log_with_prev_digest(
+                event_type=EVENT_X402_SETTLEMENT_REFUSED,
+                actor=_MANDATE_ACTOR,
+                resource_type="x402_refusal_receipt",
+                resource_id=receipt.receipt_hash(),
+                details={
+                    "server_name": receipt.server_name,
+                    "tool_name": receipt.tool_name,
+                    "challenge_hash": receipt.challenge_hash,
+                    "amount_usd": receipt.amount_usd,
+                    "reason": receipt.reason,
+                    "mandate_hash": receipt.mandate_hash,
+                    "journal_entry_hash": receipt.journal_entry_hash,
+                },
+            )
+        except Exception:  # pragma: no cover - audit mirror is best-effort
+            logger.exception("x402: failed to mirror refusal into the audit chain")
+
+
+# ---------------------------------------------------------------------------
+# Offline verification (AC3)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SpendVerifyResult:
+    """Outcome of :func:`verify_spend_receipt`."""
+
+    ok: bool
+    reason: str
+    receipt: SpendReceipt | None = None
+
+
+def verify_spend_receipt(
+    *,
+    workdir: Path,
+    lineage_root: Path,
+    hmac_key: bytes,
+    wal_sdd_dir: Path,
+    spend_receipt_hash: str,
+    intent: IntentMandate,
+) -> SpendVerifyResult:
+    """Prove a spend receipt offline against the WAL and the mandate (AC3).
+
+    Recomputes, from the recorded receipt and the presented intent alone:
+
+    * the receipt's own spine anchor over its canonical bytes (a single-byte
+      edit to the amount, challenge digest, or invocation digest fails here);
+    * the WAL invocation record: the settled run's WAL chain verifies and the
+      record at the recorded sequence still hashes to the recorded digest (a
+      tamper of the paid-for call fails here);
+    * the mandate binding: the reconstructed cart chains to the presented
+      intent and its consent receipt verifies (:func:`verify_consent_receipt`),
+      so the payment is provably inside a signed authority.
+
+    ``ok`` is True only when every recomputation matches.
+    """
+    receipt = read_spend_receipt(workdir, spend_receipt_hash)
+    if receipt is None:
+        return SpendVerifyResult(ok=False, reason="no spend receipt found")
+
+    anchor_reason = _verify_receipt_anchor(receipt, lineage_root, hmac_key)
+    if anchor_reason is not None:
+        return SpendVerifyResult(ok=False, reason=anchor_reason, receipt=receipt)
+
+    wal_reason = _verify_wal_invocation(receipt, wal_sdd_dir)
+    if wal_reason is not None:
+        return SpendVerifyResult(ok=False, reason=wal_reason, receipt=receipt)
+
+    mandate_reason = _verify_mandate_binding(receipt, workdir, lineage_root, hmac_key, intent)
+    if mandate_reason is not None:
+        return SpendVerifyResult(ok=False, reason=mandate_reason, receipt=receipt)
+
+    return SpendVerifyResult(ok=True, reason="", receipt=receipt)
+
+
+def _verify_receipt_anchor(receipt: SpendReceipt, lineage_root: Path, hmac_key: bytes) -> str | None:
+    spine = LineageSpine(lineage_root, run_id=X402_SETTLEMENT_RUN_ID, hmac_key=hmac_key)
+    spine_result = spine.verify()
+    if not spine_result.ok:
+        return f"settlement spine failed verification ({spine_result.status.value})"
+    want = content_hash_of(receipt.to_canonical_bytes())
+    for entry in spine.iter_entries():
+        if entry.content_hash == want:
+            if entry.entry_hash != receipt.journal_entry_hash:
+                return "recorded journal_entry_hash does not match the spine anchor over the receipt bytes"
+            return None
+    return "receipt is not anchored in the settlement spine"
+
+
+def _verify_wal_invocation(receipt: SpendReceipt, wal_sdd_dir: Path) -> str | None:
+    from bernstein.core.persistence.wal import WALReader
+
+    reader = WALReader(run_id=receipt.wal_run_id, sdd_dir=wal_sdd_dir)
+    try:
+        ok, _errors = reader.verify_chain()
+    except FileNotFoundError:
+        return "settled WAL run not found"
+    if not ok:
+        return "settled WAL chain integrity failed"
+    for entry in reader.iter_entries():
+        if entry.seq != receipt.wal_invocation_seq:
+            continue
+        if entry.entry_hash != receipt.wal_invocation_digest:
+            return "WAL invocation digest does not match the recorded invocation record"
+        if entry.decision_type != "mcp_tool_call":
+            return "recorded WAL invocation is not an mcp_tool_call"
+        if str(entry.inputs.get("server_name", "")) != receipt.server_name:
+            return "WAL invocation server_name does not match the receipt"
+        return None
+    return "no WAL invocation record at the recorded sequence"
+
+
+def _verify_mandate_binding(
+    receipt: SpendReceipt,
+    workdir: Path,
+    lineage_root: Path,
+    hmac_key: bytes,
+    intent: IntentMandate,
+) -> str | None:
+    if intent.mandate_hash() != receipt.intent_hash:
+        return "presented intent does not match the receipt intent_hash"
+    cart = CartMandate(
+        intent_hash=intent.mandate_hash(),
+        tool_calls=(receipt.tool_name,),
+        amount_usd=receipt.settlement_ref.amount_usd,
+    ).sign(hmac_key)
+    if cart.mandate_hash() != receipt.mandate_hash:
+        return "reconstructed cart does not match the receipt mandate_hash"
+
+    consent = read_consent_receipt(workdir, receipt.mandate_hash)
+    if consent is None:
+        return "no consent receipt found for the settlement"
+    if consent.settlement_ref.to_dict() != receipt.settlement_ref.to_dict():
+        return "consent receipt settlement reference does not match the spend receipt"
+
+    result = verify_consent_receipt(
+        workdir=workdir,
+        lineage_root=lineage_root,
+        hmac_key=hmac_key,
+        mandate_hash=receipt.mandate_hash,
+        intent=intent,
+        cart=cart,
+    )
+    if not result.ok:
+        return f"consent receipt verification failed: {result.reason}"
+    return None
+
+
+__all__ = [
+    "EVENT_X402_SETTLEMENT",
+    "EVENT_X402_SETTLEMENT_REFUSED",
+    "X402_PAYMENT_KEY",
+    "X402_SCHEMA_VERSION",
+    "X402_SETTLEMENT_RUN_ID",
+    "CallableSettlementHook",
+    "CommandSettlementHook",
+    "PreAuthResult",
+    "RefusalReceipt",
+    "SettlementContext",
+    "SettlementHook",
+    "SettlementStatus",
+    "SpendReceipt",
+    "SpendVerifyResult",
+    "X402Challenge",
+    "X402Config",
+    "X402SettlementCoordinator",
+    "build_retry_request",
+    "iter_spend_receipts",
+    "parse_challenge",
+    "read_spend_receipt",
+    "refusal_receipt_path",
+    "retried_request_hash",
+    "settlement_ref_hash",
+    "spend_receipt_path",
+    "verify_spend_receipt",
+]

--- a/tests/unit/test_mcp_gateway_x402.py
+++ b/tests/unit/test_mcp_gateway_x402.py
@@ -1,0 +1,220 @@
+"""x402 settlement wiring in the MCP gateway (issue #2528, phase 2 + AC1/AC4).
+
+These tests drive :meth:`MCPGateway.handle_jsonrpc` against a hermetic fake
+upstream that answers with a 402 challenge, exercising the settlement seam:
+
+* AC1 -- with no x402 config a 402 surfaces as an ordinary tool error and no
+  hook is looked up and no retry is sent.
+* happy path -- an active config gates, settles, retries, and records a spend
+  receipt bound to the retried WAL invocation.
+* AC4 -- replay mode serves the recorded settled response without invoking the
+  hook, so replay can never double-settle.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+from bernstein.core.mcp_gateway import GatewayReplay, MCPGateway
+from bernstein.core.wal import WALWriter
+
+from bernstein.core.protocols.payments.mandates import IntentMandate
+from bernstein.core.protocols.payments.x402 import (
+    SettlementContext,
+    X402Config,
+    X402SettlementCoordinator,
+    iter_spend_receipts,
+)
+from bernstein.core.security.audit_chain import AuditChainStore
+
+_KEY = b"x" * 32
+_SERVER = "acme-data-api"
+_TOOL = "fetch_dataset"
+
+
+class _RecordingHook:
+    def __init__(self, payment_ref: str | None = "pay-ref-0001") -> None:
+        self._ref = payment_ref
+        self.calls: list[dict[str, Any]] = []
+
+    def settle(self, challenge: Any, *, server_name: str, tool_name: str, amount_usd: float) -> str | None:
+        self.calls.append({"server_name": server_name, "tool_name": tool_name, "amount_usd": amount_usd})
+        return self._ref
+
+
+def _challenge_response(req_id: int, amount_usd: float = 4.0) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "error": {
+            "code": 402,
+            "message": "Payment Required",
+            "data": {
+                "x402Version": 1,
+                "accepts": [{"scheme": "exact", "maxAmountRequired": "4000000", "amountUsd": amount_usd}],
+            },
+        },
+    }
+
+
+def _settled_response(req_id: int) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": req_id, "result": {"content": [{"type": "text", "text": "settled"}]}}
+
+
+def _call_message(req_id: int = 7) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "method": "tools/call",
+        "params": {"name": _TOOL, "arguments": {"q": "widgets"}},
+    }
+
+
+def _signed_intent() -> IntentMandate:
+    return IntentMandate(task_id="task-x402", allowed_tool_calls=(_TOOL,), spend_cap_usd=100.0).sign(_KEY)
+
+
+def _coordinator(
+    tmp_path: Path, config: X402Config, intent: IntentMandate | None, run_id: str
+) -> X402SettlementCoordinator:
+    sdd = tmp_path / ".sdd"
+    sdd.mkdir(parents=True, exist_ok=True)
+    ctx = SettlementContext(
+        config=config,
+        hmac_key=_KEY,
+        workdir=tmp_path,
+        lineage_root=sdd / "lineage",
+        wal_sdd_dir=sdd,
+        wal_run_id=run_id,
+        intent=intent,
+        meter=None,
+        audit_chain=AuditChainStore(sdd / "audit", key=_KEY),
+        now=lambda: 1_700_000_000,
+    )
+    return X402SettlementCoordinator(ctx)
+
+
+def _make_writer(tmp_path: Path, run_id: str) -> WALWriter:
+    sdd = tmp_path / ".sdd"
+    sdd.mkdir(parents=True, exist_ok=True)
+    return WALWriter(run_id=run_id, sdd_dir=sdd)
+
+
+class TestDefaultOff:
+    @pytest.mark.asyncio
+    async def test_no_settlement_configured_surfaces_402(self, tmp_path: Any) -> None:
+        writer = _make_writer(Path(tmp_path), "gw-off")
+        gw = MCPGateway(upstream_cmd=[], wal_writer=writer, server_name=_SERVER)
+
+        sends: list[dict[str, Any]] = []
+
+        async def _mock_send(msg: dict[str, Any]) -> None:
+            await asyncio.sleep(0)
+            sends.append(msg)
+            fut = gw._pending.get(msg.get("id"))
+            if fut and not fut.done():
+                fut.set_result(_challenge_response(msg["id"]))
+
+        from unittest.mock import patch
+
+        with patch.object(gw, "_send_upstream", side_effect=_mock_send):
+            resp = await gw.handle_jsonrpc(_call_message())
+
+        assert resp is not None
+        assert resp["error"]["code"] == 402  # surfaces as an ordinary tool error
+        assert len(sends) == 1  # no retry
+
+    @pytest.mark.asyncio
+    async def test_disabled_config_does_not_invoke_hook(self, tmp_path: Any) -> None:
+        writer = _make_writer(Path(tmp_path), "gw-disabled")
+        hook = _RecordingHook()
+        coord = _coordinator(Path(tmp_path), X402Config(enabled=False, hook=hook), _signed_intent(), "gw-disabled")
+        gw = MCPGateway(upstream_cmd=[], wal_writer=writer, server_name=_SERVER, settlement=coord)
+
+        sends: list[dict[str, Any]] = []
+
+        async def _mock_send(msg: dict[str, Any]) -> None:
+            await asyncio.sleep(0)
+            sends.append(msg)
+            fut = gw._pending.get(msg.get("id"))
+            if fut and not fut.done():
+                fut.set_result(_challenge_response(msg["id"]))
+
+        from unittest.mock import patch
+
+        with patch.object(gw, "_send_upstream", side_effect=_mock_send):
+            resp = await gw.handle_jsonrpc(_call_message())
+
+        assert resp["error"]["code"] == 402
+        assert hook.calls == []  # no hook lookup
+        assert len(sends) == 1  # no retry
+
+
+class TestHappyPath:
+    @pytest.mark.asyncio
+    async def test_settles_and_retries(self, tmp_path: Any) -> None:
+        writer = _make_writer(Path(tmp_path), "gw-live")
+        hook = _RecordingHook()
+        coord = _coordinator(Path(tmp_path), X402Config(enabled=True, hook=hook), _signed_intent(), "gw-live")
+        gw = MCPGateway(upstream_cmd=[], wal_writer=writer, server_name=_SERVER, settlement=coord)
+
+        sends: list[dict[str, Any]] = []
+
+        async def _mock_send(msg: dict[str, Any]) -> None:
+            await asyncio.sleep(0)
+            sends.append(msg)
+            fut = gw._pending.get(msg.get("id"))
+            if fut and not fut.done():
+                paid = "_x402_payment" in msg.get("params", {}).get("arguments", {})
+                fut.set_result(_settled_response(msg["id"]) if paid else _challenge_response(msg["id"]))
+
+        from unittest.mock import patch
+
+        with patch.object(gw, "_send_upstream", side_effect=_mock_send):
+            resp = await gw.handle_jsonrpc(_call_message())
+
+        assert resp["result"]["content"][0]["text"] == "settled"  # settled response returned
+        assert len(hook.calls) == 1  # hook invoked once
+        assert len(sends) == 2  # original + retry
+        receipts = list(iter_spend_receipts(Path(tmp_path)))
+        assert len(receipts) == 1
+        assert receipts[0].server_name == _SERVER
+        assert receipts[0].settlement_ref.amount_usd == pytest.approx(4.0)
+
+
+class TestReplayNeverSettles:
+    @pytest.mark.asyncio
+    async def test_replay_serves_recorded_settled_response_without_hook(self, tmp_path: Any) -> None:
+        sdd = Path(tmp_path) / ".sdd"
+        sdd.mkdir(parents=True, exist_ok=True)
+        # Record a settled tool call into a WAL to replay from.
+        source = WALWriter(run_id="gw-src", sdd_dir=sdd)
+        source.append(
+            decision_type="mcp_tool_call",
+            inputs={
+                "method": "tools/call",
+                "server_name": _SERVER,
+                "tool_name": _TOOL,
+                "arguments": {},
+                "request_id": 1,
+            },
+            output={"result": {"content": [{"type": "text", "text": "settled"}]}, "error": None, "latency_ms": 2.0},
+            actor="mcp_gateway",
+        )
+
+        hook = _RecordingHook()
+        coord = _coordinator(Path(tmp_path), X402Config(enabled=True, hook=hook), _signed_intent(), "gw-replay")
+        replay = GatewayReplay(run_id="gw-src", sdd_dir=sdd)
+        writer = WALWriter(run_id="gw-replay", sdd_dir=sdd)
+        gw = MCPGateway(upstream_cmd=[], wal_writer=writer, replay=replay, server_name=_SERVER, settlement=coord)
+
+        resp = await gw.handle_jsonrpc(
+            {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": _TOOL, "arguments": {}}}
+        )
+
+        assert resp["result"]["content"][0]["text"] == "settled"
+        assert hook.calls == []  # replay never invokes the hook
+        assert list(iter_spend_receipts(Path(tmp_path))) == []  # and never settles

--- a/tests/unit/test_x402_cli.py
+++ b/tests/unit/test_x402_cli.py
@@ -1,0 +1,137 @@
+"""CLI tests for x402 settlement listing + offline verification (#2528, phase 4).
+
+``bernstein gateway settlements`` lists recorded spend receipts and
+``bernstein mandate verify-settlement`` proves one offline against the WAL
+invocation record and the authorising mandate.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from bernstein.core.wal import WALWriter
+from click.testing import CliRunner
+
+from bernstein.cli.commands.gateway_cmd import gateway_group
+from bernstein.cli.commands.mandate_cmd import mandate_group
+from bernstein.core.protocols.payments.mandates import IntentMandate
+from bernstein.core.protocols.payments.x402 import (
+    SettlementContext,
+    X402Config,
+    X402SettlementCoordinator,
+    build_retry_request,
+    parse_challenge,
+)
+from bernstein.core.security.audit import load_or_create_audit_key
+
+_SERVER = "acme-data-api"
+_TOOL = "fetch_dataset"
+
+
+class _Hook:
+    def settle(self, challenge: object, *, server_name: str, tool_name: str, amount_usd: float) -> str | None:
+        return "pay-ref-cli"
+
+
+def _challenge() -> dict[str, object]:
+    return {
+        "jsonrpc": "2.0",
+        "id": 3,
+        "error": {
+            "code": 402,
+            "message": "Payment Required",
+            "data": {"x402Version": 1, "accepts": [{"scheme": "exact", "amountUsd": 4.0}]},
+        },
+    }
+
+
+@pytest.fixture
+def settled_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, str, Path]:
+    """A workspace with one recorded spend receipt; returns (root, hash, intent_file)."""
+    monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(tmp_path / "audit.key"))
+    sdd = tmp_path / ".sdd"
+    sdd.mkdir(parents=True, exist_ok=True)
+    key = load_or_create_audit_key(tmp_path / "audit.key")
+
+    intent = IntentMandate(task_id="task-cli", allowed_tool_calls=(_TOOL,), spend_cap_usd=50.0).sign(key)
+    intent_file = tmp_path / "intent.json"
+    intent_file.write_text(json.dumps(intent.to_dict()), encoding="utf-8")
+
+    ctx = SettlementContext(
+        config=X402Config(enabled=True, hook=_Hook()),
+        hmac_key=key,
+        workdir=tmp_path,
+        lineage_root=sdd / "lineage",
+        wal_sdd_dir=sdd,
+        wal_run_id="gw-cli",
+        intent=intent,
+        meter=None,
+        audit_chain=None,
+        now=lambda: 1_700_000_000,
+    )
+    coord = X402SettlementCoordinator(ctx)
+    challenge = parse_challenge(_challenge())
+    assert challenge is not None
+    pre = coord.pre_authorize(challenge, server_name=_SERVER, tool_name=_TOOL)
+
+    writer = WALWriter(run_id="gw-cli", sdd_dir=sdd)
+    wal_entry = writer.append(
+        decision_type="mcp_tool_call",
+        inputs={"method": "tools/call", "server_name": _SERVER, "tool_name": _TOOL, "arguments": {}, "request_id": 3},
+        output={"result": {"content": []}, "error": None, "latency_ms": 1.0},
+        actor="mcp_gateway",
+    )
+    retried = build_retry_request(
+        {"jsonrpc": "2.0", "id": 3, "method": "tools/call", "params": {"name": _TOOL, "arguments": {}}},
+        pre.payment_ref,
+    )
+    receipt = coord.record_settlement(
+        challenge,
+        server_name=_SERVER,
+        tool_name=_TOOL,
+        payment_ref=pre.payment_ref,
+        amount_usd=pre.amount_usd,
+        retried_request=retried,
+        wal_entry=wal_entry,
+    )
+    return tmp_path, receipt.receipt_hash(), intent_file
+
+
+def test_gateway_settlements_lists_receipt(settled_project: tuple[Path, str, Path]) -> None:
+    root, _receipt_hash, _intent_file = settled_project
+    result = CliRunner().invoke(gateway_group, ["settlements", "--workdir", str(root)])
+    assert result.exit_code == 0, result.output
+    assert _SERVER in result.output
+    assert _TOOL in result.output
+
+
+def test_verify_settlement_ok(settled_project: tuple[Path, str, Path]) -> None:
+    root, receipt_hash, intent_file = settled_project
+    result = CliRunner().invoke(
+        mandate_group,
+        ["verify-settlement", receipt_hash, "--intent", str(intent_file), "--workdir", str(root)],
+    )
+    assert result.exit_code == 0, result.output
+    assert "OK" in result.output
+
+
+def test_verify_settlement_detects_tamper(settled_project: tuple[Path, str, Path]) -> None:
+    root, receipt_hash, intent_file = settled_project
+    path = root / ".sdd" / "x402" / "settlements" / f"{receipt_hash.replace(':', '_')}.json"
+    raw = path.read_text(encoding="utf-8")
+    path.write_text(raw.replace('"amount_usd":4.0', '"amount_usd":0.01'), encoding="utf-8")
+
+    result = CliRunner().invoke(
+        mandate_group,
+        ["verify-settlement", receipt_hash, "--intent", str(intent_file), "--workdir", str(root)],
+    )
+    assert result.exit_code == 2, result.output
+
+
+def test_gateway_settlements_empty(tmp_path: Path) -> None:
+    (tmp_path / ".sdd").mkdir(parents=True, exist_ok=True)
+    result = CliRunner().invoke(gateway_group, ["settlements", "--workdir", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert "No x402 settlements" in result.output

--- a/tests/unit/test_x402_settlement.py
+++ b/tests/unit/test_x402_settlement.py
@@ -1,0 +1,400 @@
+"""x402 settlement-hook tests (issue #2528).
+
+The settlement hook is the concrete x402 adapter over the AP2 mandate /
+consent-receipt surface (``bernstein.core.protocols.payments.mandates``). Each
+test maps to an issue #2528 acceptance criterion:
+
+* AC1 -- default off: a 402 challenge with no active x402 config invokes no
+  hook and triggers no retry.
+* AC2 -- a hook configured but no matching mandate refuses fail closed and the
+  refusal is a chain-anchored receipt.
+* AC3 -- the happy path emits a spend receipt whose bindings recompute offline
+  against the WAL invocation record and the mandate; mutating the amount, the
+  challenge digest, or the invocation digest fails verification.
+* AC5 -- spend-ledger rollups include settled amounts tagged per server.
+
+Bernstein never executes payments here; the hook is a hermetic fake that stands
+in for the operator's own payment tooling.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from bernstein.core.wal import WALEntry, WALWriter
+
+from bernstein.core.cost.mcp_server_cost import MCPServerCostMeter
+from bernstein.core.cost.spend_ledger import SpendLedger
+from bernstein.core.protocols.payments.mandates import IntentMandate
+from bernstein.core.protocols.payments.x402 import (
+    SettlementContext,
+    SettlementStatus,
+    X402Config,
+    X402SettlementCoordinator,
+    build_retry_request,
+    parse_challenge,
+    read_spend_receipt,
+    verify_spend_receipt,
+)
+from bernstein.core.security.audit_chain import AuditChainStore
+
+_KEY = b"x" * 32
+_SERVER = "acme-data-api"
+_TOOL = "fetch_dataset"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / builders
+# ---------------------------------------------------------------------------
+
+
+def _challenge_response(amount_usd: float = 4.0, *, req_id: int = 7) -> dict[str, Any]:
+    """A JSON-RPC error carrying an x402 402 challenge with an explicit USD price."""
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "error": {
+            "code": 402,
+            "message": "Payment Required",
+            "data": {
+                "x402Version": 1,
+                "accepts": [
+                    {
+                        "scheme": "exact",
+                        "network": "base",
+                        "maxAmountRequired": "4000000",
+                        "asset": "usdc",
+                        "resource": "https://acme.example/datasets/1",
+                        "amountUsd": amount_usd,
+                    }
+                ],
+            },
+        },
+    }
+
+
+def _settled_response(req_id: int = 7) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": req_id, "result": {"content": [{"type": "text", "text": "ok"}]}}
+
+
+def _call_message(req_id: int = 7) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "method": "tools/call",
+        "params": {"name": _TOOL, "arguments": {"q": "widgets"}},
+    }
+
+
+def _signed_intent(*, allowed: tuple[str, ...] = (_TOOL,), cap: float = 100.0) -> IntentMandate:
+    return IntentMandate(
+        task_id="task-x402",
+        allowed_tool_calls=allowed,
+        spend_cap_usd=cap,
+        expires_at=0,
+    ).sign(_KEY)
+
+
+class _RecordingHook:
+    """Hermetic settlement hook that records its calls and returns a fixed ref."""
+
+    def __init__(self, payment_ref: str | None = "pay-ref-0001") -> None:
+        self._ref = payment_ref
+        self.calls: list[dict[str, Any]] = []
+
+    def settle(self, challenge: Any, *, server_name: str, tool_name: str, amount_usd: float) -> str | None:
+        self.calls.append(
+            {"server_name": server_name, "tool_name": tool_name, "amount_usd": amount_usd, "challenge": challenge}
+        )
+        return self._ref
+
+
+def _context(
+    tmp_path: Path,
+    *,
+    config: X402Config,
+    intent: IntentMandate | None,
+    ledger: SpendLedger | None = None,
+) -> tuple[SettlementContext, MCPServerCostMeter, AuditChainStore]:
+    sdd = tmp_path / ".sdd"
+    sdd.mkdir(parents=True, exist_ok=True)
+    meter = MCPServerCostMeter(ledger=ledger, feature_label="x402-settlement")
+    chain = AuditChainStore(sdd / "audit", key=_KEY)
+    ctx = SettlementContext(
+        config=config,
+        hmac_key=_KEY,
+        workdir=tmp_path,
+        lineage_root=sdd / "lineage",
+        wal_sdd_dir=sdd,
+        wal_run_id="gw-test",
+        intent=intent,
+        meter=meter,
+        audit_chain=chain,
+        now=lambda: 1_700_000_000,
+    )
+    return ctx, meter, chain
+
+
+def _record_wal_call(tmp_path: Path, run_id: str = "gw-test") -> WALEntry:
+    """Append a settled mcp_tool_call to the WAL and return the entry."""
+    writer = WALWriter(run_id=run_id, sdd_dir=tmp_path / ".sdd")
+    return writer.append(
+        decision_type="mcp_tool_call",
+        inputs={
+            "method": "tools/call",
+            "server_name": _SERVER,
+            "tool_name": _TOOL,
+            "arguments": {"q": "widgets", "_x402_payment": {"payment_ref": "pay-ref-0001"}},
+            "request_id": 7,
+        },
+        output={"result": {"content": []}, "error": None, "latency_ms": 3.0},
+        actor="mcp_gateway",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 -- challenge detection + config gate
+# ---------------------------------------------------------------------------
+
+
+class TestChallengeDetection:
+    def test_parses_402_error_with_x402_data(self) -> None:
+        challenge = parse_challenge(_challenge_response())
+        assert challenge is not None
+        assert challenge.x402_version == 1
+        assert challenge.max_amount_required() == "4000000"
+        assert challenge.resolved_amount_usd() == pytest.approx(4.0)
+
+    def test_ignores_ordinary_success(self) -> None:
+        assert parse_challenge(_settled_response()) is None
+
+    def test_ignores_ordinary_error(self) -> None:
+        resp = {"jsonrpc": "2.0", "id": 1, "error": {"code": -32000, "message": "boom"}}
+        assert parse_challenge(resp) is None
+
+    def test_challenge_hash_is_stable_and_sensitive(self) -> None:
+        a = parse_challenge(_challenge_response(amount_usd=4.0))
+        b = parse_challenge(_challenge_response(amount_usd=4.0))
+        c = parse_challenge(_challenge_response(amount_usd=9.0))
+        assert a is not None and b is not None and c is not None
+        assert a.challenge_hash() == b.challenge_hash()
+        assert a.challenge_hash() != c.challenge_hash()
+
+    def test_build_retry_request_injects_payment_ref(self) -> None:
+        retried = build_retry_request(_call_message(), "pay-ref-0001")
+        assert retried["params"]["arguments"]["_x402_payment"] == {"payment_ref": "pay-ref-0001"}
+        # Original untouched.
+        assert "_x402_payment" not in _call_message()["params"]["arguments"]
+
+    def test_config_defaults_off(self) -> None:
+        assert X402Config().enabled is False
+        assert X402Config().is_active() is False
+        assert X402Config(enabled=True).is_active() is False  # no hook
+        assert X402Config(enabled=True, hook=_RecordingHook()).is_active() is True
+
+
+# ---------------------------------------------------------------------------
+# AC1 -- default off
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultOff:
+    def test_disabled_config_skips_without_hook_lookup(self, tmp_path: Path) -> None:
+        hook = _RecordingHook()
+        cfg = X402Config(enabled=False, hook=hook)
+        ctx, _meter, _chain = _context(tmp_path, config=cfg, intent=_signed_intent())
+        coord = X402SettlementCoordinator(ctx)
+
+        challenge = parse_challenge(_challenge_response())
+        assert challenge is not None
+        pre = coord.pre_authorize(challenge, server_name=_SERVER, tool_name=_TOOL)
+
+        assert pre.status is SettlementStatus.SKIPPED
+        assert hook.calls == []  # no hook lookup
+        assert pre.payment_ref is None
+
+
+# ---------------------------------------------------------------------------
+# AC2 -- no matching mandate refuses fail closed with a chain-anchored receipt
+# ---------------------------------------------------------------------------
+
+
+class TestFailClosed:
+    def test_no_intent_refuses_and_anchors_receipt(self, tmp_path: Path) -> None:
+        hook = _RecordingHook()
+        cfg = X402Config(enabled=True, hook=hook)
+        ctx, _meter, chain = _context(tmp_path, config=cfg, intent=None)
+        coord = X402SettlementCoordinator(ctx)
+
+        challenge = parse_challenge(_challenge_response())
+        assert challenge is not None
+        pre = coord.pre_authorize(challenge, server_name=_SERVER, tool_name=_TOOL)
+
+        assert pre.status is SettlementStatus.REFUSED
+        assert hook.calls == []  # never pay when no mandate authorizes
+        assert pre.refusal_receipt is not None
+        # Refusal is a chain-anchored receipt.
+        events = chain.query(event_type="x402.settlement_refused")
+        assert len(events) == 1
+        ok, _errs = chain.verify()
+        assert ok is True
+
+    def test_tool_outside_intent_refuses(self, tmp_path: Path) -> None:
+        hook = _RecordingHook()
+        cfg = X402Config(enabled=True, hook=hook)
+        ctx, _meter, _chain = _context(tmp_path, config=cfg, intent=_signed_intent(allowed=("other_tool",)))
+        coord = X402SettlementCoordinator(ctx)
+
+        challenge = parse_challenge(_challenge_response())
+        assert challenge is not None
+        pre = coord.pre_authorize(challenge, server_name=_SERVER, tool_name=_TOOL)
+
+        assert pre.status is SettlementStatus.REFUSED
+        assert hook.calls == []
+
+    def test_cap_breach_refuses_before_hook(self, tmp_path: Path) -> None:
+        hook = _RecordingHook()
+        cfg = X402Config(enabled=True, hook=hook)
+        ctx, _meter, _chain = _context(tmp_path, config=cfg, intent=_signed_intent(cap=1.0))
+        coord = X402SettlementCoordinator(ctx)
+
+        challenge = parse_challenge(_challenge_response(amount_usd=4.0))
+        assert challenge is not None
+        pre = coord.pre_authorize(challenge, server_name=_SERVER, tool_name=_TOOL)
+
+        assert pre.status is SettlementStatus.REFUSED
+        assert hook.calls == []  # cap breach is caught before paying
+
+
+# ---------------------------------------------------------------------------
+# AC3 -- happy path: emit a verifiable spend receipt; tamper fails verification
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    def _settle(self, tmp_path: Path, ledger: SpendLedger | None = None):
+        hook = _RecordingHook()
+        cfg = X402Config(enabled=True, hook=hook)
+        intent = _signed_intent()
+        ctx, meter, chain = _context(tmp_path, config=cfg, intent=intent, ledger=ledger)
+        coord = X402SettlementCoordinator(ctx)
+
+        challenge = parse_challenge(_challenge_response())
+        assert challenge is not None
+        pre = coord.pre_authorize(challenge, server_name=_SERVER, tool_name=_TOOL)
+        assert pre.status is SettlementStatus.AUTHORIZED
+        assert pre.payment_ref == "pay-ref-0001"
+        assert len(hook.calls) == 1
+
+        retried = build_retry_request(_call_message(), pre.payment_ref)
+        wal_entry = _record_wal_call(tmp_path)
+        receipt = coord.record_settlement(
+            challenge,
+            server_name=_SERVER,
+            tool_name=_TOOL,
+            payment_ref=pre.payment_ref,
+            amount_usd=pre.amount_usd,
+            retried_request=retried,
+            wal_entry=wal_entry,
+        )
+        return coord, receipt, intent, meter, chain, wal_entry
+
+    def test_emits_spend_receipt_that_verifies_offline(self, tmp_path: Path) -> None:
+        _coord, receipt, intent, _meter, chain, wal_entry = self._settle(tmp_path)
+        assert receipt.wal_invocation_digest == wal_entry.entry_hash
+        assert receipt.journal_entry_hash  # anchored
+
+        result = verify_spend_receipt(
+            workdir=tmp_path,
+            lineage_root=tmp_path / ".sdd" / "lineage",
+            hmac_key=_KEY,
+            wal_sdd_dir=tmp_path / ".sdd",
+            spend_receipt_hash=receipt.receipt_hash(),
+            intent=intent,
+        )
+        assert result.ok is True, result.reason
+
+        events = chain.query(event_type="x402.settlement")
+        assert len(events) == 1
+
+    def test_mutating_recorded_amount_fails_verification(self, tmp_path: Path) -> None:
+        _coord, receipt, intent, _meter, _chain, _wal = self._settle(tmp_path)
+        path = tmp_path / ".sdd" / "x402" / "settlements" / f"{receipt.receipt_hash().replace(':', '_')}.json"
+        raw = path.read_text(encoding="utf-8")
+        # Bump the settled amount on disk.
+        tampered = raw.replace('"amount_usd":4.0', '"amount_usd":0.01')
+        assert tampered != raw
+        path.write_text(tampered, encoding="utf-8")
+
+        stored = read_spend_receipt(tmp_path, receipt.receipt_hash())
+        assert stored is not None
+        result = verify_spend_receipt(
+            workdir=tmp_path,
+            lineage_root=tmp_path / ".sdd" / "lineage",
+            hmac_key=_KEY,
+            wal_sdd_dir=tmp_path / ".sdd",
+            spend_receipt_hash=receipt.receipt_hash(),
+            intent=intent,
+        )
+        assert result.ok is False
+
+    def test_mutating_challenge_digest_fails_verification(self, tmp_path: Path) -> None:
+        _coord, receipt, intent, _meter, _chain, _wal = self._settle(tmp_path)
+        path = tmp_path / ".sdd" / "x402" / "settlements" / f"{receipt.receipt_hash().replace(':', '_')}.json"
+        raw = path.read_text(encoding="utf-8")
+        tampered = raw.replace(receipt.settlement_ref.challenge_hash, "sha256:" + "0" * 64)
+        assert tampered != raw
+        path.write_text(tampered, encoding="utf-8")
+
+        result = verify_spend_receipt(
+            workdir=tmp_path,
+            lineage_root=tmp_path / ".sdd" / "lineage",
+            hmac_key=_KEY,
+            wal_sdd_dir=tmp_path / ".sdd",
+            spend_receipt_hash=receipt.receipt_hash(),
+            intent=intent,
+        )
+        assert result.ok is False
+
+    def test_mutating_wal_invocation_output_fails_verification(self, tmp_path: Path) -> None:
+        _coord, receipt, intent, _meter, _chain, _wal = self._settle(tmp_path)
+        # Tamper the WAL invocation record the receipt paid for.
+        wal_path = tmp_path / ".sdd" / "runtime" / "wal" / "gw-test.wal.jsonl"
+        raw = wal_path.read_text(encoding="utf-8")
+        tampered = raw.replace('"text": "ok"', '"text": "tampered"').replace('"content":[]', '"content":[1]')
+        # Whatever the exact output shape, ensure something changed.
+        if tampered == raw:
+            tampered = raw.replace('"latency_ms":3.0', '"latency_ms":9999.0')
+        wal_path.write_text(tampered, encoding="utf-8")
+
+        result = verify_spend_receipt(
+            workdir=tmp_path,
+            lineage_root=tmp_path / ".sdd" / "lineage",
+            hmac_key=_KEY,
+            wal_sdd_dir=tmp_path / ".sdd",
+            spend_receipt_hash=receipt.receipt_hash(),
+            intent=intent,
+        )
+        assert result.ok is False
+
+
+# ---------------------------------------------------------------------------
+# AC5 -- spend ledger rollups include settled amounts tagged per server
+# ---------------------------------------------------------------------------
+
+
+class TestLedgerRollup:
+    def test_settled_amount_flushed_per_server(self, tmp_path: Path) -> None:
+        ledger = SpendLedger(path=tmp_path / ".sdd" / "cost" / "ledger.jsonl", run_id="gw-test")
+        happy = TestHappyPath()
+        _coord, _receipt, _intent, meter, _chain, _wal = happy._settle(tmp_path, ledger=ledger)
+
+        # Per-server accumulation on the meter.
+        assert meter.cost_for("task-x402", _SERVER) == pytest.approx(4.0)
+        # Flushed into the shared ledger and visible in the task rollup.
+        assert ledger.totals_by("task").get("task-x402", 0.0) == pytest.approx(4.0)
+        # Tagged with the server name.
+        entries = SpendLedger.load_entries(ledger.path)
+        assert any(e.tags.get("mcp_server") == _SERVER for e in entries)


### PR DESCRIPTION
## What
Implemented issue #2528 (x402 settlement hook for metered MCP gateway calls with chained spend receipts) as the concrete x402 adapter over the existing AP2 mandate/consent-receipt surface. Staleness cross-check confirmed a genuine gap: x402.py did not exist on main and nothing executed the 402 pay-and-retry flow. New module src/bernstein/core/protocols/payments/x402.py adds structural 402 challenge detection, a SettlementHook boundary (callable + command adapters), a disabled-by-default X402Config gate, and X402SettlementCoordinator which gates a challenge against a signed IntentMandate (fail closed with a chain-anchored refusal receipt when unauthorized), invokes the operator hook only after the mandate and spend cap pass, and anchors a SpendReceipt binding {WAL invocation record digest, 402 challenge digest, payment reference, retried request digest, mandate hash}. verify_spend_receipt recomputes the receipt offline against its lineage-spine anchor, the settled WAL invocation record, and the authorising consent receipt. The gateway gained an optional settlement coordinator (byte-id

Fixes #2528

## Items
- **Phase 1: challenge detection + SettlementHook interface + config gate (x402.py), tests against a fak** — fixed: parse_challenge/X402Challenge (structural 402 detection, no network read), SettlementHook Protocol + CallableSettlementHook + CommandSettlementHook, X
- **Phase 2: gateway wiring in mcp_gateway.py (intercept 402, mandate gate, hook, retry, WAL linkage)** — fixed: MCPGateway gains optional settlement coordinator; _send_request factored out for retry reuse; _record_wal_and_metrics returns the WAL entry; _maybe_se
- **Phase 3: receipts (SettlementRef into consent receipt, flush settled amount into spend_ledger via pe** — fixed: record_settlement reuses emit_consent_receipt, anchors a SpendReceipt in the x402-settlements spine, flushes via MCPServerCostMeter, mirrors x402.sett
- **Phase 4: CLI (gateway_cmd + mandate_cmd) to list settlements and verify offline; docs with example n** — fixed: bernstein gateway settlements + bernstein mandate verify-settlement; docs/operations/x402-settlement.md with a no-op CallableSettlementHook example; c
- **AC1 default off: 402 surfaces as ordinary error, no hook lookup, no retry** — fixed: test_no_settlement_configured_surfaces_402 (settlement=None), test_disabled_config_does_not_invoke_hook, test_disabled_config_skips_without_hook_looku
- **AC2 hook configured but no matching mandate: refuse fail closed with a chain-anchored receipt** — fixed: test_no_intent_refuses_and_anchors_receipt asserts REFUSED, hook never called, refusal receipt present, x402.settlement_refused audit event queryable 
- **AC3 happy path spend receipt recomputes offline vs WAL + mandate; mutating amount/challenge/invocati** — fixed: test_emits_spend_receipt_that_verifies_offline plus three tamper tests (recorded amount, challenge digest, WAL invocation output) each assert verify f
- **AC4 replay serves recorded settled response without invoking the hook (no double-settle)** — fixed: test_replay_serves_recorded_settled_response_without_hook asserts settled response served, hook.calls empty, no spend receipts written. Settlement sea

## Verification
Adversarial review: **confirmed, 0 critical**. Backward compatibility of already-signed artefacts verified (a token/mandate/receipt signed before this change still verifies).
Added tests/unit/test_x402_settlement.py (15 tests: challenge detection, config-off, AC1 skip, AC2 fail-closed + chain-anchored refusal, AC3 happy path + 3 tamper cases, AC5 per-server ledger), tests/unit/test_mcp_gateway_x402.py (4 tests: AC1 settlement=None + disabled config, happy-path retry, AC4 replay-no-hook), tests/unit/test_x402_cli.py (4 tests: settlements list, verify-settlement ok, verify tamper -> exit 2, empty list). TDD: red capture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional x402 pay-and-retry settlement for metered gateway calls.
  * Settlement is gated by active mandates, spending caps, and configurable limits.
  * Successful settlements retry the call and produce verifiable spend receipts and cost records.
  * Added commands to list settlements and verify receipt integrity offline.

* **Documentation**
  * Added operational guidance covering settlement workflows, verification, refusal handling, and configuration.

* **Bug Fixes**
  * Replay mode prevents duplicate settlement attempts and receipts.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->