### PR TITLE
Guard provider_latency JSONL reads against malformed records (#3288)

### DIFF
--- a/src/bernstein/core/observability/provider_latency.py
+++ b/src/bernstein/core/observability/provider_latency.py
@@ -21,6 +21,59 @@ from bernstein.core.observability.metric_collector import PercentileTracker
 
 logger = logging.getLogger(__name__)
 
+
+class _MalformedLatencyRecord(ValueError):
+    """Internal marker: a persisted JSONL latency record could not be parsed.
+
+    Raised while reading history so callers can skip and count the record
+    instead of letting a ``TypeError``/``ValueError`` escape the reader.
+    """
+
+
+def _coerce_float(value: object) -> float | None:
+    """Best-effort conversion of a JSONL field to ``float``.
+
+    Persisted records are normally well-formed numbers, but truncated,
+    hand-edited, or foreign records may carry strings, ``null`` values, or the
+    wrong type. Returns ``None`` for anything that cannot be interpreted as a
+    number so the caller can skip the record rather than raising.
+
+    Booleans are rejected: ``True``/``False`` are valid ``int`` subclasses but
+    never a meaningful timestamp or latency.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _decode_record(line: str) -> dict[str, object] | None:
+    """Decode one JSONL line into a record dict.
+
+    Returns ``None`` for blank lines. Raises :class:`_MalformedLatencyRecord`
+    for lines that are not valid JSON or not a JSON object (a bare ``123`` is
+    valid JSON but has no fields to read).
+    """
+    stripped = line.strip()
+    if not stripped:
+        return None
+    try:
+        parsed: object = json.loads(stripped)
+    except json.JSONDecodeError as exc:
+        raise _MalformedLatencyRecord(str(exc)) from exc
+    if not isinstance(parsed, dict):
+        raise _MalformedLatencyRecord("record is not a JSON object")
+    # A JSON object always deserialises to ``dict[str, object]``; the cast is
+    # safe because the ``isinstance`` above has already ruled out other shapes.
+    return cast("dict[str, object]", parsed)
+
+
 # Alert when current p99 exceeds baseline p99 by this multiplier
 _DEGRADATION_THRESHOLD: float = 2.0
 
@@ -110,19 +163,27 @@ def _read_latency_samples(
     provider: str | None,
     model: str | None,
     samples: list[dict[str, object]],
-) -> None:
-    """Read and filter latency samples from a single JSONL file."""
+) -> int:
+    """Read and filter latency samples from a single JSONL file.
+
+    Malformed records (invalid JSON, non-object lines, or a non-numeric
+    timestamp) are skipped rather than raising. Returns the number of records
+    skipped so the caller can report the total.
+    """
+    skipped = 0
     with suppress(OSError):
         for line in jsonl_file.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if not line:
-                continue
             try:
-                record: dict[str, object] = json.loads(line)
-            except json.JSONDecodeError:
+                record = _decode_record(line)
+            except _MalformedLatencyRecord:
+                skipped += 1
                 continue
-            # _persist_sample writes timestamps as JSON numbers.
-            ts = float(cast(float, record.get("timestamp", 0)))
+            if record is None:
+                continue
+            ts = _coerce_float(record.get("timestamp"))
+            if ts is None:
+                skipped += 1
+                continue
             if ts < cutoff:
                 continue
             if provider and record.get("provider") != provider:
@@ -130,6 +191,7 @@ def _read_latency_samples(
             if model and record.get("model") != model:
                 continue
             samples.append(record)
+    return skipped
 
 
 class ProviderLatencyTracker:
@@ -326,11 +388,14 @@ class ProviderLatencyTracker:
         cutoff = time.time() - hours * 3600
         samples: list[dict[str, object]] = []
 
+        skipped = 0
         for jsonl_file in sorted(self._metrics_dir.glob("provider_latency_*.jsonl")):
-            _read_latency_samples(jsonl_file, cutoff, provider, model, samples)
+            skipped += _read_latency_samples(jsonl_file, cutoff, provider, model, samples)
+        if skipped:
+            logger.warning("Skipped %d malformed latency record(s) while reading history", skipped)
 
-        # The history records come from _persist_sample, which emits numeric timestamps.
-        samples.sort(key=lambda r: float(cast(float, r.get("timestamp", 0))))
+        # Retained records all carry a numeric timestamp; fall back to 0.0 defensively.
+        samples.sort(key=lambda r: _coerce_float(r.get("timestamp")) or 0.0)
         return samples
 
     # ------------------------------------------------------------------
@@ -361,21 +426,27 @@ class ProviderLatencyTracker:
 
     @staticmethod
     def _parse_latency_record(line: str, cutoff: float) -> tuple[str, float] | None:
-        """Parse a single JSONL latency record, returning ``(key, latency_ms)`` or None."""
-        line = line.strip()
-        if not line:
+        """Parse a single JSONL latency record.
+
+        Returns ``(key, latency_ms)`` for a usable record, or ``None`` when the
+        record is well-formed but filtered out (blank line, older than
+        ``cutoff``, missing provider/model, or non-positive latency). Raises
+        :class:`_MalformedLatencyRecord` when the line cannot be parsed at all
+        (invalid JSON, non-object, or non-numeric ``timestamp``/``latency_ms``).
+        """
+        record = _decode_record(line)
+        if record is None:
             return None
-        try:
-            record: dict[str, object] = json.loads(line)
-        except json.JSONDecodeError:
-            return None
-        # _persist_sample serialises both fields below as JSON numbers.
-        ts = float(cast(float, record.get("timestamp", 0)))
+        ts = _coerce_float(record.get("timestamp"))
+        if ts is None:
+            raise _MalformedLatencyRecord("non-numeric timestamp")
         if ts < cutoff:
             return None
+        latency_ms = _coerce_float(record.get("latency_ms"))
+        if latency_ms is None:
+            raise _MalformedLatencyRecord("non-numeric latency_ms")
         provider = str(record.get("provider", ""))
         model = str(record.get("model", ""))
-        latency_ms = float(cast(float, record.get("latency_ms", 0)))
         if not provider or not model or latency_ms <= 0:
             return None
         return _make_key(provider, model), latency_ms
@@ -388,16 +459,25 @@ class ProviderLatencyTracker:
         """
         cutoff = time.time() - 7 * 24 * 3600
         key_samples: dict[str, list[float]] = {}
+        skipped = 0
 
         for jsonl_file in sorted(self._metrics_dir.glob("provider_latency_*.jsonl")):
             try:
-                for line in jsonl_file.read_text(encoding="utf-8").splitlines():
-                    parsed = self._parse_latency_record(line, cutoff)
-                    if parsed is not None:
-                        key, latency_ms = parsed
-                        key_samples.setdefault(key, []).append(latency_ms)
+                lines = jsonl_file.read_text(encoding="utf-8").splitlines()
             except OSError:
                 continue
+            for line in lines:
+                try:
+                    parsed = self._parse_latency_record(line, cutoff)
+                except _MalformedLatencyRecord:
+                    skipped += 1
+                    continue
+                if parsed is not None:
+                    key, latency_ms = parsed
+                    key_samples.setdefault(key, []).append(latency_ms)
+
+        if skipped:
+            logger.warning("Skipped %d malformed latency record(s) while loading baseline", skipped)
 
         for key, samples in key_samples.items():
             if len(samples) >= _MIN_BASELINE_SAMPLES:

--- a/tests/unit/test_provider_latency.py
+++ b/tests/unit/test_provider_latency.py
@@ -3,14 +3,19 @@
 from __future__ import annotations
 
 import json
+import logging
 import time
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
 from bernstein.core.provider_latency import (
+    _MIN_BASELINE_SAMPLES,
     DegradationAlert,
     ProviderLatencyTracker,
+    _coerce_float,
     _make_key,
+    _MalformedLatencyRecord,
     _split_key,
 )
 
@@ -209,5 +214,113 @@ class TestProviderLatencyTracker:
         }
         record[field] = {"not": "numeric"}
 
