### PR TITLE
feat(interop): A2A agent-registry publication (completes the callable, discoverable node)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,15 @@ All notable project changes are tracked here (code + docs).
   receipt the caller verifies offline with `bernstein a2a verify`. Off by
   default behind `BERNSTEIN_A2A_SERVER_ENABLED`. See
   [`docs/operations/a2a-server.md`](operations/a2a-server.md). Refs #2609.
+- A2A registry publication third surface: `bernstein a2a publish` now emits an
+  AGNTCY ADS record alongside the `a2a-card` and `mcp-registry` surfaces. The
+  record is an OASF capability descriptor — a deterministic projection of the
+  signed card — bound to the node's Ed25519 key by a detached-JWS provenance
+  signature verified offline against the card key. Discovery gains a
+  resolve-and-confirm round-trip (`resolve_publication_capability` /
+  `AgentDiscovery.resolve_published_record`) that works across all three
+  surfaces: verify provenance, then confirm the required capability against the
+  node's signed card, registering only records that verify. Refs #2609.
 
 ## [3.5.0] - 2026-07-16
 

--- a/docs/operations/a2a-server.md
+++ b/docs/operations/a2a-server.md
@@ -154,10 +154,34 @@ against the operator's published key rather than trust-on-first-use.
 ## Publish for discovery
 
 `bernstein a2a publish --endpoint https://node.example/a2a` projects the node's
