### PR TITLE
fix(audit): record a release receipt when a held claim is surrendered

### DIFF
--- a/docs/orchestration/worker-coordination.md
+++ b/docs/orchestration/worker-coordination.md
@@ -35,6 +35,31 @@ Claims are journal entries: claim eligibility is reconstructable offline
 from the task journal plus the chain, and rebuilding the store from the
 same JSONL journal reproduces the identical eligibility projection.
 
+## Release receipts
+
+Every transition that ends a held claim appends the matching
+`task.release_receipt` event to the same chain, carrying `task_id`, `role`,
+`released_by` (the holder that surrendered it), `task_version`,
+`release_path`, `reason`, and the `from_status` / `to_status` pair.
+
+| Path | `release_path` |
+| --- | --- |
+| `POST /tasks/{id}/force-claim` | `force_claim` |
+| `POST /tasks/{id}/reopen` | `reopen` |
+| `POST /tasks/{id}/cancel` | `cancel_cascade` (root and descendants) |
+| `POST /tasks/{id}/fail` | `fail` / `fail_contract_violation` |
+| Typed worker refusal | `refuse` |
+| `TaskStore.abandon` | `abandon` |
+| Stale-claim reset after a restart | `restart_recovery` |
+| Cluster node departure | `node_departure` |
+
+Both halves are written by the server itself, so a plain `bernstein serve`
+node records them without the orchestrator's audit wiring. A ledger that
+records acquisitions and no surrenders replays as node A holding a task node
+B is already executing; with both halves,
+`bernstein.core.security.audit_chain.reconstruct_claim_holders` folds any
+prefix of the chain into the holder of every task at that point, offline.
+
 ## Worker mailbox
 
 `POST /tasks/{task_id}/messages` hands a structured payload to another

--- a/docs/orchestration/worker-coordination.md
+++ b/docs/orchestration/worker-coordination.md
@@ -37,7 +37,7 @@ same JSONL journal reproduces the identical eligibility projection.
 
 ## Release receipts
 
-Every transition that ends a held claim appends the matching
+Every transition that surrenders a held claim appends the matching
 `task.release_receipt` event to the same chain, carrying `task_id`, `role`,
 `released_by` (the holder that surrendered it), `task_version`,
 `release_path`, `reason`, and the `from_status` / `to_status` pair.
@@ -47,18 +47,36 @@ Every transition that ends a held claim appends the matching
 | `POST /tasks/{id}/force-claim` | `force_claim` |
 | `POST /tasks/{id}/reopen` | `reopen` |
 | `POST /tasks/{id}/cancel` | `cancel_cascade` (root and descendants) |
+| `TaskStore.cancel` | `cancel` |
 | `POST /tasks/{id}/fail` | `fail` / `fail_contract_violation` |
+| `POST /tasks/{id}/complete` with an empty summary | `fail_empty_completion` |
 | Typed worker refusal | `refuse` |
-| `TaskStore.abandon` | `abandon` |
+| `TaskStore.abandon` (the abandoned task) | `abandon` |
+| `TaskStore.abandon` (downstream tasks it blocks) | `abandon_cascade` |
 | Stale-claim reset after a restart | `restart_recovery` |
 | Cluster node departure | `node_departure` |
+
+A surrender is minted only when the task carried evidence of an actual claim
+(`claimed_at` or `claimed_by_session`). Status alone is not enough: a task can
+reach `WAITING_FOR_SUBTASKS` or `BLOCKED` without ever having been claimed,
+and a fabricated surrender on a signed chain cannot be told apart from a real
+one by a verifier.
+
+Delivery is not a surrender. A task reaching `DONE` or `CLOSED` mints no
+receipt, because the worker finished the job it claimed. Its claim ends only
+if the task later goes back to the pool, which happens through `reopen` and
+does mint one.
 
 Both halves are written by the server itself, so a plain `bernstein serve`
 node records them without the orchestrator's audit wiring. A ledger that
 records acquisitions and no surrenders replays as node A holding a task node
 B is already executing; with both halves,
 `bernstein.core.security.audit_chain.reconstruct_claim_holders` folds any
-prefix of the chain into the holder of every task at that point, offline.
+prefix of the chain into the last claimant of every task at that point,
+offline. That projection is attribution, not liveness: a delivered task stays
+mapped to the worker that delivered it, and the guarantee it does carry is
+that no task is ever mapped to one claimant while another node holds it,
+because every path back to the pool records a release first.
 
 ## Worker mailbox
 

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -30,7 +30,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Iterable, Sequence
     from pathlib import Path
 
 from bernstein.core.security.audit import (
@@ -379,6 +379,19 @@ EVENT_TASK_MAILBOX_MESSAGE = "task.mailbox_message"
 #: eligibility is reconstructable offline instead of remaining an in-memory
 #: scheduler decision.
 EVENT_TASK_CLAIM_RECEIPT = "task.claim_receipt"
+
+#: Issue #3037 -- the counterpart of :data:`EVENT_TASK_CLAIM_RECEIPT`, emitted
+#: whenever a held claim ends: the task returns to the pool (force-claim,
+#: reopen, release, restart recovery, node departure) or dies terminally
+#: without delivering (fail, cancel, abandon). The event records the task id,
+#: its role lane, the holder that surrendered it, the post-transition task
+#: version, which path ended the claim, the status pair it moved across, and
+#: the reason. Without it the chain records every acquisition and no release,
+#: so a replay reports a node as still holding a task another node is already
+#: executing. With it, folding claim and release receipts in chain order
+#: reconstructs the current holder of every task offline -- see
+#: :func:`reconstruct_claim_holders`.
+EVENT_TASK_RELEASE_RECEIPT = "task.release_receipt"
 
 #: Issue #2369 -- emitted once per packaged agent-skill / plugin install.
 #: When the bundled ``bernstein-run`` skill (or a plugin checkout a host
@@ -3914,6 +3927,104 @@ def record_task_claim_receipt(
             "claim_path": claim_path,
         },
     )
