### PR TITLE
fix(ci): guarantee every PR head gets a review-bot-ack conclusion

### DIFF
--- a/.github/workflows/review-bot-ack-publish.yml
+++ b/.github/workflows/review-bot-ack-publish.yml
@@ -31,19 +31,35 @@ name: Review-bot acknowledgement publisher
 # Failing closed has one exception, and it is not a weakening of the rule.
 # A `cancelled` gate run is not a gate that said no; it is a gate that was
 # superseded before it could say anything, and a run with no verdict must not
-# write one. The job condition drops those, and a currency check below drops
+# write one. The `publish` job drops those, and a currency check below drops
 # any other publisher that a newer gate run has already overtaken. Both are
 # necessary because publishers queue for runners, so the order they write in
 # is not the order the gates concluded in. See the job comment for the
 # incident that established this.
+#
+# Standing down has to be complementary to publishing, and it was not (#3313).
+# The currency check silenced every publisher that was not the newest for the
+# head, and the newest was then sometimes one that would never publish, so
+# nothing wrote the context at all. The `republish` job below is the other
+# half: whenever the head is about to be left with no writer, it re-dispatches
+# the gate instead of standing down silently.
 
 on:  # zizmor: ignore[dangerous-triggers]
   workflow_run:
     workflows: ["Review-bot acknowledgement gate"]
     types: [completed]
 
+# Keyed on the triggering run, not just the head SHA.
+#
+# A head collects several gate runs and therefore several publishers. Sharing
+# one group across them made the group a one-deep queue - `cancel-in-progress`
+# is false, so a third arrival cancels the pending second - which silently
+# discarded publishers. That serialisation bought nothing once the currency
+# check landed: at most one publisher per head decides to write, so there is
+# no upsert race left to prevent, and cancelling the others can only lose the
+# one write that mattered.
 concurrency:
-  group: review-bot-ack-publish-${{ github.event.workflow_run.head_sha }}
+  group: review-bot-ack-publish-${{ github.event.workflow_run.head_sha }}-${{ github.event.workflow_run.id }}
   cancel-in-progress: false
 
 permissions: {}
@@ -52,13 +68,20 @@ jobs:
   publish:
     name: review-bot-ack-publisher
     # merge_group runs of the gate publish their own context in-repo, where
-    # the token is already writable. Only pull-request runs need this hop.
+    # the token is already writable. Only pull-request runs need this hop -
+    # and `pull_request_review` is one of them. It was omitted here, and a
+    # fork's `pull_request_review` gate run gets exactly the same read-only
+    # token as its `pull_request` run: PR #3293's run 30655244121 passed at
+    # 18:28:48Z, 403'd on its own in-job publish, and had no publisher to
+    # fall back to, so the head carried no context until the pull request was
+    # closed and reopened (#3313).
     #
     # A cancelled gate run publishes nothing at all. It has no verdict: it was
     # superseded before it could reach one, which is not the same as failing.
     # `review-bot-ack.yml` already refuses to publish from a cancelled job for
     # exactly this reason, and the publisher has to honour the same rule or it
-    # reintroduces the problem one hop later.
+    # reintroduces the problem one hop later. The `republish` job below covers
+    # the case this leaves open.
     #
     # It is not enough to rely on the newer run overwriting the older verdict.
     # Publishers queue, so their execution order is not their trigger order.
@@ -69,7 +92,8 @@ jobs:
     # requests were blocked this way at once, and the only visible cause was a
     # failure on work that had already passed.
     if: >-
-      github.event.workflow_run.event == 'pull_request' &&
+      (github.event.workflow_run.event == 'pull_request' ||
+       github.event.workflow_run.event == 'pull_request_review') &&
       github.event.workflow_run.conclusion != 'cancelled'
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -113,7 +137,16 @@ jobs:
       # one. If a newer gate run exists for this head SHA, this publisher is
       # stale by definition and stays quiet: the newer run has its own
       # publisher and a better answer.
-      - name: Stand down if a newer gate run exists for this head
+      #
+      # "Newer" has to mean newer *and able to publish*. Comparing ids alone
+      # made this publisher defer to runs that would never write anything -
+      # a cancelled run, or (before the condition above was widened) a
+      # `pull_request_review` one - and the head was then left with no writer
+      # at all. On PR #3287 the survivor of a concurrency race carried a lower
+      # id than the run that was cancelled, so id order and verdict order
+      # disagreed outright. The rule lives in a script so it can be tested
+      # against those recorded histories rather than rediscovered (#3313).
+      - name: Decide whether this publisher is the current one
         id: currency
         env:
           GH_TOKEN: ${{ github.token }}
@@ -122,21 +155,13 @@ jobs:
           THIS_RUN: ${{ github.event.workflow_run.id }}
         run: |
           set -euo pipefail
-          newest="$(gh api \
-            "repos/$REPO/actions/runs?head_sha=$EVENT_SHA&per_page=100" \
-            --jq '[.workflow_runs[]
-                   | select(.name == "Review-bot acknowledgement gate")
-                   | .id] | max // 0')"
-          echo "this run: $THIS_RUN, newest gate run on $EVENT_SHA: $newest"
-          if [ "${newest:-0}" -gt "$THIS_RUN" ]; then
-            echo "stale=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::a newer gate run ($newest) exists for this head; leaving the verdict to it"
-          else
-            echo "stale=false" >> "$GITHUB_OUTPUT"
-          fi
+          gh api "repos/$REPO/actions/runs?head_sha=$EVENT_SHA&per_page=100" > gate-runs.json
+          python3 scripts/ack_publisher_currency.py \
+            --runs gate-runs.json \
+            --this-run "$THIS_RUN"
 
       - name: Resolve the conclusion, failing closed
-        if: steps.currency.outputs.stale != 'true'
+        if: steps.currency.outputs.decision == 'publish'
         env:
           GATE_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
           EVENT_SHA: ${{ github.event.workflow_run.head_sha }}
@@ -170,7 +195,7 @@ jobs:
           echo "resolved $verdict: $reason"
 
       - name: Publish the review-bot-ack context on the head commit
-        if: steps.currency.outputs.stale != 'true'
+        if: steps.currency.outputs.decision == 'publish'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -186,3 +211,89 @@ jobs:
             --title "Review-bot acknowledgement gate" \
             --summary "Every must-address CodeRabbit and Sourcery finding must be fixed in a later commit or acknowledged in the PR body. Resolved as ${VERDICT}: ${REASON}. See the sticky summary comment on the pull request for the per-finding breakdown." \
             --details-url "$GATE_RUN_URL"
