### PR TITLE
fix(eval): verify trajectory receipt bytes, not a parsed projection of them

### DIFF
--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -403,15 +403,10 @@ def _verify_trajectory_receipts() -> bool:
         )
     )
     for result in failures:
-        # Always show the receipt hash (from the result or the receipt itself)
-        # so the operator can locate the file even when result.receipt is None.
-        rh = (
-            result.receipt.receipt_hash
-            if result.receipt is not None
-            else result.reason.split("'")[1]
-            if "'" in result.reason
-            else "unknown"
-        )
+        # requested_hash is retained on every failure path, including the ones
+        # where the bytes were rejected before a receipt could be decoded, so
+        # the operator can always locate the offending file.
+        rh = result.requested_hash or (result.receipt.receipt_hash if result.receipt is not None else "unknown")
         task_idx = result.failing_task_index
         loc = f" (task [{task_idx}])" if task_idx >= 0 else ""
         console.print(f"  [red]![/red] {rh[:32]}…{loc}: {result.reason}")

--- a/src/bernstein/cli/commands/eval_benchmark_cmd.py
+++ b/src/bernstein/cli/commands/eval_benchmark_cmd.py
@@ -633,7 +633,9 @@ def benchmark_receipt_emit(run_id: str, workdir: str) -> None:
         bernstein benchmark receipt emit run-2025-07-26-001
     """
     import json
+    import math
     from pathlib import Path
+    from typing import NoReturn
 
     from bernstein.core.security.audit import AuditKeyPermissionError, load_or_create_audit_key
     from bernstein.eval.metrics import EvalScoreComponents, TierScores
@@ -680,39 +682,54 @@ def benchmark_receipt_emit(run_id: str, workdir: str) -> None:
     # it, which is exactly the fabrication mode the receipt is designed to
     # detect.
     _ZERO_HASH = "sha256:" + "0" * 64
+    _REQUIRED_TASK_FIELDS = ("task_id", "journal_head_hash", "events_content_hash", "model_id", "config_fingerprint")
+    _COMPONENT_FIELDS = ("task_success", "code_quality", "efficiency", "reliability", "safety")
+
+    def _reject(message: str) -> NoReturn:
+        console.print(f"[red]{message}[/red]")
+        raise SystemExit(1)
+
+    def _required_scalar(mapping: object, field: str, where: str) -> float:
+        if not isinstance(mapping, dict) or field not in mapping:
+            _reject(f"{where} is missing {field!r}; refusing to substitute a default into a signed receipt.")
+        value = mapping[field]
+        if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value):
+            _reject(f"{where} has a non-numeric or non-finite {field!r}: {value!r}")
+        return float(value)
+
     task_anchors: list[TaskTrajectoryAnchor] = []
-    for task in run_record.get("tasks", []):
-        jh = task.get("journal_head_hash", "")
-        if not jh or jh == _ZERO_HASH:
-            console.print(
-                f"[red]Task {task.get('task_id', '?')!r} has no real journal head hash — "
-                f"cannot emit a verifiable receipt for a run without a sealed trajectory.[/red]"
-            )
-            raise SystemExit(1)
-        c = task.get("components", {})
+    for position, task in enumerate(run_record.get("tasks", [])):
+        where = f"Task at index {position}"
+        if not isinstance(task, dict):
+            _reject(f"{where} is not an object.")
+        for field in _REQUIRED_TASK_FIELDS:
+            value = task.get(field)
+            if not isinstance(value, str) or not value:
+                _reject(f"{where} is missing a usable {field!r}; refusing to invent one.")
+        where = f"Task {task['task_id']!r}"
+        for field in ("journal_head_hash", "events_content_hash"):
+            if task[field] == _ZERO_HASH:
+                _reject(
+                    f"{where} carries a placeholder {field!r}; a receipt sealed over placeholder "
+                    f"anchors verifies clean with no trajectory behind it."
+                )
+        components = task.get("components")
         task_anchors.append(
             TaskTrajectoryAnchor(
                 task_id=task["task_id"],
-                journal_head_hash=jh,
-                events_content_hash=task.get("events_content_hash", _ZERO_HASH),
-                model_id=task.get("model_id", "unknown"),
-                config_fingerprint=task.get("config_fingerprint", "unknown"),
+                journal_head_hash=task["journal_head_hash"],
+                events_content_hash=task["events_content_hash"],
+                model_id=task["model_id"],
+                config_fingerprint=task["config_fingerprint"],
                 components=EvalScoreComponents(
-                    task_success=float(c.get("task_success", 0.0)),
-                    code_quality=float(c.get("code_quality", 0.0)),
-                    efficiency=float(c.get("efficiency", 0.0)),
-                    reliability=float(c.get("reliability", 1.0)),
-                    safety=float(c.get("safety", 1.0)),
+                    **{field: _required_scalar(components, field, where) for field in _COMPONENT_FIELDS}
                 ),
             )
         )
 
-    pt = run_record.get("per_tier", {})
+    pt = run_record.get("per_tier")
     per_tier = TierScores(
-        smoke=float(pt.get("smoke", 0.0)),
-        standard=float(pt.get("standard", 0.0)),
-        stretch=float(pt.get("stretch", 0.0)),
-        adversarial=float(pt.get("adversarial", 0.0)),
+        **{tier: _required_scalar(pt, tier, "per_tier") for tier in ("smoke", "standard", "stretch", "adversarial")}
     )
 
     receipt = build_trajectory_receipt(

--- a/src/bernstein/eval/trajectory_receipt.py
+++ b/src/bernstein/eval/trajectory_receipt.py
@@ -7,19 +7,34 @@ spine-anchored, offline-verifiable envelope whose verification *re-derives*
 the score from the embedded trajectory -- never trusts the printed aggregate.
 
 The design mirrors :mod:`bernstein.eval.gate_receipt` exactly: the receipt IS
-the proof, not a decoration on a log line.  Three failure modes that are
-currently undetectable from a published number alone are detectable offline
-from the receipt:
+the proof, not a decoration on a log line.
 
-* **Contamination** -- a golden task quietly mutated so the suite the number
-  was scored on differs from the suite it claims.  Detected via
-  ``suite_content_hash``.
-* **Fabrication** -- a scalar typed into a table with no trajectory behind it.
-  Detected because ``verify_trajectory_receipt`` replays every sealed journal
-  through ``ReplayGateway`` and recomputes the per-task score components.
-* **Cherry-picking** -- a best-of-N candidate published as if single-shot.
-  Detected because a receipt that carries only the winning candidate's journal
-  head (not all N heads + the selection rule) is rejected as unverifiable.
+What a sealed receipt establishes offline, without re-running the benchmark:
+
+* **Byte integrity** -- the stored file is exactly the canonical encoding of
+  the content its ``receipt_hash`` covers.  Verification re-canonicalises the
+  stored bytes and compares them against the file, so an unknown key, a
+  duplicate key, or a reordered field is a rejection rather than a difference
+  the decoder silently drops before rehashing.
+* **Contamination** -- the suite the number was scored on is the suite it
+  claims, via ``suite_content_hash`` recomputed from the embedded task ids.
+* **Internal consistency** -- the published scalar is entailed by the embedded
+  per-task components under the harness formula.  A scalar edited in isolation,
+  or an aggregate inflated away from its anchors, is rejected.
+* **Selection disclosure** -- the signed body always states the selection mode.
+  A best-of-N run must carry all N candidate heads plus the selection rule, and
+  a single-shot run carries an explicit signed assertion to that effect rather
+  than an absent field.
+* **Spine anchoring** -- the canonical bytes are anchored in the ``eval-bench``
+  lineage spine under a verified HMAC chain.
+
+What a receipt does **not** establish: that the anchored journals exist, or
+that replaying them reproduces the sealed per-task components.
+``journal_head_hash`` and ``events_content_hash`` *name* the trajectory to
+replay; executing that replay is a separate operator step against the journals
+themselves.  A receipt whose components were invented wholesale, with journal
+hashes pointing at nothing, is internally consistent and will verify.  The
+receipt binds a published score to a named trajectory; it does not re-run it.
 
 Offline third-party verifiability without the HMAC key is out of scope for
 this module (COSE/in-toto projection is the second PR); everything here is
@@ -28,10 +43,14 @@ verifiable by a key-holding operator.
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import logging
+import math
+import os
 import re
+import tempfile
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -58,6 +77,14 @@ EVAL_BENCH_RUN_ID = "eval-bench"
 
 #: Status written when the receipt covers zero tasks.
 NO_TASKS_STATUS = "NO_TASKS"
+
+#: Selection mode for a run that evaluated exactly one candidate.  Always
+#: written explicitly so "not best-of-N" is a signed assertion in the body
+#: rather than the absence of a field.
+SELECTION_SINGLE_SHOT = "single_shot"
+
+#: Selection mode for a run that evaluated N candidates and published one.
+SELECTION_BEST_OF_N = "best_of_n"
 
 _BENCH_ACTOR = "bernstein.eval_bench"
 _BENCH_SUBPATH = (".sdd", "eval", "bench")
@@ -195,6 +222,7 @@ class TrajectoryReceipt:
     run_id: str
     status: str
     best_of_n: BestOfNProvenance | None
+    selection_mode: str
     receipt_hash: str
     journal_entry_hash: str = ""
 
@@ -220,6 +248,7 @@ class TrajectoryReceipt:
             },
             "run_id": self.run_id,
             "status": self.status,
+            "selection_mode": self.selection_mode,
             "best_of_n": self.best_of_n.to_dict() if self.best_of_n is not None else None,
         }
         return d
@@ -233,7 +262,7 @@ class TrajectoryReceipt:
         """
         payload = self.body()
         payload["receipt_hash"] = self.receipt_hash
