### PR TITLE
fix(spawner): surface and audit sandbox isolation downgrades

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -45,17 +45,20 @@ x-bernstein-common: &bernstein-common
   volumes:
     - sdd-data:/workspace/.sdd
     - project-data:/workspace/project
-    # Container sandbox isolation (`--sandbox docker` / the `regulated`
-    # compliance preset) runs each agent in its own sibling container. It needs
-    # THREE things the lean base image does not ship - uncomment the socket
-    # mount below AND use an image that adds the runtime CLI + Docker SDK:
+    # Container sandbox isolation runs each agent in its own sibling container.
+    # It is requested ONLY via the `sandbox:` section of bernstein.yaml, the
+    # `--sandbox` flag, or BERNSTEIN_SANDBOX_RUNTIME - compliance presets
+    # (`--compliance regulated` etc.) do NOT select it. It needs THREE things
+    # the lean base image does not ship - uncomment the socket mount below AND
+    # use an image that adds the runtime CLI + Docker SDK:
     #   1. a `docker` (or `podman`) CLI on PATH inside the container;
     #   2. the Python Docker SDK: `pip install "bernstein[docker]"`;
     #   3. the host Docker socket, mounted here.
-    # Without all three, an explicit `--sandbox docker` run refuses, while a
-    # `regulated`-preset run downgrades to worktree isolation - now surfaced in
-    # the run summary and the `sandbox.isolation_downgrade` audit entry, not a
-    # silent WARNING. See docs/operations/deployment-guide.md#container-sandbox-isolation---sandbox-docker-and-the-regulated-preset.
+    # Without all three a container request cannot be honoured: it either
+    # refuses or downgrades to worktree isolation - and any downgrade is
+    # surfaced in the run summary and recorded as a `sandbox.isolation_downgrade`
+    # audit entry, never a silent WARNING. See the "Container sandbox isolation"
+    # section of docs/operations/deployment-guide.md.
     # SECURITY: mounting the Docker socket grants the container control of the
     # host daemon (≈ host root). Enable it only on trusted cluster hosts.
     # - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -45,6 +45,20 @@ x-bernstein-common: &bernstein-common
   volumes:
     - sdd-data:/workspace/.sdd
     - project-data:/workspace/project
+    # Container sandbox isolation (`--sandbox docker` / the `regulated`
+    # compliance preset) runs each agent in its own sibling container. It needs
+    # THREE things the lean base image does not ship - uncomment the socket
+    # mount below AND use an image that adds the runtime CLI + Docker SDK:
+    #   1. a `docker` (or `podman`) CLI on PATH inside the container;
+    #   2. the Python Docker SDK: `pip install "bernstein[docker]"`;
+    #   3. the host Docker socket, mounted here.
+    # Without all three, an explicit `--sandbox docker` run refuses, while a
+    # `regulated`-preset run downgrades to worktree isolation - now surfaced in
+    # the run summary and the `sandbox.isolation_downgrade` audit entry, not a
+    # silent WARNING. See docs/operations/deployment-guide.md#container-sandbox-isolation---sandbox-docker-and-the-regulated-preset.
+    # SECURITY: mounting the Docker socket grants the container control of the
+    # host daemon (≈ host root). Enable it only on trusted cluster hosts.
+    # - /var/run/docker.sock:/var/run/docker.sock
   depends_on:
     bernstein-server:
       condition: service_healthy

--- a/docs/operations/deployment-guide.md
+++ b/docs/operations/deployment-guide.md
@@ -470,8 +470,8 @@ cannot be provided never silently becomes worktree isolation:
 
 | How isolation was requested | Runtime missing |
 |---|---|
-| `--sandbox docker`, where a sandbox backend provisions a session per spawn | **refuses** - the run fails with a `SandboxSelectionError` naming the cause, rather than dropping to a host spawn |
-| Any other configured container request (e.g. `sandbox:` in `bernstein.yaml`, which is the path the published image takes) | **downgrades to worktree isolation, surfaced and audited** |
+| `--sandbox docker` | **refuses** - a `SandboxSelectionError` naming the cause. The check runs at wiring time, so a missing Docker SDK or a dead daemon aborts the run *before any agent spawns*; if the daemon attaches but a per-agent session cannot be provisioned, the spawn refuses rather than dropping to a host spawn |
+| A container request configured without `--sandbox` (e.g. `sandbox:` in `bernstein.yaml`) | **downgrades to worktree isolation, surfaced and audited** |
 
 A downgrade is no longer a log-only event. It is recorded in the end-of-run
 summary (`summary.json` → `isolation_downgrades`, plus an "Isolation downgrade"

--- a/docs/operations/deployment-guide.md
+++ b/docs/operations/deployment-guide.md
@@ -419,14 +419,32 @@ docker compose logs -f bernstein-orchestrator
 > `bernstein-worker` replicas (or migrate to the SQLite/Redis backends -
 > separate ticket) for parallelism.
 
-### Container sandbox isolation (`--sandbox docker` and the `regulated` preset)
+### Container sandbox isolation (`--sandbox docker`)
 
-Per-agent container isolation (requested directly with `--sandbox docker`, or
-implied by the `--compliance regulated` preset, which selects a stronger
-isolation boundary) runs each agent in its own container instead of a git
-worktree. Inside the published `ghcr.io/sipyourdrink-ltd/bernstein` image this
+Per-agent container isolation runs each agent in its own container instead of a
+git worktree. It is requested **only** through the sandbox configuration - there
+are exactly three sources, and they are independent of every other setting:
+
+| Source | Example |
+|---|---|
+| The `sandbox:` section of `bernstein.yaml` | `sandbox: {enabled: true, runtime: docker}` |
+| The `--sandbox` CLI flag | `bernstein run plan.yaml --sandbox docker` |
+| The `BERNSTEIN_SANDBOX_RUNTIME` env var | `BERNSTEIN_SANDBOX_RUNTIME=docker` (set by `--sandbox`) |
+
+> **Compliance presets do not change your isolation boundary.** The
+> `regulated` preset (like the other presets - `development`, `standard`,
+> `hipaa`) controls audit logging, the HMAC audit chain, signed WAL, data
+> residency, SBOM generation, approval gates, mandatory human review, and
+> evidence-bundle export. It has **no** isolation or sandbox setting:
+> `compliance` and `sandbox` are parsed as separate sections and neither reads
+> the other. A `regulated` run uses whatever `sandbox:` specifies - which, if you
+> have not set it, is the default worktree isolation. If you want container
+> isolation, request it explicitly with `sandbox:` or `--sandbox`; selecting a
+> compliance preset will not do it for you.
+
+Inside the published `ghcr.io/sipyourdrink-ltd/bernstein` image the docker
 backend is **not available by default** - the image is intentionally lean and
-ships none of the three things the docker backend needs:
+ships none of the three things it needs:
 
 1. **A container-runtime CLI** on `PATH` inside the container (`docker` or
    `podman`).
@@ -447,23 +465,26 @@ rather than baking docker into the base image).
 > constraint, not a Bernstein limitation - add the path under Docker Desktop →
 > Settings → Resources → File sharing, or run the cluster on Linux.
 
