### PR TITLE
test(reliability): pin the reap-cycle guarantee behind the log-only heartbeat cap

### DIFF
--- a/tests/unit/test_heartbeat_log_only_cap.py
+++ b/tests/unit/test_heartbeat_log_only_cap.py
@@ -12,10 +12,12 @@ from unittest.mock import patch
 
 from bernstein.core.models import AgentSession
 
+from bernstein.core.agents import agent_lifecycle
 from bernstein.core.agents.agent_lifecycle import (
     _MAX_LOG_ONLY_HEARTBEAT_TICKS,
     _refresh_heartbeat_from_signals,
 )
+from bernstein.core.defaults import ORCHESTRATOR
 
 
 def _make_orch(tmp_path: Path) -> SimpleNamespace:
@@ -99,3 +101,155 @@ def test_live_pid_resets_log_only_streak(mock_alive, tmp_path: Path) -> None:  #
     _refresh_heartbeat_from_signals(orch, session, now)
     assert session.heartbeat_ts == now
     assert session.log_only_heartbeat_ticks == 1
+
+
+@patch("bernstein.core.agents.agent_lifecycle._is_process_alive", return_value=False)
+def test_worktree_git_signal_is_capped_like_the_log(_mock_alive, tmp_path: Path) -> None:  # type: ignore[no-untyped-def]
+    """The worktree ``.git`` mtime shares the log's budget.
+
+    It is the second entry in the same capped probe list, and in a linked
+    worktree ``.git`` is a pointer file whose mtime does not move on commit,
+    so it is no stronger a progress signal than the log. Without this case the
+    cap could be dropped from the ``.git`` half alone and the log-only tests
+    would stay green.
+    """
+    orch = _make_orch(tmp_path)
+    session = AgentSession(id="sess-git", role="backend", pid=123)
+    git_path = tmp_path / ".sdd" / "worktrees" / session.id / ".git"
+
+    for tick in range(_MAX_LOG_ONLY_HEARTBEAT_TICKS):
+        now = time.time() + tick + 1
+        _touch(git_path, now)
+        _refresh_heartbeat_from_signals(orch, session, now)
+        assert session.heartbeat_ts == now, f"tick {tick} should still refresh from the worktree .git mtime"
+        assert session.log_only_heartbeat_ticks == tick + 1
+
+    capped_heartbeat_ts = session.heartbeat_ts
+    now = time.time() + _MAX_LOG_ONLY_HEARTBEAT_TICKS + 1
+    _touch(git_path, now)
+    _refresh_heartbeat_from_signals(orch, session, now)
+    assert session.heartbeat_ts == capped_heartbeat_ts, "capped tick must not refresh from .git either"
+
+
+# ---------------------------------------------------------------------------
+# The operator-visible half of issue #3058, driven through the real
+# ``reap_dead_agents`` decision loop rather than the refresh helper alone.
+#
+# The helper tests above pin the counter. They do not pin what the counter is
+# for: the wall-clock reaper extends ``session.timeout_s`` by 600s on any tick
+# where the heartbeat looks younger than 120s, so an unbounded log-only refresh
+# walks that timeout all the way to the 5400s hard cap and the stalled agent
+# holds its worker slot for the full cap window. A refactor that kept the
+# counter but moved or dropped the refresh call would leave the tests above
+# green and put that behaviour straight back.
+# ---------------------------------------------------------------------------
+
+_HARD_CAP_S = 5400.0  # agent_lifecycle.reap_dead_agents absolute ceiling
+_TICK_S = float(ORCHESTRATOR.tick_interval_s)
+_HEARTBEAT_TIMEOUT_S = 120.0
+_START_TIMEOUT_S = 1800.0
+
+
+def _reap_orch(tmp_path: Path, session: AgentSession) -> SimpleNamespace:
+    return SimpleNamespace(
+        _agents={session.id: session},
+        _config=SimpleNamespace(
+            max_agent_runtime_s=_START_TIMEOUT_S,
+            heartbeat_timeout_s=_HEARTBEAT_TIMEOUT_S,
+        ),
+        _workdir=tmp_path,
+    )
+
+
+def _walk_reap_loop(
+    orch: SimpleNamespace,
+    session: AgentSession,
+    log_path: Path | None,
+    *,
+    t0: float,
+    limit_s: float,
+) -> dict[str, float | str]:
+    """Tick ``reap_dead_agents`` on a simulated clock until it reaps.
+
+    ``log_path`` is touched on every tick when given, modelling the merged
+    stdout/stderr chatter of issue #3058: the mtime moves, nothing progresses.
+    Returns the reap verdict, or an empty dict if ``limit_s`` is reached first.
+    """
+    verdict: dict[str, float | str] = {}
+
+    def _hb_reap(_orch: object, sess: AgentSession, _r: object, _s: object, _now: float, age: float) -> None:
+        verdict.update(reason="heartbeat_timeout", heartbeat_age_s=age)
+        sess.status = "dead"
+
+    def _wc_reap(_orch: object, sess: AgentSession, _r: object, _s: object, runtime: float) -> None:
+        verdict.update(reason="wall_clock_timeout", runtime_s=runtime)
+        sess.status = "dead"
+
+    sim = 0.0
+    with (
+        patch.object(agent_lifecycle, "_reap_heartbeat_timeout", _hb_reap),
+        patch.object(agent_lifecycle, "_reap_wall_clock_timeout", _wc_reap),
+    ):
+        while sim <= limit_s:
+            now = t0 + sim
+            if log_path is not None:
+                _touch(log_path, now)
+            with patch.object(agent_lifecycle, "time", SimpleNamespace(time=lambda now=now: now)):
+                agent_lifecycle.reap_dead_agents(orch, SimpleNamespace(reaped=[]), {})
+            if verdict:
+                verdict["at_s"] = sim
+                return verdict
+            sim += _TICK_S
+    return verdict
+
+
+@patch("bernstein.core.agents.agent_lifecycle._is_process_alive", return_value=False)
+def test_chattering_log_no_longer_rides_the_reaper_to_the_hard_cap(_mock_alive, tmp_path: Path) -> None:  # type: ignore[no-untyped-def]
+    """A stalled agent whose merged log keeps moving is reaped on the heartbeat
+    path, not held to the 5400s wall-clock hard cap (issue #3058)."""
+    t0 = time.time()
+    session = AgentSession(id="sess-reap", role="backend", pid=123, task_ids=["T-1"])
+    session.spawn_ts = t0
+    session.heartbeat_ts = t0
+    session.timeout_s = _START_TIMEOUT_S
+    orch = _reap_orch(tmp_path, session)
+    log_path = tmp_path / ".sdd" / "worktrees" / session.id / ".sdd" / "runtime" / f"{session.id}.log"
+
+    verdict = _walk_reap_loop(orch, session, log_path, t0=t0, limit_s=_HARD_CAP_S + 2 * _TICK_S)
+
+    assert verdict, "the agent was never reaped at all"
+    assert verdict["reason"] == "heartbeat_timeout", (
+        f"reaped by {verdict['reason']} at {verdict['at_s']}s: log mtime alone kept the heartbeat "
+        "young enough for the wall-clock reaper to keep extending session.timeout_s"
+    )
+    # Budget: the log-only grace, then the heartbeat has to age out, then the
+    # tick that observes it. Derived rather than hardcoded so a retune of either
+    # constant moves the bound with it.
+    budget_s = _MAX_LOG_ONLY_HEARTBEAT_TICKS * _TICK_S + _HEARTBEAT_TIMEOUT_S + _TICK_S
+    assert verdict["at_s"] <= budget_s, f"reaped at {verdict['at_s']}s, past the {budget_s}s budget"
+    assert session.timeout_s == _START_TIMEOUT_S, (
+        f"session.timeout_s ratcheted to {session.timeout_s}s: the log-only refresh is still feeding "
+        "the wall-clock extension in reap_dead_agents"
+    )
+
+
+@patch("bernstein.core.agents.agent_lifecycle._is_process_alive", return_value=False)
+def test_fresh_log_still_defers_the_reap_inside_the_budget(_mock_alive, tmp_path: Path) -> None:  # type: ignore[no-untyped-def]
+    """Control for issue #3012: inside its budget a fresh log still pushes the
+    heartbeat forward, so an agent that is quiet but writing is not reaped on a
+    heartbeat that was already one second from the timeout."""
+    t0 = time.time()
+    session = AgentSession(id="sess-defer", role="backend", pid=123, task_ids=["T-1"])
+    session.spawn_ts = t0
+    session.heartbeat_ts = t0 - (_HEARTBEAT_TIMEOUT_S - 1.0)
+    session.timeout_s = _START_TIMEOUT_S
+    orch = _reap_orch(tmp_path, session)
+    log_path = tmp_path / ".sdd" / "worktrees" / session.id / ".sdd" / "runtime" / f"{session.id}.log"
+
+    # Stop one tick short of the cap: every tick in this window must defer.
+    inside_budget_s = (_MAX_LOG_ONLY_HEARTBEAT_TICKS - 1) * _TICK_S
+    verdict = _walk_reap_loop(orch, session, log_path, t0=t0, limit_s=inside_budget_s)
+
+    assert not verdict, f"reaped at {verdict.get('at_s')}s despite a log written on the same tick"
+    assert session.heartbeat_ts >= t0, "a fresh log inside the budget must still refresh heartbeat_ts"
+    assert session.status != "dead"


