### PR TITLE
fix(observability): name the gate outcome explicitly and make the snapshot corpus committable

### DIFF
--- a/.github/workflows/docs-observability-snapshot.yml
+++ b/.github/workflows/docs-observability-snapshot.yml
@@ -51,9 +51,17 @@ jobs:
           set -euo pipefail
           mkdir -p docs/_internal/observability/snapshots
           DATE=$(date -u +%Y-%m-%d)
-          uv run bernstein doctor observe --json --no-persist \
-            > "docs/_internal/observability/snapshots/${DATE}.json"
-          echo "snapshot=docs/_internal/observability/snapshots/${DATE}.json" >> "$GITHUB_OUTPUT"
+          SNAPSHOT="docs/_internal/observability/snapshots/${DATE}.json"
+          # Record the path before running observe: a WARN exit (rc 1) must
+          # not leave the later commit-verification step without a target.
+          echo "snapshot=${SNAPSHOT}" >> "$GITHUB_OUTPUT"
+          uv run bernstein doctor observe --json --no-persist > "${SNAPSHOT}"
+
+      - name: Validate snapshot JSON
+        run: |
+          set -euo pipefail
+          python3 -m json.tool "${{ steps.capture.outputs.snapshot }}" > /dev/null
+          echo "snapshot ${{ steps.capture.outputs.snapshot }} is valid JSON"
 
       - name: Render 30-day trends
         run: |
@@ -64,10 +72,10 @@ jobs:
 
       - name: Detect metric regressions
         # Non-blocking: the snapshot PR still opens on a regression. The gate
-        # diffs the new snapshot against the previous one and records any
-        # regression (a metric that crossed its fail threshold, a new or
-        # increased security finding, or a backend that lost its credentials)
-        # in the run summary.
+        # diffs the new snapshot against the previous one and names one of
+        # three outcomes in the run summary and regressions.json: regressions
+        # found, baseline compared and clean, or no baseline to compare
+        # against (comparison not performed).
         if: always()
         run: |
           set -uo pipefail
@@ -77,13 +85,8 @@ jobs:
             --out .ci/observability/regressions.json \
             --summary-out "${GITHUB_STEP_SUMMARY:-/dev/null}" || true
 
-          if [ ! -s .ci/observability/regressions.json ]; then
-            echo "No regressions recorded."
-          else
-            echo "Regressions recorded in the run summary."
-          fi
-
       - name: Open PR with snapshot + trends
+        id: snapshot-pr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -104,3 +107,33 @@ jobs:
           labels: |
             chore
             observability
+
+      - name: Verify snapshot landed in the PR commit
+        # The corpus silently stopped growing once before: git add skips
+        # gitignored paths without -f, so the commit-back step dropped the
+        # snapshot while still reporting success. Fail loudly if the file
+        # this run produced is not in the tree the PR points at.
+        env:
+          SNAPSHOT_PATH: ${{ steps.capture.outputs.snapshot }}
+          HEAD_SHA: ${{ steps.snapshot-pr.outputs.pull-request-head-sha }}
+        run: |
+          set -euo pipefail
+          if [ -z "$HEAD_SHA" ]; then
+            # No commit was created. Acceptable only if the snapshot is
+            # already tracked with identical content (same-day re-run).
+            if git ls-files --error-unmatch "$SNAPSHOT_PATH" > /dev/null 2>&1 \
+                && git diff --quiet -- "$SNAPSHOT_PATH"; then
+              echo "no new commit needed: $SNAPSHOT_PATH already tracked and unchanged"
+              exit 0
+            fi
+            echo "::error::no PR commit was created and $SNAPSHOT_PATH is not tracked; the baseline did not advance"
+            exit 1
+          fi
+          git cat-file -e "${HEAD_SHA}^{commit}" 2> /dev/null \
+            || git fetch --no-tags origin chore/observability-snapshot
+          if git ls-tree -r "$HEAD_SHA" --name-only | grep -Fxq "$SNAPSHOT_PATH"; then
+            echo "verified: $SNAPSHOT_PATH is present in PR commit $HEAD_SHA"
+          else
+            echo "::error::$SNAPSHOT_PATH is missing from PR commit $HEAD_SHA; the baseline did not advance"
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -86,7 +86,6 @@ dev/
 docs/internal/
 docs/strategy/
 docs/competitive/
