### PR TITLE
fix(security): sort JCS property names by UTF-16 code units per RFC 8785

### DIFF
--- a/docs/security/jcs-canonicalization.md
+++ b/docs/security/jcs-canonicalization.md
@@ -1,0 +1,100 @@
+# JCS canonicalization and property-name ordering
+
+Bernstein signs and hashes structured payloads over RFC 8785 (JSON
+Canonicalization Scheme) bytes. `canonicalize_jcs` in
+`bernstein.core.security.agent_card_signer` is the single producer of those
+bytes. Everything that has to be verifiable by a third party goes through it:
+
+| Surface | Module |
+| --- | --- |
+| Agent identity cards (detached JWS) | `core/security/agent_card_signer.py` |
+| A2A capability cards and conformance checks | `core/interop/a2a_card.py`, `core/interop/a2a_conformance.py` |
+| Capability tokens | `core/security/capability_tokens.py` |
+| Delegation scope digests | `core/identity/delegation_scope.py` |
+| Payment mandates and transaction receipts | `core/payments/` |
+| Tenant showback statements | `core/cost/showback_canonical.py` |
+| Update advisories and version pins | `core/distribution/update_advisory.py` |
+| `/.well-known/agent.json` and `agent-card.json` | `core/routes/well_known.py` |
+
+## Ordering rule
+
+RFC 8785 section 3.2.3 sorts object property names as **arrays of UTF-16 code
+units**. It does not sort by Unicode code point.
+
+The two orders agree for every property name whose characters are below
+U+D800, which covers ASCII, Latin, CJK and everything else in the Basic
+Multilingual Plane below the surrogate range. They disagree in exactly one
+case: a **supplementary-plane** name (a character above U+FFFF, such as an
+emoji or a plane-2 CJK ideograph) compared against a name starting in
+**U+E000 to U+FFFF**. In UTF-16 the supplementary name begins with a high
+surrogate in U+D800 to U+DBFF, which sorts *below* that range, while its code
+point sorts *above* it.
+
+```
+{"a": 1, "": 2, "\U0001F600": 3}
+
+UTF-16 code units (RFC 8785):  a , U+1F600 , U+E000
+Unicode code points:           a , U+E000  , U+1F600
+```
+
+`JCS_CANONICALIZATION_VERSION` records which rule the current build applies:
+
+| Version | Ordering | Shipped in |
+| --- | --- | --- |
+| 1 | Unicode code point | up to v3.10.0 |
+| 2 | UTF-16 code units (RFC 8785 conformant) | v3.11.0 onwards |
+
+## What changed and who is affected
+
+Version 2 changes the canonical bytes, and therefore the signature and the
+digest, for **any object that carries a supplementary-plane property name
+alongside a name in U+E000 to U+FFFF**. Nothing else changes: for every other
+payload the bytes are identical to version 1, byte for byte.
+
+Every property name Bernstein itself emits is ASCII, so all self-produced
+artefacts (agent cards, capability tokens, mandates, receipts, advisories,
+version pins, well-known routes) are unaffected and need no action.
+
+Two surfaces accept caller-supplied property names and can therefore reach the
+changed case:
+
+- `AgentIdentityCard.extensions`, a free-form map negotiated at spawn time and
+  included in the signed card body.
+- Inbound payloads canonicalized for verification: remote A2A agent cards
+  (`check_agent_card_v1_conformance`), AGNTCY ADS descriptors, advisory
+  documents, version pins, and showback statement trees supplied by a caller.
+
+## Migration
+
+If you have never used a non-ASCII key in `extensions` or in a showback
+statement payload, there is nothing to do.
+
+Otherwise:
+
+1. **Find affected artefacts.** An artefact is affected only if one of its
+   objects has both a property name above U+FFFF and a property name in
+   U+E000 to U+FFFF. `bernstein audit verify` and the A2A conformance check
+   report such an artefact as a signature mismatch, not as a reordering, so
+   look for verification failures that appear after upgrading while the bytes
+   on disk are unchanged.
+2. **Re-sign, do not re-order.** Re-issue the artefact with the current build.
+   The body content is unchanged; only the canonical byte order of the
+   affected object differs.
+3. **Verifiers upgrade first.** A verifier still on version 1 rejects a
+   version 2 signature over an affected object, and vice versa. Upgrade
+   verifying parties before re-signing.
+
+An independent RFC 8785 implementation (for example `rfc8785` in Python or
+`canonicalize` in Node) agrees with version 2 and disagreed with version 1,
+which is the reason for the change: under version 1 a conformant third-party
+verifier recomputing over the same object read a valid Bernstein signature as
+invalid.
+
+## Test vectors
+
+`tests/fixtures/showback/canonical_vectors.json` carries cross-language
+vectors for the canonical core. The last statement vector is the disagreeing
+case; its expected bytes are derived from the RFC rule itself (names sorted by
+their UTF-16BE encoding, which is a big-endian serialisation of the code-unit
+array) rather than from any implementation, so it pins the specification
+rather than a tool.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -436,6 +436,7 @@ nav:
           - Capability matrix: security/capability-matrix.md
           - Manager auth: security/manager-auth.md
           - Agent-card keystore: security/keystore.md
