### PR TITLE
ci: key main CI concurrency by SHA so merged commits keep a real pass/fail signal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,21 +119,26 @@ on:
 #     on the same PR cancel older CI runs so reviewers only ever wait on
 #     the latest push and we don't burn minutes on stale SHAs.
 #
-#   - Pushes to main: branch-scoped group, cancel-in-progress=true.
-#     A rapid wave of merges can cancel older heavy CI runs on main so
-#     the latest push supersedes stale ones. Per-SHA main observability is
-#     provided separately by main-sha-marker.yml, which is keyed by
-#     github.sha and is not cancellable by newer main pushes.
+#   - Pushes to main (and merge_group / dispatch): per-SHA group
+#     (branch + github.sha), cancel-in-progress=false. Every commit that
+#     lands on main runs its own full-matrix CI to completion, so the
+#     commit history carries a real per-commit pass/fail signal instead of
+#     a run of "cancelled" markers left behind when a burst of merges
+#     supersedes each other. A cancelled run on an already-merged commit
+#     reads as red forever and hides genuine failures behind noise; keying
+#     main by SHA removes that class of false red.
 #
-# The conditional in `group:` selects the right key per event type, and
-# `cancel-in-progress` fires for both pull_request and push: a rapid
-# wave of merges on `main` (13 commits in 90 min during the May 2026
-# META wave) used to saturate the runner queue because each sha-unique
-# group kept its own full-matrix run alive. Branch-scoped grouping +
-# always-cancel-in-progress lets the latest push supersede stale ones.
+# Tradeoff: a rapid merge wave now keeps N full main runs alive instead of
+# one (the branch-scoped policy this replaces was chosen after a May 2026
+# wave of 13 merges in 90 min saturated the runner queue). Main pushes are
+# merged PRs, far fewer than PR-branch pushes, so the load is bounded; the
+# durable fix for burst load is the merge queue (ci.yml already triggers on
+# merge_group), which tests each batch once on the prospective merged SHA.
+# PR-branch pushes keep cancel-in-progress=true, so the saturation source
+# (many pushes across many open PRs) stays capped.
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('branch-{0}', github.ref) }}
-  cancel-in-progress: true
+  group: ci-${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('branch-{0}-{1}', github.ref, github.sha) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Default-deny for the workflow token; individual jobs escalate only
 # the scopes they actually need (Scorecard token-permissions, Sonar S8264).

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -26,7 +26,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/ci-macos-nightly.yml | CI (macOS nightly) | push, schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "ci-macos-nightly-${{ github.workflow }}-${{ github.ref }}"} | 2 |
 | .github/workflows/ci-topology-heal.yml | CI topology heal | push, workflow_dispatch | {"cancel-in-progress": "true", "group": "ci-topology-heal"} | 1 |
 | .github/workflows/ci-weekly-digest.yml | CI Weekly Digest | schedule, workflow_dispatch | {"cancel-in-progress": "false", "group": "ci-weekly-digest"} | 1 |
-| .github/workflows/ci.yml | CI | merge_group, pull_request, push, workflow_dispatch | {"cancel-in-progress": "true", "group": "ci-${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) \|\| format('branch-{0}', github.ref) }}"} | 30 |
+| .github/workflows/ci.yml | CI | merge_group, pull_request, push, workflow_dispatch | {"cancel-in-progress": "${{ github.event_name == 'pull_request' }}", "group": "ci-${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) \|\| format('branch-{0}-{1}', github.ref, github.sha) }}"} | 30 |
 | .github/workflows/cifuzz-pr.yml | CIFuzz (ClusterFuzzLite, PR) | schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "cifuzz-pr-${{ github.ref }}"} | 1 |
 | .github/workflows/cleanup-runs.yml | Cleanup Action Runs | workflow_dispatch | {"cancel-in-progress": "false", "group": "cleanup-runs-${{ github.ref }}"} | 1 |
 | .github/workflows/cluster-e2e.yml | cluster-e2e | pull_request, schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "cluster-e2e-${{ github.ref }}"} | 1 |

