### PR TITLE
fix(mcp): advertise the protected-resource metadata URL on a 401

### DIFF
--- a/docs/mcp/server.md
+++ b/docs/mcp/server.md
@@ -63,8 +63,26 @@ the IdP:
 |------|----------|
 | `/.well-known/oauth-protected-resource` | RFC 9728 / MCP-draft protected-resource metadata pointing at the issuer; the `resource` field is built from the request `Host` and `X-Forwarded-Proto` headers. |
 
+Every `401` the streamable HTTP transport returns while an issuer is
+configured carries a challenge naming that document, so a client that is
+refused can locate it without knowing the well-known path in advance:
+
+```
+WWW-Authenticate: Bearer resource_metadata="https://bernstein.example.com/.well-known/oauth-protected-resource"
+```
+
+The URL is built from the same request base (`Host` plus
+`X-Forwarded-Proto`) as the `resource` field inside the document, so the
+advertised URL and the served path cannot drift. The value names nothing
+but that URL: no token, tenant, user, or issuer identifier appears in it.
+When no issuer is configured the header is omitted entirely and the
+anonymous and static-bearer flows behave exactly as before. The `401` body
+is `{"error":"unauthorized"}` in both cases.
+
 The discovery handshake is:
 
+0. Client calls `/mcp` without credentials, is refused with `401`, and
+   reads the metadata URL from `WWW-Authenticate`.
 1. Client fetches `/.well-known/oauth-protected-resource` from Bernstein.
 2. Client reads `authorization_servers[0]` (the configured issuer URL).
 3. Client fetches the IdP's own RFC 8414 metadata from the IdP, for
@@ -330,6 +348,9 @@ chain.
    export BERNSTEIN_MCP_OAUTH_ISSUER=https://idp.example.com
    # restart the server to pick up the env var, then:
    curl -s http://127.0.0.1:8053/.well-known/oauth-protected-resource
