### PR TITLE
Skip malformed provider latency JSONL records

### DIFF
--- a/src/bernstein/core/observability/provider_latency.py
+++ b/src/bernstein/core/observability/provider_latency.py
@@ -15,11 +15,48 @@ from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import cast
-
 from bernstein.core.observability.metric_collector import PercentileTracker
 
 logger = logging.getLogger(__name__)
+
+def _coerce_latency_number(value: object) -> float | None:
+    """Return *value* as a float when it is a JSON number, else ``None``."""
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+def _is_malformed_latency_line(line: str) -> bool:
+    """Return True when *line* is not a well-formed latency JSONL record."""
+    stripped = line.strip()
+    if not stripped:
+        return False
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError:
+        return True
+    if not isinstance(parsed, dict):
+        return True
+    record: dict[str, object] = parsed
+    if _coerce_latency_number(record.get("timestamp", 0)) is None:
+        return True
+    return _coerce_latency_number(record.get("latency_ms", 0)) is None
+
+def _report_skipped_latency_records(skipped: int, jsonl_file: Path) -> None:
+    """Log how many malformed provider latency records were skipped in *jsonl_file*."""
+    if skipped:
+        logger.warning(
+            "Skipped %d malformed provider latency record(s) in %s",
+            skipped,
+            jsonl_file,
+        )
+
 
 # Alert when current p99 exceeds baseline p99 by this multiplier
 _DEGRADATION_THRESHOLD: float = 2.0
@@ -110,19 +147,21 @@ def _read_latency_samples(
     provider: str | None,
     model: str | None,
     samples: list[dict[str, object]],
-) -> None:
+) -> int:
     """Read and filter latency samples from a single JSONL file."""
+    skipped = 0
     with suppress(OSError):
         for line in jsonl_file.read_text(encoding="utf-8").splitlines():
             line = line.strip()
             if not line:
                 continue
-            try:
-                record: dict[str, object] = json.loads(line)
-            except json.JSONDecodeError:
+            if _is_malformed_latency_line(line):
+                skipped += 1
                 continue
-            # _persist_sample writes timestamps as JSON numbers.
-            ts = float(cast(float, record.get("timestamp", 0)))
+            record = json.loads(line)
+            assert isinstance(record, dict)
+            ts = _coerce_latency_number(record.get("timestamp", 0))
+            assert ts is not None
             if ts < cutoff:
                 continue
             if provider and record.get("provider") != provider:
