### PR TITLE
fix(openapi): refresh the snapshot for #3168 and guard response drift

### DIFF
--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -308,10 +308,12 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful Response",
+            "description": "Server-Sent Events stream. The response body does not terminate.",
             "content": {
-              "application/json": {
-                "schema": {}
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
               }
             }
           },
@@ -381,8 +383,8 @@
           "400": {
             "description": "Authentication provider not enabled"
           },
-          "503": {
-            "description": "SSO authentication not configured"
+          "404": {
+            "description": "SSO authentication is not configured on this server"
           },
           "422": {
             "description": "Validation Error",
@@ -417,8 +419,8 @@
           "400": {
             "description": "Missing or invalid authorization code or state"
           },
-          "503": {
-            "description": "SSO authentication not configured"
+          "404": {
+            "description": "SSO authentication is not configured on this server"
           }
         }
       }
@@ -443,8 +445,8 @@
           "400": {
             "description": "Missing SAMLResponse"
           },
-          "503": {
-            "description": "SSO authentication not configured"
+          "404": {
+            "description": "SSO authentication is not configured on this server"
           }
         }
       }
@@ -466,8 +468,8 @@
               }
             }
           },
-          "503": {
-            "description": "SSO authentication not configured"
+          "404": {
+            "description": "SSO authentication is not configured on this server"
           }
         }
       }
@@ -501,8 +503,8 @@
               }
             }
           },
-          "503": {
-            "description": "SSO authentication not configured"
+          "404": {
+            "description": "SSO authentication is not configured on this server"
           },
           "422": {
             "description": "Validation Error",
@@ -546,8 +548,8 @@
               }
             }
           },
-          "503": {
-            "description": "SSO authentication not configured"
+          "404": {
+            "description": "SSO authentication is not configured on this server"
           },
           "422": {
             "description": "Validation Error",
@@ -595,8 +597,8 @@
           "401": {
             "description": "Authentication required"
           },
-          "503": {
-            "description": "SSO authentication not configured"
+          "404": {
+            "description": "SSO authentication is not configured on this server"
           },
           "422": {
             "description": "Validation Error",
@@ -653,8 +655,8 @@
               }
             }
           },
-          "503": {
-            "description": "SSO authentication not configured"
+          "404": {
+            "description": "SSO authentication is not configured on this server"
           }
         }
       }
@@ -678,8 +680,8 @@
               }
             }
           },
-          "503": {
-            "description": "SSO authentication not configured"
+          "404": {
+            "description": "SSO authentication is not configured on this server"
           }
         }
       },
@@ -718,8 +720,8 @@
           "403": {
             "description": "Admin role required"
           },
-          "503": {
-            "description": "SSO authentication not configured"
+          "404": {
+            "description": "SSO authentication is not configured on this server"
           },
           "422": {
             "description": "Validation Error",
@@ -757,8 +759,8 @@
           "403": {
             "description": "Admin role required"
           },
-          "503": {
-            "description": "SSO authentication not configured"
+          "404": {
+            "description": "SSO authentication is not configured on this server"
           }
         }
       }
@@ -3782,10 +3784,12 @@
         "operationId": "sse_events_events_get",
         "responses": {
           "200": {
-            "description": "Successful Response",
+            "description": "Server-Sent Events stream. The response body does not terminate.",
             "content": {
-              "application/json": {
-                "schema": {}
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
               }
             }
           }
@@ -4342,10 +4346,12 @@
         "operationId": "cost_events_events_cost_get",
         "responses": {
           "200": {
-            "description": "Successful Response",
+            "description": "Server-Sent Events stream. The response body does not terminate.",
             "content": {
-              "application/json": {
-                "schema": {}
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
               }
             }
           }
@@ -6466,8 +6472,8 @@
           "400": {
             "description": "Invalid status filter"
           },
-          "503": {
-            "description": "Plan store not initialized"
+          "404": {
+            "description": "Plan mode is not enabled on this server"
           },
           "422": {
             "description": "Validation Error",
@@ -6515,10 +6521,7 @@
             }
           },
           "404": {
-            "description": "Plan not found"
-          },
-          "503": {
-            "description": "Plan store not initialized"
+            "description": "Plan not found, or plan mode is not enabled on this server"
           },
           "422": {
             "description": "Validation Error",
@@ -6583,13 +6586,10 @@
             }
           },
           "404": {
-            "description": "Plan not found"
+            "description": "Plan not found, or plan mode is not enabled on this server"
           },
           "409": {
             "description": "Plan already decided"
-          },
-          "503": {
-            "description": "Plan store not initialized"
           },
           "422": {
             "description": "Validation Error",
@@ -6654,13 +6654,10 @@
             }
           },
           "404": {
-            "description": "Plan not found"
+            "description": "Plan not found, or plan mode is not enabled on this server"
           },
           "409": {
             "description": "Plan already decided"
-          },
-          "503": {
-            "description": "Plan store not initialized"
           },
           "422": {
             "description": "Validation Error",
@@ -7256,10 +7253,12 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful Response",
+            "description": "Server-Sent Events stream. The response body does not terminate.",
             "content": {
-              "application/json": {
-                "schema": {}
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
               }
             }
           },
@@ -9122,10 +9121,12 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful Response",
+            "description": "Server-Sent Events stream. The response body does not terminate.",
             "content": {
-              "application/json": {
-                "schema": {}
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
               }
             }
           },
