### PR TITLE
fix(ci): take the merge-queue gate publisher from the base ref, not the queued entry

### DIFF
--- a/.github/workflows/review-bot-ack.yml
+++ b/.github/workflows/review-bot-ack.yml
@@ -85,9 +85,26 @@ jobs:
         with:
           egress-policy: audit
 
+      # Check out the merge group's BASE ref, never the queued entry.
+      #
+      # `actions/checkout` with no `ref:` takes the ref that triggered the
+      # run. On a `merge_group` event that is the ephemeral
+      # `gh-readonly-queue/<base>/pr-<n>-<base sha>` branch, which carries
+      # the candidate pull request's tree. This job holds `checks: write`,
+      # and `checks: write` is enough to forge a required context: it can
+      # post a completed check-run named `CI gate` with conclusion
+      # `success` on any commit in the repository. Running
+      # `scripts/publish_required_check.py` out of a candidate tree would
+      # hand that capability to whoever authored the queued pull request.
+      #
+      # This is the same reasoning that pins the `pr-gate` job below to
+      # the pull request's base ref. The job needs nothing from any
+      # candidate tree: it resolves the pull request and its check-runs
+      # over the API, and the publisher is API-only too.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+          ref: ${{ github.event.merge_group.base_ref }}
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:

--- a/docs/operations/merge-queue.md
+++ b/docs/operations/merge-queue.md
@@ -13,6 +13,7 @@ shipped ruleset is currently out of sync with it; see
 | Topic | Status | Where |
 |-------|--------|-------|
 | Queue state today | Ruleset exists, `enforcement: disabled` | ruleset `main-merge-queue` |