-**What happens when the runtime is unavailable.** The behaviour depends on how
-the isolation was requested:
+**What happens when the runtime is unavailable.** Container isolation that
+cannot be provided never silently becomes worktree isolation:
 
-| Request | Runtime present | Runtime missing |
-|---|---|---|
-| Explicit `--sandbox docker` | runs in a container | **refuses** - the run fails with a clear `SandboxSelectionError` rather than silently downgrading |
-| `regulated` preset (implied) | runs in a container | **downgrades to worktree isolation, surfaced and audited** |
+| How isolation was requested | Runtime missing |
+|---|---|
+| `--sandbox docker`, where a sandbox backend provisions a session per spawn | **refuses** - the run fails with a `SandboxSelectionError` naming the cause, rather than dropping to a host spawn |
+| Any other configured container request (e.g. `sandbox:` in `bernstein.yaml`, which is the path the published image takes) | **downgrades to worktree isolation, surfaced and audited** |
 
-For the preset-implied case the downgrade is no longer a silent, log-only
-event: it is recorded in the end-of-run summary (`summary.json` →
-`isolation_downgrades`, and an "Isolation downgrade" row on the summary card)
-and as a `sandbox.isolation_downgrade` entry in the HMAC-chained audit log,
-carrying the requested-vs-actual isolation mode. An operator who selected a
-stronger boundary can therefore see, at run level, that a weaker one was used -
-and prove it from the audit chain. If your compliance posture requires the run
-to *fail closed* instead, request the backend explicitly with `--sandbox
-docker`, which refuses rather than downgrades.
+A downgrade is no longer a log-only event. It is recorded in the end-of-run
+summary (`summary.json` → `isolation_downgrades`, plus an "Isolation downgrade"
+row on the summary card) and as a `sandbox.isolation_downgrade` entry in the
+HMAC-chained audit log carrying the requested and actual isolation modes. An
+operator who asked for a stronger boundary can therefore see at run level that a
+weaker one was used - and prove it from the audit chain afterwards.
+
+If your posture requires the run to *fail closed* rather than continue on a
+weaker boundary, pin the backend with `--sandbox docker` and confirm the run
+aborts when no runtime is present. Note that a downgrade is reported per agent
+session, so a run that spawns several agents on a runtime-less host records one
+entry per affected session.
 
 ### Backing up state
 

--- a/docs/operations/deployment-guide.md
+++ b/docs/operations/deployment-guide.md
@@ -419,6 +419,52 @@ docker compose logs -f bernstein-orchestrator
 > `bernstein-worker` replicas (or migrate to the SQLite/Redis backends -
 > separate ticket) for parallelism.
 
+### Container sandbox isolation (`--sandbox docker` and the `regulated` preset)
+
+Per-agent container isolation (requested directly with `--sandbox docker`, or
+implied by the `--compliance regulated` preset, which selects a stronger
+isolation boundary) runs each agent in its own container instead of a git
+worktree. Inside the published `ghcr.io/sipyourdrink-ltd/bernstein` image this
+backend is **not available by default** - the image is intentionally lean and
+ships none of the three things the docker backend needs:
+
+1. **A container-runtime CLI** on `PATH` inside the container (`docker` or
+   `podman`).
+2. **The Python Docker SDK** - install the `docker` extra
+   (`pip install "bernstein[docker]"`, i.e. `pip install docker`).
+3. **A mounted Docker socket** so the in-container client can reach the host
+   daemon: bind-mount `/var/run/docker.sock`.
+
+Provide all three and the backend attaches and runs each agent in a sibling
+container. The shipped `docker-compose.yaml` includes a ready-to-uncomment
+socket mount on the worker/orchestrator services; you still need an image that
+contains the CLI + `docker` extra (build a thin layer on top of the base image
+rather than baking docker into the base image).
+
+> **macOS / Docker Desktop.** Docker Desktop restricts which host paths can be
+> bind-mounted into containers; a socket or workspace mount outside the shared
+> paths fails with "mounts denied". This is a Docker Desktop file-sharing
+> constraint, not a Bernstein limitation - add the path under Docker Desktop →
+> Settings → Resources → File sharing, or run the cluster on Linux.
+
+**What happens when the runtime is unavailable.** The behaviour depends on how
+the isolation was requested:
+
+| Request | Runtime present | Runtime missing |
+|---|---|---|
+| Explicit `--sandbox docker` | runs in a container | **refuses** - the run fails with a clear `SandboxSelectionError` rather than silently downgrading |
+| `regulated` preset (implied) | runs in a container | **downgrades to worktree isolation, surfaced and audited** |
+
+For the preset-implied case the downgrade is no longer a silent, log-only
+event: it is recorded in the end-of-run summary (`summary.json` →
+`isolation_downgrades`, and an "Isolation downgrade" row on the summary card)
+and as a `sandbox.isolation_downgrade` entry in the HMAC-chained audit log,
+carrying the requested-vs-actual isolation mode. An operator who selected a
+stronger boundary can therefore see, at run level, that a weaker one was used -
+and prove it from the audit chain. If your compliance posture requires the run
+to *fail closed* instead, request the backend explicitly with `--sandbox
+docker`, which refuses rather than downgrades.
+
 ### Backing up state
 
 `.sdd/` is mounted as a named volume (`sdd-data`). To back it up:

