### PR TITLE
fix(ci): key the issue-decompose concurrency group on the label its jobs filter on

### DIFF
--- a/.github/workflows/bernstein-issues-decompose.yml
+++ b/.github/workflows/bernstein-issues-decompose.yml
@@ -8,8 +8,27 @@ on:
   issues:
     types: [labeled]
 
+# The label name is part of the group key, not just the issue number.
+#
+# Every job below is gated on `github.event.label.name == 'bernstein'`, but
+# that gate is evaluated per job, after the run already exists. GitHub has no
+# label filter for `issues` triggers, so applying N labels to one issue always
+# creates N runs and N-1 of them have nothing to do.
+#
+# Keyed on the issue number alone, those N runs land in one group and
+# `cancel-in-progress` kills each as the next arrives. Adding eight labels to
+# a single issue therefore produced seven `cancelled` runs and one `skipped`
+# one, with zero real work in any of them. `cancelled` renders as a failure on
+# the branch, so ordinary triage labelling left a trail of red on `main` that
+# no amount of reading the logs could explain.
+#
+# Including the label name gives each label its own group. Runs for other
+# labels no longer contend, so they conclude `skipped`, which is the honest
+# neutral outcome for a run whose jobs were all filtered out. Two rapid
+# `bernstein` labels still share a group and still supersede each other, which
+# is the only case the cancellation was ever for.
 concurrency:
-  group: bernstein-decompose-${{ github.event.issue.number }}
+  group: bernstein-decompose-${{ github.event.issue.number }}-${{ github.event.label.name }}
   cancel-in-progress: true
 
 # Default-deny at workflow scope; jobs re-assert the minimum scopes they need.

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -18,7 +18,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/auto-heal.yml | Auto-heal v2 | workflow_call | - | 2 |
 | .github/workflows/auto-release.yml | Auto-release | workflow_call | - | 5 |
 | .github/workflows/bernstein-ci-fix.yml | Bernstein CI Fix | workflow_call | - | 4 |
-| .github/workflows/bernstein-issues-decompose.yml | Bernstein Issue Decompose | issues | {"cancel-in-progress": "true", "group": "bernstein-decompose-${{ github.event.issue.number }}"} | 4 |
+| .github/workflows/bernstein-issues-decompose.yml | Bernstein Issue Decompose | issues | {"cancel-in-progress": "true", "group": "bernstein-decompose-${{ github.event.issue.number }}-${{ github.event.label.name }}"} | 4 |
 | .github/workflows/bernstein-pr-review.yml | Bernstein PR Review | pull_request | {"cancel-in-progress": "true", "group": "bernstein-pr-${{ github.event.pull_request.number }}"} | 1 |
 | .github/workflows/bisect-on-red.yml | Bisect on Red | workflow_call | - | 1 |
 | .github/workflows/branch-protection-audit.yml | Branch protection audit | schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "branch-protection-audit-${{ github.ref }}"} | 1 |

--- a/tests/unit/test_issue_decompose_workflow_yaml.py
+++ b/tests/unit/test_issue_decompose_workflow_yaml.py
@@ -183,3 +183,41 @@ def test_diff_scope_is_validated_before_opening_pr() -> None:
     open_condition = open_pr_step.get("if", "")
     assert isinstance(open_condition, str)
     assert "steps.diff_scope.outputs.should_open_pr == 'true'" in open_condition
