### PR TITLE
fix(mcp): contain the bernstein_stop workdir to the project root it names

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -358,6 +358,7 @@ alwaysApply: false
 | `remote_transport.py` | Streamable HTTP transport for Bernstein MCP server |
 | `routine_tools.py`    | MCP tools for the rt-003 Routine <-> Scenario bridge |
 | `server.py`           | Bernstein MCP server |
+| `signal_paths.py`     | Containment barrier for the MCP shutdown-signal path |
 | `streaming.py`        | In-flight tool-call tracking with cancellation and partial-result preservation |
 | `resources/`          | MCP resource registrars for Bernstein |
 | `tool_schemas/`       | tool_schemas/ sub-package |

--- a/.goosehints
+++ b/.goosehints
@@ -359,6 +359,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `remote_transport.py` | Streamable HTTP transport for Bernstein MCP server |
 | `routine_tools.py`    | MCP tools for the rt-003 Routine <-> Scenario bridge |
 | `server.py`           | Bernstein MCP server |
+| `signal_paths.py`     | Containment barrier for the MCP shutdown-signal path |
 | `streaming.py`        | In-flight tool-call tracking with cancellation and partial-result preservation |
 | `resources/`          | MCP resource registrars for Bernstein |
 | `tool_schemas/`       | tool_schemas/ sub-package |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -359,6 +359,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `remote_transport.py` | Streamable HTTP transport for Bernstein MCP server |
 | `routine_tools.py`    | MCP tools for the rt-003 Routine <-> Scenario bridge |
 | `server.py`           | Bernstein MCP server |
+| `signal_paths.py`     | Containment barrier for the MCP shutdown-signal path |
 | `streaming.py`        | In-flight tool-call tracking with cancellation and partial-result preservation |
 | `resources/`          | MCP resource registrars for Bernstein |
 | `tool_schemas/`       | tool_schemas/ sub-package |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,6 +359,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `remote_transport.py` | Streamable HTTP transport for Bernstein MCP server |
 | `routine_tools.py`    | MCP tools for the rt-003 Routine <-> Scenario bridge |
 | `server.py`           | Bernstein MCP server |
+| `signal_paths.py`     | Containment barrier for the MCP shutdown-signal path |
 | `streaming.py`        | In-flight tool-call tracking with cancellation and partial-result preservation |
 | `resources/`          | MCP resource registrars for Bernstein |
 | `tool_schemas/`       | tool_schemas/ sub-package |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -359,6 +359,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `remote_transport.py` | Streamable HTTP transport for Bernstein MCP server |
 | `routine_tools.py`    | MCP tools for the rt-003 Routine <-> Scenario bridge |
 | `server.py`           | Bernstein MCP server |
+| `signal_paths.py`     | Containment barrier for the MCP shutdown-signal path |
 | `streaming.py`        | In-flight tool-call tracking with cancellation and partial-result preservation |
 | `resources/`          | MCP resource registrars for Bernstein |
 | `tool_schemas/`       | tool_schemas/ sub-package |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,15 @@ All notable project changes are tracked here (code + docs).
   structured tool error instead of a `status`. Both the stdio server and the
   remote HTTP transport route through the same barrier. See
   [`docs/mcp/server.md`](mcp/server.md). Refs #3080.
+- `bernstein_stop` screens the `workdir` for shape before it reads the
+  filesystem. Resolving a path stats one entry per component, and the remote
+  HTTP transport applies no tool schema, so the caller previously chose how
+  many components the barrier walked. **Behaviour change:** a `workdir` that
+  is not text, or is longer than a path may be on this filesystem, is now
+  refused on its byte count with the same structured tool error, before any
+  resolve. An input the filesystem cannot represent, such as an embedded NUL,
+  is reported as that error too rather than as a raw filesystem message.
+  Refs #3080.
 
 ### Added
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable project changes are tracked here (code + docs).
 
 ## [Unreleased]
 
+### Security
+
+- `bernstein_stop` now contains the `workdir` it is given. The MCP shutdown
+  signal path is resolved and proven to stay inside the named project root,
+  and the root must already hold a `.sdd` directory. **Behaviour change:** a
+  `workdir` that was previously accepted without containment is now refused,
+  including a directory that is not a Bernstein project, a path that traverses
+  out of one, and a root whose `.sdd` is a symlink pointing elsewhere. A
+  refused call creates no directory and writes no file, and returns the
+  structured tool error instead of a `status`. Both the stdio server and the
+  remote HTTP transport route through the same barrier. See
+  [`docs/mcp/server.md`](mcp/server.md). Refs #3080.
+
 ### Added
 
 - A2A JSON-RPC server surface: one instance can be called into as a

--- a/docs/mcp/server.md
+++ b/docs/mcp/server.md
@@ -260,6 +260,35 @@ The ingested `traceparent` is carried as the lineage entry's `step_id`
 cross-link; a verifier holding the lineage spine reads the host trace off the
 artefact's provenance row.
 
