### PR TITLE
fix(tasks): a failed required quality gate must skip merge

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -39,6 +39,10 @@ All notable project changes are tracked here (code + docs).
   default behind `BERNSTEIN_A2A_SERVER_ENABLED`. See
   [`docs/operations/a2a-server.md`](operations/a2a-server.md). Refs #2609.
 
+### Fixed
+
+- `_evaluate_approval_gate` returned `skip_merge=False` whenever a required quality gate failed, so a failed gate was logged and recorded as `blocked` in `quality_gates.jsonl` but the branch merged anyway. The failed-gate check is now split from the no-approval-gate-configured check, so a failed required gate always returns `skip_merge=True` (#3254).
+
 ## [3.5.0] - 2026-07-16
 
 Hardens audit identity across MCP protocol change and replay detection of provider-side context rewrites, plus a security dependency bump and CI reliability work. Full notes: [`docs/release-notes/v3.5.0.md`](release-notes/v3.5.0.md).

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -2924,7 +2924,14 @@ def _evaluate_approval_gate(
     janitor_passed: bool,
 ) -> bool:
     """Evaluate the approval gate and return whether to skip merge."""
-    if not janitor_passed or orch._approval_gate is None:
+    if not janitor_passed:
+        logger.warning(
+            "approval_decision: task=%s session=%s decision=held -- required quality gate failed, skipping merge",
+            task.id,
+            session.id,
+        )
+        return True
+    if orch._approval_gate is None:
         return False
 
     try:

--- a/tests/unit/test_approval_gate_janitor_polarity.py
+++ b/tests/unit/test_approval_gate_janitor_polarity.py
@@ -1,0 +1,79 @@
+"""Regression tests for issue #3254.
+
+Defect: ``task_lifecycle._evaluate_approval_gate`` returned ``False``
+(skip_merge=False, i.e. proceed to merge) whenever ``janitor_passed`` was
+``False``. The function's contract is "return whether to skip merge", so a
+failed required quality gate must return ``True`` and hold the merge instead.
+The prior code only distinguished "no approval gate configured" (correctly
+``False``) from "janitor failed" (incorrectly also ``False``) with a single
+``or`` condition.
+"""
+
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+from bernstein.core.models import AgentSession, ModelConfig, Task
+
+from bernstein.core.tasks.task_lifecycle import _evaluate_approval_gate
+
+
+def _task(task_id: str = "t-1") -> Task:
+    return Task(id=task_id, title="do the thing", description="desc", role="engineer")
+
+
+def _session(task_id: str = "t-1") -> AgentSession:
+    return AgentSession(
+        id="sess-1",
+        role="engineer",
+        task_ids=[task_id],
+        model_config=ModelConfig(model="test-model", effort="medium"),
+    )
+
+
+def _orch_with_gate(gate: Any) -> Any:
+    return SimpleNamespace(_approval_gate=gate, _config=SimpleNamespace(approval_workflow=None))
+
+
+def test_failed_janitor_skips_merge_with_no_approval_gate_configured() -> None:
+    """A failed required gate must hold the merge even with no approval gate wired up."""
+    orch = _orch_with_gate(None)
+
+    result = _evaluate_approval_gate(orch, _task(), _session(), None, janitor_passed=False)
+
+    assert result is True, "failed quality gate must skip_merge=True regardless of approval gate config"
+
+
+def test_failed_janitor_skips_merge_with_approval_gate_configured() -> None:
+    """A failed required gate must hold the merge, and must not even reach gate.evaluate()."""
+    gate = MagicMock()
+    orch = _orch_with_gate(gate)
+
+    result = _evaluate_approval_gate(orch, _task(), _session(), None, janitor_passed=False)
+
+    assert result is True
+    gate.evaluate.assert_not_called()
+
+
+def test_passed_janitor_with_no_approval_gate_does_not_skip_merge() -> None:
+    """No quality-gate failure and no approval gate configured -- merge proceeds as before."""
+    orch = _orch_with_gate(None)
+
+    result = _evaluate_approval_gate(orch, _task(), _session(), None, janitor_passed=True)
+
+    assert result is False
+
+
+def test_passed_janitor_with_approval_gate_approved_does_not_skip_merge() -> None:
+    """Quality gate passed and the approval gate approves -- merge proceeds (unchanged behavior)."""
+    gate = MagicMock()
+    gate.evaluate.return_value = SimpleNamespace(approved=True, rejected=False)
+    orch = _orch_with_gate(gate)
+
+    result = _evaluate_approval_gate(orch, _task(), _session(), None, janitor_passed=True)
+
+    assert result is False


### PR DESCRIPTION
Fixes #3254.

## Root cause

`_evaluate_approval_gate()` had one `or` covering two unrelated conditions:

```python
if not janitor_passed or orch._approval_gate is None:
    return False
```

`skip_merge=False` is correct when there's no approval gate configured, but not when the required quality gate failed. Both fell through the same line, so a failed gate was logged and recorded as `blocked` in `quality_gates.jsonl`, then the branch merged 301ms later anyway.

## Fix

Split the janitor-failed check onto its own line, returning `skip_merge=True` before the approval-gate branch is even reached. The no-approval-gate-configured path is untouched.

## Tests

`tests/unit/test_approval_gate_janitor_polarity.py`, four cases:
- failed gate + no approval gate configured -> skip_merge=True
- failed gate + approval gate configured -> skip_merge=True, gate.evaluate() never called
- passed gate + no approval gate configured -> skip_merge=False (unchanged)
- passed gate + approval gate approves -> skip_merge=False (unchanged)

Confirmed the first two fail against the pre-fix code (`assert False is True`) and pass after the fix, so they exercise the actual bug rather than the outer-exception fail-closed path already covered by `test_approval_gate_outer_fail_closed.py` (that one's unaffected, still green).

Also ran the full approval-gate test group via `scripts/run_tests.py -k approval_gate`: 7 files, 110 tests, all pass. `ruff check`, `lint-imports` clean; `pyright` shows the same 309 pre-existing baseline errors on this file with or without the change (0 new).

## Docs

No behavior-doc change needed — `docs/architecture/quality-pipeline.md:119` already states "A failing required gate hard-blocks merge"; this fix makes the code match what was already documented. Added a `docs/CHANGELOG.md` entry under Unreleased / Fixed.

## Summary by Sourcery

Fix approval gate evaluation so that a failed required quality gate consistently blocks merges, and add regression coverage and changelog entry for the corrected behavior.

Bug Fixes:
- Ensure failed required quality gates always hold merges by returning skip_merge=True from approval evaluation.

Enhancements:
- Add warning logging when merges are skipped due to failed required quality gates.

Documentation:
- Document the approval gate bug and its fix in the Unreleased section of the changelog.

Tests:
- Add regression tests for approval gate behavior covering janitor failure and approval gate configuration combinations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented merges when a required quality gate fails.
  * Correctly distinguishes failed quality checks from workflows without an approval gate.
  * Added clear “held” approval decisions for blocked merges.

* **Tests**
  * Added regression coverage for failed and passed quality-gate scenarios, with and without approval gates.

* **Documentation**
  * Updated the changelog with details of the merge-blocking fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->