+          - JCS canonicalization: security/jcs-canonicalization.md
           - MCP signing: security/mcp-signing.md
           - OWASP ASI detectors: security/owasp-asi.md
           - Promptware: security/promptware.md

--- a/src/bernstein/core/security/agent_card_signer.py
+++ b/src/bernstein/core/security/agent_card_signer.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "AGENT_CARD_V1_TYP",
+    "JCS_CANONICALIZATION_VERSION",
     "AgentCardSignature",
     "canonicalize_jcs",
     "ed25519_pem_from_jwk",
@@ -52,10 +53,62 @@ __all__ = [
 #: entry, and the v1.0 conformance suite rejects any other value.
 AGENT_CARD_V1_TYP: str = "agent-card+jws"
 
+#: Canonical-bytes revision produced by :func:`canonicalize_jcs`.
+#:
+#: ``1`` sorted object property names by Unicode code point. ``2`` sorts them
+#: as arrays of UTF-16 code units, which is what RFC 8785 §3.2.3 requires.
+#: The two revisions produce identical bytes for every property name below
+#: U+D800, so every payload whose names are ASCII or BMP is unaffected. They
+#: differ only for an object carrying a supplementary-plane name (above
+#: U+FFFF) alongside a name in U+E000..U+FFFF.
+#:
+#: See ``docs/security/jcs-canonicalization.md`` for what to re-sign.
+JCS_CANONICALIZATION_VERSION: int = 2
+
 
 # ---------------------------------------------------------------------------
 # JCS (RFC 8785) canonicalization
 # ---------------------------------------------------------------------------
+
+
+def _property_name(key: Any) -> str:
+    """Return the JSON property name ``json.dumps`` would emit for ``key``.
+
+    RFC 8785 sorts *property names*, which are always strings, so a non-string
+    mapping key is coerced first and then sorted as the string it becomes.
+    """
+    if isinstance(key, str):
+        return key
+    if isinstance(key, bool):
+        return "true" if key else "false"
+    if key is None:
+        return "null"
+    if isinstance(key, (int, float)):
+        return json.dumps(key, allow_nan=False)
+    raise TypeError(f"keys must be str, int, float, bool or None, not {type(key).__name__}")
+
+
+def _utf16_code_units(name: str) -> bytes:
+    """Return ``name`` as UTF-16BE bytes.
+
+    Comparing these bytes lexicographically is equivalent to comparing the
+    UTF-16 code-unit arrays RFC 8785 §3.2.3 specifies, because UTF-16BE is a
+    big-endian serialisation of exactly those code units. ``surrogatepass``
+    keeps the ordering total for a lone surrogate; such a value still fails
+    the UTF-8 encode below, exactly as it did before.
+    """
+    return name.encode("utf-16-be", errors="surrogatepass")
+
+
+def _sorted_by_code_units(value: Any) -> Any:
+    """Rebuild ``value`` with every object's names in RFC 8785 order."""
+    if isinstance(value, dict):
+        named = [(_property_name(key), item) for key, item in value.items()]
+        named.sort(key=lambda pair: _utf16_code_units(pair[0]))
+        return {name: _sorted_by_code_units(item) for name, item in named}
+    if isinstance(value, (list, tuple)):
+        return [_sorted_by_code_units(item) for item in value]
+    return value
 
 
 def canonicalize_jcs(value: Any) -> bytes:
@@ -65,7 +118,11 @@ def canonicalize_jcs(value: Any) -> bytes:
     AgentIdentityCard surface (strings, ints, floats from ``time.time()``,
     booleans, lists, and dicts):
 
-    - Object keys sorted lexicographically by code-point.
+    - Object property names sorted as arrays of UTF-16 code units
+      (RFC 8785 §3.2.3), not by code point. The two orders agree for every
+      name below U+D800 and disagree only when a supplementary-plane name
+      meets a name in U+E000..U+FFFF, because the supplementary name starts
+      with a high surrogate in U+D800..U+DBFF.
     - No insignificant whitespace; ``,`` and ``:`` separators only.
     - Strings emitted with UTF-8, escaping ``"``, ``\\``, and control chars.
     - Numbers via Python's ``json.dumps`` (which matches IEEE 754 double
@@ -78,8 +135,8 @@ def canonicalize_jcs(value: Any) -> bytes:
         The cards we sign do not produce those values today.
     """
     return json.dumps(
-        value,
-        sort_keys=True,
+        _sorted_by_code_units(value),
+        sort_keys=False,
         separators=(",", ":"),
         ensure_ascii=False,
         allow_nan=False,

--- a/tests/fixtures/showback/canonical_vectors.json
+++ b/tests/fixtures/showback/canonical_vectors.json
@@ -1,6 +1,6 @@
 {
   "schema": "showback-canonical-vectors-v1",
-  "notes": "Cross-language vectors for the tenant showback canonical core. money_parse/money_render cover the operator-facing decimal-string format (nano-USD fixed scale, 9 fractional digits); float_bridge covers the one-time conversion from the float spend ledger (shortest round-trip decimal of the IEEE 754 double, then ROUND_HALF_EVEN to 1e-9); nfc covers the reject-don't-repair text policy; statements bind validated payload trees to RFC 8785 canonical bytes via sha256. The statement vectors below the seed set are anchored: their canonical bytes were generated with rfc8785 0.1.4 (Python) and independently reproduced by erdtman canonicalize 3.0.0 (Node) in the agent-passport-system cross-impl suite. Note that nano_usd values are JSON numbers and the boundary cases deliberately exceed the IEEE 754 double-exact integer range, so a reader must parse them with a bigint-aware JSON parser to reproduce these vectors.",
+  "notes": "Cross-language vectors for the tenant showback canonical core. money_parse/money_render cover the operator-facing decimal-string format (nano-USD fixed scale, 9 fractional digits); float_bridge covers the one-time conversion from the float spend ledger (shortest round-trip decimal of the IEEE 754 double, then ROUND_HALF_EVEN to 1e-9); nfc covers the reject-don't-repair text policy; statements bind validated payload trees to RFC 8785 canonical bytes via sha256. The statement vectors below the seed set are anchored: their canonical bytes were generated with rfc8785 0.1.4 (Python) and independently reproduced by erdtman canonicalize 3.0.0 (Node) in the agent-passport-system cross-impl suite. Note that nano_usd values are JSON numbers and the boundary cases deliberately exceed the IEEE 754 double-exact integer range, so a reader must parse them with a bigint-aware JSON parser to reproduce these vectors. The final statement vector (supplementary-plane name against U+E000..U+FFFF) is the one case where RFC 8785 3.2.3 UTF-16 code-unit ordering and Unicode code-point ordering disagree; its canonical bytes were derived from the RFC rule itself (names sorted by their UTF-16BE encoding) rather than from any implementation, so it pins the spec rather than a tool.",
   "money_parse": [
     {
       "desc": "integer dollars",
@@ -405,6 +405,16 @@
         "😁": 4
       },
       "sha256": "5d93bf574c9410e623e62518df36b19b04c5bf2a8024adfa93598ed015d6dea0"
+    },
+    {
+      "desc": "supplementary-plane property name against a name in U+E000..U+FFFF, where code point and utf-16 order differ",
+      "payload": {
+        "a": 1,
+        "": 2,
+        "😀": 3,
+        "�": 4
+      },
+      "sha256": "343e081ac53dae4eec03f409a3b2f47dcba8e5bd492b34bdc964d642d48c72fa"
     }
   ]
 }

--- a/tests/property/test_a2a_card_bughunt.py
+++ b/tests/property/test_a2a_card_bughunt.py
@@ -19,13 +19,14 @@ surface. Findings:
     Verified against the official RFC 8785 reference test vectors -
     ``structures.json`` fails for exactly this reason (``56.0`` ≠ ``56``).
 
-#3 (xfail - RFC 8785 §3.2.3 key-sort order):
-    Object keys are sorted by Unicode code point (Python ``sort_keys``)
-    rather than UTF-16 code units (RFC 8785 §3.2.3). For BMP-only keys this
-    is identical; once a key crosses U+FFFF (surrogate pair) the bytes
-    diverge from spec. The reference ``weird.json`` test vector fails for
-    this reason - ``😂`` (U+1F602, UTF-16 high-surrogate 0xD83D) sorts
-    before ``שּ`` (U+FB33) under UTF-16 but after under codepoint order.
+#3 (FIXED in #3105 - RFC 8785 §3.2.3 key-sort order):
+    Object keys used to be sorted by Unicode code point (Python
+    ``sort_keys``) rather than by UTF-16 code units. For BMP-only keys the
+    two agree; once a key crosses U+FFFF (surrogate pair) the bytes diverged
+    from spec, because ``😂`` (U+1F602, UTF-16 high surrogate 0xD83D) sorts
+    before ``שּ`` (U+FB33) under UTF-16 and after it under code-point order.
+    ``canonicalize_jcs`` now sorts property names by UTF-16 code units, so
+    ``test_rfc_8785_utf16_keysort`` below is a positive assertion.
 
 #4 (operational, xfail - verifier accepts expired cards):
     ``verify_agent_card`` does not consult ``card.is_expired()`` -
@@ -74,7 +75,8 @@ RFC 8785 reference vector status (cyberphone/json-canonicalization):
     french.json    PASS
     values.json    PASS
     structures.json FAIL (#2 - integer-valued float ``56.0`` ≠ ``56``)
-    weird.json     FAIL (#3 - UTF-16 surrogate-pair sort)
+    weird.json     FAIL (U+007F escaping in a string value; its key order,
+                   the #3 surrogate-pair case, is correct since #3105)
 """
 
 from __future__ import annotations
@@ -271,22 +273,20 @@ def test_rfc_8785_negative_zero_normalised() -> None:
 
 
 # ---------------------------------------------------------------------------
-# #3: RFC 8785 §3.2.3 - UTF-16 code-unit key sort
+# #3: RFC 8785 §3.2.3 - UTF-16 code-unit key sort (FIXED in #3105)
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    reason=(
-        "RFC 8785 §3.2.3 sorts object keys by UTF-16 code unit. Python "
-        "sort_keys=True sorts by Unicode code point. Identical for BMP-only "
-        "keys; diverges once a key contains a non-BMP character (codepoint "
-        "> U+FFFF). Today's card surface uses ASCII keys exclusively so this "
-        "is a future-proofing concern, but a strict third-party verifier with "
-        "SMP keys in custom extensions would compute different bytes."
-    ),
-    strict=True,
-)
 def test_rfc_8785_utf16_keysort() -> None:
