### PR TITLE
fix(audit): make the chain head a record embeds the head it is written with

### DIFF
--- a/src/bernstein/core/orchestration/sla_monitor.py
+++ b/src/bernstein/core/orchestration/sla_monitor.py
@@ -23,6 +23,7 @@ disk tree; the default provider reads the on-disk substrate.
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import logging
@@ -381,10 +382,9 @@ class SLAMonitor:
         """
         emitted: list[SLAViolationReceipt] = []
         audit_entries = read_audit_window(self._store.sdd_dir, window=self._audit_window)
-        prev = self._chain.prev_chain_digest if self._chain is not None else ""
         for contract in self._store.list():
             try:
-                receipt = self._evaluate_one(contract, now, audit_entries, prev)
+                receipt = self._evaluate_one(contract, now, audit_entries)
             except Exception:  # pragma: no cover - defensive: one bad contract must not wedge the tick
                 logger.exception("SLA evaluation failed for contract %s", contract.id)
                 continue
@@ -397,24 +397,41 @@ class SLAMonitor:
         contract: SLAContract,
         now: int,
         audit_entries: list[dict[str, Any]],
-        prev: str,
     ) -> SLAViolationReceipt | None:
+        # Evidence gathering reads the substrate and does not depend on the chain
+        # head, so it stays outside the section that holds the chain.
         evidence = self._evidence_provider(contract, now)
-        receipt = build_receipt(
-            contract=contract,
-            evidence=evidence,
-            now=now,
-            caps=self._caps,
-            audit_entries=audit_entries,
-            identity=self._identity,
-            public_key=self._public_key,
-            prev_chain_digest=prev,
-        )
-        if receipt is None:
-            return None
-        signed = sign_receipt(receipt, signing_key=self._signing_key)
-        write_receipt(self._store.sdd_dir, signed)
-        self._record_chain_event(signed)
+
+        # The head is read per receipt, and inside the same section that appends
+        # that receipt's chain event. A tick appends once per breach, so a head
+        # captured once for the whole tick is already stale for the second
+        # receipt: the receipt signs ``prev_chain_digest`` and the verifier
+        # compares it against the chain entry, so a stale value turns a genuine
+        # breach receipt into one that fails its own anchor check.
+        with contextlib.ExitStack() as stack:
+            if self._chain is not None:
+                stack.enter_context(self._chain.chain_transaction())
+                prev = self._chain.resync_head()
+            else:
+                prev = ""
+            receipt = build_receipt(
+                contract=contract,
+                evidence=evidence,
+                now=now,
+                caps=self._caps,
+                audit_entries=audit_entries,
+                identity=self._identity,
+                public_key=self._public_key,
+                prev_chain_digest=prev,
+            )
+            if receipt is None:
+                return None
+            signed = sign_receipt(receipt, signing_key=self._signing_key)
+            write_receipt(self._store.sdd_dir, signed)
+            self._record_chain_event(signed)
+
+        # The sink is caller-supplied and may be slow or may itself touch the
+        # chain, so it runs after the section is released.
         if self._trigger_sink is not None:
             self._trigger_sink(normalize_sla_violation(signed))
         return signed

--- a/src/bernstein/core/security/audit.py
+++ b/src/bernstein/core/security/audit.py
@@ -959,11 +959,13 @@ class AuditLog:
             The chain head as recovered from disk under the verifier's framing.
         """
         self._prev_hmac = self._recover_chain_tail()
-        # ``log``'s fast path trusts (path, size) bookkeeping from this
-        # instance's last append; a head re-read from disk retires it, so the
-        # next append re-derives the tail rather than trusting stale sizes.
-        self._synced_path = None
-        self._synced_size = -1
+        # Re-point ``log``'s (path, size) fast path at what we just read, so an
+        # append inside the same section does not pay a second full-file scan.
+        # The day file is re-derived rather than assumed: if the clock rolls over
+        # between here and the append, the paths differ and ``log`` re-syncs.
+        day_path = self._audit_dir / f"{datetime.now(tz=UTC).strftime('%Y-%m-%d')}.jsonl"
+        self._synced_path = day_path
+        self._synced_size = _path_size(day_path)
         return self._prev_hmac
 
     # -- write --------------------------------------------------------------

--- a/src/bernstein/core/security/audit.py
+++ b/src/bernstein/core/security/audit.py
@@ -27,6 +27,7 @@ import secrets
 import shutil
 import stat
 import sys
+import threading
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -336,6 +337,32 @@ def _compute_hmac(key: bytes, prev_hmac: str, entry: dict[str, Any]) -> str:
     return _hmac.new(key, payload.encode(), hashlib.sha256).hexdigest()
 
 
+#: Per-audit-dir re-entrancy state for :func:`_chain_append_lock`.
+#:
+#: ``flock`` locks attach to an *open file description*, not to a process or a
+#: thread, so a second ``os.open`` + ``flock(LOCK_EX)`` from the thread that
+#: already holds the lock blocks on itself. That makes the naive way of turning
+#: "read the head" and "append the record" into one atomic section -- wrapping
+#: :meth:`AuditLog.log` in another ``_chain_append_lock`` -- a deadlock. The
+#: per-thread depth counter lets the outermost acquisition own the ``flock``
+#: while inner ones pass through, and the per-dir ``RLock`` keeps a *different*
+#: thread out for the whole nested section, so re-entrancy never widens the
+#: window it exists to close.
+_APPEND_GUARDS: dict[str, threading.RLock] = {}
+_APPEND_GUARDS_LOCK = threading.Lock()
+_APPEND_DEPTH = threading.local()
+
+
+def _append_guard(audit_key: str) -> threading.RLock:
+    """Return the process-wide re-entrant guard for one audit dir."""
+    with _APPEND_GUARDS_LOCK:
+        guard = _APPEND_GUARDS.get(audit_key)
+        if guard is None:
+            guard = threading.RLock()
+            _APPEND_GUARDS[audit_key] = guard
+        return guard
+
+
 @contextlib.contextmanager
 def _chain_append_lock(audit_dir: Path) -> Iterator[None]:
     """Serialise daily-log appends across processes via ``flock(LOCK_EX)``.
@@ -353,20 +380,45 @@ def _chain_append_lock(audit_dir: Path) -> Iterator[None]:
     the previous day). Falls back to a no-op on platforms without ``fcntl``
     (Windows); the in-process locks callers may hold remain the only ordering
     there, matching how the lineage spine degrades.
+
+    The section is re-entrant *within one thread*: a caller that must read the
+    chain head and append the record that sits on it without an interleaving
+    writer holds this lock across both, and the ``AuditLog.log`` inside it
+    re-enters rather than deadlocking. Other threads and other processes still
+    wait for the outermost section to end.
     """
     audit_dir.mkdir(parents=True, exist_ok=True)
