### PR TITLE
fix(platform): treat an already-gone process as a successful Windows reap

### DIFF
--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -239,6 +239,7 @@ def emit_process_reap_receipt(
             method=receipt.method,
             delivered=receipt.delivered,
             escalated=receipt.escalated,
+            already_gone=receipt.already_gone,
             grace_seconds=receipt.grace_seconds,
             reason=reason,
             actor=actor,

--- a/src/bernstein/core/config/platform_compat.py
+++ b/src/bernstein/core/config/platform_compat.py
@@ -338,6 +338,43 @@ _REAP_METHOD_POSIX = "posix_process_group"
 _REAP_METHOD_WINDOWS = "windows_process_tree"
 
 
+# Sentinels returned by :func:`_process_identity` when it cannot produce a
+# concrete identity token for a pid.  ``_IDENTITY_GONE`` means the pid maps to
+# no live process; ``_IDENTITY_UNAVAILABLE`` means the mechanism itself is not
+# available (POSIX, or the Win32 query could not run), so callers fall back to
+# a plain liveness check and preserve prior behaviour.
+_IDENTITY_GONE: object = object()
+_IDENTITY_UNAVAILABLE: object = object()
+
+
+def _process_identity(pid: int) -> object:
+    """Return a stable identity token for the live process at *pid*.
+
+    On Windows the token is the process creation time (a 64-bit ``FILETIME``),
+    which - paired with the pid - uniquely identifies a single process
+    instance.  Comparing tokens therefore distinguishes the original spawn
+    from a later process that recycled the same pid, so a reap never signals
+    or escalates onto an unrelated process.
+
+    Returns:
+        * an ``int`` creation-time token when the process is alive and
+          identifiable,
+        * :data:`_IDENTITY_GONE` when the pid maps to no live process,
+        * :data:`_IDENTITY_UNAVAILABLE` on non-Windows platforms, or when the
+          Win32 query is unavailable or fails (callers then fall back to a
+          plain liveness check).
+    """
+    if not IS_WINDOWS:
+        return _IDENTITY_UNAVAILABLE
+    try:
+        create_time = _win_process_create_time(pid)
+    except Exception:  # ctypes/Win32 unavailable - degrade to liveness-only.
+        return _IDENTITY_UNAVAILABLE
+    if create_time is None:
+        return _IDENTITY_GONE
+    return create_time
+
+
 @dataclass(frozen=True)
 class ProcessReapReceipt:
     """Structured outcome of a process-tree reap.
@@ -353,8 +390,14 @@ class ProcessReapReceipt:
         os_name: Normalised OS name (``"linux"``, ``"macos"``, ``"windows"``).
         method: Delivery mechanism identifier
             (``"posix_process_group"`` or ``"windows_process_tree"``).
-        delivered: Whether the initial graceful stop was delivered.
+        delivered: Whether the initial graceful stop was delivered to a live
+            target.
         escalated: Whether a force-kill was required after the grace window.
+        already_gone: Whether the target was confirmed not running without a
+            stop being delivered (it had already exited, or its pid had been
+            recycled to an unrelated process). For a stop the target being
+            gone is success, so ``delivered=False`` alone must not be read as
+            failure: ``delivered or already_gone`` is the stop guarantee.
         grace_seconds: The grace window that applied to this reap.
     """
 
@@ -364,6 +407,19 @@ class ProcessReapReceipt:
     delivered: bool
     escalated: bool
     grace_seconds: float
+    already_gone: bool = False
+
+    @property
+    def stopped(self) -> bool:
+        """Whether the target is no longer running after the reap.
+
+        The guarantee callers actually care about: either a graceful stop was
+        delivered (escalated to a force-kill if needed), or the target was
+        already gone. Distinguishes the outcome from the raw ``delivered``
+        bool, which is False both when a live target could not be stopped and
+        when there was nothing left to stop.
+        """
+        return self.delivered or self.already_gone
 
     def to_details(self) -> dict[str, object]:
         """Return the receipt as a plain dict for audit-chain payloads."""
@@ -373,6 +429,7 @@ class ProcessReapReceipt:
             "method": self.method,
             "delivered": self.delivered,
             "escalated": self.escalated,
+            "already_gone": self.already_gone,
             "grace_seconds": self.grace_seconds,
         }
 
