### PR TITLE
fix(ci): publish the review-bot-ack context from a workflow_run so fork pull requests can pass it

### DIFF
--- a/.github/workflows/review-bot-ack-publish.yml
+++ b/.github/workflows/review-bot-ack-publish.yml
@@ -1,0 +1,128 @@
+name: Review-bot acknowledgement publisher
+
+# Publishes the required `review-bot-ack` context on behalf of
+# `review-bot-ack.yml`.
+#
+# Why this workflow exists at all: a `pull_request` event raised from a fork
+# receives a read-only GITHUB_TOKEN, and a job-level `permissions:` block
+# cannot raise it. That cap is GitHub's. The gate job therefore computes a
+# correct verdict and then fails with
+# `403 Resource not accessible by integration` when it tries to write the
+# check-run, leaving the required context ABSENT. An absent required context
+# reads as blocked with nothing on the page to point at, so every external
+# contribution was unmergeable no matter what its author did.
+#
+# `workflow_run` runs in the base repository's context with the base token,
+# so `checks: write` here is real for a fork pull request as well.
+#
+# Trust boundary. The gate job runs on the fork's head, so its artifact is
+# attacker-influenced input. Two rules keep that harmless:
+#
+#   1. The SHA is taken from `github.event.workflow_run.head_sha`, never from
+#      the artifact. Otherwise a fork could claim `success` for a commit on
+#      another pull request.
+#   2. The conclusion is accepted only if it is exactly `success`. Anything
+#      else, including a missing artifact, a malformed one, or a gate run
+#      that did not conclude successfully, publishes `failure`. Fail closed.
+#
+# Nothing from the artifact is ever executed, and no repository content from
+# the head is checked out here.
+
+on:  # zizmor: ignore[dangerous-triggers]
+  workflow_run:
+    workflows: ["Review-bot acknowledgement gate"]
+    types: [completed]
+
+concurrency:
+  group: review-bot-ack-publish-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  publish:
+    name: review-bot-ack-publisher
+    # merge_group runs of the gate publish their own context in-repo, where
+    # the token is already writable. Only pull-request runs need this hop.
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: read
+      checks: write
+      contents: read
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      # The base branch, never the head. The publisher script must be the
+      # one this repository ships, not one a fork supplied.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.13"
+
+      - name: Download the verdict artifact
+        id: fetch
+        continue-on-error: true
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: review-bot-ack-verdict
+          path: verdict
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Resolve the conclusion, failing closed
+        env:
+          GATE_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          EVENT_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          # Fail closed on every path that is not an explicit, matching
+          # success: a gate run that did not succeed, a missing or unreadable
+          # artifact, a conclusion that is not the literal string `success`,
+          # or a head SHA that disagrees with the event's own.
+          verdict=failure
+          reason="the gate run concluded ${GATE_CONCLUSION}"
+
+          if [ "$GATE_CONCLUSION" = "success" ] && [ -r verdict/conclusion ] && [ -r verdict/head_sha ]; then
+            claimed_sha="$(tr -d '[:space:]' < verdict/head_sha)"
+            claimed="$(tr -d '[:space:]' < verdict/conclusion)"
+            if [ "$claimed_sha" != "$EVENT_SHA" ]; then
+              reason="the artifact named ${claimed_sha:-an empty SHA}, the event names ${EVENT_SHA}"
+            elif [ "$claimed" != "success" ]; then
+              reason="the gate reported ${claimed:-an empty conclusion}"
+            else
+              verdict=success
+              reason="the gate passed on ${EVENT_SHA}"
+            fi
+          elif [ "$GATE_CONCLUSION" = "success" ]; then
+            reason="the gate run succeeded but published no readable verdict artifact"
+          fi
+
+          echo "VERDICT=$verdict" >> "$GITHUB_ENV"
+          echo "REASON=$reason" >> "$GITHUB_ENV"
+          echo "resolved $verdict: $reason"
+
+      - name: Publish the review-bot-ack context on the head commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          GATE_RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          set -euo pipefail
+          python3 scripts/publish_required_check.py \
+            --repo "$REPO" \
+            --sha "$HEAD_SHA" \
+            --name review-bot-ack \
+            --conclusion "$VERDICT" \
+            --title "Review-bot acknowledgement gate" \
+            --summary "Every must-address CodeRabbit and Sourcery finding must be fixed in a later commit or acknowledged in the PR body. Resolved as ${VERDICT}: ${REASON}. See the sticky summary comment on the pull request for the per-finding breakdown." \
+            --details-url "$GATE_RUN_URL"

