### PR TITLE
fix(mcp): advertise bernstein_context at the default tool tier

### DIFF
--- a/docs/mcp/tool_tiers.md
+++ b/docs/mcp/tool_tiers.md
@@ -16,13 +16,19 @@ callable.
 | Tier | Budget | Tools advertised | Use when |
 |------|--------|------------------|----------|
 | `core` | smallest | `bernstein_health`, `bernstein_run`, `bernstein_status`, `bernstein_tasks`, `bernstein_task_handle` | Cost-sensitive runs or small-context adapters; you only need to start and observe a run. |
-| `standard` (default) | medium | core plus `bernstein_cost`, `bernstein_stop`, `bernstein_approve`, `bernstein_create_subtask`, `bernstein_claim`, `bernstein_update`, `load_skill` | The typical run: mutation, approval, the pull-worker claim/update verbs, and skill loading. |
+| `standard` (default) | medium | core plus `bernstein_cost`, `bernstein_stop`, `bernstein_approve`, `bernstein_create_subtask`, `bernstein_claim`, `bernstein_update`, `bernstein_post_artifact`, `bernstein_context`, `load_skill` | The typical run: mutation, approval, the pull-worker claim/update verbs, artifact posting, the signed context capsule, and skill loading. |
 | `all` | largest | standard plus the scenario bridge (`bernstein_scenarios`, `bernstein_scenario`, `bernstein_scenario_status`) and `verify_chain` | Power-user setups that drive scenario libraries or audit lineage. |
 
 The exact membership is declared once in
 `src/bernstein/core/protocols/mcp/tool_tiers.py` (`TOOL_TIERS`). Adding a new
 tool sets its tier at that declaration; there is no separate runtime
 registry to keep in sync.
+
+A tool with no `TOOL_TIERS` entry falls back to the `all` tier, so omitting
+the declaration removes the tool from `tools/list` at the default `standard`
+tier. That omission is a test failure, not a silent drop: a coverage test
+compares every tool the MCP server registers against `TOOL_TIERS` and fails
+on the first undeclared name.
 
 ## Selecting a tier
 

--- a/src/bernstein/core/protocols/mcp/tool_tiers.py
+++ b/src/bernstein/core/protocols/mcp/tool_tiers.py
@@ -48,7 +48,11 @@ TIER_ENV_VAR: Final[str] = "BERNSTEIN_MCP_TOOL_TIER"
 #: tool with tier ``all`` is exposed only when the active tier is ``all``.
 #:
 #: This mapping is the single source of truth for the annotation. Adding a
