### PR TITLE
feat(release): publish RPM builds to Copr from the tag publish chain

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,15 @@ on:
         description: "Release tag to publish (e.g. v2.8.1)"
         required: true
         type: string
+      # Republish a single distribution channel for a tag that is already
+      # released. The RPM channel builds from packaging/rpm/bernstein.spec
+      # rather than from dist/, so it can be replayed on its own without
+      # rebuilding or re-uploading anything else.
+      copr_only:
+        description: "Run only the Copr RPM publish for the given tag"
+        required: false
+        default: false
+        type: boolean
 
 # Permissions are declared per-job so that each job gets only what it
 # needs (Sonar S8264). The default permission for any job that does not
@@ -30,6 +39,10 @@ jobs:
   protocol-gate:
     name: Protocol Compatibility Gate
     runs-on: ubuntu-latest
+    # A single-channel republish re-releases nothing, so the release gates
+    # have nothing to gate. Skipping the three root jobs skips the whole
+    # build/publish graph with them - every other job reaches it via `needs`.
+    if: ${{ !inputs.copr_only }}
     timeout-minutes: 15
     permissions:
       contents: read
@@ -117,6 +130,7 @@ jobs:
   test:
     name: Verify tests pass
     runs-on: ubuntu-latest
+    if: ${{ !inputs.copr_only }}
     timeout-minutes: 10
     permissions:
       contents: read
@@ -140,6 +154,7 @@ jobs:
   version-check:
     name: Verify tag matches pyproject.toml
     runs-on: ubuntu-latest
+    if: ${{ !inputs.copr_only }}
     timeout-minutes: 5
     permissions:
       contents: read
@@ -328,6 +343,89 @@ jobs:
           if ! npm publish --access public; then
             echo "::warning::npm wrapper publish failed; continuing release"
           fi
+
+  # RPM channel (#3325). packaging/rpm/bernstein.spec ships a wrapper that
+  # resolves the package from PyPI at run time, so this job waits for the PyPI
+  # publish and then submits a source RPM built at the tag version to the
+  # Fedora Copr build service.
+  #
+  # It hangs off the tag trigger like every other job here rather than off
+  # `release: published`: a release created with GITHUB_TOKEN raises no event,
+  # which is what already leaves the release-event consumers unreachable for
+  # automated releases (#3323).
+  #
+  # No warn-and-continue. The RPM channel leaves no artefact in the repository,
+  # so a swallowed failure here is invisible until someone installs the package
+  # by hand - the failure mode #3322 documents for the npm wrapper.
+  publish-copr:
+    name: Publish RPM to Copr
+    runs-on: ubuntu-latest
+    needs: publish
+    # `always()` so a channel-only republish still runs with the upstream
+    # release graph skipped; the PyPI result still gates the normal tag path.
+    if: ${{ always() && (inputs.copr_only || needs.publish.result == 'success') }}
+    # Wider than the other publish jobs: the submit step waits for the Copr
+    # build itself, which queues behind other builders.
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    env:
+      COPR_PROJECT: alexchernysh/bernstein
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # A republished tag can predate the spec renderer, so in that mode the
+          # packaging sources come from the dispatch ref instead of the tag.
+          ref: ${{ inputs.copr_only && github.ref || inputs.tag || github.ref }}
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+      - name: Install rpmbuild and copr-cli
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends rpm
+          # Pinned: an unpinned installer lets an upstream release change what
+          # runs in the job that holds the publishing credential.
+          python3 -m pip install --disable-pip-version-check "copr-cli==2.5"
+          command -v rpmbuild
+          copr-cli --version
+      - name: Write copr-cli configuration
+        env:
+          COPR_CONFIG: ${{ secrets.COPR_CONFIG }}
+        run: |
+          set -euo pipefail
+          if [ -z "${COPR_CONFIG:-}" ]; then
+            echo "::error::COPR_CONFIG secret is not configured; the RPM channel cannot publish"
+            exit 1
+          fi
+          mkdir -p ~/.config
+          printf '%s\n' "${COPR_CONFIG}" > ~/.config/copr
+          # copr-cli reads an API token from this file; keep it owner-only.
+          chmod 600 ~/.config/copr
+      - name: Build the source RPM at the release version
+        id: srpm
+        run: |
+          set -euo pipefail
+          VERSION="${RELEASE_TAG#v}"
+          SRPM=$(python3 scripts/build_copr_srpm.py --version "${VERSION}" --outdir "${RUNNER_TEMP}/copr")
+          echo "built ${SRPM}"
+          echo "path=${SRPM}" >> "$GITHUB_OUTPUT"
+      - name: Submit build to Copr
+        env:
+          SRPM_PATH: ${{ steps.srpm.outputs.path }}
+        run: |
+          set -euo pipefail
+          echo "submitting ${SRPM_PATH} to ${COPR_PROJECT}"
+          # Deliberately not --nowait: copr-cli then waits for the build and
+          # exits non-zero when it fails, so the job's verdict tracks the
+          # published RPM rather than just the upload.
+          copr-cli build "${COPR_PROJECT}" "${SRPM_PATH}"
 
   # MCP registry listing (#2369). Regenerated from pyproject.toml by
   # scripts/gen_distribution_manifests.py so the listing can never drift

--- a/.github/workflows/reconcile-release.yml
+++ b/.github/workflows/reconcile-release.yml
@@ -22,7 +22,7 @@ permissions: {}
 
 jobs:
   reconcile:
-    name: Compare pyproject.toml vs PyPI
+    name: Compare pyproject.toml vs published channels
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -54,6 +54,7 @@ jobs:
           import re
           import subprocess
           import sys
+          import urllib.error
           import urllib.request
 
           def parse_version(s: str) -> tuple[int, ...]:
@@ -79,6 +80,30 @@ jobs:
           with urllib.request.urlopen(req, timeout=30) as resp:
               pypi_payload = json.load(resp)
           pypi_version = pypi_payload["info"]["version"]
+
+          # Fetch the latest RPM the Copr build service holds. The RPM channel
+          # leaves no artefact in this repository, so this reconciliation is
+          # the only place a dropped publish becomes visible (#3325).
+          copr_version = "unknown"
+          copr_api = (
+              "https://copr.fedorainfracloud.org/api_3/package"
+              "?ownername=alexchernysh&projectname=bernstein"
+              "&packagename=bernstein&with_latest_build=true"
+          )
+          try:
+              copr_req = urllib.request.Request(
+                  copr_api,
+                  headers={"User-Agent": "bernstein-reconcile-release"},
+              )
+              with urllib.request.urlopen(copr_req, timeout=30) as resp:
+                  copr_payload = json.load(resp)
+              latest_build = copr_payload["builds"]["latest"]
+              # Copr versions carry the RPM release suffix ("3.12.0-1").
+              copr_version = str(latest_build["source_package"]["version"]).split("-", 1)[0]
+          except (urllib.error.URLError, TimeoutError, ValueError, KeyError, OSError, TypeError) as exc:
+              # A Copr outage must not take the PyPI comparison down with it;
+              # the warning keeps the degraded run visible in the job log.
+              print(f"::warning::could not read the Copr package state ({exc}); RPM drift not checked")
 
           pj_t = parse_version(pj_version)
           pypi_t = parse_version(pypi_version)
