### PR TITLE
fix(janitor): fail closed on unevaluated artifact-mode completion signals

### DIFF
--- a/docs/operations/artifacts.md
+++ b/docs/operations/artifacts.md
@@ -67,6 +67,15 @@ artifact bytes (in addition to the six filesystem/test completion signals):
 
 Each has a closed evaluator; none executes artifact-supplied code.
 
+These four criteria are only evaluable with the produced artifact in scope. The
+janitor's filesystem verification path cannot see it, so it reports them as
+**not passed** with the detail
+`<type> requires artifact-mode evaluation via evaluate_artifact_signals()`.
+That is the deliberate default: a declared completion gate that no evaluator
+checked must never read as verified. Declare an artifact-mode criterion only on
+a task that is completed through the artifact path; on a task verified from the
+filesystem it will hold the task open rather than pass silently.
+
 ## `bernstein artifact verify`
 
 ```

--- a/src/bernstein/core/quality/janitor.py
+++ b/src/bernstein/core/quality/janitor.py
@@ -109,9 +109,10 @@ _NONTRIVIAL_SIGNAL_TYPES = frozenset(
 )
 
 # Completion-signal types that operate on an artifact's canonical bytes rather
-# than the filesystem (issue #2608, #2888). The filesystem-oriented
-# :func:`evaluate_signal` defers these to :func:`evaluate_artifact_signals`,
-# which has the produced artifact in scope.
+# than the filesystem (issue #2608, #2888). Only :func:`evaluate_artifact_signals`,
+# which has the produced artifact in scope, can pass one; every filesystem-path
+# evaluation of these types fails closed (issue #2968), so a declared gate that
+# no evaluator checked can never read as verified.
 _ARTIFACT_SIGNAL_TYPES = frozenset({"schema_valid", "criteria_match", "hash_stable", "figures_grounded"})
 
 
@@ -277,12 +278,15 @@ def evaluate_signal(signal: CompletionSignal, workdir: Path) -> tuple[bool, str]
         case "llm_judge":
             # llm_judge requires async evaluation - use judge_task() instead.
             return False, "llm_judge requires async evaluation via judge_task()"
-        case "schema_valid" | "criteria_match" | "hash_stable" | "figures_grounded":
+        case _ if signal.type in _ARTIFACT_SIGNAL_TYPES:
             # Artifact-mode criteria operate on the produced artifact's canonical
             # bytes (and, for figures_grounded, on lineage reads), not the
             # filesystem. They are dispatched by evaluate_artifact_signals() once
             # the artifact is in scope; the filesystem path recognises them (so
-            # they are never "unknown") but cannot evaluate them here.
+            # they are never "unknown") but cannot evaluate them here, and so
+            # fails closed. Membership is read from _ARTIFACT_SIGNAL_TYPES rather
+            # than re-listed, so adding a type to the set cannot leave this arm
+            # behind.
             return False, f"{signal.type} requires artifact-mode evaluation via evaluate_artifact_signals()"
     return False, f"unknown signal type: {signal.type}"
 
@@ -410,6 +414,15 @@ def _evaluate_figures_grounded_signal(
 def verify_task(task: Task, workdir: Path) -> tuple[bool, list[str]]:
     """Verify all completion signals for a task.
 
+    Every declared signal is dispatched through :func:`evaluate_signal`, which
+    owns the per-type default; this function never decides an outcome of its
+    own. Artifact-mode criteria therefore fail closed here with the detail
+    ``evaluate_signal`` already produces (issue #2968): the filesystem path
+    does not have the produced artifact in scope, and a declared gate that no
+    evaluator checked must not report as passed. Only
+    :func:`evaluate_artifact_signals`, called with the artifact in scope, can
+    pass them.
+
     Args:
         task: Task with completion_signals to check.
         workdir: Project root for path resolution.
@@ -422,11 +435,6 @@ def verify_task(task: Task, workdir: Path) -> tuple[bool, list[str]]:
     """
     failed: list[str] = []
     for signal in task.completion_signals:
-        # Artifact-mode criteria are verified against the produced artifact by
-        # evaluate_artifact_signals(), not against the filesystem, so the
-        # filesystem verify path skips them rather than spuriously failing.
-        if signal.type in _ARTIFACT_SIGNAL_TYPES:
-            continue
         passed, detail = evaluate_signal(signal, workdir)
         if not passed:
             desc = f"{signal.type}: {signal.value}"
@@ -443,6 +451,14 @@ def _collect_signal_results(
 ) -> list[tuple[str, bool, str]]:
     """Evaluate all signals and return structured results.
 
+    Shares :func:`evaluate_signal` with :func:`verify_task`, so the two paths
+    report the same outcome for the same signal type by construction. The one
+    signal type omitted here is ``llm_judge``, which :func:`run_janitor`
+    genuinely does evaluate later in the same pass via
+    :func:`_evaluate_judge_signals`; artifact-mode signals have no such
+    in-pass evaluator and so fail closed rather than being dropped
+    (issue #2968).
+
     Args:
         task: Task with completion_signals to check.
         workdir: Project root for path resolution.
@@ -454,8 +470,6 @@ def _collect_signal_results(
     for signal in task.completion_signals:
         if signal.type == "llm_judge":
             continue  # Evaluated async in run_janitor via judge_task()
-        if signal.type in _ARTIFACT_SIGNAL_TYPES:
-            continue  # Evaluated against the artifact via evaluate_artifact_signals()
         desc = f"{signal.type}: {signal.value}"
         passed, detail = evaluate_signal(signal, workdir)
         results.append((desc, passed, detail))

--- a/tests/unit/test_janitor.py
+++ b/tests/unit/test_janitor.py
@@ -1672,6 +1672,112 @@ class TestArtifactSignals:
         assert evaluate_artifact_signals(task, "prose\n") == []
 
 
+class TestArtifactSignalDefaultsFailClosed:
+    """Issue #2968: a declared signal that no evaluator checked must not pass.
+
+    ``evaluate_signal`` owns the per-type default. ``verify_task`` and
+    ``_collect_signal_results`` both dispatch every signal through it, so the
+    task-level paths cannot report a verdict the single-signal evaluator would
+    not. Only ``evaluate_artifact_signals`` -- which has the produced artifact
+    in scope -- can pass an artifact-mode signal.
+    """
+
+    # Types whose evaluation shells out (``test_passes``) or calls an LLM
+    # (``llm_review``). Every other declared type is exercised below, so a
+    # newly declared signal type joins the divergence check automatically.
+    _SIDE_EFFECTING = frozenset({"test_passes", "llm_review"})
+
+    @staticmethod
+    def _declared_types() -> tuple[str, ...]:
+        from typing import get_args, get_type_hints
+
+        return get_args(get_type_hints(CompletionSignal)["type"])
+
+    def _pure_types(self) -> list[str]:
+        return [t for t in self._declared_types() if t not in self._SIDE_EFFECTING]
+
+    def test_schema_valid_only_task_does_not_verify_as_passed(self, tmp_path: Path) -> None:
+        """The headline case: the only signal is artifact-mode, nothing evaluated it."""
+        task = _make_task(signals=[CompletionSignal(type="schema_valid", value='{"type": "object"}')])
+
+        passed, failed = verify_task(task, tmp_path)
+
+        assert passed is False
+        assert len(failed) == 1
+        assert "schema_valid" in failed[0]
+        assert "evaluate_artifact_signals()" in failed[0]
+
+    def test_artifact_types_are_declared_signal_types(self) -> None:
+        from bernstein.core.quality.janitor import _ARTIFACT_SIGNAL_TYPES
+
+        assert set(self._declared_types()).issuperset(_ARTIFACT_SIGNAL_TYPES)
+
+    def test_verify_task_never_diverges_from_evaluate_signal(self, tmp_path: Path) -> None:
+        """Both paths must agree per signal type -- not just for today's types."""
+        for sig_type in self._pure_types():
+            signal = CompletionSignal(type=sig_type, value="x")  # type: ignore[arg-type]
+            single_passed, single_detail = evaluate_signal(signal, tmp_path)
+
+            task_passed, failed = verify_task(_make_task(signals=[signal]), tmp_path)
+
+            assert task_passed is single_passed, sig_type
+            if single_passed:
+                assert failed == [], sig_type
+            else:
+                assert failed == [f"{sig_type}: x ({single_detail})"], sig_type
+
+    def test_collect_signal_results_agrees_with_verify_task(self, tmp_path: Path) -> None:
+        from bernstein.core.quality.janitor import _ARTIFACT_SIGNAL_TYPES, _collect_signal_results
+
+        for sig_type in sorted(_ARTIFACT_SIGNAL_TYPES):
+            signal = CompletionSignal(type=sig_type, value="x")  # type: ignore[arg-type]
+            task = _make_task(signals=[signal])
+
+            verify_passed, _failed = verify_task(task, tmp_path)
+            results = _collect_signal_results(task, tmp_path)
+
+            assert verify_passed is False, sig_type
+            assert len(results) == 1, sig_type
+            desc, passed, detail = results[0]
+            assert passed is verify_passed, sig_type
+            assert desc == f"{sig_type}: x"
+            assert detail == evaluate_signal(signal, tmp_path)[1]
+
+    @pytest.mark.asyncio
+    async def test_run_janitor_rejects_artifact_only_task(self, tmp_path: Path) -> None:
+        task = _make_task(signals=[CompletionSignal(type="hash_stable", value="sha256:deadbeef")])
+
+        results = await run_janitor([task], tmp_path)
+
+        assert len(results) == 1
+        assert results[0].passed is False
+        assert [desc for desc, ok, _ in results[0].signal_results if not ok] == ["hash_stable: sha256:deadbeef"]
+
+    def test_filesystem_only_task_is_unchanged(self, tmp_path: Path) -> None:
+        from bernstein.core.quality.janitor import _collect_signal_results
+
+        (tmp_path / "out.txt").write_text("done")
+        task = _make_task(signals=[CompletionSignal(type="path_exists", value="out.txt")])
+
+        assert verify_task(task, tmp_path) == (True, [])
+        assert _collect_signal_results(task, tmp_path) == [("path_exists: out.txt", True, "exists")]
+
+    def test_passing_filesystem_signal_does_not_mask_artifact_signal(self, tmp_path: Path) -> None:
+        (tmp_path / "out.txt").write_text("done")
+        task = _make_task(
+            signals=[
+                CompletionSignal(type="path_exists", value="out.txt"),
+                CompletionSignal(type="criteria_match", value="[]"),
+            ]
+        )
+
+        passed, failed = verify_task(task, tmp_path)
+
+        assert passed is False
+        assert len(failed) == 1
+        assert failed[0].startswith("criteria_match: []")
+
+
 class TestFiguresGroundedSignal:
     """Issue #2888: the figures_grounded completion signal and its severity."""
 


### PR DESCRIPTION
Closes #2968

## Problem

`verify_task()` and `_collect_signal_results()` skipped every artifact-mode
completion signal (`schema_valid` / `criteria_match` / `hash_stable` /
`figures_grounded`). A task whose only declared gate was artifact-mode fell
through both loops, `failed` stayed empty, and `verify_task` returned
`(True, [])` — a declared completion gate that silently did not gate.

The skip was written as a deferral to `evaluate_artifact_signals()`, but that
evaluator has no caller on the filesystem verification path, so nothing picked
the signals up. Meanwhile the single-signal `evaluate_signal()` already failed
closed for exactly these types, so two evaluation paths over the same signal
type disagreed on the default.

## Approach

Fail closed (option 1 in the issue), implemented so the two paths cannot
diverge again rather than merely agreeing today:

- `verify_task()` and `_collect_signal_results()` no longer special-case
  artifact-mode types. Both dispatch every signal through `evaluate_signal()`,
  which owns the per-type default; the task-level verdict is now a projection
  of that default instead of a second, independent policy.
- `evaluate_signal()`'s artifact arm reads its membership from
  `_ARTIFACT_SIGNAL_TYPES` instead of re-listing the four types, so adding a
  type to the set cannot leave the arm behind.
- `llm_judge` keeps its skip in `_collect_signal_results()` — `run_janitor()`
  genuinely evaluates it later in the same pass via `judge_task()`. That is a
  deferral with an evaluator; the artifact case was not.

Options 2 and 3 were rejected: a separate "unevaluated" channel changes the
`(bool, list[str])` return shape that four call sites and several tests bind
to, for no behavioural gain over failing closed; rejecting at config time would
make the signal type undeclarable and block the artifact-mode wiring tracked
separately in #2608.

## Caller audit

| Call site | Behaviour with an artifact-only task |
|---|---|
| `core/tasks/task_lifecycle.py:3763,3782` (janitor pass enqueue) | Verdict goes to `_apply_janitor_verdict_action` → retry/fail instead of verified |
| `core/agents/agent_lifecycle.py:2000` (orphaned task after agent death) | No longer auto-completes a task nothing verified |
| `core/tasks/batch_api.py:604` (batch job apply) | Fails the batch job with the signal detail instead of applying it |
| `core/quality/janitor.py:692` (`_collect_signal_results` in `run_janitor`) | Reports the same not-passed result as `verify_task` |

No task in `src/`, `templates/`, or the documented plan schema declares an
artifact-mode signal today, so no current flow turns red. `verify_upgrade_task`
already routed these types through `evaluate_signal()` and so already failed
closed — this change removes the last disagreement.

## Tests

New `TestArtifactSignalDefaultsFailClosed` in `tests/unit/test_janitor.py`:

- a `schema_valid`-only task does not verify as passed, and the failure carries
  the `evaluate_artifact_signals()` detail;
- `verify_task` and `evaluate_signal` return the same verdict for **every**
  declared signal type that can be evaluated without shelling out or calling a
  model — the covered set is derived from the `CompletionSignal` type literal,
  so a newly declared type joins the check automatically;
- `_collect_signal_results` reports the same outcome and detail as
  `verify_task` for each artifact-mode type;
- `run_janitor` rejects an artifact-only task end to end;
- filesystem-only tasks still pass with identical structured results, and a
  passing filesystem signal does not mask a failing artifact one.

Run green (isolated per file): `test_janitor.py` 122 passed, `test_orchestrator.py`
226, `test_regression_orchestrator.py` 103 passed / 7 skipped, `test_manager.py`
78, `tasks/test_lifecycle_helpers.py` 67, `test_task_lifecycle.py` 45,
`test_verification_nudge.py` 44, `test_plan_schema.py` 41,
`tasks/test_models_serialization.py` 40, `test_plan_loader.py` 35,
`tasks/test_artifact_contract.py` 33, `test_retry_or_fail_task.py` 16,
`test_crash_recovery.py` 13 passed / 3 skipped, `tasks/test_report_bundle.py` 13,
`test_mock_adapter.py` 11, `test_signal_actions.py` 9,
`test_checkpoint_retry_wiring.py` 7, `test_janitor_alive_exit.py` 6,
`test_batch_api.py` 6, `test_manager_parsing.py` 6,
`test_dlq_retry_integration.py` 4.

`uv run ruff check .` and `uv run ruff format --check .` clean. `uv run mypy src`
fails identically on `cli/display/gradients.py` before and after this change
(pre-existing, unrelated).

## Docs

`docs/operations/artifacts.md` now states the filesystem verification default
for the four criteria and when it is safe to declare one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Artifact-based verification criteria are no longer incorrectly marked as passed when the artifact cannot be inspected.
  * Tasks that require artifact validation now remain incomplete or fail until the artifact is explicitly evaluated.
  * Verification results are now consistent across task checks and signal collection.

* **Documentation**
  * Clarified when artifact criteria can be evaluated and how unevaluated criteria are reported.
  * Documented the distinction between filesystem-based checks and artifact-based validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->