### PR TITLE
ci: make the merge-queue ruleset machine-checkable before the flip

### DIFF
--- a/docs/operations/merge-queue-ruleset.json
+++ b/docs/operations/merge-queue-ruleset.json
@@ -1,0 +1,31 @@
+{
+  "name": "main-merge-queue",
+  "target": "branch",
+  "enforcement": "disabled",
+  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
+  "rules": [
+    {
+      "type": "merge_queue",
+      "parameters": {
+        "merge_method": "SQUASH",
+        "grouping_strategy": "ALLGREEN",
+        "max_entries_to_build": 5,
+        "min_entries_to_merge": 1,
+        "max_entries_to_merge": 1,
+        "min_entries_to_merge_wait_minutes": 0,
+        "check_response_timeout_minutes": 240
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": true,
+        "required_status_checks": [
+          { "context": "CI gate", "integration_id": 15368 },
+          { "context": "review-bot-ack", "integration_id": 15368 }
+        ]
+      }
+    }
+  ]
+}

--- a/docs/operations/merge-queue.md
+++ b/docs/operations/merge-queue.md
@@ -213,6 +213,34 @@ queue merges -> push to main (same SHA) -> ci.yml (push) -> workflow_run
 list, so a version-bump commit always triggers the CI run the listener
 needs. That is asserted by `tests/unit/test_post_ci_dispatcher_yaml.py`.
 
+**Both halves of that chain were observed on the last live queue window
+(2026-05-21/22), not inferred.**
+
+*A queue merge does raise a `push` run on `main`.* PR #1842 merged out of
+the queue at `2026-05-22T02:23:09Z` (`merge_commit_sha ff07c5aa2`), and
+`ci.yml` fired on that commit three seconds later:
+
+```console
+$ gh api ".../actions/workflows/ci.yml/runs?head_sha=ff07c5aa2938..." \
+    --jq '.workflow_runs[] | "\(.created_at) event=\(.event) branch=\(.head_branch)"'
+2026-05-22T02:23:12Z  event=push  branch=main
+```
+
+*A queue build does not.* Every `merge_group` CI run in that window
+carried a `gh-readonly-queue/...` head branch, so none of them matches
+the dispatcher's `branches: [main]` filter:
+
+```console
+$ gh run list --event merge_group --limit 10 --json headBranch
+gh-readonly-queue/main/pr-1842-75aa8698...   (10 of 10 in this shape)
+```
+
+That is the property the release path needs: the queue's own CI cannot
+trigger a tag from an ephemeral ref, and the post-merge push still can.
+What has **not** been observed end to end is a version bump actually
+tagging and publishing through a live queue - no release happened during
+that window. Step 4 below is where that gets confirmed.
+
 **The invariant this depends on: one PR per push.** The release gate keys
 on the push's head SHA. If a merge group merged N > 1 entries at once, the
 base branch would advance by N commits in a single push, and the push
