### PR TITLE
ci: guard against gate signals that report on unevaluated work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -560,9 +560,28 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/bootstrap
       - name: Run pyright (advisory)
+        # Advisory by design, and this job is not in ci-gate's needs, so it
+        # gates nothing. Its scope is the repo-wide pyright configuration in
+        # pyproject.toml [tool.pyright]; the blocking subset is the separate
+        # pyright-strict-zone job. The error count is echoed as a number so
+        # the advisory backlog moving is observable rather than silent.
+        # Scope and promotion path: docs/operations/type-check-scope.md.
         run: |
-          uv run pyright 2>&1 | tail -1 || true
-          echo "::notice::Typecheck is advisory while module decomposition shims are being typed"
+          log="$RUNNER_TEMP/pyright-advisory.log"
+          uv run pyright >"$log" 2>&1 || true
+          tail -1 "$log"
+          counts="$(grep -E '^[0-9]+ error' "$log" | tail -1 || true)"
+          echo "::notice::Advisory pyright (repo-wide scope, gates nothing): ${counts:-no summary line}"
+          {
+            echo "### Advisory pyright"
+            echo ""
+            echo "| scope | blocking | result |"
+            echo "|---|---|---|"
+            echo "| repo-wide (\`[tool.pyright]\`) | no | ${counts:-unknown} |"
+            echo ""
+            echo "Blocking subset: \`pyrightconfig.strict.json\` (job \`Pyright strict (security + cluster)\`)."
+            echo "Scope reference: \`docs/operations/type-check-scope.md\`."
+          } >> "$GITHUB_STEP_SUMMARY"
 
   dead-code:
     name: Dead code (Vulture)
@@ -1253,7 +1272,23 @@ jobs:
             tail -20 "$log"
             exit 1
           fi
-          echo "mypy repo-wide (advisory): $(tail -1 "$log")" >> "$GITHUB_STEP_SUMMARY"
+          # The `|| true` above makes this run advisory. Report its scope and
+          # error count as explicit numbers so the backlog moving in either
+          # direction is observable rather than silent. Only the gated zone
+          # below can fail this job.
+          advisory_errors="$(grep -cE ': error: ' "$log" || true)"
+          echo "::notice::Advisory mypy (scope: src/, gates nothing): ${advisory_errors} error(s)"
+          {
+            echo "### mypy scope"
+            echo ""
+            echo "| run | scope | blocking | errors |"
+            echo "|---|---|---|---|"
+            echo "| advisory | \`src/\` (\`[tool.mypy]\`) | no | ${advisory_errors} |"
+            echo "| gated zone | \`mypy.gate.ini\` \`files\` minus \`exclude\` | yes | must be 0 |"
+            echo ""
+            echo "Advisory tail: \`$(tail -1 "$log")\`"
+            echo "Scope reference: \`docs/operations/type-check-scope.md\`."
+          } >> "$GITHUB_STEP_SUMMARY"
       - name: Run mypy strict on the gated zone
         # The gated zone is defined in mypy.gate.ini. Widen it by removing
         # entries from `exclude` as each module reaches strict cleanliness.

--- a/.github/workflows/pr-observability-summary.yml
+++ b/.github/workflows/pr-observability-summary.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
+      checks: read
       contents: read
       pull-requests: write
       security-events: read
@@ -65,6 +66,29 @@ jobs:
           mkdir -p .ci/observability
           uv run bernstein doctor observe --json --no-persist \
             > .ci/observability/observe.json || true