--- a/.github/workflows/review-bot-ack.yml
+++ b/.github/workflows/review-bot-ack.yml
@@ -238,25 +238,36 @@ jobs:
           fi
           echo "VERDICT=$verdict" >> "$GITHUB_ENV"
 
-      - name: Publish the review-bot-ack context on the head commit
-        # Never publish while being cancelled: a cancelled job has no verdict,
-        # and an absent required context correctly reads as blocked.
+      # The verdict is handed to `review-bot-ack-publish.yml` rather than
+      # published here.
+      #
+      # A `pull_request` event raised from a fork gets a read-only
+      # GITHUB_TOKEN, and a `permissions:` block cannot raise it: that cap is
+      # GitHub's, not ours. Publishing from this job therefore failed with
+      # `403 Resource not accessible by integration` on every fork pull
+      # request, which left the required context absent and the contribution
+      # permanently unmergeable. Measured on one day: four fork pull requests
+      # got 403, the one same-repo pull request published fine.
+      #
+      # `workflow_run` runs in the base repository's context with the base
+      # token, so the publisher there can hold `checks: write` for a fork
+      # pull request exactly as it does for a branch one.
+      - name: Hand the verdict to the publisher
         if: ${{ !cancelled() }}
         env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
-          python3 scripts/publish_required_check.py \
-            --repo "$REPO" \
-            --sha "$HEAD_SHA" \
-            --name review-bot-ack \
-            --conclusion "$VERDICT" \
-            --title "Review-bot acknowledgement gate" \
-            --summary "Every must-address CodeRabbit and Sourcery finding must be fixed in a later commit or acknowledged in the PR body. See the sticky summary comment on the pull request for the per-finding breakdown." \
-            --details-url "$RUN_URL"
+          mkdir -p verdict
+          printf '%s\n' "$VERDICT" > verdict/conclusion
+          printf '%s\n' "$HEAD_SHA" > verdict/head_sha
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ !cancelled() }}
+        with:
+          name: review-bot-ack-verdict
+          path: verdict/
+          retention-days: 1
 
       - name: Reflect the verdict in this job
         if: ${{ !cancelled() }}

--- a/.github/workflows/review-bot-ack.yml
+++ b/.github/workflows/review-bot-ack.yml
@@ -269,6 +269,44 @@ jobs:
           path: verdict/
           retention-days: 1
 
+      # Best-effort direct publish, kept alongside the handoff for two
+      # reasons.
+      #
+      # Bootstrap: `workflow_run` only fires for workflows that exist on the
+      # default branch, so a pull request that introduces or edits the
+      # companion publisher cannot be published by it and would be unable to
+      # satisfy its own required context.
+      #
+      # Latency: a same-repo pull request gets the context immediately here
+      # rather than after a second workflow schedules.
+      #
+      # `continue-on-error` is what makes this safe to keep. On a fork the
+      # token is read-only and this step 403s; swallowing that is correct,
+      # because the `workflow_run` publisher is the authoritative path and
+      # would otherwise see a failed gate run and publish `failure` for a
+      # pull request that actually passed. The publish script upserts a
+      # single terminal check-run per head SHA, so both paths running is
+      # idempotent rather than duplicative.
+      - name: Publish directly when the token allows it
+        id: direct_publish
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          python3 scripts/publish_required_check.py \
+            --repo "$REPO" \
+            --sha "$HEAD_SHA" \
+            --name review-bot-ack \
+            --conclusion "$VERDICT" \
+            --title "Review-bot acknowledgement gate" \
+            --summary "Every must-address CodeRabbit and Sourcery finding must be fixed in a later commit or acknowledged in the PR body. See the sticky summary comment on the pull request for the per-finding breakdown." \
+            --details-url "$RUN_URL"
+
       - name: Reflect the verdict in this job
         if: ${{ !cancelled() }}
         run: |

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -60,6 +60,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/reconcile-release.yml | Reconcile release drift | schedule, workflow_dispatch | {"cancel-in-progress": "false", "group": "reconcile-release"} | 1 |
 | .github/workflows/release-major-minor.yml | Major/Minor Release | workflow_dispatch | {"cancel-in-progress": "false", "group": "release-major-minor-${{ github.ref }}"} | 1 |
 | .github/workflows/required-check-canary.yml | Required-check name canary | pull_request, schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "required-check-canary-${{ github.event.pull_request.number \|\| github.ref }}"} | 1 |
