### PR TITLE
chore(typing): annotate src/bernstein/core/communication/ (mypy: 35 -> 0)

### DIFF
--- a/src/bernstein/core/communication/bulletin.py
+++ b/src/bernstein/core/communication/bulletin.py
@@ -52,7 +52,10 @@ class SignalActionFailure(RuntimeError):
 
 
 # Shared cast-type constants to avoid string duplication (Sonar S1192).
-_CAST_STR_NONE = "str | None"
+type _CAST_STR_NONE = str | None
+# JSON-derived scalar shape accepted by float()/int() (values loaded from
+# a loosely-typed dict; the "or 0" fallback already guards falsy values).
+type _CAST_NUMERIC = str | float | int
 
 
 @dataclass
@@ -104,9 +107,9 @@ class AgentStatusNotification:
             status=str(d.get("status", "")),
             summary=str(d.get("summary", "")),
             result=cast("dict[str, object] | None", d.get("result")),
-            usage_tokens=int(d.get("usage_tokens", 0) or 0),
-            usage_cost_usd=float(d.get("usage_cost_usd", 0.0) or 0.0),
-            timestamp=float(d.get("timestamp", 0.0) or 0.0),
+            usage_tokens=int(cast(_CAST_NUMERIC, d.get("usage_tokens", 0)) or 0),
+            usage_cost_usd=float(cast(_CAST_NUMERIC, d.get("usage_cost_usd", 0.0)) or 0.0),
+            timestamp=float(cast(_CAST_NUMERIC, d.get("timestamp", 0.0)) or 0.0),
         )
 
 
@@ -184,11 +187,11 @@ class Delegation:
             origin_agent=str(d.get("origin_agent", "")),
             target_role=str(d.get("target_role", "")),
             description=str(d.get("description", "")),
-            deadline=float(d.get("deadline", 0.0) or 0.0),
+            deadline=float(cast(_CAST_NUMERIC, d.get("deadline", 0.0)) or 0.0),
             status=status,
             claimed_by=cast(_CAST_STR_NONE, d.get("claimed_by")),
             result=cast(_CAST_STR_NONE, d.get("result")),
-            created_at=float(d.get("created_at", 0.0) or 0.0),
+            created_at=float(cast(_CAST_NUMERIC, d.get("created_at", 0.0)) or 0.0),
             cell_id=cast(_CAST_STR_NONE, d.get("cell_id")),
         )
 
@@ -443,7 +446,7 @@ class AgentActivitySummary:
         return cls(
             agent_id=str(d.get("agent_id", "")),
             summary=str(d.get("summary", "")),
-            timestamp=float(d.get("timestamp", 0.0) or 0.0),
+            timestamp=float(cast(_CAST_NUMERIC, d.get("timestamp", 0.0)) or 0.0),
         )
 
 
@@ -927,8 +930,8 @@ class ChannelQuery:
             content=str(d.get("content", "")),
             target_agent=cast(_CAST_STR_NONE, d.get("target_agent")),
             target_role=cast(_CAST_STR_NONE, d.get("target_role")),
-            timestamp=float(d.get("timestamp", 0.0) or 0.0),
-            expires_at=float(d.get("expires_at", 0.0) or 0.0),
+            timestamp=float(cast(_CAST_NUMERIC, d.get("timestamp", 0.0)) or 0.0),
+            expires_at=float(cast(_CAST_NUMERIC, d.get("expires_at", 0.0)) or 0.0),
             resolved=bool(d.get("resolved", False)),
         )
 
@@ -969,7 +972,7 @@ class ChannelResponse:
             query_id=str(d.get("query_id", "")),
             responder_agent=str(d.get("responder_agent", "")),
             content=str(d.get("content", "")),
-            timestamp=float(d.get("timestamp", 0.0) or 0.0),
+            timestamp=float(cast(_CAST_NUMERIC, d.get("timestamp", 0.0)) or 0.0),
         )
 
 

--- a/src/bernstein/core/communication/conversation_export.py
+++ b/src/bernstein/core/communication/conversation_export.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 
 # Shared cast-type constants to avoid string duplication (Sonar S1192).
-_CAST_DICT_STR_ANY = "dict[str, Any]"
+type _CAST_DICT_STR_ANY = dict[str, Any]
 
 
 @dataclass(frozen=True)

