### PR TITLE
chore(ci): ratchet coverage baseline up to 81.95%

### DIFF
--- a/.coverage-baseline.json
+++ b/.coverage-baseline.json
@@ -1,5 +1,5 @@
 {
   "diff_coverage_floor_percent": 85,
-  "total_coverage_percent": 81.71,
-  "updated_at": "2026-07-24T09:10:11+00:00"
+  "total_coverage_percent": 81.95,
+  "updated_at": "2026-07-24T20:59:54+00:00"
 }


### PR DESCRIPTION
Raises the recorded total-coverage baseline from 81.71% to 81.95%, matching what the suite now achieves on main.

Supersedes #2963, which was authored by `github-actions` under `GITHUB_TOKEN` and therefore never triggered the `pull_request` workflows — both required contexts were missing, so it could not merge regardless of its content. Reopened under user auth so CI actually runs.

## Summary by Sourcery

Tests:
- Update the coverage baseline JSON to raise the overall coverage threshold from 81.71% to 81.95%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated reported test coverage metrics to reflect the latest results.
  * Maintained the existing minimum coverage threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->