### PR TITLE
fix(ci): fail the publish chain loudly and dispatch every release follow-up

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -233,8 +233,9 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write
-      # actions: write is required to dispatch publish-docker.yml below (a
-      # release created with GITHUB_TOKEN does not emit `release: published`).
+      # actions: write is required to dispatch the release follow-up workflows
+      # below (a release created with GITHUB_TOKEN does not emit
+      # `release: published`, so none of them start on their own).
       actions: write
     steps:
       - name: Harden runner (audit mode)
@@ -270,18 +271,34 @@ jobs:
             exit 1
           fi
 
-      # publish-docker.yml fires on `release: published`, but a release
-      # created with GITHUB_TOKEN does not emit that event (loop-prevention on
-      # token-authored events), so GHCR would never build. Dispatch it
-      # explicitly. publish-docker.yml keeps its native `release: published`
-      # trigger for releases created by a human or PAT; workflow_dispatch is
-      # exempt from the loop-prevention, and a repeat build for the same tag
-      # is harmless (idempotent image push).
+      # Three workflows fire on `release: published`, but a release created
+      # with GITHUB_TOKEN does not emit that event (loop-prevention on
+      # token-authored events), so none of them would ever run for an
+      # automated release. Dispatch each one explicitly. All three keep their
+      # native `release: published` trigger for releases created by a human or
+      # PAT; workflow_dispatch is exempt from the loop-prevention, and every
+      # one of them is idempotent for a repeated run on the same tag (image
+      # push, formula commit, SBOM asset upload).
       - name: Dispatch docker publish (release event from GITHUB_TOKEN does not trigger it)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ env.RELEASE_TAG }}
         run: gh workflow run publish-docker.yml --ref main -f tag="$TAG"
+
+      # publish-homebrew.yml takes the bare version (3.12.0), not the tag.
+      - name: Dispatch Homebrew formula publish (release event from GITHUB_TOKEN does not trigger it)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ env.RELEASE_TAG }}
+        run: gh workflow run publish-homebrew.yml --ref main -f version="${TAG#v}"
+
+      # sbom.yml takes the tag as its build ref and attaches both SBOMs to the
+      # release it resolves for that ref.
+      - name: Dispatch SBOM generation (release event from GITHUB_TOKEN does not trigger it)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ env.RELEASE_TAG }}
+        run: gh workflow run sbom.yml --ref main -f ref="$TAG"
 
   publish-npm:
     name: Publish npm wrapper
@@ -320,14 +337,41 @@ jobs:
         # Trusted publishing for the npm wrapper needs a registry-side
         # publisher configuration; token auth stays until that exists.
         run: | # zizmor: ignore[use-trusted-publishing]
+          set -uo pipefail
           if [ -z "${NPM_TOKEN:-}" ]; then
-            echo "::warning::NPM_TOKEN is not configured; skipping npm wrapper publish"
-            exit 0
+            echo "::error::NPM_TOKEN is not configured; the npm wrapper cannot be published"
+            exit 1
           fi
           cd packaging/npm
-          if ! npm publish --access public; then
-            echo "::warning::npm wrapper publish failed; continuing release"
+          # This step used to demote every publish failure to a ::warning, so an
+          # unauthorised token produced a green job while the registry kept
+          # serving the last version that did publish. Exactly one failure is
+          # legitimately non-fatal: the version is already on the registry,
+          # which happens when this job runs twice for the same tag (a workflow
+          # re-run, or the tag-push and workflow_dispatch triggers racing).
+          # npm reports that as EPUBLISHCONFLICT; older clients report an E403
+          # "cannot publish over the previously published versions". Everything
+          # else -- including the "Not Found" the registry returns for a token
+          # without publish rights on the package -- fails the job.
+          #
+          # GitHub runs this step under `bash -e`, so errexit is disabled
+          # around the capture; without it the `out=$(...)` assignment would
+          # abort the step before the exit code can be classified.
+          set +e
+          out=$(npm publish --access public 2>&1)
+          code=$?
+          set -e
+          printf '%s\n' "$out"
+          if [ "$code" -eq 0 ]; then
+            exit 0
           fi
+          if printf '%s' "$out" \
+            | grep -qiE 'EPUBLISHCONFLICT|cannot publish over the previously published version'; then
+            echo "::notice::npm wrapper version is already on the registry; treating the conflict as success (idempotent)"
+            exit 0
+          fi
+          echo "::error::npm wrapper publish failed (exit ${code}); the registry is now behind this release"
+          exit "$code"
 
   # MCP registry listing (#2369). Regenerated from pyproject.toml by
   # scripts/gen_distribution_manifests.py so the listing can never drift

--- a/.github/workflows/reconcile-release.yml
+++ b/.github/workflows/reconcile-release.yml
@@ -1,11 +1,17 @@
 name: Reconcile release drift
 
 # Daily safety net for the silent-skip class of bugs (#1273).
-# If `pyproject.toml` on main declares a version that PyPI does NOT
-# yet have AND the version commit is older than ~24h, something
-# upstream (CI / auto-release) silently dropped the publish. Open a
-# tracking issue for the operator. Re-running on the same day must not
-# spam.
+# If `pyproject.toml` on main declares a version that a published channel does
+# NOT yet have AND the version commit is older than ~24h, something upstream
+# (CI / auto-release / a publish job) silently dropped that channel. Open a
+# tracking issue for the operator. Re-running on the same day must not spam.
+#
+# The comparison set covers every channel the publish chain writes to, because
+# a channel nobody compares cannot be seen to fall behind (#3322, #3323):
+#   * PyPI                  - the sdist/wheel line
+#   * GitHub Release assets - dist artefacts and both SBOMs
+#   * npm                   - the `bernstein-orchestrator` wrapper
+#   * Homebrew tap          - the formula's pinned version
 
 on:
   schedule:
@@ -56,11 +62,20 @@ jobs:
           import sys
           import urllib.request
 