@@ -123,16 +148,25 @@ jobs:
 
           print(f"pj_version={pj_version}")
           print(f"pypi_version={pypi_version}")
+          print(f"copr_version={copr_version}")
           print(f"pj_age_hours={pj_age_hours}")
           print(f"release_exists={'true' if release_exists else 'false'}")
           print(f"asset_count={asset_count}")
 
           version_drift = pj_t > pypi_t and pj_age_hours >= 24
           missing_assets = release_exists and asset_count == 0
+          # An unreadable Copr state is reported as a warning above, not as
+          # drift: it says nothing about what the channel actually holds.
+          copr_drift = (
+              copr_version != "unknown"
+              and pj_t > parse_version(copr_version)
+              and pj_age_hours >= 24
+          )
           print(f"version_drift={'true' if version_drift else 'false'}")
           print(f"missing_assets={'true' if missing_assets else 'false'}")
+          print(f"copr_drift={'true' if copr_drift else 'false'}")
 
-          drift = version_drift or missing_assets
+          drift = version_drift or missing_assets or copr_drift
           print(f"drift={'true' if drift else 'false'}")
           PY
 
@@ -142,26 +176,30 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PJ: ${{ steps.cmp.outputs.pj_version }}
           PYPI: ${{ steps.cmp.outputs.pypi_version }}
+          COPR: ${{ steps.cmp.outputs.copr_version }}
+          COPR_DRIFT: ${{ steps.cmp.outputs.copr_drift }}
           AGE: ${{ steps.cmp.outputs.pj_age_hours }}
           RELEASE_EXISTS: ${{ steps.cmp.outputs.release_exists }}
           ASSET_COUNT: ${{ steps.cmp.outputs.asset_count }}
           MISSING_ASSETS: ${{ steps.cmp.outputs.missing_assets }}
           REPO: ${{ github.repository }}
         run: |
-          TITLE="release drift: pyproject=\`${PJ}\` pypi=\`${PYPI}\`"
+          TITLE="release drift: pyproject=\`${PJ}\` pypi=\`${PYPI}\` copr=\`${COPR}\`"
           if [ "${MISSING_ASSETS}" = "true" ]; then
             CAUSE="GitHub Release missing dist assets."
+          elif [ "${COPR_DRIFT}" = "true" ]; then
+            CAUSE="The RPM channel is behind: re-run the Copr publish with \`gh workflow run publish.yml --ref main -f tag=v${PJ} -f copr_only=true\`."
           else
             CAUSE="Likely cause: a CI run was cancelled/timed_out/action_required so \`auto-release.yml\` silently skipped the publish (see #1273)."
           fi
           # shellcheck disable=SC2016
-          BODY=$(printf 'Detected by `.github/workflows/reconcile-release.yml`.\n\n- pyproject.toml on main: **%s**\n- latest on PyPI: **%s**\n- age of pyproject bump: %sh\n- GitHub Release exists: **%s**\n- GitHub Release asset count: **%s**\n\n%s\n\nRun `gh workflow run reconcile-release.yml` after fixing to clear.\n' \
-            "${PJ}" "${PYPI}" "${AGE}" "${RELEASE_EXISTS}" "${ASSET_COUNT}" "${CAUSE}")
+          BODY=$(printf 'Detected by `.github/workflows/reconcile-release.yml`.\n\n- pyproject.toml on main: **%s**\n- latest on PyPI: **%s**\n- latest on Copr: **%s**\n- age of pyproject bump: %sh\n- GitHub Release exists: **%s**\n- GitHub Release asset count: **%s**\n\n%s\n\nRun `gh workflow run reconcile-release.yml` after fixing to clear.\n' \
+            "${PJ}" "${PYPI}" "${COPR}" "${AGE}" "${RELEASE_EXISTS}" "${ASSET_COUNT}" "${CAUSE}")
 
           # Idempotency: search for an open issue whose title matches the
-          # exact pyproject/pypi pair. Re-runs the same day just comment.
+          # exact channel triple. Re-runs the same day just comment.
           EXISTING=$(gh issue list --repo "${REPO}" --state open \
-            --search "in:title release drift pyproject=${PJ} pypi=${PYPI}" \
+            --search "in:title release drift pyproject=${PJ} pypi=${PYPI} copr=${COPR}" \
             --json number,title \
             --jq ".[] | select(.title == \"${TITLE}\") | .number" \
             | head -1)
@@ -214,7 +252,8 @@ jobs:
         env:
           PJ_VERSION: ${{ steps.cmp.outputs.pj_version }}
           PYPI_VERSION: ${{ steps.cmp.outputs.pypi_version }}
+          COPR_VERSION: ${{ steps.cmp.outputs.copr_version }}
           ASSET_COUNT: ${{ steps.cmp.outputs.asset_count }}
           MISSING_ASSETS: ${{ steps.cmp.outputs.missing_assets }}
         run: |
-          echo "::notice::No release drift detected (pyproject=${PJ_VERSION}, pypi=${PYPI_VERSION}, assets=${ASSET_COUNT}, missing_assets=${MISSING_ASSETS})."
+          echo "::notice::No release drift detected (pyproject=${PJ_VERSION}, pypi=${PYPI_VERSION}, copr=${COPR_VERSION}, assets=${ASSET_COUNT}, missing_assets=${MISSING_ASSETS})."

--- a/docs/maintainers/ci-apps.md
+++ b/docs/maintainers/ci-apps.md
@@ -190,174 +190,24 @@ gh api repos/chernistry/homebrew-tap/contents/Formula/bernstein.rb \
 
 ---
 
-## 10. COPR / RPM - kill or fix decision
+## 10. COPR / RPM - resolved
 