+
+  # The other half of the rule above.
+  #
+  # `publish` correctly refuses to speak for a cancelled gate run, and the
+  # currency check correctly silences a publisher a newer run has overtaken.
+  # Together they left a gap: when the newest gate run for a head is the
+  # cancelled one, the run that would have published has already stood down
+  # as stale and the cancelled run's own publisher never starts. Nothing
+  # writes the context, nothing ever will, and the pull request sits at
+  # BLOCKED with no failing required check to point at. Three fork pull
+  # requests hit this on one day and each needed a close/reopen (#3313).
+  #
+  # Re-running the gate is the whole remedy: the re-run keeps the same run
+  # id, so when it concludes it is by definition the newest gate run for the
+  # head and its publisher writes the verdict. Nothing here inspects or
+  # trusts anything from the head - it is API calls and a base-branch script.
+  republish:
+    name: review-bot-ack-republisher
+    if: >-
+      (github.event.workflow_run.event == 'pull_request' ||
+       github.event.workflow_run.event == 'pull_request_review') &&
+      github.event.workflow_run.conclusion == 'cancelled'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+      checks: read
+      contents: read
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      # The base branch, never the head: the decision script must be the one
+      # this repository ships, not one a fork supplied.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.13"
+
+      # Three ways this is not the head's last hope, all of them cheap to
+      # check and all of them a reason to do nothing:
+      #
+      #   * a newer gate run can still publish - it will, so stay out of it;
+      #   * a terminal `review-bot-ack` already exists on the head - the head
+      #     is not blocked, and re-running the gate would only churn it;
+      #   * some gate run on this head already carries `run_attempt > 1` -
+      #     it has been re-dispatched once, by this job or by an operator,
+      #     and one re-dispatch per head SHA is the loop guard.
+      - name: Decide whether this head still has a writer
+        id: currency
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          EVENT_SHA: ${{ github.event.workflow_run.head_sha }}
+          THIS_RUN: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+          gh api "repos/$REPO/actions/runs?head_sha=$EVENT_SHA&per_page=100" > gate-runs.json
+          published="$(gh api \
+            "repos/$REPO/commits/$EVENT_SHA/check-runs?check_name=review-bot-ack&per_page=100" \
+            --jq '[.check_runs[] | select(.status == "completed")] | length')"
+          present=false
+          if [ "${published:-0}" -gt 0 ]; then
+            present=true
+          fi
+          python3 scripts/ack_publisher_currency.py \
+            --runs gate-runs.json \
+            --this-run "$THIS_RUN" \
+            --context-present "$present"
+
+      - name: Re-dispatch the gate for this head
+        if: steps.currency.outputs.decision == 'redispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          EVENT_SHA: ${{ github.event.workflow_run.head_sha }}
+          THIS_RUN: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+          echo "::notice::no gate run can publish review-bot-ack for ${EVENT_SHA}; re-dispatching run ${THIS_RUN}"
+          gh api -X POST "repos/$REPO/actions/runs/$THIS_RUN/rerun"

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -60,7 +60,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/reconcile-release.yml | Reconcile release drift | schedule, workflow_dispatch | {"cancel-in-progress": "false", "group": "reconcile-release"} | 1 |
 | .github/workflows/release-major-minor.yml | Major/Minor Release | workflow_dispatch | {"cancel-in-progress": "false", "group": "release-major-minor-${{ github.ref }}"} | 1 |
 | .github/workflows/required-check-canary.yml | Required-check name canary | pull_request, schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "required-check-canary-${{ github.event.pull_request.number \|\| github.ref }}"} | 1 |
-| .github/workflows/review-bot-ack-publish.yml | Review-bot acknowledgement publisher | workflow_run | {"cancel-in-progress": "false", "group": "review-bot-ack-publish-${{ github.event.workflow_run.head_sha }}"} | 1 |
+| .github/workflows/review-bot-ack-publish.yml | Review-bot acknowledgement publisher | workflow_run | {"cancel-in-progress": "false", "group": "review-bot-ack-publish-${{ github.event.workflow_run.head_sha }}-${{ github.event.workflow_run.id }}"} | 2 |
 | .github/workflows/review-bot-ack.yml | Review-bot acknowledgement gate | merge_group, pull_request, pull_request_review | {"cancel-in-progress": "true", "group": "review-bot-ack-${{ github.event.pull_request.number \|\| github.ref }}"} | 2 |
 | .github/workflows/review-bot-sweep.yml | Review-bot post-merge sweep | schedule, workflow_dispatch | - | 1 |
 | .github/workflows/sbom.yml | SBOM | release, workflow_dispatch | {"cancel-in-progress": "false", "group": "sbom-${{ github.ref }}"} | 1 |
@@ -127,7 +127,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/reconcile-release.yml | reconcile: Compare pyproject.toml vs PyPI |
 | .github/workflows/release-major-minor.yml | release: ${{ inputs.bump }} release |
 | .github/workflows/required-check-canary.yml | verify: Required-check name canary |
-| .github/workflows/review-bot-ack-publish.yml | publish: review-bot-ack-publisher |
+| .github/workflows/review-bot-ack-publish.yml | publish: review-bot-ack-publisher<br>republish: review-bot-ack-republisher |
 | .github/workflows/review-bot-ack.yml | merge-group-verify: review-bot-ack-queue-verify<br>pr-gate: review-bot-ack-runner |
 | .github/workflows/review-bot-sweep.yml | sweep: Sweep recently merged PRs for unprocessed bot findings |
 | .github/workflows/sbom.yml | sbom: Generate SBOM |
@@ -194,7 +194,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/reconcile-release.yml | reconcile: {"contents": "read", "issues": "write"} | - |
 | .github/workflows/release-major-minor.yml | workflow: {"contents": "read"}<br>release: {"attestations": "write", "contents": "write", "id-token": "write"} | GITHUB_TOKEN |
 | .github/workflows/required-check-canary.yml | verify: {"contents": "read"} | - |
