### PR TITLE
feat(sandbox): boot real microVM guests via libkrun behind the existing monitor seam

### DIFF
--- a/docs/architecture/sandbox.md
+++ b/docs/architecture/sandbox.md
@@ -95,7 +95,7 @@ work.
 | `docker`   | core     | `FILE_RW`, `EXEC`, `NETWORK`                     | Launches a container per session via the `docker` Python SDK. Needs `pip install bernstein[docker]`. |
 | `e2b`      | `[e2b]` extra | `FILE_RW`, `EXEC`, `NETWORK`, `SNAPSHOT`     | Runs in E2B Firecracker microVMs. Needs `pip install bernstein[e2b]` plus `E2B_API_KEY`. |
 | `modal`    | `[modal]` extra | `FILE_RW`, `EXEC`, `NETWORK`, `SNAPSHOT`, `GPU` | Serverless containers with optional GPU. Needs `pip install bernstein[modal]` plus `MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET`. |
-| `microvm`  | core     | `FILE_RW`, `EXEC`, `NETWORK`, `SNAPSHOT`         | Firecracker microVM per session — isolates kernel / network / PID namespace at a hardware boundary. Snapshots are **content-addressed** (the snapshot id *is* the SHA-256 of the image bytes in CAS). Opt-in: not a free backend, so the heuristic path never auto-selects it; an explicit `sandbox.backend: microvm` on a host without KVM fails loudly rather than degrading isolation. **The VM boot path is experimental (not yet implemented) — see below.** |
+| `microvm`  | core     | `FILE_RW`, `EXEC`, `NETWORK`, `SNAPSHOT`         | microVM per session — isolates kernel / network / PID namespace at a hardware boundary. Snapshots are **content-addressed** (the snapshot id *is* the SHA-256 of the image bytes in CAS). Two adapters: **libkrun** boots a real guest on Linux/KVM and macOS/arm64 (opt in with `BERNSTEIN_MICROVM_MONITOR=libkrun`; see [MicroVM on libkrun](../operations/microvm-libkrun.md)), **Firecracker** is the default and still refuses to boot. Opt-in: not a free backend, so the heuristic path never auto-selects it; an explicit `sandbox.backend: microvm` on an unsupported host fails loudly rather than degrading isolation. |
 
 ### Trade-offs
 
@@ -122,24 +122,138 @@ kernel/network/PID boundary, and a snapshot contract strong enough to
 build reproducible, auditable races on.
 
 > **Status: the deterministic core (snapshot / fork-race / signed receipt)
-> is complete and fully tested; the Firecracker VM boot itself is
-> experimental and not yet implemented.** `FirecrackerMonitor` ships the
-> host preflight and the strict no-silent-downgrade contract; the full boot
-> lifecycle (API socket, drives, networking, `InstanceStart`, and an
-> in-guest vsock agent for exec/file-IO) is a tracked follow-up. It cannot
-> be built or validated without a KVM-capable Linux host plus an
-> operator-supplied kernel, rootfs, and guest agent, so `boot()` raises
-> `MicroVMUnavailableError` on every host today rather than pretending. All
-> the guarantees below are exercised host-independently over the
+> is complete and fully tested. Two hypervisor adapters ship behind the same
+> shim: `LibkrunMonitor`, which boots a real guest on ordinary developer
+> hardware, and `FirecrackerMonitor`, whose boot lifecycle is still
+> unimplemented.** `FirecrackerMonitor` ships the host preflight and the
+> strict no-silent-downgrade contract; its full boot lifecycle (API socket,
+> drives, networking, `InstanceStart`, and an in-guest vsock agent for exec
+> and file-IO transport) remains a tracked follow-up requiring a KVM-capable
+> Linux host plus an operator-supplied kernel, rootfs, and guest agent, so its
+> `boot()` raises `MicroVMUnavailableError` on every host today rather than
+> pretending. The guarantees below are exercised host-independently over the
 > `FakeMonitor`.
 
 **Monitor shim.** The backend never talks to a hypervisor directly. It
-drives a `VMMonitor` adapter (`backends/_vmmonitor.py`): a
-`FirecrackerMonitor` (production; strict host preflight for KVM +
-`firecracker` binary + kernel/rootfs) and a `FakeMonitor` (a
-deterministic, host-portable stand-in used by the tests that really
-executes commands and really freezes the workspace — not canned bytes).
+drives a `VMMonitor` adapter:
+
+| Monitor | Module | Role |
+|---|---|---|
+| `LibkrunMonitor` | `backends/_libkrun.py` | Boots a real guest through libkrun (KVM on Linux, Hypervisor.framework on macOS/arm64). Opt-in via `BERNSTEIN_MICROVM_MONITOR=libkrun`. |
+| `FirecrackerMonitor` | `backends/_vmmonitor.py` | Host preflight + no-silent-downgrade contract; boot lifecycle not implemented. Default. |
+| `FakeMonitor` | `backends/_vmmonitor.py` | Deterministic, host-portable stand-in for the tests. Really executes commands and really freezes the workspace — not canned bytes. |
+
 A Cloud Hypervisor variant fits behind the same shim and is deferred.
