### PR TITLE
chore(ci): ratchet coverage baseline up to 82.62%

### DIFF
--- a/.coverage-baseline.json
+++ b/.coverage-baseline.json
@@ -1,5 +1,5 @@
 {
   "diff_coverage_floor_percent": 85,
-  "total_coverage_percent": 82.31,
-  "updated_at": "2026-07-26T05:15:31+00:00"
+  "total_coverage_percent": 82.62,
+  "updated_at": "2026-07-27T04:19:19+00:00"
 }


### PR DESCRIPTION
Total line coverage rose on `main`, so the monotonic ratchet
bumped the committed high-water mark in `.coverage-baseline.json`
to **82.62%**.

From here, any later push whose total coverage falls below this
mark is flagged by the LEVEL 2 ratchet. The gate stays advisory
until promoted; see `docs/operations/coverage-ratchet.md`.

Generated by `.github/workflows/coverage-ratchet.yml`.

## Summary by Sourcery

Build:
- Adjust the coverage baseline configuration so future runs enforce an 82.62% minimum line coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the recorded test coverage baseline to reflect the latest coverage results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->