### PR TITLE
chore(typing): annotate the core/observability package (mypy: 50 -> 3 errors)

### DIFF
--- a/src/bernstein/core/observability/custom_metrics.py
+++ b/src/bernstein/core/observability/custom_metrics.py
@@ -91,11 +91,11 @@ def _eval_node(node: ast.AST, variables: dict[str, float]) -> float:
         return float(_BINOP_MAP[op_type](left, right))
 
     if isinstance(node, ast.UnaryOp):
-        op_type = type(node.op)
-        if op_type not in _UNARYOP_MAP:
-            raise FormulaError(f"Unsupported unary operator {op_type.__name__}")
+        unary_op_type = type(node.op)
+        if unary_op_type not in _UNARYOP_MAP:
+            raise FormulaError(f"Unsupported unary operator {unary_op_type.__name__}")
         operand = _eval_node(node.operand, variables)
-        return float(_UNARYOP_MAP[op_type](operand))
+        return float(_UNARYOP_MAP[unary_op_type](operand))
 
     raise FormulaError(
         f"Unsupported AST node type {type(node).__name__}. "

--- a/src/bernstein/core/observability/incident_timeline.py
+++ b/src/bernstein/core/observability/incident_timeline.py
@@ -21,24 +21,27 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+type EventKind = Literal[
+    "error",
+    "task_completed",
+    "task_failed",
+    "agent_spawned",
+    "agent_crashed",
+    "slo_breach",
+    "incident_created",
+    "incident_mitigated",
+    "incident_resolved",
+    "trace_step",
+    "metric_anomaly",
+]
+
+
 @dataclass
 class TimelineEvent:
     """A single event on an incident timeline."""
 
     timestamp: float
-    kind: Literal[
-        "error",
-        "task_completed",
-        "task_failed",
-        "agent_spawned",
-        "agent_crashed",
-        "slo_breach",
-        "incident_created",
-        "incident_mitigated",
-        "incident_resolved",
-        "trace_step",
-        "metric_anomaly",
-    ]
+    kind: EventKind
     source: str  # e.g. "metrics", "traces", "incident", "slo"
     summary: str
     details: dict[str, Any] = field(default_factory=dict)
@@ -129,7 +132,7 @@ def _collect_task_completion_events(metrics_dir: Path, start_ts: float, end_ts: 
                 role = labels.get("role", "?")
                 success = labels.get("success", True)
                 duration = rec.get("value", 0)
-                kind = "task_completed" if success else "task_failed"
+                kind: Literal["task_completed", "task_failed"] = "task_completed" if success else "task_failed"
                 summary = f"Task {task_id} ({role}) {'completed' if success else 'failed'} in {duration:.1f}s"
                 events.append(
                     TimelineEvent(
@@ -143,9 +146,13 @@ def _collect_task_completion_events(metrics_dir: Path, start_ts: float, end_ts: 
     return events
 
 
-def _classify_trace_step(step_type: str) -> str:
+def _classify_trace_step(step_type: str) -> Literal["agent_spawned", "agent_crashed", "trace_step"]:
     """Map a trace step type to a timeline event kind."""
-    return {"spawn": "agent_spawned", "fail": "agent_crashed"}.get(step_type, "trace_step")
+    if step_type == "spawn":
+        return "agent_spawned"
+    if step_type == "fail":
+        return "agent_crashed"
+    return "trace_step"
 
 
 def _trace_step_to_event(

--- a/src/bernstein/core/observability/llm_watcher.py
+++ b/src/bernstein/core/observability/llm_watcher.py
@@ -42,7 +42,7 @@ import logging
 import os
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import Final, Literal
+from typing import Final, Literal, cast
 
 logger = logging.getLogger(__name__)
 
@@ -555,9 +555,9 @@ def cost_runaway_detector(event: WatcherEvent) -> list[Suggestion]:
         present or no threshold is breached.
     """
     payload = event.payload
-    task_cost = float(payload.get("task_cost_usd") or 0.0)
-    run_cost = float(payload.get("run_cost_usd") or 0.0)
-    run_budget = float(payload.get("run_budget_usd") or _DEFAULT_RUN_BUDGET_USD)
+    task_cost = float(cast(float, payload.get("task_cost_usd") or 0.0))
+    run_cost = float(cast(float, payload.get("run_cost_usd") or 0.0))
+    run_budget = float(cast(float, payload.get("run_budget_usd") or _DEFAULT_RUN_BUDGET_USD))
     task_id = str(payload.get("task_id") or "?")
 
     breached_task = task_cost > _TASK_HARD_CEILING_USD
@@ -606,8 +606,8 @@ def stuck_spawn_detector(event: WatcherEvent) -> list[Suggestion]:
     payload = event.payload
     claim_confirmed = bool(payload.get("claim_confirmed"))
     task_completed = bool(payload.get("task_completed"))
-    audit_emissions = int(payload.get("audit_emissions") or 0)
-    time_in_state = float(payload.get("time_in_state_s") or 0.0)
+    audit_emissions = int(cast(int, payload.get("audit_emissions") or 0))
+    time_in_state = float(cast(float, payload.get("time_in_state_s") or 0.0))
     task_id = str(payload.get("task_id") or "?")
 
     if not claim_confirmed or task_completed:
@@ -649,7 +649,7 @@ def repeated_failure_detector(event: WatcherEvent) -> list[Suggestion]:
         Zero or one :class:`Suggestion`.
     """
     payload = event.payload
-    failure_count = int(payload.get("failure_count") or 0)
+    failure_count = int(cast(int, payload.get("failure_count") or 0))
     exit_signature = str(payload.get("exit_signature") or "").strip()
     task_id = str(payload.get("task_id") or "?")
     if not exit_signature:
@@ -689,8 +689,8 @@ def suspicious_tool_mask_detector(event: WatcherEvent) -> list[Suggestion]:
         Zero or one :class:`Suggestion`.
     """
     payload = event.payload
-    available = int(payload.get("available_tools") or 0)
-    masked = int(payload.get("masked_tools") or 0)
+    available = int(cast(int, payload.get("available_tools") or 0))
+    masked = int(cast(int, payload.get("masked_tools") or 0))
     if available <= 0:
         return []
     fraction = masked / available

--- a/src/bernstein/core/observability/metric_collector.py
+++ b/src/bernstein/core/observability/metric_collector.py
@@ -15,7 +15,10 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 from bernstein.core.persistence.runtime_state import rotate_log_file
 from bernstein.core.tenanting import normalize_tenant_id, tenant_metrics_dir
@@ -1114,7 +1117,7 @@ class MetricsCollector:
         Returns:
             Success rate as a float 0-1.
         """
-        agents = self._agent_metrics.values()
+        agents: Iterable[AgentMetrics] = self._agent_metrics.values()
         if agent_id:
             agents = [a for a in agents if a.agent_id == agent_id]
         if role:
@@ -1154,7 +1157,7 @@ class MetricsCollector:
         Returns:
             Total cost in USD.
         """
-        agents = self._agent_metrics.values()
+        agents: Iterable[AgentMetrics] = self._agent_metrics.values()
         if agent_id:
             agents = [a for a in agents if a.agent_id == agent_id]
         return sum(a.total_cost_usd for a in agents)

--- a/src/bernstein/core/observability/postmortem.py
+++ b/src/bernstein/core/observability/postmortem.py
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 
 
 # Shared cast-type constants to avoid string duplication (Sonar S1192).
-_CAST_DICT_STR_ANY = "dict[str, Any]"
+type _CAST_DICT_STR_ANY = dict[str, Any]
 
 
 @dataclass

--- a/src/bernstein/core/observability/provider_latency.py
+++ b/src/bernstein/core/observability/provider_latency.py
@@ -15,6 +15,7 @@ from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import cast
 
 from bernstein.core.observability.metric_collector import PercentileTracker
 
@@ -120,7 +121,8 @@ def _read_latency_samples(
                 record: dict[str, object] = json.loads(line)
             except json.JSONDecodeError:
                 continue
-            ts = float(record.get("timestamp", 0))
+            # _persist_sample writes timestamps as JSON numbers.
+            ts = float(cast(float, record.get("timestamp", 0)))
             if ts < cutoff:
                 continue
             if provider and record.get("provider") != provider:
@@ -327,7 +329,8 @@ class ProviderLatencyTracker:
         for jsonl_file in sorted(self._metrics_dir.glob("provider_latency_*.jsonl")):
             _read_latency_samples(jsonl_file, cutoff, provider, model, samples)
 
-        samples.sort(key=lambda r: float(r.get("timestamp", 0)))
+        # The history records come from _persist_sample, which emits numeric timestamps.
+        samples.sort(key=lambda r: float(cast(float, r.get("timestamp", 0))))
         return samples
 
     # ------------------------------------------------------------------
@@ -366,12 +369,13 @@ class ProviderLatencyTracker:
             record: dict[str, object] = json.loads(line)
         except json.JSONDecodeError:
             return None
-        ts = float(record.get("timestamp", 0))
+        # _persist_sample serialises both fields below as JSON numbers.
+        ts = float(cast(float, record.get("timestamp", 0)))
         if ts < cutoff:
             return None
         provider = str(record.get("provider", ""))
         model = str(record.get("model", ""))
-        latency_ms = float(record.get("latency_ms", 0))
+        latency_ms = float(cast(float, record.get("latency_ms", 0)))
         if not provider or not model or latency_ms <= 0:
             return None
         return _make_key(provider, model), latency_ms

--- a/src/bernstein/core/observability/run_export.py
+++ b/src/bernstein/core/observability/run_export.py
@@ -167,8 +167,9 @@ def _load_report_data(workdir: Path, run_id: str | None) -> _ExportReport:
 
     # Load cost data
     model_costs: list[_ModelCost] = []
-    cost_path = metrics_dir / f"costs_{run_id}.json"
-    if not cost_path.exists():
+    default_cost_path = metrics_dir / f"costs_{run_id}.json"
+    cost_path: Path | None = default_cost_path
+    if not default_cost_path.exists():
         fallback = workdir / ".sdd" / "runtime" / "costs" / f"{run_id}.json"
         cost_path = fallback if fallback.exists() else None
 

--- a/src/bernstein/core/observability/watchdog.py
+++ b/src/bernstein/core/observability/watchdog.py
@@ -34,7 +34,7 @@ WatchdogSource = Literal["heartbeat", "log_growth", "progress_stall"]
 
 
 # Shared cast-type constants to avoid string duplication (Sonar S1192).
-_CAST_DICT_STR_OBJ = "dict[str, object]"
+type _CAST_DICT_STR_OBJ = dict[str, object]
 
 # Heartbeat phases that mean the agent is still producing its FIRST turn. A
 # non-heartbeat adapter (consumes_heartbeat_dir=False) has only its spawn-time
@@ -47,7 +47,7 @@ _STARTING_PHASES: frozenset[str] = frozenset(
 
 
 def _is_starting_phase(phase: str | None) -> bool:
-    return bool(phase) and phase.strip().lower() in _STARTING_PHASES
+    return phase is not None and phase.strip().lower() in _STARTING_PHASES
 
 
 def _log_signal_is_fresh(log_age_s: float | None) -> bool:
@@ -549,17 +549,17 @@ class WatchdogManager:
 
 def _coerce_log_state(raw: object) -> tuple[int, int]:
     if isinstance(raw, tuple):
-        values = cast("tuple[object, ...]", raw)
-        if len(values) == 2:
-            first = _safe_int(values[0])
-            second = _safe_int(values[1])
+        tuple_values = cast("tuple[object, ...]", raw)
+        if len(tuple_values) == 2:
+            first = _safe_int(tuple_values[0])
+            second = _safe_int(tuple_values[1])
             if first is not None and second is not None:
                 return first, second
     if isinstance(raw, list):
-        values = cast("list[object]", raw)
-        if len(values) == 2:
-            first = _safe_int(values[0])
-            second = _safe_int(values[1])
+        list_values = cast("list[object]", raw)
+        if len(list_values) == 2:
+            first = _safe_int(list_values[0])
+            second = _safe_int(list_values[1])
             if first is not None and second is not None:
                 return first, second
     return 0, 0

--- a/tests/unit/test_incident_timeline.py
+++ b/tests/unit/test_incident_timeline.py
@@ -8,6 +8,7 @@ import time
 import pytest
 from bernstein.core.incident_timeline import (
     TimelineEvent,
+    _classify_trace_step,
     build_incident_timeline,
     list_incidents,
 )
@@ -203,6 +204,18 @@ class TestTimelineEvent:
         assert d["summary"] == "Test error"
         assert d["details"] == {"key": "value"}
         assert "time" in d
+
+
+@pytest.mark.parametrize(
+    ("step_type", "expected"),
+    [
+        ("spawn", "agent_spawned"),
+        ("fail", "agent_crashed"),
+        ("edit", "trace_step"),
+    ],
+)
+def test_classify_trace_step(step_type: str, expected: str) -> None:
+    assert _classify_trace_step(step_type) == expected
 
 
 class TestBuildIncidentTimeline:

--- a/tests/unit/test_provider_latency.py
+++ b/tests/unit/test_provider_latency.py
@@ -198,3 +198,16 @@ class TestProviderLatencyTracker:
         key = _make_key("openai", "gpt-4")
         assert key in tracker._baseline_p99
         assert tracker._baseline_p99[key] == pytest.approx(200.0, abs=1.0)
+
+    @pytest.mark.parametrize("field", ["timestamp", "latency_ms"])
+    def test_parse_latency_record_rejects_malformed_numeric_schema(self, field: str) -> None:
+        record: dict[str, object] = {
+            "timestamp": time.time(),
+            "provider": "openai",
+            "model": "gpt-4",
+            "latency_ms": 200.0,
+        }
+        record[field] = {"not": "numeric"}
+
+        with pytest.raises(TypeError):
+            ProviderLatencyTracker._parse_latency_record(json.dumps(record), cutoff=0.0)

--- a/tests/unit/test_run_export.py
+++ b/tests/unit/test_run_export.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import TypedDict
 
 import pytest
 from click.testing import CliRunner
@@ -20,6 +21,20 @@ from bernstein.core.observability.run_export import (
     _TaskRow,
     export_run_report,
 )
+
+
+class CostModelPayload(TypedDict):
+    model: str
+    total_cost_usd: float
+    invocation_count: int
+    total_tokens: int
+
+
+class CostReportPayload(TypedDict, total=False):
+    run_id: str
+    total_spent_usd: float
+    per_model: list[CostModelPayload]
+
 
 # ---------------------------------------------------------------------------
 # Helper: set up a minimal .sdd directory with test data
@@ -78,7 +93,7 @@ def _setup_sdd(tmp_path: Path, run_id: str = "run-001") -> Path:
         (metrics_dir / f"agent_{i}.json").write_text(json.dumps(agent_data))
 
     # Cost data
-    cost_report = {
+    cost_report: CostReportPayload = {
         "run_id": run_id,
         "total_spent_usd": 4.82,
         "per_model": [
@@ -283,21 +298,18 @@ def test_load_report_data_uses_runtime_cost_fallback(tmp_path: Path) -> None:
 
     fallback_dir = workdir / ".sdd" / "runtime" / "costs"
     fallback_dir.mkdir(parents=True)
-    (fallback_dir / f"{run_id}.json").write_text(
-        json.dumps(
+    fallback_cost_report: CostReportPayload = {
+        "total_spent_usd": 7.25,
+        "per_model": [
             {
-                "total_spent_usd": 7.25,
-                "per_model": [
-                    {
-                        "model": "fallback-model",
-                        "total_cost_usd": 7.25,
-                        "invocation_count": 2,
-                        "total_tokens": 1234,
-                    }
-                ],
+                "model": "fallback-model",
+                "total_cost_usd": 7.25,
+                "invocation_count": 2,
+                "total_tokens": 1234,
             }
-        )
-    )
+        ],
+    }
+    (fallback_dir / f"{run_id}.json").write_text(json.dumps(fallback_cost_report))
 
     report = _load_report_data(workdir, run_id)
 

--- a/tests/unit/test_run_export.py
+++ b/tests/unit/test_run_export.py
@@ -15,6 +15,7 @@ from bernstein.core.observability.run_export import (
     _ExportReport,
     _fmt_duration,
     _fmt_duration_short,
+    _load_report_data,
     _sequential_estimate,
     _TaskRow,
     export_run_report,
@@ -273,6 +274,36 @@ def test_export_html_contains_cost_table(tmp_path: Path) -> None:
     assert "claude-opus" in content
     assert "claude-sonnet" in content
     assert "codex" in content
+
+
+def test_load_report_data_uses_runtime_cost_fallback(tmp_path: Path) -> None:
+    workdir = _setup_sdd(tmp_path)
+    run_id = "run-001"
+    (workdir / ".sdd" / "metrics" / f"costs_{run_id}.json").unlink()
+
+    fallback_dir = workdir / ".sdd" / "runtime" / "costs"
+    fallback_dir.mkdir(parents=True)
+    (fallback_dir / f"{run_id}.json").write_text(
+        json.dumps(
+            {
+                "total_spent_usd": 7.25,
+                "per_model": [
+                    {
+                        "model": "fallback-model",
+                        "total_cost_usd": 7.25,
+                        "invocation_count": 2,
+                        "total_tokens": 1234,
+                    }
+                ],
+            }
+        )
+    )
+
+    report = _load_report_data(workdir, run_id)
+
+    assert report.total_cost_usd == pytest.approx(7.25)
+    assert len(report.model_costs) == 1
+    assert report.model_costs[0].model == "fallback-model"
 
 
 def test_export_html_contains_agent_stats(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

Typing slice from #2980 / #3231: annotate `src/bernstein/core/observability/` to reduce the mypy backlog. Annotation-only fixes — no intentional runtime behaviour changes.

## Why

Part of the typing cleanup in #2980 (split into per-package slices). This closes the observability slice: mypy **50 → 3**.

Fixes follow the patterns in #3231 (PEP 695 `type` aliases for cast targets; `cast` around `float`/`int` on loosely-typed dict values; explicit `Path | None` for the cost-file fallback), plus local narrowing / `Iterable` / `EventKind` Literal aliases.

Remaining 3 errors left on purpose:

- `circuit_breaker.py:28` — meta-path redirect for `bernstein.core.lifecycle` (out of scope per #3231)
- `metric_collector.py:988` — Bernstein `PluginManager` has no `.hook`; the error is swallowed, so `on_metric_record` never fires (latent bug, not a missing annotation)
- `prometheus.py:104` — stub `generate_latest` signature vs the real optional import

## How

Annotation-only changes in the observability package, plus a few focused unit tests for the touched helpers. Did not run the full test suite (memory warning in #3231).

## Validation

- `uv run mypy src/bernstein/core/observability/` — 50 → 3
- `uv run ruff check` / `ruff format --check` on that package — passed
- `uv run pytest` on the issue-named files plus the touched-module unit tests — passed

## Checklist

- [x] mypy error count is lower (50 → 3)
- [x] No new `# type: ignore` added
- [x] No runtime behaviour changed; annotations only
- [x] Ruff lint and format checks pass
- [x] Scoped unit tests pass
- [x] Documentation N/A — internal typing cleanup

Fixes #3231

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and parsing of numeric observability fields (e.g., timestamps, latency, costs, budgets, and detector metrics).
  * Ensured correct incident timeline step classification and more precise watchdog phase handling.
  * Added/strengthened fallback loading for runtime cost data when the standard cost file is missing.
* **Tests**
  * Added coverage for malformed numeric latency inputs, timeline trace-step classification, and runtime cost-file fallback.
* **Refactor**
  * Improved internal typing and casting for safer, clearer processing without changing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->