### PR TITLE
fix(cli): register merge on its command body, enforce the blast-radius ceiling, sanitise auth log sinks

### DIFF
--- a/src/bernstein/cli/commands/merge_cmd.py
+++ b/src/bernstein/cli/commands/merge_cmd.py
@@ -56,6 +56,29 @@ def _current_branch(root: Path) -> str:
     return _run_git(["rev-parse", "--abbrev-ref", "HEAD"], root)
 
 
+def _verify_merge_result(root: Path, merge_msg: str, switched: bool, original_branch: str) -> None:
+    """Verify merge succeeded or handle conflicts."""
+    _run_git(["rev-parse", "HEAD"], root)
+    merge_log = _run_git(["log", "-1", "--oneline"], root)
+
+    is_merge_success = merge_msg[:20] in merge_log or "Merge" in merge_log
+    if is_merge_success:
+        console.print(f"[green]Merged successfully:[/green] {merge_log}")
+        return
+
+    status = _run_git(["status", "--porcelain"], root)
+    has_conflicts = any(line[:2] in ("UU", "AA", "DD") for line in status.splitlines() if len(line) >= 2)
+    if has_conflicts:
+        console.print("[red]Merge conflicts detected![/red]")
+        console.print("[dim]Resolve conflicts manually, then commit.[/dim]")
+        _run_git(["merge", "--abort"], root)
+        if switched:
+            _run_git(["checkout", original_branch], root)
+        raise SystemExit(1)
+
+    console.print(f"[green]Merge completed:[/green] {merge_log}")
+
+
 # ---------------------------------------------------------------------------
 # CLI command
 # ---------------------------------------------------------------------------
@@ -87,29 +110,6 @@ def _current_branch(root: Path) -> str:
     metavar="AGENT",
     help="Also delete branches of rejected agents (repeatable).",
 )
-def _verify_merge_result(root: Path, merge_msg: str, switched: bool, original_branch: str) -> None:
-    """Verify merge succeeded or handle conflicts."""
-    _run_git(["rev-parse", "HEAD"], root)
-    merge_log = _run_git(["log", "-1", "--oneline"], root)
-
-    is_merge_success = merge_msg[:20] in merge_log or "Merge" in merge_log
-    if is_merge_success:
-        console.print(f"[green]Merged successfully:[/green] {merge_log}")
-        return
-
-    status = _run_git(["status", "--porcelain"], root)
-    has_conflicts = any(line[:2] in ("UU", "AA", "DD") for line in status.splitlines() if len(line) >= 2)
-    if has_conflicts:
-        console.print("[red]Merge conflicts detected![/red]")
-        console.print("[dim]Resolve conflicts manually, then commit.[/dim]")
-        _run_git(["merge", "--abort"], root)
-        if switched:
-            _run_git(["checkout", original_branch], root)
-        raise SystemExit(1)
-
-    console.print(f"[green]Merge completed:[/green] {merge_log}")
-
-
 def merge_cmd(
     pick: str,
     base: str,

--- a/src/bernstein/core/agents/spawner_merge.py
+++ b/src/bernstein/core/agents/spawner_merge.py
@@ -50,19 +50,24 @@ def _allow_merge_to_default_branch(env: dict[str, str] | None = None) -> bool:
     return raw is not None and raw.strip().lower() in _TRUTHY_ALLOW
 
 
-def _record_merge_refusal(worktree_root: Path, session_id: str, branch: str) -> None:
-    """Persist a visible record that a default-branch merge was refused.
+def _record_merge_refusal(
+    worktree_root: Path,
+    session_id: str,
+    branch: str,
+    reason: str = "target-is-default-branch",
+) -> None:
+    """Persist a visible record that a merge was refused.
 
     Written to ``.sdd/runtime/refused_merges.jsonl`` next to the pending-push
     journal so an operator (and any postmortem) can see exactly which session
-    was blocked, on which branch, and when.
+    was blocked, on which branch, why, and when.
     """
     import json as _json
 
     entry = {
         "session_id": _sanitise_for_log(session_id),
         "branch": _sanitise_for_log(branch),
-        "reason": "target-is-default-branch",
+        "reason": _sanitise_for_log(reason),
         "ts": time.time(),
     }
     try:
@@ -84,6 +89,63 @@ def _sanitise_for_log(value: str) -> str:
     called inside the spawner hot path.
     """
     return value.replace("\r", "").replace("\n", "") if value else value
+
+
+# ---------------------------------------------------------------------------
+# Blast-radius reversibility gate (issue #1322, wired in by #3135)
+# ---------------------------------------------------------------------------
+
+
+def _incoming_change(worktree_root: Path, branch: str) -> tuple[list[str], str]:
+    """Return ``(files, diff_text)`` for what merging ``branch`` would bring in.
+
+    Both are computed against the merge base with the checked-out branch, so
+    the score describes this merge rather than the branch's whole history.
+    An unreadable branch yields an empty change, which the scorer treats as
+    a zero-risk one; the gate below refuses only on evidence.
+    """
+    from bernstein.core.git_ops import run_git
+
+    spec = f"HEAD...{branch}"
+    names = run_git(["diff", "--name-only", spec], worktree_root, timeout=30)
+    if names.returncode != 0:
+        return [], ""
+    files = [line.strip() for line in names.stdout.splitlines() if line.strip()]
+    body = run_git(["diff", spec], worktree_root, timeout=60)
+    return files, body.stdout if body.returncode == 0 else ""
+
+
+def _blast_radius_refusal(
+    session: AgentSession,
+    worktree_root: Path,
+    branch: str,
+) -> MergeResult | None:
+    """Refuse the merge when it exceeds the operator's blast-radius ceiling.
+
+    Returns ``None`` when the merge may proceed, which includes the default
+    case where no ceiling was requested.
+    """
+    from bernstein.core.lifecycle.blast_radius_gate import ceiling_requested, evaluate_pre_merge
+
+    if not ceiling_requested():
+        return None
+
+    files, diff_text = _incoming_change(worktree_root, branch)
+    decision = evaluate_pre_merge(files=files, diff_text=diff_text)
+    if decision is None or decision.allowed:
+        return None
+
+    _record_merge_refusal(worktree_root, session.id, branch, reason="blast-radius-ceiling")
+    logger.error(
+        "Refusing to merge agent work from %s: %s",
+        _sanitise_for_log(session.id),
+        _sanitise_for_log(decision.reason),
+    )
+    from bernstein.core.metric_collector import get_collector
+
+    for task_id in session.task_ids:
+        get_collector().record_merge_result(task_id, success=False)
+    return MergeResult(success=False, conflicting_files=[], error=decision.reason)
 
 
 # ---------------------------------------------------------------------------
@@ -141,6 +203,13 @@ def _run_merge_and_push(
                 f"default branch; set {ENV_ALLOW_MERGE_TO_DEFAULT_BRANCH}=1 to override"
             ),
         )
