### PR TITLE
fix: retry bootstrap's setup-uv call once on a transient fetch failure

### DIFF
--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -4,7 +4,9 @@ description: >
   Must be invoked AFTER actions/checkout, because a local composite action
   cannot resolve until the repository is on the runner. Each caller inlines
   step-security/harden-runner and actions/checkout itself, then calls this
-  composite for Python/uv setup.
+  composite for Python/uv setup. The setup-uv call is retried once after a
+  short sleep if its first attempt fails, to tolerate a transient fetch
+  failure against raw.githubusercontent.com (issue #3360).
 
 inputs:
   python-version:
@@ -32,7 +34,15 @@ runs:
   using: "composite"
   steps:
     - name: Set up uv (with explicit python-version)
+      id: setup-uv-pinned
       if: ${{ inputs.setup-uv == 'true' && inputs.python-version != '' }}
+      # Do not fail the job on the first attempt: a bare `fetch failed`
+      # against raw.githubusercontent.com (setup-uv's own manifest lookup)
+      # is a transient network blip, not a signal about this repo's code.
+      # The retry step below re-runs it once; if that also fails, the
+      # retry step is not marked continue-on-error and the job reddens for
+      # real (issue #3360).
+      continue-on-error: true
       uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       with:
         version: "0.11.32"
@@ -45,8 +55,44 @@ runs:
         # non-zero on the empty cache dir and reddens an otherwise
         # advisory job.
         ignore-nothing-to-cache: "true"
+    - name: Retry set up uv (with explicit python-version) after transient fetch failure
+      if: ${{ inputs.setup-uv == 'true' && inputs.python-version != '' && steps.setup-uv-pinned.outcome == 'failure' }}
+      shell: bash
+      run: |
+        echo "::warning::astral-sh/setup-uv failed on its first attempt (likely a transient raw.githubusercontent.com fetch failure, see issue #3360). Retrying once after a short sleep."
+        sleep 5
+    - name: Set up uv (with explicit python-version, retry)
+      if: ${{ inputs.setup-uv == 'true' && inputs.python-version != '' && steps.setup-uv-pinned.outcome == 'failure' }}
+      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+      with:
+        version: "0.11.32"
+        enable-cache: ${{ inputs.enable-uv-cache }}
+        python-version: ${{ inputs.python-version }}
+        cache-suffix: ${{ inputs.cache-key-suffix }}
+        # See note above on ignore-nothing-to-cache.
+        ignore-nothing-to-cache: "true"
     - name: Set up uv (no python-version pin)
+      id: setup-uv-nopin
       if: ${{ inputs.setup-uv == 'true' && inputs.python-version == '' }}
+      # See note above on continue-on-error: the retry step below handles
+      # a single transient fetch failure; a second failure reddens the job.
+      continue-on-error: true
+      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+      with:
+        version: "0.11.32"
+        enable-cache: ${{ inputs.enable-uv-cache }}
+        cache-suffix: ${{ inputs.cache-key-suffix }}
+        # See note above: keep the post cache-save step from failing a
+        # job that installed no dependencies.
+        ignore-nothing-to-cache: "true"
+    - name: Retry set up uv (no python-version pin) after transient fetch failure
+      if: ${{ inputs.setup-uv == 'true' && inputs.python-version == '' && steps.setup-uv-nopin.outcome == 'failure' }}
+      shell: bash
+      run: |
+        echo "::warning::astral-sh/setup-uv failed on its first attempt (likely a transient raw.githubusercontent.com fetch failure, see issue #3360). Retrying once after a short sleep."
+        sleep 5
+    - name: Set up uv (no python-version pin, retry)
+      if: ${{ inputs.setup-uv == 'true' && inputs.python-version == '' && steps.setup-uv-nopin.outcome == 'failure' }}
       uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       with:
         version: "0.11.32"

--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -72,7 +72,7 @@ runs:
         # See note above on ignore-nothing-to-cache.
         ignore-nothing-to-cache: "true"
     - name: Set up uv (no python-version pin)
-      id: setup-uv-nopin
+      id: setup-uv-no-python-pin
       if: ${{ inputs.setup-uv == 'true' && inputs.python-version == '' }}
       # See note above on continue-on-error: the retry step below handles
       # a single transient fetch failure; a second failure reddens the job.
@@ -86,13 +86,13 @@ runs:
         # job that installed no dependencies.
         ignore-nothing-to-cache: "true"
     - name: Retry set up uv (no python-version pin) after transient fetch failure
-      if: ${{ inputs.setup-uv == 'true' && inputs.python-version == '' && steps.setup-uv-nopin.outcome == 'failure' }}
+      if: ${{ inputs.setup-uv == 'true' && inputs.python-version == '' && steps.setup-uv-no-python-pin.outcome == 'failure' }}
       shell: bash
       run: |
         echo "::warning::astral-sh/setup-uv failed on its first attempt (likely a transient raw.githubusercontent.com fetch failure, see issue #3360). Retrying once after a short sleep."
         sleep 5
     - name: Set up uv (no python-version pin, retry)
-      if: ${{ inputs.setup-uv == 'true' && inputs.python-version == '' && steps.setup-uv-nopin.outcome == 'failure' }}
+      if: ${{ inputs.setup-uv == 'true' && inputs.python-version == '' && steps.setup-uv-no-python-pin.outcome == 'failure' }}
       uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       with:
         version: "0.11.32"

--- a/tests/unit/test_workflow_uv_installers_yaml.py
+++ b/tests/unit/test_workflow_uv_installers_yaml.py
@@ -106,3 +106,46 @@ def test_local_bootstrap_action_pins_setup_uv_version() -> None:
 
     pinned_versions = {cast(str, cast(dict[str, object], step["with"])["version"]) for step in setup_uv_steps}
     assert len(pinned_versions) == 1, "bootstrap setup-uv steps must install the same uv version"
+
+
+def test_local_bootstrap_action_retries_transient_setup_uv_failure() -> None:
+    """A single transient astral-sh/setup-uv fetch failure must not redden the
+    job outright (issue #3360): the primary attempt tolerates one failure via
+    `continue-on-error`, and a retry step re-runs setup-uv once, gated on the
+    primary step's recorded outcome. The retry step itself must not be
+    continue-on-error, so a second consecutive failure genuinely fails the job.
+    """
+    parsed = _load_workflow(BOOTSTRAP_ACTION)
+    runs = parsed.get("runs")
+    assert isinstance(runs, dict)
+    raw_steps = cast(dict[str, object], runs).get("steps")
+    assert isinstance(raw_steps, list)
+    step_list = [cast(dict[str, object], step) for step in cast(list[object], raw_steps) if isinstance(step, dict)]
+
+    primary_steps = [
+        step for step in step_list if str(step.get("uses", "")).startswith("astral-sh/setup-uv@") and step.get("id")
+    ]
+    assert primary_steps, "bootstrap action must have an identifiable (id-tagged) primary setup-uv step"
+
+    for primary in primary_steps:
+        step_id = primary["id"]
+        assert primary.get("continue-on-error") is True, (
+            f"primary setup-uv step {step_id!r} must be continue-on-error so a transient "
+            "fetch failure does not redden the job before a retry gets a chance"
+        )
+
+        failure_guard = f"steps.{step_id}.outcome == 'failure'"
+        retry_steps = [
+            step
+            for step in step_list
+            if step is not primary
+            and str(step.get("uses", "")).startswith("astral-sh/setup-uv@")
+            and failure_guard in str(step.get("if", ""))
+        ]
+        assert retry_steps, f"no retry step gated on `{failure_guard}` found for primary step {step_id!r}"
+
+        for retry in retry_steps:
+            assert retry.get("continue-on-error") is not True, (
+                f"retry step for {step_id!r} must not itself be continue-on-error, "
+                "so a second consecutive setup-uv failure genuinely fails the job"
+            )


### PR DESCRIPTION
# User description
## Why

A transient network fetch that fails before any test runs turns a green PR red for reasons entirely outside the code under review: `astral-sh/setup-uv`'s own manifest lookup against `raw.githubusercontent.com` failed once, and the job died during environment setup, before checkout of test code or a single test. Since every CI job goes through `./.github/actions/bootstrap` for Python/uv setup, this can land on any job, not just the one that happened to hit it. Rejected alternative: retrying the whole job — that's much broader than the actual failure surface (one network call) and would mask a real regression in a later retry attempt just as readily as it papers over a network blip.

## What changed

- `.github/actions/bootstrap/action.yml`: each `astral-sh/setup-uv` step now runs with `continue-on-error: true` and is paired with a gated retry step (short sleep + one re-run) that fires only if the first attempt's outcome was `failure`. The retry step itself is not `continue-on-error`, so two consecutive failures still fail the job for real.
- `tests/unit/test_workflow_uv_installers_yaml.py`: added `test_local_bootstrap_action_retries_transient_setup_uv_failure`, a structural guard asserting the retry step exists and is gated on the primary step's id/outcome. Confirmed it fails against the unmodified action.yml.
- Checked `scripts/gen_workflow_topology.py` / `docs/operations/ci-topology.md`: the topology generator only scans `.github/workflows`, not composite actions under `.github/actions/`, so regenerating it produces no diff — no doc change needed.

## Test plan

- [x] `uv run python -m pytest tests/unit/test_workflow_uv_installers_yaml.py -v` — 11 passed
- [x] New guard test confirmed to fail on unmodified `action.yml`
- [x] `actionlint -shellcheck=` clean on the whole repo
- [x] `uv run ruff check` / `ruff format --check` clean on touched files
- [x] `uv run mypy tests/unit/test_workflow_uv_installers_yaml.py` — no issues

Closes #3360

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Retry the bootstrap composite action’s <code>astral-sh/setup-uv</code> setup so a transient <code>raw.githubusercontent.com</code> fetch failure gets one delayed retry before the job fails for real. Add a unit guard in <code>test_workflow_uv_installers_yaml.py</code> to verify the primary setup step is <code>continue-on-error</code> and the retry is gated on its failure outcome.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3362?tool=ast&topic=Retry+guard+test>Retry guard test</a>
        </td><td>Add a structural unit test that checks the bootstrap action’s primary <code>setup-uv</code> step is <code>continue-on-error</code> and that the retry step only runs after failure.<details><summary>Modified files (1)</summary><ul><li>tests/unit/test_workflow_uv_installers_yaml.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>fix: retry bootstrap&#x27;s...</td><td>August 03, 2026</td></tr>
<tr><td>chernistry</td><td>chore(observability): ...</td><td>July 23, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3362?tool=ast&topic=Bootstrap+retry>Bootstrap retry</a>
        </td><td>Retry <code>setup-uv</code> once after a transient fetch failure in the bootstrap composite action so CI jobs do not fail during environment setup.<details><summary>Modified files (1)</summary><ul><li>.github/actions/bootstrap/action.yml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>chore(ci): name the un...</td><td>August 03, 2026</td></tr>
<tr><td>renovate[bot]</td><td>chore(deps): update de...</td><td>July 31, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3362?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>