+    """Property names sort by UTF-16 code unit, not by code point.
+
+    This was an ``xfail(strict=True)`` recording a known deviation: a
+    supplementary-plane name starts with a high surrogate in
+    U+D800..U+DBFF, which sorts below U+E000..U+FFFF in UTF-16 and above
+    it by code point. ``AgentIdentityCard.extensions`` is a free-form map
+    that reaches the signed body, so a card could carry such a name and a
+    conformant third-party verifier would compute different bytes.
+    """
     bmp = ""  # codepoint 0xE000 (BMP private use)
     smp = "\U0001f600"  # codepoint 0x1F600, UTF-16 surrogate pair starting 0xD83D
     # UTF-16 code-unit order: smp (0xD83D) < bmp (0xE000) → smp key first.
@@ -537,11 +537,13 @@ def test_rfc_8785_vector_structures() -> None:
 
 @pytest.mark.xfail(
     reason=(
-        "RFC 8785 reference vector ``weird.json`` exercises UTF-16 code-unit "
-        "key sort with mixed BMP and SMP characters (😂 U+1F602 high "
-        "surrogate 0xD83D vs שּ U+FB33). Python sort_keys=True uses "
-        "codepoint order which inverts the relative position. Same root "
-        "cause as #3."
+        "The key-sort half of this vector passes since #3105: 😂 (U+1F602, "
+        "UTF-16 high surrogate 0xD83D) now sorts before שּ (U+FB33), which is "
+        "the RFC 8785 §3.2.3 order. The remaining divergence is unrelated to "
+        "key order - it is the escaping of U+007F inside a string VALUE, "
+        "which belongs to §3.2.2.2 string serialization and is tracked "
+        "separately. Do not fold it into a key-ordering change: it moves "
+        "signed bytes for a different class of payload."
     ),
     strict=True,
 )

