### PR TITLE
fix(quality): identify redirect tables by content so a rename cannot drop test-selection edges

### DIFF
--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -341,3 +341,39 @@ single literal job name (branch-protection required-context); it runs a
 deterministic `--shard 1/4` subset on push and the affected slice on
 PRs, with `ci-macos-nightly.yml` running the full macOS matrix daily as
 the safety net.
+
+### Legacy import aliases and `--affected`
+
+`--affected` selects tests from an import graph keyed on the dotted
+names files literally write. Some of those names have no file behind
+them: `bernstein.core` and `bernstein.cli` keep old import paths alive
+with a `sys.meta_path` finder reading a `{short_name: real_module}`
+table, so `from bernstein.core.worktree import ...` resolves to
+`bernstein/core/git/worktree.py` with nothing on disk ever named
+`core/worktree.py`. Without alias resolution the graph has no edge from
+the real file to the suite that imports it under the old name, and a
+change confined to that file selects no tests for it.
+
+`discover_module_aliases` reads those tables statically, so selection
+works on a tree that was never installed. It identifies a table by what
+it contains, **not by what it is named**: any module-level `str -> str`
+dict literal in a package `__init__` counts, and an entry survives only
+if its target is a real module and its legacy key is not. Do not add a
+naming convention on top of this - keying on the name is what made a
+plain rename delete edges silently.
+
+Static reading can still drift from what the interpreter does: a table
+built by a call, or moved out of the `__init__` into its own module,
+resolves fine at runtime and is invisible to the reader.
+`test_every_live_redirect_edge_is_discovered` in
+`tests/unit/test_test_impact_alias_edges.py` is what catches that. It
+asks the finders actually installed on `sys.meta_path` which legacy
+names they serve and fails if the selector cannot see one of them. If
+it fires, the fix is to make the table readable again (keep it a
+literal in the package `__init__`) or to widen the reader - never to
+weaken the test.
+
+Alias resolution feeds the cached `imports` lists, so changing it means
+bumping `_ANALYZER_CACHE_VERSION` and `_COMPAT_CACHE_VERSION` in
+`src/bernstein/core/quality/test_impact.py`. File hashes alone will not
+invalidate a map whose edges were derived under the old rule.

--- a/src/bernstein/core/quality/test_impact.py
+++ b/src/bernstein/core/quality/test_impact.py
@@ -19,21 +19,34 @@ from typing_extensions import TypedDict
 
 logger = logging.getLogger(__name__)
 
-_ANALYZER_CACHE_VERSION = "3"
-_COMPAT_CACHE_VERSION = "3"
+# Bumped whenever the shape or the derivation of a cached entry changes, so a
+# map built by an older rule is rebuilt rather than trusted. Cached "imports"
+# lists are alias-resolved at write time, so a change to alias discovery makes
+# every existing entry potentially short of edges even though its file hashes
+# still match.
+_ANALYZER_CACHE_VERSION = "4"
+_COMPAT_CACHE_VERSION = "4"
 _WORKFLOW_PATH_PREFIX = ".github/workflows/"
 
-# Suffix of the module-level dict literals that declare a legacy import alias.
-#
 # A package can keep an old dotted import path alive without a physical shim
 # file by registering a ``sys.meta_path`` finder backed by a
 # ``{short_name: real_dotted_module}`` table. The import then resolves, but the
 # name the importer wrote never appears on disk, so an import graph keyed on
 # literal dotted names has no edge from the real module to the file that
-# imports it under the old name. Discovering the tables by shape (any
-# module-level ``*REDIRECT_MAP`` dict literal in a package ``__init__``) keeps
-# the resolution honest when a package adds a third table.
-_ALIAS_TABLE_SUFFIX = "REDIRECT_MAP"
+# imports it under the old name.
+#
+# Which module-level dict literals count as such a table is decided by their
+# content, not by what they are bound to. An earlier version required the name
+# to end in ``REDIRECT_MAP``, which made renaming the table -- a refactor no
+# importer can observe and no reviewer would question -- silently delete
+# selection edges. The two content filters in ``discover_module_aliases`` are
+# what actually discriminate, and they are strictly safer than a name check:
+# an entry is kept only when its target is a real module on disk and its
+# legacy key is not. A key that names no real module can be imported only if
+# some redirect resolves it, so an entry harvested from a dict that is not a
+# redirect table describes an import nobody can successfully write, and
+# contributes nothing. The failure mode of guessing wrong is therefore an
+# unused map entry, never a dropped edge.
 
 # Bound on alias chain following. Chains are one hop today; the bound stops a
 # hand-written cycle in an alias table from hanging the index build.
