### PR TITLE
ci: classify a queued merge group from its own base SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,10 +181,17 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref }}
           EVENT_NAME: ${{ github.event_name }}
+          # The merge queue builds a synthetic ref that stacks every entry in
+          # the group on top of `main`. `github.event.before` does not exist on
+          # this event and the group can carry many commits, so the planner
+          # needs the group's own base SHA to see the whole combined diff.
+          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
         run: |
-          # On pull_request, diff against the base branch. On push to main
-          # (or any other push event), diff against the previous commit so
-          # the planner stays useful for filter-skipped downstream jobs.
+          # On pull_request, diff against the base branch. On merge_group,
+          # diff against the group's base SHA. On push to main (or any other
+          # push event), diff against the previous commit so the planner stays
+          # useful for filter-skipped downstream jobs.
           #
           # NOTE: checkout above uses fetch-depth: 0, so HEAD has full history.
           # However, origin/${BASE_REF} is NOT fetched by default in the PR
@@ -213,9 +220,40 @@ jobs:
               echo "diff stderr: $CHANGED"
               diff_failed=true
             fi
+          elif [ "$EVENT_NAME" = "merge_group" ]; then
+            # The queue's ephemeral ref (gh-readonly-queue/main/pr-N-<base>)
+            # stacks every entry in the group on top of main, so `HEAD~1...HEAD`
+            # sees only the tail commit. Classifying the group on that commit
+            # alone is unsafe in both directions: a docs-only tail commit sets
+            # docs_only=true and every Python test job skips, and the roll-up
+            # then reports `CI gate` green for a combination nothing ever ran.
+            # That is precisely the untested-combination hole the queue exists
+            # to close, so the planner must diff against the group's own base.
+            #
+            # `github.event.merge_group.base_sha` is the commit the group was
+            # built on, and checkout above uses fetch-depth: 0, so the range
+            # `<base_sha>...HEAD` is the exact combined diff the queue is
+            # asking CI to validate.
+            if [ -n "$MERGE_GROUP_BASE_SHA" ] && ! git cat-file -e "${MERGE_GROUP_BASE_SHA}^{commit}" 2>/dev/null; then
+              # Normally already present; fetch defensively rather than
+              # silently classifying against a commit git cannot resolve.
+              git fetch --no-tags origin "$MERGE_GROUP_BASE_SHA" || true
+            fi
+            echo "::group::git diagnostic"
+            echo "merge_group base -> ${MERGE_GROUP_BASE_SHA:-UNSET}"
+            echo "HEAD             -> $(git rev-parse HEAD 2>&1 || echo UNRESOLVED)"
+            echo "::endgroup::"
+            if [ -z "$MERGE_GROUP_BASE_SHA" ]; then
+              echo "::warning::merge_group payload carried no base_sha; falling back to safe over-broad result"
+              diff_failed=true
+            elif ! CHANGED=$(git diff --name-only "${MERGE_GROUP_BASE_SHA}...HEAD" 2>&1); then
+              echo "::warning::git diff failed against the merge_group base; falling back to safe over-broad result"
+              echo "diff stderr: $CHANGED"
+              diff_failed=true
+            fi
           else
             # `before` may be 000... on first push of a branch; fall back to HEAD~1.
-            BEFORE="${{ github.event.before }}"
+            BEFORE="$PUSH_BEFORE_SHA"
             if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
               CHANGED=$(git diff --name-only "HEAD~1...HEAD" 2>/dev/null || git ls-files)
             else
@@ -1902,11 +1940,15 @@ jobs:
           # label. merge_group must be included too: a merge queue runs CI
           # on a synthetic merge_group ref where `github.event.pull_request`
           # is null, so the `macos-needed` label and `push`-only branches of
-          # the job `if:` can never be true and these jobs always skip. The
-          # merged commit still triggers a native `push` to main that runs
-          # the full macOS suite un-gated, and ci-macos-nightly.yml covers
-          # regression -- so tolerating the skip here is what keeps the queue
-          # from wedging without losing macOS coverage on what actually lands.
+          # the job `if:` can never be true there. The remaining branch,
+          # `macos_sensitive`, is computed by `determine-changes` from the
+          # group's combined diff, so a macOS-sensitive group still runs the
+          # macOS jobs in the queue and this tolerance does not apply. A group
+          # that touches nothing macOS-sensitive skips them: the merged commit
+          # still triggers a native `push` to main that runs the full macOS
+          # suite un-gated, and ci-macos-nightly.yml covers regression -- so
+          # tolerating that skip is what keeps the queue from wedging without
+          # losing macOS coverage on what actually lands.
           MACOS_SKIP_EVENTS = ("pull_request", "workflow_dispatch", "merge_group")
 
           docs_only = plan.get("docs_only") == "true"

