### PR TITLE
chore(typing): define adapter cast aliases as types

### DIFF
--- a/src/bernstein/adapters/claude.py
+++ b/src/bernstein/adapters/claude.py
@@ -257,7 +257,7 @@ _RESULT_SCHEMA = json.dumps(
 
 
 # Shared cast-type constants to avoid string duplication (Sonar S1192).
-_CAST_DICT_STR_ANY = "dict[str, Any]"
+type _CAST_DICT_STR_ANY = dict[str, Any]
 
 
 _logger = logging.getLogger(__name__)

--- a/src/bernstein/adapters/claude_mcp_loader.py
+++ b/src/bernstein/adapters/claude_mcp_loader.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Any, cast
 
 # Shared cast-type constant to avoid string duplication (Sonar S1192).
-_CAST_DICT_STR_ANY = "dict[str, Any]"
+type _CAST_DICT_STR_ANY = dict[str, Any]
 
 
 def load_mcp_config(

--- a/src/bernstein/adapters/claude_stream_parser.py
+++ b/src/bernstein/adapters/claude_stream_parser.py
@@ -53,7 +53,7 @@ PROVIDER_MUTATION_SUBTYPES: frozenset[str] = frozenset(
 
 
 # Shared cast-type constants to avoid string duplication (Sonar S1192).
-_CAST_DICT_STR_ANY = "dict[str, Any]"
+type _CAST_DICT_STR_ANY = dict[str, Any]
 
 # Maximum number of text blocks retained for deduplication.  Bounded LRU
 # prevents unbounded growth in long-running sessions.


### PR DESCRIPTION
## What

I replaced the three string constants used as `cast()` targets in the adapters package with real PEP 695 type aliases.

## Why

Mypy treated the string constants as values rather than types, producing `valid-type` errors and cascading `attr-defined` errors. Defining them as type aliases removes 12 errors without changing runtime behavior.

## How

I updated the shared `dict[str, Any]` cast alias in:

- `claude.py`
- `claude_mcp_loader.py`
- `claude_stream_parser.py`

The remaining 11 adapter-package mypy errors are outside this mechanical alias pattern, so I left them unchanged rather than mixing runtime or SDK typing concerns into this slice.

## Validation

- `uv run mypy src/bernstein/adapters/` — reduced from 23 errors in 8 files to 11 errors in 5 files
- `uv run ruff check src/bernstein/adapters/` — passed
- `uv run ruff format --check src/bernstein/adapters/` — passed (82 files already formatted)
- `uv run pytest tests/unit/test_adapter_registry.py tests/unit/test_adapter_qwen.py -q` — 55 passed
- `uv run pytest tests/unit/test_claude_stream_parser.py tests/unit/test_mcp_config.py tests/unit/test_adapter_claude.py tests/unit/test_provider_state_capture.py tests/unit/test_hooks_injection.py -q` — 153 passed
- `git diff --check upstream/main...HEAD` — passed

## Checklist

- [x] Adapter-package mypy error count is lower (23 → 11)
- [x] No `# type: ignore` added
- [x] No runtime behavior changed; type aliases only
- [x] Ruff lint and format checks pass
- [x] The two issue-specified test files pass
- [x] Documentation is N/A because this is an internal typing-only cleanup

Fixes #3226

## Summary by Sourcery

Replace string-based cast targets in Claude adapters with proper type aliases to clean up typing without changing runtime behavior.

Enhancements:
- Define a shared dict[str, Any] adapter cast alias as a PEP 695 type alias in Claude-related adapter modules to eliminate mypy valid-type and attr-defined errors.

Chores:
- Reduce mypy error count in the adapters package by standardizing cast targets while keeping existing runtime logic intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal type handling for dictionary data across Claude integrations.
  * No changes to configuration loading, environment-variable processing, or stream behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->