### PR TITLE
chore(typing): annotate src/bernstein/core/routing/ (mypy: 52 -> 0)

### DIFF
--- a/src/bernstein/core/routing/bandit_router.py
+++ b/src/bernstein/core/routing/bandit_router.py
@@ -126,9 +126,9 @@ _LANGUAGE_BY_SUFFIX: dict[str, str] = {
 # ---------------------------------------------------------------------------
 
 
-# Shared cast-type constants to avoid string duplication (Sonar S1192).
-_CAST_DICT_STR_OBJ = "dict[str, object]"
-_CAST_LIST_OBJ = "list[object]"
+# Shared cast-type aliases to avoid string duplication (Sonar S1192).
+type _CAST_DICT_STR_OBJ = dict[str, object]
+type _CAST_LIST_OBJ = list[object]
 
 
 @dataclass

--- a/src/bernstein/core/routing/cascade.py
+++ b/src/bernstein/core/routing/cascade.py
@@ -19,7 +19,7 @@ import json
 import logging
 import time
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeGuard
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -355,7 +355,7 @@ class CascadeFallbackManager:
         excluded_providers: frozenset[str],
         min_strength: int,
         task_complexity: Complexity,
-    ) -> bool:
+    ) -> TypeGuard[AgentCapabilities]:
         """Check if an agent is a viable cascade candidate."""
         if agent is None:
             return False

--- a/src/bernstein/core/routing/router_core.py
+++ b/src/bernstein/core/routing/router_core.py
@@ -28,8 +28,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-# Shared cast-type constants to avoid string duplication (Sonar S1192).
-_CAST_DICT_STR_ANY = "dict[str, Any]"
+# Shared cast-type alias to avoid string duplication (Sonar S1192).
+type _CAST_DICT_STR_ANY = dict[str, Any]
 
 # ---------------------------------------------------------------------------
 # budget-aware routing


### PR DESCRIPTION
## Summary

Annotation-only pass over `src/bernstein/core/routing/`. No runtime behaviour changed.

Two shapes accounted for all errors:

- `bandit_router.py` and `router_core.py` defined module-level "type alias" constants as plain strings (`_CAST_DICT_STR_OBJ = "dict[str, object]"`, etc.) and passed them to `cast()`. mypy doesn't treat a `str` as a type, so every `cast()` call and every subsequent attribute access on the result failed. Replaced with real PEP 695 `type` statements (`type _CAST_DICT_STR_OBJ = dict[str, object]`); the `cast()` call sites are unchanged.
- `cascade.py`'s `_is_viable_candidate` returns `bool` but genuinely narrows its `agent: AgentCapabilities | None` argument to non-`None` on a `True` return. mypy couldn't propagate that to the caller, so the caller's use of `agent.name` / `agent.reasoning_strength` after the guard failed. Changed the return type to `TypeGuard[AgentCapabilities]`; function body and call sites unchanged.

## mypy count

| | count |
|---|---|
| before | 52 errors in 3 files |
| after | 0 errors |

## Residue

None. All 52 errors in this package resolved with annotation-only changes; no `# type: ignore` added.

## Gates

- `ruff check` on touched files: clean
- `ruff format --check` on touched files: clean
- `pytest tests/unit -k "routing" -q`: 399 passed

Closes #3230. Part of #2980.

## Summary by Sourcery

Improve type safety and static analysis coverage in the routing core without changing runtime behavior.

Enhancements:
- Replace string-based cast helpers with proper type aliases in bandit and core router modules to satisfy mypy.
- Refine the cascade viability helper to return a TypeGuard for AgentCapabilities so mypy can narrow agent types correctly.