### PR TITLE
fix(audit): verify the chain position a record states about itself

### DIFF
--- a/docs/security/audit-log.md
+++ b/docs/security/audit-log.md
@@ -248,6 +248,51 @@ filename, line number, expected vs stored prefix:
   ! 2026-05-07.jsonl:43: prev_hmac mismatch (expected a1b2c3d4… got deadbeef…)
 ```
 
+### The chain position a record states about itself
+
+many records carry `details.prev_chain_digest`: the chain head the
+writer says the record was appended onto. downstream consumers read
+it as the record's anchor - payment receipts lift it verbatim,
+capability tokens check their own `audit_head` against it, admission
+and SLA receipts link through it.
+
+the `hmac` covers the *bytes* of that statement, not its truth. a
+record naming a predecessor it never had signs exactly as cleanly as
+one naming its real predecessor, so a false anchor used to verify
+green. `verify` now compares the stated value against the record's own
+`prev_hmac` and reports the disagreement in its own words:
+
+```
+  ! 2026-05-07.jsonl:42: stated chain predecessor dededededededede… is not
+    the record's own predecessor 113651ab625159dc…
+```
+
+this is deliberately *not* worded as an HMAC or `prev_hmac` mismatch.
+those two mean the bytes or the linkage were altered. this one means
+the bytes are intact and authentic while the claim inside them is
+wrong - a writer defect, not tampering - and it is reported as a hard
+error, never as acknowledgeable tear evidence.
+
+an absent or empty `prev_chain_digest` is not a claim and is not
+checked: a writer with no chain wired records `""`, which asserts
+nothing.
+
+`bernstein audit seal` refuses over a false anchor for the same reason
+it refuses over a broken chain: a fresh root would pin a history that
+contains a claim known to be untrue. an operator who needs a seal over
+a chain carrying one - a record written by a pre-v3.11 writer, say -
+takes the documented forensic path, `--allow-broken-chain`, which
+never advances the checkpoint.
+
+one legacy exemption exists. before v3.11 the skill catalogue used the
+same key for "the previous install event *for this entry*", which is a
+real record but never the immediate predecessor. current catalogue
+writers record `prior_install_chain_head` instead, and
+`skill.catalog.install` / `skill.catalog.upgrade` records are exempt
+from the anchor check so segments written by older versions do not
+report a defect that has been removed. those records are still fully
+covered by the MAC and by `prev_hmac` linkage.
+
 run from cron (every 15 min is fine - the verify is read-only and a
 day's worth of events checks in milliseconds):
 
@@ -414,6 +459,15 @@ derived from today's UTC date). there is no in-process compaction;
 old files are gzipped into `.sdd/audit/archive/` by
 `AuditLog.archive(RetentionPolicy(retention_days=…))`, default 90
 days. invoke it from a maintenance job or a periodic timer.
+
+each segment's compress and unlink run inside one cross-process append
+section, taken per segment rather than once for the whole pass. the
+pair is not separable: the `.gz` holds the segment as the compress read
+it, so an append landing between the copy and the unlink would exist
+only in the file about to be removed. readers are tolerant of the same
+window from the other side - a segment that disappears between listing
+and reading is followed into its archived copy rather than raising, so
+a retention cycle can no longer take down an unrelated process.
 
 a minimal `logrotate` snippet, if you'd rather not run the python
 archiver:

--- a/src/bernstein/core/orchestration/schedule_supervisor.py
+++ b/src/bernstein/core/orchestration/schedule_supervisor.py
@@ -910,9 +910,15 @@ class ScheduleSupervisor:
             params_hash=params_hash,
         )
 
-        # Capture-head and append are one section: see _AuditChainAdapter.
+        # Capture-head and append are one section: see _AuditChainAdapter. A
+        # counterfactual appends nothing, so there is no record for the head to
+        # be wrong about and no reason to hold the chain against every other
+        # writer while a fire that did not happen is recorded.
         if self._chain is None:
             prev_chain = ""
+            chain_digest = self._append_audit(schedule, projection, prev_chain, counterfactual)
+        elif counterfactual:
+            prev_chain = self._chain.chain_tail
             chain_digest = self._append_audit(schedule, projection, prev_chain, counterfactual)
         else:
             with self._chain.transaction():

--- a/src/bernstein/core/orchestration/schedule_supervisor.py
+++ b/src/bernstein/core/orchestration/schedule_supervisor.py
@@ -27,6 +27,7 @@ Lifecycle: this class is callable from either a long-running
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import logging
@@ -37,7 +38,7 @@ from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterator
     from pathlib import Path
 
 from bernstein.core.orchestration.collision import (
@@ -265,13 +266,73 @@ class _AuditChainAdapter:
     Tests inject an in-memory chain; production wires the existing
     ``bernstein.core.security.audit.AuditLog`` whose HMAC chain primitives
     we re-use (do NOT invent a parallel chain - see AC and ticket Notes).
+
+    Capturing the head and appending the entry that sits on it is one
+    operation, not two. ``AuditLog.log`` re-syncs the tail from disk under a
+    cross-process lock before it writes, while :attr:`chain_tail` reads the
+    writer's per-instance cache, which never sees another process's appends. A
+    fire that captured the head first therefore recorded a chain position its
+    own record does not occupy, in both the entry payload and the receipt --
+    and because both were built from the same stale read they agreed with each
+    other, so nothing downstream noticed (#3131).
+
+    The writer is duck-typed, so the section is probed for rather than assumed.
+    :attr:`supports_transaction` says which of the two regimes is in force, so
+    a caller (and a test) can see the degradation instead of guessing.
     """
 
     def __init__(self, writer: Any) -> None:
         self._writer = writer
+        self._supports_transaction = callable(getattr(writer, "append_transaction", None)) and callable(
+            getattr(writer, "resync_head", None)
+        )
+        if not self._supports_transaction:
+            logger.debug(
+                "Audit writer %s has no append_transaction/resync_head; schedule fires will "
+                "capture the chain head from its cache, which is correct only while this "
+                "process is the sole writer.",
+                type(writer).__name__,
+            )
+
+    @property
+    def supports_transaction(self) -> bool:
+        """Whether the writer can hold the chain across capture-head and append."""
+        return self._supports_transaction
+
+    @contextlib.contextmanager
+    def transaction(self) -> Iterator[None]:
+        """Hold the chain across a capture-head-then-append section.
+
+        Degrades to a plain pass-through for a writer that cannot hold one
+        (an injected in-memory stub). That is sound for a stub, which is not
+        shared with any other process; the constructor records the degradation
+        and :attr:`supports_transaction` exposes it.
+        """
+        if not self._supports_transaction:
+            yield
+            return
+        with self._writer.append_transaction():
+            yield
+
+    def head(self) -> str:
+        """Return the chain head to record, read from disk where possible.
+
+        Must be called inside :meth:`transaction`: the value is only the head
+        the following append lands on for as long as the section is held.
+        """
+        if self._supports_transaction:
+            resynced = self._writer.resync_head()
+            if isinstance(resynced, str):
+                return resynced
+        return self.chain_tail
 
     @property
     def chain_tail(self) -> str:
+        """The writer's cached head. Safe to observe, not safe to record.
+
+        Recording this value is what #3131 was: use :meth:`head` inside
+        :meth:`transaction` for anything that ends up in an entry or a receipt.
+        """
         tail_attr = getattr(self._writer, "_prev_hmac", None)
         if isinstance(tail_attr, str):
             return tail_attr
@@ -714,8 +775,14 @@ class ScheduleSupervisor:
             # fire's own audit entry already records it).
             return self._fire(schedule, fire_epoch, counterfactual=False)
 
-        prev_chain = self._chain.chain_tail if self._chain is not None else ""
-        chain_digest = self._append_collision(schedule, fire_epoch, decision, running)
+        # Capture-head and append are one section: see _AuditChainAdapter.
+        if self._chain is None:
+            prev_chain = ""
+            chain_digest = self._append_collision(schedule, fire_epoch, decision, running)
+        else:
+            with self._chain.transaction():
+                prev_chain = self._chain.head()
+                chain_digest = self._append_collision(schedule, fire_epoch, decision, running)
         if decision.dispatch:
             # SUPERSEDE_WITH_HANDOFF: the stale run is checkpointed elsewhere;
             # the new fire proceeds, resuming from the recorded checkpoint.
@@ -843,8 +910,14 @@ class ScheduleSupervisor:
             params_hash=params_hash,
         )
 
-        prev_chain = self._chain.chain_tail if self._chain is not None else ""
-        chain_digest = self._append_audit(schedule, projection, prev_chain, counterfactual)
+        # Capture-head and append are one section: see _AuditChainAdapter.
+        if self._chain is None:
+            prev_chain = ""
+            chain_digest = self._append_audit(schedule, projection, prev_chain, counterfactual)
+        else:
+            with self._chain.transaction():
+                prev_chain = self._chain.head()
+                chain_digest = self._append_audit(schedule, projection, prev_chain, counterfactual)
 
         if not counterfactual:
             # #2302: seal the fire projection (with the schedule's recurrence

--- a/src/bernstein/core/security/audit.py
+++ b/src/bernstein/core/security/audit.py
@@ -365,15 +365,35 @@ def _compute_hmac(key: bytes, prev_hmac: str, entry: dict[str, Any]) -> str:
 #: thread out for the whole nested section, so re-entrancy never widens the
 #: window it exists to close.
 #:
-#: Guards are keyed by the *resolved* audit dir and never evicted. Resolving is
-#: load-bearing, not tidiness: two spellings of one directory would map to two
-#: guards, and a thread that entered under one spelling and re-entered under the
-#: other would see depth 0 and re-take the ``flock`` it already holds. Eviction
-#: is unsafe for the same reason a lock cannot be recreated while held, and the
-#: live set is one entry per audit dir a process actually writes to.
+#: Guards are keyed by the audit dir's ``(st_dev, st_ino)`` and never evicted.
+#: The identity is load-bearing, not tidiness: two spellings of one directory
+#: must map to one guard, or a thread that entered under one spelling and
+#: re-entered under the other sees depth 0 and re-takes the ``flock`` it already
+#: holds -- a self-deadlock, not a race. A resolved path string is *not* a
+#: sufficient identity: ``Path.resolve()`` resolves symlinks but does not fold
+#: case, and this project builds and runs on case-insensitive filesystems, so
+#: ``.../auditdir`` and ``.../AuditDir`` name one inode under two strings.
+#: Eviction is unsafe for the same reason a lock cannot be recreated while held,
+#: and the live set is one entry per audit dir a process actually writes to.
 _APPEND_GUARDS: dict[str, threading.RLock] = {}
 _APPEND_GUARDS_LOCK = threading.Lock()
 _APPEND_DEPTH = threading.local()
+
+
+def _audit_dir_key(audit_dir: Path) -> str:
+    """Return a spelling-independent identity for one audit directory.
+
+    ``(st_dev, st_ino)`` is stable across every spelling that reaches the same
+    directory: case variants, symlinks, relative and absolute forms, and bind
+    mounts of the same filesystem. Falls back to the resolved path only when
+    the directory cannot be stat'ed, which callers inside the lock never hit
+    because they create it first.
+    """
+    try:
+        stat_result = audit_dir.stat()
+    except OSError:  # pragma: no cover - the dir is created before every use
+        return f"path:{audit_dir.resolve()}"
+    return f"{stat_result.st_dev}:{stat_result.st_ino}"
 
 
 def _append_guard(audit_key: str) -> threading.RLock:
@@ -389,7 +409,7 @@ def _append_guard(audit_key: str) -> threading.RLock:
 def _inside_append_section(audit_dir: Path) -> bool:
     """Whether this thread currently holds *audit_dir*'s append section."""
     depths: dict[str, int] = getattr(_APPEND_DEPTH, "depths", None) or {}
-    return depths.get(str(audit_dir.resolve()), 0) > 0
+    return depths.get(_audit_dir_key(audit_dir), 0) > 0
 
 
 @contextlib.contextmanager
@@ -417,7 +437,7 @@ def _chain_append_lock(audit_dir: Path) -> Iterator[None]:
     wait for the outermost section to end.
     """
     audit_dir.mkdir(parents=True, exist_ok=True)
-    audit_key = str(audit_dir.resolve())
+    audit_key = _audit_dir_key(audit_dir)
     guard = _append_guard(audit_key)
     depths: dict[str, int] | None = getattr(_APPEND_DEPTH, "depths", None)
     if depths is None:
@@ -456,6 +476,67 @@ def _path_size(path: Path) -> int:
         return path.stat().st_size
     except OSError:
         return -1
+
+
+#: Sentinel stamp for a segment that is absent or unreadable.
+_ABSENT_STAMP: tuple[int, int, int, int] = (-1, -1, -1, -1)
+
+
+def _segment_stamp(path: Path) -> tuple[int, int, int, int]:
+    """Return ``(st_dev, st_ino, st_size, st_mtime_ns)`` for a live segment.
+
+    Byte length alone is not evidence that a segment is the one a writer last
+    appended to. A segment can be removed and regrown - retention compresses an
+    expired day and unlinks the original, an operator restores from a backup, a
+    container remounts a volume - and two identically shaped records occupy
+    exactly the same number of bytes, so the replacement can present the cached
+    length while holding a different chain. Identity ``(st_dev, st_ino)`` is
+    what distinguishes "still the same file" from "a different file of the same
+    size"; length still has to be there because an append by another writer
+    keeps the inode. ``st_mtime_ns`` is carried as a third signal at no extra
+    cost, though its resolution is filesystem-dependent and nothing relies on
+    it alone.
+    """
+    try:
+        stat_result = path.stat()
+    except OSError:
+        return _ABSENT_STAMP
+    return (
+        stat_result.st_dev,
+        stat_result.st_ino,
+        stat_result.st_size,
+        stat_result.st_mtime_ns,
+    )
+
+
+def _read_live_segment(log_path: Path, audit_dir: Path) -> bytes | None:
+    """Read a live segment, following retention when it archived it mid-read.
+
+    Every reader lists the live segments and then reads them, and ``archive()``
+    removes a segment between those two steps for any reader that happens to be
+    running. Before this existed the read raised ``FileNotFoundError`` and took
+    down chain recovery, ``query`` and ``verify`` alike - a routine retention
+    cycle could crash an unrelated process.
+
+    Retention writes the compressed copy and only then unlinks the original, so
+    a segment that vanished is already present in archived form. Reading that
+    copy returns exactly the bytes the live file held, which keeps the chain
+    linkage continuous instead of leaving a hole the verifier would report as
+    corruption. ``None`` means neither form is readable, which is a real
+    finding rather than a race.
+    """
+    try:
+        return log_path.read_bytes()
+    except FileNotFoundError:
+        pass
+    except OSError:
+        return None
+    gz_path = audit_dir / RetentionPolicy().archive_subdir / f"{log_path.name}.gz"
+    try:
+        with gzip.open(gz_path, "rb") as handle:
+            return handle.read()
+    except (OSError, EOFError):
+        return None
 
 
 def _split_jsonl_bytes(raw_bytes: bytes) -> list[bytes]:
@@ -517,6 +598,38 @@ class _ChainWalkContext:
     total: dict[str, int] = field(default_factory=dict)
     missing_newline: dict[str, str] = field(default_factory=dict)
     order: list[str] = field(default_factory=list)
+
+
+#: Details key by which a record states the chain head it was written onto.
+CHAIN_ANCHOR_KEY = "prev_chain_digest"
+
+#: Event types that carried :data:`CHAIN_ANCHOR_KEY` with a different meaning
+#: before v3.11: the skill catalogue used it for "the previous install of this
+#: entry", which is a real record but never the immediate predecessor. Current
+#: writers on that path record ``prior_install_chain_head`` instead, so this set
+#: only covers segments written by older versions and can be dropped once those
+#: chains have aged out of retention. Nothing is weakened by the exemption: the
+#: MAC and the ``prev_hmac`` linkage still cover those records in full, and the
+#: field they carry no longer makes a claim about chain position.
+_LEGACY_ANCHOR_EVENT_TYPES = frozenset({"skill.catalog.install", "skill.catalog.upgrade"})
+
+
+def _stated_predecessor(entry: dict[str, Any]) -> str | None:
+    """Return the chain predecessor a record states, or ``None`` if it states none.
+
+    An absent or empty value is not a claim: a caller with no chain wired
+    records ``""``, which says "I make no assertion about my position" rather
+    than asserting a false one.
+    """
+    if str(entry.get("event_type", "")) in _LEGACY_ANCHOR_EVENT_TYPES:
+        return None
+    details = entry.get("details")
+    if not isinstance(details, dict):
+        return None
+    stated = cast("dict[str, Any]", details).get(CHAIN_ANCHOR_KEY)
+    if not isinstance(stated, str) or not stated:
+        return None
+    return stated
 
 
 def _verify_log_bytes(
@@ -653,7 +766,23 @@ def _verify_log_bytes(
 
         if line_messages:
             _fail(line_no, line_offset, len(raw_line), "invalid_hmac", tuple(line_messages))
-        elif ctx is not None:
+            prev_hmac = stored_hmac
+            continue
+
+        stated = _stated_predecessor(entry)
+        if stated is not None and not _hmac.compare_digest(stated, entry_prev):
+            # Reported straight into ``errors`` and deliberately *not* into
+            # ``ctx.failures``: the bytes are canonical and the MAC is genuine,
+            # so this line is not damage. Feeding it to the tear model would
+            # shorten the verified prefix and reclassify honest history as
+            # crash-shaped tail damage an operator is invited to acknowledge
+            # away -- turning a hard failure into something clearable.
+            errors.append(
+                f"{display_name}:{line_no}: stated chain predecessor {stated[:16]}… "
+                f"is not the record's own predecessor {entry_prev[:16]}…"
+            )
+
+        if ctx is not None:
             line_end = line_offset + len(raw_line)
             if line_end < len(raw_bytes):
                 line_end += 1  # the terminator this line owns
@@ -1376,12 +1505,13 @@ class AuditLog:
         else:
             self._key = load_or_create_audit_key(key_path)
         self._prev_hmac = self._recover_chain_tail()
-        # Tracks the day file and its byte length after this instance's last
-        # append, so ``log`` can skip re-reading the tail from disk when no
-        # other writer has touched the file since (issue #2791). ``None`` /
-        # ``-1`` force a re-sync on the first append.
+        # Tracks the day file and its identity+length stamp after this
+        # instance's last append, so ``log`` can skip re-reading the tail from
+        # disk when no other writer has touched the file since (issue #2791).
+        # ``None`` / :data:`_ABSENT_STAMP` force a re-sync on the first append.
+        # See :func:`_segment_stamp` for why the stamp is not just the length.
         self._synced_path: Path | None = None
-        self._synced_size = -1
+        self._synced_stamp: tuple[int, int, int, int] = _ABSENT_STAMP
 
     # -- chain recovery -----------------------------------------------------
 
@@ -1407,7 +1537,13 @@ class AuditLog:
         """
         live_files = sorted(self._audit_dir.glob(_JSONL_GLOB), reverse=True)
         for log_path in live_files:
-            tip = _chain_tail_from_bytes(log_path.read_bytes(), self._key)
+            raw = _read_live_segment(log_path, self._audit_dir)
+            if raw is None:
+                # Retention removed the segment between the listing and the
+                # read and no archived copy is readable yet; the archived pass
+                # below covers the same history.
+                continue
+            tip = _chain_tail_from_bytes(raw, self._key)
             if tip is not None:
                 return tip
 
@@ -1492,21 +1628,28 @@ class AuditLog:
         therefore moves the head. Reading first would publish a head the next
         append does not chain onto.
 
-        Fast path: when the day file is byte-length-identical to what this
-        instance's own last append left it at, no other writer has touched it,
-        our own append always ends in ``b"\\n"`` so the tail cannot be torn,
-        and both the tear probe and the full rescan are skipped. The probe
-        must stay behind this branch: unconditionally it is a stat + open +
-        seek + read on every append, which is a measurable fraction of append
-        throughput.
+        Fast path: when the day file is the same file, of the same length, as
+        the one this instance's own last append left behind, no other writer
+        has touched it, our own append always ends in ``b"\\n"`` so the tail
+        cannot be torn, and both the tear probe and the full rescan are
+        skipped. The probe must stay behind this branch: unconditionally it is
+        a stat + open + seek + read on every append, which is a measurable
+        fraction of append throughput.
+
+        "Same file" is a real part of that test, not decoration. Length alone
+        stopped being sufficient once a segment could be removed and regrown
+        (see :func:`_segment_stamp`): the fast path then fired over a segment
+        holding a different chain, and the append chained onto a head that was
+        no longer on disk. The stamp is read from the same ``stat`` the length
+        comes from, so the check costs nothing extra.
 
         The slow path records what it synced, so a nested append inside the
         same ``append_transaction`` section takes the fast path instead of
         re-scanning the segment it just scanned. The caller must hold the
         chain append lock.
         """
-        size = _path_size(log_path)
-        if log_path == self._synced_path and size == self._synced_size:
+        stamp = _segment_stamp(log_path)
+        if log_path == self._synced_path and stamp == self._synced_stamp:
             return
         # One read serves both the tear gate and head recovery, so the slow
         # path costs a single pass over the day segment - the same order as
@@ -1523,11 +1666,16 @@ class AuditLog:
             if local_head is not None:
                 self._prev_hmac = local_head
                 self._synced_path = log_path
-                self._synced_size = len(raw)
+                # Length comes from the bytes actually read, not from a second
+                # stat: a writer that appended between the stat and the read
+                # would otherwise have its record folded into a stamp whose
+                # head predates it. Recording the shorter length errs towards
+                # a wasted rescan, which is the safe direction.
+                self._synced_stamp = (stamp[0], stamp[1], len(raw), stamp[3])
                 return
         self._prev_hmac = self._recover_chain_tail()
         self._synced_path = log_path
-        self._synced_size = _path_size(log_path)
+        self._synced_stamp = _segment_stamp(log_path)
 
     def _mint_record(
         self,
@@ -1668,7 +1816,7 @@ class AuditLog:
 
         self._prev_hmac = event.hmac
         self._synced_path = log_path
-        self._synced_size = landed
+        self._synced_stamp = _segment_stamp(log_path)
         return True
 
     # -- write --------------------------------------------------------------
@@ -1734,7 +1882,7 @@ class AuditLog:
 
             self._prev_hmac = computed_hmac
             self._synced_path = log_path
-            self._synced_size = _path_size(log_path)
+            self._synced_stamp = _segment_stamp(log_path)
         return event
 
     # -- verify -------------------------------------------------------------
@@ -1840,7 +1988,10 @@ class AuditLog:
                 if already > total:
                     return self.scan_verified(None, event_type=event_type)
                 if already == 0:
-                    raw = path.read_bytes()
+                    raw = _read_live_segment(path, self._audit_dir)
+                    if raw is None:
+                        # Retention removed it between the stat and the read.
+                        continue
                     total = len(raw)
 
             if use_index and already == 0 and raw is not None:
@@ -1991,7 +2142,14 @@ class AuditLog:
                 return ChainVerifyReport(hard_errors=errors)
             prev_hmac = _verify_log_bytes(raw, gz_path.name, prev_hmac, self._key, errors, ctx)
         for log_path in live_files:
-            prev_hmac = _verify_log_bytes(log_path.read_bytes(), log_path.name, prev_hmac, self._key, errors, ctx)
+            raw = _read_live_segment(log_path, self._audit_dir)
+            if raw is None:
+                # Listed, then removed by retention before it could be read,
+                # with no archived copy to fall back on. Reporting it beats
+                # crashing: verification must stay total.
+                errors.append(f"{log_path.name}: segment disappeared during verification")
+                return ChainVerifyReport(hard_errors=errors)
+            prev_hmac = _verify_log_bytes(raw, log_path.name, prev_hmac, self._key, errors, ctx)
 
         return _build_verify_report(errors, ctx)
 
@@ -2004,6 +2162,16 @@ class AuditLog:
         older than ``policy.retention_days`` are gzip-compressed into the
         archive subdirectory.  The original ``.jsonl`` file is removed after
         a successful compress.
+
+        Each segment's compress and unlink happen inside one cross-process
+        append section. The pair is not separable: the archived copy holds the
+        segment as it stood when the compress read it, so an append that landed
+        after the copy and before the unlink would exist only in the file about
+        to be removed. Holding the section also keeps a writer from re-syncing
+        its head off a segment that is halfway through being replaced. The
+        section is taken per segment rather than once for the whole run, so a
+        long retention pass does not hold the chain against every writer for
+        its full duration.
 
         Args:
             policy: Retention settings.  Uses defaults if ``None``.
@@ -2042,11 +2210,16 @@ class AuditLog:
             # ``.gz`` that the verifier would later read (the original
             # ``.jsonl`` is only unlinked once the full ``.gz`` is on disk).
             tmp_path = gz_path.with_name(f"{gz_path.name}.tmp")
-            with log_path.open("rb") as f_in, gzip.open(tmp_path, "wb") as f_out:
-                shutil.copyfileobj(f_in, f_out)
-            tmp_path.replace(gz_path)
-
-            log_path.unlink()
+            with _chain_append_lock(self._audit_dir):
+                if not log_path.exists():
+                    # Another retention pass took this segment while we waited
+                    # for the section.
+                    skipped.append(log_path.name)
+                    continue
+                with log_path.open("rb") as f_in, gzip.open(tmp_path, "wb") as f_out:
+                    shutil.copyfileobj(f_in, f_out)
+                tmp_path.replace(gz_path)
+                log_path.unlink()
             archived.append(log_path.name)
             logger.info("Archived audit log %s -> %s", log_path.name, gz_path.name)
 
@@ -2107,12 +2280,14 @@ class AuditLog:
         if include_archived:
             discarded: list[str] = []
             sources.extend(_read_archived_segment(gz, discarded) for gz in _archived_segment_paths(self._audit_dir))
-        sources.extend(path.read_bytes() for path in sorted(self._audit_dir.glob(_JSONL_GLOB)))
+        sources.extend(_read_live_segment(path, self._audit_dir) for path in sorted(self._audit_dir.glob(_JSONL_GLOB)))
 
         for blob in sources:
             if blob is None:
-                # Unreadable archive segment (corrupt gzip). ``verify`` reports
-                # it with a named error; a query simply has nothing to yield.
+                # An unreadable archived segment (corrupt gzip), or a live one
+                # retention removed mid-query with no readable archived copy.
+                # ``verify`` reports either with a named error; a query simply
+                # has nothing to yield.
                 continue
             # Per-line strict decode: an undecodable line is dropped whole
             # rather than becoming replacement characters, so a query never

--- a/src/bernstein/core/skills/catalog/audit.py
+++ b/src/bernstein/core/skills/catalog/audit.py
@@ -178,7 +178,7 @@ class SkillCatalogAuditor:
         manifest_sha256: str,
         manifest_signer_pubkey: str | None,
         install_id: str,
-        prev_chain_digest: str,
+        prior_install_chain_head: str,
     ) -> AuditEvent | None:
         """Record a catalog install.
 
@@ -190,10 +190,14 @@ class SkillCatalogAuditor:
                 when the install was performed with ``--allow-unverified``.
             install_id: Per-install unique identifier; ties the audit
                 event to the lockfile receipt.
-            prev_chain_digest: The chain head visible to this install
-                before the new event was appended (a chain-head pin so a
-                future replay can detect that the chain advanced
-                identically).
+            prior_install_chain_head: HMAC of the previous install event for
+                this entry, so a replay can detect that the per-entry install
+                history advanced identically. Arbitrarily many unrelated
+                records sit between that event and this one, so it is *not*
+                this record's chain predecessor and must not be recorded under
+                the ``prev_chain_digest`` key, which
+                :func:`bernstein.core.security.audit._stated_predecessor`
+                reads as exactly that claim and the verifier now checks.
         """
         return self._emit(
             EVENT_INSTALL,
@@ -203,7 +207,7 @@ class SkillCatalogAuditor:
                 "manifest_sha256": manifest_sha256,
                 "manifest_signer_pubkey": manifest_signer_pubkey,
                 "install_id": install_id,
-                "prev_chain_digest": prev_chain_digest,
+                "prior_install_chain_head": prior_install_chain_head,
             },
         )
 
@@ -216,9 +220,13 @@ class SkillCatalogAuditor:
         manifest_url: str,
         manifest_sha256: str,
         install_id: str,
-        prev_chain_digest: str,
+        prior_install_chain_head: str,
     ) -> AuditEvent | None:
-        """Record a catalog upgrade."""
+        """Record a catalog upgrade.
+
+        ``prior_install_chain_head`` carries the same per-entry link as
+        :meth:`install`; see there for why it is not the chain predecessor.
+        """
         return self._emit(
             EVENT_UPGRADE,
             entry_id,
@@ -228,7 +236,7 @@ class SkillCatalogAuditor:
                 "manifest_url": manifest_url,
                 "manifest_sha256": manifest_sha256,
                 "install_id": install_id,
-                "prev_chain_digest": prev_chain_digest,
+                "prior_install_chain_head": prior_install_chain_head,
             },
         )
 

--- a/src/bernstein/core/skills/catalog/service.py
+++ b/src/bernstein/core/skills/catalog/service.py
@@ -381,7 +381,10 @@ class SkillCatalogService:
             )
 
         install_id = fresh_install_id()
-        prev_chain_digest = prior.hmac if prior is not None else _GENESIS_HEAD
+        # The previous install event *for this entry*, not this record's chain
+        # predecessor: unrelated records land in between. Recorded under a name
+        # that says so (#3062).
+        prior_install_chain_head = prior.hmac if prior is not None else _GENESIS_HEAD
 
         audit_event = self._auditor.install(
             entry_id=entry_id,
@@ -389,7 +392,7 @@ class SkillCatalogService:
             manifest_sha256=manifest_sha,
             manifest_signer_pubkey=catalog.signer_pubkey if outcome.verified else None,
             install_id=install_id,
-            prev_chain_digest=prev_chain_digest,
+            prior_install_chain_head=prior_install_chain_head,
         )
         chain_head = audit_event.hmac if audit_event is not None else _GENESIS_HEAD
 
@@ -408,7 +411,7 @@ class SkillCatalogService:
             self.lockfile_path,
             lock_entry,
             workdir=self._config.workdir,
-            from_chain_head=prev_chain_digest,
+            from_chain_head=prior_install_chain_head,
         )
 
         # Record the verified transparency head so the *next* install can prove
@@ -674,7 +677,7 @@ class SkillCatalogService:
             manifest_url=manifest_url,
             manifest_sha256=upstream_sha,
             install_id=outcome.install_id,
-            prev_chain_digest=prior.chain_head,
+            prior_install_chain_head=prior.chain_head,
         )
         return UpgradeOutcome(
             entry_id=entry_id,

--- a/tests/unit/core/skills/test_catalog.py
+++ b/tests/unit/core/skills/test_catalog.py
@@ -748,7 +748,12 @@ def test_install_appends_chain_entry_with_required_fields(
 ) -> None:
     """The install path appends a `skill.catalog.install` event with the
     required (manifest_url, manifest_sha256, manifest_signer_pubkey,
-    install_id, prev_chain_digest) tuple."""
+    install_id, prior_install_chain_head) tuple.
+
+    The per-entry link is deliberately not called ``prev_chain_digest``:
+    that key means "this record's own chain predecessor", which the
+    previous install of the same entry is not (#3062).
+    """
     priv, pub = generate_signer_keypair()
 
     expected_digest = _compute_fixture_digest(tmp_path)
@@ -776,7 +781,8 @@ def test_install_appends_chain_entry_with_required_fields(
     assert details["manifest_sha256"]
     assert details["manifest_signer_pubkey"] == pub
     assert details["install_id"]
-    assert details["prev_chain_digest"]
+    assert details["prior_install_chain_head"]
+    assert "prev_chain_digest" not in details
 
 
 def test_replay_refuses_when_upstream_sha_drifted(

--- a/tests/unit/security/test_audit_embedded_anchor.py
+++ b/tests/unit/security/test_audit_embedded_anchor.py
@@ -1,0 +1,251 @@
+"""The chain anchor a record embeds must be the one it was written with (#3062).
+
+An audit record may carry ``details["prev_chain_digest"]``: a statement about
+which record it chains onto. The HMAC covers the bytes of that statement, not
+its truth, so a record naming a predecessor it never had signs exactly as
+cleanly as one naming its real predecessor. ``verify()`` has to check the claim
+against the record's own ``prev_hmac``, and has to say so in words an operator
+can tell apart from tampering.
+
+Three separate things are pinned here:
+
+* the verifier refuses a false anchor, with its own wording;
+* a false anchor is *hard* corruption, never crash-tear evidence an operator is
+  invited to acknowledge away;
+* the writer cannot produce one, across processes, and the re-entrant append
+  section that guarantees it does not wedge on a second spelling of the same
+  audit directory.
+"""
+
+from __future__ import annotations
+
+import json
+import multiprocessing as mp
+import threading
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.security.audit import AuditLog
+from bernstein.core.security.audit_chain import AuditChainStore
+
+KEY = b"anchor-test-key-exactly-32-bytes"
+
+#: Substring the verifier must use for a false anchor and must not use for a
+#: MAC failure, so an operator can tell a mis-stated claim from tampering.
+FALSE_ANCHOR_MARKER = "stated chain predecessor"
+
+
+def _records(audit_dir: Path) -> list[dict[str, object]]:
+    """Return every record on disk, in segment then line order."""
+    out: list[dict[str, object]] = []
+    for path in sorted(audit_dir.glob("*.jsonl")):
+        for line in path.read_bytes().split(b"\n"):
+            if line:
+                out.append(json.loads(line))
+    return out
+
+
+def test_verify_refuses_a_record_that_states_a_predecessor_it_never_had(tmp_path: Path) -> None:
+    """The core of #3062: a false claim must not verify.
+
+    The record is written through the real writer, so its bytes are canonical
+    and its MAC is genuine. Only the claim inside it is false.
+    """
+    audit_dir = tmp_path / "audit"
+    log = AuditLog(audit_dir=audit_dir, key=KEY)
+    log.log("chain.start", "actor", "resource", "r0", {})
+
+    false_anchor = "de" * 32
+    event = log.log("schedule.fire", "sched", "schedule", "s1", {"prev_chain_digest": false_anchor})
+    assert event.prev_hmac != false_anchor, "the fixture must actually state a predecessor it never had"
+
+    ok, errors = AuditLog(audit_dir=audit_dir, key=KEY).verify()
+    assert not ok, "a record stating a predecessor it never had must not verify"
+    anchor_errors = [line for line in errors if FALSE_ANCHOR_MARKER in line]
+    assert len(anchor_errors) == 1, errors
+    assert false_anchor[:16] in anchor_errors[0]
+    assert event.prev_hmac[:16] in anchor_errors[0]
+
+
+def test_false_anchor_is_worded_apart_from_a_mac_failure(tmp_path: Path) -> None:
+    """An operator must be able to tell a concurrency defect from tampering."""
+    audit_dir = tmp_path / "audit"
+    log = AuditLog(audit_dir=audit_dir, key=KEY)
+    log.log("chain.start", "actor", "resource", "r0", {})
+    log.log("schedule.fire", "sched", "schedule", "s1", {"prev_chain_digest": "de" * 32})
+
+    _, errors = AuditLog(audit_dir=audit_dir, key=KEY).verify()
+    joined = "\n".join(errors)
+    assert FALSE_ANCHOR_MARKER in joined
+    assert "HMAC mismatch" not in joined, "an intact MAC must not be reported as tampering"
+    assert "prev_hmac mismatch" not in joined, "the chain linkage itself is intact here"
+
+
+def test_a_true_anchor_still_verifies(tmp_path: Path) -> None:
+    """The check must not fire on the writer's own correct output."""
+    chain = AuditChainStore(tmp_path / "audit", key=KEY)
+    for index in range(5):
+        chain.log_with_prev_digest(
+            event_type="e",
+            actor="a",
+            resource_type="r",
+            resource_id=str(index),
+            details={"n": index},
+        )
+    ok, errors = chain.verify()
+    assert ok, errors
+
+
+def test_an_absent_or_empty_anchor_is_not_a_claim(tmp_path: Path) -> None:
+    """Only a non-empty digest states a position; nothing else is policed.
+
+    A writer with no chain wired records ``""``. That is an explicit "I make no
+    claim", not a false one, and must not be reported.
+    """
+    audit_dir = tmp_path / "audit"
+    log = AuditLog(audit_dir=audit_dir, key=KEY)
+    log.log("chain.start", "a", "r", "r0", {})
+    log.log("e", "a", "r", "r1", {})
+    log.log("e", "a", "r", "r2", {"prev_chain_digest": ""})
+
+    ok, errors = AuditLog(audit_dir=audit_dir, key=KEY).verify()
+    assert ok, errors
+
+
+def test_false_anchor_is_hard_corruption_not_tear_evidence(tmp_path: Path) -> None:
+    """Guards the failure mode where hardening turns a FAIL into a WARN.
+
+    Crash-tear evidence is acknowledgeable: ``bernstein audit ack-tear`` makes
+    verification pass again. A false anchor is not crash damage - the bytes are
+    intact and MAC-valid - so it must land in ``hard_errors``, which nothing
+    can acknowledge away.
+    """
+    audit_dir = tmp_path / "audit"
+    log = AuditLog(audit_dir=audit_dir, key=KEY)
+    log.log("chain.start", "a", "r", "r0", {})
+    log.log("schedule.fire", "sched", "schedule", "s1", {"prev_chain_digest": "de" * 32})
+
+    report = AuditLog(audit_dir=audit_dir, key=KEY).verify_detailed()
+    assert not report.ok
+    assert report.tears == [], "a false anchor is not crash-shaped damage"
+    assert any(FALSE_ANCHOR_MARKER in line for line in report.hard_errors), report.hard_errors
+
+
+def test_false_anchor_survives_the_archive_boundary(tmp_path: Path) -> None:
+    """The claim is policed in archived segments too, not only live ones."""
+    audit_dir = tmp_path / "audit"
+    log = AuditLog(audit_dir=audit_dir, key=KEY)
+    log.log("chain.start", "a", "r", "r0", {})
+    log.log("schedule.fire", "sched", "schedule", "s1", {"prev_chain_digest": "de" * 32})
+
+    segment = next(iter(sorted(audit_dir.glob("*.jsonl"))))
+    stale = audit_dir / "2020-01-01.jsonl"
+    segment.rename(stale)
+    AuditLog(audit_dir=audit_dir, key=KEY).archive()
+    assert not stale.exists()
+
+    ok, errors = AuditLog(audit_dir=audit_dir, key=KEY).verify()
+    assert not ok
+    assert any(FALSE_ANCHOR_MARKER in line for line in errors), errors
+
+
+# ---------------------------------------------------------------------------
+# writer side
+# ---------------------------------------------------------------------------
+
+
+def _append_batch(audit_dir: str, count: int) -> None:
+    """Append *count* anchored records from a separate process."""
+    chain = AuditChainStore(Path(audit_dir), key=KEY)
+    for index in range(count):
+        chain.log_with_prev_digest(
+            event_type="e",
+            actor="w",
+            resource_type="r",
+            resource_id=str(index),
+            details={},
+        )
+
+
+@pytest.mark.slow
+def test_concurrent_processes_embed_the_head_they_chain_onto(tmp_path: Path) -> None:
+    """Six processes, one audit directory, every anchor true.
+
+    Regression guard for the writer half of #3062: the head read and the append
+    that uses it are one cross-process critical section, so no record can be
+    published naming a predecessor another process overtook.
+    """
+    audit_dir = tmp_path / "audit"
+    audit_dir.mkdir(parents=True)
+    ctx = mp.get_context("spawn")
+    procs = [ctx.Process(target=_append_batch, args=(str(audit_dir), 12)) for _ in range(6)]
+    for proc in procs:
+        proc.start()
+    for proc in procs:
+        proc.join(timeout=120)
+        assert proc.exitcode == 0
+
+    records = _records(audit_dir)
+    assert len(records) == 72
+    for record in records:
+        details = record["details"]
+        assert isinstance(details, dict)
+        assert details["prev_chain_digest"] == record["prev_hmac"]
+
+    ok, errors = AuditLog(audit_dir=audit_dir, key=KEY).verify()
+    assert ok, errors
+
+
+def test_append_section_is_reentrant_under_a_second_spelling_of_the_dir(tmp_path: Path) -> None:
+    """Re-entrancy must key on the directory, not on how it was spelled.
+
+    ``flock`` binds to an open file description, so a nested append that fails
+    to recognise it is already inside the section opens a second descriptor and
+    blocks on the lock this thread already holds. The per-thread depth counter
+    prevents that only if both spellings map to one key: ``Path.resolve()`` does
+    not fold case, and this project builds on case-insensitive filesystems, so
+    two spellings of one directory produced two counters and the nested append
+    wedged forever.
+    """
+    lower = tmp_path / "auditdir"
+    lower.mkdir()
+    upper = tmp_path / "AuditDir"
+    if not upper.exists():  # pragma: no cover - case-sensitive filesystem
+        pytest.skip("filesystem is case-sensitive; the two spellings are different directories")
+
+    outer = AuditLog(audit_dir=lower, key=KEY)
+    inner = AuditLog(audit_dir=upper, key=KEY)
+    done = threading.Event()
+
+    def _nested() -> None:
+        with outer.append_transaction():
+            inner.log("e", "a", "r", "r0", {})
+        done.set()
+
+    worker = threading.Thread(target=_nested, daemon=True)
+    worker.start()
+    worker.join(timeout=20)
+    assert done.is_set(), "nested append under a second spelling of the audit dir deadlocked"
+
+
+def test_resync_head_is_reentrant_under_a_second_spelling_of_the_dir(tmp_path: Path) -> None:
+    """The section-membership probe must fold the same two spellings.
+
+    ``resync_head`` refuses outside an append section. Keyed on the spelling,
+    a caller that opened the section under one spelling and reads the head
+    through an instance built on the other is told it is outside a section it
+    is demonstrably inside.
+    """
+    lower = tmp_path / "auditdir"
+    lower.mkdir()
+    upper = tmp_path / "AuditDir"
+    if not upper.exists():  # pragma: no cover - case-sensitive filesystem
+        pytest.skip("filesystem is case-sensitive; the two spellings are different directories")
+
+    outer = AuditLog(audit_dir=lower, key=KEY)
+    inner = AuditLog(audit_dir=upper, key=KEY)
+    outer.log("e", "a", "r", "r0", {})
+
+    with outer.append_transaction():
+        assert inner.resync_head() == outer.resync_head()

--- a/tests/unit/security/test_audit_embedded_anchor.py
+++ b/tests/unit/security/test_audit_embedded_anchor.py
@@ -29,7 +29,7 @@ import pytest
 from bernstein.core.security.audit import AuditLog
 from bernstein.core.security.audit_chain import AuditChainStore
 
-KEY = b"anchor-test-key-exactly-32-bytes"
+KEY = b"a" * 32
 
 #: Substring the verifier must use for a false anchor and must not use for a
 #: MAC failure, so an operator can tell a mis-stated claim from tampering.

--- a/tests/unit/security/test_audit_segment_freshness.py
+++ b/tests/unit/security/test_audit_segment_freshness.py
@@ -20,7 +20,7 @@ import pytest
 
 from bernstein.core.security.audit import AuditLog, RetentionPolicy, _inside_append_section
 
-KEY = b"freshness-test-key-exactly-32byt"
+KEY = b"f" * 32
 
 
 def _segment(audit_dir: Path) -> Path:

--- a/tests/unit/security/test_audit_segment_freshness.py
+++ b/tests/unit/security/test_audit_segment_freshness.py
@@ -1,0 +1,247 @@
+"""A segment's byte length is not proof that nobody replaced it (#3063).
+
+``AuditLog`` skips re-reading the chain tail when the day file is the same
+length it left it at. Length stopped being a sufficient signal once a segment
+can be removed and regrown: two identically shaped records are exactly the same
+size, so a replaced segment can present the cached length while holding a
+different chain, and the append lands on a head that is no longer there.
+
+Also pinned here: the retention job may not leave a reader looking at a segment
+it is in the middle of removing, and the fast path this fix touches must keep
+firing in steady state, so the fix does not quietly undo the optimisation.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.security.audit import AuditLog, RetentionPolicy, _inside_append_section
+
+KEY = b"freshness-test-key-exactly-32byt"
+
+
+def _segment(audit_dir: Path) -> Path:
+    return next(iter(sorted(audit_dir.glob("*.jsonl"))))
+
+
+def test_removed_and_regrown_segment_of_equal_length_does_not_fork(tmp_path: Path) -> None:
+    """The reproduction from the issue, end to end.
+
+    A second writer replaces the segment with one of exactly the same byte
+    length. Before the fix the first writer's next append took the fast path
+    and chained onto a head that no longer existed on disk.
+    """
+    audit_dir = tmp_path / "audit"
+    writer = AuditLog(audit_dir=audit_dir, key=KEY)
+    writer.log("e", "a", "r", "1", {"n": 1})
+
+    segment = _segment(audit_dir)
+    cached_length = segment.stat().st_size
+    segment.unlink()
+
+    # A fresh writer re-grows the segment from genesis with the same event
+    # shape, so the file returns to exactly the length the first writer cached.
+    replacement = AuditLog(audit_dir=audit_dir, key=KEY)
+    replacement.log("e", "a", "r", "1", {"n": 1})
+    assert segment.stat().st_size == cached_length, "the fixture must restore the cached byte length"
+
+    writer.log("e", "a", "r", "2", {"n": 2})
+
+    ok, errors = AuditLog(audit_dir=audit_dir, key=KEY).verify()
+    assert ok, errors
+
+
+def test_same_length_rewrite_in_place_does_not_fork(tmp_path: Path) -> None:
+    """Replacement need not go through a fresh inode to be invisible.
+
+    A segment rewritten in place keeps its identity *and* its size, so
+    (device, inode) alone is not enough either.
+    """
+    audit_dir = tmp_path / "audit"
+    writer = AuditLog(audit_dir=audit_dir, key=KEY)
+    writer.log("e", "a", "r", "1", {"n": 1})
+    segment = _segment(audit_dir)
+
+    other = AuditLog(audit_dir=tmp_path / "other", key=KEY)
+    other.log("e", "a", "r", "1", {"n": 1})
+    foreign = _segment(tmp_path / "other").read_bytes()
+    assert len(foreign) == segment.stat().st_size, "the fixture must keep the byte length"
+
+    before = segment.stat().st_mtime_ns
+    with segment.open("r+b") as handle:
+        handle.write(foreign)
+    if segment.stat().st_mtime_ns == before:  # pragma: no cover - coarse mtime filesystem
+        pytest.skip("filesystem mtime resolution cannot distinguish a same-length in-place rewrite")
+
+    writer.log("e", "a", "r", "2", {"n": 2})
+
+    ok, errors = AuditLog(audit_dir=audit_dir, key=KEY).verify()
+    assert ok, errors
+
+
+def test_steady_state_appends_take_the_fast_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The optimisation this fix touches must still fire.
+
+    A run of ordinary appends by one writer re-reads the segment exactly once
+    (the first append, which has nothing cached); every later append is a stat
+    and nothing more.
+    """
+    audit_dir = tmp_path / "audit"
+    writer = AuditLog(audit_dir=audit_dir, key=KEY)
+
+    rescans = 0
+    original = Path.read_bytes
+
+    def _counting_read(self: Path) -> bytes:
+        nonlocal rescans
+        if self.suffix == ".jsonl":
+            rescans += 1
+        return original(self)
+
+    monkeypatch.setattr(Path, "read_bytes", _counting_read)
+
+    for index in range(25):
+        writer.log("e", "a", "r", str(index), {"n": index})
+
+    assert rescans <= 1, f"steady-state appends rescanned the segment {rescans} times"
+
+
+def test_a_second_writer_still_forces_a_rescan(tmp_path: Path) -> None:
+    """The fast path must not become so strict that it never re-syncs."""
+    audit_dir = tmp_path / "audit"
+    first = AuditLog(audit_dir=audit_dir, key=KEY)
+    first.log("e", "a", "r", "1", {})
+
+    second = AuditLog(audit_dir=audit_dir, key=KEY)
+    second.log("e", "a", "r", "2", {})
+
+    first.log("e", "a", "r", "3", {})
+
+    ok, errors = AuditLog(audit_dir=audit_dir, key=KEY).verify()
+    assert ok, errors
+
+
+# ---------------------------------------------------------------------------
+# retention
+# ---------------------------------------------------------------------------
+
+
+def _seed_expired_segment(audit_dir: Path, name: str = "2020-01-01.jsonl") -> Path:
+    """Write one record, then re-date its segment so retention will expire it."""
+    log = AuditLog(audit_dir=audit_dir, key=KEY)
+    log.log("e", "a", "r", "1", {})
+    segment = _segment(audit_dir)
+    expired = audit_dir / name
+    segment.rename(expired)
+    return expired
+
+
+def _vanish_once(target: Path, monkeypatch: pytest.MonkeyPatch) -> list[bool]:
+    """Make the first read of *target* unlink it first, as retention would."""
+    gone: list[bool] = []
+    original = Path.read_bytes
+
+    def _vanishing_read(self: Path) -> bytes:
+        if self == target and not gone:
+            gone.append(True)
+            self.unlink()
+        return original(self)
+
+    monkeypatch.setattr(Path, "read_bytes", _vanishing_read)
+    return gone
+
+
+def test_chain_recovery_tolerates_a_segment_removed_underneath_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Retention unlinking a segment must not crash a concurrent reader.
+
+    ``archive()`` lists, compresses and unlinks; a reader that listed the same
+    segment a moment earlier reads a path that is already gone. Before the fix
+    that surfaced as an unhandled ``FileNotFoundError`` from chain recovery.
+    """
+    audit_dir = tmp_path / "audit"
+    AuditLog(audit_dir=audit_dir, key=KEY).log("e", "a", "r", "1", {})
+    gone = _vanish_once(_segment(audit_dir), monkeypatch)
+
+    AuditLog(audit_dir=audit_dir, key=KEY)
+
+    assert gone, "the fixture must actually remove the segment mid-read"
+
+
+def test_query_tolerates_a_segment_removed_underneath_it(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Same race, on the read surface operators actually call."""
+    audit_dir = tmp_path / "audit"
+    AuditLog(audit_dir=audit_dir, key=KEY).log("e", "a", "r", "1", {})
+    reader = AuditLog(audit_dir=audit_dir, key=KEY)
+    gone = _vanish_once(_segment(audit_dir), monkeypatch)
+
+    assert reader.query() == []
+
+    assert gone
+
+
+def test_verify_tolerates_a_segment_removed_underneath_it(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """And on the verification surface, which must stay total."""
+    audit_dir = tmp_path / "audit"
+    AuditLog(audit_dir=audit_dir, key=KEY).log("e", "a", "r", "1", {})
+    verifier = AuditLog(audit_dir=audit_dir, key=KEY)
+    gone = _vanish_once(_segment(audit_dir), monkeypatch)
+
+    verifier.verify()
+
+    assert gone
+
+
+def test_archive_compresses_and_unlinks_inside_one_append_section(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No append may interleave between the compress and the unlink.
+
+    The compressed copy is taken from the segment as it stood; an append that
+    landed after the copy and before the unlink would be in the removed file
+    and not in the archive, so the record would simply be gone. Both halves
+    must therefore sit inside one cross-process append section.
+    """
+    audit_dir = tmp_path / "audit"
+    expired = _seed_expired_segment(audit_dir)
+    log = AuditLog(audit_dir=audit_dir, key=KEY)
+
+    held_during_compress: list[bool] = []
+    held_during_unlink: list[bool] = []
+
+    original_copy = shutil.copyfileobj
+    original_unlink = Path.unlink
+
+    def _watched_copy(*args: object, **kwargs: object) -> None:
+        held_during_compress.append(_inside_append_section(audit_dir))
+        original_copy(*args, **kwargs)  # type: ignore[arg-type]
+
+    def _watched_unlink(self: Path, missing_ok: bool = False) -> None:
+        if self == expired:
+            held_during_unlink.append(_inside_append_section(audit_dir))
+        original_unlink(self, missing_ok=missing_ok)
+
+    monkeypatch.setattr(shutil, "copyfileobj", _watched_copy)
+    monkeypatch.setattr(Path, "unlink", _watched_unlink)
+
+    log.archive(RetentionPolicy(retention_days=1))
+
+    assert held_during_compress == [True], "the compress ran outside the append section"
+    assert held_during_unlink == [True], "the unlink ran outside the append section"
+
+
+def test_archive_round_trip_keeps_the_chain_verifiable(tmp_path: Path) -> None:
+    """Ordinary retention leaves a chain that still verifies end to end."""
+    audit_dir = tmp_path / "audit"
+    _seed_expired_segment(audit_dir)
+    log = AuditLog(audit_dir=audit_dir, key=KEY)
+    log.log("e", "a", "r", "2", {})
+    log.archive(RetentionPolicy(retention_days=1))
+    log.log("e", "a", "r", "3", {})
+
+    ok, errors = AuditLog(audit_dir=audit_dir, key=KEY).verify()
+    assert ok, errors

--- a/tests/unit/test_schedule_fire_chain_anchor.py
+++ b/tests/unit/test_schedule_fire_chain_anchor.py
@@ -1,0 +1,221 @@
+"""A schedule fire must record the chain head it was actually written with (#3131).
+
+``ScheduleSupervisor`` captured the head and appended the entry as two steps.
+The capture read the writer's per-instance cache, which does not see another
+process's appends, while the append re-syncs the tail from disk under the
+cross-process lock. Every fire entry and every fire receipt written while
+another writer was active therefore named a chain position the record does not
+occupy - and because entry and receipt were built from the same stale read they
+agreed with each other, so ``verify_fire_chain`` passed.
+
+No thread race is needed to show it: a second ``AuditLog`` on the same audit
+directory is exactly what "another process" means to the writer's cache.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from bernstein.core.orchestration.schedule_supervisor import (
+    AUDIT_EVENT_TYPE,
+    COLLISION_EVENT_TYPE,
+    RunningFireState,
+    ScheduleSupervisor,
+    load_receipts,
+)
+from bernstein.core.planning.schedule_store import ScheduleStore
+from bernstein.core.security.audit import AuditLog
+
+KEY = b"schedule-anchor-key-exactly-32by"
+
+
+def _audit(tmp_path: Path) -> AuditLog:
+    audit_dir = tmp_path / "audit"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    return AuditLog(audit_dir=audit_dir, key=KEY)
+
+
+def _seed(sdd_dir: Path, *, cron: str = "* * * * *") -> str:
+    store = ScheduleStore(sdd_dir)
+    schedule = store.add(cron=cron, goal="Send nightly digest", misfire_policy="catch_up")
+    store.update_last_fire(schedule.id, float(int(datetime(2030, 1, 1, 12, 0, 0, tzinfo=UTC).timestamp())))
+    return schedule.id
+
+
+def _entries(tmp_path: Path, event_type: str) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for path in sorted((tmp_path / "audit").glob("*.jsonl")):
+        for line in path.read_bytes().split(b"\n"):
+            if not line:
+                continue
+            record = json.loads(line)
+            if record.get("event_type") == event_type:
+                out.append(record)
+    return out
+
+
+def test_fire_entry_embeds_the_head_it_chains_onto(tmp_path: Path) -> None:
+    """AC 2 and 3: read the head from disk, and record the one actually used."""
+    sdd_dir = tmp_path / "sdd"
+    sdd_dir.mkdir(parents=True)
+    _seed(sdd_dir)
+    audit = _audit(tmp_path)
+    supervisor = ScheduleSupervisor(ScheduleStore(sdd_dir), lambda _event: None, audit, catch_up_limit=10)
+
+    # Another writer on the same audit directory moves the head on disk. The
+    # supervisor's writer still holds its own cached value.
+    AuditLog(audit_dir=tmp_path / "audit", key=KEY).log("other.process", "x", "r", "r0", {})
+
+    supervisor.tick(now=int(datetime(2030, 1, 1, 12, 5, 30, tzinfo=UTC).timestamp()))
+
+    entries = _entries(tmp_path, AUDIT_EVENT_TYPE)
+    assert entries, "the tick must have fired"
+    for entry in entries:
+        assert entry["details"]["prev_chain_digest"] == entry["prev_hmac"]
+
+
+def test_fire_receipt_anchor_matches_the_entry_it_rode_on(tmp_path: Path) -> None:
+    """The receipt is a projection of the record, so it must name the same head."""
+    sdd_dir = tmp_path / "sdd"
+    sdd_dir.mkdir(parents=True)
+    _seed(sdd_dir)
+    audit = _audit(tmp_path)
+    supervisor = ScheduleSupervisor(ScheduleStore(sdd_dir), lambda _event: None, audit, catch_up_limit=10)
+    AuditLog(audit_dir=tmp_path / "audit", key=KEY).log("other.process", "x", "r", "r0", {})
+
+    supervisor.tick(now=int(datetime(2030, 1, 1, 12, 5, 30, tzinfo=UTC).timestamp()))
+
+    entries = _entries(tmp_path, AUDIT_EVENT_TYPE)
+    by_digest = {entry["hmac"]: entry for entry in entries}
+    receipts = [r for r in load_receipts(sdd_dir) if r.dispatched]
+    assert receipts
+    for receipt in receipts:
+        entry = by_digest[receipt.chain_digest]
+        assert receipt.prev_chain_digest == entry["prev_hmac"]
+
+
+def test_two_fires_in_one_tick_each_carry_their_own_head(tmp_path: Path) -> None:
+    """AC 4: a catch-up burst must not sign one head for every fire."""
+    sdd_dir = tmp_path / "sdd"
+    sdd_dir.mkdir(parents=True)
+    _seed(sdd_dir)
+    audit = _audit(tmp_path)
+    supervisor = ScheduleSupervisor(ScheduleStore(sdd_dir), lambda _event: None, audit, catch_up_limit=10)
+
+    supervisor.tick(now=int(datetime(2030, 1, 1, 12, 5, 30, tzinfo=UTC).timestamp()))
+
+    entries = _entries(tmp_path, AUDIT_EVENT_TYPE)
+    assert len(entries) >= 2, "the fixture must produce a catch-up burst"
+    anchors = [entry["details"]["prev_chain_digest"] for entry in entries]
+    assert len(set(anchors)) == len(anchors), "each fire must carry its own head"
+    for entry in entries:
+        assert entry["details"]["prev_chain_digest"] == entry["prev_hmac"]
+
+
+def test_collision_receipt_embeds_the_head_the_entry_chains_onto(tmp_path: Path) -> None:
+    """The collision path captures the head the same way and must be fixed too."""
+    sdd_dir = tmp_path / "sdd"
+    sdd_dir.mkdir(parents=True)
+    _seed(sdd_dir)
+    audit = _audit(tmp_path)
+
+    def _probe(_schedule: Any) -> RunningFireState:
+        return RunningFireState(running=True, running_count=4, fire_id="fire-1")
+
+    supervisor = ScheduleSupervisor(
+        ScheduleStore(sdd_dir),
+        lambda _event: None,
+        audit,
+        catch_up_limit=10,
+        running_probe=_probe,
+        concurrency_cap=1,
+        collision_policy="enqueue",
+    )
+    AuditLog(audit_dir=tmp_path / "audit", key=KEY).log("other.process", "x", "r", "r0", {})
+
+    supervisor.tick(now=int(datetime(2030, 1, 1, 12, 5, 30, tzinfo=UTC).timestamp()))
+
+    entries = _entries(tmp_path, COLLISION_EVENT_TYPE)
+    assert entries, "the fixture must produce a collision entry"
+    by_digest = {entry["hmac"]: entry for entry in entries}
+    receipts = [r for r in load_receipts(sdd_dir) if r.chain_digest in by_digest]
+    assert receipts
+    for receipt in receipts:
+        assert receipt.prev_chain_digest == by_digest[receipt.chain_digest]["prev_hmac"]
+
+
+def test_fire_entries_pass_chain_verification(tmp_path: Path) -> None:
+    """A fire entry naming a false predecessor must not verify (ties to #3062)."""
+    sdd_dir = tmp_path / "sdd"
+    sdd_dir.mkdir(parents=True)
+    _seed(sdd_dir)
+    audit = _audit(tmp_path)
+    supervisor = ScheduleSupervisor(ScheduleStore(sdd_dir), lambda _event: None, audit, catch_up_limit=10)
+    AuditLog(audit_dir=tmp_path / "audit", key=KEY).log("other.process", "x", "r", "r0", {})
+
+    supervisor.tick(now=int(datetime(2030, 1, 1, 12, 5, 30, tzinfo=UTC).timestamp()))
+
+    ok, errors = AuditLog(audit_dir=tmp_path / "audit", key=KEY).verify()
+    assert ok, errors
+
+
+# ---------------------------------------------------------------------------
+# duck-typed writers
+# ---------------------------------------------------------------------------
+
+
+class _StubWriter:
+    """An in-memory chain with no transaction support, as tests inject."""
+
+    def __init__(self) -> None:
+        self._prev_hmac = ""
+        self.entries: list[dict[str, Any]] = []
+
+    def log(
+        self,
+        event_type: str,
+        actor: str,
+        resource_type: str,
+        resource_id: str,
+        details: dict[str, Any],
+    ) -> Any:
+        digest = f"stub-{len(self.entries)}"
+        self.entries.append(
+            {
+                "event_type": event_type,
+                "actor": actor,
+                "resource_type": resource_type,
+                "resource_id": resource_id,
+                "details": details,
+                "prev_hmac": self._prev_hmac,
+                "hmac": digest,
+            }
+        )
+        self._prev_hmac = digest
+        return type("_Event", (), {"hmac": digest})()
+
+
+def test_a_stub_writer_without_transaction_support_still_fires(tmp_path: Path) -> None:
+    """AC 5: degrade, and say so, rather than crash or pretend."""
+    sdd_dir = tmp_path / "sdd"
+    sdd_dir.mkdir(parents=True)
+    _seed(sdd_dir)
+    writer = _StubWriter()
+    supervisor = ScheduleSupervisor(ScheduleStore(sdd_dir), lambda _event: None, writer, catch_up_limit=10)
+
+    supervisor.tick(now=int(datetime(2030, 1, 1, 12, 5, 30, tzinfo=UTC).timestamp()))
+
+    assert writer.entries, "the stub writer must still receive the fire entries"
+    for entry in writer.entries:
+        assert entry["details"]["prev_chain_digest"] == entry["prev_hmac"]
+
+
+def test_degradation_to_a_cache_read_is_explicit(tmp_path: Path) -> None:
+    """The adapter must report whether it can hold a section, not hide it."""
+    from bernstein.core.orchestration.schedule_supervisor import _AuditChainAdapter
+
+    assert not _AuditChainAdapter(_StubWriter()).supports_transaction
+    assert _AuditChainAdapter(_audit(tmp_path)).supports_transaction

--- a/tests/unit/test_schedule_fire_chain_anchor.py
+++ b/tests/unit/test_schedule_fire_chain_anchor.py
@@ -29,7 +29,7 @@ from bernstein.core.orchestration.schedule_supervisor import (
 from bernstein.core.planning.schedule_store import ScheduleStore
 from bernstein.core.security.audit import AuditLog
 
-KEY = b"schedule-anchor-key-exactly-32by"
+KEY = b"s" * 32
 
 
 def _audit(tmp_path: Path) -> AuditLog:


### PR DESCRIPTION
## What this fixes

Three defects on the audit substrate, all reproduced on `main` first. The
common thread is a claim a record makes about itself that nothing checked.

### 1. A record can state a chain predecessor it never had (#3062)

Many records carry `details.prev_chain_digest`: a statement about which record
they chain onto. Payment receipts lift it verbatim (`payments/receipt.py:284`),
capability tokens check their own `audit_head` against it, admission and SLA
receipts link through it. The HMAC covers the *bytes* of that statement, not its
truth, so a record naming a predecessor it never had signs exactly as cleanly as
one naming its real predecessor.

Reproduced on `main` through the real writer, so the bytes are canonical and the
MAC is genuine:

```
actual prev_hmac  : 113651ab625159dc
stated predecessor: dededededededede
verify ok: True errors: []
```

`verify()` now compares the stated value against the record's own `prev_hmac`:

```
! 2026-07-26.jsonl:3: stated chain predecessor abababababababab… is not the
  record's own predecessor 0c329236a2f1581d…
