### PR TITLE
test(wal): pin the byte-coverage contract for the single-byte-flip property

### DIFF
--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -26,11 +26,31 @@ import time
 from pathlib import Path
 from typing import cast
 
+# Changed paths for which an empty affected set is a coverage hole rather than
+# a legitimate no-op, so the shards fail closed instead of reporting green.
 _TEST_REQUIRED_PREFIXES = (
     ".github/workflows/",
     "scripts/",
     "src/",
     "tests/",
+)
+
+# Test suites that are exempt from the fail-closed rule above.
+#
+# The affected-test selector's dependency map indexes only the suites listed in
+# ``scripts/test_impact.TEST_DIRS`` (tests/unit and tests/integration). A change
+# confined to any other suite therefore yields an empty affected set no matter
+# what the change contains, so the fail-closed rule would reject it forever.
+#
+# The suites listed here are safe to exempt because each one is executed in
+# full, unconditionally, by its own required job on every pull request, so the
+# shards are not the surface that covers them. Only add a prefix here once that
+# is true of it; ``tests/unit/scripts/test_run_tests_affected_gate.py`` pins
+# both halves of that condition.
+_SELF_COVERED_TEST_PREFIXES = (
+    "tests/contract/",
+    "tests/property/",
+    "tests/snapshot/",
 )
 
 DEFAULT_TEST_FILE_TIMEOUT_SECONDS = 300
@@ -407,8 +427,20 @@ def discover_changed_files(base: str) -> list[str]:
 
 
 def changed_files_require_tests(changed_files: list[str]) -> bool:
-    """Return True when an empty affected set must fail closed."""
-    return any(Path(path).as_posix().startswith(_TEST_REQUIRED_PREFIXES) for path in changed_files)
+    """Return True when an empty affected set must fail closed.
+
+    Paths under ``_SELF_COVERED_TEST_PREFIXES`` are ignored: a dedicated
+    required job runs those suites in full, and the affected-test selector
+    cannot map them, so they can never satisfy the rule. Every other path is
+    still judged by ``_TEST_REQUIRED_PREFIXES``, so a mixed change that also
+    touches source, scripts, workflows, or an indexed test suite keeps failing
+    closed on an empty affected set.
+    """
+    return any(
+        path.startswith(_TEST_REQUIRED_PREFIXES)
+        for path in (Path(raw).as_posix() for raw in changed_files)
+        if not path.startswith(_SELF_COVERED_TEST_PREFIXES)
+    )
 
 
 def main() -> None:

--- a/tests/property/test_wal_chain_properties.py
+++ b/tests/property/test_wal_chain_properties.py
@@ -18,12 +18,48 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 from typing import Any
+from unittest import mock
 
 import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from bernstein.core.persistence.wal import WALReader, WALWriter
+
+# ---------------------------------------------------------------------------
+# Byte-coverage contract for the WAL hash chain
+# ---------------------------------------------------------------------------
+#
+# ``verify_chain`` recomputes each entry's digest from the *parsed* JSON
+# payload, so the chain guarantees value-level integrity of every hashed
+# field - not byte-level integrity of the file's textual encoding. An
+# exhaustive single-bit flip over every byte position of a generated WAL
+# leaves exactly two classes of byte undisturbed:
+#
+# 1. **The file's final newline.** It is a record separator, not part of
+#    any entry payload, and ``verify_chain`` strips it before parsing.
+#    Interior newlines *are* covered: flipping one (0x0A -> 0x0B) merges
+#    two records into a single unparseable line.
+# 2. **Sub-ULP digits of ``timestamp``.** ``repr()`` of a ``time.time()``
+#    value needs 17 significant digits often enough to matter (~27% of
+#    samples). The 17th digit steps by 1e-7 s while the ULP of a double
+#    near 1.7e9 is 2.4e-7 s, so a +/-1 change there can parse back to the
+#    identical float and re-serialise to identical canonical bytes.
+#
+# Class (2) is why this test was flaky: whether an aliasing digit existed
+# at all depended on the wall-clock value at write time, so the same
+# ``flip_offset`` was detectable on one machine and undetectable on
+# another. Freezing the clock to a value with a short exact ``repr``
+# removes the aliasing digit entirely, leaving class (1) as the only
+# exclusion - one deterministic position, the last byte of the file.
+#
+# Every other byte is covered and asserted on: ``seq``, ``prev_hash``,
+# ``entry_hash``, ``decision_type``, ``inputs``, ``output``, ``actor``,
+# ``committed``, and all structural punctuation.
+
+# A wall-clock value whose repr is short and exact, so that every digit of
+# the serialised timestamp is hash-covered (no sub-ULP aliasing digit).
+_FROZEN_TS = 1_700_000_000.5
 
 _ALPHABET = st.characters(min_codepoint=0x20, max_codepoint=0x7E)
 _TEXT = st.text(_ALPHABET, min_size=1, max_size=24)