+
+
+def test_concurrency_group_includes_the_label_that_gates_every_job() -> None:
+    """An irrelevant label must not cancel a run, because cancelled reads as failed.
+
+    GitHub offers no label filter on an `issues` trigger, so applying N labels
+    to one issue always creates N runs and every job here discards N-1 of them
+    through `github.event.label.name == 'bernstein'`. That job-level gate runs
+    after the run exists, so the discarded runs still need somewhere to go.
+
+    If the concurrency group omits the label, all N land in one group and
+    `cancel-in-progress` kills each as the next arrives: labelling an issue
+    eight times produced seven `cancelled` runs, and `cancelled` renders as a
+    failure on the branch. Including the label gives each its own group, so a
+    run whose jobs are all filtered out concludes `skipped` instead, which is
+    what actually happened to it.
+    """
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    concurrency = _mapping(workflow.get("concurrency"))
+    group = concurrency.get("group")
+    assert isinstance(group, str)
+
+    jobs = workflow.get("jobs", {})
+    assert isinstance(jobs, dict)
+    gated_on_label = [
+        name for name, job in jobs.items() if "github.event.label.name" in str(_mapping(job).get("if", ""))
+    ]
+    assert gated_on_label, "expected the label gate this invariant is about"
+    assert len(gated_on_label) == len(jobs), "every job is gated on the label, so no run survives a different label"
+
+    assert "github.event.label.name" in group, (
+        "the concurrency group must vary with the label the jobs filter on, "
+        "or unrelated labels cancel each other and paint the branch red"
+    )
+
+    # The cancellation itself is still wanted for the case it was written for:
+    # two rapid `bernstein` labels on one issue share a group and supersede.
+    assert concurrency.get("cancel-in-progress") is True


### PR DESCRIPTION
## What was happening

`Bernstein Issue Decompose` was the single largest producer of cancelled workflow runs in this repository. Across the most recent 100 runs it accounted for every cancellation observed, and none of those cancelled runs did any work.

The mechanism is entirely local to the workflow's own configuration:

- It triggers on `issues: [labeled]`.
- Every one of its four jobs is gated on `github.event.label.name == 'bernstein'`.
- GitHub offers no label filter for an `issues` trigger, so applying N labels to an issue creates N runs regardless. The gate discards N-1 of them, but only per job, after the run already exists.
- The concurrency group was `bernstein-decompose-${{ github.event.issue.number }}`, so all N runs shared one group, and `cancel-in-progress: true` killed each as the next arrived.

Labelling one issue with eight labels produced seven `cancelled` runs and one `skipped` run. `cancelled` renders as a failure against the branch, so routine triage labelling left red marks on `main` that no log could account for: the runs were killed before their jobs ever evaluated the condition that would have discarded them cleanly.

## The change

The group now includes the label name:

```yaml
group: bernstein-decompose-${{ github.event.issue.number }}-${{ github.event.label.name }}
```

Each label gets its own lane. Runs for unrelated labels no longer contend and conclude `skipped`, which is the accurate description of a run whose jobs were all filtered out. Two rapid `bernstein` labels on the same issue still share a group and still supersede each other, which is the only situation the cancellation was written for. `cancel-in-progress` is unchanged.

## Verification

`test_concurrency_group_includes_the_label_that_gates_every_job` asserts the invariant: when every job filters on a payload field, the concurrency group must vary with that field, and the supersede behaviour must be retained.

It was mutation-proved rather than merely written. Against the previous group expression:

```
E       assert 'github.event.label.name' in 'bernstein-decompose-${{ github.event.issue.number }}'
FAILED tests/unit/test_issue_decompose_workflow_yaml.py::test_concurrency_group_includes_the_label_that_gates_every_job
1 failed, 1 warning in 0.66s
```

Against this branch:

```
7 passed, 1 warning in 1.14s
```

`zizmor` reports no findings on the edited workflow, and `docs/operations/ci-topology.md` is regenerated so the topology drift check stays green.

## Scope

Only this workflow has the shape. A sweep of `.github/workflows` for the combination of `cancel-in-progress: true` with a job-level gate on an event field that varies between events in the same group returned one other candidate, `pr-policy.yml`, which reads `github.event.action` into an environment variable rather than gating on it; its per-pull-request group is correct, because a superseded policy run there genuinely should be cancelled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Improved handling of concurrent issue-label processing runs.
  * Runs for different labels on the same issue can now proceed independently, while duplicate runs for the same label are cancelled.

* **Documentation**
  * Updated CI topology documentation to reflect the revised concurrency behavior.

* **Tests**
  * Added coverage verifying label-based concurrency grouping, job gating, and cancellation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->