### PR TITLE
fix(mcp): advertise the enforced tool schema as the tool inputSchema

### DIFF
--- a/docs/mcp/input-validation.md
+++ b/docs/mcp/input-validation.md
@@ -50,11 +50,41 @@ The bundled server ships schemas for the core tool set:
 `bernstein_task_handle`, `bernstein_cost`, `bernstein_stop`,
 `bernstein_approve`, `bernstein_create_subtask`, `bernstein_claim`,
 `bernstein_update`, `load_skill`, `bernstein_context`,
-`bernstein_post_artifact`, and the scenario-bridge tools
+`bernstein_post_artifact`, `verify_chain`, and the scenario-bridge tools
 `bernstein_scenario`, `bernstein_scenario_status`, `bernstein_scenarios`.
 Adding a new MCP tool means adding its schema file alongside these; a tool
 with no schema file is unreachable (unknown-tool rejection), which is the
 point of deny-by-default.
+
+## One schema per tool, not two
+
+The schema file is also the schema advertised to clients. After tool
+registration, `_apply_advertised_schemas()` in
+`src/bernstein/mcp/server.py` replaces each tool's `inputSchema` with the
+schema `validate_tool_call` enforces, so a caller sees
+`scope: enum [small, medium, large]` rather than the bare `scope: string`
+FastMCP derives from the Python signature. Without this, every constrained
+argument is a guaranteed first-call failure: the caller sends a plausible
+value and gets a rejection it had no way to predict.
+
+Consequences worth knowing:
+
+- `bernstein_post_artifact` advertises its `allOf` conditional, so a client
+  can see that a `report` needs `body`, a `table` needs `columns` and
+  `rows`, and a `link` needs `url` and `link_kind`. A handler argument left
+  at its empty-string default counts as "not supplied" and is not validated
+  as if the caller had sent it.
+- Only the advertised copy is replaced. Argument coercion still runs through
+  FastMCP's signature-derived model, and enforcement still runs through
+  `validate_tool_call` inside each handler.
+- The advertised schema is a deep copy, so a client-side mutation cannot
+  reach the process-wide registry the validator reads.
+
+`tests/unit/mcp/test_advertised_schema_parity.py` is the drift guard. It
+asserts, per tool, that the advertised and enforced schemas agree on every
+constrained field, and that the set of schema file stems equals the set of
+registered tool names in both directions. Tightening enforcement without
+updating what is advertised fails the build.
 
 ## Permissive mode (migration aid)
 
@@ -85,6 +115,9 @@ rejection is enforced.
 ## Source
 
 `src/bernstein/mcp/input_validation.py` (validator, deny rules, schema
-registry); `src/bernstein/mcp/tool_schemas/*.json` (per-tool schemas); wired
-into request handling in `src/bernstein/mcp/server.py`
-(`_validate_or_error`).
+registry, the shared `validate_or_error` / `validation_error_response`
+handler helpers); `src/bernstein/mcp/tool_schemas/*.json` (per-tool
+schemas); wired into request handling in `src/bernstein/mcp/server.py`
+(`_validate_or_error`) and advertised from the same files by
+`_apply_advertised_schemas`. `verify_chain` validates in
+`src/bernstein/mcp/resources/lineage.py`.

--- a/docs/reference/FEATURE_MATRIX.md
+++ b/docs/reference/FEATURE_MATRIX.md
@@ -153,7 +153,7 @@ additionally holds the CLI's server calls to the registered route table.
 | [MCP server mode](../mcp/server.md) | Full | `bernstein mcp`, MCP server in `mcp/server.py` |
 | [MCP tool registry](../integrations/mcp-server-injection.md) | Full | Auto-discovery and per-task config |
 | [MCP catalog client](mcp-catalog.md) | Full | `bernstein mcp catalog browse/search/install` installable server catalog (`core/protocols/mcp_catalog/`) |
