### PR TITLE
fix: separate "ran nothing" from "passed" in the checks that report on it

### DIFF
--- a/docs/operations/ci.md
+++ b/docs/operations/ci.md
@@ -76,11 +76,19 @@ The measured cost of running the whole directory is 264s wall at
 critical path.
 
 Note that a file-level pass is not the same as a directory-level pass.
-`scripts/run_tests.py` reports a file whose tests all skip as `PASS`, and
-around a dozen files under `tests/integration/` are gated behind
+Around a dozen files under `tests/integration/` are gated behind
 credentials or SDKs a hosted runner does not have (`E2B_API_KEY`,
 `OPENAI_API_KEY`, `BERNSTEIN_TEST_API_KEY`, the object-store sinks, the
 opt-in `cluster_e2e` marker). Those files execute no assertions here.
+
+`scripts/run_tests.py` reports them as `NO TESTS` rather than `PASS`, and
+totals them separately (`Files: P passed, F failed, N ran no tests, T
+total`), so the passing count is a count of files that actually executed
+something. A file that ran nothing is not a failure - a credential-gated
+suite and an empty impact-based selection are both legitimate - but it is
+not evidence either. A file that exits 0 without a pytest terminal summary
+*is* a failure: pytest prints one on every completed run, so its absence
+means the subprocess stopped being pytest before it could report.
 
 ## macOS matrix policy (closes #1468)
 

--- a/scripts/check_data_freshness.py
+++ b/scripts/check_data_freshness.py
@@ -10,6 +10,10 @@ Thresholds:
 - 30 days  -> soft warning (printed, exit 0)
 - 60 days  -> hard fail when invoked with ``--strict`` (exit 1)
 
+An inventory entry whose file is not on disk fails on every invocation,
+``--strict`` or not: unlike a stale date, a path that no longer exists is
+silently checking nothing and does not fix itself with time.
+
 The strict mode is intended for the push-to-main branch of the
 ``docs-drift`` workflow under a non-required check name
 ``docs-data-freshness``; the soft mode is intended for pull-request runs.
@@ -60,6 +64,18 @@ def _parse_date(token: str) -> date | None:
         return None
 
 
+def missing_inventory_entries() -> list[str]:
+    """Return the inventory entries whose file is not on disk.
+
+    ``_scan_file`` used to return an empty result for a path that does not
+    exist, so a renamed or deleted doc quietly stopped being checked while the
+    script kept reporting that every marker was fresh. A missing entry is
+    either a stale list entry to remove or a file that went missing; both need
+    a human, and neither resolves itself the way a stale date does.
+    """
+    return [rel_path for rel_path in INVENTORY if not (REPO_ROOT / rel_path).exists()]
+
+
 def _scan_file(rel_path: str, today: date) -> list[tuple[int, str, int]]:
     """Return list of (line_no, line_text, age_days) for every marker."""
     path = REPO_ROOT / rel_path
@@ -98,6 +114,21 @@ def main(argv: list[str] | None = None) -> int:
             print(f"error: --today must be YYYY-MM-DD, got {args.today!r}", file=sys.stderr)
             return 2
         today = parsed_today
+
+    missing = missing_inventory_entries()
+    if missing:
+        print(f"::group::data-freshness missing inventory entries ({len(missing)})")
+        for rel_path in missing:
+            print(f"::error file=scripts/check_data_freshness.py::inventory entry has no file on disk: {rel_path}")
+        print("::endgroup::")
+        print(
+            f"data-freshness: {len(missing)} inventory entry/entries point at a file that "
+            "does not exist, so those paths are not being checked at all. Remove the stale "
+            "entry from INVENTORY (and the table in docs/playbooks/docs-drift.md), or "
+            "restore the file.",
+            file=sys.stderr,
+        )
+        return 1
 
     soft_hits: list[tuple[str, int, str, int]] = []
     hard_hits: list[tuple[str, int, str, int]] = []

--- a/scripts/review_bot_ack.py
+++ b/scripts/review_bot_ack.py
@@ -261,16 +261,11 @@ def classify_review_coverage(artifacts: list[BotArtifact], head_sha: str) -> lis
     return [classify_bot_run(login, artifacts, head_sha) for login in sorted(REVIEW_BOT_LOGINS)]
 
 
-def fetch_bot_artifacts(owner: str, repo: str, pr: int, token: str) -> list[BotArtifact]:
+def bot_artifacts_from(sources: dict[str, list[Any]]) -> list[BotArtifact]:
     """Collect every artefact the configured review bots left on the PR."""
-    base = f"https://api.github.com/repos/{owner}/{repo}"
     artifacts: list[BotArtifact] = []
-    for endpoint, kind in (
-        (f"{base}/pulls/{pr}/reviews", "review"),
-        (f"{base}/pulls/{pr}/comments", "review-comment"),
-        (f"{base}/issues/{pr}/comments", "issue-comment"),
-    ):
-        for item in paginate(endpoint, token):
+    for kind, items in sources.items():
+        for item in items:
             login = (item.get("user") or {}).get("login", "")
             if login not in REVIEW_BOT_LOGINS:
                 continue
@@ -285,11 +280,25 @@ def fetch_bot_artifacts(owner: str, repo: str, pr: int, token: str) -> list[BotA
     return artifacts
 
 
-def fetch_findings(owner: str, repo: str, pr: int, token: str) -> list[Finding]:
-    findings: list[Finding] = []
+def fetch_comment_sources(owner: str, repo: str, pr: int, token: str) -> dict[str, list[Any]]:
+    """Paginate each bot-comment endpoint once, keyed by artefact kind.
+
+    Findings and review coverage are both derived from these three lists, so
+    they are fetched here rather than in each consumer: ``paginate`` walks up
+    to 30 pages per endpoint and this gate runs on every pull request.
+    """
     base = f"https://api.github.com/repos/{owner}/{repo}"
-    review = paginate(f"{base}/pulls/{pr}/comments", token)
-    for c in review:
+    return {
+        "review": paginate(f"{base}/pulls/{pr}/reviews", token),
+        "review-comment": paginate(f"{base}/pulls/{pr}/comments", token),
+        "issue-comment": paginate(f"{base}/issues/{pr}/comments", token),
+    }
+
+
+def findings_from(sources: dict[str, list[Any]]) -> list[Finding]:
+    """Extract must-address / informational findings from fetched comments."""
+    findings: list[Finding] = []
+    for c in sources.get("review-comment", []):
         login = (c.get("user") or {}).get("login", "")
         if login not in REVIEW_BOT_LOGINS:
             continue
@@ -305,8 +314,7 @@ def fetch_findings(owner: str, repo: str, pr: int, token: str) -> list[Finding]:
                 html_url=c.get("html_url") or "",
             )
         )
-    issues = paginate(f"{base}/issues/{pr}/comments", token)
-    for c in issues:
+    for c in sources.get("issue-comment", []):
         login = (c.get("user") or {}).get("login", "")
         if login not in REVIEW_BOT_LOGINS:
             continue
@@ -368,15 +376,15 @@ def fixup_addresses(owner: str, repo: str, pr: int, token: str) -> set[str]:
 
 
 def evaluate(owner: str, repo: str, pr: int, token: str) -> GateOutcome:
-    findings = fetch_findings(owner, repo, pr, token)
+    sources = fetch_comment_sources(owner, repo, pr, token)
+    findings = findings_from(sources)
     body, head_sha = pr_body_and_head(owner, repo, pr, token)
     acked, nit_batch = ack_ids(body)
     commit_acks = fixup_addresses(owner, repo, pr, token)
-    artifacts = fetch_bot_artifacts(owner, repo, pr, token)
     out = GateOutcome(
         findings=findings,
         head_sha=head_sha,
-        bot_statuses=classify_review_coverage(artifacts, head_sha),
+        bot_statuses=classify_review_coverage(bot_artifacts_from(sources), head_sha),
     )
     for f in findings:
         if f.severity == "informational":

--- a/scripts/review_bot_ack.py
+++ b/scripts/review_bot_ack.py
@@ -7,6 +7,11 @@ informational (nit/style/note), and verifies every must-address finding is
 either acknowledged in the PR body via a `<!-- bot-ack: <id> ... -->` marker
 or addressed in a subsequent commit.
 
+It also tracks, per configured review bot, whether that bot actually produced
+a review for the current head commit. Zero findings from a bot that was rate
+limited is not the same result as zero findings from a bot that reviewed the
+diff and found nothing, and the summary reports the two differently.
+
 The gate posts a sticky summary comment on the PR (replacing any prior
 summary it posted) and exits 1 if any must-address finding is unresolved.
 
@@ -19,7 +24,8 @@ Required environment:
 
 Exit codes:
     0  Every must-address finding is fixed or acknowledged.
