### PR TITLE
fix(audit): refuse a head re-read taken outside the append section

### DIFF
--- a/src/bernstein/core/orchestration/sla_monitor.py
+++ b/src/bernstein/core/orchestration/sla_monitor.py
@@ -427,6 +427,13 @@ class SLAMonitor:
             if receipt is None:
                 return None
             signed = sign_receipt(receipt, signing_key=self._signing_key)
+            # ``write_receipt`` does not need the chain held, but it stays inside
+            # and ahead of the append on purpose: the receipt file is the only
+            # copy of the signed payload, while the chain event carries just its
+            # digest. Persisting first means a crash between the two leaves a
+            # receipt whose anchor is missing -- recoverable -- rather than an
+            # anchor whose receipt never existed. It is one small local write on
+            # a per-breach path, so the widened section is cheap next to that.
             write_receipt(self._store.sdd_dir, signed)
             self._record_chain_event(signed)
 

--- a/src/bernstein/core/security/audit.py
+++ b/src/bernstein/core/security/audit.py
@@ -370,6 +370,12 @@ def _append_guard(audit_key: str) -> threading.RLock:
         return guard
 
 
+def _inside_append_section(audit_dir: Path) -> bool:
+    """Whether this thread currently holds *audit_dir*'s append section."""
+    depths: dict[str, int] = getattr(_APPEND_DEPTH, "depths", None) or {}
+    return depths.get(str(audit_dir.resolve()), 0) > 0
+
+
 @contextlib.contextmanager
 def _chain_append_lock(audit_dir: Path) -> Iterator[None]:
     """Serialise daily-log appends across processes via ``flock(LOCK_EX)``.
@@ -962,9 +968,26 @@ class AuditLog:
         read and the append -- leaving a signature that names a chain position
         its own record does not occupy.
 
+        Callers that only want to *observe* the head want
+        :attr:`AuditChainStore.prev_chain_digest`; this method is for the caller
+        that is about to write, and it enforces that rather than documenting it.
+        It re-points ``log``'s fast path, so running it outside the section would
+        let an append land between the read and the bookkeeping and leave the
+        recorded size describing bytes the head does not cover -- ``log`` would
+        then skip a re-sync it needed and append onto a stale head, which is the
+        chain fork issue #2791 closed.
+
         Returns:
             The chain head as recovered from disk under the verifier's framing.
+
+        Raises:
+            RuntimeError: When called outside :meth:`append_transaction`.
         """
+        if not _inside_append_section(self._audit_dir):
+            raise RuntimeError(
+                "resync_head() must be called inside append_transaction(); "
+                "use AuditChainStore.prev_chain_digest to observe the head without appending"
+            )
         # Shares ``log``'s (path, size) fast path, in both directions. Reading it:
         # when the day file is byte-length-identical to what our own last append
         # or resync left it at, nothing has been appended since and the cached