--- a/src/bernstein/cli/display/summary_card.py
+++ b/src/bernstein/cli/display/summary_card.py
@@ -32,11 +32,11 @@ class RunSummaryData:
     sequential_time_seconds: float | None = None
     cost_per_task_usd: float = 0.0
     routing_savings_usd: float = 0.0
-    # Issue #3014: spawns whose requested (or compliance-preset-implied)
-    # container isolation could not be honoured and fell back to a weaker
-    # boundary. Each item carries ``session_id``/``requested``/``actual``/
-    # ``reason`` so the run outcome shows requested-vs-actual isolation instead
-    # of hiding the downgrade in a log WARNING.
+    # Issue #3014: spawns whose requested container isolation could not be
+    # honoured and fell back to a weaker boundary. Each item carries
+    # ``session_id``/``requested``/``actual``/``reason`` so the run outcome
+    # shows requested-vs-actual isolation instead of hiding the downgrade in a
+    # log WARNING.
     isolation_downgrades: list[dict[str, str]] = field(default_factory=list)
     timestamp: float = field(default_factory=time.time)
 
@@ -154,8 +154,8 @@ def build_summary_card(data: RunSummaryData) -> Table:
         table.add_row("Quality score", f"[{q_color}]{pct:.0f}%[/{q_color}]")
 
     # Issue #3014: surface any isolation downgrade so an operator who requested
-    # a stronger boundary (e.g. the ``regulated`` preset or ``--sandbox
-    # docker``) sees at run level that a weaker one was used.
+    # a stronger boundary (``sandbox:`` config or ``--sandbox docker``) sees at
+    # run level that a weaker one was used.
     if data.isolation_downgrades:
         requested = data.isolation_downgrades[0].get("requested", "container")
         actual = data.isolation_downgrades[0].get("actual", "worktree")

--- a/src/bernstein/cli/display/summary_card.py
+++ b/src/bernstein/cli/display/summary_card.py
@@ -32,6 +32,12 @@ class RunSummaryData:
     sequential_time_seconds: float | None = None
     cost_per_task_usd: float = 0.0
     routing_savings_usd: float = 0.0
+    # Issue #3014: spawns whose requested (or compliance-preset-implied)
+    # container isolation could not be honoured and fell back to a weaker
+    # boundary. Each item carries ``session_id``/``requested``/``actual``/
+    # ``reason`` so the run outcome shows requested-vs-actual isolation instead
+    # of hiding the downgrade in a log WARNING.
+    isolation_downgrades: list[dict[str, str]] = field(default_factory=list)
     timestamp: float = field(default_factory=time.time)
 
     @property
@@ -146,6 +152,17 @@ def build_summary_card(data: RunSummaryData) -> Table:
         else:
             q_color = "red"
         table.add_row("Quality score", f"[{q_color}]{pct:.0f}%[/{q_color}]")
+
+    # Issue #3014: surface any isolation downgrade so an operator who requested
+    # a stronger boundary (e.g. the ``regulated`` preset or ``--sandbox
+    # docker``) sees at run level that a weaker one was used.
+    if data.isolation_downgrades:
+        requested = data.isolation_downgrades[0].get("requested", "container")
+        actual = data.isolation_downgrades[0].get("actual", "worktree")
+        table.add_row(
+            "[yellow]Isolation downgrade[/yellow]",
+            f"[yellow]{requested} -> {actual} (x{len(data.isolation_downgrades)})[/yellow]",
+        )
 
     return table
 

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -91,6 +91,7 @@ from bernstein.core.models import (
     AbortReason,
     AgentBackend,
     AgentSession,
+    IsolationDowngrade,
     IsolationMode,
     ModelConfig,
     Task,
@@ -1526,6 +1527,12 @@ class AgentSpawner:
         self._runtime_bridge = runtime_bridge
         self._sandbox = sandbox if sandbox is not None and sandbox.enabled else None
         self._sandbox_managers: dict[str, ContainerManager] = {}
+        # Issue #3014: requested-vs-actual isolation downgrades recorded when a
+        # container isolation request (explicit or compliance-preset-implied)
+        # cannot be honoured and the spawn falls back to a weaker boundary. The
+        # run summary drains this so the downgrade is visible in the run
+        # outcome, not just a log WARNING.
+        self._isolation_downgrades: list[IsolationDowngrade] = []
         # oai-002 phase 1: optional SandboxBackend-issued session.
         # Phase 2 (oai-002b) routes adapter exec through the session
         # via :mod:`spawner_sandbox_session` when the backend is not
@@ -4891,7 +4898,18 @@ class AgentSpawner:
                 session_id,
                 exc,
             )
-            session.isolation = IsolationMode.WORKTREE.value if self._use_worktrees else IsolationMode.NONE.value
+            actual = IsolationMode.WORKTREE.value if self._use_worktrees else IsolationMode.NONE.value
+            session.isolation = actual
+            # Issue #3014: the operator asked for container isolation (directly,
+            # or because a compliance preset implied it) and got a weaker
+            # boundary. Record the downgrade so it lands in the run summary and
+            # the audit chain instead of only this WARNING.
+            self._record_isolation_downgrade(
+                session_id=session_id,
+                requested=IsolationMode.CONTAINER.value,
+                actual=actual,
+                reason=str(exc),
+            )
             return adapter.spawn(
                 prompt=prompt,
                 workdir=spawn_cwd,
@@ -4991,7 +5009,18 @@ class AgentSpawner:
                     session_id,
                     exc,
                 )