-    if fcntl is None:  # pragma: no cover - Windows path
-        yield
-        return
-    lock_path = audit_dir / ".chain.lock"
-    fd = os.open(str(lock_path), os.O_WRONLY | os.O_CREAT, 0o600)
-    try:
-        fcntl.flock(fd, fcntl.LOCK_EX)
-        yield
-    finally:
-        with contextlib.suppress(OSError):
-            fcntl.flock(fd, fcntl.LOCK_UN)
-        os.close(fd)
+    audit_key = str(audit_dir.resolve())
+    guard = _append_guard(audit_key)
+    depths: dict[str, int] | None = getattr(_APPEND_DEPTH, "depths", None)
+    if depths is None:
+        depths = {}
+        _APPEND_DEPTH.depths = depths
+
+    with guard:
+        depths[audit_key] = depths.get(audit_key, 0) + 1
+        try:
+            if depths[audit_key] > 1:
+                # Already inside this thread's section: the outermost frame
+                # holds the flock, so re-taking it would block on ourselves.
+                yield
+                return
+            if fcntl is None:  # pragma: no cover - Windows path
+                yield
+                return
+            lock_path = audit_dir / ".chain.lock"
+            fd = os.open(str(lock_path), os.O_WRONLY | os.O_CREAT, 0o600)
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX)
+                yield
+            finally:
+                with contextlib.suppress(OSError):
+                    fcntl.flock(fd, fcntl.LOCK_UN)
+                os.close(fd)
+        finally:
+            depths[audit_key] -= 1
+            if not depths[audit_key]:
+                del depths[audit_key]
 
 
 def _path_size(path: Path) -> int:
@@ -876,6 +928,43 @@ class AuditLog:
             if tip is not None:
                 return tip
         return _GENESIS_HMAC
+
+    # -- head ---------------------------------------------------------------
+
+    @contextlib.contextmanager
+    def append_transaction(self) -> Iterator[None]:
+        """Hold the chain against other writers for a read-then-append section.
+
+        :meth:`resync_head` is only meaningful inside this section: outside it,
+        another writer can append between the read and the record that is
+        supposed to sit on what was read. Re-entrant for the calling thread, so
+        the :meth:`log` inside the section does not block on itself; exclusive
+        against every other thread and process.
+        """
+        with _chain_append_lock(self._audit_dir):
+            yield
+
+    def resync_head(self) -> str:
+        """Re-read the chain head from disk and return it.
+
+        The cached head this instance carries reflects its *own* appends: a
+        record another process wrote lands on disk without touching it. A caller
+        that embeds the head into a payload it signs must read it through here,
+        and must do so inside the same :func:`_chain_append_lock` section that
+        appends the record, or another writer can overtake the value between the
+        read and the append -- leaving a signature that names a chain position
+        its own record does not occupy.
+
+        Returns:
+            The chain head as recovered from disk under the verifier's framing.
+        """
+        self._prev_hmac = self._recover_chain_tail()
+        # ``log``'s fast path trusts (path, size) bookkeeping from this
+        # instance's last append; a head re-read from disk retires it, so the
+        # next append re-derives the tail rather than trusting stale sizes.
+        self._synced_path = None
+        self._synced_size = -1
+        return self._prev_hmac
 
     # -- write --------------------------------------------------------------
 

--- a/src/bernstein/core/security/audit.py
+++ b/src/bernstein/core/security/audit.py
@@ -348,6 +348,13 @@ def _compute_hmac(key: bytes, prev_hmac: str, entry: dict[str, Any]) -> str:
 #: while inner ones pass through, and the per-dir ``RLock`` keeps a *different*
 #: thread out for the whole nested section, so re-entrancy never widens the
 #: window it exists to close.
+#:
+#: Guards are keyed by the *resolved* audit dir and never evicted. Resolving is
+#: load-bearing, not tidiness: two spellings of one directory would map to two
+#: guards, and a thread that entered under one spelling and re-entered under the
+#: other would see depth 0 and re-take the ``flock`` it already holds. Eviction
+#: is unsafe for the same reason a lock cannot be recreated while held, and the
+#: live set is one entry per audit dir a process actually writes to.
 _APPEND_GUARDS: dict[str, threading.RLock] = {}
 _APPEND_GUARDS_LOCK = threading.Lock()
 _APPEND_DEPTH = threading.local()