-| [MCP input contracts](../mcp/input-validation.md) | Full | Schema-validated, deny-by-default MCP tool-call input firewall (`mcp/input_validation.py`) |
+| [MCP input contracts](../mcp/input-validation.md) | Full | Schema-validated, deny-by-default MCP tool-call input firewall (`mcp/input_validation.py`); the enforced schema is also the advertised `inputSchema` |
 | [Stateless MCP anchoring](../mcp/server.md) | Full | A stateless MCP client can poll a run and verify it offline; calls anchor as `mcp.stateless_call` journal entries (`core/protocols/mcp/stateless_core.py`) |
 | [Runtime capability cards (MCP)](../mcp/server.md) | Full | Per-server capability cards for the MCP server (`mcp/capability.py`) |
 | ACP native bridge | Full | `bernstein acp serve --stdio\|--http :PORT` IDE-native bridge (`core/protocols/acp/`); see `reference/acp-bridge.md` |

--- a/src/bernstein/mcp/input_validation.py
+++ b/src/bernstein/mcp/input_validation.py
@@ -463,6 +463,33 @@ def _maybe_demote(
     return ValidatedPayload(tool_name=err.tool_name, payload={})
 
 
+def validate_or_error(tool_name: str, params: dict[str, Any]) -> ValidationError | None:
+    """Validate ``params`` against ``tool_name``'s schema, for tool handlers.
+
+    Returns ``None`` when the call is allowed, or a ``ValidationError`` the
+    caller should render via :func:`validation_error_response`. ``None``
+    values are stripped first, which keeps every tool's optional-argument
+    convention working: a Python default of ``None`` means "argument not
+    supplied", not "argument supplied as null". A schema can still mark a
+    property nullable when accepting an explicit null is the contract.
+    """
+    cleaned = {k: v for k, v in params.items() if v is not None}
+    result = validate_tool_call(tool_name, cleaned)
+    if isinstance(result, ValidatedPayload):
+        return None
+    return result
+
+
+def validation_error_response(err: ValidationError) -> str:
+    """Render a validation failure as the JSON string an MCP tool returns.
+
+    Carries the full structured error so MCP clients can show users which
+    field failed and why, without leaking server internals.
+    """
+    payload = {"error": err.message, "jsonrpc_error": to_jsonrpc_error(err)}
+    return json.dumps(payload)
+
+
 def to_jsonrpc_error(err: ValidationError) -> dict[str, Any]:
     """Render a ``ValidationError`` as a JSON-RPC 2.0 ``error`` object.
 

--- a/src/bernstein/mcp/resources/lineage.py
+++ b/src/bernstein/mcp/resources/lineage.py
@@ -30,6 +30,7 @@ from mcp.server.fastmcp.resources.templates import ResourceTemplate
 
 from bernstein.core.lineage.entry import canonicalise, entry_hash
 from bernstein.core.lineage.store import LineageStore
+from bernstein.mcp.input_validation import validate_or_error, validation_error_response
 
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
@@ -141,6 +142,9 @@ def register_lineage_resources(
         description="Verify the lineage chain of a single artefact path.",
     )
     def verify_chain(artefact_path: str) -> str:  # pyright: ignore[reportUnusedFunction]
+        err = validate_or_error("verify_chain", {"artefact_path": artefact_path})
+        if err is not None:
+            return validation_error_response(err)
         store = LineageStore(root)
         ok, reason = _verify_chain(store, artefact_path)
         return json.dumps({"ok": ok, "reason": reason})

--- a/src/bernstein/mcp/routine_tools.py
+++ b/src/bernstein/mcp/routine_tools.py
@@ -27,10 +27,9 @@ from bernstein.core.planning.scenario_library import (
     load_scenario_library,
 )
 from bernstein.mcp.input_validation import (
-    ValidatedPayload,
     ValidationError,
-    to_jsonrpc_error,
-    validate_tool_call,
+    validate_or_error,
+    validation_error_response,
 )
 
 if TYPE_CHECKING:
@@ -240,16 +239,12 @@ def _error_response(exc: Exception) -> str:
 
 def _validation_error_response(err: ValidationError) -> str:
     """Render a validation failure as the JSON string FastMCP tools return."""
-    return json.dumps({"error": err.message, "jsonrpc_error": to_jsonrpc_error(err)})
+    return validation_error_response(err)
 
 
 def _validate_or_error(tool_name: str, params: dict[str, Any]) -> ValidationError | None:
     """Run schema validation, returning the failure or ``None``."""
-    cleaned = {k: v for k, v in params.items() if v is not None}
-    result = validate_tool_call(tool_name, cleaned)
-    if isinstance(result, ValidatedPayload):
-        return None
-    return result
+    return validate_or_error(tool_name, params)
 
 
 def register_scenario_tools(mcp: FastMCP[None], server_url: str) -> None:

--- a/src/bernstein/mcp/server.py
+++ b/src/bernstein/mcp/server.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import base64
 import binascii
+import copy
 import json
 import logging
 import os
@@ -57,10 +58,10 @@ from bernstein.core.protocols.mcp.tool_tiers import (
 )
 from bernstein.mcp.cost_meter import measure_call, wrap_envelope
 from bernstein.mcp.input_validation import (
-    ValidatedPayload,
     ValidationError,
-    to_jsonrpc_error,
-    validate_tool_call,
+    get_registry,
+    validate_or_error,
+    validation_error_response,
 )
 
 _orig_convert_result = FuncMetadata.convert_result
@@ -128,29 +129,13 @@ def _error_response(exc: Exception, *, hint: str = "Task server may be restartin
 
 
 def _validation_error_response(err: ValidationError) -> str:
-    """Render a validation failure as the JSON string FastMCP tools return.
-
-    Carries the full structured error so MCP clients can show users which
-    field failed and why, without leaking server internals.
-    """
-    payload = {"error": err.message, "jsonrpc_error": to_jsonrpc_error(err)}
-    return json.dumps(payload)
+    """Render a validation failure as the JSON string FastMCP tools return."""
+    return validation_error_response(err)
 
 
 def _validate_or_error(tool_name: str, params: dict[str, Any]) -> ValidationError | None:
-    """Validate ``params`` against ``tool_name``'s schema.
-
-    Returns ``None`` when the call is allowed, or a ``ValidationError`` the
-    caller should render via :func:`_validation_error_response`. Stripping
-    ``None`` values from the params dict keeps every tool's optional-arg
-    convention working; the schema can still mark them as nullable when
-    that's the intended contract.
-    """
-    cleaned = {k: v for k, v in params.items() if v is not None}
-    result = validate_tool_call(tool_name, cleaned)
-    if isinstance(result, ValidatedPayload):
-        return None
-    return result
+    """Validate ``params`` against ``tool_name``'s schema."""
+    return validate_or_error(tool_name, params)
 
 
 def _register_health_tool(mcp: FastMCP[None]) -> None:
@@ -759,38 +744,33 @@ def _register_action_tools(mcp: FastMCP[None], server_url: str) -> None:
             JSON of the chain-anchored artifact record (``key``, ``version``,
             ``content_hash``, ``spine_entry_hash``, ``journal_index``, ...).
         """
-        err = _validate_or_error(
-            "bernstein_post_artifact",
-            {
-                "task_id": task_id,
-                "key": key,
-                "artifact_type": artifact_type,
-                "poster": poster,
-                "body": body,
-                "columns": columns,
-                "rows": rows,
-                "url": url,
-                "link_kind": link_kind,
-            },
-        )
+        # An argument left at its empty-string default means "not supplied for
+        # this artifact type", so it must not reach the validator: the schema
+        # constrains ``body`` / ``url`` / ``link_kind`` to the values a caller
+        # that actually supplies them would send. Validate exactly the fields
+        # that get posted, so the conditional shape advertised to the caller is
+        # the shape the call is judged against.
+        args: dict[str, Any] = {
+            "task_id": task_id,
+            "key": key,
+            "artifact_type": artifact_type,
+            "poster": poster,
+        }
+        if body:
+            args["body"] = body
+        if columns is not None:
+            args["columns"] = columns
+        if rows is not None:
+            args["rows"] = rows
+        if url:
+            args["url"] = url
+        if link_kind:
+            args["link_kind"] = link_kind
+        err = _validate_or_error("bernstein_post_artifact", args)
         if err is not None:
             return _validation_error_response(err)
         try:
-            payload: dict[str, Any] = {
-                "key": key,
-                "artifact_type": artifact_type,
-                "poster": poster,
-            }
-            if body:
-                payload["body"] = body
-            if columns is not None:
-                payload["columns"] = columns
-            if rows is not None:
-                payload["rows"] = rows
-            if url:
-                payload["url"] = url
-            if link_kind:
-                payload["link_kind"] = link_kind
+            payload: dict[str, Any] = {k: v for k, v in args.items() if k != "task_id"}
             # Carry the caller identity in the request header (the server's
             # authorization principal), not only in the body. The server refuses
             # posts against a task this identity does not hold the claim for.
@@ -1057,6 +1037,41 @@ def _apply_cost_meter(mcp: FastMCP[None]) -> None:
         tool.fn = metered
 
 
+def _apply_advertised_schemas(mcp: FastMCP[None]) -> None:
+    """Advertise each tool's enforced schema as its ``inputSchema``.
+
+    FastMCP derives the advertised schema from the Python signature, which
+    carries none of the constraints the input firewall enforces: a caller is
+    shown ``scope: string`` while ``validate_tool_call`` requires one of
+    ``small`` / ``medium`` / ``large``. The caller sends a plausible value and
+    gets a rejection it had no way to predict. Replacing the derived schema
+    with the schema from ``tool_schemas/<tool>.json`` gives a tool one schema
+    instead of two, so a constrained argument can be filled correctly on the
+    first call.
+
+    Only the advertised copy is replaced. Argument coercion still runs through
+    FastMCP's signature-derived model, and enforcement still runs through
+    ``validate_tool_call`` inside each handler.
+
+    Args:
+        mcp: The FastMCP server whose tools should advertise their schemas.
+    """
+    registry = get_registry()
+    # FastMCP exposes no public per-tool schema override, so patch the tool
+    # manager's registry after registration (same access pattern as
+    # _apply_tool_tier).
+    for name, tool in mcp._tool_manager._tools.items():  # pyright: ignore[reportPrivateUsage]
+        schema = registry.get(name)
+        if schema is None:
+            # Deny-by-default means such a tool is registered but not callable.
+            # Leave the derived schema alone and make the mismatch visible.
+            logger.warning("MCP tool %s has no schema file; advertising the derived schema", name)
+            continue
+        # Deep-copy so a client-side mutation of the advertised schema cannot
+        # reach the process-wide registry the validator reads.
+        tool.parameters = copy.deepcopy(schema)
+
+
 def _apply_tool_tier(mcp: FastMCP[None], active_tier: ToolTier) -> None:
     """Drop every registered tool that is outside ``active_tier``.
 
@@ -1255,6 +1270,7 @@ def create_mcp_server(
         register_lineage_resources(mcp, lineage_root=root, enabled=True)
 
     _apply_tool_tier(mcp, active_tier)
+    _apply_advertised_schemas(mcp)
     _apply_cost_meter(mcp)
     return mcp
 

--- a/src/bernstein/mcp/tool_schemas/verify_chain.json
+++ b/src/bernstein/mcp/tool_schemas/verify_chain.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "verify_chain",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["artefact_path"],
+  "properties": {
+    "artefact_path": {"type": "string", "maxLength": 4096}
+  }
+}

--- a/tests/unit/mcp/test_advertised_schema_parity.py
+++ b/tests/unit/mcp/test_advertised_schema_parity.py
@@ -1,0 +1,299 @@
+"""Parity between the advertised MCP ``inputSchema`` and the enforced schema.
+
+``src/bernstein/mcp/tool_schemas/*.json`` is the deny-by-default input
+firewall. When the schema a client is shown is looser than the schema the
+server enforces, a caller cannot satisfy a constrained argument on its first
+call: it sends a plausible value, gets a rejection it had no way to predict,
+and burns a turn.
+
+These tests are the drift guard. They fail when enforcement is tightened
+without the advertised schema following, which is how the gap appeared in the
+first place. :func:`schema_disagreements` is the comparison used by the guard
+and is itself covered by negative tests, so the guard is not a test that can
+only pass.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+from functools import cache
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import jsonschema
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from bernstein.mcp.input_validation import (
+    ValidatedPayload,
+    get_registry,
+    validate_tool_call,
+)
+from bernstein.mcp.server import create_mcp_server
+
+# Top-level JSON Schema keywords that constrain a payload. Any disagreement on
+# one of these between the advertised and the enforced schema is drift.
+_CONSTRAINING_KEYWORDS = (
+    "type",
+    "required",
+    "additionalProperties",
+    "allOf",
+    "anyOf",
+    "oneOf",
+    "not",
+)
+
+
+@cache
+def _advertised_schemas() -> dict[str, dict[str, Any]]:
+    """Return ``{tool_name: inputSchema}`` exactly as a client would see it."""
+    mcp = create_mcp_server(tier="all", lineage_enabled=True)
+    tools = asyncio.run(mcp.list_tools())
+    return {tool.name: copy.deepcopy(tool.inputSchema) for tool in tools}
+
+
+def _enforced_schemas() -> dict[str, dict[str, Any]]:
+    """Return ``{tool_name: schema}`` as ``validate_tool_call`` enforces it."""
+    return dict(get_registry().schemas)
+
+
+def schema_disagreements(
+    tool_name: str,
+    advertised: dict[str, Any],
+    enforced: dict[str, Any],
+) -> list[str]:
+    """Return one message per constrained field the two schemas disagree on.
+
+    An empty list means a caller that satisfies the advertised schema is
+    accepted by the validator, and a caller the validator would refuse is
+    refused up front by the advertised schema.
+    """
+    out: list[str] = []
+    for keyword in _CONSTRAINING_KEYWORDS:
+        adv: Any = advertised.get(keyword)
+        enf: Any = enforced.get(keyword)
+        if keyword == "required":
+            adv = sorted(adv or [])
+            enf = sorted(enf or [])
+        if adv != enf:
+            out.append(f"{tool_name}: top-level '{keyword}' advertised {adv!r}, enforced {enf!r}")
+
+    adv_props: dict[str, Any] = advertised.get("properties", {})
+    enf_props: dict[str, Any] = enforced.get("properties", {})
+    for name in sorted(set(adv_props) | set(enf_props)):
+        if name not in adv_props:
+            out.append(f"{tool_name}.{name}: enforced but never advertised")
+        elif name not in enf_props:
+            out.append(f"{tool_name}.{name}: advertised but not enforced")
+        elif adv_props[name] != enf_props[name]:
+            out.append(f"{tool_name}.{name}: advertised {adv_props[name]!r}, enforced {enf_props[name]!r}")
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Seed payloads: one minimal accepted call per shape a tool supports. Used by
+# the property tests to explore the constrained fields.
+# ---------------------------------------------------------------------------
+
+_SEEDS: dict[str, list[dict[str, Any]]] = {
+    "bernstein_health": [{}],
+    "bernstein_status": [{}],
+    "bernstein_cost": [{}],
+    "bernstein_scenarios": [{}],
+    "bernstein_run": [{"goal": "ship the thing", "scope": "medium", "complexity": "medium"}],
+    "bernstein_tasks": [{"status": "open"}],
+    "bernstein_task_handle": [{"run_id": "run-1", "workdir": "."}],
+    "bernstein_context": [{"task_id": "t-1", "workdir": ".", "verify": True}],
+    "bernstein_stop": [{"workdir": "."}],
+    "bernstein_approve": [{"task_id": "t-1", "note": "ok"}],
+    "bernstein_create_subtask": [
+        {"parent_task_id": "t-1", "goal": "sub", "role": "backend", "scope": "small", "complexity": "low"},
+    ],
+    "bernstein_claim": [{"claimer_id": "worker-1", "completed_ids": []}],
+    "bernstein_update": [{"task_id": "t-1", "body": "progress", "sender": "worker-1", "kind": "finding"}],
+    "bernstein_post_artifact": [
+        {"task_id": "t-1", "key": "k1", "artifact_type": "report", "poster": "w", "body": "# hi"},
+        {
+            "task_id": "t-1",
+            "key": "k1",
+            "artifact_type": "table",
+            "poster": "w",
+            "columns": ["a"],
+            "rows": [["1"]],
+        },
+        {
+            "task_id": "t-1",
+            "key": "k1",
+            "artifact_type": "link",
+            "poster": "w",
+            "url": "https://example.invalid/x",
+            "link_kind": "preview",
+        },
+    ],
+    "load_skill": [{"name": "backend"}],
+    "bernstein_scenario": [{"scenario_id": "pr-review", "context": "ctx"}],
+    "bernstein_scenario_status": [{"orchestration_id": "orch-1"}],
+    "verify_chain": [{"artefact_path": "src/bernstein/mcp/server.py"}],
+}
+
+
+#: Fields whose value selects which conditional branch a seed satisfies. They
+#: are not redrawn, because swapping one invalidates the rest of the seed. Each
+#: of their enum values gets its own seed above instead.
+_DISCRIMINATOR_FIELDS: dict[str, frozenset[str]] = {
+    "bernstein_post_artifact": frozenset({"artifact_type"}),
+}
+
+
+def _enum_fields(tool_name: str, schema: dict[str, Any], payload: dict[str, Any]) -> dict[str, list[Any]]:
+    """Return the enum-constrained properties of ``schema`` present in ``payload``."""
+    props: dict[str, Any] = schema.get("properties", {})
+    pinned = _DISCRIMINATOR_FIELDS.get(tool_name, frozenset())
+    return {name: list(props[name]["enum"]) for name in payload if name not in pinned and "enum" in props.get(name, {})}
+
+
+# ---------------------------------------------------------------------------
+# The registration invariant.
+# ---------------------------------------------------------------------------
+
+
+def test_schema_files_and_registered_tools_are_the_same_set() -> None:
+    """Every registered tool has a schema file and every schema file a tool."""
+    advertised = set(_advertised_schemas())
+    enforced = set(_enforced_schemas())
+    assert advertised - enforced == set(), "registered tools with no schema file"
+    assert enforced - advertised == set(), "schema files with no registered tool"
+
+
+def test_seeds_cover_every_registered_tool() -> None:
+    """A new tool must bring a seed payload, or the property tests skip it."""
+    assert set(_SEEDS) == set(_advertised_schemas())
+
+
+# ---------------------------------------------------------------------------
+# The drift guard.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("tool_name", sorted(_SEEDS))
+def test_advertised_schema_is_the_enforced_schema(tool_name: str) -> None:
+    """What a client is shown is what ``validate_tool_call`` applies."""
+    advertised = _advertised_schemas()[tool_name]
+    enforced = _enforced_schemas()[tool_name]
+    problems = schema_disagreements(tool_name, advertised, enforced)
+    assert problems == [], "advertised/enforced schema drift:\n" + "\n".join(problems)
+
+
+def test_drift_guard_catches_a_loosened_advertised_field() -> None:
+    """Dropping an enum from the advertised copy must be reported."""
+    enforced = _enforced_schemas()["bernstein_run"]
+    loosened = copy.deepcopy(enforced)
+    loosened["properties"]["scope"] = {"type": "string"}
+    problems = schema_disagreements("bernstein_run", loosened, enforced)
+    assert any("bernstein_run.scope" in p for p in problems), problems
+
+
+def test_drift_guard_catches_tightened_enforcement() -> None:
+    """Tightening only the enforced copy must be reported."""
+    advertised = _advertised_schemas()["bernstein_approve"]
+    tightened = copy.deepcopy(advertised)
+    tightened["required"] = ["task_id", "note"]
+    tightened["properties"]["note"] = {"type": "string", "enum": ["approved"]}
+    problems = schema_disagreements("bernstein_approve", advertised, tightened)
+    assert any("'required'" in p for p in problems), problems
+    assert any("bernstein_approve.note" in p for p in problems), problems
+
+
+def test_post_artifact_advertises_its_conditional_shape() -> None:
+    """A caller can see that report/table/link each need different fields."""
+    advertised = _advertised_schemas()["bernstein_post_artifact"]
+    conditionals = advertised["allOf"]
+    required_by_type = {
+        branch["if"]["properties"]["artifact_type"]["const"]: sorted(branch["then"]["required"])
+        for branch in conditionals
+    }
+    assert required_by_type == {
+        "report": ["body"],
+        "table": ["columns", "rows"],
+        "link": ["link_kind", "url"],
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("seed", _SEEDS["bernstein_post_artifact"], ids=["report", "table", "link"])
+async def test_a_call_matching_the_advertised_shape_reaches_the_task_server(seed: dict[str, Any]) -> None:
+    """Filling the advertised conditional shape must not be refused up front.
+
+    The handler defaults the fields of the other two artifact types to the
+    empty string. Those defaults are absent from the advertised shape, so they
+    must not be validated as if the caller had supplied them.
+    """
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json = MagicMock(return_value={"key": seed["key"], "version": 1})
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post = AsyncMock(return_value=mock_response)
+
+    mcp = create_mcp_server(server_url="http://localhost:8052")
+    with patch("bernstein.mcp.server.httpx.AsyncClient", return_value=mock_client):
+        result = await mcp.call_tool("bernstein_post_artifact", dict(seed))
+
+    text = result[0][0].text  # type: ignore[index]
+    assert "jsonrpc_error" not in text, text
+    mock_client.post.assert_awaited_once()
+    posted = mock_client.post.call_args.kwargs["json"]
+    assert posted == {k: v for k, v in seed.items() if k != "task_id"}
+
+
+def test_verify_chain_is_behind_the_input_firewall() -> None:
+    """``verify_chain`` used to have no schema, so it bypassed validation."""
+    assert "verify_chain" in _enforced_schemas()
+    ok = validate_tool_call("verify_chain", {"artefact_path": "src/a.py"})
+    assert isinstance(ok, ValidatedPayload)
+    bad = validate_tool_call("verify_chain", {"artefact_path": 5})
+    assert not isinstance(bad, ValidatedPayload)
+
+
+# ---------------------------------------------------------------------------
+# Property tests: advertised-valid is accepted, enforced-invalid is visible.
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=40, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+@given(data=st.data())
+def test_payloads_valid_under_the_advertised_schema_are_accepted(data: st.DataObject) -> None:
+    """Anything the advertised schema permits, the validator must accept."""
+    for tool_name, advertised in _advertised_schemas().items():
+        for seed in _SEEDS[tool_name]:
+            payload = dict(seed)
+            for field, choices in _enum_fields(tool_name, advertised, seed).items():
+                payload[field] = data.draw(st.sampled_from(choices), label=f"{tool_name}.{field}")
+            # The server strips ``None`` args before validating, so a client
+            # that picks the null branch of a nullable enum sends nothing.
+            payload = {k: v for k, v in payload.items() if v is not None}
+            jsonschema.Draft7Validator(advertised).validate(payload)
+            result = validate_tool_call(tool_name, payload)
+            assert isinstance(result, ValidatedPayload), (tool_name, payload, result)
+
+
+@settings(max_examples=40, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+@given(bad=st.text(alphabet=st.characters(min_codepoint=33, max_codepoint=122), min_size=1, max_size=12))
+def test_payloads_the_validator_rejects_are_rejected_by_the_advertised_schema(bad: str) -> None:
+    """Anything the validator refuses, the advertised schema refuses too."""
+    enforced_all = _enforced_schemas()
+    for tool_name, advertised in _advertised_schemas().items():
+        enforced = enforced_all[tool_name]
+        for seed in _SEEDS[tool_name]:
+            for field, choices in _enum_fields(tool_name, enforced, seed).items():
+                if bad in choices:
+                    continue
+                payload = {**seed, field: bad}
+                enforced_ok = not list(jsonschema.Draft7Validator(enforced).iter_errors(payload))
+                advertised_ok = not list(jsonschema.Draft7Validator(advertised).iter_errors(payload))
+                assert enforced_ok is False, (tool_name, field, bad)
+                assert advertised_ok is enforced_ok, (tool_name, field, bad)


### PR DESCRIPTION
## Problem

`src/bernstein/mcp/tool_schemas/*.json` is the deny-by-default input firewall, but nothing injected those schemas into tool registration. FastMCP derived the advertised `inputSchema` from the Python signature, so a caller was shown `scope: string` while `validate_tool_call` required `enum: [small, medium, large]`. The same gap covered `artifact_type`, `link_kind`, the mailbox `kind` enum, the `bernstein_tasks` status filter, and the entire `allOf` conditional in `bernstein_post_artifact`. Every constrained argument was a guaranteed first-call failure: the caller sent a plausible value and got a rejection it had no way to predict.

## Change

`_apply_advertised_schemas()` in `src/bernstein/mcp/server.py` replaces each registered tool's advertised `inputSchema` with the schema the validator enforces, reusing the registry `load_registry` already builds. A tool now has one schema instead of two.

Only the advertised copy is replaced. Argument coercion still runs through FastMCP's signature-derived model, and enforcement still runs through `validate_tool_call` inside each handler. The advertised schema is a deep copy, so a client-side mutation cannot reach the process-wide registry.

Two things had to be fixed for the advertised shape to be satisfiable:

- **`verify_chain` had no schema file**, so it bypassed the firewall entirely. It gets one, matching the inputs it already accepted (a string path, no new pattern or minimum length), and now validates like every other tool.
- **`bernstein_post_artifact` validated its own defaults.** The handler defaults `body` / `url` / `link_kind` to the empty string, and passed all of them to the validator. The schema constrains those fields to what a caller that actually supplies them would send, so every artifact type was rejected before reaching the task server. Only the fields that get posted are validated now, which is also what makes the advertised conditional usable.

`validate_or_error` and `validation_error_response` move into `input_validation.py`. The server, the scenario bridge, and the lineage tool were each carrying their own copy; the lineage tool needed one and a local import would have been circular.

## Test

`tests/unit/mcp/test_advertised_schema_parity.py` is the drift guard. Per tool it asserts the advertised and enforced schemas agree on `type`, `required`, `additionalProperties`, the conditional keywords, and every property subschema. It also asserts the set of schema file stems equals the set of registered tool names in both directions, so a new tool cannot ship advertised-but-unenforced or enforced-but-unregistered.

The comparison the guard uses has its own negative tests: one loosens an advertised enum, one tightens only the enforced copy, and both must be reported. Two property tests round it out, one drawing values from the advertised enums and asserting the validator accepts every one, one drawing values outside them and asserting the advertised schema refuses exactly what the validator refuses.

Verified the guard has teeth by reverting only the source change and keeping the test: 20 of 29 tests fail, reporting the concrete drift (`bernstein_run.scope: advertised {'type': 'string'}, enforced {'type': 'string', 'enum': ['small', 'medium', 'large']}`). Loosening a single advertised field with the fix in place fails the same guard.

## Docs

`docs/mcp/input-validation.md` gains a section on the single-schema rule, the `verify_chain` addition, and where the drift guard lives. `docs/reference/FEATURE_MATRIX.md` row updated.

## For the reviewer

- The advertised schemas are Draft 7 and carry `$schema` / `title` at the top level. Clients that re-validate against a newer draft, or that reject unknown top-level keys, will see those. Every enforced schema was already `Draft7Validator.check_schema`-clean at startup, so this is a change in what is shown, not in what is accepted.
- `bernstein_post_artifact` now advertises `allOf` / `if` / `then`. A client that cannot express conditionals will fall back to showing the flat property list, which is no worse than the pre-change signature-derived schema.
- `bernstein_context` is absent from `TOOL_TIERS`, so it is only exposed at tier `all` (unannotated tools default to `all`). Pre-existing and untouched here, but it means the parity test enumerates the full tool set only at that tier.
- `verify_chain` moving behind the firewall is the one behaviour change that can refuse a call that previously ran. The schema was written against its current accepted inputs; a non-string `artefact_path` is the only new rejection.

Closes #3082