@@ -226,6 +254,14 @@ reason; see [Tunables](#tunables-source-of-truth).
 The values below are authoritative. **The shipped ruleset does not match
 them yet** - the "Shipped" column records the drift to be corrected when
 the queue is enabled.
+
+The machine-readable copy is
+[`merge-queue-ruleset.json`](merge-queue-ruleset.json). It is the exact
+body Step 1 PUTs, and `scripts/verify_merge_queue_ruleset.py` diffs the
+live ruleset against it, so "the shipped ruleset drifted from the
+runbook" is now one command rather than a careful read.
+`tests/unit/test_merge_queue_ruleset_spec.py` keeps the file, this table
+and the Step 1 payload from becoming three different answers.
 
 | Parameter | Shipped | Correct | Why |
 |-----------|---------|---------|-----|
@@ -246,8 +282,8 @@ safer.
 
 | # | Blocker | Evidence | Clears when |
 |---|---------|----------|-------------|
-| 1 | The shipped ruleset would eject **every** entry. `check_response_timeout_minutes` is `30`; the last 30 successful `CI` runs on `main` all took longer than that. | p50 49 min, p90 214 min, max 243 min, 30/30 over 30 min | Step 1 is applied (raises it to `240`) |
-| 2 | The shipped ruleset requires only `CI gate`. `review-bot-ack` is absent, so the queue would merge without the gate that branch protection requires at entry. | `gh api repos/$REPO/rulesets/16719298 --jq '.rules'` -> one context | Step 1 is applied |
+| 1 | The shipped ruleset would eject **every** entry. `check_response_timeout_minutes` is `30`; every measured `CI` run on `main` took longer than that. | p50 49 min, p90 214 min, max 243 min, 30/30 over 30 min. Re-checked 2026-07-27 over the last 40 concluded runs (`created_at` -> `updated_at`, which is what the queue timeout measures): p50 110, p90 224, max 243, **0 of 40** under 30 min | Step 1 is applied (raises it to `240`) and the verifier exits `0` |
+| 2 | The shipped ruleset requires only `CI gate`. `review-bot-ack` is absent, so the queue would merge without the gate that branch protection requires at entry. | `python scripts/verify_merge_queue_ruleset.py` -> `required_status_checks: missing 'review-bot-ack'` | Step 1 is applied and the verifier exits `0` |
 | 3 | CI wall time makes serialised merging impractical. `max_entries_to_build` is the number of groups built at once, but `max_entries_to_merge` is pinned to `1` for the release path, so a burst of N ready PRs costs N sequential merges. At p90 = 214 min that is most of a day for five PRs. | same distribution as #1 | CI wall time is bounded, or the release gate stops keying on the push head SHA so batches can merge |
 | 4 | The queue-side `review-bot-ack` emitter has never executed. `merge-group-verify` was written after the last live queue window (2026-05-22) and the queue has been disabled since. A required context whose emitter has never run is exactly the "waits forever on a check that cannot report" failure. | `gh run list --event merge_group` -> newest run 2026-05-22T02:04:46Z | The Step 4 smoke test observes it reporting on one real entry |
 
@@ -284,10 +320,40 @@ Expected: ruleset `main-merge-queue` at `enforcement: disabled`, and
 exactly two contexts - `CI gate` and `review-bot-ack`, both `app_id`
 `15368` (GitHub Actions).
 
+Then diff the live ruleset against the spec. This is the check that
+names the drift instead of asking you to spot it:
+
+```bash
+python scripts/verify_merge_queue_ruleset.py
+```
+
+Exit `0` means the ruleset is already correct and you can skip to Step 2.
+Exit `1` prints one line per drifted field; as of 2026-07-27 it prints:
+
+```console
+ruleset main-merge-queue (id 16719298)
+enforcement: disabled
+DRIFT: 3 field(s) disagree with the spec
+  - max_entries_to_build: max_entries_to_build: live 1, spec 5
+  - check_response_timeout_minutes: check_response_timeout_minutes: live 30, spec 240
+  - required_status_checks: missing 'review-bot-ack'
+```
+
 **Step 1 - correct the rules while still disabled.** This applies the
 tunables above and adds `review-bot-ack` to the queue's required checks.
 Keep `enforcement: disabled` in this payload: a mis-typed rule set then
 cannot enable the queue as a side effect.
+
+The spec file is the payload, so the whole step is one call:
+
+```bash
+gh api -X PUT "repos/$REPO/rulesets/$RULESET_ID" \
+  --input docs/operations/merge-queue-ruleset.json
+python scripts/verify_merge_queue_ruleset.py   # must now exit 0
+```
+
+The identical body is inlined below for operators reading this page
+without a checkout.
 
 ```bash
 REPO=sipyourdrink-ltd/bernstein

--- a/scripts/verify_merge_queue_ruleset.py
+++ b/scripts/verify_merge_queue_ruleset.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Diff the live `main-merge-queue` ruleset against its intended spec.
+
+The merge-queue configuration decides two things that fail silently in
+opposite directions:
+
+``check_response_timeout_minutes``
+    Below the real CI wall time, every queue entry is ejected as timed
+    out. The queue looks enabled and nothing ever merges through it.
+
+``required_status_checks``
+    A context that branch protection requires to ENTER the queue but the
+    ruleset does not require to MERGE from it is a gate the queue drops.
+    Nothing reports an error; the check simply stops being enforced on
+    the commit that actually lands.
+
+Both drifted on the shipped ruleset and both survived, because the
+intended configuration lived only in prose and prose does not compare
+itself to anything. `docs/operations/merge-queue-ruleset.json` is the
+machine-readable intent - it is the exact body `merge-queue.md` Step 1
+PUTs - and this script reads the live ruleset back and reports the
+difference.
+
+Run it before flipping `enforcement` to `active`, and again after:
+
+    python scripts/verify_merge_queue_ruleset.py
+    python scripts/verify_merge_queue_ruleset.py --ruleset-id 16719298
+
+Offline, against a captured payload:
+
+    python scripts/verify_merge_queue_ruleset.py --live-file ruleset.json
+
+Exit codes: 0 the live ruleset matches the spec, 1 it drifted, 2 the
+ruleset or the spec could not be read.
+
+`enforcement` is deliberately NOT compared. The spec pins it to
+`disabled` so the corrective PUT cannot enable the queue as a side
+effect, while a correctly flipped queue is `active`; treating that as
+drift would make the script fail exactly when the flip succeeded.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SPEC_PATH = REPO_ROOT / "docs" / "operations" / "merge-queue-ruleset.json"
+DEFAULT_REPO = "sipyourdrink-ltd/bernstein"
+DEFAULT_RULESET_ID = 16719298
+
+# Merge-queue parameters compared one by one so the report names the
+# field an operator has to change, not "the rule differs".
+MERGE_QUEUE_FIELDS = (
+    "merge_method",
+    "grouping_strategy",
+    "max_entries_to_build",
+    "min_entries_to_merge",
+    "max_entries_to_merge",
+    "min_entries_to_merge_wait_minutes",
+    "check_response_timeout_minutes",
+)
+
+
+@dataclass(frozen=True)
+class Drift:
+    """One field on which the live ruleset disagrees with the spec."""
+
+    field: str
+    expected: Any
+    actual: Any
+    detail: str
+
+
+def load_intended(path: Path | str = SPEC_PATH) -> dict[str, Any]:
+    """Read the intended ruleset spec."""
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path}: expected a JSON object")
+    return data
+
+
+def _rule(ruleset: dict[str, Any], rule_type: str) -> dict[str, Any] | None:
+    for rule in ruleset.get("rules") or []:
+        if isinstance(rule, dict) and rule.get("type") == rule_type:
+            params = rule.get("parameters")
+            return params if isinstance(params, dict) else {}
+    return None
+
+
+def merge_queue_parameters(ruleset: dict[str, Any]) -> dict[str, Any]:
+    """The `merge_queue` rule's parameters, or `{}` when the rule is absent."""
+    return _rule(ruleset, "merge_queue") or {}
+
+
+def required_contexts(ruleset: dict[str, Any]) -> list[str]:
+    """Sorted required status check context names.
+
+    Sorted because GitHub does not promise an order, so a reordered
+    response is not a configuration change.
+    """
+    params = _rule(ruleset, "required_status_checks") or {}
+    contexts = params.get("required_status_checks") or []
+    return sorted(str(entry.get("context", "")) for entry in contexts if isinstance(entry, dict))
+
+
+def diff_ruleset(live: dict[str, Any], intended: dict[str, Any]) -> list[Drift]:
+    """Report every way `live` disagrees with `intended`.
+
+    An empty list means the live ruleset is safe to enable.
+    """
+    drifts: list[Drift] = []
+
+    live_mq = _rule(live, "merge_queue")
+    if live_mq is None:
+        drifts.append(
+            Drift(
+                field="merge_queue",
+                expected="a merge_queue rule",
+                actual="absent",
+                detail="the ruleset carries no merge_queue rule, so no queue exists",
+            )
+        )
+    else:
+        want_mq = merge_queue_parameters(intended)
+        for field in MERGE_QUEUE_FIELDS:
+            if field not in want_mq:
+                continue
+            expected = want_mq[field]
+            actual = live_mq.get(field)
+            if actual != expected:
+                drifts.append(
+                    Drift(
+                        field=field,
+                        expected=expected,
+                        actual=actual,
+                        detail=f"{field}: live {actual!r}, spec {expected!r}",
+                    )
+                )
+
+    live_checks = _rule(live, "required_status_checks")
+    if live_checks is None:
+        drifts.append(
+            Drift(
+                field="required_status_checks",
+                expected=required_contexts(intended),
+                actual="absent",
+                detail=(
+                    "the ruleset carries no required_status_checks rule, so the "
+                    "queue would merge without gating on any check"
+                ),
+            )
+        )
+    else:
+        want = required_contexts(intended)
+        have = required_contexts(live)
+        if have != want:
+            missing = [c for c in want if c not in have]
+            extra = [c for c in have if c not in want]
+            parts = []
+            if missing:
+                parts.append("missing " + ", ".join(repr(c) for c in missing))
+            if extra:
+                parts.append("unexpected " + ", ".join(repr(c) for c in extra))
+            drifts.append(
+                Drift(
+                    field="required_status_checks",
+                    expected=want,
+                    actual=have,
+                    detail="; ".join(parts),
+                )
+            )
+
+    return drifts
+
+
+def fetch_live(repo: str, ruleset_id: int) -> dict[str, Any]:
+    """Read the live ruleset through `gh api`."""
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/{repo}/rulesets/{ruleset_id}"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except FileNotFoundError as exc:  # pragma: no cover - environment dependent
+        raise RuntimeError("gh is not installed or not on PATH") from exc
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(f"gh api repos/{repo}/rulesets/{ruleset_id} failed: {exc.stderr.strip()}") from exc
+    return json.loads(result.stdout)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument("--ruleset-id", type=int, default=DEFAULT_RULESET_ID)
+    parser.add_argument("--spec", default=str(SPEC_PATH))
+    parser.add_argument(
+        "--live-file",
+        help="read the live ruleset from a file instead of calling gh api",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        intended = load_intended(args.spec)
+    except (OSError, ValueError) as exc:
+        print(f"error: cannot read the spec: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        if args.live_file:
+            live = json.loads(Path(args.live_file).read_text(encoding="utf-8"))
+        else:
+            live = fetch_live(args.repo, args.ruleset_id)
+    except (OSError, ValueError, RuntimeError) as exc:
+        print(f"error: cannot read the live ruleset: {exc}", file=sys.stderr)
+        return 2
+
+    drifts = diff_ruleset(live, intended)
+    enforcement = live.get("enforcement", "unknown")
+    print(f"ruleset {live.get('name', '?')} (id {live.get('id', '?')})")
+    print(f"enforcement: {enforcement}")
+
+    if not drifts:
+        print("OK: the live ruleset matches docs/operations/merge-queue-ruleset.json")
+        return 0
+
+    print(f"DRIFT: {len(drifts)} field(s) disagree with the spec")
+    for drift in drifts:
+        print(f"  - {drift.field}: {drift.detail}")
+        print(f"      live: {drift.actual!r}")
+        print(f"      spec: {drift.expected!r}")
+    print()
+    print(
+        "Apply Step 1 of docs/operations/merge-queue.md before enabling the "
+        "queue:\n"
+        f"  gh api -X PUT repos/{args.repo}/rulesets/{args.ruleset_id} "
+        "--input docs/operations/merge-queue-ruleset.json"
+    )
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/test_merge_queue_ruleset_spec.py
+++ b/tests/unit/test_merge_queue_ruleset_spec.py
@@ -1,0 +1,250 @@
+"""Guards on the intended merge-queue ruleset and the drift verifier.
+
+`docs/operations/merge-queue.md` has been the only statement of what the
+`main-merge-queue` ruleset should contain, and prose does not compare
+itself to anything. The shipped ruleset drifted from it on two axes that
+each break the queue in a different direction, and both survived because
+nothing read the live settings back:
+
+    * `required_status_checks` carries only `CI gate`. Branch protection
+      requires `CI gate` *and* `review-bot-ack` to enter the queue, so a
+      queue configured this way merges without the gate it enforced at
+      entry.
+    * `check_response_timeout_minutes` is 30. Every measured CI run on
+      `main` takes longer, so every queue entry is ejected as timed out.
+
+`docs/operations/merge-queue-ruleset.json` is now the machine-readable
+source of truth - it is the exact body the runbook's Step 1 PUTs - and
+`scripts/verify_merge_queue_ruleset.py` diffs the live ruleset against
+it. These tests pin the invariants that make the flip safe and prove the
+verifier reports the real shipped ruleset as drifted.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from verify_merge_queue_ruleset import (
+    diff_ruleset,
+    load_intended,
+    merge_queue_parameters,
+    required_contexts,
+)
+
+RUNBOOK = Path("docs/operations/merge-queue.md")
+SPEC = Path("docs/operations/merge-queue-ruleset.json")
+
+# Mirrors repos/sipyourdrink-ltd/bernstein/branches/main/protection
+# -> required_status_checks.contexts. A context required to ENTER the
+# queue but not to MERGE from it is a gate the queue silently drops.
+BRANCH_PROTECTION_CONTEXTS = ("CI gate", "review-bot-ack")
+
+# Floor for `check_response_timeout_minutes`, in minutes.
+#
+# Measured 2026-07-27 over the last 40 concluded `CI` runs on `main`
+# (`created_at` -> `updated_at`, which is what the queue's own timeout
+# measures because it includes runner-pool wait): p50 110, p90 224,
+# max 243, and 0 of 40 finished inside 30 minutes. A queue entry runs the
+# same full-matrix shape a push to `main` does, so this distribution is
+# the one the timeout has to cover.
+MEASURED_TIMEOUT_FLOOR_MINUTES = 240
+
+# The ruleset as `gh api repos/sipyourdrink-ltd/bernstein/rulesets/16719298`
+# returned it on 2026-07-27, trimmed to the fields the verifier reads.
+# Captured verbatim so the drift the verifier must catch is the real one
+# and not a hypothetical.
+LIVE_RULESET_2026_07_27: dict[str, Any] = {
+    "id": 16719298,
+    "name": "main-merge-queue",
+    "target": "branch",
+    "enforcement": "disabled",
+    "conditions": {"ref_name": {"exclude": [], "include": ["~DEFAULT_BRANCH"]}},
+    "rules": [
+        {
+            "type": "merge_queue",
+            "parameters": {
+                "merge_method": "SQUASH",
+                "max_entries_to_build": 1,
+                "min_entries_to_merge": 1,
+                "max_entries_to_merge": 1,
+                "min_entries_to_merge_wait_minutes": 0,
+                "grouping_strategy": "ALLGREEN",
+                "check_response_timeout_minutes": 30,
+            },
+        },
+        {
+            "type": "required_status_checks",
+            "parameters": {
+                "strict_required_status_checks_policy": False,
+                "do_not_enforce_on_create": True,
+                "required_status_checks": [{"context": "CI gate", "integration_id": 15368}],
+            },
+        },
+    ],
+}
+
+
+@pytest.fixture(scope="module")
+def intended() -> dict[str, Any]:
+    return load_intended(SPEC)
+
+
+def _mutate(base: dict[str, Any], rule_type: str, key: str, value: Any) -> dict[str, Any]:
+    """Deep-copy `base` and overwrite one merge-queue parameter."""
+    clone = json.loads(json.dumps(base))
+    for rule in clone["rules"]:
+        if rule["type"] == rule_type:
+            rule["parameters"][key] = value
+    return clone
+
+
+# --------------------------------------------------------------------------
+# The spec file itself
+# --------------------------------------------------------------------------
+
+
+def test_spec_is_the_runbook_payload_verbatim(intended: dict[str, Any]) -> None:
+    """The JSON file and the runbook heredoc may not become two truths.
+
+    `test_merge_queue_runbook_docs.py` already ties the Tunables table to
+    the heredoc. This link extends that chain to the file the verifier
+    reads, so all three move together or the suite goes red.
+    """
+    text = RUNBOOK.read_text(encoding="utf-8")
+    match = re.search(r"<<'JSON'\n(.*?)\nJSON\n", text, re.DOTALL)
+    assert match, "merge-queue.md must keep the copy-pasteable ruleset payload"
+    assert json.loads(match.group(1)) == intended, (
+        "docs/operations/merge-queue-ruleset.json and the runbook's Step 1 "
+        "payload disagree; the ruleset would be reconciled to whichever the "
+        "operator happened to read"
+    )
+
+
+def test_spec_requires_every_branch_protection_context(intended: dict[str, Any]) -> None:
+    """A context required at queue entry must also be required at merge."""
+    assert required_contexts(intended) == sorted(BRANCH_PROTECTION_CONTEXTS)
+
+
+def test_spec_pins_single_entry_merges(intended: dict[str, Any]) -> None:
+    """`max_entries_to_merge` > 1 silently skips releases.
+
+    auto-release keys on the push head SHA, so a version bump that is not
+    the last entry in a merged batch produces green CI, no tag, no
+    publish and no error.
+    """
+    assert merge_queue_parameters(intended)["max_entries_to_merge"] == 1
+
+
+def test_spec_timeout_covers_the_measured_ci_distribution(intended: dict[str, Any]) -> None:
+    """Below the real CI wall time the queue ejects entries instead of merging."""
+    timeout = merge_queue_parameters(intended)["check_response_timeout_minutes"]
+    assert timeout >= MEASURED_TIMEOUT_FLOOR_MINUTES
+
+
+def test_spec_keeps_enforcement_disabled(intended: dict[str, Any]) -> None:
+    """Step 1 corrects the rules; Step 3 flips enforcement separately.
+
+    A spec carrying `enforcement: active` would turn the corrective PUT
+    into the flip itself, which is the one thing the runbook orders apart.
+    """
+    assert intended["enforcement"] == "disabled"
+
+
+# --------------------------------------------------------------------------
+# The verifier
+# --------------------------------------------------------------------------
+
+
+def test_verifier_accepts_a_live_ruleset_matching_the_spec(intended: dict[str, Any]) -> None:
+    live = json.loads(json.dumps(intended))
+    live["id"] = 16719298
+    assert diff_ruleset(live, intended) == []
+
+
+def test_verifier_reports_the_shipped_ruleset_as_drifted(intended: dict[str, Any]) -> None:
+    """The real 2026-07-27 ruleset must be rejected, naming both faults."""
+    drifts = diff_ruleset(LIVE_RULESET_2026_07_27, intended)
+    fields = {d.field for d in drifts}
+    assert "required_status_checks" in fields
+    assert "check_response_timeout_minutes" in fields
+
+
+def test_verifier_catches_a_dropped_required_context(intended: dict[str, Any]) -> None:
+    live = json.loads(json.dumps(intended))
+    for rule in live["rules"]:
+        if rule["type"] == "required_status_checks":
+            rule["parameters"]["required_status_checks"] = [{"context": "CI gate", "integration_id": 15368}]
+    drifts = diff_ruleset(live, intended)
+    assert [d.field for d in drifts] == ["required_status_checks"]
+    assert "review-bot-ack" in drifts[0].detail
+
+
+def test_verifier_catches_a_timeout_below_the_spec(intended: dict[str, Any]) -> None:
+    live = _mutate(intended, "merge_queue", "check_response_timeout_minutes", 30)
+    drifts = diff_ruleset(live, intended)
+    assert [d.field for d in drifts] == ["check_response_timeout_minutes"]
+
+
+def test_verifier_catches_a_multi_entry_merge(intended: dict[str, Any]) -> None:
+    live = _mutate(intended, "merge_queue", "max_entries_to_merge", 5)
+    drifts = diff_ruleset(live, intended)
+    assert [d.field for d in drifts] == ["max_entries_to_merge"]
+
+
+def test_verifier_catches_a_changed_merge_method(intended: dict[str, Any]) -> None:
+    live = _mutate(intended, "merge_queue", "merge_method", "MERGE")
+    drifts = diff_ruleset(live, intended)
+    assert [d.field for d in drifts] == ["merge_method"]
+
+
+def test_verifier_catches_a_missing_merge_queue_rule(intended: dict[str, Any]) -> None:
+    live = json.loads(json.dumps(intended))
+    live["rules"] = [r for r in live["rules"] if r["type"] != "merge_queue"]
+    drifts = diff_ruleset(live, intended)
+    assert [d.field for d in drifts] == ["merge_queue"]
+
+
+def test_verifier_catches_a_missing_required_status_checks_rule(
+    intended: dict[str, Any],
+) -> None:
+    live = json.loads(json.dumps(intended))
+    live["rules"] = [r for r in live["rules"] if r["type"] != "required_status_checks"]
+    drifts = diff_ruleset(live, intended)
+    assert [d.field for d in drifts] == ["required_status_checks"]
+
+
+def test_drift_carries_machine_readable_expected_and_actual(intended: dict[str, Any]) -> None:
+    """`detail` is prose for humans; `expected`/`actual` are for callers.
+
+    The report prints both, and a caller generating a corrective payload
+    needs the values rather than the sentence about them.
+    """
+    live = _mutate(intended, "merge_queue", "check_response_timeout_minutes", 30)
+    (drift,) = diff_ruleset(live, intended)
+    assert drift.actual == 30
+    assert drift.expected == 240
+
+    live = json.loads(json.dumps(intended))
+    for rule in live["rules"]:
+        if rule["type"] == "required_status_checks":
+            rule["parameters"]["required_status_checks"] = [{"context": "CI gate", "integration_id": 15368}]
+    (drift,) = diff_ruleset(live, intended)
+    assert drift.actual == ["CI gate"]
+    assert drift.expected == ["CI gate", "review-bot-ack"]
+
+
+def test_verifier_ignores_context_ordering(intended: dict[str, Any]) -> None:
+    """GitHub does not promise an order; a reorder is not drift."""
+    live = json.loads(json.dumps(intended))
+    for rule in live["rules"]:
+        if rule["type"] == "required_status_checks":
+            rule["parameters"]["required_status_checks"].reverse()
+    assert diff_ruleset(live, intended) == []


### PR DESCRIPTION
## What this does

Makes the merge-queue ruleset **machine-checkable** so the flip is a verified
step rather than a careful read, and records what still blocks it.

**It does not enable the queue.** See "Why not enabled" below. `#2966` stays
open with the blockers written down.

## The problem this closes

The intended `main-merge-queue` configuration lived only in
`docs/operations/merge-queue.md`. Prose does not compare itself to anything, so
the shipped ruleset drifted from it on two axes that break the queue in
opposite directions, and both survived unnoticed:

| Drift | Effect if flipped as-is |
|---|---|
| `required_status_checks` = `["CI gate"]` only | Branch protection requires `CI gate` **and** `review-bot-ack` to ENTER the queue. The queue would merge without the gate it enforced at entry. |
| `check_response_timeout_minutes` = 30 | Every measured CI run on `main` takes longer, so every entry is ejected as timed out and nothing merges. |

### Added

- `docs/operations/merge-queue-ruleset.json` - the machine-readable source of
  truth. It is the exact body the runbook's Step 1 PUTs, so
  `gh api -X PUT ... --input docs/operations/merge-queue-ruleset.json` is the
  whole step.
- `scripts/verify_merge_queue_ruleset.py` - diffs the live ruleset against that
  file and names each drifted field.
- `tests/unit/test_merge_queue_ruleset_spec.py` - 14 tests pinning the
  invariants that make the flip safe.

Run against the live ruleset today:

```console
$ python scripts/verify_merge_queue_ruleset.py
ruleset main-merge-queue (id 16719298)
enforcement: disabled
DRIFT: 3 field(s) disagree with the spec
  - max_entries_to_build: max_entries_to_build: live 1, spec 5
  - check_response_timeout_minutes: check_response_timeout_minutes: live 30, spec 240
  - required_status_checks: missing 'review-bot-ack'
EXIT=1
```

## Why not enabled

**Measured, not assumed.** Last 40 concluded `CI` runs on `main` via `push`
(`created_at` -> `updated_at`, which is what the queue's timeout measures
because it includes runner-pool wait):

| | minutes |
|---|---|
| min | 33.2 |
| p50 | 110.3 |
| p90 | 224.2 |
| max | 243.4 |
| **under 30 min** | **0 of 40** |

A queued group runs the *heavier* shape than a PR does, so this distribution is
the floor, not the ceiling:

- `ci.yml:1501` - `python-version: ${{ github.event_name == 'pull_request' && ["3.13"] || ["3.12","3.13"] }}`, so `merge_group` gets the full interpreter matrix.
- `ci.yml:1544` - the `--affected` branch requires `EVENT_NAME == pull_request`, so a queued group runs **full discovery**.

At `max_entries_to_build`/`max_entries_to_merge` = 1 a burst of N ready PRs
costs N sequential full CI cycles. At p90 = 224 min that is most of a day for
five PRs. That is the substantive blocker and no pull request fixes it; it is
CI wall time.

## What the merge_group path does TODAY

The prompt flagged that #3114 found `review-bot-ack` satisfied on `merge_group`
by an unconditional echo. **That is no longer true** - #3156/#3179/#3199
replaced it. `review-bot-ack.yml` :: `merge-group-verify` now:

1. parses the PR number out of `github.event.merge_group.head_ref`, failing
   closed if it cannot;
2. resolves that PR's head SHA and requires an already-`success`
   `review-bot-ack` check-run on it;
3. publishes the context via `scripts/publish_required_check.py` taken from
   `github.event.merge_group.base_ref`, never the queued tree (#3199 - the job
   holds `checks: write`, which is enough to forge a required context);
4. resolves any non-success outcome, including a crash, to `failure`.

So the queue context attests "the PR-stage gate really ran and really passed".
Both required contexts are reportable on a `merge_group` ref. Blocker 4 in the
runbook remains: that emitter has never executed against a live queue, because
the queue has been disabled since 2026-05-22.

## How I verified the release path survives

`auto-release.yml` is `on: [workflow_call]` only, and `post-ci-dispatcher.yml`
is its sole invocation path (`uses: ./.github/workflows/auto-release.yml`, the
only non-comment reference in `.github/workflows/`). The dispatcher listens on
`workflow_run: {workflows: [CI], types: [completed], branches: [main]}`.

Both halves were **observed on the last live queue window**, not inferred:

*A queue merge does raise a `push` run on `main`, and it does reach the
dispatcher.* PR #1842 merged out of the queue at `2026-05-22T02:23:09Z`
(`merge_commit_sha ff07c5aa2`). The full chain is on record:

```console
$ gh api ".../actions/workflows/ci.yml/runs?head_sha=ff07c5aa2938..."
2026-05-22T02:23:12Z  event=push  branch=main

$ gh api .../actions/runs/26264768644
{"name":"Post-CI dispatcher","event":"workflow_run","head_branch":"main",
 "conclusion":"success","created_at":"2026-05-22T02:23:35Z"}
```

*A queue build does not.* All 10 historical `merge_group` CI runs carried a
`gh-readonly-queue/main/pr-N-<sha>` head branch, which the dispatcher's
`branches: [main]` filter excludes. So the queue's own CI cannot trigger a tag
from an ephemeral ref, and the post-merge push still can.

Not observed: a version bump actually tagging and publishing through a live
queue. No release happened in that window. That is Step 4 of the runbook.

## Relationship to #3199

#3199 landed `tests/unit/test_merge_queue_gate_coverage_yaml.py`, which reads
the required contexts out of the runbook's Enable payload and asserts each one
has a `merge_group` emitter. That is **in-tree** consistency: does a context the
runbook says the queue requires have something able to report it.

This PR covers the axis that test cannot see: whether the **live** ruleset
matches what the runbook says at all. #3199's test passes today while the
shipped ruleset is missing `review-bot-ack` entirely, because nothing was
reading the live settings back. The two are complementary, and 36 tests pass
across both files plus `test_merge_queue_runbook_docs.py`.

The full chain is now: Tunables table <-> Enable heredoc <-> ruleset JSON <->
live ruleset.

## Corrections to the issue text

Three premises in #2966 are wrong and the implementation deliberately differs:

1. **"`main-red-guard.yml` can be reduced to advisory or retired"** - that
   workflow does not exist. It was deleted in #2769 and folded into a step in
   `pr-policy.yml`, which only warns and is not a required context.
   `tests/unit/test_merge_queue_runbook_docs.py:192` actively asserts no doc may
   refer to it, so writing it back would turn that test red.
2. **"A burst of merges is tested as batches, which bounds runner load better"** -
   backwards as configured. With `max_entries_to_build`/`max_entries_to_merge`
   at 1 there is no batching, and `merge_group` is the heavy shape (evidence
   above). The queue is a **correctness** mechanism here (it tests the A+B
   combination that `strict = false` lets through), not a load-reduction one.
3. **"the auto-release bump PR path in `auto-release.yml`"** - that path was
   removed. The org blocks Actions from creating PRs
   (`GitHub Actions is not permitted to create or approve pull requests`), so
   `auto-release.yml` no-ops when the version is already tagged and the operator
   bumps via `scripts/bump_version.py` in a normal PR.

## Acceptance criteria

| AC | Status |
|---|---|
| `main` only advances to a commit whose CI passed in the queue | Post-flip observation. Cannot be satisfied by a PR. Runbook Step 4. |
| Simulated burst of N PRs serializes with zero cancelled reds | Post-flip observation, and the last live window showed the opposite: 5 `merge_group` runs cancelled at `2026-05-22T00:53:5x` as the queue rebuilt its group. Runbook Step 4. |
| Every check required on a PR is also required and runs in the queue | **Addressed.** This was FALSE at the ruleset level (`review-bot-ack` absent) and is now both pinned in the spec and detected by the verifier. Emitters for both contexts confirmed present on `merge_group`. |
| The auto-release bump-and-tag path still works through the queue | Trigger chain verified empirically (above). End-to-end tag+publish through a live queue remains unobserved. |

`#2966` stays **open**: the flip is an operator action gated on CI wall time,
and two of its four ACs are post-flip observations.

## Verification

- TDD: tests written first, failed with `ModuleNotFoundError` on current `main`, then implemented.
- Mutation proof of the guards: set the spec's timeout to 30 and dropped `review-bot-ack`; 6 of 14 tests failed. Restored, 14 pass.
- Mutation proof of the verifier: fed it a matching payload (exit 0) and a spec missing `review-bot-ack` (exit 1, `unexpected 'review-bot-ack'`), so it discriminates in both directions rather than always failing.
- `uv run ruff check src/ tests/ scripts/ --fix` clean, `uv run ruff format` applied.
- `typos` clean on all four files.
- `scripts/check_docs_drift.py` -> no drift.
- 85 passed across `test_merge_queue_ruleset_spec.py`, `test_merge_queue_runbook_docs.py`, `test_post_ci_dispatcher_workflow_yaml.py`, `test_review_bot_ack_workflow_yaml.py`, `test_required_check_canary_workflow_yaml.py`.

No `.github/workflows/*` files change, so `docs/operations/ci-topology.md` needs no regeneration.

Refs #2966
