### PR TITLE
docs: record external listings found in the July coverage sweep

### DIFF
--- a/docs/mentions.md
+++ b/docs/mentions.md
@@ -40,11 +40,36 @@ when they appear; if one goes dead, open an issue or a PR.
 [vinta/awesome-python](https://github.com/vinta/awesome-python),
 [Zijian-Ni/awesome-ai-agents-2026](https://github.com/Zijian-Ni/awesome-ai-agents-2026),
 [rohitg00/awesome-devops-mcp-servers](https://github.com/rohitg00/awesome-devops-mcp-servers),
+[yzfly/Awesome-MCP-ZH](https://github.com/yzfly/Awesome-MCP-ZH),
+[tensorchord/Awesome-LLMOps](https://github.com/tensorchord/Awesome-LLMOps),
+[ai-boost/awesome-harness-engineering](https://github.com/ai-boost/awesome-harness-engineering),
+[Meirtz/Awesome-Context-Engineering](https://github.com/Meirtz/Awesome-Context-Engineering),
+[kyrolabs/awesome-agents](https://github.com/kyrolabs/awesome-agents),
+[TensorBlock/awesome-mcp-servers](https://github.com/TensorBlock/awesome-mcp-servers),
+[zgsm-ai/everything-ai-coding](https://github.com/zgsm-ai/everything-ai-coding),
+[Scottcjn/awesome-agents](https://github.com/Scottcjn/awesome-agents),
+[PierrunoYT/awesome-ai-dev-tools](https://github.com/PierrunoYT/awesome-ai-dev-tools),
+[erson/awesome-coding-agent-orchestration](https://github.com/erson/awesome-coding-agent-orchestration),
+[gabrielmoreira/awesome-ai-rabbit-holes](https://github.com/gabrielmoreira/awesome-ai-rabbit-holes),
+[cbruyndoncx/awesome-comparisons](https://github.com/cbruyndoncx/awesome-comparisons/blob/main/datasets/code-orchestration/data/bernstein.md),
 [Glama MCP Catalog](https://glama.ai/mcp/servers/sipyourdrink-ltd/bernstein).
 
 Mirrors: [icopy-site/awesome](https://github.com/icopy-site/awesome),
 [icopy-site/awesome-cn](https://github.com/icopy-site/awesome-cn),
 [trackawesomelist/trackawesomelist](https://github.com/trackawesomelist/trackawesomelist).
+
+Entries here are lists that have actually merged a Bernstein entry. Submissions
+we have opened and that are still awaiting a maintainer are not listed: a
+pending request is not coverage.
+
+## Packaged or installable by third parties
+
+Places where somebody else did the packaging work:
+
+- [normful/nixos-dotfiles](https://github.com/normful/nixos-dotfiles/blob/main/packages/bernstein/default.nix): a Nix derivation for Bernstein, written independently.
+- [sudosubin/nix-skills](https://github.com/sudosubin/nix-skills): Nixpkgs overlay carrying the Bernstein agent skill.
+- [agentskillexchange/skills](https://github.com/agentskillexchange/skills/blob/main/skills/run-deterministic-multi-agent-coding-workflows-with-bernstein/SKILL.md): a dedicated skill entry in the Agent Skill Exchange catalog.
+- [kevinelliott/agentmanager](https://github.com/kevinelliott/agentmanager): a CLI that detects, installs, and updates agent CLIs, Bernstein among them.
 
 ## Prior-art citations by peer projects
 
@@ -53,6 +78,23 @@ Mirrors: [icopy-site/awesome](https://github.com/icopy-site/awesome),
 - [AJV009/drupal-contrib-workbench](https://github.com/AJV009/drupal-contrib-workbench)
 - [danielvaughan/codex-blog](https://github.com/danielvaughan/codex-blog/blob/main/_posts/2026-04-09-loki-mode-autonomous-execution.md)
 
+## Contributor discovery
+
+- [up-for-grabs.net](https://github.com/up-for-grabs/up-for-grabs.net/blob/gh-pages/_data/projects/bernstein.yml): Bernstein's `up-for-grabs` issues are surfaced to people looking for something to work on.
+
 ## Directories
 
 - [AlternativeTo](https://alternativeto.net/software/bernstein/)
+- [MCP Servers Live](https://linny006.github.io/mcp-servers-live/r/sipyourdrink-ltd/bernstein/)
+- [Arnon-hs/open-source](https://github.com/Arnon-hs/open-source/blob/main/orchestration/sipyourdrink-ltd-bernstein.md)
+- [AllStreets/SMADP](https://github.com/AllStreets/SMADP/blob/main/catalog/profiles/bernstein.json)
+- [Yashagarwal9798/Agentstack](https://github.com/Yashagarwal9798/Agentstack)
+- [soe1hom-arch/developer-hub](https://github.com/soe1hom-arch/developer-hub/blob/main/cli-tools/bernstein.json)
+- [thoughtforge-us/library-of-alexander](https://github.com/thoughtforge-us/library-of-alexander/blob/main/08-ai-agents/README.md)
+- [zwl4488-new/aiagent-club](https://github.com/zwl4488-new/aiagent-club)
+- [patrickclery/awesomer](https://github.com/patrickclery/awesomer)
+- [jaimevalero/managing-awesome-lists-frontend](https://github.com/jaimevalero/managing-awesome-lists-frontend)
+- [PyDigger](https://github.com/szabgab/pydigger-data/blob/main/data/pypi/be/bernstein.json): automated PyPI metadata index.
+
+Most of the entries in this section are auto-generated crawls rather than
+editorial choices, and are recorded for completeness rather than as a signal.


### PR DESCRIPTION
A six-angle sweep (GitHub code search, general web, Reddit and forums, newsletters, directories, non-English and academic) produced 394 candidates. After deduplication against the existing list and per-page verification, 40 were confirmed to reference this project rather than one of the several well-known people and firms sharing the name.

Of those 40, **28 are recorded here and 12 are deliberately not.**

**Not recorded**: eleven are pull requests we opened ourselves that no maintainer has merged, and one is a self-submitted resource issue. A pending request is not coverage, and listing it as such would inflate the picture. The file now states that rule explicitly so the next person updating it does not have to rediscover it.

**Recorded**, in three groups:

- Thirteen curated lists that have merged an entry, including `yzfly/Awesome-MCP-ZH`, `tensorchord/Awesome-LLMOps`, `ai-boost/awesome-harness-engineering`, `Meirtz/Awesome-Context-Engineering`, `kyrolabs/awesome-agents`, and `TensorBlock/awesome-mcp-servers`.
- A new **packaging** section for surfaces where a third party did the work: an independently written Nix derivation, a Nixpkgs overlay carrying the skill, an Agent Skill Exchange entry, and an installer CLI that offers Bernstein among the agent CLIs it manages. These are worth separating from list entries because somebody chose to maintain integration code, not just a link.
- A contributor-discovery listing (`up-for-grabs.net`, which surfaces our `up-for-grabs` issues) and ten auto-generated directory crawls, the latter marked as recorded for completeness rather than as signal.

One near-miss worth noting: `composio-community/awesome-codex-skills` came back as new, but `ComposioHQ/awesome-codex-skills` redirects to it. Same repository after an org rename, already listed, so it was dropped.

`check_docs_drift.py` clean; 28 docs and README guard tests pass.

## Summary by Sourcery

Record newly discovered external listings and clarify what qualifies as coverage in the mentions documentation.

Documentation:
- Expand docs/mentions.md with additional curated list entries referencing the project.
- Add a new section documenting third-party packaging or install surfaces for Bernstein.
- Document contributor discovery coverage via up-for-grabs.net.
- Extend the directories section with auto-generated and curated catalog entries, noting their nature as signal vs completeness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the “Mentions and citations” documentation with additional repository, directory, packaging, and catalog references.
  * Added clarification about which Bernstein entries are included.
  * Added contributor discovery information and context about automatically generated directory listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->