+
+    # Reversibility gate (#1322): an operator who set ``--max-blast-radius``
+    # gets the ceiling evaluated here, on the change this merge would land.
+    # Off by default; a run without the flag reaches the merge unchanged.
+    blast_radius_refusal = _blast_radius_refusal(session, worktree_root, f"agent/{session.id}")
+    if blast_radius_refusal is not None:
+        return blast_radius_refusal
 
     merge_start = time.perf_counter()
     # Provenance: record the call site before invoking the merge so the

--- a/src/bernstein/core/lifecycle/blast_radius_gate.py
+++ b/src/bernstein/core/lifecycle/blast_radius_gate.py
@@ -2,15 +2,20 @@
 
 This module is the single integration point between the blast-radius scorer
 in :mod:`bernstein.core.quality.blast_radius` and the merge / deploy gate.
-It is intentionally tiny: orchestrator callers invoke
-:func:`install_blast_radius_gate` after building a
-:class:`bernstein.core.security.blocking_hooks.BlockingHookRunner`. The
-function is a no-op unless the operator opted in via
-``--max-blast-radius`` (which propagates the ``BERNSTEIN_MAX_BLAST_RADIUS``
-env var).
+:func:`install_blast_radius_gate` registers the hook on a
+:class:`bernstein.core.security.blocking_hooks.BlockingHookRunner`;
+:func:`evaluate_pre_merge` is the caller-facing entry point that builds a
+runner, installs the hook and evaluates one candidate merge.  Both are
+no-ops unless the operator opted in via ``--max-blast-radius`` (which
+propagates the ``BERNSTEIN_MAX_BLAST_RADIUS`` env var).
 
 Default behaviour stays unchanged: when the env var is unset, no hook is
 registered and the gate is a pass-through.
