### PR TITLE
docs(mcp): make connect-time instructions state the run control loop

### DIFF
--- a/docs/mcp/server.md
+++ b/docs/mcp/server.md
@@ -169,6 +169,31 @@ error:
 `isError` is not set: a cancel is a client-initiated stop, not a tool failure.
 Cancelling an unknown or already-settled id is a no-op.
 
+## Connect-time instructions
+
+The server sends an `instructions` string on connect. It is the only
+Bernstein text guaranteed to stay in a connected model's context for the
+whole session, so it carries the control loop rather than a description of
+the system:
+
+1. One clause of identity.
+2. The start-then-poll loop: `bernstein_run` returns a `task_id` which is the
+   run id, `bernstein_task_handle` is polled with that value as `run_id`,
+   runs take minutes to hours, poll tens of seconds apart, and stop at a
+   terminal status (`completed`, `failed`, `cancelled`).
+3. One pointer to `load_skill` for anything deeper.
+
+Two rules keep the text honest, both enforced in
+`tests/unit/test_mcp_server.py`:
+
+- The string stays at or under 900 characters.
+- Every tool name it mentions is registered on the server, so instruction
+  text cannot outlive a tool rename.
+
+The `src/bernstein/mcp/server.py` module docstring lists every tool the
+module registers, and the same test asserts that list against the live
+registration set.
+
 ## Driving long-running runs from an MCP host (Tasks extension)
 
 A run started over MCP can outlive a single call. Rather than hold a session

--- a/src/bernstein/mcp/server.py
+++ b/src/bernstein/mcp/server.py
@@ -8,16 +8,35 @@ Transport:
     stdio  - for local IDE integration (default ``bernstein mcp``)
     sse    - for remote/web integration (``bernstein mcp --transport sse``)
 
