### PR TITLE
feat(delegation): recompute per-hop authority narrowing from receipts

### DIFF
--- a/docs/security/AUDIT.md
+++ b/docs/security/AUDIT.md
@@ -68,6 +68,9 @@ The package includes:
   verify, Merkle seal, SIEM, recovery.
 - [Multi-tenant audit-chain export](audit-multitenant.md) - per-tenant slice with
   optional RFC 3161 timestamping.
+- [Delegation narrowing](delegation-narrowing.md) - recomputing child-subset-of-parent
+  authority, separation of duties, and decision-time charter binding from delegation
+  receipts.
 - [DSSE / in-toto envelope](audit-dsse-envelope.md) - third-party-verifiable wrapper
   over the bundle.
 - [EU AI Act Article 12 evidence pack](../compliance/eu-ai-act-article-12-bundle.md)

--- a/docs/security/delegation-narrowing.md
+++ b/docs/security/delegation-narrowing.md
@@ -1,0 +1,154 @@
+# Delegation narrowing, separation of duties, and decision binding
+
+`bernstein delegation verify <run>` reconstructs a run's per-hop delegation
+receipts offline. This page covers what it can prove about *authority* —
+beyond the tamper evidence the HMAC chain already gave you.
+
+## Why sequence is not narrowing
+
+A delegation receipt records `issuer`, `subject`, `audience`, and `act`, HMAC-
+chained hop to hop. That proves the **sequence and integrity** of a delegation
+chain: the order is fixed, no hop was deleted, no field was flipped.
+
+It does not prove that authority **narrowed**, because the authority granted at
+each hop was never part of the record. Without it, the only answer to "did this
+sub-agent hold more than the worker that spawned it?" is "the route checks
+would have refused anything wider" — which is an argument about code paths, not
+something an auditor can recompute from the receipts they were handed.
+
+A hop now records the **effective scope** it granted (or a content-addressed
+reference to it) plus the **parent hop it descends from**, so the child ⊆ parent
+relation is recomputed per hop from the receipts alone.
+
+## Three checks, deliberately distinct
+
+| Check | Question | Failure |
+|---|---|---|
+| Narrowing | Did a child hop gain authority its parent lacked? | `narrowing_ok: false`, offending axis named |
+| Separation of duties | Did one principal exercise incompatible powers? | `duties_ok: false`, the duty pair named |
+| Decision binding | Was a gated decision pinned to a charter version? | `binding_ok: false` |
+
+Blurring them loses information. A chain can narrow perfectly at every hop and
+still route both `spawn` and `approve` to the same principal. A chain can
+separate duties cleanly while widening scope at one hop. Each check reports its
+own verdict; `valid` is true only when the chain is intact **and** all three
+pass.
+
+### Narrowing axes
+
+Scope axes follow the capability-token convention that `None` is the *widest*
+value, so a child that drops a bound its parent imposed widens on that axis.
+
+| Axis | Subset rule |
+|---|---|
+| `permissions` | set subset |
+| `duties` | set subset |
+| `task_ids` | allowlist subset (`None` = any task) |
+| `path_prefixes` | POSIX ancestor-or-equal coverage (`/a/b` covers `/a/b/c`, never `/a/bc`) |
+| `not_after` | no later than the parent |
+| `max_uses` | no greater than the parent |
+| `max_depth` | no greater than the parent |
+
+The allowlist, path-prefix, and bound primitives are the same code that governs
+signed capability tokens (`bernstein.core.security.capability_tokens`), so an
+axis means one thing across both surfaces.
+
+Four structural failures are reported with their own axis names:
+
+- `scope_ref_mismatch` — the inline scope does not hash to the recorded content address.
+- `unresolved_scope` — a by-reference scope could not be fetched.
+- `unresolved_parent` — `parent_ref` names no preceding hop.
+- `unscoped_parent` — the hop records a scope but its parent does not, so the ceiling it narrows against is unrecorded. Narrowing is then **unprovable**, which is reported as a failure rather than assumed to be fine.
+
+### Separation of duties
+
+Duties are `spawn`, `approve`, and `merge`. By default all three pairs are
+separated: whoever asked for the work does not bless it, and whoever blessed it
+does not land it. The acting principal is the receipt's `subject`.
+
+Duties come from the hop's recorded scope when it declares any; otherwise they
+are inferred from the `act` name on whole segments (`task.spawn` → `spawn`,
+while `spawner.status` matches nothing), so chains recorded before scopes
+existed still get coverage.
+
+The rule set is an argument, not a fixed policy — pass your own pairs to
+`check_duties(receipts, separated=...)`.
+
+### Decision binding
+
+A hop may record the charter hash and tenant-certificate version **in force
+when it was recorded**. The binding sits inside the receipt body, so it is
+covered by the receipt HMAC: rewriting a recorded version breaks the chain
+rather than silently reinterpreting a historical decision.
+
+Two failures:
+
+- `binding_missing` — the chain binds a charter version somewhere, but a hop exercising `approve` or `merge` records none, so that decision floats free of the version it was taken under.
+- `binding_drift` — a hop cites a different charter hash or certificate version than its parent. One authority chain is evaluated under one version; a changed charter needs a new certificate, not a re-interpreted hop.
+
+## Recording a scoped hop
+
+```python
+from bernstein.core.identity.delegation import record_delegation_hop
+from bernstein.core.identity.delegation_scope import DecisionBinding, DelegationScope
+
+record_delegation_hop(
+    run_id="run-42",
+    issuer="orchestrator",
+    subject="sub-agent:backend",
+    audience="sub-agent:backend",
+    act="task.delegate",
+    scope=DelegationScope(
+        permissions=frozenset({"files.read", "files.write"}),
+        duties=frozenset({"spawn"}),
+        task_ids=frozenset({"t-1"}),
+        path_prefixes=frozenset({"/repo/src"}),
+        not_after=1_800_000_000.0,
+        max_uses=4,
+        max_depth=2,
+    ),
+    binding=DecisionBinding(charter_hash="sha256:...", certificate_version="7"),
+)
+```
+
+Pass `inline_scope=False` to record only the content address; the verifier then
+needs a resolver:
+
+```python
+verify_run_chain(root=root, run_id="run-42", key=key, scope_resolver=store.get)
+```
+
+## Verifying
+
+```console
+$ bernstein delegation verify run-42
+  hop 0: principal:alex -> orchestrator  (run.authorize)
+      scope sha256:8f1c...
+  hop 1: orchestrator -> sub-agent:backend  (task.delegate)
+      scope sha256:2b90...
+scope coverage: full
+delegation chain intact (2 hop(s))
+```
+
+A widening hop exits non-zero with the axis named:
+
+```console
+$ bernstein delegation verify run-42
+  ...
+hop 1 (parent hop 0): narrowing/permissions: child scope widens the parent on
+permissions: {files.read, gate.approve} is not within {files.read, files.write}
+delegation authority verification failed: narrowing
+```
+
+`--json` emits the same verdict machine-readably, with `chain_ok` (tamper
+evidence) separate from `valid` (tamper evidence plus all three authority
+checks), an `authority` block carrying the three sub-verdicts, the scope
+coverage, and every violation with its `check`, `axis`, `hop_index`,
+`parent_hop_index`, and `principal`.
+
+## Compatibility
+
+Every field is optional. A chain recorded before these fields existed carries no
+scope, produces no violations, and hashes byte-identically to before — the
+optional keys are omitted from the signed body entirely when unset, so an old
+writer and a new writer that record the same unscoped hop produce the same HMAC.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -443,6 +443,7 @@ nav:
           - SOC 2 audit: security/AUDIT.md
           - Audit log: security/audit-log.md
           - Multi-tenant audit export: security/audit-multitenant.md
+          - Delegation narrowing: security/delegation-narrowing.md
           - DSSE / in-toto envelope: security/audit-dsse-envelope.md
           - EU AI Act Article 12: compliance/eu-ai-act-article-12-bundle.md
           - EU residency setup: compliance/eu-residency-customer-setup.md

--- a/src/bernstein/cli/commands/delegation_cmd.py
+++ b/src/bernstein/cli/commands/delegation_cmd.py
@@ -5,7 +5,10 @@ Two distinct surfaces:
 * ``delegation verify <run>`` reconstructs the per-hop HMAC *receipt* chain for
   a run (the ACT log: which principal authorized which sub-agent action, see
   :mod:`bernstein.core.identity.delegation`), exiting non-zero on any tamper,
