### PR TITLE
fix(qwen): use scoped install hint

### DIFF
--- a/examples/multi-model/bernstein.yaml
+++ b/examples/multi-model/bernstein.yaml
@@ -8,7 +8,7 @@
 #   - Claude Code:  npm install -g @anthropic-ai/claude-code  + ANTHROPIC_API_KEY
 #   - Codex CLI:    npm install -g @openai/codex              + OPENAI_API_KEY
 #   - Gemini CLI:   npm install -g @google/gemini-cli         + GOOGLE_API_KEY
-#   - Qwen:         npm install -g qwen-code                  + DASHSCOPE_API_KEY or OPENROUTER_API_KEY_FREE
+#   - Qwen:         npm install -g @qwen-code/qwen-code       + DASHSCOPE_API_KEY or OPENROUTER_API_KEY_FREE
 #
 # You don't need all four. Bernstein uses whatever is installed.
 # Run:  bernstein run

--- a/examples/multi-model/bernstein.yaml
+++ b/examples/multi-model/bernstein.yaml
@@ -8,7 +8,7 @@
 #   - Claude Code:  npm install -g @anthropic-ai/claude-code  + ANTHROPIC_API_KEY
 #   - Codex CLI:    npm install -g @openai/codex              + OPENAI_API_KEY
 #   - Gemini CLI:   npm install -g @google/gemini-cli         + GOOGLE_API_KEY
-#   - Qwen:         npm install -g @qwen-code/qwen-code       + DASHSCOPE_API_KEY or OPENROUTER_API_KEY_FREE
+#   - Qwen:         npm install -g @qwen-code/qwen-code       + OPENROUTER_API_KEY_FREE
 #
 # You don't need all four. Bernstein uses whatever is installed.
 # Run:  bernstein run

