### PR TITLE
chore(deps): update sigstore/cosign to v3

### DIFF
--- a/.github/workflows/airgap-e2e.yml
+++ b/.github/workflows/airgap-e2e.yml
@@ -70,7 +70,7 @@ jobs:
         # stable since v2.0.0 (Jan 2023).
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
-          cosign-release: v2.6.4
+          cosign-release: v3.1.1
 
       - name: Install gpg + unshare prerequisites
         run: |

--- a/docs/installation/air-gap.md
+++ b/docs/installation/air-gap.md
@@ -51,6 +51,15 @@ COSIGN_KEY=/secure/path/cosign.key \
   bash scripts/sign_airgap_wheelhouse.sh dist/airgap-wheelhouse/1.10.0
 ```
 
+**cosign versions.** The signing script is tested against cosign
+v2.4.x, v2.6.x, and v3.x, and adapts its flags to whichever is on
+`PATH`. cosign v3 changed two `sign-blob` defaults
+(`--use-signing-config` and `--new-bundle-format`) that are
+incompatible with offline keyed signing; the script opts back out of
+both when it detects a release that supports them. The detached
+`<wheel>.sig` layout is identical across all three, so a bundle signed
+under one version verifies under the others.
+
 Result: `dist/airgap-wheelhouse/1.10.0/` containing
 
 ```

--- a/scripts/sign_airgap_wheelhouse.sh
+++ b/scripts/sign_airgap_wheelhouse.sh
@@ -51,10 +51,28 @@ if [[ "${COSIGN_TLOG_UPLOAD:-}" == "true" ]]; then
   TLOG_FLAG="--tlog-upload=true"
 fi
 
+# cosign v3 flipped two sign-blob defaults that break keyed offline
+# detached signing (--tlog-upload=false + --output-signature):
+#   * --use-signing-config now defaults to true and rejects
+#     --tlog-upload=false outright;
+#   * --new-bundle-format now defaults to true and requires --bundle,
+#     so --output-signature alone errors out.
+# Opt back out of both when the installed cosign supports them.
+# --use-signing-config in the help text is the version signal: releases
+# that list it (v2.6+, v3) accept both opt-outs, while older releases
+# (<= v2.4.x) already default both behaviours off. --new-bundle-format
+# itself cannot be probed the same way -- v3 hides it from --help as
+# deprecated while still accepting it.
+COMPAT_FLAGS=()
+SIGN_BLOB_HELP="$(cosign sign-blob --help 2>&1 || true)"
+if [[ "$SIGN_BLOB_HELP" == *"--use-signing-config"* ]]; then
+  COMPAT_FLAGS+=("--use-signing-config=false" "--new-bundle-format=false")
+fi
+
 sign_blob() {
   local target="$1"
   local sig="${target}.sig"
-  cosign sign-blob --yes "$TLOG_FLAG" --key "$COSIGN_KEY" --output-signature "$sig" "$target" >/dev/null
+  cosign sign-blob --yes "$TLOG_FLAG" ${COMPAT_FLAGS[@]+"${COMPAT_FLAGS[@]}"} --key "$COSIGN_KEY" --output-signature "$sig" "$target" >/dev/null
   echo "signed: ${target##*/}"
 }
 
@@ -65,7 +83,7 @@ done
 
 manifest_target="$WHEELHOUSE_DIR/MANIFEST.json"
 manifest_sig="$WHEELHOUSE_DIR/MANIFEST.sig"
-cosign sign-blob --yes "$TLOG_FLAG" --key "$COSIGN_KEY" --output-signature "$manifest_sig" "$manifest_target" >/dev/null
+cosign sign-blob --yes "$TLOG_FLAG" ${COMPAT_FLAGS[@]+"${COMPAT_FLAGS[@]}"} --key "$COSIGN_KEY" --output-signature "$manifest_sig" "$manifest_target" >/dev/null
 echo "signed: MANIFEST.json -> MANIFEST.sig"
 
 echo

--- a/tests/integration/test_airgap_offline_e2e.py
+++ b/tests/integration/test_airgap_offline_e2e.py
@@ -23,6 +23,7 @@ boundary. This file is the proof harness.
 
 from __future__ import annotations
 
+import functools
 import json
 import os
 import shutil
@@ -64,6 +65,34 @@ from tests.fixtures.airgap import WheelhouseFixture, build_wheelhouse
 _HAS_COSIGN: Final[bool] = shutil.which("cosign") is not None
 _HAS_GPG: Final[bool] = shutil.which("gpg") is not None or shutil.which("gpg2") is not None
 _IS_LINUX: Final[bool] = sys.platform.startswith("linux")
