### PR TITLE
fix(action): plan mode passed an option `bernstein run` does not declare

### DIFF
--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -250,7 +250,14 @@ run_plan() {
     fi
 
     local status="${STATUS_SUCCESS}"
-    bernstein run "$PLAN" --budget "$BUDGET" --headless || status="${STATUS_FAILURE}"
+    # `--headless` is declared on the root `bernstein` group, not on the `run`
+    # subcommand, so passing it here made Click exit 2 at option parsing and
+    # plan mode never started. `--quiet` is the option `run` actually declares
+    # for this purpose, and it is the one this step needs: it waits for the run
+    # to reach a terminal state instead of detaching. Without that wait the
+    # `|| status=` capture below reports the exit code of a launch rather than
+    # of a run, and the run summary is read before it has been written.
+    bernstein run "$PLAN" --budget "$BUDGET" --quiet || status="${STATUS_FAILURE}"
 
     gha_endgroup
 

--- a/docs/integrations/github-action.md
+++ b/docs/integrations/github-action.md
@@ -43,6 +43,26 @@ When `task` is the literal string `"fix-ci"`, the action:
 This mode is designed for `workflow_run` triggers so it can react to CI
 failures from another workflow.
 
+### Plan mode (`plan: <path>`)
+
+When `plan` is set instead of `task`, the action runs:
+
+```
+bernstein run <plan> --budget <budget> --quiet
+```
+
+`--quiet` is what makes this mode usable in CI. The `run` subcommand renders
+a dashboard on a TTY and otherwise detaches, leaving the run going in the
+background; `--quiet` instead waits for the run to reach a terminal state and
+prints only the final summary. The step therefore blocks until the run really
+finishes, its exit code reflects the run's outcome rather than whether the
+launch succeeded, and `.sdd/run-summary.json` exists by the time the step
+reads it for the `tasks-completed` and `total-cost` outputs.
+
+Note that `--headless` is an option of the root `bernstein` group, not of
+`bernstein run`. Passing it after the `run` subcommand makes the CLI exit 2
+at option parsing without starting anything.
+
 ### Normal mode
 
 When `task` is anything other than `"fix-ci"`, the action runs:

--- a/tests/unit/test_shipped_shell_cli_invocations.py
+++ b/tests/unit/test_shipped_shell_cli_invocations.py
@@ -1,0 +1,213 @@
+"""Every ``bernstein`` invocation in a shipped shell script must parse.
+
+Companion to ``test_shipped_compose_cli_commands.py``, which guards the
+subcommand names in shipped compose files. That guard stops at the first
+token starting with ``-``, so an invocation naming a real subcommand with an
+option that subcommand does not declare is invisible to it. Click rejects an
+unknown option before running anything, so such a line is a hard exit 2 that
+no amount of runtime robustness recovers from.
+
+This is the shape that hit ``action/entrypoint.sh``: the GitHub Action's plan
+mode ran ``bernstein run <plan> --budget <n> --headless``, but ``--headless``
+is declared on the root ``bernstein`` group, not on the ``run`` subcommand.
+Every plan-mode run of the published Action failed at option parsing with
+"No such option: --headless" and never started.
+
+Both the command path and every option are resolved against the real Click
+tree in ``bernstein.cli.main``, so renaming or moving an option fails here
+rather than in an operator's CI.
+"""
+
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+
+import pytest
+from click.core import Command, Group, Parameter
+
+from bernstein.cli.main import cli
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Directories that never hold a shipped operator-facing shell script.
+_EXCLUDED_DIRS = frozenset({".git", ".venv", "venv", "node_modules", ".tox", ".mypy_cache", "dist", "build"})
+
+# Shell control operators. Everything from the first one of these onward
+# belongs to a different command, so token scanning stops there.
+_SHELL_OPERATORS = frozenset({"|", "||", "&&", ";", ";;", "&", ">", ">>", "<", "(", ")", "{", "}", "#"})
+
+# Tokens that may precede a command word in the shell forms this repo uses.
+_COMMAND_PREFIXES = frozenset({"if", "then", "else", "elif", "do", "while", "until", "!", "$(", "time"})
+
+
+def _option_map(command: Command) -> dict[str, Parameter]:
+    """Map every option string this command accepts to its parameter."""
+    mapping: dict[str, Parameter] = {}
+    for param in command.params:
+        for opt in (*param.opts, *param.secondary_opts):
+            if opt.startswith("-"):
+                mapping[opt] = param
+    return mapping
+
+
+def _takes_a_value(param: Parameter) -> bool:
+    """True when the next token is this option's value rather than a word.
+
+    A flag consumes nothing, so the token after it is the next word. A
+    value-taking option swallows the token after it, which must therefore not
+    be mistaken for a subcommand name.
+    """
+    return not getattr(param, "is_flag", False) and getattr(param, "nargs", 1) != 0
+
+
+def _bernstein_argv_lines(path: Path) -> list[tuple[int, list[str]]]:
+    """Return ``(line_number, argv_after_the_binary)`` for each invocation.
+
+    Only ``bernstein`` in *command* position counts. A mention inside an
+    ``echo`` string or a comment is documentation, not something the shell
+    will execute, and this repo has several of both.
+    """
+    found: list[tuple[int, list[str]]] = []
+    for lineno, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        try:
+            # `punctuation_chars` keeps `;`, `&&`, `||`, `|`, `<`, `>` as
+            # separate tokens. Plain `shlex.split` would hand back
+            # `--headless;` from `... --headless; then`, which reads as an
+            # unknown option and would report a defect that is not there.
+            lexer = shlex.shlex(line, posix=True, punctuation_chars=True)
+            lexer.whitespace_split = True
+            tokens = list(lexer)
+        except ValueError:
+            # Unbalanced quotes across a line continuation: not parseable in
+            # isolation, and not a shape this repo's scripts use for the CLI.
+            continue
+        for index, token in enumerate(tokens):
+            if token != "bernstein":
+                continue
+            if index > 0 and tokens[index - 1] not in _COMMAND_PREFIXES | _SHELL_OPERATORS:
+                continue  # not in command position (e.g. an echoed word)
+            argv: list[str] = []
+            for candidate in tokens[index + 1 :]:
+                if candidate in _SHELL_OPERATORS or candidate.startswith(("|", "&", ";", ">", "2>")):
+                    break
+                argv.append(candidate)
+            found.append((lineno, argv))
+            break
+    return found
+
+
+def _resolve(argv: list[str]) -> tuple[bool, str]:
+    """Walk one invocation against the real Click tree.
+
+    Returns ``(ok, detail)``. Options are checked against whichever command
+    is current at that point, since an option declared on the root group is
+    not accepted after a subcommand name and vice versa - which is exactly
+    the defect this guard exists for.
+    """
+    current: Command = cli
+    options = _option_map(current)
+    path_parts: list[str] = []
+    skip_next = False
+
+    for token in argv:
+        if skip_next:
+            skip_next = False
+            continue
+        if token.startswith("-"):
+            name = token.split("=", 1)[0]
+            if name == "--":
+                break
+            param = options.get(name)
+            if param is None:
+                where = f"bernstein {' '.join(path_parts)}".strip()
+                return False, f"`{where}` does not accept the option `{name}`"
+            if "=" not in token and _takes_a_value(param):
+                skip_next = True
+            continue
+        if isinstance(current, Group) and token in current.commands:
+            current = current.commands[token]
+            options = _option_map(current)
+            path_parts.append(token)
+            continue
+        # A bare token that is not a subcommand is a positional argument (a
+        # plan file, a goal). Options after it still belong to `current`.
+        if isinstance(current, Group) and not path_parts and not current.params:
+            return False, f"`bernstein {token}` is not a registered CLI command"
+    return True, f"`bernstein {' '.join(path_parts)}`".strip()
+
+
+def _discover_shell_scripts() -> list[Path]:
+    """Find every shell script in the repo that invokes the bernstein CLI.
+
+    Discovered rather than hand-listed, for the same reason as the compose
+    guard: a fixed list quietly stops covering scripts added later.
+    """
+    found: list[Path] = []
+    for path in sorted(REPO_ROOT.rglob("*.sh")):
+        if not _EXCLUDED_DIRS.isdisjoint(path.relative_to(REPO_ROOT).parts):
+            continue
+        if _bernstein_argv_lines(path):
+            found.append(path)
+    return found
+
+
+SHELL_SCRIPTS: list[Path] = _discover_shell_scripts()
+
+assert SHELL_SCRIPTS, f"no shell scripts invoking the bernstein CLI were discovered under {REPO_ROOT}"
+
+
+@pytest.mark.parametrize(
+    "script",
+    SHELL_SCRIPTS,
+    ids=[str(p.relative_to(REPO_ROOT)) for p in SHELL_SCRIPTS],
+)
+def test_shipped_shell_invocations_parse_against_the_real_cli(script: Path) -> None:
+    """Every command and option in the script exists on the CLI it targets."""
+    failures: list[str] = []
+    for lineno, argv in _bernstein_argv_lines(script):
+        ok, detail = _resolve(argv)
+        if not ok:
+            failures.append(f"{script.relative_to(REPO_ROOT)}:{lineno}: {detail}")
+    assert not failures, (
+        "shipped shell script invokes the bernstein CLI in a way Click rejects "
+        "before running anything (exit 2):\n  " + "\n  ".join(failures) + "\n"
+        "Cross-check the option against `bernstein <subcommand> --help`; an "
+        "option on the root group is not accepted after a subcommand name."
+    )
+
+
+def test_the_action_entrypoint_is_actually_covered() -> None:
+    """The extractor must find the Action's own invocations.
+
+    A regex that quietly matches nothing would make every case above pass
+    without checking anything, so pin the file this guard exists for and the
+    number of executable invocations it contains.
+    """
+    entrypoint = REPO_ROOT / "action" / "entrypoint.sh"
+    assert entrypoint in SHELL_SCRIPTS, "action/entrypoint.sh was not discovered by the scanner"
+    invocations = _bernstein_argv_lines(entrypoint)
+    assert len(invocations) == 3, (
+        f"expected the 3 executable bernstein invocations in {entrypoint.name}, found {len(invocations)}"
+    )
+    assert any(argv[:1] == ["run"] for _, argv in invocations), "plan mode's `bernstein run` invocation was not found"
+
+
+def test_the_resolver_rejects_an_option_from_the_wrong_command() -> None:
+    """Control: the check has teeth in both directions.
+
+    ``--headless`` is real, but only on the root group. Accepting it after a
+    subcommand name is precisely the bug, so a resolver that merged the two
+    option sets would pass the suite while shipping a broken Action.
+    """
+    ok, _ = _resolve(["-g", "some goal", "--budget", "2.00", "--headless"])
+    assert ok, "--headless is declared on the root group and must resolve there"
+
+    ok, detail = _resolve(["run", "plan.yaml", "--budget", "2.00", "--headless"])
+    assert not ok and "--headless" in detail, "an option not declared on `run` must be rejected after `run`"
+
+    ok, detail = _resolve(["run", "plan.yaml", "--budget", "2.00", "--quiet"])
+    assert ok, f"--quiet is declared on `run` and must resolve there, got: {detail}"


### PR DESCRIPTION
## What was red

`Adapter conformance + e2e (windows) (3.13)` is a required job in the ci-gate needs list, so main's gate cannot go green while it fails:

```
tests/integration/test_adapter_conformance_lifecycle.py::test_adapter_stop_terminates_a_hung_spawn[claude]
AssertionError: assert False
  where False = ProcessReapReceipt(pgid=6300, os_name='windows',
                                   method='windows_process_tree', delivered=False, escalated=False)
```

## Why

The reap reported one boolean, `delivered`, and the test read it as "the tree is no longer running". Those are different outcomes. `reap_process_group` bails out at

```python
if not kill_process_group(pgid, signal.SIGTERM):
    return _receipt(delivered=False, escalated=False)
```

whenever the Windows stop primitive returns False, and that primitive returns False both when a stop genuinely could not be delivered and when there was nothing left to stop. A tree that has already exited accepts no stop, so `delivered` is False while the guarantee the reap exists to provide holds perfectly. The Windows runner recycles pids fast enough for that to be routine rather than exotic: the failing job logged 152 `pid reused` warnings from its own process monitor.

The same code was also unsafe. The Windows fallback shelled out to `Stop-Process -Id <pid> -Force` on a bare pid, and it did so precisely when the pid was most likely to have been recycled, because `taskkill` had just reported the number missing. On a recycled pid that force-kills an unrelated process on the runner or on a user machine. It then decided the outcome by re-probing liveness immediately after an asynchronous `TerminateProcess`, which is a race even when the pid is the right one.

## What changed

**The receipt reports the guarantee, not just the delivery.** `ProcessReapReceipt` gains `already_gone` (the tree had exited before any stop tier ran) and `confirmed_dead` (the tree is verified not running once the reap returned). `delivered` keeps its existing meaning. Both new fields are mirrored into the `process.reap_receipt` audit event, so "we stopped it" and "it had already stopped" stay distinguishable to a verifier reading the chain offline instead of collapsing into one ambiguous False.

**The Windows path stops acting on bare pids.** The reap opens a handle to the target before any tier runs. While a handle to a process object is open the kernel will not reuse that pid, so for the whole reap window the number either names the process we were asked to reap or names nothing. On top of that the pin reads the target's creation time and refuses a process that started after the reap was requested, which covers a recycle that lands before the pin is taken. The terminate fallback goes through the handle instead of re-resolving the number, and the exit is confirmed by waiting on the handle rather than racing the probe. A pid that resolves to nothing is now reported, never signalled.

**Linux and macOS are unchanged.** The pin is inert on POSIX: a process group id is not recycled while the group still has members, so the guard has nothing to add. The reap still issues exactly TERM, then signal-0 probes, then KILL, and a new test pins that sequence so it stays that way.

One POSIX detail surfaced while verifying: macOS returns EPERM, not ESRCH, for a signal aimed at a group whose only remaining members are zombies, so a fully reaped group keeps looking alive to `killpg(pgid, 0)` until its parent gets round to `wait()`. `confirmed_dead` therefore treats a delivered SIGKILL as the confirmation, which is sound because SIGKILL cannot be caught, blocked, or ignored.

**The test asserts the real guarantee.** It now requires `confirmed_dead`, accepts either "a stop was delivered" or "it had already exited", and confirms the outcome against the process itself rather than against the receipt that just claimed it.

## Verification

Everything below ran on macOS; the Windows-only branches are covered by the mocked-kernel32 tests this repo already uses for Windows behaviour, including a whole-reap replay of the exact conformance scenario (a hung console process that `taskkill` refuses to stop without `/F`).

| Suite | Result |
|---|---|
| `tests/integration/test_adapter_conformance_lifecycle.py` | 9 passed |
| `tests/unit/test_platform_win_process_branch.py` | 31 passed |
| `tests/unit/test_platform_process_tree.py` | 30 passed |
| `tests/unit/test_conformance_windows_projection.py` | 15 passed |
| `tests/unit/test_audit_chain_process_reap.py` | 6 passed |
| `tests/unit/test_adapter_contract.py` | 563 passed |
| `tests/unit/test_adapter_claude.py`, `test_platform_compat.py`, `test_hard_stop_group_reap.py`, `test_cross_platform_ci.py`, `test_heartbeat_escalation.py`, `test_heartbeat_terminal_escalation.py`, `test_worker_cmd_reporting.py`, `test_worktree_isolation_windows.py` | all passed |
| `ruff check` / `ruff format --check` / `lint-imports` | clean |
| `mypy` on the changed module | same 3 pre-existing errors as on main, no new ones |

The tests were checked against deliberate breakage rather than assumed to be load-bearing. Four mutations, each reverted:

| Mutation | Detected by |
|---|---|
| Reap never signals anything and claims success | conformance test, all 3 adapters: `worker still alive after platform reap` |
| Restore the old conflation (undeliverable stop reported as failure without checking whether the target was gone) | `test_undeliverable_term_against_an_exited_target_is_success`, `test_posix_already_exited_group_reports_the_guarantee` |
| Remove the creation-time pid-reuse guard | `test_process_started_after_the_request_is_not_the_target`, `test_recycled_pid_is_not_handed_to_taskkill` |
| Remove the pinned-handle terminate fallback | `test_hung_console_spawn_is_reaped_and_confirmed` plus 2 others |

### POSIX sequence, checked against main

The "Linux and macOS unchanged" claim was measured, not asserted. Both implementations were loaded side by side and driven through the same mocked `killpg`:

| Scenario | main | this branch |
|---|---|---|
| group never exits | TERM, liveness probes, KILL, `(delivered, escalated) = (True, True)` | identical |
| group exits after TERM | TERM, liveness probes, `(True, False)` | identical |
| TERM undeliverable | TERM, `(False, False)` | TERM plus one signal-0 probe, `(False, False)` |

The only difference is one extra read-only liveness probe on the undeliverable path. It sends no signal and changes neither `delivered` nor `escalated`; it is what makes `already_gone` and `confirmed_dead` truthful instead of guessed.

## Not executed locally

No Windows host is available here, so the real `taskkill` / kernel32 behaviour was not exercised end to end. The Windows CI lane on this PR is the first real execution of the new path.
