### PR TITLE
feat(lineage): per-artifact health, attribution and production events

### DIFF
--- a/docs/lineage.md
+++ b/docs/lineage.md
@@ -242,7 +242,7 @@ Entries signed under `k-2025-01` continue to verify against the retained card; n
 
 ## See also
 
-- [Artifact keys](lineage/artifacts.md) - the URI grammar, external-artifact anchoring, and declared outputs.
+- [Artifact keys](lineage/artifacts.md) - the URI grammar, external-artifact anchoring, declared outputs, the `artifact list|log|health` surfaces, and production events.
 - [ADR-009: Lineage v1](decisions/009-lineage-v1.md) - design rationale, schema, threat model.
 - [Compliance - EU AI Act Article 12 bundle](compliance/eu-ai-act-article-12-bundle.md) - the bundle format detail.
 - [Regulatory lineage export](compliance/lineage-export.md) - operator export guide.

--- a/docs/lineage/artifacts.md
+++ b/docs/lineage/artifacts.md
@@ -17,6 +17,9 @@ default) or a canonical URI from a **closed** scheme set.
 | Do old records still work? | Yes. A bare path is the canonical form of the implicit `repo` scheme; nothing is migrated or rewritten. |
 | Case sensitivity? | Scheme and authority fold to lowercase; path segments keep their case. |
 | Who validates? | `bernstein.core.lineage.artifact_uri`, used by both lineage write boundaries. |
+| How do I inspect one? | `bernstein artifact list` / `log <uri>` / `health <uri>`. |
+| Can the dashboard disagree with the CLI? | No. Both call one function and one serialiser; same state and instant give byte-identical JSON. |
+| Does a write announce itself? | Yes. Every spine entry emits exactly one `artifact.produced` event, with no per-adapter opt-in. |
 
 ## The grammar
 
@@ -111,6 +114,104 @@ and swallowed, never allowed to fail a task that already completed. A bundle for
 a task that declares no outputs carries no diff at all and canonicalises
 byte-for-byte identically to a pre-feature bundle, so every signature and anchor
 already on disk stays valid.
+
+## Inspecting an artifact
+
+Three commands answer the questions that used to mean correlating four surfaces
+by hand. All three read local `.sdd` state and need no network.
+
+```bash
+bernstein artifact list                       # every key the local spines carry
+bernstein artifact log  pkg://pypi/bernstein/3.9.0
+bernstein artifact health pkg://pypi/bernstein/3.9.0
+```
+
+`log` is the attribution surface: newest production first, each record naming
+the producing agent identity, the model it ran, the run and step it came from,
+and the spine entry hash that proves it. `verified` is recomputed per entry, so
+a tampered row is *named* rather than averaged into a summary.
+
+`health` rolls the picture up into one verdict:
+
+| Leg | Passes when |
+|---|---|
+| `produced` | At least one spine entry records the key. |
+| `chain_integrity` | Every entry carrying the key recomputes its hash and HMAC tag, and the chains they sit in verify. |
+| `single_open_tip` | Exactly one set of bytes claims to be current. |
+| `evidence` | The newest sealed evidence bundle that declares the key verifies. |
+| `cadence` | The last production is inside the declared refresh cadence. |
+
+| Verdict | Meaning |
+|---|---|
+| `green` | Every applicable leg passes. |
+| `amber` | Nothing is broken, the artifact is just out of date. |
+| `red` | An integrity or currency failure. Exit code 2. |
+
+A leg with nothing to say reports `not_applicable` and cannot hold the verdict
+down. An artifact with no declared cadence is not "failing cadence", and one no
+bundle references is not "failing evidence" - absence of a signal is never
+reported as a negative signal.
+
+### Reproducing a verdict
+
+The verdict is a pure function of the collected state and the evaluation
+instant, and the instant is an explicit argument on both surfaces:
+
+```bash
+bernstein artifact health pkg://pypi/bernstein/3.9.0 --at 1750000000 --output-json
+curl 'http://localhost:8000/artifacts/health?uri=pkg://pypi/bernstein/3.9.0&at=1750000000'
+```
+
+Those two produce **byte-identical** bytes, because they are two callers of
+`artifact_health_json` and it is the only place a verdict is serialised. Pin a
+verdict from the dashboard, recompute it offline, compare with `diff`.
+
+## Production events
+
+Every artifact write that lands in the spine emits exactly one
+`artifact.produced` event, journaled at `.sdd/lineage/<run_id>/artifact-events.jsonl`
+beside the spine it projects from, and mirrored onto the SSE bus when a server
+is attached. The emission point is the single lineage write boundary, so there
+is no per-adapter opt-in to forget.
+
+The event is a **pure projection of one spine entry**:
+
+```json
+{"actor":"agent-release","content_hash":"sha256:…","entry_hash":"sha256:…","model":"claude-opus-5","run_id":"run-7","step_id":"publish","timestamp":1750000000,"uri":"pkg://pypi/bernstein/3.9.0","v":1,"verified":true}
+```
+
+That purity is what makes the fan-out replayable. Re-deriving the events from
+the spine reproduces the identical set, and comparing the two reports any
+difference as a divergence naming the offending `entry_hash`:
+
+| Divergence | Meaning |
+|---|---|
+| `dropped` | The spine implies a firing the journal never recorded. |
+| `duplicated` | The journal fired one entry more than once. |
+| `unexpected` | The journal carries a firing with no matching spine entry. |
+| `altered` | Same entry, different payload - a tampered spine row or an edited journal. |
+
+A byte flip anywhere in a spine row makes that artifact's event replay as
+`verified: false` while the journaled row still claims `true`; the disagreement
+surfaces as an `altered` divergence and the artifact's health verdict turns red.
+
+Emission is deliberately **fail-open**. Recording into the spine is fail-closed
+because provenance is a hard requirement; the event is a notification, and a
+full disk or a dead subscriber must never turn a successful artifact write into
+a failed one. Anything a failed emit dropped is rebuilt by replaying the spine.
+
+## Reacting to an artifact
+
+`bernstein.core.trigger_sources.artifact` normalises production events into the
+same `TriggerEvent` every other source emits, so artifact rules go through the
+existing rule matching with no second engine. The key rides in `changed_files`
+(path-shaped filters see it unchanged) and the full projected payload rides in
+`raw_payload`.
+
+URI patterns select what fires - `pkg://pypi/bernstein/*` covers every version
+of one package. An entry whose integrity verdict is false does **not** fire by
+default: a firing caused by a tampered record is worse than a firing that never
+happened.
 
 ## Compatibility
 