```

Deliberately worded apart from `HMAC mismatch` and `prev_hmac mismatch`: those
mean the bytes or the linkage were altered, this one means the bytes are intact
and authentic while the claim inside them is wrong. Through the CLI on a
three-record chain, only the false record is named, exit 1. `bernstein audit
seal` refuses over it, naming the record, exactly as it refuses over a broken
chain, and re-verifying keeps reporting it.

The finding goes into `errors` and deliberately **not** into `ctx.failures`. The
tear model classifies non-verifying lines at the tail as crash damage that
`ack-tear` can clear; feeding it a canonical, MAC-valid line would shorten the
verified prefix and turn a hard failure into something clearable. Pinned by
`test_false_anchor_is_hard_corruption_not_tear_evidence`.

### 2. Byte-length freshness can fork the chain (#3063)

`_sync_for_append`'s fast path treated equal byte length as proof that nobody
touched the segment. Length stopped being sufficient once a segment can be
removed and regrown, and two identically shaped records occupy exactly the same
number of bytes. Reproduced on `main`:

```
cached path/size: .../2026-07-26.jsonl 298   actual: 298
regrown size: 298  == cached: True
verify ok: False
   2026-07-26.jsonl:2: prev_hmac mismatch (expected 40956fcbe69e969d…, got 24cc600750a8cdc3…)
   2026-07-26.jsonl:2: HMAC mismatch (expected 2e3c81dceb62936a…, got 9d239b302468d5e3…)
