### PR TITLE
feat(lineage): first-class signed-write path so the v1 recorder can retire

### DIFF
--- a/docs/decisions/009-lineage-v1.md
+++ b/docs/decisions/009-lineage-v1.md
@@ -49,7 +49,7 @@ Agent (in worktree)
   │
   │ writes file foo.py via Bernstein adapter
   ▼
-LineageRecorder.record_write(artefact_path, new_content)
+signed_write.seal_write(artefact_path, new_content)
   │
   │ ① compute content_hash = sha256(new_content)
   │ ② look up current tip(s) of foo.py from tips/<hash-of-path>.json
@@ -69,7 +69,7 @@ OTel span emitted; cross-links to span_id in audit.jsonl
 
 | Component | Module | Lines (target) | Owner agent |
 |---|---|---|---|
-| `LineageRecorder` | `core/lineage/recorder.py` | ~300 | A |
+| Signed-write path (`seal_write` / `SignedLineageLog`) | `core/lineage/signed_write.py` | ~300 | A |
 | Entry schema + JCS canonical | `core/lineage/entry.py` | ~150 | A |
 | Storage / log writer | `core/lineage/store.py` | ~250 | A |
 | Conflict detector + CI gate | `core/lineage/gate.py` | ~200 | B |
@@ -170,7 +170,7 @@ When `bernstein conduct` spawns an agent:
 
 ### 5.2 Signing flow per write
 
-1. Recorder builds entry (without signature).
+1. `seal_write` builds entry (without signature).
 2. Canonicalize per RFC 8785 (JCS).
 3. `entry_hash = sha256(canonical_bytes)`.
 4. `jws = Ed25519-JWS-detached(entry_hash, key=agent.private_key, kid=agent.card.kid)`.
@@ -189,6 +189,39 @@ External auditor (with `bernstein-verify`):
 4. Verifies JWS using card's public key.
 5. Walks `parent_hashes` chain back to genesis.
 6. Verifies tips: every artefact must have exactly one open tip OR a merge entry resolving prior forks.
+
+### 5.4 The supported signed-write API
+
+`bernstein.core.lineage.signed_write` is the only supported way to land a
+signed entry on disk:
+
+| Surface | Use for |
+|---|---|
+| `seal_write(store, operator_hmac_key, *, artefact_path, new_content, ...)` | One-shot signed append. Returns the entry hash. |
+| `SignedLineageLog(store, operator_hmac_key=...)` | The object form, for callers sealing many writes against one store. `record_write(...)` takes the same keyword arguments. |
+
+Both perform the §5.2 flow and hand the `(entry, jws)` pair to
+`LineageStore.append`, which owns the fsync/flock and the sidecar layout of §4.
+
+**Choosing between the signed path and the spine.** `LineageSpine` is the
+always-on Merkle+HMAC provenance chain every adapter artifact write routes
+through; it proves ordering and integrity for a whole run. The signed path
+proves something the spine cannot: an Ed25519 detached JWS verifiable offline
+against a published Agent Card by someone holding no operator secret, an
+operator-HMAC envelope that catches post-signing substitution independently of
+that signature, and a caller-controlled `span_id` that receipt subsystems
+repurpose as a binding digest so receipt-core fields are covered by both. Use
+the spine for run provenance; use `signed_write` when the artefact has to be
+verifiable by a third party. Both substrates ship.
+
+**Deprecated.** `core/lineage/recorder.py::LineageRecorder` is a compatibility
+shim over `SignedLineageLog` and warns on construction;
+`core/persistence/lineage.py::LineageWriter` (WAL-backed) is deprecated for new
+code. Neither is constructed, imported, or used as a type anywhere in `src/`,
+and `tests/unit/lineage/test_spine_deprecations.py` fails CI if that changes.
+The same guard pins `LineageStore.append(entry, jws=...)` to
+`signed_write.py` alone, so a signed write cannot regress onto a deprecated
+substrate without tripping it.
 
 ---
 
@@ -419,7 +452,7 @@ These run as `tests/property/test_lineage_properties.py`:
 ### 12.3 Mutation testing (`mutmut`)
 
 Run on:
-- `core/lineage/recorder.py`
+- `core/lineage/signed_write.py`
 - `core/lineage/gate.py`
 - `core/lineage/store.py`
 - `cli/verify_main.py`