--- a/docs/operations/artifacts.md
+++ b/docs/operations/artifacts.md
@@ -141,6 +141,13 @@ filesystem it will hold the task open rather than pass silently.
 bernstein artifact verify <task_id> [--workdir .] [--output-json]
 ```
 
+This command is **task-keyed**: it proves one task's receipt. To ask the same
+kind of question about an *output* rather than a task - who produced the current
+tip of a package or a release PR, and is it good and current - use the
+URI-keyed commands documented in
+[Artifact keys](../lineage/artifacts.md#inspecting-an-artifact):
+`bernstein artifact list`, `artifact log <uri>`, `artifact health <uri>`.
+
 The command:
 
 1. Re-derives the canonical hash from the stored artifact bytes and confirms

--- a/src/bernstein/adapters/base.py
+++ b/src/bernstein/adapters/base.py
@@ -13,6 +13,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol
 
+from bernstein.core.lineage.artifact_events import emit_production_event
 from bernstein.core.lineage.spine import LineageSpine
 from bernstein.core.platform_compat import (
     kill_process_group,
@@ -26,6 +27,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from bernstein.core.config.platform_compat import ProcessReapReceipt
+    from bernstein.core.lineage.artifact_events import ArtifactProductionEvent
     from bernstein.core.lineage.identity import AgentCard
     from bernstein.core.models import AbortReason, ApiTierInfo, ModelConfig
 
@@ -1070,6 +1072,24 @@ def _filter_lineage_baggage(baggage: str | None) -> str | None:
     return ",".join(kept) if kept else None
 
 
+#: Process-wide sink for ``artifact.produced`` events (issue #2559). Left
+#: ``None`` in a plain CLI run: the event is still journaled beside the spine,
+#: so the fan-out stays replayable with no server attached. The task server
+#: installs a publisher at startup to mirror events onto the SSE bus.
+_ARTIFACT_EVENT_PUBLISHER: Callable[[ArtifactProductionEvent], None] | None = None
+
+
+def set_artifact_event_publisher(publisher: Callable[[ArtifactProductionEvent], None] | None) -> None:
+    """Install (or clear) the live sink for artifact production events.
+
+    The publisher is best-effort and its exceptions are swallowed at the write
+    boundary: a subscriber that cannot keep up must not fail the artifact write
+    that fed it.
+    """
+    global _ARTIFACT_EVENT_PUBLISHER  # one process-wide sink, by design
+    _ARTIFACT_EVENT_PUBLISHER = publisher
+
+
 def _lineage_enabled() -> bool:
     """Return whether the lineage spine write boundary is active.
 
@@ -1146,7 +1166,7 @@ def record_artifact_write(
         traceparent = None
         tracestate = None
 
-    return LineageSpine(lineage_root, run_id=run_id, hmac_key=hmac_key).record(
+    entry = LineageSpine(lineage_root, run_id=run_id, hmac_key=hmac_key).record_entry(
         artifact_path=artifact_path,
         content=content,
         actor=actor,
@@ -1157,6 +1177,20 @@ def record_artifact_write(
         tracestate=tracestate,
         baggage=baggage,
     )
+
+    # Issue #2559: exactly one production event per spine entry, emitted from
+    # the same boundary the entry was written at, so there is no per-adapter
+    # opt-in to forget and no path that records provenance without announcing
+    # it. Fail-open by construction (see ``emit_production_event``): the entry
+    # above is already durable, and the event set is re-derivable from it, so a
+    # journal or bus failure must not undo a successful write.
+    emit_production_event(
+        lineage_root,
+        run_id=run_id,
+        entry=entry,
+        publish=_ARTIFACT_EVENT_PUBLISHER,
+    )
+    return entry.entry_hash
 
 
 def post_write_lineage_hook(

--- a/src/bernstein/cli/commands/artifact_cmd.py
+++ b/src/bernstein/cli/commands/artifact_cmd.py
@@ -1,14 +1,27 @@
-"""``bernstein artifact verify``: prove a non-coding artifact (issue #2608).
+"""``bernstein artifact``: verify, inspect and score outputs by artifact key.
 
-A non-coding task's output (report / dataset / action log / ops result) is
-recorded as a signed, content-addressed lineage entry. ``artifact verify``
-re-derives the canonical hash from the stored bytes, ties it to the signed
-entry, and runs the lineage gate (Ed25519 signature + operator HMAC chain +
-parent integrity). It fails - non-zero exit - on any post-hoc byte alteration
-of the artifact or a removed lineage entry, so "the agent produced this exact
-artifact" is a cryptographic check, not a trust exercise.
+Two commands answer a *task* question:
 
     bernstein artifact verify <task_id>
+
+re-derives a non-coding task's canonical artifact hash from the stored bytes,
+ties it to the signed entry, and runs the lineage gate (Ed25519 signature +
+operator HMAC chain + parent integrity), so "the agent produced this exact
+artifact" is a cryptographic check rather than a trust exercise (issue #2608).
+
+The rest answer an *artifact* question, keyed by canonical artifact URI rather
+than by the task that happened to produce it (issue #2559)::
+
+    bernstein artifact list
+    bernstein artifact log <uri>
+    bernstein artifact health <uri>
+
+``log`` is the attribution surface: which agent identity, running which model,
+produced the current tip of this PR / package / deployment, read off the chain.
+``health`` is the rolled-up verdict -- chain integrity, a single current set of
+bytes, evidence, cadence -- recomputed offline from ``.sdd`` state alone. Its
+``--json`` output is produced by the same function the server route calls, so
+the CLI and the dashboard cannot disagree about an artifact.
 
 This is the singular ``artifact`` group; the plural ``artifacts`` group lists
 agent-posted, journal-anchored task artifacts (issue #2553) and is unrelated.
@@ -23,13 +36,20 @@ import click
 
 from bernstein.cli.helpers import console
 
+#: Exit code for a red / unverifiable verdict. Matches ``artifact verify`` so a
+#: script can treat any non-zero from this group as "do not trust this output".
+_EXIT_BAD = 2
+
 
 @click.group("artifact")
 def artifact_group() -> None:
-    """Verify a task's signed, content-addressed artifact.
+    """Verify, inspect and score outputs by artifact key.
 
     \b
       bernstein artifact verify <task_id>
+      bernstein artifact list
+      bernstein artifact log <uri>
+      bernstein artifact health <uri>
     """
 
 
@@ -90,6 +110,152 @@ def artifact_verify_cmd(task_id: str, workdir: Path, operator_secret_env: str, o
 
     if not result.ok:
         sys.exit(2)
+
+
+_workdir_option = click.option(
+    "--workdir",
+    "-w",
+    type=click.Path(file_okay=False, exists=True, path_type=Path),
+    default=".",
+    show_default=True,
+    help="Project root containing .sdd/.",
+)
+
+
+def _spine_hmac_key() -> bytes:
+    """Return the audit-chain key the lineage spine tags entries with."""
+    from bernstein.core.security.audit import load_or_create_audit_key
+
+    return load_or_create_audit_key()
+
+
+@artifact_group.command("list")
+@_workdir_option
+@click.option("--output-json", is_flag=True, help="Emit JSON instead of human text.")
+def artifact_list_cmd(workdir: Path, output_json: bool) -> None:
+    """List every artifact key the local lineage spines carry."""
+    import json
+
+    from bernstein.core.lineage.artifact_health import list_artifact_keys
+
+    counts = list_artifact_keys(workdir.resolve())
+    ordered = sorted(counts.items())
+
+    if output_json:
+        click.echo(json.dumps({"artifacts": [{"productions": n, "uri": u} for u, n in ordered]}, sort_keys=True))
+        return
+    if not ordered:
+        console.print("[yellow]no artifacts recorded[/yellow]")
+        return
+    for uri, count in ordered:
+        console.print(f"  {count:>4}  {uri}")
+
+
+@artifact_group.command("log")
+@click.argument("uri")
+@_workdir_option
+@click.option("--limit", type=int, default=0, show_default=True, help="Max records (0 = all).")
+@click.option("--output-json", is_flag=True, help="Emit JSON instead of human text.")
+def artifact_log_cmd(uri: str, workdir: Path, limit: int, output_json: bool) -> None:
+    """Show who produced URI, newest first, with the entry hash that proves it.
+
+    The first record is the current tip: the agent identity and model behind the
+    bytes that are live right now. ``verified`` is recomputed per entry, so a
+    tampered row is named here instead of being averaged away.
+    """
+    from bernstein.core.lineage.artifact_health import artifact_log, artifact_log_json
+
+    records = artifact_log(workdir.resolve(), uri, hmac_key=_spine_hmac_key(), limit=limit)
+
+    if output_json:
+        click.echo(artifact_log_json(records, uri=uri))
+        return
+    if not records:
+        console.print(f"[yellow]no productions recorded for[/yellow] {uri}")
+        return
+    console.print(f"[bold]{uri}[/bold]")
+    for i, record in enumerate(records):
+        marker = "[green]OK[/green]" if record.verified else "[red]TAMPERED[/red]"
+        label = "tip" if i == 0 else "   "
+        console.print(f"  {label} {marker} {record.entry_hash}")
+        console.print(f"        actor={record.actor or '-'} model={record.model or '-'} run={record.run_id}")
+        console.print(f"        content={record.content_hash} step={record.step_id or '-'}")
+
+
+@artifact_group.command("health")
+@click.argument("uri")
+@_workdir_option
+@click.option(
+    "--at",
+    type=int,
+    default=None,
+    help="Evaluation instant, in the unit the spine timestamps use. Defaults to the wall clock. "
+    "Pin it to reproduce a verdict byte-for-byte.",
+)
+@click.option(
+    "--cadence-seconds",
+    type=int,
+    default=None,
+    help="Declared refresh cadence. Omit when the artifact declares none; the cadence leg then reports "
+    "not_applicable rather than failing.",
+)
+@click.option("--output-json", is_flag=True, help="Emit the canonical JSON verdict instead of human text.")
+def artifact_health_cmd(
+    uri: str,
+    workdir: Path,
+    at: int | None,
+    cadence_seconds: int | None,
+    output_json: bool,
+) -> None:
+    """Recompute URI's health verdict offline from local .sdd state.
+
+    Exit codes: 0 = green or amber, 2 = red.
+
+    The verdict is a pure function of the collected state and ``--at``, and the
+    ``--json`` bytes come from the same function the server route calls, so a
+    verdict recomputed here equals the one the dashboard shows for the same
+    state and instant.
+    """
+    import json
+    import sys
+    import time
+
+    from bernstein.core.lineage.artifact_health import RED, artifact_health_json
+
+    instant = at if at is not None else int(time.time())
+    payload = artifact_health_json(
+        workdir.resolve(),
+        uri,
+        hmac_key=_spine_hmac_key(),
+        at=instant,
+        cadence_seconds=cadence_seconds,
+    )
+
+    if output_json:
+        click.echo(payload)
+    else:
+        _render_health(json.loads(payload))
+
+    if json.loads(payload)["verdict"] == RED:
+        sys.exit(_EXIT_BAD)
+
+
+def _render_health(verdict: dict) -> None:
+    """Render a verdict document as human text."""
+    colour = {"green": "green", "amber": "yellow", "red": "red"}.get(str(verdict["verdict"]), "white")
+    console.print(f"[{colour}]{str(verdict['verdict']).upper()}[/{colour}] {verdict['uri']}")
+    tip = verdict.get("tip") or {}
+    if tip.get("entry_hash"):
+        console.print(f"  tip     {tip['entry_hash']}")
+        console.print(f"  actor   {tip.get('actor') or '-'}  model {tip.get('model') or '-'}")
+    for leg in verdict.get("legs", []):
+        status = str(leg["status"])
+        mark = {
+            "pass": "[green]pass[/green]",
+            "fail": "[red]fail[/red]",
+            "stale": "[yellow]stale[/yellow]",
+        }.get(status, f"[dim]{status}[/dim]")
+        console.print(f"  {mark:<24} {leg['name']}: {leg['detail']}")
 
 
 def _json_verdict(result: object) -> dict:

--- a/src/bernstein/cli/commands/artifact_cmd.py
+++ b/src/bernstein/cli/commands/artifact_cmd.py
@@ -211,10 +211,10 @@ def artifact_health_cmd(
 
     Exit codes: 0 = green or amber, 2 = red.
 
-    The verdict is a pure function of the collected state and ``--at``, and the
-    ``--json`` bytes come from the same function the server route calls, so a
-    verdict recomputed here equals the one the dashboard shows for the same
-    state and instant.
+    The verdict is a pure function of the collected state and the evaluation
+    instant, and the JSON comes from the same function the server route calls,
+    so a verdict recomputed here equals the one the dashboard shows for the
+    same state and instant.
     """
     import json
     import sys
@@ -230,13 +230,14 @@ def artifact_health_cmd(
         at=instant,
         cadence_seconds=cadence_seconds,
     )
+    verdict = json.loads(payload)
 
     if output_json:
         click.echo(payload)
     else:
-        _render_health(json.loads(payload))
+        _render_health(verdict)
 
-    if json.loads(payload)["verdict"] == RED:
+    if verdict["verdict"] == RED:
         sys.exit(_EXIT_BAD)
 
 

--- a/src/bernstein/core/lineage/artifact_events.py
+++ b/src/bernstein/core/lineage/artifact_events.py
@@ -1,0 +1,465 @@
+"""Artifact production events, journaled beside the spine (issue #2559).
+
+The spine records *that* an artifact write happened. Nothing downstream could
+see it: no event said "artifact X was produced", so a goal that depends on
+another goal's output either polled on a cron guess or was hand-wired as a run
+dependency. This module closes that gap at the one place every in-process
+artifact write already passes through --
+:func:`bernstein.adapters.base.record_artifact_write` -- so there is no
+per-adapter opt-in to forget.
+
+The event is a projection, not a report
+---------------------------------------
+
+:func:`project_production_event` is a **pure function of one spine entry**.
+Nothing else feeds it: no wall clock, no environment, no ambient state. That is
+the whole design, and it buys three things at once.
+
+* **Replayable fan-out.** Replaying a spine reproduces the identical intended
+  event set, entry for entry, hash for hash. A firing that was dropped,
+  duplicated or altered is a *detectable divergence naming the offending
+  entry hash* (:func:`compare_fanout`), not a mystery to reconstruct from logs.
+* **Tamper visibility.** The ``verified`` flag on a replayed event is the
+  per-entry integrity verdict recomputed from the entry itself
+  (:func:`bernstein.core.lineage.spine.verify_entry`). Flip one byte of a spine
+  row -- payload or HMAC tag -- and the event for that artifact replays as
+  ``verified: false`` while the row journaled at production time still says
+  ``true``. The disagreement is the finding.
+* **No trusted emitter.** A consumer never has to believe the journal. It
+  re-derives the event set from the spine and compares; the journal is a
+  convenience index, and the spine stays the only thing that has to be trusted.
+
+Fail-open at the boundary
+-------------------------
+
+Recording into the spine is fail-closed -- provenance is a hard requirement.
+Emitting the event is deliberately **fail-open**: a full disk, a read-only
+journal or a dead subscriber must never turn a successful artifact write into a
+failed one. The write is the fact; the event is the notification. See
+:func:`emit_production_event`, which never raises, and the projection above,
+which can rebuild anything a failed emit dropped.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.lineage.spine import (
+    JOURNAL_SEAL_STEP_PREFIX,
+    LineageSpine,
+    SpineEntry,
+    verify_entry,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "ARTIFACT_EVENTS_FILENAME",
+    "ARTIFACT_EVENT_VERSION",
+    "ARTIFACT_PRODUCED_EVENT",
+    "ArtifactProductionEvent",
+    "FanoutDivergence",
+    "append_production_event",
+    "compare_fanout",
+    "emit_production_event",
+    "load_production_events",
+    "observed_artifact_keys",
+    "project_production_event",
+    "project_production_events",
+    "replay_production_events",
+]
+
+#: Wire-format version stamped into every journaled event. ``load`` skips a row
+#: whose version it does not know rather than guessing at its shape.
+ARTIFACT_EVENT_VERSION = 1
+
+#: Typed event name on the SSE bus and in the journal.
+ARTIFACT_PRODUCED_EVENT = "artifact.produced"
+
+#: Journal file, written beside ``spine.jsonl`` inside the same per-run
+#: directory. Co-located on purpose: the events are meaningless without the
+#: spine they project from, so the two travel together in any run archive.
+ARTIFACT_EVENTS_FILENAME = "artifact-events.jsonl"
+
+#: Divergence kinds reported by :func:`compare_fanout`.
+DIVERGENCE_DROPPED = "dropped"
+DIVERGENCE_DUPLICATED = "duplicated"
+DIVERGENCE_UNEXPECTED = "unexpected"
+DIVERGENCE_ALTERED = "altered"
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactProductionEvent:
+    """One ``artifact.produced`` event.
+
+    Every field except :attr:`verified` is copied verbatim from the spine entry
+    it projects, so an event is comparable to a replayed one by value.
+    :attr:`verified` is the per-entry integrity verdict *at the time the event
+    was produced*: ``True`` at emission (the entry was just written and read
+    back through the same key), recomputed on replay.
+    """
+
+    uri: str
+    entry_hash: str
+    content_hash: str
+    actor: str
+    model: str
+    step_id: str
+    run_id: str
+    timestamp: int
+    verified: bool
+    v: int = ARTIFACT_EVENT_VERSION
+
+    @property
+    def is_journal_seal(self) -> bool:
+        """Whether this event records the run's own journal seal.
+
+        The seal is a spine entry like any other -- it is journaled and it
+        replays -- but it is the run recording *itself*, not a deliverable the
+        fleet produced. Consumers that answer "what did this run produce" filter
+        it out; the conformance property (one event per spine entry) does not,
+        because an exception at the boundary is exactly the opt-in gap this
+        module exists to close.
+        """
+        return self.step_id.startswith(JOURNAL_SEAL_STEP_PREFIX)
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return the canonical payload dict (the SSE ``data`` body)."""
+        return {
+            "actor": self.actor,
+            "content_hash": self.content_hash,
+            "entry_hash": self.entry_hash,
+            "model": self.model,
+            "run_id": self.run_id,
+            "step_id": self.step_id,
+            "timestamp": self.timestamp,
+            "uri": self.uri,
+            "v": self.v,
+            "verified": self.verified,
+        }
+
+    def canonical_bytes(self) -> bytes:
+        """Return the canonical JSON bytes of the event.
+
+        Sorted keys and minimal separators, so two hosts projecting the same
+        spine entry serialise byte-identical rows.
+        """
+        return json.dumps(
+            self.to_payload(),
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+
+    @classmethod
+    def from_payload(cls, row: dict[str, Any]) -> ArtifactProductionEvent:
+        """Rebuild an event from a journaled row.
+
+        Raises:
+            ValueError: When a required field is missing or mistyped, or the
+                row carries an unknown wire-format version.
+        """
+        version = int(row["v"])
+        if version != ARTIFACT_EVENT_VERSION:
+            msg = f"unsupported artifact event version {version!r}"
+            raise ValueError(msg)
+        return cls(
+            uri=str(row["uri"]),
+            entry_hash=str(row["entry_hash"]),
+            content_hash=str(row["content_hash"]),
+            actor=str(row["actor"]),
+            model=str(row["model"]),
+            step_id=str(row["step_id"]),
+            run_id=str(row["run_id"]),
+            timestamp=int(row["timestamp"]),
+            verified=bool(row["verified"]),
+            v=version,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Projection: spine entry -> event
+# ---------------------------------------------------------------------------
+
+
+def project_production_event(entry: SpineEntry, *, run_id: str, verified: bool) -> ArtifactProductionEvent:
+    """Project one spine entry onto its production event. Pure.
+
+    Args:
+        entry: The spine entry that was appended.
+        run_id: The run whose spine carries the entry.
+        verified: The per-entry integrity verdict to stamp on the event.
+
+    Returns:
+        The event. Two callers holding the same entry and the same verdict
+        derive byte-identical events.
+    """
+    return ArtifactProductionEvent(
+        uri=entry.artifact_path,
+        entry_hash=entry.entry_hash,
+        content_hash=entry.content_hash,
+        actor=entry.actor,
+        model=entry.model,
+        step_id=entry.step_id,
+        run_id=run_id,
+        timestamp=entry.timestamp,
+        verified=verified,
+    )
+
+
+def project_production_events(
+    entries: Iterable[SpineEntry],
+    *,
+    run_id: str,
+    hmac_key: bytes,
+) -> list[ArtifactProductionEvent]:
+    """Project a whole spine onto its intended event set, in append order.
+
+    The integrity verdict is recomputed per entry, so an entry whose payload or
+    HMAC tag was altered projects with ``verified=False`` while its neighbours
+    stay ``True``.
+    """
+    return [project_production_event(entry, run_id=run_id, verified=verify_entry(entry, hmac_key)) for entry in entries]
+
+
+def replay_production_events(
+    lineage_root: Path,
+    *,
+    run_id: str,
+    hmac_key: bytes,
+) -> list[ArtifactProductionEvent]:
+    """Re-derive the intended event set for ``run_id`` from its spine alone.
+
+    Reads no journal. This is the side of :func:`compare_fanout` that cannot be
+    forged by writing rows into the event log.
+    """
+    spine = LineageSpine(lineage_root, run_id=run_id, hmac_key=hmac_key)
+    return project_production_events(spine.iter_entries(), run_id=run_id, hmac_key=hmac_key)
+
+
+# ---------------------------------------------------------------------------
+# Journal IO
+# ---------------------------------------------------------------------------
+
+
+def events_path(lineage_root: Path, run_id: str) -> Path:
+    """Return the event-journal path for ``run_id``.
+
+    Validated through :class:`LineageSpine` so a ``run_id`` that would escape
+    its per-run directory is refused here exactly as it is for the spine.
+    """
+    return LineageSpine(lineage_root, run_id=run_id, hmac_key=b"").run_dir / ARTIFACT_EVENTS_FILENAME
+
+
+def append_production_event(lineage_root: Path, *, run_id: str, event: ArtifactProductionEvent) -> None:
+    """Append one event to the run's journal.
+
+    Raises on IO failure; :func:`emit_production_event` is the fail-open wrapper
+    the write boundary uses.
+    """
+    path = events_path(lineage_root, run_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("ab") as fh:
+        fh.write(event.canonical_bytes() + b"\n")
+        fh.flush()
+        os.fsync(fh.fileno())
+
+
+def load_production_events(lineage_root: Path, *, run_id: str) -> list[ArtifactProductionEvent]:
+    """Return the journaled events for ``run_id`` in append order.
+
+    A malformed or unknown-version row is skipped with a debug log rather than
+    raising: the journal is an index, and a corrupt index must not stop a
+    verifier from reaching the spine, which is the thing that actually decides.
+    :func:`compare_fanout` reports the resulting gap as a divergence.
+    """
+    path = events_path(lineage_root, run_id)
+    if not path.is_file():
+        return []
+    out: list[ArtifactProductionEvent] = []
+    for line in path.read_bytes().split(b"\n"):
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            logger.debug("artifact events: skipping malformed row in %s", path)
+            continue
+        if not isinstance(row, dict):
+            logger.debug("artifact events: skipping non-object row in %s", path)
+            continue
+        try:
+            out.append(ArtifactProductionEvent.from_payload(row))
+        except (KeyError, TypeError, ValueError):
+            logger.debug("artifact events: skipping row with bad shape in %s", path)
+            continue
+    return out
+
+
+def emit_production_event(
+    lineage_root: Path,
+    *,
+    run_id: str,
+    entry: SpineEntry,
+    publish: Any = None,
+) -> ArtifactProductionEvent | None:
+    """Journal (and optionally publish) the event for a just-written entry.
+
+    **Never raises.** The spine write already succeeded when this runs; a
+    failure to journal or to publish would otherwise turn a recorded artifact
+    into a failed task, which inverts the priority between the two. The spine
+    keeps the fact, and :func:`replay_production_events` rebuilds any event a
+    failed emit dropped, so the fail-open path loses notification latency and
+    nothing else.
+
+    Args:
+        lineage_root: ``.sdd/lineage`` root.
+        run_id: The run whose spine carries ``entry``.
+        entry: The entry just appended.
+        publish: Optional one-argument callable handed the event for bus
+            delivery. Its exceptions are swallowed on the same terms.
+
+    Returns:
+        The event, or ``None`` when projection itself failed.
+    """
+    try:
+        event = project_production_event(entry, run_id=run_id, verified=True)
+    except Exception as exc:  # pragma: no cover - defensive; projection is total
+        logger.debug("artifact events: projection failed for run %s: %s", run_id, exc)
+        return None
+    try:
+        append_production_event(lineage_root, run_id=run_id, event=event)
+    except Exception as exc:
+        logger.debug("artifact events: journaling failed for run %s: %s", run_id, exc)
+    if publish is not None:
+        try:
+            publish(event)
+        except Exception as exc:
+            logger.debug("artifact events: publishing failed for run %s: %s", run_id, exc)
+    return event
+
+
+# ---------------------------------------------------------------------------
+# Observation
+# ---------------------------------------------------------------------------
+
+
+def observed_artifact_keys(lineage_root: Path, *, run_id: str) -> tuple[str, ...]:
+    """Return the artifact keys a run is *observed* to have produced.
+
+    Sorted and deduplicated. The run's own journal seal is excluded: it records
+    the run recording itself, not a deliverable, and counting it as production
+    would put ``.sdd/runs/<id>/journal.jsonl`` into every completion diff as an
+    undeclared write.
+
+    An empty tuple means "this run's spine carries no produced artifact", which
+    is a genuine observation. It is **not** the same as having no observation at
+    all -- callers that cannot observe pass ``None`` rather than an empty tuple,
+    because a diff computed against an absent observation manufactures findings
+    out of ignorance.
+    """
+    return tuple(sorted({e.uri for e in load_production_events(lineage_root, run_id=run_id) if not e.is_journal_seal}))
+
+
+# ---------------------------------------------------------------------------
+# Fan-out divergence
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class FanoutDivergence:
+    """One disagreement between the journaled fan-out and the replayed one.
+
+    Attributes:
+        kind: ``dropped`` (the spine implies an event the journal lacks),
+            ``duplicated`` (the journal fired one entry more than once),
+            ``unexpected`` (the journal carries an entry the spine does not),
+            or ``altered`` (same entry, different payload -- the signature of a
+            tampered spine row or an edited journal).
+        entry_hash: The offending spine entry hash. Always populated, so every
+            divergence names the exact entry a reviewer must go look at.
+        detail: Human-readable specifics.
+    """
+
+    kind: str
+    entry_hash: str
+    detail: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"kind": self.kind, "entry_hash": self.entry_hash, "detail": self.detail}
+
+
+def compare_fanout(
+    journaled: Sequence[ArtifactProductionEvent],
+    replayed: Sequence[ArtifactProductionEvent],
+) -> list[FanoutDivergence]:
+    """Compare a journaled fan-out against the one the spine implies.
+
+    An intact run yields an empty list: the journal is exactly the projection.
+    Every difference is attributed to a specific ``entry_hash``, so "a firing
+    went missing" becomes a named entry rather than an investigation.
+
+    Returns:
+        Divergences ordered by kind then entry hash, so two verifiers comparing
+        the same pair of sequences produce identical output.
+    """
+    divergences: list[FanoutDivergence] = []
+
+    journaled_by_hash: dict[str, list[ArtifactProductionEvent]] = {}
+    for event in journaled:
+        journaled_by_hash.setdefault(event.entry_hash, []).append(event)
+    replayed_by_hash = {event.entry_hash: event for event in replayed}
+
+    for entry_hash, seen in journaled_by_hash.items():
+        if len(seen) > 1:
+            divergences.append(
+                FanoutDivergence(
+                    kind=DIVERGENCE_DUPLICATED,
+                    entry_hash=entry_hash,
+                    detail=f"journal fired this entry {len(seen)} times; the spine implies exactly one",
+                )
+            )
+
+    for expected in replayed:
+        seen_list = journaled_by_hash.get(expected.entry_hash)
+        if not seen_list:
+            divergences.append(
+                FanoutDivergence(
+                    kind=DIVERGENCE_DROPPED,
+                    entry_hash=expected.entry_hash,
+                    detail=f"spine entry for {expected.uri!r} produced no journaled event",
+                )
+            )
+            continue
+        if seen_list[0].to_payload() != expected.to_payload():
+            divergences.append(
+                FanoutDivergence(
+                    kind=DIVERGENCE_ALTERED,
+                    entry_hash=expected.entry_hash,
+                    detail=(
+                        "journaled event does not match the event the spine projects "
+                        f"(journaled verified={seen_list[0].verified}, replayed verified={expected.verified})"
+                    ),
+                )
+            )
+
+    for entry_hash, seen in journaled_by_hash.items():
+        if entry_hash not in replayed_by_hash:
+            divergences.append(
+                FanoutDivergence(
+                    kind=DIVERGENCE_UNEXPECTED,
+                    entry_hash=entry_hash,
+                    detail=f"journaled event for {seen[0].uri!r} has no matching spine entry",
+                )
+            )
+
+    divergences.sort(key=lambda d: (d.kind, d.entry_hash))
+    return divergences

--- a/src/bernstein/core/lineage/artifact_health.py
+++ b/src/bernstein/core/lineage/artifact_health.py
@@ -1,0 +1,576 @@
+"""Per-artifact health as a deterministic projection (issue #2559, Phase 3).
+
+Answering "is this output good and current" used to mean correlating four
+surfaces by hand: open-tip analysis, evidence-bundle verification, spine chain
+verification, and the cadence the output was supposed to refresh on. Nothing
+rolled them up per artifact, so the answer lived in an operator's head and was
+never the same twice.
+
+This module is that roll-up, and it is a **pure function**. Everything that can
+vary between two observers is an explicit argument:
+
+* the state is read once by :func:`collect_artifact_state` and then never
+  touched again;
+* the evaluation instant is the caller-supplied ``at``, never the wall clock;
+* the declared cadence is a caller-supplied number, never an ambient default.
+
+That is what makes the CLI and the server route incapable of disagreeing: they
+are not two implementations that happen to match, they are two callers of
+:func:`artifact_health_json`, which is the only place the verdict is serialised.
+Given the same ``.sdd`` state and the same ``at``, both emit byte-identical
+bytes, and a third party can recompute either offline with no network.
+
+Verdict
+-------
+
+``green``
+    Every applicable leg passes: the artifact was produced, every spine entry
+    carrying it verifies, exactly one set of bytes is current, the newest
+    evidence bundle that references it verifies, and the last production is
+    inside the declared cadence.
+
+``amber``
+    Nothing is broken but the artifact is out of date -- the cadence lapsed.
+
+``red``
+    An integrity or currency failure: a tampered or unlinked chain entry, or
+    two different sets of bytes both claiming to be current.
+
+A leg with nothing to say reports ``not_applicable`` and cannot hold a verdict
+down: an artifact with no declared cadence is not "failing cadence", and one no
+evidence bundle references is not "failing evidence". Absence of a signal is
+never reported as a negative signal.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.lineage.artifact_uri import ArtifactURIError, canonical_artifact_key
+from bernstein.core.lineage.spine import LineageSpine, SpineStatus, verify_entry
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "AMBER",
+    "GREEN",
+    "LEG_FAIL",
+    "LEG_NOT_APPLICABLE",
+    "LEG_PASS",
+    "LEG_STALE",
+    "RED",
+    "ArtifactHealth",
+    "ArtifactProduction",
+    "ArtifactState",
+    "HealthLeg",
+    "artifact_health_json",
+    "artifact_log",
+    "artifact_log_json",
+    "collect_artifact_state",
+    "compute_artifact_health",
+    "list_artifact_keys",
+]
+
+GREEN = "green"
+AMBER = "amber"
+RED = "red"
+
+LEG_PASS = "pass"
+LEG_FAIL = "fail"
+LEG_STALE = "stale"
+LEG_NOT_APPLICABLE = "not_applicable"
+
+#: Version stamped into the serialised verdict. A consumer pinning a verdict
+#: document knows which projection produced it.
+HEALTH_SCHEMA_VERSION = 1
+
+_SPINE_LOG_NAME = "spine.jsonl"
+_BUNDLES_SUBPATH = (".sdd", "evidence", "bundles")
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactProduction:
+    """One recorded production of an artifact, as the chain saw it.
+
+    This is the attribution record ``artifact log`` renders: which agent
+    identity, running which model, produced these bytes, and whether the spine
+    entry saying so still verifies.
+    """
+
+    run_id: str
+    entry_hash: str
+    content_hash: str
+    actor: str
+    model: str
+    step_id: str
+    timestamp: int
+    verified: bool
+
+    @property
+    def order_key(self) -> tuple[int, str]:
+        """Total order over productions: newest timestamp, then entry hash.
+
+        The entry hash breaks ties so the ordering is total and identical on
+        every host -- two verifiers never disagree about which production is the
+        tip.
+        """
+        return (self.timestamp, self.entry_hash)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "actor": self.actor,
+            "content_hash": self.content_hash,
+            "entry_hash": self.entry_hash,
+            "model": self.model,
+            "run_id": self.run_id,
+            "step_id": self.step_id,
+            "timestamp": self.timestamp,
+            "verified": self.verified,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactState:
+    """Everything read off disk for one artifact key, frozen before use.
+
+    Collected once and then treated as immutable input, so the verdict is a
+    function of a snapshot rather than of whatever the filesystem happened to
+    hold at each individual read.
+    """
+
+    uri: str
+    productions: tuple[ArtifactProduction, ...] = ()
+    chain_errors: tuple[str, ...] = ()
+    evidence_task_id: str = ""
+    evidence_verified: bool | None = None
+    evidence_detail: str = ""
+
+    @property
+    def ordered(self) -> tuple[ArtifactProduction, ...]:
+        """Productions oldest-first in the total order."""
+        return tuple(sorted(self.productions, key=lambda p: p.order_key))
+
+
+@dataclass(frozen=True, slots=True)
+class HealthLeg:
+    """One named check inside the verdict."""
+
+    name: str
+    status: str
+    detail: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"detail": self.detail, "name": self.name, "status": self.status}
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactHealth:
+    """The rolled-up verdict for one artifact."""
+
+    uri: str
+    verdict: str
+    legs: tuple[HealthLeg, ...]
+    evaluated_at: int
+    tip_entry_hash: str = ""
+    tip_content_hash: str = ""
+    tip_actor: str = ""
+    tip_model: str = ""
+    tip_run_id: str = ""
+    last_produced_at: int | None = None
+    production_count: int = 0
+    schema_version: int = HEALTH_SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical verdict document."""
+        return {
+            "evaluated_at": self.evaluated_at,
+            "last_produced_at": self.last_produced_at,
+            "legs": [leg.to_dict() for leg in self.legs],
+            "production_count": self.production_count,
+            "schema_version": self.schema_version,
+            "tip": {
+                "actor": self.tip_actor,
+                "content_hash": self.tip_content_hash,
+                "entry_hash": self.tip_entry_hash,
+                "model": self.tip_model,
+                "run_id": self.tip_run_id,
+            },
+            "uri": self.uri,
+            "verdict": self.verdict,
+        }
+
+
+def _canonical_json(payload: dict[str, Any]) -> str:
+    """Serialise a verdict document deterministically.
+
+    Sorted keys and minimal separators: this single function is why two
+    surfaces cannot produce different bytes for the same verdict.
+    """
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+# ---------------------------------------------------------------------------
+# Reading state
+# ---------------------------------------------------------------------------
+
+
+def _run_ids(lineage_root: Path) -> list[str]:
+    """Return run ids under ``lineage_root`` that carry a spine, sorted."""
+    if not lineage_root.is_dir():
+        return []
+    out: list[str] = []
+    for child in sorted(lineage_root.iterdir()):
+        if child.is_dir() and (child / _SPINE_LOG_NAME).is_file():
+            out.append(child.name)
+    return out
+
+
+def list_artifact_keys(workdir: Path) -> dict[str, int]:
+    """Return every artifact key the local spines carry, with production counts.
+
+    Backs ``bernstein artifact list``. Keys are returned exactly as the chain
+    records them; no canonicalisation is applied on read, because a key that a
+    historical entry was hashed under must be reported as it was written.
+    """
+    lineage_root = workdir / ".sdd" / "lineage"
+    counts: dict[str, int] = {}
+    for run_id in _run_ids(lineage_root):
+        try:
+            spine = LineageSpine(lineage_root, run_id=run_id, hmac_key=b"")
+        except ValueError:
+            logger.debug("artifact health: skipping unusable run dir %r", run_id)
+            continue
+        for entry in spine.iter_entries():
+            counts[entry.artifact_path] = counts.get(entry.artifact_path, 0) + 1
+    return counts
+
+
+def _collect_evidence(
+    workdir: Path,
+    uri: str,
+    *,
+    hmac_key: bytes,
+) -> tuple[str, bool | None, str]:
+    """Return ``(task_id, verified, detail)`` for the newest bundle citing ``uri``.
+
+    A bundle is considered to reference the artifact when its sealed output diff
+    lists the key as declared-and-produced. That link is inside the bundle's
+    *signed* binding, so an artifact cannot be associated with a bundle it was
+    never sealed against.
+
+    Returns ``("", None, "")`` when no bundle references the artifact, which the
+    verdict reads as "not applicable" rather than as a failure.
+    """
+    from bernstein.core.evidence.bundle import EvidenceBundle, verify_evidence_bundle
+
+    bundles_dir = workdir.joinpath(*_BUNDLES_SUBPATH)
+    if not bundles_dir.is_dir():
+        return "", None, ""
+
+    newest_task = ""
+    newest_ts = -1
+    for path in sorted(bundles_dir.glob("*.json")):
+        try:
+            bundle = EvidenceBundle.from_bytes(path.read_bytes())
+        except (OSError, ValueError, KeyError, TypeError):
+            logger.debug("artifact health: malformed evidence bundle at %s", path)
+            continue
+        diff = bundle.output_diff
+        if diff is None or uri not in diff.declared_and_produced:
+            continue
+        # Ties break on task id so the choice of "newest" is deterministic.
+        if (bundle.timestamp, bundle.task_id) > (newest_ts, newest_task):
+            newest_ts = bundle.timestamp
+            newest_task = bundle.task_id
+
+    if not newest_task:
+        return "", None, ""
+
+    try:
+        result = verify_evidence_bundle(
+            workdir=workdir,
+            lineage_root=workdir / ".sdd" / "lineage",
+            hmac_key=hmac_key,
+            task_id=newest_task,
+        )
+    except Exception as exc:  # fail-open: an unverifiable bundle is a finding, not a crash
+        logger.debug("artifact health: evidence verification raised for %s: %s", newest_task, exc)
+        return newest_task, False, "evidence verification raised"
+    return newest_task, bool(result.ok), "" if result.ok else str(getattr(result, "reason", "") or "bundle failed")
+
+
+def collect_artifact_state(
+    workdir: Path,
+    uri: str,
+    *,
+    hmac_key: bytes,
+    include_evidence: bool = True,
+) -> ArtifactState:
+    """Read every local fact about ``uri`` into one immutable snapshot.
+
+    Walks each run spine under ``<workdir>/.sdd/lineage``, keeps the entries
+    whose key equals ``uri``, recomputes each one's integrity verdict, and
+    records a chain error for any run that carries the artifact but whose chain
+    does not verify. A tampered entry belonging to a *different* artifact in the
+    same run is deliberately not attributed here -- per-entry verification is
+    what keeps one bad row from turning every artifact in the run red.
+
+    Args:
+        workdir: Project root containing ``.sdd``.
+        uri: The artifact key, canonicalised before lookup.
+        hmac_key: Audit-chain HMAC key the spines were tagged with.
+        include_evidence: Read sealed evidence bundles. Off for callers that
+            only need production attribution.
+
+    Returns:
+        The snapshot the verdict is computed from.
+    """
+    try:
+        key = canonical_artifact_key(uri)
+    except ArtifactURIError:
+        # An unparseable key can still be looked up verbatim: the answer is
+        # simply that nothing was ever produced under it.
+        key = uri
+
+    lineage_root = workdir / ".sdd" / "lineage"
+    productions: list[ArtifactProduction] = []
+    chain_errors: list[str] = []
+
+    for run_id in _run_ids(lineage_root):
+        try:
+            spine = LineageSpine(lineage_root, run_id=run_id, hmac_key=hmac_key)
+        except ValueError:
+            logger.debug("artifact health: skipping unusable run dir %r", run_id)
+            continue
+        matched = [e for e in spine.iter_entries() if e.artifact_path == key]
+        if not matched:
+            continue
+        for entry in matched:
+            productions.append(
+                ArtifactProduction(
+                    run_id=run_id,
+                    entry_hash=entry.entry_hash,
+                    content_hash=entry.content_hash,
+                    actor=entry.actor,
+                    model=entry.model,
+                    step_id=entry.step_id,
+                    timestamp=entry.timestamp,
+                    verified=verify_entry(entry, hmac_key),
+                )
+            )
+        result = spine.verify()
+        if result.status is SpineStatus.TAMPERED:
+            chain_errors.append(f"run {run_id}: chain verification failed ({len(result.errors)} error(s))")
+
+    evidence_task, evidence_verified, evidence_detail = (
+        _collect_evidence(workdir, key, hmac_key=hmac_key) if include_evidence else ("", None, "")
+    )
+
+    return ArtifactState(
+        uri=key,
+        productions=tuple(productions),
+        chain_errors=tuple(chain_errors),
+        evidence_task_id=evidence_task,
+        evidence_verified=evidence_verified,
+        evidence_detail=evidence_detail,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The verdict
+# ---------------------------------------------------------------------------
+
+
+def _tip_legs(state: ArtifactState) -> tuple[list[HealthLeg], ArtifactProduction | None]:
+    """Return the production-, integrity- and tip-related legs plus the tip."""
+    ordered = state.ordered
+    if not ordered:
+        return [
+            HealthLeg(
+                name="produced",
+                status=LEG_FAIL,
+                detail="no spine entry records this artifact; nothing has ever produced it",
+            )
+        ], None
+
+    legs: list[HealthLeg] = [
+        HealthLeg(name="produced", status=LEG_PASS, detail=f"{len(ordered)} production(s) recorded")
+    ]
+
+    unverified = [p.entry_hash for p in ordered if not p.verified]
+    if unverified or state.chain_errors:
+        detail_parts: list[str] = []
+        if unverified:
+            detail_parts.append("tampered entry: " + ", ".join(sorted(unverified)))
+        detail_parts.extend(state.chain_errors)
+        legs.append(HealthLeg(name="chain_integrity", status=LEG_FAIL, detail="; ".join(detail_parts)))
+    else:
+        legs.append(
+            HealthLeg(
+                name="chain_integrity",
+                status=LEG_PASS,
+                detail="every entry hash and HMAC tag recomputes",
+            )
+        )
+
+    tip = ordered[-1]
+    contenders = [p for p in ordered if p.timestamp == tip.timestamp]
+    distinct = sorted({p.content_hash for p in contenders})
+    if len(distinct) > 1:
+        legs.append(
+            HealthLeg(
+                name="single_open_tip",
+                status=LEG_FAIL,
+                detail=(
+                    f"{len(distinct)} distinct content hashes claim to be current at "
+                    f"timestamp {tip.timestamp}: " + ", ".join(distinct)
+                ),
+            )
+        )
+    else:
+        legs.append(HealthLeg(name="single_open_tip", status=LEG_PASS, detail=f"tip {tip.entry_hash}"))
+
+    return legs, tip
+
+
+def _evidence_leg(state: ArtifactState) -> HealthLeg:
+    if state.evidence_verified is None:
+        return HealthLeg(
+            name="evidence",
+            status=LEG_NOT_APPLICABLE,
+            detail="no sealed evidence bundle declares this artifact",
+        )
+    if state.evidence_verified:
+        return HealthLeg(name="evidence", status=LEG_PASS, detail=f"bundle for task {state.evidence_task_id} verifies")
+    return HealthLeg(
+        name="evidence",
+        status=LEG_FAIL,
+        detail=f"bundle for task {state.evidence_task_id} failed verification: {state.evidence_detail}",
+    )
+
+
+def _cadence_leg(tip: ArtifactProduction | None, *, at: int, cadence_seconds: int | None) -> HealthLeg:
+    if cadence_seconds is None or cadence_seconds <= 0:
+        return HealthLeg(name="cadence", status=LEG_NOT_APPLICABLE, detail="no cadence declared for this artifact")
+    if tip is None:
+        return HealthLeg(name="cadence", status=LEG_NOT_APPLICABLE, detail="never produced")
+    age = at - tip.timestamp
+    if age <= cadence_seconds:
+        return HealthLeg(
+            name="cadence", status=LEG_PASS, detail=f"last produced {age}s ago, cadence {cadence_seconds}s"
+        )
+    return HealthLeg(
+        name="cadence",
+        status=LEG_STALE,
+        detail=f"last produced {age}s ago, past the declared cadence of {cadence_seconds}s",
+    )
+
+
+def compute_artifact_health(
+    state: ArtifactState,
+    *,
+    at: int,
+    cadence_seconds: int | None = None,
+) -> ArtifactHealth:
+    """Roll a collected state up into a verdict. Pure.
+
+    Args:
+        state: The snapshot from :func:`collect_artifact_state`.
+        at: The evaluation instant, in the same unit the spine timestamps use.
+            Explicit rather than read from the clock: a verdict that embedded
+            "now" could never be byte-identical across two surfaces, which is
+            the whole point of the projection.
+        cadence_seconds: The declared refresh cadence, or ``None`` when the
+            artifact declares none.
+
+    Returns:
+        The verdict. Depends only on its arguments.
+    """
+    legs, tip = _tip_legs(state)
+    legs.append(_evidence_leg(state))
+    legs.append(_cadence_leg(tip, at=at, cadence_seconds=cadence_seconds))
+
+    statuses = {leg.status for leg in legs}
+    if LEG_FAIL in statuses:
+        verdict = RED
+    elif LEG_STALE in statuses:
+        verdict = AMBER
+    else:
+        verdict = GREEN
+
+    return ArtifactHealth(
+        uri=state.uri,
+        verdict=verdict,
+        legs=tuple(legs),
+        evaluated_at=at,
+        tip_entry_hash=tip.entry_hash if tip else "",
+        tip_content_hash=tip.content_hash if tip else "",
+        tip_actor=tip.actor if tip else "",
+        tip_model=tip.model if tip else "",
+        tip_run_id=tip.run_id if tip else "",
+        last_produced_at=tip.timestamp if tip else None,
+        production_count=len(state.productions),
+    )
+
+
+def artifact_health_json(
+    workdir: Path,
+    uri: str,
+    *,
+    hmac_key: bytes,
+    at: int,
+    cadence_seconds: int | None = None,
+) -> str:
+    """Return the canonical verdict JSON for ``uri``.
+
+    **The** entry point. ``bernstein artifact health --json`` and the server
+    route both call exactly this, so "the CLI and the dashboard cannot disagree"
+    is a structural property rather than a pair of implementations kept in sync
+    by discipline.
+    """
+    state = collect_artifact_state(workdir, uri, hmac_key=hmac_key)
+    return _canonical_json(compute_artifact_health(state, at=at, cadence_seconds=cadence_seconds).to_dict())
+
+
+# ---------------------------------------------------------------------------
+# Attribution log
+# ---------------------------------------------------------------------------
+
+
+def artifact_log(
+    workdir: Path,
+    uri: str,
+    *,
+    hmac_key: bytes,
+    limit: int = 0,
+) -> tuple[ArtifactProduction, ...]:
+    """Return productions of ``uri`` newest-first: who produced the current tip.
+
+    Backs ``bernstein artifact log <uri>``. Each record carries the producing
+    agent identity, the model it ran, the step it came from and the spine entry
+    hash that proves it, plus whether that entry still verifies -- so the answer
+    to "which agent identity, running which model, produced the current tip of
+    this PR or this package" is read off the chain rather than reconstructed by
+    walking run directories.
+
+    Args:
+        workdir: Project root containing ``.sdd``.
+        uri: The artifact key.
+        hmac_key: Audit-chain HMAC key.
+        limit: Maximum records to return; ``0`` means all.
+    """
+    state = collect_artifact_state(workdir, uri, hmac_key=hmac_key, include_evidence=False)
+    records = tuple(reversed(state.ordered))
+    return records[:limit] if limit > 0 else records
+
+
+def artifact_log_json(records: Iterable[ArtifactProduction], *, uri: str) -> str:
+    """Serialise an attribution log canonically, for the CLI and the route."""
+    return _canonical_json({"productions": [r.to_dict() for r in records], "uri": uri})

--- a/src/bernstein/core/lineage/spine.py
+++ b/src/bernstein/core/lineage/spine.py
@@ -668,6 +668,40 @@ class LineageSpine:
         return SpineVerifyResult(status=SpineStatus.OK, count=count)
 
 
+def verify_entry(entry: SpineEntry, hmac_key: bytes) -> bool:
+    """Whether one materialised entry is intact on its own terms.
+
+    Recomputes the entry hash from the entry's own fields and the HMAC tag over
+    its body, so a single-byte mutation of any hashed field or of the tag
+    returns ``False``. This is the per-entry counterpart of
+    :meth:`LineageSpine.verify`, which additionally walks the ``prev_hash``
+    linkage across the whole chain.
+
+    Split out because a per-artifact projection needs a verdict for the exact
+    entries that carry one artifact key, not for the run's whole chain: a
+    tampered entry belonging to a different artifact must not turn every other
+    artifact in the same run red.
+
+    Returns:
+        ``True`` when both the entry hash and the HMAC tag recompute.
+    """
+    expected_hash = compute_entry_hash(
+        prev_hash=entry.prev_hash,
+        artifact_path=entry.artifact_path,
+        content_hash=entry.content_hash,
+        actor=entry.actor,
+        step_id=entry.step_id,
+        model=entry.model,
+        timestamp=entry.timestamp,
+        traceparent=entry.traceparent,
+        tracestate=entry.tracestate,
+        baggage=entry.baggage,
+    )
+    if not _hmac.compare_digest(entry.entry_hash, expected_hash):
+        return False
+    return _hmac.compare_digest(entry.hmac, _compute_hmac(hmac_key, entry.body()))
+
+
 __all__ = [
     "JOURNAL_SEAL_STEP_PREFIX",
     "SPINE_ENTRY_VERSION",
@@ -678,4 +712,5 @@ __all__ = [
     "SpineVerifyResult",
     "compute_entry_hash",
     "content_hash_of",
+    "verify_entry",
 ]

--- a/src/bernstein/core/routes/artifacts.py
+++ b/src/bernstein/core/routes/artifacts.py
@@ -1,0 +1,131 @@
+"""Artifact routes: the health verdict and attribution log, by URI (#2559).
+
+* ``GET /artifacts`` - every artifact key the local spines carry.
+* ``GET /artifacts/health`` - the rolled-up verdict for one key.
+* ``GET /artifacts/log`` - who produced the current tip of one key.
+
+The health route deliberately owns **no** projection logic. It parses the query
+string, hands the parsed values to
+:func:`bernstein.core.lineage.artifact_health.artifact_health_json`, and returns
+those bytes verbatim. ``bernstein artifact health --json`` calls the same
+function with the same arguments, so the two surfaces do not merely agree --
+they cannot differ, because there is only one implementation and only one
+serialiser. An operator can pin a verdict from the dashboard and recompute it
+offline from ``.sdd`` alone.
+
+``at`` is an explicit query parameter for the same reason the CLI has ``--at``:
+a verdict that read the wall clock could never be reproducible. Omitting it
+means "now", which is fine for a dashboard poll and useless for a comparison,
+so any comparison pins it.
+
+The key travels as a query parameter, not a path segment: an artifact URI
+carries ``:`` and ``/``, and threading that through a path would invite exactly
+the double-decoding ambiguity the canonical-key rule exists to prevent.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse, Response
+
+from bernstein.core.lineage.artifact_health import (
+    artifact_log,
+    artifact_log_json,
+    list_artifact_keys,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+#: Media type for the pinned verdict bytes. Returned as a raw ``Response`` so
+#: FastAPI's own JSON encoder cannot re-order keys and break byte-identity with
+#: the CLI.
+_JSON_MEDIA_TYPE = "application/json"
+
+_MAX_LOG_LIMIT = 500
+
+
+def _workdir(request: Request) -> Path:
+    """Return the project root the server was started against."""
+    workdir: Path = request.app.state.workdir
+    return workdir
+
+
+def _hmac_key() -> bytes:
+    from bernstein.core.security.audit import load_or_create_audit_key
+
+    return load_or_create_audit_key()
+
+
+def _int_param(request: Request, name: str) -> int | None:
+    raw = request.query_params.get(name)
+    if raw is None or raw == "":
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        raise HTTPException(status_code=400, detail=f"{name} must be an integer") from None
+
+
+def _required_uri(request: Request) -> str:
+    uri = request.query_params.get("uri", "")
+    if not uri:
+        raise HTTPException(status_code=400, detail="uri query parameter is required")
+    return uri
+
+
+@router.get("/artifacts")
+def list_artifacts(request: Request) -> JSONResponse:
+    """Return every artifact key the local lineage spines carry."""
+    counts = list_artifact_keys(_workdir(request))
+    return JSONResponse({"artifacts": [{"uri": uri, "productions": n} for uri, n in sorted(counts.items())]})
+
+
+@router.get("/artifacts/health")
+def artifact_health(request: Request) -> Response:
+    """Return the canonical health verdict for ``?uri=``.
+
+    Query parameters:
+
+    * ``uri`` (required) - the artifact key.
+    * ``at`` - evaluation instant; defaults to the wall clock. Pin it to
+      reproduce a verdict byte-for-byte against the CLI.
+    * ``cadence_seconds`` - declared refresh cadence; omitted means the cadence
+      leg reports ``not_applicable``.
+
+    The body is the exact string the CLI prints for the same state and instant,
+    byte for byte. The status is always 200: the verdict is the payload, and a
+    red artifact is a successfully computed answer, not a failed request.
+    """
+    from bernstein.core.lineage.artifact_health import artifact_health_json
+
+    uri = _required_uri(request)
+    at = _int_param(request, "at")
+    cadence = _int_param(request, "cadence_seconds")
+
+    payload = artifact_health_json(
+        _workdir(request),
+        uri,
+        hmac_key=_hmac_key(),
+        at=at if at is not None else int(time.time()),
+        cadence_seconds=cadence,
+    )
+    return Response(content=payload, media_type=_JSON_MEDIA_TYPE)
+
+
+@router.get("/artifacts/log")
+def artifact_log_route(request: Request) -> Response:
+    """Return productions of ``?uri=``, newest first (the attribution log)."""
+    uri = _required_uri(request)
+    limit = _int_param(request, "limit") or 0
+    limit = min(max(limit, 0), _MAX_LOG_LIMIT)
+    records = artifact_log(_workdir(request), uri, hmac_key=_hmac_key(), limit=limit)
+    return Response(content=artifact_log_json(records, uri=uri), media_type=_JSON_MEDIA_TYPE)

--- a/src/bernstein/core/server/server_app.py
+++ b/src/bernstein/core/server/server_app.py
@@ -667,6 +667,36 @@ async def _sse_heartbeat_loop(bus: SSEBus, interval_s: float = 15.0) -> None:
                 logger.info("SSE bus: cleaned up %d stale subscribers", removed)
 
 
+def _install_artifact_event_publisher(bus: SSEBus | None) -> None:
+    """Point the lineage write boundary's event sink at ``bus`` (issue #2559).
+
+    Passing ``None`` clears the sink, which the lifespan does on shutdown so a
+    stopped server does not leave the orchestrator publishing into a dead bus.
+
+    The write boundary swallows anything this raises: an artifact write that
+    landed in the spine must not be undone because a notification could not be
+    delivered. Journaling happens either way, so a run with no server attached
+    still replays the identical fan-out.
+    """
+    from bernstein.adapters.base import set_artifact_event_publisher
+    from bernstein.core.server.sse_events import SSEEvent
+
+    if bus is None:
+        set_artifact_event_publisher(None)
+        return
+
+    def _publish(event: Any) -> None:
+        payload = event.to_payload()
+        sse = SSEEvent.artifact_produced(
+            uri=payload.pop("uri"),
+            entry_hash=payload.pop("entry_hash"),
+            **payload,
+        )
+        bus.publish(sse.event.value, json.dumps(sse.data, sort_keys=True))
+
+    set_artifact_event_publisher(_publish)
+
+
 # ---------------------------------------------------------------------------
 # Helpers used by route modules
 # ---------------------------------------------------------------------------
@@ -1011,6 +1041,11 @@ def create_app(
         reaper = asyncio.create_task(_reaper_loop(store))
         # Launch SSE heartbeat loop
         sse_heartbeat = asyncio.create_task(_sse_heartbeat_loop(sse_bus))
+        # Issue #2559: mirror artifact production events onto the SSE bus.
+        # The events are journaled beside the spine regardless; this only adds
+        # live delivery while a server is up, and the sink is cleared on
+        # shutdown so a stopped server never holds a stale bus reference.
+        _install_artifact_event_publisher(sse_bus)
         # Launch the node-stale reaper whenever the /cluster/nodes routes are
         # mounted (always) rather than only when cluster auth is enabled. Node
         # liveness reaping is not part of the auth layer, and a worker can only
@@ -1026,6 +1061,7 @@ def create_app(
         )
         yield
         # Shutdown
+        _install_artifact_event_publisher(None)
         reaper.cancel()
         sse_heartbeat.cancel()
         with contextlib.suppress(asyncio.CancelledError):
@@ -1348,6 +1384,7 @@ def create_app(
     from bernstein.core.routes.agent_comparison import router as agent_comparison_router
     from bernstein.core.routes.api_v1 import build_router as build_api_v1_router
     from bernstein.core.routes.approvals import router as approvals_router
+    from bernstein.core.routes.artifacts import router as artifacts_router
     from bernstein.core.routes.audit_log import router as audit_log_router
     from bernstein.core.routes.batch_ops import router as batch_ops_router
     from bernstein.core.routes.custom_metrics import router as custom_metrics_router
@@ -1442,6 +1479,7 @@ def create_app(
         session_peek_router,
         orchestrator_holds_router,
         review_board_router,
+        artifacts_router,
         missions_router,
         a2a_jsonrpc_router,
     ]

--- a/src/bernstein/core/server/sse_events.py
+++ b/src/bernstein/core/server/sse_events.py
@@ -23,6 +23,7 @@ class SSEEventType(StrEnum):
     TASK_RETRIED = "task.retried"
     TASK_ARTIFACT = "task.artifact"
     TASK_PROGRESS = "task.progress"
+    ARTIFACT_PRODUCED = "artifact.produced"
     AGENT_SPAWNED = "agent.spawned"
     AGENT_EXITED = "agent.exited"
     GATE_RESULT = "gate.result"
@@ -189,6 +190,37 @@ class SSEEvent:
             | {
                 "task_id": task_id,
                 "vector_hash": vector_hash,
+            },
+        )
+
+    @classmethod
+    def artifact_produced(cls, uri: str, entry_hash: str, **extra: Any) -> SSEEvent:
+        """Create an artifact.produced event (#2559).
+
+        Emitted from the single lineage write boundary for every artifact that
+        lands in the spine, so a downstream goal fires when the upstream output
+        actually lands instead of guessing on a cron. The payload is the
+        projection of the spine entry -- identity and provenance, never the
+        artifact bytes -- and carries ``verified`` so a consumer can tell a
+        production event apart from one replayed over a tampered chain.
+
+        Args:
+            uri: The canonical artifact key that was produced.
+            entry_hash: Spine entry hash identifying this exact production.
+            **extra: The rest of the projected payload (``content_hash``,
+                ``actor``, ``model``, ``run_id``, ``verified``, ...).
+
+        Returns:
+            SSEEvent instance.
+        """
+        # Identity fields win over ``extra`` so a caller cannot rebind the
+        # artifact or the entry it claims to project from.
+        return cls(
+            event=SSEEventType.ARTIFACT_PRODUCED,
+            data=extra
+            | {
+                "uri": uri,
+                "entry_hash": entry_hash,
             },
         )
 

--- a/src/bernstein/core/trigger_sources/artifact.py
+++ b/src/bernstein/core/trigger_sources/artifact.py
@@ -1,0 +1,181 @@
+"""Artifact trigger source - fire on the fleet's own outputs (issue #2559).
+
+Every existing trigger source watches something *outside* the fleet: a forge, a
+chat workspace, a clock, a directory. Nothing watched what the fleet itself
+produced, so a goal that depends on another goal's output had to poll on a cron
+guess -- wasting a run when nothing changed, lagging a day when the upstream was
+late -- or be hand-wired as a run dependency.
+
+This source normalises ``artifact.produced`` events into the same
+:class:`~bernstein.core.tasks.models.TriggerEvent` every other source emits, so
+the existing rule matching in ``trigger_manager`` handles artifact rules with no
+new matching engine.
+
+Why the fire set is replayable
+------------------------------
+
+The intended fire set is computed by :func:`intended_fires`, a **pure function**
+of ``(spine entries, patterns)``. Nothing about it depends on when the
+orchestrator happened to be listening. So:
+
+* replaying a run's spine reproduces the exact set of firings that run should
+  have performed, in order;
+* comparing that against the journaled events (:func:`fire_divergences`) turns a
+  dropped or duplicated firing into a named ``entry_hash`` instead of an
+  investigation;
+* an event whose spine entry no longer verifies arrives with ``verified: false``
+  and is refused by default, so a tampered chain cannot be used to *cause* work.
+
+That last point is the reason this source exists in the lineage-facing layer
+rather than being a thin bus subscriber: a firing is a decision, and a decision
+taken off an unverified record is worse than a firing that never happened.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.lineage.artifact_events import (
+    ArtifactProductionEvent,
+    compare_fanout,
+    load_production_events,
+    project_production_events,
+    replay_production_events,
+)
+from bernstein.core.lineage.artifact_uri import ArtifactURIError, match_artifact_pattern
+from bernstein.core.tasks.models import TriggerEvent
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+    from pathlib import Path
+
+    from bernstein.core.lineage.artifact_events import FanoutDivergence
+    from bernstein.core.lineage.spine import SpineEntry
+
+__all__ = [
+    "ARTIFACT_TRIGGER_SOURCE",
+    "ArtifactSource",
+    "fire_divergences",
+    "intended_fires",
+    "matches_any",
+    "normalize_production_event",
+]
+
+#: ``TriggerEvent.source`` discriminator for artifact production.
+ARTIFACT_TRIGGER_SOURCE = "artifact"
+
+
+def matches_any(patterns: Sequence[str], uri: str) -> bool:
+    """Whether ``uri`` is covered by any of ``patterns``.
+
+    Uses the canonical artifact-key matcher, so ``pkg://pypi/bernstein/*``
+    covers every version of one package and a malformed pattern simply matches
+    nothing instead of raising into the orchestrator tick.
+    """
+    for pattern in patterns:
+        try:
+            if match_artifact_pattern(pattern, uri):
+                return True
+        except ArtifactURIError:
+            continue
+    return False
+
+
+def normalize_production_event(event: ArtifactProductionEvent) -> TriggerEvent:
+    """Convert one production event into a normalized :class:`TriggerEvent`.
+
+    The artifact key rides in ``changed_files`` so the existing path-shaped rule
+    filters in ``trigger_manager`` see it without a new matching engine, and the
+    full projected payload rides in ``raw_payload`` so a rule that wants the
+    provenance -- producing identity, model, entry hash, verification verdict --
+    has it without a second lookup.
+    """
+    return TriggerEvent(
+        source=ARTIFACT_TRIGGER_SOURCE,
+        timestamp=float(event.timestamp),
+        raw_payload=dict(event.to_payload()),
+        sender=event.actor,
+        changed_files=(event.uri,),
+        message=f"artifact produced: {event.uri}",
+        metadata={
+            "uri": event.uri,
+            "entry_hash": event.entry_hash,
+            "content_hash": event.content_hash,
+            "run_id": event.run_id,
+            "model": event.model,
+            "verified": event.verified,
+        },
+    )
+
+
+def intended_fires(
+    entries: Iterable[SpineEntry],
+    *,
+    run_id: str,
+    hmac_key: bytes,
+    patterns: Sequence[str] = (),
+    require_verified: bool = True,
+) -> list[ArtifactProductionEvent]:
+    """Return the events a run's spine says should have fired, in order. Pure.
+
+    Args:
+        entries: The run's spine entries, in append order.
+        run_id: The run the entries belong to.
+        hmac_key: Audit-chain key, used to recompute each entry's integrity.
+        patterns: Artifact key patterns to fire on. Empty means every produced
+            artifact.
+        require_verified: Drop entries whose integrity verdict is false. On by
+            default: a firing caused by a tampered record is worse than a
+            firing that never happened.
+
+    Returns:
+        The intended fire set. The run's own journal seal is excluded -- it is
+        the run recording itself, not an output anything should react to.
+    """
+    events = project_production_events(entries, run_id=run_id, hmac_key=hmac_key)
+    out: list[ArtifactProductionEvent] = []
+    for event in events:
+        if event.is_journal_seal:
+            continue
+        if require_verified and not event.verified:
+            continue
+        if patterns and not matches_any(patterns, event.uri):
+            continue
+        out.append(event)
+    return out
+
+
+def fire_divergences(
+    lineage_root: Path,
+    *,
+    run_id: str,
+    hmac_key: bytes,
+) -> list[FanoutDivergence]:
+    """Compare a run's journaled fan-out against the one its spine implies.
+
+    An intact run yields an empty list. A dropped, duplicated or altered firing
+    is reported as a divergence naming the offending spine ``entry_hash``, which
+    is the difference between "a trigger did not fire" as a mystery and as a
+    lookup.
+    """
+    journaled = load_production_events(lineage_root, run_id=run_id)
+    replayed = replay_production_events(lineage_root, run_id=run_id, hmac_key=hmac_key)
+    return compare_fanout(journaled, replayed)
+
+
+class ArtifactSource:
+    """Trigger source adapter for artifact production events.
+
+    Stateless: the orchestrator hands it a raw event payload (from the SSE bus
+    or read back from the journal) and gets a normalized
+    :class:`TriggerEvent`. Any state a consumer needs is in the spine.
+    """
+
+    def normalize(self, raw_event: dict[str, Any]) -> TriggerEvent:
+        """Normalize a raw ``artifact.produced`` payload.
+
+        Raises:
+            ValueError: When the payload is not a well-formed production event.
+                A malformed event is refused rather than fired on a guess.
+        """
+        return normalize_production_event(ArtifactProductionEvent.from_payload(raw_event))

--- a/tests/unit/adapters/test_artifact_production_conformance.py
+++ b/tests/unit/adapters/test_artifact_production_conformance.py
@@ -1,0 +1,286 @@
+"""No opt-in gap: one production event per spine write, every time (#2559, AC8).
+
+``record_artifact_write`` is the single write boundary for per-artifact
+provenance. The point of emitting from *there* rather than from each caller is
+that there is nothing to forget: an adapter cannot record provenance and skip
+the announcement, because the two are one call.
+
+These tests pin the property from both sides:
+
+* the conformance side -- for every adapter in the registry and for every
+  in-process caller of the boundary, ``len(events) == len(spine entries)`` and
+  the hashes line up one for one;
+* the isolation side (AC7) -- the emit path is fail-open, so a broken journal,
+  a broken bus or a hostile subscriber cannot turn a successful artifact write
+  into a failed one.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.adapters.base import (
+    post_write_lineage_hook,
+    record_artifact_write,
+    set_artifact_event_publisher,
+)
+from bernstein.adapters.registry import selectable_adapter_names
+from bernstein.core.lineage.artifact_events import (
+    load_production_events,
+    replay_production_events,
+)
+from bernstein.core.lineage.spine import LineageSpine
+
+_KEY = b"c" * 32
+_RUN = "run-conformance"
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_publisher() -> object:
+    """Keep a publisher installed by another test out of these assertions."""
+    set_artifact_event_publisher(None)
+    yield
+    set_artifact_event_publisher(None)
+
+
+def _root(tmp_path: Path) -> Path:
+    return tmp_path / ".sdd" / "lineage"
+
+
+def _entries(tmp_path: Path, run_id: str = _RUN) -> list[object]:
+    return list(LineageSpine(_root(tmp_path), run_id=run_id, hmac_key=_KEY).iter_entries())
+
+
+def _write(tmp_path: Path, *, path: str, actor: str, run_id: str = _RUN, ts: int = 1) -> str | None:
+    return record_artifact_write(
+        artifact_path=path,
+        content=f"bytes-for-{path}".encode(),
+        actor=actor,
+        step_id="step",
+        model="model-x",
+        lineage_root=_root(tmp_path),
+        run_id=run_id,
+        hmac_key=_KEY,
+        timestamp=ts,
+    )
+
+
+# ---------------------------------------------------------------------------
+# One event per write, across adapters
+# ---------------------------------------------------------------------------
+
+
+def test_every_registered_adapter_emits_exactly_one_event_per_write(tmp_path: Path) -> None:
+    """The boundary is shared, so no adapter can be the one that forgets."""
+    names = sorted(selectable_adapter_names())
+    assert names, "adapter registry should not be empty"
+
+    for i, name in enumerate(names):
+        _write(tmp_path, path=f"out/{name}.txt", actor=name, ts=i)
+
+    events = load_production_events(_root(tmp_path), run_id=_RUN)
+    entries = _entries(tmp_path)
+    assert len(events) == len(entries) == len(names)
+    assert [e.actor for e in events] == names
+    assert [e.entry_hash for e in events] == [entry.entry_hash for entry in entries]  # type: ignore[attr-defined]
+
+
+def test_one_write_emits_exactly_one_event(tmp_path: Path) -> None:
+    entry_hash = _write(tmp_path, path="dist/pkg.whl", actor="claude")
+    events = load_production_events(_root(tmp_path), run_id=_RUN)
+    assert len(events) == 1
+    assert events[0].entry_hash == entry_hash
+
+
+def test_repeated_writes_of_the_same_key_each_emit(tmp_path: Path) -> None:
+    """Idempotence is not assumed: a second write is a second production."""
+    for i in range(3):
+        _write(tmp_path, path="dist/pkg.whl", actor="claude", ts=i)
+    assert len(load_production_events(_root(tmp_path), run_id=_RUN)) == 3
+
+
+def test_external_uri_writes_emit_like_repo_path_writes(tmp_path: Path) -> None:
+    for i, key in enumerate(
+        [
+            "pr://github.com/acme/widget/2559",
+            "pkg://pypi/bernstein/3.9.0",
+            "deploy://prod/docs-site",
+            "doc://example.test/lineage/artifacts",
+            "src/bernstein/core/lineage/spine.py",
+        ]
+    ):
+        _write(tmp_path, path=key, actor="claude", ts=i)
+    events = load_production_events(_root(tmp_path), run_id=_RUN)
+    assert len(events) == 5
+    assert [e.uri for e in events] == [
+        "pr://github.com/acme/widget/2559",
+        "pkg://pypi/bernstein/3.9.0",
+        "deploy://prod/docs-site",
+        "doc://example.test/lineage/artifacts",
+        "src/bernstein/core/lineage/spine.py",
+    ]
+
+
+def test_the_deprecated_v1_shim_emits_too(tmp_path: Path) -> None:
+    """The shim routes through the boundary, so it inherits the guarantee."""
+    from bernstein.core.lineage.identity import AgentCard, generate_keypair
+
+    private_pem, public_pem = generate_keypair()
+    card = AgentCard(agent_id="agent-1", public_key_pem=public_pem, kid="kid-1")
+    post_write_lineage_hook(
+        artefact_path="docs/report.md",
+        new_content=b"report",
+        agent_id="agent-1",
+        agent_card=card,
+        private_key_pem=private_pem,
+        tool_call_id="call-1",
+        span_id="span-1",
+        lineage_root=_root(tmp_path),
+        operator_hmac_key=_KEY,
+        run_id=_RUN,
+    )
+    assert len(load_production_events(_root(tmp_path), run_id=_RUN)) == 1
+
+
+def test_a_rejected_write_emits_nothing(tmp_path: Path) -> None:
+    """No spine entry, no event: the two stay in lockstep on the refusal path."""
+    with pytest.raises(ValueError, match="path traversal"):
+        _write(tmp_path, path="../etc/passwd", actor="claude")
+    assert load_production_events(_root(tmp_path), run_id=_RUN) == []
+
+
+def test_the_disabled_gate_records_and_emits_nothing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BERNSTEIN_LINEAGE_ENABLED", "0")
+    assert _write(tmp_path, path="dist/pkg.whl", actor="claude") is None
+    assert load_production_events(_root(tmp_path), run_id=_RUN) == []
+
+
+def test_events_and_entries_stay_paired_across_runs(tmp_path: Path) -> None:
+    _write(tmp_path, path="a.txt", actor="claude", run_id="run-a", ts=1)
+    _write(tmp_path, path="b.txt", actor="codex", run_id="run-b", ts=2)
+    for run_id, uri in (("run-a", "a.txt"), ("run-b", "b.txt")):
+        events = load_production_events(_root(tmp_path), run_id=run_id)
+        assert [e.uri for e in events] == [uri]
+        assert len(_entries(tmp_path, run_id)) == 1
+
+
+def test_the_journaled_set_equals_the_replayed_set(tmp_path: Path) -> None:
+    """The conformance property restated as replay equality."""
+    for i, name in enumerate(sorted(selectable_adapter_names())[:8]):
+        _write(tmp_path, path=f"out/{name}.txt", actor=name, ts=i)
+    journaled = load_production_events(_root(tmp_path), run_id=_RUN)
+    replayed = replay_production_events(_root(tmp_path), run_id=_RUN, hmac_key=_KEY)
+    assert [e.canonical_bytes() for e in journaled] == [e.canonical_bytes() for e in replayed]
+
+
+# ---------------------------------------------------------------------------
+# In-process callers of the boundary
+# ---------------------------------------------------------------------------
+
+
+def test_journal_seal_write_emits_one_event(tmp_path: Path) -> None:
+    from bernstein.core.replay.journal import EventJournal, seal_journal_into_spine
+
+    sdd = tmp_path / ".sdd"
+    journal = EventJournal("run-seal", sdd)
+    journal.record("step.started", step="one")
+    seal_journal_into_spine(
+        journal=journal,
+        lineage_root=_root(tmp_path),
+        hmac_key=_KEY,
+        actor="orchestrator",
+    )
+    events = load_production_events(_root(tmp_path), run_id="run-seal")
+    assert len(events) == 1
+    assert events[0].is_journal_seal
+
+
+def test_mcp_trace_context_write_emits_one_event(tmp_path: Path) -> None:
+    from bernstein.core.protocols.mcp.tasks_extension import (
+        TraceContext,
+        record_trace_context_into_lineage,
+    )
+
+    trace = TraceContext(
+        trace_id="0af7651916cd43dd8448eb211c80319c",
+        parent_id="b7ad6b7169203331",
+        trace_flags="01",
+    )
+    record_trace_context_into_lineage(
+        trace=trace,
+        artifact_path="docs/report.md",
+        content=b"report",
+        actor="mcp-host",
+        run_id="run-mcp",
+        lineage_root=_root(tmp_path),
+        hmac_key=_KEY,
+        timestamp=1,
+    )
+    events = load_production_events(_root(tmp_path), run_id="run-mcp")
+    assert len(events) == 1
+    assert events[0].uri == "docs/report.md"
+
+
+# ---------------------------------------------------------------------------
+# Failure-domain isolation (AC7)
+# ---------------------------------------------------------------------------
+
+
+def test_a_journal_write_failure_does_not_fail_the_artifact_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _boom(*_a: object, **_k: object) -> None:
+        raise OSError("read-only file system")
+
+    monkeypatch.setattr("bernstein.core.lineage.artifact_events.append_production_event", _boom)
+    entry_hash = _write(tmp_path, path="dist/pkg.whl", actor="claude")
+
+    # The write succeeded and the provenance is durable ...
+    assert entry_hash is not None
+    assert len(_entries(tmp_path)) == 1
+    # ... the journal simply lost a row, which replay rebuilds from the spine.
+    assert load_production_events(_root(tmp_path), run_id=_RUN) == []
+    replayed = replay_production_events(_root(tmp_path), run_id=_RUN, hmac_key=_KEY)
+    assert [e.entry_hash for e in replayed] == [entry_hash]
+
+
+def test_a_hostile_subscriber_does_not_fail_the_artifact_write(tmp_path: Path) -> None:
+    def _hostile(_event: object) -> None:
+        raise RuntimeError("subscriber raised")
+
+    set_artifact_event_publisher(_hostile)
+    entry_hash = _write(tmp_path, path="dist/pkg.whl", actor="claude")
+    assert entry_hash is not None
+    # Journaling and publishing fail apart: the row is still on disk.
+    assert len(load_production_events(_root(tmp_path), run_id=_RUN)) == 1
+
+
+def test_a_subscriber_that_hangs_up_leaves_the_chain_intact(tmp_path: Path) -> None:
+    delivered: list[str] = []
+
+    def _flaky(event: object) -> None:
+        uri = getattr(event, "uri", "")
+        if uri.endswith("2.txt"):
+            raise ConnectionResetError("bus went away")
+        delivered.append(uri)
+
+    set_artifact_event_publisher(_flaky)
+    for i in range(4):
+        _write(tmp_path, path=f"out/{i}.txt", actor="claude", ts=i)
+
+    assert delivered == ["out/0.txt", "out/1.txt", "out/3.txt"]
+    # Every write still landed, and every one is journaled.
+    assert len(_entries(tmp_path)) == 4
+    assert len(load_production_events(_root(tmp_path), run_id=_RUN)) == 4
+
+
+def test_the_publisher_receives_the_journaled_payload_verbatim(tmp_path: Path) -> None:
+    seen: list[dict[str, object]] = []
+    set_artifact_event_publisher(lambda event: seen.append(event.to_payload()))
+    _write(tmp_path, path="dist/pkg.whl", actor="claude")
+
+    journal_path = _root(tmp_path) / _RUN / "artifact-events.jsonl"
+    assert seen == [json.loads(journal_path.read_bytes().strip())]

--- a/tests/unit/adapters/test_base_lineage_hook.py
+++ b/tests/unit/adapters/test_base_lineage_hook.py
@@ -18,7 +18,7 @@ from bernstein.adapters.base import (
     post_write_lineage_hook,
 )
 from bernstein.core.lineage.identity import AgentCard, generate_keypair
-from bernstein.core.lineage.spine import LineageSpine
+from bernstein.core.lineage.spine import LineageSpine, SpineEntry
 
 
 @pytest.fixture
@@ -113,7 +113,9 @@ def test_hook_fails_closed_when_enabled(
     from bernstein.adapters import base as base_module
 
     class _BoomSpine(LineageSpine):
-        def record(self, **_kw: object) -> str:  # type: ignore[override]
+        # The boundary appends through ``record_entry`` (issue #2559) so it can
+        # project the production event off the entry it just wrote.
+        def record_entry(self, **_kw: object) -> SpineEntry:  # type: ignore[override]
             raise RuntimeError("disk on fire")
 
     monkeypatch.setattr(base_module, "LineageSpine", _BoomSpine)

--- a/tests/unit/adapters/test_base_spine_writes.py
+++ b/tests/unit/adapters/test_base_spine_writes.py
@@ -22,7 +22,7 @@ from bernstein.adapters.base import (
     record_artifact_write,
 )
 from bernstein.adapters.registry import iter_adapter_specs
-from bernstein.core.lineage.spine import LineageSpine, SpineStatus
+from bernstein.core.lineage.spine import LineageSpine, SpineEntry, SpineStatus
 
 _KEY = b"k" * 32
 
@@ -120,7 +120,9 @@ def test_enabled_write_failure_fails_closed(tmp_path: Path, monkeypatch: pytest.
     from bernstein.adapters import base as base_module
 
     class _BoomSpine(LineageSpine):
-        def record(self, **_kw: object) -> str:  # type: ignore[override]
+        # The boundary appends through ``record_entry`` (issue #2559) so it can
+        # project the production event off the entry it just wrote.
+        def record_entry(self, **_kw: object) -> SpineEntry:  # type: ignore[override]
             raise RuntimeError("disk on fire")
 
     monkeypatch.setattr(base_module, "LineageSpine", _BoomSpine)

--- a/tests/unit/lineage/test_artifact_events.py
+++ b/tests/unit/lineage/test_artifact_events.py
@@ -1,0 +1,335 @@
+"""Production events are a pure, replayable projection of the spine (#2559).
+
+Covers the substrate the Phase-4 acceptance criteria stand on:
+
+* the event is a function of the spine entry alone -- nothing ambient leaks in,
+  so replaying reproduces byte-identical events;
+* a single-byte mutation of any spine row flips the *replayed* event to
+  ``verified: false`` while the journaled row still claims ``true``, and the
+  disagreement is reported as a named divergence;
+* the emit path never raises, whatever the filesystem or a subscriber does.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.lineage.artifact_events import (
+    ARTIFACT_EVENTS_FILENAME,
+    DIVERGENCE_ALTERED,
+    DIVERGENCE_DROPPED,
+    DIVERGENCE_DUPLICATED,
+    DIVERGENCE_UNEXPECTED,
+    ArtifactProductionEvent,
+    append_production_event,
+    compare_fanout,
+    emit_production_event,
+    load_production_events,
+    observed_artifact_keys,
+    project_production_event,
+    replay_production_events,
+)
+from bernstein.core.lineage.spine import JOURNAL_SEAL_STEP_PREFIX, LineageSpine, SpineEntry
+
+_KEY = b"k" * 32
+_RUN = "run-events"
+
+
+def _spine(tmp_path: Path, run_id: str = _RUN) -> LineageSpine:
+    return LineageSpine(tmp_path / ".sdd" / "lineage", run_id=run_id, hmac_key=_KEY)
+
+
+def _root(tmp_path: Path) -> Path:
+    return tmp_path / ".sdd" / "lineage"
+
+
+def _record(spine: LineageSpine, path: str, content: bytes, *, ts: int, step_id: str = "step") -> SpineEntry:
+    return spine.record_entry(
+        artifact_path=path,
+        content=content,
+        actor="agent-a",
+        step_id=step_id,
+        model="model-x",
+        timestamp=ts,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The projection is pure
+# ---------------------------------------------------------------------------
+
+
+def test_event_is_a_function_of_the_entry_alone(tmp_path: Path) -> None:
+    """Two projections of one entry are byte-identical."""
+    entry = _record(_spine(tmp_path), "docs/report.md", b"one", ts=10)
+    a = project_production_event(entry, run_id=_RUN, verified=True)
+    b = project_production_event(entry, run_id=_RUN, verified=True)
+    assert a == b
+    assert a.canonical_bytes() == b.canonical_bytes()
+
+
+def test_projection_copies_every_provenance_field(tmp_path: Path) -> None:
+    entry = _record(_spine(tmp_path), "pkg://pypi/bernstein/3.9.0", b"wheel", ts=42, step_id="s-7")
+    event = project_production_event(entry, run_id=_RUN, verified=True)
+    assert event.uri == "pkg://pypi/bernstein/3.9.0"
+    assert event.entry_hash == entry.entry_hash
+    assert event.content_hash == entry.content_hash
+    assert event.actor == "agent-a"
+    assert event.model == "model-x"
+    assert event.step_id == "s-7"
+    assert event.run_id == _RUN
+    assert event.timestamp == 42
+
+
+def test_payload_round_trips_through_the_journal_form(tmp_path: Path) -> None:
+    entry = _record(_spine(tmp_path), "a.txt", b"x", ts=1)
+    event = project_production_event(entry, run_id=_RUN, verified=True)
+    assert ArtifactProductionEvent.from_payload(json.loads(event.canonical_bytes())) == event
+
+
+def test_unknown_wire_version_is_refused_not_guessed(tmp_path: Path) -> None:
+    entry = _record(_spine(tmp_path), "a.txt", b"x", ts=1)
+    row = json.loads(project_production_event(entry, run_id=_RUN, verified=True).canonical_bytes())
+    row["v"] = 99
+    with pytest.raises(ValueError, match="unsupported artifact event version"):
+        ArtifactProductionEvent.from_payload(row)
+
+
+# ---------------------------------------------------------------------------
+# Journal IO
+# ---------------------------------------------------------------------------
+
+
+def test_journal_preserves_append_order(tmp_path: Path) -> None:
+    spine = _spine(tmp_path)
+    for i, name in enumerate(["a.txt", "b.txt", "c.txt"]):
+        entry = _record(spine, name, f"v{i}".encode(), ts=i)
+        emit_production_event(_root(tmp_path), run_id=_RUN, entry=entry)
+    assert [e.uri for e in load_production_events(_root(tmp_path), run_id=_RUN)] == ["a.txt", "b.txt", "c.txt"]
+
+
+def test_journal_lives_beside_the_spine(tmp_path: Path) -> None:
+    entry = _record(_spine(tmp_path), "a.txt", b"x", ts=1)
+    emit_production_event(_root(tmp_path), run_id=_RUN, entry=entry)
+    assert (_root(tmp_path) / _RUN / ARTIFACT_EVENTS_FILENAME).is_file()
+    assert (_root(tmp_path) / _RUN / "spine.jsonl").is_file()
+
+
+def test_malformed_journal_row_is_skipped_not_fatal(tmp_path: Path) -> None:
+    entry = _record(_spine(tmp_path), "a.txt", b"x", ts=1)
+    emit_production_event(_root(tmp_path), run_id=_RUN, entry=entry)
+    path = _root(tmp_path) / _RUN / ARTIFACT_EVENTS_FILENAME
+    path.write_bytes(b"{not json}\n" + path.read_bytes())
+    # The good row survives: a corrupt index must never stop a verifier from
+    # reaching the spine, which is the thing that actually decides.
+    assert [e.uri for e in load_production_events(_root(tmp_path), run_id=_RUN)] == ["a.txt"]
+
+
+def test_missing_journal_reads_as_empty(tmp_path: Path) -> None:
+    assert load_production_events(_root(tmp_path), run_id="never-ran") == []
+
+
+def test_run_id_escaping_its_directory_is_refused(tmp_path: Path) -> None:
+    entry = _record(_spine(tmp_path), "a.txt", b"x", ts=1)
+    with pytest.raises(ValueError, match="path separator"):
+        append_production_event(
+            _root(tmp_path),
+            run_id="../escape",
+            event=project_production_event(entry, run_id="x", verified=True),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fail-open (AC7)
+# ---------------------------------------------------------------------------
+
+
+def test_emit_never_raises_when_the_journal_cannot_be_written(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    entry = _record(_spine(tmp_path), "a.txt", b"x", ts=1)
+
+    def _boom(*_a: object, **_k: object) -> None:
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr("bernstein.core.lineage.artifact_events.append_production_event", _boom)
+    # Returns the event regardless: the spine entry is already durable and the
+    # event set is re-derivable, so a journal failure loses latency, not facts.
+    assert emit_production_event(_root(tmp_path), run_id=_RUN, entry=entry) is not None
+
+
+def test_emit_never_raises_when_a_subscriber_explodes(tmp_path: Path) -> None:
+    entry = _record(_spine(tmp_path), "a.txt", b"x", ts=1)
+
+    def _bad_subscriber(_event: object) -> None:
+        raise RuntimeError("subscriber is on fire")
+
+    event = emit_production_event(_root(tmp_path), run_id=_RUN, entry=entry, publish=_bad_subscriber)
+    assert event is not None
+    # The journal still got the row: publishing and journaling fail apart.
+    assert len(load_production_events(_root(tmp_path), run_id=_RUN)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Replay and tamper (AC2)
+# ---------------------------------------------------------------------------
+
+
+def test_replay_reproduces_the_journal_exactly(tmp_path: Path) -> None:
+    spine = _spine(tmp_path)
+    for i in range(4):
+        entry = _record(spine, f"f{i}.txt", f"c{i}".encode(), ts=i)
+        emit_production_event(_root(tmp_path), run_id=_RUN, entry=entry)
+
+    journaled = load_production_events(_root(tmp_path), run_id=_RUN)
+    replayed = replay_production_events(_root(tmp_path), run_id=_RUN, hmac_key=_KEY)
+    assert [e.canonical_bytes() for e in journaled] == [e.canonical_bytes() for e in replayed]
+    assert compare_fanout(journaled, replayed) == []
+
+
+@pytest.mark.parametrize("field", ["content_hash", "actor", "model", "artifact_path", "hmac"])
+def test_single_byte_flip_replays_as_unverified(tmp_path: Path, field: str) -> None:
+    """AC2: flip one byte of a spine row and the event replays ``verified: false``."""
+    spine = _spine(tmp_path)
+    entry = _record(spine, "docs/report.md", b"payload", ts=7)
+    emit_production_event(_root(tmp_path), run_id=_RUN, entry=entry)
+
+    spine_path = _root(tmp_path) / _RUN / "spine.jsonl"
+    row = json.loads(spine_path.read_bytes().strip())
+    row[field] = row[field][:-1] + ("0" if row[field][-1] != "0" else "1")
+    spine_path.write_bytes(json.dumps(row, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode() + b"\n")
+
+    replayed = replay_production_events(_root(tmp_path), run_id=_RUN, hmac_key=_KEY)
+    assert [e.verified for e in replayed] == [False]
+
+
+def test_tamper_surfaces_as_an_altered_divergence_naming_the_entry(tmp_path: Path) -> None:
+    spine = _spine(tmp_path)
+    entry = _record(spine, "docs/report.md", b"payload", ts=7)
+    emit_production_event(_root(tmp_path), run_id=_RUN, entry=entry)
+
+    spine_path = _root(tmp_path) / _RUN / "spine.jsonl"
+    row = json.loads(spine_path.read_bytes().strip())
+    row["actor"] = "someone-else"
+    spine_path.write_bytes(json.dumps(row, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode() + b"\n")
+
+    divergences = compare_fanout(
+        load_production_events(_root(tmp_path), run_id=_RUN),
+        replay_production_events(_root(tmp_path), run_id=_RUN, hmac_key=_KEY),
+    )
+    assert [d.kind for d in divergences] == [DIVERGENCE_ALTERED]
+    assert divergences[0].entry_hash == entry.entry_hash
+
+
+def test_a_wrong_hmac_key_marks_every_event_unverified(tmp_path: Path) -> None:
+    spine = _spine(tmp_path)
+    _record(spine, "a.txt", b"x", ts=1)
+    replayed = replay_production_events(_root(tmp_path), run_id=_RUN, hmac_key=b"a-different-key")
+    assert [e.verified for e in replayed] == [False]
+
+
+# ---------------------------------------------------------------------------
+# Divergence kinds (AC3)
+# ---------------------------------------------------------------------------
+
+
+def test_dropped_firing_is_reported_and_names_the_entry(tmp_path: Path) -> None:
+    spine = _spine(tmp_path)
+    kept = _record(spine, "a.txt", b"a", ts=1)
+    dropped = _record(spine, "b.txt", b"b", ts=2)
+    emit_production_event(_root(tmp_path), run_id=_RUN, entry=kept)
+    # `dropped` never reaches the journal, as if the emit had been lost.
+
+    divergences = compare_fanout(
+        load_production_events(_root(tmp_path), run_id=_RUN),
+        replay_production_events(_root(tmp_path), run_id=_RUN, hmac_key=_KEY),
+    )
+    assert [(d.kind, d.entry_hash) for d in divergences] == [(DIVERGENCE_DROPPED, dropped.entry_hash)]
+
+
+def test_duplicated_firing_is_reported_and_names_the_entry(tmp_path: Path) -> None:
+    spine = _spine(tmp_path)
+    entry = _record(spine, "a.txt", b"a", ts=1)
+    emit_production_event(_root(tmp_path), run_id=_RUN, entry=entry)
+    emit_production_event(_root(tmp_path), run_id=_RUN, entry=entry)
+
+    divergences = compare_fanout(
+        load_production_events(_root(tmp_path), run_id=_RUN),
+        replay_production_events(_root(tmp_path), run_id=_RUN, hmac_key=_KEY),
+    )
+    assert [(d.kind, d.entry_hash) for d in divergences] == [(DIVERGENCE_DUPLICATED, entry.entry_hash)]
+
+
+def test_journaled_event_with_no_spine_entry_is_unexpected(tmp_path: Path) -> None:
+    spine = _spine(tmp_path)
+    entry = _record(spine, "a.txt", b"a", ts=1)
+    forged = project_production_event(entry, run_id=_RUN, verified=True).__class__(
+        uri="pkg://pypi/ghost/1.0",
+        entry_hash="sha256:" + "f" * 64,
+        content_hash="sha256:" + "e" * 64,
+        actor="nobody",
+        model="",
+        step_id="",
+        run_id=_RUN,
+        timestamp=99,
+        verified=True,
+    )
+    emit_production_event(_root(tmp_path), run_id=_RUN, entry=entry)
+    append_production_event(_root(tmp_path), run_id=_RUN, event=forged)
+
+    divergences = compare_fanout(
+        load_production_events(_root(tmp_path), run_id=_RUN),
+        replay_production_events(_root(tmp_path), run_id=_RUN, hmac_key=_KEY),
+    )
+    assert [(d.kind, d.entry_hash) for d in divergences] == [(DIVERGENCE_UNEXPECTED, forged.entry_hash)]
+
+
+def test_divergence_order_is_deterministic(tmp_path: Path) -> None:
+    spine = _spine(tmp_path)
+    entries = [_record(spine, f"f{i}.txt", f"c{i}".encode(), ts=i) for i in range(5)]
+    emit_production_event(_root(tmp_path), run_id=_RUN, entry=entries[0])
+
+    journaled = load_production_events(_root(tmp_path), run_id=_RUN)
+    replayed = replay_production_events(_root(tmp_path), run_id=_RUN, hmac_key=_KEY)
+    first = [d.to_dict() for d in compare_fanout(journaled, replayed)]
+    second = [d.to_dict() for d in compare_fanout(journaled, replayed)]
+    assert first == second
+    assert first == sorted(first, key=lambda d: (d["kind"], d["entry_hash"]))
+
+
+# ---------------------------------------------------------------------------
+# Observation
+# ---------------------------------------------------------------------------
+
+
+def test_observed_keys_exclude_the_runs_own_journal_seal(tmp_path: Path) -> None:
+    spine = _spine(tmp_path)
+    deliverable = _record(spine, "dist/pkg.whl", b"wheel", ts=1)
+    seal = _record(
+        spine,
+        f".sdd/runs/{_RUN}/journal.jsonl",
+        b"journal",
+        ts=2,
+        step_id=f"{JOURNAL_SEAL_STEP_PREFIX}sha256:abc",
+    )
+    for entry in (deliverable, seal):
+        emit_production_event(_root(tmp_path), run_id=_RUN, entry=entry)
+
+    # Both are journaled -- the boundary has no exceptions (AC8) ...
+    assert len(load_production_events(_root(tmp_path), run_id=_RUN)) == 2
+    # ... but the run recording itself is not something the run produced.
+    assert observed_artifact_keys(_root(tmp_path), run_id=_RUN) == ("dist/pkg.whl",)
+
+
+def test_observed_keys_are_sorted_and_deduplicated(tmp_path: Path) -> None:
+    spine = _spine(tmp_path)
+    for i, name in enumerate(["z.txt", "a.txt", "z.txt"]):
+        entry = _record(spine, name, f"c{i}".encode(), ts=i)
+        emit_production_event(_root(tmp_path), run_id=_RUN, entry=entry)
+    assert observed_artifact_keys(_root(tmp_path), run_id=_RUN) == ("a.txt", "z.txt")
+
+
+def test_no_production_is_an_empty_tuple_not_an_error(tmp_path: Path) -> None:
+    """An empty observation is a genuine observation, distinct from ``None``."""
+    assert observed_artifact_keys(_root(tmp_path), run_id="quiet-run") == ()

--- a/tests/unit/lineage/test_artifact_fanout_replay.py
+++ b/tests/unit/lineage/test_artifact_fanout_replay.py
@@ -1,0 +1,252 @@
+"""Replayable fan-out: the fire set is a function of the spine (#2559, AC3).
+
+Replaying a fixture spine has to reproduce the exact intended trigger fire set
+recorded in the journal, and a synthetically dropped or duplicated firing has to
+be reported as a divergence naming the offending ``entry_hash``. That is only
+possible because :func:`intended_fires` is pure: it reads spine entries and
+patterns, nothing else. No clock, no subscriber state, no "was the orchestrator
+listening at the time".
+
+Also pinned here: an artifact production normalises into the same
+:class:`TriggerEvent` shape every other source emits, so artifact rules go
+through the existing rule matching with no second matching engine.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.lineage.artifact_events import (
+    DIVERGENCE_ALTERED,
+    DIVERGENCE_DROPPED,
+    DIVERGENCE_DUPLICATED,
+    emit_production_event,
+)
+from bernstein.core.lineage.spine import JOURNAL_SEAL_STEP_PREFIX, LineageSpine, SpineEntry
+from bernstein.core.trigger_sources.artifact import (
+    ARTIFACT_TRIGGER_SOURCE,
+    ArtifactSource,
+    fire_divergences,
+    intended_fires,
+    matches_any,
+    normalize_production_event,
+)
+
+_KEY = b"f" * 32
+_RUN = "run-fanout"
+
+
+def _root(tmp_path: Path) -> Path:
+    return tmp_path / ".sdd" / "lineage"
+
+
+def _spine(tmp_path: Path) -> LineageSpine:
+    return LineageSpine(_root(tmp_path), run_id=_RUN, hmac_key=_KEY)
+
+
+def _record(spine: LineageSpine, uri: str, content: bytes, *, ts: int, step_id: str = "publish") -> SpineEntry:
+    return spine.record_entry(
+        artifact_path=uri,
+        content=content,
+        actor="agent-release",
+        step_id=step_id,
+        model="claude-opus-5",
+        timestamp=ts,
+    )
+
+
+def _fixture_spine(tmp_path: Path) -> list[SpineEntry]:
+    """A small run: two packages, a PR, a doc, and the run's own journal seal."""
+    spine = _spine(tmp_path)
+    entries = [
+        _record(spine, "pkg://pypi/bernstein/3.9.0", b"wheel-a", ts=1),
+        _record(spine, "pr://github.com/acme/widget/2559", b"head-1", ts=2),
+        _record(spine, "pkg://pypi/bernstein/3.9.1", b"wheel-b", ts=3),
+        _record(spine, "doc://example.test/lineage", b"page", ts=4),
+        _record(
+            spine,
+            f".sdd/runs/{_RUN}/journal.jsonl",
+            b"journal",
+            ts=5,
+            step_id=f"{JOURNAL_SEAL_STEP_PREFIX}sha256:abc",
+        ),
+    ]
+    for entry in entries:
+        emit_production_event(_root(tmp_path), run_id=_RUN, entry=entry)
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# The fire set is a pure projection
+# ---------------------------------------------------------------------------
+
+
+def test_replaying_the_spine_reproduces_the_identical_fire_set(tmp_path: Path) -> None:
+    entries = _fixture_spine(tmp_path)
+    first = intended_fires(entries, run_id=_RUN, hmac_key=_KEY)
+    second = intended_fires(entries, run_id=_RUN, hmac_key=_KEY)
+    assert [e.canonical_bytes() for e in first] == [e.canonical_bytes() for e in second]
+
+
+def test_the_runs_own_journal_seal_never_fires(tmp_path: Path) -> None:
+    """The run recording itself is not an output anything should react to."""
+    entries = _fixture_spine(tmp_path)
+    fires = intended_fires(entries, run_id=_RUN, hmac_key=_KEY)
+    assert all(not e.is_journal_seal for e in fires)
+    assert len(fires) == len(entries) - 1
+
+
+def test_patterns_narrow_the_fire_set(tmp_path: Path) -> None:
+    entries = _fixture_spine(tmp_path)
+    fires = intended_fires(entries, run_id=_RUN, hmac_key=_KEY, patterns=["pkg://pypi/bernstein/*"])
+    assert [e.uri for e in fires] == ["pkg://pypi/bernstein/3.9.0", "pkg://pypi/bernstein/3.9.1"]
+
+
+def test_an_empty_pattern_list_fires_on_everything_produced(tmp_path: Path) -> None:
+    entries = _fixture_spine(tmp_path)
+    assert len(intended_fires(entries, run_id=_RUN, hmac_key=_KEY, patterns=[])) == 4
+
+
+def test_a_malformed_pattern_matches_nothing_instead_of_raising(tmp_path: Path) -> None:
+    entries = _fixture_spine(tmp_path)
+    fires = intended_fires(entries, run_id=_RUN, hmac_key=_KEY, patterns=["ftp://evil.test/*", "../etc/passwd"])
+    assert fires == []
+
+
+def test_fire_order_follows_append_order(tmp_path: Path) -> None:
+    entries = _fixture_spine(tmp_path)
+    fires = intended_fires(entries, run_id=_RUN, hmac_key=_KEY)
+    assert [e.timestamp for e in fires] == [1, 2, 3, 4]
+
+
+def test_matches_any_uses_the_canonical_matcher() -> None:
+    assert matches_any(["pkg://pypi/bernstein/*"], "pkg://pypi/bernstein/3.9.0")
+    assert not matches_any(["pkg://pypi/other/*"], "pkg://pypi/bernstein/3.9.0")
+    assert matches_any(["docs/**/*.md"], "docs/nested/page.md")
+    assert not matches_any(["not a key ://"], "pkg://pypi/bernstein/3.9.0")
+
+
+# ---------------------------------------------------------------------------
+# A tampered record cannot cause work
+# ---------------------------------------------------------------------------
+
+
+def test_an_unverified_entry_does_not_fire_by_default(tmp_path: Path) -> None:
+    entries = _fixture_spine(tmp_path)
+    # Replay under the wrong key: every entry fails per-entry verification.
+    assert intended_fires(entries, run_id=_RUN, hmac_key=b"wrong-key") == []
+
+
+def test_unverified_entries_can_be_inspected_when_explicitly_asked_for(tmp_path: Path) -> None:
+    entries = _fixture_spine(tmp_path)
+    fires = intended_fires(entries, run_id=_RUN, hmac_key=b"wrong-key", require_verified=False)
+    assert len(fires) == 4
+    assert all(not e.verified for e in fires)
+
+
+# ---------------------------------------------------------------------------
+# Divergence naming (AC3)
+# ---------------------------------------------------------------------------
+
+
+def test_an_intact_run_reports_no_divergence(tmp_path: Path) -> None:
+    _fixture_spine(tmp_path)
+    assert fire_divergences(_root(tmp_path), run_id=_RUN, hmac_key=_KEY) == []
+
+
+def test_a_dropped_firing_names_the_offending_entry_hash(tmp_path: Path) -> None:
+    entries = _fixture_spine(tmp_path)
+    events_path = _root(tmp_path) / _RUN / "artifact-events.jsonl"
+    rows = events_path.read_bytes().strip().split(b"\n")
+    # Synthetically drop the third firing, as if the emit had been lost.
+    events_path.write_bytes(b"\n".join(rows[:2] + rows[3:]) + b"\n")
+
+    divergences = fire_divergences(_root(tmp_path), run_id=_RUN, hmac_key=_KEY)
+    assert [(d.kind, d.entry_hash) for d in divergences] == [(DIVERGENCE_DROPPED, entries[2].entry_hash)]
+    assert "pkg://pypi/bernstein/3.9.1" in divergences[0].detail
+
+
+def test_a_duplicated_firing_names_the_offending_entry_hash(tmp_path: Path) -> None:
+    entries = _fixture_spine(tmp_path)
+    events_path = _root(tmp_path) / _RUN / "artifact-events.jsonl"
+    rows = events_path.read_bytes().strip().split(b"\n")
+    events_path.write_bytes(b"\n".join([*rows, rows[1]]) + b"\n")
+
+    divergences = fire_divergences(_root(tmp_path), run_id=_RUN, hmac_key=_KEY)
+    assert [(d.kind, d.entry_hash) for d in divergences] == [(DIVERGENCE_DUPLICATED, entries[1].entry_hash)]
+
+
+def test_a_tampered_spine_row_diverges_from_its_journaled_firing(tmp_path: Path) -> None:
+    entries = _fixture_spine(tmp_path)
+    spine_path = _root(tmp_path) / _RUN / "spine.jsonl"
+    rows = [json.loads(line) for line in spine_path.read_bytes().strip().split(b"\n")]
+    rows[0]["actor"] = "impostor"
+    spine_path.write_bytes(
+        b"".join(
+            json.dumps(r, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode() + b"\n" for r in rows
+        )
+    )
+
+    divergences = fire_divergences(_root(tmp_path), run_id=_RUN, hmac_key=_KEY)
+    assert (DIVERGENCE_ALTERED, entries[0].entry_hash) in [(d.kind, d.entry_hash) for d in divergences]
+
+
+def test_divergences_are_reported_in_a_stable_order(tmp_path: Path) -> None:
+    _fixture_spine(tmp_path)
+    events_path = _root(tmp_path) / _RUN / "artifact-events.jsonl"
+    rows = events_path.read_bytes().strip().split(b"\n")
+    events_path.write_bytes(b"\n".join([rows[0], rows[0], rows[2]]) + b"\n")
+
+    first = [d.to_dict() for d in fire_divergences(_root(tmp_path), run_id=_RUN, hmac_key=_KEY)]
+    second = [d.to_dict() for d in fire_divergences(_root(tmp_path), run_id=_RUN, hmac_key=_KEY)]
+    assert first == second
+    assert first
+    assert first == sorted(first, key=lambda d: (d["kind"], d["entry_hash"]))
+
+
+# ---------------------------------------------------------------------------
+# Normalisation into the existing trigger surface
+# ---------------------------------------------------------------------------
+
+
+def test_a_production_normalises_into_a_trigger_event(tmp_path: Path) -> None:
+    entries = _fixture_spine(tmp_path)
+    fires = intended_fires(entries, run_id=_RUN, hmac_key=_KEY)
+    event = normalize_production_event(fires[0])
+
+    assert event.source == ARTIFACT_TRIGGER_SOURCE
+    # The key rides in changed_files so path-shaped rule filters see it.
+    assert event.changed_files == ("pkg://pypi/bernstein/3.9.0",)
+    assert event.sender == "agent-release"
+    assert event.metadata["entry_hash"] == entries[0].entry_hash
+    assert event.metadata["verified"] is True
+    assert event.raw_payload["model"] == "claude-opus-5"
+
+
+def test_the_source_adapter_normalises_a_raw_payload(tmp_path: Path) -> None:
+    entries = _fixture_spine(tmp_path)
+    payload = intended_fires(entries, run_id=_RUN, hmac_key=_KEY)[0].to_payload()
+    event = ArtifactSource().normalize(payload)
+    assert event.source == ARTIFACT_TRIGGER_SOURCE
+    assert event.changed_files == ("pkg://pypi/bernstein/3.9.0",)
+
+
+def test_a_malformed_payload_is_refused_rather_than_fired_on(tmp_path: Path) -> None:
+    with pytest.raises((KeyError, ValueError, TypeError)):
+        ArtifactSource().normalize({"uri": "pkg://pypi/x/1.0"})
+
+
+def test_normalisation_is_deterministic(tmp_path: Path) -> None:
+    entries = _fixture_spine(tmp_path)
+    fire = intended_fires(entries, run_id=_RUN, hmac_key=_KEY)[0]
+    a = normalize_production_event(fire)
+    b = normalize_production_event(fire)
+    assert (a.source, a.changed_files, a.metadata, a.raw_payload) == (
+        b.source,
+        b.changed_files,
+        b.metadata,
+        b.raw_payload,
+    )

--- a/tests/unit/lineage/test_artifact_health.py
+++ b/tests/unit/lineage/test_artifact_health.py
@@ -298,6 +298,79 @@ def test_ordering_breaks_ties_on_entry_hash_so_the_tip_is_unambiguous() -> None:
 
 
 # ---------------------------------------------------------------------------
+# The evidence leg reads real sealed bundles
+# ---------------------------------------------------------------------------
+
+
+def _seal_bundle(workdir: Path, task_id: str, *, declared_and_produced: tuple[str, ...], ts: int) -> None:
+    """Seal a real evidence bundle whose signed binding cites ``declared_and_produced``."""
+    from bernstein.core.evidence.bundle import run_evidence_gate
+    from bernstein.core.evidence.output_diff import OutputDiff
+
+    run_evidence_gate(
+        workdir=workdir,
+        task_id=task_id,
+        producers=[],
+        timestamp=ts,
+        hmac_key=_KEY,
+        output_diff=OutputDiff(declared_and_produced=declared_and_produced),
+    )
+
+
+def test_a_verifying_bundle_that_declares_the_artifact_passes_the_leg(tmp_path: Path) -> None:
+    _record(tmp_path, _URI, b"wheel", ts=100)
+    _seal_bundle(tmp_path, "T-release", declared_and_produced=(_URI,), ts=100)
+
+    payload = artifact_health_json(tmp_path, _URI, hmac_key=_KEY, at=500)
+    evidence = _leg(payload, "evidence")
+    assert evidence["status"] == LEG_PASS
+    assert "T-release" in evidence["detail"]
+    assert json.loads(payload)["verdict"] == GREEN
+
+
+def test_a_bundle_that_does_not_declare_the_artifact_is_ignored(tmp_path: Path) -> None:
+    """Association runs through the bundle's *signed* binding, not proximity."""
+    _record(tmp_path, _URI, b"wheel", ts=100)
+    _seal_bundle(tmp_path, "T-other", declared_and_produced=("dist/unrelated.whl",), ts=100)
+
+    assert _leg(artifact_health_json(tmp_path, _URI, hmac_key=_KEY, at=500), "evidence")["status"] == (
+        LEG_NOT_APPLICABLE
+    )
+
+
+def test_a_tampered_bundle_fails_the_leg_and_turns_the_verdict_red(tmp_path: Path) -> None:
+    _record(tmp_path, _URI, b"wheel", ts=100)
+    _seal_bundle(tmp_path, "T-release", declared_and_produced=(_URI,), ts=100)
+
+    from bernstein.core.evidence.bundle import bundle_path
+
+    path = bundle_path(tmp_path, "T-release")
+    row = json.loads(path.read_bytes())
+    row["gate_passed"] = not row["gate_passed"]
+    path.write_bytes(json.dumps(row).encode())
+
+    payload = artifact_health_json(tmp_path, _URI, hmac_key=_KEY, at=500)
+    assert _leg(payload, "evidence")["status"] == LEG_FAIL
+    assert json.loads(payload)["verdict"] == RED
+
+
+def test_the_newest_declaring_bundle_wins(tmp_path: Path) -> None:
+    _record(tmp_path, _URI, b"wheel", ts=100)
+    _seal_bundle(tmp_path, "T-old", declared_and_produced=(_URI,), ts=100)
+    _seal_bundle(tmp_path, "T-new", declared_and_produced=(_URI,), ts=200)
+
+    assert "T-new" in _leg(artifact_health_json(tmp_path, _URI, hmac_key=_KEY, at=500), "evidence")["detail"]
+
+
+def test_a_malformed_bundle_does_not_crash_the_projection(tmp_path: Path) -> None:
+    _record(tmp_path, _URI, b"wheel", ts=100)
+    bundles = tmp_path / ".sdd" / "evidence" / "bundles"
+    bundles.mkdir(parents=True)
+    (bundles / "T-corrupt.json").write_bytes(b"{not json")
+    assert json.loads(artifact_health_json(tmp_path, _URI, hmac_key=_KEY, at=500))["verdict"] == GREEN
+
+
+# ---------------------------------------------------------------------------
 # Attribution (AC5) and listing
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/lineage/test_artifact_health.py
+++ b/tests/unit/lineage/test_artifact_health.py
@@ -1,0 +1,382 @@
+"""The per-artifact health verdict is a deterministic projection (#2559).
+
+The verdict has to be recomputable by a third party from local state alone,
+which means it must be a pure function of what was read off disk and of the
+evaluation instant. These tests pin that:
+
+* the same state and the same ``at`` give byte-identical JSON, every time;
+* a byte flip anywhere in a spine row carrying the artifact turns it red and
+  names the offending entry;
+* a leg with nothing to say reports ``not_applicable`` and never drags the
+  verdict down -- absence of a signal is not a negative signal;
+* a tampered entry belonging to a *different* artifact does not turn this one
+  red.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.lineage.artifact_health import (
+    AMBER,
+    GREEN,
+    LEG_FAIL,
+    LEG_NOT_APPLICABLE,
+    LEG_PASS,
+    LEG_STALE,
+    RED,
+    ArtifactProduction,
+    ArtifactState,
+    artifact_health_json,
+    artifact_log,
+    artifact_log_json,
+    collect_artifact_state,
+    compute_artifact_health,
+    list_artifact_keys,
+)
+from bernstein.core.lineage.spine import LineageSpine, SpineEntry
+
+_KEY = b"h" * 32
+_URI = "pkg://pypi/bernstein/3.9.0"
+
+
+def _spine(workdir: Path, run_id: str = "run-1") -> LineageSpine:
+    return LineageSpine(workdir / ".sdd" / "lineage", run_id=run_id, hmac_key=_KEY)
+
+
+def _record(
+    workdir: Path,
+    uri: str,
+    content: bytes,
+    *,
+    ts: int,
+    run_id: str = "run-1",
+    actor: str = "agent-release",
+    model: str = "claude-opus-5",
+) -> SpineEntry:
+    return _spine(workdir, run_id).record_entry(
+        artifact_path=uri,
+        content=content,
+        actor=actor,
+        step_id="publish",
+        model=model,
+        timestamp=ts,
+    )
+
+
+def _leg(verdict_json: str, name: str) -> dict[str, str]:
+    legs = json.loads(verdict_json)["legs"]
+    return next(leg for leg in legs if leg["name"] == name)
+
+
+# ---------------------------------------------------------------------------
+# Determinism (AC1)
+# ---------------------------------------------------------------------------
+
+
+def test_same_state_and_instant_give_byte_identical_json(tmp_path: Path) -> None:
+    _record(tmp_path, _URI, b"wheel", ts=100)
+    first = artifact_health_json(tmp_path, _URI, hmac_key=_KEY, at=500)
+    second = artifact_health_json(tmp_path, _URI, hmac_key=_KEY, at=500)
+    assert first == second
+
+
+def test_verdict_is_independent_of_the_instant_when_no_cadence_is_declared(tmp_path: Path) -> None:
+    """With no cadence, ``at`` only shows up as the recorded evaluation stamp."""
+    _record(tmp_path, _URI, b"wheel", ts=100)
+    early = json.loads(artifact_health_json(tmp_path, _URI, hmac_key=_KEY, at=101))
+    late = json.loads(artifact_health_json(tmp_path, _URI, hmac_key=_KEY, at=10_000_000))
+    early.pop("evaluated_at")
+    late.pop("evaluated_at")
+    assert early == late
+
+
+def test_verdict_document_is_canonical_json(tmp_path: Path) -> None:
+    _record(tmp_path, _URI, b"wheel", ts=100)
+    payload = artifact_health_json(tmp_path, _URI, hmac_key=_KEY, at=500)
+    assert payload == json.dumps(json.loads(payload), ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def test_collected_state_is_read_once_and_frozen(tmp_path: Path) -> None:
+    """A verdict is a function of the snapshot, not of a moving filesystem."""
+    _record(tmp_path, _URI, b"wheel", ts=100)
+    state = collect_artifact_state(tmp_path, _URI, hmac_key=_KEY)
+    _record(tmp_path, _URI, b"newer-wheel", ts=200)
+    # The already-collected state still yields its original verdict.
+    assert compute_artifact_health(state, at=500).production_count == 1
+    with pytest.raises(AttributeError):
+        state.uri = "mutated"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Green path
+# ---------------------------------------------------------------------------
+
+
+def test_a_single_intact_production_is_green(tmp_path: Path) -> None:
+    entry = _record(tmp_path, _URI, b"wheel", ts=100)
+    verdict = json.loads(artifact_health_json(tmp_path, _URI, hmac_key=_KEY, at=500))
+    assert verdict["verdict"] == GREEN
+    assert verdict["tip"]["entry_hash"] == entry.entry_hash
+    assert verdict["tip"]["actor"] == "agent-release"
+    assert verdict["tip"]["model"] == "claude-opus-5"
+    assert verdict["last_produced_at"] == 100
+
+
+def test_absent_signals_report_not_applicable(tmp_path: Path) -> None:
+    _record(tmp_path, _URI, b"wheel", ts=100)
+    payload = artifact_health_json(tmp_path, _URI, hmac_key=_KEY, at=500)
+    assert _leg(payload, "evidence")["status"] == LEG_NOT_APPLICABLE
+    assert _leg(payload, "cadence")["status"] == LEG_NOT_APPLICABLE
+    assert json.loads(payload)["verdict"] == GREEN
+
+
+def test_repeated_productions_over_time_stay_green(tmp_path: Path) -> None:
+    _record(tmp_path, _URI, b"v1", ts=100)
+    _record(tmp_path, _URI, b"v2", ts=200)
+    _record(tmp_path, _URI, b"v3", ts=300)
+    verdict = json.loads(artifact_health_json(tmp_path, _URI, hmac_key=_KEY, at=400))
+    assert verdict["verdict"] == GREEN
+    assert verdict["production_count"] == 3
+    assert verdict["last_produced_at"] == 300
+
+
+# ---------------------------------------------------------------------------
+# Red path (AC2)
+# ---------------------------------------------------------------------------
+
+
+def test_never_produced_is_red(tmp_path: Path) -> None:
+    (tmp_path / ".sdd").mkdir()
+    payload = artifact_health_json(tmp_path, _URI, hmac_key=_KEY, at=500)
+    assert json.loads(payload)["verdict"] == RED
+    assert _leg(payload, "produced")["status"] == LEG_FAIL
+
+
+@pytest.mark.parametrize("field", ["content_hash", "actor", "model", "timestamp", "hmac"])
+def test_single_byte_flip_turns_the_verdict_red(tmp_path: Path, field: str) -> None:
+    entry = _record(tmp_path, _URI, b"wheel", ts=100)
+    spine_path = tmp_path / ".sdd" / "lineage" / "run-1" / "spine.jsonl"
+    row = json.loads(spine_path.read_bytes().strip())
+    row[field] = row[field] + 1 if isinstance(row[field], int) else row[field][:-1] + "0"
+    spine_path.write_bytes(json.dumps(row, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode() + b"\n")
+
+    payload = artifact_health_json(tmp_path, _URI, hmac_key=_KEY, at=500)
+    assert json.loads(payload)["verdict"] == RED
+    integrity = _leg(payload, "chain_integrity")
+    assert integrity["status"] == LEG_FAIL
+    assert entry.entry_hash in integrity["detail"] or "chain verification failed" in integrity["detail"]
+
+
+def test_a_tampered_neighbour_artifact_does_not_turn_this_one_red(tmp_path: Path) -> None:
+    """Per-entry verification keeps one bad row from condemning the whole run."""
+    _record(tmp_path, _URI, b"wheel", ts=100)
+    _record(tmp_path, "docs/other.md", b"unrelated", ts=200)
+
+    spine_path = tmp_path / ".sdd" / "lineage" / "run-1" / "spine.jsonl"
+    rows = [json.loads(line) for line in spine_path.read_bytes().strip().split(b"\n")]
+    rows[1]["actor"] = "impostor"
+    spine_path.write_bytes(
+        b"".join(
+            json.dumps(r, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode() + b"\n" for r in rows
+        )
+    )
+
+    # The tampered artifact is red ...
+    assert json.loads(artifact_health_json(tmp_path, "docs/other.md", hmac_key=_KEY, at=500))["verdict"] == RED
+    # ... and the untouched one keeps its own per-entry verdict.
+    healthy = json.loads(artifact_health_json(tmp_path, _URI, hmac_key=_KEY, at=500))
+    assert _leg(json.dumps(healthy), "produced")["status"] == LEG_PASS
+
+
+def test_two_sets_of_bytes_claiming_to_be_current_is_red(tmp_path: Path) -> None:
+    """A fork: two runs both say they produced the newest version of one key."""
+    _record(tmp_path, _URI, b"wheel-a", ts=100, run_id="run-a")
+    _record(tmp_path, _URI, b"wheel-b", ts=100, run_id="run-b")
+    payload = artifact_health_json(tmp_path, _URI, hmac_key=_KEY, at=500)
+    assert json.loads(payload)["verdict"] == RED
+    assert _leg(payload, "single_open_tip")["status"] == LEG_FAIL
+
+
+def test_idempotent_reproduction_of_the_same_bytes_is_not_a_fork(tmp_path: Path) -> None:
+    _record(tmp_path, _URI, b"same-wheel", ts=100, run_id="run-a")
+    _record(tmp_path, _URI, b"same-wheel", ts=100, run_id="run-b")
+    payload = artifact_health_json(tmp_path, _URI, hmac_key=_KEY, at=500)
+    assert _leg(payload, "single_open_tip")["status"] == LEG_PASS
+    assert json.loads(payload)["verdict"] == GREEN
+
+
+# ---------------------------------------------------------------------------
+# Cadence
+# ---------------------------------------------------------------------------
+
+
+def test_production_inside_the_cadence_passes(tmp_path: Path) -> None:
+    _record(tmp_path, _URI, b"wheel", ts=100)
+    payload = artifact_health_json(tmp_path, _URI, hmac_key=_KEY, at=150, cadence_seconds=100)
+    assert _leg(payload, "cadence")["status"] == LEG_PASS
+    assert json.loads(payload)["verdict"] == GREEN
+
+
+def test_a_lapsed_cadence_is_amber_not_red(tmp_path: Path) -> None:
+    """Out of date is not the same as broken."""
+    _record(tmp_path, _URI, b"wheel", ts=100)
+    payload = artifact_health_json(tmp_path, _URI, hmac_key=_KEY, at=100_000, cadence_seconds=100)
+    assert _leg(payload, "cadence")["status"] == LEG_STALE
+    assert json.loads(payload)["verdict"] == AMBER
+
+
+def test_integrity_failure_outranks_a_lapsed_cadence(tmp_path: Path) -> None:
+    _record(tmp_path, _URI, b"wheel", ts=100)
+    spine_path = tmp_path / ".sdd" / "lineage" / "run-1" / "spine.jsonl"
+    row = json.loads(spine_path.read_bytes().strip())
+    row["actor"] = "impostor"
+    spine_path.write_bytes(json.dumps(row, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode() + b"\n")
+    payload = artifact_health_json(tmp_path, _URI, hmac_key=_KEY, at=100_000, cadence_seconds=100)
+    assert json.loads(payload)["verdict"] == RED
+
+
+def test_a_non_positive_cadence_is_treated_as_undeclared(tmp_path: Path) -> None:
+    _record(tmp_path, _URI, b"wheel", ts=100)
+    payload = artifact_health_json(tmp_path, _URI, hmac_key=_KEY, at=100_000, cadence_seconds=0)
+    assert _leg(payload, "cadence")["status"] == LEG_NOT_APPLICABLE
+
+
+# ---------------------------------------------------------------------------
+# Pure-function level
+# ---------------------------------------------------------------------------
+
+
+def _production(entry_hash: str, *, ts: int = 1, verified: bool = True, content: str = "c") -> ArtifactProduction:
+    return ArtifactProduction(
+        run_id="r",
+        entry_hash=entry_hash,
+        content_hash=content,
+        actor="a",
+        model="m",
+        step_id="s",
+        timestamp=ts,
+        verified=verified,
+    )
+
+
+def test_compute_is_pure_over_its_arguments() -> None:
+    state = ArtifactState(uri=_URI, productions=(_production("h1"),))
+    assert compute_artifact_health(state, at=9).to_dict() == compute_artifact_health(state, at=9).to_dict()
+
+
+def test_declared_evidence_failure_is_red() -> None:
+    state = ArtifactState(
+        uri=_URI,
+        productions=(_production("h1"),),
+        evidence_task_id="T-1",
+        evidence_verified=False,
+        evidence_detail="signature did not verify",
+    )
+    health = compute_artifact_health(state, at=9)
+    assert health.verdict == RED
+    assert any(leg.name == "evidence" and leg.status == LEG_FAIL for leg in health.legs)
+
+
+def test_declared_evidence_success_is_green() -> None:
+    state = ArtifactState(uri=_URI, productions=(_production("h1"),), evidence_task_id="T-1", evidence_verified=True)
+    assert compute_artifact_health(state, at=9).verdict == GREEN
+
+
+def test_ordering_breaks_ties_on_entry_hash_so_the_tip_is_unambiguous() -> None:
+    state = ArtifactState(
+        uri=_URI,
+        productions=(
+            _production("sha256:bbb", ts=5, content="same"),
+            _production("sha256:aaa", ts=5, content="same"),
+        ),
+    )
+    assert compute_artifact_health(state, at=9).tip_entry_hash == "sha256:bbb"
+
+
+# ---------------------------------------------------------------------------
+# Attribution (AC5) and listing
+# ---------------------------------------------------------------------------
+
+
+def test_log_answers_who_produced_the_current_tip(tmp_path: Path) -> None:
+    _record(tmp_path, _URI, b"v1", ts=100, actor="agent-old", model="model-old")
+    newest = _record(tmp_path, _URI, b"v2", ts=200, actor="agent-new", model="model-new")
+
+    records = artifact_log(tmp_path, _URI, hmac_key=_KEY)
+    assert records[0].entry_hash == newest.entry_hash
+    assert records[0].actor == "agent-new"
+    assert records[0].model == "model-new"
+    assert records[0].verified is True
+    assert [r.actor for r in records] == ["agent-new", "agent-old"]
+
+
+def test_log_spans_runs(tmp_path: Path) -> None:
+    _record(tmp_path, _URI, b"v1", ts=100, run_id="run-a", actor="agent-a")
+    _record(tmp_path, _URI, b"v2", ts=200, run_id="run-b", actor="agent-b")
+    assert [r.run_id for r in artifact_log(tmp_path, _URI, hmac_key=_KEY)] == ["run-b", "run-a"]
+
+
+def test_log_marks_a_tampered_production_rather_than_hiding_it(tmp_path: Path) -> None:
+    _record(tmp_path, _URI, b"v1", ts=100)
+    spine_path = tmp_path / ".sdd" / "lineage" / "run-1" / "spine.jsonl"
+    row = json.loads(spine_path.read_bytes().strip())
+    row["model"] = "a-model-nobody-ran"
+    spine_path.write_bytes(json.dumps(row, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode() + b"\n")
+    records = artifact_log(tmp_path, _URI, hmac_key=_KEY)
+    assert len(records) == 1
+    assert records[0].verified is False
+
+
+def test_log_limit_is_applied_from_the_tip(tmp_path: Path) -> None:
+    for i in range(5):
+        _record(tmp_path, _URI, f"v{i}".encode(), ts=i)
+    assert len(artifact_log(tmp_path, _URI, hmac_key=_KEY, limit=2)) == 2
+    assert len(artifact_log(tmp_path, _URI, hmac_key=_KEY, limit=0)) == 5
+
+
+def test_log_json_is_canonical(tmp_path: Path) -> None:
+    _record(tmp_path, _URI, b"v1", ts=100)
+    payload = artifact_log_json(artifact_log(tmp_path, _URI, hmac_key=_KEY), uri=_URI)
+    assert payload == json.dumps(json.loads(payload), ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def test_log_for_an_unknown_key_is_empty(tmp_path: Path) -> None:
+    (tmp_path / ".sdd").mkdir()
+    assert artifact_log(tmp_path, "pkg://pypi/nothing/0.0.1", hmac_key=_KEY) == ()
+
+
+def test_list_reports_every_key_with_its_production_count(tmp_path: Path) -> None:
+    _record(tmp_path, _URI, b"v1", ts=100)
+    _record(tmp_path, _URI, b"v2", ts=200)
+    _record(tmp_path, "docs/report.md", b"doc", ts=300, run_id="run-2")
+    assert list_artifact_keys(tmp_path) == {_URI: 2, "docs/report.md": 1}
+
+
+def test_list_on_a_project_with_no_lineage_is_empty(tmp_path: Path) -> None:
+    assert list_artifact_keys(tmp_path) == {}
+
+
+# ---------------------------------------------------------------------------
+# Path safety carries over
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "../etc/passwd",
+        "/etc/passwd",
+        "a/../../etc/passwd",
+        "ftp://evil.test/payload",
+        "PKG://PyPI/x/1.0",
+    ],
+)
+def test_an_unwritable_key_simply_has_no_history(tmp_path: Path, key: str) -> None:
+    """Looking one up must not crash and must not resolve to anything."""
+    _record(tmp_path, _URI, b"wheel", ts=100)
+    assert artifact_log(tmp_path, key, hmac_key=_KEY) == ()
+    assert json.loads(artifact_health_json(tmp_path, key, hmac_key=_KEY, at=500))["verdict"] == RED

--- a/tests/unit/test_artifact_cli_route_parity.py
+++ b/tests/unit/test_artifact_cli_route_parity.py
@@ -1,0 +1,255 @@
+"""The CLI and the server cannot disagree about an artifact (#2559, AC1).
+
+The determinism criterion is not "two implementations were checked against each
+other once". It is structural: ``bernstein artifact health --json`` and
+``GET /artifacts/health`` are two callers of one function, and one function
+serialises the verdict. These tests pin the observable consequence -- the same
+``.sdd`` state and the same evaluation instant give byte-identical bytes on both
+surfaces -- and the attribution surface (AC5) that reads off the same chain.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from bernstein.cli.commands.artifact_cmd import artifact_group
+from bernstein.core.lineage.spine import LineageSpine
+from bernstein.core.routes.artifacts import router as artifacts_router
+
+_KEY = b"parity-key"
+_URI = "pkg://bernstein/3.9.0"
+_PKG_URI = "pkg://pypi/bernstein/3.9.0"
+_PR_URI = "pr://github.com/acme/widget/2559"
+
+
+@pytest.fixture(autouse=True)
+def _pin_hmac_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Both surfaces resolve the spine key the same way; pin it for the test."""
+    monkeypatch.setattr("bernstein.cli.commands.artifact_cmd._spine_hmac_key", lambda: _KEY)
+    monkeypatch.setattr("bernstein.core.routes.artifacts._hmac_key", lambda: _KEY)
+
+
+def _record(
+    workdir: Path,
+    uri: str,
+    content: bytes,
+    *,
+    ts: int,
+    run_id: str = "run-1",
+    actor: str = "agent-release",
+    model: str = "claude-opus-5",
+) -> str:
+    return LineageSpine(workdir / ".sdd" / "lineage", run_id=run_id, hmac_key=_KEY).record(
+        artifact_path=uri,
+        content=content,
+        actor=actor,
+        step_id="publish",
+        model=model,
+        timestamp=ts,
+    )
+
+
+def _client(workdir: Path) -> TestClient:
+    app = FastAPI()
+    app.include_router(artifacts_router)
+    app.state.workdir = workdir
+    return TestClient(app)
+
+
+def _cli(args: list[str]) -> tuple[int, str]:
+    result = CliRunner().invoke(artifact_group, args)
+    return result.exit_code, result.output
+
+
+# ---------------------------------------------------------------------------
+# Byte-identical verdicts (AC1)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_and_route_verdicts_are_byte_identical(tmp_path: Path) -> None:
+    _record(tmp_path, _PKG_URI, b"wheel", ts=100)
+
+    code, cli_out = _cli(["health", _PKG_URI, "-w", str(tmp_path), "--at", "500", "--output-json"])
+    assert code == 0
+    route_out = _client(tmp_path).get("/artifacts/health", params={"uri": _PKG_URI, "at": 500}).text
+
+    assert cli_out.strip() == route_out
+    assert json.loads(route_out)["verdict"] == "green"
+
+
+def test_byte_identity_survives_a_red_verdict(tmp_path: Path) -> None:
+    _record(tmp_path, _PKG_URI, b"wheel", ts=100)
+    spine_path = tmp_path / ".sdd" / "lineage" / "run-1" / "spine.jsonl"
+    row = json.loads(spine_path.read_bytes().strip())
+    row["actor"] = "impostor"
+    spine_path.write_bytes(json.dumps(row, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode() + b"\n")
+
+    code, cli_out = _cli(["health", _PKG_URI, "-w", str(tmp_path), "--at", "500", "--output-json"])
+    route_out = _client(tmp_path).get("/artifacts/health", params={"uri": _PKG_URI, "at": 500}).text
+
+    assert cli_out.strip() == route_out
+    assert json.loads(route_out)["verdict"] == "red"
+    # A red artifact is a non-zero exit for the CLI and a successfully served
+    # answer for the route: the verdict travels in the payload, not the status.
+    assert code == 2
+
+
+def test_byte_identity_survives_an_amber_verdict(tmp_path: Path) -> None:
+    _record(tmp_path, _PKG_URI, b"wheel", ts=100)
+    code, cli_out = _cli(
+        ["health", _PKG_URI, "-w", str(tmp_path), "--at", "100000", "--cadence-seconds", "10", "--output-json"]
+    )
+    route_out = (
+        _client(tmp_path).get("/artifacts/health", params={"uri": _PKG_URI, "at": 100000, "cadence_seconds": 10}).text
+    )
+    assert cli_out.strip() == route_out
+    assert json.loads(route_out)["verdict"] == "amber"
+    assert code == 0
+
+
+def test_byte_identity_for_a_never_produced_artifact(tmp_path: Path) -> None:
+    (tmp_path / ".sdd").mkdir()
+    _, cli_out = _cli(["health", _PR_URI, "-w", str(tmp_path), "--at", "500", "--output-json"])
+    route_out = _client(tmp_path).get("/artifacts/health", params={"uri": _PR_URI, "at": 500}).text
+    assert cli_out.strip() == route_out
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [_PKG_URI, _PR_URI, "deploy://prod/docs-site", "doc://example.test/lineage", "src/bernstein/core/lineage/spine.py"],
+)
+def test_byte_identity_across_every_scheme(tmp_path: Path, uri: str) -> None:
+    _record(tmp_path, uri, b"bytes", ts=100)
+    _, cli_out = _cli(["health", uri, "-w", str(tmp_path), "--at", "500", "--output-json"])
+    route_out = _client(tmp_path).get("/artifacts/health", params={"uri": uri, "at": 500}).text
+    assert cli_out.strip() == route_out
+
+
+def test_the_route_serves_canonical_json_not_reordered_json(tmp_path: Path) -> None:
+    """FastAPI's encoder must not get a chance to re-order the verdict keys."""
+    _record(tmp_path, _PKG_URI, b"wheel", ts=100)
+    body = _client(tmp_path).get("/artifacts/health", params={"uri": _PKG_URI, "at": 500}).text
+    assert body == json.dumps(json.loads(body), ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def test_repeated_route_calls_are_byte_identical(tmp_path: Path) -> None:
+    _record(tmp_path, _PKG_URI, b"wheel", ts=100)
+    client = _client(tmp_path)
+    first = client.get("/artifacts/health", params={"uri": _PKG_URI, "at": 500}).text
+    second = client.get("/artifacts/health", params={"uri": _PKG_URI, "at": 500}).text
+    assert first == second
+
+
+# ---------------------------------------------------------------------------
+# Attribution (AC5)
+# ---------------------------------------------------------------------------
+
+
+def test_log_names_the_identity_and_model_behind_the_current_tip(tmp_path: Path) -> None:
+    _record(tmp_path, _PR_URI, b"head-1", ts=100, actor="agent-old", model="model-old")
+    newest = _record(tmp_path, _PR_URI, b"head-2", ts=200, actor="agent-new", model="model-new")
+
+    _, cli_out = _cli(["log", _PR_URI, "-w", str(tmp_path), "--output-json"])
+    payload = json.loads(cli_out)
+    assert payload["uri"] == _PR_URI
+    tip = payload["productions"][0]
+    assert tip["entry_hash"] == newest
+    assert tip["actor"] == "agent-new"
+    assert tip["model"] == "model-new"
+    assert tip["verified"] is True
+
+
+def test_log_is_identical_on_both_surfaces(tmp_path: Path) -> None:
+    _record(tmp_path, _PKG_URI, b"wheel", ts=100)
+    _, cli_out = _cli(["log", _PKG_URI, "-w", str(tmp_path), "--output-json"])
+    route_out = _client(tmp_path).get("/artifacts/log", params={"uri": _PKG_URI}).text
+    assert cli_out.strip() == route_out
+
+
+def test_log_human_output_flags_a_tampered_production(tmp_path: Path) -> None:
+    _record(tmp_path, _PKG_URI, b"wheel", ts=100)
+    spine_path = tmp_path / ".sdd" / "lineage" / "run-1" / "spine.jsonl"
+    row = json.loads(spine_path.read_bytes().strip())
+    row["model"] = "a-model-nobody-ran"
+    spine_path.write_bytes(json.dumps(row, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode() + b"\n")
+
+    _, out = _cli(["log", _PKG_URI, "-w", str(tmp_path)])
+    assert "TAMPERED" in out
+
+
+def test_log_limit_is_honoured_on_both_surfaces(tmp_path: Path) -> None:
+    for i in range(5):
+        _record(tmp_path, _PKG_URI, f"v{i}".encode(), ts=i)
+    _, cli_out = _cli(["log", _PKG_URI, "-w", str(tmp_path), "--limit", "2", "--output-json"])
+    route_out = _client(tmp_path).get("/artifacts/log", params={"uri": _PKG_URI, "limit": 2}).text
+    assert cli_out.strip() == route_out
+    assert len(json.loads(route_out)["productions"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Listing
+# ---------------------------------------------------------------------------
+
+
+def test_list_matches_on_both_surfaces(tmp_path: Path) -> None:
+    _record(tmp_path, _PKG_URI, b"wheel", ts=100)
+    _record(tmp_path, "docs/report.md", b"doc", ts=200)
+
+    _, cli_out = _cli(["list", "-w", str(tmp_path), "--output-json"])
+    route_payload = _client(tmp_path).get("/artifacts").json()
+    assert json.loads(cli_out)["artifacts"] == [
+        {"productions": n["productions"], "uri": n["uri"]} for n in route_payload["artifacts"]
+    ]
+
+
+def test_list_human_output_is_empty_on_a_fresh_project(tmp_path: Path) -> None:
+    code, out = _cli(["list", "-w", str(tmp_path)])
+    assert code == 0
+    assert "no artifacts recorded" in out
+
+
+# ---------------------------------------------------------------------------
+# Route input handling
+# ---------------------------------------------------------------------------
+
+
+def test_the_route_requires_a_uri(tmp_path: Path) -> None:
+    (tmp_path / ".sdd").mkdir()
+    assert _client(tmp_path).get("/artifacts/health").status_code == 400
+
+
+def test_the_route_rejects_a_non_integer_instant(tmp_path: Path) -> None:
+    (tmp_path / ".sdd").mkdir()
+    resp = _client(tmp_path).get("/artifacts/health", params={"uri": _PKG_URI, "at": "yesterday"})
+    assert resp.status_code == 400
+
+
+def test_the_artifact_routes_are_mounted_on_the_real_app(tmp_path: Path) -> None:
+    """A route nobody mounted cannot disagree with the CLI, but it also cannot serve."""
+    from bernstein.core.server import create_app
+
+    application = create_app(jsonl_path=tmp_path / "runtime" / "tasks.jsonl")
+    paths = {route.path for route in application.routes}  # type: ignore[attr-defined]
+    assert {"/artifacts", "/artifacts/health", "/artifacts/log"} <= paths
+    # AUDIT-126: every router is mounted under the versioned surface too.
+    assert {"/api/v1/artifacts", "/api/v1/artifacts/health", "/api/v1/artifacts/log"} <= paths
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    ["../etc/passwd", "/etc/passwd", "a/../../etc/passwd", "ftp://evil.test/x", "PKG://PyPI/x/1.0"],
+)
+def test_a_hostile_key_resolves_to_nothing_on_both_surfaces(tmp_path: Path, hostile: str) -> None:
+    """Path-safety verdicts are unchanged; an unwritable key simply has no history."""
+    _record(tmp_path, _PKG_URI, b"wheel", ts=100)
+    _, cli_out = _cli(["health", hostile, "-w", str(tmp_path), "--at", "500", "--output-json"])
+    route_out = _client(tmp_path).get("/artifacts/health", params={"uri": hostile, "at": 500}).text
+    assert cli_out.strip() == route_out
+    assert json.loads(route_out)["verdict"] == "red"
+    assert json.loads(route_out)["production_count"] == 0

--- a/tests/unit/test_sse_events.py
+++ b/tests/unit/test_sse_events.py
@@ -10,8 +10,8 @@ from bernstein.core.server.sse_events import SSEEvent, SSEEventType
 
 
 class TestSSEEventType:
-    def test_has_17_members(self) -> None:
-        assert len(SSEEventType) == 17
+    def test_has_18_members(self) -> None:
+        assert len(SSEEventType) == 18
 
     def test_event_type_values_are_dotted(self) -> None:
         for member in SSEEventType:
@@ -28,6 +28,7 @@ class TestSSEEventType:
             "TASK_RETRIED",
             "TASK_ARTIFACT",
             "TASK_PROGRESS",
+            "ARTIFACT_PRODUCED",
             "AGENT_SPAWNED",
             "AGENT_EXITED",
             "GATE_RESULT",
@@ -41,6 +42,30 @@ class TestSSEEventType:
         }
         actual = {m.name for m in SSEEventType}
         assert expected == actual
+
+    def test_artifact_produced_factory(self) -> None:
+        evt = SSEEvent.artifact_produced(
+            uri="pkg://pypi/bernstein/3.9.0",
+            entry_hash="sha256:abc",
+            content_hash="sha256:def",
+            actor="agent-release",
+            verified=True,
+        )
+        assert evt.event == SSEEventType.ARTIFACT_PRODUCED
+        assert evt.data["uri"] == "pkg://pypi/bernstein/3.9.0"
+        assert evt.data["entry_hash"] == "sha256:abc"
+        assert evt.data["verified"] is True
+        assert json.loads(evt.to_sse().split("data: ", 1)[1].split("\n", 1)[0])["actor"] == "agent-release"
+
+    def test_artifact_produced_carries_no_artifact_bytes(self) -> None:
+        """The payload is identity and provenance; clients re-verify the content."""
+        evt = SSEEvent.artifact_produced(
+            uri="pkg://pypi/bernstein/3.9.0",
+            entry_hash="sha256:abc",
+            content_hash="sha256:def",
+        )
+        assert "content" not in evt.data
+        assert set(evt.data) == {"uri", "entry_hash", "content_hash"}
 
     def test_mission_updated_factory(self) -> None:
         evt = SSEEvent.mission_updated("m-1", status_hash="abc", overall="active")


### PR DESCRIPTION
## Problem

An artifact write landed in the spine and nothing downstream could see it. No event said "artifact X was produced", so a goal depending on another goal's output either polled on a cron guess — wasting a run when nothing changed, lagging a day when the upstream was late — or was hand-wired as a run dependency.

And asking "is this output good and current" meant correlating four surfaces by hand: open-tip analysis, evidence-bundle verification, spine chain verification, and the cadence the output was supposed to refresh on. Nothing rolled them up per artifact, so the answer lived in an operator's head and was never the same twice. "Which agent identity, running which model, produced the current tip of this package" was a manual walk across run directories — the chain had the data but not the key.

## What this does

Phases 3 and 4 of #2559, on top of the URI grammar and declared outputs from #2991.

### Production events at the single write boundary

Every artifact write that lands in the spine now emits **exactly one** `artifact.produced` event, from `record_artifact_write` — the one place every in-process write already passes through. It is journaled at `.sdd/lineage/<run_id>/artifact-events.jsonl` beside the spine it projects from, and mirrored onto the SSE bus when a server is attached. There is no per-adapter opt-in to forget, because recording provenance and announcing it are one call.

The event is a **pure function of one spine entry** — no clock, no environment, no ambient state:

```json
{"actor":"agent-release","content_hash":"sha256:…","entry_hash":"sha256:…","model":"claude-opus-5","run_id":"run-7","step_id":"publish","timestamp":1750000000,"uri":"pkg://pypi/bernstein/3.9.0","v":1,"verified":true}
```

That purity is the whole design, and it pays for three things at once.

**Replayable fan-out.** Re-deriving the events from the spine reproduces the identical set, entry for entry. Comparing the journal against that projection reports any difference as a divergence naming the offending `entry_hash` — `dropped`, `duplicated`, `unexpected`, `altered` — so "a trigger did not fire" is a lookup instead of an investigation.

**Tamper visibility.** `verified` on a replayed event is the per-entry integrity verdict recomputed from the entry itself. Flip one byte of a spine row — payload or HMAC tag — and that artifact's event replays as `verified: false` while the row journaled at production time still claims `true`. The disagreement is the finding.

**No trusted emitter.** A consumer never has to believe the journal. It re-derives the set from the spine and compares; the journal is a convenience index, and the spine stays the only thing that has to be trusted.

Emission is deliberately **fail-open**. Recording into the spine is fail-closed because provenance is a hard requirement; the event is a notification, and a full disk, a read-only journal or a dead subscriber must never turn a successful artifact write into a failed one. Anything a failed emit dropped is rebuilt by replaying the spine, so the fail-open path loses notification latency and nothing else.

### Per-artifact health, and why the CLI and the dashboard cannot disagree

`src/bernstein/core/lineage/artifact_health.py` rolls the four surfaces into one verdict over a state snapshot read once and then frozen. Everything that could vary between two observers is an explicit argument: the evaluation instant is the caller's `at`, never the wall clock; the cadence is a caller-supplied number, never an ambient default.

| Leg | Passes when |
|---|---|
| `produced` | At least one spine entry records the key. |
| `chain_integrity` | Every entry carrying the key recomputes its hash and HMAC tag, and the chains they sit in verify. |
| `single_open_tip` | Exactly one set of bytes claims to be current. |
| `evidence` | The newest sealed bundle whose signed binding declares the key verifies. |
| `cadence` | The last production is inside the declared cadence. |

`green` / `amber` (out of date, nothing broken) / `red` (integrity or currency failure, exit 2). A leg with nothing to say reports `not_applicable` and **cannot** hold the verdict down — an artifact with no declared cadence is not "failing cadence". Absence of a signal is never reported as a negative signal.

`bernstein artifact health <uri> --json` and `GET /artifacts/health` are two callers of `artifact_health_json`, and it is the only place a verdict is serialised. The route returns those bytes verbatim as a raw `Response` so FastAPI's encoder cannot re-order the keys. Determinism is therefore structural, not a pair of implementations kept in sync by discipline:

```bash
bernstein artifact health pkg://pypi/bernstein/3.9.0 --at 1750000000 --output-json
curl 'http://localhost:8000/artifacts/health?uri=pkg://pypi/bernstein/3.9.0&at=1750000000'
```

### Attribution by URI

`bernstein artifact log <uri>` answers, newest first, which agent identity ran which model to produce each version, with the spine entry hash that proves it, across runs. `verified` is recomputed per entry, so a tampered row is *named* rather than averaged into a summary. `bernstein artifact list` enumerates every key the local spines carry.

**Per-entry verification** (`spine.verify_entry`) is what makes this safe to key by artifact: a tampered entry belonging to a *different* artifact in the same run must not turn every other artifact in that run red.

### Reacting to an artifact

`src/bernstein/core/trigger_sources/artifact.py` normalises production events into the same `TriggerEvent` every other source emits, so artifact rules go through the existing rule matching with no second engine. The key rides in `changed_files` (path-shaped filters see it unchanged) and the full payload in `raw_payload`. URI patterns select what fires. An entry whose integrity verdict is false does **not** fire by default: a firing caused by a tampered record is worse than a firing that never happened.

## Acceptance criteria

| AC | Before | After | Proof |
|---|---|---|---|
| 1 — determinism, CLI vs server byte-identical | missing (no health surface, no route) | **done** | `artifact_health.py::artifact_health_json` is the single serialiser; `test_artifact_cli_route_parity.py` compares the two surfaces across every scheme and all three verdicts |
| 2 — verifiability under tamper | missing | **done** | `test_artifact_events.py` (byte flip → `verified: false`), `test_artifact_health.py` (byte flip → red naming the entry) |
| 3 — replayable fan-out, divergence names the entry | missing (no artifact trigger source) | **done** | `test_artifact_fanout_replay.py` — dropped / duplicated / altered each named by `entry_hash` |
| 4 — intent diff distinguishes attempted-and-failed | partial (`OutputDiff` sealed, no live producer) | **still partial** — see below | `test_output_diff.py` (from #2991) |
| 5 — attribution via `artifact log <uri>` | missing (`artifact_cmd.py` task-keyed only) | **done** | `test_artifact_health.py::test_log_answers_who_produced_the_current_tip`, `test_artifact_cli_route_parity.py` |
| 6 — correctness, repo paths byte-identical | done in #2991 | **still done** | `test_artifact_uri_backcompat.py`, `test_artifact_uri_properties.py`, `test_lineage_adversarial.py` all unchanged and passing |
| 7 — failure-domain isolation, fail-open | partial (sealing only) | **done** | `test_artifact_production_conformance.py` — journal failure, hostile subscriber and mid-run bus loss each leave the chain intact and the write successful |
| 8 — no opt-in gap, one event per adapter write | missing (`record_artifact_write` emitted nothing) | **done** | `test_artifact_production_conformance.py::test_every_registered_adapter_emits_exactly_one_event_per_write` plus the in-process callers |

### Why AC4 stays partial

The completion diff still has no live producer, for the reason #2991 gave and this change confirms rather than removes: **spine entries carry no task id**. The four in-process callers of the write boundary (journal seal, retry decision, schedule fire, MCP task artifact) are orchestration-internal writes, and most adapter writes are subprocess file writes that never cross the boundary at all.

Feeding a completing task the whole run's observed produced set would attribute other tasks' writes — and the orchestrator's own — to it, generating false `produced_but_undeclared` findings. That is the same failure as an all-missing diff from an absent observation, just from the other direction, so the diff is still skipped rather than fired against a set that is not the task's.

What this change does add is the observation itself: `observed_artifact_keys` returns a run's genuinely produced set (excluding the run's own journal seal, which is the run recording itself and not a deliverable), and `None` remains distinct from `()`. Task-attributed production is what remains.

## Tests

| File | Covers | Count |
|---|---|---|
| `tests/unit/lineage/test_artifact_events.py` | projection purity, journal IO, tamper → unverified, all four divergence kinds, fail-open, observation | 26 |
| `tests/unit/lineage/test_artifact_health.py` | determinism, every leg (evidence against real sealed bundles), green/amber/red, forks, neighbour isolation, attribution, path safety | 42 |
| `tests/unit/lineage/test_artifact_fanout_replay.py` | replayable fire set, pattern narrowing, unverified entries refused, divergence naming, normalisation | 18 |
| `tests/unit/adapters/test_artifact_production_conformance.py` | one event per write across every registered adapter and every in-process caller; AC7 fault injection | 15 |
| `tests/unit/test_artifact_cli_route_parity.py` | CLI vs route byte-identity, attribution, listing, route input handling, router mounting | 25 |
| **total new** | | **126** |

Targeted run: `tests/unit/lineage/ tests/unit/adapters/ tests/unit/evidence/ tests/unit/test_artifact_cli_route_parity.py tests/unit/cli/test_artifact_verify_cmd.py` — **1160 passed**. Plus `tests/property/test_artifact_uri_properties.py tests/property/test_normalize_path_properties.py tests/security/test_lineage_adversarial.py tests/unit/lineage/test_artifact_fanout_replay.py` — **40 passed**; `tests/unit/test_sse.py tests/unit/test_sse_events.py tests/unit/test_trigger_manager.py tests/unit/test_events_triggers.py tests/unit/trigger_sources/` — **139 passed**; `tests/unit/test_api_v1_routing.py tests/unit/test_api_compat*.py tests/unit/test_artifacts_cmd.py` — **71 passed**.

`ruff check .` / `ruff format --check .` clean; `mypy --config-file mypy.gate.ini` (the gated lineage/evidence strict zone, which both new core modules land inside) clean; `vulture --min-confidence 80` and `typos` clean.

The adversarial path-safety cases are untouched and still pass: traversal at every position, absolute and drive-prefixed paths, scheme confusion, non-canonical spellings. The new surfaces inherit them — `test_artifact_health.py` and `test_artifact_cli_route_parity.py` both assert that an unwritable key simply resolves to no history rather than crashing or leaking.

## Changes to existing tests

`test_base_lineage_hook.py` and `test_base_spine_writes.py` stub the spine to prove the write boundary fails closed. The stubbed method moves from `record` to `record_entry`, which is what the boundary now calls so it can project the event off the entry it just wrote. The fail-closed assertion itself is unchanged.

`test_sse_events.py` gains `ARTIFACT_PRODUCED` to its roster and a factory test.

## Docs

`docs/lineage/artifacts.md` gains the inspection commands, the leg/verdict tables, verdict reproduction, production events with the divergence table, and the trigger surface. Cross-links updated from `docs/lineage.md` and `docs/operations/artifacts.md` (which documents the task-keyed `artifact verify` and now points at the URI-keyed commands for output-shaped questions).

## Scope

Advances #2559. Remaining: AC4's live producer, which needs task-attributed artifact writes (see above); the web panel for the health route; and sourcing the declared cadence from the recurring schedule store rather than from an operator-supplied `--cadence-seconds` / `?cadence_seconds=`.
