### PR TITLE
fix(lineage): make v2 verify byte-exact and total

### DIFF
--- a/docs/operations/lineage-v2.md
+++ b/docs/operations/lineage-v2.md
@@ -59,6 +59,15 @@ Validates the HMAC chains across **both** layers. Exits `1` on
 failure; the failure list names the offending file plus the broken
 record.
 
+Verification is byte-exact and total:
+
+- Every line must equal the canonical serialisation of the record it
+  decodes to. Bytes the JSON reader would normalise away - an unknown
+  key, a renamed field - are reported as `non-canonical bytes`, even
+  when the decoded record still satisfies every hash and HMAC.
+- A malformed, truncated or undecodable line is reported as
+  `undecodable record`, never raised. Every store gets a verdict.
+
 ### export
 
 Emits the timeline for `TASK_ID` as:
@@ -77,6 +86,8 @@ Emits the timeline for `TASK_ID` as:
 Properties enforced by the store (and proved by 22 Hypothesis tests):
 
 - HMAC unforgeability across both layers
+- Byte coverage: flipping any single byte of any record on disk is
+  reported, in either layer
 - Replay determinism (same store + same task -> identical timeline)
 - Append commutativity per task across concurrent writers
 - Verify-after-truncate detects every truncation

--- a/src/bernstein/core/lineage/v2_store.py
+++ b/src/bernstein/core/lineage/v2_store.py
@@ -198,6 +198,24 @@ def compute_child_sha(child_body: ChildBody) -> str:
 # ---------------------------------------------------------------------------
 
 
+def _iter_raw_lines(path: Path) -> Iterator[bytes]:
+    """Yield the raw bytes of each non-empty JSONL line in ``path``.
+
+    Verification works on these bytes rather than on re-serialised
+    records: the line on disk *is* the record, so anything the JSON
+    parser normalises away has to stay visible to ``verify``.
+    """
+    if not path.exists():
+        return
+    raw = path.read_bytes()
+    if not raw:
+        return
+    for line in raw.rstrip(b"\n").split(b"\n"):
+        if not line:
+            continue
+        yield line
+
+
 @contextmanager
 def _exclusive_lock(path: Path) -> Iterator[int]:
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -221,6 +239,12 @@ def _exclusive_lock(path: Path) -> Iterator[int]:
 
 def _empty_failures() -> list[str]:
     return []
+
+
+# Exceptions a hostile or corrupt line can raise while being decoded into a
+# record. ``verify`` turns every one of them into a reported failure: an
+# auditor needs a verdict, not a traceback.
+_DECODE_ERRORS = (json.JSONDecodeError, UnicodeDecodeError, KeyError, TypeError, ValueError)
 
 
 @dataclass(frozen=True, slots=True)
@@ -495,16 +519,40 @@ class LineageV2Store:
            content-address that equals the parent ref's ``child_sha``.
         6. No orphan child files (i.e., a child file with no parent ref
            pointing at it).
