### PR TITLE
fix(audit): a shrunk or crash-damaged history cannot obtain a fresh seal, and tear evidence is durable until acknowledged

### DIFF
--- a/docs/security/audit-log.md
+++ b/docs/security/audit-log.md
@@ -439,6 +439,19 @@ archive format guarantees: gzipped JSONL, the chain still verifies
 end-to-end across uncompressed + archived files as long as you feed
 both into the verifier.
 
+### The checkpoints file is exempt from rotation
+
+`.sdd/audit/checkpoints/checkpoints.jsonl` is load-bearing for shrink
+detection and **must not** be rotated, truncated, or edited: each
+checkpoint is hash-linked to its predecessor back to the first line,
+so removing early lines fails validation and blocks sealing. growth
+is modest - one small line per accepted seal that actually changed
+the tree (re-sealing an unchanged log appends nothing), each line
+pinning only the currently live segments - and it stays several
+orders of magnitude smaller than the chain it pins. if you snapshot
+audit history off-host, copy this file whole alongside the segments;
+the pinned prefixes verify against archived segments too.
+
 ## Shipping to a SIEM
 
 bernstein ships in-process exporters for splunk HEC, elasticsearch,

--- a/docs/security/audit-log.md
+++ b/docs/security/audit-log.md
@@ -297,10 +297,29 @@ what the seal binds:
   itself, so a leaf set with its last entry duplicated cannot collide
   with the un-duplicated set.
 - **chain precheck** - `audit seal` verifies the HMAC chain before
-  writing the root. a broken chain raises and **no seal is written**,
-  so re-sealing can never launder a pre-existing tamper into a fresh
-  root. seal a known-broken chain on purpose only via the recovery
-  procedure below.
+  writing the root. a broken chain aborts and **no seal is written**;
+  unacknowledged tear evidence (see below) aborts the same way. this
+  precheck alone does *not* stop laundering: a crash that truncates
+  the newest segment back to a record boundary leaves the HMAC chain
+  intact, so a chain-only precheck waves the shrunk history through.
+  that is what the checkpoint gate exists for. seal a known-broken
+  chain on purpose only via the recovery procedure below.
+- **checkpoint gate** - after every successful seal, a signed
+  checkpoint pins the chain origin, the total record count, and each
+  sealed segment's exact byte length and content hash into
+  `.sdd/audit/checkpoints/checkpoints.jsonl` (append-only, HMAC-signed
+  with the audit key, each checkpoint chained to its predecessor's
+  hash; kept outside `merkle/`, which the seal job writes). the next
+  `audit seal` refuses unless the current tree is a **consistent
+  extension** of the last checkpoint: the record count has not
+  decreased, and every pinned segment reproduces its checkpointed
+  hash from its current byte prefix (live or archived). a shrunk or
+  rewritten history therefore cannot obtain a fresh accepted seal:
+  the seal job exits non-zero naming the checkpoint it conflicts
+  with, on every run, until an operator acknowledges the divergence
+  with `bernstein audit ack-tear`. the superseded checkpoint is never
+  deleted, so the evidence of what was pinned stays on disk
+  permanently.
 
 scheme versioning: seals carry a `"scheme"` field. verification
 dispatches on it, so seals written before this hardening (`scheme` 1,
@@ -308,6 +327,45 @@ or absent) still verify under their original rule. roots produced
 before and after the upgrade are **not comparable** - re-seal once
 after upgrading, and keep any pinned pre-upgrade root labelled as the
 old scheme. this is a scheme upgrade, not a tamper alert.
+
+### Tears: crash damage at the chain tail
+
+a crashed append is not a clean truncation. file size can be
+persisted before data blocks, so the tail of the newest segment can
+hold a partial line, bytes that parse as JSON but fail their MAC, or
+bytes that are not UTF-8 at all. every such non-verifying suffix is
+classified as a **tear**, with the byte offset of the last verifiable
+record, and reported by `bernstein audit verify` as a verdict
+distinct from chain corruption.
+
+what happens around a tear:
+
+- **the next append seals it.** the writer terminates the damaged
+  tail and appends a `chain.torn_record` event - terminator and
+  evidence in one write, fsynced - so the record being written can
+  never fuse onto the fragment, and the evidence that a record was
+  damaged is itself HMAC-chained. nothing is ever truncated or
+  repaired in place.
+- **the evidence is durable.** `audit verify` keeps failing and
+  `audit seal` keeps refusing, on every run, until an operator
+  acknowledges the tear. sealing does not clear it, appending does
+  not clear it, and re-sealing does not clear it.
+- **acknowledgement is explicit and chain-resident.**
+  `bernstein audit ack-tear --segment <file> --offset <byte> --reason
+  "..."` appends a `chain.tear_acknowledged` record naming the tear
+  exactly as verify printed it. after that, verification passes again
+  and the next seal records a new checkpoint - while the torn bytes,
+  the tear record, the acknowledgement, and the superseded checkpoint
+  all stay in the history permanently.
+
+scope, stated honestly: the checkpoint gate makes a shrink
+non-launderable by the seal job and detectable by every verify run
+against the local directory. an actor with write access to **both**
+the chain segments and the checkpoints file can still rewind both to
+a mutually consistent earlier state; catching that requires retention
+outside the writer's filesystem (an independent co-signer over
+checkpoints), which is planned as a follow-up and tracked on the
+issue tracker.
 
 ## Replaying a log
 
@@ -447,9 +505,11 @@ a real tamper looks like one or both of:
 
 rare benign causes:
 
-- partial write at process kill (last line truncated). expected to be
-  unparseable JSON, not an hmac mismatch - both verifier paths log
-  this distinctly.
+- partial write at process kill (last line truncated, or garbage bytes
+  in the tail). reported as **tear evidence** with the byte offset of
+  the last verifiable record - a verdict distinct from an hmac
+  mismatch - and cleared only by `bernstein audit ack-tear` after you
+  have looked (see the tears section above).
 - key rotation done without archive-then-clear (see above).
 - legacy log written under the old `.hmac_key` filename, now read
   with the XDG-default key.
@@ -468,9 +528,12 @@ rare benign causes:
    webhook / splunk export was healthy, the SIEM has the original
    payload and you can identify exactly which fields were edited.
 4. seal the broken chain so the corruption is itself tamper-evident
