### PR TITLE
fix(ci): make the review-bot-ack required context cancel-proof and queue-honest

### DIFF
--- a/.github/workflows/review-bot-ack.yml
+++ b/.github/workflows/review-bot-ack.yml
@@ -25,35 +25,77 @@ on:
   # below republishes the same context name on this event.
   merge_group: {}
 
-# This workflow emits a required status check. The concurrency group is
-# keyed per-PR AND per-head-sha, so cancel-in-progress only ever cancels a
-# duplicate evaluation of the SAME commit (e.g. a synchronize event that
-# lands while an equal-SHA pull_request_review run is still going). A new
-# push produces a new head SHA and therefore a new group, so an in-flight
-# run for the previous commit is never cancelled and still reports its own
-# conclusion. Cancelling the redundant same-SHA run reclaims a runner and
-# avoids two runs racing to publish the required check for one commit.
+# This workflow emits a required status check, and that changes what a
+# cancellation costs. A cancelled run leaves a check-run named
+# `review-bot-ack` with conclusion `cancelled` on the head SHA, and branch
+# protection folds EVERY check-run of a required name into its verdict, so
+# one cancelled instance holds the PR at BLOCKED even after a newer run of
+# the same workflow concludes success (#3154, #3042). The previous design
+# keyed the group on (PR, SHA) without the event, so a pull_request run and
+# a pull_request_review run for the same commit cancelled each other and
+# poisoned the context they were both trying to satisfy.
+#
+# Two changes close that:
+#   * the event name is part of the group, so runs born from different
+#     events never contend with each other, and
+#   * cancel-in-progress is off, so a same-event duplicate waits its turn
+#     and reports a real conclusion instead of leaving a cancelled tombstone.
+# The job is minutes-bounded and cheap; an occasional redundant run costs a
+# runner slot, a cancelled required check costs a manual one-at-a-time
+# rerun cycle per PR.
 concurrency:
-  group: review-bot-ack-${{ github.event.pull_request.number || github.ref }}-${{ github.event.pull_request.head.sha || github.sha }}
-  cancel-in-progress: true
+  group: review-bot-ack-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event.pull_request.head.sha || github.sha }}
+  cancel-in-progress: false
 
 permissions: {}
 
 jobs:
-  # Pass-through emitter for the merge queue. The queue runs required checks
-  # on a merge_group ref with no pull_request payload, where the acknowledgement
-  # gate has nothing to evaluate. This job reports the identical `review-bot-ack`
-  # context name (job-level `name:` controls the reported context) so the queued
-  # group can satisfy branch protection instead of stalling. It runs only on
-  # merge_group; the real gate below runs on every other event.
+  # Queue-side emitter. The merge queue evaluates required checks on a
+  # synthetic merge_group ref with no pull_request payload, so the real gate
+  # below cannot run there. This job republishes the `review-bot-ack` context
+  # on the queued group, but it is NOT an unconditional pass (#3114): it
+  # resolves the pull request the queue entry was built from and requires
+  # that a `review-bot-ack` check-run already concluded `success` on that
+  # PR's own head commit. The queue context therefore attests "the PR-stage
+  # gate really ran and really passed", and it fails closed on anything it
+  # cannot resolve: an unparseable queue ref, a missing PR, or a head commit
+  # whose gate never reported success.
   merge-group-pass:
     name: review-bot-ack
     if: github.event_name == 'merge_group'
     runs-on: ubuntu-latest
-    timeout-minutes: 2
-    permissions: {}
+    timeout-minutes: 5
+    permissions:
+      checks: read
+      pull-requests: read
     steps:
-      - run: echo "review-bot-ack is PR-scoped; on the queue's ephemeral branch it passes through"
+      - name: Require a passed PR-stage gate for the queued entry
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          # refs/heads/gh-readonly-queue/<base>/pr-<number>-<base sha>
+          QUEUE_REF: ${{ github.event.merge_group.head_ref }}
+        run: |
+          set -euo pipefail
+          echo "queue ref: $QUEUE_REF"
+          pr="$(printf '%s' "$QUEUE_REF" | sed -nE 's#.*/pr-([0-9]+)-[0-9a-f]+$#\1#p')"
+          if [ -z "$pr" ]; then
+            echo "::error::cannot resolve a pull request number from the merge_group ref; refusing to satisfy a required context blind"
+            exit 1
+          fi
+          head_sha="$(gh api "repos/$REPO/pulls/$pr" --jq .head.sha)"
+          if [ -z "$head_sha" ]; then
+            echo "::error::pull request #$pr resolved from the queue ref does not exist"
+            exit 1
+          fi
+          echo "pr #$pr head $head_sha"
+          ok="$(gh api "repos/$REPO/commits/$head_sha/check-runs?check_name=review-bot-ack&per_page=100" \
+                --jq '[.check_runs[] | select(.status == "completed" and .conclusion == "success")] | length')"
+          if [ "${ok:-0}" -lt 1 ]; then
+            echo "::error::no successful review-bot-ack check-run exists on pr #$pr head $head_sha; the PR-stage gate has not passed"
+            exit 1
+          fi
+          echo "PR-stage gate passed on the queued entry's head commit ($ok successful instance(s))"
 
   review-bot-ack:
     name: review-bot-ack

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -60,7 +60,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/reconcile-release.yml | Reconcile release drift | schedule, workflow_dispatch | {"cancel-in-progress": "false", "group": "reconcile-release"} | 1 |
 | .github/workflows/release-major-minor.yml | Major/Minor Release | workflow_dispatch | {"cancel-in-progress": "false", "group": "release-major-minor-${{ github.ref }}"} | 1 |
 | .github/workflows/required-check-canary.yml | Required-check name canary | pull_request, schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "required-check-canary-${{ github.event.pull_request.number \|\| github.ref }}"} | 1 |
-| .github/workflows/review-bot-ack.yml | Review-bot acknowledgement gate | merge_group, pull_request, pull_request_review | {"cancel-in-progress": "true", "group": "review-bot-ack-${{ github.event.pull_request.number \|\| github.ref }}-${{ github.event.pull_request.head.sha \|\| github.sha }}"} | 2 |
+| .github/workflows/review-bot-ack.yml | Review-bot acknowledgement gate | merge_group, pull_request, pull_request_review | {"cancel-in-progress": "false", "group": "review-bot-ack-${{ github.event_name }}-${{ github.event.pull_request.number \|\| github.ref }}-${{ github.event.pull_request.head.sha \|\| github.sha }}"} | 2 |
 | .github/workflows/review-bot-sweep.yml | Review-bot post-merge sweep | schedule, workflow_dispatch | - | 1 |
 | .github/workflows/sbom.yml | SBOM | release, workflow_dispatch | {"cancel-in-progress": "false", "group": "sbom-${{ github.ref }}"} | 1 |
 | .github/workflows/scorecard.yml | OSSF Scorecard | branch_protection_rule, schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "scorecard-${{ github.ref }}"} | 2 |
@@ -192,7 +192,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/reconcile-release.yml | reconcile: {"contents": "read", "issues": "write"} | - |
 | .github/workflows/release-major-minor.yml | workflow: {"contents": "read"}<br>release: {"attestations": "write", "contents": "write", "id-token": "write"} | GITHUB_TOKEN |
 | .github/workflows/required-check-canary.yml | verify: {"contents": "read"} | - |
-| .github/workflows/review-bot-ack.yml | review-bot-ack: {"contents": "read", "issues": "write", "pull-requests": "write"} | - |
+| .github/workflows/review-bot-ack.yml | merge-group-pass: {"checks": "read", "pull-requests": "read"}<br>review-bot-ack: {"contents": "read", "issues": "write", "pull-requests": "write"} | - |
 | .github/workflows/review-bot-sweep.yml | sweep: {"contents": "write", "pull-requests": "write"} | GITHUB_TOKEN, LANDING_REPO_PAT |
 | .github/workflows/sbom.yml | workflow: {"contents": "read"}<br>sbom: {"contents": "write"} | - |
 | .github/workflows/scorecard.yml | workflow: {"contents": "read"}<br>analysis: {"actions": "read", "contents": "read", "id-token": "write", "security-events": "write"}<br>upload: {"contents": "read", "security-events": "write"} | - |

--- a/tests/unit/test_review_bot_ack_workflow_yaml.py
+++ b/tests/unit/test_review_bot_ack_workflow_yaml.py
@@ -78,6 +78,58 @@ def test_gate_job_emits_review_bot_ack_check(
     )
 
 