-    1  At least one must-address finding is open.
+    1  At least one must-address finding is open, or `--require-review` was
+       passed and some configured bot produced no review for the head commit.
     2  Internal error (HTTP failure, malformed JSON, etc.).
 """
 
@@ -65,6 +71,34 @@ INFORMATIONAL_PATTERNS = (
     r"\*\*note\*\*",
 )
 
+# Per-bot review coverage for the current head commit. Only BOT_REVIEWED is a
+# clean result: the other three each mean the finding count for that bot is
+# "not measured", which is not the same as "measured, and it was zero".
+BOT_REVIEWED = "reviewed"
+BOT_DECLINED = "declined"
+BOT_STALE = "stale"
+BOT_ABSENT = "absent"
+
+_BOT_STATUS_TEXT = {
+    BOT_REVIEWED: "reviewed this head commit",
+    BOT_DECLINED: "did not run (rate limited or otherwise declined)",
+    BOT_STALE: "reviewed an earlier head commit only",
+    BOT_ABSENT: "produced no review on this pull request",
+}
+
+# Bodies a review bot posts *instead of* a review. Matched case-insensitively.
+# Verbatim shapes: CodeRabbit's "Review limit reached" warning carries the
+# `rate limited by coderabbit.ai` marker comment; Sourcery replies with its
+# weekly diff-character limit as a submitted review.
+DID_NOT_RUN_PATTERNS = (
+    r"rate limited by coderabbit\.ai",
+    r"review limit reached",
+    r"you have reached your weekly rate limit",
+    r"reached your (?:daily|monthly) rate limit",
+)
+
+_SHA_RE = re.compile(r"\b[0-9a-f]{40}\b", re.IGNORECASE)
+
 STICKY_HEADER = "<!-- review-bot-ack-summary: managed -->"
 ACK_MARKER_RE = re.compile(
     r"<!--\s*bot-ack:\s*(?P<id>[\w./-]+)\s*(?:reason=(?P<reason>[^>]+?))?\s*-->",
@@ -90,11 +124,47 @@ class Finding:
 
 
 @dataclass
+class BotArtifact:
+    """One thing a review bot left on the PR.
+
+    ``commit_id`` is populated for submitted reviews and review comments and
+    is ``None`` for top-level issue comments, which is how CodeRabbit posts
+    its review; that shape is anchored via the head SHA in ``body`` instead.
+    """
+
+    author: str
+    body: str
+    commit_id: str | None = None
+    kind: str = "review"  # "review" | "review-comment" | "issue-comment"
+
+
+@dataclass
+class BotStatus:
+    """Whether one configured review bot reviewed the current head commit."""
+
+    login: str
+    status: str
+    detail: str = ""
+
+    @property
+    def clean(self) -> bool:
+        """True only when this bot actually produced a review for the head."""
+        return self.status == BOT_REVIEWED
+
+
+@dataclass
 class GateOutcome:
     findings: list[Finding] = field(default_factory=list)
     must_unresolved: list[Finding] = field(default_factory=list)
     must_acked: list[Finding] = field(default_factory=list)
     informational: list[Finding] = field(default_factory=list)
+    head_sha: str = ""
+    bot_statuses: list[BotStatus] = field(default_factory=list)
+
+    @property
+    def unreviewed_bots(self) -> list[BotStatus]:
+        """Configured bots whose finding count is not a measured zero."""
+        return [status for status in self.bot_statuses if not status.clean]
 
 
 def gh_request(
@@ -150,6 +220,71 @@ def classify(body: str) -> str:
     return "informational"
 
 
+def looks_like_a_declined_review(body: str) -> bool:
+    """True when a bot posted a rate-limit notice instead of a review."""
+    low = body.lower()
+    return any(re.search(pattern, low) for pattern in DID_NOT_RUN_PATTERNS)
+
+
+def covers_head(artifact: BotArtifact, head_sha: str) -> bool:
+    """True when this artefact is anchored to ``head_sha``.
+
+    Reviews and review comments carry ``commit_id``. Top-level comments do
+    not, so the head SHA is looked for among the 40-hex commit ids the body
+    names - CodeRabbit's summary states the range it reviewed.
+    """
+    if not head_sha:
+        return False
+    if artifact.commit_id and artifact.commit_id.lower() == head_sha.lower():
+        return True
+    return any(match.group(0).lower() == head_sha.lower() for match in _SHA_RE.finditer(artifact.body))
+
+
+def classify_bot_run(login: str, artifacts: list[BotArtifact], head_sha: str) -> BotStatus:
+    """Determine whether ``login`` produced a review for ``head_sha``."""
+    own = [artifact for artifact in artifacts if artifact.author == login]
+    if not own:
+        return BotStatus(login=login, status=BOT_ABSENT, detail=_BOT_STATUS_TEXT[BOT_ABSENT])
+
+    reviews_for_head = [a for a in own if covers_head(a, head_sha) and not looks_like_a_declined_review(a.body)]
+    if reviews_for_head:
+        return BotStatus(login=login, status=BOT_REVIEWED, detail=_BOT_STATUS_TEXT[BOT_REVIEWED])
+
+    if any(looks_like_a_declined_review(a.body) for a in own):
+        return BotStatus(login=login, status=BOT_DECLINED, detail=_BOT_STATUS_TEXT[BOT_DECLINED])
+
+    return BotStatus(login=login, status=BOT_STALE, detail=_BOT_STATUS_TEXT[BOT_STALE])
+
+
+def classify_review_coverage(artifacts: list[BotArtifact], head_sha: str) -> list[BotStatus]:
+    """Classify every configured review bot, seen on this PR or not."""
+    return [classify_bot_run(login, artifacts, head_sha) for login in sorted(REVIEW_BOT_LOGINS)]
+
+
+def fetch_bot_artifacts(owner: str, repo: str, pr: int, token: str) -> list[BotArtifact]:
+    """Collect every artefact the configured review bots left on the PR."""
+    base = f"https://api.github.com/repos/{owner}/{repo}"
+    artifacts: list[BotArtifact] = []
+    for endpoint, kind in (
+        (f"{base}/pulls/{pr}/reviews", "review"),
+        (f"{base}/pulls/{pr}/comments", "review-comment"),
+        (f"{base}/issues/{pr}/comments", "issue-comment"),
+    ):
+        for item in paginate(endpoint, token):
+            login = (item.get("user") or {}).get("login", "")
+            if login not in REVIEW_BOT_LOGINS:
+                continue
+            artifacts.append(
+                BotArtifact(
+                    author=login,
+                    body=item.get("body") or "",
+                    commit_id=item.get("commit_id"),
+                    kind=kind,
+                )
+            )
+    return artifacts
+
+
 def fetch_findings(owner: str, repo: str, pr: int, token: str) -> list[Finding]:
     findings: list[Finding] = []
     base = f"https://api.github.com/repos/{owner}/{repo}"
@@ -202,9 +337,11 @@ def fetch_findings(owner: str, repo: str, pr: int, token: str) -> list[Finding]:
     return findings
 
 
-def pr_body(owner: str, repo: str, pr: int, token: str) -> str:
-    data = gh_request("GET", f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr}", token)
-    return (data or {}).get("body") or ""
+def pr_body_and_head(owner: str, repo: str, pr: int, token: str) -> tuple[str, str]:
+    """Return the PR body and its current head SHA in one request."""
+    data = gh_request("GET", f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr}", token) or {}
+    head_sha = ((data.get("head") or {}).get("sha")) or ""
+    return data.get("body") or "", head_sha
 
 
 def ack_ids(body: str) -> tuple[set[str], bool]:
@@ -232,10 +369,15 @@ def fixup_addresses(owner: str, repo: str, pr: int, token: str) -> set[str]:
 
 def evaluate(owner: str, repo: str, pr: int, token: str) -> GateOutcome:
     findings = fetch_findings(owner, repo, pr, token)
-    body = pr_body(owner, repo, pr, token)
+    body, head_sha = pr_body_and_head(owner, repo, pr, token)
     acked, nit_batch = ack_ids(body)
     commit_acks = fixup_addresses(owner, repo, pr, token)
-    out = GateOutcome(findings=findings)
+    artifacts = fetch_bot_artifacts(owner, repo, pr, token)
+    out = GateOutcome(
+        findings=findings,
+        head_sha=head_sha,
+        bot_statuses=classify_review_coverage(artifacts, head_sha),
+    )
     for f in findings:
         if f.severity == "informational":
             out.informational.append(f)
@@ -251,6 +393,29 @@ def evaluate(owner: str, repo: str, pr: int, token: str) -> GateOutcome:
     return out
 
 
+def _render_review_coverage(outcome: GateOutcome) -> list[str]:
+    """Render the per-bot coverage block that qualifies the counts above."""
+    if not outcome.bot_statuses:
+        return []
+    head = f" for head `{outcome.head_sha[:8]}`" if outcome.head_sha else ""
+    lines = [f"### Review coverage{head}", ""]
+    for status in outcome.bot_statuses:
+        mark = "reviewed" if status.clean else "**not counted**"
+        lines.append(f"- `{status.login}`: {mark} - {status.detail}")
+    lines.append("")
+    unreviewed = outcome.unreviewed_bots
+    if unreviewed:
+        names = ", ".join(f"`{status.login}`" for status in unreviewed)
+        lines.append(
+            f"{len(unreviewed)} of {len(outcome.bot_statuses)} configured review bots "
+            f"({names}) produced no review for this head commit, so the finding counts "
+            "above are not a clean result: they are the counts from the bots that did "
+            "run. Re-request a review, or record why the gap is acceptable."
+        )
+        lines.append("")
+    return lines
+
+
 def render_summary(outcome: GateOutcome) -> str:
     lines = [STICKY_HEADER, "## Review-bot acknowledgement summary", ""]
     total_must = len(outcome.must_unresolved) + len(outcome.must_acked)
@@ -261,6 +426,7 @@ def render_summary(outcome: GateOutcome) -> str:
     )
     lines.append(f"- Informational findings: {len(outcome.informational)}")
     lines.append("")
+    lines.extend(_render_review_coverage(outcome))
     if outcome.must_unresolved:
         lines.append("### Open must-address findings")
         lines.append("")
@@ -276,6 +442,21 @@ def render_summary(outcome: GateOutcome) -> str:
     else:
         lines.append("All must-address findings are resolved or acknowledged.")
     return "\n".join(lines).rstrip() + "\n"
+
+
+def exit_code(outcome: GateOutcome, *, require_review: bool = False) -> int:
+    """Map an outcome to the process exit status.
+
+    An unreviewed bot fails only under ``--require-review``. `review-bot-ack`
+    is a required context on `main`, so an upstream rate limit turning into a
+    hard failure would wedge every open pull request; by default the gap is
+    reported in the summary and the gate keeps failing only on open findings.
+    """
+    if outcome.must_unresolved:
+        return 1
+    if require_review and outcome.unreviewed_bots:
+        return 1
+    return 0
 
 
 def upsert_sticky(owner: str, repo: str, pr: int, token: str, body: str) -> None:
@@ -317,6 +498,14 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Reserved; gate already fails on unresolved must-address.",
     )
+    p.add_argument(
+        "--require-review",
+        action="store_true",
+        help=(
+            "Also fail when a configured review bot produced no review for the "
+            "head commit, instead of only reporting the gap in the summary."
+        ),
+    )
     args = p.parse_args(argv)
 
     token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
@@ -338,7 +527,10 @@ def main(argv: list[str] | None = None) -> int:
         except Exception as exc:
             print(f"warning: could not post sticky summary: {exc}", file=sys.stderr)
 
-    return 1 if outcome.must_unresolved else 0
+    for status in outcome.unreviewed_bots:
+        print(f"warning: {status.login} {status.detail}", file=sys.stderr)
+
+    return exit_code(outcome, require_review=args.require_review)
 
 
 if __name__ == "__main__":

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 import time
@@ -65,6 +66,77 @@ DEFAULT_TEST_DIR = "tests/unit"
 # surfaces as this CPython error rather than a genuine test failure. A single
 # serial retry distinguishes the environmental flake from a real regression.
 _THREAD_EXHAUSTION_MARKER = "RuntimeError: can't start new thread"
+
+# Per-file outcomes. "Ran nothing" is a state of its own, not a flavour of
+# passing: a file whose tests all skipped, or that pytest collected nothing
+# from, executed no assertion and cannot be counted as evidence that the
+# suite ran. It stays non-fatal (a credential-gated integration file and an
+# empty impact-based selection are both legitimate), but it is reported and
+# totalled separately so "N files passed" means what a reviewer reads it as.
+OUTCOME_PASSED = "passed"
+OUTCOME_NO_TESTS = "no-tests"
+OUTCOME_FAILED = "failed"
+
+# pytest's terminal summary counts, e.g. "1 failed, 2 passed in 0.30s".
+_PYTEST_COUNT_RE = re.compile(
+    r"\b(?P<count>\d+)\s+(?P<outcome>passed|failed|error|errors|skipped|xfailed|xpassed|deselected)\b"
+)
+# The tail every completed pytest run prints, e.g. "in 0.30s" / "in 1.20 s".
+_PYTEST_DURATION_RE = re.compile(r"\bin\s+[\d.]+\s*s\b")
+_PYTEST_NO_TESTS_RE = re.compile(r"\bno tests ran\b", re.IGNORECASE)
+
+# Outcomes that mean a test body actually executed. ``skipped`` and
+# ``deselected`` are deliberately absent: neither ran anything.
+_EXECUTED_OUTCOMES = frozenset({"passed", "failed", "error", "errors", "xfailed", "xpassed"})
+
+
+def summarize_pytest_counts(output: str) -> dict[str, int] | None:
+    """Return pytest's terminal-summary counts, or ``None`` if there is none.
+
+    ``None`` is the load-bearing case: pytest prints a terminal summary on
+    every completed run, so its absence means the subprocess did not finish
+    as pytest. A test that reaches ``os.execv`` replaces the pytest process
+    with another program, which exits 0 having run nothing - the shape that
+    used to be indistinguishable from a pass.
+    """
+    for line in reversed(output.splitlines()):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if _PYTEST_NO_TESTS_RE.search(stripped):
+            return {}
+        if not _PYTEST_DURATION_RE.search(stripped):
+            continue
+        counts = {m.group("outcome"): int(m.group("count")) for m in _PYTEST_COUNT_RE.finditer(stripped)}
+        if counts:
+            return counts
+    return None
+
+
+def executed_test_count(counts: dict[str, int]) -> int:
+    """Number of tests whose body actually ran, per pytest's own counts."""
+    return sum(value for outcome, value in counts.items() if outcome in _EXECUTED_OUTCOMES)
+
+
+def classify_file_outcome(code: int, output: str) -> str:
+    """Classify one test file's subprocess result.
+
+    - ``OUTCOME_FAILED``: pytest reported a failure, *or* exited 0 without a
+      terminal summary (the process was replaced mid-run).
+    - ``OUTCOME_NO_TESTS``: pytest ran to completion and executed nothing
+      (exit code 5, or every test skipped).
+    - ``OUTCOME_PASSED``: pytest ran at least one test and none failed.
+    """
+    if code == 5:
+        return OUTCOME_NO_TESTS
+    if code != 0:
+        return OUTCOME_FAILED
+    counts = summarize_pytest_counts(output)
+    if counts is None:
+        return OUTCOME_FAILED
+    if executed_test_count(counts) == 0:
+        return OUTCOME_NO_TESTS
+    return OUTCOME_PASSED
 
 
 def test_file_timeout_seconds() -> int:
@@ -236,24 +308,46 @@ def _extract_failure_sections(lines: list[str]) -> list[str]:
     return result
 
 
-def _report_file_result(label: str, code: int, duration: float, output: str) -> bool:
-    """Report a single file result. Returns True if passed/skipped."""
+def _format_counts(counts: dict[str, int]) -> str:
+    """Render pytest's per-outcome counts for one line of the run log."""
+    if not counts:
+        return "nothing collected"
+    return ", ".join(f"{value} {outcome}" for outcome, value in sorted(counts.items()))
+
+
+def _report_file_result(label: str, code: int, duration: float, output: str) -> str:
+    """Report a single file result. Returns the ``OUTCOME_*`` classification."""
+    outcome = classify_file_outcome(code, output)
+    if outcome in (OUTCOME_PASSED, OUTCOME_NO_TESTS):
+        # Report pytest's own counts rather than whatever the subprocess
+        # happened to print last: with -s a test's stdout is not captured, so
+        # the last line is often unrelated to the result being reported.
+        counts = summarize_pytest_counts(output) or {}
+        detail = _format_counts(counts)
+        prefix = "PASS" if outcome == OUTCOME_PASSED else "NO TESTS"
+        print(f"  {prefix} {label} ({duration:.1f}s) {detail}")
+        return outcome
     if code == 0:
-        last_line = [ln for ln in output.strip().split("\n") if ln.strip()][-1] if output.strip() else ""
-        print(f"  PASS {label} ({duration:.1f}s) {last_line}")
-        return True
-    if code == 5:
-        print(f"  SKIP {label} (no tests)")
-        return True
+        # Exit 0 with no pytest terminal summary: the subprocess stopped being
+        # pytest before it could report. Nothing was verified.
+        print(f"  FAIL {label} ({duration:.1f}s) exited 0 without a pytest summary; the process was replaced mid-run")
+        _print_failure_summary(output)
+        return outcome
     print(f"  FAIL {label} ({duration:.1f}s)")
     _print_failure_summary(output)
-    return False
+    return outcome
+
+
+def _print_totals(passed: int, failed: int, no_tests: int, total: int) -> None:
+    """Print the per-file totals with ran-nothing broken out."""
+    print(f"Files: {passed} passed, {failed} failed, {no_tests} ran no tests, {total} total")
 
 
 def run_sequential(files: list[Path], extra_args: list[str], fail_fast: bool, coverage: bool = False) -> int:
     """Run test files one by one."""
     passed = 0
     failed = 0
+    no_tests = 0
     total_duration = 0.0
 
     for i, path in enumerate(files, 1):
