### PR TITLE
fix(bridge): make the replay-nonce and status-proof decisions exclusive

### DIFF
--- a/docs/integrations/automation-bridge.md
+++ b/docs/integrations/automation-bridge.md
@@ -82,6 +82,12 @@ captured replay apart from a legitimate re-fire of the same goal, so it does not
 refuse on that basis. The receipt records `"replay_protected": false` so the
 copy you store never implies a guarantee it does not carry. **Send the header.**
 
+The refusal holds when the two deliveries arrive at once. The ledger check and
+the ledger entry recording it are one section per trigger id, held against every
+other thread and every other worker process, so a trigger delivered twice in
+parallel is admitted exactly once and fires its task graph once. The second
+delivery gets the 409 and its own anchored refusal receipt, not a second run.
+
 ### Refusals
 
 A trigger that fails authentication (HTTP 401) or replays an admitted id (HTTP
@@ -172,7 +178,9 @@ parsing the body unchanged.
 
 Retries are byte-identical: the proof is minted once per `event_id` and cached,
 so a callback re-sent after a transient delivery failure repeats the same bytes
-rather than making a second, differently-anchored claim.
+rather than making a second, differently-anchored claim. Two callbacks in flight
+for one `event_id` get the same treatment: they share one `status.proof.emitted`
+chain event and are handed the same proof, which is also the proof left on disk.
 
 Set `status_proof: false` to opt out. If the install cannot reach its audit
 chain the sink logs a warning and delivers the plain payload rather than
@@ -220,8 +228,8 @@ That is the answer to "the workflow says the run passed but it did not".
 | Path | Contents |
 | --- | --- |
 | `.sdd/audit/` | The HMAC audit chain every receipt anchors into |
-| `.sdd/automation-bridge/triggers/` | The replay ledger, one file per admitted trigger id |
-| `.sdd/automation-bridge/status/` | Minted status proofs, cached so retries repeat |
+| `.sdd/automation-bridge/triggers/` | The replay ledger, one file per admitted trigger id, plus a `.lock` file per id the bridge adjudicated |
+| `.sdd/automation-bridge/status/` | Minted status proofs, cached so retries repeat, plus a `.lock` file per event id |
 | `.sdd/automation-bridge/automation-bridge-identity-key.pem` | The install's Ed25519 signing key, mode `0600` |
 
 Set `BERNSTEIN_AUTOMATION_BRIDGE_ROOT` to relocate the bridge state directory.

--- a/src/bernstein/core/trigger_sources/receipt.py
+++ b/src/bernstein/core/trigger_sources/receipt.py
@@ -40,17 +40,27 @@ checkable copy of what Bernstein actually did.
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import logging
 import os
+import sys
+import threading
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from bernstein.core.sanitize import sanitize_log
 
+if sys.platform == "win32":
+    fcntl = None  # type: ignore[assignment]
+else:
+    import fcntl  # type: ignore[no-redef]
+
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from bernstein.core.security.audit_chain import AuditChainStore
 
 logger = logging.getLogger(__name__)
@@ -178,6 +188,100 @@ def _safe_name(value: str) -> str:
     if not value:
         raise ValueError("empty identifier")
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Per-identity decision exclusivity
+# ---------------------------------------------------------------------------
+
+#: Per-lock-file re-entrancy state for :func:`_decision_lock`.
+#:
+#: Mirrors the audit chain's append guard for the same reasons. ``flock``
+#: attaches to an *open file description*, so a second ``os.open`` +
+#: ``flock(LOCK_EX)`` from the thread that already holds the lock blocks on
+#: itself; the per-thread depth counter lets the outermost acquisition own the
+#: ``flock`` while inner ones pass through, and the per-file ``RLock`` keeps a
+#: different thread out for the whole nested section so re-entrancy never
+#: widens the window it exists to close.
+#:
+#: Guards are keyed by the lock file's ``(st_dev, st_ino)`` and never evicted.
+#: The identity is load-bearing: two spellings of one path must map to one
+#: guard, or a thread that entered under one and re-entered under the other
+#: sees depth 0 and re-takes a ``flock`` it already holds. The live set is one
+#: entry per identity this process actually adjudicates.
+_DECISION_GUARDS: dict[str, threading.RLock] = {}
+_DECISION_GUARDS_LOCK = threading.Lock()
+_DECISION_DEPTH = threading.local()
+
+
+def _decision_guard(lock_key: str) -> threading.RLock:
+    """Return the process-wide re-entrant guard for one lock file."""
+    with _DECISION_GUARDS_LOCK:
+        guard = _DECISION_GUARDS.get(lock_key)
+        if guard is None:
+            guard = threading.RLock()
+            _DECISION_GUARDS[lock_key] = guard
+        return guard
+
+
+@contextlib.contextmanager
+def _decision_lock(lock_path: Path) -> Iterator[None]:
+    """Hold one inbound identity exclusively across read-decide-record.
+
+    Both bridge paths decide from state they read (the replay ledger, the proof
+    cache) and record that decision afterwards. The audit chain's own section
+    serialises the appends in between, but its domain is the audit dir and its
+    subject is the chain head; it says nothing about whether two callers reached
+    the same decision from the same read. This lock's domain is the bridge root
+    and its subject is one ``trigger_id`` or one ``event_id``, so the read, the
+    decision, and the record of it are one section against every other thread
+    and every other process.
+
+    Scoped per identity rather than per root on purpose: two workers
+    adjudicating *different* triggers never contend, which is the same property
+    the one-file-per-id ledger layout was chosen for. One lock file accompanies
+    each ledger or cache entry, so the directory's file count keeps the order it
+    already had.
+
+    Blocking ``flock(LOCK_EX)``, matching the chain's append lock: a waiter
+    waits rather than polling, so a contended decision is delayed and never
+    dropped. Falls back to a no-op on platforms without ``fcntl`` (Windows),
+    where the in-process guard remains the only ordering, exactly as the chain
+    append lock degrades.
+
+    Args:
+        lock_path: The lock file standing for the identity being adjudicated.
+    """
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(lock_path), os.O_WRONLY | os.O_CREAT, 0o600)
+    try:
+        stat_result = os.fstat(fd)
+        lock_key = f"{stat_result.st_dev}:{stat_result.st_ino}"
+        depths: dict[str, int] | None = getattr(_DECISION_DEPTH, "depths", None)
+        if depths is None:
+            depths = {}
+            _DECISION_DEPTH.depths = depths
+        if depths.get(lock_key, 0):
+            # Already inside this thread's section: the outermost frame holds
+            # the flock, so re-taking it would block on ourselves.
+            yield
+            return
+        with _decision_guard(lock_key):
+            depths[lock_key] = 1
+            try:
+                if fcntl is None:  # pragma: no cover - Windows path
+                    yield
+                    return
+                fcntl.flock(fd, fcntl.LOCK_EX)
+                try:
+                    yield
+                finally:
+                    with contextlib.suppress(OSError):
+                        fcntl.flock(fd, fcntl.LOCK_UN)
+            finally:
+                del depths[lock_key]
+    finally:
+        os.close(fd)
 
 
 # ---------------------------------------------------------------------------
