### PR TITLE
fix(tests): sync EXPECTED_CHILD_SECRETS with the heal-lane token forwards

### DIFF
--- a/tests/unit/test_post_ci_dispatcher_yaml.py
+++ b/tests/unit/test_post_ci_dispatcher_yaml.py
@@ -35,10 +35,19 @@ CHILDREN = (
 # dispatcher can forward only those (zizmor `secrets-inherit`: blanket
 # `secrets: inherit` would otherwise leak every repository secret to every
 # called workflow). GITHUB_TOKEN is auto-provided and never appears here.
+#
+# BERNSTEIN_AUTOSYNC_TOKEN is not incidental and must not be tidied away. Both
+# heal lanes open a pull request, and a reusable workflow sees only the secrets
+# its caller passes: drop the forward and `secrets.BERNSTEIN_AUTOSYNC_TOKEN`
+# reads as empty inside the callee, the `|| secrets.GITHUB_TOKEN` fallback
+# takes over, and the resulting pull request triggers no workflows, so no
+# required context ever reports and branch protection holds it at BLOCKED.
+# `test_bot_pull_request_tokens_yaml.py` asserts the forward from the other
+# side; the two guards have to agree.
 EXPECTED_CHILD_SECRETS: dict[str, frozenset[str]] = {
     "auto-release": frozenset(),
-    "auto-heal": frozenset(),
-    "bernstein-ci-fix": frozenset({"GEMINI_API_KEY"}),
+    "auto-heal": frozenset({"BERNSTEIN_AUTOSYNC_TOKEN"}),
+    "bernstein-ci-fix": frozenset({"BERNSTEIN_AUTOSYNC_TOKEN", "GEMINI_API_KEY"}),
     "bisect-on-red": frozenset(),
 }
 


### PR DESCRIPTION
## What is broken

`main` is red. `tests/unit/test_post_ci_dispatcher_yaml.py::test_dispatcher_calls_each_child` fails for `auto-heal` and `bernstein-ci-fix` on shard 3 of every full-suite run (see run 30241425595, Python 3.12 and 3.13):

```
AssertionError: job `auto-heal` must not forward any repository secrets
(expected empty, got {'BERNSTEIN_AUTOSYNC_TOKEN': '${{ secrets.BERNSTEIN_AUTOSYNC_TOKEN }}'})
```

`post-ci-dispatcher.yml` forwards `BERNSTEIN_AUTOSYNC_TOKEN` to both heal children, while `EXPECTED_CHILD_SECRETS` in the guard still declares `auto-heal` as forwarding nothing and `bernstein-ci-fix` as forwarding only `GEMINI_API_KEY`.

## Operator-visible effect

The pull-request lane selects tests by diff, and its workflow-change rule picks tests whose file name contains `workflow`. `test_post_ci_dispatcher_yaml.py` does not match, so a workflow-only change never runs this guard on the pull request. The full suite runs on `main`, so the failure appears only after merge, on a check the pull-request lane never ran. It blocks the release lane until someone lands a follow-up.

## Which side is wrong

The guard, not the workflow. Evidence:

1. Both callees declare the secret under `on.workflow_call.secrets` and read it. `auto-heal.yml` uses it at the branch push and the open-PR step; `bernstein-ci-fix.yml` uses it at the checkout and the open-PR step. The forwards are live, not dead.
2. A reusable workflow sees only the secrets its caller passes. Without the forward, `secrets.BERNSTEIN_AUTOSYNC_TOKEN` reads as empty inside the callee, the `|| secrets.GITHUB_TOKEN` fallback takes over, and the resulting pull request triggers no workflows. No required context reports and branch protection holds it at BLOCKED.
3. `tests/unit/test_bot_pull_request_tokens_yaml.py::test_callers_forward_the_secrets_reusable_pr_lanes_declare` asserts the same forward from the caller side. Removing the forward makes that guard red instead, verified locally:

```
AssertionError: these callers do not forward a secret the callee's pull-request step
reads, so it evaluates to empty inside the reusable workflow:
["post-ci-dispatcher.yml job 'auto-heal' calls auto-heal.yml without forwarding
secrets.BERNSTEIN_AUTOSYNC_TOKEN"]
```

The two guards contradict each other on `main`. This change makes them agree on the side that keeps the heal lanes working.

## Change

Update the two `EXPECTED_CHILD_SECRETS` entries to match the workflow, and record why the token belongs there so it is not removed as noise later. Same shape as the earlier `GLITCHTIP_DSN` sync in #1801. No workflow file is touched, so `docs/operations/ci-topology.md` is unchanged.

## The guard is not loosened

Per-secret equality is still enforced. Each mutation below was applied to `post-ci-dispatcher.yml` and reverted:

| Mutation | Result |
| --- | --- |
| Extra unexpected secret on `auto-heal` | red: `secrets map mismatch: expected ['BERNSTEIN_AUTOSYNC_TOKEN'], got ['BERNSTEIN_AUTOSYNC_TOKEN', 'SNEAKY_EXTRA_SECRET']` |
| Any secret on `bisect-on-red`, which expects none | red: `job 'bisect-on-red' must not forward any repository secrets` |
| `secrets: inherit` on `bernstein-ci-fix` | red: `must not use 'secrets: inherit' (zizmor secrets-inherit)` |
| Drop `GEMINI_API_KEY`, which the table expects | red: `expected ['BERNSTEIN_AUTOSYNC_TOKEN', 'GEMINI_API_KEY'], got ['BERNSTEIN_AUTOSYNC_TOKEN']` |

## Verification

Before:

```
2 failed, 20 passed
FAILED test_dispatcher_calls_each_child[auto-heal]
FAILED test_dispatcher_calls_each_child[bernstein-ci-fix]
```

After, including the adjacent workflow guard suites:

```
tests/unit/test_post_ci_dispatcher_yaml.py                22 passed
tests/unit/test_bot_pull_request_tokens_yaml.py           32 passed
8 workflow guard suites combined                         108 passed
```

`ruff check`, `ruff format --check` and `scripts/gen_workflow_topology.py` are clean.

## Out of scope

The test-selection gap that let this reach `main` is left for a separate change. `_workflow_test_files` in `src/bernstein/core/quality/test_impact.py` matches on the substring `workflow` in the test file name, so a workflow-only pull request does not select `test_post_ci_dispatcher_yaml.py`, `test_bot_pull_request_tokens_yaml.py` or `test_merge_queue_gate_coverage_yaml.py`. Widening that predicate changes selection for every workflow change and does not belong in a red-main fix.
