### PR TITLE
docs: README/docs accuracy pass - fix stale claims, close 1 defect

### DIFF
--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -281,7 +281,6 @@ Bernstein can execute agents on Cloudflare's edge infrastructure in addition to 
 - **R2WorkspaceSync** (`bridges/r2_sync.py`) - content-addressed workspace file sync via R2
 - **WorkersAIProvider** (`core/routing/cloudflare_ai.py`) - free-tier LLM models for planning
 - **D1AnalyticsClient** (`core/cost/d1_analytics.py`) - usage metering and billing
-- **VectorizeSemanticCache** (`core/memory/vectorize_cache.py`) - semantic LLM response caching
 
 The cloud bridges implement the same `RuntimeBridge` interface as local execution, so the orchestrator remains agnostic to where agents run. See the [Cloudflare Overview](../cloudflare/cloudflare-overview.md) for architecture diagrams and setup instructions.
 

--- a/docs/cloudflare/cloudflare-overview.md
+++ b/docs/cloudflare/cloudflare-overview.md
@@ -12,7 +12,7 @@ Bernstein can run agents locally or in the cloud. The Cloudflare integration let
 | CI/CD pipeline | Local (Docker/K8s) | Full filesystem access, no network hops |
 | Team with shared orchestration | Cloudflare | Centralized billing, no shared server to maintain |
 | Global team, low-latency agent dispatch | Cloudflare Workers | Edge execution near developers |
-| SaaS / hosted Bernstein | Cloudflare (full stack) | D1 analytics, R2 storage, Vectorize caching |
+| SaaS / hosted Bernstein | Cloudflare (full stack) | D1 analytics, R2 storage |
 
 ---
 
@@ -30,7 +30,6 @@ graph TD
         Workflow["Workflows<br/>(durable multi-step execution)"]
         R2["R2 Object Storage<br/>(workspace sync)"]
         D1["D1 (SQLite)<br/>(analytics & billing)"]
-        Vec["Vectorize<br/>(semantic cache)"]
         AI["Workers AI<br/>(free LLM provider)"]
         Browser["Browser Rendering<br/>(web browsing)"]
     end
@@ -43,7 +42,6 @@ graph TD
     Worker --> R2
     Workflow --> Worker
     Orch --> AI
-    Orch --> Vec
     Orch --> D1
     Orch --> Browser
     MCP --> Orch
@@ -62,7 +60,6 @@ graph TD
 | Workers AI Provider | `bernstein.core.routing.cloudflare_ai` | Free-tier LLM completions for planning and decomposition |
 | Codex-on-Cloudflare Adapter | `bernstein.adapters.codex_cloudflare` | Runs Codex in a sandbox container via an operator-deployed `@cloudflare/sandbox` bridge Worker; needs a Workers Paid plan |
 | D1 Analytics | `bernstein.core.cost.d1_analytics` | Usage metering, billing tiers, quota enforcement |
-| Vectorize Cache | `bernstein.core.memory.vectorize_cache` | Semantic cache for LLM responses using vector similarity |
 | MCP Remote Transport | `bernstein.mcp.remote_transport` | Streamable HTTP transport for remote MCP server access |
 | Cloud CLI | `bernstein.cli.commands.cloud_cmd` | `bernstein cloud` subcommands (init, deploy are local; login/run/status/cost target the experimental, currently-unavailable `api.bernstein.run`) |
 
@@ -80,7 +77,6 @@ For the full stack, you also need:
 
 - An R2 bucket for workspace sync
 - A D1 database for analytics
-- A Vectorize index for semantic caching
 
 See [Setup](cloudflare-setup.md) for step-by-step provisioning instructions.
 
@@ -92,6 +88,6 @@ See [Setup](cloudflare-setup.md) for step-by-step provisioning instructions.
 - **[Bridges](cloudflare-bridges.md)** -- runtime and workflow bridges
 - **[Adapters](cloudflare-adapters.md)** -- Codex-on-Cloudflare
 - **[Workers AI](cloudflare-ai.md)** -- free LLM provider for planning
-- **[Analytics & Caching](cloudflare-analytics.md)** -- D1 billing and Vectorize cache
+- **[Analytics & Billing](cloudflare-analytics.md)** -- D1 usage metering and billing tiers
 - **[Cloud CLI](cloudflare-cli.md)** -- `bernstein cloud` commands
 - **[MCP Remote](cloudflare-mcp.md)** -- remote MCP transport

