### PR TITLE
fix(sandbox): accept sandbox: <runtime> string shorthand in seeds

### DIFF
--- a/src/bernstein/core/config/seed_parser.py
+++ b/src/bernstein/core/config/seed_parser.py
@@ -2160,6 +2160,9 @@ _SECTION_TOP_LEVEL_KEYS: frozenset[str] = frozenset(
 # cannot connect these pairs.
 _TOP_LEVEL_KEY_ALIASES: dict[str, str] = {
     "tasks": "cells",
+    # No top-level equivalent of --container-image exists; the seed form
+    # is nested under sandbox.image, not a top-level key (see #3023).
+    "container_image": "sandbox.image",
 }
 
 

--- a/src/bernstein/core/security/sandbox.py
+++ b/src/bernstein/core/security/sandbox.py
@@ -139,8 +139,21 @@ def parse_docker_sandbox(raw: object | None) -> DockerSandbox | None:
     """
     if raw is None:
         return None
+    if isinstance(raw, str):
+        runtime_shorthand = raw.strip()
+        if runtime_shorthand not in _VALID_RUNTIMES:
+            valid = ", ".join(sorted(_VALID_RUNTIMES))
+            raise ValueError(
+                f"sandbox: {raw!r} is not a valid runtime shorthand. "
+                f"Use one of {valid} (matching --sandbox), "
+                f"or the mapping form, e.g. sandbox: {{runtime: docker}}"
+            )
+        raw = {"runtime": runtime_shorthand}
     if not isinstance(raw, Mapping):
-        raise ValueError("sandbox must be a mapping")
+        raise ValueError(
+            "sandbox must be a mapping (e.g. sandbox: {runtime: docker}) "
+            "or a runtime name string (e.g. sandbox: docker)"
+        )
 
     data = cast("Mapping[str, object]", raw)
     enabled = _parse_bool(data.get("enabled", True), "sandbox.enabled")

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -39,6 +39,51 @@ def test_parse_docker_sandbox_rejects_invalid_runtime() -> None:
         parse_docker_sandbox({"runtime": "firecracker"})
 
 
+def test_parse_docker_sandbox_accepts_string_shorthand() -> None:
+    """``sandbox: docker`` is shorthand for ``sandbox: {runtime: docker}``.
+
+    The CLI's ``--sandbox docker`` flag takes a bare backend-name string;
+    the seed key should accept the same natural mirror instead of forcing
+    operators to discover the mapping form (bug #3023).
+    """
+
+    shorthand = parse_docker_sandbox("docker")
+    mapping = parse_docker_sandbox({"runtime": "docker"})
+
+    assert shorthand == mapping
+
+
+def test_parse_docker_sandbox_accepts_podman_string_shorthand() -> None:
+    """The string shorthand supports every valid runtime, not just docker."""
+
+    shorthand = parse_docker_sandbox("podman")
+    mapping = parse_docker_sandbox({"runtime": "podman"})
+
+    assert shorthand == mapping
+
+
+def test_parse_docker_sandbox_rejects_invalid_string_shorthand() -> None:
+    """An invalid string shorthand names the valid runtimes and the mapping form."""
+
+    with pytest.raises(ValueError, match="docker") as excinfo:
+        parse_docker_sandbox("nonsense")
+
+    message = str(excinfo.value)
+    assert "docker" in message
+    assert "podman" in message
+    assert "runtime" in message  # points operators at the {runtime: ...} mapping form
+
+
+def test_parse_docker_sandbox_mapping_form_still_works() -> None:
+    """The pre-existing mapping form keeps parsing unchanged."""
+
+    sandbox = parse_docker_sandbox({"runtime": "docker", "image": "bernstein/base:latest"})
+
+    assert sandbox is not None
+    assert sandbox.runtime == "docker"
+    assert sandbox.default_image == "bernstein/base:latest"
+
+
 def test_spawn_in_sandbox_uses_adapter_specific_image(tmp_path: Path) -> None:
     """The manager should be created with the image chosen for the adapter."""
 

--- a/tests/unit/test_seed.py
+++ b/tests/unit/test_seed.py
@@ -935,3 +935,17 @@ class TestParseSeedUnknownTopLevelKeys:
 
         messages = [r.getMessage() for r in caplog.records]
         assert any("zzqqxx" in m for m in messages)
+
+    def test_container_image_key_hints_sandbox_image(
+        self, seed_file: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """``container_image:`` has no top-level equivalent; the warning must
+        point operators at ``sandbox.image`` instead of silently dropping the
+        value (bug #3023)."""
+        seed_file.write_text('goal: "Test"\ncontainer_image: bernstein-qwen:3.9.0\n')
+
+        with caplog.at_level(logging.WARNING, logger=_SEED_PARSER_LOGGER):
+            parse_seed(seed_file)
+
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("container_image" in m and "sandbox.image" in m for m in messages)


### PR DESCRIPTION
Closes #3023

## Summary

- `parse_docker_sandbox` now accepts `sandbox: docker` / `sandbox: podman` as string shorthand for `sandbox: {runtime: docker}` / `{runtime: podman}`, mirroring the `--sandbox <backend>` CLI flag.
- The mapping form (`sandbox: {runtime: docker, ...}`) keeps working unchanged.
- An invalid runtime string (e.g. `sandbox: nonsense`) now raises an error naming the accepted runtimes and showing the mapping form, instead of the previous "sandbox must be a mapping" message.
- The unknown-top-level-key warning for `container_image:` now names the seed equivalent (`sandbox.image`) instead of silently dropping the value.

## Test plan

- [x] `sandbox: docker` (string) parses to a config equal to `sandbox: {runtime: docker}`
- [x] `sandbox: podman` (string) parses equivalently to its mapping form
- [x] Invalid string shorthand (`sandbox: nonsense`) raises an error naming valid runtimes and the mapping form
- [x] Existing mapping form still parses unchanged
- [x] `container_image:` in a seed warns and points at `sandbox.image`
- [x] `uv run pytest tests/unit/test_sandbox.py tests/unit/test_seed.py` — 107 passed
- [x] `uv run ruff check` on changed files — clean
- [x] `uv run mypy` on changed files — no new errors (pre-existing baseline unchanged)

Note: full pytest suite was intentionally not run (known to exhaust host memory); only the touched seed/sandbox parser test files were run.

## Summary by Sourcery

Support string shorthand runtimes in sandbox seeds and improve seed parser warnings for container image configuration.

New Features:
- Allow sandbox seeds to specify docker and podman runtimes via a bare string shorthand equivalent to the existing mapping form.
- Add a top-level key alias so seeds using container_image receive a warning that points to the sandbox.image configuration path.

Bug Fixes:
- Reject invalid sandbox runtime shorthand strings with a clear error that lists valid runtimes and references the mapping form.
- Clarify sandbox configuration errors to mention both mapping and string forms instead of a generic mapping-only message.

Tests:
- Extend sandbox parser unit tests to cover string shorthand runtimes, invalid shorthand behavior, and continued support for the mapping form.
- Add a seed parser unit test ensuring container_image usage warns and points operators at sandbox.image.