### PR TITLE
docs(operations): name all three endpoints in shepherd step 2

### DIFF
--- a/docs/operations/review-bot-ack.md
+++ b/docs/operations/review-bot-ack.md
@@ -63,7 +63,9 @@ Shepherds:
 2. Fetch all configured review-bot artefacts via the three `gh api`
    endpoints the gate reads: `pulls/<n>/comments`,
    `issues/<n>/comments`, and `pulls/<n>/reviews`.
-3. Classify into must-address vs informational.
+3. Classify the two comment endpoints into must-address vs
+   informational. `pulls/<n>/reviews` carries no severity; it feeds
+   only the per-bot review coverage for the head commit.
 4. Apply must-address fixes in a fixup commit (`bot-ack: <id>` in
    the message) or add a `bot-ack` marker to the PR body with a
    short reason.

--- a/docs/operations/review-bot-ack.md
+++ b/docs/operations/review-bot-ack.md
@@ -60,8 +60,9 @@ manifest. The workflow authenticates with `GITHUB_TOKEN`.
 Shepherds:
 
 1. Watch CI to green.
-2. Fetch all configured review-bot comments via the two `gh api`
-   endpoints listed above.
+2. Fetch all configured review-bot artefacts via the three `gh api`
+   endpoints the gate reads: `pulls/<n>/comments`,
+   `issues/<n>/comments`, and `pulls/<n>/reviews`.
 3. Classify into must-address vs informational.
 4. Apply must-address fixes in a fixup commit (`bot-ack: <id>` in
    the message) or add a `bot-ack` marker to the PR body with a


### PR DESCRIPTION
# User description
## What

Step 2 of the Shepherd checklist in `docs/operations/review-bot-ack.md` now names all
three `gh api` endpoints the gate reads, instead of pointing at "the two endpoints
listed above".

## Why

`fetch_comment_sources` in `scripts/review_bot_ack.py` paginates three endpoints:

| Endpoint | Feeds |
|---|---|
| `pulls/<n>/comments` | findings |
| `issues/<n>/comments` | findings |
| `pulls/<n>/reviews` | review-coverage classification |

The checklist listed only the first two, so a shepherd following the doc inspected a
narrower set of inputs than the automation and could not reproduce the reviewed /
not counted / unreviewed outcome by hand.

## How

One-line docs edit. No behaviour change; `scripts/review_bot_ack.py` already reads all
three endpoints.

## Checklist

- [x] `uv run ruff check src/` passes — N/A, docs-only change
- [x] `uv run pyright src/` passes — N/A, docs-only change
- [x] `uv run python scripts/run_tests.py -x` passes — N/A, docs-only change
- [x] New code has type hints — N/A, no code

### Documentation duty (every PR that touches a feature)

- [x] User-visible README section updated (or N/A) — N/A
- [x] `docs/operations/<area>.md` updated — this PR
- [x] `docs/api/` schema regenerated if a public surface changed (or N/A) — N/A
- [x] `uv run bernstein agents-md sync` run (or N/A) — N/A, no new module
- [x] Tests cover the documented behaviour — N/A, no behaviour change

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the Shepherd review-bot ack checklist to name all three <code>gh api</code> endpoints that <code>fetch_comment_sources</code> reads, so manual review matches the gate. Clarify that <code>pulls/&lt;n&gt;/comments</code> and <code>issues/&lt;n&gt;/comments</code> drive severity classification, while <code>pulls/&lt;n&gt;/reviews</code> only feeds review coverage.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>docs(operations): scop...</td><td>August 02, 2026</td></tr>
<tr><td>chernistry</td><td>chore(ci): retire exte...</td><td>August 02, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3357?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>