+## Stopping a run: which project `bernstein_stop` can reach
+
+`bernstein_stop` takes a `workdir` and writes
+`<workdir>/.sdd/runtime/signals/SHUTDOWN`, which the orchestrator picks up
+and drains on. The `workdir` arrives from the caller, so the tool applies the
+same containment barrier the run-journal readers use before it touches the
+filesystem:
+
+- The workdir is resolved, and the signal path is rebuilt through the shared
+  containment helper. A `.sdd`, `runtime`, `signals`, or `SHUTDOWN` entry that
+  is a symlink pointing out of the resolved root is refused, because the write
+  would land outside the project the caller named.
+- The resolved root must already contain a `.sdd` directory. The tool stops a
+  Bernstein project that exists; it does not create a project tree at a path it
+  is handed.
+- A refused call creates no directory and writes no file. It returns the
+  structured tool error (`error` plus `hint`), never a `status`.
+
+Naming a root is allowed. An absolute path to a second Bernstein project on
+the same machine is a legitimate stop target; the barrier is against a
+`workdir` that reaches past the root it names. Both the stdio server and the
+remote HTTP transport serve the tool through the same helper, so the two
+surfaces cannot drift apart.
+
+Resolving the path is not the barrier on its own: `resolve()` follows symlinks
+but does not fold case, so on a case-insensitive filesystem a resolved path is
+normalised rather than canonical. Containment against the root as resolved in
+that same call is what decides whether the write stays inside.
+
 ## Running the pull-worker loop over MCP
 
 An MCP-native worker drives its own claim, update, complete loop over MCP

--- a/docs/mcp/server.md
+++ b/docs/mcp/server.md
@@ -268,6 +268,9 @@ and drains on. The `workdir` arrives from the caller, so the tool applies the
 same containment barrier the run-journal readers use before it touches the
 filesystem:
 
+- The workdir is screened for shape first, with no filesystem call: a value
+  that is not text, or that is longer than a path may be on this filesystem
+  (`MAX_PATH_BYTES`), cannot address a directory and is refused up front.
 - The workdir is resolved, and the signal path is rebuilt through the shared
   containment helper. A `.sdd`, `runtime`, `signals`, or `SHUTDOWN` entry that
   is a symlink pointing out of the resolved root is refused, because the write
@@ -288,6 +291,15 @@ Resolving the path is not the barrier on its own: `resolve()` follows symlinks
 but does not fold case, so on a case-insensitive filesystem a resolved path is
 normalised rather than canonical. Containment against the root as resolved in
 that same call is what decides whether the write stays inside.
+
+Resolving is also not free. It stats one entry per path component, and the
+remote HTTP transport serves this tool straight from the JSON-RPC arguments
+with no tool schema in front of it, so the caller picks the length. That is
+why the shape screen runs first: an over-long `workdir` is refused on its byte
+count rather than walked component by component on the serving event loop.
+Every refusal, including one from an input the filesystem cannot represent
+such as an embedded NUL, comes back as the same structured tool error rather
+than a raw filesystem message.
 
 ## Running the pull-worker loop over MCP
 

--- a/src/bernstein/mcp/remote_transport.py
+++ b/src/bernstein/mcp/remote_transport.py
@@ -943,12 +943,14 @@ class StreamableHTTPTransport:
             return await self._proxy_post("/tasks", payload)
 
         if name == "bernstein_stop":
-            from pathlib import Path
+            from bernstein.mcp.signal_paths import shutdown_signal_path
 
-            workdir = arguments.get("workdir", ".")
-            signals_dir = Path(workdir) / ".sdd" / "runtime" / "signals"
-            signals_dir.mkdir(parents=True, exist_ok=True)
-            shutdown_file = signals_dir / "SHUTDOWN"
+            # Same barrier as the stdio surface: the workdir must name an
+            # existing project root and the signal path must stay inside it.
+            # A refusal raises and is rendered as the structured tool error,
+            # before any directory is created.
+            shutdown_file = shutdown_signal_path(arguments.get("workdir", "."))
+            shutdown_file.parent.mkdir(parents=True, exist_ok=True)
             shutdown_file.write_text("mcp-remote-stop\n", encoding="utf-8")
             return json.dumps({"status": "shutdown signal sent", "path": str(shutdown_file)})
 

--- a/src/bernstein/mcp/server.py
+++ b/src/bernstein/mcp/server.py
@@ -854,10 +854,21 @@ def _register_action_tools(mcp: FastMCP[None], server_url: str) -> None:
         err = _validate_or_error("bernstein_stop", {"workdir": workdir})
         if err is not None:
             return _validation_error_response(err)
+        from bernstein.mcp.signal_paths import ShutdownSignalPathError, shutdown_signal_path
+
+        # Shared barrier rather than a local containment check, so this
+        # surface cannot drift from the other workdir-derived writers. The
+        # path is resolved and proven contained before any directory is
+        # created, so a refused call leaves nothing behind.
         try:
-            signals_dir = Path(workdir) / ".sdd" / "runtime" / "signals"
-            signals_dir.mkdir(parents=True, exist_ok=True)
-            shutdown_file = signals_dir / "SHUTDOWN"
+            shutdown_file = shutdown_signal_path(workdir)
+        except ShutdownSignalPathError as exc:
+            return _error_response(
+                exc,
+                hint="workdir must be an existing Bernstein project root",
+            )
+        try:
+            shutdown_file.parent.mkdir(parents=True, exist_ok=True)
             shutdown_file.write_text("mcp-stop\n", encoding="utf-8")
             return json.dumps({"status": "shutdown signal sent", "path": str(shutdown_file)})
         except Exception as exc:

--- a/src/bernstein/mcp/signal_paths.py
+++ b/src/bernstein/mcp/signal_paths.py
@@ -28,13 +28,34 @@ resolved from that same call, so a case variant is measured against itself.
 Naming a root is allowed; escaping it is not. An absolute path to another
 Bernstein project on the same machine is a legitimate stop target - the
 barrier is against a workdir that reaches outside the root it names.