+          USER_AGENT = {"User-Agent": "bernstein-reconcile-release"}
+          # Both SBOMs are attached to every release by `.github/workflows/sbom.yml`.
+          SBOM_ASSETS = ("bernstein.spdx.json", "bernstein.cyclonedx.json")
+
           def parse_version(s: str) -> tuple[int, ...]:
               # Tolerant tuple-of-ints parse. Pre-release suffixes (-rc1, .dev0)
               # get stripped; we only need ordering on the public release line.
               core = re.split(r"[^0-9.]", s, maxsplit=1)[0].strip(".")
               return tuple(int(p) for p in core.split(".") if p.isdigit())
+
+          def fetch(url: str, accept: str = "application/json") -> bytes:
+              req = urllib.request.Request(url, headers={**USER_AGENT, "Accept": accept})
+              with urllib.request.urlopen(req, timeout=30) as resp:
+                  return resp.read()
 
           # Read pyproject.toml version from the checked-out tree (main).
           with open("pyproject.toml", encoding="utf-8") as fh:
@@ -72,16 +87,33 @@ jobs:
           pj_version = m.group(1)
 
           # Fetch latest published version from PyPI JSON API.
-          req = urllib.request.Request(
-              "https://pypi.org/pypi/bernstein/json",
-              headers={"User-Agent": "bernstein-reconcile-release"},
-          )
-          with urllib.request.urlopen(req, timeout=30) as resp:
-              pypi_payload = json.load(resp)
+          pypi_payload = json.loads(fetch("https://pypi.org/pypi/bernstein/json"))
           pypi_version = pypi_payload["info"]["version"]
+
+          # npm wrapper. publish.yml versions packaging/npm straight from the
+          # release tag, so the `latest` dist-tag tracks the same line as
+          # pyproject.toml; anything older means a publish was dropped.
+          npm_payload = json.loads(
+              fetch(
+                  "https://registry.npmjs.org/bernstein-orchestrator",
+                  accept="application/vnd.npm.install-v1+json",
+              )
+          )
+          npm_version = npm_payload.get("dist-tags", {}).get("latest", "0")
+
+          # Homebrew tap formula. The formula pins the PyPI sdist of the version
+          # it serves, so the URL carries the version the tap is on.
+          brew_text = fetch(
+              "https://raw.githubusercontent.com/chernistry/homebrew-tap/HEAD/Formula/bernstein.rb",
+              accept="text/plain",
+          ).decode("utf-8")
+          brew_match = re.search(r"bernstein-([0-9][0-9A-Za-z.\-]*)\.tar\.gz", brew_text)
+          brew_version = brew_match.group(1) if brew_match else "0"
 
           pj_t = parse_version(pj_version)
           pypi_t = parse_version(pypi_version)
+          npm_t = parse_version(npm_version)
+          brew_t = parse_version(brew_version)
 
           release_tag = f"v{pj_version}"
           release_assets = subprocess.run(
@@ -95,20 +127,22 @@ jobs:
                   "--json",
                   "assets",
                   "--jq",
-                  ".assets | length",
+                  "[.assets[].name]",
               ],
               check=False,
               capture_output=True,
               text=True,
           )
           release_exists = release_assets.returncode == 0
-          asset_count = 0
+          asset_names: list[str] = []
           if release_exists:
               try:
-                  asset_count = int(release_assets.stdout.strip())
-              except ValueError:
-                  print(f"::error::could not parse GitHub Release asset count for {release_tag}")
+                  asset_names = json.loads(release_assets.stdout.strip() or "[]")
+              except json.JSONDecodeError:
+                  print(f"::error::could not parse GitHub Release asset list for {release_tag}")
                   sys.exit(1)
+          asset_count = len(asset_names)
+          absent_sboms = [name for name in SBOM_ASSETS if name not in asset_names]
 
           # Age of the pyproject.toml change (when did the version line last move?).
           # We use git blame on the version line; the diff threshold is >24h.
@@ -123,17 +157,44 @@ jobs:
 
           print(f"pj_version={pj_version}")
           print(f"pypi_version={pypi_version}")
+          print(f"npm_version={npm_version}")
+          print(f"brew_version={brew_version}")
           print(f"pj_age_hours={pj_age_hours}")
           print(f"release_exists={'true' if release_exists else 'false'}")
           print(f"asset_count={asset_count}")
+          print(f"absent_sboms={','.join(absent_sboms) if absent_sboms else '-'}")
 
-          version_drift = pj_t > pypi_t and pj_age_hours >= 24
+          # A channel is only "behind" once the bump has had a full publish
+          # window to land, so every version comparison shares the age gate.
+          settled = pj_age_hours >= 24
+          version_drift = pj_t > pypi_t and settled
+          npm_drift = pj_t > npm_t and settled
+          brew_drift = pj_t > brew_t and settled
           missing_assets = release_exists and asset_count == 0
+          missing_sboms = release_exists and settled and bool(absent_sboms)
           print(f"version_drift={'true' if version_drift else 'false'}")
           print(f"missing_assets={'true' if missing_assets else 'false'}")
+          print(f"npm_drift={'true' if npm_drift else 'false'}")
+          print(f"brew_drift={'true' if brew_drift else 'false'}")
+          print(f"missing_sboms={'true' if missing_sboms else 'false'}")
 
-          drift = version_drift or missing_assets
+          drift = version_drift or missing_assets or npm_drift or brew_drift or missing_sboms
           print(f"drift={'true' if drift else 'false'}")
+
+          # Name the channels that are behind so the tracking issue points at
+          # the one that needs attention instead of at "the release".
+          behind = [
+              label
+              for label, flagged in (
+                  ("pypi", version_drift),
+                  ("release-assets", missing_assets),
+                  ("npm", npm_drift),
+                  ("homebrew", brew_drift),
+                  ("sbom", missing_sboms),
+              )
+              if flagged
+          ]
+          print(f"behind={','.join(behind) if behind else '-'}")
           PY
 
       - name: Open or update drift issue (idempotent)
@@ -142,26 +203,34 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PJ: ${{ steps.cmp.outputs.pj_version }}
           PYPI: ${{ steps.cmp.outputs.pypi_version }}
