### PR TITLE
fix(security): harden skills packaging and its publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -364,17 +364,31 @@ jobs:
             exit 1
           fi
       - name: Install mcp-publisher
+        env:
+          # Pinned mcp-publisher release. Bumping requires updating the tag and
+          # the sha256 from that release's published checksums.txt together.
+          MCP_PUBLISHER_VERSION: v1.8.0
+          MCP_PUBLISHER_SHA256: 1370446bbe74d562608e8005a6ccce02d146a661fbd78674e11cc70b9618d6cf
         run: |
           set -euo pipefail
+          # This job holds id-token: write, so the publisher binary must be
+          # pinned and integrity-checked before it runs. A moving "latest"
+          # download would let an upstream tag change what executes here;
+          # instead fetch a pinned immutable release-tag asset and verify it
+          # against a sha256 recorded at authoring time before extract/execute.
           OS=$(uname -s | tr '[:upper:]' '[:lower:]')
           ARCH=$(uname -m)
-          case "$ARCH" in
-            x86_64) ARCH=amd64 ;;
-            aarch64) ARCH=arm64 ;;
-          esac
+          if [ "$OS" != "linux" ] || [ "$ARCH" != "x86_64" ]; then
+            echo "::error::pinned mcp-publisher checksum covers linux/amd64 only; runner is ${OS}/${ARCH}"
+            exit 1
+          fi
+          asset="mcp-publisher_linux_amd64.tar.gz"
           curl -fsSL \
-            "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_${OS}_${ARCH}.tar.gz" \
-            | tar xz mcp-publisher
+            "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/${asset}" \
+            -o "$asset"
+          echo "${MCP_PUBLISHER_SHA256}  ${asset}" | sha256sum -c -
+          tar xz -f "$asset" mcp-publisher
+          rm -f "$asset"
           ./mcp-publisher --version
       - name: Publish server.json
         run: |

--- a/src/bernstein/cli/commands/skills_package_cmd.py
+++ b/src/bernstein/cli/commands/skills_package_cmd.py
@@ -57,9 +57,16 @@ def _resolve_dest(
     dest: str | None,
     workdir: Path,
 ) -> tuple[Path, str, str]:
-    """Return ``(dest, host_label, scope_label)`` from the CLI selection."""
+    """Return ``(dest, host_label, scope_label)`` from the CLI selection.
+
+    An explicit ``--dest`` overrides ``--host``/``--scope`` (as documented on
+    the option), so the labels stamped into the receipt and audit event are
+    always ``('dest', 'dest')`` when a destination is given -- recording the
+    host/scope the operator also happened to pass would attribute an arbitrary
+    path to a host default it never touched (issue #2642).
+    """
     if dest is not None:
-        return Path(dest), host or "dest", "dest" if host is None else scope
+        return Path(dest), "dest", "dest"
     if host is None:
         raise click.ClickException("Provide --host (with optional --scope) or an explicit --dest.")
     try:

--- a/src/bernstein/core/skills/packaging.py
+++ b/src/bernstein/core/skills/packaging.py
@@ -137,9 +137,11 @@ def tree_content_hash(root: Path) -> str:
     relpath - byte-sensitive, name-sensitive, and location-independent.
 
     Raises:
-        PackagedInstallError: When *root* is not a directory, is empty, or
-            contains a symlink.
+        PackagedInstallError: When *root* is a symlink, is not a directory, is
+            empty, or contains a symlink.
     """
+    if root.is_symlink():
+        raise PackagedInstallError(f"refusing to hash symlinked skill tree: {root}")
     if not root.is_dir():
         raise PackagedInstallError(f"not a directory: {root}")
     entries: list[list[str]] = []
@@ -294,9 +296,14 @@ def install_packaged_skill(
         hash, and spine anchor.
 
     Raises:
-        PackagedInstallError: Missing tree, divergent destination without
-            ``force``, or path escape.
+        PackagedInstallError: Missing tree, symlinked destination, divergent
+            destination without ``force``, or path escape.
     """
+    # A symlinked destination would let the copy (or the record-only hash)
+    # follow the link and write into / read from the target outside the
+    # requested path. Refuse it before any hashing or copying (issue #2642).
+    if dest.is_symlink():
+        raise PackagedInstallError(f"refusing to install into symlinked destination: {dest}")
     copied = False
     if record_only:
         if not dest.is_dir():