@@ -181,9 +194,8 @@ def _alias_tables_in_module(path: Path) -> dict[str, str]:
             continue
         if value is None:
             continue
-        for target in targets:
-            if isinstance(target, ast.Name) and target.id.endswith(_ALIAS_TABLE_SUFFIX):
-                tables.update(_string_dict_literal(value))
+        if any(isinstance(target, ast.Name) for target in targets):
+            tables.update(_string_dict_literal(value))
     return tables
 
 

--- a/tests/unit/test_test_impact_alias_edges.py
+++ b/tests/unit/test_test_impact_alias_edges.py
@@ -14,24 +14,37 @@ written for it ever executing. The push-to-main lane uses full discovery and
 does run it, which makes the gap PR-only: the signal is missing exactly where
 it is meant to gate.
 
-These tests pin both halves:
+These tests pin three things:
 
-* the alias table is discovered from the source tree by shape, not from a
-  hardcoded list of package names, so a package that adds a third table is
-  picked up without editing the analyser;
+* a table is recognised by what it contains, not by what it is bound to. The
+  name is private to the package and unobservable from an importer, so keying
+  discovery on it lets a rename delete selection edges with nothing failing;
 * an alias whose legacy name is also a real module on disk is left alone,
   because the redirect finders are appended to ``sys.meta_path`` and the real
