### PR TITLE
docs(ci): reconcile merge-queue runbook with the shipped ruleset and release path

### DIFF
--- a/docs/operations/merge-gate.md
+++ b/docs/operations/merge-gate.md
@@ -75,7 +75,7 @@ After enabling, `gh pr merge --auto` will route the PR into the merge queue inst
 
 ### 3. Require the `CI gate` aggregator
 
-Do not enumerate individual CI job names in `required_status_checks.contexts`. The literal job names drift (the type-check context is `Type check report`, and the test matrix reports sharded contexts such as `Test (ubuntu-latest, Python 3.13, shard 1)`), and a context that never reports wedges every merge on `main`. The `ci-gate` job in `ci.yml` (context `CI gate`) already rolls up every upstream job result with conditional allowed-skips, so it is the single context to require - the same recommendation as [merge-queue.md](merge-queue.md).
+Do not enumerate individual CI job names in `required_status_checks.contexts`. The literal job names drift (the type-check context is `Type check report`, and the test matrix reports sharded contexts such as `Test (ubuntu-latest, Python 3.13, shard 1)`), and a context that never reports wedges every merge on `main`. The `ci-gate` job in `ci.yml` (context `CI gate`) already rolls up every upstream job result with conditional allowed-skips, so it is the single *CI* context to require, alongside `review-bot-ack` - the same recommendation as [merge-queue.md](merge-queue.md).
 
 ```bash
 gh api -X PATCH "repos/sipyourdrink-ltd/bernstein/branches/main/protection" \
@@ -88,7 +88,7 @@ gh api -X PATCH "repos/sipyourdrink-ltd/bernstein/branches/main/protection" \
 Notes:
 
 - `CI gate` covers `Repo hygiene`, `Lint`, `Type check report`, `Workflow lint`, `Lineage Gate`, `Bandit (security)`, `pip-audit (deps)`, the full sharded test matrix, and the rest of the `ci.yml` jobs it declares in `needs:`.
-- `review-bot-ack` runs on `pull_request` only. It belongs in the legacy branch-protection list above (queue entry), never in the merge-queue ruleset, which must require `CI gate` only; a PR-only check on the ruleset makes the queue wait forever. The main-red-guard step in `pr-policy.yml` is advisory (it warns, never fails) and is not a required context.
+- `review-bot-ack` runs on `pull_request`, `pull_request_review` **and** `merge_group`. It belongs in the legacy branch-protection list above (queue entry) *and* in the merge-queue ruleset's `required_status_checks`: `review-bot-ack.yml` carries a `merge-group-pass` job that republishes the identical context on the queue's ephemeral ref, so requiring it there cannot wedge the queue. See [merge-queue.md](merge-queue.md) for the coverage table. The main-red-guard step in `pr-policy.yml` is advisory (it warns, never fails) and is not a required context.
 - `docs-drift / Run drift check` is path-filtered (it does not report on PRs that touch no docs-relevant paths), so it must not be a blanket required check; its main-branch failure mode is the post-merge gate described in the TL;DR.
 - `PR policy` (the consolidated per-PR policy job that carries the autosync steps) is intentionally NOT required. The autosync steps run to amend the PR; if the amend fails (e.g. branch-protection rejects the push) we want the next push to retry rather than blocking the merge.
 
@@ -97,7 +97,7 @@ Notes:
 1. Open a PR that intentionally diverges `AGENTS.md` from canonical IR. Confirm the `PR policy` job runs the autosync steps and amends the PR head with a regen commit.
 2. Cause `ci.yml` on main to fail (e.g. force-push a known-bad commit to a sandbox branch, then merge with admin override). Open a fresh PR. Confirm the main-red-guard step in `PR policy` emits a warning and job summary pointing at the failing SHA.
 3. Trigger the nightly sweep manually via `gh workflow run nightly-drift-sweep.yml`. Confirm it either no-ops (no drift) or opens a sweep PR labelled `automated`.
-4. Queue two PRs via auto-merge. Confirm GitHub batches them into a single merge-group CI run via the new `merge_group:` trigger.
+4. Queue two PRs via auto-merge. Confirm each one gets its own merge-group CI run via the `merge_group:` trigger, and that `main` advances to the exact SHA the queue tested. The queue is configured with `max_entries_to_merge: 1` so one PR lands per push; see [merge-queue.md](merge-queue.md) for why.
 
 ## Windows-lane promotion (self-promoting gate)
 

--- a/docs/operations/merge-queue.md
+++ b/docs/operations/merge-queue.md
@@ -3,15 +3,23 @@
 Operator-facing notes on the GitHub merge queue for `main`. The queue is
 configured by a repository **ruleset** (not legacy branch protection).
 
+**This document is the source of truth for the queue configuration.** The
+shipped ruleset is currently out of sync with it; see
+[Tunables](#tunables-source-of-truth) for the reconciliation and
+[Enable](#enable-mechanical-steps) for the exact calls that close the gap.
+
 ## TL;DR
 
 | Topic | Status | Where |
 |-------|--------|-------|
+| Queue state today | Ruleset exists, `enforcement: disabled` | ruleset `main-merge-queue` |
 | What it solves | Tests the A+B *combination* before merge | this doc |
-| Required check on the queue | Single `CI gate` | `.github/workflows/ci.yml` |
+| Required checks on the queue | `CI gate` **and** `review-bot-ack` | `ci.yml`, `review-bot-ack.yml` |
 | Merge method | Squash | ruleset `merge_queue` rule |
 | Grouping | `ALLGREEN` (all entries in a group must pass) | ruleset |
-| Enable | One `gh api POST .../rulesets` call | below |
+| Batch size | **1** — one PR lands per push to `main` | [Tunables](#tunables-source-of-truth) |
+| Auto-release | Unaffected; the post-queue push to `main` fires the listener | [Auto-release](#auto-release-through-the-queue) |
+| Enable | Two `gh api PUT` calls, in order | [Enable](#enable-mechanical-steps) |
 | Pause | Set ruleset `enforcement` to `disabled` | below |
 | Rollback | Delete the ruleset | below |
 
@@ -33,10 +41,10 @@ whole batch is green; a red entry is ejected and the rest re-form.
 ## How the queue gates
 
 ```