-docs/_internal/
 
 # Release-notes drafts and outreach copy (live in /pr/, never the repo)
 .release-notes-*.draft.md
@@ -153,3 +152,14 @@ docs/**/RAG-*.md
 # mutmut 3 working tree (./mutants/) and mutation-test cache (.mutmut-cache)
 mutants/
 .mutmut-cache
+
+# The observability snapshot corpus is tracked on purpose: it is the
+# regression gate's baseline (scripts/observability/gate.py) and has to
+# accumulate one file per day. Re-include it from the docs internal
+# excludes above; git needs every parent directory unignored before it
+# will descend into the corpus.
+!docs/_internal/
+docs/_internal/*
+!docs/_internal/observability/
+docs/_internal/observability/*
+!docs/_internal/observability/snapshots/

--- a/scripts/observability/gate.py
+++ b/scripts/observability/gate.py
@@ -23,8 +23,15 @@ import::
         --snapshots docs/_internal/observability/snapshots \\
         --out .ci/observability/regressions.json
 
-Exit code is ``1`` when at least one ``fail``-severity regression is found,
-``0`` otherwise (including when fewer than two snapshots exist).
+The gate distinguishes three outcomes and names the active one in its
+output and in the ``--out`` JSON payload:
+
+* ``fail`` (exit 1): at least one ``fail``-severity regression.
+* ``warn`` / ``clean`` (exit 0): a baseline was compared; only warnings,
+  or nothing at all, came out of the comparison.
+* ``no-baseline`` (exit 2): fewer than two readable snapshots exist, so
+  no day-over-day comparison ran. This is an unknown state, never
+  reported as "no regressions".
 """
 
 from __future__ import annotations
@@ -56,6 +63,11 @@ _WARN_ON_INCREASE: frozenset[tuple[str, str]] = frozenset(
 _ACTIVE_STATUSES: frozenset[str] = frozenset({"ok", "warn", "fail"})
 
 _SENTINEL_METRIC = "__backend__"
+
+#: Exit codes for the three gate outcomes.
+EXIT_OK = 0
+EXIT_REGRESSIONS = 1
+EXIT_NO_BASELINE = 2
 
 
 @dataclass(frozen=True)
@@ -211,6 +223,22 @@ def _load(path: Path) -> dict[str, Any] | None:
         return None
 
 
+def dated_snapshots(snapshots_dir: Path) -> list[tuple[dt.date, Path]]:
+    """Return the ISO-date-named snapshot files, oldest first."""
+
+    if not snapshots_dir.exists():
+        return []
+    dated: list[tuple[dt.date, Path]] = []
+    for path in snapshots_dir.glob("*.json"):
+        try:
+            day = dt.date.fromisoformat(path.stem)
+        except ValueError:
+            continue
+        dated.append((day, path))
+    dated.sort(key=lambda item: item[0])
+    return dated
+
+
 def load_two_latest(
     snapshots_dir: Path,
 ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
@@ -220,16 +248,7 @@ def load_two_latest(
     snapshots exist, the missing slot(s) are ``None``.
     """
 
-    if not snapshots_dir.exists():
-        return (None, None)
-    dated: list[tuple[dt.date, Path]] = []
-    for path in snapshots_dir.glob("*.json"):
-        try:
-            day = dt.date.fromisoformat(path.stem)
-        except ValueError:
-            continue
-        dated.append((day, path))
-    dated.sort(key=lambda item: item[0])
+    dated = dated_snapshots(snapshots_dir)
     if not dated:
         return (None, None)
     curr = _load(dated[-1][1])
@@ -237,18 +256,56 @@ def load_two_latest(
     return (prev, curr)
 
 
-def _one_line(regressions: list[Regression]) -> str:
+def resolve_outcome(baseline_present: bool, regressions: list[Regression]) -> str:
+    """Name the gate outcome: ``fail`` / ``no-baseline`` / ``warn`` / ``clean``.
+
+    A ``fail``-severity finding wins even without a baseline: absolute
+    threshold failures in the newest snapshot are real regardless of the
+    missing comparison. Otherwise a missing baseline is an unknown state
+    that must not be reported as clean.
+    """
+
+    if any(r.severity == "fail" for r in regressions):
+        return "fail"
+    if not baseline_present:
+        return "no-baseline"
+    return "warn" if regressions else "clean"
+
+
+def _one_line(outcome: str, regressions: list[Regression], snapshots_found: int) -> str:
+    if outcome == "no-baseline":
+        return (
+            f"observability gate: no baseline to compare against "
+            f"({snapshots_found} snapshot(s), need 2); comparison not performed"
+        )
     if not regressions:
-        return "observability gate: no regressions"
+        return "observability gate: no regressions (baseline compared)"
     fails = sum(1 for r in regressions if r.severity == "fail")
     warns = len(regressions) - fails
     return f"observability gate: {fails} fail, {warns} warn regression(s)"
 
 
-def _render_summary(regressions: list[Regression]) -> str:
+_NO_BASELINE_NOTE = "note: no baseline snapshot; day-over-day comparison not performed"
+
+
+def _render_summary(
+    outcome: str,
+    regressions: list[Regression],
+    snapshots_found: int,
+    *,
+    baseline_present: bool,
+) -> str:
     """Render a Markdown summary block for the CI step summary."""
 
-    lines = ["## Observability regression gate", "", _one_line(regressions), ""]
+    lines = ["## Observability regression gate", "", _one_line(outcome, regressions, snapshots_found), ""]
+    if outcome == "no-baseline":
+        lines += [
+            "The snapshot corpus holds fewer than two readable dated files, "
+            "so no comparison ran. This is an unknown state, not a clean result.",
+            "",
+        ]
+    elif not baseline_present:
+        lines += [_NO_BASELINE_NOTE + "; only absolute threshold failures are reported.", ""]
     if regressions:
         lines += ["| severity | backend | metric | prev | curr | reason |", "| --- | --- | --- | ---: | ---: | --- |"]
         for r in sorted(regressions, key=lambda x: (x.severity != "fail", x.backend, x.metric)):
@@ -282,23 +339,37 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
+    snapshots_found = len(dated_snapshots(args.snapshots))
     prev, curr = load_two_latest(args.snapshots)
     regressions = detect_regressions(prev, curr)
+    baseline_present = prev is not None and curr is not None
+    outcome = resolve_outcome(baseline_present, regressions)
 
-    payload = [asdict(r) for r in regressions]
+    payload = {
+        "outcome": outcome,
+        "baseline_present": baseline_present,
+        "snapshots_found": snapshots_found,
+        "regressions": [asdict(r) for r in regressions],
+    }
     if args.out is not None:
         args.out.parent.mkdir(parents=True, exist_ok=True)
         args.out.write_text(json.dumps(payload, indent=2), encoding="utf-8")
     if args.summary_out is not None:
         with args.summary_out.open("a", encoding="utf-8") as handle:
-            handle.write(_render_summary(regressions))
+            handle.write(_render_summary(outcome, regressions, snapshots_found, baseline_present=baseline_present))
 
-    print(_one_line(regressions))
+    print(_one_line(outcome, regressions, snapshots_found))
+    if not baseline_present and outcome != "no-baseline":
+        print(f"  {_NO_BASELINE_NOTE}")
     for r in regressions:
         metric = "" if r.metric == _SENTINEL_METRIC else f".{r.metric}"
         print(f"  [{r.severity}] {r.backend}{metric}: {r.reason}")
 
-    return 1 if any(r.severity == "fail" for r in regressions) else 0
+    if outcome == "fail":
+        return EXIT_REGRESSIONS
+    if outcome == "no-baseline":
+        return EXIT_NO_BASELINE
+    return EXIT_OK
 
 
 if __name__ == "__main__":

--- a/src/bernstein/evolution/detector.py
+++ b/src/bernstein/evolution/detector.py
@@ -335,8 +335,10 @@ class OpportunityDetector:
         cost and task metrics.
 
         Guarded: returns an empty list when no snapshots directory is
-        configured, the directory is missing, or fewer than two snapshots
-        exist. Never raises.
+        configured or the scan cannot run. A missing baseline (absent
+        directory or fewer than two snapshots) is logged as an explicit
+        skipped comparison rather than treated as a clean scan. Never
+        raises.
         """
 
         if self._observability_snapshots_dir is None:
@@ -344,11 +346,17 @@ class OpportunityDetector:
         try:
             from bernstein.evolution.observability_signals import detect_regressions
 
-            regressions = detect_regressions(self._observability_snapshots_dir)
+            scan = detect_regressions(self._observability_snapshots_dir)
         except Exception:
             logger.exception("observability regression scan failed")
             return []
-        return [_regression_to_opportunity(reg) for reg in regressions]
+        if not scan.baseline_present:
+            logger.info(
+                "observability snapshots in %s lack a baseline; regression comparison not performed",
+                self._observability_snapshots_dir,
+            )
+            return []
+        return [_regression_to_opportunity(reg) for reg in scan.regressions]
 
     def _write_opportunities(self, opportunities: list[ImprovementOpportunity]) -> None:
         """Write detected opportunities to .sdd/analysis/opportunities.json."""

--- a/src/bernstein/evolution/observability_signals.py
+++ b/src/bernstein/evolution/observability_signals.py
@@ -7,12 +7,15 @@ turns the two most recent snapshots into signals the self-improvement loop can
 consume:
 
 * :func:`detect_regressions` - security regressions worth an
-  ``ImprovementOpportunity``.
+  ``ImprovementOpportunity``, wrapped in an :class:`ObservabilityScan`
+  that says whether a baseline comparison actually ran.
 
 Everything is best-effort and guarded: a missing directory, fewer than two
-snapshots, or malformed JSON yields an empty / zero result rather than an
-error. The self-improvement loop otherwise sees only internal cost and task
-metrics; these functions feed it external repo-health signals.
+snapshots, or malformed JSON never raises. A scan without a baseline is
+reported as ``baseline_present=False`` so callers can tell "nothing was
+compared" apart from "compared and found nothing". The self-improvement
+loop otherwise sees only internal cost and task metrics; these functions
+feed it external repo-health signals.
 """
 
 from __future__ import annotations
@@ -46,6 +49,18 @@ class ObservabilityRegression:
     delta: float
     kind: str  # "security"
     severity: str  # "high" | "medium" | "low"
+
+
+@dataclass(frozen=True)
+class ObservabilityScan:
+    """Result of a snapshot scan, explicit about whether a comparison ran.
+
+    ``baseline_present=False`` with empty ``regressions`` means no
+    day-over-day comparison was performed; it is not a clean result.
+    """
+
+    baseline_present: bool
+    regressions: list[ObservabilityRegression]
 
 
 def _load(path: Path) -> dict[str, Any] | None:
@@ -97,17 +112,19 @@ def _metric_numeric(payload: dict[str, Any] | None, backend: str, metric: str) -
     return None
 
 
-def detect_regressions(snapshots_dir: Path = DEFAULT_SNAPSHOTS_DIR) -> list[ObservabilityRegression]:
-    """Return security regressions from the two latest snapshots.
+def detect_regressions(snapshots_dir: Path = DEFAULT_SNAPSHOTS_DIR) -> ObservabilityScan:
+    """Scan the two latest snapshots for security regressions.
 
     A regression requires a real day-over-day baseline: a metric present only
     in the newer snapshot (for example a backend that just gained credentials)
-    is a first observation, not a regression, and is skipped.
+    is a first observation, not a regression, and is skipped. When fewer than
+    two readable snapshots exist the scan reports ``baseline_present=False``
+    instead of pretending a comparison found nothing.
     """
 
     prev, curr = latest_two_snapshots(snapshots_dir)
     if prev is None or curr is None:
-        return []
+        return ObservabilityScan(baseline_present=False, regressions=[])
 
     regressions: list[ObservabilityRegression] = []
 
@@ -130,4 +147,4 @@ def detect_regressions(snapshots_dir: Path = DEFAULT_SNAPSHOTS_DIR) -> list[Obse
                 )
             )
 
-    return regressions
+    return ObservabilityScan(baseline_present=True, regressions=regressions)

--- a/tests/unit/observability/test_gate.py
+++ b/tests/unit/observability/test_gate.py
@@ -9,7 +9,10 @@ in-memory snapshot payloads (the same shape ``bernstein doctor observe
 - a new / increased security vulnerability,
 - a backend that silently lost its credentials,
 - a clean (green) diff that must stay quiet,
-- the ``load_two_latest`` file-ordering + exit-code plumbing.
+- the ``load_two_latest`` file-ordering + exit-code plumbing,
+- the three-outcome contract: regressions found (exit 1), baseline
+  compared and clean (exit 0), and no baseline to compare against
+  (exit 2, never worded as "no regressions").
 
 The script is import-only at module level so these tests drive its pure
 functions directly without spawning a subprocess.
@@ -251,11 +254,13 @@ def test_main_exit_code_and_output(tmp_path: Path) -> None:
 
     assert code == 1  # a fail-severity regression exits non-zero
     payload = json.loads(out.read_text(encoding="utf-8"))
-    assert len(payload) == 1
-    assert payload[0]["severity"] == "fail"
+    assert payload["outcome"] == "fail"
+    assert payload["baseline_present"] is True
+    assert len(payload["regressions"]) == 1
+    assert payload["regressions"][0]["severity"] == "fail"
 
 
-def test_main_green_exits_zero_and_writes_empty(tmp_path: Path) -> None:
+def test_main_green_exits_zero_and_writes_clean(tmp_path: Path, capsys: Any) -> None:
     (tmp_path / "2026-07-13.json").write_text(json.dumps(_snapshot()), encoding="utf-8")
     (tmp_path / "2026-07-14.json").write_text(json.dumps(_snapshot()), encoding="utf-8")
     out = tmp_path / "regressions.json"
@@ -263,4 +268,148 @@ def test_main_green_exits_zero_and_writes_empty(tmp_path: Path) -> None:
     code = gate.main(["--snapshots", str(tmp_path), "--out", str(out)])
 
     assert code == 0
-    assert json.loads(out.read_text(encoding="utf-8")) == []
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["outcome"] == "clean"
+    assert payload["baseline_present"] is True
+    assert payload["snapshots_found"] == 2
+    assert payload["regressions"] == []
+    assert "no regressions" in capsys.readouterr().out
+
+
+def test_main_warn_only_regressions_exit_zero(tmp_path: Path) -> None:
+    (tmp_path / "2026-07-13.json").write_text(
+        json.dumps(_snapshot(_backend("code-scanning", "ok", [_metric("open_alerts", 0.0, "ok")]))),
+        encoding="utf-8",
+    )
+    (tmp_path / "2026-07-14.json").write_text(
+        json.dumps(_snapshot(_backend("code-scanning", "warn", [_metric("open_alerts", 2.0, "warn")]))),
+        encoding="utf-8",
+    )
+    out = tmp_path / "regressions.json"
+
+    code = gate.main(["--snapshots", str(tmp_path), "--out", str(out)])
+
+    assert code == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["outcome"] == "warn"
+    assert len(payload["regressions"]) == 1
+
+
+# --------------------------------------------------------------------------
+# no-baseline outcome: absence of evidence is not evidence of absence
+# --------------------------------------------------------------------------
+
+
+def test_main_single_snapshot_refuses_success(tmp_path: Path, capsys: Any) -> None:
+    """One green snapshot means no comparison ran; the gate must say so."""
+
+    (tmp_path / "2026-07-14.json").write_text(
+        json.dumps(_snapshot(_backend("code-scanning", "ok", [_metric("critical_alerts", 0.0, "ok")]))),
+        encoding="utf-8",
+    )
+    out = tmp_path / "regressions.json"
+
+    code = gate.main(["--snapshots", str(tmp_path), "--out", str(out)])
+    stdout = capsys.readouterr().out
+
+    assert code == 2  # distinct from both clean (0) and regressions found (1)
+    assert "no baseline" in stdout
+    assert "comparison not performed" in stdout
+    assert "no regressions" not in stdout
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["outcome"] == "no-baseline"
+    assert payload["baseline_present"] is False
+    assert payload["snapshots_found"] == 1
+    assert payload["regressions"] == []
+
+
+def test_main_empty_corpus_refuses_success(tmp_path: Path, capsys: Any) -> None:
+    out = tmp_path / "regressions.json"
+
+    code = gate.main(["--snapshots", str(tmp_path / "missing"), "--out", str(out)])
+    stdout = capsys.readouterr().out
+
+    assert code == 2
+    assert "no regressions" not in stdout
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["outcome"] == "no-baseline"
+    assert payload["snapshots_found"] == 0
+
+
+def test_main_regression_against_baseline_fails_loudly(tmp_path: Path, capsys: Any) -> None:
+    """Injected security regressions with a real baseline must exit 1."""
+
+    (tmp_path / "2026-07-13.json").write_text(
+        json.dumps(
+            _snapshot(
+                _backend(
+                    "code-scanning",
+                    "ok",
+                    [
+                        _metric("critical_alerts", 0.0, "ok"),
+                        _metric("high_alerts", 0.0, "ok"),
+                        _metric("open_alerts", 0.0, "ok"),
+                    ],
+                ),
+            )
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "2026-07-14.json").write_text(
+        json.dumps(
+            _snapshot(
+                _backend(
+                    "code-scanning",
+                    "fail",
+                    [
+                        _metric("critical_alerts", 3.0, "fail"),
+                        _metric("high_alerts", 8.0, "fail"),
+                        _metric("open_alerts", 36.0, "warn"),
+                    ],
+                ),
+            )
+        ),
+        encoding="utf-8",
+    )
+    out = tmp_path / "regressions.json"
+
+    code = gate.main(["--snapshots", str(tmp_path), "--out", str(out)])
+    stdout = capsys.readouterr().out
+
+    assert code == 1
+    assert "fail" in stdout
+    assert "no regressions" not in stdout
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["outcome"] == "fail"
+    assert len(payload["regressions"]) == 3
+
+
+def test_main_hard_fail_without_baseline_still_fails(tmp_path: Path, capsys: Any) -> None:
+    """Absolute threshold failures are real even when no comparison ran."""
+
+    (tmp_path / "2026-07-14.json").write_text(
+        json.dumps(_snapshot(_backend("code-scanning", "fail", [_metric("critical_alerts", 2.0, "fail")]))),
+        encoding="utf-8",
+    )
+    out = tmp_path / "regressions.json"
+
+    code = gate.main(["--snapshots", str(tmp_path), "--out", str(out)])
+    stdout = capsys.readouterr().out
+
+    assert code == 1  # fail-severity finding wins over the missing baseline
+    assert "comparison not performed" in stdout  # but the gap is still named
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["outcome"] == "fail"
+    assert payload["baseline_present"] is False
+
+
+def test_summary_names_no_baseline_outcome(tmp_path: Path) -> None:
+    (tmp_path / "2026-07-14.json").write_text(json.dumps(_snapshot()), encoding="utf-8")
+    summary = tmp_path / "summary.md"
+
+    code = gate.main(["--snapshots", str(tmp_path), "--summary-out", str(summary)])
+
+    assert code == 2
+    text = summary.read_text(encoding="utf-8")
+    assert "no baseline" in text
+    assert "no regressions" not in text

--- a/tests/unit/test_observability_signals.py
+++ b/tests/unit/test_observability_signals.py
@@ -3,8 +3,9 @@
 Covers ``src/bernstein/evolution/observability_signals.py`` and the
 ``OpportunityDetector.identify_observability_opportunities`` wiring:
 
-- ``detect_regressions`` flags a security increase but stays quiet on a
-  flat / improved / single-snapshot corpus,
+- ``detect_regressions`` flags a security increase, stays quiet on a
+  flat / improved corpus, and reports a missing baseline as an explicit
+  ``baseline_present=False`` scan rather than a clean empty result,
 - ``OpportunityDetector`` only emits observability opportunities when a
   snapshots directory is configured (opt-in; default stays a no-op).
 """
@@ -42,20 +43,24 @@ def test_detect_regressions_flags_security_increase(tmp_path: Path) -> None:
     _write(tmp_path, "2026-07-10", _backend("code-scanning", "ok", [_metric("high_alerts", 0.0, "ok")]))
     _write(tmp_path, "2026-07-11", _backend("code-scanning", "warn", [_metric("high_alerts", 2.0, "warn")]))
 
-    regs = sig.detect_regressions(tmp_path)
+    scan = sig.detect_regressions(tmp_path)
 
-    assert len(regs) == 1
-    assert regs[0].kind == "security"
-    assert regs[0].backend == "code-scanning"
-    assert regs[0].severity == "high"
-    assert regs[0].delta == 2.0
+    assert scan.baseline_present is True
+    assert len(scan.regressions) == 1
+    assert scan.regressions[0].kind == "security"
+    assert scan.regressions[0].backend == "code-scanning"
+    assert scan.regressions[0].severity == "high"
+    assert scan.regressions[0].delta == 2.0
 
 
 def test_detect_regressions_quiet_on_flat_and_improved(tmp_path: Path) -> None:
     _write(tmp_path, "2026-07-10", _backend("code-scanning", "warn", [_metric("high_alerts", 3.0, "warn")]))
     _write(tmp_path, "2026-07-11", _backend("code-scanning", "ok", [_metric("high_alerts", 1.0, "warn")]))
 
-    assert sig.detect_regressions(tmp_path) == []
+    scan = sig.detect_regressions(tmp_path)
+
+    assert scan.baseline_present is True
+    assert scan.regressions == []
 
 
 def test_detect_regressions_skips_first_observation(tmp_path: Path) -> None:
@@ -63,13 +68,28 @@ def test_detect_regressions_skips_first_observation(tmp_path: Path) -> None:
     _write(tmp_path, "2026-07-10", _backend("code-scanning", "ok", [_metric("open_alerts", 0.0, "ok")]))
     _write(tmp_path, "2026-07-11", _backend("code-scanning", "warn", [_metric("high_alerts", 3.0, "warn")]))
 
-    assert sig.detect_regressions(tmp_path) == []
+    scan = sig.detect_regressions(tmp_path)
+
+    assert scan.baseline_present is True
+    assert scan.regressions == []
 
 
-def test_detect_regressions_empty_without_two_snapshots(tmp_path: Path) -> None:
+def test_detect_regressions_reports_missing_baseline(tmp_path: Path) -> None:
+    """A single snapshot is an absent baseline, not a clean comparison."""
+
     _write(tmp_path, "2026-07-11", _backend("code-scanning", "fail", [_metric("critical_alerts", 5.0, "fail")]))
 
-    assert sig.detect_regressions(tmp_path) == []
+    scan = sig.detect_regressions(tmp_path)
+
+    assert scan.baseline_present is False
+    assert scan.regressions == []
+
+
+def test_detect_regressions_reports_empty_corpus(tmp_path: Path) -> None:
+    scan = sig.detect_regressions(tmp_path / "missing")
+
+    assert scan.baseline_present is False
+    assert scan.regressions == []
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Closes #3065. Closes #3066.

Both issues are one defect seen from two sides: the daily snapshot that should advance the trend gate's baseline never lands in a commit, and the gate reports "no regressions" when it has no baseline to compare against. This PR fixes the pair so the baseline actually accumulates and the gate names which of three outcomes it is reporting.

## Gate: three explicit outcomes (#3066)

`scripts/observability/gate.py` now resolves one of three outcomes and names it in stdout, the step summary, and `regressions.json`:

- regressions found: exit 1 (unchanged)
- baseline compared, clean or warnings only: exit 0, worded "no regressions (baseline compared)"
- no baseline to compare against: exit 2, worded "no baseline to compare against (N snapshot(s), need 2); comparison not performed"

`regressions.json` is now a self-describing object (`outcome`, `baseline_present`, `snapshots_found`, `regressions`) so an empty comparison result stays distinguishable from a comparison that never ran. The only prior consumer was the workflow's own `[ ! -s ... ]` echo, which printed "No regressions recorded." in the no-baseline case; that echo is removed and the gate's own output is the record.

Exit-code choice for the no-baseline state: fail-shaped (non-zero), as exit 2. The gate protects security signals (critical/high code-scanning alerts), so an unevaluated state must not be able to pass as success anywhere downstream; a distinct code keeps "proven regression" (1) separable from "could not evaluate" (2) if the gate ever becomes blocking. The workflow wiring stays non-blocking (`|| true`), so the snapshot PR still opens either way and nothing in CI starts failing on day one; the operator-facing summary is what changes.

One asymmetry is deliberate: a single snapshot whose metrics already carry `threshold_status: fail` still exits 1. Absolute threshold failures are real without a baseline; the output additionally prints "day-over-day comparison not performed" so the missing baseline is still named.

`src/bernstein/evolution/observability_signals.py::detect_regressions` had the same shape (`[]` on a missing baseline) and now returns an `ObservabilityScan` with `baseline_present`; `OpportunityDetector.identify_observability_opportunities` logs a skipped comparison instead of treating it as a clean scan.

## Snapshot persistence (#3065)

Root cause confirmed with the reproduction from the issue: `docs/_internal/observability/snapshots/` is gitignored (`.gitignore` `docs/**/_internal/`), and `git add` silently skips ignored paths unless forced, so the `create-pull-request` `add-paths` commit-back was a no-op for the snapshot while still committing `docs/observability/trends.md` rendered from data that never landed.

Chosen mechanism: re-include the snapshot directory in `.gitignore` rather than force-adding from the workflow or relocating the corpus. The corpus is already tracked at this path (9 files) and the gate, the trends renderer, and the evolution signals all read it there; unignoring the one directory fixes the workflow, local restores, and any future writer at once without fighting the action's interface or moving history. The re-include unignores only `docs/_internal/observability/snapshots/`; everything else under `docs/_internal/` stays ignored (verified below). The duplicate `docs/_internal/` entry (lines 89/133) is collapsed while in there.

Workflow hardening in `docs-observability-snapshot.yml`:

- the capture step records the snapshot path before running `doctor observe`, so a WARN exit (rc 1, `continue-on-error`) can no longer leave the verification step without a target
- a new step validates the snapshot is parseable JSON before anything renders or commits it
- a new final step fails the run when the snapshot file is absent from the tree of the PR commit the action just opened (with a carve-out for a same-day re-run where the identical snapshot is already tracked)

`docs/observability/trends.md` derives its window claim from the files actually on disk, so with the snapshot verified to land in the same commit the stale-window mismatch (trends claiming 2026-07-22 over a corpus ending 2026-07-16) can no longer be committed.

`uv run python scripts/gen_workflow_topology.py` was run after the workflow edit; the regenerated `docs/operations/ci-topology.md` is byte-identical to the committed one (steps changed, no triggers/jobs), so there is nothing to commit for it.

## Verified

Gate CLI against the real corpus and both degenerate corpora:

```
$ python scripts/observability/gate.py --snapshots docs/_internal/observability/snapshots ...
observability gate: 1 fail, 1 warn regression(s)
  [warn] code-scanning.open_alerts: open_alerts +2
  [fail] code-scanning.high_alerts: high_alerts +1
