### PR TITLE
test(ci): hold the branch push to the same token standard as the pull request

### DIFF
--- a/docs/operations/ci.md
+++ b/docs/operations/ci.md
@@ -293,7 +293,20 @@ token: ${{ secrets.BERNSTEIN_AUTOSYNC_TOKEN || secrets.GITHUB_TOKEN }}
 
 The same token is used for the branch push in those lanes, because a push
 made with the Actions token emits no `pull_request: synchronize` either,
-which would leave a re-pushed branch showing stale checks.
+which would leave a re-pushed branch showing stale checks. A lane that
+opened correctly and then re-pushed with the Actions token would be worse
+off than the original bug: the rollup would read green against a
+superseded commit rather than reading empty. Two shapes carry the token
+to git, and both are accepted:
+
+| Shape | Lanes | How git gets the token |
+|-------|-------|------------------------|
+| Persisted checkout credential | `adapter-conformance-canary`, `bernstein-ci-fix`, `nightly-drift-sweep` | `actions/checkout` is given the same `token:` expression and leaves it in `.git/config` |
+| Explicit auth header | `auto-heal`, `bernstein-issues-decompose` | the step checks out with `persist-credentials: false`, then sets `http.https://github.com/.extraheader` from `$GH_TOKEN` and unsets it on exit |
+
+Passing `persist-credentials: false` without setting the header leaves the
+push with no credential at all, which fails loudly rather than silently,
+so it is treated as a failure by the same guard.
 
 **What degrades without the secret.** On a fork, or in any environment
 where `BERNSTEIN_AUTOSYNC_TOKEN` is unset, the expression falls through to
@@ -306,9 +319,19 @@ gets a `CI gate`; that dispatch is skipped when the secret is present, to
 avoid a duplicate full-matrix run.
 
 `tests/unit/test_bot_pull_request_tokens_yaml.py` discovers the
-pull-request-opening steps from the workflow directory rather than from a
-list, so a new automation lane cannot reintroduce the Actions token
-without failing the unit suite.
+pull-request-opening steps rather than reading them from a list, so a new
+automation lane cannot reintroduce the Actions token without failing the
+unit suite. It sweeps `.github/workflows/*.yml` **and** the composite
+actions under `.github/actions/*/action.yml`, and recognises four ways to
+open a pull request: `peter-evans/create-pull-request`, `gh pr create`,
+`gh api -X POST .../pulls`, and an `actions/github-script` step calling
+`pulls.create`. The last two match nothing today; they are covered because
+a lane that reaches for the API instead of the porcelain is the cheapest
+way to reintroduce the bug past a guard that only knows two spellings.
+The same module resolves the credential each lane pushes its branch with
+and holds it to the same standard, and asserts the discovered set of lanes
+exactly, so a widened matcher cannot quietly demand a PAT of a lane that
+only reads pull requests.
 
 ### What the pool actually spends
 

--- a/tests/unit/test_bot_pull_request_tokens_yaml.py
+++ b/tests/unit/test_bot_pull_request_tokens_yaml.py
@@ -17,15 +17,45 @@ than from a list. A new automation lane that copies the old shape is caught by
 the same assertion that catches the current ones, without anyone remembering to
 extend a fixture.
 
-Two step shapes count as opening a pull request:
+Four step shapes count as opening a pull request:
 
 * ``uses: peter-evans/create-pull-request@...`` - the token is ``with.token``;
 * a ``run:`` block invoking ``gh pr create`` - the token is ``GH_TOKEN`` (or
-  ``GITHUB_TOKEN``) resolved from the step, then the job, then the workflow.
+  ``GITHUB_TOKEN``) resolved from the step, then the job, then the workflow;
+* a ``run:`` block POSTing to the ``.../pulls`` collection through ``gh api``,
+  which is the same call one layer down and takes the same token;
+* ``uses: actions/github-script@...`` whose script calls ``pulls.create`` -
+  the token is ``with.github-token``, which **defaults to the Actions token**,
+  so omitting it is the failure rather than a neutral choice.
+
+The last two shapes match nothing in the tree today. They are here because the
+guard is only worth having if it survives the next lane, and a lane that opens
+its pull request through the API instead of the porcelain is not an exotic
+hypothetical: ``issue_to_pr.py`` already opens pull requests with
+``gh api -X POST repos/{repo}/pulls`` in library code. Nothing stops that call
+from being lifted into a workflow, and a guard that only knows two spellings
+would report success while the lane it was written to protect went unchecked.
+
+The sweep covers composite actions under ``.github/actions`` as well as
+``.github/workflows``. A composite action has ``runs.steps`` rather than
+``jobs.<id>.steps``, so a pull-request step hidden behind ``uses: ./.github/
+actions/<name>`` is invisible to a workflow-only sweep while being just as
+capable of opening a pull request with the wrong token.
 
 Comment lines are stripped from ``run:`` blocks before matching, so a workflow
 that only *describes* ``gh pr create`` in a comment - ``auto-release.yml``
 explains why it stopped calling it - is not mistaken for one that calls it.