+
+Both checks read the filesystem, and resolving a path stats one entry per
+component, so the workdir is screened for shape before either runs. The
+remote HTTP surface serves this tool straight from the JSON-RPC arguments
+with no tool schema in front of it, which leaves the caller holding the
+length: an over-long workdir would otherwise turn one request into an
+unbounded run of blocking stats on the serving event loop. A workdir past
+:data:`~bernstein.core.security.path_containment.MAX_PATH_BYTES` cannot
+address a directory on this filesystem, so there is nothing to learn by
+walking it and it is refused up front.
+
+Every refusal is a :class:`ShutdownSignalPathError`. The resolve itself can
+fail on an input the filesystem cannot represent - a NUL byte raises
+``ValueError`` from the underlying ``lstat`` - and both handlers guard on
+the typed error, so an untyped failure would escape as an unhandled error
+instead of the structured tool response.
 """
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
-from bernstein.core.security.path_containment import PathContainmentError, contained_path
+from bernstein.core.security.path_containment import (
+    MAX_PATH_BYTES,
+    PathContainmentError,
+    contained_path,
+)
 
 #: Marker directory that makes a workdir a Bernstein project root.
 SDD_DIR_NAME = ".sdd"
@@ -55,6 +76,42 @@ class ShutdownSignalPathError(PathContainmentError):
     """
 
 
+def _workdir_text(workdir: str | Path) -> str:
+    """Return *workdir* as text, refusing what cannot name a path.
+
+    Screens shape only, with no filesystem call, so an input that can never
+    address a directory costs one length check instead of one stat per path
+    component.
+
+    Args:
+        workdir: The caller-supplied workdir. Untrusted.
+
+    Returns:
+        The workdir as a string.
+
+    Raises:
+        ShutdownSignalPathError: The workdir is not textual, or is longer
+            than a path may be on this filesystem.
+    """
+    try:
+        raw = os.fspath(workdir)
+    except TypeError as exc:
+        msg = f"workdir must name a path, not {type(workdir).__name__}"
+        raise ShutdownSignalPathError(msg) from exc
+    if isinstance(raw, bytes):
+        msg = "workdir must name a path as text, not bytes"
+        raise ShutdownSignalPathError(msg)
+    # Measured in encoded bytes, not characters, for the same reason
+    # ``path_containment`` measures that way: the filesystem limit is a byte
+    # limit. The input is not echoed back here - only its size - because an
+    # over-long workdir is exactly the input worth keeping out of the log.
+    encoded = len(raw.encode("utf-8", errors="surrogatepass"))
+    if encoded > MAX_PATH_BYTES:
+        msg = f"workdir is {encoded} bytes, over the {MAX_PATH_BYTES}-byte filesystem limit for a path"
+        raise ShutdownSignalPathError(msg)
+    return raw
+
+
 def shutdown_signal_path(workdir: str | Path) -> Path:
     """Return the contained ``SHUTDOWN`` path for an existing project root.
 
@@ -67,17 +124,23 @@ def shutdown_signal_path(workdir: str | Path) -> Path:
         path proven to live inside the resolved root.
 
     Raises:
-        ShutdownSignalPathError: The resolved workdir holds no ``.sdd``
-            directory, or the signal path resolves outside that root.
+        ShutdownSignalPathError: The workdir cannot name a path on this
+            filesystem, the resolved workdir holds no ``.sdd`` directory, or
+            the signal path resolves outside that root.
     """
-    root = Path(workdir).resolve()
+    raw = _workdir_text(workdir)
+    try:
+        root = Path(raw).resolve()
+    except (OSError, ValueError) as exc:
+        msg = f"workdir does not name a directory this filesystem can address: {raw!r}"
+        raise ShutdownSignalPathError(msg) from exc
     if not (root / SDD_DIR_NAME).is_dir():
-        msg = f"workdir is not an existing Bernstein project root (no {SDD_DIR_NAME} directory): {workdir!r}"
+        msg = f"workdir is not an existing Bernstein project root (no {SDD_DIR_NAME} directory): {raw!r}"
         raise ShutdownSignalPathError(msg)
     try:
         return contained_path(root, *SHUTDOWN_SEGMENTS, label="workdir")
     except PathContainmentError as exc:
-        msg = f"shutdown signal path resolves outside the project root named by workdir: {workdir!r}"
+        msg = f"shutdown signal path resolves outside the project root named by workdir: {raw!r}"
         raise ShutdownSignalPathError(msg) from exc
 
 