-PR ready ->  enters queue  ->  CI runs on merge_group ref  ->  CI gate green?
-              (passes PR-                (the A+B+... combo)        |
-               level required                                      yes -> merge (squash)
-               checks first)                                       no  -> eject, re-form group
+PR ready ->  enters queue  ->  CI runs on merge_group ref  ->  required checks green?
+              (passes PR-                (the prospective            |
+               level required             merged SHA)                yes -> merge (squash)
+               checks first)                                         no  -> eject, re-form group
 ```
 
 Two distinct gates, do not conflate them:
@@ -44,17 +52,46 @@ Two distinct gates, do not conflate them:
 | Gate | Checks enforced | Trigger event |
 |------|-----------------|---------------|
 | **Enter the queue** | Legacy branch-protection required checks (`CI gate` + `review-bot-ack`) | `pull_request` |
-| **Merge from the queue** | Ruleset `required_status_checks` (`CI gate` only) | `merge_group` |
+| **Merge from the queue** | Ruleset `required_status_checks` (must be `CI gate` + `review-bot-ack`) | `merge_group` |
 
 `CI gate` (the `ci-gate` aggregator job in `ci.yml`) runs on `merge_group`
 because the workflow declares `merge_group: {}` and `ci-gate` has
 `if: always() && !cancelled()` with no event exclusion.
 
-> **Do NOT add `review-bot-ack` to the ruleset `required_status_checks`.**
-> That workflow triggers only on `pull_request` / `pull_request_review`,
-> so it never reports on a `merge_group` ref. Requiring it on the queue
-> would wedge every merge (the queue waits forever for a check that never
-> runs). It stays a PR-entry requirement only.
+### Required-check coverage under `merge_group`
+
+Every context required on a PR also reports on a `merge_group` ref:
+
+| Required context | Emitting workflow | Runs on `merge_group`? |
+|------------------|-------------------|------------------------|
+| `CI gate` | `ci.yml` :: `ci-gate` | Yes - `merge_group: {}` |
+| `CI gate` | `ci-gate-stub.yml` :: `ci-gate` | No - `pull_request` only, and **correct** (see below) |
+| `review-bot-ack` | `review-bot-ack.yml` :: `merge-group-pass` | Yes - `if: github.event_name == 'merge_group'` |
+
+`ci-gate-stub.yml` deliberately has no `merge_group` trigger. It exists
+only because `ci.yml`'s `pull_request` trigger carries a `paths-ignore:`
+list, so a PR whose diff is fully ignored never publishes `CI gate`.
+**`paths` / `paths-ignore` filters are only evaluated for `push`,
+`pull_request` and `pull_request_target`** - they do not apply to
+`merge_group`. `ci.yml` therefore runs unconditionally on every merge
+group, including docs-only ones, and always publishes `CI gate`. Adding
+`merge_group` to the stub would publish a second check run under the same
+required-context name on the queue for no benefit.
+
+That makes `ci.yml`'s **unconditional** `merge_group: {}` trigger a
+load-bearing invariant: adding any filter to it would silently wedge the
+queue for every diff the filter excludes. It is locked by
+`tests/unit/test_required_check_canary_workflow_yaml.py`.
+
+> **`review-bot-ack` belongs in the ruleset `required_status_checks`.**
+> An earlier revision of this runbook said the opposite, on the grounds
+> that the workflow triggered only on `pull_request` /
+> `pull_request_review`. That is no longer true: `review-bot-ack.yml`
+> declares `merge_group: {}` and carries a `merge-group-pass` job that
+> republishes the identical `review-bot-ack` context on the queue's
+> ephemeral ref. Requiring it on the queue cannot wedge anything, and
+> leaving it out would leave two divergent definitions of "required" -
+> the PR gate enforcing two contexts and the queue enforcing one.
 
 ## macOS coverage under the queue
 
@@ -67,26 +104,175 @@ roll-up tolerates that skip on `merge_group` (see `MACOS_SKIP_EVENTS` in
 the daily safety net. The queue validates the integrated combination; the
 merged commit validates macOS.
 
-## Tunables (current configuration)
+## Auto-release through the queue
 
-| Parameter | Value | Meaning |
-|-----------|-------|---------|
-| `merge_method` | `SQUASH` | One commit per PR on `main` |
-| `grouping_strategy` | `ALLGREEN` | A group merges only if every entry is green |
-| `max_entries_to_build` | 5 | Up to 5 candidates built in parallel |
-| `max_entries_to_merge` | 5 | Up to 5 merged in one batch |
-| `min_entries_to_merge` | 1 | Merge as soon as 1 entry is ready (subject to wait) |
-| `min_entries_to_merge_wait_minutes` | 5 | Wait up to 5 min to fill a batch before merging |
-| `check_response_timeout_minutes` | 60 | A required check must report within 60 min or the entry is failed |
+`post-ci-dispatcher.yml` listens on `workflow_run` for the `CI` workflow,
+filtered to `branches: [main]`, and routes to `auto-release.yml`. The
+release gate then inspects **the triggering commit only** and tags when
+that commit changed `version = ` in `pyproject.toml`. Two questions had to
+be answered before the queue can be enabled.
 
-## Enable
+**Q1: do merge-queue CI runs dispatch the release listener?**
+No, and that is the desired behaviour. A `merge_group` run reports
+`head_branch = gh-readonly-queue/main/pr-<n>-<base_sha>`, which the
+dispatcher's `branches: [main]` filter excludes. Nothing is ever tagged
+from a queue ref that has not merged.
 
-The exact enable command and rollback live with whoever administers the
-repo (admin scope required). Enabling is a shared-state change applied
-once. The configuration is a repository ruleset targeting `main` with a
-`merge_queue` rule plus a `required_status_checks` rule requiring
-`CI gate`. See the PR that introduced this runbook for the precise
-`gh api` invocation, or reconstruct it from the **Tunables** table above.
+**Q2: does the post-queue merge still fire the release listener?**
+Yes. When a merge group goes green, GitHub advances the base branch to the
+**same SHA** that the queue tested and emits an ordinary `push` event on
+that branch. The push is attributed to `github-merge-queue[bot]` and is
+not suppressed by Actions' `GITHUB_TOKEN` loop prevention, so
+`push`-triggered workflows start normally.
+
+Observed on a public repository running the queue at scale
+(`cilium/cilium`, 2026-07-24):
+
+| Event | `head_branch` | `head_sha` | Actor |
+|-------|---------------|-----------|-------|
+| `merge_group` run, 23:21:05Z | `gh-readonly-queue/main/pr-47100-67dfc5a2…` | `90c7690d43…` | - |
+| `push` run, 23:34:05Z | `main` | `90c7690d43…` (identical) | `github-merge-queue[bot]` |
+
+So the chain is unchanged end to end:
+
+```
+queue merges -> push to main (same SHA) -> ci.yml (push) -> workflow_run
+             -> post-ci-dispatcher (branches: [main]) -> auto-release -> tag -> publish
+```
+
+`pyproject.toml` is deliberately **not** in `ci.yml`'s `push.paths-ignore`
+list, so a version-bump commit always triggers the CI run the listener
+needs. That is asserted by `tests/unit/test_post_ci_dispatcher_yaml.py`.
+
+**The invariant this depends on: one PR per push.** The release gate keys
+on the push's head SHA. If a merge group merged N > 1 entries at once, the
+base branch would advance by N commits in a single push, and the push
+would report only the last entry's SHA. A version bump sitting anywhere
+but last in the batch would be skipped silently - green CI, no tag, no
+publish, no error. `max_entries_to_merge` is pinned to `1` for this
+reason; see [Tunables](#tunables-source-of-truth).
+
+## Tunables (source of truth)
+
+The values below are authoritative. **The shipped ruleset does not match
+them yet** - the "Shipped" column records the drift to be corrected when
+the queue is enabled.
+
+| Parameter | Shipped | Correct | Why |
+|-----------|---------|---------|-----|
+| `merge_method` | `SQUASH` | `SQUASH` | One commit per PR on `main` |
+| `grouping_strategy` | `ALLGREEN` | `ALLGREEN` | A group merges only if every entry is green |
+| `max_entries_to_build` | 1 | **5** | Build concurrency: the number of `merge_group` webhooks in flight. At `1` the queue tests one entry at a time, so a burst of N PRs costs N sequential full CI cycles - strictly worse latency than today with no load benefit the per-SHA policy does not already provide. `5` caps concurrent queue CI at 5 instead of the unbounded N a burst produces today. |
+| `min_entries_to_merge` | 1 | **1** | Never wait for a second entry before merging |
+| `max_entries_to_merge` | 1 | **1** | One PR lands per push to `main`. Raising this breaks two things: (a) the auto-release gate keys on the push head SHA, so a bump that is not last in the batch is silently skipped; (b) `determine-changes` in `ci.yml` classifies a non-`pull_request` diff as `HEAD~1...HEAD`, which on a multi-entry group sees only the last entry - a docs-only last entry would let the whole batch skip the Python test jobs. Lifting this requires teaching `determine-changes` to diff against `github.event.merge_group.base_sha`; tracked as a follow-up. |
+| `min_entries_to_merge_wait_minutes` | 0 | **0** | With `max_entries_to_merge = 1` there is no batch to fill, so any wait is pure added latency |
+| `check_response_timeout_minutes` | 30 | **120** | Measured over the last 30 successful `CI` runs on `main`: p50 38 min, p90 58 min, max 105 min. At `30` **every** entry would be ejected as timed out; at `60` roughly one in ten would be. `120` clears the observed maximum and the `test` job's own 90-minute budget. |
+
+## Enable (mechanical steps)
+
+**Do not run these while a release is in flight.** Enabling the queue
+serialises every open PR through it. The flip is deliberately deferred
+until after `v3.10.0` ships.
+
+All calls need repository **admin** scope.
+
+**Step 0 - preflight (read-only).** Confirm the ruleset id and the
+branch-protection contexts the queue must mirror.
+
+```bash
+REPO=sipyourdrink-ltd/bernstein
+
+gh api "repos/$REPO/rulesets" --jq '.[] | "\(.id)\t\(.name)\t\(.enforcement)"'
+gh api "repos/$REPO/branches/main/protection/required_status_checks" \
+  --jq '.checks[] | "\(.context)\tapp_id=\(.app_id)"'
+```
+
+Expected: ruleset `main-merge-queue` at `enforcement: disabled`, and
+exactly two contexts - `CI gate` and `review-bot-ack`, both `app_id`
+`15368` (GitHub Actions).
+
+**Step 1 - correct the rules while still disabled.** This applies the
+tunables above and adds `review-bot-ack` to the queue's required checks.
+Keep `enforcement: disabled` in this payload: a mis-typed rule set then
+cannot enable the queue as a side effect.
+
+```bash
+REPO=sipyourdrink-ltd/bernstein
+RULESET_ID=16719298   # confirm with Step 0
+
+gh api -X PUT "repos/$REPO/rulesets/$RULESET_ID" --input - <<'JSON'
+{
+  "name": "main-merge-queue",
+  "target": "branch",
+  "enforcement": "disabled",
+  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
+  "rules": [
+    {
+      "type": "merge_queue",
+      "parameters": {
+        "merge_method": "SQUASH",
+        "grouping_strategy": "ALLGREEN",
+        "max_entries_to_build": 5,
+        "min_entries_to_merge": 1,
+        "max_entries_to_merge": 1,
+        "min_entries_to_merge_wait_minutes": 0,
+        "check_response_timeout_minutes": 120
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": true,
+        "required_status_checks": [
+          { "context": "CI gate", "integration_id": 15368 },
+          { "context": "review-bot-ack", "integration_id": 15368 }
+        ]
+      }
+    }
+  ]
+}
+JSON
+```
+
+Verify the write landed before continuing:
+
+```bash
+gh api "repos/$REPO/rulesets/$RULESET_ID" --jq '.rules'
+```
+
+**Step 2 - drain.** Confirm nothing is mid-merge, so no PR is caught
+between the two merge paths:
+
+```bash
+gh pr list --repo "$REPO" --state open --json number,title,autoMergeRequest \
+  --jq '.[] | select(.autoMergeRequest != null) | "\(.number)\t\(.title)"'
+```
+
+**Step 3 - flip.** A separate call, so enabling is one reviewable action:
+
+```bash
+gh api -X PUT "repos/$REPO/rulesets/$RULESET_ID" -f enforcement=active
+```
+
+**Step 4 - smoke test.** Enqueue one low-risk PR and confirm the whole
+chain, in order:
+
+1. A `merge_group` run appears: `gh run list --repo "$REPO" --event merge_group --limit 5`.
+2. Both `CI gate` and `review-bot-ack` report on it.
+3. The PR merges, and `main` advances to the **same SHA** the queue tested.
+4. A `push` run on `main` appears at that SHA, actor `github-merge-queue[bot]`.
+5. `post-ci-dispatcher.yml` runs off that CI run:
+   `gh run list --repo "$REPO" --workflow post-ci-dispatcher.yml --limit 3`.
+
+If step 4 or 5 does not happen, pause the queue immediately (below) - the
+release path is broken and every subsequent merge accumulates untagged.
+
+**Not part of the flip.** The main-red-guard advisory was consolidated
+into `.github/workflows/pr-policy.yml` and no longer exists as a
+standalone workflow. It already warns rather than fails and is not a
+required context, so it needs no change when the queue is enabled and
+nothing has to be retired.
 
 ## Pause (keep the ruleset, stop enforcing)
 
@@ -120,13 +306,17 @@ checks. Any PRs sitting in the queue are released back to normal merge.
 
 | Symptom | Likely cause | Action |
 |---------|--------------|--------|
-| Nothing merges; entries sit in queue | A required check does not run on `merge_group` | Confirm the ruleset requires only `CI gate`; remove any PR-only check |
+| Nothing merges; entries sit in queue | A required check does not run on `merge_group` | Compare the ruleset's `required_status_checks` against the coverage table above; every context there must have a `merge_group` emitter |
 | `CI gate` red on `merge_group` but green on the PR | A real combination failure, or a job skipped that the roll-up does not tolerate | Read the `merge_group` run log; if a legitimately-skipped job is flagged, extend the roll-up tolerance in `ci.yml` |
-| Entry failed after 60 min | A required check never reported | Check runner queue saturation; the entry is ejected and re-formed automatically |
-| Queue throughput too low | `min_entries_to_merge_wait_minutes` batching | Lower the wait or raise `max_entries_to_merge` |
+| Entries ejected as timed out | `check_response_timeout_minutes` below the real CI wall time | Raise it; see the measured distribution in Tunables |
+| Merges land but no release is tagged | The post-merge `push` CI run did not reach the dispatcher | Confirm a `push` run on `main` exists at the merged SHA, then that `post-ci-dispatcher.yml` ran off it; check `pyproject.toml` is still absent from `ci.yml`'s `push.paths-ignore` |
+| Queue throughput too low | Build concurrency, not batching | Raise `max_entries_to_build`. Do **not** raise `max_entries_to_merge` - see Tunables |
 
 The `merge_group` path is guarded by regression tests in
-`tests/unit/test_required_check_canary_workflow_yaml.py` that execute the
-shipped `ci-gate` roll-up against a synthetic `merge_group` payload. If a
-future change to `ci.yml` would wedge the queue, those tests fail in CI
-before the change can merge.
+`tests/unit/test_required_check_canary_workflow_yaml.py` (required-context
+coverage plus the shipped `ci-gate` roll-up executed against a synthetic
+`merge_group` payload), `tests/unit/test_post_ci_dispatcher_yaml.py` (the
+release chain survives the queue) and
+`tests/unit/test_merge_queue_runbook_docs.py` (this document stays
+internally consistent). If a future change would wedge the queue or break
+the release path, those tests fail in CI before it can merge.

--- a/tests/unit/test_merge_queue_runbook_docs.py
+++ b/tests/unit/test_merge_queue_runbook_docs.py
@@ -1,0 +1,212 @@
+"""Consistency assertions on ``docs/operations/merge-queue.md``.
+
+The runbook is the declared source of truth for the merge-queue ruleset:
+the shipped ruleset is reconciled *to* the document, not the other way
+round. That only holds if the document cannot contradict itself, so the
+two places it states the configuration - the **Tunables** table and the
+copy-pasteable ``gh api`` payload in **Enable** - are diffed here.
+
+Also guarded:
+
+* the required-status contexts the runbook tells the operator to put on
+  the ruleset match the ones branch protection enforces at queue entry,
+  so the two gates cannot silently diverge;
+* claims that went stale once ``review-bot-ack.yml`` gained a
+  ``merge_group`` trigger, and once ``main-red-guard.yml`` was folded
+  into ``pr-policy.yml``, do not creep back in.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+RUNBOOK = Path("docs/operations/merge-queue.md")
+MERGE_GATE = Path("docs/operations/merge-gate.md")
+
+# Mirrors repos/sipyourdrink-ltd/bernstein/branches/main/protection
+# -> required_status_checks.contexts (app_id 15368 == GitHub Actions).
+BRANCH_PROTECTION_CONTEXTS = ("CI gate", "review-bot-ack")
+ACTIONS_INTEGRATION_ID = 15368
+
+# Tunable -> the value the Enable payload must carry. Sourced from the
+# runbook's own table at test time; this map only fixes the key set so a
+# silently dropped row is caught too.
+EXPECTED_TUNABLES = (
+    "merge_method",
+    "grouping_strategy",
+    "max_entries_to_build",
+    "min_entries_to_merge",
+    "max_entries_to_merge",
+    "min_entries_to_merge_wait_minutes",
+    "check_response_timeout_minutes",
+)
+
+
+@pytest.fixture(scope="module")
+def runbook_text() -> str:
+    return RUNBOOK.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def enable_payload(runbook_text: str) -> dict[str, Any]:
+    """The JSON heredoc the operator pipes into `gh api -X PUT .../rulesets`."""
+    match = re.search(r"<<'JSON'\n(.*?)\nJSON\n", runbook_text, re.DOTALL)
+    assert match, (
+        "merge-queue.md must keep a copy-pasteable ruleset payload in a "
+        "`<<'JSON' ... JSON` heredoc; the operator flip is meant to be "
+        "mechanical, not reconstructed from prose."
+    )
+    return json.loads(match.group(1))
+
+
+@pytest.fixture(scope="module")
+def documented_tunables(runbook_text: str) -> dict[str, str]:
+    """The `Correct` column of the Tunables table, keyed by parameter."""
+    tunables: dict[str, str] = {}
+    for line in runbook_text.splitlines():
+        row = re.match(r"^\|\s*`([a-z_]+)`\s*\|([^|]*)\|([^|]*)\|", line)
+        if row:
+            tunables[row.group(1)] = row.group(3).strip().strip("*").strip("`")
+    return tunables
+
+
+def _rule(payload: dict[str, Any], rule_type: str) -> dict[str, Any]:
+    for rule in payload.get("rules", []):
+        if rule.get("type") == rule_type:
+            params = rule.get("parameters")
+            assert isinstance(params, dict)
+            return params
+    raise AssertionError(f"enable payload is missing a `{rule_type}` rule")
+
+
+def test_runbook_exists() -> None:
+    assert RUNBOOK.exists(), "the merge-queue runbook is referenced from merge-gate.md"
+
+
+def test_tunables_table_lists_every_merge_queue_parameter(
+    documented_tunables: dict[str, str],
+) -> None:
+    missing = [k for k in EXPECTED_TUNABLES if k not in documented_tunables]
+    assert not missing, (
+        f"Tunables table is missing rows for {missing}. Every merge_queue rule "
+        "parameter must be documented with its rationale, or the shipped ruleset "
+        "has nothing to be reconciled against."
+    )
+
+
+@pytest.mark.parametrize("param", EXPECTED_TUNABLES)
+def test_enable_payload_matches_tunables_table(
+    param: str,
+    documented_tunables: dict[str, str],
+    enable_payload: dict[str, Any],
+) -> None:
+    """The prose table and the copy-paste payload must not disagree.
+
+    An operator following the runbook reads one and pastes the other. If they
+    drift, the queue ships with tunables nobody reviewed - which is exactly
+    the drift this document was written to close.
+    """
+    documented = documented_tunables[param]
+    applied = _rule(enable_payload, "merge_queue")[param]
+    assert str(applied) == documented, (
+        f"`{param}`: Tunables table says {documented!r} but the Enable payload "
+        f"applies {applied!r}. Fix whichever is wrong - the table is the "
+        "source of truth for the value, the payload for the syntax."
+    )
+
+
+def test_batch_size_is_pinned_to_one(enable_payload: dict[str, Any]) -> None:
+    """`max_entries_to_merge` > 1 breaks the release path and the diff planner.
+
+    With N entries merged per push, the base branch advances N commits in one
+    push event that reports only the last SHA. auto-release keys on that SHA,
+    so a version bump anywhere but last is skipped with no error. Separately,
+    `determine-changes` in ci.yml classifies a non-pull_request diff as
+    `HEAD~1...HEAD`, which on a multi-entry group sees only the last entry.
+    """
+    params = _rule(enable_payload, "merge_queue")
+    assert params["max_entries_to_merge"] == 1, (
+        "max_entries_to_merge must stay 1 until determine-changes diffs against "
+        "github.event.merge_group.base_sha and the release gate stops keying on "
+        "the push head SHA. See merge-queue.md :: Auto-release through the queue."
+    )
+
+
+def test_enable_payload_requires_every_branch_protection_context(
+    enable_payload: dict[str, Any],
+) -> None:
+    """The queue must enforce the same contexts as queue entry does."""
+    checks = _rule(enable_payload, "required_status_checks")["required_status_checks"]
+    contexts = {c["context"] for c in checks}
+    assert contexts == set(BRANCH_PROTECTION_CONTEXTS), (
+        f"ruleset payload requires {sorted(contexts)} but branch protection "
+        f"requires {sorted(BRANCH_PROTECTION_CONTEXTS)} at queue entry. A context "
+        "required to enter the queue but not to leave it means the queue enforces "
+        "less than the PR gate did."
+    )
+    for check in checks:
+        assert check.get("integration_id") == ACTIONS_INTEGRATION_ID, (
+            f"{check['context']!r} must be pinned to the GitHub Actions app "
+            f"(integration_id {ACTIONS_INTEGRATION_ID}) so an unrelated app "
+            "cannot satisfy a required context."
+        )
+
+
+def test_enable_payload_does_not_activate_the_ruleset(
+    enable_payload: dict[str, Any],
+) -> None:
+    """Step 1 configures; Step 3 enables. Keep them separate.
+
+    Enabling is a shared-state change that serialises every open PR. Folding it
+    into the rule-writing call means a typo in the rules and the flip land
+    together, with no chance to verify the payload first.
+    """
+    assert enable_payload.get("enforcement") == "disabled", (
+        "the Step 1 payload must keep `enforcement: disabled`; the flip is a separate, reviewable call in Step 3."
+    )
+
+
+@pytest.mark.parametrize("doc", [RUNBOOK, MERGE_GATE])
+def test_no_stale_review_bot_ack_claim(doc: Path) -> None:
+    """`review-bot-ack` does run on merge_group; the old warning must not return."""
+    text = doc.read_text(encoding="utf-8")
+    stale = re.search(
+        r"review-bot-ack[^.\n]{0,80}(triggers only on|runs on `pull_request` only)",
+        text,
+    )
+    assert stale is None, (
+        f"{doc} repeats the stale claim that review-bot-ack cannot report on a "
+        f"merge_group ref ({stale.group(0)!r} if matched). review-bot-ack.yml "
+        "declares `merge_group: {}` and carries a pass-through emitter."
+    )
+
+
+@pytest.mark.parametrize("doc", [RUNBOOK, MERGE_GATE])
+def test_no_reference_to_retired_main_red_guard_workflow(doc: Path) -> None:
+    """main-red-guard is a step in pr-policy.yml, not a standalone workflow."""
+    text = doc.read_text(encoding="utf-8")
+    assert "main-red-guard.yml" not in text, (
+        f"{doc} refers to `main-red-guard.yml`, which no longer exists - the "
+        "advisory was consolidated into `.github/workflows/pr-policy.yml`. "
+        "Point operator steps at pr-policy.yml instead."
+    )
+
+
+def test_runbook_documents_the_release_path_through_the_queue(
+    runbook_text: str,
+) -> None:
+    """The highest-risk question must have a written answer, not an assumption."""
+    assert "gh-readonly-queue/" in runbook_text, (
+        "the runbook must name the queue's ephemeral ref prefix; it is why the "
+        "workflow_run listener does not fire on speculative queue builds"
+    )
+    assert "github-merge-queue[bot]" in runbook_text, (
+        "the runbook must record that the post-queue push to main is emitted by "
+        "github-merge-queue[bot] and does start push-triggered workflows - that "
+        "is the evidence the auto-release chain survives the queue"
+    )