--- a/examples/multi-model/run.sh
+++ b/examples/multi-model/run.sh
@@ -38,7 +38,7 @@ if [[ ${#AGENTS[@]} -eq 0 ]]; then
     echo "  npm install -g @anthropic-ai/claude-code   # Claude Code"
     echo "  npm install -g @openai/codex               # Codex"
     echo "  npm install -g @google/gemini-cli          # Gemini"
-    echo "  npm install -g qwen-code                   # Qwen"
+    echo "  npm install -g @qwen-code/qwen-code        # Qwen"
     exit 1
 fi
 

--- a/examples/multi-model/run.sh
+++ b/examples/multi-model/run.sh
@@ -30,7 +30,7 @@ if command -v gemini &>/dev/null; then
     AGENTS+=("gemini (Gemini CLI / Google)")
 fi
 if command -v qwen &>/dev/null; then
-    AGENTS+=("qwen (Qwen / Alibaba / OpenRouter)")
+    AGENTS+=("qwen (Qwen / OpenRouter)")
 fi
 
 if [[ ${#AGENTS[@]} -eq 0 ]]; then

--- a/src/bernstein/adapters/qwen.py
+++ b/src/bernstein/adapters/qwen.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
 from bernstein.adapters.env_isolation import build_filtered_env
 from bernstein.adapters.plugin_sdk import AdapterCapability, AdapterPluginInfo
+from bernstein.core.defaults import QWEN_INSTALL_HINT
 from bernstein.core.llm import LLMSettings
 from bernstein.core.models import ApiTier, ApiTierInfo, ModelConfig, ProviderType, RateLimit
 
@@ -230,7 +231,7 @@ class QwenAdapter(CLIAdapter):
                     start_new_session=True,
                 )
             except FileNotFoundError as exc:
-                raise RuntimeError("qwen not found in PATH. Install it with: npm install -g qwen-code") from exc
+                raise RuntimeError(f"qwen not found in PATH. Install it with: {QWEN_INSTALL_HINT}") from exc
             except PermissionError as exc:
                 raise RuntimeError(f"Permission denied executing qwen: {exc}") from exc
 

--- a/src/bernstein/core/defaults.py
+++ b/src/bernstein/core/defaults.py
@@ -77,6 +77,9 @@ COPILOT_CLAUDE_TIER_MODELS: Final[frozenset[str]] = frozenset({"opus", "sonnet",
 """Claude cascade tier names that are not valid Copilot model ids; any that reach
 the Copilot adapter are remapped to ``COPILOT_DEFAULT_MODEL``."""
 
+QWEN_INSTALL_HINT: Final[str] = "npm install -g @qwen-code/qwen-code"
+"""Install command for the Qwen CLI package that provides the ``qwen`` binary."""
+
 
 @dataclass(frozen=True)
 class DashboardStaticAsset:

--- a/src/bernstein/core/orchestration/preflight.py
+++ b/src/bernstein/core/orchestration/preflight.py
@@ -17,6 +17,8 @@ from pathlib import Path
 
 from rich.console import Console
 
+from bernstein.core.defaults import QWEN_INSTALL_HINT
+
 logger = logging.getLogger(__name__)
 
 console = Console()
@@ -41,7 +43,7 @@ _CLI_INSTALL_HINT: dict[str, str] = {
     "claude": "https://claude.ai/code",
     "codex": "npm install -g @openai/codex",
     "gemini": "npm install -g @google/gemini-cli",
-    "qwen": "npm install -g qwen-code",
+    "qwen": QWEN_INSTALL_HINT,
 }
 
 # Primary API key env var(s) per adapter.

--- a/tests/unit/test_adapter_qwen.py
+++ b/tests/unit/test_adapter_qwen.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 from typing import TYPE_CHECKING
@@ -13,6 +14,8 @@ from bernstein.core.models import ApiTier, ModelConfig, ProviderType
 
 from bernstein.adapters.plugin_sdk import AdapterCapability
 from bernstein.adapters.qwen import QwenAdapter
+from bernstein.core.defaults import QWEN_INSTALL_HINT
+from bernstein.core.orchestration.preflight import _CLI_INSTALL_HINT
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -526,6 +529,10 @@ class TestQwenAdapterName:
 
 
 class TestQwenSpawnMissingBinary:
+    def test_install_hint_uses_scoped_qwen_code_package(self) -> None:
+        assert QWEN_INSTALL_HINT == "npm install -g @qwen-code/qwen-code"
+        assert _CLI_INSTALL_HINT["qwen"] == QWEN_INSTALL_HINT
+
     def test_file_not_found_raises_runtime_error(self, tmp_path: Path) -> None:
         adapter = QwenAdapter()
         settings = _default_settings()
@@ -535,7 +542,7 @@ class TestQwenSpawnMissingBinary:
                 side_effect=FileNotFoundError("No such file"),
             ),
             patch("bernstein.adapters.qwen.LLMSettings", return_value=settings),
-            pytest.raises(RuntimeError, match="not found in PATH"),
+            pytest.raises(RuntimeError, match=re.escape(QWEN_INSTALL_HINT)),
         ):
             adapter.spawn(
                 prompt="hello",


### PR DESCRIPTION
## What
- Update Qwen install guidance to the scoped npm package `@qwen-code/qwen-code`.
- Share the install hint through `bernstein.core.defaults` for adapter and preflight paths.
- Add regression coverage for adapter/preflight hint alignment.

## Why
The unscoped `qwen-code` package does not provide the expected `qwen` binary, so the missing-binary and preflight guidance sent operators to the wrong install command.

## How
- Define `QWEN_INSTALL_HINT` once in `src/bernstein/core/defaults.py`.
- Import it from the Qwen adapter and orchestration preflight checks.
- Assert the runtime error and preflight hint use the same scoped command.

## Checklist
- [x] Tests added or updated.
- [x] Focused tests pass locally.
- [x] Lint passes locally.
- [x] Linked issue: Fixes #3006.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Qwen CLI install guidance to use the scoped npm package: `@qwen-code/qwen-code`.
  * Aligned Qwen-related preflight and adapter “executable not found” messages so the suggested install command is consistent everywhere.

* **Documentation**
  * Refreshed the multi-model example instructions and run script to reflect `@qwen-code/qwen-code`.
  * Updated the displayed Qwen/OpenRouter label in the run script.

* **Tests**
  * Added/updated unit tests to verify Qwen installation hints and error messaging match the new guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->