+
+Requesting a ceiling that cannot be honoured is not the same as not
+requesting one.  When the env var carries a value the gate cannot use,
+:func:`evaluate_pre_merge` denies instead of passing, so a merge never
+reports success under a ceiling that was never evaluated.
 """
 
 from __future__ import annotations
@@ -20,12 +25,28 @@ import os
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from bernstein.core.security.blocking_hooks import BlockingHookRunner
+    from collections.abc import Sequence
+
+    from bernstein.core.security.blocking_hooks import BlockingHookResult, BlockingHookRunner
 
 logger = logging.getLogger(__name__)
 
 #: Operator-visible env var that carries the ceiling from `bernstein run`.
 ENV_MAX_BLAST_RADIUS: str = "BERNSTEIN_MAX_BLAST_RADIUS"
+
+#: Blocking-hook event this gate registers on.
+PRE_MERGE_EVENT: str = "pre_merge"
+
+
+def ceiling_requested() -> bool:
+    """Return ``True`` when the operator asked for a ceiling at all.
+
+    Distinct from :func:`_read_ceiling` returning a value: a malformed or
+    out-of-range setting is still a request, and must not be treated as
+    "no gate wanted".
+    """
+    raw = os.environ.get(ENV_MAX_BLAST_RADIUS)
+    return raw is not None and raw.strip() != ""
 
 
 def _read_ceiling() -> float | None:
@@ -62,9 +83,68 @@ def install_blast_radius_gate(runner: BlockingHookRunner) -> bool:
     from bernstein.core.quality.blast_radius import make_pre_merge_hook
 
     hook = make_pre_merge_hook(max_score=ceiling)
-    runner.register("pre_merge", hook)
+    runner.register(PRE_MERGE_EVENT, hook)
     logger.info("Blast-radius reversibility gate active: ceiling=%.4f (pre_merge).", ceiling)
     return True
 
 
-__all__ = ["ENV_MAX_BLAST_RADIUS", "install_blast_radius_gate"]
+def evaluate_pre_merge(*, files: Sequence[str], diff_text: str) -> BlockingHookResult | None:
+    """Evaluate one candidate merge against the operator's ceiling.
+
+    Builds a :class:`BlockingHookRunner`, installs the gate on it through
+    :func:`install_blast_radius_gate`, and runs the ``pre_merge`` event for
+    the supplied change.
+
+    Args:
+        files: Paths the merge would bring in.
+        diff_text: Diff body for the content detectors.
+
+    Returns:
+        ``None`` when no ceiling was requested, so the caller proceeds
+        exactly as before.  Otherwise the hook result: ``allowed=False``
+        carries a reason naming the computed score and the ceiling.
+    """
+    if not ceiling_requested():
+        return None
+
+    from bernstein.core.hook_events import BlockingHookPayload, HookEvent
+    from bernstein.core.security.blocking_hooks import BlockingHookResult, BlockingHookRunner
+
+    raw = os.environ.get(ENV_MAX_BLAST_RADIUS, "")
+    runner = BlockingHookRunner()
+    try:
+        if not install_blast_radius_gate(runner):
+            # The operator asked for a ceiling and did not get one.  Passing
+            # here would report a gate that was never evaluated.
+            return BlockingHookResult(
+                allowed=False,
+                reason=(
+                    f"refused: {ENV_MAX_BLAST_RADIUS}={raw!r} is not a usable ceiling "
+                    f"in [0, 1], so the requested blast-radius gate could not be installed"
+                ),
+                hook_name="blast_radius",
+            )
+        payload = BlockingHookPayload(
+            event=HookEvent.PRE_MERGE,
+            action="merge",
+            context={"files": tuple(files), "diff_text": diff_text},
+        )
+        return runner.run(PRE_MERGE_EVENT, payload)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("Blast-radius gate could not be evaluated: %s", exc)
+        return BlockingHookResult(
+            allowed=False,
+            reason=f"refused: blast-radius gate could not be evaluated ({exc})",
+            hook_name="blast_radius",
+        )
+    finally:
+        runner.shutdown()
+
+
+__all__ = [
+    "ENV_MAX_BLAST_RADIUS",
+    "PRE_MERGE_EVENT",
+    "ceiling_requested",
+    "evaluate_pre_merge",
+    "install_blast_radius_gate",
+]

--- a/src/bernstein/core/quality/blast_radius.py
+++ b/src/bernstein/core/quality/blast_radius.py
@@ -506,7 +506,9 @@ def evaluate_gate(report: BlastRadiusReport, *, max_score: float | None) -> Gate
         raise ValueError(f"max_score must be in [0, 1], got {max_score}")
     if report.exceeds(max_score):
         if report.hard_one_way:
-            reason = f"refused: hard one-way detector fired and ceiling {max_score:.2f} < 1.0"
+            reason = (
+                f"refused: hard one-way detector fired, blast-radius score {report.score:.2f} > ceiling {max_score:.2f}"
+            )
         else:
             reason = f"refused: blast-radius score {report.score:.2f} > ceiling {max_score:.2f}"
         return GateDecision(allowed=False, threshold=max_score, report=report, reason=reason)

--- a/src/bernstein/core/security/auth_middleware.py
+++ b/src/bernstein/core/security/auth_middleware.py
@@ -78,6 +78,8 @@ from typing import TYPE_CHECKING, Any, Final, cast
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
+from bernstein.core.security.sanitize import sanitize_log
+
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
 
@@ -736,7 +738,7 @@ class SSOAuthMiddleware(BaseHTTPMiddleware):
             # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
             logger.warning(
                 "SSO token rejected: resource indicator mismatch (path=%s, expected=%s)",
-                path,
+                sanitize_log(path),
                 self._expected_resource,
             )
             return resource_error
@@ -780,8 +782,8 @@ class SSOAuthMiddleware(BaseHTTPMiddleware):
             if resource_error is not None:
                 logger.warning(
                     "Agent %s denied: resource indicator mismatch (path=%s, expected=%s)",
-                    agent_identity.id,
-                    path,
+                    sanitize_log(agent_identity.id),
+                    sanitize_log(path),
                     self._expected_resource,
                 )
                 return resource_error
@@ -802,8 +804,8 @@ class SSOAuthMiddleware(BaseHTTPMiddleware):
         if request.method not in _READ_METHODS and _get_required_permission(path, request.method) == _PERM_ADMIN_MANAGE:
             logger.warning(
                 "Agent %s denied operator-only path %s (admin:manage required)",
-                agent_identity.id,
-                path,
+                sanitize_log(agent_identity.id),
+                sanitize_log(path),
             )
             return JSONResponse(
                 status_code=403,
@@ -829,9 +831,9 @@ class SSOAuthMiddleware(BaseHTTPMiddleware):
             if task_scope_error is not None:
                 logger.warning(
                     "Agent %s denied task-scope access to %s: %s",
-                    agent_identity.id,
-                    path,
-                    task_scope_error,
+                    sanitize_log(agent_identity.id),
+                    sanitize_log(path),
+                    sanitize_log(task_scope_error),
                 )
                 return JSONResponse(
                     status_code=403,
@@ -1172,8 +1174,6 @@ def enforce_agent_task_scope_for_ids(request: Request, requested_task_ids: Itera
     if error is None:
         return
     from fastapi import HTTPException
-
-    from bernstein.core.security.sanitize import sanitize_log
 
     logger.warning(
         "Agent %s denied task-scope access to %s: %s",

--- a/src/bernstein/core/security/sanitize.py
+++ b/src/bernstein/core/security/sanitize.py
@@ -2,11 +2,53 @@
 
 from __future__ import annotations
 
+import re
+
+# Every character a log reader can treat as a record boundary, plus every
+# character that drives a terminal rendering the log.
+#
+# ``str.splitlines`` (and most log-shipping pipelines) break on more than CR
+# and LF: VT, FF, FS, GS, RS, NEL, LINE SEPARATOR and PARAGRAPH SEPARATOR all
+# start a new line.  URL parsing strips only TAB/CR/LF, so the rest of that
+# set reaches a log sink intact from a percent-encoded request path.  ESC and
+# the other C0/C1 bytes do not split a record but do let a caller repaint a
+# terminal or hide text from an operator reading the file.
+_UNSAFE_RE = re.compile("[\x00-\x1f\x7f-\x9f\u2028\u2029]")
+
+_NAMED_ESCAPES: dict[str, str] = {
+    "\n": "\\n",
+    "\r": "\\r",
+    "\t": "\\t",
+}
+
+_TRANSLATION: dict[int, str] = {
+    **{codepoint: f"\\x{codepoint:02x}" for codepoint in (*range(0x00, 0x20), 0x7F, *range(0x80, 0xA0))},
+    **{ord(char): escape for char, escape in _NAMED_ESCAPES.items()},
+    0x2028: "\\u2028",
+    0x2029: "\\u2029",
+}
+
 
 def sanitize_log(value: str) -> str:
-    """Remove newlines and carriage returns from a value before logging.
+    """Escape record-boundary and control characters before logging.
 
-    Prevents log injection attacks where user-controlled input could forge
-    log entries by embedding newline characters.
+    Prevents log injection, where caller-controlled input forges additional
+    log entries by embedding a character the log reader treats as the start
+    of a new record.
+
+    Printable text is returned unchanged, so sanitizing never alters the
+    meaning of a benign value.
+
+    Args:
+        value: Untrusted string bound for a ``logger.*`` call.
+
+    Returns:
+        *value* with every C0 control, DEL, C1 control, U+2028 and U+2029
+        replaced by a printable escape sequence.
     """
