### PR TITLE
fix(doctor): keep --json stdout parseable when a tool probe blows its budget

### DIFF
--- a/src/bernstein/core/quality/ci_fix.py
+++ b/src/bernstein/core/quality/ci_fix.py
@@ -349,13 +349,25 @@ def install_pre_push_hook(repo_root: Path, force: bool = False) -> bool:
 # ---------------------------------------------------------------------------
 
 
+_TOOL_PROBE_TIMEOUT_SECONDS = 10
+
+
 def _check_tool_version(name: str, *, detail_limit: int = 60) -> dict[str, str]:
     """Run ``uv run <name> --version`` and report the result as a check dict.
 
-    Turns a missing ``uv`` executable (``FileNotFoundError``, raised e.g. as
-    ``WinError 2`` on Windows) into a failed check instead of letting it
-    propagate, since ``bernstein doctor``'s entire job is to report which
-    tools are missing.
+    Every way the probe can fail to produce an answer is reported as a failed
+    check rather than raised, because reporting which tools are unusable *is*
+    the job here and the caller (``bernstein doctor``) serialises the whole
+    check list at the very end. An exception escaping this function aborts the
+    doctor before it writes anything at all, so ``--json`` consumers get an
+    empty stream instead of a payload -- indistinguishable from a clean run.
+    Three ways it can fail to answer:
+
+    - ``uv`` is absent (``FileNotFoundError``, ``WinError 2`` on Windows);
+    - ``uv`` is present but unlaunchable (any other ``OSError``);
+    - ``uv`` runs but blows the time budget (``TimeoutExpired``) -- ``uv run``
+      serialises on a shared cache lock, so concurrent invocations on a loaded
+      host queue up behind each other.
 
     Args:
         name: Tool to check (``ruff``, ``pytest``, ``pyright``, ...).
@@ -371,14 +383,28 @@ def _check_tool_version(name: str, *, detail_limit: int = 60) -> dict[str, str]:
             text=True,
             encoding="utf-8",
             errors="replace",
-            timeout=10,
+            timeout=_TOOL_PROBE_TIMEOUT_SECONDS,
         )
+    except subprocess.TimeoutExpired:
+        return {
+            "name": name,
+            "ok": "False",
+            "detail": f"probe timed out after {_TOOL_PROBE_TIMEOUT_SECONDS}s",
+            "fix": f"Re-run when the host is less loaded, or check 'uv run {name} --version' by hand",
+        }
     except FileNotFoundError:
         return {
             "name": name,
             "ok": "False",
             "detail": "uv not found on PATH",
             "fix": "Install uv (https://docs.astral.sh/uv/) and ensure it is on PATH",
+        }
+    except OSError as exc:
+        return {
+            "name": name,
+            "ok": "False",
+            "detail": f"could not run uv: {exc}"[:80],
+            "fix": "Check that uv is executable and on PATH",
         }
 
     ok = result.returncode == 0

--- a/tests/unit/test_ci_fix.py
+++ b/tests/unit/test_ci_fix.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -202,6 +203,38 @@ class TestCheckTestDependencies:
 
         assert all(check["ok"] == "True" for check in checks)
         assert all(check["fix"] == "" for check in checks)
+
+    def test_slow_uv_returns_result_instead_of_raising(self) -> None:
+        """A probe that exceeds its budget must be reported, not raised.
+
+        ``uv run`` serialises on a shared cache lock, so on a loaded host the
+        probe can exceed its 10s budget and ``subprocess.run`` raises
+        ``TimeoutExpired``. That escaped the probe and aborted ``bernstein
+        doctor`` mid-run, before it had written anything at all -- including
+        the ``--json`` payload. A probe that cannot answer is a failed check,
+        not a crash.
+        """
+        timeout = subprocess.TimeoutExpired(cmd=["uv", "run", "ruff", "--version"], timeout=10)
+        with patch("bernstein.core.quality.ci_fix.subprocess.run", side_effect=timeout):
+            checks = check_test_dependencies()
+
+        assert len(checks) == 3
+        for check in checks:
+            assert check["ok"] == "False"
+            assert "timed out" in check["detail"]
+            assert check["fix"]
+
+    def test_unreadable_uv_returns_result_instead_of_raising(self) -> None:
+        """Any OS-level failure to launch the probe is a failed check too."""
+        with patch(
+            "bernstein.core.quality.ci_fix.subprocess.run",
+            side_effect=PermissionError(13, "Permission denied"),
+        ):
+            checks = check_test_dependencies()
+
+        assert len(checks) == 3
+        assert all(check["ok"] == "False" for check in checks)
+        assert all(check["fix"] for check in checks)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_doctor.py
+++ b/tests/unit/test_doctor.py
@@ -2,6 +2,13 @@
 
 from __future__ import annotations
 
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
 from click.testing import CliRunner
 
 from bernstein.cli.main import cli
@@ -127,3 +134,50 @@ class TestDoctorCommand:
         if result.exit_code == 1:
             # When checks fail without --fix, hint should appear
             assert "--fix" in result.output
+
+
+class TestDoctorJsonStdoutContract:
+    """``--json`` must always leave a parseable payload on stdout.
+
+    Machine consumers read stdout and parse it; a diagnostic probe that
+    cannot answer has to land *in* the payload as a failed check. If it
+    escapes instead, the command dies before serialising and the consumer
+    gets an empty stream with no way to tell "everything is fine" from
+    "the doctor never ran".
+    """
+
+    def test_json_payload_survives_a_probe_that_times_out(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A tool probe blowing its budget must not empty stdout."""
+        monkeypatch.chdir(tmp_path)
+        timeout = subprocess.TimeoutExpired(cmd=["uv", "run", "ruff", "--version"], timeout=10)
+        runner = CliRunner()
+        with patch("bernstein.core.quality.ci_fix.subprocess.run", side_effect=timeout):
+            result = runner.invoke(cli, ["doctor", "--json"])
+
+        payload = _parse_json_payload(result.output)
+        assert isinstance(payload["checks"], list)
+        assert payload["runtime"] in {"local", "codespace"}
+        ci_rows = [c for c in payload["checks"] if str(c["name"]).startswith("CI tool: ")]
+        assert ci_rows, "the CI tool probes must still be represented in the payload"
+        assert all(row["ok"] is False for row in ci_rows)
+
+
+def _parse_json_payload(output: str) -> dict[str, Any]:
+    """Pull the single top-level JSON object out of the doctor's stdout."""
+    start = output.find("{")
+    assert start != -1, f"no JSON object in output:\n{output!r}"
+    depth = 0
+    for idx in range(start, len(output)):
+        if output[idx] == "{":
+            depth += 1
+        elif output[idx] == "}":
+            depth -= 1
+            if depth == 0:
+                payload = json.loads(output[start : idx + 1])
+                assert isinstance(payload, dict)
+                return payload
+    raise AssertionError(f"unterminated JSON in output:\n{output!r}")


