### PR TITLE
fix(stop): reap orphaned watchdog when its pidfile is gone

### DIFF
--- a/src/bernstein/cli/commands/stop_cmd.py
+++ b/src/bernstein/cli/commands/stop_cmd.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import contextlib
+import csv
+import io
 import json
 import os
 import shutil
@@ -33,7 +35,7 @@ from bernstein.cli.helpers import (
     sigkill_pid,
 )
 from bernstein.core.observability.icons import get_icons
-from bernstein.core.process_utils import process_cwd
+from bernstein.core.process_utils import cmdline_matches, process_cwd
 from bernstein.core.runtime_state import read_supervisor_state
 
 _LABEL_TASK_SERVER = "Task server"
@@ -458,17 +460,52 @@ def _list_process_snapshots() -> list[_ProcessSnapshot]:
     return _list_process_snapshots_unix()
 
 
-def _list_process_snapshots_windows() -> list[_ProcessSnapshot]:
-    """Windows: use WMIC or PowerShell to list processes."""
+def _parse_windows_process_csv(csv_text: str) -> list[_ProcessSnapshot]:
+    """Parse ``ConvertTo-Csv`` output of ``ProcessId, ParentProcessId, CommandLine``.
+
+    Uses the stdlib ``csv`` reader rather than a manual ``split('","')`` because
+    ``CommandLine`` routinely contains commas and quotes (paths, flag values)
+    that a naive split mis-parses; ``ConvertTo-Csv`` emits RFC4180-style
+    quoting (embedded quotes doubled) that ``csv`` decodes correctly.
+    """
+    reader = csv.reader(io.StringIO(csv_text))
+    rows = list(reader)
+    if len(rows) < 2:
+        return []
     snapshots: list[_ProcessSnapshot] = []
+    for row in rows[1:]:  # header: ProcessId,ParentProcessId,CommandLine
+        if len(row) < 3:
+            continue
+        try:
+            pid = int(row[0])
+            ppid = int(row[1]) if row[1] else 0
+        except ValueError:
+            continue
+        snapshots.append(_ProcessSnapshot(pid=pid, ppid=ppid, pgid=0, command=row[2] or ""))
+    return snapshots
+
+
+def _list_process_snapshots_windows() -> list[_ProcessSnapshot]:
+    """Windows: use PowerShell/CIM to list processes with their full command line.
+
+    Queries ``Win32_Process`` directly for ``ProcessId``, ``ParentProcessId``,
+    and ``CommandLine``. An earlier version of this probe selected ``Path``
+    (just the executable, e.g. ``python.exe``) from ``Get-Process`` instead of
+    the actual command line, so none of the argv markers
+    ``_classify_repo_process`` matches on (``--watchdog``, the heartbeat/
+    worktree path prefixes, ...) were ever present in ``command`` -- the
+    process-scan fallback could not identify a repo-owned watchdog,
+    orchestrator, or task server on Windows at all (issue #3312).
+    """
     with contextlib.suppress(OSError, subprocess.SubprocessError):
-        # Use PowerShell for better reliability
         result = subprocess.run(
             [
                 "powershell",
                 "-NoProfile",
                 "-Command",
-                "Get-Process | Select-Object Id, @{N='ParentId';E={(Get-CimInstance Win32_Process -Filter \"ProcessId=$($_.Id)\").ParentProcessId}}, Path | ConvertTo-Csv -NoTypeInformation",  # noqa: E501
+                "Get-CimInstance -ClassName Win32_Process | "
+                "Select-Object ProcessId, ParentProcessId, CommandLine | "
+                "ConvertTo-Csv -NoTypeInformation",
             ],
             capture_output=True,
             text=True,
@@ -479,22 +516,8 @@ def _list_process_snapshots_windows() -> list[_ProcessSnapshot]:
         )
         if result.returncode != 0:
             return []
