### PR TITLE
test(lineage): specify unverifiable foreign attestation

### DIFF
--- a/tests/unit/lineage/fixtures/foreign_attestation_unverifiable.json
+++ b/tests/unit/lineage/fixtures/foreign_attestation_unverifiable.json
@@ -1,0 +1,29 @@
+{
+  "schema": "bernstein.foreign-attestation-fixture/v1",
+  "case": "foreign-attestation-with-unverifiable-issuer",
+  "lineage_record": {
+    "artefact_path": "reports/derived-conclusion.md",
+    "external_attestation": {
+      "issuer": "https://attestor.example.invalid/issuers/demo",
+      "issuer_key_id": "ed25519:unavailable-demo-key",
+      "content_hash": "sha256:7d5d4abf09e11d7466eeb7a78d2beacdf6e423a3f2b3c80b6c4e5d6f71829304",
+      "claimed_subject": "artifact://workspace/reports/derived-conclusion.md",
+      "trust_class": "third_party",
+      "envelope": {
+        "format": "dsse-envelope-v1",
+        "payload_hash": "sha256:9420ed3bfe563e5a55b5544ad56f33cb9d3a5762bf63ae149dd619ce38f95710",
+        "signature": "not-verifiable-with-local-trust-material"
+      }
+    }
+  },
+  "local_chain": {
+    "expected_verdict": "verified",
+    "evidence_source": "bernstein-lineage-only"
+  },
+  "expected": {
+    "foreign_attestation_verdict": "unverifiable",
+    "foreign_attestation_must_not_pass": true,
+    "foreign_attestation_is_not_hmac_chain_evidence": true,
+    "derived_taint": "third_party"
+  }
+}

--- a/tests/unit/lineage/test_foreign_attestation_contract.py
+++ b/tests/unit/lineage/test_foreign_attestation_contract.py
@@ -1,23 +1,54 @@
 """Contract fixture for foreign attestations outside Bernstein's own chain.
 
-The fixture deliberately uses no AIPOU or other protocol-specific fields.  It
-pins the negative case first: when the foreign issuer cannot be independently
-verified, a future verifier must report ``unverifiable`` rather than treating
-the foreign envelope as proof from Bernstein's own lineage.
+The fixture carries the foreign envelope opaquely, by reference: only a format
+tag, a payload hash and an unreadable signature blob, so nothing below depends
+on which attestation format an issuer happens to use.
+
+It pins the negative case first.  When a foreign issuer cannot be independently
+verified, a future verifier must report ``unverifiable``.  That verdict is
+distinct from Bernstein's own verified lineage, and equally distinct from a
+signature that was evaluated and rejected.  "We could not evaluate this" and
+"we evaluated this and it failed" are different outcomes, and reporting the
+second in place of the first states a verdict on work that was never performed.
 """
 
 from __future__ import annotations
 
+import copy
 import json
+import re
 from pathlib import Path
 
 import pytest
 
 _FIXTURE_PATH = Path(__file__).with_name("fixtures") / "foreign_attestation_unverifiable.json"
 