-                session.isolation = IsolationMode.WORKTREE.value if self._use_worktrees else IsolationMode.NONE.value
+                actual = IsolationMode.WORKTREE.value if self._use_worktrees else IsolationMode.NONE.value
+                session.isolation = actual
+                # Issue #3014: an auto/preset-implied container isolation
+                # request that could not be provisioned degrades gracefully
+                # (the explicit path above refuses instead). Surface and audit
+                # the downgrade so it is visible in the run outcome.
+                self._record_isolation_downgrade(
+                    session_id=session_id,
+                    requested=IsolationMode.CONTAINER.value,
+                    actual=actual,
+                    reason=str(exc),
+                )
                 return adapter.spawn(
                     prompt=prompt,
                     workdir=spawn_cwd,
@@ -5319,6 +5348,64 @@ class AgentSpawner:
                 sbx_session.session_id,
                 port,
             )
+
+    @property
+    def isolation_downgrades(self) -> list[IsolationDowngrade]:
+        """Return the isolation downgrades recorded during this run.
+
+        Issue #3014: each entry is a spawn whose requested (or
+        compliance-preset-implied) container isolation could not be provided
+        and fell back to a weaker boundary. The orchestrator drains this into
+        the end-of-run summary so an operator who asked for stronger isolation
+        sees, at run level, that they got a weaker one.
+        """
+        return list(self._isolation_downgrades)
+
+    def _record_isolation_downgrade(
+        self,
+        *,
+        session_id: str,
+        requested: str,
+        actual: str,
+        reason: str,
+    ) -> None:
+        """Record - and audit - a requested-vs-actual isolation downgrade.
+
+        Issue #3014: a container isolation request that cannot be honoured used
+        to leave only a log WARNING, so an operator who selected the
+        ``regulated`` preset (or ``--sandbox docker``) silently ran on a weaker
+        boundary. This makes the downgrade a first-class, surfaced decision: it
+        is appended to :attr:`_isolation_downgrades` for the run summary and
+        written to the HMAC-chained audit log. Audit emission is best-effort and
+        never blocks the spawn (see :meth:`_emit_sandbox_audit`).
+
+        Args:
+            session_id: Agent session whose isolation was downgraded.
+            requested: Requested isolation mode (an :class:`IsolationMode`
+                value, e.g. ``"container"``).
+            actual: Isolation mode actually provided (e.g. ``"worktree"``).
+            reason: Human-readable cause (typically the runtime error).
+        """
+        self._isolation_downgrades.append(
+            IsolationDowngrade(
+                session_id=session_id,
+                requested=requested,
+                actual=actual,
+                reason=reason,
+            )
+        )
+        from bernstein.core.security.audit import SANDBOX_ISOLATION_DOWNGRADE
+
+        self._emit_sandbox_audit(
+            SANDBOX_ISOLATION_DOWNGRADE,
+            resource_id=session_id,
+            details={
+                "session_id": session_id,
+                "requested_isolation": requested,
+                "actual_isolation": actual,
+                "reason": reason,
+            },
+        )
 
     def _emit_sandbox_audit(self, event_type: str, *, resource_id: str, details: dict[str, Any]) -> None:
         """Append a sandbox lifecycle event to the HMAC-chained audit log.

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -1528,10 +1528,9 @@ class AgentSpawner:
         self._sandbox = sandbox if sandbox is not None and sandbox.enabled else None
         self._sandbox_managers: dict[str, ContainerManager] = {}
         # Issue #3014: requested-vs-actual isolation downgrades recorded when a
-        # container isolation request (explicit or compliance-preset-implied)
-        # cannot be honoured and the spawn falls back to a weaker boundary. The
-        # run summary drains this so the downgrade is visible in the run
-        # outcome, not just a log WARNING.
+        # container isolation request cannot be honoured and the spawn falls
+        # back to a weaker boundary. The run summary drains this so the
+        # downgrade is visible in the run outcome, not just a log WARNING.
         self._isolation_downgrades: list[IsolationDowngrade] = []
         # oai-002 phase 1: optional SandboxBackend-issued session.
         # Phase 2 (oai-002b) routes adapter exec through the session
@@ -4900,10 +4899,9 @@ class AgentSpawner:
             )
             actual = IsolationMode.WORKTREE.value if self._use_worktrees else IsolationMode.NONE.value
             session.isolation = actual
-            # Issue #3014: the operator asked for container isolation (directly,
-            # or because a compliance preset implied it) and got a weaker
-            # boundary. Record the downgrade so it lands in the run summary and
-            # the audit chain instead of only this WARNING.
+            # Issue #3014: the operator configured container isolation and got
+            # a weaker boundary. Record the downgrade so it lands in the run
+            # summary and the audit chain instead of only this WARNING.
             self._record_isolation_downgrade(
                 session_id=session_id,
                 requested=IsolationMode.CONTAINER.value,
@@ -5011,10 +5009,10 @@ class AgentSpawner:
                 )
                 actual = IsolationMode.WORKTREE.value if self._use_worktrees else IsolationMode.NONE.value
                 session.isolation = actual
-                # Issue #3014: an auto/preset-implied container isolation
-                # request that could not be provisioned degrades gracefully
-                # (the explicit path above refuses instead). Surface and audit
-                # the downgrade so it is visible in the run outcome.
+                # Issue #3014: a non-explicit container isolation request that
+                # could not be provisioned degrades gracefully (the explicit
+                # --sandbox path above refuses instead). Surface and audit the
+                # downgrade so it is visible in the run outcome.
                 self._record_isolation_downgrade(
                     session_id=session_id,
                     requested=IsolationMode.CONTAINER.value,
@@ -5353,11 +5351,11 @@ class AgentSpawner:
     def isolation_downgrades(self) -> list[IsolationDowngrade]:
         """Return the isolation downgrades recorded during this run.
 