--- a/docs/eval/yaml-harness.md
+++ b/docs/eval/yaml-harness.md
@@ -163,7 +163,7 @@ Every run writes a lineage stub (`*.lineage.json`) next to its JSON output:
 ```
 
 The stub is intentionally minimal so it can be emitted from offline runs
-(no HMAC, no signing material). When wired into `LineageRecorder`, the same
+(no HMAC, no signing material). When wired into the signed-write path, the same
 `artefact_path` + `content_hash` flow into the full lineage log entry.
 
 ## Python API

--- a/docs/memory/cross-task-share.md
+++ b/docs/memory/cross-task-share.md
@@ -37,7 +37,7 @@ Every fact carries the same triple a lineage entry would:
 | `ts_ns` | `int` | Wall-clock nanoseconds at publish time. |
 | `content_hash` | `str` | `sha256:<hex>` over the UTF-8 value bytes. |
 
-This mirrors `bernstein.core.lineage.recorder.LineageRecorder.record_write`, so
+This mirrors `bernstein.core.lineage.signed_write.seal_write`, so
 an auditor can correlate a fact with the lineage entry of the artefact that
 produced it.
 

--- a/docs/operations/nightly-canary.md
+++ b/docs/operations/nightly-canary.md
@@ -34,7 +34,7 @@ tears down. These are the paths the unit suite mocks:
 |------|---------------------|
 | `subprocess_spawn` | `MockAgentAdapter.spawn()` forks a real `subprocess.Popen`; the canary reaps it and asserts a clean exit + a written log |
 | `git_worktree` | `WorktreeManager.create()` runs a real `git worktree add`; `.cleanup()` runs `git worktree remove`; the canary asserts no leftover worktree |
-| `audit_and_lineage` | real HMAC-chained `AuditChainStore` append + `verify()`, then a real Ed25519-signed `LineageRecorder` receipt re-verified through `lineage.gate.check` (the auditor's own gate) |
+| `audit_and_lineage` | real HMAC-chained `AuditChainStore` append + `verify()`, then a real Ed25519-signed `seal_write` receipt re-verified through `lineage.gate.check` (the auditor's own gate) |
 
 Each flow runs independently: one failure does not stop the others, so a
 single run surfaces every broken surface, not just the first.

--- a/scripts/canary_real_run.py
+++ b/scripts/canary_real_run.py
@@ -307,7 +307,7 @@ def flow_audit_and_lineage(*, state_dir: Path) -> None:
       key creation + chaining) and assert ``verify()`` reports an intact
       chain.
     * **Lineage receipt.** Record a real artefact write through
-      :class:`bernstein.core.lineage.recorder.LineageRecorder` (content hash,
+      :class:`bernstein.core.lineage.signed_write.SignedLineageLog` (content hash,
       operator HMAC envelope, Ed25519 detached JWS) and re-verify the emitted
       receipt through :func:`bernstein.core.lineage.gate.check` -- the same
       gate an offline auditor runs. A well-formed receipt is the success
@@ -325,7 +325,7 @@ def flow_audit_and_lineage(*, state_dir: Path) -> None:
 
     from bernstein.core.lineage.gate import check as lineage_check
     from bernstein.core.lineage.identity import AgentCard, generate_keypair
-    from bernstein.core.lineage.recorder import LineageRecorder
+    from bernstein.core.lineage.signed_write import SignedLineageLog
     from bernstein.core.lineage.store import LineageStore
     from bernstein.core.security.audit_chain import AuditChainStore
 
@@ -374,7 +374,7 @@ def flow_audit_and_lineage(*, state_dir: Path) -> None:
     )
 
     store = LineageStore(state_dir / "lineage")
-    recorder = LineageRecorder(store, operator_hmac_key=operator_key)
+    recorder = SignedLineageLog(store, operator_hmac_key=operator_key)
     entry_hash = recorder.record_write(
         artefact_path="canary/output.txt",
         new_content=b"canary artefact bytes",

--- a/src/bernstein/core/agents/computer_use_attestation.py
+++ b/src/bernstein/core/agents/computer_use_attestation.py
@@ -14,7 +14,7 @@ collapses the feature rather than merely losing its log:
 
 * :mod:`bernstein.core.persistence.cas_store` -- the pre-action screenshot bytes
   are stored once by SHA-256 (dedup, byte-exact retrieval on replay).
-* :mod:`bernstein.core.lineage.recorder` / ``store`` -- the action anchor is the
+* :mod:`bernstein.core.lineage.signed_write` / ``store`` -- the action anchor is the
   entry's ``content_hash`` and its ``parent_hashes`` is the prior anchor, so the
   action stream is a single-parent, HMAC-enveloped, Ed25519-signed lineage
   chain. The signed head anchor is the run's identity.
@@ -55,7 +55,7 @@ from bernstein.core.security.audit_chain import (
 
 if TYPE_CHECKING:
     from bernstein.core.lineage.identity import AgentCard
-    from bernstein.core.lineage.recorder import LineageRecorder
+    from bernstein.core.lineage.signed_write import SignedLineageLog
     from bernstein.core.lineage.store import LineageStore
     from bernstein.core.persistence.cas_store import CASStore
     from bernstein.core.security.audit_chain import AuditChainStore
@@ -214,7 +214,7 @@ class ComputerUseSession:
         worktree_id: Worktree the run is isolated to.
         cas: Content-addressed blob store (reused, not re-created).
         audit_chain: Audit chain store.
-        lineage_recorder: The lineage recorder (holds the operator HMAC key).
+        lineage_recorder: The signed lineage log (holds the operator HMAC key).
         agent_card: Agent Card carrying the signing public key id.
         private_key_pem: PEM-encoded Ed25519 private key for the agent.
         run_byte_cap: Per-run cumulative screenshot byte cap.
@@ -228,7 +228,7 @@ class ComputerUseSession:
         worktree_id: str,
         cas: CASStore,
         audit_chain: AuditChainStore,
-        lineage_recorder: LineageRecorder,
+        lineage_recorder: SignedLineageLog,
         agent_card: AgentCard,
         private_key_pem: str,
         run_byte_cap: int = DEFAULT_RUN_BYTE_CAP,

--- a/src/bernstein/core/datasources/receipt.py
+++ b/src/bernstein/core/datasources/receipt.py
@@ -42,7 +42,7 @@ from bernstein.core.datasources.errors import DataSourceError, ReceiptNotFound
 from bernstein.core.datasources.result import NormalizedResult, canonical_bytes, content_hash
 from bernstein.core.lineage.entry import canonicalise, compute_operator_hmac, entry_hash
 from bernstein.core.lineage.identity import AgentCard, verify_detached
-from bernstein.core.lineage.recorder import seal_write
+from bernstein.core.lineage.signed_write import seal_write
 from bernstein.core.lineage.store import LineageStore
 
 if TYPE_CHECKING:
@@ -286,7 +286,7 @@ class QueryReceiptStore:
         artefact_path = _artefact_path(connection.id, qhash, phash)
         # ``span_id`` is deliberately repurposed here: instead of an OTel span
         # context, it carries the receipt-core ``binding`` digest so the binding
-        # is signed and HMAC'd along with the rest of the entry. The seal path
+        # is signed and HMAC'd along with the rest of the entry. ``seal_write``
         # does not consume ``span_id`` for telemetry (it neither opens a span
         # with it nor emits it), so the repurposing has no telemetry side effect.
         lineage_entry_hash = seal_write(

--- a/src/bernstein/core/lineage/__init__.py
+++ b/src/bernstein/core/lineage/__init__.py
@@ -9,9 +9,9 @@ Public API:
   - AgentCard - minimal A2A v1.0 Agent Card subset
   - generate_keypair, sign_detached, verify_detached - Ed25519 JWS RFC 7515
 
-Storage (LineageStore), recorder (LineageRecorder), gate, merge, compliance
-pack, and MCP resource live in sibling modules under this package and re-export
-through here once the corresponding feature branches land.
+Storage (LineageStore), the signed-write path (seal_write / SignedLineageLog),
+gate, merge, compliance pack, and MCP resource live in sibling modules under
+this package and re-export through here.
 """
 
 from bernstein.core.lineage.entry import (
@@ -40,6 +40,7 @@ from bernstein.core.lineage.merge import (
     build_merge_entry,
     resolve_policy,
 )
+from bernstein.core.lineage.signed_write import SignedLineageLog, seal_write
 from bernstein.core.lineage.spine import (
     SPINE_ENTRY_VERSION,
     LineageSpine,
@@ -88,6 +89,7 @@ __all__ = [
     "LineageV2Store",
     "MergePolicy",
     "ParentRef",
+    "SignedLineageLog",
     "SpineEntry",
     "SpineStatus",
     "SpineVerifyResult",
@@ -110,6 +112,7 @@ __all__ = [
     "is_v2_enabled",
     "jws_header_kid",
     "resolve_policy",
+    "seal_write",
     "sign_detached",
     "verify_detached",
     "wrap_adapter",

--- a/src/bernstein/core/lineage/artifact_record.py
+++ b/src/bernstein/core/lineage/artifact_record.py
@@ -1,7 +1,7 @@
 """Record and verify a non-coding artifact as a signed lineage entry (#2608).
 
 Slice 1 gives a non-coding task's output the same guarantees a code diff gets:
-the artifact's canonical bytes are recorded through :class:`LineageRecorder`,
+the artifact's canonical bytes are recorded through the signed-write path,
 so the entry carries an HMAC envelope + Ed25519 detached-JWS signature, and its
 identity is ``content_hash = sha256(canonical_bytes)``. The recorded, signed
 entry *is* the artifact - strip lineage/signing/canonicalisation and there is
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from bernstein.core.lineage.identity import AgentCard
-    from bernstein.core.lineage.recorder import LineageRecorder
+    from bernstein.core.lineage.signed_write import SignedLineageLog
     from bernstein.core.tasks.figures import FiguresVerdict, TokenizerPolicy
 
 #: Logical, repo-relative POSIX prefix under which artifact entries are anchored
@@ -138,7 +138,7 @@ class ArtifactVerifyResult:
 
 def record_artifact(
     *,
-    recorder: LineageRecorder,
+    recorder: SignedLineageLog,
     sink_root: Path,
     task_id: str,
     kind: ArtifactKind | str,
@@ -154,7 +154,7 @@ def record_artifact(
     receipt for the task (the signed lineage-entry hash, not a git SHA).
 
     Args:
-        recorder: The lineage recorder to append the signed entry through.
+        recorder: The signed lineage log to append the signed entry through.
         sink_root: Physical directory the canonical bytes + receipt are written
             under (``<sink_root>/<task_id>/``).
         task_id: The task the artifact completes.

--- a/src/bernstein/core/lineage/merge.py
+++ b/src/bernstein/core/lineage/merge.py
@@ -130,7 +130,7 @@ def build_merge_entry(
 
     The merge entry's ``operator_hmac`` covers the JCS-canonical bytes of the
     entry with the ``operator_hmac`` field blanked - identical to the scheme
-    used by :class:`bernstein.core.lineage.recorder.LineageRecorder` so the
+    used by :func:`bernstein.core.lineage.signed_write.seal_write` so the
     CI gate accepts both kinds of entry under the same operator secret.
 
     Returns a list of `(entry, jws)` pairs. Caller is responsible for appending

--- a/src/bernstein/core/lineage/provenance.py
+++ b/src/bernstein/core/lineage/provenance.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from bernstein.core.lineage.identity import AgentCard
-    from bernstein.core.lineage.recorder import LineageRecorder
+    from bernstein.core.lineage.signed_write import SignedLineageLog
 
 logger = logging.getLogger(__name__)
 
@@ -399,7 +399,7 @@ def _provenance_artefact_path(tool_name: str, content_hash: str) -> str:
 
 
 def record_tool_result(
-    recorder: LineageRecorder,
+    recorder: SignedLineageLog,
     *,
     tool_name: str,
     result_bytes: bytes,
@@ -414,7 +414,7 @@ def record_tool_result(
     """Record a tool result as a signed, content-addressed provenance entry.
 
     Args:
-        recorder: The lineage recorder to append through.
+        recorder: The signed lineage log to append through.
         tool_name: Producing surface (e.g. ``web.fetch``); only namespaces the
             path -- the trust class is authoritative.
         result_bytes: The exact tool-result bytes (content-addressed).

--- a/src/bernstein/core/lineage/recorder.py
+++ b/src/bernstein/core/lineage/recorder.py
@@ -1,272 +1,52 @@
-"""``LineageRecorder`` - orchestrates a single artefact write into the log.
+"""Deprecated v1 ``LineageRecorder`` - compatibility shim only.
 
-The recorder is the small piece of glue between the storage layer
-(``LineageStore``) and the policy that decides what an entry actually
-*means*. It:
+The sealing logic this module used to own now lives in
+:mod:`bernstein.core.lineage.signed_write`, the supported signed-write path
+(:func:`~bernstein.core.lineage.signed_write.seal_write` and
+:class:`~bernstein.core.lineage.signed_write.SignedLineageLog`). Nothing under
+``src/`` constructs :class:`LineageRecorder` or imports it, and the deprecation
+guard (``tests/unit/lineage/test_spine_deprecations.py``) fails CI if that
+changes.
 
-1. Computes ``content_hash = sha256(new_content)``.
-2. Looks up the current tip(s) for the artefact via the store.
-3. Builds a ``LineageEntry`` with the appropriate ``parent_hashes``:
-     * empty list → genesis (first write).
-     * single parent → linear successor.
-     * The caller is responsible for explicit merges; we never invent
-       multi-parent entries on the agent's behalf.
-4. Computes the HMAC envelope with the operator key over the entry's
-   canonical bytes minus the ``operator_hmac`` field itself.
-5. Signs ``entry_hash`` (RFC 7515 + RFC 8037 detached JWS, EdDSA) with
-   the agent's Ed25519 private key.
-6. Hands everything to the store, which fsyncs + flocks the log.
-7. Emits an OpenTelemetry span (no-op when telemetry is not initialised).
+The class survives only so out-of-tree callers and existing test fixtures that
+already hold a recorder keep working. It is a subclass of
+:class:`SignedLineageLog` with no behaviour of its own, so a value produced here
+is byte-identical to one produced by the supported path.
 
-The recorder rejects path traversal and absolute paths so an attacker
-controlling the call site cannot smuggle ``../`` outside the repo or
-anchor an artefact at ``/etc/passwd`` - both surface as ``ValueError``
-before any HMAC or signature is computed.
+This module deliberately does **not** re-export ``seal_write``. Re-exporting the
+sealing primitive from the deprecated module is exactly the bypass issue #2960
+closes: it would let a signed write ride a deprecated import path without
+tripping any guard. Import it from
+:mod:`bernstein.core.lineage.signed_write` instead.
 """
 
 from __future__ import annotations
 
-import hashlib
-import logging
-import time
+import warnings
 from typing import TYPE_CHECKING
 
-from bernstein.core.lineage.entry import LineageEntry, canonicalise, compute_operator_hmac, entry_hash
-from bernstein.core.lineage.identity import sign_detached
+from bernstein.core.lineage.signed_write import SignedLineageLog
 
 if TYPE_CHECKING:
-    from bernstein.core.lineage.identity import AgentCard
     from bernstein.core.lineage.store import LineageStore
 
-logger = logging.getLogger(__name__)
+__all__ = ["LineageRecorder"]
 
 
-def _is_unsafe_path(artefact_path: str) -> str | None:
-    """Return a reason string if the path is unsafe; ``None`` otherwise.
+class LineageRecorder(SignedLineageLog):
+    """Deprecated alias for :class:`SignedLineageLog`.
 
-    Rules:
-
-      * Absolute paths (``/...`` or ``C:\\...``) are rejected - lineage paths
-        are repo-relative POSIX strings.
-      * Any segment equal to ``..`` is rejected (path traversal).
-      * Empty paths are rejected.
-    """
-    if not artefact_path:
-        return "empty artefact_path"
-    # POSIX absolute (`/foo`) or Windows-style drive prefix (`C:\foo`).
-    if artefact_path.startswith("/") or (len(artefact_path) > 2 and artefact_path[1:3] == ":\\"):
-        return "absolute artefact_path not allowed"
-    # Normalise separator-style: lineage canonical is POSIX, so we treat
-    # ``\`` as a separator too for the safety check (defence in depth).
-    segments = artefact_path.replace("\\", "/").split("/")
-    if any(seg == ".." for seg in segments):
-        return "path traversal in artefact_path"
-    return None
-
-
-def seal_write(
-    store: LineageStore,
-    operator_hmac_key: bytes,
-    *,
-    artefact_path: str,
-    new_content: bytes,
-    agent_id: str,
-    agent_card: AgentCard,
-    private_key_pem: str,
-    tool_call_id: str,
-    span_id: str,
-    artefact_kind: str = "file",
-    trust_class: str | None = None,
-    extra_parents: list[str] | None = None,
-    ts_ns: int | None = None,
-) -> str:
-    """Seal a single signed lineage write into ``store``. Returns the entry hash.
-
-    This is the sealing primitive shared by :class:`LineageRecorder` and by the
-    signed-receipt subsystems (datasource query receipts, payment transaction
-    receipts) that anchor their receipts on a v1 :class:`LineageStore` entry -
-    an Ed25519 detached-JWS + operator-HMAC envelope that :func:`verify_detached`
-    and :func:`compute_operator_hmac` re-check offline. Callers use this function
-    instead of instantiating the legacy writer object (issue #2292 AC4 keeps v1
-    writer *construction* out of ``src/``; the underlying signed-append operation
-    stays available here).
-
-    Args mirror :meth:`LineageRecorder.record_write` - see that method for the
-    full field semantics.
-
-    Raises:
-        ValueError: When ``artefact_path`` is absolute or contains a
-            path-traversal segment.
-    """
-    unsafe = _is_unsafe_path(artefact_path)
-    if unsafe is not None:
-        raise ValueError(unsafe)
-
-    content_hash = "sha256:" + hashlib.sha256(new_content).hexdigest()
-    tips = store.tip_set(artefact_path)
-    # Only ever chain to the single current tip. Forks are surfaced upstream;
-    # merges are emitted by the Steward via an explicit multi-parent
-    # ``record_merge`` call (out of scope for v1 core).
-    parent_hashes: list[str] = list(tips.get("open", []))[:1]
-    # Cross-artefact edges (provenance/quarantine lineage) are appended after
-    # the tip parent, preserving order and dropping duplicates so the same
-    # source is never named twice.
-    if extra_parents:
-        for ph in extra_parents:
-            if ph not in parent_hashes:
-                parent_hashes.append(ph)
-
-    entry_ts_ns = time.time_ns() if ts_ns is None else int(ts_ns)
-
-    # Build the entry with an empty ``operator_hmac`` field, compute the
-    # canonical HMAC over its JCS bytes, then materialise the final immutable
-    # entry with the digest. The HMAC binds every field of the entry so a
-    # substitution attack post-signing is caught by both the JWS and the HMAC
-    # envelope independently. The shared :func:`compute_operator_hmac` helper is
-    # the single source of truth used by both recorder and CI gate - see
-    # ADR-009 §5.2.
-    unsigned_entry = LineageEntry(
-        v=1,
-        artefact_path=artefact_path,
-        artefact_kind=artefact_kind,
-        content_hash=content_hash,
-        parent_hashes=parent_hashes,
-        agent_id=agent_id,
-        agent_card_kid=agent_card.kid,
-        tool_call_id=tool_call_id,
-        span_id=span_id,
-        ts_ns=entry_ts_ns,
-        operator_hmac="",
-        trust_class=trust_class,
-    )
-    operator_hmac = compute_operator_hmac(unsigned_entry, operator_hmac_key)
-
-    entry = LineageEntry(
-        v=1,
-        artefact_path=artefact_path,
-        artefact_kind=artefact_kind,
-        content_hash=content_hash,
-        parent_hashes=parent_hashes,
-        agent_id=agent_id,
-        agent_card_kid=agent_card.kid,
-        tool_call_id=tool_call_id,
-        span_id=span_id,
-        ts_ns=entry_ts_ns,
-        operator_hmac=operator_hmac,
-        trust_class=trust_class,
-    )
-
-    # Sign the JCS-canonical entry bytes. The auditor verifies the same bytes
-    # via :func:`bernstein.core.lineage.identity.verify_detached` - see
-    # ADR-009 §5.2.
-    canonical = canonicalise(entry)
-    jws = sign_detached(canonical, private_key_pem, kid=agent_card.kid)
-
-    h = store.append(entry, jws=jws)
-
-    # Best-effort OTel emission. ``start_span`` is a no-op when telemetry has
-    # not been initialised, so this is safe in tests.
-    try:
-        from bernstein.core.observability.telemetry import start_span
-
-        with start_span(
-            "lineage.record_write",
-            attributes={
-                "lineage.artefact_path": artefact_path,
-                "lineage.entry_hash": h,
-                "lineage.agent_id": agent_id,
-                "lineage.tool_call_id": tool_call_id,
-                "lineage.parent_hashes_count": len(parent_hashes),
-            },
-        ):
-            pass
-    except Exception as exc:  # pragma: no cover - telemetry must never break recording
-        logger.debug("lineage OTel span emission failed: %s", exc)
-
-    # Sanity check: the entry hash returned by the store must equal what we'd
-    # recompute from the canonical bytes.
-    assert h == entry_hash(entry), "store.append entry_hash mismatch"
-
-    return h
-
-
-class LineageRecorder:
-    """Build, sign, and persist lineage entries for artefact writes.
-
-    The recorder is stateless other than its dependencies on a ``LineageStore``
-    and the operator HMAC key. Sharing one recorder across threads is safe;
-    serialisation of writes is enforced by the store's flock.
+    Emits a :class:`DeprecationWarning` on construction. Use
+    :class:`bernstein.core.lineage.signed_write.SignedLineageLog` (or the
+    module-level :func:`~bernstein.core.lineage.signed_write.seal_write`) in new
+    code; the on-disk bytes, hashes and signatures are identical either way.
     """
 
