### PR TITLE
fix(ci): harden the weekly-digest workflow

### DIFF
--- a/.github/workflows/ci-weekly-digest.yml
+++ b/.github/workflows/ci-weekly-digest.yml
@@ -75,7 +75,6 @@ jobs:
           WEEK_LABEL=$(date -u +'%G-W%V')
           SINCE=$(date -u -d "${LOOKBACK_DAYS} days ago" +'%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
             || date -u -v-"${LOOKBACK_DAYS}"d +'%Y-%m-%dT%H:%M:%SZ')
-          SINCE_DATE="${SINCE%T*}"
           TITLE="CI weekly digest ${WEEK_LABEL}"
           export TITLE
 
@@ -83,23 +82,31 @@ jobs:
 
           # ----- collect: open + recently-closed auto-release-skipped issues.
           # Both states, so the digest reflects the week even when per-event
-          # issues self-closed during cleanup.
+          # issues self-closed during cleanup. The exact ${SINCE} timestamp
+          # (not a midnight-truncated date) enforces the precise 7-day cutoff,
+          # and an explicit --limit prevents the default 30-item cap from
+          # silently undercounting on a busy week. No `|| true`: a
+          # transport/auth/pagination error must fail the step rather than
+          # publish a false "clean" digest while still closing tracking issues.
           SKIPPED=$(gh issue list --repo "${REPO}" --state all \
-            --search "in:title auto-release skipped updated:>=${SINCE_DATE}" \
-            --json number --jq '[.[].number] | join(" ")' \
-            || true)
+            --search "in:title auto-release skipped updated:>=${SINCE}" \
+            --limit 100 \
+            --json number --jq '[.[].number] | join(" ")')
 
           # ----- collect: main-branch runs in the window. Server-side
           # `created` filter + --paginate means we see EVERY run in the
           # window, not just the most recent 100 (the previous single-page
-          # query silently dropped failures on busy weeks).
+          # query silently dropped failures on busy weeks). The full ${SINCE}
+          # timestamp keeps the cutoff exact; dropping `|| true` makes a failed
+          # collection fail the step instead of yielding an empty run set that
+          # reads as a clean week.
           RUNS_FILE="$(mktemp)"
           gh api --paginate -X GET "repos/${REPO}/actions/runs" \
             -f branch=main \
-            -f "created=>=${SINCE_DATE}" \
+            -f "created=>=${SINCE}" \
             -f per_page=100 \
             --jq '.workflow_runs[] | {id, conclusion, event, name, head_sha, html_url}' \
-            > "${RUNS_FILE}" || true
+            > "${RUNS_FILE}"
 
           # ----- classify + render (unit-tested, deterministic aggregation)
           BODY_FILE="$(mktemp)"
@@ -132,15 +139,23 @@ jobs:
             DIGEST_NUMBER="${EXISTING}"
           else
             echo "Creating new digest issue"