@@ -403,21 +460,51 @@ def reap_process_group(
     os_name = _detect_os_name()
     method = _REAP_METHOD_WINDOWS if IS_WINDOWS else _REAP_METHOD_POSIX
 
-    def _receipt(*, delivered: bool, escalated: bool) -> ProcessReapReceipt:
+    def _receipt(*, delivered: bool, escalated: bool, already_gone: bool = False) -> ProcessReapReceipt:
         return ProcessReapReceipt(
             pgid=pgid,
             os_name=os_name,
             method=method,
             delivered=delivered,
             escalated=escalated,
+            already_gone=already_gone,
             grace_seconds=grace_seconds,
         )
 
     if pgid <= 0:
         return _receipt(delivered=False, escalated=False)
 
-    # Best-effort TERM first; if it fails the group is already gone.
+    # Bind to the target's identity up front so a pid recycled during the reap
+    # is recognised as "the original is gone", never mistaken for - or
+    # signalled as - the original spawn.  On POSIX (and wherever identity is
+    # unavailable) this is a no-op sentinel and the reap behaves as before.
+    start_identity = _process_identity(pgid)
+
+    def _original_gone() -> bool:
+        """Whether the original process/group at *pgid* is no longer running.
+
+        True when the group has no live members, or when the lead pid maps to
+        a *different* process than the one seen at reap start (Windows recycled
+        the pid).  When identity cannot be bound (POSIX / unavailable), a live
+        group is treated as the same target, preserving prior semantics.
+        """
+        if not process_group_alive(pgid):
+            return True
+        if start_identity is _IDENTITY_UNAVAILABLE:
+            return False
+        current = _process_identity(pgid)
+        if current is _IDENTITY_UNAVAILABLE:
+            return False
+        return current != start_identity
+
+    # Best-effort graceful stop.
     if not kill_process_group(pgid, signal.SIGTERM):
+        # TERM could not be delivered.  The goal of a reap is that the target
+        # stops running, so distinguish "already gone" (it exited, or its pid
+        # was recycled) from a genuine failure to stop a live target, instead
+        # of always reporting a bare not-delivered.
+        if _original_gone():
+            return _receipt(delivered=False, escalated=False, already_gone=True)
         return _receipt(delivered=False, escalated=False)
 
     # Poll for graceful exit.  Probe the whole process *group* rather than the
@@ -664,6 +751,59 @@ def _win_process_alive(pid: int) -> bool:
         if kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):  # type: ignore[union-attr]
             return bool(exit_code.value == _STILL_ACTIVE)
         return False
