### PR TITLE
test(audit): pin two unguarded determinism guarantees and vary cross-process chain coverage

### DIFF
--- a/docs/cluster/deployment-patterns.md
+++ b/docs/cluster/deployment-patterns.md
@@ -533,8 +533,22 @@ and `--no-check-anchors` when the audit chain is not available alongside it.
 - **STAR is unaffected.** A STAR deployment never materialises a journal, never
   provisions a MESH signing identity, and answers `409` on the gossip route.
 - **Shared filesystem.** When peers share one filesystem, they can append to
-  one journal file directly; cross-process appends serialise under an exclusive
-  advisory lock, so the chain stays linear.
+  one journal file directly. Cross-process appends serialise under an exclusive
+  advisory `flock` taken on a single lock file per directory, so the chain stays
+  linear **only where that lock is honoured across the writers**. It is:
+  - **Reliable** on local filesystems (ext4, xfs, btrfs, APFS, ZFS) and on
+    NFSv4, where lock state is carried in the protocol.
+  - **Not reliable** on NFSv3 without a working `lockd`, on SMB/CIFS, on 9p and
+    virtiofs guest shares, and on FUSE passthrough mounts such as sshfs. On
+    those, `flock` typically succeeds and locks nothing outside the local
+    client, so two hosts both recover the same chain tail and fork it.
+  - **Absent on Windows.** `fcntl` does not exist there, so the append section
+    is a documented no-op and only in-process locks order writers.
+
+  `bernstein doctor` reports which of these applies to the audit directory it
+  finds (`audit:chain-lock-filesystem`). Where the lock is not reliable, give
+  each host its own audit directory and reconcile the chains offline instead of
+  sharing one.
 
 ---
 

--- a/docs/operations/doctor.md
+++ b/docs/operations/doctor.md
@@ -53,6 +53,7 @@ note so the flag never crashes the diagnostic surface.
 | `adapter`       | `bernstein.cli.doctor.adapter_checks`                 | `bernstein.yaml`      |
 | `network`       | `bernstein.cli.doctor.network_checks`                 | `BERNSTEIN_OFFLINE=1` |
 | `environment`   | `bernstein.cli.doctor.environment_checks`             | env vars + file probes|
+| `environment`   | `bernstein.cli.doctor.audit_lock_checks`              | audit dir filesystem  |
 
 ### Installation checks
 
@@ -123,6 +124,30 @@ reporters can include the context automatically.
 Multiple markers can match simultaneously (for example, Docker inside
 GitHub Actions). The renderer suppresses the generic `CI` row when a
 more specific environment matched.
+
+### Audit-chain append lock
+
+`audit:chain-lock-filesystem` reports whether the audit directory sits where the
+chain's cross-process append lock actually works. Appends to
+`.sdd/audit/<day>.jsonl` serialise under `flock(LOCK_EX)` on one `.chain.lock`
+per directory; that is what stops two processes recovering the same chain tail
+and each appending a record carrying the same stale `prev_hmac`.
+
+| Result | When |
+|--------|------|
+| `ok`   | local filesystem (ext4, xfs, btrfs, APFS, ZFS) or any type not on the advisory list |
+| `warn` | NFS, SMB/CIFS, 9p, virtiofs, FUSE passthrough, or an overlay upper layer |
+| `warn` | no `fcntl` on this platform (Windows): the append section is a no-op |
+| `skip` | the filesystem type could not be determined |
+
+The type is read from `/proc/self/mountinfo` on Linux and from `mount` on
+macOS/BSD, taking the longest mount point that covers the directory. The check
+never returns `fail`: an operator running on a share has a working install and a
+deployment decision to make, and a red `doctor` would train them to ignore it.
+
+Remediation when it warns: keep the audit directory on a local filesystem, or
+give each host its own audit directory and reconcile the chains offline. See
+`docs/cluster/deployment-patterns.md`.
 
 ## Example output
 

--- a/src/bernstein/cli/display/summary_card.py
+++ b/src/bernstein/cli/display/summary_card.py
@@ -9,13 +9,18 @@ from __future__ import annotations
 
 import json
 import time
+from collections import Counter
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from rich import box
 from rich.console import Console
 from rich.table import Table
 from rich.text import Text
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 @dataclass
@@ -80,6 +85,67 @@ def _fmt_duration(seconds: float) -> str:
     if minutes:
         return f"{minutes}m {secs}s"
     return f"{secs}s"
+
+
+#: Rendered when an entry does not carry the field, matching the historical
+#: positional read. A downgrade record is written by the spawner and always
+#: carries both, so this is a defensive default rather than a live path.
+_DEFAULT_REQUESTED = "container"
+_DEFAULT_ACTUAL = "worktree"
+
+
+def _representative_downgrade(entries: Sequence[dict[str, str]]) -> tuple[str, str, int, int]:
+    """Return ``(requested, actual, pair_count, distinct_kinds)`` for a run.
+
+    The card names one requested-vs-actual pair, and which one it names must not
+    depend on the order the spawner happened to append in. Downgrades are
+    recorded from whichever spawn thread hit the fallback (see
+    ``SpawnerCore._record_isolation_downgrade``), so index ``0`` is whichever
+    thread won a race; with two downgrade kinds reachable in one run (#3028)
+    that made the same run render two different lines.
+
+    The pair is therefore chosen by a total order over the entries rather than
+    by position: most frequent first, ties broken on the pair itself. Any
+    permutation of the same downgrades yields the same answer.
+
+    ``pair_count`` counts only the entries that carry the chosen pair, and is
+    reported separately from the run total: attributing every downgrade in a
+    heterogeneous run to one pair overstates what happened to the boundary the
+    card names.
+
+    Args:
+        entries: Downgrade records, each with ``requested`` and ``actual``.
+
+    Returns:
+        The chosen pair, how many entries carry it, and how many distinct pairs
+        the run holds. ``(default, default, 0, 0)`` for an empty sequence.
+    """
+    counts: Counter[tuple[str, str]] = Counter(
+        (
+            str(entry.get("requested", _DEFAULT_REQUESTED)),
+            str(entry.get("actual", _DEFAULT_ACTUAL)),
+        )
+        for entry in entries
+    )
+    if not counts:
+        return _DEFAULT_REQUESTED, _DEFAULT_ACTUAL, 0, 0
+    (requested, actual), pair_count = min(counts.items(), key=lambda item: (-item[1], item[0]))
+    return requested, actual, pair_count, len(counts)
+
+
+def _downgrade_summary(entries: Sequence[dict[str, str]]) -> str:
+    """Render the isolation-downgrade cell for *entries*.
+
+    A run whose downgrades all share one pair keeps the original wording. A run
+    that holds more than one pair says so, and says how much of the run the
+    named pair accounts for, so the line cannot be read as covering downgrades
+    it does not describe.
+    """
+    requested, actual, pair_count, kinds = _representative_downgrade(entries)
+    total = len(entries)
+    if kinds <= 1:
+        return f"{requested} -> {actual} (x{total})"
+    return f"{requested} -> {actual} (x{pair_count} of {total} across {kinds} kinds)"
 
 
 def build_summary_card(data: RunSummaryData) -> Table:
@@ -157,11 +223,9 @@ def build_summary_card(data: RunSummaryData) -> Table:
     # a stronger boundary (``sandbox:`` config or ``--sandbox docker``) sees at
     # run level that a weaker one was used.
     if data.isolation_downgrades:
-        requested = data.isolation_downgrades[0].get("requested", "container")
-        actual = data.isolation_downgrades[0].get("actual", "worktree")
         table.add_row(
             "[yellow]Isolation downgrade[/yellow]",
-            f"[yellow]{requested} -> {actual} (x{len(data.isolation_downgrades)})[/yellow]",
+            f"[yellow]{_downgrade_summary(data.isolation_downgrades)}[/yellow]",
         )
 
     return table

--- a/src/bernstein/cli/doctor/__init__.py
+++ b/src/bernstein/cli/doctor/__init__.py
@@ -23,6 +23,11 @@ from bernstein.cli.doctor.adapter_checks import (
     check_adapter_binary,
     run_adapter_checks,
 )
