### PR TITLE
fix(reliability): stop reaping a still-working agent and reporting a no-output run HEALTHY

### DIFF
--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -20,14 +20,17 @@ import httpx
 from bernstein.cli.first_run_guard import handle_first_run_exception
 from bernstein.cli.helpers import (
     SDD_DIRS,
+    SDD_PID_SPAWNER,
     SERVER_URL,
     adapter_cli_choice,
     auth_headers,
     console,
     find_seed_file,
+    is_alive,
     persist_server_port,
     print_banner,
     print_startup_banner,
+    read_pid,
     server_get,
 )
 from bernstein.cli.run_preflight import (
@@ -1042,6 +1045,24 @@ def _signal_orchestrator_shutdown(*, reason: str = "cli detected run completion"
         )
 
 
+def _orchestrator_liveness() -> tuple[bool, bool]:
+    """Return ``(pidfile_present, process_alive)`` for the orchestrator.
+
+    Reads the same ``.sdd/runtime/spawner.pid`` pidfile the bootstrap
+    supervisor and the demo reap path use, through the same canonical
+    ``is_alive`` check, rather than introducing a second notion of aliveness.
+
+    Both flags are needed because "no pidfile" is ambiguous on its own: it
+    means either "the orchestrator has not started yet" (startup window) or
+    "it exited and cleaned up". A pidfile that is present but points at a dead
+    pid is NOT ambiguous -- the orchestrator ran and is now gone.
+    """
+    pid = read_pid(SDD_PID_SPAWNER)
+    if pid is None or pid <= 0:
+        return False, False
+    return True, is_alive(pid)
+
+
 def _wait_for_run_completion(
     *,
     poll_interval_s: float = 2.0,
@@ -1054,26 +1075,38 @@ def _wait_for_run_completion(
         timeout_s: Maximum total time to wait.
 
     Returns:
-        The final ``/status`` payload IF AND ONLY IF quiescence was actually
-        detected, else ``None``.
+        The ``/status`` payload IF AND ONLY IF the run actually reached a
+        terminal state, else ``None``.
+
+        There are two terminal states, and both return a payload:
+
+        * **Quiescent** -- ``open == claimed == 0`` with no live agents: every
+          declared task reached a terminal outcome.
+        * **Orchestrator gone with unfinished tasks** -- the spawner process
+          has exited while declared tasks are still non-terminal. Nothing will
+          ever advance them, so the run is over and its goal was not met
+          (issue #3010).
 
         A ``None`` return means "no verdict": the deadline expired (or the
-        server stayed unreachable) while the run was still in flight. It must
-        NOT be read as a failed run -- callers deriving an exit code from the
-        outcome have to treat it as unknown and stay at 0, because the
-        orchestrator keeps running in the background and may still complete
-        every task successfully.
+        server stayed unreachable) while the run was still genuinely in
+        flight. It must NOT be read as a failed run -- callers deriving an
+        exit code have to treat it as unknown and stay at 0, because the
+        orchestrator is still working and may complete every task.
 
-        Returning the last observed (non-quiescent) payload here instead would
-        hand callers a mid-flight snapshot that by definition still has
-        ``open``/``claimed`` > 0 -- that is exactly why quiescence was never
+        Returning the last observed (non-quiescent) payload for that case
+        instead would hand callers a mid-flight snapshot that by definition
+        still has ``open``/``claimed`` > 0 -- exactly why quiescence was never
         detected -- so a run that merely outlived the wait deadline would be
         misreported as unhealthy. Multi-hour goals are designed for (see the
         scope timeouts in ``core/defaults.py``, up to 7200s against this 3600s
         default deadline), which makes that misread the common case rather
-        than an edge one.
+        than an edge one. Orchestrator liveness -- not the task counts -- is
+        what separates "still starting up" from "ended with work unfinished".
     """
+    from bernstein.core.quality.retrospective import count_incomplete_declared
+
     deadline = time.time() + timeout_s
+    orchestrator_seen_alive = False
     while time.time() < deadline:
         status_payload = server_get("/status")
         health_payload = server_get("/health")
@@ -1092,6 +1125,40 @@ def _wait_for_run_completion(
                     agent_count,
                 )
                 _signal_orchestrator_shutdown(reason="cli detected run completion (quiescent)")
+                return status_payload
+
+            # Second terminal state: the orchestrator is gone while declared
+            # tasks are still non-terminal. Nothing will ever advance them, so
+            # this IS a verdict -- and an unhealthy one (issue #3010: the agent
+            # produced no output, its task stayed `open`, the orchestrator
+            # stopped, and the run reported success).
+            #
+            # Quiescence cannot cover this: it requires open == claimed == 0,
+            # which a stuck task never satisfies. Orchestrator liveness is the
+            # discriminator that separates it from the STARTUP window, where
+            # tasks are also `open` but the orchestrator is alive (or not yet
+            # started) and about to drive them.
+            #
+            # "Gone" is only concluded when it is unambiguous: either a pidfile
+            # is present but its pid is dead (it ran and died), or we watched
+            # the orchestrator alive earlier in this wait and it has since
+            # disappeared. A pidfile that simply has not been written yet is
+            # never read as "gone" -- when in doubt this falls through to
+            # "no verdict" and keeps waiting.
+            pid_present, alive = _orchestrator_liveness()
+            orchestrator_seen_alive = orchestrator_seen_alive or alive
+            orchestrator_gone = not alive and (pid_present or orchestrator_seen_alive)
+            if orchestrator_gone and agent_count == 0 and count_incomplete_declared(status_payload) > 0:
+                logger.warning(
+                    "run_ended_with_unfinished_tasks: orchestrator process is gone but "
+                    "total=%d open=%d claimed=%d are still non-terminal (agent_count=%d) -- "
+                    "nothing will advance them. Treating this as a terminal, non-healthy "
+                    "verdict rather than waiting out the deadline (issue #3010).",
+                    total,
+                    open_count,
+                    claimed_count,
+                    agent_count,
+                )
                 return status_payload
         time.sleep(poll_interval_s)
     logger.info(

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -49,7 +49,7 @@ from bernstein.core.orchestration.process_utils import (
     LIVENESS_ALIVE,
     LIVENESS_GONE,
     LIVENESS_UNKNOWN,
-    ORCHESTRATOR_PROCESS_MARKER,
+    ORCHESTRATOR_PROCESS_MARKERS,
     WATCHDOG_POLL_S,
     Liveness,
     classify_pidfile_liveness,
@@ -1054,19 +1054,28 @@ def _signal_orchestrator_shutdown(*, reason: str = "cli detected run completion"
 
 
 def _spawner_liveness_from_health(health_payload: Any) -> Liveness | None:
-    """Read the task server's own opinion of the orchestrator, or ``None``.
+    """Read the task server's opinion of the orchestrator, or ``None``.
 
-    ``GET /health`` reports ``components.spawner.status`` by running the same
-    pidfile check the CLI runs, but from inside the server process. That
-    matters because the server and the orchestrator are started together by
+    ``GET /health`` reports ``components.spawner.status``
+    (``core/routes/status_dashboard.py::_health_components``). The server runs
+    that check from inside its own process, which matters because the server
+    and the orchestrator are started together by
     ``core/orchestration/bootstrap.py`` and therefore share a pid namespace,
     while the CLI may not: the shipped container image runs the orchestrator in
-    a container, so a CLI outside it cannot see the orchestrator's pid at all
-    and its own probe would report a perfectly healthy orchestrator as dead.
+    a container, so a CLI outside it cannot see the orchestrator's pid at all.
+
+    This is NOT an independent second opinion, and callers must not treat it as
+    one. The server reads the SAME ``spawner.pid`` file and runs a plain
+    ``os.kill(pid, 0)`` on it, with none of the guards
+    :func:`classify_pidfile_liveness` applies: no mtime attribution, no
+    command-line identity, no zombie rejection. It is a strictly weaker read of
+    the same evidence. Treating its ``down`` as corroboration would let the
+    cruder observer override every guard the stricter one applies, and only in
+    the destructive direction. Hence :func:`_orchestrator_liveness` uses it as a
+    veto and never as a source of a verdict.
 
     Returns ``None`` when the server expresses no opinion (older server, no
-    ``sdd_dir`` configured, or no pidfile yet), which leaves the decision to
-    the local probe.
+    ``sdd_dir`` configured, or no pidfile yet).
     """
     if not isinstance(health_payload, dict):
         return None
@@ -1095,41 +1104,40 @@ def _orchestrator_liveness(
     streak of observations can tell "still the same dead process" from "a
     different process, so something restarted it".
 
-    Two observers are consulted, neither of which is trusted alone:
+    Every answer other than ``unknown`` requires positive LOCAL evidence, and
+    the task server can only veto it:
 
-    1. **The task server** (``/health`` -> ``components.spawner``), which shares
-       the orchestrator's pid namespace. It is the only observer that can see
-       the process at all when this CLI is outside that namespace.
-    2. **The local pidfile probe** (:func:`classify_pidfile_liveness` over
-       ``.sdd/runtime/spawner.pid``) -- the same classifier the recovery
-       supervisor in ``core/orchestration/bootstrap.py`` uses, so the two
-       subsystems cannot hold different definitions of "gone". It is the only
-       observer that rejects a zombie, which the server's cruder check reports
-       as running.
-
-    Resolution: agreement decides, one-sided evidence decides, and every
-    disagreement resolves to ``unknown``.
+    * **The local pidfile probe** (:func:`classify_pidfile_liveness` over
+       ``.sdd/runtime/spawner.pid``) is the sole source of a verdict. It is the
+       same classifier the recovery supervisor in
+       ``core/orchestration/bootstrap.py`` uses, so the two subsystems cannot
+       hold different definitions of "gone", and it is the only observer that
+       applies mtime attribution, command-line identity and zombie rejection.
+    * **The task server** (``/health`` -> ``components.spawner``) can veto, and
+       nothing else. It is not an independent witness: it reads the same pidfile
+       with a bare ``os.kill``, with none of those guards (see
+       :func:`_spawner_liveness_from_health`). Letting its ``down`` stand in for
+       local evidence would make every guard above overridable by the cruder
+       read of the same file, and only in the direction that reaps. What it CAN
+       do is see the orchestrator's pid namespace when this CLI cannot, so its
+       ``ok`` is allowed to overrule a local ``gone``.
 
     ==============  ==============  =========
-    server says     local probe     result
+    local probe     server says     result
     ==============  ==============  =========
-    ``ok``          ``alive``       ``alive``
-    ``ok``          ``unknown``     ``alive``
-    ``ok``          ``gone``        ``unknown``
-    ``down``        ``gone``        ``gone``
-    ``down``        ``unknown``     ``gone``
-    ``down``        ``alive``       ``unknown``
-    no opinion      ``alive``       ``alive``
-    no opinion      ``gone``        ``gone``
-    no opinion      ``unknown``     ``unknown``
+    ``gone``        ``down``        ``gone``
+    ``gone``        no opinion      ``gone``
+    ``gone``        ``ok``          ``unknown``  (veto)
+    ``alive``       ``ok``          ``alive``
+    ``alive``       no opinion      ``alive``
+    ``alive``       ``down``        ``unknown``  (veto)
+    ``unknown``     anything        ``unknown``
     ==============  ==============  =========
 
-    Neither disagreement row picks a winner, because each observer is the more
-    reliable one in a different failure mode and nothing here can tell which
-    mode is in play. ``ok``/``gone`` is either a CLI outside the namespace (the
-    server is right) or a zombie orchestrator (the local probe is right).
-    ``down``/``alive`` is either a stale pidfile whose pid has been recycled by
-    an unrelated process (the server is right) or a race (either could be).
+    The bottom row is the one the earlier revision got wrong: a missing,
+    unreadable, or previous-run pidfile used to become ``gone`` on the server's
+    say-so, contradicting the classifier's own contract and leaving ``pid`` as
+    ``None`` so a restart could not even be detected as a pid change.
 
     ``pidfile_not_before`` is forwarded to the local probe so a pidfile left
     behind by a previous run cannot be read as this run's death. Pass ``None``
@@ -1141,27 +1149,55 @@ def _orchestrator_liveness(
     local_view, pid = classify_pidfile_liveness(
         Path(SDD_PID_SPAWNER),
         not_before=pidfile_not_before,
-        expect_cmdline=ORCHESTRATOR_PROCESS_MARKER,
+        expect_cmdline=ORCHESTRATOR_PROCESS_MARKERS,
     )
-    if server_view is None or local_view == LIVENESS_UNKNOWN:
-        return (local_view if server_view is None else server_view), pid
-    if server_view != local_view:
+    if local_view == LIVENESS_UNKNOWN:
+        return LIVENESS_UNKNOWN, pid
+    if server_view is not None and server_view != local_view:
         return LIVENESS_UNKNOWN, pid
     return local_view, pid
 
 
-#: Consecutive polls that must ALL observe the orchestrator gone before the
-#: run is declared over. One observation is not evidence: see
-#: ``_ORCHESTRATOR_GONE_CONFIRM_WINDOW_S`` for why.
+#: Consecutive SUCCESSFUL OBSERVATIONS that must all find the orchestrator gone
+#: before the run is declared over. A poll that could not reach the server is
+#: not an observation and resets the count: see
+#: ``_ORCHESTRATOR_GONE_CONFIRM_WINDOW_S``.
 _ORCHESTRATOR_GONE_CONFIRMATIONS = 3
-#: Wall-clock the confirming observations must span, derived from the recovery
-#: supervisor's poll period rather than picked: ``run_watchdog`` in
+#: Monotonic seconds the confirming observations must span, derived from the
+#: recovery supervisor's poll period rather than picked: ``run_watchdog`` in
 #: ``core/orchestration/bootstrap.py`` restarts a dead orchestrator, so a dead
 #: pid is a RECOVERABLE state for up to one of its poll periods plus the
 #: restart itself. Three periods leaves the supervisor at least two full
 #: chances to act; if it did, the restarted process is observed alive (or under
-#: a new pid) and the streak resets, so the verdict can never win that race.
+#: a new pid) and the streak resets, so the verdict cannot win that race.
+#:
+#: Measured on ``time.monotonic()``, the same clock the supervisor sleeps on.
+#: On the wall clock an ordinary forward step -- an NTP correction, a container
+#: clock sync, a laptop resume -- satisfies the window without any real time
+#: passing, and a suspend-resume is the worst case: the supervisor's monotonic
+#: clock does not advance while suspended, so it wakes with zero extra restart
+#: attempts made while a wall-clock window would already read as satisfied.
 _ORCHESTRATOR_GONE_CONFIRM_WINDOW_S = 3.0 * WATCHDOG_POLL_S
+#: Monotonic slack allowed between two consecutive confirming observations
+#: before the streak is restarted. Without it, elapsed time in which this loop
+#: was not actually observing -- a hung request, a stopped process, a long GC
+#: pause -- would count towards the window just as if it had been.
+_ORCHESTRATOR_GONE_MAX_OBSERVATION_GAP_S = 2.0 * WATCHDOG_POLL_S
+
+
+def _looks_like_status_histogram(payload: dict[str, Any]) -> bool:
+    """Whether *payload* is recognisably a per-status task histogram.
+
+    ``GET /tasks/counts`` returns integer counts keyed by task status plus
+    ``total``. An error body is also a dict, and every status key is simply
+    absent from it, so counting one yields a confident zero for a run that may
+    have any amount of work outstanding. Requires ``total`` plus at least one
+    known status bucket, all integral.
+    """
+    if not isinstance(payload.get("total"), int):
+        return False
+    known = ("open", "claimed", "in_progress", "orphaned", "done", "failed")
+    return any(isinstance(payload.get(key), int) for key in known)
 
 
 def _incomplete_declared_counts(status_payload: dict[str, Any]) -> tuple[int, dict[str, Any] | None]:
@@ -1178,13 +1214,82 @@ def _incomplete_declared_counts(status_payload: dict[str, Any]) -> tuple[int, di
     the ``/status`` payload had to be used instead. Callers must treat that as
     "this count may be an undercount" and must not conclude anything terminal
     from a zero.
+
+    A dict that is not a histogram -- an error body such as
+    ``{"detail": "Not Found"}`` from a server that does not serve the route --
+    is rejected rather than accepted as an all-zero histogram. Counting it as
+    complete would report "nothing outstanding" for every run.
     """
     from bernstein.core.quality.retrospective import count_incomplete_declared
 
     full_counts = server_get("/tasks/counts")
-    if isinstance(full_counts, dict):
+    if isinstance(full_counts, dict) and _looks_like_status_histogram(full_counts):
         return count_incomplete_declared(full_counts), full_counts
     return count_incomplete_declared(status_payload), None
+
+
+def _is_quiescent(
+    *,
+    total: int,
+    open_count: int,
+    claimed_count: int,
+    agent_count: int,
+    n_incomplete: int,
+    counts_are_complete: bool,
+) -> bool:
+    """Whether every declared task has reached a terminal outcome, right now.
+
+    One definition, shared by the waiting path and the single-poll path, so the
+    two cannot drift into disagreeing about whether a run has finished.
+
+    The ``open``/``claimed`` test alone calls a run finished while a task sits
+    in ``in_progress`` or ``orphaned``, because ``/status`` has no bucket for
+    either, so the full histogram gets a veto whenever it is available. That
+    only ever tightens the test.
+
+    Unlike the "orchestrator gone" verdict this is a POSITIVE observation --
+    every task is accounted for in a terminal bucket -- rather than an inference
+    from a process's absence, so it needs no confirmation window and is safe to
+    conclude from a single poll.
+    """
+    quiescent = total > 0 and open_count == claimed_count == 0 and agent_count == 0
+    if quiescent and counts_are_complete and n_incomplete > 0:
+        return False
+    return quiescent
+
+
+def _poll_quiescent_status() -> dict[str, Any] | None:
+    """One poll: the ``/status`` payload iff the run is observably quiescent.
+
+    For the CLI paths that do NOT wait for completion (the dashboard, the Rich
+    fallback, and the non-interactive detach). Those paths still have to map an
+    already-finished run onto an exit code, or ``bernstein run && deploy``
+    deploys on a run whose tasks all failed just because the operator did not
+    pass ``--quiet`` (issue #3010).
+
+    Returns ``None`` for every other state, including "still running" and
+    "server unreachable". Only quiescence is reported here: the "orchestrator
+    gone" verdict is an inference from absence that requires a confirmation
+    window spanning several observations, which a single poll cannot supply, so
+    it stays on the waiting path alone.
+    """
+    status_payload = server_get("/status")
+    health_payload = server_get("/health")
+    if not (isinstance(status_payload, dict) and isinstance(health_payload, dict)):
+        return None
+    n_incomplete, full_counts = _incomplete_declared_counts(status_payload)
+    if full_counts is not None:
+        status_payload["task_counts"] = full_counts
+    if not _is_quiescent(
+        total=int(status_payload.get("total", 0) or 0),
+        open_count=int(status_payload.get("open", 0) or 0),
+        claimed_count=int(status_payload.get("claimed", 0) or 0),
+        agent_count=int(health_payload.get("agent_count", 0) or 0),
+        n_incomplete=n_incomplete,
+        counts_are_complete=full_counts is not None,
+    ):
+        return None
+    return status_payload
 
 
 def _wait_for_run_completion(
@@ -1232,13 +1337,13 @@ def _wait_for_run_completion(
     This verdict is the input to a non-zero exit code on a run an operator may
     still be watching, so it is built to be wrong in one direction only. Every
     condition below must hold on the SAME poll, and all of them must hold on
-    ``_ORCHESTRATOR_GONE_CONFIRMATIONS`` consecutive polls spanning at least
-    ``_ORCHESTRATOR_GONE_CONFIRM_WINDOW_S``:
+    ``_ORCHESTRATOR_GONE_CONFIRMATIONS`` consecutive SUCCESSFUL OBSERVATIONS
+    spanning at least ``_ORCHESTRATOR_GONE_CONFIRM_WINDOW_S`` of monotonic time:
 
     * :func:`_orchestrator_liveness` returns ``gone`` -- which needs positive
-      evidence of death from a pidfile attributable to this run, and needs the
-      task server (which shares the orchestrator's pid namespace, unlike this
-      CLI) not to contradict it.
+      local evidence of death from a pidfile attributable to this run, and needs
+      the task server (which shares the orchestrator's pid namespace, unlike
+      this CLI) not to contradict it.
     * the pid has not changed since the streak began. A different pid means
       something restarted the orchestrator, which resets the streak.
     * no agent is reported live.
@@ -1246,25 +1351,64 @@ def _wait_for_run_completion(
       per-status histogram. A partial histogram cannot support this verdict at
       all, because its zero is indistinguishable from an undercount.
 
-    Anything short of that -- a single dead-pid reading, a disagreement between
-    the two observers, a pidfile predating this run, an unreachable server, an
-    expired deadline -- yields no verdict and lets the run continue. The cost
-    of that is a healthy run's CLI waiting longer than it had to. The cost of
-    the opposite bias is telling an operator that a run which is still working
-    has failed.
+    "Consecutive successful observations" is the load-bearing phrase, and
+    elapsed time is not a substitute for it. The window exists to give the
+    recovery supervisor room to restart the orchestrator, so it may only be
+    satisfied by time in which a restart was actually possible AND would have
+    been seen. A poll that could not reach ``/status`` or ``/health`` is not an
+    observation: it resets the streak. That case is not hypothetical -- when the
+    task server is down, ``bootstrap._restart_spawner`` returns ``-1`` and
+    refuses to restart the orchestrator at all, so a server outage is precisely
+    the period during which recovery is impossible, and counting it as
+    confirmation would fire the verdict just as the recovery sequence reaches
+    the orchestrator. Two consecutive confirming observations more than
+    ``_ORCHESTRATOR_GONE_MAX_OBSERVATION_GAP_S`` apart also restart the streak,
+    so time this loop spent not observing cannot be credited either.
+
+    Anything short of all that -- a single dead-pid reading, a server that
+    contradicts the local probe, a pidfile predating this run, an unreachable
+    server, an expired deadline -- yields no verdict and lets the run continue.
+    The cost of that is a healthy run's CLI waiting longer than it had to. The
+    cost of the opposite bias is telling an operator that a run which is still
+    working has failed.
     """
     start = time.time()
     deadline = start + timeout_s
     orchestrator_seen_alive = False
+    # Streak state. All timing here is monotonic: see
+    # _ORCHESTRATOR_GONE_CONFIRM_WINDOW_S for why the wall clock cannot be used.
     gone_since: float | None = None
+    gone_last_seen: float | None = None
     gone_polls = 0
     gone_pid: int | None = None
+
+    def _reset_streak(reason: str, **fields: Any) -> None:
+        nonlocal gone_since, gone_last_seen, gone_polls, gone_pid
+        if gone_polls:
+            logger.info(
+                "orchestrator_gone_streak_reset after %d observation(s): reason=%s %s",
+                gone_polls,
+                reason,
+                fields,
+            )
+        gone_since = None
+        gone_last_seen = None
+        gone_polls = 0
+        gone_pid = None
+
     while True:
         now = time.time()
         if now >= deadline:
             break
+        mono = time.monotonic()
         status_payload = server_get("/status")
         health_payload = server_get("/health")
+        if not (isinstance(status_payload, dict) and isinstance(health_payload, dict)):
+            # Not an observation. The window may only be satisfied by time in
+            # which a recovery restart was possible and would have been seen,
+            # and a server this CLI cannot reach is exactly the state in which
+            # bootstrap._restart_spawner refuses to restart the orchestrator.
+            _reset_streak("server_unreachable")
         if isinstance(status_payload, dict) and isinstance(health_payload, dict):
             total = int(status_payload.get("total", 0) or 0)
             open_count = int(status_payload.get("open", 0) or 0)
@@ -1277,19 +1421,21 @@ def _wait_for_run_completion(
                 # health verdict sees in_progress/orphaned too.
                 status_payload["task_counts"] = full_counts
 
-            # Quiescence. The open/claimed test alone calls a run finished
-            # while a task sits in `in_progress` or `orphaned`, because
-            # /status has no bucket for either -- so the full histogram, when
-            # we have it, gets a veto. This only ever tightens the test.
-            quiescent = total > 0 and open_count == claimed_count == 0 and agent_count == 0
-            if quiescent and counts_are_complete and n_incomplete > 0:
+            quiescent = _is_quiescent(
+                total=total,
+                open_count=open_count,
+                claimed_count=claimed_count,
+                agent_count=agent_count,
+                n_incomplete=n_incomplete,
+                counts_are_complete=counts_are_complete,
+            )
+            if not quiescent and open_count == claimed_count == 0 and counts_are_complete and n_incomplete > 0:
                 logger.info(
                     "run_not_quiescent: open=0 claimed=0 but %d declared task(s) are still "
                     "non-terminal in the full histogram (in_progress/orphaned are invisible to "
                     "/status) - continuing to wait",
                     n_incomplete,
                 )
-                quiescent = False
             if quiescent:
                 logger.info(
                     "run_completion_detected: total=%d open=%d claimed=%d agent_count=%d "
@@ -1324,39 +1470,39 @@ def _wait_for_run_completion(
                 orchestrator_seen_alive = True
 
             terminal_shape = liveness == LIVENESS_GONE and agent_count == 0 and counts_are_complete and n_incomplete > 0
-            if not terminal_shape or (gone_since is not None and pid != gone_pid):
-                # Any non-confirming observation -- including a restart, which
-                # shows up as a different pid -- restarts the window from zero.
-                if gone_polls:
-                    logger.info(
-                        "orchestrator_gone_streak_reset after %d poll(s): liveness=%s pid=%s "
-                        "agent_count=%d incomplete=%d complete_counts=%s",
-                        gone_polls,
-                        liveness,
-                        pid,
-                        agent_count,
-                        n_incomplete,
-                        counts_are_complete,
-                    )
-                gone_since = None
-                gone_polls = 0
-                gone_pid = None
+            if not terminal_shape:
+                _reset_streak(
+                    "not_terminal_shape",
+                    liveness=liveness,
+                    agent_count=agent_count,
+                    incomplete=n_incomplete,
+                    complete_counts=counts_are_complete,
+                )
+            elif gone_since is not None and pid != gone_pid:
+                # A different pid means something restarted the orchestrator.
+                _reset_streak("pid_changed", was=gone_pid, now=pid)
+            elif gone_last_seen is not None and (mono - gone_last_seen) > _ORCHESTRATOR_GONE_MAX_OBSERVATION_GAP_S:
+                # Time passed in which this loop was not observing. It cannot
+                # count towards a window that exists to bound recovery.
+                _reset_streak("observation_gap", gap_s=round(mono - gone_last_seen, 1))
 
             if terminal_shape:
                 if gone_since is None:
-                    gone_since = now
+                    gone_since = mono
                     gone_pid = pid
+                gone_last_seen = mono
                 gone_polls += 1
-                confirmed_for = now - gone_since
+                confirmed_for = mono - gone_since
                 if gone_polls >= _ORCHESTRATOR_GONE_CONFIRMATIONS and (
                     confirmed_for >= _ORCHESTRATOR_GONE_CONFIRM_WINDOW_S
                 ):
                     logger.warning(
                         "run_ended_with_unfinished_tasks: orchestrator pid=%s observed gone on "
-                        "%d consecutive polls over %.0fs (> the %.0fs recovery-supervisor window, "
-                        "so no restart is coming) while %d declared task(s) are still non-terminal "
-                        "(total=%d open=%d claimed=%d agent_count=%d). Treating this as a terminal, "
-                        "non-healthy verdict (issue #3010).",
+                        "%d consecutive reachable polls over %.0fs monotonic (> the %.0fs "
+                        "recovery-supervisor window, so no restart is coming) while %d declared "
+                        "task(s) are still non-terminal (total=%d open=%d claimed=%d "
+                        "agent_count=%d). Treating this as a terminal, non-healthy verdict "
+                        "(issue #3010).",
                         pid,
                         gone_polls,
                         confirmed_for,
@@ -1369,8 +1515,9 @@ def _wait_for_run_completion(
                     )
                     return status_payload
                 logger.info(
-                    "orchestrator_gone_unconfirmed: pid=%s seen gone on poll %d/%d after %.0fs of "
-                    "the %.0fs confirmation window - a recovery restart would still pre-empt this",
+                    "orchestrator_gone_unconfirmed: pid=%s seen gone on observation %d/%d after "
+                    "%.0fs of the %.0fs confirmation window - a recovery restart would still "
+                    "pre-empt this",
                     pid,
                     gone_polls,
                     _ORCHESTRATOR_GONE_CONFIRMATIONS,

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -26,14 +26,13 @@ from bernstein.cli.helpers import (
     auth_headers,
     console,
     find_seed_file,
-    is_alive,
     persist_server_port,
     print_banner,
     print_startup_banner,
-    read_pid,
     server_get,
 )
 from bernstein.cli.run_preflight import (
+    _CLI_RUN_EPOCH,
     _abort_if_default_branch_merge_target,
     _configure_quality_gate_bypass,
     _emit_preflight_runtime_warnings,
@@ -46,6 +45,15 @@ from bernstein.cli.run_preflight import (
 )
 from bernstein.core.cost import estimate_run_cost
 from bernstein.core.manager_parsing import _resolve_depends_on  # pyright: ignore[reportPrivateUsage]
+from bernstein.core.orchestration.process_utils import (
+    LIVENESS_ALIVE,
+    LIVENESS_GONE,
+    LIVENESS_UNKNOWN,
+    ORCHESTRATOR_PROCESS_MARKER,
+    WATCHDOG_POLL_S,
+    Liveness,
+    classify_pidfile_liveness,
+)
 from bernstein.core.plan_loader import PlanLoadError, load_plan, load_plan_from_yaml
 
 logger = logging.getLogger(__name__)
@@ -1045,22 +1053,138 @@ def _signal_orchestrator_shutdown(*, reason: str = "cli detected run completion"
         )
 
 
-def _orchestrator_liveness() -> tuple[bool, bool]:
-    """Return ``(pidfile_present, process_alive)`` for the orchestrator.
+def _spawner_liveness_from_health(health_payload: Any) -> Liveness | None:
+    """Read the task server's own opinion of the orchestrator, or ``None``.
 
-    Reads the same ``.sdd/runtime/spawner.pid`` pidfile the bootstrap
-    supervisor and the demo reap path use, through the same canonical
-    ``is_alive`` check, rather than introducing a second notion of aliveness.
+    ``GET /health`` reports ``components.spawner.status`` by running the same
+    pidfile check the CLI runs, but from inside the server process. That
+    matters because the server and the orchestrator are started together by
+    ``core/orchestration/bootstrap.py`` and therefore share a pid namespace,
+    while the CLI may not: the shipped container image runs the orchestrator in
+    a container, so a CLI outside it cannot see the orchestrator's pid at all
+    and its own probe would report a perfectly healthy orchestrator as dead.
 
-    Both flags are needed because "no pidfile" is ambiguous on its own: it
-    means either "the orchestrator has not started yet" (startup window) or
-    "it exited and cleaned up". A pidfile that is present but points at a dead
-    pid is NOT ambiguous -- the orchestrator ran and is now gone.
+    Returns ``None`` when the server expresses no opinion (older server, no
+    ``sdd_dir`` configured, or no pidfile yet), which leaves the decision to
+    the local probe.
     """
-    pid = read_pid(SDD_PID_SPAWNER)
-    if pid is None or pid <= 0:
-        return False, False
-    return True, is_alive(pid)
+    if not isinstance(health_payload, dict):
+        return None
+    components = health_payload.get("components")
+    if not isinstance(components, dict):
+        return None
+    spawner = components.get("spawner")
+    if not isinstance(spawner, dict):
+        return None
+    status = str(spawner.get("status") or "").strip().lower()
+    if status == "ok":
+        return LIVENESS_ALIVE
+    if status == "down":
+        return LIVENESS_GONE
+    return None
+
+
+def _orchestrator_liveness(
+    health_payload: Any = None,
+    *,
+    pidfile_not_before: float | None = None,
+) -> tuple[Liveness, int | None]:
+    """Classify the orchestrator as ``alive``, ``gone``, or ``unknown``.
+
+    Returns ``(liveness, pid)``. The pid is returned so a caller tracking a
+    streak of observations can tell "still the same dead process" from "a
+    different process, so something restarted it".
+
+    Two observers are consulted, neither of which is trusted alone:
+
+    1. **The task server** (``/health`` -> ``components.spawner``), which shares
+       the orchestrator's pid namespace. It is the only observer that can see
+       the process at all when this CLI is outside that namespace.
+    2. **The local pidfile probe** (:func:`classify_pidfile_liveness` over
+       ``.sdd/runtime/spawner.pid``) -- the same classifier the recovery
+       supervisor in ``core/orchestration/bootstrap.py`` uses, so the two
+       subsystems cannot hold different definitions of "gone". It is the only
+       observer that rejects a zombie, which the server's cruder check reports
+       as running.
+
+    Resolution: agreement decides, one-sided evidence decides, and every
+    disagreement resolves to ``unknown``.
+
+    ==============  ==============  =========
+    server says     local probe     result
+    ==============  ==============  =========
+    ``ok``          ``alive``       ``alive``
+    ``ok``          ``unknown``     ``alive``
+    ``ok``          ``gone``        ``unknown``
+    ``down``        ``gone``        ``gone``
+    ``down``        ``unknown``     ``gone``
+    ``down``        ``alive``       ``unknown``
+    no opinion      ``alive``       ``alive``
+    no opinion      ``gone``        ``gone``
+    no opinion      ``unknown``     ``unknown``
+    ==============  ==============  =========
+
+    Neither disagreement row picks a winner, because each observer is the more
+    reliable one in a different failure mode and nothing here can tell which
+    mode is in play. ``ok``/``gone`` is either a CLI outside the namespace (the
+    server is right) or a zombie orchestrator (the local probe is right).
+    ``down``/``alive`` is either a stale pidfile whose pid has been recycled by
+    an unrelated process (the server is right) or a race (either could be).
+
+    ``pidfile_not_before`` is forwarded to the local probe so a pidfile left
+    behind by a previous run cannot be read as this run's death. Pass ``None``
+    once the orchestrator has actually been observed alive during this wait --
+    at that point the pidfile is known to describe a process of this run
+    regardless of its mtime.
+    """
+    server_view = _spawner_liveness_from_health(health_payload)
+    local_view, pid = classify_pidfile_liveness(
+        Path(SDD_PID_SPAWNER),
+        not_before=pidfile_not_before,
+        expect_cmdline=ORCHESTRATOR_PROCESS_MARKER,
+    )
+    if server_view is None or local_view == LIVENESS_UNKNOWN:
+        return (local_view if server_view is None else server_view), pid
+    if server_view != local_view:
+        return LIVENESS_UNKNOWN, pid
+    return local_view, pid
+
+
+#: Consecutive polls that must ALL observe the orchestrator gone before the
+#: run is declared over. One observation is not evidence: see
+#: ``_ORCHESTRATOR_GONE_CONFIRM_WINDOW_S`` for why.
+_ORCHESTRATOR_GONE_CONFIRMATIONS = 3
+#: Wall-clock the confirming observations must span, derived from the recovery
+#: supervisor's poll period rather than picked: ``run_watchdog`` in
+#: ``core/orchestration/bootstrap.py`` restarts a dead orchestrator, so a dead
+#: pid is a RECOVERABLE state for up to one of its poll periods plus the
+#: restart itself. Three periods leaves the supervisor at least two full
+#: chances to act; if it did, the restarted process is observed alive (or under
+#: a new pid) and the streak resets, so the verdict can never win that race.
+_ORCHESTRATOR_GONE_CONFIRM_WINDOW_S = 3.0 * WATCHDOG_POLL_S
+
+
+def _incomplete_declared_counts(status_payload: dict[str, Any]) -> tuple[int, dict[str, Any] | None]:
+    """Return ``(n_incomplete_declared, full_histogram_or_None)`` for the run.
+
+    ``GET /status`` reports only ``open``/``claimed``/``done``/``failed``/
+    ``refused``. Two of the four statuses that mean "declared but never
+    finished" -- ``in_progress`` and ``orphaned`` -- have no bucket in that
+    payload at all, so counting them from it always yields zero no matter how
+    many tasks are stuck in them. ``GET /tasks/counts`` is the full per-status
+    histogram and is the only source that can answer this question.
+
+    The second element is ``None`` when the full histogram was unavailable and
+    the ``/status`` payload had to be used instead. Callers must treat that as
+    "this count may be an undercount" and must not conclude anything terminal
+    from a zero.
+    """
+    from bernstein.core.quality.retrospective import count_incomplete_declared
+
+    full_counts = server_get("/tasks/counts")
+    if isinstance(full_counts, dict):
+        return count_incomplete_declared(full_counts), full_counts
+    return count_incomplete_declared(status_payload), None
 
 
 def _wait_for_run_completion(
@@ -1068,7 +1192,7 @@ def _wait_for_run_completion(
     poll_interval_s: float = 2.0,
     timeout_s: float = 3600.0,
 ) -> dict[str, Any] | None:
-    """Poll the server until the run becomes quiescent.
+    """Poll the server until the run reaches a terminal state.
 
     Args:
         poll_interval_s: Delay between status polls.
@@ -1080,34 +1204,65 @@ def _wait_for_run_completion(
 
         There are two terminal states, and both return a payload:
 
-        * **Quiescent** -- ``open == claimed == 0`` with no live agents: every
-          declared task reached a terminal outcome.
+        * **Quiescent** -- no declared task is still open/claimed/in-progress/
+          orphaned and no agent is live: every declared task reached a terminal
+          outcome.
         * **Orchestrator gone with unfinished tasks** -- the spawner process
-          has exited while declared tasks are still non-terminal. Nothing will
-          ever advance them, so the run is over and its goal was not met
-          (issue #3010).
+          has been observed gone across a confirmation window while declared
+          tasks are still non-terminal, so the run is over and its goal was not
+          met (issue #3010).
 
         A ``None`` return means "no verdict": the deadline expired (or the
         server stayed unreachable) while the run was still genuinely in
         flight. It must NOT be read as a failed run -- callers deriving an
         exit code have to treat it as unknown and stay at 0, because the
-        orchestrator is still working and may complete every task.
+        orchestrator may still be working and may complete every task.
 
         Returning the last observed (non-quiescent) payload for that case
         instead would hand callers a mid-flight snapshot that by definition
-        still has ``open``/``claimed`` > 0 -- exactly why quiescence was never
+        still has work outstanding -- exactly why quiescence was never
         detected -- so a run that merely outlived the wait deadline would be
         misreported as unhealthy. Multi-hour goals are designed for (see the
         scope timeouts in ``core/defaults.py``, up to 7200s against this 3600s
         default deadline), which makes that misread the common case rather
-        than an edge one. Orchestrator liveness -- not the task counts -- is
-        what separates "still starting up" from "ended with work unfinished".
-    """
-    from bernstein.core.quality.retrospective import count_incomplete_declared
+        than an edge one.
 
-    deadline = time.time() + timeout_s
+    What the "orchestrator gone" verdict actually requires, and why:
+
+    This verdict is the input to a non-zero exit code on a run an operator may
+    still be watching, so it is built to be wrong in one direction only. Every
+    condition below must hold on the SAME poll, and all of them must hold on
+    ``_ORCHESTRATOR_GONE_CONFIRMATIONS`` consecutive polls spanning at least
+    ``_ORCHESTRATOR_GONE_CONFIRM_WINDOW_S``:
+
+    * :func:`_orchestrator_liveness` returns ``gone`` -- which needs positive
+      evidence of death from a pidfile attributable to this run, and needs the
+      task server (which shares the orchestrator's pid namespace, unlike this
+      CLI) not to contradict it.
+    * the pid has not changed since the streak began. A different pid means
+      something restarted the orchestrator, which resets the streak.
+    * no agent is reported live.
+    * at least one declared task is still non-terminal, counted from the FULL
+      per-status histogram. A partial histogram cannot support this verdict at
+      all, because its zero is indistinguishable from an undercount.
+
+    Anything short of that -- a single dead-pid reading, a disagreement between
+    the two observers, a pidfile predating this run, an unreachable server, an
+    expired deadline -- yields no verdict and lets the run continue. The cost
+    of that is a healthy run's CLI waiting longer than it had to. The cost of
+    the opposite bias is telling an operator that a run which is still working
+    has failed.
+    """
+    start = time.time()
+    deadline = start + timeout_s
     orchestrator_seen_alive = False
-    while time.time() < deadline:
+    gone_since: float | None = None
+    gone_polls = 0
+    gone_pid: int | None = None
+    while True:
+        now = time.time()
+        if now >= deadline:
+            break
         status_payload = server_get("/status")
         health_payload = server_get("/health")
         if isinstance(status_payload, dict) and isinstance(health_payload, dict):
@@ -1115,7 +1270,27 @@ def _wait_for_run_completion(
             open_count = int(status_payload.get("open", 0) or 0)
             claimed_count = int(status_payload.get("claimed", 0) or 0)
             agent_count = int(health_payload.get("agent_count", 0) or 0)
-            if total > 0 and open_count == claimed_count == 0 and (agent_count == 0):
+            n_incomplete, full_counts = _incomplete_declared_counts(status_payload)
+            counts_are_complete = full_counts is not None
+            if full_counts is not None:
+                # Carry the full histogram with the payload so the caller's
+                # health verdict sees in_progress/orphaned too.
+                status_payload["task_counts"] = full_counts
+
+            # Quiescence. The open/claimed test alone calls a run finished
+            # while a task sits in `in_progress` or `orphaned`, because
+            # /status has no bucket for either -- so the full histogram, when
+            # we have it, gets a veto. This only ever tightens the test.
+            quiescent = total > 0 and open_count == claimed_count == 0 and agent_count == 0
+            if quiescent and counts_are_complete and n_incomplete > 0:
+                logger.info(
+                    "run_not_quiescent: open=0 claimed=0 but %d declared task(s) are still "
+                    "non-terminal in the full histogram (in_progress/orphaned are invisible to "
+                    "/status) - continuing to wait",
+                    n_incomplete,
+                )
+                quiescent = False
+            if quiescent:
                 logger.info(
                     "run_completion_detected: total=%d open=%d claimed=%d agent_count=%d "
                     "- sending belt-and-braces shutdown signal",
@@ -1128,41 +1303,83 @@ def _wait_for_run_completion(
                 return status_payload
 
             # Second terminal state: the orchestrator is gone while declared
-            # tasks are still non-terminal. Nothing will ever advance them, so
-            # this IS a verdict -- and an unhealthy one (issue #3010: the agent
-            # produced no output, its task stayed `open`, the orchestrator
-            # stopped, and the run reported success).
+            # tasks are still non-terminal (issue #3010: the agent produced no
+            # output, its task stayed non-terminal, the orchestrator stopped,
+            # and the run reported success).
             #
-            # Quiescence cannot cover this: it requires open == claimed == 0,
+            # Quiescence cannot cover this: it requires nothing outstanding,
             # which a stuck task never satisfies. Orchestrator liveness is the
             # discriminator that separates it from the STARTUP window, where
-            # tasks are also `open` but the orchestrator is alive (or not yet
-            # started) and about to drive them.
+            # tasks are also outstanding but the orchestrator is alive (or not
+            # yet started) and about to drive them.
             #
-            # "Gone" is only concluded when it is unambiguous: either a pidfile
-            # is present but its pid is dead (it ran and died), or we watched
-            # the orchestrator alive earlier in this wait and it has since
-            # disappeared. A pidfile that simply has not been written yet is
-            # never read as "gone" -- when in doubt this falls through to
-            # "no verdict" and keeps waiting.
-            pid_present, alive = _orchestrator_liveness()
-            orchestrator_seen_alive = orchestrator_seen_alive or alive
-            orchestrator_gone = not alive and (pid_present or orchestrator_seen_alive)
-            if orchestrator_gone and agent_count == 0 and count_incomplete_declared(status_payload) > 0:
-                logger.warning(
-                    "run_ended_with_unfinished_tasks: orchestrator process is gone but "
-                    "total=%d open=%d claimed=%d are still non-terminal (agent_count=%d) -- "
-                    "nothing will advance them. Treating this as a terminal, non-healthy "
-                    "verdict rather than waiting out the deadline (issue #3010).",
-                    total,
-                    open_count,
-                    claimed_count,
-                    agent_count,
+            # Once the orchestrator has been seen alive in THIS wait, its
+            # pidfile is known to belong to this run, so the mtime guard that
+            # protects the startup window is no longer needed.
+            liveness, pid = _orchestrator_liveness(
+                health_payload,
+                pidfile_not_before=None if orchestrator_seen_alive else _CLI_RUN_EPOCH,
+            )
+            if liveness == LIVENESS_ALIVE:
+                orchestrator_seen_alive = True
+
+            terminal_shape = liveness == LIVENESS_GONE and agent_count == 0 and counts_are_complete and n_incomplete > 0
+            if not terminal_shape or (gone_since is not None and pid != gone_pid):
+                # Any non-confirming observation -- including a restart, which
+                # shows up as a different pid -- restarts the window from zero.
+                if gone_polls:
+                    logger.info(
+                        "orchestrator_gone_streak_reset after %d poll(s): liveness=%s pid=%s "
+                        "agent_count=%d incomplete=%d complete_counts=%s",
+                        gone_polls,
+                        liveness,
+                        pid,
+                        agent_count,
+                        n_incomplete,
+                        counts_are_complete,
+                    )
+                gone_since = None
+                gone_polls = 0
+                gone_pid = None
+
+            if terminal_shape:
+                if gone_since is None:
+                    gone_since = now
+                    gone_pid = pid
+                gone_polls += 1
+                confirmed_for = now - gone_since
+                if gone_polls >= _ORCHESTRATOR_GONE_CONFIRMATIONS and (
+                    confirmed_for >= _ORCHESTRATOR_GONE_CONFIRM_WINDOW_S
+                ):
+                    logger.warning(
+                        "run_ended_with_unfinished_tasks: orchestrator pid=%s observed gone on "
+                        "%d consecutive polls over %.0fs (> the %.0fs recovery-supervisor window, "
+                        "so no restart is coming) while %d declared task(s) are still non-terminal "
+                        "(total=%d open=%d claimed=%d agent_count=%d). Treating this as a terminal, "
+                        "non-healthy verdict (issue #3010).",
+                        pid,
+                        gone_polls,
+                        confirmed_for,
+                        _ORCHESTRATOR_GONE_CONFIRM_WINDOW_S,
+                        n_incomplete,
+                        total,
+                        open_count,
+                        claimed_count,
+                        agent_count,
+                    )
+                    return status_payload
+                logger.info(
+                    "orchestrator_gone_unconfirmed: pid=%s seen gone on poll %d/%d after %.0fs of "
+                    "the %.0fs confirmation window - a recovery restart would still pre-empt this",
+                    pid,
+                    gone_polls,
+                    _ORCHESTRATOR_GONE_CONFIRMATIONS,
+                    confirmed_for,
+                    _ORCHESTRATOR_GONE_CONFIRM_WINDOW_S,
                 )
-                return status_payload
         time.sleep(poll_interval_s)
     logger.info(
-        "run_completion_wait_timed_out after %.0fs: quiescence never observed -- the run is "
+        "run_completion_wait_timed_out after %.0fs: no terminal state observed -- the run is "
         "still in flight in the background. Returning no verdict; callers must not treat this "
         "as a failed run.",
         timeout_s,

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -1054,15 +1054,29 @@ def _wait_for_run_completion(
         timeout_s: Maximum total time to wait.
 
     Returns:
-        Final ``/status`` payload when quiescent, else the last observed payload.
+        The final ``/status`` payload IF AND ONLY IF quiescence was actually
+        detected, else ``None``.
+
+        A ``None`` return means "no verdict": the deadline expired (or the
+        server stayed unreachable) while the run was still in flight. It must
+        NOT be read as a failed run -- callers deriving an exit code from the
+        outcome have to treat it as unknown and stay at 0, because the
+        orchestrator keeps running in the background and may still complete
+        every task successfully.
+
+        Returning the last observed (non-quiescent) payload here instead would
+        hand callers a mid-flight snapshot that by definition still has
+        ``open``/``claimed`` > 0 -- that is exactly why quiescence was never
+        detected -- so a run that merely outlived the wait deadline would be
+        misreported as unhealthy. Multi-hour goals are designed for (see the
+        scope timeouts in ``core/defaults.py``, up to 7200s against this 3600s
+        default deadline), which makes that misread the common case rather
+        than an edge one.
     """
     deadline = time.time() + timeout_s
-    last_status: dict[str, Any] | None = None
     while time.time() < deadline:
         status_payload = server_get("/status")
         health_payload = server_get("/health")
-        if isinstance(status_payload, dict):
-            last_status = status_payload
         if isinstance(status_payload, dict) and isinstance(health_payload, dict):
             total = int(status_payload.get("total", 0) or 0)
             open_count = int(status_payload.get("open", 0) or 0)
@@ -1080,7 +1094,13 @@ def _wait_for_run_completion(
                 _signal_orchestrator_shutdown(reason="cli detected run completion (quiescent)")
                 return status_payload
         time.sleep(poll_interval_s)
-    return last_status
+    logger.info(
+        "run_completion_wait_timed_out after %.0fs: quiescence never observed -- the run is "
+        "still in flight in the background. Returning no verdict; callers must not treat this "
+        "as a failed run.",
+        timeout_s,
+    )
+    return None
 
 
 #: How long the exiting CLI waits for the first spawn outcome (roughly one

--- a/src/bernstein/cli/run_preflight.py
+++ b/src/bernstein/cli/run_preflight.py
@@ -178,6 +178,35 @@ def _show_run_summary() -> None:
     _surface_merge_refusals(Path.cwd(), since_ts=_CLI_RUN_EPOCH, console=con)
 
 
+def _exit_nonzero_on_unhealthy_run(status_payload: object) -> None:
+    """Set ``bernstein run``'s exit code from the final run-health verdict.
+
+    A run that completes but did not honestly meet its goal -- a task failed,
+    or a declared task never terminated (e.g. the manager agent produced no
+    model output and was reaped) -- must not exit 0, so an operator scripting
+    ``bernstein run && deploy`` never deploys on a run that accomplished
+    nothing (issue #3010). Only the synchronous (quiescence-wait) path can
+    know the outcome; a non-dict payload (server unreachable / detached) is
+    left as exit 0 rather than guessing.
+    """
+    if not isinstance(status_payload, dict):
+        return
+    from bernstein.core.quality.retrospective import (
+        run_health_exit_code,
+        run_healthy_from_status_counts,
+    )
+
+    counts_obj = status_payload.get("summary", status_payload)
+    counts = counts_obj if isinstance(counts_obj, dict) else status_payload
+    if run_healthy_from_status_counts(counts):
+        return
+    console.print(
+        "[red]Run did not meet its goal[/red] -- a declared task never completed or a task "
+        "failed. See .sdd/runtime/retrospective.md for the run-health breakdown."
+    )
+    raise SystemExit(run_health_exit_code(healthy=False))
+
+
 def _drain_completed_backlog_files() -> None:
     """Move backlog files for terminal tasks from ``claimed/`` to ``closed/``.
 
@@ -550,8 +579,9 @@ def _finalize_run_output(*, quiet: bool) -> None:
 
     try:
         if quiet:
-            _wait_for_run_completion()
+            final_status = _wait_for_run_completion()
             _show_run_summary()
+            _exit_nonzero_on_unhealthy_run(final_status)
             return
 
         from bernstein.cli.terminal_caps import detect_capabilities

--- a/src/bernstein/cli/run_preflight.py
+++ b/src/bernstein/cli/run_preflight.py
@@ -185,9 +185,26 @@ def _exit_nonzero_on_unhealthy_run(status_payload: object) -> None:
     or a declared task never terminated (e.g. the manager agent produced no
     model output and was reaped) -- must not exit 0, so an operator scripting
     ``bernstein run && deploy`` never deploys on a run that accomplished
-    nothing (issue #3010). Only the synchronous (quiescence-wait) path can
-    know the outcome; a non-dict payload (server unreachable / detached) is
-    left as exit 0 rather than guessing.
+    nothing (issue #3010).
+
+    The verdict is applied ONLY when quiescence was actually detected.
+    ``_wait_for_run_completion`` returns ``None`` for every "no verdict" case
+    (wait deadline expired with the run still in flight, or the server was
+    unreachable), and this function maps that to exit 0 rather than guessing:
+    a long-running-but-healthy run must never be reported as a failure just
+    for outliving the CLI's wait deadline.
+
+    Scope (deliberate, do not over-read): this covers runs whose end the CLI
+    can actually observe. Quiescence is defined as ``open == claimed == 0``
+    with no live agents, so a run that ends with a task still sitting in
+    ``open`` -- the shape in issue #3010, where the orchestrator stops but the
+    task was never re-driven -- is never reported quiescent and reaches the
+    deadline instead, exiting 0 here. Widening the quiescence definition to
+    cover it would risk declaring a run finished during the startup window
+    (``open`` > 0 with no agents spawned yet) and is a separate change. The
+    retrospective's own verdict is not subject to this: it is computed at
+    shutdown from the full task-status histogram and correctly reports such a
+    run UNHEALTHY (see ``compute_run_health``).
     """
     if not isinstance(status_payload, dict):
         return

--- a/src/bernstein/cli/run_preflight.py
+++ b/src/bernstein/cli/run_preflight.py
@@ -198,7 +198,12 @@ def _exit_nonzero_on_unhealthy_run(status_payload: object) -> None:
 
     Note that the discriminator between "ended with work unfinished" and
     "still starting up" is orchestrator liveness, not the task counts -- both
-    show ``open`` > 0. See ``_wait_for_run_completion``.
+    show work outstanding. See ``_wait_for_run_completion``.
+
+    The counts are read from the full per-status histogram when the wait
+    attached one (``task_counts``), because a ``/status`` payload has no bucket
+    for ``in_progress`` or ``orphaned`` -- a run left with a task stuck in
+    either would otherwise read as "nothing outstanding" and exit 0.
     """
     if not isinstance(status_payload, dict):
         return
@@ -207,9 +212,13 @@ def _exit_nonzero_on_unhealthy_run(status_payload: object) -> None:
         run_healthy_from_status_counts,
     )
 
-    counts_obj = status_payload.get("summary", status_payload)
-    counts = counts_obj if isinstance(counts_obj, dict) else status_payload
-    if run_healthy_from_status_counts(counts):
+    counts: dict[str, object] = status_payload
+    for key in ("task_counts", "summary"):
+        candidate = status_payload.get(key)
+        if isinstance(candidate, dict):
+            counts = candidate
+            break
+    if run_healthy_from_status_counts(counts):  # type: ignore[arg-type]
         return
     console.print(
         "[red]Run did not meet its goal[/red] -- a declared task never completed or a task "

--- a/src/bernstein/cli/run_preflight.py
+++ b/src/bernstein/cli/run_preflight.py
@@ -187,24 +187,18 @@ def _exit_nonzero_on_unhealthy_run(status_payload: object) -> None:
     ``bernstein run && deploy`` never deploys on a run that accomplished
     nothing (issue #3010).
 
-    The verdict is applied ONLY when quiescence was actually detected.
-    ``_wait_for_run_completion`` returns ``None`` for every "no verdict" case
-    (wait deadline expired with the run still in flight, or the server was
-    unreachable), and this function maps that to exit 0 rather than guessing:
-    a long-running-but-healthy run must never be reported as a failure just
-    for outliving the CLI's wait deadline.
+    The verdict is applied ONLY when the run actually reached a terminal state.
+    ``_wait_for_run_completion`` returns a payload for both terminal states --
+    quiescence, and "orchestrator gone while declared tasks are still
+    non-terminal" (the issue #3010 shape) -- and ``None`` for every "no
+    verdict" case (deadline expired with the run still in flight, or the
+    server unreachable). This function maps ``None`` to exit 0 rather than
+    guessing: a long-running-but-healthy run must never be reported as a
+    failure just for outliving the CLI's wait deadline.
 
-    Scope (deliberate, do not over-read): this covers runs whose end the CLI
-    can actually observe. Quiescence is defined as ``open == claimed == 0``
-    with no live agents, so a run that ends with a task still sitting in
-    ``open`` -- the shape in issue #3010, where the orchestrator stops but the
-    task was never re-driven -- is never reported quiescent and reaches the
-    deadline instead, exiting 0 here. Widening the quiescence definition to
-    cover it would risk declaring a run finished during the startup window
-    (``open`` > 0 with no agents spawned yet) and is a separate change. The
-    retrospective's own verdict is not subject to this: it is computed at
-    shutdown from the full task-status histogram and correctly reports such a
-    run UNHEALTHY (see ``compute_run_health``).
+    Note that the discriminator between "ended with work unfinished" and
+    "still starting up" is orchestrator liveness, not the task counts -- both
+    show ``open`` > 0. See ``_wait_for_run_completion``.
     """
     if not isinstance(status_payload, dict):
         return

--- a/src/bernstein/cli/run_preflight.py
+++ b/src/bernstein/cli/run_preflight.py
@@ -592,10 +592,37 @@ def _finalize_run_output(*, quiet: bool) -> None:
     pre-drain state, and (b) it keeps cleanup correct even when the renderer
     raises ``SystemExit`` or ``KeyboardInterrupt``.
 
+    Exit-code mapping applies on EVERY branch, not only ``--quiet``. Nothing
+    turns ``--quiet`` on automatically and no documented workflow passes it, so
+    binding the outcome signal to that one flag left the ordinary invocations
+    -- the dashboard, the Rich fallback, and the non-interactive detach --
+    exiting 0 on a run that did not meet its goal (issue #3010, whose own
+    reproduction went down the non-interactive branch).
+
+    What each branch can honestly report differs, because they observe
+    different things:
+
+    * ``--quiet`` waits for a terminal state, so it reports both of them:
+      quiescence, and an orchestrator confirmed gone with work outstanding.
+    * The other three do not wait. They check ONCE, after their own work is
+      done, and report only an already-quiescent run. The "orchestrator gone"
+      verdict is an inference from absence that needs a confirmation window
+      across several observations (see ``_wait_for_run_completion``), which a
+      single poll cannot supply.
+
+    The non-interactive branch in particular detaches by design after roughly
+    one spawner tick, so its check usually finds the run still in flight and
+    changes nothing. It fires when a run reached a terminal state inside that
+    window, which is the fast-failure case.
+
     Args:
         quiet: When True, wait for quiescence and print only the terminal summary.
     """
-    from bernstein.cli.run_bootstrap import _wait_for_run_completion, exec_restart
+    from bernstein.cli.run_bootstrap import (
+        _poll_quiescent_status,
+        _wait_for_run_completion,
+        exec_restart,
+    )
 
     try:
         if quiet:
@@ -622,9 +649,13 @@ def _finalize_run_output(*, quiet: bool) -> None:
             except Exception:
                 # Textual failed at runtime -- fall through to fallback
                 _try_fallback_display()
+            # The operator watched the run to its end in the dashboard, so a
+            # finished run is the common case here, not the edge one.
+            _exit_nonzero_on_unhealthy_run(_poll_quiescent_status())
         elif caps.is_tty:
             # TTY but Textual not supported -- use Rich fallback (TUI-003)
             _try_fallback_display()
+            _exit_nonzero_on_unhealthy_run(_poll_quiescent_status())
         else:
             # Non-interactive output detaches from the run immediately, so a
             # spawn refusal in the background orchestrator would never reach
@@ -638,6 +669,9 @@ def _finalize_run_output(*, quiet: bool) -> None:
                 console.print(f"[red]Run failed before any work started:[/red] {reason}")
                 console.print("Details: run 'bernstein status' or read .sdd/runtime/retrospective.md")
                 raise SystemExit(1)
+            # A run that already reached a terminal state within the detach
+            # window must not report success on its way out.
+            _exit_nonzero_on_unhealthy_run(_poll_quiescent_status())
             console.print("Run continues in the background (check: bernstein status).")
     finally:
         _drain_completed_backlog_files()

--- a/src/bernstein/core/agents/agent_log_aggregator.py
+++ b/src/bernstein/core/agents/agent_log_aggregator.py
@@ -108,6 +108,30 @@ class AgentLogAggregator:
         log_path = self._resolve_log_path(session_id)
         return log_path is not None and log_path.exists()
 
+    def log_age_s(self, session_id: str, now: float | None = None) -> float | None:
+        """Return seconds since the session log was last written, or None.
+
+        Uses the log file's mtime (bytes-written recency), NOT the newline
+        count that ``parse_log`` tracks: a model streaming a single large turn
+        (e.g. a 51k-char reasoning block with no newlines) keeps advancing the
+        mtime while ``last_activity_line`` stays flat. This is the positive
+        liveness signal the watchdog consults so a still-writing, non-heartbeat
+        agent is not flagged stale on heartbeat age alone (issue #3012).
+
+        Returns None when the log path cannot be resolved or is unreadable.
+        """
+        import time
+
+        log_path = self._resolve_log_path(session_id)
+        if log_path is None:
+            return None
+        try:
+            mtime = log_path.stat().st_mtime
+        except OSError:
+            return None
+        reference = time.time() if now is None else now
+        return max(reference - mtime, 0.0)
+
     @staticmethod
     def _extract_unique_error_messages(error_events: list[AgentLogEvent], limit: int = 3) -> list[str]:
         """Extract up to *limit* unique error messages from events."""

--- a/src/bernstein/core/agents/heartbeat.py
+++ b/src/bernstein/core/agents/heartbeat.py
@@ -382,6 +382,41 @@ def _terminate_stuck_agent(orch: Any, session: Any, age: float) -> None:
     _reap_session_heartbeat_loop(orch, session, reason="no_heartbeat_kill")
 
 
+def _agent_has_fresh_liveness_signal(orch: Any, session: Any) -> bool:
+    """Whether the agent's LOG or GIT tree changed within the grace window.
+
+    Reuses ``agent_lifecycle._probe_liveness_signals`` -- the SAME probe that
+    defers the reap-cycle death judgment -- so the escalation ladder never
+    SIGTERMs an agent that is demonstrably alive: e.g. a non-heartbeat adapter
+    (``consumes_heartbeat_dir=False``) streaming its first turn, whose log/git
+    tree changed within the liveness grace window even though its only
+    heartbeat file is the spawn-time one. Applying this HERE, before the
+    ladder fires, fixes the disagreement where ``heartbeat_escalation`` killed
+    on heartbeat age alone while ``liveness_judgment`` -- running one tick too
+    late -- would have found the agent alive (issue #3012).
+
+    Only the LOG and GIT mtimes count: the heartbeat is already known stale in
+    the escalation path (that is why we are here), so the heartbeat file's own
+    mtime is not an independent liveness signal -- a genuinely frozen agent
+    with no log/git activity is still escalated and killed (issue #2796).
+
+    The lazy import avoids the ``heartbeat`` <-> ``agent_lifecycle`` import
+    cycle. Any failure is treated as "no fresh signal" so a genuine stall
+    still escalates.
+    """
+    workdir = getattr(orch, "_workdir", None)
+    if not isinstance(workdir, Path):
+        return False
+    try:
+        from bernstein.core.agents.agent_lifecycle import _probe_liveness_signals
+
+        result = _probe_liveness_signals(orch, session, time.time())
+    except Exception:
+        return False
+    grace_s = AGENT.liveness_grace_s
+    return any(age is not None and age < grace_s for age in (result.get("log_age_s"), result.get("git_age_s")))
+
+
 def _escalate_heartbeat(
     orch: Any,
     session: Any,
@@ -399,6 +434,11 @@ def _escalate_heartbeat(
     process is force-killed (SIGTERM then SIGKILL via the escalation ladder) so
     it is reaped and the slot frees (issue #2796). ``write_shutdown`` is itself
     idempotent per episode, so the soft SHUTDOWN below is emitted at most once.
+
+    Liveness gate (issue #3012): a stale heartbeat alone never justifies a
+    kill. If the agent's log/git tree changed within the grace window it is
+    alive, so no SIGTERM/SIGKILL and no soft SHUTDOWN is sent this tick; the
+    ladder is reset so a genuine later stall re-escalates from the start.
     """
     signal_mgr = orch._signal_mgr
     task_title = _session_task_title(session)
@@ -408,6 +448,20 @@ def _escalate_heartbeat(
         # Healthy again (or never stale): drop any prior escalation state so a
         # later stall episode re-escalates from the start.
         ladder.reset_agent(session.id)
+    elif _agent_has_fresh_liveness_signal(orch, session):
+        # Stale heartbeat BUT a fresh log/git liveness signal: the agent is
+        # demonstrably alive (see _agent_has_fresh_liveness_signal). Do NOT
+        # escalate on heartbeat age alone. Reset the ladder and skip the soft
+        # SHUTDOWN/WAKEUP a live agent should not receive.
+        ladder.reset_agent(session.id)
+        logger.info(
+            "heartbeat_escalation: NOT escalating agent %s despite heartbeat age %.0fs "
+            "-- fresh log/git liveness signal within grace window (agent is alive); will "
+            "re-evaluate once the log actually goes stale",
+            session.id,
+            age,
+        )
+        return
     else:
         action = ladder.check_and_escalate(session.id, age, pid=session.pid)
         if action is not None and action.tier >= EscalationTier.SIGKILL:

--- a/src/bernstein/core/defaults.py
+++ b/src/bernstein/core/defaults.py
@@ -171,7 +171,7 @@ class AgentDefaults:
     # `heartbeat_stale_s` to produce its first turn used to be flagged stale
     # and reaped while still working (issue #3012). The starting phase gets a
     # larger, separately-configurable window sized above a realistic slow
-    # first turn. Override via `tuning.orchestrator.heartbeat_starting_timeout_s`.
+    # first turn. Override via `tuning.agent.heartbeat_starting_timeout_s`.
     heartbeat_starting_timeout_s: float = 300.0  # 5 min
     # A log/git-tree mtime fresher than this window is a POSITIVE liveness
     # signal: the agent is demonstrably alive regardless of heartbeat age, so

--- a/src/bernstein/core/defaults.py
+++ b/src/bernstein/core/defaults.py
@@ -165,6 +165,20 @@ class AgentDefaults:
     """Heartbeat, idle detection, escalation tiers."""
 
     heartbeat_stale_s: float = 120.0  # 2 min
+    # Time-to-first-turn cap for the `starting` phase. Adapters that emit no
+    # heartbeats (e.g. `consumes_heartbeat_dir=False`) rely on log/git mtime
+    # for liveness, so a slow/free-tier model that needs longer than
+    # `heartbeat_stale_s` to produce its first turn used to be flagged stale
+    # and reaped while still working (issue #3012). The starting phase gets a
+    # larger, separately-configurable window sized above a realistic slow
+    # first turn. Override via `tuning.orchestrator.heartbeat_starting_timeout_s`.
+    heartbeat_starting_timeout_s: float = 300.0  # 5 min
+    # A log/git-tree mtime fresher than this window is a POSITIVE liveness
+    # signal: the agent is demonstrably alive regardless of heartbeat age, so
+    # the heartbeat-staleness incident is suppressed and no SIGTERM is sent
+    # (issue #3012). Mirrors agent_lifecycle._ORPHAN_LIVENESS_GRACE_S, which
+    # already defers the reap-cycle death judgment on the same signal.
+    liveness_grace_s: float = 90.0  # 1.5 min
     idle_log_age_threshold_s: float = 180.0  # 3 min
 
     # Escalation tiers (seconds of heartbeat silence)

--- a/src/bernstein/core/observability/watchdog.py
+++ b/src/bernstein/core/observability/watchdog.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 from bernstein.core.agent_log_aggregator import AgentLogAggregator
+from bernstein.core.defaults import AGENT
 from bernstein.core.heartbeat import HeartbeatMonitor, compute_stall_profile
 from bernstein.core.tasks.auto_spawn_guard import AutoSpawnGuard
 
@@ -34,6 +35,29 @@ WatchdogSource = Literal["heartbeat", "log_growth", "progress_stall"]
 
 # Shared cast-type constants to avoid string duplication (Sonar S1192).
 _CAST_DICT_STR_OBJ = "dict[str, object]"
+
+# Heartbeat phases that mean the agent is still producing its FIRST turn. A
+# non-heartbeat adapter (consumes_heartbeat_dir=False) has only its spawn-time
+# heartbeat on disk during this phase, so heartbeat age == wall-clock since
+# spawn; a slow/free model that deliberates past the normal stale threshold
+# must be judged on log/git liveness, not reaped on heartbeat age (issue #3012).
+_STARTING_PHASES: frozenset[str] = frozenset(
+    {"starting", "start", "init", "initializing", "spawning", "spawn", "boot", "booting"}
+)
+
+
+def _is_starting_phase(phase: str | None) -> bool:
+    return bool(phase) and phase.strip().lower() in _STARTING_PHASES
+
+
+def _log_signal_is_fresh(log_age_s: float | None) -> bool:
+    """Whether a log mtime proves the agent is alive within the grace window.
+
+    A log/git-tree write fresher than ``AGENT.liveness_grace_s`` is a positive
+    liveness signal that SUPPRESSES the heartbeat-staleness incident (issue
+    #3012): the agent is demonstrably alive regardless of heartbeat age.
+    """
+    return log_age_s is not None and log_age_s < AGENT.liveness_grace_s
 
 
 @dataclass(frozen=True)
@@ -84,6 +108,9 @@ def _check_session_findings(
     no_growth_ticks: int,
     stall_counts: dict[str, int],
     findings: dict[str, WatchdogFinding],
+    *,
+    log_age_s: float | None = None,
+    starting_timeout_s: float | None = None,
 ) -> None:
     """Check a single session for watchdog-worthy findings."""
     stall_count = int(stall_counts.get(task_id, 0))
@@ -112,7 +139,18 @@ def _check_session_findings(
             )
             return
 
-    _check_heartbeat_findings(session_id, task_id, task, runtime_s, hb_status, timeout_s, current_line, findings)
+    _check_heartbeat_findings(
+        session_id,
+        task_id,
+        task,
+        runtime_s,
+        hb_status,
+        timeout_s,
+        current_line,
+        findings,
+        log_age_s=log_age_s,
+        starting_timeout_s=starting_timeout_s,
+    )
     _check_log_growth_findings(session_id, task_id, task, runtime_s, current_line, no_growth_ticks, findings)
 
 
@@ -125,10 +163,33 @@ def _check_heartbeat_findings(
     timeout_s: float,
     current_line: int,
     findings: dict[str, WatchdogFinding],
+    *,
+    log_age_s: float | None = None,
+    starting_timeout_s: float | None = None,
 ) -> None:
-    """Check heartbeat-related findings for a session."""
+    """Check heartbeat-related findings for a session.
+
+    A log/git mtime fresher than ``AGENT.liveness_grace_s`` is treated as a
+    POSITIVE liveness signal that suppresses the heartbeat-staleness incident
+    entirely -- not merely defers it: the agent is demonstrably alive even if
+    its heartbeat is stale (issue #3012). While the agent is still in the
+    ``starting`` phase the (larger, configurable) ``starting_timeout_s`` is
+    used so a slow/free model's first turn is not a hard 120s cap.
+    """
+    # Fresh log/git write within the grace window -> the agent is alive; never
+    # raise a heartbeat-staleness incident against a demonstrably-live agent.
+    if _log_signal_is_fresh(log_age_s):
+        return
+
+    # A `starting` agent (only its spawn-time heartbeat on disk for a
+    # non-heartbeat adapter) is judged against the larger starting-phase
+    # window, not the general stale threshold.
+    effective_timeout = timeout_s
+    if starting_timeout_s is not None and _is_starting_phase(getattr(hb_status, "phase", None)):
+        effective_timeout = max(timeout_s, starting_timeout_s)
+
     if hb_status.last_heartbeat is None:
-        if runtime_s >= max(timeout_s / 2.0, 60.0) and current_line == 0:
+        if runtime_s >= max(effective_timeout / 2.0, 60.0) and current_line == 0:
             title = task.title if task is not None else task_id
             findings[f"heartbeat:{session_id}:{task_id}"] = WatchdogFinding(
                 key=f"heartbeat:{session_id}:{task_id}",
@@ -145,8 +206,8 @@ def _check_heartbeat_findings(
             )
         return
 
-    if hb_status.age_seconds >= max(timeout_s / 2.0, 60.0):
-        severity: WatchdogSeverity = "critical" if hb_status.age_seconds >= timeout_s else "high"
+    if hb_status.age_seconds >= max(effective_timeout / 2.0, 60.0):
+        severity: WatchdogSeverity = "critical" if hb_status.age_seconds >= effective_timeout else "high"
         title = task.title if task is not None else task_id
         findings[f"heartbeat:{session_id}:{task_id}"] = WatchdogFinding(
             key=f"heartbeat:{session_id}:{task_id}",
@@ -157,7 +218,7 @@ def _check_heartbeat_findings(
             summary=f"Heartbeat stale for task {title}",
             detail=(
                 f"Tier-1 watchdog observed heartbeat age {hb_status.age_seconds:.0f}s "
-                f"for task {task_id} (timeout={timeout_s:.0f}s, phase={hb_status.phase or 'unknown'})."
+                f"for task {task_id} (timeout={effective_timeout:.0f}s, phase={hb_status.phase or 'unknown'})."
             ),
             task_title=str(title),
         )
@@ -205,6 +266,7 @@ def collect_watchdog_findings(orch: Any) -> list[WatchdogFinding]:
 
     config = getattr(orch, "_config", None)
     timeout_s = float(getattr(config, "heartbeat_timeout_s", 120))
+    starting_timeout_s = float(getattr(config, "heartbeat_starting_timeout_s", AGENT.heartbeat_starting_timeout_s))
     monitor = HeartbeatMonitor(workdir, timeout_s=timeout_s)
     logs = AgentLogAggregator(workdir)
     now = time.time()
@@ -243,6 +305,7 @@ def collect_watchdog_findings(orch: Any) -> list[WatchdogFinding]:
         runtime_s = max(now - float(getattr(session, "spawn_ts", now)), 0.0)
         hb_status = monitor.check(session_id)
         log_summary = logs.parse_log(session_id)
+        log_age_s = logs.log_age_s(session_id, now)
         task = latest_tasks.get(task_id)
 
         prev_line, prev_no_growth = _coerce_log_state(log_state.get(session_id))
@@ -261,6 +324,8 @@ def collect_watchdog_findings(orch: Any) -> list[WatchdogFinding]:
             no_growth_ticks,
             stall_counts,
             findings,
+            log_age_s=log_age_s,
+            starting_timeout_s=starting_timeout_s,
         )
 
     for session_id in list(log_state.keys()):

--- a/src/bernstein/core/orchestration/bootstrap.py
+++ b/src/bernstein/core/orchestration/bootstrap.py
@@ -43,8 +43,8 @@ from bernstein.core.orchestration.preflight import (
     preflight_checks,
 )
 from bernstein.core.orchestration.process_utils import (
-    LIVENESS_UNKNOWN,
-    ORCHESTRATOR_PROCESS_MARKER,
+    LIVENESS_ALIVE,
+    ORCHESTRATOR_PROCESS_MARKERS,
     WATCHDOG_POLL_S,
     Liveness,
     classify_pidfile_liveness,
@@ -905,26 +905,39 @@ def _watchdog_check_process(
     post_restart_fn: Any | None = None,
     liveness: Liveness | None = None,
 ) -> tuple[float | None, int, bool]:
-    """Check a single watchdog-monitored process and restart if dead.
+    """Check a single watchdog-monitored process and restart if it is not up.
+
+    Anything that is not positively alive is restarted, including a missing or
+    unreadable pidfile. That is deliberate and it is the only safe default for a
+    RECOVERY component: refusing to restart is the destructive choice here, and
+    it is permanent, because nothing else recreates ``spawner.pid`` once it is
+    gone. ``bernstein doctor --fix`` / ``bernstein status --fix``
+    (``cli/commands/status_cmd.py::_fix_stale_pids``) deletes precisely the
+    pidfile of a process that has already crashed, so "crashed, and then its
+    stale pidfile was cleaned up" is an ordinary state that must still recover.
+
+    Teardown is NOT a reason to withhold a restart here, because this process is
+    not alive to see it: ``DrainCoordinator._stop_infrastructure`` kills
+    ``watchdog.pid`` FIRST and only removes pidfiles at the end of
+    ``_phase_cleanup``. The supervisor is already dead before teardown deletes
+    anything. ``run_watchdog`` still checks for teardown before calling this,
+    for the case where the supervisor outlives its own SIGTERM.
 
     ``liveness`` is the classification of the pidfile this supervisor owns, from
     :func:`classify_pidfile_liveness` -- the same classifier the CLI's
     run-completion verdict reads, so the two subsystems cannot disagree about
-    what "gone" means. Only ``LIVENESS_GONE`` authorises a restart. Passing
-    ``LIVENESS_UNKNOWN``, or a ``pid`` of ``None``, means the process could not
-    be attributed to a pidfile this supervisor owns, and the supervisor does
-    nothing: spawning on an unattributable reading either starts a second
-    orchestrator alongside a healthy one (both then drive the same task store)
-    or resurrects a run an operator has already torn down -- teardown deletes
-    the pidfiles, which is exactly the reading that used to trigger a restart.
+    what "gone" means. Its job here is the reverse of its job in the CLI: it
+    prevents an unrelated process that inherited a recycled pid from passing as
+    our live orchestrator and thereby SUPPRESSING a restart the run needs.
+    ``LIVENESS_ALIVE`` is the only value that withholds one.
 
-    Omitting ``liveness`` keeps the plain dead-pid behaviour for callers that
-    have no pidfile to classify.
+    Omitting ``liveness`` falls back to a bare ``_is_alive(pid)`` for callers
+    that have no pidfile to classify.
 
     Returns:
         Updated (alive_since, restarts, give_up_logged) tuple.
     """
-    if pid is not None and _is_alive(pid):
+    if liveness == LIVENESS_ALIVE or (liveness is None and pid is not None and _is_alive(pid)):
         if alive_since is None:
             return now, restarts, give_up_logged
         if restarts > 0 and (now - alive_since) >= reset_after_s:
@@ -936,18 +949,7 @@ def _watchdog_check_process(
             return alive_since, 0, False
         return alive_since, restarts, give_up_logged
 
-    if pid is None or liveness == LIVENESS_UNKNOWN:
-        # Not evidence of death: no pidfile yet, an unreadable one, or one an
-        # operator teardown removed. Keep monitoring, restart nothing.
-        logger.debug(
-            "%s liveness is unattributable (pid=%s liveness=%s) - not restarting",
-            name,
-            pid,
-            liveness,
-        )
-        return alive_since, restarts, give_up_logged
-
-    # Process is dead
+    # Not positively alive: dead, or a pid we cannot attribute to our pidfile.
     if restarts >= max_restarts:
         if not give_up_logged:
             logger.error(
@@ -974,6 +976,41 @@ def _watchdog_check_process(
             exc,
         )
     return None, restarts, give_up_logged
+
+
+def _supervisor_should_stand_down(workdir: Path) -> str | None:
+    """Positive evidence that this supervisor must stop restarting things.
+
+    Returns a short reason, or ``None`` to keep supervising.
+
+    Only POSITIVE evidence counts, because the default has to be to recover: a
+    supervisor that withholds a restart on a merely ambiguous reading leaves the
+    run with no orchestrator and nothing to notice, permanently. Two signals
+    qualify:
+
+    * ``.sdd/runtime/draining`` -- written by ``DrainCoordinator._phase_freeze``
+      when it cannot reach the server to set drain mode, which is exactly the
+      teardown case where this loop would otherwise fight the teardown.
+    * ``watchdog.pid`` no longer naming this process -- we have been superseded
+      or killed (teardown SIGTERMs it first), so we are not the supervisor of
+      record any more and must not act as one.
+
+    A missing pidfile for a SUPERVISED process is deliberately not on this list.
+    It is the ordinary aftermath of a crash plus ``bernstein doctor --fix``, and
+    must still recover.
+    """
+    runtime = workdir / ".sdd" / "runtime"
+    if (runtime / "draining").exists():
+        return "draining marker present"
+    watchdog_pid_path = runtime / "watchdog.pid"
+    if watchdog_pid_path.exists():
+        try:
+            recorded = int(watchdog_pid_path.read_text(encoding="utf-8").strip())
+        except (OSError, ValueError):
+            return None
+        if recorded != os.getpid():
+            return f"watchdog.pid names pid {recorded}, not this supervisor ({os.getpid()})"
+    return None
 
 
 def run_watchdog(
@@ -1003,6 +1040,10 @@ def run_watchdog(
     (``process_utils.WATCHDOG_POLL_S``) rather than a private default here, and
     why the CLI's run-completion verdict sizes its confirmation window from it.
 
+    The loop stands down only on positive teardown evidence (see
+    :func:`_supervisor_should_stand_down`). Everything else recovers, including
+    a supervised process whose pidfile has gone missing.
+
     Args:
         workdir: Project root directory.
         port: Task server port.
@@ -1028,6 +1069,11 @@ def run_watchdog(
         time.sleep(poll_s)
         now = time.monotonic()
 
+        stand_down = _supervisor_should_stand_down(workdir)
+        if stand_down is not None:
+            logger.info("Recovery supervisor standing down this cycle: %s", stand_down)
+            continue
+
         # Check server
         server_liveness, server_pid = classify_pidfile_liveness(server_pid_path)
         server_alive_since, server_restarts, server_give_up_logged = _watchdog_check_process(
@@ -1045,11 +1091,12 @@ def run_watchdog(
         )
 
         # Check orchestrator/spawner (only restart if server is alive). The
-        # command-line marker keeps an unrelated process that inherited a
-        # recycled pid from vouching for a pidfile that is in fact stale.
+        # command-line markers keep an unrelated process that inherited a
+        # recycled pid from passing as our live orchestrator and suppressing a
+        # restart the run needs.
         spawner_liveness, spawner_pid = classify_pidfile_liveness(
             spawner_pid_path,
-            expect_cmdline=ORCHESTRATOR_PROCESS_MARKER,
+            expect_cmdline=ORCHESTRATOR_PROCESS_MARKERS,
         )
 
         def _restart_spawner() -> int:

--- a/src/bernstein/core/orchestration/bootstrap.py
+++ b/src/bernstein/core/orchestration/bootstrap.py
@@ -42,6 +42,13 @@ from bernstein.core.orchestration.preflight import (
     gemini_has_auth,
     preflight_checks,
 )
+from bernstein.core.orchestration.process_utils import (
+    LIVENESS_UNKNOWN,
+    ORCHESTRATOR_PROCESS_MARKER,
+    WATCHDOG_POLL_S,
+    Liveness,
+    classify_pidfile_liveness,
+)
 from bernstein.core.seed import (
     NotifyConfig,
     SeedConfig,
@@ -896,8 +903,23 @@ def _watchdog_check_process(
     now: float,
     restart_fn: Any,
     post_restart_fn: Any | None = None,
+    liveness: Liveness | None = None,
 ) -> tuple[float | None, int, bool]:
     """Check a single watchdog-monitored process and restart if dead.
+
+    ``liveness`` is the classification of the pidfile this supervisor owns, from
+    :func:`classify_pidfile_liveness` -- the same classifier the CLI's
+    run-completion verdict reads, so the two subsystems cannot disagree about
+    what "gone" means. Only ``LIVENESS_GONE`` authorises a restart. Passing
+    ``LIVENESS_UNKNOWN``, or a ``pid`` of ``None``, means the process could not
+    be attributed to a pidfile this supervisor owns, and the supervisor does
+    nothing: spawning on an unattributable reading either starts a second
+    orchestrator alongside a healthy one (both then drive the same task store)
+    or resurrects a run an operator has already torn down -- teardown deletes
+    the pidfiles, which is exactly the reading that used to trigger a restart.
+
+    Omitting ``liveness`` keeps the plain dead-pid behaviour for callers that
+    have no pidfile to classify.
 
     Returns:
         Updated (alive_since, restarts, give_up_logged) tuple.
@@ -912,6 +934,17 @@ def _watchdog_check_process(
                 now - alive_since,
             )
             return alive_since, 0, False
+        return alive_since, restarts, give_up_logged
+
+    if pid is None or liveness == LIVENESS_UNKNOWN:
+        # Not evidence of death: no pidfile yet, an unreadable one, or one an
+        # operator teardown removed. Keep monitoring, restart nothing.
+        logger.debug(
+            "%s liveness is unattributable (pid=%s liveness=%s) - not restarting",
+            name,
+            pid,
+            liveness,
+        )
         return alive_since, restarts, give_up_logged
 
     # Process is dead
@@ -946,7 +979,7 @@ def _watchdog_check_process(
 def run_watchdog(
     workdir: Path,
     port: int,
-    poll_s: float = 5.0,
+    poll_s: float = WATCHDOG_POLL_S,
     adapter: str | None = None,
     model: str | None = None,
     seed_path: Path | None = None,
@@ -962,6 +995,13 @@ def run_watchdog(
     process its restart budget back. Without this, the watchdog gives up
     forever after 5 transient failures across the entire run (incident
     2026-04-11).
+
+    A dead orchestrator is therefore a RECOVERABLE state, not a terminal one,
+    for as long as this loop is running with restart budget left. Anything else
+    that wants to conclude the orchestrator will not come back has to outwait
+    ``poll_s`` -- which is why that period is a shared constant
+    (``process_utils.WATCHDOG_POLL_S``) rather than a private default here, and
+    why the CLI's run-completion verdict sizes its confirmation window from it.
 
     Args:
         workdir: Project root directory.
@@ -989,7 +1029,7 @@ def run_watchdog(
         now = time.monotonic()
 
         # Check server
-        server_pid = _read_pid(server_pid_path)
+        server_liveness, server_pid = classify_pidfile_liveness(server_pid_path)
         server_alive_since, server_restarts, server_give_up_logged = _watchdog_check_process(
             name="Server",
             pid=server_pid,
@@ -1001,10 +1041,16 @@ def run_watchdog(
             now=now,
             restart_fn=lambda: _start_server(workdir, port),
             post_restart_fn=lambda: _wait_for_server(port),
+            liveness=server_liveness,
         )
 
-        # Check orchestrator/spawner (only restart if server is alive)
-        spawner_pid = _read_pid(spawner_pid_path)
+        # Check orchestrator/spawner (only restart if server is alive). The
+        # command-line marker keeps an unrelated process that inherited a
+        # recycled pid from vouching for a pidfile that is in fact stale.
+        spawner_liveness, spawner_pid = classify_pidfile_liveness(
+            spawner_pid_path,
+            expect_cmdline=ORCHESTRATOR_PROCESS_MARKER,
+        )
 
         def _restart_spawner() -> int:
             cur_server_pid = _read_pid(server_pid_path)
@@ -1023,6 +1069,7 @@ def run_watchdog(
             reset_after_s=restart_reset_after_s,
             now=now,
             restart_fn=_restart_spawner,
+            liveness=spawner_liveness,
         )
 
 

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -2097,7 +2097,11 @@ class Orchestrator:
                     self._summary_written,
                     _action,
                 )
-                self._generate_run_summary(refreshed_tasks_by_status["done"], refreshed_tasks_by_status["failed"])
+                self._generate_run_summary(
+                    refreshed_tasks_by_status["done"],
+                    refreshed_tasks_by_status["failed"],
+                    full_status_counts={status: len(tasks) for status, tasks in refreshed_tasks_by_status.items()},
+                )
             else:
                 _action = "summary_already_written"
                 logger.info(
@@ -4496,8 +4500,18 @@ class Orchestrator:
         self,
         done_tasks: list[Task],
         failed_tasks: list[Task],
+        *,
+        full_status_counts: dict[str, int] | None = None,
     ) -> None:
-        """Write a run completion summary to .sdd/runtime/summary.md."""
+        """Write a run completion summary to .sdd/runtime/summary.md.
+
+        ``full_status_counts`` is the per-status task histogram at this moment.
+        Without it the interim retrospective sees only done and failed, so a run
+        whose tasks are all still open/claimed/in-progress/orphaned reports
+        ``0/0`` and HEALTHY (issue #3010): ``count_incomplete_declared(None)``
+        is 0, and nothing else in the report can tell "no tasks finished
+        because there were none" from "no tasks finished at all".
+        """
         runtime_dir = self._workdir / ".sdd" / "runtime"
         runtime_dir.mkdir(parents=True, exist_ok=True)
         summary_path = runtime_dir / "summary.md"
@@ -4593,6 +4607,14 @@ class Orchestrator:
         # etc.). Mark this retrospective INTERIM; run() re-generates the
         # FINAL retrospective, unconditionally overwriting this one, once the
         # tick loop actually exits (see A5 stale-retrospective bug).
+        #
+        # The histogram has to be threaded through even though this report is
+        # interim: when quiescence holds with zero terminal tasks the tick loop
+        # never exits (the self-stop block at 8b is nested under
+        # `_had_any_terminal_task`), so the FINAL regeneration never runs and
+        # this interim report is the only retrospective the run ever writes.
+        # Giving the orchestrator a terminal state for that case is a separate
+        # change to the main loop, tracked apart from this PR.
         generate_retrospective(
             done_tasks=done_tasks,
             failed_tasks=failed_tasks,
@@ -4600,6 +4622,7 @@ class Orchestrator:
             runtime_dir=runtime_dir,
             run_start_ts=self._run_start_ts,
             trigger_reason="mid-run",
+            full_status_counts=full_status_counts,
         )
 
         # Auto-PR: create a GitHub PR if BERNSTEIN_AUTO_PR is set

--- a/src/bernstein/core/orchestration/orchestrator_summary.py
+++ b/src/bernstein/core/orchestration/orchestrator_summary.py
@@ -37,6 +37,8 @@ def generate_run_summary(
     orch: Any,
     done_tasks: list[Task],
     failed_tasks: list[Task],
+    *,
+    full_status_counts: dict[str, int] | None = None,
 ) -> None:
     """Write a run completion summary to .sdd/runtime/summary.md.
 
@@ -44,6 +46,10 @@ def generate_run_summary(
         orch: The orchestrator instance.
         done_tasks: Tasks that completed successfully.
         failed_tasks: Tasks that failed.
+        full_status_counts: Per-status task histogram at this moment. Without
+            it the retrospective sees only done and failed, so a run whose
+            tasks are all still open/claimed/in-progress/orphaned reports
+            ``0/0`` and HEALTHY (issue #3010).
     """
     runtime_dir = orch._workdir / ".sdd" / "runtime"
     runtime_dir.mkdir(parents=True, exist_ok=True)
@@ -113,6 +119,13 @@ def generate_run_summary(
     # spawned just before this point can still fail afterwards. Mark the
     # retrospective INTERIM so a stale HEALTHY snapshot is never mistaken
     # for the final report (see A5 stale-retrospective bug).
+    #
+    # The histogram is threaded through even for an interim report, because
+    # when quiescence holds with zero terminal tasks the orchestrator's tick
+    # loop never exits and no FINAL retrospective is ever written, leaving this
+    # one as the run's only verdict. Giving the orchestrator a terminal state
+    # for that case is a separate change to the main loop, tracked apart from
+    # this PR.
     generate_retrospective(
         done_tasks=done_tasks,
         failed_tasks=failed_tasks,
@@ -120,6 +133,7 @@ def generate_run_summary(
         runtime_dir=runtime_dir,
         run_start_ts=orch._run_start_ts,
         trigger_reason="mid-run",
+        full_status_counts=full_status_counts,
     )
 
     emit_summary_card(

--- a/src/bernstein/core/orchestration/process_utils.py
+++ b/src/bernstein/core/orchestration/process_utils.py
@@ -4,9 +4,161 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
+from typing import Final, Literal
 
 from bernstein.core.platform_compat import IS_WINDOWS
 from bernstein.core.platform_compat import process_alive as _platform_process_alive
+
+# ---------------------------------------------------------------------------
+# Three-valued pidfile liveness
+# ---------------------------------------------------------------------------
+#
+# Two subsystems act on "is the orchestrator still running": the recovery
+# supervisor in ``core/orchestration/bootstrap.py`` (which restarts it) and the
+# CLI completion wait in ``cli/run_bootstrap.py`` (which reports the run over).
+# They must not hold different definitions of the word, so both read this one
+# classifier.
+#
+# The classification is deliberately three-valued. A boolean forces every
+# ambiguous observation into either "running" or "dead", and both callers do
+# something destructive with "dead": the supervisor spawns a process, the CLI
+# declares an in-flight run finished. ``unknown`` is the state that lets both
+# callers do nothing, which is the correct response to an ambiguous reading.
+
+Liveness = Literal["alive", "gone", "unknown"]
+
+#: Poll period of the recovery supervisor (``bootstrap.run_watchdog``), which
+#: restarts a dead server or orchestrator. It lives here, next to the liveness
+#: classifier, because it is not only the supervisor's own tuning knob: any
+#: OTHER reader that wants to conclude a dead process will stay dead has to
+#: outwait it. Keeping one definition is what stops the supervisor's recovery
+#: window and the CLI's confirmation window from drifting apart.
+WATCHDOG_POLL_S: Final[float] = 5.0
+
+#: The process exists (or something that cannot be distinguished from it does).
+LIVENESS_ALIVE: Final[Liveness] = "alive"
+#: Positive evidence of death: a pidfile this run owns, naming a dead pid.
+LIVENESS_GONE: Final[Liveness] = "gone"
+#: Not enough evidence to act. Never treat as death.
+LIVENESS_UNKNOWN: Final[Liveness] = "unknown"
+
+#: Substring identifying an orchestrator process in its command line, used to
+#: tell our process apart from an unrelated one that inherited a recycled pid.
+#: Mirrors the ``python -m <module>`` argv built by
+#: ``core/server/server_launch.py::_start_spawner``.
+ORCHESTRATOR_PROCESS_MARKER: Final[str] = "bernstein.core.orchestration.orchestrator"
+
+
+def pid_command_line(pid: int) -> str | None:
+    """Best-effort command line for *pid*, or ``None`` when it cannot be read.
+
+    ``None`` means "could not determine" (Windows, no ``ps``, the process
+    vanished mid-probe, a permissions boundary), never "no command line".
+    Callers must not read it as a mismatch.
+    """
+    if pid <= 0 or IS_WINDOWS:
+        return None
+    try:
+        result = subprocess.run(
+            ["ps", "-o", "command=", "-p", str(pid)],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=2,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def classify_pidfile_liveness(
+    pidfile: Path,
+    *,
+    not_before: float | None = None,
+    expect_cmdline: str | None = None,
+) -> tuple[Liveness, int | None]:
+    """Classify the process named by *pidfile* as alive, gone, or unknown.
+
+    Returns ``(liveness, pid)``; ``pid`` is ``None`` whenever the pidfile could
+    not be read as a positive integer.
+
+    ``LIVENESS_GONE`` is the only value that authorises a caller to act as if
+    the process will not run again, so it is returned only on positive
+    evidence of death, which means all of:
+
+    * the pidfile exists and parses to a positive pid, and
+    * that pidfile is attributable to the caller's run (see ``not_before``), and
+    * the pid is not a live process on this host.
+
+    Everything else is ``LIVENESS_UNKNOWN``. In particular:
+
+    * **A missing pidfile is never "gone".** It means the process has not
+      written it yet, or an operator teardown removed it
+      (``DrainCoordinator._clean_runtime`` deletes every ``*.pid``). Neither is
+      death. Note that the orchestrator does NOT remove its own pidfile when it
+      exits, so "pidfile gone" is not a signal it emits at all.
+    * **A pidfile older than ``not_before`` is never "gone".** It was written
+      before the caller's run began, so its pid describes some earlier process.
+      Acting on it would let a leftover file from a previous run condemn a run
+      that has not started yet.
+
+    Both guards exist because a pid is a reused integer, not an identity:
+
+    * ``not_before`` (a ``time.time()`` epoch, typically the caller's start)
+      rejects a pidfile written before the caller's run, whose pid number may
+      by now belong to anything.
+    * ``expect_cmdline`` (a substring the process's command line must contain,
+      e.g. :data:`ORCHESTRATOR_PROCESS_MARKER`) rejects the opposite recycling
+      case: the pid is alive, but it is alive as some unrelated process that
+      inherited the number after ours exited. Without it, a recycled pid reads
+      as our healthy process and can vouch for a pidfile that is in fact stale.
+      A definitive mismatch yields ``LIVENESS_UNKNOWN``, not ``LIVENESS_GONE``:
+      it proves the pid is not ours, which is not the same as proving ours
+      died, and ``ps`` output is too weak a signal to hang a destructive
+      decision on. When the command line cannot be read at all, the process is
+      assumed to be ours -- unverifiable must not become an excuse to reap.
+
+    This is a same-host check. It cannot see a process in another pid namespace
+    (the shipped container image runs the orchestrator in one), so a caller that
+    might be outside the process's namespace must corroborate ``LIVENESS_GONE``
+    with an observer inside it before acting.
+    """
+    try:
+        raw = pidfile.read_text(encoding="utf-8").strip()
+    except (OSError, ValueError):
+        return LIVENESS_UNKNOWN, None
+    if not raw:
+        return LIVENESS_UNKNOWN, None
+    try:
+        pid = int(raw)
+    except ValueError:
+        return LIVENESS_UNKNOWN, None
+    if pid <= 0:
+        return LIVENESS_UNKNOWN, None
+
+    if is_process_alive(pid):
+        if expect_cmdline is None:
+            return LIVENESS_ALIVE, pid
+        cmdline = pid_command_line(pid)
+        if cmdline is None or expect_cmdline in cmdline:
+            return LIVENESS_ALIVE, pid
+        # Alive, but not us: the number was recycled by an unrelated process.
+        return LIVENESS_UNKNOWN, pid
+
+    if not_before is not None:
+        try:
+            written_at = pidfile.stat().st_mtime
+        except OSError:
+            return LIVENESS_UNKNOWN, pid
+        if written_at < not_before:
+            # Leftover from an earlier run: its pid says nothing about this one.
+            return LIVENESS_UNKNOWN, pid
+
+    return LIVENESS_GONE, pid
 
 
 def process_state(pid: int) -> str | None:

--- a/src/bernstein/core/orchestration/process_utils.py
+++ b/src/bernstein/core/orchestration/process_utils.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
-from typing import Final, Literal
+from typing import TYPE_CHECKING, Final, Literal
 
 from bernstein.core.platform_compat import IS_WINDOWS
 from bernstein.core.platform_compat import process_alive as _platform_process_alive
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 # ---------------------------------------------------------------------------
 # Three-valued pidfile liveness
@@ -42,11 +45,39 @@ LIVENESS_GONE: Final[Liveness] = "gone"
 #: Not enough evidence to act. Never treat as death.
 LIVENESS_UNKNOWN: Final[Liveness] = "unknown"
 
-#: Substring identifying an orchestrator process in its command line, used to
+#: Substrings identifying an orchestrator process in its command line, used to
 #: tell our process apart from an unrelated one that inherited a recycled pid.
-#: Mirrors the ``python -m <module>`` argv built by
-#: ``core/server/server_launch.py::_start_spawner``.
-ORCHESTRATOR_PROCESS_MARKER: Final[str] = "bernstein.core.orchestration.orchestrator"
+#: A command line matching ANY of these is ours.
+#:
+#: There are three shipped launch forms and they do not share a spelling:
+#:
+#: 1. ``python -m bernstein.core.orchestration.orchestrator`` -- the argv built
+#:    by ``core/server/server_launch.py::_start_spawner``.
+#: 2. ``python .../bernstein/core/orchestration/orchestrator.py`` -- what the
+#:    process becomes after its own restart. ``orchestrator_cleanup.restart``
+#:    re-execs with ``os.execv(sys.executable, [sys.executable, *sys.argv])``,
+#:    and the interpreter has already rewritten ``sys.argv[0]`` from the ``-m``
+#:    module name to the module's file path, so the dotted form is gone. This
+#:    matters most precisely when pid reuse matters most: right after a restart.
+#: 3. ``python -m bernstein.core.orchestrator`` -- the ``docker-compose.yaml``
+#:    entrypoint and ``docker/demo/demo-cycle.sh``, via the redirect alias.
+#:
+#: Missing a form is safe but costly: an unrecognised command line classifies as
+#: ``LIVENESS_UNKNOWN``, which never reaps but also stops the supervisor from
+#: recognising a live orchestrator.
+ORCHESTRATOR_PROCESS_MARKERS: Final[tuple[str, ...]] = (
+    "bernstein.core.orchestration.orchestrator",
+    "bernstein/core/orchestration/orchestrator.py",
+    "bernstein.core.orchestrator",
+)
+#: Back-compat alias for the primary (``-m``) form.
+ORCHESTRATOR_PROCESS_MARKER: Final[str] = ORCHESTRATOR_PROCESS_MARKERS[0]
+
+
+def cmdline_matches(cmdline: str, markers: Sequence[str]) -> bool:
+    """Whether *cmdline* contains any of *markers*, separator-insensitively."""
+    normalized = cmdline.replace("\\", "/")
+    return any(marker.replace("\\", "/") in normalized for marker in markers)
 
 
 def pid_command_line(pid: int) -> str | None:
@@ -79,7 +110,7 @@ def classify_pidfile_liveness(
     pidfile: Path,
     *,
     not_before: float | None = None,
-    expect_cmdline: str | None = None,
+    expect_cmdline: str | Sequence[str] | None = None,
 ) -> tuple[Liveness, int | None]:
     """Classify the process named by *pidfile* as alive, gone, or unknown.
 
@@ -111,16 +142,19 @@ def classify_pidfile_liveness(
     * ``not_before`` (a ``time.time()`` epoch, typically the caller's start)
       rejects a pidfile written before the caller's run, whose pid number may
       by now belong to anything.
-    * ``expect_cmdline`` (a substring the process's command line must contain,
-      e.g. :data:`ORCHESTRATOR_PROCESS_MARKER`) rejects the opposite recycling
-      case: the pid is alive, but it is alive as some unrelated process that
-      inherited the number after ours exited. Without it, a recycled pid reads
-      as our healthy process and can vouch for a pidfile that is in fact stale.
-      A definitive mismatch yields ``LIVENESS_UNKNOWN``, not ``LIVENESS_GONE``:
-      it proves the pid is not ours, which is not the same as proving ours
-      died, and ``ps`` output is too weak a signal to hang a destructive
-      decision on. When the command line cannot be read at all, the process is
-      assumed to be ours -- unverifiable must not become an excuse to reap.
+    * ``expect_cmdline`` (one substring, or several of which any may match, that
+      the process's command line must contain -- e.g.
+      :data:`ORCHESTRATOR_PROCESS_MARKERS`) rejects the opposite recycling case:
+      the pid is alive, but it is alive as some unrelated process that inherited
+      the number after ours exited. Without it, a recycled pid reads as our
+      healthy process and can vouch for a pidfile that is in fact stale. Pass
+      every spelling the process can legitimately have -- a form that is missing
+      from the list looks exactly like a recycled pid. A definitive mismatch
+      yields ``LIVENESS_UNKNOWN``, not ``LIVENESS_GONE``: it proves the pid is
+      not ours, which is not the same as proving ours died, and ``ps`` output is
+      too weak a signal to hang a destructive decision on. When the command line
+      cannot be read at all, the process is assumed to be ours -- unverifiable
+      must not become an excuse to reap.
 
     This is a same-host check. It cannot see a process in another pid namespace
     (the shipped container image runs the orchestrator in one), so a caller that
@@ -143,8 +177,9 @@ def classify_pidfile_liveness(
     if is_process_alive(pid):
         if expect_cmdline is None:
             return LIVENESS_ALIVE, pid
+        markers = (expect_cmdline,) if isinstance(expect_cmdline, str) else tuple(expect_cmdline)
         cmdline = pid_command_line(pid)
-        if cmdline is None or expect_cmdline in cmdline:
+        if cmdline is None or cmdline_matches(cmdline, markers):
             return LIVENESS_ALIVE, pid
         # Alive, but not us: the number was recycled by an unrelated process.
         return LIVENESS_UNKNOWN, pid

--- a/src/bernstein/core/quality/retrospective.py
+++ b/src/bernstein/core/quality/retrospective.py
@@ -197,6 +197,17 @@ TERMINATOR_AGENT_COMPLETED = "agent_completed"
 # "Verdict: HEALTHY" / "Agent-completed: 1".
 TERMINATOR_AGENT_REPORTED_FAILURE = "agent_reported_failure"
 
+# A DECLARED task that never reached any terminal outcome. This is NOT a
+# classify_task_terminator category (that function only ever sees done+failed
+# tasks); it is derived from the full task-status histogram in
+# generate_retrospective and threaded into compute_run_health. Ground truth:
+# issue #3010 -- a single-task run whose manager agent produced zero model
+# output and was reaped left its one task open/claimed (neither done nor
+# failed), so done+failed was empty, total was 0, and the run reported
+# "0/0 ... -> HEALTHY" and exited 0. A declared task that simply never
+# finished is exactly the dishonest-success this module exists to prevent.
+TERMINATOR_INCOMPLETE_DECLARED = "incomplete_declared"
+
 # Categories that do NOT represent a genuine agent-reported outcome. A run
 # where most terminations fall in this set is not "healthy" no matter how
 # high the raw completion_rate looks.
@@ -214,6 +225,74 @@ _NON_AGENT_CATEGORIES: frozenset[str] = frozenset(
 # A run is UNHEALTHY when more than this fraction of task terminations were
 # non-agent-caused (watchdog/timeout/janitor/other-forced/auto-completed).
 _UNHEALTHY_NON_AGENT_FRACTION = 0.5
+
+#: Task-status-histogram buckets that mean a declared task was still
+#: unfinished at final shutdown -- it was open/claimed/in-progress/orphaned
+#: rather than having reached any terminal outcome. Intentional parking states
+#: (``planned`` awaiting approval, ``suspended`` operator-parked,
+#: ``pending_approval``) and dependency-wait states are deliberately excluded
+#: so plan-mode / parked runs are not mislabelled unhealthy; only tasks that
+#: were actively declared-and-working-but-never-finished count (issue #3010).
+_INCOMPLETE_DECLARED_STATUSES: frozenset[str] = frozenset({"open", "claimed", "in_progress", "orphaned"})
+
+# ---------------------------------------------------------------------------
+# Run-outcome exit contract (``bernstein run``)
+# ---------------------------------------------------------------------------
+#
+# ``bernstein run`` must exit non-zero when the run did not honestly succeed so
+# an operator scripting ``bernstein run && deploy`` never deploys on a run that
+# accomplished nothing (issue #3010). The mapping is a pure function of the
+# run-health verdict so the exit path is unit-testable without the CLI.
+EXIT_RUN_HEALTHY = 0
+#: Distinct non-zero code for a completed-but-not-HEALTHY run (goal unmet:
+#: forced kills dominated, a task failed, work was discarded, or a declared
+#: task was never finished). Distinct from CLI usage/connection errors (1).
+EXIT_RUN_UNHEALTHY = 2
+
+
+def run_health_exit_code(healthy: bool) -> int:
+    """Map a run-health verdict to a ``bernstein run`` process exit code."""
+    return EXIT_RUN_HEALTHY if healthy else EXIT_RUN_UNHEALTHY
+
+
+def run_healthy_from_status_counts(status_counts: dict[str, int] | None) -> bool:
+    """Conservative run-health verdict from a ``/status`` histogram payload.
+
+    Used by the CLI's synchronous completion path to set ``bernstein run``'s
+    exit code without reconstructing every ``Task``. Mirrors
+    :func:`compute_run_health`'s hard rules on the fields ``/status`` exposes:
+    any FAILED task, or any DECLARED task still unfinished
+    (open/claimed/in-progress/orphaned) at final shutdown, is NOT healthy
+    (issue #3010). A payload with no terminal failures and nothing left
+    unfinished is healthy. An empty/None payload is vacuously healthy.
+
+    The authoritative, text-classified verdict (forced-kill fractions,
+    auto-completed-after-death, merge refusals) still lives in
+    :func:`generate_retrospective`; this is the projection of its hard rules
+    onto the histogram so a completed-but-empty-goal run exits non-zero.
+    """
+    if not status_counts:
+        return True
+    n_failed = int(status_counts.get("failed", 0) or 0)
+    if n_failed > 0:
+        return False
+    return count_incomplete_declared(status_counts) == 0
+
+
+def count_incomplete_declared(full_status_counts: dict[str, int] | None) -> int:
+    """Count declared tasks still unfinished (non-terminal) at final shutdown.
+
+    Derived from the full task-status histogram (every status the task server
+    knows about, not just done/failed). Returns the number of tasks in an
+    actively-declared-but-unfinished bucket (see
+    :data:`_INCOMPLETE_DECLARED_STATUSES`). ``0`` for a ``None``/empty
+    histogram.
+    """
+    if not full_status_counts:
+        return 0
+    return sum(
+        int(count or 0) for status, count in full_status_counts.items() if status in _INCOMPLETE_DECLARED_STATUSES
+    )
 
 
 def classify_task_terminator(task: Task) -> str:
@@ -330,6 +409,7 @@ def compute_run_health(
     all_tasks: list[Task],
     n_unresolved: int = 0,
     n_refused_merges: int = 0,
+    n_incomplete_declared: int = 0,
 ) -> tuple[bool, dict[str, int]]:
     """Compute the run-health verdict and per-terminator-category counts.
 
@@ -346,29 +426,45 @@ def compute_run_health(
             merges discard completed work without producing a failed task,
             so any refusal forces ``healthy`` to ``False`` -- including for
             an otherwise-empty 0/0 run (gh-2756).
+        n_incomplete_declared: Count of DECLARED tasks still unfinished at
+            final shutdown -- open/claimed/in-progress/orphaned rather than
+            done/failed (see :func:`count_incomplete_declared`). A declared
+            task that neither completed nor failed means the run did not meet
+            its goal, so any such task forces ``healthy`` to ``False`` --
+            including for an otherwise-empty 0/0 run where the only task's
+            agent produced no output and was reaped (issue #3010).
 
     Returns:
         Tuple of ``(healthy, counts)`` where ``counts`` maps each
         ``TERMINATOR_*`` category to the number of tasks in it.
+        ``TERMINATOR_INCOMPLETE_DECLARED`` is added (only when non-zero) so
+        the reaped-no-output task is reflected in the tally rather than
+        silently dropped.
 
         Hard rule (bug fix): ``healthy`` is ``False`` whenever ANY task
         has status FAILED, or ``n_unresolved > 0``, or
-        ``n_refused_merges > 0``, or there is at least
-        one ``TERMINATOR_AUTO_COMPLETED_AFTER_DEATH`` -- regardless of the
-        text-pattern classification below. This does not depend on
-        ``classify_task_terminator`` finding a forced-kill marker in the
-        task's free text, because that classification is a best-effort
+        ``n_refused_merges > 0``, or ``n_incomplete_declared > 0``, or there
+        is at least one ``TERMINATOR_AUTO_COMPLETED_AFTER_DEATH`` --
+        regardless of the text-pattern classification below. This does not
+        depend on ``classify_task_terminator`` finding a forced-kill marker
+        in the task's free text, because that classification is a best-effort
         proxy that can miss real failures (e.g. a provider error with no
         forced-kill keyword -- see TERMINATOR_AGENT_REPORTED_FAILURE).
         Absent any hard-rule trigger, ``healthy`` is ``False`` when more
         than ``_UNHEALTHY_NON_AGENT_FRACTION`` of terminations were
         non-agent-caused (watchdog/timeout/janitor/other-forced/
         auto-completed-after-death/agent-reported-failure). An empty task
-        list with no unresolved tasks is vacuously healthy.
+        list with no unresolved and no incomplete-declared tasks is
+        vacuously healthy.
     """
     counts: dict[str, int] = defaultdict(int)
     for t in all_tasks:
         counts[classify_task_terminator(t)] += 1
+    # Surface the reaped-no-output / never-finished task in the tally so it is
+    # not silently dropped (issue #3010). Only set when non-zero to preserve
+    # the empty-run ``counts == {}`` contract.
+    if n_incomplete_declared > 0:
+        counts[TERMINATOR_INCOMPLETE_DECLARED] = n_incomplete_declared
 
     # Hard rule (gh-2756): a refused merge means completed agent work was
     # discarded, and the affected task never shows up as FAILED -- checked
@@ -377,13 +473,13 @@ def compute_run_health(
     if n_refused_merges > 0:
         return False, counts.copy()
 
-    total = len(all_tasks) + n_unresolved
+    total = len(all_tasks) + n_unresolved + n_incomplete_declared
     if total == 0:
         return True, counts.copy()
 
     n_failed = sum(1 for t in all_tasks if t.status == TaskStatus.FAILED)
     auto_completed = counts.get(TERMINATOR_AUTO_COMPLETED_AFTER_DEATH, 0)
-    if n_failed > 0 or auto_completed > 0 or n_unresolved > 0:
+    if n_failed > 0 or auto_completed > 0 or n_unresolved > 0 or n_incomplete_declared > 0:
         return False, counts.copy()
 
     non_agent = sum(counts.get(cat, 0) for cat in _NON_AGENT_CATEGORIES)
@@ -396,10 +492,16 @@ def _write_run_health_section(
     all_tasks: list[Task],
     n_unresolved: int = 0,
     n_refused_merges: int = 0,
+    n_incomplete_declared: int = 0,
 ) -> tuple[bool, dict[str, int]]:
     """Write the Run Health section and return (healthy, counts) for reuse in Recommendations."""
-    healthy, counts = compute_run_health(all_tasks, n_unresolved=n_unresolved, n_refused_merges=n_refused_merges)
-    total = len(all_tasks) + n_unresolved
+    healthy, counts = compute_run_health(
+        all_tasks,
+        n_unresolved=n_unresolved,
+        n_refused_merges=n_refused_merges,
+        n_incomplete_declared=n_incomplete_declared,
+    )
+    total = len(all_tasks) + n_unresolved + n_incomplete_declared
     agent_completed = counts.get(TERMINATOR_AGENT_COMPLETED, 0)
     watchdog_killed = counts.get(TERMINATOR_WATCHDOG_KILLED, 0)
     janitor_rejected = counts.get(TERMINATOR_JANITOR_REJECTED, 0)
@@ -412,7 +514,8 @@ def _write_run_health_section(
     logger.info(
         "run health: %d/%d agent-completed, %d watchdog-killed, %d janitor-rejected, "
         "%d timeout-killed, %d other-forced, %d auto-completed-after-death, "
-        "%d agent-reported-failure, %d unresolved-in-metrics, %d merges-refused -> %s",
+        "%d agent-reported-failure, %d unresolved-in-metrics, %d incomplete-declared, "
+        "%d merges-refused -> %s",
         agent_completed,
         total,
         watchdog_killed,
@@ -422,6 +525,7 @@ def _write_run_health_section(
         auto_completed,
         agent_reported_failure,
         n_unresolved,
+        n_incomplete_declared,
         n_refused_merges,
         verdict,
     )
@@ -440,11 +544,23 @@ def _write_run_health_section(
             f"| Timeout-killed | {timeout_killed} |",
             f"| Auto-completed after agent death | {auto_completed} |",
             f"| Other forced termination | {other_forced} |",
+            f"| Declared task unfinished (no output / never terminated) | {n_incomplete_declared} |",
             f"| Unresolved in metrics (started, outcome never reconciled) | {n_unresolved} |",
             f"| Merge refused by guard (agent work discarded) | {n_refused_merges} |",
             "",
         )
     )
+    if n_incomplete_declared > 0:
+        lines.extend(
+            (
+                f"- **Warning:** {n_incomplete_declared} declared task(s) never reached a terminal "
+                "outcome (neither done nor failed) -- the run ended while they were still "
+                "open/claimed/in-progress. The goal was not met. A common cause is an agent that "
+                "produced no model output (0 tokens) and was reaped -- the model may have rejected "
+                "the request (context/rate limit). Check .sdd/runtime/*.log for the agent transcript.",
+                "",
+            )
+        )
     if n_refused_merges > 0:
         lines.extend(
             (
@@ -816,6 +932,28 @@ def generate_retrospective(
             sorted({r.branch for r in merge_refusals}),
         )
 
+    # ------------------------------------------------------------------
+    # Declared-but-unfinished tasks: the run ended while a declared task was
+    # still open/claimed/in-progress/orphaned -- neither done nor failed.
+    # ------------------------------------------------------------------
+    #
+    # done_tasks/failed_tasks (and the collector reconciliation above) only see
+    # terminal outcomes; a task whose agent produced zero model output and was
+    # reaped can be left non-terminal, invisible to both. Without this the run
+    # reported "0/0 ... -> HEALTHY" and `bernstein run` exited 0 for a run that
+    # accomplished nothing (issue #3010). Derived from the full task-status
+    # histogram so it is caught regardless of collector state.
+    n_incomplete_declared = count_incomplete_declared(full_status_counts)
+    if n_incomplete_declared:
+        logger.warning(
+            "retrospective: %d declared task(s) never reached a terminal outcome "
+            "(open/claimed/in-progress/orphaned at shutdown) -- goal not met; counting "
+            "them against run health rather than reporting HEALTHY 0/0 (issue #3010). "
+            "histogram=%s",
+            n_incomplete_declared,
+            full_status_counts,
+        )
+
     n_done = len(done_tasks)
     n_failed = len(failed_tasks) + n_unresolved
     total = len(all_tasks) + n_unresolved
@@ -972,6 +1110,7 @@ def generate_retrospective(
         all_tasks,
         n_unresolved=n_unresolved,
         n_refused_merges=n_refused_merges,
+        n_incomplete_declared=n_incomplete_declared,
     )
 
     _write_failure_analysis(lines, done_tasks, failed_tasks)

--- a/src/bernstein/core/quality/retrospective.py
+++ b/src/bernstein/core/quality/retrospective.py
@@ -246,8 +246,15 @@ _INCOMPLETE_DECLARED_STATUSES: frozenset[str] = frozenset({"open", "claimed", "i
 EXIT_RUN_HEALTHY = 0
 #: Distinct non-zero code for a completed-but-not-HEALTHY run (goal unmet:
 #: forced kills dominated, a task failed, work was discarded, or a declared
-#: task was never finished). Distinct from CLI usage/connection errors (1).
-EXIT_RUN_UNHEALTHY = 2
+#: task was never finished).
+#:
+#: Deliberately NOT 1 or 2: 1 is the generic CLI/bootstrap error code, and 2 is
+#: already taken twice over -- click raises ``UsageError``/``NoSuchOption`` with
+#: exit code 2, and ``cli/run_bootstrap.py`` itself raises ``SystemExit(2)`` on
+#: seed/config failures. Reusing either would make "you passed a bad flag" and
+#: "the run did not meet its goal" indistinguishable to a script, defeating the
+#: machine-readable outcome signal this constant exists to provide.
+EXIT_RUN_UNHEALTHY = 3
 
 
 def run_health_exit_code(healthy: bool) -> int:
@@ -293,6 +300,25 @@ def count_incomplete_declared(full_status_counts: dict[str, int] | None) -> int:
     return sum(
         int(count or 0) for status, count in full_status_counts.items() if status in _INCOMPLETE_DECLARED_STATUSES
     )
+
+
+def count_never_terminal(n_unresolved: int, n_incomplete_declared: int) -> int:
+    """Combine the two never-reached-a-terminal-outcome signals without double-counting.
+
+    ``n_unresolved`` (collector-derived: started via ``start_task()``, absent
+    from done/failed, ``end_time is None``) and ``n_incomplete_declared``
+    (histogram-derived: open/claimed/in-progress/orphaned at shutdown) are two
+    independent *estimates of the same population* -- tasks that were declared
+    and never terminated -- read from two different sources. The same reaped
+    no-output task typically appears in BOTH, so summing them counts it twice
+    and makes the Run Health totals disagree with the Overview.
+
+    Taking the maximum keeps whichever source saw more such tasks (neither is
+    strictly a superset: the collector misses tasks it never started, the
+    histogram misses tasks the server already dropped) while never counting one
+    task twice.
+    """
+    return max(int(n_unresolved), int(n_incomplete_declared))
 
 
 def classify_task_terminator(task: Task) -> str:
@@ -473,7 +499,7 @@ def compute_run_health(
     if n_refused_merges > 0:
         return False, counts.copy()
 
-    total = len(all_tasks) + n_unresolved + n_incomplete_declared
+    total = len(all_tasks) + count_never_terminal(n_unresolved, n_incomplete_declared)
     if total == 0:
         return True, counts.copy()
 
@@ -501,7 +527,10 @@ def _write_run_health_section(
         n_refused_merges=n_refused_merges,
         n_incomplete_declared=n_incomplete_declared,
     )
-    total = len(all_tasks) + n_unresolved + n_incomplete_declared
+    # Same de-duplicated total the Overview section uses: n_unresolved and
+    # n_incomplete_declared describe the same never-terminated tasks seen from
+    # two sources, so they are combined by max(), not summed.
+    total = len(all_tasks) + count_never_terminal(n_unresolved, n_incomplete_declared)
     agent_completed = counts.get(TERMINATOR_AGENT_COMPLETED, 0)
     watchdog_killed = counts.get(TERMINATOR_WATCHDOG_KILLED, 0)
     janitor_rejected = counts.get(TERMINATOR_JANITOR_REJECTED, 0)
@@ -954,9 +983,15 @@ def generate_retrospective(
             full_status_counts,
         )
 
+    # The Overview and the Run Health section must agree, so both count the
+    # never-terminated tasks the same de-duplicated way: n_unresolved and
+    # n_incomplete_declared are two views of one population (see
+    # count_never_terminal), and summing them reported the same reaped task
+    # twice -- "2/2 terminations were NOT genuine" against "0 done / 1 total".
+    n_never_terminal = count_never_terminal(n_unresolved, n_incomplete_declared)
     n_done = len(done_tasks)
-    n_failed = len(failed_tasks) + n_unresolved
-    total = len(all_tasks) + n_unresolved
+    n_failed = len(failed_tasks) + n_never_terminal
+    total = len(all_tasks) + n_never_terminal
     completion_rate = (n_done / total * 100) if total else 0.0
 
     _status_histogram = full_status_counts if full_status_counts is not None else {"done": n_done, "failed": n_failed}

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -1494,7 +1494,7 @@ class OrchestratorConfig:
     # separate from (and larger than) ``heartbeat_timeout_s`` so a slow/free
     # model that takes >120s to its first turn is not reaped mid-work while a
     # non-heartbeat adapter has only its spawn-time heartbeat on disk (issue
-    # #3012). Overridable via ``tuning.orchestrator.heartbeat_starting_timeout_s``.
+    # #3012). Overridable via ``tuning.agent.heartbeat_starting_timeout_s``.
     heartbeat_starting_timeout_s: int = field(default_factory=lambda: int(AGENT.heartbeat_starting_timeout_s))
     heartbeat_enabled: bool = True
     # Derived from ORCHESTRATOR.max_agent_runtime_s (canonical) so

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -1490,6 +1490,12 @@ class OrchestratorConfig:
     # Unified with AGENT.heartbeat_stale_s. Previously 900s; now defaults to 120s.
     # Deployments that explicitly relied on the 900s value must set this field explicitly.
     heartbeat_timeout_s: int = field(default_factory=lambda: int(AGENT.heartbeat_stale_s))
+    # Time-to-first-turn cap for agents still in the `starting` phase. Kept
+    # separate from (and larger than) ``heartbeat_timeout_s`` so a slow/free
+    # model that takes >120s to its first turn is not reaped mid-work while a
+    # non-heartbeat adapter has only its spawn-time heartbeat on disk (issue
+    # #3012). Overridable via ``tuning.orchestrator.heartbeat_starting_timeout_s``.
+    heartbeat_starting_timeout_s: int = field(default_factory=lambda: int(AGENT.heartbeat_starting_timeout_s))
     heartbeat_enabled: bool = True
     # Derived from ORCHESTRATOR.max_agent_runtime_s (canonical) so
     # ``tuning.orchestrator.max_agent_runtime_s`` overrides the starting

--- a/tests/unit/test_heartbeat_liveness_gate.py
+++ b/tests/unit/test_heartbeat_liveness_gate.py
@@ -1,0 +1,114 @@
+"""Issue #3012: heartbeat escalation must consult log/git liveness before it kills.
+
+The Tier-1 heartbeat escalation ladder used to SIGTERM/SIGKILL an agent purely
+on heartbeat age. Adapters that emit no heartbeats (``consumes_heartbeat_dir=
+False``) have only their spawn-time heartbeat on disk, so heartbeat age is just
+wall-clock since spawn -- and a slow/free model streaming its first turn was
+reaped mid-work even though its log had just been written. The reap-cycle's
+``liveness_judgment`` correctly consults log/git freshness, but it ran one tick
+AFTER the SIGTERM. These tests drive the real ``check_stale_agents`` path and
+assert the escalation now applies the same log/git-freshness check BEFORE the
+kill.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from bernstein.core.heartbeat import check_stale_agents
+from bernstein.core.models import AgentHeartbeat, AgentSession, ModelConfig
+
+from bernstein.core.agents.agent_signals import AgentSignalManager
+
+
+def _session(*, pid: int | None = 999_999, spawn_ts: float) -> AgentSession:
+    return AgentSession(
+        id="mgr-1",
+        role="manager",
+        task_ids=["T-1"],
+        status="working",
+        spawn_ts=spawn_ts,
+        pid=pid,
+        model_config=ModelConfig("sonnet", "high"),
+    )
+
+
+def _orch(workdir: Path, session: AgentSession, *, timeout_s: float = 120.0) -> SimpleNamespace:
+    return SimpleNamespace(
+        _agents={session.id: session},
+        _signal_mgr=AgentSignalManager(workdir),
+        _spawner=MagicMock(),
+        _workdir=workdir,
+        _config=SimpleNamespace(heartbeat_enabled=True, heartbeat_timeout_s=timeout_s),
+    )
+
+
+def _write_log(workdir: Path, session_id: str, *, mtime: float | None = None) -> Path:
+    log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text("thinking... (a long first turn is still streaming)\n", encoding="utf-8")
+    if mtime is not None:
+        os.utime(log_path, (mtime, mtime))
+    return log_path
+
+
+def test_fresh_log_prevents_heartbeat_sigterm(tmp_path: Path) -> None:
+    """Stale heartbeat + a log written within the grace window -> the agent is
+    alive and NO SIGTERM/SIGKILL is sent (issue #3012)."""
+    now = time.time()
+    session = _session(spawn_ts=now - 200)
+    orch = _orch(tmp_path, session, timeout_s=120.0)
+    # Heartbeat frozen 165s ago (past the 120s timeout AND the 150s SIGKILL
+    # threshold) -- absent a liveness signal this agent would be force-killed.
+    orch._signal_mgr.write_heartbeat(session.id, AgentHeartbeat(timestamp=now - 165, status="starting"))
+    _write_log(tmp_path, session.id)  # freshly written -> mtime ~now
+
+    with patch("bernstein.core.platform_compat.kill_process_group") as kpg:
+        check_stale_agents(orch)
+
+    assert not kpg.called, "a still-writing agent must not be killed on heartbeat age alone"
+    orch._spawner.kill.assert_not_called()
+    # The soft SHUTDOWN signal must also be withheld from a live agent.
+    shutdown_file = tmp_path / ".sdd" / "runtime" / "signals" / session.id / "SHUTDOWN"
+    assert not shutdown_file.exists()
+    # Ladder was reset so a genuine later stall re-escalates from the start.
+    ladder = orch._heartbeat_escalation_ladder
+    state = ladder.get_state(session.id)
+    assert state is None or state.highest_tier.name == "NONE"
+
+
+def test_stale_log_still_allows_heartbeat_kill(tmp_path: Path) -> None:
+    """Control: same stale heartbeat, but the log mtime is ALSO past the grace
+    window -> the agent is genuinely stuck and the ladder still kills it. This
+    proves the gate is driven by log freshness, not a blanket disable (and
+    keeps issue #2796's frozen-heartbeat reaping intact)."""
+    now = time.time()
+    session = _session(spawn_ts=now - 300)
+    orch = _orch(tmp_path, session, timeout_s=120.0)
+    orch._signal_mgr.write_heartbeat(session.id, AgentHeartbeat(timestamp=now - 165, status="starting"))
+    _write_log(tmp_path, session.id, mtime=now - 300)  # log not fresh either
+
+    with patch("bernstein.core.platform_compat.kill_process_group") as kpg:
+        check_stale_agents(orch)
+
+    assert kpg.called, "a frozen agent with no log/git activity must still be killed"
+    assert kpg.call_args.args[0] == 999_999
+
+
+def test_no_log_at_all_still_allows_heartbeat_kill(tmp_path: Path) -> None:
+    """A frozen heartbeat with no log file at all (nothing ever written) has no
+    fresh signal and is escalated -- the gate never masks a truly dead agent."""
+    now = time.time()
+    session = _session(spawn_ts=now - 300)
+    orch = _orch(tmp_path, session, timeout_s=120.0)
+    orch._signal_mgr.write_heartbeat(session.id, AgentHeartbeat(timestamp=now - 165, status="starting"))
+    # No log file written.
+
+    with patch("bernstein.core.platform_compat.kill_process_group") as kpg:
+        check_stale_agents(orch)
+
+    assert kpg.called

--- a/tests/unit/test_orchestrator_liveness_false_positives.py
+++ b/tests/unit/test_orchestrator_liveness_false_positives.py
@@ -1,0 +1,522 @@
+"""False-positive regressions for the orchestrator-liveness verdict.
+
+Companion to ``test_orchestrator_liveness_verdict.py``. That file pins the
+cases where the verdict must FIRE; this one pins the cases where it must not,
+each of which shipped as a defect and was reproduced against the real code.
+
+Two harness rules, because breaking either is what let the first round of
+defects through a green suite:
+
+* **The clock fakes monotonic and wall together.** A real ``time.sleep(s)``
+  advances both. A harness that advances only one silently changes which of the
+  two the code under test is measuring.
+* **``/health`` fixtures carry the ``components`` block.** A real server always
+  emits it (``status_dashboard._health_components``). Omitting it is what made
+  the stale-pidfile guard look alive when it was being overridden.
+  ``test_health_fixture_matches_the_real_server`` pins that shape against the
+  real producer so the fixtures cannot drift back.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+import bernstein.cli.run_bootstrap as rb
+from bernstein.core.orchestration.bootstrap import _watchdog_check_process
+from bernstein.core.orchestration.process_utils import (
+    LIVENESS_ALIVE,
+    LIVENESS_GONE,
+    LIVENESS_UNKNOWN,
+    classify_pidfile_liveness,
+)
+
+
+def _markers() -> tuple[str, ...]:
+    """Every command line an orchestrator process can legitimately have.
+
+    Imported at point of use: a tree that only knows the single ``-m`` spelling
+    should fail the tests that depend on the others behaviourally, not take the
+    whole module out with a collection error.
+    """
+    from bernstein.core.orchestration import process_utils
+
+    return getattr(process_utils, "ORCHESTRATOR_PROCESS_MARKERS", (process_utils.ORCHESTRATOR_PROCESS_MARKER,))
+
+
+DEAD_PID = 999999
+
+STATUS_OPEN = {"total": 1, "open": 1, "claimed": 0, "done": 0, "failed": 0}
+FULL_OPEN = {"total": 1, "open": 1, "claimed": 0, "in_progress": 0, "orphaned": 0, "done": 0, "failed": 0}
+
+
+def _health(spawner_status: str, *, agent_count: int = 0) -> dict[str, Any]:
+    """A ``/health`` payload shaped like the real one. See the module docstring."""
+    return {
+        "status": "ok",
+        "agent_count": agent_count,
+        "components": {
+            "server": {"status": "ok"},
+            "spawner": {"status": spawner_status, "pid": DEAD_PID, "detail": "process not found"},
+            "database": {"status": "ok", "type": "TaskStore", "detail": ""},
+            "agents": {"status": "ok", "active": agent_count, "detail": "no active agents"},
+        },
+    }
+
+
+HEALTH_DOWN = _health("down")
+
+
+class _Clock:
+    """A fake clock where monotonic and wall advance together, as they really do.
+
+    ``step_wall`` moves ONLY the wall clock, which is what an NTP correction, a
+    container clock sync, or a laptop resume does to a running process.
+    """
+
+    def __init__(self) -> None:
+        self.elapsed = 0.0
+        self.wall_skew = 0.0
+        self._base_wall = time.time()
+        self._base_mono = time.monotonic()
+
+    def time(self) -> float:
+        return self._base_wall + self.elapsed + self.wall_skew
+
+    def monotonic(self) -> float:
+        return self._base_mono + self.elapsed
+
+    def sleep(self, seconds: float) -> None:
+        self.elapsed += seconds
+
+    def step_wall(self, seconds: float) -> None:
+        self.wall_skew += seconds
+
+
+def _runtime(tmp_path: Path) -> Path:
+    runtime = tmp_path / ".sdd" / "runtime"
+    runtime.mkdir(parents=True, exist_ok=True)
+    return runtime
+
+
+def _drive(
+    *,
+    clock: _Clock,
+    health: dict[str, Any] | None = None,
+    status: dict[str, Any] | None = STATUS_OPEN,
+    full_counts: dict[str, Any] | None = FULL_OPEN,
+    outage_polls: tuple[int, int] | None = None,
+    wall_step: tuple[int, float] | None = None,
+    timeout_s: float = 3600.0,
+    poll_interval_s: float = 2.0,
+) -> tuple[dict[str, Any] | None, dict[str, int]]:
+    """Drive the real wait loop. Returns (verdict, counters).
+
+    ``outage_polls`` makes ``/status`` and ``/health`` unreachable for an
+    inclusive poll range. ``wall_step`` applies a wall-clock-only jump before a
+    given poll.
+    """
+    health_payload = HEALTH_DOWN if health is None else health
+    counts = {"polls": 0, "observed": 0}
+
+    def fake_get(path: str) -> Any:
+        if path == "/status":
+            counts["polls"] += 1
+            if wall_step is not None and counts["polls"] == wall_step[0]:
+                clock.step_wall(wall_step[1])
+            if outage_polls is not None and outage_polls[0] <= counts["polls"] <= outage_polls[1]:
+                return None
+            counts["observed"] += 1
+            return status
+        if path == "/health":
+            if outage_polls is not None and outage_polls[0] <= counts["polls"] <= outage_polls[1]:
+                return None
+            return health_payload
+        if path == "/tasks/counts":
+            return full_counts
+        return None
+
+    with (
+        patch.object(rb, "server_get", side_effect=fake_get),
+        patch.object(rb, "time", clock),
+        patch.object(rb, "_signal_orchestrator_shutdown"),
+    ):
+        verdict = rb._wait_for_run_completion(poll_interval_s=poll_interval_s, timeout_s=timeout_s)
+    return verdict, counts
+
+
+# ---------------------------------------------------------------------------
+# Defect 1: the confirmation window was measured on the wall clock.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("jump", [11.5, 20.0, 60.0, 300.0])
+def test_a_wall_clock_step_does_not_shorten_the_confirmation_window(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, jump: float
+) -> None:
+    """A forward wall-clock step must not satisfy the window.
+
+    The window exists to give the recovery supervisor time to restart the
+    orchestrator, and the supervisor sleeps on ``time.monotonic()``. Measuring
+    the window on ``time.time()`` let an NTP correction, a container clock sync,
+    or a laptop resume collapse 15 seconds into 4 seconds of real time. The
+    suspend-resume case is the worst: the supervisor's monotonic clock does not
+    advance at all while suspended, so it wakes having made zero extra restart
+    attempts against a window that already reads as satisfied.
+    """
+    (_runtime(tmp_path) / "spawner.pid").write_text(str(DEAD_PID))
+    monkeypatch.chdir(tmp_path)
+
+    clock = _Clock()
+    verdict, counts = _drive(clock=clock, wall_step=(1, jump))
+
+    assert verdict is not None, "a sustained dead orchestrator must still reach a verdict"
+    assert clock.elapsed >= rb._ORCHESTRATOR_GONE_CONFIRM_WINDOW_S, (
+        f"verdict after {clock.elapsed}s of monotonic time with a +{jump}s wall step; "
+        f"the window is {rb._ORCHESTRATOR_GONE_CONFIRM_WINDOW_S}s and must be measured "
+        f"on the clock the recovery supervisor actually sleeps on"
+    )
+    assert counts["observed"] >= rb._ORCHESTRATOR_GONE_CONFIRMATIONS
+
+
+# ---------------------------------------------------------------------------
+# Defect 2: the two observers were not independent, and GONE needed only one.
+# ---------------------------------------------------------------------------
+
+
+def test_gone_requires_positive_local_evidence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The task server can veto a verdict; it can never supply one.
+
+    ``/health``'s spawner component reads the SAME ``spawner.pid`` with a bare
+    ``os.kill``, with none of the local classifier's guards: no mtime
+    attribution, no command-line identity, no zombie rejection. It is a weaker
+    read of the same evidence, not a second witness. Accepting its ``down`` as
+    corroboration made every one of those guards overridable, and only in the
+    direction that reaps.
+    """
+    runtime = _runtime(tmp_path)
+    pidfile = runtime / "spawner.pid"
+    monkeypatch.chdir(tmp_path)
+
+    # No pidfile at all. The classifier calls this unknown; so must the caller.
+    assert rb._orchestrator_liveness(HEALTH_DOWN) == (LIVENESS_UNKNOWN, None)
+
+    # A pidfile that cannot be parsed.
+    pidfile.write_text("not-a-pid")
+    assert rb._orchestrator_liveness(HEALTH_DOWN)[0] == LIVENESS_UNKNOWN
+
+    # The empty file that a torn write of `spawner.pid` leaves behind.
+    pidfile.write_text("")
+    assert rb._orchestrator_liveness(HEALTH_DOWN)[0] == LIVENESS_UNKNOWN
+
+    # A pidfile written before this run began.
+    pidfile.write_text(str(DEAD_PID))
+    old = time.time() - 86400.0
+    os.utime(pidfile, (old, old))
+    assert rb._orchestrator_liveness(HEALTH_DOWN, pidfile_not_before=rb._CLI_RUN_EPOCH)[0] == LIVENESS_UNKNOWN
+
+    # Positive local evidence, uncontradicted, is still a verdict.
+    pidfile.write_text(str(DEAD_PID))
+    assert rb._orchestrator_liveness(HEALTH_DOWN) == (LIVENESS_GONE, DEAD_PID)
+    assert rb._orchestrator_liveness({"agent_count": 0}) == (LIVENESS_GONE, DEAD_PID)
+    # ... and the server's `ok` still vetoes it.
+    assert rb._orchestrator_liveness(_health("ok"))[0] == LIVENESS_UNKNOWN
+
+
+def test_no_pidfile_plus_server_down_never_reaches_a_verdict(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """End-to-end: no pidfile on disk must not exit non-zero, whatever /health says.
+
+    With ``pid`` as ``None`` there was not even a pid for the restart-detection
+    reset to compare against, so a restart could not have cancelled the verdict.
+    """
+    _runtime(tmp_path)  # runtime dir exists, spawner.pid does not
+    monkeypatch.chdir(tmp_path)
+
+    verdict, _counts = _drive(clock=_Clock(), timeout_s=600.0)
+    assert verdict is None
+
+
+# ---------------------------------------------------------------------------
+# Defect 3: the mtime guard was dead code whenever the server had an opinion,
+# and the fixture that was supposed to prove otherwise omitted `components`.
+# ---------------------------------------------------------------------------
+
+
+def test_stale_pidfile_guard_holds_against_a_realistic_health_payload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A day-old pidfile must not condemn this run, WITH a real /health payload.
+
+    The earlier version of this guard passed only because its fixture omitted
+    the ``components`` block that a real server always emits. Restore the block
+    and the guard was inert.
+    """
+    pidfile = _runtime(tmp_path) / "spawner.pid"
+    pidfile.write_text(str(DEAD_PID))
+    old = time.time() - 86400.0
+    os.utime(pidfile, (old, old))
+    monkeypatch.chdir(tmp_path)
+
+    verdict, counts = _drive(clock=_Clock(), health=HEALTH_DOWN, timeout_s=600.0)
+    assert verdict is None, f"a previous run's pidfile produced a verdict after {counts['observed']} observations"
+
+
+def test_health_fixture_matches_the_real_server() -> None:
+    """Pin the fixture shape against the real producer, not against a memory.
+
+    Every ``/health`` fixture in these tests claims to be what the server sends.
+    This asserts it, by running the server's own component builder over a real
+    pidfile: if the key path or the status vocabulary ever changes, the fixtures
+    fail here rather than quietly stopping to exercise the code they target.
+    """
+    import tempfile
+
+    from bernstein.core.routes.status_dashboard import _health_components
+
+    with tempfile.TemporaryDirectory() as td:
+        sdd = Path(td) / ".sdd"
+        (sdd / "runtime").mkdir(parents=True)
+        request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(sdd_dir=sdd)))
+        store = SimpleNamespace(agent_count=0, jsonl_path=sdd / "runtime" / "tasks.jsonl")
+
+        # No pidfile -> the server reports neither ok nor down.
+        components = _health_components(request, store)  # type: ignore[arg-type]
+        assert set(HEALTH_DOWN["components"]) == set(components), (
+            "the /health fixture must carry the same component keys the server emits"
+        )
+        assert components["spawner"]["status"] not in ("ok", "down")
+
+        # A dead pid -> exactly the "down" the fixtures use.
+        (sdd / "runtime" / "spawner.pid").write_text(str(DEAD_PID))
+        assert _health_components(request, store)["spawner"]["status"] == "down"  # type: ignore[arg-type]
+
+        # A live pid -> exactly the "ok" the fixtures use.
+        (sdd / "runtime" / "spawner.pid").write_text(str(os.getpid()))
+        assert _health_components(request, store)["spawner"]["status"] == "ok"  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Defect 4: the supervisor stopped restarting, which regressed against main.
+# ---------------------------------------------------------------------------
+
+
+def _restart_calls(**kwargs: Any) -> list[int]:
+    """Run one supervisor check and report whether it spawned anything."""
+    calls: list[int] = []
+
+    def restart_fn() -> int:
+        calls.append(1)
+        return 4242
+
+    _watchdog_check_process(
+        name="Orchestrator",
+        alive_since=None,
+        restarts=0,
+        give_up_logged=False,
+        max_restarts=5,
+        reset_after_s=120.0,
+        now=time.monotonic(),
+        restart_fn=restart_fn,
+        **kwargs,
+    )
+    return calls
+
+
+def test_crashed_orchestrator_whose_pidfile_was_cleaned_is_still_restarted(
+    tmp_path: Path,
+) -> None:
+    """The regression: crashed, then ``bernstein doctor --fix`` removed the pidfile.
+
+    ``cli/commands/status_cmd.py::_fix_stale_pids`` deletes precisely the
+    pidfile of a process that has already died. Refusing to restart on the
+    resulting "no pidfile" reading is permanent, because nothing recreates
+    ``spawner.pid``: the run is left with no orchestrator and no recovery.
+    This walks the real doctor path rather than asserting on ``pid=None``.
+    """
+    from bernstein.cli.commands.status_cmd import _doctor_check_stale_pids, _fix_stale_pids
+
+    pidfile = _runtime(tmp_path) / "spawner.pid"
+    pidfile.write_text(str(DEAD_PID))
+
+    liveness, pid = classify_pidfile_liveness(pidfile, expect_cmdline=_markers())
+    assert _restart_calls(pid=pid, liveness=liveness) == [1], "a crash with its pidfile intact must restart"
+
+    checks: list[dict[str, Any]] = []
+    _fix_stale_pids(_doctor_check_stale_pids(checks, tmp_path), [])
+    assert not pidfile.exists(), "doctor --fix is expected to have removed the stale pidfile"
+
+    liveness, pid = classify_pidfile_liveness(pidfile, expect_cmdline=_markers())
+    assert _restart_calls(pid=pid, liveness=liveness) == [1], (
+        "the same crash must still restart once its stale pidfile has been cleaned"
+    )
+
+
+def test_recycled_pid_after_a_crash_is_still_restarted(tmp_path: Path) -> None:
+    """A pid reused by an unrelated process must not suppress recovery.
+
+    For the supervisor the identity check runs the other way round from the
+    CLI: its job is to stop a stranger's process from passing as our live
+    orchestrator and withholding a restart the run needs.
+    """
+    pidfile = _runtime(tmp_path) / "spawner.pid"
+    pidfile.write_text(str(os.getpid()))  # alive, and emphatically not an orchestrator
+
+    liveness, pid = classify_pidfile_liveness(pidfile, expect_cmdline=_markers())
+    assert liveness == LIVENESS_UNKNOWN
+    assert _restart_calls(pid=pid, liveness=liveness) == [1]
+
+
+def test_a_live_orchestrator_is_never_restarted(tmp_path: Path) -> None:
+    """Control: the one reading that withholds a restart is a positive alive."""
+    assert _restart_calls(pid=os.getpid(), liveness=LIVENESS_ALIVE) == []
+
+
+def test_supervisor_stands_down_only_on_positive_teardown_evidence(tmp_path: Path) -> None:
+    """Refusal needs evidence of teardown, not merely absence of evidence.
+
+    ``bernstein stop`` kills ``watchdog.pid`` FIRST and removes pidfiles last,
+    so a supervisor that is alive to see a missing pidfile is not looking at a
+    teardown. Only a draining marker, or having been superseded as the
+    supervisor of record, justifies standing down.
+    """
+    from bernstein.core.orchestration.bootstrap import _supervisor_should_stand_down
+
+    runtime = _runtime(tmp_path)
+
+    # Nothing on disk: no evidence of teardown, so keep supervising.
+    assert _supervisor_should_stand_down(tmp_path) is None
+
+    # A supervised process's pidfile is missing: still not teardown evidence.
+    (runtime / "spawner.pid").unlink(missing_ok=True)
+    assert _supervisor_should_stand_down(tmp_path) is None
+
+    # We are the supervisor of record: keep going.
+    (runtime / "watchdog.pid").write_text(str(os.getpid()))
+    assert _supervisor_should_stand_down(tmp_path) is None
+
+    # Superseded or killed: stand down.
+    (runtime / "watchdog.pid").write_text(str(DEAD_PID))
+    assert _supervisor_should_stand_down(tmp_path) is not None
+
+    # Drain in progress: stand down.
+    (runtime / "watchdog.pid").write_text(str(os.getpid()))
+    (runtime / "draining").write_text("draining")
+    assert _supervisor_should_stand_down(tmp_path) is not None
+
+
+# ---------------------------------------------------------------------------
+# Defect 5: the window could be satisfied by time in which recovery was
+# impossible, because unreachable polls neither reset nor advanced the streak.
+# ---------------------------------------------------------------------------
+
+
+def test_a_server_outage_is_not_credited_as_confirmation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unreachable polls must reset the streak, not silently fill the window.
+
+    A server outage is the exact period during which recovery is impossible:
+    ``bootstrap._restart_spawner`` returns ``-1`` whenever the task server is
+    not alive, so the supervisor gets zero chances to restart the orchestrator
+    throughout. Counting that time as confirmation fired the verdict just as the
+    recovery sequence reached the orchestrator, on 3 real observations out of 13
+    polls.
+    """
+    (_runtime(tmp_path) / "spawner.pid").write_text(str(DEAD_PID))
+    monkeypatch.chdir(tmp_path)
+
+    clock = _Clock()
+    verdict, counts = _drive(clock=clock, outage_polls=(3, 12), timeout_s=3600.0)
+
+    assert verdict is not None, "the run really did end; it must still be reported eventually"
+    # The outage must have bought nothing: the confirming observations all have
+    # to come after it, so the total observed count exceeds the two seen before.
+    assert counts["observed"] >= 2 + rb._ORCHESTRATOR_GONE_CONFIRMATIONS, (
+        f"verdict reached on {counts['observed']} observations; the 2 before the outage "
+        f"cannot count towards a window the outage did not advance"
+    )
+    assert clock.elapsed >= rb._ORCHESTRATOR_GONE_CONFIRM_WINDOW_S
+
+
+def test_an_outage_that_never_ends_never_produces_a_verdict(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The degenerate case: a server that goes away for good is not a verdict."""
+    (_runtime(tmp_path) / "spawner.pid").write_text(str(DEAD_PID))
+    monkeypatch.chdir(tmp_path)
+
+    verdict, _counts = _drive(clock=_Clock(), outage_polls=(3, 10**9), timeout_s=600.0)
+    assert verdict is None
+
+
+def test_uninterrupted_polling_still_reaches_the_verdict(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Control: with a reachable server the verdict still arrives promptly.
+
+    Guards the fix against over-correction: tightening the streak must not make
+    the honest #3010 case unreachable.
+    """
+    (_runtime(tmp_path) / "spawner.pid").write_text(str(DEAD_PID))
+    monkeypatch.chdir(tmp_path)
+
+    clock = _Clock()
+    verdict, counts = _drive(clock=clock, timeout_s=600.0)
+    assert verdict is not None
+    assert counts["observed"] == counts["polls"]
+    assert clock.elapsed <= 4.0 * rb._ORCHESTRATOR_GONE_CONFIRM_WINDOW_S
+
+
+# ---------------------------------------------------------------------------
+# Also reported: the command-line marker is inert after a self-restart.
+# ---------------------------------------------------------------------------
+
+
+def test_marker_covers_every_shipped_launch_form() -> None:
+    """All three spellings an orchestrator process can legitimately have.
+
+    A form that is missing from the list looks exactly like a recycled pid, so
+    the pid-reuse protection silently disappears for processes launched that
+    way. The ``execv`` form is the one that matters most: it is what the
+    orchestrator becomes after its own restart, which is precisely when a pid
+    has just been freed for reuse.
+    """
+    launch_forms = {
+        # server_launch._start_spawner
+        "spawner": "/usr/bin/python3 -m bernstein.core.orchestration.orchestrator --port 8052",
+        # orchestrator_cleanup.restart -> os.execv, after python rewrote argv[0]
+        # from the -m module name to the module file path
+        "self_restart": "/usr/bin/python3 /app/src/bernstein/core/orchestration/orchestrator.py --port 8052",
+        # docker-compose.yaml entrypoint / docker/demo/demo-cycle.sh
+        "compose": "python -m bernstein.core.orchestrator",
+    }
+    markers = _markers()
+    for form, cmdline in launch_forms.items():
+        assert any(m in cmdline for m in markers), f"{form} launch form is unrecognised: {cmdline}"
+
+    assert not any(m in "/usr/bin/python3 -m http.server" for m in markers)
+
+
+# ---------------------------------------------------------------------------
+# Also reported: an error body was accepted as a complete task histogram.
+# ---------------------------------------------------------------------------
+
+
+def test_an_error_body_is_not_a_task_histogram(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``{"detail": "Not Found"}`` must not read as "nothing outstanding".
+
+    Every status key is absent from an error body, so counting it yields a
+    confident zero for a run with any amount of work left. That zero would also
+    disable the quiescence veto that keeps an ``in_progress`` task from being
+    reported as a finished, healthy run.
+    """
+    monkeypatch.chdir(tmp_path)
+    with patch.object(rb, "server_get", return_value={"detail": "Not Found"}):
+        n_incomplete, full_counts = rb._incomplete_declared_counts(STATUS_OPEN)
+    assert full_counts is None, "an error body must not be accepted as a complete histogram"
+    assert n_incomplete == 1, "the count must fall back to the /status payload"
+
+    with patch.object(rb, "server_get", return_value=FULL_OPEN):
+        n_incomplete, full_counts = rb._incomplete_declared_counts(STATUS_OPEN)
+    assert full_counts == FULL_OPEN
+    assert n_incomplete == 1

--- a/tests/unit/test_orchestrator_liveness_verdict.py
+++ b/tests/unit/test_orchestrator_liveness_verdict.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import os
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
@@ -24,6 +25,19 @@ from bernstein.core.orchestration.bootstrap import _watchdog_check_process
 # A pid high enough to be unused on any normal host. It is the value the
 # adversarial review fed to both subsystems to show they disagreed about it.
 DEAD_PID = 999999
+
+#: A ``/health`` payload from a server that has no view of the spawner (no
+#: ``sdd_dir`` configured), which leaves the decision to the local probe. Real
+#: servers always emit the ``components`` block, so a fixture that omits it
+#: entirely tests a shape that never occurs. See
+#: ``test_orchestrator_liveness_false_positives.py`` for the fixture pin.
+HEALTH_NO_OPINION: dict[str, Any] = {
+    "agent_count": 0,
+    "components": {
+        "server": {"status": "ok"},
+        "spawner": {"status": "unknown", "pid": None, "detail": "sdd_dir not configured"},
+    },
+}
 
 
 def _drive_wait(
@@ -39,8 +53,13 @@ def _drive_wait(
     Only the server and the clock are faked. The liveness classification, the
     pidfile read and the confirmation window are the real ones, so a test that
     passes here is a statement about the shipped behaviour.
+
+    The clock advances monotonic and wall time together, exactly as a real
+    ``time.sleep`` does. Faking only one of them changes which clock the code
+    under test is measured on, which is how a wall-clock confirmation window
+    once passed a suite that thought it was testing a monotonic one.
     """
-    health_payload = {"agent_count": 0} if health is None else health
+    health_payload = HEALTH_NO_OPINION if health is None else health
     polls = {"n": 0}
 
     def fake_get(path: str) -> Any:
@@ -53,16 +72,17 @@ def _drive_wait(
             return full_counts
         return None
 
-    clock = {"t": time.time()}
-
-    def fake_time() -> float:
-        clock["t"] += tick_s
-        return clock["t"]
+    elapsed = {"s": 0.0}
+    base_wall, base_mono = time.time(), time.monotonic()
+    clock = SimpleNamespace(
+        time=lambda: base_wall + elapsed["s"],
+        monotonic=lambda: base_mono + elapsed["s"],
+        sleep=lambda seconds: elapsed.__setitem__("s", elapsed["s"] + tick_s),
+    )
 
     with (
         patch.object(rb, "server_get", side_effect=fake_get),
-        patch.object(rb.time, "sleep", return_value=None),
-        patch.object(rb.time, "time", side_effect=fake_time),
+        patch.object(rb, "time", clock),
         patch.object(rb, "_signal_orchestrator_shutdown"),
     ):
         return rb._wait_for_run_completion(timeout_s=timeout_s), polls["n"]
@@ -427,39 +447,30 @@ def _restart_calls(**kwargs: Any) -> list[int]:
     return calls
 
 
-def test_supervisor_does_not_restart_without_a_pid_to_attribute() -> None:
-    """No pid means no evidence of death, so no spawn.
+def test_sharing_the_classifier_does_not_make_the_supervisor_withhold_recovery() -> None:
+    """The shared vocabulary must not turn into a shared refusal to act.
 
-    A supervisor cycle that finds no pidfile is looking either at a run that has
-    not written one yet or at one an operator teardown removed -- teardown
-    deletes every ``*.pid``. Spawning on that reading either starts a second
-    orchestrator against a live task store or resurrects a torn-down run. The
-    old code took "pid is None" straight to the restart branch.
+    An earlier revision of this file asserted the opposite: that an
+    unattributable pid must not spawn. That was wrong, and it regressed
+    recovery against main. The two subsystems read the same classification but
+    they owe it opposite duties. For the CLI, acting on a weak reading destroys
+    a running run, so anything short of positive evidence must do nothing. For
+    the supervisor, NOT acting destroys the run just as thoroughly and
+    permanently, because nothing recreates ``spawner.pid``. So only a positive
+    ``alive`` withholds a restart here.
+
+    See ``test_orchestrator_liveness_false_positives.py`` for the doctor-path
+    scenario that made the regression concrete.
     """
-    assert _restart_calls(pid=None) == [], "a missing pidfile must not trigger a spawn"
+    from bernstein.core.orchestration.process_utils import LIVENESS_ALIVE, LIVENESS_GONE, LIVENESS_UNKNOWN
 
-
-def test_supervisor_does_not_restart_on_an_unattributable_pid() -> None:
-    """The restart path needs a pid it owns, not merely a pid that is not alive.
-
-    This is the pid the CLI classifies as gone. Handing it to the supervisor
-    with no owning pidfile must not spawn, and the two subsystems must reach
-    that conclusion through the same classifier.
-    """
-    from bernstein.core.orchestration.process_utils import LIVENESS_GONE, LIVENESS_UNKNOWN
-
-    assert _restart_calls(pid=DEAD_PID, liveness=LIVENESS_UNKNOWN) == [], (
-        "an unattributable pid must not trigger a spawn"
-    )
-    # Crash recovery itself is intact: a pidfile this supervisor owns, naming a
-    # dead pid, is still restarted. That is the supervisor's whole job.
     assert _restart_calls(pid=DEAD_PID, liveness=LIVENESS_GONE) == [1], (
-        "a genuinely crashed orchestrator must still be restarted"
+        "a genuinely crashed orchestrator must be restarted"
     )
-
-
-def test_supervisor_leaves_a_live_process_alone() -> None:
-    """Control: an alive classification never reaches the restart path."""
-    from bernstein.core.orchestration.process_utils import LIVENESS_ALIVE
-
-    assert _restart_calls(pid=os.getpid(), liveness=LIVENESS_ALIVE) == []
+    assert _restart_calls(pid=DEAD_PID, liveness=LIVENESS_UNKNOWN) == [1], (
+        "an unattributable reading is not a reason to abandon a run"
+    )
+    assert _restart_calls(pid=None) == [1], "a missing pidfile is not a reason to abandon a run either"
+    assert _restart_calls(pid=os.getpid(), liveness=LIVENESS_ALIVE) == [], (
+        "a positive alive is the one reading that withholds a restart"
+    )

--- a/tests/unit/test_orchestrator_liveness_verdict.py
+++ b/tests/unit/test_orchestrator_liveness_verdict.py
@@ -1,0 +1,465 @@
+"""Regression tests for the orchestrator-liveness run-completion verdict.
+
+This verdict decides that a run is over and its goal was not met, which turns
+into a non-zero exit code on a run an operator may still be watching. Four ways
+it could be wrong are pinned here, one test each.
+
+The bias every test encodes: the verdict fires only on positive, corroborated,
+sustained evidence of death, and every ambiguous reading leaves the run alone.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+import bernstein.cli.run_bootstrap as rb
+from bernstein.core.orchestration.bootstrap import _watchdog_check_process
+
+# A pid high enough to be unused on any normal host. It is the value the
+# adversarial review fed to both subsystems to show they disagreed about it.
+DEAD_PID = 999999
+
+
+def _drive_wait(
+    *,
+    status: dict[str, Any],
+    full_counts: dict[str, Any] | None,
+    health: dict[str, Any] | None = None,
+    timeout_s: float = 600.0,
+    tick_s: float = 2.0,
+) -> tuple[dict[str, Any] | None, int]:
+    """Run the real wait against a scripted server. Returns (verdict, n_polls).
+
+    Only the server and the clock are faked. The liveness classification, the
+    pidfile read and the confirmation window are the real ones, so a test that
+    passes here is a statement about the shipped behaviour.
+    """
+    health_payload = {"agent_count": 0} if health is None else health
+    polls = {"n": 0}
+
+    def fake_get(path: str) -> Any:
+        if path == "/status":
+            polls["n"] += 1
+            return status
+        if path == "/health":
+            return health_payload
+        if path == "/tasks/counts":
+            return full_counts
+        return None
+
+    clock = {"t": time.time()}
+
+    def fake_time() -> float:
+        clock["t"] += tick_s
+        return clock["t"]
+
+    with (
+        patch.object(rb, "server_get", side_effect=fake_get),
+        patch.object(rb.time, "sleep", return_value=None),
+        patch.object(rb.time, "time", side_effect=fake_time),
+        patch.object(rb, "_signal_orchestrator_shutdown"),
+    ):
+        return rb._wait_for_run_completion(timeout_s=timeout_s), polls["n"]
+
+
+def _runtime(tmp_path: Path) -> Path:
+    runtime = tmp_path / ".sdd" / "runtime"
+    runtime.mkdir(parents=True, exist_ok=True)
+    return runtime
+
+
+# ---------------------------------------------------------------------------
+# Finding 1: the verdict was unreachable for two of the four statuses it
+# claims to cover, and the run silently passed instead.
+# ---------------------------------------------------------------------------
+
+
+def test_stuck_in_progress_task_is_visible_to_the_verdict(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A task stuck in ``in_progress``/``orphaned`` must reach the verdict.
+
+    ``GET /status`` has buckets for open/claimed/done/failed/refused only. Two
+    of the four statuses that mean "declared but never finished" --
+    ``in_progress`` and ``orphaned`` -- have no bucket there at all, so counting
+    them from that payload always yields zero however many tasks are stuck.
+
+    The consequence was worse than a missed verdict: with open == claimed == 0
+    the run also read as QUIESCENT, so a run whose only task was orphaned by a
+    dead orchestrator was reported finished and healthy, and exited 0.
+    """
+    (_runtime(tmp_path) / "spawner.pid").write_text(str(DEAD_PID))
+    monkeypatch.chdir(tmp_path)
+    # Backdate nothing: the pidfile belongs to this run, so it is trustworthy.
+
+    # What /status can say about one orphaned task: everything looks empty.
+    status = {"total": 1, "open": 0, "claimed": 0, "done": 0, "failed": 0, "refused": 0}
+    # What the full histogram says about the same instant.
+    full_counts = {"total": 1, "open": 0, "claimed": 0, "in_progress": 0, "orphaned": 1, "done": 0, "failed": 0}
+
+    verdict, _polls = _drive_wait(status=status, full_counts=full_counts)
+
+    assert verdict is not None, "a task orphaned by a dead orchestrator must produce a verdict, not exit 0"
+    # And the verdict must carry counts the health mapping can actually read.
+    from bernstein.core.quality.retrospective import run_healthy_from_status_counts
+
+    counts = verdict.get("task_counts", verdict)
+    assert run_healthy_from_status_counts(counts) is False
+
+
+def test_quiescence_does_not_fire_while_a_task_is_in_progress(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The other half of the same hole: quiescence must not swallow the case.
+
+    With a LIVE orchestrator and one task in ``in_progress``, open and claimed
+    are both zero. The old open/claimed-only test called that quiescent and
+    returned a healthy payload. It is not quiescent: a task is running.
+    """
+    (_runtime(tmp_path) / "spawner.pid").write_text(str(os.getpid()))  # alive
+    monkeypatch.chdir(tmp_path)
+
+    status = {"total": 1, "open": 0, "claimed": 0, "done": 0, "failed": 0, "refused": 0}
+    full_counts = {"total": 1, "open": 0, "claimed": 0, "in_progress": 1, "orphaned": 0, "done": 0, "failed": 0}
+
+    verdict, _polls = _drive_wait(status=status, full_counts=full_counts, timeout_s=60.0)
+
+    assert verdict is None, "a running task must not be reported as a quiescent, healthy run"
+
+
+# ---------------------------------------------------------------------------
+# Finding 2: the verdict fired on a single poll, with nothing to outwait the
+# recovery supervisor that restarts a dead orchestrator.
+# ---------------------------------------------------------------------------
+
+
+def test_verdict_requires_a_confirmation_window_not_one_poll(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """One dead-pid reading is not evidence the run is over.
+
+    ``bootstrap.run_watchdog`` restarts a dead orchestrator every
+    ``WATCHDOG_POLL_S``, so for at least that long a dead pid is a recoverable
+    state rather than a terminal one. The verdict must therefore outlast the
+    supervisor's window and be confirmed across several polls, never concluded
+    from the first observation.
+    """
+    (_runtime(tmp_path) / "spawner.pid").write_text(str(DEAD_PID))
+    monkeypatch.chdir(tmp_path)
+
+    status = {"total": 1, "open": 1, "claimed": 0, "done": 0, "failed": 0}
+    full_counts = {"total": 1, "open": 1, "claimed": 0, "in_progress": 0, "orphaned": 0, "done": 0, "failed": 0}
+
+    verdict, polls = _drive_wait(status=status, full_counts=full_counts, tick_s=2.0)
+
+    assert verdict is not None, "a sustained dead orchestrator must still reach a verdict"
+    assert polls > 1, f"verdict concluded after {polls} poll(s): a single observation is not evidence"
+    required = getattr(rb, "_ORCHESTRATOR_GONE_CONFIRMATIONS", 0)
+    window = getattr(rb, "_ORCHESTRATOR_GONE_CONFIRM_WINDOW_S", 0.0)
+    assert polls >= required >= 2, (
+        f"verdict concluded after {polls} poll(s); it must require at least {required} consecutive confirming polls"
+    )
+
+    from bernstein.core.orchestration.process_utils import WATCHDOG_POLL_S
+
+    assert window > WATCHDOG_POLL_S, (
+        "the confirmation window must outlast the recovery supervisor's poll period, "
+        "or the verdict can win a race against a restart that was already coming"
+    )
+    # 2s ticks: the window itself, not just the poll count, has to have elapsed.
+    assert polls * 2.0 >= window
+
+
+def test_a_restart_during_the_window_cancels_the_verdict(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """If the supervisor restarts the orchestrator mid-window, no verdict.
+
+    The restarted process appears under a new, live pid. That is exactly the
+    observation the window exists to catch, and it must reset the streak rather
+    than be averaged into it.
+    """
+    pidfile = _runtime(tmp_path) / "spawner.pid"
+    pidfile.write_text(str(DEAD_PID))
+    monkeypatch.chdir(tmp_path)
+
+    status = {"total": 1, "open": 1, "claimed": 0, "done": 0, "failed": 0}
+    full_counts = {"total": 1, "open": 1, "claimed": 0, "in_progress": 0, "orphaned": 0, "done": 0, "failed": 0}
+    polls = {"n": 0}
+
+    def fake_get(path: str) -> Any:
+        if path == "/status":
+            polls["n"] += 1
+            # Second poll: the recovery supervisor restarted it.
+            if polls["n"] == 2:
+                pidfile.write_text(str(os.getpid()))
+            return status
+        if path == "/health":
+            return {"agent_count": 0}
+        if path == "/tasks/counts":
+            return full_counts
+        return None
+
+    clock = {"t": time.time()}
+
+    def fake_time() -> float:
+        clock["t"] += 2.0
+        return clock["t"]
+
+    with (
+        patch.object(rb, "server_get", side_effect=fake_get),
+        patch.object(rb.time, "sleep", return_value=None),
+        patch.object(rb.time, "time", side_effect=fake_time),
+        patch.object(rb, "_signal_orchestrator_shutdown"),
+    ):
+        verdict = rb._wait_for_run_completion(timeout_s=120.0)
+
+    assert verdict is None, "a restarted orchestrator must cancel the verdict, not be reaped through it"
+
+
+# ---------------------------------------------------------------------------
+# Finding 3: the documented premise ("nothing will ever advance them", "no
+# pidfile means it exited and cleaned up") was not what the code did.
+# ---------------------------------------------------------------------------
+
+
+def test_documented_contract_matches_the_implemented_one() -> None:
+    """The docstrings must describe the evidence the code actually requires.
+
+    Two claims were false as written:
+
+    * "Nothing will ever advance them" -- ``run_watchdog`` restarts a dead
+      orchestrator, so a dead pid does not mean nothing will advance the tasks.
+    * "no pidfile ... means it exited and cleaned up" -- the orchestrator never
+      removes its own pidfile. Only an operator teardown does. So a missing
+      pidfile is not an exit signal it can emit, and must not be read as one.
+    """
+    wait_doc = rb._wait_for_run_completion.__doc__ or ""
+    liveness_doc = rb._orchestrator_liveness.__doc__ or ""
+
+    assert "Nothing will\n          ever advance them" not in wait_doc, (
+        "the docstring must not assert a premise the recovery supervisor contradicts"
+    )
+    assert "confirmation window" in wait_doc, "the docstring must document the confirmation requirement"
+    assert "exited and cleaned up" not in liveness_doc, (
+        "a missing pidfile is not a clean-exit signal the orchestrator emits"
+    )
+
+    from bernstein.core.orchestration.process_utils import LIVENESS_UNKNOWN, classify_pidfile_liveness
+
+    classifier_doc = classify_pidfile_liveness.__doc__ or ""
+    assert "never" in classifier_doc and "missing pidfile" in classifier_doc.lower(), (
+        "the classifier must document that a missing pidfile is never death"
+    )
+    # And the behaviour the docstrings now claim, asserted rather than described.
+    assert classify_pidfile_liveness(Path("does-not-exist.pid"))[0] == LIVENESS_UNKNOWN
+
+
+def test_missing_pidfile_is_never_read_as_death(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """No pidfile at all: ambiguous, so no verdict, whatever the counts say."""
+    _runtime(tmp_path)  # runtime dir exists, pidfile does not
+    monkeypatch.chdir(tmp_path)
+
+    status = {"total": 1, "open": 1, "claimed": 0, "done": 0, "failed": 0}
+    full_counts = {"total": 1, "open": 1, "claimed": 0, "in_progress": 0, "orphaned": 0, "done": 0, "failed": 0}
+
+    verdict, _polls = _drive_wait(status=status, full_counts=full_counts, timeout_s=120.0)
+    assert verdict is None
+
+
+def test_stale_pidfile_from_a_previous_run_is_not_this_runs_death(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A leftover pidfile predating this run must not condemn it.
+
+    Its pid describes some earlier process, and the OS may since have handed
+    that number to anything at all. Reading it as this run's death lets a file
+    nobody cleaned up fail a run that has not even started.
+    """
+    pidfile = _runtime(tmp_path) / "spawner.pid"
+    pidfile.write_text(str(DEAD_PID))
+    old = time.time() - 86400.0  # a day before any CLI in this test could have started
+    os.utime(pidfile, (old, old))
+    monkeypatch.chdir(tmp_path)
+
+    status = {"total": 1, "open": 1, "claimed": 0, "done": 0, "failed": 0}
+    full_counts = {"total": 1, "open": 1, "claimed": 0, "in_progress": 0, "orphaned": 0, "done": 0, "failed": 0}
+
+    verdict, _polls = _drive_wait(status=status, full_counts=full_counts, timeout_s=120.0)
+    assert verdict is None
+
+
+def test_a_blind_local_probe_is_not_enough_to_reap(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A CLI outside the orchestrator's pid namespace must not reap it.
+
+    The shipped image runs the orchestrator in a container, so the CLI's own
+    ``os.kill`` probe reports a perfectly healthy orchestrator as dead. The task
+    server shares the orchestrator's namespace and reports it running on
+    ``/health``. The two observers disagree, and a disagreement is not evidence
+    of death whichever way round it points.
+    """
+    (_runtime(tmp_path) / "spawner.pid").write_text(str(DEAD_PID))  # invisible from here
+    monkeypatch.chdir(tmp_path)
+
+    status = {"total": 1, "open": 1, "claimed": 0, "done": 0, "failed": 0}
+    full_counts = {"total": 1, "open": 1, "claimed": 0, "in_progress": 0, "orphaned": 0, "done": 0, "failed": 0}
+    health = {"agent_count": 0, "components": {"spawner": {"status": "ok", "pid": DEAD_PID}}}
+
+    verdict, _polls = _drive_wait(status=status, full_counts=full_counts, health=health, timeout_s=120.0)
+    assert verdict is None, "the server can see the orchestrator running; a blind local probe cannot reap it"
+
+    # Corroboration in the other direction does produce a verdict.
+    health_down = {"agent_count": 0, "components": {"spawner": {"status": "down"}}}
+    verdict2, _polls2 = _drive_wait(status=status, full_counts=full_counts, health=health_down, timeout_s=600.0)
+    assert verdict2 is not None
+
+
+def test_a_recycled_pid_does_not_vouch_for_a_stale_pidfile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An alive pid that is not our process must not read as our process.
+
+    A pid is a reused integer, not an identity. This test process is alive and
+    is emphatically not an orchestrator, so a pidfile naming it describes a
+    number the OS handed to somebody else. Reading that as "our orchestrator is
+    healthy" would let a stale pidfile vouch for a run that is not running.
+
+    It resolves to ``unknown``, not ``gone``: the pid is provably not ours,
+    which is not the same as proof that ours died.
+    """
+    from bernstein.core.orchestration.process_utils import (
+        LIVENESS_ALIVE,
+        LIVENESS_UNKNOWN,
+        ORCHESTRATOR_PROCESS_MARKER,
+        classify_pidfile_liveness,
+    )
+
+    pidfile = _runtime(tmp_path) / "spawner.pid"
+    pidfile.write_text(str(os.getpid()))
+    monkeypatch.chdir(tmp_path)
+
+    # Without an identity expectation, any live pid passes for ours.
+    assert classify_pidfile_liveness(pidfile)[0] == LIVENESS_ALIVE
+    # With one, this process is correctly rejected as not-an-orchestrator.
+    assert classify_pidfile_liveness(pidfile, expect_cmdline=ORCHESTRATOR_PROCESS_MARKER)[0] == LIVENESS_UNKNOWN
+    # And the CLI applies the expectation.
+    assert rb._orchestrator_liveness()[0] == LIVENESS_UNKNOWN
+
+
+def test_a_live_orchestrator_the_server_calls_down_is_not_reaped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The other disagreement: local sees our process running, server says down.
+
+    A REAL process whose command line identifies it as an orchestrator, against
+    a server component reporting ``down``. Neither observer wins a
+    disagreement, so nothing is reaped.
+    """
+    import subprocess
+    import sys
+
+    from bernstein.core.orchestration.process_utils import ORCHESTRATOR_PROCESS_MARKER
+
+    # A live stand-in whose command line carries the orchestrator marker, so
+    # the identity check recognises it the way it would the real subprocess.
+    proc = subprocess.Popen(
+        [sys.executable, "-c", f"import time; time.sleep(120)  # {ORCHESTRATOR_PROCESS_MARKER}"],
+    )
+    try:
+        (_runtime(tmp_path) / "spawner.pid").write_text(str(proc.pid))
+        monkeypatch.chdir(tmp_path)
+
+        status = {"total": 1, "open": 1, "claimed": 0, "done": 0, "failed": 0}
+        full_counts = {"total": 1, "open": 1, "claimed": 0, "in_progress": 0, "orphaned": 0, "done": 0, "failed": 0}
+        health = {"agent_count": 0, "components": {"spawner": {"status": "down"}}}
+
+        verdict, _polls = _drive_wait(status=status, full_counts=full_counts, health=health, timeout_s=120.0)
+        assert verdict is None
+    finally:
+        proc.terminate()
+        proc.wait(timeout=10)
+
+
+# ---------------------------------------------------------------------------
+# Finding 4: the pid the CLI classified as gone was still fed to the restart
+# path, so "gone" meant two different things in the two subsystems.
+# ---------------------------------------------------------------------------
+
+
+def test_supervisor_and_cli_share_one_definition_of_gone(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Both subsystems must classify the same pid through the same function.
+
+    Otherwise one can declare the run terminally over while the other is about
+    to restart the very process it called gone.
+    """
+    pidfile = _runtime(tmp_path) / "spawner.pid"
+    pidfile.write_text(str(DEAD_PID))
+    monkeypatch.chdir(tmp_path)
+
+    cli_view, cli_pid = rb._orchestrator_liveness()
+    assert isinstance(cli_view, str), (
+        f"the CLI must report a three-valued classification, not {cli_view!r}: a boolean "
+        "forces every ambiguous reading into 'running' or 'dead', and 'dead' is destructive"
+    )
+
+    from bernstein.core.orchestration.process_utils import LIVENESS_GONE, classify_pidfile_liveness
+
+    supervisor_view, supervisor_pid = classify_pidfile_liveness(pidfile)
+    assert cli_view == supervisor_view == LIVENESS_GONE
+    assert cli_pid == supervisor_pid == DEAD_PID
+
+
+def _restart_calls(**kwargs: Any) -> list[int]:
+    """Run one supervisor check and report whether it spawned anything."""
+    calls: list[int] = []
+
+    def restart_fn() -> int:
+        calls.append(1)
+        return 4242
+
+    _watchdog_check_process(
+        name="Orchestrator",
+        alive_since=None,
+        restarts=0,
+        give_up_logged=False,
+        max_restarts=5,
+        reset_after_s=120.0,
+        now=time.monotonic(),
+        restart_fn=restart_fn,
+        **kwargs,
+    )
+    return calls
+
+
+def test_supervisor_does_not_restart_without_a_pid_to_attribute() -> None:
+    """No pid means no evidence of death, so no spawn.
+
+    A supervisor cycle that finds no pidfile is looking either at a run that has
+    not written one yet or at one an operator teardown removed -- teardown
+    deletes every ``*.pid``. Spawning on that reading either starts a second
+    orchestrator against a live task store or resurrects a torn-down run. The
+    old code took "pid is None" straight to the restart branch.
+    """
+    assert _restart_calls(pid=None) == [], "a missing pidfile must not trigger a spawn"
+
+
+def test_supervisor_does_not_restart_on_an_unattributable_pid() -> None:
+    """The restart path needs a pid it owns, not merely a pid that is not alive.
+
+    This is the pid the CLI classifies as gone. Handing it to the supervisor
+    with no owning pidfile must not spawn, and the two subsystems must reach
+    that conclusion through the same classifier.
+    """
+    from bernstein.core.orchestration.process_utils import LIVENESS_GONE, LIVENESS_UNKNOWN
+
+    assert _restart_calls(pid=DEAD_PID, liveness=LIVENESS_UNKNOWN) == [], (
+        "an unattributable pid must not trigger a spawn"
+    )
+    # Crash recovery itself is intact: a pidfile this supervisor owns, naming a
+    # dead pid, is still restarted. That is the supervisor's whole job.
+    assert _restart_calls(pid=DEAD_PID, liveness=LIVENESS_GONE) == [1], (
+        "a genuinely crashed orchestrator must still be restarted"
+    )
+
+
+def test_supervisor_leaves_a_live_process_alone() -> None:
+    """Control: an alive classification never reaches the restart path."""
+    from bernstein.core.orchestration.process_utils import LIVENESS_ALIVE
+
+    assert _restart_calls(pid=os.getpid(), liveness=LIVENESS_ALIVE) == []

--- a/tests/unit/test_retrospective.py
+++ b/tests/unit/test_retrospective.py
@@ -470,9 +470,7 @@ class TestComputeRunHealth:
         assert counts.get(TERMINATOR_INCOMPLETE_DECLARED, 0) == 1
 
     def test_incomplete_declared_alongside_completed_still_unhealthy(self) -> None:
-        healthy, counts = compute_run_health(
-            [_make_task(id="T-ok", status="done")], n_incomplete_declared=1
-        )
+        healthy, counts = compute_run_health([_make_task(id="T-ok", status="done")], n_incomplete_declared=1)
         assert healthy is False
         assert counts[TERMINATOR_AGENT_COMPLETED] == 1
         assert counts[TERMINATOR_INCOMPLETE_DECLARED] == 1

--- a/tests/unit/test_retrospective.py
+++ b/tests/unit/test_retrospective.py
@@ -22,6 +22,7 @@ from bernstein.core.retrospective import (
     classify_task_terminator,
     compute_run_health,
     count_incomplete_declared,
+    count_never_terminal,
     generate_retrospective,
     run_health_exit_code,
     run_healthy_from_status_counts,
@@ -236,7 +237,37 @@ class TestGenerateRetrospective:
         content = (tmp_path / "runtime" / "retrospective.md").read_text()
         assert "- **Verdict:** UNHEALTHY" in content
         assert "- **Verdict:** HEALTHY" not in content
+
         assert "Declared task unfinished" in content
+
+    def test_stuck_task_is_not_double_counted_across_sections(self, tmp_path: Path) -> None:
+        """One reaped no-output task must be counted ONCE.
+
+        The collector sees it as unresolved (started, never completed) and the
+        status histogram sees it as open, so summing the two signals reported
+        "2/2 task terminations were NOT genuine" while the Overview said
+        "0 done / 1 total" -- the same task counted twice, and the two sections
+        contradicting each other.
+        """
+        collector = MetricsCollector(metrics_dir=tmp_path / "metrics")
+        # Task started via the collector but never completed -> unresolved.
+        collector.start_task("T-stuck", "manager", "sonnet", "qwen")
+        generate_retrospective(
+            done_tasks=[],
+            failed_tasks=[],
+            collector=collector,
+            runtime_dir=tmp_path / "runtime",
+            run_start_ts=time.time() - 30,
+            # ...and still open server-side -> incomplete-declared. Same task.
+            full_status_counts={"open": 1},
+        )
+        content = (tmp_path / "runtime" / "retrospective.md").read_text()
+
+        assert "- **Verdict:** UNHEALTHY" in content
+        # Overview and Run Health must agree on the denominator: 1 task, not 2.
+        assert "0 done / 1 total" in content
+        assert "1/1 task terminations were NOT genuine" in content
+        assert "2/2 task terminations were NOT genuine" not in content
 
     def test_duration_stats_from_metrics(self, tmp_path: Path) -> None:
         collector = _collector_with_tasks(
@@ -495,6 +526,24 @@ class TestCountIncompleteDeclared:
         assert count_incomplete_declared(histogram) == 0
 
 
+class TestCountNeverTerminal:
+    """The two never-terminated signals describe one population, so they are
+    combined by max() -- summing counted the same reaped task twice and made
+    the Run Health totals disagree with the Overview."""
+
+    def test_overlapping_signals_are_not_summed(self) -> None:
+        # The #3010 repro: ONE task, seen by both the collector (unresolved)
+        # and the status histogram (open) -> it must count once, not twice.
+        assert count_never_terminal(1, 1) == 1
+
+    def test_takes_the_larger_estimate(self) -> None:
+        assert count_never_terminal(3, 1) == 3
+        assert count_never_terminal(1, 4) == 4
+
+    def test_zero_when_neither_signal_fired(self) -> None:
+        assert count_never_terminal(0, 0) == 0
+
+
 class TestRunHealthExitCode:
     def test_healthy_exits_zero(self) -> None:
         assert run_health_exit_code(healthy=True) == EXIT_RUN_HEALTHY == 0
@@ -503,6 +552,13 @@ class TestRunHealthExitCode:
         code = run_health_exit_code(healthy=False)
         assert code == EXIT_RUN_UNHEALTHY
         assert code != 0
+
+    def test_unhealthy_code_does_not_collide_with_cli_error_codes(self) -> None:
+        """The outcome signal is only machine-readable if it cannot be confused
+        with a CLI error: click raises UsageError/NoSuchOption with exit code 2,
+        run_bootstrap raises SystemExit(2) on seed/config failures, and 1 is the
+        generic error code."""
+        assert EXIT_RUN_UNHEALTHY not in (0, 1, 2)
 
 
 class TestRunHealthyFromStatusCounts:

--- a/tests/unit/test_retrospective.py
+++ b/tests/unit/test_retrospective.py
@@ -9,16 +9,22 @@ from typing import TYPE_CHECKING
 from bernstein.core.metrics import MetricsCollector
 from bernstein.core.models import Complexity, Scope, Task, TaskStatus, TaskType
 from bernstein.core.retrospective import (
+    EXIT_RUN_HEALTHY,
+    EXIT_RUN_UNHEALTHY,
     TERMINATOR_AGENT_COMPLETED,
     TERMINATOR_AGENT_REPORTED_FAILURE,
     TERMINATOR_AUTO_COMPLETED_AFTER_DEATH,
+    TERMINATOR_INCOMPLETE_DECLARED,
     TERMINATOR_JANITOR_REJECTED,
     TERMINATOR_WATCHDOG_KILLED,
     _build_recommendations,
     _fmt_seconds,
     classify_task_terminator,
     compute_run_health,
+    count_incomplete_declared,
     generate_retrospective,
+    run_health_exit_code,
+    run_healthy_from_status_counts,
 )
 
 if TYPE_CHECKING:
@@ -212,6 +218,25 @@ class TestGenerateRetrospective:
         content = (tmp_path / "runtime" / "retrospective.md").read_text()
         assert "### By role" in content
         assert "qa" in content
+
+    def test_incomplete_declared_task_reports_unhealthy(self, tmp_path: Path) -> None:
+        """Issue #3010 end-to-end: an empty done/failed run whose only declared
+        task is still open/claimed at shutdown must render UNHEALTHY, not the
+        old '0/0 ... HEALTHY'. The full task-status histogram carries the
+        stuck task even when done_tasks/failed_tasks are empty."""
+        collector = MetricsCollector(metrics_dir=tmp_path / "metrics")
+        generate_retrospective(
+            done_tasks=[],
+            failed_tasks=[],
+            collector=collector,
+            runtime_dir=tmp_path / "runtime",
+            run_start_ts=time.time() - 30,
+            full_status_counts={"open": 1},
+        )
+        content = (tmp_path / "runtime" / "retrospective.md").read_text()
+        assert "- **Verdict:** UNHEALTHY" in content
+        assert "- **Verdict:** HEALTHY" not in content
+        assert "Declared task unfinished" in content
 
     def test_duration_stats_from_metrics(self, tmp_path: Path) -> None:
         collector = _collector_with_tasks(
@@ -433,6 +458,70 @@ class TestComputeRunHealth:
     def test_unresolved_in_metrics_forces_unhealthy(self) -> None:
         healthy, _counts = compute_run_health([_make_task(id="T-ok", status="done")], n_unresolved=1)
         assert healthy is False
+
+    def test_incomplete_declared_task_forces_unhealthy_on_empty_run(self) -> None:
+        """Issue #3010: a single-task run whose only agent produced zero model
+        output and was reaped left its one task open/claimed -- neither done nor
+        failed -- so done+failed was empty. A 0/0 run with a declared task that
+        never finished must NOT be HEALTHY, and the reap must show in the tally
+        rather than being silently dropped."""
+        healthy, counts = compute_run_health([], n_incomplete_declared=1)
+        assert healthy is False
+        assert counts.get(TERMINATOR_INCOMPLETE_DECLARED, 0) == 1
+
+    def test_incomplete_declared_alongside_completed_still_unhealthy(self) -> None:
+        healthy, counts = compute_run_health(
+            [_make_task(id="T-ok", status="done")], n_incomplete_declared=1
+        )
+        assert healthy is False
+        assert counts[TERMINATOR_AGENT_COMPLETED] == 1
+        assert counts[TERMINATOR_INCOMPLETE_DECLARED] == 1
+
+    def test_zero_incomplete_declared_preserves_empty_counts(self) -> None:
+        """The incomplete-declared key must not leak into the empty-run tally."""
+        healthy, counts = compute_run_health([], n_incomplete_declared=0)
+        assert healthy is True
+        assert counts == {}
+
+
+class TestCountIncompleteDeclared:
+    def test_none_histogram_is_zero(self) -> None:
+        assert count_incomplete_declared(None) == 0
+
+    def test_counts_open_claimed_in_progress_orphaned(self) -> None:
+        histogram = {"open": 1, "claimed": 2, "in_progress": 1, "orphaned": 1, "done": 3, "failed": 1}
+        assert count_incomplete_declared(histogram) == 5
+
+    def test_excludes_terminal_and_parking_states(self) -> None:
+        histogram = {"done": 2, "failed": 1, "refused": 1, "planned": 1, "suspended": 1, "pending_approval": 1}
+        assert count_incomplete_declared(histogram) == 0
+
+
+class TestRunHealthExitCode:
+    def test_healthy_exits_zero(self) -> None:
+        assert run_health_exit_code(healthy=True) == EXIT_RUN_HEALTHY == 0
+
+    def test_unhealthy_exits_distinct_nonzero(self) -> None:
+        code = run_health_exit_code(healthy=False)
+        assert code == EXIT_RUN_UNHEALTHY
+        assert code != 0
+
+
+class TestRunHealthyFromStatusCounts:
+    def test_none_or_empty_is_healthy(self) -> None:
+        assert run_healthy_from_status_counts(None) is True
+        assert run_healthy_from_status_counts({}) is True
+
+    def test_all_done_is_healthy(self) -> None:
+        assert run_healthy_from_status_counts({"total": 3, "done": 3}) is True
+
+    def test_stuck_declared_task_is_unhealthy(self) -> None:
+        # Issue #3010 repro: total 1, done 0, failed 0, but the one task is
+        # still open -> the run did not meet its goal.
+        assert run_healthy_from_status_counts({"total": 1, "open": 1}) is False
+
+    def test_failed_task_is_unhealthy(self) -> None:
+        assert run_healthy_from_status_counts({"total": 1, "failed": 1}) is False
 
 
 class TestRunHealthInRecommendations:

--- a/tests/unit/test_run_cmd_track_b.py
+++ b/tests/unit/test_run_cmd_track_b.py
@@ -17,6 +17,11 @@ from bernstein.cli.run_cmd import (
     _finalize_run_output,
     _wait_for_run_completion,
 )
+from bernstein.core.orchestration.process_utils import (
+    LIVENESS_ALIVE,
+    LIVENESS_GONE,
+    LIVENESS_UNKNOWN,
+)
 
 
 def test_estimate_run_preview_uses_plan_task_count(tmp_path: Path) -> None:
@@ -66,6 +71,8 @@ def test_wait_for_run_completion_returns_quiescent_status() -> None:
     def _fake_server_get(path: str):  # type: ignore[no-untyped-def]
         if path == "/status":
             return next(status_calls)
+        if path == "/tasks/counts":
+            return None  # server without the full histogram: /status is the fallback
         return next(health_calls)
 
     def _fake_time() -> float:
@@ -125,7 +132,7 @@ def test_wait_for_run_completion_timeout_returns_no_verdict() -> None:
         patch("bernstein.cli.run_bootstrap.server_get", return_value={"total": 2, "open": 1, "claimed": 1}),
         patch("bernstein.cli.run_bootstrap.time.sleep", return_value=None),
         patch("bernstein.cli.run_bootstrap.time.time", side_effect=_fake_time),
-        patch("bernstein.cli.run_bootstrap._orchestrator_liveness", return_value=(True, True)),
+        patch("bernstein.cli.run_bootstrap._orchestrator_liveness", return_value=(LIVENESS_ALIVE, 4242)),
         patch("bernstein.cli.run_bootstrap._signal_orchestrator_shutdown"),
     ):
         result = _wait_for_run_completion(timeout_s=5.0)
@@ -145,7 +152,7 @@ def test_wait_for_run_completion_unreachable_server_returns_no_verdict() -> None
         patch("bernstein.cli.run_bootstrap.server_get", return_value=None),
         patch("bernstein.cli.run_bootstrap.time.sleep", return_value=None),
         patch("bernstein.cli.run_bootstrap.time.time", side_effect=_fake_time),
-        patch("bernstein.cli.run_bootstrap._orchestrator_liveness", return_value=(True, True)),
+        patch("bernstein.cli.run_bootstrap._orchestrator_liveness", return_value=(LIVENESS_ALIVE, 4242)),
         patch("bernstein.cli.run_bootstrap._signal_orchestrator_shutdown"),
     ):
         result = _wait_for_run_completion(timeout_s=5.0)
@@ -155,28 +162,46 @@ def test_wait_for_run_completion_unreachable_server_returns_no_verdict() -> None
 
 # ---------------------------------------------------------------------------
 # Issue #3010: orchestrator liveness -- not the task counts -- separates
-# "still starting up" from "ended with work unfinished". Both show open > 0.
+# "still starting up" from "ended with work unfinished". Both show work
+# outstanding.
+#
+# ``gone`` is never concluded from one reading: a dead orchestrator is a state
+# the recovery supervisor restarts out of, so the verdict has to outlast it.
+# The scripted sequences below therefore run for enough polls to either clear
+# or fail to clear that confirmation window.
 # ---------------------------------------------------------------------------
 
+#: Ample for the confirmation window at the 5s-per-poll fake clock below.
+_WAIT_TIMEOUT_S = 300.0
 
-def _wait_with(status, *, liveness: list[tuple[bool, bool]], timeout_s: float = 5.0):  # type: ignore[no-untyped-def]
-    """Drive _wait_for_run_completion with a scripted (pidfile_present, alive) sequence."""
+
+def _wait_with(status, *, liveness: list[tuple[str, int | None]], timeout_s: float = _WAIT_TIMEOUT_S):  # type: ignore[no-untyped-def]
+    """Drive _wait_for_run_completion with a scripted (liveness, pid) sequence.
+
+    The last entry repeats once the script runs out, so a one-entry script
+    means "this state, held indefinitely".
+    """
     clock = {"now": 0.0}
 
     def _fake_time() -> float:
-        clock["now"] += 1.0
+        clock["now"] += 5.0
         return clock["now"]
 
     it = iter(liveness)
 
-    def _fake_liveness() -> tuple[bool, bool]:
+    def _fake_liveness(*_args, **_kwargs) -> tuple[str, int | None]:  # type: ignore[no-untyped-def]
         try:
             return next(it)
         except StopIteration:
             return liveness[-1]
 
+    def _fake_get(path: str):  # type: ignore[no-untyped-def]
+        # The full histogram mirrors /status here: these cases are all about
+        # liveness, not about statuses /status cannot express.
+        return status
+
     with (
-        patch("bernstein.cli.run_bootstrap.server_get", side_effect=lambda p: status),
+        patch("bernstein.cli.run_bootstrap.server_get", side_effect=_fake_get),
         patch("bernstein.cli.run_bootstrap.time.sleep", return_value=None),
         patch("bernstein.cli.run_bootstrap.time.time", side_effect=_fake_time),
         patch("bernstein.cli.run_bootstrap._orchestrator_liveness", side_effect=_fake_liveness),
@@ -193,7 +218,7 @@ def test_startup_window_open_tasks_with_live_orchestrator_is_not_a_verdict() -> 
     """
     result = _wait_with(
         {"total": 1, "open": 1, "claimed": 0, "agent_count": 0},
-        liveness=[(True, True)],
+        liveness=[(LIVENESS_ALIVE, 4242)],
     )
     assert result is None
 
@@ -201,12 +226,12 @@ def test_startup_window_open_tasks_with_live_orchestrator_is_not_a_verdict() -> 
 def test_startup_window_before_pidfile_is_written_is_not_a_verdict() -> None:
     """State 1b: tasks open and NO pidfile yet -> still the startup window.
 
-    "No pidfile" is ambiguous (not started yet vs exited and cleaned up), so on
-    its own it must never be read as "gone".
+    "No pidfile" is ambiguous: not started yet, or an operator teardown removed
+    it. Neither is death, so it must never be read as "gone".
     """
     result = _wait_with(
         {"total": 1, "open": 1, "claimed": 0, "agent_count": 0},
-        liveness=[(False, False)],
+        liveness=[(LIVENESS_UNKNOWN, None)],
     )
     assert result is None
 
@@ -214,37 +239,78 @@ def test_startup_window_before_pidfile_is_written_is_not_a_verdict() -> None:
 def test_orchestrator_gone_with_unfinished_tasks_is_a_verdict() -> None:
     """State 2: tasks non-terminal + orchestrator GONE (the #3010 shape).
 
-    The orchestrator ran, then exited leaving the task `open`. Nothing will
-    advance it, so this is terminal -- and it must be reported rather than
-    waiting out the deadline and exiting 0.
+    The orchestrator ran, then exited leaving the task `open`, and stayed gone
+    for longer than any restart would have taken. It must be reported rather
+    than waiting out the deadline and exiting 0.
     """
     status = {"total": 1, "open": 1, "claimed": 0, "done": 0, "failed": 0, "agent_count": 0}
-    result = _wait_with(status, liveness=[(True, True), (True, False)])
+    result = _wait_with(status, liveness=[(LIVENESS_ALIVE, 4242), (LIVENESS_GONE, 4242)])
     assert result == status
 
 
 def test_stale_pidfile_with_dead_pid_is_a_verdict_without_seeing_it_alive() -> None:
     """State 2b: a crashed orchestrator that was never observed alive.
 
-    A pidfile that is PRESENT but points at a dead pid is unambiguous -- it ran
-    and died -- so the verdict must not require having watched it alive first.
+    A pidfile of this run naming a dead pid is positive evidence, so the
+    verdict must not require having watched the process alive first -- it only
+    requires the evidence to hold across the confirmation window.
     """
     status = {"total": 1, "open": 1, "claimed": 0, "done": 0, "failed": 0, "agent_count": 0}
-    result = _wait_with(status, liveness=[(True, False)])
+    result = _wait_with(status, liveness=[(LIVENESS_GONE, 4242)])
     assert result == status
 
 
-def test_watched_alive_then_pidfile_removed_is_a_verdict() -> None:
-    """State 2c: observed alive, then the pidfile disappeared on clean exit."""
+def test_transient_gone_reading_alone_is_not_a_verdict() -> None:
+    """State 2c: one gone reading, then the supervisor's restart shows up.
+
+    The restarted orchestrator appears alive under a new pid, which is exactly
+    what the confirmation window exists to catch. No verdict.
+    """
     status = {"total": 1, "open": 1, "claimed": 0, "done": 0, "failed": 0, "agent_count": 0}
-    result = _wait_with(status, liveness=[(True, True), (False, False)])
-    assert result == status
+    result = _wait_with(
+        status,
+        liveness=[(LIVENESS_GONE, 4242), (LIVENESS_ALIVE, 5150)],
+        timeout_s=120.0,
+    )
+    assert result is None
+
+
+def test_pid_change_mid_window_resets_the_confirmation_streak() -> None:
+    """A different pid means something restarted it: the streak starts over.
+
+    Two gone readings under one pid followed by two under another must not add
+    up to a confirmed verdict, however many polls have gone by.
+    """
+    status = {"total": 1, "open": 1, "claimed": 0, "done": 0, "failed": 0, "agent_count": 0}
+    result = _wait_with(
+        status,
+        liveness=[
+            (LIVENESS_GONE, 4242),
+            (LIVENESS_GONE, 4242),
+            (LIVENESS_GONE, 5150),
+            (LIVENESS_ALIVE, 5150),
+        ],
+        timeout_s=25.0,
+    )
+    assert result is None
+
+
+def test_unknown_liveness_never_produces_a_verdict() -> None:
+    """An unresolvable reading, held forever, is still not a verdict.
+
+    This covers every ambiguous case at once: no pidfile, an unreadable one, a
+    pidfile predating this run, and the two observers disagreeing. The wait
+    times out and the run is left alone.
+    """
+    status = {"total": 1, "open": 1, "claimed": 0, "done": 0, "failed": 0, "agent_count": 0}
+    result = _wait_with(status, liveness=[(LIVENESS_UNKNOWN, 4242)])
+    assert result is None
 
 
 def test_quiescent_run_is_a_verdict_regardless_of_orchestrator_state() -> None:
     """State 3: quiescent + all done -> verdict (healthy), as before."""
     status = {"total": 2, "open": 0, "claimed": 0, "done": 2, "failed": 0, "agent_count": 0}
-    result = _wait_with(status, liveness=[(False, False)])
+    result = _wait_with(status, liveness=[(LIVENESS_UNKNOWN, None)])
     assert result == status
 
 
@@ -252,7 +318,7 @@ def test_live_agents_block_the_orchestrator_gone_verdict() -> None:
     """Belt-and-braces: if agents are still reported live, work may yet land."""
     result = _wait_with(
         {"total": 1, "open": 1, "claimed": 0, "agent_count": 2},
-        liveness=[(True, False)],
+        liveness=[(LIVENESS_GONE, 4242)],
     )
     assert result is None
 

--- a/tests/unit/test_run_cmd_track_b.py
+++ b/tests/unit/test_run_cmd_track_b.py
@@ -108,7 +108,7 @@ def test_wait_for_run_completion_timeout_does_not_signal_shutdown() -> None:
 
 
 def test_wait_for_run_completion_timeout_returns_no_verdict() -> None:
-    """A wait that times out with the run still in flight returns None.
+    """A wait that times out while the ORCHESTRATOR IS STILL ALIVE returns None.
 
     Returning the last observed payload instead would hand the caller a
     mid-flight snapshot (open/claimed > 0 -- precisely why quiescence was never
@@ -125,6 +125,7 @@ def test_wait_for_run_completion_timeout_returns_no_verdict() -> None:
         patch("bernstein.cli.run_bootstrap.server_get", return_value={"total": 2, "open": 1, "claimed": 1}),
         patch("bernstein.cli.run_bootstrap.time.sleep", return_value=None),
         patch("bernstein.cli.run_bootstrap.time.time", side_effect=_fake_time),
+        patch("bernstein.cli.run_bootstrap._orchestrator_liveness", return_value=(True, True)),
         patch("bernstein.cli.run_bootstrap._signal_orchestrator_shutdown"),
     ):
         result = _wait_for_run_completion(timeout_s=5.0)
@@ -144,10 +145,115 @@ def test_wait_for_run_completion_unreachable_server_returns_no_verdict() -> None
         patch("bernstein.cli.run_bootstrap.server_get", return_value=None),
         patch("bernstein.cli.run_bootstrap.time.sleep", return_value=None),
         patch("bernstein.cli.run_bootstrap.time.time", side_effect=_fake_time),
+        patch("bernstein.cli.run_bootstrap._orchestrator_liveness", return_value=(True, True)),
         patch("bernstein.cli.run_bootstrap._signal_orchestrator_shutdown"),
     ):
         result = _wait_for_run_completion(timeout_s=5.0)
 
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #3010: orchestrator liveness -- not the task counts -- separates
+# "still starting up" from "ended with work unfinished". Both show open > 0.
+# ---------------------------------------------------------------------------
+
+
+def _wait_with(status, *, liveness: list[tuple[bool, bool]], timeout_s: float = 5.0):  # type: ignore[no-untyped-def]
+    """Drive _wait_for_run_completion with a scripted (pidfile_present, alive) sequence."""
+    clock = {"now": 0.0}
+
+    def _fake_time() -> float:
+        clock["now"] += 1.0
+        return clock["now"]
+
+    it = iter(liveness)
+
+    def _fake_liveness() -> tuple[bool, bool]:
+        try:
+            return next(it)
+        except StopIteration:
+            return liveness[-1]
+
+    with (
+        patch("bernstein.cli.run_bootstrap.server_get", side_effect=lambda p: status),
+        patch("bernstein.cli.run_bootstrap.time.sleep", return_value=None),
+        patch("bernstein.cli.run_bootstrap.time.time", side_effect=_fake_time),
+        patch("bernstein.cli.run_bootstrap._orchestrator_liveness", side_effect=_fake_liveness),
+        patch("bernstein.cli.run_bootstrap._signal_orchestrator_shutdown"),
+    ):
+        return _wait_for_run_completion(timeout_s=timeout_s)
+
+
+def test_startup_window_open_tasks_with_live_orchestrator_is_not_a_verdict() -> None:
+    """State 1: tasks open + orchestrator ALIVE (startup) -> no verdict.
+
+    Open tasks before the first spawn must never be mistaken for a finished
+    run -- this is exactly why the counts alone cannot be the discriminator.
+    """
+    result = _wait_with(
+        {"total": 1, "open": 1, "claimed": 0, "agent_count": 0},
+        liveness=[(True, True)],
+    )
+    assert result is None
+
+
+def test_startup_window_before_pidfile_is_written_is_not_a_verdict() -> None:
+    """State 1b: tasks open and NO pidfile yet -> still the startup window.
+
+    "No pidfile" is ambiguous (not started yet vs exited and cleaned up), so on
+    its own it must never be read as "gone".
+    """
+    result = _wait_with(
+        {"total": 1, "open": 1, "claimed": 0, "agent_count": 0},
+        liveness=[(False, False)],
+    )
+    assert result is None
+
+
+def test_orchestrator_gone_with_unfinished_tasks_is_a_verdict() -> None:
+    """State 2: tasks non-terminal + orchestrator GONE (the #3010 shape).
+
+    The orchestrator ran, then exited leaving the task `open`. Nothing will
+    advance it, so this is terminal -- and it must be reported rather than
+    waiting out the deadline and exiting 0.
+    """
+    status = {"total": 1, "open": 1, "claimed": 0, "done": 0, "failed": 0, "agent_count": 0}
+    result = _wait_with(status, liveness=[(True, True), (True, False)])
+    assert result == status
+
+
+def test_stale_pidfile_with_dead_pid_is_a_verdict_without_seeing_it_alive() -> None:
+    """State 2b: a crashed orchestrator that was never observed alive.
+
+    A pidfile that is PRESENT but points at a dead pid is unambiguous -- it ran
+    and died -- so the verdict must not require having watched it alive first.
+    """
+    status = {"total": 1, "open": 1, "claimed": 0, "done": 0, "failed": 0, "agent_count": 0}
+    result = _wait_with(status, liveness=[(True, False)])
+    assert result == status
+
+
+def test_watched_alive_then_pidfile_removed_is_a_verdict() -> None:
+    """State 2c: observed alive, then the pidfile disappeared on clean exit."""
+    status = {"total": 1, "open": 1, "claimed": 0, "done": 0, "failed": 0, "agent_count": 0}
+    result = _wait_with(status, liveness=[(True, True), (False, False)])
+    assert result == status
+
+
+def test_quiescent_run_is_a_verdict_regardless_of_orchestrator_state() -> None:
+    """State 3: quiescent + all done -> verdict (healthy), as before."""
+    status = {"total": 2, "open": 0, "claimed": 0, "done": 2, "failed": 0, "agent_count": 0}
+    result = _wait_with(status, liveness=[(False, False)])
+    assert result == status
+
+
+def test_live_agents_block_the_orchestrator_gone_verdict() -> None:
+    """Belt-and-braces: if agents are still reported live, work may yet land."""
+    result = _wait_with(
+        {"total": 1, "open": 1, "claimed": 0, "agent_count": 2},
+        liveness=[(True, False)],
+    )
     assert result is None
 
 

--- a/tests/unit/test_run_cmd_track_b.py
+++ b/tests/unit/test_run_cmd_track_b.py
@@ -4,7 +4,9 @@
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -180,12 +182,14 @@ def _wait_with(status, *, liveness: list[tuple[str, int | None]], timeout_s: flo
 
     The last entry repeats once the script runs out, so a one-entry script
     means "this state, held indefinitely".
-    """
-    clock = {"now": 0.0}
 
-    def _fake_time() -> float:
-        clock["now"] += 5.0
-        return clock["now"]
+    The clock advances monotonic and wall time together, as a real
+    ``time.sleep`` does. The confirmation window is measured on monotonic, so a
+    harness that fakes only ``time.time`` leaves it running on the real clock
+    and no scripted sequence can ever satisfy it.
+    """
+    elapsed = {"s": 0.0}
+    base_wall, base_mono = time.time(), time.monotonic()
 
     it = iter(liveness)
 
@@ -200,10 +204,15 @@ def _wait_with(status, *, liveness: list[tuple[str, int | None]], timeout_s: flo
         # liveness, not about statuses /status cannot express.
         return status
 
+    clock = SimpleNamespace(
+        time=lambda: base_wall + elapsed["s"],
+        monotonic=lambda: base_mono + elapsed["s"],
+        sleep=lambda _s: elapsed.__setitem__("s", elapsed["s"] + 5.0),
+    )
+
     with (
         patch("bernstein.cli.run_bootstrap.server_get", side_effect=_fake_get),
-        patch("bernstein.cli.run_bootstrap.time.sleep", return_value=None),
-        patch("bernstein.cli.run_bootstrap.time.time", side_effect=_fake_time),
+        patch("bernstein.cli.run_bootstrap.time", clock),
         patch("bernstein.cli.run_bootstrap._orchestrator_liveness", side_effect=_fake_liveness),
         patch("bernstein.cli.run_bootstrap._signal_orchestrator_shutdown"),
     ):

--- a/tests/unit/test_run_cmd_track_b.py
+++ b/tests/unit/test_run_cmd_track_b.py
@@ -107,6 +107,50 @@ def test_wait_for_run_completion_timeout_does_not_signal_shutdown() -> None:
     shutdown_signal.assert_not_called()
 
 
+def test_wait_for_run_completion_timeout_returns_no_verdict() -> None:
+    """A wait that times out with the run still in flight returns None.
+
+    Returning the last observed payload instead would hand the caller a
+    mid-flight snapshot (open/claimed > 0 -- precisely why quiescence was never
+    detected), and the run-outcome exit mapping would misreport a healthy
+    long-running run as unhealthy. None is the explicit "no verdict" signal.
+    """
+    clock = {"now": 0.0}
+
+    def _fake_time() -> float:
+        clock["now"] += 10.0
+        return clock["now"]
+
+    with (
+        patch("bernstein.cli.run_bootstrap.server_get", return_value={"total": 2, "open": 1, "claimed": 1}),
+        patch("bernstein.cli.run_bootstrap.time.sleep", return_value=None),
+        patch("bernstein.cli.run_bootstrap.time.time", side_effect=_fake_time),
+        patch("bernstein.cli.run_bootstrap._signal_orchestrator_shutdown"),
+    ):
+        result = _wait_for_run_completion(timeout_s=5.0)
+
+    assert result is None
+
+
+def test_wait_for_run_completion_unreachable_server_returns_no_verdict() -> None:
+    """An unreachable server for the whole wait is also "no verdict", not a failure."""
+    clock = {"now": 0.0}
+
+    def _fake_time() -> float:
+        clock["now"] += 10.0
+        return clock["now"]
+
+    with (
+        patch("bernstein.cli.run_bootstrap.server_get", return_value=None),
+        patch("bernstein.cli.run_bootstrap.time.sleep", return_value=None),
+        patch("bernstein.cli.run_bootstrap.time.time", side_effect=_fake_time),
+        patch("bernstein.cli.run_bootstrap._signal_orchestrator_shutdown"),
+    ):
+        result = _wait_for_run_completion(timeout_s=5.0)
+
+    assert result is None
+
+
 def test_signal_orchestrator_shutdown_posts_to_shutdown_endpoint() -> None:
     """Happy path: orchestrator still up, POST /shutdown is sent and acknowledged."""
     fake_response = type(

--- a/tests/unit/test_run_outcome_reaches_every_branch.py
+++ b/tests/unit/test_run_outcome_reaches_every_branch.py
@@ -1,0 +1,274 @@
+"""The run-outcome signal must not depend on which renderer the operator got.
+
+Two gaps kept a run that did not meet its goal reporting success (issue #3010):
+
+* the exit-code mapping existed only on the ``--quiet`` branch of
+  ``_finalize_run_output``, and nothing turns ``--quiet`` on automatically;
+* the interim retrospective was written without the task histogram, so a run
+  with no terminal tasks at all rendered ``0/0`` and HEALTHY.
+
+Both are pinned here. What this file does NOT cover is the third gap: in the
+reported shape the orchestrator never exits, because its self-stop is nested
+under "some task reached a terminal state". That needs a change to the main
+tick loop and is tracked separately.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+QUIESCENT_UNHEALTHY = {"total": 1, "open": 0, "claimed": 0, "done": 0, "failed": 1}
+QUIESCENT_HEALTHY = {"total": 1, "open": 0, "claimed": 0, "done": 1, "failed": 0}
+FULL_UNHEALTHY = {"total": 1, "open": 0, "claimed": 0, "in_progress": 0, "orphaned": 0, "done": 0, "failed": 1}
+FULL_HEALTHY = {"total": 1, "open": 0, "claimed": 0, "in_progress": 0, "orphaned": 0, "done": 1, "failed": 0}
+HEALTH = {"agent_count": 0, "components": {"spawner": {"status": "down"}}}
+
+
+def _server(status: dict[str, Any], full_counts: dict[str, Any]) -> Any:
+    def fake_get(path: str) -> Any:
+        if path == "/status":
+            return status
+        if path == "/health":
+            return HEALTH
+        if path == "/tasks/counts":
+            return full_counts
+        return None
+
+    return fake_get
+
+
+def _run_branch(
+    *,
+    supports_textual: bool,
+    is_tty: bool,
+    status: dict[str, Any] = QUIESCENT_UNHEALTHY,
+    full_counts: dict[str, Any] = FULL_UNHEALTHY,
+) -> int:
+    """Drive one _finalize_run_output branch. Returns the process exit code."""
+    import bernstein.cli.run_bootstrap as rb
+    from bernstein.cli.run_preflight import _finalize_run_output
+
+    caps = MagicMock(supports_textual=supports_textual, is_tty=is_tty)
+    # `_restart_on_exit` must be explicitly falsy: a bare MagicMock attribute is
+    # truthy, and the dashboard branch reads it to decide whether to re-exec the
+    # whole CLI over this process.
+    dashboard_app = MagicMock()
+    dashboard_app.return_value = MagicMock(_restart_on_exit=False)
+    with (
+        patch.object(rb, "server_get", side_effect=_server(status, full_counts)),
+        patch("bernstein.cli.terminal_caps.detect_capabilities", return_value=caps),
+        patch("bernstein.cli.run_preflight._show_run_summary"),
+        patch("bernstein.cli.run_preflight._try_fallback_display"),
+        patch("bernstein.cli.run_preflight._drain_completed_backlog_files"),
+        patch("bernstein.cli.run_bootstrap._await_first_spawn_outcome", return_value=("spawned", None)),
+        patch("bernstein.cli.run_bootstrap.exec_restart", side_effect=AssertionError("must not re-exec")),
+        patch("bernstein.cli.dashboard.BernsteinApp", dashboard_app),
+    ):
+        try:
+            _finalize_run_output(quiet=False)
+        except SystemExit as exc:
+            return int(exc.code or 0)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Gap A: the exit code existed only on --quiet.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("branch", "supports_textual", "is_tty"),
+    [
+        ("textual dashboard", True, True),
+        ("rich fallback", False, True),
+        ("non-interactive", False, False),
+    ],
+)
+def test_every_branch_reports_a_finished_unhealthy_run(branch: str, supports_textual: bool, is_tty: bool) -> None:
+    """A finished run whose only task failed must not exit 0 on any branch.
+
+    ``--quiet`` is not enabled automatically and no documented workflow passes
+    it, so binding the outcome signal to that flag left every ordinary
+    invocation reporting success. The reported reproduction of issue #3010 went
+    down the non-interactive branch, which prints "Run continues in the
+    background" and, before this, always exited 0.
+    """
+    from bernstein.core.retrospective import EXIT_RUN_UNHEALTHY
+
+    assert _run_branch(supports_textual=supports_textual, is_tty=is_tty) == EXIT_RUN_UNHEALTHY, (
+        f"the {branch} branch must map a finished, unhealthy run onto the outcome exit code"
+    )
+
+
+@pytest.mark.parametrize(
+    ("branch", "supports_textual", "is_tty"),
+    [
+        ("textual dashboard", True, True),
+        ("rich fallback", False, True),
+        ("non-interactive", False, False),
+    ],
+)
+def test_every_branch_still_exits_zero_on_a_healthy_run(branch: str, supports_textual: bool, is_tty: bool) -> None:
+    """Control: a run that met its goal still exits 0 everywhere."""
+    assert (
+        _run_branch(
+            supports_textual=supports_textual,
+            is_tty=is_tty,
+            status=QUIESCENT_HEALTHY,
+            full_counts=FULL_HEALTHY,
+        )
+        == 0
+    )
+
+
+def test_a_still_running_run_is_not_reported_as_failed_on_any_branch() -> None:
+    """Control: the branches that do not wait must not guess.
+
+    They check once and report only an already-quiescent run. A run still in
+    flight, or a server they cannot reach, is not a verdict, and the
+    non-interactive branch in particular detaches by design.
+    """
+    in_flight = {"total": 1, "open": 1, "claimed": 0, "done": 0, "failed": 0}
+    full_in_flight = {"total": 1, "open": 1, "claimed": 0, "in_progress": 0, "orphaned": 0, "done": 0, "failed": 0}
+    for supports_textual, is_tty in ((True, True), (False, True), (False, False)):
+        assert (
+            _run_branch(
+                supports_textual=supports_textual,
+                is_tty=is_tty,
+                status=in_flight,
+                full_counts=full_in_flight,
+            )
+            == 0
+        )
+
+    import bernstein.cli.run_bootstrap as rb
+
+    with patch.object(rb, "server_get", return_value=None):
+        assert rb._poll_quiescent_status() is None
+
+
+def test_single_poll_path_never_produces_the_orchestrator_gone_verdict(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The non-waiting branches report quiescence only, never absence.
+
+    "The orchestrator is gone" is an inference from a process not being there,
+    and it is only trustworthy after several observations spanning the recovery
+    supervisor's window. A single poll cannot supply that, so this path must not
+    reach for it even though the pidfile evidence is right there.
+    """
+    import bernstein.cli.run_bootstrap as rb
+
+    runtime = tmp_path / ".sdd" / "runtime"
+    runtime.mkdir(parents=True)
+    (runtime / "spawner.pid").write_text("999999")  # dead: the gone shape
+    monkeypatch.chdir(tmp_path)
+
+    stuck = {"total": 1, "open": 1, "claimed": 0, "done": 0, "failed": 0}
+    full_stuck = {"total": 1, "open": 1, "claimed": 0, "in_progress": 0, "orphaned": 0, "done": 0, "failed": 0}
+    with patch.object(rb, "server_get", side_effect=_server(stuck, full_stuck)):
+        assert rb._poll_quiescent_status() is None
+
+
+def test_single_poll_path_respects_the_in_progress_veto(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """One definition of quiescence, shared with the waiting path.
+
+    ``/status`` has no bucket for ``in_progress`` or ``orphaned``, so on its
+    numbers alone a run with a task in either reads as finished. The full
+    histogram vetoes that here exactly as it does in the wait.
+    """
+    import bernstein.cli.run_bootstrap as rb
+
+    monkeypatch.chdir(tmp_path)
+    looks_empty = {"total": 1, "open": 0, "claimed": 0, "done": 0, "failed": 0}
+    really_running = {"total": 1, "open": 0, "claimed": 0, "in_progress": 1, "orphaned": 0, "done": 0, "failed": 0}
+    with patch.object(rb, "server_get", side_effect=_server(looks_empty, really_running)):
+        assert rb._poll_quiescent_status() is None
+
+    all_done = {"total": 1, "open": 0, "claimed": 0, "in_progress": 0, "orphaned": 0, "done": 1, "failed": 0}
+    with patch.object(rb, "server_get", side_effect=_server(looks_empty, all_done)):
+        assert rb._poll_quiescent_status() is not None
+
+
+# ---------------------------------------------------------------------------
+# Gap C: the interim retrospective was written without the histogram.
+# ---------------------------------------------------------------------------
+
+
+def test_interim_retrospective_receives_the_task_histogram(tmp_path: Path) -> None:
+    """A run with no terminal tasks must not render as 0/0 HEALTHY.
+
+    ``generate_retrospective`` derives "declared but never finished" from the
+    full histogram. The mid-run call sites passed nothing, so
+    ``count_incomplete_declared(None)`` was 0 and every such run was HEALTHY.
+    That artefact matters more than "interim" suggests: when quiescence holds
+    with zero terminal tasks the tick loop never exits, so no final
+    retrospective is ever written and this is the run's only verdict.
+    """
+    from bernstein.core.quality.retrospective import (
+        count_incomplete_declared,
+        run_healthy_from_status_counts,
+    )
+
+    histogram = {"total": 1, "open": 1, "claimed": 0, "in_progress": 0, "orphaned": 0, "done": 0, "failed": 0}
+    assert count_incomplete_declared(None) == 0, "the None default is what made the report vacuously healthy"
+    assert run_healthy_from_status_counts(None) is True
+    assert count_incomplete_declared(histogram) == 1
+    assert run_healthy_from_status_counts(histogram) is False
+
+    # Both mid-run call sites must accept and forward the histogram.
+    import inspect
+
+    from bernstein.core.orchestration.orchestrator import Orchestrator
+    from bernstein.core.orchestration.orchestrator_summary import generate_run_summary
+
+    for fn in (Orchestrator._generate_run_summary, generate_run_summary):
+        assert "full_status_counts" in inspect.signature(fn).parameters, (
+            f"{fn.__qualname__} must accept the histogram, or its retrospective is vacuously healthy"
+        )
+
+
+def test_mid_run_retrospective_is_unhealthy_when_nothing_finished(tmp_path: Path) -> None:
+    """End-to-end through the real writer: 0 done, 0 failed, 1 still open.
+
+    This is the exact #3010 artefact. With the histogram threaded through, the
+    report is not HEALTHY.
+    """
+    from bernstein.core.metrics import get_collector
+    from bernstein.core.retrospective import generate_retrospective
+
+    runtime_dir = tmp_path / ".sdd" / "runtime"
+    runtime_dir.mkdir(parents=True)
+    collector = get_collector(tmp_path / ".sdd" / "metrics")
+    histogram = {"total": 1, "open": 1, "claimed": 0, "in_progress": 0, "orphaned": 0, "done": 0, "failed": 0}
+
+    generate_retrospective(
+        done_tasks=[],
+        failed_tasks=[],
+        collector=collector,
+        runtime_dir=runtime_dir,
+        run_start_ts=0.0,
+        trigger_reason="mid-run",
+        full_status_counts=histogram,
+    )
+    with_histogram = (runtime_dir / "retrospective.md").read_text(encoding="utf-8")
+
+    generate_retrospective(
+        done_tasks=[],
+        failed_tasks=[],
+        collector=collector,
+        runtime_dir=runtime_dir,
+        run_start_ts=0.0,
+        trigger_reason="mid-run",
+    )
+    without_histogram = (runtime_dir / "retrospective.md").read_text(encoding="utf-8")
+
+    assert "HEALTHY" in without_histogram, "baseline: without the histogram the report claims health"
+    assert with_histogram != without_histogram, "the histogram must change the verdict, not just the prose"
+    assert "HEALTHY" not in with_histogram.replace("UNHEALTHY", ""), (
+        "a run where nothing reached a terminal state must not render as HEALTHY"
+    )

--- a/tests/unit/test_run_summary_issue_953.py
+++ b/tests/unit/test_run_summary_issue_953.py
@@ -197,16 +197,23 @@ class TestCleanupOrdering:
 
     def test_quiet_run_exits_nonzero_when_task_never_completed(self) -> None:
         """Issue #3010: the synchronous (quiet) completion path must exit
-        non-zero when the run ended with a declared task neither done nor
-        failed -- an operator scripting ``bernstein run && deploy`` must not
-        deploy on a run that produced nothing."""
+        non-zero when QUIESCENCE WAS DETECTED and the run still ended with a
+        declared task neither done nor failed -- an operator scripting
+        ``bernstein run && deploy`` must not deploy on a run that produced
+        nothing.
+
+        ``_wait_for_run_completion`` returns a payload only when quiescence was
+        actually observed, so a returned payload here means "the run really
+        ended in this state", not "it was still working". The still-in-flight
+        case is covered by the timeout test below.
+        """
         from bernstein.core.retrospective import EXIT_RUN_UNHEALTHY
 
         from bernstein.cli.run_preflight import _finalize_run_output
 
-        stuck_status = {"total": 1, "done": 0, "failed": 0, "open": 1}
+        ended_stuck_status = {"total": 1, "done": 0, "failed": 0, "open": 1}
         with (
-            patch("bernstein.cli.run_bootstrap._wait_for_run_completion", return_value=stuck_status),
+            patch("bernstein.cli.run_bootstrap._wait_for_run_completion", return_value=ended_stuck_status),
             patch("bernstein.cli.run_preflight._show_run_summary"),
             patch("bernstein.cli.run_preflight._drain_completed_backlog_files") as drain,
         ):
@@ -215,6 +222,45 @@ class TestCleanupOrdering:
         assert exc_info.value.code == EXIT_RUN_UNHEALTHY
         assert exc_info.value.code != 0
         # Cleanup still runs on the non-zero-exit path.
+        drain.assert_called_once()
+
+    def test_quiet_run_exits_nonzero_on_quiescent_run_with_failed_task(self) -> None:
+        """The exit mapping fires on any observable bad outcome, not just the
+        never-terminated case: a quiescent run with a failed task exits
+        non-zero."""
+        from bernstein.core.retrospective import EXIT_RUN_UNHEALTHY
+
+        from bernstein.cli.run_preflight import _finalize_run_output
+
+        failed_status = {"total": 2, "done": 1, "failed": 1, "open": 0}
+        with (
+            patch("bernstein.cli.run_bootstrap._wait_for_run_completion", return_value=failed_status),
+            patch("bernstein.cli.run_preflight._show_run_summary"),
+            patch("bernstein.cli.run_preflight._drain_completed_backlog_files"),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                _finalize_run_output(quiet=True)
+        assert exc_info.value.code == EXIT_RUN_UNHEALTHY
+
+    def test_quiet_run_exits_zero_when_wait_times_out_still_in_flight(self) -> None:
+        """A healthy run that simply outlives the CLI wait deadline must exit 0.
+
+        ``_wait_for_run_completion`` returns None when quiescence was never
+        observed (the run is still working in the background). That is a
+        "no verdict" case, NOT a failure: multi-hour goals are designed for
+        (scope timeouts reach 7200s against a 3600s default wait), so treating
+        the timeout as unhealthy would break ``bernstein run && deploy`` in the
+        opposite direction from the bug this PR fixes.
+        """
+        from bernstein.cli.run_preflight import _finalize_run_output
+
+        with (
+            patch("bernstein.cli.run_bootstrap._wait_for_run_completion", return_value=None),
+            patch("bernstein.cli.run_preflight._show_run_summary"),
+            patch("bernstein.cli.run_preflight._drain_completed_backlog_files") as drain,
+        ):
+            # Must return normally (exit 0), not raise SystemExit.
+            _finalize_run_output(quiet=True)
         drain.assert_called_once()
 
     def test_quiet_run_exits_zero_when_all_done(self) -> None:

--- a/tests/unit/test_run_summary_issue_953.py
+++ b/tests/unit/test_run_summary_issue_953.py
@@ -263,6 +263,85 @@ class TestCleanupOrdering:
             _finalize_run_output(quiet=True)
         drain.assert_called_once()
 
+    def test_issue_3010_end_to_end_stuck_task_orchestrator_gone_exits_nonzero(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Issue #3010 end-to-end, through the REAL wait + REAL pidfile check.
+
+        The exact reported shape: one declared task that never completed, its
+        agent produced nothing, and the orchestrator has exited. Only the
+        server polls and the clock are faked -- ``_wait_for_run_completion``
+        and the orchestrator-liveness check are the real ones, reading a real
+        stale ``spawner.pid``. ``bernstein run --quiet && deploy`` must not
+        deploy on this run.
+        """
+        from bernstein.core.retrospective import EXIT_RUN_UNHEALTHY
+
+        import bernstein.cli.run_bootstrap as rb
+        from bernstein.cli.run_preflight import _finalize_run_output
+
+        runtime = tmp_path / ".sdd" / "runtime"
+        runtime.mkdir(parents=True)
+        # Orchestrator ran and exited: pidfile present, pid not alive.
+        (runtime / "spawner.pid").write_text("999999")
+        monkeypatch.chdir(tmp_path)
+
+        stuck = {"total": 1, "open": 1, "claimed": 0, "done": 0, "failed": 0}
+        clock = {"t": 0.0}
+
+        def _fake_time() -> float:
+            clock["t"] += 1.0
+            return clock["t"]
+
+        with (
+            patch.object(rb, "server_get", side_effect=lambda p: stuck if p == "/status" else {"agent_count": 0}),
+            patch.object(rb.time, "sleep", return_value=None),
+            patch.object(rb.time, "time", side_effect=_fake_time),
+            patch.object(rb, "_signal_orchestrator_shutdown"),
+            patch("bernstein.cli.run_preflight._show_run_summary"),
+            patch("bernstein.cli.run_preflight._drain_completed_backlog_files"),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                _finalize_run_output(quiet=True)
+
+        assert exc_info.value.code == EXIT_RUN_UNHEALTHY
+        assert exc_info.value.code != 0
+
+    def test_startup_window_with_live_orchestrator_does_not_exit_nonzero(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Counterpart guard: identical task counts, but the orchestrator is
+        ALIVE (startup window) -- must reach the deadline and exit 0, never be
+        mistaken for a finished run."""
+        import os
+
+        import bernstein.cli.run_bootstrap as rb
+        from bernstein.cli.run_preflight import _finalize_run_output
+
+        runtime = tmp_path / ".sdd" / "runtime"
+        runtime.mkdir(parents=True)
+        # A genuinely live pid: this test process.
+        (runtime / "spawner.pid").write_text(str(os.getpid()))
+        monkeypatch.chdir(tmp_path)
+
+        starting = {"total": 1, "open": 1, "claimed": 0, "done": 0, "failed": 0}
+        clock = {"t": 0.0}
+
+        def _fake_time() -> float:
+            clock["t"] += 1.0
+            return clock["t"]
+
+        with (
+            patch.object(rb, "server_get", side_effect=lambda p: starting if p == "/status" else {"agent_count": 0}),
+            patch.object(rb.time, "sleep", return_value=None),
+            patch.object(rb.time, "time", side_effect=_fake_time),
+            patch.object(rb, "_signal_orchestrator_shutdown"),
+            patch("bernstein.cli.run_preflight._show_run_summary"),
+            patch("bernstein.cli.run_preflight._drain_completed_backlog_files"),
+        ):
+            # Returns normally -> exit 0.
+            _finalize_run_output(quiet=True)
+
     def test_quiet_run_exits_zero_when_all_done(self) -> None:
         from bernstein.cli.run_preflight import _finalize_run_output
 

--- a/tests/unit/test_run_summary_issue_953.py
+++ b/tests/unit/test_run_summary_issue_953.py
@@ -195,6 +195,40 @@ class TestCleanupOrdering:
         # The whole point: cleanup ran even though rendering exploded.
         drain.assert_called_once()
 
+    def test_quiet_run_exits_nonzero_when_task_never_completed(self) -> None:
+        """Issue #3010: the synchronous (quiet) completion path must exit
+        non-zero when the run ended with a declared task neither done nor
+        failed -- an operator scripting ``bernstein run && deploy`` must not
+        deploy on a run that produced nothing."""
+        from bernstein.core.retrospective import EXIT_RUN_UNHEALTHY
+
+        from bernstein.cli.run_preflight import _finalize_run_output
+
+        stuck_status = {"total": 1, "done": 0, "failed": 0, "open": 1}
+        with (
+            patch("bernstein.cli.run_bootstrap._wait_for_run_completion", return_value=stuck_status),
+            patch("bernstein.cli.run_preflight._show_run_summary"),
+            patch("bernstein.cli.run_preflight._drain_completed_backlog_files") as drain,
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                _finalize_run_output(quiet=True)
+        assert exc_info.value.code == EXIT_RUN_UNHEALTHY
+        assert exc_info.value.code != 0
+        # Cleanup still runs on the non-zero-exit path.
+        drain.assert_called_once()
+
+    def test_quiet_run_exits_zero_when_all_done(self) -> None:
+        from bernstein.cli.run_preflight import _finalize_run_output
+
+        done_status = {"total": 2, "done": 2, "failed": 0, "open": 0}
+        with (
+            patch("bernstein.cli.run_bootstrap._wait_for_run_completion", return_value=done_status),
+            patch("bernstein.cli.run_preflight._show_run_summary"),
+            patch("bernstein.cli.run_preflight._drain_completed_backlog_files"),
+        ):
+            # Returns normally (no SystemExit) -> exit code 0.
+            _finalize_run_output(quiet=True)
+
     def test_drain_is_a_noop_when_no_claimed_dir(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """When ``.sdd/backlog/claimed/`` doesn't exist, drain returns silently."""
         from bernstein.cli.run_preflight import _drain_completed_backlog_files

--- a/tests/unit/test_run_summary_issue_953.py
+++ b/tests/unit/test_run_summary_issue_953.py
@@ -23,6 +23,7 @@ Three layers from the bug report are covered:
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -269,11 +270,12 @@ class TestCleanupOrdering:
         """Issue #3010 end-to-end, through the REAL wait + REAL pidfile check.
 
         The exact reported shape: one declared task that never completed, its
-        agent produced nothing, and the orchestrator has exited. Only the
-        server polls and the clock are faked -- ``_wait_for_run_completion``
-        and the orchestrator-liveness check are the real ones, reading a real
-        stale ``spawner.pid``. ``bernstein run --quiet && deploy`` must not
-        deploy on this run.
+        agent produced nothing, and the orchestrator has exited and stayed gone
+        for longer than a recovery restart would have taken. Only the server
+        polls and the clock are faked -- ``_wait_for_run_completion``, the
+        orchestrator-liveness classification and the confirmation window are
+        the real ones, reading a real stale ``spawner.pid``.
+        ``bernstein run --quiet && deploy`` must not deploy on this run.
         """
         from bernstein.core.retrospective import EXIT_RUN_UNHEALTHY
 
@@ -287,14 +289,22 @@ class TestCleanupOrdering:
         monkeypatch.chdir(tmp_path)
 
         stuck = {"total": 1, "open": 1, "claimed": 0, "done": 0, "failed": 0}
-        clock = {"t": 0.0}
+        counts = {"total": 1, "open": 1, "claimed": 0, "in_progress": 0, "orphaned": 0, "done": 0, "failed": 0}
+        clock = {"t": time.time()}
 
         def _fake_time() -> float:
-            clock["t"] += 1.0
+            clock["t"] += 2.0
             return clock["t"]
 
+        def _fake_get(path: str) -> object:
+            if path == "/status":
+                return stuck
+            if path == "/tasks/counts":
+                return counts
+            return {"agent_count": 0}
+
         with (
-            patch.object(rb, "server_get", side_effect=lambda p: stuck if p == "/status" else {"agent_count": 0}),
+            patch.object(rb, "server_get", side_effect=_fake_get),
             patch.object(rb.time, "sleep", return_value=None),
             patch.object(rb.time, "time", side_effect=_fake_time),
             patch.object(rb, "_signal_orchestrator_shutdown"),
@@ -325,10 +335,10 @@ class TestCleanupOrdering:
         monkeypatch.chdir(tmp_path)
 
         starting = {"total": 1, "open": 1, "claimed": 0, "done": 0, "failed": 0}
-        clock = {"t": 0.0}
+        clock = {"t": time.time()}
 
         def _fake_time() -> float:
-            clock["t"] += 1.0
+            clock["t"] += 10.0
             return clock["t"]
 
         with (

--- a/tests/unit/test_run_summary_issue_953.py
+++ b/tests/unit/test_run_summary_issue_953.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -290,11 +291,16 @@ class TestCleanupOrdering:
 
         stuck = {"total": 1, "open": 1, "claimed": 0, "done": 0, "failed": 0}
         counts = {"total": 1, "open": 1, "claimed": 0, "in_progress": 0, "orphaned": 0, "done": 0, "failed": 0}
-        clock = {"t": time.time()}
 
-        def _fake_time() -> float:
-            clock["t"] += 2.0
-            return clock["t"]
+        # Monotonic and wall advance together, as a real time.sleep does: the
+        # confirmation window is measured on monotonic.
+        elapsed = {"s": 0.0}
+        base_wall, base_mono = time.time(), time.monotonic()
+        clock = SimpleNamespace(
+            time=lambda: base_wall + elapsed["s"],
+            monotonic=lambda: base_mono + elapsed["s"],
+            sleep=lambda _s: elapsed.__setitem__("s", elapsed["s"] + 2.0),
+        )
 
         def _fake_get(path: str) -> object:
             if path == "/status":
@@ -305,8 +311,7 @@ class TestCleanupOrdering:
 
         with (
             patch.object(rb, "server_get", side_effect=_fake_get),
-            patch.object(rb.time, "sleep", return_value=None),
-            patch.object(rb.time, "time", side_effect=_fake_time),
+            patch.object(rb, "time", clock),
             patch.object(rb, "_signal_orchestrator_shutdown"),
             patch("bernstein.cli.run_preflight._show_run_summary"),
             patch("bernstein.cli.run_preflight._drain_completed_backlog_files"),

--- a/tests/unit/test_watchdog.py
+++ b/tests/unit/test_watchdog.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import os
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -35,17 +37,35 @@ def _write_log(workdir: Path, session_id: str, line_count: int) -> None:
     log_path.write_text("\n".join(lines), encoding="utf-8")
 
 
+def _write_heartbeat_phase(workdir: Path, session_id: str, timestamp: float, phase: str) -> None:
+    hb_path = workdir / ".sdd" / "runtime" / "heartbeats" / f"{session_id}.json"
+    hb_path.parent.mkdir(parents=True, exist_ok=True)
+    hb_path.write_text(json.dumps({"timestamp": timestamp, "phase": phase}), encoding="utf-8")
+
+
+def _age_log(workdir: Path, session_id: str, age_s: float) -> None:
+    """Backdate the log file mtime so it is NOT a fresh liveness signal."""
+    log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
+    old = time.time() - age_s
+    os.utime(log_path, (old, old))
+
+
 def _orch(
     workdir: Path,
     *,
     session: AgentSession,
     stall_count: int = 0,
     log_state: dict[str, tuple[int, int]] | None = None,
+    heartbeat_timeout_s: int = 120,
+    heartbeat_starting_timeout_s: int = 300,
 ) -> SimpleNamespace:
     task = Task(id=session.task_ids[0], title="Fix API", description="desc", role="backend")
     return SimpleNamespace(
         _workdir=workdir,
-        _config=SimpleNamespace(heartbeat_timeout_s=120),
+        _config=SimpleNamespace(
+            heartbeat_timeout_s=heartbeat_timeout_s,
+            heartbeat_starting_timeout_s=heartbeat_starting_timeout_s,
+        ),
         _agents={session.id: session},
         _stall_counts={session.task_ids[0]: stall_count},
         _watchdog_log_state={} if log_state is None else dict(log_state),
@@ -102,6 +122,98 @@ def test_collect_watchdog_findings_detects_silent_agent(tmp_path: Path) -> None:
     assert len(findings) == 1
     assert findings[0].source == "heartbeat"
     assert findings[0].severity == "high"
+
+
+# ---------------------------------------------------------------------------
+# Issue #3012: a fresh log mtime is a positive liveness signal that suppresses
+# the heartbeat-staleness incident (real wall-clock; no time patching so the
+# log mtime and the heartbeat content timestamp share one clock).
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_log_suppresses_stale_heartbeat_incident(tmp_path: Path) -> None:
+    """Heartbeat older than the timeout, but the log was written within the
+    grace window -> the agent is alive and NO heartbeat incident is raised
+    (issue #3012)."""
+    workdir = tmp_path
+    now = time.time()
+    session = _session("task-1", spawn_ts=now - 200)
+    orch = _orch(workdir, session=session, heartbeat_timeout_s=120)
+    # Heartbeat 140s old: past the 120s timeout, so absent a liveness signal
+    # this would be a CRITICAL incident.
+    _write_heartbeat(workdir, session.id, now - 140)
+    _write_log(workdir, session.id, 3)  # freshly written -> mtime ~now
+
+    findings = collect_watchdog_findings(orch)
+
+    assert [f for f in findings if f.source == "heartbeat"] == []
+
+
+def test_stale_heartbeat_with_stale_log_still_raises_critical(tmp_path: Path) -> None:
+    """Control for the suppression test: same stale heartbeat, but the log
+    mtime is ALSO past the grace window -> the critical incident still fires,
+    proving the suppression is driven by log freshness, not disabled."""
+    workdir = tmp_path
+    now = time.time()
+    session = _session("task-1", spawn_ts=now - 200)
+    orch = _orch(workdir, session=session, heartbeat_timeout_s=120)
+    _write_heartbeat(workdir, session.id, now - 140)
+    _write_log(workdir, session.id, 3)
+    _age_log(workdir, session.id, age_s=300)  # log not fresh
+
+    findings = collect_watchdog_findings(orch)
+
+    heartbeat = [f for f in findings if f.source == "heartbeat"]
+    assert len(heartbeat) == 1
+    assert heartbeat[0].severity == "critical"
+
+
+def test_starting_phase_uses_configurable_larger_timeout(tmp_path: Path) -> None:
+    """A `starting` agent is judged against the larger, configurable
+    starting-phase timeout, so a heartbeat age past the normal 120s cap but
+    below the starting window raises no incident (issue #3012)."""
+    workdir = tmp_path
+    now = time.time()
+    session = _session("task-1", spawn_ts=now - 400)
+    orch = _orch(
+        workdir,
+        session=session,
+        heartbeat_timeout_s=120,
+        heartbeat_starting_timeout_s=300,
+    )
+    # Heartbeat 140s old with phase=starting: past the 120s cap (would be
+    # critical) but below the 300s starting window and its 150s high-water mark.
+    _write_heartbeat_phase(workdir, session.id, now - 140, phase="starting")
+    _write_log(workdir, session.id, 3)
+    _age_log(workdir, session.id, age_s=300)  # stale log: isolate the phase-timeout effect
+
+    findings = collect_watchdog_findings(orch)
+
+    assert [f for f in findings if f.source == "heartbeat"] == []
+
+
+def test_starting_phase_still_flags_once_past_starting_timeout(tmp_path: Path) -> None:
+    """Beyond the starting-phase window a frozen `starting` heartbeat with no
+    log activity is still flagged critical -- the larger timeout is a grace
+    window, not a permanent exemption."""
+    workdir = tmp_path
+    now = time.time()
+    session = _session("task-1", spawn_ts=now - 600)
+    orch = _orch(
+        workdir,
+        session=session,
+        heartbeat_timeout_s=120,
+        heartbeat_starting_timeout_s=300,
+    )
+    _write_heartbeat_phase(workdir, session.id, now - 360, phase="starting")  # past 300s
+    _write_log(workdir, session.id, 3)
+    _age_log(workdir, session.id, age_s=300)  # not fresh
+
+    findings = collect_watchdog_findings(orch)
+
+    heartbeat = [f for f in findings if f.source == "heartbeat"]
+    assert len(heartbeat) == 1
+    assert heartbeat[0].severity == "critical"
 
 
 def test_watchdog_manager_creates_one_triage_task_for_active_incident(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Two causally-linked core-reliability bugs surfaced in one end-to-end run: the liveness watchdog reaps an agent that is still actively working, and the run that produced nothing is then reported HEALTHY with exit 0. They compound, so they are fixed together.

**Scope note up front:** this PR does not close #3010. It fixes three of the four things that go wrong in that shape and leaves the fourth, which needs a change to the orchestrator's main loop. See "What #3010 still needs" below.

## Behaviour changes to note in the release notes

- **A quiescent run containing a failed task now exits 3 where it previously exited 0.** A run whose tasks failed is not a success, but this does break `bernstein run && <next step>` for anyone who was tolerating partial failures. Scripts that want the old behaviour need to stop chaining on the exit code, or tolerate exit 3 explicitly.
- **The run-outcome exit code now applies on every output branch**, not only `--quiet`. An unhealthy finished run that previously exited 0 under the dashboard, the Rich fallback or a non-interactive invocation now exits 3.

## #3012 - watchdog reaps a still-working agent

A log or git mtime within the liveness grace window is now a **positive** liveness signal that:

- **Suppresses** the Tier-1 heartbeat-staleness incident, and
- **Gates the heartbeat escalation ladder before it can SIGTERM/SIGKILL** - the same signal the reap cycle already uses to defer its death judgment, applied one step earlier. This is the path that actually kills: escalation fired on heartbeat age alone while `liveness_judgment`, running one tick later, would have found the agent alive.

A genuinely frozen agent with no log or git activity is still escalated and killed (frozen-heartbeat reaping, issue #2796, is preserved).

The `phase=starting` heartbeat timeout is now separately configurable (`heartbeat_starting_timeout_s`, overridable via `tuning.agent.*`) and defaults above a realistic slow time-to-first-turn, so a non-heartbeat adapter (`consumes_heartbeat_dir=False`) is judged by log liveness rather than a hard 120s cap.

## #3010 - a no-output run reported HEALTHY / exit 0

### What this PR fixes

**1. A stuck task is no longer invisible to the health verdict.**

`GET /status` has buckets for open/claimed/done/failed/refused only. Two of the four statuses that mean "declared but never finished", `in_progress` and `orphaned`, have no bucket there at all, so counting them from that payload always yielded zero. A run whose only task was orphaned therefore read as *quiescent* (open == claimed == 0), was reported finished and healthy, and exited 0. The counts now come from the full per-status histogram (`GET /tasks/counts`), which also vetoes a false quiescence. A histogram that is unavailable, or an error body masquerading as one, cannot support a terminal conclusion at all.

**2. The outcome exit code exists on every branch, not just `--quiet`.**

Nothing enables `--quiet` automatically and no documented workflow passes it, so binding the outcome signal to that one flag left every ordinary invocation exiting 0. All four branches of `_finalize_run_output` now map the outcome. What they can honestly report differs:

| Branch | Waits? | Reports |
|---|---|---|
| `--quiet` | yes | quiescence, and an orchestrator confirmed gone with work outstanding |
| Textual dashboard | no | an already-quiescent run (the common case: the operator watched it finish) |
| Rich fallback | no | an already-quiescent run |
| Non-interactive | no, detaches by design | an already-quiescent run, if the run reached a terminal state inside the detach window |

The "orchestrator gone" verdict is an inference from a process's absence and needs a confirmation window across several observations, which a single poll cannot supply, so it stays on the waiting path alone.

**3. The interim retrospective is no longer vacuously HEALTHY.**

`generate_retrospective` derives "declared but never finished" from the full histogram, and the two mid-run call sites passed nothing, so `count_incomplete_declared(None)` was 0 and the report said HEALTHY. Both now pass it. This matters more than "interim" suggests, for the reason in the next section.

**4. A terminal run outcome is detected when the orchestrator really is gone.**

The spawner exiting with declared tasks still non-terminal is a terminal state that quiescence cannot express (it requires nothing outstanding, which a stuck task never satisfies). This is now detected, and it maps to exit code **3**, not 2: click raises `UsageError`/`NoSuchOption` with 2, and `run_bootstrap` itself raises `SystemExit(2)` on seed/config failures, so reusing 2 would make "bad flag" and "unmet goal" indistinguishable to a script.

### What #3010 still needs

**In the reported shape the orchestrator never exits, so the gone-verdict never triggers.** `orchestrator.py` computes `_had_any_terminal_task` from done/failed counts, and the entire settle-window and self-stop block, including `self._running = False`, is nested under it. When done == failed == 0 forever, which is exactly the reported shape, that block is skipped and the tick loop runs on with no global deadline. The issue's own field log ("ran ~16 quiescence detected ticks") corroborates this.

Because of that, the shutdown-final retrospective site is unreachable in this shape and the interim report is the only retrospective the run ever writes, which is why fix 3 above is load-bearing rather than cosmetic.

Giving the orchestrator a terminal state when quiescence holds with zero terminal tasks touches the main loop and can cause premature exits. It is deliberately **not** attempted here and gets its own PR and its own review. Code comments at both mid-run retrospective sites point at it.

So: an operator hitting the exact #3010 shape still gets a run that does not stop on its own. What changes is that the run no longer reports itself healthy, and the CLI no longer exits 0, once it does end.

## The liveness verdict is built to be wrong in one direction

This verdict feeds a non-zero exit code on a run an operator may still be watching, so every ambiguous reading leaves the run alone. Two adversarial reviews drove the current shape; the numbers below are from their reproductions.

**Positive local evidence is required, and the task server can only veto.** `/health`'s spawner component reads the *same* `spawner.pid` with a bare `os.kill`, with none of the local classifier's guards. It is a weaker read of the same evidence, not a second witness, so treating its `down` as corroboration made every guard overridable, and only in the direction that reaps. It can still overrule a local `gone`, because it can see the orchestrator's pid namespace when the CLI cannot (the shipped image runs the orchestrator in a container).

| local probe | server says | result |
|---|---|---|
| `gone` | `down` or silent | `gone` |
| `gone` | `ok` | `unknown` (veto) |
| `alive` | `ok` or silent | `alive` |
| `alive` | `down` | `unknown` (veto) |
| `unknown` | anything | `unknown` |

**A confirmation window on the monotonic clock.** `run_watchdog` restarts a dead orchestrator every `WATCHDOG_POLL_S`, so a dead pid is recoverable, not terminal, until that window passes. The verdict requires three consecutive *successful observations* spanning three supervisor poll periods, and a restart, visible as a live process or a changed pid, resets it. The period is a shared constant so the two windows cannot drift apart. It is measured on `time.monotonic()` because that is the clock the supervisor sleeps on: on the wall clock an NTP step, a container clock sync, or a laptop resume satisfied the window with no real time passing.

**Only time in which recovery was possible counts.** An unreachable poll is not an observation and resets the streak. When the task server is down, `_restart_spawner` returns `-1` and refuses to restart the orchestrator at all, so a server outage is precisely the period in which recovery is impossible; crediting it fired the verdict just as the recovery sequence reached the orchestrator.

**A pid is a reused integer, not an identity.** A pidfile predating this run is never this run's death. A live pid whose command line does not identify it as an orchestrator is not our process. The marker covers all three shipped launch forms: the `-m` spawner argv, the module *file path* the process has after its own `os.execv` restart, and the docker-compose entrypoint. A form that is missing looks exactly like a recycled pid, and the execv form matters most because that is when a pid has just been freed.

**A missing pidfile is never death.** The orchestrator does not remove its own pidfile; only teardown and hygiene paths do (`bernstein stop`, the pre-run reap, `_clean_stale_runtime`, `bernstein doctor --fix`).

## The recovery supervisor fails the other way

The same classifier is read by the supervisor, but it owes it the opposite duty. For the CLI, acting on a weak reading destroys a running run. For the supervisor, *not* acting destroys it just as thoroughly and permanently, because nothing recreates `spawner.pid`. `bernstein doctor --fix` deletes precisely the pidfile of a process that has already crashed, so "crashed, then its stale pidfile was cleaned up" is an ordinary state that must still recover.

So anything not positively alive is restarted, and only positive teardown evidence (a draining marker, or `watchdog.pid` no longer naming this process) makes the supervisor stand down. Teardown is not a reason to withhold a restart on its own: `_stop_infrastructure` kills `watchdog.pid` first and removes pidfiles last, so the supervisor is already dead before teardown deletes anything.

## Tests

Only the touched and related test files were run, one file per invocation, per the RAM constraint.

- **Watchdog / heartbeat:** fresh log suppresses the heartbeat incident; stale-log control still raises critical; the liveness gate blocks SIGTERM/SIGKILL while frozen-agent and no-log controls still kill.
- **Run health:** incomplete-declared accounting forces non-HEALTHY and appears in the tally; a reaped no-output task is counted once across both report sections.
- **`test_orchestrator_liveness_verdict.py`** - the cases where the verdict must fire.
- **`test_orchestrator_liveness_false_positives.py`** - the cases where it must not: wall-clock steps, single-observer verdicts, stale pidfiles, recycled pids, server outages, marker forms, error bodies. Two harness rules are enforced here because breaking either is what let the first round through a green suite: the fake clock advances monotonic and wall together, and `/health` fixtures carry the `components` block a real server always emits. `test_health_fixture_matches_the_real_server` pins that shape against the real producer.
- **`test_run_outcome_reaches_every_branch.py`** - the exit code on all four branches, and the histogram at both mid-run retrospective sites.

Refs #3010
Closes #3012
