### PR TITLE
feat(cluster): pin MESH peer keys so a node_id cannot be asserted

### DIFF
--- a/docs/cluster/deployment-patterns.md
+++ b/docs/cluster/deployment-patterns.md
@@ -394,13 +394,70 @@ cluster:
   gossip_peers:
     - https://node-b.internal:8052
     - https://node-c.internal:8052
+  gossip_peer_keys:                 # required to fold any peer's receipts
+    "8Qm...node-b-thumbprint": |
+      -----BEGIN PUBLIC KEY-----
+      MCowBQYDK2VwAyEA...
+      -----END PUBLIC KEY-----
+    "Lk4...node-c-thumbprint": "hDq7...base64url-x"
   claim_lease_ttl_s: 300            # lease granted to a successful self-claim
   claim_journal_path: null          # default: .sdd/cluster/claim_journal.jsonl
 ```
 
-`gossip_peers` and `claim_journal_path` are rejected at seed-load time when
-`topology` is not `mesh`, so a half-migrated config fails at boot rather than
-silently running STAR.
+`gossip_peers`, `gossip_peer_keys`, and `claim_journal_path` are rejected at
+seed-load time when `topology` is not `mesh`, so a half-migrated config fails at
+boot rather than silently running STAR.
+
+### Peer identity: pinning is required, not optional
+
+**Default: a MESH node folds only receipts signed by a key it has pinned.** A
+node with no `gossip_peer_keys` accepts gossip from nobody. This is the
+deliberate default — the safe posture is the one you get without configuring
+anything, and opening the boundary is an explicit act.
+
+The reason is that the gossip route authenticates the *sender's cluster
+credential*, and the receipt's Ed25519 signature authenticates the *bytes*.
+Neither binds the `node_id` a receipt declares to the key that signed it.
+Without a pin, any holder of the cluster token can gossip receipts naming any
+node, and the journal — the arbiter the whole topology rests on — records a
+well-formed claim attributed to a node that never issued it.
+
+A pin is checkable rather than merely declared. A MESH `node_id` *is* the
+RFC 7638 thumbprint of that node's claim-signing key, so the seed loader
+recomputes the thumbprint of each pinned key and refuses to boot if it does not
+reproduce the id it is filed under. You cannot pin the wrong key to a node id.
+
+| Config | Result |
+|---|---|
+| No `gossip_peers`, no `gossip_peer_keys` | Single-node MESH. Self-claims work; inbound gossip is rejected. Logged at startup. |
+| `gossip_peers` set, `gossip_peer_keys` empty | **Seed load fails.** Outbound gossip with nothing folded back is a silent one-way partition. |
+| `gossip_peer_keys` whose thumbprint ≠ its `node_id` | **Seed load fails**, naming the identity the key actually has. |
+| Both set and consistent | Receipts from pinned peers fold; everything else is rejected with `no trusted key pinned for node …`. |
+
+Each node also pins **its own** key to its own `node_id`, always. A peer
+therefore cannot gossip receipts forged in this node's name, and a node that
+lost its journal can still fold its own history back from a peer.
+
+Getting the values:
+
+```bash
+# On each peer - the id it will declare, and the key that proves it.
+bernstein cluster claims head          # any receipt's node_id is the peer's id
+cat .sdd/cluster/identity/claim_signing.pub
+```
+
+The key may be given as the SPKI PEM above, as an OKP JWK mapping, or as the
+bare base64url `x` member — all three normalise to the same pin.
+
+Pinning is symmetric: for A and B to converge, A must pin B's key *and* B must
+pin A's. Rotating a node's claim-signing identity changes its `node_id`, so a
+rotation is a config change on every peer, not a silent re-trust.
+
+> **Upgrading an existing MESH fleet.** Before this default, gossip was
+> accepted under whatever key a receipt carried. After it, an unpinned peer's
+> receipts are rejected with a reason in the gossip response. Add
+> `gossip_peer_keys` on every node before rolling out, or the fleet stops
+> converging.
 
 ### How a claim resolves
 
@@ -418,11 +475,11 @@ the journal alone.
 ### Gossip
 
 Nodes push receipts to their peers with `POST /cluster/claims/gossip`. A
-receiving node folds a receipt only after **both** the Ed25519 signature and
-the chain link verify. A receipt that does not extend the local head is not
-merged: it produces a signed `fork` receipt carrying the divergence entry
-index, which `verify` and the gossip response both surface. A partition is
-reported, never silently reconciled.
+receiving node folds a receipt only after **all three** of the pinned peer key,
+the Ed25519 signature, and the chain link verify. A receipt that does not extend
+the local head is not merged: it produces a signed `fork` receipt carrying the
+divergence entry index, which `verify` and the gossip response both surface. A
+partition is reported, never silently reconciled.
 
 Gossip rides the cluster transport and reuses the node-heartbeat auth scope,
 so the same bearer credential a worker uses to join covers it. On a Tailscale
@@ -461,8 +518,8 @@ and `--no-check-anchors` when the audit chain is not available alongside it.
 - **Leases.** A hold whose `claim_lease_ttl_s` has elapsed can be retired by
   *any* node observing it - there is no central sweep. The `expire` receipt is
   signed by the observing node and names the retired claim as referenced data,
-  so a verifier that pins keys by `node_id` still finds every receipt signed by
-  the node it says it is from.
+  so the `node_id` pinning above still finds every receipt signed by the node it
+  says it is from.
 - **STAR is unaffected.** A STAR deployment never materialises a journal, never
   provisions a MESH signing identity, and answers `409` on the gossip route.
 - **Shared filesystem.** When peers share one filesystem, they can append to

--- a/src/bernstein/core/config/config_schema.py
+++ b/src/bernstein/core/config/config_schema.py
@@ -392,6 +392,10 @@ class ClusterSchema(BaseModel):
     gossip_peers: list[str] = Field(default_factory=list)
     claim_lease_ttl_s: int = Field(default=300, ge=1)
     claim_journal_path: str | None = None
+    # Pinned peer identities (issue #2997): node_id -> Ed25519 public key,
+    # given as SPKI PEM text, an OKP JWK mapping, or the bare base64url 'x'.
+    # A MESH node folds only receipts signed by a pinned key.
+    gossip_peer_keys: dict[str, Any] = Field(default_factory=dict)
 
 
 class RemoteSchema(BaseModel):

--- a/src/bernstein/core/config/seed_parser.py
+++ b/src/bernstein/core/config/seed_parser.py
@@ -46,6 +46,7 @@ from bernstein.core.models import (
     BridgeConfigSet,
     ClusterConfig,
     ClusterTopology,
+    MeshPeerKey,
     OpenClawBridgeConfig,
     SmtpConfig,
     TestAgentConfig,
@@ -1294,6 +1295,52 @@ def _parse_storage(raw: object) -> StorageConfig | None:
     )
 
 
+def _parse_gossip_peer_keys(raw: object) -> tuple[MeshPeerKey, ...]:
+    """Parse and verify ``cluster.gossip_peer_keys`` (issue #2997).
+
+    The mapping is ``node_id -> Ed25519 public key``, where the key may be the
+    SPKI PEM a peer publishes, an OKP JWK mapping, or the bare base64url ``x``.
+
+    Every pin is checked, not merely parsed: a MESH ``node_id`` is the RFC 7638
+    thumbprint of the signing key, so the declared id must be reproducible from
+    the pinned key. A mismatch means the operator pasted one peer's id next to
+    another peer's key, which would pin the wrong identity -- caught here, at
+    seed load, rather than at the first gossip.
+
+    Returns:
+        The pins in ``node_id`` order, so the parsed config is deterministic
+        regardless of how the YAML mapping was written.
+
+    Raises:
+        SeedError: When the section is not a mapping, an id is not a non-empty
+            string, a key is unreadable, or a pin's thumbprint disagrees with
+            the id it is filed under.
+    """
+    if raw is None:
+        return ()
+    if not isinstance(raw, dict):
+        raise SeedError(
+            f"cluster.gossip_peer_keys must be a mapping of node_id to public key, got: {type(raw).__name__}"
+        )
+    pins: list[MeshPeerKey] = []
+    for node_id_raw, material in cast("dict[object, object]", raw).items():
+        if not isinstance(node_id_raw, str) or not node_id_raw.strip():
+            raise SeedError(f"cluster.gossip_peer_keys keys must be non-empty node ids, got: {node_id_raw!r}")
+        node_id = node_id_raw.strip()
+        try:
+            pin = MeshPeerKey.from_material(node_id, material)
+        except ValueError as exc:
+            raise SeedError(f"cluster.gossip_peer_keys[{node_id!r}]: {exc}") from None
+        if pin.node_id_from_key() != node_id:
+            raise SeedError(
+                f"cluster.gossip_peer_keys[{node_id!r}] is pinned to a key whose identity is "
+                f"{pin.node_id_from_key()!r}. A MESH node_id is the thumbprint of its claim-signing "
+                "key, so the id and the key must agree.",
+            )
+        pins.append(pin)
+    return tuple(sorted(pins, key=lambda pin: pin.node_id))
+
+
 def _parse_cluster(raw: object) -> ClusterConfig | None:
     """Parse the optional ``cluster`` section."""
     if raw is None:
@@ -1326,10 +1373,22 @@ def _parse_cluster(raw: object) -> ClusterConfig | None:
         raise SeedError(f"cluster.claim_lease_ttl_s must be a positive integer, got: {lease_raw!r}")
     journal_path_raw: object = cluster_dict.get("claim_journal_path")
     journal_path: str | None = str(journal_path_raw) if journal_path_raw is not None else None
-    if topology is not ClusterTopology.MESH and (gossip_peers or journal_path):
+    peer_keys = _parse_gossip_peer_keys(cluster_dict.get("gossip_peer_keys"))
+    if topology is not ClusterTopology.MESH and (gossip_peers or journal_path or peer_keys):
         raise SeedError(
-            "cluster.gossip_peers / cluster.claim_journal_path apply to topology 'mesh' only, "
-            f"but topology is {topology.value!r}",
+            "cluster.gossip_peers / cluster.claim_journal_path / cluster.gossip_peer_keys "
+            f"apply to topology 'mesh' only, but topology is {topology.value!r}",
+        )
+    if topology is ClusterTopology.MESH and gossip_peers and not peer_keys:
+        # A MESH node folds only receipts signed by a pinned key (#2997), so
+        # gossip configured without pins would push receipts out and fold none
+        # back. Failing here names the missing key instead of leaving the
+        # operator to infer it from a peer that never converges.
+        raise SeedError(
+            "cluster.gossip_peers is set but cluster.gossip_peer_keys is empty: a MESH node "
+            "folds only receipts signed by a pinned peer key, so gossip would be accepted from "
+            "no one. Pin each peer as 'gossip_peer_keys: {<node_id>: <ed25519 public key>}' "
+            "(the peer's .sdd/cluster/identity/claim_signing.pub).",
         )
     return ClusterConfig(
         enabled=bool(cluster_dict.get("enabled", False)),
@@ -1342,6 +1401,7 @@ def _parse_cluster(raw: object) -> ClusterConfig | None:
         gossip_peers=tuple(gossip_peers),
         claim_lease_ttl_s=lease_raw,
         claim_journal_path=journal_path,
+        gossip_peer_keys=peer_keys,
     )
 
 

--- a/src/bernstein/core/identity/http_signing.py
+++ b/src/bernstein/core/identity/http_signing.py
@@ -76,6 +76,7 @@ __all__ = [
     "content_digest",
     "default_keystore",
     "install_identity_keyid",
+    "public_key_jwk_from_pem",
     "record_signature",
     "sign_outbound",
     "sign_request",
@@ -132,11 +133,7 @@ def install_identity_keyid(public_pem: bytes) -> str:
     Returns:
         A short, URL-safe thumbprint string suitable as an HTTP-sig ``keyid``.
     """
-    raw = serialization.load_pem_public_key(public_pem).public_bytes(
-        serialization.Encoding.Raw,
-        serialization.PublicFormat.Raw,
-    )
-    x = base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+    x = public_key_jwk_from_pem(public_pem)["x"]
     canonical = json.dumps(
         {"crv": "Ed25519", "kty": "OKP", "x": x},
         sort_keys=True,
@@ -144,6 +141,32 @@ def install_identity_keyid(public_pem: bytes) -> str:
     ).encode("ascii")
     digest = hashlib.sha256(canonical).digest()
     return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+def public_key_jwk_from_pem(public_pem: bytes) -> dict[str, str]:
+    """Return the RFC 8037 OKP JWK for an Ed25519 SPKI PEM public key.
+
+    The counterpart to :func:`install_identity_keyid`: the thumbprint answers
+    "what is this key's identity", this answers "what key does that identity
+    have". Verifiers that pin a key by identity need both halves.
+
+    Args:
+        public_pem: SPKI PEM bytes of an Ed25519 public key.
+
+    Returns:
+        A JWK with ``kty='OKP'``, ``crv='Ed25519'``, ``alg='EdDSA'`` and the
+        base64url-encoded raw public key as ``x``.
+    """
+    raw = serialization.load_pem_public_key(public_pem).public_bytes(
+        serialization.Encoding.Raw,
+        serialization.PublicFormat.Raw,
+    )
+    return {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "alg": "EdDSA",
+        "x": base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii"),
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -6046,6 +6046,9 @@ if __name__ == "__main__":
                 gossip_peers=(cluster_cfg.gossip_peers if cluster_cfg else ()),
                 claim_lease_ttl_s=(cluster_cfg.claim_lease_ttl_s if cluster_cfg else 300),
                 claim_journal_path=(cluster_cfg.claim_journal_path if cluster_cfg else None),
+                # Carried through the env override too: dropping the pins here
+                # would leave a MESH node folding nothing from its peers (#2997).
+                gossip_peer_keys=(cluster_cfg.gossip_peer_keys if cluster_cfg else ()),
             )
 
         # Topology branch (#2558): MESH starts a leaderless coordinator instead

--- a/src/bernstein/core/protocols/cluster/mesh_coordinator.py
+++ b/src/bernstein/core/protocols/cluster/mesh_coordinator.py
@@ -94,6 +94,21 @@ def build_mesh_coordinator(
     an operator-set string means a receipt cannot claim to be from a node whose
     key it does not hold -- the two are the same fact.
 
+    That fact only binds if the verifier knows which key a ``node_id`` should
+    have, so the coordinator is always built with a pin map (#2997), never with
+    ``None``:
+
+    * ``cluster.gossip_peer_keys`` supplies the peers this node accepts gossip
+      from.
+    * This node's own public key is pinned to its own ``node_id``, so a peer
+      cannot echo back receipts attributed to us under a key of its choosing,
+      and a node recovering its journal from a peer still folds its own
+      history.
+
+    A MESH node with no configured pins therefore folds no foreign receipts at
+    all rather than trusting whatever key a receipt carries. Closed is the
+    default; opening it is an explicit act.
+
     Args:
         cluster_config: The resolved ``ClusterConfig``. Typed loosely so this
             module stays importable without pulling in the task models.
@@ -125,6 +140,7 @@ def build_mesh_coordinator(
             public_name=_MESH_PUBLIC_KEY_NAME,
         )
         node_id = install_identity_keyid(public_pem.encode("ascii"))
+        trusted_keys = _pinned_peer_keys(cluster_config, node_id=node_id, public_pem=public_pem)
         configured_path = getattr(cluster_config, "claim_journal_path", None)
         journal_path = Path(configured_path) if configured_path else default_claim_journal_path(Path(sdd_dir))
         journal = ClaimJournal(
@@ -139,11 +155,40 @@ def build_mesh_coordinator(
         # answers 409 rather than accepting receipts it cannot verify against.
         logger.error("MESH coordinator unavailable, leaderless claiming disabled: %s", exc)
         return None
+    if not any(pinned != node_id for pinned in trusted_keys):
+        logger.warning(
+            "MESH node %s has no pinned gossip peers: every gossiped receipt will be rejected. "
+            "Add cluster.gossip_peer_keys to accept a peer's receipts.",
+            node_id,
+        )
     return MeshCoordinator(
         journal=journal,
         lease_ttl_s=int(getattr(cluster_config, "claim_lease_ttl_s", DEFAULT_MESH_LEASE_TTL_S)),
         peers=tuple(getattr(cluster_config, "gossip_peers", ()) or ()),
+        trusted_keys=trusted_keys,
     )
+
+
+def _pinned_peer_keys(
+    cluster_config: object,
+    *,
+    node_id: str,
+    public_pem: str,
+) -> dict[str, dict[str, Any]]:
+    """Return the ``node_id`` to JWK pin map this coordinator verifies against.
+
+    Always includes this node's own key, so a receipt attributed to us is only
+    folded when it was signed by us. Peers come from
+    ``cluster.gossip_peer_keys``; a config that pins none yields a map holding
+    only our own entry, which rejects every foreign receipt -- the fail-closed
+    posture #2997 chose as the default.
+    """
+    from bernstein.core.identity.http_signing import public_key_jwk_from_pem
+
+    pins: dict[str, dict[str, Any]] = {node_id: dict(public_key_jwk_from_pem(public_pem.encode("ascii")))}
+    for peer_key in getattr(cluster_config, "gossip_peer_keys", ()) or ():
+        pins[peer_key.node_id] = dict(peer_key.to_jwk())
+    return pins
 
 
 @dataclass(frozen=True, slots=True)
@@ -198,10 +243,12 @@ class MeshCoordinator:
         peers: Gossip peer base URLs. Held for the gossip transport to read;
             the coordinator itself never dials them, so every method here works
             with the network down.
-        trusted_keys: Optional ``node_id`` to public-key JWK pinning applied to
-            every ingested receipt. Without it a gossiped receipt is verified
-            against the key it carries, which authenticates the bytes but not
-            the identity.
+        trusted_keys: ``node_id`` to public-key JWK pinning applied to every
+            ingested receipt. ``None`` verifies a gossiped receipt against the
+            key it carries, which authenticates the bytes but not the identity;
+            an empty map trusts no one. :func:`build_mesh_coordinator` always
+            supplies a map, so ``None`` is reachable only by constructing a
+            coordinator directly (#2997).
     """
 
     def __init__(

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -1773,6 +1773,117 @@ class NodeInfo:
 
 
 @dataclass(frozen=True)
+class MeshPeerKey:
+    """A gossip peer's pinned identity: its ``node_id`` and its public key.
+
+    A MESH ``node_id`` is not an operator-chosen label -- it is the RFC 7638
+    thumbprint of the node's Ed25519 claim-signing key, so the identity and the
+    key are the same fact. Pinning therefore has a checkable form: the
+    thumbprint of ``public_key_x`` must reproduce ``node_id``, which is what
+    :meth:`node_id_from_key` computes and the seed loader asserts. A pin that
+    does not verify is a typo, not a policy, and is rejected before a node
+    boots with it.
+
+    Attributes:
+        node_id: The peer's install identity id, as it appears in the
+            ``node_id`` field of every receipt that peer signs.
+        public_key_x: Base64url (unpadded) encoding of the peer's raw 32-byte
+            Ed25519 public key -- the JWK ``x`` member per RFC 8037.
+    """
+
+    node_id: str
+    public_key_x: str
+
+    def to_jwk(self) -> dict[str, str]:
+        """Return this key as an RFC 8037 OKP JWK."""
+        return {"kty": "OKP", "crv": "Ed25519", "alg": "EdDSA", "x": self.public_key_x}
+
+    def node_id_from_key(self) -> str:
+        """Return the RFC 7638 thumbprint of :attr:`public_key_x`.
+
+        Equals :attr:`node_id` for a correctly pinned peer; the seed loader
+        compares the two so a pin cannot name a node whose key it does not
+        carry.
+        """
+        import base64
+        import hashlib
+        import json
+
+        canonical = json.dumps(
+            {"crv": "Ed25519", "kty": "OKP", "x": self.public_key_x},
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("ascii")
+        digest = hashlib.sha256(canonical).digest()
+        return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+    @classmethod
+    def from_material(cls, node_id: str, material: object) -> MeshPeerKey:
+        """Build a pin from the key material an operator can paste into YAML.
+
+        Three forms are accepted, all normalising to the same JWK ``x``:
+
+        * The SPKI PEM a peer publishes at
+          ``.sdd/cluster/identity/claim_signing.pub``.
+        * A JWK mapping (``kty``/``crv`` must be ``OKP``/``Ed25519``).
+        * The bare base64url ``x`` member.
+
+        Args:
+            node_id: The peer's install identity id.
+            material: The key material in one of the three forms above.
+
+        Returns:
+            The normalised :class:`MeshPeerKey`.
+
+        Raises:
+            ValueError: When the material is not a usable Ed25519 public key.
+                The message names the accepted forms so a bad paste is
+                actionable at seed load.
+        """
+        import base64
+
+        if isinstance(material, dict):
+            jwk: dict[str, object] = material
+            if jwk.get("kty") != "OKP" or jwk.get("crv") != "Ed25519":
+                raise ValueError("JWK must have kty='OKP' and crv='Ed25519'")
+            x_member = jwk.get("x")
+            if not isinstance(x_member, str) or not x_member.strip():
+                raise ValueError("JWK is missing a non-empty 'x' member")
+            x = x_member.strip()
+        elif isinstance(material, str) and material.strip():
+            text = material.strip()
+            if "-----BEGIN" in text:
+                from cryptography.hazmat.primitives import serialization
+                from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+                try:
+                    loaded = serialization.load_pem_public_key(text.encode("ascii"))
+                except Exception as exc:
+                    raise ValueError(f"not a readable PEM public key: {exc}") from exc
+                if not isinstance(loaded, Ed25519PublicKey):
+                    raise ValueError("PEM public key is not Ed25519")
+                raw = loaded.public_bytes(
+                    serialization.Encoding.Raw,
+                    serialization.PublicFormat.Raw,
+                )
+                x = base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+            else:
+                x = text
+        else:
+            raise ValueError(
+                "must be an Ed25519 public key: SPKI PEM text, an OKP JWK mapping, or the base64url 'x' member",
+            )
+
+        try:
+            raw_key = base64.urlsafe_b64decode(x + "=" * (-len(x) % 4))
+        except Exception as exc:
+            raise ValueError(f"public key is not valid base64url: {exc}") from exc
+        if len(raw_key) != 32:
+            raise ValueError(f"Ed25519 public key must decode to 32 bytes, got {len(raw_key)}")
+        return cls(node_id=node_id, public_key_x=x)
+
+
+@dataclass(frozen=True)
 class ClusterConfig:
     """Configuration for distributed cluster mode.
 
@@ -1795,6 +1906,11 @@ class ClusterConfig:
         claim_journal_path: MESH only. Explicit path to the signed claim
             journal. ``None`` uses the conventional
             ``.sdd/cluster/claim_journal.jsonl``.
+        gossip_peer_keys: MESH only. The peers whose gossiped receipts this
+            node will fold, each pinned to the Ed25519 key that must have
+            signed them. Empty means no peer is trusted: a MESH node folds
+            only receipts signed by a pinned key, so gossip is closed until
+            the operator opens it deliberately (#2997).
     """
 
     enabled: bool = False
@@ -1810,6 +1926,7 @@ class ClusterConfig:
     gossip_peers: tuple[str, ...] = ()
     claim_lease_ttl_s: int = 300
     claim_journal_path: str | None = None
+    gossip_peer_keys: tuple[MeshPeerKey, ...] = ()
 
     @property
     def is_mesh(self) -> bool:

--- a/tests/unit/orchestration/test_mesh_coordinator.py
+++ b/tests/unit/orchestration/test_mesh_coordinator.py
@@ -644,6 +644,8 @@ def test_seed_parser_accepts_and_validates_mesh_keys(tmp_path: Path) -> None:
             "enabled": True,
             "topology": "mesh",
             "gossip_peers": ["https://peer-b:8052", " https://peer-c:8052 "],
+            # Gossip peers require pinned identities (#2997).
+            "gossip_peer_keys": {_node_id_for(7): _public_pem(7)},
             "claim_lease_ttl_s": 90,
             "claim_journal_path": str(tmp_path / "j.jsonl"),
         }
@@ -661,6 +663,116 @@ def test_seed_parser_accepts_and_validates_mesh_keys(tmp_path: Path) -> None:
         _parse_cluster({"topology": "mesh", "claim_lease_ttl_s": 0})
     with pytest.raises(SeedError, match="apply to topology 'mesh' only"):
         _parse_cluster({"topology": "star", "gossip_peers": ["https://peer-b:8052"]})
+
+
+# ---------------------------------------------------------------------------
+# Pinned peer identities (issue #2997)
+# ---------------------------------------------------------------------------
+
+
+def _public_pem(seed: int) -> str:
+    """Return the SPKI PEM an operator would copy out of a peer's install."""
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    return (
+        Ed25519PrivateKey.from_private_bytes(bytes([seed]) * 32)
+        .public_key()
+        .public_bytes(serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo)
+        .decode("ascii")
+    )
+
+
+def _node_id_for(seed: int) -> str:
+    """Return the node id a peer signing with ``seed`` will declare."""
+    from bernstein.core.identity.http_signing import install_identity_keyid
+
+    return install_identity_keyid(_public_pem(seed).encode("ascii"))
+
+
+def test_seed_parser_accepts_every_documented_pin_form() -> None:
+    """PEM, JWK, and bare base64url ``x`` all normalise to the same pin."""
+    from bernstein.core.config.seed_parser import _parse_cluster
+    from bernstein.core.identity.http_signing import public_key_jwk_from_pem
+
+    node_id = _node_id_for(7)
+    jwk = public_key_jwk_from_pem(_public_pem(7).encode("ascii"))
+    for material in (_public_pem(7), jwk, jwk["x"]):
+        cfg = _parse_cluster({"topology": "mesh", "gossip_peer_keys": {node_id: material}})
+        assert cfg is not None
+        assert len(cfg.gossip_peer_keys) == 1
+        assert cfg.gossip_peer_keys[0].node_id == node_id
+        assert cfg.gossip_peer_keys[0].public_key_x == jwk["x"]
+
+
+def test_seed_parser_rejects_gossip_peers_configured_without_pinned_keys() -> None:
+    """Gossip without pins would push receipts out and fold none back."""
+    from bernstein.core.config.seed_parser import SeedError, _parse_cluster
+
+    with pytest.raises(SeedError, match="gossip_peer_keys is empty"):
+        _parse_cluster({"topology": "mesh", "gossip_peers": ["https://peer-b:8052"]})
+
+
+def test_seed_parser_rejects_pinned_keys_under_a_non_mesh_topology() -> None:
+    """The pin map is a MESH-only key, like the rest of the MESH surface."""
+    from bernstein.core.config.seed_parser import SeedError, _parse_cluster
+
+    with pytest.raises(SeedError, match="apply to topology 'mesh' only"):
+        _parse_cluster({"topology": "star", "gossip_peer_keys": {_node_id_for(7): _public_pem(7)}})
+
+
+def test_seed_parser_rejects_a_pin_whose_key_does_not_derive_its_node_id() -> None:
+    """A node id *is* its key's thumbprint, so a pin is checkable, not asserted.
+
+    Filing peer B's key under peer A's id would pin the wrong identity and
+    silently accept B's receipts as A's. The mismatch is arithmetic, so it is
+    caught at seed load rather than at the first gossip.
+    """
+    from bernstein.core.config.seed_parser import SeedError, _parse_cluster
+
+    with pytest.raises(SeedError, match="pinned to a key whose identity is"):
+        _parse_cluster({"topology": "mesh", "gossip_peer_keys": {_node_id_for(9): _public_pem(7)}})
+
+
+def test_seed_parser_rejects_malformed_pin_material() -> None:
+    """A bad paste fails the seed load with what the key should look like."""
+    from bernstein.core.config.seed_parser import SeedError, _parse_cluster
+
+    with pytest.raises(SeedError, match="must be a mapping of node_id to public key"):
+        _parse_cluster({"topology": "mesh", "gossip_peer_keys": ["not-a-mapping"]})
+    with pytest.raises(SeedError, match="must decode to 32 bytes"):
+        _parse_cluster({"topology": "mesh", "gossip_peer_keys": {"n": "c2hvcnQ"}})
+    with pytest.raises(SeedError, match="must be an Ed25519 public key"):
+        _parse_cluster({"topology": "mesh", "gossip_peer_keys": {"n": 42}})
+    with pytest.raises(SeedError, match="kty='OKP'"):
+        _parse_cluster({"topology": "mesh", "gossip_peer_keys": {"n": {"kty": "RSA"}}})
+
+
+def test_mesh_coordinator_is_built_with_a_pin_map_that_is_never_none(tmp_path: Path) -> None:
+    """The production build path always pins: closed by default (#2997).
+
+    Self-pinning is part of that map, so a peer cannot gossip receipts forged
+    in this node's name even before any peer is configured.
+    """
+    from bernstein.core.config.seed_parser import _parse_cluster
+
+    node_id = _node_id_for(7)
+    cfg = _parse_cluster({"enabled": True, "topology": "mesh", "gossip_peer_keys": {node_id: _public_pem(7)}})
+    assert cfg is not None
+
+    coordinator = build_mesh_coordinator(cfg, sdd_dir=tmp_path / ".sdd")
+    assert coordinator is not None
+    pins = coordinator._trusted_keys  # the wiring under test
+    assert pins is not None
+    assert pins[node_id]["x"] == cfg.gossip_peer_keys[0].public_key_x
+    assert coordinator.node_id in pins
+
+    bare = build_mesh_coordinator(
+        ClusterConfig(enabled=True, topology=ClusterTopology.MESH),
+        sdd_dir=tmp_path / "bare" / ".sdd",
+    )
+    assert bare is not None
+    assert bare._trusted_keys == {bare.node_id: bare._trusted_keys[bare.node_id]}
 
 
 def test_star_cluster_config_keeps_its_defaults() -> None:

--- a/tests/unit/test_cluster_claims_surface.py
+++ b/tests/unit/test_cluster_claims_surface.py
@@ -17,8 +17,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
-from bernstein.core.models import ClusterConfig
+from bernstein.core.models import ClusterConfig, MeshPeerKey
 from click.testing import CliRunner
+from cryptography.hazmat.primitives import serialization
 from fastapi.testclient import TestClient
 
 from bernstein.cli.commands.cluster_cmd import cluster_group
@@ -37,7 +38,6 @@ _SECRET = "cluster-shared-secret-value"  # NOSONAR - test fixture, not a real cr
 
 
 def _kms(tmp_path: Path, *, seed: int, name: str) -> object:
-    from cryptography.hazmat.primitives import serialization
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
     from bernstein.core.security.lineage_kms import FileBasedKMSAdapter
@@ -55,15 +55,44 @@ def _kms(tmp_path: Path, *, seed: int, name: str) -> object:
     return FileBasedKMSAdapter(key_path, kid=name)
 
 
-def _peer(tmp_path: Path, *, node_id: str = "peer-node", seed: int = 7) -> MeshCoordinator:
-    """A remote node whose receipts are gossiped into the server under test."""
+def _peer(
+    tmp_path: Path,
+    *,
+    node_id: str = "peer-node",
+    seed: int = 7,
+    label: str | None = None,
+) -> MeshCoordinator:
+    """A remote node whose receipts are gossiped into the server under test.
+
+    ``label`` names the peer's own journal file and key material independently
+    of the ``node_id`` its receipts declare, so a test can build a node that
+    *claims* an identity it does not hold.
+    """
+    slug = label or node_id
     return MeshCoordinator(
         journal=ClaimJournal(
-            tmp_path / f"{node_id}.jsonl",
-            kms_adapter=_kms(tmp_path, seed=seed, name=f"{node_id}-key"),  # type: ignore[arg-type]
+            tmp_path / f"{slug}.jsonl",
+            kms_adapter=_kms(tmp_path, seed=seed, name=f"{slug}-key"),  # type: ignore[arg-type]
             node_id=node_id,
         ),
     )
+
+
+def _pin(node_id: str, *, seed: int = 7) -> MeshPeerKey:
+    """The pin an operator would configure for a peer signing with ``seed``."""
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    from bernstein.core.identity.http_signing import public_key_jwk_from_pem
+
+    public_pem = (
+        Ed25519PrivateKey.from_private_bytes(bytes([seed]) * 32)
+        .public_key()
+        .public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+    )
+    return MeshPeerKey(node_id=node_id, public_key_x=public_key_jwk_from_pem(public_pem)["x"])
 
 
 # ---------------------------------------------------------------------------
@@ -72,9 +101,9 @@ def _peer(tmp_path: Path, *, node_id: str = "peer-node", seed: int = 7) -> MeshC
 
 
 class TestGossipRoute:
-    """Verify-before-fold, STAR refusal, and fork reporting."""
+    """Verify-before-fold, peer-key pinning, STAR refusal, and fork reporting."""
 
-    def _mesh_client(self, tmp_path: Path) -> TestClient:
+    def _mesh_client(self, tmp_path: Path, *, pins: tuple[MeshPeerKey, ...] = ()) -> TestClient:
         app = create_app(
             jsonl_path=tmp_path / ".sdd" / "runtime" / "tasks.jsonl",
             auth_token=_SECRET,
@@ -82,6 +111,7 @@ class TestGossipRoute:
                 enabled=True,
                 topology=ClusterTopology.MESH,
                 auth_token=_SECRET,
+                gossip_peer_keys=pins,
             ),
         )
         return TestClient(app)
@@ -117,10 +147,10 @@ class TestGossipRoute:
         assert "mesh" in response.json()["detail"].lower()
 
     def test_mesh_node_folds_verified_receipts(self, tmp_path: Path) -> None:
-        """A signed, chain-extending receipt is folded and changes the head."""
+        """A signed, chain-extending receipt from a pinned peer is folded."""
         peer = _peer(tmp_path)
         peer.claim(tracker="jira", ticket_id="T-1", role="backend", claimer_id="w-peer", now=1000.0)
-        client = self._mesh_client(tmp_path)
+        client = self._mesh_client(tmp_path, pins=(_pin("peer-node"),))
 
         body = self._push(client, peer.journal.read())
         assert body["accepted"] == 1
@@ -137,7 +167,7 @@ class TestGossipRoute:
         """The signature and hash are checked before anything is written."""
         peer = _peer(tmp_path)
         peer.claim(tracker="jira", ticket_id="T-1", role="backend", claimer_id="w-peer", now=1000.0)
-        client = self._mesh_client(tmp_path)
+        client = self._mesh_client(tmp_path, pins=(_pin("peer-node"),))
 
         wire = peer.journal.read()[0].to_dict()
         wire["claimer_id"] = "attacker"
@@ -156,7 +186,7 @@ class TestGossipRoute:
 
     def test_divergent_chain_reports_a_fork(self, tmp_path: Path) -> None:
         """A receipt that does not extend the local head forks, never merges."""
-        client = self._mesh_client(tmp_path)
+        client = self._mesh_client(tmp_path, pins=(_pin("peer-node"),))
         coordinator = client.app.state.mesh_coordinator  # type: ignore[attr-defined]
         # The server already has a local entry, so a peer receipt built on
         # genesis cannot extend it.
@@ -194,6 +224,99 @@ class TestGossipRoute:
             headers={"Authorization": f"Bearer {_SECRET}"},
         )
         assert response.status_code == 422
+
+    # -- peer-key pinning (#2997) --------------------------------------
+
+    def test_receipt_signed_by_a_key_that_is_not_the_pinned_one_is_rejected(self, tmp_path: Path) -> None:
+        """A node_id must be *proved*, not asserted, over the real route.
+
+        The impostor holds a valid cluster token and mints a receipt that is
+        internally perfect: correctly chained, correctly hashed, and validly
+        Ed25519-signed by the key it holds. The only thing wrong with it is
+        that the key is not the one pinned for the ``node_id`` it declares.
+
+        Both receipts travel through ``POST /cluster/claims/gossip`` -- the
+        production path, with the coordinator built by ``create_app`` from
+        config -- because the defect this covers is the *wiring*: calling the
+        coordinator directly would pass even with nothing wired.
+        """
+        pinned = _pin("peer-node", seed=7)
+        client = self._mesh_client(tmp_path, pins=(pinned,))
+
+        impostor = _peer(tmp_path, node_id="peer-node", seed=9, label="impostor")
+        impostor.claim(tracker="jira", ticket_id="T-1", role="backend", claimer_id="w-impostor", now=1000.0)
+        body = self._push(client, impostor.journal.read())
+
+        assert body["accepted"] == 0
+        assert body["results"][0]["status"] == "rejected"  # type: ignore[index]
+        assert "signature" in str(body["results"][0]["reason"]).lower()  # type: ignore[index]
+
+        coordinator = client.app.state.mesh_coordinator  # type: ignore[attr-defined]
+        # Nothing was written: the journal is not merely un-folded, it is empty.
+        assert coordinator.state().holder("jira", "T-1", "backend") is None
+        assert coordinator.journal.read() == []
+
+        # The pin admits the real holder of that identity, so the rejection
+        # above is the pin working, not gossip being broken outright.
+        genuine = _peer(tmp_path, node_id="peer-node", seed=7, label="genuine")
+        genuine.claim(tracker="jira", ticket_id="T-1", role="backend", claimer_id="w-peer", now=1000.0)
+        accepted = self._push(client, genuine.journal.read())
+        assert accepted["accepted"] == 1
+        assert coordinator.state().holder("jira", "T-1", "backend") is not None
+
+    def test_a_mesh_node_with_no_pins_folds_nothing(self, tmp_path: Path) -> None:
+        """Fail-closed default: an unpinned node_id is refused, not trusted.
+
+        Before #2997 no production path populated the pin map, so a receipt was
+        verified against the key it shipped with -- authenticating the bytes but
+        not the sender. A MESH node now starts closed.
+        """
+        peer = _peer(tmp_path)
+        peer.claim(tracker="jira", ticket_id="T-1", role="backend", claimer_id="w-peer", now=1000.0)
+        client = self._mesh_client(tmp_path)
+
+        body = self._push(client, peer.journal.read())
+        assert body["accepted"] == 0
+        assert body["results"][0]["status"] == "rejected"  # type: ignore[index]
+        assert "no trusted key pinned" in str(body["results"][0]["reason"])  # type: ignore[index]
+
+        coordinator = client.app.state.mesh_coordinator  # type: ignore[attr-defined]
+        assert coordinator.state().holder("jira", "T-1", "backend") is None
+
+    def test_a_pinned_peer_cannot_speak_for_another_pinned_peer(self, tmp_path: Path) -> None:
+        """Holding one pinned key does not confer another peer's identity."""
+        client = self._mesh_client(tmp_path, pins=(_pin("peer-b", seed=7), _pin("peer-c", seed=9)))
+
+        # peer-c's key, signing a receipt that declares peer-b's node_id.
+        crossed = _peer(tmp_path, node_id="peer-b", seed=9, label="crossed")
+        crossed.claim(tracker="jira", ticket_id="T-1", role="backend", claimer_id="w", now=1000.0)
+
+        body = self._push(client, crossed.journal.read())
+        assert body["results"][0]["status"] == "rejected"  # type: ignore[index]
+        coordinator = client.app.state.mesh_coordinator  # type: ignore[attr-defined]
+        assert coordinator.journal.read() == []
+
+    def test_the_node_pins_its_own_key_to_its_own_node_id(self, tmp_path: Path) -> None:
+        """A peer cannot echo back receipts forged in this node's name.
+
+        Self-pinning also keeps recovery working: a node that lost its journal
+        can still fold its own history back from a peer, because the receipts
+        it wrote verify against the key it still holds.
+        """
+        client = self._mesh_client(tmp_path)
+        coordinator = client.app.state.mesh_coordinator  # type: ignore[attr-defined]
+
+        forger = _peer(tmp_path, node_id=coordinator.node_id, seed=11, label="forger")
+        forger.claim(tracker="jira", ticket_id="T-1", role="backend", claimer_id="w", now=1000.0)
+        body = self._push(client, forger.journal.read())
+        assert body["results"][0]["status"] == "rejected"  # type: ignore[index]
+
+        # This node's own receipt, gossiped back to it, is a duplicate -- it
+        # verifies against the self-pin rather than being refused as unknown.
+        local = coordinator.claim(tracker="jira", ticket_id="T-2", role="qa", claimer_id="w", now=1000.0)
+        assert local.granted is True
+        echoed = self._push(client, coordinator.journal.read())
+        assert [r["status"] for r in echoed["results"]] == ["duplicate"]  # type: ignore[index,union-attr]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #2997

## What was wrong

MESH gossip verified that a claim receipt was internally sound — Ed25519
signature and chain link both check out before folding — and the route sat
behind `_verify_cluster_auth` with `SCOPE_NODE_HEARTBEAT`. Neither of those
binds the `node_id` a receipt declares to the key that signed it.

`MeshCoordinator` already accepted a `trusted_keys` map and
`tracker_pipeline.ingest` already enforced it, but no config key existed and no
production construction path supplied one — so the pinning branch never
executed. Any holder of a valid cluster token could gossip receipts naming any
node, and the journal, which is the arbiter the whole leaderless topology rests
on, recorded a well-formed claim attributed to a node that never issued it.

## What changed

- **`cluster.gossip_peer_keys`** — a new MESH config key mapping `node_id` to
  the Ed25519 public key that must have signed that node's receipts. Accepted
  as SPKI PEM, an OKP JWK mapping, or the bare base64url `x`; all normalise to
  one pin. Validated at seed load and rejected under a non-MESH topology,
  exactly as `gossip_peers` / `claim_journal_path` already are.
- **The pin is checkable, not declared.** A MESH `node_id` *is* the RFC 7638
  thumbprint of the node's claim-signing key, so the seed loader recomputes the
  thumbprint of every pinned key and refuses to load when it does not reproduce
  the id it is filed under. Filing peer B's key under peer A's id — the mistake
  that would silently accept B's receipts as A's — cannot survive a boot.
- **Wiring.** `build_mesh_coordinator` now always constructs the coordinator
  with a pin map instead of `None`, so both production callers (`server_app`
  and `start_cluster_coordinator`) get it. The env-override `ClusterConfig`
  branch in the orchestrator carries the pins through, so
  `BERNSTEIN_CLUSTER_ENABLED=1` no longer silently drops them.
- **Self-pinning.** Every node pins its own key to its own `node_id`. A peer
  cannot gossip receipts forged in this node's name, and a node that lost its
  journal can still fold its own history back from a peer.
- `public_key_jwk_from_pem` added beside `install_identity_keyid` — the
  thumbprint answers "what is this key's identity", this answers "what key does
  that identity have". A pinning verifier needs both halves.

## The default, and why

**Pinning is required. A MESH node folds only receipts signed by a pinned key.**

An absent map used to mean "no pinning", which made the safe posture the one an
operator had to remember to configure. This is the identity boundary of a
leaderless cluster — the journal has no central arbiter to fall back on — so the
default is now closed:

| Config | Result |
|---|---|
| No `gossip_peers`, no `gossip_peer_keys` | Single-node MESH. Self-claims work, inbound gossip is rejected, logged at startup. |
| `gossip_peers` set, `gossip_peer_keys` empty | **Seed load fails.** Outbound gossip with nothing folded back is a one-way partition that looks healthy. |
| Pin whose thumbprint ≠ its `node_id` | **Seed load fails**, naming the identity the key actually has. |
| Both set and consistent | Pinned peers fold; everything else is rejected with `no trusted key pinned for node …`. |

There is no opt-out flag. An escape hatch here would reintroduce exactly the
posture the issue is about, and the seed-load error names the missing key, so
the migration is mechanical rather than a debugging exercise.

**This is a behaviour change for an existing MESH fleet.** Gossip previously
accepted under whatever key a receipt carried is now rejected until the peer is
pinned. `docs/cluster/deployment-patterns.md` carries the upgrade note: add
`gossip_peer_keys` on every node before rolling out. Pinning is symmetric — A
must pin B and B must pin A. Rotating a claim-signing identity changes the
`node_id`, so a rotation is an explicit config change on every peer rather than
a silent re-trust.

## Tests

The mismatched-key case runs through the **real gossip route**
(`POST /cluster/claims/gossip`, coordinator built by `create_app` from config),
not by calling the coordinator directly — the defect was the missing wiring, so
a test that bypasses it proves nothing. Reverting only
`trusted_keys=trusted_keys` in `build_mesh_coordinator` fails all four new route
tests, which is the check that they exercise the wiring rather than the
coordinator's internals.

New, in `tests/unit/test_cluster_claims_surface.py`:

- A receipt that is correctly chained, correctly hashed and validly signed — but
  by a key that is not the one pinned for the `node_id` it declares — is
  rejected, with the journal left empty. The genuine holder of that identity is
  then accepted through the same route, so the rejection is the pin working
  rather than gossip being broken.
- A pinned peer cannot sign for another pinned peer's `node_id`.
- A node with no pins folds nothing (`no trusted key pinned`).
- Receipts forged in this node's name are rejected; its own receipts gossiped
  back are a `duplicate`, not a refusal.

New, in `tests/unit/orchestration/test_mesh_coordinator.py`: all three pin forms
normalise identically; `gossip_peers` without keys fails at seed load; pins
under a non-MESH topology fail; a pin whose thumbprint disagrees with its id
fails; malformed material fails; and `build_mesh_coordinator` always yields a
pin map containing the node's own key.

Targeted runs, all passing:

| File | Tests |
|---|---|
| `tests/unit/orchestration/test_mesh_coordinator.py` | 27 |
| `tests/unit/test_cluster_claims_surface.py` | 20 |
| `tests/unit/orchestration/test_tracker_pipeline.py` | 38 |
| `tests/unit/orchestration/test_claim_journal.py` | 19 |
| `tests/unit/test_seed.py` | 98 |
| `tests/unit/test_config_schema.py` | 78 |
| `tests/unit/test_cluster.py` | 18 |
| `tests/unit/test_cluster_auth.py` | 19 |
| `tests/unit/test_cluster_audit_log.py` | 8 |
| `tests/unit/test_task_claim_receipt_route.py` | 7 |
| **Total** | **332 passed** |

Plus `test_config_fuzz.py`, `test_config_diff.py`, `test_config_provenance.py`,
`test_cluster_worker_join_auth.py` — 47 passed.

`uv run ruff check .` and `uv run ruff format --check .` are clean. `mypy` on
the touched files reports only pre-existing errors in `seed_parser.py`, none in
the added ranges.

## Docs

`docs/cluster/deployment-patterns.md` — the MESH config block gains
`gossip_peer_keys`, and a new "Peer identity: pinning is required, not optional"
section states the default, the table above, how to read a peer's id and key off
its install, and the upgrade note. (The issue named
`docs/operations/deployment-patterns.md`; that file does not exist — the MESH
deployment document is the one under `docs/cluster/`.)

## Summary by Sourcery

Require pinned peer keys for MESH gossip so receipts are only folded when signed by a trusted node identity, and wire this pinning through configuration, seed parsing, coordinator construction, and documentation.

New Features:
- Introduce MeshPeerKey model and cluster.gossip_peer_keys configuration for mapping node_ids to their Ed25519 public keys.
- Add support for building a MeshCoordinator with a non-null trusted key map that includes both configured peers and the node’s own key.
- Provide public_key_jwk_from_pem helper to expose Ed25519 SPKI PEM keys as RFC 8037 OKP JWKs.

Enhancements:
- Change MESH coordinator default posture to fail-closed, rejecting all foreign gossip unless peers are explicitly pinned.
- Extend seed parser and config schema to validate gossip_peer_keys, enforce MESH-only usage, and ensure node_id/thumbprint consistency.
- Ensure env-based ClusterConfig overrides carry gossip_peer_keys through orchestrator wiring so pins are not silently dropped.
- Update cluster deployment documentation to describe required peer key pinning, supported key formats, and upgrade guidance for existing MESH fleets.

Tests:
- Add route-level tests for gossip behavior with pinned peers, missing pins, cross-identity signing, and self-pinning semantics.
- Add seed parser and coordinator tests covering accepted pin formats, invalid configurations, malformed key material, and mandatory pin map construction.