### PR TITLE
docs: regenerate adapter last-green table from canary receipts

### DIFF
--- a/docs/adapters/conformance-canary.md
+++ b/docs/adapters/conformance-canary.md
@@ -118,14 +118,14 @@ frozen adapter locally, not only in this table.
 | Adapter | Binary | Last-green version | Verified | Receipt |
 |---|---|---|---|---|
 | agy | `agy` | 1.0.0 | 2026-07-11T05:57:23Z (stale) | `006fb946868d` |
-| claude | `claude` | 2.1.220 | 2026-08-01T07:23:36Z | `657c46cb9550` |
-| codex | `codex` | 0.146.0 | 2026-08-01T07:23:36Z | `001f0dbda391` |
-| copilot | `copilot` | 1.0.77 | 2026-08-01T07:23:36Z | `488708c45a9b` |
-| gemini | `gemini` | 0.53.1 | 2026-08-01T07:23:36Z | `28f6d635ab31` |
-| kimi | `kimi` | 1.49.0 | 2026-08-01T07:23:36Z | `724c0b6f9a50` |
-| opencode | `opencode` | 1.18.10 | 2026-08-01T07:23:36Z | `00aaf079c2f2` |
-| pydantic_ai | `clai` | 2.22.0 | 2026-08-01T07:23:36Z | `3ae61a238bf1` |
-| qwen | `qwen` | 0.21.2 | 2026-08-01T07:23:36Z | `7e6ee82ccbdf` |
+| claude | `claude` | 2.1.220 | 2026-08-02T07:28:46Z | `9db1a791c3b8` |
+| codex | `codex` | 0.146.0 | 2026-08-02T07:28:46Z | `80f373cad469` |
+| copilot | `copilot` | 1.0.77 | 2026-08-02T07:28:46Z | `78f785bfe404` |
+| gemini | `gemini` | 0.53.1 | 2026-08-02T07:28:46Z | `2d5ee176fab9` |
+| kimi | `kimi` | 1.49.0 | 2026-08-02T07:28:46Z | `f625894af6bb` |
+| opencode | `opencode` | 1.18.11 | 2026-08-02T07:28:46Z | `3aa825e89830` |
+| pydantic_ai | `clai` | 2.22.0 | 2026-08-02T07:28:46Z | `fc56cbb2f915` |
+| qwen | `qwen` | 0.21.3 | 2026-08-02T07:28:46Z | `0b5339d156b8` |
 <!-- last-green:end -->
 
 ## Operator knobs

--- a/src/bernstein/adapters/last_green.json
+++ b/src/bernstein/adapters/last_green.json
@@ -8,51 +8,51 @@
     },
     "claude": {
       "binary": "claude",
-      "receipt_sha256": "657c46cb9550b955e773f15087b757f9243dfcdf602de717e686f7396abe9943",
-      "recorded_at": "2026-08-01T07:23:36Z",
+      "receipt_sha256": "9db1a791c3b8326ad364f5d889c1754720a2d9937396760aa9df9bc965b75e9b",
+      "recorded_at": "2026-08-02T07:28:46Z",
       "version": "2.1.220"
     },
     "codex": {
       "binary": "codex",
-      "receipt_sha256": "001f0dbda391c8f48ff6dd67e46feb3e29da88930a235115274466f1053b04da",
-      "recorded_at": "2026-08-01T07:23:36Z",
+      "receipt_sha256": "80f373cad469166a700c9f9b625f38c41fc321fe98587edc1190be9e6f7d4c69",
+      "recorded_at": "2026-08-02T07:28:46Z",
       "version": "0.146.0"
     },
     "copilot": {
       "binary": "copilot",
-      "receipt_sha256": "488708c45a9b325555fbaaa0e3f75636603f569888a110fce4dba58d719ee395",
-      "recorded_at": "2026-08-01T07:23:36Z",
+      "receipt_sha256": "78f785bfe4043c7563c15e1388ae70d1d4db11d9edb34cf7b599846a8efd007e",
+      "recorded_at": "2026-08-02T07:28:46Z",
       "version": "1.0.77"
     },
     "gemini": {
       "binary": "gemini",
-      "receipt_sha256": "28f6d635ab31f3f12abd0eaf3fbb14ad67078e65deaddddc19dab83a124a68ee",
-      "recorded_at": "2026-08-01T07:23:36Z",
+      "receipt_sha256": "2d5ee176fab91b695bfd2df92ab2b943de87e06b631a7bb64ba4d4ae58ba6b06",
+      "recorded_at": "2026-08-02T07:28:46Z",
       "version": "0.53.1"
     },
     "kimi": {
       "binary": "kimi",
-      "receipt_sha256": "724c0b6f9a50a90b7dbb3e4475da208f43185740af238a06d46af844a28fda3b",
-      "recorded_at": "2026-08-01T07:23:36Z",
+      "receipt_sha256": "f625894af6bb0ddde932cba9014641a03e8772a9ae193bfd01553c9d110193e9",
+      "recorded_at": "2026-08-02T07:28:46Z",
       "version": "1.49.0"
     },
     "opencode": {
       "binary": "opencode",
-      "receipt_sha256": "00aaf079c2f2bf8b4a7fde42f71ad43d88336063a74d69351d159acbba5f3f0f",
-      "recorded_at": "2026-08-01T07:23:36Z",
-      "version": "1.18.10"
+      "receipt_sha256": "3aa825e89830216d2b45ab9cae4af4579f3fee2dd0dcf65ba17bfcfb23d1f562",
+      "recorded_at": "2026-08-02T07:28:46Z",
+      "version": "1.18.11"
     },
     "pydantic_ai": {
       "binary": "clai",
-      "receipt_sha256": "3ae61a238bf1c93bd216cac9412a41c00a13a1e3895e7409d31321b754fe7305",
-      "recorded_at": "2026-08-01T07:23:36Z",
+      "receipt_sha256": "fc56cbb2f915c9ea47e83dcf50273a496e23a09834e4994e043a896a23e686c6",
+      "recorded_at": "2026-08-02T07:28:46Z",
       "version": "2.22.0"
     },
     "qwen": {
       "binary": "qwen",
-      "receipt_sha256": "7e6ee82ccbdf4b751c3c5779e9fc9c1940a13f11e722f230205218f7b27dd71d",
-      "recorded_at": "2026-08-01T07:23:36Z",
-      "version": "0.21.2"
+      "receipt_sha256": "0b5339d156b86fede2e50ae5baded31e196fd608714109c916dc74d12c5f9d33",
+      "recorded_at": "2026-08-02T07:28:46Z",
+      "version": "0.21.3"
     }
   },
   "schema_version": 1


### PR DESCRIPTION
# User description
Nightly adapter conformance canary regeneration of the per-adapter last-green projection (packaged last_green.json + the docs table). Every row is anchored to the receipt that attested it; receipts for this run are attached to the workflow run as artifacts.

Workflow run: https://github.com/sipyourdrink-ltd/bernstein/actions/runs/30737755661

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Regenerate the adapter conformance canary snapshot in the <code>bernstein</code> adapter projection and the published conformance docs table so each row reflects the latest nightly receipts. Keep <code>last_green.json</code> and the docs projection in sync for the tracked adapters.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>canary@users.noreply.g...</td><td>docs: regenerate adapt...</td><td>August 02, 2026</td></tr>
<tr><td>chernistry</td><td>docs: regenerate adapt...</td><td>August 01, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3355?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>