-| .github/workflows/review-bot-ack-publish.yml | publish: {"actions": "read", "checks": "write", "contents": "read"} | - |
+| .github/workflows/review-bot-ack-publish.yml | publish: {"actions": "read", "checks": "write", "contents": "read"}<br>republish: {"actions": "write", "checks": "read", "contents": "read"} | - |
 | .github/workflows/review-bot-ack.yml | merge-group-verify: {"checks": "write", "contents": "read", "pull-requests": "read"}<br>pr-gate: {"checks": "write", "contents": "read", "issues": "write", "pull-requests": "write"} | - |
 | .github/workflows/review-bot-sweep.yml | sweep: {"contents": "write", "pull-requests": "write"} | GITHUB_TOKEN, LANDING_REPO_PAT |
 | .github/workflows/sbom.yml | workflow: {"contents": "read"}<br>sbom: {"contents": "write"} | - |

--- a/docs/operations/ci.md
+++ b/docs/operations/ci.md
@@ -427,6 +427,50 @@ pinned in `tests/unit/test_review_bot_ack_workflow_yaml.py`, with the
 publisher's own logic covered in
 `tests/unit/test_publish_required_check.py`.
 
+#### Every head gets a verdict, or the gate is re-dispatched
+
+A fork's gate run holds a read-only token, so the context is written by
+`review-bot-ack-publish.yml`, a `workflow_run` hop that runs in the base
+repository's context. One head SHA collects several gate runs - a push,
+two body edits, a review from each bot - and each of them wakes a
+publisher, so the hop has to elect exactly one writer per head.
+
+Electing it by run id alone is wrong, and heads that carried no
+`review-bot-ack` context at all were the symptom:
+
+- Runs released together are cancelled in an order unrelated to their
+  ids. When the cancelled run holds the higher id, the run that actually
+  passed reads itself as stale and stays quiet, while the cancelled run
+  has no verdict to publish. Nobody writes.
+- `pull_request_review` gate runs 403 on their in-job publish exactly as
+  `pull_request` ones do, so they need the hop too.
+
+The publisher now elects its writer from what each run *can* do rather
+than from its id:
+
+| Situation on the head | Outcome |
+|---|---|
+| a newer gate run can still publish | this publisher stands down |
+| this run can publish and no newer one can | this publisher writes the verdict |
+| an older run can publish | it writes; this one stands down |
+| no gate run on the head can publish | the newest re-dispatches the gate |
+
+The re-dispatch is bounded to one per head SHA: it is skipped once any
+gate run on the head carries `run_attempt > 1`, which is the mark a
+re-dispatch - or an operator's own re-run - leaves in GitHub's state. It
+is also skipped when the head already carries a terminal context.
+
+The rule is a pure function in `scripts/ack_publisher_currency.py` so it
+can be replayed against recorded run histories in
+`tests/unit/test_review_bot_ack_workflow_yaml.py`, which also pins the
+property that matters: for any history of gate runs on a head, exactly
+one publisher writes or re-dispatches, never zero and never two.
+
+Operator note: closing and reopening a pull request to republish an
+absent `review-bot-ack` should no longer be necessary. If it still is,
+the run history for that head is the evidence to attach - specifically
+each gate run's id, event, conclusion and `run_attempt`.
+
 ## Required check
 
 Branch protection points at a single status check, `CI gate`, which

