### PR TITLE
fix(ci): stop a superseded gate run from overwriting a newer review-bot-ack verdict

### DIFF
--- a/.github/workflows/review-bot-ack-publish.yml
+++ b/.github/workflows/review-bot-ack-publish.yml
@@ -22,11 +22,20 @@ name: Review-bot acknowledgement publisher
 #      the artifact. Otherwise a fork could claim `success` for a commit on
 #      another pull request.
 #   2. The conclusion is accepted only if it is exactly `success`. Anything
-#      else, including a missing artifact, a malformed one, or a gate run
-#      that did not conclude successfully, publishes `failure`. Fail closed.
+#      else, including a missing artifact, a malformed one, or a gate run that
+#      concluded `failure`, publishes `failure`. Fail closed.
 #
 # Nothing from the artifact is ever executed, and no repository content from
 # the head is checked out here.
+#
+# Failing closed has one exception, and it is not a weakening of the rule.
+# A `cancelled` gate run is not a gate that said no; it is a gate that was
+# superseded before it could say anything, and a run with no verdict must not
+# write one. The job condition drops those, and a currency check below drops
+# any other publisher that a newer gate run has already overtaken. Both are
+# necessary because publishers queue for runners, so the order they write in
+# is not the order the gates concluded in. See the job comment for the
+# incident that established this.
 
 on:  # zizmor: ignore[dangerous-triggers]
   workflow_run:
@@ -44,7 +53,24 @@ jobs:
     name: review-bot-ack-publisher
     # merge_group runs of the gate publish their own context in-repo, where
     # the token is already writable. Only pull-request runs need this hop.
-    if: github.event.workflow_run.event == 'pull_request'
+    #
+    # A cancelled gate run publishes nothing at all. It has no verdict: it was
+    # superseded before it could reach one, which is not the same as failing.
+    # `review-bot-ack.yml` already refuses to publish from a cancelled job for
+    # exactly this reason, and the publisher has to honour the same rule or it
+    # reintroduces the problem one hop later.
+    #
+    # It is not enough to rely on the newer run overwriting the older verdict.
+    # Publishers queue, so their execution order is not their trigger order.
+    # Observed on this repository: a gate run cancelled at 06:49 and its
+    # replacement succeeded at 07:02, but the cancelled run's publisher was
+    # still waiting for a runner and wrote last, turning a passing pull request
+    # red with the summary "the gate run concluded cancelled". Two pull
+    # requests were blocked this way at once, and the only visible cause was a
+    # failure on work that had already passed.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'cancelled'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -77,7 +103,40 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
 
+      # Skipping a cancelled run closes the case that actually bit us, but not
+      # the general one: any two gate runs on a head can have their publishers
+      # execute in the opposite order to the gates themselves, because a
+      # publisher waits for a runner before it writes. Whoever writes last wins
+      # the check-run, and that need not be whoever is right.
+      #
+      # So the last writer is made to check whether it is still the current
+      # one. If a newer gate run exists for this head SHA, this publisher is
+      # stale by definition and stays quiet: the newer run has its own
+      # publisher and a better answer.
+      - name: Stand down if a newer gate run exists for this head
+        id: currency
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          EVENT_SHA: ${{ github.event.workflow_run.head_sha }}
+          THIS_RUN: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+          newest="$(gh api \
+            "repos/$REPO/actions/runs?head_sha=$EVENT_SHA&per_page=100" \
+            --jq '[.workflow_runs[]
+                   | select(.name == "Review-bot acknowledgement gate")
+                   | .id] | max // 0')"
+          echo "this run: $THIS_RUN, newest gate run on $EVENT_SHA: $newest"
+          if [ "${newest:-0}" -gt "$THIS_RUN" ]; then
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::a newer gate run ($newest) exists for this head; leaving the verdict to it"
+          else
+            echo "stale=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Resolve the conclusion, failing closed
+        if: steps.currency.outputs.stale != 'true'
         env:
           GATE_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
           EVENT_SHA: ${{ github.event.workflow_run.head_sha }}
@@ -111,6 +170,7 @@ jobs:
           echo "resolved $verdict: $reason"
 
       - name: Publish the review-bot-ack context on the head commit
+        if: steps.currency.outputs.stale != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}

--- a/tests/unit/test_review_bot_ack_workflow_yaml.py
+++ b/tests/unit/test_review_bot_ack_workflow_yaml.py
@@ -471,3 +471,72 @@ def test_classifier_must_address_vs_informational() -> None:
         assert classify(body) == "must-address", body
     for body in info_examples:
         assert classify(body) == "informational", body