### PR DESCRIPTION
## Problem

`agent_lifecycle._refresh_heartbeat_from_signals` caps how many consecutive reap ticks may refresh `heartbeat_ts` from the runner log alone (#3193). The tests that shipped with it cover the counter: it increments on a log-only refresh, saturates at `_MAX_LOG_ONLY_HEARTBEAT_TICKS`, stays uncapped for the heartbeat protocol JSON, and resets on a confirmed-live PID.

None of them assert what the counter is for.

`reap_dead_agents` extends `session.timeout_s` by 600s on any tick where the heartbeat looks younger than 120s, up to a 5400s hard cap, and it reads `session.heartbeat_ts` directly. An unbounded log-only refresh feeds that extension, so a stalled agent holds its worker slot for the full cap window rather than being reaped on the heartbeat path. That is the operator-visible behaviour, and it is currently pinned only indirectly.

A refactor that kept the counter but moved or dropped the `_refresh_heartbeat_from_signals` call, or that reordered the reap decision around it, would leave every existing test green.

## Change

Tests only. No production code is touched.

Three cases added to `tests/unit/test_heartbeat_log_only_cap.py`, driving the real `reap_dead_agents` decision loop on a simulated tick clock:

- `test_chattering_log_no_longer_rides_the_reaper_to_the_hard_cap`: a stalled agent whose merged stdout/stderr log is touched on every tick is reaped on the heartbeat path, inside a budget derived from `_MAX_LOG_ONLY_HEARTBEAT_TICKS`, the tick interval and the heartbeat timeout rather than hardcoded, and `session.timeout_s` never ratchets.
- `test_fresh_log_still_defers_the_reap_inside_the_budget`: control in the other direction. Inside its budget a fresh log still pushes the heartbeat forward, so an agent that is quiet but writing is not reaped on a heartbeat that was one second from the timeout (#3012).
- `test_worktree_git_signal_is_capped_like_the_log`: the worktree `.git` mtime is the second entry in the same capped probe list and had no case of its own, so the cap could be dropped from that half alone without a red test.

## Mutation checks

Each direction was verified by breaking the behaviour and confirming the new case fails.

Cap check deleted from `_refresh_heartbeat_from_signals`:

```
AssertionError: reaped by wall_clock_timeout at 5403.0s: log mtime alone kept the
heartbeat young enough for the wall-clock reaper to keep extending session.timeout_s
FAILED test_chattering_log_no_longer_rides_the_reaper_to_the_hard_cap
```

Log branch made to never refresh (guard too aggressive):

```
AssertionError: reaped at 3.0s despite a log written on the same tick
FAILED test_fresh_log_still_defers_the_reap_inside_the_budget
```

`.git` half left uncapped: `test_worktree_git_signal_is_capped_like_the_log` fails, the log-only cases stay green.

## Verification

- `uv run ruff check` and `ruff format --check` on the changed file: clean
- `uv run lint-imports`: 3 contracts kept, 0 broken
- `uv run bernstein agents-md verify`: all 13 files in sync
- `uv run python scripts/run_tests.py` for the `heartbeat`, `lifecycle`, `liveness`, `watchdog`, `reap`, `idle_agent` and `orchestrator` groups: all passed

## Notes

Builds on #3193. Closes no issue.

Two adjacent observations, deliberately not folded in:

- `_refresh_heartbeat_from_signals` calls `_is_process_alive(session.pid)` with no `None` guard, and `process_alive` compares `pid <= 0`. The remote runtime bridge sets `session.pid = None` (`spawner_core.py`), so `reap_dead_agents` raises `TypeError` for such a session and the call site in the tick is unguarded. Predates #3193.
- `_refresh_heartbeat_from_signals` resolves only the legacy `.sdd/worktrees/<id>/` log path, while `_resolve_agent_log_path` handles three layouts. An agent under either alternate layout contributes no log signal here at all.
