### PR TITLE
fix(ci): grade review findings by their stated finding type

### DIFF
--- a/docs/operations/review-bot-ack.md
+++ b/docs/operations/review-bot-ack.md
@@ -21,14 +21,10 @@ every review submission. It calls `scripts/review_bot_ack.py`, which:
 1. Fetches inline review-comment threads (`pulls/<n>/comments`) and
    top-level issue comments (`issues/<n>/comments`) authored by the
    configured review-bot accounts (`REVIEW_BOT_LOGINS`).
-2. Classifies each comment into one of two buckets based on the
-   severity tag the bot embeds in the body
-   (`**Potential issue**`, `**issue:**`, `**security:**`,
-   `**suggestion (security):**`, etc.):
-   - `must-address`: bug, security, potential issue,
-     refactor-with-correctness-implication.
-   - `informational`: note, nit, style, refactor suggestion, testing
-     suggestion.
+2. Classifies each comment into `must-address` or `informational`.
+   A structured finding marker, when the body carries one, is
+   authoritative; prose severity headings are the fallback. See
+   [Finding taxonomy](#finding-taxonomy).
 3. Confirms every `must-address` finding is either:
    - Fixed in a commit on the PR branch whose message contains
      `bot-ack: <comment-id>` or `addresses: <comment-id>`, OR
@@ -38,6 +34,49 @@ every review submission. It calls `scripts/review_bot_ack.py`, which:
    `<!-- review-bot-ack-summary: managed -->`) listing open findings.
 5. Exits non-zero if any `must-address` finding is unresolved; that
    non-zero exit fails the `review-bot-ack` check and blocks merge.
+
+### Finding taxonomy
+
+A reviewer that states its category in a machine-readable marker is
+graded from that marker, not from the surrounding prose:
+
+```
+<!--
+_Finding type:_ `Logical Bugs`
+-->
+```
+
+The marker is plural (`_Finding types:_`) when one finding spans
+several categories, and the strictest category wins.
+
+| Finding type | Bucket | Why |
+|---|---|---|
+| `Logical Bugs` | `must-address` | Correctness defect in the change under review. |
+| `Breaking Changes` | `must-address` | Compatibility or contract break for existing callers. |
+| `Verifiable Architecture & Design Review` | `must-address` | Design-level correctness, e.g. a poll loop that runs past its configured deadline. |
+| anything reading as security | `must-address` | Matched on the category name so a renamed or new security category cannot arrive as informational. |
+| `AI Coding Guidelines` | `informational` | Convention and guideline adherence. |
+| `Naming and Typos` | `informational` | Wording, spelling, identifier names. |
+| unmapped category | `must-address` | Fails closed: an untriaged category blocks rather than passing silently. |
+
+Two rules cut across the table:
+
+- **Severity escalates.** A finding the reviewer grades `high` is
+  `must-address` whatever its category. Category alone under-reads - a
+  user-controlled path reaching `unlink()` with no containment check
+  was filed under `AI Coding Guidelines` and graded `high`.
+- **Blocking is not a veto.** A `must-address` finding is cleared by a
+  fixup commit naming it or by a `bot-ack` marker in the PR body, so
+  the effect is that a human states a position on each one.
+
+Bodies with no marker fall back to the prose severity headings other
+bots embed (`**Potential issue**`, `**bug:**`, `**security:**`,
+`nit:`, `**note**`), classified the same two ways.
+
+When the reviewer introduces a category not in the table, the gate
+blocks on it until `MUST_ADDRESS_FINDING_TYPES` /
+`INFORMATIONAL_FINDING_TYPES` in `scripts/review_bot_ack.py` are
+updated to place it.
 
 ### Skipping nit/style findings
 
@@ -79,3 +118,7 @@ Shepherds:
 - `scripts/review_bot_sweep.py` - sweep + manifest renderer.
 - `tests/unit/test_review_bot_ack_workflow_yaml.py` - structural and
   classifier assertions.
+- `tests/unit/scripts/test_review_bot_ack_finding_taxonomy.py` - the
+  finding-type taxonomy, pinned against captured finding bodies.
+- `tests/unit/scripts/test_review_bot_ack_run_detection.py` - per-bot
+  review coverage for the head commit.

