### PR TITLE
fix(ci): give bot pull requests a triggering token, follow import aliases in test selection, cover Python 3.14

### DIFF
--- a/.github/workflows/adapter-conformance-canary.yml
+++ b/.github/workflows/adapter-conformance-canary.yml
@@ -60,7 +60,15 @@ jobs:
 
       # persist-credentials kept: this job pushes the last-green
       # regeneration branch when the projection changed.
+      #
+      # The persisted credential is the same token the PR step uses, so the
+      # branch push and the pull request carry one identity. A push made with
+      # GITHUB_TOKEN emits no `pull_request: synchronize`, so a later nightly
+      # force-push onto an already-open PR would leave its checks stale even
+      # if the PR itself had been opened under a triggering token.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7  # zizmor: ignore[artipacked]
+        with:
+          token: ${{ secrets.BERNSTEIN_AUTOSYNC_TOKEN || secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
@@ -194,7 +202,15 @@ jobs:
 
       - name: Propose last-green regeneration PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # A PR created with GITHUB_TOKEN does not trigger workflows: neither
+          # `CI gate` nor `review-bot-ack` ever reports, branch protection
+          # holds it at BLOCKED while the rollup reads SUCCESS, and an
+          # operator has to close it. This lane regenerates the packaged
+          # last-green projection, so a PR that can never merge means the
+          # shipped projection goes stale while the canary keeps reporting
+          # that it ran. The GITHUB_TOKEN fallback keeps forks and
+          # secret-less environments working; see docs/operations/ci.md.
+          GH_TOKEN: ${{ secrets.BERNSTEIN_AUTOSYNC_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           if git diff --quiet -- src/bernstein/adapters/last_green.json docs/adapters/conformance-canary.md; then

--- a/.github/workflows/auto-heal.yml
+++ b/.github/workflows/auto-heal.yml
@@ -47,6 +47,17 @@ on:
         description: Display title of the upstream CI run (commit subject).
         required: true
         type: string
+    secrets:
+      BERNSTEIN_AUTOSYNC_TOKEN:
+        description: >-
+          PAT used to push the heal branch and open the heal pull request. A
+          reusable workflow sees no secret it was not passed, so this has to be
+          declared here and forwarded by post-ci-dispatcher.yml; without the
+          declaration the reference silently reads as empty and the lane falls
+          back to the Actions token, whose pull requests never trigger
+          workflows. Optional - the fallback is a working degraded mode, see
+          docs/operations/ci.md.
+        required: false
     outputs:
       heal_outcome:
         description: >-
@@ -280,6 +291,12 @@ jobs:
       pr_url: ${{ steps.open_pr.outputs.pr_url }}
       pr_number: ${{ steps.open_pr.outputs.pr_number }}
       outcome: ${{ steps.outcome.outputs.outcome }}
+    env:
+      # The `secrets` context is not readable from a step-level `if`, so the
+      # presence of the triggering token is lifted into an env flag here. It
+      # decides whether the heal PR can collect its own checks or whether the
+      # explicit ci.yml dispatch below has to stand in for them.
+      HAS_TRIGGERING_TOKEN: ${{ secrets.BERNSTEIN_AUTOSYNC_TOKEN != '' }}
     steps:
       - name: Harden runner (audit mode)
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -501,7 +518,11 @@ jobs:
         id: push_branch
         if: steps.cordon.outputs.noop != 'true' && steps.self_test.outputs.validation_failed != 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Same token as the PR step below, so the branch push and the pull
+          # request carry one identity: a push made with GITHUB_TOKEN emits no
+          # `pull_request: synchronize`, which would leave a re-pushed heal
+          # branch with stale checks.
+          GH_TOKEN: ${{ secrets.BERNSTEIN_AUTOSYNC_TOKEN || secrets.GITHUB_TOKEN }}
           SHORT_SHA: ${{ needs.triage.outputs.short_sha }}
           STRATEGY: ${{ needs.triage.outputs.strategy }}
         run: |
@@ -527,11 +548,13 @@ jobs:
 
       - name: Trigger CI on heal PR branch
         id: ci_dispatch
-        # PRs opened via secrets.GITHUB_TOKEN do not emit `pull_request`
-        # events for downstream workflows, so CI never auto-starts on the
-        # newly pushed heal branch. Dispatch ci.yml explicitly before the
-        # PR is opened so dispatch failure can block the PR path.
-        if: steps.push_branch.outputs.branch != ''
+        # Fallback only. A PR opened with secrets.GITHUB_TOKEN emits no
+        # `pull_request` event, so CI never auto-starts on the heal branch and
+        # this dispatch has to stand in for it. When
+        # BERNSTEIN_AUTOSYNC_TOKEN is configured the PR triggers its own
+        # workflows and dispatching here would only add a duplicate
+        # full-matrix run on the same head SHA.
+        if: steps.push_branch.outputs.branch != '' && env.HAS_TRIGGERING_TOKEN != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEAL_BRANCH: ${{ steps.push_branch.outputs.branch }}
@@ -551,7 +574,13 @@ jobs:
           steps.self_test.outputs.validation_failed != 'true' &&
           steps.ci_dispatch.outputs.validation_failed != 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # A PR created with GITHUB_TOKEN does not trigger workflows, so
+          # neither required context ever reports and branch protection holds
+          # it at BLOCKED while the rollup reads SUCCESS. The GITHUB_TOKEN
+          # fallback keeps forks and secret-less environments working; there
+          # the dispatch step above supplies the CI signal instead. See
+          # docs/operations/ci.md.
+          GH_TOKEN: ${{ secrets.BERNSTEIN_AUTOSYNC_TOKEN || secrets.GITHUB_TOKEN }}
           SHORT_SHA: ${{ needs.triage.outputs.short_sha }}
           STRATEGY: ${{ needs.triage.outputs.strategy }}
           HEAL_BRANCH: ${{ steps.push_branch.outputs.branch }}

--- a/.github/workflows/bernstein-ci-fix.yml
+++ b/.github/workflows/bernstein-ci-fix.yml
@@ -42,6 +42,16 @@ on:
         required: true
         type: string
     secrets:
+      BERNSTEIN_AUTOSYNC_TOKEN:
+        description: >-
+          PAT used to push the auto-heal branch and open the auto-heal pull
+          request. A reusable workflow sees no secret it was not passed, so
+          this has to be declared here and forwarded by
+          post-ci-dispatcher.yml; without the declaration the reference
+          silently reads as empty and the lane falls back to the Actions
+          token, whose pull requests never trigger workflows. Optional - the
+          fallback is a working degraded mode, see docs/operations/ci.md.
+        required: false
       GEMINI_API_KEY:
         description: >-
           Gemini API key used by the bernstein-ci-fix triage agent.
@@ -221,12 +231,17 @@ jobs:
         with:
           egress-policy: audit
       # persist-credentials kept: this job pushes back to git (auto-heal branch).
+      #
+      # The persisted credential is the same token the PR step uses, so the
+      # branch push and the pull request carry one identity. A push made with
+      # GITHUB_TOKEN emits no `pull_request: synchronize`, so re-pushing an
+      # already-open auto-heal branch would leave its checks stale.
       - name: Checkout failing commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7  # zizmor: ignore[artipacked]
         with:
           ref: ${{ needs.triage.outputs.head_sha }}
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BERNSTEIN_AUTOSYNC_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Configure git identity
         run: |
@@ -320,7 +335,13 @@ jobs:
         id: open-pr
         if: steps.diff.outputs.has_changes == 'true' && steps.size-check.outputs.within_cap == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # A PR created with GITHUB_TOKEN does not trigger workflows, so
+          # neither required context ever reports and branch protection holds
+          # it at BLOCKED while the rollup reads SUCCESS. The GITHUB_TOKEN
+          # fallback keeps forks and secret-less environments working; there
+          # the PR needs a manual close-and-reopen to collect its checks. See
+          # docs/operations/ci.md.
+          GH_TOKEN: ${{ secrets.BERNSTEIN_AUTOSYNC_TOKEN || secrets.GITHUB_TOKEN }}
           AUTO_HEAL_BRANCH: ${{ needs.triage.outputs.auto_heal_branch }}
           SHORT_SHA: ${{ needs.triage.outputs.short_sha }}
           HEAD_SHA: ${{ needs.triage.outputs.head_sha }}

--- a/.github/workflows/bernstein-issues-decompose.yml
+++ b/.github/workflows/bernstein-issues-decompose.yml
@@ -256,7 +256,10 @@ jobs:
         id: commit
         if: steps.diff_scope.outputs.should_open_pr == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          # Same token as the PR step below, so the branch push and the pull
+          # request carry one identity: a push made with the Actions token
+          # emits no `pull_request: synchronize`.
+          GH_TOKEN: ${{ secrets.BERNSTEIN_AUTOSYNC_TOKEN || github.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
           set -euo pipefail
@@ -274,7 +277,12 @@ jobs:
       - name: Open PR
         if: steps.diff_scope.outputs.should_open_pr == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          # A PR created with the Actions token does not trigger workflows, so
+          # neither required context ever reports and branch protection holds
+          # it at BLOCKED while the rollup reads SUCCESS. The `github.token`
+          # fallback keeps forks and secret-less environments working; see
+          # docs/operations/ci.md.
+          GH_TOKEN: ${{ secrets.BERNSTEIN_AUTOSYNC_TOKEN || github.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ALLOWED_SCOPE: ${{ needs.scope_gate.outputs.allowed_scope }}
         run: |

--- a/.github/workflows/coverage-ratchet-weekly.yml
+++ b/.github/workflows/coverage-ratchet-weekly.yml
@@ -117,7 +117,14 @@ jobs:
         if: steps.gate.outputs.skip != 'true' && steps.detect.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # A PR created with GITHUB_TOKEN does not trigger workflows, so
+          # neither required context (`CI gate`, `review-bot-ack`) ever
+          # reports on it: branch protection holds it at BLOCKED while the
+          # rollup reads SUCCESS, and an operator has to close it by hand.
+          # The GITHUB_TOKEN fallback keeps forks and secret-less
+          # environments working; see docs/operations/ci.md for what
+          # degrades when the secret is absent.
+          token: ${{ secrets.BERNSTEIN_AUTOSYNC_TOKEN || secrets.GITHUB_TOKEN }}
           branch: coverage-ratchet/weekly-floor-${{ github.run_id }}
           delete-branch: true
           add-paths: |

--- a/.github/workflows/docs-observability-snapshot.yml
+++ b/.github/workflows/docs-observability-snapshot.yml
@@ -89,7 +89,12 @@ jobs:
         id: snapshot-pr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # A PR created with GITHUB_TOKEN does not trigger workflows, so
+          # neither required context (`CI gate`, `review-bot-ack`) ever
+          # reports on it and branch protection holds it at BLOCKED forever.
+          # The GITHUB_TOKEN fallback keeps forks and secret-less
+          # environments working; see docs/operations/ci.md.
+          token: ${{ secrets.BERNSTEIN_AUTOSYNC_TOKEN || secrets.GITHUB_TOKEN }}
           branch: chore/observability-snapshot
           delete-branch: true
           add-paths: |

--- a/.github/workflows/nightly-deep-tests.yml
+++ b/.github/workflows/nightly-deep-tests.yml
@@ -30,6 +30,56 @@ permissions:
   contents: read
 
 jobs:
+  unit-python-314:
+    # The only lane that executes the unit suite on Python 3.14.
+    #
+    # `ci.yml` runs the unit matrix on 3.13 for pull requests and on
+    # 3.12 + 3.13 for pushes to main; ci-macos-nightly.yml is 3.13. The only
+    # 3.14 pins anywhere were the uv-tool install smoke and a handful of
+    # automation workflows, none of which execute a test. A 3.14-only
+    # regression was therefore invisible to every test lane.
+    #
+    # Why nightly and not the pull_request matrix. The `test` matrix fans out
+    # over os x python x shard, so adding a python row adds 8 jobs to every
+    # pull request (measured: `ci.yml` puts 39 jobs on a pull request head and
+    # 47 on a push to main, out of 67 check-runs total on the head SHA,
+    # against a 20-concurrent-job ceiling). Buying 3.14 coverage there would
+    # lengthen the queue on every pull request for an interpreter nothing
+    # ships on yet. Here it costs 4 jobs once a day, on a workflow with no
+    # pull_request trigger and no required context, and a 3.14-only
+    # regression surfaces within 24 hours instead of never.
+    #
+    # Sharded rather than a single job because a full unfiltered shard takes
+    # roughly half an hour; one unsharded job would run about two.
+    name: Unit tests (Python 3.14, shard ${{ matrix.shard }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/bootstrap
+        with:
+          python-version: "3.14"
+      - name: Run unit suite on 3.14
+        env:
+          SHARD: ${{ matrix.shard }}
+        run: |
+          # Full discovery, no --affected: this lane exists to catch what the
+          # pull_request lane cannot see, so narrowing it to a diff would
+          # reintroduce the blind spot on a different axis.
+          uv run python scripts/run_tests.py --parallel 4 --shard "${SHARD}/4"
+
   hypothesis-deep:
     name: Hypothesis (deep, 1000 examples)
     runs-on: ubuntu-latest

--- a/.github/workflows/post-ci-dispatcher.yml
+++ b/.github/workflows/post-ci-dispatcher.yml
@@ -186,7 +186,15 @@ jobs:
       id-token: write
       actions: read
     uses: ./.github/workflows/auto-heal.yml
-    # GITHUB_TOKEN is auto-provided to the reusable workflow.
+    # GITHUB_TOKEN is auto-provided to the reusable workflow. Nothing else
+    # is: a reusable workflow sees only the secrets passed here, so the
+    # token the heal lane uses to open its pull request has to be forwarded
+    # explicitly or the reference reads as empty and the lane degrades to
+    # the Actions token, whose pull requests never trigger workflows. The
+    # callee declares it `required: false`, so an environment without the
+    # secret still boots.
+    secrets:
+      BERNSTEIN_AUTOSYNC_TOKEN: ${{ secrets.BERNSTEIN_AUTOSYNC_TOKEN }}
     with:
       head_sha: ${{ needs.meta.outputs.head_sha }}
       run_id: ${{ needs.meta.outputs.run_id }}
@@ -228,6 +236,9 @@ jobs:
     # `required: false` on the called workflow so jobs that need it gate
     # on a non-empty value rather than failing the whole reusable call.
     secrets:
+      # See the auto-heal call above: a reusable workflow sees only what it
+      # is passed, so the pull-request token has to be forwarded explicitly.
+      BERNSTEIN_AUTOSYNC_TOKEN: ${{ secrets.BERNSTEIN_AUTOSYNC_TOKEN }}
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       # OPENROUTER_API_KEY_FREE: ${{ secrets.OPENROUTER_API_KEY_FREE }}
       # Re-enable the pass once OPENROUTER_API_KEY_FREE is defined on

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -46,7 +46,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/main-sha-marker.yml | Main SHA marker | push | {"cancel-in-progress": "false", "group": "main-sha-marker-${{ github.sha }}"} | 1 |
 | .github/workflows/mutation-fixed.yml | Mutation (fixed critical paths) | merge_group, schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "mutation-fixed-${{ github.workflow }}-${{ github.ref }}"} | 2 |
 | .github/workflows/nightly-canary.yml | Nightly real-run canary | schedule, workflow_dispatch | {"cancel-in-progress": "false", "group": "nightly-canary"} | 1 |
-| .github/workflows/nightly-deep-tests.yml | Nightly deep tests | schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "nightly-deep-tests"} | 7 |
+| .github/workflows/nightly-deep-tests.yml | Nightly deep tests | schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "nightly-deep-tests"} | 8 |
 | .github/workflows/nightly-drift-sweep.yml | Nightly drift sweep | schedule, workflow_dispatch | {"cancel-in-progress": "false", "group": "nightly-drift-sweep"} | 1 |
 | .github/workflows/pentest.yml | Adversarial Pen-Test Suite | workflow_dispatch | {"cancel-in-progress": "false", "group": "pentest-${{ github.ref }}"} | 1 |
 | .github/workflows/post-ci-dispatcher.yml | Post-CI dispatcher | workflow_run | {"cancel-in-progress": "false", "group": "post-ci-dispatcher-${{ github.event.workflow_run.head_sha }}"} | 5 |
@@ -112,7 +112,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/main-sha-marker.yml | marker: Main SHA marker |
 | .github/workflows/mutation-fixed.yml | mutate: ${{ matrix.module }}<br>summary: Summary + PR comment |
 | .github/workflows/nightly-canary.yml | canary: Real-run canary |
-| .github/workflows/nightly-deep-tests.yml | bandit-medium-and-high: Bandit (full -ll, advisory)<br>crosshair-pure-fns: CrossHair (concolic, deep)<br>hypothesis-deep: Hypothesis (deep, 1000 examples)<br>mutmut-full: Mutation (full repo, advisory)<br>pip-audit-deep: pip-audit (full closure)<br>schemathesis-deep: Schemathesis (deep, full sweep)<br>stress-leak-suite: Stress + resource-leak suite (TC-C) |
+| .github/workflows/nightly-deep-tests.yml | bandit-medium-and-high: Bandit (full -ll, advisory)<br>crosshair-pure-fns: CrossHair (concolic, deep)<br>hypothesis-deep: Hypothesis (deep, 1000 examples)<br>mutmut-full: Mutation (full repo, advisory)<br>pip-audit-deep: pip-audit (full closure)<br>schemathesis-deep: Schemathesis (deep, full sweep)<br>stress-leak-suite: Stress + resource-leak suite (TC-C)<br>unit-python-314: Unit tests (Python 3.14, shard ${{ matrix.shard }}) |
 | .github/workflows/nightly-drift-sweep.yml | sweep: Open drift-sweep PR if mirrors drifted |
 | .github/workflows/pentest.yml | pentest: Pen-test: ${{ github.event.inputs.suite \|\| 'all' }} |
 | .github/workflows/post-ci-dispatcher.yml | auto-heal: Auto-heal v2<br>auto-release: Auto-release<br>bernstein-ci-fix: Bernstein CI fix<br>bisect-on-red: Bisect on red<br>meta: Resolve upstream metadata |
@@ -144,13 +144,13 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | Workflow | Permissions | Secrets |
 | --- | --- | --- |
 | .github/workflows/a2a-federation-e2e.yml | workflow: {"contents": "read"} | - |
-| .github/workflows/adapter-conformance-canary.yml | workflow: {"contents": "read"}<br>canary: {"contents": "write", "issues": "write", "pull-requests": "write"} | GITHUB_TOKEN |
+| .github/workflows/adapter-conformance-canary.yml | workflow: {"contents": "read"}<br>canary: {"contents": "write", "issues": "write", "pull-requests": "write"} | BERNSTEIN_AUTOSYNC_TOKEN, GITHUB_TOKEN |
 | .github/workflows/adapter-contract-drift.yml | workflow: {"contents": "read"}<br>aggregate: {"contents": "read", "issues": "write"}<br>check: {"contents": "read"} | ADAPTER_CONTRACT_ANTHROPIC_API_KEY, ADAPTER_CONTRACT_GEMINI_API_KEY, ADAPTER_CONTRACT_OPENAI_API_KEY, GITHUB_TOKEN |
 | .github/workflows/airgap-e2e.yml | workflow: {"contents": "read"} | - |
-| .github/workflows/auto-heal.yml | heal: {"attestations": "write", "contents": "write", "id-token": "write", "pull-requests": "write"}<br>triage: {"actions": "read", "contents": "read", "pull-requests": "read"} | GITHUB_TOKEN |
+| .github/workflows/auto-heal.yml | heal: {"attestations": "write", "contents": "write", "id-token": "write", "pull-requests": "write"}<br>triage: {"actions": "read", "contents": "read", "pull-requests": "read"} | BERNSTEIN_AUTOSYNC_TOKEN, GITHUB_TOKEN |
 | .github/workflows/auto-release.yml | alert-on-stale-release-trigger: {"contents": "read", "issues": "write"}<br>detect-stale-alerts: {"contents": "read", "issues": "read"}<br>gate: {"contents": "read"}<br>release: {"actions": "write", "contents": "write"}<br>sweep-stale-alerts-on-success: {"contents": "read", "issues": "write"} | GITHUB_TOKEN |
-| .github/workflows/bernstein-ci-fix.yml | fallback-issue: {"contents": "read", "issues": "write"}<br>fix: {"contents": "write", "issues": "write", "pull-requests": "write"}<br>tier3-shadow: {"actions": "read", "contents": "read"}<br>triage: {"actions": "read", "contents": "read", "pull-requests": "read"} | GEMINI_API_KEY, GITHUB_TOKEN, OPENROUTER_API_KEY_FREE |
-| .github/workflows/bernstein-issues-decompose.yml | workflow: {"contents": "read"}<br>decompose: {"contents": "write", "issues": "write", "pull-requests": "write"}<br>plan: {"contents": "read"}<br>reject-untrusted-issue: {"issues": "write"}<br>scope_gate: {"issues": "write"} | ANTHROPIC_API_KEY, GOOGLE_API_KEY, OPENAI_API_KEY |
+| .github/workflows/bernstein-ci-fix.yml | fallback-issue: {"contents": "read", "issues": "write"}<br>fix: {"contents": "write", "issues": "write", "pull-requests": "write"}<br>tier3-shadow: {"actions": "read", "contents": "read"}<br>triage: {"actions": "read", "contents": "read", "pull-requests": "read"} | BERNSTEIN_AUTOSYNC_TOKEN, GEMINI_API_KEY, GITHUB_TOKEN, OPENROUTER_API_KEY_FREE |
+| .github/workflows/bernstein-issues-decompose.yml | workflow: {"contents": "read"}<br>decompose: {"contents": "write", "issues": "write", "pull-requests": "write"}<br>plan: {"contents": "read"}<br>reject-untrusted-issue: {"issues": "write"}<br>scope_gate: {"issues": "write"} | ANTHROPIC_API_KEY, BERNSTEIN_AUTOSYNC_TOKEN, GOOGLE_API_KEY, OPENAI_API_KEY |
 | .github/workflows/bernstein-pr-review.yml | workflow: {"contents": "read", "pull-requests": "write"} | ANTHROPIC_API_KEY |
 | .github/workflows/bisect-on-red.yml | bisect: {"contents": "read", "issues": "write", "pull-requests": "write"} | - |
 | .github/workflows/branch-protection-audit.yml | audit: {"contents": "read"} | BRANCH_PROTECTION_AUDIT_TOKEN |
@@ -166,22 +166,22 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/code-review-bots-ci.yml | workflow: {"contents": "read"}<br>sourcery-cli: {"contents": "read"} | SOURCERY_API_KEY |
 | .github/workflows/codeql.yml | workflow: {"contents": "read"}<br>analyze: {"actions": "read", "contents": "read", "pull-requests": "write", "security-events": "write"} | - |
 | .github/workflows/contract-drift-autofix.yml | workflow: {"contents": "write", "issues": "write", "pull-requests": "write"}<br>autofix: {"contents": "write", "issues": "write", "pull-requests": "write"} | BOT_PAT, GITHUB_TOKEN |
-| .github/workflows/coverage-ratchet-weekly.yml | bump: {"contents": "write", "pull-requests": "write"} | GITHUB_TOKEN |
+| .github/workflows/coverage-ratchet-weekly.yml | bump: {"contents": "write", "pull-requests": "write"} | BERNSTEIN_AUTOSYNC_TOKEN, GITHUB_TOKEN |
 | .github/workflows/coverage-ratchet.yml | ratchet: {"actions": "read", "contents": "write", "pull-requests": "write"} | BERNSTEIN_AUTOSYNC_TOKEN, GITHUB_TOKEN |
 | .github/workflows/dependabot-auto-merge.yml | workflow: {"contents": "read"}<br>auto-merge: {"contents": "write", "pull-requests": "write"} | GITHUB_TOKEN |
 | .github/workflows/dependency-review.yml | workflow: {"contents": "read"}<br>review: {"contents": "read", "pull-requests": "write"} | - |
 | .github/workflows/docs-drift.yml | workflow: {"contents": "read"}<br>drift-check: {"contents": "read", "issues": "write", "pull-requests": "write"} | - |
-| .github/workflows/docs-observability-snapshot.yml | workflow: {"contents": "read"}<br>snapshot: {"contents": "write", "pull-requests": "write", "security-events": "read"} | GITHUB_TOKEN |
+| .github/workflows/docs-observability-snapshot.yml | workflow: {"contents": "read"}<br>snapshot: {"contents": "write", "pull-requests": "write", "security-events": "read"} | BERNSTEIN_AUTOSYNC_TOKEN, GITHUB_TOKEN |
 | .github/workflows/eval-nightly.yml | workflow: {"contents": "read"} | EVAL_ENABLED |
 | .github/workflows/hotfix-r-tracker.yml | track: {"contents": "read", "issues": "write", "pull-requests": "write"} | - |
 | .github/workflows/license-compliance.yml | workflow: {"contents": "read"}<br>license-check: {"contents": "read"} | - |
 | .github/workflows/main-sha-marker.yml | - | - |
 | .github/workflows/mutation-fixed.yml | workflow: {"contents": "read"}<br>mutate: {"contents": "read"}<br>summary: {"contents": "read", "pull-requests": "write"} | - |
 | .github/workflows/nightly-canary.yml | workflow: {"contents": "read"} | - |
-| .github/workflows/nightly-deep-tests.yml | workflow: {"contents": "read"}<br>bandit-medium-and-high: {"contents": "read"}<br>crosshair-pure-fns: {"contents": "read"}<br>hypothesis-deep: {"contents": "read"}<br>mutmut-full: {"contents": "read"}<br>pip-audit-deep: {"contents": "read"}<br>schemathesis-deep: {"contents": "read"}<br>stress-leak-suite: {"contents": "read"} | - |
+| .github/workflows/nightly-deep-tests.yml | workflow: {"contents": "read"}<br>bandit-medium-and-high: {"contents": "read"}<br>crosshair-pure-fns: {"contents": "read"}<br>hypothesis-deep: {"contents": "read"}<br>mutmut-full: {"contents": "read"}<br>pip-audit-deep: {"contents": "read"}<br>schemathesis-deep: {"contents": "read"}<br>stress-leak-suite: {"contents": "read"}<br>unit-python-314: {"contents": "read"} | - |
 | .github/workflows/nightly-drift-sweep.yml | workflow: {"contents": "read"}<br>sweep: {"contents": "write", "pull-requests": "write"} | BERNSTEIN_AUTOSYNC_TOKEN, GITHUB_TOKEN |
 | .github/workflows/pentest.yml | workflow: {"contents": "read"} | - |
-| .github/workflows/post-ci-dispatcher.yml | auto-heal: {"actions": "read", "attestations": "write", "contents": "write", "id-token": "write", "pull-requests": "write"}<br>auto-release: {"actions": "write", "contents": "write", "issues": "write"}<br>bernstein-ci-fix: {"actions": "read", "contents": "write", "issues": "write", "pull-requests": "write"}<br>bisect-on-red: {"contents": "read", "issues": "write", "pull-requests": "write"}<br>meta: {"contents": "read"} | GEMINI_API_KEY, OPENROUTER_API_KEY_FREE |
+| .github/workflows/post-ci-dispatcher.yml | auto-heal: {"actions": "read", "attestations": "write", "contents": "write", "id-token": "write", "pull-requests": "write"}<br>auto-release: {"actions": "write", "contents": "write", "issues": "write"}<br>bernstein-ci-fix: {"actions": "read", "contents": "write", "issues": "write", "pull-requests": "write"}<br>bisect-on-red: {"contents": "read", "issues": "write", "pull-requests": "write"}<br>meta: {"contents": "read"} | BERNSTEIN_AUTOSYNC_TOKEN, GEMINI_API_KEY, OPENROUTER_API_KEY_FREE |
 | .github/workflows/pr-labels.yml | workflow: {"contents": "read"}<br>label: {"contents": "read", "issues": "write", "pull-requests": "write"} | GITHUB_TOKEN |
 | .github/workflows/pr-observability-summary.yml | workflow: {"contents": "read"}<br>summary: {"checks": "read", "contents": "read", "pull-requests": "write", "security-events": "read"} | GITHUB_TOKEN |
 | .github/workflows/pr-policy.yml | workflow: {"contents": "read"}<br>pr-policy: {"actions": "read", "contents": "write", "pull-requests": "read"} | BERNSTEIN_AUTOSYNC_TOKEN |

--- a/docs/operations/ci.md
+++ b/docs/operations/ci.md
@@ -175,6 +175,27 @@ The CI gate aggregation is unchanged: `ci-gate` still rolls up
 `needs.*.result` for every job (all remaining matrix cells included)
 and still reports on `pull_request` and `merge_group`.
 
+### Python 3.14
+
+`nightly-deep-tests.yml` carries the only lane that executes tests on
+3.14 (`unit-python-314`, the unit suite in 4 shards). Everywhere else a
+3.14 pin appears it installs the package without running a test: the
+`install-smoke-uv` cell in `ci.yml`, plus the auto-heal, reconcile-release
+and adapter-contract-drift workflows.
+
+It is deliberately not on the PR matrix. The `test` matrix fans out over
+os x python x shard, so a python row costs 8 more jobs on every pull
+request. Measured on one head SHA, `ci.yml` already puts 39 jobs on a
+pull request and 47 on a push to main, out of 67 check-runs on the head,
+against the 20-concurrent-job ceiling below. Buying 3.14 coverage on the
+PR path would lengthen every PR's queue for an interpreter nothing ships
+on yet; nightly costs 4 jobs a day and surfaces a 3.14-only regression
+within 24 hours.
+
+`tests/unit/test_nightly_deep_tests_workflow_yaml.py` pins the lane, so
+dropping 3.14 coverage has to be a deliberate edit rather than an
+omission.
+
 ## Concurrency policy
 
 | Event | Group key | `cancel-in-progress` |
@@ -252,6 +273,42 @@ Everything else that triggers on `pull_request` is advisory:
 `dependency-review`, `docs-drift`, `license-compliance`, `pr-labels`,
 `pr-observability-summary`, `pr-policy`, `required-check-canary`,
 `spiffe-extra-e2e`, `trufflehog`, `typecheck-ts`, `zizmor`.
+
+### Pull requests opened by automation
+
+A pull request created with the Actions token (`secrets.GITHUB_TOKEN`, or
+the identical `github.token`) does not trigger workflows. Neither gating
+context above ever reports on it, so branch protection holds it at
+`BLOCKED` while the status rollup reads `SUCCESS`. Nothing is red and
+nothing is pending; the only way out is an operator closing it, and a
+closed pull request cannot be revived by force-pushing its branch, so the
+next fire opens a fresh one.
+
+Every workflow that opens a pull request therefore prefers a configured
+PAT and falls back to the Actions token:
+
+```yaml
+token: ${{ secrets.BERNSTEIN_AUTOSYNC_TOKEN || secrets.GITHUB_TOKEN }}
+```
+
+The same token is used for the branch push in those lanes, because a push
+made with the Actions token emits no `pull_request: synchronize` either,
+which would leave a re-pushed branch showing stale checks.
+
+**What degrades without the secret.** On a fork, or in any environment
+where `BERNSTEIN_AUTOSYNC_TOKEN` is unset, the expression falls through to
+the Actions token and the old behaviour returns: the pull request opens
+but collects no checks and cannot merge until an operator closes and
+reopens it, or pushes a commit under their own identity.
+`auto-heal.yml` is the exception - it detects the missing secret and
+dispatches `ci.yml` on the heal branch instead, so the head SHA still
+gets a `CI gate`; that dispatch is skipped when the secret is present, to
+avoid a duplicate full-matrix run.
+
+`tests/unit/test_bot_pull_request_tokens_yaml.py` discovers the
+pull-request-opening steps from the workflow directory rather than from a
+list, so a new automation lane cannot reintroduce the Actions token
+without failing the unit suite.
 
 ### What the pool actually spends
 

--- a/scripts/test_impact.py
+++ b/scripts/test_impact.py
@@ -13,18 +13,23 @@ ROOT = Path(__file__).parent.parent
 CACHE_PATH = ROOT / ".sdd" / "test_deps.json"
 SRC_ROOT = ROOT / "src"
 TEST_DIRS = [ROOT / "tests" / "unit", ROOT / "tests" / "integration"]
-CACHE_VERSION = "2"
 
 if str(ROOT / "src") not in sys.path:
     sys.path.insert(0, str(ROOT / "src"))
 
-from bernstein.core.test_impact import _path_to_module as _core_path_to_module  # noqa: E402
 from bernstein.core.test_impact import (  # noqa: E402
+    _COMPAT_CACHE_VERSION,
     build_compat_dep_map,
     compat_cache_is_fresh,
     compat_get_affected_tests,
     extract_project_imports,
 )
+from bernstein.core.test_impact import _path_to_module as _core_path_to_module  # noqa: E402
+
+# Re-exported so the CLI and the map builder cannot disagree about the version
+# stamped into .sdd/test_deps.json; two constants would let a stale cache pass
+# the freshness check after the map's shape changed.
+CACHE_VERSION = _COMPAT_CACHE_VERSION
 
 
 def _path_to_module(path: Path) -> str:

--- a/src/bernstein/core/quality/test_impact.py
+++ b/src/bernstein/core/quality/test_impact.py
@@ -19,9 +19,25 @@ from typing_extensions import TypedDict
 
 logger = logging.getLogger(__name__)
 
-_ANALYZER_CACHE_VERSION = "2"
-_COMPAT_CACHE_VERSION = "2"
+_ANALYZER_CACHE_VERSION = "3"
+_COMPAT_CACHE_VERSION = "3"
 _WORKFLOW_PATH_PREFIX = ".github/workflows/"
+
+# Suffix of the module-level dict literals that declare a legacy import alias.
+#
+# A package can keep an old dotted import path alive without a physical shim
+# file by registering a ``sys.meta_path`` finder backed by a
+# ``{short_name: real_dotted_module}`` table. The import then resolves, but the
+# name the importer wrote never appears on disk, so an import graph keyed on
+# literal dotted names has no edge from the real module to the file that
+# imports it under the old name. Discovering the tables by shape (any
+# module-level ``*REDIRECT_MAP`` dict literal in a package ``__init__``) keeps
+# the resolution honest when a package adds a third table.
+_ALIAS_TABLE_SUFFIX = "REDIRECT_MAP"
+
+# Bound on alias chain following. Chains are one hop today; the bound stops a
+# hand-written cycle in an alias table from hanging the index build.
+_ALIAS_CHAIN_LIMIT = 8
 
 # Inert repo-root files that never affect test outcomes. A change limited to
 # these paths does not force a full-suite fallback. Kept intentionally tiny:
@@ -130,6 +146,106 @@ def extract_project_imports(path: Path, package_prefixes: set[str]) -> set[str]:
     return imports
 
 
+def _string_dict_literal(node: ast.expr) -> dict[str, str]:
+    """Return the ``str -> str`` pairs of a dict literal, ignoring the rest."""
+    if not isinstance(node, ast.Dict):
+        return {}
+    pairs: dict[str, str] = {}
+    for key, value in zip(node.keys, node.values, strict=False):
+        if (
+            isinstance(key, ast.Constant)
+            and isinstance(key.value, str)
+            and isinstance(value, ast.Constant)
+            and isinstance(value.value, str)
+        ):
+            pairs[key.value] = value.value
+    return pairs
+
+
+def _alias_tables_in_module(path: Path) -> dict[str, str]:
+    """Return the merged alias tables declared at module level in ``path``."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError, UnicodeDecodeError):
+        return {}
+
+    tables: dict[str, str] = {}
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            targets: list[ast.expr] = list(node.targets)
+            value: ast.expr | None = node.value
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+            value = node.value
+        else:
+            continue
+        if value is None:
+            continue
+        for target in targets:
+            if isinstance(target, ast.Name) and target.id.endswith(_ALIAS_TABLE_SUFFIX):
+                tables.update(_string_dict_literal(value))
+    return tables
+
+
+def _real_module_names(src_root: Path) -> set[str]:
+    """Return the dotted names of every module that physically exists."""
+    if not src_root.exists():
+        return set()
+    names: set[str] = set()
+    for source_file in src_root.rglob("*.py"):
+        module = _path_to_module(source_file, src_root)
+        if module:
+            names.add(module)
+    return names
+
+
+def discover_module_aliases(src_root: Path) -> dict[str, str]:
+    """Return legacy dotted module names mapped to the module they resolve to.
+
+    The tables are read from the package ``__init__`` files that declare them
+    rather than imported, so discovery has no import side effects and works on
+    any source tree. An alias whose legacy name is also a real module on disk
+    is dropped: the redirect finders are appended to ``sys.meta_path``, so the
+    real module wins the import and no rewrite is warranted.
+    """
+    if not src_root.exists():
+        return {}
+
+    real_modules = _real_module_names(src_root)
+    aliases: dict[str, str] = {}
+    for init_file in sorted(src_root.rglob("__init__.py")):
+        package = _path_to_module(init_file, src_root)
+        if not package:
+            continue
+        for short, target in _alias_tables_in_module(init_file).items():
+            legacy = f"{package}.{short}"
+            if legacy == target or legacy in real_modules or target not in real_modules:
+                continue
+            aliases[legacy] = target
+    return aliases
+
+
+def resolve_module_aliases(modules: set[str], aliases: dict[str, str]) -> set[str]:
+    """Return ``modules`` widened with the real module each alias resolves to.
+
+    The legacy name is kept alongside the resolved one so an existing edge
+    keyed on the old name still matches; the resolved name is what creates the
+    missing edge from the real source file to the test that imports it.
+    """
+    if not aliases:
+        return modules
+
+    resolved = set(modules)
+    for module in modules:
+        target = aliases.get(module)
+        hops = 0
+        while target is not None and hops < _ALIAS_CHAIN_LIMIT and target not in resolved:
+            resolved.add(target)
+            target = aliases.get(target)
+            hops += 1
+    return resolved
+
+
 def build_compat_dep_map(
     root: Path,
     src_root: Path,
@@ -138,6 +254,10 @@ def build_compat_dep_map(
 ) -> dict[str, Any]:
     """Build the legacy dependency-map shape used by ``scripts/test_impact.py``."""
     prefixes = package_prefixes or _iter_project_packages(src_root)
+    # A test that imports a module under a legacy alias records the alias, not
+    # the file that actually backs it. Resolving the alias here is what puts
+    # the edge from the real source file into the map at all.
+    aliases = discover_module_aliases(src_root)
     test_deps: dict[str, dict[str, Any]] = {}
     for test_dir in test_dirs:
         if not test_dir.exists():
@@ -146,7 +266,7 @@ def build_compat_dep_map(
             rel = test_file.relative_to(root).as_posix()
             test_deps[rel] = {
                 "hash": _file_hash(test_file),
-                "imports": sorted(extract_project_imports(test_file, prefixes)),
+                "imports": sorted(resolve_module_aliases(extract_project_imports(test_file, prefixes), aliases)),
             }
 
     source_imports: dict[str, dict[str, Any]] = {}
@@ -157,7 +277,7 @@ def build_compat_dep_map(
                 continue
             source_imports[module] = {
                 "hash": _file_hash(src_file),
-                "imports": sorted(extract_project_imports(src_file, prefixes)),
+                "imports": sorted(resolve_module_aliases(extract_project_imports(src_file, prefixes), aliases)),
             }
 
     return {
@@ -397,6 +517,9 @@ class TestImpactAnalyzer:
         self._test_dirs = test_dirs or [project_root / "tests"]
         self._cache_path = cache_path or (project_root / ".sdd" / "cache" / "test_impact_index.json")
         self._package_prefixes = _iter_project_packages(self._src_root)
+        # Built lazily: only a fresh index needs it, and a warm cache must not
+        # pay for an AST scan of every package __init__.
+        self._aliases: dict[str, str] | None = None
         self._graph: dict[str, set[str]] = {}
         self._reverse: dict[str, set[str]] = {}
         self._source_imports: dict[str, set[str]] = {}
@@ -417,6 +540,7 @@ class TestImpactAnalyzer:
         reverse: dict[str, set[str]] = {}
         source_imports: dict[str, set[str]] = {}
         all_tests: set[str] = set()
+        self._aliases = discover_module_aliases(self._src_root)
 
         for test_file in self._discover_tests():
             rel = test_file.relative_to(self._root).as_posix()
@@ -612,13 +736,19 @@ class TestImpactAnalyzer:
             tests.extend(sorted(path for path in test_dir.rglob("test_*.py") if path.is_file()))
         return tests
 
+    def _resolved_imports(self, path: Path) -> set[str]:
+        """Parse project imports from ``path`` with legacy aliases resolved."""
+        if self._aliases is None:
+            self._aliases = discover_module_aliases(self._src_root)
+        return resolve_module_aliases(extract_project_imports(path, self._package_prefixes), self._aliases)
+
     def _parse_test_imports(self, test_file: Path) -> set[str]:
         """Parse source dependencies imported by a test file."""
-        return extract_project_imports(test_file, self._package_prefixes)
+        return self._resolved_imports(test_file)
 
     def _parse_source_imports(self, source_file: Path) -> set[str]:
         """Parse project imports used by a source file."""
-        return extract_project_imports(source_file, self._package_prefixes)
+        return self._resolved_imports(source_file)
 
     def _name_based_mapping(self, source_rel: str) -> list[str]:
         """Map a source file to likely test files by naming convention."""

--- a/tests/unit/test_bot_pull_request_tokens_yaml.py
+++ b/tests/unit/test_bot_pull_request_tokens_yaml.py
@@ -1,0 +1,272 @@
+"""Every workflow that opens a pull request must use a triggering token.
+
+A pull request created with the Actions token (``secrets.GITHUB_TOKEN`` or the
+equivalent ``github.token``) does not trigger workflows. Neither required
+context ever reports on it, so branch protection holds it at BLOCKED while the
+status rollup reads SUCCESS. Nothing is red, nothing is pending, and the only
+way out is an operator closing it by hand - and a closed pull request cannot be
+revived by force-pushing its branch, so the next fire opens a fresh one.
+
+The damage is not the churn. An automation lane whose pull requests can never
+merge is a regeneration that never lands: the artefact it exists to refresh
+goes stale while the lane keeps reporting that it ran. That is the same shape
+as a check that reports without checking.
+
+This module enumerates the pull-request-opening steps **by discovery** rather
+than from a list. A new automation lane that copies the old shape is caught by
+the same assertion that catches the current ones, without anyone remembering to
+extend a fixture.
+
+Two step shapes count as opening a pull request:
+
+* ``uses: peter-evans/create-pull-request@...`` - the token is ``with.token``;
+* a ``run:`` block invoking ``gh pr create`` - the token is ``GH_TOKEN`` (or
+  ``GITHUB_TOKEN``) resolved from the step, then the job, then the workflow.
+
+Comment lines are stripped from ``run:`` blocks before matching, so a workflow
+that only *describes* ``gh pr create`` in a comment - ``auto-release.yml``
+explains why it stopped calling it - is not mistaken for one that calls it.
+
+The last assertion here is the one that is easiest to get wrong. A reusable
+workflow (``on: workflow_call``) sees only the secrets its caller passed:
+``secrets.SOMETHING`` that was never declared and forwarded evaluates to the
+empty string rather than raising. A ``||`` fallback then swallows it and the
+lane silently degrades to the Actions token - the fix present in the file, and
+absent at runtime. So a declared preference is only real when the callee
+declares the secret and every caller forwards it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - dev env should have pyyaml
+    pytest.skip("pyyaml not installed", allow_module_level=True)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_WORKFLOW_DIR = _REPO_ROOT / ".github" / "workflows"
+
+_CREATE_PR_ACTION = "peter-evans/create-pull-request"
+_CREATE_PR_COMMAND = re.compile(r"\bgh\s+pr\s+create\b")
+
+# The Actions token under either spelling. Both are suppressed as a workflow
+# trigger; `github.token` is not a safe alternative to `secrets.GITHUB_TOKEN`.
+_ACTIONS_TOKEN = re.compile(r"secrets\.GITHUB_TOKEN|github\.token")
+
+# Token env vars `gh` reads, in the order it prefers them.
+_GH_TOKEN_KEYS = ("GH_TOKEN", "GITHUB_TOKEN")
+
+
+def _strip_comments(script: str) -> str:
+    """Drop whole-line shell comments so prose cannot look like a call."""
+    return "\n".join(line for line in script.splitlines() if not line.lstrip().startswith("#"))
+
+
+def _as_env(raw: object) -> dict[str, str]:
+    if not isinstance(raw, dict):
+        return {}
+    return {str(key): str(value) for key, value in raw.items()}  # type: ignore[union-attr]
+
+
+def _resolve_gh_token(step: dict[str, Any], job: dict[str, Any], workflow: dict[str, Any]) -> str | None:
+    """Return the token expression `gh` would use inside ``step``."""
+    for scope in (step, job, workflow):
+        env = _as_env(scope.get("env"))
+        for key in _GH_TOKEN_KEYS:
+            if key in env:
+                return env[key]
+    return None
+
+
+def _workflow_files() -> list[Path]:
+    return sorted(p for p in _WORKFLOW_DIR.glob("*.yml") if p.is_file())
+
+
+def _pr_opening_steps() -> list[tuple[str, str, str, str | None]]:
+    """Return ``(workflow, job, step, token_expression)`` for every PR opener."""
+    found: list[tuple[str, str, str, str | None]] = []
+    for path in _workflow_files():
+        workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if not isinstance(workflow, dict):
+            continue
+        jobs = workflow.get("jobs")
+        if not isinstance(jobs, dict):
+            continue
+        for job_name, job in jobs.items():
+            if not isinstance(job, dict):
+                continue
+            steps = job.get("steps")
+            if not isinstance(steps, list):
+                continue
+            for index, step in enumerate(steps):
+                if not isinstance(step, dict):
+                    continue
+                label = str(step.get("name") or step.get("id") or f"step[{index}]")
+                uses = str(step.get("uses", ""))
+                if _CREATE_PR_ACTION in uses:
+                    with_block = step.get("with")
+                    token = None
+                    if isinstance(with_block, dict):
+                        raw_token = with_block.get("token")
+                        token = None if raw_token is None else str(raw_token)
+                    found.append((path.name, str(job_name), label, token))
+                    continue
+                script = step.get("run")
+                if isinstance(script, str) and _CREATE_PR_COMMAND.search(_strip_comments(script)):
+                    found.append(
+                        (path.name, str(job_name), label, _resolve_gh_token(step, job, workflow)),
+                    )
+    return found
+
+
+def test_workflow_directory_is_readable() -> None:
+    assert _workflow_files(), "no workflow files discovered; the sweep would pass vacuously"
+
+
+def test_discovery_finds_the_known_pull_request_lanes() -> None:
+    """Guard the discovery itself: a broken matcher would pass everything."""
+    lanes = {workflow for workflow, _job, _step, _token in _pr_opening_steps()}
+    for expected in (
+        "adapter-conformance-canary.yml",
+        "auto-heal.yml",
+        "bernstein-ci-fix.yml",
+        "bernstein-issues-decompose.yml",
+        "ci-topology-heal.yml",
+        "coverage-ratchet-weekly.yml",
+        "coverage-ratchet.yml",
+        "docs-observability-snapshot.yml",
+        "nightly-drift-sweep.yml",
+        "review-bot-sweep.yml",
+    ):
+        assert expected in lanes, f"{expected} opens a pull request but discovery missed it"
+
+
+def test_comment_only_mentions_are_not_counted_as_openers() -> None:
+    """``auto-release.yml`` explains why it no longer calls ``gh pr create``."""
+    raw = (_WORKFLOW_DIR / "auto-release.yml").read_text(encoding="utf-8")
+    assert "gh pr create" in raw, "fixture drifted: auto-release.yml no longer mentions the command"
+    lanes = {workflow for workflow, _job, _step, _token in _pr_opening_steps()}
+    assert "auto-release.yml" not in lanes
+
+
+@pytest.mark.parametrize(
+    ("workflow", "job", "step", "token"),
+    _pr_opening_steps(),
+    ids=lambda value: str(value),
+)
+def test_pull_request_is_opened_with_a_triggering_token(
+    workflow: str,
+    job: str,
+    step: str,
+    token: str | None,
+) -> None:
+    assert token is not None, (
+        f"{workflow} job {job!r} step {step!r} opens a pull request without naming a token. "
+        "The default is the Actions token, which does not trigger workflows, so the pull "
+        "request can never collect its required contexts."
+    )
+
+    without_actions_token = _ACTIONS_TOKEN.sub("", token)
+    assert "secrets." in without_actions_token, (
+        f"{workflow} job {job!r} step {step!r} opens a pull request with the Actions token only. "
+        "A pull request created that way does not trigger workflows, so branch protection holds "
+        "it at BLOCKED forever while the rollup reads SUCCESS. Prefer a configured PAT with a "
+        "GITHUB_TOKEN fallback, e.g. "
+        "${{ secrets.BERNSTEIN_AUTOSYNC_TOKEN || secrets.GITHUB_TOKEN }}."
+    )
+
+    actions_token = _ACTIONS_TOKEN.search(token)
+    if actions_token is not None:
+        assert "secrets." in token[: actions_token.start()], (
+            f"{workflow} job {job!r} step {step!r} lists the Actions token before the triggering "
+            "token. The Actions token may only be the fallback, never the preferred value."
+        )
+
+
+def _secret_names(token: str) -> set[str]:
+    """Return the secret names a token expression reads."""
+    return set(re.findall(r"secrets\.([A-Za-z_][A-Za-z0-9_]*)", token)) - {"GITHUB_TOKEN"}
+
+
+def _declared_call_secrets(workflow: dict[str, Any]) -> set[str] | None:
+    """Return declared ``workflow_call`` secrets, or None if not reusable."""
+    triggers = workflow.get("on", workflow.get(True))
+    if not isinstance(triggers, dict) or "workflow_call" not in triggers:
+        return None
+    call = triggers.get("workflow_call")
+    declared = call.get("secrets") if isinstance(call, dict) else None
+    return set(declared) if isinstance(declared, dict) else set()
+
+
+def test_reusable_workflows_declare_the_secrets_their_pr_steps_read() -> None:
+    """An undeclared secret reads as empty, so the `||` fallback hides the bug."""
+    missing: list[str] = []
+    for path in _workflow_files():
+        workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if not isinstance(workflow, dict):
+            continue
+        declared = _declared_call_secrets(workflow)
+        if declared is None:
+            continue
+        for name, job, step, token in _pr_opening_steps():
+            if name != path.name or token is None:
+                continue
+            for secret in sorted(_secret_names(token) - declared):
+                missing.append(f"{path.name} job {job!r} step {step!r} reads secrets.{secret}")
+    assert not missing, (
+        "these reusable workflows read a secret they do not declare under "
+        "on.workflow_call.secrets, so it evaluates to empty at runtime and the "
+        f"pull request is opened with the Actions token after all: {missing}"
+    )
+
+
+def test_callers_forward_the_secrets_reusable_pr_lanes_declare() -> None:
+    """Declaring the secret is only half of it; the caller has to pass it."""
+    reusable: dict[str, set[str]] = {}
+    for path in _workflow_files():
+        workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if not isinstance(workflow, dict):
+            continue
+        declared = _declared_call_secrets(workflow)
+        if not declared:
+            continue
+        needed = {
+            secret
+            for name, _job, _step, token in _pr_opening_steps()
+            if name == path.name and token is not None
+            for secret in _secret_names(token)
+        }
+        if needed & declared:
+            reusable[path.name] = needed & declared
+
+    assert reusable, "no reusable pull-request lane found; this guard would pass vacuously"
+
+    missing: list[str] = []
+    for path in _workflow_files():
+        workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+        jobs = workflow.get("jobs") if isinstance(workflow, dict) else None
+        if not isinstance(jobs, dict):
+            continue
+        for job_name, job in jobs.items():
+            if not isinstance(job, dict):
+                continue
+            uses = str(job.get("uses", ""))
+            callee = uses.rsplit("/", 1)[-1].split("@", 1)[0]
+            if callee not in reusable:
+                continue
+            passed = job.get("secrets")
+            if passed == "inherit":
+                continue
+            forwarded = set(passed) if isinstance(passed, dict) else set()
+            for secret in sorted(reusable[callee] - forwarded):
+                missing.append(f"{path.name} job {job_name!r} calls {callee} without forwarding secrets.{secret}")
+    assert not missing, (
+        "these callers do not forward a secret the callee's pull-request step reads, "
+        f"so it evaluates to empty inside the reusable workflow: {missing}"
+    )

--- a/tests/unit/test_nightly_deep_tests_workflow_yaml.py
+++ b/tests/unit/test_nightly_deep_tests_workflow_yaml.py
@@ -75,6 +75,36 @@ def test_workflow_does_not_gate_pull_requests() -> None:
     )
 
 
+def test_python_314_unit_lane_exists_here() -> None:
+    """3.14 has exactly one lane that executes tests, and it is this one.
+
+    ``ci.yml`` runs the unit matrix on 3.13 for pull requests and 3.12 + 3.13
+    for pushes; ``ci-macos-nightly.yml`` is 3.13. Every other 3.14 pin in the
+    repository installs the package without running a test. A regression that
+    only reproduces on 3.14 is therefore invisible unless this job exists, and
+    deleting it must be a deliberate act rather than a silent one.
+    """
+    job = _jobs().get("unit-python-314")
+    assert job is not None, "the only unit lane on Python 3.14 was removed"
+
+    steps = job.get("steps")
+    assert isinstance(steps, list)
+    scripts = [
+        # Comments are stripped: prose about `--affected` is not a use of it.
+        "\n".join(line for line in cast("str", step["run"]).splitlines() if not line.lstrip().startswith("#"))
+        for step in cast("list[dict[str, object]]", steps)
+        if isinstance(step.get("run"), str)
+    ]
+    body = "\n".join(scripts)
+
+    assert "3.14" in yaml.safe_dump(job)
+    assert "scripts/run_tests.py" in body, "the lane must execute the unit suite, not just install on 3.14"
+    assert "--affected" not in body, (
+        "this lane exists to see what the diff-narrowed pull_request lane cannot; "
+        "narrowing it to a diff reintroduces the blind spot"
+    )
+
+
 def test_jobs_run_independently() -> None:
     """No ``needs`` edges, so one red job cannot skip the rest.
 

--- a/tests/unit/test_test_impact.py
+++ b/tests/unit/test_test_impact.py
@@ -15,6 +15,7 @@ if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 
 from test_impact import (
+    CACHE_VERSION,
     _cache_is_fresh,
     _extract_bernstein_imports,
     build_dep_map,
@@ -145,7 +146,10 @@ class TestBuildDepMap:
             ti.SRC_ROOT = orig_src
             ti.ROOT = orig_root
 
-        assert dep_map["version"] == "2"
+        # Pin the constant, not a literal: the version exists to invalidate
+        # caches when the map's shape changes, so a bump is expected and must
+        # not be a test edit.
+        assert dep_map["version"] == CACHE_VERSION
         assert any("test_models.py" in k for k in dep_map["test_deps"])
 
     def test_nested_tests_are_discovered(self, tmp_path: Path) -> None:

--- a/tests/unit/test_test_impact_alias_edges.py
+++ b/tests/unit/test_test_impact_alias_edges.py
@@ -1,0 +1,162 @@
+"""The impact selector must not lose the edge a legacy import alias hides.
+
+A package can keep an old dotted import path alive without shipping a physical
+shim: it registers a ``sys.meta_path`` finder backed by a
+``{short_name: real_dotted_module}`` table, and ``import pkg.old_name`` then
+resolves to ``pkg.subpkg.old_name``. Nothing on disk is ever named
+``pkg.old_name``.
+
+An import graph keyed on the literal dotted name a file wrote therefore has no
+edge from the real source module to a test that imports it under the old name.
+The blocking pull_request Test shards run only what that graph selects, so a
+change confined to the real module passes the required lane without the suite
+written for it ever executing. The push-to-main lane uses full discovery and
+does run it, which makes the gap PR-only: the signal is missing exactly where
+it is meant to gate.
+
+These tests pin both halves:
+
+* the alias table is discovered from the source tree by shape, not from a
+  hardcoded list of package names, so a package that adds a third table is
+  picked up without editing the analyser;
+* an alias whose legacy name is also a real module on disk is left alone,
+  because the redirect finders are appended to ``sys.meta_path`` and the real
+  module wins the import.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Aliased on import: pytest would otherwise try to collect the class as a test
+# suite and warn about its constructor.
+from bernstein.core.quality.test_impact import TestImpactAnalyzer as ImpactAnalyzer
+from bernstein.core.quality.test_impact import (
+    build_compat_dep_map,
+    compat_get_affected_tests,
+    discover_module_aliases,
+    resolve_module_aliases,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _alias_fixture(tmp_path: Path) -> tuple[Path, Path, str, str]:
+    """Build a source tree whose package __init__ declares a redirect table."""
+    src = tmp_path / "src"
+    tests = tmp_path / "tests" / "unit"
+
+    _write(src / "proj" / "__init__.py", "")
+    _write(
+        src / "proj" / "core" / "__init__.py",
+        '_REDIRECT_MAP: dict[str, str] = {\n    "widget": "proj.core.machinery.widget",\n}\n',
+    )
+    _write(src / "proj" / "core" / "machinery" / "__init__.py", "")
+    _write(src / "proj" / "core" / "machinery" / "widget.py", "VALUE = 1\n")
+    # Imports the module under the name that only the redirect table resolves.
+    _write(tests / "test_widget_lifecycle.py", "from proj.core.widget import VALUE\n")
+    # Imports the real path, so it is selected with or without alias handling.
+    _write(tests / "test_widget_direct.py", "from proj.core.machinery.widget import VALUE\n")
+
+    return src, tests, "src/proj/core/machinery/widget.py", "tests/unit/test_widget_lifecycle.py"
+
+
+def test_alias_table_is_discovered_from_the_source_tree(tmp_path: Path) -> None:
+    src, _tests, _changed, _lifecycle = _alias_fixture(tmp_path)
+    assert discover_module_aliases(src) == {"proj.core.widget": "proj.core.machinery.widget"}
+
+
+def test_alias_shadowed_by_a_real_module_is_not_rewritten(tmp_path: Path) -> None:
+    """The redirect finders are appended to sys.meta_path, so disk wins."""
+    src = tmp_path / "src"
+    _write(src / "proj" / "__init__.py", "")
+    _write(
+        src / "proj" / "core" / "__init__.py",
+        '_REDIRECT_MAP = {"widget": "proj.core.machinery.widget"}\n',
+    )
+    _write(src / "proj" / "core" / "widget.py", "VALUE = 1\n")
+    _write(src / "proj" / "core" / "machinery" / "__init__.py", "")
+    _write(src / "proj" / "core" / "machinery" / "widget.py", "VALUE = 2\n")
+
+    assert discover_module_aliases(src) == {}
+
+
+def test_alias_target_that_does_not_exist_is_dropped(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    _write(src / "proj" / "__init__.py", "")
+    _write(src / "proj" / "core" / "__init__.py", '_REDIRECT_MAP = {"gone": "proj.core.deleted.gone"}\n')
+
+    assert discover_module_aliases(src) == {}
+
+
+def test_resolution_keeps_the_legacy_name_alongside_the_real_one() -> None:
+    aliases = {"proj.core.widget": "proj.core.machinery.widget"}
+    assert resolve_module_aliases({"proj.core.widget"}, aliases) == {
+        "proj.core.widget",
+        "proj.core.machinery.widget",
+    }
+
+
+def test_resolution_terminates_on_a_cyclic_alias_table() -> None:
+    aliases = {"a.x": "a.y", "a.y": "a.x"}
+    assert resolve_module_aliases({"a.x"}, aliases) == {"a.x", "a.y"}
+
+
+def test_compat_selector_picks_the_alias_importing_test(tmp_path: Path) -> None:
+    src, tests, changed, lifecycle = _alias_fixture(tmp_path)
+    dep_map = build_compat_dep_map(tmp_path, src, [tests], {"proj"})
+
+    selected = {
+        p.relative_to(tmp_path).as_posix()
+        for p in compat_get_affected_tests([changed], dep_map, root=tmp_path, src_root=src)
+    }
+
+    assert lifecycle in selected, (
+        "a change confined to the real module must select the suite that imports it under the legacy alias"
+    )
+    assert "tests/unit/test_widget_direct.py" in selected
+
+
+def test_analyzer_picks_the_alias_importing_test(tmp_path: Path) -> None:
+    src, tests, changed, lifecycle = _alias_fixture(tmp_path)
+    analyzer = ImpactAnalyzer(
+        tmp_path,
+        cache_path=tmp_path / "cache.json",
+        src_root=src,
+        test_dirs=[tests],
+    )
+
+    analysis = analyzer.analyze([changed])
+
+    assert not analysis.fallback_used
+    assert lifecycle in analysis.affected_tests
+
+
+def test_repo_worktree_change_selects_its_lifecycle_suite() -> None:
+    """Regression pin on the reported case, against the real source tree.
+
+    ``tests/unit/test_worktree_lifecycle.py`` imports ``bernstein.core.worktree``,
+    which exists only in the redirect table; the file on disk is
+    ``src/bernstein/core/git/worktree.py``.
+    """
+    src = _REPO_ROOT / "src"
+    changed = "src/bernstein/core/git/worktree.py"
+    lifecycle = "tests/unit/test_worktree_lifecycle.py"
+    assert (_REPO_ROOT / changed).is_file()
+    assert (_REPO_ROOT / lifecycle).is_file()
+
+    aliases = discover_module_aliases(src)
+    assert aliases.get("bernstein.core.worktree") == "bernstein.core.git.worktree"
+
+    dep_map = build_compat_dep_map(_REPO_ROOT, src, [_REPO_ROOT / "tests" / "unit"], {"bernstein"})
+    selected = {
+        p.relative_to(_REPO_ROOT).as_posix()
+        for p in compat_get_affected_tests([changed], dep_map, root=_REPO_ROOT, src_root=src)
+    }
+
+    assert lifecycle in selected


### PR DESCRIPTION
## Summary

Three CI issues in the v3.11.0 milestone. Two carried a diagnosis that the
run metadata does not support, so the correction is stated first in each
case and the change follows from what the metadata actually shows.

Closes #3093
Closes #3108
Closes #3096

## #3093 coverage ratchet

**What the history shows.** The branch has been a constant
(`coverage-ratchet/baseline`) since #2336, and the action does update the
open PR in place: #2963 carries eight `HeadRefForcePushed` events from
`github-actions` across four hours and stayed one PR the whole time. So
the workflow is not opening a PR per fire.

**What actually produces the duplicate pairs.** Every second PR in each
pair was created only after a human closed the first: #2853 closed then
#2855 opened, #2963 closed then #2978 opened, #3054 closed then #3090,
#3090 closed then #3098. The closures are the loop, and the reason for
them is that the PR cannot merge. A pull request created with
`GITHUB_TOKEN` does not trigger workflows, so `CI gate` and
`review-bot-ack` never report, branch protection holds it at BLOCKED while
the rollup reads SUCCESS, and an operator closes it to clear the list. A
closed PR cannot be reopened by force-pushing its branch, so the next fire
has to open a new one.

#3158 is that state right now: `MERGEABLE` / `BLOCKED`, `rollup=SUCCESS`,
neither required context ever reported.

**Changes.**

- The PR is created with `BERNSTEIN_AUTOSYNC_TOKEN`, falling back to
  `GITHUB_TOKEN` where the secret is absent, so it collects its checks and
  merges on its own.
- A guard step closes a second defect. `scripts/coverage_ratchet.py`
  compares the measurement against the baseline committed on `main`, not
  against the one the open ratchet PR carries, and those diverge as soon
  as a ratchet PR exists. A measurement between the two still counted as a
  bump against `main`, so force-pushing it rewrote the open PR with a
  *lower* high-water mark. The guard reads the baseline on the ratchet
  branch and skips the update unless the new measurement is strictly
  greater.
- The `.coverage-baseline.json` bump to 82.31% that #3158 carries is
  folded into this branch, so it lands under an identity that triggers CI.
  #3158 is closed as superseded.

**On the acceptance criteria.** The AC asks for `cancel-in-progress` on
the concurrency group. Kept at `false` deliberately: the group is already
a constant so two fires serialise, and cancelling between the force-push
and the `create-pull-request` call would leave a pushed branch with no
pull request. Serialising is the safer half of that trade and costs
nothing, since the job is minutes-bounded.

**Workflow enablement.** `Coverage ratchet (total)` is already `active`
in `gh workflow list`, along with `PR labels` and `PR policy`. No
re-enable step is outstanding.

**Guard evidence.** The guard's shell was extracted from the workflow and
executed against a stubbed `gh` for all four cases:

| Open PR baseline | Measured | `proceed` |
|---|---|---|
| no branch | 82.31 | `true` |
| 82.31 | 82.20 | `false` |
| 82.31 | 82.31 | `false` |
| 82.31 | 82.44 | `true` |

**Structural test.** `tests/unit/test_coverage_ratchet_workflow_yaml.py`
pins the constant branch name, the token preference and its ordering, the
existence of the guard and that the PR step is gated on it, and the
non-cancelling concurrency group.

## #3108 post-CI dispatcher

**The premise is a measurement artefact.** A `workflow_run`-triggered run
is stamped with the default-branch tip SHA, not the SHA of the run that
triggered it. So a burst of upstream completions displays as one SHA
repeated, which is what "seven runs on `65a5a1b5`" is.

Checked against the upstream runs, the dispatcher fires exactly once per
CI run:

| Dispatcher runs | Window | CI runs completing in that window |
|---|---|---|
| 12 on `59cf11af` | 20:53:44 to 20:55:05 | 12, distinct SHAs |
| 7 on `41e1c627` | 16:58:07 to 16:58:29 | 7, distinct SHAs |
| 7 on `65a5a1b5` | 16:26:31 to 16:26:36 | 7, distinct SHAs |

Every run is `run_attempt: 1`, `event: workflow_run`. There is no
multiplication and no re-run involved, so no deduplication is added.

**The real defect.** The `meta` job boots a runner for every completed CI
run, including cancelled ones, and cancelled is the dominant conclusion
during a merge wave: `ci.yml` keys push-to-main runs per SHA and never
cancels them, so the tail gets mass-cancelled to reclaim capacity and each
cancellation pays a dispatcher runner slot to reach a routing decision
that is always "nothing". `meta` now skips `cancelled` and `skipped`.

**Why that cannot suppress a release.** Every job in `auto-release.yml`
requires `inputs.conclusion == 'success'`, directly or through its `needs`
(`release` needs `gate`, `gate` carries the guard). Its stale-trigger
alert takes only `failure`, `timed_out` and `action_required`, and its own
comment records `cancelled` as deliberately excluded. `auto-heal`,
`bernstein-ci-fix` and `bisect-on-red` each require exactly `failure`.
`success` is admitted unconditionally by the new condition, so the release
path is untouched.

Verified three ways: by reading each child's gate, by
`test_auto_release_jobs_still_gate_on_success` walking the `needs` graph
in `auto-release.yml`, and by
`test_filter_does_not_intersect_the_auto_release_alert_set`, which reads
the alert conclusion list out of `auto-release.yml` rather than copying
it, so widening one file fails the test in the other.

**Idempotency of each child under a double invocation**, as the AC asks:

| Child | Idempotent | Basis |
|---|---|---|
| `auto-release` | yes | The tag push is the natural idempotency key, and the stale-alert path has two dedup layers (same title, then a 24h cross-SHA window). |
| `auto-heal` | yes | Keyed on a heal branch per SHA; a second invocation force-pushes the same branch and updates the same PR. |
| `bernstein-ci-fix` | yes | Gated on `auto-heal` not having opened a heal PR, which serialises the two fixers on a failing SHA. |
| `bisect-on-red` | yes | Comments and issue creation are per culprit SHA. |

No separate issue is needed.

**Documentation.** The file now carries a DO NOT PRUNE header naming
itself as the sole invocation path for all four `workflow_call`-only
children, since that coupling is invisible from `auto-release.yml`.

## #3096 advisory workflows

**Counting runs inverts the picture.** The free-tier ceiling is 20
concurrent *jobs*, so the budget is jobs. Measured on one head SHA of
#3157, 18 workflow runs resolve to 47 runner jobs:

| Role | Runs | Runner jobs | Share of pool |
|---|---|---|---|
| `ci.yml` | 1 | 34 | 72% |
| `review-bot-ack` | 4 | 4 | 9% |
| All advisory work | 13 | 9 | 19% |

An advisory workflow is one job; `ci.yml` is 34. Applying the AC's first
option and moving every advisory lane off the PR path would return under a
fifth of the pool while deleting all pre-merge signal that is not the test
matrix, so none of the three options is taken. The load that saturates the
pool is concurrent `ci.yml` runs, and the durable fix for that is the
merge queue, which `ci.yml` already triggers on.

The advisory lanes are also already cheap rather than merely present:
`pr-observability-summary` runs only on PRs labelled `deep-review`,
`dependabot-auto-merge` gates its only job on the Dependabot user id (0
runner jobs on a non-Dependabot PR), `pr-policy` and `pr-labels` are
consolidated single-job lanes, and the vulture / refurb / perflint jobs
run weekly.

**Fan-out, before and after.** Unchanged: 14 runs per branch push on a
docs PR (#3165), 18 on a workflow-touching PR (#3157). The number this
issue is really about is the job count, and the advisory share of it is
9 of 47.

**Concurrency AC.** All 22 `pull_request` workflows already declare a
concurrency group keyed on the PR or its ref, and all but one cancel a
superseded pull-request run. The single exception is `review-bot-ack.yml`,
which publishes a required context: branch protection folds every
check-run of a required name into its verdict, so one `cancelled` instance
holds the PR at BLOCKED even after a later run succeeds (#3154, #3042).
`ci.yml` and `codeql.yml` express cancellation as
`${{ github.event_name == 'pull_request' }}`, cancelling the PR lane and
keeping the per-SHA push-to-`main` lane alive so a release commit's CI is
never cancelled by the next merge.

`tests/unit/test_pull_request_workflow_concurrency_yaml.py` pins the rule
and the closed exception list, so a new `pull_request` workflow cannot
land without a group and an exception cannot be added silently.

**`docs/operations/ci.md`** gains a "Gating vs advisory workflows" section
naming the three gating workflows, listing the advisory ones, carrying the
job-share measurement, and documenting the no-cancel exception.

**`PR labels` and `PR policy`** are already `active` in
`gh workflow list`. No re-enable step is outstanding.

## Verification

- `uv run ruff check src/ tests/ scripts/ --fix`: clean.
- `uv run ruff format`: applied.
- `uv run pytest tests/unit/ -k "workflow or topology"`: 616 passed.
- `uvx zizmor` on both changed workflows: no findings.
- `uv run python scripts/check_docs_drift.py`: no drift.
- `docs/operations/ci-topology.md` regenerated with
  `scripts/gen_workflow_topology.py`.
- `ci.yml` reads only `diff_coverage_floor_percent` from
  `.coverage-baseline.json`, which is unchanged at 85, so the total bump
  does not move any PR gate.