@@ -958,14 +965,21 @@ class AuditLog:
         Returns:
             The chain head as recovered from disk under the verifier's framing.
         """
-        self._prev_hmac = self._recover_chain_tail()
-        # Re-point ``log``'s (path, size) fast path at what we just read, so an
-        # append inside the same section does not pay a second full-file scan.
-        # The day file is re-derived rather than assumed: if the clock rolls over
-        # between here and the append, the paths differ and ``log`` re-syncs.
+        # Shares ``log``'s (path, size) fast path, in both directions. Reading it:
+        # when the day file is byte-length-identical to what our own last append
+        # or resync left it at, nothing has been appended since and the cached
+        # head still stands, so nesting two resyncs inside one section costs one
+        # scan rather than two. Writing it: an append later in the same section
+        # skips its own scan. The day file is re-derived rather than assumed, so a
+        # clock rollover between here and the append shows up as a path mismatch
+        # and re-syncs. An append only ever grows the file, so a changed tail
+        # cannot hide behind an unchanged size.
         day_path = self._audit_dir / f"{datetime.now(tz=UTC).strftime('%Y-%m-%d')}.jsonl"
-        self._synced_path = day_path
-        self._synced_size = _path_size(day_path)
+        day_size = _path_size(day_path)
+        if day_path != self._synced_path or day_size != self._synced_size:
+            self._prev_hmac = self._recover_chain_tail()
+            self._synced_path = day_path
+            self._synced_size = day_size
         return self._prev_hmac
 
     # -- write --------------------------------------------------------------

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -25,12 +25,13 @@ is treated as the stable surface. Helpers MUST:
 
 from __future__ import annotations
 
+import contextlib
 import threading
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Sequence
+    from collections.abc import Iterable, Iterator, Sequence
     from pathlib import Path
 
 from bernstein.core.security.audit import (
@@ -922,13 +923,50 @@ class AuditChainStore:
         # lock, keeping the on-disk chain order consistent with the
         # ``prev_chain_digest`` each event embedded.
         # (bot-ack: 3284182792 -- CodeRabbit major.)
-        self._append_lock = threading.Lock()
+        # Re-entrant so :meth:`chain_transaction` can hold it across a
+        # read-then-append section whose append re-takes it.
+        self._append_lock = threading.RLock()
 
     # -- public surface -----------------------------------------------------
 
+    @contextlib.contextmanager
+    def chain_transaction(self) -> Iterator[None]:
+        """Hold the chain against other writers for a read-then-append section.
+
+        A caller that embeds the chain head into a payload it signs cannot read
+        the head and append its record as two independent steps: the work in
+        between (an Ed25519 signature, say) is a window in which another thread
+        or another process appends, and the record then chains onto a different
+        predecessor than the one the signature names. Because the head is opaque
+        bytes inside the signature, no verifier can notice.
+
+        Inside this section :meth:`resync_head` reads the true head and the
+        append that follows lands on exactly it. The section is re-entrant for
+        the calling thread and exclusive against every other thread and process.
+        """
+        with self._append_lock, self._log.append_transaction():
+            yield
+
+    def resync_head(self) -> str:
+        """Return the chain head re-read from disk, not from this instance's cache.
+
+        Use inside :meth:`chain_transaction` when the head is about to be signed
+        into a payload; see :attr:`prev_chain_digest` for why the cached read is
+        not sufficient there.
+        """
+        return self._log.resync_head()
+
     @property
     def prev_chain_digest(self) -> str:
-        """Return the HMAC of the most recent event (the chain head)."""
+        """Return the HMAC of the most recent event (the chain head).
+
+        This is a per-instance cached value: it does not see another process's
+        appends, and it is read without holding the append lock. It is therefore
+        safe only for callers that just want to observe the head. A caller that
+        *signs* the head into a payload must instead open a
+        :meth:`chain_transaction` and read through :meth:`resync_head`, so the
+        value it signs is the one its own record ends up chained onto.
+        """
         # AuditLog tracks _prev_hmac internally; exposing it here gives
         # callers the value to embed inside the next event's payload
         # without breaking the chain (the embedded value is part of the

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -988,10 +988,18 @@ class AuditChainStore:
         two concurrent calls always see distinct ``prev_chain_digest``
         values and the underlying chain stays linear.
         (bot-ack: 3284182792 -- CodeRabbit major.)
+
+        The digest is re-read from disk inside the append section rather than
+        taken from this instance's cache. A cached read sees only our own
+        appends, while the append itself re-syncs, so another process's record
+        landing in between made the event's embedded ``prev_chain_digest``
+        disagree with the ``prev_hmac`` the record was actually written with --
+        an event asserting a chain position it does not occupy, in the one field
+        a reader consults to check that very linkage.
         """
-        with self._append_lock:
+        with self._append_lock, self._log.append_transaction():
             merged: dict[str, Any] = details.copy()