+
+Opening the pull request with a triggering token is necessary but not
+sufficient. The branch has to be pushed with one too: a push made with the
+Actions token emits no ``pull_request: synchronize``, so a lane that opens
+correctly and then re-pushes incorrectly leaves an open pull request whose
+checks describe an older commit. That is worse than the original bug, because
+the rollup reads green against the wrong SHA rather than reading empty. The
+push credential is resolved the way git resolves it: an explicit
+``http.https://github.com/.extraheader`` if the step sets one, otherwise the
+credential ``actions/checkout`` persisted, which is ``github.token`` unless the
+step passed something else.
 
 The last assertion here is the one that is easiest to get wrong. A reusable
 workflow (``on: workflow_call``) sees only the secrets its caller passed:
@@ -51,9 +81,31 @@ except ModuleNotFoundError:  # pragma: no cover - dev env should have pyyaml
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _WORKFLOW_DIR = _REPO_ROOT / ".github" / "workflows"
+_ACTION_DIR = _REPO_ROOT / ".github" / "actions"
 
 _CREATE_PR_ACTION = "peter-evans/create-pull-request"
 _CREATE_PR_COMMAND = re.compile(r"\bgh\s+pr\s+create\b")
+
+# `gh api -X POST .../pulls` is `gh pr create` one layer down. The negative
+# lookahead keeps reads of a single pull request (`/pulls/123`, `/pulls/123/
+# files`) out, and the POST requirement keeps `commits/<sha>/pulls` out, which
+# is a collection-shaped path that `bisect-on-red.yml` only ever GETs.
+_GH_API_COMMAND = re.compile(r"\bgh\s+api\b")
+_GH_API_POST = re.compile(r"(?:^|\s)(?:-X\s*|--method[= ]\s*)POST\b")
+_PULLS_COLLECTION = re.compile(r"/pulls(?![/\w])")
+
+# `actions/github-script` exposes an authenticated Octokit. Its `github-token`
+# input defaults to the Actions token, so a step that omits it opens the pull
+# request with exactly the token this module exists to forbid.
+_GITHUB_SCRIPT_ACTION = "actions/github-script"
+_GITHUB_SCRIPT_CREATE_PR = re.compile(r"\bpulls\s*\.\s*create\s*\(")
+_GITHUB_SCRIPT_DEFAULT_TOKEN = "${{ github.token }}"
+
+# The branch push. Either the step configures git's auth header explicitly, or
+# it relies on the credential `actions/checkout` persisted.
+_GIT_PUSH = re.compile(r"\bgit\s+push\b")
+_EXTRAHEADER_TOKEN_VAR = re.compile(r"x-access-token:%s['\"]?\s+[\"']?\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?")
+_CHECKOUT_ACTION = "actions/checkout"
 
 # The Actions token under either spelling. Both are suppressed as a workflow
 # trigger; `github.token` is not a safe alternative to `secrets.GITHUB_TOKEN`.
@@ -88,41 +140,91 @@ def _workflow_files() -> list[Path]:
     return sorted(p for p in _WORKFLOW_DIR.glob("*.yml") if p.is_file())
 
 
