### PR TITLE
fix(tests): realign completion-seam assertions and de-platform the glob test

### DIFF
--- a/tests/unit/adapters/test_openai_agents_builtins.py
+++ b/tests/unit/adapters/test_openai_agents_builtins.py
@@ -23,6 +23,8 @@ These cover the hard conditions the builtins must satisfy:
 
 from __future__ import annotations
 
+import os
+import sys
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -136,12 +138,32 @@ class TestRunCommandNoShell:
         stdout = out.split("stdout:\n", 1)[1].split("\nstderr:", 1)[0]
         assert stdout == payload
 
-    def test_no_shell_expansion_of_glob(self, tmp_path: Path) -> None:
+    def test_no_shell_expansion_of_glob(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         (tmp_path / "one.txt").write_text("")
         (tmp_path / "two.txt").write_text("")
         _events, emit = _sink()
-        # A shell would expand ``*.txt``; argv passes it literally.
-        out = run_command_in_workdir(tmp_path, ["printf", "%s", "*.txt"], emit=emit)
+
+        # Echo argv[1] back from the running interpreter rather than from a
+        # coreutils helper. On Windows the ``printf`` that resolves on PATH is
+        # the MSYS2 build Git for Windows ships, and the MSYS runtime
+        # glob-expands argv itself before ``main()`` when the parent is not an
+        # MSYS process - so a literal ``*.txt`` arrives already split into
+        # ``one.txt two.txt`` with no shell anywhere in the chain, and the
+        # assertion measured the helper instead of this function. CPython never
+        # globs argv on any platform, so the shell=False contract is what is
+        # under test here.
+        #
+        # ``argv[0]`` must be a bare name (resolve_command rejects absolute
+        # paths and path separators), and the interpreter's own directory is
+        # not necessarily on PATH - pytest is invoked as
+        # ``sys.executable -m pytest``, which does not activate the venv. Put
+        # it on PATH so the bare name resolves deterministically everywhere.
+        monkeypatch.setenv("PATH", os.path.dirname(sys.executable) + os.pathsep + os.environ.get("PATH", ""))
+        out = run_command_in_workdir(
+            tmp_path,
+            [os.path.basename(sys.executable), "-c", "import sys; sys.stdout.write(sys.argv[1])", "*.txt"],
+            emit=emit,
+        )
         stdout = out.split("stdout:\n", 1)[1].split("\nstderr:", 1)[0]
         assert stdout == "*.txt"
 

--- a/tests/unit/test_janitor_alive_exit.py
+++ b/tests/unit/test_janitor_alive_exit.py
@@ -97,15 +97,19 @@ def test_enqueue_alive_exit_janitor_logs_and_submits(
         future = _enqueue_alive_exit_janitor_pass(orch, task, reason="alive_exit_tick")
 
     assert future is not None, "janitor future must be returned for tasks with completion_signals"
-    # Executor got a verify_task or run_janitor submission.
+    # Executor got a completion-verification or run_janitor submission.
     assert len(executor.submitted) == 1
     fn, args, _ = executor.submitted[0]
-    # Either verify_task (sync) or _verify_via_janitor (async) is acceptable.
-    from bernstein.core.janitor import verify_task
+    # Either verify_task_completion (sync) or _verify_via_janitor (async) is
+    # acceptable. #2990 moved the dispatch seam from ``verify_task`` to
+    # ``verify_task_completion`` so an artifact-mode task resolves to the
+    # signed-receipt path; a code_diff task still reaches ``verify_task``
+    # beneath it.
+    from bernstein.core.tasks.artifact_completion import verify_task_completion
 
-    assert fn in (verify_task, task_lifecycle._verify_via_janitor)
-    if fn is verify_task:
-        # verify_task(task, workdir)
+    assert fn in (verify_task_completion, task_lifecycle._verify_via_janitor)
+    if fn is verify_task_completion:
+        # verify_task_completion(task, workdir)
         assert args[0] is task
     else:
         # _verify_via_janitor(task, workdir, server_url)
@@ -292,15 +296,20 @@ def test_process_single_completed_task_logs_alive_exit_start(
 
 
 def test_dead_path_janitor_pass_unchanged() -> None:
-    """Sanity: the dead-exit ``verify_task`` call site is untouched.
+    """Sanity: the dead-exit verification call site stays synchronous.
 
-    Regresses the safe carve-out: item 30 must NOT modify
-    ``handle_orphaned_task`` (read-only territory).
+    Regresses the safe carve-out: item 30 must NOT make
+    ``handle_orphaned_task`` enqueue its pass instead of running it inline.
+
+    The callee name tracks the dispatch seam: #2990 swapped ``verify_task``
+    for ``verify_task_completion`` on both exit paths so an artifact-mode task
+    completes on its signed receipt. What this test guards is the *inline*
+    call, not which function is inlined.
     """
     import inspect
 
     from bernstein.core.agents import agent_lifecycle
 
     src = inspect.getsource(agent_lifecycle.handle_orphaned_task)
-    # The synchronous verify_task call must still be present.
-    assert "passed, failed_signals = verify_task(task, orch._workdir)" in src
+    # The synchronous completion-verification call must still be present.
+    assert "passed, failed_signals = verify_task_completion(task, orch._workdir)" in src

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -4996,13 +4996,13 @@ class TestCheckEvolve:
 
 
 class TestParallelVerification:
-    """verify_task() calls for multiple done tasks run concurrently."""
+    """verify_task_completion() calls for multiple done tasks run concurrently."""
 
     def test_multiple_done_tasks_verified_concurrently(self, tmp_path: Path) -> None:
         """Multiple done tasks with signals are verified in parallel.
 
-        Mocks verify_task with a 0.2s sleep. With 4 tasks running serially
-        this would take ~0.8s; in parallel it should finish in ~0.2s.
+        Mocks verify_task_completion with a 0.2s sleep. With 4 tasks running
+        serially this would take ~0.8s; in parallel it should finish in ~0.2s.
         """
         import threading
         from unittest.mock import patch
@@ -5033,7 +5033,12 @@ class TestParallelVerification:
         )
         orch = _build_orchestrator(tmp_path, transport)
 
-        with patch("bernstein.core.tasks.task_lifecycle.verify_task", side_effect=slow_verify):
+        # Patch the symbol the janitor enqueue actually submits to the pool.
+        # #2990 moved the completion dispatch seam from ``verify_task`` to
+        # ``verify_task_completion`` so an artifact-mode task resolves to the
+        # receipt path; a code_diff task still reaches ``verify_task`` beneath
+        # it. Patching the retired name binds nothing.
+        with patch("bernstein.core.tasks.task_lifecycle.verify_task_completion", side_effect=slow_verify):
             t_start = time.time()
             result = TickResult()
             orch._process_completed_tasks(tasks_with_signals, result)
@@ -5053,14 +5058,14 @@ class TestParallelVerification:
 
 
 class TestProcessCompletedTasksParallel:
-    """_process_completed_tasks runs verify_task() concurrently."""
+    """_process_completed_tasks runs verify_task_completion() concurrently."""
 
     def test_multiple_done_tasks_verified_concurrently(self, tmp_path: Path) -> None:
-        """verify_task() for N done tasks must run in parallel, not serially.
+        """Verification for N done tasks must run in parallel, not serially.
 
-        We mock verify_task to sleep 0.2 s per task.  With 4 tasks the serial
-        total would be >= 0.8 s; the parallel total (max_workers=4) should be
-        well under 0.5 s.
+        We mock verify_task_completion to sleep 0.2 s per task.  With 4 tasks
+        the serial total would be >= 0.8 s; the parallel total (max_workers=4)
+        should be well under 0.5 s.
         """
         import time
         from unittest.mock import patch
@@ -5103,7 +5108,9 @@ class TestProcessCompletedTasksParallel:
                 intervals.append((begin, time.monotonic()))
             return True, []
 
-        with patch("bernstein.core.tasks.task_lifecycle.verify_task", side_effect=slow_verify):
+        # See the sibling test: the dispatch seam is ``verify_task_completion``
+        # since #2990.
+        with patch("bernstein.core.tasks.task_lifecycle.verify_task_completion", side_effect=slow_verify):
             tick_result = TickResult()
             orch._process_completed_tasks([Task.from_dict(d) for d in task_dicts], tick_result)
 

--- a/tests/unit/test_task_lifecycle.py
+++ b/tests/unit/test_task_lifecycle.py
@@ -791,10 +791,12 @@ def test_process_completed_tasks_dispatches_llm_judge_to_run_janitor(
 
     dispatched = {args[0].id: fn for fn, args, _ in submitted}
     assert dispatched["T-judge"] is _verify_via_janitor
-    # Non-judge tasks keep the sync verify_task fast path.
-    from bernstein.core.janitor import verify_task as _expected_verify_task
+    # Non-judge tasks keep the sync fast path. Since #2990 that seam is
+    # ``verify_task_completion``, which dispatches on the task's artifact kind
+    # and resolves a code_diff task to ``verify_task`` unchanged.
+    from bernstein.core.tasks.artifact_completion import verify_task_completion as _expected_sync_verify
 
-    assert dispatched["T-sync"] is _expected_verify_task
+    assert dispatched["T-sync"] is _expected_sync_verify
 
 
 def test_verify_via_janitor_runs_run_janitor_for_llm_judge(


### PR DESCRIPTION
## TL;DR

`main` is red on the sharded pytest jobs for two unrelated reasons. Neither is a
production defect: the shipped behaviour is correct in both cases, and the
assertions describing it went stale. Test-only change.

The three failure families most visible in triage (`Unknown adapter`,
`seal_write` `ImportError`, starving-role `assert 0 == 1`) are **already fixed
on `main`** by #2989 and are not touched here. Details at the bottom.

## 1. The completion dispatch seam moved (5 failures)

#2990 replaced `verify_task` with `verify_task_completion` at both the
alive-exit (`task_lifecycle`) and dead-exit (`agent_lifecycle`) completion
paths, so an artifact-mode task completes on its signed receipt while a
`code_diff` task still resolves to `verify_task` beneath it. That is the
intended behaviour. Five assertions still named the retired symbol:

| Test | Symptom |
| --- | --- |
| `test_orchestrator.py::TestParallelVerification` | `AttributeError`: module has no attribute `verify_task` |
| `test_orchestrator.py::TestProcessCompletedTasksParallel` | same |
| `test_janitor_alive_exit.py::test_enqueue_alive_exit_janitor_logs_and_submits` | submitted callable is `verify_task_completion` |
| `test_janitor_alive_exit.py::test_dead_path_janitor_pass_unchanged` | source-string assertion names the old inlined callee |
| `test_task_lifecycle.py::test_process_completed_tasks_dispatches_llm_judge_to_run_janitor` | `dispatched["T-sync"] is verify_task` |

The two `mock.patch` call sites were the load-bearing ones. Patching a name the
module no longer binds raises rather than intercepting, so the concurrency
property those tests exist to prove was not being measured at all. Both now
patch the symbol the executor actually receives, and both still assert the mock
ran (`len(intervals) == N`, `len(call_times) == 4`), so the parallelism signal
is real rather than vacuous.

`test_dead_path_janitor_pass_unchanged` guards that the dead-exit path runs its
pass *inline* rather than enqueueing it. That property is intact; only the
callee it names changed, so the expected source string tracks it and the
docstring now says which property is under guard.

## 2. The glob test measured its helper, not the code (Windows shard)

`test_no_shell_expansion_of_glob` asserted that an argv-list call passes `*.txt`
literally, using `printf` as the echo helper. On Windows the `printf` that
resolves on PATH is the MSYS2 build Git for Windows ships, and the MSYS runtime
glob-expands argv itself before `main()` when the parent is not an MSYS process.
So `*.txt` arrived already split into `one.txt two.txt`, with no shell anywhere
in the chain:

```
assert 'one.txttwo.txt' == '*.txt'
```

The `shell=False` contract under test was never violated. The assertion was
reading the helper's own behaviour, so it could only ever have passed on
platforms whose `printf` does not self-glob.

It now echoes `argv[1]` back from the running interpreter, which never globs
argv on any platform. Two constraints shaped the call: `argv[0]` must be a bare
name (`resolve_command` rejects absolute paths and path separators), and
`sys.executable -m pytest` does not activate the venv, so the interpreter's own
directory is not necessarily on PATH. The test puts it there for the call.

The test stays sensitive to the regression it was written for. Driving the same
command through the shell-string form yields `one.txt` and fails the assertion,
so a list-form call that grew a shell would still be caught:

```
argv-list (shell=False) -> '*.txt'      # passes
shell-string (bash -lc) -> 'one.txt'    # fails, as it must
```

## Already fixed on `main`, not touched here

| Family | Origin | Resolved by |
| --- | --- | --- |
| `ValueError: Unknown adapter '<name>'` | #2985 admission preflight re-resolved the adapter by name | #2989 |
| `ImportError: cannot import name 'seal_write'` | #2982 moved it out of the deprecated v1 recorder | #2989 |
| Starving-role `assert 0 == 1` | same #2985 preflight: the `ValueError` was swallowed by the spawn loop, leaving `result.spawned` empty | #2989 |

All three pass at `5519aab40`. The run they were observed in has head
`ede406361`, which predates #2989.

## Triage note for next time

`scripts/run_tests.py` passes `-x` to each per-file pytest subprocess, so only
the **first** failure in a file is ever reported. The starving-role failure at
`test_orchestrator.py:552` masked the `verify_task` failures at line 5036 in the
same file, which is why fixing the first surfaced a second, previously invisible
break in the same file.

## Verification

Test-only change, so no docs update is due per the documentation duty in
`CLAUDE.md`.

```
ruff check      All checks passed
ruff format     4 files already formatted
```

| Suite | Result |
| --- | --- |
| `test_orchestrator.py` | 226 passed (was 224 passed, 2 failed) |
| `test_janitor_alive_exit.py` | 6 passed (was 4 passed, 2 failed) |
| `test_task_lifecycle.py` | 45 passed (was 44 passed, 1 failed) |
| `adapters/test_openai_agents_builtins.py` | 61 passed |
| `test_janitor*.py`, `test_agent_lifecycle.py`, `test_batch_api.py` | 161 passed |
| `tests/unit/tasks/` | 17 files passed |
| `tests/unit/lineage/` | 21 files passed |
| `tests/unit/orchestration/` | 21 files passed |
| `tests/integration/test_capability_matrix_spawn_refusal.py` | 17 passed |
| `tests/unit/test_idle_agent_detection.py`, `test_manager_write_boundary.py`, `test_mcp_config.py`, `test_mcp_registry.py`, `test_oauth_refresh.py`, `test_spawner_openclaw_bridge.py` | 90 passed |

A full `scripts/run_tests.py --test-dir tests/unit` sweep (2015 files, isolated
per-file subprocesses) is running; results will be posted as a follow-up
comment.

## Summary by Sourcery

Align test expectations with the new task completion dispatch seam and fix a platform-specific glob-handling assertion so the sharded pytest suites pass again.

Tests:
- Update janitor, orchestrator, and task lifecycle tests to assert against verify_task_completion as the primary completion dispatch entry point while preserving concurrency guarantees and synchronous dead-path behavior.
- Adjust the OpenAI agents glob test to echo arguments via the Python interpreter and ensure shell=False list invocations pass globs literally across platforms, including Windows.