### PR TITLE
fix(release): give the Copr build watch its own deadline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -408,9 +408,9 @@ jobs:
     # `always()` so a channel-only republish still runs with the upstream
     # release graph skipped; the PyPI result still gates the normal tag path.
     if: ${{ always() && (inputs.copr_only || needs.publish.result == 'success') }}
-    # Wider than the other publish jobs: the submit step waits for the Copr
-    # build itself, which queues behind other builders.
-    timeout-minutes: 45
+    # Comfortably above COPR_WATCH_SECONDS below, so the watch always ends on
+    # its own deadline rather than being cancelled part-way through.
+    timeout-minutes: 30
     permissions:
       contents: read
     env:
@@ -469,13 +469,30 @@ jobs:
       - name: Submit build to Copr
         env:
           SRPM_PATH: ${{ steps.srpm.outputs.path }}
+          # The watch's own budget. copr-cli's built-in watch has none: it runs
+          # until the build ends, however long Copr's public queue takes, and a
+          # first end-to-end run spent 45 minutes there before the job's
+          # timeout cancelled the step mid-wait.
+          COPR_WATCH_SECONDS: "900"
         run: |
           set -euo pipefail
           echo "submitting ${SRPM_PATH} to ${COPR_PROJECT}"
-          # Deliberately not --nowait: copr-cli then waits for the build and
-          # exits non-zero when it fails, so the job's verdict tracks the
-          # published RPM rather than just the upload.
-          copr-cli build "${COPR_PROJECT}" "${SRPM_PATH}"
+          # copr-cli exits non-zero when Copr rejects the submission, so a bad
+          # SRPM or an expired token fails right here.
+          copr-cli build --nowait "${COPR_PROJECT}" "${SRPM_PATH}" | tee "${RUNNER_TEMP}/copr-submit.log"
+
+          BUILD_ID=$(sed -n 's/^Created builds: \([0-9][0-9]*\).*$/\1/p' "${RUNNER_TEMP}/copr-submit.log" | head -1)
+          if [ -z "${BUILD_ID}" ]; then
+            echo "::error::Copr accepted no build id; the submission output above is the evidence"
+            exit 1
+          fi
+
+          # Terminal-state handling lives in the watcher, which is unit-tested;
+          # a failed build fails this step, and a build still queued at the
+          # deadline is handed to reconcile-release.yml.
+          python3 scripts/copr_build_watch.py \
+            --build-id "${BUILD_ID}" \
+            --deadline-seconds "${COPR_WATCH_SECONDS}"
 
   # MCP registry listing (#2369). Regenerated from pyproject.toml by
   # scripts/gen_distribution_manifests.py so the listing can never drift

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -62,6 +62,7 @@ entries to them.
 | Publishing job | `publish-copr` in `.github/workflows/publish.yml` |
 | Spec | `packaging/rpm/bernstein.spec` |
 | Builder | `scripts/build_copr_srpm.py` |
+| Build watcher | `scripts/copr_build_watch.py` |
 
 `COPR_CONFIG` holds a complete `copr-cli` configuration file — the same
 content `~/.config/copr` has on a workstation, including the `[copr-cli]`
@@ -97,11 +98,33 @@ gh workflow run publish.yml --ref main -f tag=v3.13.0 -f copr_only=true
 `publish-copr` alone. Submitting a version Copr already holds is rejected by
 the build service, so bump the release or delete the existing build first.
 
-The job waits for the Copr build instead of returning at upload, and it has no
-warn-and-continue path: a rejected submission or a failed chroot build fails
-the job. Nothing about the RPM channel is visible from this repository, so a
-swallowed failure would go unnoticed until someone installed the package by
-hand.
+### What fails the job, and what does not
+
+| Outcome | Job result |
+|---|---|
+| Copr rejects the submission (bad SRPM, expired token) | fails |
+| Copr accepts it but returns no build id | fails |
+| The build ends `failed`, `canceled` or `skipped` within the watch window | fails |
+| The build ends `succeeded` | passes |
+| The build is still queued or running when the watch window expires | passes, with a `::notice::` naming the build URL |
+
+The job has no warn-and-continue path for a *known-bad* outcome: nothing about
+the RPM channel is visible from this repository, so a swallowed failure would
+go unnoticed until someone installed the package by hand.
+
+The last row is the one deliberate exception, and it is not a swallowed
+failure — the submission already succeeded and the outcome is unknown rather
+than bad. Copr's public builders are shared and its queue can run past any
+sensible job budget; failing there would paint releases red for a build queue.
+`reconcile-release.yml` compares the published Copr version daily and opens a
+`release-drift` issue if the version never lands, which is exactly the case
+this hands off to.
+
+`copr-cli`'s own watch has no deadline — it runs until the build ends, however
+long that takes — so the submission uses `--nowait` and
+`scripts/copr_build_watch.py` owns the waiting against `COPR_WATCH_SECONDS`.
+That budget must stay below the job's `timeout-minutes`, or a slow queue
+cancels the step mid-wait instead of ending it; a guard test enforces the gap.
 
 ## Guardrails
 