-        return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+        return _canonical_dumps(payload)
 
     def to_dict(self) -> dict[str, Any]:
         payload = self.body()
@@ -271,8 +300,9 @@ class TrajectoryReceipt:
             run_id=str(raw["run_id"]),
             status=str(raw["status"]),
             best_of_n=BestOfNProvenance.from_dict(bon_raw) if bon_raw is not None else None,
+            selection_mode=str(raw["selection_mode"]),
             receipt_hash=str(raw["receipt_hash"]),
-            journal_entry_hash=str(raw.get("journal_entry_hash", "")),
+            journal_entry_hash=str(raw["journal_entry_hash"]),
         )
 
 
@@ -281,10 +311,106 @@ class TrajectoryReceipt:
 # ---------------------------------------------------------------------------
 
 
+class ReceiptBytesError(ValueError):
+    """Stored receipt bytes are not a faithful canonical encoding of a receipt.
+
+    Raised when the file on disk carries anything the receipt schema would drop
+    on the way to a hash: an unrecognised key, a duplicate key, reordered or
+    re-spaced fields, or a non-finite numeric literal.  Treating these as a
+    decode failure is what stops a tampered file from being laundered into a
+    matching hash by rehashing the parsed projection instead of the bytes.
+    """
+
+
+def _canonical_dumps(obj: Any) -> str:
+    """Canonical JSON serialisation used for every hash and every comparison.
+
+    ``allow_nan=False`` keeps the output inside RFC 8259, so a receipt written
+    here decodes identically in a verifier that is not Python.
+    """
+    return json.dumps(obj, ensure_ascii=False, separators=(",", ":"), sort_keys=True, allow_nan=False)
+
+
+def _reject_nonfinite(name: str) -> float:
+    """``json.loads`` hook rejecting the ``NaN``/``Infinity`` extensions."""
+    msg = f"non-finite JSON literal {name!r} is not valid JSON in a receipt"
+    raise ReceiptBytesError(msg)
+
+
+def _require_finite_components(components: EvalScoreComponents, *, where: str) -> None:
+    """Reject non-finite score components.
+
+    ``NaN`` defeats every tolerance comparison in this module: ``abs(x - nan)
+    > tol`` is False, so a ``NaN`` slipped into a scalar would pass the
+    published-score check rather than fail it.  Rejecting at the boundary keeps
+    the comparisons meaningful.
+
+    Raises:
+        ValueError: Any component is ``NaN`` or infinite.
+    """
+    for field_name in ("task_success", "code_quality", "efficiency", "reliability", "safety"):
+        value = getattr(components, field_name)
+        if not math.isfinite(value):
+            msg = f"non-finite {field_name} in {where}: {value!r}"
+            raise ValueError(msg)
+
+
 def _hash_obj(obj: Any) -> str:
     """Canonical JSON sha256 hash -- identical to gate_receipt._hash_obj."""