+| Safe to flip today? | **No** - 4 blockers, one substantive | [Blockers](#blockers-to-the-flip) |
 | What it solves | Tests the A+B *combination* before merge | this doc |
 | Required checks on the queue | `CI gate` **and** `review-bot-ack` | `ci.yml`, `review-bot-ack.yml` |
 | What the group's CI is planned against | The group's `base_sha`, never `HEAD~1` | [What the group's CI actually tests](#what-the-groups-ci-actually-tests) |
@@ -68,6 +69,19 @@ Every context required on a PR also reports on a `merge_group` ref:
 | `CI gate` | `ci.yml` :: `ci-gate` | Yes - `merge_group: {}` |
 | `CI gate` | `ci-gate-stub.yml` :: `ci-gate` | No - `pull_request` only, and **correct** (see below) |
 | `review-bot-ack` | `review-bot-ack.yml` :: `merge-group-verify` | Yes - `if: github.event_name == 'merge_group'` |
+
+The queue-side emitter checks out
+`github.event.merge_group.base_ref`, not the group. `actions/checkout`
+with no `ref:` takes the triggering ref, which on a `merge_group` event is
+the ephemeral `gh-readonly-queue/...` branch carrying the *candidate pull
+request's tree*. That job holds `checks: write`, and `checks: write` is
+enough to post a completed check-run named `CI gate` with conclusion
+`success` on any commit in the repository - so running its publisher out
+of a candidate tree would hand the entry's author the ability to forge the
+other required context. Pinning the base ref is the same reasoning that
+pins the `pr-gate` job to the pull request's base ref. Locked by
+`tests/unit/test_merge_queue_gate_coverage_yaml.py` and
+`tests/unit/test_review_bot_ack_workflow_yaml.py`.
 
 `ci-gate-stub.yml` deliberately has no `merge_group` trigger. It exists
 only because `ci.yml`'s `pull_request` trigger carries a `paths-ignore:`
@@ -150,19 +164,43 @@ dispatcher's `branches: [main]` filter excludes. Nothing is ever tagged
 from a queue ref that has not merged.
 
 **Q2: does the post-queue merge still fire the release listener?**
-Yes. When a merge group goes green, GitHub advances the base branch to the
-**same SHA** that the queue tested and emits an ordinary `push` event on
-that branch. The push is attributed to `github-merge-queue[bot]` and is
-not suppressed by Actions' `GITHUB_TOKEN` loop prevention, so
+Yes. When a merge group goes green, GitHub advances the base branch and
+emits an ordinary `push` event on it. The push is not made with
+`GITHUB_TOKEN`, so Actions' loop prevention does not suppress it and
 `push`-triggered workflows start normally.
 
-Observed on a public repository running the queue at scale
-(`cilium/cilium`, 2026-07-24):
+Measured in **this** repository, during the queue window of 2026-05-22
+(ruleset `main-merge-queue` was briefly `active`; `gh run list --event
+merge_group` still lists the runs). Pull request #1842, `merge_method:
+SQUASH`:
 
-| Event | `head_branch` | `head_sha` | Actor |
-|-------|---------------|-----------|-------|
-| `merge_group` run, 23:21:05Z | `gh-readonly-queue/main/pr-47100-67dfc5a2…` | `90c7690d43…` | - |
-| `push` run, 23:34:05Z | `main` | `90c7690d43…` (identical) | `github-merge-queue[bot]` |
+| Step | Evidence |
+|------|----------|
+| Queue built the entry | `merge_group` CI run `26261037066` / `26264196218`, `head_branch: gh-readonly-queue/main/pr-1842-75aa8698…`, conclusion `success` |
+| Entry merged | `gh api .../issues/1842/timeline` -> `{"event":"merged","created_at":"2026-05-22T02:23:09Z"}` |
+| `push` fired on `main` | CI run `26264756775`, `event: push`, `head_branch: main`, `head_sha: ff07c5aa…`, 02:23:12Z |
+| Listener fired off it | `Post-CI dispatcher` run `26264768644`, `event: workflow_run`, `head_sha: ff07c5aa…`, conclusion `success`, 02:23:35Z |
+
+Pull request #1839 shows the same chain 90 minutes earlier
+(`4130e2445c…` -> push CI `26262116854` -> dispatcher `26262118810`).
+
+**Two corrections to the earlier revision of this section**, both from the
+run data above rather than from a third-party repository:
+
+*The merged SHA is a new SHA.* Under `merge_method: SQUASH`, `main` does
+**not** advance to the SHA the queue tested. The group's head was
+`d8bdb47944…`; the commit that landed on `main` was `ff07c5aa29…`, and
+their trees differ too (`a93c9b5a06…` vs `ac87197073…`). Squash rewrites
+the commit onto the branch head at merge time. Only `merge_method: MERGE`
+makes the tested SHA the merged SHA. Any smoke test that asserts SHA
+equality will fail on a healthy queue.
+
+*The actor is not `github-merge-queue[bot]` here.* That identity came
+from a third-party observation. This repository's own queue merges
+reported `actor: chernistry` on the resulting push run - the operator who
+queued the entry. The property the release path depends on is narrower
+than either name: the push is not made by the Actions token, so it is not
+loop-suppressed.
 
 So the chain is unchanged end to end:
 
@@ -197,13 +235,37 @@ the queue is enabled.
 | `min_entries_to_merge` | 1 | **1** | Never wait for a second entry before merging |
 | `max_entries_to_merge` | 1 | **1** | One PR lands per push to `main`. The auto-release gate keys on the push head SHA, so merging N entries in a single push silently skips a version bump that is not last in the batch - green CI, no tag, no publish, no error. Lifting this requires the release gate to stop keying on the push head SHA; tracked as a follow-up. The second former blocker is closed: `determine-changes` now classifies a queued group against `github.event.merge_group.base_sha`, so a multi-entry group is planned from its combined diff instead of its last commit. |
 | `min_entries_to_merge_wait_minutes` | 0 | **0** | With `max_entries_to_merge = 1` there is no batch to fill, so any wait is pure added latency |
-| `check_response_timeout_minutes` | 30 | **120** | Measured over the last 30 successful `CI` runs on `main`: p50 38 min, p90 58 min, max 105 min. At `30` **every** entry would be ejected as timed out; at `60` roughly one in ten would be. `120` clears the observed maximum and the `test` job's own 90-minute budget. |
+| `check_response_timeout_minutes` | 30 | **240** | Re-measured 2026-07-27 over the last 30 successful `CI` runs on `main` (`run_started_at` -> `updated_at`): p50 **49** min, p90 **214** min, max **243** min, and **30 of 30 exceeded 30 minutes**. The earlier figures in this row (p50 38 / p90 58 / max 105) are stale. At the shipped `30`, *every* entry is ejected as timed out. At `120`, 9 of those 30 runs would still have been ejected. `240` covers all but the single 243-minute outlier. Re-measure in Step 0 before flipping - this value tracks runner-pool contention, not the test suite. |
+
+## Blockers to the flip
+
+Measured 2026-07-27. These are conditions on the repository, not code
+changes; none of them is fixed by a pull request. Until each is cleared,
+enabling the queue makes `main` slower to advance without making it
+safer.
+
+| # | Blocker | Evidence | Clears when |
+|---|---------|----------|-------------|
+| 1 | The shipped ruleset would eject **every** entry. `check_response_timeout_minutes` is `30`; the last 30 successful `CI` runs on `main` all took longer than that. | p50 49 min, p90 214 min, max 243 min, 30/30 over 30 min | Step 1 is applied (raises it to `240`) |
+| 2 | The shipped ruleset requires only `CI gate`. `review-bot-ack` is absent, so the queue would merge without the gate that branch protection requires at entry. | `gh api repos/$REPO/rulesets/16719298 --jq '.rules'` -> one context | Step 1 is applied |
+| 3 | CI wall time makes serialised merging impractical. `max_entries_to_build` is the number of groups built at once, but `max_entries_to_merge` is pinned to `1` for the release path, so a burst of N ready PRs costs N sequential merges. At p90 = 214 min that is most of a day for five PRs. | same distribution as #1 | CI wall time is bounded, or the release gate stops keying on the push head SHA so batches can merge |
+| 4 | The queue-side `review-bot-ack` emitter has never executed. `merge-group-verify` was written after the last live queue window (2026-05-22) and the queue has been disabled since. A required context whose emitter has never run is exactly the "waits forever on a check that cannot report" failure. | `gh run list --event merge_group` -> newest run 2026-05-22T02:04:46Z | The Step 4 smoke test observes it reporting on one real entry |
+
+Blocker 3 is the substantive one. Blockers 1 and 2 are two `gh api` calls;
+blocker 4 can only be retired by flipping once and watching. So the
+recommended order is: apply Step 1, fix CI wall time, then flip with a
+single low-risk pull request as the canary and Step 4 open in front of
+you.
 
 ## Enable (mechanical steps)
 
-**Do not run these while a release is in flight.** Enabling the queue
-serialises every open PR through it. The flip is deliberately deferred
-until after `v3.10.0` ships.
+**Do not run these while a release is in flight, or while a batch of
+pull requests is being landed in a deliberate order.** Enabling the queue
+serialises every open PR through it, and a queue re-forms its group after
+every ejection - so a set of PRs that conflict with each other (the usual
+case for several PRs touching `.github/workflows` and the regenerated
+`docs/operations/ci-topology.md`) will eject and rebuild repeatedly, each
+rebuild costing a full CI cycle.
 
 All calls need repository **admin** scope.
 
@@ -247,7 +309,7 @@ gh api -X PUT "repos/$REPO/rulesets/$RULESET_ID" --input - <<'JSON'
         "min_entries_to_merge": 1,
         "max_entries_to_merge": 1,
         "min_entries_to_merge_wait_minutes": 0,
-        "check_response_timeout_minutes": 120
+        "check_response_timeout_minutes": 240
       }
     },
     {
@@ -290,9 +352,19 @@ gh api -X PUT "repos/$REPO/rulesets/$RULESET_ID" -f enforcement=active
 chain, in order:
 
 1. A `merge_group` run appears: `gh run list --repo "$REPO" --event merge_group --limit 5`.
-2. Both `CI gate` and `review-bot-ack` report on it.
-3. The PR merges, and `main` advances to the **same SHA** the queue tested.
-4. A `push` run on `main` appears at that SHA, actor `github-merge-queue[bot]`.
+2. Both `CI gate` **and** `review-bot-ack` report on it. `review-bot-ack`
+   is the one to watch: its queue-side emitter (`merge-group-verify` in
+   `review-bot-ack.yml`) has never executed against a live queue, because
+   it was written after the 2026-05-22 window and the queue has been
+   disabled since. If it does not report, the entry sits forever - pause
+   immediately rather than waiting it out.
+3. The PR merges and `main` gains a new commit. Do **not** assert it is
+   the SHA the queue tested: under `merge_method: SQUASH` it is a new
+   commit with a different SHA and possibly a different tree (see
+   [Auto-release](#auto-release-through-the-queue)).
+4. A `push` run on `main` appears at `main`'s **new** head SHA. Read the
+   actor for the record, but do not gate on a particular one - the only
+   requirement is that the run exists.
 5. `post-ci-dispatcher.yml` runs off that CI run:
    `gh run list --repo "$REPO" --workflow post-ci-dispatcher.yml --limit 3`.
 

--- a/tests/unit/test_merge_queue_gate_coverage_yaml.py
+++ b/tests/unit/test_merge_queue_gate_coverage_yaml.py
@@ -1,0 +1,273 @@
+"""The merge queue cannot merge, or cannot wedge, on a required context.
+
+Enabling the queue makes ``merge_group`` the event that decides whether
+``main`` advances. Two symmetric failure modes follow, and neither one
+reports as a red check anywhere:
+
+*Wedge.* A required context that cannot report on a ``merge_group`` ref
+leaves the queue waiting forever for a check that will never arrive. The
+pull requests sit in the queue, nothing is red, and nothing merges.
+
+*Blind pass.* A job the ``CI gate`` roll-up needs, which skips on
+``merge_group`` and lands in a tolerance bucket it does not belong in,
+makes the gate green for a combination that was never built - the exact
+hole the queue exists to close.
+
+Both are decided by static structure, so they are asserted statically
+here. The roll-up's tolerance sets are read out of the shipped
+``ci.yml`` rather than restated, so this file cannot drift away from the
+code it guards.
+
+See ``docs/operations/merge-queue.md``.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - dev env should have pyyaml
+    pytest.skip("pyyaml not installed", allow_module_level=True)
+
+WORKFLOWS = Path(".github/workflows")
+CI_WF = WORKFLOWS / "ci.yml"
+RUNBOOK = Path("docs/operations/merge-queue.md")
+
+GATE_JOB_KEY = "ci-gate"
+# Job `if:` expressions that reference these are event-shape dependent:
+# their truth value changes with `github.event_name`, so they may resolve
+# differently on a queued group than on the pull request.
+EVENT_SHAPE_MARKERS = ("github.event_name", "github.event.pull_request")
+
+
+def _load(path: Path) -> dict[str, Any]:
+    doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(doc, dict), f"{path} is not a mapping"
+    return doc
+
+
+def _on(doc: dict[str, Any]) -> dict[str, Any]:
+    # PyYAML 1.1 parses a bare ``on:`` key as the boolean True.
+    on = doc.get(True, doc.get("on"))
+    assert isinstance(on, dict), "workflow must declare a mapping of triggers"
+    return on
+
+
+@pytest.fixture(scope="module")
+def ci_doc() -> dict[str, Any]:
+    return _load(CI_WF)
+
+
+@pytest.fixture(scope="module")
+def ci_jobs(ci_doc: dict[str, Any]) -> dict[str, Any]:
+    jobs = ci_doc.get("jobs")
+    assert isinstance(jobs, dict)
+    return jobs
+
+
+@pytest.fixture(scope="module")
+def rollup_source(ci_jobs: dict[str, Any]) -> str:
+    """The Python heredoc the ``ci-gate`` job runs to fold `needs.*.result`."""
+    gate = ci_jobs.get(GATE_JOB_KEY)
+    assert isinstance(gate, dict), f"ci.yml must keep a `{GATE_JOB_KEY}` job"
+    for step in gate.get("steps") or []:
+        run = str(step.get("run", ""))
+        if "<<'PY'" not in run:
+            continue
+        body = run.split("<<'PY'", 1)[1]
+        return body.split("\nPY", 1)[0]
+    raise AssertionError(f"`{GATE_JOB_KEY}` no longer runs an inline Python roll-up")
+
+
+@pytest.fixture(scope="module")
+def rollup_constants(rollup_source: str) -> dict[str, Any]:
+    """Module-level literal assignments inside the roll-up script.
+
+    Parsed rather than restated: a tolerance bucket renamed or emptied in
+    ``ci.yml`` must change what these tests assert, not slip past them.
+    """
+    tree = ast.parse(rollup_source)
+    out: dict[str, Any] = {}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        if not isinstance(target, ast.Name) or not target.id.isupper():
+            continue
+        try:
+            out[target.id] = ast.literal_eval(node.value)
+        except ValueError:
+            continue
+    return out
+
+
+@pytest.fixture(scope="module")
+def queue_required_contexts() -> tuple[str, ...]:
+    """Contexts the runbook tells the operator to require on the queue."""
+    match = re.search(r"<<'JSON'\n(.*?)\nJSON\n", RUNBOOK.read_text(encoding="utf-8"), re.DOTALL)
+    assert match, "merge-queue.md must keep the copy-pasteable ruleset payload"
+    payload = json.loads(match.group(1))
+    for rule in payload.get("rules", []):
+        if rule.get("type") == "required_status_checks":
+            checks = rule["parameters"]["required_status_checks"]
+            return tuple(c["context"] for c in checks)
+    raise AssertionError("enable payload declares no required_status_checks rule")
+
+
+def _triggers_on_merge_group(doc: dict[str, Any]) -> bool:
+    on = doc.get(True, doc.get("on"))
+    return isinstance(on, dict) and "merge_group" in on
+
+
+def test_ci_merge_group_trigger_carries_no_filter(ci_doc: dict[str, Any]) -> None:
+    """``ci.yml`` must run on every merge group, unconditionally.
+
+    ``paths`` / ``paths-ignore`` are evaluated for ``push``,
+    ``pull_request`` and ``pull_request_target`` only, so ``ci.yml``'s
+    ``paths-ignore`` list does not apply to a queued group and
+    ``ci-gate-stub.yml`` correctly has no ``merge_group`` trigger. That
+    makes the unfiltered trigger load-bearing: any filter added here
+    would stop ``CI gate`` from reporting on the groups it excludes, and
+    the queue would wait on a context that can never arrive.
+    """
+    trigger = _on(ci_doc).get("merge_group", "__absent__")
+    assert trigger != "__absent__", "ci.yml must declare a `merge_group` trigger or the queue has no `CI gate`"
+    assert trigger in (None, {}), (
+        f"ci.yml's `merge_group` trigger carries a filter ({trigger!r}). Every merge group must run CI: a group "
+        "the filter excludes never publishes `CI gate`, and the queue waits on it forever."
+    )
+
+
+def test_every_queue_required_context_has_a_merge_group_emitter(
+    queue_required_contexts: tuple[str, ...],
+) -> None:
+    """Each context required on the queue is published from a merge group.
+
+    A context required by the ruleset but emitted only from
+    ``pull_request`` is the wedge: the entry can never satisfy it.
+    """
+    assert queue_required_contexts, "the queue must require at least one context"
+    emitters: dict[str, list[str]] = {c: [] for c in queue_required_contexts}
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        try:
+            doc = _load(path)
+        except (AssertionError, yaml.YAMLError):
+            continue
+        if not _triggers_on_merge_group(doc):
+            continue
+        text = path.read_text(encoding="utf-8")
+        jobs = doc.get("jobs")
+        if not isinstance(jobs, dict):
+            continue
+        for key, job in jobs.items():
+            if not isinstance(job, dict):
+                continue
+            for context in queue_required_contexts:
+                # Either the job's own name is the context, or the job
+                # publishes it explicitly through the Checks API.
+                if job.get("name") == context or f"--name {context}" in text:
+                    emitters[context].append(f"{path.name}::{key}")
+
+    missing = sorted(c for c, found in emitters.items() if not found)
+    assert not missing, (
+        f"contexts {missing} are required on the merge queue but no workflow emits them on a `merge_group` "
+        f"event. The queue would wait on them forever. Found: { {k: v for k, v in emitters.items() if v} }"
+    )
+
+
+def test_macos_tolerance_covers_the_merge_group_event(
+    rollup_constants: dict[str, Any],
+) -> None:
+    """The roll-up must tolerate the macOS skip on a queued group.
+
+    The macOS jobs gate on ``push``, on a ``macos-needed`` label, or on
+    the planner's ``macos_sensitive`` verdict. On a merge group there is
+    no pull request payload, so the label branch cannot fire and only the
+    planner's verdict can start them. Without ``merge_group`` in the
+    tolerated-skip events, every non-macOS-sensitive group fails
+    ``CI gate`` and nothing ever merges.
+    """
+    events = rollup_constants.get("MACOS_SKIP_EVENTS")
+    assert events, "the roll-up no longer declares MACOS_SKIP_EVENTS"
+    assert "merge_group" in events, (
+        f"MACOS_SKIP_EVENTS is {events!r}. A queued group cannot set the `macos-needed` label branch, so the "
+        "macOS cells skip and `CI gate` fails on every group whose diff is not macOS-sensitive."
+    )
+
+
+def test_event_gated_required_jobs_declare_their_merge_group_tolerance(
+    ci_jobs: dict[str, Any],
+    rollup_constants: dict[str, Any],
+) -> None:
+    """No job the gate needs may gate itself off a merge group silently.
+
+    A job in ``ci-gate``'s ``needs`` whose ``if:`` depends on the event
+    shape resolves differently on a queued group than on the pull
+    request. Two outcomes, both bad and neither visible as a red check:
+    the roll-up flags the skip and the queue can never merge anything, or
+    the skip lands in a tolerance bucket that was never meant to cover it
+    and ``CI gate`` passes without the job.
+
+    So the rule is explicit: gate a required job on the event, and name
+    it in one of the roll-up's tolerance buckets in the same change.
+    """
+    gate = ci_jobs[GATE_JOB_KEY]
+    tolerated: set[str] = set()
+    for name in ("DOCS_ONLY_SKIPPABLE", "MACOS_GATED", "PUSH_ONLY"):
+        bucket = rollup_constants.get(name)
+        assert bucket, f"the roll-up no longer declares {name}"
+        tolerated |= set(bucket)
+
+    undeclared: list[str] = []
+    for key in gate.get("needs") or []:
+        job = ci_jobs.get(key)
+        assert isinstance(job, dict), f"ci-gate needs `{key}`, which is not a job in ci.yml"
+        condition = " ".join(str(job.get("if", "")).split())
+        if not any(marker in condition for marker in EVENT_SHAPE_MARKERS):
+            continue
+        if key not in tolerated:
+            undeclared.append(f"{key} (if: {condition})")
+
+    assert not undeclared, (
+        "these jobs are required by `CI gate` and gate themselves on the event shape, but no tolerance bucket in "
+        f"the roll-up names them: {undeclared}. On a merge_group ref they may skip; an undeclared skip is flagged "
+        "by the roll-up and wedges the queue. Add the job to DOCS_ONLY_SKIPPABLE, MACOS_GATED or PUSH_ONLY with "
+        "the reason its skip is safe, or drop the event condition."
+    )
+
+
+def test_review_bot_ack_queue_emitter_reads_the_repository_tree(
+    queue_required_contexts: tuple[str, ...],
+) -> None:
+    """The queue emitter must not execute the queued entry's code.
+
+    The counterpart of the wedge: a job that *can* report on the queue but
+    takes its publisher from the candidate tree. It holds ``checks:
+    write``, which is enough to post a completed ``CI gate`` success on
+    any commit in the repository, so the entry's author would gain the
+    ability to forge the other required context. The base ref is the only
+    repository-controlled tree available on a ``merge_group`` run.
+    """
+    assert "review-bot-ack" in queue_required_contexts
+    doc = _load(WORKFLOWS / "review-bot-ack.yml")
+    jobs = doc.get("jobs")
+    assert isinstance(jobs, dict)
+    job = jobs.get("merge-group-verify")
+    assert isinstance(job, dict), "review-bot-ack.yml must keep its queue-side emitter"
+    assert "merge_group" in str(job.get("if", "")), "the queue-side emitter must be gated to the merge_group event"
+    checkouts = [s for s in job.get("steps") or [] if "checkout" in str(s.get("uses", ""))]
+    assert checkouts, "the queue-side emitter must check out the publisher script"
+    for step in checkouts:
+        ref = str((step.get("with") or {}).get("ref", "")).strip()
+        assert "merge_group.base_ref" in ref, (
+            f"the queue-side emitter checks out {ref!r}; on a merge_group run anything other than "
+            "`github.event.merge_group.base_ref` is the queued entry's own tree, which the pull request author "
+            "controls, and this job runs Python from it with `checks: write`."
+        )

--- a/tests/unit/test_review_bot_ack_workflow_yaml.py
+++ b/tests/unit/test_review_bot_ack_workflow_yaml.py
@@ -157,6 +157,50 @@ def test_no_job_checks_out_the_pull_request_head(
             )
 
 
+def test_every_checkout_pins_an_explicit_base_ref(
+    gate_doc: dict[str, object],
+) -> None:
+    """INV-2c. An omitted ``ref:`` is the same defect as an explicit head ref.
+
+    ``test_no_job_checks_out_the_pull_request_head`` only rejects a ref
+    that spells the head out. A checkout step with no ``ref:`` at all
+    passes it vacuously while doing exactly the thing the docstring
+    forbids: ``actions/checkout`` defaults to the ref that triggered the
+    run, which on a ``merge_group`` event is the queued entry's own
+    ``gh-readonly-queue/...`` branch. That branch carries the candidate
+    pull request's tree, so the job runs
+    ``scripts/publish_required_check.py`` out of code the pull request
+    author controls while holding ``checks: write``.
+
+    ``checks: write`` is enough to forge a required context: it can post
+    a completed check-run named ``CI gate`` with conclusion ``success``
+    on any commit in the repository. Every job in this workflow reaches
+    the pull request over the API and needs nothing from any candidate
+    tree, so every checkout here pins the base ref.
+    """
+    seen = 0
+    for key, job in _jobs(gate_doc).items():
+        for step in _steps(job):
+            if "checkout" not in str(step.get("uses", "")):
+                continue
+            seen += 1
+            ref = str((step.get("with") or {}).get("ref", "")).strip()
+            assert ref, (
+                f"job {key!r} checks out without an explicit `ref:`. actions/checkout then takes the triggering "
+                "ref, which on a merge_group run is the queued entry's own branch, so this job would execute the "
+                "candidate pull request's code under its `checks: write` token. Pin the base ref."
+            )
+            assert "head" not in ref, (
+                f"job {key!r} checks out a head ref ({ref!r}); use the base ref so the publisher always exists "
+                "and a candidate tree cannot run code under this job's write permissions."
+            )
+            assert "base" in ref, (
+                f"job {key!r} checks out {ref!r}, which is neither the pull request base ref nor the merge "
+                "group base ref. Only a base ref is guaranteed to be repository-controlled."
+            )
+    assert seen, "workflow must check out something; otherwise this guard is vacuous"
+
+
 def test_publish_is_skipped_while_a_job_is_being_cancelled(
     gate_doc: dict[str, object],
 ) -> None:


### PR DESCRIPTION
## What this does

Three things, in order of consequence.

**1. The merge-queue gate publisher no longer runs the queued entry's code.**

`review-bot-ack.yml`'s `merge-group-verify` job checked out with no `ref:`.
On a `merge_group` event `actions/checkout` takes the ref that triggered the
run, which is the ephemeral `gh-readonly-queue/<base>/pr-<n>-<base sha>`
branch carrying the candidate pull request's tree. The job then runs
`scripts/publish_required_check.py` out of that tree while holding
`checks: write`.

`checks: write` is enough to forge the *other* required context: it can post
a completed check-run named `CI gate` with conclusion `success` on any commit
in the repository. So a pull request that reached the queue could execute code
that satisfies branch protection for a different pull request.

Fixed by pinning `ref: ${{ github.event.merge_group.base_ref }}`, which is
exactly the reasoning #3195 applied to the `pr-gate` job in the same file. The
job needs nothing from any candidate tree - it resolves the pull request and
its check-runs over the API, and the publisher is API-only too.

The existing guard `test_no_job_checks_out_the_pull_request_head` could not
catch this. It asserts `"pull_request.head" not in ref`, so a checkout with no
`ref:` at all passes it vacuously while doing the thing its own docstring
forbids. Tightened to require an explicit base ref on every checkout in the
workflow.

**2. `tests/unit/test_merge_queue_gate_coverage_yaml.py` (new, 5 tests).**

The defect class that only exists once `merge_group` decides whether `main`
advances, and that reports as neither a red check nor a stalled job:

| Guard | Failure it prevents |
|---|---|
| `test_ci_merge_group_trigger_carries_no_filter` | A filter on `ci.yml`'s `merge_group` trigger; excluded groups never publish `CI gate` and the queue waits forever |
| `test_every_queue_required_context_has_a_merge_group_emitter` | A context required by the ruleset with no `merge_group` emitter - the wedge |
| `test_macos_tolerance_covers_the_merge_group_event` | Dropping `merge_group` from `MACOS_SKIP_EVENTS`; every non-macOS-sensitive group then fails `CI gate` |
| `test_event_gated_required_jobs_declare_their_merge_group_tolerance` | A `CI gate` dependency gated on the event shape without a declared tolerance bucket - wedge, or a blind pass if it lands in the wrong bucket |
| `test_review_bot_ack_queue_emitter_reads_the_repository_tree` | Regression of item 1 |

The roll-up's tolerance sets (`DOCS_ONLY_SKIPPABLE` / `MACOS_GATED` /
`PUSH_ONLY` / `MACOS_SKIP_EVENTS`) are parsed out of the shipped `ci.yml` with
`ast`, not restated, so the guard cannot drift away from the code it guards.

**3. Four corrections to `docs/operations/merge-queue.md`,** all from run data
in this repository rather than from a third-party repository.

## Why #2966 is not closed

The queue is **not safe to enable today**, and none of the four blockers is
fixable by a pull request. They are written into the runbook under
[Blockers to the flip](https://github.com/sipyourdrink-ltd/bernstein/blob/fix/merge-queue-enablement-2966/docs/operations/merge-queue.md#blockers-to-the-flip);
summarised here so the issue thread carries them:

| # | Blocker | Evidence |
|---|---------|----------|
| 1 | Shipped `check_response_timeout_minutes` is `30`. **30 of the last 30 successful `CI` runs on `main` took longer than that**, so every queued entry would be ejected as timed out. | p50 49 min, p90 214 min, max 243 min |
| 2 | Shipped ruleset `16719298` requires only `CI gate`. `review-bot-ack` is absent, so the queue would merge without the gate branch protection requires at entry. | `gh api .../rulesets/16719298 --jq '.rules'` returns one context |
| 3 | **The substantive one.** `max_entries_to_merge` is pinned to `1` because the release gate keys on the push head SHA, so a burst of N ready pull requests costs N sequential merges. At p90 = 214 min that is most of a day for five. The queue is a correctness mechanism here, not a load-reduction one. | same distribution |
| 4 | The queue-side `review-bot-ack` emitter has never executed. `merge-group-verify` was written after the last live queue window and the queue has been disabled since. | `gh run list --event merge_group` -> newest run `2026-05-22T02:04:46Z` |

Blockers 1 and 2 are two `gh api PUT` calls the runbook already spells out
(Enable, Step 1) and are left as operator actions - this pull request does not
change live repository configuration. Blocker 4 can only be retired by
flipping once and watching, which is what Step 4 is for. Blocker 3 needs CI
wall time bounded first.

Enabling right now would also collide with the batch of pull requests
currently being landed in a deliberate order: several touch
`.github/workflows` and therefore conflict on the regenerated
`docs/operations/ci-topology.md`, and a queue re-forms its group after every
ejection, so each conflict costs a full CI cycle.

## What I verified, and how

**The release path survives the queue** - the highest-risk question, and the
runbook previously answered it from a third-party repository. `auto-release.yml`
is `workflow_call` only and `post-ci-dispatcher.yml` is its sole invocation
path, so the chain is: queue merges -> `push` on `main` -> `ci.yml` (push) ->
`workflow_run` -> dispatcher -> auto-release. Measured on this repository's own
2026-05-22 queue window, pull request #1842:

```
merge_group CI run 26264196218  gh-readonly-queue/main/pr-1842-75aa8698...  success
issues/1842/timeline            {"event":"merged","created_at":"2026-05-22T02:23:09Z"}
CI run 26264756775              event=push  head_branch=main  head_sha=ff07c5aa...  02:23:12Z
Post-CI dispatcher 26264768644  event=workflow_run  head_sha=ff07c5aa...  success  02:23:35Z
```

Pull request #1839 shows the same chain 90 minutes earlier (`4130e2445c` ->
push CI `26262116854` -> dispatcher `26262118810`). The `push` really does fire
and the listener really does run off it.

Two things that data contradicted in the runbook:

* **The merged SHA is a new SHA.** Under `merge_method: SQUASH`, `main` does
  not advance to what the queue tested. Group head `d8bdb47944`, merged commit
  `ff07c5aa29`, and the trees differ too (`a93c9b5a06` vs `ac87197073`). Step 4
  of the smoke checklist told the operator to assert SHA equality, which fails
  on a *healthy* queue. Corrected.
* **The push actor was `chernistry`,** the operator who queued the entry - not
  `github-merge-queue[bot]`, which came from the third-party observation. The
  property the release path actually needs is narrower than either name: the
  push is not made by the Actions token, so it is not loop-suppressed.

**What the `merge_group` job does today** (the #3114 question). Not an
unconditional echo any more. `merge-group-verify` resolves the pull request
number out of the queue ref, fetches that pull request's head SHA, and requires
a `review-bot-ack` check-run on it with `status == "completed" and conclusion
== "success"`, failing closed on an unparseable ref, a missing pull request, or
a head whose gate never passed. I checked the ref regex against both spellings
the payload can carry:

```
refs/heads/gh-readonly-queue/main/pr-3199-4cf96c50...  -> 3199
gh-readonly-queue/main/pr-1857-75aa8698...            -> 1857
```

Its `if:` is `github.event_name == 'merge_group'`, the publish step is guarded
by `!cancelled()`, and the verdict defaults to `failure`. What it is *not* is
proven at runtime - see blocker 4.

**Both required contexts can report on a merge group.** `CI gate` comes from
`ci.yml`, whose `merge_group: {}` trigger takes no `paths` filter (filters are
only evaluated for `push` / `pull_request` / `pull_request_target`), so every
group runs CI including docs-only ones. `ci-gate-stub.yml` correctly has no
`merge_group` trigger. Exactly three jobs in `ci-gate`'s `needs:` carry an
event-gated `if:` - `test-macos`, `adapter-integration-macos`, `coverage-report`
- and all three are covered by the roll-up's tolerance buckets, with
`merge_group` present in `MACOS_SKIP_EVENTS`. That is now asserted rather than
inspected.

## Test evidence

TDD, red first. The new checkout guard against unmodified `origin/main`:

```
E  AssertionError: job 'merge-group-verify' checks out without an explicit `ref:`.
   actions/checkout then takes the triggering ref, which on a merge_group run is
   the queued entry's own branch, so this job would execute the candidate pull
   request's code under its `checks: write` token. Pin the base ref.
E  assert ''
FAILED tests/unit/test_review_bot_ack_workflow_yaml.py::test_every_checkout_pins_an_explicit_base_ref
1 failed, 15 passed in 2.81s
```

After the one-line workflow fix: `16 passed in 2.43s`.

Every new guard proven by mutation - break it, watch it catch, restore:

| Mutation | Result |
|---|---|
| `merge_group: {}` -> `merge_group: {branches: [main]}` in `ci.yml` | `test_ci_merge_group_trigger_carries_no_filter` FAILED |
| remove `merge_group: {}` from `review-bot-ack.yml` | `test_every_queue_required_context_has_a_merge_group_emitter` FAILED - "contexts ['review-bot-ack'] are required on the merge queue but no workflow emits them" |
| drop `"merge_group"` from `MACOS_SKIP_EVENTS` | `test_macos_tolerance_covers_the_merge_group_event` FAILED |
| `PUSH_ONLY = {"coverage-report"}` -> `{"autofix"}` | `test_event_gated_required_jobs_declare_their_merge_group_tolerance` FAILED, naming `coverage-report` and its `if:` |
| revert the `ref:` line | both checkout guards FAILED |

Tree restored after each (`git diff --stat .github/` empty but for the intended
17-line addition).

Full runs:

```
uv run pytest <all 30 workflow/queue guard test files> -q
403 passed in 62.53s

uv run ruff check src/ tests/ scripts/ --fix   -> All checks passed!
uv run ruff format <touched files>             -> 2 files left unchanged
uvx zizmor .github/workflows/review-bot-ack.yml -> No findings to report
uv run python scripts/gen_workflow_topology.py -> no diff (the edit adds no job or trigger)
```

## Out of scope, noted

`adapter-contract-drift.yml`, `mutation-fixed.yml` and
`static-analysis-extended.yml` also declare `merge_group: {}` and contain jobs
with `issues: write` / `pull-requests: write` / `security-events: write`. None
of them emits a required context, so they cannot wedge or forge the queue gate,
and I left them alone rather than widen this diff. Worth a separate pass.

Relates to #2966 (left open - see the blocker table above).
