### PR TITLE
chore(release): v3.10.0

### DIFF
--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bernstein",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "description": "Deterministic orchestrator for CLI coding agents. Spawn parallel agents in per-task git worktrees, verify their work, and merge results; no model in the coordination loop, so runs replay byte-identically.",
   "author": {
     "name": "chernistry",

--- a/docs/release-notes/v3.10.0.md
+++ b/docs/release-notes/v3.10.0.md
@@ -1,0 +1,186 @@
+# v3.10.0
+
+A correctness release, and an unusually honest one.
+
+One defect class runs through it: **a check reporting success on work it never
+evaluated**. Fourteen distinct instances were found. Some were in the product,
+some were in the tests, and several were in the machinery that was supposed to
+be catching the others. The most consequential is the one this release exists
+to close, and it is worth stating plainly because it means the previous release
+was gated less thoroughly than its checks suggested.
+
+Alongside that, the MCP server surface was corrected end to end, a run that
+finishes nothing now says so, and the documentation stopped claiming
+capabilities the code cannot reach.
+
+## Behaviour changes (read before upgrading)
+
+- **A run that finishes nothing no longer reports success (#3010, #3029, #3056,
+  #3060).** A run whose tasks never reached a terminal state could report
+  `HEALTHY` and exit 0, and the exit code was correct only under `--quiet`.
+  Three things changed. A run whose task set stops moving self-stops after a
+  settle window instead of idling. Tasks that never finished are marked failed
+  with an explicit reason before the report is written, so the retrospective
+  reports the failure rather than an empty success. The exit code is derived
+  from the run's real health in every output mode.
+
+  **A quiescent run carrying a failed task now exits non-zero where it
+  previously exited 0.** Any scheduler or script treating exit 0 as "the run
+  happened" rather than "the run succeeded" will start seeing failures it was
+  previously blind to. That is the intended correction, and it can turn a green
+  pipeline red on first upgrade.
+
+  The stop is conservative at every branch: a working agent, a claimable task,
+  an empty backlog, a retry backoff, or an active hold all prevent it. The
+  criterion is absence of *progress*, measured as an unchanged task-set
+  fingerprint across consecutive ticks, not absence of *completions*.
+
+- **A liveness watchdog no longer reaps a still-working agent (#3012, #3029).**
+  Heartbeat staleness could fire while the agent's log was seconds old, killing
+  work in flight and recording it as a failure.
+
+- **`bernstein approve` over MCP is an approval gate rather than a
+  force-complete (#3081, #3107).** It previously completed any task in any
+  state. It now refuses outside the states where approval is meaningful, and
+  the refusal names the current state.
+
+- **An explicitly named container runtime fails closed (#3039, #3047).**
+  `--sandbox podman` previously degraded to worktree isolation where
+  `--sandbox docker` refused. Both now refuse. If you passed an explicit
+  runtime and relied on the silent fallback, you will now get an error.
+
+## The gate that was not gating
+
+`ci-gate-stub.yml` was satisfying the required `CI gate` context on diffs that
+carried code. Measured on a live pull request: the check concluded **success in
+eleven seconds** while all four Ubuntu test shards, both Windows shard sets and
+nineteen other checks were still pending. Branch protection requires only
+`CI gate` and `review-bot-ack`, so the shards are not required directly, which
+made the bypass total.
+
+Twelve of sixteen open pull requests had their green gate sourced from the stub
+rather than from a real run. **#3053** closes it. Every merge in this release
+was afterwards verified by fetching the workflow run by id, confirming its path
+is `ci.yml`, and requiring at least four Ubuntu shards with a `success`
+conclusion. Shard *existence* is not shard success, and an early probe that
+confused the two produced nine false positives before it was corrected.
+
+Three related holes were found and are tracked rather than fixed here: the
+second required context can also be satisfied by an unconditional step on
+merge-group events (#3114), the shard runner reports a file as passing when it
+ran zero tests (#3068), and the review tracker counts a bot that never ran as
+zero findings (#3067).
+
+**#3038** adds structural guards so this class is caught rather than
+rediscovered: collection completeness, required-context presence, and
+type-check scope.
+
+## Tests that were not running
+
+- **Seven test files had never run in CI**, including the adversarial lineage
+  suite (#3043, #3026, #3046). They are collected now, and a guard fails when a
+  test file is collected by no lane.
+- **A repo-wide invariant test only ran when its own subject file was touched.**
+  Pull-request lanes select tests by impact, so a violation could merge clean
+  and rot on the default branch. This is the mechanism that left `main` red
+  before this release started; **#3126** fixes it.
+- **A test could replace the pytest process** with `os.execv` and the run
+  reported success with zero tests (#3059).
+- `mypy` now actually checks `src` and is gated (#2981, #3003).
+
+## MCP
+
+The server surface was wrong in ways that made documented paths fail on first
+use. All of these ship fixed:
+
+- `bernstein_context` was silently dropped at the default tool tier because it
+  had no tier entry (#3073, #3089). The tier table is now the single source, and
+  the default tier advertises 14 tools.
+- `bernstein_task_handle` rejected the identifier `bernstein_run` returns, so
+  the documented polling path failed immediately (#3074, #3092).
+- The Tasks extension was both mis-gated and undeclared, so `bernstein_run`
+  returned the wrong wire shape and the task handlers were unreachable (#3079,
+  #3103). A third defect surfaced while fixing it: `Task.ttl` is required and
+  the SDK serialises with `exclude_none`, so every task response was being
+  stripped of a mandatory field and rejected by the client.
+- The strict tool schemas were enforced but never advertised, making every
+  constrained argument a first-call failure (#3082, #3104).
+- `bernstein_stop` accepted any path and wrote a shutdown file there, with no
+  containment check (#3080, #3106). It is now bounded to the project root.
+- A 401 from the remote transport carries the protected-resource metadata URL,
+  so the OAuth metadata the server already served is discoverable (#3075, #3094).
+- Connect-time instructions describe the run control loop rather than the
+  project (#3076, #3091), and state plainly that the HTTP transport validates
+  arguments less strictly than stdio (#3088, #3101).
+
+## Verifiability and lineage
+
+- Output provenance is keyed by a canonical artifact URI, so one output named
+  two ways is one lineage node (#2991).
+- A declared output that never landed on the chain is itself recorded, so "the
+  agent said it would produce this and did not" is a verifiable fact rather than
+  a silent absence (#3034).
+- Release receipts are recorded when a held claim is surrendered and when a task
+  returns to the pool (#3045, #3126).
+- Per-artifact health, attribution and production events (#3002).
+- A chain-head re-read taken outside the append section is refused rather than
+  documented against (#3129, #3149). The head read also re-points the append
+  path's `(path, size)` fast path, so a call made outside a section let a writer
+  land between the read and that bookkeeping, leaving the recorded size
+  describing bytes the head does not cover, and the next append landing on a
+  stale head. That is the chain fork #2791 closed, reachable by a second route.
+  A concurrency test that had compared two claims written from the same read now
+  asserts against the recorded predecessor instead.
+
+## Cluster, sandbox, platform
+
+- Leaderless MESH topology over the signed claim journal; two nodes reduce the
+  same journal to byte-identical state (#2988). Peer keys are pinned so a node
+  cannot assert someone else's identity (#2999).
+- A worker preflights its workspace before claiming, and a claim stranded by a
+  failed spawn is re-queued instead of sitting in `claimed` forever (#3027).
+- Real microVM guests via libkrun behind the existing sandbox interface (#2974).
+- Isolation downgrades are surfaced and audited rather than applied silently
+  (#3028).
+- Stop delivery is separated from the reap guarantee (#3055).
+
+## Documentation accuracy
+
+The README described modality support the code cannot reach. `agent_kind` is
+accepted and validated by the team manifest but no scheduler reads it, every
+bundled adapter declares git-diff output, and `artifact_spec` is absent from
+every operator-facing loader. The claims are now scoped to what is reachable,
+with the substrate described accurately, and a machine-checked guard fails in
+**both** directions: it catches the overclaim today, and once reachability lands
+it catches the now-stale correction and names the block to delete (#3127, #3132).
+
+One project description now appears across every surface, and several stale
+facts went with it: three image and package manifests pointed at GitHub
+organisations that do not exist, the adapter advisory said "30+" against 46, and
+the shipped Helm chart declared version 1.6.3 (#3148).
+
+## Contributors
+
+Thanks to the people outside the core team whose work is in this release.
+Derived from `git log v3.9.0..main`:
+
+- **@Maqbool61** shipped `bernstein-bench`, a runnable, reproducibility-gated
+  evaluation harness where every posted score carries its own proof (#3099). The
+  submission bundle commits the receipt hash at emit time, so a score cannot be
+  separated from the material it was derived from, and the verifier names the
+  exact task whose replay diverged rather than returning a bare failure.
+- **@aeoess** (Tymofii Pidlisnyi) superseded the showback canonical vectors with
+  an anchored set generated against two independent reference implementations
+  rather than against our own code (#2994).
+- **@AshSgDe29071999** removed a duplicate `--fresh` option that made
+  `bernstein run` emit a Click warning on every invocation (#3030).
+- **@chrstphe** (Christophe) added the MCP Toplist rank badge (#3019).
+- **@pollychen-lab** (Polly Labs) corrected the qwen scoped install hint (#3011).
+
+## Known issues
+
+`Trivy (filesystem)` reports one high-severity finding on the default branch: a
+frontend dependency in the shipped dashboard bundle, already present in v3.9.0.
+It is not a required check and does not gate merges. The remedy is a major
+version bump of that dependency, tracked in #3097 rather than rushed into this
+release.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -511,6 +511,7 @@ nav:
           - Glossary: reference/GLOSSARY.md
       - Release notes:
           - Changelog: CHANGELOG.md
+          - v3.10.0: release-notes/v3.10.0.md
           - v3.9.0: release-notes/v3.9.0.md
           - v3.8.4: release-notes/v3.8.4.md
           - v3.8.3: release-notes/v3.8.3.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "3.9.0"
+version = "3.10.0"
 description = "Deterministic orchestrator for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40+ more). No model in the coordination loop, so parallel runs in per-task git worktrees replay byte-identically. Signed lineage plus an opt-in HMAC audit chain a reviewer checks offline, without rerunning it. Cluster mode, air-gap deploy."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/server.json
+++ b/server.json
@@ -7,19 +7,19 @@
     "url": "https://github.com/sipyourdrink-ltd/bernstein",
     "source": "github"
   },
-  "version": "3.9.0",
+  "version": "3.10.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "bernstein",
-      "version": "3.9.0",
+      "version": "3.10.0",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/sipyourdrink-ltd/bernstein:3.9.0",
+      "identifier": "ghcr.io/sipyourdrink-ltd/bernstein:3.10.0",
       "transport": {
         "type": "stdio"
       }

--- a/uv.lock
+++ b/uv.lock
@@ -338,7 +338,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "3.9.0"
+version = "3.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
Version bump to 3.10.0 across `pyproject.toml`, `.plugin/plugin.json`, `server.json` and `uv.lock`, plus `docs/release-notes/v3.10.0.md` and its `mkdocs.yml` nav entry.

Merging this triggers `auto-release.yml` through `post-ci-dispatcher.yml`, which requires the triggering commit to change the `version = ` line in `pyproject.toml` — hence the bump lands as its own commit rather than riding an earlier one.

Release notes cover: the run-health and exit-code correction (a quiescent run carrying a failed task now exits non-zero), the required-context bypass that let a stub satisfy `CI gate`, seven test files that had never been collected, the MCP server surface fixes, and the documentation-accuracy pass. Contributors re-derived from `git log v3.9.0..main`.

`Trivy (filesystem)` red on the default branch is pre-existing, not a required check, and documented under Known issues (#3097).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release notes for v3.10.0, covering reliability, security, platform, MCP, and CI improvements.
  * Improved task failure reporting and safer behavior for container runtimes and approval operations.
  * Enhanced verifiability, sandbox isolation visibility, cluster recovery, and platform operations.

* **Documentation**
  * Added v3.10.0 to the release-notes navigation.
  * Clarified supported capabilities, known issues, and verification requirements.

* **Chores**
  * Updated the application, plugin, server, and package versions to 3.10.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->