-   forensically. a plain `audit seal` refuses a broken chain (so
-   re-sealing can't hide a tamper) - pass `--allow-broken-chain` to
-   capture the corrupted state on purpose:
+   forensically. a plain `audit seal` refuses a broken chain, refuses
+   unacknowledged tear evidence, and refuses a history that conflicts
+   with the last checkpoint - pass `--allow-broken-chain` to capture
+   the corrupted state on purpose. a forensic seal skips those gates
+   and **does not advance the checkpoint**, so the pinned history
+   stays exactly what the last accepted seal pinned:
 
    ```bash
    bernstein audit seal --allow-broken-chain

--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -553,10 +553,29 @@ def _verify_hmac_chain() -> bool:
     operator acknowledges it. In particular, re-sealing does not clear it.
     """
     from bernstein.core.audit import AuditLog
-
-    report = AuditLog(AUDIT_DIR).verify_detailed()
+    from bernstein.core.security.audit import AuditKeyMissingError, load_audit_key
 
     console.print()
+
+    # Verification is read-only and must never mint key material: a freshly
+    # generated key cannot authenticate an existing chain, so it would report
+    # a fabricated tamper alarm and leave stray key bytes behind. An empty
+    # chain needs no key at all.
+    has_segments = any(AUDIT_DIR.glob("*.jsonl")) or any((AUDIT_DIR / "archive").glob("*.jsonl.gz"))
+    if not has_segments:
+        console.print(
+            Panel("[bold green]HMAC Chain Verification Passed[/bold green]", border_style="green", expand=False)
+        )
+        return True
+    try:
+        key = load_audit_key()
+    except AuditKeyMissingError as exc:
+        console.print(Panel("[bold red]HMAC Chain Verification FAILED[/bold red]", border_style="red", expand=False))
+        console.print(f"  [red]![/red] {exc}")
+        return False
+
+    report = AuditLog(AUDIT_DIR, key=key).verify_detailed()
+
     if report.hard_errors:
         console.print(Panel("[bold red]HMAC Chain Verification FAILED[/bold red]", border_style="red", expand=False))
         for err in report.hard_errors:
@@ -742,10 +761,13 @@ def ack_tear_cmd(segment: str, offset: int, reason: str, actor: str | None) -> N
         matched = any(t.segment == segment and t.byte_offset == offset for t in report.tears)
 
         # A tear at the tail and a checkpoint divergence commonly describe the
-        # same damage (a truncation is both). One acknowledgement covers both:
-        # when the named segment also conflicts with the pinned checkpoint,
-        # the record carries the conflicting root, which is what authorises
-        # the next seal to record a new pin.
+        # same damage (a truncation is both, at the same offset). When the
+        # named (segment, offset) matches a checkpoint conflict exactly, the
+        # record carries the conflicting root, which is what authorises the
+        # next seal to record a new pin. The root is attached only on an
+        # exact match: an acknowledgement stays bound to precisely what
+        # verify printed, and a divergence whose conflict offset differs
+        # needs its own acknowledgement at that offset.
         try:
             state = load_checkpoints(AUDIT_DIR, key)
         except CheckpointFileError as exc:
@@ -753,11 +775,10 @@ def ack_tear_cmd(segment: str, offset: int, reason: str, actor: str | None) -> N
         last = state.last
         if last is not None:
             for conflict in check_extension(AUDIT_DIR, last):
-                if conflict.segment != segment:
+                if conflict.segment != segment or conflict.offset != offset:
                     continue
                 details[ACK_CHECKPOINT_ROOT_KEY] = str(last.get("root_hash", ""))
-                if conflict.offset == offset:
-                    matched = True
+                matched = True
                 break
 
         if not matched:

--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -11,7 +11,8 @@ Commands:
   bernstein audit show               Show recent audit log events.
   bernstein audit seal               Compute and store a Merkle root.
   bernstein audit seal --anchor-git  Also create a git tag.
-  bernstein audit verify             Verify HMAC chain and Merkle tree.
+  bernstein audit ack-tear           Acknowledge recorded tear evidence.
+  bernstein audit verify             Verify HMAC chain, Merkle tree, checkpoint.
   bernstein audit verify --hmac-only Verify HMAC chain only.
   bernstein audit verify --merkle-only  Verify Merkle tree only.
   bernstein audit verify --receipt   Verify one automation trigger receipt or
@@ -117,12 +118,23 @@ def show_cmd(limit: int) -> None:
 def seal_cmd(anchor_git: bool, allow_broken_chain: bool) -> None:
     """Compute a Merkle root across all audit log files and store the seal.
 
-    By default the HMAC chain is verified first and a broken chain aborts
-    the seal, so re-sealing cannot launder a pre-existing tamper into a
-    fresh root. Pass --allow-broken-chain to seal a known-corrupted log on
-    purpose (forensic evidence capture during the recovery procedure).
+    Two prechecks gate the seal. The chain must verify (a broken chain or
+    unacknowledged tear evidence aborts), and the tree must be a consistent
+    extension of the last signed checkpoint - so a history that shrank since
+    the last seal cannot obtain a fresh accepted seal, even when the
+    remaining chain is HMAC-intact. On success the checkpoint advances.
+
+    Pass --allow-broken-chain to seal a known-corrupted log on purpose
+    (forensic evidence capture during the recovery procedure); a forensic
+    seal skips both prechecks and never advances the checkpoint.
     """
     from bernstein.core.merkle import ChainBrokenError, anchor_to_git, compute_seal, save_seal
+    from bernstein.core.persistence.chain_checkpoint import (
+        CheckpointConsistencyError,
+        CheckpointFileError,
+        record_checkpoint,
+    )
+    from bernstein.core.security.audit import OutstandingTearError, load_or_create_audit_key
 
     if not AUDIT_DIR.is_dir():
         console.print(f"[red]Audit directory not found:[/red] {AUDIT_DIR}")
@@ -130,7 +142,11 @@ def seal_cmd(anchor_git: bool, allow_broken_chain: bool) -> None:
         raise SystemExit(1)
 
     try:
-        _tree, seal = compute_seal(AUDIT_DIR, verify_chain=not allow_broken_chain)
+        _tree, seal = compute_seal(
+            AUDIT_DIR,
+            verify_chain=not allow_broken_chain,
+            checkpoint_gate=not allow_broken_chain,
+        )
     except ValueError as exc:
         console.print(f"[red]{exc}[/red]")
         raise SystemExit(1) from None
@@ -141,8 +157,34 @@ def seal_cmd(anchor_git: bool, allow_broken_chain: bool) -> None:
             "To seal a known-corrupted log for forensics, re-run with --allow-broken-chain.[/dim]"
         )
         raise SystemExit(1) from None
+    except OutstandingTearError as exc:
+        console.print("[red]Refusing to seal: unacknowledged tear evidence is outstanding.[/red]")
+        for tear in exc.tears:
+            console.print(f"  [red]![/red] {tear.describe()}")
+            console.print(
+                f"  [dim]bernstein audit ack-tear --segment {tear.segment} "
+                f'--offset {tear.byte_offset} --reason "..."[/dim]'
+            )
+        raise SystemExit(1) from None
+    except CheckpointConsistencyError as exc:
+        _print_checkpoint_conflict(exc)
+        raise SystemExit(1) from None
+    except CheckpointFileError as exc:
+        console.print(f"[red]Refusing to seal: {exc}[/red]")
+        raise SystemExit(1) from None
 
     seal_path = save_seal(seal, MERKLE_DIR)
+
+    checkpoint = None
+    if not allow_broken_chain:
+        try:
+            checkpoint = record_checkpoint(AUDIT_DIR, seal, key=load_or_create_audit_key())
+        except CheckpointConsistencyError as exc:
+            _print_checkpoint_conflict(exc)
+            raise SystemExit(1) from None
+        except (CheckpointFileError, OSError) as exc:
+            console.print(f"[red]Seal written but the checkpoint could not be recorded: {exc}[/red]")
+            raise SystemExit(1) from None
 
     # Display result
     console.print()
@@ -161,10 +203,16 @@ def seal_cmd(anchor_git: bool, allow_broken_chain: bool) -> None:
     table.add_row("Leaves", str(seal["leaf_count"]))
     table.add_row("Algorithm", str(seal["algorithm"]))
     table.add_row("Scheme", str(seal.get("scheme", 1)))
+    table.add_row("Entries", str(seal.get("entry_count", "-")))
     table.add_row("Sealed at", str(seal["sealed_at_iso"]))
     table.add_row("Seal file", str(seal_path))
+    if checkpoint is not None:
+        extended = "extends previous" if checkpoint.get("extends_prev", True) else "acknowledged divergence"
+        table.add_row("Checkpoint", f"pinned at {checkpoint.get('entry_count', '-')} entries ({extended})")
     if allow_broken_chain:
-        console.print("[yellow]Sealed WITHOUT chain verification (--allow-broken-chain).[/yellow]")
+        console.print(
+            "[yellow]Sealed WITHOUT chain verification (--allow-broken-chain); checkpoint not advanced.[/yellow]"
+        )
     console.print(table)
 
     if anchor_git:
@@ -231,6 +279,14 @@ def verify_cmd(merkle_only: bool, hmac_only: bool, receipt_path: str | None, pay
 
     if not hmac_only:
         all_passed = _verify_merkle_tree() and all_passed
+
+    # Checkpoint extension is the pillar that makes a shrink sticky: a
+    # truncation that leaves the HMAC chain intact still conflicts with the
+    # last signed checkpoint, is reported here as tear evidence, and keeps
+    # failing until an operator acknowledges it. Like the evidence-bundle
+    # pillar, it runs regardless of --hmac-only / --merkle-only: a cron job
+    # invoking either narrow form must still go red when history shrinks.
+    all_passed = _verify_checkpoints() and all_passed
 
     # Evidence bundles are a third integrity pillar: a tampered evidence file
     # must fail verify exactly like a tampered chain entry (#2362). This runs
@@ -488,21 +544,231 @@ def _verify_grant_chains() -> bool:
 
 
 def _verify_hmac_chain() -> bool:
-    """Verify HMAC chain and print results. Returns True if valid."""
+    """Verify HMAC chain and print results. Returns True if valid.
+
+    Tear evidence is a verdict distinct from chain corruption: crash-shaped
+    damage at the chain tail (or its sealed remains) is reported with the byte
+    offset of the last verifiable record and an acknowledgement command, and
+    it keeps failing verification - on every run, indefinitely - until an
+    operator acknowledges it. In particular, re-sealing does not clear it.
+    """
     from bernstein.core.audit import AuditLog
 
-    hmac_valid, hmac_errors = AuditLog(AUDIT_DIR).verify()
+    report = AuditLog(AUDIT_DIR).verify_detailed()
 
     console.print()
-    if hmac_valid:
+    if report.hard_errors:
+        console.print(Panel("[bold red]HMAC Chain Verification FAILED[/bold red]", border_style="red", expand=False))
+        for err in report.hard_errors:
+            console.print(f"  [red]![/red] {err}")
+    else:
         console.print(
             Panel("[bold green]HMAC Chain Verification Passed[/bold green]", border_style="green", expand=False)
         )
+
+    outstanding = report.unacknowledged_tears
+    if outstanding:
+        console.print()
+        console.print(
+            Panel("[bold red]Chain Tear Evidence UNACKNOWLEDGED[/bold red]", border_style="red", expand=False)
+        )
+        for tear in outstanding:
+            console.print(f"  [red]![/red] {tear.describe()}")
+        console.print(
+            "  [dim]A crash (or a truncation) left a non-verifying tail. The evidence is durable\n"
+            "  and does not clear itself. Investigate, then acknowledge with:[/dim]\n"
+            f"  [dim]bernstein audit ack-tear --segment {outstanding[0].segment} "
+            f'--offset {outstanding[0].byte_offset} --reason "..."[/dim]'
+        )
+    acknowledged = [tear for tear in report.tears if tear.acknowledged]
+    if acknowledged:
+        console.print(f"  [dim]{len(acknowledged)} acknowledged tear(s) remain recorded in the chain.[/dim]")
+
+    return not report.hard_errors and not outstanding
+
+
+def _print_checkpoint_conflict(exc: object) -> None:
+    """Print a checkpoint-consistency conflict with its acknowledgement path."""
+    checkpoint = getattr(exc, "checkpoint", {}) or {}
+    conflicts = getattr(exc, "conflicts", []) or []
+    console.print(Panel("[bold red]Checkpoint Divergence (tear evidence)[/bold red]", border_style="red", expand=False))
+    console.print(
+        f"  [red]![/red] history conflicts with checkpoint root "
+        f"{str(checkpoint.get('root_hash', ''))[:16]}… "
+        f"(pinned {checkpoint.get('entry_count', '?')} entries)"
+    )
+    ackable = False
+    for conflict in conflicts:
+        console.print(f"  [red]![/red] {conflict.segment or conflict.kind}: {conflict.detail}")
+        if conflict.kind in type(conflict).ACKABLE_KINDS:
+            ackable = True
+    console.print(
+        "  [dim]The audit history shrank or was rewritten since the last accepted seal.\n"
+        "  A fresh seal will not be produced and this conflict will not clear itself.[/dim]"
+    )
+    if ackable:
+        first = next(c for c in conflicts if c.kind in type(c).ACKABLE_KINDS)
+        console.print(
+            f"  [dim]After investigating: bernstein audit ack-tear --segment {first.segment} "
+            f'--offset {first.offset} --reason "..."[/dim]'
+        )
+
+
+def _verify_checkpoints() -> bool:
+    """Verify the current tree against the last signed checkpoint.
+
+    Returns True when no checkpoint exists yet (nothing is pinned), when the
+    tree consistently extends the pin, or when a divergence has been
+    explicitly acknowledged; False otherwise. A divergence is reported as
+    tear evidence: the seal job refuses to advance over it and this check
+    keeps failing until an operator acknowledges.
+    """
+    from bernstein.core.persistence.chain_checkpoint import (
+        CheckpointConsistencyError,
+        CheckpointFileError,
+        authorize_divergence,
+        check_extension,
+        find_divergence_acks,
+        load_checkpoints,
+    )
+    from bernstein.core.security.audit import AuditKeyMissingError, load_audit_key
+
+    console.print()
+    try:
+        key = load_audit_key()
+    except AuditKeyMissingError as exc:
+        console.print(Panel("[bold red]Checkpoint Verification FAILED[/bold red]", border_style="red", expand=False))
+        console.print(f"  [red]![/red] {exc}")
+        return False
+
+    try:
+        state = load_checkpoints(AUDIT_DIR, key)
+    except CheckpointFileError as exc:
+        console.print(Panel("[bold red]Checkpoint Verification FAILED[/bold red]", border_style="red", expand=False))
+        for err in exc.errors:
+            console.print(f"  [red]![/red] {err}")
+        return False
+
+    last = state.last
+    if last is None:
+        console.print("[dim]No chain checkpoint recorded yet. Run 'bernstein audit seal' to pin the history.[/dim]")
         return True
-    console.print(Panel("[bold red]HMAC Chain Verification FAILED[/bold red]", border_style="red", expand=False))
-    for err in hmac_errors:
-        console.print(f"  [red]![/red] {err}")
+
+    conflicts = check_extension(AUDIT_DIR, last)
+    if not conflicts:
+        console.print(
+            Panel("[bold green]Checkpoint Verification Passed[/bold green]", border_style="green", expand=False)
+        )
+        table = Table(show_header=False, box=None, padding=(0, 2))
+        table.add_column("Key", style="dim", no_wrap=True, min_width=14)
+        table.add_column("Value")
+        table.add_row("Pinned root", str(last.get("root_hash", "")))
+        table.add_row("Pinned entries", str(last.get("entry_count", "-")))
+        if state.torn_tail:
+            table.add_row("Note", "checkpoints file ends in a torn append (previous pin in force)")
+        console.print(table)
+        return True
+
+    acks = find_divergence_acks(AUDIT_DIR, key, str(last.get("root_hash", "")))
+    if authorize_divergence(conflicts, acks) is not None:
+        console.print(
+            Panel("[bold yellow]Checkpoint Divergence acknowledged[/bold yellow]", border_style="yellow", expand=False)
+        )
+        console.print(
+            "  [dim]An operator acknowledged the divergence; the next 'bernstein audit seal' records a new pin.[/dim]"
+        )
+        return True
+
+    _print_checkpoint_conflict(CheckpointConsistencyError(last, conflicts))
     return False
+
+
+def _os_user() -> str:
+    """Best-effort OS user name, for acknowledgement records."""
+    import getpass
+
+    try:
+        return getpass.getuser()
+    except (OSError, KeyError):  # pragma: no cover - no passwd entry
+        return "unknown"
+
+
+@audit_group.command("ack-tear")
+@click.option("--segment", required=True, help="Segment file name as verify printed it, e.g. 2026-07-25.jsonl.")
+@click.option("--offset", required=True, type=int, help="Byte offset as verify printed it.")
+@click.option("--reason", required=True, help="What was investigated and what was concluded.")
+@click.option("--actor", default=None, help="Who is acknowledging (defaults to the OS user).")
+def ack_tear_cmd(segment: str, offset: int, reason: str, actor: str | None) -> None:
+    """Acknowledge tear evidence so verification and sealing can proceed.
+
+    The acknowledgement is appended to the chain, not written beside it:
+    nothing about clearing the alert is editable after the fact, and the
+    reason travels with the record. Acknowledging repairs nothing - torn or
+    truncated records are still gone - it records that an operator looked.
+    When the tear is a checkpoint divergence (the history shrank relative to
+    the last accepted seal), the acknowledgement also names the conflicting
+    checkpoint root, which is what authorises the next seal to record a new
+    pin. The superseded checkpoint stays in the checkpoints file permanently.
+    """
+    from bernstein.core.persistence.chain_checkpoint import (
+        ACK_CHECKPOINT_ROOT_KEY,
+        CheckpointFileError,
+        check_extension,
+        load_checkpoints,
+    )
+    from bernstein.core.security.audit import (
+        EVENT_CHAIN_TEAR_ACKNOWLEDGED,
+        AuditLog,
+        load_or_create_audit_key,
+    )
+
+    if not AUDIT_DIR.is_dir():
+        raise click.ClickException(f"audit directory not found: {AUDIT_DIR}")
+
+    key = load_or_create_audit_key()
+    log = AuditLog(AUDIT_DIR, key=key)
+    with log.append_transaction():
+        # The target must be real: either recorded/live tear evidence at
+        # exactly this (segment, offset), or a checkpoint conflict for this
+        # segment. Refusing otherwise keeps acknowledgements bound to
+        # something verify actually printed.
+        details: dict[str, object] = {"segment": segment, "byte_offset": offset, "reason": reason}
+        report = log.verify_detailed()
+        matched = any(t.segment == segment and t.byte_offset == offset for t in report.tears)
+
+        # A tear at the tail and a checkpoint divergence commonly describe the
+        # same damage (a truncation is both). One acknowledgement covers both:
+        # when the named segment also conflicts with the pinned checkpoint,
+        # the record carries the conflicting root, which is what authorises
+        # the next seal to record a new pin.
+        try:
+            state = load_checkpoints(AUDIT_DIR, key)
+        except CheckpointFileError as exc:
+            raise click.ClickException(str(exc)) from None
+        last = state.last
+        if last is not None:
+            for conflict in check_extension(AUDIT_DIR, last):
+                if conflict.segment != segment:
+                    continue
+                details[ACK_CHECKPOINT_ROOT_KEY] = str(last.get("root_hash", ""))
+                if conflict.offset == offset:
+                    matched = True
+                break
+
+        if not matched:
+            raise click.ClickException(
+                f"no recorded tear or checkpoint conflict for segment {segment!r} at byte {offset}. "
+                "Use the segment and offset exactly as 'bernstein audit verify' printed them."
+            )
+
+        log.log(
+            EVENT_CHAIN_TEAR_ACKNOWLEDGED,
+            actor or _os_user(),
+            "audit_segment",
+            segment,
+            details,
+        )
+    console.print(f"[green]Acknowledged[/green] tear in {segment} at byte {offset}.")
 
 
 def _verify_merkle_tree() -> bool:

--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -636,10 +636,15 @@ def _verify_checkpoints() -> bool:
     console.print()
     try:
         key = load_audit_key()
-    except AuditKeyMissingError as exc:
-        console.print(Panel("[bold red]Checkpoint Verification FAILED[/bold red]", border_style="red", expand=False))
-        console.print(f"  [red]![/red] {exc}")
-        return False
+    except AuditKeyMissingError:
+        # Checkpoints are HMAC-signed with the audit key. A verifier without
+        # the key cannot check them - the same limit the HMAC pillar has - so
+        # this is a named degradation, not a failure verdict.
+        console.print(
+            "[yellow]Checkpoint verification skipped: no audit HMAC key available "
+            "(checkpoints are signed with it).[/yellow]"
+        )
+        return True
 
     try:
         state = load_checkpoints(AUDIT_DIR, key)

--- a/src/bernstein/core/orchestration/orchestrator_cleanup.py
+++ b/src/bernstein/core/orchestration/orchestrator_cleanup.py
@@ -183,11 +183,14 @@ def cleanup(orch: Any) -> None:
     if orch._audit_mode and orch._audit_log is not None:
         try:
             from bernstein.core.merkle import compute_seal, save_seal
+            from bernstein.core.persistence.chain_checkpoint import record_checkpoint
+            from bernstein.core.security.audit import load_or_create_audit_key
 
             audit_dir = orch._workdir / ".sdd" / "audit"
             merkle_dir = audit_dir / "merkle"
             _tree, seal = compute_seal(audit_dir)
             seal_path = save_seal(seal, merkle_dir)
+            record_checkpoint(audit_dir, seal, key=load_or_create_audit_key())
             logger.info("Merkle audit seal written: %s (root=%s)", seal_path, seal["root_hash"])
         except Exception:
             logger.warning("Merkle seal generation on shutdown failed", exc_info=True)

--- a/src/bernstein/core/orchestration/orchestrator_cleanup.py
+++ b/src/bernstein/core/orchestration/orchestrator_cleanup.py
@@ -190,8 +190,18 @@ def cleanup(orch: Any) -> None:
             merkle_dir = audit_dir / "merkle"
             _tree, seal = compute_seal(audit_dir)
             seal_path = save_seal(seal, merkle_dir)
-            record_checkpoint(audit_dir, seal, key=load_or_create_audit_key())
             logger.info("Merkle audit seal written: %s (root=%s)", seal_path, seal["root_hash"])
+            try:
+                record_checkpoint(audit_dir, seal, key=load_or_create_audit_key())
+            except Exception:
+                # The seal above is written and valid; only the pin did not
+                # advance. Point the operator at the conflict, not the seal.
+                logger.warning(
+                    "Audit checkpoint not advanced on shutdown (seal written to %s); "
+                    "run 'bernstein audit verify' to see the conflict",
+                    seal_path,
+                    exc_info=True,
+                )
         except Exception:
             logger.warning("Merkle seal generation on shutdown failed", exc_info=True)
 

--- a/src/bernstein/core/persistence/chain_checkpoint.py
+++ b/src/bernstein/core/persistence/chain_checkpoint.py
@@ -1,0 +1,639 @@
+"""Signed chain checkpoints: the pin that makes audit-history shrink sticky.
+
+The Merkle seal (:mod:`bernstein.core.persistence.merkle`) proves the audit
+files matched a root *at seal time*, but a fresh seal is computed from
+whatever is on disk *now*. Before checkpoints, a crash that truncated the
+newest segment back to a record boundary left the HMAC chain intact, so the
+next scheduled ``bernstein audit seal`` recomputed a root over the shrunk
+history and every later ``bernstein audit verify`` passed. The damage healed
+itself on the schedule of a cron job, with no operator in the loop.
+
+A checkpoint pins, under an HMAC signature keyed by the audit key:
+
+* ``origin`` - the HMAC of the chain's first record, so a checkpoint from one
+  log can never gate another log (and a wholesale history replacement changes
+  the origin and conflicts).
+* ``entry_count`` - the number of canonical records across archived and live
+  segments at seal time.
+* ``root_hash`` and the per-file ``leaves`` with their exact ``byte_len`` at
+  seal time.
+
+A new seal is accepted only when the current tree is a consistent
+*extension* of the last checkpoint: the entry count is monotonically
+non-decreasing and every checkpointed leaf is reproducible as a byte prefix
+of the segment's current content (live or archived). This is the
+prefix-consistency check of an RFC 6962 consistency proof, adapted to the
+per-day-segment structure: the old root is recomputed from prefixes of the
+new state, so a shrunk or rewritten history mechanically cannot obtain a
+fresh accepted seal. The seal job then exits non-zero naming the checkpoint
+it conflicts with, and the conflict persists until an operator explicitly
+acknowledges it with ``bernstein audit ack-tear``.
+
+Storage discipline
+------------------
+Checkpoints live in ``<audit_dir>/checkpoints/checkpoints.jsonl`` - outside
+``merkle/``, which is the seal job's write domain. The file is append-only:
+``compute_seal`` reads it and refuses on conflict; a new checkpoint is only
+ever appended (with fsync), never rewritten, and each checkpoint carries the
+SHA-256 of its predecessor's canonical line so a spliced or reordered file
+fails validation. A crash-torn trailing fragment (an append that never
+completed) is skipped: the previous complete checkpoint stays authoritative,
+which can only make the pin *older*, never weaker than the last durable seal.
+
+Determinism: checkpoint payloads carry no timestamps and are canonically
+serialised, so two byte-identical audit directories sealed with the same key
+produce byte-identical checkpoint files.
+
+Residual (documented, not hidden): an actor with write access to both the
+chain segments and the checkpoints file can truncate both to a mutually
+consistent earlier state. Detecting that requires retention outside the
+local filesystem (a witness co-signature over checkpoints), which is a
+follow-up, not part of this module.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac as _hmac
+import json
+import os
+from contextlib import suppress
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+#: Schema version for checkpoint payloads.
+CHECKPOINT_VERSION = 1
+
+#: Subdirectory of the audit dir holding the append-only checkpoint file.
+#: Deliberately not under ``merkle/`` (the seal job's write domain) and not a
+#: ``*.jsonl`` file in the audit dir root (which the chain verifier globs).
+CHECKPOINTS_SUBDIR = "checkpoints"
+
+#: File name of the append-only checkpoint log.
+CHECKPOINTS_FILE = "checkpoints.jsonl"
+
+#: ``prev_checkpoint_sha256`` of the first checkpoint in a file.
+GENESIS_PREV = "0" * 64
+
+#: Ack detail key that authorises advancing past a conflicting checkpoint.
+ACK_CHECKPOINT_ROOT_KEY = "checkpoint_root"
+
+
+class CheckpointFileError(RuntimeError):
+    """Raised when the checkpoints file itself fails validation.
+
+    A bad signature, broken predecessor linkage, or an unparsable committed
+    line means the append-only discipline was violated (or the key is wrong);
+    the seal job must not guess which checkpoint to trust.
+    """
+
+    def __init__(self, errors: list[str]) -> None:
+        self.errors = errors
+        head = "; ".join(errors[:3])
+        super().__init__(f"Audit checkpoint file failed validation: {head}")
+
+
+@dataclass(frozen=True)
+class CheckpointConflict:
+    """One way the current tree fails to extend a checkpoint.
+
+    Attributes:
+        kind: ``segment_shrunk`` | ``segment_prefix_mismatch`` |
+            ``segment_missing`` | ``entry_count`` | ``origin`` | ``root``.
+        segment: Segment file name for per-segment kinds, else ``""``.
+        offset: Byte offset an operator would acknowledge: the current
+            segment size for a shrink, the checkpointed boundary for a
+            prefix mismatch, ``0`` otherwise.
+        detail: Human-readable explanation.
+    """
+
+    kind: str
+    segment: str
+    offset: int
+    detail: str
+
+    #: Conflict kinds an operator may acknowledge per segment. ``origin`` and
+    #: ``root`` conflicts mean the history or the checkpoint itself was
+    #: replaced, which acknowledgement must not paper over.
+    ACKABLE_KINDS = ("segment_shrunk", "segment_prefix_mismatch", "segment_missing")
+
+
+class CheckpointConsistencyError(RuntimeError):
+    """Raised when the current tree is not an extension of the last checkpoint.
+
+    Carries the conflicting checkpoint payload and the structured conflicts so
+    the CLI can name exactly what is pinned and what diverged.
+    """
+
+    def __init__(self, checkpoint: dict[str, Any], conflicts: list[CheckpointConflict]) -> None:
+        self.checkpoint = checkpoint
+        self.conflicts = conflicts
+        root = str(checkpoint.get("root_hash", ""))[:16]
+        count = checkpoint.get("entry_count", "?")
+        lines = "; ".join(f"{c.segment or c.kind}: {c.detail}" for c in conflicts[:3])
+        super().__init__(
+            f"Audit history is not an extension of checkpoint root={root}... "
+            f"(entry_count={count}); refusing to seal: {lines}"
+        )
+
+
+@dataclass(frozen=True)
+class CheckpointFileState:
+    """Validated content of the checkpoints file.
+
+    Attributes:
+        checkpoints: Complete, signature-valid checkpoint payloads in file
+            order.
+        torn_tail: ``True`` when the file ends in an incomplete append (crash
+            mid-write). The fragment is ignored; the last complete checkpoint
+            stays authoritative.
+    """
+
+    checkpoints: list[dict[str, Any]] = field(default_factory=list)
+    torn_tail: bool = False
+
+    @property
+    def last(self) -> dict[str, Any] | None:
+        return self.checkpoints[-1] if self.checkpoints else None
+
+
+# ---------------------------------------------------------------------------
+# Canonical form + signature
+# ---------------------------------------------------------------------------
+
+
+def _canonical(payload: dict[str, Any]) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+
+
+def _sign(payload: dict[str, Any], key: bytes) -> str:
+    """HMAC-SHA256 over the canonical payload, keyed by the audit key.
+
+    The audit key is the chain's existing trust root: a verifier that can
+    authenticate the chain can authenticate its checkpoints with the same
+    secret, and an attacker with write access to the audit directory (but not
+    the key, which lives outside it) cannot forge one. Ed25519 co-signing of
+    checkpoints is a planned follow-up for keyless third-party verification;
+    it layers on top of this record rather than replacing it.
+    """
+    return _hmac.new(key, _canonical(payload), hashlib.sha256).hexdigest()
+
+
+def _record_sha256(doc: dict[str, Any]) -> str:
+    return hashlib.sha256(_canonical(doc)).hexdigest()
+
+
+def checkpoints_path(audit_dir: Path) -> Path:
+    """Return the append-only checkpoints file path for *audit_dir*."""
+    return audit_dir / CHECKPOINTS_SUBDIR / CHECKPOINTS_FILE
+
+
+# ---------------------------------------------------------------------------
+# Load + validate
+# ---------------------------------------------------------------------------
+
+
+def load_checkpoints(audit_dir: Path, key: bytes) -> CheckpointFileState:
+    """Read and validate the checkpoints file.
+
+    Every complete line must parse, carry a valid HMAC signature, and link to
+    the SHA-256 of its predecessor's canonical form. A torn trailing fragment
+    (no terminator, or a terminator-bearing line that does not parse *and* is
+    the final line) is treated as a crash-interrupted append and skipped -
+    the pin regresses to the last complete checkpoint, which is conservative.
+    Everything else raises :class:`CheckpointFileError`.
+
+    Args:
+        audit_dir: The audit directory.
+        key: Audit HMAC key.
+
+    Returns:
+        The validated :class:`CheckpointFileState`.
+
+    Raises:
+        CheckpointFileError: On any committed-line validation failure.
+    """
+    path = checkpoints_path(audit_dir)
+    try:
+        raw = path.read_bytes()
+    except FileNotFoundError:
+        return CheckpointFileState()
+    except OSError as exc:
+        raise CheckpointFileError([f"unreadable checkpoints file: {exc}"]) from exc
+
+    if not raw:
+        return CheckpointFileState()
+
+    torn_tail = not raw.endswith(b"\n")
+    lines = raw.split(b"\n")
+    if lines and lines[-1] == b"":
+        lines.pop()
+
+    checkpoints: list[dict[str, Any]] = []
+    errors: list[str] = []
+    prev_sha = GENESIS_PREV
+    last_index = len(lines) - 1
+    for line_no, line in enumerate(lines):
+        is_last = line_no == last_index
+        try:
+            doc = json.loads(line)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            if is_last:
+                # Crash-interrupted append: ignore the fragment, keep the pin.
+                torn_tail = True
+                break
+            errors.append(f"checkpoints.jsonl:{line_no + 1}: unparsable committed line")
+            break
+        if not isinstance(doc, dict):
+            errors.append(f"checkpoints.jsonl:{line_no + 1}: not a JSON object")
+            break
+        payload = doc.get("payload")
+        if not isinstance(payload, dict):
+            errors.append(f"checkpoints.jsonl:{line_no + 1}: missing payload")
+            break
+        payload = cast("dict[str, Any]", payload)
+        if not _hmac.compare_digest(str(doc.get("hmac", "")), _sign(payload, key)):
+            errors.append(f"checkpoints.jsonl:{line_no + 1}: signature mismatch")
+            break
+        if str(payload.get("prev_checkpoint_sha256", "")) != prev_sha:
+            errors.append(f"checkpoints.jsonl:{line_no + 1}: predecessor linkage broken")
+            break
+        if payload.get("version") != CHECKPOINT_VERSION:
+            errors.append(f"checkpoints.jsonl:{line_no + 1}: unsupported version {payload.get('version')!r}")
+            break
+        checkpoints.append(payload)
+        prev_sha = _record_sha256(cast("dict[str, Any]", doc))
+
+    if errors:
+        raise CheckpointFileError(errors)
+    return CheckpointFileState(checkpoints=checkpoints, torn_tail=torn_tail)
+
+
+# ---------------------------------------------------------------------------
+# Chain-derived quantities
+# ---------------------------------------------------------------------------
+
+
+def _iter_segment_bytes(audit_dir: Path) -> list[tuple[str, bytes]]:
+    """Return ``(file_name, bytes)`` for archived then live segments, in chain order."""
+    from bernstein.core.security.audit import (
+        _JSONL_GLOB,
+        _archived_segment_paths,
+        _read_archived_segment,
+    )
+
+    out: list[tuple[str, bytes]] = []
+    for gz_path in _archived_segment_paths(audit_dir):
+        discard: list[str] = []
+        raw = _read_archived_segment(gz_path, discard)
+        if raw is not None:
+            # Archived segments keep their live name in checkpoints.
+            out.append((gz_path.name[: -len(".gz")], raw))
+    for live in sorted(audit_dir.glob(_JSONL_GLOB)):
+        with suppress(OSError):
+            out.append((live.name, live.read_bytes()))
+    return out
+
+
+def _canonical_records(raw: bytes) -> list[dict[str, Any]]:
+    """Return the canonical ``hmac``-bearing records in *raw*, verifier framing."""
+    from bernstein.core.security.audit import _split_jsonl_bytes
+
+    records: list[dict[str, Any]] = []
+    for line in _split_jsonl_bytes(raw):
+        if line == b"":
+            continue
+        try:
+            entry = json.loads(line)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        if not isinstance(entry, dict) or "hmac" not in entry:
+            continue
+        if json.dumps(entry, sort_keys=True).encode() != line:
+            continue
+        records.append(cast("dict[str, Any]", entry))
+    return records
+
+
+def compute_origin(audit_dir: Path) -> str | None:
+    """Return the chain origin: the HMAC of the first canonical record.
+
+    ``None`` when the chain holds no canonical record yet.
+    """
+    for _name, raw in _iter_segment_bytes(audit_dir):
+        records = _canonical_records(raw)
+        if records:
+            return str(records[0]["hmac"])
+    return None
+
+
+def count_entries(audit_dir: Path) -> int:
+    """Count canonical records across archived and live segments."""
+    return sum(len(_canonical_records(raw)) for _name, raw in _iter_segment_bytes(audit_dir))
+
+
+def _segment_bytes(audit_dir: Path, file_name: str) -> bytes | None:
+    """Return current bytes for checkpointed segment *file_name*, or ``None``.
+
+    Looks for the live file first, then its archived ``.gz`` counterpart, so a
+    checkpoint taken before retention still validates after it.
+    """
+    from bernstein.core.security.audit import RetentionPolicy, _read_archived_segment
+
+    live = audit_dir / file_name
+    if live.exists():
+        with suppress(OSError):
+            return live.read_bytes()
+    gz = audit_dir / RetentionPolicy().archive_subdir / f"{file_name}.gz"
+    if gz.exists():
+        discard: list[str] = []
+        return _read_archived_segment(gz, discard)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Extension (consistency) check
+# ---------------------------------------------------------------------------
+
+
+def check_extension(audit_dir: Path, checkpoint: dict[str, Any]) -> list[CheckpointConflict]:
+    """Check that the current on-disk chain is a consistent extension of *checkpoint*.
+
+    The equivalent of an RFC 6962 consistency proof for the per-day-segment
+    tree: the checkpointed root must be reproducible from byte prefixes of
+    the current state, and the entry count must not have decreased. Returns
+    an empty list when consistent.
+    """
+    conflicts: list[CheckpointConflict] = []
+
+    origin = compute_origin(audit_dir)
+    pinned_origin = str(checkpoint.get("origin", ""))
+    if origin != pinned_origin:
+        conflicts.append(
+            CheckpointConflict(
+                kind="origin",
+                segment="",
+                offset=0,
+                detail=(
+                    f"chain origin {str(origin)[:16]}... does not match the checkpointed "
+                    f"origin {pinned_origin[:16]}... (history replaced or emptied)"
+                ),
+            )
+        )
+
+    current_count = count_entries(audit_dir)
+    pinned_count = int(checkpoint.get("entry_count", 0) or 0)
+    if current_count < pinned_count:
+        conflicts.append(
+            CheckpointConflict(
+                kind="entry_count",
+                segment="",
+                offset=0,
+                detail=f"chain holds {current_count} records; checkpoint pinned {pinned_count}",
+            )
+        )
+
+    leaves = cast("list[dict[str, Any]]", checkpoint.get("leaves", []))
+    for leaf in leaves:
+        file_name = str(leaf.get("file", ""))
+        byte_len = int(leaf.get("byte_len", 0) or 0)
+        pinned_hash = str(leaf.get("hash", ""))
+        current = _segment_bytes(audit_dir, file_name)
+        if current is None:
+            conflicts.append(
+                CheckpointConflict(
+                    kind="segment_missing",
+                    segment=file_name,
+                    offset=0,
+                    detail="segment pinned by the checkpoint is gone (not live, not archived)",
+                )
+            )
+            continue
+        if len(current) < byte_len:
+            conflicts.append(
+                CheckpointConflict(
+                    kind="segment_shrunk",
+                    segment=file_name,
+                    offset=len(current),
+                    detail=f"segment is {len(current)} bytes; checkpoint pinned the first {byte_len}",
+                )
+            )
+            continue
+        prefix_hash = _leaf_prefix_hash(current[:byte_len])
+        if prefix_hash != pinned_hash:
+            conflicts.append(
+                CheckpointConflict(
+                    kind="segment_prefix_mismatch",
+                    segment=file_name,
+                    offset=byte_len,
+                    detail=f"first {byte_len} bytes no longer reproduce the checkpointed leaf hash",
+                )
+            )
+
+    # Self-integrity: the pinned root must be rebuildable from the pinned
+    # leaves. This cannot fail for a checkpoint this module wrote (the
+    # signature covers both), but a mismatch means the checkpoint content is
+    # internally inconsistent and must not gate anything.
+    if leaves:
+        from bernstein.core.persistence.merkle import build_merkle_tree
+
+        scheme = int(checkpoint.get("scheme", 2) or 2)
+        tree = build_merkle_tree(
+            [(str(leaf.get("file", "")), str(leaf.get("hash", ""))) for leaf in leaves],
+            scheme=scheme,
+        )
+        if tree.root.hash != checkpoint.get("root_hash"):
+            conflicts.append(
+                CheckpointConflict(
+                    kind="root",
+                    segment="",
+                    offset=0,
+                    detail="checkpointed leaves do not rebuild the checkpointed root",
+                )
+            )
+
+    return conflicts
+
+
+def _leaf_prefix_hash(prefix: bytes) -> str:
+    from bernstein.core.persistence.merkle import _leaf_digest
+
+    return _leaf_digest(prefix)
+
+
+# ---------------------------------------------------------------------------
+# Acknowledgement lookup
+# ---------------------------------------------------------------------------
+
+
+def find_divergence_acks(audit_dir: Path, key: bytes, checkpoint_root: str) -> dict[str, dict[str, Any]]:
+    """Return per-segment acknowledgement details naming *checkpoint_root*.
+
+    An acknowledgement is a ``chain.tear_acknowledged`` record whose details
+    carry ``checkpoint_root`` equal to the conflicting checkpoint's root. It
+    is chain-resident, so it is exactly as tamper-evident as the tear it
+    clears, and forging one requires the audit key.
+    """
+    from bernstein.core.security.audit import EVENT_CHAIN_TEAR_ACKNOWLEDGED, AuditLog
+
+    acks: dict[str, dict[str, Any]] = {}
+    log = AuditLog(audit_dir, key=key)
+    for event in log.query(event_type=EVENT_CHAIN_TEAR_ACKNOWLEDGED, include_archived=True):
+        details = event.details or {}
+        if str(details.get(ACK_CHECKPOINT_ROOT_KEY, "")) != checkpoint_root:
+            continue
+        segment = str(details.get("segment", ""))
+        if segment:
+            acks[segment] = {**details, "ack_hmac": event.hmac}
+    return acks
+
+
+def authorize_divergence(
+    conflicts: list[CheckpointConflict],
+    acks: dict[str, dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Return the divergence-ack block when *acks* cover *conflicts*, else ``None``.
+
+    Every per-segment conflict must be acknowledged; ``entry_count`` conflicts
+    are arithmetic consequences of an acknowledged shrink and are subsumed,
+    but only when at least one acknowledged segment conflict explains them.
+    ``origin`` and ``root`` conflicts are never authorised.
+    """
+    segment_conflicts = [c for c in conflicts if c.kind in CheckpointConflict.ACKABLE_KINDS]
+    other = [c for c in conflicts if c.kind not in CheckpointConflict.ACKABLE_KINDS and c.kind != "entry_count"]
+    if other or not segment_conflicts:
+        return None
+    covered: list[dict[str, Any]] = []
+    for conflict in segment_conflicts:
+        ack = acks.get(conflict.segment)
+        if ack is None:
+            return None
+        covered.append(
+            {
+                "segment": conflict.segment,
+                "kind": conflict.kind,
+                "offset": conflict.offset,
+                "ack_hmac": str(ack.get("ack_hmac", "")),
+            }
+        )
+    return {"segments": covered}
+
+
+# ---------------------------------------------------------------------------
+# Advance (append) after a successful seal
+# ---------------------------------------------------------------------------
+
+
+def record_checkpoint(audit_dir: Path, seal: dict[str, Any], *, key: bytes) -> dict[str, Any]:
+    """Append the checkpoint pinning *seal*, re-running the extension gate.
+
+    Idempotent: when the tree is unchanged since the last checkpoint (same
+    origin, entry count, root, and leaves) nothing is appended and the
+    existing checkpoint payload is returned, so repeated seals of an
+    unchanged log keep the checkpoints file byte-stable.
+
+    The gate is re-run here as defense in depth: a caller that skipped
+    :func:`bernstein.core.persistence.merkle.compute_seal`'s gate (or raced a
+    writer between compute and record) still cannot advance the pin over a
+    conflict without a chain-resident acknowledgement.
+
+    Args:
+        audit_dir: The audit directory.
+        seal: The seal dict produced by ``compute_seal`` (must carry
+            ``entry_count`` and per-leaf ``byte_len``).
+        key: Audit HMAC key.
+
+    Returns:
+        The checkpoint payload now pinning the log.
+
+    Raises:
+        CheckpointFileError: When the checkpoints file fails validation.
+        CheckpointConsistencyError: When the seal does not extend the last
+            checkpoint and no acknowledgement authorises the divergence.
+        ValueError: When *seal* lacks the checkpoint-bearing fields.
+    """
+    if "entry_count" not in seal:
+        msg = "seal dict lacks entry_count; compute it with compute_seal()"
+        raise ValueError(msg)
+    leaves_in = cast("list[dict[str, Any]]", seal.get("leaves", []))
+    if any("byte_len" not in leaf for leaf in leaves_in):
+        msg = "seal leaves lack byte_len; compute them with compute_seal()"
+        raise ValueError(msg)
+
+    state = load_checkpoints(audit_dir, key)
+    prev = state.last
+
+    payload: dict[str, Any] = {
+        "version": CHECKPOINT_VERSION,
+        "origin": seal.get("origin", ""),
+        "entry_count": int(cast("int", seal["entry_count"])),
+        "root_hash": str(seal.get("root_hash", "")),
+        "scheme": seal.get("scheme", 2),
+        "leaves": [
+            {
+                "file": str(leaf.get("file", "")),
+                "byte_len": int(leaf.get("byte_len", 0) or 0),
+                "hash": str(leaf.get("hash", "")),
+            }
+            for leaf in leaves_in
+        ],
+        "prev_checkpoint_sha256": GENESIS_PREV,
+        "extends_prev": True,
+    }
+
+    if prev is not None:
+        same = all(payload[k] == prev.get(k) for k in ("origin", "entry_count", "root_hash", "leaves"))
+        if same:
+            return prev
+        conflicts = check_extension(audit_dir, prev)
+        divergence_ack: dict[str, Any] | None = None
+        if conflicts:
+            acks = find_divergence_acks(audit_dir, key, str(prev.get("root_hash", "")))
+            divergence_ack = authorize_divergence(conflicts, acks)
+            if divergence_ack is None:
+                raise CheckpointConsistencyError(prev, conflicts)
+            payload["extends_prev"] = False
+            payload["divergence_ack"] = {
+                ACK_CHECKPOINT_ROOT_KEY: str(prev.get("root_hash", "")),
+                **divergence_ack,
+            }
+        prev_doc = {"payload": prev, "hmac": _sign(prev, key)}
+        payload["prev_checkpoint_sha256"] = _record_sha256(prev_doc)
+
+    doc = {"payload": payload, "hmac": _sign(payload, key)}
+    path = checkpoints_path(audit_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = _canonical(doc) + b"\n"
+    # Append + fsync: the checkpoint is the durable pin that makes a later
+    # shrink detectable, so it must not sit in the page cache when the next
+    # crash of the same class arrives.
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+    try:
+        os.write(fd, line)
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+    return payload
+
+
+__all__ = [
+    "ACK_CHECKPOINT_ROOT_KEY",
+    "CHECKPOINTS_FILE",
+    "CHECKPOINTS_SUBDIR",
+    "CHECKPOINT_VERSION",
+    "CheckpointConflict",
+    "CheckpointConsistencyError",
+    "CheckpointFileError",
+    "CheckpointFileState",
+    "authorize_divergence",
+    "check_extension",
+    "checkpoints_path",
+    "compute_origin",
+    "count_entries",
+    "find_divergence_acks",
+    "load_checkpoints",
+    "record_checkpoint",
+]

--- a/src/bernstein/core/persistence/chain_checkpoint.py
+++ b/src/bernstein/core/persistence/chain_checkpoint.py
@@ -277,8 +277,14 @@ def load_checkpoints(audit_dir: Path, key: bytes) -> CheckpointFileState:
 # ---------------------------------------------------------------------------
 
 
-def _iter_segment_bytes(audit_dir: Path) -> list[tuple[str, bytes]]:
-    """Return ``(file_name, bytes)`` for archived then live segments, in chain order."""
+def chain_snapshot(audit_dir: Path) -> list[tuple[str, bytes]]:
+    """Return ``(file_name, bytes)`` for archived then live segments, in chain order.
+
+    One snapshot serves :func:`compute_origin`, :func:`count_entries`, and
+    :func:`check_extension` through their ``segments`` parameter, so a seal
+    gate reads and decompresses the chain once instead of once per quantity.
+    Archived segments are keyed by their live name (the name checkpoints pin).
+    """
     from bernstein.core.security.audit import (
         _JSONL_GLOB,
         _archived_segment_paths,
@@ -318,21 +324,27 @@ def _canonical_records(raw: bytes) -> list[dict[str, Any]]:
     return records
 
 
-def compute_origin(audit_dir: Path) -> str | None:
+def compute_origin(audit_dir: Path, *, segments: list[tuple[str, bytes]] | None = None) -> str | None:
     """Return the chain origin: the HMAC of the first canonical record.
 
-    ``None`` when the chain holds no canonical record yet.
+    ``None`` when the chain holds no canonical record yet. Pass *segments*
+    (from :func:`chain_snapshot`) to reuse an already-read chain.
     """
-    for _name, raw in _iter_segment_bytes(audit_dir):
+    for _name, raw in segments if segments is not None else chain_snapshot(audit_dir):
         records = _canonical_records(raw)
         if records:
             return str(records[0]["hmac"])
     return None
 
 
-def count_entries(audit_dir: Path) -> int:
-    """Count canonical records across archived and live segments."""
-    return sum(len(_canonical_records(raw)) for _name, raw in _iter_segment_bytes(audit_dir))
+def count_entries(audit_dir: Path, *, segments: list[tuple[str, bytes]] | None = None) -> int:
+    """Count canonical records across archived and live segments.
+
+    Pass *segments* (from :func:`chain_snapshot`) to reuse an already-read
+    chain.
+    """
+    source = segments if segments is not None else chain_snapshot(audit_dir)
+    return sum(len(_canonical_records(raw)) for _name, raw in source)
 
 
 def _segment_bytes(audit_dir: Path, file_name: str) -> bytes | None:
@@ -359,17 +371,28 @@ def _segment_bytes(audit_dir: Path, file_name: str) -> bytes | None:
 # ---------------------------------------------------------------------------
 
 
-def check_extension(audit_dir: Path, checkpoint: dict[str, Any]) -> list[CheckpointConflict]:
+def check_extension(
+    audit_dir: Path,
+    checkpoint: dict[str, Any],
+    *,
+    segments: list[tuple[str, bytes]] | None = None,
+) -> list[CheckpointConflict]:
     """Check that the current on-disk chain is a consistent extension of *checkpoint*.
 
     The equivalent of an RFC 6962 consistency proof for the per-day-segment
     tree: the checkpointed root must be reproducible from byte prefixes of
     the current state, and the entry count must not have decreased. Returns
     an empty list when consistent.
+
+    One :func:`chain_snapshot` read serves the origin, the entry count, and
+    every per-leaf prefix comparison; pass *segments* to reuse a snapshot the
+    caller already holds.
     """
     conflicts: list[CheckpointConflict] = []
+    snapshot = segments if segments is not None else chain_snapshot(audit_dir)
+    by_name: dict[str, bytes] = dict(snapshot)
 
-    origin = compute_origin(audit_dir)
+    origin = compute_origin(audit_dir, segments=snapshot)
     pinned_origin = str(checkpoint.get("origin", ""))
     if origin != pinned_origin:
         conflicts.append(
@@ -384,7 +407,7 @@ def check_extension(audit_dir: Path, checkpoint: dict[str, Any]) -> list[Checkpo
             )
         )
 
-    current_count = count_entries(audit_dir)
+    current_count = count_entries(audit_dir, segments=snapshot)
     pinned_count = int(checkpoint.get("entry_count", 0) or 0)
     if current_count < pinned_count:
         conflicts.append(
@@ -401,7 +424,9 @@ def check_extension(audit_dir: Path, checkpoint: dict[str, Any]) -> list[Checkpo
         file_name = str(leaf.get("file", ""))
         byte_len = int(leaf.get("byte_len", 0) or 0)
         pinned_hash = str(leaf.get("hash", ""))
-        current = _segment_bytes(audit_dir, file_name)
+        current = by_name.get(file_name)
+        if current is None:
+            current = _segment_bytes(audit_dir, file_name)
         if current is None:
             conflicts.append(
                 CheckpointConflict(
@@ -540,6 +565,14 @@ def record_checkpoint(audit_dir: Path, seal: dict[str, Any], *, key: bytes) -> d
     writer between compute and record) still cannot advance the pin over a
     conflict without a chain-resident acknowledgement.
 
+    The whole read-validate-append section runs under the audit chain's
+    cross-process append lock. Two sealers are realistic (the hourly cron job
+    and the orchestrator's shutdown seal); unsynchronised, both would read
+    the same predecessor and append two checkpoints naming it, and the forked
+    linkage would fail :func:`load_checkpoints` forever after. The same lock
+    also orders this section against ``ack-tear``'s acknowledgement append,
+    which is written under it.
+
     Args:
         audit_dir: The audit directory.
         seal: The seal dict produced by ``compute_seal`` (must carry
@@ -563,6 +596,20 @@ def record_checkpoint(audit_dir: Path, seal: dict[str, Any], *, key: bytes) -> d
         msg = "seal leaves lack byte_len; compute them with compute_seal()"
         raise ValueError(msg)
 
+    from bernstein.core.security.audit import _chain_append_lock
+
+    with _chain_append_lock(audit_dir):
+        return _record_checkpoint_locked(audit_dir, seal, leaves_in, key=key)
+
+
+def _record_checkpoint_locked(
+    audit_dir: Path,
+    seal: dict[str, Any],
+    leaves_in: list[dict[str, Any]],
+    *,
+    key: bytes,
+) -> dict[str, Any]:
+    """Body of :func:`record_checkpoint`; caller holds the chain append lock."""
     state = load_checkpoints(audit_dir, key)
     prev = state.last
 
@@ -629,6 +676,7 @@ __all__ = [
     "CheckpointFileError",
     "CheckpointFileState",
     "authorize_divergence",
+    "chain_snapshot",
     "check_extension",
     "checkpoints_path",
     "compute_origin",

--- a/src/bernstein/core/persistence/merkle.py
+++ b/src/bernstein/core/persistence/merkle.py
@@ -254,6 +254,7 @@ def compute_seal(
     verify_chain: bool = True,
     key: bytes | None = None,
     key_path: Path | None = None,
+    checkpoint_gate: bool = True,
 ) -> tuple[MerkleTree, dict[str, object]]:
     """Compute a Merkle seal across all ``*.jsonl`` files in *audit_dir*.
 
@@ -261,15 +262,32 @@ def compute_seal(
     current scheme, so the seal is independent tamper coverage over the
     entire file rather than a restatement of its last stored ``hmac``.
 
-    Before computing the seal the underlying HMAC chain is verified (unless
-    *verify_chain* is ``False``). A broken chain raises
-    :class:`ChainBrokenError` rather than sealing over tampered content -
-    re-sealing must never silently launder a pre-existing tamper into a new
-    root. The chain is verified with the same key the log was written with
-    (*key*/*key_path*, or the canonical resolver when both are omitted).
+    Two prechecks gate the seal, and both exist because a fresh seal is
+    computed from whatever is on disk *now*:
+
+    1. **Checkpoint extension** (unless *checkpoint_gate* is ``False``): the
+       current tree must be a consistent extension of the last signed
+       checkpoint - entry count monotonically non-decreasing, every
+       checkpointed leaf reproducible as a byte prefix of the segment's
+       current content. A chain-intact truncation (a crash that cut the
+       newest segment back to a record boundary) passes an HMAC walk, so
+       without this gate the next scheduled seal would adopt the shrunk
+       history and verification would go green with no operator involved.
+       A conflict raises :class:`~bernstein.core.persistence.chain_checkpoint.CheckpointConsistencyError`
+       naming the checkpoint, permanently, until acknowledged via
+       ``bernstein audit ack-tear``.
+    2. **Chain verification** (unless *verify_chain* is ``False``): a broken
+       chain raises :class:`ChainBrokenError`, and unacknowledged tear
+       evidence raises :class:`~bernstein.core.security.audit.OutstandingTearError`,
+       rather than sealing over damage. The chain is verified with the same
+       key the log was written with (*key*/*key_path*, or the canonical
+       resolver when both are omitted).
 
     Returns ``(tree, seal_dict)`` where *seal_dict* is JSON-serializable
-    metadata ready to be written to disk.
+    metadata ready to be written to disk. The seal additionally carries
+    ``origin``, ``entry_count``, and per-leaf ``byte_len`` captured at hash
+    time, which :func:`~bernstein.core.persistence.chain_checkpoint.record_checkpoint`
+    pins after the seal is saved.
 
     Args:
         audit_dir: Directory holding the daily ``*.jsonl`` log files.
@@ -278,12 +296,21 @@ def compute_seal(
         key: Raw HMAC key used to verify the chain. Defaults to the
             canonical resolver (the same default the writer uses).
         key_path: Optional explicit key-file path for chain verification.
+        checkpoint_gate: When ``True`` (default) the seal refuses unless the
+            tree consistently extends the last checkpoint.
 
     Raises:
         FileNotFoundError: If the audit directory does not exist.
         ValueError: If no log files are found.
         ChainBrokenError: If *verify_chain* is set and the HMAC chain does
             not verify.
+        bernstein.core.security.audit.OutstandingTearError: If *verify_chain*
+            is set and unacknowledged tear evidence is outstanding.
+        bernstein.core.persistence.chain_checkpoint.CheckpointFileError: If
+            *checkpoint_gate* is set and the checkpoints file fails validation.
+        bernstein.core.persistence.chain_checkpoint.CheckpointConsistencyError:
+            If *checkpoint_gate* is set and the tree does not extend the last
+            checkpoint (and no chain-resident acknowledgement authorises it).
     """
     if not audit_dir.is_dir():
         msg = f"Audit directory does not exist: {audit_dir}"
@@ -294,40 +321,91 @@ def compute_seal(
         msg = f"No audit log files (*.jsonl) found in {audit_dir}"
         raise ValueError(msg)
 
-    if verify_chain:
-        chain_ok, chain_errors = _verify_hmac_chain(audit_dir, key=key, key_path=key_path)
-        if not chain_ok:
-            raise ChainBrokenError(chain_errors)
+    resolved_key = _resolve_key(key, key_path) if (verify_chain or checkpoint_gate) else None
 
-    leaf_hashes = [(f.name, file_leaf_hash(f)) for f in log_files]
+    if checkpoint_gate and resolved_key is not None:
+        _enforce_checkpoint_extension(audit_dir, resolved_key)
+
+    if verify_chain:
+        _enforce_chain_verifies(audit_dir, key=key, key_path=key_path)
+
+    # Read each file exactly once and record its byte length alongside the
+    # leaf hash: the checkpoint pins (file, byte_len, hash) and the
+    # prefix-consistency gate later recomputes the leaf over the first
+    # ``byte_len`` bytes, so length and hash must describe the same bytes.
+    leaf_entries: list[tuple[str, int, str]] = []
+    for f in log_files:
+        content = f.read_bytes()
+        leaf_entries.append((f.name, len(content), _leaf_digest(content)))
+    leaf_hashes = [(name, digest) for name, _length, digest in leaf_entries]
     tree = build_merkle_tree(leaf_hashes)
+
+    from bernstein.core.persistence.chain_checkpoint import compute_origin, count_entries
 
     seal: dict[str, object] = {
         "root_hash": tree.root.hash,
         "algorithm": _HASH_ALGO,
         "scheme": SEAL_SCHEME_VERSION,
         "leaf_count": tree.leaf_count,
-        "leaves": [{"file": name, "hash": h} for name, h in leaf_hashes],
+        "leaves": [{"file": name, "hash": digest, "byte_len": length} for name, length, digest in leaf_entries],
+        "origin": compute_origin(audit_dir) or "",
+        "entry_count": count_entries(audit_dir),
         "sealed_at": time.time(),
         "sealed_at_iso": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
     }
     return tree, seal
 
 
-def _verify_hmac_chain(
+def _resolve_key(key: bytes | None, key_path: Path | None) -> bytes:
+    """Resolve the audit key exactly as the writer does."""
+    if key is not None:
+        return key
+    from bernstein.core.security.audit import load_or_create_audit_key
+
+    return load_or_create_audit_key(key_path)
+
+
+def _enforce_checkpoint_extension(audit_dir: Path, key: bytes) -> None:
+    """Refuse unless the current tree consistently extends the last checkpoint."""
+    from bernstein.core.persistence.chain_checkpoint import (
+        CheckpointConsistencyError,
+        authorize_divergence,
+        check_extension,
+        find_divergence_acks,
+        load_checkpoints,
+    )
+
+    state = load_checkpoints(audit_dir, key)
+    prev = state.last
+    if prev is None:
+        return
+    conflicts = check_extension(audit_dir, prev)
+    if not conflicts:
+        return
+    acks = find_divergence_acks(audit_dir, key, str(prev.get("root_hash", "")))
+    if authorize_divergence(conflicts, acks) is None:
+        raise CheckpointConsistencyError(prev, conflicts)
+
+
+def _enforce_chain_verifies(
     audit_dir: Path,
     *,
     key: bytes | None = None,
     key_path: Path | None = None,
-) -> tuple[bool, list[str]]:
-    """Verify the HMAC chain under *audit_dir*; return ``(ok, errors)``.
+) -> None:
+    """Raise unless the chain verifies and carries no unacknowledged tears.
 
     Imported lazily so the Merkle module stays importable without the full
     audit subsystem (and to avoid a circular import at module load).
     """
-    from bernstein.core.security.audit import AuditLog
+    from bernstein.core.security.audit import AuditLog, OutstandingTearError
 
-    return AuditLog(audit_dir, key=key, key_path=key_path).verify()
+    report = AuditLog(audit_dir, key=key, key_path=key_path).verify_detailed()
+    if report.hard_errors:
+        raise ChainBrokenError(report.hard_errors)
+    outstanding = report.unacknowledged_tears
+    if outstanding:
+        raise OutstandingTearError(outstanding)
 
 
 def save_seal(seal: dict[str, object], merkle_dir: Path) -> Path:

--- a/src/bernstein/core/persistence/merkle.py
+++ b/src/bernstein/core/persistence/merkle.py
@@ -321,10 +321,8 @@ def compute_seal(
         msg = f"No audit log files (*.jsonl) found in {audit_dir}"
         raise ValueError(msg)
 
-    resolved_key = _resolve_key(key, key_path) if (verify_chain or checkpoint_gate) else None
-
-    if checkpoint_gate and resolved_key is not None:
-        _enforce_checkpoint_extension(audit_dir, resolved_key)
+    if checkpoint_gate:
+        _enforce_checkpoint_extension(audit_dir, _resolve_key(key, key_path))
 
     if verify_chain:
         _enforce_chain_verifies(audit_dir, key=key, key_path=key_path)
@@ -340,16 +338,17 @@ def compute_seal(
     leaf_hashes = [(name, digest) for name, _length, digest in leaf_entries]
     tree = build_merkle_tree(leaf_hashes)
 
-    from bernstein.core.persistence.chain_checkpoint import compute_origin, count_entries
+    from bernstein.core.persistence.chain_checkpoint import chain_snapshot, compute_origin, count_entries
 
+    snapshot = chain_snapshot(audit_dir)
     seal: dict[str, object] = {
         "root_hash": tree.root.hash,
         "algorithm": _HASH_ALGO,
         "scheme": SEAL_SCHEME_VERSION,
         "leaf_count": tree.leaf_count,
         "leaves": [{"file": name, "hash": digest, "byte_len": length} for name, length, digest in leaf_entries],
-        "origin": compute_origin(audit_dir) or "",
-        "entry_count": count_entries(audit_dir),
+        "origin": compute_origin(audit_dir, segments=snapshot) or "",
+        "entry_count": count_entries(audit_dir, segments=snapshot),
         "sealed_at": time.time(),
         "sealed_at_iso": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
     }

--- a/src/bernstein/core/security/audit.py
+++ b/src/bernstein/core/security/audit.py
@@ -122,6 +122,22 @@ SANDBOX_SESSION_DESTROY = "sandbox.session_destroy"
 #: first-class decision instead of leaving it in a single log WARNING.
 SANDBOX_ISOLATION_DOWNGRADE = "sandbox.isolation_downgrade"
 
+#: Emitted when an append finds the newest segment ending in a non-verifying
+#: suffix (a crash-torn partial line, bytes that fail their HMAC, or garbage
+#: that is not valid UTF-8/JSON) and seals it: the terminator and this record
+#: land in one write, so the evidence that a record was damaged cannot be
+#: separated from the repair. Details carry ``segment``, ``byte_offset`` (the
+#: segment size at seal time), ``verified_prefix_offset`` (the end of the last
+#: verifiable record), ``torn_bytes_sha256``, and ``tear_class``.
+EVENT_CHAIN_TORN_RECORD = "chain.torn_record"
+
+#: Emitted by ``bernstein audit ack-tear`` when an operator signs off on tear
+#: evidence. Appended to the chain itself, so clearing an alert is exactly as
+#: tamper-evident as the damage was. Details carry ``segment`` and
+#: ``byte_offset`` matching the tear, plus ``checkpoint_root`` when the
+#: acknowledgement authorises sealing past a conflicting chain checkpoint.
+EVENT_CHAIN_TEAR_ACKNOWLEDGED = "chain.tear_acknowledged"
+
 
 class AuditKeyPermissionError(RuntimeError):
     """Raised when the audit key file has permissions looser than 0600."""
@@ -461,12 +477,55 @@ def _split_jsonl_bytes(raw_bytes: bytes) -> list[bytes]:
     return parts
 
 
+@dataclass(frozen=True)
+class _LineFinding:
+    """One non-verifying line, with enough position data to classify it later."""
+
+    display_name: str
+    line_no: int
+    offset: int
+    length: int
+    kind: str
+    messages: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _ChainMarker:
+    """A verified tear-evidence record (``chain.torn_record`` / acknowledgement)."""
+
+    display_name: str
+    line_no: int
+    offset: int
+    event_type: str
+    details: dict[str, Any]
+    hmac: str
+
+
+@dataclass
+class _ChainWalkContext:
+    """Structured observations collected while :func:`_verify_log_bytes` walks.
+
+    Purely additive: when no context is passed the walker behaves exactly as
+    before. With one, tear-aware callers learn where each failure sits, where
+    the last verifying record of each segment ends, and which verified records
+    are tear evidence or acknowledgements - without a second pass.
+    """
+
+    failures: list[_LineFinding] = field(default_factory=list)
+    markers: list[_ChainMarker] = field(default_factory=list)
+    ok_end: dict[str, int] = field(default_factory=dict)
+    total: dict[str, int] = field(default_factory=dict)
+    missing_newline: dict[str, str] = field(default_factory=dict)
+    order: list[str] = field(default_factory=list)
+
+
 def _verify_log_bytes(
     raw_bytes: bytes,
     display_name: str,
     prev_hmac: str,
     key: bytes,
     errors: list[str],
+    ctx: _ChainWalkContext | None = None,
 ) -> str:
     """Verify the JSONL entries in ``raw_bytes``, appending errors.
 
@@ -477,13 +536,36 @@ def _verify_log_bytes(
     canonicalisation, ``prev_hmac`` linkage, and HMAC checks, so archived
     history stays exactly as tamper-evident as live history (issue #1835).
     """
+    if ctx is not None:
+        if display_name not in ctx.order:
+            ctx.order.append(display_name)
+        ctx.total[display_name] = ctx.total.get(display_name, 0) + len(raw_bytes)
+        ctx.ok_end.setdefault(display_name, 0)
+
     if raw_bytes and not raw_bytes.endswith(b"\n"):
         # The writer always terminates with ``\n``; absence is itself
         # tamper-evidence (e.g. ``\n`` flipped to ``\v`` at EOF). Continue
         # into the per-line loop so a truncated last record is still
         # surfaced as ``invalid JSON`` for callers that key on that
         # message (test_partial_last_line_flagged_as_invalid_json).
-        errors.append(f"{display_name}: missing trailing newline")
+        message = f"{display_name}: missing trailing newline"
+        errors.append(message)
+        if ctx is not None:
+            ctx.missing_newline[display_name] = message
+
+    def _fail(line_no: int, offset: int, length: int, kind: str, messages: tuple[str, ...]) -> None:
+        errors.extend(messages)
+        if ctx is not None:
+            ctx.failures.append(
+                _LineFinding(
+                    display_name=display_name,
+                    line_no=line_no,
+                    offset=offset,
+                    length=length,
+                    kind=kind,
+                    messages=messages,
+                )
+            )
 
     # ``_split_jsonl_bytes`` splits on ``b"\n"`` only, so the start offset of
     # each line inside the segment is the running sum of prior line lengths
@@ -506,13 +588,31 @@ def _verify_log_bytes(
             # taking the whole audit surface down. Undecodable bytes are
             # exactly what an operator runs ``verify`` to learn about, so this
             # is a loud failure, never a warning or a skipped segment.
-            errors.append(f"{display_name}:{line_no}: undecodable bytes at offset {line_offset + exc.start} - {exc}")
+            _fail(
+                line_no,
+                line_offset,
+                len(raw_line),
+                "undecodable",
+                (f"{display_name}:{line_no}: undecodable bytes at offset {line_offset + exc.start} - {exc}",),
+            )
             continue
         except json.JSONDecodeError as exc:
-            errors.append(f"{display_name}:{line_no}: invalid JSON - {exc}")
+            _fail(
+                line_no,
+                line_offset,
+                len(raw_line),
+                "invalid_json",
+                (f"{display_name}:{line_no}: invalid JSON - {exc}",),
+            )
             continue
         if not isinstance(parsed_entry, dict):
-            errors.append(f"{display_name}:{line_no}: entry is not a JSON object")
+            _fail(
+                line_no,
+                line_offset,
+                len(raw_line),
+                "not_object",
+                (f"{display_name}:{line_no}: entry is not a JSON object",),
+            )
             continue
         entry = cast("dict[str, Any]", parsed_entry)
 
@@ -524,25 +624,53 @@ def _verify_log_bytes(
         # surfaced as a verification failure.
         canonical = json.dumps(entry, sort_keys=True).encode()
         if canonical != raw_line:
-            errors.append(f"{display_name}:{line_no}: non-canonical line bytes")
+            _fail(
+                line_no,
+                line_offset,
+                len(raw_line),
+                "non_canonical",
+                (f"{display_name}:{line_no}: non-canonical line bytes",),
+            )
             continue
 
         stored_hmac = str(entry.pop("hmac", ""))
         entry_prev = str(entry.get("prev_hmac", ""))
+        line_messages: list[str] = []
         # Constant-time compare on the chain link - verification is offline
         # but a leaky compare in audit code is a CodeQL/Bandit smell and
         # masks regressions when the same helper is later reused on a
         # network surface.
         if not _hmac.compare_digest(entry_prev, prev_hmac):
-            errors.append(
+            line_messages.append(
                 f"{display_name}:{line_no}: prev_hmac mismatch (expected {prev_hmac[:16]}…, got {entry_prev[:16]}…)"
             )
 
         expected_hmac = _compute_hmac(key, prev_hmac, entry)
         if not _hmac.compare_digest(stored_hmac, expected_hmac):
-            errors.append(
+            line_messages.append(
                 f"{display_name}:{line_no}: HMAC mismatch (expected {expected_hmac[:16]}…, got {stored_hmac[:16]}…)"
             )
+
+        if line_messages:
+            _fail(line_no, line_offset, len(raw_line), "invalid_hmac", tuple(line_messages))
+        elif ctx is not None:
+            line_end = line_offset + len(raw_line)
+            if line_end < len(raw_bytes):
+                line_end += 1  # the terminator this line owns
+            ctx.ok_end[display_name] = ctx.total.get(display_name, 0) - len(raw_bytes) + line_end
+            event_type = str(entry.get("event_type", ""))
+            if event_type in (EVENT_CHAIN_TORN_RECORD, EVENT_CHAIN_TEAR_ACKNOWLEDGED):
+                details = entry.get("details")
+                ctx.markers.append(
+                    _ChainMarker(
+                        display_name=display_name,
+                        line_no=line_no,
+                        offset=line_offset,
+                        event_type=event_type,
+                        details=dict(details) if isinstance(details, dict) else {},
+                        hmac=stored_hmac,
+                    )
+                )
 
         prev_hmac = stored_hmac
     return prev_hmac
@@ -573,7 +701,22 @@ def _read_archived_segment(gz_path: Path, errors: list[str]) -> bytes | None:
         return None
 
 
-def _chain_tail_from_bytes(raw_bytes: bytes) -> str | None:
+def _record_is_locally_valid(key: bytes, entry: dict[str, Any]) -> bool:
+    """Whether *entry*'s stored ``hmac`` matches its own stated ``prev_hmac``.
+
+    A *local* check: it authenticates the record against the predecessor the
+    record itself names, without walking the chain. Crash garbage that happens
+    to parse as a canonical ``hmac``-bearing object still fails it, because
+    producing a matching MAC requires the audit key. It deliberately does not
+    prove the stated predecessor is the true chain head - that is ``verify``'s
+    job - only that the record was minted by a key holder.
+    """
+    body = {k: v for k, v in entry.items() if k != "hmac"}
+    expected = _compute_hmac(key, str(entry.get("prev_hmac", "")), body)
+    return _hmac.compare_digest(str(entry.get("hmac", "")), expected)
+
+
+def _chain_tail_from_bytes(raw_bytes: bytes, key: bytes | None = None) -> str | None:
     """Return the last ``hmac`` in ``raw_bytes`` (scanning in reverse), or None.
 
     Shared by live-file and archived-segment chain recovery so both resolve
@@ -599,6 +742,14 @@ def _chain_tail_from_bytes(raw_bytes: bytes) -> str | None:
     case working: a truncated final line (writer crash mid-write, no trailing
     ``\\n``) is skipped and recovery resumes from the last well-formed record,
     exactly as the legitimate truncation path does today.
+
+    When *key* is provided the candidate must additionally pass
+    :func:`_record_is_locally_valid`: crash-torn tails are arbitrary bytes, not
+    clean prefixes, and a garbage tail can parse as a canonical ``hmac``-bearing
+    object by accident. Without the MAC check recovery would adopt such a line
+    as the head and every later append would chain onto bytes no key holder
+    wrote. ``AuditLog`` always passes its key; the keyless form is kept for
+    read-only callers that only need a best-effort tip.
     """
     for raw_line in reversed(_split_jsonl_bytes(raw_bytes)):
         if raw_line == b"":
@@ -620,9 +771,308 @@ def _chain_tail_from_bytes(raw_bytes: bytes) -> str | None:
         # and is skipped rather than adopted as the tail.
         if json.dumps(entry, sort_keys=True).encode() != raw_line:
             continue
-        if "hmac" in entry:
-            return str(entry["hmac"])
+        if "hmac" not in entry:
+            continue
+        if key is not None and not _record_is_locally_valid(key, entry):
+            continue
+        return str(entry["hmac"])
     return None
+
+
+def _local_tail_state(raw: bytes, key: bytes) -> tuple[int, str | None]:
+    """Return ``(verified_prefix_end, head_hmac)`` for one segment's bytes.
+
+    Walks forward under the verifier's framing and keeps extending the prefix
+    while lines are canonical, ``hmac``-bearing, and locally MAC-valid (see
+    :func:`_record_is_locally_valid`). The returned offset is the byte after
+    the last such record (including its terminator when present), i.e. where
+    a non-verifying suffix begins; the head is that record's ``hmac``, or
+    ``None`` when the segment holds no locally valid record.
+    """
+    offset = 0
+    end_ok = 0
+    head: str | None = None
+    for raw_line in _split_jsonl_bytes(raw):
+        line_start = offset
+        offset += len(raw_line) + 1
+        if raw_line == b"":
+            continue
+        try:
+            parsed = json.loads(raw_line)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        if not isinstance(parsed, dict):
+            continue
+        entry = cast("dict[str, Any]", parsed)
+        if json.dumps(entry, sort_keys=True).encode() != raw_line:
+            continue
+        if "hmac" not in entry or not _record_is_locally_valid(key, entry):
+            continue
+        line_end = line_start + len(raw_line)
+        if line_end < len(raw):
+            line_end += 1  # the terminator this line owns
+        end_ok = line_end
+        head = str(entry["hmac"])
+    return end_ok, head
+
+
+def _classify_torn_bytes(torn: bytes) -> str:
+    """Classify a non-verifying tail per the crash-tear model.
+
+    Crashed appends can leave arbitrary bytes, not just a clean prefix of the
+    record, so every shape is named rather than assumed:
+
+    * ``unterminated_record`` - the suffix is empty: the final record itself
+      is valid and only its terminator was lost.
+    * ``garbage_bytes`` - bytes that are not valid UTF-8, or damage spanning
+      several apparent lines.
+    * ``invalid_hmac`` - a single line that parses as a canonical
+      ``hmac``-bearing object but fails its MAC (crash garbage can look like
+      JSON; only a key holder can produce a matching MAC).
+    * ``non_canonical`` - parses as JSON but is not the writer's byte framing.
+    * ``partial_record`` - a single line that does not parse: the classic
+      crash-mid-write fragment.
+    """
+    if not torn:
+        return "unterminated_record"
+    try:
+        torn.decode("utf-8")
+    except UnicodeDecodeError:
+        return "garbage_bytes"
+    fragments = [line for line in torn.split(b"\n") if line != b""]
+    if len(fragments) != 1:
+        return "garbage_bytes"
+    try:
+        parsed = json.loads(fragments[0])
+    except json.JSONDecodeError:
+        return "partial_record"
+    if not isinstance(parsed, dict) or json.dumps(parsed, sort_keys=True).encode() != fragments[0]:
+        return "non_canonical"
+    return "invalid_hmac" if "hmac" in parsed else "non_canonical"
+
+
+@dataclass(frozen=True)
+class TearEvidence:
+    """Durable evidence that a segment carried a non-verifying suffix.
+
+    Reported by :meth:`AuditLog.verify_detailed` as a verdict distinct from
+    chain corruption: a tear is crash-shaped damage at the tail (or its sealed
+    remains), stays reported until an operator acknowledges it with
+    ``bernstein audit ack-tear``, and never clears itself.
+
+    Attributes:
+        segment: Live segment file name the tear sits in.
+        byte_offset: Segment size when the tear was observed or sealed; the
+            offset an acknowledgement must name.
+        verified_prefix_offset: End of the last verifiable record before the
+            damage.
+        tear_class: See :func:`_classify_torn_bytes`.
+        sealed: Whether an :data:`EVENT_CHAIN_TORN_RECORD` record already
+            anchors the evidence in the chain.
+        acknowledged: Whether a matching acknowledgement record exists.
+        raw_errors: The verifier messages this evidence subsumes.
+    """
+
+    segment: str
+    byte_offset: int
+    verified_prefix_offset: int
+    tear_class: str
+    sealed: bool
+    acknowledged: bool
+    raw_errors: tuple[str, ...] = ()
+
+    def describe(self) -> str:
+        state = "sealed" if self.sealed else "unsealed"
+        ack = "acknowledged" if self.acknowledged else "UNACKNOWLEDGED"
+        return (
+            f"{self.segment}: {self.tear_class} tear at byte {self.byte_offset} "
+            f"(verifiable prefix ends at {self.verified_prefix_offset}; {state}, {ack})"
+        )
+
+
+@dataclass
+class ChainVerifyReport:
+    """Outcome of :meth:`AuditLog.verify_detailed`.
+
+    ``hard_errors`` are chain damage that is *not* tear-shaped (mid-history
+    tampering, broken linkage with verified records after it); ``tears`` are
+    crash-shaped tail damage, each durable until acknowledged.
+    """
+
+    hard_errors: list[str] = field(default_factory=list)
+    tears: list[TearEvidence] = field(default_factory=list)
+
+    @property
+    def unacknowledged_tears(self) -> list[TearEvidence]:
+        return [tear for tear in self.tears if not tear.acknowledged]
+
+    @property
+    def ok(self) -> bool:
+        return not self.hard_errors and not self.unacknowledged_tears
+
+
+class OutstandingTearError(RuntimeError):
+    """Raised when an operation refuses to proceed over unacknowledged tears.
+
+    Sealing over unacknowledged tear evidence would fold the damage into a
+    fresh root and stop it being reportable; the seal refuses instead, until
+    an operator acknowledges via ``bernstein audit ack-tear``.
+    """
+
+    def __init__(self, tears: list[TearEvidence]) -> None:
+        self.tears = tears
+        head = "; ".join(t.describe() for t in tears[:3])
+        super().__init__(f"Audit chain carries unacknowledged tear evidence; refusing to proceed: {head}")
+
+
+def _live_segment_name(display_name: str) -> str:
+    """Map an archived display name back to the live segment name."""
+    return display_name[: -len(".gz")] if display_name.endswith(".gz") else display_name
+
+
+def _build_verify_report(errors: list[str], ctx: _ChainWalkContext) -> ChainVerifyReport:
+    """Fold walk observations into hard errors plus classified tear evidence."""
+    claimed: set[int] = set()
+    claimed_messages: set[str] = set()
+    tears: list[TearEvidence] = []
+    seen_tears: set[tuple[str, int]] = set()
+
+    # Sealed tears: a verified torn-record marker vouches for the exact
+    # non-verifying span it recorded, in its own segment only. Anything a
+    # marker does not cover stays a hard error.
+    for marker in ctx.markers:
+        if marker.event_type != EVENT_CHAIN_TORN_RECORD:
+            continue
+        segment = _live_segment_name(marker.display_name)
+        if str(marker.details.get("segment", "")) != segment:
+            continue
+        byte_offset = int(marker.details.get("byte_offset", 0) or 0)
+        prefix_end = int(marker.details.get("verified_prefix_offset", byte_offset) or 0)
+        if (segment, byte_offset) in seen_tears:
+            continue
+        seen_tears.add((segment, byte_offset))
+        run_messages: list[str] = []
+        for index, failure in enumerate(ctx.failures):
+            if index in claimed or failure.display_name != marker.display_name:
+                continue
+            if prefix_end <= failure.offset < byte_offset:
+                claimed.add(index)
+                run_messages.extend(failure.messages)
+        claimed_messages.update(run_messages)
+        tears.append(
+            TearEvidence(
+                segment=segment,
+                byte_offset=byte_offset,
+                verified_prefix_offset=prefix_end,
+                tear_class=str(marker.details.get("tear_class", "unknown")),
+                sealed=True,
+                acknowledged=False,
+                raw_errors=tuple(run_messages),
+            )
+        )
+
+    # Unsealed tail tear: every non-verifying line after the last verifying
+    # record of the chain's final segment, extending to end of file. Damage
+    # with verified records after it is not a tail and stays hard.
+    if ctx.order:
+        final = ctx.order[-1]
+        ok_end = ctx.ok_end.get(final, 0)
+        tail_indices = [
+            index
+            for index, failure in enumerate(ctx.failures)
+            if index not in claimed and failure.display_name == final and failure.offset >= ok_end
+        ]
+        newline_message = ctx.missing_newline.get(final)
+        if tail_indices:
+            run_messages = []
+            if newline_message is not None:
+                run_messages.append(newline_message)
+                claimed_messages.add(newline_message)
+            kinds: list[str] = []
+            for index in tail_indices:
+                claimed.add(index)
+                run_messages.extend(ctx.failures[index].messages)
+                kinds.append(ctx.failures[index].kind)
+            claimed_messages.update(run_messages)
+            segment = _live_segment_name(final)
+            key = (segment, ctx.total.get(final, 0))
+            if key not in seen_tears:
+                seen_tears.add(key)
+                tears.append(
+                    TearEvidence(
+                        segment=segment,
+                        byte_offset=ctx.total.get(final, 0),
+                        verified_prefix_offset=ok_end,
+                        tear_class=_tail_tear_class(kinds, unterminated=newline_message is not None),
+                        sealed=False,
+                        acknowledged=False,
+                        raw_errors=tuple(run_messages),
+                    )
+                )
+        elif newline_message is not None:
+            # The final fragment is a fully valid record that lost only its
+            # terminator: nothing failed, but the tail is still torn and the
+            # next append must seal it.
+            claimed_messages.add(newline_message)
+            segment = _live_segment_name(final)
+            total = ctx.total.get(final, 0)
+            if (segment, total) not in seen_tears:
+                tears.append(
+                    TearEvidence(
+                        segment=segment,
+                        byte_offset=total,
+                        verified_prefix_offset=total,
+                        tear_class="unterminated_record",
+                        sealed=False,
+                        acknowledged=False,
+                        raw_errors=(newline_message,),
+                    )
+                )
+
+    # Acknowledgements are verified chain records matched by exact
+    # (segment, byte_offset); an operator must name the tear as verify
+    # printed it.
+    acked: set[tuple[str, int]] = set()
+    for marker in ctx.markers:
+        if marker.event_type != EVENT_CHAIN_TEAR_ACKNOWLEDGED:
+            continue
+        acked.add(
+            (
+                str(marker.details.get("segment", "")),
+                int(marker.details.get("byte_offset", 0) or 0),
+            )
+        )
+    tears = [
+        TearEvidence(
+            segment=tear.segment,
+            byte_offset=tear.byte_offset,
+            verified_prefix_offset=tear.verified_prefix_offset,
+            tear_class=tear.tear_class,
+            sealed=tear.sealed,
+            acknowledged=(tear.segment, tear.byte_offset) in acked,
+            raw_errors=tear.raw_errors,
+        )
+        for tear in tears
+    ]
+
+    hard_errors = [message for message in errors if message not in claimed_messages]
+    return ChainVerifyReport(hard_errors=hard_errors, tears=tears)
+
+
+def _tail_tear_class(kinds: list[str], *, unterminated: bool) -> str:
+    """Name the damage class of an unsealed tail run from its failure kinds."""
+    if "undecodable" in kinds:
+        return "garbage_bytes"
+    if len(kinds) != 1:
+        return "garbage_bytes"
+    kind = kinds[0]
+    if kind == "invalid_json":
+        return "partial_record" if unterminated else "garbage_bytes"
+    if kind == "invalid_hmac":
+        return "invalid_hmac"
+    if kind in ("non_canonical", "not_object"):
+        return "non_canonical"
+    return "garbage_bytes"
 
 
 @dataclass
@@ -757,6 +1207,34 @@ def _row_to_event(row: dict[str, Any]) -> AuditEvent:
         prev_hmac=row.get("prev_hmac", ""),
         hmac=row.get("hmac", ""),
     )
+
+
+def _decode_segment_text(raw: bytes) -> str:
+    """Decode segment bytes for record projection, skipping undecodable lines.
+
+    Strict per-line decoding: a line that is not valid UTF-8 cannot be a
+    canonical record, is dropped whole, and is never smoothed over with
+    replacement characters - so a projected record is always byte-exact
+    against what the verifier hashed, and a tampered or crash-damaged line is
+    never *returned* in laundered form, only omitted. Loudness stays with
+    ``verify``/``verify_detailed``, which name the undecodable bytes and keep
+    failing until the damage is acknowledged.
+
+    This keeps every read surface total over a chain that legitimately
+    carries sealed tear evidence: torn bytes are permanent (the log is
+    append-only and a seal never truncates), so a whole-blob strict decode
+    would turn one acknowledged crash into a forever-raising query path.
+    """
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError:
+        decoded: list[str] = []
+        for line in raw.split(b"\n"):
+            try:
+                decoded.append(line.decode("utf-8"))
+            except UnicodeDecodeError:
+                continue
+        return "\n".join(decoded)
 
 
 def _events_from_text(
@@ -923,7 +1401,7 @@ class AuditLog:
         """
         live_files = sorted(self._audit_dir.glob(_JSONL_GLOB), reverse=True)
         for log_path in live_files:
-            tip = _chain_tail_from_bytes(log_path.read_bytes())
+            tip = _chain_tail_from_bytes(log_path.read_bytes(), self._key)
             if tip is not None:
                 return tip
 
@@ -937,7 +1415,7 @@ class AuditLog:
                 # A corrupt archived segment cannot yield a trustworthy tip;
                 # skip it and keep looking at older segments.
                 continue
-            tip = _chain_tail_from_bytes(raw)
+            tip = _chain_tail_from_bytes(raw, self._key)
             if tip is not None:
                 return tip
         return _GENESIS_HMAC
@@ -988,22 +1466,175 @@ class AuditLog:
                 "resync_head() must be called inside append_transaction(); "
                 "use AuditChainStore.prev_chain_digest to observe the head without appending"
             )
-        # Shares ``log``'s (path, size) fast path, in both directions. Reading it:
-        # when the day file is byte-length-identical to what our own last append
-        # or resync left it at, nothing has been appended since and the cached
-        # head still stands, so nesting two resyncs inside one section costs one
-        # scan rather than two. Writing it: an append later in the same section
-        # skips its own scan. The day file is re-derived rather than assumed, so a
-        # clock rollover between here and the append shows up as a path mismatch
-        # and re-syncs. An append only ever grows the file, so a changed tail
-        # cannot hide behind an unchanged size.
+        # Shares ``log``'s (path, size) fast path, in both directions (see
+        # ``_sync_for_append``). The day file is re-derived rather than
+        # assumed, so a clock rollover between here and the append shows up as
+        # a path mismatch and re-syncs. Any torn tail is sealed before the head
+        # is read, so the value returned is the head the next append actually
+        # chains onto rather than the one that preceded the seal - a caller
+        # that embeds this head into a signed payload must never publish a
+        # chain position its own record will not occupy.
         day_path = self._audit_dir / f"{datetime.now(tz=UTC).strftime('%Y-%m-%d')}.jsonl"
-        day_size = _path_size(day_path)
-        if day_path != self._synced_path or day_size != self._synced_size:
-            self._prev_hmac = self._recover_chain_tail()
-            self._synced_path = day_path
-            self._synced_size = day_size
+        self._sync_for_append(day_path)
         return self._prev_hmac
+
+    def _sync_for_append(self, log_path: Path) -> None:
+        """Bring the cached chain head in line with *log_path* before appending.
+
+        Order matters: a torn tail is sealed *first*, and only then is the
+        head read, because sealing appends its own evidence record and
+        therefore moves the head. Reading first would publish a head the next
+        append does not chain onto.
+
+        Fast path: when the day file is byte-length-identical to what this
+        instance's own last append left it at, no other writer has touched it,
+        our own append always ends in ``b"\\n"`` so the tail cannot be torn,
+        and both the tear probe and the full rescan are skipped. The probe
+        must stay behind this branch: unconditionally it is a stat + open +
+        seek + read on every append, which is a measurable fraction of append
+        throughput.
+
+        The slow path records what it synced, so a nested append inside the
+        same ``append_transaction`` section takes the fast path instead of
+        re-scanning the segment it just scanned. The caller must hold the
+        chain append lock.
+        """
+        size = _path_size(log_path)
+        if log_path == self._synced_path and size == self._synced_size:
+            return
+        if self._seal_torn_tail(log_path):
+            # Sealing appended its own record and left the head and the sync
+            # markers current; re-reading would only re-derive what it wrote.
+            return
+        self._prev_hmac = self._recover_chain_tail()
+        self._synced_path = log_path
+        self._synced_size = _path_size(log_path)
+
+    def _mint_record(
+        self,
+        *,
+        ts: str,
+        event_type: str,
+        actor: str,
+        resource_type: str,
+        resource_id: str,
+        details: dict[str, Any],
+    ) -> tuple[AuditEvent, str]:
+        """Build one record against the cached head; return it with its wire line.
+
+        Minting and writing are separate so the tear seal can put a record and
+        the terminator that precedes it into one ``write``. The returned line
+        is the canonical serialisation including its terminator, so every
+        writer emits byte-identical framing. Does not advance the head; the
+        caller does that once the bytes are on disk.
+        """
+        entry_dict: dict[str, Any] = {
+            "timestamp": ts,
+            "event_type": event_type,
+            "actor": actor,
+            "resource_type": resource_type,
+            "resource_id": resource_id,
+            "details": details,
+            "prev_hmac": self._prev_hmac,
+        }
+        computed_hmac = _compute_hmac(self._key, self._prev_hmac, entry_dict)
+        entry_dict["hmac"] = computed_hmac
+        event = AuditEvent(
+            timestamp=ts,
+            event_type=event_type,
+            actor=actor,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            details=details,
+            prev_hmac=self._prev_hmac,
+            hmac=computed_hmac,
+        )
+        return event, json.dumps(entry_dict, sort_keys=True) + "\n"
+
+    def _seal_torn_tail(self, log_path: Path) -> bool:
+        """Seal a non-verifying tail so the next record cannot fuse onto it.
+
+        A crashed append is not a clean prefix: file size can persist before
+        data blocks, so the tail may hold a partial line, bytes that parse as
+        JSON but fail their MAC, or garbage that is not UTF-8 at all. Without
+        the seal, the next append writes directly onto an unterminated tail
+        and the two fuse into one unparseable line - the record being written
+        is destroyed and recovery resumes from a stale predecessor (#3130).
+
+        Never repairs and never truncates: the log is append-only, so the torn
+        bytes stay exactly where they are. The terminator and the
+        :data:`EVENT_CHAIN_TORN_RECORD` evidence record land in **one write**:
+        writing the terminator first and the evidence second leaves a
+        reachable state (crash, SIGKILL, full volume) in which the segment is
+        healed and nothing says it was ever damaged. A torn write of the
+        combined buffer leaves a fresh unterminated fragment, which the next
+        append seals and reports in turn.
+
+        The evidence is fsynced before this returns: it is the only surviving
+        statement that a record was lost, written into the same
+        crash-truncatable tail it is evidence about. One fsync per tear is not
+        a hot path - tears are crashes.
+
+        Both the terminator and the record go into *this* segment, so a tear
+        found across a UTC midnight cannot land its evidence in the next
+        day's file. The caller must hold the chain append lock.
+
+        Returns:
+            Whether a tear was sealed (and therefore whether this appended).
+        """
+        try:
+            raw = log_path.read_bytes()
+        except OSError:
+            return False
+        if not raw or raw.endswith(b"\n"):
+            return False
+
+        verified_prefix, local_head = _local_tail_state(raw, self._key)
+        torn = raw[verified_prefix:]
+        tear_class = _classify_torn_bytes(torn)
+
+        # ``_recover_chain_tail`` applies the same local-validity rule that
+        # produced ``verified_prefix``, so the head it returns is the last
+        # record the sealed segment actually carries (falling back across
+        # segments when this one holds no valid record at all).
+        self._prev_hmac = local_head if local_head is not None else self._recover_chain_tail()
+        event, line = self._mint_record(
+            ts=datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            event_type=EVENT_CHAIN_TORN_RECORD,
+            actor="audit-log",
+            resource_type="audit_segment",
+            resource_id=log_path.name,
+            details={
+                "segment": log_path.name,
+                "byte_offset": len(raw),
+                "verified_prefix_offset": verified_prefix,
+                "torn_bytes_sha256": hashlib.sha256(torn).hexdigest(),
+                "tear_class": tear_class,
+            },
+        )
+        buffer = b"\n" + line.encode("utf-8")
+        with log_path.open("ab") as fh:
+            fh.write(buffer)
+            fh.flush()
+            os.fsync(fh.fileno())
+
+        # A short write leaves the segment ending in a fresh fragment.
+        # Returning normally would let the caller append straight onto it and
+        # fuse two records - the outcome sealing exists to prevent. Refusing
+        # leaves the damage exactly as it was, and therefore still reportable.
+        landed = _path_size(log_path)
+        if landed != len(raw) + len(buffer):
+            msg = (
+                f"could not seal the torn tail of {log_path.name}: "
+                f"{landed - len(raw)} of {len(buffer)} bytes were written; "
+                "the segment is still torn and 'bernstein audit verify' still reports it"
+            )
+            raise OSError(msg)
+
+        self._prev_hmac = event.hmac
+        self._synced_path = log_path
+        self._synced_size = landed
+        return True
 
     # -- write --------------------------------------------------------------
 
@@ -1040,36 +1671,21 @@ class AuditLog:
 
             # Re-sync the chain tail from disk under the cross-process lock so a
             # concurrent writer's appended head is chained onto rather than a
-            # stale tail captured at construction (issue #2791). Fast path: when
-            # the current day file is byte-length-identical to what our own last
-            # append left it at, no other process has appended and the cached
-            # head still stands, so the re-read (a full-file scan) is skipped.
-            if log_path != self._synced_path or _path_size(log_path) != self._synced_size:
-                self._prev_hmac = self._recover_chain_tail()
+            # stale tail captured at construction (issue #2791), sealing any
+            # crash-torn tail first so this record cannot fuse onto an
+            # unterminated fragment (#3130). Fast path inside: when the day
+            # file is byte-length-identical to what our own last append left
+            # it at, no other process has appended and the cached head stands.
+            self._sync_for_append(log_path)
 
-            entry_dict: dict[str, Any] = {
-                "timestamp": ts,
-                "event_type": event_type,
-                "actor": actor,
-                "resource_type": resource_type,
-                "resource_id": resource_id,
-                "details": details or {},
-                "prev_hmac": self._prev_hmac,
-            }
-            computed_hmac = _compute_hmac(self._key, self._prev_hmac, entry_dict)
-
-            event = AuditEvent(
-                timestamp=ts,
+            event, line = self._mint_record(
+                ts=ts,
                 event_type=event_type,
                 actor=actor,
                 resource_type=resource_type,
                 resource_id=resource_id,
                 details=details or {},
-                prev_hmac=self._prev_hmac,
-                hmac=computed_hmac,
             )
-
-            entry_dict["hmac"] = computed_hmac
 
             # ``newline=""`` disables Python's universal-newline translation so
             # the literal ``\n`` we append survives byte-for-byte on Windows
@@ -1078,7 +1694,8 @@ class AuditLog:
             # frames; without this the ``\r`` stays inside each split line and
             # the byte-equality tamper check trips.
             with log_path.open("a", encoding="utf-8", newline="") as fh:
-                fh.write(json.dumps(entry_dict, sort_keys=True) + "\n")
+                fh.write(line)
+            computed_hmac = event.hmac
 
             self._prev_hmac = computed_hmac
             self._synced_path = log_path
@@ -1221,14 +1838,14 @@ class AuditLog:
                     tail = handle.read()
 
             active.prev_hmac = _verify_log_bytes(tail, path.name, active.prev_hmac, self._key, errors)
-            # Strict decode on purpose, matching ``query``: an undecodable byte
-            # is evidence (truncation, corruption, tampering), not something to
-            # paper over with replacement characters. ``_verify_log_bytes`` above
-            # already hashes the raw bytes, so a segment that reaches here is the
-            # one it verified; decoding it leniently would only let this path
-            # diverge from ``query`` and hide the very bytes verify hashes.
+            # Per-line strict decode, matching ``query``: an undecodable line is
+            # dropped whole, never smoothed with replacement characters, so a
+            # projected row is always byte-exact against what
+            # ``_verify_log_bytes`` above hashed - and the damage itself is
+            # already recorded in ``errors`` rather than raised, keeping this
+            # path total over a chain that carries sealed tear evidence.
             segment_events = _events_from_text(
-                tail.decode("utf-8"),
+                _decode_segment_text(tail),
                 event_type=event_type,
                 actor=None,
                 since=None,
@@ -1280,15 +1897,57 @@ class AuditLog:
         ``.gz`` segment, or a deleted segment, surfaces as an HMAC/linkage
         error naming the segment rather than passing silently.
 
+        Tear evidence (crash-shaped damage at the chain tail, sealed or not -
+        see :meth:`verify_detailed`) is reported through the same error list
+        until an operator acknowledges it with ``bernstein audit ack-tear``;
+        acknowledged tears no longer fail verification, but the evidence
+        records stay in the chain permanently.
+
         Returns:
             ``(valid, errors)`` where *valid* is True when the entire chain
             is intact and *errors* lists any violations found.
         """
+        report = self.verify_detailed()
+        errors = list(report.hard_errors)
+        for tear in report.unacknowledged_tears:
+            if tear.raw_errors:
+                errors.extend(tear.raw_errors)
+            else:
+                errors.append(
+                    f"{tear.segment}: {tear.tear_class} tear sealed at byte {tear.byte_offset} "
+                    "awaiting acknowledgement (run 'bernstein audit ack-tear')"
+                )
+        return len(errors) == 0, errors
+
+    def verify_detailed(self) -> ChainVerifyReport:
+        """Verify the chain, separating tear evidence from hard corruption.
+
+        The tear model is garbage-tolerant: a crashed append can leave a
+        partial line, JSON-shaped bytes that fail their MAC, or bytes that are
+        not UTF-8 at all - file size can be persisted before data blocks, so
+        no clean-prefix assumption holds. Any non-verifying suffix of the
+        chain's final segment is classified as a tear with the byte offset of
+        the last verifiable record (``sealed=False`` until an append seals
+        it). A non-verifying run elsewhere is only tear evidence when a
+        verifying :data:`EVENT_CHAIN_TORN_RECORD` record anchors it (the run
+        sits exactly on the recorded ``verified_prefix_offset .. byte_offset``
+        span in the same segment); everything else stays a hard error, because
+        damage in the middle of verified history is tampering, not a crash.
+
+        Acknowledgements are chain records themselves
+        (:data:`EVENT_CHAIN_TEAR_ACKNOWLEDGED`), matched by
+        ``(segment, byte_offset)``; an unacknowledged tear is reported on
+        every run - it never clears itself, in particular not by re-sealing.
+
+        Returns:
+            A :class:`ChainVerifyReport`.
+        """
         errors: list[str] = []
+        ctx = _ChainWalkContext()
         archived = _archived_segment_paths(self._audit_dir)
         live_files = sorted(self._audit_dir.glob(_JSONL_GLOB))
         if not archived and not live_files:
-            return True, []
+            return ChainVerifyReport()
 
         prev_hmac = _GENESIS_HMAC
         for gz_path in archived:
@@ -1297,12 +1956,12 @@ class AuditLog:
                 # Cannot establish linkage past an unreadable segment; the
                 # error is already recorded, so stop rather than mis-seed the
                 # live files from a wrong (genesis) prev_hmac.
-                return False, errors
-            prev_hmac = _verify_log_bytes(raw, gz_path.name, prev_hmac, self._key, errors)
+                return ChainVerifyReport(hard_errors=errors)
+            prev_hmac = _verify_log_bytes(raw, gz_path.name, prev_hmac, self._key, errors, ctx)
         for log_path in live_files:
-            prev_hmac = _verify_log_file(log_path, prev_hmac, self._key, errors)
+            prev_hmac = _verify_log_bytes(log_path.read_bytes(), log_path.name, prev_hmac, self._key, errors, ctx)
 
-        return len(errors) == 0, errors
+        return _build_verify_report(errors, ctx)
 
     # -- retention & archive ------------------------------------------------
 
@@ -1407,13 +2066,9 @@ class AuditLog:
 
         Returns:
             List of matching AuditEvent instances (chronological order).
-
-        Raises:
-            UnicodeDecodeError: When a segment is not valid UTF-8. Invalid
-                bytes are evidence - of a truncated write, corruption, or
-                tampering - and ``verify`` hashes the raw bytes, so silently
-                substituting replacement characters here would return records
-                that do not match what is on disk.
+            Lines that are not valid UTF-8 cannot be canonical records and
+            are skipped whole (see :func:`_decode_segment_text`); they are
+            never returned in laundered form, and ``verify`` names them.
         """
         results: list[AuditEvent] = []
         sources: list[bytes | None] = []
@@ -1427,10 +2082,12 @@ class AuditLog:
                 # Unreadable archive segment (corrupt gzip). ``verify`` reports
                 # it with a named error; a query simply has nothing to yield.
                 continue
-            # ``decode`` is strict on purpose: undecodable bytes raise rather
-            # than becoming replacement characters, so a query never reports a
-            # record that differs from the bytes ``verify`` hashed.
-            text = blob.decode("utf-8")
+            # Per-line strict decode: an undecodable line is dropped whole
+            # rather than becoming replacement characters, so a query never
+            # reports a record that differs from the bytes ``verify`` hashed -
+            # and never raises forever over a chain carrying sealed tear
+            # evidence, whose torn bytes are permanent by design.
+            text = _decode_segment_text(blob)
             # Segment-level reject: a record can only carry ``resource_id`` as a
             # field value if that value appears verbatim in the segment's bytes.
             # A segment that never mentions the id holds no match, so skip it

--- a/src/bernstein/core/security/audit.py
+++ b/src/bernstein/core/security/audit.py
@@ -973,8 +973,13 @@ def _build_verify_report(errors: list[str], ctx: _ChainWalkContext) -> ChainVeri
 
     # Unsealed tail tear: every non-verifying line after the last verifying
     # record of the chain's final segment, extending to end of file. Damage
-    # with verified records after it is not a tail and stays hard.
-    if ctx.order:
+    # with verified records after it is not a tail and stays hard. A chain
+    # with no verifying record at all is not a tear either: a crash damages
+    # the suffix of history that verified, so when nothing verifies the
+    # damage is a broken or foreign chain (e.g. written under a different
+    # key) and must stay a hard error rather than something an operator is
+    # invited to acknowledge away.
+    if ctx.order and any(ctx.ok_end.values()):
         final = ctx.order[-1]
         ok_end = ctx.ok_end.get(final, 0)
         tail_indices = [

--- a/src/bernstein/core/security/audit.py
+++ b/src/bernstein/core/security/audit.py
@@ -782,19 +782,21 @@ def _chain_tail_from_bytes(raw_bytes: bytes, key: bytes | None = None) -> str | 
 def _local_tail_state(raw: bytes, key: bytes) -> tuple[int, str | None]:
     """Return ``(verified_prefix_end, head_hmac)`` for one segment's bytes.
 
-    Walks forward under the verifier's framing and keeps extending the prefix
-    while lines are canonical, ``hmac``-bearing, and locally MAC-valid (see
-    :func:`_record_is_locally_valid`). The returned offset is the byte after
-    the last such record (including its terminator when present), i.e. where
-    a non-verifying suffix begins; the head is that record's ``hmac``, or
-    ``None`` when the segment holds no locally valid record.
+    Finds the *last* line that is canonical, ``hmac``-bearing, and locally
+    MAC-valid (see :func:`_record_is_locally_valid`), scanning from the end so
+    the cost is proportional to the damaged suffix, not the segment. The
+    returned offset is the byte after that record (including its terminator
+    when present), i.e. where the non-verifying suffix begins; the head is
+    that record's ``hmac``, or ``None`` when the segment holds no locally
+    valid record at all.
     """
+    lines: list[tuple[int, bytes]] = []
     offset = 0
-    end_ok = 0
-    head: str | None = None
     for raw_line in _split_jsonl_bytes(raw):
-        line_start = offset
+        lines.append((offset, raw_line))
         offset += len(raw_line) + 1
+
+    for line_start, raw_line in reversed(lines):
         if raw_line == b"":
             continue
         try:
@@ -811,9 +813,8 @@ def _local_tail_state(raw: bytes, key: bytes) -> tuple[int, str | None]:
         line_end = line_start + len(raw_line)
         if line_end < len(raw):
             line_end += 1  # the terminator this line owns
-        end_ok = line_end
-        head = str(entry["hmac"])
-    return end_ok, head
+        return line_end, str(entry["hmac"])
+    return 0, None
 
 
 def _classify_torn_bytes(torn: bytes) -> str:
@@ -1507,10 +1508,23 @@ class AuditLog:
         size = _path_size(log_path)
         if log_path == self._synced_path and size == self._synced_size:
             return
-        if self._seal_torn_tail(log_path):
-            # Sealing appended its own record and left the head and the sync
-            # markers current; re-reading would only re-derive what it wrote.
-            return
+        # One read serves both the tear gate and head recovery, so the slow
+        # path costs a single pass over the day segment - the same order as
+        # the plain re-sync it replaces.
+        try:
+            raw = log_path.read_bytes()
+        except OSError:
+            raw = b""
+        if raw:
+            verified_prefix, local_head = _local_tail_state(raw, self._key)
+            if verified_prefix != len(raw) or not raw.endswith(b"\n"):
+                self._seal_torn_tail(log_path, raw, verified_prefix, local_head)
+                return
+            if local_head is not None:
+                self._prev_hmac = local_head
+                self._synced_path = log_path
+                self._synced_size = len(raw)
+                return
         self._prev_hmac = self._recover_chain_tail()
         self._synced_path = log_path
         self._synced_size = _path_size(log_path)
@@ -1556,7 +1570,7 @@ class AuditLog:
         )
         return event, json.dumps(entry_dict, sort_keys=True) + "\n"
 
-    def _seal_torn_tail(self, log_path: Path) -> bool:
+    def _seal_torn_tail(self, log_path: Path, raw: bytes, verified_prefix: int, local_head: str | None) -> bool:
         """Seal a non-verifying tail so the next record cannot fuse onto it.
 
         A crashed append is not a clean prefix: file size can persist before
@@ -1587,22 +1601,37 @@ class AuditLog:
         Returns:
             Whether a tear was sealed (and therefore whether this appended).
         """
-        try:
-            raw = log_path.read_bytes()
-        except OSError:
-            return False
-        if not raw or raw.endswith(b"\n"):
-            return False
-
-        verified_prefix, local_head = _local_tail_state(raw, self._key)
+        # The caller has already established that the tail does not verify:
+        # either the terminator is missing, or a *terminated* suffix fails
+        # locally (crash garbage can parse and still fail its MAC). Sealing
+        # both shapes matters - an unsealed terminated-invalid tail would let
+        # the next append chain past it, after which the damage sits between
+        # verified records and stops being classifiable as a tear.
         torn = raw[verified_prefix:]
         tear_class = _classify_torn_bytes(torn)
 
-        # ``_recover_chain_tail`` applies the same local-validity rule that
-        # produced ``verified_prefix``, so the head it returns is the last
-        # record the sealed segment actually carries (falling back across
-        # segments when this one holds no valid record at all).
-        self._prev_hmac = local_head if local_head is not None else self._recover_chain_tail()
+        # The evidence record must chain onto the value the *verifier's*
+        # running prev will hold when it reaches the seal point, or the
+        # record cannot verify and the evidence is unreadable. The verifier
+        # adopts the stored ``hmac`` of every canonical-but-failing line it
+        # walks through, so the seal mirrors that adoption over the torn
+        # suffix, starting from the last locally valid head (falling back
+        # across segments when this one holds no valid record at all).
+        seal_prev = local_head if local_head is not None else self._recover_chain_tail()
+        for torn_line in _split_jsonl_bytes(torn):
+            if torn_line == b"":
+                continue
+            try:
+                parsed = json.loads(torn_line)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                continue
+            if not isinstance(parsed, dict):
+                continue
+            entry = cast("dict[str, Any]", parsed)
+            if json.dumps(entry, sort_keys=True).encode() != torn_line:
+                continue
+            seal_prev = str(entry.get("hmac", ""))
+        self._prev_hmac = seal_prev
         event, line = self._mint_record(
             ts=datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             event_type=EVENT_CHAIN_TORN_RECORD,
@@ -1617,7 +1646,8 @@ class AuditLog:
                 "tear_class": tear_class,
             },
         )
-        buffer = b"\n" + line.encode("utf-8")
+        terminator = b"" if raw.endswith(b"\n") else b"\n"
+        buffer = terminator + line.encode("utf-8")
         with log_path.open("ab") as fh:
             fh.write(buffer)
             fh.flush()
@@ -1918,10 +1948,7 @@ class AuditLog:
             if tear.raw_errors:
                 errors.extend(tear.raw_errors)
             else:
-                errors.append(
-                    f"{tear.segment}: {tear.tear_class} tear sealed at byte {tear.byte_offset} "
-                    "awaiting acknowledgement (run 'bernstein audit ack-tear')"
-                )
+                errors.append(f"{tear.describe()} - run 'bernstein audit ack-tear' after investigating")
         return len(errors) == 0, errors
 
     def verify_detailed(self) -> ChainVerifyReport:

--- a/tests/integration/test_audit_chain_tear_stickiness.py
+++ b/tests/integration/test_audit_chain_tear_stickiness.py
@@ -1,0 +1,318 @@
+"""A shrunk or damaged audit history cannot obtain a fresh accepted seal.
+
+The failure this pins was reproduced through real CLI invocations: with a
+seal in place and ``verify`` green, a crash truncated the newest segment
+back to a record boundary. The HMAC chain stayed intact, so the next
+scheduled ``bernstein audit seal`` recomputed a root over the shrunk history
+and ``verify`` went green again - records were gone and nobody was paged.
+
+With signed checkpoints the flip is dead:
+
+* the seal job exits non-zero naming the checkpoint it conflicts with,
+* ``verify`` reports the divergence as tear evidence,
+* rerunning the seal job changes nothing (self-clear is gone),
+* only an explicit ``bernstein audit ack-tear`` lets the next seal record a
+  new pin - and the superseded checkpoint stays on disk permanently.
+
+Everything here drives the real CLI in a subprocess, matching how the cron
+jobs invoke it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.security.audit import AuditLog, load_or_create_audit_key
+
+pytestmark = pytest.mark.integration
+
+
+def _cli(workdir: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.pop("BERNSTEIN_AUTOMATION_BRIDGE_ROOT", None)
+    return subprocess.run(
+        [sys.executable, "-m", "bernstein", *args],
+        cwd=workdir,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=180,
+        check=False,
+    )
+
+
+@pytest.fixture()
+def workdir(tmp_path: Path) -> Path:
+    """An isolated project whose chain holds eight sealed records."""
+    (tmp_path / ".sdd" / "audit").mkdir(parents=True)
+    log = AuditLog(tmp_path / ".sdd" / "audit")
+    for i in range(8):
+        log.log("test.event", "tester", "task", f"t-{i}", {"i": i})
+    return tmp_path
+
+
+def _segment(workdir: Path) -> Path:
+    return sorted((workdir / ".sdd" / "audit").glob("*.jsonl"))[0]
+
+
+def _truncate_to_records(workdir: Path, count: int) -> None:
+    """Cut the newest segment back to *count* complete records (clean boundary)."""
+    segment = _segment(workdir)
+    lines = [line for line in segment.read_bytes().split(b"\n") if line]
+    assert len(lines) > count
+    segment.write_bytes(b"\n".join(lines[:count]) + b"\n")
+
+
+def _seal_and_verify_green(workdir: Path) -> None:
+    sealed = _cli(workdir, "audit", "seal")
+    assert sealed.returncode == 0, sealed.stdout + sealed.stderr
+    verified = _cli(workdir, "audit", "verify")
+    assert verified.returncode == 0, verified.stdout + verified.stderr
+
+
+class TestTruncationIsSticky:
+    def test_boundary_truncation_cannot_obtain_a_fresh_seal(self, workdir: Path) -> None:
+        """The exact laundering reproduction, flipped.
+
+        A record-boundary truncation leaves the HMAC chain intact, which is
+        why the old precheck (chain verification only) waved it through.
+        """
+        _seal_and_verify_green(workdir)
+
+        _truncate_to_records(workdir, 4)
+
+        sealed = _cli(workdir, "audit", "seal")
+        assert sealed.returncode != 0, "the seal job must refuse a shrunk history"
+        assert "Checkpoint Divergence" in sealed.stdout
+        assert "checkpoint root" in sealed.stdout, "the refusal must name the checkpoint it conflicts with"
+        assert "pinned 8 entries" in sealed.stdout
+
+        verified = _cli(workdir, "audit", "verify")
+        assert verified.returncode != 0
+        assert "tear evidence" in verified.stdout
+
+        # Self-clear is dead: rerunning the seal job changes nothing.
+        again = _cli(workdir, "audit", "seal")
+        assert again.returncode != 0
+        assert "Checkpoint Divergence" in again.stdout
+        still = _cli(workdir, "audit", "verify")
+        assert still.returncode != 0
+        assert "tear evidence" in still.stdout
+
+    def test_midrecord_truncation_cannot_obtain_a_fresh_seal(self, workdir: Path) -> None:
+        _seal_and_verify_green(workdir)
+
+        segment = _segment(workdir)
+        raw = segment.read_bytes()
+        segment.write_bytes(raw[: len(raw) - 40])  # tears the final record mid-line
+
+        sealed = _cli(workdir, "audit", "seal")
+        assert sealed.returncode != 0
+        assert "Checkpoint Divergence" in sealed.stdout
+
+        verified = _cli(workdir, "audit", "verify")
+        assert verified.returncode != 0
+        assert "tear evidence" in verified.stdout
+
+    def test_garbage_tail_is_tear_evidence_and_survives_sealing(self, workdir: Path) -> None:
+        """The crash model is arbitrary bytes, not a clean prefix.
+
+        A garbage tail does not shrink the checkpointed history, so the
+        refusal comes from the tear pillar; the evidence survives the append
+        that seals it and every rerun of the seal job.
+        """
+        _seal_and_verify_green(workdir)
+
+        segment = _segment(workdir)
+        with segment.open("ab") as fh:
+            fh.write(b"\x80\xffnot a record{")
+
+        sealed = _cli(workdir, "audit", "seal")
+        assert sealed.returncode != 0
+        assert "unacknowledged tear evidence" in sealed.stdout
+
+        verified = _cli(workdir, "audit", "verify")
+        assert verified.returncode != 0
+        assert "Tear Evidence" in verified.stdout
+        assert "garbage_bytes" in verified.stdout
+
+        # An ordinary append seals the tear in-chain; the evidence stays.
+        AuditLog(workdir / ".sdd" / "audit").log("test.event", "tester", "task", "after-crash", {})
+        after_append = _cli(workdir, "audit", "verify")
+        assert after_append.returncode != 0
+        assert "garbage_bytes" in after_append.stdout
+        resealed = _cli(workdir, "audit", "seal")
+        assert resealed.returncode != 0, "sealing must not clear tear evidence"
+
+    def test_acknowledgement_is_the_only_way_forward(self, workdir: Path) -> None:
+        _seal_and_verify_green(workdir)
+        _truncate_to_records(workdir, 4)
+
+        offset = _segment(workdir).stat().st_size
+        segment_name = _segment(workdir).name
+
+        wrong = _cli(
+            workdir,
+            "audit",
+            "ack-tear",
+            "--segment",
+            segment_name,
+            "--offset",
+            str(offset + 1),
+            "--reason",
+            "wrong offset",
+        )
+        assert wrong.returncode != 0, "an acknowledgement must name the tear exactly as verify printed it"
+
+        acked = _cli(
+            workdir,
+            "audit",
+            "ack-tear",
+            "--segment",
+            segment_name,
+            "--offset",
+            str(offset),
+            "--reason",
+            "host crash investigated; lost records restored from the task store",
+        )
+        assert acked.returncode == 0, acked.stdout + acked.stderr
+
+        sealed = _cli(workdir, "audit", "seal")
+        assert sealed.returncode == 0, sealed.stdout + sealed.stderr
+        assert "acknowledged divergence" in sealed.stdout
+
+        verified = _cli(workdir, "audit", "verify")
+        assert verified.returncode == 0, verified.stdout + verified.stderr
+
+        # The superseded checkpoint is still on disk: evidence is permanent.
+        checkpoints = workdir / ".sdd" / "audit" / "checkpoints" / "checkpoints.jsonl"
+        payloads = [json.loads(line)["payload"] for line in checkpoints.read_text().splitlines()]
+        assert len(payloads) == 2
+        assert payloads[0]["entry_count"] == 8
+        assert payloads[1]["extends_prev"] is False
+        assert payloads[1]["divergence_ack"]["checkpoint_root"] == payloads[0]["root_hash"]
+
+    def test_normal_growth_seals_cleanly_and_advances_the_checkpoint(self, workdir: Path) -> None:
+        """The positive path: append-only growth is a consistent extension."""
+        _seal_and_verify_green(workdir)
+
+        log = AuditLog(workdir / ".sdd" / "audit")
+        for i in range(3):
+            log.log("test.event", "tester", "task", f"grown-{i}", {})
+
+        sealed = _cli(workdir, "audit", "seal")
+        assert sealed.returncode == 0, sealed.stdout + sealed.stderr
+        assert "extends previous" in sealed.stdout
+
+        verified = _cli(workdir, "audit", "verify")
+        assert verified.returncode == 0, verified.stdout + verified.stderr
+
+        checkpoints = workdir / ".sdd" / "audit" / "checkpoints" / "checkpoints.jsonl"
+        payloads = [json.loads(line)["payload"] for line in checkpoints.read_text().splitlines()]
+        assert [p["entry_count"] for p in payloads] == [8, 11]
+        assert payloads[1]["extends_prev"] is True
+
+
+class TestDeterminism:
+    def test_identical_directories_produce_byte_identical_checkpoints(self, tmp_path: Path) -> None:
+        """Checkpoints are a pure function of directory content and key."""
+        first = tmp_path / "first"
+        (first / ".sdd" / "audit").mkdir(parents=True)
+        log = AuditLog(first / ".sdd" / "audit")
+        for i in range(6):
+            log.log("test.event", "tester", "task", f"t-{i}", {"i": i})
+
+        second = tmp_path / "second"
+        (second / ".sdd").mkdir(parents=True)
+        import shutil
+
+        shutil.copytree(first / ".sdd" / "audit", second / ".sdd" / "audit")
+
+        for workdir in (first, second):
+            sealed = _cli(workdir, "audit", "seal")
+            assert sealed.returncode == 0, sealed.stdout + sealed.stderr
+
+        first_bytes = (first / ".sdd" / "audit" / "checkpoints" / "checkpoints.jsonl").read_bytes()
+        second_bytes = (second / ".sdd" / "audit" / "checkpoints" / "checkpoints.jsonl").read_bytes()
+        assert first_bytes == second_bytes
+
+    def test_resealing_an_unchanged_log_is_idempotent(self, workdir: Path) -> None:
+        _seal_and_verify_green(workdir)
+        checkpoints = workdir / ".sdd" / "audit" / "checkpoints" / "checkpoints.jsonl"
+        before = checkpoints.read_bytes()
+
+        again = _cli(workdir, "audit", "seal")
+        assert again.returncode == 0
+
+        assert checkpoints.read_bytes() == before
+
+
+class TestReadOnlyVerify:
+    def test_verify_works_against_a_read_only_audit_dir(self, workdir: Path) -> None:
+        """Verification is a pure read: an offline copy must verify as-is."""
+        _seal_and_verify_green(workdir)
+
+        audit_dir = workdir / ".sdd" / "audit"
+        stripped: list[tuple[Path, int]] = []
+        for path in [audit_dir, *audit_dir.rglob("*")]:
+            mode = stat.S_IMODE(path.stat().st_mode)
+            stripped.append((path, mode))
+            path.chmod(mode & ~0o222)
+        try:
+            verified = _cli(workdir, "audit", "verify")
+            assert verified.returncode == 0, verified.stdout + verified.stderr
+        finally:
+            for path, mode in reversed(stripped):
+                path.chmod(mode)
+
+
+@pytest.mark.slow
+class TestConcurrencySanity:
+    def test_paced_multiprocess_appends_lose_nothing(self, tmp_path: Path) -> None:
+        """N processes, M appends each: zero lost, zero refused, chain verifies.
+
+        The chain lock is a blocking ``flock``: a writer waits, it is never
+        refused. The tear-seal probe sits behind the (path, size) fast path,
+        so contention exercises the slow path on every append here.
+        """
+        import multiprocessing as mp
+        import time
+
+        audit_dir = tmp_path / "audit"
+        audit_dir.mkdir()
+        key = load_or_create_audit_key()
+
+        n_procs = 8
+        m_events = 25
+
+        def _worker(worker_id: int, barrier: object) -> None:
+            log = AuditLog(audit_dir, key=key)
+            barrier.wait()  # type: ignore[attr-defined]
+            for i in range(m_events):
+                log.log("concurrent.event", f"worker-{worker_id}", "res", f"w{worker_id}-{i}")
+                time.sleep(0.002)
+
+        ctx = mp.get_context("fork")
+        barrier = ctx.Barrier(n_procs)
+        procs = [ctx.Process(target=_worker, args=(w, barrier)) for w in range(n_procs)]
+        for proc in procs:
+            proc.start()
+        for proc in procs:
+            proc.join(timeout=120)
+        assert all(proc.exitcode == 0 for proc in procs), "no append may be refused or crash"
+
+        log = AuditLog(audit_dir, key=key)
+        events = log.query(event_type="concurrent.event")
+        assert len(events) == n_procs * m_events, "no append may be lost"
+        ids = {event.resource_id for event in events}
+        assert len(ids) == n_procs * m_events, "every append is distinct"
+
+        ok, errors = log.verify()
+        assert ok, errors

--- a/tests/integration/test_audit_chain_tear_stickiness.py
+++ b/tests/integration/test_audit_chain_tear_stickiness.py
@@ -306,6 +306,11 @@ class TestConcurrencySanity:
             proc.start()
         for proc in procs:
             proc.join(timeout=120)
+        stuck = [proc for proc in procs if proc.is_alive()]
+        for proc in stuck:
+            proc.terminate()
+            proc.join(timeout=5)
+        assert not stuck, "worker process(es) did not exit within the timeout"
         assert all(proc.exitcode == 0 for proc in procs), "no append may be refused or crash"
 
         log = AuditLog(audit_dir, key=key)

--- a/tests/unit/test_audit_query_archived_segments.py
+++ b/tests/unit/test_audit_query_archived_segments.py
@@ -15,8 +15,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
-
 from bernstein.core.security.audit import AuditLog, RetentionPolicy
 from bernstein.core.security.audit_chain import AuditChainStore
 from bernstein.core.workflows.recipe_registry import RecipePins, RecipeRegistry
@@ -95,12 +93,17 @@ class TestLineageSurvivesRetention:
         assert ok is True, errors
 
 
-class TestInvalidUtf8StaysLoud:
+class TestInvalidUtf8IsSkippedNeverLaundered:
     """Invalid bytes are evidence, and ``verify`` hashes the raw bytes.
 
     Substituting replacement characters would make ``query`` return a
     clean-looking record that does not match what is on disk - the projection
-    and the verifier would then disagree about what the log says.
+    and the verifier would then disagree about what the log says. So an
+    undecodable line is dropped whole, never returned in smoothed form, and
+    ``verify`` keeps naming it. ``query`` itself stays total: torn bytes are
+    permanent (the log is append-only and a tear seal never truncates), so a
+    raising read path would turn one acknowledged crash into a forever-broken
+    query surface for every consumer of the chain.
     """
 
     @staticmethod
@@ -111,17 +114,22 @@ class TestInvalidUtf8StaysLoud:
         assert corrupted != raw, "fixture did not corrupt anything"
         segment.write_bytes(corrupted)
 
-    def test_live_segment_with_invalid_utf8_raises(self, tmp_path: Path) -> None:
+    def test_live_segment_with_invalid_utf8_is_skipped_and_stays_loud(self, tmp_path: Path) -> None:
         sdd = tmp_path / ".sdd"
         sdd.mkdir(parents=True)
         _registry(sdd).register(spec=load_recipe_spec_from_text(_V1), pins=RecipePins(git_commit="c1"))
         self._corrupt_a_string_value(sdd / "audit")
 
         log = AuditLog(audit_dir=sdd / "audit", key=_KEY)
-        with pytest.raises(UnicodeDecodeError):
-            log.query(event_type="recipe.register")
+        events = log.query(event_type="recipe.register")
+        # The damaged record is omitted, not returned with replacement
+        # characters; nothing query yields differs from the on-disk bytes.
+        assert events == []
+        ok, errors = log.verify()
+        assert ok is False
+        assert any("undecodable" in error for error in errors)
 
-    def test_archived_segment_with_invalid_utf8_raises(self, tmp_path: Path) -> None:
+    def test_archived_segment_with_invalid_utf8_is_skipped_and_stays_loud(self, tmp_path: Path) -> None:
         sdd = tmp_path / ".sdd"
         sdd.mkdir(parents=True)
         audit = sdd / "audit"
@@ -133,6 +141,8 @@ class TestInvalidUtf8StaysLoud:
         log = AuditLog(audit_dir=audit, key=_KEY)
         # Live-only read sees nothing and must not raise...
         assert log.query(event_type="recipe.register") == []
-        # ...but reading the archive applies the same strict rule.
-        with pytest.raises(UnicodeDecodeError):
-            log.query(event_type="recipe.register", include_archived=True)
+        # ...and the archived read applies the same skip-not-launder rule.
+        assert log.query(event_type="recipe.register", include_archived=True) == []
+        ok, errors = log.verify()
+        assert ok is False
+        assert any("undecodable" in error for error in errors)

--- a/tests/unit/test_audit_tear_detection.py
+++ b/tests/unit/test_audit_tear_detection.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from bernstein.core.security.audit import (
     EVENT_CHAIN_TEAR_ACKNOWLEDGED,
@@ -34,8 +34,8 @@ def _seeded_log(tmp_path: Path, count: int = 4) -> tuple[AuditLog, Path]:
     return log, sorted(audit_dir.glob("*.jsonl"))[0]
 
 
-def _records(segment: Path) -> list[dict]:
-    out = []
+def _records(segment: Path) -> list[dict[str, Any] | None]:
+    out: list[dict[str, Any] | None] = []
     for line in segment.read_bytes().split(b"\n"):
         if not line:
             continue
@@ -159,6 +159,39 @@ class TestAppendSealsTheTear:
         # The new record chains onto the seal, not onto a stale predecessor.
         assert parsed[-1]["prev_hmac"] == torn["hmac"]
 
+    def test_terminated_invalid_tail_is_sealed_not_left_to_rot(self, tmp_path: Path) -> None:
+        """A terminated suffix that fails its MAC is sealed like any tear.
+
+        Without the seal, the next append would chain past the damaged line;
+        the damage would then sit between verified records, stop being
+        classifiable as a tear, and permanently fail verification with no
+        acknowledgement path.
+        """
+        _log, segment = _seeded_log(tmp_path, count=2)
+        fake = dict(json.loads(segment.read_bytes().split(b"\n")[0]))
+        fake["hmac"] = "0" * 64
+        with segment.open("ab") as fh:
+            fh.write(json.dumps(fake, sort_keys=True).encode() + b"\n")
+
+        log2 = AuditLog(tmp_path / "audit", key=_KEY)
+        log2.log("test.event", "tester", "task", "after-tear", {})
+
+        report = AuditLog(tmp_path / "audit", key=_KEY).verify_detailed()
+        assert not report.hard_errors, report.hard_errors
+        (tear,) = report.tears
+        assert tear.sealed is True
+        assert tear.tear_class == "invalid_hmac"
+
+        log2.log(
+            EVENT_CHAIN_TEAR_ACKNOWLEDGED,
+            "operator",
+            "audit_segment",
+            tear.segment,
+            {"segment": tear.segment, "byte_offset": tear.byte_offset, "reason": "investigated"},
+        )
+        ok, errors = AuditLog(tmp_path / "audit", key=_KEY).verify()
+        assert ok is True, errors
+
     def test_sealed_tear_is_reported_until_acknowledged(self, tmp_path: Path) -> None:
         _log, segment = _seeded_log(tmp_path, count=2)
         raw = segment.read_bytes()
@@ -204,8 +237,13 @@ class TestAppendSealsTheTear:
 
 
 class TestRecoveryRejectsForgedTails:
-    def test_recovered_head_ignores_a_json_shaped_forgery(self, tmp_path: Path) -> None:
-        """A canonical-looking tail without a valid MAC is never adopted."""
+    def test_json_shaped_forgery_is_sealed_evidence_never_a_clean_head(self, tmp_path: Path) -> None:
+        """A canonical-looking tail without a valid MAC is never adopted silently.
+
+        The next append seals it as recorded tear evidence and chains onto the
+        seal record, so the forgery can neither pose as the chain head nor
+        disappear between verified records.
+        """
         _log, segment = _seeded_log(tmp_path, count=2)
         real_last = json.loads(segment.read_bytes().split(b"\n")[-2])
 
@@ -216,4 +254,17 @@ class TestRecoveryRejectsForgedTails:
             fh.write(json.dumps(forged, sort_keys=True).encode() + b"\n")
 
         appended = AuditLog(tmp_path / "audit", key=_KEY).log("test.event", "tester", "task", "next", {})
-        assert appended.prev_hmac == real_last["hmac"], "the append must chain onto the last MAC-valid record"
+
+        records = [r for r in _records(segment) if r is not None]
+        torn = next(r for r in records if r["event_type"] == EVENT_CHAIN_TORN_RECORD)
+        assert torn["details"]["tear_class"] == "invalid_hmac"
+        assert torn["details"]["verified_prefix_offset"] == sum(
+            len(json.dumps(r, sort_keys=True).encode()) + 1 for r in records[:2]
+        )
+        assert appended.prev_hmac == torn["hmac"], "the append chains onto the seal, not onto the forgery"
+
+        report = AuditLog(tmp_path / "audit", key=_KEY).verify_detailed()
+        assert not report.hard_errors, report.hard_errors
+        (tear,) = report.tears
+        assert tear.sealed is True
+        assert tear.acknowledged is False, "the forgery stays reported until an operator looks"

--- a/tests/unit/test_audit_tear_detection.py
+++ b/tests/unit/test_audit_tear_detection.py
@@ -1,0 +1,219 @@
+"""Garbage-tolerant tail detection and the in-chain tear seal (#3130).
+
+A crashed append is not a clean prefix: file size can be persisted before
+data blocks, so the tail of the newest segment can hold a partial line,
+bytes that parse as JSON but fail their MAC, or bytes that are not UTF-8 at
+all. Every such suffix must classify as a tear with the byte offset of the
+last verifiable record - and appending onto it must never destroy the record
+being written.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import TYPE_CHECKING
+
+from bernstein.core.security.audit import (
+    EVENT_CHAIN_TEAR_ACKNOWLEDGED,
+    EVENT_CHAIN_TORN_RECORD,
+    AuditLog,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_KEY = b"tear-detection-test-key-012345678"
+
+
+def _seeded_log(tmp_path: Path, count: int = 4) -> tuple[AuditLog, Path]:
+    audit_dir = tmp_path / "audit"
+    log = AuditLog(audit_dir, key=_KEY)
+    for i in range(count):
+        log.log("test.event", "tester", "task", f"t-{i}", {"i": i})
+    return log, sorted(audit_dir.glob("*.jsonl"))[0]
+
+
+def _records(segment: Path) -> list[dict]:
+    out = []
+    for line in segment.read_bytes().split(b"\n"):
+        if not line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            out.append(None)  # placeholder for an unparseable physical line
+    return out
+
+
+class TestTailClassification:
+    """Each non-verifying suffix shape is a tear, with the right class."""
+
+    def test_partial_last_line(self, tmp_path: Path) -> None:
+        _log, segment = _seeded_log(tmp_path)
+        raw = segment.read_bytes()
+        segment.write_bytes(raw[: len(raw) - 25])
+
+        report = AuditLog(tmp_path / "audit", key=_KEY).verify_detailed()
+        assert not report.hard_errors
+        (tear,) = report.tears
+        assert tear.tear_class == "partial_record"
+        assert tear.sealed is False
+        assert tear.acknowledged is False
+        # The offset of the last verifiable record: three intact lines.
+        lines = raw.split(b"\n")
+        assert tear.verified_prefix_offset == sum(len(line) + 1 for line in lines[:3])
+
+    def test_json_shaped_tail_that_fails_its_mac(self, tmp_path: Path) -> None:
+        _log, segment = _seeded_log(tmp_path)
+        fake = dict(json.loads(segment.read_bytes().split(b"\n")[0]))
+        fake["hmac"] = "0" * 64
+        with segment.open("ab") as fh:
+            fh.write(json.dumps(fake, sort_keys=True).encode() + b"\n")
+        # Terminated garbage that parses cleanly: only the MAC gives it away.
+
+        report = AuditLog(tmp_path / "audit", key=_KEY).verify_detailed()
+        assert not report.hard_errors
+        (tear,) = report.tears
+        assert tear.tear_class == "invalid_hmac"
+        assert tear.sealed is False
+
+    def test_non_utf8_garbage(self, tmp_path: Path) -> None:
+        _log, segment = _seeded_log(tmp_path)
+        prefix_len = segment.stat().st_size
+        with segment.open("ab") as fh:
+            fh.write(b"\x80\xff\x00garbage")
+
+        report = AuditLog(tmp_path / "audit", key=_KEY).verify_detailed()
+        assert not report.hard_errors
+        (tear,) = report.tears
+        assert tear.tear_class == "garbage_bytes"
+        assert tear.verified_prefix_offset == prefix_len
+
+    def test_terminator_only_loss(self, tmp_path: Path) -> None:
+        _log, segment = _seeded_log(tmp_path)
+        raw = segment.read_bytes()
+        segment.write_bytes(raw[:-1])  # the record is whole; only ``\n`` is gone
+
+        report = AuditLog(tmp_path / "audit", key=_KEY).verify_detailed()
+        assert not report.hard_errors
+        (tear,) = report.tears
+        assert tear.tear_class == "unterminated_record"
+        assert tear.verified_prefix_offset == tear.byte_offset
+
+    def test_mid_history_damage_stays_a_hard_error(self, tmp_path: Path) -> None:
+        """Damage with verified records after it is tampering, not a crash."""
+        _log, segment = _seeded_log(tmp_path)
+        raw = segment.read_bytes()
+        mutated = raw.replace(b'"i": 1', b'"i": 9', 1)
+        assert mutated != raw
+        segment.write_bytes(mutated)
+
+        report = AuditLog(tmp_path / "audit", key=_KEY).verify_detailed()
+        assert report.hard_errors, "a rewritten middle record must not classify as a tear"
+
+
+class TestAppendSealsTheTear:
+    """#3130: appending onto an unterminated segment must not destroy records."""
+
+    def test_unterminated_complete_record_yields_parseable_lines(self, tmp_path: Path) -> None:
+        _log, segment = _seeded_log(tmp_path, count=2)
+        raw = segment.read_bytes()
+        segment.write_bytes(raw[:-1])
+
+        log2 = AuditLog(tmp_path / "audit", key=_KEY)
+        log2.log("test.event", "tester", "task", "after-tear", {})
+
+        records = _records(segment)
+        assert None not in records, "no physical line may be unparseable"
+        assert [r["event_type"] for r in records] == [
+            "test.event",
+            "test.event",
+            EVENT_CHAIN_TORN_RECORD,
+            "test.event",
+        ]
+        torn = records[2]
+        assert torn["details"]["tear_class"] == "unterminated_record"
+        assert torn["details"]["byte_offset"] == len(raw) - 1
+
+    def test_partial_record_is_isolated_not_fused(self, tmp_path: Path) -> None:
+        """The record being written survives; the fragment stays isolated."""
+        _log, segment = _seeded_log(tmp_path, count=2)
+        raw = segment.read_bytes()
+        segment.write_bytes(raw[: len(raw) - 30])
+        first_record_end = len(raw.split(b"\n")[0]) + 1
+        torn_bytes = raw[first_record_end : len(raw) - 30]
+
+        log2 = AuditLog(tmp_path / "audit", key=_KEY)
+        appended = log2.log("test.event", "tester", "task", "after-tear", {})
+
+        records = _records(segment)
+        # One placeholder: the sealed fragment. Everything else parses.
+        assert records.count(None) == 1
+        parsed = [r for r in records if r is not None]
+        assert parsed[-1]["resource_id"] == "after-tear"
+        assert parsed[-1]["hmac"] == appended.hmac
+        torn = next(r for r in parsed if r["event_type"] == EVENT_CHAIN_TORN_RECORD)
+        assert torn["details"]["tear_class"] == "partial_record"
+        assert torn["details"]["torn_bytes_sha256"] == hashlib.sha256(torn_bytes).hexdigest()
+        # The new record chains onto the seal, not onto a stale predecessor.
+        assert parsed[-1]["prev_hmac"] == torn["hmac"]
+
+    def test_sealed_tear_is_reported_until_acknowledged(self, tmp_path: Path) -> None:
+        _log, segment = _seeded_log(tmp_path, count=2)
+        raw = segment.read_bytes()
+        segment.write_bytes(raw[: len(raw) - 30])
+
+        log2 = AuditLog(tmp_path / "audit", key=_KEY)
+        log2.log("test.event", "tester", "task", "after-tear", {})
+
+        report = AuditLog(tmp_path / "audit", key=_KEY).verify_detailed()
+        (tear,) = report.tears
+        assert tear.sealed is True
+        assert tear.acknowledged is False
+        ok, errors = AuditLog(tmp_path / "audit", key=_KEY).verify()
+        assert ok is False
+        assert errors
+
+        log2.log(
+            EVENT_CHAIN_TEAR_ACKNOWLEDGED,
+            "operator",
+            "audit_segment",
+            tear.segment,
+            {"segment": tear.segment, "byte_offset": tear.byte_offset, "reason": "investigated"},
+        )
+        after = AuditLog(tmp_path / "audit", key=_KEY).verify_detailed()
+        (acked,) = after.tears
+        assert acked.acknowledged is True
+        ok, errors = AuditLog(tmp_path / "audit", key=_KEY).verify()
+        assert ok is True, errors
+
+    def test_tampering_with_the_seal_record_breaks_verification(self, tmp_path: Path) -> None:
+        """The evidence is chained like any other record."""
+        _log, segment = _seeded_log(tmp_path, count=2)
+        raw = segment.read_bytes()
+        segment.write_bytes(raw[:-1])
+        AuditLog(tmp_path / "audit", key=_KEY).log("test.event", "tester", "task", "x", {})
+
+        mutated = segment.read_bytes().replace(b'"tear_class": "unterminated_record"', b'"tear_class": "nothing"')
+        assert mutated != segment.read_bytes()
+        segment.write_bytes(mutated)
+
+        report = AuditLog(tmp_path / "audit", key=_KEY).verify_detailed()
+        assert report.hard_errors, "a mutated torn-record event must fail verification"
+
+
+class TestRecoveryRejectsForgedTails:
+    def test_recovered_head_ignores_a_json_shaped_forgery(self, tmp_path: Path) -> None:
+        """A canonical-looking tail without a valid MAC is never adopted."""
+        _log, segment = _seeded_log(tmp_path, count=2)
+        real_last = json.loads(segment.read_bytes().split(b"\n")[-2])
+
+        forged = dict(real_last)
+        forged["resource_id"] = "forged"
+        forged["hmac"] = "f" * 64
+        with segment.open("ab") as fh:
+            fh.write(json.dumps(forged, sort_keys=True).encode() + b"\n")
+
+        appended = AuditLog(tmp_path / "audit", key=_KEY).log("test.event", "tester", "task", "next", {})
+        assert appended.prev_hmac == real_last["hmac"], "the append must chain onto the last MAC-valid record"

--- a/tests/unit/test_chain_checkpoint.py
+++ b/tests/unit/test_chain_checkpoint.py
@@ -9,7 +9,7 @@ pin be recorded over a divergence.
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -45,7 +45,7 @@ def _seed(tmp_path: Path, count: int = 6) -> Path:
     return audit_dir
 
 
-def _seal_and_pin(audit_dir: Path) -> dict:
+def _seal_and_pin(audit_dir: Path) -> dict[str, Any]:
     _tree, seal = compute_seal(audit_dir, key=_KEY)
     return record_checkpoint(audit_dir, seal, key=_KEY)
 

--- a/tests/unit/test_chain_checkpoint.py
+++ b/tests/unit/test_chain_checkpoint.py
@@ -1,0 +1,293 @@
+"""Signed checkpoint substrate: pinning, extension math, append discipline.
+
+The checkpoint is the durable pin that makes an audit-history shrink sticky:
+``compute_seal`` refuses unless the current tree is a consistent extension
+of the last checkpoint, and only a chain-resident acknowledgement lets a new
+pin be recorded over a divergence.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bernstein.core.persistence.chain_checkpoint import (
+    CheckpointConsistencyError,
+    CheckpointFileError,
+    check_extension,
+    checkpoints_path,
+    compute_origin,
+    count_entries,
+    load_checkpoints,
+    record_checkpoint,
+)
+from bernstein.core.persistence.merkle import ChainBrokenError, compute_seal
+from bernstein.core.security.audit import (
+    EVENT_CHAIN_TEAR_ACKNOWLEDGED,
+    AuditLog,
+    OutstandingTearError,
+    RetentionPolicy,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_KEY = b"checkpoint-substrate-test-key-012"
+
+
+def _seed(tmp_path: Path, count: int = 6) -> Path:
+    audit_dir = tmp_path / "audit"
+    log = AuditLog(audit_dir, key=_KEY)
+    for i in range(count):
+        log.log("test.event", "tester", "task", f"t-{i}", {"i": i})
+    return audit_dir
+
+
+def _seal_and_pin(audit_dir: Path) -> dict:
+    _tree, seal = compute_seal(audit_dir, key=_KEY)
+    return record_checkpoint(audit_dir, seal, key=_KEY)
+
+
+class TestPinning:
+    def test_first_seal_records_a_genesis_linked_checkpoint(self, tmp_path: Path) -> None:
+        audit_dir = _seed(tmp_path)
+        payload = _seal_and_pin(audit_dir)
+
+        assert payload["entry_count"] == 6
+        assert payload["extends_prev"] is True
+        assert payload["prev_checkpoint_sha256"] == "0" * 64
+        assert payload["origin"] == compute_origin(audit_dir)
+        state = load_checkpoints(audit_dir, _KEY)
+        assert state.last == payload
+        assert state.torn_tail is False
+
+    def test_checkpoint_carries_no_timestamp(self, tmp_path: Path) -> None:
+        """Byte-determinism: the payload is a pure function of content + key."""
+        audit_dir = _seed(tmp_path)
+        payload = _seal_and_pin(audit_dir)
+        assert "sealed_at" not in payload
+        assert not any("time" in key or key == "at" for key in payload)
+
+    def test_growth_extends_and_links(self, tmp_path: Path) -> None:
+        audit_dir = _seed(tmp_path)
+        _seal_and_pin(audit_dir)
+        AuditLog(audit_dir, key=_KEY).log("test.event", "tester", "task", "extra", {})
+        second = _seal_and_pin(audit_dir)
+
+        assert second["entry_count"] == 7
+        assert second["extends_prev"] is True
+        assert second["prev_checkpoint_sha256"] != "0" * 64
+        assert len(load_checkpoints(audit_dir, _KEY).checkpoints) == 2
+
+    def test_unchanged_tree_does_not_append(self, tmp_path: Path) -> None:
+        audit_dir = _seed(tmp_path)
+        first = _seal_and_pin(audit_dir)
+        again = _seal_and_pin(audit_dir)
+        assert again == first
+        assert len(load_checkpoints(audit_dir, _KEY).checkpoints) == 1
+
+    def test_archived_segment_still_extends(self, tmp_path: Path) -> None:
+        """Retention moves a pinned segment to the archive; the pin still holds."""
+        audit_dir = _seed(tmp_path)
+        segment = sorted(audit_dir.glob("*.jsonl"))[0]
+        aged = audit_dir / "2020-01-01.jsonl"
+        segment.rename(aged)
+        _seal_and_pin(audit_dir)
+
+        AuditLog(audit_dir, key=_KEY).archive(RetentionPolicy())
+        assert not aged.exists(), "precondition: retention archived the pinned segment"
+
+        payload = load_checkpoints(audit_dir, _KEY).last
+        assert payload is not None
+        assert check_extension(audit_dir, payload) == []
+
+
+class TestExtensionConflicts:
+    def test_shrunk_segment_conflicts(self, tmp_path: Path) -> None:
+        audit_dir = _seed(tmp_path)
+        payload = _seal_and_pin(audit_dir)
+        segment = sorted(audit_dir.glob("*.jsonl"))[0]
+        lines = [line for line in segment.read_bytes().split(b"\n") if line]
+        segment.write_bytes(b"\n".join(lines[:3]) + b"\n")
+
+        conflicts = check_extension(audit_dir, payload)
+        kinds = {conflict.kind for conflict in conflicts}
+        assert "segment_shrunk" in kinds
+        assert "entry_count" in kinds
+        shrunk = next(c for c in conflicts if c.kind == "segment_shrunk")
+        assert shrunk.offset == segment.stat().st_size
+
+    def test_rewritten_prefix_conflicts(self, tmp_path: Path) -> None:
+        audit_dir = _seed(tmp_path)
+        payload = _seal_and_pin(audit_dir)
+        segment = sorted(audit_dir.glob("*.jsonl"))[0]
+        raw = segment.read_bytes()
+        segment.write_bytes(raw.replace(b'"i": 0', b'"i": 7', 1))
+
+        conflicts = check_extension(audit_dir, payload)
+        assert any(conflict.kind == "segment_prefix_mismatch" for conflict in conflicts)
+
+    def test_deleted_segment_conflicts(self, tmp_path: Path) -> None:
+        audit_dir = _seed(tmp_path)
+        segment = sorted(audit_dir.glob("*.jsonl"))[0]
+        aged = audit_dir / "2020-01-01.jsonl"
+        segment.rename(aged)
+        AuditLog(audit_dir, key=_KEY).log("test.event", "tester", "task", "today", {})
+        payload = _seal_and_pin(audit_dir)
+
+        aged.unlink()
+        conflicts = check_extension(audit_dir, payload)
+        assert any(conflict.kind == "segment_missing" for conflict in conflicts)
+
+    def test_compute_seal_refuses_a_shrunk_history(self, tmp_path: Path) -> None:
+        audit_dir = _seed(tmp_path)
+        _seal_and_pin(audit_dir)
+        segment = sorted(audit_dir.glob("*.jsonl"))[0]
+        lines = [line for line in segment.read_bytes().split(b"\n") if line]
+        segment.write_bytes(b"\n".join(lines[:3]) + b"\n")
+
+        with pytest.raises(CheckpointConsistencyError) as excinfo:
+            compute_seal(audit_dir, key=_KEY)
+        assert excinfo.value.conflicts
+        # Retrying does not change the outcome: self-clear is dead.
+        with pytest.raises(CheckpointConsistencyError):
+            compute_seal(audit_dir, key=_KEY)
+
+    def test_compute_seal_refuses_unacknowledged_tears(self, tmp_path: Path) -> None:
+        audit_dir = _seed(tmp_path)
+        _seal_and_pin(audit_dir)
+        segment = sorted(audit_dir.glob("*.jsonl"))[0]
+        with segment.open("ab") as fh:
+            fh.write(b"\x80\xffgarbage")
+
+        with pytest.raises(OutstandingTearError):
+            compute_seal(audit_dir, key=_KEY)
+
+    def test_compute_seal_still_refuses_hard_corruption(self, tmp_path: Path) -> None:
+        audit_dir = _seed(tmp_path)
+        segment = sorted(audit_dir.glob("*.jsonl"))[0]
+        raw = segment.read_bytes()
+        segment.write_bytes(raw.replace(b'"i": 1', b'"i": 8', 1))
+
+        with pytest.raises(ChainBrokenError):
+            compute_seal(audit_dir, key=_KEY)
+
+
+class TestDivergenceAcknowledgement:
+    def _shrink(self, audit_dir: Path) -> tuple[str, int]:
+        segment = sorted(audit_dir.glob("*.jsonl"))[0]
+        lines = [line for line in segment.read_bytes().split(b"\n") if line]
+        segment.write_bytes(b"\n".join(lines[:3]) + b"\n")
+        return segment.name, segment.stat().st_size
+
+    def test_ack_authorises_a_new_pin_and_keeps_the_old_one(self, tmp_path: Path) -> None:
+        audit_dir = _seed(tmp_path)
+        first = _seal_and_pin(audit_dir)
+        segment_name, offset = self._shrink(audit_dir)
+
+        AuditLog(audit_dir, key=_KEY).log(
+            EVENT_CHAIN_TEAR_ACKNOWLEDGED,
+            "operator",
+            "audit_segment",
+            segment_name,
+            {
+                "segment": segment_name,
+                "byte_offset": offset,
+                "reason": "investigated",
+                "checkpoint_root": first["root_hash"],
+            },
+        )
+
+        _tree, seal = compute_seal(audit_dir, key=_KEY)
+        second = record_checkpoint(audit_dir, seal, key=_KEY)
+        assert second["extends_prev"] is False
+        assert second["divergence_ack"]["checkpoint_root"] == first["root_hash"]
+
+        stored = load_checkpoints(audit_dir, _KEY).checkpoints
+        assert [payload["root_hash"] for payload in stored] == [first["root_hash"], second["root_hash"]]
+
+    def test_ack_for_a_different_checkpoint_does_not_authorise(self, tmp_path: Path) -> None:
+        audit_dir = _seed(tmp_path)
+        _seal_and_pin(audit_dir)
+        segment_name, offset = self._shrink(audit_dir)
+
+        AuditLog(audit_dir, key=_KEY).log(
+            EVENT_CHAIN_TEAR_ACKNOWLEDGED,
+            "operator",
+            "audit_segment",
+            segment_name,
+            {
+                "segment": segment_name,
+                "byte_offset": offset,
+                "reason": "names the wrong pin",
+                "checkpoint_root": "f" * 64,
+            },
+        )
+        with pytest.raises(CheckpointConsistencyError):
+            compute_seal(audit_dir, key=_KEY)
+
+
+class TestFileDiscipline:
+    def test_signature_tamper_is_a_hard_error(self, tmp_path: Path) -> None:
+        audit_dir = _seed(tmp_path)
+        _seal_and_pin(audit_dir)
+        path = checkpoints_path(audit_dir)
+        doc = json.loads(path.read_text())
+        doc["payload"]["entry_count"] = 1
+        path.write_text(json.dumps(doc, sort_keys=True, separators=(",", ":")) + "\n")
+
+        with pytest.raises(CheckpointFileError):
+            load_checkpoints(audit_dir, _KEY)
+
+    def test_reordered_or_spliced_file_breaks_linkage(self, tmp_path: Path) -> None:
+        audit_dir = _seed(tmp_path)
+        _seal_and_pin(audit_dir)
+        AuditLog(audit_dir, key=_KEY).log("test.event", "tester", "task", "extra", {})
+        _seal_and_pin(audit_dir)
+
+        path = checkpoints_path(audit_dir)
+        first_line, second_line = path.read_text().splitlines()
+        path.write_text(second_line + "\n" + first_line + "\n")
+
+        with pytest.raises(CheckpointFileError):
+            load_checkpoints(audit_dir, _KEY)
+
+    def test_torn_trailing_append_regresses_to_the_previous_pin(self, tmp_path: Path) -> None:
+        """A crash mid-append costs freshness, never validity."""
+        audit_dir = _seed(tmp_path)
+        first = _seal_and_pin(audit_dir)
+        path = checkpoints_path(audit_dir)
+        with path.open("ab") as fh:
+            fh.write(b'{"payload": {"version"')
+
+        state = load_checkpoints(audit_dir, _KEY)
+        assert state.torn_tail is True
+        assert state.last == first
+
+    def test_missing_file_means_nothing_is_pinned(self, tmp_path: Path) -> None:
+        audit_dir = _seed(tmp_path)
+        state = load_checkpoints(audit_dir, _KEY)
+        assert state.last is None
+        assert state.checkpoints == []
+
+
+class TestChainQuantities:
+    def test_origin_is_the_first_record_and_survives_archiving(self, tmp_path: Path) -> None:
+        audit_dir = _seed(tmp_path)
+        segment = sorted(audit_dir.glob("*.jsonl"))[0]
+        first_hmac = json.loads(segment.read_bytes().split(b"\n")[0])["hmac"]
+        assert compute_origin(audit_dir) == first_hmac
+
+        segment.rename(audit_dir / "2020-01-01.jsonl")
+        AuditLog(audit_dir, key=_KEY).archive(RetentionPolicy())
+        assert compute_origin(audit_dir) == first_hmac
+
+    def test_count_ignores_garbage_lines(self, tmp_path: Path) -> None:
+        audit_dir = _seed(tmp_path, count=3)
+        assert count_entries(audit_dir) == 3
+        segment = sorted(audit_dir.glob("*.jsonl"))[0]
+        with segment.open("ab") as fh:
+            fh.write(b"not a record\n")
+        assert count_entries(audit_dir) == 3


### PR DESCRIPTION
## What this fixes

Two failures that exist on `main` today, both reproduced through real CLI invocations:

1. **A history shrink launders itself through the next seal.** A crash that truncates the newest segment back to a record boundary leaves the HMAC chain intact. `compute_seal`'s precheck only refuses on a broken chain, so the next scheduled `bernstein audit seal` recomputes a root over the shrunk history and `bernstein audit verify` goes green again. Sequence on main: verify exit 0, truncate 8 records to 4, seal exit 0, verify exit 0. Records are gone and nobody is paged.
2. **A crashed append can destroy the record being written (#3130).** `AuditLog.log` appended blindly onto an unterminated tail, fusing the fragment and the new record into one unparseable line: both records lost, later appends chained onto a stale predecessor. The tear model also assumed clean prefix truncation, but a crashed append can leave arbitrary garbage (size persisted before data blocks), including bytes that parse as JSON but fail their MAC, which tail recovery would previously adopt as the chain head.

## What ships

**Signed checkpoints make a shrink sticky.** After every successful seal, a checkpoint pins the chain origin (first record's HMAC), the total record count, and each sealed segment's exact byte length and content hash. Checkpoints live in `.sdd/audit/checkpoints/checkpoints.jsonl`: append-only with fsync, HMAC-signed with the audit key, each linked to the SHA-256 of its predecessor, outside `merkle/` (the seal job's write domain), and carrying no timestamps, so two identical directories produce byte-identical checkpoint files. `compute_seal` refuses unless the current tree is a consistent extension of the last checkpoint: record count monotonically non-decreasing, and every pinned leaf reproducible from the segment's current byte prefix (live or archived, so retention does not conflict). The old root is recomputed from prefixes of the new state, the RFC 6962 consistency check adapted to the per-day-segment tree. A shrunk or rewritten history exits non-zero naming the checkpoint it conflicts with, on every run.

**Garbage-tolerant tail detection.** Any non-verifying suffix of the chain's final segment classifies as a tear with the byte offset of the last verifiable record: a torn partial line (`partial_record`), a canonical-looking line that fails its MAC (`invalid_hmac`), bytes that are not UTF-8 (`garbage_bytes`), a whole record that lost only its terminator (`unterminated_record`). Damage in the middle of verified history stays a hard error: that is tampering, not a crash.

**Appends seal tears instead of destroying records.** Before appending, a writer that finds a torn tail writes the terminator and a chained `chain.torn_record` evidence event in one fsynced write (evidence and repair cannot be separated by a second crash), then appends its own record on top. Nothing is ever truncated or repaired in place. Chain-tail recovery now also requires a locally MAC-valid record, so an append never chains onto crash garbage that happens to parse. The tear probe sits behind the existing (path, size) fast path, so the append hot path is unchanged.

**Tear evidence is durable until acknowledged.** `verify` reports tears as a verdict distinct from chain corruption; sealing, appending, and re-sealing never clear it. The new `bernstein audit ack-tear --segment --offset --reason` command appends a chain-resident acknowledgement (as tamper-evident as the tear), which is the only thing that lets verification pass and the next seal record a new pin. When the tear is a checkpoint divergence, the acknowledgement names the conflicting checkpoint root; the superseded checkpoint stays on disk permanently. `--allow-broken-chain` still produces a forensic seal, and now never advances the checkpoint.

**Read paths stay total over sealed damage.** Torn bytes are permanent (append-only log, no truncation), so `query` and `scan_verified` now skip undecodable lines instead of raising forever: nothing is ever returned in smoothed form, and `verify` keeps naming the bytes. This changes two tests that pinned the raising behavior; the raise was also inconsistent (JSON-level corruption already skipped silently) and would have turned one acknowledged crash into a permanently broken query surface for every chain consumer.

## Proof

- `tests/integration/test_audit_chain_tear_stickiness.py` recreates the laundering sequence through the real CLI and asserts the flip: seal refuses naming the checkpoint, verify reports tear evidence, rerunning changes nothing, acknowledgement is the only path forward, growth seals cleanly. Plus: byte-identical checkpoints across two identical directories, verify against a `chmod -R a-w` audit dir, and a paced 8-process append test (zero lost, zero refused, chain verifies; marked slow).
- `tests/unit/test_audit_tear_detection.py` covers every tear class, the one-write seal, fusion prevention (#3130), evidence chaining, and forged-tail rejection.
- `tests/unit/test_chain_checkpoint.py` covers pinning, extension math, retention/archive transitions, acknowledgement authorization, and checkpoint-file append discipline (signature tamper, splice, torn trailing append).

## On #3130

Closes #3130. Two deliberate deviations from its proposed design, both stronger: `verify()` does not pass right after a seal (the sealed tear stays reported until acknowledged, because a repair that silently turns verification green is the same laundering shape this PR removes), and the partial-fragment arm never truncates to a sidecar (the log is append-only; the fragment stays in place as one isolated, permanently attributable line). All other acceptance criteria are met as written: no fused lines, chained evidence with `torn_bytes_sha256`, tampering with the seal record breaks verification, seal and following record are written under one lock section, and a failed seal write fails the append.

## Related, not closed

- #3062: `resync_head` now seals a torn tail before the head is read, so a caller inside `append_transaction` can no longer publish a head that a tear seal immediately supersedes. The issue's own acceptance criteria (multi-process false-anchor reproduction, verify reporting embedded-anchor mismatches) are not addressed here.
- #3063: the (path, size) freshness fast path is unchanged by this PR.

## Non-goals

- No tenant/charter work (that remains on its own branch, to be rebased separately).
- No static-file read layout: #3160 (v4.0.0).
- No witness co-signing of checkpoints: #3161 (v4.0.0). Until then, the guarantee is scoped to the local filesystem and the docs say so explicitly: rewinding both the chain and the checkpoints file to a mutually consistent earlier state is detectable only with retention outside the writer's host.
- No chain-lock changes. The current blocking `flock` semantics (wait, never refuse) are correct and stay. Migrating to open-file-description locks was considered and rejected for this PR: flock and fcntl record locks do not conflict with each other on Linux, so an upgrade window with old and new writers on the same audit dir would have zero mutual exclusion between them, which is the exact defect class this substrate exists to prevent.

## Docs

`docs/security/audit-log.md` no longer claims that the chain precheck alone prevents re-seal laundering (it does not, for a boundary truncation); it now documents the checkpoint gate, the tear lifecycle, the acknowledgement flow, and the local-filesystem scope of the guarantee. `scripts/check_docs_drift.py` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added signed checkpoints that detect audit-history truncation, rewrites, and unexpected divergence.
  * Added durable crash-tail (“tear”) evidence and the `audit ack-tear` command for explicitly acknowledging recoverable corruption.
  * Audit verification now reports checkpoint conflicts and unacknowledged tears clearly.

* **Bug Fixes**
  * Prevented fresh seals from being created over broken or inconsistent audit history.
  * Audit queries now skip invalid UTF-8 records while verification continues to flag the corruption.

* **Documentation**
  * Expanded security and recovery guidance for checkpoints, tears, acknowledgements, and forensic sealing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->