--- a/docs/gui/index.md
+++ b/docs/gui/index.md
@@ -13,7 +13,7 @@ Browser-based operator surface for live Bernstein runs. Mounted on the same Fast
 
 ## What it is
 
-- Vite + React 18 + Tailwind 3 + shadcn/ui SPA. Source in `web/`. Built bundle ships in the wheel under `src/bernstein/gui/static/`.
+- Vite + React 19 + Tailwind 3 + shadcn/ui SPA. Source in `web/`. Built bundle ships in the wheel under `src/bernstein/gui/static/`.
 - Seven routes: Tasks, Agents, Approvals, Audit, Costs, Fleet, Settings. One nav item each.
 - Reads from `GET /api/v1/*` and the central SSE stream `GET /api/v1/events`. Uses TanStack Query 5 for caching and `setQueryData` to hydrate from SSE.
 - Auth via `Authorization: Bearer ${localStorage.bernstein_token}`. Token comes from `BERNSTEIN_AUTH_TOKEN` (auto-generated on server launch if unset).

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -88,7 +88,7 @@ group below is a section in the left nav with its own set of pages.
 
     ---
 
-    Run agents on Cloudflare's edge - Workers, R2, D1, Vectorize.
+    Run agents on Cloudflare's edge - Workers, R2, D1.
 
     [:octicons-arrow-right-24: Cloudflare overview](../cloudflare/cloudflare-overview.md)
 

--- a/docs/operations/deployment-guide.md
+++ b/docs/operations/deployment-guide.md
@@ -868,6 +868,10 @@ bernstein cloud login
 bernstein cloud run "Add OAuth2 authentication" --max-agents 5 --budget 25.00
 ```
 
+`cloud login`, `cloud run`, `cloud status`, and `cloud cost` target the
+experimental, currently-unavailable `api.bernstein.run`; `cloud deploy` and
+`cloud init` run locally against your own Cloudflare account.
+
 ### What runs where
 
 | Component | Location | Purpose |
@@ -876,7 +880,6 @@ bernstein cloud run "Add OAuth2 authentication" --max-agents 5 --budget 25.00
 | Agent execution | Cloudflare Workers / Sandboxes | Code generation, testing |
 | Workspace files | Cloudflare R2 | File sync between local and cloud agents |
 | Analytics / billing | Cloudflare D1 | Usage metering, quota enforcement |
-| LLM response cache | Cloudflare Vectorize | Semantic prompt deduplication |
 | Internal LLM (planning) | Cloudflare Workers AI | Free-tier models for task decomposition |
 
 ### Environment variables for Cloudflare
@@ -884,10 +887,10 @@ bernstein cloud run "Add OAuth2 authentication" --max-agents 5 --budget 25.00
 | Variable | Description |
 |----------|-------------|
 | `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account identifier |
-| `CLOUDFLARE_API_TOKEN` | API token with Workers, R2, D1, Vectorize permissions |
+| `CLOUDFLARE_API_TOKEN` | API token with Workers, R2, D1 permissions |
 | `BERNSTEIN_CLOUD_API_KEY` | API key for bernstein.run hosted service |
 
-For the full Cloudflare setup guide including R2 buckets, D1 databases, and Vectorize indexes, see the [Cloudflare Setup](../cloudflare/cloudflare-setup.md) documentation.
+For the full Cloudflare setup guide including R2 buckets and D1 databases, see the [Cloudflare Setup](../cloudflare/cloudflare-setup.md) documentation.
 
 ---
 

--- a/src/bernstein/core/persistence/wal.py
+++ b/src/bernstein/core/persistence/wal.py
@@ -703,6 +703,8 @@ class WALRecovery:
 
         results: list[tuple[str, WALEntry]] = []
         for wal_file in sorted(wal_dir.glob("*.wal.jsonl")):
+            if wal_file.is_symlink():
+                continue
             run_id = wal_file.name.removesuffix(".wal.jsonl")
             if run_id == exclude_run_id:
                 continue
@@ -745,6 +747,8 @@ class WALRecovery:
 
         orphans: list[tuple[str, WALEntry]] = []
         for wal_file in sorted(wal_dir.glob("*.wal.jsonl")):