-  deleted hop, or missing chain (issue #2305 AC4).
+  deleted hop, or missing chain (issue #2305 AC4). For hops that record their
+  effective scope it also recomputes child-subset-of-parent narrowing,
+  separation of duties, and decision-time charter binding, exiting non-zero
+  when any of those relations is violated (issue #2554).
 * ``delegation verify-token <token-file>`` verifies a signed *authority* token
   chain (see :mod:`bernstein.core.security.capability_tokens`): per-hop
   signature, structural linkage, identity/pubkey continuity, monotonic
@@ -49,17 +52,26 @@ def delegation_group() -> None:
 def verify_cmd(run: str, root: Path | None, as_json: bool) -> None:
     """Reconstruct and verify the delegation chain for RUN.
 
-    Exits 0 when the chain is intact (at least one hop, every hop verifies
-    from genesis to tail); 1 otherwise.
+    Checks tamper evidence (linkage plus HMAC) and, for hops that record their
+    effective scope, recomputes three distinct authority relations: that each
+    child scope is a subset of its parent's, that no principal exercised
+    separated duties (spawn / approve / merge), and that gated decisions cite
+    the charter version in force at decision time.
+
+    Exits 0 when the chain is intact and every authority check passes; 1
+    otherwise.
     """
     result = delegation.verify_run(run, root=root)
+    authority = result.authority
 
     if as_json:
         payload = {
             "run": run,
             "valid": result.valid,
+            "chain_ok": result.chain_ok,
             "hops": result.hops,
             "errors": result.errors,
+            "authority": authority.to_dict(),
             "receipts": [
                 {
                     "hop_index": r.hop_index,
@@ -67,6 +79,9 @@ def verify_cmd(run: str, root: Path | None, as_json: bool) -> None:
                     "subject": r.subject,
                     "audience": r.audience,
                     "act": r.act,
+                    "parent_ref": r.parent_ref,
+                    "scope_ref": r.scope_ref,
+                    "binding": r.binding,
                 }
                 for r in result.receipts
             ],
@@ -80,12 +95,34 @@ def verify_cmd(run: str, root: Path | None, as_json: bool) -> None:
 
     for r in result.receipts:
         console.print(f"  hop {r.hop_index}: {r.issuer} -> {r.audience}  [dim]({r.act})[/dim]")
+        if r.scope_ref:
+            console.print(f"[dim]      scope {r.scope_ref}[/dim]")
+        if r.binding:
+            bits = ", ".join(f"{k}={v}" for k, v in sorted(r.binding.items()))
+            console.print(f"[dim]      binding {bits}[/dim]")
+
+    console.print(f"[dim]scope coverage:[/dim] {authority.scope_coverage}")
+    for violation in authority.violations:
+        console.print(f"[red]  {violation}[/red]")
+    for err in result.errors:
+        console.print(f"[red]  {err}[/red]")
+
     if result.valid:
         console.print(f"[green]delegation chain intact[/green] ({result.hops} hop(s))")
         raise SystemExit(0)
-    for err in result.errors:
-        console.print(f"[red]  {err}[/red]")
-    console.print("[red]delegation chain verification failed[/red]")
+    if not result.chain_ok:
+        console.print("[red]delegation chain verification failed[/red]")
+    else:
+        failed = [
+            name
+            for name, ok in (
+                ("narrowing", authority.narrowing_ok),
+                ("separation-of-duties", authority.duties_ok),
+                ("decision binding", authority.binding_ok),
+            )
+            if not ok
+        ]
+        console.print(f"[red]delegation authority verification failed:[/red] {', '.join(failed)}")
     raise SystemExit(1)
 
 

--- a/src/bernstein/core/identity/delegation.py
+++ b/src/bernstein/core/identity/delegation.py
@@ -20,7 +20,14 @@ Each receipt is one JSONL line under ``<root>/delegation/<run_id>.jsonl``::
       "act": "task.spawn",            # the delegated action
       "created": 1730000000,
       "prev_hmac": "<hex>",
-      "hmac": "<hex>"
+      "hmac": "<hex>",
+
+      # optional authority binding (absent on receipts written before it
+      # existed); see bernstein.core.identity.delegation_scope
+      "parent_ref": "<hmac of the hop this descends from>",
+      "scope_ref": "sha256:<hex>",    # content address of the granted scope
+      "scope": {...},                 # the effective scope, carried inline
+      "binding": {"charter_hash": "...", "certificate_version": "..."}
     }
 
 The HMAC covers the previous receipt's HMAC concatenated with the canonical
@@ -32,6 +39,19 @@ deleted hop, or the wrong key surfaces as a linkage/HMAC error in
 The key is the install-scoped audit key (``load_or_create_audit_key``) so the
 delegation chain shares the install's tamper-evidence anchor: strip the
 identity and the chain no longer verifies.
+
+Sequence is not narrowing
+-------------------------
+The HMAC chain proves the *order and integrity* of a delegation sequence. It
+cannot prove that authority narrowed, because until the ``scope`` fields above
+existed the authority granted at each hop was never written down - so the only
+answer to "did this sub-agent hold more than the worker that spawned it?" was
+"the route checks would have refused it", which is an argument rather than a
+receipt. A hop that records its effective scope and names its parent lets
+:func:`verify_run_chain` recompute the child-subset-of-parent relation from the
+receipts alone. The recomputation, the separation-of-duties check, and the
+decision-time charter binding live in
+:mod:`bernstein.core.identity.delegation_scope`.
 """
 
 from __future__ import annotations
@@ -48,8 +68,16 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final
 
+from bernstein.core.identity.delegation_scope import (
+    AuthorityReport,
+    DecisionBinding,
+    DelegationScope,
+    ScopeViolation,
+    verify_authority,
+)
+
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
 
 if sys.platform == "win32":
     fcntl = None  # type: ignore[assignment]
@@ -59,9 +87,13 @@ else:
 __all__ = [
     "DEFAULT_ROOT",
     "GENESIS_HMAC",
+    "AuthorityReport",
     "ChainResult",
+    "DecisionBinding",
     "DelegationLedger",
     "DelegationReceipt",
+    "DelegationScope",
+    "ScopeViolation",
     "default_ledger",
     "record_delegation_hop",
     "verify_run",
@@ -86,6 +118,11 @@ DEFAULT_ROOT: Final[Path] = Path(".sdd/audit")
 _RUN_LOCKS: Final[dict[str, threading.Lock]] = {}
 _RUN_LOCKS_GUARD: Final[threading.Lock] = threading.Lock()
 
+#: Receipt fields that are omitted from the signed body when unset, so a hop
+#: recorded without authority binding hashes exactly as it did before those
+#: fields existed.
+_OPTIONAL_BODY_FIELDS: Final[tuple[str, ...]] = ("parent_ref", "scope_ref", "scope", "binding")
+
 
 def _run_lock(run_id: str) -> threading.Lock:
     """Return the process-wide append lock for ``run_id`` (created on demand)."""
@@ -99,7 +136,14 @@ def _run_lock(run_id: str) -> threading.Lock:
 
 @dataclass(frozen=True)
 class DelegationReceipt:
-    """A single HMAC-chained delegation hop."""
+    """A single HMAC-chained delegation hop.
+
+    The authority fields (``parent_ref``, ``scope_ref``, ``scope``,
+    ``binding``) are optional and absent from receipts recorded before they
+    existed. They are part of the signed body when present, so the grant a hop
+    carried and the charter version it was decided under are covered by the
+    receipt HMAC.
+    """
 
     run_id: str
     hop_index: int
@@ -110,11 +154,29 @@ class DelegationReceipt:
     created: int
     prev_hmac: str = GENESIS_HMAC
     hmac: str = ""
+    #: HMAC of the hop this one descends from (:data:`GENESIS_HMAC` for a root).
+    #: Lets a run record a delegation *tree* in one file: the parent is named,
+    #: not assumed to be the preceding line.
+    parent_ref: str | None = None
+    #: Content address (``sha256:<hex>``) of the effective scope granted here.
+    scope_ref: str | None = None
+    #: The effective scope body, when carried inline rather than by reference.
+    scope: dict[str, Any] | None = None
+    #: Charter hash / tenant-certificate version in force at decision time.
+    binding: dict[str, Any] | None = None
 
     def body(self) -> dict[str, Any]:
-        """Return the signed body (all fields except ``hmac``)."""
+        """Return the signed body (all fields except ``hmac``).
+
+        Optional authority fields that are unset are omitted entirely, so a
+        receipt recorded without them produces byte-identical signing input to
+        one written before the fields existed.
+        """
         data = asdict(self)
         data.pop("hmac", None)
+        for key in _OPTIONAL_BODY_FIELDS:
+            if data.get(key) is None:
+                data.pop(key, None)
         return data
 
 
@@ -131,12 +193,27 @@ def _compute_hmac(key: bytes, prev_hmac: str, body: dict[str, Any]) -> str:
 
 @dataclass
 class ChainResult:
-    """Outcome of reconstructing a run's delegation chain offline."""
+    """Outcome of reconstructing a run's delegation chain offline.
+
+    ``chain_ok`` is the tamper-evidence verdict (linkage plus HMAC), unchanged
+    from before authority checks existed. ``valid`` is the overall verdict: the
+    chain is intact *and* the recomputed authority checks found nothing. A
+    widening hop therefore fails ``bernstein delegation verify`` even though
+    every HMAC in the file is correct - which is the point, since the party
+    that wrote a widened hop holds the key that seals it.
+    """
 
     valid: bool
     hops: int
     receipts: list[DelegationReceipt] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
+    chain_ok: bool = True
+    authority: AuthorityReport = field(default_factory=lambda: AuthorityReport())
+
+    @property
+    def violations(self) -> list[ScopeViolation]:
+        """Recomputed authority failures (narrowing, duties, binding)."""
+        return self.authority.violations
 
 
 class DelegationLedger:
@@ -226,6 +303,10 @@ class DelegationLedger:
         audience: str,
         act: str,
         created: int | None = None,
+        scope: DelegationScope | None = None,
+        parent_ref: str | None = None,
+        binding: DecisionBinding | None = None,
+        inline_scope: bool = True,
     ) -> DelegationReceipt:
         """Append one delegation receipt and return it.
 
@@ -237,6 +318,19 @@ class DelegationLedger:
             act: Symbolic name of the delegated action.
             created: Optional unix timestamp; defaults to now (exposed for
                 deterministic tests).
+            scope: The effective authority granted at this hop. When supplied,
+                the receipt records its content address and (by default) the
+                scope body, so a verifier can recompute child-subset-of-parent
+                offline instead of trusting that route checks caught every
+                invalid action.
+            parent_ref: HMAC of the hop this one descends from. Defaults to the
+                preceding hop when a ``scope`` is recorded, which is the linear
+                ``principal -> orchestrator -> sub-agent`` case; pass it
+                explicitly when a run records a delegation tree.
+            binding: Charter hash / tenant-certificate version in force at
+                decision time.
+            inline_scope: When False the receipt carries only ``scope_ref`` and
+                the verifier needs a resolver to fetch the scope body.
 
         Returns:
             The freshly-appended, HMAC-computed receipt.
@@ -247,7 +341,7 @@ class DelegationLedger:
         with self._append_lock(run_id):
             prev_hmac, hop_index = self._tail(run_id)
             ts = int(created if created is not None else time.time())
-            body = {
+            body: dict[str, Any] = {
                 "run_id": run_id,
                 "hop_index": hop_index,
                 "issuer": issuer,
@@ -257,6 +351,15 @@ class DelegationLedger:
                 "created": ts,
                 "prev_hmac": prev_hmac,
             }
+            if scope is not None:
+                body["parent_ref"] = parent_ref if parent_ref is not None else prev_hmac
+                body["scope_ref"] = scope.scope_ref()
+                if inline_scope:
+                    body["scope"] = scope.to_body()
+            elif parent_ref is not None:
+                body["parent_ref"] = parent_ref
+            if binding is not None:
+                body["binding"] = binding.to_body()
             computed = _compute_hmac(self._key, prev_hmac, body)
             entry = body.copy()
             entry["hmac"] = computed
@@ -266,27 +369,38 @@ class DelegationLedger:
         return DelegationReceipt(**entry)
 
 
-def verify_run_chain(*, root: Path, run_id: str, key: bytes) -> ChainResult:
+def verify_run_chain(
+    *,
+    root: Path,
+    run_id: str,
+    key: bytes,
+    scope_resolver: Callable[[str], DelegationScope | None] | None = None,
+) -> ChainResult:
     """Reconstruct and verify a run's delegation chain offline.
 
     Walks ``<root>/delegation/<run_id>.jsonl`` from genesis, recomputing each
-    hop's HMAC and checking linkage. Reconstructs the
-    ``principal -> orchestrator -> sub-agent`` ordering (AC4).
+    hop's HMAC and checking linkage, then recomputes the authority relations
+    the receipts record: child-scope-is-a-subset-of-parent-scope per hop,
+    separation of duties across principals, and decision-time charter binding.
+    Reconstructs the ``principal -> orchestrator -> sub-agent`` ordering (AC4).
 
     Args:
         root: Base directory the ledger was rooted at.
         run_id: Run to verify.
         key: The HMAC key (install audit key) the receipts were written with.
+        scope_resolver: Optional lookup for receipts that carry only a
+            content-addressed ``scope_ref`` rather than an inline scope body.
 
     Returns:
         A :class:`ChainResult`. ``valid`` is True only when at least one hop
-        exists and the whole chain verifies from genesis to tail.
+        exists, the whole chain verifies from genesis to tail, and every
+        authority check passes.
     """
     ledger_dir = Path(root) / _SUBDIR
     safe = run_id.replace("/", "_").replace("\\", "_")
     path = ledger_dir / f"{safe}.jsonl"
     if not path.is_file():
-        return ChainResult(valid=False, hops=0, errors=["no delegation receipts for run"])
+        return ChainResult(valid=False, hops=0, errors=["no delegation receipts for run"], chain_ok=False)
 
     receipts: list[DelegationReceipt] = []
     errors: list[str] = []
@@ -311,11 +425,23 @@ def verify_run_chain(*, root: Path, run_id: str, key: bytes) -> ChainResult:
         if not _hmac.compare_digest(expected, stored_hmac):
             errors.append(f"hop {body.get('hop_index', lineno)}: HMAC mismatch (receipt tampered or wrong key)")
             break
-        receipts.append(DelegationReceipt(**obj))
+        try:
+            receipts.append(DelegationReceipt(**obj))
+        except TypeError as exc:
+            errors.append(f"hop {body.get('hop_index', lineno)}: unknown receipt field: {exc}")
+            break
         prev_hmac = stored_hmac
 
-    valid = not errors and len(receipts) > 0
-    return ChainResult(valid=valid, hops=len(receipts), receipts=receipts, errors=errors)
+    chain_ok = not errors and len(receipts) > 0
+    authority = verify_authority(receipts, scope_resolver=scope_resolver, genesis=GENESIS_HMAC)
+    return ChainResult(
+        valid=chain_ok and authority.ok,
+        hops=len(receipts),
+        receipts=receipts,
+        errors=errors,
+        chain_ok=chain_ok,
+        authority=authority,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -350,23 +476,47 @@ def record_delegation_hop(
     audience: str,
     act: str,
     root: Path | None = None,
+    scope: DelegationScope | None = None,
+    parent_ref: str | None = None,
+    binding: DecisionBinding | None = None,
 ) -> DelegationReceipt:
     """Record one delegation hop for ``run_id`` using install-anchored defaults.
 
     Convenience wrapper the orchestrator calls at each
-    ``principal -> orchestrator -> sub-agent`` handoff.
+    ``principal -> orchestrator -> sub-agent`` handoff. Pass ``scope`` to make
+    the hop's grant recomputable rather than merely sequenced.
     """
-    return default_ledger(root).record_hop(run_id=run_id, issuer=issuer, subject=subject, audience=audience, act=act)
+    return default_ledger(root).record_hop(
+        run_id=run_id,
+        issuer=issuer,
+        subject=subject,
+        audience=audience,
+        act=act,
+        scope=scope,
+        parent_ref=parent_ref,
+        binding=binding,
+    )
 
 
-def verify_run(run_id: str, *, root: Path | None = None) -> ChainResult:
+def verify_run(
+    run_id: str,
+    *,
+    root: Path | None = None,
+    scope_resolver: Callable[[str], DelegationScope | None] | None = None,
+) -> ChainResult:
     """Verify a run's delegation chain using install-anchored defaults.
 
     Args:
         run_id: Run to verify.
         root: Optional root override; defaults to :data:`DEFAULT_ROOT`.
+        scope_resolver: Optional lookup for content-addressed scope references.
 
     Returns:
         The :class:`ChainResult` from :func:`verify_run_chain`.
     """
-    return verify_run_chain(root=root or DEFAULT_ROOT, run_id=run_id, key=_audit_key())
+    return verify_run_chain(
+        root=root or DEFAULT_ROOT,
+        run_id=run_id,
+        key=_audit_key(),
+        scope_resolver=scope_resolver,
+    )

--- a/src/bernstein/core/identity/delegation_scope.py
+++ b/src/bernstein/core/identity/delegation_scope.py
@@ -1,0 +1,698 @@
+"""Recomputable authority narrowing for per-hop delegation receipts (#2554).
+
+A delegation receipt chain proves *sequence and integrity*: hop N follows hop
+N-1 and no field was flipped. On its own it cannot prove *narrowing*, because
+the authority granted at each hop was never recorded - so "did this sub-agent
+end up holding more than the worker that spawned it?" could only be answered by
+trusting that route checks had rejected every invalid action in the first
+place. That is an argument, not a receipt.
+
+This module supplies the missing record and the recomputation over it:
+
+* :class:`DelegationScope` - the effective authority granted at one hop,
+  content-addressed by :meth:`DelegationScope.scope_ref` so a receipt may carry
+  either the scope inline or just its reference.
+* :class:`DecisionBinding` - the charter hash and tenant-certificate version in
+  force *at the moment the hop was recorded*, so a later membership change
+  cannot reinterpret a historical decision.
+* Three deliberately **distinct** checks, each answering a different question:
+
+  ============================  ===================================================
+  :func:`check_narrowing`       Did a child hop gain authority its parent lacked?
+  :func:`check_duties`          Did one principal exercise incompatible powers?
+  :func:`check_binding`         Was the decision pinned to a charter version?
+  ============================  ===================================================
+
+  Blurring them loses information: a chain can narrow perfectly and still let a
+  single worker both spawn a task and approve its own gate, and a chain can
+  separate duties cleanly while silently widening scope at one hop.
+
+Subset semantics are not reinvented here. The allowlist, POSIX path-prefix, and
+upper-bound primitives are imported from
+:mod:`bernstein.core.security.capability_tokens`, which already defines them for
+signed capability tokens, so a scope axis means the same thing on both surfaces.
+
+Backward compatibility
+----------------------
+Every field this module adds to a receipt is optional. A chain recorded before
+these fields existed carries no scope, produces no violations, and verifies
+exactly as it did before. A chain that records scope must record it at *every*
+hop up to its root: a scoped hop whose parent has no recorded scope is reported
+as ``unscoped_parent``, because an unrecorded ceiling makes narrowing
+unprovable rather than proven.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.security.agent_card_signer import canonicalize_jcs
+from bernstein.core.security.capability_tokens import (
+    allowlist_narrows,
+    bound_narrows,
+    prefixes_narrow,
+    uses_narrows,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Sequence
+
+    from bernstein.core.identity.delegation import DelegationReceipt
+
+__all__ = [
+    "CHECK_BINDING",
+    "CHECK_DUTIES",
+    "CHECK_NARROWING",
+    "DEFAULT_SEPARATED_DUTIES",
+    "DUTY_APPROVE",
+    "DUTY_MERGE",
+    "DUTY_SPAWN",
+    "GATED_DUTIES",
+    "AuthorityReport",
+    "DecisionBinding",
+    "DelegationScope",
+    "ScopeViolation",
+    "check_binding",
+    "check_duties",
+    "check_narrowing",
+    "duties_for_act",
+    "narrowing_violations",
+    "verify_authority",
+]
+
+#: Duty vocabulary for separation of duties. Kept deliberately small: these are
+#: the three powers the delegation surface can separate today.
+DUTY_SPAWN: str = "spawn"
+DUTY_APPROVE: str = "approve"
+DUTY_MERGE: str = "merge"
+
+#: Duty pairs that may not be held by the same principal within one run. The
+#: maker-checker rule in both directions: whoever asked for the work does not
+#: get to bless it, and whoever blessed it does not get to land it.
+DEFAULT_SEPARATED_DUTIES: frozenset[frozenset[str]] = frozenset(
+    {
+        frozenset({DUTY_SPAWN, DUTY_APPROVE}),
+        frozenset({DUTY_SPAWN, DUTY_MERGE}),
+        frozenset({DUTY_APPROVE, DUTY_MERGE}),
+    }
+)
+
+#: Duties whose exercise is a *decision* rather than an execution step. A
+#: decision must cite the charter version it was taken under, otherwise a later
+#: membership change silently reinterprets it.
+GATED_DUTIES: frozenset[str] = frozenset({DUTY_APPROVE, DUTY_MERGE})
+
+#: Check identifiers carried on every :class:`ScopeViolation`.
+CHECK_NARROWING: str = "narrowing"
+CHECK_DUTIES: str = "separation_of_duties"
+CHECK_BINDING: str = "binding"
+
+_KNOWN_DUTIES: frozenset[str] = frozenset({DUTY_SPAWN, DUTY_APPROVE, DUTY_MERGE})
+
+
+# ---------------------------------------------------------------------------
+# Scope
+# ---------------------------------------------------------------------------
+
+
+def _frozen(value: Any) -> frozenset[str] | None:
+    """Return ``value`` as a frozenset, preserving ``None`` (unconstrained)."""
+    if value is None:
+        return None
+    return frozenset(value)
+
+
+@dataclass(frozen=True)
+class DelegationScope:
+    """The effective authority granted at one delegation hop.
+
+    Every axis follows the capability-token convention that ``None`` is the
+    *widest* value (unconstrained / unbounded), so an axis a parent left open
+    cannot be tightened away by omission on the child - a child that drops a
+    bound its parent imposed widens on that axis and is reported.
+
+    ``permissions`` and ``duties`` are plain sets: an empty set is the
+    narrowest possible grant, never the widest.
+    """
+
+    permissions: frozenset[str] = frozenset()
+    duties: frozenset[str] = frozenset()
+    task_ids: frozenset[str] | None = None
+    path_prefixes: frozenset[str] | None = None
+    not_after: float | None = None
+    max_uses: int | None = None
+    max_depth: int | None = None
+
+    def to_body(self) -> dict[str, Any]:
+        """Return the JCS-ready dict (sets rendered as sorted lists)."""
+        return {
+            "duties": sorted(self.duties),
+            "max_depth": self.max_depth,
+            "max_uses": self.max_uses,
+            "not_after": self.not_after,
+            "path_prefixes": sorted(self.path_prefixes) if self.path_prefixes is not None else None,
+            "permissions": sorted(self.permissions),
+            "task_ids": sorted(self.task_ids) if self.task_ids is not None else None,
+        }
+
+    @classmethod
+    def from_body(cls, body: dict[str, Any]) -> DelegationScope:
+        """Inverse of :meth:`to_body` (tolerates absent keys as widest/empty)."""
+        return cls(
+            permissions=frozenset(body.get("permissions") or ()),
+            duties=frozenset(body.get("duties") or ()),
+            task_ids=_frozen(body.get("task_ids")),
+            path_prefixes=_frozen(body.get("path_prefixes")),
+            not_after=None if body.get("not_after") is None else float(body["not_after"]),
+            max_uses=None if body.get("max_uses") is None else int(body["max_uses"]),
+            max_depth=None if body.get("max_depth") is None else int(body["max_depth"]),
+        )
+
+    def scope_ref(self) -> str:
+        """Return the content address of this scope (``sha256:<hex>``).
+
+        The digest is taken over the RFC 8785 canonical bytes of
+        :meth:`to_body`, so two operators describing the same authority mint
+        the same reference and a receipt can carry the reference alone.
+        """
+        return "sha256:" + hashlib.sha256(canonicalize_jcs(self.to_body())).hexdigest()
+
+    def narrowing_violations(self, parent: DelegationScope) -> tuple[str, ...]:
+        """Return the axes on which ``self`` widens ``parent`` (empty = narrows)."""
+        return narrowing_violations(self, parent)
+
+    def is_narrowing_of(self, parent: DelegationScope) -> bool:
+        """Return True iff this scope is a subset of ``parent`` on every axis."""
+        return not narrowing_violations(self, parent)
+
+
+def narrowing_violations(child: DelegationScope, parent: DelegationScope) -> tuple[str, ...]:
+    """Return the scope axes on which ``child`` widens ``parent``.
+
+    An empty tuple means the child is a strict subset of the parent's grant.
+    Axis names are stable identifiers so a verifier can report *which* axis was
+    widened instead of a bare pass/fail.
+    """
+    axes: list[str] = []
+    if not child.permissions <= parent.permissions:
+        axes.append("permissions")
+    if not child.duties <= parent.duties:
+        axes.append("duties")
+    if not allowlist_narrows(child.task_ids, parent.task_ids):
+        axes.append("task_ids")
+    if not prefixes_narrow(child.path_prefixes, parent.path_prefixes):
+        axes.append("path_prefixes")
+    if not bound_narrows(child.not_after, parent.not_after):
+        axes.append("not_after")
+    if not uses_narrows(child.max_uses, parent.max_uses):
+        axes.append("max_uses")
+    if not bound_narrows(child.max_depth, parent.max_depth):
+        axes.append("max_depth")
+    return tuple(axes)
+
+
+# ---------------------------------------------------------------------------
+# Decision-time version binding
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DecisionBinding:
+    """The charter/certificate version in force when a hop was recorded.
+
+    Carried inside the receipt body, so it is covered by the receipt HMAC: the
+    version a decision was taken under is fixed at decision time and a later
+    membership change cannot reinterpret it.
+    """
+
+    charter_hash: str
+    certificate_hash: str | None = None
+    certificate_version: str | None = None
+
+    def to_body(self) -> dict[str, Any]:
+        """Return the JSON body, omitting absent optional fields."""
+        body: dict[str, Any] = {"charter_hash": self.charter_hash}
+        if self.certificate_hash is not None:
+            body["certificate_hash"] = self.certificate_hash
+        if self.certificate_version is not None:
+            body["certificate_version"] = self.certificate_version
+        return body
+
+    @classmethod
+    def from_body(cls, body: dict[str, Any]) -> DecisionBinding:
+        """Inverse of :meth:`to_body`."""
+        return cls(
+            charter_hash=str(body.get("charter_hash", "")),
+            certificate_hash=body.get("certificate_hash"),
+            certificate_version=body.get("certificate_version"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Violations and report
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ScopeViolation:
+    """One recomputed authority failure, with the offending axis named."""
+
+    check: str
+    hop_index: int
+    axis: str
+    detail: str
+    parent_hop_index: int | None = None
+    principal: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable dict for CLI / machine consumption."""
+        return {
+            "axis": self.axis,
+            "check": self.check,
+            "detail": self.detail,
+            "hop_index": self.hop_index,
+            "parent_hop_index": self.parent_hop_index,
+            "principal": self.principal,
+        }
+
+    def __str__(self) -> str:
+        where = f"hop {self.hop_index}"
+        if self.parent_hop_index is not None:
+            where += f" (parent hop {self.parent_hop_index})"
+        return f"{where}: {self.check}/{self.axis}: {self.detail}"
+
+
+@dataclass
+class AuthorityReport:
+    """Outcome of the three authority checks over one run's receipts."""
+
+    narrowing_ok: bool = True
+    duties_ok: bool = True
+    binding_ok: bool = True
+    #: ``"none"`` (no hop records a scope), ``"partial"``, or ``"full"``.
+    scope_coverage: str = "none"
+    violations: list[ScopeViolation] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        """True iff every check passed."""
+        return self.narrowing_ok and self.duties_ok and self.binding_ok
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable dict."""
+        return {
+            "binding_ok": self.binding_ok,
+            "duties_ok": self.duties_ok,
+            "narrowing_ok": self.narrowing_ok,
+            "ok": self.ok,
+            "scope_coverage": self.scope_coverage,
+            "violations": [v.to_dict() for v in self.violations],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Receipt-side helpers
+# ---------------------------------------------------------------------------
+
+
+def duties_for_act(act: str) -> frozenset[str]:
+    """Infer the duties an ``act`` string exercises.
+
+    Only used when a receipt records no explicit scope duties, so chains
+    written before this module gain separation-of-duties coverage from the act
+    names they already carry. Matching is on whole dot/underscore/dash-separated
+    segments (``task.spawn`` -> ``spawn``), never on substrings, so an act like
+    ``spawner.status`` does not accidentally claim the spawn duty.
+    """
+    return frozenset(set(_split_act(act)) & _KNOWN_DUTIES)
+
+
+def _split_act(act: str) -> list[str]:
+    out: list[str] = []
+    current: list[str] = []
+    for ch in act.lower():
+        if ch.isalnum():
+            current.append(ch)
+        elif current:
+            out.append("".join(current))
+            current = []
+    if current:
+        out.append("".join(current))
+    return out
+
+
+def _resolve_scope(
+    receipt: DelegationReceipt,
+    resolver: Callable[[str], DelegationScope | None] | None,
+) -> DelegationScope | None:
+    """Return the scope a receipt grants, inline or via its content address."""
+    if receipt.scope is not None:
+        return DelegationScope.from_body(receipt.scope)
+    if receipt.scope_ref and resolver is not None:
+        return resolver(receipt.scope_ref)
+    return None
+
+
+def _binding_of(receipt: DelegationReceipt) -> DecisionBinding | None:
+    if receipt.binding is None:
+        return None
+    return DecisionBinding.from_body(receipt.binding)
+
+
+def _exercised_duties(
+    receipt: DelegationReceipt,
+    scope: DelegationScope | None,
+) -> frozenset[str]:
+    """Return the duties this hop exercises (explicit scope wins over the act)."""
+    if scope is not None and scope.duties:
+        return scope.duties
+    return duties_for_act(receipt.act)
+
+
+def _parent_index(
+    receipts: Sequence[DelegationReceipt],
+    index: int,
+    by_hmac: dict[str, int],
+    genesis: str,
+) -> int | None | str:
+    """Resolve a hop's parent index.
+
+    Returns the parent's index, ``None`` when the hop is a chain root, or an
+    error string when ``parent_ref`` names no earlier hop.
+    """
+    receipt = receipts[index]
+    ref = receipt.parent_ref
+    if ref is None:
+        return index - 1 if index > 0 else None
+    if ref == genesis:
+        return None
+    parent = by_hmac.get(ref)
+    if parent is None or parent >= index:
+        return f"parent_ref {ref[:16]}... names no preceding hop"
+    return parent
+
+
+# ---------------------------------------------------------------------------
+# Check 1: narrowing (did a child gain authority its parent lacked?)
+# ---------------------------------------------------------------------------
+
+
+def check_narrowing(
+    receipts: Sequence[DelegationReceipt],
+    *,
+    scope_resolver: Callable[[str], DelegationScope | None] | None = None,
+    genesis: str = "0" * 64,
+) -> tuple[list[ScopeViolation], str]:
+    """Recompute child-scope is-a-subset-of parent-scope for every hop.
+
+    Returns ``(violations, coverage)`` where ``coverage`` is ``"none"``,
+    ``"partial"``, or ``"full"``. Violations name the offending axis.
+
+    Failure modes, each reported with its own axis name:
+
+    * ``scope_ref_mismatch`` - the inline scope does not hash to the recorded
+      content address, so the reference and the body disagree.
+    * ``unresolved_parent`` - ``parent_ref`` names no preceding hop.
+    * ``unscoped_parent`` - the hop records a scope but its parent does not, so
+      the ceiling it narrows against is unrecorded and narrowing is unprovable.
+    * one entry per widened axis (``permissions``, ``duties``, ``task_ids``,
+      ``path_prefixes``, ``not_after``, ``max_uses``, ``max_depth``).
+    """
+    violations: list[ScopeViolation] = []
+    by_hmac = {r.hmac: i for i, r in enumerate(receipts) if r.hmac}
+    scopes: list[DelegationScope | None] = []
+
+    for receipt in receipts:
+        scope = _resolve_scope(receipt, scope_resolver)
+        scopes.append(scope)
+
+    scoped = sum(1 for s in scopes if s is not None)
+    if scoped == 0:
+        coverage = "none"
+    elif scoped == len(receipts):
+        coverage = "full"
+    else:
+        coverage = "partial"
+
+    for index, receipt in enumerate(receipts):
+        scope = scopes[index]
+
+        if receipt.scope is not None and receipt.scope_ref:
+            expected = DelegationScope.from_body(receipt.scope).scope_ref()
+            if expected != receipt.scope_ref:
+                violations.append(
+                    ScopeViolation(
+                        check=CHECK_NARROWING,
+                        hop_index=receipt.hop_index,
+                        axis="scope_ref_mismatch",
+                        detail=(
+                            f"recorded scope_ref {receipt.scope_ref} does not match the "
+                            f"content address of the inline scope ({expected})"
+                        ),
+                        principal=receipt.subject,
+                    )
+                )
+
+        if receipt.scope_ref and scope is None:
+            violations.append(
+                ScopeViolation(
+                    check=CHECK_NARROWING,
+                    hop_index=receipt.hop_index,
+                    axis="unresolved_scope",
+                    detail=(f"scope_ref {receipt.scope_ref} could not be resolved to a scope body"),
+                    principal=receipt.subject,
+                )
+            )
+            continue
+
+        parent = _parent_index(receipts, index, by_hmac, genesis)
+        if isinstance(parent, str):
+            violations.append(
+                ScopeViolation(
+                    check=CHECK_NARROWING,
+                    hop_index=receipt.hop_index,
+                    axis="unresolved_parent",
+                    detail=parent,
+                    principal=receipt.subject,
+                )
+            )
+            continue
+
+        if scope is None or parent is None:
+            # No recorded grant to check, or a chain root whose scope *is* the
+            # ceiling. Either way there is nothing above it to narrow against.
+            continue
+
+        parent_scope = scopes[parent]
+        parent_hop = receipts[parent].hop_index
+        if parent_scope is None:
+            violations.append(
+                ScopeViolation(
+                    check=CHECK_NARROWING,
+                    hop_index=receipt.hop_index,
+                    axis="unscoped_parent",
+                    detail=(
+                        "hop records an effective scope but its parent records none, "
+                        "so the ceiling it narrows against is unrecorded"
+                    ),
+                    parent_hop_index=parent_hop,
+                    principal=receipt.subject,
+                )
+            )
+            continue
+
+        for axis in narrowing_violations(scope, parent_scope):
+            violations.append(
+                ScopeViolation(
+                    check=CHECK_NARROWING,
+                    hop_index=receipt.hop_index,
+                    axis=axis,
+                    detail=(
+                        f"child scope widens the parent on {axis}: "
+                        f"{_axis_repr(scope, axis)} is not within {_axis_repr(parent_scope, axis)}"
+                    ),
+                    parent_hop_index=parent_hop,
+                    principal=receipt.subject,
+                )
+            )
+
+    return violations, coverage
+
+
+def _axis_repr(scope: DelegationScope, axis: str) -> str:
+    """Render one scope axis for a violation message."""
+    value = getattr(scope, axis, None)
+    if value is None:
+        return "unconstrained"
+    if isinstance(value, frozenset):
+        return "{" + ", ".join(sorted(value)) + "}"
+    return repr(value)
+
+
+# ---------------------------------------------------------------------------
+# Check 2: separation of duties (did one principal hold incompatible powers?)
+# ---------------------------------------------------------------------------
+
+
+def check_duties(
+    receipts: Sequence[DelegationReceipt],
+    *,
+    separated: Iterable[Iterable[str]] = DEFAULT_SEPARATED_DUTIES,
+    scope_resolver: Callable[[str], DelegationScope | None] | None = None,
+) -> list[ScopeViolation]:
+    """Report principals that exercised incompatible duties within one run.
+
+    This is *not* the narrowing check. Narrowing asks whether a child gained
+    authority its parent lacked; a chain can narrow perfectly at every hop and
+    still route both ``spawn`` and ``approve`` to the same principal, which is
+    exactly the separation-of-duties failure an auditor asks about.
+
+    The acting principal is the receipt's ``subject`` (the party being
+    authorized to act). Duties come from the hop's recorded scope when it
+    declares any, and are otherwise inferred from the ``act`` name so chains
+    recorded before scopes existed are still covered.
+    """
+    pairs = [frozenset(p) for p in separated]
+    seen: dict[str, dict[str, DelegationReceipt]] = {}
+    violations: list[ScopeViolation] = []
+
+    for receipt in receipts:
+        scope = _resolve_scope(receipt, scope_resolver)
+        principal = receipt.subject
+        held = seen.setdefault(principal, {})
+        for duty in sorted(_exercised_duties(receipt, scope)):
+            for pair in pairs:
+                if duty not in pair:
+                    continue
+                other = next(iter(pair - {duty}), None)
+                if other is None or other not in held:
+                    continue
+                first = held[other]
+                violations.append(
+                    ScopeViolation(
+                        check=CHECK_DUTIES,
+                        hop_index=receipt.hop_index,
+                        axis="|".join(sorted(pair)),
+                        detail=(
+                            f"principal {principal!r} exercised {other!r} at hop "
+                            f"{first.hop_index} ({first.act}) and {duty!r} at hop "
+                            f"{receipt.hop_index} ({receipt.act}); these duties are separated"
+                        ),
+                        parent_hop_index=first.hop_index,
+                        principal=principal,
+                    )
+                )
+            held.setdefault(duty, receipt)
+
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Check 3: decision-time version binding
+# ---------------------------------------------------------------------------
+
+
+def check_binding(
+    receipts: Sequence[DelegationReceipt],
+    *,
+    scope_resolver: Callable[[str], DelegationScope | None] | None = None,
+    genesis: str = "0" * 64,
+) -> list[ScopeViolation]:
+    """Report hops whose charter/certificate version binding is absent or drifts.
+
+    Two failures, both of which let a later membership change reinterpret a
+    historical decision:
+
+    * ``binding_missing`` - the chain binds a charter version somewhere, but a
+      hop exercising a gated duty (``approve`` / ``merge``) records none, so
+      that decision floats free of the version it was taken under.
+    * ``binding_drift`` - a hop cites a different charter hash or certificate
+      version than the parent it descends from. One authority chain is
+      evaluated under one version; a changed charter needs a new certificate,
+      not a re-interpreted hop.
+    """
+    violations: list[ScopeViolation] = []
+    bindings = [_binding_of(r) for r in receipts]
+    if not any(b is not None for b in bindings):
+        return violations
+
+    by_hmac = {r.hmac: i for i, r in enumerate(receipts) if r.hmac}
+
+    for index, receipt in enumerate(receipts):
+        binding = bindings[index]
+        duties = _exercised_duties(receipt, _resolve_scope(receipt, scope_resolver))
+
+        if binding is None:
+            if duties & GATED_DUTIES:
+                violations.append(
+                    ScopeViolation(
+                        check=CHECK_BINDING,
+                        hop_index=receipt.hop_index,
+                        axis="binding_missing",
+                        detail=(
+                            f"hop exercises {sorted(duties & GATED_DUTIES)} but records no "
+                            "charter/certificate binding, so a later membership change would "
+                            "reinterpret this decision"
+                        ),
+                        principal=receipt.subject,
+                    )
+                )
+            continue
+
+        parent = _parent_index(receipts, index, by_hmac, genesis)
+        if isinstance(parent, str) or parent is None:
+            continue
+        parent_binding = bindings[parent]
+        if parent_binding is None:
+            continue
+        for axis in ("charter_hash", "certificate_hash", "certificate_version"):
+            mine = getattr(binding, axis)
+            theirs = getattr(parent_binding, axis)
+            if mine != theirs:
+                violations.append(
+                    ScopeViolation(
+                        check=CHECK_BINDING,
+                        hop_index=receipt.hop_index,
+                        axis="binding_drift",
+                        detail=(
+                            f"{axis} {mine!r} differs from the parent hop's {theirs!r}; "
+                            "one authority chain is evaluated under one charter version"
+                        ),
+                        parent_hop_index=receipts[parent].hop_index,
+                        principal=receipt.subject,
+                    )
+                )
+
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Combined report
+# ---------------------------------------------------------------------------
+
+
+def verify_authority(
+    receipts: Sequence[DelegationReceipt],
+    *,
+    scope_resolver: Callable[[str], DelegationScope | None] | None = None,
+    separated: Iterable[Iterable[str]] = DEFAULT_SEPARATED_DUTIES,
+    genesis: str = "0" * 64,
+) -> AuthorityReport:
+    """Run the three authority checks and return their combined verdict.
+
+    The sub-verdicts stay separate on the report: a caller can tell a widening
+    chain from one that merely concentrated duties, which a single blended
+    boolean would hide.
+    """
+    narrowing, coverage = check_narrowing(receipts, scope_resolver=scope_resolver, genesis=genesis)
+    duties = check_duties(receipts, separated=separated, scope_resolver=scope_resolver)
+    binding = check_binding(receipts, scope_resolver=scope_resolver, genesis=genesis)
+    return AuthorityReport(
+        narrowing_ok=not narrowing,
+        duties_ok=not duties,
+        binding_ok=not binding,
+        scope_coverage=coverage,
+        violations=[*narrowing, *duties, *binding],
+    )

--- a/src/bernstein/core/security/capability_tokens.py
+++ b/src/bernstein/core/security/capability_tokens.py
@@ -109,12 +109,18 @@ __all__ = [
     "ChainVerification",
     "HopVerification",
     "TokenVerificationError",
+    "allowlist_narrows",
     "attenuate",
+    "bound_narrows",
     "caveats_for_scope",
     "mint_root",
+    "narrowing_violations",
+    "path_covered_by",
+    "prefixes_narrow",
     "scope_permissions",
     "sign_token",
     "to_actor_claims",
+    "uses_narrows",
     "verify_chain",
 ]
 
@@ -203,7 +209,7 @@ def _normalize_path(path: str) -> str:
     return posixpath.normpath(path)
 
 
-def _path_covered_by(child: str, parent: str) -> bool:
+def path_covered_by(child: str, parent: str) -> bool:
     """Return True iff *parent* is an ancestor-or-equal of *child* (POSIX).
 
     Coverage is component-wise, not string-prefix: ``/a/b`` covers ``/a/b`` and
@@ -218,7 +224,7 @@ def _path_covered_by(child: str, parent: str) -> bool:
     return c.startswith(boundary)
 
 
-def _allowlist_narrows(child: frozenset[str] | None, parent: frozenset[str] | None) -> bool:
+def allowlist_narrows(child: frozenset[str] | None, parent: frozenset[str] | None) -> bool:
     """Subset for allowlists where ``None`` is the universal (widest) set."""
     if parent is None:
         return True
@@ -227,22 +233,70 @@ def _allowlist_narrows(child: frozenset[str] | None, parent: frozenset[str] | No
     return child <= parent
 
 
-def _prefixes_narrow(child: frozenset[str] | None, parent: frozenset[str] | None) -> bool:
+def prefixes_narrow(child: frozenset[str] | None, parent: frozenset[str] | None) -> bool:
     """Every child prefix must be covered by some parent prefix (``None`` = all)."""
     if parent is None:
         return True
     if child is None:
         return False
-    return all(any(_path_covered_by(c, p) for p in parent) for c in child)
+    return all(any(path_covered_by(c, p) for p in parent) for c in child)
 
 
-def _uses_narrows(child: int | None, parent: int | None) -> bool:
+def uses_narrows(child: int | None, parent: int | None) -> bool:
     """``max_uses`` subset where ``None`` means unlimited (widest)."""
     if parent is None:
         return True
     if child is None:
         return False
     return child <= parent
+
+
+def bound_narrows(child: float | int | None, parent: float | int | None) -> bool:
+    """Upper-bound subset where ``None`` means unbounded (widest).
+
+    Used for ceilings such as ``not_after`` and depth budgets: the child may
+    only carry a bound no greater than its parent's, and may not drop a bound
+    the parent imposed.
+    """
+    if parent is None:
+        return True
+    if child is None:
+        return False
+    return child <= parent
+
+
+#: Private aliases retained so the module body reads the same as before the
+#: primitives were promoted to the public surface for reuse by the
+#: delegation-receipt narrowing verifier.
+_path_covered_by = path_covered_by
+_allowlist_narrows = allowlist_narrows
+_prefixes_narrow = prefixes_narrow
+_uses_narrows = uses_narrows
+
+
+def narrowing_violations(child: Caveats, parent: Caveats) -> tuple[str, ...]:
+    """Return the caveat axes on which ``child`` widens ``parent``.
+
+    An empty tuple means the child is a strict attenuation of the parent. The
+    axis names are stable identifiers (``permissions``, ``task_ids``,
+    ``path_prefixes``, ``not_after``, ``max_uses``, ``remaining_depth``) so a
+    verifier can name the offending axis rather than reporting a bare
+    pass/fail.
+    """
+    axes: list[str] = []
+    if not child.permissions <= parent.permissions:
+        axes.append("permissions")
+    if not allowlist_narrows(child.task_ids, parent.task_ids):
+        axes.append("task_ids")
+    if not prefixes_narrow(child.path_prefixes, parent.path_prefixes):
+        axes.append("path_prefixes")
+    if child.not_after > parent.not_after:
+        axes.append("not_after")
+    if not uses_narrows(child.max_uses, parent.max_uses):
+        axes.append("max_uses")
+    if not 0 <= child.remaining_depth < parent.remaining_depth:
+        axes.append("remaining_depth")
+    return tuple(axes)
 
 
 # ---------------------------------------------------------------------------
@@ -273,18 +327,10 @@ class Caveats:
         Enforces set-subset over permissions and task-ids, ancestor-or-equal
         prefix coverage, ``not_after <=``, ``max_uses <=``, and the
         ``max_depth`` rule ``0 <= remaining_depth < parent.remaining_depth``.
+        Delegates to :func:`narrowing_violations` so the boolean verdict and
+        the per-axis diagnosis can never disagree.
         """
-        if not self.permissions <= parent.permissions:
-            return False
-        if not _allowlist_narrows(self.task_ids, parent.task_ids):
-            return False
-        if not _prefixes_narrow(self.path_prefixes, parent.path_prefixes):
-            return False
-        if self.not_after > parent.not_after:
-            return False
-        if not _uses_narrows(self.max_uses, parent.max_uses):
-            return False
-        return 0 <= self.remaining_depth < parent.remaining_depth
+        return not narrowing_violations(self, parent)
 
     def to_body(self) -> dict[str, Any]:
         """Return a JSON/JCS-ready dict (sets rendered as sorted lists)."""
@@ -681,8 +727,12 @@ def verify_chain(
                 hop_errors.append("identity discontinuity: issuer is not the subject of the hop above")
             if prev_subject_pubkey is None or _raw_pub(token.issuer_pubkey) != _raw_pub(prev_subject_pubkey):
                 hop_errors.append("pubkey discontinuity: issuer_pubkey is not the subject_pubkey above")
-            if prev_caveats is not None and not token.caveats.is_narrowing_of(prev_caveats):
-                hop_errors.append("attenuation violated: caveats widen the parent (tokens may only narrow)")
+            widened = narrowing_violations(token.caveats, prev_caveats) if prev_caveats is not None else ()
+            if widened:
+                hop_errors.append(
+                    "attenuation violated: caveats widen the parent (tokens may only narrow); "
+                    f"offending axes: {', '.join(widened)}"
+                )
 
         if audit_events is not None and not _audit_head_matches(token, audit_events):
             hop_errors.append("audit anchor missing: no delegation_minted event cross-references this token")

--- a/tests/unit/identity/test_delegation_narrowing.py
+++ b/tests/unit/identity/test_delegation_narrowing.py
@@ -1,0 +1,809 @@
+"""Recomputed authority narrowing over delegation receipts (issue #2554).
+
+The checks under test only mean something if they can fail, so the adversarial
+cases come first: a chain whose second hop *widens* its parent, and a chain in
+which one principal both spawns work and approves it. Both are sealed with the
+correct HMAC key - the party that writes a widened hop also holds the key that
+seals it - so a check that only re-verified HMACs would pass every one of them.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from bernstein.core.identity import delegation
+from bernstein.core.identity.delegation_scope import (
+    CHECK_BINDING,
+    CHECK_DUTIES,
+    CHECK_NARROWING,
+    DUTY_APPROVE,
+    DUTY_MERGE,
+    DUTY_SPAWN,
+    DecisionBinding,
+    DelegationScope,
+    check_duties,
+    check_narrowing,
+    duties_for_act,
+    verify_authority,
+)
+
+KEY = b"k" * 32
+
+PARENT_SCOPE = DelegationScope(
+    permissions=frozenset({"files.read", "files.write", "tasks.claim"}),
+    duties=frozenset({DUTY_SPAWN}),
+    task_ids=frozenset({"t-1", "t-2"}),
+    path_prefixes=frozenset({"/repo/src"}),
+    not_after=2_000.0,
+    max_uses=10,
+    max_depth=3,
+)
+
+
+@pytest.fixture
+def ledger(tmp_path):
+    return delegation.DelegationLedger(root=tmp_path, key=KEY)
+
+
+def _axes(result, check: str) -> set[str]:
+    return {v.axis for v in result.violations if v.check == check}
+
+
+# ---------------------------------------------------------------------------
+# Adversarial: a widening hop must be rejected
+# ---------------------------------------------------------------------------
+
+
+class TestWideningIsRejected:
+    @pytest.mark.parametrize(
+        ("axis", "child_scope"),
+        [
+            (
+                "permissions",
+                DelegationScope(
+                    permissions=frozenset({"files.read", "agents.spawn"}),
+                    duties=frozenset({DUTY_SPAWN}),
+                    task_ids=frozenset({"t-1"}),
+                    path_prefixes=frozenset({"/repo/src"}),
+                    not_after=1_000.0,
+                    max_uses=2,
+                    max_depth=1,
+                ),
+            ),
+            (
+                "duties",
+                DelegationScope(
+                    permissions=frozenset({"files.read"}),
+                    duties=frozenset({DUTY_SPAWN, DUTY_APPROVE}),
+                    task_ids=frozenset({"t-1"}),
+                    path_prefixes=frozenset({"/repo/src"}),
+                    not_after=1_000.0,
+                    max_uses=2,
+                    max_depth=1,
+                ),
+            ),
+            (
+                "task_ids",
+                DelegationScope(
+                    permissions=frozenset({"files.read"}),
+                    duties=frozenset({DUTY_SPAWN}),
+                    task_ids=frozenset({"t-1", "t-9"}),
+                    path_prefixes=frozenset({"/repo/src"}),
+                    not_after=1_000.0,
+                    max_uses=2,
+                    max_depth=1,
+                ),
+            ),
+            (
+                "path_prefixes",
+                DelegationScope(
+                    permissions=frozenset({"files.read"}),
+                    duties=frozenset({DUTY_SPAWN}),
+                    task_ids=frozenset({"t-1"}),
+                    path_prefixes=frozenset({"/repo"}),
+                    not_after=1_000.0,
+                    max_uses=2,
+                    max_depth=1,
+                ),
+            ),
+            (
+                "not_after",
+                DelegationScope(
+                    permissions=frozenset({"files.read"}),
+                    duties=frozenset({DUTY_SPAWN}),
+                    task_ids=frozenset({"t-1"}),
+                    path_prefixes=frozenset({"/repo/src"}),
+                    not_after=9_999.0,
+                    max_uses=2,
+                    max_depth=1,
+                ),
+            ),
+            (
+                "max_uses",
+                DelegationScope(
+                    permissions=frozenset({"files.read"}),
+                    duties=frozenset({DUTY_SPAWN}),
+                    task_ids=frozenset({"t-1"}),
+                    path_prefixes=frozenset({"/repo/src"}),
+                    not_after=1_000.0,
+                    max_uses=99,
+                    max_depth=1,
+                ),
+            ),
+            (
+                "max_depth",
+                DelegationScope(
+                    permissions=frozenset({"files.read"}),
+                    duties=frozenset({DUTY_SPAWN}),
+                    task_ids=frozenset({"t-1"}),
+                    path_prefixes=frozenset({"/repo/src"}),
+                    not_after=1_000.0,
+                    max_uses=2,
+                    max_depth=7,
+                ),
+            ),
+        ],
+    )
+    def test_widening_hop_fails_verification_naming_the_axis(self, ledger, axis, child_scope):
+        """A child that gains authority its parent lacked fails, axis named."""
+        ledger.record_hop(
+            run_id="run-widen",
+            issuer="principal:alex",
+            subject="orchestrator",
+            audience="orchestrator",
+            act="run.authorize",
+            scope=PARENT_SCOPE,
+        )
+        ledger.record_hop(
+            run_id="run-widen",
+            issuer="orchestrator",
+            subject="sub-agent:backend",
+            audience="sub-agent:backend",
+            act="task.delegate",
+            scope=child_scope,
+        )
+
+        result = delegation.verify_run_chain(root=ledger.root, run_id="run-widen", key=KEY)
+
+        # The HMAC chain itself is perfectly intact - the widening writer held
+        # the key. Only the recomputed subset relation catches it.
+        assert result.chain_ok is True
+        assert result.valid is False
+        assert result.authority.narrowing_ok is False
+        assert axis in _axes(result, CHECK_NARROWING)
+        offending = next(v for v in result.violations if v.axis == axis)
+        assert offending.hop_index == 1
+        assert offending.parent_hop_index == 0
+
+    def test_dropping_a_bound_the_parent_imposed_is_widening(self, ledger):
+        """Omitting a constraint is not narrowing; ``None`` is the widest value."""
+        ledger.record_hop(
+            run_id="run-drop",
+            issuer="principal:alex",
+            subject="orchestrator",
+            audience="orchestrator",
+            act="run.authorize",
+            scope=PARENT_SCOPE,
+        )
+        ledger.record_hop(
+            run_id="run-drop",
+            issuer="orchestrator",
+            subject="sub-agent:backend",
+            audience="sub-agent:backend",
+            act="task.delegate",
+            scope=DelegationScope(permissions=frozenset({"files.read"}), duties=frozenset({DUTY_SPAWN})),
+        )
+
+        result = delegation.verify_run_chain(root=ledger.root, run_id="run-drop", key=KEY)
+
+        assert result.valid is False
+        assert _axes(result, CHECK_NARROWING) == {"task_ids", "path_prefixes", "not_after", "max_uses", "max_depth"}
+
+    def test_widening_survives_a_rewritten_and_resealed_chain(self, ledger, tmp_path):
+        """Re-sealing a widened hop with the real key does not launder it.
+
+        The strongest form of the attack: an insider edits a recorded scope to
+        grant itself a permission its parent never held, then recomputes the
+        HMAC so the file is internally consistent. Linkage and HMAC both pass;
+        the recomputed subset relation is what refuses.
+        """
+        ledger.record_hop(
+            run_id="run-reseal",
+            issuer="principal:alex",
+            subject="orchestrator",
+            audience="orchestrator",
+            act="run.authorize",
+            scope=PARENT_SCOPE,
+        )
+        ledger.record_hop(
+            run_id="run-reseal",
+            issuer="orchestrator",
+            subject="sub-agent:backend",
+            audience="sub-agent:backend",
+            act="task.delegate",
+            scope=DelegationScope(
+                permissions=frozenset({"files.read"}),
+                duties=frozenset({DUTY_SPAWN}),
+                task_ids=frozenset({"t-1"}),
+                path_prefixes=frozenset({"/repo/src"}),
+                not_after=1_000.0,
+                max_uses=2,
+                max_depth=1,
+            ),
+        )
+
+        path = ledger.receipt_path("run-reseal")
+        rows = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        forged = DelegationScope(
+            permissions=frozenset({"files.read", "gate.approve"}),
+            duties=frozenset({DUTY_SPAWN}),
+            task_ids=frozenset({"t-1"}),
+            path_prefixes=frozenset({"/repo/src"}),
+            not_after=1_000.0,
+            max_uses=2,
+            max_depth=1,
+        )
+        rows[1]["scope"] = forged.to_body()
+        rows[1]["scope_ref"] = forged.scope_ref()
+        body = {k: v for k, v in rows[1].items() if k != "hmac"}
+        rows[1]["hmac"] = delegation._compute_hmac(KEY, rows[1]["prev_hmac"], body)
+        path.write_text("".join(json.dumps(r, sort_keys=True) + "\n" for r in rows), encoding="utf-8")
+
+        result = delegation.verify_run_chain(root=ledger.root, run_id="run-reseal", key=KEY)
+
+        assert result.chain_ok is True, "the forged chain is HMAC-consistent by construction"
+        assert result.valid is False
+        assert "permissions" in _axes(result, CHECK_NARROWING)
+
+    def test_scope_ref_that_disagrees_with_the_inline_scope_is_caught(self, ledger):
+        """A content address must address the body it travels with."""
+        ledger.record_hop(
+            run_id="run-ref",
+            issuer="principal:alex",
+            subject="orchestrator",
+            audience="orchestrator",
+            act="run.authorize",
+            scope=PARENT_SCOPE,
+        )
+        path = ledger.receipt_path("run-ref")
+        row = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
+        row["scope_ref"] = "sha256:" + "0" * 64
+        body = {k: v for k, v in row.items() if k != "hmac"}
+        row["hmac"] = delegation._compute_hmac(KEY, row["prev_hmac"], body)
+        path.write_text(json.dumps(row, sort_keys=True) + "\n", encoding="utf-8")
+
+        result = delegation.verify_run_chain(root=ledger.root, run_id="run-ref", key=KEY)
+
+        assert result.valid is False
+        assert "scope_ref_mismatch" in _axes(result, CHECK_NARROWING)
+
+    def test_scoped_hop_under_an_unscoped_parent_is_unprovable_not_assumed_ok(self, ledger):
+        """A missing parent ceiling makes narrowing unprovable, so it fails."""
+        ledger.record_hop(
+            run_id="run-mixed",
+            issuer="principal:alex",
+            subject="orchestrator",
+            audience="orchestrator",
+            act="run.authorize",
+        )
+        ledger.record_hop(
+            run_id="run-mixed",
+            issuer="orchestrator",
+            subject="sub-agent:backend",
+            audience="sub-agent:backend",
+            act="task.delegate",
+            scope=PARENT_SCOPE,
+        )
+
+        result = delegation.verify_run_chain(root=ledger.root, run_id="run-mixed", key=KEY)
+
+        assert result.valid is False
+        assert "unscoped_parent" in _axes(result, CHECK_NARROWING)
+
+    def test_parent_ref_naming_no_preceding_hop_is_caught(self, ledger):
+        """A dangling parent reference cannot be resolved, so it cannot pass."""
+        ledger.record_hop(
+            run_id="run-dangle",
+            issuer="principal:alex",
+            subject="orchestrator",
+            audience="orchestrator",
+            act="run.authorize",
+            scope=PARENT_SCOPE,
+            parent_ref="f" * 64,
+        )
+
+        result = delegation.verify_run_chain(root=ledger.root, run_id="run-dangle", key=KEY)
+
+        assert result.valid is False
+        assert "unresolved_parent" in _axes(result, CHECK_NARROWING)
+
+    def test_unresolvable_scope_reference_is_caught(self, ledger):
+        """A by-reference scope with no resolver cannot be recomputed."""
+        ledger.record_hop(
+            run_id="run-byref",
+            issuer="principal:alex",
+            subject="orchestrator",
+            audience="orchestrator",
+            act="run.authorize",
+            scope=PARENT_SCOPE,
+            inline_scope=False,
+        )
+
+        result = delegation.verify_run_chain(root=ledger.root, run_id="run-byref", key=KEY)
+
+        assert result.valid is False
+        assert "unresolved_scope" in _axes(result, CHECK_NARROWING)
+
+
+# ---------------------------------------------------------------------------
+# Adversarial: separation of duties is a different question from narrowing
+# ---------------------------------------------------------------------------
+
+
+class TestSeparationOfDuties:
+    def test_one_principal_spawning_and_approving_is_caught(self, ledger):
+        """The worker that asked for the work does not get to bless it."""
+        ledger.record_hop(
+            run_id="run-sod",
+            issuer="principal:alex",
+            subject="worker:7",
+            audience="sub-agent:backend",
+            act="task.spawn",
+        )
+        ledger.record_hop(
+            run_id="run-sod",
+            issuer="principal:alex",
+            subject="worker:7",
+            audience="gate:merge",
+            act="gate.approve",
+        )
+
+        result = delegation.verify_run_chain(root=ledger.root, run_id="run-sod", key=KEY)
+
+        assert result.chain_ok is True
+        assert result.valid is False
+        assert result.authority.duties_ok is False
+        violation = next(v for v in result.violations if v.check == CHECK_DUTIES)
+        assert violation.axis == "approve|spawn"
+        assert violation.principal == "worker:7"
+        assert violation.parent_hop_index == 0
+
+    def test_separated_duties_across_two_principals_pass(self, ledger):
+        """The same two powers, held by different principals, are fine."""
+        ledger.record_hop(
+            run_id="run-sod-ok",
+            issuer="principal:alex",
+            subject="worker:7",
+            audience="sub-agent:backend",
+            act="task.spawn",
+        )
+        ledger.record_hop(
+            run_id="run-sod-ok",
+            issuer="principal:alex",
+            subject="reviewer:9",
+            audience="gate:merge",
+            act="gate.approve",
+        )
+
+        result = delegation.verify_run_chain(root=ledger.root, run_id="run-sod-ok", key=KEY)
+
+        assert result.valid is True
+        assert result.authority.duties_ok is True
+
+    def test_narrowing_can_pass_while_duties_fail(self, ledger):
+        """The two checks are distinct: a perfectly narrowing chain can still
+        concentrate incompatible powers in one principal."""
+        root_scope = DelegationScope(
+            permissions=frozenset({"tasks.write"}),
+            duties=frozenset({DUTY_SPAWN, DUTY_APPROVE}),
+            max_depth=5,
+        )
+        ledger.record_hop(
+            run_id="run-distinct",
+            issuer="principal:alex",
+            subject="worker:7",
+            audience="sub-agent:backend",
+            act="task.spawn",
+            scope=root_scope,
+        )
+        ledger.record_hop(
+            run_id="run-distinct",
+            issuer="worker:7",
+            subject="worker:7",
+            audience="gate:merge",
+            act="gate.approve",
+            scope=DelegationScope(
+                permissions=frozenset({"tasks.write"}),
+                duties=frozenset({DUTY_APPROVE}),
+                max_depth=4,
+            ),
+        )
+
+        result = delegation.verify_run_chain(root=ledger.root, run_id="run-distinct", key=KEY)
+
+        assert result.authority.narrowing_ok is True, "every hop is a strict subset of its parent"
+        assert result.authority.duties_ok is False, "but one principal holds spawn and approve"
+        assert result.valid is False
+
+    def test_duties_come_from_the_recorded_scope_when_present(self):
+        """An explicit scope beats act-name inference."""
+        receipts = [
+            _receipt(0, subject="worker:7", act="opaque.step", scope=DelegationScope(duties=frozenset({DUTY_SPAWN}))),
+            _receipt(1, subject="worker:7", act="opaque.step", scope=DelegationScope(duties=frozenset({DUTY_MERGE}))),
+        ]
+        violations = check_duties(receipts)
+        assert [v.axis for v in violations] == ["merge|spawn"]
+
+    def test_act_inference_matches_whole_segments_only(self):
+        """``spawner.status`` must not be read as the spawn duty."""
+        assert duties_for_act("task.spawn") == frozenset({DUTY_SPAWN})
+        assert duties_for_act("gate.approve") == frozenset({DUTY_APPROVE})
+        assert duties_for_act("pr_merge") == frozenset({DUTY_MERGE})
+        assert duties_for_act("spawner.status") == frozenset()
+        assert duties_for_act("approver_pool.read") == frozenset()
+
+    def test_custom_separated_pairs_are_honoured(self):
+        """The rule set is an argument, not a hard-coded policy."""
+        receipts = [
+            _receipt(0, subject="worker:7", act="task.spawn"),
+            _receipt(1, subject="worker:7", act="pr.merge"),
+        ]
+        assert check_duties(receipts) != []
+        assert check_duties(receipts, separated=[{DUTY_APPROVE, DUTY_MERGE}]) == []
+
+
+# ---------------------------------------------------------------------------
+# Adversarial: decision-time version binding
+# ---------------------------------------------------------------------------
+
+
+class TestDecisionBinding:
+    def test_gated_decision_without_a_binding_is_caught(self, ledger):
+        """An approval that cites no charter version floats free of it."""
+        ledger.record_hop(
+            run_id="run-bind",
+            issuer="principal:alex",
+            subject="orchestrator",
+            audience="sub-agent:backend",
+            act="task.spawn",
+            binding=DecisionBinding(charter_hash="sha256:aaa", certificate_version="3"),
+        )
+        ledger.record_hop(
+            run_id="run-bind",
+            issuer="orchestrator",
+            subject="reviewer:9",
+            audience="gate:merge",
+            act="gate.approve",
+        )
+
+        result = delegation.verify_run_chain(root=ledger.root, run_id="run-bind", key=KEY)
+
+        assert result.chain_ok is True
+        assert result.valid is False
+        assert result.authority.binding_ok is False
+        assert "binding_missing" in _axes(result, CHECK_BINDING)
+
+    def test_a_hop_citing_a_different_charter_version_than_its_parent_is_caught(self, ledger):
+        """One authority chain is evaluated under one charter version."""
+        ledger.record_hop(
+            run_id="run-drift",
+            issuer="principal:alex",
+            subject="orchestrator",
+            audience="orchestrator",
+            act="run.authorize",
+            binding=DecisionBinding(charter_hash="sha256:aaa", certificate_version="3"),
+        )
+        ledger.record_hop(
+            run_id="run-drift",
+            issuer="orchestrator",
+            subject="reviewer:9",
+            audience="gate:merge",
+            act="gate.approve",
+            binding=DecisionBinding(charter_hash="sha256:bbb", certificate_version="4"),
+        )
+
+        result = delegation.verify_run_chain(root=ledger.root, run_id="run-drift", key=KEY)
+
+        assert result.valid is False
+        assert "binding_drift" in _axes(result, CHECK_BINDING)
+
+    def test_a_consistently_bound_chain_passes(self, ledger):
+        binding = DecisionBinding(
+            charter_hash="sha256:aaa",
+            certificate_hash="sha256:ccc",
+            certificate_version="3",
+        )
+        ledger.record_hop(
+            run_id="run-bound",
+            issuer="principal:alex",
+            subject="orchestrator",
+            audience="orchestrator",
+            act="run.authorize",
+            binding=binding,
+        )
+        ledger.record_hop(
+            run_id="run-bound",
+            issuer="orchestrator",
+            subject="reviewer:9",
+            audience="gate:merge",
+            act="gate.approve",
+            binding=binding,
+        )
+
+        result = delegation.verify_run_chain(root=ledger.root, run_id="run-bound", key=KEY)
+
+        assert result.valid is True
+        assert result.authority.binding_ok is True
+        assert result.receipts[1].binding == {
+            "certificate_hash": "sha256:ccc",
+            "certificate_version": "3",
+            "charter_hash": "sha256:aaa",
+        }
+
+    def test_binding_is_covered_by_the_receipt_hmac(self, ledger):
+        """Rewriting a recorded charter version breaks tamper evidence."""
+        ledger.record_hop(
+            run_id="run-hmac",
+            issuer="principal:alex",
+            subject="orchestrator",
+            audience="orchestrator",
+            act="run.authorize",
+            binding=DecisionBinding(charter_hash="sha256:aaa", certificate_version="3"),
+        )
+        path = ledger.receipt_path("run-hmac")
+        path.write_text(
+            path.read_text(encoding="utf-8").replace('"certificate_version": "3"', '"certificate_version": "4"'),
+            encoding="utf-8",
+        )
+
+        result = delegation.verify_run_chain(root=ledger.root, run_id="run-hmac", key=KEY)
+
+        assert result.chain_ok is False
+        assert any("HMAC mismatch" in e for e in result.errors)
+
+
+# ---------------------------------------------------------------------------
+# The happy path, and the promise made to receipts written before all this
+# ---------------------------------------------------------------------------
+
+
+class TestNarrowingChainsPass:
+    def test_a_strictly_narrowing_chain_verifies(self, ledger):
+        ledger.record_hop(
+            run_id="run-ok",
+            issuer="principal:alex",
+            subject="orchestrator",
+            audience="orchestrator",
+            act="run.authorize",
+            scope=PARENT_SCOPE,
+        )
+        ledger.record_hop(
+            run_id="run-ok",
+            issuer="orchestrator",
+            subject="sub-agent:backend",
+            audience="sub-agent:backend",
+            act="task.delegate",
+            scope=DelegationScope(
+                permissions=frozenset({"files.read"}),
+                duties=frozenset({DUTY_SPAWN}),
+                task_ids=frozenset({"t-1"}),
+                path_prefixes=frozenset({"/repo/src/api"}),
+                not_after=1_500.0,
+                max_uses=3,
+                max_depth=2,
+            ),
+        )
+
+        result = delegation.verify_run_chain(root=ledger.root, run_id="run-ok", key=KEY)
+
+        assert result.valid is True
+        assert result.authority.ok is True
+        assert result.authority.scope_coverage == "full"
+        assert result.violations == []
+
+    def test_scope_reference_resolves_through_a_resolver(self, ledger):
+        """A receipt may carry the reference alone when the body is fetchable."""
+        child = DelegationScope(
+            permissions=frozenset({"files.read"}),
+            duties=frozenset({DUTY_SPAWN}),
+            task_ids=frozenset({"t-1"}),
+            path_prefixes=frozenset({"/repo/src"}),
+            not_after=1_000.0,
+            max_uses=2,
+            max_depth=1,
+        )
+        store = {PARENT_SCOPE.scope_ref(): PARENT_SCOPE, child.scope_ref(): child}
+        ledger.record_hop(
+            run_id="run-res",
+            issuer="principal:alex",
+            subject="orchestrator",
+            audience="orchestrator",
+            act="run.authorize",
+            scope=PARENT_SCOPE,
+            inline_scope=False,
+        )
+        ledger.record_hop(
+            run_id="run-res",
+            issuer="orchestrator",
+            subject="sub-agent:backend",
+            audience="sub-agent:backend",
+            act="task.delegate",
+            scope=child,
+            inline_scope=False,
+        )
+
+        result = delegation.verify_run_chain(
+            root=ledger.root,
+            run_id="run-res",
+            key=KEY,
+            scope_resolver=store.get,
+        )
+
+        assert result.valid is True
+        assert result.authority.scope_coverage == "full"
+
+    def test_scope_ref_is_a_pure_function_of_the_scope(self):
+        """Two operators describing the same authority mint the same reference."""
+        a = DelegationScope(permissions=frozenset({"b", "a"}), task_ids=frozenset({"t-2", "t-1"}))
+        b = DelegationScope(permissions=frozenset({"a", "b"}), task_ids=frozenset({"t-1", "t-2"}))
+        assert a.scope_ref() == b.scope_ref()
+        assert a.scope_ref().startswith("sha256:")
+        assert DelegationScope.from_body(a.to_body()) == a
+
+
+class TestLegacyReceiptsAreUnaffected:
+    def test_receipts_without_scope_fields_still_validate(self, ledger):
+        """The promise to chains written before narrowing existed."""
+        ledger.record_hop(
+            run_id="run-legacy",
+            issuer="principal:alex",
+            subject="orchestrator",
+            audience="orchestrator",
+            act="run.authorize",
+        )
+        ledger.record_hop(
+            run_id="run-legacy",
+            issuer="orchestrator",
+            subject="sub-agent:backend",
+            audience="sub-agent:backend",
+            act="task.delegate",
+        )
+
+        result = delegation.verify_run_chain(root=ledger.root, run_id="run-legacy", key=KEY)
+
+        assert result.valid is True
+        assert result.chain_ok is True
+        assert result.authority.scope_coverage == "none"
+        assert result.violations == []
+
+    def test_unscoped_receipt_bytes_are_unchanged_by_the_new_fields(self, ledger):
+        """No optional key is emitted, so old and new writers hash alike."""
+        receipt = ledger.record_hop(
+            run_id="run-bytes",
+            issuer="principal:alex",
+            subject="orchestrator",
+            audience="sub-agent:backend",
+            act="task.spawn",
+            created=1_730_000_000,
+        )
+        row = json.loads(ledger.receipt_path("run-bytes").read_text(encoding="utf-8").splitlines()[0])
+        assert set(row) == {
+            "act",
+            "audience",
+            "created",
+            "hmac",
+            "hop_index",
+            "issuer",
+            "prev_hmac",
+            "run_id",
+            "subject",
+        }
+        expected = delegation._compute_hmac(
+            KEY,
+            delegation.GENESIS_HMAC,
+            {
+                "act": "task.spawn",
+                "audience": "sub-agent:backend",
+                "created": 1_730_000_000,
+                "hop_index": 0,
+                "issuer": "principal:alex",
+                "prev_hmac": delegation.GENESIS_HMAC,
+                "run_id": "run-bytes",
+                "subject": "orchestrator",
+            },
+        )
+        assert receipt.hmac == expected
+        assert receipt.body() == {k: v for k, v in row.items() if k != "hmac"}
+
+    def test_an_empty_chain_reports_no_authority_violations(self):
+        report = verify_authority([])
+        assert report.ok is True
+        assert report.scope_coverage == "none"
+
+
+class TestParentReferenceForms:
+    def test_a_tree_shaped_run_narrows_against_the_named_parent(self, ledger):
+        """Two siblings both narrow hop 0, not the line above them."""
+        root_receipt = ledger.record_hop(
+            run_id="run-tree",
+            issuer="principal:alex",
+            subject="orchestrator",
+            audience="orchestrator",
+            act="run.authorize",
+            scope=PARENT_SCOPE,
+        )
+        narrow = DelegationScope(
+            permissions=frozenset({"files.read"}),
+            duties=frozenset({DUTY_SPAWN}),
+            task_ids=frozenset({"t-1"}),
+            path_prefixes=frozenset({"/repo/src"}),
+            not_after=1_000.0,
+            max_uses=1,
+            max_depth=1,
+        )
+        ledger.record_hop(
+            run_id="run-tree",
+            issuer="orchestrator",
+            subject="sub-agent:a",
+            audience="sub-agent:a",
+            act="task.delegate",
+            scope=narrow,
+            parent_ref=root_receipt.hmac,
+        )
+        # A sibling: its parent is the root, not the hop recorded just before it.
+        # Narrowing against the sibling would fail on max_uses; against the root
+        # it passes, which is the point of naming the parent explicitly.
+        ledger.record_hop(
+            run_id="run-tree",
+            issuer="orchestrator",
+            subject="sub-agent:b",
+            audience="sub-agent:b",
+            act="task.delegate",
+            scope=DelegationScope(
+                permissions=frozenset({"files.write"}),
+                duties=frozenset({DUTY_SPAWN}),
+                task_ids=frozenset({"t-2"}),
+                path_prefixes=frozenset({"/repo/src"}),
+                not_after=1_200.0,
+                max_uses=4,
+                max_depth=2,
+            ),
+            parent_ref=root_receipt.hmac,
+        )
+
+        result = delegation.verify_run_chain(root=ledger.root, run_id="run-tree", key=KEY)
+
+        assert result.valid is True, [str(v) for v in result.violations]
+
+    def test_check_narrowing_returns_coverage_alongside_violations(self):
+        receipts = [
+            _receipt(0, subject="a", act="run.authorize", scope=PARENT_SCOPE),
+            _receipt(1, subject="b", act="task.delegate"),
+        ]
+        violations, coverage = check_narrowing(receipts)
+        assert coverage == "partial"
+        assert violations == []
+
+
+def _receipt(
+    hop_index: int,
+    *,
+    subject: str,
+    act: str,
+    scope: DelegationScope | None = None,
+) -> delegation.DelegationReceipt:
+    """Build an in-memory receipt (no ledger, no HMAC) for pure-check tests."""
+    return delegation.DelegationReceipt(
+        run_id="run",
+        hop_index=hop_index,
+        issuer="principal",
+        subject=subject,
+        audience="audience",
+        act=act,
+        created=0,
+        hmac=f"h{hop_index}",
+        scope_ref=scope.scope_ref() if scope is not None else None,
+        scope=scope.to_body() if scope is not None else None,
+    )

--- a/tests/unit/identity/test_keydir_and_delegation_cli.py
+++ b/tests/unit/identity/test_keydir_and_delegation_cli.py
@@ -15,6 +15,7 @@ from click.testing import CliRunner
 from bernstein.cli.commands.delegation_cmd import delegation_group
 from bernstein.cli.commands.identity_cmd import identity_group
 from bernstein.core.identity import delegation, http_signing
+from bernstein.core.identity.delegation_scope import DecisionBinding, DelegationScope
 from bernstein.core.security.agent_card_keystore import AgentCardKeystore
 
 
@@ -90,3 +91,105 @@ class TestDelegationVerify:
         monkeypatch.setattr(delegation, "_audit_key", lambda: b"k" * 32)
         result = runner.invoke(delegation_group, ["verify", "absent", "--root", str(tmp_path)])
         assert result.exit_code == 1
+
+
+class TestDelegationVerifyNarrowing:
+    """``delegation verify`` recomputes narrowing and duty separation (#2554)."""
+
+    def _seed_widening_chain(self, root: Path, key: bytes) -> None:
+        ledger = delegation.DelegationLedger(root=root, key=key)
+        ledger.record_hop(
+            run_id="run-widen",
+            issuer="principal:alex",
+            subject="orchestrator",
+            audience="orchestrator",
+            act="run.authorize",
+            scope=DelegationScope(permissions=frozenset({"files.read"}), max_depth=2),
+        )
+        ledger.record_hop(
+            run_id="run-widen",
+            issuer="orchestrator",
+            subject="sub-agent:backend",
+            audience="sub-agent:backend",
+            act="task.delegate",
+            scope=DelegationScope(permissions=frozenset({"files.read", "files.write"}), max_depth=1),
+        )
+
+    def test_verify_nonzero_on_widening_hop(self, runner, tmp_path, monkeypatch):
+        key = b"k" * 32
+        monkeypatch.setattr(delegation, "_audit_key", lambda: key)
+        self._seed_widening_chain(tmp_path, key)
+        result = runner.invoke(delegation_group, ["verify", "run-widen", "--root", str(tmp_path)])
+        assert result.exit_code == 1
+        assert "permissions" in result.output
+
+    def test_verify_json_reports_the_offending_axis(self, runner, tmp_path, monkeypatch):
+        key = b"k" * 32
+        monkeypatch.setattr(delegation, "_audit_key", lambda: key)
+        self._seed_widening_chain(tmp_path, key)
+        result = runner.invoke(delegation_group, ["verify", "run-widen", "--root", str(tmp_path), "--json"])
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["chain_ok"] is True
+        assert payload["valid"] is False
+        assert payload["authority"]["narrowing_ok"] is False
+        assert payload["authority"]["scope_coverage"] == "full"
+        axes = {v["axis"] for v in payload["authority"]["violations"]}
+        assert "permissions" in axes
+        assert payload["receipts"][1]["scope_ref"].startswith("sha256:")
+
+    def test_verify_reports_the_certificate_binding_per_hop(self, runner, tmp_path, monkeypatch):
+        key = b"k" * 32
+        monkeypatch.setattr(delegation, "_audit_key", lambda: key)
+        ledger = delegation.DelegationLedger(root=tmp_path, key=key)
+        binding = DecisionBinding(
+            charter_hash="sha256:charter",
+            certificate_hash="sha256:cert",
+            certificate_version="7",
+        )
+        for issuer, subject, act in (
+            ("principal:alex", "orchestrator", "run.authorize"),
+            ("orchestrator", "reviewer:9", "gate.approve"),
+        ):
+            ledger.record_hop(
+                run_id="run-bound",
+                issuer=issuer,
+                subject=subject,
+                audience=subject,
+                act=act,
+                binding=binding,
+            )
+
+        result = runner.invoke(delegation_group, ["verify", "run-bound", "--root", str(tmp_path), "--json"])
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert all(r["binding"]["certificate_hash"] == "sha256:cert" for r in payload["receipts"])
+        assert payload["authority"]["binding_ok"] is True
+
+    def test_verify_nonzero_when_one_principal_holds_separated_duties(self, runner, tmp_path, monkeypatch):
+        key = b"k" * 32
+        monkeypatch.setattr(delegation, "_audit_key", lambda: key)
+        ledger = delegation.DelegationLedger(root=tmp_path, key=key)
+        ledger.record_hop(
+            run_id="run-sod",
+            issuer="principal:alex",
+            subject="worker:7",
+            audience="sub-agent:backend",
+            act="task.spawn",
+        )
+        ledger.record_hop(
+            run_id="run-sod",
+            issuer="principal:alex",
+            subject="worker:7",
+            audience="gate:merge",
+            act="gate.approve",
+        )
+
+        result = runner.invoke(delegation_group, ["verify", "run-sod", "--root", str(tmp_path), "--json"])
+
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["chain_ok"] is True
+        assert payload["authority"]["duties_ok"] is False
+        assert payload["authority"]["narrowing_ok"] is True


### PR DESCRIPTION
## Problem

Delegation receipts record `issuer`, `subject`, `audience`, and `act`, HMAC-chained hop to hop. That proves the **sequence and integrity** of a delegation chain: the order is fixed, no hop was deleted, no field was flipped.

It does not prove that authority **narrowed**, because the authority granted at each hop was never part of the record. Without it, the only answer to "did this sub-agent hold more than the worker that spawned it?" is "the route checks would have refused anything wider" — an argument about code paths, not something an auditor can recompute from the receipts they were handed.

This diagnosis, and the shape of the fix, comes from @aeoess's review on the issue: https://github.com/sipyourdrink-ltd/bernstein/issues/2554#issuecomment-3563766348

## What this does

Binds each hop to its **effective scope** (or a content-addressed scope reference) plus the **parent hop it descends from**, and teaches `verify_run_chain` and `bernstein delegation verify` to resolve both grants and recompute the child-subset-of-parent relation per hop, naming the offending axis on failure.

### Three checks, deliberately distinct

| Check | Question | Failure |
|---|---|---|
| Narrowing | Did a child hop gain authority its parent lacked? | `narrowing_ok: false`, offending axis named |
| Separation of duties | Did one principal exercise incompatible powers? | `duties_ok: false`, the duty pair named |
| Decision binding | Was a gated decision pinned to a charter version? | `binding_ok: false` |

Blurring them loses information. A chain can narrow perfectly at every hop and still route both `spawn` and `approve` to the same principal; a chain can separate duties cleanly while widening scope at one hop. `TestSeparationOfDuties::test_narrowing_can_pass_while_duties_fail` pins exactly that gap.

**Narrowing** is a subset over `permissions`, `duties`, `task_ids`, POSIX `path_prefixes`, `not_after`, `max_uses`, and `max_depth`. The allowlist, path-prefix, and bound primitives are the ones that already govern signed capability tokens (`capability_tokens.py`), promoted to that module's public surface, so an axis means one thing on both surfaces. `Caveats.is_narrowing_of` now delegates to a new `narrowing_violations()` so the boolean verdict and the per-axis diagnosis can never disagree — and `verify_chain` names the offending axis too.

**Separation of duties** covers `spawn` / `approve` / `merge`, all three pairs separated by default and overridable per call. Duties come from the hop's recorded scope when it declares any, otherwise inferred from the `act` name on whole segments (`task.spawn` → `spawn`, while `spawner.status` matches nothing), so chains recorded before scopes existed still get coverage.

**Decision binding** carries the charter hash and tenant-certificate version in force when the hop was recorded, inside the signed body, so it is covered by the receipt HMAC. Two failures: `binding_missing` (a hop exercising `approve`/`merge` in an otherwise-bound chain cites no version, so the decision floats free of it) and `binding_drift` (a hop cites a different version than its parent — one authority chain is evaluated under one version).

### Verdict shape

`chain_ok` stays the tamper-evidence verdict, unchanged. `valid` now also requires the recomputed authority checks, so a widened hop fails verification even when every HMAC in the file is correct — which matters, because the party that writes a widened hop also holds the key that seals it.

## Adversarial tests first

A narrowing check that cannot fail is worthless, so the failing cases lead:

- **Widening on every axis** (7 parametrized cases) — each asserts `chain_ok is True` and `valid is False`, so a check that only re-verified HMACs would pass all seven.
- **Re-sealed forgery** — an insider edits a recorded scope to grant a permission its parent never held, then recomputes the HMAC so the file is internally consistent. Linkage and HMAC both pass; only the recomputed subset relation refuses.
- **Dropping a bound the parent imposed** — omission is not narrowing; `None` is the widest value, and all five dropped axes are reported.
- **Separation of duties** — one principal spawns work at hop 0 and approves it at hop 1; caught with the duty pair and both hop indices.
- **`unscoped_parent`** — a scoped hop whose parent records no scope is reported rather than assumed sound: an unrecorded ceiling makes narrowing unprovable, not proven.
- Plus `scope_ref_mismatch`, `unresolved_parent`, `unresolved_scope`, and binding drift/absence.

Neutering `narrowing_violations` and `check_duties` to no-ops turns 13 of these red, confirming they are load-bearing rather than tautological.

## Compatibility

Every new field is optional and omitted from the signed body entirely when unset, so a receipt recorded without authority binding produces byte-identical signing input to one written before the fields existed. `test_unscoped_receipt_bytes_are_unchanged_by_the_new_fields` pins the exact key set and recomputes the expected HMAC by hand.

## Verification

- `uv run ruff check .` — clean
- `uv run ruff format --check .` — 4292 files already formatted
- `uv run bernstein agents-md verify` — all 13 files in sync
- `tests/unit/identity/` (incl. the new `test_delegation_narrowing.py`, 31 cases), `test_capability_tokens.py`, `test_delegation_verify_token_cmd.py`, `test_capability_token_audit_anchor.py`, `test_permission_delegation_capability.py`, `test_permission_delegation_and_matrix.py`, `test_subagent_delegation.py`, `test_audit_chain_subagent_delegation.py`, `test_payment_mandates.py`, `test_payment_mandate_audit_chain.py`, `test_admission.py`, `test_admission_hardening.py`, `test_capability_caveat_subset.py` — **336 passed**
- `test_audit_chain_properties.py`, `test_audit_chain_bughunt.py`, `test_audit_chain_capability_profile.py`, `test_capability_matrix.py`, `test_capability_matrix_adversarial.py`, `test_capability_router.py` — **144 passed, 1 xfailed**

## Docs

New `docs/security/delegation-narrowing.md` (why sequence is not narrowing, the three checks, the axis table, recording and verifying, compatibility), linked from `docs/security/AUDIT.md` and the mkdocs nav.

---

Advances #2554: implements the narrowing verifier core. The canonicalization vectors remain with @aeoess per their comment.