### PR TITLE
fix(tests): make the CLI tip assertion independent of the random tip draw

### DIFF
--- a/tests/unit/test_capability_surfaces.py
+++ b/tests/unit/test_capability_surfaces.py
@@ -372,6 +372,12 @@ def test_tips_are_suppressed_for_json_output_and_opt_out(tmp_path: Path, monkeyp
         assert tips_enabled(ctx) is False
 
 
+#: Stand-in for whichever catalog tip the selector would have drawn.  The
+#: catalog picks with ``random.choice``, so asserting on real tip text makes
+#: the test depend on the draw rather than on the wiring under test.
+_PINNED_TIP = "Pinned tip text for the CLI surface test."
+
+
 def test_tip_is_printed_after_a_real_subcommand_invocation(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
     """Running a subcommand through the root group emits one tip afterwards."""
     monkeypatch.chdir(tmp_path)
@@ -379,15 +385,19 @@ def test_tip_is_printed_after_a_real_subcommand_invocation(tmp_path: Path, monke
     monkeypatch.delenv("BERNSTEIN_NO_TIPS", raising=False)
 
     runner = CliRunner()
-    with patch("bernstein.cli.main.tips_enabled", return_value=True):
+    with (
+        patch("bernstein.cli.main.tips_enabled", return_value=True),
+        patch("bernstein.tui.contextual_tips.TipsCatalog.get_tip", return_value=_PINNED_TIP),
+    ):
         first = runner.invoke(cli, ["agents", "trust"])
         second = runner.invoke(cli, ["agents", "trust"])
 
     assert first.exit_code == 0, first.output
-    assert "bernstein" in first.output
+    assert first.output.count(_PINNED_TIP) == 1
     assert (tmp_path / ".sdd" / "tips" / "last_shown").exists()
     # The cooldown marker suppresses the very next invocation.
     assert len(second.output) < len(first.output)
+    assert _PINNED_TIP not in second.output
 
 
 def test_no_tip_when_tips_are_disabled(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]


### PR DESCRIPTION
## Problem

`tests/unit/test_capability_surfaces.py::test_tip_is_printed_after_a_real_subcommand_invocation` is flaky and intermittently blocks unrelated PRs on the ubuntu and windows shards.

The test invoked `bernstein agents trust` through the root group with tips enabled and asserted `"bernstein" in first.output`. The tip is drawn with `random.choice` over the `general` category in `src/bernstein/tui/contextual_tips.py`, and one shipped tip contains no lowercase `bernstein`:

```
Set BERNSTEIN_MAX_COST to enforce a spending cap on every run.
```

So the assertion passed or failed depending on the draw - about one invocation in three. Observed on CI:

```
AssertionError: assert 'bernstein' in 'No agent trust records yet. Trust accrues as tasks complete.\nSet BERNSTEIN_MAX_COST to enforce a spending cap on every run.\n'
```

## Fix

Pin `TipsCatalog.get_tip` to a fixed string for the duration of the test and assert on that exact text. The draw is no longer part of the assertion, and the test now covers what its name and docstring claim: the root-group result callback emits exactly one tip after a real subcommand, writes the `.sdd/tips/last_shown` marker, and the marker suppresses the tip on the next invocation.

The cooldown assertion (`len(second.output) < len(first.output)`) is unchanged - that is the behaviour under test. One assertion added: the pinned tip does not reappear in the second invocation.

Test-only change; no production behaviour is touched, so no docs update applies.

## Verification

Forcing each `general` tip in turn shows the old assertion depended on the draw and the new one does not:

| forced draw | old assertion | new assertion |
|---|---|---|
| ``Use `bernstein status` to get a quick overview of your run.`` | PASS | PASS |
| ``Run `bernstein agents list` to see which CLI agents are available.`` | PASS | PASS |
| `Set BERNSTEIN_MAX_COST to enforce a spending cap on every run.` | **FAIL** | PASS |

Repeat runs on this branch:

- `uv run pytest tests/unit/test_capability_surfaces.py -q --no-cov` x20 - 22 passed each time, 0 failures
- the single test x25 - 25 passed, 0 failures
- `uv run ruff check .` - all checks passed
- `uv run ruff format --check .` - 4301 files already formatted

## Summary by Sourcery

Stabilise the CLI tip cooldown test by decoupling its assertions from the random tip selection.

Tests:
- Introduce a pinned tip string and mock the tip catalog to return it during the CLI surface test.
- Update the tip-related assertions to check for exactly one occurrence on first invocation and absence on the second, ensuring deterministic behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for contextual CLI tips using deterministic test content.
  * Added verification that tips appear once after an eligible command, cooldown state is recorded, and tips are suppressed during the cooldown period.
  * Removed brittle assertions tied to specific tip wording, making the test suite more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->