### PR TITLE
fix(quality): select workflow guards by what they read, not by their name

### DIFF
--- a/docs/operations/ci.md
+++ b/docs/operations/ci.md
@@ -530,6 +530,37 @@ uv run python scripts/check_test_collection.py          # report
 uv run python scripts/check_test_collection.py --json   # machine-readable
 ```
 
+### Workflow-guard selection
+
+A workflow-only pull request runs the affected slice, so the guards that
+parse workflow YAML have to be inside it. Selecting those guards by the
+substring `workflow` in the test file name only finds the ones that
+follow that convention: a guard named after the workflow it pins reads
+the same YAML, breaks on the same edit, and was left out, so the failure
+surfaced on `main` after the merge instead of on the pull request.
+
+`_workflow_test_files` unions two rules, and both are load-bearing:
+
+| Rule | Why it cannot be dropped |
+|---|---|
+| `workflow` in the test file name | Keeps guards that reach workflows through a script they shell out to and so spell no workflow path of their own, `test_workflow_topology_report.py` among them |
+| Test text reaches into `.github/workflows` | Keeps guards named after the workflow they pin, `test_post_ci_dispatcher_yaml.py` among them |
+
+The content rule matches the directory written as a posix path and
+assembled from path segments (`Path(".github") / "workflows"`), which is
+how every guard in the tree reaches it. Measured against the tree at the
+time the rule landed, the name rule alone selected 36 files and the union
+selects 56.
+
+Selection stays keyed on what a test reads. A test that merely names a
+script which itself scans workflows is deliberately not selected:
+`run_tests.py` holds a `.github/workflows/` constant of its own, so that
+rule pulled in 18 further files that guard nothing about workflows.
+
+```bash
+uv run python scripts/test_impact.py --files .github/workflows/ci.yml --print-paths
+```
+
 ### Required-context presence
 
 A head commit that never produced a check-run for a required context

--- a/src/bernstein/core/quality/test_impact.py
+++ b/src/bernstein/core/quality/test_impact.py
@@ -28,6 +28,13 @@ _ANALYZER_CACHE_VERSION = "4"
 _COMPAT_CACHE_VERSION = "4"
 _WORKFLOW_PATH_PREFIX = ".github/workflows/"
 
+# The two forms a test uses to reach a workflow file: the directory spelled out
+# as a posix path, or assembled from path segments (``Path(".github") /
+# "workflows" / name``). Matching both keys selection on what a test reads
+# rather than on what the test happens to be called.
+_WORKFLOW_DIR_LITERAL = _WORKFLOW_PATH_PREFIX.rstrip("/")
+_WORKFLOW_DIR_SEGMENTS = ('".github"', "'.github'")
+
 # A package can keep an old dotted import path alive without a physical shim
 # file by registering a ``sys.meta_path`` finder backed by a
 # ``{short_name: real_dotted_module}`` table. The import then resolves, but the
@@ -397,9 +404,37 @@ def _has_workflow_change(changed_files: list[str]) -> bool:
     return any(Path(path).as_posix().startswith(_WORKFLOW_PATH_PREFIX) for path in changed_files)
 
 
-def _workflow_test_files(test_files: list[str]) -> set[str]:
-    """Return tests that validate workflow YAML or workflow tooling."""
-    return {test_file for test_file in test_files if "workflow" in Path(test_file).name}
+def _reads_workflow_files(test_path: Path) -> bool:
+    """Return True when a test file reaches into ``.github/workflows``."""
+    try:
+        text = test_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return False
+    if _WORKFLOW_DIR_LITERAL in text:
+        return True
+    return "workflows" in text and any(segment in text for segment in _WORKFLOW_DIR_SEGMENTS)
+
+
+def _workflow_test_files(test_files: list[str], root: Path) -> set[str]:
+    """Return tests that validate workflow YAML or workflow tooling.
+
+    Two rules, unioned, because neither one alone is honest.
+
+    Selecting on the substring ``workflow`` in the file name only finds guards
+    that follow that convention. A guard named after the workflow it pins reads
+    the same YAML and breaks on the same edit, so the name rule drops it and the
+    breakage surfaces only after the merge, when the full suite runs.
+
+    Reading the file instead of its name fixes that but cannot stand on its own:
+    a guard that reaches workflows through a script it shells out to spells no
+    workflow path of its own, and the checked-in CI topology report is guarded
+    exactly that way. Keeping the name rule keeps that guard selected.
+    """
+    return {
+        test_file
+        for test_file in test_files
+        if "workflow" in Path(test_file).name or _reads_workflow_files(root / test_file)
+    }
 
 
 def _collect_tests_for_modules(
@@ -487,7 +522,7 @@ def compat_get_affected_tests(
     all_affected = _expand_transitive_modules(changed_modules, source_imports)
     affected_tests = _collect_changed_test_files(changed_files, root, test_deps)
     if _has_workflow_change(changed_files):
-        affected_tests.update(_workflow_test_files(list(test_deps)))
+        affected_tests.update(_workflow_test_files(list(test_deps), root))
     affected_tests.update(_collect_tests_for_modules(all_affected, module_to_tests))
 
     return sorted(root / rel for rel in affected_tests)
@@ -649,7 +684,7 @@ class TestImpactAnalyzer:
 
         affected: set[str] = set()
         mappings: list[TestMapping] = []
-        workflow_tests = sorted(_workflow_test_files(all_tests)) if _has_workflow_change(normalized) else []
+        workflow_tests = sorted(_workflow_test_files(all_tests, self._root)) if _has_workflow_change(normalized) else []
         if workflow_tests:
             affected.update(workflow_tests)
             mappings.append(

--- a/tests/unit/test_test_impact.py
+++ b/tests/unit/test_test_impact.py
@@ -439,6 +439,36 @@ class TestGetAffectedTests:
             "tests/unit/test_ci_workflow_yaml.py",
         ]
 
+    def test_workflow_change_selects_guards_that_read_workflow_yaml(self, tmp_path: Path) -> None:
+        """The legacy CLI selects workflow guards by what they read, not by name.
+
+        The shard runner drives this path, so a guard missed here is a guard the
+        pull-request lane never runs.
+        """
+        import test_impact as ti  # type: ignore[import]
+
+        src = tmp_path / "src"
+        self._make_dep_map(tmp_path, src=src)
+        test_dir = tmp_path / "tests" / "unit"
+        (test_dir / "test_post_ci_dispatcher_yaml.py").write_text(
+            'from pathlib import Path\n\nWORKFLOW = Path(".github") / "workflows" / "post-ci-dispatcher.yml"\n'
+        )
+        (test_dir / "test_models.py").write_text("def test_model() -> None:\n    assert True\n")
+
+        orig_src, orig_root = ti.SRC_ROOT, ti.ROOT
+        ti.SRC_ROOT = src
+        ti.ROOT = tmp_path
+        try:
+            dep_map = build_dep_map(test_dirs=[test_dir])
+            affected = get_affected_tests([".github/workflows/post-ci-dispatcher.yml"], dep_map)
+        finally:
+            ti.SRC_ROOT = orig_src
+            ti.ROOT = orig_root
+
+        assert [path.relative_to(tmp_path).as_posix() for path in affected] == [
+            "tests/unit/test_post_ci_dispatcher_yaml.py",
+        ]
+
     def test_package_data_change_selects_tests_of_owning_package(self, tmp_path: Path) -> None:
         """Non-Python package data maps to the tests of its owning package.
 

--- a/tests/unit/test_test_impact_core.py
+++ b/tests/unit/test_test_impact_core.py
@@ -7,6 +7,19 @@ from pathlib import Path
 import pytest
 from bernstein.core.test_impact import TestImpactAnalyzer as ImpactAnalyzer
 
+from bernstein.core.quality.test_impact import compat_get_affected_tests
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Guards in this repository that parse workflow YAML but are named after the
+# workflow they pin rather than after the word "workflow". Each one has to be
+# selected by a workflow-only change; a name-only predicate misses all three.
+_WORKFLOW_GUARDS_WITHOUT_WORKFLOW_IN_NAME = (
+    "tests/unit/test_bot_pull_request_tokens_yaml.py",
+    "tests/unit/test_merge_queue_gate_coverage_yaml.py",
+    "tests/unit/test_post_ci_dispatcher_yaml.py",
+)
+
 
 def _write(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -120,6 +133,79 @@ def test_workflow_change_selects_workflow_yaml_tests(tmp_path: Path) -> None:
         "tests/unit/test_autoheal_workflow_yaml.py",
         "tests/unit/test_ci_workflow_yaml.py",
     ]
+
+
+def test_workflow_change_selects_guards_that_read_workflow_yaml(tmp_path: Path) -> None:
+    """A guard that reads workflow YAML is selected whatever its file is called.
+
+    Selecting on the substring ``workflow`` in the test file name only finds
+    guards that happen to follow that naming convention. A guard named after
+    the workflow it pins rather than after the word ``workflow`` reads the same
+    YAML and breaks on the same edit, so it belongs in the same selection.
+    """
+    _write(tmp_path / "src" / "demo" / "__init__.py", "")
+    _write(tmp_path / ".github" / "workflows" / "post-ci-dispatcher.yml", "name: Dispatcher\n")
+    _write(
+        tmp_path / "tests" / "unit" / "test_post_ci_dispatcher_yaml.py",
+        'from pathlib import Path\n\nWORKFLOW = Path(".github") / "workflows" / "post-ci-dispatcher.yml"\n',
+    )
+    _write(
+        tmp_path / "tests" / "unit" / "test_tokens_yaml.py",
+        'WORKFLOWS = ".github/workflows"\n\ndef test_tokens() -> None:\n    assert WORKFLOWS\n',
+    )
+    _write(tmp_path / "tests" / "unit" / "test_models.py", "def test_model() -> None:\n    assert True\n")
+
+    analyzer = ImpactAnalyzer(tmp_path, test_dirs=[tmp_path / "tests" / "unit"])
+    analysis = analyzer.analyze([".github/workflows/post-ci-dispatcher.yml"])
+
+    assert analysis.fallback_used is False
+    assert analysis.affected_tests == [
+        "tests/unit/test_post_ci_dispatcher_yaml.py",
+        "tests/unit/test_tokens_yaml.py",
+    ]
+
+
+def test_dispatcher_workflow_change_selects_the_real_dispatcher_guard() -> None:
+    """A change to post-ci-dispatcher.yml selects this repository's own guard.
+
+    The synthetic cases above pin the rule; this one pins the rule against the
+    files that actually ship. ``test_post_ci_dispatcher_yaml.py`` asserts the
+    secrets each dispatched child job receives, so an edit to that workflow is
+    exactly the edit it exists to catch, and the pull-request lane has to run
+    it before the merge rather than after.
+    """
+    dep_map = {
+        "test_deps": {guard: {"hash": "", "imports": []} for guard in _WORKFLOW_GUARDS_WITHOUT_WORKFLOW_IN_NAME},
+        "source_imports": {},
+    }
+
+    affected = compat_get_affected_tests(
+        [".github/workflows/post-ci-dispatcher.yml"],
+        dep_map,
+        root=REPO_ROOT,
+        src_root=REPO_ROOT / "src",
+    )
+
+    selected = [path.relative_to(REPO_ROOT).as_posix() for path in affected]
+    assert "tests/unit/test_post_ci_dispatcher_yaml.py" in selected
+    assert selected == sorted(_WORKFLOW_GUARDS_WITHOUT_WORKFLOW_IN_NAME)
+
+
+def test_workflow_change_leaves_tests_that_never_read_workflows(tmp_path: Path) -> None:
+    """Widening the predicate must not degrade into selecting the whole suite."""
+    _write(tmp_path / "src" / "demo" / "__init__.py", "")
+    _write(tmp_path / ".github" / "workflows" / "ci.yml", "name: CI\n")
+    _write(tmp_path / "tests" / "unit" / "test_models.py", "def test_model() -> None:\n    assert True\n")
+    _write(
+        tmp_path / "tests" / "unit" / "test_yaml_loader.py",
+        'import yaml\n\ndef test_load() -> None:\n    assert yaml.safe_load("a: 1")\n',
+    )
+
+    analyzer = ImpactAnalyzer(tmp_path, test_dirs=[tmp_path / "tests" / "unit"])
+    analysis = analyzer.analyze([".github/workflows/ci.yml"])
+
+    assert analysis.fallback_used is False
+    assert analysis.affected_tests == []
 
 
 def test_version_bump_falls_back_to_all_tests(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

Diff-scoped test selection picked workflow guards by matching the substring `workflow` in the test file **name**:

```python
return {test_file for test_file in test_files if "workflow" in Path(test_file).name}
```

A guard named after the workflow it pins reads the same YAML and breaks on the same edit, but the name rule dropped it. A workflow-only pull request therefore ran a slice that excluded those guards, merged green, and the breakage surfaced on `main` when the full suite ran.

## What the measurement showed

The gap is wider than the three guards that prompted this. Measured on the tree at `aff87b09`:

| Predicate | Files selected on a workflow change | Guards it recovers |
|---|---|---|
| Name only (before) | 36 | baseline |
| Name + `_yaml.py` suffix | 39 | 3 of 23 |
| Content only (replacing name) | 49 | 23, but regresses (below) |
| **Name OR content (this PR)** | **56** | **20 of 23** |

Twenty guards were invisible to the pull-request lane, among them `test_run_tests_affected_gate.py`, `test_run_tests_sharding.py`, `test_permissions.py`, `test_release_entrypoint_docs.py`, `test_merge_queue_runbook_docs.py`.

## Why both rules are kept

Neither rule is sufficient alone, so `_workflow_test_files` unions them.

**The name rule cannot be dropped.** `test_workflow_topology_report.py` reaches workflows only by shelling out to `scripts/gen_workflow_topology.py --check`. It names no workflow file and no workflow path, so a content scan does not see it. That guard is the drift gate on the checked-in `docs/operations/ci-topology.md`; replacing the name rule with a content rule would push that drift back to being main-only.

**The content rule cannot be dropped.** It is the only thing that selects a guard named after the workflow it pins.

## Rejected alternatives

**Per-workflow-file keying** (select only tests naming the changed workflow). Measured 56 files for a `post-ci-dispatcher.yml` change against 59 for a coarse union, so at most three files saved, in exchange for carrying a workflow-to-test map through two separate caches with their own version fields. Not taken.

**One-hop script edge** (select a test that names a script which itself scans workflows). This would recover one further genuine guard, `tests/unit/scripts/test_check_test_collection.py`, which loads `scripts/check_test_collection.py` and so guards workflow parsing indirectly. It also pulls in 18 files that guard nothing about workflows, because `scripts/run_tests.py` holds a `.github/workflows/` constant of its own and is referenced widely across the suite. Tightening the rule to require invocation by path did not reduce the noise. Not taken; the residual gap is recorded below.

## Residual gap, deliberately left

Three files reference a workflow but are not selected. Two are docstring mentions only and guard nothing (`test_cluster_tunnel_smoke.py`, `test_sigstore_attestation_verify.py`). The third, `tests/unit/scripts/test_check_test_collection.py`, is a genuine indirect guard, reachable only through the noisy script edge described above. Tracked separately rather than bought at the cost of 18 unrelated files.

## Blast radius

Twenty extra test files on a workflow change, roughly 450 extra test cases, about 88 seconds of wall clock in a single pytest process. The slowest individual test in the added set is 1.56 s, so the cost is import overhead rather than test work. Non-workflow changes are unaffected: the predicate runs only behind `_has_workflow_change`.

## Verification

- Both selection paths agree on the real repository: the legacy CLI and `TestImpactAnalyzer` each select 56 files for a `post-ci-dispatcher.yml` change, with `fallback_used=False`, so nothing falls open to the full suite.
- Before this change, the same command selected 36 and `tests/unit/test_post_ci_dispatcher_yaml.py` was absent.
- New regression tests were written first and observed failing for the right reason, then passing. Both suites green (44 tests).
- `ruff check`, `ruff format`, `scripts/check_docs_drift.py` (`clean: true`), and `bernstein agents-md verify` (13 files in sync) are clean.
- `uv run mypy src` reports no new errors for the changed file. The four it reports in `_build_fresh_index` are pre-existing and untouched by this diff; that run is advisory per the note in `ci.yml`.
- No workflow file is touched, so `docs/operations/ci-topology.md` needs no regeneration.
- A local `run_tests.py --affected` sweep over the 542 transitively affected files was still in flight when this was opened; CI covers that ground.

## Tests added

- `test_dispatcher_workflow_change_selects_the_real_dispatcher_guard` pins the rule against the files that actually ship: a change to `.github/workflows/post-ci-dispatcher.yml` selects `tests/unit/test_post_ci_dispatcher_yaml.py`, plus the other two guards the name rule missed.
- `test_workflow_change_selects_guards_that_read_workflow_yaml` covers both reference forms, the posix path and the segment-assembled path, on the analyzer path and on the legacy CLI path.
- `test_workflow_change_leaves_tests_that_never_read_workflows` pins that widening the predicate does not degrade into selecting the whole suite.

## Unrelated red on main, not addressed here

`tests/unit/test_post_ci_dispatcher_yaml.py` fails two cases on a clean `origin/main` checkout: the `bernstein-ci-fix` and `auto-heal` jobs forward `BERNSTEIN_AUTOSYNC_TOKEN`, which is absent from `EXPECTED_CHILD_SECRETS`. That is the drift this selection gap let through, and it is being fixed on its own branch. This PR changes selection only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow change detection so affected tests are selected when they reference the changed workflow file, even if their filenames do not.
  * Prevented unrelated tests from being selected unnecessarily.

* **Documentation**
  * Added guidance on workflow-based test selection, supported workflow paths, selection reporting, and inspection commands.

* **Tests**
  * Added regression coverage for workflow references, dispatcher safeguards, and unrelated test exclusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->