+
+   # or start from the refusal and follow the challenge:
+   curl -si http://127.0.0.1:8053/mcp -d '{}' | grep -i www-authenticate
    ```
 
    The protected-resource document points at the IdP via

--- a/src/bernstein/mcp/oauth.py
+++ b/src/bernstein/mcp/oauth.py
@@ -80,6 +80,44 @@ def protected_resource_metadata(resource_url: str) -> dict[str, Any] | None:
     }
 
 
+def protected_resource_metadata_url(base_url: str) -> str:
+    """Return the absolute URL of the protected-resource metadata document.
+
+    Args:
+        base_url: Scheme and authority the client reached the server on, for
+            example ``https://bernstein.example.com``.
+
+    Returns:
+        The absolute URL the transport serves the metadata document at.
+    """
+    return f"{base_url.rstrip('/')}{PR_METADATA_PATH}"
+
+
+def www_authenticate_challenge(base_url: str) -> str | None:
+    """Build the ``WWW-Authenticate`` value for an unauthenticated request.
+
+    A bare 401 leaves the protected-resource metadata undiscoverable: the
+    client has no path from the refusal to the document. The challenge names
+    the document's absolute URL so a client can start the authorization flow
+    from the refusal alone.
+
+    The value carries nothing but the metadata URL. No token, tenant, user, or
+    issuer identifier is included, so the challenge is safe to return to a
+    caller that has not authenticated.
+
+    Args:
+        base_url: Scheme and authority the client reached the server on.
+
+    Returns:
+        The header value, or ``None`` when no issuer is configured, in which
+        case the anonymous and static-bearer flows are the only advertised
+        paths and no challenge should be emitted.
+    """
+    if not oauth_discovery_enabled():
+        return None
+    return f'Bearer resource_metadata="{protected_resource_metadata_url(base_url)}"'
+
+
 def capability_card_oauth() -> dict[str, Any]:
     """Return the ``auth.oauth`` subtree for the runtime capability card.
 

--- a/src/bernstein/mcp/remote_transport.py
+++ b/src/bernstein/mcp/remote_transport.py
@@ -62,6 +62,12 @@ _LOCALHOST_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
 # Env var names used to pick up the bearer auth token if not provided explicitly.
 _TOKEN_ENV_VARS = ("BERNSTEIN_MCP_TOKEN", "BERNSTEIN_MCP_AUTH_TOKEN")
 
+# Characters a request authority may keep once it is echoed back into a
+# response header or body: registered names, IPv4 and bracketed IPv6 literals,
+# and a port. Everything else, CR and LF and the quote character included, is
+# dropped by :func:`_sanitise_authority`.
+_AUTHORITY_CHARS = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~:[]%")
+
 # Clear-text scheme, spelled as a bare token so a browser origin can only be
 # built from it deliberately. Any origin carrying this scheme has to prove it
 # is loopback-pinned (see ``RemoteMCPConfig.__post_init__``).
@@ -99,6 +105,24 @@ def _resolve_token_from_env() -> str:
 def _is_localhost(host: str) -> bool:
     """Return True if ``host`` refers to the loopback interface only."""
     return host in _LOCALHOST_HOSTS
+
+
+def _sanitise_authority(authority: str) -> str:
+    """Filter a request authority down to host and port characters.
+
+    The value reaches us from a client-supplied ``Host`` header and is
+    interpolated into response headers and bodies, so anything outside the
+    character set a host, an IPv6 literal, and a port may use is dropped. CR,
+    LF, and the quote character are the ones that matter: they would otherwise
+    terminate a header value or escape a quoted header parameter.
+
+    Args:
+        authority: Raw authority, for example ``bernstein.example.com:8053``.
+
+    Returns:
+        The filtered authority, possibly empty when nothing survived.
+    """
+    return "".join(c for c in authority.strip() if c in _AUTHORITY_CHARS)
 
 
 def _origin_host(origin: str) -> str | None:
@@ -455,11 +479,7 @@ class StreamableHTTPTransport:
 
         # Auth check.
         if not self._authenticate(headers):
-            return (
-                401,
-                {"content-type": _CONTENT_TYPE_JSON},
-                b'{"error":"unauthorized"}',
-            )
+            return self._unauthorized_response(headers)
 
         # Legacy protocol-session shim: the removed header is accepted (and
         # ignored) for a bounded window, then refused with the removal date.
@@ -985,6 +1005,58 @@ class StreamableHTTPTransport:
 
     # -- OAuth discovery -----------------------------------------------------
 
+    def _request_base_url(self, headers: dict[str, str]) -> str:
+        """Return the scheme and authority the client reached this server on.
+
+        Both the protected-resource metadata document and the
+        ``WWW-Authenticate`` challenge on a 401 are built from this, so the URL
+        a client is pointed at cannot drift from the URL that serves the
+        document.
+
+        ``Host`` and ``X-Forwarded-Proto`` are supplied by the client or by a
+        proxy in front of it, and the result is interpolated into a response
+        header, so the authority is filtered down to the characters a host and
+        port may contain. That drops CR, LF, and the quote character before
+        they can terminate the header value or the quoted parameter.
+
+        Args:
+            headers: HTTP request headers (lower-cased keys).
+
+        Returns:
+            An absolute base URL with no trailing slash.
+        """
+        fallback = f"{self._config.host}:{self._config.port}"
+        authority = _sanitise_authority(headers.get("host", "")) or _sanitise_authority(fallback)
+        scheme = "https" if headers.get("x-forwarded-proto", "").lower() == "https" else "http"
+        return f"{scheme}://{authority}"
+
+    def _unauthorized_response(
+        self,
+        headers: dict[str, str],
+    ) -> tuple[int, dict[str, str], bytes]:
+        """Build the 401 response, including the discovery challenge.
+
+        Every 401 the transport emits is built here. When an OAuth issuer is
+        configured, the response carries a ``WWW-Authenticate`` challenge
+        naming the protected-resource metadata URL, so a client that is refused
+        can locate the document and start the authorization flow instead of
+        stopping at the refusal. Without an issuer no challenge is emitted and
+        the anonymous and static-bearer flows are unchanged.
+
+        Args:
+            headers: HTTP request headers (lower-cased keys).
+
+        Returns:
+            Tuple of (401, response_headers, response_body).
+        """
+        from bernstein.mcp.oauth import www_authenticate_challenge
+
+        resp_headers = {"content-type": _CONTENT_TYPE_JSON}
+        challenge = www_authenticate_challenge(self._request_base_url(headers))
+        if challenge is not None:
+            resp_headers["www-authenticate"] = challenge
+        return (401, resp_headers, b'{"error":"unauthorized"}')
+
     @staticmethod
     def _is_well_known(path: str) -> bool:
         """Return True for the protected-resource discovery path.
@@ -1012,11 +1084,9 @@ class StreamableHTTPTransport:
         )
 
         if path == PR_METADATA_PATH:
-            # Build the absolute resource URL from the Host header so the
+            # Build the absolute resource URL from the request base so the
             # advertised resource matches what the client called.
-            host = headers.get("host", f"{self._config.host}:{self._config.port}")
-            scheme = headers.get("x-forwarded-proto", "http")
-            resource_url = f"{scheme}://{host}{self._config.path}"
+            resource_url = f"{self._request_base_url(headers)}{self._config.path}"
             meta = protected_resource_metadata(resource_url)
         else:
             meta = None

--- a/tests/unit/mcp/test_oauth_discovery.py
+++ b/tests/unit/mcp/test_oauth_discovery.py
@@ -226,3 +226,37 @@ def test_capability_card_reports_oauth_disabled(_no_issuer: None) -> None:
     # When off, oauth2_pkce remains planned, not supported.
     assert "oauth2_pkce" in card["auth"]["planned"]
     assert "oauth2_pkce" not in card["auth"]["supported"]
+
+
+# ---------------------------------------------------------------------------
+# WWW-Authenticate challenge helper (issue #3075)
+# ---------------------------------------------------------------------------
+
+
+def test_challenge_is_none_without_issuer(_no_issuer: None) -> None:
+    from bernstein.mcp.oauth import www_authenticate_challenge
+
+    assert www_authenticate_challenge("https://bernstein.example.com") is None
+
+
+def test_challenge_points_at_the_metadata_path(_with_issuer: str) -> None:
+    from bernstein.mcp.oauth import (
+        PR_METADATA_PATH,
+        protected_resource_metadata_url,
+        www_authenticate_challenge,
+    )
+
+    base = "https://bernstein.example.com"
+    url = protected_resource_metadata_url(base)
+    assert url == f"{base}{PR_METADATA_PATH}"
+    assert www_authenticate_challenge(base) == f'Bearer resource_metadata="{url}"'
+    # The challenge names the document, never the issuer or any credential.
+    assert _with_issuer not in www_authenticate_challenge(base)
+
+
+def test_challenge_normalises_a_trailing_slash_on_the_base(_with_issuer: str) -> None:
+    from bernstein.mcp.oauth import protected_resource_metadata_url
+
+    assert protected_resource_metadata_url("https://bernstein.example.com/") == (
+        "https://bernstein.example.com/.well-known/oauth-protected-resource"
+    )

--- a/tests/unit/test_mcp_remote_transport.py
+++ b/tests/unit/test_mcp_remote_transport.py
@@ -712,3 +712,197 @@ class TestProxyAuthHeader:
 
         headers = mock_client.post.call_args.kwargs.get("headers") or {}
         assert headers.get("Authorization") == "Bearer post-tok"
+
+
+# ---------------------------------------------------------------------------
+# WWW-Authenticate challenge on 401 (issue #3075)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _oauth_issuer(monkeypatch: pytest.MonkeyPatch) -> str:
+    """Configure an OAuth issuer for the duration of a test."""
+    issuer = "https://idp.example.com"
+    monkeypatch.setenv("BERNSTEIN_MCP_OAUTH_ISSUER", issuer)
+    monkeypatch.delenv("BERNSTEIN_MCP_OAUTH_SCOPES", raising=False)
+    return issuer
+
+
+@pytest.fixture
+def _no_oauth_issuer(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BERNSTEIN_MCP_OAUTH_ISSUER", raising=False)
+    monkeypatch.delenv("BERNSTEIN_MCP_OAUTH_SCOPES", raising=False)
+
+
+_PROXY_HEADERS = {"host": "bernstein.example.com", "x-forwarded-proto": "https"}
+
+
+def _www_authenticate(headers: dict[str, str]) -> str | None:
+    """Return the WWW-Authenticate value regardless of header casing."""
+    for key, value in headers.items():
+        if key.lower() == "www-authenticate":
+            return value
+    return None
+
+
+class TestUnauthorizedChallenge:
+    """A 401 with no challenge leaves the served protected-resource metadata
+    undiscoverable: the client has no path from the refusal to the document."""
+
+    @pytest.mark.anyio
+    async def test_401_carries_resource_metadata_challenge(
+        self,
+        bearer_transport: StreamableHTTPTransport,
+        _oauth_issuer: str,
+    ) -> None:
+        status, headers, _ = await bearer_transport.handle_request(
+            "POST",
+            "/mcp",
+            dict(_PROXY_HEADERS),
+            _jsonrpc_request("ping"),
+        )
+        assert status == 401
+        assert _www_authenticate(headers) == (
+            'Bearer resource_metadata="https://bernstein.example.com/.well-known/oauth-protected-resource"'
+        )
+
+    @pytest.mark.anyio
+    async def test_challenge_url_resolves_to_the_served_document(
+        self,
+        bearer_transport: StreamableHTTPTransport,
+        _oauth_issuer: str,
+    ) -> None:
+        """The advertised URL must fetch the metadata the transport serves."""
+        from urllib.parse import urlsplit
+
+        _, headers, _ = await bearer_transport.handle_request(
+            "POST",
+            "/mcp",
+            dict(_PROXY_HEADERS),
+            _jsonrpc_request("ping"),
+        )
+        challenge = _www_authenticate(headers)
+        assert challenge is not None
+        advertised = challenge.split('resource_metadata="', 1)[1].rstrip('"')
+        split = urlsplit(advertised)
+        assert split.scheme == "https"
+        assert split.netloc == "bernstein.example.com"
+
+        meta_status, _, meta_body = await bearer_transport.handle_request(
+            "GET",
+            split.path,
+            dict(_PROXY_HEADERS),
+            b"",
+        )
+        assert meta_status == 200
+        payload = json.loads(meta_body)
+        assert payload["resource"] == "https://bernstein.example.com/mcp"
+        assert payload["authorization_servers"] == [_oauth_issuer]
+
+    @pytest.mark.anyio
+    async def test_no_challenge_without_issuer(
+        self,
+        bearer_transport: StreamableHTTPTransport,
+        _no_oauth_issuer: None,
+    ) -> None:
+        """Anonymous and static-bearer deployments are unchanged."""
+        status, headers, body = await bearer_transport.handle_request(
+            "POST",
+            "/mcp",
+            dict(_PROXY_HEADERS),
+            _jsonrpc_request("ping"),
+        )
+        assert status == 401
+        assert _www_authenticate(headers) is None
+        assert body == b'{"error":"unauthorized"}'
+
+    @pytest.mark.anyio
+    async def test_401_body_is_unchanged_with_issuer(
+        self,
+        bearer_transport: StreamableHTTPTransport,
+        _oauth_issuer: str,
+    ) -> None:
+        status, _, body = await bearer_transport.handle_request(
+            "POST",
+            "/mcp",
+            dict(_PROXY_HEADERS),
+            _jsonrpc_request("ping"),
+        )
+        assert status == 401
+        assert body == b'{"error":"unauthorized"}'
+
+    @pytest.mark.anyio
+    async def test_challenge_carries_no_tenant_token_or_user_identifier(
+        self,
+        _oauth_issuer: str,
+        _clear_token_env: None,
+    ) -> None:
+        """The challenge is a public pointer, so it must name nothing private."""
+        cfg = RemoteMCPConfig(path="/mcp", auth_type="bearer", auth_token="super-secret-token")
+        transport = StreamableHTTPTransport(config=cfg, server_url="https://test:8052")
+        _, headers, _ = await transport.handle_request(
+            "POST",
+            "/mcp",
+            {
+                "host": "bernstein.example.com",
+                "x-forwarded-proto": "https",
+                "authorization": "Bearer presented-token-value",
+                "x-bernstein-tenant": "tenant-4711",
+                "x-bernstein-user": "operator-jane",
+            },
+            _jsonrpc_request("ping"),
+        )
+        challenge = _www_authenticate(headers)
+        assert challenge is not None
+        for secret in (
+            "super-secret-token",
+            "presented-token-value",
+            "tenant-4711",
+            "operator-jane",
+        ):
+            assert secret not in challenge
+
+    @pytest.mark.anyio
+    async def test_challenge_rejects_header_injection_via_host(
+        self,
+        bearer_transport: StreamableHTTPTransport,
+        _oauth_issuer: str,
+    ) -> None:
+        """The Host header is client-supplied; it must not break the value."""
+        _, headers, _ = await bearer_transport.handle_request(
+            "POST",
+            "/mcp",
+            {"host": 'evil"\r\nx-injected: 1', "x-forwarded-proto": "https"},
+            _jsonrpc_request("ping"),
+        )
+        challenge = _www_authenticate(headers)
+        assert challenge is not None
+        assert "\r" not in challenge
+        assert "\n" not in challenge
+        assert challenge.count('"') == 2
+
+    def test_every_401_goes_through_the_challenge_helper(self) -> None:
+        """Guard: a future 401 added without the helper would silently drop the
+        challenge, so no other site in the module may return a bare 401."""
+        source = textwrap.dedent(inspect.getsource(remote_transport_module))
+        tree = ast.parse(source)
+        builder = "_unauthorized_response"
+        exempt: set[int] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and node.name == builder:
+                exempt.update(inner.lineno for inner in ast.walk(node) if isinstance(inner, ast.Return))
+        offenders: list[int] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Return) or not isinstance(node.value, ast.Tuple):
+                continue
+            elts = node.value.elts
+            if not elts:
+                continue
+            first = elts[0]
+            if isinstance(first, ast.Constant) and first.value == 401 and node.lineno not in exempt:
+                offenders.append(node.lineno)
+        assert exempt, f"{builder} not found; the guard below would pass vacuously"
+        assert offenders == [], (
+            f"401 returned as a literal tuple at lines {offenders}; build it with "
+            "_unauthorized_response so the WWW-Authenticate challenge is always attached"
+        )

--- a/tests/unit/test_seed.py
+++ b/tests/unit/test_seed.py
@@ -936,9 +936,7 @@ class TestParseSeedUnknownTopLevelKeys:
         messages = [r.getMessage() for r in caplog.records]
         assert any("zzqqxx" in m for m in messages)
 
-    def test_container_image_key_hints_sandbox_image(
-        self, seed_file: Path, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_container_image_key_hints_sandbox_image(self, seed_file: Path, caplog: pytest.LogCaptureFixture) -> None:
         """``container_image:`` has no top-level equivalent; the warning must
         point operators at ``sandbox.image`` instead of silently dropping the
         value (bug #3023)."""


### PR DESCRIPTION
## Problem

`src/bernstein/mcp/oauth.py` builds a correct RFC 9728 protected-resource
metadata document and `remote_transport.py` serves it under
`/.well-known/oauth-protected-resource` whenever
`BERNSTEIN_MCP_OAUTH_ISSUER` is set.

The unauthenticated path in `handle_request` returned `401` with a
content-type header and nothing else. Without a `WWW-Authenticate` header
naming the metadata URL, a connecting client has no path from the refusal
to that document. An operator who configures an issuer on a remote
deployment gets a discovery surface that is correct and unreachable, and
every client reports only "unauthorized".

## What an operator can do after this

Set `BERNSTEIN_MCP_OAUTH_ISSUER` on a remote deployment, point an MCP
client at `/mcp` with no credentials, and have the client locate the
protected-resource metadata from the 401 alone and start the
authorization flow against the configured IdP.

## Change

- Every 401 the transport emits is built in one place,
  `StreamableHTTPTransport._unauthorized_response`.
- When an issuer is configured that response carries
  `WWW-Authenticate: Bearer resource_metadata="<base>/.well-known/oauth-protected-resource"`.
- The URL comes from `_request_base_url`, the same base used to build the
  `resource` field inside the served document, so the advertised URL and
  the served path cannot drift.
- With no issuer configured no header is emitted; the anonymous and
  static-bearer flows are unchanged. The 401 body stays
  `{"error":"unauthorized"}` in both cases.
- The request authority is filtered to host and port characters before it
  is interpolated into a response. `Host` is client-supplied and now
  reaches a response header, so CR, LF, and the quote character are
  dropped rather than allowed to terminate the header value or escape the
  quoted parameter. `X-Forwarded-Proto` is normalised to `http` or
  `https` instead of being echoed verbatim into the metadata `resource`
  field.

## Tests

Written before the implementation, in
`tests/unit/test_mcp_remote_transport.py` and
`tests/unit/mcp/test_oauth_discovery.py`:

- the exact header value on a 401 with an issuer configured;
- the advertised URL is fetched back on the same transport and returns
  the served metadata document (status 200, matching `resource` and
  `authorization_servers`);
- no configured token, presented token, tenant, or user identifier
  appears in the header value;
- no header at all without an issuer, and the body is byte-identical
  with and without one;
- a `Host` carrying CR, LF, and a quote cannot break the header value;
- a source-level guard that fails if a future 401 is returned as a
  literal tuple instead of going through the shared builder.

Reverting only the two source files with the tests in place fails 8 of
them; restoring the source passes all 97 in the two files.

## Docs

`docs/mcp/server.md` gains the challenge header in the Auth section, the
refusal as step 0 of the discovery handshake, and a curl line that reads
the header off a 401.

## Verification

```
uv run pytest tests/unit/test_mcp_remote_transport.py -q      -> 83 passed
uv run pytest tests/unit/mcp/test_oauth_discovery.py -q       -> 14 passed
uv run pytest tests/unit/mcp/test_capability_card.py -q       ->  9 passed
uv run pytest tests/unit/protocols/mcp/test_stateless_migration.py -q -> 42 passed
uv run ruff check .                                           -> All checks passed
uv run bernstein agents-md verify                             -> OK, 13 files in sync
```

Refs #3075