-def _pr_opening_steps() -> list[tuple[str, str, str, str | None]]:
-    """Return ``(workflow, job, step, token_expression)`` for every PR opener."""
-    found: list[tuple[str, str, str, str | None]] = []
-    for path in _workflow_files():
-        workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
-        if not isinstance(workflow, dict):
-            continue
-        jobs = workflow.get("jobs")
-        if not isinstance(jobs, dict):
-            continue
+def _action_files() -> list[Path]:
+    """Composite actions, which carry ``runs.steps`` instead of ``jobs``."""
+    if not _ACTION_DIR.is_dir():
+        return []
+    found = [p for suffix in ("yml", "yaml") for p in _ACTION_DIR.glob(f"*/action.{suffix}")]
+    return sorted(p for p in found if p.is_file())
+
+
+def _step_containers(document: dict[str, Any]) -> list[tuple[str, dict[str, Any], list[Any]]]:
+    """Return ``(container_name, container, steps)`` for a workflow or action."""
+    containers: list[tuple[str, dict[str, Any], list[Any]]] = []
+    jobs = document.get("jobs")
+    if isinstance(jobs, dict):
         for job_name, job in jobs.items():
-            if not isinstance(job, dict):
+            if isinstance(job, dict) and isinstance(job.get("steps"), list):
+                containers.append((str(job_name), job, job["steps"]))
+    runs = document.get("runs")
+    if isinstance(runs, dict) and isinstance(runs.get("steps"), list):
+        containers.append(("runs", runs, runs["steps"]))
+    return containers
+
+
+def _step_label(step: dict[str, Any], index: int) -> str:
+    return str(step.get("name") or step.get("id") or f"step[{index}]")
+
+
+def _openers_in_document(name: str, document: Any) -> list[tuple[str, str, str, str | None]]:
+    """Return ``(file, container, step, token_expression)`` for every PR opener."""
+    if not isinstance(document, dict):
+        return []
+    found: list[tuple[str, str, str, str | None]] = []
+    for container_name, container, steps in _step_containers(document):
+        for index, step in enumerate(steps):
+            if not isinstance(step, dict):
                 continue
-            steps = job.get("steps")
-            if not isinstance(steps, list):
+            label = _step_label(step, index)
+            uses = str(step.get("uses", ""))
+            if _CREATE_PR_ACTION in uses:
+                with_block = step.get("with")
+                token = None
+                if isinstance(with_block, dict):
+                    raw_token = with_block.get("token")
+                    token = None if raw_token is None else str(raw_token)
+                found.append((name, container_name, label, token))
                 continue
-            for index, step in enumerate(steps):
-                if not isinstance(step, dict):
-                    continue
-                label = str(step.get("name") or step.get("id") or f"step[{index}]")
-                uses = str(step.get("uses", ""))
-                if _CREATE_PR_ACTION in uses:
-                    with_block = step.get("with")
-                    token = None
-                    if isinstance(with_block, dict):
-                        raw_token = with_block.get("token")
-                        token = None if raw_token is None else str(raw_token)
-                    found.append((path.name, str(job_name), label, token))
-                    continue
-                script = step.get("run")
-                if isinstance(script, str) and _CREATE_PR_COMMAND.search(_strip_comments(script)):
-                    found.append(
-                        (path.name, str(job_name), label, _resolve_gh_token(step, job, workflow)),
-                    )
+            if _GITHUB_SCRIPT_ACTION in uses:
+                with_block = step.get("with")
+                script = with_block.get("script") if isinstance(with_block, dict) else None
+                if isinstance(script, str) and _GITHUB_SCRIPT_CREATE_PR.search(script):
+                    raw_token = with_block.get("github-token") if isinstance(with_block, dict) else None
+                    token = _GITHUB_SCRIPT_DEFAULT_TOKEN if raw_token is None else str(raw_token)
+                    found.append((name, container_name, label, token))
+                continue
+            script = step.get("run")
+            if not isinstance(script, str):
+                continue
+            body = _strip_comments(script)
+            if _CREATE_PR_COMMAND.search(body) or _opens_pull_request_over_the_api(body):
+                found.append(
+                    (name, container_name, label, _resolve_gh_token(step, container, document)),
+                )
     return found
