### PR TITLE
fix(security): derive agent task-scope enforcement from the task route table

### DIFF
--- a/docs/operations/security-and-identity.md
+++ b/docs/operations/security-and-identity.md
@@ -89,7 +89,11 @@ rejected.
    so a task route added later is covered without editing the middleware;
    the only exemptions are the collection routes under `/tasks/`
    (`TASK_COLLECTION_SEGMENTS` in `auth_middleware.py`), which address the
-   collection rather than one task.
+   collection rather than one task. The two collection routes that name
+   existing tasks in their request body (`/tasks/batch-ops`,
+   `/tasks/claim-batch`) apply the same rule at the handler via
+   `enforce_agent_task_scope_for_ids`, so an identity is bound to the same
+   tasks whether the id arrives in the path or in the body.
 4. Returns `JSONResponse(401)` on any verification failure.
 
 **Revocation.**

--- a/docs/operations/security-and-identity.md
+++ b/docs/operations/security-and-identity.md
@@ -83,18 +83,29 @@ rejected.
    expiry.
 3. Resolves the user (operator) or identity (agent), populates
    `request.state.user` / `request.state.identity`, and enforces
-   `task_ids` scoping on every mutating request that addresses a single
-   task - `/tasks/{id}` and anything below it, plus the `/api/v1` mirror.
-   The check is deny-by-default rather than an allowlist of action names,
-   so a task route added later is covered without editing the middleware;
-   the only exemptions are the collection routes under `/tasks/`
-   (`TASK_COLLECTION_SEGMENTS` in `auth_middleware.py`), which address the
-   collection rather than one task. The two collection routes that name
-   existing tasks in their request body (`/tasks/batch-ops`,
-   `/tasks/claim-batch`) apply the same rule at the handler via
-   `enforce_agent_task_scope_for_ids`, so an identity is bound to the same
-   tasks whether the id arrives in the path or in the body.
+   `task_ids` scoping on every mutating request. The rule is applied to the
+   task the request acts on, not to a list of blessed URLs, so it holds
+   wherever that id comes from (see the table below).
 4. Returns `JSONResponse(401)` on any verification failure.