-#: new tool means adding one line here at declaration time.
+#: new tool means adding one line here at declaration time. A missing entry
+#: is not a no-op: the tool falls back to ``all`` and disappears from
+#: ``tools/list`` under the default ``standard`` tier. A coverage test
+#: (``tests/unit/test_mcp_server.py``) compares the registered tools against
+#: this mapping so an omission fails instead of silently hiding a tool.
 TOOL_TIERS: Final[dict[str, ToolTier]] = {
     # core - always on: liveness plus the read-only surface needed to start
     # and observe a run.
@@ -65,6 +69,7 @@ TOOL_TIERS: Final[dict[str, ToolTier]] = {
     "bernstein_claim": "standard",
     "bernstein_update": "standard",
     "bernstein_post_artifact": "standard",
+    "bernstein_context": "standard",
     "load_skill": "standard",
     # all - power-user surface: the scenario bridge and lineage verifier.
     "bernstein_scenarios": "all",

--- a/tests/unit/mcp/test_tool_tiering.py
+++ b/tests/unit/mcp/test_tool_tiering.py
@@ -141,6 +141,21 @@ def test_standard_tier_adds_mutation_and_skill_tools() -> None:
     assert "bernstein_scenario" not in advertised
 
 
+def test_context_capsule_tool_is_in_the_standard_tier() -> None:
+    # bernstein_context lets a worker that lost its session reload its own
+    # signed assignment capsule, so it must be reachable at the default tier
+    # rather than only when an operator sets the tier to ``all``.
+    assert TOOL_TIERS["bernstein_context"] == "standard"
+    assert "bernstein_context" in tools_for_tier("standard")
+    assert "bernstein_context" in tools_for_tier("all")
+    assert "bernstein_context" not in tools_for_tier("core")
+
+
+def test_default_tier_advertises_the_context_capsule_tool(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(TIER_ENV_VAR, raising=False)
+    assert "bernstein_context" in _advertised(None)
+
+
 def test_all_tier_exposes_scenario_bridge() -> None:
     advertised = _advertised("all")
     assert "bernstein_scenarios" in advertised

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -78,6 +78,31 @@ def test_mcp_server_registers_all_tools() -> None:
     assert "bernstein_approve" in tool_names
 
 
+def test_every_registered_tool_has_an_explicit_tier(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """Every tool a server registers must declare its tier in ``TOOL_TIERS``.
+
+    ``tool_in_tier`` falls back to the ``all`` tier for an unlisted name, so a
+    tool registered without a ``TOOL_TIERS`` entry silently disappears from
+    ``tools/list`` under the default ``standard`` tier. Comparing the tool
+    manager's registry against the declaration turns that silent drop into a
+    test failure at the moment the tool is added.
+    """
+    from bernstein.core.protocols.mcp.tool_tiers import TOOL_TIERS
+    from bernstein.mcp.server import create_mcp_server
+
+    # The ``all`` tier keeps every registered tool, and lineage registration
+    # is opt-in, so this build is the widest possible registration set.
+    mcp = create_mcp_server(
+        server_url="http://localhost:8052",
+        tier="all",
+        lineage_enabled=True,
+        lineage_root=tmp_path,
+    )
+    registered = {t.name for t in mcp._tool_manager.list_tools()}
+    undeclared = sorted(registered - set(TOOL_TIERS))
+    assert not undeclared, f"MCP tools registered without a TOOL_TIERS entry: {undeclared}"
+
+
 # ---------------------------------------------------------------------------
 # bernstein_run
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_seed.py
+++ b/tests/unit/test_seed.py
@@ -936,9 +936,7 @@ class TestParseSeedUnknownTopLevelKeys:
         messages = [r.getMessage() for r in caplog.records]
         assert any("zzqqxx" in m for m in messages)
 
-    def test_container_image_key_hints_sandbox_image(
-        self, seed_file: Path, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_container_image_key_hints_sandbox_image(self, seed_file: Path, caplog: pytest.LogCaptureFixture) -> None:
         """``container_image:`` has no top-level equivalent; the warning must
         point operators at ``sandbox.image`` instead of silently dropping the
         value (bug #3023)."""


### PR DESCRIPTION
Refs #3073

## Problem

`TOOL_TIERS` in `src/bernstein/core/protocols/mcp/tool_tiers.py` is the single source of truth for which MCP tools are advertised at which tier, and it had no `bernstein_context` key. `tool_in_tier` falls back to `TOOL_TIERS.get(tool_name, "all")`, so the tool was treated as tier `all` and `_apply_tool_tier` popped it out of the FastMCP tool manager under the default `standard` tier.

The signed task context capsule was therefore neither advertised in `tools/list` nor callable unless the operator happened to set `BERNSTEIN_MCP_TOOL_TIER=all`. Nothing in the tool docstring, the docs, or the capability card said so, so it read as "the capsule tool does not exist".

## What an operator can do after this

Connect any MCP client with default settings and see and call `bernstein_context`. A worker that lost its session reloads its own signed assignment capsule without setting an environment variable.

## Changes

- `src/bernstein/core/protocols/mcp/tool_tiers.py`: declare `bernstein_context` at tier `standard`. No other tool changes tier. The `TOOL_TIERS` comment now states that a missing entry hides the tool at the default tier and that a test enforces coverage.
- `tests/unit/test_mcp_server.py`: `test_every_registered_tool_has_an_explicit_tier` builds the widest registration set (`tier="all"`, `lineage_enabled=True`) and asserts every registered tool name has an explicit `TOOL_TIERS` key, so the silent `all` fallback cannot hide another tool again.
- `tests/unit/mcp/test_tool_tiering.py`: assert `bernstein_context` is declared `standard`, is in `tools_for_tier("standard")` and not in `core`, and is advertised by a default-tier server.
- `docs/mcp/tool_tiers.md`: the tier membership table listed neither `bernstein_context` nor `bernstein_post_artifact` under `standard`. Both are now listed, and the doc states that an undeclared tool falls back to `all` and that the coverage test catches the omission.

## Verification

Tests were written first and fail against the unfixed tree.

Before the source change (tests present, `TOOL_TIERS` unchanged):

```
FAILED tests/unit/mcp/test_tool_tiering.py::test_context_capsule_tool_is_in_the_standard_tier
FAILED tests/unit/mcp/test_tool_tiering.py::test_default_tier_advertises_the_context_capsule_tool
FAILED tests/unit/test_mcp_server.py::test_every_registered_tool_has_an_explicit_tier
3 failed, 50 passed, 113 warnings in 9.62s
```

The coverage test names the offender directly:

```
E       AssertionError: MCP tools registered without a TOOL_TIERS entry: ['bernstein_context']
```

After the source change:

```
53 passed, 113 warnings in 9.51s
```

Also run: `tests/unit/mcp/test_capability_card.py` -> `9 passed`, since the capability card projects `tools_for_tier(active_tier)` and now reports one more tool at `standard`.

`uv run ruff check .` -> `All checks passed!`
`uv run bernstein agents-md verify` -> `OK all 13 file(s) in sync`

## For the reviewer

- The `standard` tier now advertises one more tool, so the `standard` capability card `advertised` list and `tools` audit output grow by one entry. That is the intended behaviour change; no consumer asserts an exact `standard` set other than the tier tests updated here.
- `uv run ruff format --check .` reports `tests/unit/test_seed.py` would be reformatted. That file is untouched by this branch and is already in that state on `origin/main`.