+          NPM: ${{ steps.cmp.outputs.npm_version }}
+          BREW: ${{ steps.cmp.outputs.brew_version }}
           AGE: ${{ steps.cmp.outputs.pj_age_hours }}
           RELEASE_EXISTS: ${{ steps.cmp.outputs.release_exists }}
           ASSET_COUNT: ${{ steps.cmp.outputs.asset_count }}
           MISSING_ASSETS: ${{ steps.cmp.outputs.missing_assets }}
+          MISSING_SBOMS: ${{ steps.cmp.outputs.missing_sboms }}
+          ABSENT_SBOMS: ${{ steps.cmp.outputs.absent_sboms }}
+          BEHIND: ${{ steps.cmp.outputs.behind }}
           REPO: ${{ github.repository }}
         run: |
-          TITLE="release drift: pyproject=\`${PJ}\` pypi=\`${PYPI}\`"
+          TITLE="release drift: pyproject=\`${PJ}\` behind=\`${BEHIND}\`"
           if [ "${MISSING_ASSETS}" = "true" ]; then
             CAUSE="GitHub Release missing dist assets."
+          elif [ "${MISSING_SBOMS}" = "true" ]; then
+            CAUSE="GitHub Release missing SBOM assets (\`${ABSENT_SBOMS}\`); \`sbom.yml\` did not attach them for this release."
           else
-            CAUSE="Likely cause: a CI run was cancelled/timed_out/action_required so \`auto-release.yml\` silently skipped the publish (see #1273)."
+            CAUSE="Likely cause: a CI run was cancelled/timed_out/action_required so \`auto-release.yml\` silently skipped the publish (see #1273), or the publish job for the named channel failed."
           fi
           # shellcheck disable=SC2016
-          BODY=$(printf 'Detected by `.github/workflows/reconcile-release.yml`.\n\n- pyproject.toml on main: **%s**\n- latest on PyPI: **%s**\n- age of pyproject bump: %sh\n- GitHub Release exists: **%s**\n- GitHub Release asset count: **%s**\n\n%s\n\nRun `gh workflow run reconcile-release.yml` after fixing to clear.\n' \
-            "${PJ}" "${PYPI}" "${AGE}" "${RELEASE_EXISTS}" "${ASSET_COUNT}" "${CAUSE}")
+          BODY=$(printf 'Detected by `.github/workflows/reconcile-release.yml`.\n\n- pyproject.toml on main: **%s**\n- latest on PyPI: **%s**\n- latest on npm (`bernstein-orchestrator`): **%s**\n- Homebrew tap formula: **%s**\n- age of pyproject bump: %sh\n- GitHub Release exists: **%s**\n- GitHub Release asset count: **%s**\n- SBOM assets absent: **%s**\n- channels behind: **%s**\n\n%s\n\nRun `gh workflow run reconcile-release.yml` after fixing to clear.\n' \
+            "${PJ}" "${PYPI}" "${NPM}" "${BREW}" "${AGE}" "${RELEASE_EXISTS}" "${ASSET_COUNT}" "${ABSENT_SBOMS}" "${BEHIND}" "${CAUSE}")
 
           # Idempotency: search for an open issue whose title matches the
-          # exact pyproject/pypi pair. Re-runs the same day just comment.
+          # exact pyproject version and channel set. Re-runs the same day just
+          # comment.
           EXISTING=$(gh issue list --repo "${REPO}" --state open \
-            --search "in:title release drift pyproject=${PJ} pypi=${PYPI}" \
+            --search "in:title release drift pyproject=${PJ}" \
             --json number,title \
             --jq ".[] | select(.title == \"${TITLE}\") | .number" \
             | head -1)
@@ -179,16 +248,17 @@ jobs:
           fi
 
       - name: Auto-close stale drift issues (no drift today)
-        # When PyPI catches up the old `release drift: pyproject=… pypi=…`
-        # issue stays OPEN forever because the previous "open or update"
-        # step only fires on the drift==true branch. Close any open
-        # release-drift issue here so the inbox self-clears on the next
-        # successful publish.
+        # When the channels catch up, the old `release drift: …` issue stays
+        # OPEN forever because the previous "open or update" step only fires
+        # on the drift==true branch. Close any open release-drift issue here
+        # so the inbox self-clears on the next successful publish.
         if: steps.cmp.outputs.drift != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PYPI_VERSION: ${{ steps.cmp.outputs.pypi_version }}