--- a/scripts/ack_publisher_currency.py
+++ b/scripts/ack_publisher_currency.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Decide which `review-bot-ack` publisher, if any, speaks for a head SHA.
+
+Why this exists
+---------------
+The required `review-bot-ack` context is published by
+`.github/workflows/review-bot-ack-publish.yml`, a `workflow_run` hop that
+exists because a fork's `pull_request` run holds a read-only token and
+cannot write a check-run itself.
+
+A head SHA routinely collects several gate runs - a push, two body edits,
+a review from each bot - and every one of them wakes a publisher. Only one
+of those publishers may write, because the check-run is upserted per head
+SHA and the last writer wins outright. Publishers also queue for runners,
+so the order they write in is not the order the gates concluded in: the
+first gate to finish can be the last publisher to run and can overwrite a
+newer, better answer.
+
+So each publisher asks whether it is still the current one. The rule used
+to be "stand down if a gate run with a higher id exists", and that rule
+left heads with no writer at all (#3313). Two ways:
+
+  * The newest gate run concluded `cancelled`. A cancelled run has no
+    verdict and must not write one, so its publisher stands down - and
+    every older publisher had already stood down as stale. Observed on
+    PR #3287: approving a first-time contributor released three parked
+    runs at 12:00:02Z, concurrency cancelled 30622786412 three seconds
+    later, and the survivor 30622733829 carried the *lower* id. Runs
+    released together are cancelled in an order unrelated to their ids,
+    so "newest id" and "newest verdict" are simply different things.
+
+  * The newest gate run came from `pull_request_review`, which the
+    publisher's job condition did not admit. Observed on PR #3293:
+    run 30655244121 passed at 18:28:48Z, its in-job publish 403'd the way
+    every fork's does, and no publisher ever ran.
+
+Both heads sat at BLOCKED with no failing check to point at, and only
+closing and reopening the pull request produced the context.
+
+The rule this module implements
+-------------------------------
+A gate run *can publish* when its event needs the hop and it did not end
+cancelled. A publisher stands down only for a successor that can publish -
+a run that never will is not a reason to stay quiet. If nothing newer can
+publish and this run cannot either, the head has no writer left, and the
+publisher re-dispatches the gate rather than standing down silently.
+
+The re-dispatch is bounded to one per head SHA: it is skipped once any
+gate run on the head carries `run_attempt > 1`, which is the mark a
+re-dispatch (or an operator's own re-run) leaves in GitHub's own state.
+No ledger, no external memory, and a second cancellation of the same head
+cannot start a loop.
+
+The decision is a pure function of the run list, so it is unit-tested
+against the three recorded incidents instead of being discovered in
+production a fourth time.
+
+Usage:
+    python scripts/ack_publisher_currency.py \\
+        --runs runs.json \\
+        --this-run 30622733829 \\
+        --context-present false
+
+`--runs` accepts either the raw `GET /repos/{repo}/actions/runs` payload
+or a bare list of runs, and reads stdin when given `-`.
+
+Outputs `decision=publish|stand-down|redispatch` on stdout and, when
+`GITHUB_OUTPUT` is set, appends it there too.
+
+Exit codes:
+    0  A decision was reached and reported.
+    1  The input could not be read or parsed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+# The gate's `pull_request` and `pull_request_review` runs both get a
+# read-only token on a fork, so both need the `workflow_run` hop. A
+# `merge_group` run already holds `checks: write` and publishes in-repo;
+# a second writer for it would only race the first.
+PUBLISHABLE_EVENTS = frozenset({"pull_request", "pull_request_review"})
+
+GATE_WORKFLOW_NAME = "Review-bot acknowledgement gate"
+
+PUBLISH = "publish"
+STAND_DOWN = "stand-down"
+REDISPATCH = "redispatch"
+
+
+def _run_id(run: dict[str, Any]) -> int:
+    """Return a run's id, or 0 when it is missing or unparseable."""
+    try:
+        return int(run.get("id") or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def can_publish(run: dict[str, Any]) -> bool:
+    """Whether this gate run will ever write the required context.
+
+    A run that is still in flight counts: it has not concluded, so it may
+    yet produce a verdict, and a publisher must not overtake it.
+    """
+    if str(run.get("event") or "") not in PUBLISHABLE_EVENTS:
+        return False
+    return str(run.get("conclusion") or "") != "cancelled"
+
+
+def gate_runs(payload: object, workflow_name: str = GATE_WORKFLOW_NAME) -> list[dict[str, Any]]:
+    """Pull the gate's runs out of an Actions API payload or a bare list."""
+    raw: object = payload
+    if isinstance(payload, dict):
+        raw = payload.get("workflow_runs", [])
+    if not isinstance(raw, list):
+        return []
+    runs: list[dict[str, Any]] = [item for item in raw if isinstance(item, dict)]
+    named = [run for run in runs if str(run.get("name") or workflow_name) == workflow_name]
+    return sorted(named, key=_run_id)
+
+
+def was_redispatched(runs: list[dict[str, Any]]) -> bool:
+    """Whether some gate run on this head has already been run again.
+
+    This is the loop guard, and it deliberately counts an operator's own
+    re-run as well as an automatic one. A re-run *is* the re-dispatch; a
+    second one on the same head would not add information, and refusing
+    to fight a human's manual recovery is the point.
+    """
+    for run in runs:
+        try:
+            attempt = int(run.get("run_attempt") or 1)
+        except (TypeError, ValueError):
+            attempt = 1
+        if attempt > 1:
+            return True
+    return False
+
+
+def decide(
+    runs: list[dict[str, Any]],
+    this_run_id: int,
+    *,
+    context_present: bool = False,
+) -> str:
+    """Return this publisher's decision for its head SHA.
+
+    ``publish``     this run holds the current verdict; write it.
+    ``stand-down``  someone else will write, or already has.
+    ``redispatch``  nothing can write for this head; re-run the gate.
+    """
+    # A newer run that can publish will publish. Standing down for one that
+    # cannot is what left three heads with no writer at all (#3313).
+    if any(_run_id(run) > this_run_id and can_publish(run) for run in runs):
+        return STAND_DOWN
+
+    mine = next((run for run in runs if _run_id(run) == this_run_id), None)
+    if mine is not None and can_publish(mine):
+        return PUBLISH
+
+    # This run has no verdict to write. That only matters if nobody else has
+    # one either: an older run that can publish is the head's writer, and
+    # rules 1 and 2 have already told it so.
+    if any(can_publish(run) for run in runs):
+        return STAND_DOWN
+
+    # No gate run on this head can ever publish. Without intervention the
+    # required context stays absent, which reads as BLOCKED with nothing on
+    # the page to point at, for the life of the commit.
+    if context_present:
+        return STAND_DOWN
+    if was_redispatched(runs):
+        return STAND_DOWN
+
+    # Exactly one run re-dispatches, and it is the newest. Every cancelled
+    # run on the head reaches this point, so without the tie-break they
+    # would all re-dispatch and race each other.
+    newest = max((_run_id(run) for run in runs), default=0)
+    if this_run_id != newest:
+        return STAND_DOWN
+    return REDISPATCH
+
+
+def _load(source: str) -> object:
+    text = sys.stdin.read() if source == "-" else Path(source).read_text(encoding="utf-8")
+    return json.loads(text)
+
+
+def _as_bool(value: str) -> bool:
+    return value.strip().lower() in {"1", "true", "yes"}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--runs", required=True, help="Actions API runs payload, or - for stdin")
+    parser.add_argument("--this-run", required=True, type=int, help="id of the gate run that woke this publisher")
+    parser.add_argument("--context-present", default="false", help="whether a terminal review-bot-ack already exists")
+    parser.add_argument("--workflow-name", default=GATE_WORKFLOW_NAME)
+    args = parser.parse_args(argv)
+
+    try:
+        payload = _load(str(args.runs))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"error: cannot read the gate runs for this head: {exc}", file=sys.stderr)
+        return 1
+
+    runs = gate_runs(payload, str(args.workflow_name))
+    decision = decide(runs, int(args.this_run), context_present=_as_bool(str(args.context_present)))
+
+    seen = ", ".join(f"{_run_id(r)}:{r.get('event')}/{r.get('conclusion') or r.get('status')}" for r in runs)
+    print(f"gate runs on this head: [{seen}]")
+    print(f"this run: {args.this_run}")
+    print(f"decision={decision}")
+
+    output = os.environ.get("GITHUB_OUTPUT")
+    if output:
+        with Path(output).open("a", encoding="utf-8") as handle:
+            handle.write(f"decision={decision}\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/tests/unit/test_review_bot_ack_workflow_yaml.py
+++ b/tests/unit/test_review_bot_ack_workflow_yaml.py
@@ -16,6 +16,8 @@ isolation. They do not call the GitHub API.
 
 from __future__ import annotations
 
+import itertools
+import json
 import re
 import sys
 from pathlib import Path
@@ -38,7 +40,26 @@ PUBLISH_SCRIPT = Path("scripts/publish_required_check.py")
 # The context branch protection requires on `main`.
 CONTEXT = "review-bot-ack"
 PUBLISHER = "scripts/publish_required_check.py"
+CURRENCY = "scripts/ack_publisher_currency.py"
 VERDICT_ARTIFACT = "review-bot-ack-verdict"
+
+# The gate triggers on these events for a pull request. Every one of them
+# gets a read-only GITHUB_TOKEN on a fork, so every one of them needs the
+# `workflow_run` hop to publish. `merge_group` is excluded on purpose: those
+# runs already hold `checks: write` and publish in-repo.
+GATE_EVENTS_NEEDING_THE_HOP = ("pull_request", "pull_request_review")
+
+# Every conclusion GitHub can hand a completed workflow run.
+RUN_CONCLUSIONS = (
+    "success",
+    "failure",
+    "cancelled",
+    "timed_out",
+    "startup_failure",
+    "skipped",
+    "neutral",
+    "action_required",
+)
 
 
 @pytest.fixture(scope="module")
@@ -61,6 +82,46 @@ def _on(doc: dict[str, object]) -> dict[str, object]:
     on = doc.get(True, doc.get("on"))
     assert isinstance(on, dict)
     return on
+
+
+_IDENTIFIER_RE = re.compile(r"[A-Za-z_][A-Za-z_0-9.]*")
+_STRING_LITERAL_RE = re.compile(r"'[^']*'|\"[^\"]*\"")
+_PY_KEYWORDS = frozenset({"and", "or", "not", "None", "True", "False"})
+
+
+def _eval_condition(expr: str, context: dict[str, str | None]) -> bool:
+    """Evaluate the slice of the GitHub expression language these job
+    conditions are written in: context lookups, single-quoted strings,
+    ``==``, ``!=``, ``&&``, ``||`` and parentheses.
+
+    The point is to read a job's ``if:`` as the predicate it actually is
+    rather than to grep it for substrings. A substring assertion cannot
+    tell whether two conditions between them cover every gate run; this
+    can.
+    """
+    text = " ".join(expr.split())
+    if text.startswith("${{") and text.endswith("}}"):
+        text = text[3:-2].strip()
+    # Longest path first so `...workflow_run.conclusion` is not clipped by a
+    # shorter prefix that happens to also be in the context.
+    for path, value in sorted(context.items(), key=lambda kv: -len(kv[0])):
+        text = text.replace(path, repr(value))
+    text = text.replace("&&", " and ").replace("||", " or ")
+    text = re.sub(r"\btrue\b", "True", text)
+    text = re.sub(r"\bfalse\b", "False", text)
+
+    # Identifiers are only interesting outside string literals; the literals
+    # themselves are values, not names the model has to know.
+    bare = _STRING_LITERAL_RE.sub(" ", text)
+    unknown = sorted({t for t in _IDENTIFIER_RE.findall(bare) if t not in _PY_KEYWORDS})
+    assert not unknown, (
+        f"condition {expr!r} reads {unknown!r}, which this test's model of the publisher does not know about. "
+        "Either add it to the model or express the condition in terms the model already covers - an untestable "
+        "condition is how #3313 stayed invisible."
+    )
+    # The grammar is restricted to the tokens asserted above, and the input
+    # is this repository's own workflow file.
+    return bool(eval(text, {"__builtins__": {}}, {}))
 
 
 def test_gate_workflow_exists() -> None:
@@ -152,13 +213,24 @@ def test_every_verdict_path_ends_in_an_api_publish(
 
     pub_jobs = _jobs(publish_doc)
     assert pub_jobs, "the companion publisher must define a job"
+    publishing_jobs = [key for key, job in pub_jobs.items() if PUBLISHER in _run_script(job)]
+    assert publishing_jobs, f"the companion publisher must have a job that runs {PUBLISHER}"
     for key, job in pub_jobs.items():
         script = _run_script(job)
-        assert PUBLISHER in script and f"--name {CONTEXT}" in script, (
-            f"publisher job {key!r} must publish {CONTEXT!r} via {PUBLISHER}"
+        if PUBLISHER in script:
+            assert f"--name {CONTEXT}" in script, f"publisher job {key!r} must publish {CONTEXT!r} via {PUBLISHER}"
+            perms = job.get("permissions")
+            assert isinstance(perms, dict) and perms.get("checks") == "write", (
+                f"publisher job {key!r} needs checks:write"
+            )
+            continue
+        # A job that does not publish must be the recovery path: the only
+        # other reason to exist in this workflow is to get a head that has
+        # no writer left back into a state where one runs (#3313).
+        assert "/rerun" in script, (
+            f"job {key!r} in the publisher neither publishes {CONTEXT!r} nor re-dispatches the gate. Those are "
+            "the only two things this workflow does; anything else is a verdict path that stops halfway."
         )
-        perms = job.get("permissions")
-        assert isinstance(perms, dict) and perms.get("checks") == "write", f"publisher job {key!r} needs checks:write"
 
 
 def test_publisher_runs_on_workflow_run_of_the_gate(
@@ -486,12 +558,127 @@ def test_publisher_never_speaks_for_a_cancelled_gate_run(
     Treating `cancelled` as `failure` is not conservative here, it is wrong,
     and it is wrong in the direction that blocks good work: it turns a passing
     pull request red with a summary describing a run that never finished.
+
+    The recovery job added for #3313 does run for a cancelled gate run, and
+    that is not a weakening of this rule: it writes no verdict at all, it
+    re-dispatches the gate so that a run with a verdict exists.
     """
     for key, job in _jobs(publish_doc).items():
+        if PUBLISHER not in _run_script(job):
+            continue
         condition = " ".join(str(job.get("if", "")).split())
         assert "conclusion != 'cancelled'" in condition, (
             f"publisher job {key!r} runs for a cancelled gate run; its condition is "
             f"{condition!r}. A cancelled run has no verdict and must publish nothing."
+        )
+
+
+def test_the_recovery_job_never_writes_a_verdict(
+    publish_doc: dict[str, object],
+) -> None:
+    """INV-2j. The job that runs for a cancelled gate run must not publish.
+
+    It exists because a cancelled run leaves the head with no writer, and
+    the remedy is to produce a run that has a verdict - not to invent one.
+    Handing it `checks: write` would let a run with no verdict write one,
+    which is the exact failure `test_publisher_never_speaks_for_a_cancelled_gate_run`
+    forbids.
+    """
+    for key, job in _jobs(publish_doc).items():
+        script = _run_script(job)
+        if PUBLISHER in script:
+            continue
+        perms = job.get("permissions")
+        assert isinstance(perms, dict), f"recovery job {key!r} must pin explicit permissions"
+        assert perms.get("checks") != "write", (
+            f"recovery job {key!r} holds checks:write. It runs for gate runs that have no verdict, so it must "
+            "not be able to write one; re-dispatching the gate is its only remedy."
+        )
+        assert perms.get("actions") == "write", f"recovery job {key!r} needs actions:write to re-dispatch the gate run"
+
+
+def test_publishers_for_one_head_do_not_cancel_each_other(
+    publish_doc: dict[str, object],
+) -> None:
+    """INV-2k. Two publishers for one head must not share a concurrency group.
+
+    With `cancel-in-progress: false` a group is a one-deep queue: a run
+    executing plus a run pending means a third arrival cancels the pending
+    one. A head SHA routinely collects several gate runs and therefore
+    several publishers, so keying the group on the head SHA alone let the
+    queue drop publishers - including, in the worst case, the only one whose
+    currency check would have said `publish`.
+
+    Serialising them stopped being worth anything once the currency check
+    landed: at most one publisher per head decides to write, so there is no
+    upsert race left to serialise against.
+    """
+    conc = publish_doc.get("concurrency")
+    assert isinstance(conc, dict), "the publisher must declare a concurrency block"
+    group = str(conc.get("group", ""))
+    assert "workflow_run.id" in group, (
+        f"the publisher's concurrency group is {group!r}, which several publishers for one head all share. "
+        "A shared group with cancel-in-progress: false cancels pending members, so a publisher that would "
+        "have written the required context can be dropped before it runs. Key the group on the triggering "
+        "run id as well."
+    )
+
+
+def test_every_gate_run_that_needs_the_hop_is_claimed_by_exactly_one_job(
+    publish_doc: dict[str, object],
+) -> None:
+    """INV-2i. No gate run may fall between the publisher's jobs (#3313).
+
+    The publisher's job conditions and its currency check are two halves of
+    one rule, and they were not complementary. The currency check silences
+    every publisher that is not the newest one for the head; the job
+    conditions then declined to run for the newest one in two cases, and a
+    head with no writer left never gets the required context at all:
+
+      * the newest gate run concluded ``cancelled`` - the job condition
+        dropped it, and every older publisher had already stood down as
+        stale (PR #3287: the first-contributor approval released three
+        parked runs at 12:00:02Z, concurrency cancelled run 30622786412
+        three seconds later, and the survivor 30622733829 carried the
+        *lower* id, so it read itself as stale);
+      * the newest gate run came from ``pull_request_review`` - the job
+        condition only admitted ``pull_request`` (PR #3293 pre-cycle: run
+        30655244121 passed at 18:28:48Z, its in-job publish 403'd as every
+        fork's does, and no publisher ever ran for it).
+
+    Both heads sat at BLOCKED with nothing on the page to point at until
+    the pull request was closed and reopened. So this is the invariant:
+    for every gate run that needs the `workflow_run` hop, exactly one job
+    in the publisher claims it - one to write the verdict, one to recover
+    when there is no verdict to write.
+    """
+    jobs = _jobs(publish_doc)
+    assert jobs, "the publisher must define jobs"
+
+    for event, conclusion in itertools.product(GATE_EVENTS_NEEDING_THE_HOP, RUN_CONCLUSIONS):
+        context = {
+            "github.event.workflow_run.event": event,
+            "github.event.workflow_run.conclusion": conclusion,
+        }
+        claimants = [key for key, job in jobs.items() if _eval_condition(str(job.get("if", "true")), context)]
+        assert len(claimants) == 1, (
+            f"a gate run with event={event!r} and conclusion={conclusion!r} is claimed by {claimants!r}. "
+            "Exactly one publisher job must own it: zero leaves the head with no `review-bot-ack` context and "
+            "no way to get one short of closing and reopening the pull request (#3313); two race on the "
+            "check-run upsert."
+        )
+
+    # A merge_group gate run publishes its own context in-repo, where the
+    # token is already writable. The hop must not run for it.
+    for conclusion in RUN_CONCLUSIONS:
+        context = {
+            "github.event.workflow_run.event": "merge_group",
+            "github.event.workflow_run.conclusion": conclusion,
+        }
+        claimants = [key for key, job in jobs.items() if _eval_condition(str(job.get("if", "true")), context)]
+        assert not claimants, (
+            f"jobs {claimants!r} run for a merge_group gate run (conclusion={conclusion!r}). Queue-side runs "
+            "already publish the context themselves; a second writer only races the first."
         )
 
 
@@ -523,10 +710,12 @@ def test_publisher_stands_down_when_a_newer_gate_run_exists(
         )
 
         probe = str(currency[0].get("run", ""))
-        assert "head_sha=" in probe and "workflow_runs" in probe, (
-            "the currency check must ask the API which gate runs exist for this head SHA"
+        assert "head_sha=" in probe, "the currency check must ask the API which gate runs exist for this head SHA"
+        assert CURRENCY in probe, (
+            f"publisher job {key!r} decides currency in workflow shell. The rule is what #3313 got wrong - "
+            f"'newest id' is not 'newest verdict' - so it lives in {CURRENCY}, where the recorded incident "
+            "histories are replayed against it in this file."
         )
-        assert "stale=true" in probe, "the currency check must be able to report staleness"
 
         publishing = [
             step
@@ -536,7 +725,179 @@ def test_publisher_stands_down_when_a_newer_gate_run_exists(
         assert publishing, f"expected publishing steps in job {key!r}"
         for step in publishing:
             guard = " ".join(str(step.get("if", "")).split())
-            assert "currency.outputs.stale" in guard, (
+            assert "currency.outputs.decision == 'publish'" in guard, (
                 f"step {step.get('name')!r} in job {key!r} writes the verdict without "
                 f"consulting the currency check; its condition is {guard!r}"
             )
+
+
+def _currency_module() -> object:
+    sys.path.insert(0, str(Path("scripts").resolve()))
+    import ack_publisher_currency
+
+    return ack_publisher_currency
+
+
+def _gate_run(run_id: int, event: str, conclusion: str | None, attempt: int = 1) -> dict[str, object]:
+    return {
+        "id": run_id,
+        "name": "Review-bot acknowledgement gate",
+        "event": event,
+        "status": "completed" if conclusion else "in_progress",
+        "conclusion": conclusion,
+        "run_attempt": attempt,
+    }
+
+
+def test_currency_replays_pr_3287_where_the_survivor_had_the_lower_id() -> None:
+    """The #3313 incident that proves id order is not verdict order.
+
+    Approving PR #3287's first-time contributor released three parked gate
+    runs at 12:00:02Z. Concurrency cancelled two of them within four
+    seconds, and the survivor - 30622733829, which passed at 12:05:31Z -
+    carried a LOWER id than the cancelled 30622786412.
+
+    Under the old "stand down if a higher id exists" rule the survivor read
+    itself as stale, the cancelled run's publisher never started, and the
+    head carried no `review-bot-ack` context for six hours until the pull
+    request was cycled. A run that will never publish is not a reason for
+    the run that can to stay quiet.
+    """
+    module = _currency_module()
+    runs = [
+        _gate_run(30622722192, "pull_request", "success"),
+        _gate_run(30622728511, "pull_request_review", "cancelled"),
+        _gate_run(30622733829, "pull_request", "success"),
+        _gate_run(30622786412, "pull_request", "cancelled"),
+    ]
+    assert module.decide(runs, 30622733829) == "publish"  # type: ignore[attr-defined]
+    assert module.decide(runs, 30622722192) == "stand-down"  # type: ignore[attr-defined]
+
+
+def test_currency_replays_pr_3293_where_the_newest_run_was_a_review_event() -> None:
+    """The other #3313 shape: the newest gate run was `pull_request_review`.
+
+    On PR #3293's pre-cycle head a048348, run 30655244121 passed at
+    18:28:48Z. Its in-job publish 403'd, as every fork's does, and the
+    publisher's job condition admitted only `pull_request`, so no publisher
+    ran for it. The two older `pull_request` runs had already stood down as
+    stale. That run is the head's current verdict and must publish.
+    """
+    module = _currency_module()
+    runs = [
+        _gate_run(30655070335, "pull_request", "success"),
+        _gate_run(30655134036, "pull_request", "success"),
+        _gate_run(30655244121, "pull_request_review", "success"),
+    ]
+    assert module.decide(runs, 30655244121) == "publish"  # type: ignore[attr-defined]
+    assert module.decide(runs, 30655134036) == "stand-down"  # type: ignore[attr-defined]
+
+
+def test_currency_redispatches_once_per_head_when_nothing_can_publish() -> None:
+    """When every gate run on a head is cancelled, someone must re-dispatch.
+
+    And exactly once. The mark of a re-dispatch is `run_attempt > 1` on some
+    gate run for the head, which is GitHub's own state rather than a ledger
+    this workflow would have to keep; an operator's manual re-run counts the
+    same way, because a manual re-run IS the re-dispatch.
+    """
+    module = _currency_module()
+    cancelled = [
+        _gate_run(11, "pull_request", "cancelled"),
+        _gate_run(12, "pull_request_review", "cancelled"),
+    ]
+    assert module.decide(cancelled, 12) == "redispatch"  # type: ignore[attr-defined]
+    assert module.decide(cancelled, 11) == "stand-down"  # type: ignore[attr-defined]
+
+    already_present = module.decide(cancelled, 12, context_present=True)  # type: ignore[attr-defined]
+    assert already_present == "stand-down", "a head that already carries the context must not be churned"
+
+    retried = [
+        _gate_run(11, "pull_request", "cancelled"),
+        _gate_run(12, "pull_request_review", "cancelled", attempt=2),
+    ]
+    assert module.decide(retried, 12) == "stand-down", "one re-dispatch per head SHA; this is the loop guard"  # type: ignore[attr-defined]
+
+
+def test_currency_defers_to_a_successor_that_is_still_running() -> None:
+    """A run with no conclusion yet may still produce a verdict.
+
+    Overtaking it would put the older answer on the head and lose the newer
+    one, which is the race the currency check exists to prevent.
+    """
+    module = _currency_module()
+    runs = [
+        _gate_run(21, "pull_request", "success"),
+        _gate_run(22, "pull_request", None),
+    ]
+    assert module.decide(runs, 21) == "stand-down"  # type: ignore[attr-defined]
+
+
+def test_every_gate_run_history_leaves_the_head_a_writer() -> None:
+    """The guarantee #3313 asks for, stated as a property.
+
+    For any history of gate runs on a head, at least one of them must reach
+    a decision that eventually puts a conclusion on the commit: either it
+    publishes, or it re-dispatches the gate so that a run which can publish
+    exists. `stand-down` for every run is the bug - that is a head nobody
+    will ever write, and the only recorded remedy was closing and reopening
+    the pull request.
+    """
+    module = _currency_module()
+    events = ("pull_request", "pull_request_review")
+    conclusions = ("success", "failure", "cancelled")
+
+    for size in (1, 2, 3):
+        for combo in itertools.product(itertools.product(events, conclusions), repeat=size):
+            runs = [_gate_run(100 + index, event, conclusion) for index, (event, conclusion) in enumerate(combo)]
+            decisions = {run["id"]: module.decide(runs, int(run["id"])) for run in runs}  # type: ignore[attr-defined]
+            writers = [decision for decision in decisions.values() if decision != "stand-down"]
+            assert writers, (
+                f"gate run history {combo!r} leaves every publisher standing down, so the head never gets a "
+                f"review-bot-ack conclusion at all: {decisions!r}"
+            )
+            assert len(writers) == 1, (
+                f"gate run history {combo!r} elects {len(writers)} writers: {decisions!r}. Two publishers race "
+                "on the check-run upsert; two re-dispatches double-run the gate for one head."
+            )
+
+
+def test_currency_cli_reports_its_decision_to_github_output(tmp_path: Path) -> None:
+    """The workflow reads the decision from `GITHUB_OUTPUT`, so the CLI has
+    to put it there and not only on stdout."""
+    module = _currency_module()
+    payload = {"workflow_runs": [_gate_run(31, "pull_request_review", "success")]}
+    runs_file = tmp_path / "runs.json"
+    runs_file.write_text(json.dumps(payload), encoding="utf-8")
+    output = tmp_path / "github_output"
+
+    import os
+
+    previous = os.environ.get("GITHUB_OUTPUT")
+    os.environ["GITHUB_OUTPUT"] = str(output)
+    try:
+        code = module.main(["--runs", str(runs_file), "--this-run", "31"])  # type: ignore[attr-defined]
+    finally:
+        if previous is None:
+            os.environ.pop("GITHUB_OUTPUT", None)
+        else:
+            os.environ["GITHUB_OUTPUT"] = previous
+
+    assert code == 0
+    assert "decision=publish" in output.read_text(encoding="utf-8")
+
+
+def test_currency_ignores_runs_of_other_workflows() -> None:
+    """The head SHA query returns every workflow's runs, and their ids sit
+    in the same space as the gate's. Counting one as a successor would
+    silence the publisher for a run that has nothing to do with the gate."""
+    module = _currency_module()
+    payload = {
+        "workflow_runs": [
+            _gate_run(41, "pull_request", "success"),
+            {"id": 42, "name": "CI gate", "event": "pull_request", "status": "completed", "conclusion": "success"},
+        ]
+    }
+    runs = module.gate_runs(payload)  # type: ignore[attr-defined]
+    assert [run["id"] for run in runs] == [41]
+    assert module.decide(runs, 41) == "publish"  # type: ignore[attr-defined]


### PR DESCRIPTION
Closes #3313

## What was wrong

The required `review-bot-ack` context is written by `review-bot-ack-publish.yml`, a `workflow_run` hop that exists because a fork's gate run holds a read-only token. One head SHA collects several gate runs — a push, two body edits, a review from each bot — and each wakes a publisher, so the hop has to elect exactly one writer per head.

It elected by run id, and the two halves of the rule were not complementary: the currency check silenced every publisher that was not the newest for the head, and the job condition then declined to run for the newest one in two cases. A head with no writer left never gets the context, and the only recorded remedy was closing and reopening the pull request.

Verified against the three incident heads:

| Head | What the run history shows |
|---|---|
| #3287 `ce1608b` | Approval released three parked gate runs at 12:00:02Z. Concurrency cancelled `30622786412` three seconds later; the survivor `30622733829` passed at 12:05:31Z carrying the **lower** id, so it read itself as stale. The cancelled run's publisher never started. No check-run until 18:28:46Z. |
| #3293 `a048348` (pre-cycle) | Newest gate run `30655244121` was `pull_request_review`, passed 18:28:48Z. Its in-job publish logged `403 Resource not accessible by integration` on `POST /check-runs`, as every fork's does. The publisher's condition admitted only `pull_request`, so no publisher ran. No check-run until 19:56:06Z, after the reopen. |
| #3267 `708e629` | Same shape — newest run `30595893409` was `pull_request_review`. Re-running older run ids could not help: the currency check stood every one of them down as stale. |

## What changed

The publisher elects its writer from what each run *can* do rather than from its id:

| Situation on the head | Outcome |
|---|---|
| a newer gate run can still publish | this publisher stands down |
| this run can publish and no newer one can | this publisher writes the verdict |
| an older run can publish | it writes; this one stands down |
| no gate run on the head can publish | the newest re-dispatches the gate |

- `pull_request_review` gate runs are admitted alongside `pull_request`; `merge_group` still self-publishes and is excluded.
- A `cancelled` run still writes nothing — that rule is unchanged. A new `republish` job covers the case it leaves open by re-running the gate, so a run with a verdict exists. It holds `actions: write` and deliberately **not** `checks: write`: a run with no verdict must not be able to write one.
- The re-dispatch is bounded to one per head SHA. The mark is `run_attempt > 1` on any gate run for the head — GitHub's own state, no ledger — and an operator's manual re-run counts the same way. It is also skipped when the head already carries a terminal context.
- The publisher's concurrency group is now keyed on the triggering run id as well. Sharing one group per head made it a one-deep queue (`cancel-in-progress: false` cancels the pending member on a third arrival), which could drop the only publisher that would have written. Serialising them stopped being worth anything once the currency check landed: at most one publisher per head decides to write.

## Tests

`tests/unit/test_review_bot_ack_workflow_yaml.py`:

- Job conditions are now read as predicates rather than grepped for substrings, and the invariant is asserted directly: for every gate run event × conclusion that needs the hop, **exactly one** job claims it. This test fails on the unmodified workflows with `event='pull_request', conclusion='cancelled' is claimed by []`.
- The three incident histories are replayed against the decision rule.
- A property test over every gate-run history up to length 3: exactly one publisher writes or re-dispatches, never zero and never two.
- Loop guard, already-published guard, still-running successor, and other workflows' runs sharing the id space.

The rule moved out of workflow shell into `scripts/ack_publisher_currency.py` — a pure function — because logic that only exists as YAML shell is how this stayed invisible.

## Docs

- `docs/operations/ci.md` documents the election rule and notes that close/reopen should no longer be needed; if it is, the run history for the head is the evidence to attach.
- `docs/operations/ci-topology.md` regenerated via `scripts/gen_workflow_topology.py`.

## Verification

```
uv run pytest tests/unit/test_review_bot_ack_workflow_yaml.py tests/unit/test_workflow_topology_report.py \
  tests/unit/test_publish_required_check.py tests/unit/test_required_check_canary_workflow_yaml.py \
  tests/unit/test_pull_request_workflow_concurrency_yaml.py tests/unit/test_zizmor_workflow_yaml.py
# 129 passed

uv run ruff check .        # All checks passed
uv run mypy scripts/ack_publisher_currency.py   # no issues
zizmor .github/workflows/review-bot-ack-publish.yml   # 2 high, unchanged from origin/main baseline
```

## Summary by Sourcery

Guarantee every eligible review-bot-ack publisher or recovery path runs per PR head so the required check is either written once or the gate is safely re-dispatched.

New Features:
- Introduce a dedicated currency decision script and CLI to elect a single review-bot-ack publisher per head and trigger gate re-dispatch when no run can publish.
- Add a republish job to the review-bot-ack publisher workflow to re-run the gate when the newest gate run is cancelled and no writer remains.

Bug Fixes:
- Ensure pull_request_review gate runs are handled by the publisher workflow so fork review events can produce the required review-bot-ack check.
- Prevent publishers for the same head SHA from cancelling each other via shared concurrency groups, avoiding loss of the only writer that would publish.
- Guarantee every gate run needing the workflow_run hop is claimed by exactly one publisher job, closing gaps that previously left some heads without any context.

Enhancements:
- Model GitHub job conditions as predicates in tests and assert coverage over all gate events and conclusions, rather than grepping for substrings.
- Refine currency logic to consider publishable capability and run attempts instead of raw run ids, and bound re-dispatch to one per head SHA with context-present safeguards.
- Extend tests to replay past incident histories, property-check all short gate-run histories, and verify currency CLI integration and workflow-run filtering.
- Update review-bot-ack publisher workflow to consume decisions from the new currency script, use stronger conditional guards, and document the incident-driven rules in comments.

Documentation:
- Document the publisher election and gate re-dispatch rules, including operational guidance that close/reopen should no longer be needed and what evidence to collect if it is.
- Regenerate CI topology documentation to reflect the new republish job, updated concurrency grouping, and permissions in the review-bot-ack publisher workflow.

Tests:
- Expand unit tests for the review-bot-ack workflows to cover condition evaluation, publisher job claiming, concurrency behavior, recovery job permissions, and the new currency script, including property tests over gate-run histories.