### PR TITLE
fix(cluster): worker heartbeat loop backs off on re-registration failure

### DIFF
--- a/src/bernstein/cli/commands/worker_cmd.py
+++ b/src/bernstein/cli/commands/worker_cmd.py
@@ -675,15 +675,25 @@ class WorkerLoop:
 
             while self._running:
                 node_id, last_heartbeat = self._do_heartbeat(client, node_id, heartbeat_s, last_heartbeat)
-                if node_id is None:
-                    continue
 
-                if self.available_slots > 0:
+                # Reap finished agents into the pending-report queue on every
+                # cycle regardless of node_id, so an agent that exits while
+                # re-registration is retrying still gets drained below instead
+                # of being stranded until node_id recovers.
+                self._reap_finished()
+
+                # A None node_id here means the heartbeat failed and the
+                # re-registration attempt that follows it also failed: there is
+                # no live node to claim tasks under. Still fall through to the
+                # same poll-interval wait the success path takes below, rather
+                # than looping straight back into another _do_heartbeat call.
+                # Retrying re-registration with no wait between attempts busy
+                # loops for as long as the server stays unreachable (#3309).
+                if node_id is not None and self.available_slots > 0:
                     self._claim_available_tasks(client, node_id)
 
-                # Drive reaped agents to a terminal state on the server. Reading
-                # available_slots above already reaped finished agents into the
-                # pending queue.
+                # Drive reaped agents to a terminal state on the server. This
+                # does not require a live node_id.
                 self._report_finished(client)
 
                 if self._wake.wait(timeout_s=poll_s) == WakeReason.ABORT:

--- a/tests/unit/test_worker_cmd_heartbeat_backoff.py
+++ b/tests/unit/test_worker_cmd_heartbeat_backoff.py
@@ -1,0 +1,94 @@
+"""Worker heartbeat loop backs off on repeated re-registration failure (#3309).
+
+Before this fix, when ``_do_heartbeat`` returned ``None`` (heartbeat failed and
+the subsequent re-registration attempt also failed), ``WorkerLoop.run``
+executed ``continue`` -- sending control straight back to the top of the
+``while self._running`` loop without ever reaching
+``self._wake.wait(timeout_s=poll_s)``, the same interval wait the success path
+takes. As long as re-registration kept failing, the worker spun on
+``_do_heartbeat`` at full speed instead of backing off, hammering the server
+with back-to-back requests.
+"""
+
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from bernstein.cli.commands import worker_cmd
+from bernstein.cli.commands.worker_cmd import PollConfig, WorkerLoop
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# Real wall-clock window for the reproduction. Short enough to keep the test
+# fast; long enough to give a correctly-throttled loop (~0.1s poll interval)
+# several real iterations while giving a busy loop plenty of room to run away.
+_WINDOW_S = 0.5
+_POLL_INTERVAL_MS = 100
+
+# A correctly-throttled loop manages roughly _WINDOW_S / (poll interval in s)
+# iterations (~5 here) plus scheduling slack. A busy loop produces many
+# thousands of calls in the same window, so this bound cleanly separates the
+# two behaviours without being timing-sensitive.
+_MAX_EXPECTED_ATTEMPTS = 60
+
+
+def _make_loop(tmp_path: Path) -> WorkerLoop:
+    return WorkerLoop(
+        server_url="http://central:8052",
+        name="test-node",
+        auth_token="secret-token",
+        adapter="claude",
+        workdir=tmp_path,
+        poll_config=PollConfig(poll_interval_ms=_POLL_INTERVAL_MS, heartbeat_interval_ms=15_000),
+    )
+
+
+class TestHeartbeatFailureBacksOff:
+    def test_forced_none_heartbeat_does_not_busy_loop(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Repeated re-registration failure waits the poll interval between
+        attempts instead of re-entering ``_do_heartbeat`` immediately."""
+        loop = _make_loop(tmp_path)
+
+        # Skip workspace preflight, registration, and enrolment -- not what
+        # this test exercises -- and keep signal.signal a no-op since run()
+        # is driven from a background thread here (signal.signal only works
+        # on the main thread).
+        monkeypatch.setattr(loop, "_workspace_setup_error", lambda: None)
+        monkeypatch.setattr(loop, "_register_with_retry", lambda client: "node-1")
+        monkeypatch.setattr(loop, "_enrol", lambda client: None)
+        monkeypatch.setattr(worker_cmd.signal, "signal", lambda *_a, **_k: None)
+
+        attempts = 0
+
+        def _forced_none_heartbeat(
+            client: httpx.Client, node_id: str, heartbeat_s: float, last_heartbeat: float
+        ) -> tuple[str | None, float]:
+            nonlocal attempts
+            attempts += 1
+            # Re-registration failed: no valid node_id, timestamp untouched --
+            # exactly what the real failure path returns.
+            return None, last_heartbeat
+
+        monkeypatch.setattr(loop, "_do_heartbeat", _forced_none_heartbeat)
+
+        thread = threading.Thread(target=loop.run, daemon=True)
+        thread.start()
+        time.sleep(_WINDOW_S)
+        loop._running = False
+        loop._wake.signal_abort()
+        thread.join(timeout=5.0)
+
+        assert not thread.is_alive(), "worker loop thread did not stop after abort"
+        assert attempts <= _MAX_EXPECTED_ATTEMPTS, (
+            f"_do_heartbeat was called {attempts} times in {_WINDOW_S}s -- the "
+            "re-registration-failure path is not waiting the poll interval "
+            "between retries (busy loop)."
+        )


### PR DESCRIPTION
## Summary

- `WorkerLoop.run`'s poll loop looped straight back into `_do_heartbeat` when it returned `None`, skipping the poll-interval wait the success path takes. Once re-registration started failing, the worker spun on the heartbeat call without ever backing off, sending back-to-back requests to the server for as long as the failure persisted.
- The failure path now falls through to the same poll-interval wait as the success path before retrying, instead of re-entering `_do_heartbeat` immediately.
- Reaping finished agents now runs every cycle regardless of `node_id`, so an agent that finishes while re-registration is retrying still gets reported instead of being stranded until `node_id` recovers.

## User-visible change

A worker whose central-server connection is flaky (heartbeat + re-registration both failing) now retries at the configured poll interval instead of busy-looping. No config or CLI surface changes.

## Test plan

- [x] Added `tests/unit/test_worker_cmd_heartbeat_backoff.py`, which forces `_do_heartbeat` to return `None` and counts calls over a bounded real-time window. Fails on unmodified code (millions of calls in 0.5s); passes after the fix (~handful of calls, bounded by the poll interval).
- [x] `uv run pytest tests/unit -k "worker_cmd or heartbeat_backoff"` — 30 passed
- [x] `uv run ruff check` / `uv run ruff format --check` on touched files — clean
- [x] `uv run mypy src/bernstein/cli/commands/worker_cmd.py` — no new errors (one pre-existing advisory error, unrelated to this change, confirmed present on `origin/main` before this fix)

Closes #3309

## Summary by Sourcery

Ensure the worker heartbeat loop backs off on repeated re-registration failures instead of busy-looping against an unreachable central server.

Bug Fixes:
- Make the worker heartbeat/re-registration failure path respect the configured poll interval instead of retrying in a tight loop.
- Ensure finished agents are reaped and reported every cycle even when node re-registration is failing and node_id is unavailable.

Tests:
- Add a unit test that forces heartbeat to return None and verifies the worker does not busy-loop, bounding retry attempts over a real-time window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Completed tasks are now reported even when node re-registration is temporarily unavailable.
  * Workers no longer repeatedly retry registration without respecting the configured polling interval.
  * Tasks are claimed only when the worker has a valid node connection.

* **Tests**
  * Added coverage to verify that repeated heartbeat failures do not cause excessive retry loops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->