### PR TITLE
fix(observability): skip malformed provider-latency records instead of raising

### DIFF
--- a/src/bernstein/core/observability/provider_latency.py
+++ b/src/bernstein/core/observability/provider_latency.py
@@ -15,7 +15,6 @@ from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import cast
 
 from bernstein.core.observability.metric_collector import PercentileTracker
 
@@ -104,25 +103,64 @@ class DegradationAlert:
         }
 
 
+def _coerce_float(value: object) -> float | None:
+    """Coerce a JSON-decoded value to a finite float, or ``None`` if it can't be trusted.
+
+    ``json.loads`` hands back whatever type was on the wire, so a "numeric"
+    field can arrive as a string, ``null``, a nested object, or (Python's
+    JSON parser is permissive) a non-finite float. Any of those means the
+    record is malformed and should be skipped rather than coerced.
+    """
+    if isinstance(value, bool):
+        return None
+    if not isinstance(value, int | float):
+        return None
+    result = float(value)
+    if result != result or result in (float("inf"), float("-inf")):  # NaN / +-Infinity
+        return None
+    return result
+
+
+def _history_sort_key(record: dict[str, object]) -> float:
+    """Sort key for history records.
+
+    ``_read_latency_samples`` only ever appends records whose timestamp
+    already coerced cleanly, so this is a defensive fallback, not a second
+    validation pass.
+    """
+    return _coerce_float(record.get("timestamp", 0)) or 0.0
+
+
 def _read_latency_samples(
     jsonl_file: Path,
     cutoff: float,
     provider: str | None,
     model: str | None,
     samples: list[dict[str, object]],
-) -> None:
-    """Read and filter latency samples from a single JSONL file."""
+) -> int:
+    """Read and filter latency samples from a single JSONL file.
+
+    Returns the number of malformed or truncated records skipped.
+    """
+    skipped = 0
     with suppress(OSError):
         for line in jsonl_file.read_text(encoding="utf-8").splitlines():
             line = line.strip()
             if not line:
                 continue
             try:
-                record: dict[str, object] = json.loads(line)
+                raw: object = json.loads(line)
             except json.JSONDecodeError:
+                skipped += 1
                 continue
-            # _persist_sample writes timestamps as JSON numbers.
-            ts = float(cast(float, record.get("timestamp", 0)))
+            if not isinstance(raw, dict):
+                skipped += 1
+                continue
+            record: dict[str, object] = raw
+            ts = _coerce_float(record.get("timestamp", 0))
+            if ts is None:
+                skipped += 1
+                continue
             if ts < cutoff:
                 continue
             if provider and record.get("provider") != provider:
