### PR TITLE
chore(typing): annotate src/bernstein/core/quality/ (mypy: 47 -> 15)

### DIFF
--- a/src/bernstein/core/quality/benchmark_gate.py
+++ b/src/bernstein/core/quality/benchmark_gate.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 # Shared cast-type constants to avoid string duplication (Sonar S1192).
-_CAST_DICT_STR_OBJ = "dict[str, object]"
+type _CAST_DICT_STR_OBJ = dict[str, object]
 
 
 @dataclass(frozen=True)

--- a/src/bernstein/core/quality/cross_model_verifier.py
+++ b/src/bernstein/core/quality/cross_model_verifier.py
@@ -382,7 +382,7 @@ def _record_rework_sample(
         from bernstein.core.routing.rework_ledger import default_ledger
     except ImportError:
         return
-    outcome = "rework" if verdict.verdict == "request_changes" else "success"
+    outcome: Literal["rework", "success"] = "rework" if verdict.verdict == "request_changes" else "success"
     effort = (task.effort or "normal").lower()
     try:
         ledger = default_ledger(worktree_path)

--- a/src/bernstein/core/quality/fast_path.py
+++ b/src/bernstein/core/quality/fast_path.py
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 
 
 # Shared cast-type constants to avoid string duplication (Sonar S1192).
-_CAST_DICT_STR_OBJ = "dict[str, object]"
+type _CAST_DICT_STR_OBJ = dict[str, object]
 
 
 class TaskLevel(Enum):

--- a/src/bernstein/core/quality/gate_commands.py
+++ b/src/bernstein/core/quality/gate_commands.py
@@ -10,7 +10,7 @@ import shlex
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from bernstein.core.quality.gate_pipeline import (
     NO_PYTHON_FILES,
@@ -830,6 +830,7 @@ class GateRunnerCommandsMixin:
             metadata[dim.name] = dim.score
         if result.errors:
             metadata["errors"] = result.errors[:3]
+        gate_status: Literal["pass", "warn", "fail"]
         if result.passed:
             gate_status = "pass"
         elif not step.required:

--- a/src/bernstein/core/quality/gate_runner.py
+++ b/src/bernstein/core/quality/gate_runner.py
@@ -14,7 +14,7 @@ import threading
 import time
 from dataclasses import asdict
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from bernstein.core.quality.gate_commands import (
     _module_name_from_path,
@@ -1055,6 +1055,7 @@ class GateRunner:
             metadata[dim.name] = dim.score
         if result.errors:
             metadata["errors"] = result.errors[:3]
+        gate_status: Literal["pass", "warn", "fail"]
         if result.passed:
             gate_status = "pass"
         elif not step.required:
@@ -1423,6 +1424,7 @@ class GateRunner:
         from bernstein.core.quality.flaky_detector import FlakyDetector
         from bernstein.core.quality.test_impact import TestImpactAnalyzer
 
+        command: str | None
         if step.command_override is not None:
             command = step.command_override
         elif not self._changed_files_resolved:

--- a/src/bernstein/core/quality/retrospective.py
+++ b/src/bernstein/core/quality/retrospective.py
@@ -17,6 +17,8 @@ from typing import TYPE_CHECKING, cast
 from bernstein.core.models import Complexity, Task, TaskStatus
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from bernstein.core.metrics import MetricsCollector, TaskMetrics
 
 logger = logging.getLogger(__name__)
@@ -621,10 +623,10 @@ def _write_rate_table(
     separator: str,
     done_counts: dict[str, int],
     failed_counts: dict[str, int],
-    sort_key: object = None,
+    sort_key: Callable[[str], int] | None = None,
 ) -> None:
     """Write a rate table (by role or complexity) into *lines*."""
-    all_keys = sorted(set(done_counts) | set(failed_counts), key=sort_key)  # type: ignore[arg-type]
+    all_keys = sorted(set(done_counts) | set(failed_counts), key=sort_key)
     if not all_keys:
         return
     lines.extend((header, "", columns, separator))
@@ -1418,7 +1420,7 @@ def gather_project_memory_from_json(sdd_dir: Path) -> str:
         goal = item.get("goal", "")
         done = item.get("tasks_done", 0)
         failed = item.get("tasks_failed", 0)
-        total = int(done) + int(failed)  # type: ignore[arg-type]
+        total = int(cast(int, done)) + int(cast(int, failed))
         cost = item.get("cost_usd", 0.0)
         lesson = item.get("lesson", "")
         lines.append(f"- **{goal}**: {done}/{total} done, ${cost:.2f}")

--- a/src/bernstein/core/quality/test_impact.py
+++ b/src/bernstein/core/quality/test_impact.py
@@ -602,10 +602,10 @@ class TestImpactAnalyzer:
                 if not module:
                     continue
                 source_imports[module] = self._parse_source_imports(source_file)
-                for test_file in self._name_based_mapping(source_file.relative_to(self._root).as_posix()):
-                    graph.setdefault(module, set()).add(test_file)
-                    reverse.setdefault(test_file, set()).add(module)
-                    all_tests.add(test_file)
+                for mapped_test in self._name_based_mapping(source_file.relative_to(self._root).as_posix()):
+                    graph.setdefault(module, set()).add(mapped_test)
+                    reverse.setdefault(mapped_test, set()).add(module)
+                    all_tests.add(mapped_test)
 
         return graph, reverse, source_imports, all_tests
 


### PR DESCRIPTION
## What
Typing slice from #2980: annotate `src/bernstein/core/quality/` to reduce the mypy backlog. Fixed mypy errors via type annotations only - no runtime behaviour changes.

## Before / after
`uv run mypy src/bernstein/core/quality/`: **47 -> 15** errors.

(The issue's original count was 38; the package has grown since it was filed, so 47 is the accurate current baseline - confirmed by running the exact command before touching anything.)

## What changed
- `benchmark_gate.py`, `fast_path.py`: the known string-constant fake-alias pattern - `_CAST_DICT_STR_OBJ = "dict[str, object]"` is a `str`, not a type, so `cast(_CAST_DICT_STR_OBJ, ...)` failed with "not valid as a type". Converted both to a real PEP 695 `type` statement. `cast()` stays a no-op at runtime either way.
- `gate_commands.py`, `gate_runner.py`: two identical blocks build a `gate_status` local across an if/elif/else and pass it to `GateResult(status=...)`, which expects `Literal['pass', 'fail', 'warn', 'timeout', 'skipped', 'bypassed']`. Without an upfront annotation mypy widens the local to plain `str`. Added `gate_status: Literal["pass", "warn", "fail"]` ahead of the branch.
- `gate_runner.py` (`_tests_command`): the `command` local is assigned a `str` on its first branch and `str | None` on a later branch; mypy locks the type to the first assignment. Annotated `command: str | None` upfront - the function already null-checks it right after (`if command is None: return None`).
- `retrospective.py`: `_write_rate_table`'s `sort_key` parameter was typed `object`, then passed straight to `sorted(..., key=sort_key)`. Typed it as `Callable[[str], int] | None`, matching every call site. Also replaced a `# type: ignore[arg-type]` in `gather_project_memory_from_json` that no longer matched mypy's actual error code (`call-overload`) with an explicit `cast(int, ...)` at the two JSON-boundary reads it was covering.
- `test_impact.py`: `_build_fresh_index` has two sequential loops in the same function; the second one's loop variable (`test_file`, bound to a `str` from `_name_based_mapping()`) shared its name with the first loop's variable (`test_file`, bound to a `Path` from `_discover_tests()`), so mypy inferred the wrong type on the second use. Renamed the second loop variable to `mapped_test` - a pure rename, no behaviour change.

## Residue (15 errors left, not fixed here)
- **14x** `Module "bernstein.core" has no attribute ...` (`quality_gates`, `dead_code_detector`, `comment_quality` across `gate_commands.py` and `gate_runner.py`). These come from the lazy-import shim in `core/__init__.py` (`_CoreRedirectFinder` / `_REDIRECT_MAP`), not from this package - no annotation here can resolve them. Per the issue, left alone.
- **1x** `gate_runner.py:639` - `GateRunner._run_dead_code_gate_sync` calls `self._build_dead_code_result(...)`, but that method is only defined on `GateRunnerCommandsMixin` in `gate_commands.py`, a class `GateRunner` never inherits from or mixes in (elsewhere in the same file, `GateRunner` calls other `GateRunnerCommandsMixin` helpers explicitly as `GateRunnerCommandsMixin._check_alembic_migrations(...)`, unbound). This looks like a pre-existing wiring gap rather than a typing issue - fixing it would mean guessing at the intended behaviour, so it's flagged here rather than silenced with a cast.

## How
Annotation-only fixes, one rename (variable-name collision, not a logic change). Verified with the exact commands from the issue.

## Checklist
- [x] `uv run mypy src/bernstein/core/quality/` reports fewer errors than 47 (15 remain, all residue above)
- [x] No `# type: ignore` added (one stale one removed where the annotation fix made it correct)
- [x] No runtime behaviour changed - annotations only
- [x] `ruff check` and `ruff format --check` clean on the touched files
- [x] Suspected pre-existing bug documented above rather than silenced

Closes #3241. Part of #2980.

## Summary by Sourcery

Improve static typing in the bernstein.core.quality package to reduce mypy errors without changing runtime behavior.

Enhancements:
- Tighten type annotations for helper functions in retrospective reporting, including explicit callable and integer casts at JSON boundaries.
- Clarify local variable types in gate runner and gate commands logic using Literal and optional string annotations to preserve precise status and command types.
- Refine type usage in benchmark and fast_path modules by replacing string-based cast aliases with proper typed aliases.
- Disambiguate loop variable usage in test impact indexing by renaming a reused variable to reflect its mapped test role.
- Constrain outcome typing in cross_model_verifier to a Literal union for recorded rework samples.

Tests:
- Adjust test impact analysis helper naming in tests to avoid type confusion while preserving behavior.