### PR TITLE
chore(typing): annotate the core/routes package

### DIFF
--- a/src/bernstein/core/routes/observability.py
+++ b/src/bernstein/core/routes/observability.py
@@ -27,9 +27,9 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
-# Shared cast-type constants to avoid string duplication (Sonar S1192).
-_CAST_DICT_STR_ANY = "dict[str, Any]"
-_CAST_LIST_DICT_STR_ANY = "list[dict[str, Any]]"
+# Shared cast-type aliases to avoid duplication at cast() call sites (Sonar S1192).
+type _CAST_DICT_STR_ANY = dict[str, Any]
+type _CAST_LIST_DICT_STR_ANY = list[dict[str, Any]]
 
 
 def _get_store(request: Request) -> TaskStore:

--- a/src/bernstein/core/routes/status_dashboard.py
+++ b/src/bernstein/core/routes/status_dashboard.py
@@ -51,8 +51,8 @@ __all__ = [
 ]
 
 
-# Shared cast-type constants to avoid string duplication (Sonar S1192).
-_CAST_DICT_STR_ANY = "dict[str, Any]"
+# Shared cast-type alias to avoid duplication at cast() call sites (Sonar S1192).
+type _CAST_DICT_STR_ANY = dict[str, Any]
 
 
 def _get_store(request: Request) -> TaskStore:
@@ -1106,6 +1106,8 @@ def _build_single_agent_detail(
     context_utilization_alert = bool(
         getattr(a, "context_utilization_alert", False) or snapshot.get("context_utilization_alert", False)
     )
+    transition_reason = getattr(a, "transition_reason", None)
+    abort_reason = getattr(a, "abort_reason", None)
     return {
         "id": a.id,
         "role": a.role,
@@ -1123,14 +1125,12 @@ def _build_single_agent_detail(
         "context_utilization_pct": context_utilization_pct,
         "context_utilization_alert": context_utilization_alert,
         "transition_reason": (
-            getattr(a, "transition_reason", None).value  # pyright: ignore[reportOptionalMemberAccess]
-            if getattr(a, "transition_reason", None) is not None
+            transition_reason.value
+            if transition_reason is not None
             else str(snapshot.get("transition_reason", "") or "")
         ),
         "abort_reason": (
-            getattr(a, "abort_reason", None).value  # pyright: ignore[reportOptionalMemberAccess]
-            if getattr(a, "abort_reason", None) is not None
-            else str(snapshot.get("abort_reason", "") or "")
+            abort_reason.value if abort_reason is not None else str(snapshot.get("abort_reason", "") or "")
         ),
         "abort_detail": str(getattr(a, "abort_detail", "") or snapshot.get("abort_detail", "") or ""),
         "finish_reason": str(getattr(a, "finish_reason", "") or snapshot.get("finish_reason", "") or ""),


### PR DESCRIPTION
# What

Annotate the `core/routes` package: convert cast-type string constants to proper `type` aliases and clean up duplicate `getattr` calls.

# Why

Part of the ongoing typing effort. The string constants (`_CAST_DICT_STR_ANY = "dict[str, Any]"`) are strings, not types — mypy can't use them for narrowing. Same pattern fixed in #3236 and #3246 for other packages.

# How

- Replaced string constants with PEP 695 `type` aliases in `observability.py` and `status_dashboard.py`.
- Beyond the type alias fixes, I also refactored the transition_reason and abort_reason lookups in status_dashboard.py. The original code called getattr() twice per field and required # pyright: ignore[reportOptionalMemberAccess] suppressions. I stored each in a local variable so the type narrowing works naturally, removing the need for the suppressions. No change in runtime behavior.

# Checklist

- [x] `uv run ruff check src/` passes
- [ ] `uv run pyright src/` passes
- [ ] `uv run python scripts/run_tests.py x` passes
- [x] New code has type hints

## Documentation duty (every PR that touches a feature)

- [x] User-visible README section updated (or N/A if internal-only) — N/A, internal typing cleanup
- [x] `docs/operations/<area>.md` updated (or N/A) — N/A
- [x] `docs/api/` schema regenerated if a public surface changed (or N/A) — N/A
- [x] `uv run bernstein agents-md sync` run so AGENTS.md, CLAUDE.md, `.goosehints`, `CONVENTIONS.md`, and `.cursor/rules/*.mdc` reflect any new module (or N/A) — N/A
- [x] Tests cover the documented behaviour — N/A, no new behaviour added

## Summary by Sourcery

Annotate core route handlers with proper type aliases and simplify optional attribute lookups without changing runtime behavior.

Enhancements:
- Replace string-based cast constants with PEP 695-style type aliases in observability and status dashboard routes.
- Refactor status dashboard agent detail construction to reuse transition and abort reason lookups and rely on natural type narrowing instead of repeated getattr calls and type-checker suppressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal type handling for observability and status dashboard data.
  * Preserved existing status and agent detail behavior, including transition and abort reason display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->