+#: Every key a foreign attestation may carry.  An allowlist rather than a
+#: denylist of one known-bad name: a field smuggling our own chain material
+#: into a foreign envelope has to fail here whatever it ends up being called.
+_ALLOWED_ATTESTATION_KEYS = frozenset(
+    {"issuer", "issuer_key_id", "content_hash", "claimed_subject", "trust_class", "envelope"}
+)
+
+_SHA256_DIGEST = re.compile(r"sha256:[0-9a-f]{64}")
+
 
 def _fixture() -> dict[str, object]:
     return json.loads(_FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def _key_paths(node: object, prefix: str = "") -> list[str]:
+    """Return every mapping key under *node*, recursively, as dotted paths."""
+    paths: list[str] = []
+    if isinstance(node, dict):
+        for key, value in node.items():
+            path = f"{prefix}.{key}" if prefix else str(key)
+            paths.append(path)
+            paths.extend(_key_paths(value, path))
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            paths.extend(_key_paths(value, f"{prefix}[{index}]"))
+    return paths
 
 
 def test_foreign_attestation_fixture_is_protocol_neutral_and_unlinked() -> None:
@@ -30,10 +61,15 @@ def test_foreign_attestation_fixture_is_protocol_neutral_and_unlinked() -> None:
     assert isinstance(expected, dict)
 
     assert fixture["schema"] == "bernstein.foreign-attestation-fixture/v1"
+    assert set(attestation) == _ALLOWED_ATTESTATION_KEYS
     assert attestation["trust_class"] == "third_party"
-    assert str(attestation["content_hash"]).startswith("sha256:")
+    assert _SHA256_DIGEST.fullmatch(str(attestation["content_hash"])) is not None
     assert attestation["claimed_subject"]
-    assert "operator_hmac" not in attestation
+
+    # Never HMAC-chain evidence: no field anywhere beneath the record may carry
+    # our own chain material, however it is named or however deeply nested.
+    assert [path for path in _key_paths(record) if "hmac" in path.lower()] == []
+
     assert expected["foreign_attestation_is_not_hmac_chain_evidence"] is True
     assert expected["foreign_attestation_verdict"] == "unverifiable"
     assert expected["foreign_attestation_must_not_pass"] is True
@@ -41,15 +77,20 @@ def test_foreign_attestation_fixture_is_protocol_neutral_and_unlinked() -> None:
 
 
 @pytest.mark.xfail(
+    raises=ImportError,
     strict=True,
     reason="issue #3133: foreign-attestation verification is not implemented yet",
 )
 def test_unverifiable_foreign_attestation_fails_closed_without_changing_local_chain() -> None:
     """Specify the verifier contract before its implementation exists.
 
-    The import intentionally fails on current main.  When the public verifier
-    lands, this test must become an ordinary passing contract test rather than
-    allowing an unexpected pass to hide an incomplete migration.
+    The import intentionally fails on current main, and ``raises=ImportError``
+    keeps that the only tolerated failure.  A verifier that lands and reports
+    the wrong verdict raises ``AssertionError``, which this marker does not
+    absorb, so the suite turns red instead of reporting a green xfail over a
+    contract it never actually checked.  A verifier that lands and is correct
+    turns this into a strict xpass, red as well, which forces whoever
+    implements it to convert this into an ordinary contract test.
     """
     from bernstein.core.lineage.foreign_attestation import verify_foreign_attestation
 
@@ -58,11 +99,17 @@ def test_unverifiable_foreign_attestation_fails_closed_without_changing_local_ch
     assert isinstance(record, dict)
     attestation = record["external_attestation"]
     assert isinstance(attestation, dict)
+    record_before = copy.deepcopy(record)
+
     result = verify_foreign_attestation(attestation)
 
     assert result.verdict == "unverifiable"
     assert result.verified is False
     assert result.taint.value == "third_party"
+
+    # Judging the foreign claim must not write back into our own material, and
+    # our own chain verdict stands on Bernstein lineage alone.
+    assert record == record_before
     assert fixture["local_chain"] == {
         "expected_verdict": "verified",
         "evidence_source": "bernstein-lineage-only",

--- a/tests/unit/lineage/test_foreign_attestation_contract.py
+++ b/tests/unit/lineage/test_foreign_attestation_contract.py
@@ -1,0 +1,69 @@
+"""Contract fixture for foreign attestations outside Bernstein's own chain.
+
+The fixture deliberately uses no AIPOU or other protocol-specific fields.  It
+pins the negative case first: when the foreign issuer cannot be independently
+verified, a future verifier must report ``unverifiable`` rather than treating
+the foreign envelope as proof from Bernstein's own lineage.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_FIXTURE_PATH = Path(__file__).with_name("fixtures") / "foreign_attestation_unverifiable.json"
+
+
+def _fixture() -> dict[str, object]:
+    return json.loads(_FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def test_foreign_attestation_fixture_is_protocol_neutral_and_unlinked() -> None:
+    fixture = _fixture()
+    record = fixture["lineage_record"]
+    assert isinstance(record, dict)
+    attestation = record["external_attestation"]
+    assert isinstance(attestation, dict)
+    expected = fixture["expected"]
+    assert isinstance(expected, dict)
+
+    assert fixture["schema"] == "bernstein.foreign-attestation-fixture/v1"
+    assert attestation["trust_class"] == "third_party"
+    assert str(attestation["content_hash"]).startswith("sha256:")
+    assert attestation["claimed_subject"]
+    assert "operator_hmac" not in attestation
+    assert expected["foreign_attestation_is_not_hmac_chain_evidence"] is True
+    assert expected["foreign_attestation_verdict"] == "unverifiable"
+    assert expected["foreign_attestation_must_not_pass"] is True
+    assert expected["derived_taint"] == "third_party"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="issue #3133: foreign-attestation verification is not implemented yet",
+)
+def test_unverifiable_foreign_attestation_fails_closed_without_changing_local_chain() -> None:
+    """Specify the verifier contract before its implementation exists.
+
+    The import intentionally fails on current main.  When the public verifier
+    lands, this test must become an ordinary passing contract test rather than
+    allowing an unexpected pass to hide an incomplete migration.
+    """
+    from bernstein.core.lineage.foreign_attestation import verify_foreign_attestation
+
+    fixture = _fixture()
+    record = fixture["lineage_record"]
+    assert isinstance(record, dict)
+    attestation = record["external_attestation"]
+    assert isinstance(attestation, dict)
+    result = verify_foreign_attestation(attestation)
+
+    assert result.verdict == "unverifiable"
+    assert result.verified is False
+    assert result.taint.value == "third_party"
+    assert fixture["local_chain"] == {
+        "expected_verdict": "verified",
+        "evidence_source": "bernstein-lineage-only",
+    }

--- a/tests/unit/lineage/test_foreign_attestation_contract.py
+++ b/tests/unit/lineage/test_foreign_attestation_contract.py
@@ -64,7 +64,14 @@ def test_foreign_attestation_fixture_is_protocol_neutral_and_unlinked() -> None:
     assert set(attestation) == _ALLOWED_ATTESTATION_KEYS
     assert attestation["trust_class"] == "third_party"
     assert _SHA256_DIGEST.fullmatch(str(attestation["content_hash"])) is not None
-    assert attestation["claimed_subject"]
+
+    # The fields a verifier has to resolve before it can reach a verdict at
+    # all. Membership in the allowlist only proves the key is present, and an
+    # empty issuer would make this fixture a different case: "there was
+    # nothing here to check" rather than "this issuer cannot be checked".
+    for field in ("issuer", "issuer_key_id", "claimed_subject"):
+        value = attestation[field]
+        assert isinstance(value, str) and value, f"{field} must be a usable string"
 
     # Never HMAC-chain evidence: no field anywhere beneath the record may carry
     # our own chain material, however it is named or however deeply nested.


### PR DESCRIPTION
## Summary
- add a protocol-neutral fixture for a foreign attestation whose issuer cannot be verified locally
- specify that foreign `unverifiable` is distinct from Bernstein's own verified lineage, preserves `third_party` taint, and is never HMAC-chain evidence
- add the initial strict `xfail` contract test so the future public verifier is implemented against the negative case

## Validation
- `uv run pytest tests/unit/lineage/test_foreign_attestation_contract.py tests/unit/lineage/test_provenance.py -q` (`20 passed, 1 xfailed`)
- `uv run ruff check tests/unit/lineage/test_foreign_attestation_contract.py`
- `uv run ruff format --check tests/unit/lineage/test_foreign_attestation_contract.py`
- secret scan of the added files: no matches

The xfail is deliberate: main has no foreign-attestation verifier yet. It becomes an XPASS failure if an implementation appears without converting the contract test to an ordinary passing test.

Refs #3133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new fixture covering an unverifiable third-party foreign attestation caused by missing or invalid trust material (including a DSSE envelope with a non-verifiable signature).
  * Added contract tests to ensure the fixture is protocol-neutral/unlinked and that unverifiable foreign attestations fail closed.
  * Verified expected verdicts and third-party taint, and ensured the check does not alter local lineage evidence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->