### PR TITLE
fix(ci): stop the ratchet guard parsing an API error body as a baseline

### DIFF
--- a/.github/workflows/coverage-ratchet.yml
+++ b/.github/workflows/coverage-ratchet.yml
@@ -159,20 +159,42 @@ jobs:
           #
           # So: read the baseline on the ratchet branch and only proceed when
           # the new measurement is strictly greater.
+          # gh prints the API error body to STDOUT on failure, so an
+          # emptiness test on the captured output cannot detect a missing
+          # branch: a 404 body parses as JSON and then fails on the absent
+          # coverage key. Branch on the exit code instead, and separate a
+          # missing ref (fine: the ratchet PR merged and its branch was
+          # auto-deleted) from every other API failure (loud).
+          set +e
           open_json=$(gh api "repos/${REPO}/contents/.coverage-baseline.json?ref=${RATCHET_BRANCH}" \
-              -H "Accept: application/vnd.github.raw" 2>/dev/null || true)
-          if [ -z "${open_json}" ]; then
-            echo "::notice::no ${RATCHET_BRANCH} branch yet; opening a fresh ratchet PR."
-            echo "proceed=true" >> "$GITHUB_OUTPUT"
-            exit 0
+              -H "Accept: application/vnd.github.raw" 2>gh-err.txt)
+          gh_rc=$?
+          set -e
+          if [ "${gh_rc}" -ne 0 ]; then
+            if grep -qE "HTTP 404|No commit found|Not Found" gh-err.txt; then
+              echo "::notice::no ${RATCHET_BRANCH} baseline (branch absent); opening a fresh ratchet PR."
+              rm -f gh-err.txt
+              echo "proceed=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "::error::could not read the open ratchet baseline (exit ${gh_rc}); refusing to guess."
+            cat gh-err.txt
+            rm -f gh-err.txt
+            exit 1
           fi
+          rm -f gh-err.txt
           printf '%s' "${open_json}" > open-baseline.json
           verdict=$(OPEN_BASELINE=open-baseline.json python3 - <<'PY'
           import json
           import os
+          import sys
 
           with open(os.environ["OPEN_BASELINE"], encoding="utf-8") as fh:
-              open_pct = float(json.load(fh)["total_coverage_percent"])
+              try:
+                  open_pct = float(json.load(fh)["total_coverage_percent"])
+              except (KeyError, ValueError, TypeError) as exc:
+                  print(f"::error::open ratchet baseline is malformed: {exc!r}", file=sys.stderr)
+                  raise SystemExit(1)
           measured = float(os.environ["MEASURED"])
           print(f"{'true' if measured > open_pct else 'false'} {open_pct}")
           PY


### PR DESCRIPTION
# User description
The coverage-ratchet guard read the open-PR baseline with `gh api ... 2>/dev/null || true` and tested the captured output for emptiness. gh prints the API error body to stdout, so when the ratchet branch was auto-deleted after its PR merged, the 404 body passed the emptiness check and reached the JSON parser, which raised `KeyError: 'total_coverage_percent'` and turned every push on main red (run 30697087119).

The guard now branches on the exit code: a missing ref proceeds as a fresh ratchet PR, any other API failure fails the job loudly with the captured error, and a baseline that parses but lacks the expected key is rejected with a clear message instead of a traceback.

Milestone v3.13.0.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Fix the <code>coverage-ratchet</code> GitHub Actions workflow so it branches on <code>gh api</code> exit codes when loading the open baseline, treating a missing <code>coverage-ratchet/baseline</code> ref as a fresh PR while failing other API errors loudly. Harden the inline Python check that compares <code>MEASURED</code> against the baseline JSON so malformed or missing <code>total_coverage_percent</code> values are rejected clearly.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3347?tool=ast&topic=Baseline+lookup>Baseline lookup</a>
        </td><td>Branch on <code>gh api</code> exit codes when loading the open ratchet baseline, so a deleted <code>coverage-ratchet/baseline</code> ref opens a fresh PR while other fetch failures surface as job errors.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/coverage-ratchet.yml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>viktorshpuktor@gmail.com</td><td>fix(ci): stop the ratc...</td><td>August 01, 2026</td></tr>
<tr><td>chernistry</td><td>fix(ci): one mergeable...</td><td>July 26, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3347?tool=ast&topic=Baseline+parse>Baseline parse</a>
        </td><td>Validate the fetched baseline JSON before comparing it to <code>MEASURED</code>, emitting a clear error when <code>total_coverage_percent</code> is missing or malformed instead of letting Python traceback.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/coverage-ratchet.yml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>viktorshpuktor@gmail.com</td><td>fix(ci): stop the ratc...</td><td>August 01, 2026</td></tr>
<tr><td>chernistry</td><td>fix(ci): one mergeable...</td><td>July 26, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3347?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>