+| .github/workflows/review-bot-ack-publish.yml | Review-bot acknowledgement publisher | workflow_run | {"cancel-in-progress": "false", "group": "review-bot-ack-publish-${{ github.event.workflow_run.head_sha }}"} | 1 |
 | .github/workflows/review-bot-ack.yml | Review-bot acknowledgement gate | merge_group, pull_request, pull_request_review | {"cancel-in-progress": "true", "group": "review-bot-ack-${{ github.event.pull_request.number \|\| github.ref }}"} | 2 |
 | .github/workflows/review-bot-sweep.yml | Review-bot post-merge sweep | schedule, workflow_dispatch | - | 1 |
 | .github/workflows/sbom.yml | SBOM | release, workflow_dispatch | {"cancel-in-progress": "false", "group": "sbom-${{ github.ref }}"} | 1 |
@@ -126,6 +127,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/reconcile-release.yml | reconcile: Compare pyproject.toml vs PyPI |
 | .github/workflows/release-major-minor.yml | release: ${{ inputs.bump }} release |
 | .github/workflows/required-check-canary.yml | verify: Required-check name canary |
+| .github/workflows/review-bot-ack-publish.yml | publish: review-bot-ack-publisher |
 | .github/workflows/review-bot-ack.yml | merge-group-verify: review-bot-ack-queue-verify<br>pr-gate: review-bot-ack-runner |
 | .github/workflows/review-bot-sweep.yml | sweep: Sweep recently merged PRs for unprocessed bot findings |
 | .github/workflows/sbom.yml | sbom: Generate SBOM |
@@ -192,6 +194,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/reconcile-release.yml | reconcile: {"contents": "read", "issues": "write"} | - |
 | .github/workflows/release-major-minor.yml | workflow: {"contents": "read"}<br>release: {"attestations": "write", "contents": "write", "id-token": "write"} | GITHUB_TOKEN |
 | .github/workflows/required-check-canary.yml | verify: {"contents": "read"} | - |
+| .github/workflows/review-bot-ack-publish.yml | publish: {"actions": "read", "checks": "write", "contents": "read"} | - |
 | .github/workflows/review-bot-ack.yml | merge-group-verify: {"checks": "write", "contents": "read", "pull-requests": "read"}<br>pr-gate: {"checks": "write", "contents": "read", "issues": "write", "pull-requests": "write"} | - |
 | .github/workflows/review-bot-sweep.yml | sweep: {"contents": "write", "pull-requests": "write"} | GITHUB_TOKEN, LANDING_REPO_PAT |
 | .github/workflows/sbom.yml | workflow: {"contents": "read"}<br>sbom: {"contents": "write"} | - |
@@ -231,6 +234,8 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/nightly-deep-tests.yml | bandit-medium-and-high: upload nightly-bandit-results<br>mutmut-full: upload nightly-mutmut-results |
 | .github/workflows/pentest.yml | pentest: upload pentest-results-${{ github.run_number }} |
 | .github/workflows/publish.yml | build: upload dist<br>github-release: download dist<br>publish: download dist |