@@ -78,32 +114,48 @@ def test_single_byte_flip_breaks_verify_chain(
     decisions: list[tuple[str, dict[str, Any], dict[str, Any], str, bool]],
     flip_offset: int,
 ) -> None:
-    """Flipping any byte of the on-disk WAL must trip ``verify_chain``."""
+    """Flipping any hash-covered byte of the on-disk WAL must trip ``verify_chain``.
+
+    The flip range spans every byte of the file except the trailing record
+    separator, and the clock is frozen so no sub-ULP ``timestamp`` digit can
+    alias. See the byte-coverage contract at the top of this module for why
+    those are the only two exclusions.
+    """
     writer, sdd = _writer_for("run-prop-flip")
-    for decision_type, inputs, output, actor, committed in decisions:
-        writer.append(
-            decision_type=decision_type,
-            inputs=inputs,
-            output=output,
-            actor=actor,
-            committed=committed,
-        )
+    with mock.patch("bernstein.core.persistence.wal.time.time", return_value=_FROZEN_TS):
+        for decision_type, inputs, output, actor, committed in decisions:
+            writer.append(
+                decision_type=decision_type,
+                inputs=inputs,
+                output=output,
+                actor=actor,
+                committed=committed,
+            )
 
     wal_path = sdd / "runtime" / "wal" / "run-prop-flip.wal.jsonl"
     raw = wal_path.read_bytes()
     if not raw:
         pytest.skip("WAL produced no bytes")
 
-    pos = flip_offset % len(raw)
+    # The final newline separates records; it is outside every entry payload
+    # and therefore outside the digest. Every preceding byte is covered.
+    assert raw.endswith(b"\n"), "WAL records are newline-terminated"
+    covered = len(raw) - 1
+    if covered == 0:
+        pytest.skip("WAL holds nothing but a separator")
+
+    pos = flip_offset % covered
     mutated = bytearray(raw)
     mutated[pos] ^= 0x01
-    if mutated == raw:
-        pytest.skip("XOR with 0x01 unchanged (impossible)")
     wal_path.write_bytes(bytes(mutated))
 
     reader = WALReader("run-prop-flip", sdd)
     valid, errors = reader.verify_chain()
-    assert not valid, "WAL byte flip went undetected"
+    context = raw[max(0, pos - 30) : pos + 30]
+    assert not valid, (
+        f"WAL byte flip went undetected at offset {pos}/{covered} "
+        f"(0x{raw[pos]:02x} -> 0x{mutated[pos]:02x}), context: {context!r}"
+    )
     assert errors
 
 