--- a/tests/unit/test_post_ci_dispatcher_yaml.py
+++ b/tests/unit/test_post_ci_dispatcher_yaml.py
@@ -262,3 +262,101 @@ def test_dispatcher_grants_cover_callee_requests(dispatcher: dict[str, Any], chi
         "conclusion: startup_failure with zero check_runs and every child silently stops running. "
         f"Widen the job's `permissions:` block to cover {required}."
     )
+
+
+# ---------------------------------------------------------------------------
+# Merge-queue readiness: the auto-release chain must survive the queue (#2966)
+#
+# Chain under the queue:
+#   queue merges -> push to `main` at the SAME SHA the queue tested
+#                -> ci.yml (push) -> workflow_run -> this dispatcher
+#                -> auto-release -> tag -> publish.
+#
+# Two properties keep that chain intact, and both are one careless edit away
+# from silently breaking (green CI, no tag, no error). See
+# docs/operations/merge-queue.md :: "Auto-release through the queue".
+# ---------------------------------------------------------------------------
+
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+# The merge queue runs CI on an ephemeral ref named
+# `gh-readonly-queue/<base>/pr-<n>-<base_sha>`, never on `main` itself.
+MERGE_QUEUE_REF_PREFIX = "gh-readonly-queue/"
+
+# The auto-release gate keys on a `version = ` change in this file, so it must
+# never be excluded from the `push` CI run the dispatcher listens for.
+RELEASE_TRIGGER_PATH = "pyproject.toml"
+
+
+@pytest.fixture(scope="module")
+def ci_workflow() -> dict[str, Any]:
+    return _load(CI_WORKFLOW)
+
+
+def test_dispatcher_does_not_listen_on_merge_queue_refs(dispatcher: dict[str, Any]) -> None:
+    """A queue ref must never dispatch auto-release.
+
+    `merge_group` CI runs report `head_branch` as the ephemeral
+    `gh-readonly-queue/...` ref. Those runs are speculative - the entry can
+    still be ejected - so tagging off one would publish a release for a
+    commit that never landed on `main`. The `branches: [main]` filter is
+    what prevents it.
+    """
+    wfr = _on(dispatcher).get("workflow_run")
+    assert isinstance(wfr, dict)
+    branches = wfr.get("branches")
+    assert branches == ["main"], (
+        "dispatcher must stay filtered to `branches: [main]`. Widening it to the "
+        f"merge queue's `{MERGE_QUEUE_REF_PREFIX}**` refs would tag releases from "
+        "speculative queue builds that may never merge."
+    )
+    for pattern in branches:
+        assert not pattern.startswith(MERGE_QUEUE_REF_PREFIX), (
+            f"`{pattern}` matches a merge-queue ephemeral ref; see above"
+        )
+
+
+def test_ci_push_trigger_still_covers_main(ci_workflow: dict[str, Any]) -> None:
+    """The post-queue push to `main` is what reaches this dispatcher.
+
+    The merge queue advances `main` to the same SHA it tested and emits an
+    ordinary `push` event (actor `github-merge-queue[bot]`). If ci.yml ever
+    stopped triggering on `push` to `main`, no `workflow_run` would fire and
+    every release would stop silently.
+    """
+    push = _on(ci_workflow).get("push")
+    assert isinstance(push, dict), "ci.yml must keep a `push:` trigger"
+    assert push.get("branches") == ["main"], (
+        "ci.yml must keep `push.branches: [main]`; post-ci-dispatcher.yml listens "
+        "for the CI run produced by the post-queue push to main."
+    )
+
+
+def test_ci_push_paths_ignore_does_not_cover_release_trigger(
+    ci_workflow: dict[str, Any],
+) -> None:
+    """`pyproject.toml` must keep triggering CI on `main`.
+
+    auto-release only tags when the triggering commit changed `version = ` in
+    pyproject.toml. Path-ignoring it would mean the version-bump merge never
+    runs CI, never produces a `workflow_run`, and never reaches the release
+    gate - with no failure anywhere to notice.
+    """
+    push = _on(ci_workflow).get("push")
+    assert isinstance(push, dict)
+    ignored = [str(p) for p in (push.get("paths-ignore") or [])]
+    offenders = [p for p in ignored if not p.startswith("!") and (p == RELEASE_TRIGGER_PATH or p in {"*", "**"})]
+    assert not offenders, (
+        f"ci.yml `push.paths-ignore` must not exclude `{RELEASE_TRIGGER_PATH}` "
+        f"(found {offenders}); the auto-release listener would never fire for a "
+        "version bump."
+    )
+
+
+def test_ci_declares_merge_group_trigger(ci_workflow: dict[str, Any]) -> None:
+    """CI must run on the queue's ephemeral ref, otherwise nothing gates it."""
+    on = _on(ci_workflow)
+    assert "merge_group" in on, (
+        "ci.yml must declare a `merge_group:` trigger; without it the `CI gate` "
+        "required context never reports on a queued group and the queue wedges."
+    )