@@ -130,6 +168,7 @@ def _read_latency_samples(
             if model and record.get("model") != model:
                 continue
             samples.append(record)
+    return skipped
 
 
 class ProviderLatencyTracker:
@@ -167,6 +206,10 @@ class ProviderLatencyTracker:
 
         # Baseline sample counts - we only trust baselines above minimum
         self._baseline_sample_counts: dict[str, int] = {}
+
+        # Count of malformed/truncated JSONL records skipped by the reader
+        # (issue #3288) - incremented by _load_baseline and get_history.
+        self._malformed_samples_skipped: int = 0
 
         self._lock = threading.Lock()
         self._load_baseline()
@@ -325,12 +368,17 @@ class ProviderLatencyTracker:
         """
         cutoff = time.time() - hours * 3600
         samples: list[dict[str, object]] = []
+        skipped = 0
 
         for jsonl_file in sorted(self._metrics_dir.glob("provider_latency_*.jsonl")):
-            _read_latency_samples(jsonl_file, cutoff, provider, model, samples)
+            skipped += _read_latency_samples(jsonl_file, cutoff, provider, model, samples)
 
-        # The history records come from _persist_sample, which emits numeric timestamps.
-        samples.sort(key=lambda r: float(cast(float, r.get("timestamp", 0))))
+        if skipped:
+            with self._lock:
+                self._malformed_samples_skipped += skipped
+            logger.warning("Skipped %d malformed provider-latency record(s) while reading history", skipped)
+
+        samples.sort(key=_history_sort_key)
         return samples
 
     # ------------------------------------------------------------------
@@ -360,25 +408,40 @@ class ProviderLatencyTracker:
             logger.warning("Failed to persist latency sample: %s", exc)
 
     @staticmethod
-    def _parse_latency_record(line: str, cutoff: float) -> tuple[str, float] | None:
-        """Parse a single JSONL latency record, returning ``(key, latency_ms)`` or None."""
+    def _parse_latency_record(line: str, cutoff: float) -> tuple[tuple[str, float] | None, bool]:
+        """Parse a single JSONL latency record.
+
+        Returns ``(key_and_latency, malformed)``. ``key_and_latency`` is
+        ``None`` both when the record is well-formed but filtered out (older
+        than ``cutoff``, missing provider/model, non-positive latency) and
+        when the record is malformed. ``malformed`` is ``True`` only in the
+        latter case (invalid JSON, a non-dict payload, or non-numeric
+        timestamp/latency fields), so callers can count and report skips
+        separately from ordinary filtering.
+        """
         line = line.strip()
         if not line:
-            return None
+            return None, False
         try:
-            record: dict[str, object] = json.loads(line)
+            raw: object = json.loads(line)
         except json.JSONDecodeError:
-            return None
-        # _persist_sample serialises both fields below as JSON numbers.
-        ts = float(cast(float, record.get("timestamp", 0)))
+            return None, True
+        if not isinstance(raw, dict):
+            return None, True
+        record: dict[str, object] = raw
+        ts = _coerce_float(record.get("timestamp", 0))
+        if ts is None:
+            return None, True
         if ts < cutoff:
-            return None
+            return None, False
+        latency_ms = _coerce_float(record.get("latency_ms", 0))
+        if latency_ms is None:
+            return None, True
         provider = str(record.get("provider", ""))
         model = str(record.get("model", ""))
-        latency_ms = float(cast(float, record.get("latency_ms", 0)))
         if not provider or not model or latency_ms <= 0:
-            return None
-        return _make_key(provider, model), latency_ms
+            return None, False
+        return (_make_key(provider, model), latency_ms), False
 
     def _load_baseline(self) -> None:
         """Load historical p99 baselines by replaying persisted JSONL data.
@@ -388,16 +451,23 @@ class ProviderLatencyTracker:
         """
         cutoff = time.time() - 7 * 24 * 3600
         key_samples: dict[str, list[float]] = {}
+        skipped = 0
 
         for jsonl_file in sorted(self._metrics_dir.glob("provider_latency_*.jsonl")):
             try:
                 for line in jsonl_file.read_text(encoding="utf-8").splitlines():
-                    parsed = self._parse_latency_record(line, cutoff)
+                    parsed, malformed = self._parse_latency_record(line, cutoff)
+                    if malformed:
+                        skipped += 1
                     if parsed is not None:
                         key, latency_ms = parsed
                         key_samples.setdefault(key, []).append(latency_ms)
             except OSError:
                 continue
+
+        if skipped:
+            self._malformed_samples_skipped += skipped
+            logger.warning("Skipped %d malformed provider-latency record(s) while loading baseline", skipped)
 
         for key, samples in key_samples.items():
             if len(samples) >= _MIN_BASELINE_SAMPLES:

--- a/tests/unit/test_provider_latency.py
+++ b/tests/unit/test_provider_latency.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import time
 from pathlib import Path
 
@@ -209,5 +210,69 @@ class TestProviderLatencyTracker:
         }
         record[field] = {"not": "numeric"}
 
-        with pytest.raises(TypeError):
-            ProviderLatencyTracker._parse_latency_record(json.dumps(record), cutoff=0.0)
+        parsed, malformed = ProviderLatencyTracker._parse_latency_record(json.dumps(record), cutoff=0.0)
+        assert parsed is None
+        assert malformed is True
+
+    def test_get_history_skips_malformed_records_and_reports_count(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """One good record plus one malformed record of each kind: wrong type, null, truncated."""
+        from datetime import UTC, datetime
+
+        tracker = ProviderLatencyTracker(tmp_path)
+
+        date_str = datetime.now(UTC).strftime("%Y-%m-%d")
+        jsonl = tmp_path / f"provider_latency_{date_str}.jsonl"
+        now = time.time()
+        lines = [
+            json.dumps({"timestamp": now, "provider": "openai", "model": "gpt-4", "latency_ms": 42.0}),
+            # Wrong type: timestamp is a string, not a number.
+            json.dumps({"timestamp": "not-a-number", "provider": "openai", "model": "gpt-4", "latency_ms": 10.0}),
+            # Null: timestamp is JSON null.
+            json.dumps({"timestamp": None, "provider": "openai", "model": "gpt-4", "latency_ms": 10.0}),
+            # Truncated: not valid JSON at all.
+            '{"timestamp": ' + repr(now) + ', "provider": "open',
+        ]
+        jsonl.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+        with caplog.at_level(logging.WARNING):
+            history = tracker.get_history(provider="openai", model="gpt-4")
+
+        assert len(history) == 1
+        assert history[0]["latency_ms"] == pytest.approx(42.0)
+        assert tracker._malformed_samples_skipped == 3
+        assert any("3" in r.message and "malformed" in r.message for r in caplog.records)
+
+    def test_load_baseline_skips_malformed_records_and_reports_count(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Malformed records in the 7-day baseline window must not crash construction."""
+        from datetime import UTC, datetime
+
+        date_str = datetime.now(UTC).strftime("%Y-%m-%d")
+        jsonl = tmp_path / f"provider_latency_{date_str}.jsonl"
+        ts = time.time() - 3600
+
+        good_lines = [
+            json.dumps({"timestamp": ts, "provider": "anthropic", "model": "sonnet", "latency_ms": 200.0})
+            for _ in range(15)
+        ]
+        malformed_lines = [
+            # Wrong type: timestamp is a string, not a number.
+            json.dumps({"timestamp": "bad", "provider": "anthropic", "model": "sonnet", "latency_ms": 200.0}),
+            # Null: timestamp is JSON null.
+            json.dumps({"timestamp": None, "provider": "anthropic", "model": "sonnet", "latency_ms": 200.0}),
+            # Truncated: not valid JSON at all.
+            '{"timestamp": ' + repr(ts) + ', "provider": "anthr',
+        ]
+        jsonl.write_text("\n".join(good_lines + malformed_lines) + "\n", encoding="utf-8")
+
+        with caplog.at_level(logging.WARNING):
+            tracker = ProviderLatencyTracker(tmp_path)
+
+        key = _make_key("anthropic", "sonnet")
+        assert key in tracker._baseline_p99
+        assert tracker._baseline_p99[key] == pytest.approx(200.0, abs=1.0)
+        assert tracker._malformed_samples_skipped == 3
+        assert any("3" in r.message and "malformed" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

- The provider-latency JSONL reader cast timestamp/latency fields straight to `float` at three read sites (`_read_latency_samples`, the history sort key, `_parse_latency_record`). A record with a wrong-typed, null, or truncated field raised out of the reader instead of being skipped.
- Because `_load_baseline()` runs during `ProviderLatencyTracker.__init__`, a single malformed line in the 7-day baseline window could crash tracker construction entirely.
- Replaced the casts with a runtime numeric coercion (`_coerce_float`); malformed records are now skipped and counted at all three sites, and the count is reported via a warning log rather than discarded silently.
- Reader-only change; the writer (`_persist_sample`) is untouched.

Closes #3288

## Test plan

- [x] Added a test writing one good record plus one malformed record of each kind (wrong type, null, truncated) and asserting the good record survives and the skip count is right, for both `get_history()` and baseline loading at construction time.
- [x] Confirmed both new tests fail on the unmodified reader (uncaught `ValueError`/`TypeError`) before applying the fix.
- [x] Updated the existing `test_parse_latency_record_rejects_malformed_numeric_schema` test, which previously asserted the crash as expected behavior.
- [x] `uv run pytest tests/unit -k provider_latency -q` - 20 passed.
- [x] `uv run ruff check` / `uv run ruff format --check` on changed files - clean.

## Summary by Sourcery

Handle malformed provider-latency JSONL records gracefully and report skipped counts instead of raising errors during history and baseline loading.

Bug Fixes:
- Prevent malformed or truncated provider-latency JSONL records from crashing history retrieval or baseline loading by skipping them.
- Ensure non-numeric, null, or non-dict timestamp and latency fields are treated as malformed and excluded from tracking.

Enhancements:
- Track and log the number of malformed provider-latency records skipped during history reads and baseline construction for observability.
- Introduce numeric coercion and defensive sorting for JSONL records to improve robustness of provider-latency metrics ingestion.

Tests:
- Add tests that verify malformed provider-latency records are skipped, counts are tracked, and warnings are emitted for both history retrieval and baseline loading.
- Update existing latency record parsing tests to expect graceful handling of malformed numeric schemas instead of exceptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed or incomplete latency records.
  * Invalid JSON, timestamps, numeric values, and record formats are now skipped safely.
  * Valid latency data continues to load correctly, even when mixed with invalid records.
  * Warning logs now indicate when records are skipped during history and baseline loading.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->