### PR TITLE
fix(ci): take the review-bot-ack scripts from the base branch, not the pull request head

### DIFF
--- a/.github/workflows/review-bot-ack.yml
+++ b/.github/workflows/review-bot-ack.yml
@@ -182,10 +182,28 @@ jobs:
         with:
           egress-policy: audit
 
+      # Check out the BASE branch, never the pull request's head.
+      #
+      # Both scripts this job runs reach the pull request over the API and
+      # need nothing from its tree, so taking the head bought nothing and
+      # cost two things.
+      #
+      # Availability: the required context is published by
+      # `scripts/publish_required_check.py`, which only exists on branches
+      # cut after it landed. On an older branch the step died with
+      # "can't open file ... publish_required_check.py", so the context was
+      # never published AT ALL and the pull request sat at BLOCKED with no
+      # failing required check to point at. Four contributor pull requests
+      # were stuck this way at once.
+      #
+      # Security: this job holds `pull-requests: write` and `issues: write`.
+      # Running Python out of a fork's tree with those permissions lets the
+      # fork author execute arbitrary code against this repository. Taking
+      # the base branch removes that entirely.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.base.ref }}
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:

--- a/tests/unit/test_review_bot_ack_workflow_yaml.py
+++ b/tests/unit/test_review_bot_ack_workflow_yaml.py
@@ -127,6 +127,36 @@ def test_every_job_publishes_the_context_through_the_api(
         )
 
 
+def test_no_job_checks_out_the_pull_request_head(
+    gate_doc: dict[str, object],
+) -> None:
+    """INV-2b. The scripts must come from the base branch, never the head.
+
+    Two independent reasons, either one sufficient:
+
+    Availability. ``scripts/publish_required_check.py`` only exists on
+    branches cut after it landed. Checking out an older head made the
+    publish step die with "can't open file", so the required context was
+    never published at all and the pull request sat at BLOCKED with no
+    failing required check to point at.
+
+    Security. These jobs hold ``pull-requests: write`` and
+    ``issues: write``. Running Python out of a fork's tree with those
+    permissions would let the fork author execute arbitrary code against
+    this repository.
+    """
+    for key, job in _jobs(gate_doc).items():
+        for step in _steps(job):
+            if "checkout" not in str(step.get("uses", "")):
+                continue
+            ref = str((step.get("with") or {}).get("ref", ""))
+            assert "pull_request.head" not in ref, (
+                f"job {key!r} checks out the pull request head ({ref!r}). Both scripts reach the pull request "
+                "over the API and need nothing from its tree; use the base ref so the publisher always exists "
+                "and a fork cannot run code under this job's write permissions."
+            )
+
+
 def test_publish_is_skipped_while_a_job_is_being_cancelled(
     gate_doc: dict[str, object],
 ) -> None:


### PR DESCRIPTION
The PR-stage job checked out the pull request head and ran both of its scripts from that tree. Neither needs it: both reach the pull request over the API.

## Availability, which is blocking contributors right now

\`scripts/publish_required_check.py\` only exists on branches cut after #3179 landed. On an older head the step dies:

\`\`\`
python3: cannot open file .../scripts/publish_required_check.py: [Errno 2] No such file or directory
##[error]Process completed with exit code 2
\`\`\`

The publisher never runs, so the required \`review-bot-ack\` context is **never published at all**. The pull request then reads \`MERGEABLE/BLOCKED\` with no failing required check to point at: the only red is \`review-bot-ack-runner\`, which is not itself a required context. There is nothing on the page that says why it cannot merge.

Four contributor pull requests are stuck this way at the time of writing (#3190, #3191, #3192, #3193), plus every other branch cut before #3179. Updating each branch clears it one at a time; this fixes the cause.

## Security

These jobs hold \`pull-requests: write\` and \`issues: write\`. Executing Python out of a fork's tree under those permissions lets the fork author run arbitrary code against this repository. Taking the base ref removes that path entirely, and it costs nothing because the scripts were never using the checked-out tree for anything.

## Guard

\`test_no_job_checks_out_the_pull_request_head\` fails if any job in this workflow takes the head again. Proved by mutation rather than asserted: red against the current \`main\` workflow file, green with this change.

\`\`\`
FAILED tests/unit/test_review_bot_ack_workflow_yaml.py::test_no_job_checks_out_the_pull_request_head   # main
15 passed                                                                                              # with the fix
\`\`\`

27 tests pass across the review-bot-ack, topology-report and required-check-canary suites. \`docs/operations/ci-topology.md\` regenerated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request review workflow security by using the base branch when checking out code.
  * Prevented workflow jobs from executing code sourced from pull request forks while retaining required review permissions.

* **Tests**
  * Added automated validation to ensure checkout steps never reference pull request head commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->