-**Status:** ❌ broken since March 2026. Last successful build was `1.4.11`.
-Every build since fails in Fedora chroots - `copr-cli buildpypi` cannot
-resolve 30+ Python `python3dist(...)` dependencies (`beartype >= 0.21`,
-`crosshair-tool`, `openai-agents`, etc.) because they are not packaged for
-Fedora.
+**Status:** ✅ wired into the release chain (#3325).
 
-The wrapper-spec workaround landed in `packaging/rpm/bernstein.spec`
-(`1.4.11-1`) but it is unused: `publish.yml` calls `copr-cli buildpypi`,
-which **ignores** the in-repo spec and synthesizes its own from PyPI
-metadata. That regenerated spec is what pulls in the missing
-`python3dist(...)` BuildRequires.
+The channel was broken from March 2026 to August 2026 because the release
+chain called `copr-cli buildpypi`, which ignores the in-repo spec and
+synthesizes its own from PyPI metadata. That generated spec pulls in 30+
+`python3dist(...)` BuildRequires that Fedora does not package, so every
+chroot build failed. The last successful build was `1.4.11`.
 
-The operator has to pick one of two paths. Both are docs-only here - the
-actual workflow / docs edits land in a follow-up PR.
+The fix keeps the channel and drops `buildpypi`. `packaging/rpm/bernstein.spec`
+ships a wrapper RPM that resolves the package through `pipx`/`uvx` at run
+time, so it declares no Python dependencies and nothing has to be packaged for
+Fedora. `scripts/build_copr_srpm.py` binds the spec to the release tag and
+`publish-copr` in `.github/workflows/publish.yml` submits the resulting SRPM.
 
-### Option A - Kill the channel
-
-Lowest-effort, recommended if COPR install volume is < 5% of downloads.
-
-Diff for `.github/workflows/publish.yml`:
-
-```diff
--  # COPR RPM rebuild - triggers a new build from the updated PyPI release.
--  trigger-copr:
--    name: Trigger COPR rebuild
--    runs-on: ubuntu-latest
--    needs: build
--    timeout-minutes: 10
--    permissions: {}
--    steps:
--      - name: Harden runner (audit mode)
--        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
--        with:
--          egress-policy: audit
--      - name: Trigger COPR build
--        run: |
--          pip install copr-cli
--          mkdir -p ~/.config
--          cat > ~/.config/copr << EOF
--          [copr-cli]
--          login = ${{ secrets.COPR_LOGIN }}
--          username = alexchernysh
--          token = ${{ secrets.COPR_TOKEN }}
--          copr_url = https://copr.fedorainfracloud.org
--          EOF
--          copr-cli buildpypi --packagename bernstein alexchernysh/bernstein --nowait
-```
-
-Then strip the COPR install path from:
-
-- `docs/getting-started/install.md` (the `Fedora / RHEL (dnf)` tab)
-- `docs/getting-started/install-linux.md` (`## Fedora / RHEL via COPR`)
-- `docs/index.html` (FAQ schema mentions `dnf copr`)
-- `docs/llms-full.txt`
-- All `docs/i18n/README.*.md` install matrix rows
-- `packaging/rpm/bernstein.spec` (delete the file; no longer published)
-- Repo secrets: delete `COPR_LOGIN` and `COPR_TOKEN`.
-
-Recommend a redirect notice: point Fedora users at `pipx install bernstein`
-or `uv tool install bernstein` - both work on Fedora 41/42 out of the box.
-
-### Option B - Fix the spec
-
-Keep COPR alive. Stop relying on `buildpypi`'s auto-generated spec; ship the
-in-repo spec and let `%pyproject_buildrequires --generate-extras` discover
-Python deps from `pyproject.toml` at build time, falling back to bundled
-wheels for anything Fedora can't resolve.
-
-Diff for `packaging/rpm/bernstein.spec` (replaces the entire current file):
-
-```diff
--Name:           bernstein
--Version:        1.4.11
--Release:        1%{?dist}
--Summary:        Multi-agent orchestration for AI coding agents
--License:        Apache-2.0
--URL:            https://github.com/sipyourdrink-ltd/bernstein
--BuildArch:      noarch
--Requires:       python3 >= 3.12
--
--%description
--Orchestrate parallel AI coding agents. Runs Claude Code, Codex, Gemini CLI
--and others in parallel with git worktree isolation and quality gates.
--
--%install
--mkdir -p %{buildroot}%{_bindir}
--cat > %{buildroot}%{_bindir}/bernstein << 'WRAPPER'
--#!/bin/bash
--if command -v pipx &>/dev/null; then
--    exec pipx run bernstein "$@"
--elif command -v uvx &>/dev/null; then
--    exec uvx bernstein "$@"
--else
--    exec python3 -m pip install --user bernstein &>/dev/null && exec python3 -m bernstein "$@"
--fi
--WRAPPER
--chmod 755 %{buildroot}%{_bindir}/bernstein
--
--%files
--%{_bindir}/bernstein
-+%global pypi_name bernstein
-+
-+Name:           bernstein
-+Version:        2.0.1
-+Release:        1%{?dist}
-+Summary:        Multi-agent orchestration for AI coding agents
-+License:        Apache-2.0
-+URL:            https://github.com/sipyourdrink-ltd/bernstein
-+Source0:        %{pypi_source %{pypi_name}}
-+BuildArch:      noarch
-+
-+BuildRequires:  python3-devel >= 3.12
-+BuildRequires:  pyproject-rpm-macros
-+
-+%description
-+Orchestrate parallel AI coding agents. Runs Claude Code, Codex, Gemini CLI
-+and others in parallel with git worktree isolation and quality gates.
-+
-+%prep
-+%autosetup -n %{pypi_name}-%{version}
-+
-+%generate_buildrequires
-+# --generate-extras lets pyproject-rpm-macros discover optional deps from
-+# pyproject.toml so missing python3dist(...) Fedora packages don't block
-+# the build. Anything not available in Fedora is pulled from bundled wheels
-+# via %pyproject_wheel.
-+%pyproject_buildrequires -r --generate-extras
-+
-+%build
-+%pyproject_wheel
-+
-+%install
-+%pyproject_install
-+%pyproject_save_files %{pypi_name}
-+
-+%files -f %{pypi_name}.files
-+%license LICENSE
-+%doc README.md
-+%{_bindir}/bernstein
-```
-
-Then change `publish.yml` to upload the in-repo spec instead of using
-`buildpypi`:
-
-```diff
--          copr-cli buildpypi --packagename bernstein alexchernysh/bernstein --nowait
-+          copr-cli build --nowait alexchernysh/bernstein packaging/rpm/bernstein.spec
-```
-
-Expect 2–3 iterations: each rebuild reveals the next missing
-`python3dist(...)` that needs to either land in Fedora or get vendored via a
-`Source1:` wheel bundle.
-
-### Recommendation
-
-**Option A (kill).** Reasoning:
-
-- `pipx`/`uv tool install` covers Fedora natively and is the upstream
-  Python recommendation; COPR is duplicate surface.
-- Option B's "2–3 iterations" is optimistic - `crosshair-tool` and
-  `openai-agents` have transitive deps that Fedora has historically taken
-  6+ months to package. Realistic timeline is months of maintenance for
-  marginal install volume.
-- Killing COPR also frees the operator from rotating `COPR_LOGIN` /
-  `COPR_TOKEN` and from monitoring a chronically red build.
-
-Pick Option B only if a downstream consumer (gov / regulated org) has a
-hard requirement for a signed `.rpm` from a Fedora-trusted source. That
-requirement should be documented before reopening the channel.
+Operator details - secret name, project URL, local build commands, and the
+single-channel republish path - live in
+[`docs/operations/release.md`](../operations/release.md#rpm-channel-copr).
+The channel is in the `reconcile-release.yml` comparison set, so a version the
+RPM channel never received opens a `release-drift` issue.

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -56,7 +56,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/publish-docker.yml | Publish Docker Image | release, workflow_dispatch | {"cancel-in-progress": "false", "group": "publish-docker-${{ github.ref }}"} | 1 |
 | .github/workflows/publish-extension.yml | Publish VS Code Extension | push, release | {"cancel-in-progress": "false", "group": "publish-extension-${{ github.ref }}"} | 1 |
 | .github/workflows/publish-homebrew.yml | Publish Homebrew Formula | release, workflow_dispatch | {"cancel-in-progress": "false", "group": "publish-homebrew-${{ github.ref }}"} | 1 |
-| .github/workflows/publish.yml | Publish | push, workflow_dispatch | - | 8 |
+| .github/workflows/publish.yml | Publish | push, workflow_dispatch | - | 9 |
 | .github/workflows/reconcile-release.yml | Reconcile release drift | schedule, workflow_dispatch | {"cancel-in-progress": "false", "group": "reconcile-release"} | 1 |
 | .github/workflows/release-major-minor.yml | Major/Minor Release | workflow_dispatch | {"cancel-in-progress": "false", "group": "release-major-minor-${{ github.ref }}"} | 1 |
 | .github/workflows/required-check-canary.yml | Required-check name canary | pull_request, schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "required-check-canary-${{ github.event.pull_request.number \|\| github.ref }}"} | 1 |
@@ -123,8 +123,8 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/publish-docker.yml | publish: Build and push image to GHCR |
 | .github/workflows/publish-extension.yml | publish |
 | .github/workflows/publish-homebrew.yml | update-formula: Update Homebrew formula |
-| .github/workflows/publish.yml | build: Build<br>github-release: Create GitHub Release<br>protocol-gate: Protocol Compatibility Gate<br>publish: Publish to PyPI<br>publish-mcp-registry: Publish MCP registry listing<br>publish-npm: Publish npm wrapper<br>test: Verify tests pass<br>version-check: Verify tag matches pyproject.toml |
-| .github/workflows/reconcile-release.yml | reconcile: Compare pyproject.toml vs PyPI |
+| .github/workflows/publish.yml | build: Build<br>github-release: Create GitHub Release<br>protocol-gate: Protocol Compatibility Gate<br>publish: Publish to PyPI<br>publish-copr: Publish RPM to Copr<br>publish-mcp-registry: Publish MCP registry listing<br>publish-npm: Publish npm wrapper<br>test: Verify tests pass<br>version-check: Verify tag matches pyproject.toml |
+| .github/workflows/reconcile-release.yml | reconcile: Compare pyproject.toml vs published channels |
 | .github/workflows/release-major-minor.yml | release: ${{ inputs.bump }} release |
 | .github/workflows/required-check-canary.yml | verify: Required-check name canary |
 | .github/workflows/review-bot-ack-publish.yml | publish: review-bot-ack-publisher |
@@ -190,7 +190,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/publish-docker.yml | publish: {"attestations": "write", "contents": "read", "id-token": "write", "packages": "write"} | GITHUB_TOKEN |
 | .github/workflows/publish-extension.yml | workflow: {"contents": "read"}<br>publish: {"contents": "write"} | OPEN_VSX_TOKEN, VS_MARKETPLACE_TOKEN |
 | .github/workflows/publish-homebrew.yml | workflow: {"contents": "read"}<br>update-formula: {"contents": "read"} | HOMEBREW_TAP_TOKEN |
-| .github/workflows/publish.yml | build: {"contents": "read"}<br>github-release: {"actions": "write", "contents": "write"}<br>protocol-gate: {"contents": "read"}<br>publish: {"attestations": "write", "contents": "read", "id-token": "write"}<br>publish-mcp-registry: {"contents": "read", "id-token": "write"}<br>publish-npm: {"contents": "read"}<br>test: {"contents": "read"}<br>version-check: {"contents": "read"} | GITHUB_TOKEN, NPM_TOKEN |
+| .github/workflows/publish.yml | build: {"contents": "read"}<br>github-release: {"actions": "write", "contents": "write"}<br>protocol-gate: {"contents": "read"}<br>publish: {"attestations": "write", "contents": "read", "id-token": "write"}<br>publish-copr: {"contents": "read"}<br>publish-mcp-registry: {"contents": "read", "id-token": "write"}<br>publish-npm: {"contents": "read"}<br>test: {"contents": "read"}<br>version-check: {"contents": "read"} | COPR_CONFIG, GITHUB_TOKEN, NPM_TOKEN |
 | .github/workflows/reconcile-release.yml | reconcile: {"contents": "read", "issues": "write"} | - |
 | .github/workflows/release-major-minor.yml | workflow: {"contents": "read"}<br>release: {"attestations": "write", "contents": "write", "id-token": "write"} | GITHUB_TOKEN |
 | .github/workflows/required-check-canary.yml | verify: {"contents": "read"} | - |

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -10,9 +10,9 @@ Update this table whenever a release workflow is added, renamed, or moved.
 |---|---|---|---|---|
 | `.github/workflows/post-ci-dispatcher.yml` | Post-CI dispatcher | `workflow_run` | Routes completed main-branch CI runs to release and recovery child workflows. | Calls `.github/workflows/auto-release.yml` when the upstream CI run targets `main`. |
 | `.github/workflows/auto-release.yml` | Auto-release | `workflow_call` | Decides whether a green main-branch CI run should create a release tag. | Pushes a `v*` tag; `.github/workflows/publish.yml` owns tag publish. |
-| `.github/workflows/publish.yml` | Publish | `push` | Builds release distributions, attests `dist/*`, publishes PyPI and npm packages, and creates or updates the GitHub Release for a `v*` tag. | GitHub Release publication triggers Docker, Homebrew, and release-scoped SBOM follow-up workflows. |
+| `.github/workflows/publish.yml` | Publish | `push` | Builds release distributions, attests `dist/*`, publishes PyPI, npm and Copr RPM packages, and creates or updates the GitHub Release for a `v*` tag. | GitHub Release publication triggers Docker, Homebrew, and release-scoped SBOM follow-up workflows. |
 | `.github/workflows/release-major-minor.yml` | Major/Minor Release | `workflow_dispatch` | Manually cuts major or minor releases after checking CI and applying the version bump. | Pushes the version commit and tag, then builds and publishes from the same run. |
-| `.github/workflows/reconcile-release.yml` | Reconcile release drift | `schedule`, `workflow_dispatch` | Compares `pyproject.toml`, PyPI, and GitHub Release assets to detect missed publish work. | Opens or updates a `release-drift` issue when published state is inconsistent. |
+| `.github/workflows/reconcile-release.yml` | Reconcile release drift | `schedule`, `workflow_dispatch` | Compares `pyproject.toml`, PyPI, Copr, and GitHub Release assets to detect missed publish work. | Opens or updates a `release-drift` issue when published state is inconsistent. |
 | `.github/workflows/publish-docker.yml` | Publish Docker Image | `release`, `workflow_dispatch` | Publishes the GHCR image and image provenance for a released tag. | Runs after a GitHub Release is published, or manually for a selected tag. |
 | `.github/workflows/publish-homebrew.yml` | Publish Homebrew Formula | `release`, `workflow_dispatch` | Updates the Homebrew tap formula for a released version. | Runs after a GitHub Release is published, or manually for a selected version. |
 | `.github/workflows/sbom.yml` | SBOM | `release`, `workflow_dispatch` | Generates SPDX + CycloneDX SBOMs and attaches them as release assets. | Runs after a GitHub Release is published, or manually for a selected ref. |
@@ -37,9 +37,59 @@ Do not hand-edit any of these files for a bump. A bump that touches only
 CI drift gates then fail. Commit the bump in a PR; the merge to `main` triggers
 CI and `.github/workflows/auto-release.yml` picks up the untagged version.
 
+## RPM channel (Copr)
+
+| Fact | Value |
+|---|---|
+| Copr project | <https://copr.fedorainfracloud.org/coprs/alexchernysh/bernstein/> |
+| Repository secret | `COPR_CONFIG` |
+| Publishing job | `publish-copr` in `.github/workflows/publish.yml` |
+| Spec | `packaging/rpm/bernstein.spec` |
+| Builder | `scripts/build_copr_srpm.py` |
+
+`COPR_CONFIG` holds a complete `copr-cli` configuration file — the same
+content `~/.config/copr` has on a workstation, including the `[copr-cli]`
+header, `login`, `username`, `token` and `copr_url`. The job writes it
+verbatim to `~/.config/copr` and restricts it to mode `600`; it is never
+interpolated into shell text. The token carries an expiry date recorded as a
+comment in the file itself, so it has to be reissued from the Copr web UI
+before that date or the job starts failing.
+
+The RPM is a wrapper: it installs a `bernstein` launcher that resolves the
+real package through `pipx`/`uvx` at run time, which is why the job waits for
+the PyPI publish and why the spec declares no Python dependencies. The version
+is bound to the release tag at build time, so the `Version:` committed in the
+spec is only what keeps the file buildable on its own.
+
+Build a source RPM locally the same way the job does:
+
+```
+python3 scripts/build_copr_srpm.py --version v3.13.0 --outdir dist-rpm
+python3 scripts/build_copr_srpm.py --version v3.13.0 --render-only   # no rpmbuild needed
+```
+
+### Republishing the RPM for an existing tag
+
+The RPM channel builds from the spec rather than from `dist/`, so it can be
+replayed on its own without cutting a release:
+
+```
+gh workflow run publish.yml --ref main -f tag=v3.13.0 -f copr_only=true
+```
+
+`copr_only` skips the release gates and the rest of the publish graph and runs
+`publish-copr` alone. Submitting a version Copr already holds is rejected by
+the build service, so bump the release or delete the existing build first.
+
+The job waits for the Copr build instead of returning at upload, and it has no
+warn-and-continue path: a rejected submission or a failed chroot build fails
+the job. Nothing about the RPM channel is visible from this repository, so a
+swallowed failure would go unnoticed until someone installed the package by
+hand.
+
 ## Guardrails
 
 - `.github/workflows/auto-release.yml` only creates tags.
 - `.github/workflows/publish.yml` owns tag-triggered package and GitHub Release publication.
-- `.github/workflows/reconcile-release.yml` is the drift detector for missing PyPI versions or empty GitHub Release assets.
+- `.github/workflows/reconcile-release.yml` is the drift detector for missing PyPI versions, a stale Copr RPM, or empty GitHub Release assets.
 - New release entrypoints must be added to the ownership table and covered by `tests/unit/test_release_entrypoint_docs.py`.

--- a/packaging/rpm/bernstein.spec
+++ b/packaging/rpm/bernstein.spec
@@ -1,4 +1,6 @@
 Name:           bernstein
+# Bound to the release tag by scripts/build_copr_srpm.py before the SRPM is
+# built; the committed value is only what makes this file buildable on its own.
 Version:        1.4.11
 Release:        1%{?dist}
 Summary:        Deterministic orchestrator for CLI coding agents
@@ -31,6 +33,6 @@ chmod 755 %{buildroot}%{_bindir}/bernstein
 %{_bindir}/bernstein
 
 %changelog
-* Thu Apr 03 2026 Alex Chernysh <alex@alexchernysh.com> - 1.4.11-1
+* Fri Apr 03 2026 Alex Chernysh <alex@alexchernysh.com> - 1.4.11-1
 - Switch to wrapper RPM: installs via pipx/uvx instead of native Python RPM
 - Fixes COPR build failures from missing Fedora packages for Python deps

--- a/scripts/build_copr_srpm.py
+++ b/scripts/build_copr_srpm.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Render the RPM spec at a release version and build the source RPM.
+
+``packaging/rpm/bernstein.spec`` carries whatever version was last committed.
+The release chain has to ship the *tag* version, so this renderer is the one
+place that binds the two together: it rewrites ``Version:``, records the
+release in ``%changelog``, and hands the resulting SRPM to ``rpmbuild -bs``.
+
+The rendering half is pure, so the version binding is testable without an
+rpmbuild on the machine (macOS developer boxes usually have none).
+
+Usage::
+
+    python3 scripts/build_copr_srpm.py --version v3.13.0 --outdir /tmp/copr
+    python3 scripts/build_copr_srpm.py --version v3.13.0 --render-only
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+SPEC_PATH = Path("packaging/rpm/bernstein.spec")
+CHANGELOG_AUTHOR = "Bernstein release automation <alex@alexchernysh.com>"
+CHANGELOG_MARKER = "%changelog\n"
+
+VERSION_LINE_RE = re.compile(r"(?m)^Version:(?P<pad>[ \t]+)\S+[ \t]*$")
+RPM_VERSION_RE = re.compile(r"[0-9][0-9A-Za-z.~+_]*")
+
+_WEEKDAYS = ("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
+_MONTHS = (
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+)
+
+
+def rpm_version(tag_or_version: str) -> str:
+    """Return an RPM-legal ``Version:`` field for a release tag.
+
+    RPM forbids ``-`` in ``Version:``; ``~`` is the pre-release separator that
+    sorts *before* the matching final release, which is what a ``-rc1`` tag
+    means.
+    """
+    version = tag_or_version.strip().removeprefix("v")
+    if not version:
+        msg = f"{tag_or_version!r} carries no release version"
+        raise ValueError(msg)
+    version = version.replace("-", "~")
+    if not RPM_VERSION_RE.fullmatch(version):
+        msg = f"{tag_or_version!r} is not an RPM-legal version (got {version!r})"
+        raise ValueError(msg)
+    return version
+
+
+def changelog_stamp(day: date) -> str:
+    """Return the RPM ``%changelog`` date stamp for ``day``.
+
+    Built from explicit tables rather than ``strftime`` so the stamp cannot
+    change with the runner's locale, and so a wrong weekday - which makes
+    rpmbuild warn on every build - is impossible.
+    """
+    return f"{_WEEKDAYS[day.weekday()]} {_MONTHS[day.month - 1]} {day.day:02d} {day.year}"
+
+
+def render_spec(spec_text: str, version: str, build_date: date) -> str:
+    """Return ``spec_text`` bound to ``version``, with a changelog entry."""
+    release_version = rpm_version(version)
+
+    rendered, replaced = VERSION_LINE_RE.subn(
+        lambda match: f"Version:{match.group('pad')}{release_version}",
+        spec_text,
+        count=1,
+    )
+    if replaced != 1:
+        msg = "spec has no `Version:` line to bind to the release"
+        raise ValueError(msg)
+
+    entry_header = f"* {changelog_stamp(build_date)} {CHANGELOG_AUTHOR} - {release_version}-1"
+    if CHANGELOG_MARKER not in rendered:
+        return f"{rendered.rstrip()}\n\n{CHANGELOG_MARKER}{entry_header}\n- Release {release_version}\n"
+
+    head, _, tail = rendered.partition(CHANGELOG_MARKER)
+    if tail.startswith(f"{entry_header}\n"):
+        # Re-rendering the same release must not stack duplicate entries.
+        return rendered
+    return f"{head}{CHANGELOG_MARKER}{entry_header}\n- Release {release_version}\n\n{tail}"
+
+
+def build_srpm(spec_text: str, outdir: Path) -> Path:
+    """Build a source RPM from ``spec_text`` and return its path."""
+    outdir.mkdir(parents=True, exist_ok=True)
+    spec_file = outdir / SPEC_PATH.name
+    spec_file.write_text(spec_text, encoding="utf-8")
+
+    for stale in outdir.glob("*.src.rpm"):
+        stale.unlink()
+
+    # Fixed argv, no shell.
+    result = subprocess.run(
+        [
+            "rpmbuild",
+            "-bs",
+            "--define",
+            f"_topdir {outdir}",
+            "--define",
+            f"_sourcedir {outdir}",
+            "--define",
+            f"_srcrpmdir {outdir}",
+            str(spec_file),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    # rpmbuild chatter belongs in the job log, not on stdout: stdout carries
+    # the SRPM path so the caller can consume it directly.
+    print(result.stdout, file=sys.stderr, end="")
+    print(result.stderr, file=sys.stderr, end="")
+    if result.returncode != 0:
+        msg = f"rpmbuild -bs failed with exit code {result.returncode}"
+        raise RuntimeError(msg)
+
+    built = sorted(outdir.glob("*.src.rpm"))
+    if len(built) != 1:
+        msg = f"expected exactly one SRPM in {outdir}, found {[p.name for p in built]}"
+        raise RuntimeError(msg)
+    return built[0]
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", required=True, help="Release tag or version, e.g. v3.13.0")
+    parser.add_argument("--spec", type=Path, default=SPEC_PATH, help="Spec file to render")
+    parser.add_argument("--outdir", type=Path, default=Path("dist-rpm"), help="Build directory")
+    parser.add_argument(
+        "--render-only",
+        action="store_true",
+        help="Print the rendered spec instead of building the SRPM.",
+    )
+    parser.add_argument(
+        "--date",
+        default=None,
+        help="Changelog date as YYYY-MM-DD (default: today in UTC).",
+    )
+    args = parser.parse_args(argv)
+
+    build_date = date.fromisoformat(str(args.date)) if args.date else datetime.now(tz=UTC).date()
+    spec_path: Path = args.spec
+    rendered = render_spec(spec_path.read_text(encoding="utf-8"), str(args.version), build_date)
+
+    if bool(args.render_only):
+        print(rendered, end="")
+        return 0
+
+    print(build_srpm(rendered, args.outdir))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/test_build_copr_srpm.py
+++ b/tests/unit/scripts/test_build_copr_srpm.py
@@ -1,0 +1,125 @@
+"""Contracts for the release-version RPM spec renderer (issue #3325).
+
+The spec checked into ``packaging/rpm/bernstein.spec`` carries whatever
+version was last committed. The release chain has to publish the *tag*
+version, so the renderer is the single place that binds the two together;
+if it silently kept the committed version the RPM channel would keep
+shipping a stale package while every job stayed green.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import date
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "scripts" / "build_copr_srpm.py"
+SPEC = REPO_ROOT / "packaging" / "rpm" / "bernstein.spec"
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("build_copr_srpm", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def mod() -> ModuleType:
+    assert SCRIPT.exists(), f"{SCRIPT} must exist"
+    return _load_module()
+
+
+@pytest.fixture(scope="module")
+def spec_text() -> str:
+    return SPEC.read_text(encoding="utf-8")
+
+
+def test_rpm_version_strips_the_tag_prefix(mod: ModuleType) -> None:
+    assert mod.rpm_version("v3.13.0") == "3.13.0"
+    assert mod.rpm_version("3.13.0") == "3.13.0"
+
+
+def test_rpm_version_uses_the_rpm_prerelease_separator(mod: ModuleType) -> None:
+    """RPM forbids ``-`` in ``Version:``; ``~`` sorts before the final release."""
+    assert mod.rpm_version("v3.13.0-rc1") == "3.13.0~rc1"
+
+
+@pytest.mark.parametrize("bad", ["", "v", "vnext", "3.13.0 0", "3.13.0/etc"])
+def test_rpm_version_rejects_values_rpm_cannot_carry(mod: ModuleType, bad: str) -> None:
+    with pytest.raises(ValueError, match="version"):
+        mod.rpm_version(bad)
+
+
+def test_render_spec_binds_the_spec_to_the_release_version(mod: ModuleType, spec_text: str) -> None:
+    """The rendered spec must declare the release version, not the committed one."""
+    rendered = mod.render_spec(spec_text, "v3.13.0", date(2026, 8, 1))
+
+    version_lines = [line for line in rendered.splitlines() if line.startswith("Version:")]
+    assert version_lines == ["Version:        3.13.0"]
+
+
+def test_render_spec_records_the_release_in_the_changelog(mod: ModuleType, spec_text: str) -> None:
+    rendered = mod.render_spec(spec_text, "v3.13.0", date(2026, 8, 1))
+    body = rendered.split("%changelog\n", 1)[1]
+
+    # 2026-08-01 is a Saturday; a wrong weekday makes rpmbuild warn.
+    assert body.splitlines()[0].startswith("* Sat Aug 01 2026 ")
+    assert body.splitlines()[0].endswith(" - 3.13.0-1")
+    assert "- Release 3.13.0" in body
+
+
+def test_render_spec_is_deterministic_and_idempotent(mod: ModuleType, spec_text: str) -> None:
+    """Re-rendering the same release must not stack duplicate changelog entries."""
+    once = mod.render_spec(spec_text, "v3.13.0", date(2026, 8, 1))
+    twice = mod.render_spec(once, "v3.13.0", date(2026, 8, 1))
+
+    assert once == mod.render_spec(spec_text, "v3.13.0", date(2026, 8, 1))
+    assert twice == once
+
+
+def test_render_spec_keeps_the_previous_changelog_history(mod: ModuleType, spec_text: str) -> None:
+    rendered = mod.render_spec(spec_text, "v3.13.0", date(2026, 8, 1))
+
+    assert "1.4.11-1" in rendered.split("%changelog\n", 1)[1]
+
+
+def test_render_spec_fails_loudly_on_a_spec_without_a_version(mod: ModuleType) -> None:
+    with pytest.raises(ValueError, match="Version:"):
+        mod.render_spec("Name: bernstein\n", "v3.13.0", date(2026, 8, 1))
+
+
+def test_committed_spec_changelog_dates_are_real_weekdays(spec_text: str) -> None:
+    """A wrong weekday in ``%changelog`` makes every rpmbuild emit a warning."""
+    import re
+
+    stamp = re.compile(r"^\* (\w{3}) (\w{3}) (\d{2}) (\d{4}) ")
+    months = {
+        "Jan": 1,
+        "Feb": 2,
+        "Mar": 3,
+        "Apr": 4,
+        "May": 5,
+        "Jun": 6,
+        "Jul": 7,
+        "Aug": 8,
+        "Sep": 9,
+        "Oct": 10,
+        "Nov": 11,
+        "Dec": 12,
+    }
+    weekdays = ("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
+
+    entries = [match for line in spec_text.splitlines() if (match := stamp.match(line))]
+    assert entries, "spec must keep a %changelog"
+    for match in entries:
+        day_name, month_name, day, year = match.groups()
+        actual = date(int(year), months[month_name], int(day))
+        assert day_name == weekdays[actual.weekday()], f"bogus changelog date: {match.group(0)!r}"

--- a/tests/unit/test_publish_workflow_yaml.py
+++ b/tests/unit/test_publish_workflow_yaml.py
@@ -1,13 +1,19 @@
-"""Structural assertions on ``.github/workflows/publish.yml`` (issue #2642).
+"""Structural assertions on ``.github/workflows/publish.yml`` (issues #2642, #3325).
 
 The MCP-registry publish job runs with ``id-token: write``; the tool it
 downloads and executes there must be pinned to an immutable release and
 integrity-checked before it runs, so an upstream ``releases/latest`` move
 cannot change what executes in the privileged job.
+
+The RPM publish job is pinned for a different reason: it is the only
+distribution channel whose failure mode is invisible from the repository,
+so it must be reachable on the tag trigger and must fail the job instead of
+warning.
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any, cast
 
@@ -27,14 +33,21 @@ def _load(path: Path) -> dict[str, Any]:
     return cast("dict[str, Any]", yaml.safe_load(path.read_text(encoding="utf-8")))
 
 
-def _step_run(workflow: dict[str, Any], job_name: str, step_name: str) -> str:
+COPR_JOB = "publish-copr"
+
+
+def _step(workflow: dict[str, Any], job_name: str, step_name: str) -> dict[str, Any]:
     job = workflow["jobs"][job_name]
     for step_value in job.get("steps", []):
         if isinstance(step_value, dict) and step_value.get("name") == step_name:
-            run = step_value.get("run")
-            assert isinstance(run, str)
-            return run
+            return cast("dict[str, Any]", step_value)
     pytest.fail(f"{WORKFLOW.name}::{job_name} has no step named {step_name!r}")
+
+
+def _step_run(workflow: dict[str, Any], job_name: str, step_name: str) -> str:
+    run = _step(workflow, job_name, step_name).get("run")
+    assert isinstance(run, str)
+    return run
 
 
 @pytest.fixture(scope="module")
@@ -69,3 +82,105 @@ def test_mcp_publisher_download_is_checksum_verified(workflow: dict[str, Any]) -
     assert verify_pos != -1, "checksum is never verified"
     assert extract_pos != -1, "archive is never extracted"
     assert verify_pos < extract_pos, "checksum must be verified before extraction"
+
+
+def test_copr_job_publishes_from_the_tag_trigger_not_the_release_event(workflow: dict[str, Any]) -> None:
+    """A release created with ``GITHUB_TOKEN`` raises no ``release`` event.
+
+    Hanging the RPM publish off ``release: published`` would make it
+    unreachable for every automated release, exactly as it already is for the
+    workflows tracked in #3323. It must sit on the same trigger the PyPI job
+    uses.
+    """
+    triggers = workflow.get("on") or workflow.get(True)
+    assert isinstance(triggers, dict)
+    assert "push" in triggers
+    assert "release" not in triggers, "the RPM publish must not depend on the release event"
+
+    job = workflow["jobs"][COPR_JOB]
+    assert job.get("needs") == "publish", "the RPM wrapper resolves the package from PyPI at run time"
+
+
+def test_copr_job_fails_the_workflow_when_the_submission_fails(workflow: dict[str, Any]) -> None:
+    """No warn-and-continue: a dropped RPM publish has to be visible (#3322)."""
+    job = workflow["jobs"][COPR_JOB]
+    assert job.get("continue-on-error") is not True
+
+    submit = _step(workflow, COPR_JOB, "Submit build to Copr")
+    assert submit.get("continue-on-error") is not True
+    run = submit["run"]
+    assert "set -euo pipefail" in run
+    assert "::warning::" not in run
+    assert "|| true" not in run
+    assert "|| echo" not in run
+
+    # `copr-cli build` exits non-zero when the build fails only if it waits for
+    # it, so the job's verdict tracks the published RPM, not just the upload.
+    commands = [line.strip() for line in run.splitlines() if not line.strip().startswith("#")]
+    submit_commands = [line for line in commands if line.startswith("copr-cli build")]
+    assert submit_commands, "the step must invoke `copr-cli build`"
+    for command in submit_commands:
+        assert "--nowait" not in command
+
+
+def test_copr_config_secret_is_written_from_the_environment_with_owner_only_mode(
+    workflow: dict[str, Any],
+) -> None:
+    """The credential must not be interpolated into the shell text, and the
+    file copr-cli reads must not be world-readable on a shared runner."""
+    step = _step(workflow, COPR_JOB, "Write copr-cli configuration")
+    env = step.get("env", {})
+    assert env.get("COPR_CONFIG") == "${{ secrets.COPR_CONFIG }}"
+
+    run = step["run"]
+    assert "${{" not in run, "secrets must reach the shell through env, not expression interpolation"
+    assert "chmod 600" in run
+    assert "~/.config/copr" in run
+
+
+def test_copr_job_fails_loudly_when_the_secret_is_absent(workflow: dict[str, Any]) -> None:
+    """A missing credential is a broken release channel, not a skip."""
+    run = _step(workflow, COPR_JOB, "Write copr-cli configuration")["run"]
+    assert "::error::" in run
+    assert "exit 1" in run
+    assert "exit 0" not in run
+
+
+def test_copr_cli_install_is_version_pinned(workflow: dict[str, Any]) -> None:
+    """An unpinned installer lets an upstream release change what runs here."""
+    run = _step(workflow, COPR_JOB, "Install rpmbuild and copr-cli")["run"]
+    assert re.search(r"copr-cli==\d+\.\d+", run), "copr-cli must be installed from a pinned version"
+
+
+def test_copr_job_can_be_replayed_for_an_already_published_tag(workflow: dict[str, Any]) -> None:
+    """Republishing one channel must not require cutting a new release."""
+    triggers = workflow.get("on") or workflow.get(True)
+    assert isinstance(triggers, dict)
+    inputs = triggers["workflow_dispatch"]["inputs"]
+    assert "copr_only" in inputs
+    assert inputs["copr_only"]["type"] == "boolean"
+
+    # The gate lives on the root jobs; everything else skips through `needs`.
+    for job_name in ("protocol-gate", "test", "version-check"):
+        condition = workflow["jobs"][job_name].get("if")
+        assert isinstance(condition, str), f"{job_name} must be skippable for a channel-only replay"
+        assert "copr_only" in condition
+
+    copr_condition = workflow["jobs"][COPR_JOB].get("if")
+    assert isinstance(copr_condition, str)
+    assert "always()" in copr_condition, "a skipped upstream job must not skip the replay"
+    assert "inputs.copr_only" in copr_condition
+    assert "needs.publish.result == 'success'" in copr_condition
+
+
+def test_copr_replay_checks_out_packaging_sources_that_carry_the_builder(workflow: dict[str, Any]) -> None:
+    """A replayed tag can predate the build script; the sources must come from
+    the dispatch ref in that mode or the job fails on a missing file."""
+    job = workflow["jobs"][COPR_JOB]
+    checkout = next(
+        step
+        for step in job["steps"]
+        if isinstance(step, dict) and str(step.get("uses", "")).startswith("actions/checkout@")
+    )
+    ref = checkout["with"]["ref"]
+    assert "inputs.copr_only" in ref

--- a/tests/unit/test_reconcile_release_workflow_yaml.py
+++ b/tests/unit/test_reconcile_release_workflow_yaml.py
@@ -101,3 +101,50 @@ def test_no_drift_notice_reports_asset_count() -> None:
 
     run = _run(step)
     assert "assets=${ASSET_COUNT}" in run
+
+
+def test_compare_step_covers_the_rpm_channel() -> None:
+    """Copr is in the comparison set (#3325).
+
+    The RPM channel has no repository-visible artefact, so a dropped publish
+    is invisible until someone installs the package by hand. The reconciler
+    is the only surface that can see it.
+    """
+    run = _run(_step("Compare versions and release assets"))
+
+    assert "copr.fedorainfracloud.org/api_3/package" in run
+    assert "copr_version=" in run
+    assert "copr_drift=" in run
+    assert "drift = version_drift or missing_assets or copr_drift" in run
+
+
+def test_copr_lookup_failure_does_not_break_the_pypi_comparison() -> None:
+    """A Copr API outage must not take the PyPI drift detector down with it."""
+    run = _run(_step("Compare versions and release assets"))
+
+    except_clause = next(line for line in run.splitlines() if line.strip().startswith("except ("))
+    for exception in ("urllib.error.URLError", "TimeoutError", "ValueError", "KeyError", "OSError"):
+        assert exception in except_clause
+
+    assert 'copr_version = "unknown"' in run
+    assert "::warning::" in run
+
+
+def test_drift_issue_reports_the_rpm_channel_version() -> None:
+    step = _step("Open or update drift issue (idempotent)")
+    env = step.get("env", {})
+    assert isinstance(env, dict)
+    assert "COPR" in env
+
+    run = _run(step)
+    assert "latest on Copr" in run
+
+
+def test_no_drift_notice_reports_the_rpm_channel_version() -> None:
+    step = _step("No drift")
+    env = step.get("env", {})
+    assert isinstance(env, dict)
+    assert "COPR_VERSION" in env
+
+    run = _run(step)
+    assert "copr=${COPR_VERSION}" in run


### PR DESCRIPTION
`packaging/rpm/bernstein.spec` exists, but nothing in the release chain built or
published it, so the RPM channel has silently shipped nothing since `1.4.11`.

## What changed

| Area | Change |
|---|---|
| `.github/workflows/publish.yml` | New `publish-copr` job beside the PyPI/npm/GHCR jobs, on the same tag trigger |
| `scripts/build_copr_srpm.py` | Binds the spec to the release tag and builds the SRPM |
| `.github/workflows/reconcile-release.yml` | Copr added to the comparison set |
| `docs/operations/release.md` | Secret name, project URL, local build and republish commands |
| `packaging/rpm/bernstein.spec` | Note on the version binding; fixed a bogus `%changelog` weekday |

## Design notes

**Tag trigger, not the release event.** A release created with `GITHUB_TOKEN`
raises no `release` event, which is what already leaves the release-event
consumers unreachable for automated releases (#3323). The job hangs off the
same trigger the PyPI job uses and gates on the PyPI publish, because the
wrapper RPM resolves the package through `pipx`/`uvx` at run time.

**Fail-loud.** No warn-and-continue path. The submit step waits for the Copr
build instead of returning at upload, so a rejected submission *or* a failed
chroot build fails the job. The RPM channel leaves no artefact in this
repository, so a swallowed failure would be invisible until someone installed
the package by hand — the failure mode #3322 documents for the npm wrapper.

**Version binding.** The spec carries whatever version was last committed;
`scripts/build_copr_srpm.py` rewrites `Version:` from the tag and records the
release in `%changelog` with a locale-independent date stamp. The rendering
half is pure, so the binding is covered by unit tests on machines without an
`rpmbuild`.

**Credential handling.** `COPR_CONFIG` reaches the shell through `env`, never
expression interpolation, and is written to `~/.config/copr` with mode `600`.
A missing secret fails the job rather than skipping the channel.

**Drift detection.** `reconcile-release.yml` reads the Copr package state and
opens a `release-drift` issue when the RPM channel is behind `pyproject.toml`,
with the single-channel republish command in the issue body. A Copr API outage
degrades to a warning rather than taking the PyPI comparison down with it.

**Single-channel republish.** A `copr_only` dispatch input runs `publish-copr`
alone for a tag that is already released:

```
gh workflow run publish.yml --ref main -f tag=v3.13.0 -f copr_only=true
```

## Verification

- `scripts/build_copr_srpm.py --version v3.12.0` builds `bernstein-3.12.0-1.src.rpm`
  locally with the correct `Version:` and no rpmbuild warnings.
- The reconciler's Copr lookup was exercised against the live API: it reads
  `1.4.11` and reports drift against `pyproject.toml`.
- New guard tests: 13 on the spec renderer, 7 on the publish job, 4 on the
  reconciler. All were red before the change.
- `docs/operations/ci-topology.md` regenerated.

## User-visible changes

- Fedora/EPEL users get the current version from the Copr repository again.
- Operators get a `release-drift` issue when the RPM channel falls behind.

Closes #3325

## Summary by Sourcery

Wire the Fedora Copr RPM channel into the release and drift-detection workflows so RPM builds are published from tags and monitored alongside other distribution channels.

New Features:
- Add a publish-copr job to the tag-triggered publish workflow to build a version-bound SRPM from the in-repo spec and submit it to Copr.
- Introduce scripts/build_copr_srpm.py to render the RPM spec at a given release version and build a source RPM, enabling wrapper-based RPM publishing.

Enhancements:
- Document Copr/RPM release operations, credentials, local build commands, and single-channel republish flow in the release operations guide.
- Extend the reconcile-release workflow to compare pyproject.toml against Copr’s latest RPM and surface RPM drift via release-drift issues.
- Update CI topology and workflow guardrail docs to reflect the new RPM channel and publish-copr job, including permissions and job counts.
- Clarify the committed RPM spec’s version-binding role and correct its changelog weekday to keep builds warning-free.

Tests:
- Add unit tests for the SRPM/spec renderer, Copr publish workflow structure and failure behavior, and reconcile-release’s Copr comparison and outage handling.