### PR TITLE
fix(cli): use Text.append instead of nonexistent Text.extend in agents match

### DIFF
--- a/src/bernstein/cli/commands/agents_cmd.py
+++ b/src/bernstein/cli/commands/agents_cmd.py
@@ -522,7 +522,7 @@ def agents_match(role: str, task_description: str) -> None:
     t.append("  Priority  ", style="dim")
     t.append(f"{match.priority}\n")
     t.append("  Tools     ", style="dim")
-    t.extend((", ".join(match.tools) if match.tools else "-", "\n\n"))
+    t.append(f"{', '.join(match.tools) if match.tools else '-'}\n\n")
     t.append("  Description\n", style="dim")
     t.append(f"    {match.description[:120]}\n")
 

--- a/tests/unit/test_agents_cmd_match.py
+++ b/tests/unit/test_agents_cmd_match.py
@@ -1,0 +1,68 @@
+"""Tests for `bernstein agents match` -- catalog-hit rendering (issue #3310).
+
+`agents_match` renders a `rich.text.Text` summary when the catalog registry
+finds a matching agent. Drive the command through its actual CLI surface
+(not by importing the render logic directly) so a regression in the Text
+API usage is caught the way an operator would hit it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from bernstein.agents.catalog import CatalogAgent, CatalogRegistry
+from bernstein.cli.commands.agents_cmd import agents_group
+
+
+def _registry_with_agent(**overrides: object) -> CatalogRegistry:
+    defaults: dict[str, object] = {
+        "name": "BackendBot",
+        "role": "backend",
+        "description": "Backend engineer specializing in REST APIs.",
+        "system_prompt": "You are a specialist.",
+        "id": "test:backend-bot",
+        "tools": ["pytest", "ruff"],
+        "priority": 10,
+        "source": "catalog",
+    }
+    defaults.update(overrides)
+    registry = CatalogRegistry()
+    registry.register_agent(CatalogAgent(**defaults))  # type: ignore[arg-type]
+    return registry
+
+
+def test_agents_match_renders_catalog_hit_without_error(tmp_path: Path) -> None:
+    """A catalog hit must render successfully instead of raising AttributeError.
+
+    Reproduces issue #3310: the catalog-hit rendering path called
+    `Text.extend(...)`, which does not exist on `rich.text.Text`, so any
+    `bernstein agents match` invocation that found a catalog agent crashed.
+    """
+    runner = CliRunner()
+    registry = _registry_with_agent()
+
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        with patch.object(CatalogRegistry, "default", classmethod(lambda cls: registry)):
+            result = runner.invoke(agents_group, ["match", "--role", "backend"])
+
+    assert result.exit_code == 0, result.output
+    assert result.exception is None
+    assert "BackendBot" in result.output
+    assert "pytest, ruff" in result.output
+
+
+def test_agents_match_renders_catalog_hit_with_no_tools(tmp_path: Path) -> None:
+    """The tools line falls back to '-' when the matched agent has none."""
+    runner = CliRunner()
+    registry = _registry_with_agent(name="NoToolsBot", tools=[])
+
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        with patch.object(CatalogRegistry, "default", classmethod(lambda cls: registry)):
+            result = runner.invoke(agents_group, ["match", "--role", "backend"])
+
+    assert result.exit_code == 0, result.output
+    assert result.exception is None
+    assert "NoToolsBot" in result.output


### PR DESCRIPTION
## Summary

`bernstein agents match` crashed with `AttributeError` on any catalog hit: the rendering path called `Text.extend(...)`, a method `rich.text.Text` does not expose (it has `append`, `append_text`, `append_tokens`, `join`). The no-hit path never reached the call, so it shipped without coverage.

- Replace the call with `Text.append`, matching every other line in the same block.
- Add tests that drive `bernstein agents match` through the catalog-hit branch (with and without tools), which previously had no coverage.

## User-visible change

`bernstein agents match --role <role>` no longer crashes when the role matches a catalog agent; it renders the match panel as intended.

## Test plan

- [x] `pytest tests/unit -k "agents_cmd or agents_match"` fails on unmodified code with the reported `AttributeError`, passes after the fix
- [x] `ruff check` / `ruff format --check` on changed files
- [x] `mypy` on changed files

Closes #3310

## Summary by Sourcery

Fix the CLI agents match command to correctly render catalog agent matches without crashing and add regression tests for the catalog-hit rendering paths.

Bug Fixes:
- Prevent agents match from raising AttributeError by using a valid Text API when rendering tools for a catalog agent match.

Tests:
- Add CLI-level tests that exercise bernstein agents match through catalog-hit branches, including agents with and without tools, to ensure rendering succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting of agent-match results, preserving the tools list and spacing.
  * Added a clear `-` fallback when matched agents have no tools.

* **Tests**
  * Added coverage for successful agent-match output and no-tools scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->