+
+**Where the task id comes from.** A rule enforced on only some of these is
+enforced on an arbitrary subset, so all of them are covered:
+
+| How the request names a task | Enforced by |
+| --- | --- |
+| `/tasks/{id}` and anything below it, plus the `/api/v<n>` mirror | deny-by-default path gate; a task route added later is covered without editing the middleware |
+| `{task_id}` in the path under any other prefix (`/approvals/{task_id}/approve`, the review board's per-task decision route) | matchers compiled from the app's own route table (`task_id_route_patterns`), so they cannot drift from the routes it registers |
+| ids in a request body on a `/tasks/` collection route (`batch-ops`, `claim-batch`, `self-create`) | `enforce_agent_task_scope_for_ids` in the handler |
+| a body-carried id outside `/tasks/` (`POST /a2a/message`) | `enforce_agent_task_scope_for_ids` in the handler |
+| an id the handler resolves from another key (the task behind an ACP run, the tasks a plan decision transitions, the tasks a cluster steal reassigns) | `enforce_agent_task_scope_for_ids` on the resolved ids, before the mutation |
+
+The only exemptions are the collection routes under `/tasks/`
+(`TASK_COLLECTION_SEGMENTS` in `auth_middleware.py`), which address the
+collection rather than one task, and the claim-next routes
+(`GET /tasks/next/{role}`, `POST /tasks/claim-receipt`), where the server
+picks the row and the caller cannot name a task. A token with an empty
+`task_ids` claim is an unrestricted manager token, and non-agent
+credentials never reach the check at all.
 
 **Revocation.**
 

--- a/docs/operations/security-and-identity.md
+++ b/docs/operations/security-and-identity.md
@@ -83,8 +83,13 @@ rejected.
    expiry.
 3. Resolves the user (operator) or identity (agent), populates
    `request.state.user` / `request.state.identity`, and enforces
-   `task_ids` scoping for `/tasks/{id}/{complete,fail,progress,cancel,
-   block,steal}` paths (`auth_middleware.py:55`).
+   `task_ids` scoping on every mutating request that addresses a single
+   task - `/tasks/{id}` and anything below it, plus the `/api/v1` mirror.
+   The check is deny-by-default rather than an allowlist of action names,
+   so a task route added later is covered without editing the middleware;
+   the only exemptions are the collection routes under `/tasks/`
+   (`TASK_COLLECTION_SEGMENTS` in `auth_middleware.py`), which address the
+   collection rather than one task.
 4. Returns `JSONResponse(401)` on any verification failure.
 
 **Revocation.**

--- a/docs/orchestration/worker-coordination.md
+++ b/docs/orchestration/worker-coordination.md
@@ -37,10 +37,9 @@ same JSONL journal reproduces the identical eligibility projection.
 
 ## Worker mailbox
 
-`POST /tasks/{task_id}/messages` hands a structured payload to another
-worker's task mid-run. This is not chat: payloads are typed, size-capped,
-and addressed to exactly one task - no freeform threads, no undeclared
-fan-out.
+`POST /tasks/{task_id}/messages` hands a structured payload to a worker's
+task mid-run. This is not chat: payloads are typed, size-capped, and
+addressed to exactly one task - no freeform threads, no undeclared fan-out.
 
 | Field | Constraint |
 | --- | --- |
@@ -52,8 +51,28 @@ fan-out.
 Per task, at most 128 messages are held (`429` beyond that). Unknown kinds
 and oversize bodies are rejected with `422`.
 
+### Who may post to which mailbox
+
+Posting is a write against the addressed task, so it carries the same task
+scope as every other per-task write. The credential decides the reach:
+
+| Credential | May post to |
+| --- | --- |
+| Operator bearer token, SSO user, cluster shared secret or cluster JWT | any task's mailbox |
+| Agent JWT with an empty `task_ids` claim (manager / orchestrator) | any task's mailbox |
+| Agent JWT scoped to specific tasks | only the mailboxes of the tasks in its own `task_ids` |
+
+A task-scoped agent posting to a task outside its scope receives `403` and
+the mailbox is not written. Fan-out between tasks is therefore an
+orchestrator-level operation: a worker cannot address a sibling task's
+mailbox with the session token it was spawned with. Route the handoff
+through the orchestrator, or mint a token scoped to both tasks. The MCP
+`bernstein_update` tool authenticates with `BERNSTEIN_AUTH_TOKEN`, so it is
+unaffected.
+
 ```bash
 curl -s -X POST http://127.0.0.1:8052/tasks/<task-id>/messages \
+  -H "Authorization: Bearer <token>" \
   -H "Content-Type: application/json" \
   -d '{"sender": "reviewer-1", "kind": "finding",
        "body": "Error mapping duplicated; use the shared helper in core/errors."}'

--- a/src/bernstein/core/routes/acp.py
+++ b/src/bernstein/core/routes/acp.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
+from bernstein.core.security.auth_middleware import enforce_agent_task_scope_for_ids
 from bernstein.core.server import TaskCreate, TaskStore
 from bernstein.core.tenanting import request_tenant_id
 
@@ -225,6 +226,12 @@ async def cancel_acp_run(run_id: str, request: Request) -> ACPRunResponse:
 
     # Cancel the underlying Bernstein task if it's still active
     if run.bernstein_task_id is not None:
+        # The run id is the only task identifier in the path, and it resolves
+        # to a Bernstein task this handler then cancels - the same mutation
+        # ``POST /tasks/{id}/cancel`` performs under the path-level scope
+        # gate. Check the id the handler resolved, not the one the caller
+        # supplied, so the lookup cannot carry a task past the check.
+        enforce_agent_task_scope_for_ids(request, [run.bernstein_task_id])
         task = store.get_task(run.bernstein_task_id)
         if task is not None and task.status.value in ("open", "claimed", "in_progress"):
             with contextlib.suppress(KeyError, ValueError):

--- a/src/bernstein/core/routes/batch_ops.py
+++ b/src/bernstein/core/routes/batch_ops.py
@@ -14,6 +14,8 @@ from typing import TYPE_CHECKING
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
+from bernstein.core.security.auth_middleware import enforce_agent_task_scope_for_ids
+
 if TYPE_CHECKING:
     from bernstein.core.task_store import TaskStore
 
@@ -166,11 +168,16 @@ async def batch_operations(body: BatchRequest, request: Request) -> BatchResult:
     if errors:
         raise HTTPException(status_code=422, detail="; ".join(errors))
 
+    # Normalise first, then scope-check the normalised ids: these are the
+    # values the loop below acts on, and checking the raw input instead would
+    # let the rewrite carry an id past the check.
+    task_ids = [re.sub(r"[^\w\-]", "", raw_id)[:64] for raw_id in body.ids]
+    enforce_agent_task_scope_for_ids(request, task_ids)
+
     store = _get_store(request)
     result = BatchResult()
 
-    for raw_id in body.ids:
-        task_id = re.sub(r"[^\w\-]", "", raw_id)[:64]
+    for task_id in task_ids:
         try:
             if body.action == BatchAction.CANCEL:
                 await _cancel_task(store, task_id)

--- a/src/bernstein/core/routes/plans.py
+++ b/src/bernstein/core/routes/plans.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel
 
 from bernstein.core.lifecycle import transition_task
 from bernstein.core.models import PlanStatus, TaskStatus
+from bernstein.core.security.auth_middleware import enforce_agent_task_scope_for_ids
 
 if TYPE_CHECKING:
     from bernstein.core.plan_approval import PlanStore
@@ -100,6 +101,11 @@ def approve_plan(request: Request, plan_id: str, body: PlanDecisionRequest | Non
 
     # Promote tasks from PLANNED to OPEN
     task_store = request.app.state.store  # type: ignore[attr-defined]
+    # The plan id resolves to a batch of existing tasks this route
+    # transitions, so the scope rule is applied to the resolved ids rather
+    # than to the plan: promoting task B here is the same mutation a
+    # path-scoped route would refuse for a token that does not hold B.
+    enforce_agent_task_scope_for_ids(request, [e.task_id for e in plan.task_estimates])
     promoted: list[str] = []
     for estimate in plan.task_estimates:
         task = task_store._tasks.get(estimate.task_id)  # pyright: ignore[reportPrivateUsage]
@@ -144,6 +150,9 @@ def reject_plan(request: Request, plan_id: str, body: PlanDecisionRequest | None
 
     # Cancel PLANNED tasks
     task_store = request.app.state.store  # type: ignore[attr-defined]
+    # Same rule as approve: the tasks this cancels are named by the plan, not
+    # by the path, so bind the identity to the ids it is about to act on.
+    enforce_agent_task_scope_for_ids(request, [e.task_id for e in plan.task_estimates])
     cancelled: list[str] = []
     for estimate in plan.task_estimates:
         task = task_store._tasks.get(estimate.task_id)  # pyright: ignore[reportPrivateUsage]

--- a/src/bernstein/core/routes/task_a2a.py
+++ b/src/bernstein/core/routes/task_a2a.py
@@ -10,6 +10,7 @@ from fastapi import APIRouter, HTTPException, Request
 
 from bernstein.core.a2a import AgentCard
 from bernstein.core.difficulty_estimator import estimate_difficulty, minutes_for_level
+from bernstein.core.security.auth_middleware import enforce_agent_task_scope_for_ids
 from bernstein.core.server import (
     A2AAgentCardResponse,
     A2AArtifactRequest,
@@ -132,6 +133,12 @@ async def a2a_message(body: A2AMessageRequest, request: Request) -> A2AMessageRe
     store = _get_store(request)
     sse_bus = _get_sse_bus(request)
     a2a_handler = _get_a2a_handler(request)
+
+    # ``task_id`` names an existing task and the handler appends progress to
+    # it, which is what ``POST /tasks/{id}/progress`` does. That route is
+    # path-scoped; this one carries the id in the body where the middleware
+    # gate cannot read it, so the same rule is applied here.
+    enforce_agent_task_scope_for_ids(request, [body.task_id])
 
     task = store.get_task(body.task_id)
     if task is None:

--- a/src/bernstein/core/routes/task_cluster.py
+++ b/src/bernstein/core/routes/task_cluster.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from fastapi import APIRouter, HTTPException, Request, Response
 
 from bernstein.core.models import NodeCapacity, NodeInfo, NodeStatus
+from bernstein.core.security.auth_middleware import enforce_agent_task_scope_for_ids
 from bernstein.core.server import (
     ClaimGossipRequest,
     ClaimGossipResponse,
@@ -304,6 +305,15 @@ async def steal_tasks(body: TaskStealRequest, request: Request) -> TaskStealResp
         # oldest claimed tasks (best-effort redistribution).
         if not donor_tasks and claimed:
             donor_tasks = sorted(claimed, key=lambda t: t.version)[:count]
+
+        # The caller names no task here - the policy picks them - but the
+        # force-claim below is the same mutation ``POST /tasks/{id}/force-claim``
+        # performs behind the path-level scope gate. Bind the identity to the
+        # ids the policy resolved so a task-scoped token cannot reset a task
+        # it does not hold. Cluster peers authenticate with the shared secret
+        # or a cluster JWT and never populate an agent identity, so this is a
+        # no-op on the real redistribution path.
+        enforce_agent_task_scope_for_ids(request, [task.id for task in donor_tasks])
 
         stolen_ids: list[str] = []
         for task in donor_tasks:

--- a/src/bernstein/core/routes/task_crud.py
+++ b/src/bernstein/core/routes/task_crud.py
@@ -92,7 +92,7 @@ logger = logging.getLogger(__name__)
 _DRAINING_DETAIL = "Server is draining -- no new claims accepted"
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator
+    from collections.abc import AsyncGenerator, Sequence
     from pathlib import Path
 
     from bernstein.core.models import Task
@@ -221,6 +221,31 @@ def _require_task_access(task: Task, request: Request, requested_tenant: str | N
     effective_tenant = _resolve_request_tenant_scope(request, requested_tenant)
     if task.tenant_id != effective_tenant:
         raise HTTPException(status_code=404, detail=f"Task '{task.id}' not found")
+
+
+def _enforce_parent_task_scope(request: Request, parent_task_ids: Sequence[str | None]) -> None:
+    """Bind a create request's ``parent_task_id`` values to the agent's scope.
+
+    The created task is new and unconstrained, but the parent it names is an
+    EXISTING task, and grafting a child onto it writes into the subtree that
+    parent's completion logic reads: an ancestor sitting in
+    ``waiting_for_subtasks`` is promoted only once every direct child is
+    ``done``, so a new child changes whether and when it completes.  The id
+    arrives in the request body, where the middleware's path gate cannot see
+    it, so the same rule is applied here.
+
+    ``depends_on`` is deliberately NOT checked: a dependency edge is stored
+    on the new row and the referenced task is neither mutated nor made
+    unreachable by it.
+
+    Args:
+        request: The active request, carrying the resolved agent identity.
+        parent_task_ids: Parent ids from the body; ``None`` entries (no
+            parent) are dropped.
+    """
+    named = [task_id for task_id in parent_task_ids if task_id]
+    if named:
+        enforce_agent_task_scope_for_ids(request, named)
 
 
 # ---------------------------------------------------------------------------
@@ -779,6 +804,7 @@ async def create_task(body: TaskCreate, request: Request) -> TaskResponse:
     """Create a new task."""
     store = _get_store(request)
     sse_bus = _get_sse_bus(request)
+    _enforce_parent_task_scope(request, [body.parent_task_id])
     effective_body = body.model_copy(update={"tenant_id": request_tenant_id(request)})
     if effective_body.metadata is None:
         effective_body.metadata = {}
@@ -921,6 +947,8 @@ async def create_tasks_batch(body: BatchCreateRequest, request: Request) -> Batc
     store = _get_store(request)
     sse_bus = _get_sse_bus(request)
 
+    _enforce_parent_task_scope(request, [entry.parent_task_id for entry in body.tasks])
+
     prepared: list[TaskCreate] = []
     assessments: list[TaskRiskAssessment] = []
     for task_body in body.tasks:
@@ -994,6 +1022,14 @@ async def self_create_subtask(body: TaskSelfCreate, request: Request) -> TaskRes
     """
     store = _get_store(request)
     sse_bus = _get_sse_bus(request)
+
+    # The new subtask is unconstrained, but ``parent_task_id`` names an
+    # EXISTING task that this route transitions to ``waiting_for_subtasks``
+    # below - the same mutation ``POST /tasks/{parent}/wait-for-subtasks``
+    # performs, and that route is path-scoped. The id arrives in the body, so
+    # the middleware gate cannot see it: without this call a token scoped to
+    # task A could park task B in ``waiting_for_subtasks`` one path over.
+    enforce_agent_task_scope_for_ids(request, [body.parent_task_id])
 
     # Validate parent exists
     parent = store.get_task(body.parent_task_id)

--- a/src/bernstein/core/routes/task_crud.py
+++ b/src/bernstein/core/routes/task_crud.py
@@ -29,6 +29,7 @@ from bernstein.core.eu_ai_act import (
 from bernstein.core.lifecycle import IllegalTransitionError
 from bernstein.core.role_classifier import classify_role
 from bernstein.core.routes._rate_limit_headers import rate_limit_exception
+from bernstein.core.security.auth_middleware import enforce_agent_task_scope_for_ids
 from bernstein.core.security.sanitize import sanitize_log
 
 # Import Pydantic models from server - this works because server.py's
@@ -1090,6 +1091,11 @@ async def claim_batch(body: BatchClaimRequest, request: Request) -> BatchClaimRe
             detail=_DRAINING_DETAIL,
         )
     with start_span("task.claim_batch", {"agent_id": body.agent_id, "task_count": len(body.task_ids)}):
+        # The ids arrive in the body, so the path-level agent task-scope gate
+        # in the middleware cannot see them: a token scoped to task A would
+        # otherwise claim task B here after being denied on
+        # ``POST /tasks/B/claim``.
+        enforce_agent_task_scope_for_ids(request, body.task_ids)
         store = _get_store(request)
         tenant_id = _resolve_request_tenant_scope(request)
         # Tenant authorization is enforced inside store.claim_batch under

--- a/src/bernstein/core/security/auth_middleware.py
+++ b/src/bernstein/core/security/auth_middleware.py
@@ -22,10 +22,15 @@ once per process.
 Zero-trust enforcement
 ----------------------
 When an agent presents a task-scoped JWT, the middleware extracts the task ID
-from the URL path for mutating operations (complete, fail, progress, cancel,
-block) and validates that the task ID appears in the token's ``task_ids``
-claim.  A token without a task scope (``task_ids == []``) is treated as
-unrestricted (manager / orchestrator tokens).
+from the URL path of every mutating request that addresses a single task and
+validates that the task ID appears in the token's ``task_ids`` claim.  The
+check is deny-by-default over the whole ``/tasks/{id}/...`` surface (and its
+``/api/v1`` mirror) rather than an enumeration of action names, so a task
+route added later is covered without touching this module; only the
+collection routes in ``TASK_COLLECTION_SEGMENTS`` are exempt.  A token
+without a task scope (``task_ids == []``) is treated as unrestricted
+(manager / orchestrator tokens), and non-agent credentials (SSO users, the
+legacy operator bearer, the cluster secret) never reach this check at all.
 
 RFC 8707 resource indicators
 ----------------------------
@@ -70,8 +75,53 @@ _EMPTY_EXPECTED_RESOURCES: Final[tuple[str, ...]] = ()
 
 logger = logging.getLogger(__name__)
 
-# Regex to extract task ID from paths like /tasks/{id}/complete
-_TASK_ID_PATH_RE = re.compile(r"^/tasks/([^/]+)/(?:complete|fail|progress|cancel|block|steal)$")
+# Regex to extract the addressed task ID from any per-task path.
+#
+# Deny-by-default: this matches ``/tasks/<id>`` and every sub-path below it,
+# on the root mount and on the versioned mirrors the app also registers
+# (``/api/v1/tasks/...``).  It deliberately does NOT enumerate action names -
+# the previous alternation (``complete|fail|progress|cancel|block|steal``)
+# was hand-maintained, drifted from the route table as routes were added,
+# and still named ``steal``, which is not a task route at all (the real one
+# is ``POST /cluster/steal``).  Anything that addresses a single task by id
+# is now scope-checked; only the collection segments listed in
+# ``TASK_COLLECTION_SEGMENTS`` are exempt.
+_TASK_ID_PATH_RE = re.compile(r"^(?:/api/v\d+)?/tasks/(?P<task_id>[^/]+)(?:/.*)?$")
+
+# Segments that sit where a task id would but are NOT task ids: collection
+# routes registered directly under ``/tasks/``.  Each entry is exempt because
+# it addresses the task collection rather than one task, so there is no task
+# id to bind the agent identity to:
+#
+#   archive, counts, graph, search  - read-only collection queries
+#   next                            - ``GET /tasks/next/{role}`` claim-next
+#   batch, claim-batch, batch-ops   - collection writes; the affected ids
+#                                     live in the request body, which this
+#                                     path-level gate cannot inspect
+#   claim-receipt                   - claim receipt lookup for the caller
+#   self-create                     - an agent decomposing its own work
+#                                     creates a NEW task, so no existing id
+#                                     can be in scope yet
+#
+# ``tests/unit/test_auth_middleware_task_scope_routes.py`` pins this set to
+# the literal segments actually registered under ``/tasks/``: a new
+# collection route fails that test until it is exempted deliberately, and a
+# new ``/tasks/{task_id}/...`` route needs no change here because it is
+# covered by default.
+TASK_COLLECTION_SEGMENTS: Final[frozenset[str]] = frozenset(
+    {
+        "archive",
+        "batch",
+        "batch-ops",
+        "claim-batch",
+        "claim-receipt",
+        "counts",
+        "graph",
+        "next",
+        "search",
+        "self-create",
+    }
+)
 
 # ---------------------------------------------------------------------------
 # Public and HMAC-authenticated paths
@@ -716,8 +766,14 @@ def _check_agent_task_scope(path: str, allowed_task_ids: list[str]) -> str | Non
 
     Returns None when the request is permitted.
 
-    Only task-mutating operations are checked - reads and non-task paths are
-    always allowed so agents can query status and post to the bulletin board.
+    The caller (:meth:`SSOAuthMiddleware._try_agent_jwt`) invokes this only
+    for mutating requests carrying a task-scoped agent identity, so reads and
+    every non-agent credential are unaffected.  Within that population the
+    rule is deny-by-default: any path addressing a single task by id is
+    checked, whatever the action segment below it, on both the root mount and
+    the ``/api/v<n>`` mirrors.  Paths that are not task-addressed (bulletin,
+    status, ...) and the collection routes listed in
+    ``TASK_COLLECTION_SEGMENTS`` are allowed.
 
     Args:
         path: Request URL path.
@@ -728,9 +784,12 @@ def _check_agent_task_scope(path: str, allowed_task_ids: list[str]) -> str | Non
     """
     m = _TASK_ID_PATH_RE.match(path)
     if m is None:
-        # Not a task-specific mutating path - allow (bulletin, status, etc.)
+        # Not a path addressing a single task - allow (bulletin, status, ...).
         return None
-    task_id = m.group(1)
+    task_id = m.group("task_id")
+    if task_id in TASK_COLLECTION_SEGMENTS:
+        # A collection route under /tasks/, not a task id.
+        return None
     if task_id not in allowed_task_ids:
         return f"Task {task_id!r} is not in this agent's task scope (allowed: {allowed_task_ids})"
     return None

--- a/src/bernstein/core/security/auth_middleware.py
+++ b/src/bernstein/core/security/auth_middleware.py
@@ -27,10 +27,14 @@ validates that the task ID appears in the token's ``task_ids`` claim.  The
 check is deny-by-default over the whole ``/tasks/{id}/...`` surface (and its
 ``/api/v1`` mirror) rather than an enumeration of action names, so a task
 route added later is covered without touching this module; only the
-collection routes in ``TASK_COLLECTION_SEGMENTS`` are exempt.  A token
-without a task scope (``task_ids == []``) is treated as unrestricted
-(manager / orchestrator tokens), and non-agent credentials (SSO users, the
-legacy operator bearer, the cluster secret) never reach this check at all.
+collection routes in ``TASK_COLLECTION_SEGMENTS`` are exempt.  The two
+collection routes that name existing tasks in their request body
+(``TASK_BODY_SCOPED_SEGMENTS``) apply the same rule at the handler through
+:func:`enforce_agent_task_scope_for_ids`, so an identity is bound to the same
+tasks whether the id arrives in the path or in the body.  A token without a
+task scope (``task_ids == []``) is treated as unrestricted (manager /
+orchestrator tokens), and non-agent credentials (SSO users, the legacy
+operator bearer, the cluster secret) never reach this check at all.
 
 RFC 8707 resource indicators
 ----------------------------
@@ -58,7 +62,7 @@ from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterable
 
     from fastapi import Request
     from starlette.responses import Response as StarletteResponse
@@ -88,17 +92,37 @@ logger = logging.getLogger(__name__)
 # ``TASK_COLLECTION_SEGMENTS`` are exempt.
 _TASK_ID_PATH_RE = re.compile(r"^(?:/api/v\d+)?/tasks/(?P<task_id>[^/]+)(?:/.*)?$")
 
+# Collection routes registered directly under ``/tasks/`` that name an
+# EXISTING task id in the request body rather than in the path.  The
+# path-level gate cannot see a request body, so these routes carry the same
+# rule at the handler by calling :func:`enforce_agent_task_scope_for_ids` on
+# the ids they are about to act on.  Without that call a token scoped to task
+# A could cancel task B through ``POST /tasks/batch-ops`` while
+# ``POST /tasks/B/cancel`` denied it - the same operation, one path over.
+TASK_BODY_SCOPED_SEGMENTS: Final[frozenset[str]] = frozenset(
+    {
+        "batch-ops",
+        "claim-batch",
+    }
+)
+
 # Segments that sit where a task id would but are NOT task ids: collection
-# routes registered directly under ``/tasks/``.  Each entry is exempt because
-# it addresses the task collection rather than one task, so there is no task
-# id to bind the agent identity to:
+# routes registered directly under ``/tasks/``.  Each entry is exempt from
+# the path-level check because it addresses the task collection rather than
+# one task, so there is no task id in the path to bind the identity to:
 #
 #   archive, counts, graph, search  - read-only collection queries
-#   next                            - ``GET /tasks/next/{role}`` claim-next
-#   batch, claim-batch, batch-ops   - collection writes; the affected ids
-#                                     live in the request body, which this
-#                                     path-level gate cannot inspect
-#   claim-receipt                   - claim receipt lookup for the caller
+#   next                            - ``GET /tasks/next/{role}`` claim-next;
+#                                     the server picks the row, the caller
+#                                     cannot name one
+#   batch                           - creates NEW tasks, so no existing id
+#                                     can be in scope yet
+#   batch-ops, claim-batch          - name existing ids in the body; scoped
+#                                     at the handler, see
+#                                     ``TASK_BODY_SCOPED_SEGMENTS`` above
+#   claim-receipt                   - claims the next eligible backlog row
+#                                     for the caller; like ``next``, the
+#                                     caller cannot name a task
 #   self-create                     - an agent decomposing its own work
 #                                     creates a NEW task, so no existing id
 #                                     can be in scope yet
@@ -108,19 +132,20 @@ _TASK_ID_PATH_RE = re.compile(r"^(?:/api/v\d+)?/tasks/(?P<task_id>[^/]+)(?:/.*)?
 # collection route fails that test until it is exempted deliberately, and a
 # new ``/tasks/{task_id}/...`` route needs no change here because it is
 # covered by default.
-TASK_COLLECTION_SEGMENTS: Final[frozenset[str]] = frozenset(
-    {
-        "archive",
-        "batch",
-        "batch-ops",
-        "claim-batch",
-        "claim-receipt",
-        "counts",
-        "graph",
-        "next",
-        "search",
-        "self-create",
-    }
+TASK_COLLECTION_SEGMENTS: Final[frozenset[str]] = (
+    frozenset(
+        {
+            "archive",
+            "batch",
+            "claim-receipt",
+            "counts",
+            "graph",
+            "next",
+            "search",
+            "self-create",
+        }
+    )
+    | TASK_BODY_SCOPED_SEGMENTS
 )
 
 # ---------------------------------------------------------------------------
@@ -793,3 +818,74 @@ def _check_agent_task_scope(path: str, allowed_task_ids: list[str]) -> str | Non
     if task_id not in allowed_task_ids:
         return f"Task {task_id!r} is not in this agent's task scope (allowed: {allowed_task_ids})"
     return None
+
+
+def check_agent_task_scope_ids(
+    allowed_task_ids: Sequence[str],
+    requested_task_ids: Iterable[str],
+) -> str | None:
+    """Return an error message if any requested task id is out of scope.
+
+    The body-carried counterpart of :func:`_check_agent_task_scope`, applying
+    the same rule to ids a caller names in a request body instead of in the
+    path.  An empty ``allowed_task_ids`` means an unrestricted (manager)
+    token and permits everything, exactly as the path-level gate does.
+
+    Args:
+        allowed_task_ids: Task IDs the agent token is scoped to.
+        requested_task_ids: Task IDs the request is about to act on.
+
+    Returns:
+        Error message string if access should be denied, None otherwise.
+    """
+    if not allowed_task_ids:
+        return None
+    allowed = set(allowed_task_ids)
+    out_of_scope = sorted({task_id for task_id in requested_task_ids if task_id not in allowed})
+    if not out_of_scope:
+        return None
+    return f"Tasks {out_of_scope} are not in this agent's task scope (allowed: {list(allowed_task_ids)})"
+
+
+def enforce_agent_task_scope_for_ids(request: Request, requested_task_ids: Iterable[str]) -> None:
+    """Deny a task-scoped agent that names a task outside its scope in a body.
+
+    Collection routes under ``/tasks/`` take the affected ids from the request
+    body, which the path-level middleware gate cannot inspect.  Handlers for
+    the segments in :data:`TASK_BODY_SCOPED_SEGMENTS` call this with the ids
+    they are about to act on, so the same identity is bound to the same tasks
+    whichever route names them.
+
+    Pass the ids the handler will actually use, after any normalisation it
+    applies - checking the raw input while acting on a rewritten value would
+    let a rewrite carry an id past the check.
+
+    No-op for every credential that is not a task-scoped agent identity:
+    operator bearer tokens, SSO users, the cluster secret, unscoped manager
+    agent tokens (``task_ids == []``), and requests served with auth disabled
+    never set (or never populate) ``request.state.agent_identity``.
+
+    Args:
+        request: The active request, carrying the resolved agent identity.
+        requested_task_ids: Task IDs the handler is about to act on.
+
+    Raises:
+        HTTPException: 403 when any requested id is outside the agent's scope.
+    """
+    identity = getattr(request.state, "agent_identity", None)
+    if identity is None:
+        return
+    error = check_agent_task_scope_ids(getattr(identity, "task_ids", None) or [], requested_task_ids)
+    if error is None:
+        return
+    from fastapi import HTTPException
+
+    from bernstein.core.security.sanitize import sanitize_log
+
+    logger.warning(
+        "Agent %s denied task-scope access to %s: %s",
+        sanitize_log(str(getattr(identity, "id", "unknown"))),
+        sanitize_log(request.url.path),
+        sanitize_log(error),
+    )
+    raise HTTPException(status_code=403, detail=error)

--- a/src/bernstein/core/security/auth_middleware.py
+++ b/src/bernstein/core/security/auth_middleware.py
@@ -21,20 +21,33 @@ once per process.
 
 Zero-trust enforcement
 ----------------------
-When an agent presents a task-scoped JWT, the middleware extracts the task ID
-from the URL path of every mutating request that addresses a single task and
-validates that the task ID appears in the token's ``task_ids`` claim.  The
-check is deny-by-default over the whole ``/tasks/{id}/...`` surface (and its
-``/api/v1`` mirror) rather than an enumeration of action names, so a task
-route added later is covered without touching this module; only the
-collection routes in ``TASK_COLLECTION_SEGMENTS`` are exempt.  The two
-collection routes that name existing tasks in their request body
-(``TASK_BODY_SCOPED_SEGMENTS``) apply the same rule at the handler through
-:func:`enforce_agent_task_scope_for_ids`, so an identity is bound to the same
-tasks whether the id arrives in the path or in the body.  A token without a
-task scope (``task_ids == []``) is treated as unrestricted (manager /
-orchestrator tokens), and non-agent credentials (SSO users, the legacy
-operator bearer, the cluster secret) never reach this check at all.
+When an agent presents a task-scoped JWT, the middleware resolves the task
+the request is about to act on and validates that its id appears in the
+token's ``task_ids`` claim.  The rule is applied to the task identity, not
+to a list of blessed URLs, so it holds wherever that identity arrives from:
+
+* **Path-addressed.**  Deny-by-default over the whole ``/tasks/{id}/...``
+  surface (and its ``/api/v<n>`` mirror), whatever the action segment below
+  it, plus every other registered route whose path template declares a
+  ``{task_id}`` parameter - ``/approvals/{task_id}/approve``, the review
+  board's per-task decision route, and any per-task route added later under
+  any prefix.  That second set is compiled from the app's own route table
+  (:func:`task_id_route_patterns`), so it cannot drift from the routes the
+  app registers.
+* **Body-addressed and batch-addressed.**  The collection routes under
+  ``/tasks/`` that name existing tasks in their request body
+  (``TASK_BODY_SCOPED_SEGMENTS``) have no id in the path for the gate above
+  to read, so their handlers apply the same rule through
+  :func:`enforce_agent_task_scope_for_ids`.
+* **Indirectly resolved.**  Handlers that reach a task through some other
+  key - an ACP run, a plan, a cluster steal decision - call the same
+  function with the ids they resolved, before mutating them.
+
+Only the collection routes in ``TASK_COLLECTION_SEGMENTS`` are exempt from
+the path gate, because they address the collection rather than one task.  A
+token without a task scope (``task_ids == []``) is treated as unrestricted
+(manager / orchestrator tokens), and non-agent credentials (SSO users, the
+legacy operator bearer, the cluster secret) never reach this check at all.
 
 RFC 8707 resource indicators
 ----------------------------
@@ -99,10 +112,18 @@ _TASK_ID_PATH_RE = re.compile(r"^(?:/api/v\d+)?/tasks/(?P<task_id>[^/]+)(?:/.*)?
 # the ids they are about to act on.  Without that call a token scoped to task
 # A could cancel task B through ``POST /tasks/batch-ops`` while
 # ``POST /tasks/B/cancel`` denied it - the same operation, one path over.
+#
+#   batch-ops    - ``ids``: the tasks the bulk action mutates
+#   claim-batch  - ``task_ids``: the tasks claimed for the caller
+#   self-create  - ``parent_task_id``: the NEW task is unconstrained, but the
+#                  named parent is an existing task this route transitions to
+#                  ``waiting_for_subtasks``, which is exactly what
+#                  ``POST /tasks/{parent}/wait-for-subtasks`` does
 TASK_BODY_SCOPED_SEGMENTS: Final[frozenset[str]] = frozenset(
     {
         "batch-ops",
         "claim-batch",
+        "self-create",
     }
 )
 
@@ -117,15 +138,12 @@ TASK_BODY_SCOPED_SEGMENTS: Final[frozenset[str]] = frozenset(
 #                                     cannot name one
 #   batch                           - creates NEW tasks, so no existing id
 #                                     can be in scope yet
-#   batch-ops, claim-batch          - name existing ids in the body; scoped
-#                                     at the handler, see
+#   batch-ops, claim-batch,         - name existing ids in the body; scoped
+#   self-create                       at the handler, see
 #                                     ``TASK_BODY_SCOPED_SEGMENTS`` above
 #   claim-receipt                   - claims the next eligible backlog row
 #                                     for the caller; like ``next``, the
 #                                     caller cannot name a task
-#   self-create                     - an agent decomposing its own work
-#                                     creates a NEW task, so no existing id
-#                                     can be in scope yet
 #
 # ``tests/unit/test_auth_middleware_task_scope_routes.py`` pins this set to
 # the literal segments actually registered under ``/tasks/``: a new
@@ -142,11 +160,24 @@ TASK_COLLECTION_SEGMENTS: Final[frozenset[str]] = (
             "graph",
             "next",
             "search",
-            "self-create",
         }
     )
     | TASK_BODY_SCOPED_SEGMENTS
 )
+
+# Path templates carry ``{task_id}`` for the task they address.  Per-task
+# routes exist outside ``/tasks/`` too (``/approvals/{task_id}/approve``,
+# ``/dashboard/review-board/runs/{run_id}/tasks/{task_id}/review``), and the
+# ``/tasks/``-anchored pattern above cannot see them.  Rather than name those
+# prefixes here - the enumeration that #3036 was filed about - the matchers
+# are compiled from the route table the app actually registers.
+_TASK_ID_TEMPLATE_PARAM: Final[str] = "task_id"
+
+# One ``{name}`` or ``{name:convertor}`` placeholder in a path template.
+_TEMPLATE_PARAM_RE = re.compile(r"\{(?P<name>[^{}:]+)(?::(?P<convertor>[^{}]+))?\}")
+
+# Where the compiled matchers are memoised on ``app.state``.
+_TASK_ROUTE_PATTERNS_ATTR: Final[str] = "_agent_task_scope_route_patterns"
 
 # ---------------------------------------------------------------------------
 # Public and HMAC-authenticated paths
@@ -766,7 +797,11 @@ class SSOAuthMiddleware(BaseHTTPMiddleware):
         # Agents with a non-empty task_ids list may only act on their assigned
         # tasks.  Agents with task_ids=[] are unrestricted (manager role).
         if agent_identity.task_ids and request.method not in _READ_METHODS:
-            task_scope_error = _check_agent_task_scope(path, agent_identity.task_ids)
+            task_scope_error = _check_agent_task_scope(
+                path,
+                agent_identity.task_ids,
+                task_id_route_patterns(request.app),
+            )
             if task_scope_error is not None:
                 logger.warning(
                     "Agent %s denied task-scope access to %s: %s",
@@ -786,7 +821,103 @@ class SSOAuthMiddleware(BaseHTTPMiddleware):
         return response
 
 
-def _check_agent_task_scope(path: str, allowed_task_ids: list[str]) -> str | None:
+def _compile_task_id_route_pattern(template: str) -> re.Pattern[str] | None:
+    """Compile one path template into a matcher capturing its ``task_id``.
+
+    Returns ``None`` for templates that do not address a task by id.  Other
+    placeholders in the same template become non-capturing wildcards: a
+    ``path`` convertor may span ``/`` (``{file_path:path}``), every other
+    convertor matches one segment, and so does a task id.
+
+    Args:
+        template: Route path template, e.g. ``/approvals/{task_id}/approve``.
+
+    Returns:
+        A compiled anchored pattern with a ``task_id`` group, or None.
+    """
+    if f"{{{_TASK_ID_TEMPLATE_PARAM}}}" not in template:
+        return None
+    parts: list[str] = []
+    cursor = 0
+    for match in _TEMPLATE_PARAM_RE.finditer(template):
+        parts.append(re.escape(template[cursor : match.start()]))
+        if match.group("name") == _TASK_ID_TEMPLATE_PARAM:
+            parts.append(f"(?P<{_TASK_ID_TEMPLATE_PARAM}>[^/]+)")
+        elif match.group("convertor") == "path":
+            parts.append(".+")
+        else:
+            parts.append("[^/]+")
+        cursor = match.end()
+    parts.append(re.escape(template[cursor:]))
+    return re.compile("^" + "".join(parts) + "$")
+
+
+def task_id_route_patterns(app: Any) -> tuple[re.Pattern[str], ...]:
+    """Return a matcher per registered route that addresses a task by id.
+
+    Derived from the app's own route table, so a per-task route registered
+    under a prefix other than ``/tasks/`` is covered the moment it exists and
+    this module never carries a list of prefixes to keep in step.  The result
+    is memoised on ``app.state`` because the route table is fixed once the
+    app is built.
+
+    Args:
+        app: The FastAPI/Starlette application serving the request.
+
+    Returns:
+        Compiled patterns, each capturing a ``task_id`` group.  Empty when
+        the app exposes no route table (a bare ASGI callable in a test).
+    """
+    state = getattr(app, "state", None)
+    cached = getattr(state, _TASK_ROUTE_PATTERNS_ATTR, None) if state is not None else None
+    if cached is not None:
+        return cast("tuple[re.Pattern[str], ...]", cached)
+    templates: set[str] = set()
+    for route in getattr(getattr(app, "router", None), "routes", ()) or ():
+        template = getattr(route, "path", "")
+        if template:
+            templates.add(template)
+    compiled = tuple(
+        pattern for pattern in (_compile_task_id_route_pattern(t) for t in sorted(templates)) if pattern is not None
+    )
+    if state is not None:
+        setattr(state, _TASK_ROUTE_PATTERNS_ATTR, compiled)
+    return compiled
+
+
+def _addressed_task_id(path: str, route_patterns: Sequence[re.Pattern[str]] = ()) -> str | None:
+    """Return the single task id this path addresses, or None.
+
+    ``/tasks/``-anchored paths are resolved first and their answer is final:
+    a collection segment there (``batch-ops``, ``next``, ...) is not a task
+    id, and a path below ``/tasks/{id}/`` is one whether or not a route is
+    registered for it, so an unrouted probe cannot slip past the gate.
+    Everything else is matched against the route-table-derived patterns.
+
+    Args:
+        path: Request URL path.
+        route_patterns: Matchers from :func:`task_id_route_patterns`.
+
+    Returns:
+        The addressed task id, or None when the path addresses no single task.
+    """
+    anchored = _TASK_ID_PATH_RE.match(path)
+    if anchored is not None:
+        task_id = anchored.group(_TASK_ID_TEMPLATE_PARAM)
+        # A collection route under /tasks/, not a task id.
+        return None if task_id in TASK_COLLECTION_SEGMENTS else task_id
+    for pattern in route_patterns:
+        match = pattern.match(path)
+        if match is not None:
+            return match.group(_TASK_ID_TEMPLATE_PARAM)
+    return None
+
+
+def _check_agent_task_scope(
+    path: str,
+    allowed_task_ids: list[str],
+    route_patterns: Sequence[re.Pattern[str]] = (),
+) -> str | None:
     """Return an error message if the request path is out of the agent's task scope.
 
     Returns None when the request is permitted.
@@ -796,24 +927,22 @@ def _check_agent_task_scope(path: str, allowed_task_ids: list[str]) -> str | Non
     every non-agent credential are unaffected.  Within that population the
     rule is deny-by-default: any path addressing a single task by id is
     checked, whatever the action segment below it, on both the root mount and
-    the ``/api/v<n>`` mirrors.  Paths that are not task-addressed (bulletin,
-    status, ...) and the collection routes listed in
-    ``TASK_COLLECTION_SEGMENTS`` are allowed.
+    the ``/api/v<n>`` mirrors, and on every other registered per-task route.
+    Paths that are not task-addressed (bulletin, status, ...) and the
+    collection routes listed in ``TASK_COLLECTION_SEGMENTS`` are allowed.
 
     Args:
         path: Request URL path.
         allowed_task_ids: Task IDs the agent token is scoped to.
+        route_patterns: Per-task route matchers for prefixes other than
+            ``/tasks/``, from :func:`task_id_route_patterns`.  Defaults to
+            empty so the ``/tasks/`` surface can be checked without an app.
 
     Returns:
         Error message string if access should be denied, None otherwise.
     """
-    m = _TASK_ID_PATH_RE.match(path)
-    if m is None:
-        # Not a path addressing a single task - allow (bulletin, status, ...).
-        return None
-    task_id = m.group("task_id")
-    if task_id in TASK_COLLECTION_SEGMENTS:
-        # A collection route under /tasks/, not a task id.
+    task_id = _addressed_task_id(path, route_patterns)
+    if task_id is None:
         return None
     if task_id not in allowed_task_ids:
         return f"Task {task_id!r} is not in this agent's task scope (allowed: {allowed_task_ids})"
@@ -848,17 +977,25 @@ def check_agent_task_scope_ids(
 
 
 def enforce_agent_task_scope_for_ids(request: Request, requested_task_ids: Iterable[str]) -> None:
-    """Deny a task-scoped agent that names a task outside its scope in a body.
+    """Deny a task-scoped agent that reaches a task outside its scope.
 
-    Collection routes under ``/tasks/`` take the affected ids from the request
-    body, which the path-level middleware gate cannot inspect.  Handlers for
-    the segments in :data:`TASK_BODY_SCOPED_SEGMENTS` call this with the ids
-    they are about to act on, so the same identity is bound to the same tasks
-    whichever route names them.
+    The handler-side half of the task-scope rule, for every id the path-level
+    gate in this module cannot see:
 
-    Pass the ids the handler will actually use, after any normalisation it
-    applies - checking the raw input while acting on a rewritten value would
-    let a rewrite carry an id past the check.
+    * ids the caller names in a request body - the collection routes under
+      ``/tasks/`` listed in :data:`TASK_BODY_SCOPED_SEGMENTS`, and the
+      per-task id ``POST /a2a/message`` carries;
+    * ids the handler resolves from some other key - the Bernstein task
+      behind an ACP run, the tasks a plan decision promotes or cancels, the
+      tasks a cluster steal is about to reassign.
+
+    Calling it binds the identity to the same tasks whichever route reaches
+    them, so ``POST /tasks/B/cancel`` and every operation equivalent to it
+    answer the same way for the same token.
+
+    Pass the ids the handler will actually use, after any normalisation or
+    lookup it applies - checking the raw input while acting on a rewritten or
+    indirectly resolved value would let that step carry an id past the check.
 
     No-op for every credential that is not a task-scoped agent identity:
     operator bearer tokens, SSO users, the cluster secret, unscoped manager

--- a/src/bernstein/core/security/auth_middleware.py
+++ b/src/bernstein/core/security/auth_middleware.py
@@ -800,7 +800,7 @@ class SSOAuthMiddleware(BaseHTTPMiddleware):
             task_scope_error = _check_agent_task_scope(
                 path,
                 agent_identity.task_ids,
-                task_id_route_patterns(request.app),
+                task_id_route_patterns(request.scope.get("app")),
             )
             if task_scope_error is not None:
                 logger.warning(
@@ -852,7 +852,7 @@ def _compile_task_id_route_pattern(template: str) -> re.Pattern[str] | None:
     return re.compile("^" + "".join(parts) + "$")
 
 
-def task_id_route_patterns(app: Any) -> tuple[re.Pattern[str], ...]:
+def task_id_route_patterns(app: Any | None) -> tuple[re.Pattern[str], ...]:
     """Return a matcher per registered route that addresses a task by id.
 
     Derived from the app's own route table, so a per-task route registered
@@ -862,12 +862,18 @@ def task_id_route_patterns(app: Any) -> tuple[re.Pattern[str], ...]:
     app is built.
 
     Args:
-        app: The FastAPI/Starlette application serving the request.
+        app: The FastAPI/Starlette application serving the request, or None
+            when the scope carries none.
 
     Returns:
         Compiled patterns, each capturing a ``task_id`` group.  Empty when
-        the app exposes no route table (a bare ASGI callable in a test).
+        the app exposes no route table (``None``, or a bare ASGI callable
+        mounted directly in a test).  The ``/tasks/`` surface is matched by
+        the anchored pattern either way, so an empty result narrows the gate
+        to that surface rather than opening it.
     """
+    if app is None:
+        return ()
     state = getattr(app, "state", None)
     cached = getattr(state, _TASK_ROUTE_PATTERNS_ATTR, None) if state is not None else None
     if cached is not None:

--- a/src/bernstein/core/security/auth_middleware.py
+++ b/src/bernstein/core/security/auth_middleware.py
@@ -43,11 +43,15 @@ to a list of blessed URLs, so it holds wherever that identity arrives from:
   key - an ACP run, a plan, a cluster steal decision - call the same
   function with the ids they resolved, before mutating them.
 
-Only the collection routes in ``TASK_COLLECTION_SEGMENTS`` are exempt from
-the path gate, because they address the collection rather than one task.  A
-token without a task scope (``task_ids == []``) is treated as unrestricted
-(manager / orchestrator tokens), and non-agent credentials (SSO users, the
-legacy operator bearer, the cluster secret) never reach this check at all.
+Only the registered ``/tasks/`` collection routes are exempt from the path
+gate, because they address the collection rather than one task.  That
+exemption is keyed on the route a path resolves to
+(:func:`task_collection_route_patterns`), not on the text of its first
+segment, so a task whose id equals a collection segment name cannot borrow
+the exemption.  A token without a task scope (``task_ids == []``) is treated
+as unrestricted (manager / orchestrator tokens), and non-agent credentials
+(SSO users, the legacy operator bearer, the cluster secret) never reach this
+check at all.
 
 RFC 8707 resource indicators
 ----------------------------
@@ -87,6 +91,10 @@ _PERM_TASKS_WRITE = "tasks:write"
 _PERM_ADMIN_MANAGE = "admin:manage"
 
 type _ExpectedResourceConfig = str | Sequence[str] | None
+
+# One registered ``/tasks/`` collection route: its anchored path matcher and
+# the methods it accepts.  Both must match for a path to be exempt.
+type _CollectionRoutePatterns = Sequence[tuple[re.Pattern[str], frozenset[str]]]
 
 _EMPTY_EXPECTED_RESOURCES: Final[tuple[str, ...]] = ()
 
@@ -145,6 +153,13 @@ TASK_BODY_SCOPED_SEGMENTS: Final[frozenset[str]] = frozenset(
 #                                     for the caller; like ``next``, the
 #                                     caller cannot name a task
 #
+# Membership here is necessary but not sufficient: the exemption applies to
+# the registered collection ROUTES these segments name, not to the segment
+# text wherever it appears.  ``/tasks/archive`` is exempt;
+# ``/tasks/archive/cancel`` is a per-task path that happens to carry
+# ``archive`` as the id and stays gated.  See
+# :func:`task_collection_route_patterns`.
+#
 # ``tests/unit/test_auth_middleware_task_scope_routes.py`` pins this set to
 # the literal segments actually registered under ``/tasks/``: a new
 # collection route fails that test until it is exempted deliberately, and a
@@ -176,8 +191,14 @@ _TASK_ID_TEMPLATE_PARAM: Final[str] = "task_id"
 # One ``{name}`` or ``{name:convertor}`` placeholder in a path template.
 _TEMPLATE_PARAM_RE = re.compile(r"\{(?P<name>[^{}:]+)(?::(?P<convertor>[^{}]+))?\}")
 
+# A path template whose first segment under ``/tasks/`` is a literal rather
+# than a placeholder, on the root mount or an ``/api/v<n>`` mirror.  Used to
+# pick the registered collection routes out of the route table.
+_TASK_COLLECTION_TEMPLATE_RE = re.compile(r"^(?:/api/v\d+)?/tasks/(?P<segment>[^/{}]+)(?:/.*)?$")
+
 # Where the compiled matchers are memoised on ``app.state``.
 _TASK_ROUTE_PATTERNS_ATTR: Final[str] = "_agent_task_scope_route_patterns"
+_TASK_COLLECTION_ROUTE_PATTERNS_ATTR: Final[str] = "_agent_task_scope_collection_route_patterns"
 
 # ---------------------------------------------------------------------------
 # Public and HMAC-authenticated paths
@@ -797,10 +818,13 @@ class SSOAuthMiddleware(BaseHTTPMiddleware):
         # Agents with a non-empty task_ids list may only act on their assigned
         # tasks.  Agents with task_ids=[] are unrestricted (manager role).
         if agent_identity.task_ids and request.method not in _READ_METHODS:
+            app = request.scope.get("app")
             task_scope_error = _check_agent_task_scope(
                 path,
                 agent_identity.task_ids,
-                task_id_route_patterns(request.scope.get("app")),
+                task_id_route_patterns(app),
+                task_collection_route_patterns(app),
+                request.method,
             )
             if task_scope_error is not None:
                 logger.warning(
@@ -821,28 +845,26 @@ class SSOAuthMiddleware(BaseHTTPMiddleware):
         return response
 
 
-def _compile_task_id_route_pattern(template: str) -> re.Pattern[str] | None:
-    """Compile one path template into a matcher capturing its ``task_id``.
+def _template_to_pattern(template: str, capture: str | None = None) -> re.Pattern[str]:
+    """Compile a path template into an anchored matcher.
 
-    Returns ``None`` for templates that do not address a task by id.  Other
-    placeholders in the same template become non-capturing wildcards: a
-    ``path`` convertor may span ``/`` (``{file_path:path}``), every other
-    convertor matches one segment, and so does a task id.
+    Placeholders become wildcards: a ``path`` convertor may span ``/``
+    (``{file_path:path}``), every other convertor matches one segment.  The
+    placeholder named *capture*, if any, becomes a named group instead.
 
     Args:
         template: Route path template, e.g. ``/approvals/{task_id}/approve``.
+        capture: Placeholder name to capture, or None to wildcard them all.
 
     Returns:
-        A compiled anchored pattern with a ``task_id`` group, or None.
+        A compiled anchored pattern.
     """
-    if f"{{{_TASK_ID_TEMPLATE_PARAM}}}" not in template:
-        return None
     parts: list[str] = []
     cursor = 0
     for match in _TEMPLATE_PARAM_RE.finditer(template):
         parts.append(re.escape(template[cursor : match.start()]))
-        if match.group("name") == _TASK_ID_TEMPLATE_PARAM:
-            parts.append(f"(?P<{_TASK_ID_TEMPLATE_PARAM}>[^/]+)")
+        if capture is not None and match.group("name") == capture:
+            parts.append(f"(?P<{capture}>[^/]+)")
         elif match.group("convertor") == "path":
             parts.append(".+")
         else:
@@ -852,14 +874,109 @@ def _compile_task_id_route_pattern(template: str) -> re.Pattern[str] | None:
     return re.compile("^" + "".join(parts) + "$")
 
 
+def _compile_task_id_route_pattern(template: str) -> re.Pattern[str] | None:
+    """Compile one path template into a matcher capturing its ``task_id``.
+
+    Args:
+        template: Route path template, e.g. ``/approvals/{task_id}/approve``.
+
+    Returns:
+        A compiled anchored pattern with a ``task_id`` group, or None for a
+        template that does not address a task by id.
+    """
+    if f"{{{_TASK_ID_TEMPLATE_PARAM}}}" not in template:
+        return None
+    return _template_to_pattern(template, _TASK_ID_TEMPLATE_PARAM)
+
+
+def _route_templates(app: Any) -> list[str]:
+    """Return the app's registered path templates, sorted."""
+    templates: set[str] = set()
+    for route in getattr(getattr(app, "router", None), "routes", ()) or ():
+        template = getattr(route, "path", "")
+        if template:
+            templates.add(template)
+    return sorted(templates)
+
+
+def _build_task_id_route_patterns(app: Any) -> tuple[re.Pattern[str], ...]:
+    """Compile a ``task_id``-capturing matcher per per-task route template."""
+    compiled = (_compile_task_id_route_pattern(t) for t in _route_templates(app))
+    return tuple(pattern for pattern in compiled if pattern is not None)
+
+
+def _build_task_collection_route_patterns(app: Any) -> _CollectionRoutePatterns:
+    """Compile a ``(matcher, methods)`` pair per ``/tasks/`` collection route.
+
+    A collection route is one whose first segment under ``/tasks/`` is a
+    literal listed in :data:`TASK_COLLECTION_SEGMENTS` rather than a task id,
+    for example ``/tasks/batch-ops`` or ``/tasks/next/{role}``.
+
+    Two things make the exemption route-resolved rather than text-matched.
+    The matcher covers the WHOLE template, so ``/tasks/archive/cancel`` never
+    matches ``/tasks/archive`` and stays gated even though ``archive`` is a
+    collection segment.  The methods are carried alongside, because a
+    template can match a path the router would dispatch elsewhere for a
+    different method: ``POST /tasks/next/cancel`` matches the GET-only
+    ``/tasks/next/{role}`` on path, yet the router sends it to
+    ``POST /tasks/{task_id}/cancel`` with the id ``next``.  Matching the
+    method too keeps that request gated.
+
+    Args:
+        app: The FastAPI/Starlette application serving the request.
+
+    Returns:
+        Pairs of anchored pattern and the methods that route accepts, in a
+        deterministic order derived from the sorted route table.
+    """
+    methods_by_template: dict[str, set[str]] = {}
+    for route in getattr(getattr(app, "router", None), "routes", ()) or ():
+        template = getattr(route, "path", "")
+        if not template:
+            continue
+        match = _TASK_COLLECTION_TEMPLATE_RE.match(template)
+        if match is None or match.group("segment") not in TASK_COLLECTION_SEGMENTS:
+            continue
+        methods_by_template.setdefault(template, set()).update(getattr(route, "methods", None) or ())
+    return tuple(
+        (_template_to_pattern(template), frozenset(methods_by_template[template]))
+        for template in sorted(methods_by_template)
+    )
+
+
+def _memoise_on_app_state[T](app: Any | None, attr: str, build: Callable[[Any], T]) -> T | tuple[()]:
+    """Return ``build(app)``, memoised on ``app.state`` under *attr*.
+
+    The route table is fixed once the app is built, so the compiled result is
+    cached for the life of the app.
+
+    Args:
+        app: The FastAPI/Starlette application, or None when the ASGI scope
+            carries none.
+        attr: ``app.state`` attribute the result is memoised under.
+        build: Builds the value from the app.
+
+    Returns:
+        The built value, or an empty tuple when there is no app.
+    """
+    if app is None:
+        return ()
+    state = getattr(app, "state", None)
+    cached = getattr(state, attr, None) if state is not None else None
+    if cached is not None:
+        return cast("T", cached)
+    value = build(app)
+    if state is not None:
+        setattr(state, attr, value)
+    return value
+
+
 def task_id_route_patterns(app: Any | None) -> tuple[re.Pattern[str], ...]:
     """Return a matcher per registered route that addresses a task by id.
 
     Derived from the app's own route table, so a per-task route registered
     under a prefix other than ``/tasks/`` is covered the moment it exists and
-    this module never carries a list of prefixes to keep in step.  The result
-    is memoised on ``app.state`` because the route table is fixed once the
-    app is built.
+    this module never carries a list of prefixes to keep in step.
 
     Args:
         app: The FastAPI/Starlette application serving the request, or None
@@ -872,46 +989,72 @@ def task_id_route_patterns(app: Any | None) -> tuple[re.Pattern[str], ...]:
         the anchored pattern either way, so an empty result narrows the gate
         to that surface rather than opening it.
     """
-    if app is None:
-        return ()
-    state = getattr(app, "state", None)
-    cached = getattr(state, _TASK_ROUTE_PATTERNS_ATTR, None) if state is not None else None
-    if cached is not None:
-        return cast("tuple[re.Pattern[str], ...]", cached)
-    templates: set[str] = set()
-    for route in getattr(getattr(app, "router", None), "routes", ()) or ():
-        template = getattr(route, "path", "")
-        if template:
-            templates.add(template)
-    compiled = tuple(
-        pattern for pattern in (_compile_task_id_route_pattern(t) for t in sorted(templates)) if pattern is not None
+    return _memoise_on_app_state(app, _TASK_ROUTE_PATTERNS_ATTR, _build_task_id_route_patterns)
+
+
+def task_collection_route_patterns(app: Any | None) -> _CollectionRoutePatterns:
+    """Return a ``(matcher, methods)`` pair per registered collection route.
+
+    These name the only paths exempt from the ``/tasks/``-anchored gate.  The
+    exemption is keyed on the route a path resolves to, not on the literal
+    text of its first segment, so a task whose id happens to equal a
+    collection segment name cannot borrow that segment's exemption.
+
+    Args:
+        app: The FastAPI/Starlette application serving the request, or None
+            when the scope carries none.
+
+    Returns:
+        Pairs of anchored pattern and accepted methods.  Empty when the app
+        exposes no route table, which exempts nothing and so keeps the gate
+        at its most restrictive.
+    """
+    return _memoise_on_app_state(
+        app,
+        _TASK_COLLECTION_ROUTE_PATTERNS_ATTR,
+        _build_task_collection_route_patterns,
     )
-    if state is not None:
-        setattr(state, _TASK_ROUTE_PATTERNS_ATTR, compiled)
-    return compiled
 
 
-def _addressed_task_id(path: str, route_patterns: Sequence[re.Pattern[str]] = ()) -> str | None:
+def _addressed_task_id(
+    path: str,
+    route_patterns: Sequence[re.Pattern[str]] = (),
+    collection_patterns: _CollectionRoutePatterns = (),
+    method: str | None = None,
+) -> str | None:
     """Return the single task id this path addresses, or None.
 
     ``/tasks/``-anchored paths are resolved first and their answer is final:
-    a collection segment there (``batch-ops``, ``next``, ...) is not a task
-    id, and a path below ``/tasks/{id}/`` is one whether or not a route is
+    a path below ``/tasks/{id}/`` addresses a task whether or not a route is
     registered for it, so an unrouted probe cannot slip past the gate.
     Everything else is matched against the route-table-derived patterns.
+
+    The exemption for collection routes is keyed on the route the path and
+    method resolve to, not on the literal first segment.  Checking the
+    segment text alone would hand a task whose id equals a collection segment
+    name (``archive``, ``next``, ...) that segment's exemption, leaving
+    ``/tasks/archive/cancel`` ungated while ``/tasks/<other>/cancel`` was
+    denied.
 
     Args:
         path: Request URL path.
         route_patterns: Matchers from :func:`task_id_route_patterns`.
+        collection_patterns: Matchers from
+            :func:`task_collection_route_patterns`.
+        method: Request method, matched against the methods each collection
+            route accepts.  None matches any, for callers that only care
+            about the path surface.
 
     Returns:
         The addressed task id, or None when the path addresses no single task.
     """
     anchored = _TASK_ID_PATH_RE.match(path)
     if anchored is not None:
-        task_id = anchored.group(_TASK_ID_TEMPLATE_PARAM)
-        # A collection route under /tasks/, not a task id.
-        return None if task_id in TASK_COLLECTION_SEGMENTS else task_id
+        for pattern, methods in collection_patterns:
+            if pattern.match(path) and (method is None or method in methods):
+                # A registered collection route under /tasks/, not a task id.
+                return None
+        return anchored.group(_TASK_ID_TEMPLATE_PARAM)
     for pattern in route_patterns:
         match = pattern.match(path)
         if match is not None:
@@ -923,6 +1066,8 @@ def _check_agent_task_scope(
     path: str,
     allowed_task_ids: list[str],
     route_patterns: Sequence[re.Pattern[str]] = (),
+    collection_patterns: _CollectionRoutePatterns = (),
+    method: str | None = None,
 ) -> str | None:
     """Return an error message if the request path is out of the agent's task scope.
 
@@ -935,7 +1080,7 @@ def _check_agent_task_scope(
     checked, whatever the action segment below it, on both the root mount and
     the ``/api/v<n>`` mirrors, and on every other registered per-task route.
     Paths that are not task-addressed (bulletin, status, ...) and the
-    collection routes listed in ``TASK_COLLECTION_SEGMENTS`` are allowed.
+    registered ``/tasks/`` collection routes are allowed.
 
     Args:
         path: Request URL path.
@@ -943,11 +1088,16 @@ def _check_agent_task_scope(
         route_patterns: Per-task route matchers for prefixes other than
             ``/tasks/``, from :func:`task_id_route_patterns`.  Defaults to
             empty so the ``/tasks/`` surface can be checked without an app.
+        collection_patterns: Collection-route matchers from
+            :func:`task_collection_route_patterns`.  Defaults to empty, which
+            exempts nothing.
+        method: Request method, matched against the methods each collection
+            route accepts.  None matches any.
 
     Returns:
         Error message string if access should be denied, None otherwise.
     """
-    task_id = _addressed_task_id(path, route_patterns)
+    task_id = _addressed_task_id(path, route_patterns, collection_patterns, method)
     if task_id is None:
         return None
     if task_id not in allowed_task_ids:

--- a/tests/unit/test_auth_middleware_task_scope_indirect.py
+++ b/tests/unit/test_auth_middleware_task_scope_indirect.py
@@ -1,0 +1,582 @@
+"""Task scoping for ids the URL path does not carry (#3036).
+
+The companion module ``test_auth_middleware_task_scope_routes.py`` covers the
+``/tasks/`` surface: paths that name a task and the collection routes that
+take ids in their body.  This module covers the rest of the ways a request
+reaches a task, because a rule enforced on only some of them is enforced on
+an arbitrary subset:
+
+* a **parent id** in a create body, which grafts a child onto an existing
+  task and changes when that task can complete;
+* a **body-carried id** on a route outside ``/tasks/`` (``POST /a2a/message``
+  appends progress to the task it names);
+* an id the handler **resolves indirectly** - the Bernstein task behind an
+  ACP run, the tasks a plan decision promotes or cancels, the tasks a cluster
+  steal reassigns;
+* per-task routes whose path names ``{task_id}`` under some prefix other than
+  ``/tasks/`` (``/approvals/{task_id}/approve`` and the review board), which
+  a ``/tasks/``-anchored pattern cannot see.
+
+Several of those routes are also refused for agent tokens by the fail-closed
+``admin:manage`` fallback in ``_get_required_permission``, which answers 403
+for reasons that have nothing to do with task scope.  Tests that would
+otherwise be measuring that fallback give the route a non-admin permission
+first, so the assertion is about the task-scope rule and not about which
+route happens to be missing from ``_ROUTE_PERMISSIONS`` today.
+"""
+
+# pyright: reportPrivateUsage=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from bernstein.core.auth_middleware import (
+    _check_agent_task_scope,
+    task_id_route_patterns,
+)
+from fastapi.testclient import TestClient
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from fastapi import FastAPI
+
+# These tests exercise the secure-by-default middleware, so opt out of the
+# autouse fixture that sets ``BERNSTEIN_AUTH_DISABLED`` for the suite.
+pytestmark = pytest.mark.auth_enabled
+
+_OPERATOR_TOKEN = "operator-token-for-indirect-scope-tests"
+_READ_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+_OUT_OF_SCOPE_TASK_ID = "task-not-mine"
+_IN_SCOPE_TASK_ID = "task-mine"
+
+# Any registered path template that addresses a task by id, under any prefix.
+_TASK_ID_TEMPLATE_RE = re.compile(r"\{task_id\}")
+
+# Sanity floor for the enumeration below: the app registers per-task routes
+# outside ``/tasks/`` (approvals, the review board), so a matcher set that
+# found none of them would make the assertion pass vacuously.
+_MIN_NON_TASKS_PREFIX_ROUTES = 2
+
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app(tmp_path: Path) -> FastAPI:
+    """The real application, with an operator bearer token for fixture setup."""
+    from bernstein.core.server import create_app
+
+    return create_app(
+        jsonl_path=tmp_path / ".sdd" / "runtime" / "tasks.jsonl",
+        auth_token=_OPERATOR_TOKEN,
+        plan_mode=True,
+    )
+
+
+def _client(application: FastAPI, index: int) -> TestClient:
+    """A client with a distinct peer address so the write rate limiter allows it."""
+    return TestClient(application, client=(f"10.30.{index // 256}.{index % 256}", 42000 + index))
+
+
+def _operator_headers() -> dict[str, str]:
+    return {"Authorization": f"Bearer {_OPERATOR_TOKEN}"}
+
+
+def _agent_headers(application: FastAPI, session: str, task_ids: list[str]) -> dict[str, str]:
+    """Mint an agent identity token scoped to *task_ids*."""
+    identity_store: Any = application.state.identity_store
+    _, token = identity_store.create_identity(session, "backend", task_ids=task_ids)
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _create_task(application: FastAPI, index: int, title: str) -> str:
+    """Create a task with the operator credential and return its id."""
+    response = _client(application, index).post(
+        "/tasks",
+        headers=_operator_headers(),
+        json={"title": title, "description": title, "role": "backend"},
+    )
+    assert response.status_code == 201, response.text
+    return str(response.json()["id"])
+
+
+def _task(application: FastAPI, task_id: str) -> Any:
+    task = application.state.store.get_task(task_id)
+    assert task is not None, task_id
+    return task
+
+
+def _grant_non_admin_permission(monkeypatch: pytest.MonkeyPatch, prefix: str) -> None:
+    """Stop *prefix* falling through to the fail-closed ``admin:manage``.
+
+    Agent tokens are refused outright on any write whose required permission
+    is ``admin:manage``, which would answer 403 whatever the task scope says.
+    Giving the prefix ``tasks:write`` for the duration of a test isolates the
+    task-scope rule, and states the invariant the rule has to hold under: the
+    scoping must not depend on which prefixes are absent from
+    ``_ROUTE_PERMISSIONS``.
+    """
+    from bernstein.core.security import auth_middleware
+
+    monkeypatch.setitem(auth_middleware._ROUTE_PERMISSIONS, prefix, "tasks:write")
+
+
+# ---------------------------------------------------------------------------
+# Parent ids in a create body
+# ---------------------------------------------------------------------------
+
+
+def test_create_task_denies_an_out_of_scope_parent(app: FastAPI) -> None:
+    """``POST /tasks`` cannot graft a child onto another agent's task."""
+    victim_id = _create_task(app, 0, "victim-parent")
+    own_id = _create_task(app, 1, "own-task")
+    headers = _agent_headers(app, "session-create-parent", [own_id])
+
+    response = _client(app, 2).post(
+        "/tasks",
+        headers=headers,
+        json={"title": "child", "description": "child", "role": "backend", "parent_task_id": victim_id},
+    )
+
+    assert response.status_code == 403, response.text
+    assert victim_id in response.json()["detail"]
+    assert app.state.store.count_subtasks(victim_id) == 0
+
+
+def test_create_task_allows_the_agents_own_parent(app: FastAPI) -> None:
+    """The same route still works when the parent is the token's own task."""
+    own_id = _create_task(app, 3, "own-parent")
+    headers = _agent_headers(app, "session-create-own-parent", [own_id])
+
+    response = _client(app, 4).post(
+        "/tasks",
+        headers=headers,
+        json={"title": "child", "description": "child", "role": "backend", "parent_task_id": own_id},
+    )
+
+    assert response.status_code == 201, response.text
+    assert response.json()["parent_task_id"] == own_id
+
+
+def test_create_task_without_a_parent_is_unaffected(app: FastAPI) -> None:
+    """A create that names no parent names no existing task, so it is allowed."""
+    own_id = _create_task(app, 5, "own-noparent")
+    headers = _agent_headers(app, "session-create-noparent", [own_id])
+
+    response = _client(app, 6).post(
+        "/tasks",
+        headers=headers,
+        json={"title": "standalone", "description": "standalone", "role": "backend"},
+    )
+
+    assert response.status_code == 201, response.text
+
+
+def test_batch_create_denies_an_out_of_scope_parent(app: FastAPI) -> None:
+    """One out-of-scope parent in a batch stops the whole batch."""
+    victim_id = _create_task(app, 7, "victim-batch-parent")
+    own_id = _create_task(app, 8, "own-batch")
+    headers = _agent_headers(app, "session-batch-parent", [own_id])
+
+    response = _client(app, 9).post(
+        "/tasks/batch",
+        headers=headers,
+        json={
+            "tasks": [
+                {"title": "mine", "description": "mine", "role": "backend", "parent_task_id": own_id},
+                {"title": "theirs", "description": "theirs", "role": "backend", "parent_task_id": victim_id},
+            ]
+        },
+    )
+
+    assert response.status_code == 403, response.text
+    assert victim_id in response.json()["detail"]
+    assert app.state.store.count_subtasks(victim_id) == 0
+    assert app.state.store.count_subtasks(own_id) == 0
+
+
+def test_depends_on_is_not_scope_checked(app: FastAPI) -> None:
+    """A dependency edge is stored on the new row and mutates nothing.
+
+    Pinned deliberately: ``depends_on`` names an existing task but neither
+    changes its state nor its reachability, so it is outside this gate. If
+    that ever stops being true, this test is the place the decision is
+    revisited.
+    """
+    other_id = _create_task(app, 10, "dependency-target")
+    own_id = _create_task(app, 11, "own-depends")
+    headers = _agent_headers(app, "session-depends", [own_id])
+    before = _task(app, other_id)
+
+    response = _client(app, 12).post(
+        "/tasks",
+        headers=headers,
+        json={"title": "dependent", "description": "dependent", "role": "backend", "depends_on": [other_id]},
+    )
+
+    assert response.status_code == 201, response.text
+    after = _task(app, other_id)
+    assert after.status == before.status
+    assert after.version == before.version
+
+
+# ---------------------------------------------------------------------------
+# Body-carried id outside /tasks/: POST /a2a/message
+# ---------------------------------------------------------------------------
+
+
+def test_a2a_message_denies_an_out_of_scope_task(app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Naming another agent's task in an A2A message body is denied."""
+    _grant_non_admin_permission(monkeypatch, "/a2a")
+    victim_id = _create_task(app, 13, "victim-a2a")
+    own_id = _create_task(app, 14, "own-a2a")
+    headers = _agent_headers(app, "session-a2a", [own_id])
+    before = _task(app, victim_id)
+
+    response = _client(app, 15).post(
+        "/a2a/message",
+        headers=headers,
+        json={"task_id": victim_id, "content": "injected", "sender": "probe", "recipient": "bernstein"},
+    )
+
+    assert response.status_code == 403, response.text
+    assert victim_id in response.json()["detail"]
+    after = _task(app, victim_id)
+    assert after.version == before.version
+
+
+def test_a2a_message_allows_the_agents_own_task(app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The same route still works for the task the token was issued for."""
+    _grant_non_admin_permission(monkeypatch, "/a2a")
+    own_id = _create_task(app, 16, "own-a2a-allowed")
+    headers = _agent_headers(app, "session-a2a-own", [own_id])
+
+    response = _client(app, 17).post(
+        "/a2a/message",
+        headers=headers,
+        json={"task_id": own_id, "content": "hello", "sender": "probe", "recipient": "bernstein"},
+    )
+
+    assert response.status_code == 201, response.text
+    assert response.json()["task_id"] == own_id
+
+
+# ---------------------------------------------------------------------------
+# Indirect resolution: an ACP run id resolves to a Bernstein task
+# ---------------------------------------------------------------------------
+
+
+def _create_acp_run(application: FastAPI, index: int, text: str) -> tuple[str, str]:
+    """Create an ACP run with the operator credential.
+
+    Returns:
+        ``(run_id, bernstein_task_id)``.
+    """
+    response = _client(application, index).post(
+        "/acp/v0/runs",
+        headers=_operator_headers(),
+        json={"input": text},
+    )
+    assert response.status_code in (200, 201), response.text
+    payload = response.json()
+    run_id = str(payload["run_id"] if "run_id" in payload else payload["id"])
+    handler = application.state.acp_handler
+    run = handler.get_run(run_id)
+    assert run is not None and run.bernstein_task_id is not None, payload
+    return run_id, str(run.bernstein_task_id)
+
+
+def test_acp_run_cancel_denies_an_out_of_scope_task(app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Cancelling through a run id is scoped like ``POST /tasks/{id}/cancel``."""
+    _grant_non_admin_permission(monkeypatch, "/acp")
+    run_id, victim_id = _create_acp_run(app, 18, "victim run")
+    own_id = _create_task(app, 19, "own-acp")
+    headers = _agent_headers(app, "session-acp", [own_id])
+
+    response = _client(app, 20).delete(f"/acp/v0/runs/{run_id}", headers=headers)
+
+    assert response.status_code == 403, response.text
+    assert victim_id in response.json()["detail"]
+    assert _task(app, victim_id).status.value != "cancelled"
+
+
+def test_acp_run_cancel_allows_the_agents_own_task(app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A token holding the underlying task may still cancel its own run."""
+    _grant_non_admin_permission(monkeypatch, "/acp")
+    run_id, own_id = _create_acp_run(app, 21, "own run")
+    headers = _agent_headers(app, "session-acp-own", [own_id])
+
+    response = _client(app, 22).delete(f"/acp/v0/runs/{run_id}", headers=headers)
+
+    assert response.status_code == 200, response.text
+    assert _task(app, own_id).status.value == "cancelled"
+
+
+# ---------------------------------------------------------------------------
+# Indirect resolution: a plan id resolves to a batch of tasks
+# ---------------------------------------------------------------------------
+
+
+def _save_plan(application: FastAPI, task_ids: list[str]) -> str:
+    """Persist a plan over *task_ids* and return its id."""
+    from bernstein.core.security.plan_approval import create_plan
+
+    tasks = [_task(application, task_id) for task_id in task_ids]
+    plan = create_plan("probe goal", tasks)
+    application.state.plan_store.save_plan(plan)
+    return str(plan.id)
+
+
+@pytest.mark.parametrize("decision", ["approve", "reject"])
+def test_plan_decision_denies_out_of_scope_tasks(
+    app: FastAPI,
+    monkeypatch: pytest.MonkeyPatch,
+    decision: str,
+) -> None:
+    """A plan decision is scoped to the tasks it is about to transition."""
+    _grant_non_admin_permission(monkeypatch, "/plans")
+    victim_id = _create_task(app, 23, f"victim-plan-{decision}")
+    own_id = _create_task(app, 24, f"own-plan-{decision}")
+    plan_id = _save_plan(app, [victim_id])
+    headers = _agent_headers(app, f"session-plan-{decision}", [own_id])
+    before = _task(app, victim_id)
+
+    response = _client(app, 25).post(f"/plans/{plan_id}/{decision}", headers=headers, json={"reason": "probe"})
+
+    assert response.status_code == 403, response.text
+    assert victim_id in response.json()["detail"]
+    after = _task(app, victim_id)
+    assert after.status == before.status
+    assert app.state.plan_store.get_plan(plan_id).status.value == "pending"
+
+
+def test_plan_decision_allows_a_plan_over_the_agents_own_tasks(
+    app: FastAPI,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A plan whose tasks are all in scope is still decidable."""
+    _grant_non_admin_permission(monkeypatch, "/plans")
+    own_id = _create_task(app, 26, "own-plan-allowed")
+    plan_id = _save_plan(app, [own_id])
+    headers = _agent_headers(app, "session-plan-own", [own_id])
+
+    response = _client(app, 27).post(f"/plans/{plan_id}/approve", headers=headers, json={"reason": "probe"})
+
+    assert response.status_code == 200, response.text
+    assert app.state.plan_store.get_plan(plan_id).status.value == "approved"
+
+
+# ---------------------------------------------------------------------------
+# Server-resolved ids: POST /cluster/steal
+# ---------------------------------------------------------------------------
+
+
+def _register_node(application: FastAPI, index: int, name: str, slots: int) -> str:
+    response = _client(application, index).post(
+        "/cluster/nodes",
+        headers=_operator_headers(),
+        json={
+            "name": name,
+            "url": f"http://{name}.invalid:8000",
+            "capacity": {"max_agents": 8, "available_slots": slots, "active_agents": 0},
+        },
+    )
+    assert response.status_code == 201, response.text
+    return str(response.json()["id"])
+
+
+def test_cluster_steal_denies_an_out_of_scope_task(app: FastAPI) -> None:
+    """Steal reassigns tasks the caller never named; the ids are still bound.
+
+    ``POST /cluster/steal`` reaches ``force_claim`` on tasks the policy picks,
+    which is the mutation ``POST /tasks/{id}/force-claim`` performs behind the
+    path gate.  The check runs on the ids the policy resolved, so a
+    task-scoped token cannot reset a task it does not hold.
+    """
+    victim_id = _create_task(app, 28, "victim-steal")
+    own_id = _create_task(app, 29, "own-steal")
+    claimed = _client(app, 30).post(f"/tasks/{victim_id}/claim", headers=_operator_headers())
+    assert claimed.status_code == 200, claimed.text
+    before = _task(app, victim_id)
+
+    donor = _register_node(app, 31, "overloaded", slots=1)
+    receiver = _register_node(app, 32, "idle", slots=8)
+    headers = _agent_headers(app, "session-steal", [own_id])
+
+    response = _client(app, 33).post(
+        "/cluster/steal",
+        headers=headers,
+        json={"queue_depths": {donor: 10, receiver: 0}},
+    )
+
+    assert response.status_code == 403, response.text
+    assert victim_id in response.json()["detail"]
+    after = _task(app, victim_id)
+    assert after.status == before.status
+    assert after.version == before.version
+
+
+def test_cluster_steal_is_unrestricted_for_an_unscoped_token(app: FastAPI) -> None:
+    """A manager token (``task_ids == []``) redistributes as before."""
+    victim_id = _create_task(app, 34, "manager-steal")
+    claimed = _client(app, 35).post(f"/tasks/{victim_id}/claim", headers=_operator_headers())
+    assert claimed.status_code == 200, claimed.text
+
+    donor = _register_node(app, 36, "overloaded-mgr", slots=1)
+    receiver = _register_node(app, 37, "idle-mgr", slots=8)
+    headers = _agent_headers(app, "session-steal-manager", [])
+
+    response = _client(app, 38).post(
+        "/cluster/steal",
+        headers=headers,
+        json={"queue_depths": {donor: 10, receiver: 0}},
+    )
+
+    assert response.status_code == 200, response.text
+
+
+# ---------------------------------------------------------------------------
+# Per-task paths outside /tasks/
+# ---------------------------------------------------------------------------
+
+
+def _per_task_route_templates(application: FastAPI) -> list[tuple[str, str]]:
+    """Return ``(method, template)`` for every mutating route naming ``{task_id}``."""
+    found: set[tuple[str, str]] = set()
+    for route in application.routes:
+        template = getattr(route, "path", "")
+        if not template or not _TASK_ID_TEMPLATE_RE.search(template):
+            continue
+        for method in getattr(route, "methods", set()) or set():
+            if method.upper() not in _READ_METHODS:
+                found.add((method.upper(), template))
+    return sorted(found)
+
+
+def _fill(template: str, task_id: str) -> str:
+    """Fill a path template, giving every non-task placeholder a literal."""
+    filled = template.replace("{task_id}", task_id)
+    return re.sub(r"\{[^{}]+\}", "probe", filled)
+
+
+def test_enumeration_finds_per_task_routes_outside_the_tasks_prefix(app: FastAPI) -> None:
+    """The enumeration below is non-empty, so its assertion can bite."""
+    outside = [
+        (method, template)
+        for method, template in _per_task_route_templates(app)
+        if not re.match(r"^(?:/api/v\d+)?/tasks/", template)
+    ]
+
+    assert len(outside) >= _MIN_NON_TASKS_PREFIX_ROUTES, outside
+
+
+def test_every_registered_per_task_route_is_scope_checked(app: FastAPI) -> None:
+    """Every mutating route whose path names a task denies an out-of-scope id.
+
+    Derived from the route table rather than from a list of prefixes: a
+    per-task route registered later under any prefix is covered the moment it
+    exists, which is the property #3036 was filed about.
+    """
+    patterns = task_id_route_patterns(app)
+    for method, template in _per_task_route_templates(app):
+        path = _fill(template, _OUT_OF_SCOPE_TASK_ID)
+        error = _check_agent_task_scope(path, [_IN_SCOPE_TASK_ID], patterns)
+
+        assert error is not None, f"{method} {path} is not scope-checked"
+        assert _OUT_OF_SCOPE_TASK_ID in error, f"{method} {path}"
+
+
+def test_every_registered_per_task_route_allows_the_agents_own_task(app: FastAPI) -> None:
+    """The same routes are permitted when the path names the token's own task."""
+    patterns = task_id_route_patterns(app)
+    for method, template in _per_task_route_templates(app):
+        path = _fill(template, _IN_SCOPE_TASK_ID)
+
+        assert _check_agent_task_scope(path, [_IN_SCOPE_TASK_ID], patterns) is None, f"{method} {path}"
+
+
+def test_approvals_route_is_scope_checked(app: FastAPI) -> None:
+    """``POST /approvals/{task_id}/approve`` is a per-task write outside ``/tasks/``."""
+    patterns = task_id_route_patterns(app)
+
+    for action in ("approve", "reject"):
+        error = _check_agent_task_scope(
+            f"/approvals/{_OUT_OF_SCOPE_TASK_ID}/{action}",
+            [_IN_SCOPE_TASK_ID],
+            patterns,
+        )
+
+        assert error is not None, action
+        assert _OUT_OF_SCOPE_TASK_ID in error, action
+
+
+def test_review_board_route_is_scope_checked(app: FastAPI) -> None:
+    """The review board's per-task decision route carries ``{task_id}`` too."""
+    patterns = task_id_route_patterns(app)
+
+    error = _check_agent_task_scope(
+        f"/dashboard/review-board/runs/run-1/tasks/{_OUT_OF_SCOPE_TASK_ID}/review",
+        [_IN_SCOPE_TASK_ID],
+        patterns,
+    )
+
+    assert error is not None
+    assert _OUT_OF_SCOPE_TASK_ID in error
+
+
+def test_a2a_task_ids_are_not_bernstein_task_ids(app: FastAPI) -> None:
+    """``/a2a/tasks/{a2a_task_id}`` addresses the A2A namespace, not a task id.
+
+    Pinned deliberately: the A2A id is a separate identifier that the handler
+    links to a Bernstein task, so checking it against ``task_ids`` would
+    compare values from two different namespaces.
+    """
+    patterns = task_id_route_patterns(app)
+
+    assert (
+        _check_agent_task_scope(f"/a2a/tasks/{_OUT_OF_SCOPE_TASK_ID}/artifacts", [_IN_SCOPE_TASK_ID], patterns) is None
+    )
+
+
+def test_route_patterns_are_memoised_on_the_app(app: FastAPI) -> None:
+    """The matchers are compiled once, not per request."""
+    assert task_id_route_patterns(app) is task_id_route_patterns(app)
+
+
+# ---------------------------------------------------------------------------
+# Credentials that must stay unaffected
+# ---------------------------------------------------------------------------
+
+
+def test_operator_credential_is_unaffected_by_the_indirect_checks(app: FastAPI) -> None:
+    """The operator bearer is not an agent identity, so nothing is bound."""
+    victim_id = _create_task(app, 39, "operator-parent")
+
+    response = _client(app, 40).post(
+        "/tasks",
+        headers=_operator_headers(),
+        json={"title": "child", "description": "child", "role": "backend", "parent_task_id": victim_id},
+    )
+
+    assert response.status_code == 201, response.text
+    assert response.json()["parent_task_id"] == victim_id
+
+
+def test_unscoped_agent_token_is_unaffected_by_the_indirect_checks(app: FastAPI) -> None:
+    """A manager token (``task_ids == []``) stays unrestricted, as on the path gate."""
+    victim_id = _create_task(app, 41, "manager-parent")
+    headers = _agent_headers(app, "session-manager-indirect", [])
+
+    response = _client(app, 42).post(
+        "/tasks",
+        headers=headers,
+        json={"title": "child", "description": "child", "role": "backend", "parent_task_id": victim_id},
+    )
+
+    assert response.status_code == 201, response.text

--- a/tests/unit/test_auth_middleware_task_scope_indirect.py
+++ b/tests/unit/test_auth_middleware_task_scope_indirect.py
@@ -37,6 +37,7 @@ from bernstein.core.auth_middleware import (
     _check_agent_task_scope,
     task_id_route_patterns,
 )
+from bernstein.core.models import TaskStatus
 from fastapi.testclient import TestClient
 
 if TYPE_CHECKING:
@@ -323,10 +324,27 @@ def test_acp_run_cancel_allows_the_agents_own_task(app: FastAPI, monkeypatch: py
 # ---------------------------------------------------------------------------
 
 
+def _mark_planned(application: FastAPI, task_id: str) -> None:
+    """Move a task into ``PLANNED``, the state a plan decision transitions.
+
+    A plan decision only touches its ``PLANNED`` tasks, so a probe left in
+    ``OPEN`` would prove nothing: the route would answer 200 having mutated
+    nothing at all, and the denial assertion would not be measuring the scope
+    rule.
+    """
+    store = application.state.store
+    task = _task(application, task_id)
+    store._index_remove(task)
+    task.status = TaskStatus.PLANNED
+    store._index_add(task)
+
+
 def _save_plan(application: FastAPI, task_ids: list[str]) -> str:
-    """Persist a plan over *task_ids* and return its id."""
+    """Persist a plan over *task_ids* (moved to ``PLANNED``) and return its id."""
     from bernstein.core.security.plan_approval import create_plan
 
+    for task_id in task_ids:
+        _mark_planned(application, task_id)
     tasks = [_task(application, task_id) for task_id in task_ids]
     plan = create_plan("probe goal", tasks)
     application.state.plan_store.save_plan(plan)
@@ -352,7 +370,7 @@ def test_plan_decision_denies_out_of_scope_tasks(
     assert response.status_code == 403, response.text
     assert victim_id in response.json()["detail"]
     after = _task(app, victim_id)
-    assert after.status == before.status
+    assert after.status == before.status == TaskStatus.PLANNED
     assert app.state.plan_store.get_plan(plan_id).status.value == "pending"
 
 
@@ -369,6 +387,7 @@ def test_plan_decision_allows_a_plan_over_the_agents_own_tasks(
     response = _client(app, 27).post(f"/plans/{plan_id}/approve", headers=headers, json={"reason": "probe"})
 
     assert response.status_code == 200, response.text
+    assert response.json()["promoted_task_ids"] == [own_id]
     assert app.state.plan_store.get_plan(plan_id).status.value == "approved"
 
 

--- a/tests/unit/test_auth_middleware_task_scope_routes.py
+++ b/tests/unit/test_auth_middleware_task_scope_routes.py
@@ -22,6 +22,7 @@ from bernstein.core.auth_middleware import (
     TASK_BODY_SCOPED_SEGMENTS,
     TASK_COLLECTION_SEGMENTS,
     _check_agent_task_scope,
+    task_collection_route_patterns,
 )
 from fastapi.testclient import TestClient
 
@@ -43,6 +44,9 @@ _TASK_ID_ROUTE_RE = re.compile(r"^(?:/api/v\d+)?/tasks/\{task_id\}(?:/|$)")
 # A literal segment directly under ``/tasks/`` - a collection route, not a
 # task id (e.g. ``/tasks/self-create``).
 _TASK_COLLECTION_ROUTE_RE = re.compile(r"^(?:/api/v\d+)?/tasks/(?P<segment>[^/{}]+)(?:/|$)")
+
+# One ``{name}`` or ``{name:convertor}`` placeholder in a path template.
+_TEMPLATE_PARAM_RE = re.compile(r"\{[^{}]+\}")
 
 _IN_SCOPE_TASK_ID = "task-mine"
 _OUT_OF_SCOPE_TASK_ID = "task-not-mine"
@@ -83,6 +87,23 @@ def _task_collection_segments(application: FastAPI) -> set[str]:
         if match is not None:
             segments.add(match.group("segment"))
     return segments
+
+
+def _task_collection_routes(application: FastAPI) -> list[tuple[str, str]]:
+    """Return ``(method, path_template)`` for every registered collection route."""
+    found: set[tuple[str, str]] = set()
+    for route in application.routes:
+        template = getattr(route, "path", "")
+        if not template or _TASK_COLLECTION_ROUTE_RE.match(template) is None:
+            continue
+        for method in getattr(route, "methods", set()) or set():
+            found.add((method.upper(), template))
+    return sorted(found)
+
+
+def _fill_collection_template(template: str) -> str:
+    """Substitute a placeholder value for any parameter in a collection template."""
+    return _TEMPLATE_PARAM_RE.sub("backend", template)
 
 
 def test_enumeration_finds_the_task_surface(app: FastAPI) -> None:
@@ -144,9 +165,46 @@ def test_task_collection_segments_are_pinned_to_the_route_table(app: FastAPI) ->
 
 def test_collection_routes_are_not_treated_as_task_ids(app: FastAPI) -> None:
     """Collection routes stay reachable for a task-scoped agent."""
-    for segment in _task_collection_segments(app):
-        assert _check_agent_task_scope(f"/tasks/{segment}", [_IN_SCOPE_TASK_ID]) is None, segment
-        assert _check_agent_task_scope(f"/api/v1/tasks/{segment}", [_IN_SCOPE_TASK_ID]) is None, segment
+    collection = task_collection_route_patterns(app)
+    for method, template in _task_collection_routes(app):
+        path = _fill_collection_template(template)
+
+        assert _check_agent_task_scope(path, [_IN_SCOPE_TASK_ID], (), collection, method) is None, path
+
+
+def test_a_task_id_equal_to_a_collection_segment_is_still_scope_checked(app: FastAPI) -> None:
+    """A collection segment name used as a task id does not borrow the exemption.
+
+    The exemption belongs to the registered collection ROUTE, not to the text
+    of the segment.  Keying it on the text alone would leave
+    ``POST /tasks/archive/cancel`` ungated for a task whose id is
+    ``archive``, while ``POST /tasks/<any other id>/cancel`` was denied.
+    """
+    collection = task_collection_route_patterns(app)
+    for segment in sorted(TASK_COLLECTION_SEGMENTS):
+        for path in (f"/tasks/{segment}/cancel", f"/api/v1/tasks/{segment}/complete"):
+            error = _check_agent_task_scope(path, [_IN_SCOPE_TASK_ID], (), collection, "POST")
+
+            assert error is not None, f"{path} is not scope-checked"
+            assert segment in error, path
+
+
+def test_a_collection_route_is_exempt_only_for_the_methods_it_serves(app: FastAPI) -> None:
+    """A path a collection template matches under another method stays gated.
+
+    ``POST /tasks/next/cancel`` matches the GET-only ``/tasks/next/{role}``
+    on path alone, but the router dispatches it to
+    ``POST /tasks/{task_id}/cancel`` with the id ``next``, so the gate has to
+    follow the router rather than the path match.
+    """
+    collection = task_collection_route_patterns(app)
+
+    assert _check_agent_task_scope("/tasks/next/backend", [_IN_SCOPE_TASK_ID], (), collection, "GET") is None
+
+    error = _check_agent_task_scope("/tasks/next/cancel", [_IN_SCOPE_TASK_ID], (), collection, "POST")
+
+    assert error is not None
+    assert "next" in error
 
 
 def test_versioned_mirror_is_scope_checked() -> None:

--- a/tests/unit/test_auth_middleware_task_scope_routes.py
+++ b/tests/unit/test_auth_middleware_task_scope_routes.py
@@ -194,6 +194,14 @@ _BODY_SCOPED_PROBES: dict[str, dict[str, Any]] = {
     "claim-batch": {"task_ids": ["{task_id}"], "agent_id": "probe-agent"},
 }
 
+# The response field each probe reports its successfully handled ids under, so
+# a permitted request is asserted to have actually run rather than merely to
+# have avoided a 403.
+_BODY_SCOPED_SUCCESS_FIELD: dict[str, str] = {
+    "batch-ops": "succeeded",
+    "claim-batch": "claimed",
+}
+
 
 @pytest.fixture
 def authed_app(tmp_path: Path) -> FastAPI:
@@ -234,6 +242,7 @@ def _probe_body(segment: str, task_id: str) -> dict[str, Any]:
 def test_body_scoped_segments_all_have_a_probe() -> None:
     """Every body-scoped segment is exercised by the tests below."""
     assert set(_BODY_SCOPED_PROBES) == set(TASK_BODY_SCOPED_SEGMENTS)
+    assert set(_BODY_SCOPED_SUCCESS_FIELD) == set(TASK_BODY_SCOPED_SEGMENTS)
 
 
 def test_body_scoped_segments_are_exempt_from_the_path_gate() -> None:
@@ -280,22 +289,26 @@ def test_body_scoped_routes_allow_the_agents_own_task(authed_app: FastAPI) -> No
         )
 
         assert response.status_code == 200, f"/tasks/{segment} -> {response.status_code} {response.text}"
+        assert own_id in response.json()[_BODY_SCOPED_SUCCESS_FIELD[segment]], f"/tasks/{segment} {response.text}"
 
 
 def test_body_scoped_routes_allow_an_unscoped_manager_token(authed_app: FastAPI) -> None:
     """A token with ``task_ids == []`` stays unrestricted, as on the path gate."""
-    victim_id = _create_task(authed_app, 40, "manager-target")
     store: Any = authed_app.state.identity_store
     _, token = store.create_identity("session-manager", "backend", task_ids=[])
 
     for index, segment in enumerate(sorted(TASK_BODY_SCOPED_SEGMENTS)):
+        # A task the manager token was never scoped to, fresh per segment so
+        # one probe cannot leave the next one nothing to act on.
+        target_id = _create_task(authed_app, 40 + index, f"manager-target-{segment}")
         response = _client(authed_app, 50 + index).post(
             f"/tasks/{segment}",
             headers={"Authorization": f"Bearer {token}"},
-            json=_probe_body(segment, victim_id),
+            json=_probe_body(segment, target_id),
         )
 
         assert response.status_code == 200, f"/tasks/{segment} -> {response.status_code} {response.text}"
+        assert target_id in response.json()[_BODY_SCOPED_SUCCESS_FIELD[segment]], f"/tasks/{segment} {response.text}"
 
 
 def test_batch_ops_scope_check_sees_the_normalised_id(authed_app: FastAPI) -> None:

--- a/tests/unit/test_auth_middleware_task_scope_routes.py
+++ b/tests/unit/test_auth_middleware_task_scope_routes.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 from bernstein.core.auth_middleware import (
     _TASK_ID_PATH_RE,
+    TASK_BODY_SCOPED_SEGMENTS,
     TASK_COLLECTION_SEGMENTS,
     _check_agent_task_scope,
 )
@@ -170,3 +171,166 @@ def test_non_task_paths_are_unaffected() -> None:
     """Bulletin/status/task-collection paths never trigger a scope error."""
     for path in ("/bulletin", "/status", "/tasks", "/tasks/", "/agents/a1/kill", "/api/v1/tasks"):
         assert _check_agent_task_scope(path, [_IN_SCOPE_TASK_ID]) is None, path
+
+
+# ---------------------------------------------------------------------------
+# Collection routes that name existing tasks in the request body
+# ---------------------------------------------------------------------------
+#
+# The path-level gate cannot see a request body, so exempting these segments
+# from it is only safe while their handlers apply the same rule to the ids
+# they act on.  Without that, a token scoped to task A is denied on
+# ``POST /tasks/B/cancel`` and permitted to cancel the same task B through
+# ``POST /tasks/batch-ops``.
+
+_OPERATOR_TOKEN = "operator-token-for-scope-tests"
+
+# One probe body per body-scoped segment, with ``{task_id}`` standing in for
+# the task the request names.  ``test_body_scoped_segments_all_have_a_probe``
+# pins this mapping to the segment set, so a newly exempted segment fails
+# until its handler is covered here.
+_BODY_SCOPED_PROBES: dict[str, dict[str, Any]] = {
+    "batch-ops": {"action": "cancel", "ids": ["{task_id}"]},
+    "claim-batch": {"task_ids": ["{task_id}"], "agent_id": "probe-agent"},
+}
+
+
+@pytest.fixture
+def authed_app(tmp_path: Path) -> FastAPI:
+    """The real application with an operator bearer token for fixture setup."""
+    from bernstein.core.server import create_app
+
+    return create_app(
+        jsonl_path=tmp_path / ".sdd" / "runtime" / "tasks.jsonl",
+        auth_token=_OPERATOR_TOKEN,
+    )
+
+
+def _client(application: FastAPI, index: int) -> TestClient:
+    """A client with a distinct peer address so the write rate limiter allows it."""
+    return TestClient(application, client=(f"10.20.{index // 256}.{index % 256}", 41000 + index))
+
+
+def _create_task(application: FastAPI, index: int, title: str) -> str:
+    """Create a task with the operator credential and return its server-assigned id."""
+    response = _client(application, index).post(
+        "/tasks",
+        headers={"Authorization": f"Bearer {_OPERATOR_TOKEN}"},
+        json={"title": title, "description": title, "role": "backend"},
+    )
+    assert response.status_code == 201, response.text
+    return str(response.json()["id"])
+
+
+def _probe_body(segment: str, task_id: str) -> dict[str, Any]:
+    """Fill a probe body template with a concrete task id."""
+    template = _BODY_SCOPED_PROBES[segment]
+    return {
+        key: [task_id if item == "{task_id}" else item for item in value] if isinstance(value, list) else value
+        for key, value in template.items()
+    }
+
+
+def test_body_scoped_segments_all_have_a_probe() -> None:
+    """Every body-scoped segment is exercised by the tests below."""
+    assert set(_BODY_SCOPED_PROBES) == set(TASK_BODY_SCOPED_SEGMENTS)
+
+
+def test_body_scoped_segments_are_exempt_from_the_path_gate() -> None:
+    """The body-scoped segments are a subset of the path-level exemptions."""
+    assert TASK_BODY_SCOPED_SEGMENTS <= TASK_COLLECTION_SEGMENTS
+
+
+def test_body_scoped_routes_deny_an_out_of_scope_task_id(authed_app: FastAPI) -> None:
+    """Naming another agent's task in the body is denied, and nothing is mutated."""
+    victim_id = _create_task(authed_app, 0, "victim")
+    own_id = _create_task(authed_app, 1, "own")
+    store: Any = authed_app.state.identity_store
+    _, token = store.create_identity("session-body-scope", "backend", task_ids=[own_id])
+    headers = {"Authorization": f"Bearer {token}"}
+    before = authed_app.state.store.get_task(victim_id)
+    assert before is not None
+
+    for index, segment in enumerate(sorted(TASK_BODY_SCOPED_SEGMENTS)):
+        response = _client(authed_app, 10 + index).post(
+            f"/tasks/{segment}",
+            headers=headers,
+            json=_probe_body(segment, victim_id),
+        )
+
+        assert response.status_code == 403, f"/tasks/{segment} -> {response.status_code} {response.text}"
+        assert victim_id in response.json()["detail"]
+        after = authed_app.state.store.get_task(victim_id)
+        assert after is not None
+        assert after.status == before.status, f"/tasks/{segment} mutated an out-of-scope task"
+        assert after.version == before.version, f"/tasks/{segment} mutated an out-of-scope task"
+
+
+def test_body_scoped_routes_allow_the_agents_own_task(authed_app: FastAPI) -> None:
+    """The same routes still work when the body names the token's own task."""
+    store: Any = authed_app.state.identity_store
+
+    for index, segment in enumerate(sorted(TASK_BODY_SCOPED_SEGMENTS)):
+        own_id = _create_task(authed_app, 20 + index, f"own-{segment}")
+        _, token = store.create_identity(f"session-own-{segment}", "backend", task_ids=[own_id])
+        response = _client(authed_app, 30 + index).post(
+            f"/tasks/{segment}",
+            headers={"Authorization": f"Bearer {token}"},
+            json=_probe_body(segment, own_id),
+        )
+
+        assert response.status_code == 200, f"/tasks/{segment} -> {response.status_code} {response.text}"
+
+
+def test_body_scoped_routes_allow_an_unscoped_manager_token(authed_app: FastAPI) -> None:
+    """A token with ``task_ids == []`` stays unrestricted, as on the path gate."""
+    victim_id = _create_task(authed_app, 40, "manager-target")
+    store: Any = authed_app.state.identity_store
+    _, token = store.create_identity("session-manager", "backend", task_ids=[])
+
+    for index, segment in enumerate(sorted(TASK_BODY_SCOPED_SEGMENTS)):
+        response = _client(authed_app, 50 + index).post(
+            f"/tasks/{segment}",
+            headers={"Authorization": f"Bearer {token}"},
+            json=_probe_body(segment, victim_id),
+        )
+
+        assert response.status_code == 200, f"/tasks/{segment} -> {response.status_code} {response.text}"
+
+
+def test_batch_ops_scope_check_sees_the_normalised_id(authed_app: FastAPI) -> None:
+    """The check runs on the id the handler acts on, not on the raw input.
+
+    ``batch-ops`` strips non-word characters before touching the store, so a
+    check against the raw string would let ``<victim>!`` through and then
+    cancel ``<victim>``.
+    """
+    victim_id = _create_task(authed_app, 60, "victim-normalised")
+    own_id = _create_task(authed_app, 61, "own-normalised")
+    store: Any = authed_app.state.identity_store
+    _, token = store.create_identity("session-normalised", "backend", task_ids=[own_id])
+
+    response = _client(authed_app, 62).post(
+        "/tasks/batch-ops",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"action": "cancel", "ids": [f"{victim_id}!!"]},
+    )
+
+    assert response.status_code == 403, response.text
+    victim = authed_app.state.store.get_task(victim_id)
+    assert victim is not None
+    assert victim.status.value != "cancelled"
+
+
+def test_body_scoped_routes_are_unaffected_for_the_operator_credential(authed_app: FastAPI) -> None:
+    """The operator bearer token is not an agent identity and stays unrestricted."""
+    victim_id = _create_task(authed_app, 70, "operator-target")
+
+    response = _client(authed_app, 71).post(
+        "/tasks/batch-ops",
+        headers={"Authorization": f"Bearer {_OPERATOR_TOKEN}"},
+        json={"action": "cancel", "ids": [victim_id]},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["succeeded"] == [victim_id]

--- a/tests/unit/test_auth_middleware_task_scope_routes.py
+++ b/tests/unit/test_auth_middleware_task_scope_routes.py
@@ -1,0 +1,172 @@
+"""Route-table-derived coverage for per-agent task scoping (#3036).
+
+``_check_agent_task_scope`` binds an agent identity to the tasks its token
+was issued for.  The guarded set used to be a hand-maintained alternation
+of action names, so every task route added afterwards silently escaped the
+check.  These tests derive the expectations from the *registered* route
+table instead of a literal list: a newly added ``/tasks/{task_id}/...``
+mutation is covered automatically, and a newly added collection route under
+``/tasks/`` fails the pinning test until it is exempted deliberately.
+"""
+
+# pyright: reportPrivateUsage=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from bernstein.core.auth_middleware import (
+    _TASK_ID_PATH_RE,
+    TASK_COLLECTION_SEGMENTS,
+    _check_agent_task_scope,
+)
+from fastapi.testclient import TestClient
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from fastapi import FastAPI
+
+# These tests exercise the secure-by-default middleware, so opt out of the
+# autouse fixture that sets ``BERNSTEIN_AUTH_DISABLED`` for the suite.
+pytestmark = pytest.mark.auth_enabled
+
+_READ_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+
+# Any path template that addresses a single task by id, on the root mount or
+# on a versioned mirror (``/api/v1/...``).
+_TASK_ID_ROUTE_RE = re.compile(r"^(?:/api/v\d+)?/tasks/\{task_id\}(?:/|$)")
+
+# A literal segment directly under ``/tasks/`` - a collection route, not a
+# task id (e.g. ``/tasks/self-create``).
+_TASK_COLLECTION_ROUTE_RE = re.compile(r"^(?:/api/v\d+)?/tasks/(?P<segment>[^/{}]+)(?:/|$)")
+
+_IN_SCOPE_TASK_ID = "task-mine"
+_OUT_OF_SCOPE_TASK_ID = "task-not-mine"
+
+# Sanity floor: the enumeration must actually find the task surface. Without
+# it a refactor that stops matching route templates would make every
+# enumerating assertion pass vacuously.
+_MIN_EXPECTED_MUTATING_ROUTES = 20
+
+
+@pytest.fixture
+def app(tmp_path: Path) -> FastAPI:
+    """Build the real application so its route table drives the assertions."""
+    from bernstein.core.server import create_app
+
+    return create_app(jsonl_path=tmp_path / ".sdd" / "runtime" / "tasks.jsonl")
+
+
+def _mutating_task_id_routes(application: FastAPI) -> list[tuple[str, str]]:
+    """Return ``(method, path_template)`` for every mutating per-task route."""
+    found: set[tuple[str, str]] = set()
+    for route in application.routes:
+        template = getattr(route, "path", "")
+        if not template or not _TASK_ID_ROUTE_RE.match(template):
+            continue
+        for method in getattr(route, "methods", set()) or set():
+            if method.upper() not in _READ_METHODS:
+                found.add((method.upper(), template))
+    return sorted(found)
+
+
+def _task_collection_segments(application: FastAPI) -> set[str]:
+    """Return the literal (non task-id) first segments under ``/tasks/``."""
+    segments: set[str] = set()
+    for route in application.routes:
+        template = getattr(route, "path", "")
+        match = _TASK_COLLECTION_ROUTE_RE.match(template) if template else None
+        if match is not None:
+            segments.add(match.group("segment"))
+    return segments
+
+
+def test_enumeration_finds_the_task_surface(app: FastAPI) -> None:
+    """The route enumeration is non-empty, so the assertions below can bite."""
+    routes = _mutating_task_id_routes(app)
+
+    assert len(routes) >= _MIN_EXPECTED_MUTATING_ROUTES, routes
+
+
+def test_every_mutating_task_route_is_scope_checked(app: FastAPI) -> None:
+    """Every mutating per-task route reports an out-of-scope task id."""
+    for method, template in _mutating_task_id_routes(app):
+        path = template.replace("{task_id}", _OUT_OF_SCOPE_TASK_ID)
+        error = _check_agent_task_scope(path, [_IN_SCOPE_TASK_ID])
+
+        assert error is not None, f"{method} {path} is not scope-checked"
+        assert _OUT_OF_SCOPE_TASK_ID in error, f"{method} {path}"
+
+
+def test_every_mutating_task_route_denies_out_of_scope_identity(app: FastAPI) -> None:
+    """A token scoped to task A is rejected on every mutating task-B route.
+
+    End-to-end through the real middleware stack: the handler must never run
+    for a task the token was not issued for.
+    """
+    store: Any = app.state.identity_store
+    _, token = store.create_identity("session-scope-probe", "backend", task_ids=[_IN_SCOPE_TASK_ID])
+    headers = {"Authorization": f"Bearer {token}"}
+
+    routes = _mutating_task_id_routes(app)
+    for index, (method, template) in enumerate(routes):
+        path = template.replace("{task_id}", _OUT_OF_SCOPE_TASK_ID)
+        # A fresh peer address per request: the write rate limiter allows 30
+        # requests/minute per client and would answer 429 long before the
+        # enumeration finished, masking the authorization result.
+        client = TestClient(app, client=(f"10.{index // 256}.{index % 256}.1", 40000 + index))
+        response = client.request(method, path, headers=headers, json={})
+
+        assert response.status_code == 403, f"{method} {path} -> {response.status_code}"
+
+
+def test_every_mutating_task_route_allows_in_scope_identity(app: FastAPI) -> None:
+    """The same routes are permitted when the path addresses the token's own task."""
+    for method, template in _mutating_task_id_routes(app):
+        path = template.replace("{task_id}", _IN_SCOPE_TASK_ID)
+
+        assert _check_agent_task_scope(path, [_IN_SCOPE_TASK_ID]) is None, f"{method} {path}"
+
+
+def test_task_collection_segments_are_pinned_to_the_route_table(app: FastAPI) -> None:
+    """Exempt segments match the collection routes actually registered.
+
+    Adding a new ``/tasks/<literal>`` route fails here until the segment is
+    added to ``TASK_COLLECTION_SEGMENTS`` deliberately - the exemption can
+    never be acquired by accident.
+    """
+    assert _task_collection_segments(app) == set(TASK_COLLECTION_SEGMENTS)
+
+
+def test_collection_routes_are_not_treated_as_task_ids(app: FastAPI) -> None:
+    """Collection routes stay reachable for a task-scoped agent."""
+    for segment in _task_collection_segments(app):
+        assert _check_agent_task_scope(f"/tasks/{segment}", [_IN_SCOPE_TASK_ID]) is None, segment
+        assert _check_agent_task_scope(f"/api/v1/tasks/{segment}", [_IN_SCOPE_TASK_ID]) is None, segment
+
+
+def test_versioned_mirror_is_scope_checked() -> None:
+    """The ``/api/v1`` mirror of a task route is gated like the root mount."""
+    error = _check_agent_task_scope(f"/api/v1/tasks/{_OUT_OF_SCOPE_TASK_ID}/complete", [_IN_SCOPE_TASK_ID])
+
+    assert error is not None
+    assert _OUT_OF_SCOPE_TASK_ID in error
+
+
+def test_dead_steal_alternative_is_gone() -> None:
+    """``/tasks/{id}/steal`` never existed; the pattern no longer names it."""
+    assert "steal" not in _TASK_ID_PATH_RE.pattern
+
+
+def test_cluster_steal_is_not_a_task_scoped_path() -> None:
+    """The real steal route (``POST /cluster/steal``) is outside this gate."""
+    assert _check_agent_task_scope("/cluster/steal", [_IN_SCOPE_TASK_ID]) is None
+
+
+def test_non_task_paths_are_unaffected() -> None:
+    """Bulletin/status/task-collection paths never trigger a scope error."""
+    for path in ("/bulletin", "/status", "/tasks", "/tasks/", "/agents/a1/kill", "/api/v1/tasks"):
+        assert _check_agent_task_scope(path, [_IN_SCOPE_TASK_ID]) is None, path

--- a/tests/unit/test_auth_middleware_task_scope_routes.py
+++ b/tests/unit/test_auth_middleware_task_scope_routes.py
@@ -192,6 +192,12 @@ _OPERATOR_TOKEN = "operator-token-for-scope-tests"
 _BODY_SCOPED_PROBES: dict[str, dict[str, Any]] = {
     "batch-ops": {"action": "cancel", "ids": ["{task_id}"]},
     "claim-batch": {"task_ids": ["{task_id}"], "agent_id": "probe-agent"},
+    "self-create": {
+        "title": "probe subtask",
+        "description": "probe subtask",
+        "role": "backend",
+        "parent_task_id": "{task_id}",
+    },
 }
 
 # The response field each probe reports its successfully handled ids under, so
@@ -200,7 +206,12 @@ _BODY_SCOPED_PROBES: dict[str, dict[str, Any]] = {
 _BODY_SCOPED_SUCCESS_FIELD: dict[str, str] = {
     "batch-ops": "succeeded",
     "claim-batch": "claimed",
+    "self-create": "parent_task_id",
 }
+
+# Status code a permitted probe answers with. ``self-create`` is a creation
+# route and answers 201; the rest report per-id outcomes with 200.
+_BODY_SCOPED_OK_STATUS: dict[str, int] = {"self-create": 201}
 
 
 @pytest.fixture
@@ -231,18 +242,25 @@ def _create_task(application: FastAPI, index: int, title: str) -> str:
 
 
 def _probe_body(segment: str, task_id: str) -> dict[str, Any]:
-    """Fill a probe body template with a concrete task id."""
-    template = _BODY_SCOPED_PROBES[segment]
-    return {
-        key: [task_id if item == "{task_id}" else item for item in value] if isinstance(value, list) else value
-        for key, value in template.items()
-    }
+    """Fill a probe body template with a concrete task id.
+
+    The placeholder is substituted whether the template carries it as a bare
+    value (``parent_task_id``) or inside a list (``ids``, ``task_ids``).
+    """
+
+    def _fill(value: Any) -> Any:
+        if isinstance(value, list):
+            return [_fill(item) for item in value]  # pyright: ignore[reportUnknownVariableType]
+        return task_id if value == "{task_id}" else value
+
+    return {key: _fill(value) for key, value in _BODY_SCOPED_PROBES[segment].items()}
 
 
 def test_body_scoped_segments_all_have_a_probe() -> None:
     """Every body-scoped segment is exercised by the tests below."""
     assert set(_BODY_SCOPED_PROBES) == set(TASK_BODY_SCOPED_SEGMENTS)
     assert set(_BODY_SCOPED_SUCCESS_FIELD) == set(TASK_BODY_SCOPED_SEGMENTS)
+    assert set(_BODY_SCOPED_OK_STATUS) <= set(TASK_BODY_SCOPED_SEGMENTS)
 
 
 def test_body_scoped_segments_are_exempt_from_the_path_gate() -> None:
@@ -288,7 +306,8 @@ def test_body_scoped_routes_allow_the_agents_own_task(authed_app: FastAPI) -> No
             json=_probe_body(segment, own_id),
         )
 
-        assert response.status_code == 200, f"/tasks/{segment} -> {response.status_code} {response.text}"
+        expected = _BODY_SCOPED_OK_STATUS.get(segment, 200)
+        assert response.status_code == expected, f"/tasks/{segment} -> {response.status_code} {response.text}"
         assert own_id in response.json()[_BODY_SCOPED_SUCCESS_FIELD[segment]], f"/tasks/{segment} {response.text}"
 
 
@@ -307,7 +326,8 @@ def test_body_scoped_routes_allow_an_unscoped_manager_token(authed_app: FastAPI)
             json=_probe_body(segment, target_id),
         )
 
-        assert response.status_code == 200, f"/tasks/{segment} -> {response.status_code} {response.text}"
+        expected = _BODY_SCOPED_OK_STATUS.get(segment, 200)
+        assert response.status_code == expected, f"/tasks/{segment} -> {response.status_code} {response.text}"
         assert target_id in response.json()[_BODY_SCOPED_SUCCESS_FIELD[segment]], f"/tasks/{segment} {response.text}"
 
 


### PR DESCRIPTION
Closes #3036

## Problem

`_TASK_ID_PATH_RE` is the gate that binds an agent identity to the task its
token was issued for. It matched a hand-maintained alternation of action names
(`complete|fail|progress|cancel|block|steal`), which had drifted from the
routes the app actually registers:

- it named `steal`, which is not a task route at all (`POST /cluster/steal` is
  the real one);
- it missed every per-task route added since it was written;
- it was anchored at `/tasks/...`, so the `/api/v1/tasks/...` mirror that
  `create_app` registers for the same routers was never matched.

Result: a token scoped to task A could mutate task B through any path the
alternation did not name, while `/complete` and `/fail` correctly denied it.

The deeper problem is the shape of the rule, not the contents of the list. The
gate was written against a set of URLs, so it could only ever cover the ways of
reaching a task that someone had remembered to enumerate. Each review pass
found another one.

## Change

Bind the rule to the task identity the request acts on, wherever that identity
comes from.

**Path-addressed.** Any path that addresses a single task by id is
scope-checked, whatever the action segment below it, on the root mount and on
the `/api/v<n>` mirror:

```
^(?:/api/v\d+)?/tasks/(?P<task_id>[^/]+)(?:/.*)?$
```

Per-task routes exist outside `/tasks/` as well, and a `/tasks/`-anchored
pattern cannot see them. Rather than adding a second list of prefixes, the
matchers for those are compiled from the app's own route table: one per
registered path template that declares a `{task_id}` parameter
(`task_id_route_patterns`, memoised on `app.state`). A per-task route
registered later under any prefix is covered the moment it exists.

**Body-addressed and batch-addressed.** The collection routes under `/tasks/`
that name existing tasks in their body have no id in the path, so their
handlers apply the same rule through `enforce_agent_task_scope_for_ids`. Ids
are checked after any normalisation the handler applies, so a rewrite cannot
carry an id past the check.

**Indirectly resolved.** Handlers that reach a task through some other key call
the same function on the ids they resolved, before the mutation.

The only exemptions are the collection routes under `/tasks/`
(`TASK_COLLECTION_SEGMENTS`), which address the collection rather than one
task, each justified per entry in the module. The dead `steal` alternative is
gone.

## Route-by-route

Built by enumerating the route table `create_app` registers (529 routes, 178
mutating route/method pairs) and reading every handler that reaches a
task-state mutation, not from this description. "Before" is the state at
`67e72404`, the commit the review looked at.

### Gaps closed here

| Route | How the task is addressed | Enforced before | Enforced after |
| --- | --- | --- | --- |
| `POST /approvals/{task_id}/{approve,reject}` (both mounts) | path, outside `/tasks/` | no; refused only by the `admin:manage` fallback | path gate, matcher derived from the route table |
| `POST /dashboard/review-board/runs/{run_id}/tasks/{task_id}/review` (both mounts) | path, outside `/tasks/` | no; refused only by the `admin:manage` fallback | path gate, matcher derived from the route table |
| `POST /tasks/self-create` | body `parent_task_id`; transitions the parent to `waiting_for_subtasks` | no; exempt as a collection route | handler check on the parent id |
| `POST /tasks` | body `parent_task_id` | no | handler check on the parent id |
| `POST /tasks/batch` | body `parent_task_id` per entry | no | handler check on every parent id in the batch |
| `POST /a2a/message` | body `task_id`; appends progress | no; refused only by the `admin:manage` fallback | handler check on the body id |
| `DELETE /acp/v0/runs/{run_id}` | run id resolves to a task; cancels it | no; refused only by the `admin:manage` fallback | handler check on the resolved id |
| `POST /plans/{plan_id}/approve` | plan id resolves to a batch; promotes them to `open` | no; refused only by the `admin:manage` fallback | handler check on the resolved ids |
| `POST /plans/{plan_id}/reject` | plan id resolves to a batch; cancels them | no; refused only by the `admin:manage` fallback | handler check on the resolved ids |
| `POST /cluster/steal` | the policy resolves the tasks; force-claims them | no, and reachable for an agent token (`cluster:write`) | handler check on the resolved ids |

Closed in the two earlier commits on this branch and re-verified here:

| Route | How the task is addressed | Enforced before | Enforced after |
| --- | --- | --- | --- |
| 32 mutating `/tasks/{id}/...` pairs (both mounts) | path | 5 of 32 | 32 of 32 |
| `POST /tasks/batch-ops` | body `ids` | no | handler check on the normalised ids |
| `POST /tasks/claim-batch` | body `task_ids` | no | handler check on the body ids |

Path-gate coverage is now 38 mutating route/method pairs, up from 32 after the
first commit and 5 before it.

### Checked and deliberately not scoped

| Route or field | Why |
| --- | --- |
| `depends_on` on the create routes | the edge is stored on the new row; the referenced task is neither mutated nor made unreachable. Pinned by a test so the decision is revisited if that changes |
| `GET /tasks/next/{role}`, `POST /tasks/claim-receipt` | claim-next: the server picks the row and the caller cannot name a task, so there is no requested identity to bind. `completed_ids` on `claim-receipt` is a dependency filter, not a set of tasks to mutate |
| `POST /a2a/tasks/{a2a_task_id}/artifacts` | the A2A id is a separate identifier the handler links to a task; checking it against `task_ids` would compare two namespaces. Pinned by a test |
| `POST /cluster/claims/gossip` | folds signed peer receipts into the MESH journal and does not touch the task store. Gossip between nodes whose journals cover different tasks is the point of the route |
| `POST /agents/{session_id}/kill` | writes a session kill signal; it does not read or write task state, and an agent token carries `task_ids`, not session ids |
| `POST /graduation/{session_id}/record-event` | records graduation metrics keyed by session; the `task_id` in the body is metadata and no task state is read or written |
| `POST /tasks`, `/tasks/batch`, `/tasks/self-create`, `/a2a/tasks/send`, `/a2a/v0/tasks`, `/a2a/v1` `message/send`, `/acp/v0/runs`, `/webhook`, `/webhooks/*`, Slack and Discord commands | create new tasks; there is no existing id to bind |
| `POST /graphql` | read-only resolvers; no mutations are defined |
| Per-task reads (`GET /tasks/{id}` and below, `/dashboard/tasks/{id}` and below, mission and review-board evidence) | reads are outside this gate by design, unchanged here |

A path-normalisation sweep found no path that the router resolves to a per-task
handler while the gate misses it (`//tasks/...`, `/./tasks/...`,
`/api//v1/tasks/...`, `/TASKS/...`, trailing slash: all unrouted). No registered
route accepts a task id in more than one position.

## Blast radius

`enforce_agent_task_scope_for_ids` returns immediately unless
`request.state.agent_identity` is populated with a non-empty `task_ids`, so
operator bearer tokens, SSO users, the cluster shared secret, the cluster JWT
and unscoped manager agent tokens (`task_ids == []`) are all unchanged, as are
reads. Cluster peers authenticate with the shared secret or a cluster JWT and
never populate an agent identity, so `POST /cluster/steal` is unchanged on the
real redistribution path.

The path-gate generalisation is a no-op for currently reachable traffic: the
routes it newly covers (`/approvals/...`, the review board) are already refused
for every agent token by the `admin:manage` fallback. It stops the scoping from
depending on which prefixes happen to be absent from `_ROUTE_PERMISSIONS`.

Agent tokens are issued by the spawner scoped to exactly the tasks the session
was spawned for, so an agent acting on its own task sees no behaviour change.

### Behaviour change to declare: the cross-task worker mailbox

`POST /tasks/{task_id}/messages` is a per-task write, so it is now covered by
the path gate like every other one. For a task-scoped agent token addressing a
task outside its own scope this changes `201` to `403`, and the mailbox is not
written. Measured on this branch against the same request:

| Credential | Target | Before | After |
| --- | --- | --- | --- |
| operator bearer | any task | 201 | 201 |
| agent JWT, `task_ids == []` | any task | 201 | 201 |
| agent JWT scoped to task A | task A | 201 | 201 |
| agent JWT scoped to task A | task B | 201 | 403 |
| agent JWT scoped to A and B | task B | 201 | 201 |

This is the one case where the generalisation is not a no-op for reachable
traffic, so it is called out separately rather than folded into the 32-of-32
row above. `docs/orchestration/worker-coordination.md` described the mailbox as
an unrestricted worker-to-worker handoff and is updated in this PR to state
which credential may post to which mailbox.

No in-repo caller is affected. The MCP `bernstein_update` tool authenticates
with `BERNSTEIN_AUTH_TOKEN`, `bernstein worker` uses the cluster bearer, and
the spawn prompt renders inbound mailbox messages without teaching an outbound
cross-task post. An operator who does drive the mailbox across tasks with a
task-scoped token should route the handoff through the orchestrator or mint a
token scoped to both tasks.

## Why it cannot drift again

- A new `/tasks/{task_id}/...` route is covered the moment it is registered.
- A new per-task route under any other prefix is covered as soon as its template
  declares `{task_id}`, because the matchers are compiled from the route table.
- A new `/tasks/<literal>` collection route fails
  `test_task_collection_segments_are_pinned_to_the_route_table` until the
  segment is added to the exemption set deliberately, and a newly exempted
  body-scoped segment fails `test_body_scoped_segments_all_have_a_probe` until a
  probe body covers it.

## The collection exemption is resolved, not text-matched

Membership in `TASK_COLLECTION_SEGMENTS` is necessary but not sufficient. The
exemption applies to the registered collection ROUTE a request resolves to, on
both path and method, not to the segment text wherever it appears:

- `GET /tasks/archive` matches the registered template and is exempt.
- `POST /tasks/archive/cancel` matches no collection template, so it is a
  per-task path carrying `archive` as the id, and it is gated.
- `POST /tasks/next/cancel` matches the GET-only `/tasks/next/{role}` on path
  alone, but the router dispatches it to `POST /tasks/{task_id}/cancel` with
  the id `next`. Carrying the accepted methods alongside each matcher keeps it
  gated, so the gate follows the router rather than the path match.

Keying the exemption on segment text alone would have left all ten collection
segment names usable as an ungated task id. That is not reachable through the
API today, since ids are `uuid4().hex[:12]`, but it made the gate depend on how
ids happen to be generated rather than on what the route does.
`test_a_task_id_equal_to_a_collection_segment_is_still_scope_checked` and
`test_a_collection_route_is_exempt_only_for_the_methods_it_serves` pin both
directions.

## Tests

`tests/unit/test_auth_middleware_task_scope_routes.py` (19) covers the `/tasks/`
surface, enumerating the registered route table rather than a literal list.

`tests/unit/test_auth_middleware_task_scope_indirect.py` (23, new) covers the
rest: parent ids in a create body, the body-carried id on `/a2a/message`, the
ids resolved from an ACP run, a plan and a steal decision, and the per-task
paths outside `/tasks/`. Each denial is asserted end to end through the real
middleware stack and paired with an assertion that the target task was not
mutated, alongside the permitted direction and the unscoped-manager and
operator no-op directions.

Routes that the `admin:manage` fallback would refuse for unrelated reasons are
given a non-admin permission for the duration of the test, so the assertion
measures the task-scope rule rather than which prefix is missing from
`_ROUTE_PERMISSIONS`.

### Verified red before, green after

Run against the tree at `54949837` with the source reverted and the tests held
at their new state.

| Test | Before | After |
| --- | --- | --- |
| `test_create_task_denies_an_out_of_scope_parent` | 201, child created under the victim | 403 |
| `test_batch_create_denies_an_out_of_scope_parent` | 201, both children created | 403 |
| `test_a2a_message_denies_an_out_of_scope_task` | 201, progress injected into the victim | 403 |
| `test_acp_run_cancel_denies_an_out_of_scope_task` | 200, victim `status: cancelled` | 403 |
| `test_plan_decision_denies_out_of_scope_tasks[approve]` | 200, `tasks_promoted: 1` | 403 |
| `test_plan_decision_denies_out_of_scope_tasks[reject]` | 200, `tasks_cancelled: 1` | 403 |
| `test_cluster_steal_denies_an_out_of_scope_task` | 200, victim in the steal action's `task_ids` | 403 |
| `test_every_registered_per_task_route_is_scope_checked` | fails | passes |
| `test_approvals_route_is_scope_checked` | `_check_agent_task_scope('/approvals/task-not-mine/approve', ['task-mine'])` returned `None` | returns the denial |
| `test_review_board_route_is_scope_checked` | same, `None` | returns the denial |

12 of the 23 fail on the pre-fix source; 23 pass after.

### Test files run

`test_auth_middleware_task_scope_indirect.py` (23),
`test_auth_middleware_task_scope_routes.py` (19), `test_auth_middleware.py`
(22), `test_auth_middleware_defaults.py` (28),
`test_auth_middleware_resource_indicator.py` (15), `test_agent_identity.py`
(46), `test_agent_identity_jwt.py` (8), `test_spawner_agent_token.py` (7),
`test_self_create_subtask.py` (4), `test_acp.py` (43), `test_a2a_messages.py`
(3), `test_route_batch_ops.py` (29), `test_plan_approval.py` (5),
`test_task_claim_receipt_route.py` (7), `test_task_claiming_by_session.py` (8),
`test_clearance_gate.py` (13), `test_task_store_count_subtasks.py` (4),
`test_server.py` (122), `test_paginated_tasks_route.py` (14),
`test_api_contracts.py` (33), `test_completion_contract_api.py` (12),
`test_task_store_batch.py` (6), `test_cli_snapshots.py` (3),
`orchestration/test_mesh_coordinator.py` (27), `protocols/test_a2a_handler.py`
(44), `test_context_inheritance.py` (1), `test_coordinator.py` (9),
`integration/test_cluster_e2e.py` (6), `integration/test_jetbrains_acp.py`
(14). All pass.

`ruff check` and `ruff format --check` clean across `src/bernstein` and the
touched tests. `pyright --project pyrightconfig.strict.json`: 0 errors.
`bernstein agents-md verify`: all 13 files in sync. `mypy` on the touched source
reports only the four errors that are also present on `main`.

