### PR TITLE
chore(release): v3.12.0

### DIFF
--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bernstein",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "description": "Deterministic orchestrator for CLI coding agents. Spawn parallel agents in per-task git worktrees, verify their work, and merge results; no model in the coordination loop, so runs replay byte-identically.",
   "author": {
     "name": "chernistry",

--- a/docs/release-notes/v3.11.0.md
+++ b/docs/release-notes/v3.11.0.md
@@ -1,4 +1,4 @@
-# v3.11.0 (in progress)
+# v3.11.0
 
 This wave corrects the MCP surface an operator actually reads and drives: one
 tool per question, a per-run cancel, typed results a client can validate,

--- a/docs/release-notes/v3.12.0.md
+++ b/docs/release-notes/v3.12.0.md
@@ -1,0 +1,193 @@
+# v3.12.0
+
+A correctness release. Three surfaces that reported success while doing
+something else are fixed: a required quality gate now blocks the merge it was
+already logging about, `--plan-only` no longer runs the work it was asked to
+describe, and the write-ahead log recovers a torn tail onto its real
+predecessor instead of forking the hash chain off genesis. Around those, the
+reap path stops losing agents to worktree-layout drift, the documentation was
+re-checked against the code rather than against itself, and the mypy backlog
+came down by several hundred errors across a dozen packages. Upgrade in place;
+read the behaviour changes first.
+
+## Behaviour changes (read before upgrading)
+
+- **A failed required quality gate now stops the merge (#3254).** One `or` in
+  `_evaluate_approval_gate` covered two unrelated conditions: "no approval gate
+  is configured" and "the required gate failed". Returning `skip_merge=False`
+  is right for the first and wrong for the second, so a failed gate was
+  reported, recorded as `blocked` in `quality_gates.jsonl`, and the branch
+  merged about 300ms later anyway. The two conditions are now separate. This is
+  a behaviour change in the direction of the documented contract: work that
+  previously merged past a failing required gate no longer merges, so a project
+  that had a permanently red required gate will start seeing merges refused —
+  which is what the gate was for.
+
+- **`--plan-only` no longer executes the run when the plan came from a
+  positional plan file (#3255).** `plan_file` is positional, so
+  `bernstein run plan.yaml --plan-only` took the plan-file dispatch, which
+  called the bootstrap entry point and returned before the flag was ever
+  consulted: task server, watchdog, spawner, a live agent, a worktree, a
+  commit, the merge path, exit code 0. The flag is now checked ahead of the
+  whole `--plan-file` / `--from-plan` dispatch, because it is a property of the
+  run and not of how the plan was supplied. With a plan file present the
+  preview renders the loaded plan, so its tasks appear with their roles and
+  models instead of a single synthetic task built from the plan's name, and the
+  rerun hint points back at the plan file rather than at `--from-plan`, which
+  reads only the goal line and would re-decompose from the plan name. The saved
+  plan is written as UTF-8; the render always emits status glyphs, so the
+  platform default encoding raised `UnicodeEncodeError` on a cp1252 locale.
+
+- **A stalled agent that is still writing bytes now gets reaped (#3058).** The
+  escalation ladder and the Tier-1 watchdog both treat a recently-written
+  runner log as proof of life, and every adapter except `claude` merges the
+  child's stderr into that same file — so retry chatter, a spinner, or a
+  deprecation warning refreshed the mtime and reset the ladder, with no upper
+  bound. The deferral is now capped by `AGENT.liveness_suppression_cap_s`
+  (900s, overridable via `tuning.agent.liveness_suppression_cap_s`). Below the
+  cap a slow first turn keeps the grace it was given; past that much continuous
+  heartbeat silence the mtime is read as output noise and the ladder escalates,
+  so a stuck agent releases its worker slot at the escalation threshold instead
+  of holding it to the wall-clock hard cap.
+
+- **The MCP deprecated tool aliases announced in v3.11.0 for removal in this
+  release are still served.** That removal did not land in this cycle. Set
+  `BERNSTEIN_MCP_DEPRECATED_ALIASES=0` to drop them now and surface any caller
+  still using an old name.
+
+## Write-ahead log
+
+Four defects in `core/persistence/wal.py`, each reproduced against unmodified
+code before the fix (#3270, #3271, #3272, #3273).
+
+- Torn-tail recovery no longer forks the chain. `_load_tail` fell back to
+  `(count - 1, GENESIS_HASH)` when the trailing line failed to parse, so the
+  next `append` chained its `prev_hash` off genesis rather than off its real
+  predecessor and the chain forked silently at the truncation point. Recovery
+  now rescans for the last entry whose stored `entry_hash` equals the SHA-256
+  of its own payload and resumes both `seq` and `prev_hash` from there, so a
+  partially-written line cannot become the chain anchor.
+- `append` is fsync-failure-safe. It wrote and fsynced before advancing `seq`
+  and `prev_hash`, so an `fsync` raising `ENOSPC` or `EIO` left the line
+  durable with the counters unadvanced and the caller's retry reused the same
+  sequence number. The file length is now recorded before the write and
+  truncated back on any failure, then the original error is re-raised.
+- Recovery reads verify before trusting. `find_orphaned_claims` and
+  `get_uncommitted_entries` treated every parsed entry as authoritative. Both
+  now read through `WALReader.iter_verified_entries`, which applies the same
+  two checks `verify_chain` makes and drops entries failing either.
+  Verification is per entry rather than a whole-file gate, because a crashed
+  run's WAL legitimately ends in a torn line and gating the whole file would
+  discard exactly the orphans recovery exists to reclaim.
+- `close_wal` fsyncs the marker's parent directory, so the dirent cannot be
+  lost in a crash and leave recovery re-scanning an already-handled WAL.
+
+## Agent lifecycle and reaping
+
+- The reap tick's log and `.git` liveness probe resolves the agent log in every
+  worktree layout instead of one hardcoded path (#3215), and usage accounting
+  and the stall-detection aggregator now do the same (#3216). Both consumers
+  probed only the legacy `.sdd/worktrees/<id>/` shape, so a session under the
+  current default layout produced no signal at all: token accounting silently
+  under-reported, and stall profiling ran on an empty log summary rather than
+  failing loudly. Both now reuse the same worktree-directory helper, and
+  `check_stalled_tasks` passes the session's own reported log path, which the
+  remote runtime bridge, container, and sandbox spawn paths need because no
+  candidate layout would find it.
+- The reap liveness probe is guarded against a session with no local PID
+  (#3212).
+- A heartbeat's `status` is no longer folded into its `phase` (#3202). The two
+  describe different things — the heartbeat file's own lifecycle versus the
+  agent's work stage — and a `phase or status` fallback meant `phase="starting"`
+  arrived with no writer in the tree producing it. The monitor now reads `phase`
+  alone, and the pre-spawn writer emits `phase="starting"` explicitly from a
+  single shared helper. Both halves are load-bearing: an adapter with
+  `consumes_heartbeat_dir=False` never overwrites the spawn-time file, so that
+  writer is the only source of the starting phase for that whole population,
+  and dropping the fallback without it would have flagged a slow first turn
+  against the general threshold instead of the starting window.
+
+## Verifiability
+
+- Trajectory receipt verification checks the stored bytes rather than a decoded
+  projection of them (#3211). Verification decoded the file into dataclasses
+  and rehashed the object, and the decode is lossy twice over: unrecognised
+  keys are dropped, and `journal_entry_hash` fell back to a `.get` default.
+  Anything outside the schema never reached the hash, so an edited receipt
+  could verify clean. Three claims the module made that its code did not
+  implement were corrected at the same time.
+
+## Test selection and CI
+
+- Diff-scoped test selection picks workflow guards by what they read rather
+  than by their file name (#3214). The old rule matched the substring
+  `workflow` in the test filename, so a guard named after the workflow it pins
+  — reading the same YAML, breaking on the same edit — was dropped from the
+  slice. Workflow-only pull requests merged green and the breakage surfaced on
+  `main` when the full suite ran.
+- The stock-server sweep drives the documented SSE operations as streams
+  (#3274), so an endpoint documented as streaming is now exercised as one.
+
+## Terminal UI
+
+Four defects reported from a single session against the TUI, each fixed with
+the test that reproduces it: the debounce timer handles are annotated as
+`Timer` rather than `object`, which was hiding a missing `stop()` (#3247);
+`TaskSearchInput.__init__` no longer raises `TypeError` when a caller passes
+`placeholder` explicitly (#3248); the approval panel reads the selected row
+from `row_key` instead of `cursor_row`, which is an `int` and was never the
+attribute wanted (#3249); and `ApprovalAction` is a real `Message` subclass, so
+`post_message()` type-checks against what it actually receives (#3251).
+
+## Cost and provider data
+
+- The MiniMax price table is refreshed and carries cache tiers (#3261); the
+  shipped table had drifted from the published rates.
+- `provider_latency` skips malformed JSONL records instead of raising on the
+  first bad numeric field (#3288), so one corrupt line no longer takes down the
+  whole reading.
+
+## Typing
+
+The mypy backlog came down across twelve packages this cycle: `core/protocols`
+(93 to 41), `cli/commands` (73 to 3), `core/routing` (52 to 0),
+`core/observability` (50 to 3), `core/quality` (47 to 15), `tui` (41 to 15),
+`core/communication` (35 to 0), `core/tasks` (23 to 3), plus `core/routes`,
+`core/config`, and `adapters`. The pattern that recurs is string constants fed
+into `cast()` — mypy cannot use a string as a type — converted to real PEP 695
+`type` aliases; after that, explicit declarations where a first-branch
+assignment fixed a variable's type too early, and casts into the nested shape a
+`dict[str, object]` read actually has. No `# type: ignore` was added to buy any
+of it, and the three errors left in `cli/commands` are real defects an
+annotation cannot honestly paper over, filed separately rather than silenced.
+
+## Documentation
+
+- Capability claims were verified against the code, with stale counts and
+  examples corrected (#3275).
+- The adapter last-green table is regenerated from canary receipts rather than
+  maintained by hand (#3218, #3280).
+
+## Contributors
+
+This release carries work from:
+
+- **casbrbr-beep** — found and reported the quality-gate polarity defect
+  (#3254, P0) and contributed the fix (#3266); diagnosed `--plan-only` (#3255)
+  down to the exact dispatch branch after a first static read had cleared it,
+  and specified the design this release implements.
+- **bymyforge** — annotated the `tui` package (#3236), typed the debounce timer
+  handles (#3252), fixed the approval-panel row-selection crash (#3253), and
+  filed four TUI defects (#3247, #3248, #3249, #3251) with reproductions.
+- **qwenbona** — separated heartbeat status from phase, both halves (#3223).
+- **seescer** — annotated the `core/observability` package (#3265).
+- **PyaaZz** — annotated the `core/routes` package (#3267).
+- **MochiGem** — converted the `core/config` string constant type aliases to
+  `type` statements (#3287).
+- **Iqbalez** — hardened the provider-latency reader against malformed records
+  (#3294).
+- **w3lld1** — defined the adapter cast aliases as types (#3246).
+- **mmaxjr** — made `bernstein doctor` report a missing `uv` as a failed check
+  instead of crashing with a raw traceback (#3258).
+- **octo-patch** — corrected the MiniMax price table and added its cache tiers
+  (#3261).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -515,7 +515,7 @@ nav:
           - Glossary: reference/GLOSSARY.md
       - Release notes:
           - Changelog: CHANGELOG.md
-          - v3.11.0: release-notes/v3.11.0.md
+          - v3.12.0: release-notes/v3.12.0.md
           - v3.11.0: release-notes/v3.11.0.md
           - v3.10.0: release-notes/v3.10.0.md
           - v3.9.0: release-notes/v3.9.0.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "3.11.0"
+version = "3.12.0"
 description = "Deterministic orchestrator for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40+ more). No model in the coordination loop, so parallel runs in per-task git worktrees replay byte-identically. Signed lineage plus an opt-in HMAC audit chain a reviewer checks offline, without rerunning it. Cluster mode, air-gap deploy."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/server.json
+++ b/server.json
@@ -7,19 +7,19 @@
     "url": "https://github.com/sipyourdrink-ltd/bernstein",
     "source": "github"
   },
-  "version": "3.11.0",
+  "version": "3.12.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "bernstein",
-      "version": "3.11.0",
+      "version": "3.12.0",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/sipyourdrink-ltd/bernstein:3.11.0",
+      "identifier": "ghcr.io/sipyourdrink-ltd/bernstein:3.12.0",
       "transport": {
         "type": "stdio"
       }

--- a/uv.lock
+++ b/uv.lock
@@ -338,7 +338,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "3.11.0"
+version = "3.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
Version bump for v3.12.0, produced by `scripts/bump_version.py 3.12.0` so `pyproject.toml`, `uv.lock`, `server.json` and `.plugin/plugin.json` move together.

## Contents

- Version 3.11.0 -> 3.12.0 across the four coupled files.
- `docs/release-notes/v3.12.0.md`, hand-written.
- mkdocs nav entry for the new notes. The nav listed `v3.11.0` twice; the duplicate line is replaced by the `v3.12.0` entry rather than left in place.
- Drops the stale `(in progress)` suffix from the `v3.11.0` notes heading.

No source changes.

## Release gate

- Milestone v3.12.0: 0 open issues, 35 closed. The last open bug (#3255) closed with #3314.
- `Nightly deep tests` dispatched on the `main` head this bump is cut from.
- The three non-bug issues left on the milestone (#3232, #3233, #3256) moved to v4.0.0 with their scope unchanged; #2554 remains on v4.0.0.

Merging this to `main` hands off to `auto-release.yml`, which tags `v3.12.0`, and then to `publish.yml` for PyPI, npm and the GitHub Release.

## Summary by Sourcery

Prepare the v3.12.0 release by updating version metadata and release documentation without changing source code.

Build:
- Bump project and plugin versions from 3.11.0 to 3.12.0 across pyproject, lockfile, server, and plugin metadata.

Documentation:
- Add release notes for v3.12.0 and link them in the MkDocs navigation.
- Update the v3.11.0 release notes heading to remove the stale "in progress" suffix.

Chores:
- Align coupled versioned files for the v3.12.0 release to support automated tagging and publication workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCP alias availability, heartbeat phases, improved worktree-layout handling, and enhanced agent lifecycle management.
  * Added WAL recovery and verification, receipt verification, and expanded testing support.
* **Bug Fixes**
  * Improved `--plan-only` behavior, TUI stability, provider data, and quality-gate enforcement.
* **Documentation**
  * Added comprehensive v3.12.0 release notes and updated release navigation.
* **Release**
  * Updated the application, plugin, server, package, and container versions to 3.12.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->