--- a/tests/unit/test_required_check_canary_workflow_yaml.py
+++ b/tests/unit/test_required_check_canary_workflow_yaml.py
@@ -476,3 +476,118 @@ def test_ci_gate_rollup_passes_on_push(ci_doc: dict[str, object], tmp_path: Path
         plan={"docs_only": "false", "macos_sensitive": "false"},
     )
     assert proc.returncode == 0, f"CI gate roll-up must pass on push.\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+
+
+# ---------------------------------------------------------------------------
+# Merge-queue required-context coverage (#2966)
+#
+# Every context branch protection requires on a PR must also be reportable on
+# a `merge_group` ref, otherwise the queue waits forever for a check that can
+# never publish. See docs/operations/merge-queue.md ::
+# "Required-check coverage under `merge_group`".
+# ---------------------------------------------------------------------------
+
+REVIEW_BOT_ACK_CONTEXT = "review-bot-ack"
+REVIEW_BOT_ACK_WF = Path(".github/workflows/review-bot-ack.yml")
+
+# Mirrors `repos/sipyourdrink-ltd/bernstein/branches/main/protection`
+# -> required_status_checks.contexts. Keep in sync with the canary's
+# BRANCH_PROTECTION_CONTEXTS_JSON.
+BRANCH_PROTECTION_CONTEXTS = (REQUIRED_CONTEXT, REVIEW_BOT_ACK_CONTEXT)
+
+
+def _on(doc: dict[str, object]) -> dict[str, object]:
+    # PyYAML 1.1 parses a bare ``on:`` key as the boolean True.
+    on = doc.get(True, doc.get("on"))
+    assert isinstance(on, dict), "workflow must have an `on:` block"
+    return on
+
+
+def _merge_group_context_emitters() -> dict[str, list[str]]:
+    """Map check-run name -> ``file::job`` for jobs reachable on merge_group."""
+    emitters: dict[str, list[str]] = {}
+    for wf_path in sorted(WORKFLOWS_DIR.glob("*.yml")):
+        doc = yaml.safe_load(wf_path.read_text(encoding="utf-8"))
+        if not isinstance(doc, dict):
+            continue
+        on = doc.get(True, doc.get("on"))
+        if not isinstance(on, dict) or "merge_group" not in on:
+            continue
+        jobs = doc.get("jobs")
+        if not isinstance(jobs, dict):
+            continue
+        for key, body in jobs.items():
+            if not isinstance(body, dict):
+                continue
+            name = body.get("name")
+            if not isinstance(name, str):
+                continue
+            # A job gated to some *other* event cannot report on the queue.
+            guard = str(body.get("if") or "")
+            if "github.event_name != 'merge_group'" in guard:
+                continue
+            emitters.setdefault(name, []).append(f"{wf_path.name}::{key}")
+    return emitters
+
+
+@pytest.mark.parametrize("context", BRANCH_PROTECTION_CONTEXTS)
+def test_required_context_has_a_merge_group_emitter(context: str) -> None:
+    """Each PR-required context must be publishable on a merge_group ref."""
+    emitters = _merge_group_context_emitters()
+    assert context in emitters, (
+        f"No workflow publishes the required context {context!r} on a "
+        "`merge_group` event. Enabling the merge queue would wedge every merge: "
+        "the queue blocks forever on a required check that never reports. Add a "
+        "`merge_group:` trigger and a job whose `name:` is exactly this context. "
+        f"Contexts currently reachable on merge_group: {sorted(emitters)}"
+    )
+
+
+def test_ci_merge_group_trigger_is_unconditional(ci_doc: dict[str, object]) -> None:
+    """`ci.yml`'s merge_group trigger must carry no filters.
+
+    This is what makes ``ci-gate-stub.yml`` safe to leave on ``pull_request``
+    only. The stub exists because ci.yml's ``pull_request`` trigger is
+    ``paths-ignore``-filtered, so a fully-ignored diff never publishes
+    ``CI gate``. ``paths``/``paths-ignore`` are evaluated only for ``push``,
+    ``pull_request`` and ``pull_request_target``, so on a merge group ci.yml
+    always runs and always publishes the context - no stub needed.
+
+    Adding any filter here (or gating the job on an event) would silently
+    wedge the queue for every diff the filter excludes.
+    """
+    merge_group = _on(ci_doc).get("merge_group")
+    assert merge_group in (None, {}), (
+        "ci.yml `merge_group:` must stay unconditional (`merge_group: {}`); "
+        f"found {merge_group!r}. A filtered merge_group trigger means some "
+        "merge groups never publish `CI gate` and sit in the queue forever."
+    )
+
+
+def test_review_bot_ack_has_merge_group_passthrough() -> None:
+    """The queue-side emitter for `review-bot-ack` must stay wired.
+
+    The real gate evaluates PR review threads and has nothing to evaluate on
+    the queue's ephemeral ref, so a dedicated pass-through job republishes the
+    identical context name there. Without it the context cannot be required on
+    the ruleset, and the two gates (PR entry vs queue merge) drift apart.
+    """
+    doc = yaml.safe_load(REVIEW_BOT_ACK_WF.read_text(encoding="utf-8"))
+    assert isinstance(doc, dict)
+    assert "merge_group" in _on(doc), "review-bot-ack.yml must trigger on merge_group"
+
+    jobs = doc.get("jobs")
+    assert isinstance(jobs, dict)
+    passthrough = [
+        key
+        for key, body in jobs.items()
+        if isinstance(body, dict)
+        and body.get("name") == REVIEW_BOT_ACK_CONTEXT
+        and "merge_group" in str(body.get("if") or "")
+        and "!=" not in str(body.get("if") or "")
+    ]
+    assert passthrough, (
+        f"review-bot-ack.yml must keep a job named {REVIEW_BOT_ACK_CONTEXT!r} "
+        "gated to `github.event_name == 'merge_group'` so the context reports "
+        "on queued groups."
+    )


