### PR TITLE
fix(tui): make ApprovalAction a real Message subclass

### DIFF
--- a/src/bernstein/tui/approval_panel.py
+++ b/src/bernstein/tui/approval_panel.py
@@ -12,6 +12,7 @@ from typing import Any, ClassVar, cast
 
 from rich.text import Text
 from textual.containers import Container, Vertical
+from textual.message import Message
 from textual.widgets import DataTable, Label, Static
 
 from bernstein.tui.task_list import generate_sparkline
@@ -144,13 +145,14 @@ class ApprovalPanel(Static):
         self.notify("Approval sent: " + ("approved" if event.approved else "rejected"))
 
 
-@dataclass
-class ApprovalAction:
+class ApprovalAction(Message):
     """Message posted when user approves or rejects a pending task."""
 
-    approved: bool
-    task_id: str
-    reason: str = ""
+    def __init__(self, approved: bool, task_id: str, reason: str = "") -> None:
+        self.approved = approved
+        self.task_id = task_id
+        self.reason = reason
+        super().__init__()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_approval_panel_message.py
+++ b/tests/unit/test_approval_panel_message.py
@@ -1,0 +1,88 @@
+"""Tests for ApprovalAction message dispatch in the TUI approval panel.
+
+``ApprovalAction`` is posted to the running app via ``post_message`` from
+``ApprovalPanel.action_approve``/``action_reject``. Textual's message pump
+requires anything passed to ``post_message`` to be a genuine ``Message``
+instance (it checks for attributes only ``Message.__init__`` sets); a plain
+dataclass fails that contract. These tests drive the real code path through
+a minimal Textual app harness (App test pilot) so a regression here is
+caught by an actual message-dispatch failure, not just a type-checker run.
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.message import Message
+
+from bernstein.tui.approval_panel import ApprovalAction, ApprovalEntry, ApprovalPanel
+
+
+class _ApprovalHarnessApp(App[None]):
+    """Minimal app that mounts ApprovalPanel and records dispatched actions."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.received: list[ApprovalAction] = []
+
+    def compose(self) -> ComposeResult:
+        yield ApprovalPanel()
+
+    def on_approval_action(self, event: ApprovalAction) -> None:
+        self.received.append(event)
+
+
+def _one_entry(task_id: str = "t1") -> ApprovalEntry:
+    return ApprovalEntry(
+        task_id=task_id,
+        task_title="Some task",
+        session_id="s1",
+        diff_preview="",
+        test_summary="",
+    )
+
+
+class TestApprovalActionMessage:
+    """ApprovalAction must be a real Message subclass, not a plain dataclass."""
+
+    def test_approval_action_is_a_message_subclass(self) -> None:
+        """post_message() only accepts Message instances - ApprovalAction must qualify."""
+        assert issubclass(ApprovalAction, Message)
+
+    @pytest.mark.asyncio
+    async def test_action_approve_dispatches_to_handler(self) -> None:
+        """action_approve() posts an ApprovalAction that a handler actually receives."""
+        app = _ApprovalHarnessApp()
+        async with app.run_test() as pilot:
+            panel = app.query_one(ApprovalPanel)
+            panel.refresh_entries([_one_entry("t1")])
+            panel._selected_index = 0
+
+            await panel.action_approve()
+            await pilot.pause()
+
+            assert len(app.received) == 1
+            action = app.received[0]
+            assert isinstance(action, ApprovalAction)
+            assert action.approved is True
+            assert action.task_id == "t1"
+            assert action.reason == "Approved via TUI"
+
+    @pytest.mark.asyncio
+    async def test_action_reject_dispatches_to_handler(self) -> None:
+        """action_reject() posts an ApprovalAction that a handler actually receives."""
+        app = _ApprovalHarnessApp()
+        async with app.run_test() as pilot:
+            panel = app.query_one(ApprovalPanel)
+            panel.refresh_entries([_one_entry("t2")])
+            panel._selected_index = 0
+
+            await panel.action_reject()
+            await pilot.pause()
+
+            assert len(app.received) == 1
+            action = app.received[0]
+            assert isinstance(action, ApprovalAction)
+            assert action.approved is False
+            assert action.task_id == "t2"
+            assert action.reason == "Rejected via TUI"


### PR DESCRIPTION
## Summary

- `ApprovalAction` in `src/bernstein/tui/approval_panel.py` was a plain `@dataclass` handed to `post_message()`, which requires a genuine `textual.message.Message` instance. `post_message()` checks for attributes only `Message.__init__` sets, so passing the dataclass raises `RuntimeError: Message is missing attributes; did you forget to call super().__init__() ?` at runtime, and `on_approval_action` never receives the approve/reject action.
- Made `ApprovalAction` subclass `Message` directly (same convention already used for `ApprovalResolved` in `src/bernstein/cli/display/approval_panel.py`), with an explicit `__init__` that sets the three fields and calls `super().__init__()`. The class stays top-level (not nested), so `Message.handler_name` resolution is unchanged and `on_approval_action` keeps dispatching under its existing name.
- `mypy` no longer flags the `post_message()` call sites (previously incompatible-type errors at the reported lines).

## Test plan

- [x] Added `tests/unit/test_approval_panel_message.py`: a Textual app-pilot harness that mounts `ApprovalPanel`, drives `action_approve()`/`action_reject()`, and asserts the posted `ApprovalAction` actually reaches a handler with the right fields — confirmed this fails on unmodified code (`RuntimeError` from `post_message`) and passes after the fix.
- [x] `python -m pytest tests/unit -k "approval" -q -p no:cacheprovider` — 505 passed
- [x] `mypy src/bernstein/tui/approval_panel.py` — no issues
- [x] `ruff check` / `ruff format --check` on changed files — clean

Closes #3251

## Summary by Sourcery

Make the TUI approval panel emit a proper Textual message for approval actions and verify its dispatch behavior with tests.

New Features:
- Ensure ApprovalAction in the TUI approval panel is a concrete Textual Message subclass that can be posted and handled correctly.

Bug Fixes:
- Fix runtime failures where posting a plain dataclass as an approval action caused post_message to reject it and prevented handlers from receiving the event.

Tests:
- Add an async Textual app harness test suite that drives approval and rejection actions and asserts ApprovalAction messages are delivered with correct fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved approval and rejection action handling in the approval panel.
  - Approval decisions now reliably carry the associated task, status, and optional reason through the interface.
  - This improves consistency when processing and displaying approval outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->