-            merged["prev_chain_digest"] = self.prev_chain_digest
+            merged["prev_chain_digest"] = self._log.resync_head()
             return self._log.log(
                 event_type=event_type,
                 actor=actor,

--- a/src/bernstein/core/security/capability_tokens.py
+++ b/src/bernstein/core/security/capability_tokens.py
@@ -69,6 +69,7 @@ format. The projection refuses an unverified chain.
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import posixpath
@@ -96,6 +97,8 @@ from bernstein.core.security.agent_card_signer import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from bernstein.core.security.audit import AuditEvent
     from bernstein.core.security.audit_chain import AuditChainStore
 
@@ -536,10 +539,27 @@ def _anchor_and_head(
     audit_chain: AuditChainStore | None,
     default_head: str,
 ) -> str:
-    """Return the audit head to bind into a mint (the chain tip, or default)."""
+    """Return the audit head to bind into a mint (the chain tip, or default).
+
+    Read from disk, not from the store's cache, and only meaningful inside the
+    :meth:`AuditChainStore.chain_transaction` that also records the mint: the
+    head is signed into the token and ``_audit_head_matches`` compares it back
+    against the mint record, so a head that moves in between turns a valid token
+    into one that fails its own anchor check.
+    """
     if audit_chain is None:
         return default_head
-    return audit_chain.prev_chain_digest
+    return audit_chain.resync_head()
+
+
+@contextlib.contextmanager
+def _mint_section(audit_chain: AuditChainStore | None) -> Iterator[None]:
+    """Hold the chain across capture-head -> sign -> record, when one is wired."""
+    if audit_chain is None:
+        yield
+        return
+    with audit_chain.chain_transaction():
+        yield
 
 
 def _record_mint(audit_chain: AuditChainStore | None, token: CapabilityToken) -> AuditEvent | None:
@@ -580,19 +600,20 @@ def mint_root(
     audit event is emitted whose ``token_hash`` and ``prev_chain_digest``
     cross-reference this token.
     """
-    head = _anchor_and_head(audit_chain, audit_head)
-    token = sign_token(
-        token_id=token_id or uuid.uuid4().hex,
-        issuer_identity_id=issuer_identity_id,
-        issuer_private_key=issuer_private_key,
-        subject_identity_id=subject_identity_id,
-        subject_pubkey=subject_pubkey,
-        caveats=caveats,
-        parent_token_hash=GENESIS_PARENT,
-        audit_head=head,
-        granted_at=granted_at if granted_at is not None else time.time(),
-    )
-    _record_mint(audit_chain, token)
+    with _mint_section(audit_chain):
+        head = _anchor_and_head(audit_chain, audit_head)
+        token = sign_token(
+            token_id=token_id or uuid.uuid4().hex,
+            issuer_identity_id=issuer_identity_id,
+            issuer_private_key=issuer_private_key,
+            subject_identity_id=subject_identity_id,
+            subject_pubkey=subject_pubkey,
+            caveats=caveats,
+            parent_token_hash=GENESIS_PARENT,
+            audit_head=head,
+            granted_at=granted_at if granted_at is not None else time.time(),
+        )
+        _record_mint(audit_chain, token)
     return token
 
 
@@ -626,19 +647,20 @@ def attenuate(
             "child caveats widen the parent (permissions, task_ids, path_prefixes, "
             "expiry, max_uses, or remaining_depth); tokens may only narrow"
         )
-    head = _anchor_and_head(audit_chain, audit_head if audit_head is not None else parent.audit_head)
-    token = sign_token(
-        token_id=token_id or uuid.uuid4().hex,
-        issuer_identity_id=parent.subject_identity_id,
-        issuer_private_key=issuer_private_key,
-        subject_identity_id=subject_identity_id,
-        subject_pubkey=subject_pubkey,
-        caveats=caveats,
-        parent_token_hash=parent.token_hash(),
-        audit_head=head,
-        granted_at=granted_at if granted_at is not None else time.time(),
-    )
-    _record_mint(audit_chain, token)
+    with _mint_section(audit_chain):
+        head = _anchor_and_head(audit_chain, audit_head if audit_head is not None else parent.audit_head)
+        token = sign_token(
+            token_id=token_id or uuid.uuid4().hex,
+            issuer_identity_id=parent.subject_identity_id,
+            issuer_private_key=issuer_private_key,
+            subject_identity_id=subject_identity_id,
+            subject_pubkey=subject_pubkey,
+            caveats=caveats,
+            parent_token_hash=parent.token_hash(),
+            audit_head=head,
+            granted_at=granted_at if granted_at is not None else time.time(),
+        )
+        _record_mint(audit_chain, token)
     return token
 
 

--- a/src/bernstein/core/trigger_sources/receipt.py
+++ b/src/bernstein/core/trigger_sources/receipt.py
@@ -660,43 +660,53 @@ def admit_trigger(
 
     outcome = TRIGGER_OUTCOME_REFUSED if reason else TRIGGER_OUTCOME_ADMITTED
     chain = _chain_store(audit_dir, hmac_key)
-    unsigned = TriggerReceipt(
-        trigger_id=trigger_id,
-        platform=platform,
-        request_path=request_path,
-        payload_digest=payload_digest,
-        graph_digest=graph_digest,
-        scope="" if reason else scope,
-        outcome=outcome,
-        refusal_reason=reason,
-        # The head read before appending: the chain position the trigger was
-        # adjudicated at, and part of the signed binding.
-        admission_chain_head=chain.prev_chain_digest,
-        replay_protected=enforce_replay,
-        timestamp=timestamp,
-        task_ids=() if reason else task_ids,
-    )
 
+    # Loading the bridge identity may create and persist a keypair; it does not
+    # depend on the chain head, so it stays outside the section below rather
+    # than holding the chain against every other writer while it runs.
     private_pem, public_pem = load_or_create_bridge_identity(root)
+    from bernstein.core.security.audit_chain import record_trigger_receipt
     from bernstein.core.skills.catalog.signature import sign_payload
 
-    signature = sign_payload(unsigned.to_canonical_bytes(), private_pem)
+    # Reading the head, signing it, and appending the record that sits on it are
+    # one atomic section. Split apart, a writer appending during the signature
+    # leaves the receipt naming a chain position its own record does not occupy,
+    # and the head is opaque payload to the signature so nothing downstream can
+    # tell. The head is read from disk here, not from the store's cache, so
+    # another process's appends are seen too.
+    with chain.chain_transaction():
+        unsigned = TriggerReceipt(
+            trigger_id=trigger_id,
+            platform=platform,
+            request_path=request_path,
+            payload_digest=payload_digest,
+            graph_digest=graph_digest,
+            scope="" if reason else scope,
+            outcome=outcome,
+            refusal_reason=reason,
+            # The head this trigger was adjudicated at, and part of the signed
+            # binding: the record appended below chains onto exactly it.
+            admission_chain_head=chain.resync_head(),
+            replay_protected=enforce_replay,
+            timestamp=timestamp,
+            task_ids=() if reason else task_ids,
+        )
 
-    from bernstein.core.security.audit_chain import record_trigger_receipt
+        signature = sign_payload(unsigned.to_canonical_bytes(), private_pem)
 
-    event = record_trigger_receipt(
-        chain=chain,
-        trigger_id=trigger_id,
-        platform=platform,
-        request_path=request_path,
-        payload_digest=payload_digest,
-        graph_digest=graph_digest,
-        scope=unsigned.scope,
-        outcome=outcome,
-        receipt_digest=unsigned.binding_digest(),
-        refusal_reason=reason,
-        suppressed_refusals=suppressed,
-    )
+        event = record_trigger_receipt(
+            chain=chain,
+            trigger_id=trigger_id,
+            platform=platform,
+            request_path=request_path,
+            payload_digest=payload_digest,
+            graph_digest=graph_digest,
+            scope=unsigned.scope,
+            outcome=outcome,
+            receipt_digest=unsigned.binding_digest(),
+            refusal_reason=reason,
+            suppressed_refusals=suppressed,
+        )
 
     receipt = TriggerReceipt(
         trigger_id=unsigned.trigger_id,
@@ -875,30 +885,37 @@ def emit_status_proof(
     effective_status = status or derive_status(payload)
     run_id = str(payload.get("run_id", "") or "")
     chain = _chain_store(audit_dir, hmac_key)
-    unsigned = StatusProof(
-        event_id=event_id,
-        run_id=run_id,
-        status=effective_status,
-        producing_event_digest=compute_document_digest(payload),
-        chain_head=chain.prev_chain_digest,
-        timestamp=timestamp,
-    )
 
+    # Outside the section below: no dependency on the chain head, and creating
+    # the keypair should not hold the chain against other writers.
     private_pem, public_pem = load_or_create_bridge_identity(root)
+    from bernstein.core.security.audit_chain import record_status_proof
     from bernstein.core.skills.catalog.signature import sign_payload
 
-    signature = sign_payload(unsigned.to_canonical_bytes(), private_pem)
+    # One atomic section for the same reason as the trigger path: the head is
+    # signed into the proof, so it has to be the head the proof's own record
+    # ends up chained onto, and it is read from disk rather than from the
+    # store's per-instance cache.
+    with chain.chain_transaction():
+        unsigned = StatusProof(
+            event_id=event_id,
+            run_id=run_id,
+            status=effective_status,
+            producing_event_digest=compute_document_digest(payload),
+            chain_head=chain.resync_head(),
+            timestamp=timestamp,
+        )
 
-    from bernstein.core.security.audit_chain import record_status_proof
+        signature = sign_payload(unsigned.to_canonical_bytes(), private_pem)
 
-    event = record_status_proof(
-        chain=chain,
-        event_id=event_id,
-        run_id=run_id,
-        status=effective_status,
-        producing_event_digest=unsigned.producing_event_digest,
-        proof_digest=unsigned.binding_digest(),
-    )
+        event = record_status_proof(
+            chain=chain,
+            event_id=event_id,
+            run_id=run_id,
+            status=effective_status,
+            producing_event_digest=unsigned.producing_event_digest,
+            proof_digest=unsigned.binding_digest(),
+        )
 
     proof = StatusProof(
         event_id=unsigned.event_id,

--- a/tests/integration/test_sla_audit_chain.py
+++ b/tests/integration/test_sla_audit_chain.py
@@ -196,3 +196,51 @@ def test_error_budget_report_is_byte_identical_across_checkouts(tmp_path: Path) 
     assert json.dumps(report_a, sort_keys=True) == json.dumps(report_b, sort_keys=True)
     assert report_a["error_budget"]["failed_events"] == 1  # type: ignore[index]
     assert report_a["error_budget"]["total_events"] == 2  # type: ignore[index]
+
+
+def test_every_violation_receipt_in_a_tick_carries_its_own_records_head(tmp_path: Path) -> None:
+    """Each receipt's ``prev_chain_digest`` is the head its own chain event sits on.
+
+    The receipt binds ``prev_chain_digest`` into the payload it signs, and the
+    verifier compares that value against the chain entry (see
+    ``sla_receipt._chain_link``). A tick that breaches more than one contract
+    appends once per breach, so a head captured once for the whole tick is stale
+    for every receipt after the first: the signed value names a chain position
+    the record does not sit on, and full-chain verification of the receipt's
+    anchor no longer agrees with the receipt.
+    """
+    sdd = tmp_path / ".sdd"
+    sdd.mkdir()
+    store = SLAStore(sdd)
+    # Two contracts over the same stale artifact: one tick, two breaches.
+    for subject_id in ("sched_nightly", "sched_weekly"):
+        store.add(
+            build_contract(
+                subject_type="schedule",
+                subject_id=subject_id,
+                artifact_freshness_s=90_000,
+                artifact_path=_ARTIFACT,
+            )
+        )
+    _seed_stale_artifact(sdd, age_s=200_000)
+
+    chain = AuditChainStore(sdd / "audit", key=load_or_create_audit_key())
+    monitor = build_monitor_from_sdd(sdd, chain=chain)
+
+    receipts = monitor.evaluate(_NOW)
+    assert len(receipts) == 2, "both contracts must breach for this to test anything"
+
+    events = chain.query(event_type="sla.violation")
+    assert len(events) == 2
+    by_receipt = {str(e.details["receipt_digest"]): e for e in events}
+
+    for receipt in receipts:
+        event = by_receipt.get(receipt.payload_digest)
+        assert event is not None, f"no chain event anchors receipt {receipt.receipt_id}"
+        assert receipt.prev_chain_digest == event.details["prev_chain_digest"], (
+            f"receipt {receipt.receipt_id} signed head {receipt.prev_chain_digest!r} "
+            f"but its own chain event sits on {event.details['prev_chain_digest']!r}"
+        )
+
+    ok, errors = chain.verify()
+    assert ok, errors

--- a/tests/unit/protocols/mcp/test_stateless_migration.py
+++ b/tests/unit/protocols/mcp/test_stateless_migration.py
@@ -20,6 +20,7 @@ All tests isolate state with ``tmp_path``; no sockets are opened.
 from __future__ import annotations
 
 import json
+import threading
 from datetime import date
 from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
@@ -510,6 +511,28 @@ class TestCallIndexAllocation:
         assert chain.query(event_type=EVENT_MCP_STATELESS_CALL) == []
 
 
+def _held_against_other_threads(lock: threading.Lock | threading.RLock) -> bool:
+    """Return whether ``lock`` would block an acquire from a *different* thread.
+
+    The append lock is re-entrant, so the owning thread can always re-acquire
+    it and ``locked()`` is not part of the re-entrant lock's public surface.
+    Probing from another thread states the guarantee the test is really about:
+    a concurrent writer is kept out for the whole critical section.
+    """
+    outcome: dict[str, bool] = {}
+
+    def _probe() -> None:
+        acquired = lock.acquire(blocking=False)
+        outcome["acquired"] = acquired
+        if acquired:
+            lock.release()
+
+    prober = threading.Thread(target=_probe)
+    prober.start()
+    prober.join()
+    return not outcome["acquired"]
+
+
 class TestChainReconstruction:
     def _seed(self, tmp_path: Path, count: int = 3) -> AuditChainStore:
         chain = AuditChainStore(tmp_path / "audit", key=b"k" * 32)
@@ -582,7 +605,7 @@ class TestChainReconstruction:
         real_verify = chain._log.verify
 
         def _spy_verify() -> tuple[bool, list[str]]:
-            observed["locked_during_verify"] = chain._append_lock.locked()
+            observed["locked_during_verify"] = _held_against_other_threads(chain._append_lock)
             return real_verify()
 
         chain._log.verify = _spy_verify  # type: ignore[method-assign]
@@ -590,7 +613,7 @@ class TestChainReconstruction:
         assert ok
         assert observed["locked_during_verify"] is True
         # The lock is released once the operation returns.
-        assert not chain._append_lock.locked()
+        assert not _held_against_other_threads(chain._append_lock)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/security/test_receipt_chain_head_atomicity.py
+++ b/tests/unit/security/test_receipt_chain_head_atomicity.py
@@ -1,0 +1,198 @@
+"""The head a bridge receipt signs is the head its own chain record sits on.
+
+Both bridge receipt paths embed the chain head into the payload they
+Ed25519-sign, and only then append their own record. The head is opaque bytes
+inside that signature, so nothing downstream can notice when the two disagree:
+a verifier recomputes the binding, matches it, and accepts a receipt that names
+a chain position its record does not occupy.
+
+The window between the head read and the append is real work -- an Ed25519
+signature over the canonical payload -- so another writer appending in that
+window is not a theoretical interleaving. These tests put a genuine concurrent
+append there (a second thread, as a second process would) and pin the invariant
+that closes the gap: the head the receipt carries equals the ``prev_hmac`` of
+the record the receipt is anchored to.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bernstein.core.security.audit import load_or_create_audit_key
+from bernstein.core.trigger_sources.receipt import admit_trigger, emit_status_proof
+
+_BODY = json.dumps({"title": "Rotate the deploy key", "description": "quarterly"}).encode()
+_PAYLOAD: dict[str, Any] = {"event_id": "ev-77", "run_id": "run-77", "severity": "error"}
+
+# The other writer signals that it is about to append, which is waited on
+# deterministically; only the append itself is then given a bounded grace
+# period. Unserialised that append takes about a millisecond, so the grace is
+# orders of magnitude more than it needs; serialised it blocks until the section
+# ends and the grace is what the suite pays instead of hanging.
+_INTERLOPER_START_S = 10.0
+_INTERLOPER_GRACE_S = 1.5
+
+
+@pytest.fixture()
+def bridge(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Return an isolated bridge root, audit dir, and HMAC key."""
+    monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(tmp_path / "audit.key"))
+    return {
+        "root": tmp_path / "automation-bridge",
+        "audit_dir": tmp_path / "audit",
+        "hmac_key": load_or_create_audit_key(tmp_path / "audit.key"),
+    }
+
+
+def _seed_chain(bridge: dict[str, Any], count: int = 2) -> None:
+    """Put real events on the chain so the head under test is not genesis."""
+    for index in range(count):
+        admit_trigger(
+            root=bridge["root"],
+            audit_dir=bridge["audit_dir"],
+            hmac_key=bridge["hmac_key"],
+            platform="n8n",
+            request_path="/webhook",
+            trigger_id=f"seed-{index}",
+            body=_BODY,
+            scope="task:create",
+            timestamp=1_700_000_000,
+        )
+
+
+def _record_by_hmac(audit_dir: Path, entry_hmac: str) -> dict[str, Any]:
+    """Return the chain record whose ``hmac`` is *entry_hmac*.
+
+    Reads with the writer's framing (``b"\\n"``-delimited canonical JSON) so a
+    record fused onto an unterminated neighbour is reported as missing rather
+    than silently half-parsed.
+    """
+    for log_path in sorted(audit_dir.glob("*.jsonl")):
+        for raw_line in log_path.read_bytes().split(b"\n"):
+            if not raw_line:
+                continue
+            try:
+                parsed = json.loads(raw_line)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                continue
+            if isinstance(parsed, dict) and parsed.get("hmac") == entry_hmac:
+                return parsed
+    raise AssertionError(f"no chain record carries hmac {entry_hmac!r}")
+
+
+class _ConcurrentAppender:
+    """Append to the chain from another thread inside the signing window.
+
+    Patched over ``sign_payload``, which is the real work sitting between the
+    head read and the append. The append runs on its own thread because that is
+    what a second writer is: a thread of execution the receipt path does not
+    control, which an in-process re-entrant lock must not wave through.
+    """
+
+    def __init__(self, audit_dir: Path, hmac_key: bytes) -> None:
+        self._audit_dir = audit_dir
+        self._hmac_key = hmac_key
+        self._fired = False
+        self._thread: threading.Thread | None = None
+        self.started = threading.Event()
+        self.landed = threading.Event()
+
+    def _append(self) -> None:
+        from bernstein.core.security.audit_chain import AuditChainStore
+
+        store = AuditChainStore(self._audit_dir, key=self._hmac_key)
+        self.started.set()
+        store.log(
+            event_type="test.interloper",
+            actor="other-writer",
+            resource_type="test",
+            resource_id="interloper",
+            details={},
+        )
+        self.landed.set()
+
+    def install(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from bernstein.core.skills.catalog import signature as signature_module
+
+        real_sign = signature_module.sign_payload
+
+        def sign_with_a_concurrent_append(payload: bytes, private_pem: str) -> str:
+            if not self._fired:
+                self._fired = True
+                self._thread = threading.Thread(target=self._append, daemon=True)
+                self._thread.start()
+                # Wait for the other writer to actually reach its append, so the
+                # race is entered rather than merely scheduled...
+                assert self.started.wait(_INTERLOPER_START_S), "the other writer never started"
+                # ...then give that append every chance to land first.
+                # Unserialised it does; serialised it blocks and we fall through.
+                self.landed.wait(_INTERLOPER_GRACE_S)
+            return real_sign(payload, private_pem)
+
+        monkeypatch.setattr(signature_module, "sign_payload", sign_with_a_concurrent_append)
+
+    def join(self) -> None:
+        """Let the other writer finish so it cannot outlive the test."""
+        if self._thread is not None:
+            self._thread.join(timeout=_INTERLOPER_START_S)
+            assert not self._thread.is_alive(), "the other writer never completed its append"
+
+
+def test_trigger_receipt_head_is_its_own_records_predecessor(
+    bridge: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A concurrent append cannot move the head out from under a trigger receipt."""
+    _seed_chain(bridge)
+    appender = _ConcurrentAppender(bridge["audit_dir"], bridge["hmac_key"])
+    appender.install(monkeypatch)
+
+    admission = admit_trigger(
+        root=bridge["root"],
+        audit_dir=bridge["audit_dir"],
+        hmac_key=bridge["hmac_key"],
+        platform="n8n",
+        request_path="/webhook",
+        trigger_id="trigger-under-test",
+        body=_BODY,
+        scope="task:create",
+        timestamp=1_700_000_100,
+    )
+    appender.join()
+
+    receipt = admission.receipt
+    assert receipt is not None
+    record = _record_by_hmac(bridge["audit_dir"], receipt.chain_entry_hash)
+    assert receipt.admission_chain_head == record["prev_hmac"], (
+        "the receipt signed a chain head its own record does not sit on: "
+        f"signed {receipt.admission_chain_head!r}, record follows {record['prev_hmac']!r}"
+    )
+
+
+def test_status_proof_head_is_its_own_records_predecessor(
+    bridge: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A concurrent append cannot move the head out from under a status proof."""
+    _seed_chain(bridge)
+    appender = _ConcurrentAppender(bridge["audit_dir"], bridge["hmac_key"])
+    appender.install(monkeypatch)
+
+    proof = emit_status_proof(
+        root=bridge["root"],
+        audit_dir=bridge["audit_dir"],
+        hmac_key=bridge["hmac_key"],
+        payload=_PAYLOAD,
+        status="failed",
+        timestamp=1_700_000_500,
+    )
+    appender.join()
+
+    record = _record_by_hmac(bridge["audit_dir"], proof.chain_entry_hash)
+    assert proof.chain_head == record["prev_hmac"], (
+        "the proof signed a chain head its own record does not sit on: "
+        f"signed {proof.chain_head!r}, record follows {record['prev_hmac']!r}"
+    )

--- a/tests/unit/test_capability_token_audit_anchor.py
+++ b/tests/unit/test_capability_token_audit_anchor.py
@@ -10,7 +10,10 @@ chain to confirm the anchor without ever depending on it for tamper detection.
 from __future__ import annotations
 
 import os
+import threading
 from pathlib import Path
+
+import pytest
 
 from bernstein.core.security import capability_tokens as ct
 from bernstein.core.security.agent_card_signer import generate_ed25519_keypair
@@ -140,3 +143,69 @@ def test_verify_chain_flags_missing_audit_anchor(tmp_path: Path) -> None:
     result = ct.verify_chain(cap_chain, trust_anchors=anchors, audit_chain=anchor_chain)
     assert not result.valid
     assert any("audit anchor" in e for e in result.hops[0].errors)
+
+
+def test_mint_audit_head_matches_its_own_delegation_record(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A writer appending while the token is signed cannot move the anchor.
+
+    ``verify_chain`` checks the two-way cross-reference the other way round: the
+    ``delegation_minted`` event's ``prev_chain_digest`` must equal the token's
+    ``audit_head`` (see ``_audit_head_matches``). Reading the head and appending
+    the record as separate steps leaves an Ed25519 signature's worth of window
+    between them, so a concurrent append makes a genuinely-valid token fail its
+    own anchor check.
+    """
+    # An explicit key so the other writer opens the same chain.
+    chain_key = os.urandom(32)
+    chain = AuditChainStore(tmp_path / "audit", key=chain_key)
+    p_priv, _p_pub = generate_ed25519_keypair()
+    _o_priv, o_pub = generate_ed25519_keypair()
+
+    started = threading.Event()
+    landed = threading.Event()
+    holder: dict[str, threading.Thread] = {}
+
+    def append_from_another_writer() -> None:
+        other = AuditChainStore(tmp_path / "audit", key=chain_key)
+        started.set()
+        other.log(event_type="test.interloper", actor="other", resource_type="t", resource_id="i", details={})
+        landed.set()
+
+    real_sign_token = ct.sign_token
+
+    def sign_token_with_a_concurrent_append(**kwargs: object) -> ct.CapabilityToken:
+        if "thread" not in holder:
+            thread = threading.Thread(target=append_from_another_writer, daemon=True)
+            holder["thread"] = thread
+            thread.start()
+            assert started.wait(10.0), "the other writer never started"
+            landed.wait(1.5)
+        return real_sign_token(**kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(ct, "sign_token", sign_token_with_a_concurrent_append)
+
+    root = ct.mint_root(
+        issuer_identity_id="principal",
+        issuer_private_key=p_priv,
+        subject_identity_id="orchestrator",
+        subject_pubkey=o_pub,
+        caveats=_caveats({"files:read"}, depth=2),
+        audit_chain=chain,
+    )
+    holder["thread"].join(timeout=10.0)
+    assert not holder["thread"].is_alive(), "the other writer never completed its append"
+
+    mints = chain.query(event_type=EVENT_DELEGATION_MINTED)
+    assert len(mints) == 1
+    mint_event = mints[0]
+    # The head the event *claims* is the head the event actually sits on. Both
+    # come from the same store, so a cached read makes them disagree silently.
+    assert mint_event.details["prev_chain_digest"] == mint_event.prev_hmac, (
+        f"mint record claims it follows {mint_event.details['prev_chain_digest']!r} "
+        f"but actually follows {mint_event.prev_hmac!r}"
+    )
+    # ...and the token is anchored to that same position.
+    assert root.audit_head == mint_event.prev_hmac, (
+        f"token bound audit_head {root.audit_head!r} but its own mint record follows {mint_event.prev_hmac!r}"
+    )
+    assert ct._audit_head_matches(root, mints)


### PR DESCRIPTION
## Problem

Callers that embed the audit-chain head into a payload read the head and append the record as two independent steps. The append re-syncs the tail from disk; the read does not. When another writer appends in between, the embedded head names a chain position the record does not occupy.

Nothing downstream detects it in the receipt cases, because the head is opaque bytes inside an Ed25519 signature: a verifier recomputes the binding, matches it, and accepts.

Four sites, one root cause.

| Site | Symptom |
|---|---|
| `AuditChainStore.log_with_prev_digest` | Embedded `prev_chain_digest` disagrees with the `prev_hmac` the record was written with. All 122 `record_*` helpers route through here, so this is chain-wide. |
| `trigger_sources/receipt.py` admission path | Signed `admission_chain_head` names a position the record does not sit on. |
| `trigger_sources/receipt.py` status-proof path | Same, for `chain_head`. |
| `capability_tokens.mint_root` / `attenuate` | `_audit_head_matches` compares the token's `audit_head` against the mint record, so a moved head makes a valid token **fail its own anchor check**. |
| `orchestration/sla_monitor` | Reads the head once per tick, appends once per breach. Not a race: after the first breach, every further receipt in the tick signs a stale head. |

## Fix

A new `AuditChainStore.chain_transaction()` holds the chain across capture-head, sign, append. The head is read with `resync_head()`, which reads from disk rather than the per-instance cache, so another process's appends are seen.

Making that section atomic required the append lock to become re-entrant. `flock` locks attach to an open file description, not a thread, so wrapping `AuditLog.log` in a second `_chain_append_lock` blocks on itself (verified deadlock). The lock now keeps a per-thread depth count: the outermost acquisition owns the flock, inner ones pass through, and a per-dir `RLock` keeps other threads out for the whole nested section, so re-entrancy does not widen the window it exists to close.

`prev_chain_digest` keeps its cached, lock-free behaviour for callers that only observe the head; its docstring now says why signing it requires the transaction.

### Cost

Neutral, measured rather than assumed. `resync_head` shares `log`'s `(path, size)` fast path in both directions, so a second head re-read inside one section is free and an append in that section skips its own scan.

Counting `_recover_chain_tail` calls for one trigger receipt: **2 on this branch, 2 on `origin/main`** (construction, plus one re-sync). `flock` is acquired once per append, as before. `tests/stress/test_audit_throughput.py` and `test_audit_append_hotpath.py` pass unchanged.

Two things moved *out* of the held section as a side effect: bridge identity creation, and the SLA monitor's evidence provider and caller-supplied trigger sink. Arbitrary callback code no longer runs while the chain is held.

## Tests

Four tests, each proven to fail before the change:

* `tests/unit/security/test_receipt_chain_head_atomicity.py` (2) — a real concurrent append (another thread, as another process would) lands in the signing window; asserts the head each receipt carries equals the `prev_hmac` of its own chain record.
* `tests/unit/test_capability_token_audit_anchor.py` — same shape for a token mint; asserts the mint record's embedded head equals its actual `prev_hmac` **and** the token's `audit_head`.
* `tests/integration/test_sla_audit_chain.py` — two breaching contracts in one tick; asserts each receipt's signed head matches its own event. Deterministic, no concurrency needed.

The interloping append is gated on a start handshake, so the race is entered rather than merely scheduled, and the blocked case costs a bounded 1.5s rather than hanging.

## Verification

* Blocking gate `pyright --project pyrightconfig.strict.json`: 0 errors.
* Advisory pyright on the changed files: 15 before, 15 after.
* `ruff check` / `ruff format`: clean.
* 222 chain-related test files run individually: no failures.

## Not in scope

Appending onto a segment whose trailing newline is missing fuses the new record onto the unterminated line, producing one unparsable line and destroying the record being written. It is generic to every `AuditLog.log` append, and repairing it silently would erase the `missing trailing newline` signal `verify()` is designed to report. Filed separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audit-chain reliability during concurrent activity.
  * Ensured receipts, status proofs, and capability tokens consistently reference the correct preceding chain record.
  * Fixed SLA monitoring so multiple violations generated in one evaluation remain correctly linked to their corresponding audit events.
  * Prevented potential locking issues during nested audit operations.

* **Tests**
  * Added coverage for concurrent writes and audit-chain consistency across SLA receipts, trigger receipts, status proofs, and capability tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