### PR DESCRIPTION
Prepares #2966; the ruleset flip is deliberately deferred until after the v3.10.0 release.

This PR makes the repo **ready** for the merge queue. It changes no repository settings and no workflow triggers.

## merge_group coverage audit

Required contexts on `main` (branch protection): `CI gate`, `review-bot-ack`.
Ruleset `main-merge-queue` (`enforcement: disabled`) requires: `CI gate` only.

| Required context | Emitter | Runs on `merge_group`? |
|---|---|---|
| `CI gate` | `ci.yml :: ci-gate` | Yes |
| `CI gate` | `ci-gate-stub.yml :: ci-gate` | No — and correct |
| `review-bot-ack` | `review-bot-ack.yml :: merge-group-pass` | Yes |

**No trigger gap; no workflow file was edited** (so no `ci-topology.md` regeneration was required).

`ci-gate-stub.yml` exists only because `ci.yml`'s `pull_request` trigger is `paths-ignore`-filtered. `paths`/`paths-ignore` are evaluated only for `push`, `pull_request` and `pull_request_target`, so `ci.yml` runs on **every** merge group and always publishes `CI gate`. That makes ci.yml's unconditional `merge_group: {}` a load-bearing invariant — now locked by a test rather than left implicit.

## review-bot-ack contradiction — resolved