-            # `ci` is the only guaranteed label; fall back to no label so a
-            # missing label never blocks publishing.
-            DIGEST_URL=$(gh issue create --repo "${REPO}" \
-              --title "${TITLE}" \
-              --body-file "${BODY_FILE}" \
-              --label "ci" 2>/dev/null \
-              || gh issue create --repo "${REPO}" \
+            # Apply the `ci` label only when it is confirmed to exist. A blind
+            # `create --label ci || create` retries on *any* failure -- including
+            # a transport error that already created the issue -- and can open a
+            # duplicate digest. Probing the label first makes the choice
+            # deterministic: exactly one create runs, chosen by a real condition,
+            # never an error-triggered second attempt.
+            LABELS=$(gh label list --repo "${REPO}" --limit 100 --json name --jq '.[].name')
+            if grep -qxF "ci" <<<"${LABELS}"; then
+              DIGEST_URL=$(gh issue create --repo "${REPO}" \
+                --title "${TITLE}" \
+                --body-file "${BODY_FILE}" \
+                --label "ci")
+            else
+              DIGEST_URL=$(gh issue create --repo "${REPO}" \
                 --title "${TITLE}" \
                 --body-file "${BODY_FILE}")
+            fi
             DIGEST_NUMBER=$(basename "${DIGEST_URL}")
           fi
 
@@ -150,6 +165,7 @@ jobs:
           mapfile -t OLD_DIGESTS < <(
             gh issue list --repo "${REPO}" --state open \
               --search "in:title \"CI weekly digest\"" \
+              --limit 100 \
               --json number,title,author \
               --jq '.[]
                     | select(.author.is_bot == true)
@@ -171,6 +187,7 @@ jobs:
           mapfile -t OPEN_SKIPPED < <(
             gh issue list --repo "${REPO}" --state open \
               --search "in:title auto-release skipped" \
+              --limit 100 \
               --json number \
               --jq '.[].number' \
               || true

--- a/tests/unit/test_ci_weekly_digest_workflow_yaml.py
+++ b/tests/unit/test_ci_weekly_digest_workflow_yaml.py
@@ -1,0 +1,115 @@
+"""Structural hardening assertions for ``ci-weekly-digest.yml``.
+
+The aggregation maths live in ``scripts/ci_weekly_digest.py`` (covered by
+``test_ci_weekly_digest.py``). The *shell* step that collects signal and
+mutates the tracker is equally trust-critical: a swallowed collection error
+publishes a false "clean" digest while still closing tracking issues, a
+default-capped cleanup query leaves stale issues open forever, a blind
+create-fallback can open a duplicate digest, and a midnight-truncated window
+widens the 7-day cutoff by up to a day. These tests pin those invariants on
+the workflow text so a regression is caught at unit time, not in production.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - dev env should have pyyaml
+    pytest.skip("pyyaml not installed", allow_module_level=True)
+
+
+WORKFLOW = Path(".github/workflows/ci-weekly-digest.yml")
+STEP_NAME = "Build and publish weekly digest"
+
+
+def _mapping(value: object) -> dict[str, object]:
+    assert isinstance(value, dict)
+    return {str(key): item for key, item in cast("dict[object, object]", value).items()}
+
+
+@pytest.fixture(scope="module")
+def digest_run() -> str:
+    """The shell body of the digest build-and-publish step."""
+    parsed = cast("object", yaml.safe_load(WORKFLOW.read_text(encoding="utf-8")))
+    workflow = _mapping(parsed)
+    jobs = _mapping(workflow.get("jobs"))
+    digest = _mapping(jobs.get("digest"))
+    steps = digest.get("steps")
+    assert isinstance(steps, list)
+    for step in cast("list[object]", steps):
+        step_map = _mapping(step)
+        if step_map.get("name") == STEP_NAME:
+            run = step_map.get("run")
+            assert isinstance(run, str)
+            return run
+    raise AssertionError(f"step {STEP_NAME!r} not found")
+
+
+def _slice(run: str, start: str, end: str) -> str:
+    assert start in run, f"marker {start!r} missing"
+    assert end in run, f"marker {end!r} missing"
+    return run.split(start, 1)[1].split(end, 1)[0]
+
+
+def _code_only(fragment: str) -> str:
+    """Drop shell comment lines so assertions target executable text only."""
+    return "\n".join(ln for ln in fragment.splitlines() if not ln.strip().startswith("#"))
+
+
+# --- item 1: collection errors must fail the step, not publish a false clean ---
+
+
+def test_collection_commands_do_not_swallow_errors(digest_run: str) -> None:
+    collect = _slice(digest_run, "# ----- collect:", "# ----- classify")
+    # both collection sources present ...
+    assert "gh issue list" in collect
+    assert "gh api --paginate" in collect
+    # ... and neither executable line is guarded by `|| true`, so
+    # transport/auth/pagination failures fail the step before any issue is
+    # closed. (Comment prose may mention the phrase; only code is checked.)
+    assert "|| true" not in _code_only(collect), "collection command still swallows errors with `|| true`"
+
+
+# --- item 2: cleanup must not silently cap at gh's 30-item default -------------
+
+
+def test_rollforward_cleanup_query_uses_explicit_limit(digest_run: str) -> None:
+    roll_forward = _slice(digest_run, "# ----- roll forward:", "# ----- close per-event")
+    assert "gh issue list" in roll_forward
+    assert "--limit" in roll_forward, "prior-digest cleanup query omits --limit (caps at 30)"
+
+
+def test_close_skipped_cleanup_query_uses_explicit_limit(digest_run: str) -> None:
+    close_events = _slice(digest_run, "# ----- close per-event", "# ----- run summary")
+    assert "gh issue list" in close_events
+    assert "--limit" in close_events, "per-event cleanup query omits --limit (caps at 30)"
+
+
+# --- item 3: issue creation must never blindly retry into a duplicate ----------
+
+
+def test_issue_create_has_no_blind_fallback(digest_run: str) -> None:
+    normalized = " ".join(digest_run.split())
+    assert "|| gh issue create" not in normalized, "blind create-fallback can open a duplicate digest"
+
+
+def test_issue_create_probes_label_existence(digest_run: str) -> None:
+    # The `ci` label is applied only when confirmed to exist, so a missing
+    # label degrades deterministically instead of via an error-triggered retry.
+    assert "gh label list" in digest_run
+
+
+# --- item 4: the window must use the exact 7-day cutoff, not midnight ----------
+
+
+def test_digest_window_uses_exact_timestamp_cutoff(digest_run: str) -> None:
+    # The full ISO timestamp (SINCE), not a midnight-truncated date, drives
+    # both the run and the auto-release-skipped filters.
+    assert "SINCE_DATE" not in digest_run, "digest window still truncates SINCE to a midnight date"
+    assert "created=>=${SINCE}" in digest_run
+    assert "updated:>=${SINCE}" in digest_run


### PR DESCRIPTION
## What
Hardened .github/workflows/ci-weekly-digest.yml against 4 correctness/data-integrity gaps in the gh shell step. Staleness cross-check: all 4 checklist items were GENUINE gaps on current main (HEAD 16084aaf5) — none already shipped. The generic hardening axes named in guidance (SHA-pinned actions, least-privilege permissions:{}, injection-safe env interpolation) were already satisfied on main and left untouched. Added one regression test file (6 tests) pinning each invariant on the workflow text. Regenerated ci-topology.md (byte-identical, no graph change since only shell internals changed); actionlint clean. One coherent commit, pushed, no PR.

Fixes #2645

## Items
- **Item 1 — collection commands swallow errors via `|| true`, publishing a false clean digest while sti** — fixed
- **Item 2 — cleanup queries omit --limit, so stale issues beyond gh's 30 default are never closed (corr** — fixed
- **Item 3 — blind `gh issue create --label ci || create` fallback can open a duplicate digest (data-int** — fixed
- **Item 4 — digest window uses a midnight-truncated date instead of the exact 7-day cutoff (correctness** — fixed

## Verification
Adversarial review: **confirmed, 0 critical**. Workflow edit: ci-topology.md regenerated in the same commit, actionlint clean.
TDD followed. New file tests/unit/test_ci_weekly_digest_workflow_yaml.py: 6 tests, one+ per checklist item, asserting hardening invariants on the parsed workflow run script (collection region has no `|| true` on executable lines; both cleanup queries carry --limit; no `|| gh issue create` blind fallback + label probe present; no SINCE_DATE + filters use `${SINCE}`). Captured RED (6 failed) before 
