### PR TITLE
feat(cli): add --tool flag form to approve/reject (#3141)

### DIFF
--- a/docs/operations/commands.md
+++ b/docs/operations/commands.md
@@ -15,7 +15,7 @@ For session monitoring commands (`live`, `dashboard`, `status`, `ps`, `cost`, `d
 | `bernstein hooks` | Lifecycle hooks for `pre_task`, `post_task`, `pre_merge`, `post_merge`, `pre_spawn`, `post_spawn`; shell scripts or pluggy `@hookimpl`s. `hooks list`, `hooks run <event>`, `hooks check`. |
 | `bernstein chat serve --platform=telegram\|discord\|slack` | Drive runs from chat with `/run`, `/status`, `/approve`, `/reject`, `/switch`, `/stop`. |
 | `bernstein workflow run <name>` | Run a YAML workflow manifest. Also `workflow list`, `workflow init`, `workflow validate`. |
-| `bernstein approve-tool` / `bernstein reject-tool` | Interactive mid-run tool-call approval. `--latest`, `--id`, `--always`. |
+| `bernstein approve-tool` / `bernstein reject-tool` | Interactive mid-run tool-call approval. `--latest`, `--id`, `--always`. Flag form: `approve --tool <id>` / `reject --tool <id>`. |
 | `bernstein autofix` | Daemon that monitors open Bernstein PRs; spawns a fixer agent when CI fails and pushes the repair automatically. |
 | `bernstein preview start` | Sandboxed dev server for the current branch with a shareable public tunnel URL. |
 | `bernstein remote` | SSH sandbox backend. `remote test <host>`, `remote run <host> <path>`, `remote forget <host>`. ControlMaster socket reuse for fast repeat calls. |

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -709,13 +709,13 @@ The group also accepts `--web [host:]port` to run the web view instead of the TU
 | `bernstein mandate` | Verifiable spending mandates as journal-anchored consent receipts (group): `emit` / `verify` / `revoke`. | `cli/commands/mandate_cmd.py` |
 | `bernstein compaction` | Compaction receipt-chain ops (group). | `cli/commands/compaction_cmd.py:32` |
 | `bernstein quarantine` | Quarantined-task ops (group). | `cli/commands/advanced_cmd.py:1120` |
-| `bernstein approve-tool` | Approve a tool-call request. | `cli/commands/approval_cmd.py:approve_tool_cmd` |
-| `bernstein reject-tool` | Reject a tool-call request. | `cli/commands/approval_cmd.py:reject_tool_cmd` |
+| `bernstein approve-tool` | Approve a tool-call request (alias; flag form `approve --tool <id>`). | `cli/commands/approval_cmd.py:approve_tool_cmd` |
+| `bernstein reject-tool` | Reject a tool-call request (alias; flag form `reject --tool <id>`). | `cli/commands/approval_cmd.py:reject_tool_cmd` |
 | `bernstein review-receipt` | Attested PR review receipts binding issue / plan / tool calls / diff (group): `emit` / `verify`. | `cli/commands/review_receipt_cmd.py` |
 | `bernstein gate verify <run>` | Verify a maker-checker / judge-panel gate's signed adjudication record: recompute `inputs_hash` from `--inputs` and confirm the panel saw exactly those inputs, then confirm the spine anchor still verifies. Exit 1 when no record, 2 on mismatch. | `cli/commands/gate_cmd.py` |
 | `bernstein governance verify <run>` | Recompute every RBAC access and per-subject budget decision recorded for a run from the signed spine and confirm the recorded verdicts: re-resolve roles from the signed `--bindings`, re-project spend from the `--ledger`, and match. Exit 1 when no records, 2 on mismatch. | `cli/commands/governance_cmd.py` |
 
-> Task-level `approve` / `reject` are different commands - see [Plan & tasks](#plan-tasks).
+> Task-level `approve` / `reject` are different commands - see [Plan & tasks](#plan-tasks). Both also accept `--tool <id>` to resolve tool-call approvals (the flag form of `approve-tool` / `reject-tool`).
 
 #### `bernstein identity`
 
@@ -884,9 +884,15 @@ advisory-only, `1` on any critical/high finding, `2` when there is no diff.
 Tool-call approval gate. When an agent requests a sensitive tool call (network egress, file write outside its worktree, exec outside its sandbox), the orchestrator pauses and writes a request to `.sdd/runtime/tool_approvals/`. Resolve with these commands.
 
 ```bash
-bernstein approve-tool <request_id>
-bernstein reject-tool  <request_id>
+bernstein approve-tool --id <request_id>
+bernstein reject-tool  --id <request_id>
+# Flag form (the aliases above stay registered through the 3.10 line,
+# unregistered in 4.0.0):
+bernstein approve --tool <request_id>
+bernstein reject --tool <request_id>
 ```
+
+With no identifier, the oldest pending approval is resolved.
 
 ---
 

--- a/docs/reference/cli/task-lifecycle.md
+++ b/docs/reference/cli/task-lifecycle.md
@@ -139,7 +139,7 @@ bernstein reject  TASK_ID [--workdir .]
 
 Both commands are file-only: they write `.sdd/runtime/approvals/<id>.approved` or `.rejected`. The orchestrator's next tick picks the file up, transitions the task (merge on approve, cleanup on reject), and removes the file. **Approval and rejection are both idempotent** - the orchestrator scrubs duplicates.
 
-> **Not the same as `bernstein approve-tool` / `bernstein reject-tool`.** Those resolve **tool-call** approvals (a single tool invocation by a running agent). The lifecycle approve/reject above resolves a **whole task's verification** review. See `cli/commands/approval_cmd.py` for the tool-call variants.
+> **Not the same as `bernstein approve-tool` / `bernstein reject-tool`.** Those resolve **tool-call** approvals (a single tool invocation by a running agent) and are also reachable as `bernstein approve --tool <id>` / `bernstein reject --tool <id>`. The lifecycle approve/reject above resolves a **whole task's verification** review. See `cli/commands/approval_cmd.py` for the tool-call variants.
 
 ---
 

--- a/src/bernstein/cli/commands/approval_cmd.py
+++ b/src/bernstein/cli/commands/approval_cmd.py
@@ -78,7 +78,7 @@ def approve_tool_cmd(
     always: bool,
     workdir: str,
 ) -> None:
-    """Approve a pending tool-call approval (op-002).
+    """Approve a pending tool-call approval.
 
     Pops the oldest pending approval from ``.sdd/runtime/approvals/`` and
     records an ``allow`` decision. Pass ``--latest`` to resolve the most
@@ -91,6 +91,21 @@ def approve_tool_cmd(
       bernstein approve-tool
       bernstein approve-tool --always
       bernstein approve-tool --id ap-1a2b3c4d5e6f
+    """
+    approve_tool(latest=latest, approval_id=approval_id, always=always, workdir=workdir)
+
+
+def approve_tool(
+    *,
+    latest: bool,
+    approval_id: str | None,
+    always: bool,
+    workdir: str,
+) -> None:
+    """Resolve a pending tool-call approval.
+
+    Shared implementation behind the ``approve-tool`` command and the
+    ``bernstein approve --tool <id>`` flag form.
     """
     queue = _queue_for(workdir)
     approval = _select_approval(queue, latest=latest, approval_id=approval_id)
@@ -131,7 +146,7 @@ def reject_tool_cmd(
     approval_id: str | None,
     workdir: str,
 ) -> None:
-    """Reject a pending tool-call approval (op-002).
+    """Reject a pending tool-call approval.
 
     Records a ``reject`` decision so the blocked agent surfaces a
     permission error. With no flags the oldest pending approval is
@@ -141,6 +156,20 @@ def reject_tool_cmd(
     Examples:
       bernstein reject-tool
       bernstein reject-tool --id ap-1a2b3c4d5e6f
+    """
+    reject_tool(latest=latest, approval_id=approval_id, workdir=workdir)
+
+
+def reject_tool(
+    *,
+    latest: bool,
+    approval_id: str | None,
+    workdir: str,
+) -> None:
+    """Resolve a pending tool-call approval as rejected.
+
+    Shared implementation behind the ``reject-tool`` command and the
+    ``bernstein reject --tool <id>`` flag form.
     """
     queue = _queue_for(workdir)
     approval = _select_approval(queue, latest=latest, approval_id=approval_id)
@@ -156,4 +185,4 @@ def reject_tool_cmd(
     console.print(f"[red]Rejected {approval.id}[/]")
 
 
-__all__ = ["approve_tool_cmd", "reject_tool_cmd"]
+__all__ = ["approve_tool", "approve_tool_cmd", "reject_tool", "reject_tool_cmd"]

--- a/src/bernstein/cli/commands/approve_cmd.py
+++ b/src/bernstein/cli/commands/approve_cmd.py
@@ -125,8 +125,7 @@ def approve(task_id: str | None, workdir: str, prompt: bool, tool_id: str | None
 
     if task_id is None:
         raise click.UsageError(
-            "Missing argument 'TASK_ID'; pass a task id, or --tool <id> "
-            "to resolve a pending tool-call approval."
+            "Missing argument 'TASK_ID'; pass a task id, or --tool <id> to resolve a pending tool-call approval."
         )
 
     from bernstein.core.orchestration.approval_gate import UnsafeApprovalIdError, approval_path

--- a/src/bernstein/cli/commands/approve_cmd.py
+++ b/src/bernstein/cli/commands/approve_cmd.py
@@ -78,7 +78,7 @@ def _foreground_confirm(prompt: str) -> bool:
 
 
 @click.command("approve")
-@click.argument("task_id")
+@click.argument("task_id", required=False)
 @click.option(
     "--workdir",
     default=".",
@@ -91,7 +91,13 @@ def _foreground_confirm(prompt: str) -> bool:
     show_default=True,
     help="Foreground TTY prompts confirm before writing the sentinel.",
 )
-def approve(task_id: str, workdir: str, prompt: bool) -> None:
+@click.option(
+    "--tool",
+    "tool_id",
+    default=None,
+    help="Resolve a pending tool-call approval by id instead of a task (flag form of ``approve-tool``).",
+)
+def approve(task_id: str | None, workdir: str, prompt: bool, tool_id: str | None) -> None:
     """Approve a pending task (review gate or pre-spawn approval gate).
 
     Writes a ``<task_id>.approved`` decision file under
@@ -102,10 +108,27 @@ def approve(task_id: str, workdir: str, prompt: bool) -> None:
     creates the file, subsequent invocations report ``already resolved``
     and exit without rewriting state.
 
+    Pass ``--tool <id>`` instead to resolve a pending tool-call approval
+    from the interactive approval queue; ``approve-tool`` remains as an
+    alias for this flag form.
+
     \b
-    Example:
+    Examples:
       bernstein approve T-abc123
+      bernstein approve --tool ap-1a2b3c4d5e6f
     """
+    if tool_id is not None:
+        from bernstein.cli.commands.approval_cmd import approve_tool
+
+        approve_tool(latest=False, approval_id=tool_id, always=False, workdir=workdir)
+        return
+
+    if task_id is None:
+        raise click.UsageError(
+            "Missing argument 'TASK_ID'; pass a task id, or --tool <id> "
+            "to resolve a pending tool-call approval."
+        )
+
     from bernstein.core.orchestration.approval_gate import UnsafeApprovalIdError, approval_path
 
     # The decision file name is derived from task_id, so the id goes through the

--- a/src/bernstein/cli/commands/reject_cmd.py
+++ b/src/bernstein/cli/commands/reject_cmd.py
@@ -19,7 +19,7 @@ from bernstein.cli.helpers import console
 
 
 @click.command("reject")
-@click.argument("task_id")
+@click.argument("task_id", required=False)
 @click.option(
     "--workdir",
     default=".",
@@ -32,7 +32,13 @@ from bernstein.cli.helpers import console
     show_default=True,
     help="Foreground TTY prompts confirm before writing the sentinel.",
 )
-def reject(task_id: str, workdir: str, prompt: bool) -> None:
+@click.option(
+    "--tool",
+    "tool_id",
+    default=None,
+    help="Resolve a pending tool-call approval by id instead of a task (flag form of ``reject-tool``).",
+)
+def reject(task_id: str | None, workdir: str, prompt: bool, tool_id: str | None) -> None:
     """Reject a pending task (review gate or pre-spawn approval gate).
 
     Writes a ``<task_id>.rejected`` decision file under
@@ -44,10 +50,27 @@ def reject(task_id: str, workdir: str, prompt: bool) -> None:
     creates the file, subsequent invocations exit with ``already
     resolved``.
 
+    Pass ``--tool <id>`` instead to refuse a pending tool-call approval
+    from the interactive approval queue; ``reject-tool`` remains as an
+    alias for this flag form.
+
     \b
-    Example:
+    Examples:
       bernstein reject T-abc123
+      bernstein reject --tool ap-1a2b3c4d5e6f
     """
+    if tool_id is not None:
+        from bernstein.cli.commands.approval_cmd import reject_tool
+
+        reject_tool(latest=False, approval_id=tool_id, workdir=workdir)
+        return
+
+    if task_id is None:
+        raise click.UsageError(
+            "Missing argument 'TASK_ID'; pass a task id, or --tool <id> "
+            "to resolve a pending tool-call approval."
+        )
+
     from bernstein.core.orchestration.approval_gate import UnsafeApprovalIdError, approval_path
 
     # Same rule as the approve and read sides; validated before mkdir.

--- a/src/bernstein/cli/commands/reject_cmd.py
+++ b/src/bernstein/cli/commands/reject_cmd.py
@@ -67,8 +67,7 @@ def reject(task_id: str | None, workdir: str, prompt: bool, tool_id: str | None)
 
     if task_id is None:
         raise click.UsageError(
-            "Missing argument 'TASK_ID'; pass a task id, or --tool <id> "
-            "to resolve a pending tool-call approval."
+            "Missing argument 'TASK_ID'; pass a task id, or --tool <id> to resolve a pending tool-call approval."
         )
 
     from bernstein.core.orchestration.approval_gate import UnsafeApprovalIdError, approval_path

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -1174,7 +1174,8 @@ cli.add_command(aliases_cmd, "aliases")
 cli.add_command(debug_cmd, "debug-bundle")
 
 # op-002: interactive tool-call approval (approve-tool / reject-tool).
-# These are the tool-call resolvers; task-level ``approve``/``reject`` live in task_cmd.
+# These are the tool-call resolvers; task-level ``approve``/``reject`` live in
+# approve_cmd/reject_cmd and also accept ``--tool <id>`` for this queue.
 cli.add_command(approve_tool_cmd, "approve-tool")
 cli.add_command(reject_tool_cmd, "reject-tool")
 # ``bernstein debug`` is the structured diagnostics group; ``debug bundle``

--- a/tests/unit/test_approval_cli.py
+++ b/tests/unit/test_approval_cli.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from click.testing import CliRunner
 
 from bernstein.cli.commands.approval_cmd import approve_tool_cmd, reject_tool_cmd
+from bernstein.cli.commands.approve_cmd import approve
+from bernstein.cli.commands.reject_cmd import reject
 from bernstein.core.approval.models import PendingApproval
 from bernstein.core.approval.queue import ApprovalQueue
 
@@ -123,3 +125,100 @@ def test_reject_tool_handles_empty_queue(tmp_path: Path) -> None:
     result = runner.invoke(reject_tool_cmd, ["--workdir", str(tmp_path)])
     assert result.exit_code == 0
     assert "No pending approvals" in result.output
+
+
+# --- flag form: ``approve --tool <id>`` / ``reject --tool <id>`` (issue #3141) ---
+
+
+def test_approve_flag_form_resolves_tool_approval(tmp_path: Path) -> None:
+    queue = _queue_at(tmp_path)
+    first = queue.push(
+        PendingApproval(session_id="S", agent_role="backend", tool_name="shell", tool_args={"command": "ls"})
+    )
+    target = queue.push(
+        PendingApproval(session_id="S", agent_role="backend", tool_name="shell", tool_args={"command": "pwd"})
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(approve, ["--tool", target.id, "--workdir", str(tmp_path)])
+
+    assert result.exit_code == 0, result.output
+    reopened = ApprovalQueue(base_dir=queue.base_dir)
+    resolved = reopened.get_resolution(target.id)
+    assert resolved is not None
+    assert resolved.decision.value == "allow"
+    # The non-targeted approval is untouched: the identifier was parsed as an
+    # approval id, not resolved as the oldest entry.
+    assert reopened.get_resolution(first.id) is None
+
+
+def test_approve_flag_form_matches_alias_semantics(tmp_path: Path) -> None:
+    # Equivalence: ``approve --tool <id>`` must resolve identically to
+    # ``approve-tool --id <id>`` (same identifier, same decision, same exit code).
+    def run(cmd, args):
+        return CliRunner().invoke(cmd, args)
+
+    q_alias = _queue_at(tmp_path)
+    a_alias = q_alias.push(
+        PendingApproval(session_id="S", agent_role="backend", tool_name="shell", tool_args={"command": "ls"})
+    )
+    r_alias = run(approve_tool_cmd, ["--workdir", str(tmp_path), "--id", a_alias.id])
+
+    q_flag = _queue_at(tmp_path)
+    a_flag = q_flag.push(
+        PendingApproval(session_id="S", agent_role="backend", tool_name="shell", tool_args={"command": "ls"})
+    )
+    r_flag = run(approve, ["--workdir", str(tmp_path), "--tool", a_flag.id])
+
+    assert r_flag.exit_code == r_alias.exit_code == 0, (r_flag.output, r_alias.output)
+    res_alias = ApprovalQueue(base_dir=q_alias.base_dir).get_resolution(a_alias.id)
+    res_flag = ApprovalQueue(base_dir=q_flag.base_dir).get_resolution(a_flag.id)
+    assert res_alias is not None and res_flag is not None
+    assert res_flag.decision.value == res_alias.decision.value == "allow"
+
+
+def test_approve_flag_form_unknown_id_fails(tmp_path: Path) -> None:
+    queue = _queue_at(tmp_path)
+    queue.push(
+        PendingApproval(session_id="S", agent_role="backend", tool_name="shell", tool_args={"command": "ls"})
+    )
+
+    result = CliRunner().invoke(approve, ["--tool", "ap-unknown", "--workdir", str(tmp_path)])
+
+    # Same exit code as ``approve-tool --id ap-unknown``.
+    assert result.exit_code == 1
+    assert "ap-unknown" in result.output
+
+
+def test_reject_flag_form_records_reject(tmp_path: Path) -> None:
+    queue = _queue_at(tmp_path)
+    approval = queue.push(
+        PendingApproval(session_id="S", agent_role="backend", tool_name="shell", tool_args={"command": "rm -rf /"})
+    )
+
+    result = CliRunner().invoke(reject, ["--tool", approval.id, "--workdir", str(tmp_path)])
+
+    assert result.exit_code == 0, result.output
+    resolved_file = queue.base_dir / f"{approval.id}.resolved.json"
+    assert resolved_file.exists()
+    assert json.loads(resolved_file.read_text())["decision"] == "reject"
+
+
+def test_approve_without_task_or_tool_is_usage_error(tmp_path: Path) -> None:
+    result = CliRunner().invoke(approve, ["--workdir", str(tmp_path)])
+    assert result.exit_code == 2
+    assert "TASK_ID" in result.output
+
+
+def test_reject_without_task_or_tool_is_usage_error(tmp_path: Path) -> None:
+    result = CliRunner().invoke(reject, ["--workdir", str(tmp_path)])
+    assert result.exit_code == 2
+    assert "TASK_ID" in result.output
+
+
+def test_help_strings_have_no_internal_references() -> None:
+    # (op-002) is an internal reference a user cannot resolve from --help.
+    for cmd in (approve_tool_cmd, reject_tool_cmd, approve, reject):
+        result = CliRunner().invoke(cmd, ["--help"])
+        assert result.exit_code == 0, result.output
+        assert "(op-002)" not in result.output

--- a/tests/unit/test_approval_cli.py
+++ b/tests/unit/test_approval_cli.py
@@ -179,9 +179,7 @@ def test_approve_flag_form_matches_alias_semantics(tmp_path: Path) -> None:
 
 def test_approve_flag_form_unknown_id_fails(tmp_path: Path) -> None:
     queue = _queue_at(tmp_path)
-    queue.push(
-        PendingApproval(session_id="S", agent_role="backend", tool_name="shell", tool_args={"command": "ls"})
-    )
+    queue.push(PendingApproval(session_id="S", agent_role="backend", tool_name="shell", tool_args={"command": "ls"}))
 
     result = CliRunner().invoke(approve, ["--tool", "ap-unknown", "--workdir", str(tmp_path)])
 


### PR DESCRIPTION
## What

`bernstein approve --tool <id>` / `bernstein reject --tool <id>` become the canonical way to resolve a pending tool-call approval. `approve-tool` / `reject-tool` stay registered as aliases (kept through the 3.10 line, unregistered in 4.0.0 per #3147).

## Why

Closes #3141. Approval was split by object type into separate top-level names (`approve`, `reject`, `approve-tool`, `reject-tool`); making the object type a flag reduces four names to two.

## How

- Extracted the resolution logic in `cli/commands/approval_cmd.py` into `approve_tool()` / `reject_tool()` shared by the alias commands and the flag form, so the two surfaces cannot drift apart.
- `approve` / `reject` now take an optional `TASK_ID` plus `--tool <id>`. The flag form parses the identifier identically to `approve-tool --id <id>` and produces the same exit codes (0 resolved / 1 unknown id / 2 usage).
- Stripped the internal `(op-002)` reference from both command help strings, as requested.
- `--latest` / `--always` remain on the alias commands; folding them into the flag form can happen when the aliases are removed in 4.0.0.

## Checklist

- [x] `uv run ruff check src/` passes (also checked the touched test file)
- [x] mypy clean on the 3 touched source modules
- [ ] pyright not run in this environment
- [x] `pytest tests/unit/test_approval_cli.py` - 14 passed (7 existing + 7 new covering the flag form, equivalence with the alias, exit codes, and help strings)
- [x] New code has type hints

### Documentation duty

- [x] `docs/reference/cli-reference.md`, `docs/operations/commands.md`, `docs/reference/cli/task-lifecycle.md` updated (flag form documented)
- [ ] `docs/api/` schema regenerated - N/A (no API surface change)
- [x] Tests cover the documented behaviour

---

Disclosure: this change was authored with assistance from an AI coding agent (Hermes Agent, Mike profile). All changes were reviewed against the issue's acceptance criteria before submission.