`review-bot-ack.yml` now declares `merge_group: {}` with a `merge-group-pass` job that republishes the identical context, so the runbook's blockquote saying it must never go on the ruleset was factually stale. Decision: **it belongs on the ruleset**, alongside `CI gate`. Leaving it off would mean the queue enforces less than PR entry does. Corrected in `merge-queue.md` and `merge-gate.md`.

## Auto-release verdict: the release path survives the queue

Verified against a public repository running the queue at scale (`cilium/cilium`, 2026-07-24):

| Event | `head_branch` | `head_sha` | Actor |
|---|---|---|---|
| `merge_group` run, 23:21:05Z | `gh-readonly-queue/main/pr-47100-67dfc5a2…` | `90c7690d43…` | — |
| `push` run, 23:34:05Z | `main` | `90c7690d43…` (identical) | `github-merge-queue[bot]` |

- The queue advances `main` to the **same SHA** it tested and emits an ordinary `push` event, which is **not** suppressed by Actions loop prevention. `ci.yml` (push) → `workflow_run` → `post-ci-dispatcher.yml` → `auto-release.yml` is intact.
- `merge_group` runs report a `gh-readonly-queue/...` head branch, which the dispatcher's existing `branches: [main]` filter excludes. Nothing is tagged from a speculative queue build that may never merge.