+          NPM_VERSION: ${{ steps.cmp.outputs.npm_version }}
+          BREW_VERSION: ${{ steps.cmp.outputs.brew_version }}
         run: |
           set -euo pipefail
           OPEN=$(gh issue list \
@@ -201,11 +271,12 @@ jobs:
             echo "::notice::No open release-drift issues to close."
             exit 0
           fi
+          CLEARED="PyPI \`${PYPI_VERSION}\`, npm \`${NPM_VERSION}\`, Homebrew \`${BREW_VERSION}\`"
           for NUM in $OPEN; do
-            echo "Closing release-drift issue #${NUM} (PyPI now at ${PYPI_VERSION})."
+            echo "Closing release-drift issue #${NUM} (${CLEARED})."
             gh issue close "$NUM" \
               --repo "${REPO}" \
-              --comment "PyPI now reports \`${PYPI_VERSION}\`; drift cleared on $(date -u +%Y-%m-%dT%H:%MZ)." \
+              --comment "Every channel is level: ${CLEARED}; drift cleared on $(date -u +%Y-%m-%dT%H:%MZ)." \
               --reason completed || true
           done
 
@@ -214,7 +285,10 @@ jobs:
         env:
           PJ_VERSION: ${{ steps.cmp.outputs.pj_version }}
           PYPI_VERSION: ${{ steps.cmp.outputs.pypi_version }}
+          NPM_VERSION: ${{ steps.cmp.outputs.npm_version }}
+          BREW_VERSION: ${{ steps.cmp.outputs.brew_version }}
           ASSET_COUNT: ${{ steps.cmp.outputs.asset_count }}
           MISSING_ASSETS: ${{ steps.cmp.outputs.missing_assets }}
+          MISSING_SBOMS: ${{ steps.cmp.outputs.missing_sboms }}
         run: |
-          echo "::notice::No release drift detected (pyproject=${PJ_VERSION}, pypi=${PYPI_VERSION}, assets=${ASSET_COUNT}, missing_assets=${MISSING_ASSETS})."
+          echo "::notice::No release drift detected (pyproject=${PJ_VERSION}, pypi=${PYPI_VERSION}, npm=${NPM_VERSION}, homebrew=${BREW_VERSION}, assets=${ASSET_COUNT}, missing_assets=${MISSING_ASSETS}, missing_sboms=${MISSING_SBOMS})."

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -4,7 +4,15 @@ name: SBOM
 # as release assets. Downstream consumers can ingest these into their own
 # SCA tooling (Grype, Trivy, etc.).
 #
-# Ref: #1273
+# Two entry paths reach the same outcome:
+#   * `release: published`, for a release created in the GitHub UI;
+#   * `workflow_dispatch`, which publish.yml uses after it creates the release
+#     itself -- a release created with GITHUB_TOKEN emits no release event.
+# The attachment decision is therefore keyed on whether a release exists for
+# the ref being built, not on which event started the run. Keying it on the
+# event left the dispatch path generating SBOMs it never attached.
+#
+# Ref: #1273, #3323
 
 on:
   release:
@@ -37,6 +45,31 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
 
+      - name: Resolve release for ref
+        id: rel
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_REF: ${{ inputs.ref }}
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ -n "$EVENT_TAG" ]; then
+            TAG="$EVENT_TAG"
+          elif [ -n "$INPUT_REF" ]; then
+            TAG="$INPUT_REF"
+          else
+            TAG="${GITHUB_REF_NAME}"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+            echo "release $TAG exists; SBOMs will be attached to it"
+            echo "release_exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::no release for $TAG; SBOMs stay a workflow artifact only"
+            echo "release_exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Set up uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
         with:
@@ -56,7 +89,9 @@ jobs:
           artifact-name: bernstein.spdx.json
           output-file: bernstein.spdx.json
           upload-artifact: true
-          upload-release-assets: ${{ github.event_name == 'release' }}
+          # Attachment is done by the explicit upload step below, which is the
+          # one code path both entry paths share.
+          upload-release-assets: false
 
       - name: Generate CycloneDX SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
@@ -66,7 +101,7 @@ jobs:
           artifact-name: bernstein.cyclonedx.json
           output-file: bernstein.cyclonedx.json
           upload-artifact: true
-          upload-release-assets: ${{ github.event_name == 'release' }}
+          upload-release-assets: false
 
       - name: Upload SBOMs as workflow artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
@@ -77,3 +112,17 @@ jobs:
             bernstein.cyclonedx.json
           if-no-files-found: error
           retention-days: 30
+
+      - name: Attach SBOMs to the release
+        if: steps.rel.outputs.release_exists == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ steps.rel.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh release upload "$TAG" \
+            bernstein.spdx.json \
+            bernstein.cyclonedx.json \
+            --repo "$REPO" \
+            --clobber

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -10,12 +10,12 @@ Update this table whenever a release workflow is added, renamed, or moved.
 |---|---|---|---|---|
 | `.github/workflows/post-ci-dispatcher.yml` | Post-CI dispatcher | `workflow_run` | Routes completed main-branch CI runs to release and recovery child workflows. | Calls `.github/workflows/auto-release.yml` when the upstream CI run targets `main`. |
 | `.github/workflows/auto-release.yml` | Auto-release | `workflow_call` | Decides whether a green main-branch CI run should create a release tag. | Pushes a `v*` tag; `.github/workflows/publish.yml` owns tag publish. |
-| `.github/workflows/publish.yml` | Publish | `push` | Builds release distributions, attests `dist/*`, publishes PyPI and npm packages, and creates or updates the GitHub Release for a `v*` tag. | GitHub Release publication triggers Docker, Homebrew, and release-scoped SBOM follow-up workflows. |
+| `.github/workflows/publish.yml` | Publish | `push` | Builds release distributions, attests `dist/*`, publishes PyPI and npm packages, and creates or updates the GitHub Release for a `v*` tag. | Dispatches the Docker, Homebrew, and SBOM follow-up workflows after creating the release, because a release created with `GITHUB_TOKEN` emits no `release: published` event. |
 | `.github/workflows/release-major-minor.yml` | Major/Minor Release | `workflow_dispatch` | Manually cuts major or minor releases after checking CI and applying the version bump. | Pushes the version commit and tag, then builds and publishes from the same run. |
-| `.github/workflows/reconcile-release.yml` | Reconcile release drift | `schedule`, `workflow_dispatch` | Compares `pyproject.toml`, PyPI, and GitHub Release assets to detect missed publish work. | Opens or updates a `release-drift` issue when published state is inconsistent. |
-| `.github/workflows/publish-docker.yml` | Publish Docker Image | `release`, `workflow_dispatch` | Publishes the GHCR image and image provenance for a released tag. | Runs after a GitHub Release is published, or manually for a selected tag. |
-| `.github/workflows/publish-homebrew.yml` | Publish Homebrew Formula | `release`, `workflow_dispatch` | Updates the Homebrew tap formula for a released version. | Runs after a GitHub Release is published, or manually for a selected version. |
-| `.github/workflows/sbom.yml` | SBOM | `release`, `workflow_dispatch` | Generates SPDX + CycloneDX SBOMs and attaches them as release assets. | Runs after a GitHub Release is published, or manually for a selected ref. |
+| `.github/workflows/reconcile-release.yml` | Reconcile release drift | `schedule`, `workflow_dispatch` | Compares `pyproject.toml` against PyPI, npm, the Homebrew tap, and GitHub Release assets (dist + SBOM) to detect missed publish work. | Opens or updates a `release-drift` issue naming the channels that are behind. |
+| `.github/workflows/publish-docker.yml` | Publish Docker Image | `release`, `workflow_dispatch` | Publishes the GHCR image and image provenance for a released tag. | Dispatched by `publish.yml` for automated releases; the `release` event covers releases created in the UI. |
+| `.github/workflows/publish-homebrew.yml` | Publish Homebrew Formula | `release`, `workflow_dispatch` | Updates the Homebrew tap formula for a released version. | Dispatched by `publish.yml` for automated releases; the `release` event covers releases created in the UI. |
+| `.github/workflows/sbom.yml` | SBOM | `release`, `workflow_dispatch` | Generates SPDX + CycloneDX SBOMs and attaches them to the release that exists for the built ref. | Dispatched by `publish.yml` for automated releases; the `release` event covers releases created in the UI. |
 
 ## Bumping the version
 
