### PR TITLE
feat(mcp): add discoverable skill index

### DIFF
--- a/src/bernstein/core/skills/index_builder.py
+++ b/src/bernstein/core/skills/index_builder.py
@@ -11,10 +11,14 @@ for the role.
 
 from __future__ import annotations
 
+import hashlib
+import json
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from bernstein.core.skills.loader import LoadedSkill, SkillLoader
+
+SKILL_INDEX_RESOURCE_URI = "bernstein://skills/index"
 
 
 def build_skill_index(
@@ -70,3 +74,21 @@ def _fmt_entry(skill: LoadedSkill) -> str:
     body.
     """
     return skill.description.strip().replace("\n", " ")
+
+
+def serialize_skill_discovery_index(loader: SkillLoader) -> str:
+    """Return the deterministic JSON index exposed to MCP clients.
+
+    Skill bodies stay behind ``load_skill(name=...)``. Their hashes let a
+    client invalidate a cached body without putting that body in discovery
+    output.
+    """
+    skills = [
+        {
+            "content_hash": hashlib.sha256(skill.body.encode("utf-8")).hexdigest(),
+            "description": _fmt_entry(skill),
+            "name": skill.name,
+        }
+        for skill in loader.list_all()
+    ]
+    return json.dumps({"skills": skills}, ensure_ascii=False, separators=(",", ":"), sort_keys=True)

--- a/src/bernstein/mcp/server.py
+++ b/src/bernstein/mcp/server.py
@@ -1180,22 +1180,47 @@ def _register_skill_tools(mcp: FastMCP[None]) -> None:
         mcp: FastMCP instance to register the tool on.
     """
 
+    def _skill_loader():  # type: ignore[no-untyped-def]
+        # Local imports keep the MCP module cheap to import when the skills
+        # tree is missing (for example, a dev CLI without templates).
+        from pathlib import Path as _Path
+
+        from bernstein import get_templates_dir
+        from bernstein.core.skills.loader import default_loader_from_templates
+
+        templates_root = get_templates_dir(_Path.cwd())
+        return default_loader_from_templates(templates_root / "roles")
+
+    def _skill_index_json() -> str:
+        from bernstein.core.skills.index_builder import serialize_skill_discovery_index
+
+        return serialize_skill_discovery_index(_skill_loader())
+
+    from bernstein.core.skills.index_builder import SKILL_INDEX_RESOURCE_URI
+
+    @mcp.resource(
+        SKILL_INDEX_RESOURCE_URI,
+        name="skill_index",
+        description="Compact index of loadable Bernstein skills and their content hashes.",
+        mime_type="application/json",
+    )
+    def skill_index() -> str:  # pyright: ignore[reportUnusedFunction]
+        return _skill_index_json()
+
     @mcp.tool()
     async def load_skill(  # pyright: ignore[reportUnusedFunction]
-        name: str,
+        name: str | None = None,
         reference: str | None = None,
         script: str | None = None,
     ) -> str:
-        """Load a skill pack body (and optionally a reference or script).
+        """Discover skills, or load a named skill body, reference, or script.
 
-        Agents receive only a compact skill index in their system prompt.
-        Call this tool to fetch the full ``SKILL.md`` body for a skill
-        when you decide it's relevant to the current task. Pass
-        ``reference`` to get a deeper-context file or ``script`` to read
-        the content of an executable helper.
+        Omit ``name`` to receive the compact skill index. Pass a skill name
+        to fetch its full ``SKILL.md`` body. ``reference`` and ``script``
+        are valid only with a named skill.
 
         Args:
-            name: Skill name (matches the index entry, e.g. ``"backend"``).
+            name: Optional skill name (for example ``"backend"``).
             reference: Optional filename under ``references/`` - for
                 example ``"python-conventions.md"``.
             script: Optional filename under ``scripts/`` - for example
@@ -1203,21 +1228,28 @@ def _register_skill_tools(mcp: FastMCP[None]) -> None:
                 MCP harness does not execute it.
 
         Returns:
-            JSON with ``name``, ``body``, ``available_references``,
-            ``available_scripts``, and the optional fetched content.
+            The compact index when ``name`` is omitted; otherwise JSON with
+            ``name``, ``body``, available files, and optional fetched content.
         """
+        payload = {
+            key: value
+            for key, value in {
+                "name": name,
+                "reference": reference,
+                "script": script,
+            }.items()
+            if value is not None
+        }
         err = _validate_or_error(
             "load_skill",
-            {"name": name, "reference": reference, "script": script},
+            payload,
         )
         if err is not None:
             return _validation_error_response(err)
         try:
-            # Local import so the MCP module stays cheap to import even when
-            # the skills tree is missing (e.g. dev CLI without templates).
-            from pathlib import Path as _Path
+            if name is None:
+                return _skill_index_json()
 
-            from bernstein import get_templates_dir
             from bernstein.core.skills.load_skill_tool import (
                 load_skill as _load_skill_impl,
             )
@@ -1225,13 +1257,11 @@ def _register_skill_tools(mcp: FastMCP[None]) -> None:
                 result_as_dict,
             )
 
-            templates_root = get_templates_dir(_Path.cwd())
-            templates_roles_dir = templates_root / "roles"
             result = _load_skill_impl(
                 name=name,
                 reference=reference,
                 script=script,
-                templates_roles_dir=templates_roles_dir,
+                loader=_skill_loader(),
             )
             return json.dumps(result_as_dict(result), indent=2)
         except Exception as exc:

--- a/src/bernstein/mcp/tool_schemas/load_skill.json
+++ b/src/bernstein/mcp/tool_schemas/load_skill.json
@@ -1,11 +1,15 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "load_skill",
+  "description": "List available skills when name is omitted, or load a named skill body, reference, or script.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["name"],
+  "dependencies": {
+    "reference": ["name"],
+    "script": ["name"]
+  },
   "properties": {
-    "name": {"type": "string", "minLength": 1, "maxLength": 128, "pattern": "^[A-Za-z0-9_.-]+$"},
+    "name": {"type": "string", "description": "Skill to load. Omit to return the compact skill index.", "minLength": 1, "maxLength": 128, "pattern": "^[A-Za-z0-9_.-]+$"},
     "reference": {"type": ["string", "null"], "maxLength": 256, "pattern": "^[A-Za-z0-9_./-]+$"},
     "script": {"type": ["string", "null"], "maxLength": 256, "pattern": "^[A-Za-z0-9_./-]+$"}
   }

--- a/tests/unit/mcp/test_skill_index_resource.py
+++ b/tests/unit/mcp/test_skill_index_resource.py
@@ -1,0 +1,55 @@
+"""MCP skill discovery parity tests (issue #3077)."""
+
+from __future__ import annotations
+
+import json
+import re
+
+import pytest
+
+from bernstein.core.skills.index_builder import SKILL_INDEX_RESOURCE_URI
+from bernstein.mcp.server import create_mcp_server
+
+_INDEX_SIZE_CEILING = 16 * 1024
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+@pytest.mark.asyncio
+async def test_no_arg_tool_and_resource_return_the_same_compact_index(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BERNSTEIN_MCP_COST_METER", "0")
+    mcp = create_mcp_server(tier="all")
+
+    tool_result = await mcp.call_tool("load_skill", {})
+    tool_body = tool_result[0][0].text  # type: ignore[index]
+    resource_contents = await mcp.read_resource(SKILL_INDEX_RESOURCE_URI)
+    resource_body = next(iter(resource_contents)).content
+
+    assert tool_body == resource_body
+    assert len(tool_body.encode("utf-8")) < _INDEX_SIZE_CEILING
+
+    index = json.loads(tool_body)
+    assert index["skills"]
+    for entry in index["skills"]:
+        assert set(entry) == {"content_hash", "description", "name"}
+        assert "\n" not in entry["description"]
+        assert _SHA256_RE.fullmatch(entry["content_hash"])
+        assert "body" not in entry
+
+
+@pytest.mark.asyncio
+async def test_named_load_skill_keeps_returning_the_full_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BERNSTEIN_MCP_COST_METER", "0")
+    mcp = create_mcp_server(tier="all")
+    index_result = await mcp.call_tool("load_skill", {})
+    index = json.loads(index_result[0][0].text)  # type: ignore[index]
+    name = index["skills"][0]["name"]
+
+    named_result = await mcp.call_tool("load_skill", {"name": name})
+    loaded = json.loads(named_result[0][0].text)  # type: ignore[index]
+
+    assert loaded["name"] == name
+    assert loaded["body"]


### PR DESCRIPTION
## What
- allow `load_skill` with no arguments to return a compact deterministic skill index
- expose byte-identical JSON at `bernstein://skills/index`
- include name, one-line description, and SHA-256 content hash without skill bodies
- preserve named skill loading and reject reference/script requests without a name

## Why
MCP clients can now discover available skills even when no prompt-provided index is available.

Fixes #3077

## Impact
Additive MCP discovery behavior. Named `load_skill` responses are unchanged.

## Checks
- `uv run pytest tests/unit/mcp/test_skill_index_resource.py -q` (2 passed)
- `uv run ruff format --check ...`
- `uv run ruff check ...`

## Note
Whole-file Pyright currently reports 28 diagnostics in existing server code outside the changed discovery ranges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a compact skill index for discovery through the `load_skill` tool and a new MCP resource.
  - Calling `load_skill` without a name now returns the skill index.
  - Calling `load_skill` with a name continues to return the complete skill details.
  - Skill index entries include descriptions and content hashes for reliable discovery and change detection.
  - Added validation to ensure optional reference and script parameters are used only with a skill name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->