+from bernstein.cli.doctor.audit_lock_checks import (
+    UNRELIABLE_FILESYSTEMS,
+    check_audit_lock_filesystem,
+    resolve_filesystem_type,
+)
 from bernstein.cli.doctor.environment_checks import (
     ENVIRONMENT_PROBES,
     detect_environments,
@@ -58,10 +63,12 @@ __all__ = [
     "ENVIRONMENT_PROBES",
     "PROVIDER_HOSTS",
     "STATUS_GLYPHS",
+    "UNRELIABLE_FILESYSTEMS",
     "DoctorResult",
     "DoctorStatus",
     "UnansweredTopic",
     "check_adapter_binary",
+    "check_audit_lock_filesystem",
     "check_provider_reachability",
     "detect_environments",
     "exit_code_for",
@@ -71,6 +78,7 @@ __all__ = [
     "load_unanswered_topics",
     "render_report",
     "render_suggestions",
+    "resolve_filesystem_type",
     "run_adapter_checks",
     "run_all",
     "run_environment_checks",

--- a/src/bernstein/cli/doctor/audit_lock_checks.py
+++ b/src/bernstein/cli/doctor/audit_lock_checks.py
@@ -1,0 +1,265 @@
+"""Warn when the audit chain's append lock cannot do its job (issue #3064).
+
+Cross-process appends to ``.sdd/audit/<day>.jsonl`` serialise under
+``flock(LOCK_EX)`` on a single ``.chain.lock`` per audit directory. That lock is
+what keeps two processes from recovering the same chain tail and each appending
+a record embedding the same stale ``prev_hmac``.
+
+``flock`` is not universal. It is honoured on local filesystems and on NFSv4; it
+is unreliable or client-local on NFSv3 without a working ``lockd``, on SMB/CIFS,
+and on 9p and FUSE passthrough mounts; and on Windows the append section is a
+documented no-op, because :mod:`fcntl` does not exist there and only in-process
+locks remain.
+
+An operator who puts ``.sdd`` on a network share therefore loses a guarantee
+without any signal. This probe gives them the signal. It never fails the doctor
+run: an unreliable lock is a deployment fact to weigh, not a broken install, and
+turning ``bernstein doctor`` red for a laptop on a mounted share would train
+operators to ignore it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from bernstein.cli.doctor.report import DoctorResult
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from collections.abc import Mapping
+
+__all__ = [
+    "CHECK_NAME",
+    "UNRELIABLE_FILESYSTEMS",
+    "check_audit_lock_filesystem",
+    "fstype_from_bsd_mount",
+    "fstype_from_mountinfo",
+    "resolve_filesystem_type",
+]
+
+#: Stable identifier for the check, as it appears in the doctor table.
+CHECK_NAME = "audit:chain-lock-filesystem"
+
+#: Filesystem types where ``flock`` does not reliably serialise writers on
+#: different hosts, mapped to what specifically goes wrong. Keys are matched
+#: case-insensitively against the type the OS reports.
+UNRELIABLE_FILESYSTEMS: dict[str, str] = {
+    "nfs": "NFSv3 needs a working lockd for flock to reach the server; without it the lock is client-local",
+    "nfs4": "NFSv4 carries locks in the protocol, but a server that drops lock state on restart still loses them",
+    "smbfs": "SMB does not map flock onto a cross-client lock",
+    "cifs": "CIFS does not map flock onto a cross-client lock",
+    "smb2": "SMB does not map flock onto a cross-client lock",
+    "9p": "9p passthrough mounts (VM and container shares) do not carry flock to the host",
+    "virtiofs": "virtiofs shares do not carry flock across the guest boundary",
+    "fuse.sshfs": "sshfs locks are client-local",
+    "fuse.s3fs": "object-store FUSE mounts have no lock semantics at all",
+    "overlay": "an overlay upper layer can hide writes from another mount namespace",
+}
+
+_REMEDIATION = (
+    "Move the audit directory to a local filesystem, or give each host its own "
+    "audit directory and reconcile the chains offline. See "
+    "docs/cluster/deployment-patterns.md."
+)
+
+
+def fstype_from_mountinfo(target: Path, mountinfo_text: str) -> str | None:
+    """Return the filesystem type serving ``target`` per Linux ``mountinfo``.
+
+    Each line is ``id parent major:minor root mountpoint options [tags] - fstype
+    source superopts``. The mount point is field 4 of the left half and the type
+    is field 0 of the right half; the optional tags before the ``-`` are what
+    makes positional parsing of the whole line wrong.
+
+    The longest matching mount point wins, so a bind mount nested inside another
+    filesystem is attributed to the nested mount rather than to its parent.
+
+    Args:
+        target: An absolute, resolved path.
+        mountinfo_text: Contents of ``/proc/self/mountinfo``.
+
+    Returns:
+        The filesystem type, or ``None`` when no mount point covers ``target``.
+    """
+    best: tuple[int, str] | None = None
+    for line in mountinfo_text.splitlines():
+        left, separator, right = line.partition(" - ")
+        if not separator:
+            continue
+        left_fields = left.split()
+        right_fields = right.split()
+        if len(left_fields) < 5 or not right_fields:
+            continue
+        mount_point = left_fields[4].replace("\\040", " ")
+        fstype = right_fields[0]
+        if not _covers(mount_point, target):
+            continue
+        if best is None or len(mount_point) > best[0]:
+            best = (len(mount_point), fstype)
+    return None if best is None else best[1]
+
+
+def fstype_from_bsd_mount(target: Path, mount_text: str) -> str | None:
+    """Return the filesystem type serving ``target`` per BSD ``mount`` output.
+
+    Lines read ``<source> on <mount point> (<type>, <flags...>)``. macOS has no
+    ``/proc``, and :func:`os.statvfs` does not expose ``f_fstypename`` through
+    Python, so the mount table is the portable source of the answer.
+
+    Args:
+        target: An absolute, resolved path.
+        mount_text: Output of ``mount`` with no arguments.
+
+    Returns:
+        The filesystem type, or ``None`` when no mount point covers ``target``.
+    """
+    best: tuple[int, str] | None = None
+    for line in mount_text.splitlines():
+        head, separator, tail = line.partition(" on ")
+        if not separator or not head:
+            continue
+        mount_point, paren, flags = tail.partition(" (")
+        if not paren:
+            continue
+        fstype = flags.split(",")[0].rstrip(")").strip()
+        if not fstype or not _covers(mount_point, target):
+            continue
+        if best is None or len(mount_point) > best[0]:
+            best = (len(mount_point), fstype)
+    return None if best is None else best[1]
+
+
+def _covers(mount_point: str, target: Path) -> bool:
+    """Whether ``mount_point`` is ``target`` or one of its ancestors."""
+    try:
+        mount = Path(mount_point)
+    except ValueError:  # pragma: no cover - defensive
+        return False
+    return target == mount or mount in target.parents
+
+
+def resolve_filesystem_type(
+    path: Path,
+    *,
+    mountinfo: Path | None = None,
+    mount_command: tuple[str, ...] = ("mount",),
+    platform: str | None = None,
+) -> str | None:
+    """Return the filesystem type serving ``path``, or ``None`` if unknown.
+
+    Best-effort by construction: an unknown type downgrades the check to a skip
+    rather than guessing, because a wrong warning about the audit directory is
+    worse than no warning.
+
+    Args:
+        path: Directory to resolve. Need not exist; the nearest existing
+            ancestor is used, which is what a not-yet-created ``.sdd/audit``
+            needs.
+        mountinfo: Override for ``/proc/self/mountinfo`` (tests).
+        mount_command: Override for the BSD ``mount`` invocation (tests).
+        platform: Override for :data:`sys.platform` (tests).
+    """
+    plat = sys.platform if platform is None else platform
+    target = _nearest_existing(path)
+
+    source = Path("/proc/self/mountinfo") if mountinfo is None else mountinfo
+    try:
+        text = source.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        text = ""
+    if text:
+        return fstype_from_mountinfo(target, text)
+
+    if plat.startswith(("darwin", "freebsd", "openbsd", "netbsd")):
+        try:
+            completed = subprocess.run(
+                list(mount_command),
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return None
+        if completed.returncode != 0:
+            return None
+        return fstype_from_bsd_mount(target, completed.stdout)
+
+    return None
+
+
+def _nearest_existing(path: Path) -> Path:
+    """Return ``path`` resolved, or its nearest existing resolved ancestor."""
+    resolved = Path(path).expanduser().resolve()
+    candidate = resolved
+    while not candidate.exists():
+        parent = candidate.parent
+        if parent == candidate:
+            break
+        candidate = parent
+    return candidate
+
+
+def check_audit_lock_filesystem(
+    audit_dir: Path,
+    *,
+    has_fcntl: bool | None = None,
+    filesystem: str | None = None,
+    advisories: Mapping[str, str] | None = None,
+) -> DoctorResult:
+    """Report whether the audit chain's append lock is reliable where it lives.
+
+    Args:
+        audit_dir: The audit directory, typically ``.sdd/audit``.
+        has_fcntl: Override for whether :mod:`fcntl` is importable (tests).
+        filesystem: Override for the resolved filesystem type (tests).
+        advisories: Override for :data:`UNRELIABLE_FILESYSTEMS` (tests).
+
+    Returns:
+        A :class:`DoctorResult`. Never ``fail``: this reports a property of the
+        deployment, and an operator on a mounted share has a working install.
+    """
+    table = UNRELIABLE_FILESYSTEMS if advisories is None else advisories
+    if has_fcntl is None:
+        from bernstein.core.security.audit import fcntl
+
+        has_fcntl = fcntl is not None
+
+    if not has_fcntl:
+        return DoctorResult(
+            name=CHECK_NAME,
+            category="environment",
+            status="warn",
+            detail=(
+                "this platform has no fcntl, so the audit chain's cross-process "
+                "append lock is a no-op; only threads inside one process are ordered"
+            ),
+            remediation="Run the writers that share one audit directory in a single process.",
+        )
+
+    fstype = resolve_filesystem_type(audit_dir) if filesystem is None else filesystem
+    if not fstype:
+        return DoctorResult(
+            name=CHECK_NAME,
+            category="environment",
+            status="skip",
+            detail=f"could not determine the filesystem serving {audit_dir}",
+        )
+
+    advisory = table.get(fstype.lower())
+    if advisory is None:
+        return DoctorResult(
+            name=CHECK_NAME,
+            category="environment",
+            status="ok",
+            detail=f"{audit_dir} is on {fstype}; flock serialises cross-process appends here",
+        )
+    return DoctorResult(
+        name=CHECK_NAME,
+        category="environment",
+        status="warn",
+        detail=f"{audit_dir} is on {fstype}: {advisory}",
+        remediation=_REMEDIATION,
+    )

--- a/src/bernstein/cli/doctor/report.py
+++ b/src/bernstein/cli/doctor/report.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
@@ -127,20 +128,29 @@ async def run_all(
     *,
     adapter_names: Iterable[str] | None = None,
     provider_names: Iterable[str] | None = None,
+    audit_dir: Path | None = None,
 ) -> list[DoctorResult]:
     """Run every doctor category and return the merged result list.
 
     The four categories run in parallel where safe. Installation checks
     remain synchronous because they shell out trivially and complete
     instantly.
+
+    Args:
+        adapter_names: Restrict the adapter probes.
+        provider_names: Restrict the network probes.
+        audit_dir: Audit directory to check the append lock against. Defaults
+            to ``.sdd/audit`` under the working directory.
     """
     from bernstein.cli.doctor.adapter_checks import run_adapter_checks
+    from bernstein.cli.doctor.audit_lock_checks import check_audit_lock_filesystem
     from bernstein.cli.doctor.environment_checks import run_environment_checks
     from bernstein.cli.doctor.network_checks import run_network_checks
     from bernstein.cli.install_check import check_installations
 
     install_results = _installation_to_doctor(check_installations())
     env_results = run_environment_checks()
+    env_results.append(check_audit_lock_filesystem(audit_dir or Path.cwd() / ".sdd" / "audit"))
 
     adapter_task = asyncio.create_task(run_adapter_checks(adapter_names))
     network_task = asyncio.create_task(run_network_checks(provider_names))

--- a/tests/unit/doctor/test_report.py
+++ b/tests/unit/doctor/test_report.py
@@ -118,12 +118,20 @@ def test_run_all_handles_empty_inputs(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(network_mod, "run_network_checks", empty)
     monkeypatch.setattr(env_mod, "run_environment_checks", lambda: [])
 
+    # The audit-lock probe (#3064) is a fifth source. It always emits exactly
+    # one row, so it is pinned to a sentinel here: the property under test is
+    # that ``run_all`` merges its sources and adds nothing of its own.
+    import bernstein.cli.doctor.audit_lock_checks as audit_lock_mod
+
+    sentinel = _make("skip", category="environment")
+    monkeypatch.setattr(audit_lock_mod, "check_audit_lock_filesystem", lambda *_a, **_k: sentinel)
+
     from bernstein.cli import install_check
 
     monkeypatch.setattr(install_check, "check_installations", lambda: [])
 
     results = asyncio.run(run_all())
-    assert results == []
+    assert results == [sentinel]
 
 
 def test_render_report_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/lineage/test_artifact_attempt_determinism.py
+++ b/tests/unit/lineage/test_artifact_attempt_determinism.py
@@ -1,0 +1,133 @@
+"""Hash-seed determinism of the artifact-attempt chain (issue #3071).
+
+``_concrete_keys`` accumulates declared outputs into a ``set`` and returns
+``tuple(sorted(...))``. The sort is load-bearing rather than cosmetic:
+:func:`reconcile_declared_outputs` walks that tuple in order and appends one
+spine entry per key, and each entry hashes its predecessor. Drop the sort and
+the chain the run produces becomes a function of ``PYTHONHASHSEED``, so two
+replays of the same declaration on the same inputs disagree on the head hash.
+
+Nothing in the existing suite could see that. ``tests/unit/lineage/
+test_artifact_attempt.py`` and ``tests/property/test_artifact_health_properties.py``
+are the only files that touch this module, and both compare orders *inside one
+interpreter at one hash seed* - the exact axis a randomised ``set`` iteration is
+invariant along. Removing the sort left all 37 of those tests green.
+
+So the probe runs in a child interpreter under an explicit ``PYTHONHASHSEED``
+and compares the artefact the guarantee is about: the spine head hash, plus the
+key order the reconciliation reports. Both are pinned because they can break
+independently - a later edit that sorts the *returned* list while appending in
+set order would keep the reported order stable and still fork the chain.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# Seeds the issue measured the divergence at, plus one more. ``0`` disables
+# randomisation entirely, so it is the odd one out and worth keeping.
+_HASH_SEEDS = ("0", "1", "12345", "777")
+
+# Eight declared outputs whose canonical keys are distinct strings, which is
+# what makes ``set`` iteration order seed-dependent. Any smaller set risks a
+# collision-free layout that happens to iterate in sorted order under every
+# seed we try, which would make the probe pass for the wrong reason.
+_DECLARED = [
+    "src/pkg/mod_alpha.py",
+    "src/pkg/mod_beta.py",
+    "src/pkg/mod_gamma.py",
+    "src/pkg/mod_delta.py",
+    "src/pkg/mod_epsilon.py",
+    "src/pkg/mod_zeta.py",
+    "src/pkg/mod_eta.py",
+    "src/pkg/mod_theta.py",
+]
+
+_PROBE = """
+import json, sys, tempfile
+sys.path.insert(0, {src!r})
+from pathlib import Path
+
+from bernstein.core.lineage.artifact_attempt import reconcile_declared_outputs
+
+declared = {declared!r}
+with tempfile.TemporaryDirectory() as td:
+    root = Path(td) / "lineage"
+    recorded = reconcile_declared_outputs(
+        root,
+        run_id="run-determinism",
+        declared=declared,
+        task_id="task-1",
+        actor="tester",
+        model="test-model",
+        hmac_key=b"determinism-probe-key-0123456789",
+        timestamp=0,
+        outcome="failed",
+        reason="probe",
+    )
+    head = json.loads((root / "run-determinism" / "spine.head").read_text(encoding="utf-8"))
+
+print(json.dumps({{"recorded": list(recorded), "head": head}}, sort_keys=True))
+"""
+
+
+def _probe_under_seed(seed: str) -> str:
+    """Run the reconciliation in a child interpreter at ``PYTHONHASHSEED=seed``."""
+    src = str(Path(__file__).resolve().parents[3] / "src")
+    env = os.environ.copy()
+    env["PYTHONHASHSEED"] = seed
+    proc = subprocess.run(
+        [sys.executable, "-c", _PROBE.format(src=src, declared=_DECLARED)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=120,
+    )
+    return proc.stdout.strip()
+
+
+def test_attempt_chain_head_is_identical_across_hash_seeds() -> None:
+    """The spine head over the same declaration does not depend on the hash seed.
+
+    Fails with four distinct head hashes when ``sorted()`` is removed from
+    ``_concrete_keys``, which is the guarantee this pins.
+    """
+    outputs = {seed: _probe_under_seed(seed) for seed in _HASH_SEEDS}
+    heads = {seed: json.loads(out)["head"]["head_hash"] for seed, out in outputs.items()}
+    assert len(set(heads.values())) == 1, f"attempt chain head diverged across hash seeds: {heads}"
+
+
+def test_recorded_key_order_is_identical_across_hash_seeds() -> None:
+    """The reported key order is the sorted order at every hash seed."""
+    orders = {seed: json.loads(_probe_under_seed(seed))["recorded"] for seed in _HASH_SEEDS}
+    distinct = {tuple(order) for order in orders.values()}
+    assert len(distinct) == 1, f"recorded key order diverged across hash seeds: {orders}"
+    assert next(iter(distinct)) == tuple(sorted(_DECLARED))
+
+
+def test_declaration_order_does_not_change_the_chain() -> None:
+    """Two spellings of one declaration set produce the same head.
+
+    Complements the seed axis: the sort has to normalise the *caller's* order
+    too, not only the interpreter's iteration order.
+    """
+    src = str(Path(__file__).resolve().parents[3] / "src")
+    env = os.environ.copy()
+    env["PYTHONHASHSEED"] = "0"
+    heads: list[str] = []
+    for declared in (_DECLARED, list(reversed(_DECLARED))):
+        proc = subprocess.run(
+            [sys.executable, "-c", _PROBE.format(src=src, declared=declared)],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=120,
+        )
+        heads.append(json.loads(proc.stdout)["head"]["head_hash"])
+    assert heads[0] == heads[1], f"declaration order changed the chain head: {heads}"

--- a/tests/unit/test_audit_chain_crossprocess_axes.py
+++ b/tests/unit/test_audit_chain_crossprocess_axes.py
@@ -1,0 +1,656 @@
+"""Cross-process audit-chain appends, varied along four axes (issue #3064).
+
+``tests/unit/test_audit_chain_crossprocess.py`` already races four processes
+against one audit directory and asserts the chain verifies. What it does not do
+is vary anything: one spelling of one directory, one day, no retention running,
+no exception unwinding out of the append path. Every defect found in this area
+so far was found by measurement rather than by the suite, and a single-vector
+test cannot tell whether a change to the append path preserved the property in
+the shapes that actually break it.
+
+The four axes here are the ones where the append section carries weight beyond
+"two writers, one file":
+
+``path spelling``
+    ``_chain_append_lock`` keys its in-process guard on ``(st_dev, st_ino)``
+    rather than on a path string, precisely so that a symlinked or dot-segmented
+    spelling of one directory maps to one guard. The flock is taken on
+    ``<dir>/.chain.lock``, which is one inode under every spelling. Workers here
+    are handed *different* spellings of the same directory.
+
+``day rollover crossed mid-append``
+    The lock file is a single stable ``.chain.lock`` per directory rather than
+    one per day, so a writer that has rolled to the next day still contends with
+    one still on the previous day. Workers cross a UTC midnight partway through
+    their appends, all at the same chain position, so the rollover is deterministic
+    rather than a function of how long the test happened to take.
+
+``archive concurrent with appends``
+    ``AuditLog.archive`` compresses and unlinks a segment inside the append
+    section, because the pair is not separable. A writer racing it must not
+    recover a head from a segment that is halfway through being replaced.
+
+``exception unwinding out of the append path``
+    The section's ``finally`` releases the flock and decrements the re-entrancy
+    depth. If either leaked, the next append in the same process would either
+    block on itself forever or silently skip the flock and stop excluding other
+    processes.
+
+Design notes
+------------
+
+Workers are real interpreters started with :mod:`subprocess`, not threads and
+not ``multiprocessing`` children: the defects this covers are ones a shared
+address space hides, and ``fork`` is unavailable on one of the platforms the
+suite runs on. They synchronise on a *filesystem* barrier taken after their
+imports and after ``AuditLog`` construction, so they genuinely race the append
+rather than serialising on interpreter startup.
+
+That barrier polls a file. It is test scaffolding and nothing else: the chain
+lock itself must stay a blocking ``flock`` with no deadline, because a polling
+or deadline-based append lock was measured to drop appends and is rejected.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import os
+import subprocess
+import sys
+import time
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.security.audit import (
+    AuditLog,
+    RetentionPolicy,
+    _audit_dir_key,
+    _chain_append_lock,
+    _inside_append_section,
+    fcntl,
+)
+
+_KEY = b"crossprocess-axes-key-0123456789"
+_SRC = str(Path(__file__).resolve().parents[2] / "src")
+
+requires_flock = pytest.mark.skipif(
+    fcntl is None,
+    reason=(
+        "the cross-process append lock is a documented no-op without fcntl "
+        "(Windows); only the in-process locks order appends there, so a "
+        "cross-process linearity assertion would be asserting something the "
+        "platform does not provide"
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Worker
+# ---------------------------------------------------------------------------
+
+_WORKER = '''
+"""One audit-chain writer, driven by a JSON config file."""
+
+import json
+import sys
+import time
+from pathlib import Path
+
+cfg = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+sys.path.insert(0, cfg["src"])
+
+from datetime import UTC, datetime, timedelta  # noqa: E402
+
+import bernstein.core.security.audit as audit_mod  # noqa: E402
+from bernstein.core.security.audit import AuditLog, RetentionPolicy  # noqa: E402
+
+audit_dir = Path(cfg["audit_dir"])
+barrier = Path(cfg["barrier"])
+key = cfg["key"].encode("utf-8")
+worker = cfg["worker"]
+events = cfg["events"]
+mode = cfg["mode"]
+
+if cfg.get("break_lock"):
+    # Reproduces the platform where the append section cannot take an OS lock.
+    audit_mod.fcntl = None
+
+if mode == "rollover":
+    _BASE = datetime(2026, 3, 14, 23, 59, 50, tzinfo=UTC)
+    _SWITCH_AT = cfg["switch_at"]
+
+    class _RolloverClock(datetime):
+        """A clock every worker agrees on, driven by chain length not wall time.
+
+        ``now`` is read inside the append section, so the number of records on
+        disk is stable while it is being counted and rises monotonically. Every
+        worker therefore crosses the same midnight at the same chain position,
+        which makes the rollover reproducible instead of a function of how long
+        the test took.
+        """
+
+        @classmethod
+        def now(cls, tz=None):
+            written = 0
+            for path in audit_dir.glob("*.jsonl"):
+                written += sum(1 for line in path.read_bytes().split(b"\\n") if line)
+            offset = timedelta(seconds=20) if written >= _SWITCH_AT else timedelta()
+            return _BASE + offset
+
+    audit_mod.datetime = _RolloverClock
+
+log = AuditLog(audit_dir, key=key)
+
+# Filesystem barrier, taken after imports and after construction so the
+# workers race the append rather than the interpreter start.
+(barrier / ("ready-" + worker)).write_text("1", encoding="utf-8")
+deadline = time.monotonic() + 60.0
+while not (barrier / "go").exists():
+    if time.monotonic() > deadline:
+        raise SystemExit("barrier timeout waiting for go")
+    time.sleep(0.002)
+
+if mode in {"append", "rollover"}:
+    for i in range(events):
+        log.log("concurrent.event", worker, "res", worker + "-" + str(i))
+
+elif mode == "archive":
+    result = log.archive(RetentionPolicy(retention_days=cfg["retention_days"]))
+    print(json.dumps({"archived": result.archived}))
+
+elif mode == "raise_then_append":
+    # The section must unwind cleanly: the flock is released and the
+    # re-entrancy depth returns to zero, so the appends below neither block on
+    # a leaked descriptor nor silently skip the lock.
+    try:
+        with log.append_transaction():
+            log.resync_head()
+            raise RuntimeError("deliberate unwind")
+    except RuntimeError:
+        pass
+    for i in range(events):
+        log.log("concurrent.event", worker, "res", worker + "-" + str(i))
+
+elif mode == "hold_lock":
+    from bernstein.core.security.audit import _chain_append_lock
+
+    with _chain_append_lock(audit_dir):
+        (barrier / "held").write_text("1", encoding="utf-8")
+        time.sleep(cfg["hold_seconds"])
+        # Written as the last act *inside* the section. Writing it after the
+        # block would leave a window between the flock dropping and the mark
+        # landing, and the prober would report a violation that never happened.
+        (barrier / "holder-done").write_text("1", encoding="utf-8")
+
+elif mode == "probe_lock":
+    from bernstein.core.security.audit import _chain_append_lock
+
+    deadline = time.monotonic() + 60.0
+    while not (barrier / "held").exists():
+        if time.monotonic() > deadline:
+            raise SystemExit("barrier timeout waiting for held")
+        time.sleep(0.002)
+    with _chain_append_lock(audit_dir):
+        print(json.dumps({"holder_had_finished": (barrier / "holder-done").exists()}))
+
+else:
+    raise SystemExit("unknown mode " + mode)
+'''
+
+
+def _write_worker(tmp_path: Path) -> Path:
+    path = tmp_path / "audit_worker.py"
+    path.write_text(_WORKER, encoding="utf-8")
+    return path
+
+
+def _spawn(
+    worker_script: Path,
+    tmp_path: Path,
+    *,
+    name: str,
+    audit_dir: Path | str,
+    barrier: Path,
+    mode: str,
+    events: int = 0,
+    **extra: object,
+) -> subprocess.Popen[str]:
+    cfg = {
+        "src": _SRC,
+        "audit_dir": str(audit_dir),
+        "barrier": str(barrier),
+        "key": _KEY.decode("utf-8"),
+        "worker": name,
+        "events": events,
+        "mode": mode,
+        **extra,
+    }
+    cfg_path = tmp_path / f"cfg-{name}.json"
+    cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
+    return subprocess.Popen(
+        [sys.executable, str(worker_script), str(cfg_path)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+    )
+
+
+def _release_barrier(barrier: Path, names: list[str], *, timeout: float = 90.0) -> None:
+    """Wait until every worker has signalled ready, then let them all go."""
+    deadline = time.monotonic() + timeout
+    while True:
+        if all((barrier / f"ready-{name}").exists() for name in names):
+            break
+        if time.monotonic() > deadline:
+            missing = [n for n in names if not (barrier / f"ready-{n}").exists()]
+            pytest.fail(f"workers never reached the barrier: {missing}")
+        time.sleep(0.005)
+    (barrier / "go").write_text("1", encoding="utf-8")
+
+
+def _reap(procs: list[subprocess.Popen[str]], *, timeout: float = 120.0) -> list[str]:
+    outs: list[str] = []
+    for proc in procs:
+        try:
+            out, err = proc.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.communicate()
+            pytest.fail("a worker did not finish; the append section most likely blocked on itself")
+        assert proc.returncode == 0, f"worker failed rc={proc.returncode}\nstdout={out}\nstderr={err}"
+        outs.append(out)
+    return outs
+
+
+def _live_lines(audit_dir: Path) -> int:
+    return sum(len([ln for ln in path.read_bytes().split(b"\n") if ln]) for path in audit_dir.glob("*.jsonl"))
+
+
+def _archived_lines(audit_dir: Path) -> int:
+    total = 0
+    for path in sorted(audit_dir.glob("archive/*.jsonl.gz")):
+        total += len([ln for ln in gzip.decompress(path.read_bytes()).split(b"\n") if ln])
+    return total
+
+
+def _run_writers(
+    tmp_path: Path,
+    *,
+    spellings: list[Path | str],
+    events: int,
+    mode: str = "append",
+    **extra: object,
+) -> None:
+    """Race one writer per spelling and reap them all."""
+    worker_script = _write_worker(tmp_path)
+    barrier = tmp_path / "barrier"
+    barrier.mkdir(exist_ok=True)
+    names = [f"w{i}" for i in range(len(spellings))]
+    procs = [
+        _spawn(
+            worker_script,
+            tmp_path,
+            name=name,
+            audit_dir=spelling,
+            barrier=barrier,
+            mode=mode,
+            events=events,
+            **extra,
+        )
+        for name, spelling in zip(names, spellings, strict=True)
+    ]
+    _release_barrier(barrier, names)
+    _reap(procs)
+
+
+# ---------------------------------------------------------------------------
+# Axis: the harness itself has teeth
+# ---------------------------------------------------------------------------
+
+
+@requires_flock
+def test_two_processes_never_occupy_the_append_section_at_once(tmp_path: Path) -> None:
+    """A second process cannot enter the section while the first holds it.
+
+    Deterministic in both directions, which the N-writers tests below are not:
+    the holder marks the section entered, sleeps for a fixed span, then marks it
+    left. The prober takes the section the instant it sees the entry mark, so if
+    it gets in it can only be because the lock did not exclude it.
+    """
+    audit_dir = tmp_path / "audit"
+    audit_dir.mkdir()
+    barrier = tmp_path / "barrier"
+    barrier.mkdir()
+    worker_script = _write_worker(tmp_path)
+
+    holder = _spawn(
+        worker_script,
+        tmp_path,
+        name="holder",
+        audit_dir=audit_dir,
+        barrier=barrier,
+        mode="hold_lock",
+        hold_seconds=2.0,
+    )
+    prober = _spawn(
+        worker_script,
+        tmp_path,
+        name="prober",
+        audit_dir=audit_dir,
+        barrier=barrier,
+        mode="probe_lock",
+    )
+    _release_barrier(barrier, ["holder", "prober"])
+    _, prober_out = _reap([holder, prober])
+    assert json.loads(prober_out)["holder_had_finished"] is True, (
+        "a second process entered the append section while the first still held it"
+    )
+
+
+@requires_flock
+def test_the_probe_reports_a_violation_when_the_lock_cannot_lock(tmp_path: Path) -> None:
+    """The same probe against a section that takes no OS lock reports the breach.
+
+    This is the teeth. A mutual-exclusion assertion that has never been seen to
+    fail proves nothing about the lock; running the identical harness against
+    the ``fcntl is None`` path - the one the code already documents as a no-op -
+    shows the assertion is load bearing.
+    """
+    audit_dir = tmp_path / "audit"
+    audit_dir.mkdir()
+    barrier = tmp_path / "barrier"
+    barrier.mkdir()
+    worker_script = _write_worker(tmp_path)
+
+    holder = _spawn(
+        worker_script,
+        tmp_path,
+        name="holder",
+        audit_dir=audit_dir,
+        barrier=barrier,
+        mode="hold_lock",
+        hold_seconds=2.0,
+        break_lock=True,
+    )
+    prober = _spawn(
+        worker_script,
+        tmp_path,
+        name="prober",
+        audit_dir=audit_dir,
+        barrier=barrier,
+        mode="probe_lock",
+        break_lock=True,
+    )
+    _release_barrier(barrier, ["holder", "prober"])
+    _, prober_out = _reap([holder, prober])
+    assert json.loads(prober_out)["holder_had_finished"] is False, (
+        "expected the no-lock variant to let a second process in; if this passes, "
+        "the probe is measuring something other than the lock"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Axis: path spelling
+# ---------------------------------------------------------------------------
+
+
+def _spelling_variants(audit_dir: Path, tmp_path: Path) -> list[Path | str]:
+    """Return distinct path strings that all name ``audit_dir``.
+
+    The dot-segment forms work everywhere. The symlink is added only where the
+    platform lets an unprivileged process create one, so the test degrades to
+    fewer spellings rather than failing on a Windows runner without developer
+    mode.
+    """
+    variants: list[Path | str] = [
+        str(audit_dir),
+        str(audit_dir.parent / "." / audit_dir.name),
+        str(audit_dir / "." / ".." / audit_dir.name),
+    ]
+    link = tmp_path / "audit-link"
+    try:
+        link.symlink_to(audit_dir, target_is_directory=True)
+    except (OSError, NotImplementedError):  # pragma: no cover - platform dependent
+        return variants
+    variants.append(str(link))
+    return variants
+
+
+def test_one_audit_dir_under_several_spellings_is_one_identity(tmp_path: Path) -> None:
+    """``_audit_dir_key`` folds every spelling onto one key.
+
+    The in-process guard is keyed on this. Two spellings that hashed apart would
+    hand one thread two guards for one directory, and the re-entrancy bookkeeping
+    would then re-take a flock it already holds.
+    """
+    audit_dir = tmp_path / "audit"
+    audit_dir.mkdir()
+    keys = {_audit_dir_key(Path(spelling)) for spelling in _spelling_variants(audit_dir, tmp_path)}
+    assert len(keys) == 1, f"spellings of one directory produced several identities: {keys}"
+
+
+@requires_flock
+def test_writers_using_different_spellings_share_one_chain(tmp_path: Path) -> None:
+    """Concurrent writers that name the directory differently still serialise."""
+    audit_dir = tmp_path / "audit"
+    audit_dir.mkdir()
+    spellings = _spelling_variants(audit_dir, tmp_path)
+    events = 15
+
+    _run_writers(tmp_path, spellings=spellings, events=events)
+
+    valid, errors = AuditLog(audit_dir, key=_KEY).verify()
+    assert valid, f"chain forked across path spellings: {errors[:5]}"
+    assert _live_lines(audit_dir) == len(spellings) * events
+    # One lock file, not one per spelling.
+    assert [p.name for p in audit_dir.glob(".chain.lock*")] == [".chain.lock"]
+
+
+# ---------------------------------------------------------------------------
+# Axis: day rollover crossed mid-append
+# ---------------------------------------------------------------------------
+
+
+@requires_flock
+def test_appends_that_cross_a_day_boundary_keep_one_chain(tmp_path: Path) -> None:
+    """Writers straddling UTC midnight contend on the same lock and stay linear.
+
+    The lock file is deliberately one stable ``.chain.lock`` per directory
+    rather than one per day. A per-day lock would let a writer that has already
+    rolled over append at the same time as one that has not, and the second
+    segment's first record would chain onto a head that moved underneath it.
+    """
+    audit_dir = tmp_path / "audit"
+    audit_dir.mkdir()
+    workers = 4
+    events = 10
+    total = workers * events
+
+    _run_writers(
+        tmp_path,
+        spellings=[audit_dir] * workers,
+        events=events,
+        mode="rollover",
+        switch_at=total // 2,
+    )
+
+    segments = sorted(p.name for p in audit_dir.glob("*.jsonl"))
+    assert segments == ["2026-03-14.jsonl", "2026-03-15.jsonl"], (
+        f"expected the run to straddle the rollover, got {segments}"
+    )
+    for name in segments:
+        assert (audit_dir / name).stat().st_size > 0
+
+    valid, errors = AuditLog(audit_dir, key=_KEY).verify()
+    assert valid, f"chain broke across the day rollover: {errors[:5]}"
+    assert _live_lines(audit_dir) == total
+
+
+# ---------------------------------------------------------------------------
+# Axis: archive concurrent with appends
+# ---------------------------------------------------------------------------
+
+
+def _seed_old_segment(audit_dir: Path, *, days_ago: int, count: int) -> str:
+    """Write ``count`` real chain records dated ``days_ago`` and return the stem."""
+    import bernstein.core.security.audit as audit_mod
+
+    stamp = datetime.now(tz=UTC) - timedelta(days=days_ago)
+
+    class _FrozenClock(datetime):
+        @classmethod
+        def now(cls, tz: object = None) -> datetime:
+            return stamp
+
+    real = audit_mod.datetime
+    audit_mod.datetime = _FrozenClock  # type: ignore[misc]
+    try:
+        log = AuditLog(audit_dir, key=_KEY)
+        for i in range(count):
+            log.log("seed.event", "seeder", "res", f"seed-{i}")
+    finally:
+        audit_mod.datetime = real  # type: ignore[misc]
+    return stamp.strftime("%Y-%m-%d")
+
+
+@requires_flock
+def test_archive_running_against_live_appends_loses_no_record(tmp_path: Path) -> None:
+    """Retention compressing an old segment does not race the writers appending.
+
+    ``archive`` compresses and unlinks inside the append section because an
+    append that landed between the copy and the unlink would exist only in the
+    file about to be removed. The writers here construct their ``AuditLog``
+    while the old segment is still live, so at least one of them recovers its
+    chain tail from a segment that retention is about to replace.
+    """
+    audit_dir = tmp_path / "audit"
+    audit_dir.mkdir()
+    seeded = 6
+    stem = _seed_old_segment(audit_dir, days_ago=40, count=seeded)
+
+    workers = 3
+    events = 12
+    worker_script = _write_worker(tmp_path)
+    barrier = tmp_path / "barrier"
+    barrier.mkdir()
+
+    names = [f"w{i}" for i in range(workers)]
+    procs = [
+        _spawn(
+            worker_script,
+            tmp_path,
+            name=name,
+            audit_dir=audit_dir,
+            barrier=barrier,
+            mode="append",
+            events=events,
+        )
+        for name in names
+    ]
+    names.append("archiver")
+    procs.append(
+        _spawn(
+            worker_script,
+            tmp_path,
+            name="archiver",
+            audit_dir=audit_dir,
+            barrier=barrier,
+            mode="archive",
+            retention_days=7,
+        )
+    )
+    _release_barrier(barrier, names)
+    outs = _reap(procs)
+
+    assert json.loads(outs[-1])["archived"] == [f"{stem}.jsonl"]
+    assert not (audit_dir / f"{stem}.jsonl").exists()
+
+    valid, errors = AuditLog(audit_dir, key=_KEY).verify()
+    assert valid, f"chain broke while retention ran against live appends: {errors[:5]}"
+    assert _archived_lines(audit_dir) + _live_lines(audit_dir) == seeded + workers * events
+
+
+# ---------------------------------------------------------------------------
+# Axis: an exception unwinding out of the append path
+# ---------------------------------------------------------------------------
+
+
+def test_an_exception_leaves_no_append_section_open(tmp_path: Path) -> None:
+    """The re-entrancy depth returns to zero when the body raises.
+
+    A leaked depth would make the *next* append in this thread believe it is
+    nested, skip the flock, and stop excluding other processes: a lock that
+    reports success and locks nothing.
+    """
+    audit_dir = tmp_path / "audit"
+    audit_dir.mkdir()
+
+    with pytest.raises(RuntimeError, match="deliberate"), _chain_append_lock(audit_dir):
+        assert _inside_append_section(audit_dir) is True
+        raise RuntimeError("deliberate unwind")
+
+    assert _inside_append_section(audit_dir) is False
+
+
+@requires_flock
+def test_a_writer_that_raised_still_excludes_another_process(tmp_path: Path) -> None:
+    """After an unwind, appends from two processes still produce one chain.
+
+    Covers the two ways the ``finally`` could leak: a descriptor still holding
+    the flock (the worker would block on itself and the reap would time out) and
+    a depth that never returned to zero (the worker would keep appending without
+    the flock and fork the chain against the second writer).
+    """
+    audit_dir = tmp_path / "audit"
+    audit_dir.mkdir()
+    events = 15
+    worker_script = _write_worker(tmp_path)
+    barrier = tmp_path / "barrier"
+    barrier.mkdir()
+
+    names = ["raiser", "plain"]
+    procs = [
+        _spawn(
+            worker_script,
+            tmp_path,
+            name="raiser",
+            audit_dir=audit_dir,
+            barrier=barrier,
+            mode="raise_then_append",
+            events=events,
+        ),
+        _spawn(
+            worker_script,
+            tmp_path,
+            name="plain",
+            audit_dir=audit_dir,
+            barrier=barrier,
+            mode="append",
+            events=events,
+        ),
+    ]
+    _release_barrier(barrier, names)
+    _reap(procs)
+
+    valid, errors = AuditLog(audit_dir, key=_KEY).verify()
+    assert valid, f"chain broke after an exception unwound out of the append path: {errors[:5]}"
+    assert _live_lines(audit_dir) == 2 * events
+
+
+# ---------------------------------------------------------------------------
+# The constant the archive axis leans on
+# ---------------------------------------------------------------------------
+
+
+def test_retention_policy_default_is_not_what_the_archive_axis_relies_on() -> None:
+    """Guard the constant the archive axis picks its dates against.
+
+    ``retention_days=7`` in the archive test is only meaningful while the
+    default window is wider than a few days; if the default shrank to zero the
+    axis would archive today's segment too and stop testing the race it names.
+    """
+    assert RetentionPolicy().retention_days >= 7

--- a/tests/unit/test_audit_chain_crossprocess_axes.py
+++ b/tests/unit/test_audit_chain_crossprocess_axes.py
@@ -179,6 +179,15 @@ elif mode == "hold_lock":
 
     with _chain_append_lock(audit_dir):
         (barrier / "held").write_text("1", encoding="utf-8")
+        # Do not leave the section until the prober has announced that it is
+        # about to take it. Under a working lock the prober is then blocked and
+        # the outcome is a function of the lock rather than of who the
+        # scheduler ran first.
+        deadline = time.monotonic() + 60.0
+        while not (barrier / "probing").exists():
+            if time.monotonic() > deadline:
+                raise SystemExit("barrier timeout waiting for probing")
+            time.sleep(0.002)
         time.sleep(cfg["hold_seconds"])
         # Written as the last act *inside* the section. Writing it after the
         # block would leave a window between the flock dropping and the mark
@@ -193,6 +202,7 @@ elif mode == "probe_lock":
         if time.monotonic() > deadline:
             raise SystemExit("barrier timeout waiting for held")
         time.sleep(0.002)
+    (barrier / "probing").write_text("1", encoding="utf-8")
     with _chain_append_lock(audit_dir):
         print(json.dumps({"holder_had_finished": (barrier / "holder-done").exists()}))
 
@@ -316,10 +326,12 @@ def _run_writers(
 def test_two_processes_never_occupy_the_append_section_at_once(tmp_path: Path) -> None:
     """A second process cannot enter the section while the first holds it.
 
-    Deterministic in both directions, which the N-writers tests below are not:
-    the holder marks the section entered, sleeps for a fixed span, then marks it
-    left. The prober takes the section the instant it sees the entry mark, so if
-    it gets in it can only be because the lock did not exclude it.
+    Timing-free, unlike the N-writers tests below: the holder does not leave the
+    section until the prober has announced it is about to take it, and marks the
+    section left as its last act inside. Under a working lock the prober is
+    blocked at that point, so it can only ever observe the mark, whatever the
+    scheduler does. ``hold_seconds`` is therefore zero here; it exists for the
+    no-lock twin, where the holder has to still be inside when the prober looks.
     """
     audit_dir = tmp_path / "audit"
     audit_dir.mkdir()
@@ -334,7 +346,7 @@ def test_two_processes_never_occupy_the_append_section_at_once(tmp_path: Path) -
         audit_dir=audit_dir,
         barrier=barrier,
         mode="hold_lock",
-        hold_seconds=2.0,
+        hold_seconds=0.0,
     )
     prober = _spawn(
         worker_script,
@@ -359,6 +371,12 @@ def test_the_probe_reports_a_violation_when_the_lock_cannot_lock(tmp_path: Path)
     fail proves nothing about the lock; running the identical harness against
     the ``fcntl is None`` path - the one the code already documents as a no-op -
     shows the assertion is load bearing.
+
+    The holder stays inside for five seconds after the prober announces itself.
+    The prober's announce-then-acquire-then-stat is a handful of syscalls, so
+    the margin is not a tuning knob to be trimmed: it is the gap between a
+    couple of milliseconds of work and a deschedule long enough to make a loaded
+    runner report a lock it does not have.
     """
     audit_dir = tmp_path / "audit"
     audit_dir.mkdir()
@@ -373,7 +391,7 @@ def test_the_probe_reports_a_violation_when_the_lock_cannot_lock(tmp_path: Path)
         audit_dir=audit_dir,
         barrier=barrier,
         mode="hold_lock",
-        hold_seconds=2.0,
+        hold_seconds=5.0,
         break_lock=True,
     )
     prober = _spawn(

--- a/tests/unit/test_doctor_audit_lock_checks.py
+++ b/tests/unit/test_doctor_audit_lock_checks.py
@@ -1,0 +1,207 @@
+"""The doctor probe for the audit chain's append lock (issue #3064).
+
+The chain's cross-process guarantee is an advisory ``flock`` on one lock file
+per audit directory. That is a guarantee about a *filesystem*, not about the
+product: an operator who puts ``.sdd`` on an SMB share or in a 9p guest mount
+loses it with no signal at all. This probe is the signal.
+
+Both mount-table parsers are exercised against captured text rather than
+against the machine running the test, so the Linux path is covered on macOS and
+the BSD path is covered on Linux. Anything the parser cannot answer degrades to
+a skip: a confident wrong answer about where the audit chain lives is worse than
+no answer.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.cli.doctor.audit_lock_checks import (
+    CHECK_NAME,
+    UNRELIABLE_FILESYSTEMS,
+    check_audit_lock_filesystem,
+    fstype_from_bsd_mount,
+    fstype_from_mountinfo,
+    resolve_filesystem_type,
+)
+
+# A trimmed /proc/self/mountinfo. The nfs line carries an optional field
+# (``shared:1``) before the ``-`` separator, which is exactly what breaks a
+# parser that splits the whole line positionally.
+_MOUNTINFO = """\
+23 28 0:21 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw
+25 28 0:6 / /dev rw,nosuid - devtmpfs udev rw,size=4045748k
+28 1 8:1 / / rw,relatime - ext4 /dev/sda1 rw
+41 28 0:38 / /srv/shared rw,relatime shared:1 - nfs4 10.0.0.4:/export rw,vers=4.2
+44 28 0:39 / /mnt/win rw,relatime - cifs //fileserver/share rw
+47 28 0:40 / /mnt/host rw,relatime - 9p host9p rw,trans=virtio
+"""
+
+_BSD_MOUNT = """\
+/dev/disk3s1s1 on / (apfs, sealed, local, read-only, journaled)
+devfs on /dev (devfs, local, nobrowse)
+/dev/disk3s5 on /System/Volumes/Data (apfs, local, journaled, nobrowse)
+//guest@nas._smb._tcp.local/media on /Volumes/media (smbfs, nodev, nosuid, mounted by op)
+"""
+
+
+# ---------------------------------------------------------------------------
+# Linux mountinfo
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("/", "ext4"),
+        ("/home/op/proj/.sdd/audit", "ext4"),
+        ("/srv/shared", "nfs4"),
+        ("/srv/shared/team/.sdd/audit", "nfs4"),
+        ("/mnt/win/.sdd/audit", "cifs"),
+        ("/mnt/host/work/.sdd/audit", "9p"),
+        ("/proc/self", "proc"),
+    ],
+)
+def test_mountinfo_attributes_a_path_to_its_longest_mount(path: str, expected: str) -> None:
+    """The nested mount wins, not its parent."""
+    assert fstype_from_mountinfo(Path(path), _MOUNTINFO) == expected
+
+
+def test_mountinfo_ignores_lines_without_the_separator() -> None:
+    """A truncated table yields no answer rather than a wrong one."""
+    assert fstype_from_mountinfo(Path("/srv/shared"), "23 28 0:21 / /srv/shared rw\n") is None
+
+
+def test_mountinfo_decodes_an_escaped_space_in_a_mount_point() -> None:
+    table = "28 1 8:1 / /mnt/my\\040share rw,relatime - cifs //srv/s rw\n"
+    assert fstype_from_mountinfo(Path("/mnt/my share/.sdd/audit"), table) == "cifs"
+
+
+# ---------------------------------------------------------------------------
+# BSD mount
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("/Users/op/proj/.sdd/audit", "apfs"),
+        ("/System/Volumes/Data/anything", "apfs"),
+        ("/Volumes/media/team/.sdd/audit", "smbfs"),
+        ("/dev/null", "devfs"),
+    ],
+)
+def test_bsd_mount_attributes_a_path_to_its_longest_mount(path: str, expected: str) -> None:
+    assert fstype_from_bsd_mount(Path(path), _BSD_MOUNT) == expected
+
+
+def test_bsd_mount_ignores_lines_it_cannot_parse() -> None:
+    assert fstype_from_bsd_mount(Path("/Volumes/media"), "some banner line\n") is None
+
+
+# ---------------------------------------------------------------------------
+# Resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolution_uses_mountinfo_when_it_exists(tmp_path: Path) -> None:
+    mountinfo = tmp_path / "mountinfo"
+    mountinfo.write_text(f"28 1 8:1 / {tmp_path} rw,relatime - nfs srv:/e rw\n", encoding="utf-8")
+    assert resolve_filesystem_type(tmp_path, mountinfo=mountinfo) == "nfs"
+
+
+def test_resolution_walks_up_to_an_existing_ancestor(tmp_path: Path) -> None:
+    """A ``.sdd/audit`` that has not been created yet still resolves."""
+    mountinfo = tmp_path / "mountinfo"
+    mountinfo.write_text(f"28 1 8:1 / {tmp_path} rw,relatime - cifs //srv/s rw\n", encoding="utf-8")
+    missing = tmp_path / "workspace" / ".sdd" / "audit"
+    assert resolve_filesystem_type(missing, mountinfo=mountinfo) == "cifs"
+
+
+def test_resolution_returns_none_on_a_platform_with_neither_source(tmp_path: Path) -> None:
+    assert (
+        resolve_filesystem_type(
+            tmp_path,
+            mountinfo=tmp_path / "does-not-exist",
+            platform="win32",
+        )
+        is None
+    )
+
+
+def test_resolution_survives_a_mount_command_that_is_not_there(tmp_path: Path) -> None:
+    assert (
+        resolve_filesystem_type(
+            tmp_path,
+            mountinfo=tmp_path / "does-not-exist",
+            mount_command=("this-binary-does-not-exist",),
+            platform="darwin",
+        )
+        is None
+    )
+
+
+# ---------------------------------------------------------------------------
+# The check
+# ---------------------------------------------------------------------------
+
+
+def test_a_local_filesystem_is_ok(tmp_path: Path) -> None:
+    result = check_audit_lock_filesystem(tmp_path, has_fcntl=True, filesystem="ext4")
+    assert (result.name, result.status) == (CHECK_NAME, "ok")
+    assert "ext4" in result.detail
+
+
+@pytest.mark.parametrize("fstype", sorted(UNRELIABLE_FILESYSTEMS))
+def test_every_listed_filesystem_warns_and_says_why(tmp_path: Path, fstype: str) -> None:
+    result = check_audit_lock_filesystem(tmp_path, has_fcntl=True, filesystem=fstype)
+    assert result.status == "warn"
+    assert fstype in result.detail
+    assert UNRELIABLE_FILESYSTEMS[fstype] in result.detail
+    assert result.remediation
+
+
+def test_the_type_is_matched_case_insensitively(tmp_path: Path) -> None:
+    assert check_audit_lock_filesystem(tmp_path, has_fcntl=True, filesystem="NFS4").status == "warn"
+
+
+def test_a_platform_without_fcntl_warns_before_it_looks_at_the_filesystem(tmp_path: Path) -> None:
+    """The lock is a no-op there whatever the disk is, so the disk is not consulted."""
+    result = check_audit_lock_filesystem(tmp_path, has_fcntl=False, filesystem="ext4")
+    assert result.status == "warn"
+    assert "no-op" in result.detail
+
+
+def test_an_unresolvable_filesystem_skips_rather_than_guesses(tmp_path: Path) -> None:
+    """No answer is reported as no answer, not as a clean bill of health."""
+    result = check_audit_lock_filesystem(tmp_path, has_fcntl=True, filesystem="")
+    assert result.status == "skip"
+    assert str(tmp_path) in result.detail
+
+
+def test_a_filesystem_not_on_the_advisory_list_reads_ok(tmp_path: Path) -> None:
+    """The list is a denylist: an unfamiliar local type is not warned about."""
+    result = check_audit_lock_filesystem(tmp_path, has_fcntl=True, filesystem="bcachefs")
+    assert result.status == "ok"
+
+
+def test_the_check_never_fails_the_doctor_run(tmp_path: Path) -> None:
+    """An operator on a share has a working install, not a broken one."""
+    statuses = {
+        check_audit_lock_filesystem(tmp_path, has_fcntl=True, filesystem=fstype).status
+        for fstype in [*UNRELIABLE_FILESYSTEMS, "ext4", "apfs", "btrfs", "xfs"]
+    }
+    statuses.add(check_audit_lock_filesystem(tmp_path, has_fcntl=False, filesystem="ext4").status)
+    assert "fail" not in statuses
+
+
+def test_the_check_is_wired_into_the_doctor_run(tmp_path: Path) -> None:
+    """``bernstein doctor`` carries the row; an unwired check helps nobody."""
+    import asyncio
+
+    from bernstein.cli.doctor.report import run_all
+
+    results = asyncio.run(run_all(adapter_names=[], provider_names=[], audit_dir=tmp_path / "audit"))
+    assert any(r.name == CHECK_NAME for r in results), [r.name for r in results]

--- a/tests/unit/test_summary_card_isolation_downgrade_determinism.py
+++ b/tests/unit/test_summary_card_isolation_downgrade_determinism.py
@@ -1,0 +1,153 @@
+"""The isolation-downgrade row does not depend on spawn scheduling (issue #3071).
+
+``SpawnerCore._record_isolation_downgrade`` appends to a plain list from
+whichever spawn thread hit the fallback. Which entry lands at index ``0`` is a
+function of thread scheduling, and the summary card used to render
+``isolation_downgrades[0]``. That was invisible while every downgrade in a run
+carried the same ``(requested, actual)`` pair; #3028 added a second downgrade
+kind, so one run can now hold two distinct pairs and the card can name either
+of them for the same run.
+
+The fix is in the display, not in the recording. Serialising the append under
+the sandbox audit lock would make append-and-emit atomic, but it would not
+change which entry a race puts first, so the card would stay scheduling
+dependent. Choosing the representative pair by a total order over the entries
+removes the dependency outright: any permutation of the same downgrades renders
+the same line.
+
+These tests fail on the positional implementation and pass on the ordered one.
+"""
+
+from __future__ import annotations
+
+import itertools
+from io import StringIO
+
+from rich.console import Console
+
+from bernstein.cli.display.summary_card import (
+    RunSummaryData,
+    _representative_downgrade,
+    build_summary_card,
+)
+
+
+def _downgrade(session: str, requested: str, actual: str) -> dict[str, str]:
+    return {
+        "session_id": session,
+        "requested": requested,
+        "actual": actual,
+        "reason": "probe",
+    }
+
+
+def _render(downgrades: list[dict[str, str]]) -> str:
+    data = RunSummaryData(
+        run_id="run-1",
+        tasks_completed=2,
+        tasks_total=2,
+        tasks_failed=0,
+        wall_clock_seconds=10.0,
+        total_cost_usd=0.0,
+        quality_score=None,
+        isolation_downgrades=downgrades,
+    )
+    buf = StringIO()
+    Console(file=buf, width=100, color_system=None).print(build_summary_card(data))
+    return buf.getvalue()
+
+
+def _downgrade_line(rendered: str) -> str:
+    lines = [ln for ln in rendered.splitlines() if "Isolation downgrade" in ln]
+    assert len(lines) == 1, f"expected exactly one downgrade row, got {lines}"
+    return lines[0]
+
+
+# ---------------------------------------------------------------------------
+# The permutation axis
+# ---------------------------------------------------------------------------
+
+
+def test_two_downgrade_kinds_render_identically_in_either_order() -> None:
+    """A heterogeneous run renders the same line whichever entry raced first."""
+    container = _downgrade("sess-a", "container", "worktree")
+    vm = _downgrade("sess-b", "vm", "container")
+
+    first = _downgrade_line(_render([container, vm]))
+    second = _downgrade_line(_render([vm, container]))
+
+    assert first == second, f"downgrade row depends on list order:\n{first}\n{second}"
+
+
+def test_every_permutation_of_a_mixed_run_renders_one_line() -> None:
+    """Order independence holds across the whole permutation group, not one swap.
+
+    Three entries, two kinds: six orderings, one rendered line. A rule that
+    happened to be stable under a single swap but not under rotation would pass
+    the two-entry case and fail here.
+    """
+    entries = [
+        _downgrade("sess-a", "container", "worktree"),
+        _downgrade("sess-b", "container", "worktree"),
+        _downgrade("sess-c", "vm", "container"),
+    ]
+    rendered = {_downgrade_line(_render(list(perm))) for perm in itertools.permutations(entries)}
+    assert len(rendered) == 1, f"downgrade row varies across permutations: {sorted(rendered)}"
+
+
+def test_homogeneous_run_still_names_the_pair_and_the_total() -> None:
+    """The single-kind case, which is the common one, keeps its wording."""
+    entries = [_downgrade(f"sess-{i}", "container", "worktree") for i in range(3)]
+    line = _downgrade_line(_render(entries))
+    assert "container -> worktree" in line
+    assert "x3" in line
+
+
+def test_mixed_run_reports_the_representative_count_not_the_total() -> None:
+    """A heterogeneous run must not attribute every downgrade to one pair.
+
+    Rendering ``requested -> actual (xN)`` with ``N`` the total says three
+    spawns fell back the way the named pair did, which is false when only two
+    of them did.
+    """
+    entries = [
+        _downgrade("sess-a", "container", "worktree"),
+        _downgrade("sess-b", "container", "worktree"),
+        _downgrade("sess-c", "vm", "container"),
+    ]
+    line = _downgrade_line(_render(entries))
+    assert "container -> worktree" in line
+    assert "2 of 3" in line
+    assert "2 kinds" in line
+
+
+# ---------------------------------------------------------------------------
+# The selection rule itself
+# ---------------------------------------------------------------------------
+
+
+def test_representative_is_the_most_frequent_pair() -> None:
+    entries = [
+        _downgrade("a", "vm", "container"),
+        _downgrade("b", "container", "worktree"),
+        _downgrade("c", "container", "worktree"),
+    ]
+    assert _representative_downgrade(entries) == ("container", "worktree", 2, 2)
+
+
+def test_equal_frequency_breaks_the_tie_lexicographically() -> None:
+    """A tie must resolve on the pair itself, never on arrival order."""
+    vm = _downgrade("a", "vm", "container")
+    container = _downgrade("b", "container", "worktree")
+    assert _representative_downgrade([vm, container]) == _representative_downgrade([container, vm])
+    assert _representative_downgrade([vm, container]) == ("container", "worktree", 1, 2)
+
+
+def test_missing_fields_fall_back_to_the_documented_defaults() -> None:
+    """An entry without the keys still resolves, as the positional read did."""
+    assert _representative_downgrade([{"session_id": "a"}]) == ("container", "worktree", 1, 1)
+
+
+def test_empty_input_is_not_reachable_from_the_card_but_is_still_total() -> None:
+    """The helper is total: the card guards on truthiness, the helper does not rely on it."""
+    assert _representative_downgrade([]) == ("container", "worktree", 0, 0)


### PR DESCRIPTION
Closes #3071
Closes #3064

Two ordering guarantees that held in the shipped code with no test protecting them, and the audit chain's cross-process append section, which had one test that varied nothing.

## #3071, guarantee 1: the sort in the artifact attempt chain

`_concrete_keys` accumulates declared outputs into a `set` and returns `tuple(sorted(...))`. `reconcile_declared_outputs` walks that tuple in order and appends one chained spine entry per key, so the sort decides the run's head hash.

The existing coverage could not see it. `tests/unit/lineage/test_artifact_attempt.py` and `tests/property/test_artifact_health_properties.py` compare declaration orders inside one interpreter at one hash seed, which is exactly the axis a randomised `set` iteration is invariant along.

The deliverable is a test, not a code change. `src/bernstein/core/lineage/artifact_attempt.py` is untouched.

Mutation 1, `return tuple(sorted(out))` -> `return tuple(out)`:

```
$ .venv/bin/python -m pytest tests/unit/lineage/test_artifact_attempt_determinism.py -q
FAILED tests/unit/lineage/test_artifact_attempt_determinism.py::test_attempt_chain_head_is_identical_across_hash_seeds
FAILED tests/unit/lineage/test_artifact_attempt_determinism.py::test_recorded_key_order_is_identical_across_hash_seeds
2 failed, 1 passed

$ .venv/bin/python -m pytest tests/unit/lineage/test_artifact_attempt.py tests/property/test_artifact_health_properties.py -q
37 passed
```

The four head hashes under that mutation, one per `PYTHONHASHSEED` in `{0, 1, 12345, 777}`:

```
sha256:37533d961301867b8b05a0276e9cc1b2ce9f9972f2b3f1f55c9440610686278e
sha256:f20226d20a98265aa532f8a2c9cd19e4e6f79d0863ccdcfd40d27dd82f48dbeb
sha256:abeba38887bb26d09eb7e1025f4591a86143d175b3f26bafec50ae784d77c93e
sha256:94eea64dc7ac48daf4a761f5ca2f2a2b70457e07c2789f95b5ba976f92ad7ad9
```

Mutation 2, the set replaced by a declaration-ordered list with no sort, kills the third test:

```
FAILED ...::test_recorded_key_order_is_identical_across_hash_seeds
FAILED ...::test_declaration_order_does_not_change_the_chain
2 failed, 1 passed
```

Unmutated: `3 passed`.

## #3071, guarantee 2: the isolation-downgrade row

The issue asks for the append to `SpawnerCore._isolation_downgrades` to move inside `_SANDBOX_AUDIT_LOCK`, or for the summary to select deterministically. **The first option does not fix the reported defect and is not implemented.** `list.append` is atomic under CPython, so no entry is lost or torn; what varies is which of two concurrently-downgrading spawn threads lands first, and `isolation_downgrades[0]` picks the winner of that race. Taking the audit lock around the append buys append-and-emit atomicity and leaves the ordering exactly as scheduling-dependent as before, so the card would stay nondeterministic. The issue's second option is implemented instead.

Reproduced against unmodified `origin/main` at 4cf96c509, same two downgrades in two orders:

```
order [a,b]: | Isolation downgrade  | container -> worktree (x2) |
order [b,a]: | Isolation downgrade  |     vm -> container (x2) |
IDENTICAL: False
```

Note the second defect visible in that output: `(x2)` in both spellings, while only one spawn used each pair. The fix picks the pair by a total order (most frequent, lexicographic tie-break) and, when a run holds more than one pair, reports how much of the run the named pair actually covers. A single-kind run, which is the common case, keeps its original wording byte for byte.

Mutation, the selection reverted to `entries[0]`:

```
FAILED ...::test_two_downgrade_kinds_render_identically_in_either_order
FAILED ...::test_every_permutation_of_a_mixed_run_renders_one_line
FAILED ...::test_representative_is_the_most_frequent_pair
FAILED ...::test_equal_frequency_breaks_the_tie_lexicographically
4 failed, 4 passed
```

## #3064: cross-process coverage for the chain

### On the issue's premise

The issue opens with "There is no test anywhere in `tests/` that exercises the audit chain from more than one process", evidenced by `grep -rn "_chain_append_lock" tests/` returning nothing. That grep is the wrong probe. `tests/unit/test_audit_chain_crossprocess.py::test_concurrent_process_appends_verify` exercises the lock through `AuditLog.log` and never names it, so it is invisible to the grep while being the test AC bullet 1 describes: four processes, a barrier taken after imports, verify plus a no-loss assertion. AC bullet 1 is already satisfied and is not re-implemented here.

What that test does not do is vary anything: one spelling of one directory, one day, no retention running, no exception unwinding out of the append path. That is what this PR adds, per AC bullet 3.

The doc line is at `docs/cluster/deployment-patterns.md:536`, not `:525`, and its subject is the MESH journal on a shared filesystem rather than the audit chain. The correction is still needed and is made; this PR says what it is actually correcting.

"A guarantee the lock cannot give" overstates the case. `flock` does work on local filesystems and on NFSv4. The honest statement, which is what the doc now carries, is that it is unreliable on specific network and passthrough filesystems and absent entirely on Windows.

### The four axes

`tests/unit/test_audit_chain_crossprocess_axes.py`. Workers are real interpreters started with `subprocess`, not threads and not `multiprocessing` children, synchronised on a filesystem barrier taken after imports and after `AuditLog` construction.

| Axis | What it leans on |
|---|---|
| Path spelling | `_audit_dir_key` folds `(st_dev, st_ino)`, so a symlinked or dot-segmented spelling maps to one guard and one `.chain.lock` inode |
| Day rollover mid-append | One stable `.chain.lock` per directory, not one per day, so a writer that has rolled over still contends with one that has not |
| Archive against live appends | `archive` compresses and unlinks inside the section, because an append landing between the copy and the unlink would exist only in the file about to be removed |
| Exception unwinding | The `finally` must release the flock and return the re-entrancy depth to zero, or the next append either blocks on itself or silently stops locking |

The rollover is driven off chain length rather than wall time, so every worker crosses the same midnight at the same chain position and the test does not depend on how long it took to run.

The barrier polls a file. That is test scaffolding only; the chain lock stays a blocking `flock` with no deadline, and no polling or deadline-based append lock is introduced.

### Teeth (AC bullet 2)

Two ways, one shipped and one demonstrated.

Shipped: `test_two_processes_never_occupy_the_append_section_at_once` measures mutual exclusion between two processes, and its twin `test_the_probe_reports_a_violation_when_the_lock_cannot_lock` runs the identical harness against a section that takes no OS lock and *requires* the breach. A pass on the first is only meaningful because the second proves the probe can see a violation.

The handshake is timing-free in the healthy direction: the holder does not leave the section until the prober has announced it is about to take it, and writes the section-left mark as its last act inside. Under a working lock the prober is provably blocked at that moment, so it can only ever observe the mark, whatever the scheduler does. The no-lock twin keeps a five second margin, which is the gap between the prober's handful of syscalls and a deschedule long enough to make a loaded runner report a lock it does not have.

Demonstrated: `_chain_append_lock` mutated so the flock is never taken (the `fcntl is None` branch forced on):

```
$ .venv/bin/python -m pytest tests/unit/test_audit_chain_crossprocess_axes.py tests/unit/test_audit_chain_crossprocess.py -q
FAILED tests/unit/test_audit_chain_crossprocess_axes.py::test_two_processes_never_occupy_the_append_section_at_once
FAILED tests/unit/test_audit_chain_crossprocess_axes.py::test_writers_using_different_spellings_share_one_chain
FAILED tests/unit/test_audit_chain_crossprocess_axes.py::test_appends_that_cross_a_day_boundary_keep_one_chain
FAILED tests/unit/test_audit_chain_crossprocess_axes.py::test_archive_running_against_live_appends_loses_no_record
FAILED tests/unit/test_audit_chain_crossprocess_axes.py::test_a_writer_that_raised_still_excludes_another_process
FAILED tests/unit/test_audit_chain_crossprocess.py::test_concurrent_process_appends_verify
6 failed, 5 passed
```

The rollover axis reports the fork concretely:

```
E  AssertionError: chain broke across the day rollover: [
E    '2026-03-14.jsonl:2: prev_hmac mismatch (expected cab0d8142c695433..., got 0000000000000000...)',
E    '2026-03-14.jsonl:2: HMAC mismatch (expected 176efdeed1b281bf..., got e6fdbdb90ef19e2a...)',
E    '2026-03-14.jsonl:3: prev_hmac mismatch (expected e6fdbdb90ef19e2a..., got cab0d8142c695433...)', ...]
```

Restored, same command: `11 passed`.

The five cross-process assertions carry `skipif(fcntl is None)`. On Windows the append section is a documented no-op, so asserting cross-process linearity there would be asserting something the platform does not provide; the doc now says so rather than the test pretending otherwise.

### Doc (AC bullet 4)

`docs/cluster/deployment-patterns.md:536` said the chain stays linear whenever peers share a filesystem. It now names reliable (local filesystems, NFSv4), not reliable (NFSv3 without `lockd`, SMB/CIFS, 9p, virtiofs, FUSE passthrough), and absent (Windows, no `fcntl`), plus what to do instead.

### Probe (AC bullet 5)

`bernstein doctor` gains `audit:chain-lock-filesystem`. It resolves the filesystem serving the audit directory from `/proc/self/mountinfo` on Linux and from `mount` on macOS/BSD, taking the longest covering mount point, and warns on the types above. It never returns `fail`: an operator on a share has a working install and a deployment decision, and a red `doctor` would train them to ignore it. An unresolvable type is reported as `skip` rather than as a clean bill of health.

Both mount-table parsers are unit-tested against captured text, so the Linux path is covered on macOS and the BSD path on Linux. Live on the machine this was written on:

```
fstype: apfs
ok | .../.sdd/audit is on apfs; flock serialises cross-process appends here
```

`tests/unit/doctor/test_report.py::test_run_all_handles_empty_inputs` asserted that `run_all` with its four sources stubbed empty returns `[]`. There are now five sources; the test stubs the fifth and keeps asserting the same property, that `run_all` merges its sources and adds nothing of its own.

## Local gates

```
uv run ruff check src/ tests/ scripts/ --fix   -> All checks passed!
uv run ruff format src/ tests/ scripts/        -> 4315 files left unchanged
uv run bernstein agents-md verify              -> OK  all 13 file(s) in sync
```

Touched test files, all green together:

```
$ .venv/bin/python -m pytest \
    tests/unit/test_audit_chain_crossprocess_axes.py \
    tests/unit/test_doctor_audit_lock_checks.py \
    tests/unit/doctor \
    tests/unit/test_summary_card_isolation_downgrade_determinism.py \
    tests/unit/lineage/test_artifact_attempt_determinism.py -q
118 passed
```

Plus the pre-existing audit-chain cross-process suites, unchanged and still green:

```
$ .venv/bin/python -m pytest tests/unit/test_audit_chain_crossprocess_axes.py \
    tests/unit/test_audit_chain_crossprocess.py \
    tests/integration/test_audit_chain_tear_stickiness.py -q
20 passed
```

No workflow file is touched, so `docs/operations/ci-topology.md` needs no regeneration. No serialized response-model field is added or removed, so the CLI golden snapshots are unaffected.

## Residual, deliberately out of scope

Alias discovery in `test_impact` keys on the name suffix `REDIRECT_MAP`; a third alias table registered under any other name would silently drop its edges. Unrelated to either issue here and worth its own ticket.