--- a/tests/unit/test_canonicalize_jcs_key_order.py
+++ b/tests/unit/test_canonicalize_jcs_key_order.py
@@ -1,0 +1,130 @@
+"""RFC 8785 property-name ordering for ``canonicalize_jcs`` (#3105).
+
+RFC 8785 section 3.2.3 sorts object property names as arrays of UTF-16 code
+units.  Sorting by Unicode code point agrees with that everywhere except one
+case: a supplementary-plane name (above U+FFFF) compared against a name
+starting in U+E000 to U+FFFF.  In UTF-16 the supplementary name begins with a
+high surrogate in U+D800 to U+DBFF, which sorts below that range, while its
+code point sorts above it.
+
+``canonicalize_jcs`` produces the bytes that get signed, so the two orders
+producing different bytes means an independent RFC 8785 verifier recomputing
+over the same object reads a valid signature as invalid.
+
+The expected byte strings below are derived from the RFC rule directly (sort
+the names by their UTF-16BE encoding, which is a byte-order-preserving
+serialisation of the code-unit array) rather than from an implementation, so
+this file does not inherit any implementation's opinion.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from bernstein.core.security.agent_card_signer import canonicalize_jcs
+
+# The minimal disagreeing pair from the issue: U+10000 (supplementary,
+# UTF-16 D800 DC00) against U+FF21 (BMP, above the surrogate range).
+_LOW_IN_UTF16 = chr(0x10000)
+_HIGH_IN_UTF16 = chr(0xFF21)
+
+
+def _rfc8785_order(obj: dict[str, object]) -> bytes:
+    """Encode *obj* with property names sorted per RFC 8785 section 3.2.3."""
+    ordered = {key: obj[key] for key in sorted(obj, key=lambda name: name.encode("utf-16-be"))}
+    return json.dumps(ordered, separators=(",", ":"), ensure_ascii=False, allow_nan=False).encode("utf-8")
+
+
+def test_supplementary_name_sorts_below_private_use_name() -> None:
+    """The exact pair named in the issue, pinned to literal bytes."""
+    obj = {_LOW_IN_UTF16: 1, _HIGH_IN_UTF16: 2}
+
+    assert canonicalize_jcs(obj) == b'{"\xf0\x90\x80\x80":1,"\xef\xbc\xa1":2}'
+
+
+def test_code_point_order_would_differ() -> None:
+    """Guard: the vector is only meaningful because the two orders disagree.
+
+    If a future change made code-point order agree here, this test would stop
+    proving anything, so assert the disagreement explicitly.
+    """
+    obj = {_LOW_IN_UTF16: 1, _HIGH_IN_UTF16: 2}
+    code_point_bytes = json.dumps(
+        obj,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+    assert canonicalize_jcs(obj) != code_point_bytes
+
+
+@pytest.mark.parametrize(
+    "obj",
+    [
+        # Supplementary name against the whole U+E000..U+FFFF band.
+        {chr(0x1F600): 1, chr(0xE000): 2, chr(0xFFFD): 3},
+        # Mixed planes, including names the two orders agree on.
+        {"a": 0, chr(0x1F600): 1, chr(0xE000): 2, chr(0xFFFD): 3, chr(0x4E2D): 4},
+        # Two supplementary names against each other.
+        {chr(0x10000): 1, chr(0x10FFFD): 2, chr(0xE000): 3},
+        # Nested objects are canonicalized too, not just the root.
+        {"outer": {chr(0x20000): 1, chr(0xF900): 2}},
+        # Inside an array element.
+        {"items": [{chr(0x1F600): 1, chr(0xFFFD): 2}]},
+    ],
+)
+def test_property_names_sort_by_utf16_code_units(obj: dict[str, object]) -> None:
+    assert canonicalize_jcs(obj) == _rfc8785_order_deep(obj)
+
+
+def _rfc8785_order_deep(value: object) -> bytes:
+    return json.dumps(
+        _sorted_tree(value),
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _sorted_tree(value: object) -> object:
+    if isinstance(value, dict):
+        return {
+            key: _sorted_tree(value[key])  # type: ignore[index]
+            for key in sorted(value, key=lambda name: str(name).encode("utf-16-be"))
+        }
+    if isinstance(value, list):
+        return [_sorted_tree(item) for item in value]
+    return value
+
+
+def test_ascii_and_bmp_payloads_are_byte_identical_to_code_point_order() -> None:
+    """Every name below U+D800 keeps the bytes it had before this change.
+
+    All shipped signing surfaces use ASCII property names, so this is the
+    property that makes the fix non-breaking for them.
+    """
+    payloads: list[dict[str, object]] = [
+        {"alg": "EdDSA", "kid": "k1", "typ": "JOSE"},
+        {"agent_id": "a", "role": "backend", "task_ids": ["t1"], "nested": {"b": 1, "a": 2}},
+        {"café": 1, "中": 2, "z": 3, "퟿": 4},
+    ]
+    for payload in payloads:
+        code_point_bytes = json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        ).encode("utf-8")
+
+        assert canonicalize_jcs(payload) == code_point_bytes, payload
+
+
+def test_non_string_property_names_still_encode() -> None:
+    """Integer and boolean names keep working, coerced as JSON requires."""
+    assert canonicalize_jcs({2: "b", 10: "a"}) == b'{"10":"a","2":"b"}'
+    assert canonicalize_jcs({True: 1, None: 2}) == b'{"null":2,"true":1}'


### PR DESCRIPTION
`canonicalize_jcs` sorted object property names by Unicode code point. RFC 8785 section 3.2.3 sorts them as arrays of UTF-16 code units.

The two orders agree for every name below U+D800. They disagree in exactly one case: a supplementary-plane name (above U+FFFF) against a name in U+E000..U+FFFF. In UTF-16 the supplementary name begins with a high surrogate in U+D800..U+DBFF, which sorts *below* that band, while its code point sorts *above* it.

```
{"a": 1, "": 2, "\U0001F600": 3}

RFC 8785 (UTF-16 code units):  a , U+1F600 , U+E000
code point (what we shipped):  a , U+E000  , U+1F600
```

This function produces the bytes that get signed: agent cards, payment mandates and receipts, capability tokens, delegation scope digests, showback statements, update advisories and version pins, and the well-known routes. Under the old order a conformant third-party verifier recomputing over the same object read a valid signature as *invalid* rather than as a reordering.

## This is a real compatibility break, not a latent one

The issue describes the condition as latent because property names on the signed surfaces are ASCII today. That is true of names Bernstein *emits*. It is not true of names Bernstein *canonicalizes*, and this was checked against the source rather than assumed. Three reachable paths:

| Path | Why a non-BMP name can arrive |
| --- | --- |
| `AgentIdentityCard.extensions` (`core/security/agent_identity.py`) | Declared `dict[str, str \| bool \| int \| float]`, documented as "free-form extension flags negotiated at spawn time", included in the signed card body via `_card_to_dict`. `_hydrate_card` reads it back from `identity.json` and deliberately tolerates unknown keys. |
| `check_agent_card_v1_conformance` (`core/interop/a2a_conformance.py:398`) | Canonicalizes an inbound remote agent card through `_strip_signatures`, which is `{k: v for k, v in payload.items() if k != "signatures"}` - a passthrough for every other key at every depth. |
| `verify_advisory_document`, `read_version_pin`, `canonical_statement_bytes` | Canonicalize caller- or file-supplied mappings. |

Verified empirically against this tree: signing a card with `extensions={"\U0001F600": True, "": 1}` produces a JWS that `verify_agent_card` accepts, with the supplementary-plane name inside the signed bytes.

No validator anywhere on these paths constrains a property name's plane. The only key-level check in the whole set is showback's `require_nfc`, and NFC is plane-agnostic: an emoji and a plane-2 CJK ideograph are already NFC. The five JSON schemas in `schemas/` carry no `propertyNames` or `patternProperties`.

So this needs a version marker, and it is not bundled with unrelated CLI work.

## Version marker and migration

`JCS_CANONICALIZATION_VERSION` records the revision (`1` = code point, `2` = UTF-16 code units). `docs/security/jcs-canonicalization.md` documents the ordering rule, which surfaces go through the canonicalizer, exactly which payloads change bytes, and the re-sign procedure (verifiers upgrade first; re-issue rather than re-order; artefacts appear as signature mismatches, not reorderings).

Bytes are unchanged for every payload whose property names are ASCII or BMP-below-surrogate, which is all self-produced artefacts. A test pins that property directly rather than leaving it as a claim.

## Non-string mapping keys

RFC 8785 sorts *property names*, which are always strings, so a non-string mapping key is coerced to its JSON name before sorting. An int-keyed dict now canonicalizes as `{"10":..,"2":..}` rather than `{"2":..,"10":..}`. No shipped payload uses non-string keys; every call site is either a dataclass `asdict`, a literal-keyed body, or parsed JSON.

## Tests

`tests/unit/test_canonicalize_jcs_key_order.py`, 8 of 9 tests failing on `origin/main` and all passing here. Expected bytes are derived from the RFC rule itself (names sorted by their UTF-16BE encoding, a big-endian serialisation of the code-unit array) rather than from any implementation, so the file pins the specification and not a tool's opinion. It also asserts the disagreement explicitly, so the vector cannot quietly stop proving anything.

`tests/fixtures/showback/canonical_vectors.json` gains the disagreeing vector, which is what the issue author asked for. The existing set stopped at `"supplementary-plane property names where code point and utf-16 order agree"`, so the cross-language suite exercised only the agreeing case. The new vector's note records that its bytes come from the RFC rather than from `rfc8785` or `canonicalize`, unlike the anchored vectors above it.

## Verification

- `uv run ruff check src/ tests/ scripts/ --fix`: clean
- `uv run ruff format src/ tests/ scripts/`: clean
- `test_canonicalize_jcs_key_order`, `test_showback_canonical`, `test_agent_card_signer`: 112 passed

Closes #3105