### PR DESCRIPTION
## What broke

`bernstein doctor --json` could exit having written **nothing at all** to stdout. A machine consumer then cannot tell "the doctor ran and everything is fine" from "the doctor never produced a payload".

This is what turned `main` red — `tests/unit/cli/test_init_remote.py::test_doctor_json_runtime_local` on the ubuntu/3.12 shard:

```
E   AssertionError: no JSON object in output:
E     
E   assert -1 != -1
```

The captured stdout is the empty string. Not malformed JSON, not JSON with a banner in front of it — nothing.

## Root cause

`_check_tool_version` in `src/bernstein/core/quality/ci_fix.py` probes each CI tool with `uv run <tool> --version` under a 10s budget and caught only `FileNotFoundError`. A `subprocess.TimeoutExpired` — or any other `OSError` from a failed launch — propagated out through `check_test_dependencies` → `_doctor_check_ci_tools` → the doctor command.

The doctor accumulates every check row and serialises the list once, at the very end. So an exception escaping anywhere before that point discards the entire payload rather than a single row.

`uv run` serialises on a shared cache lock, so several concurrent probes on a loaded host queue behind one another and the 10s budget becomes reachable. That makes the failure load-dependent: it appears intermittently, only under contention, and the file's scheduling position within its shard moved (`[26/525]` → `[28/525]`) on the commit where it surfaced. Nothing on the doctor code path itself had changed.

## The fix

Both conditions are now reported the way a diagnostic is supposed to report them — as a failed check row with an actionable fix hint, carried inside the payload:

- probe exceeds its budget → `ok=False`, detail names the timeout;
- probe cannot be launched at all (any `OSError`, not just a missing binary) → `ok=False`, detail names the launch failure.

The timeout is now a named constant so the budget and the detail string cannot drift apart.

This restores the invariant the surrounding code already assumed and the existing `FileNotFoundError` branch already documented: reporting which tools are unusable *is* this function's job, so it must not raise.

## Verification

Reproduced first on unmodified source, byte-identical to the CI symptom:

```
E   AssertionError: no JSON object in output:
      ''
```

Regression coverage added at both levels, each failing before the fix and passing after:

| Test | Pins |
|---|---|
| `test_slow_uv_returns_result_instead_of_raising` | a probe over budget is a failed row, not an exception |
| `test_unreadable_uv_returns_result_instead_of_raising` | an unlaunchable probe is a failed row too |
| `test_json_payload_survives_a_probe_that_times_out` | `doctor --json` still emits one parseable object with every `CI tool: *` row present |

Run on Python 3.12 (the shard that failed):

```
tests/unit/test_ci_fix.py tests/unit/test_doctor.py tests/unit/cli/test_init_remote.py
75 passed, 1 skipped
```

`ruff check`, `ruff format --check`, and `mypy` clean on the touched files. The failing test was not modified.

## User-visible change

`bernstein doctor` (both modes) now shows a `CI tool: <name>` row reading `probe timed out after 10s` instead of aborting the run, when the probe cannot finish in time. `--json` consumers always receive a parseable payload.

Closes #3330.

## Summary by Sourcery

Handle CI tool probe failures in the doctor command without aborting output so JSON mode always emits a parseable payload.

Bug Fixes:
- Report CI tool probes that time out or fail to launch as failed checks instead of raising exceptions that prevent doctor from writing any output.
- Ensure `bernstein doctor --json` always produces a JSON payload even when CI tool detection fails under load or due to OS errors.

Enhancements:
- Introduce a shared timeout constant for CI tool version probes and surface clearer diagnostic messages and fix hints when probes cannot complete.

Tests:
- Add tests ensuring CI tool timeouts and launch failures are reported as failed check rows rather than exceptions, and that doctor JSON output remains parseable with CI tool failures present.