@@ -273,15 +367,18 @@ def run_sequential(files: list[Path], extra_args: list[str], fail_fast: bool, co
             code, duration, output = retry
 
         total_duration += duration
-        if _report_file_result(label, code, duration, output):
+        outcome = _report_file_result(label, code, duration, output)
+        if outcome == OUTCOME_PASSED:
             passed += 1
+        elif outcome == OUTCOME_NO_TESTS:
+            no_tests += 1
         else:
             failed += 1
             if fail_fast:
                 break
 
     print(f"\n{'=' * 60}")
-    print(f"Files: {passed} passed, {failed} failed, {len(files)} total")
+    _print_totals(passed, failed, no_tests, len(files))
     print(f"Time:  {total_duration:.1f}s")
     return 1 if failed else 0
 
@@ -294,6 +391,7 @@ def run_parallel(
 
     passed = 0
     failed = 0
+    no_tests = 0
     done = 0
     total = len(files)
     abort = False
@@ -327,8 +425,11 @@ def run_parallel(
 
             done += 1
             label = f"[{done}/{total}] {fpath.name}"
-            if _report_file_result(label, code, duration, output):
+            outcome = _report_file_result(label, code, duration, output)
+            if outcome == OUTCOME_PASSED:
                 passed += 1
+            elif outcome == OUTCOME_NO_TESTS:
+                no_tests += 1
             else:
                 failed += 1
                 if fail_fast:
@@ -338,7 +439,7 @@ def run_parallel(
 
     wall_time = time.monotonic() - wall_start
     print(f"\n{'=' * 60}")
-    print(f"Files: {passed} passed, {failed} failed, {total} total")
+    _print_totals(passed, failed, no_tests, total)
     print(f"Wall:  {wall_time:.1f}s ({workers} workers)")
     return 1 if failed else 0
 

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -1623,8 +1623,25 @@ def exec_restart() -> None:
     image entirely - no orphan.  On Windows, ``os.execv`` does not truly
     replace the process (it spawns a child), so we use ``subprocess.Popen``
     and ``sys.exit`` instead.
+
+    Refuses to run inside a pytest process. A test that hands the dashboard a
+    bare ``MagicMock`` gets a truthy ``_restart_on_exit`` - every attribute of
+    a bare MagicMock is truthy - so the caller reaches this function and the
+    ``os.execv`` below replaces the running pytest process. The run then
+    prints no test results and exits 0, which is indistinguishable from a
+    pass, and the whole file silently stops protecting anything. Raising here
+    turns that into a loud failure in the offending test.
     """
     import subprocess
+
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        raise RuntimeError(
+            "exec_restart() refuses to re-exec inside a pytest process "
+            "(PYTEST_CURRENT_TEST is set): replacing the process would end the "
+            "test run with no results and a zero exit code. Patch "
+            "bernstein.cli.run_bootstrap.exec_restart, or give the dashboard "
+            "double an explicit falsy _restart_on_exit."
+        )
 
     argv = [sys.executable, "-m", "bernstein.cli.main", "run"]
     if sys.platform == "win32":

--- a/tests/integration/endpoints/test_certify_verify.py
+++ b/tests/integration/endpoints/test_certify_verify.py
@@ -2,20 +2,27 @@
 
 Spins up an in-process fake OpenAI-compatible HTTP server.
 No external service needed.
+
+The product modules are imported at module scope on purpose. `_run_certify`
+and `_run_verify` used to catch `ImportError` and fall back to
+reimplementations defined in this file, so blocking
+`bernstein.core.endpoints.certify` and `.verify` still left 22 of 30 tests
+passing - against the test file's own shims, with the product unimportable.
+An ImportError here now fails collection, which is the honest signal.
 """
 
 from __future__ import annotations
 
 import json
 import threading
-import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from pathlib import Path
 from typing import Any
 
 import pytest
 
+from bernstein.core.endpoints.certify import certify_endpoint
 from bernstein.core.endpoints.conformance import PATCH_REFERENCE_DIFF
+from bernstein.core.endpoints.verify import verify_cert
 
 # ---------------------------------------------------------------------------
 # Fake OpenAI-compatible server
@@ -163,153 +170,13 @@ def fake_oai_server():
 
 
 def _run_certify(base_url, model, out_dir, token="", strict=False, timeout=5):
-    try:
-        from bernstein.core.endpoints.certify import certify_endpoint
-
-        return certify_endpoint(
-            base_url=base_url, token=token, model=model, out_dir=out_dir, strict=strict, timeout=timeout
-        )
-    except ImportError:
-        return _shim_certify(base_url, model, out_dir, token, strict, timeout)
-
-
-def _shim_certify(base_url, model, out_dir, token, strict, timeout):
-    import hashlib
-    import urllib.error
-    import urllib.request
-
-    probes = []
-
-    def _get(path):
-        req = urllib.request.Request(base_url.rstrip("/") + path)
-        if token:
-            req.add_header("Authorization", f"Bearer {token}")
-        try:
-            with urllib.request.urlopen(req, timeout=timeout) as r:
-                return r.status, r.read()
-        except Exception:
-            return 0, b""
-
-    def _post(path, payload):
-        data = json.dumps(payload).encode()
-        req = urllib.request.Request(
-            base_url.rstrip("/") + path,
-            data=data,
-            headers={"Content-Type": "application/json"},
-        )
-        if token:
-            req.add_header("Authorization", f"Bearer {token}")
-        try:
-            with urllib.request.urlopen(req, timeout=timeout) as r:
-                return r.status, r.read()
-        except urllib.error.HTTPError as e:
-            return e.code, b""
-        except Exception:
-            return 0, b""
-
-    # Probe 1: GET /v1/models
-    status, _ = _get("/models")
-    probes.append({"id": "models_list", "required": True, "passed": status == 200})
-
-    # Probe 2: POST chat completions (non-streaming)
-    status, body = _post("/chat/completions", {"model": model, "messages": [{"role": "user", "content": "ping"}]})
-    parsed = json.loads(body) if status == 200 and body else {}
-    probes.append({"id": "chat_completions", "required": True, "passed": status == 200})
-
-    # Probe 3: streaming — check status and that response contains SSE data
-    status_s, body_s = _post(
-        "/chat/completions", {"model": model, "messages": [{"role": "user", "content": "ping"}], "stream": True}
+    return certify_endpoint(
+        base_url=base_url, token=token, model=model, out_dir=out_dir, strict=strict, timeout=timeout
     )
-    streaming_ok = status_s == 200 and b"data:" in body_s
-    probes.append({"id": "chat_streaming", "required": True, "passed": streaming_ok})
-
-    # Probe 4: tool_calls (optional)
-    status_t, body_t = _post(
-        "/chat/completions",
-        {
-            "model": model,
-            "messages": [{"role": "user", "content": "read foo.py"}],
-            "tools": [
-                {
-                    "type": "function",
-                    "function": {
-                        "name": "read_file",
-                        "description": "read",
-                        "parameters": {"type": "object", "properties": {"path": {"type": "string"}}},
-                    },
-                }
-            ],
-        },
-    )
-    tool_ok = False
-    if status_t == 200 and body_t:
-        resp = json.loads(body_t)
-        choices = resp.get("choices", [])
-        tool_ok = bool(choices and choices[0].get("message", {}).get("tool_calls"))
-    probes.append({"id": "tool_calls", "required": False, "passed": tool_ok})
-
-    # Probe 5: finish_reason present
-    finish_ok = False
-    if parsed:
-        choices = parsed.get("choices", [])
-        finish_ok = bool(choices and choices[0].get("finish_reason"))
-    probes.append({"id": "finish_reason", "required": True, "passed": finish_ok})
-
-    # Probe 6: role=assistant present
-    role_ok = False
-    if parsed:
-        choices = parsed.get("choices", [])
-        role_ok = bool(choices and choices[0].get("message", {}).get("role") == "assistant")
-    probes.append({"id": "assistant_role", "required": True, "passed": role_ok})
-
-    required_failed = [p for p in probes if p["required"] and not p["passed"]]
-    optional_failed = [p for p in probes if not p["required"] and not p["passed"]]
-    passed = len(required_failed) == 0 and (not strict or len(optional_failed) == 0)
-
-    certified_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
-    fingerprint = hashlib.sha256(f"{base_url}|{model}|{certified_at}".encode()).hexdigest()[:16]
-
-    record = {
-        "schema": "bernstein.endpoint.certification.v1",
-        "base_url": base_url,
-        "model": model,
-        "certified_at": certified_at,
-        "probes": probes,
-        "passed": passed,
-        "install_key_fp": "ed25519/shim-test-key",
-        "signature": f"shim-sig-{fingerprint}",
-    }
-
-    out_dir = Path(out_dir)
-    out_dir.mkdir(parents=True, exist_ok=True)
-    (out_dir / f"{fingerprint}.json").write_text(json.dumps(record, indent=2))
-    return record
 
 
-def _run_verify(cert_path, *, skip_signature=True):
-    try:
-        from bernstein.core.endpoints.verify import verify_cert
-
-        return verify_cert(cert_path=cert_path)
-    except ImportError:
-        return _shim_verify(cert_path)
-
-
-def _shim_verify(cert_path):
-    record = json.loads(Path(cert_path).read_text())
-    assert record.get("schema") == "bernstein.endpoint.certification.v1"
-    assert "base_url" in record
-    assert "model" in record
-    assert "certified_at" in record
-    assert isinstance(record.get("probes"), list)
-    assert "passed" in record
-    assert "install_key_fp" in record
-    assert "signature" in record
-    for probe in record["probes"]:
-        assert "id" in probe
-        assert "required" in probe
-        assert "passed" in probe
-    return {"valid": True, "record": record}
+def _run_verify(cert_path):
+    return verify_cert(cert_path=cert_path)
 
 
 # ---------------------------------------------------------------------------
@@ -406,11 +273,10 @@ class TestVerifyLoop:
         record = json.loads(cert_path.read_text())
         record["base_url"] = "http://evil.example.com/v1"
         cert_path.write_text(json.dumps(record))
-        try:
-            result = _run_verify(cert_path, skip_signature=False)
-            assert result.get("valid") is False
-        except Exception:
-            pass  # tampered cert raising is also acceptable
+        # Editing a signed field breaks the Ed25519 signature over the
+        # canonical binding, so verification fails closed and deterministically.
+        result = _run_verify(cert_path)
+        assert result["valid"] is False
 
     def test_verify_cert_preserves_base_url(self, fake_oai_server, tmp_path):
         out_dir = tmp_path / "certs"
@@ -512,10 +378,10 @@ class TestCertifyDifferentModels:
 
 class TestIntegrationsListEntry:
     def test_use_case_entry_exists(self):
-        try:
-            from bernstein.adapters.use_cases import USE_CASES
-        except ImportError:
-            pytest.skip("use_cases module not importable")
+        # Imported here rather than guarded by a skip: a use-case catalogue
+        # that stopped importing is a product regression, not a reason for
+        # this test to report itself green without checking anything.
+        from bernstein.adapters.use_cases import USE_CASES
 
         if isinstance(USE_CASES, dict):
             assert "self-hosted-endpoints" in USE_CASES, "USE_CASES missing 'self-hosted-endpoints' key"

--- a/tests/unit/scripts/test_check_data_freshness.py
+++ b/tests/unit/scripts/test_check_data_freshness.py
@@ -1,0 +1,95 @@
+"""A freshness inventory entry whose file is missing must be reported.
+
+``scripts/check_data_freshness.py`` walks a hand-maintained ``INVENTORY`` of
+docs carrying ``as of YYYY-MM-DD`` markers. ``_scan_file`` returned an empty
+result for a path that does not exist, so a renamed or deleted doc quietly
+stopped being checked while the script kept printing that every marker was
+fresh. Two entries had been inert for that reason before anyone noticed.
+
+A missing entry is either a stale list entry to remove or a file that went
+missing; both need a human, so the script reports it and fails rather than
+skipping it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from collections.abc import Generator
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check_data_freshness.py"
+
+
+@pytest.fixture
+def freshness_module() -> Generator[ModuleType, None, None]:
+    """Load scripts/check_data_freshness.py as an importable module."""
+    spec = importlib.util.spec_from_file_location("check_data_freshness_under_test", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    yield module
+    sys.modules.pop(spec.name, None)
+
+
+def test_missing_inventory_entries_are_listed(freshness_module: ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``missing_inventory_entries`` names every entry with no file on disk."""
+    monkeypatch.setattr(
+        freshness_module,
+        "INVENTORY",
+        ("README.md", "docs/deleted-in-a-rename.md"),
+    )
+    assert freshness_module.missing_inventory_entries() == ["docs/deleted-in-a-rename.md"]
+
+
+def test_shipped_inventory_has_no_missing_entries(freshness_module: ModuleType) -> None:
+    """Every entry the repo ships today points at a file that exists."""
+    assert freshness_module.missing_inventory_entries() == []
+
+
+def test_missing_entry_fails_the_check(
+    freshness_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A missing entry exits non-zero and names the path, without --strict.
+
+    Staleness is temporal and resolves itself; a missing inventory entry does
+    not, so it is reported the same way on every invocation.
+    """
+    monkeypatch.setattr(
+        freshness_module,
+        "INVENTORY",
+        ("README.md", "docs/deleted-in-a-rename.md"),
+    )
+
+    rc = freshness_module.main(["--today", "2026-01-01"])
+
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert rc == 1
+    assert "docs/deleted-in-a-rename.md" in combined
+    assert "missing" in combined.lower()
+
+
+def test_intact_inventory_still_reports_fresh(
+    freshness_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """With every entry present and fresh the check stays green."""
+    doc = tmp_path / "fresh.md"
+    doc.write_text("Downloads as of 2026-01-01: 12345\n", encoding="utf-8")
+    monkeypatch.setattr(freshness_module, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(freshness_module, "INVENTORY", ("fresh.md",))
+
+    rc = freshness_module.main(["--today", "2026-01-10"])
+
+    assert rc == 0
+    assert "all markers under" in capsys.readouterr().out

--- a/tests/unit/scripts/test_review_bot_ack_run_detection.py
+++ b/tests/unit/scripts/test_review_bot_ack_run_detection.py
@@ -133,6 +133,36 @@ def test_pr_3041_shape_reports_both_bots_as_not_run(ack: ModuleType) -> None:
     assert {s.login: s.clean for s in statuses} == {SOURCERY: False, CODERABBIT: False}
 
 
+def test_bot_artifacts_are_built_from_the_fetched_comment_sources(ack: ModuleType) -> None:
+    """Every fetched source contributes artefacts, tagged with its kind."""
+    sources = {
+        "review": [{"user": {"login": SOURCERY}, "body": SOURCERY_CLEAN_REVIEW, "commit_id": HEAD}],
+        "review-comment": [{"user": {"login": CODERABBIT}, "body": "nit: spacing", "commit_id": HEAD}],
+        "issue-comment": [
+            {"user": {"login": CODERABBIT}, "body": CODERABBIT_CLEAN_REVIEW},
+            {"user": {"login": "chernistry"}, "body": "a human comment"},
+        ],
+    }
+    artifacts = ack.bot_artifacts_from(sources)
+    assert [(a.author, a.kind) for a in artifacts] == [
+        (SOURCERY, "review"),
+        (CODERABBIT, "review-comment"),
+        (CODERABBIT, "issue-comment"),
+    ]
+
+
+def test_each_comment_endpoint_is_paginated_once(ack: ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Findings and coverage share one fetch instead of walking twice.
+
+    ``paginate`` follows up to 30 pages per endpoint and this gate runs on
+    every pull request, so a second sweep of the same endpoints is real cost.
+    """
+    calls: list[str] = []
+    monkeypatch.setattr(ack, "paginate", lambda url, token: calls.append(url) or [])
+    ack.fetch_comment_sources("owner", "repo", 1, "token")
+    assert len(calls) == len(set(calls)) == 3
+
+
 # --- summary rendering -----------------------------------------------------
 
 

--- a/tests/unit/scripts/test_review_bot_ack_run_detection.py
+++ b/tests/unit/scripts/test_review_bot_ack_run_detection.py
@@ -1,0 +1,200 @@
+"""A review bot that never ran must not be reported as a clean zero.
+
+``scripts/review_bot_ack.py`` backs one of the two required contexts on
+``main``, and its sticky summary is the artefact a human reads to decide
+whether the bot findings were dealt with. It counted findings and nothing
+else, so a bot that was rate limited and produced no review at all
+contributed zero findings and the summary read::
+
+    - Must-address findings: 0 (0 acknowledged, 0 open)
+
+which is the same sentence a fully reviewed, genuinely clean PR gets.
+
+These tests pin the per-bot run detection: a review anchored to the current
+head commit is the only clean result, and a rate-limit notice, a review of an
+older head, or no artefact at all are each reported as their own state.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from collections.abc import Generator
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "review_bot_ack.py"
+
+HEAD = "1932e7b4b3200f7f5e15b3e17f39323a751e8da8"
+OLDER = "67e724044f1beb34f2b571ec359152f0f937e4f7"
+
+CODERABBIT = "coderabbitai[bot]"
+SOURCERY = "sourcery-ai[bot]"
+
+# Verbatim shapes observed on sipyourdrink-ltd/bernstein#3041 and #3165.
+SOURCERY_RATE_LIMIT = "Sorry @chernistry, you have reached your weekly rate limit of 500000 diff characters.\n"
+SOURCERY_CLEAN_REVIEW = "Hey - I've reviewed your changes and they look great!\n"
+CODERABBIT_RATE_LIMIT = (
+    "<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n"
+    "<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->\n"
+    "> [!WARNING]\n> ## Review limit reached\n"
+)
+CODERABBIT_CLEAN_REVIEW = (
+    "<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n"
+    "No actionable comments were generated in the recent review.\n"
+    f"Reviewing files that changed from the base of the PR and between {OLDER} and {HEAD}.\n"
+)
+
+
+@pytest.fixture
+def ack() -> Generator[ModuleType, None, None]:
+    """Load scripts/review_bot_ack.py as an importable module."""
+    spec = importlib.util.spec_from_file_location("review_bot_ack_under_test", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    yield module
+    sys.modules.pop(spec.name, None)
+
+
+def _artifact(ack: ModuleType, author: str, body: str, commit_id: str | None = None, kind: str = "review"):
+    return ack.BotArtifact(author=author, body=body, commit_id=commit_id, kind=kind)
+
+
+# --- per-bot run detection -------------------------------------------------
+
+
+def test_review_on_head_sha_is_a_clean_result(ack: ModuleType) -> None:
+    """A real review anchored to the head commit is the only clean state."""
+    artifacts = [_artifact(ack, SOURCERY, SOURCERY_CLEAN_REVIEW, commit_id=HEAD)]
+    status = ack.classify_bot_run(SOURCERY, artifacts, HEAD)
+    assert status.status == ack.BOT_REVIEWED
+    assert status.clean is True
+
+
+def test_summary_naming_the_head_sha_counts_as_reviewed(ack: ModuleType) -> None:
+    """An issue comment with no ``commit_id`` still anchors via its body.
+
+    CodeRabbit posts its review as a top-level comment, which carries no
+    ``commit_id`` field, but names the reviewed range in the body.
+    """
+    artifacts = [_artifact(ack, CODERABBIT, CODERABBIT_CLEAN_REVIEW, kind="issue-comment")]
+    status = ack.classify_bot_run(CODERABBIT, artifacts, HEAD)
+    assert status.status == ack.BOT_REVIEWED
+
+
+def test_rate_limited_sourcery_review_is_not_a_review(ack: ModuleType) -> None:
+    """A rate-limit notice submitted as a review does not count as reviewed."""
+    artifacts = [_artifact(ack, SOURCERY, SOURCERY_RATE_LIMIT, commit_id=HEAD)]
+    status = ack.classify_bot_run(SOURCERY, artifacts, HEAD)
+    assert status.status == ack.BOT_DECLINED
+    assert status.clean is False
+
+
+def test_rate_limited_coderabbit_comment_is_not_a_review(ack: ModuleType) -> None:
+    """CodeRabbit's review-limit warning does not count as reviewed."""
+    artifacts = [_artifact(ack, CODERABBIT, CODERABBIT_RATE_LIMIT, kind="issue-comment")]
+    status = ack.classify_bot_run(CODERABBIT, artifacts, HEAD)
+    assert status.status == ack.BOT_DECLINED
+
+
+def test_review_of_an_older_head_is_stale(ack: ModuleType) -> None:
+    """A review that covers only a superseded commit is not a clean result."""
+    artifacts = [_artifact(ack, SOURCERY, SOURCERY_CLEAN_REVIEW, commit_id=OLDER)]
+    status = ack.classify_bot_run(SOURCERY, artifacts, HEAD)
+    assert status.status == ack.BOT_STALE
+    assert status.clean is False
+
+
+def test_no_artifact_at_all_is_absent(ack: ModuleType) -> None:
+    """A configured bot with nothing on the PR is reported as absent."""
+    status = ack.classify_bot_run(CODERABBIT, [], HEAD)
+    assert status.status == ack.BOT_ABSENT
+    assert status.clean is False
+
+
+def test_only_the_named_bot_is_considered(ack: ModuleType) -> None:
+    """One bot's review never stands in for another bot's."""
+    artifacts = [_artifact(ack, SOURCERY, SOURCERY_CLEAN_REVIEW, commit_id=HEAD)]
+    assert ack.classify_bot_run(CODERABBIT, artifacts, HEAD).status == ack.BOT_ABSENT
+
+
+def test_pr_3041_shape_reports_both_bots_as_not_run(ack: ModuleType) -> None:
+    """The exact artefact set from #3041: neither bot produced a review."""
+    artifacts = [
+        _artifact(ack, SOURCERY, SOURCERY_RATE_LIMIT, commit_id=OLDER),
+        _artifact(ack, CODERABBIT, CODERABBIT_RATE_LIMIT, kind="issue-comment"),
+    ]
+    statuses = ack.classify_review_coverage(artifacts, HEAD)
+    assert {s.login: s.clean for s in statuses} == {SOURCERY: False, CODERABBIT: False}
+
+
+# --- summary rendering -----------------------------------------------------
+
+
+def _outcome(ack: ModuleType, statuses: list[object]):
+    return ack.GateOutcome(head_sha=HEAD, bot_statuses=statuses)
+
+
+def test_summary_flags_zero_findings_from_a_bot_that_never_ran(ack: ModuleType) -> None:
+    """Zero findings plus a bot that did not run is not presented as clean."""
+    artifacts = [
+        _artifact(ack, SOURCERY, SOURCERY_RATE_LIMIT, commit_id=OLDER),
+        _artifact(ack, CODERABBIT, CODERABBIT_RATE_LIMIT, kind="issue-comment"),
+    ]
+    outcome = _outcome(ack, ack.classify_review_coverage(artifacts, HEAD))
+
+    summary = ack.render_summary(outcome)
+
+    assert "Must-address findings: **0**" in summary
+    assert "not a clean result" in summary
+    assert SOURCERY in summary
+    assert CODERABBIT in summary
+
+
+def test_summary_reports_a_fully_reviewed_pr_as_clean(ack: ModuleType) -> None:
+    """When every bot reviewed the head commit the caveat is absent."""
+    artifacts = [
+        _artifact(ack, SOURCERY, SOURCERY_CLEAN_REVIEW, commit_id=HEAD),
+        _artifact(ack, CODERABBIT, CODERABBIT_CLEAN_REVIEW, kind="issue-comment"),
+    ]
+    outcome = _outcome(ack, ack.classify_review_coverage(artifacts, HEAD))
+
+    summary = ack.render_summary(outcome)
+
+    assert "not a clean result" not in summary
+    assert "All must-address findings are resolved or acknowledged." in summary
+
+
+def test_summary_lists_every_configured_bot(ack: ModuleType) -> None:
+    """The coverage section enumerates the configured bots, not just seen ones."""
+    outcome = _outcome(ack, ack.classify_review_coverage([], HEAD))
+    summary = ack.render_summary(outcome)
+    for login in ack.REVIEW_BOT_LOGINS:
+        assert login in summary
+
+
+# --- exit status -----------------------------------------------------------
+
+
+def test_require_review_fails_when_a_bot_did_not_run(ack: ModuleType) -> None:
+    """``--require-review`` turns an unreviewed bot into a gate failure."""
+    artifacts = [_artifact(ack, SOURCERY, SOURCERY_RATE_LIMIT, commit_id=OLDER)]
+    outcome = _outcome(ack, ack.classify_review_coverage(artifacts, HEAD))
+    assert outcome.unreviewed_bots
+    assert ack.exit_code(outcome, require_review=True) == 1
+
+
+def test_default_exit_status_is_unchanged_by_an_unreviewed_bot(ack: ModuleType) -> None:
+    """Without the flag the gate keeps failing only on open findings.
+
+    ``review-bot-ack`` is a required context, so an upstream rate limit must
+    not wedge every PR on the repository by default.
+    """
+    artifacts = [_artifact(ack, SOURCERY, SOURCERY_RATE_LIMIT, commit_id=OLDER)]
+    outcome = _outcome(ack, ack.classify_review_coverage(artifacts, HEAD))
+    assert ack.exit_code(outcome, require_review=False) == 0

--- a/tests/unit/scripts/test_run_tests_zero_test_outcomes.py
+++ b/tests/unit/scripts/test_run_tests_zero_test_outcomes.py
@@ -1,0 +1,214 @@
+"""A file that ran no tests must not be reported as a passing file.
+
+``scripts/run_tests.py`` is the shard runner behind the required ``CI gate``
+context, and its ``Files: N passed`` line is what a reviewer reads as evidence
+that a suite executed. Three distinct outcomes used to collapse into that one
+number:
+
+- a file whose tests all skipped at runtime (missing credential, absent
+  optional dependency) exited 0 and was counted as passed;
+- a file pytest collected nothing from (exit code 5) was counted as passed;
+- a file whose pytest process was replaced mid-run (a test reaching
+  ``os.execv``) exited 0 with no pytest summary at all and was counted as
+  passed.
+
+The first two are legitimate states that must stay non-fatal but must be
+counted separately. The third is a file that stopped protecting anything
+without saying so, and is a hard failure.
+
+These tests pin the classification and the totals line.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from collections.abc import Generator
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "run_tests.py"
+
+
+@pytest.fixture
+def run_tests_module() -> Generator[ModuleType, None, None]:
+    """Load scripts/run_tests.py as an importable module."""
+    spec = importlib.util.spec_from_file_location("run_tests_zero_outcomes", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    yield module
+    sys.modules.pop(spec.name, None)
+
+
+# --- summarize_pytest_counts ----------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("output", "expected"),
+    [
+        ("5 passed in 0.12s", {"passed": 5}),
+        ("1 failed, 2 passed in 0.30s", {"failed": 1, "passed": 2}),
+        ("13 skipped in 3.10s", {"skipped": 13}),
+        ("5 passed, 1 warning in 0.12s", {"passed": 5}),
+        ("2 xfailed, 1 xpassed in 0.20s", {"xfailed": 2, "xpassed": 1}),
+        ("no tests ran in 0.01s", {}),
+        ("3 passed, 2 deselected in 0.10s", {"passed": 3, "deselected": 2}),
+    ],
+)
+def test_summarize_pytest_counts_reads_the_terminal_summary(
+    run_tests_module: ModuleType, output: str, expected: dict[str, int]
+) -> None:
+    """Every pytest terminal-summary shape yields its per-outcome counts."""
+    assert run_tests_module.summarize_pytest_counts(output) == expected
+
+
+def test_summarize_pytest_counts_ignores_leading_progress_output(run_tests_module: ModuleType) -> None:
+    """The summary is found even behind progress dots and captured stdout."""
+    output = "some captured print\n.....                        [100%]\n5 passed in 0.12s\n"
+    assert run_tests_module.summarize_pytest_counts(output) == {"passed": 5}
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        "",
+        "   \n\n",
+        "Bernstein starting\nOrchestrator ready\n",
+    ],
+)
+def test_summarize_pytest_counts_is_none_without_a_summary(run_tests_module: ModuleType, output: str) -> None:
+    """Output that carries no pytest terminal summary is reported as absent.
+
+    This is the ``os.execv`` shape: the pytest process was replaced, so the
+    output belongs to some other program entirely.
+    """
+    assert run_tests_module.summarize_pytest_counts(output) is None
+
+
+# --- classify_file_outcome -------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("code", "output", "expected"),
+    [
+        (0, "5 passed in 0.12s", "passed"),
+        (0, "3 passed, 2 skipped in 0.20s", "passed"),
+        (0, "2 xfailed, 1 xpassed in 0.20s", "passed"),
+        # Every test in the file skipped: the file executed nothing.
+        (0, "13 skipped in 3.10s", "no-tests"),
+        # pytest exit 5: nothing was collected.
+        (5, "no tests ran in 0.01s", "no-tests"),
+        (1, "1 failed, 2 passed in 0.30s", "failed"),
+        (2, "ERROR: usage error", "failed"),
+        # Process replaced mid-run: exit 0, no pytest summary anywhere.
+        (0, "", "failed"),
+        (0, "Bernstein starting\nOrchestrator ready\n", "failed"),
+    ],
+)
+def test_classify_file_outcome(run_tests_module: ModuleType, code: int, output: str, expected: str) -> None:
+    """A file's outcome separates passed, ran-nothing, and failed."""
+    assert run_tests_module.classify_file_outcome(code, output) == expected
+
+
+def test_outcome_constants_are_distinct(run_tests_module: ModuleType) -> None:
+    """The three outcomes are three values, not two."""
+    outcomes = {
+        run_tests_module.OUTCOME_PASSED,
+        run_tests_module.OUTCOME_NO_TESTS,
+        run_tests_module.OUTCOME_FAILED,
+    }
+    assert len(outcomes) == 3
+
+
+# --- reporting -------------------------------------------------------------
+
+
+def test_report_file_result_labels_a_file_that_ran_nothing(
+    run_tests_module: ModuleType, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """An all-skipped file is not printed as PASS."""
+    outcome = run_tests_module._report_file_result("[1/1] test_x.py", 0, 3.1, "13 skipped in 3.10s")
+    captured = capsys.readouterr().out
+    assert outcome == run_tests_module.OUTCOME_NO_TESTS
+    assert "PASS" not in captured
+    assert "NO TESTS" in captured
+
+
+def test_report_file_result_fails_a_replaced_process(
+    run_tests_module: ModuleType, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Exit 0 with no pytest summary is reported as a failure, not a pass."""
+    outcome = run_tests_module._report_file_result("[1/1] test_x.py", 0, 0.4, "")
+    captured = capsys.readouterr().out
+    assert outcome == run_tests_module.OUTCOME_FAILED
+    assert "FAIL" in captured
+    assert "PASS" not in captured
+
+
+def _stub_run_file(results: dict[str, tuple[int, str]]) -> Any:
+    """Build a ``run_file`` replacement returning canned per-file results."""
+
+    def _run_file(path: Path, extra_args: list[str], coverage: bool = False) -> tuple[Path, int, float, str]:
+        code, output = results[path.name]
+        return path, code, 0.1, output
+
+    return _run_file
+
+
+def test_sequential_totals_count_ran_nothing_separately(
+    run_tests_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The totals line reports passed, failed, and ran-nothing as three numbers."""
+    files = [Path("tests/unit/test_a.py"), Path("tests/unit/test_b.py"), Path("tests/unit/test_c.py")]
+    monkeypatch.setattr(
+        run_tests_module,
+        "run_file",
+        _stub_run_file(
+            {
+                "test_a.py": (0, "4 passed in 0.10s"),
+                "test_b.py": (0, "13 skipped in 3.10s"),
+                "test_c.py": (5, "no tests ran in 0.01s"),
+            }
+        ),
+    )
+
+    code = run_tests_module.run_sequential(files, [], fail_fast=False)
+
+    captured = capsys.readouterr().out
+    assert "Files: 1 passed, 0 failed, 2 ran no tests, 3 total" in captured
+    # Ran-nothing stays non-fatal: impact-based selection and credential-gated
+    # suites legitimately execute nothing on some lanes.
+    assert code == 0
+
+
+def test_sequential_totals_fail_on_a_replaced_process(
+    run_tests_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A file whose process vanished mid-run makes the run non-zero."""
+    files = [Path("tests/unit/test_a.py"), Path("tests/unit/test_b.py")]
+    monkeypatch.setattr(
+        run_tests_module,
+        "run_file",
+        _stub_run_file(
+            {
+                "test_a.py": (0, "4 passed in 0.10s"),
+                "test_b.py": (0, "Bernstein starting\n"),
+            }
+        ),
+    )
+
+    code = run_tests_module.run_sequential(files, [], fail_fast=False)
+
+    captured = capsys.readouterr().out
+    assert "Files: 1 passed, 1 failed, 0 ran no tests, 2 total" in captured
+    assert code == 1

--- a/tests/unit/test_exec_restart_refuses_inside_pytest.py
+++ b/tests/unit/test_exec_restart_refuses_inside_pytest.py
@@ -1,0 +1,66 @@
+"""``exec_restart`` must refuse to replace a running pytest process.
+
+``bernstein.cli.run_bootstrap.exec_restart`` calls ``os.execv``, which replaces
+the current process image. A test that hands the dashboard a bare ``MagicMock``
+gets a truthy ``_restart_on_exit`` (every attribute of a bare MagicMock is
+truthy), the production path then reaches ``exec_restart``, and the pytest
+process is replaced by ``bernstein run``. The observable result is a run that
+prints no test results and exits 0 - indistinguishable from success, with a
+whole file having silently stopped protecting anything.
+
+The guard closes the hole at the source: inside a pytest process the call
+raises instead of exec'ing, so the offending test fails loudly.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, NoReturn
+
+import pytest
+
+from bernstein.cli.run_bootstrap import exec_restart
+
+
+def test_exec_restart_raises_inside_a_pytest_process(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Under pytest, exec_restart refuses rather than replacing the process."""
+
+    def _must_not_exec(*args: Any, **kwargs: Any) -> NoReturn:
+        raise AssertionError("os.execv must not run inside a pytest process")
+
+    monkeypatch.setattr(os, "execv", _must_not_exec)
+    assert os.environ.get("PYTEST_CURRENT_TEST"), "pytest sets this for every running test"
+
+    with pytest.raises(RuntimeError, match="pytest"):
+        exec_restart()
+
+
+def test_exec_restart_refusal_names_the_environment_variable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The error tells the reader why the restart was refused."""
+
+    def _must_not_exec(*args: Any, **kwargs: Any) -> NoReturn:
+        raise AssertionError("os.execv must not run inside a pytest process")
+
+    monkeypatch.setattr(os, "execv", _must_not_exec)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        exec_restart()
+    assert "PYTEST_CURRENT_TEST" in str(excinfo.value)
+
+
+def test_exec_restart_still_execs_outside_pytest(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The production path is unchanged when no pytest process is running."""
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setattr("sys.platform", "linux")
+    calls: list[tuple[str, list[str]]] = []
+
+    def _record(executable: str, argv: list[str]) -> None:
+        calls.append((executable, argv))
+
+    monkeypatch.setattr(os, "execv", _record)
+
+    exec_restart()
+
+    assert len(calls) == 1
+    _executable, argv = calls[0]
+    assert argv[1:] == ["-m", "bernstein.cli.main", "run"]

--- a/tests/unit/test_shipped_compose_cli_commands.py
+++ b/tests/unit/test_shipped_compose_cli_commands.py
@@ -265,22 +265,81 @@ def test_shipped_compose_commands_resolve_to_real_cli_subcommands(compose_file: 
         )
 
 
+# The bernstein-CLI services each shipped compose file is expected to expose.
+# Every entry of `SHIPPED_COMPOSE_FILES` must appear here (asserted below), so
+# the anti-vacuity guard cannot cover a strict subset of what the parametrized
+# tests iterate. An empty set records a file whose services all override
+# `entrypoint:` to something other than the `bernstein` binary (uvicorn, a
+# Python module, a shell wrapper), so the CLI-tree walk has nothing to check
+# there. Those files are still listed, so a `_resolved_argv` regression that
+# started claiming a uvicorn service execs the bernstein CLI is caught too.
+_EXPECTED_SERVICES_BY_FILE: dict[Path, set[str]] = {
+    REPO_ROOT / "docker-compose.yaml": set(),
+    REPO_ROOT / "docker" / "demo" / "docker-compose.yaml": set(),
+    REPO_ROOT / "docker" / "sandbox" / "docker-compose.yaml": {"bernstein-server"},
+    REPO_ROOT / "docker" / "sandbox" / "docker-compose.researcher.yaml": {"bernstein-server"},
+    REPO_ROOT / "examples" / "cluster" / "tailscale" / "docker-compose.yml": {"bernstein-central"},
+    REPO_ROOT / "examples" / "cluster" / "cloudflared" / "docker-compose.yml": {"bernstein-central"},
+}
+
+
+def test_anti_vacuity_guard_covers_every_discovered_compose_file() -> None:
+    """The guard's expectations cover exactly the files the main test iterates.
+
+    The guard below exists to stop a broken `_resolved_argv` /
+    `_builds_bernstein_image` from making the main regression test pass
+    vacuously, but it enumerated 4 of the 6 discovered compose files. A helper
+    regression affecting only the two omitted files would have gone unseen, so
+    the guard itself was partly vacuous. Pinning the two lists as equal means
+    a compose file added later cannot slip past the guard either.
+    """
+    assert set(_EXPECTED_SERVICES_BY_FILE) == set(SHIPPED_COMPOSE_FILES), (
+        "the anti-vacuity guard's expectations and the discovered compose files "
+        "have diverged; add the new file to _EXPECTED_SERVICES_BY_FILE (mapping "
+        "to an empty set if every service overrides entrypoint: away from the "
+        "bernstein binary)"
+    )
+
+
 def test_guard_actually_inspects_the_known_bernstein_services() -> None:
     """Sanity-check the extraction logic itself finds the services this
     guard exists to protect, so a bug in `_resolved_argv`/
     `_builds_bernstein_image` (e.g. a broken path) can't make every check
     above pass vacuously by finding zero services anywhere.
     """
-    expected_services_by_file = {
-        REPO_ROOT / "docker" / "sandbox" / "docker-compose.yaml": {"bernstein-server"},
-        REPO_ROOT / "docker" / "sandbox" / "docker-compose.researcher.yaml": {"bernstein-server"},
-        REPO_ROOT / "examples" / "cluster" / "tailscale" / "docker-compose.yml": {"bernstein-central"},
-        REPO_ROOT / "examples" / "cluster" / "cloudflared" / "docker-compose.yml": {"bernstein-central"},
-    }
-    for compose_file, expected_services in expected_services_by_file.items():
+    for compose_file, expected_services in _EXPECTED_SERVICES_BY_FILE.items():
         found_services = {name for name, _ in _bernstein_invocations(compose_file)}
         assert found_services == expected_services, (
             f"{compose_file.relative_to(REPO_ROOT)}: expected to find bernstein-CLI "
             f"services {sorted(expected_services)}, found {sorted(found_services)} - "
             "the extraction logic in this test may have regressed"
         )
+
+
+def test_files_expected_to_yield_nothing_still_declare_services() -> None:
+    """An empty expectation means "excluded", never "nothing was parsed".
+
+    Without this, a `_load_yaml` regression that returned an empty mapping
+    would satisfy the empty expectations above and look like a pass.
+    """
+    for compose_file, expected_services in _EXPECTED_SERVICES_BY_FILE.items():
+        if expected_services:
+            continue
+        services = _load_yaml(compose_file).get("services", {})
+        assert isinstance(services, dict) and services, (
+            f"{compose_file.relative_to(REPO_ROOT)}: expected the file to declare "
+            "services that the extraction deliberately excludes, found none"
+        )
+
+
+def test_guard_asserts_a_real_service_set_for_the_cli_driven_files() -> None:
+    """The expectation map is not all-empty.
+
+    An all-empty map would satisfy every check above while asserting nothing
+    about the CLI-tree walk the main regression test performs.
+    """
+    non_empty = [f for f, services in _EXPECTED_SERVICES_BY_FILE.items() if services]
+    assert len(non_empty) >= 4, (
+        "the anti-vacuity guard must assert a real service set for every shipped "
+        f"compose file whose services exec the bernstein CLI, found only {len(non_empty)}"
+    )


### PR DESCRIPTION
Four checks in this repo reported success on work they never evaluated. Same defect class, four places.

## `scripts/run_tests.py`: a file that ran no tests was counted as passing

Closes #3068.

Three outcomes collapsed into one number in `Files: N passed`:

| Case | Before | After |
|---|---|---|
| every test in the file skipped at runtime | `PASS ... 13 skipped`, counted passed | `NO TESTS`, counted separately |
| pytest exit 5 (nothing collected) | `SKIP`, counted passed | `NO TESTS`, counted separately |
| pytest process replaced mid-run, exit 0, no summary | `PASS`, counted passed | `FAIL` |

The totals line is now `Files: P passed, F failed, N ran no tests, T total`.

**Zero-collected is a named distinct outcome, not a hard error.** Two lanes legitimately execute nothing: at least 23 files under `tests/integration` are module-level gated on a credential or an optional dependency and run zero tests without secrets present, and `--affected` selection can legitimately pick nothing. Turning either into a failure would redden lanes that are behaving correctly. The issue's own framing is that the reporting is what misleads, so the exit status is unchanged for this case. The file-selection-level empty case (`_report_empty_selection` / `changed_files_require_tests`) already fails closed where it should and is untouched.

**Exit 0 with no pytest terminal summary is a hard failure.** pytest prints a terminal summary on every completed run, so its absence with a zero exit means the subprocess stopped being pytest before it could report. Nothing was verified. That is the `os.execv` shape below.

The `PASS` / `NO TESTS` lines now echo pytest's own parsed counts instead of the subprocess's last printed line: `run_file` passes `-s`, so test stdout is not captured and the last line is frequently unrelated to the result being reported. Observed on `main`: `PASS [128/139] test_skills_injector.py (18.9s) Preparing worktree (new branch 'agent-branch')`.

## `exec_restart` could replace the running pytest process

Closes #3059.

A test that constructs a bare `MagicMock` for the dashboard gets a truthy `_restart_on_exit`, because every attribute of a bare MagicMock is truthy. The production path then reaches `exec_restart`, whose `os.execv` replaces the running pytest process. The run prints no test results and exits 0.

`bernstein.cli.run_bootstrap.exec_restart` now raises when `PYTEST_CURRENT_TEST` is set, so the offending test fails loudly instead. The production path is unchanged and still covered by a test.

The issue lists three possible directions; the first two are the same fix and both land here. The narrow guard closes the specific hole at the source, and the `run_tests.py` classification above closes the class, since a file that vanishes mid-run is now a failure rather than a pass.

## `scripts/review_bot_ack.py`: zero findings from a bot that never ran

Closes #3067.

The gate counted findings and nothing else, so a rate-limited bot that produced no review contributed zero findings and the summary read `Must-address findings: 0 (0 acknowledged, 0 open)` - the same sentence a genuinely reviewed, clean PR gets.

It now resolves, per configured bot, whether that bot produced a review anchored to the current head commit:

- submitted reviews and review comments carry `commit_id`;
- a bot that posts its review as a top-level comment carries no `commit_id`, so the head SHA is matched among the 40-hex commit ids the body names;
- a body matching a known rate-limit shape is a declined review, not a review, whichever commit it is attached to.

Four states, only one of which is clean: `reviewed`, `declined`, `stale` (reviewed an earlier head only), `absent`. The summary gains a coverage section and, when any bot did not run, states outright that the counts are not a clean result.

Exit status is unchanged by default. `review-bot-ack` is a required context on `main`, and both bots are currently rate limited on several open PRs, so turning that into a hard failure would wedge every open pull request. `--require-review` opts in to failing on the gap. The flag is deliberately not wired into `.github/workflows/review-bot-ack.yml`: workflow files are owned by a separate change in flight.

Empirical check against the two PRs the issue names, run with the patched script:

```
PR #3041 (head 1932e7b4)
  coderabbitai[bot]: not counted - did not run (rate limited or otherwise declined)
  sourcery-ai[bot]:  not counted - did not run (rate limited or otherwise declined)
  -> "the finding counts above are not a clean result"

PR #3165 (head 8059528d)
  coderabbitai[bot]: reviewed
  sourcery-ai[bot]:  reviewed
  -> no caveat
```

## Three more instances named by #3069

Closes #3069. It is **not** subsumed by the other three: it names three further instances, all fixed here.

**1. `tests/integration/endpoints/test_certify_verify.py` bound to an in-test reimplementation.** `_run_certify` and `_run_verify` caught `ImportError` and fell back to `_shim_certify` / `_shim_verify`, defined in the test file. The product modules are now imported at module scope, so an `ImportError` fails collection. Reproduced with a `sys.meta_path` blocker on `bernstein.core.endpoints.certify` and `.verify`:

```
before:  8 failed, 22 passed          (22 tests passing against the test file's own shims)
after:   1 error during collection
```

Unblocked, the file is `30 passed` before and after, now against the product. The tampered-receipt test also stopped swallowing every exception as an acceptable result: editing a signed field breaks the Ed25519 signature over the canonical binding, so `verify_cert` fails closed deterministically and the test asserts that. A nearby `except ImportError: pytest.skip(...)` on the use-case catalogue is gone for the same reason.

**2. `scripts/check_data_freshness.py` silently skipped missing inventory entries.** A path that was deleted or renamed stopped being checked while the script kept reporting every marker fresh. Missing entries are now listed and fail on every invocation, `--strict` or not: unlike a stale date, a path that no longer exists does not fix itself with time, and it is either a stale entry to remove or a file that went missing. Both need a human. `docs-drift` is not a required context, so this surfaces as a visible red rather than a merge block. Both entries currently in `INVENTORY` exist, so nothing changes today.

**3. The anti-vacuity guard in `tests/unit/test_shipped_compose_cli_commands.py` covered 4 of 6 files.** `SHIPPED_COMPOSE_FILES` discovers six compose files; `expected_services_by_file` enumerated four, omitting the root `docker-compose.yaml` and `docker/demo/docker-compose.yaml`, both of which the main parametrized test iterates. The expectation map is now asserted equal to the discovered set, so a compose file added later cannot slip past either. Both previously omitted files map to an empty expectation, because every service in them overrides `entrypoint:` away from the `bernstein` binary (uvicorn, a Python module, a shell wrapper); a second test asserts those files still declare services, so an empty expectation means "excluded", never "nothing was parsed", and a third asserts the map is not all-empty.

## Evidence

Every test here fails on `origin/main` first.

```
43 failed, 2 passed        # new tests against unmodified source
```

(The 2 that passed are `test_exec_restart_still_execs_outside_pytest`, which pins unchanged behaviour, and `test_summarize_pytest_counts_ignores_leading_progress_output`.) After the change:

```
tests/unit/scripts/test_run_tests_zero_test_outcomes.py          25 passed
tests/unit/scripts/test_review_bot_ack_run_detection.py          13 passed
tests/unit/scripts/test_check_data_freshness.py                   4 passed
tests/unit/test_exec_restart_refuses_inside_pytest.py             3 passed
tests/unit/test_shipped_compose_cli_commands.py                  16 passed
tests/integration/endpoints/test_certify_verify.py               30 passed
```

Wider sweep: `scripts/run_tests.py --affected HEAD` ran 139 files, all passing. `scripts/check_test_collection.py` reports 0 uncollected and no stale allowlist entries. `ruff check` and `ruff format` clean.

Live behaviour of the runner on the exact files from #3068:

```
NO TESTS [1/4] test_azure_blob_sink.py (4.4s) 13 skipped
NO TESTS [2/4] test_gcs_sink.py        (4.4s) 13 skipped
NO TESTS [3/4] test_r2_sink.py         (4.5s) 13 skipped
NO TESTS [4/4] test_s3_sink.py         (4.6s) 13 skipped

Files: 0 passed, 0 failed, 4 ran no tests, 4 total
```

No files under `.github/workflows/` are touched and `docs/operations/ci-topology.md` is not regenerated.

`docs/operations/ci.md` stated that `scripts/run_tests.py` reports a file whose tests all skip as `PASS`. That is exactly the behaviour this branch changes, so the note is updated to describe the outcome classes that now exist.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Test runs now distinguish passed, failed, and files where no tests ran.
  * Review status now identifies whether configured review checks covered the latest changes, with an optional requirement for complete coverage.
  * Data freshness checks now flag missing inventory files.

* **Bug Fixes**
  * Prevented process replacement during active test runs.
  * Correctly treats incomplete test output as a failure instead of a pass.

* **Documentation**
  * Updated integration-test guidance for no-test results, count reporting, and incomplete test summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->