### PR TITLE
docs: regenerate adapter last-green table from canary receipts

### DIFF
--- a/docs/adapters/conformance-canary.md
+++ b/docs/adapters/conformance-canary.md
@@ -118,14 +118,14 @@ frozen adapter locally, not only in this table.
 | Adapter | Binary | Last-green version | Verified | Receipt |
 |---|---|---|---|---|
 | agy | `agy` | 1.0.0 | 2026-07-11T05:57:23Z (stale) | `006fb946868d` |
-| claude | `claude` | 2.1.220 | 2026-08-02T07:28:46Z | `9db1a791c3b8` |
-| codex | `codex` | 0.146.0 | 2026-08-02T07:28:46Z | `80f373cad469` |
-| copilot | `copilot` | 1.0.77 | 2026-08-02T07:28:46Z | `78f785bfe404` |
-| gemini | `gemini` | 0.53.1 | 2026-08-02T07:28:46Z | `2d5ee176fab9` |
-| kimi | `kimi` | 1.49.0 | 2026-08-02T07:28:46Z | `f625894af6bb` |
-| opencode | `opencode` | 1.18.11 | 2026-08-02T07:28:46Z | `3aa825e89830` |
-| pydantic_ai | `clai` | 2.22.0 | 2026-08-02T07:28:46Z | `fc56cbb2f915` |
-| qwen | `qwen` | 0.21.3 | 2026-08-02T07:28:46Z | `0b5339d156b8` |
+| claude | `claude` | 2.1.220 | 2026-08-03T08:22:35Z | `89b14db55dfc` |
+| codex | `codex` | 0.146.0 | 2026-08-03T08:22:35Z | `83d79ea56020` |
+| copilot | `copilot` | 1.0.77 | 2026-08-03T08:22:35Z | `38276b234dd8` |
+| gemini | `gemini` | 0.53.1 | 2026-08-03T08:22:35Z | `ac2d42d07c11` |
+| kimi | `kimi` | 1.49.0 | 2026-08-03T08:22:35Z | `9c16955bcdd1` |
+| opencode | `opencode` | 1.18.11 | 2026-08-03T08:22:35Z | `8891fa5dfce7` |
+| pydantic_ai | `clai` | 2.22.0 | 2026-08-03T08:22:35Z | `443d6373221e` |
+| qwen | `qwen` | 0.21.4 | 2026-08-03T08:22:35Z | `e65581b298b5` |
 <!-- last-green:end -->
 
 ## Operator knobs

--- a/src/bernstein/adapters/last_green.json
+++ b/src/bernstein/adapters/last_green.json
@@ -8,51 +8,51 @@
     },
     "claude": {
       "binary": "claude",
-      "receipt_sha256": "9db1a791c3b8326ad364f5d889c1754720a2d9937396760aa9df9bc965b75e9b",
-      "recorded_at": "2026-08-02T07:28:46Z",
+      "receipt_sha256": "89b14db55dfc4c3ef9285a0df9edfbbbf00b8d85ca8150f53c38b1b4f8c7e92a",
+      "recorded_at": "2026-08-03T08:22:35Z",
       "version": "2.1.220"
     },
     "codex": {
       "binary": "codex",
-      "receipt_sha256": "80f373cad469166a700c9f9b625f38c41fc321fe98587edc1190be9e6f7d4c69",
-      "recorded_at": "2026-08-02T07:28:46Z",
+      "receipt_sha256": "83d79ea5602099629d149c4502da062755dd0a65375c9f3571b203fcaaf3247d",
+      "recorded_at": "2026-08-03T08:22:35Z",
       "version": "0.146.0"
     },
     "copilot": {
       "binary": "copilot",
-      "receipt_sha256": "78f785bfe4043c7563c15e1388ae70d1d4db11d9edb34cf7b599846a8efd007e",
-      "recorded_at": "2026-08-02T07:28:46Z",
+      "receipt_sha256": "38276b234dd8209a7b183035e6f400676a41fbfbd1b2a6ec44a270f2461130bd",
+      "recorded_at": "2026-08-03T08:22:35Z",
       "version": "1.0.77"
     },
     "gemini": {
       "binary": "gemini",
-      "receipt_sha256": "2d5ee176fab91b695bfd2df92ab2b943de87e06b631a7bb64ba4d4ae58ba6b06",
-      "recorded_at": "2026-08-02T07:28:46Z",
+      "receipt_sha256": "ac2d42d07c11e2e36411f795b5f2f472113640e33b0668efd5b0baa2fb0c1ed5",
+      "recorded_at": "2026-08-03T08:22:35Z",
       "version": "0.53.1"
     },
     "kimi": {
       "binary": "kimi",
-      "receipt_sha256": "f625894af6bb0ddde932cba9014641a03e8772a9ae193bfd01553c9d110193e9",
-      "recorded_at": "2026-08-02T07:28:46Z",
+      "receipt_sha256": "9c16955bcdd16f47d2695e933f2f4c44ac948fbb4cc333c99448d639098f0f1b",
+      "recorded_at": "2026-08-03T08:22:35Z",
       "version": "1.49.0"
     },
     "opencode": {
       "binary": "opencode",
-      "receipt_sha256": "3aa825e89830216d2b45ab9cae4af4579f3fee2dd0dcf65ba17bfcfb23d1f562",
-      "recorded_at": "2026-08-02T07:28:46Z",
+      "receipt_sha256": "8891fa5dfce7ec91cabc4714d0c2ddb202de96f7c5a6ec77bc5dd67f15049458",
+      "recorded_at": "2026-08-03T08:22:35Z",
       "version": "1.18.11"
     },
     "pydantic_ai": {
       "binary": "clai",
-      "receipt_sha256": "fc56cbb2f915c9ea47e83dcf50273a496e23a09834e4994e043a896a23e686c6",
-      "recorded_at": "2026-08-02T07:28:46Z",
+      "receipt_sha256": "443d6373221e862ca0f50bf157f66db1769980bdf0b188b17eb77f6b8bdb16e2",
+      "recorded_at": "2026-08-03T08:22:35Z",
       "version": "2.22.0"
     },
     "qwen": {
       "binary": "qwen",
-      "receipt_sha256": "0b5339d156b86fede2e50ae5baded31e196fd608714109c916dc74d12c5f9d33",
-      "recorded_at": "2026-08-02T07:28:46Z",
-      "version": "0.21.3"
+      "receipt_sha256": "e65581b298b5d3f846f4c8e0b3b2d92c0c4e6ff20d5bd3b3bbbc7908116b80a1",
+      "recorded_at": "2026-08-03T08:22:35Z",
+      "version": "0.21.4"
     }
   },
   "schema_version": 1


### PR DESCRIPTION
# User description
Nightly adapter conformance canary regeneration of the per-adapter last-green projection (packaged last_green.json + the docs table). Every row is anchored to the receipt that attested it; receipts for this run are attached to the workflow run as artifacts.

Workflow run: https://github.com/sipyourdrink-ltd/bernstein/actions/runs/30796740934

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Regenerate the adapter last-green projection in <code>last_green.json</code> from the latest canary receipts. Update the conformance table in the adapter docs so each row matches the recorded receipt, timestamp, and version, including the new <code>qwen</code> value.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>canary@users.noreply.g...</td><td>docs: regenerate adapt...</td><td>August 03, 2026</td></tr>
<tr><td>chernistry</td><td>docs: regenerate adapt...</td><td>August 03, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3364?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>