+def test_gate_concurrency_never_cancels_a_required_context(
+    gate_doc: dict[str, object],
+) -> None:
+    """A cancelled run leaves a `cancelled` check-run that branch protection
+    folds into the required context's verdict, blocking the PR even after a
+    newer run concludes success (#3154, #3042). The group key must therefore
+    separate runs born from different events, and cancel-in-progress must be
+    off so a same-event duplicate reports a real conclusion instead of a
+    cancelled tombstone.
+    """
+    conc = gate_doc.get("concurrency")
+    assert isinstance(conc, dict), "workflow must declare a concurrency block"
+    assert conc.get("cancel-in-progress") is False, (
+        "cancel-in-progress must be false: a cancelled run of a required "
+        "context poisons the rollup for its head SHA (#3154)"
+    )
+    group = str(conc.get("group", ""))
+    assert "github.event_name" in group, (
+        "the concurrency group must include the event name so runs born "
+        "from different events never contend with each other (#3154)"
+    )
+
+
+def test_merge_group_job_verifies_instead_of_echoing(
+    gate_doc: dict[str, object],
+) -> None:
+    """The merge_group emitter must not satisfy the required context
+    unconditionally (#3114). It has to resolve the queued entry's pull
+    request and require a successful PR-stage `review-bot-ack` check-run on
+    that PR's head commit, failing closed on anything it cannot resolve.
+    """
+    jobs = gate_doc.get("jobs")
+    assert isinstance(jobs, dict)
+    job = jobs.get("merge-group-pass")
+    assert isinstance(job, dict), "queue-side emitter job must exist"
+    assert job.get("name") == "review-bot-ack"
+    perms = job.get("permissions")
+    assert isinstance(perms, dict) and perms.get("checks") == "read", (
+        "the queue-side job needs checks:read to verify the PR-stage gate"
+    )
+    steps = job.get("steps") or []
+    assert isinstance(steps, list) and steps, "job must have steps"
+    scripts = "\n".join(str(s.get("run", "")) for s in steps if isinstance(s, dict))
+    assert "check-runs" in scripts and "review-bot-ack" in scripts, (
+        "the queue-side job must query check-runs for the PR-stage gate rather than passing unconditionally (#3114)"
+    )
+    assert "exit 1" in scripts, "the queue-side job must fail closed"
+    assert "merge_group.head_ref" in (
+        scripts + "\n".join(str(s.get("env") or {}) for s in steps if isinstance(s, dict))
+    ), "the queued entry's PR must be resolved from the merge_group ref"
+
+
 def test_gate_actions_sha_pinned() -> None:
     text = GATE_WF.read_text(encoding="utf-8")
     uses = [m.group(0) for m in re.finditer(r"uses:\s*[^\s#]+", text)]


### PR DESCRIPTION
Closes #3154. Closes #3114. Closes #3042.

Two defects in the same required context.

**A cancelled run poisons the context it was trying to satisfy (#3154, #3042).** The concurrency group was keyed on (PR, SHA) without the event, so a `pull_request` run and a `pull_request_review` run for the same commit landed in one group and `cancel-in-progress` cancelled one of them. The cancelled run leaves a check-run named `review-bot-ack` with conclusion `cancelled`, and branch protection folds every check-run of a required name into its verdict, so the PR reads BLOCKED even after a newer run concludes success. Observed on the v3.10.0 release PR: one SHA, three runs, six check-run instances, and the healing rerun had to be issued for the single cancelled run alone because rerunning two together re-created the race.

The group key now includes `github.event_name`, so runs born from different events never contend, and `cancel-in-progress` is off, so a same-event duplicate waits and reports a real conclusion instead of a cancelled tombstone. The job is minutes-bounded; an occasional redundant run costs a runner slot, a cancelled required check costs a manual one-at-a-time rerun cycle per PR.

**The merge_group emitter satisfied the context with an unconditional echo (#3114).** It now resolves the queued entry's pull request from the queue ref (`gh-readonly-queue/<base>/pr-<n>-<sha>`) and requires a `review-bot-ack` check-run with conclusion `success` on that PR's own head commit, so the queue context attests that the PR-stage gate really ran and really passed. It fails closed on an unparseable ref, a missing PR, or a head commit whose gate never reported success. This unblocks enabling the merge queue (#2966) without running every queued entry through a context answered by `echo`.

**Guards.** Two structural tests pin both properties in `tests/unit/test_review_bot_ack_workflow_yaml.py`: the concurrency block must keep `cancel-in-progress: false` with the event in the group key, and the queue-side job must query check-runs and fail closed rather than pass unconditionally. `docs/operations/ci-topology.md` regenerated for the workflow change.

**Verification.** All 11 tests in the workflow-yaml suite pass, plus the 61 tests across the required-check canary, branch-protection audit, merge-queue runbook, and required-contexts script suites.