-        with pytest.raises(TypeError):
+        # A non-numeric field is flagged with the internal marker so the reader
+        # can skip and count it, instead of a bare TypeError/ValueError escaping.
+        with pytest.raises(_MalformedLatencyRecord):
             ProviderLatencyTracker._parse_latency_record(json.dumps(record), cutoff=0.0)
+
+
+class TestCoerceFloat:
+    """_coerce_float turns arbitrary JSONL field values into float | None (#3288)."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (12.5, 12.5),
+            (0, 0.0),
+            (200, 200.0),
+            ("12.5", 12.5),
+            ("  3 ", 3.0),
+            (None, None),
+            ("not-a-number", None),
+            ("", None),
+            ([1, 2], None),
+            ({"a": 1}, None),
+            (True, None),  # bool is an int subclass but never a real value
+            (False, None),
+        ],
+    )
+    def test_coerce_float(self, value: object, expected: float | None) -> None:
+        assert _coerce_float(value) == expected
+
+
+class TestMalformedRecordHandling:
+    """The reader skips malformed/truncated JSONL records instead of raising (#3288)."""
+
+    @staticmethod
+    def _write_jsonl(metrics_dir: Path, lines: list[str]) -> Path:
+        date_str = datetime.now(UTC).strftime("%Y-%m-%d")
+        jsonl = metrics_dir / f"provider_latency_{date_str}.jsonl"
+        jsonl.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        return jsonl
+
+    def test_get_history_skips_malformed_and_reports_count(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        now = time.time()
+        good_a = json.dumps({"timestamp": now, "provider": "anthropic", "model": "sonnet", "latency_ms": 12.5})
+        good_b = json.dumps({"timestamp": now - 60, "provider": "anthropic", "model": "sonnet", "latency_ms": 30.0})
+        lines = [
+            good_a,
+            '{"timestamp": "not-a-number", "provider": "a", "model": "m", "latency_ms": 5}',
+            '{"timestamp": null, "provider": "a", "model": "m", "latency_ms": 5}',
+            '{"timestamp": ' + repr(now) + ', "provider": "a", "model": "m", "laten',  # truncated
+            "42",  # valid JSON, but not an object
+            "",  # blank line - ignored, not counted as malformed
+            good_b,
+        ]
+        self._write_jsonl(tmp_path, lines)
+
+        tracker = ProviderLatencyTracker(tmp_path)
+        with caplog.at_level(logging.WARNING):
+            history = tracker.get_history()
+
+        # Only the two well-formed records survive, ordered by timestamp ascending.
+        assert [r["latency_ms"] for r in history] == [30.0, 12.5]
+        assert "Skipped 4 malformed latency record(s) while reading history" in caplog.text
+
+    def test_get_history_clean_file_logs_nothing(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        now = time.time()
+        self._write_jsonl(
+            tmp_path,
+            [json.dumps({"timestamp": now, "provider": "openai", "model": "gpt-4", "latency_ms": 10.0})],
+        )
+        tracker = ProviderLatencyTracker(tmp_path)
+        with caplog.at_level(logging.WARNING):
+            history = tracker.get_history()
+
+        assert len(history) == 1
+        assert "malformed" not in caplog.text
+
+    def test_load_baseline_skips_malformed_and_still_builds_baseline(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        ts = time.time() - 3600
+        good = [
+            json.dumps({"timestamp": ts, "provider": "openai", "model": "gpt-4", "latency_ms": 200.0})
+            for _ in range(_MIN_BASELINE_SAMPLES)
+        ]
+        malformed = [
+            '{"timestamp": "oops", "provider": "openai", "model": "gpt-4", "latency_ms": 200}',
+            '{"timestamp": ' + repr(ts) + ', "provider": "openai", "model": "gpt-4", "latency_ms": null}',
+            "{ truncated json",
+            "3.14",  # not an object
+        ]
+        self._write_jsonl(tmp_path, [*good, *malformed])
+
+        with caplog.at_level(logging.WARNING):
+            tracker = ProviderLatencyTracker(tmp_path)
+
+        key = _make_key("openai", "gpt-4")
+        assert key in tracker._baseline_p99
+        assert tracker._baseline_p99[key] == pytest.approx(200.0, abs=1.0)
+        assert "Skipped 4 malformed latency record(s) while loading baseline" in caplog.text
+
+    def test_get_history_all_malformed_returns_empty(self, tmp_path: Path) -> None:
+        self._write_jsonl(
+            tmp_path,
+            ['{"timestamp": null}', "not json at all", "[1, 2, 3]"],
+        )
+        tracker = ProviderLatencyTracker(tmp_path)
+        # No traceback; simply nothing to return.
+        assert tracker.get_history() == []


### PR DESCRIPTION
## What

Make `provider_latency`'s JSONL reader skip malformed/truncated records instead of aborting the read with a traceback. Fixes #3288.

## Why

The reader converted `timestamp` and `latency_ms` straight to `float` at three read sites using `cast(float, ...)`, which is a no-op at runtime:

```python
ts = float(cast(float, record.get("timestamp", 0)))
latency_ms = float(cast(float, record.get("latency_ms", 0)))
```

A record that is truncated, hand-edited, or from an unexpected source (string timestamp, `null` value, non-object line) therefore raised `TypeError`/`ValueError` and aborted the entire read — including baseline loading on startup — rather than skipping the one bad record.

Before this change, a single `{"timestamp": null, ...}` line makes `get_history()`/`_load_baseline()` crash:

```
TypeError: float() argument must be a string or a real number, not 'NoneType'
```

## How

- Add `_coerce_float(value)` — best-effort numeric coercion returning `float | None` for strings, `null`, wrong types, and booleans.
- Add `_decode_record(line)` — JSON decode plus a non-object guard (a bare `42` line is valid JSON but has no fields), raising an internal `_MalformedLatencyRecord` marker.
- Route all three read sites (`_read_latency_samples`, the `get_history` sort key, and `_parse_latency_record`) through them, so malformed records are skipped.
- Count skipped records per read path and report them with a `logger.warning`.
- Remove the unnecessary `cast(float, ...)` calls. The only remaining `cast` narrows a dict *after* a runtime `isinstance` check.
- The writer (`_persist_sample`) is unchanged.

## Tests

`uv run pytest tests/unit -k provider_latency -q` → **34 passed** (18 existing + 16 new).

New coverage: a `_coerce_float` parameter table (good number, numeric string, `null`, wrong type, bool), and reader tests with good + malformed records (string/null timestamp, wrong-type field, truncated JSON, non-object line) asserting graceful skips, correct retained records, and the reported skip counts via `caplog`. The existing `test_parse_latency_record_rejects_malformed_numeric_schema` was updated from expecting a bare `TypeError` to the new controlled `_MalformedLatencyRecord` marker.

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run ruff format --check` passes
- [x] `uv run mypy src/…/provider_latency.py` passes
- [x] New code has type hints
- [x] Tests cover the documented behaviour

Documentation duty: N/A — internal reader hardening, no user-visible behaviour, public API, or new module.

## Summary by Sourcery

Harden provider latency JSONL reading so malformed records are skipped and reported instead of crashing history and baseline loading.

Bug Fixes:
- Prevent TypeError/ValueError crashes when reading provider_latency JSONL files containing non-numeric or malformed fields.
- Ensure baseline loading continues even when latency history files contain truncated or non-object JSONL lines.

Enhancements:
- Introduce dedicated helpers for decoding JSONL records and coercing numeric fields, along with an internal malformed-record marker to centralize validation and error handling.
- Log the number of malformed latency records skipped when building history or baselines to aid observability.

Tests:
- Add parameterized tests for numeric coercion and multiple scenarios of malformed JSONL records, asserting graceful skipping, preserved valid samples, baseline construction, and warning logs.
- Update existing latency record parsing tests to expect the new controlled malformed-record marker instead of raw type errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when reading latency history and baseline data.
  * Malformed or invalid records are now skipped with warnings instead of causing failures.
  * Numeric timestamp and latency values are validated and handled more reliably.
  * Empty results are returned safely when all available records are invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->