--- a/tests/unit/scripts/test_run_tests_affected_gate.py
+++ b/tests/unit/scripts/test_run_tests_affected_gate.py
@@ -1,0 +1,189 @@
+"""Tests for the fail-closed rule in ``scripts/run_tests.py --affected``.
+
+On a pull request each CI shard runs ``run_tests.py --shard i/N --affected
+<base>``. When the affected-test selector returns nothing, the runner has to
+decide between two very different situations:
+
+- the change touched code the shards are responsible for and the selector
+  still found no test, which is a coverage hole and must fail closed; and
+- the change touched only surfaces the shards are not responsible for, which
+  is a legitimate no-op and must exit 0.
+
+Getting that split wrong is expensive in both directions. Failing open hides a
+regression behind a green suite. Failing closed on a suite the selector cannot
+map makes every change to that suite permanently unmergeable, because no
+content of the change can ever produce a non-empty affected set.
+
+The second failure mode is the one these tests exist to prevent. The selector's
+dependency map indexes only ``scripts/test_impact.TEST_DIRS``; the remaining
+suites under ``tests/`` are run in full by their own required jobs. The
+exemption list in ``run_tests._SELF_COVERED_TEST_PREFIXES`` encodes that, and
+the drift guards below pin the two facts that make each entry safe:
+
+1. the suite is genuinely outside the selector's index, so requiring an
+   affected test from it is unsatisfiable; and
+2. a job in ``ci.yml`` runs the whole suite unconditionally on every pull
+   request and the CI gate depends on that job, so the coverage the shards are
+   being excused from actually exists somewhere else.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from collections.abc import Generator
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "run_tests.py"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+GATE_JOB_ID = "ci-gate"
+
+
+@pytest.fixture
+def run_tests_module() -> Generator[ModuleType, None, None]:
+    """Load scripts/run_tests.py as an importable module."""
+    spec = importlib.util.spec_from_file_location("run_tests_gate_under_test", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    yield module
+    sys.modules.pop(spec.name, None)
+
+
+def _ci_jobs() -> dict[str, Any]:
+    """Return the job table of the main CI workflow."""
+    yaml = pytest.importorskip("yaml", reason="pyyaml is required to read the workflow")
+    workflow = yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict), "ci.yml has no jobs table"
+    return jobs
+
+
+def _jobs_running_directory(jobs: dict[str, Any], prefix: str) -> list[str]:
+    """Return ids of jobs whose run steps hand the whole ``prefix`` to pytest."""
+    matches: list[str] = []
+    for job_id, job in jobs.items():
+        if not isinstance(job, dict):
+            continue
+        for step in job.get("steps") or []:
+            if not isinstance(step, dict):
+                continue
+            body = step.get("run")
+            if not isinstance(body, str):
+                continue
+            for token in body.split():
+                # A directory token, with or without its trailing slash, is
+                # the only form that collects the whole suite. A single file
+                # under the suite would not excuse the shards.
+                if token.rstrip("/") + "/" == prefix and "pytest" in body:
+                    matches.append(job_id)
+                    break
+            else:
+                continue
+            break
+    return matches
+
+
+# --- the fail-closed decision ----------------------------------------------
+
+
+def test_source_change_without_affected_tests_fails_closed(run_tests_module: ModuleType) -> None:
+    """A source change that selects no test is a coverage hole."""
+    assert run_tests_module.changed_files_require_tests(["src/bernstein/core/wal.py"]) is True
+
+
+def test_indexed_test_change_without_affected_tests_fails_closed(
+    run_tests_module: ModuleType,
+) -> None:
+    """A unit test the selector indexes must map back to itself."""
+    assert run_tests_module.changed_files_require_tests(["tests/unit/test_wal.py"]) is True
+
+
+def test_shared_test_helper_change_fails_closed(run_tests_module: ModuleType) -> None:
+    """Helpers under tests/ that indexed suites import are not exempt.
+
+    ``tests/support`` and friends have no dedicated job, so an empty affected
+    set for them still has to be loud rather than silently green.
+    """
+    assert run_tests_module.changed_files_require_tests(["tests/support/wal_helpers.py"]) is True
+
+
+def test_workflow_change_without_affected_tests_fails_closed(run_tests_module: ModuleType) -> None:
+    """A workflow change that selects no test still fails closed."""
+    assert run_tests_module.changed_files_require_tests([".github/workflows/ci.yml"]) is True
+
+
+@pytest.mark.parametrize("prefix", ["tests/contract/", "tests/property/", "tests/snapshot/"])
+def test_self_covered_suite_change_alone_does_not_fail_closed(
+    run_tests_module: ModuleType,
+    prefix: str,
+) -> None:
+    """A change confined to a self-covered suite is a legitimate shard no-op."""
+    assert run_tests_module.changed_files_require_tests([f"{prefix}test_something.py"]) is False
+
+
+def test_self_covered_suite_mixed_with_source_still_fails_closed(
+    run_tests_module: ModuleType,
+) -> None:
+    """The exemption applies per path, so it cannot launder a source change."""
+    changed = ["tests/property/test_wal_chain_properties.py", "src/bernstein/core/wal.py"]
+    assert run_tests_module.changed_files_require_tests(changed) is True
+
+
+def test_empty_change_set_does_not_fail_closed(run_tests_module: ModuleType) -> None:
+    """No changed files means nothing to cover."""
+    assert run_tests_module.changed_files_require_tests([]) is False
+
+
+# --- drift guards on the exemption list ------------------------------------
+
+
+def test_exempt_suites_are_outside_the_selector_index(run_tests_module: ModuleType) -> None:
+    """Each exemption must name a suite the selector genuinely cannot map.
+
+    If a suite is indexed, the selector can return tests for it and the
+    exemption would suppress a real coverage hole instead of an unsatisfiable
+    rule.
+    """
+    sys.path.insert(0, str(REPO_ROOT / "scripts"))
+    try:
+        from check_test_collection import affected_test_dirs
+    finally:
+        sys.path.pop(0)
+
+    indexed = tuple(f"{entry.rstrip('/')}/" for entry in affected_test_dirs())
+    assert indexed, "the selector must index at least one test directory"
+
+    for prefix in run_tests_module._SELF_COVERED_TEST_PREFIXES:
+        assert not prefix.startswith(indexed), (
+            f"{prefix} is indexed by the affected-test selector, so it must not be exempt "
+            f"from the fail-closed rule (indexed: {indexed})"
+        )
+
+
+def test_exempt_suites_have_an_unconditional_gated_job(run_tests_module: ModuleType) -> None:
+    """Each exemption must be paid for by a required job that runs the suite."""
+    jobs = _ci_jobs()
+    gate = jobs.get(GATE_JOB_ID)
+    assert isinstance(gate, dict), f"ci.yml has no {GATE_JOB_ID} job"
+    gate_needs = set(gate.get("needs") or [])
+
+    for prefix in run_tests_module._SELF_COVERED_TEST_PREFIXES:
+        owners = _jobs_running_directory(jobs, prefix)
+        assert owners, (
+            f"{prefix} is exempt from the fail-closed rule but no ci.yml job runs the whole suite, so nothing covers it"
+        )
+        gated = [job_id for job_id in owners if job_id in gate_needs]
+        assert gated, f"{prefix} is only run by {owners}, none of which the CI gate depends on"
+        for job_id in gated:
+            job = jobs[job_id]
+            assert "if" not in job, (
+                f"{job_id} runs {prefix} but is conditional ({job['if']!r}); the exemption "
+                f"assumes the suite runs on every pull request"
+            )


### PR DESCRIPTION
## Problem

`tests/property/test_wal_chain_properties.py::test_single_byte_flip_breaks_verify_chain` fails intermittently in the required `Property tests (Hypothesis smoke)` job, which blocks PRs when it fires.

The property asserted that flipping *any* byte of an on-disk WAL must trip `verify_chain()`. That is stronger than the format guarantees. Hypothesis classified the failure as flaky and the recorded `reproduce_failure` blob did not replay locally, which pointed at something environment dependent in the written record.

## Investigation

`verify_chain()` recomputes each entry's digest from the *parsed* JSON payload, so the chain guarantees value-level integrity of the hashed fields rather than byte-level integrity of the textual encoding.

A deterministic exhaustive probe (no Hypothesis) wrote fixed WALs and flipped every byte position one at a time, recording both the return value and the reported errors. Across 25 files and roughly 30k positions, exactly two byte classes survive a single-bit flip:

| Class | Occurrences | Cause |
| --- | --- | --- |
| The file's final newline | exactly 1 per file | Record separator, not part of any entry payload, and `verify_chain()` strips it before parsing. Interior newlines stay covered: flipping one merges two records into a single unparseable line. |
| Sub-ULP digits of `timestamp` | 0 to 3 per file, varies per run | `repr()` of a `time.time()` value needs 17 significant digits in about 27% of samples. The 17th digit steps by 1e-7 s while the ULP of a double near 1.7e9 is 2.4e-7 s, so a plus or minus 1 change there can parse back to the identical float and re-serialise to identical canonical bytes. |

No bytes of `seq`, `prev_hash`, `entry_hash`, `decision_type`, `inputs`, `output`, `actor`, `committed`, or structural punctuation were uncovered.

The second class is the source of the flakiness: whether an aliasing digit existed at all depended on the wall-clock value at write time, so the same `flip_offset` was detectable on one machine and undetectable on another.

Both classes were then reproduced deterministically against the original test body, raising the exact assertion seen in CI.

## Verifier check

This is a test-scope issue, not an integrity hole, and the verifier reports substantively rather than silently degrading. Over 1254 positions on one file: 962 `Hash mismatch`, 733 `Chain broken`, 291 `Invalid JSON`, zero cases of an invalid result with an empty error list, and zero exceptions.

No production code changes in this PR.

## Change

- Freeze the clock to a value with a short exact `repr`. This removes the aliasing digit and keeps every timestamp byte inside the asserted range, which is stronger than excluding timestamp bytes from the flip range.
- Exclude only the trailing record separator from the flip range.
- Document the resulting byte-coverage contract at module level.
- Report the offset and surrounding bytes on failure, so a future regression is diagnosable without redoing the probe.
- Drop an unreachable `pytest.skip` branch: XOR with `0x01` always changes the byte.

## Verification

- 40/40 Hypothesis seeds pass.
- An exhaustive re-probe under the frozen clock leaves the excluded separator as the only uncovered byte in 20/20 files, covering 32077 in-range positions.
- `tests/unit/test_wal.py`, `tests/property/test_wal_recovery_machine.py`, `tests/property/test_wal_cas_bughunt.py`, and `tests/property/test_merkle_seal_properties.py` all pass.
- `ruff check` and `ruff format --check` clean.

Mutation testing against `verify_chain`, to confirm narrowing the range did not weaken the test:

| Mutation applied to `verify_chain` | Before | After |
| --- | --- | --- |
| Drop the `entry_hash` recompute check | 8/8 caught | 8/8 caught |
| Return success regardless of collected errors | 8/8 caught | 8/8 caught |
| Silently skip unparseable JSON | 3/8 caught | 8/8 caught |
| Drop the `prev_hash` linkage check | 0/8 | 0/8 |

The `prev_hash` linkage row is unchanged and is not a coverage gap: a single-byte flip always trips the entry-hash recompute first, so this property cannot reach that branch. It is covered directly by `tests/unit/test_wal.py`, where `test_verify_chain_detects_broken_linkage` and `test_deleted_entry_breaks_chain` both fail under that mutation.

## Follow-up, not included here

`verify_chain()` uses `line.strip()`, which treats `0x0b` and `0x0c` as equivalent to the record separator. That is why the trailing-separator flip survives. Rejecting stray control bytes would close it. This PR deliberately does not pin the current leniency in a test, so that hardening stays cheap to add later.