@@ -9195,8 +9196,8 @@
           "400": {
             "description": "Authentication provider not enabled"
           },
-          "503": {
-            "description": "SSO authentication not configured"
+          "404": {
+            "description": "SSO authentication is not configured on this server"
           },
           "422": {
             "description": "Validation Error",
@@ -9231,8 +9232,8 @@
           "400": {
             "description": "Missing or invalid authorization code or state"
           },
-          "503": {
-            "description": "SSO authentication not configured"
+          "404": {
+            "description": "SSO authentication is not configured on this server"
           }
         }
       }
@@ -9257,8 +9258,8 @@
           "400": {
             "description": "Missing SAMLResponse"
           },
-          "503": {
-            "description": "SSO authentication not configured"
+          "404": {
+            "description": "SSO authentication is not configured on this server"
           }
         }
       }
@@ -9280,8 +9281,8 @@
               }
             }
           },
-          "503": {
-            "description": "SSO authentication not configured"
+          "404": {
+            "description": "SSO authentication is not configured on this server"
           }
         }
       }
@@ -9315,8 +9316,8 @@
               }
             }
           },
-          "503": {
-            "description": "SSO authentication not configured"
+          "404": {
+            "description": "SSO authentication is not configured on this server"
           },
           "422": {
             "description": "Validation Error",
@@ -9360,8 +9361,8 @@
               }
             }
           },
-          "503": {
-            "description": "SSO authentication not configured"
+          "404": {
+            "description": "SSO authentication is not configured on this server"
           },
           "422": {
             "description": "Validation Error",
@@ -9409,8 +9410,8 @@
           "401": {
             "description": "Authentication required"
           },
-          "503": {
-            "description": "SSO authentication not configured"
+          "404": {
+            "description": "SSO authentication is not configured on this server"
           },
           "422": {
             "description": "Validation Error",
@@ -9467,8 +9468,8 @@
               }
             }
           },
-          "503": {
-            "description": "SSO authentication not configured"
+          "404": {
+            "description": "SSO authentication is not configured on this server"
           }
         }
       }
@@ -9492,8 +9493,8 @@
               }
             }
           },
-          "503": {
-            "description": "SSO authentication not configured"
+          "404": {
+            "description": "SSO authentication is not configured on this server"
           }
         }
       },
@@ -9532,8 +9533,8 @@
           "403": {
             "description": "Admin role required"
           },
