### PR TITLE
fix(packaging): make the shipped README work off the repository, advertise 3.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@
 [![PyPI](https://img.shields.io/pypi/v/bernstein)](https://pypi.org/project/bernstein/)
 [![GHCR](https://img.shields.io/badge/ghcr.io-bernstein-2496ed?logo=docker&logoColor=white)](https://ghcr.io/sipyourdrink-ltd/bernstein)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-3776ab?logo=python&logoColor=white)](https://python.org)
-[![License](https://img.shields.io/github/license/sipyourdrink-ltd/bernstein)](LICENSE)
+[![License](https://img.shields.io/github/license/sipyourdrink-ltd/bernstein)](https://github.com/sipyourdrink-ltd/bernstein/blob/main/LICENSE)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/sipyourdrink-ltd/bernstein/badge)](https://scorecard.dev/viewer/?uri=github.com/sipyourdrink-ltd/bernstein)
 [![CodeQL](https://github.com/sipyourdrink-ltd/bernstein/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/sipyourdrink-ltd/bernstein/actions/workflows/codeql.yml)
 [![Open in Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sipyourdrink-ltd/bernstein?quickstart=1)
 [![MCP Toplist](https://mcptoplist.com/badge/io.github.sipyourdrink-ltd%2Fbernstein.svg)](https://mcptoplist.com/server/io.github.sipyourdrink-ltd%2Fbernstein)
 
-[website](https://bernstein.run) &middot; [docs](https://bernstein.readthedocs.io/) &middot; [install](docs/getting-started/install.md) &middot; [first run](docs/getting-started/first-run.md) &middot; [glossary](docs/reference/GLOSSARY.md) &middot; [limitations](docs/reference/KNOWN_LIMITATIONS.md) &middot; [sponsor](https://github.com/sponsors/chernistry)
+[website](https://bernstein.run) &middot; [docs](https://bernstein.readthedocs.io/) &middot; [install](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/getting-started/install.md) &middot; [first run](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/getting-started/first-run.md) &middot; [glossary](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/GLOSSARY.md) &middot; [limitations](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/KNOWN_LIMITATIONS.md) &middot; [sponsor](https://github.com/sponsors/chernistry)
 
 </div>
 
@@ -39,7 +39,7 @@ Four things set it apart; everything after is detail.
 - **Isolated by construction.** Each task gets its own git worktree behind merge gates. No shared mutable state between agents.
 - **Broad and local.** 40+ CLI agent adapters plus a generic `--prompt` wrapper, file-based state, no SaaS hop, no third-party data plane.
 
-The full list is on the [capabilities page](docs/reference/capabilities.md); the [feature matrix](docs/reference/FEATURE_MATRIX.md) is the exhaustive index.
+The full list is on the [capabilities page](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/capabilities.md); the [feature matrix](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/FEATURE_MATRIX.md) is the exhaustive index.
 
 ### install in 30 seconds
 
@@ -49,7 +49,7 @@ bernstein init
 bernstein -g "fix the failing test in tests/test_foo.py"
 ```
 
-pip, uv, brew, dnf, npm, Docker, and the air-gapped wheelhouse are covered in the [install guide](docs/getting-started/install.md).
+pip, uv, brew, dnf, npm, Docker, and the air-gapped wheelhouse are covered in the [install guide](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/getting-started/install.md).
 
 <img alt="Bernstein in action: parallel AI agents orchestrated in real time" src="docs/assets/in-action-small.gif" width="700">
 
@@ -76,7 +76,7 @@ Each goal moves through four stages:
 3. **Verify**. The janitor checks concrete signals: tests pass, files exist, lint clean, types correct.
 4. **Merge**. Verified work lands in main. Failed tasks get retried or routed to a different model.
 
-Why the scheduler is plain Python, and what that trades away: [why deterministic](docs/architecture/WHY_DETERMINISTIC.md).
+Why the scheduler is plain Python, and what that trades away: [why deterministic](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/architecture/WHY_DETERMINISTIC.md).
 
 ### everyday commands
 
@@ -89,11 +89,11 @@ bernstein run plan.yaml           # multi-stage plan: skip LLM planning, execute
 bernstein stop                    # graceful shutdown with drain
 ```
 
-The full operator surface (PR automation, schedules, chat bridges, the autofix daemon) is in [operator commands](docs/operations/commands.md).
+The full operator surface (PR automation, schedules, chat bridges, the autofix daemon) is in [operator commands](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/operations/commands.md).
 
 ### supported agents
 
-Claude Code, Codex CLI, Gemini CLI, GitHub Copilot CLI, Cursor, Aider, Goose, OpenAI Agents SDK, Amp, Cody, Continue, Devin Terminal, Junie, Kilo, Kiro, AWS Q Developer, Ollama, OpenCode, OpenHands, Open Interpreter, gptme, Plandex, AIChat, Letta Code, Qwen, and more. The [adapter index](docs/adapters/index.md) carries the full table with install commands; anything else with a `--prompt` flag works through the generic wrapper.
+Claude Code, Codex CLI, Gemini CLI, GitHub Copilot CLI, Cursor, Aider, Goose, OpenAI Agents SDK, Amp, Cody, Continue, Devin Terminal, Junie, Kilo, Kiro, AWS Q Developer, Ollama, OpenCode, OpenHands, Open Interpreter, gptme, Plandex, AIChat, Letta Code, Qwen, and more. The [adapter index](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/adapters/index.md) carries the full table with install commands; anything else with a `--prompt` flag works through the generic wrapper.
 
 Mix agents in the same run: cheap local models for boilerplate, heavier cloud models for architecture. `bernstein integrations list --installed` shows what is available on your machine.
 
@@ -103,13 +103,13 @@ Everything deep lives on the [docs site](https://bernstein.readthedocs.io/):
 
 | | |
 |---|---|
-| [capabilities](docs/reference/capabilities.md) | the full capability list: MCP server mode, signed agent cards, sandbox backends, artifact sinks, regulatory mappings |
-| [who this is for](docs/use-cases.md) | where the value lands, and where Bernstein is the wrong tool |
-| [workflows](docs/operations/workflow-manifests.md) | declarative YAML DAGs of agent / command / loop nodes |
-| [web UI](docs/gui/index.md) | browser dashboard on the same API the TUI uses |
-| [cloud execution](docs/cloudflare/cloudflare-overview.md) | run agents on Cloudflare Workers with R2 workspace sync |
-| [security](docs/operations/security.md) | scorecard, fuzzing, hardening |
-| [architecture](docs/architecture/ARCHITECTURE.md) | how it works under the hood |
+| [capabilities](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/capabilities.md) | the full capability list: MCP server mode, signed agent cards, sandbox backends, artifact sinks, regulatory mappings |
+| [who this is for](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/use-cases.md) | where the value lands, and where Bernstein is the wrong tool |
+| [workflows](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/operations/workflow-manifests.md) | declarative YAML DAGs of agent / command / loop nodes |
+| [web UI](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/gui/index.md) | browser dashboard on the same API the TUI uses |
+| [cloud execution](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/cloudflare/cloudflare-overview.md) | run agents on Cloudflare Workers with R2 workspace sync |
+| [security](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/operations/security.md) | scorecard, fuzzing, hardening |
+| [architecture](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/architecture/ARCHITECTURE.md) | how it works under the hood |
 
 ### why the name?
 
@@ -125,15 +125,15 @@ Listed in [vinta/awesome-python](https://github.com/vinta/awesome-python), cover
 <summary>All coverage: 20+ awesome lists, directories, newsletters, and peer citations</summary>
 <br>
 
-The full tracked list, including every awesome-list entry, catalog listing, prior-art citation, and newsletter mention, lives in [docs/mentions.md](docs/mentions.md). Entries are added as they appear; corrections welcome by issue or PR.
+The full tracked list, including every awesome-list entry, catalog listing, prior-art citation, and newsletter mention, lives in [docs/mentions.md](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/mentions.md). Entries are added as they appear; corrections welcome by issue or PR.
 
 </details>
 
 ### contributing, support, license
 
-PRs welcome; [CONTRIBUTING.md](CONTRIBUTING.md) has setup and code style. Security reports go through [SECURITY.md](SECURITY.md). If Bernstein saves you time: [GitHub Sponsors](https://github.com/sponsors/chernistry). Contact: [forte@bernstein.run](mailto:forte@bernstein.run).
+PRs welcome; [CONTRIBUTING.md](https://github.com/sipyourdrink-ltd/bernstein/blob/main/CONTRIBUTING.md) has setup and code style. Security reports go through [SECURITY.md](https://github.com/sipyourdrink-ltd/bernstein/blob/main/SECURITY.md). If Bernstein saves you time: [GitHub Sponsors](https://github.com/sponsors/chernistry). Contact: [forte@bernstein.run](mailto:forte@bernstein.run).
 
-Citation metadata lives in [CITATION.cff](CITATION.cff). License: [Apache-2.0](LICENSE).
+Citation metadata lives in [CITATION.cff](https://github.com/sipyourdrink-ltd/bernstein/blob/main/CITATION.cff). License: [Apache-2.0](https://github.com/sipyourdrink-ltd/bernstein/blob/main/LICENSE).
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development",
     "Topic :: Software Development :: Build Tools",
     "Topic :: Software Development :: Code Generators",

--- a/tests/unit/test_packaged_readme_renders_off_repo.py
+++ b/tests/unit/test_packaged_readme_renders_off_repo.py
@@ -1,0 +1,108 @@
+"""The README ships inside the wheel, so it has to work away from the repo.
+
+`pyproject.toml` sets `readme = "README.md"`, which makes this file the
+package's long description. PyPI renders that description standalone: there is
+no repository around it, so a link written as `docs/getting-started/install.md`
+resolves against `https://pypi.org/project/bernstein/` and 404s.
+
+Nothing caught this when the README was rebuilt as a front page. The previous
+README was one self-contained 70KB document that mostly linked outward; the
+front-page rewrite replaced it with a short page whose whole job is pointing at
+files elsewhere in the repository, and every one of those pointers was written
+in the form that only works on github.com.
+
+These tests fix the packaged artefact against the surface it is published on,
+rather than against the surface it is authored on.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+README = REPO_ROOT / "README.md"
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+LINK = re.compile(r"\]\(([^)]+)\)")
+OFF_REPO_SAFE = ("http://", "https://", "#", "mailto:")
+
+
+def _links() -> list[str]:
+    return LINK.findall(README.read_text(encoding="utf-8"))
+
+
+def _project() -> dict[str, object]:
+    with PYPROJECT.open("rb") as handle:
+        data = tomllib.load(handle)
+    project = data.get("project")
+    assert isinstance(project, dict)
+    return project
+
+
+def test_readme_is_the_packaged_long_description() -> None:
+    """The premise of every other test here. If this changes, they stop mattering."""
+    assert _project().get("readme") == "README.md"
+
+
+def test_no_readme_link_depends_on_the_repository_around_it() -> None:
+    relative = [link for link in _links() if not link.startswith(OFF_REPO_SAFE)]
+    assert not relative, (
+        "these README links resolve only inside the repository, so they 404 on "
+        f"PyPI where this file is the project description: {sorted(set(relative))}"
+    )
+
+
+def test_readme_absolute_links_point_at_paths_this_repo_actually_has() -> None:
+    """An absolute link is not automatically a working one.
+
+    Rewriting a relative path to a blob URL is a mechanical edit, and a typo in
+    it fails in exactly the place nobody looks: rendered on PyPI, months later.
+    Checking the path component against the working tree catches that here
+    instead, without needing the network.
+    """
+    blob = "https://github.com/sipyourdrink-ltd/bernstein/blob/main/"
+    broken: list[str] = []
+    for link in _links():
+        if not link.startswith(blob):
+            continue
+        path = link[len(blob) :].split("#", 1)[0]
+        if not (REPO_ROOT / path).exists():
+            broken.append(link)
+    assert not broken, f"README links to paths this repository does not contain: {broken}"
+
+
+def test_python_classifiers_match_the_versions_the_project_supports() -> None:
+    """A classifier is what package indexes filter on, so a stale one hides the project.
+
+    `requires-python` is the enforced floor and the CI matrix is the tested set;
+    the classifier list is the advertised one, and it drifts silently because
+    nothing fails when it lags.
+    """
+    classifiers = _project().get("classifiers")
+    assert isinstance(classifiers, list)
+    advertised = {
+        item.rsplit(" :: ", 1)[-1]
+        for item in classifiers
+        if isinstance(item, str) and item.startswith("Programming Language :: Python :: 3.")
+    }
+
+    # Only `python-version:` assignments count as the tested set. Scanning the
+    # whole file for version-shaped text reads prose as configuration: ci.yml
+    # carries the comment "3.11 is intentionally excluded", and a loose scan
+    # turns that sentence into a demand to advertise 3.11, which
+    # `requires-python = ">=3.12"` refuses to install on.
+    ci = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    tested: set[str] = set()
+    for line in ci.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#") or not stripped.startswith("python-version:"):
+            continue
+        tested.update(re.findall(r"3\.\d+", stripped))
+
+    assert tested, "expected to find python-version assignments in ci.yml"
+    assert tested <= advertised, (
+        f"CI tests Python {sorted(tested - advertised)} but the classifiers do not "
+        "advertise it, so index filters exclude the project from those searches"
+    )


### PR DESCRIPTION
## What is wrong on the published page

`pyproject.toml` sets `readme = "README.md"`, which makes that file the package's long description. The index renders it standalone, with no repository around it, so a link written as `docs/getting-started/install.md` resolves against the project page URL and 404s.

Every one of the twenty relative links in the README was in that form. The front-page rewrite replaced a self-contained document with a short page whose purpose is pointing at files elsewhere in the repository, and each pointer was written the way that works on github.com and nowhere else. Nothing in the build or the test suite looked at the README from the surface it is published on, so this was only visible by reading the rendered project page.

Separately, the classifier list stopped at 3.13 while CI has been testing 3.14 since #3188. Classifiers are what index filters use, so the project was excluded from 3.14 searches while actually supporting it.

## The change

- All twenty relative links are now absolute. Each was verified individually to return 200.
- `Programming Language :: Python :: 3.14` is added. `requires-python` stays at `>=3.12` and is unchanged.
- Four guards fix the packaged artefact against the surface it is published on.

The sibling npm and VS Code READMEs were checked for the same shape and carry no relative links, so this is confined to the Python package.

## Verification on the built artefact, not on the source tree

```
Checking dist/bernstein-3.10.0-py3-none-any.whl: PASSED

Description-Content-Type: text/markdown
classifiers 3.x: ['3.12', '3.13', '3.14']
long_description bytes: 10840
relative links in the SHIPPED description: none
```

The 10840 bytes confirm the wheel carries the current front page rather than the previous 70KB document.

## The guards, and one of them being wrong first

Each guard was mutation-proved rather than merely asserted to pass.

`test_no_readme_link_depends_on_the_repository_around_it`, against the previous README:

```
E  AssertionError: these README links resolve only inside the repository, so they 404 on PyPI
   where this file is the project description: ['CITATION.cff', 'CONTRIBUTING.md', 'LICENSE', ...]
```

`test_readme_absolute_links_point_at_paths_this_repo_actually_has`, against a deliberately corrupted URL, because rewriting twenty links by hand is exactly where a typo hides:

```
E  AssertionError: README links to paths this repository does not contain:
   ['https://github.com/sipyourdrink-ltd/bernstein/blob/main/CONTRIBUTNG.md']
```

`test_python_classifiers_match_the_versions_the_project_supports`, against the previous classifier list:

```
E  AssertionError: CI tests Python ['3.14'] but the classifiers do not advertise it
E  assert {'3.12', '3.13', '3.14'} <= {'3.12', '3.13'}
```

That last guard was wrong on its first draft, and the mutation run is what exposed it. Scanning ci.yml for version-shaped text pulled "3.11" out of the comment `3.11 is intentionally excluded` and demanded the project advertise an interpreter `requires-python` refuses to install on. It now reads only `python-version:` assignments. The failure mode is the same one this release keeps turning up elsewhere: a check that measures a projection of the thing rather than the thing.