@@ -697,6 +704,12 @@ def verify_packaged_install(
     tampered tree resolves to a content address with neither receipt - the
     tamper verdict is structural, not a comparison an attacker can update.
 
+    A verified receipt and spine are only half the attestation the install
+    emits: every install also mirrors a ``plugin.install_receipt`` (or, for an
+    updated tree, a ``plugin.update_receipt``) event into the HMAC audit chain.
+    Verification requires that event too, so a partial attestation -- a receipt
+    and spine written without the chain mirror -- cannot pass.
+
     Args:
         workdir: Project root holding ``.sdd/``.
         dest: The installed skill / plugin directory.
@@ -718,12 +731,61 @@ def verify_packaged_install(
         installed_manifest_hash=manifest_hash,
     )
     if result.ok or read_install_receipt(workdir, skill_hash) is not None:
-        return result
-    return _verify_updated_install(
+        spine_result = result
+        is_update = False
+    else:
+        spine_result = _verify_updated_install(
+            workdir=workdir,
+            hmac_key=hmac_key,
+            skill_hash=skill_hash,
+            installed_manifest_hash=manifest_hash,
+        )
+        is_update = True
+    if not spine_result.ok:
+        return spine_result
+    return _require_chain_event(
         workdir=workdir,
         hmac_key=hmac_key,
         skill_hash=skill_hash,
-        installed_manifest_hash=manifest_hash,
+        manifest_hash=manifest_hash,
+        is_update=is_update,
+    )
+
+
+def _require_chain_event(
+    *,
+    workdir: Path,
+    hmac_key: bytes,
+    skill_hash: str,
+    manifest_hash: str,
+    is_update: bool,
+) -> InstallVerifyResult:
+    """Require a matching install/update event in the HMAC audit chain.
+
+    The chain is verified end-to-end and a ``plugin.install_receipt`` (or
+    ``plugin.update_receipt`` for an updated tree) event whose ``skill_hash``
+    and ``manifest_hash`` match the installed content must be present. A
+    receipt/spine written without this event -- a partial attestation -- fails
+    here rather than passing on the receipt alone.
+    """
+    from bernstein.core.security.audit_chain import (
+        EVENT_PLUGIN_INSTALL_RECEIPT,
+        EVENT_PLUGIN_UPDATE_RECEIPT,
+        AuditChainStore,
+    )
+
+    event_type = EVENT_PLUGIN_UPDATE_RECEIPT if is_update else EVENT_PLUGIN_INSTALL_RECEIPT
+    chain = AuditChainStore(workdir / ".sdd" / "audit", key=hmac_key)
+    ok, errors, events = chain.verify_and_query(event_type=event_type, resource_id=skill_hash)
+    if not ok:
+        joined = "; ".join(errors)[:160]
+        return InstallVerifyResult(ok=False, reason=f"audit chain failed verification ({joined})")
+    for event in events:
+        if event.details.get("skill_hash") == skill_hash and event.details.get("manifest_hash") == manifest_hash:
+            return InstallVerifyResult(ok=True, reason="")
+    return InstallVerifyResult(
+        ok=False,
+        reason=f"no matching {event_type} event in the audit chain for {skill_hash[:19]}...",
     )
 
 

--- a/tests/unit/cli/test_skills_package_cmd.py
+++ b/tests/unit/cli/test_skills_package_cmd.py
@@ -62,6 +62,41 @@ def test_install_to_dest_writes_receipt_and_verifies(tmp_path: Path) -> None:
     assert verify.exit_code == 0, verify.output
 
 
+def test_dest_overrides_host_scope_in_audit_labels(tmp_path: Path) -> None:
+    """An explicit --dest is documented to override --host/--scope; the audit
+    event and install_id must record the override, not the arbitrary host/scope
+    the operator also passed (data-integrity, issue #2642)."""
+    from bernstein.core.security.audit_chain import (
+        EVENT_PLUGIN_INSTALL_RECEIPT,
+        AuditChainStore,
+    )
+
+    workdir = _workdir(tmp_path)
+    dest = tmp_path / "explicit" / PACKAGED_SKILL_NAME
+    result = CliRunner().invoke(
+        package_group,
+        [
+            "install",
+            "--dest",
+            str(dest),
+            "--host",
+            "claude",
+            "--scope",
+            "user",
+            "--workdir",
+            str(workdir),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    chain = AuditChainStore(workdir / ".sdd" / "audit", key=_KEY)
+    events = chain.query(event_type=EVENT_PLUGIN_INSTALL_RECEIPT)
+    assert len(events) == 1
+    assert events[0].details["host"] == "dest"
+    assert events[0].details["scope"] == "dest"
+    assert events[0].details["install_id"] == "agent-plugin-dest-dest"
+
+
 def test_install_host_scope_project_targets_host_dir(tmp_path: Path) -> None:
     workdir = _workdir(tmp_path)
     result = CliRunner().invoke(

--- a/tests/unit/core/skills/test_packaging.py
+++ b/tests/unit/core/skills/test_packaging.py
@@ -95,6 +95,17 @@ def test_manifest_hash_prefers_skill_md(tmp_path: Path) -> None:
     assert len(digest) == 64
 
 
+def test_tree_content_hash_rejects_symlinked_root(tmp_path: Path) -> None:
+    """A symlinked tree root is refused: following it would hash bytes outside
+    the requested path (security, issue #2642)."""
+    real = tmp_path / "real"
+    _write_tree(real, {"SKILL.md": "content\n"})
+    link = tmp_path / "link"
+    link.symlink_to(real, target_is_directory=True)
+    with pytest.raises(PackagedInstallError):
+        tree_content_hash(link)
+
+
 # ---------------------------------------------------------------------------
 # Bundled asset resolution
 # ---------------------------------------------------------------------------
@@ -236,6 +247,33 @@ def test_record_only_anchors_existing_tree_without_copying(tmp_path: Path) -> No
     assert read_install_receipt(workdir, outcome.skill_hash) is not None
 
 
+def test_install_rejects_symlinked_dest(tmp_path: Path) -> None:
+    """A symlinked destination is refused before any copy, so the install can
+    never write into the link target outside the requested path (security,
+    issue #2642)."""
+    workdir = tmp_path / "proj"
+    workdir.mkdir()
+    source = _skill_fixture(tmp_path)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    dest_parent = tmp_path / "host"
+    dest_parent.mkdir()
+    dest = dest_parent / PACKAGED_SKILL_NAME
+    dest.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(PackagedInstallError):
+        install_packaged_skill(
+            workdir=workdir,
+            dest=dest,
+            source=source,
+            hmac_key=_KEY,
+            install_id="i1",
+            timestamp=1,
+        )
+    # The copy never ran: nothing leaked into the symlink target.
+    assert not any(outside.iterdir())
+
+
 def test_record_only_missing_dest_raises(tmp_path: Path) -> None:
     with pytest.raises(PackagedInstallError):
         install_packaged_skill(
@@ -315,6 +353,37 @@ def test_verify_detects_spine_tamper(tmp_path: Path) -> None:
 def test_verify_missing_dest_reports_bad_input(tmp_path: Path) -> None:
     result = verify_packaged_install(workdir=tmp_path, dest=tmp_path / "absent", hmac_key=_KEY)
     assert not result.ok
+
+
+def test_verify_rejects_receipt_without_chain_event(tmp_path: Path) -> None:
+    """A receipt + spine written without the matching audit-chain event is a
+    partial attestation and must not verify (data-integrity, issue #2642)."""
+    from bernstein.core.skills.provenance import InstallReceipt, write_install_receipt
+
+    workdir = tmp_path / "proj"
+    workdir.mkdir()
+    dest = tmp_path / "host" / PACKAGED_SKILL_NAME
+    _write_tree(dest, {"SKILL.md": "---\nname: bernstein-run\n---\nbody\n"})
+    skill_hash = tree_content_hash(dest)
+    _, manifest_hash = manifest_hash_for(dest)
+
+    # Anchor the receipt and spine directly, bypassing the audit-chain mirror
+    # install_packaged_skill would otherwise write.
+    write_install_receipt(
+        workdir=workdir,
+        lineage_root=workdir / ".sdd" / "lineage",
+        hmac_key=_KEY,
+        receipt=InstallReceipt(
+            skill_hash=skill_hash,
+            manifest_hash=manifest_hash,
+            install_id="i1",
+            timestamp=1,
+        ),
+    )
+
+    result = verify_packaged_install(workdir=workdir, dest=dest, hmac_key=_KEY)
+    assert not result.ok
+    assert "chain" in result.reason.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_publish_workflow_yaml.py
+++ b/tests/unit/test_publish_workflow_yaml.py
@@ -1,0 +1,71 @@
+"""Structural assertions on ``.github/workflows/publish.yml`` (issue #2642).
+
+The MCP-registry publish job runs with ``id-token: write``; the tool it
+downloads and executes there must be pinned to an immutable release and
+integrity-checked before it runs, so an upstream ``releases/latest`` move
+cannot change what executes in the privileged job.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - dev env should have pyyaml
+    pytest.skip("pyyaml not installed", allow_module_level=True)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "publish.yml"
+
+
+def _load(path: Path) -> dict[str, Any]:
+    return cast("dict[str, Any]", yaml.safe_load(path.read_text(encoding="utf-8")))
+
+
+def _step_run(workflow: dict[str, Any], job_name: str, step_name: str) -> str:
+    job = workflow["jobs"][job_name]
+    for step_value in job.get("steps", []):
+        if isinstance(step_value, dict) and step_value.get("name") == step_name:
+            run = step_value.get("run")
+            assert isinstance(run, str)
+            return run
+    pytest.fail(f"{WORKFLOW.name}::{job_name} has no step named {step_name!r}")
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict[str, Any]:
+    return _load(WORKFLOW)
+
+
+def test_mcp_publisher_download_is_pinned_not_latest(workflow: dict[str, Any]) -> None:
+    run = _step_run(workflow, "publish-mcp-registry", "Install mcp-publisher")
+    assert "releases/latest" not in run
+    # Immutable release-tag asset URL.
+    assert "releases/download/" in run
+
+
+def test_mcp_publisher_download_is_checksum_verified(workflow: dict[str, Any]) -> None:
+    """The pinned asset is verified against a recorded sha256 before it is
+    extracted and executed."""
+    job = workflow["jobs"]["publish-mcp-registry"]
+    install_step = next(
+        step for step in job["steps"] if isinstance(step, dict) and step.get("name") == "Install mcp-publisher"
+    )
+    run = install_step["run"]
+    env = install_step.get("env", {})
+    assert "MCP_PUBLISHER_SHA256" in env
+    # A pinned, non-empty 64-hex checksum.
+    checksum = str(env["MCP_PUBLISHER_SHA256"])
+    assert len(checksum) == 64
+    assert all(c in "0123456789abcdef" for c in checksum)
+    # The checksum is enforced (sha256sum -c) before the archive is unpacked.
+    verify_pos = run.find("sha256sum -c")
+    extract_pos = run.find("tar ")
+    assert verify_pos != -1, "checksum is never verified"
+    assert extract_pos != -1, "archive is never extracted"
+    assert verify_pos < extract_pos, "checksum must be verified before extraction"


### PR DESCRIPTION
## What
All four checklist items were genuine gaps on current main (origin/main @16084aaf5). Each was closed TDD (failing test captured first, then fix). 3 coherent commits pushed. No PR opened. New/changed regression tests: 63 passed; unit collection sentinel: 38494 collected, no errors; changed source files clean under ruff + mypy; publish.yml passes actionlint; ci-topology.md regenerated (no drift).

Fixes #2642

## Items
- **publish.yml:360 — unpinned mcp-publisher from releases/latest executed in an id-token: write job** — fixed
- **skills_package_cmd.py:62 — audit/receipt records host+scope for an arbitrary --dest, contradicting t** — fixed
- **packaging.py:238 — symlinked install destination followed; copy writes into the link target outside ** — fixed
- **packaging.py:713 — verify_packaged_install proves receipt/spine but never requires the matching audi** — fixed

## Verification
Adversarial review: **confirmed, 0 critical**. Workflow edit: ci-topology.md regenerated in the same commit, actionlint clean.
Added 6 regression tests across 3 files: tests/unit/test_publish_workflow_yaml.py (new, 2 tests: pinned-not-latest, checksum-verified-before-extract); tests/unit/core/skills/test_packaging.py (+3: symlinked root rejected, symlinked dest rejected pre-copy, receipt-without-chain-event fails verify); tests/unit/cli/test_skills_package_cmd.py (+1: --dest overrides host/scope in audit labels). Full aff