-Tools:
-    bernstein_run     - start an orchestration run with a goal
-    bernstein_status  - get task counts summary
-    bernstein_tasks   - list tasks with optional status filter
-    bernstein_task_handle - verifiable Tasks-extension run handle (poll a run)
-    bernstein_cost    - get cost summary across all roles
-    bernstein_stop    - graceful shutdown (writes SHUTDOWN signal)
-    bernstein_approve - approve a pending/blocked task
-    bernstein_health  - liveness check (always succeeds)
-    load_skill        - load a skill pack body / reference / script (oai-004)
+Tools registered by ``create_mcp_server`` below. The list is exhaustive and
+is asserted against the live registration set by
+``tests/unit/test_mcp_server.py``, so a tool added here without a docstring
+line fails that test. Tiers are declared in
+:data:`bernstein.core.protocols.mcp.tool_tiers.TOOL_TIERS`; the widest tier
+plus lineage exposes all of them.
+
+    bernstein_health        - liveness check (always succeeds)
+    bernstein_run           - start an orchestration run with a goal
+    bernstein_status        - get task counts summary
+    bernstein_tasks         - list tasks with optional status filter
+    bernstein_task_handle   - verifiable run handle, polled by run id
+    bernstein_cost          - get cost summary across all roles
+    bernstein_context       - signed spawn capsule for a worker (#2545)
+    bernstein_claim         - claim the next dependency-gated task
+    bernstein_update        - post progress on a claimed task
+    bernstein_post_artifact - attach an artefact to a task
+    bernstein_stop          - graceful shutdown (writes SHUTDOWN signal)
+    bernstein_approve       - approve a pending/blocked task
+    bernstein_create_subtask - split a claimed task into a child task
+    load_skill              - load a skill pack body / reference / script
+
+Registered from sibling modules by the same ``create_mcp_server`` call:
+
+    bernstein_scenarios       - list scenario definitions (routine_tools)
+    bernstein_scenario        - start a scenario run (routine_tools)
+    bernstein_scenario_status - poll a scenario run (routine_tools)
+    verify_chain              - verify an artefact against the audit chain
+                                (resources.lineage, lineage builds only)
 """
 
 from __future__ import annotations
@@ -76,16 +95,26 @@ FuncMetadata.convert_result = _patched_convert_result
 
 _DEFAULT_SERVER_URL = "http://127.0.0.1:8052"
 
-# Self-description advertised to MCP clients on connect.
+# Advertised to MCP clients on connect and therefore the only Bernstein text
+# guaranteed to sit in the connected model's context for the whole session.
+# It spends that budget on the control loop, not on a system description:
+# a client that starts a run and then polls wrongly pays for a second run.
+# Budget and tool-name accuracy are asserted in tests/unit/test_mcp_server.py.
 _SERVER_INSTRUCTIONS = (
-    "Bernstein: deterministic, verifiable orchestration for CLI coding agents - "
-    "reproducible parallel runs, signed audit trail, air-gap friendly. "
-    "Dispatches goals across 40+ CLI agent adapters (Claude Code, Codex, "
-    "Gemini CLI, and more), each task in its own git worktree behind "
-    "lint/type/test gates. Scheduling is plain Python with no LLM in the "
-    "coordination loop, so runs replay byte-identically. An always-on lineage "
-    "spine and replay journal record every run; an opt-in HMAC-chained audit "
-    "log adds receipts that verify offline."
+    "Bernstein runs CLI coding agents deterministically, one git worktree per "
+    "task, against an offline-verifiable audit chain.\n"
+    "Driving a run:\n"
+    "1. bernstein_run starts a run and returns immediately with a task_id, "
+    "which is the run id. It does not wait for the run to finish.\n"
+    "2. Poll bernstein_task_handle with run_id set to that value. The handle "
+    "is reprojected from the run journal, so it is safe to poll from anywhere.\n"
+    "3. Runs take minutes to hours. Poll on a slow cadence, tens of seconds "
+    "apart. A handle still reading working is normal progress, not a stall, "
+    "so do not start the goal again.\n"
+    "4. Stop polling once status is terminal: completed, failed or cancelled. "
+    "input_required means the run is waiting on you.\n"
+    "For anything deeper, call load_skill with a name from the skill index and "
+    "load only the pack the task needs."
 )
 
 # Timeout for all httpx calls to the task server (seconds).

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import re
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -622,3 +624,87 @@ async def test_bernstein_run_sends_auth_header_when_set(
 
     headers = mock_client.post.call_args.kwargs.get("headers") or {}
     assert headers.get("Authorization") == "Bearer run-tok"
+
+
+# ---------------------------------------------------------------------------
+# Connect-time server instructions and module docstring (issue #3076)
+# ---------------------------------------------------------------------------
+
+#: Every tool name Bernstein advertises matches one of these shapes, so a
+#: rename that leaves prose behind is caught rather than silently shipped.
+_TOOL_NAME_RE = re.compile(r"\b(?:bernstein_[a-z0-9_]+|load_skill|verify_chain)\b")
+
+#: Character budget for the text pinned in a connected model's context for
+#: the whole session.
+_INSTRUCTIONS_BUDGET = 900
+
+
+def _registered_tool_names(tmp_path: Path) -> set[str]:
+    """Return every tool name registered by ``bernstein.mcp.server``.
+
+    Built at the widest tier with lineage on, so the set covers every tool
+    the module can register rather than just the default tier.
+    """
+    from bernstein.mcp.server import create_mcp_server
+
+    mcp = create_mcp_server(
+        server_url="http://localhost:8052",
+        tier="all",
+        lineage_enabled=True,
+        lineage_root=tmp_path / "lineage",
+    )
+    return set(mcp._tool_manager._tools)
+
+
+def _tool_names_in(text: str) -> set[str]:
+    """Return the tool-shaped identifiers mentioned in ``text``."""
+    return set(_TOOL_NAME_RE.findall(text))
+
+
+def test_server_instructions_fit_the_context_budget() -> None:
+    """The connect-time instructions stay inside their character budget."""
+    from bernstein.mcp.server import _SERVER_INSTRUCTIONS
+
+    assert len(_SERVER_INSTRUCTIONS) <= _INSTRUCTIONS_BUDGET
+
+
+def test_server_instructions_state_the_control_loop_in_order() -> None:
+    """Identity, then the start-then-poll loop, then the pointer to skills."""
+    from bernstein.mcp.server import _SERVER_INSTRUCTIONS
+
+    text = _SERVER_INSTRUCTIONS
+    lowered = text.lower()
+
+    run_at = text.index("bernstein_run")
+    handle_at = text.index("bernstein_task_handle")
+    skill_at = text.index("load_skill")
+
+    # Identity comes first, before any tool is named.
+    assert lowered.index("bernstein") < run_at
+    # Start, then poll, then the deeper-material pointer.
+    assert run_at < handle_at < skill_at
+
+    # The poll loop must say what the identifier is, how long a run lasts,
+    # how often to poll, and when to stop.
+    assert "run_id" in text
+    assert "minutes to hours" in lowered
+    assert "poll" in lowered
+    for terminal in ("completed", "failed", "cancelled"):
+        assert terminal in lowered
+
+
+def test_server_instruction_tool_names_are_registered(tmp_path: Path) -> None:
+    """Instruction text must not outlive a tool rename."""
+    from bernstein.mcp.server import _SERVER_INSTRUCTIONS
+
+    mentioned = _tool_names_in(_SERVER_INSTRUCTIONS)
+    assert mentioned, "instructions should name the tools that drive a run"
+    assert mentioned <= _registered_tool_names(tmp_path)
+
+
+def test_module_docstring_lists_every_registered_tool(tmp_path: Path) -> None:
+    """The first thing a contributor reads must match what the module ships."""
+    import bernstein.mcp.server as server_module
+
+    docstring = server_module.__doc__ or ""
+    assert _tool_names_in(docstring) == _registered_tool_names(tmp_path)

--- a/tests/unit/test_seed.py
+++ b/tests/unit/test_seed.py
@@ -936,9 +936,7 @@ class TestParseSeedUnknownTopLevelKeys:
         messages = [r.getMessage() for r in caplog.records]
         assert any("zzqqxx" in m for m in messages)
 
-    def test_container_image_key_hints_sandbox_image(
-        self, seed_file: Path, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_container_image_key_hints_sandbox_image(self, seed_file: Path, caplog: pytest.LogCaptureFixture) -> None:
         """``container_image:`` has no top-level equivalent; the warning must
         point operators at ``sandbox.image`` instead of silently dropping the
         value (bug #3023)."""


### PR DESCRIPTION
## Problem

`_SERVER_INSTRUCTIONS` in `src/bernstein/mcp/server.py` is passed to
`FastMCP(name, instructions=...)`, so it is the only Bernstein text guaranteed
to sit in a connected model's context for the whole session. It spent that
budget describing the system. A client model could start a run and then have
no in-context statement of how long a run lasts, which tool polls it, or which
identifier that tool wants, so a quiet poll reads as a stall and the goal gets
started a second time.

Separately, the `server.py` module docstring listed 9 of the 18 tools the
module registers, which is the first thing a contributor reads.

## What an operator can do after this

Connect a client and have the model follow the start-then-poll loop on the
first attempt, instead of re-issuing an expensive run because a poll looked
quiet.

## Change

- `_SERVER_INSTRUCTIONS` now states, in order: one clause of identity; the
  control loop (`bernstein_run` returns a `task_id` which is the run id, poll
  `bernstein_task_handle` with that value as `run_id`, runs take minutes to
  hours, poll tens of seconds apart, stop at `completed` / `failed` /
  `cancelled`, `input_required` means the run is waiting on you); and one
  pointer to `load_skill`. 817 characters.
- The module docstring lists every tool `create_mcp_server` registers, split
  into the ones defined in this module and the ones registered from
  `routine_tools` and `resources.lineage`.
- `docs/mcp/server.md` gains a "Connect-time instructions" section describing
  the contract and the two tests that hold it.

No tool behaviour changes: no handler, schema, tier or transport was touched.

## Tests

`tests/unit/test_mcp_server.py`:

- `test_server_instructions_fit_the_context_budget` - at most 900 characters.
- `test_server_instructions_state_the_control_loop_in_order` - identity before
  any tool name, `bernstein_run` before `bernstein_task_handle` before
  `load_skill`, and the run duration, poll cadence and terminal statuses are
  present.
- `test_server_instruction_tool_names_are_registered` - every tool-shaped
  identifier in the instructions is registered on the server, so instruction
  text cannot outlive a tool rename.
- `test_module_docstring_lists_every_registered_tool` - the docstring's tool
  list equals the live registration set read from `mcp._tool_manager._tools`,
  built at tier `all` with lineage enabled.

The last three fail against the pre-change module and pass after it.

```
uv run pytest tests/unit/test_mcp_server.py -q
29 passed, 85 warnings in 5.21s
```

Refs #3076