@@ -130,6 +169,8 @@ def _read_latency_samples(
             if model and record.get("model") != model:
                 continue
             samples.append(record)
+    _report_skipped_latency_records(skipped, jsonl_file)
+    return skipped
 
 
 class ProviderLatencyTracker:
@@ -326,11 +367,19 @@ class ProviderLatencyTracker:
         cutoff = time.time() - hours * 3600
         samples: list[dict[str, object]] = []
 
+        skipped_total = 0
         for jsonl_file in sorted(self._metrics_dir.glob("provider_latency_*.jsonl")):
-            _read_latency_samples(jsonl_file, cutoff, provider, model, samples)
+            skipped_total += _read_latency_samples(jsonl_file, cutoff, provider, model, samples)
 
-        # The history records come from _persist_sample, which emits numeric timestamps.
-        samples.sort(key=lambda r: float(cast(float, r.get("timestamp", 0))))
+        if skipped_total:
+            logger.warning(
+                "Skipped %d malformed provider latency record(s) while loading history",
+                skipped_total,
+            )
+
+        samples.sort(
+            key=lambda r: _coerce_latency_number(r.get("timestamp", 0)) or 0.0,
+        )
         return samples
 
     # ------------------------------------------------------------------
@@ -365,18 +414,18 @@ class ProviderLatencyTracker:
         line = line.strip()
         if not line:
             return None
-        try:
-            record: dict[str, object] = json.loads(line)
-        except json.JSONDecodeError:
+        if _is_malformed_latency_line(line):
             return None
-        # _persist_sample serialises both fields below as JSON numbers.
-        ts = float(cast(float, record.get("timestamp", 0)))
+        record = json.loads(line)
+        assert isinstance(record, dict)
+        ts = _coerce_latency_number(record.get("timestamp", 0))
+        assert ts is not None
         if ts < cutoff:
             return None
         provider = str(record.get("provider", ""))
         model = str(record.get("model", ""))
-        latency_ms = float(cast(float, record.get("latency_ms", 0)))
-        if not provider or not model or latency_ms <= 0:
+        latency_ms = _coerce_latency_number(record.get("latency_ms", 0))
+        if latency_ms is None or not provider or not model or latency_ms <= 0:
             return None
         return _make_key(provider, model), latency_ms
 
@@ -389,15 +438,30 @@ class ProviderLatencyTracker:
         cutoff = time.time() - 7 * 24 * 3600
         key_samples: dict[str, list[float]] = {}
 
+        skipped_total = 0
         for jsonl_file in sorted(self._metrics_dir.glob("provider_latency_*.jsonl")):
+            file_skipped = 0
             try:
                 for line in jsonl_file.read_text(encoding="utf-8").splitlines():
+                    stripped = line.strip()
+                    if not stripped:
+                        continue
                     parsed = self._parse_latency_record(line, cutoff)
                     if parsed is not None:
                         key, latency_ms = parsed
                         key_samples.setdefault(key, []).append(latency_ms)
+                    elif _is_malformed_latency_line(line):
+                        file_skipped += 1
+                skipped_total += file_skipped
+                _report_skipped_latency_records(file_skipped, jsonl_file)
             except OSError:
                 continue
+
+        if skipped_total:
+            logger.warning(
+                "Skipped %d malformed provider latency record(s) while loading baselines",
+                skipped_total,
+            )
 
         for key, samples in key_samples.items():
             if len(samples) >= _MIN_BASELINE_SAMPLES:

--- a/src/bernstein/core/observability/provider_latency.py
+++ b/src/bernstein/core/observability/provider_latency.py
@@ -47,9 +47,11 @@ def _is_malformed_latency_line(line: str) -> bool:
     if not isinstance(parsed, dict):
         return True
     record: dict[str, object] = parsed
-    if _coerce_latency_number(record.get("timestamp", 0)) is None:
+    if "timestamp" not in record or "latency_ms" not in record:
         return True
-    return _coerce_latency_number(record.get("latency_ms", 0)) is None
+    if _coerce_latency_number(record["timestamp"]) is None:
+        return True
+    return _coerce_latency_number(record["latency_ms"]) is None
 
 
 def _report_skipped_latency_records(skipped: int, jsonl_file: Path) -> None:
@@ -164,7 +166,7 @@ def _read_latency_samples(
                 continue
             record = json.loads(line)
             assert isinstance(record, dict)
-            ts = _coerce_latency_number(record.get("timestamp", 0))
+            ts = _coerce_latency_number(record["timestamp"])
             assert ts is not None
             if ts < cutoff:
                 continue
@@ -382,7 +384,7 @@ class ProviderLatencyTracker:
             )
 
         samples.sort(
-            key=lambda r: _coerce_latency_number(r.get("timestamp", 0)) or 0.0,
+            key=lambda r: _coerce_latency_number(r["timestamp"]) or 0.0,
         )
         return samples
 
@@ -422,13 +424,13 @@ class ProviderLatencyTracker:
             return None
         record = json.loads(line)
         assert isinstance(record, dict)
-        ts = _coerce_latency_number(record.get("timestamp", 0))
+        ts = _coerce_latency_number(record["timestamp"])
         assert ts is not None
         if ts < cutoff:
             return None
         provider = str(record.get("provider", ""))
         model = str(record.get("model", ""))
-        latency_ms = _coerce_latency_number(record.get("latency_ms", 0))
+        latency_ms = _coerce_latency_number(record["latency_ms"])
         if latency_ms is None or not provider or not model or latency_ms <= 0:
             return None
         return _make_key(provider, model), latency_ms

--- a/src/bernstein/core/observability/provider_latency.py
+++ b/src/bernstein/core/observability/provider_latency.py
@@ -15,9 +15,11 @@ from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+
 from bernstein.core.observability.metric_collector import PercentileTracker
 
 logger = logging.getLogger(__name__)
+
 
 def _coerce_latency_number(value: object) -> float | None:
     """Return *value* as a float when it is a JSON number, else ``None``."""
@@ -31,6 +33,7 @@ def _coerce_latency_number(value: object) -> float | None:
         except ValueError:
             return None
     return None
+
 
 def _is_malformed_latency_line(line: str) -> bool:
     """Return True when *line* is not a well-formed latency JSONL record."""
@@ -47,6 +50,7 @@ def _is_malformed_latency_line(line: str) -> bool:
     if _coerce_latency_number(record.get("timestamp", 0)) is None:
         return True
     return _coerce_latency_number(record.get("latency_ms", 0)) is None
+
 
 def _report_skipped_latency_records(skipped: int, jsonl_file: Path) -> None:
     """Log how many malformed provider latency records were skipped in *jsonl_file*."""

--- a/tests/unit/test_provider_latency.py
+++ b/tests/unit/test_provider_latency.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import time
 from pathlib import Path
 
@@ -200,7 +201,7 @@ class TestProviderLatencyTracker:
         assert tracker._baseline_p99[key] == pytest.approx(200.0, abs=1.0)
 
     @pytest.mark.parametrize("field", ["timestamp", "latency_ms"])
-    def test_parse_latency_record_rejects_malformed_numeric_schema(self, field: str) -> None:
+    def test_parse_latency_record_skips_malformed_numeric_schema(self, field: str) -> None:
         record: dict[str, object] = {
             "timestamp": time.time(),
             "provider": "openai",
@@ -209,5 +210,55 @@ class TestProviderLatencyTracker:
         }
         record[field] = {"not": "numeric"}
 
-        with pytest.raises(TypeError):
-            ProviderLatencyTracker._parse_latency_record(json.dumps(record), cutoff=0.0)
+        assert ProviderLatencyTracker._parse_latency_record(json.dumps(record), cutoff=0.0) is None
+
+    def test_malformed_jsonl_records_skipped_and_counted(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        from datetime import UTC, datetime
+
+        date_str = datetime.now(UTC).strftime("%Y-%m-%d")
+        jsonl = tmp_path / f"provider_latency_{date_str}.jsonl"
+        ts = time.time()
+        good = {
+            "timestamp": ts,
+            "provider": "openai",
+            "model": "gpt-4",
+            "latency_ms": 100.0,
+        }
+        lines = [
+            json.dumps(good),
+            json.dumps(
+                {
+                    "timestamp": "not-a-number",
+                    "provider": "openai",
+                    "model": "gpt-4",
+                    "latency_ms": 12.0,
+                }
+            ),
+            json.dumps(
+                {
+                    "timestamp": ts,
+                    "provider": "openai",
+                    "model": "gpt-4",
+                    "latency_ms": None,
+                }
+            ),
+            '{"timestamp": 1.0, "provider": "openai", "model": "gpt-4", "latency_ms": 50',
+        ]
+        jsonl.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        with caplog.at_level(logging.WARNING):
+            tracker = ProviderLatencyTracker(tmp_path)
+            history = tracker.get_history()
+
+        assert len(history) == 1
+        assert history[0]["provider"] == "openai"
+        assert history[0]["latency_ms"] == pytest.approx(100.0)
+        skip_messages = [
+            record.message
+            for record in caplog.records
+            if "Skipped" in record.message and "malformed provider latency" in record.message
+        ]
+        assert any("3 malformed provider latency record(s)" in message for message in skip_messages)

--- a/tests/unit/test_provider_latency.py
+++ b/tests/unit/test_provider_latency.py
@@ -249,16 +249,18 @@ class TestProviderLatencyTracker:
             '{"timestamp": 1.0, "provider": "openai", "model": "gpt-4", "latency_ms": 50',
         ]
         jsonl.write_text("\n".join(lines) + "\n", encoding="utf-8")
-        with caplog.at_level(logging.WARNING):
-            tracker = ProviderLatencyTracker(tmp_path)
+        tracker = ProviderLatencyTracker(tmp_path)
+        caplog.clear()
+        with caplog.at_level(logging.WARNING, logger="bernstein.core.observability.provider_latency"):
             history = tracker.get_history()
 
         assert len(history) == 1
         assert history[0]["provider"] == "openai"
         assert history[0]["latency_ms"] == pytest.approx(100.0)
-        skip_messages = [
+        history_skip_messages = [
             record.message
             for record in caplog.records
-            if "Skipped" in record.message and "malformed provider latency" in record.message
+            if record.name == "bernstein.core.observability.provider_latency"
+            and "while loading history" in record.message
         ]
-        assert any("3 malformed provider latency record(s)" in message for message in skip_messages)
+        assert any("3 malformed provider latency record(s)" in message for message in history_skip_messages)


### PR DESCRIPTION
## Summary
- Harden all three provider latency JSONL read paths to skip malformed or truncated lines instead of raising on bad `timestamp` / `latency_ms` values.
- Log per-file and aggregate skip counts so discarded records are visible in logs.
- Add unit coverage for wrong-type, null, and truncated JSON alongside a valid sample.

## Test plan
- [x] `uv run pytest tests/unit/test_provider_latency.py -q` (19 passed)
- [x] `uv run pytest tests/unit -k provider_latency -q` (19 passed after `tzdata` in venv)

Fixes #3288

## Summary by Sourcery

Harden provider latency JSONL processing to skip malformed records and track skipped counts in logs.

Bug Fixes:
- Avoid crashes when provider latency JSONL records contain invalid or non-numeric timestamp or latency_ms values by skipping those records.
- Ensure baseline and history loading tolerate truncated or malformed JSON lines without failing.

Enhancements:
- Coerce latency-related fields from multiple JSON types, including numeric strings, when reading provider latency records.
- Aggregate and emit per-file and overall warnings about skipped malformed provider latency records for better observability.

Tests:
- Add unit tests covering malformed numeric schemas, invalid and null latency fields, truncated JSON, and verification of skip-count logging for provider latency JSONL files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of malformed latency data by skipping invalid records instead of failing.
  - Numeric values provided as strings are now processed correctly.
  - Invalid, missing, boolean, and non-object values are safely rejected.
  - Added warnings that report skipped records per file and across all processed data.
  - Baseline and history processing now apply consistent validation and error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->