-    return value.replace("\n", "\\n").replace("\r", "\\r")
+    if not _UNSAFE_RE.search(value):
+        return value
+    return value.translate(_TRANSLATION)
+
+
+__all__ = ["sanitize_log"]

--- a/tests/unit/test_auth_middleware_log_sanitization.py
+++ b/tests/unit/test_auth_middleware_log_sanitization.py
@@ -1,0 +1,156 @@
+"""Log-sanitization tests for the auth middleware's denial sinks (#3070).
+
+The middleware logs the request path and the agent id on every denial
+branch.  ``path`` comes from the request line and is percent-decoded before
+it reaches the middleware, so ``%0A`` (and every other percent-encoded
+control byte) arrives as a raw control character.  An unescaped control
+character in a log argument lets a caller forge a second log record.
+
+Two properties are asserted here:
+
+*   The sink wrapper (``sanitize_log``) escapes every character that a log
+    reader treats as a record boundary, not only CR and LF.  ``str.splitlines``
+    also breaks on VT, FF, FS, GS, RS, NEL, U+2028 and U+2029, and any of
+    those survives URL parsing.
+*   Every denial branch in the middleware routes its untrusted values
+    through that wrapper, so a crafted path cannot forge a record on any of
+    them.  Fixing one call site would leave the neighbouring branches open.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+from urllib.parse import quote
+
+import pytest
+from fastapi.testclient import TestClient
+
+from bernstein.core.security.sanitize import sanitize_log
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from fastapi import FastAPI
+
+# These tests exercise the secure-by-default middleware, so opt out of the
+# autouse fixture that sets ``BERNSTEIN_AUTH_DISABLED`` for the suite.
+pytestmark = pytest.mark.auth_enabled
+
+_AUTH_LOGGER = "bernstein.core.security.auth_middleware"
+
+# Characters that survive URL parsing and still split a log record or drive a
+# terminal.  ``urlsplit`` removes TAB/CR/LF from the URL it is handed, so the
+# rest of this set is what actually reaches the sink from a live request.
+_RECORD_BREAKERS = "\v\f\x1c\x1d\x1e\x85\u2028\u2029"
+_TERMINAL_DRIVERS = "\x1b\x00\x07\x7f"
+_INJECTION_SUFFIX = "\nWARNING forged record\r\n" + _RECORD_BREAKERS + _TERMINAL_DRIVERS
+
+
+def _wire(raw_path: str) -> str:
+    """Percent-encode *raw_path* the way an attacker would put it on the wire.
+
+    The ASGI server decodes it back into ``scope["path"]``, which is how the
+    control characters reach the middleware in production.
+    """
+    return quote(raw_path, safe="/")
+
+
+def _is_clean(text: str) -> bool:
+    """True when *text* is a single record with no control characters left."""
+    if len(text.splitlines()) > 1:
+        return False
+    return all(ch == "\t" or (ch >= " " and ch != "\x7f" and not ("\x80" <= ch <= "\x9f")) for ch in text)
+
+
+# ---------------------------------------------------------------------------
+# Sink wrapper
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_log_escapes_every_record_breaker() -> None:
+    """No character that ``str.splitlines`` breaks on survives the wrapper."""
+    for ch in "\n\r" + _RECORD_BREAKERS:
+        cleaned = sanitize_log(f"before{ch}after")
+
+        assert ch not in cleaned, f"U+{ord(ch):04X} survived sanitize_log: {cleaned!r}"
+        assert len(cleaned.splitlines()) == 1, f"U+{ord(ch):04X} still forges a record: {cleaned!r}"
+
+
+def test_sanitize_log_escapes_control_bytes() -> None:
+    """C0, DEL and C1 control bytes are escaped rather than passed through."""
+    for ch in _TERMINAL_DRIVERS + "\x0e\x1f\x9b":
+        cleaned = sanitize_log(f"before{ch}after")
+
+        assert ch not in cleaned, f"U+{ord(ch):04X} survived sanitize_log: {cleaned!r}"
+    assert _is_clean(sanitize_log("".join(chr(c) for c in range(0, 0xA0))))
+
+
+def test_sanitize_log_keeps_printable_text_verbatim() -> None:
+    """Sanitizing must not change the meaning of a benign value."""
+    for value in ("safe content 123", "/tasks/abc-123/cancel", "agent-é中\U0001f600"):
+        assert sanitize_log(value) == value
+
+
+# ---------------------------------------------------------------------------
+# Middleware denial branches
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app(tmp_path: Path) -> FastAPI:
+    """Build the real application so the real middleware stack runs."""
+    from bernstein.core.server import create_app
+
+    return create_app(jsonl_path=tmp_path / ".sdd" / "runtime" / "tasks.jsonl")
+
+
+def _agent_headers(application: FastAPI, *, task_ids: list[str]) -> dict[str, str]:
+    store: Any = application.state.identity_store
+    _, token = store.create_identity("session-log-injection-probe", "backend", task_ids=task_ids)
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _denial_records(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    return [r for r in caplog.records if r.name == _AUTH_LOGGER and r.levelno >= logging.WARNING]
+
+
+def _assert_no_forged_record(caplog: pytest.LogCaptureFixture) -> None:
+    records = _denial_records(caplog)
+    assert records, "the denial branch did not log, so this test proves nothing"
+    for record in records:
+        message = record.getMessage()
+
+        assert _is_clean(message), f"unsanitised value reached the log sink: {message!r}"
+
+
+def test_operator_only_denial_log_is_sanitised(app: FastAPI, caplog: pytest.LogCaptureFixture) -> None:
+    """The ``admin:manage`` denial escapes the path it logs.
+
+    Unknown write routes fail closed to ``admin:manage``, so this reaches
+    the operator-only branch without depending on a specific route existing.
+    """
+    headers = _agent_headers(app, task_ids=[])
+    path = "/unknown-write-route" + _INJECTION_SUFFIX
+
+    with caplog.at_level(logging.WARNING, logger=_AUTH_LOGGER):
+        response = TestClient(app, client=("10.9.0.1", 41001)).post(_wire(path), headers=headers, json={})
+
+    assert response.status_code == 403, response.text
+    _assert_no_forged_record(caplog)
+
+
+def test_task_scope_denial_log_is_sanitised(app: FastAPI, caplog: pytest.LogCaptureFixture) -> None:
+    """The task-scope denial escapes both the agent id and the path.
+
+    The scope error message embeds the addressed task id, which is a slice
+    of the same attacker-controlled path, so it needs the wrapper too.
+    """
+    headers = _agent_headers(app, task_ids=["task-mine"])
+    path = "/tasks/task-not-mine" + _INJECTION_SUFFIX + "/cancel"
+
+    with caplog.at_level(logging.WARNING, logger=_AUTH_LOGGER):
+        response = TestClient(app, client=("10.9.0.2", 41002)).post(_wire(path), headers=headers, json={})
+
+    assert response.status_code == 403, response.text
+    _assert_no_forged_record(caplog)

--- a/tests/unit/test_blast_radius_run_gate.py
+++ b/tests/unit/test_blast_radius_run_gate.py
@@ -1,0 +1,225 @@
+"""``bernstein run --max-blast-radius`` must actually gate the merge (#3135).
+
+The ceiling reaches the orchestrator as ``BERNSTEIN_MAX_BLAST_RADIUS``,
+propagated by the ``bernstein run`` bootstrap.  Until this change nothing
+read it on the merge path, so an operator who set a ceiling in CI watched
+runs pass and concluded the ceiling held.
+
+These tests drive the ceiling through the CLI's own propagation function
+and then exercise the production merge path against a real git repository.
+The merge callable is a recorder, so "the merge never ran" is observable
+rather than inferred.  Calling ``install_blast_radius_gate`` directly is
+deliberately avoided: the existing unit tests already do that and passed
+throughout the period the flag did nothing.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
+
+import pytest
+
+from bernstein.core.agents.spawner_merge import _do_merge
+from bernstein.core.lifecycle.blast_radius_gate import ENV_MAX_BLAST_RADIUS
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_SESSION_ID = "backend-blastprobe"
+_BRANCH = f"agent/{_SESSION_ID}"
+
+# A hard one-way change: the shipped detectors force score 1.0 for a SQL
+# DROP inside a migration, so any ceiling below 1.0 must refuse it.
+_HARD_ONE_WAY_FILE = "migrations/0001_drop_users.sql"
+_HARD_ONE_WAY_BODY = "DROP TABLE users;\n"
+
+# A documentation-only change scores far below any sane ceiling.
+_REVERSIBLE_FILE = "docs/notes.md"
+_REVERSIBLE_BODY = "Some prose about the feature.\n"
+
+
+@pytest.fixture(autouse=True)
+def _restore_environ() -> Any:
+    """``_propagate_env_flags`` writes ``os.environ`` directly, so snapshot it."""
+    before = os.environ.copy()
+    yield
+    os.environ.clear()
+    os.environ.update(before)
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def _repo_with_agent_branch(tmp_path: Path, *, filename: str, body: str) -> Path:
+    """Build a repo on a non-default trunk with one agent branch to merge.
+
+    The trunk is deliberately not ``main``/``master`` so the pre-existing
+    protected-default-branch guard does not fire and mask the result.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "trunk")
+    _git(repo, "config", "user.email", "probe@example.invalid")
+    _git(repo, "config", "user.name", "Probe")
+    (repo / "README.md").write_text("start\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "initial")
+
+    _git(repo, "checkout", "-b", _BRANCH)
+    target = repo / filename
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(body, encoding="utf-8")
+    _git(repo, "add", filename)
+    _git(repo, "commit", "-m", "agent work")
+    _git(repo, "checkout", "trunk")
+    return repo
+
+
+def _set_ceiling_via_run_flag(ceiling: float | None) -> None:
+    """Propagate ``--max-blast-radius`` exactly as ``bernstein run`` does."""
+    from bernstein.cli.run_bootstrap import _propagate_env_flags
+
+    _propagate_env_flags(
+        profile=False,
+        workflow=None,
+        routing=None,
+        compliance=None,
+        sandbox=None,
+        container=False,
+        container_image=None,
+        two_phase_sandbox=False,
+        quiet=False,
+        task_filter=None,
+        auto_pr=False,
+        activity_log_path=None,
+        audit=False,
+        max_blast_radius=ceiling,
+    )
+
+
+def _make_session() -> Any:
+    class _Stub:
+        id = _SESSION_ID
+        task_ids = ["T-blast"]
+        role = "backend"
+
+    return _Stub()
+
+
+class _RecordingMergeFn:
+    """Records whether the merge was attempted at all."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def __call__(self, session_id: str, repo_root: Path) -> Any:
+        self.calls.append(session_id)
+
+        class _Result:
+            success = True
+            conflicting_files: list[str] = []
+            error = None
+
+        return _Result()
+
+
+def _merge(repo: Path) -> tuple[Any, _RecordingMergeFn]:
+    merge_fn = _RecordingMergeFn()
+    with patch("bernstein.core.git_ops.safe_push") as safe_push:
+        safe_push.return_value.ok = True
+        safe_push.return_value.stderr = ""
+        result = _do_merge(_make_session(), repo, {}, merge_fn)
+    return result, merge_fn
+
+
+# ---------------------------------------------------------------------------
+# The flag is propagated where the gate looks for it
+# ---------------------------------------------------------------------------
+
+
+def test_run_flag_propagates_the_ceiling_the_gate_reads() -> None:
+    """``--max-blast-radius`` lands on the env var the gate consumes."""
+    _set_ceiling_via_run_flag(0.25)
+
+    assert float(os.environ[ENV_MAX_BLAST_RADIUS]) == pytest.approx(0.25)
+
+
+def test_no_flag_leaves_the_ceiling_unset() -> None:
+    """Off by default: existing runs stay unaffected."""
+    os.environ.pop(ENV_MAX_BLAST_RADIUS, None)
+    _set_ceiling_via_run_flag(None)
+
+    assert ENV_MAX_BLAST_RADIUS not in os.environ
+
+
+# ---------------------------------------------------------------------------
+# The ceiling is enforced on the production merge path
+# ---------------------------------------------------------------------------
+
+
+def test_merge_refused_when_change_exceeds_the_run_ceiling(tmp_path: Path) -> None:
+    """A change above the ceiling is blocked, and the merge is never attempted."""
+    repo = _repo_with_agent_branch(tmp_path, filename=_HARD_ONE_WAY_FILE, body=_HARD_ONE_WAY_BODY)
+    _set_ceiling_via_run_flag(0.2)
+
+    result, merge_fn = _merge(repo)
+
+    assert merge_fn.calls == [], "the merge ran despite the ceiling"
+    assert result is not None
+    assert result.success is False
+    error = result.error or ""
+    assert "1.00" in error, f"the computed score is not named in the failure: {error!r}"
+    assert "0.20" in error, f"the ceiling is not named in the failure: {error!r}"
+
+
+def test_merge_proceeds_when_change_is_within_the_ceiling(tmp_path: Path) -> None:
+    """A reversible change under the ceiling is merged unchanged."""
+    repo = _repo_with_agent_branch(tmp_path, filename=_REVERSIBLE_FILE, body=_REVERSIBLE_BODY)
+    _set_ceiling_via_run_flag(0.9)
+
+    result, merge_fn = _merge(repo)
+
+    assert merge_fn.calls == [_SESSION_ID], "an in-budget change was blocked"
+    assert result is not None
+    assert result.success is True
+
+
+def test_merge_proceeds_when_no_ceiling_was_requested(tmp_path: Path) -> None:
+    """With no ``--max-blast-radius`` the gate is a pass-through."""
+    repo = _repo_with_agent_branch(tmp_path, filename=_HARD_ONE_WAY_FILE, body=_HARD_ONE_WAY_BODY)
+    os.environ.pop(ENV_MAX_BLAST_RADIUS, None)
+
+    result, merge_fn = _merge(repo)
+
+    assert merge_fn.calls == [_SESSION_ID]
+    assert result is not None
+    assert result.success is True
+
+
+def test_unusable_ceiling_refuses_rather_than_continuing(tmp_path: Path) -> None:
+    """A ceiling that cannot be installed must not read as a passed gate.
+
+    An operator who exported a malformed ceiling asked for enforcement.
+    Continuing would teach them the ceiling held when it was never
+    evaluated, which is the defect this issue is about.
+    """
+    repo = _repo_with_agent_branch(tmp_path, filename=_REVERSIBLE_FILE, body=_REVERSIBLE_BODY)
+    os.environ[ENV_MAX_BLAST_RADIUS] = "not-a-float"
+
+    result, merge_fn = _merge(repo)
+
+    assert merge_fn.calls == [], "the merge ran with an unusable ceiling in force"
+    assert result is not None
+    assert result.success is False
+    assert "not-a-float" in (result.error or "")

--- a/tests/unit/test_cli_command_registration.py
+++ b/tests/unit/test_cli_command_registration.py
@@ -1,0 +1,105 @@
+"""Registration-level coverage for the top-level ``bernstein`` CLI group.
+
+Issue #3134: ``bernstein merge`` shipped broken because a ``@click.command``
+decorator stack landed on a private helper instead of on the command body.
+The bare function was then handed to ``cli.add_command``, so the object
+registered under ``merge`` was not a Click command at all.  Every existing
+test drove command implementations directly, so nothing exercised the
+top-level ``cli`` object and the defect stayed invisible.
+
+These tests close that gap.  They walk ``cli.commands`` and drive the CLI
+through ``CliRunner``, which is the only layer where a mis-wired decorator
+is observable.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.main import cli
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _command_names() -> list[str]:
+    return sorted(cli.commands)
+
+
+def test_every_registered_entry_is_a_click_command() -> None:
+    """No bare function may be registered on the top-level group.
+
+    ``Group.add_command`` stores whatever object it is handed.  A function
+    that lost its decorator stack is accepted silently and only fails when a
+    user (or ``man-pages``) reaches it.
+    """
+    not_commands = {
+        name: type(obj).__name__ for name, obj in cli.commands.items() if not isinstance(obj, click.Command)
+    }
+    assert not_commands == {}, f"Entries registered on the top-level CLI that are not click.Command: {not_commands}"
+
+
+def test_every_registered_command_exposes_help() -> None:
+    """Every registered entry must carry a help string the tree walker can read.
+
+    ``generate_all_man_pages`` reads ``cmd.help`` for every entry in
+    ``cli.commands``.  An entry without that attribute takes
+    ``bernstein man-pages`` down.
+    """
+    missing = sorted(
+        name for name, obj in cli.commands.items() if not (hasattr(obj, "help") and hasattr(obj, "short_help"))
+    )
+    assert missing == [], f"Registered commands the man-page tree walker cannot read: {missing}"
+
+
+@pytest.mark.parametrize("name", _command_names())
+def test_command_help_resolves_through_top_level_cli(name: str) -> None:
+    """``bernstein <command> --help`` must resolve for every registered command.
+
+    Driving this through the top-level ``cli`` object is the point: a
+    module-level invocation of the implementation function would pass even
+    when the registration is broken.
+    """
+    result = CliRunner().invoke(cli, [name, "--help"])
+    assert result.exit_code == 0, (
+        f"`bernstein {name} --help` exited {result.exit_code}: {result.output}\n{result.exception!r}"
+    )
+
+
+def test_merge_help_lists_documented_options() -> None:
+    """``bernstein merge --help`` publishes the options documented for it.
+
+    ``docs/reference/cli/task-lifecycle.md`` publishes a synopsis for this
+    command, so the flags below are a documented contract.
+    """
+    result = CliRunner().invoke(cli, ["merge", "--help"])
+    assert result.exit_code == 0, f"{result.output}\n{result.exception!r}"
+    for option in ("--pick", "--base", "--workdir", "--no-ff", "--message", "--dry-run", "--reject"):
+        assert option in result.output, f"`bernstein merge --help` does not list {option}:\n{result.output}"
+
+
+def test_merge_dry_run_reports_and_exits_zero(tmp_path: Path) -> None:
+    """``bernstein merge --pick ... --dry-run`` runs the real command body.
+
+    With no agents registered the command reports that nothing resolved and
+    exits non-zero, which still proves the 216-line command body is reached:
+    the broken registration could not get this far.
+    """
+    result = CliRunner().invoke(cli, ["merge", "--pick", "no-such-agent", "--workdir", str(tmp_path), "--dry-run"])
+    assert not isinstance(result.exception, AttributeError), repr(result.exception)
+    assert "no-such-agent" in result.output, result.output
+
+
+def test_man_pages_completes(tmp_path: Path) -> None:
+    """``bernstein man-pages`` walks the whole command tree without raising.
+
+    It fails as collateral damage from any non-command entry in
+    ``cli.commands``.
+    """
+    result = CliRunner().invoke(cli, ["man-pages", "--output-dir", str(tmp_path)])
+    assert result.exit_code == 0, f"{result.output}\n{result.exception!r}"
+    assert list(tmp_path.glob("bernstein-merge.1")), sorted(p.name for p in tmp_path.iterdir())[:20]


### PR DESCRIPTION
Three independent defects on the run and auth surface, each with a test that fails on current `main` and passes here.

## `bernstein merge` was registered on the wrong function (#3134)

The `@click.command("merge")` stack plus every `@click.option` sat on the private helper `_verify_merge_result`, and the 216-line command body `merge_cmd` was left undecorated. `cli.add_command(merge_cmd, "merge")` then registered a bare function.

Two consequences, both reproduced on `origin/main`:

```
>>> cli.commands['merge']
<class 'function'>            # not a click.Command
>>> CliRunner().invoke(cli, ['merge', '--help'])
AttributeError("'function' object has no attribute 'make_context'")
>>> CliRunner().invoke(cli, ['man-pages', '--output-dir', d])
AttributeError("'function' object has no attribute 'help'")
```

`man-pages` walks `cli.commands` reading `cmd.help`, so it went down as collateral damage. Moving the decorator stack onto `merge_cmd` clears both.

The registered name does not change, so `DOCUMENTED_COMMANDS` in `tests/unit/test_readme_api_coverage.py` already lists `merge` and needs no edit. Both of its tests still pass.

**New coverage.** `tests/unit/test_cli_command_registration.py` walks `cli.commands` and asserts every entry is a `click.Command` with a readable `help`, then drives `<command> --help` through the top-level `cli` object for all of them. No test in the tree drove any command through `cli` before, which is exactly why this shipped. On `main`: 5 failures. After: 206 pass.

## `run --max-blast-radius` was accepted and never enforced (#3135)

The flag propagated to `BERNSTEIN_MAX_BLAST_RADIUS` and nothing read it.

**Why the fix is not the one the issue proposed.** The issue suggests calling `install_blast_radius_gate` on a lifecycle hook runner during run bootstrap. There is no hook runner on that path, and grepping `src/` for anything that emits `pre_merge` returns only enum definitions and a notification mapping table. No production code runs blocking hooks at all. Installing the gate on a runner nothing invokes would have replaced one decorative flag with another, which is the same defect class the issue is about.

The flag's own help text says it refuses merges. So the ceiling is enforced where a run actually merges: `_run_merge_and_push` in `core/agents/spawner_merge.py`, the reap-and-merge of an agent worktree branch back into the checked-out branch, immediately after the existing protected-default-branch guard and shaped the same way.

`install_blast_radius_gate` keeps its documented role as the single integration point. A new `evaluate_pre_merge` builds the runner, installs the gate through it, and runs the `pre_merge` event over the change the merge would land (`git diff HEAD...agent/<session>`).

Against the acceptance criteria:

| Criterion | How it is met |
| --- | --- |
| Over-ceiling run is blocked, score and ceiling both named | Refusal message carries both. `evaluate_gate`'s hard-one-way branch named only the ceiling, so it now names the score too. |
| Under-ceiling run proceeds unchanged | Merge callable is invoked as before. |
| Gate that cannot be installed does not silently continue | A ceiling that is requested but unusable (malformed, out of range, or an installation error) refuses. `_read_ceiling` returning `None` for a malformed value used to be indistinguishable from "no ceiling wanted". |
| Driven from the flag, not from `install_blast_radius_gate` | The test propagates the ceiling through `run_bootstrap`'s own `_propagate_env_flags` and exercises the merge path against a real git repository. |

Off by default: with no flag set, `ceiling_requested()` is false and the merge path is untouched.

**New coverage.** `tests/unit/test_blast_radius_run_gate.py`. The merge callable is a recorder, so "the merge never ran" is observed rather than inferred. On `main` the two enforcement tests fail; the pass-through tests pass on both sides, which is the point.

## Unsanitised request path reached the auth middleware log sink (#3070)

`path` is `request.url.path`, which is percent-decoded, so control bytes arrive raw.

Sanitising only the call site named in the issue would have left three neighbouring denial branches open, and would not have helped anyway, because `sanitize_log` escaped only CR and LF. `str.splitlines` (and most log-shipping pipelines) also break on VT, FF, FS, GS, RS, NEL, U+2028 and U+2029. `urlsplit` strips TAB/CR/LF from the URL it parses, so **those are precisely the characters that do reach the sink**, along with ESC for terminal escapes.

So the fix is at the sink and at every call site:

- `sanitize_log` now escapes every C0 control, DEL, every C1 control, and U+2028/U+2029. Printable input is returned unchanged, so a benign value's logged meaning is untouched. CR and LF keep their existing `\n` / `\r` escapes.
- All four denial branches in `auth_middleware` (SSO resource mismatch, agent resource mismatch, operator-only path, task scope) route the agent id, the path and the scope error through it. The task-scope error embeds the addressed task id, a slice of the same attacker-controlled path.

**New coverage.** `tests/unit/test_auth_middleware_log_sanitization.py` drives the real FastAPI middleware with a percent-encoded path carrying `\n`, `\r\n`, VT, FF, FS, GS, RS, NEL, U+2028, U+2029, ESC, NUL, BEL and DEL, then asserts the emitted record is a single line with no control characters left. On `main`, the captured record is:

```
Agent session-... denied task-scope access to /tasks/task-not-mineWARNING forged record\x0b\x0c\x1c\x1d\x1e\x85  \x1b\x00\x07\x7f/cancel: ...
```

## Verification

- `uv run ruff check src/ tests/ scripts/ --fix`: clean
- `uv run ruff format src/ tests/ scripts/`: clean
- New suites plus `test_sanitize`, `test_blast_radius`, `test_readme_api_coverage`, `test_spawner_merge_queue_wiring`: 254 passed
- Everything matching `sanitiz|sanitis|auth_middleware|clearance|task_crud|sla_receipt|claim_next` under `tests/unit`: 368 passed

RFC 8785 key ordering (#3105) is deliberately not in this branch: it moves signed bytes and lands separately.

Closes #3134
Closes #3135
Closes #3070
