### PR TITLE
chore(typing): annotate src/bernstein/core/protocols/ (mypy: 93 -> 41)

### DIFF
--- a/src/bernstein/core/protocols/cluster/cluster_audit.py
+++ b/src/bernstein/core/protocols/cluster/cluster_audit.py
@@ -13,7 +13,10 @@ fixture to spin up an HMAC key.
 from __future__ import annotations
 
 import logging
-from typing import Final
+from typing import TYPE_CHECKING, Final
+
+if TYPE_CHECKING:
+    from bernstein.core.security.audit import AuditLog
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +47,7 @@ _KNOWN_LEAVE_REASONS: Final[frozenset[str]] = frozenset(
 )
 
 
-def _audit_log() -> object | None:
+def _audit_log() -> AuditLog | None:
     """Return the wired AuditLog singleton, or None.
 
     Imported lazily to break a circular import (lifecycle -> task_store

--- a/src/bernstein/core/protocols/mcp/mcp_composition.py
+++ b/src/bernstein/core/protocols/mcp/mcp_composition.py
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 
 
 # Shared cast-type constants to avoid string duplication (Sonar S1192).
-_CAST_DICT_STR_ANY = "dict[str, Any]"
+type _CAST_DICT_STR_ANY = dict[str, Any]
 
 
 @dataclass(frozen=True)
@@ -275,7 +275,7 @@ def _parse_single_step(raw_step: dict[str, Any]) -> ToolStep:
         server=str(raw_step.get("server", "")),
         args_template=args_dict,
         output_key=str(raw_step.get("output_key", "")),
-        on_failure=on_failure,
+        on_failure=cast(Literal["stop", "skip", "retry"], on_failure),
     )
 
 

--- a/src/bernstein/core/protocols/mcp/mcp_tool_normalization.py
+++ b/src/bernstein/core/protocols/mcp/mcp_tool_normalization.py
@@ -41,8 +41,8 @@ logger = logging.getLogger(__name__)
 
 
 # Shared cast-type constants to avoid string duplication (Sonar S1192).
-_CAST_DICT_STR_ANY = "dict[str, Any]"
-_CAST_STR_NONE = "str | None"
+type _CAST_DICT_STR_ANY = dict[str, Any]
+type _CAST_STR_NONE = str | None
 
 
 @dataclass(frozen=True)

--- a/src/bernstein/core/protocols/mcp/mcp_usage_analytics.py
+++ b/src/bernstein/core/protocols/mcp/mcp_usage_analytics.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 
 # Shared cast-type constants to avoid string duplication (Sonar S1192).
-_CAST_DICT_STR_OBJ = "dict[str, object]"
+type _CAST_DICT_STR_OBJ = dict[str, object]
 
 
 @dataclass(frozen=True)

--- a/src/bernstein/core/protocols/pm_sync.py
+++ b/src/bernstein/core/protocols/pm_sync.py
@@ -139,8 +139,8 @@ _API_BASE_URLS: dict[PMProvider, str] = {
 # Shared string constants to avoid duplication (Sonar S1192).
 _CONTENT_TYPE_JSON = "application/json"
 _GRAPHQL_ENDPOINT = "/graphql"
-_CAST_DICT_STR_ANY = "dict[str, Any]"
-_CAST_LIST_DICT_STR_ANY = "list[dict[str, Any]]"
+type _CAST_DICT_STR_ANY = dict[str, Any]
+type _CAST_LIST_DICT_STR_ANY = list[dict[str, Any]]
 
 # ---------------------------------------------------------------------------
 # PMClient


### PR DESCRIPTION
## Summary

Annotate `src/bernstein/core/protocols/` so mypy stops treating module-level
string constants as usable type expressions, and cast one runtime-validated
string to its `Literal` at the point of use.

- `pm_sync.py`, `mcp/mcp_usage_analytics.py`, `mcp/mcp_tool_normalization.py`,
  `mcp/mcp_composition.py`: the `_CAST_*` constants were plain `str` values
  passed to `cast()`. mypy can't treat a variable as a type unless it's a real
  type alias, so every `cast()` call and every attribute access on the result
  errored. Converted each to a PEP 695 `type` statement; every call site is
  unchanged.
- `mcp/mcp_composition.py`: `on_failure` is validated against
  `("stop", "skip", "retry")` at runtime but stayed typed as `str`, so passing
  it to `ToolStep(on_failure=...)` (declared `Literal["stop", "skip", "retry"]`)
  didn't type-check. Added `cast(Literal[...], on_failure)` at the call site,
  after the validation.
- `cluster/cluster_audit.py`: `_audit_log()` returned `object | None` to keep
  the lazy import that breaks a `lifecycle -> task_store -> cluster` circular
  import. Added a `TYPE_CHECKING`-only import of `AuditLog` and narrowed the
  return type to `AuditLog | None`; the runtime import stays exactly as
  deferred as before.

No `# type: ignore` added. No behaviour changes - annotations only.

## mypy

| | errors | files |
|---|---|---|
| before | 93 | 8 |
| after | 41 | 3 |

## Residue (left as-is, per the issue)

- `protocols/grpc/grpc_server.py`, `protocols/grpc/grpc_client.py` (38 errors):
  `Module "bernstein.core.grpc_gen" has no attribute "*_pb2*"`. The generated
  protobuf stubs aren't checked into this repo (only `__init__.py` is present
  under `grpc_gen/`); fixing this needs a codegen/stub step, not annotations.
- `protocols/mcp/mcp_verifier.py` (3 errors): the `DSAPublicKey.verify` /
  `RSAPublicKey.verify` / `EllipticCurvePublicKey.verify` calls are genuine
  overload-resolution errors from `cryptography`'s key-type union - the
  correct fix needs per-key-type narrowing, left for a follow-up.

## Testing

- `uv run ruff check` on touched files: clean
- `uv run ruff format --check` on touched files: clean
- `uv run pytest tests/unit -k "protocols" -q`: 446 passed

Closes #3228. Part of #2980.

## Summary by Sourcery

Improve type safety and mypy coverage for core protocols by tightening annotations and eliminating string-based cast type hints.

Bug Fixes:
- Ensure on_failure in MCP tool composition is correctly typed as the validated failure mode literal set when constructing ToolStep.

Enhancements:
- Replace string-encoded cast type hints with proper PEP 695 type aliases across MCP, PM sync, and usage analytics modules to satisfy mypy.
- Narrow the cluster audit helper’s return type from a generic object union to the specific AuditLog type via TYPE_CHECKING-only imports without changing lazy import behavior.