### PR TITLE
fix(audit): record a release receipt when a task is returned to the pool

### DIFF
--- a/docs/orchestration/worker-coordination.md
+++ b/docs/orchestration/worker-coordination.md
@@ -46,6 +46,7 @@ Every transition that surrenders a held claim appends the matching
 | --- | --- |
 | `POST /tasks/{id}/force-claim` | `force_claim` |
 | `POST /tasks/{id}/reopen` | `reopen` |
+| `POST /tasks/{id}/release` | `release` |
 | `POST /tasks/{id}/cancel` | `cancel_cascade` (root and descendants) |
 | `TaskStore.cancel` | `cancel` |
 | `POST /tasks/{id}/fail` | `fail` / `fail_contract_violation` |

--- a/src/bernstein/core/tasks/task_store_core.py
+++ b/src/bernstein/core/tasks/task_store_core.py
@@ -2294,6 +2294,10 @@ class TaskStore:
             # the task de-indexed. Only in-flight tasks can be released.
             if task.status not in (TaskStatus.CLAIMED, TaskStatus.IN_PROGRESS):
                 raise IllegalTransitionError("task", task.id, task.status.value, TaskStatus.OPEN.value)
+            # Read the claim off the task before the transition clears it: this
+            # path returns the task to the pool, so it is a surrender and needs
+            # the matching task.release_receipt (#3037).
+            snapshot = self._claim_snapshot(task)
             self._index_remove(task)
             transition_task(
                 task,
@@ -2307,6 +2311,12 @@ class TaskStore:
             task.version += 1
             self._index_add(task)
             await self._append_jsonl(self._task_to_record(task))
+            self._record_release_receipt(
+                task,
+                snapshot,
+                release_path="release",
+                reason=reason or "released_to_pool",
+            )
             logger.info(
                 "task.release: task_id=%s reason=%s",
                 sanitize_log(task_id),

--- a/tests/unit/test_task_release_receipt.py
+++ b/tests/unit/test_task_release_receipt.py
@@ -127,6 +127,25 @@ class TestEveryUnclaimPathMintsAReceipt:
         assert events[0].details["released_by"] == _HOLDER
         assert events[0].details["to_status"] == "open"
 
+    async def test_release(self, tmp_path: Path) -> None:
+        """A worker handing an unstartable task back to the pool (#3018)."""
+        store, chain = _store(tmp_path)
+        _held(store)
+        await store.release("T-1", "workspace is not a usable checkout")
+        events = _releases(chain)
+        assert len(events) == 1
+        assert events[0].details["release_path"] == "release"
+        assert events[0].details["released_by"] == _HOLDER
+        assert events[0].details["from_status"] == "in_progress"
+        assert events[0].details["to_status"] == "open"
+
+    async def test_release_of_a_never_claimed_task_mints_nothing(self, tmp_path: Path) -> None:
+        """release() requires CLAIMED/IN_PROGRESS, but claim evidence still decides."""
+        store, chain = _store(tmp_path)
+        _held(store, status=TaskStatus.CLAIMED, claimed_at=None, claimed_by_session="")
+        await store.release("T-1", "spawn failed")
+        assert _releases(chain) == []
+
     async def test_cancel(self, tmp_path: Path) -> None:
         store, chain = _store(tmp_path)
         _held(store)
@@ -459,6 +478,7 @@ def _create_and_claim(client: TestClient, title: str = "release me") -> str:
         ("force-claim", None, "force_claim"),
         ("cancel", {"reason": "operator cancelled"}, "cancel_cascade"),
         ("fail", {"reason": "tests red"}, "fail"),
+        ("release", {"reason": "workspace unusable"}, "release"),
     ],
 )
 def test_plain_serve_node_mints_the_receipt(
@@ -493,6 +513,31 @@ def test_plain_serve_node_reconstructs_the_holder_over_http(plain_serve_app: Any
         assert reconstruct_claim_holders(chain.query()).get(task_id) == _HOLDER
 
         assert client.post(f"/tasks/{task_id}/force-claim").status_code == 200
+        assert task_id not in reconstruct_claim_holders(chain.query())
+
+        reclaimed = client.post(f"/tasks/{task_id}/claim", params={"claimed_by_session": "node-b"})
+        assert reclaimed.status_code == 200, reclaimed.text
+        assert reconstruct_claim_holders(chain.query()).get(task_id) == "node-b"
+
+    ok, errors = chain.verify()
+    assert ok, errors
+
+
+def test_plain_serve_node_does_not_strand_a_released_task(plain_serve_app: Any) -> None:
+    """A task handed back by /release is in the pool, so the fold must not hold it.
+
+    The window that matters is between the release and the next claim: a
+    verifier replaying the chain there must not name a node that has already
+    surrendered the task (#3018).
+    """
+    chain = plain_serve_app.state.audit_chain
+    with TestClient(plain_serve_app) as client:
+        task_id = _create_and_claim(client, "released back to the pool")
+        assert reconstruct_claim_holders(chain.query()).get(task_id) == _HOLDER
+
+        released = client.post(f"/tasks/{task_id}/release", json={"reason": "workspace unusable"})
+        assert released.status_code == 200, released.text
+        assert released.json()["status"] == "open"
         assert task_id not in reconstruct_claim_holders(chain.query())
 
         reclaimed = client.post(f"/tasks/{task_id}/claim", params={"claimed_by_session": "node-b"})
@@ -702,6 +747,7 @@ def test_the_release_guard_covers_the_known_surrender_paths() -> None:
     expected = {
         "force_claim": "force_claim",
         "reopen": "reopen",
+        "release": "release",
         "cancel": "cancel",
         "cancel_cascade": "cancel_cascade",
         "fail": "fail",


### PR DESCRIPTION
## Problem

`TaskStore.release` (added in #3027, reachable as `POST /tasks/{id}/release`)
moves a `CLAIMED` or `IN_PROGRESS` task back to `OPEN` and clears
`claimed_at`, `claimed_by_session` and `assigned_agent`. That ends a held
claim, and it appended nothing to the audit chain.

#3037 established the property that every path returning a task to the pool
records a `task.release_receipt` first, so an offline fold of the chain never
reports a task as held by a node that no longer holds it. This call site is
the one gap in that property.

Observed on `main` at 658720b7, over HTTP on a plain `bernstein serve` node:

- `/release` returns 200 with `status: open`, and the chain carries zero
  release receipts for the task;
- `reconstruct_claim_holders` still reports the task held by the releasing
  node while it sits in the open pool, claimable by anyone;
- replaying the chain in the window between the release and the next claim
  names a node that had already surrendered the task.

Once another node claims the task the fold corrects itself, so the ledger is
wrong for the interval in which a reader would consult it to answer which
node is executing this task.

## Change

`release` captures the claim snapshot before the transition and appends
`task.release_receipt` with `release_path` `release` after it, so the receipt
carries the post-transition version. This is the same shape as every other
path that returns a task to the pool.

A task carrying no claim evidence still mints nothing: `_record_release_receipt`
no-ops on `held=False`, so the never-claimed case cannot produce a surrender
for a claim that did not exist.

The append is best-effort in the same sense as the other paths, so a
read-only chain volume never rolls back a release that already happened.

## Verification

The static release guard in `tests/unit/test_task_release_receipt.py` walks
every `transition_task` call site in `TaskStore` and requires a paired
receipt. It already failed on this call site on `main`:

    FAILED test_every_claim_ending_transition_is_paired_with_a_receipt
    FAILED test_the_release_guard_covers_the_known_surrender_paths
    Left contains one more item:
      _ReleaseSite(method='release', line=2298, target='OPEN', release_paths=())

So `main` is currently red on that file. With this change the file is green
at 34 tests, up from 30, adding:

- `test_release`, the receipt shape for the new path;
- `test_release_of_a_never_claimed_task_mints_nothing`, pinning that claim
  evidence and not status decides whether a surrender happened;
- `release` in the plain-serve HTTP enumeration, so the path is covered end
  to end on a node with no orchestrator audit wiring;
- `test_plain_serve_node_does_not_strand_a_released_task`, which asserts the
  fold over the chain prefix between release and re-claim names nobody, and
  that `chain.verify()` is clean.

Also run green, unchanged: `test_task_release_requeue.py` (7),
`test_task_store.py` (10), `test_abandon_lifecycle.py` (34),
`test_completion_contract_api.py` (12), `test_task_claim_receipt_route.py` (7),
`test_task_store_property.py` (4), `test_worker_cmd_requeue.py` (3),
`test_batch_api.py` (6).

`uv run ruff check .` passes. `pyright --project pyrightconfig.strict.json`
reports 0 errors. `scripts/check_test_collection.py` reports 0 uncollected
files.

## Note

`uv run ruff format --check .` reports `tests/unit/test_cli_run_params.py`
as needing reformatting. That file is untouched here and is identical to
`origin/main`, so it is a pre-existing condition on the default branch rather
than something this branch introduces.