### PR TITLE
fix(ci): one mergeable ratchet PR, no dispatcher runs that route nothing, gating vs advisory documented

### DIFF
--- a/.coverage-baseline.json
+++ b/.coverage-baseline.json
@@ -1,5 +1,5 @@
 {
   "diff_coverage_floor_percent": 85,
-  "total_coverage_percent": 82.07,
-  "updated_at": "2026-07-25T13:16:59+00:00"
+  "total_coverage_percent": 82.31,
+  "updated_at": "2026-07-26T05:15:31+00:00"
 }

--- a/.github/workflows/coverage-ratchet.yml
+++ b/.github/workflows/coverage-ratchet.yml
@@ -23,6 +23,20 @@ name: Coverage ratchet (total)
 # makes every baseline movement a reviewable, auditable artifact - the
 # ratchet click is a PR, not a silent rewrite.
 #
+# Why the PR is opened with BERNSTEIN_AUTOSYNC_TOKEN and not GITHUB_TOKEN:
+# a pull request created with GITHUB_TOKEN does not trigger workflows, so
+# neither required context (`CI gate`, `review-bot-ack`) ever reports on
+# it. The PR then reads MERGEABLE with a SUCCESS rollup while branch
+# protection holds it at BLOCKED forever, and the only way out is for an
+# operator to close it by hand. Closing it is what produced the apparent
+# "one new PR per fire": the branch below is stable and the action does
+# update the open PR in place, but a closed PR cannot be reopened by a
+# force-push, so the next fire has to open a fresh one. Creating the PR
+# under a token that triggers workflows lets it merge on its own and the
+# churn stops at the source. The fallback to GITHUB_TOKEN keeps forks and
+# secret-less environments working; there the PR still needs a manual
+# close-and-reopen to collect its checks.
+#
 # Trigger: push to main, then resolve the freshest CI run that actually
 # uploaded a coverage-report artifact. Under the rapid-merge cadence
 # ci.yml's cancel-in-progress concurrency cancels
@@ -123,14 +137,71 @@ jobs:
             --coverage-xml coverage.xml \
             --baseline .coverage-baseline.json
 
-      - name: Open PR with the bumped baseline
-        # Only when the ratchet actually clicked (coverage rose). The check
-        # step rewrote .coverage-baseline.json in place; open a PR with that
-        # change (main is protected, so a direct push would be rejected).
+      - name: Guard the open ratchet PR against a downward move
+        id: guard
         if: steps.ratchet.outputs.baseline_bumped == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MEASURED: ${{ steps.ratchet.outputs.measured }}