-    def __init__(
-        self,
-        store: LineageStore,
-        *,
-        operator_hmac_key: bytes,
-    ) -> None:
-        self.store: LineageStore = store
-        self._hmac_key: bytes = operator_hmac_key
-
-    def record_write(
-        self,
-        *,
-        artefact_path: str,
-        new_content: bytes,
-        agent_id: str,
-        agent_card: AgentCard,
-        private_key_pem: str,
-        tool_call_id: str,
-        span_id: str,
-        artefact_kind: str = "file",
-        trust_class: str | None = None,
-        extra_parents: list[str] | None = None,
-        ts_ns: int | None = None,
-    ) -> str:
-        """Record a single artefact write. Returns the entry hash.
-
-        Args:
-            artefact_path: Repo-relative POSIX path of the artefact written.
-            new_content: The bytes that just landed on disk.
-            agent_id: Bernstein agent slug (e.g. ``agent:claude-worker-3``).
-            agent_card: Agent Card with the public key the auditor will use.
-            private_key_pem: PEM-encoded Ed25519 private key for the agent.
-            tool_call_id: Cross-link to the originating audit entry.
-            span_id: OTel span hex; used both in the entry body and as the
-                child span's parent context when telemetry is enabled.
-            artefact_kind: One of ``ARTEFACT_KINDS``; defaults to ``file``.
-            trust_class: Optional provenance trust class (issue #2513). Set on
-                tool-result records so the signed entry itself carries the
-                label; taint propagation is a projection over these entries.
-            extra_parents: Optional additional ``parent_hashes`` to record on
-                top of the artefact's own tip. This is the cross-artefact
-                lineage edge that anchors a derived artefact (or a quarantine
-                extraction) back to the tainted source it was produced from.
-            ts_ns: Optional deterministic entry timestamp (nanoseconds). When
-                ``None`` (the default, and every existing caller) the wall
-                clock is stamped, preserving byte-identical behaviour. Artifact
-                -mode callers pass a logical timestamp so two operators with
-                equal inputs produce a byte-identical signed entry - the
-                deterministic projection of ``(task, inputs)`` (issue #2608).
-
-        Raises:
-            ValueError: When ``artefact_path`` is absolute or contains a
-                path-traversal segment.
-        """
-        return seal_write(
-            self.store,
-            self._hmac_key,
-            artefact_path=artefact_path,
-            new_content=new_content,
-            agent_id=agent_id,
-            agent_card=agent_card,
-            private_key_pem=private_key_pem,
-            tool_call_id=tool_call_id,
-            span_id=span_id,
-            artefact_kind=artefact_kind,
-            trust_class=trust_class,
-            extra_parents=extra_parents,
-            ts_ns=ts_ns,
+    def __init__(self, store: LineageStore, *, operator_hmac_key: bytes) -> None:
+        warnings.warn(
+            "LineageRecorder is deprecated; use "
+            "bernstein.core.lineage.signed_write.SignedLineageLog (or seal_write) instead",
+            DeprecationWarning,
+            stacklevel=2,
         )
-
-
-__all__ = ["LineageRecorder", "seal_write"]
+        super().__init__(store, operator_hmac_key=operator_hmac_key)

--- a/src/bernstein/core/lineage/signed_write.py
+++ b/src/bernstein/core/lineage/signed_write.py
@@ -1,0 +1,306 @@
+"""The supported signed-lineage write path (Ed25519 detached JWS + operator HMAC).
+
+This module is the single, non-deprecated home for *sealing* a lineage entry:
+computing the content hash, chaining it to the artefact's current tip, wrapping
+it in the operator-HMAC envelope, signing the JCS-canonical bytes with the
+agent's Ed25519 key, and handing the ``(entry, jws)`` pair to
+:class:`~bernstein.core.lineage.store.LineageStore`.
+
+Relationship to :class:`~bernstein.core.lineage.spine.LineageSpine`
+------------------------------------------------------------------
+
+The spine is the always-on Merkle+HMAC provenance chain that every adapter
+artifact write routes through. It is deliberately keyless beyond the operator
+HMAC: it proves *ordering and integrity* for a whole run.
+
+A signed lineage entry proves something the spine cannot: **attributable
+non-repudiation**. It carries
+
+* an Ed25519 detached JWS over the entry's canonical bytes, verifiable offline
+  against a published Agent Card by someone who holds no operator secret;
+* an operator-HMAC envelope over every field, so a substitution attack after
+  signing is caught independently of the signature;
+* a caller-controlled ``span_id``, which the receipt subsystems repurpose as a
+  *binding digest* so receipt-core fields are covered by both the signature and
+  the HMAC.
+
+Those three properties are what the datasource query receipts and the payment
+transaction receipts verify. They are not a superset or a subset of the spine -
+they are a different proof. Both substrates stay, and this module is the
+supported entry point for the signed one.
+
+What is deprecated
+------------------
+
+The *class* wrapper that used to own this logic
+(:class:`bernstein.core.lineage.recorder.LineageRecorder`) is deprecated and
+reduced to a shim over :class:`SignedLineageLog` here; the WAL-backed
+:class:`bernstein.core.persistence.lineage.LineageWriter` is deprecated for new
+code. The signed-append operation itself is not deprecated and lives here.
+``tests/unit/lineage/test_spine_deprecations.py`` enforces that
+:meth:`LineageStore.append` is reached from nowhere else in ``src/``, so a
+signed write cannot silently regress onto a deprecated substrate.
+
+Path safety
+-----------
+
+Absolute paths and ``..`` traversal are rejected before any HMAC or signature
+is computed, so a caller that controls ``artefact_path`` cannot anchor an
+artefact outside the repo.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import time
+from typing import TYPE_CHECKING
+
+from bernstein.core.lineage.entry import LineageEntry, canonicalise, compute_operator_hmac, entry_hash
+from bernstein.core.lineage.identity import sign_detached
+
+if TYPE_CHECKING:
+    from bernstein.core.lineage.identity import AgentCard
+    from bernstein.core.lineage.store import LineageStore
+
+logger = logging.getLogger(__name__)
+
+
+def _is_unsafe_path(artefact_path: str) -> str | None:
+    """Return a reason string if the path is unsafe; ``None`` otherwise.
+
+    Rules:
+
+      * Absolute paths (``/...`` or ``C:\\...``) are rejected - lineage paths
+        are repo-relative POSIX strings.
+      * Any segment equal to ``..`` is rejected (path traversal).
+      * Empty paths are rejected.
+    """
+    if not artefact_path:
+        return "empty artefact_path"
+    # POSIX absolute (`/foo`) or Windows-style drive prefix (`C:\foo`).
+    if artefact_path.startswith("/") or (len(artefact_path) > 2 and artefact_path[1:3] == ":\\"):
+        return "absolute artefact_path not allowed"
+    # Normalise separator-style: lineage canonical is POSIX, so we treat
+    # ``\`` as a separator too for the safety check (defence in depth).
+    segments = artefact_path.replace("\\", "/").split("/")
+    if any(seg == ".." for seg in segments):
+        return "path traversal in artefact_path"
+    return None
+
+
+def seal_write(
+    store: LineageStore,
+    operator_hmac_key: bytes,
+    *,
+    artefact_path: str,
+    new_content: bytes,
+    agent_id: str,
+    agent_card: AgentCard,
+    private_key_pem: str,
+    tool_call_id: str,
+    span_id: str,
+    artefact_kind: str = "file",
+    trust_class: str | None = None,
+    extra_parents: list[str] | None = None,
+    ts_ns: int | None = None,
+) -> str:
+    """Seal a single signed lineage write into ``store``. Returns the entry hash.
+
+    This is the supported signed-write primitive. It:
+
+    1. Computes ``content_hash = sha256(new_content)``.
+    2. Looks up the current tip(s) for the artefact via the store.
+    3. Builds a :class:`~bernstein.core.lineage.entry.LineageEntry` with the
+       appropriate ``parent_hashes`` - empty for genesis, the single current
+       tip for a linear successor, plus any explicit ``extra_parents``. Merges
+       are never invented on the agent's behalf.
+    4. Computes the HMAC envelope with the operator key over the entry's
+       canonical bytes minus the ``operator_hmac`` field itself.
+    5. Signs the canonical bytes (RFC 7515 + RFC 8037 detached JWS, EdDSA) with
+       the agent's Ed25519 private key.
+    6. Hands everything to the store, which fsyncs + flocks the log and writes
+       the ``signatures/<aa>/<full>/<entry-hash>.jws`` sidecar.
+    7. Emits an OpenTelemetry span (no-op when telemetry is not initialised).
+
+    Args:
+        store: The lineage store the entry is appended to.
+        operator_hmac_key: Operator secret for the HMAC envelope.
+        artefact_path: Repo-relative POSIX path of the artefact written.
+        new_content: The bytes that just landed on disk.
+        agent_id: Bernstein agent slug (e.g. ``agent:claude-worker-3``).
+        agent_card: Agent Card with the public key the auditor will use.
+        private_key_pem: PEM-encoded Ed25519 private key for the agent.
+        tool_call_id: Cross-link to the originating audit entry.
+        span_id: OTel span hex; carried verbatim in the signed entry body. The
+            receipt subsystems repurpose it as a receipt-core *binding digest*
+            so those fields are covered by the signature and the HMAC. This
+            function neither opens a span with it nor emits it, so the
+            repurposing has no telemetry side effect.
+        artefact_kind: One of ``ARTEFACT_KINDS``; defaults to ``file``.
+        trust_class: Optional provenance trust class (issue #2513). Set on
+            tool-result records so the signed entry itself carries the label;
+            taint propagation is a projection over these entries.
+        extra_parents: Optional additional ``parent_hashes`` recorded on top of
+            the artefact's own tip. This is the cross-artefact lineage edge that
+            anchors a derived artefact (or a quarantine extraction) back to the
+            tainted source it was produced from.
+        ts_ns: Optional deterministic entry timestamp (nanoseconds). When
+            ``None`` the wall clock is stamped. Artifact-mode callers pass a
+            logical timestamp so two operators with equal inputs produce a
+            byte-identical signed entry - the deterministic projection of
+            ``(task, inputs)`` (issue #2608).
+
+    Raises:
+        ValueError: When ``artefact_path`` is absolute or contains a
+            path-traversal segment.
+    """
+    unsafe = _is_unsafe_path(artefact_path)
+    if unsafe is not None:
+        raise ValueError(unsafe)
+
+    content_hash = "sha256:" + hashlib.sha256(new_content).hexdigest()
+    tips = store.tip_set(artefact_path)
+    # Only ever chain to the single current tip. Forks are surfaced upstream;
+    # merges are emitted by the Steward via an explicit multi-parent
+    # ``record_merge`` call (out of scope for v1 core).
+    parent_hashes: list[str] = list(tips.get("open", []))[:1]
+    # Cross-artefact edges (provenance/quarantine lineage) are appended after
+    # the tip parent, preserving order and dropping duplicates so the same
+    # source is never named twice.
+    if extra_parents:
+        for ph in extra_parents:
+            if ph not in parent_hashes:
+                parent_hashes.append(ph)
+
+    entry_ts_ns = time.time_ns() if ts_ns is None else int(ts_ns)
+
+    # Build the entry with an empty ``operator_hmac`` field, compute the
+    # canonical HMAC over its JCS bytes, then materialise the final immutable
+    # entry with the digest. The HMAC binds every field of the entry so a
+    # substitution attack post-signing is caught by both the JWS and the HMAC
+    # envelope independently. The shared :func:`compute_operator_hmac` helper is
+    # the single source of truth used by both this path and the CI gate - see
+    # ADR-009 §5.2.
+    unsigned_entry = LineageEntry(
+        v=1,
+        artefact_path=artefact_path,
+        artefact_kind=artefact_kind,
+        content_hash=content_hash,
+        parent_hashes=parent_hashes,
+        agent_id=agent_id,
+        agent_card_kid=agent_card.kid,
+        tool_call_id=tool_call_id,
+        span_id=span_id,
+        ts_ns=entry_ts_ns,
+        operator_hmac="",
+        trust_class=trust_class,
+    )
+    operator_hmac = compute_operator_hmac(unsigned_entry, operator_hmac_key)
+
+    entry = LineageEntry(
+        v=1,
+        artefact_path=artefact_path,
+        artefact_kind=artefact_kind,
+        content_hash=content_hash,
+        parent_hashes=parent_hashes,
+        agent_id=agent_id,
+        agent_card_kid=agent_card.kid,
+        tool_call_id=tool_call_id,
+        span_id=span_id,
+        ts_ns=entry_ts_ns,
+        operator_hmac=operator_hmac,
+        trust_class=trust_class,
+    )
+
+    # Sign the JCS-canonical entry bytes. The auditor verifies the same bytes
+    # via :func:`bernstein.core.lineage.identity.verify_detached` - see
+    # ADR-009 §5.2.
+    canonical = canonicalise(entry)
+    jws = sign_detached(canonical, private_key_pem, kid=agent_card.kid)
+
+    h = store.append(entry, jws=jws)
+
+    # Best-effort OTel emission. ``start_span`` is a no-op when telemetry has
+    # not been initialised, so this is safe in tests.
+    try:
+        from bernstein.core.observability.telemetry import start_span
+
+        with start_span(
+            "lineage.record_write",
+            attributes={
+                "lineage.artefact_path": artefact_path,
+                "lineage.entry_hash": h,
+                "lineage.agent_id": agent_id,
+                "lineage.tool_call_id": tool_call_id,
+                "lineage.parent_hashes_count": len(parent_hashes),
+            },
+        ):
+            pass
+    except Exception as exc:  # pragma: no cover - telemetry must never break recording
+        logger.debug("lineage OTel span emission failed: %s", exc)
+
+    # Sanity check: the entry hash returned by the store must equal what we'd
+    # recompute from the canonical bytes.
+    assert h == entry_hash(entry), "store.append entry_hash mismatch"
+
+    return h
+
+
+class SignedLineageLog:
+    """A lineage store bound to an operator key, writing signed entries.
+
+    The supported object form of :func:`seal_write`, for callers that seal many
+    writes against one store and one operator secret (the artifact sink, the
+    provenance recorder, the computer-use attestor). It is stateless beyond its
+    two dependencies; sharing one instance across threads is safe because
+    serialisation of writes is enforced by the store's ``flock``.
+    """
+
+    def __init__(
+        self,
+        store: LineageStore,
+        *,
+        operator_hmac_key: bytes,
+    ) -> None:
+        self.store: LineageStore = store
+        self._hmac_key: bytes = operator_hmac_key
+
+    def record_write(
+        self,
+        *,
+        artefact_path: str,
+        new_content: bytes,
+        agent_id: str,
+        agent_card: AgentCard,
+        private_key_pem: str,
+        tool_call_id: str,
+        span_id: str,
+        artefact_kind: str = "file",
+        trust_class: str | None = None,
+        extra_parents: list[str] | None = None,
+        ts_ns: int | None = None,
+    ) -> str:
+        """Seal one artefact write into the bound store. Returns the entry hash.
+
+        Arguments and failure modes are exactly those of :func:`seal_write`;
+        ``store`` and ``operator_hmac_key`` come from the instance.
+        """
+        return seal_write(
+            self.store,
+            self._hmac_key,
+            artefact_path=artefact_path,
+            new_content=new_content,
+            agent_id=agent_id,
+            agent_card=agent_card,
+            private_key_pem=private_key_pem,
+            tool_call_id=tool_call_id,
+            span_id=span_id,
+            artefact_kind=artefact_kind,
+            trust_class=trust_class,
+            extra_parents=extra_parents,
+            ts_ns=ts_ns,
+        )
+
+
+__all__ = ["SignedLineageLog", "seal_write"]

--- a/src/bernstein/core/memory/cross_task_kb.py
+++ b/src/bernstein/core/memory/cross_task_kb.py
@@ -10,7 +10,7 @@ This module is a thin facade. It does not introduce new storage. Every fact is
 persisted as a row in the existing ``memory`` table with ``type='cross_task'``
 and an extra ``cross_task_meta`` row carrying the lineage-style attribution
 triple ``(producer_task_id, ts_ns, content_hash)``. That mirrors the pattern
-used by :mod:`bernstein.core.lineage.recorder` for artefact writes.
+used by :mod:`bernstein.core.lineage.signed_write` for artefact writes.
 
 Two scopes are supported, both single-host:
 

--- a/src/bernstein/core/orchestration/phase_gate_lineage.py
+++ b/src/bernstein/core/orchestration/phase_gate_lineage.py
@@ -18,25 +18,18 @@ Boundary entry mapped onto :meth:`LineageSpine.record`::
     model         -> phase id
     timestamp     -> caller-supplied stable int (default 0)
 
-The legacy :func:`make_lineage_hook` (v1 ``LineageWriter``) is retained for
-tests and out-of-tree callers that already hold a writer; it is never
-constructed inside ``src/``.
+The v1 WAL-backed hook that used to live here has been retired (issue #2960):
+nothing under ``src/`` names or types against the deprecated
+``bernstein.core.persistence.lineage.LineageWriter`` any more.
 """
 
 from __future__ import annotations
 
 import hashlib
 import json
-import time
 from typing import TYPE_CHECKING, Any
 
 from bernstein.core.lineage.spine import LineageSpine
-from bernstein.core.persistence.lineage import (
-    AgentRef,
-    ArtifactRef,
-    LineageRecord,
-    hash_file,
-)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -44,11 +37,7 @@ if TYPE_CHECKING:
 
     from bernstein.core.orchestration.phase_gates import GateResult
     from bernstein.core.orchestration.phase_pipeline import Phase
-    from bernstein.core.persistence.lineage import LineageWriter
     from bernstein.core.tasks.models import Task
-
-
-PHASE_GATE_REGULATORY_CLASS = "phase_gate"
 
 
 def gate_results_summary(results: list[GateResult]) -> dict[str, Any]:
@@ -117,76 +106,6 @@ def _boundary_content(
         "rules": [{"rule_id": r.rule_id, "outcome": r.outcome.value} for r in results],
     }
     return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
-
-
-def build_phase_gate_record(
-    *,
-    task: Task,
-    phase: Phase,
-    boundary: tuple[Phase, Phase],
-    results: list[GateResult],
-    artifact_path: Path,
-) -> LineageRecord:
-    """Build a :class:`LineageRecord` for a single boundary evaluation."""
-    output_ref = ArtifactRef(
-        path=str(artifact_path),
-        sha256=hash_file(artifact_path),
-    )
-    return LineageRecord(
-        output_artifact=output_ref,
-        inputs=[],
-        producer=AgentRef(
-            agent_id=f"phase_gate:{phase.value}",
-            run_id=task.id,
-            tick_id=f"{boundary[0].value}->{boundary[1].value}",
-        ),
-        prompt_sha=_prompt_sha(results),
-        model=phase.value,
-        cost_usd=0.0,
-        tokens=0,
-        timestamp=time.time(),
-        regulatory_class=PHASE_GATE_REGULATORY_CLASS,
-    )
-
-
-def make_lineage_hook(
-    writer: LineageWriter,
-    *,
-    artifact_path_resolver: Callable[[Task, Phase], Path] | None = None,
-) -> Any:
-    """Return a hook usable as :attr:`PhasedRunner.gate_lineage_hook`.
-
-    The closure captures *writer* and the optional resolver so callers
-    don't have to thread the writer through the runner constructor.
-
-    Args:
-        writer: WAL-backed lineage writer for the active run.
-        artifact_path_resolver: Optional callable mapping
-            ``(task, phase) -> Path`` to override the default
-            ``.sdd/runtime/phase_artifacts/<task_id>/<phase>.json`` lookup.
-    """
-    from pathlib import Path as _Path
-
-    def _hook(
-        task: Task,
-        phase: Phase,
-        boundary: tuple[Phase, Phase],
-        results: list[GateResult],
-    ) -> None:
-        if artifact_path_resolver is not None:
-            artifact_path = artifact_path_resolver(task, phase)
-        else:
-            artifact_path = _Path(".sdd/runtime/phase_artifacts") / task.id / f"{phase.value}.json"
-        record = build_phase_gate_record(
-            task=task,
-            phase=phase,
-            boundary=boundary,
-            results=results,
-            artifact_path=artifact_path,
-        )
-        writer.emit(record, actor=f"phase_gate:{phase.value}")
-
-    return _hook
 
 
 def make_spine_lineage_hook(
@@ -392,11 +311,8 @@ def build_phased_runner_with_gate_lineage(
 
 
 __all__ = [
-    "PHASE_GATE_REGULATORY_CLASS",
-    "build_phase_gate_record",
     "build_phased_runner_with_gate_lineage",
     "gate_results_summary",
     "make_adjudication_hook",
-    "make_lineage_hook",
     "make_spine_lineage_hook",
 ]

--- a/src/bernstein/core/payments/receipt.py
+++ b/src/bernstein/core/payments/receipt.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING
 
 from bernstein.core.lineage.entry import LineageEntry, canonicalise, compute_operator_hmac, entry_hash
 from bernstein.core.lineage.identity import AgentCard, verify_detached
-from bernstein.core.lineage.recorder import seal_write
+from bernstein.core.lineage.signed_write import seal_write
 from bernstein.core.lineage.store import LineageStore
 from bernstein.core.security.agent_card_signer import canonicalize_jcs
 from bernstein.core.security.audit_chain import (

--- a/tests/property/test_normalize_path_properties.py
+++ b/tests/property/test_normalize_path_properties.py
@@ -7,7 +7,7 @@ Bernstein has two related path safety surfaces:
    args, gitignore patterns, etc. Bugs here surface as broken path
    matching on either platform.
 
-2. ``bernstein.core.lineage.recorder._is_unsafe_path`` - the
+2. ``bernstein.core.lineage.signed_write._is_unsafe_path`` - the
    defence-in-depth check that rejects absolute and traversal
    artefact paths before they reach disk. A regression here is a
    direct path-traversal vulnerability (the recorder could write
@@ -40,7 +40,7 @@ from hypothesis import assume, given
 from hypothesis import strategies as st
 
 from bernstein.core.config.platform_compat import normalize_path
-from bernstein.core.lineage.recorder import _is_unsafe_path
+from bernstein.core.lineage.signed_write import _is_unsafe_path
 
 _SAFE_SEG = st.text(
     alphabet=st.characters(

--- a/tests/unit/cli/test_artifact_verify_cmd.py
+++ b/tests/unit/cli/test_artifact_verify_cmd.py
@@ -10,7 +10,7 @@ from click.testing import CliRunner
 from bernstein.cli.main import cli
 from bernstein.core.lineage.artifact_record import record_artifact
 from bernstein.core.lineage.identity import AgentCard, generate_keypair
-from bernstein.core.lineage.recorder import LineageRecorder
+from bernstein.core.lineage.signed_write import SignedLineageLog
 from bernstein.core.lineage.store import LineageStore
 from bernstein.core.tasks.artifacts import ArtifactKind
 
@@ -24,7 +24,7 @@ def _seed_artifact(workdir: Path, task_id: str, artifact: object) -> None:
     priv_pem, pub_pem = generate_keypair()
     card = AgentCard(agent_id="agent:worker", kid="key-001", public_key_pem=pub_pem)
     record_artifact(
-        recorder=LineageRecorder(store=LineageStore(sdd / "lineage"), operator_hmac_key=_SECRET.encode("utf-8")),
+        recorder=SignedLineageLog(store=LineageStore(sdd / "lineage"), operator_hmac_key=_SECRET.encode("utf-8")),
         sink_root=sdd / "artifacts",
         task_id=task_id,
         kind=ArtifactKind.OPS_RESULT,
@@ -108,7 +108,7 @@ def _seed_report(workdir: Path, task_id: str, body: str) -> None:
     sdd = workdir / ".sdd"
     priv_pem, pub_pem = generate_keypair()
     card = AgentCard(agent_id="agent:worker", kid="key-001", public_key_pem=pub_pem)
-    rec = LineageRecorder(store=LineageStore(sdd / "lineage"), operator_hmac_key=_SECRET.encode("utf-8"))
+    rec = SignedLineageLog(store=LineageStore(sdd / "lineage"), operator_hmac_key=_SECRET.encode("utf-8"))
     src = record_artifact(
         recorder=rec,
         sink_root=sdd / "artifacts",

--- a/tests/unit/lineage/test_artifact_record.py
+++ b/tests/unit/lineage/test_artifact_record.py
@@ -27,7 +27,7 @@ from bernstein.core.lineage.artifact_record import (
     verify_artifact,
 )
 from bernstein.core.lineage.identity import AgentCard, generate_keypair
-from bernstein.core.lineage.recorder import LineageRecorder
+from bernstein.core.lineage.signed_write import SignedLineageLog
 from bernstein.core.lineage.store import LineageStore
 from bernstein.core.tasks.artifacts import ArtifactKind
 
@@ -42,8 +42,8 @@ def identity() -> tuple[AgentCard, str]:
     return card, priv_pem
 
 
-def _recorder(root: Path) -> LineageRecorder:
-    return LineageRecorder(store=LineageStore(root / "lineage"), operator_hmac_key=_HMAC_KEY)
+def _recorder(root: Path) -> SignedLineageLog:
+    return SignedLineageLog(store=LineageStore(root / "lineage"), operator_hmac_key=_HMAC_KEY)
 
 
 def _write_card(cards_dir: Path, card: AgentCard) -> None:
@@ -122,7 +122,7 @@ def _record_and_paths(tmp_path: Path, card: AgentCard, priv: str, artifact: obje
     log_root = tmp_path / "lineage"
     cards_dir = tmp_path / "cards"
     record_artifact(
-        recorder=LineageRecorder(store=LineageStore(log_root), operator_hmac_key=_HMAC_KEY),
+        recorder=SignedLineageLog(store=LineageStore(log_root), operator_hmac_key=_HMAC_KEY),
         sink_root=sink_root,
         task_id="T-9",
         kind=ArtifactKind.OPS_RESULT,

--- a/tests/unit/lineage/test_figure_grounding.py
+++ b/tests/unit/lineage/test_figure_grounding.py
@@ -19,7 +19,7 @@ import pytest
 from bernstein.core.lineage.artifact_record import record_artifact
 from bernstein.core.lineage.figure_grounding import LineageAnchorResolver, verify_report_figures
 from bernstein.core.lineage.identity import AgentCard, generate_keypair
-from bernstein.core.lineage.recorder import LineageRecorder
+from bernstein.core.lineage.signed_write import SignedLineageLog
 from bernstein.core.lineage.store import LineageStore
 from bernstein.core.tasks.artifacts import ArtifactKind
 from bernstein.core.tasks.figures import (
@@ -52,7 +52,7 @@ def _seed_source(tmp_path: Path, card: AgentCard, priv: str, rows: object) -> tu
     log_root = tmp_path / "lineage"
     cards_dir = tmp_path / "cards"
     receipt = record_artifact(
-        recorder=LineageRecorder(store=LineageStore(log_root), operator_hmac_key=_HMAC),
+        recorder=SignedLineageLog(store=LineageStore(log_root), operator_hmac_key=_HMAC),
         sink_root=tmp_path / "artifacts",
         task_id="SRC-1",
         kind=ArtifactKind.DATASET,
@@ -167,7 +167,7 @@ def _seed_report_and_source(
 
     sdd = tmp_path / ".sdd"
     store = LineageStore(sdd / "lineage")
-    rec = LineageRecorder(store=store, operator_hmac_key=_HMAC)
+    rec = SignedLineageLog(store=store, operator_hmac_key=_HMAC)
     src = record_artifact(
         recorder=rec,
         sink_root=sdd / "artifacts",

--- a/tests/unit/lineage/test_gate.py
+++ b/tests/unit/lineage/test_gate.py
@@ -384,7 +384,7 @@ def test_gate_accepts_recorder_emitted_entries_under_operator_secret(tmp_path: P
     recorder output failed 100% of entries. Pin the agreement end-to-end.
     """
     from bernstein.core.lineage.identity import generate_keypair
-    from bernstein.core.lineage.recorder import LineageRecorder
+    from bernstein.core.lineage.signed_write import SignedLineageLog
     from bernstein.core.lineage.store import LineageStore
 
     priv, pub = generate_keypair()
@@ -405,7 +405,7 @@ def test_gate_accepts_recorder_emitted_entries_under_operator_secret(tmp_path: P
 
     operator_secret = b"recorder-gate-shared-secret"
     store = LineageStore(tmp_path / "lineage")
-    recorder = LineageRecorder(store=store, operator_hmac_key=operator_secret)
+    recorder = SignedLineageLog(store=store, operator_hmac_key=operator_secret)
     recorder.record_write(
         artefact_path="src/foo.py",
         new_content=b"hello",

--- a/tests/unit/lineage/test_provenance.py
+++ b/tests/unit/lineage/test_provenance.py
@@ -32,7 +32,7 @@ from bernstein.core.lineage.provenance import (
     trust_class_for_source,
     trust_rank,
 )
-from bernstein.core.lineage.recorder import LineageRecorder
+from bernstein.core.lineage.signed_write import SignedLineageLog
 from bernstein.core.lineage.store import LineageStore
 
 # ---------------------------------------------------------------------------
@@ -256,8 +256,8 @@ def test_default_map_used_when_none_passed() -> None:
 
 
 @pytest.fixture
-def recorder(tmp_path: Path) -> LineageRecorder:
-    return LineageRecorder(store=LineageStore(tmp_path / "lineage"), operator_hmac_key=b"0" * 64)
+def recorder(tmp_path: Path) -> SignedLineageLog:
+    return SignedLineageLog(store=LineageStore(tmp_path / "lineage"), operator_hmac_key=b"0" * 64)
 
 
 @pytest.fixture
@@ -267,7 +267,7 @@ def card_and_key() -> tuple[AgentCard, str]:
 
 
 def test_record_tool_result_writes_a_provenance_lineage_entry(
-    recorder: LineageRecorder,
+    recorder: SignedLineageLog,
     card_and_key: tuple[AgentCard, str],
 ) -> None:
     card, priv = card_and_key
@@ -298,7 +298,7 @@ def test_record_tool_result_writes_a_provenance_lineage_entry(
 
 
 def test_taint_for_artefact_resolves_latest_tip(
-    recorder: LineageRecorder,
+    recorder: SignedLineageLog,
     card_and_key: tuple[AgentCard, str],
 ) -> None:
     card, priv = card_and_key

--- a/tests/unit/lineage/test_signed_write.py
+++ b/tests/unit/lineage/test_signed_write.py
@@ -1,6 +1,7 @@
-"""Tests for `LineageRecorder` - the full record_write pipeline.
+"""Tests for the supported signed-lineage write path (issue #2960).
 
-These cover the orchestration the recorder performs on top of `LineageStore`:
+These cover the orchestration ``SignedLineageLog`` / ``seal_write`` perform on
+top of `LineageStore`:
 
   * content_hash computed from the bytes about to be written.
   * Tip lookup → parent_hashes wired correctly (genesis vs successor).
@@ -23,7 +24,7 @@ from bernstein.core.lineage.identity import (
     generate_keypair,
     verify_detached,
 )
-from bernstein.core.lineage.recorder import LineageRecorder
+from bernstein.core.lineage.signed_write import SignedLineageLog
 from bernstein.core.lineage.store import LineageStore
 
 
@@ -41,8 +42,8 @@ def card_and_keys() -> tuple[AgentCard, str]:
 
 
 @pytest.fixture
-def recorder(tmp_path: Path, hmac_key: bytes) -> LineageRecorder:
-    return LineageRecorder(store=LineageStore(tmp_path / "lineage"), operator_hmac_key=hmac_key)
+def recorder(tmp_path: Path, hmac_key: bytes) -> SignedLineageLog:
+    return SignedLineageLog(store=LineageStore(tmp_path / "lineage"), operator_hmac_key=hmac_key)
 
 
 # ---------------------------------------------------------------------------
@@ -52,7 +53,7 @@ def recorder(tmp_path: Path, hmac_key: bytes) -> LineageRecorder:
 
 def test_genesis_write_creates_entry_with_no_parents(
     tmp_path: Path,
-    recorder: LineageRecorder,
+    recorder: SignedLineageLog,
     card_and_keys: tuple[AgentCard, str],
 ) -> None:
     card, priv = card_and_keys
@@ -77,7 +78,7 @@ def test_genesis_write_creates_entry_with_no_parents(
 
 
 def test_successor_write_parents_chain_to_prior_tip(
-    recorder: LineageRecorder,
+    recorder: SignedLineageLog,
     card_and_keys: tuple[AgentCard, str],
 ) -> None:
     card, priv = card_and_keys
@@ -106,7 +107,7 @@ def test_successor_write_parents_chain_to_prior_tip(
 
 
 def test_writes_to_distinct_artefacts_are_independent(
-    recorder: LineageRecorder,
+    recorder: SignedLineageLog,
     card_and_keys: tuple[AgentCard, str],
 ) -> None:
     card, priv = card_and_keys
@@ -141,7 +142,7 @@ def test_writes_to_distinct_artefacts_are_independent(
 
 
 def test_recorded_jws_verifies_against_card(
-    recorder: LineageRecorder,
+    recorder: SignedLineageLog,
     card_and_keys: tuple[AgentCard, str],
 ) -> None:
     card, priv = card_and_keys
@@ -155,13 +156,13 @@ def test_recorded_jws_verifies_against_card(
         span_id="span-1",
     )
     entry, jws = next(iter(recorder.store.read_log()))
-    # The recorder signs the JCS-canonical entry bytes; the verifier (gate)
+    # The signed-write path signs the JCS-canonical entry bytes; the verifier (gate)
     # recomputes the same bytes - see ADR-009 §5.2.
     assert verify_detached(canonicalise(entry), jws, card) is True
 
 
 def test_signature_does_not_verify_against_wrong_card(
-    recorder: LineageRecorder,
+    recorder: SignedLineageLog,
     card_and_keys: tuple[AgentCard, str],
 ) -> None:
     card, priv = card_and_keys
@@ -186,7 +187,7 @@ def test_signature_does_not_verify_against_wrong_card(
 
 
 def test_operator_hmac_matches_recomputed_envelope(
-    recorder: LineageRecorder,
+    recorder: SignedLineageLog,
     card_and_keys: tuple[AgentCard, str],
     hmac_key: bytes,
 ) -> None:
@@ -215,7 +216,7 @@ def test_operator_hmac_matches_recomputed_envelope(
 
 
 def test_operator_hmac_differs_under_tamper(
-    recorder: LineageRecorder,
+    recorder: SignedLineageLog,
     card_and_keys: tuple[AgentCard, str],
     hmac_key: bytes,
 ) -> None:
@@ -245,7 +246,7 @@ def test_operator_hmac_differs_under_tamper(
 
 
 def test_rejects_path_traversal(
-    recorder: LineageRecorder,
+    recorder: SignedLineageLog,
     card_and_keys: tuple[AgentCard, str],
 ) -> None:
     card, priv = card_and_keys
@@ -262,7 +263,7 @@ def test_rejects_path_traversal(
 
 
 def test_rejects_absolute_path(
-    recorder: LineageRecorder,
+    recorder: SignedLineageLog,
     card_and_keys: tuple[AgentCard, str],
 ) -> None:
     card, priv = card_and_keys
@@ -286,7 +287,7 @@ def test_rejects_absolute_path(
 def entry_hash_payload(canonical_bytes: bytes) -> bytes:
     """Legacy helper retained for back-compat with older test imports.
 
-    The recorder now signs the JCS-canonical entry bytes directly so callers
+    The signed-write path signs the JCS-canonical entry bytes directly so callers
     should pass ``canonicalise(entry)`` to ``verify_detached``; this helper
     is kept so external test modules that import it keep working.
     """

--- a/tests/unit/lineage/test_signed_write_golden.py
+++ b/tests/unit/lineage/test_signed_write_golden.py
@@ -1,0 +1,367 @@
+"""Golden: the signed-lineage write path stays byte-identical to the v1 recorder.
+
+Issue #2960 moved the sealing body out of the deprecated
+:mod:`bernstein.core.lineage.recorder` into the supported
+:mod:`bernstein.core.lineage.signed_write`. The security model is the on-disk
+bytes, so "byte-identical" is the acceptance criterion, not a nice-to-have: a
+lineage entry whose canonical pre-image shifted by one byte invalidates every
+signature and every operator HMAC previously written against it, and every
+receipt anchored on one.
+
+The fixtures below were captured by running the *pre-migration*
+``LineageRecorder.record_write`` against pinned inputs, and are pinned verbatim.
+Every byte the store lays down has to reproduce: the JCS log line, the operator
+HMAC inside it, the Ed25519 detached-JWS sidecar, the tip projection and the
+per-artefact projection.
+
+Ed25519 (RFC 8032) signs deterministically, so with a pinned key, pinned inputs
+and a pinned ``ts_ns`` the signature bytes are themselves a golden value - a
+drift in the canonical pre-image surfaces as a different JWS rather than as a
+flake.
+
+The four pinned writes cover both migrated receipt shapes plus the chaining
+behaviour they depend on:
+
+* a genesis ``query-result`` entry and its linear successor on the same artefact
+  (the datasource query-receipt shape, ``span_id`` carrying a binding digest),
+* an ``sdd-runtime`` entry with the all-zero span (the payment-receipt shape),
+* a ``tool-result`` entry with a ``trust_class`` and a cross-artefact
+  ``extra_parents`` edge.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from bernstein.core.datasources.connection import DataSourceConnection
+from bernstein.core.datasources.receipt import QueryReceiptStore
+from bernstein.core.lineage import signed_write as signed_write_module
+from bernstein.core.lineage.entry import canonicalise, entry_hash
+from bernstein.core.lineage.identity import AgentCard, verify_detached
+from bernstein.core.lineage.signed_write import SignedLineageLog, seal_write
+from bernstein.core.lineage.store import LineageStore
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+# --- pinned identity --------------------------------------------------------
+
+_PRIVATE_PEM = "-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIAABAgMEBQYHCAkKCwwNDg8QERITFBUWFxgZGhscHR4f\n-----END PRIVATE KEY-----\n"
+
+_PUBLIC_PEM = "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAA6EHv/POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg=\n-----END PUBLIC KEY-----\n"
+
+_CARD = AgentCard(agent_id="agent:golden", kid="golden-kid-1", public_key_pem=_PUBLIC_PEM)
+_AGENT_ID = "agent:golden"
+_OPERATOR_KEY = b"golden-operator-hmac-key-32bytes"
+_FIXED_NS = 1_700_000_000_000_000_001
+
+# --- pinned writes ----------------------------------------------------------
+
+_WRITES: list[dict[str, Any]] = [
+    {
+        "artefact_path": ".sdd/datasources/queries/sales/aaaa_bbbb.jsonl",
+        "new_content": b'{"rows":[[1,"a"]]}',
+        "tool_call_id": "query:sales",
+        "span_id": "b" * 64,
+        "artefact_kind": "query-result",
+        "trust_class": None,
+        "extra_parents": None,
+        "ts_ns": 1_700_000_000_000_000_001,
+    },
+    {
+        "artefact_path": ".sdd/datasources/queries/sales/aaaa_bbbb.jsonl",
+        "new_content": b'{"rows":[[1,"a"],[2,"b"]]}',
+        "tool_call_id": "query:sales",
+        "span_id": "c" * 64,
+        "artefact_kind": "query-result",
+        "trust_class": None,
+        "extra_parents": None,
+        "ts_ns": 1_700_000_000_000_000_002,
+    },
+    {
+        "artefact_path": ".sdd/payments/receipts/deadbeef.json",
+        "new_content": b'{"decision":"authorized"}',
+        "tool_call_id": "sha256:deadbeef",
+        "span_id": "0" * 16,
+        "artefact_kind": "sdd-runtime",
+        "trust_class": None,
+        "extra_parents": None,
+        "ts_ns": 1_700_000_000_000_000_003,
+    },
+    {
+        "artefact_path": "provenance/web-fetch/0123456789abcdef",
+        "new_content": b"tool result bytes",
+        "tool_call_id": "tc-1",
+        "span_id": "d" * 16,
+        "artefact_kind": "tool-result",
+        "trust_class": "third_party",
+        "extra_parents": ["sha256:" + "f" * 64],
+        "ts_ns": 1_700_000_000_000_000_004,
+    },
+]
+
+# --- golden values captured from the pre-migration recorder -----------------
+
+_GOLDEN_ENTRY_HASHES = [
+    "sha256:deb1afd74f366ab843b81bc3870f11abb66dffa7517fdd52971c7abc52b3971e",
+    "sha256:595bbbf0912273eb1d888d439b8f5fa506303678aedaddfcebdf81cd4e241fa9",
+    "sha256:2e0da03cb6c7b885bf42f009d8a7e29bdb1557df6f981be01b91d5fad718b254",
+    "sha256:6a27540503ba199db1228c8fc6de5f8ac963ae0502bb7c68ade41628945fe86e",
+]
+
+_GOLDEN_LOG_JSONL = '{"agent_card_kid":"golden-kid-1","agent_id":"agent:golden","artefact_kind":"query-result","artefact_path":".sdd/datasources/queries/sales/aaaa_bbbb.jsonl","content_hash":"sha256:8fcdff05f0875521ab5e9922ba713607eaffd79d564d7a62cd570d1d895d6a43","operator_hmac":"5ffd67f70fba4f1fc6766ce6ff3dd64a79ed63bde0f34c7c50eae5fd7eb0447a","parent_hashes":[],"span_id":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","tool_call_id":"query:sales","ts_ns":1700000000000000001,"v":1}\n{"agent_card_kid":"golden-kid-1","agent_id":"agent:golden","artefact_kind":"query-result","artefact_path":".sdd/datasources/queries/sales/aaaa_bbbb.jsonl","content_hash":"sha256:66bc805454af11bd3a1a45563821429f23e12827be151676d1a3bcc6775be99b","operator_hmac":"0befc5bd3fd13a2967c923720f1ff771f13fa22d062b9662093d412811c891fe","parent_hashes":["sha256:deb1afd74f366ab843b81bc3870f11abb66dffa7517fdd52971c7abc52b3971e"],"span_id":"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","tool_call_id":"query:sales","ts_ns":1700000000000000002,"v":1}\n{"agent_card_kid":"golden-kid-1","agent_id":"agent:golden","artefact_kind":"sdd-runtime","artefact_path":".sdd/payments/receipts/deadbeef.json","content_hash":"sha256:c29c0017f2b13d5a5eac15adcd8e276c2653aadde40c581a2a95f1e38aa97eaa","operator_hmac":"30dd2d6b55ae336eb84f007cf5e652b0ca45609557a05223f7f9c017a6bff1b7","parent_hashes":[],"span_id":"0000000000000000","tool_call_id":"sha256:deadbeef","ts_ns":1700000000000000003,"v":1}\n{"agent_card_kid":"golden-kid-1","agent_id":"agent:golden","artefact_kind":"tool-result","artefact_path":"provenance/web-fetch/0123456789abcdef","content_hash":"sha256:2bea7a6b2569e1b8b64ee6ef1a6d5fd621f9175083d6508dc5de6511cb7b7bcc","operator_hmac":"28ad1d19bc2119553f7bf8c41b60e82d6c64ed88146cda395639b8579405dd37","parent_hashes":["sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"],"span_id":"dddddddddddddddd","tool_call_id":"tc-1","trust_class":"third_party","ts_ns":1700000000000000004,"v":1}\n'
+
+_GOLDEN_JWS = {
+    "signatures/32/32d9ad089a5f11bea1928e8d74e35d1a69f884506e5d4140470ab0bc7e6c7a12/6a27540503ba199db1228c8fc6de5f8ac963ae0502bb7c68ade41628945fe86e.jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il0sImtpZCI6ImdvbGRlbi1raWQtMSJ9..S7CromjmAur3vBbYR697oKJZNruUqCZjsxRZDtwIxzlo5mLhSo66EcyxQXtZUuJncisr0-NDsKG-aTWDFhSjAw",
+    "signatures/7d/7d7cb30784fd17b481e0ebd6fef60c45d92cef2da5bb7323b6f97e55a47710f8/595bbbf0912273eb1d888d439b8f5fa506303678aedaddfcebdf81cd4e241fa9.jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il0sImtpZCI6ImdvbGRlbi1raWQtMSJ9..E-PLT3H5j28zkRnuZCQNtEc86pXxKCbYrgqmEFgROjY9yxyeCSd6_dh7GojprHJtpFO0G2f2HVExPP5Kcr3lCw",
+    "signatures/7d/7d7cb30784fd17b481e0ebd6fef60c45d92cef2da5bb7323b6f97e55a47710f8/deb1afd74f366ab843b81bc3870f11abb66dffa7517fdd52971c7abc52b3971e.jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il0sImtpZCI6ImdvbGRlbi1raWQtMSJ9..uEG-KnHSQ-XJ6qpi-cULU6DAdDkIXSwhOdIxUxzWmmIXkiDOmW-PlqIQTZUXQ-9Gk-Irigk2tRfOwbRH5kxgBQ",
+    "signatures/90/909fce934e0dbeca05f7cac876d38c25fdd6222357642bc310f4c54226b7a073/2e0da03cb6c7b885bf42f009d8a7e29bdb1557df6f981be01b91d5fad718b254.jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il0sImtpZCI6ImdvbGRlbi1raWQtMSJ9..berhflXYhJh-6eiXL-cmBWCUDjF1YUV12z1xH9SDuFonLCsE4zFkvhyyIrsfCalBCXM4McTTukFb68x1o_mdDw",
+}
+
+_GOLDEN_TIPS = {
+    "tips/32d9ad089a5f11bea1928e8d74e35d1a69f884506e5d4140470ab0bc7e6c7a12.json": '{"merged":[],"open":["sha256:6a27540503ba199db1228c8fc6de5f8ac963ae0502bb7c68ade41628945fe86e"]}',
+    "tips/7d7cb30784fd17b481e0ebd6fef60c45d92cef2da5bb7323b6f97e55a47710f8.json": '{"merged":[],"open":["sha256:595bbbf0912273eb1d888d439b8f5fa506303678aedaddfcebdf81cd4e241fa9"]}',
+    "tips/909fce934e0dbeca05f7cac876d38c25fdd6222357642bc310f4c54226b7a073.json": '{"merged":[],"open":["sha256:2e0da03cb6c7b885bf42f009d8a7e29bdb1557df6f981be01b91d5fad718b254"]}',
+}
+
+_GOLDEN_TREE_SHA256 = {
+    "by-artefact/32/32d9ad089a5f11bea1928e8d74e35d1a69f884506e5d4140470ab0bc7e6c7a12.jsonl": "2f038cad5dcbc30e843855ec3f65317ce8013fc13f58413e3422ac4b6c2c763a",
+    "by-artefact/7d/7d7cb30784fd17b481e0ebd6fef60c45d92cef2da5bb7323b6f97e55a47710f8.jsonl": "48f9d0d5e69d3846f921107fe05fdac5be372410207a75406ffcd7036672b528",
+    "by-artefact/90/909fce934e0dbeca05f7cac876d38c25fdd6222357642bc310f4c54226b7a073.jsonl": "42dd473198cb5a8eb2db323f36cf0ce74882ab07abfddac629852cd0cc39c672",
+    "log.jsonl": "73a6c2fd202fa6a203e7ac95e7988a218de40fe9b81f874a63a897c1a79b1763",
+    "signatures/32/32d9ad089a5f11bea1928e8d74e35d1a69f884506e5d4140470ab0bc7e6c7a12/6a27540503ba199db1228c8fc6de5f8ac963ae0502bb7c68ade41628945fe86e.jws": "a74c5b9957fb04ac84b4e2f3d23891b8bd9de6abc7dd080959ea8f084bd4e655",
+    "signatures/7d/7d7cb30784fd17b481e0ebd6fef60c45d92cef2da5bb7323b6f97e55a47710f8/595bbbf0912273eb1d888d439b8f5fa506303678aedaddfcebdf81cd4e241fa9.jws": "e76edf83be23339db0a74f992f5a1b2f8e3784f64104aeb56690d649c57fa343",
+    "signatures/7d/7d7cb30784fd17b481e0ebd6fef60c45d92cef2da5bb7323b6f97e55a47710f8/deb1afd74f366ab843b81bc3870f11abb66dffa7517fdd52971c7abc52b3971e.jws": "30263e3c0545dd6aa8b60f0863a76632b1923a74f625a50855e16c16a7aa990d",
+    "signatures/90/909fce934e0dbeca05f7cac876d38c25fdd6222357642bc310f4c54226b7a073/2e0da03cb6c7b885bf42f009d8a7e29bdb1557df6f981be01b91d5fad718b254.jws": "572218cf69a0f00d152c8060274578d22e8dc272e2b2a509b079fe33097c0bac",
+    "tips/32d9ad089a5f11bea1928e8d74e35d1a69f884506e5d4140470ab0bc7e6c7a12.json": "c56ef2e74bd4915861cb71dfae71ffa386c27d76dcf7ad735a79c3747d849327",
+    "tips/7d7cb30784fd17b481e0ebd6fef60c45d92cef2da5bb7323b6f97e55a47710f8.json": "c1ce84529c5db807c72743c8b1f975a4d416e67bc959c16364aec05b9a2a2c5c",
+    "tips/909fce934e0dbeca05f7cac876d38c25fdd6222357642bc310f4c54226b7a073.json": "61b0104db05290798772f4c80e6b8d7cb3caaf0c33e167b50138276b3a17d07b",
+}
+
+# Receipt-level golden: the full on-disk tree ``QueryReceiptStore.record``
+# produces for one pinned query, including the receipt JSON and audit mirror.
+_GOLDEN_RECEIPT_ID = "sha256:9b28e9c35d2b102b4915b09dc613a764f21a6985c648bd41107e878b453b5e45"
+
+_GOLDEN_RECEIPT_LOG_JSONL = '{"agent_card_kid":"golden-kid-1","agent_id":"agent:golden","artefact_kind":"query-result","artefact_path":".sdd/datasources/queries/sales/2eb4274bbea699a3_74234e98afe7498f.jsonl","content_hash":"sha256:539251727489ad89b71c4b7a750707ed3422f456c31bbd47ccf60e092a4bca1d","operator_hmac":"16bc870c4aba895934dfe362eb5489079926e5d0fb70143031397d8ec0541635","parent_hashes":[],"span_id":"426a558010060f244a7b19ba83eb12a024b139c2dd4ab654e1c3d7e6c376cacf","tool_call_id":"query:sales","ts_ns":1700000000000000001,"v":1}\n'
+
+_GOLDEN_RECEIPT_JSON = '{\n  "artefact_path": ".sdd/datasources/queries/sales/2eb4274bbea699a3_74234e98afe7498f.jsonl",\n  "binding": "426a558010060f244a7b19ba83eb12a024b139c2dd4ab654e1c3d7e6c376cacf",\n  "connection_id": "sales",\n  "content_hash": "sha256:539251727489ad89b71c4b7a750707ed3422f456c31bbd47ccf60e092a4bca1d",\n  "driver": "sqlite",\n  "engine": "sqlite",\n  "executed_at_ns": 1700000000000000001,\n  "lineage_entry_hash": "sha256:9b28e9c35d2b102b4915b09dc613a764f21a6985c648bd41107e878b453b5e45",\n  "params": null,\n  "params_hash": "sha256:74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",\n  "query_text": "SELECT id, name FROM t ORDER BY id",\n  "query_text_hash": "sha256:2eb4274bbea699a3e8976c75ad2da578ef3e0135c7d070e690cb44a741da00ba",\n  "receipt_id": "sha256:9b28e9c35d2b102b4915b09dc613a764f21a6985c648bd41107e878b453b5e45",\n  "result_copy_relpath": "results/539251727489ad89b71c4b7a750707ed3422f456c31bbd47ccf60e092a4bca1d.bin",\n  "row_cap": 10000,\n  "row_count": 2,\n  "truncated": false,\n  "v": 1\n}'
+
+_GOLDEN_RECEIPT_AUDIT_JSONL = '{"connection_id": "sales", "content_hash": "sha256:539251727489ad89b71c4b7a750707ed3422f456c31bbd47ccf60e092a4bca1d", "event": "datasource.query_receipt", "params_hash": "sha256:74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b", "query_text_hash": "sha256:2eb4274bbea699a3e8976c75ad2da578ef3e0135c7d070e690cb44a741da00ba", "receipt_id": "sha256:9b28e9c35d2b102b4915b09dc613a764f21a6985c648bd41107e878b453b5e45", "row_count": 2, "timestamp": 1700000000.0, "truncated": false}\n'
+
+_GOLDEN_RECEIPT_JWS = "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il0sImtpZCI6ImdvbGRlbi1raWQtMSJ9..YSXmB-VWEvGYY4veBn_pyzkta6kEW6_uOIH1sd5ZLxaQCVvAvm5296TxYu6gzsVWSbVnn02rAkgR7pdgjXY7Bg"
+
+_GOLDEN_RECEIPT_TREE_SHA256 = {
+    "identity/agent:golden/card.json": "600909af55c532baf2f58863ecefac3fc6cc42e3aac7a7799d53d533c0dab738",
+    "lineage/by-artefact/72/72725e594c28d45e66e3d702d69da6f2d24541e913ecb5515481d95df844452e.jsonl": "b402ea31850cfe166a0ac03b858929c7da6d97361c3df3a1944248da03d65dba",
+    "lineage/log.jsonl": "b402ea31850cfe166a0ac03b858929c7da6d97361c3df3a1944248da03d65dba",
+    "lineage/signatures/72/72725e594c28d45e66e3d702d69da6f2d24541e913ecb5515481d95df844452e/9b28e9c35d2b102b4915b09dc613a764f21a6985c648bd41107e878b453b5e45.jws": "1f7bb73e776c1e132e5e4153319e1336a6430e743ac0c34e49482c9a6acffc9e",
+    "lineage/tips/72725e594c28d45e66e3d702d69da6f2d24541e913ecb5515481d95df844452e.json": "a38b41d8714cc0aa815fe9eb9c46090ef7ce7129d872e6db3107c9bf6688a642",
+    "receipts-audit.jsonl": "e6d1cb788a43b3dfbe4a51eb7c9abab6e423327feeec8427c5f19b039c0908f7",
+    "receipts/9b28e9c35d2b102b4915b09dc613a764f21a6985c648bd41107e878b453b5e45.json": "b15620a887f433a36b208ed18f92cf794ff80da1937ee6dfdb5e87d98ae4bff6",
+    "results/539251727489ad89b71c4b7a750707ed3422f456c31bbd47ccf60e092a4bca1d.bin": "539251727489ad89b71c4b7a750707ed3422f456c31bbd47ccf60e092a4bca1d",
+}
+
+
+# --- helpers ----------------------------------------------------------------
+
+
+def _tree_digest(root: Path) -> dict[str, str]:
+    """Return ``{relpath: sha256}`` for every file under *root*."""
+    return {
+        p.relative_to(root).as_posix(): hashlib.sha256(p.read_bytes()).hexdigest()
+        for p in sorted(root.rglob("*"))
+        if p.is_file()
+    }
+
+
+def _seal_all(store: LineageStore) -> list[str]:
+    """Replay the pinned writes through the module-level primitive."""
+    return [
+        seal_write(
+            store,
+            _OPERATOR_KEY,
+            agent_id=_AGENT_ID,
+            agent_card=_CARD,
+            private_key_pem=_PRIVATE_PEM,
+            **write,
+        )
+        for write in _WRITES
+    ]
+
+
+@pytest.fixture
+def sealed(tmp_path: Path) -> tuple[Path, list[str]]:
+    root = tmp_path / "lineage"
+    hashes = _seal_all(LineageStore(root))
+    return root, hashes
+
+
+# --- primitive-level byte identity ------------------------------------------
+
+
+def test_entry_hashes_match_the_golden(sealed: tuple[Path, list[str]]) -> None:
+    _, hashes = sealed
+    assert hashes == _GOLDEN_ENTRY_HASHES
+
+
+def test_log_jsonl_is_byte_identical(sealed: tuple[Path, list[str]]) -> None:
+    root, _ = sealed
+    assert (root / "log.jsonl").read_bytes() == _GOLDEN_LOG_JSONL.encode("utf-8")
+
+
+def test_jws_sidecars_are_byte_identical(sealed: tuple[Path, list[str]]) -> None:
+    """The Ed25519 detached signatures, at their exact sidecar paths."""
+    root, _ = sealed
+    produced = {
+        p.relative_to(root).as_posix(): p.read_text(encoding="utf-8")
+        for p in sorted((root / "signatures").rglob("*.jws"))
+    }
+    assert produced == _GOLDEN_JWS
+
+
+def test_tip_projections_are_byte_identical(sealed: tuple[Path, list[str]]) -> None:
+    root, _ = sealed
+    produced = {
+        p.relative_to(root).as_posix(): p.read_text(encoding="utf-8") for p in sorted((root / "tips").rglob("*.json"))
+    }
+    assert produced == _GOLDEN_TIPS
+
+
+def test_whole_store_tree_is_byte_identical(sealed: tuple[Path, list[str]]) -> None:
+    """Every file the store lays down, including the by-artefact projections."""
+    root, _ = sealed
+    assert _tree_digest(root) == _GOLDEN_TREE_SHA256
+
+
+def test_golden_signatures_still_verify(sealed: tuple[Path, list[str]]) -> None:
+    """The pinned bytes are not just stable - they are valid signatures."""
+    root, _ = sealed
+    store = LineageStore(root)
+    checked = 0
+    for entry, jws in store.read_log():
+        assert jws, f"missing sidecar for {entry.artefact_path}"
+        assert verify_detached(canonicalise(entry), jws, _CARD)
+        assert "sha256:" + hashlib.sha256(canonicalise(entry)).hexdigest() == entry_hash(entry)
+        checked += 1
+    assert checked == len(_WRITES)
+
+
+def test_object_form_and_deprecated_shim_produce_the_same_bytes(tmp_path: Path) -> None:
+    """``SignedLineageLog``, its deprecated ``LineageRecorder`` shim and the
+    module-level primitive are three doors onto one substrate."""
+    from bernstein.core.lineage.recorder import LineageRecorder
+
+    roots: list[Path] = []
+    for name, factory in (
+        ("log", SignedLineageLog),
+        ("shim", LineageRecorder),
+    ):
+        root = tmp_path / name
+        writer = factory(LineageStore(root), operator_hmac_key=_OPERATOR_KEY)
+        for write in _WRITES:
+            writer.record_write(
+                agent_id=_AGENT_ID,
+                agent_card=_CARD,
+                private_key_pem=_PRIVATE_PEM,
+                **write,
+            )
+        roots.append(root)
+
+    assert _tree_digest(roots[0]) == _GOLDEN_TREE_SHA256
+    assert _tree_digest(roots[1]) == _GOLDEN_TREE_SHA256
+
+
+# --- receipt-level byte identity --------------------------------------------
+
+
+class _FixedClock:
+    """Stand-in for the ``time`` module inside the signed-write path."""
+
+    @staticmethod
+    def time_ns() -> int:
+        return _FIXED_NS
+
+
+@pytest.fixture
+def fixed_clock(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setattr(signed_write_module, "time", _FixedClock)
+    yield
+
+
+def _make_db(path: Path) -> str:
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE t (id INTEGER, name TEXT)")
+    conn.executemany("INSERT INTO t VALUES (?, ?)", [(1, "a"), (2, "b")])
+    conn.commit()
+    conn.close()
+    return str(path)
+
+
+def _record_golden_receipt(tmp_path: Path) -> tuple[Path, Any]:
+    db = _make_db(tmp_path / "g.db")
+    root = tmp_path / "datasources"
+    store = QueryReceiptStore(
+        root,
+        agent_card=_CARD,
+        private_key_pem=_PRIVATE_PEM,
+        operator_hmac_key=_OPERATOR_KEY,
+    )
+    connection = DataSourceConnection(id="sales", driver="sqlite", dsn=db)
+    sql = "SELECT id, name FROM t ORDER BY id"
+    result = connection.open_engine().execute(sql, row_cap=10_000)
+    receipt = store.record(
+        connection=connection,
+        query_text=sql,
+        params=None,
+        result=result,
+        store_result_copy=True,
+        now_ns=_FIXED_NS,
+    )
+    return root, receipt
+
+
+@pytest.mark.usefixtures("fixed_clock")
+def test_query_receipt_tree_is_byte_identical(tmp_path: Path) -> None:
+    """The migrated datasource receipt path lays down the same bytes as before."""
+    root, receipt = _record_golden_receipt(tmp_path)
+    assert receipt.receipt_id == _GOLDEN_RECEIPT_ID
+    assert (root / "lineage" / "log.jsonl").read_bytes() == _GOLDEN_RECEIPT_LOG_JSONL.encode("utf-8")
+    assert (root / "receipts-audit.jsonl").read_bytes() == _GOLDEN_RECEIPT_AUDIT_JSONL.encode("utf-8")
+    receipt_path = root / "receipts" / f"{_GOLDEN_RECEIPT_ID.split(':', 1)[1]}.json"
+    assert receipt_path.read_bytes() == _GOLDEN_RECEIPT_JSON.encode("utf-8")
+    (jws_path,) = sorted((root / "lineage" / "signatures").rglob("*.jws"))
+    assert jws_path.read_text(encoding="utf-8") == _GOLDEN_RECEIPT_JWS
+    assert _tree_digest(root) == _GOLDEN_RECEIPT_TREE_SHA256
+
+
+@pytest.mark.usefixtures("fixed_clock")
+def test_query_receipt_still_verifies_against_the_golden_bytes(tmp_path: Path) -> None:
+    """Byte identity is worth nothing if ``verify()`` stopped meaning anything."""
+    root, receipt = _record_golden_receipt(tmp_path)
+    store = QueryReceiptStore(
+        root,
+        agent_card=_CARD,
+        private_key_pem=_PRIVATE_PEM,
+        operator_hmac_key=_OPERATOR_KEY,
+    )
+    outcome = store.verify(receipt.receipt_id)
+    assert outcome.ok, outcome.failures
+    assert outcome.checks["signature"] is True
+    assert outcome.checks["operator_hmac"] is True
+    assert outcome.checks["receipt_body"] is True
+
+
+@pytest.mark.usefixtures("fixed_clock")
+def test_golden_receipt_log_line_is_canonical_json(tmp_path: Path) -> None:
+    """The pinned log line is the JCS form, not merely a stable string."""
+    root, _ = _record_golden_receipt(tmp_path)
+    raw = (root / "lineage" / "log.jsonl").read_bytes().rstrip(b"\n")
+    payload = json.loads(raw)
+    recanonicalised = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    assert recanonicalised.encode("utf-8") == raw

--- a/tests/unit/lineage/test_spine_deprecations.py
+++ b/tests/unit/lineage/test_spine_deprecations.py
@@ -1,31 +1,61 @@
-"""Guard: deprecated v1 lineage writers have no construction sites in src/.
+"""Guard: deprecated v1 lineage writers are unreachable from src/.
 
-Issue #2292 AC4 - v1 ``LineageRecorder`` and persistence
-``LineageWriter`` must have zero remaining construction sites in
-``src/``. New artifact-provenance writes go through
-:class:`bernstein.core.lineage.spine.LineageSpine` at the single adapter
-write boundary. This test scans the shipped source tree (not tests, not
-docstrings) so a regression that reintroduces a v1 writer construction
-fails CI.
+Issue #2292 AC4 established that v1 ``LineageRecorder`` and persistence
+``LineageWriter`` must have zero construction sites in ``src/``. New
+artifact-provenance writes go through
+:class:`bernstein.core.lineage.spine.LineageSpine` at the single adapter write
+boundary.
+
+Issue #2960 closes the bypass that a constructor-only check leaves open. A
+constructor check is satisfied by moving the deprecated body into a module-level
+helper and calling that instead, so a signed write could still ride the
+deprecated module without tripping anything. The guard therefore now enforces
+four properties over the shipped source tree (not tests, not docstrings):
+
+1. No construction of a deprecated v1 writer.
+2. No *import* of a deprecated v1 writer at all - including under
+   ``TYPE_CHECKING`` - so no ``src/`` entrypoint can be typed against one.
+3. The signed-append substrate (``LineageStore.append(entry, jws=...)``) is
+   reached only from the one supported module,
+   :mod:`bernstein.core.lineage.signed_write`. Any other call site is a signed
+   write that skipped the supported path.
+4. The deprecated recorder module does not re-export the sealing primitive, so
+   ``from ...lineage.recorder import seal_write`` cannot become the new bypass.
 """
 
 from __future__ import annotations
 
 import ast
+import importlib
 from pathlib import Path
 
 _SRC = Path(__file__).resolve().parents[3] / "src" / "bernstein"
 
 _FORBIDDEN_CTORS = {"LineageRecorder", "LineageWriter"}
 
+#: Deprecated modules whose members must not be imported anywhere in ``src/``.
+_DEPRECATED_RECORDER_MODULE = "bernstein.core.lineage.recorder"
+
+#: The single module allowed to perform a signed append against ``LineageStore``.
+_SIGNED_WRITE_MODULE = _SRC / "core" / "lineage" / "signed_write.py"
+
+#: Sealing primitives that must only ever be imported from the supported module.
+_SEALING_NAMES = {"seal_write", "SignedLineageLog"}
+
+
+def _iter_src_modules() -> list[tuple[Path, ast.Module]]:
+    out: list[tuple[Path, ast.Module]] = []
+    for py in sorted(_SRC.rglob("*.py")):
+        try:
+            out.append((py, ast.parse(py.read_text(encoding="utf-8"))))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+    return out
+
 
 def _construction_sites() -> list[str]:
     hits: list[str] = []
-    for py in _SRC.rglob("*.py"):
-        try:
-            tree = ast.parse(py.read_text(encoding="utf-8"))
-        except (SyntaxError, UnicodeDecodeError):
-            continue
+    for py, tree in _iter_src_modules():
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
                 continue
@@ -44,9 +74,112 @@ def _construction_sites() -> list[str]:
     return hits
 
 
+def _import_sites() -> list[str]:
+    """Return every ``src/`` import of a deprecated v1 writer name."""
+    hits: list[str] = []
+    for py, tree in _iter_src_modules():
+        if py.name == "recorder.py" and py.parent.name == "lineage":
+            # The deprecated module is allowed to define its own class.
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                for alias in node.names:
+                    if alias.name in _FORBIDDEN_CTORS:
+                        hits.append(f"{py}:{node.lineno}: from {node.module} import {alias.name}")
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.asname in _FORBIDDEN_CTORS:
+                        hits.append(f"{py}:{node.lineno}: import {alias.name} as {alias.asname}")
+    return hits
+
+
+def _signed_append_sites() -> list[str]:
+    """Return every ``.append(..., jws=...)`` call outside the supported module.
+
+    ``LineageStore.append`` is the only way v1 signed bytes land on disk; it is
+    identified by its ``jws`` keyword, which no other ``append`` in the tree
+    takes.
+    """
+    hits: list[str] = []
+    for py, tree in _iter_src_modules():
+        if py == _SIGNED_WRITE_MODULE:
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if not (isinstance(func, ast.Attribute) and func.attr == "append"):
+                continue
+            if any(kw.arg == "jws" for kw in node.keywords):
+                hits.append(f"{py}:{node.lineno}: signed append outside signed_write.py")
+    return hits
+
+
+def _sealing_import_bypasses() -> list[str]:
+    """Return ``src/`` imports of a sealing primitive from the deprecated module."""
+    hits: list[str] = []
+    for py, tree in _iter_src_modules():
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom):
+                continue
+            if node.module != _DEPRECATED_RECORDER_MODULE:
+                continue
+            for alias in node.names:
+                if alias.name in _SEALING_NAMES:
+                    hits.append(f"{py}:{node.lineno}: from {node.module} import {alias.name}")
+    return hits
+
+
 def test_no_v1_writer_construction_in_src() -> None:
     sites = _construction_sites()
     assert sites == [], (
         "deprecated v1 lineage writers must not be constructed in src/; "
-        "route writes through LineageSpine instead:\n" + "\n".join(sites)
+        "route provenance writes through LineageSpine, or signed writes through "
+        "bernstein.core.lineage.signed_write:\n" + "\n".join(sites)
     )
+
+
+def test_no_v1_writer_import_in_src() -> None:
+    """A v1-typed entrypoint is a construction site waiting to happen."""
+    sites = _import_sites()
+    assert sites == [], (
+        "deprecated v1 lineage writers must not be imported in src/ (not even "
+        "under TYPE_CHECKING); type signed-write entrypoints against "
+        "bernstein.core.lineage.signed_write.SignedLineageLog:\n" + "\n".join(sites)
+    )
+
+
+def test_signed_append_only_from_the_supported_module() -> None:
+    """A signed write cannot silently regress onto a deprecated substrate."""
+    sites = _signed_append_sites()
+    assert sites == [], (
+        "LineageStore.append(entry, jws=...) is the signed-write substrate and may "
+        "only be called from bernstein/core/lineage/signed_write.py; call seal_write "
+        "instead:\n" + "\n".join(sites)
+    )
+
+
+def test_deprecated_recorder_does_not_re_export_the_sealing_primitive() -> None:
+    """The deprecated module must not become the new signed-write door."""
+    recorder = importlib.import_module(_DEPRECATED_RECORDER_MODULE)
+    assert recorder.__all__ == ["LineageRecorder"], (
+        f"{_DEPRECATED_RECORDER_MODULE} must export only the deprecated shim, got {recorder.__all__}"
+    )
+    # ``SignedLineageLog`` is necessarily bound here - the shim subclasses it -
+    # but the sealing *function* must not be reachable through this module.
+    assert not hasattr(recorder, "seal_write"), (
+        f"{_DEPRECATED_RECORDER_MODULE}.seal_write re-opens the bypass issue #2960 closed"
+    )
+    bypasses = _sealing_import_bypasses()
+    assert bypasses == [], "sealing primitives must be imported from signed_write:\n" + "\n".join(bypasses)
+
+
+def test_deprecated_recorder_is_a_shim_over_the_supported_path() -> None:
+    """``LineageRecorder`` carries no substrate of its own any more."""
+    from bernstein.core.lineage.recorder import LineageRecorder
+    from bernstein.core.lineage.signed_write import SignedLineageLog
+
+    assert issubclass(LineageRecorder, SignedLineageLog)
+    # The shim adds a deprecation warning and nothing else: no override of the
+    # write path, so it cannot diverge from the supported bytes.
+    assert "record_write" not in vars(LineageRecorder)

--- a/tests/unit/mcp/test_lineage_resource.py
+++ b/tests/unit/mcp/test_lineage_resource.py
@@ -22,7 +22,7 @@ import pytest
 from mcp.server.fastmcp import FastMCP
 
 from bernstein.core.lineage.identity import AgentCard, generate_keypair
-from bernstein.core.lineage.recorder import LineageRecorder
+from bernstein.core.lineage.signed_write import SignedLineageLog
 from bernstein.core.lineage.store import LineageStore
 from bernstein.mcp.resources.lineage import register_lineage_resources
 
@@ -32,7 +32,7 @@ def seeded_store(tmp_path: Path) -> tuple[Path, LineageStore]:
     """Two-entry chain on ``src/foo.py``."""
     root = tmp_path / "lineage"
     store = LineageStore(root)
-    recorder = LineageRecorder(store=store, operator_hmac_key=b"k" * 32)
+    recorder = SignedLineageLog(store=store, operator_hmac_key=b"k" * 32)
     priv, pub = generate_keypair()
     card = AgentCard(agent_id="agent:worker", kid="k1", public_key_pem=pub)
     recorder.record_write(

--- a/tests/unit/test_computer_use_lineage.py
+++ b/tests/unit/test_computer_use_lineage.py
@@ -44,7 +44,7 @@ from bernstein.core.agents.computer_use_attestation import (
 )
 from bernstein.core.agents.multimodal_attestation import CapabilityRefusal
 from bernstein.core.lineage.identity import AgentCard, generate_keypair
-from bernstein.core.lineage.recorder import LineageRecorder
+from bernstein.core.lineage.signed_write import SignedLineageLog
 from bernstein.core.lineage.store import LineageStore
 from bernstein.core.persistence.cas_store import CASStore
 from bernstein.core.security.audit_chain import (
@@ -61,7 +61,7 @@ def _session(tmp_path: Path, *, run_id: str = "run-1", worktree_id: str = "wt-a"
     cas = CASStore(tmp_path / "cas")
     chain = AuditChainStore(audit_dir=tmp_path / "audit", key=b"k" * 32)
     store = LineageStore(tmp_path / "lineage")
-    recorder = LineageRecorder(store, operator_hmac_key=b"h" * 32)
+    recorder = SignedLineageLog(store, operator_hmac_key=b"h" * 32)
     priv, pub = generate_keypair()
     card = AgentCard(agent_id="agent:cu-worker", kid="kid-cu-1", public_key_pem=pub)
     return ComputerUseSession(

--- a/tests/unit/test_janitor.py
+++ b/tests/unit/test_janitor.py
@@ -1683,7 +1683,7 @@ class TestFiguresGroundedSignal:
 
         from bernstein.core.lineage.artifact_record import record_artifact
         from bernstein.core.lineage.identity import AgentCard, generate_keypair
-        from bernstein.core.lineage.recorder import LineageRecorder
+        from bernstein.core.lineage.signed_write import SignedLineageLog
         from bernstein.core.lineage.store import LineageStore
         from bernstein.core.tasks.artifacts import ArtifactKind
         from bernstein.core.tasks.figures import Figure, FigureAnchor, ReportBundle
@@ -1691,7 +1691,7 @@ class TestFiguresGroundedSignal:
         sdd = tmp_path / ".sdd"
         priv, pub = generate_keypair()
         card = AgentCard(agent_id="agent:analyst", kid="key-fg", public_key_pem=pub)
-        rec = LineageRecorder(store=LineageStore(sdd / "lineage"), operator_hmac_key=self._HMAC)
+        rec = SignedLineageLog(store=LineageStore(sdd / "lineage"), operator_hmac_key=self._HMAC)
         src = record_artifact(
             recorder=rec,
             sink_root=sdd / "artifacts",

--- a/tests/unit/test_phase_gate_lineage.py
+++ b/tests/unit/test_phase_gate_lineage.py
@@ -1,39 +1,18 @@
-"""Lineage-emission helper for phase-gate boundary events.
+"""Phase-gate boundary lineage helpers.
 
-The hook builder writes one ``phase_gate``-tagged record into the run's
-WAL per boundary.  The hash chain stays a single chain - we reuse the
-existing :class:`LineageWriter` rather than introducing a parallel one.
+The per-boundary write goes through :class:`LineageSpine` (see
+``tests/unit/test_phase_gate_spine_lineage.py`` for the end-to-end wiring).
+This module covers the pure projection helper the adjudication hook renders
+into its signed record, plus the guard that the retired v1 WAL-backed hook
+does not creep back in.
 """
 
 from __future__ import annotations
 
-from pathlib import Path
-
-from bernstein.core.orchestration.phase_gate_lineage import (
-    PHASE_GATE_REGULATORY_CLASS,
-    build_phase_gate_record,
-    gate_results_summary,
-    make_lineage_hook,
-)
+from bernstein.core.orchestration import phase_gate_lineage
+from bernstein.core.orchestration.phase_gate_lineage import gate_results_summary
 from bernstein.core.orchestration.phase_gates import GateOutcome, GateResult
 from bernstein.core.orchestration.phase_pipeline import Phase
-from bernstein.core.persistence.lineage import LineageReader, LineageWriter
-from bernstein.core.tasks.models import Complexity, Scope, Task, TaskStatus, TaskType
-
-
-def _task() -> Task:
-    return Task(
-        id="t-lineage-1",
-        title="t",
-        description="d",
-        role="backend",
-        priority=2,
-        scope=Scope.MEDIUM,
-        complexity=Complexity.MEDIUM,
-        status=TaskStatus.OPEN,
-        task_type=TaskType.STANDARD,
-        metadata={},
-    )
 
 
 def _result(rule_id: str, outcome: GateOutcome) -> GateResult:
@@ -44,23 +23,6 @@ def _result(rule_id: str, outcome: GateOutcome) -> GateResult:
         boundary_from=Phase.RESEARCH,
         boundary_to=Phase.PLAN,
     )
-
-
-def test_build_record_tags_regulatory_class(tmp_path: Path) -> None:
-    fake_artifact = tmp_path / "research.json"
-    fake_artifact.write_text('{"summary": "x"}', encoding="utf-8")
-    record = build_phase_gate_record(
-        task=_task(),
-        phase=Phase.PLAN,
-        boundary=(Phase.RESEARCH, Phase.PLAN),
-        results=[_result("R001-no-open-questions", GateOutcome.PASS)],
-        artifact_path=fake_artifact,
-    )
-    assert record.regulatory_class == PHASE_GATE_REGULATORY_CLASS
-    assert record.producer.agent_id == "phase_gate:plan"
-    assert record.producer.tick_id == "research->plan"
-    # prompt_sha is the stable hash of the rule outcomes.
-    assert len(record.prompt_sha) == 64
 
 
 def test_gate_results_summary_includes_per_rule_outcome() -> None:
@@ -76,33 +38,15 @@ def test_gate_results_summary_includes_per_rule_outcome() -> None:
     assert outcomes == {"pass", "fail"}
 
 
-def test_lineage_hook_writes_one_record_per_call(tmp_path: Path) -> None:
-    sdd_dir = tmp_path / ".sdd"
-    fake_artifact = tmp_path / "phase.json"
-    fake_artifact.write_text("{}", encoding="utf-8")
+def test_gate_results_summary_carries_the_boundary_per_rule() -> None:
+    summary = gate_results_summary([_result("R001-no-open-questions", GateOutcome.PASS)])
+    (rule,) = summary["rules"]
+    assert rule["boundary_from"] == Phase.RESEARCH.value
+    assert rule["boundary_to"] == Phase.PLAN.value
 
-    writer = LineageWriter.for_run("run-1", sdd_dir)
-    hook = make_lineage_hook(
-        writer,
-        artifact_path_resolver=lambda _t, _p: fake_artifact,
-    )
-    hook(
-        _task(),
-        Phase.PLAN,
-        (Phase.RESEARCH, Phase.PLAN),
-        [_result("R001-no-open-questions", GateOutcome.PASS)],
-    )
-    hook(
-        _task(),
-        Phase.IMPLEMENT,
-        (Phase.PLAN, Phase.IMPLEMENT),
-        [_result("R004-monotonic-constraint-set", GateOutcome.PASS)],
-    )
 
-    reader = LineageReader(sdd_dir)
-    records = list(reader.iter_records())
-    assert len(records) == 2
-    classes = {r.regulatory_class for r in records}
-    assert classes == {PHASE_GATE_REGULATORY_CLASS}
-    actor_ids = {r.producer.agent_id for r in records}
-    assert actor_ids == {"phase_gate:plan", "phase_gate:implement"}
+def test_v1_writer_typed_entrypoints_are_retired() -> None:
+    """No entrypoint here is typed on the deprecated v1 ``LineageWriter``."""
+    for retired in ("make_lineage_hook", "build_phase_gate_record", "PHASE_GATE_REGULATORY_CLASS"):
+        assert not hasattr(phase_gate_lineage, retired), f"{retired} must stay retired (issue #2960)"
+    assert "make_lineage_hook" not in phase_gate_lineage.__all__

--- a/tests/unit/test_provenance_end_to_end.py
+++ b/tests/unit/test_provenance_end_to_end.py
@@ -18,7 +18,7 @@ from bernstein.core.lineage.provenance import (
     taint_for_artefact,
     verify_taint,
 )
-from bernstein.core.lineage.recorder import LineageRecorder
+from bernstein.core.lineage.signed_write import SignedLineageLog
 from bernstein.core.lineage.store import LineageStore
 from bernstein.core.security.auto_approve import Decision, classify_command
 from bernstein.core.security.capability_matrix import (
@@ -52,7 +52,7 @@ def _cards_dir(tmp_path: Path, card: AgentCard) -> Path:
 
 def test_untrusted_result_confined_end_to_end(tmp_path: Path) -> None:
     store = LineageStore(tmp_path / "lineage")
-    recorder = LineageRecorder(store=store, operator_hmac_key=_OP_SECRET)
+    recorder = SignedLineageLog(store=store, operator_hmac_key=_OP_SECRET)
     priv, pub = generate_keypair()
     card = AgentCard(agent_id="agent:gw", kid="k1", public_key_pem=pub)
     cards = _cards_dir(tmp_path, card)


### PR DESCRIPTION
Closes #2960

## Problem

Two signed-receipt paths — datasource query receipts and payment transaction
receipts — need the v1 substrate's Ed25519 detached JWS + operator-HMAC envelope
+ caller-controlled `span_id` binding. `LineageSpine` is Merkle+HMAC only, so
routing them through it would break their `verify()` paths and downgrade the
security model.

The release unblock lifted the sealing body into a module-level helper inside
the *deprecated* `core/lineage/recorder.py`. That satisfied a constructor-only
guard while leaving the deprecated module on the live signed-write path — and
left the guard bypassable by construction.

## Option chosen: B

Option A (fold an optional Ed25519 layer into `LineageSpine`) cannot be done
without changing on-disk bytes, which is the hard constraint here. The spine's
entry shape, hash chain and `verify()` semantics are unrelated to the v1
transparency-log layout (`log.jsonl` + `by-artefact/` + `tips/` +
`signatures/*.jws`) the receipts verify against. A "signed mode" would have to
write a different format from its own unsigned mode — one class, two substrates,
two verifiers.

The accurate diagnosis is narrower: `LineageStore`, `LineageEntry` and the
detached-JWS identity layer were never deprecated. Only the *recorder class*
was. So the signed append needs a supported home, not a new substrate.

## What changed

- **New** `src/bernstein/core/lineage/signed_write.py` — `seal_write()` (body
  moved verbatim) and `SignedLineageLog`. Documented in ADR-009 §5.4, including
  when to reach for it versus the spine.
- **Both receipts** import from it. `verify()` and the tamper/forgery tests are
  untouched.
- **`core/lineage/recorder.py`** is now a compatibility shim: `LineageRecorder`
  subclasses `SignedLineageLog`, warns on construction, overrides nothing, and
  no longer re-exports the sealing primitive.
- **Re-typed** the v1-typed entrypoints (`artifact_record`, `provenance`,
  `computer_use_attestation`) against `SignedLineageLog`.
- **Retired** `make_lineage_hook` and `build_phase_gate_record` — the last
  `src/` entrypoints typed against the deprecated persistence `LineageWriter`.
  The live boundary write already went through the spine.

`LineageRecorder` and `LineageWriter` now have zero construction, zero imports
and zero typed entrypoints under `src/`.

## Guard tightening

A constructor check is satisfied by moving the body into a helper, which is
exactly how the bypass appeared. `tests/unit/lineage/test_spine_deprecations.py`
now also fails on:

| Check | Closes |
|---|---|
| any `src/` **import** of a deprecated writer, including under `TYPE_CHECKING` | v1-typed entrypoints |
| `LineageStore.append(entry, jws=...)` called outside `signed_write.py` | a signed write reaching the substrate off-path |
| the deprecated module re-exporting `seal_write` | the helper-rename bypass |
| the shim overriding `record_write` | the shim silently diverging |

## Byte-identity proof

`tests/unit/lineage/test_signed_write_golden.py`. Fixtures were captured by
running the **pre-migration** write path against pinned inputs and are pinned
verbatim. Ed25519 (RFC 8032) signs deterministically, so with a pinned key,
pinned inputs and a pinned `ts_ns` the signature bytes are themselves a golden
value — a shifted canonical pre-image shows up as a different JWS, not a flake.

Pinned at the primitive level (four writes covering both receipt shapes,
genesis + linear successor, `trust_class` + cross-artefact `extra_parents`):
entry hashes, `log.jsonl` bytes, every `.jws` sidecar at its exact path, tip
projections, and the whole-tree sha256 map. Pinned again end-to-end through
`QueryReceiptStore.record`: lineage log, receipt JSON, audit mirror, JWS and
tree digest. `SignedLineageLog`, the deprecated shim and the module-level
primitive are all asserted to land the identical tree.

## Verification

`uv run ruff check .` and `uv run ruff format --check .` clean. Vulture clean.
Pyright on the changed files reports only the three pre-existing
`reportUnknownVariableType` findings in `datasources/receipt.py::reexecute`
(untouched code; the repo-wide pyright run is advisory).

Named targets:

| File | Passed |
|---|---|
| `tests/unit/lineage/test_spine_deprecations.py` (guard, tightened) | 5 |
| `tests/unit/lineage/test_signed_write_golden.py` (new) | 10 |
| `tests/unit/lineage/test_signed_write.py` (was `test_recorder.py`) | 9 |
| `tests/unit/datasources/test_receipt.py` (unmodified) | 14 |
| `tests/unit/core/payments/test_verify.py` (unmodified) | 11 |
| `tests/unit/core/payments/test_enforce.py` (unmodified) | 10 |
| `tests/unit/test_phase_gate_lineage.py` (rewritten) | 3 |

Full sweep of every touched area — 458 passed:

| Group | Passed |
|---|---|
| `tests/unit/lineage/` | 255 |
| `tests/unit/datasources/` | 71 |
| `tests/unit/core/payments/` | 74 |
| `tests/unit/test_phase_gate_{lineage,spine_lineage,adjudication_wiring}.py` | 10 |
| `test_provenance_end_to_end.py`, `test_computer_use_lineage.py`, `mcp/test_lineage_resource.py`, `cli/test_artifact_verify_cmd.py`, `property/test_normalize_path_properties.py` | 48 |

Plus `tests/unit/test_janitor.py -k FiguresGroundedSignal` (5 passed).

`tests/unit/datasources/test_receipt.py`, `tests/unit/core/payments/test_verify.py`
and `tests/unit/core/payments/test_enforce.py` are **not** in the diff. Their
JWS, operator-HMAC, tamper and forgery assertions — stripped `.jws` sidecar,
mutated receipt body, wrong operator key, removed lineage entry, fabricated
authorization without substrate, refusal flipped to authorized — all still pass
unmodified.