-        lines = result.stdout.strip().splitlines()
-        if len(lines) < 2:
-            return []
-        # Skip header: "Id","ParentId","Path"
-        for line in lines[1:]:
-            # Parse CSV: "1234","5678","C:\path\to\exe"
-            parts = line.strip().strip('"').split('","')
-            if len(parts) >= 3:
-                try:
-                    pid = int(parts[0])
-                    ppid = int(parts[1]) if parts[1] else 0
-                    command = parts[2]
-                    snapshots.append(_ProcessSnapshot(pid=pid, ppid=ppid, pgid=0, command=command))
-                except (ValueError, IndexError):
-                    continue
-    return snapshots
+        return _parse_windows_process_csv(result.stdout)
+    return []
 
 
 def _list_process_snapshots_unix() -> list[_ProcessSnapshot]:
@@ -533,6 +556,22 @@ def _list_process_snapshots_unix() -> list[_ProcessSnapshot]:
     return snapshots
 
 
+def _watchdog_names_workdir(command: str, workdir: Path) -> bool:
+    """Whether *command* embeds *workdir* via the watchdog's own ``--workdir`` marker.
+
+    ``process_cwd()`` has no working implementation on Windows - it shells out
+    to ``lsof``, which does not exist there - so the live-cwd cross-check the
+    other infra kinds fall back on can never positively confirm anything on
+    that platform, and an orphaned watchdog (its pidfile overwritten by a
+    later run, or never written) was unreachable by the process-scan fallback
+    (issue #3312). ``_start_watchdog`` now writes ``--workdir <path>`` into its
+    own launch argv, so ownership can be read straight off the command line -
+    the same technique already used for heartbeat/worktree orphans - with no
+    cwd probe needed at all.
+    """
+    return cmdline_matches(command, (str(workdir),))
+
+
 def _classify_repo_process(
     snapshot: Any,
     workdir: Path,
@@ -544,7 +583,10 @@ def _classify_repo_process(
     ``kind`` is ``"agent"`` for orphaned worktree/heartbeat processes (matched
     purely by command-line marker, no cwd probe) or ``"infra"`` for the
     orchestrator/server/watchdog - which must additionally run with a cwd
-    inside this project, so a sibling checkout's server is never touched.
+    inside this project, so a sibling checkout's server is never touched.  The
+    watchdog gets one extra, cwd-probe-free path first (see
+    :func:`_watchdog_names_workdir`) because it is the only infra kind whose
+    launch argv self-declares its workdir.
     """
     command = snapshot.command
 
@@ -559,6 +601,9 @@ def _classify_repo_process(
 
     if not (is_watchdog or is_orchestrator or is_server):
         return None
+
+    if is_watchdog and _watchdog_names_workdir(command, workdir):
+        return "infra", "Watchdog"
 
     if process_cwd(snapshot.pid) != workdir:
         return None

--- a/src/bernstein/core/orchestration/bootstrap.py
+++ b/src/bernstein/core/orchestration/bootstrap.py
@@ -848,6 +848,13 @@ def _start_watchdog(
         "--watchdog",
         "--port",
         str(port),
+        # Self-describing so the stop path can attribute an orphaned watchdog to
+        # this checkout by reading its argv, without a live cwd probe (issue
+        # #3312). The subprocess already runs with ``cwd=workdir`` below; this
+        # flag is not consumed for that -- it exists purely so ``ps``/WMI output
+        # carries the workdir as a command-line marker.
+        "--workdir",
+        str(workdir),
     ]
     if adapter:
         argv.extend(["--adapter", adapter])
@@ -1490,6 +1497,18 @@ if __name__ == "__main__":
         type=str,
         default=os.environ.get("BERNSTEIN_SEED_PATH", "").strip() or None,
         help="Resolved bernstein.yaml path, threaded through from bootstrap_from_seed().",
+    )
+    _parser.add_argument(
+        "--workdir",
+        type=str,
+        default=None,
+        help=(
+            "Project root this watchdog was launched for. Not read by the "
+            "watchdog itself (its cwd already is workdir) -- it is only a "
+            "command-line marker so 'bernstein stop --force' can attribute an "
+            "orphaned watchdog to this checkout when it has no live cwd probe "
+            "to fall back on (issue #3312)."
+        ),
     )
     _args = _parser.parse_args()
 

--- a/tests/unit/test_stop_cmd_watchdog_reap.py
+++ b/tests/unit/test_stop_cmd_watchdog_reap.py
@@ -1,0 +1,295 @@
+"""``bernstein stop --force`` must not leave an orphaned watchdog alive (issue #3312).
+
+The process-scan fallback (`hard_stop`'s source D, `_collect_repo_processes`)
+is supposed to catch a watchdog whose pidfile was overwritten by a later run
+or was never written. On Windows that fallback silently excluded the watchdog
+(and the orchestrator/server) from every sweep, for two independent reasons:
+
+1. ``_list_process_snapshots_windows`` queried ``Get-Process | Select
+   ... Path`` -- the *executable* path (``python.exe``), never the actual
+   command line -- so none of ``_classify_repo_process``'s argv markers
+   (``--watchdog``, the heartbeat/worktree path prefixes) could ever match.
+2. Even with the command line visible, ``_classify_repo_process`` required
+   ``process_cwd(pid) == workdir`` for the watchdog/orchestrator/server kinds.
+   ``process_cwd`` shells out to ``lsof``, which does not exist on Windows, so
+   it always returns ``None`` there and the check always failed.
+
+The fix makes ``_start_watchdog`` write ``--workdir <path>`` into its own
+argv and teaches ``_classify_repo_process`` to read watchdog ownership
+straight from that marker, without a cwd probe, plus fixes the Windows
+snapshot probe to capture the real command line.
+
+These tests reproduce the enumeration gap platform-independently by forcing
+``process_cwd`` to always return ``None`` -- exactly what happens for real on
+Windows -- rather than requiring an actual Windows host.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bernstein.cli.commands import stop_cmd
+from bernstein.core.orchestration import bootstrap
+
+
+def _alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _wait_dead(pid: int, timeout: float = 6.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not _alive(pid):
+            return True
+        time.sleep(0.05)
+    return not _alive(pid)
+
+
+def _wait_dead_direct_child(proc: subprocess.Popen[bytes], timeout: float = 6.0) -> bool:
+    """Reap a stub spawned directly by this test via ``Popen.wait``.
+
+    ``proc`` is a direct child of the test process, so a killed-but-unreaped
+    child becomes a zombie: it still exists in the process table and
+    ``os.kill(pid, 0)`` keeps succeeding on it until something calls
+    ``wait()``. A negative return code confirms the process was terminated
+    by a signal rather than having exited on its own.
+    """
+    try:
+        return proc.wait(timeout=timeout) < 0
+    except subprocess.TimeoutExpired:
+        return False
+
+
+def _spawn_orphan_watchdog_stub() -> subprocess.Popen[bytes]:
+    """A tiny real process standing in for an orphaned watchdog.
+
+    Started detached (``start_new_session=True``), exactly like the real
+    watchdog launched by ``_start_watchdog``, so it survives its "parent"
+    (the test) the same way a real watchdog survives a crashed CLI process.
+    We never actually run the watchdog module here -- the classifier only
+    ever reads the *command-line string* we hand it via a crafted
+    ``_ProcessSnapshot``, not the process's real argv.
+    """
+    return subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(120)"],
+        start_new_session=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def _hard_cleanup(proc: subprocess.Popen[bytes]) -> None:
+    with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+        os.killpg(proc.pid, 9)
+    with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+        os.kill(proc.pid, 9)
+    with contextlib.suppress(subprocess.TimeoutExpired):
+        proc.wait(timeout=3)
+
+
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="uses POSIX process groups to spawn/verify the stub")
+
+
+class TestStartWatchdogNamesItsOwnWorkdir:
+    """``_start_watchdog`` must self-declare its workdir in argv (issue #3312)."""
+
+    def test_argv_contains_workdir_flag(self, tmp_path: Path, monkeypatch: Any) -> None:
+        captured: dict[str, list[str]] = {}
+
+        class _FakeProc:
+            def __init__(self) -> None:
+                self.pid = 424242
+
+            def wait(self, timeout: float | None = None) -> int:
+                raise subprocess.TimeoutExpired(cmd="watchdog", timeout=timeout or 0.0)
+
+        def _fake_popen(argv: list[str], **_kwargs: Any) -> _FakeProc:
+            captured["argv"] = argv
+            return _FakeProc()
+
+        monkeypatch.setattr(bootstrap.subprocess, "Popen", _fake_popen)
+        (tmp_path / ".sdd" / "runtime").mkdir(parents=True)
+
+        bootstrap._start_watchdog(tmp_path, 8052)
+
+        argv = captured["argv"]
+        assert "--workdir" in argv, argv
+        assert argv[argv.index("--workdir") + 1] == str(tmp_path)
+
+
+class TestClassifyRepoProcessWatchdogWithoutCwdProbe:
+    """``_classify_repo_process`` must attribute a watchdog via its argv marker."""
+
+    def test_fails_without_workdir_marker_when_cwd_probe_is_unavailable(self, tmp_path: Path) -> None:
+        """Pre-fix shape: no ``--workdir`` marker, cwd probe unavailable (Windows)."""
+        snapshot = stop_cmd._ProcessSnapshot(
+            pid=999,
+            ppid=1,
+            pgid=999,
+            command=f"{sys.executable} -m bernstein.core.orchestration.bootstrap --watchdog --port 8052",
+        )
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(_force_process_cwd_unavailable())
+            result = stop_cmd._classify_repo_process(
+                snapshot, tmp_path, str(tmp_path / "heartbeats"), str(tmp_path / "worktrees")
+            )
+        assert result is None
+
+    def test_succeeds_with_workdir_marker_when_cwd_probe_is_unavailable(self, tmp_path: Path) -> None:
+        """Post-fix shape: ``--workdir`` marker present, cwd probe still unavailable."""
+        snapshot = stop_cmd._ProcessSnapshot(
+            pid=999,
+            ppid=1,
+            pgid=999,
+            command=(
+                f"{sys.executable} -m bernstein.core.orchestration.bootstrap "
+                f"--watchdog --port 8052 --workdir {tmp_path}"
+            ),
+        )
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(_force_process_cwd_unavailable())
+            result = stop_cmd._classify_repo_process(
+                snapshot, tmp_path, str(tmp_path / "heartbeats"), str(tmp_path / "worktrees")
+            )
+        assert result == ("infra", "Watchdog")
+
+
+def _force_process_cwd_unavailable() -> Any:
+    """Context manager simulating the real Windows behaviour: ``process_cwd`` always ``None``.
+
+    ``process_cwd`` shells out to ``lsof``, absent on Windows, so every call
+    returns ``None`` there regardless of the pid queried. Forcing that here
+    reproduces the platform gap on any host.
+    """
+    import unittest.mock
+
+    return unittest.mock.patch.object(stop_cmd, "process_cwd", return_value=None)
+
+
+class TestCollectRepoProcessesReapsOrphanedWatchdog:
+    """End-to-end: the reap-fallback sweep used by ``stop --force`` kills a real orphan."""
+
+    def test_reaps_watchdog_via_argv_marker_when_pidfile_and_cwd_probe_are_both_gone(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        """Reproduces issue #3312: no pidfile for this watchdog, no cwd probe (Windows).
+
+        Mirrors the reported scenario: an earlier run's watchdog is still
+        alive but its pidfile was overwritten (or was never written) by a
+        later run, and the host is Windows so the process-scan fallback's
+        cwd cross-check can never confirm anything. Fails on unmodified code
+        because ``_classify_repo_process`` has no argv-only path for the
+        watchdog and therefore never classifies it.
+        """
+        monkeypatch.chdir(tmp_path)
+        stub = _spawn_orphan_watchdog_stub()
+        try:
+            snapshot = stop_cmd._ProcessSnapshot(
+                pid=stub.pid,
+                ppid=1,
+                pgid=stub.pid,
+                command=(
+                    f"{sys.executable} -m bernstein.core.orchestration.bootstrap "
+                    f"--watchdog --port 8052 --workdir {tmp_path}"
+                ),
+            )
+            monkeypatch.setattr(stop_cmd, "_list_process_snapshots", lambda: [snapshot])
+            monkeypatch.setattr(stop_cmd, "process_cwd", lambda _pid: None)
+
+            # No watchdog.pid on disk at all -- exactly the "pidfile belongs to
+            # a run whose other state was already cleaned up" scenario named
+            # in the issue.
+            assert not (tmp_path / ".sdd" / "runtime" / "watchdog.pid").exists()
+
+            killed: set[int] = set()
+            stop_cmd._collect_repo_processes(killed)
+
+            assert _wait_dead_direct_child(stub), "orphaned watchdog stub survived the reap-fallback sweep"
+            assert stub.pid in killed
+        finally:
+            _hard_cleanup(stub)
+
+
+class TestHardStopReapsOrphanedWatchdog:
+    """``stop --force`` (``hard_stop``) itself must not leave the watchdog running."""
+
+    def test_hard_stop_kills_orphaned_watchdog_with_no_pidfile_on_simulated_windows(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        stub = _spawn_orphan_watchdog_stub()
+        try:
+            snapshot = stop_cmd._ProcessSnapshot(
+                pid=stub.pid,
+                ppid=1,
+                pgid=stub.pid,
+                command=(
+                    f"{sys.executable} -m bernstein.core.orchestration.bootstrap "
+                    f"--watchdog --port 8052 --workdir {tmp_path}"
+                ),
+            )
+            monkeypatch.setattr(stop_cmd, "_list_process_snapshots", lambda: [snapshot])
+            monkeypatch.setattr(stop_cmd, "process_cwd", lambda _pid: None)
+            # Keep the sweep hermetic: no session server, no tunnels, no real
+            # port holder on this host should be touched by the test.
+            monkeypatch.setattr(stop_cmd, "save_session_on_stop", lambda _workdir: None)
+            monkeypatch.setattr(stop_cmd, "stop_active_tunnels", lambda: 0)
+            monkeypatch.setattr(stop_cmd, "_kill_port_holder", lambda *_a, **_k: None)
+
+            stop_cmd.hard_stop()
+
+            assert _wait_dead_direct_child(stub), "'bernstein stop --force' left the watchdog running"
+        finally:
+            _hard_cleanup(stub)
+
+
+class TestParseWindowsProcessCsv:
+    """The Windows snapshot probe must capture the full command line (issue #3312)."""
+
+    def test_captures_full_command_line_not_just_executable_path(self) -> None:
+        csv_text = (
+            '"ProcessId","ParentProcessId","CommandLine"\n'
+            '"4242","1","\\"C:\\\\Python312\\\\python.exe\\" -m '
+            "bernstein.core.orchestration.bootstrap --watchdog --port 8052 "
+            '--workdir \\"C:\\\\Users\\\\op\\\\proj\\""\n'
+        )
+
+        snapshots = stop_cmd._parse_windows_process_csv(csv_text)
+
+        assert len(snapshots) == 1
+        snap = snapshots[0]
+        assert snap.pid == 4242
+        assert snap.ppid == 1
+        assert "bernstein.core.orchestration.bootstrap" in snap.command
+        assert "--watchdog" in snap.command
+        assert "--workdir" in snap.command
+
+    def test_handles_commas_inside_quoted_command_line(self) -> None:
+        """A naive ``split('","')`` mis-parses a CommandLine containing a comma."""
+        csv_text = '"ProcessId","ParentProcessId","CommandLine"\n"10","1","python.exe --seed goal-a,goal-b"\n'
+
+        snapshots = stop_cmd._parse_windows_process_csv(csv_text)
+
+        assert len(snapshots) == 1
+        assert snapshots[0].command == "python.exe --seed goal-a,goal-b"
+
+    def test_empty_output_yields_no_snapshots(self) -> None:
+        assert stop_cmd._parse_windows_process_csv("") == []
+
+    def test_header_only_yields_no_snapshots(self) -> None:
+        csv_text = '"ProcessId","ParentProcessId","CommandLine"\n'
+        assert stop_cmd._parse_windows_process_csv(csv_text) == []


### PR DESCRIPTION
## Summary

`stop --force` enumerates infrastructure processes two ways: by reading
the pidfile Bernstein wrote for the current run, and (as a fallback) by
scanning all local processes for ones this checkout owns. The fallback
scan never attributed a watchdog to its checkout on Windows, so a
watchdog whose pidfile was missing, stale, or overwritten by a later
run in the same working directory was left running after `stop --force`
reported success.

Root cause, two compounding gaps in the Windows fallback path:

- The Windows process probe selected the process's executable path
  (e.g. `python.exe`) rather than its actual command line, so none of
  the argv markers the classifier looks for were ever present in what
  it read.
- Ownership of a watchdog/orchestrator/server process was confirmed via
  a live current-working-directory probe that shells out to `lsof`,
  which does not exist on Windows and therefore never returns an
  answer there.

## Fix

- `_start_watchdog` now writes its own working directory into its
  launch argv, so the fallback scan can attribute an orphaned watchdog
  to its checkout by reading the command line directly, with no
  cwd probe required.
- The Windows process probe now queries the real command line via
  `Win32_Process` instead of just the executable path, parsed with the
  stdlib `csv` reader so a comma or quote embedded in the command line
  no longer breaks a naive split.

No CLI-facing flags changed; `bernstein stop --force` and `--hard`
behave the same from an operator's perspective, just reliably now.

## Test plan

- [x] `tests/unit/test_stop_cmd_watchdog_reap.py` (new): reproduces the
      gap platform-independently by forcing the cwd probe to return no
      answer (the real Windows behavior) and asserting a real orphaned
      process survives on unmodified code, then is reaped after the fix
      — including through `hard_stop()` itself.
- [x] `uv run pytest tests/unit -k "stop_cmd or watchdog"` - 78 passed
- [x] `uv run ruff check` / `uv run ruff format --check` on changed files
- [x] `uv run mypy` on changed files (one pre-existing, unrelated error
      at `bootstrap.py:184` confirmed present before this change)

Closes #3312

## Summary by Sourcery

Ensure orphaned watchdog processes are correctly detected and reaped by `bernstein stop --force`, including on Windows where pidfiles or cwd probes may be missing.

Bug Fixes:
- Fix Windows process enumeration to read full command lines via `Win32_Process` so repo-owned infrastructure processes can be identified.
- Allow watchdog processes to be attributed to their checkout without relying on a cwd probe by embedding the workdir in their launch arguments.

Enhancements:
- Introduce a robust CSV parser for Windows process snapshots to correctly handle quoted command lines with commas and embedded quotes.
- Extend the bootstrap watchdog CLI to accept a `--workdir` marker solely for process attribution during stop operations.

Tests:
- Add unit tests covering watchdog argv contents, classification without cwd probes, end-to-end orphan watchdog reaping via `_collect_repo_processes` and `hard_stop`, and Windows CSV parsing edge cases.