--- a/tests/unit/test_main_sha_marker_workflow_yaml.py
+++ b/tests/unit/test_main_sha_marker_workflow_yaml.py
@@ -41,19 +41,28 @@ def _mapping(value: object, message: str) -> dict[str, object]:
     return cast("dict[str, object]", value)
 
 
-def test_ci_concurrency_comment_matches_branch_cancellation() -> None:
-    """The heavy CI comment must not promise per-SHA main push completion."""
+def test_ci_concurrency_keys_main_by_sha_and_cancels_only_prs() -> None:
+    """Heavy CI runs every merged main commit to completion (per-SHA group, no
+    cancel) while still cancelling superseded PR-branch runs, so an already-merged
+    commit never carries a permanent "cancelled" red."""
     ci_doc = _load(CI)
     concurrency = _mapping(ci_doc.get("concurrency"), "CI workflow must define concurrency")
-    assert concurrency.get("cancel-in-progress") is True
+    # cancel-in-progress fires only for pull_request events; pushes to main
+    # (and merge_group / dispatch) are never cancelled by a later merge.
+    assert concurrency.get("cancel-in-progress") == "${{ github.event_name == 'pull_request' }}"
     group = concurrency.get("group")
     assert isinstance(group, str)
+    # PR runs group by PR number; everything else groups by ref + sha so each
+    # commit is its own non-cancelling run.
+    assert "pr-" in group
     assert "branch-" in group
+    assert "github.sha" in group
 
     text = CI.read_text(encoding="utf-8")
-    assert "Pushes to main (incl. squash-merges from auto/bump-* PRs): per-SHA" not in text
-    assert "cancel-in-progress=false" not in text
-    assert "main-sha-marker.yml" in text
+    # The comment documents the per-SHA main policy and its durable follow-up.
+    assert "per-SHA group" in text
+    assert "cancel-in-progress=false" in text
+    assert "merge queue" in text
 
 
 def test_main_sha_marker_workflow_is_exact_sha_and_non_cancellable() -> None:


### PR DESCRIPTION
## Problem

The compare view across a release range shows a long run of commits marked
failed/cancelled even though the code is green. Root cause: `ci.yml` grouped
main-branch CI by `branch-${{ github.ref }}` with `cancel-in-progress: true`, so
every push to `main` shared one concurrency group. During a burst of merges each
new merge cancelled the previous commit's in-progress CI. A cancelled run on an
already-merged commit reads as red permanently and hides genuine failures in the
noise. `main-red-guard.yml` documents this exact hazard ("rapid burst of merges
cancelled each other's CI runs, leaving 'green' only on a SHA that was never
committed").

## Change

Key main-branch CI by SHA and stop cancelling it:

- Pull requests: unchanged — per-PR group + `cancel-in-progress: true` (stale
  pushes on the same PR still cancel, so PR-branch load stays capped).
- Pushes to main / merge_group / dispatch: per-SHA group
  (`branch-${{ github.ref }}-${{ github.sha }}`) + `cancel-in-progress: false`,
  so every commit that lands on main runs its full-matrix CI to completion and
  carries a real per-commit pass/fail signal.

`docs/operations/ci-topology.md` is regenerated in the same commit.

## Tradeoff

A rapid merge wave now keeps N main runs alive instead of one (the branch-scoped
policy this replaces was adopted after a burst saturated the runner queue). Main
pushes are merged PRs — far fewer than PR-branch pushes — so the load is bounded,
and PR pushes keep `cancel-in-progress`. The durable fix for burst load is the
merge queue (ci.yml already triggers on `merge_group`), tracked separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI reliability by preventing completed-commit checks from being cancelled unexpectedly.
  * Pull request checks continue to cancel superseded runs to provide faster feedback.

* **Documentation**
  * Updated the CI workflow documentation to reflect the revised run grouping and cancellation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->