+    finally:
+        kernel32.CloseHandle(handle)  # type: ignore[union-attr]
+
+
+def _win_process_create_time(pid: int) -> int | None:
+    """Return the process creation time for *pid* on Windows, or ``None``.
+
+    The creation time (a 64-bit ``FILETIME``) paired with the pid uniquely
+    identifies a single process instance: two processes that reuse the same
+    pid at different times have different creation times.  Used by
+    :func:`_process_identity` to detect a recycled pid so a reap never signals
+    a process it did not spawn.
+
+    This function is only called on Windows (via :func:`_process_identity`,
+    which is guarded by the ``IS_WINDOWS`` check).  ``None`` is returned when
+    the process does not exist or its handle cannot be opened or queried, so
+    an unopenable/recycled pid reads as "not our process".
+
+    Args:
+        pid: Process ID.
+
+    Returns:
+        The creation-time ``FILETIME`` as an ``int``, or ``None`` if the
+        process is gone or cannot be identified.
+    """
+    import ctypes
+    import ctypes.wintypes
+
+    _PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+
+    kernel32: object = ctypes.windll.kernel32  # type: ignore[attr-defined]
+    handle: int = kernel32.OpenProcess(  # type: ignore[union-attr]
+        _PROCESS_QUERY_LIMITED_INFORMATION,
+        False,
+        pid,
+    )
+    if not handle:
+        return None
+    try:
+        creation = ctypes.wintypes.FILETIME()
+        exit_t = ctypes.wintypes.FILETIME()
+        kernel_t = ctypes.wintypes.FILETIME()
+        user_t = ctypes.wintypes.FILETIME()
+        ok = kernel32.GetProcessTimes(  # type: ignore[union-attr]
+            handle,
+            ctypes.byref(creation),
+            ctypes.byref(exit_t),
+            ctypes.byref(kernel_t),
+            ctypes.byref(user_t),
+        )
+        if not ok:
+            return None
+        return (creation.dwHighDateTime << 32) | creation.dwLowDateTime
     finally:
         kernel32.CloseHandle(handle)  # type: ignore[union-attr]
 

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -4576,6 +4576,7 @@ def record_process_reap_receipt(
     escalated: bool,
     grace_seconds: float,
     reason: str,
+    already_gone: bool = False,
     actor: str = "spawner",
 ) -> AuditEvent:
     """Append a ``process.reap_receipt`` event into *chain* (#2367).
@@ -4599,6 +4600,10 @@ def record_process_reap_receipt(
         grace_seconds: The grace window that applied to this reap.
         reason: Why the reap ran (e.g. ``"kill_requested"``,
             ``"heartbeat_stale"``, ``"wall_clock_timeout"``).
+        already_gone: Whether the target was confirmed already gone (exited,
+            or its pid recycled) so no stop had to be delivered; the reap
+            still succeeded. Recorded so a verifier can distinguish "we
+            stopped it" from "it was already gone".
         actor: Recorded actor; defaults to ``"spawner"``.
 
     Returns:
@@ -4617,6 +4622,7 @@ def record_process_reap_receipt(
             "method": method,
             "delivered": delivered,
             "escalated": escalated,
+            "already_gone": already_gone,
             "grace_seconds": grace_seconds,
             "reason": reason,
         },

--- a/tests/integration/test_adapter_conformance_lifecycle.py
+++ b/tests/integration/test_adapter_conformance_lifecycle.py
@@ -112,8 +112,13 @@ def test_adapter_stop_terminates_a_hung_spawn(
     pid = int(getattr(result, "pid", 0))
     assert pid > 0
     receipt = reap_process_group(pid, grace_seconds=3.0)
-    assert receipt.delivered
-    # The worker must actually be gone after the reap.
+    # Assert the real guarantee -- the hung spawn is stopped -- not the raw
+    # ``delivered`` bool. On Windows a hung spawn can exit before the reap
+    # runs and its pid may be recycled, so a graceful stop is never delivered
+    # to it; ``stopped`` (delivered or already_gone) is the honest, flake-free
+    # projection of "no longer running".
+    assert receipt.stopped, f"reap did not stop the spawn: {receipt}"
+    # ...and prove it independently: the worker must actually be gone.
     proc = getattr(result, "proc", None)
     if proc is not None and hasattr(proc, "wait"):
         with contextlib.suppress(subprocess.TimeoutExpired):

--- a/tests/unit/test_audit_chain_process_reap.py
+++ b/tests/unit/test_audit_chain_process_reap.py
@@ -66,6 +66,33 @@ def test_record_process_reap_receipt_windows_method(tmp_path: Path) -> None:
     assert rows[0].actor == "orchestrator"
 
 
+def test_record_process_reap_receipt_already_gone(tmp_path: Path) -> None:
+    """An already-gone stop is mirrored as a distinct forensic outcome.
+
+    The audit event distinguishes "the target was already gone" from a
+    delivered stop, so a verifier can tell that no signal was sent while the
+    reap still succeeded.
+    """
+    chain = AuditChainStore(tmp_path / "audit", key=b"0" * 32)
+    record_process_reap_receipt(
+        chain=chain,
+        session_id="agent-3",
+        pgid=2904,
+        os_name="windows",
+        method="windows_process_tree",
+        delivered=False,
+        escalated=False,
+        already_gone=True,
+        grace_seconds=3.0,
+        reason="kill_requested",
+    )
+    rows = chain.query(event_type=EVENT_PROCESS_REAP_RECEIPT)
+    assert rows[0].details["already_gone"] is True
+    assert rows[0].details["delivered"] is False
+    ok, errors = chain.verify()
+    assert ok, errors
+
+
 def test_audit_chain_stays_verifiable_after_reap_receipt(tmp_path: Path) -> None:
     chain = AuditChainStore(tmp_path / "audit", key=b"0" * 32)
     record_process_reap_receipt(

--- a/tests/unit/test_platform_process_tree.py
+++ b/tests/unit/test_platform_process_tree.py
@@ -81,11 +81,41 @@ class TestReapProcessGroup:
         assert receipt.escalated is False
         assert receipt.pgid == 0
 
-    def test_undeliverable_term_receipt(self) -> None:
-        with patch(f"{_PC}.kill_process_group", return_value=False) as mock_kpg:
+    def test_undeliverable_term_on_live_target_is_not_delivered(self) -> None:
+        """TERM undeliverable while the group is still alive -> genuine failure.
+
+        A live group that could not be signalled is a real failure to stop it:
+        ``delivered`` and ``already_gone`` are both False so the caller does
+        not mistake it for a successful reap.
+        """
+        with (
+            patch(f"{_PC}.kill_process_group", return_value=False) as mock_kpg,
+            patch(f"{_PC}.process_group_alive", return_value=True),
+            # Stable identity across the reap: the same process holds the pid,
+            # so it is a genuine failure to stop, not a recycled/gone pid.
+            patch(f"{_PC}._process_identity", return_value=4242),
+        ):
             receipt = reap_process_group(12345)
         assert receipt.delivered is False
         assert receipt.escalated is False
+        assert receipt.already_gone is False
+        mock_kpg.assert_called_once_with(12345, signal.SIGTERM)
+
+    def test_undeliverable_term_but_target_gone_is_already_gone(self) -> None:
+        """TERM undeliverable because the target already exited -> already_gone.
+
+        The stop goal is satisfied (nothing is running), so the receipt records
+        ``already_gone=True`` instead of a misleading bare ``delivered=False``.
+        """
+        with (
+            patch(f"{_PC}.kill_process_group", return_value=False) as mock_kpg,
+            patch(f"{_PC}.process_group_alive", return_value=False),
+        ):
+            receipt = reap_process_group(12345)
+        assert receipt.delivered is False
+        assert receipt.escalated is False
+        assert receipt.already_gone is True
+        assert receipt.stopped is True
         mock_kpg.assert_called_once_with(12345, signal.SIGTERM)
 
     def test_clean_exit_receipt(self) -> None:
@@ -155,6 +185,7 @@ class TestReapProcessGroup:
             "method": "posix_process_group",
             "delivered": True,
             "escalated": False,
+            "already_gone": False,
             "grace_seconds": 3.0,
         }
         # Frozen dataclass: two identical receipts project identically.

--- a/tests/unit/test_platform_win_process_branch.py
+++ b/tests/unit/test_platform_win_process_branch.py
@@ -322,15 +322,21 @@ class TestReapReceiptWindowsProjection:
         assert sigs[0] == signal.SIGTERM
         assert sigs[-1] == 9
 
-    def test_undeliverable_term_projects_not_delivered(self, monkeypatch: Any) -> None:
+    def test_undeliverable_term_on_live_original_is_genuine_failure(self, monkeypatch: Any) -> None:
+        """TERM undeliverable while the *original* still runs -> not delivered.
+
+        When the graceful stop cannot be delivered and the pid still maps to
+        the same live process that was there at reap start, the reap genuinely
+        failed to stop it: the receipt must report ``delivered=False`` and must
+        NOT claim the process was already gone.
+        """
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
         monkeypatch.setattr(pc, "_detect_os_name", lambda: "windows")
         monkeypatch.setattr(pc, "kill_process_group", lambda pgid, sig=signal.SIGTERM: False)
-        monkeypatch.setattr(
-            pc,
-            "process_alive",
-            lambda pid: (_ for _ in ()).throw(AssertionError("polled")),
-        )
+        # The pid holds the same live process throughout: the group stays alive
+        # and its identity token is stable.
+        monkeypatch.setattr(pc, "process_group_alive", lambda pid: True)
+        monkeypatch.setattr(pc, "_process_identity", lambda pid: 4242)
 
         receipt = pc.reap_process_group(999, grace_seconds=0.05, poll_interval=0.01)
 
@@ -338,3 +344,60 @@ class TestReapReceiptWindowsProjection:
         assert receipt.method == "windows_process_tree"
         assert receipt.delivered is False
         assert receipt.escalated is False
+        assert receipt.already_gone is False
+
+
+# ---------------------------------------------------------------------------
+# reap_process_group - "already gone" is a successful stop, not a failure
+# ---------------------------------------------------------------------------
+
+
+class TestReapAlreadyGoneWindows:
+    """A stop whose target is already gone must project onto success.
+
+    On Windows a reap of a hung spawn can find that the process has already
+    exited (and its pid may have been recycled by the kernel). The stop goal
+    -- the hung spawn is no longer running -- is satisfied, so the receipt
+    records ``already_gone=True`` instead of a misleading ``delivered=False``.
+    A recycled pid must never be signalled as if it were the original spawn.
+    """
+
+    def test_undeliverable_term_but_pid_gone_projects_already_gone(self, monkeypatch: Any) -> None:
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc, "_detect_os_name", lambda: "windows")
+        monkeypatch.setattr(pc, "kill_process_group", lambda pgid, sig=signal.SIGTERM: False)
+        # The original process is gone: taskkill could not deliver, and the
+        # pid no longer maps to any live process.
+        monkeypatch.setattr(pc, "process_group_alive", lambda pid: False)
+
+        receipt = pc.reap_process_group(2904, grace_seconds=0.05, poll_interval=0.01)
+
+        assert receipt.method == "windows_process_tree"
+        assert receipt.delivered is False
+        assert receipt.escalated is False
+        assert receipt.already_gone is True
+        # The stop guarantee holds even though nothing was delivered.
+        assert receipt.stopped is True
+
+    def test_undeliverable_term_but_pid_recycled_projects_already_gone(self, monkeypatch: Any) -> None:
+        """A recycled pid (different creation time) reads as already-gone.
+
+        The pid still hosts a *live* process, but it is a different process
+        than the one seen at reap start -- Windows recycled the pid. The
+        original spawn is therefore gone, and the reap must not have signalled
+        (or escalated onto) the unrelated process.
+        """
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc, "_detect_os_name", lambda: "windows")
+        monkeypatch.setattr(pc, "kill_process_group", lambda pgid, sig=signal.SIGTERM: False)
+        monkeypatch.setattr(pc, "process_group_alive", lambda pid: True)
+        # Identity token captured at reap start (111) differs from the token
+        # observed after the failed TERM (222): the pid was recycled.
+        identities = iter([111, 222])
+        monkeypatch.setattr(pc, "_process_identity", lambda pid: next(identities))
+
+        receipt = pc.reap_process_group(2904, grace_seconds=0.05, poll_interval=0.01)
+
+        assert receipt.delivered is False
+        assert receipt.escalated is False
+        assert receipt.already_gone is True


### PR DESCRIPTION
## Problem

The required Windows job **Adapter conformance + e2e (windows)** intermittently reddens `main`.

Observed on run 29736915130:

```
tests/integration/test_adapter_conformance_lifecycle.py::test_adapter_stop_terminates_a_hung_spawn[claude]
assert receipt.delivered -> AssertionError: assert False
receipt = ProcessReapReceipt(pgid=2904, os_name='windows',
          method='windows_process_tree', delivered=False, escalated=False, grace_seconds=3.0)
```

The runner log shows repeated "pid reused" warnings around the same pgid.

## Root cause

On Windows, `reap_process_group` returned `delivered=False` whenever the graceful stop could not be delivered. `kill_process_group` returns False only when a live process still holds the pid after `taskkill` and the PowerShell fallback. For our own spawned children (same user, non-protected) `Stop-Process -Force` always succeeds, so a `delivered=False` in this reap context means the hung spawn had already exited and Windows recycled its pid.

`delivered=False` therefore conflated two different outcomes:

- we failed to stop a live target, and
- the target was already gone.

For a stop operation "already gone" is success. The conformance test asserted the raw `delivered` bool, so the required gate flaked even though the hung spawn was genuinely no longer running.

## Fix

- Add `ProcessReapReceipt.already_gone` and a `stopped` property (`delivered or already_gone`). `already_gone` is included in `to_details()` and in the `process.reap_receipt` audit event so the outcome is reconstructable offline.
- Bind the target's identity (Windows process creation time) at reap start. A recycled pid (different creation time) is recognised as "the original is gone" and is never signalled or escalated onto as if it were the original spawn.
- When the graceful stop cannot be delivered, report `already_gone=True` if the original process/group is confirmed no longer running, instead of a bare not-delivered.
- POSIX behaviour is unchanged: `delivered`, `escalated`, and `method` are identical, and identity binding is a no-op sentinel on Linux/macOS.
- The conformance test now asserts the real guarantee (the hung spawn is no longer running after stop, tolerant of already-gone) instead of the raw `delivered` bool, and keeps the independent worker-exit check.

Fixes the flaky required Windows adapter-conformance gate.

## Verification

Targeted runs (never the full suite):

- `tests/unit/test_platform_process_tree.py`
- `tests/unit/test_platform_win_process_branch.py`
- `tests/unit/test_conformance_windows_projection.py`
- `tests/unit/test_audit_chain_process_reap.py`
- `tests/integration/test_adapter_conformance_lifecycle.py`

All green on POSIX. The Windows-only reap branch is covered by mocked-Windows unit tests (identity gone and recycled-pid cases) that run on every host, plus reasoning about the real Windows path.