-    payload = json.dumps(obj, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
-    return "sha256:" + hashlib.sha256(payload).hexdigest()
+    return "sha256:" + hashlib.sha256(_canonical_dumps(obj).encode("utf-8")).hexdigest()
+
+
+def decode_receipt_bytes(raw: bytes) -> TrajectoryReceipt:
+    """Decode sealed receipt bytes, proving the bytes are canonical.
+
+    The decode is deliberately not tolerant.  After parsing, the parsed record
+    is re-canonicalised and compared byte-for-byte against *raw*.  Any content
+    the schema does not round-trip -- an injected key, a duplicate key, a
+    reordering, stray whitespace -- makes the two differ and is rejected here,
+    before any hash is recomputed.
+
+    Without this step a verifier rehashes its own parsed projection of the
+    file rather than the file, and reports a clean result on bytes that were
+    edited after sealing.
+
+    Args:
+        raw: The exact bytes read from the receipt file.
+
+    Returns:
+        The decoded :class:`TrajectoryReceipt`.
+
+    Raises:
+        ReceiptBytesError: The bytes are not the canonical encoding of a
+            well-formed receipt.
+    """
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        msg = f"receipt bytes are not valid UTF-8: {exc}"
+        raise ReceiptBytesError(msg) from exc
+
+    try:
+        parsed = json.loads(text, parse_constant=_reject_nonfinite)
+    except json.JSONDecodeError as exc:
+        msg = f"receipt bytes are not valid JSON: {exc}"
+        raise ReceiptBytesError(msg) from exc
+
+    try:
+        receipt = TrajectoryReceipt.from_dict(parsed)
+    except (KeyError, TypeError, ValueError) as exc:
+        msg = f"receipt bytes do not decode to a well-formed receipt: {exc}"
+        raise ReceiptBytesError(msg) from exc
+
+    try:
+        recanonicalised = _canonical_dumps(receipt.to_dict())
+    except ValueError as exc:  # non-finite float that survived parsing
+        msg = f"receipt carries a non-finite numeric value: {exc}"
+        raise ReceiptBytesError(msg) from exc
+
+    if recanonicalised != text:
+        msg = "stored receipt bytes are not the canonical encoding of their own content"
+        raise ReceiptBytesError(msg)
+    return receipt
 
 
 def _recompute_aggregate(task_anchors: list[TaskTrajectoryAnchor]) -> EvalScoreComponents:
@@ -391,11 +517,16 @@ def build_trajectory_receipt(
         lineage_root: ``.sdd/lineage`` root for the spine.
         hmac_key: Audit-chain HMAC key for the spine seal.
         best_of_n: When the run used best-of-N, provenance covering all N
-            candidates.  A receipt lacking this when N > 1 is unverifiable.
+            candidates.  Omitting it seals ``selection_mode=single_shot``,
+            which is an explicit claim in the signed body, not a silent gap.
         chain: Optional :class:`AuditChainStore` accepting the mirror.
 
     Returns:
         The sealed :class:`TrajectoryReceipt`.
+
+    Raises:
+        ValueError: Two anchors share a ``task_id``, or a component value is
+            not finite.
     """
     # Canonicalise task order by task_id so the receipt hash is independent of
     # the order in which the caller supplies anchors (order-canonical, not
@@ -403,6 +534,17 @@ def build_trajectory_receipt(
     # task_anchors list itself must also be sorted so that the per-task
     # section of the body is deterministic across independent recordings.
     canonical_anchors = sorted(task_anchors, key=lambda a: a.task_id)
+
+    # Two anchors with the same task_id collapse in suite_content_hash (which
+    # de-duplicates) while both still feed the aggregate mean, so a duplicate
+    # would let one task be counted twice behind an honest-looking suite hash.
+    seen: set[str] = set()
+    for a in canonical_anchors:
+        if a.task_id in seen:
+            msg = f"duplicate task_id in task_anchors: {a.task_id!r}"
+            raise ValueError(msg)
+        seen.add(a.task_id)
+        _require_finite_components(a.components, where=f"task {a.task_id!r}")
 
     if not canonical_anchors:
         status = NO_TASKS_STATUS
@@ -414,6 +556,7 @@ def build_trajectory_receipt(
         published_score = aggregate.final_score
 
     s_hash = suite_content_hash([a.task_id for a in canonical_anchors])
+    selection_mode = SELECTION_SINGLE_SHOT if best_of_n is None else SELECTION_BEST_OF_N
 
     unsealed = TrajectoryReceipt(
         schema_version=TRAJECTORY_RECEIPT_SCHEMA_VERSION,
@@ -425,6 +568,7 @@ def build_trajectory_receipt(
         run_id=run_id,
         status=status,
         best_of_n=best_of_n,
+        selection_mode=selection_mode,
         receipt_hash="",
     )
     receipt_hash = _hash_obj(unsealed.body())
@@ -439,6 +583,7 @@ def build_trajectory_receipt(
         run_id=unsealed.run_id,
         status=unsealed.status,
         best_of_n=unsealed.best_of_n,
+        selection_mode=unsealed.selection_mode,
         receipt_hash=receipt_hash,
     )
 
@@ -463,6 +608,7 @@ def build_trajectory_receipt(
         run_id=sealed_no_anchor.run_id,
         status=sealed_no_anchor.status,
         best_of_n=sealed_no_anchor.best_of_n,
+        selection_mode=sealed_no_anchor.selection_mode,
         receipt_hash=receipt_hash,
         journal_entry_hash=anchor,
     )
@@ -486,12 +632,31 @@ def build_trajectory_receipt(
 
     path = trajectory_receipt_path(workdir, receipt_hash)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        json.dumps(sealed.to_dict(), ensure_ascii=False, separators=(",", ":"), sort_keys=True),
-        encoding="utf-8",
-    )
+    _write_atomic(path, _canonical_dumps(sealed.to_dict()))
 
     return sealed
+
+
+def _write_atomic(path: Path, text: str) -> None:
+    """Write *text* to *path* via a same-directory temp file and ``replace``.
+
+    The spine entry and the audit-chain mirror are already durable by the time
+    the receipt file is written, so a torn write here would leave a verifier
+    reading a truncated receipt for an anchor that exists.  ``os.replace`` is
+    atomic within a filesystem, so a reader sees either the previous state or
+    the complete receipt.
+    """
+    fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=".receipt-", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_name, path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_name)
+        raise
 
 
 # ---------------------------------------------------------------------------
@@ -500,18 +665,42 @@ def build_trajectory_receipt(
 
 
 def read_trajectory_receipt(workdir: Path, receipt_hash: str) -> TrajectoryReceipt | None:
-    """Return the sealed receipt for *receipt_hash* or ``None`` if absent/bad."""
+    """Return the sealed receipt for *receipt_hash* or ``None`` if absent/bad.
+
+    "Bad" includes bytes that parse but are not the canonical encoding of what
+    they decode to; see :func:`decode_receipt_bytes`.
+    """
+    try:
+        receipt, _ = _load_receipt(workdir, receipt_hash)
+    except ReceiptBytesError as exc:
+        logger.warning("eval: malformed trajectory receipt for %s: %s", receipt_hash, exc)
+        return None
+    return receipt
+
+
+def _load_receipt(workdir: Path, receipt_hash: str) -> tuple[TrajectoryReceipt | None, str]:
+    """Load and canonically validate one receipt.
+
+    Returns:
+        ``(receipt, reason)``.  ``receipt`` is ``None`` with a populated
+        *reason* when the receipt is simply absent; a receipt that is present
+        but unacceptable raises instead.
+
+    Raises:
+        ReceiptBytesError: The file exists but its bytes are not a faithful
+            canonical encoding of a well-formed receipt.
+    """
     try:
         path = trajectory_receipt_path(workdir, receipt_hash)
-    except ValueError:
-        return None
+    except ValueError as exc:
+        return None, str(exc)
     if not path.is_file():
-        return None
+        return None, f"no trajectory receipt for {receipt_hash!r}"
     try:
-        return TrajectoryReceipt.from_dict(json.loads(path.read_text(encoding="utf-8")))
-    except (json.JSONDecodeError, KeyError, TypeError, ValueError):
-        logger.warning("eval: malformed trajectory receipt at %s", path)
-        return None
+        raw = path.read_bytes()
+    except OSError as exc:
+        return None, f"trajectory receipt unreadable for {receipt_hash!r}: {exc}"
+    return decode_receipt_bytes(raw), ""
 
 
 # ---------------------------------------------------------------------------
@@ -528,6 +717,10 @@ class TrajectoryVerifyResult:
     receipt: TrajectoryReceipt | None
     #: Zero-based index of the first divergent task anchor, or -1 when none.
     failing_task_index: int = -1
+    #: The hash that was asked for, retained on every path (including the ones
+    #: where the receipt could not be decoded) so a caller can always name the
+    #: file it failed on.
+    requested_hash: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -546,15 +739,19 @@ def verify_trajectory_receipt(
 
     Verification fails closed unless every step passes:
 
+    0. The stored bytes are exactly the canonical encoding of the receipt they
+       decode to, so the hash covers the file rather than a parsed projection
+       of it (byte-integrity detection).
     1. The receipt hash recomputes from the stored body (tamper detection).
     2. The ``suite_content_hash`` recomputes from the embedded task ids
        (contamination detection).
     3. The aggregate ``EvalScoreComponents`` re-derives from the per-task
-       components via the harness formula (fabrication detection).
+       components via the harness formula (inflated-aggregate detection).
     4. The ``published_score`` matches the recomputed ``final_score``
        (scalar-edit detection).
-    5. If best-of-N, the re-selected index matches the published one, and
-       all candidate heads are present (cherry-pick detection).
+    5. The sealed ``selection_mode`` agrees with the presence of
+       ``best_of_n``, and a best-of-N receipt carries all N candidate heads
+       with an in-range selected index (cherry-pick detection).
     6. The lineage spine verifies and contains an entry whose content hash
        matches the receipt's canonical bytes and whose entry hash matches
        ``journal_entry_hash``.
@@ -563,20 +760,34 @@ def verify_trajectory_receipt(
     ``published_score=0.0`` and zero task anchors; step 3 re-derives the
     same empty aggregate.
 
+    This proves the receipt is intact and self-consistent.  It does not replay
+    the anchored journals; see the module docstring for what that leaves open.
+
     Raises nothing; all failure modes return ``ok=False`` with a reason.
     """
-    receipt = read_trajectory_receipt(workdir, receipt_hash)
+    # Step 0 -- the stored bytes are canonical for their own content.
+    try:
+        receipt, absent_reason = _load_receipt(workdir, receipt_hash)
+    except ReceiptBytesError as exc:
+        return TrajectoryVerifyResult(
+            ok=False,
+            reason=f"receipt bytes rejected (tampered): {exc}",
+            receipt=None,
+            requested_hash=receipt_hash,
+        )
     if receipt is None:
         return TrajectoryVerifyResult(
             ok=False,
-            reason=f"no trajectory receipt for {receipt_hash!r}",
+            reason=absent_reason,
             receipt=None,
+            requested_hash=receipt_hash,
         )
     if receipt.receipt_hash != receipt_hash:
         return TrajectoryVerifyResult(
             ok=False,
             reason="receipt hash does not match request",
             receipt=receipt,
+            requested_hash=receipt_hash,
         )
 
     # Step 1 -- hash recomputes
@@ -586,6 +797,7 @@ def verify_trajectory_receipt(
             ok=False,
             reason="receipt_hash does not recompute from the receipt body (tampered)",
             receipt=receipt,
+            requested_hash=receipt_hash,
         )
 
     # Step 2 -- suite-content-hash (contamination)
@@ -598,31 +810,31 @@ def verify_trajectory_receipt(
                 f"!= recomputed {expected_suite_hash!r} (contamination)"
             ),
             receipt=receipt,
+            requested_hash=receipt_hash,
         )
 
-    # Step 3 -- re-derive aggregate from per-task components (fabrication).
-    # Identify the first divergent task by index (mirrors diff_event_logs
-    # semantics: the first offending item is named in the reason).
+    # Step 3 -- re-derive aggregate from per-task components.
+    #
+    # The divergence is between the stored aggregate and the aggregate implied
+    # by the anchors; it does not localise to a single task.  An earlier
+    # version named the anchor furthest from the recomputed mean, which is the
+    # honest outlier of the suite rather than the edited record, so the report
+    # now lists the divergent aggregate fields and names no task.
     recomputed_agg = _recompute_aggregate(receipt.task_anchors)
     if not _components_equal(recomputed_agg, receipt.aggregate):
-        failing_idx = -1
-        max_dev = 0.0
-        for i, anchor in enumerate(receipt.task_anchors):
-            dev = abs(anchor.components.task_success - recomputed_agg.task_success)
-            if dev > max_dev:
-                max_dev = dev
-                failing_idx = i
-        offending = receipt.task_anchors[failing_idx].task_id if failing_idx >= 0 else "?"
+        divergent = ", ".join(
+            f"{name}: stored={getattr(receipt.aggregate, name)!r} recomputed={getattr(recomputed_agg, name)!r}"
+            for name in ("task_success", "code_quality", "efficiency", "reliability", "safety")
+            if abs(getattr(receipt.aggregate, name) - getattr(recomputed_agg, name)) >= 1e-9
+        )
         return TrajectoryVerifyResult(
             ok=False,
             reason=(
-                "aggregate EvalScoreComponents do not re-derive from per-task anchors "
-                f"(fabrication) — first suspect task [{failing_idx}] {offending!r}: "
-                f"stored aggregate task_success={receipt.aggregate.task_success} "
-                f"vs recomputed={recomputed_agg.task_success}"
+                "aggregate EvalScoreComponents do not re-derive from the "
+                f"{len(receipt.task_anchors)} per-task anchors; divergent fields -- {divergent}"
             ),
             receipt=receipt,
-            failing_task_index=failing_idx,
+            requested_hash=receipt_hash,
         )
 
     # Step 4 -- published_score matches recomputed final_score (scalar edit)
@@ -635,9 +847,31 @@ def verify_trajectory_receipt(
                 f"recomputed final_score {recomputed_score} (scalar edit)"
             ),
             receipt=receipt,
+            requested_hash=receipt_hash,
         )
 