-          "503": {
-            "description": "SSO authentication not configured"
+          "404": {
+            "description": "SSO authentication is not configured on this server"
           },
           "422": {
             "description": "Validation Error",
@@ -9571,8 +9572,8 @@
           "403": {
             "description": "Admin role required"
           },
-          "503": {
-            "description": "SSO authentication not configured"
+          "404": {
+            "description": "SSO authentication is not configured on this server"
           }
         }
       }
@@ -12596,10 +12597,12 @@
         "operationId": "sse_events_api_v1_events_get",
         "responses": {
           "200": {
-            "description": "Successful Response",
+            "description": "Server-Sent Events stream. The response body does not terminate.",
             "content": {
-              "application/json": {
-                "schema": {}
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
               }
             }
           }
@@ -13156,10 +13159,12 @@
         "operationId": "cost_events_api_v1_events_cost_get",
         "responses": {
           "200": {
-            "description": "Successful Response",
+            "description": "Server-Sent Events stream. The response body does not terminate.",
             "content": {
-              "application/json": {
-                "schema": {}
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
               }
             }
           }
@@ -15280,8 +15285,8 @@
           "400": {
             "description": "Invalid status filter"
           },
-          "503": {
-            "description": "Plan store not initialized"
+          "404": {
+            "description": "Plan mode is not enabled on this server"
           },
           "422": {
             "description": "Validation Error",
@@ -15329,10 +15334,7 @@
             }
           },
           "404": {
-            "description": "Plan not found"
-          },
-          "503": {
-            "description": "Plan store not initialized"
+            "description": "Plan not found, or plan mode is not enabled on this server"
           },
           "422": {
             "description": "Validation Error",
@@ -15397,13 +15399,10 @@
             }
           },
           "404": {
-            "description": "Plan not found"
+            "description": "Plan not found, or plan mode is not enabled on this server"
           },
           "409": {
             "description": "Plan already decided"
-          },
-          "503": {
-            "description": "Plan store not initialized"
           },
           "422": {
             "description": "Validation Error",
@@ -15468,13 +15467,10 @@
             }
           },
           "404": {
-            "description": "Plan not found"
+            "description": "Plan not found, or plan mode is not enabled on this server"
           },
           "409": {
             "description": "Plan already decided"
-          },
-          "503": {
-            "description": "Plan store not initialized"
           },
           "422": {
             "description": "Validation Error",
@@ -16070,10 +16066,12 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful Response",
+            "description": "Server-Sent Events stream. The response body does not terminate.",
             "content": {
-              "application/json": {
-                "schema": {}
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
               }
             }
           },

--- a/tests/unit/test_openapi_snapshot_drift.py
+++ b/tests/unit/test_openapi_snapshot_drift.py
@@ -11,6 +11,13 @@ regenerating the snapshot, and they name the offending paths so the fix is one
 command:
 
     uv run python scripts/generate_openapi.py
+
+Status codes are compared too. The first version of this guard checked only
+path and schema names, and #3168 changed the documented codes for ``/auth/*``
+and ``/plans*`` from 503 to 404 on the same day -- 30 operations went stale
+without a single test going red. Comparing the declared status codes closes
+that hole while still ignoring prose (summaries, descriptions, examples), so
+editing a docstring does not force a snapshot commit.
 """
 
 from __future__ import annotations
@@ -114,4 +121,38 @@ def test_snapshot_schema_names_match_live_app() -> None:
 
     assert live == committed, "docs/reference/openapi.json component schemas are stale.\n" + _format(
         "schema", live - committed, committed - live
+    )
+
+
+_METHODS = frozenset({"get", "post", "put", "patch", "delete", "head", "options", "trace"})
+
+
+def _responses(spec: dict[str, Any]) -> set[str]:
+    """Flatten the spec into ``METHOD /path -> code [media types]`` strings."""
+    return {
+        f"{method.upper()} {path} -> {code} {sorted((body or {}).get('content') or {})}"
+        for path, operations in spec.get("paths", {}).items()
+        for method, operation in operations.items()
+        if method in _METHODS and isinstance(operation, dict)
+        for code, body in (operation.get("responses") or {}).items()
+    }
+
+
+def test_snapshot_responses_match_live_app() -> None:
+    """Documented status codes and media types track the handlers.
+
+    Both halves come from the same incident. #3168 moved ``/auth/*`` and
+    ``/plans*`` from 503 to 404 and, in the same change, corrected eight SSE
+    routes from ``application/json`` to ``text/event-stream``. The media type
+    moved while the status code stayed 200, so comparing codes alone would
+    still have missed those eight.
+
+    Prose is deliberately not compared: no summaries, descriptions, or
+    examples, so rewording a docstring does not demand a snapshot commit.
+    """
+    live = _responses(_live_spec())
+    committed = _responses(_committed_spec())
+
+    assert live == committed, "docs/reference/openapi.json responses are stale.\n" + _format(
+        "response", live - committed, committed - live
     )


### PR DESCRIPTION
## What

`main` currently documents behaviour the app no longer has. #3168 and #3184 merged 95 minutes apart, and #3184 was branched before #3168 landed, so the snapshot it regenerated predates the route changes:

| Surface | Snapshot in `main` | Actual handler |
|---|---|---|
| `/auth/*`, `/plans*` (30 operations) | `503` | `404` |
| 8 SSE routes | `application/json` | `text/event-stream` |

The guard added in #3184 compared paths and component schema names only, so none of this went red. This refreshes the snapshot and closes the hole.

## The new check

A third comparison over declared responses - status code plus media types, keyed by method and path:

```
docs/reference/openapi.json responses are stale.
  32 live response(s) absent from the snapshot:
    + GET /agents/{session_id}/stream -> 200 ['text/event-stream']
    + GET /auth/login -> 404 []
    ...
  Regenerate with: uv run python scripts/generate_openapi.py
```

Both halves earned their place in the same incident. **Comparing status codes alone would still have missed the eight SSE routes** - their media type changed while the code stayed `200`. That is why the check is over `(code, media types)` rather than codes.

## What is deliberately not compared

Prose: summaries, descriptions, examples. Rewording a docstring should not demand a snapshot commit.

Full document equality would catch strictly more, at the cost of a regeneration on every PR touching a route or model. #3184 flagged that tradeoff as a deliberate decision rather than something to smuggle in; this PR takes the middle position, which is the one the incident actually justifies. Structural response shape is pinned, prose is free.

## Verification

- 5 tests pass. The new one was watched failing first against the snapshot currently in `main`: 32 discrepancies, both classes named.
- Sensitivity checked by mutation - injecting a `418` on `GET /tasks` is caught and named.
- Snapshot diff is 190 lines and confined to the affected responses; regeneration is idempotent.
- `ruff check` / `format` clean, `scripts/check_docs_drift.py` reports no drift.

## Note on ordering

#3184 called out this exact risk and said to re-run the generator after #3168 landed. That step was missed because #3184 auto-merged on green rather than waiting. Nothing else is outstanding from that PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced OpenAPI snapshot validation to detect changes in declared response status codes and media types.
  * Added clearer failure details for responses missing from or removed from the committed snapshot.
  * Clarified that prose-only updates, such as summaries, descriptions, and examples, do not trigger snapshot drift failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->