--- a/docs/operations/merge-queue.md
+++ b/docs/operations/merge-queue.md
@@ -15,6 +15,7 @@ shipped ruleset is currently out of sync with it; see
 | Queue state today | Ruleset exists, `enforcement: disabled` | ruleset `main-merge-queue` |
 | What it solves | Tests the A+B *combination* before merge | this doc |
 | Required checks on the queue | `CI gate` **and** `review-bot-ack` | `ci.yml`, `review-bot-ack.yml` |
+| What the group's CI is planned against | The group's `base_sha`, never `HEAD~1` | [What the group's CI actually tests](#what-the-groups-ci-actually-tests) |
 | Merge method | Squash | ruleset `merge_queue` rule |
 | Grouping | `ALLGREEN` (all entries in a group must pass) | ruleset |
 | Batch size | **1** — one PR lands per push to `main` | [Tunables](#tunables-source-of-truth) |
@@ -93,16 +94,46 @@ queue for every diff the filter excludes. It is locked by
 > leaving it out would leave two divergent definitions of "required" -
 > the PR gate enforcing two contexts and the queue enforcing one.
 
+### What the group's CI actually tests
+
+Reporting `CI gate` on the group is necessary but not sufficient: the gate
+has to be green for the *right* reason. `ci.yml` classifies the diff first
+(`determine-changes` emits `docs_only` / `macos_sensitive`) and the roll-up
+tolerates a skipped job only when that classification says the skip was
+intentional. So the classification is what decides how much of the suite a
+queued group really runs.
+
+On a `merge_group` event the ref is
+`gh-readonly-queue/main/pr-<n>-<base_sha>`, which stacks every entry in the
+group on top of `main`. The planner therefore diffs against
+`github.event.merge_group.base_sha` - the group's own base - and sees the
+whole combined change.
+
+The push heuristic (`HEAD~1...HEAD`) must not be reused here. It reads only
+the tail commit, so a group whose last commit happens to be docs-only would
+classify as `docs_only=true`, every job in the roll-up's `DOCS_ONLY_SKIPPABLE`
+set would skip, and `CI gate` would go green for a combination nothing built -
+reintroducing the untested-combination hole the queue exists to close. If the
+base SHA is absent or unresolvable the planner falls back to the over-broad
+"everything changed" classification, so an infrastructure problem costs runner
+minutes rather than coverage.
+
+Locked by `tests/unit/test_required_check_canary_workflow_yaml.py`, which runs
+the shipped classifier against a synthetic two-entry group whose tail entry is
+docs-only.
+
 ## macOS coverage under the queue
 
 The macOS matrix (`test-macos`, `adapter-integration-macos`) is **gated**:
 it runs on `push` to `main`, on macOS-sensitive diffs, and on the
-`macos-needed` label - not on a plain `merge_group` event. The `CI gate`
-roll-up tolerates that skip on `merge_group` (see `MACOS_SKIP_EVENTS` in
-`ci.yml`). Coverage is preserved because the **post-merge `push` to
-`main`** runs the full macOS suite un-gated, and `ci-macos-nightly.yml` is
-the daily safety net. The queue validates the integrated combination; the
-merged commit validates macOS.
+`macos-needed` label. On a queued group the label and `push` branches cannot
+fire, so `macos_sensitive` - computed from the group's combined diff - is what
+decides: a group touching a macOS-sensitive path runs the macOS cells in the
+queue, and a group that does not skips them. The `CI gate` roll-up tolerates
+exactly that skip (see `MACOS_SKIP_EVENTS` in `ci.yml`). Coverage is preserved
+because the **post-merge `push` to `main`** runs the full macOS suite
+un-gated, and `ci-macos-nightly.yml` is the daily safety net. The queue
+validates the integrated combination; the merged commit validates macOS.
 
 ## Auto-release through the queue
 
@@ -164,7 +195,7 @@ the queue is enabled.
 | `grouping_strategy` | `ALLGREEN` | `ALLGREEN` | A group merges only if every entry is green |
 | `max_entries_to_build` | 1 | **5** | Build concurrency: the number of `merge_group` webhooks in flight. At `1` the queue tests one entry at a time, so a burst of N PRs costs N sequential full CI cycles - strictly worse latency than today with no load benefit the per-SHA policy does not already provide. `5` caps concurrent queue CI at 5 instead of the unbounded N a burst produces today. |
 | `min_entries_to_merge` | 1 | **1** | Never wait for a second entry before merging |
-| `max_entries_to_merge` | 1 | **1** | One PR lands per push to `main`. Raising this breaks two things: (a) the auto-release gate keys on the push head SHA, so a bump that is not last in the batch is silently skipped; (b) `determine-changes` in `ci.yml` classifies a non-`pull_request` diff as `HEAD~1...HEAD`, which on a multi-entry group sees only the last entry - a docs-only last entry would let the whole batch skip the Python test jobs. Lifting this requires teaching `determine-changes` to diff against `github.event.merge_group.base_sha`; tracked as a follow-up. |
+| `max_entries_to_merge` | 1 | **1** | One PR lands per push to `main`. The auto-release gate keys on the push head SHA, so merging N entries in a single push silently skips a version bump that is not last in the batch - green CI, no tag, no publish, no error. Lifting this requires the release gate to stop keying on the push head SHA; tracked as a follow-up. The second former blocker is closed: `determine-changes` now classifies a queued group against `github.event.merge_group.base_sha`, so a multi-entry group is planned from its combined diff instead of its last commit. |
 | `min_entries_to_merge_wait_minutes` | 0 | **0** | With `max_entries_to_merge = 1` there is no batch to fill, so any wait is pure added latency |
 | `check_response_timeout_minutes` | 30 | **120** | Measured over the last 30 successful `CI` runs on `main`: p50 38 min, p90 58 min, max 105 min. At `30` **every** entry would be ejected as timed out; at `60` roughly one in ten would be. `120` clears the observed maximum and the `test` job's own 90-minute budget. |
 
@@ -308,6 +339,7 @@ checks. Any PRs sitting in the queue are released back to normal merge.
 |---------|--------------|--------|
 | Nothing merges; entries sit in queue | A required check does not run on `merge_group` | Compare the ruleset's `required_status_checks` against the coverage table above; every context there must have a `merge_group` emitter |
 | `CI gate` red on `merge_group` but green on the PR | A real combination failure, or a job skipped that the roll-up does not tolerate | Read the `merge_group` run log; if a legitimately-skipped job is flagged, extend the roll-up tolerance in `ci.yml` |
+| `CI gate` green on `merge_group` but the test jobs did not run | The planner classified the group too narrowly | Open the `Determine changes` job log and check the `git diagnostic` group: the merge_group base must be the group's `base_sha`, and the changed-file list must cover every entry in the group |
 | Entries ejected as timed out | `check_response_timeout_minutes` below the real CI wall time | Raise it; see the measured distribution in Tunables |
 | Merges land but no release is tagged | The post-merge `push` CI run did not reach the dispatcher | Confirm a `push` run on `main` exists at the merged SHA, then that `post-ci-dispatcher.yml` ran off it; check `pyproject.toml` is still absent from `ci.yml`'s `push.paths-ignore` |
 | Queue throughput too low | Build concurrency, not batching | Raise `max_entries_to_build`. Do **not** raise `max_entries_to_merge` - see Tunables |

--- a/tests/unit/test_merge_queue_runbook_docs.py
+++ b/tests/unit/test_merge_queue_runbook_docs.py
@@ -121,19 +121,20 @@ def test_enable_payload_matches_tunables_table(
 
 
 def test_batch_size_is_pinned_to_one(enable_payload: dict[str, Any]) -> None:
-    """`max_entries_to_merge` > 1 breaks the release path and the diff planner.
+    """`max_entries_to_merge` > 1 breaks the release path.
 
     With N entries merged per push, the base branch advances N commits in one
     push event that reports only the last SHA. auto-release keys on that SHA,
-    so a version bump anywhere but last is skipped with no error. Separately,
-    `determine-changes` in ci.yml classifies a non-pull_request diff as
-    `HEAD~1...HEAD`, which on a multi-entry group sees only the last entry.
+    so a version bump anywhere but last is skipped with no error.
+
+    The diff planner is no longer part of this: `determine-changes` classifies
+    a merge group against `github.event.merge_group.base_sha`, so it already
+    sees every entry in a multi-entry group.
     """
     params = _rule(enable_payload, "merge_queue")
     assert params["max_entries_to_merge"] == 1, (
-        "max_entries_to_merge must stay 1 until determine-changes diffs against "
-        "github.event.merge_group.base_sha and the release gate stops keying on "
-        "the push head SHA. See merge-queue.md :: Auto-release through the queue."
+        "max_entries_to_merge must stay 1 until the release gate stops keying "
+        "on the push head SHA. See merge-queue.md :: Auto-release through the queue."
     )
 
 

--- a/tests/unit/test_required_check_canary_workflow_yaml.py
+++ b/tests/unit/test_required_check_canary_workflow_yaml.py
@@ -23,12 +23,18 @@ Invariants exercised here:
    ``pull_request``/``schedule``/``workflow_dispatch`` triggers, with
    every action SHA-pinned and the verify step asserting the same set
    of invariants.
+5. Every context branch protection requires on a PR is also reportable on
+   a ``merge_group`` ref, and the diff planner that decides which jobs may
+   skip classifies a queued group from the group's own base SHA - so a
+   green ``CI gate`` on the queue means the whole combination was built.
 """
 
 from __future__ import annotations
 
 import json
+import os
 import re
+import shutil
 import subprocess
 import sys
 import textwrap
@@ -591,3 +597,228 @@ def test_review_bot_ack_has_merge_group_passthrough() -> None:
         "gated to `github.event_name == 'merge_group'` so the context reports "
         "on queued groups."
     )
+
+
+# ---------------------------------------------------------------------------
+# Diff-planner correctness on a merge group (#2966)
+#
+# `determine-changes` decides which downstream jobs may legitimately skip, and
+# the `ci-gate` roll-up trusts that decision. On a merge group the ref stacks
+# every queued entry on top of `main`, so classifying it with the push
+# heuristic (`HEAD~1...HEAD`) reads only the tail commit. A docs-only tail
+# would mark the whole group docs-only, skip every Python test job, and let
+# `CI gate` report green for a combination that was never built - the exact
+# untested-combination hole the queue is meant to close.
+#
+# These tests execute the shipped classifier, not a copy of it.
+# ---------------------------------------------------------------------------
+
+MERGE_GROUP_BASE_SHA_EXPR = "github.event.merge_group.base_sha"
+
+_SHELL_TOOLS_PRESENT = shutil.which("bash") is not None and shutil.which("git") is not None
+requires_shell_tools = pytest.mark.skipif(
+    not _SHELL_TOOLS_PRESENT,
+    reason="needs bash and git to execute the shipped classify script",
+)
+
+
+def _classify_script(ci_doc: dict[str, object]) -> str:
+    """Extract the `run:` body of the `classify` step in `determine-changes`."""
+    jobs = ci_doc["jobs"]
+    assert isinstance(jobs, dict)
+    planner = jobs["determine-changes"]
+    assert isinstance(planner, dict)
+    steps = planner["steps"]
+    assert isinstance(steps, list)
+    for step in steps:
+        if isinstance(step, dict) and step.get("id") == "classify":
+            run = step.get("run")
+            assert isinstance(run, str)
+            return run
+    raise AssertionError("ci.yml `determine-changes` no longer has a `classify` step")
+
+
+def _classify_env(ci_doc: dict[str, object]) -> dict[str, str]:
+    """The `env:` mapping of the `classify` step."""
+    jobs = ci_doc["jobs"]
+    assert isinstance(jobs, dict)
+    planner = jobs["determine-changes"]
+    assert isinstance(planner, dict)
+    steps = planner["steps"]
+    assert isinstance(steps, list)
+    for step in steps:
+        if isinstance(step, dict) and step.get("id") == "classify":
+            env = step.get("env")
+            assert isinstance(env, dict)
+            return {str(k): str(v) for k, v in env.items()}
+    raise AssertionError("ci.yml `determine-changes` no longer has a `classify` step")
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.email=ci@example.invalid",
+            "-c",
+            "user.name=ci",
+            "-c",
+            "commit.gpgsign=false",
+            *args,
+        ],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _commit_file(repo: Path, relpath: str, body: str, message: str) -> str:
+    target = repo / relpath
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(body, encoding="utf-8")
+    _git(repo, "add", relpath)
+    _git(repo, "commit", "-m", message)
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return head.stdout.strip()
+
+
+def _synthetic_merge_group(tmp_path: Path) -> tuple[Path, str]:
+    """Build a two-entry merge group whose tail entry is docs-only.
+
+    Returns the repo path and the group's `base_sha`. Entry 1 touches a
+    macOS-sensitive Python module; entry 2 touches only docs. A planner that
+    reads the tail alone sees a docs-only group.
+    """
+    repo = tmp_path / "queue-ref"
+    repo.mkdir()
+    _git(repo, "init", "--initial-branch=main")
+    base_sha = _commit_file(repo, "README.md", "base\n", "base commit")
+    _commit_file(repo, "src/bernstein/core/tunnels/ssh.py", "x = 1\n", "entry 1: tunnels")
+    _commit_file(repo, "docs/notes.md", "notes\n", "entry 2: docs only")
+    return repo, base_sha
+
+
+def _run_classify(
+    repo: Path,
+    script: str,
+    *,
+    event: str,
+    extra_env: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Run the shipped classify script and return its `GITHUB_OUTPUT` pairs."""
+    output_path = repo / "github_output.txt"
+    output_path.write_text("", encoding="utf-8")
+    env = {
+        "PATH": os.environ.get("PATH", ""),
+        "HOME": str(repo),
+        "EVENT_NAME": event,
+        "BASE_REF": "",
+        "MERGE_GROUP_BASE_SHA": "",
+        "PUSH_BEFORE_SHA": "",
+        "GITHUB_OUTPUT": str(output_path),
+    }
+    env.update(extra_env or {})
+    proc = subprocess.run(
+        ["bash", "-e", "-c", script],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, (
+        f"the classify step must never fail the planner job.\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )
+    parsed: dict[str, str] = {}
+    for line in output_path.read_text(encoding="utf-8").splitlines():
+        if "=" in line:
+            key, _, value = line.partition("=")
+            parsed[key.strip()] = value.strip()
+    return parsed
+
+
+def test_classify_step_reads_the_merge_group_base_sha(ci_doc: dict[str, object]) -> None:
+    """The group's base SHA must reach the script through `env:`.
+
+    Interpolating it straight into the `run:` body would be a template
+    injection surface; reading it from the environment keeps the script
+    auditable and testable.
+    """
+    env = _classify_env(ci_doc)
+    assert any(MERGE_GROUP_BASE_SHA_EXPR in value for value in env.values()), (
+        "the `classify` step must expose `github.event.merge_group.base_sha` via "
+        f"`env:`; found {env!r}. Without it the planner classifies a queued group "
+        "from its tail commit only."
+    )
+
+
+@requires_shell_tools
+def test_planner_classifies_the_whole_merge_group(ci_doc: dict[str, object], tmp_path: Path) -> None:
+    """A group whose tail commit is docs-only is still not a docs-only group.
+
+    Entry 1 changes a macOS-sensitive Python module and entry 2 changes only
+    docs. The planner must report the union, otherwise every Python test job
+    skips and `CI gate` certifies an untested combination.
+    """
+    repo, base_sha = _synthetic_merge_group(tmp_path)
+    outputs = _run_classify(
+        repo,
+        _classify_script(ci_doc),
+        event="merge_group",
+        extra_env={"MERGE_GROUP_BASE_SHA": base_sha},
+    )
+    assert outputs["docs_only"] == "false", (
+        "planner reported docs_only=true for a merge group that changes "
+        f"src/**.py in an earlier entry; outputs={outputs!r}. Every job in "
+        "DOCS_ONLY_SKIPPABLE would skip and the gate would pass regardless."
+    )
+    assert outputs["python_changed"] == "true", (
+        f"planner missed the Python change in the group's first entry; outputs={outputs!r}"
+    )
+    assert outputs["macos_sensitive"] == "true", (
+        "planner missed the macOS-sensitive path in the group's first entry, so "
+        f"the queue would not run the macOS cells for it; outputs={outputs!r}"
+    )
+
+
+@requires_shell_tools
+def test_tail_only_classification_would_have_missed_it(ci_doc: dict[str, object], tmp_path: Path) -> None:
+    """Pin down why the base SHA is needed rather than `HEAD~1`.
+
+    The same tree classified from the tail commit alone reads as docs-only.
+    This is correct for a single-commit push to `main` and wrong for a merge
+    group; the test exists so a future simplification back to one shared
+    heuristic fails loudly instead of silently skipping the test suite.
+    """
+    repo, _ = _synthetic_merge_group(tmp_path)
+    outputs = _run_classify(repo, _classify_script(ci_doc), event="push")
+    assert outputs["docs_only"] == "true", (
+        "expected the tail-only (push) heuristic to see just the docs commit; "
+        f"outputs={outputs!r}. If this changed, revisit the merge_group branch."
+    )
+
+
+@requires_shell_tools
+def test_planner_fails_safe_when_the_group_base_is_missing(ci_doc: dict[str, object], tmp_path: Path) -> None:
+    """No base SHA must widen the classification, never narrow it.
+
+    A missing or unresolvable base is an infrastructure problem. Skipping test
+    jobs because of one would let the queue merge an unvalidated combination,
+    so the planner has to fall back to "everything changed".
+    """
+    repo, _ = _synthetic_merge_group(tmp_path)
+    outputs = _run_classify(repo, _classify_script(ci_doc), event="merge_group")
+    assert outputs["docs_only"] == "false", (
+        f"planner must not report docs_only on an unresolvable base; outputs={outputs!r}"
+    )
+    for key in ("python_changed", "tests_changed", "gha_workflows_changed", "macos_sensitive"):
+        assert outputs[key] == "true", (
+            f"fail-safe classification must set {key}=true so no job skips; outputs={outputs!r}"
+        )


### PR DESCRIPTION
> **Does not change branch protection; the ruleset flip is a documented post-release operator step.**

Refs #2966 (the ruleset flip remains an operator step; this PR does not enable the queue)

Repo-content half only. Nothing here touches required-check configuration at
the repository-settings level, and the `main-merge-queue` ruleset is left at
`enforcement: disabled`. The flip is a separate operator action taken after the
release is tagged; the exact calls are in `docs/operations/merge-queue.md`.

## Problem

A PR is not required to be up to date with `main` before merging, so two PRs
that are each green against an older base can both land and break `main` -
no CI run ever built the combination. The merge queue closes that by testing
each candidate on a synthetic `merge_group` ref before it merges.

Two things have to hold before the queue is safe to switch on:

1. every required context must be able to report on a `merge_group` ref,
   otherwise the queue blocks forever on a check that never publishes;
2. a green `CI gate` on the group must mean the whole group was actually
   built.

(1) already held. (2) did not.

`determine-changes` classifies the diff and the `ci-gate` roll-up passes when
every non-success job was an intentional skip according to that
classification. On a `merge_group` event the planner fell through to the push
heuristic: `github.event.before` does not exist there, so it diffed
`HEAD~1...HEAD`. The queue's ref stacks every entry in the group on top of
`main`, so that range reads only the tail commit. A group whose last commit
happens to be docs-only classified as `docs_only=true`, every Python test job
skipped, and `CI gate` reported green for a combination nothing built - the
exact case the queue is being enabled to catch.

## Required-check coverage on `merge_group` (audited)

Live required contexts on `main` were read back with
`gh api repos/<repo>/branches/main/protection` (read-only): exactly `CI gate`
and `review-bot-ack`, both pinned to the GitHub Actions app (`app_id 15368`).

| Required context | Emitter | Reports on `merge_group`? | Evidence |
|---|---|---|---|
| `CI gate` | `ci.yml` :: `ci-gate` | **Yes** | `on: merge_group: {}` with no filters, and `paths`/`paths-ignore` are not evaluated for `merge_group`, so the workflow runs on every group. The job is `if: always() && !cancelled()` with no event exclusion. |
| `CI gate` | `ci-gate-stub.yml` :: `ci-gate` | No - and correct | The stub exists only to cover `ci.yml`'s `paths-ignore` on `pull_request`. That filter has no effect on `merge_group`, so adding the trigger would publish a duplicate check run under the same required-context name for no benefit. |
| `review-bot-ack` | `review-bot-ack.yml` :: `merge-group-pass` | **Yes** | Dedicated pass-through job, `if: github.event_name == 'merge_group'`, publishing the identical context name on the queue's ephemeral ref. |

Both contexts are locked by
`tests/unit/test_required_check_canary_workflow_yaml.py`, which fails if a
required context loses its `merge_group` emitter or if `ci.yml`'s
`merge_group:` trigger ever gains a filter.

## Changes

- **`.github/workflows/ci.yml`** - `determine-changes` gets an explicit
  `merge_group` branch that diffs against
  `github.event.merge_group.base_sha`, the group's own base, so the
  classification covers every entry. A missing or unresolvable base falls back
  to the existing over-broad "everything changed" result, so an infrastructure
  fault costs runner minutes rather than coverage. `github.event.before` moves
  out of the inline expression into the step `env:` block so the classifier can
  be executed under test.
- Side effect worth calling out: `macos_sensitive` becomes meaningful on a
  queued group, so a group touching a macOS-sensitive path now runs the macOS
  cells in the queue instead of always skipping them. The roll-up's existing
  tolerance still covers the non-sensitive case, and the comment describing it
  was corrected.
- **`tests/unit/test_required_check_canary_workflow_yaml.py`** - executes the
  shipped classifier (not a copy) against a synthetic two-entry group whose
  first entry changes a macOS-sensitive Python module and whose tail entry is
  docs-only. Asserts the union is seen, that the tail-only heuristic would have
  missed it, and that a missing base SHA fails safe.
- **`docs/operations/merge-queue.md`** - new "What the group's CI actually
  tests" section, corrected macOS section, a troubleshooting row for a group
  that goes green without running the suite, and the `max_entries_to_merge`
  rationale updated (the planner half of that constraint is now closed; the
  release-gate half is not, so the value stays `1`).
- `docs/operations/ci-topology.md` regenerated with
  `scripts/gen_workflow_topology.py` in the same commit as the workflow edit;
  the reported topology is unchanged, so the file has no diff
  (`--check` passes).

## Verification

- `actionlint -shellcheck=shellcheck .github/workflows/ci.yml` - clean.
- `python3 scripts/gen_workflow_topology.py --check` - clean.
- `pytest tests/unit/test_required_check_canary_workflow_yaml.py tests/unit/test_merge_queue_runbook_docs.py tests/unit/test_post_ci_dispatcher_yaml.py` - 64 passed.
- The three new tests were run against the pre-fix `ci.yml` and all three fail
  there, so they are real regression coverage rather than restatements.
- Full suite not run locally; CI owns that.

## Operator steps (deliberately not performed here)

`docs/operations/merge-queue.md` carries the mechanical procedure. Summary of
what is still outstanding after this PR merges, to be done **after the release
is tagged**:

- Step 0 - preflight, read-only: confirm the ruleset id and that branch
  protection still lists exactly `CI gate` and `review-bot-ack`.
- Step 1 - `gh api -X PUT .../rulesets/<id>` with the payload in the runbook.
  It applies the reviewed tunables and adds `review-bot-ack` to the queue's
  required checks, and deliberately keeps `enforcement: disabled` so a
  mistyped rule set cannot enable the queue as a side effect.
- Step 2 - drain: confirm no PR is sitting mid-merge with auto-merge armed.
- Step 3 - `gh api -X PUT .../rulesets/<id> -f enforcement=active`, a separate
  call so enabling is one reviewable action.
- Step 4 - smoke test one low-risk PR through the queue and confirm the
  post-queue `push` to `main` still reaches the release listener.

Rollback: pause with `-f enforcement=disabled` (PRs revert to the legacy
branch-protection merge path), or remove the queue entirely with
`gh api -X DELETE .../rulesets/<id>`. Both are in the runbook.

## Summary by Sourcery

Ensure merge-queue CI classification is based on the merge group’s base SHA so queued combinations are fully validated without changing branch protection or ruleset enforcement.

Enhancements:
- Update the CI diff planner to treat merge_group events as diffs against github.event.merge_group.base_sha, with a safe fallback when the base SHA is missing or unresolvable.
- Clarify macOS job skip tolerance so macOS-sensitive changes within a merge group still run macOS jobs while non-sensitive groups rely on post-merge push and nightly coverage.
- Strengthen merge-queue documentation with an explanation of what the group’s CI actually tests, updated macOS coverage semantics, and revised rationale for max_entries_to_merge now that planner constraints are closed.

Documentation:
- Expand merge-queue runbook to describe CI planning against merge_group base_sha, troubleshooting for green CI without tests, and updated tunables rationale.
- Regenerate CI topology documentation alongside workflow changes to keep the described topology in sync, with no effective topology change.

Tests:
- Add workflow canary tests that execute the shipped diff-classifier against synthetic merge_group scenarios to ensure whole-group classification, correct tail-only behavior, and fail-safe handling of missing bases.
- Adjust merge-queue runbook tests so batch-size constraints are now pinned solely by the release path, reflecting that the diff planner supports multi-entry groups.
