### PR TITLE
feat(mcp): add provider-neutral tool-call attestation interlock

### DIFF
--- a/docs/operations/mcp-gateway.md
+++ b/docs/operations/mcp-gateway.md
@@ -86,6 +86,51 @@ without the WAL file. A failure to anchor a call is logged but never takes
 the proxy down — it shows up to a verifier as a call-index gap rather than
 a crash.
 
+## Attestation interlock modes
+
+The gateway has a provider-neutral pre-dispatch interlock for integrations
+that need a completeness claim over connector calls. It is separate from the
+observe-only instrumenter:
+
+- **Enforced:** before upstream I/O, the configured evidence provider must
+  return non-empty handles for both a verified, durably chained attestation
+  and the dispatch marker that references it. A provider, signer, or durable
+  append failure raises and the connector is not invoked.
+- **Observed:** the gateway attempts the same preparation, but a failure is
+  logged and the connector remains reachable. A receipt can still be built,
+  but its verifier reports `observed`, never complete.
+
+Completeness is derived from ordered chain projections. Every
+`toolcall.enforced_dispatch` marker must reference a preceding
+`toolcall.attestation`; a receipt field claiming `complete` cannot upgrade a
+run with absent, reordered, or unmatched markers. The interlock protocol owns
+neither identity keys nor policy evaluation, so native and external providers
+can implement the same contract without becoming dependencies of the gateway.
+The gateway hashes an opaque provider-defined scope, request span, server,
+tool, request id, and argument digest into one call-intent digest. Returned
+evidence must bind that exact digest; stale evidence for a different call is a
+hard failure in enforced mode.
+
+This initial integration seam is programmatic. The CLI does not select a
+provider yet, and an unwired gateway retains its existing observe-only
+behavior. The boundary covers calls that cross the gateway; it cannot contain
+effects that bypass the host dispatch hook.
+
+Measure the partial seam at its real boundary with:
+
+```bash
+uv run python scripts/bench_toolcall_interlock.py \
+  --calls 256 --parallel 32 --repetitions 5
+```
+
+The script times complete `MCPGateway.handle_jsonrpc` dispatches, including WAL
+recording, with and without the interlock under parallel load. Its in-process
+provider returns content-bound evidence handles, so the reported delta is the
+host-seam budget—not the future cost of signature verification or durable
+chain storage. Repeat the same gateway-level measurement with the native
+provider when that implementation lands; a signer-only microbenchmark does not
+satisfy the dispatch-path requirement.
+
 ## SSE transport correlation
 
 The SSE transport is stateless by design (no gateway instance holds
@@ -101,4 +146,7 @@ juggling several in-flight requests still matches each response correctly.
 `src/bernstein/cli/commands/gateway_cmd.py` (registered as
 `bernstein gateway`, reachable via the back-compat alias
 `bernstein.cli.gateway_cmd`), `src/bernstein/core/protocols/mcp/mcp_gateway.py`
-(`MCPGateway`, `GatewayReplay`, `ToolMetrics`, `create_gateway_sse_app`).
+(`MCPGateway`, `GatewayReplay`, `ToolMetrics`, `create_gateway_sse_app`), and
+`src/bernstein/core/security/toolcall_interlock.py` (provider-neutral enforced
+and observed dispatch contract). `scripts/bench_toolcall_interlock.py` measures
+the seam at that gateway boundary under parallel load.

--- a/docs/sdd/toolcall-attestation-interlock.md
+++ b/docs/sdd/toolcall-attestation-interlock.md
@@ -1,0 +1,70 @@
+# Tool-call attestation interlock
+
+## Scope
+
+The interlock is the orchestrator-owned boundary between evidence preparation
+and a live connector side effect. It does not replace
+`RunInstrumenter.log_tool_call`: instrumentation remains observe-only and may
+never take a run down. The interlock is opt-in and applies only to calls that
+cross a host dispatch hook such as `MCPGateway`.
+
+## Contract
+
+`ToolCallAttestationInterlock` accepts a `ToolCallEvidenceProvider` and an
+opaque `scope_id`. The scope binds the provider's run, agent identity, and
+authority context without requiring Bernstein's gateway to understand the
+provider's identity, key, or policy schema.
+
+For each pending call, the gateway derives a `ToolCallIntent` from:
+
+- the opaque scope;
+- server and method;
+- tool name and JSON-RPC request id;
+- the content-derived request span;
+- a SHA-256 digest of canonicalized arguments.
+
+The provider must verify and durably record the call's attestation and a
+dispatch marker that references it. It returns opaque attestation and dispatch
+references plus the exact intent digest. The interlock validates the scope,
+non-empty references, and intent-digest equality before upstream I/O becomes
+reachable.
+
+## Modes and invariants
+
+### Enforced
+
+Any provider, verification, durability, empty-handle, or intent-mismatch
+failure raises `ToolCallInterlockError`. The connector is invoked zero times.
+
+### Observed
+
+The same failure is logged and dispatch may continue. Receipt projection
+reports `observed`; a caller-supplied `complete` label has no authority.
+
+### Chain-derived verdict
+
+`complete` requires at least one `toolcall.enforced_dispatch` marker and a
+preceding `toolcall.attestation` with the same attestation reference and intent
+digest. Missing, reordered, or mismatched evidence deterministically
+downgrades to `observed`.
+
+## Trust boundary
+
+The provider protocol promises that returned handles are verified and durable;
+the initial seam does not implement a signer, key store, identity issuer,
+policy engine, or chain backend. Bernstein's native implementation can reuse
+its existing identity and audit substrate. External providers can implement the
+same contract without becoming core dependencies.
+
+This boundary does not contain direct filesystem, process, network, or
+connector effects that bypass the host hook. A completeness statement is valid
+only for the dispatch surfaces wired through the interlock.
+
+## Performance measurement
+
+`scripts/bench_toolcall_interlock.py` compares full
+`MCPGateway.handle_jsonrpc` dispatches with and without the enforced seam under
+parallel load. The bundled in-process provider isolates host overhead; it does
+not measure future signature verification or durable-chain storage. When a
+native provider lands, use the same gateway-level harness so the measured path
+still includes the actual interlock location.

--- a/scripts/bench_toolcall_interlock.py
+++ b/scripts/bench_toolcall_interlock.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Measure the tool-call interlock at the live MCP gateway boundary.
+
+This intentionally times complete ``MCPGateway.handle_jsonrpc`` dispatches
+under bounded parallelism.  It compares an unwired gateway with an enforced
+gateway using an in-process evidence provider, so the delta isolates host-seam
+overhead without pretending to measure a future signer or durable store.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import platform
+import statistics
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+from bernstein.core.persistence.wal import WALWriter
+from bernstein.core.protocols.mcp.mcp_gateway import MCPGateway
+from bernstein.core.security.toolcall_interlock import (
+    AttestationMode,
+    ToolCallAttestationInterlock,
+    ToolCallIntent,
+    VerifiedDispatchEvidence,
+)
+
+
+class _InProcessEvidenceProvider:
+    async def prepare_dispatch(self, intent: ToolCallIntent) -> VerifiedDispatchEvidence:
+        return VerifiedDispatchEvidence(
+            attestation_ref=f"attestation:{intent.span_id}",
+            dispatch_ref=f"dispatch:{intent.span_id}",
+            intent_digest=intent.digest(),
+        )
+
+
+class _BenchmarkGateway(MCPGateway):
+    async def _send_upstream(self, message: dict[str, Any]) -> None:
+        request_id = message.get("id")
+        future = self._pending[request_id]
+        future.set_result({"jsonrpc": "2.0", "id": request_id, "result": {"ok": True}})
+
+
+async def _measure_once(*, enforced: bool, calls: int, parallel: int) -> dict[str, float]:
+    with tempfile.TemporaryDirectory(prefix="bernstein-interlock-bench-") as temporary:
+        sdd_dir = Path(temporary) / ".sdd"
+        sdd_dir.mkdir()
+        interlock = None
+        if enforced:
+            interlock = ToolCallAttestationInterlock(
+                provider=_InProcessEvidenceProvider(),
+                scope_id="scope:benchmark:agent-1",
+                mode=AttestationMode.ENFORCED,
+            )
+        gateway = _BenchmarkGateway(
+            upstream_cmd=[],
+            wal_writer=WALWriter(run_id="toolcall-interlock-bench", sdd_dir=sdd_dir),
+            server_name="benchmark",
+            attestation_interlock=interlock,
+        )
+        samples_ms: list[float] = []
+
+        async def dispatch(index: int) -> None:
+            started = time.perf_counter_ns()
+            await gateway.handle_jsonrpc(
+                {
+                    "jsonrpc": "2.0",
+                    "id": index,
+                    "method": "tools/call",
+                    "params": {"name": "noop", "arguments": {"index": index}},
+                }
+            )
+            samples_ms.append((time.perf_counter_ns() - started) / 1_000_000)
+
+        started = time.perf_counter_ns()
+        for offset in range(0, calls, parallel):
+            await asyncio.gather(*(dispatch(index) for index in range(offset, min(offset + parallel, calls))))
+        elapsed_ms = (time.perf_counter_ns() - started) / 1_000_000
+        samples_ms.sort()
+        p95_index = max(0, int(len(samples_ms) * 0.95) - 1)
+        return {
+            "elapsed_ms": elapsed_ms,
+            "per_dispatch_wall_ms": elapsed_ms / calls,
+            "p50_call_ms": statistics.median(samples_ms),
+            "p95_call_ms": samples_ms[p95_index],
+        }
+
+
+async def run_benchmark(*, calls: int, parallel: int, repetitions: int) -> dict[str, Any]:
+    """Return median gateway-level baseline and enforced measurements."""
+    if calls <= 0 or parallel <= 0 or repetitions <= 0:
+        raise ValueError("calls, parallel, and repetitions must be positive")
+    parallel = min(parallel, calls)
+
+    # Warm both import and filesystem paths outside the reported samples.
+    await _measure_once(enforced=False, calls=min(calls, parallel), parallel=parallel)
+    await _measure_once(enforced=True, calls=min(calls, parallel), parallel=parallel)
+
+    baseline_runs: list[dict[str, float]] = []
+    enforced_runs: list[dict[str, float]] = []
+    for _ in range(repetitions):
+        baseline_runs.append(await _measure_once(enforced=False, calls=calls, parallel=parallel))
+        enforced_runs.append(await _measure_once(enforced=True, calls=calls, parallel=parallel))
+
+    def medians(rows: list[dict[str, float]]) -> dict[str, float]:
+        return {key: statistics.median(row[key] for row in rows) for key in rows[0]}
+
+    baseline = medians(baseline_runs)
+    enforced = medians(enforced_runs)
+    return {
+        "schema": "bernstein.toolcall-interlock-benchmark/v1",
+        "calls": calls,
+        "parallel": parallel,
+        "repetitions": repetitions,
+        "python": platform.python_version(),
+        "platform": platform.platform(),
+        "provider": "in-process evidence handle; signing and durable-chain storage excluded",
+        "baseline": baseline,
+        "enforced": enforced,
+        "delta_per_dispatch_wall_ms": enforced["per_dispatch_wall_ms"] - baseline["per_dispatch_wall_ms"],
+    }
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--calls", type=int, default=256)
+    parser.add_argument("--parallel", type=int, default=32)
+    parser.add_argument("--repetitions", type=int, default=5)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    report = asyncio.run(run_benchmark(calls=args.calls, parallel=args.parallel, repetitions=args.repetitions))
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bernstein/core/protocols/mcp/mcp_gateway.py
+++ b/src/bernstein/core/protocols/mcp/mcp_gateway.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
     from bernstein.core.protocols.payments.x402 import X402SettlementCoordinator
     from bernstein.core.replay.journal import EventJournal
     from bernstein.core.security.audit_chain import AuditChainStore
+    from bernstein.core.security.toolcall_interlock import ToolCallAttestationInterlock
     from bernstein.core.wal import WALEntry, WALWriter
 
 
@@ -176,6 +177,7 @@ class MCPGateway:
         journal: EventJournal | None = None,
         audit_chain: AuditChainStore | None = None,
         settlement: X402SettlementCoordinator | None = None,
+        attestation_interlock: ToolCallAttestationInterlock | None = None,
     ) -> None:
         self._upstream_cmd = upstream_cmd
         self._wal_writer = wal_writer