-signed capability card into agent-registry manifests (A2A card + MCP registry),
-each carrying a verifiable publisher fingerprint, so peers discover the node by
-verifiable capability rather than by an opaque URL. The AGNTCY ADS / OASF
-descriptor surface is a separate follow-up.
+signed capability card into agent-registry manifests, each carrying a verifiable
+publisher fingerprint, so peers discover the node by verifiable capability
+rather than by an opaque URL. Three surfaces are emitted (repeat `--surface` to
+narrow):
+
+| Surface | Record | Trust root |
+|---|---|---|
+| `a2a-card` | The signed capability card itself (JWS per RFC 7515 over RFC 8785 canonical bytes). | The card signature. |
+| `mcp-registry` | A `server.json`-shaped record carrying the `ed25519/<fp>` publisher block the MCP verifier already parses, plus a `sha256/` content hash over the embedded card. | The card signature + content hash. |
+| `agntcy-ads` | An [OASF](https://schema.oasf.outshift.com/) capability descriptor — a deterministic projection of the signed card — bound to the node's key by a Sigstore-style provenance statement: a detached JWS (RFC 7515 §A.5) over the RFC 8785-canonical descriptor, signed with the card's Ed25519 key. | The provenance signature (verified against the card key). |
+
+The `agntcy-ads` surface signs a fresh provenance, so it needs the node's
+private key. In the normal mint-and-reuse flow the key sits beside the card
+(`<card>.key.pem`, `0600`); if only a card file is present the surface is skipped
+by default, or fails loudly when requested with `--surface agntcy-ads`. Online
+keyless submission (Fulcio + Rekor) for the provenance is a separate follow-up;
+the emitted record verifies offline today. Every record is deterministic:
+republishing an unchanged node rewrites identical bytes.
+
+### Resolve a published record
+
+A peer that fetched any of these records runs the full round-trip offline —
+verify provenance, then confirm the capability it needs is one the node's signed
+card actually advertises — via `resolve_publication_capability` (or
+`AgentDiscovery.resolve_published_record`, which additionally tracks a verified
+node as an `a2a-registry` directory entry). Resolution fails on a tampered record
+or a missing capability, and the registry never becomes an authority: an
+unverifiable record is never registered.
 
 ## Related
 

--- a/src/bernstein/agents/discovery.py
+++ b/src/bernstein/agents/discovery.py
@@ -18,11 +18,14 @@ import logging
 import time
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from bernstein.core.protocols.a2a.publish import ResolvedPublication
 
 logger = logging.getLogger(__name__)
 
-DiscoverySourceType = Literal["local", "project", "github", "npm"]
+DiscoverySourceType = Literal["local", "project", "github", "npm", "a2a-registry"]
 
 _REGISTRY_PATH = Path(".sdd/agents/registry.json")
 _USER_AGENTS_DIR = Path.home() / ".bernstein" / "agents"
@@ -329,6 +332,58 @@ class AgentDiscovery:
         self.last_full_sync = _now_iso()
         self.save()
         return results
+
+    # ------------------------------------------------------------------ #
+    # Published-record resolution (A2A registry surfaces, #2609)           #
+    # ------------------------------------------------------------------ #
+
+    def resolve_published_record(
+        self,
+        record: dict[str, Any],
+        *,
+        required_capability: str | None = None,
+        register: bool = True,
+    ) -> ResolvedPublication:
+        """Resolve a published A2A registry record into a verified node.
+
+        Completes the discovery round-trip for any publish surface (A2A card,
+        MCP registry, or AGNTCY ADS / OASF descriptor): the record's provenance
+        is verified offline, the advertised capability is confirmed against the
+        node's signed card, and - only when it verifies - the node is recorded
+        as a directory entry. The registry is treated as a transport: an
+        unverifiable record is never registered.
+
+        Args:
+            record: A published record (as fetched from a registry index).
+            required_capability: Optional capability to confirm is advertised.
+            register: When ``True`` (default), a verified node is tracked as an
+                ``a2a-registry`` directory entry keyed by its endpoint.
+
+        Returns:
+            A ``ResolvedPublication`` describing the outcome.
+        """
+        from bernstein.core.protocols.a2a.publish import resolve_publication_capability
+
+        resolved = resolve_publication_capability(record, required_capability=required_capability)
+        if resolved.ok and register and resolved.endpoint:
+            self._register_resolved_node(resolved)
+        return resolved
+
+    def _register_resolved_node(self, resolved: ResolvedPublication) -> None:
+        """Record a verified A2A node as a directory entry (idempotent by URL)."""
+        for entry in self.directories:
+            if entry.source_type == "a2a-registry" and entry.url == resolved.endpoint:
+                entry.last_sync = _now_iso()
+                return
+        self.directories.append(
+            DirectoryEntry(
+                name=resolved.issuer or (resolved.endpoint or "a2a-node"),
+                source_type="a2a-registry",
+                url=resolved.endpoint,
+                agents=1,
+                last_sync=_now_iso(),
+            )
+        )
 
     # ------------------------------------------------------------------ #
     # Metrics                                                              #

--- a/src/bernstein/cli/commands/a2a_cmd.py
+++ b/src/bernstein/cli/commands/a2a_cmd.py
@@ -237,17 +237,33 @@ def publish(
         version = installed_version
 
     try:
-        card = _load_or_issue_card(card_path, endpoint=endpoint)
+        card, signing_key = _load_or_issue_card(card_path, endpoint=endpoint)
     except (OSError, ValueError) as exc:
         _fail(f"could not resolve the capability card: {exc}")
         return
+
+    requested = surfaces or PUBLISH_SURFACES
+    # The AGNTCY ADS surface signs fresh provenance, so it needs the node's
+    # private key. In the normal mint-and-reuse flow the key sits beside the
+    # card; if an operator supplied a card without its key sidecar, fail loudly
+    # when the surface is asked for explicitly, and quietly drop it from the
+    # default set otherwise so the keyless surfaces still publish.
+    if "agntcy-ads" in requested and signing_key is None:
+        if surfaces:
+            _fail(
+                "publishing to 'agntcy-ads' needs the node signing key, but no key "
+                "sidecar was found beside the card; re-mint the card or omit this surface"
+            )
+            return
+        requested = tuple(s for s in requested if s != "agntcy-ads")
 
     try:
         publication = build_publication(
             card,
             endpoint=endpoint,
             version=version,
-            surfaces=surfaces or PUBLISH_SURFACES,
+            surfaces=requested,
+            signing_key_pem=signing_key,
         )
     except ValueError as exc:
         _fail(str(exc))
@@ -272,17 +288,23 @@ def publish(
         console.print(f"  {surface}: {path}")
 
 
-def _load_or_issue_card(card_path: Path, *, endpoint: str) -> SignedCapabilityCard:
-    """Return the node's capability card, minting and persisting it once.
+def _load_or_issue_card(card_path: Path, *, endpoint: str) -> tuple[SignedCapabilityCard, bytes | None]:
+    """Return the node's capability card and its private key, minting once.
 
     Reusing a persisted card keeps one stable identity across republications;
     minting a fresh card each time would hand peers a new key to trust on
-    every publish. The private key is written beside the card at ``0600``.
+    every publish. The private key is written beside the card at ``0600`` and
+    returned so provenance-signing surfaces (AGNTCY ADS) can reuse it. When an
+    operator supplied only a card file, the key is ``None`` and the caller
+    decides whether the missing-key surface is required.
     """
-    if card_path.exists():
-        return SignedCapabilityCard.from_json(card_path.read_text(encoding="utf-8"))
-
     key_path = card_path.with_suffix(card_path.suffix + ".key.pem")
+
+    if card_path.exists():
+        signed = SignedCapabilityCard.from_json(card_path.read_text(encoding="utf-8"))
+        private_key_pem = key_path.read_bytes() if key_path.exists() else None
+        return signed, private_key_pem
+
     private_key_pem = key_path.read_bytes() if key_path.exists() else None
 
     signed, private_key_pem = issue_capability_card(
@@ -299,7 +321,7 @@ def _load_or_issue_card(card_path: Path, *, endpoint: str) -> SignedCapabilityCa
     if not key_path.exists():
         key_path.write_bytes(private_key_pem)
         key_path.chmod(0o600)
-    return signed
+    return signed, private_key_pem
 
 
 __all__ = ["a2a_group", "publish", "verify"]

--- a/src/bernstein/core/protocols/a2a/publish.py
+++ b/src/bernstein/core/protocols/a2a/publish.py
@@ -20,13 +20,22 @@ its own projection rather than one lowest-common-denominator record:
     block that :mod:`bernstein.core.protocols.mcp.mcp_verifier` already
     parses, so an MCP-side consumer needs no new primitive.
 
-AGNTCY ADS (OASF descriptor + Sigstore provenance) is a third surface with a
-different trust root again; it is tracked separately rather than shipped
-half-built here.
+``agntcy-ads``
+    An AGNTCY ADS record: an OASF capability descriptor (a deterministic
+    projection of the signed card into the OASF schema shape) bound to the
+    node's key by a Sigstore-style provenance statement. The provenance is a
+    detached JWS (RFC 7515 §A.5) over the RFC 8785-canonical descriptor,
+    signed with the same Ed25519 key that signed the card - the "local-key"
+    mode of :mod:`bernstein.core.security.sigstore_attestation`. Online
+    keyless submission (Fulcio + Rekor) is a separate follow-up; the record
+    verifies offline today. This surface has its own trust root (the OASF
+    descriptor + provenance signature) rather than the bare card, so it gets
+    its own projection.
 
 Every emitted record is verifiable offline with
-:func:`verify_publication_record`, which is what makes the registry a
-transport rather than an authority.
+:func:`verify_publication_record`, and resolvable to a capability-confirmed
+node with :func:`resolve_publication_capability`, which is what makes the
+registry a transport rather than an authority.
 """
 
 from __future__ import annotations
@@ -34,6 +43,7 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from typing import Any
 
 from bernstein.core.interop.a2a_card import (
@@ -41,24 +51,47 @@ from bernstein.core.interop.a2a_card import (
     card_public_key_fingerprint,
     verify_capability_card,
 )
+from bernstein.core.security.agent_card_signer import (
+    canonicalize_jcs,
+    sign_detached_jws_over_canonical,
+    verify_detached_jws_over_canonical,
+)
 
 __all__ = [
+    "AGNTCY_PROVENANCE_TYP",
+    "OASF_SCHEMA_VERSION",
     "PUBLISH_SURFACES",
     "PublicationVerification",
+    "ResolvedPublication",
     "build_a2a_card_record",
+    "build_agntcy_ads_record",
     "build_mcp_registry_record",
     "build_publication",
+    "resolve_publication_capability",
     "verify_publication_record",
 ]
 
-#: Registry surfaces this node can publish to.
-PUBLISH_SURFACES: tuple[str, ...] = ("a2a-card", "mcp-registry")
+#: Registry surfaces this node can publish to. The AGNTCY ADS surface signs a
+#: fresh provenance, so - unlike the other two - it requires the node's signing
+#: key rather than being a pure projection of the public card.
+PUBLISH_SURFACES: tuple[str, ...] = ("a2a-card", "mcp-registry", "agntcy-ads")
 
 #: Publication record schema version. Bumping requires a parallel reader.
 _PUBLICATION_SCHEMA_VERSION: int = 1
 
 #: Prefix the MCP verifier expects on a publisher fingerprint.
 _ED25519_FINGERPRINT_PREFIX = "ed25519/"
+
+#: OASF capability-descriptor schema version the AGNTCY ADS record targets.
+OASF_SCHEMA_VERSION: str = "0.3.1"
+
+#: JWS ``typ`` binding a provenance signature to the AGNTCY ADS surface, so a
+#: signature minted for the capability card or a receipt cannot be replayed as
+#: descriptor provenance.
+AGNTCY_PROVENANCE_TYP: str = "agntcy-ads-provenance+jws"
+
+#: in-toto predicate type carried on the provenance statement.
+_AGNTCY_PREDICATE_TYPE: str = "https://in-toto.io/attestation/agntcy-ads-descriptor/v1"
 
 
 def _canonical(payload: Any) -> bytes:
@@ -158,12 +191,115 @@ def build_mcp_registry_record(
     }
 
 
+def _build_oasf_descriptor(
+    card: SignedCapabilityCard,
+    *,
+    endpoint: str,
+    version: str,
+) -> dict[str, Any]:
+    """Return the OASF capability descriptor for this node.
+
+    The descriptor is a **deterministic projection** of the signed card into
+    the OASF schema shape: every field is derived from a card the node already
+    signed, so a consumer that verifies the provenance and re-derives the
+    descriptor confirms the advertised capabilities are the ones the signed
+    identity backs - not a wider set bolted onto the registry entry.
+
+    No wall-clock value enters the descriptor; ``created_at`` is taken from the
+    signed card, so two runs over the same card yield byte-identical bytes.
+    """
+    body = card.card
+    created_at = datetime.fromtimestamp(body.created_at, tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return {
+        "schema_version": OASF_SCHEMA_VERSION,
+        "name": body.name,
+        "namespace": body.issuer,
+        "version": version,
+        "description": body.description,
+        "authors": [body.issuer],
+        "created_at": created_at,
+        "skills": [{"name": tool} for tool in body.advertised_tools],
+        "locators": [{"type": "a2a", "url": endpoint}],
+        "extensions": [
+            {
+                "name": "schema.oasf.agntcy.org/features/runtime/a2a-policies",
+                "version": "v1",
+                "data": body.policies.to_dict(),
+            }
+        ],
+        "annotations": {"a2a.card.kid": body.kid},
+    }
+
+
+def build_agntcy_ads_record(
+    card: SignedCapabilityCard,
+    *,
+    endpoint: str,
+    version: str,
+    signing_key_pem: bytes | None,
+) -> dict[str, Any]:
+    """Return the AGNTCY ADS record: OASF descriptor + signed provenance.
+
+    The descriptor is projected from the signed card and then attested with a
+    detached-JWS provenance signature over its RFC 8785-canonical bytes,
+    produced with the node's Ed25519 key. That signature - not the registry -
+    is the trust root: a consumer verifies it offline against the card key.
+
+    Args:
+        card: The node's signed capability card.
+        endpoint: Public base URL peers send A2A traffic to.
+        version: Version string to publish.
+        signing_key_pem: The node's Ed25519 private key (PKCS#8 PEM). The
+            AGNTCY surface signs fresh provenance, so - unlike the keyless
+            surfaces - it cannot be built from the public card alone.
+
+    Raises:
+        ValueError: When no signing key is given, the card would not verify, or
+            the key does not match the card's public key.
+    """
+    _require_publishable(card)
+    if signing_key_pem is None:
+        raise ValueError("publishing to 'agntcy-ads' requires the node signing key (signing_key_pem)")
+
+    descriptor = _build_oasf_descriptor(card, endpoint=endpoint, version=version)
+    canonical = canonicalize_jcs(descriptor)
+    provenance_jws = sign_detached_jws_over_canonical(
+        canonical, signing_key_pem, typ=AGNTCY_PROVENANCE_TYP, kid=card.card.kid
+    )
+    # Fail fast if the key does not match the card, rather than emit a record
+    # that only fails at the consumer.
+    if not verify_detached_jws_over_canonical(
+        canonical, provenance_jws, card.card.public_key_pem.encode("ascii"), expected_typ=AGNTCY_PROVENANCE_TYP
+    ):
+        raise ValueError("signing key does not match the capability card's public key")
+
+    subject_digest = hashlib.sha256(canonical).hexdigest()
+    return {
+        "schema_version": _PUBLICATION_SCHEMA_VERSION,
+        "surface": "agntcy-ads",
+        "endpoint": endpoint,
+        "publisher": {
+            "name": card.card.issuer,
+            "fingerprint": _publisher_fingerprint(card),
+            "kid": card.card.kid,
+        },
+        "oasfDescriptor": descriptor,
+        "provenance": {
+            "predicate_type": _AGNTCY_PREDICATE_TYPE,
+            "subject": [{"name": card.card.name, "digest": {"sha256": subject_digest}}],
+            "signature": {"alg": "EdDSA", "kid": card.card.kid, "jws": provenance_jws},
+        },
+        "capabilityCard": card.to_dict(),
+    }
+
+
 def build_publication(
     card: SignedCapabilityCard,
     *,
     endpoint: str,
     version: str,
     surfaces: tuple[str, ...] = PUBLISH_SURFACES,
+    signing_key_pem: bytes | None = None,
 ) -> dict[str, dict[str, Any]]:
     """Return one record per requested surface, keyed by surface name.
 
@@ -172,9 +308,13 @@ def build_publication(
         endpoint: Public base URL peers send A2A traffic to.
         version: Version string to publish.
         surfaces: Surfaces to emit; defaults to all supported ones.
+        signing_key_pem: The node's Ed25519 private key, required only when
+            ``agntcy-ads`` is among ``surfaces`` (its provenance is a fresh
+            signature). Ignored by the keyless surfaces.
 
     Raises:
-        ValueError: On an unknown surface, or a card that would not verify.
+        ValueError: On an unknown surface, a card that would not verify, or a
+            request for ``agntcy-ads`` without a signing key.
     """
     unknown = [s for s in surfaces if s not in PUBLISH_SURFACES]
     if unknown:
@@ -186,6 +326,10 @@ def build_publication(
             records[surface] = build_a2a_card_record(card, endpoint=endpoint)
         elif surface == "mcp-registry":
             records[surface] = build_mcp_registry_record(card, endpoint=endpoint, version=version)
+        elif surface == "agntcy-ads":
+            records[surface] = build_agntcy_ads_record(
+                card, endpoint=endpoint, version=version, signing_key_pem=signing_key_pem
+            )
     return records
 
 
@@ -238,10 +382,10 @@ def verify_publication_record(record: dict[str, Any]) -> PublicationVerification
         errors.append("capabilityCard signature does not verify")
 
     fingerprint = _publisher_fingerprint(card)
-    if surface == "a2a-card":
-        declared = (record.get("publisher") or {}).get("fingerprint")
-    else:
+    if surface == "mcp-registry":
         declared = ((record.get("server") or {}).get("publisher") or {}).get("fingerprint")
+    else:  # a2a-card, agntcy-ads
+        declared = (record.get("publisher") or {}).get("fingerprint")
     if declared != fingerprint:
         errors.append(f"publisher fingerprint {declared!r} does not match the card key {fingerprint!r}")
 
@@ -251,6 +395,124 @@ def verify_publication_record(record: dict[str, Any]) -> PublicationVerification
         if declared_hash != expected:
             errors.append("server.content_hash does not cover the embedded capability card")
 
+    if surface == "agntcy-ads":
+        errors.extend(_verify_agntcy_ads(record, card))
+
     if errors:
         return PublicationVerification(ok=False, errors=errors)
     return PublicationVerification(ok=True, fingerprint=fingerprint)
+
+
+def _verify_agntcy_ads(record: dict[str, Any], card: SignedCapabilityCard) -> list[str]:
+    """Return AGNTCY-ADS-specific verification errors (empty when valid).
+
+    Three layered checks bind the OASF descriptor to the signed card:
+
+    1. The descriptor must be the canonical projection of the card - so a
+       widened capability list is caught even before touching the signature.
+    2. The provenance ``subject`` digest must cover the descriptor bytes.
+    3. The provenance JWS must verify against the card's public key with the
+       AGNTCY-ADS ``typ`` - so only the node's own key can attest a descriptor.
+    """
+    errors: list[str] = []
+    descriptor = record.get("oasfDescriptor")
+    if not isinstance(descriptor, dict):
+        return ["oasfDescriptor is missing or not an object"]
+
+    expected = _build_oasf_descriptor(
+        card, endpoint=str(record.get("endpoint", "")), version=str(descriptor.get("version", ""))
+    )
+    canonical = canonicalize_jcs(descriptor)
+    if canonical != canonicalize_jcs(expected):
+        errors.append("oasfDescriptor is not the canonical projection of the capability card")
+
+    provenance = record.get("provenance")
+    if not isinstance(provenance, dict):
+        errors.append("provenance is missing or not an object")
+        return errors
+
+    subject = provenance.get("subject")
+    declared_digest = None
+    if isinstance(subject, list) and subject and isinstance(subject[0], dict):
+        declared_digest = (subject[0].get("digest") or {}).get("sha256")
+    if declared_digest != hashlib.sha256(canonical).hexdigest():
+        errors.append("provenance subject digest does not cover the OASF descriptor")
+
+    jws = (provenance.get("signature") or {}).get("jws")
+    if not isinstance(jws, str) or not verify_detached_jws_over_canonical(
+        canonical, jws, card.card.public_key_pem.encode("ascii"), expected_typ=AGNTCY_PROVENANCE_TYP
+    ):
+        errors.append("provenance signature does not verify against the capability card key")
+    return errors
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedPublication:
+    """Outcome of resolving a published record to a capability-confirmed node.
+
+    ``ok`` is ``True`` only when the record verifies offline AND (if one was
+    requested) the required capability is advertised. ``capabilities`` is the
+    tool set the node's *signed* card attests, so a caller confirms capability
+    against the identity, not against an unsigned registry field.
+    """
+
+    ok: bool
+    surface: str | None = None
+    endpoint: str | None = None
+    issuer: str | None = None
+    fingerprint: str | None = None
+    capabilities: tuple[str, ...] = ()
+    errors: list[str] = field(default_factory=list)
+
+
+def resolve_publication_capability(
+    record: dict[str, Any],
+    *,
+    required_capability: str | None = None,
+) -> ResolvedPublication:
+    """Resolve a published record to a verified, capability-confirmed node.
+
+    The discovery round-trip a peer runs on any surface: verify the record's
+    provenance offline, read the advertised capability set off the signed
+    card, and - when ``required_capability`` is given - confirm it is present.
+    Never raises on malformed input; a bad record returns ``ok=False``.
+
+    Args:
+        record: A record produced by one of the ``build_*`` functions.
+        required_capability: Optional capability the caller needs. When set and
+            absent from the node's advertised tools, resolution fails with the
+            node still authenticated (the failure is capability, not identity).
+
+    Returns:
+        A :class:`ResolvedPublication`.
+    """
+    surface = record.get("surface") if isinstance(record, dict) else None
+    verification = verify_publication_record(record)
+    if not verification.ok:
+        return ResolvedPublication(ok=False, surface=surface, errors=list(verification.errors))
+
+    card = SignedCapabilityCard.from_dict(record["capabilityCard"])
+    capabilities = tuple(card.card.advertised_tools)
+    endpoint = record.get("endpoint")
+    issuer = card.card.issuer
+
+    if required_capability is not None and required_capability not in capabilities:
+        advertised = ", ".join(capabilities) or "(none)"
+        return ResolvedPublication(
+            ok=False,
+            surface=surface,
+            endpoint=endpoint,
+            issuer=issuer,
+            fingerprint=verification.fingerprint,
+            capabilities=capabilities,
+            errors=[f"required capability {required_capability!r} not advertised (has: {advertised})"],
+        )
+
+    return ResolvedPublication(
+        ok=True,
+        surface=surface,
+        endpoint=endpoint,
+        issuer=issuer,
+        fingerprint=verification.fingerprint,
+        capabilities=capabilities,
+    )

--- a/tests/unit/test_a2a_cli.py
+++ b/tests/unit/test_a2a_cli.py
@@ -265,11 +265,34 @@ def test_publish_rejects_an_unknown_surface(runner: CliRunner, tmp_path: Path) -
             "--output-dir",
             str(tmp_path / "p"),
             "--surface",
-            "agntcy-ads",
+            "not-a-registry",
         ],
     )
 
     assert result.exit_code != 0
+
+
+def test_publish_default_emits_the_agntcy_ads_surface(runner: CliRunner, tmp_path: Path) -> None:
+    """A freshly minted node publishes all three surfaces, AGNTCY included."""
+    out_dir = tmp_path / "publish"
+
+    result = runner.invoke(
+        a2a_group,
+        [
+            "publish",
+            "--endpoint",
+            "https://node.example/a2a",
+            "--output-dir",
+            str(out_dir),
+            "--card",
+            str(tmp_path / "card.json"),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    record = json.loads((out_dir / "agntcy-ads.json").read_text(encoding="utf-8"))
+    assert record["surface"] == "agntcy-ads"
+    assert verify_publication_record(record).ok, record
 
 
 def test_publish_output_is_deterministic(runner: CliRunner, tmp_path: Path) -> None:

--- a/tests/unit/test_a2a_discovery_resolve.py
+++ b/tests/unit/test_a2a_discovery_resolve.py
@@ -1,0 +1,128 @@
+"""Discovery round-trip over published A2A registry records (#2609).
+
+A published record is only useful if a peer can go the whole way from an index
+entry to a callable, capability-confirmed node **without trusting the
+registry**: resolve the record, verify its provenance offline, and confirm the
+capability it needs is one the node's signed identity actually advertises.
+
+``resolve_publication_capability`` is that round-trip primitive; the
+``AgentDiscovery.resolve_published_record`` method is the discovery-side entry
+point. Both must work for every publish surface (A2A card, MCP registry, and
+the AGNTCY ADS / OASF descriptor), so a peer that fetched our record from any
+of them lands in the same verified state.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.agents.discovery import AgentDiscovery
+from bernstein.core.interop.a2a_card import (
+    CardPolicies,
+    SignedCapabilityCard,
+    issue_capability_card,
+)
+from bernstein.core.protocols.a2a.publish import (
+    build_publication,
+    resolve_publication_capability,
+)
+
+
+@pytest.fixture()
+def keyed_card() -> tuple[SignedCapabilityCard, bytes]:
+    return issue_capability_card(
+        issuer="bernstein",
+        name="bernstein",
+        description="Deterministic multi-agent orchestrator.",
+        advertised_tools=["task_orchestration", "code_review"],
+        policies=CardPolicies(cost_cap_usd=0.0, redaction_tier="standard", sandbox_profile="container"),
+    )
+
+
+@pytest.fixture()
+def every_record(keyed_card: tuple[SignedCapabilityCard, bytes]) -> dict[str, dict]:
+    card, private_key = keyed_card
+    return build_publication(
+        card,
+        endpoint="https://node.example/a2a",
+        version="3.9.0",
+        signing_key_pem=private_key,
+    )
+
+
+# ---------------------------------------------------------------------------
+# resolve_publication_capability
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("surface", ["a2a-card", "mcp-registry", "agntcy-ads"])
+def test_resolve_confirms_capability_from_every_surface(every_record: dict[str, dict], surface: str) -> None:
+    resolved = resolve_publication_capability(every_record[surface], required_capability="code_review")
+
+    assert resolved.ok
+    assert resolved.surface == surface
+    assert resolved.endpoint == "https://node.example/a2a"
+    assert resolved.fingerprint.startswith("ed25519/")
+    assert "code_review" in resolved.capabilities
+
+
+@pytest.mark.parametrize("surface", ["a2a-card", "mcp-registry", "agntcy-ads"])
+def test_resolve_reports_a_missing_capability(every_record: dict[str, dict], surface: str) -> None:
+    resolved = resolve_publication_capability(every_record[surface], required_capability="deploy_to_prod")
+
+    assert not resolved.ok
+    assert resolved.errors
+    # The node authenticates, so the failure is about capability, not identity.
+    assert "code_review" in resolved.capabilities
+
+
+@pytest.mark.parametrize("surface", ["a2a-card", "mcp-registry", "agntcy-ads"])
+def test_resolve_rejects_a_tampered_record(every_record: dict[str, dict], surface: str) -> None:
+    record = every_record[surface]
+    record["endpoint"] = "https://evil.example/a2a"
+    # Widen the advertised capability set on whatever the surface exposes.
+    card = record.get("capabilityCard", {}).get("card")
+    if card is not None:
+        card["advertised_tools"] = ["everything"]
+    if "oasfDescriptor" in record:
+        record["oasfDescriptor"]["skills"] = [{"name": "everything"}]
+
+    resolved = resolve_publication_capability(record, required_capability="everything")
+
+    assert not resolved.ok
+    assert resolved.errors
+
+
+def test_resolve_without_a_required_capability_still_verifies(every_record: dict[str, dict]) -> None:
+    resolved = resolve_publication_capability(every_record["a2a-card"])
+
+    assert resolved.ok
+    assert set(resolved.capabilities) == {"task_orchestration", "code_review"}
+
+
+# ---------------------------------------------------------------------------
+# AgentDiscovery.resolve_published_record
+# ---------------------------------------------------------------------------
+
+
+def test_discovery_resolves_and_registers_a_verified_node(tmp_path, every_record: dict[str, dict]) -> None:
+    discovery = AgentDiscovery(registry_path=tmp_path / "registry.json")
+
+    resolved = discovery.resolve_published_record(every_record["agntcy-ads"], required_capability="code_review")
+
+    assert resolved.ok
+    # The verified node is tracked in the directory registry.
+    entries = [d for d in discovery.directories if d.url == "https://node.example/a2a"]
+    assert len(entries) == 1
+    assert entries[0].source_type == "a2a-registry"
+
+
+def test_discovery_does_not_register_an_unverified_node(tmp_path, every_record: dict[str, dict]) -> None:
+    discovery = AgentDiscovery(registry_path=tmp_path / "registry.json")
+    record = every_record["a2a-card"]
+    record["capabilityCard"]["card"]["advertised_tools"] = ["forged"]
+
+    resolved = discovery.resolve_published_record(record)
+
+    assert not resolved.ok
+    assert discovery.directories == []

--- a/tests/unit/test_a2a_publish.py
+++ b/tests/unit/test_a2a_publish.py
@@ -10,6 +10,8 @@ Covered here:
 * **A2A Agent Card** - the JWS-signed card itself (RFC 7515 + RFC 8785).
 * **MCP Registry** - a ``server.json`` carrying the ``ed25519/<fp>``
   publisher fingerprint the MCP verifier already understands.
+* **AGNTCY ADS** - an OASF capability descriptor bound to the node's key by a
+  detached-JWS provenance signature (Sigstore-style, Ed25519 local-key mode).
 """
 
 from __future__ import annotations
@@ -27,11 +29,17 @@ from bernstein.core.interop.a2a_card import (
     verify_capability_card,
 )
 from bernstein.core.protocols.a2a.publish import (
+    AGNTCY_PROVENANCE_TYP,
     PUBLISH_SURFACES,
     build_a2a_card_record,
+    build_agntcy_ads_record,
     build_mcp_registry_record,
     build_publication,
     verify_publication_record,
+)
+from bernstein.core.security.agent_card_signer import (
+    canonicalize_jcs,
+    sign_detached_jws_over_canonical,
 )
 
 if TYPE_CHECKING:
@@ -50,6 +58,22 @@ def signed_card() -> SignedCapabilityCard:
     return signed
 
 
+@pytest.fixture()
+def keyed_card() -> tuple[SignedCapabilityCard, bytes]:
+    """A signed card plus the private key that signed it.
+
+    The AGNTCY ADS surface signs a fresh provenance over the OASF descriptor,
+    so its tests need the node's private key, not only the public card.
+    """
+    return issue_capability_card(
+        issuer="bernstein",
+        name="bernstein",
+        description="Deterministic multi-agent orchestrator.",
+        advertised_tools=["task_orchestration", "code_review"],
+        policies=CardPolicies(cost_cap_usd=0.0, redaction_tier="standard", sandbox_profile="container"),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Surfaces
 # ---------------------------------------------------------------------------
@@ -58,6 +82,7 @@ def signed_card() -> SignedCapabilityCard:
 def test_publish_surfaces_are_declared() -> None:
     assert "a2a-card" in PUBLISH_SURFACES
     assert "mcp-registry" in PUBLISH_SURFACES
+    assert "agntcy-ads" in PUBLISH_SURFACES
 
 
 # ---------------------------------------------------------------------------
@@ -161,8 +186,16 @@ def test_build_publication_emits_every_requested_surface(signed_card: SignedCapa
 
 
 def test_publication_is_deterministic(signed_card: SignedCapabilityCard) -> None:
-    """Two runs over the same card produce byte-identical manifests."""
-    kwargs = {"endpoint": "https://node.example/a2a", "version": "3.8.0"}
+    """Two runs over the same card produce byte-identical manifests.
+
+    Scoped to the keyless surfaces; the AGNTCY ADS surface has its own
+    determinism test (it also needs the private key to sign provenance).
+    """
+    kwargs = {
+        "endpoint": "https://node.example/a2a",
+        "version": "3.8.0",
+        "surfaces": ("a2a-card", "mcp-registry"),
+    }
     first = build_publication(signed_card, **kwargs)
     second = build_publication(signed_card, **kwargs)
 
@@ -175,8 +208,129 @@ def test_unknown_surface_is_rejected(signed_card: SignedCapabilityCard) -> None:
             signed_card,
             endpoint="https://node.example/a2a",
             version="3.8.0",
-            surfaces=("agntcy-ads",),
+            surfaces=("not-a-registry",),
         )
+
+
+# ---------------------------------------------------------------------------
+# AGNTCY ADS surface (OASF descriptor + signed provenance)
+# ---------------------------------------------------------------------------
+
+
+def test_agntcy_ads_record_projects_the_card_into_an_oasf_descriptor(
+    keyed_card: tuple[SignedCapabilityCard, bytes],
+) -> None:
+    card, private_key = keyed_card
+    record = build_agntcy_ads_record(
+        card,
+        endpoint="https://node.example/a2a",
+        version="3.9.0",
+        signing_key_pem=private_key,
+    )
+
+    assert record["surface"] == "agntcy-ads"
+    assert record["endpoint"] == "https://node.example/a2a"
+
+    descriptor = record["oasfDescriptor"]
+    assert descriptor["name"] == card.card.name
+    assert descriptor["version"] == "3.9.0"
+    # The advertised capability set is a projection of the *signed* card, so a
+    # consumer confirms capability against the same tools the card attests.
+    assert [skill["name"] for skill in descriptor["skills"]] == list(card.card.advertised_tools)
+    assert {"type": "a2a", "url": "https://node.example/a2a"} in descriptor["locators"]
+
+
+def test_agntcy_ads_record_carries_verifiable_signed_provenance(
+    keyed_card: tuple[SignedCapabilityCard, bytes],
+) -> None:
+    """The provenance is a real Ed25519 signature over the OASF descriptor."""
+    card, private_key = keyed_card
+    record = build_agntcy_ads_record(
+        card, endpoint="https://node.example/a2a", version="3.9.0", signing_key_pem=private_key
+    )
+
+    provenance = record["provenance"]
+    assert provenance["signature"]["alg"] == "EdDSA"
+    assert provenance["signature"]["kid"] == card.card.kid
+    assert provenance["subject"][0]["digest"]["sha256"]
+
+    expected_fp = card_public_key_fingerprint(card.card.public_key_pem)
+    assert record["publisher"]["fingerprint"] == f"ed25519/{expected_fp}"
+
+    assert verify_publication_record(record).ok
+
+
+def test_agntcy_ads_requires_the_signing_key(keyed_card: tuple[SignedCapabilityCard, bytes]) -> None:
+    card, _private = keyed_card
+    with pytest.raises(ValueError, match="signing key"):
+        build_agntcy_ads_record(card, endpoint="https://e/a2a", version="3.9.0", signing_key_pem=None)
+
+
+def test_tampered_agntcy_descriptor_fails_verification(
+    keyed_card: tuple[SignedCapabilityCard, bytes],
+) -> None:
+    card, private_key = keyed_card
+    record = build_agntcy_ads_record(card, endpoint="https://e/a2a", version="3.9.0", signing_key_pem=private_key)
+    # Widen the advertised capability without re-signing.
+    record["oasfDescriptor"]["skills"].append({"name": "exfiltrate_secrets"})
+
+    result = verify_publication_record(record)
+
+    assert not result.ok
+    assert result.errors
+
+
+def test_agntcy_provenance_signed_by_a_foreign_key_fails(
+    keyed_card: tuple[SignedCapabilityCard, bytes],
+) -> None:
+    """A provenance signature not made by the card's key is rejected."""
+    card, private_key = keyed_card
+    _other, other_key = issue_capability_card(
+        issuer="attacker",
+        name="attacker",
+        description="d",
+        advertised_tools=["x"],
+        policies=CardPolicies(cost_cap_usd=1.0, redaction_tier="none", sandbox_profile="none"),
+    )
+
+    record = build_agntcy_ads_record(card, endpoint="https://e/a2a", version="3.9.0", signing_key_pem=private_key)
+    canonical = canonicalize_jcs(record["oasfDescriptor"])
+    forged = sign_detached_jws_over_canonical(canonical, other_key, typ=AGNTCY_PROVENANCE_TYP, kid=card.card.kid)
+    record["provenance"]["signature"]["jws"] = forged
+
+    assert not verify_publication_record(record).ok
+
+
+def test_agntcy_ads_record_is_deterministic(keyed_card: tuple[SignedCapabilityCard, bytes]) -> None:
+    """EdDSA over a canonical projection is byte-identical across runs."""
+    card, private_key = keyed_card
+    kwargs = {"endpoint": "https://node.example/a2a", "version": "3.9.0", "signing_key_pem": private_key}
+    first = build_agntcy_ads_record(card, **kwargs)
+    second = build_agntcy_ads_record(card, **kwargs)
+
+    assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
+
+
+def test_build_publication_emits_agntcy_with_a_key(keyed_card: tuple[SignedCapabilityCard, bytes]) -> None:
+    card, private_key = keyed_card
+    publication = build_publication(
+        card,
+        endpoint="https://node.example/a2a",
+        version="3.9.0",
+        surfaces=("agntcy-ads",),
+        signing_key_pem=private_key,
+    )
+
+    assert set(publication) == {"agntcy-ads"}
+    assert verify_publication_record(publication["agntcy-ads"]).ok
+
+
+def test_build_publication_agntcy_without_a_key_is_rejected(
+    keyed_card: tuple[SignedCapabilityCard, bytes],
+) -> None:
+    card, _private = keyed_card
+    with pytest.raises(ValueError, match="signing key"):
+        build_publication(card, endpoint="https://e/a2a", version="3.9.0", surfaces=("agntcy-ads",))
 
 
 def test_verification_checks_authenticity_not_freshness(signed_card: SignedCapabilityCard) -> None:


### PR DESCRIPTION
## What
Staleness cross-check confirmed the A2A server core and the first two registry-publication surfaces already shipped (#2677/#2911): signed card at both well-known paths, message/send + tasks/get, card-declared auth, chain-anchored receipts, persisted handler, and `bernstein a2a publish` for the a2a-card + mcp-registry surfaces. The one genuine remaining gap was AC5's third surface — the AGNTCY ADS / OASF capability descriptor with Sigstore-style provenance — plus the discovery resolve->verify->confirm-capability round-trip, both explicitly deferred in the issue comments and in docs/operations/a2a-server.md ("separate follow-up"). Implemented that gap via TDD: a new `agntcy-ads` publish surface emitting an OASF descriptor (a deterministic projection of the signed card) bound to the node's Ed25519 key by a detached-JWS provenance over the RFC 8785-canonical descriptor, offline-verifiable against the card key with an AGNTCY-scoped `typ`; plus `resolve_publication_capability` / `AgentDiscov

Fixes #2609

## Items
- **AC1: /.well-known/agent.json serves a JWS SignedCapabilityCard, offline-verifiable, tampered card fa** — already-shipped
- **AC2: every inbound POST /a2a/tasks/send response carries a lineage receipt {entry_hash, content_hash** — already-shipped
- **AC3: EMPIRICAL — `bernstein a2a verify --receipt` rejects a one-byte-tampered answer, untampered ver** — already-shipped
- **AC4: two identical inbound tasks produce byte-identical receipts (deterministic projection)** — already-shipped
- **AC5: `bernstein a2a publish` emits records for A2A card; MCP registry; AGNTCY ADS/OASF descriptor wi** — fixed
- **AC6: handler state survives a server restart (loss-on-restart flag closed)** — already-shipped

## Verification
Adversarial review: **confirmed, 0 critical**. 
TDD: wrote failing tests first (import errors captured as red), then implemented to green. New/updated tests: tests/unit/test_a2a_publish.py (AGNTCY build/verify/tamper/foreign-key/determinism/key-required), tests/unit/test_a2a_discovery_resolve.py (new: resolve+confirm capability across all 3 surfaces, tamper rejection, missing-capability, discovery register/no-register), tests/unit/test_a2a_cli.
