### PR TITLE
docs: record a new editorial mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ i wrote bernstein because i was paying $400/month in claude bills running three 
 
 ### mentioned in
 
-Listed in [vinta/awesome-python](https://github.com/vinta/awesome-python), covered in Augment Code's [open-source agent orchestrators](https://www.augmentcode.com/tools/open-source-agent-orchestrators) roundup, cited by [awesome-agentic-patterns](https://github.com/nibzard/awesome-agentic-patterns/blob/main/patterns/deterministic-zero-llm-orchestration.md) as the production implementation of deterministic zero-LLM orchestration, and featured in [Python Weekly #742](https://www.pythonweekly.com/p/python-weekly-issue-742-april-23-2026).
+Listed in [vinta/awesome-python](https://github.com/vinta/awesome-python), covered in Augment Code's [open-source agent orchestrators](https://www.augmentcode.com/tools/open-source-agent-orchestrators) roundup, cited by [awesome-agentic-patterns](https://github.com/nibzard/awesome-agentic-patterns/blob/main/patterns/deterministic-zero-llm-orchestration.md) as the production implementation of deterministic zero-LLM orchestration, featured in [Python Weekly #742](https://www.pythonweekly.com/p/python-weekly-issue-742-april-23-2026), and ranked as the orchestration layer in a ten-repo [Claude Code agent-system breakdown](https://x.com/Granite0x/status/2080665298609328201).
 
 <details>
 <summary>All coverage: 20+ awesome lists, directories, newsletters, and peer citations</summary>

--- a/docs/mentions.md
+++ b/docs/mentions.md
@@ -13,6 +13,7 @@ when they appear; if one goes dead, open an issue or a PR.
 ## Editorial coverage
 
 - [Augment Code - 9 Open-Source Agent Orchestrators for AI Coding (2026)](https://www.augmentcode.com/tools/open-source-agent-orchestrators): editorial roundup.
+- [A Graph of Loops: Build a Full Claude Code Agent System From GitHub](https://x.com/Granite0x/status/2080665298609328201): ten-repo architecture breakdown; Bernstein ranked G1, the orchestration layer, with the scheduler source read directly.
 - [nibzard/awesome-agentic-patterns](https://github.com/nibzard/awesome-agentic-patterns/blob/main/patterns/deterministic-zero-llm-orchestration.md): Bernstein cited as the production implementation of the "deterministic zero-LLM orchestration" pattern.
 - [Python Weekly](https://www.pythonweekly.com/p/python-weekly-issue-742-april-23-2026): newsletter mention.
 - [Future Digest](https://futuredigestnews.substack.com/p/your-claude-bill-just-hit-874-heres): cost-cutting playbook write-up.


### PR DESCRIPTION
# User description
Adds a ten-repo architecture breakdown that covers the scheduler to docs/mentions.md and the README's mentioned-in line, following the existing entry format.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update <code>docs/mentions.md</code> and the README&#x27;s <code>mentioned in</code> section to add a new editorial mention and keep the public coverage list in sync. Record the ten-repo Claude Code agent-system breakdown that ranks Bernstein&#x27;s G1 orchestration layer and references the scheduler source.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>viktorshpuktor@gmail.com</td><td>docs: record a new edi...</td><td>August 03, 2026</td></tr>
<tr><td>chernistry</td><td>fix: stumbles on the d...</td><td>August 01, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3365?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>