### PR TITLE
fix(worker): keep long prompts off the Windows .cmd/.bat shim command line

### DIFF
--- a/docs/operations/TROUBLESHOOTING.md
+++ b/docs/operations/TROUBLESHOOTING.md
@@ -79,6 +79,14 @@ claude --version  # should print version info
 
 **Resolution:** Bernstein now resolves the bare name via `shutil.which` and, on Windows, routes a resolved `.cmd`/`.bat` shim through `cmd.exe /c` automatically. Ensure `PATHEXT` is present in your environment (it is passed through to spawned agents). No manual action is needed on current versions; if you see this on an older build, upgrade Bernstein.
 
+### 2b. Windows: long prompt fails silently through a `.cmd`/`.bat` shim
+
+**Symptom:** On Windows, a task with a large prompt (roughly 8000+ characters) spawns and exits almost immediately with no useful output; Bernstein treats it as an agent that started and produced no work.
+
+**Cause:** Routing a resolved `.cmd`/`.bat` shim through `cmd.exe /c` (see 2a) makes the *whole* command line subject to cmd.exe's own ~8191-character internal line buffer -- a much smaller limit than the ~32767 characters `CreateProcess` itself allows. A long prompt passed as a command-line argument can push the line past that buffer; cmd.exe then refuses the launch with `The command line is too long.` before the adapter binary starts.
+
+**Resolution:** For the `claude` adapter, Bernstein now writes an oversized prompt to a file under `.sdd/runtime/prompts/` and pipes it to the CLI's stdin instead of passing it on the command line, so the shim's command line stays under cmd.exe's limit regardless of prompt size. No manual action is needed. Other adapters whose CLI is not yet confirmed to accept a stdin-piped prompt still fail the same way on an oversized prompt; installing the CLI's native `.exe` build (bypassing the Node version manager's `.cmd` shim) avoids the cmd.exe hop entirely.
+
 ---
 
 ## 3. API Key Not Set

--- a/src/bernstein/core/orchestration/worker.py
+++ b/src/bernstein/core/orchestration/worker.py
@@ -118,6 +118,99 @@ def _resolve_launch_cmd(cmd: list[str]) -> list[str]:
     return [resolved, *rest]
 
 
+# cmd.exe's own internal line buffer is ~8191 characters -- independent of,
+# and much smaller than, the ~32767-character command line CreateProcess
+# itself allows. A ``.cmd``/``.bat`` shim always spawns through
+# ``cmd.exe /c`` (see ``_resolve_launch_cmd`` above), so a long prompt that
+# fits comfortably under CreateProcess's own limit can still push the *whole*
+# ``/c`` line past cmd.exe's buffer. cmd.exe then refuses the launch with
+# "The command line is too long." on stderr before the adapter binary ever
+# starts, which Bernstein reads as a process that started and produced no
+# work and routes to the merge path -- discarding real work over a spawn
+# failure that was never surfaced as one (issue #3311).
+_CMD_EXE_LINE_LIMIT = 8191
+# Safety margin below the hard limit: list2cmdline's own quoting can grow
+# an argument by a few characters per embedded space/quote, and resolved
+# shim paths vary in length across hosts.
+_CMD_EXE_LINE_MARGIN = 200
+
+# Adapters whose CLI is verified to read the prompt from stdin when their
+# prompt flag is passed with no trailing value (Claude Code's headless
+# ``-p`` / ``--print`` mode: with an argument it is the one-shot prompt,
+# without one it reads stdin). Deliberately narrow: an adapter binary not
+# listed here keeps today's behaviour -- the prompt stays on the command
+# line and an overlong one still fails the same way it does now -- rather
+# than guessing at an unverified CLI contract and silently invoking some
+# other CLI with a missing prompt argument.
+_STDIN_PROMPT_FLAGS: dict[str, str] = {
+    "claude": "-p",
+}
+
+
+def _avoid_shim_line_overflow(
+    cmd: list[str],
+    launch_cmd: list[str],
+    *,
+    workdir: Path,
+    session: str,
+) -> tuple[list[str], Path | None]:
+    """Move an overlong trailing prompt off a cmd.exe-routed command line.
+
+    Only engages when *launch_cmd* is the ``cmd.exe /c`` wrapping
+    :func:`_resolve_launch_cmd` produces for a ``.cmd``/``.bat`` shim and the
+    resulting line would exceed cmd.exe's own buffer (issue #3311). Real
+    ``.exe`` targets and every POSIX spawn are untouched by this function --
+    ``launch_cmd`` comes back unchanged and no file is written.
+
+    For adapters in :data:`_STDIN_PROMPT_FLAGS`, the trailing
+    ``[prompt_flag, prompt]`` pair is rewritten to just ``[prompt_flag]`` and
+    the prompt is written to a session-scoped file under
+    ``<workdir>/.sdd/runtime/prompts/`` -- the same location and naming
+    convention the container/sandbox spawn paths already use for prompts
+    that would overflow ``ARG_MAX`` (see ``_spawn_in_container`` /
+    ``_spawn_in_sandbox`` in ``core/agents/spawner_core.py``) -- for the
+    caller to open and pipe in as the child's stdin.
+
+    Args:
+        cmd: The original (pre-resolution) inner argv, e.g.
+            ``["claude", "--model", ..., "-p", prompt]``.
+        launch_cmd: The result of :func:`_resolve_launch_cmd` for *cmd*.
+        workdir: Project root, used to place the overflow prompt file
+            alongside the existing ``.sdd/runtime/prompts/`` convention.
+        session: Session ID, used to name the overflow prompt file so it is
+            diagnosable and never collides across concurrent spawns.
+
+    Returns:
+        A ``(launch_cmd, prompt_path)`` pair. ``prompt_path`` is ``None``
+        unless the prompt was moved to a file, in which case the caller
+        should open it and pass it as the child's ``stdin``.
+    """
+    if len(launch_cmd) < 3 or launch_cmd[1] != "/c":
+        return launch_cmd, None  # not a cmd.exe shim wrap; no line limit applies
+
+    if len(subprocess.list2cmdline(launch_cmd)) <= _CMD_EXE_LINE_LIMIT - _CMD_EXE_LINE_MARGIN:
+        return launch_cmd, None  # comfortably under cmd.exe's buffer
+
+    binary = cmd[0] if cmd else ""
+    flag = _STDIN_PROMPT_FLAGS.get(binary)
+    if flag is None or len(cmd) < 3 or cmd[-2] != flag:
+        # No verified stdin fallback for this CLI (or the trailing tokens
+        # don't match the known prompt-flag shape) -- leave the command line
+        # as-is. It still overflows and cmd.exe will still reject it, same
+        # as today; we do not guess at a contract we haven't verified.
+        return launch_cmd, None
+
+    prompt = cmd[-1]
+    prompt_dir = workdir / ".sdd" / "runtime" / "prompts"
+    prompt_dir.mkdir(parents=True, exist_ok=True)
+    prompt_path = prompt_dir / f"{session}.stdin-overflow"
+    prompt_path.write_text(prompt, encoding="utf-8")
+
+    trimmed_cmd = cmd[:-1]  # drop the prompt; keep the bare flag
+    trimmed_launch_cmd = _resolve_launch_cmd(trimmed_cmd)
+    return trimmed_launch_cmd, prompt_path
+
+
 def _set_proctitle(title: str) -> None:
     """Set the process title for ps / Activity Monitor."""
     with contextlib.suppress(ImportError):
@@ -427,12 +520,21 @@ def main() -> None:
     # than failing in CreateProcess. ``cmd[0]`` is preserved for the
     # command-not-found diagnostic below.
     launch_cmd = _resolve_launch_cmd(cmd)
+    # For a .cmd/.bat shim whose resolved line would overflow cmd.exe's
+    # ~8191-character buffer, move the prompt off the command line into a
+    # file and pipe it in as stdin instead (issue #3311). No-op -- returns
+    # launch_cmd unchanged and stdin_prompt_path=None -- for every spawn that
+    # already fits, which is every POSIX spawn and most Windows ones.
+    launch_cmd, stdin_prompt_path = _avoid_shim_line_overflow(
+        cmd, launch_cmd, workdir=Path(args.workdir), session=args.session
+    )
+    stdin_file = stdin_prompt_path.open("rb") if stdin_prompt_path is not None else None
     try:
         # launch_cmd is an argv list (never a shell string) built from the
         # trusted adapter command; shell=False, so there is no shell to inject
         # into. The Windows cmd.exe /c wrapper also passes each arg as a
         # separate list element, not a concatenated command line.
-        child = subprocess.Popen(launch_cmd)  # nosemgrep
+        child = subprocess.Popen(launch_cmd, stdin=stdin_file)  # nosemgrep
         # Publish the child so the already-installed terminating-signal
         # handler forwards to it (and lets main() reap it) instead of
         # unlinking + exiting on its own.
@@ -471,6 +573,14 @@ def main() -> None:
         )
         del exc
         sys.exit(126)
