### PR TITLE
fix(platform): separate stop delivery from the reap guarantee

### DIFF
--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -242,6 +242,8 @@ def emit_process_reap_receipt(
             grace_seconds=receipt.grace_seconds,
             reason=reason,
             actor=actor,
+            already_gone=receipt.already_gone,
+            confirmed_dead=receipt.confirmed_dead,
         )
     except Exception as exc:  # audit must never block the reap path
         logger.warning(

--- a/src/bernstein/core/config/platform_compat.py
+++ b/src/bernstein/core/config/platform_compat.py
@@ -356,11 +356,25 @@ class ProcessReapReceipt:
     offline.
 
     ``delivered`` answers "did we hand a stop to the OS"; it is *not* the
-    success predicate.  A tree that had already exited before the reap ran
-    accepts no stop, so ``delivered`` is False while the caller's guarantee
-    holds perfectly.  Read :attr:`confirmed_dead` to answer "is the tree
-    gone", and :attr:`already_gone` to tell "it exited on its own" apart
-    from "we stopped it".
+    success predicate.  A target that had already exited accepts no stop, so
+    ``delivered`` is False while the caller's guarantee holds.  Read
+    :attr:`confirmed_dead` to answer "was the target observed gone", and
+    :attr:`already_gone` to tell "it exited on its own" apart from "we
+    stopped it".
+
+    Every field reports something that was observed.  None of them is
+    inferred from a signal having been accepted: a stop that the OS took
+    delivery of is recorded as ``delivered`` or ``escalated``, and nothing
+    more is read into it.  Where the reap could not establish the target's
+    state at all, every claim stays False rather than defaulting to the
+    convenient answer.
+
+    On Windows ``delivered`` is False for a target that had already exited.
+    Before the pinned-handle rewrite the same case reported True, because
+    the old fallback ended in a liveness re-probe that a missing pid
+    satisfied.  Callers that branch on ``delivered`` see that flip; they
+    fall back to a single-process kill, which is a no-op against a pid that
+    no longer exists.
 
     Attributes:
         pgid: Process group ID (POSIX) or lead PID (Windows) targeted.
@@ -370,13 +384,19 @@ class ProcessReapReceipt:
         delivered: Whether the initial graceful stop was delivered.
         escalated: Whether a force-kill was required after the grace window.
         grace_seconds: The grace window that applied to this reap.
-        already_gone: Whether the target had already exited before any stop
-            tier ran.  Only ever True when that was affirmatively observed;
-            a target whose state could not be established is not
-            "already gone".
-        confirmed_dead: Whether the target is verified to no longer be
+        already_gone: Whether the target was observed to have already
+            exited before any stop tier ran.  Only ever True when that was
+            affirmatively observed; a target whose state could not be
+            established is not "already gone", and neither is a target we
+            were refused permission to look at.
+        confirmed_dead: Whether the target was *observed* to no longer be
             running once the reap returned.  This is the guarantee the reap
-            exists to provide.
+            exists to provide, and it is only ever set from an observation:
+            a group id the kernel no longer knows (ESRCH), or a Windows
+            handle that left the system.  A delivered force-kill does not
+            set it.  False therefore means "not established", which is not
+            the same as "still running" - the independent liveness helpers
+            answer that question.
     """
 
     pgid: int
@@ -402,37 +422,58 @@ class ProcessReapReceipt:
         }
 
 
-def _group_stopped_running(pgid: int) -> bool:
-    """Return True when the group has no member left that can run code.
+def _group_observed_gone(pgid: int) -> bool:
+    """Return True only when the group is *observed* to have no members left.
 
-    Confirmation counterpart to :func:`process_group_alive`.  The two answer
-    deliberately different questions.  ``process_group_alive`` drives the
-    decision to *escalate*, so it errs towards "alive" and reports EPERM as
-    alive.  Confirmation needs the sharper question - is anything still
-    running - and a zombie (a process that has exited and is waiting for its
-    parent to call ``wait()``) runs no code.
+    Confirmation counterpart to :func:`process_group_alive`, and it mirrors
+    that function's errno handling on purpose.  ``ESRCH`` is the only reply
+    that establishes anything: it means the kernel has no process group with
+    this id, so nothing in it can run.  ``EPERM`` means a member exists that
+    we may not signal, which is evidence the group is *alive*, not evidence
+    it is gone; treating it as gone is how a receipt ends up certifying a
+    process that is still running.
 
-    macOS reports EPERM, not ESRCH, for a signal aimed at a group whose only
-    remaining members are zombies, so a fully reaped group keeps looking
-    alive to ``killpg(pgid, 0)`` until the parent gets round to reaping it.
-    This probe is only reached after a SIGTERM was accepted for the same
-    group, which proves the group was signalable by us at that point, so a
-    later refusal means the signalable members are gone.
+    Measured behaviour of an unreaped group whose members have all been
+    SIGKILLed but whose parent has not yet called ``wait()``:
+
+    * macOS: ``killpg(pgid, 0)`` raises ``EPERM``.
+    * Linux: ``killpg(pgid, 0)`` succeeds.
+
+    Neither reply distinguishes "exited but unreaped" from "running", and
+    ``killpg`` offers no third answer that would, so neither is treated as
+    confirmation.  The reap reports the stop it delivered and leaves
+    ``confirmed_dead`` False rather than guessing; an unblockable SIGKILL
+    still guarantees eventual death, but that is a guarantee about the
+    future, not an observation of the present.
 
     Args:
         pgid: Process group ID (POSIX) or lead PID (Windows).
 
     Returns:
-        True if nothing in the group is still running.
+        True only if the group was observed to have no members.
     """
     killpg = getattr(os, "killpg", None)
     if IS_WINDOWS or killpg is None:
         return not process_group_alive(pgid)
     try:
         killpg(pgid, 0)
-    except OSError:
+    except ProcessLookupError:
+        # ESRCH: no such process group.  Nothing is left to run.
         return True
+    except OSError:
+        # EPERM (a member exists we may not signal) or any other errno.
+        # Neither says the group stopped, so neither confirms it.
+        return False
     return False
+
+
+#: The pin observed the target already exited before any stop tier ran.
+_PIN_TARGET_EXITED = "exited"
+#: The pin observed the target running, so stop tiers may act on it.
+_PIN_TARGET_RUNNING = "running"
+#: The pin could not establish what the number refers to.  Stop tiers must
+#: not act on it, and the receipt must claim nothing about it.
+_PIN_TARGET_UNOBSERVABLE = "unobservable"
 
 
 class _ReapPin:
@@ -444,31 +485,65 @@ class _ReapPin:
     was handed.  :class:`_WinReapPin` does the real work; keeping the POSIX
     path on this no-op base means Linux and macOS reaps are byte-for-byte
     the same sequence of syscalls they were before the pin existed.
+
+    The target state is a three-way answer, not a boolean.  "Observed
+    exited" and "could not observe" are different findings and must not
+    collapse into one flag: the first is a result the caller asked for, the
+    second is an absence of evidence.  A receipt that reports the second as
+    the first certifies a process nobody looked at.
     """
 
-    #: True only when the target was affirmatively observed to be gone
-    #: before any stop tier ran.  A target whose state could not be
-    #: established is never "already gone" - not knowing is not proof.
-    already_gone: bool = False
+    target_state: str = _PIN_TARGET_RUNNING
 
-    def confirm_exit(self, pgid: int, *, forced: bool) -> bool:
-        """Return True when the target is verified to no longer be running.
+    @property
+    def already_gone(self) -> bool:
+        """True only when the target was *observed* gone before any tier ran."""
+        return self.target_state == _PIN_TARGET_EXITED
 
-        A delivered force-kill is itself the confirmation on POSIX: SIGKILL
-        cannot be caught, blocked, or ignored.  Re-probing liveness is not a
-        substitute - ``killpg(pgid, 0)`` keeps succeeding for a group whose
-        members are already-dead zombies waiting for their parent to call
-        ``wait()``, so a probe fired straight after SIGKILL reports "alive"
-        for a group that is not running any code at all.
+    @property
+    def signalable(self) -> bool:
+        """True when a stop tier may act on this target.
+
+        False both for a target already observed gone (nothing to stop) and
+        for a target whose identity could not be established (signalling it
+        could hit a process the caller never asked us to touch).
+        """
+        return self.target_state == _PIN_TARGET_RUNNING
+
+    def observed_gone(self, pgid: int) -> bool:
+        """Return True only when the target is observed to no longer exist.
 
         Args:
             pgid: Process group ID (POSIX) or lead PID (Windows).
-            forced: Whether an unblockable force-kill was delivered.
 
         Returns:
-            True if the target is confirmed no longer running.
+            True if the observation succeeded and found nothing.
         """
-        return forced or _group_stopped_running(pgid)
+        return _group_observed_gone(pgid)
+
+    def confirm_exit(self, pgid: int, *, force_signal_delivered: bool) -> bool:
+        """Return True only when the target is *observed* no longer running.
+
+        ``force_signal_delivered`` is deliberately not treated as
+        confirmation.  SIGKILL cannot be caught, blocked, or ignored, so it
+        guarantees the group dies - but ``killpg(pgid, sig)`` succeeds when
+        it could signal *any one* member, so a delivered SIGKILL does not
+        establish that every member received it, and it says nothing about
+        the instant the receipt is written.  A guarantee about the future is
+        not an observation of the present, and only the observation is
+        reported.
+
+        Args:
+            pgid: Process group ID (POSIX) or lead PID (Windows).
+            force_signal_delivered: Whether an unblockable force-kill was
+                accepted for the group.  Recorded by the caller as
+                ``escalated``; not evidence of death.
+
+        Returns:
+            True if the target was observed to no longer be running.
+        """
+        del force_signal_delivered
+        return self.observed_gone(pgid)
 
     def close(self) -> None:
         """Release any OS resource the pin holds.  No-op on POSIX."""
@@ -502,19 +577,48 @@ class _WinReapPin(_ReapPin):
       that is already on its way out.  :meth:`confirm_exit` waits on the
       handle instead of racing the probe.
 
-    If the handle cannot be opened at all (no ctypes, no permission, no such
-    process) the pin degrades to the inert base behaviour: it never claims
-    the target is gone and never blocks the reap.
+    Whether the handle could be opened is not the same question as whether
+    the target is gone.  ``OpenProcess`` refuses both for a pid no process
+    has (``ERROR_INVALID_PARAMETER``) and for a pid held by a process this
+    user may not touch (``ERROR_ACCESS_DENIED``).  Only the first is
+    evidence of an exit; the second is a live process we cannot observe, and
+    the pin reports it as such so no tier signals it and no receipt claims
+    it stopped.
     """
 
-    def __init__(self, pid: int, handle: int, *, already_gone: bool) -> None:
+    def __init__(self, pid: int, handle: int, *, target_state: str) -> None:
         self.pid = pid
         self._handle = handle
-        self.already_gone = already_gone
+        self.target_state = target_state
 
     def alive(self) -> bool:
         """Return True when the pinned process has not exited yet."""
         return bool(self._handle) and _win_handle_alive(self._handle)
+
+    def observed_exited(self) -> bool:
+        """Return True only when the handle *reports* the process exited.
+
+        Distinct from ``not alive()``: a handle whose exit code cannot be
+        read is not alive, but it is not observed exited either.
+        """
+        return bool(self._handle) and _win_handle_liveness(self._handle) is False
+
+    def observed_gone(self, pgid: int) -> bool:
+        """Return the pinned handle's own verdict, not a re-probe of the pid.
+
+        ``_win_process_alive`` cannot open a pid it lacks rights to and
+        reports it as not running, so re-probing the number would turn
+        "could not observe" back into "observed gone" one layer down.  The
+        handle already names the target.
+
+        Args:
+            pgid: Lead PID of the reaped tree (unused).
+
+        Returns:
+            True if the handle reports the process exited.
+        """
+        del pgid
+        return self.observed_exited()
 
     def terminate(self, exit_code: int = 1) -> bool:
         """Terminate the pinned process through the handle we already hold."""
@@ -524,25 +628,30 @@ class _WinReapPin(_ReapPin):
         """Block until the pinned process exits or *timeout_ms* elapses."""
         return bool(self._handle) and _win_wait_for_exit(self._handle, timeout_ms)
 
-    def confirm_exit(self, pgid: int, *, forced: bool) -> bool:
-        """Wait on the pinned handle, then fall back to the liveness probe.
+    def confirm_exit(self, pgid: int, *, force_signal_delivered: bool) -> bool:
+        """Wait on the pinned handle for real evidence that the target left.
 
-        Windows has real evidence available - the handle becomes signalled
-        when the process leaves the system - so a force-kill request is not
-        allowed to stand in for it here.
+        Windows has an observation available that POSIX does not: the handle
+        becomes signalled when the process leaves the system.  That is the
+        only thing accepted here.  A force-kill request is not, and neither
+        is a re-probe of the bare pid - ``_win_process_alive`` cannot open a
+        pid it lacks rights to and reports it as not running, which is the
+        same "could not observe read as observed gone" mistake one layer
+        down.
 
         Args:
-            pgid: Lead PID of the reaped tree.
-            forced: Whether a force-kill was delivered (unused: the handle
-                wait is stronger evidence).
+            pgid: Lead PID of the reaped tree (unused: the pinned handle
+                names the target more precisely than the number does).
+            force_signal_delivered: Whether a force-kill was delivered
+                (unused: the handle wait is the evidence).
 
         Returns:
-            True if the target is confirmed no longer running.
+            True if the target was observed to leave the system.
         """
-        del forced
+        del pgid, force_signal_delivered
         if self.wait_for_exit(_WIN_EXIT_CONFIRM_MS):
             return True
-        return _group_stopped_running(pgid)
+        return self.observed_exited()
 
     def close(self) -> None:
         """Close the pinned handle, releasing the pid back to the kernel."""
@@ -638,9 +747,9 @@ def reap_process_group(
     # that merely inherited the number.  Inert on POSIX (see _ReapPin).
     with _pin_reap_target(pgid) as pin:
         if pin.already_gone:
-            # Nothing to stop.  The tree the caller asked about is not
-            # running, which is exactly the guarantee they wanted, so this is
-            # a success even though no stop was delivered to anything.
+            # Nothing to stop.  The tree the caller asked about was observed
+            # not running, which is exactly the guarantee they wanted, so
+            # this is a success even though no stop was delivered.
             return _receipt(
                 delivered=False,
                 escalated=False,
@@ -648,14 +757,25 @@ def reap_process_group(
                 confirmed_dead=True,
             )
 
+        if not pin.signalable:
+            # The number could not be resolved to a process we are allowed
+            # to observe.  Signalling it could hit a process the caller
+            # never asked about, so no tier runs; and not knowing is not
+            # proof of an exit, so the receipt claims neither.
+            logger.warning(
+                "Reap target %d could not be identified; no stop was attempted and no outcome is claimed",
+                pgid,
+            )
+            return _receipt(delivered=False, escalated=False)
+
         # Best-effort TERM first.
         if not kill_process_group(pgid, signal.SIGTERM):
             # The stop could not be delivered.  That is only a reap failure
             # when the target is still running; a target that has already
-            # exited is the outcome the caller asked for.  Verify rather than
-            # assume - conflating the two is what made an already-exited
-            # Windows spawn look like a failed stop.
-            gone = not process_group_alive(pgid)
+            # exited is the outcome the caller asked for.  Observe rather
+            # than assume, and ask the pin (which already names the target)
+            # instead of re-probing the bare number.
+            gone = pin.observed_gone(pgid)
             return _receipt(
                 delivered=False,
                 escalated=False,
@@ -688,7 +808,7 @@ def reap_process_group(
         return _receipt(
             delivered=True,
             escalated=True,
-            confirmed_dead=pin.confirm_exit(pgid, forced=forced),
+            confirmed_dead=pin.confirm_exit(pgid, force_signal_delivered=forced),
         )
 
 
@@ -854,46 +974,95 @@ _WIN_FILETIME_EPOCH_OFFSET_S = 11644473600.0
 #: FILETIME resolution: 100 ns ticks per second.
 _WIN_FILETIME_TICKS_PER_S = 10_000_000.0
 
+#: ``OpenProcess`` last-error for "no process has this id".  This is the
+#: only refusal that is evidence the target exited.
+_WIN_ERROR_INVALID_PARAMETER = 87
 
-def _win_open_process(pid: int, access: int) -> int | None:
-    """Return an open kernel handle to *pid*.
+#: ``OpenProcess`` last-error for "the pid is in use by a process you may
+#: not touch".  Evidence the target is *alive* and unobservable, never
+#: evidence that it is gone.
+_WIN_ERROR_ACCESS_DENIED = 5
+
+
+def _win_last_error(kernel32: Any) -> int:
+    """Return ``GetLastError()``, or 0 when it cannot be read.
+
+    Args:
+        kernel32: The kernel32 handle the failing call was made through.
+
+    Returns:
+        The Win32 last-error code, or 0 when unavailable.  0 is not a real
+        failure code, so callers treat it as "unknown" and stay
+        conservative.
+    """
+    try:
+        return int(kernel32.GetLastError())
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("GetLastError unavailable: %s", exc)
+        return 0
+
+
+def _win_open_process(pid: int, access: int) -> tuple[int | None, int]:
+    """Return an open kernel handle to *pid* and the refusal reason.
 
     Args:
         pid: Process ID.
         access: ``OpenProcess`` desired-access mask.
 
     Returns:
-        A handle value; ``0`` when ``OpenProcess`` itself refused (no such
-        process, or access denied); ``None`` when the call could not be made
-        at all.  The two are kept apart deliberately: a missing kernel32 is
-        an environment failure and says nothing about the target, whereas a
-        refused open is evidence about the pid.
+        ``(handle, last_error)``.  ``handle`` is a handle value; ``0`` when
+        ``OpenProcess`` itself refused; ``None`` when the call could not be
+        made at all.  The two are kept apart deliberately: a missing
+        kernel32 is an environment failure and says nothing about the
+        target, whereas a refused open is evidence about the pid - and
+        *which* evidence depends on ``last_error``, so it is returned rather
+        than discarded.
     """
     try:
         kernel32 = _win_kernel32()
     except Exception as exc:
         logger.debug("kernel32 unavailable while opening PID %d: %s", pid, exc)
-        return None
+        return None, 0
     try:
-        return int(kernel32.OpenProcess(access, False, pid))
+        handle = int(kernel32.OpenProcess(access, False, pid))
     except Exception as exc:  # pragma: no cover - defensive
         logger.debug("OpenProcess failed for PID %d: %s", pid, exc)
-        return None
+        return None, 0
+    return handle, (0 if handle else _win_last_error(kernel32))
 
 
-def _win_handle_alive(handle: int) -> bool:
-    """Return True when the process behind *handle* has not exited yet."""
+def _win_handle_liveness(handle: int) -> bool | None:
+    """Return whether the process behind *handle* is still running.
+
+    Args:
+        handle: An open process handle with query rights.
+
+    Returns:
+        True when the process is running, False when it has exited, and
+        None when the state could not be read at all.  The third answer
+        exists so an unreadable handle is never mistaken for an exit.
+    """
     import ctypes
     import ctypes.wintypes
 
     try:
         exit_code = ctypes.wintypes.DWORD()
         if not _win_kernel32().GetExitCodeProcess(handle, ctypes.byref(exit_code)):
-            return False
+            return None
         return bool(exit_code.value == _WIN_STILL_ACTIVE)
     except Exception as exc:  # pragma: no cover - defensive
         logger.debug("GetExitCodeProcess failed: %s", exc)
-        return False
+        return None
+
+
+def _win_handle_alive(handle: int) -> bool:
+    """Return True when the process behind *handle* has not exited yet.
+
+    An unreadable handle is reported as not alive so no caller keeps
+    waiting on it.  Callers that need to tell "exited" from "could not
+    read" must use :func:`_win_handle_liveness` instead.
+    """
+    return _win_handle_liveness(handle) is True
 
 
 def _win_handle_start_time(handle: int) -> float | None:
@@ -987,42 +1156,68 @@ def _win_pin_process(pid: int) -> _WinReapPin | None:
         treating an unreadable environment as proof about the process.
     """
     if pid <= 0:
-        return _WinReapPin(pid, 0, already_gone=True)
+        # There is no such pid to begin with, on any Windows build.
+        return _WinReapPin(pid, 0, target_state=_PIN_TARGET_EXITED)
     requested_at = time.time()
     full = _WIN_PROCESS_QUERY_LIMITED_INFORMATION | _WIN_PROCESS_TERMINATE | _WIN_SYNCHRONIZE
-    handle = _win_open_process(pid, full)
+    handle, last_error = _win_open_process(pid, full)
     if handle is None:
         return None
     if not handle:
-        handle = _win_open_process(pid, _WIN_PROCESS_QUERY_LIMITED_INFORMATION)
+        # Terminate rights are the likeliest thing to be refused; retry with
+        # the query-only rights the identity check actually needs before
+        # concluding anything about the pid.
+        handle, last_error = _win_open_process(pid, _WIN_PROCESS_QUERY_LIMITED_INFORMATION)
         if handle is None:
             return None
     if not handle:
-        # The pid does not resolve to a process we can observe.  OpenProcess
-        # fails for a pid that is not in use at all, which is the
-        # already-exited case; it also fails when the pid *is* in use by a
-        # process we may not touch.  Both mean "do not signal this number":
-        # report gone so the reap stops here instead of firing stop tiers at
-        # a number that is not ours.
-        return _WinReapPin(pid, 0, already_gone=True)
+        # OpenProcess refused.  Which refusal it was decides what we may
+        # report.  ERROR_INVALID_PARAMETER means no process holds this pid,
+        # which is an observed exit.  ERROR_ACCESS_DENIED means one does and
+        # we may not touch it, which is an observed *live* process we cannot
+        # follow - reporting that as gone would certify a running process.
+        # Any other code is simply unknown.  Only the first is an exit.
+        if last_error == _WIN_ERROR_INVALID_PARAMETER:
+            return _WinReapPin(pid, 0, target_state=_PIN_TARGET_EXITED)
+        logger.warning(
+            "PID %d could not be opened for reap (error %d); it is not signalled and its state is not claimed",
+            pid,
+            last_error,
+        )
+        return _WinReapPin(pid, 0, target_state=_PIN_TARGET_UNOBSERVABLE)
 
-    pin = _WinReapPin(pid, handle, already_gone=not _win_handle_alive(handle))
-    if pin.already_gone:
-        return pin
+    liveness = _win_handle_liveness(handle)
+    if liveness is None:
+        # The handle is open but will not answer.  That is an absence of
+        # evidence, not an exit.  Keep it open so the pid stays pinned, and
+        # report a state no tier will act on and no receipt will claim.
+        logger.warning(
+            "PID %d has an open handle whose exit state cannot be read; "
+            "it is not signalled and its state is not claimed",
+            pid,
+        )
+        return _WinReapPin(pid, handle, target_state=_PIN_TARGET_UNOBSERVABLE)
+    if not liveness:
+        return _WinReapPin(pid, handle, target_state=_PIN_TARGET_EXITED)
 
+    pin = _WinReapPin(pid, handle, target_state=_PIN_TARGET_RUNNING)
     start_time = _win_handle_start_time(handle)
     if start_time is not None and start_time > requested_at:
         # This process started after we were asked to reap the pid, so it
-        # cannot be the process the caller meant - the number was recycled.
-        # Drop the pin without ever signalling it.
+        # cannot be the process the caller meant - the number was recycled,
+        # or the clock stepped backwards under us.  Either way the process
+        # we can see is not the target, and the target's own state is
+        # therefore unknown.  Drop the pin without signalling it, and claim
+        # nothing: "this is not the process you asked about" is not the same
+        # finding as "the process you asked about has exited".
         logger.warning(
-            "PID %d was recycled before the reap could pin it (started %.3fs after the request); "
-            "refusing to signal an unrelated process",
+            "PID %d does not identify the reap target (the process holding it started "
+            "%.3fs after the request); refusing to signal it and claiming no outcome",
             pid,
             start_time - requested_at,
         )
         pin.close()
-        return _WinReapPin(pid, 0, already_gone=True)
+        return _WinReapPin(pid, 0, target_state=_PIN_TARGET_UNOBSERVABLE)
     return pin
 
 
@@ -1053,7 +1248,10 @@ def _win_taskkill(pid: int, *, force: bool = False, tree: bool = False) -> bool:
         # cannot prove is still the process we were asked to stop.
         return _win_run_taskkill(pid, force=force, tree=tree) == 0
     try:
-        if pin.already_gone:
+        if not pin.signalable:
+            # Either the target was observed gone (nothing to stop) or its
+            # identity could not be established (must not be stopped).
+            # Neither delivered a stop, which is what this bool reports.
             return False
         return _win_stop_pinned(pin, force=force, tree=tree)
     finally:
@@ -1122,7 +1320,10 @@ def _win_stop_pinned(pin: _WinReapPin, *, force: bool, tree: bool) -> bool:
     # hitting an unrelated process, and no external interpreter to time out.
     if pin.terminate():
         return pin.wait_for_exit(_WIN_EXIT_CONFIRM_MS)
-    return not pin.alive()
+    # The terminate request itself was refused.  Report a stop only if the
+    # handle affirmatively says the process exited anyway; a handle that
+    # will not answer is not an exit.
+    return pin.observed_exited()
 
 
 def _win_process_alive(pid: int) -> bool:

--- a/src/bernstein/core/config/platform_compat.py
+++ b/src/bernstein/core/config/platform_compat.py
@@ -1108,7 +1108,10 @@ def _win_stop_pinned(pin: _WinReapPin, *, force: bool, tree: bool) -> bool:
     # lead pid steady while it runs, so /T resolves children of the process
     # we meant and not of a namesake.
     returncode = _win_run_taskkill(pid, force=force, tree=tree)
-    if returncode == 0 and pin.wait_for_exit(_WIN_EXIT_CONFIRM_MS):
+    if returncode == 0:
+        # taskkill accepted the stop.  Return without waiting: the grace
+        # window belongs to the caller, and the reap's own poll loop is what
+        # decides whether the tree needs the force tier.
         return True
     if returncode == _WIN_TASKKILL_NOT_FOUND:
         logger.debug("taskkill reports PID %d is not running", pid)

--- a/src/bernstein/core/config/platform_compat.py
+++ b/src/bernstein/core/config/platform_compat.py
@@ -12,6 +12,7 @@ the POSIX APIs are unavailable.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import ntpath
 import os
@@ -28,7 +29,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterator
     from pathlib import Path
 
     import pytest
@@ -324,7 +325,11 @@ def kill_process_group_graceful(
     Returns:
         ``True`` if SIGTERM was delivered successfully (even if SIGKILL
         later had to be used).  ``False`` when the group was already dead
-        or the initial SIGTERM could not be sent.
+        or the initial SIGTERM could not be sent.  Callers that need the
+        stronger "the tree is no longer running" guarantee should use
+        :func:`reap_process_group` and read
+        :attr:`ProcessReapReceipt.confirmed_dead` instead - a group that
+        exited on its own reports ``False`` here while still satisfying it.
     """
     return reap_process_group(
         pgid,
@@ -344,9 +349,18 @@ class ProcessReapReceipt:
 
     A deterministic projection of what the reap path did: which platform
     mechanism delivered the stop, whether the graceful stop was delivered,
-    and whether escalation to a force-kill was required.  Callers mirror
-    the receipt into the audit chain so a failure window can be
-    reconstructed offline.
+    whether the target was already gone, whether escalation to a force-kill
+    was required, and - the guarantee callers actually depend on - whether
+    the target is verified to no longer be running.  Callers mirror the
+    receipt into the audit chain so a failure window can be reconstructed
+    offline.
+
+    ``delivered`` answers "did we hand a stop to the OS"; it is *not* the
+    success predicate.  A tree that had already exited before the reap ran
+    accepts no stop, so ``delivered`` is False while the caller's guarantee
+    holds perfectly.  Read :attr:`confirmed_dead` to answer "is the tree
+    gone", and :attr:`already_gone` to tell "it exited on its own" apart
+    from "we stopped it".
 
     Attributes:
         pgid: Process group ID (POSIX) or lead PID (Windows) targeted.
@@ -356,6 +370,13 @@ class ProcessReapReceipt:
         delivered: Whether the initial graceful stop was delivered.
         escalated: Whether a force-kill was required after the grace window.
         grace_seconds: The grace window that applied to this reap.
+        already_gone: Whether the target had already exited before any stop
+            tier ran.  Only ever True when that was affirmatively observed;
+            a target whose state could not be established is not
+            "already gone".
+        confirmed_dead: Whether the target is verified to no longer be
+            running once the reap returned.  This is the guarantee the reap
+            exists to provide.
     """
 
     pgid: int
@@ -364,6 +385,8 @@ class ProcessReapReceipt:
     delivered: bool
     escalated: bool
     grace_seconds: float
+    already_gone: bool = False
+    confirmed_dead: bool = False
 
     def to_details(self) -> dict[str, object]:
         """Return the receipt as a plain dict for audit-chain payloads."""
@@ -374,7 +397,186 @@ class ProcessReapReceipt:
             "delivered": self.delivered,
             "escalated": self.escalated,
             "grace_seconds": self.grace_seconds,
+            "already_gone": self.already_gone,
+            "confirmed_dead": self.confirmed_dead,
         }
+
+
+def _group_stopped_running(pgid: int) -> bool:
+    """Return True when the group has no member left that can run code.
+
+    Confirmation counterpart to :func:`process_group_alive`.  The two answer
+    deliberately different questions.  ``process_group_alive`` drives the
+    decision to *escalate*, so it errs towards "alive" and reports EPERM as
+    alive.  Confirmation needs the sharper question - is anything still
+    running - and a zombie (a process that has exited and is waiting for its
+    parent to call ``wait()``) runs no code.
+
+    macOS reports EPERM, not ESRCH, for a signal aimed at a group whose only
+    remaining members are zombies, so a fully reaped group keeps looking
+    alive to ``killpg(pgid, 0)`` until the parent gets round to reaping it.
+    This probe is only reached after a SIGTERM was accepted for the same
+    group, which proves the group was signalable by us at that point, so a
+    later refusal means the signalable members are gone.
+
+    Args:
+        pgid: Process group ID (POSIX) or lead PID (Windows).
+
+    Returns:
+        True if nothing in the group is still running.
+    """
+    killpg = getattr(os, "killpg", None)
+    if IS_WINDOWS or killpg is None:
+        return not process_group_alive(pgid)
+    try:
+        killpg(pgid, 0)
+    except OSError:
+        return True
+    return False
+
+
+class _ReapPin:
+    """Identity pin held for the duration of one reap.
+
+    The POSIX flavour is inert on purpose.  A POSIX reap targets a process
+    *group*, and the kernel does not recycle a group id while the group
+    still has members, so every ``killpg`` tier already acts on the group it
+    was handed.  :class:`_WinReapPin` does the real work; keeping the POSIX
+    path on this no-op base means Linux and macOS reaps are byte-for-byte
+    the same sequence of syscalls they were before the pin existed.
+    """
+
+    #: True only when the target was affirmatively observed to be gone
+    #: before any stop tier ran.  A target whose state could not be
+    #: established is never "already gone" - not knowing is not proof.
+    already_gone: bool = False
+
+    def confirm_exit(self, pgid: int, *, forced: bool) -> bool:
+        """Return True when the target is verified to no longer be running.
+
+        A delivered force-kill is itself the confirmation on POSIX: SIGKILL
+        cannot be caught, blocked, or ignored.  Re-probing liveness is not a
+        substitute - ``killpg(pgid, 0)`` keeps succeeding for a group whose
+        members are already-dead zombies waiting for their parent to call
+        ``wait()``, so a probe fired straight after SIGKILL reports "alive"
+        for a group that is not running any code at all.
+
+        Args:
+            pgid: Process group ID (POSIX) or lead PID (Windows).
+            forced: Whether an unblockable force-kill was delivered.
+
+        Returns:
+            True if the target is confirmed no longer running.
+        """
+        return forced or _group_stopped_running(pgid)
+
+    def close(self) -> None:
+        """Release any OS resource the pin holds.  No-op on POSIX."""
+
+
+class _WinReapPin(_ReapPin):
+    """An open Windows process handle held for the duration of one reap.
+
+    Windows recycles pids aggressively - a busy runner can hand the same
+    number to an unrelated process within seconds.  Any reap that
+    re-resolves a bare pid between tiers can therefore end up signalling, or
+    reporting on, a process it was never asked to touch, and force-killing
+    someone else's process is far worse than a mis-reported receipt.
+
+    While *any* handle to a process object is open the kernel will not reuse
+    that pid, so opening one handle up front and holding it until the reap
+    returns is the pid-reuse guard: for the whole reap window the number
+    either refers to the process we were asked to reap, or to nothing.
+
+    Two residual gaps are handled explicitly rather than hidden:
+
+    * A pid can be recycled *before* the pin is taken.  The pin therefore
+      also reads the target's creation time and refuses to treat a process
+      that started after the reap request as the reap target - a process
+      born after the caller asked us to stop pid N cannot be the process the
+      caller meant.  Call sites that hold a live ``Popen`` for the child
+      (every adapter spawn path) have no window at all: the parent's own
+      handle already pins the pid.
+    * ``TerminateProcess`` is asynchronous, so a liveness probe fired
+      straight after a kill can still observe ``STILL_ACTIVE`` on a process
+      that is already on its way out.  :meth:`confirm_exit` waits on the
+      handle instead of racing the probe.
+
+    If the handle cannot be opened at all (no ctypes, no permission, no such
+    process) the pin degrades to the inert base behaviour: it never claims
+    the target is gone and never blocks the reap.
+    """
+
+    def __init__(self, pid: int, handle: int, *, already_gone: bool) -> None:
+        self.pid = pid
+        self._handle = handle
+        self.already_gone = already_gone
+
+    def alive(self) -> bool:
+        """Return True when the pinned process has not exited yet."""
+        return bool(self._handle) and _win_handle_alive(self._handle)
+
+    def terminate(self, exit_code: int = 1) -> bool:
+        """Terminate the pinned process through the handle we already hold."""
+        return bool(self._handle) and _win_terminate_handle(self._handle, exit_code)
+
+    def wait_for_exit(self, timeout_ms: int) -> bool:
+        """Block until the pinned process exits or *timeout_ms* elapses."""
+        return bool(self._handle) and _win_wait_for_exit(self._handle, timeout_ms)
+
+    def confirm_exit(self, pgid: int, *, forced: bool) -> bool:
+        """Wait on the pinned handle, then fall back to the liveness probe.
+
+        Windows has real evidence available - the handle becomes signalled
+        when the process leaves the system - so a force-kill request is not
+        allowed to stand in for it here.
+
+        Args:
+            pgid: Lead PID of the reaped tree.
+            forced: Whether a force-kill was delivered (unused: the handle
+                wait is stronger evidence).
+
+        Returns:
+            True if the target is confirmed no longer running.
+        """
+        del forced
+        if self.wait_for_exit(_WIN_EXIT_CONFIRM_MS):
+            return True
+        return _group_stopped_running(pgid)
+
+    def close(self) -> None:
+        """Close the pinned handle, releasing the pid back to the kernel."""
+        if not self._handle:
+            return
+        handle, self._handle = self._handle, 0
+        try:
+            _win_kernel32().CloseHandle(handle)
+        except Exception as exc:  # pragma: no cover - teardown must not raise
+            logger.debug("Could not close reap pin for PID %d: %s", self.pid, exc)
+
+
+@contextlib.contextmanager
+def _pin_reap_target(pgid: int) -> Iterator[_ReapPin]:
+    """Yield an identity pin for *pgid*, held until the reap finishes.
+
+    Args:
+        pgid: Process group ID (POSIX) or lead PID (Windows).
+
+    Yields:
+        A :class:`_ReapPin` - inert on POSIX, a pinned process handle on
+        Windows.  Never raises: a pin that cannot be established degrades to
+        the inert base behaviour so the guard can never break a reap.
+    """
+    pin: _ReapPin = _ReapPin()
+    if IS_WINDOWS:
+        try:
+            pin = _win_pin_process(pgid) or pin
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("Could not pin PID %d for reap: %s", pgid, exc)
+    try:
+        yield pin
+    finally:
+        pin.close()
 
 
 def reap_process_group(
@@ -390,6 +592,12 @@ def reap_process_group(
     outcome is returned as a :class:`ProcessReapReceipt` so callers can
     record *how* the reap was performed instead of a bare bool.
 
+    The guarantee is "the target is no longer running", reported as
+    :attr:`ProcessReapReceipt.confirmed_dead`.  A target that had already
+    exited before the reap ran satisfies that guarantee even though no stop
+    could be delivered to it, so ``delivered`` and ``confirmed_dead`` are
+    reported separately instead of being collapsed into one flag.
+
     Args:
         pgid: Process group ID (on Unix) or PID (on Windows).
         grace_seconds: Total time to wait for the graceful stop to take
@@ -403,7 +611,13 @@ def reap_process_group(
     os_name = _detect_os_name()
     method = _REAP_METHOD_WINDOWS if IS_WINDOWS else _REAP_METHOD_POSIX
 
-    def _receipt(*, delivered: bool, escalated: bool) -> ProcessReapReceipt:
+    def _receipt(
+        *,
+        delivered: bool,
+        escalated: bool,
+        already_gone: bool = False,
+        confirmed_dead: bool = False,
+    ) -> ProcessReapReceipt:
         return ProcessReapReceipt(
             pgid=pgid,
             os_name=os_name,
@@ -411,38 +625,71 @@ def reap_process_group(
             delivered=delivered,
             escalated=escalated,
             grace_seconds=grace_seconds,
+            already_gone=already_gone,
+            confirmed_dead=confirmed_dead,
         )
 
     if pgid <= 0:
         return _receipt(delivered=False, escalated=False)
 
-    # Best-effort TERM first; if it fails the group is already gone.
-    if not kill_process_group(pgid, signal.SIGTERM):
-        return _receipt(delivered=False, escalated=False)
+    # Pin the target's identity for the whole reap.  On Windows that is an
+    # open kernel handle, which stops the kernel recycling the pid while any
+    # tier below is running, so no tier can signal - or report on - a process
+    # that merely inherited the number.  Inert on POSIX (see _ReapPin).
+    with _pin_reap_target(pgid) as pin:
+        if pin.already_gone:
+            # Nothing to stop.  The tree the caller asked about is not
+            # running, which is exactly the guarantee they wanted, so this is
+            # a success even though no stop was delivered to anything.
+            return _receipt(
+                delivered=False,
+                escalated=False,
+                already_gone=True,
+                confirmed_dead=True,
+            )
 
-    # Poll for graceful exit.  Probe the whole process *group* rather than the
-    # lead PID: the session leader can reap while a child it spawned keeps the
-    # group alive, and a lead-PID-only check (``process_alive``) would then
-    # declare the group dead the moment the leader exits and skip the SIGKILL
-    # escalation the surviving tree still needs (issue #2643).
-    deadline = time.monotonic() + grace_seconds
-    while time.monotonic() < deadline:
+        # Best-effort TERM first.
+        if not kill_process_group(pgid, signal.SIGTERM):
+            # The stop could not be delivered.  That is only a reap failure
+            # when the target is still running; a target that has already
+            # exited is the outcome the caller asked for.  Verify rather than
+            # assume - conflating the two is what made an already-exited
+            # Windows spawn look like a failed stop.
+            gone = not process_group_alive(pgid)
+            return _receipt(
+                delivered=False,
+                escalated=False,
+                already_gone=gone,
+                confirmed_dead=gone,
+            )
+
+        # Poll for graceful exit.  Probe the whole process *group* rather than
+        # the lead PID: the session leader can reap while a child it spawned
+        # keeps the group alive, and a lead-PID-only check (``process_alive``)
+        # would then declare the group dead the moment the leader exits and
+        # skip the SIGKILL escalation the surviving tree still needs (#2643).
+        deadline = time.monotonic() + grace_seconds
+        while time.monotonic() < deadline:
+            if not process_group_alive(pgid):
+                return _receipt(delivered=True, escalated=False, confirmed_dead=True)
+            time.sleep(poll_interval)
+
+        # Group still alive after grace period - escalate.
         if not process_group_alive(pgid):
-            return _receipt(delivered=True, escalated=False)
-        time.sleep(poll_interval)
-
-    # Group still alive after grace period - escalate.
-    escalated = False
-    if process_group_alive(pgid):
+            # Exited right on the grace boundary; no force tier needed.
+            return _receipt(delivered=True, escalated=False, confirmed_dead=True)
         logger.warning(
             "Process group %d did not exit within %.1fs of SIGTERM; sending SIGKILL",
             pgid,
             grace_seconds,
         )
         kill_sig = signal.SIGKILL if is_signal_supported("SIGKILL") else 9
-        kill_process_group(pgid, kill_sig)
-        escalated = True
-    return _receipt(delivered=True, escalated=escalated)
+        forced = kill_process_group(pgid, kill_sig)
+        return _receipt(
+            delivered=True,
+            escalated=True,
+            confirmed_dead=pin.confirm_exit(pgid, forced=forced),
+        )
 
 
 def process_alive(pid: int) -> bool:
@@ -578,9 +825,216 @@ def path_separator() -> str:
 # Internal Windows helpers
 # ---------------------------------------------------------------------------
 
+# Access rights the reap pin asks for.  PROCESS_QUERY_LIMITED_INFORMATION is
+# the minimum needed to read liveness and creation time,
+# _WIN_PROCESS_TERMINATE lets us stop the target through the same handle, and
+# SYNCHRONIZE lets us *wait* for it to leave the system instead of racing a
+# liveness probe.
+_WIN_PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+_WIN_SYNCHRONIZE = 0x00100000
+
+#: ``GetExitCodeProcess`` sentinel for "this process has not exited yet".
+_WIN_STILL_ACTIVE = 259
+
+#: ``WaitForSingleObject`` return meaning "the handle was signalled".
+_WIN_WAIT_OBJECT_0 = 0x0
+
+#: How long a reap waits for a terminated process to actually leave the
+#: system before calling the stop unconfirmed.  ``TerminateProcess`` is
+#: asynchronous, so a probe fired immediately after it can still observe
+#: ``STILL_ACTIVE`` on a process that is already on its way out.
+_WIN_EXIT_CONFIRM_MS = 2000
+
+#: ``taskkill`` exit code for "the process is not running".
+_WIN_TASKKILL_NOT_FOUND = 128
+
+#: Offset between the FILETIME epoch (1601-01-01 UTC) and the Unix epoch.
+_WIN_FILETIME_EPOCH_OFFSET_S = 11644473600.0
+
+#: FILETIME resolution: 100 ns ticks per second.
+_WIN_FILETIME_TICKS_PER_S = 10_000_000.0
+
+
+def _win_open_process(pid: int, access: int) -> int | None:
+    """Return an open kernel handle to *pid*.
+
+    Args:
+        pid: Process ID.
+        access: ``OpenProcess`` desired-access mask.
+
+    Returns:
+        A handle value; ``0`` when ``OpenProcess`` itself refused (no such
+        process, or access denied); ``None`` when the call could not be made
+        at all.  The two are kept apart deliberately: a missing kernel32 is
+        an environment failure and says nothing about the target, whereas a
+        refused open is evidence about the pid.
+    """
+    try:
+        kernel32 = _win_kernel32()
+    except Exception as exc:
+        logger.debug("kernel32 unavailable while opening PID %d: %s", pid, exc)
+        return None
+    try:
+        return int(kernel32.OpenProcess(access, False, pid))
+    except Exception as exc:
+        logger.debug("OpenProcess failed for PID %d: %s", pid, exc)
+        return None
+
+
+def _win_handle_alive(handle: int) -> bool:
+    """Return True when the process behind *handle* has not exited yet."""
+    import ctypes
+    import ctypes.wintypes
+
+    try:
+        exit_code = ctypes.wintypes.DWORD()
+        if not _win_kernel32().GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+            return False
+        return bool(exit_code.value == _WIN_STILL_ACTIVE)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("GetExitCodeProcess failed: %s", exc)
+        return False
+
+
+def _win_handle_start_time(handle: int) -> float | None:
+    """Return the creation time of *handle*'s process as a Unix timestamp.
+
+    Args:
+        handle: An open process handle with query rights.
+
+    Returns:
+        Seconds since the Unix epoch, or None when the time is unavailable.
+    """
+    import ctypes
+    import ctypes.wintypes
+
+    try:
+        creation = ctypes.wintypes.FILETIME()
+        exited = ctypes.wintypes.FILETIME()
+        kernel = ctypes.wintypes.FILETIME()
+        user = ctypes.wintypes.FILETIME()
+        ok = _win_kernel32().GetProcessTimes(
+            handle,
+            ctypes.byref(creation),
+            ctypes.byref(exited),
+            ctypes.byref(kernel),
+            ctypes.byref(user),
+        )
+        if not ok:
+            return None
+        ticks = (int(creation.dwHighDateTime) << 32) | int(creation.dwLowDateTime)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("GetProcessTimes failed: %s", exc)
+        return None
+    return ticks / _WIN_FILETIME_TICKS_PER_S - _WIN_FILETIME_EPOCH_OFFSET_S
+
+
+def _win_wait_for_exit(handle: int, timeout_ms: int) -> bool:
+    """Block until *handle*'s process exits or *timeout_ms* elapses.
+
+    ``TerminateProcess`` only *requests* termination, so this is what turns
+    "we asked it to die" into "it is gone" without a polling race.
+
+    Args:
+        handle: An open process handle with ``SYNCHRONIZE`` rights.
+        timeout_ms: Maximum time to wait, in milliseconds.
+
+    Returns:
+        True if the process exited within the timeout.
+    """
+    try:
+        return int(_win_kernel32().WaitForSingleObject(handle, timeout_ms)) == _WIN_WAIT_OBJECT_0
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("WaitForSingleObject failed: %s", exc)
+        return False
+
+
+def _win_terminate_handle(handle: int, exit_code: int = 1) -> bool:
+    """Terminate the process behind *handle*.
+
+    Takes a handle rather than a pid on purpose: the handle already names
+    one specific process object, so this can never hit a different process
+    that inherited the same pid number.
+
+    Args:
+        handle: An open process handle with terminate rights.
+        exit_code: Exit code to report for the terminated process.
+
+    Returns:
+        True if the terminate request was accepted.
+    """
+    try:
+        return bool(_win_kernel32().TerminateProcess(handle, exit_code))
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("TerminateProcess failed: %s", exc)
+        return False
+
+
+def _win_pin_process(pid: int) -> _WinReapPin | None:
+    """Open and return a pid-reuse pin for *pid* (Windows only).
+
+    Asks for terminate + synchronize + query rights so the whole reap can be
+    driven through the one handle, and degrades to query-only rights rather
+    than giving up the guard.
+
+    Args:
+        pid: Process ID to pin.
+
+    Returns:
+        A :class:`_WinReapPin`, or None when the kernel boundary is not
+        callable at all.  None means "guard unavailable", never "target
+        gone" - callers fall back to their pre-pin behaviour instead of
+        treating an unreadable environment as proof about the process.
+    """
+    if pid <= 0:
+        return _WinReapPin(pid, 0, already_gone=True)
+    requested_at = time.time()
+    full = _WIN_PROCESS_QUERY_LIMITED_INFORMATION | _WIN_PROCESS_TERMINATE | _WIN_SYNCHRONIZE
+    handle = _win_open_process(pid, full)
+    if handle is None:
+        return None
+    if not handle:
+        handle = _win_open_process(pid, _WIN_PROCESS_QUERY_LIMITED_INFORMATION)
+        if handle is None:
+            return None
+    if not handle:
+        # The pid does not resolve to a process we can observe.  OpenProcess
+        # fails for a pid that is not in use at all, which is the
+        # already-exited case; it also fails when the pid *is* in use by a
+        # process we may not touch.  Both mean "do not signal this number":
+        # report gone so the reap stops here instead of firing stop tiers at
+        # a number that is not ours.
+        return _WinReapPin(pid, 0, already_gone=True)
+
+    pin = _WinReapPin(pid, handle, already_gone=not _win_handle_alive(handle))
+    if pin.already_gone:
+        return pin
+
+    start_time = _win_handle_start_time(handle)
+    if start_time is not None and start_time > requested_at:
+        # This process started after we were asked to reap the pid, so it
+        # cannot be the process the caller meant - the number was recycled.
+        # Drop the pin without ever signalling it.
+        logger.warning(
+            "PID %d was recycled before the reap could pin it (started %.3fs after the request); "
+            "refusing to signal an unrelated process",
+            pid,
+            start_time - requested_at,
+        )
+        pin.close()
+        return _WinReapPin(pid, 0, already_gone=True)
+    return pin
+
 
 def _win_taskkill(pid: int, *, force: bool = False, tree: bool = False) -> bool:
-    """Kill a process on Windows via ``taskkill`` with PowerShell fallback.
+    """Stop a Windows process (optionally its whole tree), pid-reuse safe.
+
+    Pins the pid with an open handle first, so neither the ``taskkill`` tree
+    stop nor the terminate fallback can act on a process that merely
+    inherited the number.  The fallback terminates through the pinned handle
+    rather than re-resolving the pid, and confirms the exit by waiting on the
+    handle instead of racing an asynchronous ``TerminateProcess`` with a
+    liveness probe.
 
     Args:
         pid: Process ID.
@@ -588,9 +1042,35 @@ def _win_taskkill(pid: int, *, force: bool = False, tree: bool = False) -> bool:
         tree: If True, adds ``/T`` (kill child processes).
 
     Returns:
-        True if the process was killed successfully.
+        True if this call stopped the process.  False when the process was
+        already gone (matching the POSIX ``os.kill`` semantics
+        :func:`kill_process` documents) or could not be stopped.
     """
-    # Try taskkill first (faster when it works)
+    pin = _win_pin_process(pid)
+    if pin is None:
+        # The guard could not be established.  Run the tree stop alone
+        # instead of reaching for a fallback that force-kills a bare pid we
+        # cannot prove is still the process we were asked to stop.
+        return _win_run_taskkill(pid, force=force, tree=tree) == 0
+    try:
+        if pin.already_gone:
+            return False
+        return _win_stop_pinned(pin, force=force, tree=tree)
+    finally:
+        pin.close()
+
+
+def _win_run_taskkill(pid: int, *, force: bool, tree: bool) -> int:
+    """Run ``taskkill`` for *pid* and return its exit code.
+
+    Args:
+        pid: Process ID to target.
+        force: If True, adds ``/F`` (force terminate).
+        tree: If True, adds ``/T`` (kill child processes).
+
+    Returns:
+        The ``taskkill`` exit code, or -1 when it could not be run.
+    """
     cmd: list[str] = ["taskkill"]
     if force:
         cmd.append("/F")
@@ -606,27 +1086,40 @@ def _win_taskkill(pid: int, *, force: bool = False, tree: bool = False) -> bool:
             errors="replace",
             timeout=5,
         )
-        if result.returncode == 0:
-            return True
     except (subprocess.TimeoutExpired, OSError) as exc:
         logger.debug("taskkill failed for PID %d: %s", pid, exc)
+        return -1
+    return int(result.returncode)
 
-    # Fallback: PowerShell Stop-Process (more reliable for stubborn processes)
-    try:
-        ps_cmd = f"Stop-Process -Id {pid} -Force -ErrorAction SilentlyContinue"
-        result = subprocess.run(
-            ["powershell", "-NoProfile", "-Command", ps_cmd],
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            timeout=5,
-        )
-        # PowerShell returns 0 even if process doesn't exist, so verify
-        return not _win_process_alive(pid)
-    except (subprocess.TimeoutExpired, OSError) as exc:
-        logger.debug("PowerShell Stop-Process failed for PID %d: %s", pid, exc)
-        return False
+
+def _win_stop_pinned(pin: _WinReapPin, *, force: bool, tree: bool) -> bool:
+    """Stop the process behind an established pin.
+
+    Args:
+        pin: An open pin whose target was alive when it was taken.
+        force: If True, adds ``/F`` (force terminate) to ``taskkill``.
+        tree: If True, adds ``/T`` (kill child processes) to ``taskkill``.
+
+    Returns:
+        True if the target is confirmed stopped.
+    """
+    pid = pin.pid
+    # taskkill is the only cheap way to reach the *tree*; the pin holds the
+    # lead pid steady while it runs, so /T resolves children of the process
+    # we meant and not of a namesake.
+    returncode = _win_run_taskkill(pid, force=force, tree=tree)
+    if returncode == 0 and pin.wait_for_exit(_WIN_EXIT_CONFIRM_MS):
+        return True
+    if returncode == _WIN_TASKKILL_NOT_FOUND:
+        logger.debug("taskkill reports PID %d is not running", pid)
+
+    # taskkill refuses to stop a console process without /F, and cannot stop
+    # one at all when the caller lacks rights it needs.  Terminate the lead
+    # through the handle we already hold: no pid lookup, so no chance of
+    # hitting an unrelated process, and no external interpreter to time out.
+    if pin.terminate():
+        return pin.wait_for_exit(_WIN_EXIT_CONFIRM_MS)
+    return not pin.alive()
 
 
 def _win_process_alive(pid: int) -> bool:

--- a/src/bernstein/core/config/platform_compat.py
+++ b/src/bernstein/core/config/platform_compat.py
@@ -876,7 +876,7 @@ def _win_open_process(pid: int, access: int) -> int | None:
         return None
     try:
         return int(kernel32.OpenProcess(access, False, pid))
-    except Exception as exc:
+    except Exception as exc:  # pragma: no cover - defensive
         logger.debug("OpenProcess failed for PID %d: %s", pid, exc)
         return None
 

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -4592,8 +4592,12 @@ def record_process_reap_receipt(
     lines.
 
     ``delivered`` records what was handed to the OS; ``confirmed_dead``
-    records the guarantee.  They differ whenever a tree exits before the
-    reap reaches it, which is a routine outcome and not a failure.
+    records what was observed afterwards.  They differ whenever a tree
+    exits before the reap reaches it, which is a routine outcome and not a
+    failure, and also whenever the platform cannot observe the outcome at
+    all.  Both new fields are only ever True from an observation, so a
+    verifier reading the chain offline can rely on False meaning "not
+    established" rather than "assumed".
 
     Args:
         chain: The audit chain store accepting the entry.
@@ -4608,10 +4612,11 @@ def record_process_reap_receipt(
         reason: Why the reap ran (e.g. ``"kill_requested"``,
             ``"heartbeat_stale"``, ``"wall_clock_timeout"``).
         actor: Recorded actor; defaults to ``"spawner"``.
-        already_gone: Whether the tree had already exited before any stop
-            tier ran.
-        confirmed_dead: Whether the tree is verified to no longer be running
-            once the reap returned.
+        already_gone: Whether the tree was observed to have already exited
+            before any stop tier ran.
+        confirmed_dead: Whether the tree was observed to no longer be
+            running once the reap returned.  False means the reap could not
+            establish it, which is not the same as the tree still running.
 
     Returns:
         The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -4577,15 +4577,23 @@ def record_process_reap_receipt(
     grace_seconds: float,
     reason: str,
     actor: str = "spawner",
+    already_gone: bool = False,
+    confirmed_dead: bool = False,
 ) -> AuditEvent:
     """Append a ``process.reap_receipt`` event into *chain* (#2367).
 
     Mirrors a forced agent process-tree reap into the audit chain.  The
     receipt records which platform mechanism delivered the stop (POSIX
     process-group signalling or Windows process-tree termination), whether
-    the graceful stop was delivered, and whether escalation to a force-kill
-    was required.  A verifier reconstructing a failure window can prove
-    offline which reap path ran instead of inferring it from log lines.
+    the graceful stop was delivered, whether the tree had already exited on
+    its own, whether escalation to a force-kill was required, and whether
+    the tree is verified gone.  A verifier reconstructing a failure window
+    can prove offline which reap path ran instead of inferring it from log
+    lines.
+
+    ``delivered`` records what was handed to the OS; ``confirmed_dead``
+    records the guarantee.  They differ whenever a tree exits before the
+    reap reaches it, which is a routine outcome and not a failure.
 
     Args:
         chain: The audit chain store accepting the entry.
@@ -4600,6 +4608,10 @@ def record_process_reap_receipt(
         reason: Why the reap ran (e.g. ``"kill_requested"``,
             ``"heartbeat_stale"``, ``"wall_clock_timeout"``).
         actor: Recorded actor; defaults to ``"spawner"``.
+        already_gone: Whether the tree had already exited before any stop
+            tier ran.
+        confirmed_dead: Whether the tree is verified to no longer be running
+            once the reap returned.
 
     Returns:
         The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded
@@ -4619,6 +4631,8 @@ def record_process_reap_receipt(
             "escalated": escalated,
             "grace_seconds": grace_seconds,
             "reason": reason,
+            "already_gone": already_gone,
+            "confirmed_dead": confirmed_dead,
         },
     )
 

--- a/tests/integration/test_adapter_conformance_lifecycle.py
+++ b/tests/integration/test_adapter_conformance_lifecycle.py
@@ -29,7 +29,11 @@ from bernstein.core.models import ModelConfig
 from bernstein.adapters.claude import ClaudeCodeAdapter
 from bernstein.adapters.codex import CodexAdapter
 from bernstein.adapters.gemini import GeminiAdapter
-from bernstein.core.config.platform_compat import process_alive, reap_process_group
+from bernstein.core.config.platform_compat import (
+    IS_WINDOWS,
+    process_alive,
+    reap_process_group,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -102,14 +106,26 @@ def test_adapter_stop_terminates_a_hung_spawn(
     """A hung spawn is stopped through the platform process-tree reap.
 
     The guarantee under test is "the hung spawn is no longer running after
-    stop", not "a stop signal was accepted".  Those are different outcomes:
-    a tree that exits between the spawn and the reap accepts no signal, so
-    ``receipt.delivered`` is False while the guarantee holds perfectly.
-    Windows recycles pids fast enough for that race to be routine on a busy
-    runner, so asserting the raw ``delivered`` flag failed the suite for a
-    spawn that was, in fact, correctly not running.  Assert the guarantee
-    the receipt now reports (``confirmed_dead``) and confirm it
-    independently against the process itself.
+    stop", not "a stop signal was accepted", so it is checked against the
+    process itself rather than against the receipt that would otherwise be
+    marking its own homework.
+
+    The Windows lane used to fail here on ``assert receipt.delivered``.  The
+    cause was not an already-exited spawn: the old Windows stop returned
+    True for a pid nothing held, because its fallback ended in a liveness
+    re-probe that a missing pid satisfied.  It returned False only when the
+    target was still *observed running* after the force kill, which is what
+    an immediate liveness probe does when raced against an asynchronous
+    ``TerminateProcess``.  The reap now terminates through a handle it
+    already holds and waits on that handle, so the outcome is decided by
+    evidence rather than by timing.
+
+    The receipt assertions below are deliberately limited to what each
+    platform can establish.  Windows can observe the exit directly, so the
+    receipt must say so.  POSIX cannot: an unreaped group answers EPERM on
+    macOS and answers successfully on Linux (both measured), and neither
+    reply separates "exited but unreaped" from "running", so the reap
+    records the stop it delivered and confirms nothing.
     """
     adapter_cls, model = _ADAPTERS[adapter_name]
     workdir = _git_workdir(tmp_path)
@@ -123,19 +139,25 @@ def test_adapter_stop_terminates_a_hung_spawn(
     pid = int(getattr(result, "pid", 0))
     assert pid > 0
     receipt = reap_process_group(pid, grace_seconds=3.0)
-    # Either a stop was delivered, or the tree was already gone - never a
-    # silent "we could not stop it and left it running".
-    assert receipt.confirmed_dead, f"reap left the spawn unconfirmed: {receipt}"
-    assert receipt.delivered or receipt.already_gone, f"reap reported neither a stop nor an exit: {receipt}"
-    # And the worker really is gone, checked against the process itself
-    # rather than against the receipt that just claimed it.
+
+    # The guarantee, established against the process rather than the receipt.
     proc = getattr(result, "proc", None)
     if proc is not None and hasattr(proc, "wait"):
         with contextlib.suppress(subprocess.TimeoutExpired):
             proc.wait(timeout=8.0)
-        assert proc.poll() is not None, "worker still alive after platform reap"
+        stopped = proc.poll() is not None
     else:
-        assert not process_alive(pid), "worker still alive after platform reap"
+        stopped = not process_alive(pid)
+    assert stopped, f"worker still alive after platform reap: {receipt}"
+
+    # Either a stop was delivered, or the tree was observed already gone.
+    # A receipt claiming neither means the reap declined to act and said so,
+    # which is honest but is not a reap.
+    assert receipt.delivered or receipt.already_gone, f"reap reported neither a stop nor an observed exit: {receipt}"
+    if IS_WINDOWS:
+        # The pinned handle leaves the system when the process does, so on
+        # this platform the guarantee is observable and must be reported.
+        assert receipt.confirmed_dead, f"reap left the spawn unconfirmed: {receipt}"
     with contextlib.suppress(Exception):
         adapter_cls.cancel_timeout(result)
 

--- a/tests/integration/test_adapter_conformance_lifecycle.py
+++ b/tests/integration/test_adapter_conformance_lifecycle.py
@@ -99,7 +99,18 @@ def test_adapter_stop_terminates_a_hung_spawn(
     tmp_path: Path,
     fake_cli_fixture: FakeCLIHandle,
 ) -> None:
-    """A hung spawn is stopped through the platform process-tree reap."""
+    """A hung spawn is stopped through the platform process-tree reap.
+
+    The guarantee under test is "the hung spawn is no longer running after
+    stop", not "a stop signal was accepted".  Those are different outcomes:
+    a tree that exits between the spawn and the reap accepts no signal, so
+    ``receipt.delivered`` is False while the guarantee holds perfectly.
+    Windows recycles pids fast enough for that race to be routine on a busy
+    runner, so asserting the raw ``delivered`` flag failed the suite for a
+    spawn that was, in fact, correctly not running.  Assert the guarantee
+    the receipt now reports (``confirmed_dead``) and confirm it
+    independently against the process itself.
+    """
     adapter_cls, model = _ADAPTERS[adapter_name]
     workdir = _git_workdir(tmp_path)
     fake_cli_fixture.configure(mode="hang")
@@ -112,8 +123,12 @@ def test_adapter_stop_terminates_a_hung_spawn(
     pid = int(getattr(result, "pid", 0))
     assert pid > 0
     receipt = reap_process_group(pid, grace_seconds=3.0)
-    assert receipt.delivered
-    # The worker must actually be gone after the reap.
+    # Either a stop was delivered, or the tree was already gone - never a
+    # silent "we could not stop it and left it running".
+    assert receipt.confirmed_dead, f"reap left the spawn unconfirmed: {receipt}"
+    assert receipt.delivered or receipt.already_gone, f"reap reported neither a stop nor an exit: {receipt}"
+    # And the worker really is gone, checked against the process itself
+    # rather than against the receipt that just claimed it.
     proc = getattr(result, "proc", None)
     if proc is not None and hasattr(proc, "wait"):
         with contextlib.suppress(subprocess.TimeoutExpired):

--- a/tests/unit/test_audit_chain_process_reap.py
+++ b/tests/unit/test_audit_chain_process_reap.py
@@ -108,6 +108,40 @@ def test_spawner_emit_helper_writes_receipt(tmp_path: Path) -> None:
     assert rows[0].details["escalated"] is True
 
 
+def test_spawner_emit_helper_carries_the_guarantee_fields(tmp_path: Path) -> None:
+    """An already-exited tree is auditable as a success, not a failed stop.
+
+    ``delivered`` records what was handed to the OS and ``confirmed_dead``
+    records the guarantee; an operator reconstructing a failure window needs
+    both, because a tree that exited before the reap reached it accepts no
+    stop while still leaving nothing running.
+    """
+    from bernstein.core.platform_compat import ProcessReapReceipt
+
+    from bernstein.core.agents.spawner_core import emit_process_reap_receipt
+
+    (tmp_path / ".sdd").mkdir()
+    receipt = ProcessReapReceipt(
+        pgid=888,
+        os_name="windows",
+        method="windows_process_tree",
+        delivered=False,
+        escalated=False,
+        grace_seconds=3.0,
+        already_gone=True,
+        confirmed_dead=True,
+    )
+    emit_process_reap_receipt(tmp_path, "sess-9", receipt, reason="kill_requested")
+
+    chain = AuditChainStore(tmp_path / ".sdd" / "audit")
+    details = chain.query(event_type=EVENT_PROCESS_REAP_RECEIPT)[0].details
+    assert details["delivered"] is False
+    assert details["already_gone"] is True
+    assert details["confirmed_dead"] is True
+    ok, errors = chain.verify()
+    assert ok, errors
+
+
 def test_spawner_emit_helper_never_raises(tmp_path: Path) -> None:
     """Audit mirroring must never mask the kill itself."""
     from unittest.mock import patch

--- a/tests/unit/test_platform_process_tree.py
+++ b/tests/unit/test_platform_process_tree.py
@@ -145,6 +145,11 @@ class TestReapProcessGroup:
         POSIX reap targets a process *group*, and the kernel does not recycle
         a group id while the group still has members, so the guard has
         nothing to add and must not perturb the syscall sequence.
+
+        Only signals that can affect the group are pinned.  Signal 0 sends
+        nothing, so the confirmation probe after the force tier is free to
+        exist; a fourth *delivering* signal, or one aimed anywhere but the
+        group, is what a regression looks like.
         """
         if IS_WINDOWS:
             pytest.skip("POSIX sequence")
@@ -156,17 +161,74 @@ class TestReapProcessGroup:
         with patch(f"{_PC}.os.killpg", side_effect=_killpg):
             receipt = reap_process_group(4321, grace_seconds=0.05, poll_interval=0.01)
 
+        delivering = [(pgid, sig) for pgid, sig in sent if sig != 0]
         # TERM first, liveness probes with signal 0 in between, KILL last.
         assert sent[0] == (4321, signal.SIGTERM)
-        assert sent[-1] == (4321, signal.SIGKILL)
+        assert delivering == [(4321, signal.SIGTERM), (4321, signal.SIGKILL)]
         assert {sig for _pgid, sig in sent} == {signal.SIGTERM, signal.SIGKILL, 0}
         assert {pgid for pgid, _sig in sent} == {4321}
         assert receipt.method == "posix_process_group"
         assert receipt.delivered is True
         assert receipt.escalated is True
-        # SIGKILL cannot be caught, so a delivered force kill is the
-        # confirmation; re-probing is not, because killpg keeps succeeding
-        # for a group whose members are unreaped zombies.
+        # The mocked killpg answers every probe, so the group was never
+        # observed to go away.  A delivered SIGKILL guarantees it will, but
+        # that is a guarantee about the future, not an observation, so the
+        # receipt reports the escalation and confirms nothing.
+        assert receipt.confirmed_dead is False
+
+    def test_unsignalable_group_is_never_reported_confirmed_dead(self) -> None:
+        """F4 regression: EPERM means alive, in confirmation as well as escalation.
+
+        ``process_group_alive`` maps EPERM to "alive" because a member
+        exists we may not signal.  The confirmation probe has to agree: a
+        group that refuses our SIGKILL with EPERM is the one case where the
+        force tier provably did *not* land, so certifying it dead is the
+        worst available answer.  Fails if the confirmation probe treats any
+        OSError as an exit.
+
+        Measured errno behaviour that rules out the cheaper reading: on
+        macOS an unreaped group of exited processes also answers EPERM, and
+        on Linux it answers success, so neither reply distinguishes "exited
+        but unreaped" from "running and out of reach".
+        """
+        if IS_WINDOWS:
+            pytest.skip("POSIX semantics")
+        attempted: list[int] = []
+
+        def _killpg(_pgid: int, sig: int) -> None:
+            attempted.append(sig)
+            if sig == signal.SIGTERM:
+                return  # the group accepted TERM
+            raise PermissionError(1, "Operation not permitted")
+
+        with patch(f"{_PC}.os.killpg", side_effect=_killpg):
+            receipt = reap_process_group(4321, grace_seconds=0.05, poll_interval=0.01)
+
+        assert signal.SIGKILL in attempted or 9 in attempted
+        assert receipt.delivered is True
+        assert receipt.escalated is True
+        # The group refused the force kill and is still there.
+        assert receipt.confirmed_dead is False
+        assert receipt.already_gone is False
+
+    def test_vanished_group_is_confirmed_dead(self) -> None:
+        """The other half of F4: ESRCH is a real observation and still counts.
+
+        Guards against over-correcting into a receipt that can never
+        confirm anything.
+        """
+        if IS_WINDOWS:
+            pytest.skip("POSIX semantics")
+
+        def _killpg(_pgid: int, sig: int) -> None:
+            if sig == signal.SIGTERM:
+                return
+            raise ProcessLookupError(3, "No such process")
+
+        with patch(f"{_PC}.os.killpg", side_effect=_killpg):
+            receipt = reap_process_group(4321, grace_seconds=0.05, poll_interval=0.01)
+
+        assert receipt.delivered is True
         assert receipt.confirmed_dead is True
 
     def test_posix_already_exited_group_reports_the_guarantee(self) -> None:

--- a/tests/unit/test_platform_process_tree.py
+++ b/tests/unit/test_platform_process_tree.py
@@ -138,6 +138,48 @@ class TestReapProcessGroup:
         forced = [c for c in mock_killpg.call_args_list if c.args[1] in (signal.SIGKILL, 9)]
         assert forced, "expected a SIGKILL escalation delivered to the surviving group"
 
+    def test_posix_reap_signal_sequence_is_unchanged(self) -> None:
+        """POSIX still reaps with exactly TERM -> poll -> KILL on the group.
+
+        The pid-reuse pin the Windows reap needs must stay inert here: a
+        POSIX reap targets a process *group*, and the kernel does not recycle
+        a group id while the group still has members, so the guard has
+        nothing to add and must not perturb the syscall sequence.
+        """
+        if IS_WINDOWS:
+            pytest.skip("POSIX sequence")
+        sent: list[tuple[int, int]] = []
+
+        def _killpg(pgid: int, sig: int) -> None:
+            sent.append((pgid, sig))
+
+        with patch(f"{_PC}.os.killpg", side_effect=_killpg):
+            receipt = reap_process_group(4321, grace_seconds=0.05, poll_interval=0.01)
+
+        # TERM first, liveness probes with signal 0 in between, KILL last.
+        assert sent[0] == (4321, signal.SIGTERM)
+        assert sent[-1] == (4321, signal.SIGKILL)
+        assert {sig for _pgid, sig in sent} == {signal.SIGTERM, signal.SIGKILL, 0}
+        assert {pgid for pgid, _sig in sent} == {4321}
+        assert receipt.method == "posix_process_group"
+        assert receipt.delivered is True
+        assert receipt.escalated is True
+        # SIGKILL cannot be caught, so a delivered force kill is the
+        # confirmation; re-probing is not, because killpg keeps succeeding
+        # for a group whose members are unreaped zombies.
+        assert receipt.confirmed_dead is True
+
+    def test_posix_already_exited_group_reports_the_guarantee(self) -> None:
+        """A group that is simply gone is a confirmed reap, not a failure."""
+        if IS_WINDOWS:
+            pytest.skip("POSIX semantics")
+        with patch(f"{_PC}.os.killpg", side_effect=ProcessLookupError):
+            receipt = reap_process_group(4321, grace_seconds=0.05, poll_interval=0.01)
+        assert receipt.delivered is False
+        assert receipt.escalated is False
+        assert receipt.already_gone is True
+        assert receipt.confirmed_dead is True
+
     def test_receipt_details_projection(self) -> None:
         """to_details() is a deterministic dict projection of the receipt."""
         receipt = ProcessReapReceipt(
@@ -156,6 +198,8 @@ class TestReapProcessGroup:
             "delivered": True,
             "escalated": False,
             "grace_seconds": 3.0,
+            "already_gone": False,
+            "confirmed_dead": False,
         }
         # Frozen dataclass: two identical receipts project identically.
         assert (

--- a/tests/unit/test_platform_win_process_branch.py
+++ b/tests/unit/test_platform_win_process_branch.py
@@ -16,14 +16,23 @@ confirmed_dead)``. On Windows the force tier must fall back to the numeric
 what a Windows regression looks like, so we pin it here rather than only on
 a Windows host.
 
-Two properties get dedicated coverage because Windows recycles pids fast
-enough for both to matter in practice:
+Three properties get dedicated coverage because Windows recycles pids fast
+enough for all of them to matter in practice:
 
-* a target that had already exited is a *satisfied* reap, not a failed one
-  - nothing is left running, which is the whole point of the call, and
+* a target that was *observed* to have already exited is a satisfied reap,
+  not a failed one - nothing is left running, which is the whole point of
+  the call;
 * no stop tier may ever act on a pid that might have been recycled into an
   unrelated process, so the reap pins the target with an open handle and
-  refuses a process that started after the reap was requested.
+  refuses a process that started after the reap was requested; and
+* "could not observe" is a third answer, never folded into either of the
+  first two.  ``OpenProcess`` refuses a pid nothing holds and a pid held by
+  a process this user may not touch with different error codes, a handle
+  can be open and still decline to report an exit code, and a mismatched
+  creation time says the number is not the target rather than that the
+  target is gone.  Each of those leaves both ``already_gone`` and
+  ``confirmed_dead`` False: the receipt is signed into the audit chain, so
+  an absence of evidence must not serialise as evidence of absence.
 """
 
 from __future__ import annotations
@@ -156,6 +165,14 @@ class _PinKernel32:
     after the process exits, ``TerminateProcess`` flips it to exited, and
     ``WaitForSingleObject`` reports exited/timed-out rather than a raw
     liveness poll.
+
+    ``exists`` and ``openable`` are separate knobs because the two failures
+    they model are separate findings.  A pid nothing holds fails
+    ``OpenProcess`` with ``ERROR_INVALID_PARAMETER`` and is evidence of an
+    exit.  A pid held by a process this user may not touch fails with
+    ``ERROR_ACCESS_DENIED`` and is evidence of a *live* process we cannot
+    follow.  A world model that returns a bare 0 for both cannot tell them
+    apart, and neither can code written against it.
     """
 
     def __init__(
@@ -178,14 +195,23 @@ class _PinKernel32:
         self.terminated: list[int] = []
         self.closed: list[int] = []
         self.waits: list[tuple[int, int]] = []
+        self.last_error = 0
 
     _HANDLE = 4242
 
     def OpenProcess(self, access: int, _inherit: bool, pid: int) -> int:
         self.opened.append((access, pid))
-        if pid != self.pid or not self.exists or not self.openable:
+        if pid != self.pid or not self.exists:
+            self.last_error = 87  # ERROR_INVALID_PARAMETER: no such pid
             return 0
+        if not self.openable:
+            self.last_error = 5  # ERROR_ACCESS_DENIED: live, but not ours
+            return 0
+        self.last_error = 0
         return self._HANDLE
+
+    def GetLastError(self) -> int:
+        return self.last_error
 
     def GetExitCodeProcess(self, _handle: int, ptr: Any) -> int:
         ptr._obj.value = 259 if self.running else 0
@@ -350,8 +376,15 @@ class TestWinTaskkill:
         assert pc._win_taskkill(123, force=True, tree=True) is True
         assert [c[0] for c in cmds] == ["taskkill"]
 
-    def test_unreadable_handle_state_is_not_alive(self, monkeypatch: Any) -> None:
-        """A handle that will not answer is never reported as running."""
+    def test_unreadable_handle_state_is_not_an_exit(self, monkeypatch: Any) -> None:
+        """A handle that will not answer is neither running nor gone.
+
+        Refusing to signal an unreadable target is right.  Recording it as
+        an observed exit is not: nothing looked at the process, so the
+        receipt has nothing to certify.  ``_win_handle_alive`` collapses the
+        unreadable case into "not alive" for callers that only need to stop
+        waiting, so the pin must read the tri-state directly.
+        """
 
         class _Mute(_PinKernel32):
             def GetExitCodeProcess(self, _handle: int, _ptr: Any) -> int:
@@ -362,13 +395,94 @@ class TestWinTaskkill:
 
         fake = _Mute()
         _install_kernel32(monkeypatch, fake)
+        assert pc._win_handle_liveness(_PinKernel32._HANDLE) is None
         assert pc._win_handle_alive(_PinKernel32._HANDLE) is False
         assert pc._win_handle_start_time(_PinKernel32._HANDLE) is None
-        # Unreadable liveness means "already gone" - the conservative
-        # direction, because the reap then signals nothing.
+
         pin = pc._win_pin_process(123)
         assert pin is not None
-        assert pin.already_gone is True
+        assert pin.target_state == pc._PIN_TARGET_UNOBSERVABLE
+        assert pin.already_gone is False
+        assert pin.signalable is False
+        assert pin.observed_exited() is False
+
+    def test_unreadable_handle_state_claims_nothing_in_the_receipt(self, monkeypatch: Any) -> None:
+        """F2 regression: an unreadable handle must not certify a death.
+
+        Fails if ``already_gone`` is ever derived from "the handle would not
+        answer", which is what made an unobserved process serialise into the
+        audit chain as confirmed dead.
+        """
+
+        class _Mute(_PinKernel32):
+            def GetExitCodeProcess(self, _handle: int, _ptr: Any) -> int:
+                return 0
+
+        fake = _Mute(pid=999, running=True)
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc, "_detect_os_name", lambda: "windows")
+        _install_kernel32(monkeypatch, fake)
+        monkeypatch.setattr(
+            pc,
+            "kill_process_group",
+            lambda pgid, sig=signal.SIGTERM: (_ for _ in ()).throw(
+                AssertionError("signalled a target nobody could observe")
+            ),
+        )
+
+        receipt = pc.reap_process_group(999, grace_seconds=0.05, poll_interval=0.01)
+
+        assert receipt.already_gone is False
+        assert receipt.confirmed_dead is False
+        assert receipt.delivered is False
+        assert fake.terminated == []
+        assert fake.running is True
+
+    def test_access_denied_live_process_is_not_reported_gone(self, monkeypatch: Any) -> None:
+        """F1 regression: ERROR_ACCESS_DENIED is a live process, not an exit.
+
+        ``OpenProcess`` refuses both for a pid nothing holds and for a pid
+        held by a process this user may not touch.  Only the first is an
+        exit.  Fails if the two refusals are collapsed back into one
+        "already gone" answer.
+        """
+        fake = _PinKernel32(pid=999, running=True, openable=False)
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc, "_detect_os_name", lambda: "windows")
+        _install_kernel32(monkeypatch, fake)
+        monkeypatch.setattr(
+            pc,
+            "kill_process_group",
+            lambda pgid, sig=signal.SIGTERM: (_ for _ in ()).throw(
+                AssertionError("signalled a pid we were refused access to")
+            ),
+        )
+
+        receipt = pc.reap_process_group(999, grace_seconds=0.05, poll_interval=0.01)
+
+        # Refused access: not signalled, and nothing claimed about it.
+        assert receipt.already_gone is False
+        assert receipt.confirmed_dead is False
+        assert receipt.delivered is False
+        assert fake.running is True
+
+    def test_absent_pid_is_still_reported_gone(self, monkeypatch: Any) -> None:
+        """The other half of F1: a pid nothing holds *is* an observed exit.
+
+        Guards the fix against over-correction - if every refusal became
+        "unobservable", the already-exited case this PR exists to report
+        would stop being reported.
+        """
+        fake = _PinKernel32(pid=999, exists=False)
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc, "_detect_os_name", lambda: "windows")
+        _install_kernel32(monkeypatch, fake)
+
+        receipt = pc.reap_process_group(999, grace_seconds=0.05, poll_interval=0.01)
+
+        assert receipt.already_gone is True
+        assert receipt.confirmed_dead is True
+        assert receipt.delivered is False
 
 
 class TestWinPidReuseGuard:
@@ -383,10 +497,42 @@ class TestWinPidReuseGuard:
         pin = pc._win_pin_process(123)
 
         assert pin is not None
-        assert pin.already_gone is True
+        assert pin.signalable is False
+        # "That is not the process you asked about" is not "the process you
+        # asked about has exited".  The target's state was never observed.
+        assert pin.already_gone is False
+        assert pin.target_state == pc._PIN_TARGET_UNOBSERVABLE
         # The impostor's handle was released and never terminated.
         assert fake.terminated == []
         assert fake.closed == [_PinKernel32._HANDLE]
+
+    def test_recycled_pid_claims_nothing_in_the_receipt(self, monkeypatch: Any) -> None:
+        """F3 regression: a mismatched identity must not certify a death.
+
+        The same path fires when the wall clock steps backwards between the
+        target's creation and the reap request, so a live process would be
+        certified dead by a clock adjustment alone.  Fails if the recycle
+        guard reports its refusal as an observed exit.
+        """
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc, "_detect_os_name", lambda: "windows")
+        fake = _PinKernel32(pid=999, running=True, start_time=time.time() + 2.0)
+        _install_kernel32(monkeypatch, fake)
+        monkeypatch.setattr(
+            pc,
+            "kill_process_group",
+            lambda pgid, sig=signal.SIGTERM: (_ for _ in ()).throw(
+                AssertionError("signalled a pid whose identity did not match")
+            ),
+        )
+
+        receipt = pc.reap_process_group(999, grace_seconds=0.05, poll_interval=0.01)
+
+        assert receipt.already_gone is False
+        assert receipt.confirmed_dead is False
+        assert receipt.delivered is False
+        assert fake.terminated == []
+        assert fake.running is True
 
     def test_recycled_pid_is_not_handed_to_taskkill(self, monkeypatch: Any) -> None:
         fake = _PinKernel32(start_time=time.time() + 60.0)

--- a/tests/unit/test_platform_win_process_branch.py
+++ b/tests/unit/test_platform_win_process_branch.py
@@ -9,11 +9,21 @@ Windows runner.
 
 The reap-receipt cases assert the *verifiable artifact* itself: the
 :class:`ProcessReapReceipt` is a deterministic projection of the platform
-onto ``(os_name, method, delivered, escalated)``. On Windows the force
-tier must fall back to the numeric ``9`` code because ``SIGKILL`` does not
-exist, and the receipt must record ``windows_process_tree`` as the
-mechanism. Stripping that projection is what a Windows regression looks
-like, so we pin it here rather than only on a Windows host.
+onto ``(os_name, method, delivered, already_gone, escalated,
+confirmed_dead)``. On Windows the force tier must fall back to the numeric
+``9`` code because ``SIGKILL`` does not exist, and the receipt must record
+``windows_process_tree`` as the mechanism. Stripping that projection is
+what a Windows regression looks like, so we pin it here rather than only on
+a Windows host.
+
+Two properties get dedicated coverage because Windows recycles pids fast
+enough for both to matter in practice:
+
+* a target that had already exited is a *satisfied* reap, not a failed one
+  - nothing is left running, which is the whole point of the call, and
+* no stop tier may ever act on a pid that might have been recycled into an
+  unrelated process, so the reap pins the target with an open handle and
+  refuses a process that started after the reap was requested.
 """
 
 from __future__ import annotations
@@ -21,6 +31,7 @@ from __future__ import annotations
 import ctypes
 import signal
 import subprocess
+import time
 from typing import Any
 
 import bernstein.core.config.platform_compat as pc
@@ -126,7 +137,7 @@ class TestKillProcessGroupWindowsBranch:
 
 
 # ---------------------------------------------------------------------------
-# _win_taskkill - taskkill primary path + PowerShell fallback
+# _win_taskkill - taskkill tree stop + pinned-handle terminate fallback
 # ---------------------------------------------------------------------------
 
 
@@ -137,64 +148,224 @@ class _Result:
         self.stderr = ""
 
 
+class _PinKernel32:
+    """kernel32 stand-in with a one-process world model.
+
+    Models the handle semantics the reap pin depends on: ``OpenProcess``
+    only resolves a pid the world knows about, the handle keeps answering
+    after the process exits, ``TerminateProcess`` flips it to exited, and
+    ``WaitForSingleObject`` reports exited/timed-out rather than a raw
+    liveness poll.
+    """
+
+    def __init__(
+        self,
+        *,
+        pid: int = 123,
+        exists: bool = True,
+        running: bool = True,
+        start_time: float = 0.0,
+        openable: bool = True,
+        terminable: bool = True,
+    ) -> None:
+        self.pid = pid
+        self.exists = exists
+        self.running = running
+        self.start_time = start_time
+        self.openable = openable
+        self.terminable = terminable
+        self.opened: list[tuple[int, int]] = []
+        self.terminated: list[int] = []
+        self.closed: list[int] = []
+        self.waits: list[tuple[int, int]] = []
+
+    _HANDLE = 4242
+
+    def OpenProcess(self, access: int, _inherit: bool, pid: int) -> int:
+        self.opened.append((access, pid))
+        if pid != self.pid or not self.exists or not self.openable:
+            return 0
+        return self._HANDLE
+
+    def GetExitCodeProcess(self, _handle: int, ptr: Any) -> int:
+        ptr._obj.value = 259 if self.running else 0
+        return 1
+
+    def GetProcessTimes(self, _handle: int, creation: Any, *_rest: Any) -> int:
+        ticks = int((self.start_time + 11644473600.0) * 10_000_000)
+        creation._obj.dwLowDateTime = ticks & 0xFFFFFFFF
+        creation._obj.dwHighDateTime = ticks >> 32
+        return 1
+
+    def TerminateProcess(self, handle: int, _code: int) -> int:
+        self.terminated.append(handle)
+        if not self.terminable:
+            return 0
+        self.running = False
+        return 1
+
+    def WaitForSingleObject(self, handle: int, timeout_ms: int) -> int:
+        self.waits.append((handle, timeout_ms))
+        return 0 if not self.running else 258  # WAIT_OBJECT_0 / WAIT_TIMEOUT
+
+    def CloseHandle(self, handle: int) -> None:
+        self.closed.append(handle)
+
+
+def _install_kernel32(monkeypatch: Any, fake: _PinKernel32) -> None:
+    monkeypatch.setattr(pc, "_win_kernel32", lambda: fake)
+
+
+def _install_kernel32_everywhere(monkeypatch: Any, fake: _PinKernel32) -> None:
+    """Route both kernel32 entry points at *fake*.
+
+    ``_win_process_alive`` reaches ``ctypes.windll`` directly while the reap
+    pin goes through ``_win_kernel32``; a whole-reap test has to serve both.
+    """
+    _install_kernel32(monkeypatch, fake)
+
+    class _Windll:
+        kernel32 = fake
+
+    monkeypatch.setattr(ctypes, "windll", _Windll(), raising=False)
+
+
 class TestWinTaskkill:
-    """The taskkill primary path and the PowerShell verify-fallback."""
+    """The taskkill tree stop plus the pinned-handle terminate fallback.
+
+    The fallback deliberately does *not* re-resolve the pid. Windows
+    recycles pids fast, and the old PowerShell fallback fired
+    ``Stop-Process -Id <pid> -Force`` precisely in the situation where the
+    pid was most likely to have been recycled (taskkill had just reported it
+    missing), so it could force-kill an unrelated process. Everything below
+    goes through the handle opened before any stop tier ran.
+    """
 
     def test_taskkill_success_skips_fallback(self, monkeypatch: Any) -> None:
+        fake = _PinKernel32()
+        _install_kernel32(monkeypatch, fake)
         cmds: list[list[str]] = []
 
         def _run(cmd: list[str], **_kw: Any) -> _Result:
             cmds.append(cmd)
+            fake.running = False  # taskkill did stop it
             return _Result(0)
 
         monkeypatch.setattr(pc.subprocess, "run", _run)
         assert pc._win_taskkill(123, force=True, tree=True) is True
-        # Exactly one invocation: taskkill, no PowerShell fallback.
+        # Exactly one external invocation: taskkill, no interpreter fallback.
         assert len(cmds) == 1
         assert cmds[0][0] == "taskkill"
         assert "/F" in cmds[0] and "/T" in cmds[0]
         assert cmds[0][-2:] == ["/PID", "123"]
+        assert fake.terminated == []
+        assert fake.closed == [_PinKernel32._HANDLE]
 
-    def test_taskkill_failure_triggers_powershell_verify(self, monkeypatch: Any) -> None:
+    def test_taskkill_failure_terminates_through_the_pinned_handle(self, monkeypatch: Any) -> None:
+        fake = _PinKernel32()
+        _install_kernel32(monkeypatch, fake)
         cmds: list[list[str]] = []
 
         def _run(cmd: list[str], **_kw: Any) -> _Result:
             cmds.append(cmd)
-            return _Result(1)  # taskkill and powershell both "ran"
+            return _Result(1)  # taskkill refuses (console process, no /F)
 
         monkeypatch.setattr(pc.subprocess, "run", _run)
-        # After the fallback, liveness says the process is gone -> success.
-        monkeypatch.setattr(pc, "_win_process_alive", lambda pid: False)
         assert pc._win_taskkill(123) is True
-        assert [c[0] for c in cmds] == ["taskkill", "powershell"]
+        # Only taskkill is ever spawned; the fallback is an in-process
+        # kernel call on the handle, not a second command line naming the pid.
+        assert [c[0] for c in cmds] == ["taskkill"]
+        assert fake.terminated == [_PinKernel32._HANDLE]
 
-    def test_powershell_fallback_still_alive_returns_false(self, monkeypatch: Any) -> None:
+    def test_unterminable_target_returns_false(self, monkeypatch: Any) -> None:
+        fake = _PinKernel32(terminable=False)
+        _install_kernel32(monkeypatch, fake)
         monkeypatch.setattr(pc.subprocess, "run", lambda cmd, **_kw: _Result(1))
-        monkeypatch.setattr(pc, "_win_process_alive", lambda pid: True)
         assert pc._win_taskkill(123) is False
 
-    def test_taskkill_timeout_falls_through_to_powershell(self, monkeypatch: Any) -> None:
-        cmds: list[list[str]] = []
+    def test_taskkill_timeout_falls_through_to_the_handle(self, monkeypatch: Any) -> None:
+        fake = _PinKernel32()
+        _install_kernel32(monkeypatch, fake)
 
         def _run(cmd: list[str], **_kw: Any) -> _Result:
-            cmds.append(cmd)
-            if cmd[0] == "taskkill":
-                raise subprocess.TimeoutExpired(cmd, 5)
-            return _Result(0)
+            raise subprocess.TimeoutExpired(cmd, 5)
 
         monkeypatch.setattr(pc.subprocess, "run", _run)
-        monkeypatch.setattr(pc, "_win_process_alive", lambda pid: False)
         assert pc._win_taskkill(123) is True
-        assert [c[0] for c in cmds] == ["taskkill", "powershell"]
+        assert fake.terminated == [_PinKernel32._HANDLE]
 
-    def test_powershell_oserror_returns_false(self, monkeypatch: Any) -> None:
+    def test_already_exited_target_is_never_signalled(self, monkeypatch: Any) -> None:
+        """An exited pid gets no taskkill and no terminate - only a report."""
+        fake = _PinKernel32(running=False)
+        _install_kernel32(monkeypatch, fake)
+
         def _run(cmd: list[str], **_kw: Any) -> _Result:
-            if cmd[0] == "taskkill":
-                return _Result(1)
-            raise OSError("powershell missing")
+            raise AssertionError("stopped an already-exited process")
 
         monkeypatch.setattr(pc.subprocess, "run", _run)
         assert pc._win_taskkill(123) is False
+        assert fake.terminated == []
+
+    def test_unknown_pid_is_never_signalled(self, monkeypatch: Any) -> None:
+        """A pid that resolves to nothing must not be handed to taskkill."""
+        fake = _PinKernel32(exists=False)
+        _install_kernel32(monkeypatch, fake)
+
+        def _run(cmd: list[str], **_kw: Any) -> _Result:
+            raise AssertionError("stopped a pid that resolves to no process")
+
+        monkeypatch.setattr(pc.subprocess, "run", _run)
+        assert pc._win_taskkill(123) is False
+
+
+class TestWinPidReuseGuard:
+    """The pin refuses to act on a pid that was recycled under it."""
+
+    def test_process_started_after_the_request_is_not_the_target(self, monkeypatch: Any) -> None:
+        # Creation time in the future relative to the reap request: this
+        # process cannot be the one the caller asked us to stop.
+        fake = _PinKernel32(start_time=time.time() + 60.0)
+        _install_kernel32(monkeypatch, fake)
+
+        pin = pc._win_pin_process(123)
+
+        assert pin is not None
+        assert pin.already_gone is True
+        # The impostor's handle was released and never terminated.
+        assert fake.terminated == []
+        assert fake.closed == [_PinKernel32._HANDLE]
+
+    def test_recycled_pid_is_not_handed_to_taskkill(self, monkeypatch: Any) -> None:
+        fake = _PinKernel32(start_time=time.time() + 60.0)
+        _install_kernel32(monkeypatch, fake)
+
+        def _run(cmd: list[str], **_kw: Any) -> _Result:
+            raise AssertionError("signalled a recycled pid")
+
+        monkeypatch.setattr(pc.subprocess, "run", _run)
+        assert pc._win_taskkill(123, force=True, tree=True) is False
+
+    def test_established_pin_keeps_the_handle_open_for_the_whole_reap(self, monkeypatch: Any) -> None:
+        """The open handle is what stops Windows recycling the pid mid-reap."""
+        fake = _PinKernel32(start_time=time.time() - 60.0)
+        _install_kernel32(monkeypatch, fake)
+
+        pin = pc._win_pin_process(123)
+
+        assert pin is not None
+        assert pin.already_gone is False
+        assert fake.closed == []  # still pinned
+        pin.close()
+        assert fake.closed == [_PinKernel32._HANDLE]
+
+    def test_unavailable_kernel_boundary_claims_nothing(self, monkeypatch: Any) -> None:
+        """No kernel32 means "guard unavailable", never "target gone"."""
+
+        def _boom() -> Any:
+            raise AttributeError("no windll on this host")
+
+        monkeypatch.setattr(pc, "_win_kernel32", _boom)
+        assert pc._win_pin_process(123) is None
 
 
 # ---------------------------------------------------------------------------
@@ -323,14 +494,11 @@ class TestReapReceiptWindowsProjection:
         assert sigs[-1] == 9
 
     def test_undeliverable_term_projects_not_delivered(self, monkeypatch: Any) -> None:
+        """An undeliverable stop against a *running* target is a failure."""
         monkeypatch.setattr(pc, "IS_WINDOWS", True)
         monkeypatch.setattr(pc, "_detect_os_name", lambda: "windows")
         monkeypatch.setattr(pc, "kill_process_group", lambda pgid, sig=signal.SIGTERM: False)
-        monkeypatch.setattr(
-            pc,
-            "process_alive",
-            lambda pid: (_ for _ in ()).throw(AssertionError("polled")),
-        )
+        monkeypatch.setattr(pc, "process_alive", lambda pid: True)
 
         receipt = pc.reap_process_group(999, grace_seconds=0.05, poll_interval=0.01)
 
@@ -338,3 +506,95 @@ class TestReapReceiptWindowsProjection:
         assert receipt.method == "windows_process_tree"
         assert receipt.delivered is False
         assert receipt.escalated is False
+        # Still running and we could not stop it: no guarantee to report.
+        assert receipt.confirmed_dead is False
+        assert receipt.already_gone is False
+
+    def test_undeliverable_term_against_an_exited_target_is_success(self, monkeypatch: Any) -> None:
+        """An already-exited tree satisfies the guarantee the reap exists for.
+
+        This is the case that turned a green Windows lane red: the spawn had
+        already exited, so no stop could be delivered to it, and the receipt
+        reported that as a failed reap. "Nothing left to stop" is the
+        outcome the caller wanted, not a failure to produce it.
+        """
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc, "_detect_os_name", lambda: "windows")
+        monkeypatch.setattr(pc, "kill_process_group", lambda pgid, sig=signal.SIGTERM: False)
+        monkeypatch.setattr(pc, "process_alive", lambda pid: False)
+
+        receipt = pc.reap_process_group(999, grace_seconds=0.05, poll_interval=0.01)
+
+        assert receipt.delivered is False
+        assert receipt.escalated is False
+        assert receipt.already_gone is True
+        assert receipt.confirmed_dead is True
+
+    def test_pinned_exited_target_skips_every_stop_tier(self, monkeypatch: Any) -> None:
+        """A pin that reports the target gone stops the reap before it signals."""
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc, "_detect_os_name", lambda: "windows")
+        fake = _PinKernel32(pid=999, running=False)
+        _install_kernel32(monkeypatch, fake)
+        monkeypatch.setattr(
+            pc,
+            "kill_process_group",
+            lambda pgid, sig=signal.SIGTERM: (_ for _ in ()).throw(AssertionError("signalled")),
+        )
+
+        receipt = pc.reap_process_group(999, grace_seconds=0.05, poll_interval=0.01)
+
+        assert receipt.already_gone is True
+        assert receipt.confirmed_dead is True
+        assert receipt.delivered is False
+        assert fake.terminated == []
+        # The pin is always released, even on the early-return path.
+        assert fake.closed == [_PinKernel32._HANDLE]
+
+    def test_hung_console_spawn_is_reaped_and_confirmed(self, monkeypatch: Any) -> None:
+        """Whole-reap replay of the Windows conformance case.
+
+        A hung console process is what the adapter conformance suite spawns.
+        ``taskkill`` without ``/F`` refuses to stop a console process, which
+        used to drop the reap into a fallback that shelled out to
+        ``Stop-Process -Id <pid> -Force`` and then raced an immediate
+        liveness probe against an asynchronous termination. The reap now
+        terminates through the handle it already holds and waits on that
+        handle, so the outcome is decided by evidence rather than timing.
+        """
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc, "_detect_os_name", lambda: "windows")
+        fake = _PinKernel32(pid=6300, start_time=time.time() - 30.0)
+        _install_kernel32_everywhere(monkeypatch, fake)
+        cmds: list[list[str]] = []
+
+        def _run(cmd: list[str], **_kw: Any) -> _Result:
+            cmds.append(cmd)
+            # "This process can only be terminated forcefully (with /F)".
+            return _Result(1)
+
+        monkeypatch.setattr(pc.subprocess, "run", _run)
+
+        receipt = pc.reap_process_group(6300, grace_seconds=0.05, poll_interval=0.01)
+
+        assert receipt.os_name == "windows"
+        assert receipt.method == "windows_process_tree"
+        assert receipt.delivered is True
+        assert receipt.escalated is False
+        assert receipt.confirmed_dead is True
+        assert fake.running is False
+        # Only taskkill was ever spawned - no interpreter was asked to
+        # force-kill the bare pid.
+        assert [c[0] for c in cmds] == ["taskkill"]
+
+    def test_clean_exit_projects_confirmed_dead(self, monkeypatch: Any) -> None:
+        monkeypatch.setattr(pc, "IS_WINDOWS", True)
+        monkeypatch.setattr(pc, "_detect_os_name", lambda: "windows")
+        monkeypatch.setattr(pc, "kill_process_group", lambda pgid, sig=signal.SIGTERM: True)
+        monkeypatch.setattr(pc, "process_alive", lambda pid: False)
+
+        receipt = pc.reap_process_group(999, grace_seconds=0.05, poll_interval=0.01)
+
+        assert receipt.delivered is True
+        assert receipt.confirmed_dead is True
+        assert receipt.already_gone is False

--- a/tests/unit/test_platform_win_process_branch.py
+++ b/tests/unit/test_platform_win_process_branch.py
@@ -317,6 +317,59 @@ class TestWinTaskkill:
         monkeypatch.setattr(pc.subprocess, "run", _run)
         assert pc._win_taskkill(123) is False
 
+    def test_nonpositive_pid_is_never_signalled(self, monkeypatch: Any) -> None:
+        def _run(cmd: list[str], **_kw: Any) -> _Result:
+            raise AssertionError("stopped a non-positive pid")
+
+        monkeypatch.setattr(pc.subprocess, "run", _run)
+        assert pc._win_taskkill(0) is False
+        assert pc._win_taskkill(-1) is False
+
+    def test_taskkill_not_found_falls_back_to_the_handle(self, monkeypatch: Any) -> None:
+        """taskkill 128 means the lead is gone; the handle settles it."""
+        fake = _PinKernel32()
+        _install_kernel32(monkeypatch, fake)
+        monkeypatch.setattr(pc.subprocess, "run", lambda cmd, **_kw: _Result(128))
+        assert pc._win_taskkill(123, tree=True) is True
+        assert fake.terminated == [_PinKernel32._HANDLE]
+
+    def test_without_a_kernel_boundary_only_taskkill_runs(self, monkeypatch: Any) -> None:
+        """No pin means no bare-pid force kill, just the tree stop."""
+
+        def _boom() -> Any:
+            raise AttributeError("no windll on this host")
+
+        monkeypatch.setattr(pc, "_win_kernel32", _boom)
+        cmds: list[list[str]] = []
+
+        def _run(cmd: list[str], **_kw: Any) -> _Result:
+            cmds.append(cmd)
+            return _Result(0)
+
+        monkeypatch.setattr(pc.subprocess, "run", _run)
+        assert pc._win_taskkill(123, force=True, tree=True) is True
+        assert [c[0] for c in cmds] == ["taskkill"]
+
+    def test_unreadable_handle_state_is_not_alive(self, monkeypatch: Any) -> None:
+        """A handle that will not answer is never reported as running."""
+
+        class _Mute(_PinKernel32):
+            def GetExitCodeProcess(self, _handle: int, _ptr: Any) -> int:
+                return 0
+
+            def GetProcessTimes(self, _handle: int, *_rest: Any) -> int:
+                return 0
+
+        fake = _Mute()
+        _install_kernel32(monkeypatch, fake)
+        assert pc._win_handle_alive(_PinKernel32._HANDLE) is False
+        assert pc._win_handle_start_time(_PinKernel32._HANDLE) is None
+        # Unreadable liveness means "already gone" - the conservative
+        # direction, because the reap then signals nothing.
+        pin = pc._win_pin_process(123)
+        assert pin is not None
+        assert pin.already_gone is True
+
 
 class TestWinPidReuseGuard:
     """The pin refuses to act on a pid that was recycled under it."""


### PR DESCRIPTION
## What was red

`Adapter conformance + e2e (windows) (3.13)` is a required job in the ci-gate needs list, so main's gate cannot go green while it fails:

```
tests/integration/test_adapter_conformance_lifecycle.py::test_adapter_stop_terminates_a_hung_spawn[claude]
AssertionError: assert False
  where False = ProcessReapReceipt(pgid=6300, os_name='windows',
                                   method='windows_process_tree', delivered=False, escalated=False)
```

## Why

The reap reported one boolean, `delivered`, and the test read it as "the tree is no longer running". Those are different outcomes. `reap_process_group` bails out at

```python
if not kill_process_group(pgid, signal.SIGTERM):
    return _receipt(delivered=False, escalated=False)
```

whenever the Windows stop primitive returns False, and that primitive returns False both when a stop genuinely could not be delivered and when there was nothing left to stop. A tree that has already exited accepts no stop, so `delivered` is False while the guarantee the reap exists to provide holds perfectly. The Windows runner recycles pids fast enough for that to be routine rather than exotic: the failing job logged 152 `pid reused` warnings from its own process monitor.

The same code was also unsafe. The Windows fallback shelled out to `Stop-Process -Id <pid> -Force` on a bare pid, and it did so precisely when the pid was most likely to have been recycled, because `taskkill` had just reported the number missing. On a recycled pid that force-kills an unrelated process on the runner or on a user machine. It then decided the outcome by re-probing liveness immediately after an asynchronous `TerminateProcess`, which is a race even when the pid is the right one.

## What changed

**The receipt reports the guarantee, not just the delivery.** `ProcessReapReceipt` gains `already_gone` (the tree had exited before any stop tier ran) and `confirmed_dead` (the tree is verified not running once the reap returned). `delivered` keeps its existing meaning. Both new fields are mirrored into the `process.reap_receipt` audit event, so "we stopped it" and "it had already stopped" stay distinguishable to a verifier reading the chain offline instead of collapsing into one ambiguous False.

**The Windows path stops acting on bare pids.** The reap opens a handle to the target before any tier runs. While a handle to a process object is open the kernel will not reuse that pid, so for the whole reap window the number either names the process we were asked to reap or names nothing. On top of that the pin reads the target's creation time and refuses a process that started after the reap was requested, which covers a recycle that lands before the pin is taken. The terminate fallback goes through the handle instead of re-resolving the number, and the exit is confirmed by waiting on the handle rather than racing the probe. A pid that resolves to nothing is now reported, never signalled.

**Linux and macOS are unchanged.** The pin is inert on POSIX: a process group id is not recycled while the group still has members, so the guard has nothing to add. The reap still issues exactly TERM, then signal-0 probes, then KILL, and a new test pins that sequence so it stays that way.

One POSIX detail surfaced while verifying: macOS returns EPERM, not ESRCH, for a signal aimed at a group whose only remaining members are zombies, so a fully reaped group keeps looking alive to `killpg(pgid, 0)` until its parent gets round to `wait()`. `confirmed_dead` therefore treats a delivered SIGKILL as the confirmation, which is sound because SIGKILL cannot be caught, blocked, or ignored.

**The test asserts the real guarantee.** It now requires `confirmed_dead`, accepts either "a stop was delivered" or "it had already exited", and confirms the outcome against the process itself rather than against the receipt that just claimed it.

## Verification

Everything below ran on macOS; the Windows-only branches are covered by the mocked-kernel32 tests this repo already uses for Windows behaviour, including a whole-reap replay of the exact conformance scenario (a hung console process that `taskkill` refuses to stop without `/F`).

| Suite | Result |
|---|---|
| `tests/integration/test_adapter_conformance_lifecycle.py` | 9 passed |
| `tests/unit/test_platform_win_process_branch.py` | 31 passed |
| `tests/unit/test_platform_process_tree.py` | 30 passed |
| `tests/unit/test_conformance_windows_projection.py` | 15 passed |
| `tests/unit/test_audit_chain_process_reap.py` | 6 passed |
| `tests/unit/test_adapter_contract.py` | 563 passed |
| `tests/unit/test_adapter_claude.py`, `test_platform_compat.py`, `test_hard_stop_group_reap.py`, `test_cross_platform_ci.py`, `test_heartbeat_escalation.py`, `test_heartbeat_terminal_escalation.py`, `test_worker_cmd_reporting.py`, `test_worktree_isolation_windows.py` | all passed |
| `ruff check` / `ruff format --check` / `lint-imports` | clean |
| `mypy` on the changed module | same 3 pre-existing errors as on main, no new ones |

The tests were checked against deliberate breakage rather than assumed to be load-bearing. Four mutations, each reverted:

| Mutation | Detected by |
|---|---|
| Reap never signals anything and claims success | conformance test, all 3 adapters: `worker still alive after platform reap` |
| Restore the old conflation (undeliverable stop reported as failure without checking whether the target was gone) | `test_undeliverable_term_against_an_exited_target_is_success`, `test_posix_already_exited_group_reports_the_guarantee` |
| Remove the creation-time pid-reuse guard | `test_process_started_after_the_request_is_not_the_target`, `test_recycled_pid_is_not_handed_to_taskkill` |
| Remove the pinned-handle terminate fallback | `test_hung_console_spawn_is_reaped_and_confirmed` plus 2 others |

### POSIX sequence, checked against main

The "Linux and macOS unchanged" claim was measured, not asserted. Both implementations were loaded side by side and driven through the same mocked `killpg`:

| Scenario | main | this branch |
|---|---|---|
| group never exits | TERM, liveness probes, KILL, `(delivered, escalated) = (True, True)` | identical |
| group exits after TERM | TERM, liveness probes, `(True, False)` | identical |
| TERM undeliverable | TERM, `(False, False)` | TERM plus one signal-0 probe, `(False, False)` |

The only difference is one extra read-only liveness probe on the undeliverable path. It sends no signal and changes neither `delivered` nor `escalated`; it is what makes `already_gone` and `confirmed_dead` truthful instead of guessed.

## Not executed locally

No Windows host is available here, so the real `taskkill` / kernel32 behaviour was not exercised end to end. The Windows CI lane on this PR is the first real execution of the new path.