-    # Step 5 -- best-of-N cherry-pick detection
+    # Step 5 -- selection provenance.
+    #
+    # selection_mode is mandatory in the signed body, so a best-of-N receipt
+    # cannot be downgraded to "single-shot" by deleting a field: the claim is
+    # always stated, and the two representations must agree.
+    if receipt.selection_mode not in (SELECTION_SINGLE_SHOT, SELECTION_BEST_OF_N):
+        return TrajectoryVerifyResult(
+            ok=False,
+            reason=f"unknown selection_mode {receipt.selection_mode!r}",
+            receipt=receipt,
+            requested_hash=receipt_hash,
+        )
+    if (receipt.selection_mode == SELECTION_BEST_OF_N) != (receipt.best_of_n is not None):
+        return TrajectoryVerifyResult(
+            ok=False,
+            reason=(
+                f"selection_mode={receipt.selection_mode!r} disagrees with best_of_n "
+                f"{'present' if receipt.best_of_n is not None else 'absent'} (cherry-pick)"
+            ),
+            receipt=receipt,
+            requested_hash=receipt_hash,
+        )
     if receipt.best_of_n is not None:
         bon = receipt.best_of_n
         if len(bon.candidate_journal_heads) != bon.n_candidates:
@@ -648,6 +882,7 @@ def verify_trajectory_receipt(
                     f"but claims n_candidates={bon.n_candidates} (cherry-pick: missing heads)"
                 ),
                 receipt=receipt,
+                requested_hash=receipt_hash,
             )
         if bon.selected_index < 0 or bon.selected_index >= bon.n_candidates:
             return TrajectoryVerifyResult(
@@ -656,6 +891,7 @@ def verify_trajectory_receipt(
                     f"best_of_n selected_index={bon.selected_index} out of range [0, {bon.n_candidates}) (cherry-pick)"
                 ),
                 receipt=receipt,
+                requested_hash=receipt_hash,
             )
 
     # Step 6 -- spine verification and anchor check
@@ -667,6 +903,7 @@ def verify_trajectory_receipt(
             ok=False,
             reason=f"eval-bench spine failed verification: {detail}",
             receipt=receipt,
+            requested_hash=receipt_hash,
         )
 
     expected_content = content_hash_of(receipt.canonical_bytes())
@@ -679,9 +916,10 @@ def verify_trajectory_receipt(
             ok=False,
             reason="receipt is not anchored in the eval-bench spine",
             receipt=receipt,
+            requested_hash=receipt_hash,
         )
 
-    return TrajectoryVerifyResult(ok=True, reason="", receipt=receipt)
+    return TrajectoryVerifyResult(ok=True, reason="", receipt=receipt, requested_hash=receipt_hash)
 
 
 def verify_all_trajectory_receipts(workdir: Path, *, hmac_key: bytes) -> list[TrajectoryVerifyResult]:
@@ -713,12 +951,16 @@ def verify_all_trajectory_receipts(workdir: Path, *, hmac_key: bytes) -> list[Tr
 __all__ = [
     "EVAL_BENCH_RUN_ID",
     "NO_TASKS_STATUS",
+    "SELECTION_BEST_OF_N",
+    "SELECTION_SINGLE_SHOT",
     "TRAJECTORY_RECEIPT_SCHEMA_VERSION",
     "BestOfNProvenance",
+    "ReceiptBytesError",
     "TaskTrajectoryAnchor",
     "TrajectoryReceipt",
     "TrajectoryVerifyResult",
     "build_trajectory_receipt",
+    "decode_receipt_bytes",
     "read_trajectory_receipt",
     "trajectory_receipt_path",
     "verify_all_trajectory_receipts",

--- a/tests/unit/cli/test_benchmark_cmd_paths.py
+++ b/tests/unit/cli/test_benchmark_cmd_paths.py
@@ -180,3 +180,83 @@ def test_eval_calibration_help_lists_flags() -> None:
     assert result.exit_code == 0, result.output
     assert "--since" in result.output
     assert "--bins" in result.output
+
+
+# ---------------------------------------------------------------------------
+# benchmark receipt emit - input validation
+#
+# emit turns a persisted run record into signed bytes. Anything it substitutes
+# for missing input is sealed and then verifies clean, so a run record that is
+# short of a field has to be refused rather than defaulted.
+# ---------------------------------------------------------------------------
+
+
+_GOOD_TASK = {
+    "task_id": "smoke-001",
+    "journal_head_hash": "sha256:" + "1" * 64,
+    "events_content_hash": "sha256:" + "2" * 64,
+    "model_id": "test-model",
+    "config_fingerprint": "cfg-v1",
+    "components": {
+        "task_success": 1.0,
+        "code_quality": 0.9,
+        "efficiency": 0.8,
+        "reliability": 1.0,
+        "safety": 1.0,
+    },
+}
+_GOOD_PER_TIER = {"smoke": 1.0, "standard": 0.0, "stretch": 0.0, "adversarial": 0.0}
+
+
+def _write_run_record(root: Path, record: dict) -> None:
+    runs_path = root / ".sdd" / "benchmarks" / "benchmark_runs.jsonl"
+    runs_path.parent.mkdir(parents=True, exist_ok=True)
+    runs_path.write_text(json.dumps(record) + "\n", encoding="utf-8")
+
+
+def _emit(record: dict):
+    runner = CliRunner()
+    with runner.isolated_filesystem() as tmp:
+        _write_run_record(Path(tmp), record)
+        return runner.invoke(benchmark_group, ["receipt", "emit", "run-1", "--workdir", tmp])
+
+
+def test_receipt_emit_rejects_task_missing_journal_head() -> None:
+    task = {k: v for k, v in _GOOD_TASK.items() if k != "journal_head_hash"}
+    result = _emit({"run_id": "run-1", "tasks": [task], "per_tier": _GOOD_PER_TIER})
+    assert result.exit_code == 1, result.output
+    assert "journal_head_hash" in result.output
+
+
+def test_receipt_emit_rejects_placeholder_events_hash() -> None:
+    task = {**_GOOD_TASK, "events_content_hash": "sha256:" + "0" * 64}
+    result = _emit({"run_id": "run-1", "tasks": [task], "per_tier": _GOOD_PER_TIER})
+    assert result.exit_code == 1, result.output
+    assert "placeholder" in result.output
+
+
+def test_receipt_emit_rejects_missing_score_component() -> None:
+    components = {k: v for k, v in _GOOD_TASK["components"].items() if k != "efficiency"}
+    task = {**_GOOD_TASK, "components": components}
+    result = _emit({"run_id": "run-1", "tasks": [task], "per_tier": _GOOD_PER_TIER})
+    assert result.exit_code == 1, result.output
+    assert "efficiency" in result.output
+
+
+def test_receipt_emit_rejects_missing_per_tier() -> None:
+    result = _emit({"run_id": "run-1", "tasks": [_GOOD_TASK]})
+    assert result.exit_code == 1, result.output
+    assert "per_tier" in result.output
+
+
+def test_receipt_emit_rejects_non_numeric_component() -> None:
+    task = {**_GOOD_TASK, "components": {**_GOOD_TASK["components"], "safety": "high"}}
+    result = _emit({"run_id": "run-1", "tasks": [task], "per_tier": _GOOD_PER_TIER})
+    assert result.exit_code == 1, result.output
+    assert "non-numeric" in result.output
+
+
+def test_receipt_emit_accepts_a_complete_run_record() -> None:
+    result = _emit({"run_id": "run-1", "tasks": [_GOOD_TASK], "per_tier": _GOOD_PER_TIER})
+    assert result.exit_code == 0, result.output
+    assert "Trajectory receipt emitted" in result.output

--- a/tests/unit/eval/test_trajectory_receipt.py
+++ b/tests/unit/eval/test_trajectory_receipt.py
@@ -10,21 +10,28 @@ Acceptance criteria under test:
    components and rejects any receipt whose embedded trajectory does not entail
    its published number.
 
-3. Adversarial tests -- one per failure mode:
-   (a) flip one golden task body → suite-hash mismatch (contamination)
-   (b) edit one per-task component → score re-derivation mismatch (fabrication)
+3. Adversarial tests, in two rounds per failure mode.  The first edits the file
+   and leaves ``receipt_hash`` stale, which the hash-recompute step catches.
+   The second re-seals the hash so the attacker reaches the semantic check the
+   guard actually exists for:
+   (a) rename a golden task → suite-hash mismatch (contamination)
+   (b) inflate the aggregate away from its anchors → re-derivation mismatch
    (c) hand-edit the published scalar → formula mismatch (scalar edit)
-   (d) drop all-but-winner candidate heads → cherry-pick rejection
+   (d) delete ``best_of_n`` from a best-of-N receipt → cherry-pick rejection
 
-4. A receipt carrying all best-of-N heads re-selects the published index
+4. Byte integrity: an injected key, a duplicate key, re-spaced bytes, and a
+   ``NaN`` literal are each rejected.  Verification hashes the stored bytes,
+   not a decoded projection of them that drops what it does not recognise.
+
+5. A receipt carrying all best-of-N heads re-selects the published index
    deterministically.
 
-5. An empty suite produces a distinct ``NO_TASKS`` status receipt, never a
+6. An empty suite produces a distinct ``NO_TASKS`` status receipt, never a
    trivial pass.
 
-6. Round-trip: emit → reload from stored bytes → verify → assert clean.
+7. Round-trip: emit → reload from stored bytes → verify → assert clean.
 
-7. ``EVENT_TRAJECTORY_RECEIPT`` is present in the HMAC chain when a chain is
+8. ``EVENT_TRAJECTORY_RECEIPT`` is present in the HMAC chain when a chain is
    supplied.
 
 All tests are hermetic: separate tmp dirs per run, no live providers, no
@@ -33,6 +40,7 @@ wall-clock in sealed bytes.
 
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 
@@ -45,9 +53,12 @@ from bernstein.core.security.audit_chain import (
 from bernstein.eval.metrics import EvalScoreComponents, TierScores
 from bernstein.eval.trajectory_receipt import (
     NO_TASKS_STATUS,
+    SELECTION_BEST_OF_N,
+    SELECTION_SINGLE_SHOT,
     BestOfNProvenance,
     TaskTrajectoryAnchor,
     TrajectoryReceipt,
+    TrajectoryVerifyResult,
     build_trajectory_receipt,
     read_trajectory_receipt,
     trajectory_receipt_path,
@@ -123,13 +134,47 @@ def _build(
     )
 
 
-def _verify(workdir: Path, receipt_hash: str):
+def _verify(workdir: Path, receipt_hash: str) -> TrajectoryVerifyResult:
     return verify_trajectory_receipt(
         workdir=workdir,
         lineage_root=workdir / ".sdd" / "lineage",
         hmac_key=_KEY,
         receipt_hash=receipt_hash,
     )
+
+
+def _canonical(payload: dict) -> str:
+    """The exact encoding the receipt writer produces."""
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def _load_payload(workdir: Path, receipt_hash: str) -> dict:
+    return json.loads(trajectory_receipt_path(workdir, receipt_hash).read_text(encoding="utf-8"))
+
+
+def _rewrite_canonical(workdir: Path, receipt_hash: str, payload: dict) -> None:
+    """Store a tampered *payload* in canonical form under the same name.
+
+    Tamper tests must write canonical bytes, otherwise the byte-integrity gate
+    fires on the re-encoding alone and the semantic check under test is never
+    reached.
+    """
+    trajectory_receipt_path(workdir, receipt_hash).write_text(_canonical(payload), encoding="utf-8")
+
+
+def _reseal(workdir: Path, payload: dict) -> str:
+    """Re-hash a tampered payload and store it under its new content address.
+
+    Models the strongest attacker short of holding the HMAC key: one who edits
+    the receipt and recomputes ``receipt_hash`` so the hash-recompute step
+    cannot catch them.  Without this the semantic checks below step 1 are never
+    exercised.
+    """
+    body = {k: v for k, v in payload.items() if k not in ("receipt_hash", "journal_entry_hash")}
+    new_hash = "sha256:" + hashlib.sha256(_canonical(body).encode("utf-8")).hexdigest()
+    payload["receipt_hash"] = new_hash
+    trajectory_receipt_path(workdir, new_hash).write_text(_canonical(payload), encoding="utf-8")
+    return new_hash
 
 
 # ---------------------------------------------------------------------------
@@ -150,6 +195,14 @@ def test_two_independent_runs_produce_identical_receipt(tmp_path: Path) -> None:
     assert receipt_a.receipt_hash == receipt_b.receipt_hash
     assert receipt_a.canonical_payload_without_anchor() == receipt_b.canonical_payload_without_anchor()
     assert receipt_a.canonical_bytes() == receipt_b.canonical_bytes()
+    # The lineage anchor is assigned post-seal, so it is the field most likely
+    # to pick up ambient state. Two fresh spines must still agree on it.
+    assert receipt_a.journal_entry_hash == receipt_b.journal_entry_hash
+    # And the published artefact itself -- what an operator actually ships --
+    # must match byte for byte, not merely agree on its hash.
+    bytes_a = trajectory_receipt_path(dir_a, receipt_a.receipt_hash).read_bytes()
+    bytes_b = trajectory_receipt_path(dir_b, receipt_b.receipt_hash).read_bytes()
+    assert bytes_a == bytes_b
 
 
 def test_receipt_hash_is_stable_across_identical_inputs(tmp_path: Path) -> None:
@@ -218,18 +271,35 @@ def test_missing_receipt_returns_not_ok(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_contamination_mutated_task_id_fails_verification(tmp_path: Path) -> None:
+def test_contamination_mutated_task_id_fails_hash_recompute(tmp_path: Path) -> None:
+    """A rename with a stale receipt_hash is caught by the hash-recompute step."""
     receipt = _build(tmp_path)
-    path = trajectory_receipt_path(tmp_path, receipt.receipt_hash)
-    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload = _load_payload(tmp_path, receipt.receipt_hash)
     # Silently rename a task — simulates a mutated golden suite.
     payload["task_anchors"][0]["task_id"] = "smoke-TAMPERED"
     # Do NOT recompute receipt_hash — leave it stale so tamper is visible.
-    path.write_text(json.dumps(payload), encoding="utf-8")
+    _rewrite_canonical(tmp_path, receipt.receipt_hash, payload)
     result = _verify(tmp_path, receipt.receipt_hash)
     assert not result.ok
-    # Should fail either on hash recompute or suite-content-hash mismatch.
-    assert result.ok is False
+    assert "does not recompute" in result.reason
+
+
+def test_contamination_survives_resealing_and_hits_suite_hash(tmp_path: Path) -> None:
+    """A rename WITH a recomputed hash must still fail on suite_content_hash.
+
+    This is the check the contamination guard exists for.  Re-sealing carries
+    the attacker past the hash-recompute step, so without step 2 a mutated
+    golden suite would verify clean.
+    """
+    receipt = _build(tmp_path)
+    payload = _load_payload(tmp_path, receipt.receipt_hash)
+    payload["task_anchors"][0]["task_id"] = "smoke-TAMPERED"
+    tampered_hash = _reseal(tmp_path, payload)
+
+    result = _verify(tmp_path, tampered_hash)
+    assert not result.ok
+    assert "suite_content_hash mismatch" in result.reason
+    assert "contamination" in result.reason
 
 
 # ---------------------------------------------------------------------------
@@ -237,15 +307,54 @@ def test_contamination_mutated_task_id_fails_verification(tmp_path: Path) -> Non
 # ---------------------------------------------------------------------------
 
 
-def test_fabrication_edited_component_fails_verification(tmp_path: Path) -> None:
+def test_edited_component_fails_verification(tmp_path: Path) -> None:
     receipt = _build(tmp_path)
-    path = trajectory_receipt_path(tmp_path, receipt.receipt_hash)
-    payload = json.loads(path.read_text(encoding="utf-8"))
-    # Push task_success to 1.0 on the first task without recomputing hashes.
+    payload = _load_payload(tmp_path, receipt.receipt_hash)
+    # Drop task_success to 0.0 on the first task without recomputing hashes.
     payload["task_anchors"][0]["components"]["task_success"] = 0.0
-    path.write_text(json.dumps(payload), encoding="utf-8")
+    _rewrite_canonical(tmp_path, receipt.receipt_hash, payload)
     result = _verify(tmp_path, receipt.receipt_hash)
     assert not result.ok
+    assert "does not recompute" in result.reason
+
+
+def test_inflated_aggregate_survives_resealing_and_hits_rederivation(tmp_path: Path) -> None:
+    """An aggregate raised away from honest anchors fails re-derivation."""
+    receipt = _build(tmp_path)
+    payload = _load_payload(tmp_path, receipt.receipt_hash)
+    payload["aggregate"]["task_success"] = 1.0
+    payload["task_anchors"][0]["components"]["task_success"] = 0.0
+    tampered_hash = _reseal(tmp_path, payload)
+
+    result = _verify(tmp_path, tampered_hash)
+    assert not result.ok
+    assert "do not re-derive" in result.reason
+
+
+def test_aggregate_divergence_blames_no_individual_task(tmp_path: Path) -> None:
+    """Regression: the report must not name an honest outlier as the culprit.
+
+    Only the aggregate is inflated here; every anchor is untouched.  A blame
+    heuristic that picks the anchor furthest from the recomputed mean would
+    accuse ``task-d``, which is simply the suite's genuine low scorer.
+    """
+    anchors = [
+        _anchor("task-a", journal_head="sha256:" + "1" * 64),
+        _anchor("task-b", journal_head="sha256:" + "2" * 64),
+        _anchor("task-c", journal_head="sha256:" + "3" * 64),
+        _anchor("task-d", task_success=0.0, journal_head="sha256:" + "4" * 64),
+    ]
+    receipt = _build(tmp_path, anchors)
+    payload = _load_payload(tmp_path, receipt.receipt_hash)
+    payload["aggregate"]["task_success"] = 1.0
+    tampered_hash = _reseal(tmp_path, payload)
+
+    result = _verify(tmp_path, tampered_hash)
+    assert not result.ok
+    assert result.failing_task_index == -1
+    assert "task-d" not in result.reason
+    # The report names the divergent aggregate field instead.
+    assert "task_success" in result.reason
 
 
 # ---------------------------------------------------------------------------
@@ -255,13 +364,25 @@ def test_fabrication_edited_component_fails_verification(tmp_path: Path) -> None
 
 def test_scalar_edit_fails_verification(tmp_path: Path) -> None:
     receipt = _build(tmp_path)
-    path = trajectory_receipt_path(tmp_path, receipt.receipt_hash)
-    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload = _load_payload(tmp_path, receipt.receipt_hash)
     # Bump the published score without touching anything else.
     payload["published_score"] = 0.9999
-    path.write_text(json.dumps(payload), encoding="utf-8")
+    _rewrite_canonical(tmp_path, receipt.receipt_hash, payload)
     result = _verify(tmp_path, receipt.receipt_hash)
     assert not result.ok
+    assert "does not recompute" in result.reason
+
+
+def test_scalar_edit_survives_resealing_and_hits_formula(tmp_path: Path) -> None:
+    """A re-sealed scalar edit must still fail the formula check."""
+    receipt = _build(tmp_path)
+    payload = _load_payload(tmp_path, receipt.receipt_hash)
+    payload["published_score"] = 0.9999
+    tampered_hash = _reseal(tmp_path, payload)
+
+    result = _verify(tmp_path, tampered_hash)
+    assert not result.ok
+    assert "scalar edit" in result.reason
 
 
 # ---------------------------------------------------------------------------
@@ -361,6 +482,188 @@ def test_read_trajectory_receipt_returns_none_for_bad_hash(tmp_path: Path) -> No
 def test_trajectory_receipt_path_rejects_non_sha256(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="canonical sha256"):
         trajectory_receipt_path(tmp_path, "not-a-hash")
+
+
+# ---------------------------------------------------------------------------
+# Byte integrity -- verification must hash the stored bytes, not a projection
+# ---------------------------------------------------------------------------
+
+
+def test_injected_unknown_top_level_key_is_rejected(tmp_path: Path) -> None:
+    """A key the schema does not know must not be droppable before hashing.
+
+    Decoding into the dataclass discards unrecognised keys.  If the verifier
+    then rehashes that parsed projection, anything outside the schema rides
+    along in the published file while verification still reports clean.
+    """
+    receipt = _build(tmp_path)
+    payload = _load_payload(tmp_path, receipt.receipt_hash)
+    payload["published_score_display"] = 0.99
+    _rewrite_canonical(tmp_path, receipt.receipt_hash, payload)
+
+    result = _verify(tmp_path, receipt.receipt_hash)
+    assert not result.ok
+    assert "canonical encoding" in result.reason
+
+
+def test_injected_unknown_key_inside_anchor_is_rejected(tmp_path: Path) -> None:
+    """The same hole one level down, inside a task anchor and its components."""
+    receipt = _build(tmp_path)
+    payload = _load_payload(tmp_path, receipt.receipt_hash)
+    payload["task_anchors"][0]["real_task_success"] = 0.0
+    payload["task_anchors"][0]["components"]["shadow"] = 999
+    _rewrite_canonical(tmp_path, receipt.receipt_hash, payload)
+
+    result = _verify(tmp_path, receipt.receipt_hash)
+    assert not result.ok
+    assert "canonical encoding" in result.reason
+
+
+def test_duplicate_json_key_is_rejected(tmp_path: Path) -> None:
+    """Duplicate keys make the file mean different things to different parsers.
+
+    Python keeps the last occurrence, so a decoy inserted ahead of the honest
+    value leaves this verifier reading the honest one while a first-wins
+    parser elsewhere reads the decoy.
+    """
+    receipt = _build(tmp_path)
+    path = trajectory_receipt_path(tmp_path, receipt.receipt_hash)
+    text = path.read_text(encoding="utf-8")
+    tampered = text.replace('{"aggregate"', '{"published_score":0.99,"aggregate"', 1)
+    assert tampered != text, "canonical layout changed; update this fixture"
+    path.write_text(tampered, encoding="utf-8")
+
+    result = _verify(tmp_path, receipt.receipt_hash)
+    assert not result.ok
+    assert "canonical encoding" in result.reason
+
+
+def test_semantically_identical_reformatting_is_rejected(tmp_path: Path) -> None:
+    """Re-spaced but otherwise identical bytes are not the sealed bytes."""
+    receipt = _build(tmp_path)
+    path = trajectory_receipt_path(tmp_path, receipt.receipt_hash)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    result = _verify(tmp_path, receipt.receipt_hash)
+    assert not result.ok
+    assert "canonical encoding" in result.reason
+
+
+def test_non_finite_literal_is_rejected(tmp_path: Path) -> None:
+    """``NaN`` is a Python extension to JSON and defeats tolerance checks.
+
+    ``abs(x - nan) > tol`` is False, so a NaN scalar would pass the published
+    score check rather than fail it, and the file would not parse at all in a
+    conforming third-party verifier.
+    """
+    receipt = _build(tmp_path)
+    path = trajectory_receipt_path(tmp_path, receipt.receipt_hash)
+    text = path.read_text(encoding="utf-8")
+    path.write_text(text.replace('"published_score":0.93', '"published_score":NaN', 1), encoding="utf-8")
+
+    result = _verify(tmp_path, receipt.receipt_hash)
+    assert not result.ok
+    assert "non-finite" in result.reason
+
+
+def test_clean_receipt_bytes_are_byte_identical_to_canonical_form(tmp_path: Path) -> None:
+    """The writer's output is exactly what the verifier re-derives."""
+    receipt = _build(tmp_path)
+    stored = trajectory_receipt_path(tmp_path, receipt.receipt_hash).read_text(encoding="utf-8")
+    assert stored == _canonical(receipt.to_dict())
+
+
+def test_requested_hash_is_retained_when_bytes_are_rejected(tmp_path: Path) -> None:
+    """An operator must be able to name the file even on an undecodable one."""
+    receipt = _build(tmp_path)
+    payload = _load_payload(tmp_path, receipt.receipt_hash)
+    payload["mystery"] = 1
+    _rewrite_canonical(tmp_path, receipt.receipt_hash, payload)
+
+    result = _verify(tmp_path, receipt.receipt_hash)
+    assert not result.ok
+    assert result.receipt is None
+    assert result.requested_hash == receipt.receipt_hash
+
+
+# ---------------------------------------------------------------------------
+# Selection disclosure -- "not best-of-N" is a claim, not an absent field
+# ---------------------------------------------------------------------------
+
+
+def test_single_shot_receipt_states_its_selection_mode(tmp_path: Path) -> None:
+    receipt = _build(tmp_path)
+    assert receipt.selection_mode == SELECTION_SINGLE_SHOT
+    assert receipt.body()["selection_mode"] == SELECTION_SINGLE_SHOT
+
+
+def test_best_of_n_receipt_states_its_selection_mode(tmp_path: Path) -> None:
+    bon = BestOfNProvenance(
+        n_candidates=2,
+        candidate_journal_heads=["sha256:" + "c" * 64, "sha256:" + "d" * 64],
+        selection_rule="highest_final_score",
+        selected_index=0,
+    )
+    receipt = _build(tmp_path, best_of_n=bon)
+    assert receipt.selection_mode == SELECTION_BEST_OF_N
+
+
+def test_stripping_best_of_n_from_a_sealed_receipt_is_rejected(tmp_path: Path) -> None:
+    """Downgrading a sealed best-of-N receipt to single-shot must fail.
+
+    Selection mode lives in the signed body, so deleting ``best_of_n`` leaves
+    a receipt that contradicts its own declared mode even after re-sealing.
+    """
+    bon = BestOfNProvenance(
+        n_candidates=5,
+        candidate_journal_heads=["sha256:" + c * 64 for c in "abcde"],
+        selection_rule="highest_final_score",
+        selected_index=3,
+    )
+    receipt = _build(tmp_path, best_of_n=bon)
+    assert _verify(tmp_path, receipt.receipt_hash).ok
+
+    payload = _load_payload(tmp_path, receipt.receipt_hash)
+    payload["best_of_n"] = None
+    tampered_hash = _reseal(tmp_path, payload)
+
+    result = _verify(tmp_path, tampered_hash)
+    assert not result.ok
+    assert "cherry-pick" in result.reason
+
+
+def test_declaring_best_of_n_without_provenance_is_rejected(tmp_path: Path) -> None:
+    receipt = _build(tmp_path)
+    payload = _load_payload(tmp_path, receipt.receipt_hash)
+    payload["selection_mode"] = SELECTION_BEST_OF_N
+    tampered_hash = _reseal(tmp_path, payload)
+
+    result = _verify(tmp_path, tampered_hash)
+    assert not result.ok
+    assert "cherry-pick" in result.reason
+
+
+# ---------------------------------------------------------------------------
+# Build-time input validation
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_task_id_is_rejected_at_build(tmp_path: Path) -> None:
+    """A repeated task would be counted twice behind an honest suite hash.
+
+    ``suite_content_hash`` de-duplicates its input, so two anchors sharing an
+    id hash the same as one while both still feed the aggregate mean.
+    """
+    anchors = [_anchor("smoke-001"), _anchor("smoke-001", task_success=0.0)]
+    with pytest.raises(ValueError, match="duplicate task_id"):
+        _build(tmp_path, anchors)
+
+
+def test_non_finite_component_is_rejected_at_build(tmp_path: Path) -> None:
+    anchors = [_anchor("smoke-001", task_success=float("nan"))]
+    with pytest.raises(ValueError, match="non-finite"):
+        _build(tmp_path, anchors)
 
 
 def test_receipt_no_wall_clock_in_body(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

Makes `verify_trajectory_receipt` verify the stored receipt bytes rather than a decoded projection of them, and corrects three claims the module made that its code did not implement.

Follows #3191, which introduced the module. Closes nothing.

## Why

A receipt is only worth the tamper it refuses. Verification decoded the file into dataclasses and then rehashed that object. The decode is lossy in two ways: `from_dict` drops keys the schema does not recognise, and `journal_entry_hash` fell back to a `.get` default. Anything outside the schema therefore never reached the hash, so an edited file could verify clean.

Reproduced against the merged code before this change:

| Tamper applied to a sealed receipt | Verifier said |
|---|---|
| inject `published_score_display` and `auditor_note` at top level | `ok=True` |
| inject unknown keys inside a task anchor and its components | `ok=True` |
| insert a duplicate `published_score` ahead of the honest one | `ok=True` |

The duplicate-key case is the sharpest. Python keeps the last occurrence, so this verifier reads the honest value while a first-wins parser reading the same published file reads the decoy. The two disagree about what the receipt says and both consider it valid.

Three further claims did not hold as written:

1. The module docstring said verification "replays every sealed journal through `ReplayGateway` and recomputes the per-task score components". There is no such call anywhere in the module. A suite of ten anchors with invented components and journal hashes pointing at nothing verifies clean with `published_score=1.0`.
2. Cherry-pick detection ran only when `best_of_n` was present, so nothing distinguished a single-shot run from a best-of-N run with the field removed.
3. The aggregate mismatch report named a "first suspect task" by picking the anchor furthest from the recomputed mean. That is the suite's honest low scorer, not the edited record. On a four-task suite with the aggregate inflated and every anchor untouched, it accused `task-d`, and two CLI paths printed that index.

## How

Verification now re-canonicalises the parsed record and compares it byte for byte against the file before any hash is recomputed. Anything the schema would have dropped makes the two differ and is rejected. The decoder also refuses the `NaN` and `Infinity` literals that Python accepts but RFC 8259 does not, so the file means the same thing to a verifier that is not Python, and `NaN` can no longer slip past `abs(x - y) > tol`, which is False for `NaN` and would have passed the published-score check rather than failed it.

`selection_mode` is now mandatory in the signed body. Deleting `best_of_n` from a sealed best-of-N receipt leaves a receipt that contradicts its own declared mode. A publisher can still seal a false claim at emit time, which no verifier can detect, but the claim is now explicit in the signed bytes instead of absent.

The module docstring now states what a receipt establishes and what it leaves to a separate replay step, including that a wholly invented trajectory is internally consistent and will verify.

Smaller items in the same pass:

- `build_trajectory_receipt` rejects duplicate task ids. `suite_content_hash` de-duplicates its input, so two anchors sharing an id hash as one entry while both still feed the aggregate mean.
- `build_trajectory_receipt` rejects non-finite components at the boundary.
- `benchmark receipt emit` requires every field it seals. It previously substituted a zero `events_content_hash`, `"unknown"` model and config, and zeroed components, then sealed them.
- The receipt file is written through a temp file and `os.replace`. The spine entry and chain mirror are already durable at that point, so a torn write left a truncated receipt behind a live anchor.
- `TrajectoryVerifyResult` carries the requested hash on every failure path. `audit verify` previously recovered it by splitting the reason string on quote characters and printed `?` when that failed.

### Determinism

Two independent runs produce byte-identical output, including the lineage anchor. The existing test did not establish that. Under a mutant that leaks a wall clock into `spine.record`, all three of its assertions stayed green:

```
ORIGINAL assertion 1 (receipt_hash)          : True
ORIGINAL assertion 2 (canonical_payload)     : True
ORIGINAL assertion 3 (canonical_bytes)       : True
ADDED    assertion 4 (journal_entry_hash)    : False
```

The test now also compares `journal_entry_hash` and the on-disk bytes of both receipts, which is what an operator actually ships.

### Tests

36 tests in `test_trajectory_receipt.py`, up from 19, plus 6 CLI validation tests. The adversarial cases now run in two rounds each: once leaving `receipt_hash` stale, which the hash-recompute step catches, and once re-sealing the hash so the attacker reaches the semantic check the guard exists for. The originals only exercised the first round, so the contamination test never reached the contamination check.

Every new guard was mutation-proved by disabling it and confirming the intended tests go red:

| Guard disabled | Tests that went red |
|---|---|
| byte-integrity comparison | 5 |
| selection-mode consistency | 2 |
| aggregate blame removal | 1 |
| build-time anchor validation | 2 |
| `timestamp=0` in the spine record | 1 |

## Checklist

- [x] `uv run ruff check .` passes
- [x] `uv run ruff format --check .` passes
- [x] `uv run mypy --config-file mypy.gate.ini` passes
- [x] `tests/unit/eval`, `tests/unit/cli`, `tests/unit/lineage`: 1232 passed, 1 skipped
- [x] `-k "audit_chain or audit_cmd or audit_verify"`: 202 passed
- [x] New code has type hints

### Documentation duty

- [x] User-visible README section updated (N/A, no new user-facing surface)
- [x] `docs/operations/<area>.md` updated (N/A)
- [x] `docs/api/` schema regenerated if a public surface changed (N/A)
- [x] `uv run bernstein agents-md verify` reports all 13 files in sync
- [x] Tests cover the documented behaviour


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Strengthened trajectory receipt verification to detect tampering, malformed data, non-canonical files, duplicate tasks, and invalid numeric values.
  * Receipt files are now written atomically and validated consistently during reading and verification.

* **Benchmarking**
  * Benchmark receipt generation now rejects incomplete runs, placeholder hashes, missing score data, and invalid scores instead of filling in defaults.

* **Diagnostics**
  * Verification results preserve the requested hash and provide more accurate failure details.
  * Receipts now clearly distinguish single-shot and best-of-N evaluations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->