+
+
+@functools.cache
+def _cosign_sign_blob_compat_flags() -> tuple[str, ...]:
+    """Extra ``sign-blob`` flags for keyed offline detached signing.
+
+    cosign v3 flipped two defaults that break the
+    ``--tlog-upload=false`` + ``--output-signature`` invocation:
+    ``--use-signing-config`` (rejects ``--tlog-upload=false``) and
+    ``--new-bundle-format`` (requires ``--bundle``). Opt back out of
+    both when the installed cosign supports them. ``--use-signing-config``
+    in the help text is the version signal: releases that list it
+    (v2.6+, v3) accept both opt-outs, while older releases (<= v2.4.x)
+    already default both behaviours off. ``--new-bundle-format`` itself
+    cannot be probed the same way -- v3 hides it from ``--help`` as
+    deprecated while still accepting it. Mirrors
+    scripts/sign_airgap_wheelhouse.sh.
+    """
+    result = subprocess.run(
+        ["cosign", "sign-blob", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    help_text = result.stdout + result.stderr
+    if "--use-signing-config" in help_text:
+        return ("--use-signing-config=false", "--new-bundle-format=false")
+    return ()
 
 
 def _probe_unshare_capable() -> bool:
@@ -260,6 +289,7 @@ def test_real_cosign_sign_and_verify_passes(
                 "sign-blob",
                 "--yes",
                 "--tlog-upload=false",
+                *_cosign_sign_blob_compat_flags(),
                 "--key",
                 str(priv),
                 "--output-signature",
@@ -279,6 +309,7 @@ def test_real_cosign_sign_and_verify_passes(
             "sign-blob",
             "--yes",
             "--tlog-upload=false",
+            *_cosign_sign_blob_compat_flags(),
             "--key",
             str(priv),
             "--output-signature",
@@ -315,6 +346,7 @@ def test_real_cosign_detects_wheel_byte_tamper(
             "sign-blob",
             "--yes",
             "--tlog-upload=false",
+            *_cosign_sign_blob_compat_flags(),
             "--key",
             str(priv),
             "--output-signature",
@@ -352,6 +384,7 @@ def test_real_cosign_detects_manifest_sha_tamper(
             "sign-blob",
             "--yes",
             "--tlog-upload=false",
+            *_cosign_sign_blob_compat_flags(),
             "--key",
             str(priv),
             "--output-signature",

--- a/tests/integration/test_airgap_wheelhouse.py
+++ b/tests/integration/test_airgap_wheelhouse.py
@@ -342,6 +342,24 @@ def test_sign_script_present() -> None:
     assert "MANIFEST" in contents
 
 
+def test_sign_script_keeps_cosign_v3_offline_flags() -> None:
+    """Offline keyed signing must stay compatible with cosign v3.
+
+    cosign v3 defaults ``--use-signing-config`` and
+    ``--new-bundle-format`` to true, which rejects the
+    ``--tlog-upload=false`` + ``--output-signature`` invocation the
+    air-gap path relies on. Dropping either opt-out silently breaks
+    signing on any host with cosign v3 while still passing on v2.4.x,
+    so pin the requirement here rather than only in the real-cosign
+    integration test (which skips when cosign is absent).
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    contents = (repo_root / "scripts" / "sign_airgap_wheelhouse.sh").read_text()
+    assert "--use-signing-config=false" in contents
+    assert "--new-bundle-format=false" in contents
+    assert "--tlog-upload=false" in contents
+
+
 # ---------------------------------------------------------------------------
 # Phase 2: pluggable verifier + wheelhouse CLI subcommands
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Supersedes #2948, which pinned `cosign-release: v3.1.1` but left the airgap E2E job red.

## What changed

- `.github/workflows/airgap-e2e.yml`: `cosign-release` v2.6.4 -> v3.1.1 (carried from #2948)
- `scripts/sign_airgap_wheelhouse.sh` + `tests/integration/test_airgap_offline_e2e.py`: make keyed offline `sign-blob` work under cosign v3

## Why the bump alone failed

cosign v3 changed two `sign-blob` defaults that the air-gap detached-signature path depends on:

| Flag | v2.4.x default | v3 default | Effect on `--tlog-upload=false --output-signature` |
|---|---|---|---|
| `--use-signing-config` | off (flag absent) | `true` | Errors: `--tlog-upload=false is not supported with --signing-config or --use-signing-config` |
| `--new-bundle-format` | `false` | `true` | Errors: `must specify --bundle with --new-bundle-format` |

Both surface as exit 1 from `cosign sign-blob`, which is the `CalledProcessError` in `test_real_cosign_sign_and_verify_passes`.

## Fix

Probe `cosign sign-blob --help` once for `--use-signing-config`; when present, pass `--use-signing-config=false --new-bundle-format=false`. That keeps offline keyed signing (no Rekor dial-out) intact and preserves the existing `<blob>.sig` detached-signature layout, so `verify-blob` and `CosignVerifier` are unchanged.

`--use-signing-config` is the version signal rather than probing each flag separately: cosign v3 marks `--new-bundle-format` deprecated and omits it from `--help` while still accepting it, so a per-flag probe silently drops it and the invocation still fails.

Releases up to v2.4.x predate `--use-signing-config` and already default both behaviours off, so the probe yields no extra flags there and the old invocation is preserved verbatim.

`COSIGN_TLOG_UPLOAD=true` (private Rekor opt-in) is untouched.

## Verification

Real cosign binaries on PATH, targeted airgap files only:

| cosign | `test_airgap_offline_e2e.py` | `test_airgap_wheelhouse.py` | `sign_airgap_wheelhouse.sh` |
|---|---|---|---|
| v3.1.2 | 35 passed, 2 skipped | 43 passed | exit 0, 3 sigs |
| v2.6.4 | 35 passed, 2 skipped | — | exit 0, 3 sigs |
| v2.4.1 | 35 passed, 2 skipped | — | exit 0, 3 sigs |

`ruff check` and `ruff format --check` clean on the changed files.