+            if wal_file.is_symlink():
+                continue
             run_id = wal_file.name.removesuffix(".wal.jsonl")
             if run_id == exclude_run_id:
                 continue

--- a/tests/property/test_wal_cas_bughunt.py
+++ b/tests/property/test_wal_cas_bughunt.py
@@ -330,24 +330,10 @@ def test_fsync_failure_does_not_create_duplicate_seqs(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Finding 3 (MED): symlinks under .sdd/runtime/wal/ are silently followed.
+# Finding 3 (MED, fixed): symlinks under .sdd/runtime/wal/ are now skipped.
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "bug-hunt finding #3 (MED): WALRecovery.scan_all_uncommitted "
-        "and find_orphaned_claims call wal_dir.glob('*.wal.jsonl') "
-        "with no symlink filter. An attacker (or a misconfigured test) "
-        "that drops a symlink into .sdd/runtime/wal/ pointing at a "
-        "foreign WAL file will see those uncommitted entries replayed "
-        "in the local orchestrator's recovery - producing force-claim "
-        "POSTs against arbitrary task IDs from another project's WAL. "
-        "Fix: skip wal_file when wal_file.is_symlink() (or resolve and "
-        "assert it stays inside wal_dir). 5 LOC change."
-    ),
-)
 def test_symlinked_wal_is_not_replayed(tmp_path: Path) -> None:
     """A symlinked WAL pointing outside its project must not be scanned.
 


### PR DESCRIPTION
## Summary

Documentation-accuracy pass over README.md and the top-level docs/ pages linked from it. Every concrete capability claim was checked against the implementing code, and the README quickstart/prove-a-run examples were run literally in a fresh venv.

## Claim audit

| Claim | Status | Action taken |
|---|---|---|
| 40+ CLI agent adapters | CONFIRMED | `src/bernstein/adapters/registry.py` registers 46 hand-written adapters plus profile-built ones; `bernstein integrations list --installed` matches. None. |
| README "supported agents" name list (25 names) | CONFIRMED | Every name matches a `registry.py` key exactly. None. |
| No LLM in the coordination loop / deterministic scheduler | CONFIRMED | `docs/architecture/WHY_DETERMINISTIC.md`, orchestrator tick loop has no LLM import. None. |
| Per-task git worktree isolation | CONFIRMED | `src/bernstein/core/git/worktree.py`, spawner uses `git worktree add`. None. |
| Always-on lineage spine + replay journal | CONFIRMED | `core/lineage/spine.py`, `core/replay/journal.py`; `bernstein lineage verify` / `bernstein replay list` work as documented. None. |
| Opt-in HMAC-chained audit log (`--audit`) | CONFIRMED | `core/security/audit_chain.py`; `bernstein audit verify` runs, reports "no chain to check" when audit was not enabled, matching the README caveat. None. |
| Air-gap install profile | CONFIRMED | `core/distribution/doctor_airgap.py`, `wheelhouse_cmd.py`, `docs/installation/air-gap.md`. None. |
| Apache-2.0 license | CONFIRMED | `LICENSE`. None. |
| Python 3.12+ badge | CONFIRMED | `pyproject.toml` `requires-python = ">=3.12"`. None. |
| Install methods: pipx/pip/uv/brew/dnf/npm/Docker/wheelhouse | CONFIRMED | All covered in `docs/getting-started/install.md`; `pipx install` / `bernstein init` / `bernstein -g ... --plan-only` all ran as written. None. |
| `bernstein init`, `bernstein -g`, `bernstein live`, `bernstein run`, `bernstein stop` | CONFIRMED | Ran each in a fresh test project; behavior and `--help` text match README. None. |
| "prove a run" commands (`replay list`, `replay latest --verify`, `lineage verify`, `audit verify`) | CONFIRMED | All ran; empty-state messaging matches documented behavior. None. |
| `docs/reference/capabilities.md` (40+ elaborate capability bullets, each naming a CLI command) | CONFIRMED | Every named CLI command resolves to a real command group in the installed CLI. None. |
| `docs/reference/FEATURE_MATRIX.md` (66 file refs, 95 relative doc links) | CONFIRMED | Scripted check: 0 missing files, 0 missing links. None. |
| `docs/gui/index.md`: "Vite + React 18 + Tailwind 3 + shadcn/ui" | CORRECTED | `web/package.json` pins React `^19.0.0` (upgraded in a prior PR). Changed to "React 19". |
| `docs/architecture/ARCHITECTURE.md`: `VectorizeSemanticCache` (`core/memory/vectorize_cache.py`) | DELETED (UNBACKED) | File does not exist - it was deleted as dead code in a prior "delete unwired vectorize_cache" commit; docs were never updated. Removed the bullet. |
| `docs/cloudflare/cloudflare-overview.md`: Vectorize node/row/bullet (module map, diagram, "what you need") | DELETED (UNBACKED) | Same root cause as above; `cloudflare-analytics.md` and `cloudflare-setup.md` already correctly state prompt caching does not use Vectorize. Removed all Vectorize references from this page. |
| `docs/operations/deployment-guide.md`: Vectorize row + env var permissions + closing sentence | DELETED (UNBACKED) | Same root cause. Also added the same "experimental, currently-unavailable api.bernstein.run" caveat that cloudflare-overview.md already carries for `cloud login/run/status/cost`, since this page's quick-start uses those commands without the caveat. |
| `docs/guides/index.md`: "Workers, R2, D1, Vectorize" | CORRECTED | Dropped "Vectorize". |
| Known limitations / feature-matrix file+doc-link references (spot-checked broadly) | CONFIRMED | No other missing files or dead links found in the pages linked from README. None. |

## Skipped-test / defect sweep

`grep -rn "TODO\|FIXME" src/` found 0 real code markers (all hits were string literals like `"TODO API"` or enum members, not comments). `tests/property/` carries a "bug-hunt" suite of `xfail(strict=True)` regressions, each pinning down one still-open defect in the WAL/crash-recovery persistence layer with an exact reproducer. Five were picked as the most user/operator-affecting:

| # | Defect | Action |
|---|---|---|
| 1 | `WALRecovery.scan_all_uncommitted` / `find_orphaned_claims` followed symlinks under `.sdd/runtime/wal/`, so a symlink pointing at another project's WAL file would have its entries replayed by local crash recovery | **Fixed in this branch** (2-line guard in each function) + un-xfailed the regression test |
| 2 | WAL torn-tail recovery resets `prev_hash` to `GENESIS_HASH` instead of the last valid entry's hash, forking the hash chain | Issue: sipyourdrink-ltd/bernstein#3270 |
| 3 | `WALWriter.append` can produce duplicate `seq` numbers if `fsync` fails mid-append | Issue: sipyourdrink-ltd/bernstein#3271 |
| 4 | `find_orphaned_claims` never calls `verify_chain()`, so a WAL with a forged `entry_hash` is trusted during crash recovery | Issue: sipyourdrink-ltd/bernstein#3272 |
| 5 | `close_wal` fsyncs the `.closed` marker file but not its parent directory, so the marker can be lost after a crash | Issue: sipyourdrink-ltd/bernstein#3273 |

## Test plan

- [x] `pip install -e .` in a fresh venv, ran `bernstein init` / `bernstein -g ... --plan-only` / `bernstein replay list` / `bernstein audit verify` / `bernstein integrations list --installed` as literally written in the README
- [x] `pytest tests/unit/test_wal.py tests/unit/test_wal_recovery_retry.py tests/unit/test_chaos_server_restart.py tests/property/test_wal_cas_bughunt.py` - 109 passed, 5 xfailed (the four still-open findings + one Hypothesis state-machine placeholder), 0 failed
- [x] Verified no remaining `vectorize` references outside the two pages that correctly document its absence

## Summary by Sourcery

Audit and correct documentation around Cloudflare integrations, GUI stack, and cloud CLI behavior, and fix a WAL crash-recovery defect involving symlinked log files.

Bug Fixes:
- Prevent WAL crash recovery from replaying entries from symlinked WAL files in other projects by skipping symlinked WALs during scans.

Enhancements:
- Clarify Cloudflare deployment docs to distinguish local Cloudflare usage from experimental, currently-unavailable hosted cloud commands.
- Remove stale references to Cloudflare Vectorize-based semantic caching across architecture, Cloudflare overview, deployment, and guides documentation.
- Update GUI documentation to reflect the current React 19 frontend stack.

Tests:
- Promote the symlinked WAL crash-recovery regression from expected-fail to a passing property test, validating the new protection against symlinked WAL files.