### PR TITLE
fix(watchdog): remove dead heartbeat_starting_timeout_s config

### DIFF
--- a/src/bernstein/core/defaults.py
+++ b/src/bernstein/core/defaults.py
@@ -187,14 +187,6 @@ class AgentDefaults:
     """Heartbeat, idle detection, escalation tiers."""
 
     heartbeat_stale_s: float = 120.0  # 2 min
-    # Time-to-first-turn cap for the `starting` phase. Adapters that emit no
-    # heartbeats (e.g. `consumes_heartbeat_dir=False`) rely on log/git mtime
-    # for liveness, so a slow/free-tier model that needs longer than
-    # `heartbeat_stale_s` to produce its first turn used to be flagged stale
-    # and reaped while still working (issue #3012). The starting phase gets a
-    # larger, separately-configurable window sized above a realistic slow
-    # first turn. Override via `tuning.agent.heartbeat_starting_timeout_s`.
-    heartbeat_starting_timeout_s: float = 300.0  # 5 min
     # A log/git-tree mtime fresher than this window is a POSITIVE liveness
     # signal: the agent is demonstrably alive regardless of heartbeat age, so
     # the heartbeat-staleness incident is suppressed and no SIGTERM is sent

--- a/src/bernstein/core/observability/watchdog.py
+++ b/src/bernstein/core/observability/watchdog.py
@@ -36,19 +36,6 @@ WatchdogSource = Literal["heartbeat", "log_growth", "progress_stall"]
 # Shared cast-type constants to avoid string duplication (Sonar S1192).
 _CAST_DICT_STR_OBJ = "dict[str, object]"
 
-# Heartbeat phases that mean the agent is still producing its FIRST turn. A
-# non-heartbeat adapter (consumes_heartbeat_dir=False) has only its spawn-time
-# heartbeat on disk during this phase, so heartbeat age == wall-clock since
-# spawn; a slow/free model that deliberates past the normal stale threshold
-# must be judged on log/git liveness, not reaped on heartbeat age (issue #3012).
-_STARTING_PHASES: frozenset[str] = frozenset(
-    {"starting", "start", "init", "initializing", "spawning", "spawn", "boot", "booting"}
-)
-
-
-def _is_starting_phase(phase: str | None) -> bool:
-    return bool(phase) and phase.strip().lower() in _STARTING_PHASES
-
 
 def _log_signal_is_fresh(log_age_s: float | None) -> bool:
     """Whether a log mtime proves the agent is alive within the grace window.
@@ -110,7 +97,6 @@ def _check_session_findings(
     findings: dict[str, WatchdogFinding],
     *,
     log_age_s: float | None = None,
-    starting_timeout_s: float | None = None,
 ) -> None:
     """Check a single session for watchdog-worthy findings."""
     stall_count = int(stall_counts.get(task_id, 0))
@@ -149,7 +135,6 @@ def _check_session_findings(
         current_line,
         findings,
         log_age_s=log_age_s,
-        starting_timeout_s=starting_timeout_s,
     )
     _check_log_growth_findings(session_id, task_id, task, runtime_s, current_line, no_growth_ticks, findings)
 
@@ -165,31 +150,21 @@ def _check_heartbeat_findings(
     findings: dict[str, WatchdogFinding],
     *,
     log_age_s: float | None = None,
-    starting_timeout_s: float | None = None,
 ) -> None:
     """Check heartbeat-related findings for a session.
 
     A log/git mtime fresher than ``AGENT.liveness_grace_s`` is treated as a
     POSITIVE liveness signal that suppresses the heartbeat-staleness incident
     entirely -- not merely defers it: the agent is demonstrably alive even if