@@ -468,8 +572,24 @@ class TriggerNonceLedger:
         """Return the ledger path recording ``trigger_id``."""
         return self._dir / f"{_safe_name(trigger_id)}.json"
 
+    def decision_lock(self, trigger_id: str) -> contextlib.AbstractContextManager[None]:
+        """Return the section that makes one id's admission decision exclusive.
+
+        :meth:`seen` and :meth:`remember` are a check and an act. Held apart,
+        two deliveries of one id both read "not admitted" and both take the
+        admitted branch, so the nonce stops being a nonce while the receipt
+        still claims ``replay_protected=True``. Callers hold this across both
+        halves; the lock's domain is the bridge root, which is a different
+        domain from the audit chain's.
+        """
+        return _decision_lock(self._dir / f"{_safe_name(trigger_id)}.lock")
+
     def seen(self, trigger_id: str) -> bool:
-        """Return whether ``trigger_id`` was already admitted."""
+        """Return whether ``trigger_id`` was already admitted.
+
+        Only meaningful as a decision inside :meth:`decision_lock`; outside it
+        the answer can be stale before the caller acts on it.
+        """
         return self.path_for(trigger_id).is_file()
 
     def remember(self, trigger_id: str, receipt: TriggerReceipt) -> None:
@@ -634,100 +754,115 @@ def admit_trigger(
     ledger = TriggerNonceLedger(root)
     payload_digest = compute_payload_digest(body)
 
-    reason = ""
-    if not authenticated:
-        reason = refusal_reason or REFUSAL_UNAUTHENTICATED
-    elif enforce_replay and ledger.seen(trigger_id):
-        reason = REFUSAL_REPLAYED_TRIGGER
+    # The replay decision and the ledger entry recording it are one section, so
+    # a doubly-delivered trigger id cannot be read as unseen twice. Only the
+    # regime that actually consults the ledger takes the section: an
+    # unauthenticated trigger is refused before the ledger is reached, and an
+    # unenforced replay regime never reads or writes it, so neither waits behind
+    # a decision it does not make.
+    adjudicating_nonce = enforce_replay and authenticated
+    nonce_section = ledger.decision_lock(trigger_id) if adjudicating_nonce else contextlib.nullcontext()
 
-    # Only the unauthenticated path is budgeted. Producing a replay refusal
-    # requires a valid signature, so that path is already gated by the secret.
-    suppressed = 0
-    if reason and not authenticated and budget is not None:
-        anchor, suppressed = budget.take(timestamp)
-        if not anchor:
-            logger.warning(
-                "automation bridge: refusal budget exhausted; refusing %s without anchoring a receipt",
-                sanitize_log(request_path),
+    with nonce_section:
+        reason = ""
+        if not authenticated:
+            reason = refusal_reason or REFUSAL_UNAUTHENTICATED
+        elif enforce_replay and ledger.seen(trigger_id):
+            reason = REFUSAL_REPLAYED_TRIGGER
+
+        # Only the unauthenticated path is budgeted. Producing a replay refusal
+        # requires a valid signature, so that path is already gated by the secret.
+        suppressed = 0
+        if reason and not authenticated and budget is not None:
+            anchor, suppressed = budget.take(timestamp)
+            if not anchor:
+                logger.warning(
+                    "automation bridge: refusal budget exhausted; refusing %s without anchoring a receipt",
+                    sanitize_log(request_path),
+                )
+                return TriggerAdmission(receipt=None, admitted=False, graph=None)
+
+        graph: TaskGraphProjection | None = None
+        graph_digest = ""
+        if not reason:
+            graph = project_task_graph(platform=platform, intent=intent if intent is not None else _decode_intent(body))
+            graph_digest = graph.graph_digest
+
+        outcome = TRIGGER_OUTCOME_REFUSED if reason else TRIGGER_OUTCOME_ADMITTED
+        chain = _chain_store(audit_dir, hmac_key)
+
+        # Loading the bridge identity may create and persist a keypair; it does
+        # not depend on the chain head, so it stays outside the chain section
+        # below rather than holding the chain against every other writer while
+        # it runs. It stays inside the nonce section, which is scoped to this
+        # trigger id alone and so blocks nobody else's admission.
+        private_pem, public_pem = load_or_create_bridge_identity(root)
+        from bernstein.core.security.audit_chain import record_trigger_receipt
+        from bernstein.core.skills.catalog.signature import sign_payload
+
+        # Reading the head, signing it, and appending the record that sits on it
+        # are one atomic section. Split apart, a writer appending during the
+        # signature leaves the receipt naming a chain position its own record
+        # does not occupy, and the head is opaque payload to the signature so
+        # nothing downstream can tell. The head is read from disk here, not from
+        # the store's cache, so another process's appends are seen too.
+        with chain.chain_transaction():
+            unsigned = TriggerReceipt(
+                trigger_id=trigger_id,
+                platform=platform,
+                request_path=request_path,
+                payload_digest=payload_digest,
+                graph_digest=graph_digest,
+                scope="" if reason else scope,
+                outcome=outcome,
+                refusal_reason=reason,
+                # The head this trigger was adjudicated at, and part of the
+                # signed binding: the record appended below chains onto it.
+                admission_chain_head=chain.resync_head(),
+                replay_protected=enforce_replay,
+                timestamp=timestamp,
+                task_ids=() if reason else task_ids,
             )
-            return TriggerAdmission(receipt=None, admitted=False, graph=None)
 
-    graph: TaskGraphProjection | None = None
-    graph_digest = ""
-    if not reason:
-        graph = project_task_graph(platform=platform, intent=intent if intent is not None else _decode_intent(body))
-        graph_digest = graph.graph_digest
+            signature = sign_payload(unsigned.to_canonical_bytes(), private_pem)
 
-    outcome = TRIGGER_OUTCOME_REFUSED if reason else TRIGGER_OUTCOME_ADMITTED
-    chain = _chain_store(audit_dir, hmac_key)
+            event = record_trigger_receipt(
+                chain=chain,
+                trigger_id=trigger_id,
+                platform=platform,
+                request_path=request_path,
+                payload_digest=payload_digest,
+                graph_digest=graph_digest,
+                scope=unsigned.scope,
+                outcome=outcome,
+                receipt_digest=unsigned.binding_digest(),
+                refusal_reason=reason,
+                suppressed_refusals=suppressed,
+            )
 
-    # Loading the bridge identity may create and persist a keypair; it does not
-    # depend on the chain head, so it stays outside the section below rather
-    # than holding the chain against every other writer while it runs.
-    private_pem, public_pem = load_or_create_bridge_identity(root)
-    from bernstein.core.security.audit_chain import record_trigger_receipt
-    from bernstein.core.skills.catalog.signature import sign_payload
-
-    # Reading the head, signing it, and appending the record that sits on it are
-    # one atomic section. Split apart, a writer appending during the signature
-    # leaves the receipt naming a chain position its own record does not occupy,
-    # and the head is opaque payload to the signature so nothing downstream can
-    # tell. The head is read from disk here, not from the store's cache, so
-    # another process's appends are seen too.
-    with chain.chain_transaction():
-        unsigned = TriggerReceipt(
-            trigger_id=trigger_id,
-            platform=platform,
-            request_path=request_path,
-            payload_digest=payload_digest,
-            graph_digest=graph_digest,
-            scope="" if reason else scope,
-            outcome=outcome,
-            refusal_reason=reason,
-            # The head this trigger was adjudicated at, and part of the signed
-            # binding: the record appended below chains onto exactly it.
-            admission_chain_head=chain.resync_head(),
-            replay_protected=enforce_replay,
-            timestamp=timestamp,
-            task_ids=() if reason else task_ids,
-        )
-
-        signature = sign_payload(unsigned.to_canonical_bytes(), private_pem)
-
-        event = record_trigger_receipt(
-            chain=chain,
-            trigger_id=trigger_id,
-            platform=platform,
-            request_path=request_path,
-            payload_digest=payload_digest,
-            graph_digest=graph_digest,
+        receipt = TriggerReceipt(
+            trigger_id=unsigned.trigger_id,
+            platform=unsigned.platform,
+            request_path=unsigned.request_path,
+            payload_digest=unsigned.payload_digest,
+            graph_digest=unsigned.graph_digest,
             scope=unsigned.scope,
-            outcome=outcome,
-            receipt_digest=unsigned.binding_digest(),
-            refusal_reason=reason,
-            suppressed_refusals=suppressed,
+            outcome=unsigned.outcome,
+            refusal_reason=unsigned.refusal_reason,
+            admission_chain_head=unsigned.admission_chain_head,
+            replay_protected=unsigned.replay_protected,
+            timestamp=unsigned.timestamp,
+            task_ids=unsigned.task_ids,
+            signer_public_key_pem=public_pem,
+            signature=signature,
+            chain_entry_hash=event.hmac,
         )
-
-    receipt = TriggerReceipt(
-        trigger_id=unsigned.trigger_id,
-        platform=unsigned.platform,
-        request_path=unsigned.request_path,
-        payload_digest=unsigned.payload_digest,
-        graph_digest=unsigned.graph_digest,
-        scope=unsigned.scope,
-        outcome=unsigned.outcome,
-        refusal_reason=unsigned.refusal_reason,
-        admission_chain_head=unsigned.admission_chain_head,
-        replay_protected=unsigned.replay_protected,
-        timestamp=unsigned.timestamp,
-        task_ids=unsigned.task_ids,
-        signer_public_key_pem=public_pem,
-        signature=signature,
-        chain_entry_hash=event.hmac,
-    )
-    if not reason and enforce_replay:
-        ledger.remember(trigger_id, receipt)
-    return TriggerAdmission(receipt=receipt, admitted=not reason, graph=graph)
+        # Inside the nonce section: the id becomes seen before the next
+        # delivery of it can read the ledger, which is what the check above
+        # then decides on.
+        if not reason and enforce_replay:
+            ledger.remember(trigger_id, receipt)
+        return TriggerAdmission(receipt=receipt, admitted=not reason, graph=graph)
 
 
 def _decode_intent(body: bytes) -> dict[str, Any]:
@@ -827,6 +962,29 @@ def status_proof_path(root: Path, event_id: str) -> Path:
     return root / _STATUS_SUBDIR / f"{_safe_name(event_id)}.json"
 
 
+def _status_proof_lock_path(root: Path, event_id: str) -> Path:
+    """Return the lock file guarding the mint of ``event_id``'s proof."""
+    return root / _STATUS_SUBDIR / f"{_safe_name(event_id)}.lock"
+
+
+def _cached_status_proof(path: Path, *, report_malformed: bool) -> StatusProof | None:
+    """Return the proof cached at ``path``, or ``None`` when there is none to use.
+
+    A cache file that cannot be parsed is treated as absent so the callback is
+    still answered, and is reported only once per emission: the probe outside
+    the mint section is best-effort, and re-reporting it inside would log the
+    same file twice for one call.
+    """
+    if not path.is_file():
+        return None
+    try:
+        return StatusProof.from_dict(json.loads(path.read_text(encoding="utf-8")))
+    except (AutomationBridgeError, json.JSONDecodeError, OSError):
+        if report_malformed:
+            logger.warning("automation bridge: malformed status proof at %s", sanitize_log(str(path)))
+        return None
+
+
 def derive_status(payload: dict[str, Any]) -> str:
     """Return the status a notification payload reports.
 
@@ -857,6 +1015,14 @@ def emit_status_proof(
     delivery failure returns the recorded proof, so the retried envelope is
     byte-identical rather than a second, differently-anchored claim.
 
+    That holds under concurrency too. The cache probe, the mint, and the cache
+    write are one section per ``event_id``, so two callbacks in flight for one
+    event anchor one ``status.proof.emitted`` row between them and are handed
+    the same proof: the second waits for the first and then reads what the
+    first recorded, instead of minting a second anchor and overwriting the
+    proof its peer already holds. A cache hit is answered before the section is
+    entered, so the common re-send costs no lock and touches nothing.
+
     Args:
         root: Bridge state root.
         audit_dir: Audit-chain directory.
@@ -876,64 +1042,79 @@ def emit_status_proof(
         raise AutomationBridgeError("status payload has no event_id to anchor")
 
     cached_path = status_proof_path(root, event_id)
-    if cached_path.is_file():
-        try:
-            return StatusProof.from_dict(json.loads(cached_path.read_text(encoding="utf-8")))
-        except (AutomationBridgeError, json.JSONDecodeError, OSError):
-            logger.warning("automation bridge: malformed status proof at %s", sanitize_log(str(cached_path)))
+    # Answered before the section: a re-send of an already-proved event takes
+    # no lock, creates nothing, and so still works where the bridge root is
+    # mounted read-only.
+    already_proved = _cached_status_proof(cached_path, report_malformed=False)
+    if already_proved is not None:
+        return already_proved
 
     effective_status = status or derive_status(payload)
     run_id = str(payload.get("run_id", "") or "")
     chain = _chain_store(audit_dir, hmac_key)
 
-    # Outside the section below: no dependency on the chain head, and creating
-    # the keypair should not hold the chain against other writers.
-    private_pem, public_pem = load_or_create_bridge_identity(root)
-    from bernstein.core.security.audit_chain import record_status_proof
-    from bernstein.core.skills.catalog.signature import sign_payload
+    # The probe, the mint, and the cache write are one section per event id, so
+    # one event id yields one anchor. Held apart, two callbacks both miss the
+    # cache, both anchor a ``status.proof.emitted`` row, and the later write
+    # replaces the proof the earlier caller was already handed -- leaving a peer
+    # holding a proof that is not the proof on disk, with both rows honestly
+    # chained so nothing reads as tampering.
+    with _decision_lock(_status_proof_lock_path(root, event_id)):
+        # The waiter re-probes here: by the time it holds the section the first
+        # caller has recorded its proof, and returning that is what makes the
+        # two envelopes byte-identical.
+        recorded = _cached_status_proof(cached_path, report_malformed=True)
+        if recorded is not None:
+            return recorded
 
-    # One atomic section for the same reason as the trigger path: the head is
-    # signed into the proof, so it has to be the head the proof's own record
-    # ends up chained onto, and it is read from disk rather than from the
-    # store's per-instance cache.
-    with chain.chain_transaction():
-        unsigned = StatusProof(
-            event_id=event_id,
-            run_id=run_id,
-            status=effective_status,
-            producing_event_digest=compute_document_digest(payload),
-            chain_head=chain.resync_head(),
-            timestamp=timestamp,
-        )
+        # Outside the chain section below: no dependency on the chain head, and
+        # creating the keypair should not hold the chain against other writers.
+        private_pem, public_pem = load_or_create_bridge_identity(root)
+        from bernstein.core.security.audit_chain import record_status_proof
+        from bernstein.core.skills.catalog.signature import sign_payload
 
-        signature = sign_payload(unsigned.to_canonical_bytes(), private_pem)
+        # One atomic section for the same reason as the trigger path: the head
+        # is signed into the proof, so it has to be the head the proof's own
+        # record ends up chained onto, and it is read from disk rather than from
+        # the store's per-instance cache.
+        with chain.chain_transaction():
+            unsigned = StatusProof(
+                event_id=event_id,
+                run_id=run_id,
+                status=effective_status,
+                producing_event_digest=compute_document_digest(payload),
+                chain_head=chain.resync_head(),
+                timestamp=timestamp,
+            )
 
-        event = record_status_proof(
-            chain=chain,
-            event_id=event_id,
-            run_id=run_id,
-            status=effective_status,
+            signature = sign_payload(unsigned.to_canonical_bytes(), private_pem)
+
+            event = record_status_proof(
+                chain=chain,
+                event_id=event_id,
+                run_id=run_id,
+                status=effective_status,
+                producing_event_digest=unsigned.producing_event_digest,
+                proof_digest=unsigned.binding_digest(),
+            )
+
+        proof = StatusProof(
+            event_id=unsigned.event_id,
+            run_id=unsigned.run_id,
+            status=unsigned.status,
             producing_event_digest=unsigned.producing_event_digest,
-            proof_digest=unsigned.binding_digest(),
+            chain_head=unsigned.chain_head,
+            timestamp=unsigned.timestamp,
+            signer_public_key_pem=public_pem,
+            signature=signature,
+            chain_entry_hash=event.hmac,
         )
-
-    proof = StatusProof(
-        event_id=unsigned.event_id,
-        run_id=unsigned.run_id,
-        status=unsigned.status,
-        producing_event_digest=unsigned.producing_event_digest,
-        chain_head=unsigned.chain_head,
-        timestamp=unsigned.timestamp,
-        signer_public_key_pem=public_pem,
-        signature=signature,
-        chain_entry_hash=event.hmac,
-    )
-    cached_path.parent.mkdir(parents=True, exist_ok=True)
-    cached_path.write_text(
-        json.dumps(proof.to_dict(), ensure_ascii=False, separators=(",", ":"), sort_keys=True),
-        encoding="utf-8",
-    )
-    return proof
+        cached_path.parent.mkdir(parents=True, exist_ok=True)
+        cached_path.write_text(
+            json.dumps(proof.to_dict(), ensure_ascii=False, separators=(",", ":"), sort_keys=True),
+            encoding="utf-8",
+        )
+        return proof
 
 
 def wrap_status_payload(payload: dict[str, Any], proof: StatusProof) -> dict[str, Any]:

--- a/tests/unit/security/test_bridge_decision_exclusivity.py
+++ b/tests/unit/security/test_bridge_decision_exclusivity.py
@@ -1,0 +1,382 @@
+"""One inbound identity yields one bridge decision, under concurrency.
+
+Both bridge paths take a decision from state they read before the section that
+is supposed to make the decision exclusive, and record it after that section:
+
+* ``admit_trigger`` reads the replay ledger, then anchors, then remembers the
+  nonce. Two deliveries of one ``trigger_id`` both read "not seen" and both
+  take the admitted branch, so the task graph is projected and fired twice
+  while the receipt still says ``replay_protected=True``.
+* ``emit_status_proof`` probes the proof cache, then anchors, then writes the
+  cache. Two callbacks for one ``event_id`` both miss, both anchor their own
+  ``status.proof.emitted`` event, and the later write overwrites the earlier
+  proof, so a peer holds a proof that is not the proof on disk.
+
+Serialising the appends is not the same guarantee: the chain stays linear
+either way, which is exactly why neither defect shows up as chain corruption.
+These tests race two real threads through the real code and pin the decision
+itself as exclusive.
+
+The rendezvous is installed on ``load_or_create_bridge_identity`` because that
+is real work both paths perform after the state read and before the anchoring
+section. Two threads meeting there have both already taken their decision on
+the pre-fix code, which is what makes the race entered rather than merely
+scheduled. Once the decision is exclusive the second thread never reaches the
+rendezvous, so the wait falls through on its timeout and the barrier stays
+broken for the rest of the test.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import subprocess
+import sys
+import threading
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bernstein.core.security.audit import AuditEvent, load_or_create_audit_key
+from bernstein.core.security.audit_chain import (
+    EVENT_STATUS_PROOF_EMITTED,
+    EVENT_TRIGGER_RECEIPT_ISSUED,
+    EVENT_TRIGGER_RECEIPT_REFUSED,
+    AuditChainStore,
+)
+from bernstein.core.trigger_sources import receipt as receipt_module
+from bernstein.core.trigger_sources.receipt import (
+    REFUSAL_REPLAYED_TRIGGER,
+    TriggerAdmission,
+    admit_trigger,
+    emit_status_proof,
+    status_proof_path,
+)
+
+_BODY = json.dumps({"title": "Rotate the deploy key", "description": "quarterly"}).encode()
+
+#: How long a thread waits at the rendezvous for its twin. Pre-fix both threads
+#: arrive and it costs nothing. Post-fix only one arrives, so the suite pays
+#: this once per test; it is small for that reason rather than generous.
+_RENDEZVOUS_S = 0.5
+
+#: Bound on a worker thread completing once the rendezvous has resolved.
+_JOIN_S = 30.0
+
+
+@dataclass(frozen=True)
+class _Bridge:
+    """The bridge locations one test operates on."""
+
+    root: Path
+    audit_dir: Path
+    hmac_key: bytes
+
+
+@pytest.fixture()
+def bridge(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> _Bridge:
+    """Return an isolated bridge root, audit dir, and HMAC key."""
+    monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(tmp_path / "audit.key"))
+    return _Bridge(
+        root=tmp_path / "automation-bridge",
+        audit_dir=tmp_path / "audit",
+        hmac_key=load_or_create_audit_key(tmp_path / "audit.key"),
+    )
+
+
+def _install_rendezvous(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make both racing threads meet after their read and before their append.
+
+    Wraps the real identity load rather than replacing it, so the code under
+    test still runs end to end; the only change is that the first thread
+    through waits for its twin instead of racing ahead on scheduler luck.
+    """
+    barrier = threading.Barrier(2)
+    real_load = receipt_module.load_or_create_bridge_identity
+
+    def load_at_the_rendezvous(root: Path) -> tuple[str, str]:
+        with contextlib.suppress(threading.BrokenBarrierError):
+            barrier.wait(timeout=_RENDEZVOUS_S)
+        return real_load(root)
+
+    monkeypatch.setattr(receipt_module, "load_or_create_bridge_identity", load_at_the_rendezvous)
+
+
+def _seed_chain(bridge: _Bridge, count: int = 2) -> None:
+    """Put real events on the chain so the head under test is not genesis."""
+    for index in range(count):
+        admit_trigger(
+            root=bridge.root,
+            audit_dir=bridge.audit_dir,
+            hmac_key=bridge.hmac_key,
+            platform="n8n",
+            request_path="/webhook",
+            trigger_id=f"seed-{index}",
+            body=_BODY,
+            scope="task:create",
+            timestamp=1_700_000_000,
+        )
+
+
+def _chain_rows(bridge: _Bridge, event_type: str, resource_id: str) -> list[AuditEvent]:
+    """Return the chain rows of *event_type* recorded against *resource_id*."""
+    chain = AuditChainStore(bridge.audit_dir, key=bridge.hmac_key)
+    return chain.query(event_type=event_type, resource_id=resource_id)
+
+
+def _race[T](call: Callable[[], T]) -> tuple[T, T]:
+    """Run *call* twice on two threads and return both results."""
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(call) for _ in range(2)]
+        return (futures[0].result(timeout=_JOIN_S), futures[1].result(timeout=_JOIN_S))
+
+
+# ---------------------------------------------------------------------------
+# #3150 -- the replay-nonce decision is exclusive
+# ---------------------------------------------------------------------------
+
+
+def test_doubly_delivered_trigger_is_admitted_exactly_once(bridge: _Bridge, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two concurrent deliveries of one trigger id yield one admission.
+
+    ``replay_protected=True`` on the receipt states that the id was checked
+    against the ledger. That is only true if the check and the record of it are
+    one decision: read-then-record lets both deliveries pass the check and both
+    fire the graph, and neither receipt is distinguishable from an honest one.
+    """
+    _seed_chain(bridge)
+    _install_rendezvous(monkeypatch)
+
+    def deliver() -> TriggerAdmission:
+        return admit_trigger(
+            root=bridge.root,
+            audit_dir=bridge.audit_dir,
+            hmac_key=bridge.hmac_key,
+            platform="n8n",
+            request_path="/webhook",
+            trigger_id="delivered-twice",
+            body=_BODY,
+            scope="task:create",
+            timestamp=1_700_000_100,
+        )
+
+    first, second = _race(deliver)
+
+    admitted = [outcome for outcome in (first, second) if outcome.admitted]
+    refused = [outcome for outcome in (first, second) if not outcome.admitted]
+    assert len(admitted) == 1, (
+        "both concurrent deliveries of one trigger id were admitted; "
+        f"outcomes: {[outcome.admitted for outcome in (first, second)]}"
+    )
+    assert len(refused) == 1
+    assert refused[0].refusal_reason == REFUSAL_REPLAYED_TRIGGER
+
+    # The graph is projected once, so the caller fires it once.
+    projected = [outcome for outcome in (first, second) if outcome.graph is not None]
+    assert len(projected) == 1, "the task graph was projected twice for one trigger id"
+
+    # The refusal is a signed, chain-anchored receipt in its own right.
+    refusal_receipt = refused[0].receipt
+    assert refusal_receipt is not None
+    assert refusal_receipt.signature
+    assert refusal_receipt.chain_entry_hash
+    assert refusal_receipt.replay_protected is True
+
+    assert len(_chain_rows(bridge, EVENT_TRIGGER_RECEIPT_ISSUED, "delivered-twice")) == 1
+    assert len(_chain_rows(bridge, EVENT_TRIGGER_RECEIPT_REFUSED, "delivered-twice")) == 1
+
+    ok, problems = AuditChainStore(bridge.audit_dir, key=bridge.hmac_key).verify()
+    assert ok, problems
+
+
+def test_unenforced_replay_still_admits_a_repeated_id(bridge: _Bridge, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A derived id must not start being refused.
+
+    With ``enforce_replay=False`` the id was derived from the request, so it
+    cannot tell a captured replay from a legitimate re-fire. Making the ledger
+    decision exclusive must not turn the second re-fire into an error.
+    """
+    _seed_chain(bridge)
+    _install_rendezvous(monkeypatch)
+
+    def deliver() -> TriggerAdmission:
+        return admit_trigger(
+            root=bridge.root,
+            audit_dir=bridge.audit_dir,
+            hmac_key=bridge.hmac_key,
+            platform="n8n",
+            request_path="/webhook",
+            trigger_id="derived-id",
+            body=_BODY,
+            scope="task:create",
+            timestamp=1_700_000_200,
+            enforce_replay=False,
+        )
+
+    first, second = _race(deliver)
+
+    assert first.admitted and second.admitted
+    assert first.receipt is not None and first.receipt.replay_protected is False
+    assert second.receipt is not None and second.receipt.replay_protected is False
+    assert len(_chain_rows(bridge, EVENT_TRIGGER_RECEIPT_ISSUED, "derived-id")) == 2
+
+
+#: A second interpreter delivering the same trigger id. The rendezvous is the
+#: same one the thread tests install, written as files because the two sides
+#: share nothing else. Booting is waited on generously (an interpreter start
+#: plus the package import); the rendezvous itself is short, because once the
+#: decision is exclusive only one process arrives and the other side of that
+#: wait is time the suite spends on every run.
+_CHILD_DELIVERY = '''
+import json, sys, time
+from pathlib import Path
+
+from bernstein.core.security.audit import load_or_create_audit_key
+from bernstein.core.trigger_sources import receipt as receipt_module
+
+root, audit_dir, key_path = Path(sys.argv[1]), Path(sys.argv[2]), Path(sys.argv[3])
+slot, sync = sys.argv[4], Path(sys.argv[5])
+
+
+def rendezvous(suffix, deadline_s):
+    """Wait for the other interpreter to reach the same point, or give up."""
+    (sync / f"{slot}.{suffix}").write_text("", encoding="utf-8")
+    deadline = time.monotonic() + deadline_s
+    while time.monotonic() < deadline and len(list(sync.glob(f"*.{suffix}"))) < 2:
+        time.sleep(0.005)
+
+
+real_load = receipt_module.load_or_create_bridge_identity
+
+
+def load_at_the_rendezvous(bridge_root):
+    rendezvous("ready", RENDEZVOUS_S)
+    return real_load(bridge_root)
+
+
+receipt_module.load_or_create_bridge_identity = load_at_the_rendezvous
+
+rendezvous("booted", 60.0)
+admission = receipt_module.admit_trigger(
+    root=root,
+    audit_dir=audit_dir,
+    hmac_key=load_or_create_audit_key(key_path),
+    platform="n8n",
+    request_path="/webhook",
+    trigger_id="delivered-twice-across-processes",
+    body=BODY,
+    scope="task:create",
+    timestamp=1_700_000_300,
+)
+print(json.dumps({
+    "admitted": admission.admitted,
+    "refusal_reason": admission.refusal_reason,
+    "projected": admission.graph is not None,
+}))
+'''
+
+
+def test_doubly_delivered_trigger_is_admitted_once_across_processes(bridge: _Bridge, tmp_path: Path) -> None:
+    """The admission decision is exclusive against another process, not just another thread.
+
+    The bridge is served by whatever worker happens to receive the delivery, so
+    an in-process guard would leave the guarantee to how the deployment was
+    started. Two interpreters race here for that reason: a lock that only holds
+    within one process passes the thread test and fails this one.
+    """
+    _seed_chain(bridge)
+    sync = tmp_path / "sync"
+    sync.mkdir()
+    script = tmp_path / "deliver.py"
+    script.write_text(
+        f"BODY = {_BODY!r}\nRENDEZVOUS_S = {_RENDEZVOUS_S!r}\n{_CHILD_DELIVERY}",
+        encoding="utf-8",
+    )
+
+    children = [
+        subprocess.Popen(
+            [
+                sys.executable,
+                str(script),
+                str(bridge.root),
+                str(bridge.audit_dir),
+                str(tmp_path / "audit.key"),
+                slot,
+                str(sync),
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        for slot in ("a", "b")
+    ]
+    results: list[dict[str, Any]] = []
+    for child in children:
+        out, err = child.communicate(timeout=_JOIN_S * 4)
+        assert child.returncode == 0, f"delivery process failed: {err}"
+        results.append(json.loads(out.strip().splitlines()[-1]))
+
+    admitted = [row for row in results if row["admitted"]]
+    assert len(admitted) == 1, f"two processes both admitted one trigger id: {results}"
+    refused = [row for row in results if not row["admitted"]]
+    assert refused[0]["refusal_reason"] == REFUSAL_REPLAYED_TRIGGER
+    assert sum(bool(row["projected"]) for row in results) == 1
+
+    resource = "delivered-twice-across-processes"
+    assert len(_chain_rows(bridge, EVENT_TRIGGER_RECEIPT_ISSUED, resource)) == 1
+    assert len(_chain_rows(bridge, EVENT_TRIGGER_RECEIPT_REFUSED, resource)) == 1
+
+    ok, problems = AuditChainStore(bridge.audit_dir, key=bridge.hmac_key).verify()
+    assert ok, problems
+
+
+# ---------------------------------------------------------------------------
+# #3151 -- one event_id mints one proof
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_callbacks_mint_one_status_proof(bridge: _Bridge, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two concurrent callbacks for one event id share one anchored proof.
+
+    The cache exists so a re-sent callback carries a byte-identical envelope
+    rather than a second, differently-anchored claim. Probing before the
+    section and writing after it lets both callers anchor their own event and
+    lets the later write replace the proof the earlier caller already holds.
+    """
+    _seed_chain(bridge)
+    _install_rendezvous(monkeypatch)
+    payload: dict[str, Any] = {"event_id": "ev-raced", "run_id": "run-9", "severity": "error"}
+
+    def callback() -> dict[str, Any]:
+        return emit_status_proof(
+            root=bridge.root,
+            audit_dir=bridge.audit_dir,
+            hmac_key=bridge.hmac_key,
+            payload=payload,
+            status="failed",
+            timestamp=1_700_000_500,
+        ).to_dict()
+
+    first, second = _race(callback)
+
+    assert first == second, (
+        "two concurrent callbacks for one event id returned differently-anchored proofs: "
+        f"{first.get('chain_entry_hash')!r} vs {second.get('chain_entry_hash')!r}"
+    )
+
+    rows = _chain_rows(bridge, EVENT_STATUS_PROOF_EMITTED, "ev-raced")
+    assert len(rows) == 1, f"one event id anchored {len(rows)} status proofs"
+
+    on_disk = json.loads(status_proof_path(bridge.root, "ev-raced").read_text(encoding="utf-8"))
+    assert on_disk == first, "the proof on disk is not the proof the callers were handed"
+
+    # A later re-send still returns the cached proof and appends nothing.
+    assert callback() == first
+    assert len(_chain_rows(bridge, EVENT_STATUS_PROOF_EMITTED, "ev-raced")) == 1
+
+    ok, problems = AuditChainStore(bridge.audit_dir, key=bridge.hmac_key).verify()
+    assert ok, problems


### PR DESCRIPTION
Closes #3150
Closes #3151

Both are the same defect seen twice: a decision taken from state read *before* the section meant to make that decision exclusive, and recorded *after* it. `chain_transaction()` serialises the appends in between, so the chain stays linear in both cases, which is exactly why neither defect reads as tampering.

## What changed

The nonce ledger and the proof cache each get their own exclusive section, keyed per identity under the bridge root. That is a different lock domain from the audit chain's, whose domain is the audit dir and whose subject is the chain head.

* Blocking `flock(LOCK_EX)`, re-entrant per thread the same way the chain append lock is. No polling and no deadline, so a contended decision is delayed and never dropped, and the guarantee holds across worker processes rather than only across threads in one of them.
* Scoped per `trigger_id` and per `event_id`, so two workers adjudicating different identities still never contend. That is the property the one-file-per-id ledger layout was chosen for.
* No exclusive lock is held across a history read. Reads stay lock-free.
* `admit_trigger` takes the section only when it actually consults the ledger. An unauthenticated trigger is refused before the ledger is reached, and an unenforced replay regime never reads or writes it, so a derived id keeps its current behaviour and does not start being refused (#3150 AC 5).
* `emit_status_proof` answers a cache hit before entering the section, so the common re-send takes no lock, creates nothing, and still works with the bridge root mounted read-only. A caller that waits re-probes inside the section and returns what the first caller recorded, which is what makes the two envelopes byte-identical.

## #3150: the replay-nonce decision was not exclusive

`ledger.seen(trigger_id)` ran before the section and `ledger.remember(...)` after it. Two concurrent deliveries of one `trigger_id` both read "not seen", both took the admitted branch, and both projected and fired the task graph, while each receipt still carried `replay_protected=True`.

Two threads racing the real code, rendezvousing on `load_or_create_bridge_identity`, which is real work both paths perform after the state read and before the anchoring section.

Before, on `origin/main`:

```
$ uv run pytest tests/unit/security/test_bridge_decision_exclusivity.py -q
E  AssertionError: both concurrent deliveries of one trigger id were admitted; outcomes: [True, True]
E  assert 2 == 1
E  AssertionError: two processes both admitted one trigger id:
     [{'admitted': True, 'refusal_reason': '', 'projected': True},
      {'admitted': True, 'refusal_reason': '', 'projected': True}]
E  assert 2 == 1
```

The same race through a standalone driver, so the symptom is visible rather than inferred:

```
#3150 admitted flags        : [True, True]
#3150 graphs projected      : 2
#3150 graph_digests fired   : ['sha256:4466bd43b3ab463e', 'sha256:4466bd43b3ab463e']
#3150 replay_protected says : [True, True]
#3150 chain rows            : issued=2 refused=0

chain verify                : True []
```

Two admissions, the identical graph fired twice, both receipts asserting replay protection, and the chain verifying clean throughout.

After:

```
#3150 admitted flags        : [False, True]
#3150 graphs projected      : 1
#3150 graph_digests fired   : [None, 'sha256:4466bd43b3ab463e']
#3150 replay_protected says : [True, True]
#3150 chain rows            : issued=1 refused=1

chain verify                : True []
```

One admission, one graph projected, and the loser gets a signed, chain-anchored `trigger.receipt.refused` carrying `replayed_trigger_id`, which is what the single-threaded replay path already produced.

## #3151: one event_id could mint two differently-anchored proofs

The cache probe read `cached_path` before the section and the write landed after it. Two concurrent callbacks for one `event_id` both missed, both anchored a `status.proof.emitted` event, and the second `write_text` overwrote the first.

Before, on `origin/main`:

```
#3151 caller A anchor        : 736d14ff5e6d1c8ba68b721c9ac8f8f2
#3151 caller B anchor        : 903542bfee666d05711c9cd74fa48d24
#3151 proofs identical       : False
#3151 on-disk anchor         : 903542bfee666d05711c9cd74fa48d24
#3151 on-disk == caller A    : False
#3151 on-disk == caller B    : True
#3151 status.proof.emitted   : 2
```

Caller A holds a proof that is not the proof on disk. As the test reports it:

```
E  AssertionError: two concurrent callbacks for one event id returned differently-anchored proofs:
     '4d8d55644cb30398c1d9997a4cb0e1dbc04e290bcdbf41940f80ac573d98df81'
     vs '61de436eba5d3a727f46ef6c561ee21a2435e1aacfbd32001b56f47f10fe2bc2'
E  Differing items:
E    {'chain_head': ...} != {'chain_head': ...}
E    {'chain_entry_hash': ...} != {'chain_entry_hash': ...}
E    {'signature': ...} != {'signature': ...}
```

After:

```
#3151 caller A anchor        : 0c36c23ce5278381819b274f229e5219
#3151 caller B anchor        : 0c36c23ce5278381819b274f229e5219
#3151 proofs identical       : True
#3151 on-disk anchor         : 0c36c23ce5278381819b274f229e5219
#3151 on-disk == caller A    : True
#3151 on-disk == caller B    : True
#3151 status.proof.emitted   : 1
```

One chain event, one proof, and the proof on disk is the proof both callers were handed.

## Tests

`tests/unit/security/test_bridge_decision_exclusivity.py`, four tests, all racing the real code:

| Test | Pins |
| --- | --- |
| `test_doubly_delivered_trigger_is_admitted_exactly_once` | one admission, one projection, an anchored refusal for the loser (#3150 AC 1-4) |
| `test_doubly_delivered_trigger_is_admitted_once_across_processes` | the same across two interpreters, since the bridge is served by whichever worker receives the delivery and an in-process guard would leave the guarantee to how the deployment was started |
| `test_unenforced_replay_still_admits_a_repeated_id` | a derived id does not start being refused (#3150 AC 5) |
| `test_concurrent_callbacks_mint_one_status_proof` | one chain event, byte-identical proofs, on-disk equals delivered, a later re-send still appends nothing (#3151 AC 1-5) |

Three of the four fail on `origin/main` and pass here. `test_unenforced_replay_still_admits_a_repeated_id` passes on both, which is the point of it.

Local checks: `ruff check src/ tests/ scripts/` clean, `ruff format` applied, `pyright` clean on both changed files and on `pyrightconfig.strict.json`, `lint-imports` 3 kept and 0 broken, and the bridge, webhook-sink, receipt-verify and chain-head-atomicity suites green (53 passed) alongside the new file.
