### PR TITLE
fix(release): pin copr-cli to a release whose dependencies are declared

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -436,8 +436,14 @@ jobs:
           sudo apt-get install -y --no-install-recommends rpm
           # Pinned: an unpinned installer lets an upstream release change what
           # runs in the job that holds the publishing credential.
-          python3 -m pip install --disable-pip-version-check "copr-cli==2.5"
+          #
+          # 2.4 rather than 2.5: 2.5 imports `rich` at module scope but
+          # declares only `copr, humanize, jinja2, setuptools`, so a clean
+          # install of it produces a CLI that cannot start.
+          python3 -m pip install --disable-pip-version-check "copr-cli==2.4"
           command -v rpmbuild
+          # Run the CLI once here: an install that cannot import fails in this
+          # step rather than after the API token is written to disk.
           copr-cli --version
       - name: Write copr-cli configuration
         env:

--- a/tests/unit/test_publish_workflow_yaml.py
+++ b/tests/unit/test_publish_workflow_yaml.py
@@ -283,3 +283,34 @@ def test_dispatched_inputs_match_the_target_workflow_inputs(workflow: dict[str, 
         declared = _declared_dispatch_inputs(workflow_file)
         unknown = passed_inputs - declared
         assert not unknown, f"{workflow_file} does not declare dispatch input(s) {sorted(unknown)}"
+
+
+# copr-cli 2.5 imports `rich` at module scope but declares only
+# `copr, humanize, jinja2, setuptools`, so a clean `pip install copr-cli==2.5`
+# produces a CLI that cannot start. Recorded here so a future bump cannot
+# walk back into a release with a known-incomplete dependency set.
+COPR_CLI_RELEASES_WITH_UNDECLARED_IMPORTS = frozenset({"2.5"})
+
+
+def test_copr_cli_pin_avoids_releases_with_undeclared_imports(workflow: dict[str, Any]) -> None:
+    run = _step(workflow, COPR_JOB, "Install rpmbuild and copr-cli")["run"]
+    match = re.search(r"copr-cli==(\S+?)\"", run)
+    assert match is not None, "copr-cli must be installed from a pinned version"
+    assert match.group(1) not in COPR_CLI_RELEASES_WITH_UNDECLARED_IMPORTS
+
+
+def test_copr_cli_install_is_proven_to_run_before_the_credential_is_written(
+    workflow: dict[str, Any],
+) -> None:
+    """Running the CLI once at install time turns an unusable install into an
+    install-step failure instead of a failure after the token is on disk."""
+    run = _step(workflow, COPR_JOB, "Install rpmbuild and copr-cli")["run"]
+    install_pos = run.find("copr-cli==")
+    smoke_pos = run.find("copr-cli --version")
+    assert smoke_pos != -1, "the install step must run copr-cli once to prove it imports"
+    assert install_pos < smoke_pos
+
+    # The smoke check has to be in the install step, which runs before the
+    # step that writes ~/.config/copr.
+    steps = [step.get("name") for step in workflow["jobs"][COPR_JOB]["steps"] if isinstance(step, dict)]
+    assert steps.index("Install rpmbuild and copr-cli") < steps.index("Write copr-cli configuration")


### PR DESCRIPTION
# User description
The first Copr publish run failed at the install step, before any credential
was written:

```
File ".../copr_cli/main.py", line 17, in <module>
    from rich.text import Text
ModuleNotFoundError: No module named 'rich'
```

## Cause

`copr-cli` 2.5 imports `rich` at module scope, but its published metadata
declares only `copr, humanize, jinja2, setuptools`. A clean install therefore
produces a CLI that cannot start. It is not an environment problem — the
dependency set is incomplete at the source.

Reproduced in a throwaway venv:

| Version | `copr-cli --version` | `rich` references in `main.py` |
|---|---|---|
| 2.5 | `ModuleNotFoundError: No module named 'rich'` | 1 |
| 2.4 | `copr version 2.4` | 0 |

2.4 also reads the live API successfully.

## Fix

Pin 2.4 and record 2.5 in a guard set, so a later bump cannot walk back into a
release with a known-incomplete dependency set. Bumping past it stays open —
only the known-bad release is blocked.

The `copr-cli --version` smoke check that surfaced this is now covered by a
guard test that also pins its ordering ahead of the step writing
`~/.config/copr`: an install that cannot import has to fail before the API
token reaches disk.

## Verification

- Local venv reproduction of both versions, as tabulated above.
- `test_copr_cli_pin_avoids_releases_with_undeclared_imports` was red on the
  2.5 pin and is green on 2.4.
- 33 workflow guard and spec-renderer tests pass.

Refs #3325

## Summary by Sourcery

Pin the Copr publishing workflow to a known-good copr-cli release and add guards to ensure the CLI imports successfully before credentials are written.

Bug Fixes:
- Avoid using copr-cli 2.5, whose undeclared dependency on rich causes the CLI to fail on clean installs.

Enhancements:
- Introduce tests that enforce copr-cli is pinned away from known-bad releases and that a smoke check runs before the credential-writing step in the Copr publish workflow.

CI:
- Update the publish workflow to install copr-cli 2.4 and run a copr-cli --version smoke check prior to writing Copr configuration.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Pin the Copr publish workflow’s <code>copr-cli</code> install to 2.4 and run <code>copr-cli --version</code> during the install step so import failures surface before <code>~/.config/copr</code> is written. Add guard tests that block known-bad releases and enforce the smoke-check ordering.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>chernistry</td><td>fix(ci): fail the publ...</td><td>August 01, 2026</td></tr>
<tr><td>alex@alexchernysh.com</td><td>fix(release): pin copr...</td><td>August 01, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3339?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>