### PR TITLE
fix(tasks): correct three typed-interface mismatches in the tasks package

### DIFF
--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -3229,6 +3229,20 @@ def _cleanup_batch_session(orch: Any, session: AgentSession) -> None:
         release_files(session.id)
 
 
+def _session_files_changed(orch: Any, session: AgentSession) -> int:
+    """Return the changed-file count *session*'s agent last reported.
+
+    ``AgentSession`` carries no changed-file counter: the agent reports one
+    in its heartbeat, which the signal manager persists per session. Falls
+    back to 0 when the agent never wrote a heartbeat.
+    """
+    signal_mgr = getattr(orch, "_signal_mgr", None)
+    if signal_mgr is None:
+        return 0
+    heartbeat = signal_mgr.read_heartbeat(session.id)
+    return int(heartbeat.files_changed) if heartbeat is not None else 0
+
+
 def _record_ab_test_outcome(
     orch: Any,
     task: Task,
@@ -3252,7 +3266,7 @@ def _record_ab_test_outcome(
             model=model_map[task.id],
             session_id=session.id,
             tokens_used=session.tokens_used,
-            files_changed=session.files_changed,
+            files_changed=_session_files_changed(orch, session),
             status="completed" if janitor_passed else "failed",
             duration_s=time.time() - session.spawn_ts,
         )

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -814,9 +814,7 @@ def _enqueue_dlq_if_workdir(
         synth = IncidentSynthesizer(workdir)
         case = synth.synthesize_from_dlq_entry(entry)
         if case is not None:
-            existing = synth._load_existing_ids()
-            if case.id not in existing:
-                synth._write_case(case)
+            synth.emit_case(case)
     except Exception as exc:
         logger.debug("incident synthesiser skipped for task %s: %s", task.id, exc)
 

--- a/src/bernstein/core/tasks/task_store_core.py
+++ b/src/bernstein/core/tasks/task_store_core.py
@@ -1089,6 +1089,10 @@ class TaskStore:
             "claimed_by_session": task.claimed_by_session,
             "parent_session_id": task.parent_session_id,
             "subtask_wait_started_at": task.subtask_wait_started_at,
+            # The parent agent's context summary is what ties a subtask back to
+            # the exploration that produced it; omitting it here rebuilt every
+            # subtask without its parent context after a replay.
+            "parent_context": task.parent_context,
             # retry bookkeeping (typed source of truth).
             "retry_count": task.retry_count,
             "max_retries": task.max_retries,

--- a/src/bernstein/eval/incident_synthesizer.py
+++ b/src/bernstein/eval/incident_synthesizer.py
@@ -238,6 +238,28 @@ class IncidentSynthesizer:
         """
         return self._synthesize_eval_case(entry)
 
+    def emit_case(self, case: IncidentEvalCase, *, dry_run: bool = False) -> IncidentSyncResult:
+        """Persist a single synthesised case, deduping against the corpus.
+
+        The one-case counterpart to :meth:`sync`, for callers that already
+        hold a case from ``synthesize_from_*`` and want it written with the
+        same dedup rules a full pass would apply - both the content-hash and
+        the source-incident axis, so a re-observed incident does not land
+        twice.
+
+        Args:
+            case: The case to write.
+            dry_run: When True, nothing is written; the result still reports
+                what would have happened.
+
+        Returns:
+            An :class:`IncidentSyncResult` covering just this case.
+        """
+        existing_ids, existing_sources = self._load_existing_state()
+        result = IncidentSyncResult(dry_run=dry_run)
+        self._emit(case, existing_ids, existing_sources, result, dry_run=dry_run)
+        return result
+
     def synthesize_from_ci_postmortem(self, pm: CIFailurePostmortem) -> IncidentEvalCase | None:
         """Build a single eval case from a CI-failure post-mortem.
 

--- a/tests/unit/test_task_lifecycle.py
+++ b/tests/unit/test_task_lifecycle.py
@@ -5,14 +5,17 @@
 from __future__ import annotations
 
 import collections
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import httpx
+from bernstein.core.ab_test_results import ABTestStore
 from bernstein.core.convergence_guard import ConvergenceGuard
 from bernstein.core.models import (
+    AgentHeartbeat,
     AgentSession,
     CompletionSignal,
     Complexity,
@@ -27,6 +30,7 @@ from bernstein.core.task_lifecycle import (
     _enqueue_paired_test_task,
     _has_llm_judge_signal,
     _move_backlog_ticket,
+    _record_ab_test_outcome,
     _verify_via_janitor,
     claim_and_spawn_batches,
     prepare_speculative_warm_pool,
@@ -35,6 +39,7 @@ from bernstein.core.task_lifecycle import (
 )
 from bernstein.core.warm_pool import WarmPool, WarmPoolConfig
 
+from bernstein.core.agents.agent_signals import AgentSignalManager
 from bernstein.core.knowledge.task_graph import TaskGraph
 
 
@@ -1507,3 +1512,60 @@ def test_repeated_dead_letter_does_not_duplicate_the_incident_case(tmp_path: Pat
 
     written = sorted(_incident_cases_dir(tmp_path).glob("inc-*.yaml"))
     assert len(written) == 1, f"expected deduplication to one case, found {[p.name for p in written]}"
+
+
+def test_ab_test_outcome_records_the_files_changed_the_agent_reported(
+    tmp_path: Path,
+    make_task: Any,
+) -> None:
+    """The persisted A/B record carries the agent's own changed-file count.
+
+    files_changed is one of the three axes an A/B comparison is decided on.
+    Recording is fail-open, so reading it from the wrong place costs every
+    A/B record silently rather than raising.
+    """
+    task = make_task(id="T-ab", title="Tune the router")
+    session = _session_for(task.id, exit_code=0)
+
+    signal_mgr = AgentSignalManager(tmp_path)
+    signal_mgr.write_heartbeat(
+        session.id,
+        AgentHeartbeat(timestamp=time.time(), files_changed=7, status="working"),
+    )
+
+    orch = SimpleNamespace(
+        _config=SimpleNamespace(ab_test=True),
+        _ab_split_tracker={task.id: "sonnet"},
+        _workdir=tmp_path,
+        _signal_mgr=signal_mgr,
+    )
+
+    _record_ab_test_outcome(orch, task, session, janitor_passed=True)
+
+    records = ABTestStore(tmp_path).load()
+    assert len(records) == 1, "expected exactly one A/B outcome record"
+    assert records[0].files_changed == 7
+    assert records[0].status == "completed"
+
+
+def test_ab_test_outcome_defaults_files_changed_when_no_heartbeat(
+    tmp_path: Path,
+    make_task: Any,
+) -> None:
+    """A session that never reported a heartbeat still records an outcome."""
+    task = make_task(id="T-ab-nohb", title="Tune the router")
+    session = _session_for(task.id, exit_code=0)
+
+    orch = SimpleNamespace(
+        _config=SimpleNamespace(ab_test=True),
+        _ab_split_tracker={task.id: "sonnet"},
+        _workdir=tmp_path,
+        _signal_mgr=AgentSignalManager(tmp_path),
+    )
+
+    _record_ab_test_outcome(orch, task, session, janitor_passed=False)
+
+    records = ABTestStore(tmp_path).load()
+    assert len(records) == 1, "expected exactly one A/B outcome record"
+    assert records[0].files_changed == 0
+    assert records[0].status == "failed"

--- a/tests/unit/test_task_lifecycle.py
+++ b/tests/unit/test_task_lifecycle.py
@@ -23,6 +23,7 @@ from bernstein.core.models import (
 )
 from bernstein.core.orchestrator import TickResult
 from bernstein.core.task_lifecycle import (
+    _enqueue_dlq_if_workdir,
     _enqueue_paired_test_task,
     _has_llm_judge_signal,
     _move_backlog_ticket,
@@ -1456,3 +1457,53 @@ def test_completion_survives_evidence_gate_exception(tmp_path: Path, make_task: 
 
     assert result.verified == [task.id]
     orch._spawner.cleanup_worktree.assert_called_once_with(session.id)
+
+
+def _incident_cases_dir(workdir: Path) -> Path:
+    """Return the corpus directory IncidentSynthesizer writes cases into."""
+    return workdir / "src" / "bernstein" / "eval" / "cases" / "incidents"
+
+
+def test_dead_lettered_task_writes_an_incident_eval_case(tmp_path: Path, make_task: Any) -> None:
+    """A task that exhausts its retry budget leaves an incident eval case on disk.
+
+    Reaching the dead-letter queue is the trigger for synthesising a
+    regression case from the failure. The synthesis step is fail-open, so a
+    broken call into the synthesiser costs the corpus every terminal failure
+    without surfacing anything louder than a debug line.
+    """
+    task = make_task(id="T-dlq-synth", title="Stabilize parser", role="backend")
+
+    _enqueue_dlq_if_workdir(
+        workdir=tmp_path,
+        task=task,
+        retry_count=3,
+        reason="max_retries_exceeded",
+        original_error="AssertionError: parser returned None",
+    )
+
+    written = sorted(_incident_cases_dir(tmp_path).glob("inc-*.yaml"))
+    assert len(written) == 1, f"expected one incident eval case, found {[p.name for p in written]}"
+    body = written[0].read_text(encoding="utf-8")
+    assert "Stabilize parser" in body
+    assert "max_retries_exceeded" in body
+
+
+def test_repeated_dead_letter_does_not_duplicate_the_incident_case(tmp_path: Path, make_task: Any) -> None:
+    """The same terminal failure twice yields exactly one incident eval case.
+
+    Cases are content-addressed, so a re-run of the same failure must be
+    recognised as already present rather than written a second time.
+    """
+    task = make_task(id="T-dlq-dup", title="Stabilize parser", role="backend")
+    kwargs: dict[str, Any] = {
+        "retry_count": 3,
+        "reason": "max_retries_exceeded",
+        "original_error": "AssertionError: parser returned None",
+    }
+
+    _enqueue_dlq_if_workdir(workdir=tmp_path, task=task, **kwargs)
+    _enqueue_dlq_if_workdir(workdir=tmp_path, task=task, **kwargs)
+
+    written = sorted(_incident_cases_dir(tmp_path).glob("inc-*.yaml"))
+    assert len(written) == 1, f"expected deduplication to one case, found {[p.name for p in written]}"

--- a/tests/unit/test_task_store.py
+++ b/tests/unit/test_task_store.py
@@ -21,6 +21,7 @@ def _task_request(
     scope: str = "medium",
     complexity: str = "medium",
     depends_on: list[str] | None = None,
+    parent_context: str | None = None,
 ) -> Any:
     """Build a create-task request object with the TaskCreate attributes TaskStore expects."""
     return SimpleNamespace(
@@ -41,6 +42,7 @@ def _task_request(
         batch_eligible=False,
         completion_signals=[],
         slack_context=None,
+        parent_context=parent_context,
     )
 
 
@@ -109,6 +111,34 @@ async def test_replay_jsonl_reconstructs_latest_task_state(tmp_path: Path) -> No
     assert restored is not None
     assert restored.status == TaskStatus.CLAIMED
     assert restored.version == 1
+
+
+@pytest.mark.anyio
+async def test_replay_jsonl_preserves_subtask_parent_context(tmp_path: Path) -> None:
+    """A subtask's parent_context survives the JSONL write/replay round-trip.
+
+    The parent agent's context summary is the only thing tying a subtask to
+    the exploration that produced it. If the serialiser drops it, the subtask
+    is silently rebuilt without that context after a restart and the spawned
+    agent starts cold.
+    """
+    jsonl_path = tmp_path / "runtime" / "tasks.jsonl"
+    store = TaskStore(jsonl_path)
+    parent_context = "Parent explored src/parser.py and chose a recursive-descent design."
+
+    task = await store.create(_task_request(parent_context=parent_context))
+    await store.flush_buffer()
+
+    in_memory = store.get_task(task.id)
+    assert in_memory is not None
+    assert in_memory.parent_context == parent_context
+
+    replayed = TaskStore(jsonl_path)
+    replayed.replay_jsonl()
+    restored = replayed.get_task(task.id)
+
+    assert restored is not None
+    assert restored.parent_context == parent_context
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Three typed-interface mismatches in the tasks package, each a real runtime
defect on its own path rather than an annotation gap. All three sit behind
fail-open guards, so none of them raised in production - they silently
dropped the work they were supposed to do. One commit per issue.

## Closes #3315 - parent_context dropped when serialising a task record

`_task_to_record` built a `TaskRecord` without the `parent_context` key the
TypedDict declares as required. The reader uses `.get()`, so a subtask
persisted and replayed came back with no parent context, and the agent
spawned for it started without the exploration that produced its task.

Populated the field at the construction site, and covered the write/replay
round-trip.

## Closes #3316 - dead-lettered tasks never produced an incident eval case

The dead-letter path called `IncidentSynthesizer._load_existing_ids`, which
does not exist. Synthesis is deliberately fail-open, so the `AttributeError`
was swallowed as a debug line and every terminal failure was dropped instead
of becoming a regression case.

`_load_existing_state` is not a drop-in for the missing name - it returns a
pair of sets, so a rename alone would have made the membership test
meaningless and rewritten the case on every failure. Added `emit_case` as
the single-case counterpart to `sync()`, applying both dedup axes and the
severity metric, and routed the dead-letter path through it. This also stops
`task_lifecycle` reaching into the synthesiser's private methods.

## Closes #3317 - A/B outcomes were never recorded

The A/B outcome path read `files_changed` off `AgentSession`, which declares
no such attribute. Recording is fail-open too, so no A/B record was written
at all - losing the tokens, duration and status axes as well, not just the
file count.

An agent reports its changed-file count in its heartbeat, which the signal
manager persists per session. Reading it from there, defaulting to 0 when the
agent never wrote a heartbeat.

## User-visible changes

- Subtasks keep their parent context across a server restart.
- Terminal task failures now land in the incident eval corpus, deduplicated.
- `ab_test` runs now produce records in `.sdd/metrics/ab_test_results.jsonl`.

CHANGELOG.md intentionally untouched to avoid collisions with parallel PRs.

## Verification

Each fix has a test that fails on unmodified code and passes after:

| Issue | Test |
|---|---|
| #3315 | `test_replay_jsonl_preserves_subtask_parent_context` |
| #3316 | `test_dead_lettered_task_writes_an_incident_eval_case`, `test_repeated_dead_letter_does_not_duplicate_the_incident_case` |
| #3317 | `test_ab_test_outcome_records_the_files_changed_the_agent_reported`, `test_ab_test_outcome_defaults_files_changed_when_no_heartbeat` |

- `pytest tests/unit -k task_lifecycle` - 81 passed
- `pytest` across task_store, ab_test, agent_signals, heartbeat and incident
  synthesizer suites - 126 passed
- `ruff check` / `ruff format --check` clean on all touched files
- `mypy` clean on all touched source files