--- a/tests/integration/test_sla_audit_chain.py
+++ b/tests/integration/test_sla_audit_chain.py
@@ -237,9 +237,16 @@ def test_every_violation_receipt_in_a_tick_carries_its_own_records_head(tmp_path
     for receipt in receipts:
         event = by_receipt.get(receipt.payload_digest)
         assert event is not None, f"no chain event anchors receipt {receipt.receipt_id}"
-        assert receipt.prev_chain_digest == event.details["prev_chain_digest"], (
+        # Against the record's own ``prev_hmac``, not against the head the event
+        # merely claims: both claims are written from the same read, so comparing
+        # them to each other would agree even if both diverged from the record.
+        assert receipt.prev_chain_digest == event.prev_hmac, (
             f"receipt {receipt.receipt_id} signed head {receipt.prev_chain_digest!r} "
-            f"but its own chain event sits on {event.details['prev_chain_digest']!r}"
+            f"but its own chain event follows {event.prev_hmac!r}"
+        )
+        assert event.details["prev_chain_digest"] == event.prev_hmac, (
+            f"chain event for receipt {receipt.receipt_id} claims it follows "
+            f"{event.details['prev_chain_digest']!r} but actually follows {event.prev_hmac!r}"
         )
 
     ok, errors = chain.verify()

--- a/tests/unit/security/test_receipt_chain_head_atomicity.py
+++ b/tests/unit/security/test_receipt_chain_head_atomicity.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import threading
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -29,33 +30,44 @@ from bernstein.core.trigger_sources.receipt import admit_trigger, emit_status_pr
 _BODY = json.dumps({"title": "Rotate the deploy key", "description": "quarterly"}).encode()
 _PAYLOAD: dict[str, Any] = {"event_id": "ev-77", "run_id": "run-77", "severity": "error"}
 
+
+@dataclass(frozen=True)
+class _Bridge:
+    """The bridge locations one test operates on."""
+
+    root: Path
+    audit_dir: Path
+    hmac_key: bytes
+
+
 # The other writer signals that it is about to append, which is waited on
 # deterministically; only the append itself is then given a bounded grace
-# period. Unserialised that append takes about a millisecond, so the grace is
-# orders of magnitude more than it needs; serialised it blocks until the section
-# ends and the grace is what the suite pays instead of hanging.
+# period. Unserialised that append takes about a millisecond, so the grace still
+# leaves two orders of magnitude of slack; serialised it blocks until the section
+# ends, and the grace is then dead wait the suite pays on every run -- which is
+# why it is small rather than generous.
 _INTERLOPER_START_S = 10.0
-_INTERLOPER_GRACE_S = 1.5
+_INTERLOPER_GRACE_S = 0.2
 
 
 @pytest.fixture()
-def bridge(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+def bridge(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> _Bridge:
     """Return an isolated bridge root, audit dir, and HMAC key."""
     monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(tmp_path / "audit.key"))
-    return {
-        "root": tmp_path / "automation-bridge",
-        "audit_dir": tmp_path / "audit",
-        "hmac_key": load_or_create_audit_key(tmp_path / "audit.key"),
-    }
+    return _Bridge(
+        root=tmp_path / "automation-bridge",
+        audit_dir=tmp_path / "audit",
+        hmac_key=load_or_create_audit_key(tmp_path / "audit.key"),
+    )
 
 
-def _seed_chain(bridge: dict[str, Any], count: int = 2) -> None:
+def _seed_chain(bridge: _Bridge, count: int = 2) -> None:
     """Put real events on the chain so the head under test is not genesis."""
     for index in range(count):
         admit_trigger(
-            root=bridge["root"],
-            audit_dir=bridge["audit_dir"],
-            hmac_key=bridge["hmac_key"],
+            root=bridge.root,
+            audit_dir=bridge.audit_dir,
+            hmac_key=bridge.hmac_key,
             platform="n8n",
             request_path="/webhook",
             trigger_id=f"seed-{index}",
@@ -143,18 +155,16 @@ class _ConcurrentAppender:
             assert not self._thread.is_alive(), "the other writer never completed its append"
 
 
-def test_trigger_receipt_head_is_its_own_records_predecessor(
-    bridge: dict[str, Any], monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_trigger_receipt_head_is_its_own_records_predecessor(bridge: _Bridge, monkeypatch: pytest.MonkeyPatch) -> None:
     """A concurrent append cannot move the head out from under a trigger receipt."""
     _seed_chain(bridge)
-    appender = _ConcurrentAppender(bridge["audit_dir"], bridge["hmac_key"])
+    appender = _ConcurrentAppender(bridge.audit_dir, bridge.hmac_key)
     appender.install(monkeypatch)
 
     admission = admit_trigger(
-        root=bridge["root"],
-        audit_dir=bridge["audit_dir"],
-        hmac_key=bridge["hmac_key"],
+        root=bridge.root,
+        audit_dir=bridge.audit_dir,
+        hmac_key=bridge.hmac_key,
         platform="n8n",
         request_path="/webhook",
         trigger_id="trigger-under-test",
@@ -166,33 +176,56 @@ def test_trigger_receipt_head_is_its_own_records_predecessor(
 
     receipt = admission.receipt
     assert receipt is not None
-    record = _record_by_hmac(bridge["audit_dir"], receipt.chain_entry_hash)
+    record = _record_by_hmac(bridge.audit_dir, receipt.chain_entry_hash)
     assert receipt.admission_chain_head == record["prev_hmac"], (
         "the receipt signed a chain head its own record does not sit on: "
         f"signed {receipt.admission_chain_head!r}, record follows {record['prev_hmac']!r}"
     )
 
 
-def test_status_proof_head_is_its_own_records_predecessor(
-    bridge: dict[str, Any], monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_status_proof_head_is_its_own_records_predecessor(bridge: _Bridge, monkeypatch: pytest.MonkeyPatch) -> None:
     """A concurrent append cannot move the head out from under a status proof."""
     _seed_chain(bridge)
-    appender = _ConcurrentAppender(bridge["audit_dir"], bridge["hmac_key"])
+    appender = _ConcurrentAppender(bridge.audit_dir, bridge.hmac_key)
     appender.install(monkeypatch)
 
     proof = emit_status_proof(
-        root=bridge["root"],
-        audit_dir=bridge["audit_dir"],
-        hmac_key=bridge["hmac_key"],
+        root=bridge.root,
+        audit_dir=bridge.audit_dir,
+        hmac_key=bridge.hmac_key,
         payload=_PAYLOAD,
         status="failed",
         timestamp=1_700_000_500,
     )
     appender.join()
 
-    record = _record_by_hmac(bridge["audit_dir"], proof.chain_entry_hash)
+    record = _record_by_hmac(bridge.audit_dir, proof.chain_entry_hash)
     assert proof.chain_head == record["prev_hmac"], (
         "the proof signed a chain head its own record does not sit on: "
         f"signed {proof.chain_head!r}, record follows {record['prev_hmac']!r}"
     )
+
+
+def test_resync_head_outside_a_transaction_is_refused(bridge: _Bridge) -> None:
+    """Reading the head for signing is only meaningful while the chain is held.
+
+    ``resync_head`` re-points the append fast path, so a call made outside the
+    section lets a writer land between the read and that bookkeeping, leaving the
+    recorded size describing bytes the head does not cover. The next append then
+    skips a re-sync it needed and chains onto a stale head. The precondition is
+    enforced rather than documented so that misuse is a loud error instead of a
+    silently forked chain.
+    """
+    from bernstein.core.security.audit_chain import AuditChainStore
+
+    chain = AuditChainStore(bridge.audit_dir, key=bridge.hmac_key)
+
+    with pytest.raises(RuntimeError, match="append_transaction"):
+        chain.resync_head()
+
+    # Observing the head never needs the section.
+    assert isinstance(chain.prev_chain_digest, str)
+
+    # Inside the section it is the supported read.
+    with chain.chain_transaction():
+        assert chain.resync_head() == chain.prev_chain_digest

--- a/tests/unit/test_capability_token_audit_anchor.py
+++ b/tests/unit/test_capability_token_audit_anchor.py
@@ -21,6 +21,13 @@ from bernstein.core.security.audit_chain import EVENT_DELEGATION_MINTED, AuditCh
 
 _NOW = 1_800_000_000.0
 
+# Mirrors tests/unit/security/test_receipt_chain_head_atomicity.py: the other
+# writer's start is waited on deterministically, and only its append gets a
+# bounded grace. Serialised, that grace is dead wait paid on every run, so it is
+# small; an unserialised append takes about a millisecond either way.
+_INTERLOPER_START_S = 10.0
+_INTERLOPER_GRACE_S = 0.2
+
 
 def _caveats(perms: set[str], depth: int) -> ct.Caveats:
     return ct.Caveats(permissions=frozenset(perms), remaining_depth=depth, not_after=_NOW + 3600)
@@ -178,8 +185,8 @@ def test_mint_audit_head_matches_its_own_delegation_record(tmp_path: Path, monke
             thread = threading.Thread(target=append_from_another_writer, daemon=True)
             holder["thread"] = thread
             thread.start()
-            assert started.wait(10.0), "the other writer never started"
-            landed.wait(1.5)
+            assert started.wait(_INTERLOPER_START_S), "the other writer never started"
+            landed.wait(_INTERLOPER_GRACE_S)
         return real_sign_token(**kwargs)  # type: ignore[arg-type]
 
     monkeypatch.setattr(ct, "sign_token", sign_token_with_a_concurrent_append)
@@ -192,7 +199,7 @@ def test_mint_audit_head_matches_its_own_delegation_record(tmp_path: Path, monke
         caveats=_caveats({"files:read"}, depth=2),
         audit_chain=chain,
     )
-    holder["thread"].join(timeout=10.0)
+    holder["thread"].join(timeout=_INTERLOPER_START_S)
     assert not holder["thread"].is_alive(), "the other writer never completed its append"
 
     mints = chain.query(event_type=EVENT_DELEGATION_MINTED)

--- a/tests/unit/test_cli_run_params.py
+++ b/tests/unit/test_cli_run_params.py
@@ -95,7 +95,4 @@ def test_run_has_no_duplicate_click_options() -> None:
 
     names = [param.name for param in run.params]
     duplicates = sorted(name for name, count in Counter(names).items() if count > 1)
-    assert not duplicates, (
-        f"run declares duplicate Click params: {duplicates}. "
-        "Each option name must appear only once."
-    )
+    assert not duplicates, f"run declares duplicate Click params: {duplicates}. Each option name must appear only once."

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1041,6 +1041,8 @@ async def test_task_handle_unresolvable_ids_keep_existing_shapes(tmp_path, monke
     unknown = await _call_unwrapped(mcp, "bernstein_task_handle", run_id="nope")
     assert unknown["runId"] == "nope"
     assert unknown["status"] == "working"
+
+
 # Connect-time server instructions and module docstring (issue #3076)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Review follow-ups to #3129, which merged before its review comments were worked through.

## Changes

**`resync_head` enforces its precondition** (was documentation only). It re-points `log`'s `(path, size)` fast path, so a call outside an append section lets a writer land between the read and that bookkeeping, leaving the recorded size describing bytes the head does not cover. `log` then skips a re-sync it needed and appends onto a stale head, which is the chain fork #2791 closed. It now raises, and the docstring points observers at `prev_chain_digest`. All five callers already sit inside a section; a new test pins both arms.

**The SLA test compared two claims, not a claim against the record.** `receipt.prev_chain_digest` and `event.details["prev_chain_digest"]` are both written from the same read, so they agreed even where both diverged from the record's actual predecessor. It now asserts against `AuditEvent.prev_hmac`, and separately pins that the event's embedded claim matches it — the shape the capability-token test already used.

**Concurrency-test grace 1.5s -> 0.2s.** With the fix in place the interloping append never lands, so that wait is dead time on every run.

**Smaller:** frozen dataclass for the bridge fixture instead of a raw dict; timing constants mirrored into the token test.

## Not changed, and why

`write_receipt` stays inside the SLA chain section. It does not need the lock, but the receipt file is the only copy of the signed payload while the chain event carries only its digest. Persisting first means a crash between the two leaves a receipt whose anchor is missing (recoverable) rather than an anchor whose receipt never existed. One small local write on a per-breach path. Now stated in a comment so the next reader does not reach for the obvious change.

## Verification

The grace reduction was re-proved rather than reasoned about. Measured against `143327727`, the commit before #3129 merged:

| Test | Runs at 0.2s on pre-fix code |
|---|---|
| bridge pair | 8/8 fail |
| token mint | 3/3 fail |

An earlier check appeared to show RED was lost; that check was run against a `main` that already contained the fix, so the interloper was correctly blocked and the tests correctly passed. Re-run against the true pre-fix commit, RED holds.

Green on Python 3.13 (the version whose cells gate CI): the three changed test files plus `test_audit`, `test_audit_adversarial`, `test_audit_chain_crossprocess`, `test_audit_chain_bughunt`, `test_audit_throughput`, `test_automation_bridge`, `test_stateless_migration`. Blocking `pyright --project pyrightconfig.strict.json`: 0 errors. `ruff check` / `format` clean.

## Deferred

Two review findings are real, pre-existing, and out of scope here — filed separately rather than bundled into a follow-up that is already touching a shared security primitive.