+        7. Every line's bytes are exactly the canonical serialisation of
+           the record it decodes to.
+
+        Check 7 is what makes the byte coverage total. Checks 1-6 run on
+        a record *parsed out of* the line, and that parse is not
+        injective: unknown keys are dropped and a missing ``payload``
+        reads back as ``{}``. A mutation that lands in a region the
+        parser normalises away therefore reconstructs the very bytes
+        that were signed, and checks 1-6 all pass on it. Comparing the
+        line against the canonical form of what it decoded to closes
+        that class: every writer in this module emits canonical bytes,
+        so a line that is not its own canonical form was not written
+        here.
+
+        ``verify`` is total - a malformed, truncated or undecodable line
+        is reported as a failure rather than raised. Callers get a
+        verdict on every input.
         """
         failures: list[str] = []
         parent_count = 0
         child_count = 0
         referenced_shas: set[str] = set()
 
-        # 1+2: parent chain
+        # 1+2+7: parent chain
         prev = ""
-        for idx, ref in enumerate(self.iter_parent_refs()):
+        for idx, raw_line in enumerate(_iter_raw_lines(self.parent_log)):
             parent_count += 1
+            try:
+                ref = _parent_ref_from_dict(json.loads(raw_line))
+            except _DECODE_ERRORS as exc:
+                failures.append(f"parent[{idx}] undecodable record ({type(exc).__name__})")
+                continue
+            if _canonicalise(asdict(ref)) != raw_line:
+                failures.append(f"parent[{idx}] non-canonical bytes (task={ref.task_id})")
             expected = _compute_hmac(self._hmac_key, _parent_body_for_hmac(ref))
             if ref.hmac != expected:
                 failures.append(f"parent[{idx}] hmac mismatch (task={ref.task_id})")
@@ -513,15 +561,22 @@ class LineageV2Store:
             prev = ref.hmac
             referenced_shas.add(ref.child_sha)
 
-            # 3+4+5: child chain for this ref
+            # 3+4+5+7: child chain for this ref
             child_path = self.child_log(ref.child_sha)
             if not child_path.exists():
                 failures.append(f"parent[{idx}] missing child file {ref.child_sha}")
                 continue
 
             child_prev = ""
-            bodies_in_file = list(self.iter_child_bodies(ref.child_sha))
-            for bidx, body in enumerate(bodies_in_file):
+            for bidx, child_raw in enumerate(_iter_raw_lines(child_path)):
+                child_count += 1
+                try:
+                    body = _child_body_from_dict(json.loads(child_raw))
+                except _DECODE_ERRORS as exc:
+                    failures.append(f"child[{ref.child_sha[:16]}..][{bidx}] undecodable record ({type(exc).__name__})")
+                    continue
+                if _canonicalise(asdict(body)) != child_raw:
+                    failures.append(f"child[{ref.child_sha[:16]}..][{bidx}] non-canonical bytes")
                 if bidx == 0:
                     # Content-address check: the first body's
                     # sha-of-canonical-body must equal child_sha.
@@ -546,7 +601,6 @@ class LineageV2Store:
                 if body.prev_hmac != child_prev:
                     failures.append(f"child[{ref.child_sha[:16]}..][{bidx}] prev_hmac break")
                 child_prev = body.hmac
-                child_count += 1
 
         # 6: orphan child files
         children_dir = self.root / _CHILDREN_DIR

--- a/tests/property/test_lineage_v2_properties.py
+++ b/tests/property/test_lineage_v2_properties.py
@@ -4,13 +4,15 @@ Properties:
 
 1. HMAC chain unforgeability       - flipping any byte of any record on disk
                                      produces at least one verify() failure.
+                                     ``verify`` is total: it reports, it never
+                                     raises and never passes silently.
 2. Replay determinism              - replay() is a pure function of disk state.
 3. Append commutativity per task   - sequences of appends targeting distinct
                                      tasks can be interleaved without changing
                                      the per-task replay output.
 4. Verify-after-truncate invariants - truncating bytes never produces a
-                                     "silent ok" result; verify either raises
-                                     or returns ok=False.
+                                     "silent ok" result; verify returns
+                                     ok=False.
 5. Roundtrip                       - any well-formed (parent, child) pair
                                      written and read back equals the input
                                      (modulo the prev_hmac/hmac stamps).
@@ -125,12 +127,11 @@ def test_property_parent_byte_flip_breaks_verify(
         # XOR with 0x01 keeps it valid UTF-8 in our ASCII payloads.
         mutated[idx] ^= 0x01
         store.parent_log.write_bytes(bytes(mutated))
-        # Either verify raises (torn JSON) or reports failures - never silent ok.
-        try:
-            r = store.verify()
-        except (json.JSONDecodeError, ValueError, UnicodeDecodeError, KeyError):
-            return
-        assert not r.ok or len(r.failures) > 0
+        # verify() is total: every mutation is reported, none raises and
+        # none passes silently.
+        r = store.verify()
+        assert not r.ok
+        assert r.failures
 
 
 @given(payload=_payload(), flip_offset=st.integers(min_value=0, max_value=2048))
@@ -153,11 +154,9 @@ def test_property_child_byte_flip_breaks_verify(payload: dict[str, object], flip
         mutated = bytearray(raw)
         mutated[idx] ^= 0x01
         cpath.write_bytes(bytes(mutated))
-        try:
-            r = store.verify()
-        except (json.JSONDecodeError, ValueError, UnicodeDecodeError, KeyError):
-            return
-        assert not r.ok or len(r.failures) > 0
+        r = store.verify()
+        assert not r.ok
+        assert r.failures
 
 
 # ---------------------------------------------------------------------------
@@ -267,10 +266,7 @@ def test_property_truncate_parent_never_silent_ok(n: int, drop_last_k: int) -> N
         lines = raw.rstrip(b"\n").split(b"\n")
         kept = lines[: len(lines) - drop_last_k]
         store.parent_log.write_bytes(b"\n".join(kept) + b"\n")
-        try:
-            r = store.verify()
-        except (json.JSONDecodeError, ValueError, UnicodeDecodeError, KeyError):
-            return
+        r = store.verify()
         assert not r.ok
 
 

--- a/tests/unit/test_lineage_v2_store.py
+++ b/tests/unit/test_lineage_v2_store.py
@@ -638,14 +638,111 @@ def test_verify_wrong_key_fails_chain(tmp_path: Path) -> None:
 
 
 def test_verify_after_truncation(tmp_path: Path) -> None:
-    """Truncating bytes from the parent log produces an unverifiable chain."""
+    """Truncating bytes from the parent log produces an unverifiable chain.
+
+    ``verify`` reports the torn line rather than raising: an auditor
+    needs a verdict on the store, not a traceback from the JSON parser.
+    """
     store = LineageV2Store(tmp_path / "v2", hmac_key=_TEST_KEY)
     store.append(_make_parent(), _make_child())
     raw = store.parent_log.read_bytes()
-    # Lop off the last 5 bytes - the parser will reject torn JSON.
+    # Lop off the last 5 bytes - the line is now torn JSON.
     store.parent_log.write_bytes(raw[:-5])
-    with pytest.raises((json.JSONDecodeError, ValueError)):
-        store.verify()
+    r = store.verify()
+    assert not r.ok
+    assert any("undecodable" in f for f in r.failures)
+
+
+# ---------------------------------------------------------------------------
+# verify - byte coverage
+# ---------------------------------------------------------------------------
+
+
+def _flip_every_byte_and_verify(store: LineageV2Store, path: Path) -> list[tuple[int, str]]:
+    """Flip each non-newline byte of ``path`` in turn; return silent passes.
+
+    Returns ``(offset, character)`` for every byte whose mutation left
+    ``verify`` reporting a clean store. A correct verifier returns [].
+    """
+    original = path.read_bytes()
+    undetected: list[tuple[int, str]] = []
+    try:
+        for idx in range(len(original)):
+            if original[idx : idx + 1] == b"\n":
+                continue
+            mutated = bytearray(original)
+            mutated[idx] ^= 0x01
+            path.write_bytes(bytes(mutated))
+            # Must not raise - a tampered store still gets a verdict.
+            result = store.verify()
+            if result.ok or not result.failures:
+                undetected.append((idx, chr(original[idx])))
+    finally:
+        path.write_bytes(original)
+    return undetected
+
+
+def test_verify_detects_every_single_byte_flip_in_child_log(tmp_path: Path) -> None:
+    """Exhaustive: no byte of a child log can be flipped undetected.
+
+    The empty payload is the case that matters. The reader defaults a
+    missing ``payload`` key to ``{}``, so renaming that key - one bit in
+    any of its seven letters - used to rebuild a record identical to the
+    one that was signed. HMAC, chain and content address all matched and
+    ``verify`` reported ok.
+    """
+    store = LineageV2Store(tmp_path / "v2", hmac_key=_TEST_KEY)
+    child_sha, _ = store.append(_make_parent(), _make_child(payload={}))
+    assert store.verify().ok
+
+    undetected = _flip_every_byte_and_verify(store, store.child_log(child_sha))
+    assert undetected == []
+
+
+def test_verify_detects_every_single_byte_flip_in_parent_log(tmp_path: Path) -> None:
+    """Exhaustive: no byte of the parent log can be flipped undetected."""
+    store = LineageV2Store(tmp_path / "v2", hmac_key=_TEST_KEY)
+    store.append(_make_parent(), _make_child(payload={"k": "v"}))
+    assert store.verify().ok
+
+    undetected = _flip_every_byte_and_verify(store, store.parent_log)
+    assert undetected == []
+
+
+def test_verify_detects_renamed_payload_key(tmp_path: Path) -> None:
+    """Renaming ``payload`` on an empty-payload record must not verify.
+
+    Pins the exact regression: the mutated line still decodes, and every
+    hash and HMAC over the decoded record still matches, because the
+    dropped key reads back as the ``{}`` that was signed. Only the bytes
+    differ - so only a byte-level check catches it.
+    """
+    store = LineageV2Store(tmp_path / "v2", hmac_key=_TEST_KEY)
+    child_sha, _ = store.append(_make_parent(), _make_child(payload={}))
+    path = store.child_log(child_sha)
+
+    tampered = path.read_bytes().replace(b'"payload":', b'"payloae":')
+    assert tampered != path.read_bytes(), "fixture did not mutate the payload key"
+    path.write_bytes(tampered)
+
+    r = store.verify()
+    assert not r.ok
+    assert any("non-canonical bytes" in f for f in r.failures)
+
+
+def test_verify_rejects_unknown_key_appended_to_child_record(tmp_path: Path) -> None:
+    """A key the reader ignores still has to break verification."""
+    store = LineageV2Store(tmp_path / "v2", hmac_key=_TEST_KEY)
+    child_sha, _ = store.append(_make_parent(), _make_child())
+    path = store.child_log(child_sha)
+
+    obj = json.loads(path.read_bytes())
+    obj["injected"] = "ignored-by-the-reader"
+    path.write_bytes(json.dumps(obj, sort_keys=True, separators=(",", ":")).encode() + b"\n")
+
+    r = store.verify()
+    assert not r.ok
+    assert any("non-canonical bytes" in f for f in r.failures)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`LineageV2Store.verify()` could report a clean store after a child log had been
mutated on disk. This makes verification byte-exact, and makes it return a
verdict on every input instead of raising.

## Root cause

`verify()` validated a record *parsed out of* each line, never the line itself.
That parse is not injective:

- unknown keys are dropped
- `_child_body_from_dict` reads `payload.get("payload", {})`, the only defaulted field

So renaming the `payload` key (one bit in any of its seven letters) on a record
whose payload was already `{}` reconstructs exactly the record that was signed.
The HMAC, the `prev_hmac` chain and the `child_sha` content address all still
match, because every one of those checks runs on the reconstructed object.
`verify()` returns `ok=True, failures=[]`.

This is category (a), a real gap, not a degenerate example. The test's guard was
not too weak about the mutated region: the region is genuinely covered by the
format, and the verifier was not looking at it.

### Measured, before the fix

Exhaustive single-byte flip over a one-entry child log, 171 flippable bytes:

| Outcome | Bytes | Share |
|---|---|---|
| Reported as a failure | 69 | 40% |
| Raised out of `verify()` | 95 | 56% |
| **Passed silently** | **7** | **4%** |

The 7 silent bytes are the letters of the `payload` key. The 95 raising bytes
were only "detected" because the property test caught the exception and
returned, so more than half the byte range was never actually asserted on.

## Not a stale Hypothesis example

The failure reproduces from a **fresh** `.hypothesis` directory on 4 of 20 seeds.
It is a genuinely flaky property, not a cached local counter-example: it needs
`payload={}` drawn together with a `flip_offset` landing on those 7 bytes, which
is roughly a coin flip over a 50-example smoke run. CI has simply not drawn it
yet on the runs that were checked.

The falsifying example is `payload={}, flip_offset=121`, which pytest prints on
its own locals line. The empty `payload=,` in Hypothesis's own falsifying-example
block is cosmetic and does not indicate anything about the failure.

## Fix

Verification now iterates raw line bytes:

1. **Byte-canonical check.** Every line must equal the canonical serialisation of
   the record it decodes to. Every writer in the module emits canonical bytes, so
   a line that is not its own canonical form was not written here. This closes the
   entire lossy-parse class rather than only the `payload` default.

   This cannot reject an honest record. Anything that fails to round-trip already
   fails the existing HMAC check today, because the stored HMAC was computed over
   the writer's field set. The byte check adds failures only where the HMAC check
   passes but the bytes differ, which is exactly the silent-tamper class.

2. **`verify()` is total.** Decode errors are reported as `undecodable record`
   instead of propagating. `LineageSpine.verify()` in the same package already
   works this way; v2 now matches it. An operator running `bernstein lineage v2
   verify` gets a tamper report rather than a traceback.

### Measured, after the fix

| Layer | Flippable bytes | Reported | Raised | Silent |
|---|---|---|---|---|
| Child log | 171 | **171** | 0 | 0 |
| Parent log | 263 | **263** | 0 | 0 |

## Tests

Deterministic coverage, since a property test alone will not pin this:

- `test_verify_detects_every_single_byte_flip_in_child_log` - exhaustive per byte
- `test_verify_detects_every_single_byte_flip_in_parent_log` - exhaustive per byte
- `test_verify_detects_renamed_payload_key` - names the exact regression
- `test_verify_rejects_unknown_key_appended_to_child_record` - a key the reader ignores

Both exhaustive tests also fail if `verify()` raises, which pins totality.

The two byte-flip properties dropped their `except -> return` escape and now
assert `not r.ok` and `r.failures`. The assertion was not weakened: the old
`not r.ok or len(r.failures) > 0` is equivalent to `r.failures != []`, and the
escape that hid 56% of offsets is gone.

`test_verify_after_truncation` now asserts a reported failure rather than a
raised parser error, matching the new contract.

## Verification

| Check | Result |
|---|---|
| Lineage v2 unit + integration + property | 147 passed |
| Wider lineage + autoheal surface | 1037 passed |
| 25 seeds, fresh DB, both byte-flip properties | 0 failures (was 4/20) |
| `HYPOTHESIS_PROFILE=deep` (1000 examples) | passed |
| `ruff check` / `ruff format` / `mypy` | clean |
| `bernstein agents-md verify` | 13 files in sync |

## Docs

`docs/operations/lineage-v2.md` records the byte-exact and total guarantees under
`verify`, and adds byte coverage to the enforced-properties list.
