### PR TITLE
chore(ci): ratchet coverage baseline up to 82.71%

### DIFF
--- a/.coverage-baseline.json
+++ b/.coverage-baseline.json
@@ -1,5 +1,5 @@
 {
   "diff_coverage_floor_percent": 85,
-  "total_coverage_percent": 82.62,
-  "updated_at": "2026-07-27T04:19:19+00:00"
+  "total_coverage_percent": 82.71,
+  "updated_at": "2026-08-01T14:35:09+00:00"
 }


### PR DESCRIPTION
# User description
Total line coverage rose on `main`, so the monotonic ratchet
bumped the committed high-water mark in `.coverage-baseline.json`
to **82.71%**.

From here, any later push whose total coverage falls below this
mark is flagged by the LEVEL 2 ratchet. The gate stays advisory
until promoted; see `docs/operations/coverage-ratchet.md`.

Generated by `.github/workflows/coverage-ratchet.yml`.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the coverage ratchet baseline metadata that the <code>coverage-ratchet</code> workflow uses to track the project’s total coverage high-water mark. Raise the committed floor to 82.71% so future drops are flagged by the advisory LEVEL 2 gate.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>chernistry</td><td>chore(ci): ratchet cov...</td><td>August 01, 2026</td></tr>
<tr><td>github-actions[bot]</td><td>chore(ci): ratchet cov...</td><td>July 25, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3348?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>