--- a/scripts/copr_build_watch.py
+++ b/scripts/copr_build_watch.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Watch a Copr build to a verdict, on a deadline this job controls.
+
+``copr-cli build`` can watch its own build, but its watch runs until the build
+ends - however long Copr's public queue takes. When that outlives the job's
+``timeout-minutes`` the step is cancelled, and a build that was merely slow
+becomes indistinguishable from one that failed.
+
+So the submission uses ``--nowait`` and this watcher owns the waiting:
+
+* a build that reaches a terminal failure inside the window fails the job,
+* a build that succeeds inside the window passes it, and
+* a build still queued at the deadline is handed to
+  ``.github/workflows/reconcile-release.yml``, which compares the published
+  Copr version daily and opens a ``release-drift`` issue if it never lands.
+
+The last case is not a swallowed failure: the submission already succeeded and
+the outcome is unknown rather than bad. Failing there would paint releases red
+for a public build queue.
+
+Usage::
+
+    python3 scripts/copr_build_watch.py --build-id 10802217 --deadline-seconds 900
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+import urllib.error
+import urllib.request
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+API_URL = "https://copr.fedorainfracloud.org/api_3/build/{build_id}"
+BUILD_URL = "https://copr.fedorainfracloud.org/coprs/build/{build_id}"
+USER_AGENT = "bernstein-copr-build-watch"
+
+SUCCESS_STATES = frozenset({"succeeded"})
+# `skipped` means Copr already had this exact build and did not rebuild it. It
+# is terminal and produces no new RPM, so it must not read as a publish.
+FAILURE_STATES = frozenset({"failed", "canceled", "cancelled", "skipped"})
+
+READ_ERRORS = (urllib.error.URLError, TimeoutError, ValueError, KeyError, OSError, TypeError)
+
+
+def classify(state: str) -> str:
+    """Return ``success``, ``failure`` or ``pending`` for a Copr build state.
+
+    Unrecognised states count as ``pending``: Copr can add states, and reading
+    an unknown one as terminal would invent a verdict nobody checked.
+    """
+    normalised = state.strip().lower()
+    if normalised in SUCCESS_STATES:
+        return "success"
+    if normalised in FAILURE_STATES:
+        return "failure"
+    return "pending"
+
+
+def fetch_state(build_id: int) -> str:
+    """Return the current Copr state for ``build_id``."""
+    # Fixed https API host, no user-controlled scheme.
+    request = urllib.request.Request(
+        API_URL.format(build_id=build_id),
+        headers={"User-Agent": USER_AGENT},
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        payload = json.load(response)
+    return str(payload["state"])
+
+
+def watch(
+    build_id: int,
+    *,
+    fetch: Callable[[int], str] = fetch_state,
+    deadline_seconds: float = 900,
+    poll_seconds: float = 30,
+    time_fn: Callable[[], float] = time.monotonic,
+    sleep_fn: Callable[[float], None] = time.sleep,
+) -> int:
+    """Watch ``build_id`` until it settles or the deadline passes.
+
+    Returns the process exit code: 0 when the build succeeded or is still
+    running at the deadline, 1 when it ended in a terminal failure.
+    """
+    build_url = BUILD_URL.format(build_id=build_id)
+    deadline = time_fn() + deadline_seconds
+    state = "unknown"
+
+    while True:
+        try:
+            state = fetch(build_id)
+        except READ_ERRORS as exc:
+            # One unreadable poll says nothing about the build.
+            print(f"build {build_id}: could not read state ({exc})")
+        else:
+            print(f"build {build_id}: {state}")
+            verdict = classify(state)
+            if verdict == "success":
+                print(f"Copr published build {build_id}: {build_url}")
+                return 0
+            if verdict == "failure":
+                print(f"::error::Copr build {build_id} ended in state '{state}': {build_url}")
+                return 1
+
+        remaining = deadline - time_fn()
+        if remaining <= 0:
+            print(
+                f"::notice::Copr build {build_id} is still '{state}' after "
+                f"{deadline_seconds:.0f}s: {build_url}. The submission succeeded; "
+                "reconcile-release.yml compares the published Copr version daily "
+                "and opens a release-drift issue if this version never lands."
+            )
+            return 0
+        sleep_fn(min(poll_seconds, remaining))
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--build-id", required=True, type=int, help="Copr build id to watch")
+    parser.add_argument(
+        "--deadline-seconds",
+        type=float,
+        default=900,
+        help="Stop watching after this many seconds (default: 900).",
+    )
+    parser.add_argument(
+        "--poll-seconds",
+        type=float,
+        default=30,
+        help="Seconds between polls (default: 30).",
+    )
+    args = parser.parse_args(argv)
+
+    return watch(
+        int(args.build_id),
+        deadline_seconds=float(args.deadline_seconds),
+        poll_seconds=float(args.poll_seconds),
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/test_copr_build_watch.py
+++ b/tests/unit/scripts/test_copr_build_watch.py
@@ -1,0 +1,189 @@
+"""Contracts for the Copr build watcher (issue #3325).
+
+The first end-to-end publish run submitted its build in under a second and
+then sat 45 minutes watching a build that never left the Copr queue, until the
+job's own ``timeout-minutes`` killed it. ``copr-cli``'s built-in watch has no
+deadline of its own, so the wait outlived the budget the job had for it.
+
+This watcher owns the deadline. A build that reaches a terminal failure inside
+the window fails the job; a build still queued at the deadline is handed to
+``reconcile-release.yml``, which compares the Copr version daily.
+
+No network: the transport is injected.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "scripts" / "copr_build_watch.py"
+
+BUILD_ID = 10802217
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("copr_build_watch", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def mod() -> ModuleType:
+    assert SCRIPT.exists(), f"{SCRIPT} must exist"
+    return _load_module()
+
+
+class FakeClock:
+    """Monotonic clock that only advances when the watcher sleeps."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.slept: list[float] = []
+
+    def time(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.slept.append(seconds)
+        self.now += seconds
+
+
+def _fetcher(states: list[Any]) -> Any:
+    """Return a transport replaying ``states``; an exception instance is raised."""
+    remaining = list(states)
+
+    def fetch(build_id: int) -> str:
+        assert build_id == BUILD_ID
+        item = remaining.pop(0) if remaining else remaining_last
+        if isinstance(item, Exception):
+            raise item
+        return str(item)
+
+    remaining_last = states[-1] if states else "pending"
+    return fetch
+
+
+def test_succeeded_build_passes(mod: ModuleType) -> None:
+    clock = FakeClock()
+    code = mod.watch(
+        BUILD_ID,
+        fetch=_fetcher(["pending", "running", "succeeded"]),
+        deadline_seconds=600,
+        poll_seconds=30,
+        time_fn=clock.time,
+        sleep_fn=clock.sleep,
+    )
+    assert code == 0
+
+
+@pytest.mark.parametrize("state", ["failed", "canceled", "cancelled", "skipped"])
+def test_terminal_failure_fails_the_job(mod: ModuleType, state: str, capsys: pytest.CaptureFixture[str]) -> None:
+    """A build that ends badly must fail the job, not warn inside a green run."""
+    clock = FakeClock()
+    code = mod.watch(
+        BUILD_ID,
+        fetch=_fetcher(["pending", state]),
+        deadline_seconds=600,
+        poll_seconds=30,
+        time_fn=clock.time,
+        sleep_fn=clock.sleep,
+    )
+    assert code == 1
+
+    out = capsys.readouterr().out
+    assert "::error::" in out
+    assert state in out
+    assert str(BUILD_ID) in out
+
+
+def test_build_still_queued_at_the_deadline_hands_off_to_the_reconciler(
+    mod: ModuleType, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Copr's queue latency is not a release failure.
+
+    The submission already succeeded; the outcome is unknown, not bad. Failing
+    here would paint releases red for a public build queue, so the still-queued
+    case is handed to the daily Copr comparison instead.
+    """
+    clock = FakeClock()
+    code = mod.watch(
+        BUILD_ID,
+        fetch=_fetcher(["pending"]),
+        deadline_seconds=120,
+        poll_seconds=30,
+        time_fn=clock.time,
+        sleep_fn=clock.sleep,
+    )
+    assert code == 0
+
+    out = capsys.readouterr().out
+    assert "::error::" not in out
+    assert "::notice::" in out
+    assert "reconcile-release" in out
+    assert str(BUILD_ID) in out
+
+
+def test_watch_stops_at_its_own_deadline(mod: ModuleType) -> None:
+    """The watch must end on its own budget rather than run until the job is
+    killed - that is the defect this watcher exists for."""
+    clock = FakeClock()
+    mod.watch(
+        BUILD_ID,
+        fetch=_fetcher(["pending"]),
+        deadline_seconds=120,
+        poll_seconds=30,
+        time_fn=clock.time,
+        sleep_fn=clock.sleep,
+    )
+    assert clock.now <= 120
+
+
+def test_transient_read_errors_do_not_end_the_watch(mod: ModuleType) -> None:
+    """One failed API read is not a build failure."""
+    clock = FakeClock()
+    code = mod.watch(
+        BUILD_ID,
+        fetch=_fetcher([OSError("connection reset"), "pending", "succeeded"]),
+        deadline_seconds=600,
+        poll_seconds=30,
+        time_fn=clock.time,
+        sleep_fn=clock.sleep,
+    )
+    assert code == 0
+
+
+def test_unreadable_state_never_reports_success_of_its_own(mod: ModuleType, capsys: pytest.CaptureFixture[str]) -> None:
+    """An API that never answers leaves the outcome unknown, not succeeded."""
+    clock = FakeClock()
+    code = mod.watch(
+        BUILD_ID,
+        fetch=_fetcher([OSError("connection reset")]),
+        deadline_seconds=120,
+        poll_seconds=30,
+        time_fn=clock.time,
+        sleep_fn=clock.sleep,
+    )
+    assert code == 0
+
+    out = capsys.readouterr().out
+    assert "::notice::" in out
+    assert "reconcile-release" in out
+
+
+def test_unknown_states_are_treated_as_still_running(mod: ModuleType) -> None:
+    """Copr may add states; an unrecognised one must not read as terminal."""
+    assert mod.classify("importing") == "pending"
+    assert mod.classify("waiting") == "pending"
+    assert mod.classify("some-new-state") == "pending"
+    assert mod.classify("succeeded") == "success"
+    assert mod.classify("failed") == "failure"

--- a/tests/unit/test_publish_workflow_yaml.py
+++ b/tests/unit/test_publish_workflow_yaml.py
@@ -158,16 +158,43 @@ def test_copr_job_fails_the_workflow_when_the_submission_fails(workflow: dict[st
     run = submit["run"]
     assert "set -euo pipefail" in run
     assert "::warning::" not in run
-    assert "|| true" not in run
-    assert "|| echo" not in run
 
-    # `copr-cli build` exits non-zero when the build fails only if it waits for
-    # it, so the job's verdict tracks the published RPM, not just the upload.
+    # copr-cli exits non-zero when Copr rejects the submission, and nothing may
+    # map that exit code back to success.
     commands = [line.strip() for line in run.splitlines() if not line.strip().startswith("#")]
     submit_commands = [line for line in commands if line.startswith("copr-cli build")]
     assert submit_commands, "the step must invoke `copr-cli build`"
     for command in submit_commands:
-        assert "--nowait" not in command
+        assert "|| true" not in command
+        assert "|| echo" not in command
+
+
+def test_copr_build_watch_deadline_fits_inside_the_job_budget(workflow: dict[str, Any]) -> None:
+    """The watch must end on its own budget, before the job runs out of time.
+
+    The first end-to-end run submitted in under a second, then watched a queued
+    build until `timeout-minutes` cancelled the step - so a build that was
+    merely slow was indistinguishable from one that failed.
+    """
+    job = workflow["jobs"][COPR_JOB]
+    submit = _step(workflow, COPR_JOB, "Submit build to Copr")
+
+    watch_seconds = int(str(submit["env"]["COPR_WATCH_SECONDS"]))
+    job_budget_seconds = int(job["timeout-minutes"]) * 60
+
+    assert watch_seconds > 0
+    assert watch_seconds < job_budget_seconds, (
+        "the watch deadline must leave the job time to finish, or a slow Copr "
+        "queue cancels the step instead of ending it"
+    )
+
+
+def test_copr_build_watch_is_delegated_to_the_tested_watcher(workflow: dict[str, Any]) -> None:
+    """The terminal-state logic lives in a unit-tested script, not in shell."""
+    run = _step(workflow, COPR_JOB, "Submit build to Copr")["run"]
+
+    assert "scripts/copr_build_watch.py" in run
+    assert "--nowait" in run, "copr-cli's own watch has no deadline; the watcher owns it"
 
 
 def test_copr_config_secret_is_written_from_the_environment_with_owner_only_mode(


### PR DESCRIPTION
# User description
The first end-to-end publish run reached the Copr build service correctly and
then failed on the wait:

```
Created builds: 10802217
Watching build(s): (this may be safely interrupted)
  09:45:16 Build 10802217: pending
##[error]The operation was canceled.
```

Every step up to and including the submission succeeded. The step was
cancelled 45 minutes later — exactly the job's `timeout-minutes`.

## Cause

`copr-cli`'s watch has no deadline of its own; it runs until the build ends,
however long Copr's shared public builders take. That wait outlived the budget
the job had for it, so the step was killed part-way through and a build that
was merely slow became indistinguishable from one that failed. `copr-cli`
itself flags the watch as optional — "this may be safely interrupted".

## Fix

Submit with `--nowait` and let `scripts/copr_build_watch.py` own the waiting,
against a deadline the job sets.

| Outcome | Job result |
|---|---|
| Copr rejects the submission | fails |
| Copr returns no build id | fails |
| Build ends `failed` / `canceled` / `skipped` in the window | fails |
| Build ends `succeeded` | passes |
| Build still queued when the window closes | passes, `::notice::` with the build URL |

The last row is the one deliberate exception and it is not a swallowed
failure: the submission already succeeded, so the outcome is unknown rather
than bad. Failing there would paint releases red for a public build queue.
`reconcile-release.yml` compares the published Copr version daily and opens a
`release-drift` issue if the version never lands — that channel is in its
comparison set precisely for this case.

`skipped` is treated as a failure: it means Copr already had that exact build
and produced no new RPM.

Unrecognised states count as still-running, so a future Copr state cannot be
read as a verdict nobody checked.

`timeout-minutes` drops from 45 to 30, comfortably above the 15-minute watch
window.

## Verification

- 10 unit tests on the watcher with an injected transport and clock: success,
  each terminal failure state, deadline hand-off, transient read errors, an
  API that never answers, and state classification.
- `test_copr_build_watch_deadline_fits_inside_the_job_budget` reads both
  numbers out of the workflow and fails if the watch could outlive the job —
  the defect this PR fixes.
- The watcher run against the live Copr API on the real build `10802217`:
  polls, then exits 0 at its deadline with the notice.
- zizmor clean; topology report unchanged.

Refs #3325

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Separate Copr submission from build watching so <code>publish-copr</code> submits with <code>--nowait</code> and <code>scripts/copr_build_watch.py</code> owns the deadline. Update the release docs and tests so slow public queues pass with a notice while rejected, failed, and skipped builds still fail.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3346?tool=ast&topic=Deadline+watcher>Deadline watcher</a>
        </td><td>Add a deadline-aware watcher that polls Copr build state, classifies terminal states, tolerates transient read errors, and hands off unfinished builds to release-drift monitoring.<details><summary>Modified files (3)</summary><ul><li>docs/operations/release.md</li>
<li>scripts/copr_build_watch.py</li>
<li>tests/unit/scripts/test_copr_build_watch.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>fix(release): give the...</td><td>August 01, 2026</td></tr>
<tr><td>chernistry</td><td>docs: point the change...</td><td>August 01, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3346?tool=ast&topic=Copr+publish+flow>Copr publish flow</a>
        </td><td>Split the release job into submission and deadline-bounded watching, failing fast on rejected submissions or terminal build failures while treating a queued build at the deadline as an unknown outcome with a notice.<details><summary>Modified files (3)</summary><ul><li>.github/workflows/publish.yml</li>
<li>docs/operations/release.md</li>
<li>tests/unit/test_publish_workflow_yaml.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>fix(release): give the...</td><td>August 01, 2026</td></tr>
<tr><td>chernistry</td><td>fix(release): pin copr...</td><td>August 01, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3346?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>