### PR TITLE
docs: describe the tag-based auto-release flow instead of release-please

### DIFF
--- a/docs/operations/security.md
+++ b/docs/operations/security.md
@@ -44,7 +44,7 @@ existing artefacts in this repository.
 | Documented contribution process | `CONTRIBUTING.md`. |
 | OSI-approved license, license file present | `LICENSE` (Apache-2.0). |
 | Documented build instructions | `README.md` "install" section; `docs/getting-started/install.md`. |
-| Cryptographically signed releases | `release-please` + signed PyPI uploads; `SECURITY.md`. |
+| Cryptographically signed releases | Tag-based `.github/workflows/auto-release.yml` hands off to `publish.yml` (Sigstore build-provenance attestation) + signed PyPI uploads; `SECURITY.md`. |
 | Vulnerability reporting process | `SECURITY.md`. |
 | Documented secure development knowledge for at least one committer | `docs/operations/security-and-identity.md`; CONTRIBUTING checklist. |
 | Public bug tracker | GitHub Issues. |

--- a/docs/playbooks/docs-drift.md
+++ b/docs/playbooks/docs-drift.md
@@ -45,7 +45,7 @@ Drift remediation paths used by the rows below:
 | `CODE_OF_CONDUCT.md` | None (Contributor Covenant 2.1 verbatim) | Repo URL change, contact email change | `static` |
 | `CONTRIBUTING.md` | `src/bernstein/adapters/registry.py`, `src/bernstein/adapters/base.py`, `templates/roles/`, `scripts/run_tests.py`, `.importlinter` | New adapter contract method, new role added under `templates/roles/`, change to lint / type-check pipeline | `manual-prose` |
 | `SECURITY.md` | `pyproject.toml` version, security policy contacts | Disclosure policy changes, scope changes, new in-scope target | `manual-prose` |
-| `CHANGELOG.md` | Pointer document; release history lives in `docs/release-notes/` | The release-notes location moves | `manual-prose` |
+| `CHANGELOG.md` | Pointer document; release history lives in `docs/release-notes/` and release tags are cut by `.github/workflows/auto-release.yml` | The release-notes location moves, or the tag-cutting workflow changes | `manual-prose` |
 | `CONTRIBUTORS.md` | None (hand-curated list of named contributors) | New contributor merged a PR | `static` |
 
 ### `docs/` top-level

--- a/docs/playbooks/docs-update-sweep.md
+++ b/docs/playbooks/docs-update-sweep.md
@@ -10,7 +10,9 @@ across multiple agents without merge conflicts.
 
 Run a full sweep on any of the following triggers:
 
-- After a release tag has been cut (release-please merge to `main`).
+- After a release tag has been cut (`.github/workflows/auto-release.yml`
+  pushes the `v*` tag once a version-bump PR merges to `main` and CI
+  passes).
 - After a feature wave lands a set of related PRs that touched multiple
   source-of-truth modules (typically 5+ PRs that each named a module from
   `docs-drift.md`).
@@ -41,8 +43,7 @@ Recommended split for a full sweep: assign one agent per partition. The
 is already running because the row count is small.
 
 Each agent works on its own branch, opens its own PR, and never touches
-files outside its partition. The merge train (release-please or the
-operator) handles ordering of PRs.
+files outside its partition. The operator handles ordering of PRs.
 
 ## Per-partition recipe
 
@@ -129,7 +130,7 @@ touch the same file. Conflict avoidance rules:
   picks it up.
 - Each agent opens a separate PR. Do not stack PRs unless the operator
   explicitly requests it.
-- The merge train (release-please plus the operator) orders the PRs. The
+- The operator orders the PRs. The
   drift gate runs on every PR and on `main`, so the order of merges does
   not matter as long as each PR is internally consistent.
 - If two partitions both name the same source-of-truth file (this should
@@ -169,6 +170,9 @@ The following items are explicitly out of scope for a docs-update sweep:
   `docs/release-notes/unreleased.md` for what has landed since the newest
   tag; a feature-wave PR may append to that page but a docs sweep does not
   touch it.
+- Release tags themselves are cut by the tag-based
+  `.github/workflows/auto-release.yml` flow (a version-bump PR merged on
+  main triggers the tag); a docs sweep never touches that workflow.
 - Any doc that names a third-party ecosystem tool in its filename and
   exists only as an integration memo is treated as static for sweep
   purposes; refresh only on explicit operator request.


### PR DESCRIPTION
# User description
Three docs still describe `CHANGELOG.md` / releases as managed by release-please via `release-please-config.json` / `release-please-manifest.json`. Nothing in `.github/workflows/` or `scripts/` reads those files — the live release path is the tag-based `.github/workflows/auto-release.yml` flow (version-bump PR merges to `main` → CI passes → `v*` tag → `publish.yml`). #3340 removes the two config files; this PR updates the remaining doc references to match.

- `docs/playbooks/docs-update-sweep.md`: sweep trigger, merge-train notes, and the `CHANGELOG.md` skip rule now describe the auto-release flow; `CHANGELOG.md` is documented as hand-curated.
- `docs/playbooks/docs-drift.md`: `CHANGELOG.md` table row now points at `auto-release.yml` instead of the removed release-please configs.
- `docs/operations/security.md`: the "Cryptographically signed releases" row now names `auto-release.yml` → `publish.yml` (Sigstore build-provenance attestation) + signed PyPI uploads.

Docs-only. `python3 scripts/check_docs_drift.py --strict` passes locally.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the documentation to describe the tag-based release flow, where <code>.github/workflows/auto-release.yml</code> cuts <code>v*</code> tags after version-bump PRs merge and <code>publish.yml</code> handles publishing. Replace the old <code>release-please</code> references in the docs sweep, drift, and security guidance so they match the live release path.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3344?tool=ast&topic=Release+workflow>Release workflow</a>
        </td><td>Update the docs sweep and drift guidance to treat <code>CHANGELOG.md</code> as hand-curated and to point release tracking at the tag-based <code>auto-release.yml</code> flow.<details><summary>Modified files (2)</summary><ul><li>docs/playbooks/docs-drift.md</li>
<li>docs/playbooks/docs-update-sweep.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>chernistry</td><td>docs: point the change...</td><td>August 01, 2026</td></tr>
<tr><td>viktorshpuktor@gmail.com</td><td>docs: describe the tag...</td><td>August 01, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3344?tool=ast&topic=Signed+releases>Signed releases</a>
        </td><td>Revise the release-security matrix to describe <code>auto-release.yml</code> handing off to <code>publish.yml</code> for Sigstore attestation and signed PyPI uploads.<details><summary>Modified files (1)</summary><ul><li>docs/operations/security.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>viktorshpuktor@gmail.com</td><td>docs: describe the tag...</td><td>August 01, 2026</td></tr>
<tr><td>chernistry</td><td>docs: fix runnable exa...</td><td>July 16, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3344?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>