+
+
+def _opens_pull_request_over_the_api(body: str) -> bool:
+    """True for ``gh api`` calls that POST to the ``.../pulls`` collection."""
+    return bool(
+        _GH_API_COMMAND.search(body) and _GH_API_POST.search(body) and _PULLS_COLLECTION.search(body),
+    )
+
+
+def _pr_opening_steps() -> list[tuple[str, str, str, str | None]]:
+    """Return ``(file, container, step, token_expression)`` across the sweep."""
+    found: list[tuple[str, str, str, str | None]] = []
+    for path in _workflow_files() + _action_files():
+        document = yaml.safe_load(path.read_text(encoding="utf-8"))
+        found.extend(_openers_in_document(_sweep_name(path), document))
+    return found
+
+
+def _sweep_name(path: Path) -> str:
+    """Workflows are named by file; composite actions by directory."""
+    if path.name.startswith("action."):
+        return f"{path.parent.name}/{path.name}"
+    return path.name
 
 
 def test_workflow_directory_is_readable() -> None:
@@ -270,3 +372,276 @@ def test_callers_forward_the_secrets_reusable_pr_lanes_declare() -> None:
         "these callers do not forward a secret the callee's pull-request step reads, "
         f"so it evaluates to empty inside the reusable workflow: {missing}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Discovery durability: the shapes a future lane could use to slip past