-  module wins the import.
+  module wins the import;
+* whatever the reader manages to see statically agrees with what the running
+  interpreter actually serves. The first two are rules about the shapes we
+  read today; the last is the property those rules exist to deliver, checked
+  against the finders themselves so a table we cannot read is a failure rather
+  than a silent omission.
 """
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
+from typing import cast
+
+# Imported for their side effect: each package __init__ appends its redirect
+# finder to sys.meta_path, which is what the reconciliation test interrogates.
+import bernstein.cli
+import bernstein.core  # noqa: F401
 
 # Aliased on import: pytest would otherwise try to collect the class as a test
 # suite and warn about its constructor.
 from bernstein.core.quality.test_impact import TestImpactAnalyzer as ImpactAnalyzer
 from bernstein.core.quality.test_impact import (
+    _real_module_names,
     build_compat_dep_map,
     compat_get_affected_tests,
     discover_module_aliases,
@@ -46,15 +59,19 @@ def _write(path: Path, text: str) -> None:
     path.write_text(text, encoding="utf-8")
 
 
-def _alias_fixture(tmp_path: Path) -> tuple[Path, Path, str, str]:
-    """Build a source tree whose package __init__ declares a redirect table."""
+def _alias_fixture(tmp_path: Path, table_name: str = "_REDIRECT_MAP") -> tuple[Path, Path, str, str]:
+    """Build a source tree whose package __init__ declares a redirect table.
+
+    ``table_name`` is the identifier the table is bound to. Nothing in the
+    import system cares what it is called, so discovery must not either.
+    """
     src = tmp_path / "src"
     tests = tmp_path / "tests" / "unit"
 
     _write(src / "proj" / "__init__.py", "")
     _write(
         src / "proj" / "core" / "__init__.py",
-        '_REDIRECT_MAP: dict[str, str] = {\n    "widget": "proj.core.machinery.widget",\n}\n',
+        f'{table_name}: dict[str, str] = {{\n    "widget": "proj.core.machinery.widget",\n}}\n',
     )
     _write(src / "proj" / "core" / "machinery" / "__init__.py", "")
     _write(src / "proj" / "core" / "machinery" / "widget.py", "VALUE = 1\n")
@@ -69,6 +86,35 @@ def _alias_fixture(tmp_path: Path) -> tuple[Path, Path, str, str]:
 def test_alias_table_is_discovered_from_the_source_tree(tmp_path: Path) -> None:
     src, _tests, _changed, _lifecycle = _alias_fixture(tmp_path)
     assert discover_module_aliases(src) == {"proj.core.widget": "proj.core.machinery.widget"}
+
+
+def test_alias_table_bound_to_any_name_is_discovered(tmp_path: Path) -> None:
+    """Discovery must key on the table's shape, not on what it is called.
+
+    The import system resolves a redirect through the finder that reads the
+    table. The identifier the table is bound to is private to the package and
+    never observable from an importer, so a rename is a refactor no reviewer
+    would question. Keying discovery on the name makes that refactor delete
+    test-selection edges with nothing turning red.
+    """
+    src, _tests, _changed, _lifecycle = _alias_fixture(tmp_path, table_name="_LEGACY_MODULES")
+    assert discover_module_aliases(src) == {"proj.core.widget": "proj.core.machinery.widget"}
+
+
+def test_selector_picks_the_alias_test_when_the_table_is_named_differently(tmp_path: Path) -> None:
+    """The end-to-end consequence of the rule above, at selector level."""
+    src, tests, changed, lifecycle = _alias_fixture(tmp_path, table_name="_LEGACY_MODULES")
+    dep_map = build_compat_dep_map(tmp_path, src, [tests], {"proj"})
+
+    selected = {
+        p.relative_to(tmp_path).as_posix()
+        for p in compat_get_affected_tests([changed], dep_map, root=tmp_path, src_root=src)
+    }
+
+    assert lifecycle in selected, (
+        "a change confined to the real module must select the suite that imports it under the "
+        "legacy alias, whatever the redirect table happens to be called"
+    )
 
 
 def test_alias_shadowed_by_a_real_module_is_not_rewritten(tmp_path: Path) -> None:
@@ -160,3 +206,74 @@ def test_repo_worktree_change_selects_its_lifecycle_suite() -> None:
     }
 
     assert lifecycle in selected
+
+
+def _live_redirect_edges() -> dict[str, str]:
+    """Return the alias edges the installed finders actually serve.
+
+    Read from the running interpreter rather than from the source text: every
+    finder ``bernstein`` put on ``sys.meta_path`` is asked, by calling it,
+    which legacy names it resolves. Candidate keys come from iterating the
+    defining module's globals for ``str -> str`` mappings, with no filter on
+    what those mappings are named, and ``find_spec`` decides which of them are
+    really redirect keys. An unrelated ``str -> str`` global is rejected
+    because the finder declines it, not because of how it is spelled.
+    """
+    edges: dict[str, str] = {}
+    for finder in list(sys.meta_path):
+        finder_cls = type(finder)
+        defining_module = sys.modules.get(getattr(finder_cls, "__module__", "") or "")
+        prefix = getattr(finder_cls, "_PREFIX", None)
+        if defining_module is None or not isinstance(prefix, str):
+            continue
+        if not getattr(defining_module, "__name__", "").startswith("bernstein"):
+            continue
+        for candidate in list(vars(defining_module).values()):
+            if not isinstance(candidate, dict):
+                continue
+            for short, target in cast("dict[object, object]", candidate).items():
+                if not isinstance(short, str) or not isinstance(target, str):
+                    continue
+                legacy = f"{prefix}{short}"
+                if finder.find_spec(legacy, None, None) is not None:
+                    edges[legacy] = target
+    return edges
+
+
+def test_every_live_redirect_edge_is_discovered() -> None:
+    """Reconcile what the import system serves against what the analyser sees.
+
+    The tests above pin the shapes of table that discovery reads today. This
+    one pins the property those shapes exist to deliver, and it does so
+    without reference to any of them: whatever a package does to install a
+    redirect, if the running interpreter resolves a legacy name through it,
+    the selector has to know about that edge, or a change to the real module
+    silently stops selecting the suites that import it under the legacy name.
+
+    Reading the tables statically is deliberate in ``discover_module_aliases``
+    and stays that way; it keeps discovery free of import side effects and
+    usable on a tree that is not installed. The cost of that choice is that
+    the reader can drift from the importer. This is the test that notices.
+    """
+    src = _REPO_ROOT / "src"
+    real_modules = _real_module_names(src)
+
+    # Same two exclusions discover_module_aliases applies, for a like-for-like
+    # comparison: a legacy name that is also a real module loses to disk
+    # because the finders are appended to sys.meta_path, and an edge pointing
+    # outside the source tree has no source file to hang a dependency on.
+    live = {
+        legacy: target
+        for legacy, target in _live_redirect_edges().items()
+        if legacy not in real_modules and target in real_modules
+    }
+    assert live, "no redirect finder was live, so this test would prove nothing"
+
+    discovered = discover_module_aliases(src)
+    missing = sorted(legacy for legacy in live if legacy not in discovered)
+
+    assert not missing, (
+        f"{len(missing)} legacy import names resolve at runtime but are invisible to the test "
+        f"selector, so a change to the module behind them would not select the suites that "
+        f"import them under the legacy name: {missing[:10]}"
+    )


### PR DESCRIPTION
This pull request closes no issue. All three issues in this cluster are already closed and correctly so; the reason for each is below. What it does close is the one residual that was deferred rather than fixed, recorded in #3048's own closing comment as "alias discovery keys on the name suffix `REDIRECT_MAP`. A third alias table registered under any other name would silently contribute no edges, and nothing currently forbids that naming."

Nothing forbids it now either. This makes the naming irrelevant instead.

## The defect

`_alias_tables_in_module` required the identifier a redirect table is bound to to end in `REDIRECT_MAP`. That identifier is private to the package. No importer can observe it, no test asserted it, and no reviewer would question a rename.

Renaming `_REDIRECT_MAP` to `_LEGACY_MODULES` in `src/bernstein/core/__init__.py`, on `origin/main` @f9eb4e12a:

```
baseline alias edges: 618
  worktree edge present: 'bernstein.core.git.worktree'
after renaming _REDIRECT_MAP -> _LEGACY_MODULES: 122 edges
  worktree edge present: None
  edges lost: 496
```

The edge that disappears first is the one #3048 was filed about. The rename is silent in the way that matters: the import system does not care what the table is called.

```
$ python -c "import bernstein.core.worktree as m; print('runtime import OK ->', m.__name__)"
rc: 0
runtime import OK -> bernstein.core.git.worktree
```

Green suite, 496 fewer selection edges, `--affected` quietly stops selecting the suites that import through them.

## The change

Any module-level `str -> str` dict literal in a package `__init__` now counts. The name check is removed rather than widened.

Dropping it costs no precision, because it was never what discriminated. The two content filters in `discover_module_aliases` were already doing that work. Measured on this tree:

```
strict(suffix)=618  loose(any str->str dict literal)=618
loose adds 0 edges beyond strict
```

They are also safer than a name check in the one direction that matters. An entry survives only if its target is a real module on disk and its legacy key is not. A key that names no real module can be imported only if some redirect resolves it, so an entry harvested from a dict that is not a redirect table describes an import nobody can successfully write and contributes nothing. Guessing wrong yields an unused map entry; the old rule's failure mode was a dropped edge. Over-selection also fails in the safe direction for a gate whose reported bug was under-selection.

Cache versions move 3 to 4. Cached `imports` lists are alias-resolved at write time, so an existing map whose file hashes still match would keep serving edges derived under the old rule.

## The guard, and why a second mechanism is warranted

Removing the name check fixes the shape that was reported. It does not make the static reader complete, and no static reader can be: a table assembled at runtime, or one living outside the package `__init__`, resolves perfectly and is unreadable.

`test_every_live_redirect_edge_is_discovered` closes that by not reading source at all. It asks each finder `bernstein` installed on `sys.meta_path` which legacy names it actually serves, harvesting candidate keys by iterating the defining module's globals for `str -> str` mappings with no filter on what they are named, and letting `find_spec` decide which are real redirect keys. An unrelated `str -> str` global is rejected because the finder declines it, not because of how it is spelled. Then it asserts the selector can see every one.

Cost: 0.34s, in an existing shard.

## Evidence

TDD, red before green, behavioural failures rather than collection errors. Against unmodified `origin/main` source:

```
FAILED tests/unit/test_test_impact_alias_edges.py::test_alias_table_bound_to_any_name_is_discovered
FAILED tests/unit/test_test_impact_alias_edges.py::test_selector_picks_the_alias_test_when_the_table_is_named_differently
2 failed, 9 passed
E  assert 'tests/unit/test_widget_lifecycle.py' in {'tests/unit/test_widget_direct.py'}
```

After the change: `11 passed`. Touched plus adjacent (`test_test_impact.py`, `test_test_impact_core.py`): `51 passed`. Docs guards: `9 passed`. `ruff check src/ tests/ scripts/`: `All checks passed!`.

Real-tree behaviour is unchanged, which is the point of a fix whose value is that nothing moves:

```
alias edges after fix: 618
worktree edge: bernstein.core.git.worktree
```

Mutations, each applied to `src/bernstein/core/__init__.py` and restored (`git status --porcelain` empty afterwards):

| Mutation | Runtime | Fix reverted | Fix in place |
|---|---|---|---|
| Rename table to `_LEGACY_MODULES` | imports fine | guard **FAILED**, 496 names | **passes** |
| Split the table and merge two literals | imports fine | n/a | **passes**, both halves are still literals |
| Move the 600-entry table into its own module | imports fine | n/a | guard **FAILED**, 496 names |

The reverted-fix run, which is the guard proving it would have caught the original defect:

```
E  AssertionError: 496 legacy import names resolve at runtime but are invisible to the
   test selector, so a change to the module behind them would not select the suites that
   import them under the legacy name: ['bernstein.core.a2a', 'bernstein.core.a2a_federation',
   'bernstein.core.ab_test', ...]
FAILED tests/unit/test_test_impact_alias_edges.py::test_every_live_redirect_edge_is_discovered
```

The third row is the one that justifies keeping both mechanisms. Lifting a 600-entry table out of a package `__init__` is an ordinary tidy-up, it leaves every import working, and the static reader cannot follow it. The guard is fully red there while the fix alone is fully green.

## Job budget

No workflow file changes, so the topology doc is untouched and no runner job is added. The free-tier ceiling is 20 concurrent jobs and `ci.yml` already puts roughly 34 of the 47 jobs on a pull request head, so anything that widens a matrix has to earn it. This adds one test to an existing shard at 0.34s.

## Cluster status

| Issue | State | By | This pull request |
|---|---|---|---|
| #3178 bot pull requests get no CI gate | closed | 4cf96c509 (#3188), guard durability in #3198 | not touched |
| #3048 selection can skip a test covering the changed module | closed | 4cf96c509 (#3188) | discharges the residual its closing comment deferred |
| #3049 no unit-test lane runs Python 3.14 | closed | 4cf96c509 (#3188) | not touched |

All three were fixed by #3188 and stayed open only because that pull request carried a copy of #3170's body, so its `Closes` lines pointed at issues #3170 had already closed. That was corrected before this branch existed. Reopening #3048 to re-close it here would misrepresent when the reported defect was fixed: its own reproduction passes on `origin/main` without this change. The residual is a separate, narrower defect that this pull request fixes on its own merits.

Two watch items from that cluster remain observations rather than code, and this pull request does not claim them: the first post-fix `adapter-conformance-canary` fire has to be seen collecting both required contexts and merging, and `nightly-deep-tests.yml`'s `unit-python-314` lane has its first scheduled fire at 2026-07-28T03:00Z with no runtime evidence yet.

## Noted, deliberately not changed

`src/bernstein/core/knowledge/agents_md_generator.py:531` gates on the literal strings `_REDIRECT_MAP` and `_CoreRedirectFinder` when deciding whether to emit its back-compat-aliases paragraph. The same rename would drop that paragraph from the generated `AGENTS.md`. It is prose generation, not test selection, and the failure is a missing doc section rather than an unrun suite, so folding it into a fix for the selector would widen the blast radius of this change for no gain.
