### PR TITLE
fix(doctor): report missing uv as failed check instead of crashing

### DIFF
--- a/src/bernstein/core/quality/ci_fix.py
+++ b/src/bernstein/core/quality/ci_fix.py
@@ -349,72 +349,58 @@ def install_pre_push_hook(repo_root: Path, force: bool = False) -> bool:
 # ---------------------------------------------------------------------------
 
 
+def _check_tool_version(name: str, *, detail_limit: int = 60) -> dict[str, str]:
+    """Run ``uv run <name> --version`` and report the result as a check dict.
+
+    Turns a missing ``uv`` executable (``FileNotFoundError``, raised e.g. as
+    ``WinError 2`` on Windows) into a failed check instead of letting it
+    propagate, since ``bernstein doctor``'s entire job is to report which
+    tools are missing.
+
+    Args:
+        name: Tool to check (``ruff``, ``pytest``, ``pyright``, ...).
+        detail_limit: Max characters of stdout to keep in ``detail`` on success.
+
+    Returns:
+        Check result dict with keys: name, ok (bool), detail, fix.
+    """
+    try:
+        result = subprocess.run(
+            ["uv", "run", name, "--version"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=10,
+        )
+    except FileNotFoundError:
+        return {
+            "name": name,
+            "ok": "False",
+            "detail": "uv not found on PATH",
+            "fix": "Install uv (https://docs.astral.sh/uv/) and ensure it is on PATH",
+        }
+
+    ok = result.returncode == 0
+    return {
+        "name": name,
+        "ok": str(ok),
+        "detail": result.stdout.strip()[:detail_limit] if ok else result.stderr.strip()[:80],
+        "fix": "" if ok else f"Add {name} to [dependency-groups] dev in pyproject.toml",
+    }
+
+
 def check_test_dependencies() -> list[dict[str, str]]:
     """Check that all CI tool dependencies are importable/executable.
 
     Returns:
         List of check result dicts with keys: name, ok (bool), detail, fix.
     """
-    checks: list[dict[str, str]] = []
-
-    # ruff
-    result = subprocess.run(
-        ["uv", "run", "ruff", "--version"],
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        timeout=10,
-    )
-    ruff_ok = result.returncode == 0
-    checks.append(
-        {
-            "name": "ruff",
-            "ok": str(ruff_ok),
-            "detail": result.stdout.strip() if ruff_ok else result.stderr.strip()[:80],
-            "fix": "" if ruff_ok else "Add ruff to [dependency-groups] dev in pyproject.toml",
-        }
-    )
-
-    # pytest
-    result = subprocess.run(
-        ["uv", "run", "pytest", "--version"],
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        timeout=10,
-    )
-    pytest_ok = result.returncode == 0
-    checks.append(
-        {
-            "name": "pytest",
-            "ok": str(pytest_ok),
-            "detail": result.stdout.strip()[:60] if pytest_ok else result.stderr.strip()[:80],
-            "fix": "" if pytest_ok else "Add pytest to [dependency-groups] dev in pyproject.toml",
-        }
-    )
-
-    # pyright
-    result = subprocess.run(
-        ["uv", "run", "pyright", "--version"],
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        timeout=10,
-    )
-    pyright_ok = result.returncode == 0
-    checks.append(
-        {
-            "name": "pyright",
-            "ok": str(pyright_ok),
-            "detail": result.stdout.strip()[:60] if pyright_ok else result.stderr.strip()[:80],
-            "fix": "" if pyright_ok else "Add pyright to [dependency-groups] dev in pyproject.toml",
-        }
-    )
-
-    return checks
+    return [
+        _check_tool_version("ruff"),
+        _check_tool_version("pytest"),
+        _check_tool_version("pyright"),
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_ci_fix.py
+++ b/tests/unit/test_ci_fix.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from bernstein.core.ci_fix import (
@@ -14,6 +14,7 @@ from bernstein.core.ci_fix import (
     CIFixPipeline,
     CIFixResult,
     build_task_payload,
+    check_test_dependencies,
     install_pre_push_hook,
     parse_failures,
     write_ci_fix_task,
@@ -175,6 +176,32 @@ class TestInstallPrePushHook:
         git_hooks = tmp_path / ".git" / "hooks"
         git_hooks.mkdir(parents=True)
         install_pre_push_hook(tmp_path)
+
+
+class TestCheckTestDependencies:
+    def test_no_uv_returns_result_instead_of_raising(self) -> None:
+        """A missing ``uv`` on PATH must be reported, not raised.
+
+        Regression test: ``check_test_dependencies`` previously let
+        ``FileNotFoundError`` (WinError 2 on Windows) from ``subprocess.run``
+        propagate, crashing ``bernstein doctor`` for anyone who installed
+        Bernstein with pipx/pip instead of uv.
+        """
+        with patch("bernstein.core.quality.ci_fix.subprocess.run", side_effect=FileNotFoundError):
+            checks = check_test_dependencies()
+
+        assert len(checks) == 3
+        for check in checks:
+            assert check["ok"] == "False"
+            assert check["fix"]
+
+    def test_uv_present_reports_ok(self) -> None:
+        mock_result = Mock(returncode=0, stdout="ruff 0.1.0\n", stderr="")
+        with patch("bernstein.core.quality.ci_fix.subprocess.run", return_value=mock_result):
+            checks = check_test_dependencies()
+
+        assert all(check["ok"] == "True" for check in checks)
+        assert all(check["fix"] == "" for check in checks)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #3257

`check_test_dependencies()` shelled out to `uv run <tool> --version`
without handling `FileNotFoundError`, so `bernstein doctor` crashed
with a raw traceback (WinError 2 on Windows) for anyone who installed
Bernstein via pipx/pip instead of uv — defeating the purpose of a
command whose job is to report missing tools.

Factored the three near-identical checks (ruff, pytest, pyright) into
a single `_check_tool_version()` helper that catches `FileNotFoundError`
and returns a normal failed-check result with an install hint, so every
subprocess.run call in the function is covered, not just the first.

## Testing
- Added `TestCheckTestDependencies` with two cases: `uv` missing
  (monkeypatched `subprocess.run` to raise `FileNotFoundError`) and
  `uv` present, asserting a result is returned instead of raising.
- `uv run pytest tests/unit -k ci_fix -q` → 48 passed
- `uv run ruff check` / `uv run ruff format --check` → clean

## Summary by Sourcery

Handle missing uv when checking CI test dependencies so bernstein doctor reports failures instead of crashing.

Bug Fixes:
- Treat a missing uv executable during test dependency checks as a failed check rather than propagating FileNotFoundError.

Enhancements:
- Introduce a shared helper to run uv tool version checks and standardize their success/failure reporting.

Tests:
- Add unit tests verifying that missing uv yields failed checks and that present uv reports all tools as OK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test dependency checks to handle missing tooling gracefully without interrupting validation.
  * Standardized version-check results and diagnostic messages across supported tools.
  * Ensured failures provide actionable remediation details while successful checks remain concise.

* **Tests**
  * Added coverage for missing tool executables and successful dependency validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->