-        Issue #3014: each entry is a spawn whose requested (or
-        compliance-preset-implied) container isolation could not be provided
-        and fell back to a weaker boundary. The orchestrator drains this into
-        the end-of-run summary so an operator who asked for stronger isolation
-        sees, at run level, that they got a weaker one.
+        Issue #3014: each entry is a spawn whose requested container isolation
+        could not be provided and fell back to a weaker boundary. The
+        orchestrator drains this into the end-of-run summary so an operator who
+        asked for stronger isolation sees, at run level, that they got a weaker
+        one.
         """
         return list(self._isolation_downgrades)
 
@@ -5372,9 +5370,9 @@ class AgentSpawner:
         """Record - and audit - a requested-vs-actual isolation downgrade.
 
         Issue #3014: a container isolation request that cannot be honoured used
-        to leave only a log WARNING, so an operator who selected the
-        ``regulated`` preset (or ``--sandbox docker``) silently ran on a weaker
-        boundary. This makes the downgrade a first-class, surfaced decision: it
+        to leave only a log WARNING, so an operator who configured ``sandbox:
+        docker`` silently ran on a weaker boundary. This makes the downgrade a
+        first-class, surfaced decision: it
         is appended to :attr:`_isolation_downgrades` for the run summary and
         written to the HMAC-chained audit log. Audit emission is best-effort and
         never blocks the spawn (see :meth:`_emit_sandbox_audit`).

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -4837,10 +4837,10 @@ class Orchestrator:
     def _collect_isolation_downgrades(self) -> list[dict[str, str]]:
         """Return requested-vs-actual isolation downgrades from the spawner.
 
-        Issue #3014: when a container isolation request (explicit or implied by
-        the ``regulated`` compliance preset) cannot be honoured, the spawn
-        falls back to a weaker boundary and records the downgrade. Draining it
-        into the run summary makes the downgrade visible in the run outcome.
+        Issue #3014: when a container isolation request cannot be honoured, the
+        spawn falls back to a weaker boundary and records the downgrade.
+        Draining it into the run summary makes the downgrade visible in the run
+        outcome.
         Guarded so an older or stubbed spawner without the attribute never
         breaks summary emission.
         """

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -4834,6 +4834,21 @@ class Orchestrator:
             )
         return ""
 
+    def _collect_isolation_downgrades(self) -> list[dict[str, str]]:
+        """Return requested-vs-actual isolation downgrades from the spawner.
+
+        Issue #3014: when a container isolation request (explicit or implied by
+        the ``regulated`` compliance preset) cannot be honoured, the spawn
+        falls back to a weaker boundary and records the downgrade. Draining it
+        into the run summary makes the downgrade visible in the run outcome.
+        Guarded so an older or stubbed spawner without the attribute never
+        breaks summary emission.
+        """
+        downgrades = getattr(self._spawner, "isolation_downgrades", None)
+        if not isinstance(downgrades, list):
+            return []
+        return [d.as_dict() for d in downgrades]
+
     def _emit_summary_card(
         self,
         done_tasks: list[Task],
@@ -4872,6 +4887,7 @@ class Orchestrator:
             wall_clock_seconds=wall_clock_s,
             total_cost_usd=total_cost,
             quality_score=quality_score,
+            isolation_downgrades=self._collect_isolation_downgrades(),
         )
 
         sdd_dir = self._workdir / ".sdd"