+    finally:
+        # The child inherited its own handle to stdin_file when Popen
+        # returned (or never started, on the FileNotFoundError/
+        # PermissionError paths above); the parent's copy can close either
+        # way. Mirrors the existing pattern in adapters/cursor.py, the other
+        # stdin-prompt spawn path in this codebase.
+        if stdin_file is not None:
+            stdin_file.close()
 
     # Update PID file with child PID
     # Validate pid_file stays within pid_dir to prevent path traversal (S2083)

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -13,7 +13,11 @@ from typing import TYPE_CHECKING
 import pytest
 
 from bernstein.adapters.base import build_worker_cmd
-from bernstein.core.orchestration.worker import _resolve_launch_cmd
+from bernstein.core.orchestration.worker import (
+    _CMD_EXE_LINE_LIMIT,
+    _avoid_shim_line_overflow,
+    _resolve_launch_cmd,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -171,6 +175,96 @@ class TestResolveLaunchCmd:
     def test_empty_cmd_returned_as_is(self) -> None:
         """Guard: an empty argv is returned unchanged (main() handles it)."""
         assert _resolve_launch_cmd([]) == []
+
+
+# ---------------------------------------------------------------------------
+# _avoid_shim_line_overflow -- keep .cmd/.bat spawns under cmd.exe's
+# ~8191-character line buffer (issue #3311)
+# ---------------------------------------------------------------------------
+
+
+class TestAvoidShimLineOverflow:
+    """A prompt over cmd.exe's buffer must not reach the shim command line.
+
+    cmd.exe enforces an ~8191-character line limit independent of (and much
+    smaller than) CreateProcess's own ~32767-character allowance. A ``.cmd``/
+    ``.bat`` shim always spawns through ``cmd.exe /c`` (``_resolve_launch_cmd``),
+    so a long prompt can overflow cmd.exe's buffer even though the process
+    launch itself would otherwise succeed. cmd.exe then writes "The command
+    line is too long." and exits before the adapter binary starts, which
+    Bernstein reads as a dead agent instead of a spawn failure.
+    """
+
+    def _windows_shim_launch_cmd(self, monkeypatch: pytest.MonkeyPatch, cmd: list[str]) -> list[str]:
+        monkeypatch.setattr("bernstein.core.orchestration.worker.os.name", "nt")
+        monkeypatch.setattr("bernstein.core.orchestration.worker.os.sep", "\\")
+        monkeypatch.setattr("bernstein.core.orchestration.worker.os.altsep", "/")
+        monkeypatch.setenv("COMSPEC", r"C:\Windows\System32\cmd.exe")
+        monkeypatch.setattr(
+            "bernstein.core.orchestration.worker.shutil.which",
+            lambda name: rf"C:\nvm4w\nodejs\{name}.CMD",
+        )
+        return _resolve_launch_cmd(cmd)
+
+    def test_long_claude_prompt_moved_to_stdin_file(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """A >8191-char prompt is pulled off the command line entirely."""
+        prompt = "x" * 16_043  # the exact size reported in issue #3311
+        cmd = ["claude", "--model", "sonnet", "--effort", "high", "-p", prompt]
+        launch_cmd = self._windows_shim_launch_cmd(monkeypatch, cmd)
+        # Unmodified, this line is far over the limit -- the reproduction.
+        assert len(subprocess.list2cmdline(launch_cmd)) > _CMD_EXE_LINE_LIMIT
+
+        result, prompt_path = _avoid_shim_line_overflow(cmd, launch_cmd, workdir=tmp_path, session="qa-abc123")
+
+        assert len(subprocess.list2cmdline(result)) <= _CMD_EXE_LINE_LIMIT
+        assert prompt not in result
+        assert result[-1] == "-p"  # bare flag kept so claude reads stdin
+        assert prompt_path is not None
+        assert prompt_path.read_text(encoding="utf-8") == prompt
+
+    def test_short_prompt_left_on_command_line(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """A prompt well under the limit is untouched -- no file, no rewrite."""
+        cmd = ["claude", "--model", "sonnet", "-p", "fix the failing test"]
+        launch_cmd = self._windows_shim_launch_cmd(monkeypatch, cmd)
+
+        result, prompt_path = _avoid_shim_line_overflow(cmd, launch_cmd, workdir=tmp_path, session="qa-abc123")
+
+        assert result == launch_cmd
+        assert prompt_path is None
+
+    def test_unknown_binary_with_long_prompt_left_unchanged(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A CLI with no verified stdin fallback keeps today's behaviour.
+
+        The command line still overflows -- we do not silently drop an
+        argument against a CLI we haven't verified reads stdin instead.
+        """
+        prompt = "x" * 16_043
+        cmd = ["some-other-agent", "--go", prompt]
+        launch_cmd = self._windows_shim_launch_cmd(monkeypatch, cmd)
+
+        result, prompt_path = _avoid_shim_line_overflow(cmd, launch_cmd, workdir=tmp_path, session="qa-abc123")
+
+        assert result == launch_cmd
+        assert prompt_path is None
+
+    def test_posix_target_never_rewritten(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Off the cmd.exe /c path (POSIX, or a real .exe), nothing changes."""
+        monkeypatch.setattr("bernstein.core.orchestration.worker.os.name", "posix")
+        monkeypatch.setattr(
+            "bernstein.core.orchestration.worker.shutil.which",
+            lambda name: f"/usr/local/bin/{name}",
+        )
+        prompt = "x" * 16_043
+        cmd = ["claude", "--model", "sonnet", "-p", prompt]
+        launch_cmd = _resolve_launch_cmd(cmd)
+
+        result, prompt_path = _avoid_shim_line_overflow(cmd, launch_cmd, workdir=tmp_path, session="qa-abc123")
+
+        assert result == launch_cmd
+        assert prompt in result
+        assert prompt_path is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- On Windows, a `.cmd`/`.bat` shim (the shape nvm-windows installs for the Claude/Codex/Gemini CLIs) always spawns through `cmd.exe /c`, which enforces its own ~8191-character line buffer — independent of, and much smaller than, the ~32767-character command line `CreateProcess` itself allows.
- A prompt long enough to push the whole `cmd.exe /c` line past that buffer made cmd.exe reject the launch with `The command line is too long.` before the adapter binary ever started. Bernstein read the immediate exit as an agent that started and produced no work and proceeded to the merge path, discarding real work instead of surfacing a spawn failure.
- `bernstein-worker` now detects when the resolved `cmd.exe /c` line would overflow the buffer and, for the `claude` adapter (whose CLI reads the prompt from stdin when `-p` is passed with no value), writes the prompt to a session-scoped file under `.sdd/runtime/prompts/` and pipes it in as stdin instead of putting it on the command line. Every spawn that already fits under the buffer — which is every POSIX spawn and most Windows ones — is unaffected.
- Other adapters keep today's behaviour: the command line still overflows on an oversized prompt through a `.cmd`/`.bat` shim, same as before this change, since their CLI's stdin contract for the prompt isn't yet verified.
- Documented the failure mode and current scope in `docs/operations/TROUBLESHOOTING.md`.

## User-visible change

None for prompts under the buffer limit. On Windows, a `claude`-adapter task with a large prompt that previously failed silently through a `.cmd` shim now spawns correctly.

## Test plan

- [x] `tests/unit/test_worker.py::TestAvoidShimLineOverflow` — new coverage: an oversized `claude` prompt is moved off the command line and the resulting line stays under the limit (fails on unmodified code); a short prompt is left untouched; an adapter with no verified stdin fallback is left untouched; a POSIX/real-`.exe` target is never rewritten.
- [x] `uv run pytest tests/unit -k "spawn and (cmd or shim or windows)"` — 31 passed
- [x] `uv run pytest tests/unit/test_worker.py` — full file, 20 passed
- [x] `uv run ruff check` / `uv run ruff format --check` on changed files
- [x] `uv run mypy src/bernstein/core/orchestration/worker.py` — no issues

Closes #3311

## Summary by Sourcery

Handle oversized Windows shim command lines by moving verified adapter prompts to stdin to prevent silent spawn failures.

New Features:
- Support stdin-based prompt delivery for the claude adapter when a Windows .cmd/.bat shim command line would exceed cmd.exe's buffer.

Bug Fixes:
- Prevent large claude prompts on Windows from failing silently when launched via a .cmd/.bat shim that overflows cmd.exe's command-line buffer.

Enhancements:
- Introduce a shim-aware helper that detects potential cmd.exe line overflows and rewrites the launch command to keep it within safe limits.
- Align overflow prompt handling with existing container/sandbox prompt file conventions and ensure stdin file handles are correctly managed.

Documentation:
- Document the Windows .cmd/.bat shim line-length failure mode and its current mitigation scope in troubleshooting guidance.

Tests:
- Add unit tests covering Windows shim resolution and prompt overflow handling, including claude-specific behaviour, non-stdin-capable adapters, and POSIX targets.