exit=1   outcome=fail baseline_present=True snapshots_found=9

$ python scripts/observability/gate.py --snapshots <empty-dir> ...
observability gate: no baseline to compare against (0 snapshot(s), need 2); comparison not performed
exit=2

$ python scripts/observability/gate.py --snapshots <single-snapshot-dir> ...
observability gate: no baseline to compare against (1 snapshot(s), need 2); comparison not performed
exit=2
```

(The exit 1 against the real corpus is a live finding between 2026-07-12 and 2026-07-16; the daily workflow keeps the gate non-blocking.)

Ignore semantics after the `.gitignore` change:

```
$ git check-ignore -v docs/_internal/observability/snapshots/2026-07-25.json   # exit 1, not ignored
$ git add docs/_internal/observability/snapshots/<new-file>.json               # stages without -f
$ git check-ignore docs/_internal/secret-notes.md                              # still ignored
$ git check-ignore docs/_internal/observability/private-notes.md               # still ignored
$ git check-ignore docs/foo/_internal/x.md                                     # still ignored
```

Tests (new tests written first and confirmed failing before the fix):

```
tests/unit/observability/ + test_observability_signals + test_observability_api
  + test_observability_tasks_by_id + test_workflow_uv_installers_yaml: 144 passed
tests/unit/test_evolution*.py + tests/integration/test_evolution_feedback_loop.py: 143 passed
ruff check src/ tests/ scripts/: all checks passed
```

New coverage includes: a sub-threshold corpus must not report success (exit 2, output names the no-baseline state, never "no regressions"); injected regressions against a real baseline fail loudly (exit 1); warn-only regressions stay exit 0; the step summary names the no-baseline outcome; the evolution scan reports `baseline_present=False` distinctly from an empty result.