--- a/src/bernstein/core/orchestration/orchestrator_summary.py
+++ b/src/bernstein/core/orchestration/orchestrator_summary.py
@@ -173,9 +173,7 @@ def emit_summary_card(
     # Issue #3014: surface requested-vs-actual isolation downgrades recorded by
     # the spawner. Guarded so a stubbed/mock spawner without a real list is safe.
     spawner_downgrades = getattr(getattr(orch, "_spawner", None), "isolation_downgrades", None)
-    isolation_downgrades = (
-        [d.as_dict() for d in spawner_downgrades] if isinstance(spawner_downgrades, list) else []
-    )
+    isolation_downgrades = [d.as_dict() for d in spawner_downgrades] if isinstance(spawner_downgrades, list) else []
 
     summary_data = RunSummaryData(
         run_id=orch._run_id,

--- a/src/bernstein/core/orchestration/orchestrator_summary.py
+++ b/src/bernstein/core/orchestration/orchestrator_summary.py
@@ -170,6 +170,13 @@ def emit_summary_card(
         completed_tasks=len(done_tasks),
     )
 
+    # Issue #3014: surface requested-vs-actual isolation downgrades recorded by
+    # the spawner. Guarded so a stubbed/mock spawner without a real list is safe.
+    spawner_downgrades = getattr(getattr(orch, "_spawner", None), "isolation_downgrades", None)
+    isolation_downgrades = (
+        [d.as_dict() for d in spawner_downgrades] if isinstance(spawner_downgrades, list) else []
+    )
+
     summary_data = RunSummaryData(
         run_id=orch._run_id,
         tasks_completed=len(done_tasks),
@@ -181,6 +188,7 @@ def emit_summary_card(
         sequential_time_seconds=savings.sequential_time_seconds,
         cost_per_task_usd=savings.cost_per_task_usd,
         routing_savings_usd=savings.routing_savings_usd,
+        isolation_downgrades=isolation_downgrades,
     )
 
     sdd_dir = orch._workdir / ".sdd"

--- a/src/bernstein/core/security/audit.py
+++ b/src/bernstein/core/security/audit.py
@@ -114,12 +114,11 @@ SANDBOX_EXEC_END = "sandbox.exec_end"
 #: Issue #2162 - emitted when a per-agent sandbox session is destroyed.
 SANDBOX_SESSION_DESTROY = "sandbox.session_destroy"
 
-#: Issue #3014 - emitted when a requested (or compliance-preset-implied)
-#: container isolation boundary cannot be provided (no container runtime CLI,
-#: SDK, or socket) and the spawn falls back to a weaker boundary. Details carry
-#: the requested-vs-actual isolation mode and the reason, so the audit chain
-#: records the downgrade as a first-class decision instead of leaving it in a
-#: single log WARNING.
+#: Issue #3014 - emitted when a requested container isolation boundary cannot
+#: be provided (no container runtime CLI, SDK, or socket) and the spawn falls
+#: back to a weaker boundary. Details carry the requested-vs-actual isolation
+#: mode and the reason, so the audit chain records the downgrade as a
+#: first-class decision instead of leaving it in a single log WARNING.
 SANDBOX_ISOLATION_DOWNGRADE = "sandbox.isolation_downgrade"
 
 

--- a/src/bernstein/core/security/audit.py
+++ b/src/bernstein/core/security/audit.py
@@ -114,6 +114,14 @@ SANDBOX_EXEC_END = "sandbox.exec_end"
 #: Issue #2162 - emitted when a per-agent sandbox session is destroyed.
 SANDBOX_SESSION_DESTROY = "sandbox.session_destroy"
 
+#: Issue #3014 - emitted when a requested (or compliance-preset-implied)
+#: container isolation boundary cannot be provided (no container runtime CLI,
+#: SDK, or socket) and the spawn falls back to a weaker boundary. Details carry
+#: the requested-vs-actual isolation mode and the reason, so the audit chain
+#: records the downgrade as a first-class decision instead of leaving it in a
+#: single log WARNING.
+SANDBOX_ISOLATION_DOWNGRADE = "sandbox.isolation_downgrade"
+
 
 class AuditKeyPermissionError(RuntimeError):
     """Raised when the audit key file has permissions looser than 0600."""

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -1182,6 +1182,43 @@ class IsolationMode(StrEnum):
     CONTAINER = "container"
 
 
+@dataclass(frozen=True, slots=True)
+class IsolationDowngrade:
+    """A requested isolation boundary that could not be provided.
+
+    Issue #3014: when a spawn is routed to container isolation - directly via
+    ``--sandbox docker`` or, more subtly, because a compliance preset
+    (``regulated``) implied it - but no container runtime is available, the
+    spawn falls back to a weaker boundary (worktree, or none). Left as a bare
+    log WARNING, that downgrade is invisible to the operator who asked for the
+    stronger boundary. Recording it as a typed value lets the run summary and
+    the HMAC-chained audit log both surface requested-vs-actual isolation, so
+    the weaker posture is an auditable decision rather than a silent
+    substitution.
+
+    Attributes:
+        session_id: Agent session whose isolation was downgraded.
+        requested: The isolation mode that was requested (an
+            :class:`IsolationMode` value, e.g. ``"container"``).
+        actual: The isolation mode actually provided (e.g. ``"worktree"``).
+        reason: Human-readable cause (typically the container-runtime error).
+    """
+
+    session_id: str
+    requested: str
+    actual: str
+    reason: str
+
+    def as_dict(self) -> dict[str, str]:
+        """Return a JSON-serialisable mapping for run-summary rendering."""
+        return {
+            "session_id": self.session_id,
+            "requested": self.requested,
+            "actual": self.actual,
+            "reason": self.reason,
+        }
+
+
 class AgentBackend(StrEnum):
     """Agent execution backend.
 

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -1186,15 +1186,14 @@ class IsolationMode(StrEnum):
 class IsolationDowngrade:
     """A requested isolation boundary that could not be provided.
 
-    Issue #3014: when a spawn is routed to container isolation - directly via
-    ``--sandbox docker`` or, more subtly, because a compliance preset
-    (``regulated``) implied it - but no container runtime is available, the
-    spawn falls back to a weaker boundary (worktree, or none). Left as a bare
-    log WARNING, that downgrade is invisible to the operator who asked for the
-    stronger boundary. Recording it as a typed value lets the run summary and
-    the HMAC-chained audit log both surface requested-vs-actual isolation, so
-    the weaker posture is an auditable decision rather than a silent
-    substitution.
+    Issue #3014: when a spawn is routed to container isolation - via the
+    ``sandbox:`` config, ``--sandbox docker``, or ``BERNSTEIN_SANDBOX_RUNTIME``
+    - but no container runtime is available, the spawn falls back to a weaker
+    boundary (worktree, or none). Left as a bare log WARNING, that downgrade is
+    invisible to the operator who asked for the stronger boundary. Recording it
+    as a typed value lets the run summary and the HMAC-chained audit log both
+    surface requested-vs-actual isolation, so the weaker posture is an auditable
+    decision rather than a silent substitution.
 
     Attributes:
         session_id: Agent session whose isolation was downgraded.

--- a/tests/unit/test_spawner_sandbox.py
+++ b/tests/unit/test_spawner_sandbox.py
@@ -130,18 +130,24 @@ def _read_audit_events(audit_dir: Path) -> list[dict[str, object]]:
     return events
 
 
-def test_preset_implied_downgrade_is_surfaced_and_audited(
+def test_non_explicit_docker_request_downgrade_is_surfaced_and_audited(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Issue #3014: a preset-implied docker isolation request that cannot be
+    """Issue #3014: a non-explicit docker isolation request that cannot be
 
     honoured (no container runtime) must record a *surfaced* downgrade the run
     summary can render AND an audit-chain entry noting requested-vs-actual
-    isolation - not just a log WARNING. The explicit ``--sandbox docker`` path
-    already refuses (issue #2809); this covers the preset-implied fallback.
+    isolation - not just a log WARNING.
+
+    "Non-explicit" here means the sandbox came from the ``sandbox:`` section of
+    bernstein.yaml rather than from the ``--sandbox`` flag, so the
+    ``BERNSTEIN_SANDBOX_RUNTIME`` intent signal is unset and the spawn degrades
+    gracefully instead of refusing (the explicit path refuses - issue #2809).
+    This is the path the published image takes.
     """
     monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(tmp_path / "audit.key"))
-    # Preset-implied, NOT explicit: the --sandbox intent signal is unset.
+    # Configured via `sandbox:`, NOT pinned by --sandbox: the intent signal is
+    # unset, so this exercises the graceful-degradation path.
     monkeypatch.delenv("BERNSTEIN_SANDBOX_RUNTIME", raising=False)
 
     adapter = FakeAdapter("codex")

--- a/tests/unit/test_spawner_sandbox.py
+++ b/tests/unit/test_spawner_sandbox.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
 from bernstein.core.container import ContainerError, ContainerHandle
-from bernstein.core.models import AgentSession, ModelConfig
+from bernstein.core.models import AgentSession, IsolationMode, ModelConfig
 from bernstein.core.spawner import AgentSpawner
 
 from bernstein.adapters.base import CLIAdapter, SpawnResult
@@ -117,3 +119,123 @@ def test_spawn_in_sandbox_falls_back_to_adapter_on_runtime_failure(tmp_path: Pat
     assert adapter.spawn_calls == [("fallback", tmp_path)]
     assert session.container_id is None
     assert session.isolation == "worktree"
+
+
+def _read_audit_events(audit_dir: Path) -> list[dict[str, object]]:
+    """Return every audit-chain entry under ``audit_dir`` as parsed dicts."""
+    events: list[dict[str, object]] = []
+    for jsonl in audit_dir.glob("*.jsonl"):
+        for line in jsonl.read_text(encoding="utf-8").splitlines():
+            events.append(json.loads(line))
+    return events
+
+
+def test_preset_implied_downgrade_is_surfaced_and_audited(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Issue #3014: a preset-implied docker isolation request that cannot be
+
+    honoured (no container runtime) must record a *surfaced* downgrade the run
+    summary can render AND an audit-chain entry noting requested-vs-actual
+    isolation - not just a log WARNING. The explicit ``--sandbox docker`` path
+    already refuses (issue #2809); this covers the preset-implied fallback.
+    """
+    monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(tmp_path / "audit.key"))
+    # Preset-implied, NOT explicit: the --sandbox intent signal is unset.
+    monkeypatch.delenv("BERNSTEIN_SANDBOX_RUNTIME", raising=False)
+
+    adapter = FakeAdapter("codex")
+    sandbox = DockerSandbox(enabled=True)
+    session = AgentSession(id="S-3014", role="backend")
+
+    with (
+        patch("bernstein.core.agents.spawner_core.get_registry", return_value=MagicMock()),
+        patch(
+            "bernstein.core.agents.spawner_core.spawn_in_sandbox",
+            side_effect=ContainerError("Container runtime CLI 'docker' not found on PATH."),
+        ),
+    ):
+        spawner = AgentSpawner(
+            adapter=adapter,
+            templates_dir=tmp_path,
+            workdir=tmp_path,
+            use_worktrees=True,
+            sandbox=sandbox,
+        )
+        result = spawner._spawn_in_sandbox(  # pyright: ignore[reportPrivateUsage]
+            session_id="S-3014",
+            prompt="fallback",
+            spawn_cwd=tmp_path,
+            model_config=ModelConfig("sonnet", "high"),
+            mcp_config=None,
+            session=session,
+            adapter=adapter,
+        )
+
+    # The graceful fallback still runs on worktree isolation (behaviour kept).
+    assert result.pid == 42
+    assert session.isolation == IsolationMode.WORKTREE.value
+
+    # 1) Surfaced on the spawner so the run summary can render requested-vs-actual.
+    downgrades = spawner.isolation_downgrades
+    assert len(downgrades) == 1
+    entry = downgrades[0]
+    assert entry.session_id == "S-3014"
+    assert entry.requested == IsolationMode.CONTAINER.value
+    assert entry.actual == IsolationMode.WORKTREE.value
+    assert "docker" in entry.reason.lower()
+
+    # 2) Audited in the HMAC-chained audit log with requested-vs-actual isolation.
+    audit_dir = tmp_path / ".sdd" / "audit"
+    downgrade_events = [
+        e for e in _read_audit_events(audit_dir) if e["event_type"] == "sandbox.isolation_downgrade"
+    ]
+    assert len(downgrade_events) == 1
+    details = downgrade_events[0]["details"]
+    assert isinstance(details, dict)
+    assert details["requested_isolation"] == IsolationMode.CONTAINER.value
+    assert details["actual_isolation"] == IsolationMode.WORKTREE.value
+
+    # 3) The run-summary surface renders requested-vs-actual isolation.
+    from bernstein.cli.display.summary_card import RunSummaryData, write_summary_json
+
+    data = RunSummaryData(
+        run_id="R-3014",
+        tasks_completed=1,
+        tasks_total=1,
+        tasks_failed=0,
+        wall_clock_seconds=1.0,
+        total_cost_usd=0.0,
+        quality_score=None,
+        isolation_downgrades=[d.as_dict() for d in downgrades],
+    )
+    summary_path = write_summary_json(data, "R-3014", tmp_path / ".sdd")
+    summary_text = summary_path.read_text(encoding="utf-8")
+    assert "isolation" in summary_text.lower()
+    assert IsolationMode.CONTAINER.value in summary_text
+    assert IsolationMode.WORKTREE.value in summary_text
+
+
+def test_worktree_only_spawner_records_no_downgrade(tmp_path: Path) -> None:
+    """Operator explicitly choosing worktree isolation is left un-noised: no
+
+    downgrade is recorded and no ``sandbox.isolation_downgrade`` audit event is
+    emitted when no stronger isolation was ever requested (issue #3014).
+    """
+    adapter = FakeAdapter("claude")
+
+    with patch("bernstein.core.agents.spawner_core.get_registry", return_value=MagicMock()):
+        spawner = AgentSpawner(
+            adapter=adapter,
+            templates_dir=tmp_path,
+            workdir=tmp_path,
+            use_worktrees=True,
+            sandbox=None,
+        )
+
+    assert spawner.isolation_downgrades == []
+    audit_dir = tmp_path / ".sdd" / "audit"
+    if audit_dir.exists():
+        assert not [
+            e for e in _read_audit_events(audit_dir) if e["event_type"] == "sandbox.isolation_downgrade"
+        ]

--- a/tests/unit/test_spawner_sandbox.py
+++ b/tests/unit/test_spawner_sandbox.py
@@ -193,9 +193,7 @@ def test_non_explicit_docker_request_downgrade_is_surfaced_and_audited(
 
     # 2) Audited in the HMAC-chained audit log with requested-vs-actual isolation.
     audit_dir = tmp_path / ".sdd" / "audit"
-    downgrade_events = [
-        e for e in _read_audit_events(audit_dir) if e["event_type"] == "sandbox.isolation_downgrade"
-    ]
+    downgrade_events = [e for e in _read_audit_events(audit_dir) if e["event_type"] == "sandbox.isolation_downgrade"]
     assert len(downgrade_events) == 1
     details = downgrade_events[0]["details"]
     assert isinstance(details, dict)
@@ -242,6 +240,4 @@ def test_worktree_only_spawner_records_no_downgrade(tmp_path: Path) -> None:
     assert spawner.isolation_downgrades == []
     audit_dir = tmp_path / ".sdd" / "audit"
     if audit_dir.exists():
-        assert not [
-            e for e in _read_audit_events(audit_dir) if e["event_type"] == "sandbox.isolation_downgrade"
-        ]
+        assert not [e for e in _read_audit_events(audit_dir) if e["event_type"] == "sandbox.isolation_downgrade"]


### PR DESCRIPTION
Closes #3014

## Problem

Inside the published image the docker sandbox backend has no container-runtime CLI, so a configured container-isolation request silently fell back to worktree isolation behind a single log WARNING:

```
WARNING ... Sandbox runtime unavailable ... falling back to worktree isolation:
Container runtime CLI 'docker' not found on PATH.
```

An operator who asked for the stronger boundary got a weaker one with no run-level signal, no audit entry, and no refusal.

### Correction to the issue's premise

The issue states that the `regulated` compliance preset "indirectly" requests docker isolation. **That coupling does not exist**, and this PR does not assert it. Verified:

- `ComplianceConfig` has no isolation/sandbox/container field; the `REGULATED` branch sets none (`src/bernstein/core/security/compliance.py`).
- `compliance` and `sandbox` are parsed as independent sections (`src/bernstein/core/config/seed_parser.py`).
- The sandbox is wired only from `seed.sandbox` or `BERNSTEIN_SANDBOX_RUNTIME` (`src/bernstein/core/orchestration/orchestrator.py`); `--compliance` maps solely to `BERNSTEIN_COMPLIANCE`.

The downgrade observed in the issue came from the sandbox-selection path, not from the preset. The fix is therefore scoped to: **a non-explicit isolation request that cannot be honoured must be surfaced and audited.** Whether a compliance preset *should* imply an isolation floor is a design decision, not a doc fix — deliberately **not** implemented here.

## Fix

Make the fallback a first-class, **surfaced and audited** decision instead of a log-only event:

- **Run summary** — a requested-vs-actual `IsolationDowngrade` is recorded on the spawner and drained into the end-of-run summary: `summary.json` gains an `isolation_downgrades` list and the summary card shows an `Isolation downgrade` row (`container -> worktree`).
- **Audit chain** — each downgrade is written to the HMAC-chained audit log as a `sandbox.isolation_downgrade` event carrying `requested_isolation`, `actual_isolation`, and the reason. Emission is best-effort and never blocks the spawn.

The gate is the `--sandbox` intent signal (`BERNSTEIN_SANDBOX_RUNTIME`), never the compliance preset. An explicit `--sandbox docker` already **refuses** and is left unchanged: `attach_docker_backend(explicit=True)` raises at wiring time before any agent spawns when the SDK or daemon is unavailable, and a per-agent session that fails to provision refuses again at spawn time (issue #2809). This PR only affects container requests that were *not* pinned with `--sandbox`, which previously degraded silently. Worktree-default runs record nothing and stay un-noised.

## Docs & packaging

- `docs/operations/deployment-guide.md` documents that container isolation comes from exactly three sources (`sandbox:`, `--sandbox`, `BERNSTEIN_SANDBOX_RUNTIME`), states explicitly that **compliance presets do not change the isolation boundary**, lists the three things the lean image omits (a `docker`/`podman` CLI, the `bernstein[docker]` SDK, a mounted `/var/run/docker.sock`), and describes the actual refuse-vs-degrade behaviour plus the Docker-Desktop-for-Mac file-sharing caveat.
- `docker-compose.yaml` ships a ready-to-uncomment socket mount on the worker/orchestrator services with a security note; baking docker into the base image is intentionally avoided.

## Tests

`tests/unit/test_spawner_sandbox.py`:

- `test_non_explicit_docker_request_downgrade_is_surfaced_and_audited` — a configured (`sandbox:`-style) docker request with the `--sandbox` intent signal unset and no runtime present records the downgrade on the spawner, writes a `sandbox.isolation_downgrade` audit entry (requested vs actual), and renders requested-vs-actual isolation in the run summary — not just a WARNING. Graceful worktree fallback is preserved. The scenario is a genuine non-explicit request (a configured `DockerSandbox`), not an assumption that a preset triggers one.
- `test_worktree_only_spawner_records_no_downgrade` — explicit worktree isolation records no downgrade and emits no audit noise.

Ran only the touched test files (`test_spawner_sandbox.py`, `test_spawner_sandbox_session.py`, `test_summary_card.py`, `test_run_report.py`, `test_audit.py`, `test_models.py`) — all green. `ruff` clean; no new `mypy` errors; compose YAML validated.