+# ---------------------------------------------------------------------------
+
+
+def _load(text: str) -> Any:
+    return yaml.safe_load(text)
+
+
+def test_github_script_pull_request_creation_is_discovered() -> None:
+    """`github-token` defaults to the Actions token, so omitting it is the bug."""
+    document = _load(
+        """
+jobs:
+  propose:
+    steps:
+      - name: Open PR via github-script
+        uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: 'bot/branch',
+              base: 'main',
+              title: 'chore: regenerate',
+            });
+"""
+    )
+    openers = _openers_in_document("synthetic.yml", document)
+    assert openers, "a github-script step calling pulls.create opens a pull request"
+    assert openers[0][2] == "Open PR via github-script"
+    with pytest.raises(AssertionError):
+        test_pull_request_is_opened_with_a_triggering_token(*openers[0])
+
+
+def test_github_script_pull_request_creation_reads_its_declared_token() -> None:
+    document = _load(
+        """
+jobs:
+  propose:
+    steps:
+      - name: Open PR via github-script
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.BERNSTEIN_AUTOSYNC_TOKEN || secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.pulls.create({head: 'b', base: 'main', title: 't'});
+"""
+    )
+    openers = _openers_in_document("synthetic.yml", document)
+    assert len(openers) == 1
+    test_pull_request_is_opened_with_a_triggering_token(*openers[0])
+
+
+def test_github_script_that_only_comments_is_not_an_opener() -> None:
+    """`issues.createComment` is the common shape and must not be swept up."""
+    document = _load(
+        """
+jobs:
+  notify:
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.issues.createComment({issue_number: 1, body: 'hi'});
+"""
+    )
+    assert _openers_in_document("synthetic.yml", document) == []
+
+
+def test_gh_api_post_to_the_pulls_collection_is_discovered() -> None:
+    """The porcelain is not the only spelling; `issue_to_pr.py` uses this one."""
+    document = _load(
+        """
+jobs:
+  propose:
+    steps:
+      - name: Open PR through the REST API
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api -X POST "repos/${REPO}/pulls" --input payload.json
+"""
+    )
+    openers = _openers_in_document("synthetic.yml", document)
+    assert openers, "gh api -X POST .../pulls opens a pull request"
+    with pytest.raises(AssertionError):
+        test_pull_request_is_opened_with_a_triggering_token(*openers[0])
+
+
+@pytest.mark.parametrize(
+    "script",
+    [
+        'gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq .merged',
+        'gh api "repos/${REPO}/commits/${SHA}/pulls" --jq ".[0].number"',
+        'gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files"',
+        'gh api -X POST "repos/${REPO}/issues/${N}/comments" -f body=hi',
+    ],
+    ids=["read-one", "read-for-commit", "read-files", "post-elsewhere"],
+)
+def test_gh_api_calls_that_do_not_open_a_pull_request_are_not_swept_up(script: str) -> None:
+    """A false positive would demand a PAT of a lane that only reads."""
+    document = _load("jobs:\n  j:\n    steps:\n      - run: PLACEHOLDER\n")
+    document["jobs"]["j"]["steps"][0]["run"] = script
+    assert _openers_in_document("synthetic.yml", document) == []
+
+
+def test_composite_action_pull_request_step_is_discovered() -> None:
+    """`runs.steps`, not `jobs.<id>.steps` - a workflow-only sweep misses it."""
+    document = _load(
+        """
+name: open-pr
+runs:
+  using: composite
+  steps:
+    - name: Open PR
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: gh pr create --fill
+"""
+    )
+    openers = _openers_in_document("open-pr/action.yml", document)
+    assert openers, "a composite action step can open a pull request too"
+    assert openers[0][1] == "runs"
+    with pytest.raises(AssertionError):
+        test_pull_request_is_opened_with_a_triggering_token(*openers[0])
+
+
+def test_the_sweep_reads_the_composite_action_directory() -> None:
+    """Anti-vacuity: the action sweep must actually resolve files."""
+    assert _action_files(), "no composite action discovered; the action sweep is vacuous"
+
+
+def test_discovery_matches_exactly_the_known_pull_request_lanes() -> None:
+    """Exact set, so a widened matcher cannot quietly add a false positive."""
+    lanes = {name for name, _c, _s, _t in _pr_opening_steps()}
+    assert lanes == {
+        "adapter-conformance-canary.yml",
+        "auto-heal.yml",
+        "bernstein-ci-fix.yml",
+        "bernstein-issues-decompose.yml",
+        "ci-topology-heal.yml",
+        "coverage-ratchet-weekly.yml",
+        "coverage-ratchet.yml",
+        "docs-observability-snapshot.yml",
+        "nightly-drift-sweep.yml",
+        "review-bot-sweep.yml",
+    }
+
+
+# ---------------------------------------------------------------------------
+# The branch push, which the pull-request token alone does not cover
+# ---------------------------------------------------------------------------
+
+
+def _checkout_credential(step: dict[str, Any]) -> tuple[str | None, str]:
+    """Return the credential ``actions/checkout`` persists, and how it got it."""
+    with_block = step.get("with")
+    with_block = with_block if isinstance(with_block, dict) else {}
+    if with_block.get("persist-credentials") is False:
+        return None, "checkout ran with persist-credentials: false and the push sets no extraheader"
+    raw_token = with_block.get("token")
+    if raw_token is None:
+        return "${{ github.token }}", "checkout persisted its default credential"
+    return str(raw_token), "checkout persisted the token it was given"
+
+
+def _push_steps_in_document(name: str, document: Any) -> list[tuple[str, str, str, str | None, str]]:
+    """Resolve the credential every branch push in a PR-opening container uses."""
+    if not isinstance(document, dict):
+        return []
+    found: list[tuple[str, str, str, str | None, str]] = []
+    for container_name, container, steps in _step_containers(document):
+        commands = [
+            _strip_comments(step["run"])
+            for step in steps
+            if isinstance(step, dict) and isinstance(step.get("run"), str)
+        ]
+        if not any(_CREATE_PR_COMMAND.search(body) or _opens_pull_request_over_the_api(body) for body in commands):
+            continue
+        checkout: tuple[str | None, str] = (None, "the container runs no actions/checkout")
+        for index, step in enumerate(steps):
+            if not isinstance(step, dict):
+                continue
+            if _CHECKOUT_ACTION in str(step.get("uses", "")):
+                checkout = _checkout_credential(step)
+            script = step.get("run")
+            if not isinstance(script, str):
+                continue
+            body = _strip_comments(script)
+            if not _GIT_PUSH.search(body):
+                continue
+            label = _step_label(step, index)
+            explicit = _EXTRAHEADER_TOKEN_VAR.search(body)
+            if explicit is not None:
+                variable = explicit.group(1)
+                env = _as_env(step.get("env")) or {}
+                resolved = (
+                    env.get(variable)
+                    or _as_env(container.get("env")).get(variable)
+                    or _as_env(document.get("env")).get(variable)
+                )
+                found.append(
+                    (name, container_name, label, resolved, f"push sets an extraheader from ${variable}"),
+                )
+                continue
+            credential, source = checkout
+            found.append((name, container_name, label, credential, source))
+    return found
+
+
+def _branch_push_steps() -> list[tuple[str, str, str, str | None, str]]:
+    found: list[tuple[str, str, str, str | None, str]] = []
+    for path in _workflow_files() + _action_files():
+        document = yaml.safe_load(path.read_text(encoding="utf-8"))
+        found.extend(_push_steps_in_document(_sweep_name(path), document))
+    return found
+
+
+def test_branch_push_discovery_covers_every_gh_pr_create_lane() -> None:
+    """Anti-vacuity: every porcelain lane pushes a branch, so all must appear."""
+    porcelain = {
+        name
+        for name, _c, _s, _t in _pr_opening_steps()
+        if name
+        in {
+            "adapter-conformance-canary.yml",
+            "auto-heal.yml",
+            "bernstein-ci-fix.yml",
+            "bernstein-issues-decompose.yml",
+            "nightly-drift-sweep.yml",
+        }
+    }
+    pushed = {name for name, _c, _s, _cred, _src in _branch_push_steps()}
+    assert porcelain, "no gh pr create lane discovered; this guard would pass vacuously"
+    assert porcelain <= pushed, f"lanes that open a pull request without a discovered push: {porcelain - pushed}"
+
+
+@pytest.mark.parametrize(
+    ("workflow", "job", "step", "credential", "source"),
+    _branch_push_steps(),
+    ids=lambda value: str(value),
+)
+def test_branch_push_uses_a_triggering_token(
+    workflow: str,
+    job: str,
+    step: str,
+    credential: str | None,
+    source: str,
+) -> None:
+    assert credential is not None, (
+        f"{workflow} job {job!r} step {step!r} pushes the pull request branch with no resolvable "
+        f"credential ({source}). A push with no credential fails outright; a push with the Actions "
+        "token emits no `pull_request: synchronize`, so the open pull request keeps the checks of "
+        "an older commit."
+    )
+    without_actions_token = _ACTIONS_TOKEN.sub("", credential)
+    assert "secrets." in without_actions_token, (
+        f"{workflow} job {job!r} step {step!r} pushes the pull request branch with the Actions "
+        f"token only ({source}). The pull request is opened with a triggering token but every "
+        "later push is invisible, so the rollup reports green against a superseded SHA - worse "
+        "than the empty rollup this lane was fixed to avoid."
+    )
+    actions_token = _ACTIONS_TOKEN.search(credential)
+    if actions_token is not None:
+        assert "secrets." in credential[: actions_token.start()], (
+            f"{workflow} job {job!r} step {step!r} lists the Actions token before the triggering "
+            "token when pushing the branch. The Actions token may only be the fallback."
+        )


