### PR TITLE
fix(tui): stop TaskSearchInput crashing on caller-supplied placeholder

### DIFF
--- a/src/bernstein/tui/task_search.py
+++ b/src/bernstein/tui/task_search.py
@@ -114,11 +114,10 @@ class TaskSearchInput(Input):
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(
-            *args,
-            placeholder="Search tasks or use status:, role:, priority:, agent:",
-            **kwargs,
+        kwargs.setdefault(
+            "placeholder", "Search tasks or use status:, role:, priority:, agent:"
         )
+        super().__init__(*args, **kwargs)
 
     def on_key(self, event: Key) -> None:
         """Handle key events."""

--- a/src/bernstein/tui/task_search.py
+++ b/src/bernstein/tui/task_search.py
@@ -114,9 +114,7 @@ class TaskSearchInput(Input):
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        kwargs.setdefault(
-            "placeholder", "Search tasks or use status:, role:, priority:, agent:"
-        )
+        kwargs.setdefault("placeholder", "Search tasks or use status:, role:, priority:, agent:")
         super().__init__(*args, **kwargs)
 
     def on_key(self, event: Key) -> None:

--- a/tests/unit/test_tui_task_search.py
+++ b/tests/unit/test_tui_task_search.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from bernstein.tui.task_search import TaskSearchQuery, matches_task_search, parse_task_search
+from bernstein.tui.task_search import (
+    TaskSearchInput,
+    TaskSearchQuery,
+    matches_task_search,
+    parse_task_search,
+)
 
 
 @dataclass(frozen=True)
@@ -51,3 +56,20 @@ class TestMatchesTaskSearch:
     def test_matches_assigned_agent_and_blocker_text(self) -> None:
         task = _TaskStub("abc123", "Fix auth", "backend", "blocked", 2, "sonnet", "agent-123", "waiting on deps")
         assert matches_task_search(task, parse_task_search("agent:123 deps")) is True
+
+
+class TestTaskSearchInputPlaceholder:
+    def test_caller_supplied_placeholder_does_not_raise(self) -> None:
+        """Regression test for #3248.
+
+        ``TaskSearchInput.__init__`` used to pass ``placeholder`` both
+        explicitly and via ``**kwargs``, so a caller supplying
+        ``placeholder=`` hit ``TypeError: got multiple values for keyword
+        argument 'placeholder'``.
+        """
+        widget = TaskSearchInput(placeholder="custom text")
+        assert widget.placeholder == "custom text"
+
+    def test_default_placeholder_used_when_not_supplied(self) -> None:
+        widget = TaskSearchInput()
+        assert widget.placeholder == "Search tasks or use status:, role:, priority:, agent:"


### PR DESCRIPTION
## Summary
- `TaskSearchInput.__init__` passed `placeholder` both explicitly and via `**kwargs`, so a caller supplying `placeholder=` hit `TypeError: got multiple values for keyword argument 'placeholder'`.
- Switched to `kwargs.setdefault(...)` so a caller-supplied placeholder takes precedence, and the built-in filter-syntax hint (`status:`, `role:`, `priority:`, `agent:`) still applies when none is given.

Closes #3248

## Test plan
- [x] Added a regression test that reproduces the `TypeError` on unmodified code
- [x] `uv run python -m pytest tests/unit -k "task_search" -q -p no:cacheprovider` — 9 passed

## Summary by Sourcery

Prevent TaskSearchInput from raising a TypeError when a caller supplies a custom placeholder while preserving the default placeholder behavior.

Bug Fixes:
- Fix TaskSearchInput initialization to avoid passing the placeholder argument twice when a caller provides a custom placeholder.

Tests:
- Add regression tests verifying that a caller-supplied placeholder does not raise and that the default placeholder text is used when none is provided.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed task search input initialization when a custom placeholder is provided.
  * Preserved the default search prompt when no placeholder is specified.

* **Tests**
  * Added coverage for custom and default placeholder behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->