--- a/src/bernstein/core/communication/signal_actions.py
+++ b/src/bernstein/core/communication/signal_actions.py
@@ -41,7 +41,7 @@ import json
 import threading
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Protocol, cast
 
 from bernstein.core.security.audit_chain import (
     EVENT_SIGNAL_GATE_PROJECTION,
@@ -241,11 +241,11 @@ def spec_from_receipt(details: Mapping[str, object], *, journal_prefix_hash: str
     return ClearanceGateSpec(
         blocker_content_hash=str(details.get("blocker_content_hash", "")),
         clearance_task_id=str(details.get("clearance_task_id", "")),
-        injected_edges=tuple(str(edge) for edge in details.get("injected_edges", []) or []),
+        injected_edges=tuple(str(edge) for edge in cast("list[object]", details.get("injected_edges", []) or [])),
         scope_cell_id=str(details.get("scope_cell_id", "")),
         journal_prefix_hash=journal_prefix_hash or str(details.get("journal_prefix_hash", "")),
         graph_delta_hash=str(details.get("graph_delta_hash", "")),
-        deadline=int(details.get("deadline", 0) or 0),
+        deadline=int(cast("str | float | int", details.get("deadline", 0)) or 0),
     )
 
 
@@ -285,9 +285,9 @@ class GateAnchor:
         self.blocker_content_hash = str(details.get("blocker_content_hash", ""))
         self.graph_delta_hash = str(details.get("graph_delta_hash", ""))
         self.scope_cell_id = str(details.get("scope_cell_id", ""))
-        self.deadline = int(details.get("deadline", 0) or 0)
+        self.deadline = int(cast("str | float | int", details.get("deadline", 0)) or 0)
         self.journal_prefix_hash = str(details.get("journal_prefix_hash", ""))
-        self.edges = {str(edge) for edge in details.get("injected_edges", []) or []}
+        self.edges = {str(edge) for edge in cast("list[object]", details.get("injected_edges", []) or [])}
         self.index = index
         self.entry_hmac = hmac
         if hmac:
@@ -951,8 +951,12 @@ def _validate_gate_resolution_row(
         ("blocker_content_hash", str(details.get("blocker_content_hash", "")), anchor.blocker_content_hash),
         ("graph_delta_hash", str(details.get("graph_delta_hash", "")), anchor.graph_delta_hash),
         ("scope_cell_id", str(details.get("scope_cell_id", "")), anchor.scope_cell_id),
-        ("deadline", int(details.get("deadline", 0) or 0), anchor.deadline),
-        ("injected_edges", {str(e) for e in details.get("injected_edges", []) or []}, anchor.edges),
+        ("deadline", int(cast("str | float | int", details.get("deadline", 0)) or 0), anchor.deadline),
+        (
+            "injected_edges",
+            {str(e) for e in cast("list[object]", details.get("injected_edges", []) or [])},
+            anchor.edges,
+        ),
     )
     for name, actual, expected in field_checks:
         if actual != expected:

--- a/src/bernstein/core/communication/voting.py
+++ b/src/bernstein/core/communication/voting.py
@@ -15,7 +15,7 @@ import logging
 import time
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, cast
 
 from bernstein.core.llm import call_llm
 
@@ -422,7 +422,7 @@ class VotingProtocol:
         else:
             verdict = "abstain"
 
-        confidence = float(data.get("confidence", 0.8))
+        confidence = float(cast("str | float | int", data.get("confidence", 0.8)))
         confidence = max(0.0, min(1.0, confidence))  # clamp to [0, 1]
 
         reasoning = str(data.get("feedback", data.get("reasoning", "")))

--- a/src/bernstein/core/communication/whiteboard.py
+++ b/src/bernstein/core/communication/whiteboard.py
@@ -269,7 +269,7 @@ class Whiteboard:
         lazy.
         """
         if not self._path.exists():
-            return iter(())
+            return
         # The file is opened eagerly so the descriptor lifetime is
         # bound to the iterator generator; closing happens when the
         # generator is exhausted or garbage-collected.


### PR DESCRIPTION
## What

Fixes the 35 mypy errors in `src/bernstein/core/communication/`
(10 files) with type annotations only. No behaviour changes.

**Before:** 35 errors
**After:** 0 errors

## Approach

Two patterns account for all 35 errors:

1. **Fake string-alias cast constants** (18 errors, `bulletin.py` and
   `conversation_export.py`). A module-level constant like
   `_CAST_DICT_STR_ANY = "dict[str, Any]"` is a plain `str`, not a
   type, so `cast(_CAST_DICT_STR_ANY, value)` fails with
   `not valid as a type [valid-type]`. Converted each to a real PEP
   695 type statement (`type _CAST_DICT_STR_ANY = dict[str, Any]`).
   `cast()` is a no-op at runtime, so call sites are unchanged.

2. **`float()`/`int()`/iteration on `object`** (17 errors, `bulletin.py`,
   `voting.py`, `signal_actions.py`). Values pulled out of a loosely
   typed `dict[str, object]` payload (parsed JSON / a `Mapping`) are
   typed `object`, so `float(d.get(...))`, `int(d.get(...))`, and
   `for x in d.get(...)` don't type-check even though the runtime
   values are always numeric/list-shaped. Added a shared
   `_CAST_NUMERIC = str | float | int` alias (`bulletin.py`) plus
   inline `cast("list[object]", ...)` / `cast("str | float | int", ...)`
   at each site, matching the existing inline-cast style already used
   nearby in the same files. No change to the `or 0` / `or 0.0`
   fallback logic.

One additional fix outside those two patterns:

- `whiteboard.py::Whiteboard.iter_visible` is a generator (it does
  `yield from` further down), so its declared return type
  `Iterator[WhiteboardEntry]` doesn't accept a value on `return`.
  The early-exit path did `return iter(())`, which mypy flagged as
  `No return value expected [return-value]`. That returned iterator
  was never observable anyway -- callers only ever consume the
  generator via normal iteration (`list(...)`, `for`), which never
  sees a generator's `StopIteration.value`. Replaced with a bare
  `return`, which terminates the generator identically.

## Residue

None. All 35 errors are annotation-only fixes; nothing was left
unfixed or suppressed.

## Verification

- `uv run mypy src/bernstein/core/communication/` -> 0 errors (was 35)
- `uv run ruff check` / `uv run ruff format --check` on touched files -> clean
- `uv run pytest tests/unit/test_bulletin.py tests/unit/test_bulletin_activity_summary.py tests/unit/test_bulletin_status_notification.py tests/unit/test_conversation_export.py tests/unit/test_signal_actions.py tests/unit/test_voting.py tests/unit/test_whiteboard.py -q` -> 102 passed

Closes #3240. Part of #2980.

## Summary by Sourcery

Resolve mypy typing issues in the communication module with annotation-only changes and a minor generator signature fix.

Enhancements:
- Introduce proper PEP 695 type aliases for shared cast types in bulletin and conversation_export to replace string-based type names.
- Tighten typing around JSON- and Mapping-derived values in bulletin, signal_actions, and voting by casting numeric and list-shaped payload fields to more precise types.
- Adjust Whiteboard.iter_visible to return as a generator (using a bare return on the empty-path case) to match its declared iterator return type.