### PR DESCRIPTION
Closes #3178

## What this changes

`tests/unit/test_bot_pull_request_tokens_yaml.py` landed in #3188 and fixed the live bug: every lane that opens a pull request now uses a triggering token. Verified on `origin/main` @4cf96c509, and confirmed live by #3196, which `coverage-ratchet.yml` opened under the PAT and which collected both `CI gate` and `review-bot-ack` as SUCCESS.

The guard that came with it stops one step short of the property #3178 asked for, in two ways. This PR closes both. It is test and docs only; no workflow file changed, so `docs/operations/ci-topology.md` is untouched.

### 1. The branch push was unguarded

The old guard asserted the token used to *open* the pull request. A lane could open with the PAT and then push the branch with the Actions token. That push emits no `pull_request: synchronize`, so the open pull request keeps the checks of an older commit and the rollup reads green against a superseded SHA.

That failure mode is worse than the one #3178 reported. An unchecked pull request reads empty and an operator notices. A stale-checked pull request reads answered.

`docs/operations/ci.md` already claimed "the same token is used for the branch push in those lanes". Nothing tested it. It does now. The credential is resolved the way git resolves it:

| Shape | Lanes | Resolution |
|---|---|---|
| Persisted checkout credential | `adapter-conformance-canary`, `bernstein-ci-fix`, `nightly-drift-sweep` | `actions/checkout` `with.token`, defaulting to `github.token` when absent |
| Explicit auth header | `auto-heal`, `bernstein-issues-decompose` | `http.https://github.com/.extraheader` built from `$GH_TOKEN`, resolved through step then job then workflow env |

All five resolve to a triggering credential today. `persist-credentials: false` with no header resolves to no credential and is also a failure, which matches runtime: that push fails outright.

### 2. Discovery knew two spellings and one directory

The old matcher recognised `peter-evans/create-pull-request` and `gh pr create`, in `.github/workflows/*.yml` only. Three ways to open a pull request were invisible to it:

- `gh api -X POST .../pulls`. Not hypothetical here: `src/bernstein/core/orchestration/issue_to_pr.py:545` already opens pull requests that way in library code, and nothing stops that call being lifted into a workflow.
- `actions/github-script` calling `pulls.create`. Its `github-token` input **defaults to the Actions token**, so omitting it is the bug rather than a neutral choice. Three workflows already use `actions/github-script` for other purposes.
- A composite action under `.github/actions/*/action.yml`, which carries `runs.steps` instead of `jobs.<id>.steps`.

All four shapes now match and both directories are swept. The discovered lane set is asserted **exactly**, not as a subset, so a widened matcher cannot quietly demand a PAT of a lane that only reads pull requests. Four `gh api` read shapes already in the tree are pinned as non-openers.

## Evidence

TDD, behavioural red before green (not a collection error):

```
FAILED test_github_script_pull_request_creation_is_discovered
FAILED test_github_script_pull_request_creation_reads_its_declared_token
FAILED test_gh_api_post_to_the_pulls_collection_is_discovered
FAILED test_branch_push_discovery_covers_every_gh_pr_create_lane
4 failed, 23 passed, 1 skipped
```

After: `32 passed`. Touched plus adjacent files: `89 passed`.

Mutation proofs, each restored afterwards (`git diff --stat .github/` empty):

1. `bernstein-ci-fix.yml` checkout token to `secrets.GITHUB_TOKEN`, leaving `gh pr create` on the PAT. New guard: `FAILED test_branch_push_uses_a_triggering_token[bernstein-ci-fix.yml-...]`. The pre-existing pull-request-token assertion for that same lane: `1 passed`. That asymmetry is the hole.
2. `auto-heal.yml:525`, the extraheader source, to `secrets.GITHUB_TOKEN`. `FAILED test_branch_push_uses_a_triggering_token[auto-heal.yml-heal-Push heal branch-...]`.
3. A `github-script` opener with the default token added to `docs-observability-snapshot.yml`. This branch: `1 failed`. `origin/main`'s copy of the same test file against the same mutated tree: `15 passed`.
4. A composite action at `.github/actions/tmpopener/action.yml` opening a pull request with `github.token`. This branch: `2 failed`. `origin/main`'s copy: `15 passed`.

Mutations 3 and 4 are the durability gap stated as a measurement rather than an opinion: the shipped guard is fully green against a workflow that reintroduces the exact bug it was written to prevent.

## Acceptance criteria not met by any pull request

One AC bullet on #3178 reads "#3176, or its successor from the next nightly fire, actually merges". No pull request can satisfy it and this one does not claim to.

#3176 is closed and was never merged. The last `adapter-conformance-canary` run is 30192841454 at 2026-07-26T07:27:37Z, which predates #3188 merging at 2026-07-27T04:52:48Z, so no post-fix fire has happened yet. The next one is due around 07:2x UTC. Someone should confirm the pull request it opens collects `CI gate` plus `review-bot-ack` and merges.

The pattern is already proven live by #3196 on the `create-pull-request` path; what remains unobserved is the `gh pr create` path specifically. Closing #3178 on the code and the guards is the right call; the observation is a watch item, not an implementation gap.

## The other two issues in this cluster

#3048 and #3049 were also fixed by #3188 and stayed open only because that pull request carried a copy of #3170's body, so its `Closes` lines pointed at three issues #3170 had already closed and never referenced these. Both are closed directly against 4cf96c509 with their evidence rather than being re-fixed here, since neither needs a code change:

- **#3048**: the issue's own reproduction now passes on `origin/main`. `scripts/test_impact.py --print-paths --files src/bernstein/core/git/worktree.py` returns 585 paths against the 265 the issue measured, and includes `tests/unit/test_worktree_lifecycle.py`, the file it named as missing.
- **#3049**: `nightly-deep-tests.yml` gained the `unit-python-314` job, 4 shards, full discovery. The issue pre-authorised a nightly lane. Keeping 3.14 off the pull request matrix is deliberate: that matrix fans out over os x python x shard, so one extra python row is +8 jobs on every pull request. `ci.yml` already puts 34 of the 47 runner jobs on a pull request head against a 20-concurrent-job free-tier ceiling, so the row would lengthen every queue for an interpreter nothing ships on. Nightly costs 4 jobs once a day on a workflow with no required context.