+
+
+def record_task_release_receipt(
+    *,
+    chain: AuditChainStore,
+    task_id: str,
+    role: str,
+    released_by: str,
+    task_version: int,
+    release_path: str,
+    reason: str,
+    from_status: str,
+    to_status: str,
+    actor: str = "task_store",
+) -> AuditEvent:
+    """Append a ``task.release_receipt`` event into *chain* (#3037).
+
+    The surrender half of the claim ledger. ``task.claim_receipt`` records
+    that a worker took a task; this records that the same worker no longer
+    holds it, because the task went back to the pool or died terminally
+    without delivering. Recording only acquisitions supports a strictly
+    weaker question than the claim receipt is for: a replay of an
+    acquisition-only ledger reports node A as holding a task node B has
+    already re-claimed. With both halves on one chain,
+    :func:`reconstruct_claim_holders` folds them in chain order and answers
+    "who holds this task" offline, at any point in the chain.
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        task_id: The task whose claim ended.
+        role: The task's role lane.
+        released_by: The holder that surrendered the claim -- the session or
+            agent identifier recorded at claim time (may be empty when the
+            claim carried no session id).
+        task_version: The task version after the releasing transition.
+        release_path: Which path ended the claim (``force_claim`` /
+            ``reopen`` / ``release`` / ``cancel`` / ``cancel_cascade`` /
+            ``fail`` / ``abandon`` / ``restart_recovery`` /
+            ``node_departure``).
+        reason: The transition's recorded reason.
+        from_status: Task status the claim was held in.
+        to_status: Task status the release moved it to.
+        actor: Recorded actor; defaults to ``"task_store"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded
+        in its details payload.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_TASK_RELEASE_RECEIPT,
+        actor=actor,
+        resource_type="task_claim",
+        resource_id=task_id,
+        details={
+            "task_id": task_id,
+            "role": role,
+            "released_by": released_by,
+            "task_version": task_version,
+            "release_path": release_path,
+            "reason": reason,
+            "from_status": from_status,
+            "to_status": to_status,
+        },
+    )
+
+
+def reconstruct_claim_holders(events: Iterable[AuditEvent]) -> dict[str, str]:
+    """Fold claim and release receipts into the current holder per task (#3037).
+
+    Offline reconstruction of task ownership from the chain alone: a
+    ``task.claim_receipt`` records a task as held by its claimer, the matching
+    ``task.release_receipt`` removes it. Pass a prefix of the chain to
+    reconstruct ownership as of that point.
+
+    A release for a task with no recorded claim is tolerated (the claim may
+    predate the range passed in, or have been granted through a store-level
+    path that mints no receipt) and simply leaves the task unheld.
+
+    Args:
+        events: Audit events in chain order. Non-claim events are ignored, so
+            the full chain can be passed unfiltered.
+
+    Returns:
+        Mapping of task id to the identifier currently holding it. Tasks with
+        no live claim are absent. A held task whose claim carried no session
+        id maps to the empty string, which is still distinguishable from
+        "not held" by key membership.
+    """
+    holders: dict[str, str] = {}
+    for event in events:
+        if event.event_type == EVENT_TASK_CLAIM_RECEIPT:
+            task_id = str(event.details.get("task_id", "") or event.resource_id)
+            if task_id:
+                holders[task_id] = str(event.details.get("claimed_by", "") or "")
+        elif event.event_type == EVENT_TASK_RELEASE_RECEIPT:
+            task_id = str(event.details.get("task_id", "") or event.resource_id)
+            holders.pop(task_id, None)
+    return holders
 
 
 def record_claim_journal_receipt(
@@ -7739,6 +7850,7 @@ __all__ = [
     "EVENT_SUBAGENT_DELEGATION",
     "EVENT_TASK_CLAIM_RECEIPT",
     "EVENT_TASK_MAILBOX_MESSAGE",
+    "EVENT_TASK_RELEASE_RECEIPT",
     "EVENT_TASK_RESOURCE_RELEASE",
     "EVENT_TASK_RESUMED",
     "EVENT_TASK_SUSPENDED",
@@ -7765,6 +7877,7 @@ __all__ = [
     "SkillInstallReceiptDetails",
     "SkillVerificationRefusalDetails",
     "ThreadApprovalDetails",
+    "reconstruct_claim_holders",
     "reconstruct_mcp_call_order",
     "record_a2a_message_receipt",
     "record_activity_result",
@@ -7869,6 +7982,7 @@ __all__ = [
     "record_taint_decision",
     "record_task_claim_receipt",
     "record_task_mailbox_message",
+    "record_task_release_receipt",
     "record_task_resource_release",
     "record_task_resume",
     "record_task_suspension",

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -381,15 +381,18 @@ EVENT_TASK_MAILBOX_MESSAGE = "task.mailbox_message"
 EVENT_TASK_CLAIM_RECEIPT = "task.claim_receipt"
 
 #: Issue #3037 -- the counterpart of :data:`EVENT_TASK_CLAIM_RECEIPT`, emitted
-#: whenever a held claim ends: the task returns to the pool (force-claim,
-#: reopen, release, restart recovery, node departure) or dies terminally
-#: without delivering (fail, cancel, abandon). The event records the task id,
+#: whenever a held claim is surrendered: the task returns to the pool
+#: (force-claim, reopen, release, restart recovery, node departure) or dies
+#: terminally without delivering (fail, cancel, abandon, refuse, and the
+#: downstream leg of an abandon cascade). Delivery is not a surrender, so a
+#: task reaching ``DONE`` or ``CLOSED`` mints nothing; its claim ends only if
+#: it is later reopened, which does mint one. The event records the task id,
 #: its role lane, the holder that surrendered it, the post-transition task
 #: version, which path ended the claim, the status pair it moved across, and
 #: the reason. Without it the chain records every acquisition and no release,
 #: so a replay reports a node as still holding a task another node is already
 #: executing. With it, folding claim and release receipts in chain order
-#: reconstructs the current holder of every task offline -- see
+#: reconstructs the last claimant of every task offline -- see
 #: :func:`reconstruct_claim_holders`.
 EVENT_TASK_RELEASE_RECEIPT = "task.release_receipt"
 
@@ -3952,7 +3955,8 @@ def record_task_release_receipt(
     acquisition-only ledger reports node A as holding a task node B has
     already re-claimed. With both halves on one chain,
     :func:`reconstruct_claim_holders` folds them in chain order and answers
-    "who holds this task" offline, at any point in the chain.
+    "who last took this task, and has it gone back to the pool" offline, at
+    any point in the chain.
 
     Args:
         chain: The audit chain store accepting the entry.
@@ -3964,8 +3968,9 @@ def record_task_release_receipt(
         task_version: The task version after the releasing transition.
         release_path: Which path ended the claim (``force_claim`` /
             ``reopen`` / ``release`` / ``cancel`` / ``cancel_cascade`` /
-            ``fail`` / ``abandon`` / ``restart_recovery`` /
-            ``node_departure``).
+            ``fail`` / ``fail_contract_violation`` /
+            ``fail_empty_completion`` / ``refuse`` / ``abandon`` /
+            ``abandon_cascade`` / ``restart_recovery`` / ``node_departure``).
         reason: The transition's recorded reason.
         from_status: Task status the claim was held in.
         to_status: Task status the release moved it to.
@@ -3994,26 +3999,40 @@ def record_task_release_receipt(
 
 
 def reconstruct_claim_holders(events: Iterable[AuditEvent]) -> dict[str, str]:
-    """Fold claim and release receipts into the current holder per task (#3037).
+    """Fold claim and release receipts into the last claimant per task (#3037).
 
-    Offline reconstruction of task ownership from the chain alone: a
-    ``task.claim_receipt`` records a task as held by its claimer, the matching
-    ``task.release_receipt`` removes it. Pass a prefix of the chain to
-    reconstruct ownership as of that point.
+    Offline reconstruction from the chain alone: a ``task.claim_receipt``
+    records a task as taken by its claimer, the matching
+    ``task.release_receipt`` drops it. Pass a prefix of the chain to
+    reconstruct the same projection as of that point.
+
+    This is not "who is executing this task right now". Delivery mints no
+    release receipt, so a task that ran to completion stays mapped to the
+    worker that delivered it until something puts it back in the pool. What
+    the fold does guarantee is the property the acquisition-only ledger could
+    not support: every path that returns a task to the pool records a release
+    first, so a task is never mapped to one claimant while another holds it.
+    Cross-check the task's status when the caller needs liveness rather than
+    attribution.
 
     A release for a task with no recorded claim is tolerated (the claim may
     predate the range passed in, or have been granted through a store-level
-    path that mints no receipt) and simply leaves the task unheld.
+    path that mints no receipt) and simply leaves the task unclaimed.
+
+    Chains written before #3037 carry acquisitions only, so over that region
+    the fold reports every task ever claimed as still claimed; nothing in the
+    receipt marks where the release half starts, so a caller reading a chain
+    that spans the upgrade has to bound the range itself.
 
     Args:
         events: Audit events in chain order. Non-claim events are ignored, so
             the full chain can be passed unfiltered.
 
     Returns:
-        Mapping of task id to the identifier currently holding it. Tasks with
-        no live claim are absent. A held task whose claim carried no session
-        id maps to the empty string, which is still distinguishable from
-        "not held" by key membership.
+        Mapping of task id to the identifier that last claimed it without a
+        recorded release. Tasks whose claim was released are absent. A claim
+        that carried no session id maps to the empty string, which is still
+        distinguishable from "released" by key membership.
     """
     holders: dict[str, str] = {}
     for event in events:

--- a/src/bernstein/core/server/server_app.py
+++ b/src/bernstein/core/server/server_app.py
@@ -1322,6 +1322,14 @@ def create_app(
     from bernstein.core.communication.task_mailbox import TaskMailbox
 
     application.state.audit_chain = _audit_chain  # type: ignore[attr-defined]
+    # Both halves of the claim ledger land on this chain (#3037). The claim
+    # routes mirror every granted claim as ``task.claim_receipt``; the store
+    # mirrors every transition that ends a held claim as the matching
+    # ``task.release_receipt``. Attached here rather than behind
+    # ``BERNSTEIN_AUDIT`` so a plain ``bernstein serve`` node records both --
+    # an acquisition-only ledger replays as node A holding a task node B is
+    # already running.
+    store.attach_audit_chain(_audit_chain)
     application.state.task_mailbox = TaskMailbox(  # type: ignore[attr-defined]
         jsonl_path.parent / "mailbox.jsonl",
         hmac_key=_chain_key,

--- a/src/bernstein/core/server/server_app.py
+++ b/src/bernstein/core/server/server_app.py
@@ -1324,7 +1324,7 @@ def create_app(
     application.state.audit_chain = _audit_chain  # type: ignore[attr-defined]
     # Both halves of the claim ledger land on this chain (#3037). The claim
     # routes mirror every granted claim as ``task.claim_receipt``; the store
-    # mirrors every transition that ends a held claim as the matching
+    # mirrors every transition that surrenders a held claim as the matching
     # ``task.release_receipt``. Attached here rather than behind
     # ``BERNSTEIN_AUDIT`` so a plain ``bernstein serve`` node records both --
     # an acquisition-only ledger replays as node A holding a task node B is

--- a/src/bernstein/core/tasks/task_store_core.py
+++ b/src/bernstein/core/tasks/task_store_core.py
@@ -49,14 +49,16 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-#: Statuses in which a claim granted by a claim endpoint is still held by its
-#: owner (#3037). A task leaving one of these has surrendered its claim -- it
-#: either returned to the pool or died terminally without delivering -- and the
-#: transition mints a ``task.release_receipt`` on the audit chain, the
-#: counterpart of the ``task.claim_receipt`` the claim minted. ``OPEN`` and
-#: ``PLANNED`` are excluded because nothing holds those; the terminal statuses
-#: are excluded because the claim has already ended by the time they are
-#: reached.
+#: Statuses a worker can be sitting in while it still owns the task (#3037).
+#: A task moving out of one of these is either going back to the pool or
+#: terminating without delivering, so the transition has to be paired with a
+#: ``task.release_receipt`` unless it is a delivery (``DONE`` / ``CLOSED``, see
+#: :data:`CLAIM_DELIVERED_STATUSES`). ``OPEN`` and ``PLANNED`` are excluded
+#: because nothing owns those. This set is not the test for "was a claim
+#: actually held" -- that is claim evidence on the task itself, see
+#: :meth:`TaskStore._claim_snapshot` -- it is the set the release guard in
+#: ``tests/unit/test_task_release_receipt.py`` reads to decide which
+#: transitions need a receipt.
 CLAIM_HELD_STATUSES: frozenset[TaskStatus] = frozenset(
     {
         TaskStatus.CLAIMED,
@@ -64,7 +66,20 @@ CLAIM_HELD_STATUSES: frozenset[TaskStatus] = frozenset(
         TaskStatus.WAITING_FOR_SUBTASKS,
         TaskStatus.BLOCKED,
         TaskStatus.ORPHANED,
-        TaskStatus.SUSPENDED,
+    }
+)
+
+#: Statuses a task reaches by delivering its result (#3037). Reaching one of
+#: these is not a surrender: the worker finished the job it claimed, and the
+#: claim only ends when the task later goes back to the pool (``reopen``, which
+#: does mint a receipt) or stays terminal. Release receipts are deliberately
+#: not minted here, so a fold of the chain reports a delivered task under the
+#: worker that delivered it rather than as unowned. See
+#: :func:`bernstein.core.security.audit_chain.reconstruct_claim_holders`.
+CLAIM_DELIVERED_STATUSES: frozenset[TaskStatus] = frozenset(
+    {
+        TaskStatus.DONE,
+        TaskStatus.CLOSED,
     }
 )
 
@@ -75,7 +90,11 @@ class ClaimSnapshot(NamedTuple):
     Attributes:
         status: Status the task was in.
         holder: Claim owner, matching the claim receipt's ``claimed_by``.
-        held: Whether a claim existed to surrender at all.
+        held: Whether the task carried evidence of an actual claim. Status
+            membership is deliberately not part of this: a task can reach
+            ``WAITING_FOR_SUBTASKS`` or ``BLOCKED`` without ever having been
+            claimed, and minting a surrender for a claim that never existed
+            writes a false record onto a signed chain.
     """
 
     status: TaskStatus
@@ -403,8 +422,8 @@ class TaskStore:
     def attach_audit_chain(self, chain: AuditChainStore | None) -> None:
         """Route this store's claim ledger to *chain* (#3037).
 
-        Claims mint a ``task.claim_receipt``; every transition that ends a
-        held claim mints the matching ``task.release_receipt`` here, so the
+        Claims mint a ``task.claim_receipt``; every transition that surrenders
+        a held claim mints the matching ``task.release_receipt`` here, so the
         chain records both halves and a replay reports the real holder of a
         task instead of the last node that acquired it.
 
@@ -422,18 +441,26 @@ class TaskStore:
         ``claimed_at`` / ``claimed_by_session`` and move the status, so after
         the fact there is nothing left to attribute the release to.
 
+        ``held`` is decided on claim evidence carried by the task, not on its
+        status. ``OPEN -> WAITING_FOR_SUBTASKS`` and ``... -> BLOCKED`` are
+        legal without any claim, so a status test mints a surrender for a
+        claim that never existed, and a fabricated surrender on a signed chain
+        is worse than a missing one: a verifier folding the chain cannot tell
+        it apart from a real one.
+
         Args:
             task: The task about to transition.
 
         Returns:
-            The status, claim owner, and whether a claim was held at all. The
-            owner matches the ``claimed_by`` field of the claim receipt, so
-            claim and release receipts name the same identity.
+            The status, claim owner, and whether the task carried evidence of
+            an actual claim. The owner matches the ``claimed_by`` field of the
+            claim receipt, so claim and release receipts name the same
+            identity.
         """
         return ClaimSnapshot(
             status=task.status,
             holder=task.claimed_by_session or task.assigned_agent or "",
-            held=task.claimed_at is not None or task.status in CLAIM_HELD_STATUSES,
+            held=task.claimed_at is not None or bool(task.claimed_by_session),
         )
 
     def _record_release_receipt(
@@ -447,11 +474,12 @@ class TaskStore:
         """Mirror a surrendered claim into the audit chain (#3037).
 
         The counterpart of the claim receipt the claim path mints. Called by
-        every transition that ends a held claim, after the transition has been
-        applied, so the receipt carries the post-transition task version.
+        every transition that surrenders a held claim, after the transition
+        has been applied, so the receipt carries the post-transition task
+        version.
 
-        No-ops when no chain is attached or when the task held no claim to
-        surrender (a never-claimed task being cancelled surrenders nothing).
+        No-ops when no chain is attached or when the task carried no claim
+        evidence (a never-claimed task being cancelled surrenders nothing).
         Best-effort: a chain append failure never rolls back the transition
         that already happened.
 
@@ -1879,6 +1907,7 @@ class TaskStore:
                     TaskStatus.REFUSED,
                 ):
                     raise EmptyCompletionError(task_id, task)
+                snapshot = self._claim_snapshot(task)
                 self._index_remove(task)
                 transition_task(
                     task,
@@ -1893,6 +1922,16 @@ class TaskStore:
                 completed_at = task.completed_at
                 await self._append_jsonl(self._task_to_record(task))
                 await self._append_archive(task, completed_at)
+                # The slot this frees is a surrender, not a delivery: the
+                # worker held the claim and produced nothing, so the ledger
+                # needs the release half or the chain keeps naming it as the
+                # holder of a task it never finished (#3037).
+                self._record_release_receipt(
+                    task,
+                    snapshot,
+                    release_path="fail_empty_completion",
+                    reason=_EMPTY_COMPLETION_REASON,
+                )
             raise EmptyCompletionError(task_id, task)
 
         async with self._lock:
@@ -2302,7 +2341,10 @@ class TaskStore:
             )
 
             # Cascade: downstream tasks waiting on this one move to
-            # BLOCKED_BY_ABANDON so consumers stop waiting forever.
+            # BLOCKED_BY_ABANDON so consumers stop waiting forever. A
+            # downstream can be CLAIMED or IN_PROGRESS under a different node
+            # than the one that abandoned the upstream, so this loop ends
+            # claims it never granted and owes each one a receipt (#3037).
             for downstream in list(self._tasks.values()):
                 if task_id not in downstream.depends_on:
                     continue
@@ -2313,6 +2355,7 @@ class TaskStore:
                     TaskStatus.WAITING_FOR_SUBTASKS,
                 }:
                     continue
+                downstream_snapshot = self._claim_snapshot(downstream)
                 self._index_remove(downstream)
                 try:
                     transition_task(
@@ -2329,6 +2372,12 @@ class TaskStore:
                 downstream.version += 1
                 self._index_add(downstream)
                 await self._append_jsonl(self._task_to_record(downstream))
+                self._record_release_receipt(
+                    downstream,
+                    downstream_snapshot,
+                    release_path="abandon_cascade",
+                    reason=f"upstream {task_id} abandoned: {row.reason.value}",
+                )
 
             # Ledger write is last so the in-memory state is the source
             # of truth even when the ledger file is read-only / OOS.

--- a/src/bernstein/core/tasks/task_store_core.py
+++ b/src/bernstein/core/tasks/task_store_core.py
@@ -15,7 +15,7 @@ import uuid
 from collections import deque
 from dataclasses import asdict
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, NotRequired, Protocol, cast
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, NotRequired, Protocol, cast
 
 from fastapi import HTTPException
 from typing_extensions import TypedDict
@@ -44,9 +44,44 @@ from bernstein.core.tenanting import ensure_tenant_layout, normalize_tenant_id
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
 
+    from bernstein.core.security.audit_chain import AuditChainStore
     from bernstein.core.tasks.contracts import ContractViolation, WorkerCompletion, WorkerRefusal
 
 logger = logging.getLogger(__name__)
+
+#: Statuses in which a claim granted by a claim endpoint is still held by its
+#: owner (#3037). A task leaving one of these has surrendered its claim -- it
+#: either returned to the pool or died terminally without delivering -- and the
+#: transition mints a ``task.release_receipt`` on the audit chain, the
+#: counterpart of the ``task.claim_receipt`` the claim minted. ``OPEN`` and
+#: ``PLANNED`` are excluded because nothing holds those; the terminal statuses
+#: are excluded because the claim has already ended by the time they are
+#: reached.
+CLAIM_HELD_STATUSES: frozenset[TaskStatus] = frozenset(
+    {
+        TaskStatus.CLAIMED,
+        TaskStatus.IN_PROGRESS,
+        TaskStatus.WAITING_FOR_SUBTASKS,
+        TaskStatus.BLOCKED,
+        TaskStatus.ORPHANED,
+        TaskStatus.SUSPENDED,
+    }
+)
+
+
+class ClaimSnapshot(NamedTuple):
+    """Claim state read off a task before a transition that may end it (#3037).
+
+    Attributes:
+        status: Status the task was in.
+        holder: Claim owner, matching the claim receipt's ``claimed_by``.
+        held: Whether a claim existed to surrender at all.
+    """
+
+    status: TaskStatus
+    holder: str
+    held: bool
+
 
 # ---------------------------------------------------------------------------
 # TypedDicts for file-based state records
@@ -356,6 +391,96 @@ class TaskStore:
         # here so that progress history survives a server crash.  Rebuilt on
         # startup by ``replay_progress()``.
         self._progress_dir: Path = jsonl_path.parent / "progress"
+        # Audit chain the claim ledger is written to (#3037). Attached by
+        # ``create_app`` on every server, so a plain ``bernstein serve`` node
+        # mints release receipts without the orchestrator's ``BERNSTEIN_AUDIT``
+        # wiring. ``None`` in bare store usage (CLI, tests), where the receipt
+        # is skipped rather than the transition refused.
+        self._audit_chain: AuditChainStore | None = None
+
+    # -- claim ledger --------------------------------------------------------
+
+    def attach_audit_chain(self, chain: AuditChainStore | None) -> None:
+        """Route this store's claim ledger to *chain* (#3037).
+
+        Claims mint a ``task.claim_receipt``; every transition that ends a
+        held claim mints the matching ``task.release_receipt`` here, so the
+        chain records both halves and a replay reports the real holder of a
+        task instead of the last node that acquired it.
+
+        Args:
+            chain: Audit chain store to append release receipts to, or
+                ``None`` to detach.
+        """
+        self._audit_chain = chain
+
+    @staticmethod
+    def _claim_snapshot(task: Task) -> ClaimSnapshot:
+        """Capture *task*'s claim state before a transition that may end it (#3037).
+
+        Must be read before the transition: the releasing paths clear
+        ``claimed_at`` / ``claimed_by_session`` and move the status, so after
+        the fact there is nothing left to attribute the release to.
+
+        Args:
+            task: The task about to transition.
+
+        Returns:
+            The status, claim owner, and whether a claim was held at all. The
+            owner matches the ``claimed_by`` field of the claim receipt, so
+            claim and release receipts name the same identity.
+        """
+        return ClaimSnapshot(
+            status=task.status,
+            holder=task.claimed_by_session or task.assigned_agent or "",
+            held=task.claimed_at is not None or task.status in CLAIM_HELD_STATUSES,
+        )
+
+    def _record_release_receipt(
+        self,
+        task: Task,
+        snapshot: ClaimSnapshot,
+        *,
+        release_path: str,
+        reason: str,
+    ) -> None:
+        """Mirror a surrendered claim into the audit chain (#3037).
+
+        The counterpart of the claim receipt the claim path mints. Called by
+        every transition that ends a held claim, after the transition has been
+        applied, so the receipt carries the post-transition task version.
+
+        No-ops when no chain is attached or when the task held no claim to
+        surrender (a never-claimed task being cancelled surrenders nothing).
+        Best-effort: a chain append failure never rolls back the transition
+        that already happened.
+
+        Args:
+            task: The task whose claim ended, already transitioned.
+            snapshot: Claim state captured by :meth:`_claim_snapshot` before
+                the transition.
+            release_path: Which path ended the claim.
+            reason: The transition's recorded reason.
+        """
+        chain = self._audit_chain
+        if chain is None or not snapshot.held:
+            return
+        from bernstein.core.security.audit_chain import record_task_release_receipt
+
+        try:
+            record_task_release_receipt(
+                chain=chain,
+                task_id=task.id,
+                role=task.role,
+                released_by=snapshot.holder,
+                task_version=task.version,
+                release_path=release_path,
+                reason=reason,
+                from_status=snapshot.status.value,
+                to_status=task.status.value,
+            )
+        except Exception as exc:  # intentional-broad-except: receipt mirror is best-effort, never blocks the transition
+            logger.warning("task.release receipt append failed: %s", type(exc).__name__)
 
     # -- index helpers -------------------------------------------------------
 
@@ -487,6 +612,7 @@ class TaskStore:
         reset_tasks: list[Task] = []
         for stale_status in (TaskStatus.CLAIMED, TaskStatus.IN_PROGRESS):
             for task in list(self._by_status.get(stale_status, {}).values()):
+                snapshot = self._claim_snapshot(task)
                 self._index_remove(task)
                 # Use the FSM for the transition so audit/telemetry fire and
                 # any illegal jump is caught.  CLAIMED→OPEN and
@@ -501,6 +627,12 @@ class TaskStore:
                 task.claimed_at = None
                 task.claimed_by_session = None
                 self._index_add(task)
+                self._record_release_receipt(
+                    task,
+                    snapshot,
+                    release_path="restart_recovery",
+                    reason="recover_stale_after_restart",
+                )
                 reset_tasks.append(task)
                 reset_count += 1
         if reset_count:
@@ -543,6 +675,7 @@ class TaskStore:
             for task in list(self._by_status.get(stale_status, {}).values()):
                 if task.claimed_by_session != node_id:
                     continue
+                snapshot = self._claim_snapshot(task)
                 self._index_remove(task)
                 transition_task(
                     task,
@@ -554,6 +687,12 @@ class TaskStore:
                 task.claimed_by_session = None
                 task.version += 1
                 self._index_add(task)
+                self._record_release_receipt(
+                    task,
+                    snapshot,
+                    release_path="node_departure",
+                    reason="recover_node_departed",
+                )
                 reset_tasks.append(task)
                 reset_count += 1
         if reset_count:
@@ -1845,6 +1984,7 @@ class TaskStore:
             task = self._tasks.get(task_id)
             if task is None:
                 raise KeyError(task_id)
+            snapshot = self._claim_snapshot(task)
             self._index_remove(task)
             transition_task(task, TaskStatus.FAILED, actor="task_store", reason=reason)
             task.result_summary = reason
@@ -1856,6 +1996,7 @@ class TaskStore:
             completed_at = task.completed_at
             await self._append_jsonl(self._task_to_record(task))
             await self._append_archive(task, completed_at)
+            self._record_release_receipt(task, snapshot, release_path="fail", reason=reason)
             return task
 
     async def fail_contract_violation(self, task_id: str, violation: ContractViolation) -> Task:
@@ -1885,6 +2026,7 @@ class TaskStore:
             task = self._tasks.get(task_id)
             if task is None:
                 raise KeyError(task_id)
+            snapshot = self._claim_snapshot(task)
             self._index_remove(task)
             transition_task(task, TaskStatus.FAILED, actor="task_store", reason=reason)
             task.result_summary = reason
@@ -1898,6 +2040,7 @@ class TaskStore:
             completed_at = task.completed_at
             await self._append_jsonl(self._task_to_record(task))
             await self._append_archive(task, completed_at)
+            self._record_release_receipt(task, snapshot, release_path="fail_contract_violation", reason=reason)
         self._audit_contract_outcome(task_id, outcome="violation", schema_error_path=violation.path)
         return task
 
@@ -1929,6 +2072,7 @@ class TaskStore:
             task = self._tasks.get(task_id)
             if task is None:
                 raise KeyError(task_id)
+            snapshot = self._claim_snapshot(task)
             self._index_remove(task)
             transition_task(task, TaskStatus.REFUSED, actor="task_store", reason=refusal.detail)
             task.result_summary = refusal.detail
@@ -1942,6 +2086,7 @@ class TaskStore:
             completed_at = task.completed_at
             await self._append_jsonl(self._task_to_record(task))
             await self._append_archive(task, completed_at)
+            self._record_release_receipt(task, snapshot, release_path="refuse", reason=outcome)
         self._audit_contract_outcome(task_id, outcome=outcome)
         return task
 
@@ -2053,6 +2198,7 @@ class TaskStore:
             task = self._tasks.get(task_id)
             if task is None:
                 raise KeyError(task_id)
+            snapshot = self._claim_snapshot(task)
             self._index_remove(task)
             transition_task(task, TaskStatus.OPEN, actor="task_store", reason=reason)
             reopen_count = int(task.metadata.get("janitor_reopen_count", 0) or 0) + 1
@@ -2066,6 +2212,7 @@ class TaskStore:
             task.version += 1
             self._index_add(task)
             await self._append_jsonl(self._task_to_record(task))
+            self._record_release_receipt(task, snapshot, release_path="reopen", reason=reason)
             logger.info(
                 "task.reopen: task_id=%s reopen_count=%d reason=%s",
                 sanitize_log(task_id),
@@ -2136,6 +2283,7 @@ class TaskStore:
                 attempts=task.retry_count,
             )
 
+            snapshot = self._claim_snapshot(task)
             self._index_remove(task)
             transition_task(task, TaskStatus.ABANDONED, actor="task_store", reason=detail or reason)
             task.result_summary = detail or reason
@@ -2146,6 +2294,12 @@ class TaskStore:
             completed_at = task.completed_at
             await self._append_jsonl(self._task_to_record(task))
             await self._append_archive(task, completed_at)
+            self._record_release_receipt(
+                task,
+                snapshot,
+                release_path="abandon",
+                reason=row.reason.value,
+            )
 
             # Cascade: downstream tasks waiting on this one move to
             # BLOCKED_BY_ABANDON so consumers stop waiting forever.
@@ -2368,6 +2522,7 @@ class TaskStore:
             }
             if task.status not in _cancellable:
                 raise ValueError(f"Task '{task_id}' cannot be cancelled from status '{task.status.value}'")
+            snapshot = self._claim_snapshot(task)
             self._index_remove(task)
             transition_task(task, TaskStatus.CANCELLED, actor="task_store", reason=reason)
             task.result_summary = reason
@@ -2377,6 +2532,7 @@ class TaskStore:
             completed_at = task.completed_at
             await self._append_jsonl(self._task_to_record(task))
             await self._append_archive(task, completed_at)
+            self._record_release_receipt(task, snapshot, release_path="cancel", reason=reason)
             return task
 
     # -- TASK-002: WAITING_FOR_SUBTASKS timeout with escalation ---------------
@@ -2501,12 +2657,14 @@ class TaskStore:
                 task = self._tasks.get(tid)
                 if task is None or task.status not in cancellable:
                     continue
+                cascade_reason = reason if tid == task_id else f"parent {task_id} cancelled: {reason}"
+                snapshot = self._claim_snapshot(task)
                 self._index_remove(task)
                 transition_task(
                     task,
                     TaskStatus.CANCELLED,
                     actor="task_store",
-                    reason=reason if tid == task_id else f"parent {task_id} cancelled: {reason}",
+                    reason=cascade_reason,
                 )
                 task.result_summary = reason if tid == task_id else f"Cascade: parent {task_id} cancelled"
                 task.completed_at = time.time()
@@ -2515,6 +2673,12 @@ class TaskStore:
                 completed_at = task.completed_at
                 await self._append_jsonl(self._task_to_record(task))
                 await self._append_archive(task, completed_at)
+                self._record_release_receipt(
+                    task,
+                    snapshot,
+                    release_path="cancel_cascade",
+                    reason=cascade_reason,
+                )
                 cancelled.append(task)
 
         return cancelled
@@ -2621,6 +2785,7 @@ class TaskStore:
                 raise ValueError(
                     f"Task '{task_id}' is in terminal state '{task.status.value}' and cannot be force-claimed"
                 )
+            snapshot = self._claim_snapshot(task)
             # Set priority *before* re-indexing so the heap entry carries the
             # final priority - otherwise the pushed (old_priority, id) tuple
             # diverges from task.priority and claim_next will skip it as
@@ -2640,6 +2805,7 @@ class TaskStore:
             task.claimed_by_session = None  # Clear ownership on force-claim
             task.version += 1
             await self._append_jsonl(self._task_to_record(task))
+            self._record_release_receipt(task, snapshot, release_path="force_claim", reason="force_claim")
             return task
 
     # -- query / listing (delegated from task_store_index) ------------------

--- a/tests/unit/test_task_release_receipt.py
+++ b/tests/unit/test_task_release_receipt.py
@@ -1,0 +1,439 @@
+"""Release-receipt regression tests (#3037).
+
+Claiming a task mints a ``task.claim_receipt`` on the audit chain. These tests
+pin the other half: every transition that ends a held claim mints the matching
+``task.release_receipt``, so folding the chain reconstructs the real holder of
+a task instead of the last node that acquired it.
+
+The tests are organised as:
+
+* an enumeration over every un-claim path in :class:`TaskStore`, so a new path
+  that forgets the receipt is caught by name rather than by luck;
+* an offline reconstruction of claim -> release -> re-claim asserted from the
+  chain alone;
+* the same reconstruction on a plain ``bernstein serve`` node, with the
+  orchestrator's ``BERNSTEIN_AUDIT`` lifecycle wiring absent;
+* a static guard that no future method can clear ``claimed_by_session``
+  without minting the receipt.
+"""
+
+from __future__ import annotations
+
+import ast
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from bernstein.core.security.audit_chain import (
+    EVENT_TASK_CLAIM_RECEIPT,
+    EVENT_TASK_RELEASE_RECEIPT,
+    AuditChainStore,
+    reconstruct_claim_holders,
+)
+from bernstein.core.tasks.contracts import ContractViolation, RefusalKind, WorkerRefusal
+from bernstein.core.tasks.models import Task, TaskStatus
+from bernstein.core.tasks.task_store_core import TaskStore
+
+if TYPE_CHECKING:
+    from bernstein.core.security.audit import AuditEvent
+
+_KEY = b"release-receipt-test-key"
+_HOLDER = "node-a"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _store(tmp_path: Path) -> tuple[TaskStore, AuditChainStore]:
+    """Build a TaskStore with an audit chain attached, as ``create_app`` does."""
+    runtime = tmp_path / "runtime"
+    runtime.mkdir(parents=True, exist_ok=True)
+    store = TaskStore(runtime / "tasks.jsonl", archive_path=tmp_path / "archive" / "tasks.jsonl")
+    chain = AuditChainStore(tmp_path / "audit", key=_KEY)
+    store.attach_audit_chain(chain)
+    return store, chain
+
+
+def _held(store: TaskStore, task_id: str = "T-1", **overrides: Any) -> Task:
+    """Insert a task that a worker currently holds a claim on."""
+    base: dict[str, Any] = {
+        "id": task_id,
+        "title": "t",
+        "description": "d",
+        "role": "backend",
+        "status": TaskStatus.IN_PROGRESS,
+        "claimed_at": time.time(),
+        "claimed_by_session": _HOLDER,
+    }
+    base.update(overrides)
+    task = Task(**base)
+    store._tasks[task.id] = task
+    store._index_add(task)
+    return task
+
+
+def _releases(chain: AuditChainStore) -> list[AuditEvent]:
+    return chain.query(event_type=EVENT_TASK_RELEASE_RECEIPT)
+
+
+# ---------------------------------------------------------------------------
+# One test per un-claim path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestEveryUnclaimPathMintsAReceipt:
+    """Enumerates the un-claim paths instead of spot-checking one of them."""
+
+    async def test_force_claim(self, tmp_path: Path) -> None:
+        store, chain = _store(tmp_path)
+        _held(store)
+        await store.force_claim("T-1")
+        events = _releases(chain)
+        assert len(events) == 1
+        assert events[0].details["release_path"] == "force_claim"
+        assert events[0].details["released_by"] == _HOLDER
+        assert events[0].details["from_status"] == "in_progress"
+        assert events[0].details["to_status"] == "open"
+
+    async def test_reopen(self, tmp_path: Path) -> None:
+        store, chain = _store(tmp_path)
+        _held(store, status=TaskStatus.DONE)
+        await store.reopen("T-1", "janitor verification failed")
+        events = _releases(chain)
+        assert len(events) == 1
+        assert events[0].details["release_path"] == "reopen"
+        assert events[0].details["released_by"] == _HOLDER
+        assert events[0].details["to_status"] == "open"
+
+    async def test_cancel(self, tmp_path: Path) -> None:
+        store, chain = _store(tmp_path)
+        _held(store)
+        await store.cancel("T-1", "operator cancelled")
+        events = _releases(chain)
+        assert len(events) == 1
+        assert events[0].details["release_path"] == "cancel"
+        assert events[0].details["to_status"] == "cancelled"
+
+    async def test_cancel_cascade(self, tmp_path: Path) -> None:
+        # The /tasks/{id}/cancel route cascades, so the cascade body needs its
+        # own receipt: a child held by another node is un-claimed here too.
+        store, chain = _store(tmp_path)
+        _held(store, "T-1")
+        _held(store, "T-2", parent_task_id="T-1", claimed_by_session="node-b")
+        await store.cancel_cascade("T-1", "operator cancelled the tree")
+        released = {e.details["task_id"]: e.details["released_by"] for e in _releases(chain)}
+        assert released == {"T-1": _HOLDER, "T-2": "node-b"}
+
+    async def test_fail(self, tmp_path: Path) -> None:
+        store, chain = _store(tmp_path)
+        _held(store)
+        await store.fail("T-1", "tests red")
+        events = _releases(chain)
+        assert len(events) == 1
+        assert events[0].details["release_path"] == "fail"
+        assert events[0].details["to_status"] == "failed"
+
+    async def test_fail_contract_violation(self, tmp_path: Path) -> None:
+        store, chain = _store(tmp_path)
+        _held(store)
+        await store.fail_contract_violation("T-1", ContractViolation(path="$.status", message="missing"))
+        events = _releases(chain)
+        assert len(events) == 1
+        assert events[0].details["release_path"] == "fail_contract_violation"
+
+    async def test_refuse(self, tmp_path: Path) -> None:
+        store, chain = _store(tmp_path)
+        _held(store)
+        await store.refuse(
+            "T-1",
+            WorkerRefusal(kind=RefusalKind.SCOPE_EXCEEDED, detail="needs a spec change"),
+        )
+        events = _releases(chain)
+        assert len(events) == 1
+        assert events[0].details["release_path"] == "refuse"
+        assert events[0].details["to_status"] == "refused"
+
+    async def test_abandon(self, tmp_path: Path) -> None:
+        store, chain = _store(tmp_path)
+        _held(store)
+        await store.abandon("T-1", "out_of_scope", "spec mismatch")
+        events = _releases(chain)
+        assert len(events) == 1
+        assert events[0].details["release_path"] == "abandon"
+        assert events[0].details["to_status"] == "abandoned"
+
+    async def test_restart_recovery(self, tmp_path: Path) -> None:
+        store, chain = _store(tmp_path)
+        _held(store, "T-1", status=TaskStatus.CLAIMED)
+        _held(store, "T-2", status=TaskStatus.IN_PROGRESS)
+        assert store.recover_stale_claimed_tasks() == 2
+        events = _releases(chain)
+        assert {e.details["task_id"] for e in events} == {"T-1", "T-2"}
+        assert {e.details["release_path"] for e in events} == {"restart_recovery"}
+
+    async def test_node_departure(self, tmp_path: Path) -> None:
+        store, chain = _store(tmp_path)
+        _held(store, "T-1")
+        _held(store, "T-2", claimed_by_session="node-b")
+        assert store.reopen_tasks_for_node(_HOLDER) == 1
+        events = _releases(chain)
+        assert len(events) == 1
+        assert events[0].details["task_id"] == "T-1"
+        assert events[0].details["release_path"] == "node_departure"
+        assert events[0].details["released_by"] == _HOLDER
+
+
+@pytest.mark.asyncio
+class TestReceiptShape:
+    async def test_a_never_claimed_task_surrenders_nothing(self, tmp_path: Path) -> None:
+        # Cancelling an open task that no worker ever held is not a surrender,
+        # so it must not add a release with nothing to release.
+        store, chain = _store(tmp_path)
+        _held(store, status=TaskStatus.OPEN, claimed_at=None, claimed_by_session=None)
+        await store.cancel("T-1", "never started")
+        assert _releases(chain) == []
+
+    async def test_receipt_carries_the_post_transition_version_and_reason(self, tmp_path: Path) -> None:
+        store, chain = _store(tmp_path)
+        task = _held(store)
+        before = task.version
+        await store.fail("T-1", "tests red")
+        details = _releases(chain)[0].details
+        assert details["task_version"] == before + 1
+        assert details["reason"] == "tests red"
+        assert details["role"] == "backend"
+        # Chain-anchored exactly like the claim receipt it answers.
+        assert details["prev_chain_digest"]
+        ok, errors = chain.verify()
+        assert ok, errors
+
+    async def test_a_chain_append_failure_never_blocks_the_transition(self, tmp_path: Path) -> None:
+        store, _chain = _store(tmp_path)
+
+        class _Broken:
+            def log_with_prev_digest(self, **_: Any) -> None:
+                raise OSError("chain volume is read-only")
+
+        store.attach_audit_chain(_Broken())  # type: ignore[arg-type]
+        _held(store)
+        task = await store.force_claim("T-1")
+        assert task.status is TaskStatus.OPEN
+
+
+# ---------------------------------------------------------------------------
+# Offline reconstruction from the chain alone
+# ---------------------------------------------------------------------------
+
+
+def _seed_claim(chain: AuditChainStore, task_id: str, holder: str) -> None:
+    from bernstein.core.security.audit_chain import record_task_claim_receipt
+
+    record_task_claim_receipt(
+        chain=chain,
+        task_id=task_id,
+        role="backend",
+        claimed_by=holder,
+        depends_on=[],
+        task_version=1,
+        claim_path="by_id",
+    )
+
+
+@pytest.mark.asyncio
+async def test_replay_reconstructs_the_holder_at_each_point(tmp_path: Path) -> None:
+    """claim -> release -> re-claim, read back offline from the chain."""
+    store, chain = _store(tmp_path)
+    _held(store, status=TaskStatus.CLAIMED)
+    _seed_claim(chain, "T-1", _HOLDER)
+    assert reconstruct_claim_holders(chain.query()) == {"T-1": _HOLDER}
+
+    await store.force_claim("T-1")
+    assert reconstruct_claim_holders(chain.query()) == {}
+
+    _held(store, status=TaskStatus.CLAIMED, claimed_by_session="node-b")
+    _seed_claim(chain, "T-1", "node-b")
+    assert reconstruct_claim_holders(chain.query()) == {"T-1": "node-b"}
+
+    # Every prefix answers the question, not just the head: a verifier holding
+    # a copy of the chain replays ownership as of any point.
+    events = chain.query()
+    holders_by_prefix = [reconstruct_claim_holders(events[:n]) for n in range(len(events) + 1)]
+    assert holders_by_prefix[-1] == {"T-1": "node-b"}
+    assert {} in holders_by_prefix
+
+    # A second store over the same on-disk chain reaches the same answer.
+    reloaded = AuditChainStore(tmp_path / "audit", key=_KEY)
+    assert reconstruct_claim_holders(reloaded.query()) == {"T-1": "node-b"}
+
+
+def test_an_acquisition_only_chain_misreports_the_holder(tmp_path: Path) -> None:
+    """The failure this issue is about, pinned as the contrast case."""
+    chain = AuditChainStore(tmp_path / "audit", key=_KEY)
+    _seed_claim(chain, "T-1", "node-a")
+    _seed_claim(chain, "T-1", "node-b")
+    # Claims alone cannot distinguish "node-a handed it over" from "both hold
+    # it": only the release receipt in between makes the sequence legible.
+    claims = [e.details["claimed_by"] for e in chain.query(event_type=EVENT_TASK_CLAIM_RECEIPT)]
+    assert claims == ["node-a", "node-b"]
+    assert reconstruct_claim_holders(chain.query()) == {"T-1": "node-b"}
+
+
+# ---------------------------------------------------------------------------
+# Plain ``bernstein serve`` node -- no BERNSTEIN_AUDIT wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def plain_serve_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):  # type: ignore[no-untyped-def]
+    """A server built the way ``bernstein serve`` builds one.
+
+    ``BERNSTEIN_AUDIT`` is what wires the orchestrator's lifecycle audit log,
+    which is where the generic ``task.transition`` event comes from. It is
+    cleared here, and the lifecycle module's global is reset, so the only
+    events this app can produce are the ones the server itself writes.
+    """
+    from bernstein.core.server import create_app
+    from bernstein.core.tasks import lifecycle
+
+    monkeypatch.delenv("BERNSTEIN_AUDIT", raising=False)
+    monkeypatch.setattr(lifecycle, "_audit_log", None)
+    app = create_app(jsonl_path=tmp_path / "runtime" / "tasks.jsonl")
+    app.state.draining = False
+    return app
+
+
+def _create_and_claim(client: TestClient, title: str = "release me") -> str:
+    created = client.post("/tasks", json={"title": title, "description": "d", "role": "backend"})
+    assert created.status_code == 201, created.text
+    task_id = created.json()["id"]
+    claimed = client.post(f"/tasks/{task_id}/claim", params={"claimed_by_session": _HOLDER})
+    assert claimed.status_code == 200, claimed.text
+    return str(task_id)
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "body", "release_path"),
+    [
+        ("force-claim", None, "force_claim"),
+        ("cancel", {"reason": "operator cancelled"}, "cancel_cascade"),
+        ("fail", {"reason": "tests red"}, "fail"),
+    ],
+)
+def test_plain_serve_node_mints_the_receipt(
+    plain_serve_app: Any,
+    endpoint: str,
+    body: dict[str, str] | None,
+    release_path: str,
+) -> None:
+    from bernstein.core.tasks.lifecycle import get_audit_log
+
+    assert get_audit_log() is None, "the orchestrator's BERNSTEIN_AUDIT wiring must be absent"
+    chain = plain_serve_app.state.audit_chain
+    with TestClient(plain_serve_app) as client:
+        task_id = _create_and_claim(client, f"release via {endpoint}")
+        before = len(chain.query(event_type=EVENT_TASK_RELEASE_RECEIPT))
+        resp = client.post(f"/tasks/{task_id}/{endpoint}", json=body)
+        assert resp.status_code == 200, resp.text
+
+    events = chain.query(event_type=EVENT_TASK_RELEASE_RECEIPT)
+    assert len(events) == before + 1
+    mine = [e for e in events if e.details["task_id"] == task_id]
+    assert len(mine) == 1
+    assert mine[0].details["release_path"] == release_path
+    assert mine[0].details["released_by"] == _HOLDER
+
+
+def test_plain_serve_node_reconstructs_the_holder_over_http(plain_serve_app: Any) -> None:
+    """The whole loop on a plain node: claim, release, re-claim, replay."""
+    chain = plain_serve_app.state.audit_chain
+    with TestClient(plain_serve_app) as client:
+        task_id = _create_and_claim(client, "reclaimed after release")
+        assert reconstruct_claim_holders(chain.query()).get(task_id) == _HOLDER
+
+        assert client.post(f"/tasks/{task_id}/force-claim").status_code == 200
+        assert task_id not in reconstruct_claim_holders(chain.query())
+
+        reclaimed = client.post(f"/tasks/{task_id}/claim", params={"claimed_by_session": "node-b"})
+        assert reclaimed.status_code == 200, reclaimed.text
+        assert reconstruct_claim_holders(chain.query()).get(task_id) == "node-b"
+
+    ok, errors = chain.verify()
+    assert ok, errors
+
+
+def test_plain_serve_node_mints_the_receipt_on_reopen(plain_serve_app: Any) -> None:
+    chain = plain_serve_app.state.audit_chain
+    with TestClient(plain_serve_app) as client:
+        task_id = _create_and_claim(client, "reopened after janitor")
+        assert client.post(f"/tasks/{task_id}/complete", json={"result_summary": "done"}).status_code == 200
+        resp = client.post(f"/tasks/{task_id}/reopen", json={"reason": "janitor signals failed"})
+        assert resp.status_code == 200, resp.text
+
+    mine = [e for e in chain.query(event_type=EVENT_TASK_RELEASE_RECEIPT) if e.details["task_id"] == task_id]
+    assert len(mine) == 1
+    assert mine[0].details["release_path"] == "reopen"
+    assert task_id not in reconstruct_claim_holders(chain.query())
+
+
+# ---------------------------------------------------------------------------
+# Static guard: no future un-claim path can skip the receipt
+# ---------------------------------------------------------------------------
+
+
+_STORE_SOURCE = Path(__file__).resolve().parents[2] / "src" / "bernstein" / "core" / "tasks" / "task_store_core.py"
+
+
+def _clears_claim(node: ast.AST) -> bool:
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Assign):
+            continue
+        if not (isinstance(child.value, ast.Constant) and child.value.value is None):
+            continue
+        for target in child.targets:
+            if isinstance(target, ast.Attribute) and target.attr == "claimed_by_session":
+                return True
+    return False
+
+
+def _mints_receipt(node: ast.AST) -> bool:
+    return any(isinstance(child, ast.Attribute) and child.attr == "_record_release_receipt" for child in ast.walk(node))
+
+
+def test_every_method_that_clears_a_claim_mints_the_receipt() -> None:
+    """A new un-claim path is a compile-time-visible omission, not a silent one.
+
+    The asymmetry this issue reports came from adding un-claim paths one at a
+    time, each next to the last. This walks the store instead of trusting the
+    list above to stay complete.
+    """
+    tree = ast.parse(_STORE_SOURCE.read_text(encoding="utf-8"))
+    store_class = next(node for node in ast.walk(tree) if isinstance(node, ast.ClassDef) and node.name == "TaskStore")
+    offenders = [
+        method.name
+        for method in store_class.body
+        if isinstance(method, ast.FunctionDef | ast.AsyncFunctionDef)
+        and _clears_claim(method)
+        and not _mints_receipt(method)
+    ]
+    assert offenders == [], (
+        f"{offenders} clear claimed_by_session without minting a task.release_receipt; "
+        "call self._record_release_receipt with a snapshot taken before the transition"
+    )
+
+
+def test_the_guard_sees_the_known_unclaim_paths() -> None:
+    """The guard above is only worth anything if it actually matches methods."""
+    tree = ast.parse(_STORE_SOURCE.read_text(encoding="utf-8"))
+    store_class = next(node for node in ast.walk(tree) if isinstance(node, ast.ClassDef) and node.name == "TaskStore")
+    clearing = {
+        method.name
+        for method in store_class.body
+        if isinstance(method, ast.FunctionDef | ast.AsyncFunctionDef) and _clears_claim(method)
+    }
+    assert {"force_claim", "reopen", "recover_stale_claimed_tasks", "reopen_tasks_for_node"} <= clearing

--- a/tests/unit/test_task_release_receipt.py
+++ b/tests/unit/test_task_release_receipt.py
@@ -1,20 +1,31 @@
 """Release-receipt regression tests (#3037).
 
 Claiming a task mints a ``task.claim_receipt`` on the audit chain. These tests
-pin the other half: every transition that ends a held claim mints the matching
-``task.release_receipt``, so folding the chain reconstructs the real holder of
-a task instead of the last node that acquired it.
+pin the other half: every transition that surrenders a held claim mints the
+matching ``task.release_receipt``, so folding the chain reports the last
+claimant of a task instead of every node that ever acquired it.
+
+Two things are deliberately not surrenders, and both are pinned here rather
+than left to the reader:
+
+* delivery. ``DONE`` and ``CLOSED`` mint nothing, because the worker finished
+  the job it claimed. The claim ends only if the task goes back to the pool,
+  which ``reopen`` does and does mint;
+* a claim that never existed. A task can reach ``WAITING_FOR_SUBTASKS`` or
+  ``BLOCKED`` without ever having been claimed, and minting a surrender there
+  writes a record a verifier cannot tell apart from a real one.
 
 The tests are organised as:
 
-* an enumeration over every un-claim path in :class:`TaskStore`, so a new path
-  that forgets the receipt is caught by name rather than by luck;
+* an enumeration over every surrender path in :class:`TaskStore`, so a new
+  path that forgets the receipt is caught by name rather than by luck;
 * an offline reconstruction of claim -> release -> re-claim asserted from the
   chain alone;
 * the same reconstruction on a plain ``bernstein serve`` node, with the
   orchestrator's ``BERNSTEIN_AUDIT`` lifecycle wiring absent;
-* a static guard that no future method can clear ``claimed_by_session``
-  without minting the receipt.
+* a release guard that walks every ``transition_task`` call site in the store
+  and fails on any claim-ending one that is not paired with a receipt, then
+  proves the pairing actually appends.
 """
 
 from __future__ import annotations
@@ -22,7 +33,7 @@ from __future__ import annotations
 import ast
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 import pytest
 from fastapi.testclient import TestClient
@@ -35,7 +46,12 @@ from bernstein.core.security.audit_chain import (
 )
 from bernstein.core.tasks.contracts import ContractViolation, RefusalKind, WorkerRefusal
 from bernstein.core.tasks.models import Task, TaskStatus
-from bernstein.core.tasks.task_store_core import TaskStore
+from bernstein.core.tasks.task_store_core import (
+    CLAIM_DELIVERED_STATUSES,
+    CLAIM_HELD_STATUSES,
+    ClaimSnapshot,
+    TaskStore,
+)
 
 if TYPE_CHECKING:
     from bernstein.core.security.audit import AuditEvent
@@ -168,6 +184,48 @@ class TestEveryUnclaimPathMintsAReceipt:
         assert events[0].details["release_path"] == "abandon"
         assert events[0].details["to_status"] == "abandoned"
 
+    async def test_abandon_cascade_releases_a_downstream_held_by_another_node(self, tmp_path: Path) -> None:
+        # The cascade ends claims the abandoning node never granted: a
+        # downstream task can be IN_PROGRESS under a different node, and
+        # BLOCKED_BY_ABANDON is a legal source for OPEN, so without the
+        # receipt that task is re-claimed with no surrender in between.
+        store, chain = _store(tmp_path)
+        _held(store, "T-up")
+        _held(store, "T-down", depends_on=["T-up"], claimed_by_session="node-b")
+        await store.abandon("T-up", "out_of_scope", "spec mismatch")
+        assert store._tasks["T-down"].status is TaskStatus.BLOCKED_BY_ABANDON
+        released = {e.details["task_id"]: e.details for e in _releases(chain)}
+        assert set(released) == {"T-up", "T-down"}
+        assert released["T-up"]["release_path"] == "abandon"
+        assert released["T-down"]["release_path"] == "abandon_cascade"
+        assert released["T-down"]["released_by"] == "node-b"
+        assert released["T-down"]["from_status"] == "in_progress"
+        assert released["T-down"]["to_status"] == "blocked_by_abandon"
+
+    async def test_abandon_cascade_skips_a_downstream_no_one_claimed(self, tmp_path: Path) -> None:
+        store, chain = _store(tmp_path)
+        _held(store, "T-up")
+        _held(store, "T-down", depends_on=["T-up"], status=TaskStatus.OPEN, claimed_at=None, claimed_by_session=None)
+        await store.abandon("T-up", "out_of_scope", "spec mismatch")
+        assert store._tasks["T-down"].status is TaskStatus.BLOCKED_BY_ABANDON
+        assert {e.details["task_id"] for e in _releases(chain)} == {"T-up"}
+
+    async def test_fail_empty_completion(self, tmp_path: Path) -> None:
+        # complete() auto-fails a held task when the summary is empty. Its own
+        # docstring calls that releasing the slot, so the ledger owes a receipt.
+        from bernstein.core.tasks.task_store_core import EmptyCompletionError
+
+        store, chain = _store(tmp_path)
+        _held(store)
+        with pytest.raises(EmptyCompletionError):
+            await store.complete("T-1", "")
+        assert store._tasks["T-1"].status is TaskStatus.FAILED
+        events = _releases(chain)
+        assert len(events) == 1
+        assert events[0].details["release_path"] == "fail_empty_completion"
+        assert events[0].details["released_by"] == _HOLDER
+        assert events[0].details["to_status"] == "failed"
+
     async def test_restart_recovery(self, tmp_path: Path) -> None:
         store, chain = _store(tmp_path)
         _held(store, "T-1", status=TaskStatus.CLAIMED)
@@ -190,15 +248,93 @@ class TestEveryUnclaimPathMintsAReceipt:
 
 
 @pytest.mark.asyncio
-class TestReceiptShape:
-    async def test_a_never_claimed_task_surrenders_nothing(self, tmp_path: Path) -> None:
-        # Cancelling an open task that no worker ever held is not a surrender,
-        # so it must not add a release with nothing to release.
+class TestANeverHeldClaimSurrendersNothing:
+    """A fabricated surrender is the worst failure mode this event has.
+
+    A missing receipt is visible as an asymmetry; a receipt for a claim that
+    never existed is indistinguishable, to any offline verifier, from a real
+    surrender by a real worker. Deciding ``held`` on status membership mints
+    exactly that, because ``OPEN -> WAITING_FOR_SUBTASKS`` and the paths into
+    ``BLOCKED`` are legal with no claim anywhere. Each status a task can sit
+    in unclaimed is enumerated here rather than spot-checked on ``OPEN``.
+    """
+
+    async def test_open(self, tmp_path: Path) -> None:
         store, chain = _store(tmp_path)
         _held(store, status=TaskStatus.OPEN, claimed_at=None, claimed_by_session=None)
         await store.cancel("T-1", "never started")
         assert _releases(chain) == []
 
+    async def test_waiting_for_subtasks(self, tmp_path: Path) -> None:
+        # OPEN -> WAITING_FOR_SUBTASKS needs no claim: a planner can split a
+        # task nobody ever picked up.
+        store, chain = _store(tmp_path)
+        _held(store, status=TaskStatus.OPEN, claimed_at=None, claimed_by_session=None)
+        await store.wait_for_subtasks("T-1", 3)
+        assert store._tasks["T-1"].status is TaskStatus.WAITING_FOR_SUBTASKS
+        await store.cancel("T-1", "operator changed their mind")
+        assert _releases(chain) == []
+
+    async def test_blocked(self, tmp_path: Path) -> None:
+        store, chain = _store(tmp_path)
+        _held(store, status=TaskStatus.OPEN, claimed_at=None, claimed_by_session=None)
+        await store.wait_for_subtasks("T-1", 3)
+        await store.block("T-1", "needs a human")
+        assert store._tasks["T-1"].status is TaskStatus.BLOCKED
+        await store.cancel("T-1", "operator changed their mind")
+        assert _releases(chain) == []
+
+    async def test_a_held_status_alone_does_not_make_a_surrender(self, tmp_path: Path) -> None:
+        # The regression in one line: every status in CLAIM_HELD_STATUSES that
+        # a task can be cancelled from, with no claim evidence on the task.
+        store, chain = _store(tmp_path)
+        cancellable_held = [
+            status
+            for status in sorted(CLAIM_HELD_STATUSES, key=lambda s: s.value)
+            if status
+            in {TaskStatus.CLAIMED, TaskStatus.IN_PROGRESS, TaskStatus.WAITING_FOR_SUBTASKS, TaskStatus.BLOCKED}
+        ]
+        assert cancellable_held, "the guard set must not be empty or this test asserts nothing"
+        for index, status in enumerate(cancellable_held):
+            task_id = f"T-nc-{index}"
+            _held(store, task_id, status=status, claimed_at=None, claimed_by_session=None)
+            await store.cancel(task_id, "never started")
+        assert _releases(chain) == []
+
+
+@pytest.mark.asyncio
+class TestDeliveryIsNotASurrender:
+    """The narrowed contract, pinned so it cannot drift into the docs alone.
+
+    A worker that delivers has not surrendered anything, so ``DONE`` and
+    ``CLOSED`` mint nothing. The claim ends when the task goes back to the
+    pool, and ``reopen`` is the path that does that.
+    """
+
+    async def test_complete_and_close_mint_nothing(self, tmp_path: Path) -> None:
+        store, chain = _store(tmp_path)
+        _held(store)
+        await store.complete("T-1", "shipped")
+        assert _releases(chain) == []
+        await store.close("T-1")
+        assert _releases(chain) == []
+
+    async def test_reopening_a_delivered_task_is_the_surrender(self, tmp_path: Path) -> None:
+        store, chain = _store(tmp_path)
+        _held(store)
+        _seed_claim(chain, "T-1", _HOLDER)
+        await store.complete("T-1", "shipped")
+        assert reconstruct_claim_holders(chain.query()) == {"T-1": _HOLDER}
+        await store.reopen("T-1", "janitor verification failed")
+        events = _releases(chain)
+        assert len(events) == 1
+        assert events[0].details["release_path"] == "reopen"
+        assert events[0].details["from_status"] == "done"
+        assert reconstruct_claim_holders(chain.query()) == {}
+
+
+@pytest.mark.asyncio
+class TestReceiptShape:
     async def test_receipt_carries_the_post_transition_version_and_reason(self, tmp_path: Path) -> None:
         store, chain = _store(tmp_path)
         task = _held(store)
@@ -382,58 +518,209 @@ def test_plain_serve_node_mints_the_receipt_on_reopen(plain_serve_app: Any) -> N
 
 
 # ---------------------------------------------------------------------------
-# Static guard: no future un-claim path can skip the receipt
+# Release guard: no claim-ending transition can skip the receipt
 # ---------------------------------------------------------------------------
+#
+# The previous guard matched methods that assign ``claimed_by_session = None``.
+# That is four methods, and none of the terminal paths (fail, cancel, abandon,
+# refuse) clears the field at all, so the guard could not see the class of
+# omission it was written to catch. It also matched per method, so a method
+# that mints a receipt on one branch and forgets another read as clean.
+#
+# This one walks every ``transition_task`` call site in the store, works out
+# the status it moves to, and requires a receipt in the same block for every
+# site that leaves the held set for something other than a delivery. It then
+# proves the pairing is not decorative by exercising the helper.
 
 
 _STORE_SOURCE = Path(__file__).resolve().parents[2] / "src" / "bernstein" / "core" / "tasks" / "task_store_core.py"
 
+#: Targets a transition may reach without surrendering a claim: the statuses a
+#: holder can sit in while still owning the task, plus the delivery statuses.
+#: Read off the source module so the guard and the store cannot disagree.
+_EXEMPT_TARGETS: frozenset[str] = frozenset(status.name for status in (CLAIM_HELD_STATUSES | CLAIM_DELIVERED_STATUSES))
 
-def _clears_claim(node: ast.AST) -> bool:
-    for child in ast.walk(node):
-        if not isinstance(child, ast.Assign):
-            continue
-        if not (isinstance(child.value, ast.Constant) and child.value.value is None):
-            continue
-        for target in child.targets:
-            if isinstance(target, ast.Attribute) and target.attr == "claimed_by_session":
-                return True
-    return False
-
-
-def _mints_receipt(node: ast.AST) -> bool:
-    return any(isinstance(child, ast.Attribute) and child.attr == "_record_release_receipt" for child in ast.walk(node))
+#: Blocks that scope a receipt to its call site. A transition inside a loop
+#: body needs the receipt inside that same body, not merely somewhere in the
+#: method: the abandon cascade regression was a receipt for the root task
+#: sitting in the method body while the loop below it released nothing.
+_SCOPING_BLOCKS = (ast.For, ast.AsyncFor, ast.While, ast.With, ast.AsyncWith)
 
 
-def test_every_method_that_clears_a_claim_mints_the_receipt() -> None:
-    """A new un-claim path is a compile-time-visible omission, not a silent one.
+class _ReleaseSite(NamedTuple):
+    """A ``transition_task`` call that ends a claim, and how it is paired."""
 
-    The asymmetry this issue reports came from adding un-claim paths one at a
-    time, each next to the last. This walks the store instead of trusting the
-    list above to stay complete.
+    method: str
+    line: int
+    target: str
+    release_paths: tuple[str, ...]
+
+
+def _parents(root: ast.AST) -> dict[ast.AST, ast.AST]:
+    """Map every node under *root* to its parent."""
+    table: dict[ast.AST, ast.AST] = {}
+    for node in ast.walk(root):
+        for child in ast.iter_child_nodes(node):
+            table[child] = node
+    return table
+
+
+def _transition_target(call: ast.Call) -> str | None:
+    """Return the ``TaskStatus`` member name a ``transition_task`` call moves to.
+
+    ``None`` when the target cannot be read statically, which the guard treats
+    as needing a receipt: an unreadable transition is not a safe one.
     """
+    candidates: list[ast.expr] = list(call.args[1:2])
+    candidates += [kw.value for kw in call.keywords if kw.arg in {"new_status", "status"}]
+    for candidate in candidates:
+        if (
+            isinstance(candidate, ast.Attribute)
+            and isinstance(candidate.value, ast.Name)
+            and candidate.value.id == "TaskStatus"
+        ):
+            return candidate.attr
+    return None
+
+
+def _scope_body(node: ast.AST, method: ast.AST, parents: dict[ast.AST, ast.AST]) -> list[ast.stmt]:
+    """Return the statement list that must contain *node*'s receipt.
+
+    The innermost enclosing loop or ``with`` block, or the method body when the
+    call site sits directly in it.
+    """
+    current: ast.AST | None = node
+    while current is not None and current is not method:
+        parent = parents.get(current)
+        if isinstance(parent, _SCOPING_BLOCKS) and current in parent.body:
+            return parent.body
+        current = parent
+    return list(getattr(method, "body", []))
+
+
+def _receipt_paths(body: list[ast.stmt]) -> tuple[str, ...]:
+    """Return the ``release_path`` literals of receipts minted inside *body*.
+
+    Nested loops and ``with`` blocks are skipped: they are scopes of their own,
+    so a receipt inside one does not pay for a transition outside it. Without
+    that, the receipt in ``abandon()``'s cascade loop would satisfy the root
+    transition sitting above the loop.
+    """
+    paths: list[str] = []
+    for statement in body:
+        if isinstance(statement, _SCOPING_BLOCKS):
+            continue
+        for node in ast.walk(statement):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if not (isinstance(func, ast.Attribute) and func.attr == "_record_release_receipt"):
+                continue
+            literal = next(
+                (
+                    kw.value.value
+                    for kw in node.keywords
+                    if kw.arg == "release_path"
+                    and isinstance(kw.value, ast.Constant)
+                    and isinstance(kw.value.value, str)
+                ),
+                "",
+            )
+            paths.append(str(literal))
+    return tuple(paths)
+
+
+def _release_sites() -> tuple[list[_ReleaseSite], list[_ReleaseSite]]:
+    """Return (paired, unpaired) claim-ending transition sites in ``TaskStore``."""
     tree = ast.parse(_STORE_SOURCE.read_text(encoding="utf-8"))
     store_class = next(node for node in ast.walk(tree) if isinstance(node, ast.ClassDef) and node.name == "TaskStore")
-    offenders = [
-        method.name
-        for method in store_class.body
-        if isinstance(method, ast.FunctionDef | ast.AsyncFunctionDef)
-        and _clears_claim(method)
-        and not _mints_receipt(method)
-    ]
-    assert offenders == [], (
-        f"{offenders} clear claimed_by_session without minting a task.release_receipt; "
-        "call self._record_release_receipt with a snapshot taken before the transition"
+    parents = _parents(store_class)
+    paired: list[_ReleaseSite] = []
+    unpaired: list[_ReleaseSite] = []
+    for method in store_class.body:
+        if not isinstance(method, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        for node in ast.walk(method):
+            if not (
+                isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "transition_task"
+            ):
+                continue
+            target = _transition_target(node)
+            if target is not None and target in _EXEMPT_TARGETS:
+                continue
+            receipts = _receipt_paths(_scope_body(node, method, parents))
+            site = _ReleaseSite(method.name, node.lineno, target or "<unreadable>", receipts)
+            (paired if receipts else unpaired).append(site)
+    return paired, unpaired
+
+
+def test_every_claim_ending_transition_is_paired_with_a_receipt(tmp_path: Path) -> None:
+    """Per call site, not per method, and the pairing has to actually append.
+
+    Two halves, because either one alone is a gate that passes on work it
+    never evaluated. The AST half catches a claim-ending transition with no
+    receipt beside it. The runtime half catches the pairing being present and
+    inert, which no amount of source walking can see.
+    """
+    _paired, unpaired = _release_sites()
+
+    assert unpaired == [], (
+        "these transition_task call sites end a claim with no task.release_receipt in the same block: "
+        + "; ".join(f"{site.method}() line {site.line} -> TaskStatus.{site.target}" for site in unpaired)
+        + ". Call self._record_release_receipt with a snapshot taken before the transition, in the same "
+        "block as the transition. If the target status is not a surrender, add it to CLAIM_HELD_STATUSES "
+        "or CLAIM_DELIVERED_STATUSES in task_store_core.py and say why."
+    )
+
+    store, chain = _store(tmp_path)
+    task = _held(store, "T-guard")
+    store._record_release_receipt(
+        task,
+        ClaimSnapshot(status=TaskStatus.IN_PROGRESS, holder=_HOLDER, held=True),
+        release_path="guard_probe",
+        reason="guard probe",
+    )
+    assert [event.details["release_path"] for event in _releases(chain)] == ["guard_probe"], (
+        "every claim-ending transition is paired with a _record_release_receipt call, but the call "
+        "appended nothing to the chain, so the whole ledger half is inert"
     )
 
 
-def test_the_guard_sees_the_known_unclaim_paths() -> None:
-    """The guard above is only worth anything if it actually matches methods."""
-    tree = ast.parse(_STORE_SOURCE.read_text(encoding="utf-8"))
-    store_class = next(node for node in ast.walk(tree) if isinstance(node, ast.ClassDef) and node.name == "TaskStore")
-    clearing = {
-        method.name
-        for method in store_class.body
-        if isinstance(method, ast.FunctionDef | ast.AsyncFunctionDef) and _clears_claim(method)
+def test_the_release_guard_covers_the_known_surrender_paths() -> None:
+    """The guard is only worth anything if it matches the real call sites.
+
+    Pins both directions: the surrender paths must be seen and paired, and the
+    delivery paths must be exempt rather than accidentally uncovered.
+    """
+    paired, unpaired = _release_sites()
+    assert unpaired == []
+
+    by_method: dict[str, set[str]] = {}
+    for site in paired:
+        by_method.setdefault(site.method, set()).update(site.release_paths)
+
+    expected = {
+        "force_claim": "force_claim",
+        "reopen": "reopen",
+        "cancel": "cancel",
+        "cancel_cascade": "cancel_cascade",
+        "fail": "fail",
+        "fail_contract_violation": "fail_contract_violation",
+        "refuse": "refuse",
+        "abandon": "abandon",
+        "complete": "fail_empty_completion",
+        "recover_stale_claimed_tasks": "restart_recovery",
+        "reopen_tasks_for_node": "node_departure",
     }
-    assert {"force_claim", "reopen", "recover_stale_claimed_tasks", "reopen_tasks_for_node"} <= clearing
+    missing = {method: path for method, path in expected.items() if path not in by_method.get(method, set())}
+    assert missing == {}, f"the guard no longer sees these surrender paths: {missing}"
+
+    # The abandon cascade is a second, separately scoped site inside abandon().
+    assert "abandon_cascade" in by_method["abandon"], (
+        "abandon() cascades held downstream tasks to BLOCKED_BY_ABANDON in a loop of its own; "
+        "that loop needs its own receipt"
+    )
+
+    # Delivery must be exempt by name, not by having drifted out of the walk.
+    assert {"DONE", "CLOSED"} <= _EXEMPT_TARGETS
+    assert "SUSPENDED" not in _EXEMPT_TARGETS, "SUSPENDED has no transitions in the task FSM"


### PR DESCRIPTION
## Problem

A granted claim appends a signed `task.claim_receipt` to the audit chain. No
un-claim path appended anything. Replaying the chain therefore reports node A
as holding a task node B is already executing, and under claim/release churn
the chain accumulates N acquisitions with zero surrenders.

The claim receipt exists so ownership is reconstructable offline. An
acquisition-only ledger cannot answer that question, so this is a gap in the
guarantee rather than a missing log line.

The only existing record of an un-claim was the generic `task.transition`
event, which is written only when `BERNSTEIN_AUDIT=1` has wired the
orchestrator's lifecycle audit log. A plain `bernstein serve` node wrote
nothing at all.

## Change

New chain event `task.release_receipt`, the counterpart of
`task.claim_receipt`, minted by `TaskStore` for every transition that
surrenders a held claim.

| Transition | `release_path` |
| --- | --- |
| `POST /tasks/{id}/force-claim` | `force_claim` |
| `POST /tasks/{id}/reopen` | `reopen` |
| `POST /tasks/{id}/cancel` | `cancel_cascade` (root and every descendant) |
| `TaskStore.cancel` | `cancel` |
| `POST /tasks/{id}/fail` | `fail` |
| Contract-violation fail | `fail_contract_violation` |
| `POST /tasks/{id}/complete` with an empty summary | `fail_empty_completion` |
| Typed worker refusal | `refuse` |
| `TaskStore.abandon`, the abandoned task | `abandon` |
| `TaskStore.abandon`, the downstream tasks it blocks | `abandon_cascade` |
| Stale-claim reset after a restart | `restart_recovery` |
| Cluster node departure | `node_departure` |

The receipt carries `task_id`, `role`, `released_by` (the holder captured
before the transition, matching the claim receipt's `claimed_by`),
`task_version`, `release_path`, `reason`, and the `from_status` / `to_status`
pair. It is appended with `log_with_prev_digest`, so it is chained exactly
like the claim receipt it answers.

`create_app` attaches the chain to the store next to `app.state.audit_chain`,
unconditionally. Both halves of the ledger are written by the server itself,
so a plain `bernstein serve` node records them with no orchestrator wiring
involved.

The append is best-effort in the same sense as the claim receipt, so a
read-only chain volume never rolls back a transition that already happened.

## What counts as a surrender

Two cases deliberately mint nothing, and both are pinned by tests rather than
left to the reader.

**Delivery is not a surrender.** A task reaching `DONE` or `CLOSED` mints no
receipt, because the worker finished the job it claimed. Its claim ends when
the task goes back to the pool, which `reopen` does and does mint.

**A claim that never existed cannot be surrendered.** Whether a claim was held
is decided on claim evidence carried by the task (`claimed_at` or
`claimed_by_session`), not on its status. `OPEN -> WAITING_FOR_SUBTASKS` and
the paths into `BLOCKED` are legal with no claim anywhere, so a status test
mints a surrender for a claim that never happened. An offline verifier cannot
tell a fabricated surrender from a real one, which makes it a worse failure
than a missing receipt.

## Reconstruction semantics

`reconstruct_claim_holders(events)` folds claim and release receipts in chain
order. It returns the last claimant of each task, which is attribution rather
than liveness: a delivered task stays mapped to the worker that delivered it
until something puts it back in the pool. Callers that need liveness
cross-check the task status.

The property the fold does carry is the one an acquisition-only ledger could
not support: no task is ever mapped to one claimant while another node holds
it, because every path back to the pool records a release first. Passing a
prefix of the chain reconstructs the same projection as of that point,
offline, from the chain alone.

Over a chain region written before this change there are acquisitions only, so
the fold reports every task ever claimed as still claimed. Nothing in the
receipt marks where the release half starts, so a caller reading a chain that
spans the upgrade has to bound the range itself. This is stated in the
function docstring.

## Behaviour changes for existing users

- Every server writes additional chain records. A node that claims and
  releases tasks roughly doubles the number of claim-ledger events in
  `.sdd/audit/<day>.jsonl`. This happens on a plain `bernstein serve`, not
  only under `BERNSTEIN_AUDIT`.
- `POST /tasks/{id}/cancel` records one receipt per cancelled task in the
  tree, not one for the task named in the request.
- `TaskStore.abandon` records one receipt for the abandoned task and one for
  each downstream task it moves to `BLOCKED_BY_ABANDON`.
- Absolute chain indices shift, because the chain carries more events.
  `bernstein audit verify-gates` reports positions as chain indices, so the
  index printed for a given logical event moves. The verdict does not change,
  only the reported position.
- The store now appends to the audit chain while holding its own lock. The
  chain append takes a cross-process file lock, so a fail, cancel, abandon,
  reopen or force-claim can now wait on another process writing to the same
  chain directory.
- No existing record changes shape, ordering or hash inputs. A chain written
  by an older version verifies unchanged under this one, and a chain
  containing `task.release_receipt` verifies unchanged under an older one.
  Both directions were run.

## Verification

`tests/unit/test_task_release_receipt.py`, 30 tests:

- one test per surrender path, enumerated rather than spot-checked, including
  an abandon cascade whose downstream task is held by a second node;
- the two non-surrender cases: `complete` then `close` mint nothing while
  `reopen` does, and a task cancelled from `OPEN`, `WAITING_FOR_SUBTASKS` or
  `BLOCKED` with no claim evidence mints nothing;
- receipt shape: post-transition version, reason, chained digest, and
  `chain.verify()` clean;
- offline replay of claim -> release -> re-claim, asserted at every prefix of
  the chain and again from a second chain store opened over the same files;
- the same loop over HTTP against a server built with `BERNSTEIN_AUDIT`
  removed from the environment and the lifecycle audit log asserted `None`,
  which is what a plain `bernstein serve` node looks like;
- a release guard over `task_store_core.py`.

The guard walks every `transition_task` call site in `TaskStore`, resolves the
status it moves to, and requires a `_record_release_receipt` in the same block
for each site that leaves `CLAIM_HELD_STATUSES` for anything other than a
delivery. Nested loops and `with` blocks are separate scopes, so a receipt in
an inner loop does not pay for a transition outside it, and a target status
that cannot be read statically fails closed. A second half exercises the
helper against a real chain, so a pairing that is present but does nothing
fails as well.

The guard was checked against three mutations of the source: making the
receipt helper inert, deleting the receipt call in `fail`, and deleting the
receipt call in the abandon cascade. It fails on each. The static half catches
the two deletions and names the offending call site with its line and target
status; the runtime half catches the inert helper.

Receipt payloads and their ordering are byte-identical across five
`PYTHONHASHSEED` values over one run covering cancel cascade, abandon cascade,
empty completion and restart recovery. No wall-clock value, generated id,
hostname, path or set iteration reaches the receipt payload. The enclosing
chain envelope carries a timestamp, as every event on this chain does, so
event HMACs are not reproducible across runs; that is unchanged by this work.

Also run green, unchanged: `test_task_store.py`, `test_task_store_property.py`,
`test_abandon_lifecycle.py`, `test_completion_contract_api.py`,
`test_task_claim_receipt_route.py`. `pyright --project pyrightconfig.strict.json`
is clean.

## Notes

`#3027` adds `TaskStore.release` and `POST /tasks/{id}/release`. That method
ends a held claim, so once it lands the release guard fails until it calls
`self._record_release_receipt` with a snapshot taken before the transition.
That is the intended handoff, not a conflict.

The MCP claim path (`POST /tasks/claim-receipt`, `claim_path="mcp_claim"`)
mints `task.claim_receipt` against the shared JSON backlog, which is a
different store from `TaskStore`. Those claims have no release path here, so
they accumulate in a `reconstruct_claim_holders` fold. Tracked separately.

Closes #3037