+
+
+def test_publisher_never_speaks_for_a_cancelled_gate_run(
+    publish_doc: dict[str, object],
+) -> None:
+    """INV-2g. A run with no verdict must not write one.
+
+    A `cancelled` gate run did not decide against the pull request; it was
+    superseded before it could decide anything. `review-bot-ack.yml` already
+    refuses to publish from a cancelled job for that reason, and the publisher
+    has to hold the same line or the problem simply moves one hop later.
+
+    Treating `cancelled` as `failure` is not conservative here, it is wrong,
+    and it is wrong in the direction that blocks good work: it turns a passing
+    pull request red with a summary describing a run that never finished.
+    """
+    for key, job in _jobs(publish_doc).items():
+        condition = " ".join(str(job.get("if", "")).split())
+        assert "conclusion != 'cancelled'" in condition, (
+            f"publisher job {key!r} runs for a cancelled gate run; its condition is "
+            f"{condition!r}. A cancelled run has no verdict and must publish nothing."
+        )
+
+
+def test_publisher_stands_down_when_a_newer_gate_run_exists(
+    publish_doc: dict[str, object],
+) -> None:
+    """INV-2h. The last writer must check that it is still the current one.
+
+    Dropping cancelled runs closes the observed case but not the general one.
+    Publishers wait for runners, so the order they write the check-run in is
+    not the order the gate runs concluded in: a gate that finished first can
+    have its publisher scheduled last and overwrite a newer, better answer.
+    Since the check-run is upserted per head SHA, last writer wins outright.
+
+    So the publisher resolves the newest gate run for its own head SHA and
+    stays quiet if that is not itself, which makes the outcome independent of
+    scheduling order rather than merely less likely to be wrong.
+    """
+    for key, job in _jobs(publish_doc).items():
+        steps = _steps(job)
+        script = "\n".join(str(step.get("run", "")) for step in steps)
+        if PUBLISHER not in script:
+            continue
+
+        currency = [step for step in steps if step.get("id") == "currency"]
+        assert currency, (
+            f"publisher job {key!r} has no currency check; a stale publisher can "
+            "overwrite a newer verdict because it happened to be scheduled later"
+        )
+
+        probe = str(currency[0].get("run", ""))
+        assert "head_sha=" in probe and "workflow_runs" in probe, (
+            "the currency check must ask the API which gate runs exist for this head SHA"
+        )
+        assert "stale=true" in probe, "the currency check must be able to report staleness"
+
+        publishing = [
+            step
+            for step in steps
+            if PUBLISHER in str(step.get("run", "")) or "Resolve the conclusion" in str(step.get("name", ""))
+        ]
+        assert publishing, f"expected publishing steps in job {key!r}"
+        for step in publishing:
+            guard = " ".join(str(step.get("if", "")).split())
+            assert "currency.outputs.stale" in guard, (
+                f"step {step.get('name')!r} in job {key!r} writes the verdict without "
+                f"consulting the currency check; its condition is {guard!r}"
+            )


### PR DESCRIPTION
## What went wrong

Two pull requests went red this morning with `review-bot-ack` reporting:

> Resolved as failure: the gate run concluded cancelled.

Both had already passed. On #3204 and #3207 the head commit carried two gate runs each: one `cancelled`, one `success`. The success was the later of the two, so the outcome should have been green.

It was not, because the publisher writes the check-run and publishers queue for runners. On #3207 the gate was cancelled at 06:49 and its replacement succeeded at 07:02, but the cancelled run's publisher was still waiting for a runner and wrote last. The check-run is upserted per head SHA, so last writer wins outright, and the last writer was describing a run that never finished.

Nothing on either pull request page pointed at the cause. The failing check named a cancelled run; the cancelled run was superseded and irrelevant; the run that mattered had succeeded and was invisible.

## Two problems, not one

**A cancelled gate run has no verdict.** It did not decide against the pull request, it was superseded before it could decide anything. Mapping `cancelled` onto `failure` is not a conservative default, it is a wrong answer in the direction that blocks good work. `review-bot-ack.yml` already refuses to publish from a cancelled job for precisely this reason; the publisher was reintroducing the problem one hop later.

**Newer does not mean last.** Even among runs that do carry a verdict, the write order is the runner-scheduling order, not the gate-completion order. Fixing only the cancelled case would leave the same race with a smaller window, which is the kind of fix that comes back.

## The change

- The job condition drops `cancelled` runs entirely.
- A currency step resolves the newest gate run for its own head SHA and stands down when that is not itself. Both the resolve and the publish steps are gated on it.

Together the outcome stops depending on scheduling order, rather than merely being less likely to be wrong.

Failing closed is unchanged wherever there is an actual verdict: a gate that concluded `failure`, a missing or unreadable artifact, an artifact naming a different SHA, and any conclusion that is not the literal `success` all still publish `failure`.

## Verification

Both guards were mutation-proved rather than asserted to pass.

Against the previous workflow:

```
E  AssertionError: publisher job 'publish' runs for a cancelled gate run; its condition is
   "github.event.workflow_run.event == 'pull_request'". A cancelled run has no verdict and
   must publish nothing.
E  AssertionError: publisher job 'publish' has no currency check; a stale publisher can
   overwrite a newer verdict because it happened to be scheduled later
2 failed, 1 passed
```

Against a variant that keeps the currency check but leaves the publish step ungated, so the check is present but decorative:

```
E  AssertionError: step 'Publish the review-bot-ack context on the head commit' in job 'publish'
   writes the verdict without consulting the currency check; its condition is ''
1 failed
```

On this branch: `22 passed`.

`zizmor` reports the same two pre-existing findings as `origin/main` for this file (`4 findings (1 ignored, 1 suppressed)` in both), so nothing new is introduced. The currency step writes to `GITHUB_OUTPUT` rather than `GITHUB_ENV`.