@@ -41,5 +41,7 @@ CI and `.github/workflows/auto-release.yml` picks up the untagged version.
 
 - `.github/workflows/auto-release.yml` only creates tags.
 - `.github/workflows/publish.yml` owns tag-triggered package and GitHub Release publication.
-- `.github/workflows/reconcile-release.yml` is the drift detector for missing PyPI versions or empty GitHub Release assets.
+- `.github/workflows/reconcile-release.yml` is the drift detector for every published channel: PyPI, npm, the Homebrew tap, and the GitHub Release's dist and SBOM assets.
+- Events raised with `GITHUB_TOKEN` do not start further workflow runs, so `publish.yml` dispatches every follow-up workflow explicitly rather than relying on `release: published`. A new follow-up workflow needs both the dispatch step and its own `workflow_dispatch` inputs.
+- A publish job must fail on a failed publish. A channel whose failure is demoted to a warning goes stale without anyone noticing.
 - New release entrypoints must be added to the ownership table and covered by `tests/unit/test_release_entrypoint_docs.py`.

--- a/packaging/npm/README.md
+++ b/packaging/npm/README.md
@@ -16,6 +16,14 @@ npm install -g bernstein-orchestrator
 Requires Python 3.12+. The wrapper delegates to the
 [bernstein PyPI package](https://pypi.org/project/bernstein/).
 
+## Versions
+
+The wrapper version matches the `bernstein` release it ships with, but the
+registry history has a gap: publishes between 2.3.0 and 3.12.0 did not reach
+npm, so those versions cannot be installed by exact version from here. Install
+the latest, or take any version from
+[PyPI](https://pypi.org/project/bernstein/), which has the complete history.
+
 ## Usage
 
 ```bash

--- a/tests/unit/test_publish_workflow_yaml.py
+++ b/tests/unit/test_publish_workflow_yaml.py
@@ -1,13 +1,23 @@
-"""Structural assertions on ``.github/workflows/publish.yml`` (issue #2642).
+"""Structural assertions on ``.github/workflows/publish.yml`` (issues #2642,
+#3322, #3323).
 
 The MCP-registry publish job runs with ``id-token: write``; the tool it
 downloads and executes there must be pinned to an immutable release and
 integrity-checked before it runs, so an upstream ``releases/latest`` move
 cannot change what executes in the privileged job.
+
+Two further contracts are pinned here:
+
+* the npm wrapper publish must fail the job on a publish error instead of
+  demoting it to a warning inside a green run, and
+* every workflow that consumes the ``release: published`` event must also be
+  dispatched explicitly, because a release created with ``GITHUB_TOKEN`` never
+  emits that event.
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any, cast
 
@@ -20,21 +30,58 @@ except ModuleNotFoundError:  # pragma: no cover - dev env should have pyyaml
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-WORKFLOW = REPO_ROOT / ".github" / "workflows" / "publish.yml"
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+WORKFLOW = WORKFLOWS_DIR / "publish.yml"
+
+# Workflows that only ever ran off `release: published` and therefore never ran
+# for a release the publish chain created itself.
+RELEASE_EVENT_CONSUMERS = ("publish-docker.yml", "publish-homebrew.yml", "sbom.yml")
+
+_DISPATCH_RE = re.compile(r"gh workflow run\s+(?P<workflow>[\w.-]+\.ya?ml)")
+_DISPATCH_INPUT_RE = re.compile(r"-f\s+(?P<name>[A-Za-z_][\w-]*)=")
 
 
 def _load(path: Path) -> dict[str, Any]:
     return cast("dict[str, Any]", yaml.safe_load(path.read_text(encoding="utf-8")))
 
 
-def _step_run(workflow: dict[str, Any], job_name: str, step_name: str) -> str:
+def _steps(workflow: dict[str, Any], job_name: str) -> list[dict[str, Any]]:
     job = workflow["jobs"][job_name]
-    for step_value in job.get("steps", []):
-        if isinstance(step_value, dict) and step_value.get("name") == step_name:
+    return [step for step in job.get("steps", []) if isinstance(step, dict)]
+
+
+def _step_run(workflow: dict[str, Any], job_name: str, step_name: str) -> str:
+    for step_value in _steps(workflow, job_name):
+        if step_value.get("name") == step_name:
             run = step_value.get("run")
             assert isinstance(run, str)
             return run
     pytest.fail(f"{WORKFLOW.name}::{job_name} has no step named {step_name!r}")
+
+
+def _dispatches(workflow: dict[str, Any], job_name: str) -> dict[str, set[str]]:
+    """Map dispatched workflow file -> the input names passed with ``-f``."""
+    dispatched: dict[str, set[str]] = {}
+    for step in _steps(workflow, job_name):
+        run = step.get("run")
+        if not isinstance(run, str):
+            continue
+        match = _DISPATCH_RE.search(run)
+        if match is None:
+            continue
+        dispatched[match.group("workflow")] = set(_DISPATCH_INPUT_RE.findall(run))
+    return dispatched
+
+
+def _declared_dispatch_inputs(workflow_file: str) -> set[str]:
+    doc = _load(WORKFLOWS_DIR / workflow_file)
+    triggers = doc.get("on", doc.get(True))
+    assert isinstance(triggers, dict), f"{workflow_file} must declare mapping-style triggers"
+    dispatch = triggers.get("workflow_dispatch")
+    assert isinstance(dispatch, dict), f"{workflow_file} must accept workflow_dispatch"
+    inputs = dispatch.get("inputs", {})
+    assert isinstance(inputs, dict)
+    return {str(name) for name in inputs}
 
 
 @pytest.fixture(scope="module")
@@ -69,3 +116,55 @@ def test_mcp_publisher_download_is_checksum_verified(workflow: dict[str, Any]) -
     assert verify_pos != -1, "checksum is never verified"
     assert extract_pos != -1, "archive is never extracted"
     assert verify_pos < extract_pos, "checksum must be verified before extraction"
+
+
+def test_npm_publish_failure_fails_the_job(workflow: dict[str, Any]) -> None:
+    """A failed wrapper publish must fail the job, not warn inside a green run."""
+    run = _step_run(workflow, "publish-npm", "Publish to npm")
+
+    assert "::warning::npm wrapper publish failed" not in run, (
+        "a publish failure demoted to ::warning: leaves the job green while the registry stays behind"
+    )
+    assert "::error::" in run, "a publish failure must be reported as an error annotation"
+    assert 'exit "$code"' in run, "the npm exit code must propagate to the job result"
+
+
+def test_npm_publish_tolerates_only_an_already_published_version(workflow: dict[str, Any]) -> None:
+    """The single non-fatal failure is a version already on the registry."""
+    run = _step_run(workflow, "publish-npm", "Publish to npm")
+
+    # npm reports a re-publish of an existing version as EPUBLISHCONFLICT
+    # (older clients: E403 "cannot publish over the previously published versions").
+    assert "EPUBLISHCONFLICT" in run
+    assert "cannot publish over the previously published version" in run
+    # The registry answers an unauthorised token with a 404 on the PUT. That
+    # must stay outside the tolerated set, or the original defect returns in a
+    # new shape.
+    assert "404" not in run, "a 404 (token without publish rights) must not be treated as success"
+
+
+def test_npm_missing_token_fails_the_job(workflow: dict[str, Any]) -> None:
+    """A release channel without its credential is a failure, not a silent skip."""
+    run = _step_run(workflow, "publish-npm", "Publish to npm")
+
+    assert "::warning::NPM_TOKEN is not configured" not in run
+    assert "::error::NPM_TOKEN is not configured" in run
+    assert "exit 1" in run
+
+
+def test_github_release_dispatches_every_release_event_consumer(workflow: dict[str, Any]) -> None:
+    """A GITHUB_TOKEN release emits no `release: published`, so each consumer is dispatched."""
+    dispatched = _dispatches(workflow, "github-release")
+
+    for consumer in RELEASE_EVENT_CONSUMERS:
+        assert consumer in dispatched, f"{consumer} consumes `release: published` but is never dispatched"
+
+
+def test_dispatched_inputs_match_the_target_workflow_inputs(workflow: dict[str, Any]) -> None:
+    """Every `-f name=` passed on dispatch must be an input the target declares."""
+    dispatched = _dispatches(workflow, "github-release")
+
+    for workflow_file, passed_inputs in dispatched.items():
+        declared = _declared_dispatch_inputs(workflow_file)
+        unknown = passed_inputs - declared
+        assert not unknown, f"{workflow_file} does not declare dispatch input(s) {sorted(unknown)}"

--- a/tests/unit/test_reconcile_release_workflow_yaml.py
+++ b/tests/unit/test_reconcile_release_workflow_yaml.py
@@ -74,6 +74,35 @@ def test_compare_step_audits_github_release_assets() -> None:
     assert "drift = version_drift or missing_assets" in run
 
 
+def test_compare_step_covers_every_published_channel() -> None:
+    """Drift detection must cover each channel the publish chain writes to (#3322, #3323).
+
+    A channel absent from the comparison set cannot be seen to fall behind: the
+    npm wrapper sat at a stale version for months precisely because nothing
+    compared the registry to `pyproject.toml`.
+    """
+    run = _run(_step("Compare versions and release assets"))
+
+    # npm wrapper.
+    assert "registry.npmjs.org/bernstein-orchestrator" in run
+    assert "npm_version=" in run
+    assert "npm_drift" in run
+
+    # Homebrew tap formula.
+    assert "homebrew-tap" in run
+    assert "brew_version=" in run
+    assert "brew_drift" in run
+
+    # SBOM assets on the GitHub Release.
+    assert "bernstein.spdx.json" in run
+    assert "bernstein.cyclonedx.json" in run
+    assert "missing_sboms" in run
+
+    # Every channel feeds the single drift verdict.
+    for flag in ("version_drift", "missing_assets", "npm_drift", "brew_drift", "missing_sboms"):
+        assert flag in run.split("drift = ")[-1].splitlines()[0], f"{flag} is computed but not part of the verdict"
+
+
 def test_drift_issue_includes_missing_asset_context() -> None:
     """The tracking issue should open for missing assets and include asset evidence."""
     step = _step("Open or update drift issue (idempotent)")
@@ -89,6 +118,20 @@ def test_drift_issue_includes_missing_asset_context() -> None:
     run = _run(step)
     assert "GitHub Release missing dist assets" in run
     assert "GitHub Release asset count" in run
+
+
+def test_drift_issue_reports_every_channel() -> None:
+    """The tracking issue must name the channel that fell behind."""
+    step = _step("Open or update drift issue (idempotent)")
+    env = step.get("env", {})
+    assert isinstance(env, dict)
+    for name in ("NPM", "BREW", "MISSING_SBOMS"):
+        assert name in env, f"drift issue body cannot report the {name} channel"
+
+    run = _run(step)
+    assert "npm" in run
+    assert "Homebrew" in run
+    assert "SBOM" in run
 
 
 def test_no_drift_notice_reports_asset_count() -> None:

--- a/tests/unit/test_release_attestation_workflow.py
+++ b/tests/unit/test_release_attestation_workflow.py
@@ -236,15 +236,25 @@ def test_auto_release_does_not_create_github_releases() -> None:
 
 
 def test_npm_publish_failures_do_not_block_python_release() -> None:
-    """The npm wrapper is advisory and must not block Python release publication."""
+    """The npm wrapper stays off the Python release critical path.
+
+    The wrapper used to be kept off that path by swallowing its own failures,
+    which also hid a broken token for months (#3322). Isolation is a property
+    of the job graph, not of the step's error handling: no job may depend on
+    ``publish-npm``, so a red wrapper publish reports the problem without
+    holding back PyPI or the GitHub Release.
+    """
     data = _load_yaml(PUBLISH_WF)
     job = _job(data, "publish-npm")
     assert job.get("name") == "Publish npm wrapper"
 
+    jobs = cast("YamlMap", data["jobs"])
+    for job_id, raw_job in jobs.items():
+        needs = cast("YamlMap", raw_job).get("needs")
+        dependencies = [needs] if isinstance(needs, str) else list(needs or [])
+        assert "publish-npm" not in dependencies, f"job {job_id!r} would be blocked by the npm wrapper publish"
+
     publish_step = _step(data, "publish-npm", "Publish to npm")
     run = publish_step.get("run")
     assert isinstance(run, str)
-    assert "::error::" not in run
-    assert "::warning::NPM_TOKEN is not configured; skipping npm wrapper publish" in run
-    assert "::warning::npm wrapper publish failed; continuing release" in run
     assert "npm publish --access public" in run

--- a/tests/unit/test_release_entrypoint_docs.py
+++ b/tests/unit/test_release_entrypoint_docs.py
@@ -22,7 +22,18 @@ RELEASE_ENTRYPOINTS: dict[str, tuple[str, ...]] = {
     "reconcile-release.yml": ("schedule", "workflow_dispatch"),
     "publish-docker.yml": ("release", "workflow_dispatch"),
     "publish-homebrew.yml": ("release", "workflow_dispatch"),
+    "sbom.yml": ("release", "workflow_dispatch"),
 }
+
+# Release-event consumers. A release created with GITHUB_TOKEN emits no
+# `release: published` event, so the ownership table must describe each of
+# these as dispatched by publish.yml rather than as running "after a GitHub
+# Release is published" (issue #3323).
+DISPATCHED_BY_PUBLISH: tuple[str, ...] = (
+    "publish-docker.yml",
+    "publish-homebrew.yml",
+    "sbom.yml",
+)
 
 
 @dataclass(frozen=True)
@@ -98,3 +109,18 @@ def test_release_entrypoint_doc_references_actual_workflows() -> None:
         for trigger in expected_triggers:
             assert trigger in workflow_triggers, f"{documented_path} no longer has trigger {trigger}"
             assert trigger in row.triggers, f"{documented_path} doc row must list trigger {trigger}"
+
+
+def test_release_event_consumers_are_documented_as_dispatched() -> None:
+    """The doc must not claim a release event starts workflows it cannot start."""
+    rows = _release_table_rows(RELEASE_DOC.read_text(encoding="utf-8"))
+
+    for workflow_file in DISPATCHED_BY_PUBLISH:
+        documented_path = f".github/workflows/{workflow_file}"
+        row = rows[documented_path]
+        assert "dispatch" in row.handoff.lower(), (
+            f"{documented_path} is dispatched by publish.yml; the handoff column must say so"
+        )
+        assert "Runs after a GitHub Release is published, or manually" not in row.handoff, (
+            f"{documented_path} does not run off the release event for an automated release"
+        )

--- a/tests/unit/test_sbom_workflow_yaml.py
+++ b/tests/unit/test_sbom_workflow_yaml.py
@@ -1,0 +1,90 @@
+"""Structural assertions on ``.github/workflows/sbom.yml`` (issue #3323).
+
+The SBOM run has two entry paths: the ``release: published`` event, and an
+explicit dispatch from ``publish.yml`` for the releases that event never fires
+for. Both must attach the generated SBOMs to the release, so the attachment
+decision is keyed on "a release exists for this ref", never on which event
+started the run.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - dev env should have pyyaml
+    pytest.skip("pyyaml not installed", allow_module_level=True)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "sbom.yml"
+
+SBOM_FILES = ("bernstein.spdx.json", "bernstein.cyclonedx.json")
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict[str, Any]:
+    return cast("dict[str, Any]", yaml.safe_load(WORKFLOW.read_text(encoding="utf-8")))
+
+
+def _steps(workflow: dict[str, Any]) -> list[dict[str, Any]]:
+    job = workflow["jobs"]["sbom"]
+    return [step for step in job.get("steps", []) if isinstance(step, dict)]
+
+
+def _step(workflow: dict[str, Any], name: str) -> dict[str, Any]:
+    match = next((step for step in _steps(workflow) if step.get("name") == name), None)
+    assert match is not None, f"{WORKFLOW.name} has no step named {name!r}"
+    return match
+
+
+def test_asset_attachment_is_not_gated_on_the_triggering_event(workflow: dict[str, Any]) -> None:
+    """`event_name == 'release'` makes a dispatched run generate SBOMs it never attaches."""
+    for step in _steps(workflow):
+        conditions = [str(step.get("if", ""))]
+        with_block = step.get("with", {})
+        if isinstance(with_block, dict):
+            conditions.extend(str(value) for value in cast("dict[str, Any]", with_block).values())
+        for condition in conditions:
+            assert "github.event_name == 'release'" not in condition, (
+                f"step {step.get('name')!r} still keys asset attachment on the triggering event"
+            )
+
+
+def test_release_is_resolved_from_the_ref_not_the_event(workflow: dict[str, Any]) -> None:
+    """The tag comes from the dispatch input as readily as from the release payload."""
+    step = _step(workflow, "Resolve release for ref")
+    run = str(step.get("run", ""))
+    env = step.get("env", {})
+    assert isinstance(env, dict)
+
+    assert step.get("id") == "rel"
+    assert "inputs.ref" in str(env)
+    assert "github.event.release.tag_name" in str(env)
+    assert "gh release view" in run
+    assert "release_exists=" in run
+    assert "tag=" in run
+
+
+def test_sboms_are_attached_whenever_a_release_exists(workflow: dict[str, Any]) -> None:
+    """Both SBOMs land on the release on the dispatch path as well as the event path."""
+    step = _step(workflow, "Attach SBOMs to the release")
+    condition = str(step.get("if", ""))
+    run = str(step.get("run", ""))
+
+    assert "steps.rel.outputs.release_exists == 'true'" in condition
+    assert "gh release upload" in run
+    assert "--clobber" in run
+    for sbom in SBOM_FILES:
+        assert sbom in run, f"{sbom} is never attached to the release"
+
+
+def test_sbom_job_can_write_release_assets(workflow: dict[str, Any]) -> None:
+    """Attaching assets needs `contents: write` on the job."""
+    permissions = workflow["jobs"]["sbom"].get("permissions", {})
+    assert isinstance(permissions, dict)
+    assert permissions.get("contents") == "write"


### PR DESCRIPTION
Closes #3322
Closes #3323

Both issues are the same defect in two places: a step in the publish chain could not report its own failure, so a release reported success while a distribution channel stayed behind.

## npm wrapper publish (#3322)

The publish step was written so a failure could not fail the job:

```
if ! npm publish --access public; then
  echo "::warning::npm wrapper publish failed; continuing release"
fi
```

A warning inside a green job is not a signal anyone reads, so the wrapper sat on a registry version from May while every release since reported success.

The step now classifies the outcome instead of ignoring it:

| npm outcome | Result |
|---|---|
| publish succeeds | job passes |
| `EPUBLISHCONFLICT`, or the older `E403` "cannot publish over the previously published versions" | `::notice::`, job passes — the version is already on the registry, so a re-run or two triggers racing the same tag is idempotent |
| anything else, including the `404` the registry answers for a token without publish rights | `::error::`, job fails with npm's exit code |
| `NPM_TOKEN` unset | `::error::`, job fails |

`publish-npm` only needs `build`, and nothing needs `publish-npm`, so a failure here surfaces the problem without holding back the PyPI publish or the GitHub Release.

Verified against a stubbed `npm` covering all six cases, including the exact 404 output recorded in the issue.

## Release follow-up workflows (#3323)

`publish-homebrew.yml` and `sbom.yml` triggered only on `release: published`. A release created with `GITHUB_TOKEN` does not emit that event, so neither ran for an automated release — the same limitation `publish.yml` already worked around for Docker with an explicit dispatch.

- `publish.yml` now dispatches all three follow-up workflows after creating the release, using the repo-scoped token and `actions: write` the Docker dispatch already used. Each keeps its `release` trigger for releases created in the UI.
- `sbom.yml` gated attachment on `github.event_name == 'release'`, so a dispatched run generated both SBOMs and attached neither. Attachment is now keyed on a release existing for the ref being built, which both entry paths satisfy, and both paths share one explicit upload step rather than two divergent ones.

Verified with a stubbed `gh`: the release-event path and the dispatch path resolve the same tag and attach; a dispatch with no ref on `main` correctly declines.

## Drift detection

`reconcile-release.yml` compared `pyproject.toml`, PyPI and the presence of GitHub Release assets. Neither defect above was visible to it — a channel nobody compares cannot be seen to fall behind. The comparison set now also covers:

- the npm `latest` dist-tag for `bernstein-orchestrator`,
- the version pinned by the Homebrew tap formula,
- both SBOM assets on the GitHub Release.

Merged with the Copr RPM channel that landed on main meanwhile, so the verdict is the union of all six channels. Copr's lookup is unchanged; npm and the Homebrew tap go through a shared `probe` helper making the same bargain Copr's inline `try`/`except` already did — one registry's outage warns and drops that channel from the verdict rather than taking the whole comparison down. The issue title now carries the set of channels that are behind instead of a version per channel: six versions do not fit in a title, and the channel needing attention is the useful part.

Every version comparison shares the existing 24h settle window, so a publish still in flight does not open an issue. The tracking issue title and body name the channels that are behind rather than describing "the release".

Exercised against the live registries (all channels level today) and against stubbed scenarios: npm alone behind, tap plus SBOM missed, several channels behind, a fresh bump mid-publish, and a release with zero assets.

## Guards

Failing first on unmodified workflows, passing after:

- `tests/unit/test_publish_workflow_yaml.py` — npm failure classification, the missing-token branch, a dispatch step per release-event consumer, and every `-f name=` checked against the inputs the target workflow declares.
- `tests/unit/test_sbom_workflow_yaml.py` (new) — attachment is not keyed on the triggering event, the release is resolved from the ref, both SBOMs are attached when a release exists.
- `tests/unit/test_reconcile_release_workflow_yaml.py` — every published channel is in the comparison set and feeds the drift verdict.
- `tests/unit/test_release_entrypoint_docs.py` — `sbom.yml` added to the ownership map; the handoff column may no longer claim a release event starts these workflows.
- `tests/unit/test_release_attestation_workflow.py` — `test_npm_publish_failures_do_not_block_python_release` pinned the two `::warning::` strings the step used to emit, so it encoded the masking rather than the property it names. The wrapper stays off the Python release critical path because no job depends on `publish-npm`; the guard now asserts that job-graph property instead.

`docs/operations/release.md` is corrected accordingly; `docs/operations/ci-topology.md` regenerates unchanged (`scripts/gen_workflow_topology.py --check` passes) because the edits touch step bodies rather than the graph surfaces it renders.

`actionlint` (with shellcheck) is clean on all three changed workflows.

## Operator-visible changes

- A failed npm wrapper publish now turns the release run red instead of passing quietly.
- Homebrew and SBOM artifacts land automatically for automated releases; no hand-dispatch and no manual asset upload.
- Release-drift issues name the channel that is behind, and close with a per-channel summary.
- `packaging/npm/README.md` states that the registry history has a gap between 2.3.0 and 3.12.0, so nobody hunts for versions that were never published; PyPI carries the complete line.