--- a/scripts/review_bot_ack.py
+++ b/scripts/review_bot_ack.py
@@ -2,11 +2,14 @@
 """Review-bot acknowledgement gate.
 
 Parses comments the configured review bots (``REVIEW_BOT_LOGINS``) left on a
-PR, classifies each as must-address
-(bug/security/potential-issue/refactor-with-correctness) or informational
-(nit/style/note), and verifies every must-address finding is either
-acknowledged in the PR body via a `<!-- bot-ack: <id> ... -->` marker
-or addressed in a subsequent commit.
+PR, classifies each as must-address or informational, and verifies every
+must-address finding is either acknowledged in the PR body via a
+`<!-- bot-ack: <id> ... -->` marker or addressed in a subsequent commit.
+
+Grading reads a reviewer's structured `_Finding type:_` marker when the body
+carries one (see ``MUST_ADDRESS_FINDING_TYPES``), and otherwise falls back to
+the prose severity headings other bots embed - `**Potential issue**`,
+`**bug:**`, `nit:`.
 
 It also tracks, per configured review bot, whether that bot actually produced
 a review for the current head commit. Zero findings from a bot that was rate
@@ -75,6 +78,82 @@ INFORMATIONAL_PATTERNS = (
     r"refactor suggestion",
     r"\*\*note\*\*",
 )
+
+# --- structured finding markers ---------------------------------------------
+#
+# The patterns above read severity out of prose headings. A reviewer that
+# instead states its category in a machine-readable marker matches none of
+# them, so every finding it files lands in the informational bucket and the
+# gate never blocks. The marker is authoritative when present:
+#
+#     <!--
+#     _Finding type:_ `Logical Bugs`
+#     -->
+#
+# and plural when one finding spans several categories:
+#
+#     <!--
+#     _Finding types:_ `Logical Bugs` `AI Coding Guidelines`
+#     -->
+#
+# Reading the marker rather than the surrounding prose also keeps the grading
+# stable: a finding body ends with a verbatim "Prompt for AI Agents" block that
+# restates the problem in whatever words the reviewer chose, and that text is
+# dense with the terms the prose heuristics match on.
+FINDING_TYPE_RE = re.compile(r"_finding types?:_((?:\s*`[^`]+`)+)", re.IGNORECASE)
+_BACKTICKED_RE = re.compile(r"`([^`]+)`")
+
+# The severity the reviewer itself assigned, read from the badge it renders
+# next to the marker. Anchored on `type=reviewer` so a badge of another kind
+# on the same comment cannot supply the value.
+FINDING_SEVERITY_RE = re.compile(r"type=reviewer&content=[^\s\"']*?&severity=([a-z]+)", re.IGNORECASE)
+
+# Categories that block the gate, and why. Each names a defect that ships
+# broken behaviour if it is merged unexamined, which is exactly the class the
+# acknowledgement contract exists for:
+#
+#   Logical Bugs   - a correctness defect in the change under review.
+#   Breaking Changes - a compatibility or contract break for existing callers.
+#   Verifiable Architecture & Design Review - design-level correctness, e.g. a
+#     poll loop that runs past its configured deadline and eats the budget of
+#     later steps. Filed as design, but the payload is a defect.
+#
+# Blocking is not a veto: an open finding is cleared either by a fixup commit
+# naming it or by a `<!-- bot-ack: <id> reason=... -->` marker in the PR body,
+# so the effect is that a human states a position on each one.
+MUST_ADDRESS_FINDING_TYPES = frozenset(
+    {
+        "logical bugs",
+        "breaking changes",
+        "verifiable architecture & design review",
+    }
+)
+
+# Categories that stay informational: real feedback, but merging without acting
+# on it does not ship a defect. Keeping these non-blocking is deliberate - if a
+# missing relative pronoun required an ack marker, the marker would be routine
+# on every PR and would stop carrying the signal that a human consciously
+# accepted a real defect.
+#
+#   AI Coding Guidelines - convention and guideline adherence.
+#   Naming and Typos     - wording, spelling, identifier names.
+INFORMATIONAL_FINDING_TYPES = frozenset(
+    {
+        "ai coding guidelines",
+        "naming and typos",
+    }
+)
+
+# Severities that block regardless of category. The category alone under-reads:
+# a user-controlled path reaching `unlink()` with no containment check was
+# filed under `AI Coding Guidelines` and graded `high`. Whatever drawer the
+# reviewer files a finding in, its own top severity grade blocks.
+ESCALATING_FINDING_SEVERITIES = frozenset({"high"})
+
+# Substrings that make a category blocking even when it is not enumerated
+# above, so a renamed or newly introduced security category cannot arrive as
+# informational.
+SECURITY_FINDING_TYPE_HINTS = ("security", "vulnerab", "injection")
 
 # Per-bot review coverage for the current head commit. Only BOT_REVIEWED is a
 # clean result: the other three each mean the finding count for that bot is
@@ -211,7 +290,65 @@ def paginate(url: str, token: str) -> list[Any]:
     return out
 
 
+def finding_types(body: str) -> list[str]:
+    """Return every category named by a structured finding marker, lowercased.
+
+    Empty when the body carries no marker - the reviewer's own "addressed by
+    commit X" follow-ups are shaped that way, as is any bot that states
+    severity in prose instead.
+    """
+    out: list[str] = []
+    for match in FINDING_TYPE_RE.finditer(body):
+        for name in _BACKTICKED_RE.findall(match.group(1)):
+            name = name.strip().lower()
+            if name and name not in out:
+                out.append(name)
+    return out
+
+
+def finding_severity(body: str) -> str:
+    """Return the severity the reviewer assigned, or "" when it states none."""
+    match = FINDING_SEVERITY_RE.search(body)
+    return match.group(1).lower() if match else ""
+
+
+def classify_finding_marker(body: str) -> str | None:
+    """Grade a finding from its structured marker, or ``None`` if unmarked.
+
+    Precedence, strictest first:
+
+    1. Any category in :data:`MUST_ADDRESS_FINDING_TYPES`, or one that reads as
+       security, blocks - a finding filed under several categories takes the
+       strictest of them.
+    2. The reviewer's own severity blocks at :data:`ESCALATING_FINDING_SEVERITIES`
+       whatever the category.
+    3. Categories in :data:`INFORMATIONAL_FINDING_TYPES` are advisory.
+    4. Anything else blocks. An unmapped category is one nobody has triaged,
+       and defaulting those to informational is what let a whole reviewer's
+       output pass silently; failing closed makes the next new category
+       announce itself on a pull request instead of being waved through.
+    """
+    types = finding_types(body)
+    if not types:
+        return None
+    if any(name in MUST_ADDRESS_FINDING_TYPES for name in types):
+        return "must-address"
+    if any(hint in name for name in types for hint in SECURITY_FINDING_TYPE_HINTS):
+        return "must-address"
+    if finding_severity(body) in ESCALATING_FINDING_SEVERITIES:
+        return "must-address"
+    if all(name in INFORMATIONAL_FINDING_TYPES for name in types):
+        return "informational"
+    return "must-address"
+
+
 def classify(body: str) -> str:
+    # A structured marker is the reviewer stating its own category, so it wins
+    # over the prose heuristics below, which would otherwise read the verbatim
+    # agent-prompt block appended to every finding.
+    marked = classify_finding_marker(body)
+    if marked is not None:
+        return marked
     low = body.lower()
     is_must = any(re.search(p, low) for p in MUST_ADDRESS_PATTERNS)
     is_info = any(re.search(p, low) for p in INFORMATIONAL_PATTERNS)

--- a/scripts/review_bot_ack.py
+++ b/scripts/review_bot_ack.py
@@ -147,12 +147,24 @@ MUST_ADDRESS_FINDING_TYPES = frozenset(
 # on every PR and would stop carrying the signal that a human consciously
 # accepted a real defect.
 #
-#   AI Coding Guidelines - convention and guideline adherence.
-#   Naming and Typos     - wording, spelling, identifier names.
+#   AI Coding Guidelines       - convention and guideline adherence.
+#   Naming and Typos           - wording, spelling, identifier names.
+#   Code Dedup and Conventions - repetition a refactor would fold together.
+#
+# `Code Dedup and Conventions` is here because the fail-closed rule below
+# worked: it is a category nobody had triaged, it surfaced on the first pull
+# request that drew one, and triaging it is the response that rule is asking
+# for. It reads as conventions, the finding that surfaced it was a
+# factor-out-the-duplicate suggestion graded `low`, and a `high` one is still
+# caught by the severity escalation, so it belongs in the same drawer as the
+# two above. Leaving it unmapped would have blocked a pull request on a
+# duplication nit and taught the operator to apply the ack marker routinely,
+# which is the habit this split exists to avoid.
 INFORMATIONAL_FINDING_TYPES = frozenset(
     {
         "ai coding guidelines",
         "naming and typos",
+        "code dedup and conventions",
     }
 )
 

--- a/scripts/review_bot_ack.py
+++ b/scripts/review_bot_ack.py
@@ -36,11 +36,13 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import html
 import json
 import os
 import re
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 from dataclasses import dataclass, field
 from typing import Any
@@ -104,9 +106,19 @@ FINDING_TYPE_RE = re.compile(r"_finding types?:_((?:\s*`[^`]+`)+)", re.IGNORECAS
 _BACKTICKED_RE = re.compile(r"`([^`]+)`")
 
 # The severity the reviewer itself assigned, read from the badge it renders
-# next to the marker. Anchored on `type=reviewer` so a badge of another kind
+# next to the marker, and scoped to `type=reviewer` so a badge of another kind
 # on the same comment cannot supply the value.
-FINDING_SEVERITY_RE = re.compile(r"type=reviewer&content=[^\s\"']*?&severity=([a-z]+)", re.IGNORECASE)
+#
+# Read by parsing the badge URL's query rather than by matching one fixed
+# parameter order. The order is the reviewer's rendering detail, not a
+# contract: a reordered or re-encoded badge made the severity unreadable, and
+# at the call site an unreadable severity was indistinguishable from a
+# genuinely low one. That silently demoted exactly the case the escalation
+# rule exists for - a `high` finding filed under an informational category -
+# so the gap sat in the escalation path itself. Parsing the query makes the
+# order irrelevant, and an unreadable grade on a badge that IS present now
+# fails closed instead of reading as absent.
+_URL_RE = re.compile(r"https?://[^\s\"'<>]+", re.IGNORECASE)
 
 # Categories that block the gate, and why. Each names a defect that ships
 # broken behaviour if it is merged unexamined, which is exactly the class the
@@ -306,10 +318,40 @@ def finding_types(body: str) -> list[str]:
     return out
 
 
+def reviewer_badge_severities(body: str) -> list[str]:
+    """Return the severity of every reviewer badge in ``body``, in order.
+
+    An entry is ``""`` when that badge carries no readable ``severity``. The
+    caller needs to tell "no reviewer badge at all" (no entries) apart from "a
+    badge whose grade could not be read" (an empty entry): the first is a bot
+    that states no severity, the second is a grade lost in transit, and only
+    the second is a reason to fail closed.
+    """
+    out: list[str] = []
+    for raw_url in _URL_RE.findall(body):
+        # `&amp;` survives into some rendered bodies; without unescaping it the
+        # parameters after the first parse as `amp;content` and `amp;severity`.
+        query = urllib.parse.urlsplit(html.unescape(raw_url)).query
+        params = urllib.parse.parse_qs(query, keep_blank_values=True)
+        if not any(value.strip().lower() == "reviewer" for value in params.get("type", [])):
+            continue
+        graded = [value.strip().lower() for value in params.get("severity", []) if value.strip()]
+        out.append(graded[0] if graded else "")
+    return out
+
+
 def finding_severity(body: str) -> str:
     """Return the severity the reviewer assigned, or "" when it states none."""
-    match = FINDING_SEVERITY_RE.search(body)
-    return match.group(1).lower() if match else ""
+    for severity in reviewer_badge_severities(body):
+        if severity:
+            return severity
+    return ""
+
+
+def has_unreadable_reviewer_severity(body: str) -> bool:
+    """True when a reviewer badge is present but states no readable severity."""
+    severities = reviewer_badge_severities(body)
+    return bool(severities) and not any(severities)
 
 
 def classify_finding_marker(body: str) -> str | None:
@@ -322,8 +364,13 @@ def classify_finding_marker(body: str) -> str | None:
        strictest of them.
     2. The reviewer's own severity blocks at :data:`ESCALATING_FINDING_SEVERITIES`
        whatever the category.
-    3. Categories in :data:`INFORMATIONAL_FINDING_TYPES` are advisory.
-    4. Anything else blocks. An unmapped category is one nobody has triaged,
+    3. A reviewer badge whose severity cannot be read blocks. The reviewer
+       graded that finding and the grade did not survive the round trip;
+       reading the absence as "not high" is the same silent demotion rule 2
+       exists to stop, so an unreadable grade fails closed like an unmapped
+       category does.
+    4. Categories in :data:`INFORMATIONAL_FINDING_TYPES` are advisory.
+    5. Anything else blocks. An unmapped category is one nobody has triaged,
        and defaulting those to informational is what let a whole reviewer's
        output pass silently; failing closed makes the next new category
        announce itself on a pull request instead of being waved through.
@@ -336,6 +383,8 @@ def classify_finding_marker(body: str) -> str | None:
     if any(hint in name for name in types for hint in SECURITY_FINDING_TYPE_HINTS):
         return "must-address"
     if finding_severity(body) in ESCALATING_FINDING_SEVERITIES:
+        return "must-address"
+    if has_unreadable_reviewer_severity(body):
         return "must-address"
     if all(name in INFORMATIONAL_FINDING_TYPES for name in types):
         return "informational"

--- a/tests/unit/scripts/test_review_bot_ack_finding_taxonomy.py
+++ b/tests/unit/scripts/test_review_bot_ack_finding_taxonomy.py
@@ -1,0 +1,267 @@
+"""The gate must block on the finding types the configured reviewer emits.
+
+``scripts/review_bot_ack.py`` splits review-bot comments into must-address and
+informational, and only must-address findings hold the required
+``review-bot-ack`` context. That split was written against severity headings
+embedded in prose (``**Potential issue**``, ``**bug:**``, ``nit:``). The
+reviewer this repository configures does not write those headings: it states
+its category in a machine-readable marker instead, e.g.::
+
+    <!--
+    _Finding type:_ `Logical Bugs`
+    -->
+
+so every finding it files fell through to the informational bucket. The gate
+counted the findings, rendered them in the sticky summary, and exited 0 - a
+correctness defect and a typo were graded identically.
+
+These tests pin the taxonomy against bodies captured verbatim from findings the
+reviewer filed on this repository. They assert both directions: a correctness
+category blocks, and a cosmetic category stays informational, so the fix cannot
+degenerate into "block on any finding" - that would make the ack marker
+mandatory on every typo and train operators to rubber-stamp it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from collections.abc import Generator
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "review_bot_ack.py"
+
+
+@pytest.fixture
+def ack() -> Generator[ModuleType, None, None]:
+    """Load scripts/review_bot_ack.py as an importable module."""
+    spec = importlib.util.spec_from_file_location("review_bot_ack_taxonomy_under_test", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    yield module
+    sys.modules.pop(spec.name, None)
+
+
+def _body(prose: str, marker: str, badge_content: str, severity: str) -> str:
+    """Assemble a finding in the shape the configured reviewer posts them.
+
+    The trailing "Prompt for AI Agents" block is reproduced because it is the
+    bulk of a real body and it is dense with words the prose heuristics look
+    for; a classifier that reads it instead of the marker misgrades findings.
+    """
+    return (
+        f"{prose}\n"
+        f"<!--\n{marker}\n-->\n\n"
+        f'<picture><img src="https://baz.co/api/v2/badges?type=reviewer'
+        f'&content={badge_content}&severity={severity}" alt="Severity" height="24" /></picture>\n\n'
+        "**Baz can fix this** - reply `apply commit` / `apply pr` to fix without changes, "
+        "or comment to modify the plan.\n\n"
+        "<details>\n<summary>Prompt for AI Agents</summary>\n\n"
+        "```text\nBefore applying, verify this suggestion against the current code. "
+        "Two related issues need fixing in this style of block.\n```\n\n"
+        "</details>\n"
+    )
+
+
+# --- bodies captured from findings filed on this repository -----------------
+
+# A release workflow creates its GitHub Release with GITHUB_TOKEN, which does
+# not start follow-up workflows, so Docker/Homebrew/SBOM publication silently
+# never runs. Graded `high` by the reviewer.
+LOGICAL_BUG = _body(
+    "### Major/minor release follow-ups undocumented\n\n"
+    "`docs/operations/release.md` says the Docker/Homebrew/SBOM follow-ups run from either\n"
+    "`publish.yml` or the `release` event, but `release-major-minor.yml` creates the release\n"
+    "with `GITHUB_TOKEN`, which doesn't start new workflows, so those follow-ups never run.\n",
+    "_Finding type:_ `Logical Bugs`",
+    "Logical%20Bugs",
+    "high",
+)
+
+# A watcher documents that a reconcile workflow checks the published version,
+# but the workflow reads a local file, so a republished tag misses a gap.
+BREAKING_CHANGE = _body(
+    "### Handoff notice checks wrong version\n\n"
+    "`copr_build_watch.py` says `reconcile-release.yml` checks the published Copr version,\n"
+    "but the workflow reads `pj_version` from the checked-out `pyproject.toml`.\n",
+    "_Finding type:_ `Breaking Changes`",
+    "Breaking%20Changes",
+    "medium",
+)
+
+# A polling loop starts another fetch with a fixed timeout even when less time
+# remains, so it can run past its configured deadline.
+DESIGN_REVIEW = _body(
+    "### Watcher exceeds configured deadline\n\n"
+    "`watch` starts another `fetch` with `fetch_state`'s fixed 30-second timeout even when\n"
+    "less time remains, so a late poll can run past `deadline_seconds`.\n",
+    "_Finding type:_ `Verifiable Architecture & Design Review`",
+    "Verifiable%20Architecture%20%26%20Design%20Review",
+    "low",
+)
+
+# A missing relative pronoun in a release note.
+NAMING_AND_TYPOS = _body(
+    "### Release note contains grammatical error\n\n"
+    "Could we change ``on a workspace `bernstein init` has just created`` to\n"
+    "``on a workspace that `bernstein init` has just created``?\n",
+    "_Finding type:_ `Naming and Typos`",
+    "Naming%20and%20Typos",
+    "low",
+)
+
+# A checklist in an operations doc fetches two comment endpoints but not the
+# reviews endpoint. A documentation-completeness point, graded `low`.
+GUIDELINES_LOW = _body(
+    "### Shepherd checklist misses review endpoint\n\n"
+    "In the Shepherds checklist, step 2 only fetches `pulls/<n>/comments` and\n"
+    "`issues/<n>/comments`, so the human workflow misses the review artifacts.\n",
+    "_Finding type:_ `AI Coding Guidelines`",
+    "AI%20Coding%20Guidelines",
+    "low",
+)
+
+# Same category, but the finding is a path-traversal hole: a user-controlled
+# pattern reaches `unlink()` with no resolved-path containment check. Graded
+# `high`. This is why the category alone cannot decide the split.
+GUIDELINES_HIGH = _body(
+    "### Overstated file-delete safety in docs\n\n"
+    '`file_remove()` feeds user-controlled `--pattern` into `wt.glob(f"src/**/{pattern}")`\n'
+    "and then calls `target.unlink()` without a resolved-path containment check, so the\n"
+    "promise that `file-remove` won't delete outside the worktree isn't enforced.\n",
+    "_Finding type:_ `AI Coding Guidelines`",
+    "AI%20Coding%20Guidelines",
+    "high",
+)
+
+# The reviewer files one finding under two categories, with a plural marker.
+MULTI_TYPE = _body(
+    "### Shepherds step 3 misstates where severity comes from\n\n"
+    "`Shepherds` step 3 tells operators to classify `pulls/<n>/reviews` into must-address vs\n"
+    "informational, but the gate derives that split from the comment endpoints only.\n",
+    "_Finding types:_ `Logical Bugs` `AI Coding Guidelines`",
+    "Logical%20Bugs%20%C2%B7%20AI%20Coding%20Guidelines",
+    "low",
+)
+
+# The reviewer's own follow-up confirming an earlier finding was applied. It
+# carries no marker and must not be graded as a fresh blocking finding.
+RESOLUTION_REPLY = (
+    "Commit 9a71f38 **addressed** this comment by separating comment severity "
+    "classification from review coverage, explicitly stating that `pulls/<n>/reviews` "
+    "carries no severity and only supplies per-bot head-commit coverage.\n"
+)
+
+
+# --- correctness categories block ------------------------------------------
+
+
+def test_a_logical_bug_finding_is_must_address(ack: ModuleType) -> None:
+    """The reviewer's bug category is what the gate exists to hold PRs on."""
+    assert ack.classify(LOGICAL_BUG) == "must-address"
+
+
+def test_a_breaking_change_finding_is_must_address(ack: ModuleType) -> None:
+    """A compatibility break is a correctness defect, not a suggestion."""
+    assert ack.classify(BREAKING_CHANGE) == "must-address"
+
+
+def test_a_design_review_finding_is_must_address(ack: ModuleType) -> None:
+    """The design category files correctness defects, e.g. a blown deadline."""
+    assert ack.classify(DESIGN_REVIEW) == "must-address"
+
+
+def test_a_multi_type_finding_blocks_when_any_type_blocks(ack: ModuleType) -> None:
+    """A finding filed under several categories takes the strictest one.
+
+    The marker is plural (``_Finding types:_``) with one backticked name per
+    category, so the parser must read all of them, not just the first.
+    """
+    assert ack.classify(MULTI_TYPE) == "must-address"
+
+
+# --- cosmetic categories stay informational --------------------------------
+
+
+def test_a_typo_finding_stays_informational(ack: ModuleType) -> None:
+    """A missing relative pronoun must not require an ack marker to merge.
+
+    If cosmetic findings block, the ack marker becomes routine and stops
+    carrying the signal that a real defect was consciously accepted.
+    """
+    assert ack.classify(NAMING_AND_TYPOS) == "informational"
+
+
+def test_a_low_severity_guidelines_finding_stays_informational(ack: ModuleType) -> None:
+    """Convention adherence is advisory at the severity the reviewer assigns."""
+    assert ack.classify(GUIDELINES_LOW) == "informational"
+
+
+def test_a_resolution_reply_is_not_a_blocking_finding(ack: ModuleType) -> None:
+    """The reviewer's "addressed by commit X" follow-up carries no marker."""
+    assert ack.classify(RESOLUTION_REPLY) == "informational"
+
+
+# --- severity escalates across categories -----------------------------------
+
+
+def test_high_severity_escalates_an_informational_category(ack: ModuleType) -> None:
+    """Category alone under-reads: this one is a path-traversal delete.
+
+    The reviewer filed a user-controlled path reaching ``unlink()`` under its
+    conventions category and graded it `high`. Trusting the category would let
+    it through, so the assigned severity escalates independently.
+    """
+    assert ack.classify(GUIDELINES_HIGH) == "must-address"
+
+
+# --- unmapped categories fail closed ---------------------------------------
+
+
+def test_an_unmapped_finding_type_is_must_address(ack: ModuleType) -> None:
+    """A category nobody has triaged yet blocks rather than passing silently.
+
+    This bug was invisible precisely because unrecognised findings defaulted to
+    informational. Failing closed makes the next new category announce itself
+    on a PR instead of being waved through; the ack marker is the escape hatch
+    while the taxonomy is updated.
+    """
+    unmapped = _body(
+        "### Some newly introduced category\n\nA finding of a kind not yet mapped.\n",
+        "_Finding type:_ `Concurrency Hazards`",
+        "Concurrency%20Hazards",
+        "low",
+    )
+    assert ack.classify(unmapped) == "must-address"
+
+
+def test_every_mapped_category_is_classified_exactly_once(ack: ModuleType) -> None:
+    """No category may be listed as both blocking and informational."""
+    overlap = ack.MUST_ADDRESS_FINDING_TYPES & ack.INFORMATIONAL_FINDING_TYPES
+    assert overlap == frozenset()
+
+
+def test_finding_type_markers_are_read_from_the_whole_body(ack: ModuleType) -> None:
+    """The marker parser returns every category the body names, lowercased."""
+    assert ack.finding_types(MULTI_TYPE) == ["logical bugs", "ai coding guidelines"]
+    assert ack.finding_types(LOGICAL_BUG) == ["logical bugs"]
+    assert ack.finding_types(RESOLUTION_REPLY) == []
+
+
+# --- the prose heuristics still serve bodies with no marker -----------------
+
+
+def test_prose_severity_headings_still_classify(ack: ModuleType) -> None:
+    """Bodies with no marker keep falling back to the heading heuristics.
+
+    The marker path is additive: a reviewer that writes ``**Potential issue**``
+    in prose rather than a structured marker must keep grading as before.
+    """
+    assert ack.classify("**Potential issue**\n\nThis dereferences a null.") == "must-address"
+    assert ack.classify("nit: spacing here") == "informational"

--- a/tests/unit/scripts/test_review_bot_ack_finding_taxonomy.py
+++ b/tests/unit/scripts/test_review_bot_ack_finding_taxonomy.py
@@ -127,6 +127,19 @@ GUIDELINES_LOW = _body(
     "low",
 )
 
+# A composite action repeats one retry flow in both of its branches, so a
+# change to the delay or the pin has to be made twice. A factor-out
+# suggestion, graded `low`.
+CODE_DEDUP = _body(
+    "### Duplicated retry flow can drift\n\n"
+    "The bootstrap action repeats the same `astral-sh/setup-uv` retry flow in both\n"
+    "python-version branches, so changes to the delay, warning text, pin, or cache\n"
+    "flags have to be kept in sync twice.\n",
+    "_Finding type:_ `Code Dedup and Conventions`",
+    "Code%20Dedup%20and%20Conventions",
+    "low",
+)
+
 # Same category, but the finding is a path-traversal hole: a user-controlled
 # pattern reaches `unlink()` with no resolved-path containment check. Graded
 # `high`. This is why the category alone cannot decide the split.
@@ -201,6 +214,30 @@ def test_a_typo_finding_stays_informational(ack: ModuleType) -> None:
 def test_a_low_severity_guidelines_finding_stays_informational(ack: ModuleType) -> None:
     """Convention adherence is advisory at the severity the reviewer assigns."""
     assert ack.classify(GUIDELINES_LOW) == "informational"
+
+
+def test_a_code_dedup_finding_stays_informational(ack: ModuleType) -> None:
+    """Repetition a refactor would fold together is advisory, not a defect.
+
+    This category is mapped because the fail-closed rule surfaced it: it was
+    unmapped, it arrived on a pull request, and triaging it is the response
+    that rule asks for. Leaving it to fail closed would block a change on a
+    duplication nit and make the ack marker routine, which is the habit the
+    must-address / informational split exists to avoid.
+    """
+    assert ack.classify(CODE_DEDUP) == "informational"
+
+
+def test_a_high_severity_code_dedup_finding_still_escalates(ack: ModuleType) -> None:
+    """Mapping the category does not exempt it from the severity rule."""
+    escalated = _body(
+        "### Duplicated flow hides a divergent security check\n\n"
+        "The two copies no longer agree on the containment check.\n",
+        "_Finding type:_ `Code Dedup and Conventions`",
+        "Code%20Dedup%20and%20Conventions",
+        "high",
+    )
+    assert ack.classify(escalated) == "must-address"
 
 
 def test_a_resolution_reply_is_not_a_blocking_finding(ack: ModuleType) -> None:

--- a/tests/unit/scripts/test_review_bot_ack_finding_taxonomy.py
+++ b/tests/unit/scripts/test_review_bot_ack_finding_taxonomy.py
@@ -221,6 +221,89 @@ def test_high_severity_escalates_an_informational_category(ack: ModuleType) -> N
     assert ack.classify(GUIDELINES_HIGH) == "must-address"
 
 
+# --- the escalation path survives the badge's own rendering -----------------
+#
+# Rule 2 above is the only thing standing between a `high` finding filed under
+# an informational category and a silent pass, and it reads its input out of a
+# URL the reviewer renders. Anything that makes that URL unreadable disarms the
+# rule quietly, so the reads below pin the parse against the shapes a URL is
+# allowed to take, and pin the fail-closed behaviour for the shapes it is not.
+
+
+def _reviewer_badge(query: str) -> str:
+    """A guidelines finding whose reviewer badge carries ``query`` verbatim."""
+    return (
+        "### A conventions finding the reviewer graded high\n\n"
+        "<!--\n_Finding type:_ `AI Coding Guidelines`\n-->\n\n"
+        f'<picture><img src="https://baz.co/api/v2/badges?{query}" alt="Severity" height="24" /></picture>\n'
+    )
+
+
+def test_severity_is_read_regardless_of_badge_parameter_order(ack: ModuleType) -> None:
+    """Parameter order is the reviewer's rendering detail, not a contract."""
+    for query in (
+        "type=reviewer&content=AI%20Coding%20Guidelines&severity=high",
+        "severity=high&type=reviewer&content=AI%20Coding%20Guidelines",
+        "content=AI%20Coding%20Guidelines&severity=high&type=reviewer",
+    ):
+        assert ack.finding_severity(_reviewer_badge(query)) == "high", query
+        assert ack.classify(_reviewer_badge(query)) == "must-address", query
+
+
+def test_severity_is_read_through_html_escaped_separators(ack: ModuleType) -> None:
+    """`&amp;` in a rendered body must not hide the grade behind `amp;severity`."""
+    escaped = _reviewer_badge("type=reviewer&amp;content=AI%20Coding%20Guidelines&amp;severity=high")
+    assert ack.finding_severity(escaped) == "high"
+    assert ack.classify(escaped) == "must-address"
+
+
+def test_severity_is_case_insensitive(ack: ModuleType) -> None:
+    """The grade is the reviewer's word, not its capitalisation."""
+    assert ack.finding_severity(_reviewer_badge("type=Reviewer&severity=HIGH")) == "high"
+
+
+def test_a_badge_of_another_kind_cannot_supply_the_severity(ack: ModuleType) -> None:
+    """Only a `type=reviewer` badge grades a finding.
+
+    Scoping by parameter rather than by position has to keep this property: a
+    coverage or build badge sitting in the same body must not be able to raise
+    or lower the reviewer's own grade.
+    """
+    body = (
+        "### A typo\n\n<!--\n_Finding type:_ `Naming and Typos`\n-->\n\n"
+        '<img src="https://example.test/badges?type=coverage&severity=high" alt="Coverage" />\n'
+        '<img src="https://baz.co/api/v2/badges?type=reviewer&content=Naming%20and%20Typos&severity=low" alt="Severity" />\n'
+    )
+    assert ack.finding_severity(body) == "low"
+    assert ack.classify(body) == "informational"
+
+
+def test_an_unreadable_reviewer_grade_fails_closed(ack: ModuleType) -> None:
+    """A reviewer badge with no readable severity blocks rather than passing.
+
+    The reviewer graded the finding; the grade did not survive the round trip.
+    Reading that absence as "not high" is the demotion the escalation rule
+    exists to prevent, so it blocks and the ack marker stays the escape hatch.
+    """
+    for query in (
+        "type=reviewer&content=AI%20Coding%20Guidelines",
+        "type=reviewer&content=AI%20Coding%20Guidelines&severity=",
+    ):
+        assert ack.has_unreadable_reviewer_severity(_reviewer_badge(query)) is True, query
+        assert ack.classify(_reviewer_badge(query)) == "must-address", query
+
+
+def test_a_body_with_no_reviewer_badge_does_not_fail_closed(ack: ModuleType) -> None:
+    """ "No badge" is a bot that states no severity, not a grade lost in transit.
+
+    Failing closed on this instead would block every finding from any reviewer
+    that does not render a badge at all, which is a different bug in the same
+    direction as the one being fixed.
+    """
+    assert ack.has_unreadable_reviewer_severity(NAMING_AND_TYPOS.split("<picture>")[0]) is False
+    assert ack.classify(RESOLUTION_REPLY) == "informational"
+
+
 # --- unmapped categories fail closed ---------------------------------------
 
 


### PR DESCRIPTION
# User description
## What

`scripts/review_bot_ack.py` graded findings by matching severity headings written in prose (`**Potential issue**`, `**bug:**`, `nit:`). The reviewer configured on this repository does not write those headings — it states its category in a machine-readable marker:

```
<!--
_Finding type:_ `Logical Bugs`
-->
```

No prose pattern matches that, so every finding it filed fell through to the informational bucket. Replaying the classifier over the 22 findings currently on this repository's pull requests graded **all 22 informational**, two of which the reviewer itself graded `high`. The gate counted them, listed them in the sticky summary, and exited 0 — a correctness defect and a typo were indistinguishable to the required `review-bot-ack` context.

This reads the marker when a body carries one and keeps the prose headings as the fallback for bodies without one.

## Why this shape

The gate's whole value is that `must-address` means something narrower than "the reviewer said something", so the fix had to restore blocking without flattening the distinction; the obvious cheaper alternative — treat every finding as must-address and drop the classifier — was rejected because it makes the `bot-ack` marker mandatory on every typo, and a marker applied routinely stops carrying the one signal it exists to carry, that a human consciously accepted a real defect. Mapping the categories keeps the escape hatch rare and meaningful. Two rules cut across the mapping: severity escalates independently of category, because a user-controlled path reaching `unlink()` with no containment check was filed under the conventions category and graded `high`, so trusting the category alone would have let it through; and an unrecognised category blocks rather than passing silently, since defaulting unknowns to informational is precisely what made this invisible, and failing closed makes the next new category announce itself on a PR instead of being waved through.

## Mapping

| Finding type | Bucket | Why |
|---|---|---|
| `Logical Bugs` | must-address | Correctness defect in the change under review. |
| `Breaking Changes` | must-address | Compatibility or contract break for existing callers. |
| `Verifiable Architecture & Design Review` | must-address | Design-level correctness, e.g. a poll loop running past its deadline. |
| anything reading as security | must-address | Matched on the name so a renamed or new security category cannot arrive as informational. |
| `AI Coding Guidelines` | informational | Convention and guideline adherence. |
| `Naming and Typos` | informational | Wording, spelling, identifier names. |
| unmapped | must-address | Fails closed until the taxonomy is updated. |

Blocking is not a veto — a finding is cleared by a fixup commit naming it or a `bot-ack` marker in the PR body, so the effect is that a human states a position on each one.

## Effect on real data

Replaying both classifiers over the 22 findings on recent pull requests:

| Finding type | Severity | Before | After | n |
|---|---|---|---|---|
| Logical Bugs | high | informational | **must-address** | 2 |
| Logical Bugs | medium | informational | **must-address** | 1 |
| Logical Bugs | low | informational | **must-address** | 5 |
| Logical Bugs + AI Coding Guidelines | low | informational | **must-address** | 1 |
| Breaking Changes | medium | informational | **must-address** | 1 |
| Verifiable Architecture & Design Review | low | informational | **must-address** | 1 |
| AI Coding Guidelines | high | informational | **must-address** | 1 |
| AI Coding Guidelines | low | informational | informational | 7 |
| Naming and Typos | low | informational | informational | 1 |
| (no marker — resolution replies) | — | informational | informational | 2 |

0 blocking before, 12 blocking after.

## Tests

`tests/unit/scripts/test_review_bot_ack_finding_taxonomy.py` — pinned against finding bodies captured from this repository, asserting both directions (correctness blocks, cosmetic does not), severity escalation, plural multi-category markers, unmapped-fails-closed, and that the prose fallback still grades bodies without a marker. The 8 new assertions fail on the pre-fix classifier.

```
uv run pytest tests/unit -k "review_bot_ack" -q
64 passed
```

## Docs

`docs/operations/review-bot-ack.md` gains a Finding taxonomy section with the mapping table, the two cross-cutting rules, and the note that a new category blocks until the sets in `scripts/review_bot_ack.py` are updated to place it.

No workflow files changed, so ci-topology is untouched.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update <code>review_bot_ack</code> to grade review findings from structured <code>_Finding type_</code> markers before falling back to prose headings, so <code>must-address</code> findings block correctly and unknown categories fail closed. Document the taxonomy in <code>review-bot-ack</code> guidance and add coverage for severity escalation, multi-category markers, and fallback behavior.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3361?tool=ast&topic=Taxonomy+docs>Taxonomy docs</a>
        </td><td>Document the review-bot finding taxonomy, marker syntax, and blocking rules for the <code>review-bot-ack</code> gate.<details><summary>Modified files (1)</summary><ul><li>docs/operations/review-bot-ack.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>fix(ci): grade review ...</td><td>August 03, 2026</td></tr>
<tr><td>chernistry</td><td>docs(operations): name...</td><td>August 03, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3361?tool=ast&topic=Finding+grading>Finding grading</a>
        </td><td>Grade findings from structured markers, escalate high-severity or unmapped categories, and preserve prose-based fallback for older bodies.<details><summary>Modified files (2)</summary><ul><li>scripts/review_bot_ack.py</li>
<li>tests/unit/scripts/test_review_bot_ack_finding_taxonomy.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>fix(ci): map the revie...</td><td>August 03, 2026</td></tr>
<tr><td>chernistry</td><td>chore(ci): retire exte...</td><td>August 02, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3361?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>