### PR TITLE
docs: drop deleted chaos/cloud verbs and back countable claims

### DIFF
--- a/.github/workflows/docs-drift.yml
+++ b/.github/workflows/docs-drift.yml
@@ -8,6 +8,10 @@ name: docs-drift
 # report is posted as a non-blocking PR comment so the change can land in
 # the same PR. On pushes to main the gate fails so the drift gets fixed in
 # a follow-up.
+#
+# The removed-verb check below is the one hard gate that also fails on pull
+# requests: a doc naming a deleted command surface is a factual error, not
+# staleness, so it must not be allowed to land and be fixed later.
 
 on:
   pull_request:
@@ -145,6 +149,42 @@ jobs:
                 owner, repo, issue_number, body: payload,
               });
             }
+
+      - name: Fail on docs referencing removed CLI verbs
+        # These command surfaces were deleted from the CLI, so a doc that
+        # spells one out again documents something the binary cannot run.
+        # Unlike the drift report above, this fails on pull requests too.
+        # Historical records (release notes, blog posts) legitimately name
+        # what existed at the time, so those directories are skipped.
+        run: |
+          set -uo pipefail
+          scan_paths=(docs README.md CONTRIBUTING.md AGENTS.md CLAUDE.md CONVENTIONS.md)
+          patterns=(
+            'bernstein chaos [a-z/-]*rate-limit'
+            'bernstein chaos [a-z/-]*agent-oom'
+            'bernstein chaos [a-z/-]*disk-full'
+            'bernstein cloud [a-z/-]*deploy'
+            '--chaos([^a-z-]|$)'
+          )
+          failed=0
+          for pattern in "${patterns[@]}"; do
+            hits="$(grep -rnE --include='*.md' \
+              --exclude-dir=release-notes --exclude-dir=blog \
+              -- "${pattern}" "${scan_paths[@]}" || true)"
+            if [ -n "${hits}" ]; then
+              failed=1
+              echo "::error::Doc references a removed CLI surface matching /${pattern}/"
+              printf '%s\n' "${hits}"
+            fi
+          done
+          if [ "${failed}" -ne 0 ]; then
+            echo
+            echo "These command surfaces were deleted from the CLI. Replace the"
+            echo "reference with a verb that 'bernstein --help' lists, or drop it."
+            exit 1
+          fi
+          echo "No references to removed CLI verbs."
+        shell: bash
 
       - name: Fail the gate on main-branch drift
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The full operator surface (PR automation, schedules, chat bridges, the autofix d
 
 ### supported agents
 
-Claude Code, Codex CLI, Gemini CLI, GitHub Copilot CLI, Cursor, Aider, Goose, OpenAI Agents SDK, Amp, Cody, Continue, Devin Terminal, Junie, Kilo, Kiro, AWS Q Developer, Ollama, OpenCode, OpenHands, Open Interpreter, gptme, Plandex, AIChat, Letta Code, Qwen, and more. The [adapter index](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/adapters/index.md) carries the full table with install commands; anything else with a `--prompt` flag works through the generic wrapper.
+Claude Code, Codex CLI, Gemini CLI, GitHub Copilot CLI, Cursor, Aider, Goose, OpenAI Agents SDK, Amp, Cody, Continue, Devin Terminal, Junie, Kilo, Kiro, AWS Q Developer, Ollama, OpenCode, OpenHands, Open Interpreter, gptme, Plandex, AIChat, Letta Code, Qwen, and more. The [adapter index](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/adapters/index.md) carries install commands for 29 of them; `bernstein integrations list` enumerates all 48 wired-in adapters from `src/bernstein/adapters/use_cases.py`, which is the single source of truth. Anything else with a `--prompt` flag works through the generic wrapper.
 
 Mix agents in the same run: cheap local models for boilerplate, heavier cloud models for architecture. `bernstein integrations list --installed` shows what is available on your machine.
 
@@ -111,7 +111,7 @@ Everything deep lives on the [docs site](https://bernstein.readthedocs.io/):
 | [who this is for](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/use-cases.md) | where the value lands, and where Bernstein is the wrong tool |
 | [workflows](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/operations/workflow-manifests.md) | declarative YAML DAGs of agent / command / loop nodes |
 | [web UI](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/gui/index.md) | browser dashboard on the same API the TUI uses |
-| [cloud execution](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/cloudflare/cloudflare-overview.md) | run agents on Cloudflare Workers with R2 workspace sync |
+| [cloud execution](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/cloudflare/cloudflare-overview.md) | experimental: run agents on Cloudflare Workers with R2 workspace sync against your own account. The hosted `api.bernstein.run` service is not yet available |
 | [security](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/operations/security.md) | scorecard, fuzzing, hardening |
 | [architecture](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/architecture/ARCHITECTURE.md) | how it works under the hood |
 

--- a/docs/cloudflare/cloudflare-cli.md
+++ b/docs/cloudflare/cloudflare-cli.md
@@ -2,15 +2,15 @@
 
 **Module:** `bernstein.cli.commands.cloud_cmd`
 
-The `bernstein cloud` command group manages hosted orchestration on Cloudflare. It provides authentication, remote run management, cost reporting, and worker scaffolding/deployment.
+The `bernstein cloud` command group manages hosted orchestration on Cloudflare. It provides authentication, remote run management, cost reporting, and worker scaffolding.
 
 !!! warning "Hosted service is experimental"
     The hosted API at `api.bernstein.run` is experimental and **not currently
     available** — the host does not resolve in DNS. The `login`, `run`,
     `status`, `runs`, and `cost` commands target it; when it is unreachable they
     report a clear "not reachable / not currently available" message and exit
-    non-zero (rather than a traceback). `init` and `deploy` are local and work
-    against your own Cloudflare account.
+    non-zero (rather than a traceback). `init` is local and works against your
+    own Cloudflare account.
 
 ---
 
@@ -155,26 +155,12 @@ An existing `src/index.js` is left unchanged. The scaffolded `wrangler.toml`
 declares no paid bindings (Queues, KV, Durable Objects, and R2 are commented
 out).
 
----
-
-### `bernstein cloud deploy`
-
-Print the command to deploy the Bernstein agent Worker to your Cloudflare account.
+Deployment is a wrangler step, not a Bernstein one. Set `account_id` in the
+generated `wrangler.toml`, then:
 
 ```bash
-bernstein cloud deploy
-
-# Custom worker name
-bernstein cloud deploy --worker-name my-bernstein-worker
+npx wrangler deploy
 ```
-
-| Option | Default | Description |
-|--------|---------|-------------|
-| `--worker-name` | `"bernstein-agent"` | Cloudflare Worker script name |
-
-!!! note "Manual step"
-    This command prints the `wrangler deploy` command; run it to complete
-    deployment. Scaffold a deployable worker first with `bernstein cloud init`.
 
 ---
 

--- a/docs/cloudflare/cloudflare-overview.md
+++ b/docs/cloudflare/cloudflare-overview.md
@@ -1,5 +1,12 @@
 # Cloudflare Integration Overview
 
+!!! warning "Experimental; hosted API not yet available"
+    Cloud execution is experimental. Workers, R2, D1, and Workers AI run
+    against **your own** Cloudflare account. The hosted Bernstein Cloud API at
+    `api.bernstein.run` does not resolve in DNS, so `bernstein cloud login`,
+    `run`, `status`, `runs`, and `cost` report that the service is unreachable
+    and exit non-zero.
+
 Bernstein can run agents locally or in the cloud. The Cloudflare integration lets you execute agents on Cloudflare's edge infrastructure using Workers, Durable Objects, and Workflows -- while the orchestrator stays deterministic and local.
 
 ---

--- a/docs/cloudflare/cloudflare-setup.md
+++ b/docs/cloudflare/cloudflare-setup.md
@@ -134,8 +134,8 @@ bernstein cloud init                 # writes wrangler.toml + src/index.js
 npx wrangler deploy --name bernstein-agent
 ```
 
-`bernstein cloud deploy --worker-name bernstein-agent` prints the same
-`wrangler deploy` command for reference.
+`bernstein cloud init` only scaffolds; the deploy itself is a wrangler step
+run against your own Cloudflare account.
 
 ---
 

--- a/docs/operations/chaos-engineering.md
+++ b/docs/operations/chaos-engineering.md
@@ -4,12 +4,12 @@
 prove the orchestrator survives the failure modes its docs claim it
 survives. It is **not** a load generator and **not** a security fuzzer.
 The verbs map directly to scenarios the deterministic core is supposed
-to recover from: an agent dies mid-task, a provider returns 429, a file
-disappears from a worktree, the disk fills up.
+to recover from: an agent dies mid-task, a file disappears from a
+worktree.
 
-The CLI lives in `cli/commands/chaos_cmd.py:33` (`@click.group("chaos")`).
+The CLI lives in `cli/commands/chaos_cmd.py:31` (`@click.group("chaos")`).
 All state - including replayable history - is written under
-`.sdd/runtime/chaos/` (`chaos_cmd.py:29`).
+`.sdd/runtime/chaos/` (`chaos_cmd.py:28`).
 
 ---
 
@@ -21,9 +21,6 @@ failure paths are exercised rarely. The same boring path covers:
 - **WAL replay**: an agent crashes mid-task. The orchestrator must
   re-claim, re-spawn, and finish the work without producing two
   conflicting commits (see `architecture/state-persistence.md`).
-- **Cross-adapter failover**: a provider rate-limits. The cascade
-  fallback manager must walk the configured order
-  (`opus → sonnet → codex → gemini → qwen`) without dropping the task.
 - **Worktree integrity**: a file the agent was editing disappears
   underneath it. The agent must surface a clean error rather than
   silently rewriting it.
@@ -49,7 +46,7 @@ bernstein chaos agent-kill [--agent-id <name>]
 
 Walks `.sdd/runtime/agents/`, finds every agent whose `pid` file points
 at a live process, and sends `SIGTERM` to one of them
-(`chaos_cmd.py:74-99`). With `--agent-id` you target a specific agent;
+(`chaos_cmd.py:73-98`). With `--agent-id` you target a specific agent;
 without it, one is chosen at random.
 
 **What recovery should look like.** The orchestrator detects the dead
@@ -59,22 +56,6 @@ the tier is too flaky, escalates to the next adapter. No commit should
 land for the killed run, and no second commit should land for the same
 task ID once it completes.
 
-### `rate-limit` - simulate a provider 429
-
-```
-bernstein chaos rate-limit [--provider claude] [--duration 60]
-```
-
-Writes a marker file `rate_limit_active.json` with an `expires_at` epoch
-(`chaos_cmd.py:102-127`). Code paths that consult the marker (the
-fallback manager, the routing layer) must treat the named provider as
-rate-limited until the marker expires.
-
-**What recovery should look like.** New tasks route to the next
-adapter in the cascade. In-flight tasks targeting the rate-limited
-provider should retry with backoff, then escalate. No tokens should be
-spent on the throttled provider during the window.
-
 ### `file-remove` - yank a file out of a worktree
 
 ```
@@ -83,7 +64,7 @@ bernstein chaos file-remove [--pattern "*.py"]
 
 Picks a random non-`__init__.py` file under
 `.claude/worktrees/*/src/**/<pattern>`, copies it to a `.chaos_backup`
-sibling, and deletes the original (`chaos_cmd.py:130-165`).
+sibling, and deletes the original (`chaos_cmd.py:101-136`).
 
 **What recovery should look like.** The agent operating in that
 worktree must either fail loudly (gate failure, missing import) or
@@ -98,9 +79,7 @@ bernstein chaos status [--limit 20]
 
 Reads `.sdd/runtime/chaos/chaos_log.jsonl` and prints a table of recent
 events: timestamp, scenario, target, success/error
-(`chaos_cmd.py:204-241`). Also surfaces any unexpired rate-limit
-simulation so operators do not forget a marker is still pinned
-(`chaos_cmd.py:244-261`).
+(`chaos_cmd.py:139-175`).
 
 ### `slo` - read the SLO dashboard during the experiment
 
@@ -109,7 +88,7 @@ bernstein chaos slo
 ```
 
 Loads `.sdd/metrics/slos.json` and prints traffic-light status per SLO
-plus the error-budget panel (`chaos_cmd.py:264-318`).
+plus the error-budget panel (`chaos_cmd.py:178-232`).
 
 The output table contains:
 
@@ -155,7 +134,7 @@ The chaos CLI is intentionally narrow:
 - **No user data is touched.** `file-remove` operates on
   `.claude/worktrees/*/src/**` only. It will not delete files outside
   the worktree, and it always writes a `.chaos_backup` sibling first
-  (`chaos_cmd.py:153-159`).
+  (`chaos_cmd.py:126-130`).
 - **No production credentials are exfiltrated or rotated.** No
   subcommand reads from the credential vault.
 - **No commits or PRs are produced.** The CLI never invokes git or
@@ -176,14 +155,14 @@ chaos run reproducible.
 
 ## Code pointers
 
-- `cli/commands/chaos_cmd.py:33` - `@click.group("chaos")` entry point.
-- `cli/commands/chaos_cmd.py:38-72` - active-agent discovery and target
+- `cli/commands/chaos_cmd.py:31` - `@click.group("chaos")` entry point.
+- `cli/commands/chaos_cmd.py:36-70` - active-agent discovery and target
   selection.
-- `cli/commands/chaos_cmd.py:75-100` - `agent-kill`.
-- `cli/commands/chaos_cmd.py:104-139` - `file-remove` with backup.
-- `cli/commands/chaos_cmd.py:142-178` - `status` (chaos log table).
-- `cli/commands/chaos_cmd.py:181-235` - `slo` (SLO dashboard).
-- `cli/commands/chaos_cmd.py:238-256` - `_record_chaos_event` (JSONL
+- `cli/commands/chaos_cmd.py:73-98` - `agent-kill`.
+- `cli/commands/chaos_cmd.py:101-136` - `file-remove` with backup.
+- `cli/commands/chaos_cmd.py:139-175` - `status` (chaos log table).
+- `cli/commands/chaos_cmd.py:178-232` - `slo` (SLO dashboard).
+- `cli/commands/chaos_cmd.py:235-253` - `_record_chaos_event` (JSONL
   append).
 - `.sdd/runtime/chaos/chaos_log.jsonl` - replayable event log.
 - `.sdd/metrics/slos.json` - SLO dashboard source consumed by

--- a/docs/operations/deployment-guide.md
+++ b/docs/operations/deployment-guide.md
@@ -858,8 +858,9 @@ Bernstein can execute agents on Cloudflare's edge infrastructure instead of loca
 npm install -g wrangler
 wrangler login
 
-# 2. Deploy the agent Worker
-bernstein cloud deploy --worker-name bernstein-agent
+# 2. Scaffold the agent Worker, set account_id in wrangler.toml, then deploy it
+bernstein cloud init --worker-name bernstein-agent
+npx wrangler deploy
 
 # 3. Authenticate with Bernstein Cloud
 bernstein cloud login
@@ -869,8 +870,10 @@ bernstein cloud run "Add OAuth2 authentication" --max-agents 5 --budget 25.00
 ```
 
 `cloud login`, `cloud run`, `cloud status`, and `cloud cost` target the
-experimental, currently-unavailable `api.bernstein.run`; `cloud deploy` and
-`cloud init` run locally against your own Cloudflare account.
+experimental, currently-unavailable `api.bernstein.run`; `cloud init` runs
+locally against your own Cloudflare account, and step 2's `wrangler deploy`
+talks to Cloudflare directly. Steps 3 and 4 do not work until the hosted
+service exists.
 
 ### What runs where
 

--- a/docs/reference/FEATURE_MATRIX.md
+++ b/docs/reference/FEATURE_MATRIX.md
@@ -177,7 +177,7 @@ additionally holds the CLI's server calls to the registered route table.
 | Cache policy engine | Full | Content-addressed key recipes, drift expiry, and fleet dedup with signed duplicate-of receipts (`core/persistence/cache_policy.py`) |
 | Sovereign deployment profile | Full | Signed residency-posture attestation; posture drift at spawn is a signed refusal (`core/security/deployment_profile.py`) |
 | [Workflow DSL](../operations/workflow-manifests.md) | Full | `bernstein workflow validate/list/show` |
-| [Chaos engineering](../operations/chaos-engineering.md) | Full | `bernstein chaos agent-kill/rate-limit/file-remove/status/slo` |
+| [Chaos engineering](../operations/chaos-engineering.md) | Full | `bernstein chaos agent-kill/file-remove/status/slo` |
 | Benchmark suite | Full | `bernstein benchmark run/compare/swe-bench` |
 | [Eval harness](../eval/golden-harness.md) | Full | `bernstein eval run/report/failures` |
 | SWE-Bench harness | Full | Verified eval in `benchmarks/swe_bench/run.py` |

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -374,7 +374,7 @@ set. (`cli/commands/advanced_cmd.py`, `core/observability/otel_projection.py`.)
 | `bernstein verify` | Verify WAL integrity, execution determinism, memory provenance, formal properties, or a wheelhouse. | `cli/commands/verify_cmd.py` |
 | `bernstein autofix` | Auto-repair CI failures (group). | `cli/commands/autofix_cmd.py:172` |
 | `bernstein ci` | CI integration commands (group). | `cli/commands/ci_cmd.py:49` |
-| `bernstein chaos` | Chaos engineering (group). | `cli/commands/chaos_cmd.py:32` |
+| `bernstein chaos` | Chaos engineering (group). | `cli/commands/chaos_cmd.py:33` |
 | `bernstein eval` | Evaluation pipelines (group). | `cli/commands/eval_benchmark_cmd.py:426` |
 | `bernstein benchmark` | Benchmark pipelines (group). | `cli/commands/eval_benchmark_cmd.py:29` |
 | `bernstein api-check` | Detect breaking-API changes. | `cli/api_check_cmd.py:22` |
@@ -420,13 +420,11 @@ Common flags: `--token` (env: `GITHUB_TOKEN`), `--server`, `--interval`. (`cli/c
 | Subcommand | Purpose |
 |---|---|
 | `agent-kill` | Kill a random or specific agent. |
-| `rate-limit` | Simulate provider rate-limit. |
 | `file-remove` | Delete files matching a glob. |
-| `pause-agent` | Pause an agent for N seconds. |
 | `status` | Show recent chaos events. |
 | `slo` | SLO impact of recent chaos events. |
 
-Most subcommands accept `--agent-id`, `--duration`, `--pattern` as relevant. (`cli/commands/chaos_cmd.py:32+`.)
+`agent-kill` accepts `--agent-id`, `file-remove` accepts `--pattern`, and `status` accepts `--limit`. (`cli/commands/chaos_cmd.py:33+`.)
 
 #### `bernstein eval` / `bernstein benchmark`
 
@@ -1245,7 +1243,7 @@ See [`reference/mcp-catalog.md`](mcp-catalog.md) for the full reference.
 | `bernstein ab-test` | A/B model comparison. | `cli/commands/ab_test_cmd.py:14` |
 | `bernstein acp serve` | Run an ACP server. | `cli/commands/acp_cmd.py:33` |
 | `bernstein scaffold "<prompt>"` | Bootstrap a project from a prompt. | `cli/commands/scaffold_cmd.py` |
-| `bernstein test` | Run automated resilience tests with optional chaos injection. | `cli/test_cmd.py:13` |
+| `bernstein test` | Run automated resilience tests. | `cli/commands/test_cmd.py:13` |
 | `bernstein wiki build` | Render `WIKI.md` from the AST symbol graph. | `cli/commands/wiki_cmd.py` |
 | `bernstein workflow` | Workflow mgmt (group). | `cli/workflow_cmd.py:15` |
 | `bernstein replay RUN_ID --verify` / `--from-step N` | Recompute the run journal's Merkle head and report the first divergent step (writes `divergence_report.json`), or rebuild deterministic state to step N. | `cli/commands/advanced_cmd.py` |
@@ -1325,12 +1323,11 @@ Experimental voice control (see [`operations/voice-control.md`](../operations/vo
 
 #### `bernstein test`
 
-Runs automated resilience tests with optional chaos injection. This is not a project test-suite runner; use `bernstein.yaml: quality_gates.tests` (and your configured test runner) for that.
+Runs automated resilience tests. This is not a project test-suite runner; use `bernstein.yaml: quality_gates.tests` (and your configured test runner) for that.
 
 | Flag | Default | Meaning |
 |---|---|---|
-| `--chaos` | off | Enable random chaos injection during the test. |
-| `--duration N` | none | Test duration in seconds. |
+| `--duration N` | 300 | Test duration in seconds. |
 | `--workdir PATH` | `.` | Project root. |
 
 #### `bernstein wiki build`

--- a/src/bernstein/cli/commands/chaos_cmd.py
+++ b/src/bernstein/cli/commands/chaos_cmd.py
@@ -1,16 +1,14 @@
 """Chaos engineering CLI for agent systems.
 
-Periodically inject failures to test resilience:
+Inject failures to test resilience:
 - Kill a random agent mid-task
-- Simulate rate limit
 - Remove a file being edited
-- Inject random errors
 
 Usage:
   bernstein chaos agent-kill     Kill a random active agent
-  bernstein chaos rate-limit     Simulate API rate limiting
   bernstein chaos file-remove    Remove a file an agent is editing
   bernstein chaos status         Show chaos experiment history
+  bernstein chaos slo            Show the SLO dashboard
 """
 
 from __future__ import annotations

--- a/tests/unit/test_chaos_doc_code_pointers.py
+++ b/tests/unit/test_chaos_doc_code_pointers.py
@@ -1,0 +1,88 @@
+"""Verify the chaos-engineering doc's ``chaos_cmd.py:N`` pointers resolve.
+
+``docs/operations/chaos-engineering.md`` cites line numbers in
+``cli/commands/chaos_cmd.py`` for every subcommand. Those numbers shift on any
+edit to the module - including edits far above the cited region - so they rot
+without anyone noticing.
+
+This test resolves each cited range against the module's AST. A range is
+accepted when it covers exactly one top-level definition, which is what every
+pointer in the doc claims. Bare line pointers must land on a definition or
+assignment rather than on whitespace.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOC = REPO_ROOT / "docs" / "operations" / "chaos-engineering.md"
+MODULE = REPO_ROOT / "src" / "bernstein" / "cli" / "commands" / "chaos_cmd.py"
+
+# Matches `chaos_cmd.py:31` and `chaos_cmd.py:73-98`, with or without the
+# `cli/commands/` prefix the doc uses in its code-pointer list.
+_POINTER_RE = re.compile(r"chaos_cmd\.py:(\d+)(?:-(\d+))?")
+
+
+def _module_lines() -> int:
+    return len(MODULE.read_text(encoding="utf-8").splitlines())
+
+
+def _top_level_spans() -> list[tuple[int, int]]:
+    """Return ``(start, end)`` line spans of every top-level definition.
+
+    ``start`` includes decorators, matching how the doc cites a command.
+    """
+    tree = ast.parse(MODULE.read_text(encoding="utf-8"))
+    spans: list[tuple[int, int]] = []
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+            start = min([dec.lineno for dec in node.decorator_list] + [node.lineno])
+            assert node.end_lineno is not None
+            spans.append((start, node.end_lineno))
+    return spans
+
+
+def _pointers() -> list[tuple[int, int | None]]:
+    text = DOC.read_text(encoding="utf-8")
+    found = [(int(start), int(end) if end else None) for start, end in _POINTER_RE.findall(text)]
+    assert found, f"no chaos_cmd.py pointers found in {DOC}"
+    return found
+
+
+@pytest.mark.parametrize(("start", "end"), _pointers())
+def test_pointer_is_within_the_module(start: int, end: int | None) -> None:
+    """Every cited line exists in the module."""
+    total = _module_lines()
+    assert 1 <= start <= total, f"chaos_cmd.py:{start} is past the end of the module ({total} lines)"
+    if end is not None:
+        assert start < end <= total, f"chaos_cmd.py:{start}-{end} is not a valid range in a {total}-line module"
+
+
+@pytest.mark.parametrize(("start", "end"), [(s, e) for s, e in _pointers() if e is not None])
+def test_range_pointer_does_not_straddle_a_definition(start: int, end: int) -> None:
+    """A cited range must stay inside definition boundaries.
+
+    The doc cites ranges two ways: whole definitions (a command implementation
+    or a helper pair) and a block nested inside one (the ``file-remove`` backup
+    logic). Both are fine. A range that starts inside one definition and ends
+    inside another means the numbers drifted after an edit to the module.
+    """
+    spans = _top_level_spans()
+    enclosing = [span for span in spans if span[0] <= start and end <= span[1]]
+    if enclosing:
+        # Nested block: fully inside a single definition.
+        assert len(enclosing) == 1, f"chaos_cmd.py:{start}-{end} resolves ambiguously to {enclosing}"
+        return
+
+    covered = [span for span in spans if start <= span[0] and span[1] <= end]
+    overlapping = [span for span in spans if span[0] <= end and start <= span[1]]
+    assert covered, f"chaos_cmd.py:{start}-{end} covers no top-level definition"
+    assert covered == overlapping, (
+        f"chaos_cmd.py:{start}-{end} straddles a definition boundary; "
+        f"it partially overlaps {sorted(set(overlapping) - set(covered))}"
+    )

--- a/tests/unit/test_docs_drift_workflow_yaml.py
+++ b/tests/unit/test_docs_drift_workflow_yaml.py
@@ -1,0 +1,96 @@
+"""Structural assertions for the docs-drift removed-verb gate.
+
+The workflow greps the docs tree for command surfaces that no longer exist in
+the CLI. The gate only works while every removed verb is still listed and the
+step stays unconditional - an ``if:`` on the step would silently reduce it to
+the advisory behaviour of the drift report it sits next to.
+
+These tests pin both properties, plus the fact that the guarded verbs really
+are absent from the CLI, so the list cannot rot into checking for commands
+that were reinstated.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TypedDict, cast
+
+import pytest
+import yaml
+
+
+class WorkflowStep(TypedDict, total=False):
+    name: object
+    run: object
+    if_: object
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "docs-drift.yml"
+
+STEP_NAME = "Fail on docs referencing removed CLI verbs"
+
+#: Verb -> the ``bernstein`` group it was removed from. Every entry must be
+#: absent from that group's command list and present in the workflow grep.
+REMOVED_VERBS: dict[str, str] = {
+    "rate-limit": "chaos",
+    "agent-oom": "chaos",
+    "disk-full": "chaos",
+    "deploy": "cloud",
+}
+
+
+def _steps() -> list[dict[str, object]]:
+    data = cast("dict[str, object]", yaml.safe_load(WORKFLOW.read_text(encoding="utf-8")))
+    jobs = data.get("jobs")
+    assert isinstance(jobs, dict), "docs-drift.yml has no jobs mapping"
+    job = jobs.get("drift-check")
+    assert isinstance(job, dict), "expected a drift-check job"
+    steps = job.get("steps")
+    assert isinstance(steps, list), "drift-check job has no steps"
+    return [step for step in steps if isinstance(step, dict)]
+
+
+def _removed_verb_step() -> dict[str, object]:
+    for step in _steps():
+        if step.get("name") == STEP_NAME:
+            return step
+    pytest.fail(f"docs-drift.yml has no {STEP_NAME!r} step")
+
+
+def test_removed_verb_step_exists_and_is_unconditional() -> None:
+    """The gate must run on every event, including pull requests."""
+    step = _removed_verb_step()
+    assert "if" not in step, f"{STEP_NAME!r} must not be conditional - it gates pull requests too"
+    assert isinstance(step.get("run"), str)
+
+
+@pytest.mark.parametrize(("verb", "group"), sorted(REMOVED_VERBS.items()))
+def test_workflow_greps_for_each_removed_verb(verb: str, group: str) -> None:
+    """Every removed verb is named in the workflow's grep patterns."""
+    script = cast("str", _removed_verb_step()["run"])
+    assert f"bernstein {group} [a-z/-]*{verb}" in script, f"no grep pattern guards `bernstein {group} {verb}`"
+
+
+@pytest.mark.parametrize(("verb", "group"), sorted(REMOVED_VERBS.items()))
+def test_guarded_verbs_are_absent_from_the_cli(verb: str, group: str) -> None:
+    """A guarded verb must not exist on the CLI group it was removed from."""
+    from bernstein.cli.main import cli
+
+    group_cmd = cli.commands.get(group)
+    assert group_cmd is not None, f"expected a `bernstein {group}` group"
+    subcommands = getattr(group_cmd, "commands", {})
+    assert verb not in subcommands, f"`bernstein {group} {verb}` exists again; drop it from the removed-verb gate"
+
+
+def test_removed_test_chaos_flag_is_guarded_and_gone() -> None:
+    """The `bernstein test --chaos` flag is both guarded and absent."""
+    from bernstein.cli.main import cli
+
+    script = cast("str", _removed_verb_step()["run"])
+    assert "--chaos" in script, "no grep pattern guards the removed `--chaos` flag"
+
+    test_cmd = cli.commands.get("test")
+    assert test_cmd is not None, "expected a `bernstein test` command"
+    flags = {opt for param in test_cmd.params for opt in getattr(param, "opts", [])}
+    assert "--chaos" not in flags, "`bernstein test --chaos` exists again; drop it from the removed-verb gate"

--- a/tests/unit/test_readme_adapter_counts.py
+++ b/tests/unit/test_readme_adapter_counts.py
@@ -1,0 +1,78 @@
+"""Guard the adapter counts the README states against the code they describe.
+
+The README's "supported agents" paragraph makes two countable claims:
+
+1. ``docs/adapters/index.md`` carries install commands for N adapters.
+2. ``bernstein integrations list`` enumerates M wired-in adapters.
+
+Both numbers drift silently when an adapter is added or the install matrix
+gains a row. These tests recompute each number from its source - the markdown
+table for N, ``integrations_cmd._enumerate_rows()`` for M - so a stale README
+count fails here instead of shipping as a claim the code cannot back.
+
+When the count legitimately changes, update the README sentence and these
+tests will pass again.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from bernstein.cli.commands.integrations_cmd import _enumerate_rows
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+README = REPO_ROOT / "README.md"
+ADAPTER_INDEX = REPO_ROOT / "docs" / "adapters" / "index.md"
+
+# "carries install commands for 29 of them"
+_MATRIX_CLAIM_RE = re.compile(r"carries install commands for (\d+) of them")
+# "enumerates all 48 wired-in adapters"
+_TOTAL_CLAIM_RE = re.compile(r"enumerates all (\d+) wired-in adapters")
+
+
+def _claimed(pattern: re.Pattern[str]) -> int:
+    """Return the single integer *pattern* captures in the README."""
+    matches = pattern.findall(README.read_text(encoding="utf-8"))
+    assert len(matches) == 1, f"expected exactly one README match for {pattern.pattern!r}, got {matches}"
+    return int(matches[0])
+
+
+def _install_matrix_rows() -> list[str]:
+    """Return the data rows of the ``## Install matrix`` table.
+
+    The table is the last one on the page; rows are collected from the
+    ``## Install matrix`` heading onward, skipping the header row and the
+    ``|---|---|`` separator.
+    """
+    lines = ADAPTER_INDEX.read_text(encoding="utf-8").splitlines()
+    try:
+        start = next(i for i, line in enumerate(lines) if line.strip() == "## Install matrix")
+    except StopIteration:  # pragma: no cover - defensive
+        pytest.fail(f"'## Install matrix' heading not found in {ADAPTER_INDEX}")
+
+    rows = [line for line in lines[start:] if line.startswith("|")]
+    assert rows, f"no table rows found under '## Install matrix' in {ADAPTER_INDEX}"
+    # Drop the header row and the separator row.
+    return [row for row in rows[2:] if set(row) - set("|- ")]
+
+
+def test_readme_install_matrix_count_matches_the_table() -> None:
+    """The README's install-command count equals the matrix row count."""
+    assert _claimed(_MATRIX_CLAIM_RE) == len(_install_matrix_rows())
+
+
+def test_readme_total_adapter_count_matches_the_registry() -> None:
+    """The README's wired-in adapter count equals what the CLI enumerates."""
+    assert _claimed(_TOTAL_CLAIM_RE) == len(_enumerate_rows())
+
+
+def test_install_matrix_is_a_subset_claim_not_a_full_one() -> None:
+    """The matrix must stay smaller than or equal to the enumerated set.
+
+    A matrix larger than the registry means the table lists agents that no
+    adapter drives - the inverse of the drift this module guards against.
+    """
+    assert len(_install_matrix_rows()) <= len(_enumerate_rows())


### PR DESCRIPTION
# User description
## What

Docs still documented command surfaces that were deleted in #3293, plus two claims the code could not back.

**Removed surfaces swept**

| Surface | Was documented in |
|---|---|
| `chaos rate-limit` | `chaos-engineering.md`, `cli-reference.md`, `FEATURE_MATRIX.md`, `chaos_cmd.py` docstring |
| `chaos agent-oom` / `chaos disk-full` | `chaos_cmd.py` docstring (scenario list) |
| `cloud deploy` | `cloudflare-cli.md`, `cloudflare-setup.md`, `deployment-guide.md` |
| `test --chaos` | `cli-reference.md` |

The `deployment-guide.md` Cloudflare quickstart step 2 is rewritten to the path that works today (`bernstein cloud init`, then `npx wrangler deploy`) rather than deleted, so the quickstart still runs end to end. Each verb's current surface was read off `bernstein chaos --help` / `bernstein cloud --help` and the `cli/commands` registry, not assumed.

Also dropped while in these files: a `pause-agent` row in `cli-reference.md` that matches no registered command, and a `--duration` default listed as `none` when it is `300`.

**Gate**

`docs-drift.yml` gains a step that greps the docs tree for the deleted verbs. Unlike the drift report next to it, this one fails on pull requests — a doc naming a deleted command is a factual error, not staleness. `docs/release-notes/` and `docs/blog/` are excluded; they record what existed at the time.

**Accuracy**

- Cloud execution is qualified as experimental with `api.bernstein.run` noted as unavailable, in the README row and at the top of `cloudflare-overview.md`. It was previously admitted only at `deployment-guide.md:870`.
- The README claimed the adapter index "carries the full table with install commands". The install matrix holds 29 rows against 48 wired-in adapters. Generating the matrix from `use_cases.py` is not possible: `AdapterUseCase` carries `headline` / `binary` / `details` / `docs_path` and no install command, so the column has no source to generate from. The claim is corrected to state both counts instead of inventing install commands for the missing 19.
- `chaos-engineering.md` code pointers were stale by dozens of lines; all 14 recomputed from the AST.

## Tests

| File | Covers |
|---|---|
| `test_docs_drift_workflow_yaml.py` | the gate step exists, is unconditional, names every removed verb, and those verbs are genuinely absent from the CLI |
| `test_readme_adapter_counts.py` | both README counts, recomputed from the markdown table and `_enumerate_rows()` |
| `test_chaos_doc_code_pointers.py` | every `chaos_cmd.py:N` pointer resolves against the module AST |

The pointer guard was verified to fail on a two-line drift, and the workflow grep was verified to catch all five reintroduced surfaces.

Run foreground, narrow selectors:

```
uv run pytest tests/unit/test_chaos_doc_code_pointers.py \
  tests/unit/test_docs_drift_workflow_yaml.py \
  tests/unit/test_readme_adapter_counts.py \
  tests/unit/test_readme_api_coverage.py \
  tests/unit/test_packaged_readme_renders_off_repo.py \
  tests/unit/test_chaos.py tests/unit/test_cloud_cmd.py
# 92 passed
```

`scripts/check_docs_drift.py` reports no drift. `ruff check` and `ruff format --check` pass on the changed Python.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the Cloudflare onboarding docs to use <code>bernstein cloud init</code> followed by <code>npx wrangler deploy</code>, and mark hosted cloud execution as experimental and unavailable. Remove stale <code>chaos</code> and <code>test</code> command references from the CLI docs, then add drift checks and tests to keep deleted verbs and README counts aligned with <code>bernstein.cli.commands</code>.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3342?tool=ast&topic=Cloudflare+docs>Cloudflare docs</a>
        </td><td>Update the Cloudflare docs to route deployment through <code>bernstein cloud init</code> and direct Wrangler deploys, while clarifying that the hosted <code>api.bernstein.run</code> service is experimental and unavailable.<details><summary>Modified files (5)</summary><ul><li>README.md</li>
<li>docs/cloudflare/cloudflare-cli.md</li>
<li>docs/cloudflare/cloudflare-overview.md</li>
<li>docs/cloudflare/cloudflare-setup.md</li>
<li>docs/operations/deployment-guide.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>docs: drop deleted cha...</td><td>August 01, 2026</td></tr>
<tr><td>chernistry</td><td>docs: verify capabilit...</td><td>July 31, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3342?tool=ast&topic=CLI+docs+drift>CLI docs drift</a>
        </td><td>Remove stale <code>chaos</code> and <code>test</code> surface references from the CLI docs, refresh code pointers and option tables, and add a workflow gate plus tests that catch deleted verbs and inaccurate adapter counts.<details><summary>Modified files (8)</summary><ul><li>.github/workflows/docs-drift.yml</li>
<li>docs/operations/chaos-engineering.md</li>
<li>docs/reference/FEATURE_MATRIX.md</li>
<li>docs/reference/cli-reference.md</li>
<li>src/bernstein/cli/commands/chaos_cmd.py</li>
<li>tests/unit/test_chaos_doc_code_pointers.py</li>
<li>tests/unit/test_docs_drift_workflow_yaml.py</li>
<li>tests/unit/test_readme_adapter_counts.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>docs: drop deleted cha...</td><td>August 01, 2026</td></tr>
<tr><td>gettofarmila@gmail.com</td><td>fix(cli): remove four ...</td><td>July 31, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3342?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>