@@ -189,6 +191,10 @@ class MCPGateway:
         # before any payment. The settlement seam lives on the live-proxy
         # branch only, so replay can never invoke the hook or double-settle.
         self._settlement = settlement
+        # Provider-neutral enforced/observed boundary (#2931).  When wired,
+        # every live ``tools/call`` must cross it before upstream I/O.  Replay
+        # never invokes the interlock because it has no connector side effect.
+        self._attestation_interlock = attestation_interlock
         self._metrics: dict[str, ToolMetrics] = {}
         self._proc: asyncio.subprocess.Process | None = None
         self._pending: dict[Any, asyncio.Future[dict[str, Any]]] = {}
@@ -326,10 +332,12 @@ class MCPGateway:
             return self._handle_replay(method, params, req_id, is_notification)
 
         if is_notification:
+            await self._prepare_tool_dispatch(message, method, params, req_id)
             if self._proc:
                 await self._send_upstream(message)
             return None
 
+        await self._prepare_tool_dispatch(message, method, params, req_id)
         response, latency_ms = await self._send_request(message, req_id)
         self._record_wal_and_metrics(method, params, req_id, response, latency_ms)
         self._anchor_proxied_call(method, params)
@@ -338,6 +346,29 @@ class MCPGateway:
             response = await self._maybe_settle(message, params, response)
 
         return response