+
+      - name: Report required-context presence on the PR head
+        # A head commit missing a required check context produces the same
+        # empty failure list as one whose checks all passed. This step names
+        # which of the two the PR is in. Advisory: `continue-on-error` keeps
+        # the report out of the gate - mergeability is still decided by the
+        # required contexts themselves.
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+        run: |
+          set -uo pipefail
+          report="$(uv run python scripts/check_required_contexts.py --pr "$PR_NUMBER" 2>&1)" && rc=0 || rc=$?
+          {
+            echo "### Required-context presence"
+            echo ""
+            echo '```text'
+            echo "$report"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "$report"
+          exit "$rc"
 
       - name: Build PR summary markdown
         id: build

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -188,7 +188,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/pentest.yml | workflow: {"contents": "read"} | - |
 | .github/workflows/post-ci-dispatcher.yml | auto-heal: {"actions": "read", "attestations": "write", "contents": "write", "id-token": "write", "pull-requests": "write"}<br>auto-release: {"actions": "write", "contents": "write", "issues": "write"}<br>bernstein-ci-fix: {"actions": "read", "contents": "write", "issues": "write", "pull-requests": "write"}<br>bisect-on-red: {"contents": "read", "issues": "write", "pull-requests": "write"}<br>meta: {"contents": "read"} | GEMINI_API_KEY, OPENROUTER_API_KEY_FREE |
 | .github/workflows/pr-labels.yml | workflow: {"contents": "read"}<br>label: {"contents": "read", "issues": "write", "pull-requests": "write"} | GITHUB_TOKEN |
-| .github/workflows/pr-observability-summary.yml | workflow: {"contents": "read"}<br>summary: {"contents": "read", "pull-requests": "write", "security-events": "read"} | GITHUB_TOKEN |
+| .github/workflows/pr-observability-summary.yml | workflow: {"contents": "read"}<br>summary: {"checks": "read", "contents": "read", "pull-requests": "write", "security-events": "read"} | GITHUB_TOKEN |
 | .github/workflows/pr-policy.yml | workflow: {"contents": "read"}<br>pr-policy: {"actions": "read", "contents": "write", "pull-requests": "read"} | BERNSTEIN_AUTOSYNC_TOKEN |
 | .github/workflows/publish-docker.yml | publish: {"attestations": "write", "contents": "read", "id-token": "write", "packages": "write"} | GITHUB_TOKEN |
 | .github/workflows/publish-extension.yml | workflow: {"contents": "read"}<br>publish: {"contents": "write"} | OPEN_VSX_TOKEN, VS_MARKETPLACE_TOKEN |

--- a/docs/operations/ci.md
+++ b/docs/operations/ci.md
@@ -14,6 +14,9 @@ documentation read the inline comments in `.github/workflows/ci.yml`.
 | macOS safety net | Nightly + push-on-sensitive | `.github/workflows/ci-macos-nightly.yml` |
 | Required check | Single `CI gate` job | `.github/workflows/ci.yml` |
 | Concurrency | PR-scoped cancel, push-scoped non-cancel | `.github/workflows/ci.yml` |
+| Collection completeness | Guard test, fails on an uncollected test file | `scripts/check_test_collection.py` |
+| Required-context presence | Operator command + advisory PR step | `scripts/check_required_contexts.py` |
+| Type-check scope | Blocking vs advisory scopes | `docs/operations/type-check-scope.md` |
 
 ## macOS matrix policy (closes #1468)
 
@@ -149,3 +152,80 @@ intentional-skip allow-lists. The aggregator understands:
 
 If you add a new conditionally-gated job, register it in the
 appropriate allow-list inside the `roll-up` step of `ci-gate`.
+
+## Gate evaluation coverage
+
+A green gate is only evidence of correctness when the gate evaluated the
+work. Two guards make the difference between "everything passed" and
+"nothing ran" visible.
+
+### Collection completeness
+
+`scripts/check_test_collection.py` walks `tests/` and reports any test
+file that no CI configuration collects. The collected set is derived from
+the workflows themselves, not restated:
+
+| Source | What it contributes |
+|---|---|
+| `run:` bodies in `.github/workflows/*.yml` | Every `pytest` / `run_tests.py` invocation |
+| `scripts/run_tests.py::DEFAULT_TEST_DIR` | The directory the shards discover when no `--test-dir` is given |
+| `scripts/test_impact.py::TEST_DIRS` | The universe a `--affected` run can select from |
+
+Rules the derivation applies:
+
+- a `run_tests.py` directory collects `test_*.py` only (its `rglob`
+  pattern), so a `*_test.py` file under a shard directory counts as
+  uncollected;
+- a `pytest` directory collects pytest's own `python_files` patterns;
+- a `-k`-narrowed invocation credits nothing (the expression, not the
+  path, decides what runs);
+- a `-m`-narrowed invocation credits the path (collection still walks it).
+
+`tests/unit/scripts/test_check_test_collection.py` runs the derivation in
+the shards, so adding a test file somewhere no shard reaches fails CI.
+A file that is deliberately not run in CI needs an entry, with a reason,
+in that script's `ALLOWLIST`; an entry that stops matching a file is
+reported as stale and must be removed.
+
+```bash
+uv run python scripts/check_test_collection.py          # report
+uv run python scripts/check_test_collection.py --json   # machine-readable
+```
+
+### Required-context presence
+
+A head commit that never produced a check-run for a required context
+shows the same empty failure list as a commit whose checks all passed.
+`scripts/check_required_contexts.py` names which of the two a commit is
+in. The required contexts are read from
+`.github/workflows/required-check-canary.yml`
+(`BRANCH_PROTECTION_CONTEXTS_JSON`) - the same in-tree source the
+scheduled branch-protection audit compares live settings against. The
+script reads check-runs only; it never touches branch protection.
+
+```bash
+uv run python scripts/check_required_contexts.py --pr 1234
+uv run python scripts/check_required_contexts.py --sha "$GITHUB_SHA" --json
+```
+
+| State | Meaning |
+|---|---|
+| `missing` | No check-run with that name on the commit - the context never ran |
+| `pending` | Present, not finished |
+| `failing` | Completed as failure / timed_out / cancelled / action_required |
+| `skipped` | Completed as skipped |
+| `passing` | Completed as success / neutral |
+
+Exit status is non-zero only for `missing`; a red required check is the
+merge gate's business, an absent one is this script's. The same command
+runs as an advisory step in `pr-observability-summary.yml` (opt-in via
+the `deep-review` label or `workflow_dispatch`) and reports into the job
+summary without gating.
+
+Reach for it when a PR reads BLOCKED with no visible failures: either a
+required context is `missing`, or it is present and `failing`.
+
+### Type-check scope
+
+Which paths each type job covers, and what the `|| true` runs report,
+are documented in `docs/operations/type-check-scope.md`.

--- a/docs/operations/type-check-scope.md
+++ b/docs/operations/type-check-scope.md
@@ -1,0 +1,91 @@
+# Type-check scope
+
+Which paths the type checkers actually cover, which runs can fail a pull
+request, and how a path graduates from advisory to blocking.
+
+Two of the three type runs in `ci.yml` end in `|| true`. A green PR page
+therefore says nothing about the advisory runs, and an error introduced outside
+a blocking scope lands without a signal. This page makes each scope explicit so
+that gap is a known quantity rather than a surprise.
+
+## TL;DR
+
+| Run | CI job | Config | Scope | Blocking |
+|---|---|---|---|---|
+| mypy gated zone | `mypy strict (lineage substrate)` | `mypy.gate.ini` | `files` minus `exclude` | Yes - in `ci-gate` needs |
+| mypy parse check | `mypy strict (lineage substrate)` | `[tool.mypy]` | `src/` | Only on a parse abort |
+| mypy advisory | `mypy strict (lineage substrate)` | `[tool.mypy]` | `src/` | No - error count reported |
+| pyright strict zone | `Pyright strict (security + cluster)` | `pyrightconfig.strict.json` | `include` list | Yes - in `ci-gate` needs |
+| pyright advisory | `Type check report` | `[tool.pyright]` | repo-wide | No - job is not in `ci-gate` needs |
+
+## Blocking scopes
+
+### mypy - `mypy.gate.ini`
+
+Strict mode over the lineage substrate. The zone is exactly the `files` list
+minus the `exclude` regex:
+
+| Field | Meaning |
+|---|---|
+| `files` | `src/bernstein/core/evidence`, `.../identity`, `.../lineage`, `.../persistence` |
+| `exclude` | Modules inside those packages that are not strict-clean yet |
+| `follow_imports = silent` | Imports outside the zone are resolved for types but their errors are not reported |
+
+Widen the zone by deleting an entry from `exclude`, then by adding a package to
+`files`. Both directions are a config-only change; no workflow edit is needed.
+
+A path **not** in the zone is checked only by the advisory run below.
+
+### pyright - `pyrightconfig.strict.json`
+
+Strict mode over a curated file allow-list (`include`). Add a file once it is
+strict-clean. Everything else is covered only by the repo-wide advisory run.
+
+## Advisory scopes
+
+### mypy advisory - `src/`
+
+`uv run mypy src || true` runs before the gated zone. It carries a
+pre-existing backlog, so its exit status is discarded, with one exception: if
+the output contains `errors prevented further checking`, mypy aborted before
+checking the tree and the step fails. That distinction matters - an aborted run
+reports few errors for the same reason an unopened file reports none.
+
+The step prints the advisory error count as a number, both as a `::notice::`
+annotation and in the job summary:
+
+| run | scope | blocking | errors |
+|---|---|---|---|
+| advisory | `src/` (`[tool.mypy]`) | no | *N* |
+| gated zone | `mypy.gate.ini` `files` minus `exclude` | yes | must be 0 |
+
+The count is the observable: it is expected to fall as modules leave `exclude`,
+and a jump upward is visible in the job summary without changing what gates.
+
+### pyright advisory - repo-wide
+
+The `Type check report` job runs repo-wide pyright in the basic mode configured
+by `[tool.pyright]`, discards the exit status, and reports the summary counts
+in the job summary. The job is **not** in `ci-gate`'s `needs` list, so it
+cannot block a merge in any state.
+
+## Reading a type failure
+
+| Symptom | Meaning |
+|---|---|
+| `mypy strict (lineage substrate)` red, gated-zone step failed | A real error inside `mypy.gate.ini`'s zone. Fix it or the PR does not merge |
+| `mypy strict (lineage substrate)` red, parse step failed | mypy aborted before checking anything - the reported error count is meaningless until this is fixed |
+| Advisory error count moved, everything green | An error landed (or was fixed) outside every blocking scope. No gate reacts; the number in the job summary is the only signal |
+| A file has type errors and CI is green | Expected when the file is outside both blocking scopes. Promote it (above) if it should gate |
+
+## Promoting a path
+
+1. Fix the errors in the file.
+2. Remove its entry from `mypy.gate.ini`'s `exclude`, or add it to
+   `pyrightconfig.strict.json`'s `include`.
+3. Push. The blocking job now covers it; no workflow change is involved.
+
+## Related
+
+- `docs/operations/ci.md` - CI runbook, including the gate-evaluation guards.
+- `docs/operations/merge-gate.md` - the merge-gate layers themselves.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -405,6 +405,7 @@ nav:
           - Nightly canary: operations/nightly-canary.md
           - CI: operations/ci.md
           - CI topology: operations/ci-topology.md
+          - Type-check scope: operations/type-check-scope.md
           - Post-CI dispatcher: operations/post-ci-dispatcher.md
           - Review pipeline DSL: operations/review-pipeline.md
           - Review and autofix receipts: operations/review-receipts.md

--- a/scripts/check_required_contexts.py
+++ b/scripts/check_required_contexts.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Report required check contexts that are absent from a commit.
+
+A pull request whose head commit carries no check-run for a required context
+looks exactly like a pull request whose checks all passed: the failure
+histogram reads zero either way. The two states are opposites - "0 failures
+because everything passed" and "0 failures because nothing ran" - and this
+script names which one a commit is in.
+
+The required contexts are read from the in-tree canary
+(``.github/workflows/required-check-canary.yml``, key
+``BRANCH_PROTECTION_CONTEXTS_JSON``), the same source the scheduled
+branch-protection audit compares live settings against. Nothing here reads or
+changes branch protection.
+
+Every context is classified as one of:
+
+``missing``   no check-run with that name exists on the commit
+``pending``   a check-run exists but has not completed
+``failing``   completed with failure / timed_out / cancelled / action_required
+``skipped``   completed as skipped
+``passing``   completed as success or neutral
+
+The exit code is non-zero only for ``missing`` - a real failure is the merge
+gate's business, an absent context is this script's.
+
+Usage::
+
+    python scripts/check_required_contexts.py --pr 3032
+    python scripts/check_required_contexts.py --sha "$GITHUB_SHA"
+    python scripts/check_required_contexts.py --sha abc123 --check-runs runs.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CANARY_PATH = REPO_ROOT / ".github" / "workflows" / "required-check-canary.yml"
+CONTEXTS_ENV_KEY = "BRANCH_PROTECTION_CONTEXTS_JSON"
+
+MISSING = "missing"
+PENDING = "pending"
+FAILING = "failing"
+SKIPPED = "skipped"
+PASSING = "passing"
+
+_FAILING_CONCLUSIONS = frozenset({"failure", "timed_out", "cancelled", "action_required", "stale"})
+_PASSING_CONCLUSIONS = frozenset({"success", "neutral"})
+
+
+@dataclass(frozen=True)
+class ContextState:
+    """The state of one required context on a commit."""
+
+    name: str
+    state: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class PresenceReport:
+    """Presence of every required context on a commit."""
+
+    sha: str
+    states: tuple[ContextState, ...]
+
+    @property
+    def missing(self) -> tuple[ContextState, ...]:
+        """Required contexts with no check-run at all."""
+        return tuple(state for state in self.states if state.state == MISSING)
+
+    @property
+    def ok(self) -> bool:
+        """True when every required context is present in some form."""
+        return not self.missing
+
+
+def read_required_contexts(canary_path: Path | None = None) -> list[str]:
+    """Read the required contexts from the in-tree canary workflow."""
+    path = CANARY_PATH if canary_path is None else canary_path
+    try:
+        import yaml
+    except ModuleNotFoundError as exc:  # pragma: no cover - dev env has pyyaml
+        raise RuntimeError("pyyaml is required to read the required-check canary") from exc
+
+    document = yaml.safe_load(path.read_text(encoding="utf-8"))
+    raw = _find_contexts_value(document)
+    if raw is None:
+        raise ValueError(f"{path} does not define {CONTEXTS_ENV_KEY}")
+    parsed = json.loads(raw)
+    if not isinstance(parsed, list) or not all(isinstance(item, str) for item in parsed):
+        raise ValueError(f"{path} {CONTEXTS_ENV_KEY} must be a JSON list of strings")
+    contexts = [item for item in parsed if item]
+    if not contexts:
+        raise ValueError(f"{path} {CONTEXTS_ENV_KEY} is empty")
+    return contexts
+
+
+def _find_contexts_value(document: object) -> str | None:
+    """Return the raw contexts JSON from any ``env:`` block in the document."""
+    if isinstance(document, dict):
+        for key, value in document.items():
+            if key == CONTEXTS_ENV_KEY and isinstance(value, str):
+                return value
+            found = _find_contexts_value(value)
+            if found is not None:
+                return found
+    elif isinstance(document, list):
+        for item in document:
+            found = _find_contexts_value(item)
+            if found is not None:
+                return found
+    return None
+
+
+def classify(required: list[str], check_runs: list[dict[str, Any]], sha: str = "") -> PresenceReport:
+    """Classify each required context against the commit's check-runs."""
+    by_name: dict[str, list[dict[str, Any]]] = {}
+    for run in check_runs:
+        name = run.get("name")
+        if isinstance(name, str):
+            by_name.setdefault(name, []).append(run)
+
+    states: list[ContextState] = []
+    for context in required:
+        runs = by_name.get(context)
+        if not runs:
+            states.append(ContextState(context, MISSING, "no check-run with this name on the commit"))
+            continue
+        run = runs[-1]
+        status = str(run.get("status", ""))
+        conclusion = str(run.get("conclusion") or "")
+        if status != "completed":
+            states.append(ContextState(context, PENDING, f"status={status or 'unknown'}"))
+        elif conclusion in _FAILING_CONCLUSIONS:
+            states.append(ContextState(context, FAILING, f"conclusion={conclusion}"))
+        elif conclusion == SKIPPED:
+            states.append(ContextState(context, SKIPPED, "conclusion=skipped"))
+        elif conclusion in _PASSING_CONCLUSIONS:
+            states.append(ContextState(context, PASSING, f"conclusion={conclusion}"))
+        else:
+            states.append(ContextState(context, PENDING, f"conclusion={conclusion or 'unknown'}"))
+    return PresenceReport(sha=sha, states=tuple(states))
+
+
+def summary_line(report: PresenceReport) -> str:
+    """Return the one-line verdict a reader needs."""
+    if report.missing:
+        names = ", ".join(state.name for state in report.missing)
+        return f"{len(report.missing)} required context(s) never ran on {report.sha or 'the commit'}: {names}"
+    failing = [state for state in report.states if state.state == FAILING]
+    if failing:
+        return f"all required contexts present; {len(failing)} failing"
+    pending = [state for state in report.states if state.state == PENDING]
+    if pending:
+        return f"all required contexts present; {len(pending)} still running"
+    return "all required contexts present and completed"
+
+
+def _gh(args: list[str]) -> str:
+    """Run a ``gh`` command and return stdout."""
+    try:
+        result = subprocess.run(["gh", *args], capture_output=True, text=True, check=True)
+    except FileNotFoundError as exc:
+        raise RuntimeError("the GitHub CLI (gh) is required to fetch check-runs") from exc
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(exc.stderr.strip() or f"gh {' '.join(args)} failed") from exc
+    return result.stdout
+
+
+def resolve_pr_head(pr: str, repo: str | None) -> str:
+    """Return the head commit SHA of a pull request."""
+    args = ["pr", "view", pr, "--json", "headRefOid"]
+    if repo:
+        args += ["--repo", repo]
+    payload = json.loads(_gh(args))
+    head = payload.get("headRefOid")
+    if not isinstance(head, str) or not head:
+        raise RuntimeError(f"could not resolve the head commit of PR {pr}")
+    return head
+
+
+def fetch_check_runs(sha: str, repo: str | None) -> list[dict[str, Any]]:
+    """Return every check-run recorded against a commit."""
+    slug = repo or "{owner}/{repo}"
+    endpoint = f"repos/{slug}/commits/{sha}/check-runs?per_page=100"
+    output = _gh(["api", "--paginate", endpoint, "--jq", ".check_runs[]"])
+    runs: list[dict[str, Any]] = []
+    for line in output.splitlines():
+        if not line.strip():
+            continue
+        entry = json.loads(line)
+        if isinstance(entry, dict):
+            runs.append(entry)
+    return runs
+
+
+def _load_check_runs_file(path: str) -> list[dict[str, Any]]:
+    """Read check-runs from a file (or stdin), accepting the API or list shape."""
+    raw = sys.stdin.read() if path == "-" else Path(path).read_text(encoding="utf-8")
+    payload = json.loads(raw)
+    if isinstance(payload, dict):
+        payload = payload.get("check_runs", [])
+    if not isinstance(payload, list):
+        raise ValueError("check-runs input must be a list or an object with check_runs")
+    return [entry for entry in payload if isinstance(entry, dict)]
+
+
+def _print_report(report: PresenceReport) -> None:
+    """Print the per-context table and the verdict."""
+    print(f"Required-context presence on {report.sha or 'commit'}:")
+    for state in report.states:
+        marker = "x" if state.state == MISSING else "-"
+        print(f"  {marker} {state.name}: {state.state} ({state.detail})")
+    print(summary_line(report))
+    for state in report.missing:
+        print(
+            f"::error title=Required context never ran::{state.name} has no check-run on "
+            f"{report.sha or 'the head commit'}. A green PR page here means the context was "
+            f"never evaluated, not that it passed."
+        )
+
+
+def main() -> int:
+    """Entry point: report required contexts absent from a commit."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    target = parser.add_mutually_exclusive_group(required=True)
+    target.add_argument("--sha", help="Commit SHA to inspect")
+    target.add_argument("--pr", help="Pull request number; its head commit is inspected")
+    parser.add_argument("--repo", help="OWNER/REPO (defaults to the current repository)")
+    parser.add_argument("--check-runs", help="Read check-runs from a JSON file instead of the API ('-' for stdin)")
+    parser.add_argument("--json", action="store_true", help="Emit the report as JSON")
+    args = parser.parse_args()
+
+    required = read_required_contexts()
+    sha = args.sha or resolve_pr_head(args.pr, args.repo)
+    check_runs = _load_check_runs_file(args.check_runs) if args.check_runs else fetch_check_runs(sha, args.repo)
+    report = classify(required, check_runs, sha=sha)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "sha": report.sha,
+                    "required": required,
+                    "states": [
+                        {"name": state.name, "state": state.state, "detail": state.detail} for state in report.states
+                    ],
+                    "missing": [state.name for state in report.missing],
+                    "summary": summary_line(report),
+                },
+                indent=2,
+            )
+        )
+    else:
+        _print_report(report)
+    return 0 if report.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_test_collection.py
+++ b/scripts/check_test_collection.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""Report test files that no CI configuration collects.
+
+A test file that no workflow ever hands to pytest is indistinguishable, from
+the outside, from a test file that passes: the suite is green because the file
+was never opened. This script derives the set of test files CI actually
+collects from the workflow definitions themselves and reports anything left
+over.
+
+Derivation (no hardcoded copy of the CI layout):
+
+* every ``run:`` body in ``.github/workflows/*.yml`` is scanned for ``pytest``
+  and ``scripts/run_tests.py`` invocations;
+* a ``run_tests.py`` invocation collects ``<--test-dir>/**/test_*.py``, with
+  the default directory read from ``scripts/run_tests.DEFAULT_TEST_DIR`` -
+  that is the same constant argparse uses, so the two cannot drift;
+* a ``run_tests.py --affected`` invocation collects the impact-analysis
+  universe, read from ``scripts/test_impact.TEST_DIRS``;
+* a ``pytest`` invocation collects every ``tests/...`` path token it is given,
+  expanded with pytest's own ``python_files`` patterns when the token is a
+  directory.
+
+Two deliberately conservative rules:
+
+* an invocation narrowed by ``-k``/``--keyword`` is ignored - it runs a subset
+  the expression decides, so it cannot be credited with a whole directory;
+* a marker-narrowed invocation (``-m``) is credited, because collection still
+  walks the directory and the marker only deselects.
+
+Anything not collected must appear in ``ALLOWLIST`` with a reason. A stale
+allowlist entry (one that matches no file) is reported too, so the list cannot
+quietly outlive the file it excused.
+
+Usage::
+
+    python scripts/check_test_collection.py           # human-readable report
+    python scripts/check_test_collection.py --json    # machine-readable
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import re
+import shlex
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+TESTS_DIR = REPO_ROOT / "tests"
+
+# pytest's default ``python_files``; pyproject.toml does not override it, so a
+# directory handed to pytest collects both shapes.
+PYTEST_FILE_PATTERNS = ("test_*.py", "*_test.py")
+# scripts/run_tests.py discovers with rglob("test_*.py") - a ``*_test.py`` file
+# under a run_tests.py directory is NOT executed by the shards.
+RUN_TESTS_FILE_PATTERN = "test_*.py"
+
+# Test files no CI configuration collects, each with the reason it is excused.
+# A key is either a repo-relative file path or a directory prefix ending in
+# "/". Directory entries excuse a whole suite that is deliberately operated by
+# hand; file entries excuse a single file and are expected to disappear as the
+# file is relocated under a collected directory.
+#
+# Adding an entry is a decision to let a test never run. Prefer moving the file
+# into tests/unit/ or tests/integration/, or naming it in a workflow.
+ALLOWLIST: dict[str, str] = {
+    # --- Deliberately not run in CI -------------------------------------
+    "tests/chaos/": (
+        "Chaos suite: kills and restarts real server processes and simulates "
+        "disk-full/OOM conditions. Operated on demand, not from the PR lane."
+    ),
+    "tests/perf/": (
+        "Wall-clock performance smoke; thresholds are not meaningful on shared "
+        "runners. Run on demand (ADR-009 section 12.5)."
+    ),
+    # --- Not collected today; relocation tracked separately ---------------
+    "tests/test_worktree.py": (
+        "Sits at the tests/ root, so no shard collects it. Relocation into tests/unit/ is tracked in #3026."
+    ),
+    "tests/test_server.py": ("Sits at the tests/ root, so no shard collects it. Pending relocation into tests/unit/."),
+    "tests/test_evolution_e2e.py": (
+        "Sits at the tests/ root, so no shard collects it. Pending relocation into tests/integration/."
+    ),
+    "tests/endpoints/test_certify_verify.py": (
+        "tests/endpoints/ is outside every shard directory. Pending relocation into tests/unit/endpoints/."
+    ),
+    "tests/observability/test_gate.py": (
+        "tests/observability/ is outside every shard directory. Pending relocation into tests/unit/observability/."
+    ),
+    "tests/plugins/test_background_hooks.py": (
+        "tests/plugins/ is outside every shard directory. Pending relocation into tests/unit/plugins/."
+    ),
+    "tests/security/test_lineage_adversarial.py": (
+        "tests/security/ is outside every shard directory. Pending relocation into tests/unit/security/."
+    ),
+}
+
+
+@dataclass
+class Invocation:
+    """One test-running command found in a workflow ``run:`` body."""
+
+    workflow: str
+    kind: str
+    paths: tuple[str, ...]
+    patterns: tuple[str, ...]
+
+
+@dataclass
+class CollectionReport:
+    """Outcome of comparing the tests tree against the CI-derived set."""
+
+    collected: dict[str, set[str]] = field(default_factory=dict)
+    uncollected: list[str] = field(default_factory=list)
+    allowlisted: dict[str, str] = field(default_factory=dict)
+    stale_allowlist: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        """True when nothing is uncollected and no allowlist entry is stale."""
+        return not self.uncollected and not self.stale_allowlist
+
+
+def _load_yaml() -> Any:
+    try:
+        import yaml
+    except ModuleNotFoundError as exc:  # pragma: no cover - dev env has pyyaml
+        raise RuntimeError("pyyaml is required to read the workflow definitions") from exc
+    return yaml
+
+
+def _import_script(name: str) -> Any:
+    """Import a module from ``scripts/`` so constants are read, not copied.
+
+    Loaded under a private module name so this never collides with a test
+    module of the same stem in the running interpreter.
+    """
+    alias = f"_ci_collection_{name}"
+    cached = sys.modules.get(alias)
+    if cached is not None:
+        return cached
+    scripts_dir = str(REPO_ROOT / "scripts")
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+    spec = importlib.util.spec_from_file_location(alias, REPO_ROOT / "scripts" / f"{name}.py")
+    if spec is None or spec.loader is None:  # pragma: no cover - path is in-tree
+        raise RuntimeError(f"cannot load scripts/{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[alias] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def default_test_dir() -> str:
+    """Return the directory ``run_tests.py`` discovers when no flag is given."""
+    run_tests = _import_script("run_tests")
+    return str(run_tests.DEFAULT_TEST_DIR)
+
+
+def affected_test_dirs() -> tuple[str, ...]:
+    """Return the directories the impact analyser can select tests from."""
+    test_impact = _import_script("test_impact")
+    dirs: list[str] = []
+    for entry in test_impact.TEST_DIRS:
+        path = Path(entry)
+        rel = path.relative_to(REPO_ROOT) if path.is_absolute() else path
+        dirs.append(rel.as_posix())
+    return tuple(dirs)
+
+
+def iter_test_files() -> list[str]:
+    """Return every repo-relative test file under ``tests/``, sorted."""
+    found: set[str] = set()
+    for pattern in PYTEST_FILE_PATTERNS:
+        for path in TESTS_DIR.rglob(pattern):
+            if path.is_file():
+                found.add(path.relative_to(REPO_ROOT).as_posix())
+    return sorted(found)
+
+
+def _join_continuations(body: str) -> str:
+    """Collapse POSIX ``\\`` and PowerShell `````` line continuations."""
+    body = re.sub(r"\\\s*\n\s*", " ", body)
+    return re.sub(r"`\s*\n\s*", " ", body)
+
+
+def _split_commands(body: str) -> list[str]:
+    """Split a run body into individual commands."""
+    normalised = _join_continuations(body)
+    return [part for part in re.split(r"[\n;]|&&|\|\||\|", normalised) if part.strip()]
+
+
+def _tokenise(command: str) -> list[str]:
+    """Tokenise a command, tolerating GitHub expression syntax and quoting."""
+    try:
+        tokens = shlex.split(command, posix=True)
+    except ValueError:
+        tokens = command.split()
+    return [token.strip("`'\"") for token in tokens if token.strip("`'\"")]
+
+
+def _test_path_tokens(tokens: list[str]) -> list[str]:
+    """Return the ``tests/...`` path arguments in a token list."""
+    paths: list[str] = []
+    for token in tokens:
+        if not token.startswith("tests/") and token != "tests":
+            continue
+        if "$" in token or "*" in token:
+            continue
+        paths.append(token.rstrip("/.,"))
+    return paths
+
+
+def _has_keyword_filter(tokens: list[str]) -> bool:
+    """True when the invocation is narrowed by a ``-k`` expression."""
+    return any(token in {"-k", "--keyword"} or token.startswith("--keyword=") for token in tokens)
+
+
+def _test_dir_argument(tokens: list[str]) -> str | None:
+    """Return the explicit ``--test-dir`` value, if the invocation has one."""
+    for index, token in enumerate(tokens):
+        if token == "--test-dir" and index + 1 < len(tokens):
+            return tokens[index + 1]
+        if token.startswith("--test-dir="):
+            return token.split("=", 1)[1]
+    return None
+
+
+def parse_command(workflow: str, command: str) -> Invocation | None:
+    """Return the collection an individual command performs, if it runs tests."""
+    if "run_tests.py" not in command and not re.search(r"(?<![\w-])pytest(?![\w-])", command):
+        return None
+    tokens = _tokenise(command)
+    if not tokens or _has_keyword_filter(tokens):
+        return None
+
+    if any(token.endswith("run_tests.py") for token in tokens):
+        paths: list[str] = []
+        explicit = _test_dir_argument(tokens)
+        paths.append(explicit if explicit is not None else default_test_dir())
+        if any(token == "--affected" or token.startswith("--affected=") for token in tokens):
+            paths.extend(affected_test_dirs())
+        return Invocation(workflow, "run_tests", tuple(paths), (RUN_TESTS_FILE_PATTERN,))
+
+    paths = _test_path_tokens(tokens)
+    if not paths:
+        return None
+    return Invocation(workflow, "pytest", tuple(paths), PYTEST_FILE_PATTERNS)
+
+
+def iter_invocations() -> list[Invocation]:
+    """Return every test-running invocation declared by a workflow."""
+    yaml = _load_yaml()
+    invocations: list[Invocation] = []
+    for workflow_path in sorted(WORKFLOWS_DIR.glob("*.yml")):
+        document = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+        if not isinstance(document, dict):
+            continue
+        jobs = document.get("jobs")
+        if not isinstance(jobs, dict):
+            continue
+        name = workflow_path.name
+        for job in jobs.values():
+            if not isinstance(job, dict):
+                continue
+            steps = job.get("steps")
+            if not isinstance(steps, list):
+                continue
+            for step in steps:
+                if not isinstance(step, dict):
+                    continue
+                run_body = step.get("run")
+                if not isinstance(run_body, str):
+                    continue
+                for command in _split_commands(run_body):
+                    invocation = parse_command(name, command)
+                    if invocation is not None:
+                        invocations.append(invocation)
+    return invocations
+
+
+def _expand(invocation: Invocation) -> set[str]:
+    """Expand one invocation into the repo-relative files it collects."""
+    files: set[str] = set()
+    for raw in invocation.paths:
+        target = REPO_ROOT / raw
+        if target.is_file():
+            files.add(target.relative_to(REPO_ROOT).as_posix())
+            continue
+        if not target.is_dir():
+            continue
+        for pattern in invocation.patterns:
+            for path in target.rglob(pattern):
+                if path.is_file():
+                    files.add(path.relative_to(REPO_ROOT).as_posix())
+    return files
+
+
+def _allowlist_reason(rel_path: str, allowlist: dict[str, str]) -> str | None:
+    """Return the reason excusing ``rel_path``, or None when it is not excused."""
+    if rel_path in allowlist:
+        return allowlist[rel_path]
+    for key, reason in allowlist.items():
+        if key.endswith("/") and rel_path.startswith(key):
+            return reason
+    return None
+
+
+def build_report(allowlist: dict[str, str] | None = None) -> CollectionReport:
+    """Compare the tests tree against the CI-derived collected set."""
+    entries = ALLOWLIST if allowlist is None else allowlist
+    collected: dict[str, set[str]] = {}
+    for invocation in iter_invocations():
+        for rel_path in _expand(invocation):
+            collected.setdefault(rel_path, set()).add(invocation.workflow)
+
+    report = CollectionReport(collected=collected)
+    used: set[str] = set()
+    for rel_path in iter_test_files():
+        if rel_path in collected:
+            continue
+        reason = _allowlist_reason(rel_path, entries)
+        if reason is None:
+            report.uncollected.append(rel_path)
+            continue
+        report.allowlisted[rel_path] = reason
+        for key in entries:
+            if key == rel_path or (key.endswith("/") and rel_path.startswith(key)):
+                used.add(key)
+    report.stale_allowlist = sorted(set(entries) - used)
+    return report
+
+
+def _print_report(report: CollectionReport) -> None:
+    """Print a human-readable summary of the collection report."""
+    print(f"Test files collected by CI: {len(report.collected)}")
+    print(f"Allowlisted (not collected): {len(report.allowlisted)}")
+    for rel_path, reason in sorted(report.allowlisted.items()):
+        print(f"  - {rel_path}: {reason}")
+    if report.stale_allowlist:
+        print(f"Stale allowlist entries: {len(report.stale_allowlist)}")
+        for key in report.stale_allowlist:
+            print(f"  ! {key} matches no test file - remove it")
+    if report.uncollected:
+        print(f"Uncollected test files: {len(report.uncollected)}")
+        for rel_path in report.uncollected:
+            print(f"  x {rel_path}")
+    else:
+        print("Uncollected test files: 0")
+
+
+def main() -> int:
+    """Entry point: report uncollected test files, non-zero when any exist."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="Emit the report as JSON")
+    args = parser.parse_args()
+
+    report = build_report()
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "collected": {path: sorted(sources) for path, sources in sorted(report.collected.items())},
+                    "uncollected": report.uncollected,
+                    "allowlisted": report.allowlisted,
+                    "stale_allowlist": report.stale_allowlist,
+                },
+                indent=2,
+            )
+        )
+    else:
+        _print_report(report)
+    return 0 if report.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_test_collection.py
+++ b/scripts/check_test_collection.py
@@ -87,7 +87,8 @@ ALLOWLIST: dict[str, str] = {
         "Sits at the tests/ root, so no shard collects it. Pending relocation into tests/integration/."
     ),
     "tests/endpoints/test_certify_verify.py": (
-        "tests/endpoints/ is outside every shard directory. Pending relocation into tests/unit/endpoints/."
+        "tests/endpoints/ is outside every shard directory. Binds a loopback HTTP "
+        "server, so relocation into tests/integration/ is pending."
     ),
     "tests/observability/test_gate.py": (
         "tests/observability/ is outside every shard directory. Pending relocation into tests/unit/observability/."

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -36,6 +36,11 @@ _TEST_REQUIRED_PREFIXES = (
 DEFAULT_TEST_FILE_TIMEOUT_SECONDS = 300
 TEST_FILE_TIMEOUT_ENV = "BERNSTEIN_TEST_FILE_TIMEOUT_SECONDS"
 
+# Directory discovered when no ``--test-dir`` is passed. The CI shards rely on
+# this default, and scripts/check_test_collection.py reads this constant to
+# derive what the shards collect, so the two cannot drift apart.
+DEFAULT_TEST_DIR = "tests/unit"
+
 # A heavily-parallel shard can transiently exhaust the OS thread table, which
 # surfaces as this CPython error rather than a genuine test failure. A single
 # serial retry distinguishes the environmental flake from a real regression.
@@ -417,7 +422,7 @@ def main() -> None:
         default=default_workers,
         help=f"Number of parallel workers (1=sequential, default={default_workers})",
     )
-    parser.add_argument("--test-dir", default="tests/unit", help="Test directory")
+    parser.add_argument("--test-dir", default=DEFAULT_TEST_DIR, help="Test directory")
     parser.add_argument(
         "--affected",
         nargs="?",

--- a/tests/unit/scripts/test_check_required_contexts.py
+++ b/tests/unit/scripts/test_check_required_contexts.py
@@ -1,0 +1,157 @@
+"""Unit tests for ``scripts/check_required_contexts.py``.
+
+The script exists to separate two states that produce an identical zero in the
+PR failure histogram: every required context passed, and a required context
+never ran. These tests pin that classification and the fact that the required
+context list is read from the in-tree canary rather than restated here.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check_required_contexts.py"
+
+
+@pytest.fixture(scope="module")
+def module() -> ModuleType:
+    """Load ``scripts/check_required_contexts.py`` as an importable module."""
+    spec = importlib.util.spec_from_file_location("check_required_contexts_under_test", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    loaded = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = loaded
+    spec.loader.exec_module(loaded)
+    return loaded
+
+
+def _run(name: str, status: str = "completed", conclusion: str | None = "success") -> dict[str, object]:
+    """Build a check-run payload in the shape the API returns."""
+    return {"name": name, "status": status, "conclusion": conclusion}
+
+
+def test_required_contexts_come_from_the_canary(module: ModuleType) -> None:
+    """The required list is read from the workflow the audit already trusts."""
+    contexts = module.read_required_contexts()
+    assert contexts, "the canary must define at least one required context"
+    assert "CI gate" in contexts
+
+
+def test_canary_without_the_key_is_rejected(module: ModuleType, tmp_path: Path) -> None:
+    """A canary that lost the key fails loudly instead of returning nothing."""
+    canary = tmp_path / "canary.yml"
+    canary.write_text("jobs:\n  verify:\n    steps:\n      - run: echo hi\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="does not define"):
+        module.read_required_contexts(canary)
+
+
+def test_absent_context_is_missing_not_passing(module: ModuleType) -> None:
+    """A required context with no check-run is reported as never having run."""
+    report = module.classify(["CI gate", "review-bot-ack"], [_run("review-bot-ack")], sha="abc123")
+    assert [state.name for state in report.missing] == ["CI gate"]
+    assert not report.ok
+    assert "never ran" in module.summary_line(report)
+    assert "abc123" in module.summary_line(report)
+
+
+def test_all_present_and_passing_is_ok(module: ModuleType) -> None:
+    """Everything present and green reads as such."""
+    report = module.classify(["CI gate", "review-bot-ack"], [_run("CI gate"), _run("review-bot-ack")], sha="abc123")
+    assert report.ok
+    assert module.summary_line(report) == "all required contexts present and completed"
+
+
+def test_failing_context_is_present_not_missing(module: ModuleType) -> None:
+    """A red required check is present; presence is what this script judges."""
+    report = module.classify(["CI gate"], [_run("CI gate", conclusion="failure")], sha="abc123")
+    assert report.ok, "a failing context is still present, so this guard stays quiet"
+    assert report.states[0].state == module.FAILING
+    assert "1 failing" in module.summary_line(report)
+
+
+def test_pending_context_is_present(module: ModuleType) -> None:
+    """A queued or running check is present, not absent."""
+    report = module.classify(["CI gate"], [_run("CI gate", status="in_progress", conclusion=None)], sha="abc")
+    assert report.states[0].state == module.PENDING
+    assert report.ok
+    assert "still running" in module.summary_line(report)
+
+
+def test_cancelled_context_is_failing(module: ModuleType) -> None:
+    """A cancelled run is a completed non-pass, not an absence."""
+    report = module.classify(["review-bot-ack"], [_run("review-bot-ack", conclusion="cancelled")], sha="abc")
+    assert report.states[0].state == module.FAILING
+
+
+def test_skipped_context_has_its_own_state(module: ModuleType) -> None:
+    """A skipped required job is neither a pass nor an absence."""
+    report = module.classify(["CI gate"], [_run("CI gate", conclusion="skipped")], sha="abc")
+    assert report.states[0].state == module.SKIPPED
+    assert report.ok
+
+
+def test_latest_run_of_a_repeated_name_wins(module: ModuleType) -> None:
+    """A re-run replaces the earlier attempt's verdict."""
+    runs = [_run("CI gate", conclusion="failure"), _run("CI gate", conclusion="success")]
+    report = module.classify(["CI gate"], runs, sha="abc")
+    assert report.states[0].state == module.PASSING
+
+
+def test_unrelated_check_runs_do_not_satisfy_a_context(module: ModuleType) -> None:
+    """A commit full of green checks can still be missing the required one."""
+    runs = [_run(f"Test (ubuntu-latest, Python 3.13, shard {index})") for index in range(1, 5)]
+    report = module.classify(["CI gate"], runs, sha="abc")
+    assert [state.name for state in report.missing] == ["CI gate"]
+
+
+def test_check_runs_file_accepts_both_shapes(module: ModuleType, tmp_path: Path) -> None:
+    """The offline input reads the raw API object and a plain list alike."""
+    api_shape = tmp_path / "api.json"
+    api_shape.write_text(json.dumps({"check_runs": [_run("CI gate")]}), encoding="utf-8")
+    list_shape = tmp_path / "list.json"
+    list_shape.write_text(json.dumps([_run("CI gate")]), encoding="utf-8")
+
+    assert module._load_check_runs_file(str(api_shape)) == [_run("CI gate")]
+    assert module._load_check_runs_file(str(list_shape)) == [_run("CI gate")]
+
+
+def test_cli_reports_missing_context_and_exits_non_zero(
+    module: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """End to end: an absent required context exits non-zero and says why."""
+    runs = tmp_path / "runs.json"
+    runs.write_text(json.dumps({"check_runs": [_run("review-bot-ack")]}), encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", ["check_required_contexts.py", "--sha", "deadbeef", "--check-runs", str(runs)])
+
+    exit_code = module.main()
+    captured = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "CI gate: missing" in captured
+    assert "::error title=Required context never ran::" in captured
+    assert "deadbeef" in captured
+
+
+def test_cli_is_quiet_when_every_context_is_present(
+    module: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A commit carrying every required context exits zero."""
+    present = [_run(name) for name in module.read_required_contexts()]
+    runs = tmp_path / "runs.json"
+    runs.write_text(json.dumps({"check_runs": present}), encoding="utf-8")
+    monkeypatch.setattr(
+        sys, "argv", ["check_required_contexts.py", "--sha", "deadbeef", "--check-runs", str(runs), "--json"]
+    )
+
+    exit_code = module.main()
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["missing"] == []
+    assert payload["sha"] == "deadbeef"

--- a/tests/unit/scripts/test_check_test_collection.py
+++ b/tests/unit/scripts/test_check_test_collection.py
@@ -1,0 +1,217 @@
+"""Collection-completeness guard for the test tree.
+
+A test file that no CI configuration ever hands to pytest produces the same
+signal as a passing one: the suite is green because the file was never opened.
+``scripts/check_test_collection.py`` derives the collected set from the
+workflow definitions and the shard runner's own constants; this module runs
+that derivation against the repository and pins the parser behaviour it
+depends on.
+
+The repository-level assertions are the guard proper:
+
+- every test file under ``tests/`` is either collected by some workflow or
+  carries an allowlist entry explaining why it is not;
+- no allowlist entry outlives the file it excuses;
+- with the allowlist emptied the report is non-empty, so a parser that
+  silently started collecting everything cannot pass this file.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check_test_collection.py"
+
+
+@pytest.fixture(scope="module")
+def check_module() -> ModuleType:
+    """Load ``scripts/check_test_collection.py`` as an importable module."""
+    spec = importlib.util.spec_from_file_location("check_test_collection_under_test", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def report(check_module: ModuleType) -> object:
+    """Build the collection report once for the repository-level assertions."""
+    return check_module.build_report()
+
+
+# ---------------------------------------------------------------------------
+# Repository-level guard
+# ---------------------------------------------------------------------------
+
+
+def test_every_test_file_is_collected_or_allowlisted(report: object) -> None:
+    """No test file may sit outside both the collected set and the allowlist."""
+    uncollected = report.uncollected  # type: ignore[attr-defined]
+    assert uncollected == [], (
+        "These test files are never collected by any CI configuration, so they "
+        "cannot fail a build. Move each one under a collected directory "
+        "(tests/unit/ or tests/integration/), name it in a workflow, or add an "
+        "entry with a reason to ALLOWLIST in scripts/check_test_collection.py:\n  " + "\n  ".join(uncollected)
+    )
+
+
+def test_allowlist_entries_are_all_live(report: object) -> None:
+    """An allowlist entry that matches no file must be removed."""
+    stale = report.stale_allowlist  # type: ignore[attr-defined]
+    assert stale == [], (
+        "These ALLOWLIST entries in scripts/check_test_collection.py no longer "
+        "match an uncollected test file and must be deleted:\n  " + "\n  ".join(stale)
+    )
+
+
+def test_allowlist_entries_carry_a_reason(check_module: ModuleType) -> None:
+    """Every excused path states why it is excused."""
+    for key, reason in check_module.ALLOWLIST.items():
+        assert reason.strip(), f"ALLOWLIST entry {key!r} has no reason"
+        assert len(reason.strip()) >= 30, f"ALLOWLIST entry {key!r} needs a reason a reader can act on"
+
+
+def test_guard_fails_when_the_allowlist_is_empty(check_module: ModuleType) -> None:
+    """The derivation must discriminate: without excuses, gaps are reported."""
+    unexcused = check_module.build_report(allowlist={})
+    assert unexcused.uncollected, "with an empty allowlist the report must list the uncollected files"
+    gaps = set(unexcused.uncollected)
+    for key in check_module.ALLOWLIST:
+        matched = any(path.startswith(key) for path in gaps) if key.endswith("/") else key in gaps
+        assert matched, f"allowlist entry {key!r} should surface as uncollected once the allowlist is dropped"
+
+
+def test_stale_entries_are_detected(check_module: ModuleType) -> None:
+    """An entry pointing at a collected file is reported as stale."""
+    fabricated = {"tests/unit/test_does_not_exist_anywhere.py": "x" * 40}
+    stale_report = check_module.build_report(allowlist=fabricated)
+    assert "tests/unit/test_does_not_exist_anywhere.py" in stale_report.stale_allowlist
+
+
+def test_collected_set_discriminates(report: object, check_module: ModuleType) -> None:
+    """The shard directory is collected; an excused suite is not."""
+    collected = report.collected  # type: ignore[attr-defined]
+    assert "tests/unit/scripts/test_check_test_collection.py" in collected, (
+        "this guard must itself be collected by the shards"
+    )
+    assert not any(path.startswith("tests/chaos/") for path in collected)
+    assert check_module.default_test_dir() == "tests/unit"
+
+
+def test_shard_directory_comes_from_the_runner_constant(check_module: ModuleType) -> None:
+    """The default shard directory is read from the runner, never duplicated."""
+    run_tests = check_module._import_script("run_tests")
+    assert check_module.default_test_dir() == run_tests.DEFAULT_TEST_DIR
+
+
+def test_affected_universe_comes_from_the_impact_analyser(check_module: ModuleType) -> None:
+    """The affected-run universe is read from the impact analyser's own list."""
+    dirs = check_module.affected_test_dirs()
+    assert "tests/unit" in dirs
+    assert "tests/integration" in dirs
+
+
+# ---------------------------------------------------------------------------
+# Parser behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_run_tests_without_flags_collects_the_default_directory(check_module: ModuleType) -> None:
+    """A bare shard invocation collects the runner's default directory."""
+    invocation = check_module.parse_command("ci.yml", "uv run python scripts/run_tests.py --parallel 4 --shard 1/4")
+    assert invocation is not None
+    assert invocation.kind == "run_tests"
+    assert invocation.paths == ("tests/unit",)
+    assert invocation.patterns == ("test_*.py",)
+
+
+def test_run_tests_honours_an_explicit_test_dir(check_module: ModuleType) -> None:
+    """``--test-dir`` overrides the default directory."""
+    invocation = check_module.parse_command("ci.yml", "python scripts/run_tests.py --test-dir tests/integration")
+    assert invocation is not None
+    assert invocation.paths == ("tests/integration",)
+
+    equals_form = check_module.parse_command("ci.yml", "python scripts/run_tests.py --test-dir=tests/property")
+    assert equals_form is not None
+    assert equals_form.paths == ("tests/property",)
+
+
+def test_affected_run_adds_the_impact_universe(check_module: ModuleType) -> None:
+    """``--affected`` can select any file the impact analyser knows about."""
+    invocation = check_module.parse_command(
+        "ci.yml", "uv run python scripts/run_tests.py --parallel 4 --affected refs/remotes/origin/main"
+    )
+    assert invocation is not None
+    assert "tests/unit" in invocation.paths
+    assert "tests/integration" in invocation.paths
+
+
+def test_keyword_filtered_runs_are_not_credited(check_module: ModuleType) -> None:
+    """A ``-k`` expression runs an unknown subset, so it credits nothing."""
+    assert check_module.parse_command("publish.yml", "uv run python scripts/run_tests.py -k release -x") is None
+    assert check_module.parse_command("ci.yml", "uv run pytest tests/unit -k adapter") is None
+
+
+def test_marker_filtered_runs_are_credited(check_module: ModuleType) -> None:
+    """A ``-m`` marker deselects after collection, so the directory counts."""
+    invocation = check_module.parse_command("nightly.yml", "uv run pytest tests/stress -m stress --no-cov -q")
+    assert invocation is not None
+    assert invocation.paths == ("tests/stress",)
+
+
+def test_pytest_paths_are_extracted(check_module: ModuleType) -> None:
+    """Explicit pytest path arguments are collected with pytest's patterns."""
+    invocation = check_module.parse_command(
+        "pentest.yml", "uv run pytest tests/pentest/test_api_security.py -v --timeout=120"
+    )
+    assert invocation is not None
+    assert invocation.kind == "pytest"
+    assert invocation.paths == ("tests/pentest/test_api_security.py",)
+    assert invocation.patterns == ("test_*.py", "*_test.py")
+
+
+def test_non_test_commands_are_ignored(check_module: ModuleType) -> None:
+    """Commands that run no tests contribute nothing."""
+    assert check_module.parse_command("ci.yml", "uv run ruff check src tests") is None
+    assert check_module.parse_command("ci.yml", 'echo "pytest_exit_code=$rc"') is None
+    assert check_module.parse_command("ci.yml", "uv run pytest --version") is None
+
+
+def test_line_continuations_are_joined(check_module: ModuleType) -> None:
+    """POSIX and PowerShell continuations keep a command in one piece."""
+    posix = check_module._split_commands("uv run pytest \\\n  tests/integration/test_airgap_wheelhouse.py \\\n  -x")
+    assert len(posix) == 1
+    invocation = check_module.parse_command("airgap.yml", posix[0])
+    assert invocation is not None
+    assert invocation.paths == ("tests/integration/test_airgap_wheelhouse.py",)
+
+    pwsh = check_module._split_commands("uv run pytest `\n  tests/unit/test_worktree_isolation_windows.py `\n  -x -q")
+    assert len(pwsh) == 1
+    windows = check_module.parse_command("ci.yml", pwsh[0])
+    assert windows is not None
+    assert windows.paths == ("tests/unit/test_worktree_isolation_windows.py",)
+
+
+def test_commands_are_split_on_shell_separators(check_module: ModuleType) -> None:
+    """Chained commands are inspected individually."""
+    parts = check_module._split_commands("set -euo pipefail\nuv run pytest tests/snapshot/ -q | tee out.log")
+    assert any("tests/snapshot/" in part for part in parts)
+    invocation = next(
+        result for result in (check_module.parse_command("ci.yml", part) for part in parts) if result is not None
+    )
+    assert invocation.paths == ("tests/snapshot",)
+
+
+def test_allowlist_matching_supports_files_and_directories(check_module: ModuleType) -> None:
+    """A trailing slash excuses a whole suite; a plain path excuses one file."""
+    allowlist = {"tests/chaos/": "y" * 40, "tests/test_server.py": "z" * 40}
+    assert check_module._allowlist_reason("tests/chaos/test_disk_full.py", allowlist) == "y" * 40
+    assert check_module._allowlist_reason("tests/test_server.py", allowlist) == "z" * 40
+    assert check_module._allowlist_reason("tests/unit/test_anything.py", allowlist) is None


### PR DESCRIPTION
Closes #3032

## What

Three guards that make "the gate never evaluated this" visible, instead of it reading as a pass. Guards only: no new required contexts, no branch-protection or ruleset edits, no change to how any existing PR is gated.

### 1. Collection completeness

`scripts/check_test_collection.py` walks `tests/` and reports every test file that no CI configuration collects. The collected set is derived from the real configuration rather than restated:

| Source | Contributes |
|---|---|
| `run:` bodies in `.github/workflows/*.yml` | Every `pytest` / `run_tests.py` invocation |
| `scripts/run_tests.py::DEFAULT_TEST_DIR` | The directory the shards discover with no `--test-dir` |
| `scripts/test_impact.py::TEST_DIRS` | The universe an `--affected` run can select from |

Rules: a `run_tests.py` directory collects `test_*.py` only (its own `rglob` pattern), a `pytest` directory collects pytest's `python_files` patterns, a `-k`-narrowed invocation credits nothing, a `-m`-narrowed one credits the path.

`tests/unit/scripts/test_check_test_collection.py` runs the derivation inside the shards, so a test file added where no shard reaches now fails CI. Deliberate exclusions live in the script's `ALLOWLIST`, each with a reason; an entry that stops matching a file is reported as stale and must be removed.

### 2. Required-context presence

`scripts/check_required_contexts.py` classifies each required context on a commit as `missing` / `pending` / `failing` / `skipped` / `passing`, so "0 failures because everything passed" is distinguishable from "0 failures because nothing ran". Exit status is non-zero only for `missing`.

The required list is read from `.github/workflows/required-check-canary.yml` (`BRANCH_PROTECTION_CONTEXTS_JSON`) - the same in-tree source the scheduled branch-protection audit compares live settings against. The script reads check-runs only.

```bash
uv run python scripts/check_required_contexts.py --pr 1234
uv run python scripts/check_required_contexts.py --sha "$GITHUB_SHA" --json
```

It also runs as an advisory (`continue-on-error`) step in `pr-observability-summary.yml`, which is opt-in via the `deep-review` label or `workflow_dispatch`, so no PR gains a new blocking surface.

### 3. Type-scope honesty

`docs/operations/type-check-scope.md` records which paths each blocking type job covers (`mypy.gate.ini`, `pyrightconfig.strict.json`), what the `|| true` runs cover, and how a path is promoted. The advisory mypy and pyright steps now print their scope and error count as explicit numbers in the job summary, so drift in the advisory backlog is observable.

## Uncollected test files found

The guard passes today by allowlisting exactly what exists, with reasons. Nothing in these files is modified here.

| Path | Triage |
|---|---|
| `tests/chaos/` (11 files) | Genuinely excluded - restarts real server processes, simulates disk-full / OOM |
| `tests/perf/test_n1_elimination.py` | Genuinely excluded - wall-clock thresholds, unreliable on shared runners |
| `tests/test_worktree.py` | Should be collected - relocation tracked in #3026 |
| `tests/test_server.py` | Should be collected - ASGI round-trip test at the `tests/` root |
| `tests/test_evolution_e2e.py` | Should be collected - end-to-end test at the `tests/` root |
| `tests/endpoints/test_certify_verify.py` | Should be collected - directory sits outside every shard; binds a loopback server, so `tests/integration/` is the destination |
| `tests/observability/test_gate.py` | Should be collected - unit test, directory sits outside every shard |
| `tests/plugins/test_background_hooks.py` | Should be collected - unit test, directory sits outside every shard |
| `tests/security/test_lineage_adversarial.py` | Should be collected - adversarial lineage coverage (ADR-009 section 12.6) |

The seven "should be collected" files need relocation under `tests/unit/` or `tests/integration/`; each will already have an `ALLOWLIST` entry to delete when it moves.

## Workflow changes

Both are advisory reporting only; `docs/operations/ci-topology.md` is regenerated in the same commit.

| File | Change |
|---|---|
| `ci.yml` | `Run pyright (advisory)` and the mypy parse step report scope + error count into the job summary |
| `pr-observability-summary.yml` | New `continue-on-error` step running the required-context report; job gains `checks: read` |

## Verification

```
tests/unit/scripts/test_check_test_collection.py          18 passed
tests/unit/scripts/test_check_required_contexts.py        13 passed
tests/unit/test_ci_advisory_reports_workflow_yaml.py
tests/unit/test_workflow_uv_installers_yaml.py
tests/unit/scripts/test_run_tests_sharding.py
tests/unit/test_workflow_topology_report.py
tests/unit/test_required_check_canary_workflow_yaml.py    107 passed (combined)
tests/unit/test_merge_queue_runbook_docs.py
tests/unit/test_post_ci_dispatcher_yaml.py                39 passed (combined)
```

`actionlint`, `typos`, `ruff check`, `ruff format --check` and `gen_workflow_topology.py --check` are clean. The required-context script was also smoke-tested against a live PR head.