--- a/src/bernstein/mcp/signal_paths.py
+++ b/src/bernstein/mcp/signal_paths.py
@@ -1,0 +1,89 @@
+"""Containment barrier for the MCP shutdown-signal path.
+
+``bernstein_stop`` takes a ``workdir`` from the caller and turns it into a
+``.sdd/runtime/signals/SHUTDOWN`` write. With no barrier that is an
+arbitrary directory-creation and file-write primitive reachable over MCP: a
+crafted workdir addresses any directory on the machine, ``mkdir(parents=True)``
+builds the tree there, and the write stops an unrelated Bernstein project.
+
+Two checks, neither sufficient on its own:
+
+1. **Existing project root.** The resolved workdir must already contain a
+   ``.sdd`` directory. The tool can only stop a Bernstein project that is
+   already on disk; it never materialises a tree at a path it was handed.
+2. **Realpath containment.** The signal path is rebuilt through
+   :func:`~bernstein.core.security.path_containment.contained_path` - the
+   same barrier ``run_journal_path`` puts in front of the run journal -
+   so a ``.sdd``, ``runtime``, ``signals``, or ``SHUTDOWN`` entry that is a
+   symlink out of the project cannot redirect the write.
+
+Resolving the workdir is not the barrier by itself. ``Path.resolve`` and
+``os.path.realpath`` follow symlinks but do not fold case, so on a
+case-insensitive filesystem a resolved path is normalised, not canonical: a
+case variant of a project root resolves to a different string for the same
+directory. Containment, not the resolve, is what decides whether the write
+lands inside the named root, and it is evaluated against the root as
+resolved from that same call, so a case variant is measured against itself.
+
+Naming a root is allowed; escaping it is not. An absolute path to another
+Bernstein project on the same machine is a legitimate stop target - the
+barrier is against a workdir that reaches outside the root it names.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from bernstein.core.security.path_containment import PathContainmentError, contained_path
+
+#: Marker directory that makes a workdir a Bernstein project root.
+SDD_DIR_NAME = ".sdd"
+
+#: Fixed segments from the project root down to the signal file. Constants,
+#: not caller data - the caller only names the root - but they are still
+#: routed through the barrier because any of them can be a symlink on disk.
+SHUTDOWN_SEGMENTS = (SDD_DIR_NAME, "runtime", "signals", "SHUTDOWN")
+
+
+class ShutdownSignalPathError(PathContainmentError):
+    """Raised when a workdir cannot safely name a shutdown-signal path.
+
+    Subclasses :class:`~bernstein.core.security.path_containment.PathContainmentError`
+    (and so :class:`ValueError`), matching how ``JournalPathError`` reports a
+    refused run id, so both MCP surfaces render it with the same structured
+    error shape.
+    """
+
+
+def shutdown_signal_path(workdir: str | Path) -> Path:
+    """Return the contained ``SHUTDOWN`` path for an existing project root.
+
+    Args:
+        workdir: Project root named by the caller. Untrusted.
+
+    Returns:
+        The normalised, containment-checked path of the ``SHUTDOWN`` signal
+        file. Callers must write through this return value: it is the only
+        path proven to live inside the resolved root.
+
+    Raises:
+        ShutdownSignalPathError: The resolved workdir holds no ``.sdd``
+            directory, or the signal path resolves outside that root.
+    """
+    root = Path(workdir).resolve()
+    if not (root / SDD_DIR_NAME).is_dir():
+        msg = f"workdir is not an existing Bernstein project root (no {SDD_DIR_NAME} directory): {workdir!r}"
+        raise ShutdownSignalPathError(msg)
+    try:
+        return contained_path(root, *SHUTDOWN_SEGMENTS, label="workdir")
+    except PathContainmentError as exc:
+        msg = f"shutdown signal path resolves outside the project root named by workdir: {workdir!r}"
+        raise ShutdownSignalPathError(msg) from exc
+
+
+__all__ = [
+    "SDD_DIR_NAME",
+    "SHUTDOWN_SEGMENTS",
+    "ShutdownSignalPathError",
+    "shutdown_signal_path",
+]

--- a/tests/unit/test_mcp_remote_transport.py
+++ b/tests/unit/test_mcp_remote_transport.py
@@ -481,6 +481,9 @@ class TestToolExecution:
         from pathlib import Path
 
         workdir = Path(str(tmp_path))
+        # The workdir must already be a Bernstein project root: the tool stops
+        # a project that exists, it does not create a tree where it is pointed.
+        (workdir / ".sdd").mkdir()
         body = _jsonrpc_request(
             "tools/call",
             {"name": "bernstein_stop", "arguments": {"workdir": str(workdir)}},
@@ -492,6 +495,32 @@ class TestToolExecution:
         assert text["status"] == "shutdown signal sent"
         signal_file = workdir / ".sdd" / "runtime" / "signals" / "SHUTDOWN"
         assert signal_file.exists()
+
+    @pytest.mark.anyio
+    async def test_stop_tool_refuses_a_workdir_that_is_not_a_project(
+        self, transport: StreamableHTTPTransport, tmp_path: object
+    ) -> None:
+        """The remote surface serves the same tool and needs the same barrier.
+
+        Before the barrier this transport ran ``mkdir(parents=True)`` on any
+        path the caller named, so a stop against an unrelated directory both
+        created a ``.sdd`` tree there and dropped a SHUTDOWN file in it.
+        """
+        from pathlib import Path
+
+        victim = Path(str(tmp_path)) / "victim"
+        victim.mkdir()
+        body = _jsonrpc_request(
+            "tools/call",
+            {"name": "bernstein_stop", "arguments": {"workdir": str(victim)}},
+        )
+        status, _, resp_body = await transport.handle_request("POST", "/mcp", {}, body)
+        assert status == 200
+        data = json.loads(resp_body)
+        text = _tool_result(data["result"]["content"][0]["text"])
+        assert "error" in text
+        assert "status" not in text
+        assert list(victim.iterdir()) == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_mcp_remote_transport.py
+++ b/tests/unit/test_mcp_remote_transport.py
@@ -522,6 +522,34 @@ class TestToolExecution:
         assert "status" not in text
         assert list(victim.iterdir()) == []
 
+    @pytest.mark.anyio
+    async def test_stop_tool_refuses_a_workdir_the_filesystem_cannot_address(
+        self, transport: StreamableHTTPTransport, tmp_path: object
+    ) -> None:
+        """This surface applies no tool schema, so the barrier owns the refusal.
+
+        The stdio server bounds ``workdir`` in its tool schema before the
+        handler runs. This transport serves the tool straight from the
+        JSON-RPC arguments, so a workdir that cannot name a directory reaches
+        the barrier unfiltered and must come back as the barrier's own
+        refusal rather than a raw filesystem message.
+        """
+        from pathlib import Path
+
+        unaddressable = f"{Path(str(tmp_path))}/pro\x00ject"
+        body = _jsonrpc_request(
+            "tools/call",
+            {"name": "bernstein_stop", "arguments": {"workdir": unaddressable}},
+        )
+        status, _, resp_body = await transport.handle_request("POST", "/mcp", {}, body)
+        assert status == 200
+        data = json.loads(resp_body)
+        text = _tool_result(data["result"]["content"][0]["text"])
+        assert "error" in text
+        assert "status" not in text
+        assert "workdir" in text["error"]
+        assert "lstat" not in text["error"]
+
 
 # ---------------------------------------------------------------------------
 # CORS headers tests

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -287,23 +287,23 @@ async def test_bernstein_cost_returns_cost_summary() -> None:
 
 
 @pytest.mark.asyncio
-async def test_bernstein_stop_sends_stop_signal() -> None:
-    """bernstein_stop writes a SHUTDOWN signal file and confirms."""
+async def test_bernstein_stop_sends_stop_signal(tmp_path: Path) -> None:
+    """bernstein_stop writes a SHUTDOWN signal file and confirms.
+
+    A real project root on disk rather than a patched ``Path``: the handler
+    now proves the signal path is contained under the resolved workdir, and
+    a mocked path cannot exercise that.
+    """
     from bernstein.mcp.server import create_mcp_server
 
+    (tmp_path / ".sdd").mkdir()
     mcp = create_mcp_server(server_url="http://localhost:8052")
 
-    with patch("bernstein.mcp.server.Path") as mock_path_cls:
-        mock_path = MagicMock()
-        mock_path_cls.return_value = mock_path
-        mock_path.__truediv__ = MagicMock(return_value=mock_path)
-        mock_path.exists = MagicMock(return_value=True)
-        mock_path.write_text = MagicMock()
-
-        result = await mcp.call_tool("bernstein_stop", {})
+    result = await mcp.call_tool("bernstein_stop", {"workdir": str(tmp_path)})
 
     text = result[0][0].text  # type: ignore[index]
     assert "stop" in text.lower() or "shutdown" in text.lower()
+    assert (tmp_path / ".sdd" / "runtime" / "signals" / "SHUTDOWN").is_file()
 
 
 # ---------------------------------------------------------------------------
@@ -508,19 +508,21 @@ async def test_crash_protection_bernstein_approve() -> None:
 
 
 @pytest.mark.asyncio
-async def test_crash_protection_bernstein_stop() -> None:
-    """bernstein_stop returns error JSON on filesystem failure."""
+async def test_crash_protection_bernstein_stop(tmp_path: Path) -> None:
+    """bernstein_stop returns error JSON on filesystem failure.
+
+    The workdir is a real project root so the call clears the containment
+    barrier and fails where this test means it to: at the directory create.
+    """
+    import pathlib
+
     from bernstein.mcp.server import create_mcp_server
 
+    (tmp_path / ".sdd").mkdir()
     mcp = create_mcp_server(server_url="http://localhost:8052")
 
-    with patch("bernstein.mcp.server.Path") as mock_path_cls:
-        mock_path = MagicMock()
-        mock_path_cls.return_value = mock_path
-        mock_path.__truediv__ = MagicMock(return_value=mock_path)
-        mock_path.mkdir = MagicMock(side_effect=PermissionError("not allowed"))
-
-        result = await mcp.call_tool("bernstein_stop", {})
+    with patch.object(pathlib.Path, "mkdir", side_effect=PermissionError("not allowed")):
+        result = await mcp.call_tool("bernstein_stop", {"workdir": str(tmp_path)})
 
     text = result[0][0].text  # type: ignore[index]
     parsed = json.loads(text)

--- a/tests/unit/test_path_containment.py
+++ b/tests/unit/test_path_containment.py
@@ -1089,3 +1089,76 @@ async def test_bernstein_stop_refuses_a_symlinked_sdd_and_leaves_the_target_alon
 
     assert "error" in payload
     assert not (victim / ".sdd" / "runtime").exists()
+
+
+# ---------------------------------------------------------------------------
+# The barrier must refuse before it walks the filesystem
+# ---------------------------------------------------------------------------
+#
+# ``workdir`` reaches the barrier unbounded on the remote HTTP surface: that
+# transport serves the tool straight from the JSON-RPC arguments and applies
+# no tool schema, so the caller picks the length. Resolving a path stats one
+# entry per component, so an over-long workdir turns a single request into
+# an unbounded run of blocking syscalls on the serving event loop. The length
+# a path may occupy is already decided by ``MAX_PATH_BYTES``, so a workdir
+# past it can never address a directory and there is nothing to learn from
+# walking it.
+
+
+def _counting_lstat(monkeypatch: pytest.MonkeyPatch) -> dict[str, int]:
+    """Count ``os.lstat`` calls made while resolving a path."""
+    import os
+
+    seen = {"calls": 0}
+    real = os.lstat
+
+    def counted(path: Any, *args: Any, **kwargs: Any) -> Any:
+        seen["calls"] += 1
+        return real(path, *args, **kwargs)
+
+    monkeypatch.setattr(os, "lstat", counted)
+    return seen
+
+
+def test_shutdown_signal_path_refuses_an_over_long_workdir_without_walking_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A workdir past the path limit is refused before any filesystem call.
+
+    Deliberately not a timing assertion: the property is that the barrier
+    consults no filesystem entry at all for an input that cannot name one.
+    """
+    from bernstein.mcp.signal_paths import ShutdownSignalPathError, shutdown_signal_path
+
+    over_long = "/" + "/".join(["a"] * MAX_PATH_BYTES)
+    seen = _counting_lstat(monkeypatch)
+
+    with pytest.raises(ShutdownSignalPathError):
+        shutdown_signal_path(over_long)
+
+    assert seen["calls"] == 0, f"resolved {seen['calls']} components of a workdir that cannot name a directory"
+
+
+def test_shutdown_signal_path_still_accepts_a_workdir_at_the_addressable_limit(tmp_path: Path) -> None:
+    """The bound refuses only what cannot exist, not ordinary deep projects."""
+    from bernstein.mcp.signal_paths import shutdown_signal_path
+
+    project = _make_project(tmp_path / ("d" * 200) / ("e" * 200))
+
+    resolved = shutdown_signal_path(str(project))
+
+    assert resolved.is_relative_to(project.resolve())
+
+
+def test_shutdown_signal_path_refuses_a_workdir_the_filesystem_cannot_address(tmp_path: Path) -> None:
+    """A workdir carrying a NUL is refused as a containment error.
+
+    The barrier documents one refusal type. A raw ``ValueError`` from the
+    resolve escapes the ``except ShutdownSignalPathError`` both handlers
+    guard with, so the caller sees an unhandled failure instead of the
+    structured tool error.
+    """
+    from bernstein.mcp.signal_paths import ShutdownSignalPathError, shutdown_signal_path
+
+    with pytest.raises(ShutdownSignalPathError):
+        shutdown_signal_path(f"{tmp_path}/pro\x00ject")