+| .github/workflows/review-bot-ack-publish.yml | publish: download review-bot-ack-verdict |
+| .github/workflows/review-bot-ack.yml | pr-gate: upload review-bot-ack-verdict |
 | .github/workflows/sbom.yml | sbom: upload sbom |
 | .github/workflows/scorecard.yml | analysis: upload scorecard-results<br>upload: download scorecard-results |
 | .github/workflows/soc2-evidence-nightly.yml | pack: upload soc2-evidence-${{ github.run_id }} |

--- a/tests/unit/test_review_bot_ack_workflow_yaml.py
+++ b/tests/unit/test_review_bot_ack_workflow_yaml.py
@@ -29,6 +29,7 @@ except ModuleNotFoundError:  # pragma: no cover - dev env should have pyyaml
 
 
 GATE_WF = Path(".github/workflows/review-bot-ack.yml")
+PUBLISH_WF = Path(".github/workflows/review-bot-ack-publish.yml")
 SWEEP_WF = Path(".github/workflows/review-bot-sweep.yml")
 GATE_SCRIPT = Path("scripts/review_bot_ack.py")
 SWEEP_SCRIPT = Path("scripts/review_bot_sweep.py")
@@ -37,11 +38,17 @@ PUBLISH_SCRIPT = Path("scripts/publish_required_check.py")
 # The context branch protection requires on `main`.
 CONTEXT = "review-bot-ack"
 PUBLISHER = "scripts/publish_required_check.py"