+          REPO: ${{ github.repository }}
+          RATCHET_BRANCH: coverage-ratchet/baseline
+        run: |
+          set -euo pipefail
+          # scripts/coverage_ratchet.py compares the measurement against the
+          # baseline committed on main, NOT against the one the open ratchet
+          # PR already carries. Those two diverge as soon as a ratchet PR is
+          # open: main still holds the old mark while the PR branch holds a
+          # higher one. A later push whose measurement lands between them
+          # still counts as a bump against main, and force-pushing it would
+          # rewrite the open PR with a LOWER high-water mark - the exact
+          # inverse of a monotonic ratchet, and invisible in review because
+          # the PR title changes with it.
+          #
+          # So: read the baseline on the ratchet branch and only proceed when
+          # the new measurement is strictly greater.
+          open_json=$(gh api "repos/${REPO}/contents/.coverage-baseline.json?ref=${RATCHET_BRANCH}" \
+              -H "Accept: application/vnd.github.raw" 2>/dev/null || true)
+          if [ -z "${open_json}" ]; then
+            echo "::notice::no ${RATCHET_BRANCH} branch yet; opening a fresh ratchet PR."
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          printf '%s' "${open_json}" > open-baseline.json
+          verdict=$(OPEN_BASELINE=open-baseline.json python3 - <<'PY'
+          import json
+          import os
+
+          with open(os.environ["OPEN_BASELINE"], encoding="utf-8") as fh:
+              open_pct = float(json.load(fh)["total_coverage_percent"])
+          measured = float(os.environ["MEASURED"])
+          print(f"{'true' if measured > open_pct else 'false'} {open_pct}")
+          PY
+          )
+          proceed=${verdict%% *}
+          open_pct=${verdict##* }
+          rm -f open-baseline.json
+          if [ "${proceed}" = "true" ]; then
+            echo "::notice::measured ${MEASURED}% > open ratchet PR ${open_pct}%; updating it."
+          else
+            echo "::notice::measured ${MEASURED}% is not above the open ratchet PR's ${open_pct}%; leaving it alone."
+          fi
+          echo "proceed=${proceed}" >> "$GITHUB_OUTPUT"
+
+      - name: Open PR with the bumped baseline
+        # Only when the ratchet actually clicked (coverage rose) AND the new
+        # mark is above whatever the currently-open ratchet PR carries.
+        # The check step rewrote .coverage-baseline.json in place; open a PR
+        # with that change (main is protected, so a direct push would be
+        # rejected).
+        if: >-
+          steps.ratchet.outputs.baseline_bumped == 'true' &&
+          steps.guard.outputs.proceed == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # A PR opened with GITHUB_TOKEN never triggers the workflows that
+          # publish `CI gate` and `review-bot-ack`, so it can never satisfy
+          # branch protection. See the header block.
+          token: ${{ secrets.BERNSTEIN_AUTOSYNC_TOKEN || secrets.GITHUB_TOKEN }}
           # Stable branch so create-pull-request UPDATES the single open
           # ratchet PR in place instead of opening a fresh PR every push.
           branch: coverage-ratchet/baseline

--- a/.github/workflows/post-ci-dispatcher.yml
+++ b/.github/workflows/post-ci-dispatcher.yml
@@ -1,5 +1,19 @@
 name: Post-CI dispatcher
 
+# ---------------------------------------------------------------------------
+# DO NOT PRUNE THIS WORKFLOW FOR RUNNER CAPACITY.
+#
+# `.github/workflows/auto-release.yml` declares `on: workflow_call:` and
+# nothing else, and so do auto-heal.yml, bernstein-ci-fix.yml and
+# bisect-on-red.yml. This dispatcher is their ONLY invocation path. A
+# dispatcher run that is cancelled, disabled or filtered away takes the
+# release automation with it, and nothing anywhere reports a failing check
+# when that happens - the release simply does not occur.
+#
+# Any change to the routing below has to keep `conclusion == 'success'` on
+# `main` reaching the auto-release job.
+# ---------------------------------------------------------------------------
+#
 # Single workflow_run: CI completed listener that consolidates the fanout
 # previously paid out across sibling workflows (auto-release, auto-heal,
 # bernstein-ci-fix, bisect-on-red). Each child is now a reusable workflow
@@ -57,6 +71,28 @@ jobs:
     name: Resolve upstream metadata
     runs-on: ubuntu-latest
     timeout-minutes: 2
+    # Do not boot a runner for an upstream conclusion no route can act on.
+    #
+    # Every job in auto-release.yml gates on `inputs.conclusion == 'success'`
+    # except its stale-trigger alert, which gates on the explicit list
+    # ["failure", "timed_out", "action_required"] and documents `cancelled`
+    # as deliberately excluded. auto-heal, bernstein-ci-fix and bisect-on-red
+    # each require exactly `failure`. So `cancelled` and `skipped` route
+    # nothing: today they boot this job, resolve metadata, and every child
+    # then skips.
+    #
+    # That is not a rare case. ci.yml keys push-to-main runs per SHA and
+    # never cancels them, so a merge wave leaves a long tail of main CI runs
+    # that an operator mass-cancels to reclaim the pool; `workflow_run` fires
+    # on `completed`, which includes `cancelled`, and each one paid a runner
+    # slot here for no routing decision.
+    #
+    # `success` is admitted unconditionally, so the release path is
+    # untouched. tests/unit/test_post_ci_dispatcher_workflow_yaml.py pins
+    # that: the inert set may not intersect any conclusion a child acts on.
+    if: >-
+      github.event.workflow_run.conclusion != 'cancelled' &&
+      github.event.workflow_run.conclusion != 'skipped'
     permissions:
       contents: read
     outputs:

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -167,7 +167,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/codeql.yml | workflow: {"contents": "read"}<br>analyze: {"actions": "read", "contents": "read", "pull-requests": "write", "security-events": "write"} | - |
 | .github/workflows/contract-drift-autofix.yml | workflow: {"contents": "write", "issues": "write", "pull-requests": "write"}<br>autofix: {"contents": "write", "issues": "write", "pull-requests": "write"} | BOT_PAT, GITHUB_TOKEN |
 | .github/workflows/coverage-ratchet-weekly.yml | bump: {"contents": "write", "pull-requests": "write"} | GITHUB_TOKEN |
-| .github/workflows/coverage-ratchet.yml | ratchet: {"actions": "read", "contents": "write", "pull-requests": "write"} | GITHUB_TOKEN |
+| .github/workflows/coverage-ratchet.yml | ratchet: {"actions": "read", "contents": "write", "pull-requests": "write"} | BERNSTEIN_AUTOSYNC_TOKEN, GITHUB_TOKEN |
 | .github/workflows/dependabot-auto-merge.yml | workflow: {"contents": "read"}<br>auto-merge: {"contents": "write", "pull-requests": "write"} | GITHUB_TOKEN |
 | .github/workflows/dependency-review.yml | workflow: {"contents": "read"}<br>review: {"contents": "read", "pull-requests": "write"} | - |
 | .github/workflows/docs-drift.yml | workflow: {"contents": "read"}<br>drift-check: {"contents": "read", "issues": "write", "pull-requests": "write"} | - |

--- a/docs/operations/ci.md
+++ b/docs/operations/ci.md
@@ -226,6 +226,71 @@ the vulture / refurb / perflint jobs in
 the refurb SARIF upload is filtered to error-level results so style
 findings stay out of the code-scanning alert feed.
 
+## Gating vs advisory workflows
+
+Two contexts gate a merge. Everything else is advisory and cannot
+block or unblock one.
+
+| Role | Workflow | Context published |
+|------|----------|-------------------|
+| Gating | `ci.yml` | `CI gate` |
+| Gating | `ci-gate-stub.yml` | `CI gate` (fully-ignored diffs only) |
+| Gating | `review-bot-ack.yml` | `review-bot-ack` |
+
+Everything else that triggers on `pull_request` is advisory:
+`a2a-federation-e2e`, `airgap-e2e`, `bernstein-pr-review`,
+`cluster-e2e`, `code-review-bots-ci`, `codeql`,
+`contract-drift-autofix`, `dependabot-auto-merge`,
+`dependency-review`, `docs-drift`, `license-compliance`, `pr-labels`,
+`pr-observability-summary`, `pr-policy`, `required-check-canary`,
+`spiffe-extra-e2e`, `trufflehog`, `typecheck-ts`, `zizmor`.
+
+### What the pool actually spends
+
+The free-tier public-repo ceiling is 20 concurrent jobs, so the budget
+is jobs, not runs. Measured on one head SHA of a workflow-touching PR
+(#3157), 18 workflow runs resolved to 47 runner jobs:
+
+| Role | Runs | Runner jobs | Share |
+|------|------|-------------|-------|
+| Gating (`ci.yml`) | 1 | 34 | 72% |
+| Gating (`review-bot-ack`) | 4 | 4 | 9% |
+| Advisory (all of it) | 13 | 9 | 19% |
+
+Counting runs instead of jobs inverts that picture and makes advisory
+work look dominant. It is not: an advisory workflow is one job, `ci.yml`
+is 34. Moving every advisory lane off the PR path would return under a
+fifth of the pool while deleting all pre-merge signal that is not the
+test matrix, so the advisory lanes stay where they are. The load that
+saturates the pool during a merge wave is concurrent `ci.yml` runs, and
+the durable fix for that is the merge queue (see *Concurrency policy*).
+
+Advisory lanes are kept cheap instead of removed:
+`pr-observability-summary` runs only on PRs labelled `deep-review`,
+`dependabot-auto-merge` gates its only job on the Dependabot user id,
+`pr-policy` and `pr-labels` are consolidated single-job lanes, and the
+vulture / refurb / perflint jobs run weekly rather than per PR.
+
+### Concurrency on `pull_request` workflows
+
+Every workflow triggering on `pull_request` declares a `concurrency`
+group keyed on the PR, and every one of them cancels a superseded
+pull-request run. There is one exception:
+
+| Workflow | Why it must not cancel |
+|----------|------------------------|
+| `review-bot-ack.yml` | Publishes a required context. Branch protection folds every check-run of a required name into its verdict, so one `cancelled` instance holds the PR at BLOCKED even after a later run succeeds (#3154, #3042). The group also carries `github.event_name` so a `pull_request` run and a `pull_request_review` run for the same commit cannot cancel each other. |
+
+`ci.yml` and `codeql.yml` express cancellation as
+`cancel-in-progress: ${{ github.event_name == 'pull_request' }}`: they
+cancel on the PR lane and keep the per-SHA push-to-`main` lane alive, so
+a release commit's CI is never cancelled by the next merge.
+
+`tests/unit/test_pull_request_workflow_concurrency_yaml.py` pins both
+the rule and the exception list, so a new `pull_request` workflow
+cannot land without a concurrency group and an exception cannot be
+added silently.
+
 ## Required check
 
 Branch protection points at a single status check, `CI gate`, which

--- a/tests/unit/test_coverage_ratchet_workflow_yaml.py
+++ b/tests/unit/test_coverage_ratchet_workflow_yaml.py
@@ -1,0 +1,139 @@
+"""Structural assertions on the total-coverage ratchet workflow.
+
+``.github/workflows/coverage-ratchet.yml`` fires on every push to ``main``
+whose measured total coverage exceeds the committed baseline, and opens a
+pull request carrying the new high-water mark.
+
+The failures this module exists to prevent
+------------------------------------------
+1. **A per-fire pull request.** The branch name must stay a constant so
+   ``peter-evans/create-pull-request`` updates the single open ratchet PR
+   in place. A branch name carrying the run id, the SHA or the measured
+   percentage would open a fresh PR on every fire.
+
+2. **A PR that can never merge.** A pull request created with
+   ``GITHUB_TOKEN`` does not trigger workflows, so neither required
+   context (``CI gate``, ``review-bot-ack``) ever reports on it. Branch
+   protection then holds it at BLOCKED forever while the rollup reads
+   SUCCESS, and the only way out is an operator closing it by hand. A
+   closed PR cannot be reopened by force-pushing its branch, so the next
+   fire has to open a new one - which is what the stable branch above
+   looks like it failed to do. The PR-opening step must therefore prefer
+   a token that triggers workflows.
+
+3. **A downward move on the open PR.** ``scripts/coverage_ratchet.py``
+   compares the measurement against the baseline committed on ``main``,
+   not against the one the open ratchet PR already carries. Those diverge
+   the moment a ratchet PR is open. A later measurement sitting between
+   the two still counts as a bump against ``main``, and force-pushing it
+   would rewrite the open PR with a *lower* mark. A guard step must read
+   the ratchet branch and gate the PR step on it.
+
+4. **A cancelling concurrency group.** Two fires racing on the same
+   branch must serialise, not cancel: a run cancelled between the
+   force-push and the PR call leaves a pushed branch with no pull
+   request.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - dev env should have pyyaml
+    pytest.skip("pyyaml not installed", allow_module_level=True)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "coverage-ratchet.yml"
+
+RATCHET_BRANCH = "coverage-ratchet/baseline"
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict:
+    return yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def steps(workflow: dict) -> list[dict]:
+    return workflow["jobs"]["ratchet"]["steps"]
+
+
+def _step_by_id(steps: list[dict], step_id: str) -> dict:
+    for step in steps:
+        if step.get("id") == step_id:
+            return step
+    raise AssertionError(f"no step with id={step_id!r} in coverage-ratchet.yml")
+
+
+def _create_pr_step(steps: list[dict]) -> dict:
+    for step in steps:
+        if "peter-evans/create-pull-request" in str(step.get("uses", "")):
+            return step
+    raise AssertionError("coverage-ratchet.yml no longer calls create-pull-request")
+
+
+def test_workflow_file_exists() -> None:
+    assert _WORKFLOW.is_file()
+
+
+def test_branch_name_is_a_constant(steps: list[dict]) -> None:
+    """A templated branch name opens one PR per fire instead of updating one."""
+    branch = _create_pr_step(steps)["with"]["branch"]
+    assert branch == RATCHET_BRANCH
+    assert "${{" not in branch, (
+        "the ratchet branch must be a constant; a run id / SHA / percentage in "
+        "the name makes create-pull-request open a new PR on every fire"
+    )
+
+
+def test_pr_is_opened_with_a_token_that_triggers_workflows(steps: list[dict]) -> None:
+    """GITHUB_TOKEN-authored PRs never collect the two required contexts."""
+    token = _create_pr_step(steps)["with"]["token"]
+    assert "BERNSTEIN_AUTOSYNC_TOKEN" in token, (
+        "a PR created with GITHUB_TOKEN does not trigger workflows, so `CI gate` "
+        "and `review-bot-ack` never report and the PR can never merge"
+    )
+    assert token.index("BERNSTEIN_AUTOSYNC_TOKEN") < token.index("GITHUB_TOKEN"), (
+        "GITHUB_TOKEN may only be the fallback, never the preferred token"
+    )
+
+
+def test_downward_guard_exists_and_reads_the_ratchet_branch(steps: list[dict]) -> None:
+    guard = _step_by_id(steps, "guard")
+    assert RATCHET_BRANCH in yaml.safe_dump(guard), (
+        "the guard must read the baseline carried by the open ratchet branch, not only the one committed on main"
+    )
+    assert "proceed=" in guard["run"]
+
+
+def test_pr_step_is_gated_on_the_downward_guard(steps: list[dict]) -> None:
+    condition = " ".join(_create_pr_step(steps)["if"].split())
+    assert "steps.ratchet.outputs.baseline_bumped == 'true'" in condition
+    assert "steps.guard.outputs.proceed == 'true'" in condition, (
+        "without the guard a measurement between main's baseline and the open "
+        "PR's baseline rewrites the open PR with a lower high-water mark"
+    )
+
+
+def test_guard_runs_only_when_the_ratchet_clicked(steps: list[dict]) -> None:
+    assert _step_by_id(steps, "guard")["if"] == "steps.ratchet.outputs.baseline_bumped == 'true'"
+
+
+def test_concurrency_serialises_and_never_cancels(workflow: dict) -> None:
+    concurrency = workflow["concurrency"]
+    assert "${{" not in str(concurrency["group"]), (
+        "a templated group key gives every push its own group, so two fires can still race on the same branch"
+    )
+    assert concurrency["cancel-in-progress"] is False, (
+        "cancelling between the force-push and the create-pull-request call "
+        "leaves a pushed ratchet branch with no pull request"
+    )
+
+
+def test_still_fires_on_push_to_main(workflow: dict) -> None:
+    on = workflow.get("on", workflow.get(True))
+    assert on["push"]["branches"] == ["main"]

--- a/tests/unit/test_post_ci_dispatcher_workflow_yaml.py
+++ b/tests/unit/test_post_ci_dispatcher_workflow_yaml.py
@@ -1,0 +1,156 @@
+"""Structural assertions on the Post-CI dispatcher's routing filter.
+
+``.github/workflows/post-ci-dispatcher.yml`` is the sole invocation path
+for ``auto-release.yml``, ``auto-heal.yml``, ``bernstein-ci-fix.yml`` and
+``bisect-on-red.yml``: each of those declares ``on: workflow_call:`` and
+nothing else. Nothing publishes a failing check when the dispatcher stops
+routing, so a filter that is one conclusion too wide disables automated
+releases silently.
+
+The dispatcher's ``meta`` job skips upstream conclusions no child can act
+on. This module pins that the skipped set stays *provably* inert:
+
+1. The set is exactly ``{cancelled, skipped}``.
+2. ``success`` is not in it. Every release job in ``auto-release.yml``
+   gates on ``inputs.conclusion == 'success'``.
+3. No conclusion that ``auto-release.yml``'s stale-trigger alert acts on
+   is in it - that list is read out of ``auto-release.yml`` rather than
+   copied here, so widening one file fails the test in the other.
+4. The failure routes still require exactly ``failure``, which the filter
+   admits.
+5. The dispatcher still calls all four children.
+
+It also pins the DO-NOT-PRUNE header, because the coupling between this
+file and the release path is invisible from ``auto-release.yml``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - dev env should have pyyaml
+    pytest.skip("pyyaml not installed", allow_module_level=True)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_WORKFLOWS = _REPO_ROOT / ".github" / "workflows"
+_DISPATCHER = _WORKFLOWS / "post-ci-dispatcher.yml"
+_AUTO_RELEASE = _WORKFLOWS / "auto-release.yml"
+
+# Conclusions the dispatcher declines to boot a runner for.
+INERT_CONCLUSIONS = {"cancelled", "skipped"}
+
+CHILDREN = {
+    "auto-release": "./.github/workflows/auto-release.yml",
+    "auto-heal": "./.github/workflows/auto-heal.yml",
+    "bernstein-ci-fix": "./.github/workflows/bernstein-ci-fix.yml",
+    "bisect-on-red": "./.github/workflows/bisect-on-red.yml",
+}
+
+
+@pytest.fixture(scope="module")
+def dispatcher() -> dict:
+    return yaml.safe_load(_DISPATCHER.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def meta_condition(dispatcher: dict) -> str:
+    return " ".join(dispatcher["jobs"]["meta"]["if"].split())
+
+
+def _excluded_conclusions(condition: str) -> set[str]:
+    return set(re.findall(r"github\.event\.workflow_run\.conclusion\s*!=\s*'([a-z_]+)'", condition))
+
+
+def _alerting_conclusions() -> set[str]:
+    """Conclusions auto-release.yml's stale-trigger alert reacts to."""
+    auto_release = yaml.safe_load(_AUTO_RELEASE.read_text(encoding="utf-8"))
+    condition = auto_release["jobs"]["alert-on-stale-release-trigger"]["if"]
+    return set(re.findall(r'"([a-z_]+)"', condition))
+
+
+def test_meta_skips_exactly_the_inert_conclusions(meta_condition: str) -> None:
+    assert _excluded_conclusions(meta_condition) == INERT_CONCLUSIONS
+
+
+def test_meta_never_filters_out_a_successful_ci_run(meta_condition: str) -> None:
+    """The release path runs on success only; filtering it disables releases."""
+    assert "success" not in _excluded_conclusions(meta_condition)
+    assert "'success'" not in meta_condition
+
+
+def test_filter_does_not_intersect_the_auto_release_alert_set(
+    meta_condition: str,
+) -> None:
+    alerting = _alerting_conclusions()
+    assert alerting, "could not read the alert conclusion list from auto-release.yml"
+    assert not (alerting & _excluded_conclusions(meta_condition)), (
+        "the dispatcher would swallow a conclusion auto-release.yml still acts on"
+    )
+
+
+def test_auto_release_jobs_still_gate_on_success() -> None:
+    """The premise of the filter: no release job acts on cancelled/skipped.
+
+    A job qualifies either by requiring ``success`` itself or by depending
+    on a job that does - ``release`` needs ``gate``, and ``gate`` carries
+    the guard.
+    """
+    jobs = yaml.safe_load(_AUTO_RELEASE.read_text(encoding="utf-8"))["jobs"]
+
+    def requires_success(name: str, seen: frozenset[str] = frozenset()) -> bool:
+        if name in seen:
+            return False
+        job = jobs[name]
+        if "inputs.conclusion == 'success'" in " ".join(str(job.get("if", "")).split()):
+            return True
+        needs = job.get("needs") or []
+        if isinstance(needs, str):
+            needs = [needs]
+        return bool(needs) and all(requires_success(dep, seen | {name}) for dep in needs)
+
+    release_jobs = set(jobs) - {"alert-on-stale-release-trigger"}
+    assert release_jobs
+    for name in sorted(release_jobs):
+        assert requires_success(name), (
+            f"auto-release job {name!r} no longer requires a successful CI run, "
+            "so the dispatcher's cancelled/skipped filter may now suppress real work"
+        )
+
+
+def test_failure_routes_require_exactly_failure(dispatcher: dict) -> None:
+    for job_name in ("auto-heal", "bernstein-ci-fix", "bisect-on-red"):
+        condition = " ".join(dispatcher["jobs"][job_name]["if"].split())
+        assert "needs.meta.outputs.conclusion == 'failure'" in condition
+
+
+def test_dispatcher_still_routes_to_every_child(dispatcher: dict) -> None:
+    for job_name, path in CHILDREN.items():
+        assert dispatcher["jobs"][job_name]["uses"] == path
+
+
+def test_children_have_no_trigger_other_than_workflow_call() -> None:
+    """If this ever stops holding, the DO-NOT-PRUNE note needs revisiting."""
+    for path in CHILDREN.values():
+        child = yaml.safe_load((_REPO_ROOT / path[2:]).read_text(encoding="utf-8"))
+        on = child.get("on", child.get(True))
+        assert set(on) == {"workflow_call"}, (
+            f"{path} gained a second trigger; the dispatcher is documented as its sole invocation path"
+        )
+
+
+def test_sole_trigger_coupling_is_stated_at_the_top_of_the_file() -> None:
+    header = _DISPATCHER.read_text(encoding="utf-8").split("jobs:", 1)[0]
+    assert "DO NOT PRUNE" in header
+    assert "auto-release.yml" in header
+    assert "ONLY invocation path" in header
+
+
+def test_upstream_trigger_is_still_a_single_workflow(dispatcher: dict) -> None:
+    on = dispatcher.get("on", dispatcher.get(True))
+    assert on["workflow_run"]["workflows"] == ["CI"]
+    assert on["workflow_run"]["types"] == ["completed"]

--- a/tests/unit/test_pull_request_workflow_concurrency_yaml.py
+++ b/tests/unit/test_pull_request_workflow_concurrency_yaml.py
@@ -1,0 +1,130 @@
+"""Every ``pull_request`` workflow declares a per-PR concurrency group.
+
+A single branch push fans out across every workflow that triggers on
+``pull_request``. Without a concurrency group each push leaves the
+previous push's runs alive, so a PR that is pushed three times holds
+three generations of runners on a pool whose free-tier ceiling is 20
+concurrent jobs.
+
+Cancelling is not universally correct, though. Branch protection folds
+*every* check-run of a required name into its verdict, so one
+``cancelled`` instance holds a PR at BLOCKED even after a later run of
+the same workflow concludes success (#3154, #3042). Workflows that
+publish a required context therefore keep ``cancel-in-progress: false``
+and let a duplicate report a real conclusion instead of leaving a
+cancelled tombstone.
+
+This module pins both halves: the rule, and the closed list of
+exceptions. Adding a `pull_request` workflow without a group fails here,
+and so does turning cancellation off on a workflow not on the list.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - dev env should have pyyaml
+    pytest.skip("pyyaml not installed", allow_module_level=True)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_WORKFLOWS = _REPO_ROOT / ".github" / "workflows"
+
+# Workflows that do NOT cancel a superseded run on a pull_request event.
+# Documented in docs/operations/ci.md under "Gating vs advisory workflows".
+NO_CANCEL_EXCEPTIONS = {
+    # Publishes the required `review-bot-ack` context. A cancelled instance
+    # of a required check-run holds the PR at BLOCKED (#3154, #3042).
+    "review-bot-ack.yml",
+}
+
+# `cancel-in-progress` may be an expression rather than a literal. This one
+# cancels on pull_request and preserves the per-SHA push-to-main signal, so
+# it satisfies the PR-side rule.
+_PR_ONLY_CANCEL = "github.event_name == 'pull_request'"
+
+# Workflows that publish a context branch protection requires on `main`.
+GATING_WORKFLOWS = {"ci.yml", "ci-gate-stub.yml", "review-bot-ack.yml"}
+
+
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _triggers(workflow: dict) -> dict:
+    on = workflow.get("on", workflow.get(True)) or {}
+    if isinstance(on, str):
+        return {on: None}
+    if isinstance(on, list):
+        return dict.fromkeys(on)
+    return on
+
+
+def _pull_request_workflows() -> list[tuple[str, dict]]:
+    found = []
+    for path in sorted(_WORKFLOWS.glob("*.yml")):
+        workflow = _load(path)
+        if "pull_request" in _triggers(workflow):
+            found.append((path.name, workflow))
+    return found
+
+
+def test_there_are_pull_request_workflows_to_check() -> None:
+    assert len(_pull_request_workflows()) >= 15
+
+
+@pytest.mark.parametrize("name, workflow", _pull_request_workflows(), ids=lambda v: v if isinstance(v, str) else "")
+def test_declares_a_pr_scoped_concurrency_group(name: str, workflow: dict) -> None:
+    concurrency = workflow.get("concurrency")
+    assert concurrency, (
+        f"{name} triggers on pull_request without a concurrency group, so each "
+        "push to a PR leaves the previous push's runs holding the pool"
+    )
+    group = str(concurrency["group"] if isinstance(concurrency, dict) else concurrency)
+    assert "github.event.pull_request.number" in group or "github.ref" in group, (
+        f"{name}'s concurrency group is not keyed on the PR or its ref"
+    )
+
+
+@pytest.mark.parametrize("name, workflow", _pull_request_workflows(), ids=lambda v: v if isinstance(v, str) else "")
+def test_cancellation_is_off_only_for_documented_exceptions(name: str, workflow: dict) -> None:
+    concurrency = workflow.get("concurrency")
+    cancel = concurrency.get("cancel-in-progress") if isinstance(concurrency, dict) else None
+    cancels_on_pr = cancel is True or (isinstance(cancel, str) and _PR_ONLY_CANCEL in cancel)
+    if name in NO_CANCEL_EXCEPTIONS:
+        assert not cancels_on_pr, (
+            f"{name} is listed as a no-cancel exception but cancels on pull_request; "
+            "drop it from NO_CANCEL_EXCEPTIONS and from docs/operations/ci.md"
+        )
+        return
+    assert cancels_on_pr, (
+        f"{name} does not cancel a superseded pull_request run and is not a "
+        "documented exception. Only workflows publishing a required context may "
+        "skip cancellation - a cancelled required check-run holds the PR at "
+        "BLOCKED (#3154, #3042)."
+    )
+
+
+def test_gating_workflows_are_the_only_required_context_emitters() -> None:
+    """Guard the premise of the exception list."""
+    emitters = set()
+    for path in sorted(_WORKFLOWS.glob("*.yml")):
+        text = path.read_text(encoding="utf-8")
+        if "review-bot-ack" in text and "pull_request" in text:
+            emitters.add(path.name)
+    assert "review-bot-ack.yml" in emitters
+    assert NO_CANCEL_EXCEPTIONS <= GATING_WORKFLOWS, (
+        "a no-cancel exception was granted to a workflow that publishes no required context; advisory work must cancel"
+    )
+
+
+def test_ci_md_documents_the_gating_split() -> None:
+    ci_md = (_REPO_ROOT / "docs" / "operations" / "ci.md").read_text(encoding="utf-8")
+    assert "## Gating vs advisory workflows" in ci_md
+    for name in GATING_WORKFLOWS:
+        assert name in ci_md, f"{name} is gating but not named in docs/operations/ci.md"
+    for name in NO_CANCEL_EXCEPTIONS:
+        assert name in ci_md, f"{name} is a no-cancel exception but is undocumented"


### PR DESCRIPTION
## Summary

Three CI issues in the v3.11.0 milestone. Two carried a diagnosis that the
run metadata does not support, so the correction is stated first in each
case and the change follows from what the metadata actually shows.

Closes #3093
Closes #3108
Closes #3096

## #3093 coverage ratchet

**What the history shows.** The branch has been a constant
(`coverage-ratchet/baseline`) since #2336, and the action does update the
open PR in place: #2963 carries eight `HeadRefForcePushed` events from
`github-actions` across four hours and stayed one PR the whole time. So
the workflow is not opening a PR per fire.

**What actually produces the duplicate pairs.** Every second PR in each
pair was created only after a human closed the first: #2853 closed then
#2855 opened, #2963 closed then #2978 opened, #3054 closed then #3090,
#3090 closed then #3098. The closures are the loop, and the reason for
them is that the PR cannot merge. A pull request created with
`GITHUB_TOKEN` does not trigger workflows, so `CI gate` and
`review-bot-ack` never report, branch protection holds it at BLOCKED while
the rollup reads SUCCESS, and an operator closes it to clear the list. A
closed PR cannot be reopened by force-pushing its branch, so the next fire
has to open a new one.

#3158 is that state right now: `MERGEABLE` / `BLOCKED`, `rollup=SUCCESS`,
neither required context ever reported.

**Changes.**

- The PR is created with `BERNSTEIN_AUTOSYNC_TOKEN`, falling back to
  `GITHUB_TOKEN` where the secret is absent, so it collects its checks and
  merges on its own.
- A guard step closes a second defect. `scripts/coverage_ratchet.py`
  compares the measurement against the baseline committed on `main`, not
  against the one the open ratchet PR carries, and those diverge as soon
  as a ratchet PR exists. A measurement between the two still counted as a
  bump against `main`, so force-pushing it rewrote the open PR with a
  *lower* high-water mark. The guard reads the baseline on the ratchet
  branch and skips the update unless the new measurement is strictly
  greater.
- The `.coverage-baseline.json` bump to 82.31% that #3158 carries is
  folded into this branch, so it lands under an identity that triggers CI.
  #3158 is closed as superseded.

**On the acceptance criteria.** The AC asks for `cancel-in-progress` on
the concurrency group. Kept at `false` deliberately: the group is already
a constant so two fires serialise, and cancelling between the force-push
and the `create-pull-request` call would leave a pushed branch with no
pull request. Serialising is the safer half of that trade and costs
nothing, since the job is minutes-bounded.

**Workflow enablement.** `Coverage ratchet (total)` is already `active`
in `gh workflow list`, along with `PR labels` and `PR policy`. No
re-enable step is outstanding.

**Guard evidence.** The guard's shell was extracted from the workflow and
executed against a stubbed `gh` for all four cases:

| Open PR baseline | Measured | `proceed` |
|---|---|---|
| no branch | 82.31 | `true` |
| 82.31 | 82.20 | `false` |
| 82.31 | 82.31 | `false` |
| 82.31 | 82.44 | `true` |

**Structural test.** `tests/unit/test_coverage_ratchet_workflow_yaml.py`
pins the constant branch name, the token preference and its ordering, the
existence of the guard and that the PR step is gated on it, and the
non-cancelling concurrency group.

## #3108 post-CI dispatcher

**The premise is a measurement artefact.** A `workflow_run`-triggered run
is stamped with the default-branch tip SHA, not the SHA of the run that
triggered it. So a burst of upstream completions displays as one SHA
repeated, which is what "seven runs on `65a5a1b5`" is.

Checked against the upstream runs, the dispatcher fires exactly once per
CI run:

| Dispatcher runs | Window | CI runs completing in that window |
|---|---|---|
| 12 on `59cf11af` | 20:53:44 to 20:55:05 | 12, distinct SHAs |
| 7 on `41e1c627` | 16:58:07 to 16:58:29 | 7, distinct SHAs |
| 7 on `65a5a1b5` | 16:26:31 to 16:26:36 | 7, distinct SHAs |

Every run is `run_attempt: 1`, `event: workflow_run`. There is no
multiplication and no re-run involved, so no deduplication is added.

**The real defect.** The `meta` job boots a runner for every completed CI
run, including cancelled ones, and cancelled is the dominant conclusion
during a merge wave: `ci.yml` keys push-to-main runs per SHA and never
cancels them, so the tail gets mass-cancelled to reclaim capacity and each
cancellation pays a dispatcher runner slot to reach a routing decision
that is always "nothing". `meta` now skips `cancelled` and `skipped`.

**Why that cannot suppress a release.** Every job in `auto-release.yml`
requires `inputs.conclusion == 'success'`, directly or through its `needs`
(`release` needs `gate`, `gate` carries the guard). Its stale-trigger
alert takes only `failure`, `timed_out` and `action_required`, and its own
comment records `cancelled` as deliberately excluded. `auto-heal`,
`bernstein-ci-fix` and `bisect-on-red` each require exactly `failure`.
`success` is admitted unconditionally by the new condition, so the release
path is untouched.

Verified three ways: by reading each child's gate, by
`test_auto_release_jobs_still_gate_on_success` walking the `needs` graph
in `auto-release.yml`, and by
`test_filter_does_not_intersect_the_auto_release_alert_set`, which reads
the alert conclusion list out of `auto-release.yml` rather than copying
it, so widening one file fails the test in the other.

**Idempotency of each child under a double invocation**, as the AC asks:

| Child | Idempotent | Basis |
|---|---|---|
| `auto-release` | yes | The tag push is the natural idempotency key, and the stale-alert path has two dedup layers (same title, then a 24h cross-SHA window). |
| `auto-heal` | yes | Keyed on a heal branch per SHA; a second invocation force-pushes the same branch and updates the same PR. |
| `bernstein-ci-fix` | yes | Gated on `auto-heal` not having opened a heal PR, which serialises the two fixers on a failing SHA. |
| `bisect-on-red` | yes | Comments and issue creation are per culprit SHA. |

No separate issue is needed.

**Documentation.** The file now carries a DO NOT PRUNE header naming
itself as the sole invocation path for all four `workflow_call`-only
children, since that coupling is invisible from `auto-release.yml`.

## #3096 advisory workflows

**Counting runs inverts the picture.** The free-tier ceiling is 20
concurrent *jobs*, so the budget is jobs. Measured on one head SHA of
#3157, 18 workflow runs resolve to 47 runner jobs:

| Role | Runs | Runner jobs | Share of pool |
|---|---|---|---|
| `ci.yml` | 1 | 34 | 72% |
| `review-bot-ack` | 4 | 4 | 9% |
| All advisory work | 13 | 9 | 19% |

An advisory workflow is one job; `ci.yml` is 34. Applying the AC's first
option and moving every advisory lane off the PR path would return under a
fifth of the pool while deleting all pre-merge signal that is not the test
matrix, so none of the three options is taken. The load that saturates the
pool is concurrent `ci.yml` runs, and the durable fix for that is the
merge queue, which `ci.yml` already triggers on.

The advisory lanes are also already cheap rather than merely present:
`pr-observability-summary` runs only on PRs labelled `deep-review`,
`dependabot-auto-merge` gates its only job on the Dependabot user id (0
runner jobs on a non-Dependabot PR), `pr-policy` and `pr-labels` are
consolidated single-job lanes, and the vulture / refurb / perflint jobs
run weekly.

**Fan-out, before and after.** Unchanged: 14 runs per branch push on a
docs PR (#3165), 18 on a workflow-touching PR (#3157). The number this
issue is really about is the job count, and the advisory share of it is
9 of 47.

**Concurrency AC.** All 22 `pull_request` workflows already declare a
concurrency group keyed on the PR or its ref, and all but one cancel a
superseded pull-request run. The single exception is `review-bot-ack.yml`,
which publishes a required context: branch protection folds every
check-run of a required name into its verdict, so one `cancelled` instance
holds the PR at BLOCKED even after a later run succeeds (#3154, #3042).
`ci.yml` and `codeql.yml` express cancellation as
`${{ github.event_name == 'pull_request' }}`, cancelling the PR lane and
keeping the per-SHA push-to-`main` lane alive so a release commit's CI is
never cancelled by the next merge.

`tests/unit/test_pull_request_workflow_concurrency_yaml.py` pins the rule
and the closed exception list, so a new `pull_request` workflow cannot
land without a group and an exception cannot be added silently.

**`docs/operations/ci.md`** gains a "Gating vs advisory workflows" section
naming the three gating workflows, listing the advisory ones, carrying the
job-share measurement, and documenting the no-cancel exception.

**`PR labels` and `PR policy`** are already `active` in
`gh workflow list`. No re-enable step is outstanding.

## Verification

- `uv run ruff check src/ tests/ scripts/ --fix`: clean.
- `uv run ruff format`: applied.
- `uv run pytest tests/unit/ -k "workflow or topology"`: 616 passed.
- `uvx zizmor` on both changed workflows: no findings.
- `uv run python scripts/check_docs_drift.py`: no drift.
- `docs/operations/ci-topology.md` regenerated with
  `scripts/gen_workflow_topology.py`.
- `ci.yml` reads only `diff_coverage_floor_percent` from
  `.coverage-baseline.json`, which is unchanged at 85, so the total bump
  does not move any PR gate.