-    its heartbeat is stale (issue #3012). While the agent is still in the
-    ``starting`` phase the (larger, configurable) ``starting_timeout_s`` is
-    used so a slow/free model's first turn is not a hard 120s cap.
+    its heartbeat is stale (issue #3012).
     """
     # Fresh log/git write within the grace window -> the agent is alive; never
     # raise a heartbeat-staleness incident against a demonstrably-live agent.
     if _log_signal_is_fresh(log_age_s):
         return
 
-    # A `starting` agent (only its spawn-time heartbeat on disk for a
-    # non-heartbeat adapter) is judged against the larger starting-phase
-    # window, not the general stale threshold.
-    effective_timeout = timeout_s
-    if starting_timeout_s is not None and _is_starting_phase(getattr(hb_status, "phase", None)):
-        effective_timeout = max(timeout_s, starting_timeout_s)
-
     if hb_status.last_heartbeat is None:
-        if runtime_s >= max(effective_timeout / 2.0, 60.0) and current_line == 0:
+        if runtime_s >= max(timeout_s / 2.0, 60.0) and current_line == 0:
             title = task.title if task is not None else task_id
             findings[f"heartbeat:{session_id}:{task_id}"] = WatchdogFinding(
                 key=f"heartbeat:{session_id}:{task_id}",
@@ -206,8 +181,8 @@ def _check_heartbeat_findings(
             )
         return
 
-    if hb_status.age_seconds >= max(effective_timeout / 2.0, 60.0):
-        severity: WatchdogSeverity = "critical" if hb_status.age_seconds >= effective_timeout else "high"
+    if hb_status.age_seconds >= max(timeout_s / 2.0, 60.0):
+        severity: WatchdogSeverity = "critical" if hb_status.age_seconds >= timeout_s else "high"
         title = task.title if task is not None else task_id
         findings[f"heartbeat:{session_id}:{task_id}"] = WatchdogFinding(
             key=f"heartbeat:{session_id}:{task_id}",
@@ -218,7 +193,7 @@ def _check_heartbeat_findings(
             summary=f"Heartbeat stale for task {title}",
             detail=(
                 f"Tier-1 watchdog observed heartbeat age {hb_status.age_seconds:.0f}s "
-                f"for task {task_id} (timeout={effective_timeout:.0f}s, phase={hb_status.phase or 'unknown'})."
+                f"for task {task_id} (timeout={timeout_s:.0f}s, phase={hb_status.phase or 'unknown'})."
             ),
             task_title=str(title),
         )
@@ -266,7 +241,6 @@ def collect_watchdog_findings(orch: Any) -> list[WatchdogFinding]:
 
     config = getattr(orch, "_config", None)
     timeout_s = float(getattr(config, "heartbeat_timeout_s", 120))
-    starting_timeout_s = float(getattr(config, "heartbeat_starting_timeout_s", AGENT.heartbeat_starting_timeout_s))
     monitor = HeartbeatMonitor(workdir, timeout_s=timeout_s)
     logs = AgentLogAggregator(workdir)
     now = time.time()
@@ -325,7 +299,6 @@ def collect_watchdog_findings(orch: Any) -> list[WatchdogFinding]:
             stall_counts,
             findings,
             log_age_s=log_age_s,
-            starting_timeout_s=starting_timeout_s,
         )
 
     for session_id in list(log_state.keys()):

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -1526,12 +1526,6 @@ class OrchestratorConfig:
     # Unified with AGENT.heartbeat_stale_s. Previously 900s; now defaults to 120s.
     # Deployments that explicitly relied on the 900s value must set this field explicitly.
     heartbeat_timeout_s: int = field(default_factory=lambda: int(AGENT.heartbeat_stale_s))
-    # Time-to-first-turn cap for agents still in the `starting` phase. Kept
-    # separate from (and larger than) ``heartbeat_timeout_s`` so a slow/free
-    # model that takes >120s to its first turn is not reaped mid-work while a
-    # non-heartbeat adapter has only its spawn-time heartbeat on disk (issue
-    # #3012). Overridable via ``tuning.agent.heartbeat_starting_timeout_s``.
-    heartbeat_starting_timeout_s: int = field(default_factory=lambda: int(AGENT.heartbeat_starting_timeout_s))
     heartbeat_enabled: bool = True
     # Derived from ORCHESTRATOR.max_agent_runtime_s (canonical) so
     # ``tuning.orchestrator.max_agent_runtime_s`` overrides the starting

--- a/tests/unit/test_watchdog.py
+++ b/tests/unit/test_watchdog.py
@@ -57,14 +57,12 @@ def _orch(
     stall_count: int = 0,
     log_state: dict[str, tuple[int, int]] | None = None,
     heartbeat_timeout_s: int = 120,
-    heartbeat_starting_timeout_s: int = 300,
 ) -> SimpleNamespace:
     task = Task(id=session.task_ids[0], title="Fix API", description="desc", role="backend")
     return SimpleNamespace(
         _workdir=workdir,
         _config=SimpleNamespace(
             heartbeat_timeout_s=heartbeat_timeout_s,
-            heartbeat_starting_timeout_s=heartbeat_starting_timeout_s,
         ),
         _agents={session.id: session},
         _stall_counts={session.task_ids[0]: stall_count},
@@ -168,46 +166,19 @@ def test_stale_heartbeat_with_stale_log_still_raises_critical(tmp_path: Path) ->
     assert heartbeat[0].severity == "critical"
 
 
-def test_starting_phase_uses_configurable_larger_timeout(tmp_path: Path) -> None:
-    """A `starting` agent is judged against the larger, configurable
-    starting-phase timeout, so a heartbeat age past the normal 120s cap but
-    below the starting window raises no incident (issue #3012)."""
+def test_starting_phase_heartbeat_uses_the_ordinary_timeout(tmp_path: Path) -> None:
+    """No shipped heartbeat writer ever emits `phase: starting` (issue #3057),
+    so a heartbeat labeled `starting` is judged by the ordinary
+    `heartbeat_timeout_s` like any other phase, with no separate grace
+    window."""
     workdir = tmp_path
     now = time.time()
     session = _session("task-1", spawn_ts=now - 400)
-    orch = _orch(
-        workdir,
-        session=session,
-        heartbeat_timeout_s=120,
-        heartbeat_starting_timeout_s=300,
-    )
-    # Heartbeat 140s old with phase=starting: past the 120s cap (would be
-    # critical) but below the 300s starting window and its 150s high-water mark.
+    orch = _orch(workdir, session=session, heartbeat_timeout_s=120)
+    # Heartbeat 140s old with phase=starting: past the 120s timeout.
     _write_heartbeat_phase(workdir, session.id, now - 140, phase="starting")
     _write_log(workdir, session.id, 3)
-    _age_log(workdir, session.id, age_s=300)  # stale log: isolate the phase-timeout effect
-
-    findings = collect_watchdog_findings(orch)
-
-    assert [f for f in findings if f.source == "heartbeat"] == []
-
-
-def test_starting_phase_still_flags_once_past_starting_timeout(tmp_path: Path) -> None:
-    """Beyond the starting-phase window a frozen `starting` heartbeat with no
-    log activity is still flagged critical -- the larger timeout is a grace
-    window, not a permanent exemption."""
-    workdir = tmp_path
-    now = time.time()
-    session = _session("task-1", spawn_ts=now - 600)
-    orch = _orch(
-        workdir,
-        session=session,
-        heartbeat_timeout_s=120,
-        heartbeat_starting_timeout_s=300,
-    )
-    _write_heartbeat_phase(workdir, session.id, now - 360, phase="starting")  # past 300s
-    _write_log(workdir, session.id, 3)
-    _age_log(workdir, session.id, age_s=300)  # not fresh
+    _age_log(workdir, session.id, age_s=300)  # stale log: isolate the heartbeat-timeout effect
 
     findings = collect_watchdog_findings(orch)
 


### PR DESCRIPTION
## What

Remove `heartbeat_starting_timeout_s`: dead configuration that no shipped heartbeat writer can ever trigger.

## Why

The watchdog gives agents in the `starting` phase a larger, separately-configurable timeout before flagging a stale heartbeat. Both shipped writers, `heartbeat.py` and `spawner_sandbox_session.py`, hardcode `phase="implementing"` and neither ever emits `"starting"`. `_is_starting_phase` therefore can never match a real heartbeat, so `heartbeat_starting_timeout_s` has zero effect on any actual run. An operator who tunes it believes they changed watchdog behavior and did not.

Confirmed on fresh HEAD (`18ca10b5`): `grep -rn 'phase.*[:=].*"starting"' src/` returns zero hits, matching the issue.

## How

Removed the dead setting and everything downstream of it rather than wiring a synthetic writer, since no real producer of the `starting` phase exists to justify keeping the knob:

- `AgentDefaults.heartbeat_starting_timeout_s` (`defaults.py`)
- `OrchestratorConfig.heartbeat_starting_timeout_s` (`tasks/models.py`)
- `_STARTING_PHASES`, `_is_starting_phase`, and the `starting_timeout_s` parameter threaded through `collect_watchdog_findings` -> `_check_session_findings` -> `_check_heartbeat_findings` (`observability/watchdog.py`)

A heartbeat labeled `starting` is now judged by the ordinary `heartbeat_timeout_s`, same as every other phase.

`heartbeat_starting_timeout_s` has no other references anywhere in the tree (source, tests, or docs) outside the four files this PR touches, so nothing else depends on it.

## Verification

Ran in a clean Docker container (`python:3.12-slim`) against this branch:

- `tests/unit/test_watchdog.py`, `test_orchestration_watchdog.py`, `test_config_watcher.py`, `test_poll_config.py`, `test_defaults.py`, `test_manifest.py`, `tests/unit/tasks/`: 541 passed.
- Confirmed the new regression test (`test_starting_phase_heartbeat_uses_the_ordinary_timeout`, replacing the two tests that asserted the old grace-window behavior) fails against unmodified `main` and passes on this branch.
- `ruff check` and `ruff format --check` on the changed files: clean.
- `lint-imports` (architecture contracts): clean.
- `vulture src/ vulture_whitelist.py --min-confidence 80 --exclude tests,docs`: no new dead code.
- `typos`: clean on the changed files.

Not run, in plain terms: `ruff check src/` on the whole tree currently reports one pre-existing error in `identity/delegation_scope.py` unrelated to this change (confirmed present on unmodified `main` too), so I did not check that box below. `pyright src/` similarly carries a large pre-existing repo-wide backlog per `ci.yml`'s own comment ("Advisory pyright...gates nothing"); the blocking `pyright-strict-zone`/`mypy-strict-zone` jobs are scoped to `pyrightconfig.strict.json` / `mypy.gate.ini`, and none of the three files this PR touches are in either allow-list. I did not run the full `scripts/run_tests.py` (sharded across ~1.4k files in CI) or the property/snapshot suites; the exhaustive grep above is why I'm confident nothing else in the tree references the removed symbols.

Fixes #3057

## Checklist

- [x] `uv run ruff check src/` passes on every file this PR touches (one unrelated pre-existing error elsewhere in `src/` on `main`, not introduced here)
- [ ] `uv run pyright src/` (not run repo-wide; changed files are outside both gated strict zones, see Verification)
- [ ] `uv run python scripts/run_tests.py -x` (ran the specific affected test files directly under pytest instead, 541 passed; did not run the full suite, see Verification)
- [x] New code has type hints

### Documentation duty

- [x] User-visible README section updated (N/A, `heartbeat_starting_timeout_s` isn't documented in README)
- [x] `docs/operations/<area>.md` updated (N/A, not documented there either)
- [x] `docs/api/` schema regenerated (N/A, no public API surface changed)
- [x] `uv run bernstein agents-md sync` (N/A, no new module)
- [x] Tests cover the documented behaviour


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Heartbeat monitoring now uses one consistent timeout throughout all agent phases, including startup.
  * Removed the separate startup heartbeat timeout setting.
  * The default heartbeat timeout now aligns with the standard stale-heartbeat threshold.
* **Bug Fixes**
  * Updated watchdog incident detection and reporting to reflect the unified timeout behavior.
* **Tests**
  * Added coverage confirming startup heartbeats use the ordinary timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->