+VERDICT_ARTIFACT = "review-bot-ack-verdict"
 
 
 @pytest.fixture(scope="module")
 def gate_doc() -> dict[str, object]:
     return yaml.safe_load(GATE_WF.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def publish_doc() -> dict[str, object]:
+    return yaml.safe_load(PUBLISH_WF.read_text(encoding="utf-8"))
 
 
 @pytest.fixture(scope="module")
@@ -111,19 +118,103 @@ def test_no_job_is_named_after_the_required_context(
     )
 
 
-def test_every_job_publishes_the_context_through_the_api(
+def test_every_verdict_path_ends_in_an_api_publish(
     gate_doc: dict[str, object],
+    publish_doc: dict[str, object],
 ) -> None:
-    """INV-2. Each job must write the verdict explicitly, with `checks: write`."""
+    """INV-2. Every job that resolves a verdict must reach an explicit publish.
+
+    A job either publishes the context itself, which needs `checks: write`,
+    or hands the verdict to the companion `workflow_run` publisher, which
+    publishes on its behalf. Nothing may resolve a verdict and stop.
+
+    The handoff exists because a `pull_request` event raised from a fork
+    gets a read-only GITHUB_TOKEN that a `permissions:` block cannot raise,
+    so publishing in-job returned 403 for every external contribution and
+    left the required context absent.
+    """
     jobs = _jobs(gate_doc)
     assert jobs, "workflow must define jobs"
     for key, job in jobs.items():
         script = _run_script(job)
-        assert PUBLISHER in script, f"job {key!r} does not publish the required context via {PUBLISHER}"
-        assert f"--name {CONTEXT}" in script, f"job {key!r} publishes some other context name"
+        publishes = PUBLISHER in script
+        hands_off = any(VERDICT_ARTIFACT in str((step.get("with") or {}).get("name", "")) for step in _steps(job))
+        assert publishes or hands_off, (
+            f"job {key!r} resolves a verdict but neither publishes it via {PUBLISHER} nor uploads it as "
+            f"the {VERDICT_ARTIFACT!r} artifact for the companion publisher"
+        )
+        if publishes:
+            assert f"--name {CONTEXT}" in script, f"job {key!r} publishes some other context name"
+            perms = job.get("permissions")
+            assert isinstance(perms, dict) and perms.get("checks") == "write", (
+                f"job {key!r} needs checks:write to publish the required context"
+            )
+
+    pub_jobs = _jobs(publish_doc)
+    assert pub_jobs, "the companion publisher must define a job"
+    for key, job in pub_jobs.items():
+        script = _run_script(job)
+        assert PUBLISHER in script and f"--name {CONTEXT}" in script, (
+            f"publisher job {key!r} must publish {CONTEXT!r} via {PUBLISHER}"
+        )
         perms = job.get("permissions")
-        assert isinstance(perms, dict) and perms.get("checks") == "write", (
-            f"job {key!r} needs checks:write to publish the required context"
+        assert isinstance(perms, dict) and perms.get("checks") == "write", f"publisher job {key!r} needs checks:write"
+
+
+def test_publisher_runs_on_workflow_run_of_the_gate(
+    publish_doc: dict[str, object],
+) -> None:
+    """INV-2c. The publisher must run in the base context, not the head's.
+
+    `workflow_run` is what makes the token writable for a fork pull
+    request. Any other trigger reintroduces the 403.
+    """
+    on = _on(publish_doc)
+    run = on.get("workflow_run")
+    assert isinstance(run, dict), "publisher must be triggered by workflow_run"
+    assert "Review-bot acknowledgement gate" in (run.get("workflows") or []), (
+        "publisher must key off the gate workflow by name"
+    )
+
+
+def test_publisher_pins_the_sha_to_the_event_not_the_artifact(
+    publish_doc: dict[str, object],
+) -> None:
+    """INV-2d. The published SHA comes from the event, never from the fork.
+
+    The verdict artifact is written by a job running on the fork's head, so
+    it is attacker-influenced. If the publisher took the SHA from it, a fork
+    could publish `success` onto a commit belonging to a different pull
+    request. The event's own `head_sha` is not forgeable that way.
+    """
+    for key, job in _jobs(publish_doc).items():
+        for step in _steps(job):
+            if PUBLISHER not in str(step.get("run", "")):
+                continue
+            env = {k: str(v) for k, v in (step.get("env") or {}).items()}
+            sha_source = env.get("HEAD_SHA", "")
+            assert "workflow_run.head_sha" in sha_source, (
+                f"publisher job {key!r} takes the SHA from {sha_source!r}; it must come from "
+                "github.event.workflow_run.head_sha so a fork cannot name someone else's commit"
+            )
+
+
+def test_publisher_fails_closed(publish_doc: dict[str, object]) -> None:
+    """INV-2e. Anything short of an explicit match publishes failure.
+
+    A missing artifact, an unreadable one, a conclusion that is not the
+    literal `success`, a SHA that disagrees with the event, or a gate run
+    that did not itself succeed must all resolve to `failure`.
+    """
+    for key, job in _jobs(publish_doc).items():
+        script = _run_script(job)
+        if PUBLISHER not in script:
+            continue
+        assert "verdict=failure" in script, (
+            f"publisher job {key!r} must default the verdict to failure before any check succeeds"
+        )
+        assert "workflow_run.conclusion" in str(job), (
+            f"publisher job {key!r} must refuse to publish success when the gate run did not succeed"
         )
 
 

--- a/tests/unit/test_review_bot_ack_workflow_yaml.py
+++ b/tests/unit/test_review_bot_ack_workflow_yaml.py
@@ -218,6 +218,38 @@ def test_publisher_fails_closed(publish_doc: dict[str, object]) -> None:
         )
 
 
+def test_direct_publish_never_fails_the_gate_job(
+    gate_doc: dict[str, object],
+) -> None:
+    """INV-2f. The in-job publish must be best effort, never load bearing.
+
+    It is kept for two reasons. `workflow_run` only fires for workflows
+    present on the default branch, so a pull request that introduces or
+    edits the companion publisher cannot be published by it and could not
+    satisfy its own required context. And a same-repo pull request gets the
+    context immediately rather than after a second workflow schedules.
+
+    On a fork the token is read-only and this step 403s. If that failure
+    propagated, the gate run would conclude `failure`, and the authoritative
+    `workflow_run` publisher would then publish `failure` for a pull request
+    that actually passed. So the step must carry `continue-on-error`.
+    """
+    for key, job in _jobs(gate_doc).items():
+        for step in _steps(job):
+            if PUBLISHER not in str(step.get("run", "")):
+                continue
+            hands_off = any(VERDICT_ARTIFACT in str((s.get("with") or {}).get("name", "")) for s in _steps(job))
+            if not hands_off:
+                # A job with no handoff has nothing else to publish for it,
+                # so its publish is load bearing and must not be swallowed.
+                continue
+            assert step.get("continue-on-error") is True, (
+                f"job {key!r} both hands the verdict off and publishes directly, so the direct publish must "
+                "carry continue-on-error: a fork's read-only token makes it 403, and letting that fail the "
+                "job would make the workflow_run publisher report failure for a passing pull request"
+            )
+
+
 def test_no_job_checks_out_the_pull_request_head(
     gate_doc: dict[str, object],
 ) -> None:


### PR DESCRIPTION
Follow-up to #3195, which fixed the script being missing. This fixes the wall behind it.

## No external contribution could pass the required gate

A `pull_request` event raised from a fork receives a **read-only** `GITHUB_TOKEN`, and a job-level `permissions:` block cannot raise it. That cap is GitHub's, not our configuration. So the gate job computed a correct verdict and then died on the write:

```
- Must-address findings: 0 (0 acknowledged, 0 open)
  All must-address findings are resolved or acknowledged.
...
error: POST /repos/.../check-runs failed: 403
       {"message":"Resource not accessible by integration"}
```

The required `review-bot-ack` context was therefore **never published**. An absent required context reads as BLOCKED with nothing on the page to point at: the only red is `review-bot-ack-runner`, which is not itself required. No fork pull request could merge regardless of its content, and no rebase or rerun could help.

The natural experiment on one day is unambiguous:

| Pull request | Fork | Context published |
|---|---|---|
| #3190, #3191, #3192, #3193 | yes | **403** |
| #3196 | no | success |

## The fix

The gate uploads its verdict as an artifact; a `workflow_run` companion publishes it. `workflow_run` executes in the base repository context with the base token, so `checks: write` is real there for a fork pull request too. This is the documented pattern for exactly this constraint, and the repository already uses it for `post-ci-dispatcher`, `auto-release` and `coverage-ratchet`.

## Trust boundary

The verdict artifact is written by a job running on the fork's head, so it is attacker-influenced input. Two rules keep that harmless, and both are guarded:

- **The SHA comes from `github.event.workflow_run.head_sha`, never from the artifact.** Otherwise a fork could publish `success` onto a commit belonging to someone else's pull request.
- **Anything other than an exact `success` match publishes `failure`.** A missing artifact, an unreadable one, a conclusion that is not the literal string, a SHA that disagrees with the event, or a gate run that did not itself succeed all fail closed.

Nothing from the artifact is executed and no head content is checked out in the publisher.

## Guards, proved by mutation rather than asserted

| Mutation applied | Guard that caught it |
|---|---|
| publisher takes the SHA from the artifact | `test_publisher_pins_the_sha_to_the_event_not_the_artifact` |
| publisher defaults the verdict to `success` | `test_publisher_fails_closed` |
| publisher triggered by `pull_request` instead of `workflow_run` | `test_publisher_runs_on_workflow_run_of_the_gate` |

The pre-existing INV-2 guard was rewritten rather than relaxed: it now requires every job that resolves a verdict to either publish it or hand it off, and separately requires the companion publisher to publish through the same script with `checks: write`.

88 tests pass across the review-bot-ack, required-check-canary, pull-request-concurrency and topology-report suites. `docs/operations/ci-topology.md` regenerated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Improved pull request validation for fork-based contributions by reliably publishing the required review acknowledgment check.
  * Added fail-closed handling so missing, invalid, or mismatched validation results are reported as failures.
  * Preserved successful validation results even when direct publishing is unavailable.

* **Documentation**
  * Updated CI topology documentation to describe the new validation handoff and permissions.

* **Tests**
  * Added coverage for workflow wiring, verdict handoff, SHA verification, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->