+
+    async def _prepare_tool_dispatch(
+        self,
+        message: dict[str, Any],
+        method: str,
+        params: dict[str, Any],
+        req_id: Any,
+    ) -> None:
+        """Cross the attestation interlock before live connector I/O."""
+        if method != "tools/call" or self._attestation_interlock is None:
+            return
+        from bernstein.core.security.toolcall_interlock import ToolCallIntent
+
+        intent = ToolCallIntent.from_request(
+            scope_id=self._attestation_interlock.scope_id,
+            server_name=self._server_name,
+            method=method,
+            tool_name=str(params.get("name", "")),
+            request_id=req_id,
+            span_id=request_span_id(message),
+            arguments=params.get("arguments", {}),
+        )
+        await self._attestation_interlock.before_dispatch(intent)
 
     async def _send_request(self, message: dict[str, Any], req_id: Any) -> tuple[dict[str, Any], float]:
         """Send one JSON-RPC request upstream and await its response.
@@ -392,6 +423,7 @@ class MCPGateway:
         retried = build_retry_request(message, pre.payment_ref)
         retried_id = retried.get("id")
         retried_params: dict[str, Any] = retried.get("params") or {}
+        await self._prepare_tool_dispatch(retried, "tools/call", retried_params, retried_id)
         settled, latency_ms = await self._send_request(retried, retried_id)
         wal_entry = self._record_wal_and_metrics("tools/call", retried_params, retried_id, settled, latency_ms)
         self._anchor_proxied_call("tools/call", retried_params)

--- a/src/bernstein/core/security/toolcall_interlock.py
+++ b/src/bernstein/core/security/toolcall_interlock.py
@@ -1,0 +1,242 @@
+"""Provider-neutral pre-dispatch interlock for attested tool calls.
+
+The observe-only instrumenter must remain non-blocking.  Completeness therefore
+needs a separate boundary owned by the orchestrator: in enforced mode this
+module requires a provider to verify and durably record the attestation and its
+dispatch marker before the connector callback becomes reachable.  Observed
+mode attempts the same preparation but deliberately keeps failures non-fatal.
+
+The provider protocol is intentionally about evidence, not key management or
+policy.  Bernstein's native signer can implement it, as can an operator adapter,
+without making either implementation a dependency of the dispatch boundary.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, Protocol, cast
+
+from bernstein.core.security.sanitize import sanitize_log
+
+logger = logging.getLogger(__name__)
+
+
+class AttestationMode(StrEnum):
+    """Runtime behavior when attestation preparation fails."""
+
+    ENFORCED = "enforced"
+    OBSERVED = "observed"
+
+
+class AttestationVerdict(StrEnum):
+    """Completeness verdict derived from chain evidence."""
+
+    COMPLETE = "complete"
+    OBSERVED = "observed"
+
+
+@dataclass(frozen=True, slots=True)
+class ToolCallIntent:
+    """Content-derived description of one about-to-dispatch tool call.
+
+    ``scope_id`` is an opaque run/agent authority binding supplied by the
+    provider integration.  It lets the host bind evidence to the correct
+    execution scope without owning the provider's identity or policy schema.
+    """
+
+    scope_id: str
+    server_name: str
+    method: str
+    tool_name: str
+    request_id: str
+    span_id: str
+    args_digest: str
+
+    @classmethod
+    def from_request(
+        cls,
+        *,
+        scope_id: str,
+        server_name: str,
+        method: str,
+        tool_name: str,
+        request_id: Any,
+        span_id: str,
+        arguments: Any,
+    ) -> ToolCallIntent:
+        """Build an intent without retaining raw connector arguments."""
+        canonical = json.dumps(arguments, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+        return cls(
+            scope_id=scope_id,
+            server_name=server_name,
+            method=method,
+            tool_name=tool_name,
+            request_id=str(request_id),
+            span_id=span_id,
+            args_digest="sha256:" + hashlib.sha256(canonical).hexdigest(),
+        )
+
+    def digest(self) -> str:
+        """Return the canonical digest a provider's evidence must bind."""
+        payload = {
+            "args_digest": self.args_digest,
+            "method": self.method,
+            "request_id": self.request_id,
+            "scope_id": self.scope_id,
+            "server_name": self.server_name,
+            "span_id": self.span_id,
+            "tool_name": self.tool_name,
+        }
+        canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+        return "sha256:" + hashlib.sha256(canonical).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class VerifiedDispatchEvidence:
+    """Opaque handles proving preparation completed before dispatch.
+
+    ``attestation_ref`` identifies the verified, durably chained attestation.
+    ``dispatch_ref`` identifies the chained dispatch marker that references it.
+    ``intent_digest`` binds both handles back to the exact host-derived call
+    intent.  The interlock treats the references as opaque provider-owned
+    handles, but refuses empty or mismatched evidence so an accidental stale or
+    no-op implementation cannot authorize a call.
+    """
+
+    attestation_ref: str
+    dispatch_ref: str
+    intent_digest: str
+
+
+class ToolCallEvidenceProvider(Protocol):
+    """Verify and durably record evidence for one pending dispatch."""
+
+    async def prepare_dispatch(self, intent: ToolCallIntent) -> VerifiedDispatchEvidence:
+        """Return only after the attestation and dispatch marker are durable."""
+        ...
+
+
+class ToolCallInterlockError(RuntimeError):
+    """Raised when enforced dispatch cannot establish durable evidence."""
+
+
+@dataclass(frozen=True, slots=True)
+class AttestationModeProjection:
+    """Receipt-facing mode projection derived from chain markers."""
+
+    claimed_mode: str
+    verdict: AttestationVerdict
+
+    @property
+    def complete(self) -> bool:
+        """Whether chain evidence supports a completeness claim."""
+        return self.verdict is AttestationVerdict.COMPLETE
+
+
+@dataclass(slots=True)
+class ToolCallAttestationInterlock:
+    """Apply enforced or observed semantics at a connector boundary."""
+
+    provider: ToolCallEvidenceProvider
+    scope_id: str
+    mode: AttestationMode = AttestationMode.ENFORCED
+
+    async def before_dispatch(self, intent: ToolCallIntent) -> VerifiedDispatchEvidence | None:
+        """Prepare evidence before a connector is invoked.
+
+        Enforced mode fails closed.  Observed mode logs preparation failures and
+        returns ``None`` so the connector remains reachable, which is precisely
+        why a verifier must report that run as observed rather than complete.
+        """
+        try:
+            if not self.scope_id.strip() or intent.scope_id != self.scope_id:
+                raise ToolCallInterlockError("tool-call intent is not bound to the configured evidence scope")
+            evidence = await self.provider.prepare_dispatch(intent)
+            if not evidence.attestation_ref.strip() or not evidence.dispatch_ref.strip():
+                raise ToolCallInterlockError("attestation provider returned an incomplete evidence handle")
+            if evidence.intent_digest != intent.digest():
+                raise ToolCallInterlockError("attestation provider returned evidence for a different tool-call intent")
+            return evidence
+        except Exception as exc:
+            if self.mode is AttestationMode.OBSERVED:
+                logger.warning(
+                    "Observed tool-call attestation preparation failed for %s/%s: %s",
+                    sanitize_log(intent.server_name),
+                    sanitize_log(intent.tool_name),
+                    sanitize_log(str(exc)),
+                )
+                return None
+            if isinstance(exc, ToolCallInterlockError):
+                raise
+            raise ToolCallInterlockError(
+                f"enforced tool-call attestation preparation failed for {intent.server_name}/{intent.tool_name}"
+            ) from exc
+
+
+def derive_attestation_verdict(events: Sequence[Mapping[str, Any]]) -> AttestationVerdict:
+    """Derive completeness from ordered chain projections, never a claim field.
+
+    A complete verdict requires at least one ``toolcall.enforced_dispatch``
+    event and, for every such event, a preceding ``toolcall.attestation`` whose
+    ``attestation_ref`` it references.  Missing, reordered, or unpaired markers
+    always downgrade to :attr:`AttestationVerdict.OBSERVED`.
+
+    Receipt fields such as ``claimed_mode`` are intentionally ignored.
+    """
+    attestations: dict[str, str] = {}
+    dispatch_count = 0
+    for event in events:
+        event_type = str(event.get("event_type", event.get("event", "")))
+        details = event.get("details")
+        payload: Mapping[str, Any] = cast("Mapping[str, Any]", details) if isinstance(details, Mapping) else event
+        if event_type == "toolcall.attestation":
+            reference = str(payload.get("attestation_ref", "")).strip()
+            intent_digest = str(payload.get("intent_digest", "")).strip()
+            if reference and intent_digest:
+                attestations[reference] = intent_digest
+            continue
+        if event_type != "toolcall.enforced_dispatch":
+            continue
+        dispatch_count += 1
+        reference = str(payload.get("attestation_ref", "")).strip()
+        intent_digest = str(payload.get("intent_digest", "")).strip()
+        if not reference or not intent_digest or attestations.get(reference) != intent_digest:
+            return AttestationVerdict.OBSERVED
+    if dispatch_count == 0:
+        return AttestationVerdict.OBSERVED
+    return AttestationVerdict.COMPLETE
+
+
+def project_attestation_mode(
+    events: Sequence[Mapping[str, Any]], *, claimed_mode: str = ""
+) -> AttestationModeProjection:
+    """Construct the receipt-facing projection without trusting its claim.
+
+    ``claimed_mode`` is retained so a verifier can explain a downgrade, but it
+    has no influence on the verdict.  Observed-mode receipt construction thus
+    remains available after an instrumentation failure without manufacturing a
+    completeness guarantee.
+    """
+    return AttestationModeProjection(
+        claimed_mode=claimed_mode,
+        verdict=derive_attestation_verdict(events),
+    )
+
+
+__all__ = [
+    "AttestationMode",
+    "AttestationModeProjection",
+    "AttestationVerdict",
+    "ToolCallAttestationInterlock",
+    "ToolCallEvidenceProvider",
+    "ToolCallIntent",
+    "ToolCallInterlockError",
+    "VerifiedDispatchEvidence",
+    "derive_attestation_verdict",
+    "project_attestation_mode",
+]

--- a/tests/unit/security/test_toolcall_interlock.py
+++ b/tests/unit/security/test_toolcall_interlock.py
@@ -1,0 +1,181 @@
+"""Negative contracts for enforced versus observed tool-call attestation."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from bernstein.core.persistence.wal import WALWriter
+from bernstein.core.protocols.mcp.mcp_gateway import MCPGateway
+from bernstein.core.security.toolcall_interlock import (
+    AttestationMode,
+    AttestationVerdict,
+    ToolCallAttestationInterlock,
+    ToolCallIntent,
+    ToolCallInterlockError,
+    VerifiedDispatchEvidence,
+    derive_attestation_verdict,
+    project_attestation_mode,
+)
+
+
+class _FailingProvider:
+    async def prepare_dispatch(self, intent: ToolCallIntent) -> VerifiedDispatchEvidence:
+        del intent
+        raise OSError("audit volume full")
+
+
+class _RecordingProvider:
+    def __init__(self, *, stale: bool = False) -> None:
+        self.intents: list[ToolCallIntent] = []
+        self.stale = stale
+
+    async def prepare_dispatch(self, intent: ToolCallIntent) -> VerifiedDispatchEvidence:
+        self.intents.append(intent)
+        return VerifiedDispatchEvidence(
+            attestation_ref=f"attestation:{intent.span_id}",
+            dispatch_ref=f"dispatch:{intent.span_id}",
+            intent_digest="sha256:stale" if self.stale else intent.digest(),
+        )
+
+
+def _gateway(tmp_path: Any, mode: AttestationMode) -> MCPGateway:
+    sdd = tmp_path / ".sdd"
+    sdd.mkdir()
+    writer = WALWriter(run_id=f"attestation-{mode}", sdd_dir=sdd)
+    return MCPGateway(
+        upstream_cmd=[],
+        wal_writer=writer,
+        server_name="filesystem",
+        attestation_interlock=ToolCallAttestationInterlock(
+            provider=_FailingProvider(), scope_id="scope:test-run:agent-1", mode=mode
+        ),
+    )
+
+
+def _request() -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": 7,
+        "method": "tools/call",
+        "params": {"name": "read_file", "arguments": {"path": "/tmp/x"}},
+    }
+
+
+@pytest.mark.asyncio
+async def test_enforced_failure_makes_connector_unreachable(tmp_path: Any) -> None:
+    gateway = _gateway(tmp_path, AttestationMode.ENFORCED)
+
+    with (
+        patch.object(gateway, "_send_request", new_callable=AsyncMock) as connector,
+        pytest.raises(ToolCallInterlockError, match="enforced tool-call attestation preparation failed"),
+    ):
+        await gateway.handle_jsonrpc(_request())
+
+    connector.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_observed_failure_allows_call_and_receipt_stays_observed(tmp_path: Any) -> None:
+    gateway = _gateway(tmp_path, AttestationMode.OBSERVED)
+    response: dict[str, Any] = {"jsonrpc": "2.0", "id": 7, "result": {"ok": True}}
+
+    with patch.object(gateway, "_send_request", new_callable=AsyncMock, return_value=(response, 0.0)) as send:
+        result = await gateway.handle_jsonrpc(_request())
+
+    assert result == response
+    send.assert_awaited_once()
+    # Receipt construction projects an empty marker range rather than failing;
+    # the absence of enforcement evidence is the observed verdict.
+    receipt = project_attestation_mode([], claimed_mode="complete")
+    assert receipt.verdict is AttestationVerdict.OBSERVED
+    assert not receipt.complete
+
+
+@pytest.mark.asyncio
+async def test_matching_evidence_reaches_connector_with_content_bound_intent(tmp_path: Any) -> None:
+    sdd = tmp_path / ".sdd"
+    sdd.mkdir()
+    provider = _RecordingProvider()
+    gateway = MCPGateway(
+        upstream_cmd=[],
+        wal_writer=WALWriter(run_id="attestation-matched", sdd_dir=sdd),
+        server_name="filesystem",
+        attestation_interlock=ToolCallAttestationInterlock(
+            provider=provider,
+            scope_id="scope:test-run:agent-1",
+            mode=AttestationMode.ENFORCED,
+        ),
+    )
+    response: dict[str, Any] = {"jsonrpc": "2.0", "id": 7, "result": {"ok": True}}
+
+    with patch.object(gateway, "_send_request", new_callable=AsyncMock, return_value=(response, 0.0)) as send:
+        assert await gateway.handle_jsonrpc(_request()) == response
+
+    send.assert_awaited_once()
+    assert len(provider.intents) == 1
+    intent = provider.intents[0]
+    assert intent.scope_id == "scope:test-run:agent-1"
+    assert intent.server_name == "filesystem"
+    assert intent.tool_name == "read_file"
+    assert intent.args_digest.startswith("sha256:")
+    assert intent.span_id
+
+
+@pytest.mark.asyncio
+async def test_stale_evidence_for_different_intent_blocks_connector(tmp_path: Any) -> None:
+    sdd = tmp_path / ".sdd"
+    sdd.mkdir()
+    gateway = MCPGateway(
+        upstream_cmd=[],
+        wal_writer=WALWriter(run_id="attestation-stale", sdd_dir=sdd),
+        server_name="filesystem",
+        attestation_interlock=ToolCallAttestationInterlock(
+            provider=_RecordingProvider(stale=True),
+            scope_id="scope:test-run:agent-1",
+            mode=AttestationMode.ENFORCED,
+        ),
+    )
+    with (
+        patch.object(gateway, "_send_request", new_callable=AsyncMock) as connector,
+        pytest.raises(ToolCallInterlockError, match="different tool-call intent"),
+    ):
+        await gateway.handle_jsonrpc(_request())
+
+    connector.assert_not_awaited()
+
+
+def test_complete_claim_without_chain_markers_is_downgraded() -> None:
+    receipt_claim = {"claimed_mode": "complete"}
+
+    projection = project_attestation_mode([receipt_claim], claimed_mode="complete")
+
+    assert projection.claimed_mode == "complete"
+    assert projection.verdict is AttestationVerdict.OBSERVED
+
+
+def test_complete_is_derived_only_from_ordered_matching_markers() -> None:
+    events: list[Mapping[str, Any]] = [
+        {
+            "event_type": "toolcall.attestation",
+            "details": {"attestation_ref": "sha256:a", "intent_digest": "sha256:intent"},
+        },
+        {
+            "event_type": "toolcall.enforced_dispatch",
+            "details": {"attestation_ref": "sha256:a", "intent_digest": "sha256:intent"},
+        },
+    ]
+
+    assert derive_attestation_verdict(events) is AttestationVerdict.COMPLETE
+    assert derive_attestation_verdict(list(reversed(events))) is AttestationVerdict.OBSERVED
+    mismatched: list[Mapping[str, Any]] = [
+        events[0],
+        {
+            "event_type": "toolcall.enforced_dispatch",
+            "details": {"attestation_ref": "sha256:a", "intent_digest": "sha256:different"},
+        },
+    ]
+    assert derive_attestation_verdict(mismatched) is AttestationVerdict.OBSERVED

--- a/tests/unit/security/test_toolcall_interlock_benchmark.py
+++ b/tests/unit/security/test_toolcall_interlock_benchmark.py
@@ -1,0 +1,29 @@
+"""Hermetic contract test for the gateway-level interlock benchmark."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[3] / "scripts" / "bench_toolcall_interlock.py"
+_spec = importlib.util.spec_from_file_location("_bench_toolcall_interlock", _SCRIPT_PATH)
+assert _spec is not None and _spec.loader is not None
+bench: Any = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = bench
+_spec.loader.exec_module(bench)
+
+
+@pytest.mark.asyncio
+async def test_parallel_gateway_benchmark_reports_both_paths() -> None:
+    report = await bench.run_benchmark(calls=8, parallel=4, repetitions=1)
+
+    assert report["schema"] == "bernstein.toolcall-interlock-benchmark/v1"
+    assert report["calls"] == 8
+    assert report["parallel"] == 4
+    assert report["baseline"]["per_dispatch_wall_ms"] > 0
+    assert report["enforced"]["per_dispatch_wall_ms"] > 0
+    assert "signing and durable-chain storage excluded" in report["provider"]


### PR DESCRIPTION
Refs #2931.

## Summary

- add an injected pre-dispatch interlock at the live MCP gateway boundary;
- keep `RunInstrumenter.log_tool_call` observe-only and non-blocking;
- make enforced evidence failure, empty evidence, or stale/mismatched evidence leave upstream connector invocation unreachable;
- let observed mode continue while receipt projection deterministically reports `observed`;
- bind provider evidence to an opaque execution scope and the exact content-derived call intent;
- add a reproducible parallel gateway benchmark plus operator and architecture documentation.

This is the tests-first partial discussed in the issue, not the complete signed-identity and receipt stack.

## Enforcement contract

The gateway derives a `ToolCallIntent` from an opaque provider-defined scope, server, method, tool name, request id, content-derived span id, and canonical argument digest. A provider must return only after it has verified and durably recorded both the call attestation and the dispatch marker that references it.

The returned handles stay opaque to the gateway, but they must be non-empty and carry the exact host-derived intent digest. That prevents a stale handle for another tool call from opening the gate without making the gateway own identity keys or policy semantics.

- **Enforced:** provider, verification, durability, empty-handle, scope, or intent-binding failure raises before `_send_request`; the connector is invoked zero times.
- **Observed:** the same preparation failure is logged and dispatch may continue; receipt projection reports `observed` and ignores any unsupported `complete` claim.

`complete` is derived only when each enforced dispatch marker follows a matching attestation reference with the same intent digest. Missing, reordered, or mismatched markers downgrade to `observed`.

## Parallel dispatch measurement

Command:

```bash
uv run python scripts/bench_toolcall_interlock.py \
  --calls 256 --parallel 32 --repetitions 5
```

Measured on macOS arm64 with Python 3.14.6:

| Gateway-level metric | Baseline | Enforced seam | Delta |
|---|---:|---:|---:|
| Wall cost per dispatch | 0.294 ms | 0.348 ms | +0.053 ms |
| Per-call p50 | 0.222 ms | 0.288 ms | +0.067 ms |
| Per-call p95 | 0.515 ms | 0.522 ms | +0.007 ms |

The partial-slice budget is at most 0.10 ms added p50 latency per dispatch for the provider-neutral host seam at concurrency 32 on the same host. This run is within that budget.

The benchmark times complete `MCPGateway.handle_jsonrpc` calls at the actual interlock location, including WAL recording. Its provider is intentionally in-process, so these numbers isolate the host seam and do **not** claim to include future signature verification or durable-chain storage. The native provider should be measured with this same gateway-level harness when it lands; a signer-only microbenchmark would not satisfy the dispatch-path requirement.

## Tests and checks

- 6 interlock behavior and chain-projection tests;
- 1 hermetic benchmark-harness test;
- 20 MCP gateway regression tests;
- 4 x402 gateway retry tests;
- Ruff clean;
- Pyright and Mypy clean for the new module and benchmark;
- `bernstein agents-md verify` clean across all 13 generated targets;
- strict documentation-drift check clean across 50 inventory rows.

## Explicit boundary

This slice does not implement the production signer, key custody, identity issuance, authorization policy, audit-chain provider, standard receipt formats, lineage-gate coupling, or CLI. It defines the host-owned enforcement socket those implementations can satisfy without becoming dependencies of the MCP gateway.

The completeness boundary covers only calls that cross the wired gateway hook. It does not contain direct filesystem, process, network, or connector effects that bypass the host.

Follow-up slices can implement Bernstein's native evidence provider and then carry the verified events through receipt projection, lineage gating, and CLI verification.
