### PR TITLE
test(contract): stop one operation's drain outliving its own test in the Schemathesis sweep

### DIFF
--- a/tests/contract/test_task_server_schemathesis.py
+++ b/tests/contract/test_task_server_schemathesis.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING, Any
 import anyio
 import pytest
 import schemathesis
+from fastapi.testclient import TestClient
 from hypothesis import settings
 from schemathesis import checks as st_checks
 
@@ -108,6 +109,28 @@ _STREAMING_OPERATIONS = _streaming_operations()
 # unhandled-exception leaks against arbitrary Hypothesis-generated
 # request bodies.
 _CHECKS = [st_checks.not_a_server_error]
+
+
+@pytest.fixture(autouse=True)
+def _reset_server_mutable_state() -> Any:
+    """Undo the server-state mutations one operation's sweep leaves behind.
+
+    `_app` is built once at module scope and every parametrized operation
+    shares it, so a documented side effect outlives the test that caused it.
+    `POST /api/v1/drain` sets `app.state.draining` and nothing in the sweep
+    clears it; from that point on `GET /api/v1/ready`,
+    `GET /api/v1/health/ready` and `GET /api/v1/tasks/next/{role}` correctly
+    answer 503, which `not_a_server_error` reports as a server error. The
+    result is an order-dependent failure that says the readiness contract is
+    broken when it is being honoured.
+
+    Resetting per test is enough: Hypothesis runs its examples inside one test
+    function, and all of them drive the same operation, so contamination only
+    ever crosses a test boundary.
+    """
+    _app.state.draining = False
+    yield
+    _app.state.draining = False
 
 
 @schema.parametrize()
@@ -248,3 +271,54 @@ def test_streaming_operations_are_declared_in_the_schema() -> None:
     is legible.
     """
     assert _STREAMING_OPERATIONS, "no operation declares text/event-stream; the SSE routes lost their media type"
+
+
+# ---------------------------------------------------------------------------
+# Server-state isolation
+# ---------------------------------------------------------------------------
+
+
+_DRAIN_AWARE_READS = (
+    "/api/v1/ready",
+    "/api/v1/health/ready",
+)
+
+# The sweep ahead of this test has already spent the per-address request
+# budget, so a client on the default `testclient` address is answered 429 and
+# this test would be measuring the rate limiter instead of the drain contract.
+# Same reason the streaming probes each present a distinct peer; a separate
+# subnet keeps the two sets from consuming each other's budget.
+_DRAIN_PROBE_PEER = ("10.0.1.1", 1234)
+
+
+def test_drain_is_not_left_set_for_the_next_operation() -> None:
+    """A drain raised by one operation must not outlive its own test.
+
+    `_app` is shared by every parametrized operation, so before this was
+    pinned a single `POST /api/v1/drain` example turned every later
+    readiness and claim example into a 503 that `not_a_server_error` read as
+    a crash. The sweep reported the readiness contract broken at exactly the
+    moment it was being honoured, and which operations were hit depended on
+    ordering.
+
+    The first assertion is the regression: the autouse fixture must have
+    handed this test a server that is not draining, whatever ran before it.
+    The rest pins the contract that made the leak look like a defect --
+    while draining, a readiness probe is deliberately 503.
+    """
+    assert _app.state.draining is False, "a previous test left the shared app draining"
+
+    with TestClient(_app, client=_DRAIN_PROBE_PEER) as client:
+        assert client.post("/api/v1/drain").status_code == 200
+        assert _app.state.draining is True
+
+        for path in _DRAIN_AWARE_READS:
+            response = client.get(path)
+            assert response.status_code == 503, f"{path} answered {response.status_code} while draining"
+            assert response.json()["reason"] == "draining"
+
+        assert client.post("/api/v1/drain/cancel").status_code == 200
+        assert _app.state.draining is False
+
+        for path in _DRAIN_AWARE_READS:
+            assert client.get(path).status_code == 200, f"{path} stayed unready after the drain was cancelled"


### PR DESCRIPTION
The nightly `Schemathesis (deep, full sweep)` job failed on `main` at d9d60be4: 3 failed, 487 passed. All three failures are the same 503, and the 503 is correct behaviour.

```
FAILED test_no_unhandled_exceptions[GET /api/v1/tasks/next/{role}]
FAILED test_no_unhandled_exceptions[GET /api/v1/health/ready]
FAILED test_no_unhandled_exceptions[GET /api/v1/ready]

[503] {"status":"not_ready","reason":"draining"}
[503] {"detail":"Server is draining -- no new claims accepted"}
```

A draining server is supposed to report itself not ready and refuse new claims. The defect is that the server was draining.

## Cause

`_app` is built once at module scope and every parametrized operation shares it. `POST /api/v1/drain` sets `app.state.draining` (`src/bernstein/core/routes/drain.py:28`) and nothing in the sweep clears it.

`POST /api/v1/drain/cancel` is collected next, so on a lucky schedule the flag is cleared before the readiness operations run. But the cancel is itself a fuzzed operation subject to the per-address rate limiter the sweep has been spending all run, and once it is answered 429 the flag stays set for every operation after it. `not_a_server_error` then reports the readiness contract broken at exactly the moment it is being honoured, and which operations get named depends on where the limiter tripped.

That rate-limit interaction is not hypothetical: the first draft of the regression test below was itself answered 429 on the default `testclient` address after the sweep ahead of it.

## Change

An autouse fixture resets `_app.state.draining` around each test, so no operation depends on a later fuzzed operation happening to succeed in order to restore server state. Per test is sufficient — Hypothesis runs its examples inside one test function and all of them drive the same operation, so contamination only ever crosses a test boundary.

`test_drain_is_not_left_set_for_the_next_operation` asserts the precondition (each test is handed a server that is not draining, whatever ran before it) and pins the contract that made the leak look like a defect: while draining both readiness probes are deliberately 503 with `reason: draining`, and both return to 200 once the drain is cancelled. It presents its own peer address for the same reason the streaming probes each do, so it measures the drain contract rather than the limiter.

Test-only change. No source file is touched.

## Verification

- `pytest tests/contract/test_task_server_schemathesis.py` (smoke) — 94 passed, 405 skipped.
- `SCHEMATHESIS_PROFILE=deep pytest -k "drain or ready or next"` — 15 passed.
- `ruff check`, `ruff format --check` — clean.

The sweep is order- and limiter-dependent by nature, so the honest end-to-end verification is the nightly itself: `Nightly deep tests` will be re-dispatched on `main` after this merges and is expected green before v3.12.0 is tagged.

## Wider point

Any operation with a documented server-state side effect has this shape. Drain is the one the sweep has hit; the fixture is where the next one goes.

Closes #3319.

## Summary by Sourcery

Ensure Schemathesis contract tests isolate server drain state between operations to prevent order-dependent readiness failures.

Bug Fixes:
- Prevent draining state from one operation causing subsequent readiness and claim endpoints to return expected 503s that are misinterpreted as server errors in the sweep.

Tests:
- Add an autouse fixture that resets the shared app draining flag around each test to avoid cross-test state contamination.
- Add a regression test that verifies drain state is cleared before each test and asserts the readiness endpoints’ behaviour while draining and after drain cancellation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where readiness checks could remain unavailable after a drain operation was canceled.
  * Readiness endpoints now correctly return to a healthy status after draining ends.

* **Tests**
  * Added regression coverage to verify draining behavior and prevent state from carrying over between operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->