+
+### The libkrun monitor
+
+libkrun *is* the L1 hypervisor, so it needs no nested virtualisation and runs
+on ordinary developer hardware — including Apple Silicon, where nested virt
+would otherwise rule the boundary out entirely.
+
+The decisive API is `krun_add_virtiofs()`. The session workspace is a host
+directory passed straight through to the guest, so `read_file`, `write_file`,
+`ls`, `freeze_image` and `restore_image` are plain host filesystem operations:
+five of the protocol's nine members need **no guest agent at all**.
+`freeze_image()` reuses `canonical_workspace_image` unchanged, so its digests
+are byte-identical to the ones `FakeMonitor` produces for the same tree — there
+is no second implementation to drift.
+
+The shares are attached with `KRUN_SEMANTICS_LINUX_SIMPLIFIED`, which stores
+permission bits in the host inode rather than an extended attribute. Guest and
+host must agree on a file's mode, because the snapshot is taken by reading the
+tree from the host: under the default semantics a file the guest creates `0644`
+lands on the host `0600`, and freezing it would silently drop the executable bit
+off anything the guest built.
+
+`krun_start_enter()` never returns: the VMM takes over the calling process and
+exits with the workload's exit code. One process therefore runs one VM, and
+`exec()` spawns the `krunlaunch` binary per call (see
+[host requirements](#host-requirements) for why that binary is separate). A
+short-lived VM per `exec` is semantically correct here because all session state
+lives in the shared workspace rather than in VM memory.
+
+**Exit-code disambiguation.** libkrun reserves `125` (init could not set up the
+environment), `126` (could not execute the workload) and `127` (workload not
+found) for its own failures — and a guest command can legitimately return those
+same values. The process exit code alone is therefore ambiguous. The guest
+wrapper writes an explicit status line into a control directory that is *not*
+part of the workspace, only after the command has finished, and that file — not
+the process exit code — decides:
+
+| Status file | Process exit | Reported as |
+|---|---|---|
+| present, well-formed | anything | the guest command's exit code (including 125/126/127) |
+| absent, or truncated/malformed | 125/126/127 | `MicroVMUnavailableError`, naming the libkrun-level reason |
+| absent, or truncated/malformed | anything else | `MicroVMUnavailableError` — the result is unknown, never guessed |
+
+The control directory lives outside the workspace precisely so stdio and the
+status file can never reach a snapshot and shift its content address.
+
+**No memory snapshots.** libkrun has no checkpoint/restore API (only
+macOS-only `krun_vm_pause`/`krun_vm_resume`), which costs this backend nothing:
+the snapshot contract is filesystem-level by design. That is also the safer
+choice — restoring one VM memory snapshot into several VMs would replicate PRNG
+state and cached secrets across the branches of a race.
+
+#### Host requirements
+
+Step-by-step setup, including troubleshooting, is in
+[`docs/operations/microvm-libkrun.md`](../operations/microvm-libkrun.md).
+
+Common to both platforms:
+
+| Requirement | How it is configured |
+|---|---|
+| libkrun + libkrunfw (the guest kernel) installed | discovered in well-known locations; `$BERNSTEIN_MICROVM_LIBKRUN_LIB` overrides |
+| The `krunlaunch` launcher binary, built once per host | `bernstein sandbox microvm-launcher`; `$BERNSTEIN_MICROVM_LIBKRUN_LAUNCHER` overrides the location |
+| A guest root filesystem **directory** providing `/bin/sh` and a `mount` that speaks virtiofs | `$BERNSTEIN_MICROVM_LIBKRUN_ROOTFS` |
+| Guest sizing (optional) | `$BERNSTEIN_MICROVM_LIBKRUN_VCPUS`, `$BERNSTEIN_MICROVM_LIBKRUN_RAM_MIB`, `$BERNSTEIN_MICROVM_LIBKRUN_SHM_BYTES` |
+
+**Linux:** `/dev/kvm` must exist and be readable+writable by the running user.
+Distribution packages provide `libkrun` and `libkrunfw`. A C compiler is needed
+once, to build the launcher.
+
+**macOS / Apple Silicon (arm64):** `brew tap slp/krun && brew install libkrun`
+installs libkrun and libkrunfw. Hypervisor.framework additionally requires the
+**running executable image** to be code-signed with the
+`com.apple.security.hypervisor` entitlement — without it `krun_start_enter()`
+returns `-EINVAL` and libkrun logs `Building the microVM failed:
+Internal(Vm(VmSetup(VmCreate)))`.
+
+This is the second reason the launcher is a separate binary. The entitlement
+attaches to the image the kernel actually executes, and a framework CPython
+(Homebrew, python.org) re-execs itself into
+`Python.framework/.../Resources/Python.app/Contents/MacOS/Python` — so
+`sys.executable` is not that image, and signing it changes nothing. Rather than
+asking operators to sign an interpreter, `bernstein sandbox microvm-launcher`
+builds and ad-hoc-signs a launcher the project owns, with
+`com.apple.security.hypervisor` and
+`com.apple.security.cs.disable-library-validation` (libkrun `dlopen`s libkrunfw,
+which library validation would otherwise refuse). `preflight()` verifies both
+entitlements are present on the binary it is about to spawn.
+
+Intel Macs are not supported: libkrun's macOS backend is Apple-Silicon only.
+
+`preflight()` names every one of these that is missing, side-effect-free — it
+never builds the launcher as a side effect of a support probe — and `boot()`
+refuses when any is missing. It never falls back to a weaker isolation mode.
+
+#### What the boundary does and does not cover
+
+**Does:** a separate guest kernel, a separate process tree, and a separate
+network stack. Guest code cannot see host processes or the host filesystem
+beyond what was shared.
+
+**Does not:** the guest and the VMM share a security context — virtiofs is a
+passthrough, not a sandbox, and it does not constrain access *within* the
+directory that was shared beyond ordinary filesystem permissions. A guest that
+escapes into the VMM process holds whatever privileges that process holds.
+Confining the VMM itself (user namespaces, seccomp, or a dedicated uid on
+Linux) remains the operator's responsibility, exactly as it is for any
+hypervisor. The workspace directory is the shared surface: anything the host
+places there is readable by the guest, and anything the guest writes there is
+immediately visible to the host.
 
 **Content-addressed snapshots.** `snapshot()` freezes the workspace into a
 *canonicalised image* (a tar with sorted paths, zeroed mtimes/uids, real
@@ -212,8 +326,13 @@ Precedence when several apply: `failed` > `unreadable` > `incomplete` (absent) >
 `fork-race` requires a microVM-capable host; on an unsupported host it
 fails loudly. The determinism/tamper guarantees are validated
 host-independently over the `FakeMonitor` (see
-`tests/unit/sandbox/test_fork_race.py`); the real Firecracker boot is
-covered by the KVM-gated `tests/integration/sandbox/test_microvm_firecracker.py`.
+`tests/unit/sandbox/test_fork_race.py`). The real libkrun boot/exec/freeze
+round trip is covered by the host-gated
+`tests/integration/sandbox/test_microvm_libkrun.py` (opt in with
+`BERNSTEIN_MICROVM_LIBKRUN_INTEGRATION=1` on a host that satisfies the
+requirements above); the Firecracker path is covered by the KVM-gated
+`tests/integration/sandbox/test_microvm_firecracker.py`. The refusal-invariant
+assertions in both files run everywhere.
 
 ## `plan.yaml` extension
 

--- a/docs/operations/microvm-libkrun.md
+++ b/docs/operations/microvm-libkrun.md
@@ -1,0 +1,169 @@
+# Running the microVM backend on libkrun
+
+The `microvm` sandbox backend isolates agent work behind a real hardware
+boundary — its own kernel, process tree and network stack. The libkrun adapter
+implements that boundary on ordinary developer hardware: KVM on Linux,
+Hypervisor.framework on macOS/Apple Silicon. No nested virtualisation is
+involved, so it works on machines where Firecracker cannot run at all.
+
+Architecture and design rationale live in
+[`docs/architecture/sandbox.md`](../architecture/sandbox.md). This page is the
+host setup.
+
+## TL;DR
+
+| Step | Command | Status when done |
+|---|---|---|
+| 1. Install libkrun + libkrunfw | `brew tap slp/krun && brew install libkrun` (macOS) / distro package (Linux) | ✅ hypervisor + guest kernel present |
+| 2. Build the launcher | `uv run bernstein sandbox microvm-launcher` | ✅ signed `krunlaunch` in the build cache |
+| 3. Provide a guest rootfs | export `BERNSTEIN_MICROVM_LIBKRUN_ROOTFS=/path/to/rootfs` | ✅ guest can run `/bin/sh` |
+| 4. Select the adapter | export `BERNSTEIN_MICROVM_MONITOR=libkrun` | ✅ `microvm` backend uses libkrun |
+
+Check the result at any point — it lists everything still missing and creates
+nothing:
+
+```bash
+uv run python -c "
+from bernstein.core.sandbox.backends._libkrun import LibkrunMonitor
+print(LibkrunMonitor().preflight() or 'host ready')"
+```
+
+## 1. Install libkrun and libkrunfw
+
+`libkrunfw` carries the guest kernel and is `dlopen`ed by libkrun when the VM
+starts, so both must be present. A host with libkrun but no libkrunfw is
+reported as a missing precondition rather than failing later with a loader
+error.
+
+**macOS (Apple Silicon only):**
+
+```bash
+brew tap slp/krun
+brew install libkrun
+```
+
+**Linux:** install your distribution's `libkrun` and `libkrunfw` packages, and
+make sure `/dev/kvm` is readable and writable by the user running Bernstein
+(usually membership of the `kvm` group).
+
+Override discovery with `BERNSTEIN_MICROVM_LIBKRUN_LIB` if the library is not in
+a standard location.
+
+## 2. Build the launcher
+
+```bash
+uv run bernstein sandbox microvm-launcher
+```
+
+This compiles a small C program, `krunlaunch`, against the locally installed
+libkrun and caches it (by default under `~/.cache/bernstein/libkrun/`). Pass
+`--output` to put it elsewhere, and point
+`BERNSTEIN_MICROVM_LIBKRUN_LAUNCHER` at it.
+
+The launcher is a separate process for two independent reasons, either of which
+alone would force it:
+
+- `krun_start_enter()` never returns — it hands the calling process to the VMM,
+  which exits with the workload's status. A VM *is* a process, so the
+  orchestrator cannot host one in-process.
+- On macOS, `hv_vm_create()` fails unless the running executable image carries
+  `com.apple.security.hypervisor`. A framework CPython re-execs into a binary
+  that cannot usefully carry it, so the entitled image has to be one the project
+  builds and signs itself.
+
+On macOS the build ad-hoc code-signs the binary with
+`com.apple.security.hypervisor` and
+`com.apple.security.cs.disable-library-validation`. Rebuild it after upgrading
+libkrun. Until it exists, `preflight()` reports it as a missing host
+precondition — exactly like a missing hypervisor. It is never built implicitly.
+
+## 3. Provide a guest root filesystem
+
+Point `BERNSTEIN_MICROVM_LIBKRUN_ROOTFS` at a **host directory** holding a Linux
+root filesystem for the guest architecture. libkrun exposes it to the guest as
+`/` over virtio-fs.
+
+It must provide:
+
+- `/bin/sh` — a POSIX shell. The monitor runs each command through a small
+  wrapper script.
+- `mount` supporting `-t virtiofs` — the wrapper mounts the workspace and
+  control shares itself.
+
+Any minimal userland with those two (busybox-based images are the usual choice)
+is enough. Extract an OCI image for your guest architecture into a directory, or
+build a rootfs with your distribution's tooling.
+
+Use a directory dedicated to sandboxing: the guest root share is writable, so a
+guest can modify the rootfs directory it was given.
+
+Optional sizing knobs:
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `BERNSTEIN_MICROVM_LIBKRUN_VCPUS` | `1` | guest vCPUs |
+| `BERNSTEIN_MICROVM_LIBKRUN_RAM_MIB` | `512` | guest RAM, MiB |
+| `BERNSTEIN_MICROVM_LIBKRUN_SHM_BYTES` | 512 MiB | virtio-fs DAX window per share |
+
+## 4. Select the adapter
+
+Selection is opt-in at two levels, and neither changes the backend heuristic:
+
+```bash
+export BERNSTEIN_MICROVM_MONITOR=libkrun   # microvm backend -> libkrun adapter
+```
+
+then request the `microvm` backend explicitly, either in `plan.yaml`:
+
+```yaml
+sandbox:
+  backend: microvm
+```
+
+or through the sandbox CLI. Without `BERNSTEIN_MICROVM_MONITOR=libkrun` the
+`microvm` backend keeps its historical Firecracker adapter, which still refuses
+to boot.
+
+## Verifying the setup
+
+```bash
+BERNSTEIN_MICROVM_LIBKRUN_INTEGRATION=1 \
+  uv run pytest tests/integration/sandbox/test_microvm_libkrun.py -v
+```
+
+The opt-in tests boot real guests and exercise exec, stdin, file I/O and the
+canonical freeze. They skip themselves when `preflight()` still reports
+anything missing. The refusal-invariant assertions in the same file run
+everywhere, with or without a hypervisor.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `libkrun shared library not found` | libkrun not installed, or in a non-standard prefix | install it, or set `BERNSTEIN_MICROVM_LIBKRUN_LIB` |
+| `libkrunfw shared library not found` | guest kernel package missing | install `libkrunfw` |
+| `launcher binary missing at ...` | step 2 not run | `uv run bernstein sandbox microvm-launcher` |
+| `launcher ... is not code-signed with com.apple.security.hypervisor` | signing failed, or the binary was copied without its signature | rebuild it in place |
+| `Building the microVM failed: Internal(Vm(VmSetup(VmCreate)))` | the process calling libkrun is not entitled | you are not going through `krunlaunch`; rebuild it |
+| `libkrun "init" could not find the guest entrypoint` (127) | the rootfs has no `/bin/sh` | fix the rootfs |
+| `libkrun "init" found the guest entrypoint but could not execute it` (126) | `/bin/sh` is not executable, or is built for the wrong architecture | fix the rootfs |
+| `guest produced no status report` | the VM died before the command finished | check the quoted diagnostics in the error; they carry the VMM's own message |
+
+A guest command that *itself* exits 125, 126 or 127 is reported as an ordinary
+result with that exit code, never as a VM failure. The two cases are
+distinguished by a status file the guest wrapper writes only after the command
+completes, so the process exit code is never used to guess.
+
+## What the boundary does and does not cover
+
+**Does:** a separate guest kernel, a separate process tree, a separate network
+stack. Guest code cannot see host processes, or host files outside the shared
+directories.
+
+**Does not:** the guest and the VMM share a security context, so a hypervisor
+escape lands with the privileges of the process that spawned the launcher.
+virtio-fs is a passthrough, not a sandbox — it does not constrain access within
+a shared directory beyond ordinary filesystem permissions, and the guest root
+share is writable. Confining the VMM process itself (user namespaces, seccomp,
+or a dedicated uid on Linux) remains an operator responsibility, as it is for
+any hypervisor.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -195,6 +195,7 @@ nav:
           - Overview: architecture/sandbox.md
           - Backend selector: concepts/sandbox-selector.md
           - Named sandbox pools: operations/sandbox-pools.md
+          - MicroVM on libkrun: operations/microvm-libkrun.md
           - Daytona: sandbox/daytona.md
           - Blaxel: sandbox/blaxel.md
           - Runloop: sandbox/runloop.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -392,6 +392,15 @@ artifacts = [
     # the wheel ships pre-built. Rebuild with: cd web && npm run build.
     "src/bernstein/gui/static/**/*",
     "src/bernstein/dashboard/static/**/*",
+    # microVM launcher source. The libkrun monitor spawns one process per VM
+    # and, on macOS, that process must carry the hypervisor entitlement, so the
+    # binary is compiled and signed on the operator's host from this source
+    # (`bernstein sandbox microvm-launcher`). Shipping the source rather than a
+    # binary keeps the wheel platform-independent and lets the link step resolve
+    # the local libkrun prefix. Loader:
+    # bernstein.core.sandbox.backends._libkrun.launcher_source_dir.
+    "src/bernstein/core/sandbox/backends/_libkrun_launcher/*.c",
+    "src/bernstein/core/sandbox/backends/_libkrun_launcher/*.plist",
     # SDD ticket schemas. Shipped alongside the validator so downstream
     # projects can lint their .sdd/backlog tickets via importlib.resources
     # without a source checkout. Loader: bernstein.sdd.validator.load_schema.

--- a/src/bernstein/cli/commands/sandbox_cmd.py
+++ b/src/bernstein/cli/commands/sandbox_cmd.py
@@ -301,6 +301,56 @@ def fork_race_cmd(
     console.print(f"[dim]receipt: {out_path}[/dim]")
 
 
+@sandbox_group.command("microvm-launcher")
+@click.option(
+    "--output",
+    "output",
+    default=None,
+    type=click.Path(dir_okay=False, path_type=Path),
+    help="Where to write the binary (default: the per-user build cache).",
+)
+@click.option(
+    "--library",
+    "library",
+    default=None,
+    help="Explicit libkrun shared-library path, used to derive the link rpath.",
+)
+def microvm_launcher_cmd(output: Path | None, library: str | None) -> None:
+    """Build the signed launcher the libkrun microVM monitor spawns per exec.
+
+    The ``microvm`` backend's libkrun adapter runs each guest in its own
+    process, because ``krun_start_enter()`` never returns and, on macOS,
+    Hypervisor.framework refuses a process whose executable image is not
+    entitled. Both are satisfied by a small C launcher that ships as source
+    with the package and is compiled here against the locally installed
+    libkrun, then ad-hoc code-signed on macOS.
+
+    Until it exists the monitor's ``preflight()`` reports it as a missing host
+    precondition, exactly like a missing hypervisor - the backend never
+    degrades to a weaker boundary.
+    """
+    from bernstein.core.sandbox.backends._libkrun import (
+        LibkrunMonitor,
+        build_launcher,
+    )
+    from bernstein.core.sandbox.backends._vmmonitor import MicroVMUnavailableError
+
+    try:
+        built = build_launcher(dest=output, library=library)
+    except MicroVMUnavailableError as exc:
+        console.print(f"[red]FAILED[/red] {exc}")
+        raise click.exceptions.Exit(code=1) from exc
+
+    console.print(f"[green]built[/green] {built}")
+    missing = LibkrunMonitor(launcher=str(built)).preflight()
+    if missing:
+        console.print("[yellow]still missing for a bootable guest:[/yellow]")
+        for entry in missing:
+            console.print(f"  - {entry}")
+    else:
+        console.print("[green]host is ready to boot a libkrun microVM.[/green]")
+
+
 @sandbox_group.group("receipt")
 def receipt_group() -> None:
     """Inspect and verify fork-race selection receipts."""
@@ -482,6 +532,7 @@ def receipt_verify_cmd(receipt_path: Path, cas_dir: Path, expected_keyid: str | 
 
 __all__ = [
     "fork_race_cmd",
+    "microvm_launcher_cmd",
     "receipt_group",
     "receipt_verify_cmd",
     "sandbox_group",

--- a/src/bernstein/core/sandbox/backends/_libkrun.py
+++ b/src/bernstein/core/sandbox/backends/_libkrun.py
@@ -208,15 +208,13 @@ def _lib_names(stem: str) -> tuple[str, ...]:
     return (f"{stem}.so.1", f"{stem}.so.5", f"{stem}.so")
 
 
-def _find_shared_object(stem: str, explicit: str | None = None) -> str | None:
+def _find_shared_object(stem: str, search: tuple[str, ...] = ()) -> str | None:
     """Locate a shared object without loading it.
 
     Deliberately does *not* ``dlopen`` anything: :meth:`LibkrunMonitor.preflight`
     must stay side-effect-free, and loading a hypervisor library is not that.
     """
-    if explicit:
-        return explicit if Path(explicit).exists() else None
-    for directory in _lib_dirs():
+    for directory in (*search, *_lib_dirs()):
         for name in _lib_names(stem):
             candidate = Path(directory) / name
             if candidate.exists():
@@ -228,18 +226,26 @@ def _find_shared_object(stem: str, explicit: str | None = None) -> str | None:
 
 def find_libkrun(explicit: str | None = None) -> str | None:
     """Locate the libkrun shared library, or ``None`` when it is absent."""
-    return _find_shared_object("libkrun", explicit)
+    if explicit:
+        return explicit if Path(explicit).exists() else None
+    return _find_shared_object("libkrun")
 
 
-def find_libkrunfw() -> str | None:
+def find_libkrunfw(library: str | None = None) -> str | None:
     """Locate libkrunfw (the packaged guest kernel), or ``None`` when absent.
 
     libkrun ``dlopen``s it at VM-start time rather than linking it, so a host
     with libkrun but no libkrunfw preflights as ready and then fails at boot
     with an opaque loader error. Checking for it here turns that into a named
     precondition.
+
+    libkrun's own directory is searched first: an operator who pointed
+    ``$BERNSTEIN_MICROVM_LIBKRUN_LIB`` at a non-standard prefix has almost
+    certainly put the guest kernel beside it, and reporting that host as
+    missing libkrunfw would be wrong.
     """
-    return _find_shared_object("libkrunfw")
+    beside = libkrun_library_dir(library)
+    return _find_shared_object("libkrunfw", (beside,) if beside else ())
 
 
 def libkrun_library_dir(library: str | None = None) -> str | None:
@@ -648,7 +654,7 @@ class LibkrunMonitor:
         if find_libkrun(self._library_override) is None:
             hint = "" if self._library_override else f" (install libkrun, or set ${LIBRARY_ENV})"
             missing.append(f"libkrun shared library not found{hint}")
-        if find_libkrunfw() is None:
+        if find_libkrunfw(self._library_override) is None:
             missing.append(
                 "libkrunfw shared library not found (it carries the guest kernel; libkrun loads it when the VM starts)"
             )

--- a/src/bernstein/core/sandbox/backends/_libkrun.py
+++ b/src/bernstein/core/sandbox/backends/_libkrun.py
@@ -941,14 +941,14 @@ class LibkrunMonitor:
         try:
             _, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
         except TimeoutError as exc:
-            # Kill the VM before propagating: a wedged guest that outlives the
-            # call would keep its virtio-fs shares (and this session's
-            # workspace) alive after shutdown().
-            with contextlib.suppress(ProcessLookupError):
-                proc.kill()
-            await proc.wait()
+            await _kill(proc)
             msg = f"Command timed out after {timeout}s: {cmd!r}"
             raise TimeoutError(msg) from exc
+        except asyncio.CancelledError:
+            # A cancelled fork-race branch must not leave a VM running against
+            # a workspace the caller is about to delete.
+            await _kill(proc)
+            raise
         return (
             proc.returncode if proc.returncode is not None else -1,
             stderr.decode("utf-8", "replace"),
@@ -969,6 +969,18 @@ def _env_int(name: str, default: int) -> int:
     except ValueError:
         return default
     return value if value > 0 else default
+
+
+async def _kill(proc: asyncio.subprocess.Process) -> None:
+    """Kill and reap a VM process, so an abandoned guest outlives nothing.
+
+    A wedged or abandoned guest keeps its virtio-fs shares - and therefore this
+    session's workspace - alive past ``shutdown()``.
+    """
+    with contextlib.suppress(ProcessLookupError):
+        proc.kill()
+    with contextlib.suppress(asyncio.CancelledError):
+        await proc.wait()
 
 
 def _read_bytes(path: Path) -> bytes:

--- a/src/bernstein/core/sandbox/backends/_libkrun.py
+++ b/src/bernstein/core/sandbox/backends/_libkrun.py
@@ -1,0 +1,1025 @@
+"""libkrun-backed microVM monitor for the ``microvm`` sandbox backend (#2971).
+
+:class:`LibkrunMonitor` satisfies the same
+:class:`~bernstein.core.sandbox.backends._vmmonitor.VMMonitor` protocol as
+:class:`~bernstein.core.sandbox.backends._vmmonitor.FirecrackerMonitor` and
+:class:`~bernstein.core.sandbox.backends._vmmonitor.FakeMonitor`, so everything
+above the seam - the backend, the content-addressed snapshots, the fork-race
+and the selection receipts - is unchanged.
+
+Why libkrun
+-----------
+libkrun *is* the L1 hypervisor (KVM on Linux, Hypervisor.framework on
+macOS/arm64), so it needs no nested virtualisation and boots on ordinary
+developer hardware. It also exposes ``krun_add_virtiofs3()``, which lets the
+session workspace be a real host directory passed through to the guest. That
+makes :meth:`LibkrunMonitor.read_file`, :meth:`LibkrunMonitor.write_file`,
+:meth:`LibkrunMonitor.ls`, :meth:`LibkrunMonitor.freeze_image` and
+:meth:`LibkrunMonitor.restore_image` plain host filesystem operations - no
+guest agent, no framing protocol, no watchdog. ``freeze_image`` reuses
+:func:`~bernstein.core.sandbox.backends._vmmonitor.canonical_workspace_image`
+unchanged, so its bytes (and therefore the content address) are identical to
+the ones ``FakeMonitor`` produces for the same tree, with no second
+implementation to drift.
+
+Three shares make up a guest:
+
+===============  ==========================  =====================================
+virtio-fs tag    host directory              guest mount
+===============  ==========================  =====================================
+``/dev/root``    operator-supplied rootfs    ``/`` (mounted by libkrun's own init)
+``bnsws``        session workspace           the monitor's logical root
+``bnsctl``       per-exec control directory  :data:`GUEST_CONTROL_DIR`
+===============  ==========================  =====================================
+
+The control directory carries stdin/stdout/stderr and the status report. It is
+deliberately *outside* the workspace: a snapshot must contain the workspace and
+nothing else, or ``freeze_image`` would stop matching ``FakeMonitor``.
+
+The two bernstein shares are attached with ``KRUN_SEMANTICS_LINUX_SIMPLIFIED``,
+which stores permission bits in the host inode rather than an extended
+attribute. The workspace is snapshotted by reading it from the host, so the two
+views have to agree: under the default semantics a file the guest creates 0644
+lands on the host 0600, and freezing it would silently drop the mode - an
+executable the guest built would restore non-executable.
+
+Process model
+-------------
+``krun_start_enter()`` never returns - the VMM takes over the calling process
+and ``exit()``s with the workload's status - so one process runs one VM.
+On macOS there is a second, independent reason the VM cannot live in the
+orchestrator process: ``hv_vm_create()`` fails with ``EINVAL`` unless the
+*running executable image* carries ``com.apple.security.hypervisor``, and a
+framework CPython cannot usefully carry it. Both constraints are satisfied by
+the same artifact: a small signed launcher binary (``krunlaunch``, source in
+``_libkrun_launcher/``) that :meth:`LibkrunMonitor.exec` spawns per call. Its
+absence is reported by :meth:`LibkrunMonitor.preflight` exactly like a missing
+hypervisor; build it with :func:`build_launcher` or
+``bernstein sandbox microvm-launcher``.
+
+Session state lives entirely in the shared workspace rather than in VM memory,
+which is what makes a short-lived VM per ``exec`` semantically correct.
+
+Exit-code disambiguation
+------------------------
+libkrun reserves 125/126/127 for *its own* failures (see
+:data:`LIBKRUN_RESERVED_EXIT_CODES`), and a guest command can legitimately
+return those same values. Trusting the launcher's exit code alone would report
+a VM-level failure as a guest result, or the reverse. The guest wrapper
+therefore writes an explicit status line into the control share *after* the
+command completes, and :func:`resolve_guest_exit_code` treats that file - not
+the process exit code - as authoritative. A guest command returning 127 is
+reported as ``exit_code=127``; a libkrun 127 (guest entrypoint not found)
+leaves no status file and raises
+:class:`~bernstein.core.sandbox.backends._vmmonitor.MicroVMUnavailableError`.
+
+No silent downgrade
+-------------------
+On an unsupported host :meth:`LibkrunMonitor.preflight` names every missing
+precondition and :meth:`LibkrunMonitor.boot` raises
+:class:`~bernstein.core.sandbox.backends._vmmonitor.MicroVMUnavailableError`.
+It never falls back to a weaker isolation mode - an operator who asked for a
+hardware boundary gets an error, not a surprise.
+
+Isolation caveat
+----------------
+The hardware boundary is real: a separate kernel, a separate process tree, a
+separate network stack. It is not a complete answer. The guest and the VMM
+share a security context, so a hypervisor escape lands with the privileges of
+the process that spawned the launcher, and virtio-fs does not itself constrain
+access beyond the directories that were shared - the guest root share is
+writable, so a guest can modify the rootfs directory it was given. Use a rootfs
+directory dedicated to sandboxing, and keep host-side confinement of the VMM
+process (user namespaces / seccomp on Linux) an operator responsibility.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import ctypes.util
+import os
+import posixpath
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import uuid
+from importlib import resources
+from pathlib import Path
+from typing import TYPE_CHECKING, Final
+
+from bernstein.core.sandbox.backend import ExecResult
+from bernstein.core.sandbox.backends._vmmonitor import (
+    MicroVMUnavailableError,
+    canonical_workspace_image,
+    extract_workspace_image,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Mapping, Sequence
+    from importlib.resources.abc import Traversable
+
+# ---------------------------------------------------------------------------
+# Host configuration surface
+# ---------------------------------------------------------------------------
+
+#: Env var pointing at the guest root filesystem (a host *directory*, exposed
+#: to the guest as ``/`` through virtio-fs).
+ROOTFS_ENV: Final = "BERNSTEIN_MICROVM_LIBKRUN_ROOTFS"
+#: Env var overriding the libkrun shared-library path.
+LIBRARY_ENV: Final = "BERNSTEIN_MICROVM_LIBKRUN_LIB"
+#: Env var pointing at a prebuilt, signed ``krunlaunch`` binary.
+LAUNCHER_ENV: Final = "BERNSTEIN_MICROVM_LIBKRUN_LAUNCHER"
+#: Env var overriding the guest vCPU count.
+VCPUS_ENV: Final = "BERNSTEIN_MICROVM_LIBKRUN_VCPUS"
+#: Env var overriding the guest RAM allocation, in MiB.
+RAM_MIB_ENV: Final = "BERNSTEIN_MICROVM_LIBKRUN_RAM_MIB"
+#: Env var overriding the virtio-fs DAX window size, in bytes.
+SHM_BYTES_ENV: Final = "BERNSTEIN_MICROVM_LIBKRUN_SHM_BYTES"
+
+#: macOS entitlement required to call ``hv_vm_create`` (Hypervisor.framework).
+HYPERVISOR_ENTITLEMENT: Final = "com.apple.security.hypervisor"
+#: macOS entitlement required for libkrun to ``dlopen`` libkrunfw.
+LIBRARY_VALIDATION_ENTITLEMENT: Final = "com.apple.security.cs.disable-library-validation"
+
+#: virtio-fs tag for the session workspace.
+WORKSPACE_TAG: Final = "bnsws"
+#: virtio-fs tag for the per-exec control directory.
+CONTROL_TAG: Final = "bnsctl"
+#: Guest mount point for the control directory (never part of a snapshot).
+GUEST_CONTROL_DIR: Final = "/.bernstein-control"
+#: Interpreter the guest wrapper runs under, relative to the guest root.
+GUEST_SHELL: Final = "/bin/sh"
+#: File name of the launcher binary.
+LAUNCHER_NAME: Final = "krunlaunch"
+
+_DEFAULT_VCPUS: Final = 1
+_DEFAULT_RAM_MIB: Final = 512
+#: 512 MiB DAX window per share. Sizes from 0 to 4 GiB behave identically here;
+#: this one is comfortably inside what Hypervisor.framework accepts for three
+#: simultaneous shares.
+_DEFAULT_SHM_BYTES: Final = 1 << 29
+
+#: Exit codes libkrun's own ``init`` reserves for VM-level failures. A guest
+#: command may legitimately return any of these too, which is exactly why the
+#: status file - not the process exit code - decides (see
+#: :func:`resolve_guest_exit_code`).
+LIBKRUN_RESERVED_EXIT_CODES: Final[dict[int, str]] = {
+    125: 'libkrun "init" could not set up the environment inside the microVM',
+    126: 'libkrun "init" found the guest entrypoint but could not execute it',
+    127: 'libkrun "init" could not find the guest entrypoint',
+}
+
+#: Marker the guest wrapper writes to report the command's real exit code.
+#: Namespaced and explicit so a truncated or absent file can never be mistaken
+#: for a successful report.
+STATUS_PREFIX: Final = "bernstein-guest-status:"
+
+_CONTROL_STDIN: Final = "stdin"
+_CONTROL_STDOUT: Final = "stdout"
+_CONTROL_STDERR: Final = "stderr"
+_CONTROL_STATUS: Final = "status"
+_CONTROL_ENV: Final = "env.sh"
+_CONTROL_SCRIPT: Final = "run.sh"
+_CONTROL_CONSOLE: Final = "console"
+
+#: How much launcher stderr / guest console to quote when a VM fails.
+_DIAGNOSTIC_TAIL_CHARS: Final = 800
+
+
+# ---------------------------------------------------------------------------
+# Host discovery (read-only - safe to call from preflight)
+# ---------------------------------------------------------------------------
+
+
+def _lib_dirs() -> tuple[str, ...]:
+    """Well-known directories holding the libkrun / libkrunfw shared objects."""
+    if sys.platform == "darwin":
+        return ("/opt/homebrew/lib", "/usr/local/lib")
+    return ("/usr/lib64", "/usr/lib", "/usr/local/lib")
+
+
+def _lib_names(stem: str) -> tuple[str, ...]:
+    """Candidate file names for a shared object, newest soname first."""
+    if sys.platform == "darwin":
+        return (f"{stem}.dylib",)
+    return (f"{stem}.so.1", f"{stem}.so.5", f"{stem}.so")
+
+
+def _find_shared_object(stem: str, explicit: str | None = None) -> str | None:
+    """Locate a shared object without loading it.
+
+    Deliberately does *not* ``dlopen`` anything: :meth:`LibkrunMonitor.preflight`
+    must stay side-effect-free, and loading a hypervisor library is not that.
+    """
+    if explicit:
+        return explicit if Path(explicit).exists() else None
+    for directory in _lib_dirs():
+        for name in _lib_names(stem):
+            candidate = Path(directory) / name
+            if candidate.exists():
+                return str(candidate)
+    # find_library resolves a name against the loader's search path without
+    # loading it.
+    return ctypes.util.find_library(stem.removeprefix("lib"))
+
+
+def find_libkrun(explicit: str | None = None) -> str | None:
+    """Locate the libkrun shared library, or ``None`` when it is absent."""
+    return _find_shared_object("libkrun", explicit)
+
+
+def find_libkrunfw() -> str | None:
+    """Locate libkrunfw (the packaged guest kernel), or ``None`` when absent.
+
+    libkrun ``dlopen``s it at VM-start time rather than linking it, so a host
+    with libkrun but no libkrunfw preflights as ready and then fails at boot
+    with an opaque loader error. Checking for it here turns that into a named
+    precondition.
+    """
+    return _find_shared_object("libkrunfw")
+
+
+def libkrun_library_dir(library: str | None = None) -> str | None:
+    """Directory holding the libkrun shared object, for ``-L`` and ``-rpath``.
+
+    The launcher must carry an rpath to this directory: code signing strips
+    ``DYLD_*`` from the environment, so a signed binary that relies on
+    ``DYLD_LIBRARY_PATH`` cannot resolve libkrunfw at runtime. Resolving it from
+    the located library keeps a hardcoded ``/opt/homebrew`` out of the build.
+
+    Symlinks are deliberately *not* followed. A package manager links both
+    libkrun and libkrunfw into one directory while their real files sit in
+    per-version directories; resolving would yield a directory holding libkrun
+    alone, and the rpath would miss the guest kernel.
+
+    Returns:
+        The directory, or ``None`` when the library was found by soname alone
+        (already on the loader's default search path, so no rpath is needed).
+    """
+    resolved = find_libkrun(library)
+    if resolved is None or os.sep not in resolved:
+        return None
+    return str(Path(resolved).parent)
+
+
+def launcher_source_dir() -> Traversable:
+    """Packaged directory holding ``krunlaunch.c`` and its entitlements."""
+    return resources.files("bernstein.core.sandbox.backends") / "_libkrun_launcher"
+
+
+def default_launcher_path() -> Path:
+    """Where a built launcher is cached, honouring ``$XDG_CACHE_HOME``."""
+    xdg = os.environ.get("XDG_CACHE_HOME")
+    base = Path(xdg).expanduser() if xdg else Path.home() / ".cache"
+    return base / "bernstein" / "libkrun" / LAUNCHER_NAME
+
+
+def launcher_path(explicit: str | None = None) -> Path:
+    """Resolve the launcher location (explicit > env > cache)."""
+    override = explicit or os.environ.get(LAUNCHER_ENV)
+    return Path(override).expanduser() if override else default_launcher_path()
+
+
+def launcher_entitlements(path: Path) -> frozenset[str] | None:
+    """Entitlements embedded in *path*'s code signature.
+
+    Read-only: it shells out to ``codesign -d``, which only inspects.
+
+    Returns:
+        The entitlement keys found, or ``None`` when the check itself could not
+        run (no ``codesign``, timeout) - the caller reports "cannot verify"
+        rather than guessing either way.
+    """
+    if shutil.which("codesign") is None:
+        return None
+    try:
+        # Fixed argv, no shell: this only inspects an existing signature.
+        proc = subprocess.run(
+            ["codesign", "-d", "--entitlements", "-", "--xml", str(path)],
+            capture_output=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    blob = (proc.stdout + proc.stderr).decode("utf-8", "replace")
+    return frozenset(
+        entitlement for entitlement in (HYPERVISOR_ENTITLEMENT, LIBRARY_VALIDATION_ENTITLEMENT) if entitlement in blob
+    )
+
+
+# ---------------------------------------------------------------------------
+# Launcher build (the only step that writes anything - never called from
+# preflight, which must stay side-effect-free)
+# ---------------------------------------------------------------------------
+
+
+def build_launcher(
+    *,
+    dest: Path | None = None,
+    library: str | None = None,
+    compiler: str | None = None,
+) -> Path:
+    """Compile and (on macOS) sign the ``krunlaunch`` binary.
+
+    Args:
+        dest: Output path. Defaults to :func:`launcher_path`.
+        library: Explicit libkrun path, used to derive the link prefix.
+        compiler: C compiler to invoke. Defaults to ``$CC`` then ``cc``.
+
+    Returns:
+        The path to the built launcher.
+
+    Raises:
+        MicroVMUnavailableError: When libkrun is not installed, no compiler is
+            available, or the compile/sign step fails. The message carries the
+            tool's own diagnostics so the operator can act on it.
+    """
+    if find_libkrun(library) is None:
+        msg = (
+            "cannot build the libkrun launcher: the libkrun shared library was not found "
+            f"(install libkrun, or set ${LIBRARY_ENV})"
+        )
+        raise MicroVMUnavailableError(msg)
+    lib_dir = libkrun_library_dir(library)
+
+    cc = compiler or os.environ.get("CC") or "cc"
+    if shutil.which(cc) is None:
+        msg = f"cannot build the libkrun launcher: C compiler {cc!r} not found on PATH"
+        raise MicroVMUnavailableError(msg)
+
+    target = (dest or launcher_path()).expanduser()
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    with resources.as_file(launcher_source_dir()) as source_dir:
+        _compile_launcher(cc, source_dir / "krunlaunch.c", target, lib_dir)
+        if sys.platform == "darwin":
+            _sign_launcher(source_dir / "krunlaunch.entitlements.plist", target)
+    return target
+
+
+def _compile_launcher(cc: str, source: Path, target: Path, lib_dir: str | None) -> None:
+    """Link the launcher against libkrun, with an rpath to *lib_dir*."""
+    argv = [cc, "-O2", "-o", str(target), str(source)]
+    if lib_dir is not None:
+        # Signed binaries lose DYLD_*, so the library search path has to be
+        # baked in at link time or libkrunfw cannot be resolved at runtime.
+        argv += [f"-L{lib_dir}", f"-Wl,-rpath,{lib_dir}"]
+    argv.append("-lkrun")
+    _run_tool(argv, "compiling the libkrun launcher")
+
+
+def _sign_launcher(entitlements: Path, target: Path) -> None:
+    """Ad-hoc sign *target* with the hypervisor entitlements.
+
+    Ad-hoc (``--sign -``) is sufficient for Hypervisor.framework; it is what
+    the packaged ``krunkit`` binary does.
+    """
+    argv = [
+        "codesign",
+        "--force",
+        "--sign",
+        "-",
+        "--entitlements",
+        str(entitlements),
+        str(target),
+    ]
+    _run_tool(argv, "signing the libkrun launcher")
+
+
+def _run_tool(argv: list[str], what: str) -> None:
+    try:
+        proc = subprocess.run(argv, capture_output=True, timeout=300, check=False)
+    except (OSError, subprocess.SubprocessError) as exc:
+        msg = f"failed while {what}: {exc}"
+        raise MicroVMUnavailableError(msg) from exc
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout).decode("utf-8", "replace").strip()
+        msg = f"failed while {what} (exit {proc.returncode}): {detail}"
+        raise MicroVMUnavailableError(msg)
+
+
+# ---------------------------------------------------------------------------
+# Exit-code disambiguation (pure - unit-testable on every host)
+# ---------------------------------------------------------------------------
+
+
+def parse_guest_status(raw: str | None) -> int | None:
+    """Extract the guest command's exit code from a status file's contents.
+
+    Args:
+        raw: The status file's text, or ``None`` when it does not exist.
+
+    Returns:
+        The reported exit code, or ``None`` when the wrapper never got far
+        enough to report one (absent, truncated, or malformed file). ``None``
+        always means "no guest result", never "the guest returned 0".
+    """
+    if raw is None:
+        return None
+    for line in raw.splitlines():
+        candidate = line.strip()
+        if not candidate.startswith(STATUS_PREFIX):
+            continue
+        payload = candidate[len(STATUS_PREFIX) :].strip()
+        if not payload.isdigit():
+            return None
+        value = int(payload)
+        # A POSIX wait status carries 8 bits; anything else means the file was
+        # not written by our wrapper and must not be trusted as a result.
+        return value if 0 <= value <= 255 else None
+    return None
+
+
+def resolve_guest_exit_code(
+    *,
+    launcher_exit_code: int,
+    status_raw: str | None,
+    diagnostics: str = "",
+) -> int:
+    """Decide whether a finished VM carried a guest result or a VM failure.
+
+    This is the correctness-critical half of the adapter. The launcher's exit
+    code is ambiguous by construction: libkrun reserves 125/126/127 for its own
+    failures and a guest command can return those values too. The status file
+    resolves the ambiguity out of band - the guest wrapper writes it only
+    *after* the command completed, so its presence proves the command ran and
+    its payload is the command's real exit code.
+
+    Args:
+        launcher_exit_code: Exit code of the process that ran the VM.
+        status_raw: Contents of the guest-written status file, or ``None``.
+        diagnostics: Launcher stderr / guest console tail, quoted on failure.
+
+    Returns:
+        The guest command's exit code.
+
+    Raises:
+        MicroVMUnavailableError: When the guest command never ran to
+            completion, naming the libkrun-level reason when the reserved exit
+            code identifies one.
+    """
+    guest_rc = parse_guest_status(status_raw)
+    if guest_rc is not None:
+        # Authoritative: the wrapper ran the command and reported its status.
+        # This is the branch that keeps a *guest* 125/126/127 a guest result.
+        return guest_rc
+
+    suffix = f" Diagnostics: {diagnostics.strip()}" if diagnostics.strip() else ""
+    reserved = LIBKRUN_RESERVED_EXIT_CODES.get(launcher_exit_code)
+    if reserved is not None:
+        msg = (
+            f"microVM (libkrun) failed before the guest command produced a result: {reserved} "
+            f"(reserved exit code {launcher_exit_code}). The guest root filesystem must provide "
+            f"{GUEST_SHELL} and a mount(8) that supports virtiofs.{suffix}"
+        )
+        raise MicroVMUnavailableError(msg)
+    msg = (
+        f"microVM (libkrun) guest produced no status report; the VM process exited "
+        f"{launcher_exit_code}. The guest command's result is unknown, so it is reported as a "
+        f"VM failure rather than guessed from the process exit code.{suffix}"
+    )
+    raise MicroVMUnavailableError(msg)
+
+
+# ---------------------------------------------------------------------------
+# Guest-side program
+# ---------------------------------------------------------------------------
+
+
+def build_bootstrap_argument() -> str:
+    """The ``sh -c`` program libkrun starts the guest with.
+
+    Kept deliberately tiny and constant. Everything libkrun is asked to start
+    the guest with travels on the kernel command line, which has a hard size
+    limit - overrunning it aborts the VMM rather than returning an error. So
+    this only mounts the control share and hands over to a script that lives
+    *in* that share, where the command, the environment and the working
+    directory can be any size.
+    """
+    ctl = shlex.quote(GUEST_CONTROL_DIR)
+    return (
+        f"mkdir -p {ctl} 2>/dev/null; "
+        f"mount -t virtiofs {CONTROL_TAG} {ctl} || exit 125; "
+        f"exec {GUEST_SHELL} {ctl}/{_CONTROL_SCRIPT}"
+    )
+
+
+def build_guest_script(*, cmd: Sequence[str], workspace_mount: str, cwd: str) -> str:
+    """Render the wrapper the guest runs once the control share is mounted.
+
+    It mounts the workspace, applies the session environment, runs *cmd* with
+    stdio wired to files in the control share, and - last - writes the status
+    line that :func:`resolve_guest_exit_code` treats as authoritative. Writing
+    the status last is what makes its presence mean "the command completed": a
+    failed mount exits before it and is reported as a VM failure.
+    """
+    quoted_cmd = " ".join(shlex.quote(part) for part in cmd)
+    ws = shlex.quote(workspace_mount)
+    ctl = shlex.quote(GUEST_CONTROL_DIR)
+    target = shlex.quote(cwd)
+    # 125 is libkrun's own "init could not set up the environment" code, which
+    # is exactly what a failed workspace mount is from the caller's viewpoint.
+    return f"""set -u
+mkdir -p {ws} 2>/dev/null
+mount -t virtiofs {WORKSPACE_TAG} {ws} || exit 125
+. {ctl}/{_CONTROL_ENV}
+cd {target} 2>>{ctl}/{_CONTROL_STDERR}
+__bns_rc=$?
+if [ "$__bns_rc" -eq 0 ]; then
+{quoted_cmd} <{ctl}/{_CONTROL_STDIN} >>{ctl}/{_CONTROL_STDOUT} 2>>{ctl}/{_CONTROL_STDERR}
+__bns_rc=$?
+fi
+printf '{STATUS_PREFIX}%s\\n' "$__bns_rc" >{ctl}/{_CONTROL_STATUS}
+exit 0
+"""
+
+
+def build_guest_env_script(env: Mapping[str, str]) -> str:
+    """Render the sourced environment file for the guest wrapper.
+
+    The session environment does not travel on the kernel command line (see
+    :func:`build_bootstrap_argument`); it is sourced from the control share, so
+    its size is unbounded. Names that are not valid shell identifiers are
+    dropped rather than emitted as syntax that would abort the wrapper.
+    """
+    lines = ["# generated per exec by LibkrunMonitor; sourced by the guest wrapper"]
+    for key in sorted(env):
+        if not key.isidentifier() or key.startswith("__bns_"):
+            continue
+        lines.append(f"export {key}={shlex.quote(env[key])}")
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# LibkrunMonitor
+# ---------------------------------------------------------------------------
+
+
+class LibkrunMonitor:
+    """Real microVM monitor driving libkrun guests.
+
+    Construction is cheap and never boots a VM. :meth:`preflight` reports every
+    missing host precondition side-effect-free; :meth:`boot` runs it and raises
+    :class:`~bernstein.core.sandbox.backends._vmmonitor.MicroVMUnavailableError`
+    when anything is missing, never degrading to a weaker isolation mode.
+
+    Args:
+        root: Logical workspace root inside the guest.
+        rootfs: Guest root filesystem *directory* on the host. Defaults to
+            ``$BERNSTEIN_MICROVM_LIBKRUN_ROOTFS``.
+        library: libkrun shared-library path. Defaults to
+            ``$BERNSTEIN_MICROVM_LIBKRUN_LIB`` then well-known locations.
+        launcher: Path to the signed ``krunlaunch`` binary. Defaults to
+            ``$BERNSTEIN_MICROVM_LIBKRUN_LAUNCHER`` then the build cache.
+        vcpus: Guest vCPU count.
+        ram_mib: Guest RAM in MiB.
+        shm_bytes: virtio-fs DAX window size, in bytes.
+    """
+
+    def __init__(
+        self,
+        *,
+        root: str = "/workspace",
+        rootfs: str | None = None,
+        library: str | None = None,
+        launcher: str | None = None,
+        vcpus: int | None = None,
+        ram_mib: int | None = None,
+        shm_bytes: int | None = None,
+    ) -> None:
+        self._logical_root = root
+        self._rootfs = rootfs or os.environ.get(ROOTFS_ENV)
+        self._library_override = library or os.environ.get(LIBRARY_ENV)
+        self._launcher = launcher_path(launcher)
+        self._vcpus = vcpus if vcpus is not None else _env_int(VCPUS_ENV, _DEFAULT_VCPUS)
+        self._ram_mib = ram_mib if ram_mib is not None else _env_int(RAM_MIB_ENV, _DEFAULT_RAM_MIB)
+        self._shm_bytes = shm_bytes if shm_bytes is not None else _env_int(SHM_BYTES_ENV, _DEFAULT_SHM_BYTES)
+        self._workspace: Path | None = None
+        self._control_root: Path | None = None
+        self._base_env: dict[str, str] = {}
+        self._closed = False
+
+    # -- protocol surface --------------------------------------------------
+
+    @property
+    def workdir(self) -> str:
+        return self._logical_root
+
+    # -- host preflight ----------------------------------------------------
+
+    def preflight(self) -> list[str]:
+        """Return every missing host precondition (empty == ready).
+
+        Side-effect-free: it stats files and inspects a code signature, but
+        loads no library, compiles nothing and starts no VM, so the selector
+        can probe support before committing to a boot. The list is exhaustive
+        rather than short-circuiting - an operator provisioning a host should
+        learn about all of it in one pass.
+        """
+        return [
+            *self._preflight_platform(),
+            *self._preflight_libraries(),
+            *self._preflight_launcher(),
+            *self._preflight_rootfs(),
+        ]
+
+    def _preflight_platform(self) -> list[str]:
+        """Hypervisor availability for this OS."""
+        if sys.platform == "linux":
+            if not Path("/dev/kvm").exists():
+                return ["/dev/kvm not present (no hardware virtualization / KVM)"]
+            if not os.access("/dev/kvm", os.R_OK | os.W_OK):
+                return ["/dev/kvm is not readable+writable by this user"]
+            return []
+        if sys.platform == "darwin":
+            machine = os.uname().machine
+            if machine != "arm64":
+                return [f"macOS host is {machine!r}; libkrun requires Apple Silicon (arm64)"]
+            return []
+        return [f"host OS is {sys.platform!r}; libkrun supports Linux and macOS/arm64"]
+
+    def _preflight_libraries(self) -> list[str]:
+        """libkrun itself, and the guest kernel it dlopens at start time."""
+        missing: list[str] = []
+        if find_libkrun(self._library_override) is None:
+            hint = "" if self._library_override else f" (install libkrun, or set ${LIBRARY_ENV})"
+            missing.append(f"libkrun shared library not found{hint}")
+        if find_libkrunfw() is None:
+            missing.append(
+                "libkrunfw shared library not found (it carries the guest kernel; libkrun loads it when the VM starts)"
+            )
+        return missing
+
+    def _preflight_launcher(self) -> list[str]:
+        """The signed launcher binary that hosts one VM per exec."""
+        missing: list[str] = []
+        launcher = self._launcher
+        if not launcher.is_file():
+            return [
+                f"libkrun launcher binary missing at {str(launcher)!r} "
+                f"(build it with `bernstein sandbox microvm-launcher`, or set ${LAUNCHER_ENV})"
+            ]
+        if not os.access(launcher, os.X_OK):
+            missing.append(f"libkrun launcher {str(launcher)!r} is not executable")
+        if sys.platform == "darwin":
+            missing.extend(self._preflight_signature(launcher))
+        return missing
+
+    def _preflight_signature(self, launcher: Path) -> list[str]:
+        """macOS only: Hypervisor.framework needs an entitled executable image.
+
+        Checked here rather than left to boot because the failure it prevents
+        is opaque - ``hv_vm_create`` returns a bare ``EINVAL`` that surfaces as
+        ``Internal(Vm(VmSetup(VmCreate)))``.
+        """
+        found = launcher_entitlements(launcher)
+        if found is None:
+            return [f"cannot verify the code signature of {str(launcher)!r} (codesign unavailable)"]
+        required = {HYPERVISOR_ENTITLEMENT, LIBRARY_VALIDATION_ENTITLEMENT}
+        absent = sorted(required - found)
+        if absent:
+            return [
+                f"libkrun launcher {str(launcher)!r} is not code-signed with "
+                f"{', '.join(absent)} (rebuild it with `bernstein sandbox microvm-launcher`)"
+            ]
+        return []
+
+    def _preflight_rootfs(self) -> list[str]:
+        """The operator-supplied guest root filesystem."""
+        if not self._rootfs:
+            return [f"guest root filesystem directory not configured (set ${ROOTFS_ENV})"]
+        root = Path(self._rootfs)
+        if not root.is_dir():
+            return [f"guest root filesystem {self._rootfs!r} is not a directory (set ${ROOTFS_ENV})"]
+        # lexists, not exists: in a real rootfs /bin/sh is usually a symlink to
+        # an absolute in-guest path (busybox), which resolves inside the guest
+        # and dangles on the host. Following it here would reject every rootfs
+        # built the normal way.
+        if not os.path.lexists(root / GUEST_SHELL.lstrip("/")):
+            return [f"guest root filesystem {self._rootfs!r} has no {GUEST_SHELL}"]
+        return []
+
+    def _require_available(self) -> None:
+        missing = self.preflight()
+        if missing:
+            detail = "; ".join(missing)
+            msg = f"MicroVM (libkrun) unavailable on this host: {detail}"
+            raise MicroVMUnavailableError(msg)
+
+    # -- lifecycle ---------------------------------------------------------
+
+    async def boot(self, *, base_env: Mapping[str, str]) -> None:
+        """Validate the host and prepare an empty workspace root.
+
+        No VM is started here. ``krun_start_enter`` owns a whole process and
+        every byte of session state lives in the shared workspace rather than
+        in VM memory, so a guest is booted per :meth:`exec` instead of being
+        held open across the session.
+
+        Raises:
+            MicroVMUnavailableError: When any host precondition is missing.
+                The backend refuses rather than degrading isolation.
+        """
+        self._require_available()
+        self._base_env = dict(base_env)
+        # Resolve symlinks up front (macOS /var -> /private/var) so the
+        # containment check in _resolve compares like with like, and so the
+        # path handed to virtio-fs is the real one.
+        if self._workspace is None:
+            self._workspace = Path(tempfile.mkdtemp(prefix="bernstein-microvm-krun-")).resolve()
+        if self._control_root is None:
+            self._control_root = Path(tempfile.mkdtemp(prefix="bernstein-microvm-krun-ctl-")).resolve()
+        self._workspace.mkdir(parents=True, exist_ok=True)
+        self._closed = False
+
+    async def shutdown(self) -> None:
+        """Tear the session down. Idempotent."""
+        if self._closed:
+            return
+        self._closed = True
+        for directory in (self._workspace, self._control_root):
+            if directory is not None:
+                shutil.rmtree(directory, ignore_errors=True)
+
+    # -- filesystem surface (plain host I/O over the shared workspace) ------
+
+    def _require_booted(self) -> Path:
+        return self._require_dirs()[0]
+
+    def _require_dirs(self) -> tuple[Path, Path]:
+        """Return (workspace, control root) for a live session, or refuse."""
+        if self._workspace is None or self._control_root is None or self._closed:
+            msg = "microVM (libkrun) session is not booted"
+            raise MicroVMUnavailableError(msg)
+        return self._workspace, self._control_root
+
+    def _resolve(self, path: str) -> Path:
+        """Map a guest path to a host path pinned under the shared workspace."""
+        workspace = self._require_booted()
+        rel = path
+        if Path(path).is_absolute():
+            rel = os.path.relpath(path, self._logical_root)
+        target = (workspace / rel).resolve()
+        if target != workspace and workspace not in target.parents:
+            msg = f"Path {path!r} escapes the guest workspace"
+            raise ValueError(msg)
+        return target
+
+    async def read_file(self, path: str) -> bytes:
+        target = self._resolve(path)
+        if not target.exists():
+            msg = f"No such file in guest: {path}"
+            raise FileNotFoundError(msg)
+        return target.read_bytes()
+
+    async def write_file(self, path: str, data: bytes, *, mode: int = 0o644) -> None:
+        target = self._resolve(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(data)
+        with contextlib.suppress(OSError):
+            target.chmod(mode)
+
+    async def ls(self, path: str) -> list[str]:
+        target = self._resolve(path)
+        if not target.is_dir():
+            msg = f"Not a directory in guest: {path}"
+            raise NotADirectoryError(msg)
+        return sorted(p.name for p in target.iterdir())
+
+    async def freeze_image(self) -> bytes:
+        """Canonical workspace image of the shared directory.
+
+        Reuses :func:`canonical_workspace_image` unchanged, so the bytes - and
+        therefore the content address - are identical to the ones
+        ``FakeMonitor`` produces for the same tree.
+        """
+        return canonical_workspace_image(self._require_booted())
+
+    async def restore_image(self, image: bytes) -> None:
+        workspace = self._require_booted()
+        workspace.mkdir(parents=True, exist_ok=True)
+        extract_workspace_image(image, workspace)
+
+    # -- exec --------------------------------------------------------------
+
+    async def exec(
+        self,
+        cmd: list[str],
+        *,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout: int | None = None,
+        stdin: bytes | None = None,
+    ) -> ExecResult:
+        """Boot a guest, run *cmd* in it, and capture its result.
+
+        Raises:
+            MicroVMUnavailableError: When the VM could not run the command to
+                completion. Distinct from a guest command that merely exited
+                non-zero - see :func:`resolve_guest_exit_code`.
+            TimeoutError: When *timeout* elapsed; the VM process is killed.
+        """
+        workspace, control_root = self._require_dirs()
+        with self._exec_control_dir(control_root) as control:
+            self._write_control_files(control, cmd=cmd, cwd=cwd, env=env, stdin=stdin)
+            loop = asyncio.get_running_loop()
+            start = loop.time()
+            launcher_rc, launcher_stderr = await self._run_launcher(
+                workspace=workspace,
+                control=control,
+                timeout=timeout,
+                cmd=cmd,
+            )
+            duration = loop.time() - start
+            exit_code = resolve_guest_exit_code(
+                launcher_exit_code=launcher_rc,
+                status_raw=_read_text(control / _CONTROL_STATUS),
+                diagnostics=_diagnostics(launcher_stderr, control / _CONTROL_CONSOLE),
+            )
+            return ExecResult(
+                exit_code=exit_code,
+                stdout=_read_bytes(control / _CONTROL_STDOUT),
+                stderr=_read_bytes(control / _CONTROL_STDERR),
+                duration_seconds=duration,
+            )
+
+    @contextlib.contextmanager
+    def _exec_control_dir(self, control_root: Path) -> Iterator[Path]:
+        """A private control directory for one exec, removed afterwards.
+
+        Per-exec rather than per-session so two concurrent ``exec`` calls on
+        one session cannot read each other's status file - which would let one
+        command's exit code be reported as another's.
+        """
+        control = control_root / uuid.uuid4().hex
+        control.mkdir(parents=True)
+        try:
+            yield control
+        finally:
+            shutil.rmtree(control, ignore_errors=True)
+
+    def _write_control_files(
+        self,
+        control: Path,
+        *,
+        cmd: list[str],
+        cwd: str | None,
+        env: Mapping[str, str] | None,
+        stdin: bytes | None,
+    ) -> None:
+        """Lay out the control share the guest wrapper reads and writes."""
+        run_env = dict(self._base_env)
+        if env:
+            run_env.update(env)
+        (control / _CONTROL_STDIN).write_bytes(stdin or b"")
+        (control / _CONTROL_STDOUT).write_bytes(b"")
+        (control / _CONTROL_STDERR).write_bytes(b"")
+        (control / _CONTROL_ENV).write_text(build_guest_env_script(run_env), encoding="utf-8")
+        (control / _CONTROL_SCRIPT).write_text(
+            build_guest_script(
+                cmd=cmd,
+                workspace_mount=self._logical_root,
+                cwd=self._guest_cwd(cwd),
+            ),
+            encoding="utf-8",
+        )
+
+    def _guest_cwd(self, cwd: str | None) -> str:
+        """Absolute guest path for *cwd* (relative paths hang off the root)."""
+        if not cwd:
+            return self._logical_root
+        if posixpath.isabs(cwd):
+            return cwd
+        return posixpath.join(self._logical_root, cwd)
+
+    def _launcher_env(self, *, workspace: Path, control: Path) -> dict[str, str]:
+        """Environment for the launcher process (never reaches the guest)."""
+        return {
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "KRUNLAUNCH_VCPUS": str(self._vcpus),
+            "KRUNLAUNCH_RAM_MIB": str(self._ram_mib),
+            "KRUNLAUNCH_SHM_BYTES": str(self._shm_bytes),
+            "KRUNLAUNCH_CONSOLE": str(control / _CONTROL_CONSOLE),
+            # The launcher reads KRUNLAUNCH_SHARE_<n> until the first gap.
+            "KRUNLAUNCH_SHARE_0": f"{WORKSPACE_TAG}={workspace}",
+            "KRUNLAUNCH_SHARE_1": f"{CONTROL_TAG}={control}",
+        }
+
+    async def _run_launcher(
+        self,
+        *,
+        workspace: Path,
+        control: Path,
+        timeout: int | None,
+        cmd: list[str],
+    ) -> tuple[int, str]:
+        """Spawn one VM and wait for it, honouring *timeout*.
+
+        Returns:
+            The launcher's exit code and its stderr (diagnostics only - the
+            guest's own streams come from the control share).
+        """
+        if self._rootfs is None:  # pragma: no cover - boot() already refused
+            msg = "MicroVM (libkrun) unavailable on this host: guest rootfs not configured"
+            raise MicroVMUnavailableError(msg)
+        proc = await asyncio.create_subprocess_exec(
+            str(self._launcher),
+            self._rootfs,
+            "/",
+            GUEST_SHELL,
+            "-c",
+            build_bootstrap_argument(),
+            env=self._launcher_env(workspace=workspace, control=control),
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            _, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        except TimeoutError as exc:
+            # Kill the VM before propagating: a wedged guest that outlives the
+            # call would keep its virtio-fs shares (and this session's
+            # workspace) alive after shutdown().
+            with contextlib.suppress(ProcessLookupError):
+                proc.kill()
+            await proc.wait()
+            msg = f"Command timed out after {timeout}s: {cmd!r}"
+            raise TimeoutError(msg) from exc
+        return (
+            proc.returncode if proc.returncode is not None else -1,
+            stderr.decode("utf-8", "replace"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Small helpers
+# ---------------------------------------------------------------------------
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def _read_bytes(path: Path) -> bytes:
+    try:
+        return path.read_bytes()
+    except OSError:
+        return b""
+
+
+def _read_text(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+
+
+def _diagnostics(launcher_stderr: str, console: Path) -> str:
+    """Tail of the launcher's stderr plus the guest console, for error messages."""
+    parts = [launcher_stderr.strip(), (_read_text(console) or "").strip()]
+    joined = " | ".join(part for part in parts if part)
+    return joined[-_DIAGNOSTIC_TAIL_CHARS:]
+
+
+__all__ = [
+    "CONTROL_TAG",
+    "GUEST_CONTROL_DIR",
+    "GUEST_SHELL",
+    "HYPERVISOR_ENTITLEMENT",
+    "LAUNCHER_ENV",
+    "LAUNCHER_NAME",
+    "LIBKRUN_RESERVED_EXIT_CODES",
+    "LIBRARY_ENV",
+    "LIBRARY_VALIDATION_ENTITLEMENT",
+    "RAM_MIB_ENV",
+    "ROOTFS_ENV",
+    "SHM_BYTES_ENV",
+    "STATUS_PREFIX",
+    "VCPUS_ENV",
+    "WORKSPACE_TAG",
+    "LibkrunMonitor",
+    "build_bootstrap_argument",
+    "build_guest_env_script",
+    "build_guest_script",
+    "build_launcher",
+    "default_launcher_path",
+    "find_libkrun",
+    "find_libkrunfw",
+    "launcher_entitlements",
+    "launcher_path",
+    "launcher_source_dir",
+    "libkrun_library_dir",
+    "parse_guest_status",
+    "resolve_guest_exit_code",
+]

--- a/src/bernstein/core/sandbox/backends/_libkrun_launcher/krunlaunch.c
+++ b/src/bernstein/core/sandbox/backends/_libkrun_launcher/krunlaunch.c
@@ -1,0 +1,169 @@
+/*
+ * krunlaunch - one process, one microVM.
+ *
+ * `LibkrunMonitor` (src/bernstein/core/sandbox/backends/_libkrun.py) spawns
+ * this binary once per `exec()`. It exists as a separate executable for two
+ * independent reasons, either of which alone would force it:
+ *
+ *   1. krun_start_enter() never returns. It hands the calling process to the
+ *      VMM, which exit()s with the workload's status. A VM therefore *is* a
+ *      process; the orchestrator cannot host one in-process.
+ *   2. On macOS, hv_vm_create() fails with EINVAL unless the running
+ *      executable image carries com.apple.security.hypervisor. A Homebrew /
+ *      python.org CPython re-execs into a framework binary that cannot
+ *      usefully carry it, so the entitled image has to be our own.
+ *
+ * Build + sign: see `bernstein.core.sandbox.backends._libkrun.build_launcher`,
+ * or `docs/operations/microvm-libkrun.md`. The link line must carry an rpath
+ * to the libkrun prefix: code signing strips DYLD_* from the environment, so a
+ * signed binary that relies on DYLD_LIBRARY_PATH fails to resolve libkrunfw.
+ *
+ * usage: krunlaunch <rootfs_dir> <guest_workdir> <guest_exec> [args...]
+ *
+ * environment (read from the host process, never forwarded to the guest):
+ *   KRUNLAUNCH_VCPUS        guest vCPUs                       (default 1)
+ *   KRUNLAUNCH_RAM_MIB      guest RAM in MiB                  (default 512)
+ *   KRUNLAUNCH_SHM_BYTES    virtio-fs DAX window, bytes       (default 512 MiB)
+ *   KRUNLAUNCH_LOG_LEVEL    libkrun log level                 (default: unset)
+ *   KRUNLAUNCH_CONSOLE      file to receive the guest console (default: stdout)
+ *   KRUNLAUNCH_SHARE_<N>    extra virtio-fs share, "tag=/host/path", N from 0
+ *
+ * exit codes: 125 for any libkrun-level failure, mirroring libkrun's own
+ * reserved range. The guest's real status is reported out of band by the
+ * monitor's wrapper script, because a guest command may legitimately return
+ * 125/126/127 itself.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+extern int32_t krun_set_log_level(uint32_t level);
+extern int32_t krun_create_ctx(void);
+extern int32_t krun_set_vm_config(uint32_t ctx_id, uint8_t num_vcpus, uint32_t ram_mib);
+extern int32_t krun_add_virtiofs3(uint32_t ctx_id, const char *tag, const char *path,
+                                  uint64_t shm_size, bool read_only);
+extern int32_t krun_add_virtiofs4(uint32_t ctx_id, const char *tag, const char *path,
+                                  uint64_t shm_size, bool read_only, uint32_t semantics);
+extern int32_t krun_set_workdir(uint32_t ctx_id, const char *workdir);
+extern int32_t krun_set_console_output(uint32_t ctx_id, const char *filepath);
+extern int32_t krun_set_exec(uint32_t ctx_id, const char *exec_path,
+                             const char *const argv[], const char *const envp[]);
+extern int32_t krun_start_enter(uint32_t ctx_id);
+
+/* Reserved tag: libkrun mounts this share as the guest root. */
+#define KRUN_FS_ROOT_TAG "/dev/root"
+
+/* Store permission bits in the host inode instead of an extended attribute.
+ * The workspace share is snapshotted by reading it from the host, so the two
+ * views have to agree: under the default semantics a file the guest creates
+ * 0644 lands on the host 0600, and freezing it would silently drop the mode
+ * (an executable the guest built would restore non-executable). */
+#define KRUN_SEMANTICS_LINUX_SIMPLIFIED 1
+
+/* libkrun-level failure. Distinct from the guest's status, which the monitor
+ * reads from the status file the wrapper writes into the control share. */
+#define RC_VMM_FAILURE 125
+
+#define MAX_EXTRA_SHARES 8
+
+static int fail(const char *what, int32_t rc) {
+    fprintf(stderr, "krunlaunch: %s failed rc=%d\n", what, rc);
+    return RC_VMM_FAILURE;
+}
+
+int main(int argc, char **argv) {
+    if (argc < 4) {
+        fprintf(stderr, "usage: %s <rootfs> <workdir> <exec> [args...]\n", argv[0]);
+        return RC_VMM_FAILURE;
+    }
+    const char *rootfs = argv[1];
+    const char *workdir = argv[2];
+    const char *exec_path = argv[3];
+
+    const char *vcpus_s = getenv("KRUNLAUNCH_VCPUS");
+    const char *ram_s = getenv("KRUNLAUNCH_RAM_MIB");
+    const char *shm_s = getenv("KRUNLAUNCH_SHM_BYTES");
+    const char *log_s = getenv("KRUNLAUNCH_LOG_LEVEL");
+    const char *console = getenv("KRUNLAUNCH_CONSOLE");
+    uint8_t vcpus = vcpus_s ? (uint8_t)atoi(vcpus_s) : 1;
+    uint32_t ram = ram_s ? (uint32_t)strtoul(ram_s, NULL, 10) : 512;
+    uint64_t shm = shm_s ? strtoull(shm_s, NULL, 10) : (1ULL << 29);
+
+    if (log_s) krun_set_log_level((uint32_t)atoi(log_s));
+
+    int32_t ctx = krun_create_ctx();
+    if (ctx < 0) return fail("krun_create_ctx", ctx);
+
+    int32_t rc;
+    if ((rc = krun_set_vm_config((uint32_t)ctx, vcpus, ram)) < 0)
+        return fail("krun_set_vm_config", rc);
+
+    /* The root share. krun_set_root() would also work, but virtiofs3 is what
+     * exposes the DAX window size, and an oversized window is rejected by
+     * Hypervisor.framework. */
+    if ((rc = krun_add_virtiofs3((uint32_t)ctx, KRUN_FS_ROOT_TAG, rootfs, shm, false)) < 0)
+        return fail("krun_add_virtiofs3(root)", rc);
+
+    /* Extra shares. The workspace and the control directory arrive this way so
+     * neither has to live inside the guest root filesystem: the workspace is
+     * exactly the tree freeze_image() canonicalises, and the control directory
+     * (stdio + status) must never appear in a snapshot. */
+    for (int n = 0; n < MAX_EXTRA_SHARES; n++) {
+        char key[32];
+        snprintf(key, sizeof(key), "KRUNLAUNCH_SHARE_%d", n);
+        const char *spec = getenv(key);
+        if (!spec) break;
+        const char *sep = strchr(spec, '=');
+        if (!sep || sep == spec || sep[1] == '\0') {
+            fprintf(stderr, "krunlaunch: %s must be \"tag=/host/path\"\n", key);
+            return RC_VMM_FAILURE;
+        }
+        size_t taglen = (size_t)(sep - spec);
+        char *tag = strndup(spec, taglen);
+        if (!tag) return RC_VMM_FAILURE;
+        rc = krun_add_virtiofs4((uint32_t)ctx, tag, sep + 1, shm, false,
+                                KRUN_SEMANTICS_LINUX_SIMPLIFIED);
+        free(tag);
+        if (rc < 0) return fail("krun_add_virtiofs4(share)", rc);
+    }
+
+    if ((rc = krun_set_workdir((uint32_t)ctx, workdir)) < 0)
+        return fail("krun_set_workdir", rc);
+
+    /* Kernel boot chatter shares the console with the guest's own writes to
+     * /dev/console. Diverting it to a file keeps this process's stdout clean
+     * and gives the monitor something to quote when a boot fails. */
+    if (console && (rc = krun_set_console_output((uint32_t)ctx, console)) < 0)
+        return fail("krun_set_console_output", rc);
+
+    /* Guest argv, excluding argv[0]: libkrun derives that from exec_path. */
+    int guest_argc = argc - 4;
+    const char **gargv = calloc((size_t)guest_argc + 1, sizeof(char *));
+    if (!gargv) return RC_VMM_FAILURE;
+    for (int i = 0; i < guest_argc; i++) gargv[i] = argv[4 + i];
+    gargv[guest_argc] = NULL;
+
+    /* An explicit, minimal environment is REQUIRED. Passing NULL makes libkrun
+     * collect the *host* environment and fold it into the guest kernel command
+     * line, which overruns CMDLINE_MAX_SIZE and aborts the VMM (SIGABRT, not an
+     * error return). The session's real environment is not passed here either,
+     * for the same size reason: the monitor writes it into the control share
+     * and the wrapper script sources it. */
+    const char *genvp[] = {
+        "PATH=/bin:/sbin:/usr/bin:/usr/sbin",
+        "HOME=/root",
+        "TERM=dumb",
+        NULL,
+    };
+
+    if ((rc = krun_set_exec((uint32_t)ctx, exec_path, gargv, genvp)) < 0)
+        return fail("krun_set_exec", rc);
+
+    krun_start_enter((uint32_t)ctx);
+    /* Unreachable unless the VMM refused to start. */
+    fprintf(stderr, "krunlaunch: krun_start_enter returned\n");
+    return RC_VMM_FAILURE;
+}

--- a/src/bernstein/core/sandbox/backends/_libkrun_launcher/krunlaunch.entitlements.plist
+++ b/src/bernstein/core/sandbox/backends/_libkrun_launcher/krunlaunch.entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Hypervisor.framework refuses hv_vm_create() without this. -->
+    <key>com.apple.security.hypervisor</key>
+    <true/>
+    <!-- libkrun dlopen()s libkrunfw, which is signed by a different identity. -->
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/src/bernstein/core/sandbox/backends/microvm.py
+++ b/src/bernstein/core/sandbox/backends/microvm.py
@@ -34,19 +34,23 @@ therefore honours an explicit ``sandbox.backend: microvm`` with a loud
 error on an unsupported host instead of a surprise worktree.
 
 .. note::
-   **The Firecracker VM boot path is experimental and not yet implemented.**
-   This release ships the deterministic, fully-tested core - content-addressed
-   snapshots, the fork-and-race primitive, and the signed selection receipt -
-   plus the host preflight and no-silent-downgrade contract. The real guest
-   boot + vsock-agent transport (which needs a KVM host and operator-supplied
-   kernel/rootfs/agent, unbuildable on a host without ``/dev/kvm``) is a
-   tracked follow-up. The snapshot/receipt machinery is validated
-   host-independently over the ``FakeMonitor``.
+   Two hypervisor adapters ship behind the monitor shim.
+   :class:`~bernstein.core.sandbox.backends._libkrun.LibkrunMonitor` boots a
+   real guest (KVM on Linux, Hypervisor.framework on macOS/arm64) and passes
+   the workspace through virtiofs; select it with
+   ``BERNSTEIN_MICROVM_MONITOR=libkrun`` (see :data:`MONITOR_ENV`).
+   :class:`~bernstein.core.sandbox.backends._vmmonitor.FirecrackerMonitor`
+   remains the default and still refuses to boot: its guest boot + vsock-agent
+   exec/file-IO transport (which needs a KVM host and operator-supplied
+   kernel/rootfs/agent) is a tracked follow-up. Either way the host preflight
+   and no-silent-downgrade contract hold, and the snapshot/receipt machinery is
+   validated host-independently over the ``FakeMonitor``.
 """
 
 from __future__ import annotations
 
 import logging
+import os
 import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -106,8 +110,28 @@ class MicroVMProvisioningError(RuntimeError):
     """
 
 
+#: Env var selecting which hypervisor adapter the ``microvm`` backend drives.
+#: Opt-in by design: an unset value keeps the historical Firecracker adapter,
+#: and this never changes *whether* the microvm backend is chosen - only which
+#: monitor it uses once an operator has explicitly asked for it.
+MONITOR_ENV = "BERNSTEIN_MICROVM_MONITOR"
+
+
 def _default_monitor_factory(root: str) -> VMMonitor:
-    """Production factory: a real Firecracker monitor (preflighted on boot)."""
+    """Production factory: the monitor named by :data:`MONITOR_ENV`.
+
+    Defaults to :class:`FirecrackerMonitor`. ``libkrun`` selects
+    :class:`~bernstein.core.sandbox.backends._libkrun.LibkrunMonitor`, which
+    boots on ordinary developer hardware (KVM on Linux, Hypervisor.framework on
+    macOS/arm64) and passes the workspace through virtiofs. Either way the
+    monitor preflights the host on ``boot`` and refuses rather than degrading.
+    """
+    if os.environ.get(MONITOR_ENV, "").strip().lower() == "libkrun":
+        # Imported lazily: the module loads ctypes and is only needed when an
+        # operator has explicitly selected this adapter.
+        from bernstein.core.sandbox.backends._libkrun import LibkrunMonitor
+
+        return LibkrunMonitor(root=root)
     return FirecrackerMonitor(root=root)
 
 
@@ -372,6 +396,7 @@ class MicroVMSandboxBackend:
 
 
 __all__ = [
+    "MONITOR_ENV",
     "MicroVMProvisioningError",
     "MicroVMSandboxBackend",
     "MicroVMSandboxSession",

--- a/tests/integration/sandbox/test_microvm_libkrun.py
+++ b/tests/integration/sandbox/test_microvm_libkrun.py
@@ -1,0 +1,240 @@
+"""Host-gated integration tests for the libkrun microVM monitor (#2971).
+
+Mirrors the opt-in style of ``test_microvm_firecracker.py``. Two tiers:
+
+- The refusal-invariant assertions run **everywhere**: on a host that cannot
+  run a microVM, ``preflight()`` names what is missing and ``boot()`` raises,
+  never degrading to a weaker isolation mode.
+- The real boot/exec/file-IO/freeze round trip is **opt-in**. It boots actual
+  virtual machines, so it is skipped unless
+  ``BERNSTEIN_MICROVM_LIBKRUN_INTEGRATION=1`` *and* the monitor's own preflight
+  reports nothing missing.
+
+Provisioning the opt-in tier (see ``docs/architecture/sandbox.md`` for the full
+write-up):
+
+1. Install libkrun and libkrunfw. macOS/arm64:
+   ``brew tap slp/krun && brew install libkrun``. Linux: the distribution
+   packages, plus a readable+writable ``/dev/kvm``.
+2. Build the launcher: ``bernstein sandbox microvm-launcher``. It compiles the
+   packaged C source against the local libkrun and, on macOS, ad-hoc signs it
+   with the hypervisor entitlements.
+3. Point ``$BERNSTEIN_MICROVM_LIBKRUN_ROOTFS`` at a guest root filesystem
+   *directory* providing ``/bin/sh`` and a ``mount`` that speaks virtiofs (an
+   extracted Alpine ``minirootfs`` tarball is enough).
+
+The tests do not provision anything themselves: ``preflight()`` is the contract,
+and a test that silently fixed the host would hide exactly the failure this
+backend exists to report.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from bernstein.core.sandbox.backends._libkrun import LibkrunMonitor
+from bernstein.core.sandbox.backends._vmmonitor import (
+    FakeMonitor,
+    MicroVMUnavailableError,
+)
+
+INTEGRATION_ENV = "BERNSTEIN_MICROVM_LIBKRUN_INTEGRATION"
+
+_opt_in = pytest.mark.skipif(
+    os.environ.get(INTEGRATION_ENV) != "1",
+    reason=f"opt-in libkrun integration (boots real VMs); set {INTEGRATION_ENV}=1",
+)
+
+
+def _require_supported_host() -> LibkrunMonitor:
+    monitor = LibkrunMonitor()
+    missing = monitor.preflight()
+    if missing:
+        pytest.skip(f"host cannot run a libkrun guest: {'; '.join(missing)}")
+    return monitor
+
+
+# ---------------------------------------------------------------------------
+# Runs everywhere: the no-silent-downgrade invariant
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_reports_missing_preconditions() -> None:
+    """preflight() is side-effect-free and enumerates what the host lacks."""
+    missing = LibkrunMonitor().preflight()
+    # On an unprovisioned host the list is non-empty; on a ready host it may be
+    # empty. Either way the call must not raise and must not touch the host.
+    assert isinstance(missing, list)
+    assert all(isinstance(entry, str) for entry in missing)
+
+
+@pytest.mark.asyncio
+async def test_boot_refuses_on_unsupported_host() -> None:
+    monitor = LibkrunMonitor()
+    if not monitor.preflight():
+        pytest.skip("host supports libkrun; unsupported-host refusal not exercisable")
+    with pytest.raises(MicroVMUnavailableError):
+        await monitor.boot(base_env={})
+
+
+# ---------------------------------------------------------------------------
+# Opt-in: a real guest
+# ---------------------------------------------------------------------------
+
+
+@_opt_in
+@pytest.mark.asyncio
+async def test_real_guest_roundtrip() -> None:
+    """boot -> exec -> write/read -> ls against a real libkrun guest."""
+    monitor = _require_supported_host()
+    await monitor.boot(base_env={"BERNSTEIN_TEST": "1"})
+    try:
+        await monitor.write_file("input.txt", b"payload from host\n")
+
+        # The guest really executes: it must see the host-written file through
+        # the virtiofs share, and its streams must come back separated.
+        result = await monitor.exec(["/bin/sh", "-c", "uname -s; cat input.txt; echo oops >&2"])
+        assert result.exit_code == 0
+        assert result.stdout == b"Linux\npayload from host\n"
+        assert b"oops" in result.stderr
+
+        # A guest write must be visible on the host side of the same share.
+        written = await monitor.exec(["/bin/sh", "-c", "echo from-guest > output.txt"])
+        assert written.exit_code == 0
+        assert await monitor.read_file("output.txt") == b"from-guest\n"
+        assert "output.txt" in await monitor.ls(monitor.workdir)
+    finally:
+        await monitor.shutdown()
+
+
+@_opt_in
+@pytest.mark.asyncio
+async def test_real_guest_runs_a_separate_kernel() -> None:
+    """The boundary is a real one: the guest is not this host's kernel."""
+    monitor = _require_supported_host()
+    await monitor.boot(base_env={})
+    try:
+        result = await monitor.exec(["/bin/sh", "-c", "uname -sr"])
+        assert result.exit_code == 0
+        assert result.stdout.startswith(b"Linux ")
+    finally:
+        await monitor.shutdown()
+
+
+@_opt_in
+@pytest.mark.asyncio
+async def test_real_guest_exit_codes_are_not_confused_with_libkrun_failures() -> None:
+    """A guest command returning 127 is a result, not a VM failure.
+
+    This is the collision the adapter exists to disambiguate: 125/126/127 are
+    libkrun's own failure codes *and* legitimate guest exit codes.
+    """
+    monitor = _require_supported_host()
+    await monitor.boot(base_env={})
+    try:
+        for code in (0, 1, 42, 125, 126, 127):
+            result = await monitor.exec(["/bin/sh", "-c", f"exit {code}"])
+            assert result.exit_code == code, f"guest exit {code} was not reported faithfully"
+    finally:
+        await monitor.shutdown()
+
+
+@_opt_in
+@pytest.mark.asyncio
+async def test_real_guest_receives_stdin_and_the_session_environment() -> None:
+    monitor = _require_supported_host()
+    await monitor.boot(base_env={"FROM_BASE": "base-value"})
+    try:
+        piped = await monitor.exec(["/bin/sh", "-c", "cat"], stdin=b"piped\n")
+        assert piped.exit_code == 0
+        assert piped.stdout == b"piped\n"
+
+        env = await monitor.exec(
+            ["/bin/sh", "-c", "echo $FROM_BASE $FROM_CALL"],
+            env={"FROM_CALL": "call-value"},
+        )
+        assert env.stdout == b"base-value call-value\n"
+    finally:
+        await monitor.shutdown()
+
+
+@_opt_in
+@pytest.mark.asyncio
+async def test_real_freeze_matches_fakemonitor_byte_for_byte() -> None:
+    """The acceptance criterion: identical inputs, identical content address.
+
+    The workspace is built *inside the guest* here, then frozen on the host;
+    ``FakeMonitor`` builds the same tree locally. Identical bytes prove the
+    canonical image is a pure function of the tree, independent of which
+    monitor produced it.
+    """
+    monitor = _require_supported_host()
+    await monitor.boot(base_env={})
+    fake = FakeMonitor()
+    await fake.boot(base_env={})
+    try:
+        script = "mkdir -p sub && printf alpha > top.txt && printf beta > sub/nested.txt"
+        result = await monitor.exec(["/bin/sh", "-c", script])
+        assert result.exit_code == 0
+
+        await fake.write_file("top.txt", b"alpha")
+        await fake.write_file("sub/nested.txt", b"beta")
+
+        assert await monitor.freeze_image() == await fake.freeze_image()
+    finally:
+        await monitor.shutdown()
+        await fake.shutdown()
+
+
+@_opt_in
+@pytest.mark.asyncio
+async def test_real_restore_repopulates_a_guest_workspace() -> None:
+    """A frozen image restores into a fresh session and the guest can read it."""
+    monitor = _require_supported_host()
+    await monitor.boot(base_env={})
+    try:
+        await monitor.write_file("state.txt", b"captured\n")
+        image = await monitor.freeze_image()
+    finally:
+        await monitor.shutdown()
+
+    restored = _require_supported_host()
+    await restored.boot(base_env={})
+    try:
+        await restored.restore_image(image)
+        result = await restored.exec(["/bin/sh", "-c", "cat state.txt"])
+        assert result.exit_code == 0
+        assert result.stdout == b"captured\n"
+        assert await restored.freeze_image() == image
+    finally:
+        await restored.shutdown()
+
+
+@_opt_in
+@pytest.mark.asyncio
+async def test_real_backend_roundtrip_through_the_seam(tmp_path) -> None:
+    """The backend above the seam drives the real monitor unchanged."""
+    from bernstein.core.persistence.cas_store import CASStore
+    from bernstein.core.sandbox.backends.microvm import MicroVMSandboxBackend
+    from bernstein.core.sandbox.manifest import WorkspaceManifest
+
+    _require_supported_host()
+    backend = MicroVMSandboxBackend(
+        monitor_factory=lambda root: LibkrunMonitor(root=root),
+        cas=CASStore(tmp_path / "cas"),
+    )
+    session = await backend.create(WorkspaceManifest(root="/workspace"))
+    try:
+        await session.write("state.txt", b"captured")
+        digest = await session.snapshot()
+        assert digest
+    finally:
+        await backend.destroy(session)
+
+    resumed = await backend.resume(digest)
+    try:
+        assert await resumed.read("state.txt") == b"captured"
+    finally:
+        await backend.destroy(resumed)

--- a/tests/unit/sandbox/test_libkrun_monitor.py
+++ b/tests/unit/sandbox/test_libkrun_monitor.py
@@ -1,0 +1,927 @@
+"""Host-portable unit tests for :class:`LibkrunMonitor` (#2971).
+
+These run everywhere - no hypervisor, no guest rootfs, no code signature. They
+cover the four things that must hold on *every* host:
+
+- ``preflight()`` is side-effect-free and names each missing precondition,
+  including the ones specific to this adapter (the launcher binary and its
+  entitlements);
+- the no-silent-downgrade invariant: an unsupported host refuses at ``boot()``
+  instead of degrading to a weaker isolation mode;
+- the exit-code disambiguation, which is the correctness-critical half of the
+  adapter (libkrun reserves 125/126/127 and a guest command may return them);
+- ``freeze_image()`` produces bytes identical to ``FakeMonitor``'s for the same
+  workspace tree - the issue's byte-identity acceptance criterion.
+
+``exec()`` is exercised end to end against a *stub launcher*: a small script
+that plays the part of the VM process by writing the control files a real guest
+would write. That covers the whole host-side plumbing (control-directory
+lifecycle, stdio capture, status resolution, timeout, cleanup) without needing a
+hypervisor. The guest-side wrapper is exercised separately, by running the
+generated script under the host shell with ``mount`` stubbed out.
+
+The real boot/exec round trip lives in the opt-in host-gated integration test
+``tests/integration/sandbox/test_microvm_libkrun.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bernstein.core.sandbox.backends import _libkrun
+from bernstein.core.sandbox.backends._libkrun import (
+    GUEST_SHELL,
+    HYPERVISOR_ENTITLEMENT,
+    LAUNCHER_ENV,
+    LIBKRUN_RESERVED_EXIT_CODES,
+    LIBRARY_ENV,
+    LIBRARY_VALIDATION_ENTITLEMENT,
+    ROOTFS_ENV,
+    STATUS_PREFIX,
+    LibkrunMonitor,
+    build_bootstrap_argument,
+    build_guest_env_script,
+    build_guest_script,
+    default_launcher_path,
+    find_libkrun,
+    launcher_path,
+    parse_guest_status,
+    resolve_guest_exit_code,
+)
+from bernstein.core.sandbox.backends._vmmonitor import (
+    FakeMonitor,
+    MicroVMUnavailableError,
+    VMMonitor,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+# ---------------------------------------------------------------------------
+# Fixtures: a host that looks provisioned, minus the hypervisor
+# ---------------------------------------------------------------------------
+
+
+def _touch(path: Path) -> Path:
+    path.write_bytes(b"")
+    return path
+
+
+def _make_rootfs(tmp_path: Path) -> Path:
+    """A directory shaped like a guest root filesystem."""
+    rootfs = tmp_path / "rootfs"
+    (rootfs / "bin").mkdir(parents=True)
+    (rootfs / GUEST_SHELL.lstrip("/")).write_text("#!/bin/sh\n")
+    return rootfs
+
+
+def _make_stub_launcher(tmp_path: Path, body: str) -> Path:
+    """A stand-in for the VM process.
+
+    A real launcher enters a microVM whose guest writes the control files; the
+    stub writes them directly. That is exactly the surface ``exec()`` consumes,
+    so every host-side branch stays reachable without a hypervisor.
+    """
+    launcher = tmp_path / "krunlaunch"
+    launcher.write_text(
+        f"#!{sys.executable}\n"
+        + textwrap.dedent("""
+            import os, sys
+            control = os.environ["KRUNLAUNCH_SHARE_1"].split("=", 1)[1]
+            workspace = os.environ["KRUNLAUNCH_SHARE_0"].split("=", 1)[1]
+            """)
+        + textwrap.dedent(body)
+    )
+    launcher.chmod(launcher.stat().st_mode | stat.S_IEXEC)
+    return launcher
+
+
+_GUEST_OK = """
+open(os.path.join(control, "stdout"), "w").write("out\\n")
+open(os.path.join(control, "stderr"), "w").write("err\\n")
+open(os.path.join(control, "status"), "w").write("bernstein-guest-status:0\\n")
+sys.exit(0)
+"""
+
+
+def _monitor(
+    tmp_path: Path,
+    *,
+    launcher_body: str = "sys.exit(0)\n",
+    root: str = "/workspace",
+) -> LibkrunMonitor:
+    """A monitor whose every host precondition is satisfied by a real file."""
+    return LibkrunMonitor(
+        root=root,
+        rootfs=str(_make_rootfs(tmp_path)),
+        library=str(_touch(tmp_path / "libkrun.stub")),
+        launcher=str(_make_stub_launcher(tmp_path, launcher_body)),
+    )
+
+
+def _stub_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub only the checks that genuinely need a hypervisor or a signature."""
+    monkeypatch.setattr(LibkrunMonitor, "_preflight_platform", lambda self: [])
+    monkeypatch.setattr(LibkrunMonitor, "_preflight_signature", lambda self, launcher: [])
+    monkeypatch.setattr(_libkrun, "find_libkrunfw", lambda: "/stub/libkrunfw")
+
+
+async def _boot_stubbed(
+    monitor: LibkrunMonitor,
+    monkeypatch: pytest.MonkeyPatch,
+    base_env: dict[str, str] | None = None,
+) -> None:
+    _stub_host(monkeypatch)
+    await monitor.boot(base_env=base_env or {})
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+def test_satisfies_the_vmmonitor_protocol() -> None:
+    """The backend above the seam depends only on this surface."""
+    monitor = LibkrunMonitor()
+    assert isinstance(monitor, VMMonitor)
+    for method in (
+        "boot",
+        "exec",
+        "read_file",
+        "write_file",
+        "ls",
+        "freeze_image",
+        "restore_image",
+        "shutdown",
+    ):
+        assert callable(getattr(monitor, method)), method
+    assert monitor.workdir == "/workspace"
+    assert LibkrunMonitor(root="/srv/work").workdir == "/srv/work"
+
+
+# ---------------------------------------------------------------------------
+# preflight
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_returns_a_list_and_does_not_raise() -> None:
+    """Cheap and side-effect-free so the selector can probe before booting."""
+    missing = LibkrunMonitor().preflight()
+    assert isinstance(missing, list)
+    assert all(isinstance(entry, str) for entry in missing)
+
+
+def test_preflight_creates_nothing(tmp_path: Path) -> None:
+    """'Side-effect-free' is load-bearing: probing support must not touch disk."""
+    monitor = LibkrunMonitor(
+        rootfs=str(tmp_path / "absent-rootfs"),
+        library=str(tmp_path / "absent-libkrun"),
+        launcher=str(tmp_path / "absent-launcher"),
+    )
+    monitor.preflight()
+    monitor.preflight()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_preflight_names_a_missing_rootfs(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(ROOTFS_ENV, raising=False)
+    assert any(ROOTFS_ENV in entry for entry in LibkrunMonitor().preflight())
+
+
+def test_preflight_names_a_rootfs_that_is_not_a_directory(tmp_path: Path) -> None:
+    missing = LibkrunMonitor(rootfs=str(_touch(tmp_path / "rootfs.img"))).preflight()
+    assert any("is not a directory" in entry for entry in missing)
+
+
+def test_preflight_names_a_rootfs_without_a_shell(tmp_path: Path) -> None:
+    empty = tmp_path / "empty-rootfs"
+    empty.mkdir()
+    missing = LibkrunMonitor(rootfs=str(empty)).preflight()
+    assert any(GUEST_SHELL in entry for entry in missing)
+
+
+def test_preflight_accepts_a_rootfs_whose_shell_is_a_dangling_symlink(tmp_path: Path) -> None:
+    """A normal rootfs has ``/bin/sh -> /bin/busybox``: absolute, guest-relative.
+
+    Resolving that link on the host makes it dangle, so a check that followed it
+    would reject every rootfs built the usual way.
+    """
+    rootfs = tmp_path / "rootfs"
+    (rootfs / "bin").mkdir(parents=True)
+    (rootfs / "bin" / "sh").symlink_to("/bin/busybox")
+    missing = LibkrunMonitor(rootfs=str(rootfs)).preflight()
+    assert not any(GUEST_SHELL in entry for entry in missing)
+
+
+def test_preflight_names_a_missing_library(tmp_path: Path) -> None:
+    missing = LibkrunMonitor(library=str(tmp_path / "nope.dylib")).preflight()
+    assert any("libkrun shared library not found" in entry for entry in missing)
+
+
+def test_preflight_names_a_missing_launcher(tmp_path: Path) -> None:
+    """A missing launcher is a reported precondition, like a missing hypervisor."""
+    missing = LibkrunMonitor(launcher=str(tmp_path / "krunlaunch")).preflight()
+    assert any("launcher binary missing" in entry for entry in missing)
+    # The remedy must be actionable, not merely a diagnosis.
+    assert any("microvm-launcher" in entry or LAUNCHER_ENV in entry for entry in missing)
+
+
+def test_preflight_names_an_unsigned_launcher(tmp_path: Path) -> None:
+    """macOS only: an unentitled launcher fails inside hv_vm_create, opaquely."""
+    if sys.platform != "darwin":
+        pytest.skip("code-signature preconditions are macOS-only")
+    launcher = _make_stub_launcher(tmp_path, "sys.exit(0)\n")
+    missing = LibkrunMonitor(launcher=str(launcher)).preflight()
+    assert any(HYPERVISOR_ENTITLEMENT in entry for entry in missing)
+    assert any(LIBRARY_VALIDATION_ENTITLEMENT in entry for entry in missing)
+
+
+def test_preflight_enumerates_every_missing_precondition(tmp_path: Path) -> None:
+    """It reports the whole list, not the first failure.
+
+    An operator provisioning a host should learn everything in one pass rather
+    than rediscovering the next gap after each fix.
+    """
+    monitor = LibkrunMonitor(
+        rootfs=str(tmp_path / "absent-rootfs"),
+        library=str(tmp_path / "absent-libkrun"),
+        launcher=str(tmp_path / "absent-launcher"),
+    )
+    missing = monitor.preflight()
+    assert any("libkrun shared library" in entry for entry in missing)
+    assert any("launcher binary" in entry for entry in missing)
+    assert any(ROOTFS_ENV in entry for entry in missing)
+
+
+def test_launcher_path_prefers_the_explicit_value_then_the_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(LAUNCHER_ENV, str(tmp_path / "from-env"))
+    assert launcher_path(str(tmp_path / "explicit")) == tmp_path / "explicit"
+    assert launcher_path() == tmp_path / "from-env"
+    monkeypatch.delenv(LAUNCHER_ENV)
+    assert launcher_path() == default_launcher_path()
+
+
+def test_find_libkrun_rejects_a_nonexistent_explicit_path(tmp_path: Path) -> None:
+    assert find_libkrun(str(tmp_path / "absent.dylib")) is None
+
+
+def test_find_libkrun_accepts_an_existing_explicit_path(tmp_path: Path) -> None:
+    present = _touch(tmp_path / "libkrun.dylib")
+    assert find_libkrun(str(present)) == str(present)
+    assert LIBRARY_ENV  # the documented override named in the refusal messages
+
+
+# ---------------------------------------------------------------------------
+# The no-silent-downgrade invariant
+# ---------------------------------------------------------------------------
+
+
+def _unprovisioned(tmp_path: Path) -> LibkrunMonitor:
+    return LibkrunMonitor(
+        rootfs=str(tmp_path / "absent"),
+        library=str(tmp_path / "absent"),
+        launcher=str(tmp_path / "absent"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_boot_refuses_on_an_unsupported_host(tmp_path: Path) -> None:
+    with pytest.raises(MicroVMUnavailableError):
+        await _unprovisioned(tmp_path).boot(base_env={})
+
+
+@pytest.mark.asyncio
+async def test_the_refusal_names_the_missing_preconditions(tmp_path: Path) -> None:
+    """The error is the operator's remediation list, not just a failure."""
+    with pytest.raises(MicroVMUnavailableError) as excinfo:
+        await _unprovisioned(tmp_path).boot(base_env={})
+    message = str(excinfo.value)
+    assert "libkrun shared library" in message
+    assert "launcher binary" in message
+    assert ROOTFS_ENV in message
+
+
+@pytest.mark.asyncio
+async def test_a_refused_boot_leaves_no_usable_session(tmp_path: Path) -> None:
+    """Refusal must be total: no half-open session that later reads as isolated."""
+    monitor = _unprovisioned(tmp_path)
+    with pytest.raises(MicroVMUnavailableError):
+        await monitor.boot(base_env={})
+    for coro in (
+        monitor.read_file("x"),
+        monitor.write_file("x", b""),
+        monitor.ls("."),
+        monitor.freeze_image(),
+        monitor.restore_image(b""),
+        monitor.exec(["true"]),
+    ):
+        with pytest.raises(MicroVMUnavailableError):
+            await coro
+
+
+@pytest.mark.asyncio
+async def test_shutdown_is_idempotent_after_a_refused_boot(tmp_path: Path) -> None:
+    monitor = _unprovisioned(tmp_path)
+    with pytest.raises(MicroVMUnavailableError):
+        await monitor.boot(base_env={})
+    await monitor.shutdown()
+    await monitor.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Exit-code disambiguation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("code", sorted(LIBKRUN_RESERVED_EXIT_CODES))
+def test_a_guest_command_may_legitimately_return_a_reserved_code(code: int) -> None:
+    """125/126/127 from the guest is a *result* when the wrapper reported it."""
+    assert (
+        resolve_guest_exit_code(
+            launcher_exit_code=code,
+            status_raw=f"{STATUS_PREFIX}{code}\n",
+        )
+        == code
+    )
+
+
+@pytest.mark.parametrize("code", sorted(LIBKRUN_RESERVED_EXIT_CODES))
+def test_a_libkrun_reserved_code_without_a_status_is_a_vm_failure(code: int) -> None:
+    """The same number, no status file: a VM failure, never reported as a result."""
+    with pytest.raises(MicroVMUnavailableError) as excinfo:
+        resolve_guest_exit_code(launcher_exit_code=code, status_raw=None)
+    assert LIBKRUN_RESERVED_EXIT_CODES[code] in str(excinfo.value)
+
+
+def test_reserved_codes_are_never_conflated() -> None:
+    """The whole point: the two readings of one number stay distinguishable."""
+    for code in LIBKRUN_RESERVED_EXIT_CODES:
+        assert resolve_guest_exit_code(launcher_exit_code=code, status_raw=f"{STATUS_PREFIX}{code}") == code
+        with pytest.raises(MicroVMUnavailableError):
+            resolve_guest_exit_code(launcher_exit_code=code, status_raw=None)
+
+
+def test_a_status_file_beats_a_disagreeing_process_exit_code() -> None:
+    """The wrapper's report is authoritative; the process code is a fallback."""
+    assert resolve_guest_exit_code(launcher_exit_code=0, status_raw=f"{STATUS_PREFIX}9") == 9
+    assert resolve_guest_exit_code(launcher_exit_code=1, status_raw=f"{STATUS_PREFIX}0") == 0
+
+
+def test_a_vm_failure_quotes_its_diagnostics() -> None:
+    """The launcher's own stderr is often the only clue to a boot failure."""
+    with pytest.raises(MicroVMUnavailableError) as excinfo:
+        resolve_guest_exit_code(
+            launcher_exit_code=125,
+            status_raw=None,
+            diagnostics="krunlaunch: krun_add_virtiofs3(root) failed rc=-22",
+        )
+    assert "krun_add_virtiofs3" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "",
+        "\n",
+        "garbage",
+        STATUS_PREFIX,
+        f"{STATUS_PREFIX}abc",
+        f"{STATUS_PREFIX}-1",
+        f"{STATUS_PREFIX}256",
+        f"{STATUS_PREFIX}1 2",
+    ],
+)
+def test_a_malformed_status_is_not_a_result(raw: str) -> None:
+    """A partially-written or foreign file must never read as an exit code."""
+    assert parse_guest_status(raw) is None
+    with pytest.raises(MicroVMUnavailableError):
+        resolve_guest_exit_code(launcher_exit_code=0, status_raw=raw)
+
+
+@pytest.mark.parametrize("code", [0, 1, 2, 42, 125, 126, 127, 128, 255])
+def test_every_valid_exit_code_round_trips(code: int) -> None:
+    assert parse_guest_status(f"{STATUS_PREFIX}{code}\n") == code
+
+
+def test_status_parsing_tolerates_surrounding_noise() -> None:
+    """Console spill into the status file must not corrupt the reading."""
+    raw = f"[  0.42] random kernel line\n  {STATUS_PREFIX}17  \ntrailing\n"
+    assert parse_guest_status(raw) == 17
+
+
+def test_an_unknown_nonzero_exit_without_a_status_is_a_vm_failure() -> None:
+    """An unexplained exit is reported as unknown, never guessed as a result."""
+    with pytest.raises(MicroVMUnavailableError) as excinfo:
+        resolve_guest_exit_code(launcher_exit_code=3, status_raw=None)
+    assert "unknown" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# The guest-side program
+# ---------------------------------------------------------------------------
+
+
+def test_the_bootstrap_argument_stays_small_and_constant() -> None:
+    """It travels on the kernel command line, which overflows fatally.
+
+    Everything variable (the command, the environment, the working directory)
+    goes into the control share instead, so this string never grows with them.
+    """
+    bootstrap = build_bootstrap_argument()
+    assert len(bootstrap) < 256
+    assert _libkrun.CONTROL_TAG in bootstrap
+    assert _libkrun.GUEST_CONTROL_DIR in bootstrap
+    assert bootstrap == build_bootstrap_argument()
+
+
+def test_guest_script_mounts_the_workspace_and_reports_status_last() -> None:
+    """Ordering is the contract: a status file means the command completed."""
+    script = build_guest_script(cmd=["echo", "hi"], workspace_mount="/workspace", cwd="/workspace")
+    mount_at = script.index(f"mount -t virtiofs {_libkrun.WORKSPACE_TAG}")
+    status_at = script.index(STATUS_PREFIX)
+    command_at = script.index("echo hi")
+    assert mount_at < command_at < status_at
+    assert "exit 125" in script  # a failed mount is a VM failure, not a result
+
+
+def test_guest_script_quotes_hostile_arguments() -> None:
+    """Command parts are data. They must not become guest shell syntax."""
+    script = build_guest_script(
+        cmd=["echo", "; rm -rf /", "$(id)"],
+        workspace_mount="/workspace",
+        cwd="/workspace",
+    )
+    assert "'; rm -rf /'" in script
+    assert "'$(id)'" in script
+
+
+def test_guest_env_script_quotes_values_and_drops_invalid_names() -> None:
+    """Values are data. Sourcing the file must not execute any of them."""
+    hostile = "a b'c; echo pwned"
+    rendered = build_guest_env_script({"OK": hostile, "bad-name": "x", "": "y"})
+    assert "bad-name" not in rendered
+    proc = subprocess.run(
+        ["/bin/sh", "-c", f'{rendered}\nprintf %s "$OK"'],
+        capture_output=True,
+        check=True,
+    )
+    assert proc.stdout == hostile.encode()
+
+
+def test_guest_env_script_is_deterministic() -> None:
+    forward = {"B": "2", "A": "1", "C": "3"}
+    backward = {"C": "3", "A": "1", "B": "2"}
+    assert build_guest_env_script(forward) == build_guest_env_script(backward)
+
+
+def _run_wrapper(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    cmd: Sequence[str],
+    stdin: bytes = b"",
+    env: dict[str, str] | None = None,
+    mount_fails: bool = False,
+) -> tuple[int, bytes, bytes, str | None]:
+    """Execute the generated wrapper under the host shell.
+
+    ``mount`` and the two guest mount points are the only guest-specific
+    pieces, so stubbing ``mount`` on ``PATH`` and pointing the directories at
+    real temporary ones exercises the wrapper's actual stdio/status logic
+    without a hypervisor.
+    """
+    workspace = tmp_path / "ws"
+    control = tmp_path / "ctl"
+    bindir = tmp_path / "bin"
+    for directory in (workspace, control, bindir):
+        directory.mkdir(exist_ok=True)
+    mount = bindir / "mount"
+    mount.write_text("#!/bin/sh\nexit 1\n" if mount_fails else "#!/bin/sh\nexit 0\n")
+    mount.chmod(0o755)
+
+    monkeypatch.setattr(_libkrun, "GUEST_CONTROL_DIR", str(control))
+    (control / "stdin").write_bytes(stdin)
+    (control / "stdout").write_bytes(b"")
+    (control / "stderr").write_bytes(b"")
+    (control / "env.sh").write_text(build_guest_env_script(env or {}))
+    script = build_guest_script(cmd=cmd, workspace_mount=str(workspace), cwd=str(workspace))
+    proc = subprocess.run(
+        ["/bin/sh", "-c", script],
+        capture_output=True,
+        env={"PATH": f"{bindir}:{os.environ.get('PATH', '/usr/bin:/bin')}"},
+        check=False,
+    )
+    status_file = control / "status"
+    return (
+        proc.returncode,
+        (control / "stdout").read_bytes(),
+        (control / "stderr").read_bytes(),
+        status_file.read_text() if status_file.exists() else None,
+    )
+
+
+@pytest.mark.parametrize("code", [0, 1, 42, 125, 126, 127])
+def test_wrapper_records_the_commands_own_exit_code(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, code: int) -> None:
+    """Including the reserved values - that is what makes them distinguishable."""
+    rc, _, _, status = _run_wrapper(tmp_path, monkeypatch, cmd=["/bin/sh", "-c", f"exit {code}"])
+    assert rc == 0
+    assert resolve_guest_exit_code(launcher_exit_code=rc, status_raw=status) == code
+
+
+def test_wrapper_separates_stdout_and_stderr(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _, out, err, status = _run_wrapper(tmp_path, monkeypatch, cmd=["/bin/sh", "-c", "echo O; echo E >&2"])
+    assert out == b"O\n"
+    assert err == b"E\n"
+    assert parse_guest_status(status) == 0
+
+
+def test_wrapper_delivers_stdin(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _, out, _, _ = _run_wrapper(tmp_path, monkeypatch, cmd=["/bin/sh", "-c", "cat"], stdin=b"fed\n")
+    assert out == b"fed\n"
+
+
+def test_wrapper_applies_the_session_environment(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _, out, _, _ = _run_wrapper(
+        tmp_path,
+        monkeypatch,
+        cmd=["/bin/sh", "-c", "echo $BERNSTEIN_SESSION"],
+        env={"BERNSTEIN_SESSION": "abc123"},
+    )
+    assert out == b"abc123\n"
+
+
+def test_wrapper_does_not_interpret_arguments_as_shell_syntax(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _, out, _, _ = _run_wrapper(tmp_path, monkeypatch, cmd=["echo", "a; echo b"])
+    assert out == b"a; echo b\n"
+
+
+def test_wrapper_reports_a_failed_mount_as_a_vm_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """No status file, reserved exit code: unambiguously a VM-level failure."""
+    rc, _, _, status = _run_wrapper(tmp_path, monkeypatch, cmd=["/bin/sh", "-c", "exit 0"], mount_fails=True)
+    assert rc == 125
+    assert status is None
+    with pytest.raises(MicroVMUnavailableError):
+        resolve_guest_exit_code(launcher_exit_code=rc, status_raw=status)
+
+
+# ---------------------------------------------------------------------------
+# The filesystem surface (plain host I/O over the shared workspace)
+# ---------------------------------------------------------------------------
+
+
+async def _populate(monitor: FakeMonitor | LibkrunMonitor) -> None:
+    """The same workspace tree, written through the protocol surface."""
+    await monitor.write_file("top.txt", b"alpha")
+    await monitor.write_file("sub/nested.txt", b"beta")
+    await monitor.write_file("sub/deeper/leaf.bin", b"\x00\x01\x02")
+    await monitor.write_file("private.key", b"secret", mode=0o600)
+
+
+@pytest.mark.asyncio
+async def test_freeze_image_is_byte_identical_to_fakemonitor(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The issue's acceptance criterion, and the reason to reuse the helper.
+
+    ``freeze_image`` calls ``canonical_workspace_image`` unchanged, so the
+    snapshot's content address cannot drift between monitors: the same tree
+    yields the same bytes whichever one produced it.
+    """
+    monitor = _monitor(tmp_path)
+    await _boot_stubbed(monitor, monkeypatch)
+    fake = FakeMonitor()
+    await fake.boot(base_env={})
+    try:
+        await _populate(monitor)
+        await _populate(fake)
+        assert await monitor.freeze_image() == await fake.freeze_image()
+    finally:
+        await monitor.shutdown()
+        await fake.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_freeze_and_restore_round_trip_across_monitors(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An image frozen here restores identically into a FakeMonitor."""
+    monitor = _monitor(tmp_path)
+    await _boot_stubbed(monitor, monkeypatch)
+    fake = FakeMonitor()
+    await fake.boot(base_env={})
+    try:
+        await _populate(monitor)
+        image = await monitor.freeze_image()
+        await fake.restore_image(image)
+        assert await fake.freeze_image() == image
+        assert await fake.read_file("sub/nested.txt") == b"beta"
+    finally:
+        await monitor.shutdown()
+        await fake.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_restore_image_repopulates_the_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monitor = _monitor(tmp_path)
+    await _boot_stubbed(monitor, monkeypatch)
+    fake = FakeMonitor()
+    await fake.boot(base_env={})
+    try:
+        await _populate(fake)
+        await monitor.restore_image(await fake.freeze_image())
+        assert await monitor.read_file("top.txt") == b"alpha"
+        assert await monitor.ls("/workspace") == ["private.key", "sub", "top.txt"]
+    finally:
+        await monitor.shutdown()
+        await fake.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_file_roundtrip_through_the_shared_directory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monitor = _monitor(tmp_path)
+    await _boot_stubbed(monitor, monkeypatch)
+    try:
+        await monitor.write_file("a.txt", b"one")
+        await monitor.write_file("d/b.txt", b"two")
+        assert await monitor.read_file("a.txt") == b"one"
+        assert await monitor.read_file("/workspace/d/b.txt") == b"two"
+        assert await monitor.ls("/workspace") == ["a.txt", "d"]
+    finally:
+        await monitor.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_missing_file_raises_filenotfound(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monitor = _monitor(tmp_path)
+    await _boot_stubbed(monitor, monkeypatch)
+    try:
+        with pytest.raises(FileNotFoundError):
+            await monitor.read_file("absent")
+    finally:
+        await monitor.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_ls_on_a_file_raises_notadirectory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monitor = _monitor(tmp_path)
+    await _boot_stubbed(monitor, monkeypatch)
+    try:
+        await monitor.write_file("f", b"")
+        with pytest.raises(NotADirectoryError):
+            await monitor.ls("f")
+    finally:
+        await monitor.shutdown()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("escape", ["../outside", "/etc/passwd", "a/../../outside"])
+async def test_paths_cannot_escape_the_shared_workspace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, escape: str
+) -> None:
+    """The share is a passthrough; containment is enforced on the host side."""
+    monitor = _monitor(tmp_path)
+    await _boot_stubbed(monitor, monkeypatch)
+    try:
+        with pytest.raises(ValueError, match="escapes"):
+            await monitor.write_file(escape, b"x")
+    finally:
+        await monitor.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_removes_the_workspace_and_control_directories(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monitor = _monitor(tmp_path)
+    await _boot_stubbed(monitor, monkeypatch)
+    await monitor.write_file("f", b"x")
+    workspace = monitor._workspace
+    control = monitor._control_root
+    assert workspace is not None
+    assert control is not None
+    await monitor.shutdown()
+    assert not workspace.exists()
+    assert not control.exists()
+
+
+@pytest.mark.asyncio
+async def test_operations_refuse_after_shutdown(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monitor = _monitor(tmp_path)
+    await _boot_stubbed(monitor, monkeypatch)
+    await monitor.shutdown()
+    with pytest.raises(MicroVMUnavailableError):
+        await monitor.read_file("f")
+
+
+# ---------------------------------------------------------------------------
+# exec(), against a stub launcher standing in for the VM process
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_exec_returns_the_guests_streams_and_status(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monitor = _monitor(tmp_path, launcher_body=_GUEST_OK)
+    await _boot_stubbed(monitor, monkeypatch)
+    try:
+        result = await monitor.exec(["echo", "hi"])
+        assert result.exit_code == 0
+        assert result.stdout == b"out\n"
+        assert result.stderr == b"err\n"
+        assert result.duration_seconds >= 0
+    finally:
+        await monitor.shutdown()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("code", [1, 42, 125, 126, 127])
+async def test_exec_reports_a_guest_reserved_code_as_a_result(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, code: int
+) -> None:
+    """The launcher exits with the same reserved number; the status file wins."""
+    body = f"""
+open(os.path.join(control, "status"), "w").write("bernstein-guest-status:{code}\\n")
+sys.exit({code})
+"""
+    monitor = _monitor(tmp_path, launcher_body=body)
+    await _boot_stubbed(monitor, monkeypatch)
+    try:
+        assert (await monitor.exec(["true"])).exit_code == code
+    finally:
+        await monitor.shutdown()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("code", sorted(LIBKRUN_RESERVED_EXIT_CODES))
+async def test_exec_reports_a_libkrun_reserved_code_as_a_vm_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, code: int
+) -> None:
+    """Same number, no status file: the VM failed, and exec must say so."""
+    body = f'sys.stderr.write("krunlaunch: boom\\n"); sys.exit({code})\n'
+    monitor = _monitor(tmp_path, launcher_body=body)
+    await _boot_stubbed(monitor, monkeypatch)
+    try:
+        with pytest.raises(MicroVMUnavailableError) as excinfo:
+            await monitor.exec(["true"])
+        assert LIBKRUN_RESERVED_EXIT_CODES[code] in str(excinfo.value)
+        assert "krunlaunch: boom" in str(excinfo.value)
+    finally:
+        await monitor.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_exec_hands_the_guest_its_stdin_command_and_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The control share is the whole channel: nothing rides the command line."""
+    body = """
+payload = open(os.path.join(control, "stdin"), "rb").read()
+script = open(os.path.join(control, "run.sh")).read()
+envsh = open(os.path.join(control, "env.sh")).read()
+open(os.path.join(control, "stdout"), "wb").write(payload)
+open(os.path.join(control, "stderr"), "w").write(script + envsh)
+open(os.path.join(control, "status"), "w").write("bernstein-guest-status:0\\n")
+sys.exit(0)
+"""
+    monitor = _monitor(tmp_path, launcher_body=body)
+    await _boot_stubbed(monitor, monkeypatch)
+    try:
+        result = await monitor.exec(
+            ["printenv", "SESSION"],
+            cwd="sub",
+            env={"SESSION": "call-level"},
+            stdin=b"piped",
+        )
+        assert result.stdout == b"piped"
+        rendered = result.stderr.decode()
+        assert "printenv SESSION" in rendered
+        assert "export SESSION=call-level" in rendered
+        assert "cd /workspace/sub" in rendered
+    finally:
+        await monitor.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_exec_layers_call_env_over_base_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    body = """
+open(os.path.join(control, "stdout"), "wb").write(
+    open(os.path.join(control, "env.sh"), "rb").read()
+)
+open(os.path.join(control, "status"), "w").write("bernstein-guest-status:0\\n")
+sys.exit(0)
+"""
+    monitor = _monitor(tmp_path, launcher_body=body)
+    await _boot_stubbed(monitor, monkeypatch, {"SHARED": "base", "ONLY_BASE": "1"})
+    try:
+        rendered = (await monitor.exec(["true"], env={"SHARED": "call"})).stdout.decode()
+        assert "export SHARED=call" in rendered
+        assert "export ONLY_BASE=1" in rendered
+    finally:
+        await monitor.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_exec_never_leaves_control_files_in_the_workspace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Control state in the workspace would shift the snapshot's content address."""
+    monitor = _monitor(tmp_path, launcher_body=_GUEST_OK)
+    await _boot_stubbed(monitor, monkeypatch)
+    fake = FakeMonitor()
+    await fake.boot(base_env={})
+    try:
+        await monitor.exec(["true"])
+        await monitor.exec(["true"], stdin=b"x")
+        assert await monitor.ls("/workspace") == []
+        assert await monitor.freeze_image() == await fake.freeze_image()
+    finally:
+        await monitor.shutdown()
+        await fake.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_exec_does_not_reuse_a_previous_status(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Each exec gets a private control directory, so no stale result leaks."""
+    body = """
+marker = os.path.join(control, "status")
+if os.path.exists(marker):
+    sys.exit(70)
+open(marker, "w").write("bernstein-guest-status:5\\n")
+sys.exit(0)
+"""
+    monitor = _monitor(tmp_path, launcher_body=body)
+    await _boot_stubbed(monitor, monkeypatch)
+    try:
+        assert (await monitor.exec(["true"])).exit_code == 5
+        assert (await monitor.exec(["true"])).exit_code == 5
+    finally:
+        await monitor.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_exec_times_out_and_kills_the_vm(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monitor = _monitor(tmp_path, launcher_body="import time\ntime.sleep(30)\n")
+    await _boot_stubbed(monitor, monkeypatch)
+    try:
+        with pytest.raises(TimeoutError):
+            await monitor.exec(["sleep", "30"], timeout=1)
+    finally:
+        await monitor.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_exec_removes_its_control_directory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A per-exec directory that outlived the call would leak stdio to disk."""
+    monitor = _monitor(tmp_path, launcher_body=_GUEST_OK)
+    await _boot_stubbed(monitor, monkeypatch)
+    try:
+        await monitor.exec(["true"])
+        control_root = monitor._control_root
+        assert control_root is not None
+        assert list(control_root.iterdir()) == []
+    finally:
+        await monitor.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# The packaged launcher and its build step
+# ---------------------------------------------------------------------------
+
+
+def test_build_launcher_refuses_without_libkrun(tmp_path: Path) -> None:
+    """It never silently produces a launcher that cannot run a VM."""
+    with pytest.raises(MicroVMUnavailableError, match="libkrun shared library"):
+        _libkrun.build_launcher(dest=tmp_path / "krunlaunch", library=str(tmp_path / "absent.dylib"))
+
+
+def test_the_launcher_source_ships_with_the_package() -> None:
+    """The build step compiles packaged source, not a checkout-only file."""
+    source_dir = _libkrun.launcher_source_dir()
+    assert (source_dir / "krunlaunch.c").is_file()
+    plist = (source_dir / "krunlaunch.entitlements.plist").read_text()
+    assert HYPERVISOR_ENTITLEMENT in plist
+    assert LIBRARY_VALIDATION_ENTITLEMENT in plist
+
+
+def test_the_launcher_shares_the_workspace_with_host_stored_permissions() -> None:
+    """Guest and host must agree on a file's mode, or freezing loses it.
+
+    Under libkrun's default virtio-fs semantics a file the guest creates 0644
+    lands on the host 0600 (the real mode lives in an extended attribute), so a
+    snapshot taken from the host would silently drop the executable bit off
+    anything the guest built.
+    """
+    source = (_libkrun.launcher_source_dir() / "krunlaunch.c").read_text()
+    assert "KRUN_SEMANTICS_LINUX_SIMPLIFIED 1" in source
+    assert "krun_add_virtiofs4" in source
+
+
+def test_the_launcher_source_passes_an_explicit_guest_environment() -> None:
+    """Passing NULL makes libkrun fold the host environment into the kernel
+    command line, overrun its size limit, and abort the VMM."""
+    source = (_libkrun.launcher_source_dir() / "krunlaunch.c").read_text()
+    assert "krun_set_exec((uint32_t)ctx, exec_path, gargv, genvp)" in source
+    assert "PATH=/bin:/sbin:/usr/bin:/usr/sbin" in source

--- a/tests/unit/sandbox/test_libkrun_monitor.py
+++ b/tests/unit/sandbox/test_libkrun_monitor.py
@@ -26,6 +26,7 @@ The real boot/exec round trip lives in the opt-in host-gated integration test
 
 from __future__ import annotations
 
+import asyncio
 import os
 import stat
 import subprocess
@@ -879,6 +880,29 @@ async def test_exec_removes_its_control_directory(tmp_path: Path, monkeypatch: p
     await _boot_stubbed(monitor, monkeypatch)
     try:
         await monitor.exec(["true"])
+        control_root = monitor._control_root
+        assert control_root is not None
+        assert list(control_root.iterdir()) == []
+    finally:
+        await monitor.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_cancelling_an_exec_kills_the_vm_and_cleans_up(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A cancelled fork-race branch must not strand a VM on the workspace.
+
+    The guest holds the session's virtio-fs shares open, so a VM that outlives
+    its cancelled call keeps writing into a workspace the caller is about to
+    delete.
+    """
+    monitor = _monitor(tmp_path, launcher_body="import time\ntime.sleep(30)\n")
+    await _boot_stubbed(monitor, monkeypatch)
+    try:
+        task = asyncio.create_task(monitor.exec(["sleep", "30"]))
+        await asyncio.sleep(0.2)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
         control_root = monitor._control_root
         assert control_root is not None
         assert list(control_root.iterdir()) == []

--- a/tests/unit/sandbox/test_libkrun_monitor.py
+++ b/tests/unit/sandbox/test_libkrun_monitor.py
@@ -132,7 +132,7 @@ def _stub_host(monkeypatch: pytest.MonkeyPatch) -> None:
     """Stub only the checks that genuinely need a hypervisor or a signature."""
     monkeypatch.setattr(LibkrunMonitor, "_preflight_platform", lambda self: [])
     monkeypatch.setattr(LibkrunMonitor, "_preflight_signature", lambda self, launcher: [])
-    monkeypatch.setattr(_libkrun, "find_libkrunfw", lambda: "/stub/libkrunfw")
+    monkeypatch.setattr(_libkrun, "find_libkrunfw", lambda library=None: "/stub/libkrunfw")
 
 
 async def _boot_stubbed(


### PR DESCRIPTION
Closes #2971

## What

`LibkrunMonitor` — a second implementation of the existing `VMMonitor` protocol
that actually boots a guest. Nothing above the hypervisor seam changes:
snapshots, the fork-race, the selection receipts and the no-silent-downgrade
invariant are untouched, and the acceptance suite over them passes unmodified.

libkrun is the L1 hypervisor itself (KVM on Linux, Hypervisor.framework on
macOS/arm64), so it needs no nested virtualisation and boots on ordinary
developer hardware — including Apple Silicon, where nested virt rules the
Firecracker path out entirely. `FirecrackerMonitor` is unchanged and stays the
default; it still refuses loudly and documents why.

## How it works

| Piece | Choice |
|---|---|
| Workspace transport | virtio-fs share. `read_file` / `write_file` / `ls` / `freeze_image` / `restore_image` are plain host filesystem operations — **no guest agent** |
| Snapshot | `canonical_workspace_image` reused unchanged, so digests stay byte-identical to `FakeMonitor`'s for the same tree |
| Process model | one process per VM: `krun_start_enter()` never returns, and on macOS the running image must carry `com.apple.security.hypervisor` |
| Exec | spawns `krunlaunch`, a small C launcher shipped as source and built + signed on the host by `bernstein sandbox microvm-launcher` |
| Guest status | a status file in a control share outside the workspace, so a snapshot's content address never shifts |

### Exit-code disambiguation

libkrun reserves 125/126/127 for its own failures and a guest command can
legitimately return the same values, so the process exit code alone is
ambiguous. The guest wrapper writes its status line only *after* the command
completes, and that file — not the exit code — decides:

| Status file | Process exit | Reported as |
|---|---|---|
| present, well-formed | anything | the guest command's exit code, including 125/126/127 |
| absent or malformed | 125/126/127 | `MicroVMUnavailableError`, naming the libkrun-level reason |
| absent or malformed | anything else | `MicroVMUnavailableError` — unknown, never guessed |

### Permission semantics

Shares use `KRUN_SEMANTICS_LINUX_SIMPLIFIED` so permission bits live in the host
inode. Under the default semantics a file the guest creates `0644` lands on the
host `0600`, and freezing it would silently drop the executable bit off anything
the guest built.

### No silent downgrade

`preflight()` is side-effect-free and names *every* missing precondition in one
pass — libkrun, libkrunfw, the launcher binary, its entitlements, and the guest
rootfs. It never builds the launcher as a side effect of a support probe.
`boot()` refuses when anything is missing. Selection stays opt-in at both
levels: the heuristic never picks the `microvm` backend, and the backend keeps
its Firecracker adapter unless `BERNSTEIN_MICROVM_MONITOR=libkrun`.

## Verification

Run on an Apple M1 Pro / macOS 26.5 with libkrun 1.19.4 + libkrunfw 5.5.0
(guest kernel `Linux 6.12.91 aarch64`).

Host-gated integration tests, booting **real** microVMs:

```
$ BERNSTEIN_MICROVM_LIBKRUN_INTEGRATION=1 \
  BERNSTEIN_MICROVM_LIBKRUN_ROOTFS=<alpine-minirootfs> \
  uv run pytest tests/integration/sandbox/test_microvm_libkrun.py -v

test_preflight_reports_missing_preconditions                        PASSED
test_boot_refuses_on_unsupported_host                               SKIPPED
test_real_guest_roundtrip                                           PASSED
test_real_guest_runs_a_separate_kernel                              PASSED
test_real_guest_exit_codes_are_not_confused_with_libkrun_failures   PASSED
test_real_guest_receives_stdin_and_the_session_environment          PASSED
test_real_freeze_matches_fakemonitor_byte_for_byte                  PASSED
test_real_restore_repopulates_a_guest_workspace                     PASSED
test_real_backend_roundtrip_through_the_seam                        PASSED

8 passed, 1 skipped in 3.68s
```

(the skip is the unsupported-host refusal, which is not exercisable on a host
that *is* supported; it runs everywhere else.)

Host-portable suites, no hypervisor required:

| Suite | Result |
|---|---|
| `tests/unit/sandbox/test_libkrun_monitor.py` | 93 passed |
| `test_microvm_backend.py`, `test_vmmonitor_canonical.py`, `test_selection_receipt.py` | 68 passed |
| `test_fork_race.py`, `test_backend_protocol.py`, `test_sandbox_cli.py`, `test_registry.py`, `test_selector.py` | 81 passed |
| `tests/integration/sandbox/test_microvm_firecracker.py` | 2 passed, 1 skipped |

`uv run ruff check .` and `uv run ruff format --check .` clean. `uv run mypy`
reports no errors in any changed file. `scripts/check_docs_drift.py` reports no
drift. The built wheel carries the launcher source.

## Docs

- `docs/operations/microvm-libkrun.md` — host setup for Linux and macOS/arm64,
  the launcher build+sign step, troubleshooting, and an honest statement of what
  the boundary does and does not cover (guest and VMM share a security context;
  virtio-fs is a passthrough, not a sandbox).
- `docs/architecture/sandbox.md` — the monitor table, the design rationale and
  the exit-code contract.

## Not in scope

No memory-snapshot capability. libkrun has no checkpoint/restore API, and the
snapshot contract here is filesystem-level by design — restoring one VM memory
image into several VMs would replicate PRNG state and cached secrets across the
branches of a race.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added libkrun-based microVM sandbox support for supported Linux and macOS hosts.
  * Added the `sandbox microvm-launcher` command to build and validate the launcher.
  * Added configurable VM resources, guest root filesystems, file sharing, snapshots, command execution, and exit-code reporting.
* **Documentation**
  * Added setup, configuration, troubleshooting, host requirements, and isolation-boundary guidance.
  * Added the libkrun guide to the sandbox documentation navigation.
* **Tests**
  * Added unit and opt-in integration coverage for microVM execution, snapshots, isolation, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->