## Tunables: the doc is the source of truth

| Parameter | Shipped | Now documented | Why |
|---|---|---|---|
| `max_entries_to_build` | 1 | **5** | Build concurrency. At 1 a burst of N PRs costs N sequential full CI cycles with no load benefit over today. |
| `max_entries_to_merge` | 1 | **1** (was documented as 5) | See below. |
| `min_entries_to_merge_wait_minutes` | 0 | **0** (was documented as 5) | Nothing to wait for with batch size 1. |
| `check_response_timeout_minutes` | 30 | **120** (was documented as 60) | Measured over the last 30 successful CI runs on `main`: p50 38 min, p90 58 min, max 105 min. At 30 **every** entry would be ejected as timed out; at 60, roughly one in ten. |

`max_entries_to_merge` is pinned to 1 rather than raised to 5, because merging N entries lands N commits under a **single** push SHA:

1. `auto-release`'s gate only tags when *the triggering commit* changed `version = ` in `pyproject.toml`. A bump anywhere but last in a batch would be skipped with no error — green CI, no tag, no publish.
2. `determine-changes` in `ci.yml` classifies non-`pull_request` diffs as `HEAD~1...HEAD`, which on a multi-entry group sees only the last entry. A docs-only last entry would let the whole batch skip the Python test jobs via the `DOCS_ONLY_SKIPPABLE` tolerance.

Lifting it needs `determine-changes` to diff against `github.event.merge_group.base_sha`; noted as a follow-up in the runbook.

## Also

- Added an ordered **Enable (mechanical steps)** section: read-only preflight → configure rules while still disabled → drain → flip → smoke-test the release chain, with rollback.
- `main-red-guard.yml` no longer exists standalone (consolidated into `pr-policy.yml`); the runbook states it is already advisory-only and needs no action at flip time.

## Tests

New coverage in `tests/unit/test_required_check_canary_workflow_yaml.py`, `tests/unit/test_post_ci_dispatcher_yaml.py` and `tests/unit/test_merge_queue_runbook_docs.py`. Each new assertion was verified non-vacuous by mutating the invariant it guards (dropping the `merge_group` trigger, filtering it, path-ignoring `pyproject.toml`, widening the dispatcher to queue refs, drifting the tunables table, restoring the stale claim, raising the batch size) — all seven mutations fail the suite.

`69 passed` across the four targeted files; `ruff check` and `ruff format --check` clean; `typos` clean.

## Left for the operator

Enabling the queue is **not** part of this PR. `docs/operations/merge-queue.md` carries the exact ordered commands.