```

The cached stamp is now `(st_dev, st_ino, st_size, st_mtime_ns)`: identity plus
length, per the AC's first option. Identity is what separates "still the same
file" from "a different file of the same size"; length has to stay because
another writer's append keeps the inode. It is read from the same `stat` the
length already came from, so the check adds no syscall.

Retention is the other half. `archive()` compressed and unlinked with no lock
over the pair, and every reader that listed a segment a moment before it was
removed raised `FileNotFoundError` out of chain recovery, `query` and `verify`
alike:

```
recover CRASH: FileNotFoundError [Errno 2] No such file or directory: '.../2026-07-26.jsonl'
```

The compress and unlink now run inside one cross-process append section, taken
per segment so a long retention pass does not hold the chain for its whole
duration, and readers follow a vanished live segment into the archived copy that
retention writes before it unlinks.

### 3. Schedule fire receipts embed a head read before the append (#3131)

`_fire` and `_dispatch_or_collide` read `_AuditChainAdapter.chain_tail`, the
writer's per-instance cache, and appended the entry as a second step.
`AuditLog.log` re-syncs the tail from disk under the cross-process lock, so any
fire written while another process was appending named a position its own record
does not occupy, in both the entry and the receipt. Because both were built from
the same stale read they agreed with each other and `verify_fire_chain` passed.

No thread race is needed to show it: a second `AuditLog` on the same directory is
exactly what "another process" means to the cache.

Capture and append now sit in one section via `_AuditChainAdapter.transaction()`,
and the head is read from disk through `resync_head()` when the writer supports
it. The writer is duck-typed (tests inject in-memory stubs), so support is probed
for and reported: `supports_transaction` is public, the degradation is logged at
construction, and a stub still fires correctly.

## Overlap with #3162, checked rather than assumed

#3162 states it does not address #3062's acceptance criteria or #3063, and that
holds. #3129, though, already closed two of #3062's ACs, and they are reported
here rather than re-implemented:

| #3062 AC | Status |
|---|---|
| 1: N concurrent processes, every embedded anchor true | **Already closed by #3129.** 6 processes x 12 appends through `log_with_prev_digest` on one directory: 72 records, 0 false anchors, chain verifies. Kept as a regression guard (`@pytest.mark.slow`). |
| 2: the test fails on the current tree | **Does not, for AC 1.** Stated with the measurement above rather than manufactured. The adversarial case in AC 3 is what fails on `main`, and its baseline output is below. |
| 3: verify reports a false anchor, distinct from an HMAC failure | Implemented here. |
| 4: a receipt built from a false anchor no longer verifies, or the anchor can no longer be false | The second disjunct, on both paths: payments route through `log_with_prev_digest` (anchor correct since #3129), schedule fires are fixed here. Any residual false anchor now fails chain verification, so the chain a receipt is anchored in refuses. |
| 5: the read and the append happen under one lock held across both | Already true via `chain_transaction()` (#3129). One real hole in it is fixed here, see below. |
| 6: single-process append throughput does not regress. State the measurement | Stated below. |

### The AC's own implementation note was still live

#3062 says re-entrancy needs a key "stable on something like `(st_dev, st_ino)`;
a `Path` does not work". The merged code keys on `str(audit_dir.resolve())`.
`Path.resolve()` resolves symlinks but does not fold case, and this project
builds on case-insensitive filesystems, so two spellings of one directory map to
two depth counters and a nested append opens a second descriptor and blocks on
the `flock` its own thread already holds. Reproduced as a hang (`timeout` exit
124). Now keyed on `(st_dev, st_ino)`.

### One AC implemented differently, deliberately

#3062 AC 4 as written implies making receipt verification reject a false anchor.
That would be the weaker half of the disjunction: the receipt comparison at
`payments/receipt.py:432` reads the same field from the same record, so both
sides move together and a stale pair still agrees. Checking the claim at the
chain, where the true predecessor is known, is the version that cannot be
defeated by consistent staleness, and it covers every consumer of the field
rather than one.

### A key that meant two things

The skill catalogue recorded `prev_chain_digest` as "the previous install event
for this entry". That is a real record but never the immediate predecessor, so
those records literally state a chain position they never had. They now record
`prior_install_chain_head`, and the two legacy event types are exempt from the
new check so segments written by older versions do not report a defect that has
been removed. The exemption weakens nothing: the MAC and the `prev_hmac` linkage
still cover those records in full, and the field no longer makes a claim.

## Test evidence

Baseline on `origin/main` (`c8e019d15`), 16 failed / 8 passed:

```
FAILED test_audit_embedded_anchor.py::test_verify_refuses_a_record_that_states_a_predecessor_it_never_had
FAILED test_audit_embedded_anchor.py::test_false_anchor_is_worded_apart_from_a_mac_failure
FAILED test_audit_embedded_anchor.py::test_false_anchor_is_hard_corruption_not_tear_evidence
FAILED test_audit_embedded_anchor.py::test_false_anchor_survives_the_archive_boundary
FAILED test_audit_embedded_anchor.py::test_append_section_is_reentrant_under_a_second_spelling_of_the_dir
FAILED test_audit_embedded_anchor.py::test_resync_head_is_reentrant_under_a_second_spelling_of_the_dir
FAILED test_audit_segment_freshness.py::test_removed_and_regrown_segment_of_equal_length_does_not_fork
FAILED test_audit_segment_freshness.py::test_same_length_rewrite_in_place_does_not_fork
FAILED test_audit_segment_freshness.py::test_chain_recovery_tolerates_a_segment_removed_underneath_it
FAILED test_audit_segment_freshness.py::test_query_tolerates_a_segment_removed_underneath_it
FAILED test_audit_segment_freshness.py::test_verify_tolerates_a_segment_removed_underneath_it
FAILED test_audit_segment_freshness.py::test_archive_compresses_and_unlinks_inside_one_append_section
FAILED test_schedule_fire_chain_anchor.py::test_fire_entry_embeds_the_head_it_chains_onto
FAILED test_schedule_fire_chain_anchor.py::test_fire_receipt_anchor_matches_the_entry_it_rode_on
FAILED test_schedule_fire_chain_anchor.py::test_collision_receipt_embeds_the_head_the_entry_chains_onto
FAILED test_schedule_fire_chain_anchor.py::test_degradation_to_a_cache_read_is_explicit
16 failed, 8 passed, 1 deselected in 23.39s
```

All 24 pass on this branch. The 8 that passed on `main` are the
must-not-break side: a true anchor still verifies, an empty anchor is not a
claim, a second writer still forces a rescan, the steady-state fast path still
fires, an archive round trip still verifies.

Three tests exist specifically to catch this change set weakening something it
touches:

* `test_steady_state_appends_take_the_fast_path` asserts at most one segment
  re-read across 25 ordinary appends, so the freshness fix cannot silently undo
  the optimisation it lives in.
* `test_false_anchor_is_hard_corruption_not_tear_evidence` asserts the new
  finding lands in `hard_errors` with `tears == []`.
* `test_a_second_writer_still_forces_a_rescan` asserts the fast path did not
  become so strict that it never re-syncs.

Every reproduction runs through the real storage path (real writer, real file,
real MAC) rather than a hand-built record, and the CLI checks above confirm what
`bernstein audit verify` actually prints, not only what the gate refuses.

## Throughput (#3062 AC 6)

Single-process appends, 4000 per sample, 7 samples per run, `main` and this
branch interleaved on the same machine:

| run | main (appends/sec, median) | branch (appends/sec, median) |
|---|---|---|
| 1 | 9347 | 9168 |
| 2 | 10189 | 10567 |
| 3 | 9672 | 10414 |

No regression. The hot path swaps `path.stat().st_size` for one `path.stat()`
read four ways, so the syscall count per append is unchanged.

## Verification

* `ruff check src/ tests/ scripts/ --fix`, `ruff format`: clean.
* `pyright --project pyrightconfig.strict.json`: 0 errors, 0 warnings.
* `scripts/check_docs_drift.py`: no drift.
* Suites run green locally: the audit/merkle/chain unit selection, `tests/unit/security`,
  the schedule supervisor and SLA suites, `tests/integration/test_audit_chain_tear_stickiness.py`,
  `tests/integration/test_schedule_audit_chain.py`, the audit property suites,
  `test_audit_append_hotpath.py`, `tests/stress/test_audit_throughput.py`, and the
  skills catalogue suites.

## Docs

`docs/security/audit-log.md` gains the anchor check under "Verifying the chain":
what the field means, the new verdict and why it is worded apart from tampering,
why an empty value is not a claim, the legacy catalogue exemption, and the
`--allow-broken-chain` path for an operator holding a pre-v3.11 chain that
carries one. The retention section documents the append-section coupling and the
reader tolerance.

## Disposition

Closes #3062. Closes #3063. Closes #3131.
