### PR TITLE
fix(cli): resolve undo audit logging via its canonical module path

### DIFF
--- a/src/bernstein/cli/commands/undo_cmd.py
+++ b/src/bernstein/cli/commands/undo_cmd.py
@@ -91,24 +91,31 @@ def _execute_reverts(commits: list[tuple[str, str]]) -> int:
 
 
 def _log_undo_audit(task_id: str | None, revert_all: bool, success_count: int) -> None:
-    """Log undo action to audit trail (best-effort)."""
-    with suppress(Exception):
-        from bernstein.core.lifecycle import get_audit_log
+    """Log undo action to audit trail (best-effort).
 
-        audit = get_audit_log()
-        if audit:
-            audit.log(
-                event_type="git.undo",
-                actor="user",
-                resource_type="session",
-                resource_id=task_id or "all",
-                details={
-                    "action": "revert",
-                    "commit_count": success_count,
-                    "task_id": task_id,
-                    "revert_all": revert_all,
-                },
-            )
+    The import below must resolve for any correctly-installed bernstein
+    package, so it is allowed to raise if it doesn't - that would signal a
+    broken install, not a normal runtime condition. Only the write itself is
+    best-effort: a misbehaving audit backend must not fail the undo.
+    """
+    from bernstein.core.tasks.lifecycle import get_audit_log
+
+    audit = get_audit_log()
+    if audit is None:
+        return
+    with suppress(Exception):
+        audit.log(
+            event_type="git.undo",
+            actor="user",
+            resource_type="session",
+            resource_id=task_id or "all",
+            details={
+                "action": "revert",
+                "commit_count": success_count,
+                "task_id": task_id,
+                "revert_all": revert_all,
+            },
+        )
 
 
 def _run_post_revert_tests() -> None:

--- a/tests/unit/cli/test_undo_cmd.py
+++ b/tests/unit/cli/test_undo_cmd.py
@@ -1,0 +1,73 @@
+"""Tests for ``bernstein.cli.commands.undo_cmd`` audit logging.
+
+``_log_undo_audit`` must append a ``git.undo`` entry to whichever ``AuditLog``
+is currently wired via ``bernstein.core.tasks.lifecycle.set_audit_log``. It
+gets there through ``get_audit_log``, which the module previously imported
+from ``bernstein.core.lifecycle`` - a compatibility alias
+(``bernstein/core/lifecycle/__init__.py`` re-points
+``sys.modules["bernstein.core.lifecycle"]`` at the real
+``bernstein.core.tasks.lifecycle`` module) rather than the module's actual
+home. The alias keeps this working at runtime, but static analysis can't see
+through it (``mypy`` flags ``attr-defined`` on the import), and the
+surrounding ``contextlib.suppress(Exception)`` would have silently eaten any
+future failure to resolve it. These tests pin the observable behavior -
+importing from the canonical module and writing the audit entry - so a
+regression here is caught instead of swallowed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from bernstein.cli.commands.undo_cmd import _log_undo_audit
+from bernstein.core.tasks.lifecycle import set_audit_log
+
+
+def test_log_undo_audit_writes_entry() -> None:
+    """undo must append a ``git.undo`` entry to the wired audit log."""
+    mock_audit = MagicMock()
+    set_audit_log(mock_audit)
+    try:
+        _log_undo_audit("task-123", False, 2)
+    finally:
+        set_audit_log(None)
+
+    assert mock_audit.log.called, "undo did not write an audit entry"
+    _args, kwargs = mock_audit.log.call_args
+    assert kwargs["event_type"] == "git.undo"
+    assert kwargs["resource_id"] == "task-123"
+    assert kwargs["details"]["commit_count"] == 2
+    assert kwargs["details"]["revert_all"] is False
+
+
+def test_log_undo_audit_writes_entry_for_revert_all() -> None:
+    """The ``--all`` path logs too, with ``revert_all`` reflected in details."""
+    mock_audit = MagicMock()
+    set_audit_log(mock_audit)
+    try:
+        _log_undo_audit(None, True, 5)
+    finally:
+        set_audit_log(None)
+
+    assert mock_audit.log.called, "undo --all did not write an audit entry"
+    _args, kwargs = mock_audit.log.call_args
+    assert kwargs["resource_id"] == "all"
+    assert kwargs["details"]["commit_count"] == 5
+    assert kwargs["details"]["revert_all"] is True
+
+
+def test_log_undo_audit_noop_when_no_audit_log_wired() -> None:
+    """No audit log configured means no crash and simply nothing to write."""
+    set_audit_log(None)  # ensure clean baseline
+    _log_undo_audit("task-789", False, 1)  # must not raise
+
+
+def test_log_undo_audit_swallows_backend_failure() -> None:
+    """A misbehaving audit backend must not fail the undo command itself."""
+    mock_audit = MagicMock()
+    mock_audit.log.side_effect = RuntimeError("audit backend unavailable")
+    set_audit_log(mock_audit)
+    try:
+        _log_undo_audit("task-999", False, 1)  # must not raise
+    finally:
+        set_audit_log(None)


### PR DESCRIPTION
## Summary

- `undo_cmd._log_undo_audit` imported `get_audit_log` from `bernstein.core.lifecycle`, an internal compatibility alias for `bernstein.core.tasks.lifecycle`, rather than the function's home module. The alias resolves correctly at runtime, but static analysis can't see through it (mypy flagged `attr-defined` on the import), and the surrounding `contextlib.suppress(Exception)` wrapped the import too, so any future failure to resolve it would have been swallowed silently instead of surfacing.
- Import from the canonical module directly, and narrow the `suppress` to cover only the audit write itself (a misbehaving audit backend should not fail the undo command) rather than the import.

## User-visible changes

None expected — the alias already resolved to the same function, so undo's audit-write behavior is unchanged. This closes a static-analysis gap and removes a latent silent-failure mode in the import.

## Test plan

- [x] `pytest tests/unit -k "undo"` — new regression coverage for `_log_undo_audit` (writes an entry, `--all` path, no-op when no audit log is wired, backend failure doesn't propagate)
- [x] `mypy src/bernstein/cli/commands/undo_cmd.py` — was 1 `attr-defined` error, now clean
- [x] `ruff check` / `ruff format --check` on changed files

Closes #3308

## Summary by Sourcery

Ensure undo CLI audit logging relies on the canonical lifecycle module and only treats the audit write as best-effort.

Enhancements:
- Import undo audit logging utilities from the canonical bernstein.core.tasks.lifecycle module to avoid silent import failures and static-analysis issues.

Tests:
- Add unit tests for _log_undo_audit covering normal writes, --all behavior, absence of an audit log, and backend failures being swallowed.