--- a/tests/unit/test_path_containment.py
+++ b/tests/unit/test_path_containment.py
@@ -1162,3 +1162,18 @@ def test_shutdown_signal_path_refuses_a_workdir_the_filesystem_cannot_address(tm
 
     with pytest.raises(ShutdownSignalPathError):
         shutdown_signal_path(f"{tmp_path}/pro\x00ject")
+
+
+def test_shutdown_signal_path_refuses_a_workdir_that_is_not_textual() -> None:
+    """A non-textual workdir is refused as a containment error too.
+
+    The remote HTTP surface serves this tool from untyped JSON-RPC
+    arguments, so the value need not be a string at all. Each of these
+    reaches the barrier as-is and must come back as the one documented
+    refusal type rather than as a bare ``TypeError``.
+    """
+    from bernstein.mcp.signal_paths import ShutdownSignalPathError, shutdown_signal_path
+
+    for hostile in (123, ["/tmp"], {"workdir": "/tmp"}, None, b"/tmp"):
+        with pytest.raises(ShutdownSignalPathError):
+            shutdown_signal_path(hostile)  # type: ignore[arg-type]

--- a/tests/unit/test_path_containment.py
+++ b/tests/unit/test_path_containment.py
@@ -15,6 +15,7 @@ still round-trips unchanged.
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 from typing import Any
@@ -837,3 +838,254 @@ def test_sweeps_skip_a_symlinked_run_directory_with_an_innocent_name(tmp_path: P
     replay_dirs = {d.name for d in _replay_find_run_dirs(runs_root)}
     assert "run-ok" not in replay_dirs
     assert "run-honest" in replay_dirs
+
+
+# ---------------------------------------------------------------------------
+# MCP shutdown signal: workdir names a root, it does not reach past one
+# ---------------------------------------------------------------------------
+#
+# ``bernstein_stop`` turns a caller-supplied ``workdir`` into a
+# ``.sdd/runtime/signals/SHUTDOWN`` write preceded by
+# ``mkdir(parents=True)``. Unbarriered that is arbitrary directory creation
+# and an arbitrary file write reachable over MCP, and it stops an unrelated
+# Bernstein project. Naming a root stays legal; reaching outside the named
+# root does not.
+
+
+def _make_project(root: Path) -> Path:
+    """Create a minimal Bernstein project root and return it."""
+    (root / ".sdd").mkdir(parents=True)
+    return root
+
+
+def _case_insensitive_fs(probe_dir: Path) -> bool:
+    """Report whether *probe_dir* lives on a case-insensitive filesystem."""
+    probe = probe_dir / "CaseProbe"
+    probe.mkdir()
+    insensitive = (probe_dir / "caseprobe").is_dir()
+    probe.rmdir()
+    return insensitive
+
+
+def test_shutdown_signal_path_round_trips(tmp_path: Path) -> None:
+    """An ordinary project root yields the documented signal path."""
+    from bernstein.mcp.signal_paths import shutdown_signal_path
+
+    project = _make_project(tmp_path / "project")
+
+    assert shutdown_signal_path(project) == project.resolve() / ".sdd" / "runtime" / "signals" / "SHUTDOWN"
+
+
+def test_shutdown_signal_path_allows_a_second_project_by_absolute_path(tmp_path: Path) -> None:
+    """Naming another project on the same machine is legal, not an escape.
+
+    The barrier is against a workdir that reaches outside the root it names.
+    Stopping a different Bernstein project by absolute path is the tool
+    working as documented.
+    """
+    from bernstein.mcp.signal_paths import shutdown_signal_path
+
+    other = _make_project(tmp_path / "other-project")
+
+    resolved = shutdown_signal_path(str(other.resolve()))
+
+    assert resolved.is_relative_to(other.resolve())
+
+
+def test_shutdown_signal_path_refuses_a_root_without_sdd(tmp_path: Path) -> None:
+    """A directory that is not a Bernstein project cannot be stopped."""
+    from bernstein.mcp.signal_paths import ShutdownSignalPathError, shutdown_signal_path
+
+    plain = tmp_path / "not-a-project"
+    plain.mkdir()
+
+    with pytest.raises(ShutdownSignalPathError):
+        shutdown_signal_path(plain)
+
+
+def test_shutdown_signal_path_refuses_traversal_out_of_the_project(tmp_path: Path) -> None:
+    """``../`` out of a real project lands on a non-project and is refused."""
+    from bernstein.mcp.signal_paths import ShutdownSignalPathError, shutdown_signal_path
+
+    project = _make_project(tmp_path / "project")
+    (tmp_path / "victim").mkdir()
+
+    with pytest.raises(ShutdownSignalPathError):
+        shutdown_signal_path(str(project / ".." / "victim"))
+
+
+def test_shutdown_signal_path_refuses_an_absolute_path_outside_any_project(tmp_path: Path) -> None:
+    """An absolute path to an arbitrary directory is refused."""
+    from bernstein.mcp.signal_paths import ShutdownSignalPathError, shutdown_signal_path
+
+    with pytest.raises(ShutdownSignalPathError):
+        shutdown_signal_path(str(tmp_path))
+
+
+def test_shutdown_signal_path_refuses_a_symlinked_sdd(tmp_path: Path) -> None:
+    """A ``.sdd`` that points out of the project cannot redirect the write.
+
+    This is the case the ``.sdd``-exists check cannot catch on its own: the
+    entry is present and is a directory, but following it leaves the root.
+    """
+    from bernstein.mcp.signal_paths import ShutdownSignalPathError, shutdown_signal_path
+
+    project = tmp_path / "project"
+    project.mkdir()
+    victim = _make_project(tmp_path / "victim")
+    _symlink_or_skip(project / ".sdd", victim / ".sdd")
+
+    assert (project / ".sdd").is_dir(), "the planted .sdd should look ordinary"
+
+    with pytest.raises(ShutdownSignalPathError):
+        shutdown_signal_path(project)
+
+
+def test_shutdown_signal_path_refuses_a_symlinked_signals_dir(tmp_path: Path) -> None:
+    """A symlink further down the fixed segments is refused too."""
+    from bernstein.mcp.signal_paths import ShutdownSignalPathError, shutdown_signal_path
+
+    project = _make_project(tmp_path / "project")
+    (project / ".sdd" / "runtime").mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    _symlink_or_skip(project / ".sdd" / "runtime" / "signals", outside)
+
+    with pytest.raises(ShutdownSignalPathError):
+        shutdown_signal_path(project)
+
+
+def test_shutdown_signal_path_refuses_a_symlinked_sdd_named_by_case_variant(tmp_path: Path) -> None:
+    """A case variant of the root does not slip past the symlink barrier.
+
+    ``resolve()`` follows symlinks but does not fold case, so on a
+    case-insensitive filesystem a case variant of a root is a different
+    string for the same directory and a resolve-only check would compare
+    the wrong pair. Containment is evaluated against the root as resolved
+    from this same call, so the variant is measured against itself and the
+    symlinked ``.sdd`` is still caught. On a case-sensitive filesystem the
+    variant simply names nothing and is refused by the project-root check.
+    Either way the answer is refusal.
+    """
+    from bernstein.mcp.signal_paths import ShutdownSignalPathError, shutdown_signal_path
+
+    project = tmp_path / "project"
+    project.mkdir()
+    victim = _make_project(tmp_path / "victim")
+    _symlink_or_skip(project / ".sdd", victim / ".sdd")
+
+    variant = project.parent / project.name.upper()
+
+    with pytest.raises(ShutdownSignalPathError):
+        shutdown_signal_path(variant)
+
+
+def test_shutdown_signal_path_case_variant_of_a_real_root_stays_inside_it(tmp_path: Path) -> None:
+    """A case variant of a legitimate root never addresses a different tree.
+
+    On a case-insensitive filesystem the variant is the same project, so it
+    is accepted and the resolved path is the real project's signal file. On
+    a case-sensitive filesystem it names nothing and is refused. Neither
+    branch may reach a directory outside the root the caller named.
+    """
+    from bernstein.mcp.signal_paths import ShutdownSignalPathError, shutdown_signal_path
+
+    project = _make_project(tmp_path / "project")
+    variant = project.parent / project.name.upper()
+
+    if not _case_insensitive_fs(tmp_path):
+        with pytest.raises(ShutdownSignalPathError):
+            shutdown_signal_path(variant)
+        return
+
+    resolved = shutdown_signal_path(variant)
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    resolved.write_text("probe\n", encoding="utf-8")
+
+    assert (project / ".sdd" / "runtime" / "signals" / "SHUTDOWN").is_file()
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["project"]
+
+
+def test_shutdown_signal_path_error_is_a_containment_error_and_value_error(tmp_path: Path) -> None:
+    """Callers guarding on ``ValueError`` keep working unchanged."""
+    from bernstein.mcp.signal_paths import ShutdownSignalPathError
+
+    assert issubclass(ShutdownSignalPathError, PathContainmentError)
+    assert issubclass(ShutdownSignalPathError, ValueError)
+
+
+# ---------------------------------------------------------------------------
+# Routing: both MCP surfaces must go through the barrier
+# ---------------------------------------------------------------------------
+
+
+async def _call_stop_tool(workdir: str) -> dict[str, Any]:
+    """Invoke the stdio ``bernstein_stop`` tool and return its JSON body.
+
+    Tool responses may be wrapped in the per-call cost-meter envelope, so the
+    inner result is unwrapped before the assertion reads it.
+    """
+    from bernstein.mcp.server import create_mcp_server
+
+    mcp = create_mcp_server(server_url="http://localhost:8052")
+    result = await mcp.call_tool("bernstein_stop", {"workdir": workdir})
+    parsed: dict[str, Any] = json.loads(result[0][0].text)  # type: ignore[index, union-attr]
+    inner = parsed.get("result") if "_meter" in parsed else parsed
+    assert isinstance(inner, dict)
+    return inner
+
+
+@pytest.mark.asyncio
+async def test_bernstein_stop_writes_the_signal_for_a_real_project(tmp_path: Path) -> None:
+    """The legitimate path still works end to end through the MCP tool."""
+    project = _make_project(tmp_path / "project")
+
+    payload = await _call_stop_tool(str(project))
+
+    assert payload["status"] == "shutdown signal sent"
+    assert (project / ".sdd" / "runtime" / "signals" / "SHUTDOWN").is_file()
+
+
+@pytest.mark.asyncio
+async def test_bernstein_stop_refuses_an_uncontained_workdir_and_creates_nothing(tmp_path: Path) -> None:
+    """A refused stop returns the structured error and leaves the disk alone.
+
+    ``mkdir(parents=True)`` ran before any barrier, so the pre-fix handler
+    built ``.sdd/runtime/signals`` under whatever directory it was handed.
+    A refusal must create nothing.
+    """
+    victim = tmp_path / "victim"
+    victim.mkdir()
+
+    payload = await _call_stop_tool(str(victim))
+
+    assert "error" in payload
+    assert "status" not in payload
+    assert list(victim.iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_bernstein_stop_refuses_traversal_and_creates_nothing(tmp_path: Path) -> None:
+    """``../`` from a real project cannot reach a sibling directory."""
+    project = _make_project(tmp_path / "project")
+    victim = tmp_path / "victim"
+    victim.mkdir()
+
+    payload = await _call_stop_tool(str(project / ".." / "victim"))
+
+    assert "error" in payload
+    assert list(victim.iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_bernstein_stop_refuses_a_symlinked_sdd_and_leaves_the_target_alone(tmp_path: Path) -> None:
+    """A symlinked ``.sdd`` does not let the stop reach another project."""
+    project = tmp_path / "project"
+    project.mkdir()
+    victim = _make_project(tmp_path / "victim")
+    _symlink_or_skip(project / ".sdd", victim / ".sdd")
+
+    payload = await _call_stop_tool(str(project))
+
+    assert "error" in payload
+    assert not (victim / ".sdd" / "runtime").exists()


### PR DESCRIPTION
## What

`bernstein_stop` took a caller-supplied `workdir`, joined `.sdd/runtime/signals` onto it, ran `mkdir(parents=True, exist_ok=True)` and wrote a `SHUTDOWN` file. The only validation was a max-length string check in the tool schema. That is an arbitrary directory-creation and file-write primitive reachable over MCP, and it can stop an unrelated Bernstein project on the same machine.

Both MCP surfaces now route through one barrier, `shutdown_signal_path`, built on the same `contained_path` helper the run-journal readers already use rather than a second containment implementation:

- the `workdir` is resolved, and the signal path is proven to stay inside the resolved root, so a `.sdd`, `runtime`, `signals`, or `SHUTDOWN` entry that is a symlink out of the project cannot redirect the write;
- the resolved root must already hold a `.sdd` directory, so the tool can only stop a Bernstein project that exists;
- the check runs before any directory is created, so a refused call leaves nothing on disk and returns the structured tool error (`error` plus `hint`, no `status`).

Naming a root stays legal. An absolute path to a second Bernstein project on the same machine is still a valid stop target; the barrier is against a `workdir` that reaches past the root it names.

The remote HTTP transport carried the same unbarriered handler and had no schema check at all, so it is routed through the same helper. Leaving it would have left the hole open on the surface that is reachable over the network.

## Behaviour change

A `workdir` that was previously accepted without containment is now refused: a directory that is not a Bernstein project, a path that traverses out of one, and a root whose `.sdd` points elsewhere. Recorded in `docs/CHANGELOG.md` under `[Unreleased]`.

## Attack coverage

Each of these is asserted refused in `tests/unit/test_path_containment.py`, and the routing tests additionally assert that nothing appears on disk:

| Input | Refused by |
|---|---|
| `<project>/../victim` traversal | project-root check on the resolved path |
| absolute path to an arbitrary directory | project-root check |
| `.sdd` that is a symlink to another project | realpath containment |
| `signals` that is a symlink out of the project | realpath containment |
| case variant of a root whose `.sdd` is symlinked out | realpath containment (case-insensitive fs) or project-root check (case-sensitive fs) |
| legitimate absolute path to a second project | accepted, per the tool's contract |

On the case-variant leg: `resolve()` follows symlinks but does not fold case, so on a case-insensitive filesystem a resolved path is normalised rather than canonical. Containment is evaluated against the root as resolved in that same call, so a case variant is measured against itself and the symlink barrier still fires. A case variant of a legitimate root names the same directory on such a filesystem and is therefore accepted; `test_shutdown_signal_path_case_variant_of_a_real_root_stays_inside_it` pins that it can only reach the real project and nothing beside it.

## Notes for the reviewer

- `test_bernstein_stop_sends_stop_signal` and `test_crash_protection_bernstein_stop` previously patched `bernstein.mcp.server.Path` with a `MagicMock`. A mocked path cannot exercise a containment check, so both now use a real project root under `tmp_path`; the crash-protection test forces the failure at `Path.mkdir` instead.
- `test_stop_tool_writes_signal` in the remote-transport suite now creates `.sdd` in its workdir, which is exactly the behaviour change above.
- There is a residual TOCTOU window between the containment check and the `mkdir`. Closing it needs an `O_NOFOLLOW`-style create, which is a wider change than this fix and is not what the issue asks for.

Refs #3080
