### PR TITLE
fix(doctor): report missing uv as a failed check instead of crashing

### DIFF
--- a/src/bernstein/core/quality/ci_fix.py
+++ b/src/bernstein/core/quality/ci_fix.py
@@ -357,62 +357,51 @@ def check_test_dependencies() -> list[dict[str, str]]:
     """
     checks: list[dict[str, str]] = []
 
-    # ruff
-    result = subprocess.run(
+    def _check(cmd: list[str], name: str, missing_fix: str, failed_fix: str) -> dict[str, str]:
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=10,
+            )
+        except FileNotFoundError:
+            return {
+                "name": name,
+                "ok": "False",
+                "detail": f"'{cmd[0]}' not found on PATH",
+                "fix": missing_fix,
+            }
+        ok = result.returncode == 0
+        return {
+            "name": name,
+            "ok": str(ok),
+            "detail": result.stdout.strip() if ok else result.stderr.strip()[:80],
+            "fix": "" if ok else failed_fix,
+        }
+
+    _UV_FIX = "Install uv: https://docs.astral.sh/uv/getting-started/installation/"
+
+    checks.append(_check(
         ["uv", "run", "ruff", "--version"],
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        timeout=10,
-    )
-    ruff_ok = result.returncode == 0
-    checks.append(
-        {
-            "name": "ruff",
-            "ok": str(ruff_ok),
-            "detail": result.stdout.strip() if ruff_ok else result.stderr.strip()[:80],
-            "fix": "" if ruff_ok else "Add ruff to [dependency-groups] dev in pyproject.toml",
-        }
-    )
-
-    # pytest
-    result = subprocess.run(
+        "ruff",
+        _UV_FIX,
+        "Add ruff to [dependency-groups] dev in pyproject.toml",
+    ))
+    checks.append(_check(
         ["uv", "run", "pytest", "--version"],
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        timeout=10,
-    )
-    pytest_ok = result.returncode == 0
-    checks.append(
-        {
-            "name": "pytest",
-            "ok": str(pytest_ok),
-            "detail": result.stdout.strip()[:60] if pytest_ok else result.stderr.strip()[:80],
-            "fix": "" if pytest_ok else "Add pytest to [dependency-groups] dev in pyproject.toml",
-        }
-    )
-
-    # pyright
-    result = subprocess.run(
+        "pytest",
+        _UV_FIX,
+        "Add pytest to [dependency-groups] dev in pyproject.toml",
+    ))
+    checks.append(_check(
         ["uv", "run", "pyright", "--version"],
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        timeout=10,
-    )
-    pyright_ok = result.returncode == 0
-    checks.append(
-        {
-            "name": "pyright",
-            "ok": str(pyright_ok),
-            "detail": result.stdout.strip()[:60] if pyright_ok else result.stderr.strip()[:80],
-            "fix": "" if pyright_ok else "Add pyright to [dependency-groups] dev in pyproject.toml",
-        }
-    )
+        "pyright",
+        _UV_FIX,
+        "Add pyright to [dependency-groups] dev in pyproject.toml",
+    ))
 
     return checks
 

--- a/tests/unit/test_ci_fix.py
+++ b/tests/unit/test_ci_fix.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from bernstein.core.ci_fix import (
@@ -453,3 +453,55 @@ class TestGHADownload:
         # Has a run ID but not a github.com URL, so owner/repo extraction fails.
         with pytest.raises(ValueError, match="Cannot parse owner/repo"):
             download_github_actions_log_api("https://not-github.com/foo/actions/runs/123")
+
+
+# ---------------------------------------------------------------------------
+# Doctor / check_test_dependencies tests
+# ---------------------------------------------------------------------------
+
+
+class TestCheckTestDependencies:
+    def test_returns_results_not_raises_when_uv_missing(self) -> None:
+        from bernstein.core.quality.ci_fix import check_test_dependencies
+
+        with patch(
+            "bernstein.core.quality.ci_fix.subprocess.run",
+            side_effect=FileNotFoundError("uv: No such file or directory"),
+        ):
+            results = check_test_dependencies()
+
+        assert isinstance(results, list)
+        assert len(results) == 3
+        names = {r["name"] for r in results}
+        assert names == {"ruff", "pytest", "pyright"}
+
+    def test_missing_uv_produces_failed_checks_with_fix(self) -> None:
+        from bernstein.core.quality.ci_fix import check_test_dependencies
+
+        with patch(
+            "bernstein.core.quality.ci_fix.subprocess.run",
+            side_effect=FileNotFoundError("uv: No such file or directory"),
+        ):
+            results = check_test_dependencies()
+
+        for r in results:
+            assert r["ok"] == "False"
+            assert "uv" in r["fix"].lower()
+            assert r["detail"]  # non-empty, human-readable reason
+
+    def test_all_tools_ok_when_uv_present(self) -> None:
+        from bernstein.core.quality.ci_fix import check_test_dependencies
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "ruff 0.4.0"
+        mock_result.stderr = ""
+
+        with patch(
+            "bernstein.core.quality.ci_fix.subprocess.run",
+            return_value=mock_result,
+        ):
+            results = check_test_dependencies()
+
+        assert all(r["ok"] == "True" for r in results)
+        assert all(r["fix"] == "" for r in results)


### PR DESCRIPTION
## Summary

- `bernstein doctor` crashed with a raw traceback on machines that installed bernstein via `pipx` or `pip` without `uv` on PATH
- Root cause: all three `subprocess.run(["uv", ...])` calls in `check_test_dependencies()` were unguarded against `FileNotFoundError`
- Introduced a private `_check()` helper that catches the OS error and converts it into an `ok=False` check dict with an install-uv hint for all three tools (ruff, pytest, pyright)

Fixes #3257

## Test plan

- [ ] `uv run pytest tests/unit -k ci_fix -q` passes
- [ ] New `TestCheckTestDependencies` class covers: uv-missing → no raise, `ok=False` for all tools with non-empty fix hint, and uv-present → all `ok=True`
- [ ] `uv run ruff check src/ tests/` clean
- [ ] `uv run ruff format --check src/ tests/` clean

## Summary by Sourcery

Handle missing uv in test dependency checks without crashing and add coverage for this behavior.

Bug Fixes:
- Prevent bernstein doctor from crashing when uv is not installed by treating missing uv as failed checks with guidance.

Enhancements:
- Refactor test dependency checks to share a common helper for running uv-based commands.

Tests:
- Add unit tests verifying behavior when uv is missing and when all tools are available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI dependency checks to handle missing tooling without raising errors.
  * Standardized check results and failure details across supported tools.
  * Added clearer guidance when the required package manager is unavailable.

* **Tests**
  * Added coverage for missing-tool scenarios, suggested fixes, and successful dependency checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->