### PR TITLE
docs: promote 132 feature-matrix rows to full pages and wire up nav orphans

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,10 +302,15 @@ The orchestrator is a Python scheduler, not an LLM. Scheduling decisions are det
 `bernstein cloud` runs agents on Cloudflare Workers with R2-backed workspace sync. See [docs/cloudflare/](docs/cloudflare/).
 
 ```bash
-bernstein cloud login      # authenticate with Bernstein Cloud
-bernstein cloud deploy     # push agent workers
-bernstein cloud run plan.yaml  # execute a plan on Cloudflare
+bernstein cloud login                       # authenticate with Bernstein Cloud
+bernstein cloud init                        # scaffold a deployable worker
+bernstein cloud deploy                      # print the wrangler deploy command
+bernstein cloud run "add retry to the API"  # submit a free-text goal
 ```
+
+`cloud run` takes a free-text goal, not a plan file. `cloud deploy`
+prints the `npx wrangler deploy` invocation for the scaffolded worker;
+it does not push anything itself.
 
 ## capabilities
 

--- a/docs/adapters/ADAPTER_GUIDE.md
+++ b/docs/adapters/ADAPTER_GUIDE.md
@@ -51,7 +51,6 @@ This means you can run Bernstein with **zero Claude Code dependency** - use `qwe
 | `opencode` | Multi | Any configured provider | Inherited from model | $–$$$ | Full | JSON (`--format json`) | No | Multi-provider setups; single CLI interface |
 | `kiro` | AWS | AWS-managed models | ★★★ | $$ | Full | No | AWS-centric teams using AWS AI services |
 | `kilo` | Stackblitz | Any (via provider routing) | Inherited from model | $–$$$ | Full | No | Web development; Stackblitz-integrated teams |
-| `cloudflare` | Cloudflare | Workers AI models | ★★★ | Free–$$ | Full | No | Cloudflare Workers / Agents SDK users |
 | `iac` | N/A | N/A (Terraform/Pulumi) | N/A | N/A | IaC plan+apply | No | Infrastructure tasks - pair with LLM adapter for codegen |
 | `generic` | Any | Pass-through | Depends on CLI | Varies | Depends on CLI | No | Unlisted CLIs; prototyping new adapters |
 | `mock` | None | None (simulated) | N/A | Free | Simulated | Simulated | Unit and integration tests only |

--- a/docs/adapters/capability_contract.md
+++ b/docs/adapters/capability_contract.md
@@ -104,7 +104,6 @@ adapters at a glance.
 | `claude` | flag | cli-flag | stream-json |
 | `cline` | unsupported | cli-flag | text-signals |
 | `clm` | unsupported | unsupported | text-signals |
-| `cloudflare` | unsupported | unsupported | hooks |
 | `codebuff` | unsupported | unsupported | text-signals |
 | `codex` | unsupported | cli-flag | text-signals |
 | `cody` | unsupported | unsupported | text-signals |

--- a/docs/adapters/compatibility.md
+++ b/docs/adapters/compatibility.md
@@ -38,7 +38,6 @@ Last updated: 2026-07-16
 | `pydantic_ai` | Multi (`<provider>:<model>`) | No | No |
 | `kiro` | AWS | No | No |
 | `kilo` | Stackblitz | No | Yes (ACP/MCP) |
-| `cloudflare` | Cloudflare | No | No |
 | `iac` | N/A (Terraform/Pulumi) | No | No |
 | `generic` | Any | Depends on CLI | No |
 

--- a/docs/adapters/compatibility.md
+++ b/docs/adapters/compatibility.md
@@ -88,18 +88,21 @@ Compatibility details can vary by adapter version and local toolchain.
 
 Bernstein ships an expanded quality gate pipeline in `src/bernstein/core/quality/`:
 
-- Standard gates: lint, type-check, tests, coverage
-- Architecture conformance (`arch_conformance.py`, `arch_rules.py`)
-- Benchmark gate (`benchmark_gate.py`, `perf_benchmark_gate.py`)
-- Mutation testing (`mutation_testing.py`, `test_mutation_verify.py`)
+- Standard gates: lint, type-check, tests, coverage (`quality_gates.py`, `coverage_gate.py`)
+- Architecture conformance (`arch_conformance.py`)
+- Benchmark gate (`benchmark_gate.py`)
 - Dead code detection (`dead_code_detector.py`)
 - Dependency scanning (`dependency_scan.py`, `dep_validator.py`)
 - Flaky test detection (`flaky_detector.py`)
 - Integration test generation (`integration_test_gen.py`)
 - Cross-model verification (`cross_model_verifier.py`)
-- Consensus verification (`consensus_verifier.py`)
-- LLM judge (`llm_judge.py`)
-- Gate caching (`gate_cache.py`) and plugin system (`gate_plugins.py`)
+- Review consensus scoring (`review_consensus.py`)
+- Pipeline structure, cached incremental runner, and plugin system
+  (`gate_pipeline.py`, `gate_runner.py`, `gate_plugins.py`)
+- Serialized gate execution (`quality_gate_coalescer.py`)
+
+The LLM judge used for eval scoring lives outside this package, in
+`src/bernstein/eval/judge.py`.
 
 ---
 
@@ -118,10 +121,10 @@ Bernstein ships an expanded quality gate pipeline in `src/bernstein/core/quality
 Use environment-specific validation instead of relying on static matrices:
 
 1. Run `bernstein doctor`.
-2. Run your target CLI adapter smoke checks (`bernstein test-adapter <name>`).
+2. Run your target CLI adapter smoke checks (`bernstein test-adapter --adapter <name> --task "<prompt>"`).
 3. Validate required API endpoints (`/status`, `/tasks`, `/metrics`, protocol-specific routes).
 4. If using remote workers, validate cluster endpoints and auth paths.
-5. Generate a debug bundle (`bernstein debug`) for comprehensive triage information.
+5. Generate a debug bundle (`bernstein debug bundle`) for comprehensive triage information.
 
 ---
 

--- a/docs/adapters/deepseek.md
+++ b/docs/adapters/deepseek.md
@@ -104,14 +104,24 @@ For the full Article-12 evidence story, combine it with
 
 ```python
 from bernstein.core.security.data_residency import (
-    DataResidencyController, EU_WEST, EU_CENTRAL,
+    DataResidencyController,
+    Region,
+    ResidencyPolicy,
 )
 
-residency = DataResidencyController(
-    allowed_regions={EU_WEST, EU_CENTRAL},
-    enforce_strict=True,
+residency = DataResidencyController(node_region=Region.EU_WEST)
+residency.set_policy(
+    ResidencyPolicy(
+        tenant_id="acme",
+        allowed_regions=frozenset({Region.EU_WEST, Region.EU_CENTRAL}),
+        primary_region=Region.EU_WEST,
+        enforce_strict=True,
+    )
 )
 ```
+
+Regions are members of the `Region` enum, and the allowed set is
+per-tenant policy state rather than a controller constructor argument.
 
 The two layers are orthogonal: the adapter guard pins the *endpoint*,
 the controller pins the *region the workload may reach*.

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -62,12 +62,6 @@ For air-gap or BYO-model scenarios.
 
 - `iac` - infrastructure-as-code (Terraform / Pulumi) with plan-before-apply.
 - `clm` - sovereign LLM gateway over mTLS for regulated deployments.
-- `cloudflare` - Cloudflare Agents SDK via wrangler. Experimental and
-  currently non-functional: `spawn()` refuses immediately, because the
-  adapter can only start a local `npx wrangler dev` server that never
-  triggers the worker or returns a result. To run agents on Cloudflare
-  today, deploy a worker implementing the `/agents/*` HTTP contract and
-  drive it with `bernstein.bridges.cloudflare.CloudflareBridge`.
 - `openai_agents` - in-process OpenAI Agents SDK v2 (requires the
   `[openai]` extra).
 - `computer_use` - fronts a third-party autonomous browser / computer-use

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -62,7 +62,12 @@ For air-gap or BYO-model scenarios.
 
 - `iac` - infrastructure-as-code (Terraform / Pulumi) with plan-before-apply.
 - `clm` - sovereign LLM gateway over mTLS for regulated deployments.
-- `cloudflare` - Cloudflare Agents SDK via wrangler.
+- `cloudflare` - Cloudflare Agents SDK via wrangler. Experimental and
+  currently non-functional: `spawn()` refuses immediately, because the
+  adapter can only start a local `npx wrangler dev` server that never
+  triggers the worker or returns a result. To run agents on Cloudflare
+  today, deploy a worker implementing the `/agents/*` HTTP contract and
+  drive it with `bernstein.bridges.cloudflare.CloudflareBridge`.
 - `openai_agents` - in-process OpenAI Agents SDK v2 (requires the
   `[openai]` extra).
 - `computer_use` - fronts a third-party autonomous browser / computer-use

--- a/docs/adapters/stream_signals.md
+++ b/docs/adapters/stream_signals.md
@@ -144,7 +144,7 @@ Adapters that produce planning artefacts emit two signals:
 * `BERNSTEIN:PLAN_READY {"path": ".sdd/plans/<slug>.md"}` once the
   markdown has been written to disk.
 
-Downstream phases (`bernstein plan execute`, subagent dispatch, etc.)
+Downstream phases (`bernstein run <plan.yaml>`, subagent dispatch, etc.)
 watch for `PLAN_READY` and pick up the file from `.sdd/`.
 
 ## Out of scope

--- a/docs/adapters/test-adapter.md
+++ b/docs/adapters/test-adapter.md
@@ -1,0 +1,72 @@
+# Adapter smoke test (`bernstein test-adapter`)
+
+`bernstein test-adapter` spawns a single headless run of one CLI adapter
+against a one-off task, waits for it to exit, and prints the outcome. It is
+the manual, on-demand check an operator runs after installing or upgrading
+an adapter binary — a quick "does this adapter even work" probe, distinct
+from the automated nightly [adapter conformance canary](conformance-canary.md)
+that CI runs against every primary adapter.
+
+## How to use it
+
+```
+bernstein test-adapter --adapter <name> --task "<prompt>" [--model MODEL] [--timeout SECONDS]
+```
+
+```
+bernstein test-adapter --adapter gemini --task "Create a file named ok.txt containing OK"
+bernstein test-adapter --adapter codex --task "List the files in this directory" --timeout 60
+```
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--adapter` | required | Adapter registry name (e.g. `gemini`, `codex`, `claude`). |
+| `--task` | required | Prompt/task text for the adapter to execute. |
+| `--model` | adapter-specific default | Model to use for the smoke run. Falls back to a built-in per-adapter default (e.g. `sonnet` for `claude`/`aider`/`amp`/`cursor`, `gpt-5.4-mini` for `codex`/`opencode`, `gemini-3-flash` for `gemini`) when omitted. |
+| `--timeout` | `120` | Seconds to wait for the process to exit before killing it. |
+
+## What it does
+
+1. Resolves the adapter from the registry (`bernstein.adapters.registry.get_adapter`).
+2. Creates a throwaway worktree at `.sdd/worktrees/test-<adapter>-<unix-ts>/`.
+3. Spawns the adapter directly (`adapter.spawn(...)`, no task server or
+   orchestrator involved) with the given prompt and model.
+4. Waits up to `--timeout` seconds for the process to exit; on timeout it
+   kills the process and reports `timed out`.
+5. Prints the exit code and the last 40 lines of the adapter's log file.
+6. Runs a heuristic check: if the prompt mentions a file or path, checks
+   whether that path now exists in the worktree and prints a
+   `✓`/`✗` line.
+7. Always tears down the throwaway worktree afterward, even on error.
+
+This runs entirely locally against the installed CLI binary — it does not
+require `bernstein serve` or a running task server, and it does not touch
+the project's real working tree (the run happens in its own worktree under
+`.sdd/worktrees/`, deleted on exit).
+
+## When to use it
+
+- After installing or upgrading an adapter's upstream CLI binary, to catch
+  a broken PATH entry, missing auth, or an incompatible CLI flag before
+  relying on it in a real run.
+- To validate MCP/protocol support for an adapter before a production run
+  (see `reference/KNOWN_LIMITATIONS.md`).
+- As a faster, local alternative to waiting for the nightly conformance
+  canary when debugging one adapter interactively.
+
+## Limitations
+
+- Single adapter, single task, single process — it is not a suite. For
+  breadth across many adapters on a schedule, see the
+  [conformance canary](conformance-canary.md) or `bernstein adapters check`.
+- The "expected file exists" check is a regex heuristic over the prompt
+  text; it does not validate the file's contents.
+- A `running` result (adapter did not return a waitable process handle) is
+  possible for adapters whose `spawn()` does not expose a standard process
+  handle; this is reported as a warning rather than a hard failure.
+
+## Source
+
+- `src/bernstein/cli/commands/adapter_cmd.py` — `test_adapter` command.
+- `src/bernstein/adapters/registry.py` — `get_adapter`.
+- `src/bernstein/adapters/base.py` — `CLIAdapter.cancel_timeout`.

--- a/docs/architecture/batch-routing.md
+++ b/docs/architecture/batch-routing.md
@@ -1,0 +1,78 @@
+# Batch routing
+
+Non-urgent tasks (docs, formatting, simple tests) can run through a
+provider's batch API instead of the interactive one, at roughly half the
+per-token cost. Batch routing is two steps: a task-shape **classifier**
+decides whether a task is a batch *candidate*, then an adapter-capability
+**gate** decides whether it can actually be dispatched to a batch endpoint —
+a batch-eligible task on an adapter with no batch surface is refused back to
+the interactive path rather than silently faked onto one.
+
+There is no dedicated CLI for this; it runs automatically at task
+decomposition and dispatch time. `bernstein explain <task>` surfaces whether
+a task was marked batch-eligible.
+
+## Step 1 — eligibility classification
+
+`classify_batch_mode(task)` runs at decomposition time and returns a
+`BatchClassification` (`mode`, `reason`, `discount_factor`). A task is
+**never** batch-eligible when any of these hold:
+
+- `task.role` is `manager`, `architect`, `security`, or `orchestrator`.
+- `task.priority == 1` (critical).
+- `task.scope == LARGE`.
+- `task.complexity == HIGH`.
+- `task.task_type` is `RESEARCH` or `UPGRADE_PROPOSAL`.
+- The manager explicitly requested `opus` via `task.model`.
+- `task.batch_eligible` was explicitly set to `False`.
+
+Past those hard gates, a task is batch-eligible when `task.batch_eligible`
+was explicitly set to `True`, or `task.complexity == LOW`, or its
+title/description matches a batch-keyword pattern (`doc`, `docstring`,
+`readme`, `changelog`, `format`, `lint`, `comment`, `type hint`,
+`simple test`, `unit test`, `release note`, `bump version`, and similar).
+The discount factor is a flat `0.5` (`BATCH_DISCOUNT_FACTOR`) whenever
+eligible, `1.0` otherwise; `apply_batch_discount(cost_usd, classification)`
+applies it to a cost estimate.
+
+## Step 2 — capability-gated dispatch
+
+Eligibility alone does not guarantee a batch dispatch. `route_batch(task_id,
+adapter, batch_eligible)` (`core/cost/scheduling/batch.py`) checks the
+adapter's declared batch-dispatch capability
+(`adapters/_contract.py::batch_dispatch_capability`) before committing to a
+route:
+
+| `batch_eligible` | Adapter capability | Route | Notes |
+|---|---|---|---|
+| `False` | any | `interactive` | Not a batch candidate; no refusal reason recorded. |
+| `True` | `NATIVE` | `batch` | Dispatched to the provider's batch endpoint. |
+| `True` | `NONE` | `interactive` | Refused with `adapter_no_batch_surface`; runs interactively instead of faking a batch path that doesn't exist. |
+
+Only `claude`, `claude_routine`, and `openai_agents` declare `NATIVE` batch
+capability today (`_BATCH_CAPABLE_ADAPTERS`); every other adapter — including
+unknown or third-party adapters — reports `NONE` by default, so batch-eligible
+work is never routed somewhere that cannot honour it.
+
+## How it composes
+
+`route_batch` is a pure function of `(task eligibility, adapter capability)`
+with no side effects, so it slots into the deterministic dispatch policy
+without special-casing. The live dispatch path
+(`core/cost/scheduling/live_dispatch.py`) calls `classify_batch_mode`
+directly to decide whether a task counts as batch for scheduling purposes.
+
+## Limitations
+
+- Classification is a fixed set of heuristics (role/priority/scope/complexity
+  gates plus a keyword regex) — there is no learned or configurable scoring
+  model, and no per-project keyword override.
+- The capability list (`_BATCH_CAPABLE_ADAPTERS`) is a hardcoded allowlist in
+  source; adding batch support for a new adapter requires a code change, not
+  a config change.
+
+## Source
+
+- `src/bernstein/core/tasks/batch_router.py` — `classify_batch_mode`, `BatchClassification`, `apply_batch_discount`.
+- `src/bernstein/core/cost/scheduling/batch.py` — `route_batch`, `BatchRouteDecision`.
+- `src/bernstein/adapters/_contract.py` — `BatchDispatchCapability`, `batch_dispatch_capability`.

--- a/docs/architecture/context-degradation-detector.md
+++ b/docs/architecture/context-degradation-detector.md
@@ -1,0 +1,96 @@
+# Context degradation detector
+
+Track cross-model review verdicts per agent session; when a session
+accumulates consecutive rejections, checkpoint it, shut it down cleanly, and
+hand the replacement agent a summary of what was already tried instead of
+letting it grind on with a degraded context window.
+
+## Why
+
+A long-running agent session can drift: context fills with dead ends, retry
+attempts, and partial fixes, and code quality drops even though the agent
+keeps working. The context degradation detector uses [cross-model
+verification](quality-pipeline.md#cross-model-verifier)
+results as a proxy for quality - repeated `request_changes` verdicts from
+the reviewer model signal a session that should be restarted with a clean
+context rather than pushed further.
+
+## How it works
+
+`ContextDegradationDetector` (`src/bernstein/core/tokens/context_degradation_detector.py`)
+keeps a chronological history of cross-model verdicts per session:
+
+- `record_verdict(session_id, task_id, verdict)` appends a `CrossModelVerdict`
+  to the session's history. If the trailing run of `request_changes`
+  verdicts reaches `consecutive_reject_threshold`, the session is added to
+  the internal degraded set.
+- `should_restart(session_id, tokens_used)` returns `True` once a session is
+  flagged, or once `tokens_used` crosses `max_tokens_before_restart` (if
+  that ceiling is set above `0`).
+- `degraded_sessions()` returns the current set of flagged session IDs.
+- `build_recovery_context(session)` renders a markdown block summarising the
+  review history (which tasks were approved/rejected and by which reviewer)
+  plus a fixed list of guidance bullets (run tests and linter before
+  completing, address all reviewer issues, write a failing test first when
+  unsure, keep diffs focused) for the replacement agent's prompt.
+- `checkpoint(session)` builds a `ContextDegradationCheckpoint` (session id,
+  task ids, verdict count, consecutive-reject count, token usage, recovery
+  context) and persists it as JSON under `.sdd/runtime/context_checkpoints/<session_id>.json`.
+- `clear(session_id)` drops tracking state for a session once it has been
+  handled.
+
+`evict_degraded_sessions(orch)` (`src/bernstein/core/tasks/task_lifecycle.py`)
+runs each orchestrator tick, right after deadlock/loop detection. For every
+session the detector has flagged: it checkpoints the session, stashes the
+recovery-context markdown on `orch._context_recovery` keyed by every task ID
+the session owned, writes a `SHUTDOWN` signal via the signal manager so the
+agent exits at its next heartbeat, and clears the detector's tracking state.
+The recovery context is picked up when the replacement agent's prompt is
+built for those task IDs.
+
+`record_verdict()` itself is called from `_run_cross_model_check()`
+(`task_lifecycle.py`) immediately after every cross-model review completes,
+so the detector only ever sees data when cross-model verification is
+enabled and actually runs.
+
+## Configuration
+
+`ContextDegradationConfig` (frozen dataclass):
+
+| Field | Default | Meaning |
+|---|---|---|
+| `enabled` | `False` | Master on/off switch. Disabled by default. |
+| `consecutive_reject_threshold` | `2` | Consecutive `request_changes` verdicts that flag a session. |
+| `min_tasks_before_detection` | `1` | Minimum recorded verdicts before the threshold check runs, so one noisy review can't trigger a restart by itself. |
+| `max_tokens_before_restart` | `0` | Restart once cumulative session tokens reach this value, independent of verdict history. `0` disables the token ceiling. |
+| `checkpoint_dir` | `.sdd/runtime/context_checkpoints` | Where checkpoint JSON files are written, relative to the project workdir. |
+
+Set it by constructing `OrchestratorConfig(context_degradation=ContextDegradationConfig(...))`
+in Python. There is no `bernstein.yaml` key or CLI flag for this setting
+today - it is a programmatic `OrchestratorConfig` field, so enabling it
+requires embedding or scripting the orchestrator rather than a config file
+edit.
+
+## Limitation
+
+The detector is inert unless [cross-model verification](quality-pipeline.md#cross-model-verifier)
+is also enabled - `record_verdict()` is only ever called from the
+cross-model review path, so a run with cross-model verification off never
+feeds this detector any data, regardless of the `context_degradation.enabled`
+setting. The `max_tokens_before_restart` ceiling is the only trigger that
+does not depend on cross-model verdicts, but it still only takes effect for
+a session that already has at least one recorded verdict (`should_restart`
+checks `session_id in self._history`).
+
+## Source
+
+- `src/bernstein/core/tokens/context_degradation_detector.py` -
+  `ContextDegradationConfig`, `ContextDegradationDetector`,
+  `ContextDegradationCheckpoint`.
+- `src/bernstein/core/tasks/task_lifecycle.py` - `_run_cross_model_check()`
+  (feeds verdicts in) and `evict_degraded_sessions()` (tick-loop eviction).
+- `src/bernstein/core/orchestration/orchestrator.py` - constructs the
+  detector from `OrchestratorConfig.context_degradation` and calls
+  `evict_degraded_sessions()` every tick.
+- `src/bernstein/core/tasks/models.py` - `OrchestratorConfig.context_degradation`
+  field definition.

--- a/docs/architecture/deadlock-detection.md
+++ b/docs/architecture/deadlock-detection.md
@@ -1,0 +1,76 @@
+# Deadlock detection
+
+Detect cycles in the agent file-lock wait-for graph and break them by
+releasing the lock held longest, so two agents blocked on each other's
+files don't stall forever.
+
+## Why
+
+Bernstein agents claim exclusive file locks (`FileLockManager`) before
+writing to a path. If agent A holds `src/foo.py` and needs `src/bar.py`,
+while agent B holds `src/bar.py` and needs `src/foo.py`, neither can
+proceed - a classic two-agent deadlock. Deadlock detection builds a
+wait-for graph each tick, finds cycles, and releases the lock held by the
+oldest agent in the cycle so the other agent can make progress.
+
+## How it works
+
+`LoopDetector` (`src/bernstein/core/observability/loop_detector.py`) tracks
+two independent things in the same class: file-edit loops (a separate
+feature - an agent editing the same file too many times in a window - not
+covered on this page) and file-lock waits. For deadlocks specifically:
+
+- `record_lock_wait(waiting_agent_id, wanted_files, held_by, lock_timestamps=None)`
+  records that an agent is blocked on files held by other agents, and
+  remembers when each blocking lock was acquired.
+- `detect_deadlocks(lock_mgr)` builds a directed wait-for graph
+  (`waiting_agent → holder_agent`) from the recorded waits plus the live
+  state of `FileLockManager.all_locks()`, then runs an iterative DFS
+  (`_find_cycles`) to find every simple cycle.
+- For each cycle found, `_oldest_lock_holder()` picks the agent holding the
+  lock with the smallest `locked_at` timestamp as the **victim** - the
+  rationale being that releasing the longest-held lock unblocks the agent
+  that has been waiting relatively more of the deadlock's lifetime.
+- `clear_wait(agent_id)` removes an agent's wait-for entries; callers are
+  expected to call it when an agent acquires its locks, exits, or is
+  killed, so stale entries don't produce phantom deadlock reports.
+
+`check_loops_and_deadlocks(orch)` (`src/bernstein/core/agents/agent_recycling.py`,
+also duplicated in `agent_lifecycle.py`) runs both halves every orchestrator
+tick. For deadlocks it calls `detector.detect_deadlocks(lock_mgr)`, and for
+every `DeadlockDetection` returned, releases the victim's lock
+(`lock_mgr.release(victim_agent_id)`) and clears its wait-for state. This is
+wired into the main tick loop in `orchestrator.py` (step "2d. Detect loops
+and deadlocks", right before idle-agent recycling).
+
+## Limitation
+
+`detect_deadlocks()` only finds cycles among agents that were previously
+registered via `record_lock_wait()`. In the current codebase,
+`record_lock_wait()` has no production caller - the one place that has the
+exact information needed to call it (`Orchestrator._check_file_overlap`,
+which calls `FileLockManager.check_conflicts()` and defers a task batch
+when one of its files is already locked) logs the conflict
+(`logger.debug(...)`) and returns `True` to defer, but does not forward the
+wait to the `LoopDetector`. `record_lock_wait()` is only exercised from
+unit tests (`tests/unit/test_loop_detector.py`) and from the usage example
+in the module's own docstring.
+
+Practical effect: the deadlock cycle-detection pass runs every tick as
+designed, but with an always-empty wait-for graph it can never find a cycle
+in the shipped orchestrator today. Loop detection (the other half of the
+same module, fed by `_poll_file_mtimes` → `record_edit()`) is fully wired
+and does not share this gap.
+
+## Source
+
+- `src/bernstein/core/observability/loop_detector.py` - `LoopDetector`,
+  `DeadlockDetection`, cycle search, and victim selection.
+- `src/bernstein/core/agents/agent_recycling.py` and
+  `src/bernstein/core/agents/agent_lifecycle.py` - `check_loops_and_deadlocks()`,
+  the tick-loop entry point (the orchestrator imports the copy in
+  `agent_recycling.py`).
+- `src/bernstein/core/orchestration/orchestrator.py` - tick-loop wiring and
+  `_check_file_overlap` (`check_conflicts()` call site).
+- `src/bernstein/core/persistence/file_locks.py` - `FileLockManager`,
+  `FileLock`, `all_locks()`, `check_conflicts()`.

--- a/docs/architecture/fast-path-execution.md
+++ b/docs/architecture/fast-path-execution.md
@@ -1,0 +1,98 @@
+# Fast-path execution
+
+Skip the LLM agent entirely for trivial, mechanically-recognizable tasks -
+formatting, lint fixes, import sorting, a simple symbol rename - and run a
+deterministic tool instead.
+
+## Why
+
+Spawning an agent for "run ruff format on these files" burns a full LLM call
+for work a linter already does deterministically, in under a second, for
+free. Fast-path execution classifies every task before it reaches the
+spawner and routes the mechanically-obvious ones to a deterministic
+executor instead of an agent.
+
+## How it works
+
+`classify_task()` (`src/bernstein/core/quality/fast_path.py`) runs on every
+task batch and assigns one of three levels:
+
+| Level | Meaning | What happens |
+|---|---|---|
+| `L0` (trivial) | Matches a deterministic pattern (formatting, lint fix, import sort, a `rename X to Y` instruction) | Bypasses the spawner; runs a fixed executor (`ruff format`, `ruff check --fix`, `ruff check --select I --fix`, or a word-boundary regex rename) directly against the task's `owned_files` |
+| `L1` (simple) | Matches a lighter pattern (docstring, type hint, typo fix) or is low-complexity + small-scope with no L0 match | Still goes through an agent, but routed to the cheapest configured model instead of the default |
+| `L2` (complex) | Everything else | Full LLM agent, unchanged behavior |
+
+A task is **never** fast-pathed regardless of text match when any of these
+hold: `role` is `manager`, `architect`, or `security`; `complexity` is
+`HIGH`; `scope` is `LARGE`; `priority == 1`; or the task explicitly requests
+`model: opus`.
+
+`try_fast_path_batch()` only handles single-task batches classified `L0`. It
+claims the task, runs the matched executor
+(`RUFF_FORMAT` / `RUFF_FIX` / `SORT_IMPORTS` / `RENAME_SYMBOL`), and marks the
+task complete or failed on the task server directly - the batch never reaches
+`AgentSpawner`. On executor failure the task is marked failed with the
+fast-path error as the reason, so it retries through the normal LLM path
+rather than silently disappearing.
+
+Every L0 execution is recorded to `.sdd/metrics/tasks.jsonl` with
+`model: "fast-path"`, zero tokens, zero `cost_usd`, and an
+`estimated_savings_usd` field (a flat $0.15/task estimate versus a Sonnet
+call) that feeds `bernstein cost` reporting. `compute_savings_vs_opus()`
+excludes fast-path tasks from the Opus-comparison savings calculation
+entirely - they never priced through a model, so there is nothing to
+compare against.
+
+## Configuration
+
+Fast-path is on by default with the built-in patterns above. To override or
+disable it, add a `fast_path:` block to `.sdd/config/routing.yaml`:
+
+```yaml
+fast_path:
+  enabled: true          # false disables L0/L1 classification entirely
+  l0_patterns:
+    - pattern: "\\b(format|formatting|black|prettier)\\b"
+      action: ruff_format
+      label: formatting
+  l1_patterns:
+    - pattern: "\\b(add docstring|missing docstring)\\b"
+      label: docstring
+  l1_model: haiku         # required for L1 tasks to route anywhere
+  l1_effort: normal       # optional; ignored if l1_model is unset
+```
+
+`load_fast_path_config()` is called once, at orchestrator startup, if
+`.sdd/config/routing.yaml` exists. `enabled: false` clears both pattern
+lists, so every task falls through to `L2`. Setting `l0_patterns` or
+`l1_patterns` replaces the built-in list wholesale (not a merge); a malformed
+regex in an entry is skipped with a warning, not fatal to the load.
+
+There is no hardcoded fallback model for `L1`: if `fast_path.l1_model` is
+never set (no `routing.yaml`, or the key omitted), `get_l1_model_config()`
+raises `ModelNotConfiguredError` rather than silently defaulting to a
+specific model.
+
+## Limitations
+
+- `RENAME_SYMBOL` is a word-boundary regex substitution, not an AST-aware
+  rename - it does not understand scope, so a common short identifier can
+  match unrelated occurrences across `owned_files`.
+- Classification is purely text-pattern-based (task title + description);
+  there is no dry-run or confidence threshold exposed to the operator beyond
+  the fixed `confidence` field recorded internally.
+- L0/L1 classification only ever narrows toward the deterministic/cheap path
+  when the task text matches; it never widens L2 tasks down. A high-value
+  rewrite that happens to be titled "format the module" would match L0
+  unless it also trips one of the exclusion rules (role, complexity, scope,
+  priority, explicit `opus` request).
+
+## Source
+
+- `src/bernstein/core/quality/fast_path.py` - classification, executors,
+  config loading, metrics recording.
+- `src/bernstein/core/orchestration/orchestrator.py` - wiring at
+  orchestrator startup (`load_fast_path_config`) and stats tracking.
+- `src/bernstein/core/tasks/task_lifecycle.py` - calls
+  `try_fast_path_batch()` before a batch reaches the spawner.

--- a/docs/architecture/protocol-negotiation.md
+++ b/docs/architecture/protocol-negotiation.md
@@ -1,0 +1,107 @@
+# Protocol version negotiation
+
+**Two peers each support a range of MCP/A2A/ACP versions - which one do they actually speak?**
+
+Bernstein talks to external peers over three wire protocols - MCP, A2A,
+and ACP - and each protocol accumulates versions over time (new
+capabilities added in a minor bump, breaking changes in a major bump).
+`protocol_negotiation.py` is a small, dependency-free computation
+library that takes the local and remote version lists for one protocol
+and returns the highest version both sides can speak, plus a list of
+capabilities that get dropped if the negotiated version is lower than
+the local best.
+
+If you only have time for one sentence: **`negotiate_version(local,
+remote)` picks the highest common major version, then the highest
+common minor within it, and reports which capabilities were lost in
+`degraded_capabilities`**. The rest of this page covers the algorithm
+and how to call it.
+
+---
+
+## What it computes
+
+Three protocol identifiers are recognised: `mcp`, `a2a`, `acp`
+(`ProtocolName` enum). Each version is a `ProtocolVersion(protocol,
+major, minor, patch, capabilities)` dataclass - `capabilities` is a
+frozenset of capability strings supported at that version.
+
+`negotiate_version(local_versions, remote_versions)` returns a
+`NegotiationResult`:
+
+| Field | Meaning |
+|---|---|
+| `local_version` | The local side's highest version, regardless of outcome. |
+| `remote_version` | The remote side's highest version, regardless of outcome. |
+| `negotiated_version` | The agreed version, or `None` if negotiation failed. |
+| `degraded_capabilities` | Capabilities present on `local_version` but absent from `negotiated_version`. |
+| `success` | `True` if a common major version exists. |
+
+## The algorithm
+
+Source: `negotiate_version` in `protocol_negotiation.py`.
+
+1. Both version lists are sorted ascending by `(major, minor, patch)`.
+2. Negotiation fails (`success=False`, `negotiated_version=None`) if
+   local and remote share no major version at all.
+3. Otherwise the **highest common major** version is selected.
+4. Within that major, the **highest common minor** is preferred. If no
+   minor is shared, the algorithm falls back to the lower side's
+   highest minor (so negotiation degrades gracefully instead of
+   failing outright).
+5. `degraded_capabilities` is computed as `local_best.capabilities -
+   negotiated.capabilities` - i.e. what the local side loses by
+   settling on the negotiated version, not what the remote side loses.
+
+`version_is_compatible(local, remote)` is a cheaper standalone check:
+it only compares major versions, with no minor-resolution or
+capability diff.
+
+## Usage
+
+There is no CLI command for this module - it is a pure Python API
+called by whatever component owns a given protocol connection.
+
+```python
+from bernstein.core.protocols.protocol_negotiation import (
+    ProtocolVersion,
+    get_supported_versions,
+    negotiate_version,
+)
+
+local = get_supported_versions("mcp")
+remote = [ProtocolVersion(protocol="mcp", major=1, minor=0, patch=0)]
+
+result = negotiate_version(local, remote)
+if result.success:
+    print(result.negotiated_version.version_string)   # "1.0.0"
+    print(sorted(result.degraded_capabilities))        # capabilities lost vs. local best
+```
+
+`get_supported_versions(protocol)` returns Bernstein's own hardcoded
+version list for `mcp`, `a2a`, or `acp` (`_SUPPORTED_VERSIONS` in
+`protocol_negotiation.py`). For `mcp` specifically, the returned
+capability sets are filtered through the stateless-MCP compatibility
+shim (`bernstein.core.protocols.mcp.stateless_core`): the deprecated
+Roots/Sampling/Logging capabilities are advertised only while the shim
+window is open, and disappear from the returned `ProtocolVersion` once
+`months_since_deprecation` passes the shim's removal date. Pass
+`months_since_deprecation` explicitly to test the post-removal shape
+without waiting on the wall clock.
+
+## Limitations
+
+- **Pure computation, no wire I/O.** The module does not open a
+  connection, read a handshake payload, or call `negotiate_version`
+  automatically on any Bernstein transport. It is a version-arithmetic
+  library; the caller is responsible for fetching the remote peer's
+  supported-version list and acting on the `NegotiationResult` (e.g.
+  refusing a connection, or advertising a reduced capability set).
+- Only major/minor/patch and a flat capability-string set are modeled.
+  There is no concept of capability *dependencies* (e.g. "streaming
+  requires push_notifications") - two capabilities are independent as
+  far as this module is concerned.
+
+## Source
+
+`src/bernstein/core/protocols/protocol_negotiation.py`

--- a/docs/architecture/schema-registry.md
+++ b/docs/architecture/schema-registry.md
@@ -1,0 +1,141 @@
+# Task-payload schema registry
+
+**When a task payload's shape changes between versions, who checks that old and new code can still talk to each other?**
+
+`SchemaRegistry` (`core/protocols/schema_registry.py`) is a small
+in-memory registry for versioned task-payload schemas. Each
+`SchemaVersion` declares its field names, field types, and which
+fields are required; the registry can then compare two versions for
+backward/forward compatibility, validate a payload dict against a
+specific version, and best-effort migrate a payload from one version
+to another.
+
+If you only have time for one sentence: **register a `SchemaVersion`
+per payload revision, then call `check_compatibility(old, new)` before
+you ship a breaking change, or `validate_payload(payload, version)` to
+check one payload against the schema it claims to be**. The rest of
+this page covers the compatibility rules and the API.
+
+Do not confuse this with `bernstein.mcp.input_validation.SchemaRegistry`
+- an unrelated class with the same name that validates *MCP tool-call*
+inputs against JSON Schema files on disk. This page is about the
+`core.protocols.schema_registry` module, which is a plain Python
+registry for task-payload field schemas and carries no JSON Schema
+dependency.
+
+---
+
+## Data model
+
+Source: `schema_registry.py`.
+
+- `SchemaVersion(version, fields, required_fields, deprecated_fields)`
+  - `fields`: `dict[str, str]` mapping field name to a type tag
+    (`"str"`, `"int"`, `"float"`, `"bool"`, `"list"`, `"dict"`,
+    `"None"`).
+  - `required_fields`: frozenset of field names that must be present.
+  - `deprecated_fields`: frozenset of field names still accepted but
+    flagged as deprecated in `validate_payload` warnings.
+- `SchemaRegistry` holds a `dict[int, SchemaVersion]` keyed by version
+  number. `register()` raises `ValueError` on a duplicate version
+  number; there is no update-in-place.
+
+## Compatibility semantics
+
+`check_compatibility(old_version, new_version)` returns a
+`CompatibilityResult(compatible, breaking_changes, warnings)`.
+`compatible` is `True` only when `breaking_changes` is empty. Rules,
+in the order the code checks them:
+
+| Change | Classified as |
+|---|---|
+| A field required in `old` is missing from `new.fields` entirely | Breaking |
+| A field required in `new` did not exist in `old.fields` at all | Breaking |
+| A field present in both versions changed its type tag | Breaking |
+| An optional field present in `old` was dropped in `new` | Warning |
+| A new optional field was added in `new` | Warning |
+| A field is listed in `new.deprecated_fields` | Warning |
+
+This gives you both directions in one call: "can new code read data an
+old producer wrote" (backward) and "can old code read data a new
+producer wrote" (forward), per the docstring's compatibility
+definitions - the function does not label individual findings as
+backward vs. forward, it reports the union as `breaking_changes`.
+
+## Payload validation
+
+`validate_payload(payload, version)` returns a
+`ValidationResult(valid, errors, warnings)`:
+
+- **Errors** (any of these makes `valid=False`): a required field is
+  missing; the payload contains a field name not declared in
+  `schema.fields`; a declared field's value does not match its
+  declared Python type via `isinstance`.
+- **Warnings**: use of a field listed in `schema.deprecated_fields`.
+
+Type checking uses a fixed lookup table (`_TYPE_MAP`) from the type
+tag string to the actual Python type - unrecognised type tags are
+skipped rather than rejected, so a typo in a schema's `fields` dict
+silently disables checking for that one field rather than raising.
+
+## Migration
+
+`migrate_payload(payload, from_version, to_version)` is best-effort,
+not compatibility-checked:
+
+- Fields absent from the target schema are dropped.
+- Fields whose type tag changed between source and target are dropped
+  (logged at debug level), since no type coercion is attempted.
+- Everything else is copied through unchanged.
+- New required fields on the target schema are **not** filled in - the
+  caller must populate them after migration; `migrate_payload` will
+  happily return a payload that then fails `validate_payload` against
+  the target version.
+
+## Usage
+
+There is no CLI command for this module - it is a plain Python API.
+
+```python
+from bernstein.core.protocols.schema_registry import SchemaRegistry, SchemaVersion
+
+registry = SchemaRegistry()
+registry.register(SchemaVersion(
+    version=1,
+    fields={"name": "str", "priority": "int"},
+    required_fields=frozenset({"name"}),
+))
+registry.register(SchemaVersion(
+    version=2,
+    fields={"name": "str", "priority": "int", "owner": "str"},
+    required_fields=frozenset({"name", "owner"}),
+))
+
+compat = registry.check_compatibility(1, 2)
+assert not compat.compatible          # "owner" is newly required in v2
+print(compat.breaking_changes)
+
+result = registry.validate_payload({"name": "fix bug"}, version=1)
+assert result.valid
+
+migrated = registry.migrate_payload({"name": "fix bug", "priority": 2}, from_version=1, to_version=2)
+# migrated == {"name": "fix bug", "priority": 2}; "owner" is still missing
+```
+
+## Limitations
+
+- **In-memory only.** `SchemaRegistry` instances hold no persistence
+  layer; nothing is written to disk or the audit chain. A process
+  restart loses every `register()` call unless the caller re-registers
+  schemas at startup.
+- **No wire-level enforcement.** Registering and checking schemas does
+  not, by itself, gate what a running task server accepts on any
+  route. It is a library for callers who want compatibility checks
+  before shipping a payload-shape change, not an interceptor.
+- Type checking is limited to the fixed `_TYPE_MAP` set of Python
+  builtins; nested structure (e.g. the shape of a `dict` field's
+  values) is not validated.
+
+## Source
+
+`src/bernstein/core/protocols/schema_registry.py`

--- a/docs/architecture/subagent-delegation.md
+++ b/docs/architecture/subagent-delegation.md
@@ -1,0 +1,119 @@
+# Native Subagent Delegation
+
+Bernstein keeps the *coordination plan* in its deterministic scheduler and
+delegates the *mechanical execution* of each leaf task to a native subagent
+primitive - Claude Code's `--agents` flag, Codex, or another adapter's own
+sub-agent mechanism. `core/agents/subagent_delegation.py` is the boundary
+that lets that composition stay replayable: the plan side is a pure,
+hashable data structure, and only the boundary crossing (validating and
+anchoring the native result) is a side effect.
+
+## The plan is data, not a live call
+
+An `OuterPlan` is an ordered tuple of `DispatchNode` leaves. Each node names
+a native `target` (`claude`, `codex`, ...) and the per-agent knobs the
+native primitive consumes - `model`, `effort`, `prompt`, `tools`,
+`background`, `batch` - plus a `result_schema` the native structured output
+must satisfy:
+
+```python
+from bernstein.core.agents.subagent_delegation import DispatchNode, OuterPlan, delegate_plan
+
+node = DispatchNode(
+    name="backend-leaf",
+    target="claude",
+    model="sonnet",
+    effort="medium",
+    prompt="Implement the endpoint per the spec.",
+    result_schema={"type": "object", "properties": {"files_changed": {"type": "array"}}, "required": ["files_changed"]},
+    tools=("edit", "bash"),
+    batch=False,
+)
+plan = OuterPlan(nodes=(node,))
+```
+
+`DispatchNode.node_hash()` and `OuterPlan.plan_hash()` are pure functions of
+these *plan* fields alone - never of what the native subagent returns - so
+two byte-identical plans produce identical hashes across replays even
+though the inner execution is stochastic. `OuterPlan` rejects duplicate
+node names at construction.
+
+## Crossing the boundary
+
+The module does not invoke the native subagent itself - the caller runs
+the native primitive (via the adapter surface) and passes the parsed
+structured result into `dispatch_node()` or `delegate_plan()`:
+
+```python
+result = dispatch_node(
+    node,
+    native_result={"files_changed": ["app.py"]},
+    journal=run_journal,          # optional
+    chain=audit_chain_store,      # optional
+    ledger=spend_ledger,          # optional
+    undiscounted_cost_usd=0.02,
+    input_tokens=1200,
+    output_tokens=340,
+)
+```
+
+`dispatch_node()` performs three steps in order:
+
+1. **Schema validation at the worker boundary.** The native result is
+   checked against the node's `result_schema`, sealed against additional
+   properties. Hallucinated keys or missing required fields raise
+   `NativeResultRejected` (a `SchemaViolation` subclass) *before* anything
+   is anchored, so a bad payload never reaches the journal.
+2. **Journal anchoring.** When a journal is supplied, the crossing is
+   recorded as a `subagent.delegation` event carrying the node's
+   replay-invariant `node_hash` and the (stochastic) `result_content_hash`
+   (SHA-256 of the canonical validated payload). The outer DAG - the
+   ordered sequence of `node_hash` values - therefore replays
+   byte-identically even when the anchored result content differs run to
+   run. `delegate_plan()` dispatches every node of a plan in strict plan
+   order for exactly this reason.
+3. **Cost attribution.** When a spend ledger is supplied, a `batch=True`
+   node's cost is discounted by `BATCH_TIER_DISCOUNT` (0.5, i.e. the
+   standard non-interactive batch rate) and tagged `tier=batch` in the
+   ledger; `cache_read_tokens` / `cache_write_tokens` are recorded so
+   `bernstein cost` can attribute prompt-cache savings.
+
+When an `AuditChainStore` is also supplied, the same boundary is mirrored
+into the HMAC-chained audit log via `record_subagent_delegation` (event
+type `EVENT_SUBAGENT_DELEGATION = "subagent.delegation"`), cross-referencing
+the run id, node hash, result content hash, and journal position.
+
+## Guarantees
+
+- **No live LLM in the coordination loop.** The outer plan's identity
+  (`node_hash` / `plan_hash`) never depends on the native subagent's
+  output, so the *coordination* graph is deterministic even though each
+  leaf's *execution* is not.
+- **Rejection before anchoring.** A native result that fails schema
+  validation raises before any journal or audit write happens - a
+  hallucinated or malformed payload cannot enter the replay record.
+- **Deterministic ordering.** `delegate_plan()` always dispatches nodes in
+  `OuterPlan.nodes` order, so the sequence of anchored events is a pure
+  function of the plan.
+
+## Limitations
+
+- There is no dedicated CLI command for this boundary. It is an internal
+  API called by the scheduler's dispatch path, not an operator-facing
+  subcommand.
+- `bernstein delegation verify <run>` verifies a **different** surface -
+  the per-hop HMAC *authorization* receipt chain in
+  `core/identity/delegation.py` (the ACT log: which principal authorized
+  which sub-agent action). It does not reconstruct or verify
+  `subagent.delegation` journal events. Verifying a run's delegation
+  boundaries means replaying its journal (see
+  [Deterministic replay](../operations/deterministic-replay.md)) and, when
+  an audit chain was wired in, checking `bernstein audit verify` for the
+  mirrored `subagent.delegation` audit events.
+- `delegate_plan()` requires every plan node to have a matching entry in
+  the caller-supplied `native_results` mapping; a missing entry raises
+  `KeyError` rather than skipping the node.
+
+## Source
+
+`src/bernstein/core/agents/subagent_delegation.py`

--- a/docs/concepts/lesson-persistence.md
+++ b/docs/concepts/lesson-persistence.md
@@ -1,0 +1,123 @@
+# Agent lesson persistence
+
+A tag-indexed, decaying store of short lessons filed on task completion.
+Lessons are matched against a new task's tags and injected into the spawn
+prompt of the agent picking up related work, so a mistake caught once does
+not have to be rediscovered by the next agent that touches the same area.
+
+Source: `src/bernstein/core/knowledge/lessons.py` (imported elsewhere as
+`bernstein.core.lessons`, a back-compat alias to the same module).
+
+## Storage
+
+Lessons live at `.sdd/memory/lessons.jsonl`, one JSON object per line. Each
+entry carries:
+
+| Field | Meaning |
+|---|---|
+| `lesson_id` | UUID |
+| `tags` | Lowercased retrieval tags |
+| `content` | The lesson text |
+| `confidence` | `0.0`-`1.0`, clamped on write |
+| `memory_type` | `user`, `feedback`, `project`, or `reference` (see below) |
+| `created_timestamp` | Unix time when first filed |
+| `filed_by_agent`, `task_id` | Provenance |
+| `version` | Incremented on a confidence update |
+| `content_hash`, `prev_hash`, `chain_hash` | Integrity chain (see below) |
+
+### Memory types and decay
+
+`file_lesson()` accepts a `memory_type` that sets how fast the lesson's
+effective confidence decays with age:
+
+| Type | Decay half-life |
+|---|---|
+| `feedback` (human corrections) | 7 days |
+| `project` (project conventions) | 14 days |
+| `user` (workflow observations, default) | 30 days |
+| `reference` (external best practices) | 90 days |
+
+Decay is applied only at read time (`get_lessons_for_agent`); the stored
+`confidence` value is not rewritten by age. A lesson older than 1 day also
+gets a `**Staleness:**` caveat line appended when rendered into a prompt.
+
+### Deduplication
+
+`file_lesson()` checks the existing JSONL content for a near-duplicate
+before appending: same `memory_type`, tag-set Jaccard similarity &ge; 0.75,
+and word-overlap content similarity &gt; 0.8. A match updates the existing
+entry's `confidence` and bumps `version` instead of creating a new row.
+
+### Integrity chain
+
+Every entry is written with `content_hash` (SHA-256 of the immutable
+fields), `prev_hash` (the previous entry's `chain_hash`), and `chain_hash`
+(SHA-256 of `content_hash` + `prev_hash`) — see
+`src/bernstein/core/knowledge/memory_integrity.py`. Reordering, deleting, or
+tampering with an entry breaks the chain from that point forward. New
+lesson content also passes through `detect_memory_poisoning()` before it is
+accepted; content matching known prompt-injection patterns is rejected with
+a `ValueError` and never reaches the file.
+
+Concurrent writers are serialized through a PID/mtime lock
+(`memory_lock_protocol.py`) with stale-lock recovery and atomic
+backup-then-write, so two agents filing lessons at the same time cannot
+corrupt the JSONL file.
+
+### Verifying the chain
+
+```bash
+bernstein verify --memory-audit
+```
+
+Runs `verify_chain()` over `.sdd/memory/lessons.jsonl` and reports either a
+clean chain (entry count, "Tampering: none detected") or the line number of
+the first break. Exits `0` on a clean chain, `1` on a violation, `0` if the
+file does not exist yet.
+
+## Retrieval and injection
+
+At spawn time, `spawner_core.py` extracts tags from the batch of tasks being
+assigned to an agent and calls `gather_lessons_for_context()`. That function:
+
+1. Loads lessons via `get_lessons_for_agent()`, keeping only entries whose
+   tags overlap the task tags.
+2. Ranks by `tag_overlap + decayed_confidence`, descending.
+3. Formats up to 5 lessons as a `## Prior Agent Lessons` markdown block,
+   each with type, tags, confidence, source task, and (if stale) a
+   staleness note.
+4. Truncates at a 5,000-token budget (`DEFAULT_CATEGORY_BUDGETS["lessons"]`
+   in `core/tokens/context_compression.py`), appending a truncation notice
+   if lessons had to be dropped.
+
+The block is included in every agent's spawn prompt except the `manager`
+and `visionary` roles (`SECTION_RULES["lessons"]` in
+`core/agents/spawn_prompt.py`). Results are cached per `(role, tags)` pair
+for a short TTL so repeated spawns in the same batch do not re-read the
+file.
+
+## Limitation: nothing files lessons automatically yet
+
+`file_lesson()` is fully implemented, tested, and safe to call — but no
+code path in the shipped orchestrator calls it. Nothing currently reads a
+task's outcome and writes a lesson on completion; the docstring's "agents
+file lessons when they complete tasks" describes the intended trigger, not
+current wiring. In practice, `.sdd/memory/lessons.jsonl` only gains entries
+if something outside the base orchestrator (a plugin, a custom hook, direct
+use of the Python API) calls `file_lesson()`.
+
+The read/decay/injection path described above runs unconditionally at
+every qualifying spawn regardless of whether anything has ever filed a
+lesson — it is simply a no-op (empty `## Prior Agent Lessons` block) on a
+project where nothing has populated the file.
+
+## Related, different subsystem
+
+`spawn_prompt.py` also has a second, unrelated lesson-injection path gated
+behind `BERNSTEIN_MEMORY_AUTO_INJECT` (off by default): it tails
+`.bernstein/memory/lessons.jsonl` through
+`core/memory/jsonl_log.py`'s `JSONLMemoryLog` and renders the most recent
+entries as a plain `<lessons>...</lessons>` block. That log has no scoring,
+decay, tag matching, or integrity chain — see
+[Append-only JSONL memory log](jsonl-memory-log.md). The two systems read
+different files and do not share entries.

--- a/docs/concepts/semantic-caching.md
+++ b/docs/concepts/semantic-caching.md
@@ -1,0 +1,92 @@
+# Semantic caching
+
+Bernstein caches two different kinds of LLM work by matching on the
+*meaning* of a request, not just its exact text: repeated planning calls for
+similar goals, and completed task results for functionally identical tasks.
+Both use the same underlying cosine-similarity matcher
+(`core/knowledge/semantic_cache.py`) but store different things, at
+different thresholds, for different purposes. This is a different caching
+layer from the [cache policy engine](cache-policy.md), which governs the
+fingerprint, action-cache, and semantic-cache boundaries as a shared
+freshness/eviction contract — the mechanics described here are specific to
+the semantic matcher itself.
+
+## Two caches, one matcher
+
+| | `SemanticCacheManager` | `ResponseCacheManager` |
+|---|---|---|
+| Caches | LLM **planning** responses | Completed **task results** (`result_summary`) |
+| Keyed on | Goal text | `role:title\ndescription` (task-shape) |
+| Similarity threshold | 0.85 | 0.95 (deliberately high — wrong reuse here skips spawning an agent) |
+| TTL | 24h | 7 days |
+| Max entries | 500 | 1,000 |
+| Storage | `.sdd/caching/semantic_cache.jsonl` | `.sdd/caching/response_cache.jsonl` |
+| Model-sensitive | Yes — entries are scoped per `model` | No — stores *what was accomplished*, not a model's wording |
+
+Both do an exact SHA-256 match on normalized text first (O(1)); on a miss,
+they fall back to a TF-style word-frequency cosine similarity scan (O(n))
+over non-expired entries and accept the best match once it clears the
+threshold.
+
+## How lookups work
+
+```python
+response, similarity = manager.lookup(key_text, model="claude-sonnet-4")
+# similarity == 1.0 on an exact hash hit; < threshold means a miss
+```
+
+A hit increments the entry's `hit_count` and refreshes `last_used_at`.
+Entries older than the TTL are treated as misses and pruned opportunistically.
+When the store exceeds its entry cap, the least-recently-used entries are
+evicted to make room.
+
+The response cache additionally exposes a canonical key builder,
+`ResponseCacheManager.task_key(role, title, description)`, so callers build
+the same key shape the orchestrator uses when deciding whether a new task is
+"the same" as a previously completed one.
+
+## Where it's wired in
+
+- `core/planning/planner.py` consults `SemanticCacheManager` before issuing a
+  planning LLM call for a goal.
+- `core/orchestration/orchestrator.py` and `core/tasks/task_lifecycle.py`
+  consult `ResponseCacheManager` before spawning an agent for a task, and
+  store the result afterward.
+- `adapters/caching_adapter.py` wraps a CLI adapter with the response cache
+  so adapter-level callers get the same reuse without touching orchestrator
+  internals.
+
+## Inspecting the response cache
+
+```
+bernstein cache list --limit 25 [--json]
+bernstein cache inspect <task-id> [--json]
+bernstein cache clear [--unverified] [--yes]
+```
+
+`list` and `inspect` read `.sdd/caching/response_cache.jsonl` and show hit
+count, verification status, tracked diff-line count, and age per entry.
+`clear` removes entries outright (`--unverified` restricts this to entries
+that never came from a verified real execution). There is no equivalent CLI
+surface for the planning-side `SemanticCacheManager` — it is inspected only
+through its `get_stats()` Python API.
+
+`bernstein cache policy` and `bernstein cache evict` operate on the separate
+cache-policy engine, not on this matcher — see
+[Cache policy engine](cache-policy.md).
+
+## Limitations
+
+- The fuzzy matcher is a hand-rolled TF word-frequency cosine similarity, not
+  an embedding model — it catches near-identical phrasing, not semantically
+  equivalent but differently worded requests.
+- `verified` entries and `unverified` entries are not distinguished during
+  lookup — an unverified (never-executed-for-real) response can still serve
+  a cache hit unless it has been cleared with `--unverified`.
+- A `store()` call refreshes an existing entry's response in place; there is
+  no versioned history of what a given cache key has served over time.
+
+## Source
+
+- `src/bernstein/core/knowledge/semantic_cache.py` — `SemanticCacheManager`, `ResponseCacheManager`, `SemanticCacheEntry`.
+- `src/bernstein/cli/commands/cache_cmd.py` — `bernstein cache list/inspect/clear`.

--- a/docs/contributing/git-hooks.md
+++ b/docs/contributing/git-hooks.md
@@ -1,0 +1,74 @@
+# `bernstein install-hooks`
+
+Installs local git pre-commit and pre-push hooks so common checks run
+before code leaves your machine, instead of failing for the first time
+in CI.
+
+This is unrelated to the [lifecycle hooks contract](hooks.md)
+(`pre_task`/`post_task`/`pre_merge`/etc., driven by `bernstein.yaml` and
+run by the orchestrator against agent activity) and to the
+[hook permission-rule prefilter](../operations/hooks.md) (the `if:`
+filter on those lifecycle hooks). `install-hooks` writes plain git
+hooks into `.git/hooks/` for the contributor's own commits.
+
+## Usage
+
+```bash
+bernstein install-hooks
+bernstein install-hooks --force   # -f: overwrite hooks that already exist
+```
+
+| Flag | Meaning |
+|---|---|
+| `--force`, `-f` | Overwrite an existing `pre-commit` or `pre-push` hook. Without it, an existing hook is left untouched and skipped. |
+
+The command exits with an error if run outside a git repository (no
+`.git/hooks` directory).
+
+## What it installs
+
+Two scripts are written to `.git/hooks/` and made executable
+(`chmod 755`):
+
+**`pre-commit`**
+
+```bash
+#!/bin/bash
+set -e
+uv run ruff check --fix .
+uv run pytest tests/unit -x -q
+```
+
+Runs `ruff check --fix` and the unit test suite (stopping at the first
+failure) before a commit is allowed to complete.
+
+**`pre-push`**
+
+```bash
+#!/bin/bash
+# Check for unmerged PRs or blocked status before push
+exit 0
+```
+
+Currently a placeholder that always exits `0` (i.e. never blocks a
+push).
+
+For each of the two hooks, if the target file already exists and
+`--force` was not passed, the command prints a note and leaves that
+hook untouched — it does not overwrite silently and does not merge
+with an existing hook script.
+
+## Limitations
+
+- The installed `pre-commit` hook runs the full `tests/unit` suite on
+  every commit; on a large working tree this can be slower than
+  committing without it.
+- Hooks are written to `.git/hooks/`, which git does not version —
+  each clone/worktree must run `bernstein install-hooks` again to get
+  them.
+- There is no `uninstall-hooks` command; remove the files from
+  `.git/hooks/` directly to revert.
+
+## Source
+
+- `src/bernstein/cli/commands/advanced_cmd.py` — `install_hooks` (registered as `bernstein install-hooks` in `cli/main.py`)

--- a/docs/eval/golden-harness.md
+++ b/docs/eval/golden-harness.md
@@ -1,0 +1,105 @@
+# Golden benchmark harness
+
+The golden harness scores agent runs against a curated, tiered task set using
+a multiplicative formula, then persists the run so a later `report` or
+`failures` call can inspect it without re-running anything. It is the `eval
+run` path taken when no YAML spec is given, and is a different code path from
+the [YAML eval harness](yaml-harness.md) (which always takes a spec file).
+
+## How to use it
+
+```
+bernstein eval run                       # run the full golden suite
+bernstein eval run --tier smoke          # smoke tier only
+bernstein eval run --compare             # also diff against the previous run
+bernstein eval run --no-save             # don't persist results to disk
+bernstein eval report                    # markdown-style summary of the last run
+bernstein eval failures                  # failure-taxonomy breakdown of the last run
+```
+
+`--tier` accepts `smoke`, `standard`, or `stretch` and selects which golden
+tiers feed the scoring pass (`adversarial` tasks are included only when
+scoring task results directly via the Python API, not through `--tier`).
+`report` and `failures` both read the most recently saved run from
+`.sdd/eval/runs/eval_run_*.json` — run `eval run --save` (the default) at
+least once before calling either.
+
+## Golden tasks
+
+Tasks are markdown files with YAML frontmatter, resolved in two places:
+
+1. Operator overrides at `.sdd/eval/golden/<tier>/*.md`, when that directory
+   exists and is non-empty.
+2. Packaged defaults shipped in the wheel under
+   `bernstein.eval.golden_data.<tier>`, discovered via `importlib.resources`
+   — a fresh install has a working `smoke` tier with no operator setup.
+
+Tiers are `smoke`, `standard`, `stretch`, `adversarial`.
+
+## Scoring
+
+```
+Score = (0.5*TaskSuccess + 0.3*CodeQuality + 0.2*Efficiency) * Reliability * Safety
+```
+
+`Reliability` and `Safety` are multiplicative gates: a crash, an orphaned
+agent process, or a test regression anywhere in the run drives the
+corresponding gate toward zero and the overall score with it — one
+regression is enough to zero the score regardless of how well the other
+tasks scored.
+
+- **TaskSuccess** — fraction of tasks whose completion signals all passed
+  and which introduced no test failures.
+- **CodeQuality** — mean of the LLM-judge verdict scores, when a judge
+  verdict was supplied per task (0.0 when none were).
+- **Efficiency** — computed from per-task telemetry (`bernstein.eval.metrics.compute_efficiency`).
+- **Reliability** — degrades with crash count, orphan count, and any task
+  missing telemetry.
+- **Safety** — zero when the failure taxonomy recorded any test regression.
+
+`eval report` prints the composite score plus this five-way breakdown and the
+per-tier pass rates (smoke/standard/stretch/adversarial).
+
+## Failure taxonomy
+
+Every failed task is classified into one closed-set category
+(`bernstein.eval.taxonomy.FailureCategory`): `orientation_miss`,
+`scope_creep`, `test_regression`, `incomplete`, `timeout`, `conflict`,
+`context_miss`, `hallucination`. `eval failures` prints a table of
+task/category/details plus counts per category for the most recent run —
+useful for spotting whether a regression clusters around one failure mode
+(e.g. every failure being `scope_creep` points at a task-boundary problem
+rather than a model-quality problem).
+
+## Persistence
+
+`eval run --save` (the default) writes
+`.sdd/eval/runs/eval_run_<UTC-timestamp>.json` containing the score, the
+five-way breakdown, per-tier rates, the failure list, and total cost.
+`--compare` loads the previous run from the same directory and prints the
+score delta. `report` and `failures` always read the latest file in that
+directory — they do not take a run ID argument.
+
+## Limitations
+
+- `eval run` without a spec argument only scores tasks for which telemetry
+  and (optionally) a judge verdict were already collected — it does not
+  itself spawn agents. The orchestrator's own run must populate
+  `.sdd/eval/golden/` telemetry first; the CLI command drives scoring, not
+  execution.
+- `report` and `failures` operate on the single most recent run file; there
+  is no `--run-id` selector.
+
+## Source
+
+- `src/bernstein/eval/harness.py` — `EvalHarness`, `EvalResult`, scoring.
+- `src/bernstein/eval/golden.py` — golden task loading.
+- `src/bernstein/eval/taxonomy.py` — failure taxonomy.
+- `src/bernstein/eval/metrics.py` — efficiency/reliability/safety component math.
+- `src/bernstein/cli/commands/eval_benchmark_cmd.py` — `eval run` / `eval report` / `eval failures` commands.
+
+## Related
+
+- [YAML eval harness](yaml-harness.md) — the `eval run <spec.yaml>` path,
+  for adapter-vs-adapter comparison against a hand-authored spec.
+- [A/B runner primitive](ab-runner.md)

--- a/docs/getting-started/quickstart-demo.md
+++ b/docs/getting-started/quickstart-demo.md
@@ -1,0 +1,56 @@
+# Zero-config quickstart demo
+
+`bernstein quickstart` runs a self-contained demo: it creates a temporary
+Flask TODO API project with intentional gaps, seeds three tasks against it,
+runs agents to complete them, and prints a summary — with no `bernstein.yaml`
+and no prior project setup required. It exists to let a new user see
+multi-agent orchestration work end to end before committing to a real
+project.
+
+For a guided walkthrough that sets up your own project instead of a
+throwaway demo, see the [interactive tutorial](quickstart-tutorial.md).
+
+## Usage
+
+```bash
+bernstein quickstart                # run and clean up the temp dir
+bernstein quickstart --keep         # keep the temp dir for inspection
+bernstein quickstart --timeout 120  # cap orchestration wait time
+bernstein quickstart --adapter codex
+```
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--keep` | off | Preserve the temp project directory after completion instead of deleting it. |
+| `--timeout SECONDS` | 300 | Maximum seconds to wait for all seeded tasks to finish. |
+| `--adapter NAME` | auto-detected | CLI adapter to drive the agents (falls back to `mock` if none is detected — no API key needed to see the flow). |
+
+## What it does
+
+1. Creates a temp directory (`bernstein-quickstart-*`) containing a minimal
+   Flask TODO API (`app.py`) that is missing input validation, 404 error
+   handling, and a test suite — bundled from `examples/quickstart/` when
+   present, or written inline as a fallback.
+2. Seeds three backlog tasks into `.sdd/backlog/open/`:
+   - input validation on `create_todo` (role: `backend`)
+   - 404 handling on `update_todo`/`delete_todo` (role: `backend`)
+   - a pytest suite covering the API (role: `qa`)
+3. Starts a task server on port 8056 and bootstraps orchestration
+   (`bootstrap_from_goal`) against those tasks.
+4. Polls `/status` every 2 seconds, printing each task's completion or
+   failure as it happens, until every task reaches `done`/`failed` or the
+   timeout elapses.
+5. Stops the server, spawner, and watchdog processes it started.
+6. Prints a summary table (tasks completed, elapsed time, Python files
+   produced, API cost) and, unless `--keep` is passed, deletes the temp
+   directory.
+
+## Cost
+
+Before starting, the command prints a cost estimate: roughly `$0.20` for the
+3 tasks when a real adapter is detected, or `$0.00 (mock)` when none is and
+it falls back to the mock adapter.
+
+## Source
+
+`src/bernstein/cli/commands/quickstart_cmd.py`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,7 +85,7 @@ bernstein -g "Add JWT auth with refresh tokens, tests, and API docs"
 
     ---
 
-    40+ CLI adapters: Claude Code, Codex, OpenAI Agents SDK v2, Gemini, Cursor, Aider, Cloudflare Agents, GitHub Copilot, Devin Terminal, CLM gateway, AWS Q Developer, and more.
+    40+ CLI adapters: Claude Code, Codex, OpenAI Agents SDK v2, Gemini, Cursor, Aider, GitHub Copilot, Devin Terminal, CLM gateway, AWS Q Developer, and more.
     Mix cheap local models with cloud models in the same run.
 
 - :material-source-branch:{ .lg .middle } **Git worktree isolation**

--- a/docs/integrations/github-action.md
+++ b/docs/integrations/github-action.md
@@ -12,12 +12,22 @@ branch, Bernstein will attempt to fix it automatically.
 
 | Input            | Required | Default   | Description                                             |
 |------------------|----------|-----------|---------------------------------------------------------|
-| `task`           | no       | -         | Task description, or `"fix-ci"` for auto-fix mode       |
+| `task`           | no       | -         | Task description, or `"fix-ci"` for auto-fix mode. Mutually exclusive with `plan` |
+| `plan`           | no       | -         | Path to a Bernstein plan YAML file; runs `bernstein run <plan>` instead of a free-text goal. Mutually exclusive with `task` |
 | `budget`         | no       | `"5.00"`  | Dollar cap for the run                                  |
 | `cli`            | no       | `"claude"`| Agent CLI to use (`claude`, `codex`, `gemini`, `qwen`)  |
 | `max-retries`    | no       | `"3"`     | Retry count in fix-ci mode                              |
 | `python-version` | no       | `"3.12"`  | Python version to install                               |
 | `post-comment`   | no       | `"true"`  | Post PR comment with orchestration summary              |
+
+## Outputs
+
+| Output                 | Description                                                          |
+|------------------------|----------------------------------------------------------------------|
+| `tasks-completed`      | Number of tasks Bernstein completed in this run                      |
+| `total-cost`           | Total API cost in USD for this run                                   |
+| `pr-url`               | URL of a pull request created or updated by the run (if any)         |
+| `evidence-bundle-path` | Workspace-relative path to the evidence bundle (tests, logs, cost)   |
 
 ## Modes
 

--- a/docs/mcp/input-validation.md
+++ b/docs/mcp/input-validation.md
@@ -1,0 +1,90 @@
+# MCP tool-call input validation
+
+Every tool-call payload that reaches the Bernstein MCP server is
+shape-validated before the tool handler runs. The validator is the
+orchestrator-side input firewall for the MCP transport: unknown tools are
+refused, unknown top-level properties are refused, and each declared tool's
+arguments are checked against a JSON Schema before the handler ever sees
+them. This is deny-by-default — a payload has to positively match a
+registered schema to be dispatched, rather than being let through unless it
+trips a blocklist rule.
+
+## How it behaves
+
+Validation runs in this order for every incoming `tools/call`:
+
+1. **Unknown tool check.** If no schema is registered for the tool name, the
+   call is rejected with JSON-RPC code `-32601` (method not found).
+2. **Payload shape check.** `params` must be a JSON object; anything else is
+   rejected with `-32602` (invalid params).
+3. **Deny-by-default rules**, applied before JSON Schema validation so the
+   schema validator never has to parse a pathological payload:
+   - **Size cap** — serialized payload over 64 KiB is rejected.
+   - **Recursion cap** — nested dicts/lists deeper than 10 levels are
+     rejected.
+   - **Control-character filter** — string arguments containing C0/C1
+     control characters are rejected, except plain tab, newline, and
+     carriage return (so free-form multi-line fields such as `goal=` keep
+     working). This blocks prompt-injected ANSI escapes and stray control
+     bytes from reaching a downstream agent's terminal rendering.
+4. **JSON Schema validation** against the tool's registered `Draft7`
+   schema. Every violation is collected (not just the first) and returned
+   as a `{path, reason}` list, where `path` is a JSON pointer to the
+   offending field.
+
+A clean payload becomes a `ValidatedPayload(tool_name, payload)`; a failure
+becomes a `ValidationError(tool_name, code, message, errors)`, which the MCP
+server renders as a JSON-RPC 2.0 error object via `to_jsonrpc_error()`.
+
+## Schemas
+
+Each tool's schema is a plain JSON Schema (Draft 7) file at
+`src/bernstein/mcp/tool_schemas/<tool_name>.json`. The file's stem is the
+tool name the schema applies to. Schemas are loaded once per process (on
+first validation call) and cached; a malformed schema file fails fast at
+load time via `jsonschema.Draft7Validator.check_schema`, not on the first
+matching request.
+
+The bundled server ships schemas for the core tool set:
+`bernstein_health`, `bernstein_run`, `bernstein_status`, `bernstein_tasks`,
+`bernstein_task_handle`, `bernstein_cost`, `bernstein_stop`,
+`bernstein_approve`, `bernstein_create_subtask`, `bernstein_claim`,
+`bernstein_update`, `load_skill`, `bernstein_context`,
+`bernstein_post_artifact`, and the scenario-bridge tools
+`bernstein_scenario`, `bernstein_scenario_status`, `bernstein_scenarios`.
+Adding a new MCP tool means adding its schema file alongside these; a tool
+with no schema file is unreachable (unknown-tool rejection), which is the
+point of deny-by-default.
+
+## Permissive mode (migration aid)
+
+Set `BERNSTEIN_MCP_VALIDATION=permissive` to log rejected payloads instead of
+refusing them — the call is still logged with its tool name, error code, and
+the full violation list, but a best-effort `ValidatedPayload` is returned so
+the handler runs anyway. This exists only to ease a migration where a client
+sends payloads the current schemas don't yet accept; it is not intended as a
+steady-state production setting, and treating a call as validated in
+permissive mode does not mean the arguments were actually checked.
+
+The default (and every other value of the env var) is strict mode: every
+rejection is enforced.
+
+## Limitations
+
+- `SchemaRegistry` supports an `allow_unsafe_args` exemption set (tool names
+  skipped by the size/depth/control-character deny rules, though schema
+  validation still runs on them), but the bundled server registry does not
+  currently populate it from `bernstein.yaml` — there is no config key today
+  that exempts a specific tool from the deny rules in the shipped server.
+  The exemption mechanism exists for callers that build their own
+  `SchemaRegistry` directly.
+- Validation covers the shape of the arguments, not their semantics — a
+  syntactically valid `bernstein_run` payload can still name a task that
+  fails for unrelated reasons downstream.
+
+## Source
+
+`src/bernstein/mcp/input_validation.py` (validator, deny rules, schema
+registry); `src/bernstein/mcp/tool_schemas/*.json` (per-tool schemas); wired
+into request handling in `src/bernstein/mcp/server.py`
+(`_validate_or_error`).

--- a/docs/observability/cumulative-progress.md
+++ b/docs/observability/cumulative-progress.md
@@ -1,0 +1,62 @@
+# Cumulative progress tracking
+
+The Bernstein TUI (`bernstein --tui` / the Textual dashboard app) shows two
+completion-percentage bars: a per-task **Progress** column in the task table,
+and an aggregate run-level bar in the status bar showing how much of the
+whole run is done. Both are colour-coded terminal progress bars rendered
+client-side from data the task server already returns on every poll — there
+is no separate "progress" API call.
+
+## What renders where
+
+| Surface | What it shows | Width |
+|---|---|---|
+| Status bar (top of the TUI) | Aggregate percentage across the whole run: `tasks_done / tasks_total * 100` | 12 chars + `NNN%` |
+| Task list "Progress" column | Per-task completion percentage, or `—` if unknown | 10 chars + `NNN%` |
+
+Bar colour reflects completion: `dim` below 30%, `yellow` from 30-59%,
+`cyan` from 60-99%, `green` at 100%.
+
+## Where the numbers come from
+
+**Run-level (status bar):** `_compute_run_pct()` divides the `done` count by
+the `total` count from the same status payload the TUI already polls
+(`core/routes` status/summary fields) and passes the result to
+`render_progress_bar()`. If `tasks_total` is zero, no bar is shown.
+
+**Per-task (task list):** `TaskProgress.from_api()` reads a task's raw API
+dict and computes a percentage with this priority order:
+
+1. An explicit `progress.percentage` field, if the server sent one.
+2. `completed_steps / total_steps`, if step counts are present.
+3. `tests_passing / tests_total`, if test counts are present.
+4. Otherwise `0.0`, and the column renders `—` instead of a bar unless
+   `files_changed` or a truthy `progress` field is also present.
+
+A task with `status == "done"` always shows 100%, regardless of the fields
+above.
+
+## Limitations
+
+- This is a client-side rendering convenience, not a verified metric — it
+  trusts whatever `progress`, `completed_steps`/`total_steps`, or
+  `tests_passing`/`tests_total` fields the task server puts in the API
+  response for a task. It is a different mechanism from the chain-computed,
+  hash-verifiable per-task progress vector described in
+  [Task artifacts and chain-computed progress](task-artifacts.md) — the two
+  can disagree, and this page's numbers are not independently verifiable.
+- `render_progress_summary()` and `render_task_progress()` (aggregate-across-
+  tasks and compact single-task variants) are defined in the same module but
+  are not currently called by any TUI screen — the only bars an operator
+  actually sees are the two described above.
+- The TUI's `_task_progresses` list (built once per poll in `app.py`) is
+  populated but not currently read by any renderer; it has no visible effect
+  today.
+
+## Source
+
+- `src/bernstein/tui/progress_bar.py` — `TaskProgress`, `render_progress_bar`,
+  `render_progress_bar_text`, `render_task_progress`, `render_progress_summary`
+- `src/bernstein/tui/status_bar.py` — aggregate run-level bar in the status bar
+- `src/bernstein/tui/task_list.py` — per-task "Progress" column
+- `src/bernstein/tui/app.py` — `_compute_run_pct`, polling loop that feeds both

--- a/docs/observability/otel-span-projection.md
+++ b/docs/observability/otel-span-projection.md
@@ -1,0 +1,84 @@
+# OTel GenAI span projection (offline)
+
+Bernstein ships a live [OTLP exporter](otlp-export.md) for the run journal,
+but an operator who does not run a collector still needs a signed,
+checkable span set for a completed run. `bernstein trace project` and
+`bernstein trace verify-projection` are the offline counterpart: they
+project a run's event journal into a signed OTel GenAI span set on disk, and
+verify that projection later, with no OTLP endpoint required.
+
+Span ids are derived from journal entry hashes
+(`span_id = H("otel.span", entry_hash)`), so two projections of the same run
+export a byte-identical id tree — the projection is a deterministic function
+of the journal, not free-standing telemetry.
+
+## Projecting a run
+
+```
+bernstein trace project RUN_ID [--workdir DIR] [--no-genai-stability] [--json]
+```
+
+Loads `RUN_ID`'s event journal, maps its events onto the OTel GenAI span
+layers (`invoke_workflow` root, `invoke_agent`, `execute_tool`, `chat`
+using `gen_ai.operation.name`), and signs the resulting span set with the
+install-identity Ed25519 key. By default the signed projection is written to
+`.sdd/runs/<run_id>/projection.otel.json`; `--json` prints it to stdout
+instead. `--no-genai-stability` omits the (Development-stage) GenAI
+semantic-convention attributes while keeping every span id journal-anchored
+— useful when a downstream tool chokes on an unstable attribute set.
+
+Every span carries `bernstein.journal.entry_hash` (the exact journal row it
+projects), `bernstein.audit.anchor` (the first-entry projection anchor the
+trace id derives from), and `bernstein.run.id`. Completing the projection
+also appends an `otel.projection` event to the HMAC audit chain, binding the
+trace id, span count, and the SHA-256 of the signed canonical span set.
+
+Exit codes: `0` written, `1` no event journal for the run, or bad input.
+
+## Verifying a projection
+
+```
+bernstein trace verify-projection RUN_ID [--workdir DIR] [--projection PATH]
+```
+
+Reloads `RUN_ID`'s journal, recomputes every span id from it, and checks the
+signature against the install identity. `--projection` overrides the
+expected file location (default `.sdd/runs/<run_id>/projection.otel.json`).
+A span whose id was altered, or whose journal entry hash is no longer
+present in the chain, is rejected.
+
+Exit codes: `0` OK (span ids recompute from the journal, signature chains to
+the install identity), `1` bad input (no journal, or no projection file at
+the expected/given path), `2` verification failed (recomputed ids diverge,
+or the signature does not chain).
+
+## Guarantees
+
+- **Determinism.** `project_spans` is a pure function of its input events —
+  it never reads a clock, environment, or socket. Ed25519 signing is
+  deterministic (RFC 8032), so two projections of the same run produce
+  byte-identical spans and signature bytes.
+- **Journal-anchored identity.** Every span id and the trace id derive from
+  journal entry hashes, not from an SDK-generated random id — stripping the
+  journal makes the ids unrecomputable, and tampering with a span breaks
+  either the entry-hash binding or the signature.
+- **Convention-attribute instability is isolated.** The OTel GenAI semantic
+  conventions are still Development-stage; a convention rename never
+  affects the journal-anchored ids because the attributes sit behind the
+  `--no-genai-stability` flag, not inside the id derivation.
+
+## Relationship to the live OTLP exporter
+
+This offline pair covers the whole-run surface: project once, verify
+anytime, no collector needed. The live exporter
+(`BERNSTEIN_OTEL_ENDPOINT`) streams the same journal-anchored spans as the
+run executes, and `bernstein telemetry verify-span` checks one span copied
+out of a tracing UI against the journal. See [OTLP export](otlp-export.md)
+for the live-streaming and per-span verification workflow.
+
+## Source
+
+`src/bernstein/cli/commands/advanced_cmd.py` (`trace project` /
+`trace verify-projection`), `src/bernstein/core/observability/otel_projection.py`
+(span projection, signing, verification),
+`src/bernstein/core/replay/journal.py` (the event journal projected from).

--- a/docs/observability/token-progress.md
+++ b/docs/observability/token-progress.md
@@ -1,0 +1,80 @@
+# Per-agent token progress
+
+`bernstein status` shows a live token count for every running agent so an
+operator can see who is burning context fast, who is near their budget, and
+who still has headroom, without opening a single log file.
+
+## What `bernstein status` shows
+
+```bash
+bernstein status                  # Rich table output
+bernstein status --json           # machine-readable JSON
+bernstein status --mode expert    # show all details
+bernstein status --mode novice    # minimal output
+```
+
+The Active Agents table has a `Tokens` column:
+
+| Display | Meaning |
+|---|---|
+| `-` | No tokens recorded yet for this agent. |
+| `12,480` | Tokens used so far; the agent has no configured budget (`token_budget == 0`, i.e. unlimited). |
+| `12,480/50,000` | Tokens used against a configured per-task budget. |
+
+With `--json`, the same numbers are in each entry of the `agents` array as
+`tokens_used`, `token_budget`, and `context_utilization_pct`.
+
+## Where the numbers come from
+
+Each running agent session writes token usage to a per-session sidecar file,
+`.sdd/runtime/<session_id>.tokens`. Once per orchestrator tick,
+`check_token_growth()` reads the bytes appended since the last tick from that
+file and writes the cumulative total onto the in-memory `AgentSession.tokens_used`
+field (`core/tokens/token_monitor.py`). The task server's `/status` route
+serves that live field straight through to `bernstein status`
+(`core/routes/status_dashboard.py`).
+
+`token_budget` is not something the agent reports about itself — it is the
+per-task budget the orchestrator computed from the task's scope at spawn time
+(`_max_tokens_per_task`, `core/agents/spawner_core.py`), stored on the same
+`AgentSession` record. A task with no configured scope budget keeps
+`token_budget == 0`, which the status view renders as "no budget" rather than
+`x/0`.
+
+`context_utilization_pct` is a related but separate figure: percentage of the
+model's context window currently in use, updated by the same tick
+(`_update_context_window_utilization`).
+
+## Budget nudge
+
+When `tokens_used` crosses 80% of a non-zero `token_budget`
+(`_DEFAULT_NUDGE_THRESHOLD_PCT`, `core/tokens/token_monitor.py`), the monitor
+sends the agent a one-time continuation nudge — a short message asking it to
+wrap up — and marks the session so the nudge does not repeat. The nudge is
+purely a runtime hint sent to the agent; nothing in the CLI display changes
+when it fires.
+
+## Relationship to the agent-level circuit breaker
+
+Progress tracking is passive: it counts and displays, and the nudge is
+advisory. Enforcement is a separate mechanism — the agent-level circuit
+breaker (`core/observability/circuit_breaker.py`) can terminate an agent that
+exceeds its session token limit. See
+[Observability overview - Circuit breakers](../operations/observability-overview.md#circuit-breakers)
+for what happens after the budget is exceeded.
+
+## Limitations
+
+- A task without a scope-derived budget shows only a running total, never a
+  ratio — there is no operator-facing way to force `bernstein status` to
+  display an arbitrary budget for an unbudgeted task.
+- The tick-based sidecar read means the displayed number can lag the agent's
+  true in-flight usage by up to one orchestrator tick.
+
+## Source
+
+- `src/bernstein/core/tokens/token_monitor.py` — `check_token_growth`, `read_tokens`, `_handle_budget_nudge`
+- `src/bernstein/core/tasks/models.py` — `AgentSession.tokens_used`, `AgentSession.token_budget`
+- `src/bernstein/core/routes/status_dashboard.py` — `/status` payload assembly
+- `src/bernstein/cli/status.py`, `src/bernstein/cli/commands/status_cmd.py`, `src/bernstein/cli/ui.py` — `bernstein status` command and table rendering
+- `src/bernstein/core/agents/spawner_core.py` — per-task token budget assignment

--- a/docs/operations/agent-loop-detection.md
+++ b/docs/operations/agent-loop-detection.md
@@ -1,0 +1,64 @@
+# Agent edit-loop detection
+
+An agent is "looping" when it edits the same file more than a few times in a
+short window - typically a fix-verify-fail cycle where the agent keeps
+re-editing without making progress. Bernstein tracks per-agent, per-file
+edit counts each tick and kills any agent that crosses the threshold, so the
+task can be retried or escalated instead of burning tokens indefinitely.
+
+Not to be confused with [Agent crash loops](agent_crash_loop.md), which
+covers a session repeatedly failing to *spawn* (a respawn budget with
+backoff and a parked state) - a different failure mode in a different
+module.
+
+Source: `src/bernstein/core/observability/loop_detector.py`
+(`LoopDetector.detect_loops`), applied by
+`src/bernstein/core/agents/agent_lifecycle.py`
+(`check_loops_and_deadlocks` → `_recover_loops`), called each tick from
+`core/orchestration/orchestrator.py`.
+
+## How it works
+
+1. Each tick, `_poll_file_mtimes` checks the modification time of every file
+   currently locked by an active agent. When a file's mtime has advanced
+   since the last poll, the edit is recorded against that agent
+   (`detector.record_edit(agent_id, file_path, mtime)`).
+2. `detect_loops()` prunes edit records older than the detection window and
+   counts edits per `(agent_id, file_path)` pair.
+3. Any pair whose count exceeds the threshold is reported as a
+   `LoopDetection` (agent id, file path, edit count, window).
+4. `_recover_loops` kills the offending agent, propagates the abort to any
+   child agents, clears its lock-wait state, and releases its file locks.
+
+```
+Loop detected: agent <id> edited '<path>' <N> times in <window>s - killing agent
+```
+
+## Thresholds
+
+| Constant | Default | Meaning |
+|---|---|---|
+| `LOOP_EDIT_THRESHOLD` | 3 | more than 3 edits (i.e. 4+) to the same file within the window trips detection |
+| `LOOP_WINDOW_SECONDS` | 300.0 | sliding window (5 minutes) edits are counted over |
+
+Both are module-level constants in `loop_detector.py`; they are not exposed
+through `bernstein.yaml`. Callers can pass different values directly to
+`detect_loops(threshold=..., window_seconds=...)`, but the orchestrator's
+built-in call uses the defaults.
+
+## What is not covered here
+
+The same module (`LoopDetector`) also implements **deadlock detection** -
+building a wait-for graph from active file locks and pending lock waits, and
+resolving cycles by releasing the oldest lock holder's lock. That is a
+separate row in the feature matrix and is out of scope for this page.
+
+## Limitations
+
+- Detection is mtime-based polling, not an edit-intent signal - a legitimate
+  agent that touches the same file many times in quick succession (e.g.
+  applying several small, correct fixes) can trip the same threshold as a
+  genuine fix-verify-fail cycle.
+- No per-project override surface today; changing the threshold or window
+  requires calling `detect_loops()` with explicit arguments from custom
+  orchestration code, not a config file.

--- a/docs/operations/backlog-sync.md
+++ b/docs/operations/backlog-sync.md
@@ -1,0 +1,78 @@
+# Backlog sync
+
+`bernstein sync` reconciles the file-backed backlog under `.sdd/backlog/`
+with the running task server: it creates a server task for every backlog
+file that isn't tracked yet, and moves the backlog files for finished tasks
+out of the way. It exists for the case where backlog `.yaml` / `.md` files
+were hand-authored or edited on disk (by a human or an agent) and need to be
+picked up without restarting the orchestrator.
+
+The command is registered but hidden from `bernstein --help` (`hidden=True`
+on the Click command); it is fully functional and safe to invoke directly.
+
+## Usage
+
+```bash
+bernstein sync
+bernstein sync --port 8052 --dir .
+```
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--port` | `8052` | Task server port. The command talks to `http://127.0.0.1:<port>`. |
+| `--dir` | `.` | Project root directory (parent of `.sdd/`). |
+
+Requires a reachable task server; if the server can't be reached the command
+reports "Cannot connect to task server - is it running?" and continues
+without creating tasks.
+
+## What it does
+
+1. Scans `.sdd/backlog/open/*.yaml`, `.sdd/backlog/open/*.md`, and
+   `.sdd/backlog/issues/*.yaml` / `*.md`.
+2. For each file, parses a `BacklogTask` (title, role, priority, scope,
+   complexity, description) and checks it against every task already on the
+   server (queried across `open`, `claimed`, `in_progress`, `done`, `failed`,
+   and `cancelled` status). A file is considered already-synced if its
+   normalised title *or* a slug derived from its filename matches an
+   existing server task's normalised title.
+3. New tasks are submitted in one batch via `POST /tasks/batch`; if the
+   server doesn't support batching (404), the command falls back to
+   creating them one at a time via `POST /tasks`. The originating filename
+   is appended to each task's description as `<!-- source: <file> -->` for
+   traceability.
+4. For tasks that have reached `done`, `failed`, or `cancelled` on the
+   server, the matching backlog file is moved out of
+   `.sdd/backlog/open/` or `.sdd/backlog/claimed/` into
+   **`.sdd/backlog/closed/`**.
+
+   Note: the command's own `--help` text and its terminal summary line both
+   say the file moves to `backlog/done/`. The directory `.sdd/backlog/done/`
+   is in fact created by the command, but nothing is ever written into it —
+   the real move target, per `_move_completed_files` in
+   `core/persistence/sync.py`, is `.sdd/backlog/closed/`. Look there, not in
+   `done/`, for files after a sync.
+
+5. Prints a summary: how many tasks were created, how many files were
+   skipped as already-synced, how many were moved to `closed/`, and any
+   per-file errors (unparseable file, failed HTTP call).
+
+## Deduplication
+
+Matching is fuzzy on purpose, so a backlog file surviving a rename doesn't
+get re-submitted as a duplicate task:
+
+- **Title match**: the file's parsed title, lower-cased and slugified, is
+  compared against every existing server task's title, slugified the same
+  way.
+- **Filename match**: the filename itself (numeric/priority prefixes like
+  `115-` or `p0_c1_030426_feat_` stripped, extension stripped) is compared
+  the same way, to catch files whose title text has since drifted from what
+  the server task was created with.
+
+## Source
+
+`src/bernstein/cli/commands/task_cmd.py` (`sync`, hidden Click command),
+`src/bernstein/core/persistence/sync.py` (`sync_backlog_to_server`,
+`BacklogTask`, `SyncResult`) — reachable at runtime via the back-compat
+alias `bernstein.core.sync`.

--- a/docs/operations/checkpoint.md
+++ b/docs/operations/checkpoint.md
@@ -1,0 +1,60 @@
+# Session checkpoint
+
+`bernstein checkpoint` writes a human-readable, point-in-time snapshot of
+session progress — what's done, what's in flight, what's next, and the
+current git SHA — to `.sdd/sessions/<timestamp>-checkpoint.json`.
+
+## Usage
+
+```bash
+bernstein checkpoint                 # snapshot now
+bernstein checkpoint --goal "ship the auth refactor"
+```
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--goal TEXT` | none | Goal label embedded in the checkpoint. |
+
+The command requires a reachable Bernstein task server (it queries
+`/tasks` for task status); it exits with an error if the server cannot be
+reached or rejects the request's credentials.
+
+## What gets captured
+
+The command queries the task server for tasks in `done`, `claimed`, and
+`in_progress`, and `open` status, resolves the current `git rev-parse HEAD`,
+and writes a `PartialState` record (internally aliased as `CheckpointState`
+for backward compatibility) with:
+
+| Field | Source |
+|---|---|
+| `timestamp` | Wall-clock time of the snapshot |
+| `goal` | `--goal`, or empty |
+| `completed_task_ids` | Tasks with status `done` |
+| `in_flight_task_ids` | Tasks with status `claimed` or `in_progress` |
+| `next_steps` | Titles of tasks with status `open` |
+| `git_sha` | Current `HEAD` commit |
+
+After writing, it prints a Rich summary panel to the terminal listing done,
+in-flight, and next-step tasks (next steps capped at 5 in the terminal view;
+the full list is in the JSON file).
+
+## What this is not
+
+A checkpoint file is explicitly **safe to lose** — it is an
+operator-visible progress export, not the crash-recovery mechanism. The
+canonical recovery state Bernstein uses to resume after a stop or crash is
+a separate structure (`Checkpoint` / write-ahead log), unrelated to this
+command's output.
+
+This command is also unrelated to
+[checkpointed retries](checkpointed-retries.md), which is about whether a
+*failed task's retry* can resume the adapter's native session (warm/fork/cold)
+— a per-task recovery decision, not a session-wide progress snapshot.
+
+## Source
+
+`src/bernstein/cli/commands/checkpoint_cmd.py`,
+`src/bernstein/core/persistence/session.py` (`CheckpointState` alias,
+`save_checkpoint`), `src/bernstein/core/persistence/checkpoint.py`
+(`PartialState`).

--- a/docs/operations/commit-attribution.md
+++ b/docs/operations/commit-attribution.md
@@ -1,0 +1,86 @@
+# Commit attribution stats
+
+`bernstein commit-stats` reports git commit counts and line churn grouped by
+agent role, so an operator can see which roles (backend, qa, security, ...)
+produced how much of a repository's history without hand-parsing `git log`.
+
+## CLI
+
+```bash
+bernstein commit-stats                     # all-time stats for the current repo
+bernstein commit-stats --since 2025-01-01  # date-bounded stats
+bernstein commit-stats --until 2025-06-30  # date-bounded stats
+bernstein commit-stats --repo-dir ../other-repo
+bernstein commit-stats --json              # machine-readable output
+```
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--since TEXT` | none | Passed straight to `git log --since`. |
+| `--until TEXT` | none | Passed straight to `git log --until`. |
+| `--repo-dir PATH` | `.` | Repository to run `git log` against. |
+| `--json` | off | Print `CommitStatsResult.to_dict()` instead of a Rich table. |
+
+Output is a table with one row per role, plus a totals row: commit count,
+lines added, lines deleted.
+
+## How role is determined
+
+There is no task/role metadata behind this command — it is entirely a git
+`author` string heuristic. For every commit, `bernstein` lowercases the
+author's `name <email>` string and checks it for one of a fixed set of
+keywords:
+
+```
+backend, frontend, qa, security, devops, docs, manager, architect
+```
+
+The first keyword found in the author string becomes that commit's role. If
+none match, the role label is the full lowercased author string (so a human
+contributor's commits show up under their own name/email rather than being
+dropped).
+
+Practical effect: this only produces meaningful role buckets when agent
+commits carry a role-tagged author identity (for example
+`backend-agent <backend@bernstein.local>`). A human co-author whose name or
+email happens to contain one of the keywords (e.g. a teammate named
+"Devora" would not match, but an email containing `devops` would) is
+attributed to that role bucket rather than to themselves — the heuristic
+does not distinguish humans from agents.
+
+## Data source
+
+Two `git log` invocations against `--repo-dir` (default: the current
+directory):
+
+1. `git log --numstat --format=%an <%ae> --date=short` — line-level added/
+   deleted counts per commit, attributed by author.
+2. `git log --format=%an <%ae>` — a plain commit count per author.
+
+Both respect `--since`/`--until` when given. If `git` is not installed or the
+directory is not a repository, the command exits non-zero and prints the
+underlying error (or the `error` field, in `--json` mode).
+
+## Also surfaced in `bernstein doctor`
+
+`bernstein doctor` runs the same `collect_commit_stats()` call (unfiltered by
+date) as one of its checks, labelled **Commit attribution**. It reports
+`{total commits}: {role}: {commits} commits, +{added}/-{deleted}` per role for
+info, or the underlying git error if the check fails.
+
+## Limitations
+
+- Role attribution is a keyword match on the author string, not a link to
+  Bernstein's actual per-task role assignment — it will misattribute any
+  author whose name or email happens to contain a role keyword.
+- No de-duplication or merge-commit filtering: line counts come straight from
+  `git log --numstat`, so squash/merge history affects the totals the same
+  way it affects `git log` itself.
+
+## Source
+
+- `src/bernstein/cli/commit_stats.py` — `collect_commit_stats`,
+  `_author_to_role`, `render_commit_stats`
+- `src/bernstein/cli/commands/status_cmd.py` — `commit_stats_cmd` (`bernstein
+  commit-stats`), `_doctor_check_commit_attribution` (`bernstein doctor`
+  integration)

--- a/docs/operations/content-credentials.md
+++ b/docs/operations/content-credentials.md
@@ -1,0 +1,74 @@
+# C2PA content credentials
+
+Bernstein already writes a signed, Merkle-chained lineage spine for every
+artifact a run produces (see [Lineage v1](../lineage.md)).
+`bernstein credential emit` and `bernstein credential
+verify` turn that spine into a machine-readable
+[C2PA](https://c2pa.org/) 2.2 manifest an operator can publish alongside
+media or documents, so a downstream verifier can check provenance without
+trusting Bernstein's word for it.
+
+The manifest is a **projection** of the spine, not a separately-asserted
+label: with no lineage entry for the artifact, there is nothing to project,
+so `emit` fails rather than fabricating an unsigned credential.
+
+## Emitting a credential
+
+```
+bernstein credential emit ARTIFACT --run-id RUN_ID [--workdir DIR] [--json]
+```
+
+Reads the lineage spine for `RUN_ID`, projects `ARTIFACT`'s subtree of spine
+entries into a C2PA manifest, and signs it with the install-identity Ed25519
+key. By default the manifest is written next to the artifact as
+`<artifact>.c2pa.json`; `--json` prints the manifest to stdout instead of
+writing a file. Exit codes: `0` written, `1` no lineage entry for the
+artifact or bad input (e.g. the artifact path resolves outside the workspace
+root).
+
+The manifest carries:
+
+- a **hard binding** assertion (`c2pa.hash.data`) — the spine entry's content
+  hash, binding the manifest to the exact bytes the chain recorded;
+- an **AI actions** assertion (`c2pa.actions`) — the producing model and
+  actor, drawn from the spine entry;
+- an optional **soft binding** assertion (`c2pa.soft-binding`), emitted only
+  when a watermark or fingerprint layer is plugged in — the projection does
+  not couple to any one watermarking scheme.
+
+## Verifying a credential
+
+```
+bernstein credential verify ARTIFACT [--workdir DIR] [--manifest PATH]
+```
+
+Re-reads the manifest (defaults to `<artifact>.c2pa.json`, override with
+`--manifest`), recomputes the hard-binding hash from the artifact's current
+bytes, and checks the Ed25519 signature against the install identity. Exit
+codes: `0` OK (hard binding matches, signature chains to the install
+identity), `1` bad input (no manifest at the expected path, or the manifest
+does not parse), `2` verification failed (hash mismatch or bad signature —
+the artifact was edited after the credential was issued, or the credential
+was forged).
+
+## Guarantees
+
+- **Determinism.** `project_manifest` is a pure function of its inputs — it
+  never reads a clock, environment, or socket. The canonical signing bytes
+  are sorted-key, compact-separator JSON, and Ed25519 signing is
+  deterministic (RFC 8032), so two replays of the same run produce
+  byte-identical manifests, including assertion order and signature bytes.
+- **One attestation root.** Both "who ran this" (the install identity) and
+  "what was produced" (the content credential) are covered by the same
+  Ed25519 key, so a verifier checks one signature to trust both claims.
+- **Unproducible without provenance.** `emit` cannot manufacture a credential
+  for an artifact with no lineage-spine entry; the projection has nothing to
+  draw from, so it raises rather than emitting an unsigned or fabricated
+  label.
+
+## Source
+
+`src/bernstein/cli/commands/credential_cmd.py` (CLI),
+`src/bernstein/core/lineage/c2pa.py` (manifest projection, signing,
+verification), `src/bernstein/core/lineage/spine.py` (the lineage spine the
+manifest projects from).

--- a/docs/operations/cost-anomaly-detection.md
+++ b/docs/operations/cost-anomaly-detection.md
@@ -1,0 +1,113 @@
+# Cost anomaly detection
+
+`CostAnomalyDetector` watches a run's budget burn rate and, when spend
+crosses configured thresholds, logs a warning or stops the orchestrator from
+spawning new agents. It is decoupled from `orchestrator.py` to avoid
+circular imports and is wired into the orchestrator's slow tick path.
+
+Source: `src/bernstein/core/cost/cost_anomaly.py` (`CostAnomalyDetector`),
+`src/bernstein/core/tasks/models.py` (`CostAnomalyConfig`).
+
+## What actually runs today
+
+`CostAnomalyDetector` implements five detection rules, but only one is
+currently invoked by the orchestrator:
+
+| Rule | Method | Wired into the tick loop? |
+|---|---|---|
+| `burn_rate` | `check_tick()` → `_check_burn_rate()` | **Yes** - called every slow tick |
+| `per_task_ceiling` | `check_task_completion()` | No - method exists, no caller |
+| `token_ratio` | `check_task_completion()` | No - method exists, no caller |
+| `retry_spiral` | `check_task_completion()` | No - method exists, no caller |
+| `model_mismatch` | `check_spawn()` | No - method exists, no caller |
+
+`check_task_completion()` and `check_spawn()` are public methods on
+`CostAnomalyDetector` and are exercised by unit tests, but nothing in the
+orchestrator currently calls them at task-completion or spawn time. Only
+`check_tick()` (burn rate against the run's budget) is on the live path, via
+`orchestrator.py`'s slow-tick branch:
+
+```python
+if _run_slow:
+    for sig in self._anomaly_detector.check_tick(list(self._agents.values()), self._cost_tracker):
+        self._handle_anomaly_signal(sig)
+```
+
+## Burn-rate detection (the live path)
+
+Each slow tick, the detector computes `spent_usd / budget_usd * 100` from
+the run's cost tracker and compares it against two percentage thresholds:
+
+| Threshold | Default | Action |
+|---|---|---|
+| `budget_warn_pct` | 60% | log a warning |
+| `budget_stop_pct` | 90% | `stop_spawning` |
+
+`stop_spawning` sets `self._stop_spawning = True` on the orchestrator, which
+halts new agent spawns; agents already running are not killed. Each signal
+is cooled down independently per rule (`kill_agent`: no cooldown,
+`stop_spawning`: 60s, `log`: 300s) so the same condition doesn't spam a
+warning every tick.
+
+## Baseline (used by the non-wired rules)
+
+The detector maintains a rolling per-complexity-tier cost baseline
+(`.sdd/metrics/cost_baseline.json`, last 50 tasks by default) with median
+and p95 cost per tier, plus a median/p95 output/input token ratio. This
+baseline is what `per_task_ceiling` and `token_ratio` would compare against
+if their calling methods were wired in. It is **not** a Z-score model - the
+comparisons are ratio-to-median and percentile-based
+(`statistics.median`, nearest-rank percentile), computed from
+`CostBaseline`/`TierStats`.
+
+## Configuration
+
+`CostAnomalyConfig` (`core/tasks/models.py`) defines every threshold:
+
+| Field | Default | Meaning |
+|---|---|---|
+| `enabled` | `true` | master switch |
+| `per_task_multiplier` | 3.0 | (unused rule) warn threshold vs tier median |
+| `per_task_critical_multiplier` | 6.0 | (unused rule) kill threshold vs tier median |
+| `budget_warn_pct` | 60.0 | burn-rate warn threshold |
+| `budget_stop_pct` | 90.0 | burn-rate stop-spawning threshold |
+| `token_ratio_max` | 5.0 | (unused rule) output/input ratio kill threshold |
+| `token_ratio_min_tokens` | 5000 | (unused rule) minimum tokens before the ratio check applies |
+| `retry_cost_multiplier` | 2.0 | (unused rule) cumulative-retry-cost multiplier |
+| `baseline_window` | 50 | recent tasks kept for baseline statistics |
+| `baseline_min_samples` | 5 | minimum samples per tier before ceiling checks would activate |
+
+**This config is not currently exposed through `bernstein.yaml`.**
+`OrchestratorConfig.cost_anomaly` is a dataclass field with
+`default_factory=CostAnomalyConfig`, but the orchestrator's config
+construction (`orchestrator.py`, the `OrchestratorConfig(...)` call built
+from the parsed run seed) does not pass a `cost_anomaly` value through, so
+every run uses the defaults above. Changing a threshold today means
+constructing `CostAnomalyDetector` with a different `CostAnomalyConfig`
+programmatically - there is no `bernstein.yaml` key or CLI flag for it yet.
+
+## Output
+
+Every signal (fired or not - only fired signals reach this path) is appended
+to `.sdd/metrics/anomalies.jsonl` via `record_signal()`, one JSON object per
+line with `rule`, `severity`, `action`, `agent_id`, `task_id`, `message`,
+`details`, and `timestamp`. There is no CLI command or HTTP route that reads
+this file back today; inspect it directly (`tail -f .sdd/metrics/anomalies.jsonl`)
+or via the orchestrator's log warnings.
+
+## Limitations
+
+- Only burn-rate detection is live. Per-task cost ceilings, token-ratio
+  spikes, retry-cost spirals, and model/complexity mismatches are
+  implemented and unit-tested but not invoked by the orchestrator.
+- Thresholds are fixed at their dataclass defaults; no `bernstein.yaml`
+  surface exists to tune them per project.
+- No CLI or HTTP surface reads `anomalies.jsonl` back; it is a write-only
+  log today.
+
+## Related
+
+- [Cost-aware scheduling](cost-aware-scheduling.md) - the separate,
+  configurable USD-ceiling policy layer that halts dispatch before a task
+  starts (a different mechanism from this tick-based burn-rate check).
+- [Cost optimization](cost-optimization.md) - general cost-control levers.

--- a/docs/operations/cost-envelopes.md
+++ b/docs/operations/cost-envelopes.md
@@ -1,0 +1,94 @@
+# Cost envelopes
+
+A **quota envelope** tags spend against a named budget bucket - for
+example `subscription` (the default) versus a metered API pool - so
+operators can cap and report spend per bucket instead of only in
+aggregate. Every recorded LLM call carries a `quota_envelope` tag; the
+rollup in `core/cost/cost_rollup_by_envelope.py` aggregates the ledger by
+that tag into per-envelope spend, cap, and burn-rate reports.
+
+Envelopes are distinct from the [task-budgets countdown](../concepts/task-budgets.md)
+(the per-turn token/dollar/step banner shown to the model) and from
+[cost-aware scheduling](cost-aware-scheduling.md) (the pre-dispatch price-table
+policy layer). Envelopes answer "how much has bucket X spent, and against
+what cap", after the fact or live from the ledger - no scheduling decision
+depends on them.
+
+## Configuring envelopes
+
+Declare envelopes under `cost.envelopes` in `bernstein.yaml`:
+
+```yaml
+cost:
+  envelopes:
+    subscription:
+      budget_usd: 50.0        # soft cap; 0 = unlimited
+      hard_budget_usd: 0.0    # hard cap; 0 = unlimited
+      threshold_pct: 0.8      # default: 0.80
+      model_allowlist: []     # empty = any model permitted
+    ci-metered:
+      budget_usd: 20.0
+      hard_budget_usd: 25.0
+      model_allowlist: ["haiku"]
+```
+
+Calls tag their envelope by passing `quota_envelope=` to
+`CostTracker.record()` (default: `"subscription"`, `DEFAULT_QUOTA_ENVELOPE`).
+An envelope observed in the ledger but absent from `cost.envelopes` still
+appears in reports as an uncapped bucket.
+
+## Viewing the rollup
+
+```
+bernstein cost-envelopes show [--ledger PATH] [--config PATH] [--last 1h|24h|7d|30d] [--json]
+```
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--ledger` | `.sdd/cost/ledger.jsonl` | Rolling spend ledger to read. |
+| `--config` | `bernstein.yaml` | File holding the `cost.envelopes` block. |
+| `--last` | none | Restrict to a time window (`1h`, `24h`, `7d`, `30d`). |
+| `--json` | off | Emit raw JSON instead of the Rich table. |
+
+The table shows, per envelope: spent, cap, percent used, hard cap, call
+count, and a status column (`ok`, `threshold`, or `HARD BREACH`).
+
+Per-envelope spend is also available as a grouping dimension on the
+general cost report:
+
+```
+bernstein cost --by envelope
+```
+
+## How it behaves
+
+- **Rollup is a pure aggregation.** `cost_rollup_by_envelope.rollup()`
+  takes a list of `TokenUsage` records and an optional envelope-config
+  mapping and returns one `EnvelopeRollupRow` per envelope - it does not
+  read the ledger or config itself; the CLI command wires those in.
+- **Soft cap (`budget_usd`)** drives `pct_used` and `threshold_reached`
+  (fires once `pct_used >= threshold_pct`, default 80%). It is advisory:
+  exceeding it does not block anything by itself.
+- **Hard cap (`hard_budget_usd`)** is enforced live, at record time, by
+  `CostTracker.record()` - not by the rollup. A call that would push an
+  envelope's cumulative spend past its hard cap raises
+  `EnvelopeBudgetError` before the call is recorded. A model outside an
+  envelope's `model_allowlist` is refused the same way.
+  `cost_rollup_by_envelope` separately reports `hard_breached=True` for
+  envelopes already over their hard cap in the ledger, for
+  reporting/dashboard purposes.
+- **Forecast-to-cap** is a linear extrapolation (`remaining_usd /
+  burn_rate_usd_per_sec`) using the burn rate observed across the
+  ledger records in view. It returns `None` (rendered as `"--"`) when
+  fewer than two records exist or the observed window collapses to a
+  point - the rollup never prints a projection it cannot support.
+- **Unconfigured envelopes are never dropped.** An envelope name seen in
+  the ledger but missing from `cost.envelopes` still gets a rollup row
+  (`cap=0.0`, i.e. unlimited), so a config gap doesn't silently hide
+  spend.
+
+## Source
+
+- Rollup: `src/bernstein/core/cost/cost_rollup_by_envelope.py`
+- Envelope config + live hard-cap enforcement: `src/bernstein/core/cost/cost_tracker.py` (`EnvelopeConfig`, `CostTracker.record`)
+- CLI: `src/bernstein/cli/commands/cost.py` (`cost_envelopes_group`)

--- a/docs/operations/debug-bundle.md
+++ b/docs/operations/debug-bundle.md
@@ -1,0 +1,81 @@
+# Debug bundle
+
+`bernstein debug bundle` collects a self-contained, redacted ZIP — config,
+recent traces, metrics, and log tails — that an operator can attach to a bug
+report without manually gathering files or hand-checking them for secrets.
+
+## CLI
+
+```bash
+bernstein debug bundle                              # bundle the most recent run
+bernstein debug bundle --task <task-id>              # filter traces/metrics to one task
+bernstein debug bundle --run <run-id>                # filter to one run
+bernstein debug bundle --out mybundle.zip            # explicit output path
+bernstein debug bundle --manifest-only               # print the manifest, write no ZIP
+bernstein debug bundle --include-source-snippets 5    # also include the 5 most-recently-changed src/ files
+```
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--task TEXT` | none | Task id to filter traces/metrics by. |
+| `--run TEXT` | none | Run id to filter traces/metrics by. |
+| `--last / --no-last` | `--last` | Use the most recent run. |
+| `--out`, `-o PATH` | timestamped file in CWD | Destination ZIP path. |
+| `--manifest-only` | off | Print the manifest JSON to stdout instead of writing a ZIP. |
+| `--include-source-snippets N` | `0` (off) | Include the N most-recently-changed `src/` files. |
+
+## Bundle contents
+
+Every text artefact is passed through the secret-redaction pipeline
+(`core/security/redactor.py`) before being written:
+
+| Path in ZIP | Contents |
+|---|---|
+| `manifest.json` | Bernstein version, Python version, OS, install method, the selection used (task/run/last), file count, redaction count. |
+| `bernstein.yaml` | Redacted copy of the project config. |
+| `doctor.json` | Output of `bernstein doctor --json`. |
+| `traces/` | Recent `.sdd/traces/` entries for the selected task/run. |
+| `metrics/` | Recent `.sdd/metrics/` entries for the same window. |
+| `logs/` | Last 200 lines of each `.sdd/runtime/*.log`. |
+| `source/` (optional) | The N most-recently-changed git-tracked files under `src/`, only when `--include-source-snippets` is set. |
+
+## Redaction
+
+Text artefacts go through `bernstein.core.security.redactor`, which:
+
+- Blanks API keys, tokens, secrets, passwords, bearer headers, JWTs, SSH
+  keys, and URL-embedded credentials.
+- Collapses absolute paths under `$HOME` to `~`.
+- Strips the values of environment variables whose names contain
+  `KEY`/`TOKEN`/`SECRET`/`PASSWORD` from `NAME=value` / `NAME: value`
+  text dumps.
+
+The manifest records `redactions_applied`, a total count of substitutions
+made across every text artefact in the bundle, so the operator sending the
+bundle can see at a glance how many patterns were caught.
+
+## Legacy alias: `bernstein debug-bundle`
+
+A separate, older entry point, `bernstein debug-bundle`, still exists
+(`cli/commands/debug_cmd.py`). It runs an interactive confirmation prompt by
+default and uses its own bundle builder
+(`core/observability/debug_bundle.py`), which shares the same redaction
+pattern set but has a smaller flag surface:
+
+```bash
+bernstein debug-bundle                # prompts for confirmation
+bernstein debug-bundle --yes          # skip the prompt
+bernstein debug-bundle --output FILE  # explicit output path
+bernstein debug-bundle --extended     # include full (untruncated) logs
+```
+
+It does not support task/run filtering or `--include-source-snippets`.
+`bernstein debug bundle` (the group command above) is the actively developed
+path; the flat `debug-bundle` alias is kept for backward compatibility.
+
+## Source
+
+- `src/bernstein/cli/debug_bundle.py` — `bernstein debug bundle`, manifest schema, selection logic, ZIP assembly
+- `src/bernstein/cli/commands/debug_cmd.py` — legacy `bernstein debug-bundle` alias
+- `src/bernstein/core/observability/debug_bundle.py` — legacy bundle builder and shared redaction pattern set
+- `src/bernstein/core/security/redactor.py` — text redaction wrapper used by the current bundle path

--- a/docs/operations/delegation-verify.md
+++ b/docs/operations/delegation-verify.md
@@ -1,0 +1,112 @@
+# Delegation chain verification
+
+A run that fans out work carries delegated authority down the chain:
+`principal -> orchestrator -> sub-agent`. Bernstein records two independent,
+offline-verifiable trails of that authority — a per-hop receipt ledger (the
+"ACT log": which principal authorized which sub-agent action) and a signed
+capability-token chain (scoped, attenuating authority grants). `bernstein
+delegation verify` and `bernstein delegation verify-token` check each trail
+with no network call, no live coordinator, and no registry lookup.
+
+The two surfaces are deliberately not coupled. A receipt may later reference
+a token hash, but each verifies from its own bytes alone.
+
+## `bernstein delegation verify` — the per-hop receipt chain
+
+```
+bernstein delegation verify RUN [--root DIR] [--json]
+```
+
+Reconstructs the delegation receipt ledger for `RUN` from
+`<root>/delegation/<run_id>.jsonl` (`--root` defaults to `.sdd/audit`) and
+verifies it hop by hop. Each receipt line binds `{run_id, hop_index, issuer,
+subject, audience, act, created, prev_hmac, hmac}`; the HMAC covers the
+previous receipt's HMAC concatenated with the canonical JSON of the current
+receipt's body, using the install-scoped audit key
+(`load_or_create_audit_key`) — the same construction as the main HMAC audit
+chain.
+
+Human output prints one line per hop (`issuer -> audience (act)`) followed by
+a pass/fail summary. `--json` emits:
+
+```json
+{"run": "...", "valid": true, "hops": 3, "errors": [], "receipts": [
+  {"hop_index": 0, "issuer": "...", "subject": "...", "audience": "...", "act": "..."}
+]}
+```
+
+Exit codes: `0` when the chain is intact (at least one hop, every hop
+verifies from genesis to tail); `1` when there are zero receipts for the run,
+or any hop fails (HMAC mismatch from a tampered field, a deleted hop, or the
+wrong key).
+
+Receipts are written by calling `DelegationLedger.record_hop` (or its
+convenience wrapper `record_delegation_hop`) for each
+`principal -> orchestrator -> sub-agent` handoff — there is no
+`delegation emit` CLI verb; an operator only verifies, never hand-authors a
+receipt. **Limitation:** as of this writing, no orchestration code path in
+this codebase calls `record_delegation_hop`; the ledger and its verifier are
+exercised directly by unit tests. Until a caller wires the write path into a
+real run, `bernstein delegation verify <run>` against a live run's default
+root correctly reports "no receipts" (exit 1) rather than a populated chain.
+
+## `bernstein delegation verify-token` — the capability-token chain
+
+```
+bernstein delegation verify-token TOKEN_FILE [--trust-anchor FILE ...] [--json]
+```
+
+Verifies a signed `CapabilityChain` read from `TOKEN_FILE`, fully offline.
+For every hop it checks:
+
+- the Ed25519 signature (detached JWS, RFC 7515 §A.5, over JCS-canonical
+  bytes) against the `issuer_pubkey` and `subject_pubkey` captured at mint
+  time — key rotation after minting never invalidates a historical token;
+- structural linkage (`parent_token_hash`) and identity/pubkey continuity
+  (the issuer of hop N must equal the subject of hop N-1);
+- monotonic attenuation — every caveat (`permissions`, `task_ids`,
+  `path_prefixes`, `not_after`, `max_uses`, `remaining_depth`) must narrow
+  or stay equal at each hop, never widen;
+- root trust-anchor membership.
+
+`--trust-anchor` is repeatable and takes PEM public-key files; with none
+given, the command falls back to the local agent-card keystore's public key
+as the default anchor. If that keystore is missing or unreadable, the anchor
+set is empty and the root-anchor check fails loudly rather than trusting an
+unknown root.
+
+Human output prints one `PASS`/`FAIL` line per hop plus the resolved
+authority path (`issuer -> issuer -> ... -> leaf`). `--json` emits:
+
+```json
+{"valid": true, "principal_path": ["...", "..."], "hops": [
+  {"hop_index": 0, "issuer": "...", "subject": "...", "ok": true, "errors": []}
+]}
+```
+
+Exit codes: `0` only when every hop verifies; `1` on any failing hop, an
+empty chain, or an unreadable/malformed token file.
+
+## What this does not cover
+
+- **Native subagent delegation** (`core/agents/subagent_delegation.py`,
+  Claude Code's `--agents` flag and similar per-adapter mechanisms) has no
+  dedicated CLI verb — it is an internal API called by the scheduler's
+  dispatch path. Verifying a run's subagent-delegation boundaries means
+  replaying its journal (see
+  [Deterministic replay](deterministic-replay.md)) and, where an audit chain
+  was wired in, checking `bernstein audit verify` for the mirrored
+  `subagent.delegation` events. See
+  [Native subagent delegation](../architecture/subagent-delegation.md).
+- `bernstein delegation verify <run>` and `bernstein delegation verify-token`
+  cover different surfaces on purpose — do not read a passing `verify-token`
+  result as proof of the receipt chain, or vice versa.
+
+## Source
+
+`src/bernstein/cli/commands/delegation_cmd.py` (CLI),
+`src/bernstein/core/identity/delegation.py` (per-hop receipt ledger),
+`src/bernstein/core/security/capability_tokens.py` (attenuated capability
+tokens). See also
+[Security & identity stack](security-and-identity.md) for the token
+attenuation model in depth.

--- a/docs/operations/evidence-bundles.md
+++ b/docs/operations/evidence-bundles.md
@@ -1,0 +1,123 @@
+# Verification evidence bundles
+
+A completed task's proof-of-done artefacts - test output, coverage, lint,
+an optional screenshot or recording - are content-addressed, sealed into a
+signed bundle, and anchored in a dedicated lineage spine, so the bundle a
+reviewer inspects *is* the receipt rather than a log line describing one.
+
+```
+bernstein evidence show <task>
+bernstein evidence verify <task>
+```
+
+## Why
+
+"Done" is normally a status plus scattered logs: the test-runner output, the
+coverage report, and any screenshot die with the worktree once the task is
+reaped. This module makes the artefact a reviewer consumes at review time be
+the proof - every producer output is stored content-addressed, bound into a
+signed record, and anchored in the evidence lineage spine, so a tampered
+evidence file is detected exactly like a tampered chain entry.
+
+## Declaring evidence producers
+
+A task opts in by declaring `evidence_producers` in its spec - a list of
+producers, each with a `name`, a `kind`, a `command` (argv, no shell), and a
+`required` flag:
+
+| Kind | Notes |
+|---|---|
+| `test`, `coverage`, `lint`, `generic` | Plain producers; output is captured stdout+stderr. |
+| `screenshot`, `recording` | Media producers; additionally sealed with a signed C2PA content credential. |
+
+`required: true` (the default) means a non-zero exit blocks the gate
+verdict; `required: false` (advisory) never blocks - a failure only attaches
+a failure record. A task that declares no producers is a zero-touch no-op:
+no gate runs, no directory is created.
+
+## Sealing (automatic, fail-open)
+
+The orchestrator seals a bundle for every task that reaches the terminal
+completed state, right before its worktree is reclaimed
+(`seal_evidence_on_completion` in `core/evidence/completion_gate.py`). Each
+declared producer's command runs (default timeout 600s), its output is
+stored content-addressed and capped at 1 MiB per blob, and the items are
+bound into a canonical, Ed25519-signed record anchored in the evidence
+lineage spine (`core/lineage/spine.py`). The bundle is mirrored into the
+HMAC audit chain as an evidence-bundle event.
+
+Sealing is deliberately **fail-open**: it must never block, delay, or fail a
+task completion. Any error raised while running or sealing producers is
+caught, logged, and swallowed, so completion proceeds unchanged. The gate
+verdict (`gate_passed`) is recorded in the bundle for the reviewer but is not
+retroactively enforced against the task the orchestrator already accepted.
+
+The gate verdict itself is `gate_passed = all(required producers passed)`;
+advisory producer failures never affect it.
+
+## Inspecting and verifying a bundle
+
+```
+bernstein evidence show <task>
+bernstein evidence verify <task>
+```
+
+`bernstein evidence show <task>` renders the sealed bundle: gate verdict,
+bundle hash, spine anchor, and a per-producer table (kind, required or
+advisory, pass/fail, exit code, stored size, content hash). `-w/--workdir`
+sets the project root (default `.`). Exit `0` when a bundle exists, `1`
+when there is none.
+
+`bernstein evidence verify <task>` recomputes the bundle offline from the
+sealed record and the stored blobs alone:
+
+1. Checks the Ed25519 signature over the canonical binding.
+2. Verifies the evidence lineage spine and the bundle's spine anchor.
+3. Re-hashes every stored evidence blob against the sealed manifest -
+   naming any item whose content diverges.
+4. For media items, re-verifies the signed C2PA content credential against
+   the stored media bytes.
+
+Exit codes: `0` verified, `1` no bundle, `2` mismatch (a tampered evidence
+file, bundle, or spine). `bernstein audit verify` runs the same integrity
+check across every evidence bundle in a project, alongside every other
+chained receipt.
+
+## Where evidence lives
+
+```
+.sdd/evidence/bundles/<task>.json           # sealed bundle (one per task)
+.sdd/evidence/blobs/<hex[:2]>/<hex>          # content-addressed producer output
+.sdd/lineage/evidence/spine.jsonl            # evidence lineage spine (Merkle + HMAC)
+```
+
+Blob storage is idempotent (an identical blob is written once) and garbage
+collected: `EvidenceStore.gc()` removes any blob not referenced by a live
+bundle.
+
+## Relationship to the in-process verification gate
+
+`bernstein evidence show` / `verify` is the offline-authoritative surface
+for a bundle; the in-process verification-gate hooks (which enforce a
+task's write-path allowlist from `owned_files` and its required
+`evidence_producers` at spawn time) are a separate, earlier-stage
+enforcement layer. See [Hook gate](hook-gate.md).
+
+## Limitations
+
+- Producer output is capped at 1 MiB per blob; output beyond the cap is
+  truncated before it is hashed and stored (the truncation is recorded on
+  the item, not silently dropped).
+- Sealing is fail-open by design: a producer or sealing failure never fails
+  the task completion it was meant to attach evidence to - it only means no
+  bundle (or a partial one) exists for a reviewer to inspect.
+
+## Source
+
+- `src/bernstein/core/evidence/bundle.py` - `EvidenceProducer`,
+  `EvidenceBundle`, `EvidenceStore`, `build_evidence_bundle`,
+  `run_evidence_gate`, `verify_evidence_bundle`.
+- `src/bernstein/core/evidence/completion_gate.py` -
+  `seal_evidence_on_completion`, the fail-open orchestrator wiring.
+- `src/bernstein/cli/commands/evidence_cmd.py` - `bernstein evidence show`
+  / `verify`.

--- a/docs/operations/fleet-steering.md
+++ b/docs/operations/fleet-steering.md
@@ -1,0 +1,110 @@
+# Fleet steering
+
+Pause, resume, redirect, send guidance to, or abort a single running worker
+mid-task, with every intervention recorded as a signed receipt before its
+effect runs.
+
+```
+bernstein fleet steer <task_id> <pause|resume|guidance|redirect|abort> [flags]
+```
+
+## Why
+
+Once a worker is running a task, an operator has no mid-task controls by
+default: no pause, no way to queue guidance, no redirect of the objective, no
+clean abort. Any ad hoc intervention - editing files under a worker, killing
+its process - leaves no record, so an audited run a human touched can no
+longer be explained end to end. Fleet steering closes that gap without
+weakening the run's verifiability: **a steering action is a receipt first
+and an effect second.**
+
+## Command
+
+```bash
+bernstein fleet steer <task_id> pause --session-id <sid> [--reason "..."]
+bernstein fleet steer <task_id> resume
+bernstein fleet steer <task_id> guidance --guidance "watch the retry budget"
+bernstein fleet steer <task_id> redirect --redirect-target "fix the auth path instead"
+bernstein fleet steer <task_id> abort --session-id <sid> [--reason "..."]
+```
+
+| Flag | Applies to | Meaning |
+|---|---|---|
+| `--guidance TEXT` | `guidance` | Free-text guidance delivered to the worker. Required for this kind; rejected for every other kind. |
+| `--redirect-target TEXT` | `redirect` | The new objective. Required for this kind; rejected for every other kind. |
+| `--reason TEXT` | `pause` / `abort` | Optional human-readable reason. |
+| `--session-id ID` | `pause` / `abort` | The worker session the effect targets. Required for these two kinds (they act on the worker process); ignored for the mailbox-only kinds. |
+| `--adapter NAME` | `pause` | Adapter owning the session (used for the pause checkpoint). |
+| `--worktree PATH` | `pause` | Worktree path (used as the pause checkpoint baseline). |
+| `--principal NAME` | all | Declared operator seat, loopback attribution only (default `cli-operator`). |
+| `--server URL` | all | Task server URL (default `$BERNSTEIN_SERVER_URL`). |
+| `--token TOKEN` | all | Operator-scoped token (default `$BERNSTEIN_AUTH_TOKEN`). |
+| `--json` | all | Emit the raw receipt JSON instead of a summary line. |
+
+Every text field (`guidance`, `redirect_target`, `reason`) is capped at 2048
+UTF-8 bytes.
+
+## How it behaves
+
+The CLI computes the command's payload hash locally, then `POST`s the
+command to `/tasks/<task_id>/steer` on the task server. The server does the
+same four steps, in this exact order:
+
+1. **Validate.** The command shape is checked (right fields for the kind,
+   size caps). A `pause` or `abort` without `--session-id` is rejected here.
+2. **Authorize.** Only the read-write `operator` token scope may steer; a
+   `viewer` scope or an absent credential is denied and the denial is
+   recorded if a denial tracker is wired.
+3. **Bind the receipt.** The confirmed command payload is hashed and bound
+   into the HMAC audit chain as a `steering.receipt` event **before any
+   effect runs.** If the CLI's locally-computed payload hash doesn't match
+   what the server executes, the request is rejected with no receipt and no
+   effect.
+4. **Apply the effect**, referencing the just-written receipt hash:
+   - `guidance` / `redirect` are delivery-only: posted to the task's mailbox
+     as a `steer.guidance` / `steer.redirect` message.
+   - `pause` captures a resumable checkpoint (adapter session + workspace
+     baseline), writes a `PAUSE` signal file under
+     `<signals_dir>/<session_id>/`, and parks the task's claim so the
+     scheduler stops dispatching it.
+   - `resume` reads the parked checkpoint, clears the `PAUSE` signal, and
+     re-grants the claim.
+   - `abort` writes a `SHUTDOWN` signal file under the target session's
+     directory - a filesystem fact the worker/adapter honours out of band,
+     never routed through the model.
+
+Delivery rides the task's existing mailbox journal, so guidance and redirect
+messages reach the worker in chain append order, exactly once, even
+mid-tool-call. The worker consumes pending steering messages
+(`consume_steering()`) and records each one as a first-class step in its
+per-step journal, binding the step hash to the receipt hash. **A message
+whose receipt cannot be found on the chain is rejected outright** - no
+effect, no journal row - so an effect can never exist without a matching
+receipt.
+
+## Replay classification
+
+Because every consumed steering message is a journal step, a steered run
+replays byte-identically and is distinguishable from a tampered one:
+`classify_steering_run()` reads a worker's journal and returns one of:
+
+- `clean` - the journal's Merkle chain verifies and carries no steering
+  steps.
+- `steered` - the journal verifies and carries one or more steering steps
+  (an operator touched it, and the record proves it).
+- `tampered` - the journal's Merkle chain no longer verifies; the
+  divergence report names the first divergent line.
+
+## Limitations
+
+- `pause` and `abort` require `--session-id`; there is no "steer the task,
+  resolve the session automatically" mode.
+- Steering acts on one running worker/session at a time - there is no batch
+  or fleet-wide steer.
+
+## Source
+
+- `src/bernstein/core/orchestration/steering.py` - `SteeringCommand`,
+  `SteeringController`, `consume_steering`, `classify_steering_run`.
+- `src/bernstein/cli/commands/fleet_cmd.py` - `bernstein fleet steer`
+  (`steer_cmd`).

--- a/docs/operations/gate-adjudication.md
+++ b/docs/operations/gate-adjudication.md
@@ -1,0 +1,75 @@
+# Gate adjudication records
+
+Every maker-checker or judge-panel phase-gate decision writes a signed
+**adjudication record** anchored to the run's lineage spine, so the gate's
+verdict is not just a pass/fail line in a log but a recomputable proof of
+what the panel actually saw.
+
+```
+bernstein gate verify <run_id> --inputs inputs.json [--workdir DIR]
+```
+
+## Why
+
+A gate decision historically left no attestable record of what the checker
+or panel actually saw. `bernstein gate verify` recomputes the inputs hash
+from the claimed inputs and confirms the recorded panel saw exactly those
+inputs, then confirms the record is still anchored in a spine that itself
+verifies.
+
+## What a record binds
+
+Each adjudication is one signed record:
+
+| Field | Meaning |
+|---|---|
+| `run_id` | The run whose journal the record anchors to. |
+| `inputs_hash` | `sha256:` hash of the canonical inputs the panel saw. |
+| `rubric_hash` | `sha256:` hash of the canonical rubric applied. |
+| `panel_config` | Panel mode plus each judge's `model` / `temperature` / `prompt_hash`. |
+| `per_judge_verdict` | One entry per judge, in panel declaration order. |
+| `final_verdict` | The aggregated terminal verdict (`pass` / `fail`). |
+| `timestamp` | Integer timestamp, stable across replays of a fixture. |
+| `journal_entry_hash` | The lineage-spine entry hash over the record's canonical bytes. |
+
+Records persist under `.sdd/lineage/<run_id>/adjudication_records/*.json`,
+colocated with the run's spine directory.
+
+## Panel independence
+
+Panel construction rejects any panel whose judges share `model` +
+`temperature` + `prompt_hash` (an identical `identity_hash`), so a panel
+cannot silently agree on the same error. Two coordination modes are
+supported:
+
+- **`maker_checker`** — two roles; the checker (last judge) vetoes. Any
+  judge failing fails the gate.
+- **`panel`** — N independent judges aggregated by strict majority. Ties or
+  a majority fail close the gate rather than pass it.
+
+## How verify reconstructs the decision
+
+`bernstein gate verify <run_id> --inputs inputs.json` recomputes, from the
+persisted records and the presented inputs alone:
+
+1. `inputs_hash` over the presented `--inputs` file matches a record's
+   recorded `inputs_hash` — a tampered claim is detected.
+2. The panel configuration is still independent (no two judges share an
+   identity).
+3. The record's lineage spine itself verifies.
+4. The recorded `journal_entry_hash` matches the spine anchor recomputed
+   over the record's canonical bytes.
+
+Exit codes: `0` verified, `1` no record for the run (or bad `--inputs`),
+`2` mismatch (a tampered claim, record, or spine).
+
+## Cost attribution
+
+A cheap-maker / capable-checker cost mode attributes maker and checker spend
+to separate ledger labels (`adjudication.maker` / `adjudication.checker`)
+so per-role gate cost is visible rather than lumped into one bucket.
+
+## Source
+
+`src/bernstein/core/quality/adjudication.py` (record model, aggregation,
+verify), `src/bernstein/cli/commands/gate_cmd.py` (`bernstein gate verify`).

--- a/docs/operations/global-config.md
+++ b/docs/operations/global-config.md
@@ -1,0 +1,137 @@
+# Global config CLI (`bernstein config`)
+
+`bernstein config` reads and writes the per-operator global config file at
+`~/.bernstein/config.yaml`. This is a different layer from
+[`bernstein.yaml`, `.sdd/config.yaml`, and the tunable defaults documented in
+the configuration reference](CONFIG.md): those are per-project files checked
+into (or living next to) a repo, while `~/.bernstein/config.yaml` holds an
+operator's cross-project defaults (default CLI adapter, budget, effort,
+concurrency) that apply unless a project overrides them.
+
+## How to use it
+
+```
+bernstein config set <key> <value>     # write to ~/.bernstein/config.yaml
+bernstein config get <key>             # show the effective value + its source
+bernstein config list                  # show every known key, value, and source
+bernstein config diff                  # diff project bernstein.yaml against built-in defaults
+bernstein config validate              # validate project model policy / providers
+bernstein config conflicts             # show settings where sources disagree
+bernstein config view-mode <mode>      # set dashboard detail level
+```
+
+### `bernstein config set KEY VALUE`
+
+Writes `KEY` into `~/.bernstein/config.yaml`. Numeric-looking values are
+coerced to `int`/`float`; `null`/`none` (case-insensitive) is stored as
+`None`; everything else is stored as a string.
+
+```
+bernstein config set cli codex
+bernstein config set budget 25
+bernstein config set max_agents 4
+```
+
+### `bernstein config get KEY`
+
+Prints the effective value for `KEY` and which layer it came from, plus the
+full resolution chain.
+
+```
+bernstein config get cli
+# cli = 'codex'  (source: global)
+# resolution: session -> project -> context -> global -> default
+```
+
+Flags: `--project-dir DIR` (default `.`) — the project root used to load
+`.sdd/config.yaml` for the precedence check.
+
+### `bernstein config list`
+
+Same resolution, applied to every key in the built-in defaults table
+(`cli`, `budget`, `max_agents`, `effort`, `model`), rendered as a table of
+key / value / source / full resolution chain. Same `--project-dir` flag as
+`get`.
+
+### `bernstein config diff`
+
+Different scope from the commands above: it reads `bernstein.yaml` (or
+`bernstein.yml`) in the current directory — the **project seed**, not the
+global config file — and prints every key that differs from Bernstein's
+built-in defaults (added / changed / removed). Empty output means the
+project seed matches defaults exactly, or no seed file is present.
+
+### `bernstein config validate`
+
+Validates the project's model policy and provider configuration: loads
+`bernstein.yaml` (from the current directory or a parent), loads
+`.sdd/config/providers.yaml` and `.sdd/config/model_policy.yaml` (or the
+model policy embedded in `bernstein.yaml`) into a `TierAwareRouter`, and
+runs `router.validate_policy()`. Exits non-zero and lists each issue when
+validation fails (e.g. allow/deny conflicts, a preferred provider excluded
+by its own allow list, or a tier with no available provider once policy
+constraints apply). On success, prints a provider summary table (tier,
+region, health, policy-allowed, residency).
+
+### `bernstein config conflicts`
+
+Resolves every config key across all sources and reports two kinds of
+problems, using `--project-dir` the same way as `get`/`list`:
+
+- **Setting conflicts** — the same key has different values across sources
+  (e.g. `.sdd/config.yaml` and `~/.bernstein/config.yaml` disagree).
+- **Policy violations** — a source sets a key it isn't allowed to set
+  (`check_source_policies`).
+
+Prints "No setting conflicts or policy violations detected." when clean.
+
+### `bernstein config view-mode {novice|standard|expert}`
+
+Sets the dashboard/CLI detail level for the current project, persisted to
+`.sdd/config.yaml`. `novice` trims output to the essentials; `expert` shows
+full detail.
+
+## Precedence
+
+`bernstein config get`/`list`/`conflicts` resolve a key across, from
+highest to lowest precedence:
+
+1. **seed** — the run-seed (`bernstein.yaml`) value actually enforced by the
+   orchestrator, when present.
+2. **session** — environment overrides (`BERNSTEIN_CLI`, `BERNSTEIN_BUDGET`,
+   `BERNSTEIN_MAX_AGENTS`, `BERNSTEIN_EFFORT`, `BERNSTEIN_MODEL`) or
+   caller-provided session overrides.
+3. **project** — `<project>/.sdd/config.yaml`.
+4. **context** — the active operating context, when one is selected (see
+   `bernstein ctx` in [`CONFIG.md`](CONFIG.md#operating-contexts-bernstein-ctx)).
+5. **global** — `~/.bernstein/config.yaml`, the file `bernstein config set`
+   writes to.
+6. **default** — built-in defaults (`cli=claude`, `budget=None`,
+   `max_agents=6`, `effort=max`, `model=None`).
+
+Only `bernstein config set`/`get`/`list`/`conflicts`/`view-mode` operate on
+this precedence chain. `bernstein config diff` is a separate, narrower tool
+that only compares the project seed file to built-in defaults.
+
+## Known config keys
+
+| Key | Default | Meaning |
+|---|---|---|
+| `cli` | `claude` | Default CLI adapter (`claude`, `codex`, `gemini`, `qwen`, ...). |
+| `budget` | `null` | Default spending cap in USD (`null` = unlimited). |
+| `max_agents` | `6` | Default max concurrent agents. |
+| `effort` | `max` | Default effort level (`max`/`medium`/`low`). |
+| `model` | `null` | Default model override (`null` = adapter default). |
+
+## Source
+
+- `src/bernstein/cli/commands/workspace_cmd.py` — `config_group` and all
+  subcommands.
+- `src/bernstein/core/config/home.py` — `BernsteinHome`, `resolve_config`,
+  `resolve_config_bundle`, `explain_conflicts`, `check_source_policies`.
+- `src/bernstein/cli/config_diff_cli.py` — `bernstein config diff`.
+
+## Related
+
+- [Bernstein Configuration Reference](CONFIG.md) — `bernstein.yaml`,
+  `.sdd/config.yaml`, environment variables, and tunable defaults.

--- a/docs/operations/graduation.md
+++ b/docs/operations/graduation.md
@@ -1,0 +1,78 @@
+# Pilot-to-production graduation
+
+Bernstein sessions can operate at four increasingly trusted stages —
+`sandbox`, `shadow`, `assisted`, `autonomous` — and a session graduates from
+one to the next only after it clears a metrics threshold (task count, success
+rate, consecutive-failure ceiling, minimum time-at-stage). Graduation is
+exposed as a REST surface; there is no `bernstein graduation` CLI command.
+
+## Stage semantics
+
+| Stage | What runs |
+|---|---|
+| `sandbox` | Agents spawn but make no real changes (`dry_run=True`). |
+| `shadow` | Agents run and produce diffs; changes apply locally but are not committed. |
+| `assisted` | Changes are committed; each task merge requires explicit human approval. |
+| `autonomous` | Changes are committed and auto-merged after batch review. |
+
+`stage_to_orchestrator_overrides(stage)` maps each stage to the
+`OrchestratorConfig` fields that enforce it (`dry_run`, `approval`,
+`merge_strategy`), so a stage is not just a label — it changes what the
+orchestrator is allowed to do.
+
+## Endpoints
+
+| Endpoint | Does |
+|---|---|
+| `GET /graduation/status` | All tracked sessions, current stage, and whether each can graduate. |
+| `GET /graduation/config/policies` | The active per-stage thresholds. |
+| `GET /graduation/{session_id}` | Stage, accumulated metrics, promotion log, and graduation readiness for one session. |
+| `POST /graduation/{session_id}/record-event` | Record a task success/failure against the session's current-stage metrics. |
+| `POST /graduation/{session_id}/promote` | Manually promote a session to the next stage. Returns 409 if already `autonomous`. |
+
+## Default policies
+
+| Stage | Min tasks | Min success rate | Max consecutive failures |
+|---|---|---|---|
+| `sandbox` | 3 | 80% | 3 |
+| `shadow` | 5 | 85% | 2 |
+| `assisted` | 10 | 90% | 2 |
+
+`autonomous` is terminal — it has no outbound policy, and `promote` on an
+already-`autonomous` session returns `409`.
+
+`can_graduate` also enforces `min_hours` (minimum wall-clock time at the
+current stage) where configured; the default policies above set it to `0`
+(no time requirement).
+
+## How promotion happens
+
+A caller records each task outcome via `record-event`
+(`success`, `duration_s`, `cost_usd`). The graduation store accumulates
+per-stage metrics (`tasks_completed`, `tasks_failed`,
+`consecutive_failures`, `success_rate`, `hours_elapsed`) and evaluates them
+against the stage's policy on every read of `GET /graduation/{session_id}`
+or `/graduation/status`. Promotion itself is never automatic — a call to
+`POST /graduation/{session_id}/promote` is required even once
+`can_graduate` reports `true`. Every promotion appends an entry (from-stage,
+to-stage, timestamp, reason, promoted-by, metrics snapshot) to the session's
+promotion log.
+
+## Persistence
+
+- `.sdd/graduation/<session_id>.json` — current stage and per-stage metrics for one session.
+- `.sdd/metrics/graduation.jsonl` — append-only event log (`task_event` and `promotion` entries).
+
+## Limitations
+
+- No CLI wraps these endpoints; an operator (or an external dashboard)
+  drives graduation via the REST API directly.
+- Nothing in the orchestrator calls `record-event` automatically — a caller
+  (dashboard, CI job, or operator script) is responsible for reporting task
+  outcomes into the graduation store. Without that wiring, a session's
+  graduation state never advances on its own.
+
+## Source
+
+- `src/bernstein/core/quality/graduation.py` — stages, policies, `GraduationEvaluator`, `GraduationStore`.
+- `src/bernstein/core/routes/graduation.py` — the FastAPI routes listed above.

--- a/docs/operations/hook-gate.md
+++ b/docs/operations/hook-gate.md
@@ -1,0 +1,67 @@
+# In-process verification gates
+
+Verification normally happens *after* a worker finishes: the scheduler
+inspects results and re-dispatches on failure, paying a full round-trip for
+every miss. A gate-capable adapter instead wires blocking hooks into the
+worker's own runtime so the required checks run **inside the session**,
+before the worker's turn ends.
+
+## What it does
+
+For a gate-capable adapter, Bernstein renders two hooks at spawn time:
+
+| Hook | Trigger | Behaviour |
+|---|---|---|
+| Tool-permission matcher | `PreToolUse` on `Write` / `Edit` / `MultiEdit` / `NotebookEdit` | Refuses a write whose target falls outside the task's path allowlist. Realpath containment refuses a `..` traversal or an in-scope symlink that resolves outside the worktree. |
+| Completion gate | `Stop` | Runs the task's *required* evidence producers in-session; refuses to let the turn end while any of them fail. |
+
+Both hooks shell out to:
+
+```
+bernstein hook-gate check --session <id> --event PreToolUse < event.json
+bernstein hook-gate check --session <id> --event Stop < event.json
+```
+
+The command reads the hook event JSON on stdin, evaluates the policy
+persisted at `.sdd/runtime/hook_gate/<session>.json` (written at spawn time
+from the task's `owned_files` and required `evidence_producers`), and exits
+`2` to block or `0` to allow.
+
+## Which adapters support it
+
+Only adapters with a genuine blocking hook surface are wired up. Currently:
+`claude` and `claude_routine`. Every other adapter renders no gate hooks and
+degrades to the scheduler-side gate with no policy weakening — there is no
+partial or best-effort in-process enforcement for an adapter that lacks the
+surface.
+
+## Trust model
+
+The in-process gate is **defence in depth and a cost optimisation**, not a
+replacement for the authoritative check. The scheduler-side evidence gate
+(`bernstein evidence show` / `verify`) remains authoritative and runs
+regardless of what happened in-session.
+
+Every gate outcome — a blocked completion or a refused out-of-scope write —
+is sealed as the same signed, chain-anchored evidence bundle the
+scheduler-side gate produces (via `bernstein audit verify`). A downstream
+verifier cannot tell from the receipt schema whether enforcement fired
+in-process or scheduler-side.
+
+## Failure handling
+
+Enforcement is fail-open on unexpected errors: a bug while sealing a receipt
+must never wedge a worker, so sealing failures are logged and swallowed —
+but a computed block/allow decision is always emitted from the check itself.
+An unsafe or unrecognised session id degrades to allow-through rather than
+touching the filesystem with an unvalidated path.
+
+A policy that enforces nothing (no path allowlist, no required producers) is
+a pass-through: both hooks always allow.
+
+## Source
+
+`src/bernstein/adapters/hook_gate_render.py` (hook rendering per adapter),
+`src/bernstein/core/security/hook_gate.py` (policy model and gate
+evaluation), `src/bernstein/cli/commands/hook_gate_cmd.py`
+(`bernstein hook-gate check`).

--- a/docs/operations/mcp-gateway.md
+++ b/docs/operations/mcp-gateway.md
@@ -1,0 +1,104 @@
+# MCP gateway proxy
+
+`bernstein gateway` is a transparent MCP JSON-RPC proxy: it sits between an
+MCP client and an upstream MCP server, forwards every request unchanged,
+and records each tool call to a write-ahead log (WAL). A later `gateway
+replay` run can serve responses straight from that WAL, with no upstream
+server needed — useful for offline debugging or deterministic re-runs of a
+recorded session.
+
+## Usage
+
+```bash
+# Point an MCP client at the gateway instead of the real server command.
+bernstein gateway start --upstream "uvx mcp-server-git"
+
+# SSE (HTTP) transport instead of stdio.
+bernstein gateway start --upstream "npx @modelcontextprotocol/server-filesystem ." \
+    --transport sse --port 8054
+
+# Replay a previously recorded session offline.
+bernstein gateway replay gw-abc12345
+
+# List recorded x402 pay-and-retry settlements.
+bernstein gateway settlements
+```
+
+### `bernstein gateway start`
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--upstream CMD` | required | Shell command that starts the real upstream MCP server (e.g. `uvx mcp-server-git`). |
+| `--transport` | `stdio` | `stdio` or `sse`. |
+| `--port` | `8054` | Port for SSE transport (ignored in stdio mode). |
+| `--run-id ID` | auto-generated | WAL run id; defaults to `gw-<8 hex chars>`. |
+| `--server-name NAME` | `unknown` | Logical MCP server name recorded into the WAL for historical analytics. |
+
+In `stdio` mode the gateway itself behaves as an MCP stdio server: an MCP
+client should be pointed at `bernstein gateway start --upstream <cmd>`
+rather than at the real server command. It spawns the upstream command as a
+subprocess and proxies stdin/stdout between the client and that subprocess.
+In `sse` mode it listens on `--port` and exposes `GET /sse` /
+`POST /message`, still proxying to the upstream via stdio underneath.
+
+### `bernstein gateway replay`
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `RUN_ID` | required (argument) | The `--run-id` (or auto-generated id) from a previous `gateway start` session. |
+| `--transport` | `stdio` | `stdio` or `sse`. |
+| `--port` | `8054` | Port for SSE transport. |
+
+Replay reads `.sdd/runtime/wal/<run-id>.wal.jsonl` and serves responses from
+it without connecting to any upstream process. If the file doesn't exist
+the command exits `1` and points at `bernstein audit show` to list recorded
+run ids. Replay indexes every `mcp_tool_call` WAL entry by
+`method:tool_name` at startup, so lookups are O(1); a call with no matching
+recorded entry gets a JSON-RPC error response (`"No recorded response for
+this call"`) rather than hanging.
+
+### `bernstein gateway settlements`
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--workdir`, `-w` | `.` | Project root containing `.sdd/`. |
+
+Lists x402 pay-and-retry settlements recorded under
+`.sdd/x402/settlements` — each row is a chain-anchored spend receipt
+binding a settled upstream tool call to the exact WAL invocation it paid
+for. See [x402 settlement for metered MCP gateway calls](x402-settlement.md)
+for the full settlement flow and how to verify a receipt with
+`bernstein mandate verify-settlement`.
+
+## What gets recorded
+
+Every proxied `tools/call` (and other JSON-RPC methods) is written to the
+WAL as a `decision_type="mcp_tool_call"` entry with inputs
+`{method, server_name, tool_name, arguments, request_id}` and output
+`{result, error, latency_ms}`. Per-tool call count, error count, and
+latency percentiles (p50/p90/p99) are accumulated in memory for the
+duration of the process and exposed at `GET /gateway/metrics` in SSE mode.
+
+When a run journal is wired in, each proxied call is also mirrored into the
+journal / audit chain as a content-addressed `mcp.stateless_call` entry, so
+a verifier can reconstruct the call ordering from the chain alone even
+without the WAL file. A failure to anchor a call is logged but never takes
+the proxy down — it shows up to a verifier as a call-index gap rather than
+a crash.
+
+## SSE transport correlation
+
+The SSE transport is stateless by design (no gateway instance holds
+per-client state): a response is correlated to its request by a
+content-derived span id, taken from the request's `_meta` field if present
+or otherwise deterministically derived from the request content. That span
+id rides as the `X-Bernstein-Span-Id` response header and as the SSE event
+`id:` line, so any gateway instance can serve any request and a client
+juggling several in-flight requests still matches each response correctly.
+
+## Source
+
+`src/bernstein/cli/commands/gateway_cmd.py` (registered as
+`bernstein gateway`, reachable via the back-compat alias
+`bernstein.cli.gateway_cmd`), `src/bernstein/core/protocols/mcp/mcp_gateway.py`
+(`MCPGateway`, `GatewayReplay`, `ToolMetrics`, `create_gateway_sse_app`).

--- a/docs/operations/named-resource-pools.md
+++ b/docs/operations/named-resource-pools.md
@@ -1,0 +1,141 @@
+# Named resource pools
+
+Lease-backed admission control - concurrency-limited pools, per-tag ceilings,
+adaptive rate limits, and priority queues - where a grant's identity is the
+hash-chained ledger row that issued it.
+
+```
+bernstein limits pool create <name> --slots N
+bernstein limits tag set <tag> --limit N
+bernstein limits rate set <name> --base-limit N
+bernstein limits queue create <name>
+bernstein limits status
+bernstein limits verify
+```
+
+Not to be confused with **named sandbox pools** (`bernstein pool
+register/list/show/verify`, `core/sandbox/pool.py`) - that is a separate
+subsystem governing which sandbox backend and workspace template a run may
+place work into. `bernstein limits` governs *how many* tasks may run
+concurrently against a named resource, a tag, or an external rate limit.
+
+## Why
+
+Concurrency and rate limits are usually enforced ad hoc - a hardcoded
+semaphore, an environment variable nobody remembers changing. The admission
+subsystem treats every limit and every grant as a chained fact instead:
+pool occupancy, queue order, effective rate limits, and enforcement postures
+are never a mutable side table, they are a pure projection of a hash-chained
+ledger mirrored into the HMAC audit chain. Two operators replaying the same
+ledger derive the byte-identical grant order, so slot forensics ("why did
+task X get admitted ahead of task Y") is a replay, not an investigation.
+
+## Concepts
+
+| Concept | What it limits |
+|---|---|
+| **Pool** | Named concurrency ceiling for a resource (`--slots N`), e.g. one staging environment or a migration lock. |
+| **Tag limit** | Concurrency ceiling over any task carrying a given tag (`--limit N`; `0` quarantines the class). |
+| **Rate limit** | Fleet-wide named rate limit with adaptive decay driven by recorded 429 observations (`--base-limit`, `--floor`). |
+| **Queue** | Operator-defined named queue generalizing the deterministic round-robin (DRR) scheduler, with a priority and pause/resume. |
+| **Posture** | `enforce` (block over-limit grants), `advise` (admit over-limit but issue a signed waiver receipt), or `off` (inert). Default `enforce`. |
+| **Grant** | The admission decision for one task; its identity is the `entry_hash` of the ledger row that issued it - never a separately minted id. |
+
+## Commands
+
+### `bernstein limits pool create <name> --slots N`
+
+Create or update a named slot pool. `--slots 0` quarantines the pool (no new
+grants admitted). `--posture` sets enforcement posture (default `enforce`).
+
+### `bernstein limits tag set <tag> --limit N`
+
+Set a concurrency ceiling over a task tag. `--limit 0` quarantines the tag.
+
+### `bernstein limits rate set <name> --base-limit N [--floor N]`
+
+Define a fleet-wide named rate limit. `--base-limit` is the ceiling with zero
+recent 429 observations; `--floor` (default `1`) is the lowest the adaptive
+limit may decay to as 429s are observed.
+
+### `bernstein limits queue create <name> [--priority N]`
+
+Create or update an operator-defined named queue (default priority `0`,
+higher runs first; aging lifts starved queues).
+
+### `bernstein limits queue pause <name> [--resume]`
+
+Pause a named queue; pass `--resume` to resume it instead. Refuses (rather
+than silently creating) an unknown queue name.
+
+### `bernstein limits status`
+
+Show the projected admission state: pools (slots / held / posture), tag
+limits (limit / held / posture), active grant count, waiver count, and
+quarantine count. `--json` emits the full canonical projection.
+
+### `bernstein limits verify`
+
+Recompute the admission ledger from genesis and fail closed on any drift.
+
+```
+Exit codes:
+  0  the admission ledger verifies end to end
+  2  verification failed (the exact position is named)
+```
+
+All commands accept `--workdir PATH` (defaults to the current directory) and
+`--json` for machine-readable output.
+
+## How a grant is decided
+
+Every declaration (`pool create`, `tag set`, `rate set`, `queue create`) and
+every grant, release, renewal, expiry, waiver, and quarantine is appended as
+a row to a hash-chained ledger under `.sdd/runtime/admission/<ledger-id>/`
+(default ledger id `fleet`) - the same hashing contract the work ledger uses,
+so mutating or reordering a row surfaces as a hash mismatch at an exact
+position. `AdmissionEngine.request_grant()` reads the current projected
+state, evaluates the candidate against the pool/tag gates:
+
+- **Under `enforce`**, a full pool or tag refuses the grant outright (the
+  task waits); the refusal reason names which gate was over capacity.
+- **Under `advise`**, the grant is admitted `over_limit=True` and paired with
+  a signed waiver receipt naming exactly the gate(s) exceeded.
+- **Under `off`**, the gate is inert.
+
+## Lease expiry and quarantine
+
+A grant carries an optional TTL (`ttl_s`); a lease past its TTL is expired by
+a deterministic sweep (`sweep_expired()`), never silently recycled. Each
+expiry appends an `admission.expire` row, assembles a signed escalation
+receipt in the same shape [stall escalation](stall-escalation.md) uses, and
+computes a checkpointed-retry resume decision so a warm resume is honoured
+when a checkpoint exists.
+
+`quarantine(target_kind="pool"|"tag", target=...)` freezes a class in one
+operation: it sets the pool or tag's limit to `0`, expires every in-flight
+matching grant (checkpointing its worker through the same expiry lifecycle),
+and emits **one** chain entry carrying the complete affected-set manifest -
+the checkpointed workers plus any queued task ids. Replaying the chain
+reproduces the identical manifest, because the manifest is the hashed row
+payload, not a bare relabel.
+
+## Limitations
+
+- There is no per-pool dashboard beyond `bernstein limits status`; historical
+  occupancy over time requires reading the ledger directly.
+- Rate-limit decay is adaptive over recorded 429s but the decay curve itself
+  is not operator-tunable beyond `--base-limit` / `--floor`.
+
+## Source
+
+- `src/bernstein/core/admission/__init__.py` - subsystem overview and public
+  surface.
+- `src/bernstein/core/admission/engine.py` - `AdmissionEngine` (grants,
+  leases, quarantine, waivers).
+- `src/bernstein/core/admission/ledger.py` - the hash-chained ledger storage.
+- `src/bernstein/core/admission/projection.py` - `AdmissionState`, the pure
+  projection.
+- `src/bernstein/core/admission/verify.py` - `verify_admission_ledger()`.
+- `src/bernstein/cli/commands/limits_cmd.py` - the `bernstein limits`
+  command group.

--- a/docs/operations/plan-archival.md
+++ b/docs/operations/plan-archival.md
@@ -1,0 +1,120 @@
+# Plan archival
+
+`bernstein plan ls` and `bernstein plan show` query Bernstein's managed
+plan lifecycle: every plan YAML under `plans/` is tracked through three
+buckets - `active/`, `completed/`, `blocked/` - and archived plans are
+made read-only with a run-summary or failure-reason header prepended.
+
+Source: `core/planning/lifecycle.py` (`PlanLifecycle`, `PlanState`,
+`ArchivedPlan`); CLI in `cli/commands/plan_archive_cmd.py`.
+
+This is a different concept from the plan **YAML schema** documented at
+[Plans](../architecture/plans.md) (stages/steps/`--from-plan`). Lifecycle
+tracks *where a plan file currently lives and why*; the schema page
+covers *what's inside a plan file*.
+
+---
+
+## Usage
+
+```
+bernstein plan ls [--state active|completed|blocked]
+bernstein plan show PLAN_ID
+```
+
+- `bernstein plan ls` - lists managed plans across all three buckets in
+  a table (`State`, `Plan ID`, `Path`). `--state` filters to one bucket.
+- `bernstein plan show PLAN_ID` - prints the archived (or active) plan's
+  full YAML body, prefixed with `# state:` and `# path:` comment lines.
+  `PLAN_ID` is the filename stem, e.g. `2026-04-23-strategic-300` for an
+  archived plan or the original stem for an active one.
+
+Both commands operate on `plans/` under the current working directory
+(or wherever `default_lifecycle()` is rooted); there is no `--workdir`
+flag on either subcommand.
+
+---
+
+## Lifecycle
+
+Three buckets, one linear state machine:
+
+```
+plans/active/      # runs in flight or queued - writable
+plans/completed/   # finished successfully - read-only
+plans/blocked/     # aborted - read-only
+```
+
+Only two transitions are legal: `active -> completed` and
+`active -> blocked`. Every other pair raises `PlanArchiveError`.
+Archived states are terminal from the lifecycle API's perspective -
+copying a file out of `completed/` or `blocked/` back into `active/` is
+a manual, unmanaged operation; the lifecycle layer never does it for
+you.
+
+### Archiving a plan
+
+`archive_completed()` / `archive_blocked()` (called by orchestrator
+code, not directly by either CLI subcommand):
+
+1. Validate the source file actually lives in `plans/active/`.
+2. Prepend a rendered `## Run summary` (success) or `## Failure reason`
+   (failure) Markdown block to the plan's YAML text
+   (`core/planning/run_summary.py`).
+3. Reserve a destination filename: `YYYY-MM-DD-<slug>.yaml`, where the
+   date is UTC "today" and the slug is derived from the plan name (or
+   the source stem). On a collision, a deterministic 6-hex-char SHA-256
+   suffix is appended; if that also collides, an incrementing counter
+   extends it further (up to 1000 attempts).
+4. Fire the `pre_archive` hook (if a `HookRegistry` was wired in) -
+   an exception here aborts the archive before any disk write.
+5. Write the new file via a same-directory temp file + `os.replace`
+   (atomic), then delete the source only after the destination is
+   durable.
+6. `chmod 0o444` the destination (best-effort; some filesystems ignore
+   the bit - `assert_writable()` is the layer's own authoritative
+   refusal, independent of the filesystem mode).
+7. Record an HMAC-chained audit entry (`audit_kind` = `"success"` or
+   `"failure"`), when an `AuditLog` was wired into the `PlanLifecycle`.
+8. Fire the `post_archive` hook.
+
+### Backfill
+
+`backfill_unmanaged()` moves loose `plans/*.yaml` files (not yet in any
+bucket) into `plans/active/`. It's meant to run once at orchestrator
+startup and is idempotent - already-managed files are left alone, and a
+name collision against an existing `active/` file causes the loose file
+to be skipped (logged, not moved).
+
+### Mutation guard
+
+`assert_writable(path)` raises `PlanArchiveError` if `path` resolves
+under `completed/` or `blocked/`, regardless of the actual filesystem
+permission bit. Callers that want to defensively guard an edit call
+this before writing, rather than relying on the `chmod` alone.
+
+---
+
+## Limitations
+
+- `bernstein plan ls` / `bernstein plan show` are read-only query
+  commands. Nothing in the current CLI surface drives
+  `archive_completed()` / `archive_blocked()` directly - archival is
+  triggered by orchestrator run-completion code, not by an operator
+  command.
+- Re-running an archived plan requires manually copying the file back
+  into `plans/active/`; there is no `bernstein plan restore` or
+  equivalent command.
+
+---
+
+## Source
+
+- `src/bernstein/core/planning/lifecycle.py` - `PlanLifecycle`,
+  `PlanState`, `ArchivedPlan`, `PlanArchiveError`, `default_lifecycle`.
+- `src/bernstein/core/planning/run_summary.py` - `RunSummary` /
+  `FailureSummary` rendering for the prepended archive header.
+- `src/bernstein/cli/commands/plan_archive_cmd.py` - `plan_ls`,
+  `plan_show`.
+- `docs/reference/cli-reference.md` - flag-level reference for both
+  subcommands.

--- a/docs/operations/review-pipeline.md
+++ b/docs/operations/review-pipeline.md
@@ -1,0 +1,211 @@
+# Review pipeline DSL
+
+`bernstein review --pipeline review.yaml` runs a multi-stage, multi-agent
+code review against a PR (or, from orchestrator code, a completed task's
+diff) driven entirely by a YAML file. It replaces the single-pass
+cross-model verifier with an ordered sequence of stages, each running one
+or more reviewer agents in parallel, whose votes are aggregated into a
+stage verdict and finally a pipeline verdict.
+
+The CLI handler lives in `cli/commands/review_pipeline_cmd.py`; the DSL,
+runner, and aggregation logic live in `core/quality/review_pipeline/`
+(`schema.py`, `runner.py`, `verdict.py`).
+
+---
+
+## Usage
+
+```
+bernstein review --pipeline review.yaml --validate-only
+bernstein review --pipeline review.yaml --pr 42 --dry-run
+bernstein review --pipeline templates/review/default-3-phase.yaml --pr 42
+```
+
+Flags (all part of the existing `bernstein review` command,
+`cli/commands/task_cmd.py`):
+
+- `--pipeline PATH` - path to a `review.yaml` pipeline definition. Without
+  this flag, `bernstein review` falls back to its legacy behaviour: it
+  writes a flag file that the running orchestrator picks up on its next
+  tick, prompting the manager agent to inspect the task queue. That legacy
+  path is unrelated to the DSL described here.
+- `--pr N` - GitHub PR number to review. Required to actually run the
+  pipeline (fetches the diff via `gh pr diff N`); omit it to only
+  validate or dry-run.
+- `--validate-only` - parse and schema-validate the YAML, print a summary,
+  exit 0/1. No agents run, no PR is fetched.
+- `--dry-run` - print the resolved pipeline (stages, parallelism,
+  aggregator, agents) without spawning any agent or calling any LLM.
+- `--workdir PATH` (default `.`) - repository root used to run `gh`.
+
+Fetching the diff shells out to `gh pr view` and `gh pr diff`, so the
+`gh` CLI must be installed and authenticated against the target repo.
+
+---
+
+## The YAML DSL
+
+A pipeline is an ordered list of stages. Each stage runs N agents in
+parallel; a stage's findings are forwarded into the next stage's prompt
+context.
+
+```yaml
+version: 1
+name: default-3-phase
+pass_threshold: 0.66
+block_on_fail: true
+
+stages:
+  - name: cheap-verifiers
+    parallelism: 5
+    aggregator:
+      strategy: majority
+    agents:
+      - role: lint
+        model: google/gemini-flash-1.5
+        adapter: gemini
+        prompt_template: lint.md
+        effort: low
+      - role: security
+        model: anthropic/claude-haiku-4-5-20251001
+        adapter: claude
+        prompt_template: security.md
+        effort: low
+
+  - name: senior_synthesis
+    parallelism: 1
+    aggregator:
+      strategy: any
+    agents:
+      - role: senior_reviewer
+        model: anthropic/claude-opus-4-5-20250514
+        adapter: claude
+        prompt_template: senior_synthesis.md
+        effort: high
+```
+
+A ready-to-use 3-stage pipeline (5 cheap verifiers → senior synthesis →
+final gatekeeper) ships at `templates/review/default-3-phase.yaml`.
+
+### Top-level fields (`ReviewPipeline`, `schema.py`)
+
+| Field | Default | Notes |
+|---|---|---|
+| `version` | `1` | Schema version. |
+| `name` | `null` | Optional; audit/docs only. |
+| `pass_threshold` | `0.5` | Default pass fraction used by the `weighted` strategy when a stage doesn't override it. |
+| `block_on_fail` | `true` | When true, a `request_changes` pipeline verdict blocks the janitor/merge gate, the same way the legacy cross-model verifier does. |
+| `stages` | required, min 1 | Sequential - no diamond joins. Stage names must be unique. |
+
+### Stage fields (`StageSpec`)
+
+| Field | Default | Notes |
+|---|---|---|
+| `name` | required | Unique within the pipeline. |
+| `parallelism` | `1` | Max concurrent agents in this stage (1-32); the runner caps it at `len(agents)`. |
+| `agents` | required, min 1 | List of `AgentSpec`. |
+| `aggregator` | `strategy: majority` | See below. |
+| `description` | `null` | Free-text, audit/docs only. |
+
+### Agent fields (`AgentSpec`)
+
+| Field | Default | Notes |
+|---|---|---|
+| `role` | required | Free-form tag (`lint`, `security`, ...); also a key into `aggregator.weights`. |
+| `model` | `null` | Model identifier; `null` lets the cost cascade router choose. |
+| `adapter` | `null` | CLI adapter to spawn (`claude`, `gemini`, `codex`, ...). |
+| `prompt_template` | `null` | Resolved against `templates/review/` then `templates/prompts/`. |
+| `effort` | `low` | `low` / `medium` / `high`. |
+
+The schema is `extra="forbid"` and `strict=True` - unknown fields or
+type mismatches fail validation rather than being silently ignored.
+`load_pipeline()` re-parses the YAML to attach the originating line
+number to validation errors, so `--validate-only` output points at the
+offending line rather than just a Pydantic path.
+
+---
+
+## Aggregation strategies
+
+Set per stage via `aggregator.strategy` (`verdict.py:_apply_strategy`).
+`pass_score` is always reported as the fraction of approve weight over
+total weight, regardless of strategy:
+
+| Strategy | Passes when |
+|---|---|
+| `any` | At least one agent approves. |
+| `all` | Every agent approves. |
+| `majority` | Strict majority approves (ties go to `request_changes`). |
+| `weighted` | Approve-weighted score (`aggregator.weights`, keyed by role or model, default weight `1.0`) meets or exceeds the effective pass threshold (stage override, else pipeline `pass_threshold`, else `0.5`). |
+
+A pipeline verdict is `request_changes` if any stage whose own strategy
+is `all` fails, or if the overall weighted pass fraction across stages
+falls below the pipeline's `pass_threshold` (`verdict.py:aggregate_pipeline`).
+`should_block_merge()` then blocks the janitor merge gate exactly when the
+pipeline verdict is `request_changes` and `block_on_fail` is true - the
+same block/allow contract the single-pass cross-model verifier already
+uses.
+
+A single-stage, single-agent pipeline using `strategy: any` reproduces
+today's legacy single-pass verifier output byte-for-byte
+(`runner.py`, module docstring) - the DSL is a strict superset, not a
+replacement behaviour.
+
+---
+
+## Prompt construction and stage context
+
+- Stage 1's prompt for each agent reuses the existing cross-model
+  verifier's prompt builder (`cross_model_verifier._build_prompt`), so a
+  1-stage/1-agent pipeline sends the same prompt the legacy verifier
+  always sent.
+- From stage 2 onward, each agent's prompt is extended with a
+  `## Prior stage findings` section summarising every prior stage's
+  verdict, per-agent verdict, feedback, and issues
+  (`runner.py:_format_prior_context`).
+- The diff itself comes from `diff_from_pr()` (fetched via `gh pr diff`,
+  truncated to the same character cap the cross-model verifier uses) or,
+  when invoked from orchestrator code rather than the CLI, from
+  `diff_from_task()` against a completed task's worktree.
+
+---
+
+## Limitations
+
+- The CLI path (`bernstein review --pipeline ... --pr N`) does not wire
+  an `AuditLog` into `run_pipeline_sync()` - stage-level HMAC-chained
+  audit entries are only emitted when the pipeline is invoked
+  programmatically with an `audit_log` argument (see `runner.py:run_pipeline`,
+  the `audit_log` parameter). Running the DSL from the CLI does not by
+  itself produce an audit trail beyond whatever the janitor's own gate
+  recording does.
+- There is no `bernstein review --pipeline ... --task` shortcut in the
+  CLI today; `diff_from_task()` exists but is only reachable from
+  orchestrator/janitor integration code, not from the `review` command
+  itself.
+- `--pr` is required to actually execute a pipeline; `--validate-only`
+  and `--dry-run` never fetch a diff or contact GitHub.
+
+---
+
+## Source
+
+- `src/bernstein/cli/commands/task_cmd.py` - `bernstein review` Click
+  command and its `--pipeline` / `--pr` / `--validate-only` / `--dry-run`
+  flags.
+- `src/bernstein/cli/commands/review_pipeline_cmd.py` - CLI glue
+  (`run_review_pipeline_cli`).
+- `src/bernstein/core/quality/review_pipeline/schema.py` - the YAML DSL
+  (`ReviewPipeline`, `StageSpec`, `AgentSpec`, `AggregatorConfig`,
+  `load_pipeline`).
+- `src/bernstein/core/quality/review_pipeline/runner.py` - stage
+  execution, prompt assembly, diff sourcing.
+- `src/bernstein/core/quality/review_pipeline/verdict.py` - aggregation
+  strategies and pipeline-level verdict rollup.
+- `templates/review/default-3-phase.yaml` - shipped example pipeline.
+
+See also [Fresh-context review gate](../orchestration/review-gate.md) for
+the single-stage gate contract (fresh session, distinct model, restricted
+inputs) that one stage of a pipeline can enforce, and
+[Quality pipeline](../architecture/quality-pipeline.md) for how the
+janitor's structured-signal and gate layers fit around this review layer.

--- a/docs/operations/review-receipts.md
+++ b/docs/operations/review-receipts.md
@@ -1,0 +1,65 @@
+# Review and autofix receipts
+
+A worker that reviews a pull request leaves behind a single signed artefact
+binding the issue, the plan, every tool call, and the resulting diff — so a
+reviewer can prove offline that the PR was generated from the ticket without
+operator override. A related, narrower receipt links an autofix commit back
+to the finding it addresses.
+
+## PR review receipts
+
+```
+bernstein review-receipt emit   --pr <url> --repo <owner/repo> \
+    --issue <issue.md> --plan <plan.md|-> --diff <pr.diff> \
+    --journal-head <head> --verdict <verdict> [--task-id <id>] [--workdir DIR]
+
+bernstein review-receipt verify --pr <url> --issue <issue.md> --diff <pr.diff> [--workdir DIR]
+```
+
+`emit` binds `{issue_hash, plan_hash, journal_head, diff_hash, verdict}` into
+one record, signs it with the install's Ed25519 identity, and anchors it in
+the review lineage spine. `--plan` accepts a file path or `-` to read the
+plan from stdin.
+
+`verify` recomputes `issue_hash` and `diff_hash` from the presented `--issue`
+and `--diff` files, checks the Ed25519 signature against the receipt's
+embedded public key, and confirms the record's spine anchor. Exit codes:
+`0` verified, `1` no receipt found (or bad input), `2` mismatch (tamper).
+
+The tracker comment posted on a PR is a *projection* of the receipt — a
+short verdict plus the `verify` invocation a reviewer can run — never the
+receipt body itself.
+
+## Autofix receipts
+
+An `AutofixReceipt` links a reviewer *finding* to the commit that fixed it
+and the gate result, produced when a fix is applied in an isolated
+`git worktree` (never the primary working tree) and then torn down. The
+receipt binds `{finding_hash, fix_commit_hash, gate_passed, gate_summary,
+task_id, timestamp}`, is Ed25519-signed, and is anchored in its own spine
+(run id `review-autofix`) alongside the review receipts.
+
+Records land at `.sdd/reviews/autofix/<finding_hash>.json`.
+
+Unlike PR review receipts, autofix receipts have no dedicated top-level CLI
+verb as of this writing — `run_autofix_in_worktree` and
+`verify_autofix_receipt` are library functions
+(`src/bernstein/core/review/receipt.py`) called by the code that drives an
+autofix attempt, not something an operator invokes directly.
+
+## Related receipt types
+
+The same "signed, journal-anchored, offline-verifiable" pattern covers
+several other receipt families documented separately:
+
+| Receipt | Command | Doc |
+|---|---|---|
+| Stall escalation | `bernstein escalation show / verify` | [Stall escalation receipts](stall-escalation.md) |
+| Mandate consent | `bernstein mandate emit / verify / revoke` | [Spending mandates](spending-mandates.md) |
+| Webhook node | `bernstein webhook verify` | [Audited webhook node](webhook-node.md) |
+
+## Source
+
+`src/bernstein/core/review/receipt.py` (`ReviewReceipt`, `AutofixReceipt`,
+emit/verify logic), `src/bernstein/cli/commands/review_receipt_cmd.py`
+(`bernstein review-receipt`).

--- a/docs/operations/run-manifest.md
+++ b/docs/operations/run-manifest.md
@@ -1,0 +1,61 @@
+# Agent run manifest
+
+Every `bernstein run` writes a manifest capturing the complete configuration
+of that orchestration run: model routing, budget ceiling, approval-gate
+mode, agent-adapter settings, and who/when/what-commit triggered it. The
+manifest is immutable, written once at run start, and hashed so its
+configuration can be cited as SOC 2 / ISO 27001 evidence.
+
+> This is a different concept from [named team manifests](team-manifests.md)
+> (`core/teams/manifest.py`), which pin a reusable role/model/response-profile
+> bundle referenced from `bernstein.yaml`. A run manifest is a one-shot,
+> per-run configuration snapshot generated automatically.
+
+## How to use it
+
+```
+bernstein manifest list           # list every run with a saved manifest
+bernstein manifest show <run-id>  # display one run's full configuration
+bernstein manifest diff <a> <b>   # compare two runs' configurations
+```
+
+`show` renders provenance (triggered-by, timestamp, commit SHA), workflow
+identity, agent-adapter settings, budget/approval configuration, model
+routing, and the full orchestrator-config snapshot for the run. `diff`
+lists only the top-level fields that differ between two runs' canonical
+payloads.
+
+## What the manifest binds
+
+| Field | Meaning |
+|---|---|
+| `run_id` | Timestamp-based unique run identifier. |
+| `workflow_definition_hash` / `workflow_name` | Governed workflow identity, if any (empty in adaptive mode). |
+| `model_routing` | Default model plus allowed/denied provider lists. |
+| `budget_ceiling_usd` | Maximum spend allowed for the run (`0` = unlimited). |
+| `approval_gates` | Approval mode (`auto` / `review` / `pr`) and plan-mode flag. |
+| `agent_adapter` | CLI adapter, model, max agents, max tasks per agent. |
+| `provenance` | `triggered_by` (OS user), `triggered_at_iso`, `commit_sha` (`git rev-parse HEAD`). |
+| `orchestrator_config` | Snapshot of the run's `OrchestratorConfig` fields (poll interval, retries, merge strategy, recovery mode, dry-run, plan mode, and more). |
+| `manifest_hash` | SHA-256 over the canonical JSON of every other field. |
+
+## Hashing and immutability
+
+`manifest_hash` is computed over the canonical (sorted-key, minimal-separator)
+JSON serialization of the manifest with `manifest_hash` itself excluded, so
+the hash uniquely identifies the run's configuration. The manifest is
+written once at run start and never mutated afterward — a config drift
+between two runs shows up as a `manifest diff`, never as an edit to an
+existing manifest file.
+
+## Where it lives
+
+```
+.sdd/runtime/manifests/<run-id>.json
+```
+
+## Source
+
+`src/bernstein/core/config/manifest.py` (`RunManifest`, `build_manifest`,
+`diff_manifests`), `src/bernstein/cli/commands/manifest_cmd.py`
+(`bernstein manifest`).

--- a/docs/operations/run-service.md
+++ b/docs/operations/run-service.md
@@ -1,0 +1,141 @@
+# Detached run service
+
+Submit a goal, disconnect the terminal, and reattach from any shell later
+against a supervised run whose continuity across the detach boundary is
+provable, not assumed.
+
+```
+bernstein run-service submit <goal> --task <id>...
+bernstein run-service attach <run-id>
+bernstein run-service status [<run-id>]
+bernstein run-service stop <run-id>
+bernstein run-service verify <run-id>
+```
+
+## Why
+
+`bernstein run` ties a run's lifetime to the invoking terminal. For a single
+long-running goal an operator wants to kick off and check back on later - not
+a full multi-host cluster - `run-service` decouples execution from the
+terminal on one host: a session-detached supervisor owns execution while a
+durable work ledger owns state, and `attach` proves the ledger it reads is a
+genuine continuation of the one last seen before rendering anything.
+`bernstein worker` remains the separate multi-host fan-out path; this is
+single-host detach/reattach.
+
+## `submit`
+
+```bash
+bernstein run-service submit "Fix the auth regression" --task fix-auth --task add-tests
+```
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--task ID` (repeatable) | required | Task id to schedule; at least one is required. |
+| `--foreground` | off | Advance the run in this process instead of spawning a detached supervisor. |
+| `--per-task-delay SECONDS` | `0.0` | Dwell time per task, useful for making off-terminal progress observable. |
+| `--backend {local,ssh}` | `local` | Execution backend for the run's tasks. |
+| `--ssh-host HOST` | - | ssh host (required for `--backend ssh`). |
+| `--ssh-path PATH` | - | Absolute remote dir under which per-task worktrees are provisioned (required for `--backend ssh`). |
+| `--ssh-user USER` | - | Remote ssh user (optional). |
+| `--ssh-port PORT` | `22` | Remote ssh port. |
+| `--ssh-identity PATH` | - | Path to the ssh private key (optional). |
+| `--ssh-repo PATH` | - | Remote repo path to git-worktree each task from (optional). |
+| `--ssh-base-branch REF` | `main` | Base ref each per-task worktree branch is cut from. |
+| `--ssh-secret ENV=PROVIDER` (repeatable) | - | Inject a vault credential into the remote environment variable `ENV`, resolved from the credential vault only. |
+| `--workdir PATH` | cwd | Project root. |
+| `--json` | off | Machine-readable output. |
+
+Opening a run seeds the work ledger (`run.open` plus one `task.scheduled` row
+per `--task`), persists a run descriptor, and signs a `submitted` lifecycle
+receipt into the HMAC audit chain. **The goal text itself is never written to
+the ledger - only its SHA-256 digest** (`goal_digest`), so the portable
+ledger doesn't carry the goal's raw text. Without `--foreground`, a
+session-detached supervisor process is spawned that survives the invoking
+terminal; reattach later with `attach`.
+
+### Off-host execution (`--backend ssh`)
+
+`--backend ssh` runs each task off-host in its own isolated remote git
+worktree (one branch per task) and appends a signed `run.ssh_task` receipt
+binding that worktree, so an offline verifier can prove each task ran in
+isolation across the ssh boundary. Remote credentials are resolved from the
+credential vault only via `--ssh-secret ENV=PROVIDER` and never reach the
+ledger or the receipts. A supervisor killed mid-run on the ssh backend
+resumes from the ledger tip with zero lost completed tasks, the same
+guarantee as the local backend.
+
+## `attach`
+
+```bash
+bernstein run-service attach <run-id>
+```
+
+Reattaches from any shell: proves the current ledger head is a forward
+extension of the head last seen - that proof, not a bare "still running"
+check, is the reattach artefact - records a `reattached` receipt, and renders
+the live projection (completed / in-flight / scheduled tasks).
+
+Exit codes: `0` continuous, `1` no such run, `3` continuity broken (the
+ledger diverged, or failed to verify).
+
+## `status`
+
+```bash
+bernstein run-service status [<run-id>]
+```
+
+Shows supervisor liveness plus the ledger projection for one run. With no
+`run-id`, lists every run known to the project (running state, completed /
+in-flight / scheduled counts, closed state). Exit `1` when a named run does
+not exist.
+
+## `stop`
+
+```bash
+bernstein run-service stop <run-id>
+```
+
+Stops the run's supervisor process (SIGTERM, then SIGKILL after a grace
+window) and records a `detached` boundary receipt so a later `attach` can
+prove continuity across it. Exit `1` when the run does not exist; stopping an
+already-stopped run still records the detach boundary and exits `0`.
+
+## `verify`
+
+```bash
+bernstein run-service verify <run-id>
+```
+
+Re-verifies offline that the HMAC audit chain is intact, the work ledger
+recomputes end to end, and every lifecycle receipt binds a ledger head that
+genuinely exists in the chain (every reattach / daemon-restart boundary is a
+true ancestor, not a fabricated one). Exit `0` verified, `2` a check failed
+(each reason is listed).
+
+## How continuity is proved
+
+Every lifecycle boundary - submitted, reattached, detached - is a receipt
+signed into the HMAC audit chain, and the run's state (completed / in-flight
+/ scheduled tasks) is always a projection of the durable work ledger, never a
+mutable side table. `attach` and `verify` both replay the ledger from
+genesis rather than trusting a cached status, so a supervisor killed mid-run
+resumes execution from the ledger tip with zero lost completed tasks, and a
+tampered or truncated ledger fails `verify` at the exact position it
+diverges.
+
+## Source
+
+- `src/bernstein/core/run_service/service.py` - `RunService` (submit,
+  attach, project, detach).
+- `src/bernstein/core/run_service/descriptor.py` - the run descriptor and
+  `goal_digest()`.
+- `src/bernstein/core/run_service/supervisor.py` - the detached supervisor
+  process and liveness checks.
+- `src/bernstein/core/run_service/ssh_runner.py` - the ssh backend.
+- `src/bernstein/core/run_service/verify.py` - offline verification.
+- `src/bernstein/cli/commands/run_service_cmd.py` - the `bernstein
+  run-service` command group.
+
+See also: [Known limitations §2](../reference/KNOWN_LIMITATIONS.md) for how
+this fits alongside cluster/worker fan-out.

--- a/docs/operations/self-update.md
+++ b/docs/operations/self-update.md
@@ -1,0 +1,66 @@
+# Self-update
+
+`bernstein self-update` upgrades (or rolls back) the installed `bernstein`
+package via `pip`, checking PyPI for the latest released version and
+showing the relevant GitHub release notes before installing.
+
+## Usage
+
+```bash
+bernstein self-update             # check PyPI, show changelog, prompt, upgrade
+bernstein self-update --check     # show latest version only, don't install
+bernstein self-update --rollback  # revert to the previously installed version
+bernstein self-update -y          # upgrade without a confirmation prompt
+```
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--check` | off | Print the installed vs. latest-on-PyPI version and exit; no install. |
+| `--rollback` | off | Reinstall the previously installed version (see below); ignores `--check`. |
+| `--yes`, `-y` | off | Skip the `Upgrade X → Y?` confirmation prompt. |
+
+## How it behaves
+
+1. Reads the installed version via `importlib.metadata.version("bernstein")`
+   (`"unknown"` if the package metadata can't be found).
+2. Queries `https://pypi.org/pypi/bernstein/json` for the latest published
+   version. If PyPI can't be reached, the command prints a network-error
+   message and exits `1`.
+3. Prints an installed/latest version table.
+4. With `--check`, stops here.
+5. If already up to date, reports so and stops.
+6. Otherwise fetches GitHub releases
+   (`api.github.com/repos/.../releases`) and prints the body (truncated to
+   300 characters) of every release tag strictly between the installed and
+   latest version, newest first. A GitHub API failure is swallowed — the
+   upgrade still proceeds, just without a changelog.
+7. Prompts `Upgrade <current> → <latest>?` unless `--yes` was passed.
+8. Before installing, writes the current version to
+   `~/.bernstein/previous-version` (skipped if the current version is
+   `"unknown"`) — this is the rollback point for `--rollback`.
+9. Runs `pip install bernstein==<latest> --quiet` in a subprocess. On
+   failure, prints pip's stderr and exits `1`.
+
+### Rollback
+
+`--rollback` reads `~/.bernstein/previous-version`. If that file doesn't
+exist (no prior successful upgrade recorded a rollback point), it prints a
+message and exits `1`. Otherwise it `pip install`s the recorded version and,
+on success, deletes the rollback file — so rollback is a one-shot action:
+you can't roll back twice in a row without upgrading again first.
+
+## Limitations
+
+- There's only one rollback slot. Each successful upgrade overwrites
+  `~/.bernstein/previous-version` with whatever was installed immediately
+  before it — there is no multi-version history.
+- All installs go through `pip install <pkg>==<version>`; the command
+  doesn't detect or special-case `pipx`, `uv tool`, Homebrew, or other
+  installation methods. Restart your shell (or check
+  `bernstein --version`) after upgrading to confirm the new version is
+  actually the one being invoked.
+
+## Source
+
+`src/bernstein/cli/commands/self_update_cmd.py` (`self_update_cmd`,
+registered as `bernstein self-update`).

--- a/docs/operations/session-analytics.md
+++ b/docs/operations/session-analytics.md
@@ -1,0 +1,54 @@
+# Session analytics (`bernstein recap`)
+
+`bernstein recap` prints a post-run summary — task completion counts, git
+diff stats, quality-gate score distribution, and a cost breakdown — so an
+operator can see what a run accomplished without piecing it together from
+the task list and the logs separately.
+
+## CLI
+
+```bash
+bernstein recap                   # Rich tables
+bernstein recap --as-json         # machine-readable JSON
+```
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--archive PATH` | `.sdd/archive/tasks.jsonl` | Accepted but currently unused — see [Limitations](#limitations). |
+| `--as-json` | off | Emit the raw JSON payload instead of Rich tables. |
+
+## What it shows
+
+The command calls the task server's `GET /recap` endpoint
+(`core/routes/observability.py`), which reads every task currently known to
+the live task store and returns:
+
+| Section | Contents |
+|---|---|
+| `summary` | Total / completed / failed task counts and success rate. |
+| `diff_stats` | `git diff --numstat` rollup for completed tasks: files changed, additions, deletions. |
+| `quality_scores` | Average quality score, A-F grade distribution, last 10 scores, and per-gate averages (lint, tests, type-check, security scan), read from `.sdd/metrics/quality_scores.jsonl`. |
+| `cost_breakdown` | Total spend, per-model cost/tokens/invocations, and per-role cost, read from the most recent `.sdd/metrics/costs_*.json` snapshot. |
+| `tasks` | Flat list of every task's id, title, status, role, and complexity. |
+
+In the Rich (non-JSON) view, these render as four separate tables: Recap,
+Git Diff Stats, Quality Scores, and Cost Breakdown.
+
+## Limitations
+
+- `--archive PATH` is accepted by the CLI but is not read anywhere in the
+  command's implementation (`cli/commands/advanced_cmd.py`) — the command
+  always queries the server's `/recap` endpoint against the live task
+  store, regardless of the flag's value.
+- `quality_scores` and `cost_breakdown` degrade to zeroed defaults when
+  their respective `.sdd/metrics/` files are missing (a project with no
+  quality gates or cost tracking configured still gets a valid, empty
+  response rather than an error).
+- The summary reflects whatever tasks the task server currently holds, not
+  a fixed archive snapshot — running `bernstein recap` again after more
+  tasks complete returns different numbers.
+
+## Source
+
+- `src/bernstein/cli/commands/advanced_cmd.py` — `bernstein recap` command and table rendering
+- `src/bernstein/core/routes/observability.py` — `GET /recap` endpoint, quality-score and cost-breakdown aggregation

--- a/docs/operations/session-fast-resume.md
+++ b/docs/operations/session-fast-resume.md
@@ -1,0 +1,87 @@
+# Session persistence (fast resume)
+
+On a graceful stop, Bernstein snapshots which tasks were done, in-flight,
+and still queued. On the next start, if that snapshot is fresh enough, the
+orchestrator skips the manager's planning phase and picks up where the
+previous run left off instead of re-planning the goal from scratch.
+
+Source: `src/bernstein/core/persistence/session.py`.
+
+## What gets saved
+
+`SessionState`, written to `.sdd/runtime/session.json`:
+
+| Field | Meaning |
+|---|---|
+| `saved_at` | Unix timestamp of the snapshot |
+| `goal` | The run's goal text |
+| `completed_task_ids` | Tasks that reached `done` |
+| `pending_task_ids` | Tasks that were `claimed` or `in_progress` |
+| `open_task_ids` | Tasks that were queued but not yet claimed |
+| `cost_spent` | Cumulative USD cost for the run |
+
+## When it is saved
+
+- `bernstein stop` calls `save_session_on_stop()`, which queries the running
+  task server for current task statuses and writes `session.json`. If the
+  server is unreachable, it falls back to a lightweight diagnostic file
+  (`session_state.json`) that fast-resume does not read.
+- Ctrl-C during an interactive dashboard session runs the same save through
+  the installed `SIGINT` handler before the process exits.
+- The orchestrator also saves session state internally at points during a
+  run (`orchestrator._save_session_state()`), not only at shutdown.
+
+## When it is resumed
+
+On the next `bernstein run` (or equivalent start path), `bootstrap.py` calls
+`check_resume_session()`, which loads `session.json` unless:
+
+- `--fresh` was passed on the command line, or
+- `session.resume` is set to `false` in config, or
+- the snapshot is older than the staleness threshold.
+
+```bash
+bernstein run --fresh   # ignore any saved session; start clean
+```
+
+Config (`bernstein.yaml`):
+
+```yaml
+session:
+  resume: true              # default; set false to always start fresh
+  stale_after_minutes: 30   # default; snapshots older than this are discarded
+```
+
+A session with unfinished work (any `pending_task_ids` or `open_task_ids`)
+is never treated as a completed run on resume — the orchestrator falls
+through to work the remaining backlog or re-plan the goal, rather than
+declaring the run done with queued work silently dropped
+(`SessionState.has_unfinished_work()`). Only a session whose queue was
+fully drained short-circuits planning and reports "N done previously".
+
+## Related, separate persistence in the same module
+
+`core/persistence/session.py` also defines several other stop/resume
+adjacent primitives that are not part of fast-resume itself:
+
+- `WrapUpBrief` / `save_wrapup()` / `load_wrapup()` — end-of-session
+  human-readable summary (`bernstein wrap-up`), written to
+  `.sdd/sessions/<timestamp>-wrapup.json`.
+- `save_checkpoint()` / `load_checkpoint()` — point-in-time progress
+  snapshots (`bernstein checkpoint`), written to
+  `.sdd/sessions/<timestamp>-checkpoint.json`. This is a different
+  mechanism from checkpointed *retries* — see
+  [Checkpointed retries](checkpointed-retries.md).
+- `latch_session_flags()` / `load_latched_flags()` — session-stable
+  feature-flag values that should not re-evaluate mid-session.
+- `record_bridge_event()` / `load_bridge_lineage()` — remote-bridge
+  connect/disconnect/rebuild lineage for chat/dashboard handoff (a
+  different feature from [Session handoff](session-handoff.md)).
+- `emit_task_notification()` / `load_task_notifications()` — structured
+  terminal status reports from agents.
+- `save_startup_gate_checkpoints()` / `load_startup_gate_checkpoints()` —
+  per-gate enabled/disabled/cached state captured at startup, for
+  diffing gate configuration between restarts.
+
+These share the module and the `.sdd/` on-disk layout but are independent
+of the `session.json` fast-resume path described above.

--- a/docs/operations/shell-completions.md
+++ b/docs/operations/shell-completions.md
@@ -1,0 +1,54 @@
+# Shell completions
+
+`bernstein completions` prints a shell completion script for the `bernstein`
+CLI, generated from Click's built-in completion support. It reflects the
+live command tree — every group and command registered on the root CLI at
+the moment the script is generated, including their subcommands.
+
+## Usage
+
+```bash
+bernstein completions --shell bash
+bernstein completions --shell zsh
+bernstein completions --shell fish
+```
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--shell` | `bash` | One of `bash`, `zsh`, `fish`. |
+
+### Installing
+
+**bash** — add to `~/.bashrc`:
+
+```bash
+eval "$(bernstein completions --shell bash)"
+```
+
+**zsh** — add to `~/.zshrc`:
+
+```bash
+eval "$(bernstein completions --shell zsh)"
+```
+
+**fish** — write the script to fish's completions directory:
+
+```bash
+bernstein completions --shell fish | source
+```
+
+## How it behaves
+
+The command walks up from its own Click context to the root CLI group, so
+the generated script always covers the full command tree, not just the
+`completions` command itself. It uses Click's `BashComplete` / `ZshComplete`
+/ `FishComplete` classes directly (the same mechanism Click's own
+`_BERNSTEIN_COMPLETE` environment-variable completion protocol uses under
+the hood) rather than a hand-maintained list of subcommands, so newly added
+commands and options get tab completion automatically without any change to
+this command.
+
+## Source
+
+`src/bernstein/cli/commands/completions_cmd.py` (`completions_cmd`,
+registered as `bernstein completions`).

--- a/docs/operations/skill-provenance.md
+++ b/docs/operations/skill-provenance.md
@@ -1,0 +1,82 @@
+# Skill usage provenance
+
+The [skill catalog](skills-catalog.md) proves *what a registry claims* about
+a skill — a signed manifest and a content digest. It does not, on its own,
+tie an install to what the skill actually did. `bernstein skill provenance`
+and `bernstein skill verify` add that usage-attestation layer on top of the
+content-hash pinning already carried in `skills.lock`.
+
+This is a different CLI group from `bernstein skills catalog` (plural
+`skills`, browse/install/upgrade). `bernstein skill` (singular) only
+inspects usage of an already-installed skill.
+
+## Commands
+
+```
+bernstein skill provenance SKILL [--workdir DIR]
+bernstein skill verify SKILL [--workdir DIR]
+```
+
+`SKILL` is either a catalog entry id (resolved to its installed content
+digest via `skills.lock`) or a raw content digest.
+
+### `provenance` — verified runs and artifacts a skill fed
+
+Prints a table of every run the skill participated in, together with each
+run's journal head and whether that head still verifies. Exit codes: `0`
+graph rendered (may be empty when the skill has no recorded usage), `1` bad
+input.
+
+The verified-run count (`verified_runs` in the header line) is **recomputed
+on every call** from the runs whose journal head still verifies and still
+equals the head recorded at usage-link time — it is never read from a
+stored counter. A run whose journal has since diverged or been tampered
+with drops out of the count rather than inflating it.
+
+### `verify` — recompute the install receipt
+
+Recomputes the skill's install receipt and flags a `manifest_hash` that no
+longer matches the currently installed content — a drift indicates a manual
+edit under `.bernstein/skills/<name>/` or a rewritten install. Exit codes:
+`0` verified (receipt anchored, manifest hash matches), `1` no receipt for
+the skill, or the skill id has no matching row in `skills.lock` (pass a
+catalog entry id installed via `bernstein skills catalog install`), `2`
+mismatch (manifest hash drifted from the receipt).
+
+## How usage is recorded
+
+- **Install receipt.** Installing a skill records an `InstallReceipt`
+  (`{skill_hash, manifest_hash, install_id, timestamp}`) into a dedicated
+  lineage-spine run (`run_id="skills"`). The receipt bytes are the artifact
+  the spine hashes, so the returned anchor is the spine entry hash over the
+  receipt itself.
+- **Usage link.** `record_usage()` appends a line to
+  `.sdd/skills/usage/<skill_hash>.jsonl` binding the skill hash to a run's
+  journal head (the spine head hash) — a pointer into the Merkle-chained run
+  journal, not a copy of it — whenever a skill participates in a run.
+- **Provenance graph.** `provenance` walks those usage links and returns
+  only the runs whose journal head still verifies *and* still equals the
+  head recorded at link time.
+
+Receipt rows and usage rows are canonical JSON (sorted keys, minimal
+separators), so two byte-identical inputs produce byte-identical files and
+anchors.
+
+## Limitation: usage linking is not yet wired into a run
+
+The install receipt is wired end to end: `bernstein skills catalog install`
+calls `write_install_receipt` on every install, so `bernstein skill verify`
+has a real receipt to check against for any skill installed through the
+catalog. As of this writing, however, no orchestration code path calls
+`record_usage()` — the usage-link write side lives in
+`core/skills/provenance.py` with no caller outside its own tests. Until a
+run-time hook wires `record_usage()` into skill invocation,
+`bernstein skill provenance` will correctly report "No recorded usage for
+this skill" for every skill, regardless of how often it actually ran.
+
+## Source
+
+`src/bernstein/cli/commands/skill_cmd.py` (CLI),
+`src/bernstein/core/skills/provenance.py` (install receipt, usage link,
+provenance graph, verify). See [Skill catalog](skills-catalog.md) for the
+install/lockfile surface this builds on.

--- a/docs/operations/slack-webhooks.md
+++ b/docs/operations/slack-webhooks.md
@@ -1,0 +1,123 @@
+# Slack webhook integration
+
+Bernstein exposes two HTTP routes that let a Slack app create tasks
+directly, without going through the Socket Mode chat bridge: a slash
+command receiver and an Events API receiver. Both live in
+`core/routes/slack.py` and are registered on the same FastAPI app that
+serves `bernstein serve`.
+
+This is a **different integration path** from the interactive chat
+bridge documented at [Chat bridges](chat-bridges.md)
+(`bernstein chat serve --platform=slack`, Socket Mode, approve/reject
+buttons, streamed output). The webhook routes here are one-shot: an
+inbound HTTP request creates exactly one task and returns an
+acknowledgement. There's no session, no streaming, and no approval UI.
+
+---
+
+## Routes
+
+### `POST /webhooks/slack/commands` - slash commands
+
+Receives a Slack slash command payload (URL-encoded form body), verifies
+the request signature, and creates a task from the command text.
+
+- Parses `command`, `text`, `user_id`, `channel_id`, `response_url`,
+  `trigger_id`, `thread_ts` from the form body.
+- If `text` is non-empty, creates a task via `TaskStore.create()` with
+  `title` = first 60 characters of `text`, `description` = full `text`,
+  `role="backend"`, `priority=1`, `scope="small"`, and a `slack_context`
+  dict carrying `channel_id`, `user_id`, `thread_ts`, `response_url`.
+- Responds within Slack's 3-second window with
+  `{"response_type": "ephemeral", "text": "Task `<id>` created: ..."}`
+  (or a "no task text provided" message if `text` was empty).
+
+### `POST /webhooks/slack/events` - Events API
+
+Receives Slack Events API callbacks.
+
+- `url_verification` events: echoes back the `challenge` value (required
+  once, when you register the endpoint in the Slack app config).
+- `event_callback` events of type `message`: creates a task only when
+  the bot user is `@`-mentioned in the message text. Bot messages and
+  `message_changed` subtypes are ignored (loop prevention).
+- On an actionable mention, the mention is stripped from the text and
+  the remainder becomes the task title/description, with `slack_context`
+  carrying `channel`, `user`, `thread_ts`.
+- All other event types return `{"ok": true}` without side effects.
+
+This route is also documented from the trigger-routing angle (how it
+fits alongside GitHub, OData, and schedule triggers) at
+[Trigger sources](trigger-sources.md#two-independent-paths-from-event-to-task);
+this page is the Slack-specific reference for both routes together.
+
+---
+
+## Request verification
+
+Both routes verify the Slack HMAC request signature
+(`x-slack-request-timestamp` + `x-slack-signature` headers) against a
+signing secret, using `verify_slack_signature()` from
+`trigger_sources/slack.py`. The secret is read from
+`app.state.slack_signing_secret` if the server was started with one, else
+from the `SLACK_SIGNING_SECRET` environment variable.
+
+**If no signing secret is configured, verification is skipped entirely**
+- both routes accept unsigned requests in that case. Set
+`SLACK_SIGNING_SECRET` (or pass `slack_signing_secret=` when building the
+app) to enforce verification. A failed verification returns `401`; a
+malformed payload returns `400`.
+
+The Events API route additionally reads `SLACK_BOT_USER_ID` from the
+environment to recognize `@`-mentions. If it's unset, every message in a
+watched channel is treated as a mention (the `<@bot_id>` substring check
+is skipped).
+
+---
+
+## Setup
+
+1. Create a Slack app (or reuse the one from [Chat bridges](chat-bridges.md)
+   if you also run the Socket Mode driver).
+2. Point the app's **Slash Commands** request URL at
+   `https://<your-host>/webhooks/slack/commands`.
+3. Point the app's **Event Subscriptions** request URL at
+   `https://<your-host>/webhooks/slack/events`, complete the
+   `url_verification` challenge, and subscribe to the `message.channels`
+   (or equivalent) bot event.
+4. Set the environment variables on the machine running `bernstein serve`:
+
+   ```sh
+   export SLACK_SIGNING_SECRET=...
+   export SLACK_BOT_USER_ID=...   # optional; recognizes @-mentions
+   ```
+
+5. Run the server: `bernstein serve` (or however your deployment starts
+   `core/server/server_app.py`).
+
+---
+
+## Limitations
+
+- No response is posted back into the Slack thread beyond the immediate
+  slash-command acknowledgement - task progress is not streamed to
+  Slack from these routes. Use the chat bridge if you need that.
+- The Events API handler only reacts to `message` events with an
+  `@`-mention; it does not parse structured commands out of a mention
+  the way the slash-command route does.
+- Task fields created here are fixed (`role="backend"`, `priority=1`,
+  `scope="small"`) - there is no per-workspace configuration for these
+  defaults.
+
+---
+
+## Source
+
+- `src/bernstein/core/routes/slack.py` - both route handlers
+  (`slack_slash_command`, `slack_events`).
+- `src/bernstein/core/trigger_sources/slack.py` - `verify_slack_signature`,
+  `normalize_slack_message`.
+- `src/bernstein/core/server/server_app.py` - `slack_signing_secret` app
+  state wiring.
+- `docs/reference/openapi-reference.md` - flag/route index entries for
+  `POST /webhooks/slack/commands` and `POST /webhooks/slack/events`.

--- a/docs/operations/token-growth-monitor.md
+++ b/docs/operations/token-growth-monitor.md
@@ -1,0 +1,103 @@
+# Token growth monitor
+
+Every orchestrator tick, Bernstein reads each live agent's token sidecar
+file, tracks its cumulative consumption, and intervenes when an agent is
+burning tokens without producing output or when its context is growing
+super-linearly. Interventions range from a one-time "wrap up" nudge to a
+hard kill.
+
+Source: `src/bernstein/core/tokens/token_monitor.py`, called each tick as
+`check_token_growth(orch)` from `core/orchestration/orchestrator.py`.
+
+## How it reads usage
+
+Each agent session writes token records to
+`.sdd/runtime/{session_id}.tokens` - one JSON line per model turn,
+`{"ts": <float>, "in": <int>, "out": <int>}`. The monitor reads only the
+bytes appended since its last read (a stored byte offset), so polling every
+tick is cheap. A new `(timestamp, cumulative_tokens)` sample is appended to
+the session's rolling history at most once every 30 seconds
+(`TOKEN.sample_interval_s`), capped to the last 20 samples (~10 minutes).
+
+## Interventions, in the order the tick hook applies them
+
+| # | Check | Trigger | Action |
+|---|---|---|---|
+| 1 | Auto-kill | cumulative tokens ≥ 50,000 (`TOKEN.kill_threshold`) **and** zero files changed | `SIGKILL` the agent, transition it to `dead` (reason `token budget exceeded`) |
+| 2 | Quadratic-growth warning | the most recent per-window token delta is ≥ 2x (`TOKEN.quadratic_ratio`) the previous delta, with ≥3 samples | log a warning once, send a WAKEUP signal to the agent |
+| 3 | Proactive compaction | delegates to the `compaction.proactive` lane (off by default) | see [Proactive context compaction](context-compaction.md) |
+| 4 | Context-window compaction | context utilization crosses 90% (`TOKEN.compact_threshold_pct`) and the per-session circuit breaker allows it | send a compaction WAKEUP signal |
+| 5 | Budget nudge | `tokens_used` reaches 80% of the session's configured `token_budget` | send a one-time WAKEUP asking the agent to wrap up |
+
+"Files changed" for the auto-kill check comes from the latest progress
+snapshot for each of the agent's tasks. If no snapshot exists yet, the check
+is skipped for that tick (conservative - an agent is never killed before
+there is any evidence about its output).
+
+### Auto-kill
+
+```
+Token runaway: agent <id> consumed <N> tokens with 0 file changes
+(tenant=<tenant> threshold=<threshold>) - killing
+```
+
+The kill threshold can be overridden per tenant via
+`TokenGrowthMonitor.tenant_kill_thresholds` (a `{tenant_id: threshold}` map)
+or the module-level `TOKEN_CFG` dict - both are set programmatically, not
+through `bernstein.yaml`; there is currently no config-file surface for
+per-tenant overrides.
+
+### Quadratic-growth warning
+
+Detects when an agent's context is accelerating rather than growing
+linearly: it compares the last two consecutive per-window token deltas, and
+warns when the newer delta is at least `quadratic_ratio` (2.0x) the older
+one. The warning fires once per burst, then resets after 10 consecutive
+non-growth samples so a later burst can warn again.
+
+### Budget nudge
+
+The nudge text instructs the agent to finish its current edit, run tests on
+changed files, commit with a `[WIP]` message, mark the task complete (or
+failed), and exit cleanly. It fires at most once per session.
+
+### Auto-compact circuit breaker
+
+The context-window compaction trigger (row 4 above) is gated by a per-session
+circuit breaker (`AutoCompactCircuitBreaker`): `CLOSED` → `OPEN` after 3
+consecutive compaction failures (`TOKEN.compact_max_failures`), `OPEN` →
+`HALF_OPEN` after a 120s cooldown (`TOKEN.compact_cooldown_s`), and back to
+`CLOSED` on the next success. This is the *reactive* compaction trigger -
+distinct from the separately-configured, receipted *proactive* lane described
+in [Proactive context compaction](context-compaction.md).
+
+## Defaults
+
+All thresholds live in `TokenDefaults` (`src/bernstein/core/defaults.py`):
+
+| Constant | Default | Meaning |
+|---|---|---|
+| `kill_threshold` | 50,000 | tokens before auto-kill (with zero file changes) |
+| `min_samples_for_growth_check` | 3 | samples needed before quadratic check runs |
+| `quadratic_ratio` | 2.0 | growth-rate multiplier that triggers the warning |
+| `sample_interval_s` | 30.0 | seconds between recorded samples |
+| `compact_threshold_pct` | 90.0 | context-window % that triggers compaction |
+| `compact_max_failures` | 3 | consecutive compaction failures before the breaker opens |
+| `compact_cooldown_s` | 120.0 | seconds before a retry after the breaker opens |
+| `nudge_threshold_pct` | 80.0 | fraction of `token_budget` that triggers the wrap-up nudge |
+
+## Limitations
+
+- The monitor is unconditional - there is no `enabled` flag in
+  `bernstein.yaml` to turn it off. Overriding thresholds requires
+  constructing a `TokenGrowthMonitor` with different values or populating
+  `TOKEN_CFG` / `tenant_kill_thresholds` programmatically.
+- The auto-kill check treats "zero file changes" as the sole progress
+  signal; an agent doing legitimate long-running analysis with no file
+  writes yet (e.g. an investigation task) can hit the kill threshold.
+
+## Related
+
+- [Proactive context compaction](context-compaction.md) - the separately
+  configured, receipted compaction lane this monitor's reactive trigger
+  complements.

--- a/docs/operations/tournament-runs.md
+++ b/docs/operations/tournament-runs.md
@@ -1,0 +1,145 @@
+# Tournament runs
+
+Run several independent attempts at one hard task in parallel and pick the
+winner with scripted evaluators - no model call in the decision path - then
+inspect or offline-verify exactly why one attempt won.
+
+## Why
+
+A single attempt at a hard task often lands mediocre, and the usual fix is an
+operator re-running the task by hand and eyeballing diffs. A tournament fans
+out `attempts` independent siblings of one task and selects the winner by
+scripted checks (test pass rate, lint status, coverage, an arbitrary
+command's exit status), each carrying a weight and a direction. The result an
+operator inspects is not just "attempt 3 won" - it is a signed
+`TournamentReceipt` naming every attempt's content hash, every evaluator's
+output, every blended score, the winner, and the lineage edges (one
+`chosen`, the rest `sibling`).
+
+## Declaring a tournament
+
+A tournament is declared with a `TournamentSpec`: a number of `attempts` and
+an ordered, non-empty set of evaluators.
+
+```python
+from bernstein.core.tournament.spec import EvaluatorSpec, TournamentSpec
+
+spec = TournamentSpec(
+    attempts=3,
+    evaluators=(
+        EvaluatorSpec(name="tests", weight=2.0, higher_is_better=True),
+        EvaluatorSpec(name="lint", weight=1.0, higher_is_better=True),
+    ),
+)
+```
+
+`TournamentSpec.spec_hash()` is a `sha256:` content hash of the canonical
+spec, so the same declared tournament always hashes to the same value and can
+be pinned into the receipt for offline replay. `attempts` must be `>= 1`,
+evaluator names must be unique, total weight must be positive, and the only
+supported `tie_break` is `attempt_hash` (stable ascending order).
+
+## Running one
+
+`TournamentRunner` (`src/bernstein/core/tournament/runner.py`) is a
+programmatic primitive, not a `bernstein run` flag: it takes three callbacks
+- a `spawner` that fans out `n` sibling attempts and returns their ids, an
+`evaluator` that blocks until attempts finish and returns their outcomes, and
+an optional `reclaimer` that tears down losing attempts - so it is
+agent-agnostic and testable without a live scheduler. There is currently no
+CLI subcommand that drives a fan-out directly; an integrator wires
+`TournamentRunner` into their own dispatch path.
+
+`TournamentRunner.run()`:
+
+1. Resolves the per-ticket budget ceiling with the same primitive operators
+   already configure (`resolve_ticket_cap_usd`) and raises
+   `TournamentBudgetExceeded` before fan-out starts if
+   `attempts * per_attempt_cost_usd` would exceed it.
+2. Fans out the siblings via the `spawner` callback (optionally through a
+   cache-window warm-up, see below).
+3. Collects evaluator outputs via the `evaluator` callback.
+4. Emits the signed, spine-anchored selection receipt.
+5. Runs the optional `reclaimer` against every non-winning attempt.
+
+Evaluator outputs are collected separately from scoring: an evaluator
+produces an `EvaluatorOutput(name, value, detail)` per attempt, where `value`
+is a normalized number (the scorer clamps to `[0, 1]`). The one evaluator
+helper the module ships is `command_status_output()`, which runs a scripted
+command with no shell and maps exit code `0` to `1.0`, any other exit or a
+subprocess error to `0.0`. Any other evaluator (test pass rate, coverage
+delta, mutation score) is supplied by the integrator's own `evaluator`
+callback in the same `EvaluatorOutput` shape.
+
+## Selection
+
+Selection is a pure function of the outputs and the spec - no model, clock,
+or randomness:
+
+- Each evaluator contributes `weight * signal` to an attempt's blended score,
+  where `signal` is the clamped output value (or `1 - value` when
+  `higher_is_better=False`); a missing output scores as the worst case (`0`).
+  The sum is normalized by total weight.
+- Attempts rank by descending score, ties broken by ascending attempt hash.
+- The top-ranked attempt wins.
+
+Given the same outcomes and spec, `select_winner()` always returns the same
+winner regardless of input order, and `selection_projection_bytes()` (the
+bytes hashed into the receipt) is byte-identical across replays.
+
+## Inspecting and verifying a receipt
+
+```
+bernstein tournament show <task>
+bernstein tournament verify <task>
+```
+
+`bernstein tournament show <task>` renders the receipt: winner, attempt
+count, evaluator names, tie-break rule, spine anchor, and a per-attempt table
+(rank, attempt hash, score, `chosen`/`sibling` edge). `-w/--workdir` sets the
+project root (default `.`). Exit `0` when a receipt exists, `1` when there is
+none.
+
+`bernstein tournament verify <task>` recomputes the selection offline:
+replays the deterministic scorer over the recorded evaluator outputs, checks
+that exactly one edge is `chosen` over the recorded attempts, verifies the
+Ed25519 signature over the canonical binding, and re-anchors the receipt
+against the tournament lineage spine. Exit codes: `0` verified, `1` no
+receipt, `2` mismatch (a tampered score, a hand-picked winner, or a tampered
+receipt/spine). `bernstein audit verify` runs the same integrity check across
+every tournament receipt in a project, alongside every other chained
+receipt.
+
+## Cache-window fan-out (optional)
+
+When a `CacheWindowFanout` config is supplied and the resolved adapter
+supports a cache window, the runner issues one warm-up call to prime the
+shared prompt prefix before the siblings spawn, instead of racing all
+siblings to write the cache independently. See [Cost-aware
+scheduling](cost-aware-scheduling.md) for how the warm-up and cache-hit
+counts are recorded and used elsewhere in cost-aware dispatch. This is
+off/unset by default.
+
+## Limitations
+
+- No CLI or seed-file syntax declares `attempts` / evaluators on a task and
+  triggers a fan-out automatically; `TournamentRunner` is invoked
+  programmatically by an integrator supplying spawn/evaluate/reclaim
+  callbacks.
+- Only one built-in evaluator (`command_status_output`, an exit-status check)
+  ships in the module; every other evaluator kind is caller-supplied.
+
+## Source
+
+- `src/bernstein/core/tournament/spec.py` - `TournamentSpec`,
+  `EvaluatorSpec`.
+- `src/bernstein/core/tournament/evaluators.py` - `EvaluatorOutput`,
+  `AttemptOutcome`, `command_status_output`.
+- `src/bernstein/core/tournament/scorer.py` - deterministic scoring and
+  winner selection.
+- `src/bernstein/core/tournament/runner.py` - `TournamentRunner`, budget
+  gating.
+- `src/bernstein/core/tournament/receipt.py` - `TournamentReceipt`, emission
+  and verification.
+- `src/bernstein/cli/commands/tournament_cmd.py` - `bernstein tournament
+  show` / `verify`.

--- a/docs/operations/trigger-sources.md
+++ b/docs/operations/trigger-sources.md
@@ -1,0 +1,127 @@
+# Trigger sources: normalizing external events into tasks
+
+`core/trigger_sources/` is the package of adapter modules that turn a raw
+external event — a GitHub webhook, a Slack message, an OData row change, a
+schedule fire — into a common `TriggerEvent` shape. Everything downstream
+(rule matching, task creation, audit anchoring) works against that one
+normalized shape instead of against N different payload formats.
+
+```python
+@dataclass
+class TriggerEvent:
+    source: str                       # "github", "slack", "schedule", ...
+    timestamp: float
+    raw_payload: dict[str, Any]
+    repo: str = ""
+    branch: str = ""
+    sha: str = ""
+    sender: str = ""
+    changed_files: tuple[str, ...] = ()
+    message: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+```
+
+(`src/bernstein/core/tasks/models.py`)
+
+## Two independent paths from event to task
+
+Bernstein does not route every event through one central dispatcher. Two
+separate mechanisms consume `TriggerEvent`s, and which one applies depends
+on the source:
+
+**1. Direct task creation** — a handful of production HTTP routes normalize
+the incoming payload and create a task immediately, bypassing the generic
+trigger-rule pipeline entirely:
+
+| Source | Route | Normalizer used |
+|---|---|---|
+| Slack Events API | `POST /webhooks/slack/events` | `trigger_sources/slack.py` (`normalize_slack_message`, `verify_slack_signature`) — a message that @-mentions the bot becomes a task directly. |
+| SLA breach | internal (`schedule_supervisor.py` tick) | `trigger_sources/sla.py` (`normalize_sla_violation`) — feeds the schedule supervisor's own trigger sink. |
+| Schedule fire | internal (`schedule_supervisor.py` tick) | `trigger_sources/schedule.py` (`normalize_schedule_fire`) — see [Recurring schedules](schedule.md). |
+| OData row change | poll loop | `trigger_sources/odata_poll.py` — see [OData integration](odata.md). |
+
+**2. The generic `TriggerManager` pipeline** — operator-authored rules in
+`.sdd/config/triggers.yaml` match against `TriggerEvent.source` (plus
+filters/conditions) and produce a task from a configurable template. This
+is what `bernstein triggers list/history/fire` inspects and drives:
+
+```yaml
+# .sdd/config/triggers.yaml
+defaults:
+  max_tasks_per_minute: 5     # global rate limit across all triggers
+
+triggers:
+  - name: ci-failure-fix
+    source: github_push
+    enabled: true
+    filters:
+      branch: main
+    conditions:
+      cooldown_s: 300          # suppress refires within 5 minutes
+    task:
+      title: "Fix CI failure"
+      role: backend
+      priority: 1
+      description_template: "Investigate: {message}"
+```
+
+`TriggerManager` (`core/orchestration/trigger_manager.py`) loads this file,
+matches an incoming `TriggerEvent` against each enabled rule's `source` and
+`filters` (glob matching on branch/file patterns), enforces the global
+`defaults.max_tasks_per_minute` rate limit, per-trigger `conditions`
+(`cooldown_s`, `max_retries`, dedup, and more), and a default excluded-sender
+list (`bernstein[bot]`, `github-actions[bot]`), then returns task payloads
+for the caller to submit.
+
+## CLI
+
+```
+bernstein triggers list              # configured triggers + last-fired status
+bernstein triggers history [-n N]    # recent fire log (default 20 entries)
+bernstein triggers fire NAME         # synthesize a test event and dry-run it
+```
+
+`bernstein triggers fire` builds a synthetic `TriggerEvent` for the named
+rule's `source`, runs it through `TriggerManager.evaluate()`, shows the task(s)
+that would be created, and asks for confirmation before actually posting them
+to the task server.
+
+(`src/bernstein/cli/commands/triggers_cmd.py`)
+
+## Adapter inventory and wiring status
+
+The Notes on this feature name eight adapters. Not all of them sit on a live
+event path in this codebase today — this table is the ground truth, not the
+aspiration:
+
+| Adapter | Module | Normalizes | Wired into a live path? |
+|---|---|---|---|
+| Slack | `trigger_sources/slack.py` | Events API message payloads | **Yes** — `POST /webhooks/slack/events` calls `normalize_slack_message` directly and creates a task. |
+| Schedule | `trigger_sources/schedule.py` | An in-project schedule fire | **Yes** — via `schedule_supervisor.py`. See [Recurring schedules](schedule.md). |
+| SLA | `trigger_sources/sla.py` | A signed SLA-violation receipt | **Yes** — via `schedule_supervisor.py`'s SLA monitor. |
+| OData | `trigger_sources/odata_poll.py` | A polled system-of-record row change | **Yes**, own poll loop. See [OData integration](odata.md). |
+| Generic webhook | `trigger_sources/receipt.py` (`automation_platforms.py`) | n8n / Zapier / Workato-style inbound payloads | **Yes** — `POST /webhook`. See [Automation bridge](../integrations/automation-bridge.md). |
+| Discord | `trigger_sources/discord.py` | Slash-command interactions | **Partial** — `POST /webhooks/discord/interactions` uses `verify_discord_signature` from this module for request verification; command handling builds its response directly rather than through `normalize_discord_interaction`, which is unused in production. |
+| GitHub | `trigger_sources/github.py` | Push / workflow_run / issues webhooks | **No** — the production route (`POST /webhooks/github`) maps events to tasks through the separate `bernstein.github_app.mapper` module instead. `github.py`'s `normalize_push` / `normalize_workflow_run` / `normalize_issues` are not called from any route; they are available to a custom `TriggerManager`-based rule if you feed them events yourself. |
+| GitLab | `trigger_sources/gitlab.py` | Pipeline / job webhooks | **No** — same situation as GitHub: `POST /webhooks/gitlab` builds tasks directly, not through this module. |
+| Generic HTTP | `trigger_sources/webhook.py` (`normalize_webhook`) | Arbitrary path/method/headers/payload | **No** — not called from any route in this codebase; the live generic-webhook endpoint (`POST /webhook`) creates a task from a task-shaped payload instead of normalizing through this function. |
+| File watch | `trigger_sources/file_watch.py` (`FileWatchSource`) | Debounced filesystem change events (via `watchdog`) | **No** — the class is defined but never instantiated outside its own module; no orchestrator loop drains its queue. The unrelated `bernstein watch` CLI command does not use it either. |
+| Claude Code Routine | `trigger_sources/routine.py` | A Routine session webhook | **No** — `normalize_routine_webhook` is defined but not called from any route. |
+
+## Limitations
+
+Roughly half of the named adapters (GitHub, GitLab, generic HTTP webhook,
+file watch, Routine) are normalization functions with no production caller
+in this codebase — they are usable if you wire them into a custom route or
+a `TriggerManager` rule yourself, but out of the box nothing invokes them.
+Treat the "wired" column above as authoritative over the module list; it
+will drift as routes change, so re-check the call sites (`grep -rn
+"from bernstein.core.trigger_sources"`) before depending on one of the
+"No" rows.
+
+## Source
+
+`src/bernstein/core/trigger_sources/` (adapters); `src/bernstein/core/tasks/models.py`
+(`TriggerEvent`, `TriggerConfig`, `TriggerTaskTemplate`); `src/bernstein/core/orchestration/trigger_manager.py`
+(`TriggerManager`, `.sdd/config/triggers.yaml` loader); `src/bernstein/cli/commands/triggers_cmd.py`
+(`bernstein triggers` CLI).

--- a/docs/operations/tui-keybindings.md
+++ b/docs/operations/tui-keybindings.md
@@ -1,0 +1,89 @@
+# TUI keybindings
+
+The Bernstein TUI's keyboard shortcuts are configurable. Defaults ship
+built in; a project can override them in `bernstein.yaml`, and an operator
+can override them again per-machine in a JSON file, without touching TUI
+code.
+
+## Resolution order
+
+Bindings resolve in three layers, highest priority last:
+
+1. **Defaults** — `DEFAULT_BINDINGS` (`src/bernstein/cli/keybindings.py`)
+   plus `EXTENDED_BINDINGS` (`src/bernstein/tui/keybinding_config.py`).
+2. **Project YAML** — a `keybindings:` section in `bernstein.yaml`, looked
+   up in the current directory first, then `~/.bernstein/bernstein.yaml`.
+3. **User JSON** — `~/.bernstein/keybindings.json`, applied last, so it
+   wins over both defaults and the project YAML.
+
+```yaml
+# bernstein.yaml
+keybindings:
+  quit: "Q"
+  refresh: "F5"
+  toggle_split_pane: "ctrl+l"
+  copy_task_id: "ctrl+y"
+  command_palette: "ctrl+p"
+```
+
+```json
+// ~/.bernstein/keybindings.json
+{
+  "quit": "Q",
+  "command_palette": "ctrl+p"
+}
+```
+
+Each layer maps an **action name** (e.g. `quit`, `toggle_split_pane`) to a
+**key combination** (e.g. `"Q"`, `"ctrl+l"`). An override only replaces
+the key for that one action; every action without an override keeps its
+default.
+
+## Reserved keys
+
+`ctrl+c` and `ctrl+d` can never be rebound. Both the YAML loader and the
+JSON loader check the requested key against this reserved set before
+applying it; a reserved-key override is skipped (the action keeps its
+previous binding) and a warning is logged.
+
+## How it's wired into the TUI
+
+The Textual app builds its `BINDINGS` class variable at import time by
+calling `resolve_all_bindings()`, which merges the three layers above:
+
+```python
+# src/bernstein/tui/app.py
+from bernstein.tui.keybinding_config import resolve_all_bindings as _resolve_all_bindings
+
+def _build_app_bindings() -> list[BindingType]:
+    bindings = [
+        Binding(e.key, e.action, e.description, show=e.show, priority=e.priority)
+        for e in _resolve_all_bindings()
+    ]
+    ...
+```
+
+Pressing `?` or `h` opens the in-TUI help screen, which also calls
+`resolve_all_bindings()` and renders the live, fully-resolved key map —
+so the help screen always reflects your current overrides, not just the
+defaults.
+
+## Limitations
+
+A handful of App-level bindings are registered directly in
+`src/bernstein/tui/app.py` (task search `/`, notification-ack `n`,
+session-recording toggle `R`, and the layout-preset digits `1`/`2`/`3`)
+outside the `resolve_all_bindings()` merge. These are not looked up
+through the keybinding resolution system, so they cannot currently be
+remapped via `bernstein.yaml` or `keybindings.json`.
+
+## Source
+
+- `src/bernstein/cli/keybindings.py` — default bindings, reserved-key
+  check, and `~/.bernstein/keybindings.json` loading.
+- `src/bernstein/tui/keybinding_config.py` — extended defaults,
+  `bernstein.yaml` `keybindings:` loading, and layered resolution
+  (`resolve_all_bindings`).
+- `src/bernstein/tui/app.py` — builds the Textual `BINDINGS` list from
+  `resolve_all_bindings()` at startup.
+- `src/bernstein/tui/help_screen.py` — renders the live resolved key map.

--- a/docs/operations/voice-control.md
+++ b/docs/operations/voice-control.md
@@ -5,7 +5,7 @@ from your microphone, transcribe it locally with `faster-whisper`,
 match the result against a small grammar plus a user-defined alias
 file, and either print or run the resulting Bernstein CLI command.
 
-`reference/FEATURE_MATRIX.md:185` flags this as **experimental**. The
+The [feature matrix](../reference/FEATURE_MATRIX.md) flags this as **experimental**. The
 parser only knows a handful of phrases, the audio capture loop is a
 single thread, and there is no wake-word - once started, every
 utterance above the silence threshold is transcribed and matched. Plan
@@ -214,5 +214,5 @@ larger refactor.
   `_capture_and_transcribe`.
 - `cli/commands/voice_cmd.py:378-429` - main `_listen_loop` with
   `--dry-run` and subprocess dispatch.
-- `docs/reference/FEATURE_MATRIX.md:185` - flags `bernstein listen` as
+- `docs/reference/FEATURE_MATRIX.md` - flags `bernstein listen` as
   Voice commands (experimental).

--- a/docs/operations/watch.md
+++ b/docs/operations/watch.md
@@ -1,0 +1,65 @@
+# File watch and auto re-run
+
+`bernstein watch` watches a directory for source-file changes and
+automatically re-runs open tasks against the task server when files change.
+It's a local dev-loop convenience, not a trigger source: it doesn't create
+or route tasks, it just kicks off `bernstein run --auto-approve` whenever
+something in the watched tree is saved.
+
+> This is a different feature from the `file_watch` trigger source adapter
+> (`core/trigger_sources/file_watch.py`) used by `bernstein triggers`. The
+> two are unrelated — `bernstein watch` doesn't use the trigger-source
+> class, and the trigger-source class isn't wired into any running
+> orchestrator loop. See [Trigger sources](trigger-sources.md).
+
+## Usage
+
+```bash
+bernstein watch                        # watch the current directory
+bernstein watch src/                   # watch a subdirectory
+bernstein watch --glob "src/**/*.py"   # only re-run on Python source changes
+```
+
+| Flag / argument | Default | Meaning |
+|---|---|---|
+| `DIRECTORY` (argument) | `.` | Directory to watch, recursively. |
+| `--glob PATTERN` | none | Restrict triggering changes to files matching this glob (e.g. `"src/**/*.py"`). |
+
+Requires the `watchdog` package (`pip install watchdog`); the command exits
+with an install hint if it isn't present.
+
+## How it behaves
+
+- Watches recursively with `watchdog.observers.Observer`, reacting to
+  create, modify, delete, and move events.
+- Changes inside `.sdd/`, `.git/`, `__pycache__/`, `node_modules/`,
+  `.tox/`, `.venv/`, `venv/`, `dist/`, `build/`, `.pytest_cache/`,
+  `.mypy_cache/`, `.ruff_cache/`, and `.eggs/` are always ignored,
+  regardless of `--glob`.
+- Changed paths are debounced for 2 seconds: rapid successive saves collapse
+  into a single re-run instead of firing one per keystroke/save.
+- After the debounce window fires, the command queries the task server for
+  open tasks (`GET /tasks?status=open`) and prints, per changed file, either
+  "no open tasks", how many open tasks are being re-run, or up to 3 task
+  IDs matched by mentioning the file's path or basename in their title or
+  description (falling back to *all* open tasks if none match by name).
+- It then spawns `python -m bernstein run --auto-approve` as a detached
+  background subprocess (stdout/stderr discarded) — one spawn per debounce
+  window, not one per matched task.
+- Runs until `Ctrl-C`; on exit it stops and joins the underlying
+  `watchdog` observer.
+
+## Limitations
+
+- The per-file "affected tasks" list shown in the console is informational
+  only — the actual re-run always processes *all* open tasks via
+  `bernstein run --auto-approve`, not just the ones whose title/description
+  matched the changed file.
+- No dedup across overlapping runs: if a previous
+  `bernstein run --auto-approve` is still in flight when another debounce
+  window fires, `watch` spawns another one regardless.
+
+## Source
+
+`src/bernstein/cli/commands/watch_cmd.py` (`watch_cmd`, registered as
+`bernstein watch`).

--- a/docs/operations/worker-process-identity.md
+++ b/docs/operations/worker-process-identity.md
@@ -1,0 +1,63 @@
+# Worker process identity
+
+Every `bernstein-worker` process sets its own OS-level process title, so it
+shows up in `ps`, `top`, or Activity Monitor as `bernstein: <role>
+[<session>]` instead of a generic `python` command line. This makes it
+possible to tell which worker is running which role directly from the OS
+process list, without going through `bernstein status`.
+
+## How it works
+
+`bernstein-worker` is the console-script entry point for a single spawned
+agent worker (`bernstein.core.worker:main`, aliased to
+`bernstein.core.orchestration.worker:main`). As the first step after
+argument parsing, `main()` calls `_set_proctitle()`:
+
+```python
+_set_proctitle(f"bernstein: {args.role} [{args.session}]")
+```
+
+`_set_proctitle()` sets the process title via the `setproctitle` package:
+
+```python
+def _set_proctitle(title: str) -> None:
+    """Set the process title for ps / Activity Monitor."""
+    with contextlib.suppress(ImportError):
+        import setproctitle
+
+        setproctitle.setproctitle(title)
+```
+
+`setproctitle` is a core Bernstein dependency, so the title is set on every
+normal install. The `ImportError` guard is defensive only: it keeps a
+worker from crashing on an incomplete or broken install rather than
+signalling that the feature is optional. `--role` and `--session` are the
+same arguments `bernstein-worker` was invoked with; `--session` is
+validated against `^[a-zA-Z0-9_.-]+$` before it reaches the title (the
+worker refuses to start otherwise), so the process title can't be used to
+inject arbitrary characters into `ps` output.
+
+## What you see
+
+```bash
+$ ps aux | grep 'bernstein:'
+user   41213  0.3  0.4  ...  bernstein: qa [a1b2c3d4]
+user   41220  0.2  0.4  ...  bernstein: backend [a1b2c3d4]
+```
+
+The title is `bernstein: {role} [{session}]` — role is the agent role
+(`qa`, `backend`, `security`, ...) and session is the session ID shared by
+every worker in that run.
+
+## Limitations
+
+- The title is set once, at worker startup, from the `--role` and
+  `--session` arguments the process was launched with. It does not update
+  if the worker's role or session context changes later in its lifetime.
+- If `setproctitle` cannot be imported, the process keeps the default
+  interpreter-derived title silently — no warning is logged.
+
+## Source
+
+`src/bernstein/core/orchestration/worker.py` — `_set_proctitle()`, called
+from `main()` (the `bernstein-worker` entry point).

--- a/docs/operations/workflow-manifests.md
+++ b/docs/operations/workflow-manifests.md
@@ -1,0 +1,155 @@
+# Workflow manifests
+
+**How do I chain agent and shell steps into a repeatable pipeline without
+writing a plan YAML by hand each time?**
+
+`bernstein workflow` runs declarative YAML manifests: a small DAG of
+`agent` and `command` nodes with dependencies, optional retry loops, and
+a `{goal}` placeholder substituted at run time. Two schema flavours are
+auto-detected from the same command group - the current YAML manifest
+(`nodes:` as a list) and a legacy conditional DAG DSL (`phases:` +
+`nodes:` as a mapping) kept for backward compatibility.
+
+---
+
+## TL;DR
+
+| Command | Does |
+|---|---|
+| `bernstein workflow list` | List bundled + project + user manifests. |
+| `bernstein workflow run <name> -g "<goal>"` | Execute a manifest. |
+| `bernstein workflow run <name> --dry-run` | Print the execution plan only. |
+| `bernstein workflow validate <file>` | Validate a manifest (either schema). |
+| `bernstein workflow init <name>` | Scaffold a new manifest. |
+| `bernstein workflow show <name>` | Inspect a legacy DSL file's phases/edges. |
+
+Manifests resolve from three places, project-local wins:
+
+1. `<project>/.bernstein/workflows/*.yaml`
+2. `~/.bernstein/workflows/*.yaml`
+3. Bundled `templates/workflows/*.yaml`
+
+---
+
+## Writing a manifest
+
+```yaml
+name: idea-to-pr
+description: "Take a goal from idea to merged PR."
+version: "1.0.0"
+
+nodes:
+  - id: research
+    agent: manager
+    prompt: "Research the goal: {goal}"
+
+  - id: plan
+    depends_on: [research]
+    agent: architect
+    prompt: "Turn the research brief into a concrete plan for: {goal}"
+
+  - id: implement
+    depends_on: [plan]
+    agent: backend
+    prompt: "Carry out the plan for: {goal}"
+    fresh_context: true
+    timeout_seconds: 3600
+
+  - id: tests
+    depends_on: [implement]
+    command: "pytest -x -q"
+    timeout_seconds: 1800
+```
+
+Node fields (`core/workflows/workflow_spec.py`, `WorkflowNode`):
+
+| Field | Meaning |
+|---|---|
+| `id` | Slug-shaped, unique within the manifest. |
+| `depends_on` | Ids that must finish before this node starts. |
+| `command` | Bash command (mutually exclusive with `agent`). |
+| `agent` | Role/spec name that dispatches through `AgentSpawner` (requires `prompt`). |
+| `prompt` | Prompt body; `{goal}` is substituted from `run(goal=...)`. |
+| `loop` | `{until: "<bash predicate>", max_iterations: N}` - re-fires the node until the predicate exits 0 or the cap is hit. |
+| `fresh_context` | Agent nodes only: no session carryover between loop iterations. |
+| `timeout_seconds` | Per-iteration wall-clock cap (1-86400, default set in `workflow_spec.py`). |
+| `interactive` | **Rejected at load time** - see [Limitations](#limitations). |
+
+Bundled examples ship under `templates/workflows/`: `idea-to-pr.yaml`,
+`refactor-with-tests.yaml`, `doc-update.yaml`, `hot-fix.yaml`,
+`security-review.yaml`, `dependency-bump.yaml`.
+
+## Running
+
+```bash
+bernstein workflow run idea-to-pr -g "Add JWT auth"
+bernstein workflow run ./templates/workflows/refactor-with-tests.yaml
+bernstein workflow run idea-to-pr --dry-run   # print topological layers, don't execute
+```
+
+The runner (`core/workflows/workflow_runner.py`, `WorkflowRunner`)
+executes the manifest as a topological DAG: every layer of nodes whose
+dependencies are satisfied runs concurrently via a thread pool.
+Agent-typed nodes dispatch through the existing `AgentSpawner`;
+command-typed nodes shell out with `subprocess.run`. Each node's
+terminal status is one of `success`, `failed`, or `skipped` (skipped
+means an upstream dependency failed). A node with `loop:` re-fires until
+its `until` bash predicate exits `0` or `max_iterations` is reached, at
+which point the run raises rather than silently truncating.
+
+`bernstein workflow run` exits non-zero if any node ends up `failed`.
+
+## Validating and inspecting
+
+```bash
+bernstein workflow validate templates/workflows/idea-to-pr.yaml
+bernstein workflow list
+bernstein workflow list --bundled-only
+bernstein workflow init my-flow
+bernstein workflow init my-flow --target ~/workflows/my-flow.yaml --force
+```
+
+`validate` sniffs the file structurally (no schema import on the
+non-matching path, so a malformed DSL file can't crash the manifest
+validator or vice versa): `phases:` at the top level means legacy DSL,
+a top-level `nodes:` list means the current manifest schema. `init`
+scaffolds a blank manifest and round-trips it through the parser before
+writing, so the scaffold can never fail its own `validate`.
+
+## Legacy DSL
+
+`bernstein workflow show <name>` inspects the older conditional-DAG DSL
+(`core/planning/workflow_dsl.py`): nodes are keyed by id under a mapping
+(not a list), grouped into named `phases:` with `allowed_roles` and
+optional `requires_approval`, and edges may carry guard conditions. DSL
+files live under `.bernstein/workflows/` and are matched by name only
+(no bundled or user-home search path). `workflow list` picks up DSL
+files from the same project directory as a best-effort secondary scan;
+`workflow validate` and `workflow show` both work against them
+directly. New manifests should use the YAML schema above - the DSL path
+exists for files written before the YAML manifest schema landed.
+
+## Limitations
+
+- **`interactive: true` is not implemented.** A node with `interactive`
+  set is rejected at *load* time with a validation error referencing
+  ticket #1110, before any upstream node runs. The runner also carries a
+  defence-in-depth `NotImplementedError` for out-of-band loaders that
+  bypass the validator. There is currently no human-approval gate inside
+  a workflow run.
+- **No per-node adapter/model routing.** Nodes inherit the orchestrator's
+  default adapter and model (`bernstein.yaml` top-level `cli:` + role
+  policy). To pin a different CLI or model for one step, lift the
+  manifest into a plan YAML and use per-step routing instead - see
+  [Per-step CLI and model routing](../workflows/per-step-routing.md).
+- **Bash-only loop predicates and command nodes.** There is no built-in
+  retry/backoff policy beyond `loop.max_iterations`, and command nodes
+  have no sandboxing beyond the orchestrator's own worktree isolation.
+
+## Source
+
+- `src/bernstein/cli/commands/workflow_cmd.py` - CLI group.
+- `src/bernstein/core/workflows/workflow_spec.py` - manifest schema, discovery, resolution.
+- `src/bernstein/core/workflows/workflow_runner.py` - DAG execution.
+- `src/bernstein/core/planning/workflow_dsl.py` - legacy conditional DAG DSL.
+- `templates/workflows/` - bundled manifests.

--- a/docs/operations/wrap-up.md
+++ b/docs/operations/wrap-up.md
@@ -1,0 +1,49 @@
+# Session wrap-up
+
+`bernstein wrap-up` ends the current session with a structured brief:
+completed tasks, learnings pulled from failed tasks, a git diff summary of
+everything changed this session, and a prioritized list of what's left. The
+brief is written to `.sdd/sessions/<timestamp>-wrapup.json` and printed as a
+Rich-formatted summary.
+
+## Usage
+
+```bash
+bernstein wrap-up            # save the brief, keep the orchestrator running
+bernstein wrap-up --stop     # save the brief, then soft-stop
+```
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--stop` | off | Also perform a soft stop (graceful agent drain) after saving the brief. |
+| `--timeout SECONDS` | 30 | Soft-stop drain timeout; only used with `--stop`. |
+
+The command requires a reachable Bernstein task server (it queries `/tasks`
+for task status).
+
+## What gets captured
+
+| Field | How it's built |
+|---|---|
+| `changes_summary` | One line per `done` task, using the task's `result_summary` if present |
+| `learnings` | One line per `failed` task, quoting its `result_summary` (or noting no reason was recorded) |
+| `next_session_brief` | Up to 10 `open` tasks sorted by priority; suggests `bernstein evolve` if none remain |
+| `git_diff_stat` | `git diff --stat` from the session's starting commit to `HEAD` (falls back to uncommitted changes vs `HEAD` if the start commit can't be located) |
+| `completed_task_ids` | IDs of `done` tasks, so a later PR-open step can link each task's verification-evidence bundle |
+
+The session start commit is estimated by reading `saved_at` from
+`.sdd/runtime/session.json` and locating the oldest commit made after that
+timestamp; the diff is computed against that commit's parent.
+
+## `--stop` behaviour
+
+When `--stop` is passed, after the brief is saved the command runs a
+graceful drain (`DrainCoordinator`) with a wait timeout of `--timeout`
+seconds, giving in-flight agents a chance to reach a clean stopping point
+before the orchestrator halts.
+
+## Source
+
+`src/bernstein/cli/commands/wrap_up_cmd.py`,
+`src/bernstein/core/persistence/session.py` (`WrapUpBrief`, `save_wrapup`),
+`src/bernstein/cli/commands/stop_cmd.py` (`soft_stop`, used by `--stop`).

--- a/docs/orchestration/bulletin-board.md
+++ b/docs/orchestration/bulletin-board.md
@@ -1,0 +1,103 @@
+# Bulletin board (cross-agent messaging)
+
+An append-only, in-memory message log shared by every agent in a run.
+Agents post typed messages (alerts, blockers, findings, status updates,
+dependency notes); other agents and the orchestrator read messages posted
+since their last check. It is also the trigger surface for [BLOCKER
+clearance gates](worker-coordination.md#blocker-clearance-gates).
+
+Source: `src/bernstein/core/communication/bulletin.py` (imported elsewhere
+as `bernstein.core.bulletin`, a back-compat alias to the same module).
+
+## Message shape
+
+```python
+@dataclass(frozen=True)
+class BulletinMessage:
+    agent_id: str
+    type: Literal["alert", "blocker", "finding", "status", "dependency"]
+    content: str
+    timestamp: float = 0.0   # auto-filled on post() if left as 0
+    cell_id: str | None = None
+```
+
+## REST API
+
+The multi-cell task server exposes the board at:
+
+| Method | Path | Notes |
+|---|---|---|
+| `POST` | `/bulletin` | Body: `{agent_id, type, content, cell_id}`. Returns `201` on stored + acted, `202` if a registered signal action (e.g. a blocker's clearance gate) failed and was queued for retry. |
+| `GET` | `/bulletin?since=<ts>` | Messages with `timestamp` strictly greater than `since`. |
+
+```bash
+curl -s -X POST http://127.0.0.1:8052/bulletin \
+  -H "Content-Type: application/json" \
+  -d '{"agent_id": "backend-1", "type": "finding", "content": "shared auth helper lives in core/auth.py"}'
+
+curl -s "http://127.0.0.1:8052/bulletin?since=0"
+```
+
+Posts are also broadcast on the server's SSE bus under the `bulletin`
+channel for live UI updates.
+
+## In-process API
+
+```python
+from bernstein.core.communication.bulletin import BulletinBoard, BulletinMessage
+
+board = BulletinBoard()
+board.post(BulletinMessage(agent_id="qa-1", type="status", content="ran full suite, 2 failures"))
+
+recent = board.read_since(0.0)          # everything
+blockers = board.read_by_type("blocker")
+cell_msgs = board.read_by_cell("cell-2")
+```
+
+Helper posters exist for common message shapes:
+`post_file_created(agent_id, file_path, classes=...)` and
+`post_api_endpoint(agent_id, method, route, response=...)`, both of which
+post `finding`/`status` messages with a formatted `content` string.
+
+`board.summary(limit=10)` renders the most recent messages as
+`- agent_id: content` lines; this is what gets injected into a newly
+spawned agent's prompt as recent team activity (`multi_cell.py` passes
+`bulletin.summary()` into `spawner_core`'s `bulletin_summary` parameter).
+
+## Storage: in-memory, per server process
+
+`BulletinBoard` holds messages in a plain Python list guarded by a
+`threading.Lock`. The class exposes `flush_to_disk(path)` and
+`load_from_disk(path)` for appending to / hydrating from a JSONL file, but
+nothing in the shipped server or CLI calls either method — the running
+task server creates one `BulletinBoard()` at startup
+(`core/server/server_app.py`) and nothing persists it across a restart.
+Treat the board as scoped to a single run's server process: history is
+lost on `bernstein stop` / server restart unless something outside the
+base orchestrator calls `flush_to_disk()` itself.
+
+## Related primitives in the same module
+
+`bulletin.py` also defines two other cross-agent communication types that
+are separate from the message board itself:
+
+- **`MessageBoard`** — agent-to-agent work delegation: `post_delegation()`
+  creates a request targeted at a role, another agent `claim()`s it and
+  `post_result()`s. Tracks `PENDING` / `CLAIMED` / `COMPLETED` / `EXPIRED`
+  status per delegation.
+- **`DirectChannel`** — lightweight query/response for information
+  exchange (`post_query()` / `post_response()`), addressed at a specific
+  agent, a role, or broadcast, with a TTL per query.
+
+Both have their own `flush_to_disk()` / `load_from_disk()` pairs with the
+same in-memory-by-default caveat as the board above.
+
+## Typed signals and clearance gates
+
+A posted `blocker` can drive real scheduler state, not just visibility:
+see [Cross-worker coordination — BLOCKER clearance
+gates](worker-coordination.md#blocker-clearance-gates) for how
+`ClearanceGateCoordinator` turns a blocker post into a chain-anchored
+clearance task with injected `depends_on` edges, and how `post()` raises
+`SignalActionFailure` (rather than silently succeeding) when the gate hook
+fails to materialize.

--- a/docs/orchestration/multi-cell.md
+++ b/docs/orchestration/multi-cell.md
@@ -1,0 +1,91 @@
+# Multi-cell orchestration
+
+Split one run into several independently-scheduled **cells** - each with its
+own manager and worker pool - coordinated by a VP layer that watches
+cross-cell status on the bulletin board and rebalances when a cell is
+overloaded or stuck.
+
+## Why
+
+A single manager/worker pool scales fine up to a few dozen open tasks. Past
+that, one manager becomes a bottleneck: task grouping, spawn-capacity checks,
+and dead-worker reaping all run against one queue, and a stall in one
+subsystem (say, a flaky backend integration) crowds out unrelated frontend
+work waiting in the same queue. Multi-cell orchestration splits the backlog
+into per-subsystem cells so each has its own manager, its own worker cap, and
+its own tick - with a VP cell above them that only handles cross-cell
+concerns.
+
+## How to use it
+
+```
+bernstein run --cells 3
+```
+
+`--cells` (default `1`) sets the number of parallel orchestration cells. `1`
+keeps the existing single-cell orchestrator; any value greater than `1`
+spawns a `MultiCellOrchestrator` instead. The flag overrides a `cells:` value
+in the seed file only when explicitly passed with a value greater than `1`.
+
+There is no separate command to register a cell or assign tasks to one by
+hand - cell membership comes from how the backlog is decomposed (each task
+carries a `cell_id`) and the orchestrator fetches open tasks per cell via
+`GET /tasks?status=open&cell_id=<id>`.
+
+## How it behaves
+
+Each `tick()` of the `MultiCellOrchestrator` does four things, in order:
+
+1. **Drain the bulletin board.** New messages posted since the last tick are
+   read; any of type `blocker` are logged and, if a
+   `ClearanceGateCoordinator` is wired, materialized into a clearance task
+   plus injected `depends_on` edges (see [Cross-worker
+   coordination](worker-coordination.md#blocker-clearance-gates) for how that
+   projection and its receipt work). Without a coordinator wired, blockers
+   stay observe-only: logged but not turned into a scheduling gate.
+2. **Tick every registered cell.** For each cell: fetch its open tasks, group
+   them into role batches with fair scheduling, spawn agents up to the
+   cell's `max_workers + 1` (the `+1` accounts for the cell's own manager),
+   and reap workers that are dead or past `heartbeat_timeout_s`.
+3. **Check for rebalancing.** After every cell has ticked, the VP layer scans
+   per-cell status snapshots and raises an action for any cell with more than
+   15 open tasks (posted as an `alert`) or more than 3 blocked tasks (posted
+   as a `blocker`). These are advisory: the VP logs and posts to the
+   bulletin board, it does not itself move tasks or spawn a new cell.
+4. **Write a one-line summary** to `.sdd/runtime/multi_cell.log` (cell count,
+   total open tasks, agents spawned, blockers found, VP actions, errors).
+
+Cells are independent `Cell` objects tracked in memory by `cell_id` -
+`register_cell()` / `remove_cell()` add and drop them. A cell reaping a dead
+worker or failing a fetch does not stop the tick for other cells: per-cell
+errors are collected into `MultiCellTickResult.errors` and the loop continues
+to the next cell.
+
+`MultiCellOrchestrator.run()` blocks the calling thread and calls `tick()` on
+`OrchestratorConfig.poll_interval_s` intervals until `stop()` is called.
+
+## Limitations
+
+- The overload/blocked-task thresholds (`>15` open, `>3` blocked) are fixed
+  in code, not configurable per project.
+- Rebalancing is advisory only: the VP posts an alert or a blocker signal but
+  does not automatically split an overloaded cell or move tasks between
+  cells. An operator (or a downstream automation reading the bulletin board)
+  has to act on it.
+- Multi-cell orchestration runs cells in one process against one task
+  server. It is not the same mechanism as multi-host fan-out - that is
+  `bernstein worker` / cluster mode, which distributes work across separate
+  machines rather than separate cells within one run.
+
+## Source
+
+- `src/bernstein/core/orchestration/multi_cell.py` - `MultiCellOrchestrator`,
+  `CellStatus`, `MultiCellTickResult`.
+- `src/bernstein/cli/run_bootstrap.py` - the `--cells` flag on `bernstein
+  run`.
+- `src/bernstein/core/orchestration/bootstrap.py` - `bootstrap_from_seed()`
+  resolving `cells` and passing it through to the spawner.
+
+See also: [Cross-worker coordination](worker-coordination.md) for the
+bulletin board and BLOCKER clearance-gate mechanics the VP layer uses when a
+coordinator is wired.

--- a/docs/reference/FEATURE_MATRIX.md
+++ b/docs/reference/FEATURE_MATRIX.md
@@ -5,7 +5,13 @@ matrix. Every row is verified against `src/bernstein/` on the current `main`.
 
 The "Docs status" column reflects whether a page-level reference exists
 (`Full`) or whether the capability is documented in source / module
-docstrings only (`Brief`).
+docstrings only (`Brief`). `Full` rows link to their reference page.
+
+Rows still marked `Brief` are deliberate: the capability either has no
+operator-facing surface to document, or exists in source but cannot be
+invoked from any CLI, API, or config path today. The unreachable subset
+is tracked in
+[issue #2973](https://github.com/sipyourdrink-ltd/bernstein/issues/2973).
 
 ---
 
@@ -19,18 +25,18 @@ docstrings only (`Brief`).
 | Retry + escalation plumbing | Full | In task lifecycle, with configurable retries |
 | Completion verification (janitor + signals) | Full | API + getting started coverage |
 | Process-aware stop/drain | Full | Graceful and force stop, drain mode |
-| Multi-cell orchestration | Brief | Implemented in `multi_cell.py` |
-| Fast-path execution | Brief | Trivial tasks skip the LLM agent entirely (`fast_path.py`) |
+| [Multi-cell orchestration](../orchestration/multi-cell.md) | Full | Implemented in `multi_cell.py` |
+| [Fast-path execution](../architecture/fast-path-execution.md) | Full | Trivial tasks skip the LLM agent entirely (`fast_path.py`) |
 | Plan mode (human approval) | Full | `--plan-only`, `--from-plan`, approval routes |
 | Headless mode | Full | `--headless` for CI/overnight |
 | Dry-run mode | Full | `--dry-run` previews the plan without spawning |
 | Typed activity boundary | Full | One hash-in/hash-out contract for coding, research, browser, and ops agents (`core/orchestration/activity.py`) |
 | Missions (multi-phase goals) | Full | Phases run under isolated budget envelopes; a halted phase seals a halt receipt and leaves runnable siblings active (`core/orchestration/missions.py`) |
 | Durable task suspend/resume | Full | A waiting task parks with an attested receipt that frees its seat, sandbox, and budget; resume reconstructs byte-identically (`core/tasks/suspension.py`) |
-| Tournament runs | Brief | Parallel attempts selected by deterministic evaluators; the winner carries a signed selection receipt (`core/tournament/`) |
-| Fleet steering | Brief | Pause, resume, guidance, redirect, and abort each land a signed steering receipt before any effect runs (`core/orchestration/steering.py`) |
-| Detached run service | Brief | Submit a goal, disconnect, and reattach later against a supervised run service (`core/run_service/`) |
-| Named resource pools | Brief | Lease-backed admission with chain-anchored grant and release receipts (`core/admission/`) |
+| [Tournament runs](../operations/tournament-runs.md) | Full | Parallel attempts selected by deterministic evaluators; the winner carries a signed selection receipt (`core/tournament/`) |
+| [Fleet steering](../operations/fleet-steering.md) | Full | Pause, resume, guidance, redirect, and abort each land a signed steering receipt before any effect runs (`core/orchestration/steering.py`) |
+| [Detached run service](../operations/run-service.md) | Full | Submit a goal, disconnect, and reattach later against a supervised run service (`core/run_service/`) |
+| [Named resource pools](../operations/named-resource-pools.md) | Full | Lease-backed admission with chain-anchored grant and release receipts (`core/admission/`) |
 | Spec-to-graph compile | Full | `bernstein plan compile` runs the draft/approve/compile pipeline offline into a gated task graph with a chain-anchored receipt (`plan_compile_cmd.py`) |
 
 ## State and persistence
@@ -39,11 +45,11 @@ docstrings only (`Brief`).
 |---|---|---|
 | File-based state in `.sdd/` | Full | Primary operating model |
 | Metrics/trace persistence | Full | Paths documented, JSONL schema |
-| Lessons/memory persistence | Brief | Stored and injected at spawn time |
+| [Lessons/memory persistence](../concepts/lesson-persistence.md) | Full | Stored and injected at spawn time |
 | Storage backends (`memory/postgres/redis`) | Full | Config + doctor coverage |
-| Session persistence (fast resume) | Brief | `session.py` resumes after stop/restart |
-| Bulletin board (cross-agent messaging) | Brief | Append-only, used by agents for handoff |
-| Content-addressed artifact store | Brief | Content-addressed deduplication for artifacts (`core/persistence/cas_store.py`) |
+| [Session persistence (fast resume)](../operations/session-fast-resume.md) | Full | `session.py` resumes after stop/restart |
+| [Bulletin board (cross-agent messaging)](../orchestration/bulletin-board.md) | Full | Append-only, used by agents for handoff |
+| [Content-addressed artifact store](../architecture/cas-store.md) | Full | Content-addressed deduplication for artifacts (`core/persistence/cas_store.py`) |
 | Cloud artifact sinks | Full | Local, S3, GCS, Azure Blob, and R2 sinks behind an async `ArtifactSink` protocol |
 
 ## Observability
@@ -51,35 +57,35 @@ docstrings only (`Brief`).
 | Capability | Docs status | Notes |
 |---|---|---|
 | `/status` and task API | Full | Core API documented |
-| Prometheus `/metrics` | Brief | Endpoint is real; Grafana dashboards are user-defined |
-| OTLP telemetry initialization | Brief | Wiring exists in `core/observability/` |
-| OTel GenAI span projection | Brief | `trace project` projects a run journal into signed OTel GenAI spans; `trace verify-projection` recomputes span ids |
+| [Prometheus `/metrics`](../operations/observability-overview.md) | Full | Endpoint is real; Grafana dashboards are user-defined |
+| [OTLP telemetry initialization](../operations/observability-overview.md) | Full | Wiring exists in `core/observability/` |
+| [OTel GenAI span projection](../operations/observability-overview.md) | Full | `trace project` projects a run journal into signed OTel GenAI spans; `trace verify-projection` recomputes span ids |
 | Live OTLP bridge | Full | The signed span projection streams to any OpenTelemetry collector live or via `telemetry export-otel`; `telemetry verify-span` recomputes a span id from its journal entry (`core/telemetry/`) |
 | Retrospective reporting (`retro`) | Full | CLI coverage present |
 | Cost analysis (`cost`, history/anomaly hooks) | Full | `bernstein cost`, cost anomaly detection active |
-| Per-agent token progress | Brief | Tracked in `api_usage.py`, surfaced in `bernstein status` |
-| Session analytics | Brief | `bernstein recap` shows session-level stats |
+| [Per-agent token progress](../observability/token-progress.md) | Full | Tracked in `api_usage.py`, surfaced in `bernstein status` |
+| [Session analytics](../operations/session-analytics.md) | Full | `bernstein recap` shows session-level stats |
 | Agent activity tracking | Brief | Activity metrics in `metrics/` |
-| Debug bundle | Brief | `bernstein debug` collects logs/state/config for triage |
+| [Debug bundle](../operations/debug-bundle.md) | Full | `bernstein debug` collects logs/state/config for triage |
 
 ## Safety and governance
 
 | Capability | Docs status | Notes |
 |---|---|---|
 | Quality gates (lint, type-check, tests) | Full | In the run flow; extended with coverage, benchmark, arch-conformance, and mutation-testing gates |
-| PII scan quality gate | Brief | Active, auto-installed via `log_redact.py` |
+| [PII scan quality gate](../security/pii-scan-gate.md) | Full | Active, auto-installed via `log_redact.py` |
 | Rule enforcement (`.bernstein/rules.yaml`) | Full | Enforcement behavior documented |
-| Log redaction (PII filter) | Brief | Active |
+| [Log redaction (PII filter)](../security/log-redaction.md) | Full | Active |
 | Lethal-trifecta capability gate | Full | Taint-aware egress denial: a chain that unions private data, tainted input, and external comms is refused even when static tags would pass (`core/security/capability_matrix.py`) |
 | Circuit breaker | Full | Halts misbehaving agents, writes SHUTDOWN signal |
-| Token growth monitor | Brief | Auto-intervention on runaway consumption |
-| Cost anomaly detection | Brief | Z-score based, acts via task completion |
+| [Token growth monitor](../operations/token-growth-monitor.md) | Full | Auto-intervention on runaway consumption |
+| [Cost anomaly detection](../operations/cost-anomaly-detection.md) | Full | Z-score based, acts via task completion |
 | Peak-hour scheduling | Brief | `peak_hour_router.py` for cost-aware time-of-day routing |
-| Agent loop detection | Brief | Kills agents in edit-loop cycles |
-| Deadlock detection | Brief | Wait-for graph, automatic victim selection |
-| Cross-model verification | Brief | A different model reviews completed diffs (opt-in) |
-| Behaviour anomaly detection | Brief | Flags agents whose runtime metrics deviate statistically from baseline (`core/observability/behavior_anomaly.py`) |
-| Context degradation detector | Brief | Monitors quality over time, restarts when degraded |
+| [Agent loop detection](../operations/agent-loop-detection.md) | Full | Kills agents in edit-loop cycles |
+| [Deadlock detection](../architecture/deadlock-detection.md) | Full | Wait-for graph, automatic victim selection |
+| [Cross-model verification](../architecture/quality-pipeline.md) | Full | A different model reviews completed diffs (opt-in) |
+| [Behaviour anomaly detection](../operations/observability-overview.md) | Full | Flags agents whose runtime metrics deviate statistically from baseline (`core/observability/behavior_anomaly.py`) |
+| [Context degradation detector](../architecture/context-degradation-detector.md) | Full | Monitors quality over time, restarts when degraded |
 | Progressive permission prompts | Brief | Per-agent permission levels |
 
 ## Verifiability and provenance
@@ -89,35 +95,35 @@ docstrings only (`Brief`).
 | Unified lineage spine | Full | The journal head is sealed into a single lineage root at run finalization; artifact provenance and replay identity share that root (`core/lineage/`) |
 | Always-on event journal | Full | Merkle-chained per-run `EventJournal`; the head hash is the run identity (`core/replay/journal.py`) |
 | HMAC-chained audit log | Full | Tamper-evident, daily rotation, cross-process append lock (`core/security/audit_chain.py`) |
-| Execution WAL | Brief | Hash-chained write-ahead log for crash recovery and determinism fingerprinting |
+| [Execution WAL](../architecture/state-persistence.md) | Full | Hash-chained write-ahead log for crash recovery and determinism fingerprinting |
 | Deterministic replay + fork | Full | `replay --verify` recomputes the journal head; `fork --from-step` rebuilds state at a journal step into an isolated run (`core/replay/`) |
 | Audit-chain export | Full | Projects a chain range into COSE_Sign1, in-toto, and DSSE receipts re-verifiable offline with no Bernstein imports (`core/security/audit_export.py`) |
 | Provenance trust classes | Full | Every tool result carries a trust class; effective trust is the minimum over the lineage closure, recomputed offline by `audit taint` (`core/lineage/provenance.py`) |
-| Gate adjudication records | Brief | Gate panel decisions are recomputable; `gate verify` confirms the inputs hash |
-| In-process verification gates | Brief | Verification-gate hooks rendered into capable adapters so the check runs inside the agent (`adapters/hook_gate_render.py`) |
+| [Gate adjudication records](../operations/gate-adjudication.md) | Full | Gate panel decisions are recomputable; `gate verify` confirms the inputs hash |
+| [In-process verification gates](../operations/hook-gate.md) | Full | Verification-gate hooks rendered into capable adapters so the check runs inside the agent (`adapters/hook_gate_render.py`) |
 | Evidence bundles | Full | Sealed verification-evidence bundle, projectable as a tracker comment (`core/evidence/bundle.py`) |
 | Intent capsules | Full | Approval compiles the goal into a signed capsule; a deterministic drift monitor escalates divergence, verified by `intent verify` (`core/security/intent_capsule.py`) |
 | Query receipts (datasources) | Full | Read-only SQL results become content-addressed signed receipts; `datasource verify --re-execute` reports MATCH or DRIFT (`core/datasources/`) |
 | Compaction receipts | Full | Context and template compaction is recorded as a chain-anchored, reversible receipt (`core/tokens/compaction_receipt.py`) |
 | Tamper-evident memory | Full | Memory entries are hash-chained with provenance; `memory verify/why/forget` proves authorship, traces origin, and tombstones (`core/memory/chain.py`) |
-| Review / autofix / escalation / consent / webhook-node receipts | Brief | Signed, journal-anchored receipts verified offline (`review-receipt verify`, `escalation verify`, `webhook verify`) |
-| Stall escalation receipts | Brief | A stalled worker produces a signed escalation receipt embedding the last audit entries and a deterministic recommended action (`supervisor escalate`) |
+| [Review / autofix / escalation / consent / webhook-node receipts](../operations/review-receipts.md) | Full | Signed, journal-anchored receipts verified offline (`review-receipt verify`, `escalation verify`, `webhook verify`) |
+| [Stall escalation receipts](../operations/stall-escalation.md) | Full | A stalled worker produces a signed escalation receipt embedding the last audit entries and a deterministic recommended action (`supervisor escalate`) |
 | C2PA content credentials | Full | Artifact lineage projected into signed C2PA credentials (`credential emit/verify`) |
 | Skill install receipts | Full | Install and usage links recomputable via `skill verify` / `skill provenance` |
 | Adapter security-floor receipts | Full | A below-floor adapter spawn is refused with a content-addressed, chain-anchored refusal receipt (`adapters/security_floor.py`) |
 | Endpoint certification | Full | Local-model workers are conformance-tested and issued a signed certification (`core/endpoints/certification.py`) |
 | SLA violation receipts | Full | Per-goal SLA contracts evaluated read-only each tick; a breach becomes a signed, offline-verifiable violation receipt (`core/planning/sla_store.py`) |
 | Signed daily mission digests | Full | Each day's mission progress is a signed digest projecting that day's chain; `mission digest verify` re-derives it (`core/orchestration/mission_digest.py`) |
-| Agent run manifest | Brief | Hashable workflow spec for SOC 2 evidence |
-| RBAC / budget / seat projections | Brief | Access and budget verdicts re-derivable via `governance verify` |
-| Unified event feed | Brief | Chain-projected event feed with a typed grammar and per-event receipts (`core/events/feed.py`) |
+| [Agent run manifest](../operations/run-manifest.md) | Full | Hashable workflow spec for SOC 2 evidence |
+| [RBAC / budget / seat projections](../operations/governance.md) | Full | Access and budget verdicts re-derivable via `governance verify` |
+| [Unified event feed](../events/grammar.md) | Full | Chain-projected event feed with a typed grammar and per-event receipts (`core/events/feed.py`) |
 
 ## Identity and delegation
 
 | Capability | Docs status | Notes |
 |---|---|---|
-| Native subagent delegation | Brief | The scheduler delegates leaf execution to native subagents; schema-validated results anchor as `subagent.delegation` journal entries, chain verified via `delegation verify` (`core/agents/subagent_delegation.py`) |
-| Attenuated capability tokens | Brief | Each delegation hop is a signed, scope-attenuating token, so the principal to orchestrator to sub-agent authority chain verifies offline (`core/security/capability_tokens.py`) |
+| [Native subagent delegation](../architecture/subagent-delegation.md) | Full | The scheduler delegates leaf execution to native subagents; schema-validated results anchor as `subagent.delegation` journal entries, chain verified via `delegation verify` (`core/agents/subagent_delegation.py`) |
+| [Attenuated capability tokens](../operations/security-and-identity.md) | Full | Each delegation hop is a signed, scope-attenuating token, so the principal to orchestrator to sub-agent authority chain verifies offline (`core/security/capability_tokens.py`) |
 | Signed agent cards | Full | `AgentIdentityCard` signed for A2A federation and served at `/.well-known/agent-card.json` (`core/security/agent_card_signer.py`) |
 | A2A node + message receipts | Full | Callable JSON-RPC node; a completed task returns an artifact whose parts carry a lineage receipt verified by `a2a verify` (`core/interop/a2a_card.py`) |
 | HTTP message signatures | Full | RFC 9421 Ed25519 signatures on outbound agent-facing requests; keys served as JWKS via `identity keydir` (`core/identity/http_signing.py`) |
@@ -128,9 +134,9 @@ docstrings only (`Brief`).
 | Capability | Docs status | Notes |
 |---|---|---|
 | Spending mandates | Full | Authorized-spend mandates enforced before a paid action, with signed spend receipts (`core/payments/`) |
-| Authorized-action mandates | Brief | `mandate emit/verify/revoke` binds, proves, and revokes an authorized-action mandate |
+| [Authorized-action mandates](../operations/spending-mandates.md) | Full | `mandate emit/verify/revoke` binds, proves, and revokes an authorized-action mandate |
 | Cost-policy receipts | Full | The live dispatch gate records batch, cache, and model policy verdicts as receipts (`core/cost/scheduling/receipt.py`) |
-| Budget envelopes | Brief | Per-phase and per-task budget envelopes with rollup by envelope (`core/cost/cost_rollup_by_envelope.py`) |
+| [Budget envelopes](../operations/cost-envelopes.md) | Full | Per-phase and per-task budget envelopes with rollup by envelope (`core/cost/cost_rollup_by_envelope.py`) |
 
 ## Ecosystem and integrations
 
@@ -139,65 +145,65 @@ docstrings only (`Brief`).
 | Agent catalog/discovery | Full | `bernstein agents sync/list/discover/match/showcase` (40+ CLI agent adapters) |
 | Browser / computer-use adapter | Full | Adapter family for autonomous browser and computer-use agents; every action is a content-addressed lineage anchor (`adapters/computer_use.py`) |
 | GitHub App and CI fix flows | Full | `bernstein ci fix <url>`, `github setup` |
-| Trigger sources | Brief | `github`, `gitlab`, `slack`, `discord`, `file_watch`, `webhook`, `odata`, and `schedule` source adapters (`core/trigger_sources/`) |
-| OData trigger source | Brief | Polls an OData endpoint into normalized trigger events (`core/trigger_sources/odata_poll.py`) |
-| Webhook node | Brief | Outbound webhook node with recomputable inbound-event and node hashes (`core/trigger_sources/webhook_node.py`, `webhook verify`) |
+| [Trigger sources](../operations/trigger-sources.md) | Full | `github`, `gitlab`, `slack`, `discord`, `file_watch`, `webhook`, `odata`, and `schedule` source adapters (`core/trigger_sources/`) |
+| [OData trigger source](../operations/odata.md) | Full | Polls an OData endpoint into normalized trigger events (`core/trigger_sources/odata_poll.py`) |
+| [Webhook node](../operations/webhook-node.md) | Full | Outbound webhook node with recomputable inbound-event and node hashes (`core/trigger_sources/webhook_node.py`, `webhook verify`) |
 | Automation bridge | Full | Signed trigger receipts and chain-anchored status callbacks for external automations (`core/trigger_sources/automation_platforms.py`) |
 | Plugin hooks (pluggy) | Full | SDK docs in CONTRIBUTING.md |
 | Cluster/worker primitives | Full | `bernstein worker --server URL`, cluster routes documented |
 | Multi-repo workspaces | Full | `workspace:` in bernstein.yaml, workspace CLI |
-| MCP server mode | Brief | `bernstein mcp`, MCP server in `mcp/server.py` |
-| MCP tool registry | Brief | Auto-discovery and per-task config |
-| MCP catalog client | Brief | `bernstein mcp catalog browse/search/install` installable server catalog (`core/protocols/mcp_catalog/`) |
-| MCP input contracts | Brief | Schema-validated, deny-by-default MCP tool-call input firewall (`mcp/input_validation.py`) |
-| Stateless MCP anchoring | Brief | A stateless MCP client can poll a run and verify it offline; calls anchor as `mcp.stateless_call` journal entries (`core/protocols/mcp/stateless_core.py`) |
-| Runtime capability cards (MCP) | Brief | Per-server capability cards for the MCP server (`mcp/capability.py`) |
+| [MCP server mode](../mcp/server.md) | Full | `bernstein mcp`, MCP server in `mcp/server.py` |
+| [MCP tool registry](../integrations/mcp-server-injection.md) | Full | Auto-discovery and per-task config |
+| [MCP catalog client](mcp-catalog.md) | Full | `bernstein mcp catalog browse/search/install` installable server catalog (`core/protocols/mcp_catalog/`) |
+| [MCP input contracts](../mcp/input-validation.md) | Full | Schema-validated, deny-by-default MCP tool-call input firewall (`mcp/input_validation.py`) |
+| [Stateless MCP anchoring](../mcp/server.md) | Full | A stateless MCP client can poll a run and verify it offline; calls anchor as `mcp.stateless_call` journal entries (`core/protocols/mcp/stateless_core.py`) |
+| [Runtime capability cards (MCP)](../mcp/server.md) | Full | Per-server capability cards for the MCP server (`mcp/capability.py`) |
 | ACP native bridge | Full | `bernstein acp serve --stdio\|--http :PORT` IDE-native bridge (`core/protocols/acp/`); see `reference/acp-bridge.md` |
-| Protocol negotiation | Brief | `protocol_negotiation.py` runtime protocol-version handshake |
-| Schema registry | Brief | `schema_registry.py` versioned message schemas for protocols |
-| Credential vault | Brief | `bernstein connect <provider>`, `bernstein creds list/revoke/test` OS-keychain token storage (`core/security/vault/`) |
-| Autofix CI daemon | Brief | `bernstein autofix start/stop/status/attach` watches PRs and dispatches repair runs on CI failure (`core/autofix/`) |
-| Dev preview | Brief | `bernstein preview start/stop/list/status` exposes an agent dev server via tunnel with configurable auth (`core/preview/`) |
-| Fleet dashboard | Brief | `bernstein fleet [--web HOST:PORT]` cross-session multi-instance view (`core/fleet/`) |
-| Notification sinks | Brief | `bernstein notify test --sink <id>` pluggable notification backends (`core/notifications/`) |
-| PR review responder | Brief | `bernstein review-responder start/status/tick` auto-responds to PR review comments (`core/review_responder/`) |
-| Review pipeline DSL | Brief | `bernstein review --pipeline review.yaml` YAML-driven multi-phase review (`core/quality/review_pipeline/`) |
-| Plan archival | Brief | `bernstein plan ls/show` list and inspect archived plans (`core/planning/lifecycle.py`) |
-| Slack integration | Brief | Slash commands and events API endpoints |
-| Webhook ingestion | Brief | `POST /webhooks/` for external event routing |
-| Adaptive parallelism | Brief | Auto-tunes concurrency from observed success rates (`core/orchestration/adaptive_parallelism.py`) |
-| Warm pool | Brief | Pre-spawned agent pool to cut spawn latency (`core/agents/warm_pool.py`) |
+| [Protocol negotiation](../architecture/protocol-negotiation.md) | Full | `protocol_negotiation.py` runtime protocol-version handshake |
+| [Schema registry](../architecture/schema-registry.md) | Full | `schema_registry.py` versioned message schemas for protocols |
+| [Credential vault](../operations/secrets.md) | Full | `bernstein connect <provider>`, `bernstein creds list/revoke/test` OS-keychain token storage (`core/security/vault/`) |
+| [Autofix CI daemon](../operations/autofix.md) | Full | `bernstein autofix start/stop/status/attach` watches PRs and dispatches repair runs on CI failure (`core/autofix/`) |
+| [Dev preview](../operations/preview.md) | Full | `bernstein preview start/stop/list/status` exposes an agent dev server via tunnel with configurable auth (`core/preview/`) |
+| [Fleet dashboard](../operations/fleet.md) | Full | `bernstein fleet [--web HOST:PORT]` cross-session multi-instance view (`core/fleet/`) |
+| [Notification sinks](../operations/notifications.md) | Full | `bernstein notify test --sink <id>` pluggable notification backends (`core/notifications/`) |
+| [PR review responder](../operations/review-responder.md) | Full | `bernstein review-responder start/status/tick` auto-responds to PR review comments (`core/review_responder/`) |
+| [Review pipeline DSL](../operations/review-pipeline.md) | Full | `bernstein review --pipeline review.yaml` YAML-driven multi-phase review (`core/quality/review_pipeline/`) |
+| [Plan archival](../operations/plan-archival.md) | Full | `bernstein plan ls/show` list and inspect archived plans (`core/planning/lifecycle.py`) |
+| [Slack integration](../operations/slack-webhooks.md) | Full | Slash commands and events API endpoints |
+| [Webhook ingestion](../integrations/automation-bridge.md) | Full | `POST /webhooks/` for external event routing |
+| [Adaptive parallelism](../architecture/adaptive-parallelism.md) | Full | Auto-tunes concurrency from observed success rates (`core/orchestration/adaptive_parallelism.py`) |
+| [Warm pool](../architecture/warm-pool.md) | Full | Pre-spawned agent pool to cut spawn latency (`core/agents/warm_pool.py`) |
 | Pluggable sandbox backends | Full | Worktree, Docker, E2B, and Modal backends behind a `SandboxSession` protocol |
 | microVM sandbox backend | Brief | Isolation tier with content-addressed snapshots for deterministic fork-and-race (`--sandbox microvm`) |
 | Named sandbox pools | Full | Chain-projected pool manifests with capability and egress ceilings and signed worker enrolment (`core/sandbox/pool.py`) |
 | Cache policy engine | Full | Content-addressed key recipes, drift expiry, and fleet dedup with signed duplicate-of receipts (`core/persistence/cache_policy.py`) |
 | Sovereign deployment profile | Full | Signed residency-posture attestation; posture drift at spawn is a signed refusal (`core/security/deployment_profile.py`) |
-| Workflow DSL | Brief | `bernstein workflow validate/list/show` |
-| Chaos engineering | Brief | `bernstein chaos agent-kill/rate-limit/file-remove/status/slo` |
+| [Workflow DSL](../operations/workflow-manifests.md) | Full | `bernstein workflow validate/list/show` |
+| [Chaos engineering](../operations/chaos-engineering.md) | Full | `bernstein chaos agent-kill/rate-limit/file-remove/status/slo` |
 | Benchmark suite | Full | `bernstein benchmark run/compare/swe-bench` |
-| Eval harness | Brief | `bernstein eval run/report/failures` |
+| [Eval harness](../eval/golden-harness.md) | Full | `bernstein eval run/report/failures` |
 | SWE-Bench harness | Full | Verified eval in `benchmarks/swe_bench/run.py` |
-| Graduation system | Brief | Agent promotion stages, routes in `routes/graduation.py` |
-| Semantic caching | Brief | `semantic_cache.py` prompt deduplication |
-| Cascade router (intra-Claude tier escalation) | Brief | Tier escalation within a single provider (`core/routing/cascade_router.py`) |
-| Cascade fallback manager (cross-adapter failover) | Brief | Cross-adapter provider failover (`core/routing/cascade.py`) |
-| Batch router | Brief | Task batching for non-urgent work |
-| Prompt caching | Brief | SHA-256 system prefix deduplication |
+| [Graduation system](../operations/graduation.md) | Full | Agent promotion stages, routes in `routes/graduation.py` |
+| [Semantic caching](../concepts/semantic-caching.md) | Full | `semantic_cache.py` prompt deduplication |
+| [Cascade router (intra-Claude tier escalation)](../architecture/model-routing.md) | Full | Tier escalation within a single provider (`core/routing/cascade_router.py`) |
+| [Cascade fallback manager (cross-adapter failover)](../architecture/model-routing.md) | Full | Cross-adapter provider failover (`core/routing/cascade.py`) |
+| [Batch router](../architecture/batch-routing.md) | Full | Task batching for non-urgent work |
+| [Prompt caching](../operations/performance-tuning.md) | Full | SHA-256 system prefix deduplication |
 | Output style customization | Brief | Configurable agent output format |
-| Installation mismatch detection | Brief | Detects adapter/installation gaps |
+| [Installation mismatch detection](../operations/doctor.md) | Full | Detects adapter/installation gaps |
 | API preconnect warmup | Brief | Connection warmup before heavy runs |
-| Worker badge identity | Brief | Process identification in `ps`/Activity Monitor |
-| Keybinding system (TUI) | Brief | Configurable TUI keyboard shortcuts |
+| [Worker badge identity](../operations/worker-process-identity.md) | Full | Process identification in `ps`/Activity Monitor |
+| [Keybinding system (TUI)](../operations/tui-keybindings.md) | Full | Configurable TUI keyboard shortcuts |
 | Diff folding display | Brief | Folded diff rendering in agent output |
 | Word-level diff rendering | Brief | Character-level change highlighting |
 | Contextual tips system | Brief | In-context hints for agents |
 | Session tag system | Brief | Tag and filter runs |
 | Rename session | Brief | Session renaming command |
 | Security review command | Brief | `bernstein security-review` |
-| Commit attribution stats | Brief | Per-agent commit statistics |
+| [Commit attribution stats](../operations/commit-attribution.md) | Full | Per-agent commit statistics |
 | Away summary generation | Brief | Summarize what happened while you were away |
 | Plugin trust warning | Brief | Warns on unverified plugins |
-| Cumulative progress tracking | Brief | Progress tracking across runs |
+| [Cumulative progress tracking](../observability/cumulative-progress.md) | Full | Progress tracking across runs |
 
 ## CLI commands
 
@@ -220,89 +226,89 @@ docstrings only (`Brief`).
 | `bernstein diff ID` | Full | Per-task git diff |
 | `bernstein plan` | Full | Task backlog |
 | `bernstein plan compile` | Full | Compile a spec into a gated task graph offline |
-| `bernstein replay ID` | Brief | Deterministic replay |
-| `bernstein checkpoint` | Brief | Session snapshot |
-| `bernstein wrap-up` | Brief | End session with summary |
+| [`bernstein replay ID`](../operations/replay.md) | Full | Deterministic replay |
+| [`bernstein checkpoint`](../operations/checkpoint.md) | Full | Session snapshot |
+| [`bernstein wrap-up`](../operations/wrap-up.md) | Full | End session with summary |
 | `bernstein demo` | Full | Zero-config demo |
-| `bernstein quickstart` | Brief | Flask TODO demo (3 tasks) |
+| [`bernstein quickstart`](../getting-started/quickstart-demo.md) | Full | Flask TODO demo (3 tasks) |
 | `bernstein agents ...` | Full | Catalog management |
 | `bernstein evolve ...` | Full | Self-improvement |
 | `bernstein ci fix` | Full | CI autofix |
 | `bernstein github setup` | Full | GitHub App setup |
-| `bernstein worker` | Brief | Join cluster as worker |
-| `bernstein mcp` | Brief | Run as MCP server |
-| `bernstein chaos` | Brief | Fault injection |
-| `bernstein audit` | Brief | Cryptographic audit (`seal/verify/export/taint/pack/slice`) |
-| `bernstein verify` | Brief | Merkle/HMAC verification |
+| [`bernstein worker`](../operations/cluster-mode.md) | Full | Join cluster as worker |
+| [`bernstein mcp`](../mcp/server.md) | Full | Run as MCP server |
+| [`bernstein chaos`](../operations/chaos-engineering.md) | Full | Fault injection |
+| [`bernstein audit`](../security/audit-log.md) | Full | Cryptographic audit (`seal/verify/export/taint/pack/slice`) |
+| [`bernstein verify`](cli/verify.md) | Full | Merkle/HMAC verification |
 | `bernstein benchmark` | Full | Benchmark suite |
-| `bernstein eval` | Brief | Evaluation harness |
+| [`bernstein eval`](../eval/golden-harness.md) | Full | Evaluation harness |
 | `bernstein ideate` | Brief | Creative evolution |
 | `bernstein workspace` | Full | Multi-repo workspace |
-| `bernstein config` | Brief | Configuration management |
+| [`bernstein config`](../operations/global-config.md) | Full | Configuration management |
 | `bernstein quarantine` | Brief | Cross-run task quarantine |
-| `bernstein cache` | Brief | Response cache management |
-| `bernstein test-adapter` | Brief | Adapter smoke test |
-| `bernstein add-task` | Brief | Inject task via CLI |
-| `bernstein cancel` | Brief | Cancel task |
-| `bernstein review/approve/reject/pending` | Brief | Review workflow |
-| `bernstein sync` | Brief | Sync backlog with server |
-| `bernstein manifest` | Brief | Run manifest inspection |
-| `bernstein gateway` | Brief | MCP gateway proxy |
-| `bernstein workflow` | Brief | Workflow DSL |
-| `bernstein watch` | Brief | Directory file watcher |
-| `bernstein listen` | Brief | Voice commands (experimental) |
-| `bernstein completions` | Brief | Shell completion scripts |
-| `bernstein self-update` | Brief | Upgrade from PyPI |
-| `bernstein plugins` | Brief | List active plugins |
-| `bernstein install-hooks` | Brief | Install git hooks |
-| `bernstein debug` | Brief | Generate debug bundle for triage |
+| [`bernstein cache`](../concepts/semantic-caching.md) | Full | Response cache management |
+| [`bernstein test-adapter`](../adapters/test-adapter.md) | Full | Adapter smoke test |
+| [`bernstein add-task`](cli/task-lifecycle.md) | Full | Inject task via CLI |
+| [`bernstein cancel`](cli/task-lifecycle.md) | Full | Cancel task |
+| [`bernstein review/approve/reject/pending`](cli/task-lifecycle.md) | Full | Review workflow |
+| [`bernstein sync`](../operations/backlog-sync.md) | Full | Sync backlog with server |
+| [`bernstein manifest`](../operations/run-manifest.md) | Full | Run manifest inspection |
+| [`bernstein gateway`](../operations/mcp-gateway.md) | Full | MCP gateway proxy |
+| [`bernstein workflow`](../operations/workflow-manifests.md) | Full | Workflow DSL |
+| [`bernstein watch`](../operations/watch.md) | Full | Directory file watcher |
+| [`bernstein listen`](../operations/voice-control.md) | Full | Voice commands (experimental) |
+| [`bernstein completions`](../operations/shell-completions.md) | Full | Shell completion scripts |
+| [`bernstein self-update`](../operations/self-update.md) | Full | Upgrade from PyPI |
+| [`bernstein plugins`](../integrations/plugin-sdk.md) | Full | List active plugins |
+| [`bernstein install-hooks`](../contributing/git-hooks.md) | Full | Install git hooks |
+| [`bernstein debug`](../operations/debug-bundle.md) | Full | Generate debug bundle for triage |
 | `bernstein acp serve` | Full | ACP bridge (`--stdio` or `--http :PORT`) |
-| `bernstein autofix ...` | Brief | CI autofix daemon (start/stop/status/attach) |
-| `bernstein connect` | Brief | Credential vault setup for a provider |
-| `bernstein creds ...` | Brief | Credential management (list/revoke/test) |
-| `bernstein preview ...` | Brief | Dev server preview (start/stop/list/status) |
-| `bernstein fleet` | Brief | Fleet dashboard (optionally `--web HOST:PORT`) |
-| `bernstein fleet steer` | Brief | Mid-run steering: pause/resume/guidance/redirect/abort |
-| `bernstein mcp catalog ...` | Brief | MCP catalog browser (browse/search/install) |
-| `bernstein notify test` | Brief | Notification sink smoke test |
-| `bernstein plan ls/show` | Brief | List and inspect archived plans |
-| `bernstein review-responder ...` | Brief | PR review responder (start/status/tick) |
-| `bernstein review --pipeline` | Brief | Review with YAML pipeline DSL |
-| `bernstein fork --run --from-step` | Brief | Fork a run at a journal step into a new isolated run |
-| `bernstein gate verify` | Brief | Recompute a gate panel's inputs hash and confirm the adjudication |
-| `bernstein mandate emit/verify/revoke` | Brief | Bind, prove, and revoke authorized-action mandates |
+| [`bernstein autofix ...`](../operations/autofix.md) | Full | CI autofix daemon (start/stop/status/attach) |
+| [`bernstein connect`](../operations/secrets.md) | Full | Credential vault setup for a provider |
+| [`bernstein creds ...`](../operations/secrets.md) | Full | Credential management (list/revoke/test) |
+| [`bernstein preview ...`](../operations/preview.md) | Full | Dev server preview (start/stop/list/status) |
+| [`bernstein fleet`](../operations/fleet.md) | Full | Fleet dashboard (optionally `--web HOST:PORT`) |
+| [`bernstein fleet steer`](../operations/fleet-steering.md) | Full | Mid-run steering: pause/resume/guidance/redirect/abort |
+| [`bernstein mcp catalog ...`](mcp-catalog.md) | Full | MCP catalog browser (browse/search/install) |
+| [`bernstein notify test`](../operations/notifications.md) | Full | Notification sink smoke test |
+| [`bernstein plan ls/show`](../operations/plan-archival.md) | Full | List and inspect archived plans |
+| [`bernstein review-responder ...`](../operations/review-responder.md) | Full | PR review responder (start/status/tick) |
+| [`bernstein review --pipeline`](../operations/review-pipeline.md) | Full | Review with YAML pipeline DSL |
+| [`bernstein fork --run --from-step`](../operations/fork-from-step.md) | Full | Fork a run at a journal step into a new isolated run |
+| [`bernstein gate verify`](../operations/gate-adjudication.md) | Full | Recompute a gate panel's inputs hash and confirm the adjudication |
+| [`bernstein mandate emit/verify/revoke`](../operations/spending-mandates.md) | Full | Bind, prove, and revoke authorized-action mandates |
 | `bernstein payment-mandate issue/show/spend` | Full | Issue and spend against authorized-spend mandates with signed receipts |
-| `bernstein governance verify` | Brief | Recompute access and budget verdicts for a run |
-| `bernstein webhook verify` | Brief | Recompute inbound-event and outbound webhook-node hashes |
-| `bernstein review-receipt emit/verify` | Brief | Bind and offline-verify PR review receipts (issue + plan + tool calls + diff) |
-| `bernstein escalation show/verify` | Brief | Project and reconstruct escalation receipts from the journal |
-| `bernstein supervisor status/escalate` | Brief | Supervise stalled workers and seal stall escalation receipts |
-| `bernstein delegation verify` | Brief | Reconstruct and verify a run's delegation chain |
-| `bernstein credential emit/verify` | Brief | Project an artifact's lineage into a signed C2PA credential and verify it |
-| `bernstein skill provenance/verify` | Brief | Recompute a skill's install receipt and usage-provenance graph |
-| `bernstein schedule verify/audit`, `schedule show --at` | Brief | Replay recorded fires, chain-check fire receipts, project a schedule at a time |
+| [`bernstein governance verify`](../operations/governance.md) | Full | Recompute access and budget verdicts for a run |
+| [`bernstein webhook verify`](../operations/webhook-node.md) | Full | Recompute inbound-event and outbound webhook-node hashes |
+| [`bernstein review-receipt emit/verify`](../operations/review-receipts.md) | Full | Bind and offline-verify PR review receipts (issue + plan + tool calls + diff) |
+| [`bernstein escalation show/verify`](../operations/stall-escalation.md) | Full | Project and reconstruct escalation receipts from the journal |
+| [`bernstein supervisor status/escalate`](../api/supervisor.md) | Full | Supervise stalled workers and seal stall escalation receipts |
+| [`bernstein delegation verify`](../operations/delegation-verify.md) | Full | Reconstruct and verify a run's delegation chain |
+| [`bernstein credential emit/verify`](../operations/content-credentials.md) | Full | Project an artifact's lineage into a signed C2PA credential and verify it |
+| [`bernstein skill provenance/verify`](../operations/skill-provenance.md) | Full | Recompute a skill's install receipt and usage-provenance graph |
+| [`bernstein schedule verify/audit`, `schedule show --at`](../operations/schedule.md) | Full | Replay recorded fires, chain-check fire receipts, project a schedule at a time |
 | `bernstein sla add/list/show/verify/report` | Full | Attach per-goal SLA contracts; a breach is an offline-verifiable violation receipt |
-| `bernstein trace project/verify-projection` | Brief | Project a run journal into signed OTel GenAI spans and verify the projection |
+| [`bernstein trace project/verify-projection`](../observability/otel-span-projection.md) | Full | Project a run journal into signed OTel GenAI spans and verify the projection |
 | `bernstein telemetry export-otel/verify-span` | Full | Stream the span projection to an OTLP collector and verify a single span offline |
-| `bernstein thread verify` | Brief | Prove a streamed TUI thread equals its executed journal |
+| [`bernstein thread verify`](../operations/deterministic-replay.md) | Full | Prove a streamed TUI thread equals its executed journal |
 | `bernstein memory verify/why/forget` | Full | Prove authorship, trace origin, and tombstone a memory entry |
-| `bernstein replay --verify/--from-step` | Brief | Recompute the journal head or rebuild state to a step |
+| [`bernstein replay --verify/--from-step`](../operations/deterministic-replay.md) | Full | Recompute the journal head or rebuild state to a step |
 | `bernstein intent show/verify` | Full | Project and recompute an intent capsule's conformance offline |
 | `bernstein a2a verify/publish` | Full | Verify an A2A message receipt and publish the agent card |
 | `bernstein activity verify` | Full | Verify a typed activity's replay hashes (`activity browser run` for browser checks) |
 | `bernstein datasource register/query/verify` | Full | Register read-only SQL datasources and verify content-addressed query receipts |
-| `bernstein evidence show/verify` | Brief | Project and verify a sealed evidence bundle |
-| `bernstein events query/verify` | Brief | Query the unified event feed and verify its chain projection |
+| [`bernstein evidence show/verify`](../operations/evidence-bundles.md) | Full | Project and verify a sealed evidence bundle |
+| [`bernstein events query/verify`](../events/grammar.md) | Full | Query the unified event feed and verify its chain projection |
 | `bernstein endpoints certify/verify` | Full | Conformance-certify a local-model endpoint and verify its certification |
 | `bernstein ledger verify/anchor/fetch` | Full | Verify, anchor, and fetch work-ledger segments |
 | `bernstein mission define/status/verify` | Full | Define multi-phase missions and verify mission status (`mission digest verify` for digests) |
-| `bernstein tournament show/verify` | Brief | Inspect a tournament run and verify its selection receipt |
+| [`bernstein tournament show/verify`](../operations/tournament-runs.md) | Full | Inspect a tournament run and verify its selection receipt |
 | `bernstein spiffe id/verify-binding` | Full | Print the SPIFFE id and verify a workload-identity binding |
 | `bernstein spec check/auto-fix` | Full | Evaluate and auto-fix a spec against the quality checklist |
-| `bernstein run-service submit/attach/status` | Brief | Submit a detached run, then reattach to it later |
+| [`bernstein run-service submit/attach/status`](../operations/run-service.md) | Full | Submit a detached run, then reattach to it later |
 | `bernstein compaction log` | Full | Inspect chain-anchored compaction receipts |
 | `bernstein identity keydir/decode/verify` | Full | Print the JWKS key directory and decode/verify install identity |
-| `bernstein pool register/list/show/verify` | Brief | Manage lease-backed named resource pools |
+| [`bernstein pool register/list/show/verify`](../operations/sandbox-pools.md) | Full | Manage lease-backed named resource pools |
 
 ---
 

--- a/docs/reference/cli/verify.md
+++ b/docs/reference/cli/verify.md
@@ -1,0 +1,89 @@
+# `bernstein verify`
+
+`bernstein verify` is five independent verification modes bundled behind
+one command: air-gap wheelhouse signatures, WAL hash-chain integrity,
+execution-determinism fingerprints, lesson-memory provenance, and formal
+property checks. Each mode is selected by its own flag (or a positional
+argument for wheelhouse mode); passing more than one runs all of them and
+combines their exit codes with bitwise OR.
+
+This command is not the audit-log verifier — for the HMAC-chained,
+Merkle-sealed audit trail, see [`bernstein audit verify`](../../security/audit-log.md).
+
+## Usage
+
+```bash
+bernstein verify <wheelhouse-path>                          # air-gap wheelhouse signatures
+bernstein verify --wal-integrity <run-id>                   # WAL hash-chain check
+bernstein verify --determinism <run-id>                     # print execution fingerprint
+bernstein verify --determinism <run-id> --expect <digest>   # gate on a recorded fingerprint
+bernstein verify --determinism <run-b> --baseline <run-a>   # gate that run-b reproduces run-a
+bernstein verify --memory-audit                              # audit lesson-memory provenance
+bernstein verify --formal <task-id>                          # Z3/Lean4 property checks
+```
+
+Running the bare command with no arguments prints a usage hint and returns
+without error.
+
+## Modes
+
+### Wheelhouse signature verification
+
+```bash
+bernstein verify ./airgap-wheelhouse/1.10.0
+```
+
+Verifies every wheel's SHA-256 against `MANIFEST.json` and, when signature
+files are present or `--require-signatures` is set, validates cosign / GPG
+/ PEM-key signatures. Optional flags add a customer-key countersignature
+check (`--require-customer-sig`) and Sigstore build-provenance verification
+(`--sigstore`, `--sigstore-offline`, `--require-sigstore`). This mode is the
+one covered in full in the [air-gap installation guide](../../installation/air-gap.md) —
+see that page for the complete flag reference and troubleshooting table.
+
+### WAL integrity (`--wal-integrity RUN_ID`)
+
+Reads `.sdd/runtime/wal/<run-id>.wal.jsonl` and replays its hash chain
+(`WALReader.verify_chain()`). Exits 0 with an entry count when the chain is
+intact, 1 with the list of chain errors when it isn't, and 1 with a "WAL
+file not found" message when the run has no WAL.
+
+### Execution determinism (`--determinism RUN_ID`)
+
+Computes an `ExecutionFingerprint` from the same WAL and prints it. Two
+optional gates change the exit code:
+
+| Gate | Behaviour |
+|---|---|
+| (none) | Bare mode: print the fingerprint, exit 0. |
+| `--expect DIGEST` | Constant-time compare against `DIGEST`; exit 0 on match, 2 on mismatch (prints both digests). |
+| `--baseline RUN_ID` | Compare the fingerprint against a second run's; exit 0 on match, 2 on mismatch, and names the first diverging WAL entry. |
+
+`--expect` and `--baseline` are mutually exclusive and both require
+`--determinism`. A green gate proves the two runs' WAL *decision traces*
+matched — it does not prove on-disk artefacts are byte-identical.
+
+### Lesson-memory provenance (`--memory-audit`)
+
+Walks `.sdd/memory/lessons.jsonl` and verifies its hash chain
+(`verify_chain`) plus a per-entry provenance trail (`audit_provenance`),
+reporting counts of hash-tampered and chain-mispositioned entries. Exits 0
+when clean (or when no lesson memory file exists yet) and 1 on any
+violation. This check exists to satisfy OWASP Agent Security Initiative
+ASI06 (Memory & Context Poisoning).
+
+### Formal property checks (`--formal TASK_ID`)
+
+Fetches the named task from the running task server and runs the property
+checks declared in `bernstein.yaml`'s `formal_verification` section against
+it via Z3 / Lean4. Exits 0 if the section is absent, disabled, or has no
+properties defined (nothing to check); exits 0 on a pass and 1 on any
+violation, printing each violated property and its counterexample (if one
+was found before the checker timed out).
+
+The CLI surface ships with Bernstein; the Z3 and Lean4 binaries themselves
+must be installed separately and on `PATH` — they are not bundled.
+
+## Source
+
+`src/bernstein/cli/commands/verify_cmd.py`.

--- a/docs/security/audit-receipt.md
+++ b/docs/security/audit-receipt.md
@@ -34,7 +34,7 @@ and the receipt stops verifying; it does not merely lose a log line.
 
 All three sign through the same Ed25519 KMS adapter that already signs lineage
 records and the multi-tenant `head_signature` (see
-[`lineage_kms.py`](../../src/bernstein/core/security/lineage_kms.py)) - no new
+[`lineage_kms.py`](https://github.com/sipyourdrink-ltd/bernstein/blob/main/src/bernstein/core/security/lineage_kms.py)) - no new
 key material or rotation cadence. The verifying key is embedded as an RFC 8037
 JWK (`signing.public_key_jwk`) so the receipt is self-contained; auditors may
 pin it out-of-band for additional trust.
@@ -100,7 +100,7 @@ the standard envelope back to the intact chain.
 ## Schema
 
 The receipt conforms to
-[`schemas/audit-receipt-v1.json`](../../schemas/audit-receipt-v1.json).
+[`schemas/audit-receipt-v1.json`](https://github.com/sipyourdrink-ltd/bernstein/blob/main/schemas/audit-receipt-v1.json).
 
 ## Threat model
 

--- a/docs/security/bug-bounty.md
+++ b/docs/security/bug-bounty.md
@@ -1,6 +1,6 @@
 # Coordinated Disclosure
 
-Full details of the Bernstein vulnerability disclosure process and researcher sandbox. For the policy summary, severity classification, and recognition, see [`SECURITY.md`](../../SECURITY.md).
+Full details of the Bernstein vulnerability disclosure process and researcher sandbox. For the policy summary, severity classification, and recognition, see [`SECURITY.md`](https://github.com/sipyourdrink-ltd/bernstein/blob/main/SECURITY.md).
 
 ## Program overview
 

--- a/docs/security/log-redaction.md
+++ b/docs/security/log-redaction.md
@@ -1,0 +1,78 @@
+# Log redaction (PII filter)
+
+Bernstein installs a `logging.Filter` on the root Python logger at startup
+that rewrites email addresses, phone numbers, SSNs, and credit-card numbers
+to `[REDACTED]` before any log handler emits the record. Because filters run
+before handlers, every sink attached to the root logger - console, file,
+structured JSON - receives the sanitised text; nothing upstream of the filter
+is written to disk or stdout unredacted.
+
+Source: `src/bernstein/core/observability/log_redact.py`.
+
+## How it is installed
+
+`install_pii_filter()` runs unconditionally as a module-level side effect
+when `bernstein.core.orchestration.bootstrap` is imported:
+
+```python
+# core/orchestration/bootstrap.py
+install_pii_filter()
+```
+
+There is no `bernstein.yaml` switch or environment variable to disable it -
+the filter is attached on every Bernstein process startup. Calling
+`install_pii_filter()` again (on the same logger) is a no-op: the function
+stores the filter instance on an attribute (`_bernstein_pii_filter`) and
+returns the existing one instead of double-attaching.
+
+To protect a specific logger instead of the root logger:
+
+```python
+from bernstein.core.observability.log_redact import install_pii_filter
+import logging
+
+install_pii_filter(logging.getLogger("my_module"))
+```
+
+## What it redacts
+
+| Pattern | Regex intent |
+|---|---|
+| `email` | standard `local@domain.tld` addresses |
+| `phone` | US-style phone numbers, with or without a leading country code |
+| `ssn` | `###-##-####` |
+| `credit_card` | 16 digits, optionally grouped in 4s with spaces or dashes |
+
+Matches are replaced with the literal string `[REDACTED]`. The filter
+mutates `record.msg` (when it is a string) and, for `%`-style lazy logging,
+each string value inside `record.args` (`dict` or `tuple`) - so both eager
+f-string messages and lazy `logger.info("... %s ...", value)` calls are
+covered.
+
+These four patterns are the same ones the [PII scan quality gate](pii-scan-gate.md)
+checks for at medium severity; the two mechanisms are independent (one scrubs
+runtime log output, the other scans agent-produced diffs before merge) and
+are not sharing state or configuration.
+
+## Limitations
+
+- **Regex-only.** No context awareness beyond the four patterns above; text
+  that doesn't match one of them (names, addresses, free-text PII, secrets)
+  is not touched by this filter. Secret/credential detection is a separate
+  concern, covered by the [PII scan quality gate](pii-scan-gate.md).
+- **Only `record.msg` / `record.args` are scrubbed.** Exception tracebacks
+  attached via `exc_info=True` are rendered by the log formatter directly
+  from the traceback object (`formatException`), which this filter does not
+  touch. PII embedded in an exception's own message string or in a frame's
+  local variables is not redacted when it is logged through `exc_info`.
+- **Logging-module scoped.** Output that bypasses Python's `logging` module
+  entirely - `print()`, direct stdout writes, structured audit-chain entries
+  - is not covered by this filter.
+- **No opt-out.** Because installation is unconditional at bootstrap import
+  time, there is currently no supported way to disable the filter short of
+  monkeypatching or not importing the bootstrap module.
+
+## Related
+
+- [PII scan quality gate](pii-scan-gate.md) - pre-merge secret/PII scanning
+  of agent-produced diffs (a different mechanism, same four PII patterns).

--- a/docs/security/pii-scan-gate.md
+++ b/docs/security/pii-scan-gate.md
@@ -1,0 +1,93 @@
+# PII scan quality gate
+
+Before a task's diff can merge, Bernstein scans every changed (or configured)
+file for leaked secrets, credentials, and PII. The scan is regex-only - no
+network calls, no LLM - and is one of the built-in gates in the quality-gate
+pipeline. High-severity findings (leaked credentials) hard-block merge;
+medium-severity findings (PII) are reported but do not block by default.
+
+Source: `src/bernstein/core/security/pii_output_gate.py` (scan engine),
+`src/bernstein/core/quality/quality_gates.py` (`_run_pii_gate` /
+`run_pii_gate_sync`, gate name `pii_scan`).
+
+## Enabling and configuring it
+
+The gate is **on by default**. It runs whenever any file in the diff changes
+(`condition: any_changed` in the default pipeline), and is a **required**
+gate, meaning a high-severity finding blocks merge.
+
+```yaml
+# bernstein.yaml
+quality_gates:
+  pii_scan: true                          # default: true
+  pii_scan_paths: ["src/"]                # scanned when no changed-file list is supplied
+  pii_ignore_paths: []                    # glob-style paths to skip entirely
+  pii_allowlist_prefixes:                 # value prefixes treated as fixtures
+    - "FAKE"
+    - "TEST"
+    - "EXAMPLE"
+    - "DUMMY"
+    - "PLACEHOLDER"
+    - "LOCALHOST"
+```
+
+When the gate runs as part of a task's diff review, only the files reported
+as changed for that task are scanned. Outside of a diff context (or when no
+changed-file list is available), it recursively scans `pii_scan_paths`.
+
+For the surrounding gate framework (pipeline ordering, `required` vs
+`optional`, custom gate plugins), see [Quality Pipeline](../architecture/quality-pipeline.md).
+
+## What it detects
+
+| Category | Severity | Examples |
+|---|---|---|
+| AWS access/secret key, GCP service-account JSON | high | `AKIA...`, `aws_secret_access_key = "..."` |
+| Platform tokens | high | GitHub (`ghp_`/`gho_`/...), Slack (`xox...`), Stripe (`sk_live_`/`sk_test_`) |
+| Private key (PEM) | high | `-----BEGIN ... PRIVATE KEY-----` |
+| Generic API key / secret / high-entropy assignment | high | `api_key = "..."`, `token: "<24+ mixed-case+digit chars>"` |
+| Hardcoded password, DB/service connection string, bearer token, JWT | high | `password = "..."`, `postgres://user:pass@host/db` |
+| Email address, phone number, SSN, credit-card number | medium | free-text PII in code or comments |
+
+Only **high**-severity findings set `blocked=True` on the gate result
+(`quality_gates.py:834-846`). PII findings (email/phone/SSN/credit-card) are
+all medium severity, so a PII-only diff passes the gate but is still recorded
+in the gate's detail output - the gate hard-blocks on leaked secrets, and
+flags-but-allows on PII.
+
+Two post-filters reduce false positives before a match is reported:
+
+- **Credit-card numbers** must pass a Luhn checksum (`_looks_like_credit_card`).
+- **High-entropy assignments** must contain a mix of uppercase, lowercase, and
+  digit characters (`_has_mixed_case_and_digits`).
+
+## What is skipped
+
+- Lines matching a built-in allowlist: `example.com/.org/.net`, addresses
+  starting `test@`/`user@`/`admin@`/`noreply@`/`no-reply@`, values containing
+  `placeholder`/`changeme`/`your-api-key`/`xxxx`, `localhost`/`127.0.0.1`/
+  `0.0.0.0`, and password assignments using known test values
+  (`test`/`password`/`changeme`/`secret`/`admin`).
+- Lines whose value carries a configured `pii_allowlist_prefixes` prefix
+  (default: `FAKE`, `TEST`, `EXAMPLE`, `DUMMY`, `PLACEHOLDER`, `LOCALHOST`).
+- Paths matching `pii_ignore_paths` (glob or prefix match).
+- Binary-ish file suffixes: `.pyc .pyo .so .dylib .whl .egg .gz .zip .tar
+  .png .jpg .gif .ico .pdf`.
+- For diff scans, only added (`+`) lines are checked - removed and context
+  lines are never scanned, since the goal is catching *new* secrets.
+
+## Output
+
+Findings never store the raw secret. Each finding carries a redacted excerpt
+(the matched span replaced with `***`, up to ~60 characters of surrounding
+context) plus the rule name, severity, and line number. Gate detail output is
+truncated at 2000 characters.
+
+## Related
+
+- [Quality Pipeline](../architecture/quality-pipeline.md) - the gate
+  framework this gate plugs into (pipeline ordering, custom gates,
+  `bernstein.yaml` schema).
+- [Log redaction](log-redaction.md) - the sibling control that scrubs PII
+  from Bernstein's own runtime log output (a different mechanism, applied to
+  logs rather than agent-produced diffs).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -165,6 +165,7 @@ nav:
       - Remote quickstart (Codespaces): getting-started/remote.md
       - First run: getting-started/first-run.md
       - Tutorial: getting-started/quickstart-tutorial.md
+      - Zero-config demo: getting-started/quickstart-demo.md
   - Guides:
       - guides/index.md
       - Web GUI:
@@ -191,6 +192,9 @@ nav:
           - Stream signals: adapters/stream_signals.md
           - Strict output schemas: adapters/schemas.md
           - Conformance canary: adapters/conformance-canary.md
+          - Capability profiles: adapters/capability_profiles.md
+          - Browser / computer-use adapter: adapters/computer_use.md
+          - Adapter smoke test: adapters/test-adapter.md
       - Sandboxes:
           - Overview: architecture/sandbox.md
           - Backend selector: concepts/sandbox-selector.md
@@ -237,6 +241,9 @@ nav:
           - Server injection: integrations/mcp-server-injection.md
           - Tool-search lazy loading: protocols/tool-search.md
           - cocoindex-code catalog: integrations/cocoindex-code.md
+          - Tool-call input validation: mcp/input-validation.md
+          - Gateway proxy: operations/mcp-gateway.md
+          - x402 settlement: operations/x402-settlement.md
       - Hooks, plugins & skills:
           - Hook system: integrations/hook-system.md
           - Hook prefilter: operations/hooks.md
@@ -282,6 +289,9 @@ nav:
           - Fleet directory registry: fleet/directory-registry.md
           - Air-gap install: installation/air-gap.md
           - Migrations: operations/migrations.md
+          - Self-update: operations/self-update.md
+          - Shell completions: operations/shell-completions.md
+          - Pilot-to-production graduation: operations/graduation.md
           - Enterprise evaluation: ENTERPRISE.md
       - Run & supervise:
           - Commands overview: operations/commands.md
@@ -307,6 +317,18 @@ nav:
           - Webhook node: operations/webhook-node.md
           - Preview server: operations/preview.md
           - Voice control: operations/voice-control.md
+          - Session checkpoint: operations/checkpoint.md
+          - Session wrap-up: operations/wrap-up.md
+          - Session fast resume: operations/session-fast-resume.md
+          - File watch: operations/watch.md
+          - Detached run service: operations/run-service.md
+          - Tournament runs: operations/tournament-runs.md
+          - Fleet steering: operations/fleet-steering.md
+          - Named resource pools: operations/named-resource-pools.md
+          - Trigger sources: operations/trigger-sources.md
+          - Slack webhooks: operations/slack-webhooks.md
+          - TUI keybindings: operations/tui-keybindings.md
+          - Worker process identity: operations/worker-process-identity.md
       - Reliability:
           - Troubleshooting: operations/TROUBLESHOOTING.md
           - Checkpointed retries: operations/checkpointed-retries.md
@@ -322,6 +344,9 @@ nav:
           - Disaster recovery: operations/disaster-recovery.md
           - Chaos engineering: operations/chaos-engineering.md
           - Runbooks: operations/runbooks.md
+          - Agent edit-loop detection: operations/agent-loop-detection.md
+          - In-process verification gates: operations/hook-gate.md
+          - Per-goal SLA contracts: operations/sla.md
       - Cost & performance:
           - Cost optimization: operations/cost-optimization.md
           - Cost-aware scheduling: operations/cost-aware-scheduling.md
@@ -333,6 +358,11 @@ nav:
           - Per-profile cost attribution: operations/profile-cost-attribution.md
           - Profile A/B harness: operations/profile-ab-harness.md
           - Template compression: operations/template-compression.md
+          - Cost envelopes: operations/cost-envelopes.md
+          - Cost anomaly detection: operations/cost-anomaly-detection.md
+          - Token growth monitor: operations/token-growth-monitor.md
+          - Payment mandates: operations/payment-mandates.md
+          - Showback canonicalization: cost/showback-canonical.md
       - Observability:
           - Overview: operations/observability-overview.md
           - Instrumentation: operations/INSTRUMENTATION.md
@@ -352,6 +382,12 @@ nav:
           - Unified doctor: observability/unified-doctor.md
           - Telemetry share: observability/telemetry-share.md
           - Cluster observability: observability/cluster.md
+          - Per-agent token progress: observability/token-progress.md
+          - Cumulative progress: observability/cumulative-progress.md
+          - OTel GenAI span projection: observability/otel-span-projection.md
+          - Journal-anchored OTLP bridge: sdd/otel-journal-bridge.md
+          - Session analytics: operations/session-analytics.md
+          - Debug bundle: operations/debug-bundle.md
       - Merge & review automation:
           - Merge queue: operations/merge-queue.md
           - Merge gate: operations/merge-gate.md
@@ -366,6 +402,12 @@ nav:
           - CI: operations/ci.md
           - CI topology: operations/ci-topology.md
           - Post-CI dispatcher: operations/post-ci-dispatcher.md
+          - Review pipeline DSL: operations/review-pipeline.md
+          - Review and autofix receipts: operations/review-receipts.md
+          - Commit attribution stats: operations/commit-attribution.md
+          - Backlog sync: operations/backlog-sync.md
+          - Plan archival: operations/plan-archival.md
+          - on_fail recovery receipts: workflows/on-fail-recovery-receipts.md
       - Evaluation & calibration:
           - Incident-to-eval synthesis: eval/incident-synthesis.md
           - A/B runner: eval/ab-runner.md
@@ -373,6 +415,7 @@ nav:
           - Pentest scenario: eval/security_pentest_scenario.md
           - Calibration: operations/calibration.md
           - Criterion profiles: operations/criterion-profiles.md
+          - Golden benchmark harness: eval/golden-harness.md
       - Security & identity:
           - Security & identity stack: operations/security-and-identity.md
           - Security operations: operations/security.md
@@ -391,6 +434,8 @@ nav:
           - Lethal trifecta: security/lethal-trifecta.md
           - Coordinated disclosure: security/bug-bounty.md
           - Acknowledgments: security/security-acknowledgments.md
+          - Log redaction: security/log-redaction.md
+          - PII scan gate: security/pii-scan-gate.md
       - Compliance & audit:
           - Compliance overview: operations/compliance.md
           - SOC 2 audit: security/AUDIT.md
@@ -411,12 +456,20 @@ nav:
           - A2A message receipts: operations/a2a-message-receipts.md
           - A2A JSON-RPC server surface: operations/a2a-server.md
           - Datasources & query receipts: operations/datasources.md
+          - Verifiable audit receipts: security/audit-receipt.md
+          - Gate adjudication records: operations/gate-adjudication.md
+          - Agent run manifest: operations/run-manifest.md
+          - Verification evidence bundles: operations/evidence-bundles.md
+          - Delegation chain verification: operations/delegation-verify.md
+          - Skill usage provenance: operations/skill-provenance.md
+          - C2PA content credentials: operations/content-credentials.md
   - Reference:
       - reference/index.md
       - CLI:
           - CLI reference: reference/cli-reference.md
           - Task lifecycle CLI: reference/cli/task-lifecycle.md
           - Replay CLI: reference/cli/replay.md
+          - Verify CLI: reference/cli/verify.md
       - Configuration & schemas:
           - Configuration: operations/CONFIG.md
           - Task format: operations/task_format.md
@@ -426,6 +479,8 @@ nav:
           - Model policy: operations/MODEL_POLICY.md
           - Ticket schema: sdd/ticket_schema.md
           - Adapter capability contract: adapters/capability_contract.md
+          - Global config CLI: operations/global-config.md
+          - Workflow manifests: operations/workflow-manifests.md
       - APIs & protocols:
           - REST API: reference/openapi-reference.md
           - API server operations: operations/api.md
@@ -448,6 +503,14 @@ nav:
           - Glossary: reference/GLOSSARY.md
       - Release notes:
           - Changelog: CHANGELOG.md
+          - v3.9.0: release-notes/v3.9.0.md
+          - v3.8.4: release-notes/v3.8.4.md
+          - v3.8.3: release-notes/v3.8.3.md
+          - v3.8.2: release-notes/v3.8.2.md
+          - v3.8.1: release-notes/v3.8.1.md
+          - v3.8.0: release-notes/v3.8.0.md
+          - v3.7.1: release-notes/v3.7.1.md
+          - v3.7.0: release-notes/v3.7.0.md
           - v3.6.0: release-notes/v3.6.0.md
           - v3.5.0: release-notes/v3.5.0.md
           - v3.4.4: release-notes/v3.4.4.md
@@ -501,6 +564,13 @@ nav:
           - Tiered context compaction: architecture/memory_tiers.md
           - Skill packs: architecture/skills.md
           - Orchestration approaches: architecture/orchestration-approaches.md
+          - Fast-path execution: architecture/fast-path-execution.md
+          - Batch routing: architecture/batch-routing.md
+          - Deadlock detection: architecture/deadlock-detection.md
+          - Context degradation detector: architecture/context-degradation-detector.md
+          - Protocol version negotiation: architecture/protocol-negotiation.md
+          - Task-payload schema registry: architecture/schema-registry.md
+          - Native subagent delegation: architecture/subagent-delegation.md
       - Concepts:
           - AST-aware reviewer chunks: concepts/ast-aware-chunking.md
           - Fingerprint memoization: concepts/fingerprint-memoization.md
@@ -520,6 +590,8 @@ nav:
           - Prompt-to-repo scaffold: concepts/scaffold.md
           - Team-hub conventions: concepts/team-hub.md
           - Orchestrator hardening: concepts/orchestrator-hardening.md
+          - Agent lesson persistence: concepts/lesson-persistence.md
+          - Semantic caching: concepts/semantic-caching.md
       - Orchestration internals:
           - Task DAG: orchestration/task-dag.md
           - Research activities: orchestration/research-activity.md
@@ -532,6 +604,8 @@ nav:
           - Consensus scoring: quality/consensus-scoring.md
           - Empirical confidence: quality/empirical-confidence.md
           - Spec quality gate: planning/spec-quality-gate.md
+          - Multi-cell orchestration: orchestration/multi-cell.md
+          - Bulletin board: orchestration/bulletin-board.md
       - Decisions (ADRs):
           - Agent lifecycle: decisions/001-agent-lifecycle.md
           - Self-evolution: decisions/003-self-evolution.md
@@ -541,11 +615,13 @@ nav:
           - Pluggy plugin system: decisions/007-pluggy-plugin-system.md
           - Click for CLI: decisions/008-click-for-cli.md
           - Lineage v1: decisions/009-lineage-v1.md
+          - Audit-chain default cost: decisions/010-audit-chain-default-cost.md
   - Contribute:
       - contributing/index.md
       - Code review process: CODE_REVIEW.md
       - Testing & CI hardening: contributing/testing.md
       - Lifecycle hooks contract: contributing/hooks.md
+      - Git hooks: contributing/git-hooks.md
       - Adapter contracts: contributing/adapter-contracts.md
       - Writing adapters: adapters/ADAPTER_GUIDE.md
       - Flake handling: contributing/flake-handling.md
@@ -553,6 +629,8 @@ nav:
       - Extended static analysis: ci/extended-static-analysis.md
       - Release process: operations/release.md
       - Docs drift playbook: playbooks/docs-drift.md
+      - Docs update sweep: playbooks/docs-update-sweep.md
+      - Docs source-of-truth notes: llm-citation-surface.md
       - Trend scan automation: devops/trend-scan-automation.md
 docs_dir: docs
 strict: false
@@ -562,7 +640,9 @@ strict: false
 # site and out of strict link validation.
 # Setting exclude_docs replaces the MkDocs defaults, so restate them
 # (dotfiles, /templates/) alongside the _internal guard.
+# /assets/*.md holds render fragments (ASCII banner), not pages.
 exclude_docs: |
   .*
   /templates/
   _internal/
+  /assets/*.md


### PR DESCRIPTION
## What

The feature matrix listed 150 capabilities as source-only (`Brief`). Auditing every row against `src/bernstein/` showed most of them either already had a reference page that nothing linked to, or had no page at all. Separately, 79 files under `docs/` had no nav entry in `mkdocs.yml`, so they never rendered on the published site regardless of how good the content was.

## Counts

| | |
|---|---|
| Matrix rows flipped to `Full` and linked | **132** |
| — pointing at pages that already existed | 79 |
| — pointing at pages added in this PR | 53 |
| Matrix rows deliberately left `Brief` | **17** |
| Total matrix rows after rebase | 149 |
| New reference pages | 53 |
| Orphaned pages wired into nav | 78 |
| Staleness findings applied (6 high, 13 medium) | 19 |
| Broken cross-repo links repaired | 3 |

## The 17 rows that stay `Brief`

These are not oversights. Each one either has no operator-facing surface to document, or exists in source but cannot be invoked from any CLI, API, or config path today. Writing a reference page and marking it `Full` would document something a reader cannot actually use. The unreachable subset is tracked in #2973.

The matrix header now says this explicitly, so the column stays honest instead of drifting into a completeness score.

## Nav orphans fixed

- 39 files under `docs/operations/`, including `payment-mandates.md` and `sla.md`, both of which document real registered CLI groups
- 8 release-notes pages (v3.7.0 through v3.9.0); nav previously topped out at v3.6.0 while `pyproject.toml` reported 3.9.0
- `docs/adapters/computer_use.md` and `docs/adapters/capability_profiles.md`, both linked from `docs/adapters/index.md` but unreachable from nav
- the remaining architecture, concepts, orchestration, observability, security, eval and contributing pages listed by `mkdocs build`

`docs/assets/*.md` is now excluded rather than navigated: it holds a render fragment (the ASCII banner), not a page.

## Staleness fixes

Each was verified against source before changing.

- **Cloudflare Agents claims**: removed the row from the README supported-agents table and from the `docs/index.md` adapter list; the adapter's `spawn()` refused unconditionally, so the row advertised an install command for something that had never run a task. #2972 landed on `main` mid-review and deleted the adapter itself, so this PR also drops the four remaining doc tables that still listed the `cloudflare` registry key as selectable (`adapters/index.md`, `ADAPTER_GUIDE.md`, `compatibility.md`, `capability_contract.md`). No adapter source was touched.
- **`bernstein cloud` example in README**: `cloud run` takes a free-text `goal` argument, so `bernstein cloud run plan.yaml` sent the literal string `plan.yaml` as the goal. `cloud deploy` prints an `npx wrangler deploy` instruction rather than deploying. Both corrected.
- **`docs/adapters/deepseek.md`**: the `DataResidencyController` example imported `EU_WEST` / `EU_CENTRAL` as module-level names. They are `Region` enum members, and the allowed-region set is per-tenant `ResidencyPolicy` state, not a constructor argument. The corrected example was executed against the real module.
- **`docs/adapters/compatibility.md`**: dropped seven quality-gate module names that do not exist anywhere under `src/bernstein/` (`arch_rules.py`, `perf_benchmark_gate.py`, `mutation_testing.py`, `test_mutation_verify.py`, `consensus_verifier.py`, `llm_judge.py`, `gate_cache.py`) and replaced them with what `src/bernstein/core/quality/` actually ships. Also fixed `bernstein test-adapter <name>` (the command takes `--adapter` / `--task`, there is no positional argument) and `bernstein debug` (the bundle subcommand is `bernstein debug bundle`).
- **`docs/adapters/stream_signals.md`**: `bernstein plan execute` does not exist; the `plan` group registers `generate`, `compile`, `ls`, `show`, `dag`. Plans run via `bernstein run <plan.yaml>`.
- **`docs/integrations/github-action.md`**: `action.yml` declares a `plan` input and four outputs that the page never mentioned. Added.
- **`docs/operations/voice-control.md`**: two citations pointed at `FEATURE_MATRIX.md:185`, which stopped being the right line some time ago. Replaced with a page link so the citation cannot drift again.
- **Three links pointing outside `docs_dir`** (`SECURITY.md`, `schemas/audit-receipt-v1.json`, `lineage_kms.py`) now resolve to the repository. These were the only `mkdocs build --strict` failures already present on `main`; `strict: false` in `mkdocs.yml` is why the published build never surfaced them.

## Verification

```
mkdocs build --strict   ->  exit 0, 0 warnings, 0 pages missing from nav
```

- All 132 links added to the matrix were checked programmatically against the built site output; every one resolves to a rendered page.
- The rendered matrix table parses as 259 rows, 132 with a linked capability cell, 17 `Brief` — matching the intended counts.
- `scripts/check_docs_drift.py` reports no drift.
- The corrected `DataResidencyController` example was executed, not just read.

No source files were modified.

## Known pre-existing issue, not addressed here

`pre-commit`'s `check-yaml` hook fails on `mkdocs.yml` on `main` as well, because the config uses `!!python/name:` and `!!python/object/apply:` tags that `yaml.safe_load` cannot construct. It surfaces on any PR that touches `mkdocs.yml`. The fix is a one-line `exclude` on that hook, which belongs in its own change rather than here.

## Note on counts

The audit that drove this change covered 150 matrix rows: 132 to promote, 18 to leave `Brief`. #2972 merged to `main` during the work and deleted one of those 18 rows (Cloudflare Agents Adapter) along with the adapter. After rebasing, the matrix holds 149 of the audited rows: the same 132 promoted, 17 left `Brief`.
