### PR TITLE
feat(adapters): drive Codex on Cloudflare through the sandbox bridge

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -112,7 +112,7 @@ alwaysApply: false
 | `clm_tls_launcher.py`       | mTLS launcher for the CLM adapter |
 | `codebuff.py`               | Codebuff CLI adapter |
 | `codex.py`                  | OpenAI Codex CLI adapter |
-| `codex_cloudflare.py`       | Codex adapter for Cloudflare Sandbox execution (experimental, non-functional) |
+| `codex_cloudflare.py`       | Codex adapter driving Cloudflare's first-party sandbox bridge (issue #2969) |
 | `cody.py`                   | Sourcegraph Cody CLI adapter |
 | `composio.py`               | Composio Agent Orchestrator (``ao``) CLI adapter |
 | `computer_use.py`           | Browser / computer-use adapter family (#2606) |

--- a/.goosehints
+++ b/.goosehints
@@ -113,7 +113,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `clm_tls_launcher.py`       | mTLS launcher for the CLM adapter |
 | `codebuff.py`               | Codebuff CLI adapter |
 | `codex.py`                  | OpenAI Codex CLI adapter |
-| `codex_cloudflare.py`       | Codex adapter for Cloudflare Sandbox execution (experimental, non-functional) |
+| `codex_cloudflare.py`       | Codex adapter driving Cloudflare's first-party sandbox bridge (issue #2969) |
 | `cody.py`                   | Sourcegraph Cody CLI adapter |
 | `composio.py`               | Composio Agent Orchestrator (``ao``) CLI adapter |
 | `computer_use.py`           | Browser / computer-use adapter family (#2606) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `clm_tls_launcher.py`       | mTLS launcher for the CLM adapter |
 | `codebuff.py`               | Codebuff CLI adapter |
 | `codex.py`                  | OpenAI Codex CLI adapter |
-| `codex_cloudflare.py`       | Codex adapter for Cloudflare Sandbox execution (experimental, non-functional) |
+| `codex_cloudflare.py`       | Codex adapter driving Cloudflare's first-party sandbox bridge (issue #2969) |
 | `cody.py`                   | Sourcegraph Cody CLI adapter |
 | `composio.py`               | Composio Agent Orchestrator (``ao``) CLI adapter |
 | `computer_use.py`           | Browser / computer-use adapter family (#2606) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `clm_tls_launcher.py`       | mTLS launcher for the CLM adapter |
 | `codebuff.py`               | Codebuff CLI adapter |
 | `codex.py`                  | OpenAI Codex CLI adapter |
-| `codex_cloudflare.py`       | Codex adapter for Cloudflare Sandbox execution (experimental, non-functional) |
+| `codex_cloudflare.py`       | Codex adapter driving Cloudflare's first-party sandbox bridge (issue #2969) |
 | `cody.py`                   | Sourcegraph Cody CLI adapter |
 | `composio.py`               | Composio Agent Orchestrator (``ao``) CLI adapter |
 | `computer_use.py`           | Browser / computer-use adapter family (#2606) |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -113,7 +113,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `clm_tls_launcher.py`       | mTLS launcher for the CLM adapter |
 | `codebuff.py`               | Codebuff CLI adapter |
 | `codex.py`                  | OpenAI Codex CLI adapter |
-| `codex_cloudflare.py`       | Codex adapter for Cloudflare Sandbox execution (experimental, non-functional) |
+| `codex_cloudflare.py`       | Codex adapter driving Cloudflare's first-party sandbox bridge (issue #2969) |
 | `cody.py`                   | Sourcegraph Cody CLI adapter |
 | `composio.py`               | Composio Agent Orchestrator (``ao``) CLI adapter |
 | `computer_use.py`           | Browser / computer-use adapter family (#2606) |

--- a/docs/adapters/ADAPTER_GUIDE.md
+++ b/docs/adapters/ADAPTER_GUIDE.md
@@ -459,17 +459,35 @@ wrangler login
 
 ### codex_cloudflare (Codex on Cloudflare Sandboxes)
 
-Runs OpenAI Codex inside Cloudflare sandboxes for isolated, scalable execution.
+Runs OpenAI Codex inside a Cloudflare sandbox container, driven over HTTP through
+a bridge Worker the operator deploys (`@cloudflare/sandbox` 0.12.4, API contract
+`1.0.0`).
 
 **Unique features:**
-- Full container sandbox with configurable memory (default 512 MiB), CPU, and network access
-- Workspace synced via R2 (same bucket as other Cloudflare bridges)
-- Automatic cleanup on timeout or error
-- Polls sandbox status every 5 seconds until completion
+- Container-isolated execution off the orchestrator host, over REST + SSE
+- Output streamed as it arrives (base64 SSE frames decoded per chunk), not buffered to the end
+- Workspace seeded and collected as a tar (`hydrate` / `persist`), returning a real file diff
+- Cancellation issues the explicit sandbox delete, so remote work actually stops
+- Records content-addressed sandbox evidence that signs into a selection receipt
 
-**Configuration:** `CodexSandboxConfig` with `cloudflare_account_id`, `cloudflare_api_token`, `openai_api_key`, `sandbox_image`, `max_execution_minutes`, `memory_mb`, `cpu_cores`, `network_access`, `r2_bucket`.
+**Prerequisites:** a Cloudflare Workers Paid plan, an operator-deployed bridge
+Worker with its `SANDBOX_API_KEY` secret set, and a container image carrying the
+`codex` CLI at `instance_type` `standard-3` or larger. Unconfigured, every method
+refuses — it never falls back to local execution.
 
-**Best for:** Running Codex agents in isolated environments where you need container-level security and R2-based workspace sync. See the [Cloudflare Adapters guide](../cloudflare/cloudflare-adapters.md) for full details.
+**Configuration:** `CodexSandboxConfig` with `bridge_url`, `bridge_api_key`,
+`openai_api_key`, `workdir`, `agent_command`, `extra_env`,
+`max_execution_minutes`, `request_timeout_seconds`, `persist_excludes`,
+`require_supported_api_version`. Per-request memory/CPU sizing and network
+restriction are absent: container sizing is a deploy-time wrangler setting and the
+bridge applies no egress restrictions.
+
+**Status:** built against the published bridge contract with recorded HTTP and SSE
+fixtures; end-to-end verification against a live deployment is pending.
+
+**Best for:** running Codex off-host in a container you control, when you already
+run on Cloudflare. See [Codex on Cloudflare Sandboxes](../cloudflare/cloudflare-codex-sandbox.md)
+for deploy steps, the authentication warning, and the stated limitations.
 
 ---
 

--- a/docs/cloudflare/cloudflare-adapters.md
+++ b/docs/cloudflare/cloudflare-adapters.md
@@ -1,6 +1,6 @@
 # Cloudflare Adapters
 
-The Codex-on-Cloudflare adapter runs agents on Cloudflare infrastructure instead of locally. **It is experimental and currently non-functional** — see the status note below before relying on it.
+The Codex-on-Cloudflare adapter runs agents on Cloudflare infrastructure instead of locally, by driving the sandbox bridge Worker you deploy into your own account. It needs a Cloudflare Workers Paid plan, and end-to-end verification against a live deployment is still pending — see the status note below before relying on it.
 
 The Cloudflare Agents SDK adapter (registry key `cloudflare`) was removed in issue #2970. It refused every spawn and had no path to a working one: the Agents SDK dispatches to a Worker the operator writes rather than exposing an invocation contract to implement against, and it does not execute shell. Configuring `cli: cloudflare` now fails with an error naming this page's supported path instead of resolving to an adapter that always refuses.
 
@@ -11,63 +11,39 @@ The Cloudflare Agents SDK adapter (registry key `cloudflare`) was removed in iss
 **Module:** `bernstein.adapters.codex_cloudflare`
 **Class:** `CodexCloudflareAdapter`
 
-!!! warning "Experimental — non-functional (issue #2783)"
-    This adapter drove every operation against
-    `https://api.cloudflare.com/client/v4/accounts/{id}/sandbox/...`, a REST
-    route family that **does not exist** — an authenticated request returns
-    HTTP 400 with Cloudflare errors 7000/7003 ("No route for that URI").
-    Cloudflare's real sandbox/container product runs inside a Worker/Durable
-    Object (the `@cloudflare/sandbox` SDK), not a `client/v4` REST surface.
+Runs Codex inside a Cloudflare sandbox container by driving the sandbox bridge
+Worker you deploy into your own account (`@cloudflare/sandbox` 0.12.4, API
+contract `1.0.0`). It creates a sandbox, seeds a workspace, streams the run over
+SSE, collects a workspace diff, records content-addressed sandbox evidence, and
+tears the container down.
 
-    Because the target API cannot be routed, no operation can run or populate a
-    result. Every public method (`execute`, `get_status`, `cancel`, `get_logs`)
-    now raises `RuntimeError` with an actionable message instead of issuing a
-    doomed request. To run Codex on Cloudflare, drive a deployed worker via
-    `bernstein.bridges.cloudflare.CloudflareBridge`; to run Codex locally, use
-    the `codex` adapter.
+Requires a Cloudflare Workers Paid plan and an operator-deployed bridge; without
+`bridge_url` and `bridge_api_key` every method refuses, and it never falls back
+to local execution.
 
-### Configuration
+!!! info "End-to-end verification against a live deployment is pending"
+    Built and tested against the published bridge contract with recorded HTTP
+    and SSE fixtures; not yet run against a real Cloudflare deployment.
 
-`CodexSandboxConfig` and `CodexSandboxResult` remain importable so callers and
-a future real implementation keep a stable surface, but no method issues a
-request today.
-
-`CodexSandboxConfig` dataclass fields:
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `cloudflare_account_id` | `str` | `""` | Cloudflare account ID |
-| `cloudflare_api_token` | `str` | `""` | Cloudflare API token |
-| `openai_api_key` | `str` | `""` | OpenAI API key for Codex |
-| `sandbox_image` | `str` | `"codex-sandbox:latest"` | Container image for the sandbox |
-| `max_execution_minutes` | `int` | `30` | Maximum execution time |
-| `memory_mb` | `int` | `512` | Memory allocation in MiB |
-| `cpu_cores` | `float` | `1.0` | CPU cores allocation |
-| `network_access` | `str` | `"restricted"` | Network access level |
-| `r2_bucket` | `str` | `"bernstein-workspaces"` | R2 bucket for workspace sync |
-
-### Result type
-
-`CodexSandboxResult` fields (populated only once a real sandbox surface is
-implemented):
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `sandbox_id` | `str` | Sandbox instance identifier |
-| `status` | `str` | `"completed"`, `"failed"`, `"timeout"`, or `"cancelled"` |
-| `files_changed` | `list[str]` | Relative paths of modified files |
-| `stdout` | `str` | Captured stdout |
-| `stderr` | `str` | Captured stderr |
-| `exit_code` | `int` | Process exit code |
-| `execution_time_seconds` | `float` | Wall-clock execution time |
-| `tokens_used` | `int` | Tokens consumed by Codex |
+**See [Codex on Cloudflare Sandboxes](cloudflare-codex-sandbox.md)** for deploy
+steps, the instance-type requirement, the authentication warning, the
+cancellation semantics, the live-verification command, and the stated
+limitations.
 
 ---
 
 ## Running agents today
 
-The Codex-on-Cloudflare adapter is non-functional at present (see the status note
-above). Run agents locally (`claude`, `codex`, `aider`, `mock`) or drive a worker
-you deployed yourself via `bernstein.bridges.cloudflare.CloudflareBridge`. That
-bridge calls a `/agents/*` route contract defined by Bernstein, not by Cloudflare:
-the Worker you deploy has to implement those routes.
+To run a coding agent on Cloudflare, use the Codex-on-Cloudflare adapter with a
+bridge Worker deployed into your own account — see
+[Codex on Cloudflare Sandboxes](cloudflare-codex-sandbox.md). It needs a Workers
+Paid plan, and end-to-end verification against a live deployment is still
+pending.
+
+The alternative is to drive a worker you deployed yourself via
+`bernstein.bridges.cloudflare.CloudflareBridge`. That bridge calls a `/agents/*`
+route contract defined by Bernstein, not by Cloudflare: the Worker you deploy has
+to implement those routes.
+
+To run agents on this host instead, use a local adapter such as `claude`,
+`codex`, `aider`, or `mock`.

--- a/docs/cloudflare/cloudflare-codex-sandbox.md
+++ b/docs/cloudflare/cloudflare-codex-sandbox.md
@@ -1,0 +1,355 @@
+# Codex on Cloudflare Sandboxes
+
+Run Codex inside a Cloudflare sandbox container instead of on the orchestrator
+host, by driving the sandbox bridge Worker you deploy into your own account.
+
+**Module:** `bernstein.adapters.codex_cloudflare`
+**Class:** `CodexCloudflareAdapter`
+
+!!! info "Implementation status"
+    Implemented against the HTTP bridge published by
+    **`@cloudflare/sandbox` 0.12.4**, which serves **API contract version
+    `1.0.0`** at `GET /v1/openapi.json`.
+
+    **End-to-end verification against a live deployment is pending.** The
+    adapter is built and tested against the published bridge contract, with
+    recorded HTTP and SSE fixtures that mirror the documented payloads. It has
+    **not** been run against a real Cloudflare deployment. If you have a
+    Workers Paid account, the [live verification](#live-verification) command
+    below is the one-shot check — please report what you find.
+
+---
+
+## What it does
+
+| Step | Bridge route |
+|---|---|
+| Create sandbox | `POST /v1/sandbox` → `{"id": ...}` |
+| Seed workspace | `POST /v1/sandbox/:id/hydrate` (tar) or `PUT /v1/sandbox/:id/file/*` |
+| Open session (cwd + env) | `POST /v1/sandbox/:id/session` → `{"id": ...}` |
+| Run the agent | `POST /v1/sandbox/:id/exec` → SSE, `Session-Id` header |
+| Collect the workspace | `POST /v1/sandbox/:id/persist` → tar → diff |
+| Stop and tear down | `DELETE /v1/sandbox/:id` |
+| Pool bookkeeping | `GET /v1/pool/stats` |
+
+`stdout` and `stderr` arrive as base64 SSE frames and are decoded and handed to
+your `on_output` callback as they stream, not buffered to the end. The stream
+terminates on `exit` (`{"exit_code": N}`) or `error` (`{"error": ..., "code": ...}`).
+
+---
+
+## Prerequisites
+
+1. **A Cloudflare Workers Paid plan** ($5/month). Containers — which sandboxes
+   are built on — cannot be deployed on the free plan.
+2. **Docker running locally** and Node.js ≥ 16.17, to build and push the
+   container image at deploy time.
+3. **An operator-deployed bridge Worker.** Bernstein does not host it and
+   cannot deploy it for you; it lives in your account and bills to it.
+
+---
+
+## Operator deploy steps
+
+```bash
+# 1. Scaffold the bridge Worker from the upstream template.
+npm create cloudflare -- sandbox-bridge --template=cloudflare/sandbox-sdk/bridge/worker
+cd sandbox-bridge
+
+# 2. Pin the SDK version this adapter implements against.
+npm install @cloudflare/sandbox@0.12.4
+
+# 3. Set the shared secret. THIS STEP IS NOT OPTIONAL - see the warning below.
+npx wrangler secret put SANDBOX_API_KEY
+
+# 4. Deploy.
+npx wrangler deploy
+```
+
+Then point Bernstein at it:
+
+```python
+from bernstein.adapters.codex_cloudflare import CodexCloudflareAdapter, CodexSandboxConfig
+
+adapter = CodexCloudflareAdapter(
+    CodexSandboxConfig(
+        bridge_url="https://sandbox-bridge.<your-subdomain>.workers.dev",
+        bridge_api_key="<the SANDBOX_API_KEY you just set>",
+        openai_api_key="<key the codex CLI needs inside the sandbox>",
+    ),
+)
+```
+
+### Instance type: the default is too small for a coding agent
+
+The upstream template ships `"instance_type": "lite"`, which is **1/16 vCPU,
+256 MiB RAM, 2 GB disk**. That is enough to run `echo`; it is not enough to run
+a coding agent that clones a repo, installs a toolchain, and runs a test suite.
+
+Set the instance type in your Worker's `wrangler.jsonc` before deploying:
+
+```jsonc
+{
+  "containers": [
+    {
+      "class_name": "Sandbox",
+      "image": "./Dockerfile",
+      "instance_type": "standard-3",  // 2 vCPU, 8 GiB RAM, 16 GB disk
+      "max_instances": 5              // raise if you run sandboxes concurrently
+    }
+  ]
+}
+```
+
+| Instance type | vCPU | Memory | Disk |
+|---|---|---|---|
+| `lite` (template default) | 1/16 | 256 MiB | 2 GB |
+| `basic` | 1/4 | 1 GiB | 4 GB |
+| `standard-1` | 1/2 | 4 GiB | 8 GB |
+| `standard-2` | 1 | 6 GiB | 12 GB |
+| `standard-3` | 2 | 8 GiB | 16 GB |
+| `standard-4` | 4 | 12 GiB | 20 GB |
+
+**`standard-3` or larger is the realistic floor for a coding agent.** Sizing is
+a deploy-time decision: the bridge exposes no per-request memory or CPU
+control, which is why the adapter has no such setting (see
+[retired settings](#settings-that-no-longer-exist)).
+
+The container image must also contain the `codex` CLI. Add it to the
+Dockerfile you deploy — the stock image does not include it.
+
+---
+
+## The authentication warning
+
+!!! danger "A bridge with no `SANDBOX_API_KEY` is open to the internet"
+    The bridge's auth checks are **conditional on the secret being set**. With
+    `SANDBOX_API_KEY` unset, both the `/v1/sandbox/*` middleware and the inline
+    check on `POST /v1/sandbox` pass every request through — anyone who finds
+    the URL can create containers, run commands, and read files, billed to your
+    account.
+
+    `CodexCloudflareAdapter.preflight()` therefore probes `POST /v1/sandbox`
+    with no `Authorization` header. If that call **succeeds**, preflight deletes
+    the sandbox it just created and raises
+    `CodexCloudflareBridgeAuthError` rather than using the deployment. Run
+    preflight before your first real run.
+
+Preflight also reads `GET /v1/openapi.json` and:
+
+- refuses a bridge whose API contract **major** differs from `1.0.0`
+  (`CodexCloudflareBridgeVersionError` — opt out with
+  `require_supported_api_version=False`);
+- refuses a bridge whose published `paths` are missing any route the adapter
+  drives (`CodexCloudflareBridgeContractError` — always strict).
+
+The route check is the one that matters in practice: `info.version` is the
+hand-maintained API contract version, **not** the npm package version, and it
+can stay at `1.0.0` while routes move underneath it. The package has already
+removed transports across releases.
+
+---
+
+## Cancellation
+
+Closing the `/exec` SSE stream **does not stop the remote process.** The
+container keeps running the command and keeps billing. Cancellation is the
+explicit `DELETE /v1/sandbox/:id`, which `CodexCloudflareAdapter.cancel()`
+issues; `execute()` also issues it from a `finally`, so a failed or cancelled
+run tears its sandbox down.
+
+`cancel()` deliberately does **not** confirm with
+`GET /v1/sandbox/:id/running`. That route sits behind the bridge's warm-pool
+middleware, which acquires — and if necessary **starts** — a container for the
+id before the handler runs `true` inside it. Probing it after a delete would
+report `running: true` on a perfectly healthy bridge *and* start a fresh
+billable container, undoing the cancellation. Teardown is confirmed against
+`GET /v1/pool/stats`, which reads pool state without allocating, and the result
+is returned on `CancelOutcome.pool_after`.
+
+`is_running()` and `get_status()` remain available for asking about a sandbox
+you intend to keep using — but they carry the same allocation caveat.
+
+---
+
+## Sandbox evidence
+
+A remote run lands the same signed evidence as a local one. `execute()` hashes
+the exact tar returned by `/persist` into a content address and records it on
+`CodexSandboxResult.evidence`:
+
+```python
+result = await adapter.execute(prompt, workspace_id, workspace_tar=seed)
+candidate = result.evidence.to_race_candidate("task-1", {"correctness": 1.0})
+# -> bernstein.core.sandbox.selection_receipt.RaceCandidate
+```
+
+The candidate carries `terminal_snapshot_digest` (SHA-256 of the workspace tar,
+re-hashable offline) and `isolation = "requested:codex-cloudflare"`, so it signs
+into a selection receipt alongside locally-produced candidates and a verifier
+can see *where* the task ran. The `requested:` prefix matches the convention in
+`bernstein.core.sandbox.fork_race`: the adapter asked a remote bridge to run the
+work, it did not boot or probe the isolation boundary, so it does not claim to
+attest the posture. What it does attest — the content-addressed digest — is
+verifiable without the network.
+
+---
+
+## Live verification
+
+If you have a Workers Paid account and a deployed bridge, this is the one
+command that exercises the full path — preflight, seed, stream, diff, evidence,
+and teardown — against your real deployment:
+
+```bash
+BRIDGE_URL="https://sandbox-bridge.<your-subdomain>.workers.dev" \
+BRIDGE_API_KEY="<your SANDBOX_API_KEY>" \
+uv run python - <<'PY'
+import asyncio, io, os, tarfile
+from bernstein.adapters.codex_cloudflare import CodexCloudflareAdapter, CodexSandboxConfig
+
+def seed() -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        data = b"before\n"
+        info = tarfile.TarInfo("./probe.txt"); info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+async def main() -> None:
+    adapter = CodexCloudflareAdapter(
+        CodexSandboxConfig(
+            bridge_url=os.environ["BRIDGE_URL"],
+            bridge_api_key=os.environ["BRIDGE_API_KEY"],
+            agent_command=("sh", "-c"),   # stand in for `codex` so no model key is needed
+        ),
+    )
+    print("preflight:", await adapter.preflight())
+    result = await adapter.execute(
+        "echo hello && echo after > /workspace/probe.txt",
+        "live-check",
+        model="ignored",
+        timeout_minutes=2,
+        workspace_tar=seed(),
+        on_output=lambda stream, chunk: print(f"[{stream}] {chunk.decode(errors='replace')}", end=""),
+    )
+    print("status:", result.status, "exit:", result.exit_code)
+    print("files_changed:", result.files_changed)
+    print("evidence:", result.evidence)
+    print("cancel:", await adapter.cancel(result.sandbox_id))
+
+asyncio.run(main())
+PY
+```
+
+Expected: preflight reports `auth_enforced=True` and `api_version='1.0.0'`;
+`status: completed exit: 0`; `files_changed: ['probe.txt']`; a 64-hex
+`terminal_snapshot_digest`; and a cancel outcome whose `pool_after.assigned`
+does not count the sandbox.
+
+`agent_command=("sh", "-c")` keeps the check independent of whether your image
+carries the `codex` CLI. With the real agent installed, drop that override and
+the adapter runs `codex exec --model <model> <prompt>`.
+
+!!! warning "This costs money"
+    The command starts a real container on your paid account. It tears it down
+    at the end, but a crashed run can leave one behind — check the Cloudflare
+    dashboard, or `DELETE /v1/sandbox/:id`, if you interrupt it.
+
+---
+
+## Limitations
+
+These are properties of the bridge, stated plainly rather than papered over.
+
+**No egress restriction.** The bridge applies none, and exposes no domain
+allowlist. Code running in the sandbox can reach the internet. If you need
+network containment, the sandbox is not where you get it.
+
+**Symlink escape caveat.** The bridge resolves request paths within
+`/workspace` and rejects traversal, but a *symlink created inside the
+workspace* can still name a path outside it, and the persist archive is built
+by `tar` from that tree. Bernstein never extracts the returned tar — it only
+reads member contents to compute the diff and the digest — so an escaping
+symlink cannot become a write on your host. Extract a persisted workspace
+yourself only with a tar reader you trust to refuse absolute and traversing
+member paths.
+
+**32 MiB payload cap.** Both `PUT /v1/sandbox/:id/file/*` and
+`POST /v1/sandbox/:id/hydrate` reject payloads over 32 MiB. The adapter checks
+locally first and raises `CodexCloudflarePayloadTooLargeError` with the size,
+rather than letting you discover it as an opaque rejection. Trim the seed with
+`persist_excludes`, or clone large inputs from inside the sandbox.
+
+**Sessions do not survive container sleep.** The adapter opens one session per
+run for `cwd` and environment. A container that sleeps mid-run loses it.
+
+**No remote log store.** Output exists only on the `/exec` SSE stream while the
+command runs. `get_logs()` returns the transcript this adapter buffered — it
+does not fetch anything back from Cloudflare.
+
+**Unconfigured means refused.** Without `bridge_url` and `bridge_api_key`,
+every method raises `CodexCloudflareNotConfiguredError`. The adapter never
+falls back to running the agent on the orchestrator host — if you want that,
+use the `codex` adapter deliberately.
+
+---
+
+## Configuration
+
+`CodexSandboxConfig` fields:
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `bridge_url` | `str` | `""` | Base URL of your deployed bridge Worker |
+| `bridge_api_key` | `str` | `""` | The Worker's `SANDBOX_API_KEY`, sent as Bearer |
+| `openai_api_key` | `str` | `""` | Key the agent CLI needs inside the sandbox |
+| `workdir` | `str` | `"/workspace"` | Workspace root inside the sandbox |
+| `agent_command` | `tuple[str, ...]` | `("codex", "exec")` | argv prefix; `--model` and the prompt are appended |
+| `extra_env` | `tuple[tuple[str, str], ...]` | `()` | Extra session environment pairs |
+| `max_execution_minutes` | `int` | `30` | Default run ceiling, sent as `timeout_ms` |
+| `request_timeout_seconds` | `float` | `60.0` | HTTP timeout for control-plane calls |
+| `persist_excludes` | `tuple[str, ...]` | `(".git",)` | Paths dropped from the persisted tar |
+| `require_supported_api_version` | `bool` | `True` | Refuse a different API contract major |
+
+The agent's API key travels on the **session**, not in argv: the bridge's
+`ExecRequest` schema is exactly `{argv, timeout_ms, cwd}` with no `env` field,
+and keeping the key out of argv also keeps it out of the sandbox process table
+and the shell command string the bridge assembles.
+
+### Settings that no longer exist
+
+Building against the real bridge retired settings it cannot honour. They are
+**absent**, not ignored, and `CodexSandboxConfig.from_mapping()` rejects each
+by name with the reason — so an old config produces an explanation rather than
+silent no-ops.
+
+| Retired setting | Why the bridge cannot honour it |
+|---|---|
+| `memory_mb`, `cpu_cores` | Container sizing is the deploy-time wrangler `instance_type` |
+| `network_access` | The bridge applies no egress restrictions and has no allowlist |
+| `sandbox_image` | The image is the deploy-time wrangler `image` |
+| `r2_bucket` | Bucket mounts need a deploy-time R2 binding; transfer uses hydrate/persist |
+| `cloudflare_account_id`, `cloudflare_api_token` | The bridge authenticates with its own secret |
+| `tokens_used` (result) | The bridge reports exit codes and output, never token counts |
+
+```python
+CodexSandboxConfig.from_mapping({"memory_mb": 1024})
+# CodexCloudflareConfigError: ... `memory_mb`: container memory is a deploy-time
+# wrangler setting (`containers[].instance_type`); it cannot be sized per request.
+```
+
+---
+
+## Errors
+
+| Error | Raised when |
+|---|---|
+| `CodexCloudflareNotConfiguredError` | No `bridge_url` / `bridge_api_key` |
+| `CodexCloudflareConfigError` | Retired or unknown config key |
+| `CodexCloudflareBridgeAuthError` | Bridge serves `/v1/sandbox` unauthenticated |
+| `CodexCloudflareBridgeVersionError` | Served API contract major differs |
+| `CodexCloudflareBridgeContractError` | A required route is missing from the OpenAPI document |
+| `CodexCloudflareBridgeApiError` | Any bridge route returned non-2xx |
+| `CodexCloudflarePayloadTooLargeError` | Upload over the 32 MiB cap |
+| `CodexCloudflareCancelError` | The delete that stops the container was refused |

--- a/docs/cloudflare/cloudflare-overview.md
+++ b/docs/cloudflare/cloudflare-overview.md
@@ -60,7 +60,7 @@ graph TD
 | Browser Rendering | `bernstein.bridges.browser_rendering` | Headless browsing, screenshots, scraping, PDF generation |
 | R2 Workspace Sync | `bernstein.bridges.r2_sync` | Content-addressed file sync between local and R2 |
 | Workers AI Provider | `bernstein.core.routing.cloudflare_ai` | Free-tier LLM completions for planning and decomposition |
-| Codex-on-Cloudflare Adapter | `bernstein.adapters.codex_cloudflare` | Experimental / non-functional — targets a nonexistent sandbox API (issue #2783) |
+| Codex-on-Cloudflare Adapter | `bernstein.adapters.codex_cloudflare` | Runs Codex in a sandbox container via an operator-deployed `@cloudflare/sandbox` bridge Worker; needs a Workers Paid plan |
 | D1 Analytics | `bernstein.core.cost.d1_analytics` | Usage metering, billing tiers, quota enforcement |
 | Vectorize Cache | `bernstein.core.memory.vectorize_cache` | Semantic cache for LLM responses using vector similarity |
 | MCP Remote Transport | `bernstein.mcp.remote_transport` | Streamable HTTP transport for remote MCP server access |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -259,6 +259,7 @@ nav:
           - Bridges: cloudflare/cloudflare-bridges.md
           - Browser Rendering: cloudflare/cloudflare-browser-rendering.md
           - Adapters: cloudflare/cloudflare-adapters.md
+          - Codex sandboxes: cloudflare/cloudflare-codex-sandbox.md
           - Workers AI: cloudflare/cloudflare-ai.md
           - MCP Remote: cloudflare/cloudflare-mcp.md
           - Analytics: cloudflare/cloudflare-analytics.md

--- a/src/bernstein/adapters/codex_cloudflare.py
+++ b/src/bernstein/adapters/codex_cloudflare.py
@@ -1,80 +1,1125 @@
-"""Codex adapter for Cloudflare Sandbox execution (experimental, non-functional).
+"""Codex adapter driving Cloudflare's first-party sandbox bridge (issue #2969).
 
-This adapter targeted ``https://api.cloudflare.com/client/v4/accounts/{id}/sandbox/...``,
-a REST route family that does not exist: an authenticated request returns HTTP
-400 with Cloudflare errors 7000/7003 ("No route for that URI"). Cloudflare's real
-sandbox/container product runs inside a Worker/Durable Object (the
-``@cloudflare/sandbox`` SDK), not a ``client/v4`` REST surface (issue #2783).
+The previous implementation refused every operation, and the refusal was
+correct at the time: it targeted
+``https://api.cloudflare.com/client/v4/accounts/{id}/sandbox/...``, a REST
+route family that has never existed, and the sandbox product was reachable
+only as a Worker binding - not callable from a Python process.
 
-Because the target API does not resolve to a route, no operation could ever
-populate a result. Rather than pretend, every public method refuses with an
-actionable error. A future implementation would drive a deployed worker (the
-pattern ``bernstein.bridges.cloudflare.CloudflareBridge`` already uses).
+That premise expired. ``@cloudflare/sandbox`` now ships a first-party HTTP
+bridge (``@cloudflare/sandbox/bridge``): a small Worker the operator deploys
+that exposes the sandbox as REST + SSE with Bearer auth. An external process
+can create a sandbox, seed a workspace, stream a command, collect a workspace
+tar, and destroy the container over plain HTTP. This module drives that
+bridge.
+
+Pinned contract
+---------------
+
+Implemented against ``@cloudflare/sandbox`` :data:`BRIDGE_SDK_VERSION`, whose
+bridge serves API contract :data:`BRIDGE_API_CONTRACT_VERSION` at
+``GET /v1/openapi.json``.
+
+Those two version lines are deliberately separate, and conflating them is a
+trap worth naming: the served document's ``info.version`` is the *API contract*
+version (``1.0.0`` - the schema is titled "Cloudflare Sandbox Service API"), not
+the npm package version. A healthy deployment of the pinned SDK reports
+``1.0.0``, so comparing ``info.version`` against the package version would
+refuse every real bridge. :meth:`CodexCloudflareAdapter.preflight` therefore
+checks the API contract major series, and separately validates that the served
+``paths`` still carry every route this adapter drives - a capability probe that
+stays honest even if the hand-maintained ``info.version`` goes stale while
+routes move underneath it.
+
+Three behaviours are load-bearing and deliberate:
+
+* **Cancellation issues the delete, and does not resurrect what it deleted.**
+  Closing the ``/exec`` SSE stream does not stop the container process - the
+  command keeps running and keeps billing. :meth:`CodexCloudflareAdapter.cancel`
+  issues ``DELETE /v1/sandbox/:id``, which the bridge routes through an
+  allocation-free pool lookup. It deliberately does **not** confirm with
+  ``GET /v1/sandbox/:id/running``: that route sits behind the warm-pool
+  middleware, which allocates (and will start) a container for the id before
+  answering, so a post-delete ``running`` probe both reports ``true`` on a
+  perfectly healthy bridge and creates a fresh billable container. Teardown is
+  confirmed instead against ``GET /v1/pool/stats``, which reads pool state
+  without allocating.
+
+* **Preflight refuses an unauthenticated bridge.** The bridge's auth checks are
+  conditional on its ``SANDBOX_API_KEY`` secret: with the secret unset both the
+  ``/v1/sandbox/*`` middleware and the inline check on ``POST /v1/sandbox`` pass
+  every request through. Preflight probes ``POST /v1/sandbox`` with no
+  ``Authorization`` header and refuses when the call succeeds - a world-writable
+  sandbox endpoint is a misconfigured deployment, not a usable one.
+
+* **The run lands sandbox evidence, not a gap.** ``POST /v1/sandbox/:id/persist``
+  returns the workspace as a tar; the adapter hashes those bytes into a content
+  address and records it on the result as :class:`SandboxEvidence`, which
+  converts to the same
+  :class:`~bernstein.core.sandbox.selection_receipt.RaceCandidate` a local
+  backend produces. Where a task ran is an attribute of the record - the
+  ``isolation`` field carries :data:`REMOTE_ISOLATION` - rather than a hole in
+  it.
+
+Configuration honesty
+---------------------
+
+Fields the bridge cannot honour are gone rather than accepted-and-ignored:
+per-request ``memory_mb`` / ``cpu_cores`` (container sizing is the deploy-time
+wrangler ``instance_type``), ``network_access`` (the bridge applies no egress
+restrictions), ``sandbox_image`` (deploy-time wrangler ``image``), ``r2_bucket``
+(bucket mounts need a deploy-time binding), and the account-scoped
+``cloudflare_account_id`` / ``cloudflare_api_token`` (the bridge authenticates
+with its own secret). Removing them is a breaking config change, so
+:meth:`CodexSandboxConfig.from_mapping` rejects each retired key by name with
+the reason and the replacement - an operator carrying an old config gets an
+explanation, not a silently ignored knob.
 """
 
 from __future__ import annotations
 
+import asyncio
+import base64
+import binascii
+import contextlib
+import hashlib
+import io
+import json
 import logging
+import tarfile
+import time
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
+    from bernstein.core.sandbox.selection_receipt import RaceCandidate
 
 logger = logging.getLogger(__name__)
 
-_UNAVAILABLE_MSG = (
-    "Codex-on-Cloudflare adapter is experimental and currently non-functional: "
-    "it targets a Cloudflare sandbox REST API "
-    "(client/v4/accounts/{id}/sandbox/...) that does not exist, so no operation "
-    "can run or return a result (issue #2783). Cloudflare's real sandbox product "
-    "runs inside a Worker/Durable Object; drive a deployed worker via "
-    "`bernstein.bridges.cloudflare.CloudflareBridge`, or run Codex locally with "
-    "the `codex` adapter."
+# ---------------------------------------------------------------------------
+# Pinned bridge contract
+# ---------------------------------------------------------------------------
+
+#: npm package that ships the bridge Worker the adapter talks to.
+BRIDGE_PACKAGE = "@cloudflare/sandbox"
+
+#: Exact package version this adapter was written and tested against. Recorded
+#: for operators and release notes; it is deliberately **not** compared against
+#: anything the bridge serves (see :data:`BRIDGE_API_CONTRACT_VERSION`).
+BRIDGE_SDK_VERSION = "0.12.4"
+
+#: ``info.version`` the pinned bridge publishes in ``GET /v1/openapi.json``.
+#: This is the API contract version, independent of the package version, and it
+#: is what preflight compares against.
+BRIDGE_API_CONTRACT_VERSION = "1.0.0"
+
+#: Route prefix every bridge endpoint lives under.
+BRIDGE_API_PREFIX = "/v1"
+
+#: Templated OpenAPI paths the adapter drives. Preflight requires all of them
+#: to be present in the served document, so a bridge that has moved or dropped
+#: a route is caught even when its ``info.version`` has not been bumped.
+REQUIRED_BRIDGE_PATHS: tuple[str, ...] = (
+    "/v1/sandbox",
+    "/v1/sandbox/{id}",
+    "/v1/sandbox/{id}/exec",
+    "/v1/sandbox/{id}/hydrate",
+    "/v1/sandbox/{id}/persist",
+    "/v1/sandbox/{id}/session",
+    "/v1/pool/stats",
 )
+
+#: Hard cap the bridge enforces on ``PUT /file/*`` and ``POST /hydrate``
+#: payloads. Exceeding it is rejected locally so the operator gets a sized
+#: error instead of an opaque bridge rejection.
+BRIDGE_MAX_PAYLOAD_BYTES = 32 * 1024 * 1024
+
+#: Value recorded in the ``isolation`` field of the sandbox evidence.
+#:
+#: Prefixed ``requested:`` for the same reason
+#: :mod:`bernstein.core.sandbox.fork_race` does it: the adapter asks a remote
+#: bridge to run the work, it does not boot or probe the isolation boundary,
+#: so it cannot attest the posture was in effect. The genuinely verified part
+#: is the content-addressed terminal digest, which is re-hashable offline.
+REMOTE_ISOLATION = "requested:codex-cloudflare"
+
+#: Default workspace root inside the sandbox. Bridge path containment rejects
+#: anything that resolves outside it.
+DEFAULT_WORKDIR = "/workspace"
+
+#: Config keys the real bridge surface cannot honour, mapped to the reason and
+#: the replacement. Consumed by :meth:`CodexSandboxConfig.from_mapping`.
+RETIRED_CONFIG_FIELDS: dict[str, str] = {
+    "cloudflare_account_id": (
+        "the bridge authenticates with its own SANDBOX_API_KEY secret, not an "
+        "account-scoped credential; set `bridge_url` and `bridge_api_key` instead"
+    ),
+    "cloudflare_api_token": (
+        "the bridge authenticates with its own SANDBOX_API_KEY secret, not a "
+        "Cloudflare API token; set `bridge_api_key` instead"
+    ),
+    "sandbox_image": (
+        "the container image is a deploy-time wrangler setting on the bridge "
+        "Worker (`containers[].image`); it cannot be chosen per request"
+    ),
+    "memory_mb": (
+        "container memory is a deploy-time wrangler setting "
+        "(`containers[].instance_type`); it cannot be sized per request"
+    ),
+    "cpu_cores": (
+        "container vCPU is a deploy-time wrangler setting "
+        "(`containers[].instance_type`); it cannot be sized per request"
+    ),
+    "network_access": (
+        "the bridge applies no egress restrictions and exposes no domain "
+        "allowlist, so this could only ever have been ignored"
+    ),
+    "r2_bucket": (
+        "bucket mounts require a deploy-time R2 binding on the bridge Worker; "
+        "workspace transfer here uses hydrate/persist instead"
+    ),
+    "tokens_used": "the bridge reports process exit codes and output, never token counts",
+}
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class CodexCloudflareError(RuntimeError):
+    """Base class for every Codex-on-Cloudflare failure."""
+
+
+class CodexCloudflareNotConfiguredError(CodexCloudflareError):
+    """Raised when no bridge deployment has been configured.
+
+    The adapter never falls back to local execution: an unconfigured remote
+    sandbox is a refusal, because silently running the agent on the
+    orchestrator host would discard the isolation the caller asked for.
+    """
+
+    def __init__(self, missing: tuple[str, ...]) -> None:
+        self.missing = missing
+        names = ", ".join(missing)
+        super().__init__(
+            "Codex-on-Cloudflare adapter is not configured: missing "
+            f"{names}. Deploy the {BRIDGE_PACKAGE} bridge Worker "
+            f"(pinned {BRIDGE_SDK_VERSION}), then set `bridge_url` to its URL "
+            "and `bridge_api_key` to its SANDBOX_API_KEY secret. This adapter "
+            "does not fall back to local execution - use the `codex` adapter "
+            "to run Codex on this host on purpose.",
+        )
+
+
+class CodexCloudflareConfigError(CodexCloudflareError):
+    """Raised when a config mapping carries a key the bridge cannot honour."""
+
+
+class CodexCloudflareBridgeAuthError(CodexCloudflareError):
+    """Raised when the bridge serves ``/v1/sandbox`` without authentication.
+
+    The bridge's auth checks only run when its ``SANDBOX_API_KEY`` secret is
+    set; with the secret unset it passes every request through. A bridge in
+    that state hands any caller a container on the operator's account, so the
+    adapter refuses rather than using it.
+    """
+
+    def __init__(self, bridge_url: str) -> None:
+        self.bridge_url = bridge_url
+        super().__init__(
+            f"Cloudflare sandbox bridge at {bridge_url} accepted POST "
+            f"{BRIDGE_API_PREFIX}/sandbox with no Authorization header: its "
+            "SANDBOX_API_KEY secret is unset, so it skips authentication and "
+            "will create containers for any caller. Refusing to use it. Set "
+            "the secret on the Worker (`npx wrangler secret put "
+            "SANDBOX_API_KEY`), redeploy, and put the same value in "
+            "`bridge_api_key`.",
+        )
+
+
+class CodexCloudflareBridgeVersionError(CodexCloudflareError):
+    """Raised when the bridge serves an unsupported API contract version."""
+
+    def __init__(self, observed: str, bridge_url: str) -> None:
+        self.observed = observed
+        self.bridge_url = bridge_url
+        seen = observed or "<absent>"
+        super().__init__(
+            f"Cloudflare sandbox bridge at {bridge_url} serves API contract "
+            f"version {seen}; this adapter implements the "
+            f"{BRIDGE_API_CONTRACT_VERSION} contract (as published by "
+            f"{BRIDGE_PACKAGE}@{BRIDGE_SDK_VERSION}). A different major "
+            "contract changes route semantics, so it is not safe to drive "
+            "blindly. Redeploy the bridge from "
+            f"{BRIDGE_PACKAGE}@{BRIDGE_SDK_VERSION}, or set "
+            "`require_supported_api_version=False` to accept the drift "
+            "deliberately - the route probe stays strict either way.",
+        )
+
+
+class CodexCloudflareBridgeContractError(CodexCloudflareError):
+    """Raised when the served OpenAPI document is missing routes the adapter needs."""
+
+    def __init__(self, missing: tuple[str, ...], bridge_url: str) -> None:
+        self.missing = missing
+        self.bridge_url = bridge_url
+        names = ", ".join(missing)
+        super().__init__(
+            f"Cloudflare sandbox bridge at {bridge_url} does not publish "
+            f"route(s) this adapter drives: {names}. The {BRIDGE_PACKAGE} "
+            "package moves and removes routes across releases, so a bridge "
+            "missing them cannot complete a run. Redeploy the bridge from "
+            f"{BRIDGE_PACKAGE}@{BRIDGE_SDK_VERSION}.",
+        )
+
+
+class CodexCloudflareBridgeApiError(CodexCloudflareError):
+    """Raised when a bridge route returns a non-2xx response."""
+
+    def __init__(self, route: str, status_code: int, body: str) -> None:
+        self.route = route
+        self.status_code = status_code
+        self.body = body
+        super().__init__(
+            f"Cloudflare sandbox bridge returned HTTP {status_code} for {route}: {body[:1024]}",
+        )
+
+
+class CodexCloudflarePayloadTooLargeError(CodexCloudflareError):
+    """Raised before upload when a payload exceeds the bridge's 32 MiB cap."""
+
+    def __init__(self, route: str, size_bytes: int) -> None:
+        self.route = route
+        self.size_bytes = size_bytes
+        super().__init__(
+            f"Payload for {route} is {size_bytes} bytes, over the bridge's "
+            f"{BRIDGE_MAX_PAYLOAD_BYTES}-byte cap. Trim the workspace (the "
+            "`persist_excludes` setting drops paths from the returned tar) or "
+            "seed large inputs by cloning them inside the sandbox instead.",
+        )
+
+
+class CodexCloudflareCancelError(CodexCloudflareError):
+    """Raised when the delete that stops the remote container did not land."""
+
+    def __init__(self, sandbox_id: str, detail: str) -> None:
+        self.sandbox_id = sandbox_id
+        self.detail = detail
+        super().__init__(
+            f"Could not stop Cloudflare sandbox {sandbox_id}: "
+            f"DELETE {BRIDGE_API_PREFIX}/sandbox/{sandbox_id} failed ({detail}). "
+            "The remote command may still be running and billing; retry the "
+            "delete, then check the bridge Worker logs and the Cloudflare "
+            "dashboard.",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
 
 
 @dataclass(frozen=True)
 class CodexSandboxConfig:
-    """Configuration for Codex on Cloudflare sandbox."""
+    """Configuration for Codex execution on a deployed sandbox bridge.
 
-    cloudflare_account_id: str = ""
-    cloudflare_api_token: str = ""
+    Every field here maps to something the bridge actually honours. Knobs the
+    bridge cannot implement are listed in :data:`RETIRED_CONFIG_FIELDS` and
+    rejected by :meth:`from_mapping`.
+
+    Attributes:
+        bridge_url: Base URL of the operator-deployed bridge Worker, e.g.
+            ``https://sandbox-bridge.example.workers.dev``. The ``/v1``
+            prefix is appended by the adapter.
+        bridge_api_key: The Worker's ``SANDBOX_API_KEY`` secret, sent as
+            ``Authorization: Bearer``.
+        openai_api_key: API key the Codex CLI needs *inside* the sandbox.
+            Injected as session environment, never as an argv element.
+        workdir: Workspace root inside the sandbox. The bridge rejects paths
+            resolving outside ``/workspace``.
+        agent_command: argv prefix for the coding agent inside the sandbox.
+            The model flag and the prompt are appended.
+        extra_env: Additional environment pairs for the sandbox session.
+            Tuple-of-pairs so the config stays frozen and hashable.
+        max_execution_minutes: Default wall-clock ceiling for one run,
+            forwarded as the bridge's ``timeout_ms``.
+        request_timeout_seconds: Per-request HTTP timeout for the short
+            control-plane calls (create, persist, delete). The ``/exec``
+            stream gets ``max_execution_minutes`` plus this as headroom.
+        persist_excludes: Relative paths dropped from the persisted workspace
+            tar, forwarded as the ``excludes`` query parameter. The bridge
+            rejects excludes containing ``..``.
+        require_supported_api_version: When true (default) preflight refuses a
+            bridge whose served API contract major differs from
+            :data:`BRIDGE_API_CONTRACT_VERSION`. The route probe is
+            unconditional either way.
+    """
+
+    bridge_url: str = ""
+    bridge_api_key: str = ""
     openai_api_key: str = ""
-    sandbox_image: str = "codex-sandbox:latest"
+    workdir: str = DEFAULT_WORKDIR
+    agent_command: tuple[str, ...] = ("codex", "exec")
+    extra_env: tuple[tuple[str, str], ...] = ()
     max_execution_minutes: int = 30
-    memory_mb: int = 512
-    cpu_cores: float = 1.0
-    network_access: str = "restricted"
-    r2_bucket: str = "bernstein-workspaces"
+    request_timeout_seconds: float = 60.0
+    persist_excludes: tuple[str, ...] = (".git",)
+    require_supported_api_version: bool = True
+
+    @property
+    def is_configured(self) -> bool:
+        """True when both the bridge URL and its API key are present."""
+        return not self.missing_fields()
+
+    def missing_fields(self) -> tuple[str, ...]:
+        """Names of the required fields that are empty."""
+        missing: list[str] = []
+        if not self.bridge_url.strip():
+            missing.append("bridge_url")
+        if not self.bridge_api_key.strip():
+            missing.append("bridge_api_key")
+        return tuple(missing)
+
+    @classmethod
+    def from_mapping(cls, values: Mapping[str, Any]) -> CodexSandboxConfig:
+        """Build a config from a mapping, refusing keys the bridge cannot honour.
+
+        This is the construction path for operator-supplied config. A key the
+        bridge has no way to implement is rejected by name with the reason and
+        the replacement, so an operator carrying a pre-bridge config learns why
+        the knob is gone instead of watching it be ignored.
+
+        Args:
+            values: Mapping of config field names to values.
+
+        Returns:
+            The constructed :class:`CodexSandboxConfig`.
+
+        Raises:
+            CodexCloudflareConfigError: If any key is retired or unknown.
+        """
+        retired = [key for key in values if key in RETIRED_CONFIG_FIELDS]
+        if retired:
+            reasons = "; ".join(f"`{key}`: {RETIRED_CONFIG_FIELDS[key]}" for key in sorted(retired))
+            raise CodexCloudflareConfigError(
+                "Codex-on-Cloudflare config carries settings the deployed "
+                f"bridge cannot honour, so they are refused rather than ignored - {reasons}.",
+            )
+        known = set(cls.__dataclass_fields__)
+        unknown = sorted(set(values) - known)
+        if unknown:
+            raise CodexCloudflareConfigError(
+                f"Unknown Codex-on-Cloudflare config key(s): {', '.join(unknown)}. "
+                f"Known keys: {', '.join(sorted(known))}.",
+            )
+        payload = dict(values)
+        for tuple_field in ("agent_command", "persist_excludes"):
+            if tuple_field in payload:
+                payload[tuple_field] = tuple(payload[tuple_field])
+        if "extra_env" in payload:
+            raw_env = payload["extra_env"]
+            pairs = raw_env.items() if isinstance(raw_env, dict) else raw_env
+            payload["extra_env"] = tuple((str(k), str(v)) for k, v in pairs)
+        return cls(**payload)
+
+
+# ---------------------------------------------------------------------------
+# Results and evidence
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SandboxEvidence:
+    """Content-addressed evidence that a remote run produced a workspace.
+
+    A remote sandbox must not be a weaker link in the chain than a local one.
+    The local sandbox path records a candidate's terminal workspace as a CAS
+    digest a verifier re-hashes offline; this is that same record for a
+    bridge-executed run. The digest is the SHA-256 of the exact tar bytes the
+    bridge returned from ``POST /v1/sandbox/:id/persist``, so a verifier
+    holding the blob re-derives it without reaching the network - and
+    ``isolation`` names where the work ran.
+
+    Attributes:
+        terminal_snapshot_digest: SHA-256 hex digest of the persisted
+            workspace tar, in the same 64-lowercase-hex shape the CAS verifier
+            expects.
+        isolation: :data:`REMOTE_ISOLATION`.
+        sandbox_id: Bridge-assigned sandbox identifier the run used.
+        bridge_api_version: API contract version observed at preflight, or the
+            pinned contract version when preflight was skipped.
+        bridge_sdk_version: Package version the adapter implements against.
+        workspace_bytes: Size of the persisted tar in bytes.
+    """
+
+    terminal_snapshot_digest: str
+    isolation: str = REMOTE_ISOLATION
+    sandbox_id: str = ""
+    bridge_api_version: str = BRIDGE_API_CONTRACT_VERSION
+    bridge_sdk_version: str = BRIDGE_SDK_VERSION
+    workspace_bytes: int = 0
+
+    def to_race_candidate(self, task_id: str, score_vector: Mapping[str, float]) -> RaceCandidate:
+        """Project the evidence onto the signed selection-receipt candidate shape.
+
+        Args:
+            task_id: Stable candidate identifier.
+            score_vector: Deterministic per-axis scores for the ranker.
+
+        Returns:
+            A :class:`~bernstein.core.sandbox.selection_receipt.RaceCandidate`
+            carrying this run's terminal digest and isolation tier, ready to be
+            signed into a selection receipt alongside locally-produced
+            candidates.
+        """
+        # Imported here rather than at module scope: the receipt module pulls
+        # in `cryptography`, and importing an adapter should not pay for
+        # signing machinery the caller may never use.
+        from bernstein.core.sandbox.selection_receipt import RaceCandidate
+
+        return RaceCandidate(
+            task_id=task_id,
+            terminal_snapshot_digest=self.terminal_snapshot_digest,
+            score_vector=dict(score_vector),
+            isolation=self.isolation,
+        )
 
 
 @dataclass(frozen=True)
 class CodexSandboxResult:
-    """Result from a Codex sandbox execution."""
+    """Result of one Codex run on the bridge.
+
+    Attributes:
+        sandbox_id: Bridge-assigned sandbox identifier.
+        status: ``"completed"``, ``"failed"``, or ``"timeout"``.
+        files_changed: Workspace-relative paths whose content differs from the
+            seeded workspace (or that are new/removed), derived by diffing the
+            seeded tar against the persisted one.
+        stdout: Decoded stdout, reassembled from the base64 SSE frames.
+        stderr: Decoded stderr, reassembled from the base64 SSE frames.
+        exit_code: Process exit code from the terminal ``exit`` event.
+        execution_time_seconds: Wall-clock duration of the exec stream.
+        workspace_tar: Raw tar bytes returned by ``/persist``.
+        evidence: Content-addressed sandbox evidence for the run.
+        error: Message from a terminal ``error`` SSE event, empty otherwise.
+    """
 
     sandbox_id: str
-    status: str  # "completed", "failed", "timeout", "cancelled"
-    files_changed: list[str] = field(default_factory=list)
+    status: str
+    files_changed: list[str] = field(default_factory=list[str])
     stdout: str = ""
     stderr: str = ""
     exit_code: int = 0
     execution_time_seconds: float = 0.0
-    tokens_used: int = 0
+    workspace_tar: bytes | None = None
+    evidence: SandboxEvidence | None = None
+    error: str = ""
+
+
+@dataclass(frozen=True)
+class WarmPoolStats:
+    """Allocation-free snapshot of the bridge's warm-pool state.
+
+    Read from ``GET /v1/pool/stats``, which reports pool bookkeeping without
+    acquiring or starting a container - unlike the per-sandbox routes.
+
+    Attributes:
+        warm: Pre-warmed containers not yet assigned to a sandbox id.
+        assigned: Containers currently assigned to a sandbox id.
+        total: ``warm + assigned``.
+    """
+
+    warm: int = 0
+    assigned: int = 0
+    total: int = 0
+
+
+@dataclass(frozen=True)
+class CancelOutcome:
+    """Result of :meth:`CodexCloudflareAdapter.cancel`.
+
+    Attributes:
+        sandbox_id: The sandbox that was deleted.
+        deleted: ``True`` when the bridge accepted the delete.
+        pool_after: Warm-pool state read after the delete, without allocating.
+    """
+
+    sandbox_id: str
+    deleted: bool
+    pool_after: WarmPoolStats
+
+
+@dataclass(frozen=True)
+class BridgePreflight:
+    """Outcome of :meth:`CodexCloudflareAdapter.preflight`.
+
+    Attributes:
+        bridge_url: Base URL that was probed.
+        api_version: ``info.version`` from the served OpenAPI document - the
+            API contract version, not the npm package version.
+        auth_enforced: Always ``True`` when preflight returns - an
+            unauthenticated bridge raises instead of reporting ``False``.
+        api_version_supported: ``True`` when ``api_version`` shares a major
+            with :data:`BRIDGE_API_CONTRACT_VERSION`.
+        routes_verified: The :data:`REQUIRED_BRIDGE_PATHS` found in the served
+            document.
+    """
+
+    bridge_url: str
+    api_version: str
+    auth_enforced: bool
+    api_version_supported: bool
+    routes_verified: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _ExecOutcome:
+    """Folded result of one ``/exec`` SSE stream."""
+
+    status: str
+    exit_code: int
+    stdout: bytes
+    stderr: bytes
+    error: str
+
+
+# ---------------------------------------------------------------------------
+# SSE framing
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _SseFrame:
+    """One parsed ``event:``/``data:`` frame from an SSE stream."""
+
+    event: str
+    data: str
+
+
+def _parse_sse_frames(lines: list[str]) -> list[_SseFrame]:
+    """Parse SSE body lines into frames.
+
+    The bridge emits one ``event:`` line followed by one or more ``data:``
+    lines, terminated by a blank line; its writer splits a multi-line payload
+    across ``data:`` lines, and they are rejoined here with newlines.
+
+    Args:
+        lines: Lines of the SSE body, without trailing newlines.
+
+    Returns:
+        The frames in arrival order.
+    """
+    frames: list[_SseFrame] = []
+    event = ""
+    data: list[str] = []
+    for raw in lines:
+        line = raw.rstrip("\r")
+        if not line:
+            if event or data:
+                frames.append(_SseFrame(event=event or "message", data="\n".join(data)))
+            event = ""
+            data = []
+            continue
+        if line.startswith(":"):
+            continue
+        if line.startswith("event:"):
+            event = line[len("event:") :].strip()
+        elif line.startswith("data:"):
+            data.append(line[len("data:") :].removeprefix(" "))
+    if event or data:
+        frames.append(_SseFrame(event=event or "message", data="\n".join(data)))
+    return frames
+
+
+def _decode_stream_payload(payload: str) -> bytes:
+    """Decode a base64 ``stdout``/``stderr`` SSE payload.
+
+    Args:
+        payload: The frame's ``data`` value.
+
+    Returns:
+        The decoded bytes, or the payload's UTF-8 bytes when it is not valid
+        base64 - a malformed frame must not silently lose operator output.
+    """
+    compact = "".join(payload.split())
+    if not compact:
+        return b""
+    try:
+        return base64.b64decode(compact, validate=True)
+    except (binascii.Error, ValueError):
+        logger.warning("Cloudflare bridge emitted a non-base64 output frame; passing it through verbatim")
+        return payload.encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Workspace diffing
+# ---------------------------------------------------------------------------
+
+
+def _tar_index(tar_bytes: bytes) -> dict[str, str]:
+    """Map each regular file in a tar to the SHA-256 of its content.
+
+    The bridge builds the persist archive with ``tar cf ... -C /workspace .``,
+    so members arrive as ``./path``; the leading ``./`` is normalised away.
+    Members are only *read*, never extracted, so the sandbox's symlink caveat
+    (a symlink inside the workspace can name a path outside it) cannot turn a
+    diff into a host write.
+
+    Args:
+        tar_bytes: Raw tar archive bytes.
+
+    Returns:
+        Mapping of normalised member path to content digest. Non-regular
+        members (directories, symlinks, devices) are skipped.
+    """
+    index: dict[str, str] = {}
+    try:
+        with tarfile.open(fileobj=io.BytesIO(tar_bytes), mode="r:*") as archive:
+            for member in archive:
+                if not member.isfile():
+                    continue
+                handle = archive.extractfile(member)
+                if handle is None:
+                    continue
+                name = member.name.removeprefix("./").lstrip("/")
+                index[name] = hashlib.sha256(handle.read()).hexdigest()
+    except (tarfile.TarError, OSError) as exc:
+        logger.warning("Could not index workspace tar for diffing: %s", exc)
+        return {}
+    return index
+
+
+def _diff_paths(before: Mapping[str, str], after: Mapping[str, str]) -> list[str]:
+    """Return sorted paths that were added, removed, or modified."""
+    changed = {path for path, digest in after.items() if before.get(path) != digest}
+    changed |= set(before) - set(after)
+    return sorted(changed)
+
+
+# ---------------------------------------------------------------------------
+# Adapter
+# ---------------------------------------------------------------------------
 
 
 class CodexCloudflareAdapter:
-    """Experimental Codex-on-Cloudflare adapter that refuses every operation.
+    """Runs Codex inside a Cloudflare sandbox via the deployed HTTP bridge.
 
-    The adapter's target REST API does not exist, so it cannot create a sandbox,
-    inject a command, poll status, or collect results. Every public method raises
-    a clear ``RuntimeError`` instead of issuing a request that Cloudflare cannot
-    route (issue #2783).
+    Args:
+        config: Bridge connection and run settings.
+        transport: Optional :class:`httpx.AsyncBaseTransport` used for every
+            request. Tests inject an :class:`httpx.MockTransport` carrying
+            recorded bridge responses; production leaves it ``None``.
     """
 
-    def __init__(self, config: CodexSandboxConfig) -> None:
+    def __init__(
+        self,
+        config: CodexSandboxConfig,
+        *,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
         self._config = config
+        self._transport = transport
+        self._api_version = BRIDGE_API_CONTRACT_VERSION
+        self._transcripts: dict[str, str] = {}
 
     @property
     def name(self) -> str:
         """Return adapter name."""
         return "codex-cloudflare"
+
+    @property
+    def config(self) -> CodexSandboxConfig:
+        """The configuration this adapter was constructed with."""
+        return self._config
+
+    @property
+    def is_configured(self) -> bool:
+        """True when a bridge URL and API key are present."""
+        return self._config.is_configured
+
+    # -- HTTP plumbing ------------------------------------------------------
+
+    def _require_configured(self) -> None:
+        """Raise when no bridge is configured.
+
+        Raises:
+            CodexCloudflareNotConfiguredError: If the bridge URL or API key is
+                missing. Never degrades to local execution.
+        """
+        missing = self._config.missing_fields()
+        if missing:
+            raise CodexCloudflareNotConfiguredError(missing)
+
+    def _base_url(self) -> str:
+        return self._config.bridge_url.rstrip("/")
+
+    def _client(self, *, timeout: float | None = None) -> httpx.AsyncClient:
+        """Build a client with no default Authorization header.
+
+        Auth is passed per request so :meth:`preflight` can issue one
+        deliberately unauthenticated call without fighting client defaults.
+        """
+        return httpx.AsyncClient(
+            base_url=self._base_url(),
+            timeout=timeout if timeout is not None else self._config.request_timeout_seconds,
+            transport=self._transport,
+        )
+
+    def _auth_headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self._config.bridge_api_key}"}
+
+    @staticmethod
+    def _check(route: str, response: httpx.Response) -> None:
+        """Raise :class:`CodexCloudflareBridgeApiError` for a non-2xx response."""
+        if response.status_code < 400:
+            return
+        body = ""
+        with contextlib.suppress(httpx.HTTPError, UnicodeDecodeError, RuntimeError):
+            body = response.text
+        raise CodexCloudflareBridgeApiError(route, response.status_code, body)
+
+    # -- Preflight ----------------------------------------------------------
+
+    async def preflight(self) -> BridgePreflight:
+        """Verify the bridge is authenticated and serving the expected contract.
+
+        Three checks, each with its own error:
+
+        1. ``POST /v1/sandbox`` is issued **without** an ``Authorization``
+           header. The bridge only authenticates when its ``SANDBOX_API_KEY``
+           secret is set, so a success here proves the secret is unset and the
+           deployment is world-writable; the probe deletes any sandbox it
+           accidentally created, then refuses. The create route carries no
+           sandbox-id path segment, so this probe cannot be short-circuited by
+           the bridge's id-format validation (which runs before the auth check
+           on ``/v1/sandbox/:id/*``).
+        2. ``GET /v1/openapi.json`` is read with auth and its ``info.version``
+           - the API *contract* version, not the npm package version -
+           compared against :data:`BRIDGE_API_CONTRACT_VERSION` by major.
+        3. Every path in :data:`REQUIRED_BRIDGE_PATHS` must be present in the
+           served document. This is the check that actually protects against
+           the package's route churn: ``info.version`` is hand-maintained and
+           can lag, the published paths cannot.
+
+        Returns:
+            The :class:`BridgePreflight` record for the deployment.
+
+        Raises:
+            CodexCloudflareNotConfiguredError: If no bridge is configured.
+            CodexCloudflareBridgeAuthError: If the bridge answers
+                ``/v1/sandbox`` without authentication.
+            CodexCloudflareBridgeVersionError: If the served contract major
+                differs and drift was not opted into.
+            CodexCloudflareBridgeContractError: If a required route is absent.
+            CodexCloudflareBridgeApiError: If a probe fails for another reason.
+        """
+        self._require_configured()
+        async with self._client() as client:
+            await self._assert_auth_enforced(client)
+            document = await self._read_openapi_document(client)
+
+        version = _document_api_version(document)
+        supported = _same_major_series(version, BRIDGE_API_CONTRACT_VERSION)
+        if not supported and self._config.require_supported_api_version:
+            raise CodexCloudflareBridgeVersionError(version, self._base_url())
+        if not supported:
+            logger.warning(
+                "Cloudflare sandbox bridge at %s serves API contract %s, not the expected %s; "
+                "proceeding because require_supported_api_version is disabled",
+                self._base_url(),
+                version or "<absent>",
+                BRIDGE_API_CONTRACT_VERSION,
+            )
+
+        published = _document_paths(document)
+        missing = tuple(path for path in REQUIRED_BRIDGE_PATHS if path not in published)
+        if missing:
+            raise CodexCloudflareBridgeContractError(missing, self._base_url())
+
+        self._api_version = version or BRIDGE_API_CONTRACT_VERSION
+        return BridgePreflight(
+            bridge_url=self._base_url(),
+            api_version=self._api_version,
+            auth_enforced=True,
+            api_version_supported=supported,
+            routes_verified=REQUIRED_BRIDGE_PATHS,
+        )
+
+    async def _assert_auth_enforced(self, client: httpx.AsyncClient) -> None:
+        """Refuse a bridge that creates sandboxes for unauthenticated callers."""
+        route = f"{BRIDGE_API_PREFIX}/sandbox"
+        response = await client.post(route)
+        if response.status_code in (401, 403):
+            return
+        if response.status_code < 400:
+            # The bridge just handed an anonymous caller a container. Clean it
+            # up before refusing so the probe does not leak a billable sandbox.
+            leaked = _json_str_field(response, "id")
+            if leaked:
+                with contextlib.suppress(httpx.HTTPError):
+                    await client.delete(f"{route}/{leaked}")
+            raise CodexCloudflareBridgeAuthError(self._base_url())
+        self._check(f"POST {route} (unauthenticated auth probe)", response)
+
+    async def _read_openapi_document(self, client: httpx.AsyncClient) -> dict[str, Any]:
+        """Fetch and parse the bridge's served OpenAPI document."""
+        route = f"{BRIDGE_API_PREFIX}/openapi.json"
+        response = await client.get(route, headers=self._auth_headers())
+        self._check(f"GET {route}", response)
+        try:
+            document: Any = response.json()
+        except ValueError as exc:
+            raise CodexCloudflareBridgeContractError(REQUIRED_BRIDGE_PATHS, self._base_url()) from exc
+        if not isinstance(document, dict):
+            raise CodexCloudflareBridgeContractError(REQUIRED_BRIDGE_PATHS, self._base_url())
+        return document
+
+    # -- Lifecycle ----------------------------------------------------------
+
+    async def create_sandbox(self) -> str:
+        """Create a sandbox and return its bridge-assigned id.
+
+        Returns:
+            The sandbox identifier.
+
+        Raises:
+            CodexCloudflareNotConfiguredError: If no bridge is configured.
+            CodexCloudflareBridgeApiError: If the bridge refuses the create.
+        """
+        self._require_configured()
+        async with self._client() as client:
+            return await self._create_sandbox(client)
+
+    async def _create_sandbox(self, client: httpx.AsyncClient) -> str:
+        route = f"{BRIDGE_API_PREFIX}/sandbox"
+        response = await client.post(route, headers=self._auth_headers())
+        self._check(f"POST {route}", response)
+        sandbox_id = _json_str_field(response, "id")
+        if not sandbox_id:
+            raise CodexCloudflareBridgeApiError(f"POST {route}", response.status_code, response.text)
+        return sandbox_id
+
+    async def is_running(self, sandbox_id: str) -> bool:
+        """Return the bridge's ``running`` verdict for *sandbox_id*.
+
+        **This call can start a container.** ``GET /v1/sandbox/:id/running``
+        sits behind the bridge's warm-pool middleware, which acquires - and if
+        necessary *starts* - a container for the id before the handler runs
+        ``true`` inside it. On a bridge with no container for this id the
+        answer is therefore ``True``, produced by the container the probe just
+        created.
+
+        Do not use this to confirm a teardown: see :meth:`cancel`, which reads
+        ``GET /v1/pool/stats`` instead because that route does not allocate.
+        This method is for asking whether a sandbox you intend to keep using is
+        up.
+
+        Args:
+            sandbox_id: The sandbox identifier.
+
+        Returns:
+            ``True`` when a container for the id is up (possibly because this
+            call started one), ``False`` otherwise.
+
+        Raises:
+            CodexCloudflareNotConfiguredError: If no bridge is configured.
+        """
+        self._require_configured()
+        async with self._client() as client:
+            return await self._is_running(client, sandbox_id)
+
+    async def _is_running(self, client: httpx.AsyncClient, sandbox_id: str) -> bool:
+        route = f"{BRIDGE_API_PREFIX}/sandbox/{sandbox_id}/running"
+        response = await client.get(route, headers=self._auth_headers())
+        self._check(f"GET {route}", response)
+        try:
+            payload: Any = response.json()
+        except ValueError:
+            return False
+        return bool(payload.get("running", False)) if isinstance(payload, dict) else False
+
+    async def get_status(self, sandbox_id: str) -> str:
+        """Return ``"running"`` or ``"stopped"`` for *sandbox_id*.
+
+        Carries the same allocation caveat as :meth:`is_running`.
+
+        Args:
+            sandbox_id: The sandbox identifier.
+
+        Returns:
+            ``"running"`` when a container for the id is up, else ``"stopped"``.
+        """
+        return "running" if await self.is_running(sandbox_id) else "stopped"
+
+    async def pool_stats(self) -> WarmPoolStats:
+        """Read the bridge's warm-pool bookkeeping without allocating.
+
+        Returns:
+            The current :class:`WarmPoolStats`.
+
+        Raises:
+            CodexCloudflareNotConfiguredError: If no bridge is configured.
+        """
+        self._require_configured()
+        async with self._client() as client:
+            return await self._pool_stats(client)
+
+    async def _pool_stats(self, client: httpx.AsyncClient) -> WarmPoolStats:
+        route = f"{BRIDGE_API_PREFIX}/pool/stats"
+        response = await client.get(route, headers=self._auth_headers())
+        self._check(f"GET {route}", response)
+        try:
+            payload: Any = response.json()
+        except ValueError:
+            return WarmPoolStats()
+        if not isinstance(payload, dict):
+            return WarmPoolStats()
+        return WarmPoolStats(
+            warm=_as_int(payload.get("warm")),
+            assigned=_as_int(payload.get("assigned")),
+            total=_as_int(payload.get("total")),
+        )
+
+    async def cancel(self, sandbox_id: str) -> CancelOutcome:
+        """Stop the remote work, and confirm teardown without restarting it.
+
+        Closing the ``/exec`` SSE stream does not stop the container process -
+        the command keeps running on the operator's account. Cancellation is
+        therefore the explicit ``DELETE /v1/sandbox/:id``, which the bridge
+        serves through an allocation-free pool lookup (it returns 204 outright
+        when the id has no container, and otherwise destroys the container and
+        drops it from the pool).
+
+        Confirmation deliberately does **not** read
+        ``GET /v1/sandbox/:id/running``. That route is behind the warm-pool
+        middleware, which allocates a container for the id before answering, so
+        probing it after a delete would report ``true`` on a healthy bridge and
+        - worse - start a fresh billable container, undoing the cancel. The
+        allocation-free ``GET /v1/pool/stats`` is read instead and returned on
+        the outcome.
+
+        Args:
+            sandbox_id: The sandbox identifier.
+
+        Returns:
+            The :class:`CancelOutcome`, carrying the post-delete pool state.
+
+        Raises:
+            CodexCloudflareNotConfiguredError: If no bridge is configured.
+            CodexCloudflareCancelError: If the bridge refused the delete, so
+                the container may still be running.
+        """
+        self._require_configured()
+        async with self._client() as client:
+            try:
+                await self._destroy(client, sandbox_id)
+            except (CodexCloudflareBridgeApiError, httpx.HTTPError) as exc:
+                raise CodexCloudflareCancelError(sandbox_id, str(exc)) from exc
+            pool = await self._pool_stats(client)
+        return CancelOutcome(sandbox_id=sandbox_id, deleted=True, pool_after=pool)
+
+    async def _destroy(self, client: httpx.AsyncClient, sandbox_id: str) -> None:
+        route = f"{BRIDGE_API_PREFIX}/sandbox/{sandbox_id}"
+        response = await client.delete(route, headers=self._auth_headers())
+        if response.status_code == 404:
+            return
+        self._check(f"DELETE {route}", response)
+
+    async def _reap(self, client: httpx.AsyncClient, sandbox_id: str) -> None:
+        """Delete *sandbox_id*, completing the delete even under a mid-teardown cancel.
+
+        A cancel can land while this coroutine is suspended inside the delete,
+        which would leave a container running and billing. Catch the
+        cancellation, drive one more bounded delete, then re-raise so the task
+        still terminates. No :func:`asyncio.shield`: shielding an unbounded
+        teardown turns a cancel into a hang, one bounded retry does not.
+        """
+        try:
+            await self._destroy(client, sandbox_id)
+        except asyncio.CancelledError:
+            with contextlib.suppress(BaseException):
+                await self._destroy(client, sandbox_id)
+            raise
+        except (CodexCloudflareError, httpx.HTTPError) as exc:
+            logger.warning("Could not delete Cloudflare sandbox %s: %s", sandbox_id, exc)
+
+    # -- Workspace transfer -------------------------------------------------
+
+    async def _hydrate(self, client: httpx.AsyncClient, sandbox_id: str, tar_bytes: bytes) -> None:
+        # No Session-Id header: the bridge's hydrate handler does not read one,
+        # it always writes into /workspace on the container itself.
+        route = f"{BRIDGE_API_PREFIX}/sandbox/{sandbox_id}/hydrate"
+        if len(tar_bytes) > BRIDGE_MAX_PAYLOAD_BYTES:
+            raise CodexCloudflarePayloadTooLargeError(f"POST {route}", len(tar_bytes))
+        response = await client.post(
+            route,
+            content=tar_bytes,
+            headers={**self._auth_headers(), "Content-Type": "application/octet-stream"},
+        )
+        self._check(f"POST {route}", response)
+
+    async def _persist(self, client: httpx.AsyncClient, sandbox_id: str) -> bytes:
+        route = f"{BRIDGE_API_PREFIX}/sandbox/{sandbox_id}/persist"
+        params = {"excludes": ",".join(self._config.persist_excludes)} if self._config.persist_excludes else None
+        response = await client.post(route, headers=self._auth_headers(), params=params)
+        self._check(f"POST {route}", response)
+        return response.content
+
+    async def write_file(self, sandbox_id: str, path: str, content: bytes) -> None:
+        """Write raw bytes to *path* inside the sandbox workspace.
+
+        Args:
+            sandbox_id: The sandbox identifier.
+            path: Workspace-relative path. The bridge rejects anything that
+                resolves outside ``/workspace``.
+            content: Raw file bytes, at most 32 MiB.
+
+        Raises:
+            CodexCloudflareNotConfiguredError: If no bridge is configured.
+            CodexCloudflarePayloadTooLargeError: If *content* exceeds the cap.
+            CodexCloudflareBridgeApiError: If the bridge refuses the write.
+        """
+        self._require_configured()
+        route = f"{BRIDGE_API_PREFIX}/sandbox/{sandbox_id}/file/{path.lstrip('/')}"
+        if len(content) > BRIDGE_MAX_PAYLOAD_BYTES:
+            raise CodexCloudflarePayloadTooLargeError(f"PUT {route}", len(content))
+        async with self._client() as client:
+            response = await client.put(
+                route,
+                content=content,
+                headers={**self._auth_headers(), "Content-Type": "application/octet-stream"},
+            )
+            self._check(f"PUT {route}", response)
+
+    # -- Sessions -----------------------------------------------------------
+
+    async def _create_session(self, client: httpx.AsyncClient, sandbox_id: str) -> str:
+        """Create a session carrying the workdir and the agent's environment.
+
+        The exec route's request schema is ``{argv, timeout_ms, cwd}`` - there
+        is no ``env`` field. The session route takes ``{id, cwd, env}``, so
+        that is where the coding-agent API key goes; it also keeps the key out
+        of argv, and therefore out of the sandbox process table and the shell
+        command string the bridge assembles. Sessions do not survive container
+        sleep, so one is created per run.
+        """
+        route = f"{BRIDGE_API_PREFIX}/sandbox/{sandbox_id}/session"
+        env = dict(self._config.extra_env)
+        if self._config.openai_api_key:
+            env["OPENAI_API_KEY"] = self._config.openai_api_key
+        body: dict[str, Any] = {"cwd": self._config.workdir}
+        if env:
+            body["env"] = env
+        response = await client.post(route, json=body, headers=self._auth_headers())
+        self._check(f"POST {route}", response)
+        return _json_str_field(response, "id")
+
+    # -- Execution ----------------------------------------------------------
 
     async def execute(
         self,
@@ -83,49 +1128,283 @@ class CodexCloudflareAdapter:
         *,
         model: str = "codex-mini",
         timeout_minutes: int | None = None,
+        workspace_tar: bytes | None = None,
+        on_output: Callable[[str, bytes], None] | None = None,
     ) -> CodexSandboxResult:
-        """Refuse to execute: the Cloudflare sandbox REST API does not exist.
+        """Run Codex on the bridge and return the result with its evidence.
+
+        The full lifecycle: create the sandbox, seed the workspace when a tar
+        is supplied, open a session carrying the agent's environment, stream
+        ``/exec`` decoding base64 output frames as they arrive, persist the
+        workspace, and delete the sandbox. The delete runs in a ``finally``, so
+        a cancelled or failed run still stops the remote container instead of
+        leaving it running and billing.
 
         Args:
-            prompt: The task prompt (unused).
-            workspace_id: Workspace identifier (unused).
-            model: The Codex model to use (unused).
-            timeout_minutes: Max execution time (unused).
+            prompt: Task prompt handed to the coding agent. Passed as a single
+                argv element, never through a shell.
+            workspace_id: Caller-side workspace identifier, used for logging
+                and correlation only.
+            model: Model name passed to the agent CLI.
+            timeout_minutes: Wall-clock ceiling for this run. Defaults to the
+                config's ``max_execution_minutes``.
+            workspace_tar: Optional tar of the starting workspace, hydrated
+                into the sandbox before the run and used as the baseline for
+                the returned diff.
+            on_output: Optional callback invoked as ``(stream, chunk)`` for
+                each decoded output frame, where ``stream`` is ``"stdout"`` or
+                ``"stderr"``. Called during the stream, not after it.
+
+        Returns:
+            The :class:`CodexSandboxResult` for the run.
 
         Raises:
-            RuntimeError: Always, because the adapter is non-functional.
+            CodexCloudflareNotConfiguredError: If no bridge is configured. The
+                adapter never falls back to running the agent locally.
+            CodexCloudflarePayloadTooLargeError: If *workspace_tar* exceeds the
+                bridge's 32 MiB cap.
+            CodexCloudflareBridgeApiError: If a bridge route fails.
         """
-        raise RuntimeError(_UNAVAILABLE_MSG)
+        self._require_configured()
+        minutes = timeout_minutes if timeout_minutes is not None else self._config.max_execution_minutes
+        timeout_ms = max(1, int(minutes * 60_000))
+        stream_timeout = timeout_ms / 1000.0 + self._config.request_timeout_seconds
+        before = _tar_index(workspace_tar) if workspace_tar else {}
+        argv = [*self._config.agent_command, "--model", model, prompt]
 
-    async def get_status(self, sandbox_id: str) -> str:
-        """Refuse: the sandbox status route does not exist.
+        async with self._client(timeout=stream_timeout) as client:
+            sandbox_id = await self._create_sandbox(client)
+            logger.info(
+                "Cloudflare sandbox %s created for workspace %s (bridge API %s)",
+                sandbox_id,
+                workspace_id,
+                self._api_version,
+            )
+            try:
+                if workspace_tar:
+                    await self._hydrate(client, sandbox_id, workspace_tar)
+                session_id = await self._create_session(client, sandbox_id)
+                started = time.monotonic()
+                outcome = await self._stream_exec(
+                    client,
+                    sandbox_id,
+                    session_id=session_id,
+                    argv=argv,
+                    timeout_ms=timeout_ms,
+                    on_output=on_output,
+                )
+                elapsed = time.monotonic() - started
+                tar_bytes = await self._persist(client, sandbox_id)
+            finally:
+                await self._reap(client, sandbox_id)
 
-        Args:
-            sandbox_id: The sandbox instance identifier (unused).
+        evidence = SandboxEvidence(
+            terminal_snapshot_digest=hashlib.sha256(tar_bytes).hexdigest(),
+            isolation=REMOTE_ISOLATION,
+            sandbox_id=sandbox_id,
+            bridge_api_version=self._api_version,
+            bridge_sdk_version=BRIDGE_SDK_VERSION,
+            workspace_bytes=len(tar_bytes),
+        )
+        stdout = outcome.stdout.decode("utf-8", errors="replace")
+        stderr = outcome.stderr.decode("utf-8", errors="replace")
+        self._transcripts[sandbox_id] = stdout + stderr
+        return CodexSandboxResult(
+            sandbox_id=sandbox_id,
+            status=outcome.status,
+            files_changed=_diff_paths(before, _tar_index(tar_bytes)),
+            stdout=stdout,
+            stderr=stderr,
+            exit_code=outcome.exit_code,
+            execution_time_seconds=elapsed,
+            workspace_tar=tar_bytes,
+            evidence=evidence,
+            error=outcome.error,
+        )
 
-        Raises:
-            RuntimeError: Always, because the adapter is non-functional.
+    async def _stream_exec(
+        self,
+        client: httpx.AsyncClient,
+        sandbox_id: str,
+        *,
+        session_id: str,
+        argv: list[str],
+        timeout_ms: int,
+        on_output: Callable[[str, bytes], None] | None,
+    ) -> _ExecOutcome:
+        """Drive ``POST /exec`` and fold its SSE frames into an outcome.
+
+        The body carries exactly the published ``ExecRequest`` fields
+        (``argv``, ``timeout_ms``, ``cwd``); environment is delivered by the
+        session referenced through the ``Session-Id`` header, which this route
+        honours.
         """
-        raise RuntimeError(_UNAVAILABLE_MSG)
+        route = f"{BRIDGE_API_PREFIX}/sandbox/{sandbox_id}/exec"
+        headers = {**self._auth_headers(), "Accept": "text/event-stream"}
+        if session_id:
+            headers["Session-Id"] = session_id
+        body = {"argv": argv, "timeout_ms": timeout_ms, "cwd": self._config.workdir}
+        stdout = bytearray()
+        stderr = bytearray()
+        exit_code = 0
+        status = "failed"
+        error = ""
+        pending: list[str] = []
 
-    async def cancel(self, sandbox_id: str) -> None:
-        """Refuse: the sandbox cancel route does not exist.
+        async with client.stream("POST", route, json=body, headers=headers) as response:
+            if response.status_code >= 400:
+                await response.aread()
+                self._check(f"POST {route}", response)
+            async for line in response.aiter_lines():
+                pending.append(line)
+                if line.strip():
+                    continue
+                for frame in _parse_sse_frames(pending):
+                    if frame.event in ("stdout", "stderr"):
+                        chunk = _decode_stream_payload(frame.data)
+                        if frame.event == "stdout":
+                            stdout.extend(chunk)
+                        else:
+                            stderr.extend(chunk)
+                        if on_output is not None:
+                            on_output(frame.event, chunk)
+                    elif frame.event == "exit":
+                        exit_code = _int_field(frame.data, "exit_code")
+                        status = "completed" if exit_code == 0 else "failed"
+                    elif frame.event == "error":
+                        error = _str_field(frame.data, "error")
+                        status = "timeout" if _looks_like_timeout(error) else "failed"
+                pending = []
 
-        Args:
-            sandbox_id: The sandbox instance identifier (unused).
-
-        Raises:
-            RuntimeError: Always, because the adapter is non-functional.
-        """
-        raise RuntimeError(_UNAVAILABLE_MSG)
+        return _ExecOutcome(
+            status=status,
+            exit_code=exit_code,
+            stdout=bytes(stdout),
+            stderr=bytes(stderr),
+            error=error,
+        )
 
     async def get_logs(self, sandbox_id: str) -> str:
-        """Refuse: the sandbox logs route does not exist.
+        """Return the transcript this adapter buffered for *sandbox_id*.
+
+        The bridge exposes no log-retrieval route: output exists only on the
+        ``/exec`` SSE stream while the command runs. What survives afterwards
+        is what the adapter recorded, and that is what this returns rather than
+        pretending a remote log store exists.
 
         Args:
-            sandbox_id: The sandbox instance identifier (unused).
+            sandbox_id: The sandbox identifier.
 
-        Raises:
-            RuntimeError: Always, because the adapter is non-functional.
+        Returns:
+            The merged stdout+stderr transcript, or an empty string when this
+            adapter instance did not run that sandbox.
         """
-        raise RuntimeError(_UNAVAILABLE_MSG)
+        return self._transcripts.get(sandbox_id, "")
+
+
+# ---------------------------------------------------------------------------
+# Small helpers
+# ---------------------------------------------------------------------------
+
+
+#: Substrings that mark a bridge ``error`` event as a timeout rather than a
+#: generic failure. The terminal error frame carries only ``{error, code}``,
+#: and ``code`` is ``exec_error``/``exec_transport_error`` for every cause, so
+#: the human-readable message is the sole timeout signal available. Both
+#: spellings are matched because the wording comes from the container runtime,
+#: not from a stable enum.
+_TIMEOUT_MARKERS = ("timeout", "timed out")
+
+
+def _looks_like_timeout(message: str) -> bool:
+    """True when a bridge error message reads as a timeout."""
+    lowered = message.lower()
+    return any(marker in lowered for marker in _TIMEOUT_MARKERS)
+
+
+def _same_major_series(observed: str, expected: str) -> bool:
+    """True when *observed* shares a major version with *expected*."""
+    if not observed:
+        return False
+    obs = observed.strip().lstrip("v").split(".")
+    return bool(obs[0]) and obs[0] == expected.split(".")[0]
+
+
+def _document_api_version(document: Mapping[str, Any]) -> str:
+    """Read ``info.version`` (the API contract version) from an OpenAPI document."""
+    info = document.get("info")
+    version = info.get("version") if isinstance(info, dict) else None
+    return version if isinstance(version, str) else ""
+
+
+def _document_paths(document: Mapping[str, Any]) -> frozenset[str]:
+    """Read the templated path keys published by an OpenAPI document."""
+    paths = document.get("paths")
+    if not isinstance(paths, dict):
+        return frozenset()
+    return frozenset(str(key) for key in paths)
+
+
+def _as_int(value: Any) -> int:
+    """Coerce a JSON number to ``int``, defaulting to 0."""
+    return value if isinstance(value, int) and not isinstance(value, bool) else 0
+
+
+def _json_str_field(response: httpx.Response, key: str) -> str:
+    """Read a string field from a JSON response body, or ``""``."""
+    try:
+        payload: Any = response.json()
+    except ValueError:
+        return ""
+    if not isinstance(payload, dict):
+        return ""
+    value = payload.get(key)
+    return value if isinstance(value, str) else ""
+
+
+def _int_field(payload: str, key: str) -> int:
+    """Read an integer field from a JSON SSE payload, defaulting to 0."""
+    try:
+        document: Any = json.loads(payload)
+    except (ValueError, TypeError):
+        return 0
+    return _as_int(document.get(key)) if isinstance(document, dict) else 0
+
+
+def _str_field(payload: str, key: str) -> str:
+    """Read a string field from a JSON SSE payload, defaulting to the raw text."""
+    try:
+        document: Any = json.loads(payload)
+    except (ValueError, TypeError):
+        return payload
+    value = document.get(key) if isinstance(document, dict) else None
+    return value if isinstance(value, str) else payload
+
+
+__all__ = [
+    "BRIDGE_API_CONTRACT_VERSION",
+    "BRIDGE_API_PREFIX",
+    "BRIDGE_MAX_PAYLOAD_BYTES",
+    "BRIDGE_PACKAGE",
+    "BRIDGE_SDK_VERSION",
+    "DEFAULT_WORKDIR",
+    "REMOTE_ISOLATION",
+    "REQUIRED_BRIDGE_PATHS",
+    "RETIRED_CONFIG_FIELDS",
+    "BridgePreflight",
+    "CancelOutcome",
+    "CodexCloudflareAdapter",
+    "CodexCloudflareBridgeApiError",
+    "CodexCloudflareBridgeAuthError",
+    "CodexCloudflareBridgeContractError",
+    "CodexCloudflareBridgeVersionError",
+    "CodexCloudflareCancelError",
+    "CodexCloudflareConfigError",
+    "CodexCloudflareError",
+    "CodexCloudflareNotConfiguredError",
+    "CodexCloudflarePayloadTooLargeError",
+    "CodexSandboxConfig",
+    "CodexSandboxResult",
+    "SandboxEvidence",
+    "WarmPoolStats",
+]

--- a/tests/unit/test_codex_cloudflare.py
+++ b/tests/unit/test_codex_cloudflare.py
@@ -1,153 +1,814 @@
-"""Unit tests for CodexCloudflareAdapter.
+"""Unit tests for the Codex-on-Cloudflare bridge adapter (issue #2969).
 
-The adapter is experimental and non-functional (issue #2783): its target
-Cloudflare sandbox REST API does not exist, so every public operation refuses
-with a clear error instead of issuing a request Cloudflare cannot route.
+Every HTTP interaction here is served by an ``httpx.MockTransport`` whose
+payloads were recorded from the bridge shipped in ``@cloudflare/sandbox``
+0.12.4 (``package/dist/bridge/index.js``): the route table, the OpenAPI
+document it serves (API contract ``1.0.0``, distinct from the package
+version), the ``{"error", "code"}`` failure shape, and the SSE frames -
+base64 ``stdout``/``stderr`` chunks plus a terminal ``exit`` or ``error``.
+
+:class:`_Bridge` also reproduces two behaviours that shape the adapter's
+design, so the tests fail if either assumption is dropped:
+
+* ``GET /v1/sandbox/:id/running`` runs behind the warm-pool middleware and
+  *acquires a container* before answering, so probing it after a delete
+  restarts what was just torn down.
+* ``DELETE /v1/sandbox/:id`` looks the container up without allocating, and
+  drops the assignment.
+
+There is no live Cloudflare deployment behind these tests. End-to-end
+verification against a real bridge is documented in
+``docs/cloudflare/cloudflare-codex-sandbox.md`` and has not been run.
 """
 
 from __future__ import annotations
 
+import asyncio
+import base64
+import hashlib
+import io
+import json
+import tarfile
+from typing import TYPE_CHECKING, Any
+
+import httpx
 import pytest
 
 from bernstein.adapters.codex_cloudflare import (
+    BRIDGE_API_CONTRACT_VERSION,
+    BRIDGE_SDK_VERSION,
+    REMOTE_ISOLATION,
+    REQUIRED_BRIDGE_PATHS,
+    RETIRED_CONFIG_FIELDS,
     CodexCloudflareAdapter,
+    CodexCloudflareBridgeAuthError,
+    CodexCloudflareBridgeContractError,
+    CodexCloudflareBridgeVersionError,
+    CodexCloudflareCancelError,
+    CodexCloudflareConfigError,
+    CodexCloudflareNotConfiguredError,
+    CodexCloudflarePayloadTooLargeError,
     CodexSandboxConfig,
     CodexSandboxResult,
+    SandboxEvidence,
+    _decode_stream_payload,
+    _parse_sse_frames,
 )
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
+BRIDGE_URL = "https://sandbox-bridge.example.workers.dev"
+API_KEY = "bridge-secret"
+#: Base32 lowercase, matching the bridge's own ``^[a-z2-7]{1,128}$`` id format.
+SANDBOX_ID = "mfrggzdfmy2tqnrzgezdgnbv"
+SESSION_ID = "sess-1"
+
+#: Paths the bridge publishes in its OpenAPI document, read from the bundle.
+PUBLISHED_PATHS = [
+    "/v1/sandbox",
+    "/v1/sandbox/{id}",
+    "/v1/sandbox/{id}/exec",
+    "/v1/sandbox/{id}/file/{path}",
+    "/v1/sandbox/{id}/hydrate",
+    "/v1/sandbox/{id}/mount",
+    "/v1/sandbox/{id}/persist",
+    "/v1/sandbox/{id}/pty",
+    "/v1/sandbox/{id}/running",
+    "/v1/sandbox/{id}/session",
+    "/v1/sandbox/{id}/session/{sid}",
+    "/v1/sandbox/{id}/tunnel/{port}",
+    "/v1/sandbox/{id}/unmount",
+    "/v1/openapi.json",
+    "/v1/pool/prime",
+    "/v1/pool/shutdown-prewarmed",
+    "/v1/pool/stats",
+]
+
+
 # ---------------------------------------------------------------------------
-# CodexSandboxConfig
+# Recorded bridge fixtures
+# ---------------------------------------------------------------------------
+
+
+def _tar(entries: dict[str, bytes]) -> bytes:
+    """Build a deterministic in-memory tar, with the ``./`` prefix the bridge emits."""
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w") as archive:
+        for name, payload in sorted(entries.items()):
+            info = tarfile.TarInfo(name=f"./{name}")
+            info.size = len(payload)
+            info.mtime = 0
+            archive.addfile(info, io.BytesIO(payload))
+    return buffer.getvalue()
+
+
+def _sse(frames: list[tuple[str, str]]) -> bytes:
+    """Render SSE frames the way the bridge's ``writeSSE`` helper does."""
+    chunks = []
+    for event, data in frames:
+        body = "\n".join(f"data: {line}" for line in data.split("\n"))
+        chunks.append(f"event: {event}\n{body}\n\n")
+    return "".join(chunks).encode("utf-8")
+
+
+def _b64(text: str) -> str:
+    return base64.b64encode(text.encode("utf-8")).decode("ascii")
+
+
+#: The exec stream a successful run produces, mirroring the documented frames.
+EXEC_STREAM_OK = _sse(
+    [
+        ("stdout", _b64("applying patch\n")),
+        ("stderr", _b64("warning: no tests\n")),
+        ("stdout", _b64("done\n")),
+        ("exit", '{"exit_code":0}'),
+    ],
+)
+
+SEED_TAR = _tar({"README.md": b"before\n", "src/app.py": b"print(1)\n"})
+RESULT_TAR = _tar(
+    {
+        "README.md": b"before\n",
+        "src/app.py": b"print(2)\n",
+        "src/new.py": b"added\n",
+    },
+)
+
+
+class _Bridge:
+    """Scripted stand-in for a deployed bridge Worker.
+
+    Models the warm pool the way the real bridge does: any ``/sandbox/:id/*``
+    route acquires a container for the id (starting one if needed), while
+    ``DELETE /sandbox/:id`` looks it up without allocating and then drops it.
+    ``/pool/stats`` reports the resulting bookkeeping.
+    """
+
+    def __init__(
+        self,
+        *,
+        exec_stream: bytes = EXEC_STREAM_OK,
+        persist_tar: bytes = RESULT_TAR,
+        openapi_version: str = BRIDGE_API_CONTRACT_VERSION,
+        published_paths: list[str] | None = None,
+        auth_enforced: bool = True,
+        exec_status: int = 200,
+        delete_status: int = 204,
+    ) -> None:
+        self.exec_stream = exec_stream
+        self.persist_tar = persist_tar
+        self.openapi_version = openapi_version
+        self.published_paths = PUBLISHED_PATHS if published_paths is None else published_paths
+        self.auth_enforced = auth_enforced
+        self.exec_status = exec_status
+        self.delete_status = delete_status
+        self.requests: list[tuple[str, str]] = []
+        self.bodies: dict[str, bytes] = {}
+        self.deleted: list[str] = []
+        #: Sandbox ids the warm pool currently holds a container for.
+        self.assigned: set[str] = set()
+
+    @property
+    def transport(self) -> httpx.MockTransport:
+        return httpx.MockTransport(self.handle)
+
+    def routes(self) -> list[str]:
+        return [f"{method} {path}" for method, path in self.requests]
+
+    def _openapi(self) -> dict[str, Any]:
+        return {
+            "openapi": "3.1.0",
+            "info": {"title": "Cloudflare Sandbox Service API", "version": self.openapi_version},
+            "paths": {path: {} for path in self.published_paths},
+        }
+
+    def handle(self, request: httpx.Request) -> httpx.Response:
+        method = request.method
+        path = request.url.path
+        self.requests.append((method, path))
+        self.bodies[f"{method} {path}"] = request.content
+        authorised = request.headers.get("Authorization") == f"Bearer {API_KEY}"
+
+        if self.auth_enforced and not authorised:
+            return httpx.Response(401, json={"error": "Unauthorized", "code": "unauthorized"})
+
+        if method == "POST" and path == "/v1/sandbox":
+            # The create route mints an id; it does not allocate a container.
+            return httpx.Response(200, json={"id": SANDBOX_ID})
+        if method == "GET" and path == "/v1/openapi.json":
+            return httpx.Response(200, json=self._openapi())
+        if method == "GET" and path == "/v1/pool/stats":
+            count = len(self.assigned)
+            return httpx.Response(200, json={"warm": 0, "assigned": count, "total": count})
+        if method == "DELETE" and path == f"/v1/sandbox/{SANDBOX_ID}":
+            # Allocation-free: looks the container up, drops it, never starts one.
+            self.deleted.append(path)
+            self.assigned.discard(SANDBOX_ID)
+            if self.delete_status >= 400:
+                return httpx.Response(self.delete_status, json={"error": "pool error", "code": "pool_error"})
+            return httpx.Response(204)
+
+        if path.startswith(f"/v1/sandbox/{SANDBOX_ID}/"):
+            # Warm-pool middleware: acquires (and would start) a container.
+            self.assigned.add(SANDBOX_ID)
+
+        if method == "POST" and path.endswith("/hydrate"):
+            return httpx.Response(200, json={"ok": True})
+        if method == "POST" and path.endswith("/session"):
+            return httpx.Response(200, json={"id": SESSION_ID})
+        if method == "POST" and path.endswith("/exec"):
+            if self.exec_status >= 400:
+                return httpx.Response(self.exec_status, json={"error": "boom", "code": "exec_error"})
+            return httpx.Response(
+                200,
+                content=self.exec_stream,
+                headers={"content-type": "text/event-stream"},
+            )
+        if method == "POST" and path.endswith("/persist"):
+            return httpx.Response(200, content=self.persist_tar)
+        if method == "GET" and path.endswith("/running"):
+            # The handler runs `true` in the container the middleware just
+            # acquired, so it answers true even for an id that had none.
+            return httpx.Response(200, json={"running": True})
+        if method == "PUT" and "/file/" in path:
+            return httpx.Response(200, json={"ok": True})
+        return httpx.Response(404, json={"error": "not found", "code": "not_found"})
+
+
+def _config(**overrides: Any) -> CodexSandboxConfig:
+    base: dict[str, Any] = {
+        "bridge_url": BRIDGE_URL,
+        "bridge_api_key": API_KEY,
+        "openai_api_key": "sk-test",
+    }
+    base.update(overrides)
+    return CodexSandboxConfig(**base)
+
+
+def _adapter(bridge: _Bridge, **overrides: Any) -> CodexCloudflareAdapter:
+    return CodexCloudflareAdapter(_config(**overrides), transport=bridge.transport)
+
+
+# ---------------------------------------------------------------------------
+# Configuration surface
 # ---------------------------------------------------------------------------
 
 
 class TestCodexSandboxConfig:
-    """CodexSandboxConfig dataclass defaults and overrides."""
-
-    def test_defaults(self) -> None:
+    def test_defaults_describe_only_honourable_settings(self) -> None:
         cfg = CodexSandboxConfig()
-        assert cfg.cloudflare_account_id == ""
-        assert cfg.cloudflare_api_token == ""
-        assert cfg.openai_api_key == ""
-        assert cfg.sandbox_image == "codex-sandbox:latest"
+        assert cfg.bridge_url == ""
+        assert cfg.bridge_api_key == ""
+        assert cfg.workdir == "/workspace"
+        assert cfg.agent_command == ("codex", "exec")
         assert cfg.max_execution_minutes == 30
-        assert cfg.memory_mb == 512
-        assert cfg.cpu_cores == pytest.approx(1.0)
-        assert cfg.network_access == "restricted"
-        assert cfg.r2_bucket == "bernstein-workspaces"
+        assert cfg.persist_excludes == (".git",)
+        assert cfg.require_supported_api_version is True
 
-    def test_custom_values(self) -> None:
-        cfg = CodexSandboxConfig(
-            cloudflare_account_id="acct-1",
-            cloudflare_api_token="tok-abc",
-            openai_api_key="sk-test",
-            sandbox_image="custom:v2",
-            max_execution_minutes=60,
-            memory_mb=1024,
-            cpu_cores=2.0,
-            network_access="full",
-            r2_bucket="my-bucket",
-        )
-        assert cfg.cloudflare_account_id == "acct-1"
-        assert cfg.cloudflare_api_token == "tok-abc"
-        assert cfg.openai_api_key == "sk-test"
-        assert cfg.sandbox_image == "custom:v2"
-        assert cfg.max_execution_minutes == 60
-        assert cfg.memory_mb == 1024
-        assert cfg.cpu_cores == pytest.approx(2.0)
-        assert cfg.network_access == "full"
-        assert cfg.r2_bucket == "my-bucket"
+    def test_retired_fields_are_absent_from_the_dataclass(self) -> None:
+        fields = set(CodexSandboxConfig.__dataclass_fields__)
+        assert fields.isdisjoint(RETIRED_CONFIG_FIELDS)
+
+    def test_is_configured_requires_url_and_key(self) -> None:
+        assert not CodexSandboxConfig(bridge_url=BRIDGE_URL).is_configured
+        assert not CodexSandboxConfig(bridge_api_key=API_KEY).is_configured
+        assert _config().is_configured
+
+    def test_missing_fields_names_both(self) -> None:
+        assert CodexSandboxConfig().missing_fields() == ("bridge_url", "bridge_api_key")
 
     def test_frozen(self) -> None:
         cfg = CodexSandboxConfig()
         with pytest.raises(AttributeError):
-            cfg.memory_mb = 2048  # type: ignore[misc]
+            cfg.bridge_url = "x"  # type: ignore[misc]
+
+    @pytest.mark.parametrize("retired", sorted(RETIRED_CONFIG_FIELDS))
+    def test_from_mapping_refuses_each_retired_field_by_name(self, retired: str) -> None:
+        with pytest.raises(CodexCloudflareConfigError) as excinfo:
+            CodexSandboxConfig.from_mapping({"bridge_url": BRIDGE_URL, retired: 1})
+        message = str(excinfo.value)
+        assert retired in message
+        assert "cannot honour" in message
+        assert "ignored" in message
+
+    def test_from_mapping_explains_sizing_is_deploy_time(self) -> None:
+        with pytest.raises(CodexCloudflareConfigError, match="instance_type"):
+            CodexSandboxConfig.from_mapping({"memory_mb": 1024})
+
+    def test_from_mapping_explains_no_egress_restriction(self) -> None:
+        with pytest.raises(CodexCloudflareConfigError, match="no egress restrictions"):
+            CodexSandboxConfig.from_mapping({"network_access": "restricted"})
+
+    def test_from_mapping_rejects_unknown_keys(self) -> None:
+        with pytest.raises(CodexCloudflareConfigError, match="Unknown"):
+            CodexSandboxConfig.from_mapping({"nope": 1})
+
+    def test_from_mapping_normalises_sequences_and_env(self) -> None:
+        cfg = CodexSandboxConfig.from_mapping(
+            {
+                "bridge_url": BRIDGE_URL,
+                "bridge_api_key": API_KEY,
+                "agent_command": ["codex", "exec", "--full-auto"],
+                "persist_excludes": [".git", "node_modules"],
+                "extra_env": {"FOO": "bar"},
+            },
+        )
+        assert cfg.agent_command == ("codex", "exec", "--full-auto")
+        assert cfg.persist_excludes == (".git", "node_modules")
+        assert cfg.extra_env == (("FOO", "bar"),)
 
 
 # ---------------------------------------------------------------------------
-# CodexSandboxResult
+# Unconfigured: refusal, never a silent local fallback
+# ---------------------------------------------------------------------------
+
+
+class TestNotConfigured:
+    @pytest.mark.asyncio
+    async def test_execute_refuses(self) -> None:
+        adapter = CodexCloudflareAdapter(CodexSandboxConfig())
+        with pytest.raises(CodexCloudflareNotConfiguredError) as excinfo:
+            await adapter.execute("do stuff", "ws-1")
+        message = str(excinfo.value)
+        assert "not configured" in message
+        assert "bridge_url" in message
+        assert "does not fall back to local execution" in message
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("method", ["get_status", "cancel", "is_running"])
+    async def test_lifecycle_methods_refuse(self, method: str) -> None:
+        adapter = CodexCloudflareAdapter(CodexSandboxConfig())
+        with pytest.raises(CodexCloudflareNotConfiguredError):
+            await getattr(adapter, method)(SANDBOX_ID)
+
+    @pytest.mark.asyncio
+    async def test_preflight_refuses(self) -> None:
+        adapter = CodexCloudflareAdapter(CodexSandboxConfig(bridge_url=BRIDGE_URL))
+        with pytest.raises(CodexCloudflareNotConfiguredError, match="bridge_api_key"):
+            await adapter.preflight()
+
+    def test_name(self) -> None:
+        assert CodexCloudflareAdapter(CodexSandboxConfig()).name == "codex-cloudflare"
+
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+
+
+class TestPreflight:
+    @pytest.mark.asyncio
+    async def test_accepts_a_healthy_pinned_bridge(self) -> None:
+        bridge = _Bridge()
+        result = await _adapter(bridge).preflight()
+        assert result.auth_enforced is True
+        assert result.api_version_supported is True
+        assert result.api_version == BRIDGE_API_CONTRACT_VERSION
+        assert result.routes_verified == REQUIRED_BRIDGE_PATHS
+        assert "POST /v1/sandbox" in bridge.routes()
+        assert "GET /v1/openapi.json" in bridge.routes()
+
+    @pytest.mark.asyncio
+    async def test_api_contract_version_is_not_the_package_version(self) -> None:
+        """A healthy bridge from the pinned package serves contract 1.0.0.
+
+        Comparing that against the package version (0.12.4) would refuse every
+        real deployment, so the two version lines stay separate.
+        """
+        assert BRIDGE_API_CONTRACT_VERSION.split(".")[0] != BRIDGE_SDK_VERSION.split(".")[0]
+        bridge = _Bridge(openapi_version="1.0.0")
+        result = await _adapter(bridge).preflight()
+        assert result.api_version_supported is True
+
+    @pytest.mark.asyncio
+    async def test_refuses_bridge_that_skips_authentication(self) -> None:
+        bridge = _Bridge(auth_enforced=False)
+        with pytest.raises(CodexCloudflareBridgeAuthError) as excinfo:
+            await _adapter(bridge).preflight()
+        message = str(excinfo.value)
+        assert "SANDBOX_API_KEY secret is unset" in message
+        assert "wrangler secret put" in message
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_probe_cleans_up_the_sandbox_it_created(self) -> None:
+        bridge = _Bridge(auth_enforced=False)
+        with pytest.raises(CodexCloudflareBridgeAuthError):
+            await _adapter(bridge).preflight()
+        assert bridge.deleted == [f"/v1/sandbox/{SANDBOX_ID}"]
+
+    @pytest.mark.asyncio
+    async def test_auth_probe_targets_the_route_without_an_id_segment(self) -> None:
+        """The bridge validates the sandbox-id format *before* checking auth.
+
+        Probing an id-bearing route would return 400 for a malformed id and
+        misreport the auth posture, so the probe uses the create route, which
+        carries no id.
+        """
+        bridge = _Bridge()
+        await _adapter(bridge).preflight()
+        first_method, first_path = bridge.requests[0]
+        assert (first_method, first_path) == ("POST", "/v1/sandbox")
+
+    @pytest.mark.asyncio
+    async def test_refuses_a_different_major_contract(self) -> None:
+        bridge = _Bridge(openapi_version="2.0.0")
+        with pytest.raises(CodexCloudflareBridgeVersionError) as excinfo:
+            await _adapter(bridge).preflight()
+        message = str(excinfo.value)
+        assert "2.0.0" in message
+        assert BRIDGE_API_CONTRACT_VERSION in message
+
+    @pytest.mark.asyncio
+    async def test_refuses_bridge_without_a_declared_version(self) -> None:
+        bridge = _Bridge(openapi_version="")
+        with pytest.raises(CodexCloudflareBridgeVersionError, match="<absent>"):
+            await _adapter(bridge).preflight()
+
+    @pytest.mark.asyncio
+    async def test_refuses_bridge_missing_a_route_the_adapter_drives(self) -> None:
+        without_persist = [p for p in PUBLISHED_PATHS if p != "/v1/sandbox/{id}/persist"]
+        bridge = _Bridge(published_paths=without_persist)
+        with pytest.raises(CodexCloudflareBridgeContractError) as excinfo:
+            await _adapter(bridge).preflight()
+        assert "/v1/sandbox/{id}/persist" in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_route_probe_stays_strict_when_version_drift_is_allowed(self) -> None:
+        without_exec = [p for p in PUBLISHED_PATHS if p != "/v1/sandbox/{id}/exec"]
+        bridge = _Bridge(openapi_version="2.0.0", published_paths=without_exec)
+        adapter = _adapter(bridge, require_supported_api_version=False)
+        with pytest.raises(CodexCloudflareBridgeContractError, match="exec"):
+            await adapter.preflight()
+
+    @pytest.mark.asyncio
+    async def test_version_drift_can_be_opted_into(self) -> None:
+        bridge = _Bridge(openapi_version="2.0.0")
+        adapter = _adapter(bridge, require_supported_api_version=False)
+        result = await adapter.preflight()
+        assert result.api_version_supported is False
+        assert result.api_version == "2.0.0"
+
+    def test_auth_version_and_contract_failures_are_distinct_errors(self) -> None:
+        auth = CodexCloudflareBridgeAuthError(BRIDGE_URL)
+        version = CodexCloudflareBridgeVersionError("2.0.0", BRIDGE_URL)
+        contract = CodexCloudflareBridgeContractError(("/v1/sandbox/{id}/exec",), BRIDGE_URL)
+        assert not isinstance(auth, CodexCloudflareBridgeVersionError)
+        assert not isinstance(version, CodexCloudflareBridgeContractError)
+        assert len({str(auth), str(version), str(contract)}) == 3
+
+
+# ---------------------------------------------------------------------------
+# Execution
+# ---------------------------------------------------------------------------
+
+
+class TestExecute:
+    @pytest.mark.asyncio
+    async def test_full_lifecycle_route_sequence(self) -> None:
+        bridge = _Bridge()
+        await _adapter(bridge).execute("fix the bug", "ws-1", workspace_tar=SEED_TAR)
+        assert bridge.routes() == [
+            "POST /v1/sandbox",
+            f"POST /v1/sandbox/{SANDBOX_ID}/hydrate",
+            f"POST /v1/sandbox/{SANDBOX_ID}/session",
+            f"POST /v1/sandbox/{SANDBOX_ID}/exec",
+            f"POST /v1/sandbox/{SANDBOX_ID}/persist",
+            f"DELETE /v1/sandbox/{SANDBOX_ID}",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_decodes_base64_output_frames(self) -> None:
+        bridge = _Bridge()
+        result = await _adapter(bridge).execute("fix the bug", "ws-1")
+        assert result.stdout == "applying patch\ndone\n"
+        assert result.stderr == "warning: no tests\n"
+        assert result.exit_code == 0
+        assert result.status == "completed"
+
+    @pytest.mark.asyncio
+    async def test_output_is_streamed_before_the_workspace_is_collected(self) -> None:
+        bridge = _Bridge()
+        seen: list[tuple[str, bytes, tuple[str, ...]]] = []
+
+        def record(stream: str, chunk: bytes) -> None:
+            seen.append((stream, chunk, tuple(bridge.routes())))
+
+        await _adapter(bridge).execute("fix the bug", "ws-1", on_output=record)
+
+        assert [(stream, chunk) for stream, chunk, _ in seen] == [
+            ("stdout", b"applying patch\n"),
+            ("stderr", b"warning: no tests\n"),
+            ("stdout", b"done\n"),
+        ]
+        # Every frame reached the caller while the stream was still open: no
+        # /persist had been requested yet at callback time.
+        for _, _, routes_at_call in seen:
+            assert not any("persist" in route for route in routes_at_call)
+
+    @pytest.mark.asyncio
+    async def test_returns_a_diff_against_the_seeded_workspace(self) -> None:
+        bridge = _Bridge()
+        result = await _adapter(bridge).execute("fix the bug", "ws-1", workspace_tar=SEED_TAR)
+        assert result.files_changed == ["src/app.py", "src/new.py"]
+
+    @pytest.mark.asyncio
+    async def test_agent_key_is_injected_as_session_env_not_argv(self) -> None:
+        bridge = _Bridge()
+        await _adapter(bridge).execute("fix the bug", "ws-1")
+        session_body = json.loads(bridge.bodies[f"POST /v1/sandbox/{SANDBOX_ID}/session"])
+        exec_body = bridge.bodies[f"POST /v1/sandbox/{SANDBOX_ID}/exec"].decode()
+        assert session_body == {"cwd": "/workspace", "env": {"OPENAI_API_KEY": "sk-test"}}
+        assert "sk-test" not in exec_body
+
+    @pytest.mark.asyncio
+    async def test_exec_body_matches_the_published_schema(self) -> None:
+        bridge = _Bridge()
+        await _adapter(bridge).execute("fix the bug", "ws-1", model="codex-mini", timeout_minutes=2)
+        body = json.loads(bridge.bodies[f"POST /v1/sandbox/{SANDBOX_ID}/exec"])
+        # ExecRequest publishes exactly argv / timeout_ms / cwd - there is no
+        # env field, which is why the key travels on the session instead.
+        assert set(body) == {"argv", "timeout_ms", "cwd"}
+        assert body["argv"] == ["codex", "exec", "--model", "codex-mini", "fix the bug"]
+        assert body["timeout_ms"] == 120_000
+        assert body["cwd"] == "/workspace"
+
+    @pytest.mark.asyncio
+    async def test_exec_carries_the_session_id_header_and_hydrate_does_not(self) -> None:
+        bridge = _Bridge()
+        headers: dict[str, dict[str, str]] = {}
+        inner = bridge.handle
+
+        def spy(request: httpx.Request) -> httpx.Response:
+            key = request.url.path.rsplit("/", 1)[-1]
+            headers[key] = dict(request.headers)
+            return inner(request)
+
+        adapter = CodexCloudflareAdapter(_config(), transport=httpx.MockTransport(spy))
+        await adapter.execute("fix the bug", "ws-1", workspace_tar=SEED_TAR)
+        assert headers["exec"]["session-id"] == SESSION_ID
+        assert headers["exec"]["accept"] == "text/event-stream"
+        # The hydrate handler does not read Session-Id, so none is sent.
+        assert "session-id" not in headers["hydrate"]
+
+    @pytest.mark.asyncio
+    async def test_persist_forwards_the_excludes_query_parameter(self) -> None:
+        bridge = _Bridge()
+        captured: list[str] = []
+        inner = bridge.handle
+
+        def spy(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/persist"):
+                captured.append(request.url.query.decode())
+            return inner(request)
+
+        adapter = CodexCloudflareAdapter(
+            _config(persist_excludes=(".git", "node_modules")),
+            transport=httpx.MockTransport(spy),
+        )
+        await adapter.execute("fix the bug", "ws-1")
+        assert captured == ["excludes=.git%2Cnode_modules"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("message", ["command timed out", "exec timeout after 30000ms"])
+    async def test_terminal_timeout_error_is_surfaced(self, message: str) -> None:
+        stream = _sse([("error", json.dumps({"error": message, "code": "exec_error"}))])
+        bridge = _Bridge(exec_stream=stream)
+        result = await _adapter(bridge).execute("fix the bug", "ws-1")
+        assert result.status == "timeout"
+        assert result.error == message
+
+    @pytest.mark.asyncio
+    async def test_terminal_transport_error_is_a_plain_failure(self) -> None:
+        stream = _sse([("error", '{"error":"exec failed: boom","code":"exec_transport_error"}')])
+        bridge = _Bridge(exec_stream=stream)
+        result = await _adapter(bridge).execute("fix the bug", "ws-1")
+        assert result.status == "failed"
+        assert result.error == "exec failed: boom"
+
+    @pytest.mark.asyncio
+    async def test_nonzero_exit_is_failed(self) -> None:
+        stream = _sse([("stdout", _b64("nope\n")), ("exit", '{"exit_code":2}')])
+        bridge = _Bridge(exec_stream=stream)
+        result = await _adapter(bridge).execute("fix the bug", "ws-1")
+        assert result.status == "failed"
+        assert result.exit_code == 2
+
+    @pytest.mark.asyncio
+    async def test_sandbox_is_deleted_even_when_the_run_blows_up(self) -> None:
+        bridge = _Bridge(exec_status=500)
+        with pytest.raises(RuntimeError, match="HTTP 500"):
+            await _adapter(bridge).execute("fix the bug", "ws-1")
+        assert bridge.deleted == [f"/v1/sandbox/{SANDBOX_ID}"]
+        assert bridge.assigned == set()
+
+    @pytest.mark.asyncio
+    async def test_oversized_seed_is_refused_before_upload(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("bernstein.adapters.codex_cloudflare.BRIDGE_MAX_PAYLOAD_BYTES", 8)
+        bridge = _Bridge()
+        with pytest.raises(CodexCloudflarePayloadTooLargeError, match="over the bridge"):
+            await _adapter(bridge).execute("fix the bug", "ws-1", workspace_tar=SEED_TAR)
+        assert not any("hydrate" in route for route in bridge.routes())
+        assert bridge.deleted == [f"/v1/sandbox/{SANDBOX_ID}"]
+
+    @pytest.mark.asyncio
+    async def test_get_logs_returns_the_recorded_transcript(self) -> None:
+        bridge = _Bridge()
+        adapter = _adapter(bridge)
+        await adapter.execute("fix the bug", "ws-1")
+        assert await adapter.get_logs(SANDBOX_ID) == "applying patch\ndone\nwarning: no tests\n"
+        assert await adapter.get_logs("unknown") == ""
+
+    @pytest.mark.asyncio
+    async def test_write_file_rejects_oversized_content(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("bernstein.adapters.codex_cloudflare.BRIDGE_MAX_PAYLOAD_BYTES", 4)
+        bridge = _Bridge()
+        with pytest.raises(CodexCloudflarePayloadTooLargeError):
+            await _adapter(bridge).write_file(SANDBOX_ID, "a.txt", b"too long")
+        assert bridge.routes() == []
+
+
+# ---------------------------------------------------------------------------
+# Cancellation must stop remote work, not just the local stream
+# ---------------------------------------------------------------------------
+
+
+class TestCancellation:
+    @pytest.mark.asyncio
+    async def test_cancel_issues_the_explicit_delete(self) -> None:
+        bridge = _Bridge()
+        bridge.assigned.add(SANDBOX_ID)
+        outcome = await _adapter(bridge).cancel(SANDBOX_ID)
+        assert outcome.deleted is True
+        assert bridge.deleted == [f"/v1/sandbox/{SANDBOX_ID}"]
+
+    @pytest.mark.asyncio
+    async def test_teardown_is_confirmed_without_restarting_the_container(self) -> None:
+        """After cancel the pool holds no container, and none was started.
+
+        Teardown is read from ``/v1/pool/stats`` rather than
+        ``/v1/sandbox/:id/running``: the latter runs behind the warm-pool
+        middleware, which acquires a container before answering, so probing it
+        here would restart exactly what the delete stopped.
+        """
+        bridge = _Bridge()
+        bridge.assigned.add(SANDBOX_ID)
+        outcome = await _adapter(bridge).cancel(SANDBOX_ID)
+        assert outcome.pool_after.assigned == 0
+        assert outcome.pool_after.total == 0
+        assert bridge.assigned == set()
+        assert not any(route.endswith("/running") for route in bridge.routes())
+
+    @pytest.mark.asyncio
+    async def test_running_probe_after_a_delete_would_restart_the_container(self) -> None:
+        """The hazard the cancel path avoids, made explicit.
+
+        This is the bridge behaviour, not a bug in the adapter: asking
+        ``/running`` for a deleted id allocates a container and then reports
+        it as up. Cancellation must not be built on this signal.
+        """
+        bridge = _Bridge()
+        bridge.assigned.add(SANDBOX_ID)
+        adapter = _adapter(bridge)
+        await adapter.cancel(SANDBOX_ID)
+        assert bridge.assigned == set()
+
+        assert await adapter.is_running(SANDBOX_ID) is True
+        assert bridge.assigned == {SANDBOX_ID}
+
+    @pytest.mark.asyncio
+    async def test_cancel_raises_when_the_bridge_refuses_the_delete(self) -> None:
+        bridge = _Bridge(delete_status=502)
+        with pytest.raises(CodexCloudflareCancelError) as excinfo:
+            await _adapter(bridge).cancel(SANDBOX_ID)
+        message = str(excinfo.value)
+        assert "may still be running" in message
+        assert SANDBOX_ID in message
+
+    @pytest.mark.asyncio
+    async def test_pool_stats_are_readable_on_their_own(self) -> None:
+        bridge = _Bridge()
+        bridge.assigned.add(SANDBOX_ID)
+        stats = await _adapter(bridge).pool_stats()
+        assert stats.assigned == 1
+        assert stats.total == 1
+        assert stats.warm == 0
+
+    @pytest.mark.asyncio
+    async def test_reap_retries_once_when_cancelled_mid_teardown(self) -> None:
+        bridge = _Bridge()
+        adapter = _adapter(bridge)
+        calls: list[str] = []
+
+        async def flaky_destroy(_client: httpx.AsyncClient, sandbox_id: str) -> None:
+            calls.append(sandbox_id)
+            if len(calls) == 1:
+                raise asyncio.CancelledError
+            bridge.deleted.append(f"/v1/sandbox/{sandbox_id}")
+
+        adapter._destroy = flaky_destroy  # type: ignore[method-assign]
+        async with httpx.AsyncClient(transport=bridge.transport) as client:
+            with pytest.raises(asyncio.CancelledError):
+                await adapter._reap(client, SANDBOX_ID)
+        assert calls == [SANDBOX_ID, SANDBOX_ID]
+        assert bridge.deleted == [f"/v1/sandbox/{SANDBOX_ID}"]
+
+
+# ---------------------------------------------------------------------------
+# Sandbox evidence: a remote run records where it ran
+# ---------------------------------------------------------------------------
+
+
+class TestSandboxEvidence:
+    @pytest.mark.asyncio
+    async def test_digest_is_the_content_address_of_the_persisted_workspace(self) -> None:
+        bridge = _Bridge()
+        result = await _adapter(bridge).execute("fix the bug", "ws-1", workspace_tar=SEED_TAR)
+        assert result.evidence is not None
+        assert result.evidence.terminal_snapshot_digest == hashlib.sha256(RESULT_TAR).hexdigest()
+        assert result.evidence.workspace_bytes == len(RESULT_TAR)
+        assert result.workspace_tar == RESULT_TAR
+
+    @pytest.mark.asyncio
+    async def test_isolation_names_where_the_task_ran(self) -> None:
+        bridge = _Bridge()
+        result = await _adapter(bridge).execute("fix the bug", "ws-1")
+        assert result.evidence is not None
+        assert result.evidence.isolation == REMOTE_ISOLATION
+        assert result.evidence.sandbox_id == SANDBOX_ID
+        assert result.evidence.bridge_api_version == BRIDGE_API_CONTRACT_VERSION
+        assert result.evidence.bridge_sdk_version == BRIDGE_SDK_VERSION
+
+    @pytest.mark.asyncio
+    async def test_evidence_signs_and_verifies_as_a_selection_receipt(self, tmp_path: Path) -> None:
+        from bernstein.core.sandbox.selection_receipt import (
+            build_selection_receipt,
+            load_or_create_signing_key,
+            sign_receipt,
+            snapshot_digests,
+            verify_receipt,
+        )
+
+        bridge = _Bridge()
+        result = await _adapter(bridge).execute("fix the bug", "ws-1", workspace_tar=SEED_TAR)
+        assert result.evidence is not None
+        candidate = result.evidence.to_race_candidate("task-1", {"correctness": 1.0})
+
+        key = load_or_create_signing_key(tmp_path / "signing.pem")
+        receipt = build_selection_receipt(
+            base_snapshot_digest=hashlib.sha256(SEED_TAR).hexdigest(),
+            candidates=[candidate],
+            winner_task_id="task-1",
+            ranker_profile={"method": "topsis", "criteria": []},
+            public_key=key.public_key(),
+        )
+        signed = sign_receipt(receipt, private_key=key)
+
+        verification = verify_receipt(signed)
+        assert verification.ok, verification.errors
+        assert signed.winner_snapshot_digest == result.evidence.terminal_snapshot_digest
+        assert result.evidence.terminal_snapshot_digest in snapshot_digests(signed)
+        assert signed.candidates[0]["isolation"] == REMOTE_ISOLATION
+
+    def test_evidence_defaults(self) -> None:
+        evidence = SandboxEvidence(terminal_snapshot_digest="0" * 64)
+        assert evidence.isolation == REMOTE_ISOLATION
+        assert evidence.bridge_api_version == BRIDGE_API_CONTRACT_VERSION
+
+
+# ---------------------------------------------------------------------------
+# SSE framing details
+# ---------------------------------------------------------------------------
+
+
+class TestSseFraming:
+    def test_multiline_data_is_rejoined(self) -> None:
+        frames = _parse_sse_frames(["event: error", "data: line one", "data: line two", ""])
+        assert len(frames) == 1
+        assert frames[0].event == "error"
+        assert frames[0].data == "line one\nline two"
+
+    def test_comment_lines_are_ignored(self) -> None:
+        frames = _parse_sse_frames([": keep-alive", "event: exit", 'data: {"exit_code":0}', ""])
+        assert [f.event for f in frames] == ["exit"]
+
+    def test_non_base64_payload_is_passed_through(self) -> None:
+        assert _decode_stream_payload("not base64!!") == b"not base64!!"
+        assert _decode_stream_payload("") == b""
+        assert _decode_stream_payload(_b64("ok")) == b"ok"
+
+
+# ---------------------------------------------------------------------------
+# Result shape
 # ---------------------------------------------------------------------------
 
 
 class TestCodexSandboxResult:
-    """CodexSandboxResult creation with all fields."""
-
-    def test_creation_with_defaults(self) -> None:
+    def test_defaults(self) -> None:
         result = CodexSandboxResult(sandbox_id="sb-1", status="completed")
-        assert result.sandbox_id == "sb-1"
-        assert result.status == "completed"
         assert result.files_changed == []
         assert result.stdout == ""
-        assert result.stderr == ""
         assert result.exit_code == 0
-        assert result.execution_time_seconds == pytest.approx(0.0)
-        assert result.tokens_used == 0
-
-    def test_creation_with_all_fields(self) -> None:
-        result = CodexSandboxResult(
-            sandbox_id="sb-2",
-            status="failed",
-            files_changed=["a.py", "b.py"],
-            stdout="output",
-            stderr="error",
-            exit_code=1,
-            execution_time_seconds=42.5,
-            tokens_used=1500,
-        )
-        assert result.sandbox_id == "sb-2"
-        assert result.status == "failed"
-        assert result.files_changed == ["a.py", "b.py"]
-        assert result.stdout == "output"
-        assert result.stderr == "error"
-        assert result.exit_code == 1
-        assert result.execution_time_seconds == pytest.approx(42.5)
-        assert result.tokens_used == 1500
-
-
-# ---------------------------------------------------------------------------
-# CodexCloudflareAdapter - name
-# ---------------------------------------------------------------------------
-
-
-class TestCodexCloudflareAdapterName:
-    def test_name_returns_codex_cloudflare(self) -> None:
-        adapter = CodexCloudflareAdapter(CodexSandboxConfig())
-        assert adapter.name == "codex-cloudflare"
-
-
-# ---------------------------------------------------------------------------
-# Refusal: the target Cloudflare sandbox REST API does not exist (issue #2783)
-# ---------------------------------------------------------------------------
-
-
-def _adapter() -> CodexCloudflareAdapter:
-    return CodexCloudflareAdapter(CodexSandboxConfig(cloudflare_account_id="a", cloudflare_api_token="t"))
-
-
-class TestRefusal:
-    @pytest.mark.asyncio
-    async def test_execute_refuses(self) -> None:
-        with pytest.raises(RuntimeError, match="experimental"):
-            await _adapter().execute("do stuff", "ws-1", model="codex-mini")
-
-    @pytest.mark.asyncio
-    async def test_get_status_refuses(self) -> None:
-        with pytest.raises(RuntimeError, match="experimental"):
-            await _adapter().get_status("sb-1")
-
-    @pytest.mark.asyncio
-    async def test_cancel_refuses(self) -> None:
-        with pytest.raises(RuntimeError, match="experimental"):
-            await _adapter().cancel("sb-1")
-
-    @pytest.mark.asyncio
-    async def test_get_logs_refuses(self) -> None:
-        with pytest.raises(RuntimeError, match="experimental"):
-            await _adapter().get_logs("sb-1")
-
-    @pytest.mark.asyncio
-    async def test_refusal_message_is_actionable(self) -> None:
-        with pytest.raises(RuntimeError) as exc:
-            await _adapter().execute("do stuff", "ws-1")
-        message = str(exc.value)
-        assert "#2783" in message
-        assert "CloudflareBridge" in message
+        assert result.workspace_tar is None
+        assert result.evidence is None
+        assert result.error == ""

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -138,6 +138,6 @@ capture_output  # noqa
 # which vulture's AST walker cannot resolve.
 JsonSchemaValidationError  # noqa
 
-# Refusal-stub keyword parameter kept for public API surface stability
-# (codex_cloudflare.execute refuses; callers may still pass the kwarg).
+# Optional keyword on adapter entry points that callers pass but in-repo
+# call sites often leave at the default (e.g. codex_cloudflare.execute).
 timeout_minutes  # noqa


### PR DESCRIPTION
Closes #2969

## What changed

`codex_cloudflare` refused every operation because it targeted an account-scoped REST route family that has never existed. The sandbox is now reachable over HTTP: `@cloudflare/sandbox` ships a bridge Worker the operator deploys, exposing the sandbox as REST + SSE with Bearer auth. The refusal stub is replaced with an httpx client against that bridge.

Lifecycle per run: `POST /v1/sandbox` -> `POST /:id/hydrate` (tar seed) -> `POST /:id/session` (cwd + agent env) -> `POST /:id/exec` (SSE, `Session-Id`) -> `POST /:id/persist` (tar -> diff) -> `DELETE /:id`. The delete runs from a `finally`, so a failed or cancelled run still stops the remote container.

## Pinned contract

Implemented against **`@cloudflare/sandbox` 0.12.4**, whose bridge serves **API contract `1.0.0`** at `GET /v1/openapi.json`. Both are recorded in code and docs.

The two version lines are tracked separately on purpose. The served `info.version` is the *API contract* version (schema title: "Cloudflare Sandbox Service API"), **not** the npm package version - a healthy deployment of the pinned package reports `1.0.0`, so comparing it against `0.12.4` would refuse every real bridge. Preflight checks the contract major, and separately validates that the served `paths` still carry every route the adapter drives. The route probe is the check that actually protects against this package's route churn: a hand-maintained version field can go stale, published paths cannot.

Contract facts were read from the shipped bundle (`npm pack @cloudflare/sandbox@0.12.4` -> `package/dist/bridge/index.js`), not inferred from the docs site.

## Behaviours worth reviewing

**Cancellation stops remote work.** Closing the SSE stream does not stop the container process. `cancel()` issues the explicit `DELETE`, which the bridge serves through an allocation-free pool lookup.

It deliberately does **not** confirm with `GET /:id/running`. That route sits behind the warm-pool middleware, which acquires - and if necessary starts - a container for the id before running `true` inside it. Probing it after a delete would report `running: true` on a perfectly healthy bridge *and* start a fresh billable container, undoing the cancel. Teardown is confirmed against `GET /v1/pool/stats`, which reads pool state without allocating. The test fixture reproduces the resurrection behaviour, so a regression that reintroduces the `/running` probe fails.

**Preflight refuses an unauthenticated bridge.** The bridge's auth checks are conditional on its `SANDBOX_API_KEY` secret; with the secret unset it serves `/v1/sandbox/*` to anyone. Preflight probes `POST /v1/sandbox` with no `Authorization` header, deletes the sandbox it accidentally created, and refuses. The probe targets the create route specifically because sandbox-id format validation runs *before* the auth check on id-bearing routes, so an id-bearing probe would misread the posture.

**Remote runs land the same evidence as local ones.** The persisted tar is hashed to a content address and exposed via `SandboxEvidence.to_race_candidate()`, producing a `RaceCandidate` with `isolation="requested:codex-cloudflare"` that signs into a selection receipt alongside locally-produced candidates. A test signs one and verifies it. The `requested:` prefix follows `fork_race`'s convention - the adapter does not boot or probe the isolation boundary, so it does not claim to attest it; the digest it does attest is re-hashable offline.

**The agent key travels on the session, not argv.** The published `ExecRequest` schema is exactly `{argv, timeout_ms, cwd}` with no `env` field. Using the session route also keeps the key out of the sandbox process table and the shell command string the bridge assembles.

## Config surface

Settings the bridge cannot honour are **absent**, not accepted-and-ignored: per-request `memory_mb`/`cpu_cores` (sizing is the deploy-time wrangler `instance_type`), `network_access` (the bridge applies no egress restrictions), `sandbox_image`, `r2_bucket`, and the account-scoped credentials. Removing them is a breaking config change, so `CodexSandboxConfig.from_mapping()` rejects each by name with the reason and the replacement rather than letting an old config silently no-op.

Unconfigured, every method raises `CodexCloudflareNotConfiguredError`. There is no fallback to local execution.

## Verification

| Check | Result |
|---|---|
| `uv run ruff check .` | clean |
| `uv run ruff format --check .` | clean (4291 files) |
| `uv run mypy src/bernstein/adapters/codex_cloudflare.py` | 0 errors in this file |
| `uv run lint-imports` | 3 contracts kept, 0 broken |
| `tests/unit/test_codex_cloudflare.py` | **64 passed** |
| `tests/unit/test_docs_url_hygiene.py` | 1 passed |
| adapter-wide suites (`test_adapter_consistency`, `test_adapter_registry`, `test_adapter_canary`, `test_adapter_conformance_suite`, `test_arch_conformance`, `test_adapter_contract`, `test_adapter_contract_check`) | **1462 passed, 115 skipped** |

## Not verified

**End-to-end against a live deployment has not been run** - there is no Cloudflare Workers Paid account available here. The adapter is built and tested against the published bridge contract using recorded HTTP and SSE fixtures that mirror the documented payloads (base64 stdout/stderr frames, terminal `exit`/`error` events, the `{"error","code"}` failure shape). The docs page carries a single command anyone with a paid account can run to exercise the full path against a real bridge, with the expected output stated.

Also unverified: behaviour under real container cold starts and warm-pool contention; SSE backpressure with high-volume output; whether a real `codex` CLI in the container image behaves as the argv construction assumes; `uv run mypy src` as a whole (it stops on a pre-existing syntax error in `src/bernstein/cli/display/gradients.py`, unrelated to this change).

## Docs

New page `docs/cloudflare/cloudflare-codex-sandbox.md` covers the deploy steps, the instance-type requirement (the upstream template's `lite` is 1/16 vCPU / 256 MiB - `standard-3` or larger is the realistic floor for a coding agent), the Workers Paid prerequisite, the authentication warning, cancellation semantics, the live-verification command, and the limitations: no egress restriction, the symlink-escape caveat, the 32 MiB payload cap, sessions not surviving container sleep, and no remote log store.

`FEATURE_MATRIX.md` is intentionally untouched. The module-map tables in `AGENTS.md` / `CLAUDE.md` / `CONVENTIONS.md` / `.goosehints` are generated from module docstrings by `bernstein agents-md sync` and are left to that path to avoid colliding with concurrent adapter work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added functional Codex execution through a Cloudflare sandbox bridge.
  - Supports streamed output, workspace transfer, file-change reporting, evidence receipts, cancellation, and remote status checks.
  - Added configuration validation and clear errors for missing or incompatible bridge settings.

- **Documentation**
  - Added deployment, configuration, workflow, and limitations guidance.
  - Updated Cloudflare documentation and navigation to reflect sandbox support.

- **Tests**
  - Expanded coverage for execution, streaming, validation, evidence, cancellation, and bridge compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->