### PR TITLE
feat(security): anchor signed agent identity to each run

### DIFF
--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -30,11 +30,15 @@ locally without waiting for the cloud runner.
 | **coverage ratchet** (LEVEL 2) | Total coverage dropped below the committed high-water mark      | push to main (advisory) |
 | **import-linter**           | Architecture-contract violations (cross-package imports)          | PR                  |
 | **No-network guard**        | Unit tests that open a real outbound connection (flaky by design) | PR (every unit run) |
+| **Spawned-process identity race** | Duplicate run identities hidden by thread-only locking      | PR (identity anchor unit suite) |
 | **ruff** + **typos**        | Lint, format drift, common typos                                  | PR                  |
 
 ## Run any of the above locally
 
 ```bash
+# Identity anchoring, including a real two-process race against one audit dir
+uv run pytest tests/unit/security/test_identity_spawn_anchor.py -q --no-cov
+
 # Property suite (smoke)
 HYPOTHESIS_PROFILE=smoke uv run pytest tests/property/ -q --no-cov
 

--- a/docs/sdd/identity-spawn-anchor.md
+++ b/docs/sdd/identity-spawn-anchor.md
@@ -1,0 +1,43 @@
+# Identity spawn anchor
+
+## Scope
+
+`IdentitySpawnAnchor` implements the first acceptance criterion of issue #2931:
+one Bernstein run may retain exactly one verified, signed agent identity. It is
+an additive security primitive and is not yet wired into every spawn path.
+
+The anchor accepts a signed `AgentIdentityCard`, resolves the JWS `kid` only
+against a Bernstein-controlled trust mapping, validates the card at spawn time,
+and records an `identity.spawn_attestation` event in the HMAC audit chain. A key
+asserted by the card itself is never a trust source.
+
+## Retained evidence
+
+The event freezes the material required for later offline verification:
+
+- a snapshot of the card and detached JWS;
+- the exact validation timestamp;
+- the public Ed25519 JWK selected from Bernstein's trusted key mapping;
+- a canonical SHA-256 digest of that JWK;
+- the card digest, SVID reference, and run-journal head.
+
+Historical reconstruction verifies the HMAC chain, signed-card digest, frozen
+JWK digest and metadata, detached signature, and the card's validity at the
+recorded validation time. It does not consult the current clock or require the
+live JWKS to retain a rotated-out key. The retained JWK is public verification
+material; no private signing key is written to the event.
+
+## Transaction and retry invariants
+
+The lookup for an existing run identity and the append happen inside one
+`chain_transaction()`. The transaction is exclusive across threads and
+processes, so two orchestrators cannot bind different identities to the same
+run.
+
+An identical retry is idempotent and produces no second event. Any competing
+identity is rejected. A retry carrying a different `run_journal_head` is
+reported as a moved-head conflict and is never silently re-anchored, including
+after a legitimate crash during spawn.
+
+This slice does not make authorization decisions, issue identities, or replace
+the tool-call attestation interlock. Those remain separate issue #2931 layers.

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -905,6 +905,7 @@ EVENT_ODATA_WRITEBACK = "odata.writeback_receipt"
 #: after the attestation record was durable.
 EVENT_TOOLCALL_ATTESTATION = "toolcall.attestation"
 EVENT_TOOLCALL_ENFORCED_DISPATCH = "toolcall.enforced_dispatch"
+EVENT_IDENTITY_SPAWN_ATTESTATION = "identity.spawn_attestation"
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/core/security/identity_spawn_anchor.py
+++ b/src/bernstein/core/security/identity_spawn_anchor.py
@@ -1,0 +1,135 @@
+"""Bind one verified signed agent identity to one Bernstein run."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import time
+from copy import deepcopy
+from dataclasses import asdict, dataclass
+from typing import TYPE_CHECKING, cast
+
+from bernstein.core.security.agent_card_signer import (
+    AgentCardSignature,
+    canonicalize_jcs,
+    verify_agent_card,
+)
+from bernstein.core.security.audit_chain import (
+    EVENT_IDENTITY_SPAWN_ATTESTATION,
+    AuditChainStore,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
+    from bernstein.core.security.agent_identity import AgentIdentityCard
+
+
+class IdentitySpawnAnchorError(RuntimeError):
+    """Raised when a run identity cannot be anchored or reconstructed."""
+
+
+def _jws_kid(detached_jws: str) -> str:
+    try:
+        protected, payload, _signature = detached_jws.split(".")
+        if payload:
+            raise ValueError
+        padded = protected + "=" * (-len(protected) % 4)
+        header = cast(object, json.loads(base64.urlsafe_b64decode(padded)))
+    except (ValueError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise IdentitySpawnAnchorError("invalid detached agent-card JWS") from exc
+    if not isinstance(header, dict):
+        raise IdentitySpawnAnchorError("agent-card JWS has no valid kid")
+    kid = cast(dict[str, object], header).get("kid")
+    if not isinstance(kid, str):
+        raise IdentitySpawnAnchorError("agent-card JWS has no valid kid")
+    return kid
+
+
+@dataclass(frozen=True, slots=True)
+class AnchoredRunIdentity:
+    run_id: str
+    agent_id: str
+    agent_card_kid: str
+    card_hash: str
+    signed_card_digest: str
+    svid_reference: str
+    run_journal_head: str
+
+
+@dataclass(slots=True)
+class IdentitySpawnAnchor:
+    chain: AuditChainStore
+    trusted_public_keys: Mapping[str, bytes]
+    clock: Callable[[], float] = time.time
+
+    def anchor(
+        self,
+        *,
+        run_id: str,
+        card: AgentIdentityCard,
+        signature: AgentCardSignature,
+        run_journal_head: str,
+    ) -> AnchoredRunIdentity:
+        snapshot = deepcopy(card)
+        kid = _jws_kid(signature.detached_jws)
+        if signature.kid != kid:
+            raise IdentitySpawnAnchorError("agent-card kid substitution detected")
+        public_key = self.trusted_public_keys.get(kid)
+        if public_key is None or not verify_agent_card(snapshot, signature, public_key):
+            raise IdentitySpawnAnchorError("agent-card signature is not trusted")
+        now = float(self.clock())
+        if snapshot.created_at > now or (snapshot.expires_at and snapshot.expires_at <= now):
+            raise IdentitySpawnAnchorError("agent card is not valid at spawn time")
+
+        envelope = {"card": asdict(snapshot), "signature": asdict(signature)}
+        digest = "sha256:" + hashlib.sha256(canonicalize_jcs(envelope)).hexdigest()
+        identity = AnchoredRunIdentity(
+            run_id=run_id,
+            agent_id=snapshot.agent_id,
+            agent_card_kid=kid,
+            card_hash=snapshot.card_hash,
+            signed_card_digest=digest,
+            svid_reference=snapshot.svid_reference,
+            run_journal_head=run_journal_head,
+        )
+        details = {**asdict(identity), "anchored_at": now, "signed_card": envelope}
+
+        with self.chain.chain_transaction():
+            existing = self.chain.query(
+                event_type=EVENT_IDENTITY_SPAWN_ATTESTATION,
+                resource_id=run_id,
+            )
+            if existing:
+                prior = {key: existing[0].details.get(key) for key in asdict(identity)}
+                if prior == asdict(identity):
+                    return identity
+                raise IdentitySpawnAnchorError("a conflicting identity is already anchored to this run")
+            self.chain.log_with_prev_digest(
+                event_type=EVENT_IDENTITY_SPAWN_ATTESTATION,
+                actor="bernstein.identity-anchor",
+                resource_type="run",
+                resource_id=run_id,
+                details=details,
+            )
+        return identity
+
+    def reconstruct(self, run_id: str) -> AnchoredRunIdentity:
+        valid, errors = self.chain.verify()
+        if not valid:
+            raise IdentitySpawnAnchorError(f"audit chain verification failed: {'; '.join(errors)}")
+        events = self.chain.query(event_type=EVENT_IDENTITY_SPAWN_ATTESTATION, resource_id=run_id)
+        if len(events) != 1:
+            raise IdentitySpawnAnchorError("run must contain exactly one identity spawn attestation")
+        details = events[0].details
+        envelope = details.get("signed_card")
+        if not isinstance(envelope, dict):
+            raise IdentitySpawnAnchorError("signed-card evidence is unavailable")
+        digest = "sha256:" + hashlib.sha256(canonicalize_jcs(envelope)).hexdigest()
+        if digest != details.get("signed_card_digest"):
+            raise IdentitySpawnAnchorError("signed-card evidence digest mismatch")
+        return AnchoredRunIdentity(**{field: details[field] for field in AnchoredRunIdentity.__dataclass_fields__})
+
+
+__all__ = ["AnchoredRunIdentity", "IdentitySpawnAnchor", "IdentitySpawnAnchorError"]

--- a/src/bernstein/core/security/identity_spawn_anchor.py
+++ b/src/bernstein/core/security/identity_spawn_anchor.py
@@ -8,13 +8,14 @@ import json
 import time
 from copy import deepcopy
 from dataclasses import asdict, dataclass
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from bernstein.core.security.agent_card_signer import (
     AgentCardSignature,
     canonicalize_jcs,
     verify_agent_card,
 )
+from bernstein.core.security.agent_identity import AgentIdentityCard
 from bernstein.core.security.audit_chain import (
     EVENT_IDENTITY_SPAWN_ATTESTATION,
     AuditChainStore,
@@ -23,7 +24,6 @@ from bernstein.core.security.audit_chain import (
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
 
-    from bernstein.core.security.agent_identity import AgentIdentityCard
 
 
 class IdentitySpawnAnchorError(RuntimeError):
@@ -123,12 +123,29 @@ class IdentitySpawnAnchor:
         if len(events) != 1:
             raise IdentitySpawnAnchorError("run must contain exactly one identity spawn attestation")
         details = events[0].details
-        envelope = details.get("signed_card")
+        envelope = cast(object, details.get("signed_card"))
         if not isinstance(envelope, dict):
             raise IdentitySpawnAnchorError("signed-card evidence is unavailable")
+        typed_envelope = cast(dict[str, Any], envelope)
         digest = "sha256:" + hashlib.sha256(canonicalize_jcs(envelope)).hexdigest()
         if digest != details.get("signed_card_digest"):
             raise IdentitySpawnAnchorError("signed-card evidence digest mismatch")
+        card_data = cast(object, typed_envelope.get("card"))
+        signature_data = cast(object, typed_envelope.get("signature"))
+        if not isinstance(card_data, dict) or not isinstance(signature_data, dict):
+            raise IdentitySpawnAnchorError("signed-card evidence is malformed")
+        try:
+            card = AgentIdentityCard(**cast(dict[str, Any], card_data))
+            signature = AgentCardSignature(**cast(dict[str, Any], signature_data))
+            kid = _jws_kid(signature.detached_jws)
+        except (TypeError, IdentitySpawnAnchorError) as exc:
+            raise IdentitySpawnAnchorError("signed-card evidence is malformed") from exc
+        public_key = self.trusted_public_keys.get(kid)
+        if public_key is None:
+            raise IdentitySpawnAnchorError("historical verification key is unavailable")
+        identity_mismatch = signature.kid != kid or kid != details.get("agent_card_kid")
+        if identity_mismatch or not verify_agent_card(card, signature, public_key):
+            raise IdentitySpawnAnchorError("historical signed-card verification failed")
         return AnchoredRunIdentity(**{field: details[field] for field in AnchoredRunIdentity.__dataclass_fields__})
 
 

--- a/src/bernstein/core/security/identity_spawn_anchor.py
+++ b/src/bernstein/core/security/identity_spawn_anchor.py
@@ -13,6 +13,8 @@ from typing import TYPE_CHECKING, Any, cast
 from bernstein.core.security.agent_card_signer import (
     AgentCardSignature,
     canonicalize_jcs,
+    ed25519_pem_from_jwk,
+    ed25519_public_jwk,
     verify_agent_card,
 )
 from bernstein.core.security.agent_identity import AgentIdentityCard
@@ -25,9 +27,16 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
 
 
-
 class IdentitySpawnAnchorError(RuntimeError):
     """Raised when a run identity cannot be anchored or reconstructed."""
+
+
+def _sha256_digest(value: object) -> str:
+    return "sha256:" + hashlib.sha256(canonicalize_jcs(value)).hexdigest()
+
+
+def _card_is_valid_at(card: AgentIdentityCard, instant: float) -> bool:
+    return card.created_at <= instant and (not card.expires_at or card.expires_at > instant)
 
 
 def _jws_kid(detached_jws: str) -> str:
@@ -79,12 +88,13 @@ class IdentitySpawnAnchor:
         public_key = self.trusted_public_keys.get(kid)
         if public_key is None or not verify_agent_card(snapshot, signature, public_key):
             raise IdentitySpawnAnchorError("agent-card signature is not trusted")
-        now = float(self.clock())
-        if snapshot.created_at > now or (snapshot.expires_at and snapshot.expires_at <= now):
+        validated_at = float(self.clock())
+        if not _card_is_valid_at(snapshot, validated_at):
             raise IdentitySpawnAnchorError("agent card is not valid at spawn time")
 
         envelope = {"card": asdict(snapshot), "signature": asdict(signature)}
-        digest = "sha256:" + hashlib.sha256(canonicalize_jcs(envelope)).hexdigest()
+        digest = _sha256_digest(envelope)
+        public_jwk = ed25519_public_jwk(public_key, kid=kid)
         identity = AnchoredRunIdentity(
             run_id=run_id,
             agent_id=snapshot.agent_id,
@@ -94,7 +104,13 @@ class IdentitySpawnAnchor:
             svid_reference=snapshot.svid_reference,
             run_journal_head=run_journal_head,
         )
-        details = {**asdict(identity), "anchored_at": now, "signed_card": envelope}
+        details = {
+            **asdict(identity),
+            "validated_at": validated_at,
+            "signed_card": envelope,
+            "verification_key_jwk": public_jwk,
+            "verification_key_digest": _sha256_digest(public_jwk),
+        }
 
         with self.chain.chain_transaction():
             existing = self.chain.query(
@@ -105,6 +121,8 @@ class IdentitySpawnAnchor:
                 prior = {key: existing[0].details.get(key) for key in asdict(identity)}
                 if prior == asdict(identity):
                     return identity
+                if prior.get("run_journal_head") != run_journal_head:
+                    raise IdentitySpawnAnchorError("run journal head moved since the identity was anchored")
                 raise IdentitySpawnAnchorError("a conflicting identity is already anchored to this run")
             self.chain.log_with_prev_digest(
                 event_type=EVENT_IDENTITY_SPAWN_ATTESTATION,
@@ -127,7 +145,7 @@ class IdentitySpawnAnchor:
         if not isinstance(envelope, dict):
             raise IdentitySpawnAnchorError("signed-card evidence is unavailable")
         typed_envelope = cast(dict[str, Any], envelope)
-        digest = "sha256:" + hashlib.sha256(canonicalize_jcs(envelope)).hexdigest()
+        digest = _sha256_digest(typed_envelope)
         if digest != details.get("signed_card_digest"):
             raise IdentitySpawnAnchorError("signed-card evidence digest mismatch")
         card_data = cast(object, typed_envelope.get("card"))
@@ -140,9 +158,25 @@ class IdentitySpawnAnchor:
             kid = _jws_kid(signature.detached_jws)
         except (TypeError, IdentitySpawnAnchorError) as exc:
             raise IdentitySpawnAnchorError("signed-card evidence is malformed") from exc
-        public_key = self.trusted_public_keys.get(kid)
-        if public_key is None:
-            raise IdentitySpawnAnchorError("historical verification key is unavailable")
+
+        validated_at = details.get("validated_at")
+        if not isinstance(validated_at, (int, float)) or isinstance(validated_at, bool):
+            raise IdentitySpawnAnchorError("historical validation timestamp is unavailable")
+        if not _card_is_valid_at(card, float(validated_at)):
+            raise IdentitySpawnAnchorError("agent card was not valid at its recorded validation time")
+
+        public_jwk = cast(object, details.get("verification_key_jwk"))
+        if not isinstance(public_jwk, dict):
+            raise IdentitySpawnAnchorError("frozen historical verification key is unavailable")
+        typed_jwk = cast(dict[str, Any], public_jwk)
+        if _sha256_digest(typed_jwk) != details.get("verification_key_digest"):
+            raise IdentitySpawnAnchorError("frozen historical verification key digest mismatch")
+        if typed_jwk.get("kid") != kid or typed_jwk.get("alg") != "EdDSA" or typed_jwk.get("use") != "sig":
+            raise IdentitySpawnAnchorError("frozen historical verification key metadata mismatch")
+        try:
+            public_key = ed25519_pem_from_jwk(typed_jwk)
+        except ValueError as exc:
+            raise IdentitySpawnAnchorError("frozen historical verification key is malformed") from exc
         identity_mismatch = signature.kid != kid or kid != details.get("agent_card_kid")
         if identity_mismatch or not verify_agent_card(card, signature, public_key):
             raise IdentitySpawnAnchorError("historical signed-card verification failed")

--- a/tests/unit/security/test_identity_spawn_anchor.py
+++ b/tests/unit/security/test_identity_spawn_anchor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
 from unittest.mock import patch
 
@@ -91,5 +92,78 @@ def test_missing_signed_card_evidence_fails_closed(tmp_path):
     with (
         patch.object(anchor.chain, "query", return_value=[event]),
         pytest.raises(IdentitySpawnAnchorError, match="unavailable"),
+    ):
+        anchor.reconstruct("run-1")
+
+
+def test_historical_anchor_survives_later_card_expiry(tmp_path):
+    anchor, card, signature, _ = setup_anchor(tmp_path)
+    expected = anchor.anchor(run_id="run-1", card=card, signature=signature, run_journal_head="journal:1")
+    anchor.clock = lambda: 999
+    assert anchor.reconstruct("run-1") == expected
+
+
+def test_missing_historical_public_key_fails_closed(tmp_path):
+    anchor, card, signature, _ = setup_anchor(tmp_path)
+    anchor.anchor(run_id="run-1", card=card, signature=signature, run_journal_head="journal:1")
+    anchor.trusted_public_keys = {}
+    with pytest.raises(IdentitySpawnAnchorError, match="historical verification key"):
+        anchor.reconstruct("run-1")
+
+
+def test_self_asserted_key_cannot_replace_trust_source(tmp_path):
+    anchor, card, _signature, _ = setup_anchor(tmp_path)
+    attacker_private, attacker_public = generate_ed25519_keypair()
+    forged_card = replace(card, extensions={"public_key": attacker_public.decode()})
+    forged_signature = sign_agent_card(forged_card, attacker_private, kid="agent-bernstein-orchestrator")
+    with pytest.raises(IdentitySpawnAnchorError, match="not trusted"):
+        anchor.anchor(run_id="run-1", card=forged_card, signature=forged_signature, run_journal_head="journal:1")
+
+
+def test_competing_thread_identities_cannot_both_anchor(tmp_path):
+    anchor, card, signature, private = setup_anchor(tmp_path)
+    other = replace(card, agent_id="agent-2")
+    other_signature = sign_agent_card(other, private, kid="agent-bernstein-orchestrator")
+
+    def attempt(candidate, signed):
+        try:
+            return anchor.anchor(run_id="run-1", card=candidate, signature=signed, run_journal_head="journal:1")
+        except IdentitySpawnAnchorError:
+            return None
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(lambda pair: attempt(*pair), [(card, signature), (other, other_signature)]))
+    assert sum(result is not None for result in results) == 1
+    assert len(anchor.chain.query(event_type="identity.spawn_attestation", resource_id="run-1")) == 1
+
+
+def test_separate_store_append_cannot_move_identity_predecessor(tmp_path):
+    anchor, card, signature, _ = setup_anchor(tmp_path)
+    other_store = AuditChainStore(tmp_path / "audit", key=b"k" * 32)
+    other_store.log(event_type="unrelated", actor="other", resource_type="test", resource_id="other")
+    anchor.anchor(run_id="run-1", card=card, signature=signature, run_journal_head="journal:1")
+    assert anchor.chain.verify() == (True, [])
+    events = anchor.chain.query(event_type="identity.spawn_attestation", resource_id="run-1")
+    assert events[0].details["prev_chain_digest"] != ""
+
+
+def test_physical_chain_tamper_blocks_reconstruction(tmp_path):
+    anchor, card, signature, _ = setup_anchor(tmp_path)
+    anchor.anchor(run_id="run-1", card=card, signature=signature, run_journal_head="journal:1")
+    log_path = next((tmp_path / "audit").glob("*.jsonl"))
+    original = log_path.read_text()
+    log_path.write_text(original.replace("agent-1", "agent-X", 1))
+    with pytest.raises(IdentitySpawnAnchorError, match="audit chain verification failed"):
+        anchor.reconstruct("run-1")
+
+
+def test_signed_envelope_corruption_fails_digest_check(tmp_path):
+    anchor, card, signature, _ = setup_anchor(tmp_path)
+    anchor.anchor(run_id="run-1", card=card, signature=signature, run_journal_head="journal:1")
+    event = anchor.chain.query(event_type="identity.spawn_attestation", resource_id="run-1")[0]
+    event.details["signed_card"]["card"]["agent_id"] = "agent-X"
+    with (
+        patch.object(anchor.chain, "query", return_value=[event]),
+        pytest.raises(IdentitySpawnAnchorError, match="digest mismatch"),
     ):
         anchor.reconstruct("run-1")

--- a/tests/unit/security/test_identity_spawn_anchor.py
+++ b/tests/unit/security/test_identity_spawn_anchor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import multiprocessing
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
 from unittest.mock import patch
@@ -12,11 +13,38 @@ from bernstein.core.security.audit_chain import AuditChainStore
 from bernstein.core.security.identity_spawn_anchor import IdentitySpawnAnchor, IdentitySpawnAnchorError
 
 
+def _cross_process_anchor(audit_dir, public_key, card, signature, ready, start, results):
+    anchor = IdentitySpawnAnchor(
+        AuditChainStore(audit_dir, key=b"k" * 32),
+        {signature.kid: public_key},
+        clock=lambda: 150,
+    )
+    ready.put(card.agent_id)
+    if not start.wait(timeout=10):
+        results.put(("timeout", card.agent_id))
+        return
+    try:
+        anchor.anchor(
+            run_id="run-1",
+            card=card,
+            signature=signature,
+            run_journal_head="journal:1",
+        )
+    except IdentitySpawnAnchorError as exc:
+        results.put(("rejected", str(exc)))
+    else:
+        results.put(("anchored", card.agent_id))
+
+
 def setup_anchor(tmp_path):
     private, public = generate_ed25519_keypair()
-    card = AgentIdentityCard(agent_id="agent-1", role="coder", adapter="codex", model="gpt", created_at=100, expires_at=200)
+    card = AgentIdentityCard(
+        agent_id="agent-1", role="coder", adapter="codex", model="gpt", created_at=100, expires_at=200
+    )
     signature = sign_agent_card(card, private, kid="agent-bernstein-orchestrator")
-    anchor = IdentitySpawnAnchor(AuditChainStore(tmp_path / "audit", key=b"k" * 32), {signature.kid: public}, clock=lambda: 150)
+    anchor = IdentitySpawnAnchor(
+        AuditChainStore(tmp_path / "audit", key=b"k" * 32), {signature.kid: public}, clock=lambda: 150
+    )
     return anchor, card, signature, private
 
 
@@ -44,7 +72,9 @@ def test_wrong_key_is_rejected(tmp_path):
 def test_post_signing_mutation_is_rejected(tmp_path):
     anchor, card, signature, _ = setup_anchor(tmp_path)
     with pytest.raises(IdentitySpawnAnchorError, match="not trusted"):
-        anchor.anchor(run_id="run-1", card=replace(card, agent_id="attacker"), signature=signature, run_journal_head="journal:1")
+        anchor.anchor(
+            run_id="run-1", card=replace(card, agent_id="attacker"), signature=signature, run_journal_head="journal:1"
+        )
 
 
 def test_kid_substitution_is_rejected(tmp_path):
@@ -70,10 +100,10 @@ def test_identical_retry_is_idempotent(tmp_path):
     assert len(anchor.chain.query(event_type="identity.spawn_attestation", resource_id="run-1")) == 1
 
 
-def test_conflicting_retry_is_rejected(tmp_path):
+def test_retry_with_moved_journal_head_is_rejected_and_surfaced(tmp_path):
     anchor, card, signature, _ = setup_anchor(tmp_path)
     anchor.anchor(run_id="run-1", card=card, signature=signature, run_journal_head="journal:1")
-    with pytest.raises(IdentitySpawnAnchorError, match="conflicting"):
+    with pytest.raises(IdentitySpawnAnchorError, match="journal head moved"):
         anchor.anchor(run_id="run-1", card=card, signature=signature, run_journal_head="journal:2")
 
 
@@ -103,11 +133,48 @@ def test_historical_anchor_survives_later_card_expiry(tmp_path):
     assert anchor.reconstruct("run-1") == expected
 
 
-def test_missing_historical_public_key_fails_closed(tmp_path):
+def test_validation_timestamp_is_recorded_and_checked_historically(tmp_path):
     anchor, card, signature, _ = setup_anchor(tmp_path)
     anchor.anchor(run_id="run-1", card=card, signature=signature, run_journal_head="journal:1")
+    event = anchor.chain.query(event_type="identity.spawn_attestation", resource_id="run-1")[0]
+    assert event.details["validated_at"] == 150
+
+    event.details["validated_at"] = 250
+    with (
+        patch.object(anchor.chain, "query", return_value=[event]),
+        pytest.raises(IdentitySpawnAnchorError, match="recorded validation time"),
+    ):
+        anchor.reconstruct("run-1")
+
+
+def test_live_key_rotation_does_not_orphan_historical_verification(tmp_path):
+    anchor, card, signature, _ = setup_anchor(tmp_path)
+    expected = anchor.anchor(run_id="run-1", card=card, signature=signature, run_journal_head="journal:1")
     anchor.trusted_public_keys = {}
-    with pytest.raises(IdentitySpawnAnchorError, match="historical verification key"):
+    assert anchor.reconstruct("run-1") == expected
+
+
+def test_missing_frozen_historical_public_key_fails_closed(tmp_path):
+    anchor, card, signature, _ = setup_anchor(tmp_path)
+    anchor.anchor(run_id="run-1", card=card, signature=signature, run_journal_head="journal:1")
+    event = anchor.chain.query(event_type="identity.spawn_attestation", resource_id="run-1")[0]
+    event.details.pop("verification_key_jwk")
+    with (
+        patch.object(anchor.chain, "query", return_value=[event]),
+        pytest.raises(IdentitySpawnAnchorError, match="frozen historical verification key"),
+    ):
+        anchor.reconstruct("run-1")
+
+
+def test_frozen_historical_public_key_tamper_fails_digest_check(tmp_path):
+    anchor, card, signature, _ = setup_anchor(tmp_path)
+    anchor.anchor(run_id="run-1", card=card, signature=signature, run_journal_head="journal:1")
+    event = anchor.chain.query(event_type="identity.spawn_attestation", resource_id="run-1")[0]
+    event.details["verification_key_jwk"]["kid"] = "attacker"
+    with (
+        patch.object(anchor.chain, "query", return_value=[event]),
+        pytest.raises(IdentitySpawnAnchorError, match="verification key digest mismatch"),
+    ):
         anchor.reconstruct("run-1")
 
 
@@ -135,6 +202,48 @@ def test_competing_thread_identities_cannot_both_anchor(tmp_path):
         results = list(pool.map(lambda pair: attempt(*pair), [(card, signature), (other, other_signature)]))
     assert sum(result is not None for result in results) == 1
     assert len(anchor.chain.query(event_type="identity.spawn_attestation", resource_id="run-1")) == 1
+
+
+def test_competing_cross_process_identities_cannot_both_anchor(tmp_path):
+    _anchor, card, signature, private = setup_anchor(tmp_path)
+    other = replace(card, agent_id="agent-2")
+    other_signature = sign_agent_card(other, private, kid="agent-bernstein-orchestrator")
+    context = multiprocessing.get_context("spawn")
+    ready = context.Queue()
+    start = context.Event()
+    results = context.Queue()
+    processes = [
+        context.Process(
+            target=_cross_process_anchor,
+            args=(
+                tmp_path / "audit",
+                _anchor.trusted_public_keys[signature.kid],
+                candidate,
+                signed,
+                ready,
+                start,
+                results,
+            ),
+        )
+        for candidate, signed in ((card, signature), (other, other_signature))
+    ]
+
+    for process in processes:
+        process.start()
+    assert {ready.get(timeout=10), ready.get(timeout=10)} == {"agent-1", "agent-2"}
+    start.set()
+    for process in processes:
+        process.join(timeout=10)
+        assert process.exitcode == 0
+
+    outcomes = [results.get(timeout=10), results.get(timeout=10)]
+    assert [status for status, _detail in outcomes].count("anchored") == 1
+    assert [status for status, _detail in outcomes].count("rejected") == 1
+    assert "conflicting identity" in next(detail for status, detail in outcomes if status == "rejected")
+
+    chain = AuditChainStore(tmp_path / "audit", key=b"k" * 32)
+    assert chain.verify() == (True, [])
+    assert len(chain.query(event_type="identity.spawn_attestation", resource_id="run-1")) == 1
 
 
 def test_separate_store_append_cannot_move_identity_predecessor(tmp_path):

--- a/tests/unit/security/test_identity_spawn_anchor.py
+++ b/tests/unit/security/test_identity_spawn_anchor.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from unittest.mock import patch
+
+import pytest
+
+from bernstein.core.security.agent_card_signer import generate_ed25519_keypair, sign_agent_card
+from bernstein.core.security.agent_identity import AgentIdentityCard
+from bernstein.core.security.audit_chain import AuditChainStore
+from bernstein.core.security.identity_spawn_anchor import IdentitySpawnAnchor, IdentitySpawnAnchorError
+
+
+def setup_anchor(tmp_path):
+    private, public = generate_ed25519_keypair()
+    card = AgentIdentityCard(agent_id="agent-1", role="coder", adapter="codex", model="gpt", created_at=100, expires_at=200)
+    signature = sign_agent_card(card, private, kid="agent-bernstein-orchestrator")
+    anchor = IdentitySpawnAnchor(AuditChainStore(tmp_path / "audit", key=b"k" * 32), {signature.kid: public}, clock=lambda: 150)
+    return anchor, card, signature, private
+
+
+def test_valid_card_anchors_once_and_reconstructs(tmp_path):
+    anchor, card, signature, _ = setup_anchor(tmp_path)
+    expected = anchor.anchor(run_id="run-1", card=card, signature=signature, run_journal_head="journal:1")
+    assert anchor.reconstruct("run-1") == expected
+
+
+def test_unsigned_or_untrusted_card_is_rejected(tmp_path):
+    anchor, card, signature, _ = setup_anchor(tmp_path)
+    anchor.trusted_public_keys = {}
+    with pytest.raises(IdentitySpawnAnchorError, match="not trusted"):
+        anchor.anchor(run_id="run-1", card=card, signature=signature, run_journal_head="journal:1")
+
+
+def test_wrong_key_is_rejected(tmp_path):
+    anchor, card, signature, _ = setup_anchor(tmp_path)
+    _, wrong_public = generate_ed25519_keypair()
+    anchor.trusted_public_keys = {signature.kid: wrong_public}
+    with pytest.raises(IdentitySpawnAnchorError, match="not trusted"):
+        anchor.anchor(run_id="run-1", card=card, signature=signature, run_journal_head="journal:1")
+
+
+def test_post_signing_mutation_is_rejected(tmp_path):
+    anchor, card, signature, _ = setup_anchor(tmp_path)
+    with pytest.raises(IdentitySpawnAnchorError, match="not trusted"):
+        anchor.anchor(run_id="run-1", card=replace(card, agent_id="attacker"), signature=signature, run_journal_head="journal:1")
+
+
+def test_kid_substitution_is_rejected(tmp_path):
+    anchor, card, signature, _ = setup_anchor(tmp_path)
+    forged = replace(signature, kid="other")
+    with pytest.raises(IdentitySpawnAnchorError, match="substitution"):
+        anchor.anchor(run_id="run-1", card=card, signature=forged, run_journal_head="journal:1")
+
+
+@pytest.mark.parametrize("created,expires", [(151, 200), (100, 150)])
+def test_invalid_validity_window_is_rejected(tmp_path, created, expires):
+    anchor, card, _signature, private = setup_anchor(tmp_path)
+    card = replace(card, created_at=created, expires_at=expires)
+    signature = sign_agent_card(card, private, kid="agent-bernstein-orchestrator")
+    with pytest.raises(IdentitySpawnAnchorError, match="not valid"):
+        anchor.anchor(run_id="run-1", card=card, signature=signature, run_journal_head="journal:1")
+
+
+def test_identical_retry_is_idempotent(tmp_path):
+    anchor, card, signature, _ = setup_anchor(tmp_path)
+    first = anchor.anchor(run_id="run-1", card=card, signature=signature, run_journal_head="journal:1")
+    assert anchor.anchor(run_id="run-1", card=card, signature=signature, run_journal_head="journal:1") == first
+    assert len(anchor.chain.query(event_type="identity.spawn_attestation", resource_id="run-1")) == 1
+
+
+def test_conflicting_retry_is_rejected(tmp_path):
+    anchor, card, signature, _ = setup_anchor(tmp_path)
+    anchor.anchor(run_id="run-1", card=card, signature=signature, run_journal_head="journal:1")
+    with pytest.raises(IdentitySpawnAnchorError, match="conflicting"):
+        anchor.anchor(run_id="run-1", card=card, signature=signature, run_journal_head="journal:2")
+
+
+def test_empty_svid_and_genesis_are_honest(tmp_path):
+    anchor, card, signature, _ = setup_anchor(tmp_path)
+    identity = anchor.anchor(run_id="run-1", card=card, signature=signature, run_journal_head="")
+    assert identity.svid_reference == ""
+    assert identity.run_journal_head == ""
+
+
+def test_missing_signed_card_evidence_fails_closed(tmp_path):
+    anchor, card, signature, _ = setup_anchor(tmp_path)
+    anchor.anchor(run_id="run-1", card=card, signature=signature, run_journal_head="journal:1")
+    event = anchor.chain.query(event_type="identity.spawn_attestation", resource_id="run-1")[0]
+    event.details.pop("signed_card")
+    with (
+        patch.object(anchor.chain, "query", return_value=[event]),
+        pytest.raises(IdentitySpawnAnchorError, match="unavailable"),
+    ):
+        anchor.reconstruct("run-1")


### PR DESCRIPTION
## What changed

- add an `IdentitySpawnAnchor` that verifies a signed `AgentIdentityCard` against a Bernstein-controlled `kid` trust mapping before anchoring it to a run
- retain the signed card, exact validation timestamp, public verification JWK and its canonical digest in one HMAC-chained `identity.spawn_attestation` event
- reconstruct historical identity evidence offline using the frozen JWK and the card's validity at the recorded instant, without depending on the current clock or live JWKS retention
- make identical retries idempotent while explicitly rejecting a moved `run_journal_head` or a competing identity
- cover thread and real spawned-process races against the same audit directory
- document the trust boundary, retained evidence, retry semantics and cross-process test layer

## Why

Bernstein can sign agent identity cards, but a run does not yet retain a durable proof of which signed identity was valid when that run spawned. This slice establishes that root binding without claiming to complete the later per-tool-call, receipt, gate or CLI work in #2931.

The historical verifier freezes only public verification material. The signing key remains private, and initial trust still comes exclusively from Bernstein's configured key mapping rather than any key asserted by the card.

## Maintainer follow-up incorporated

- historical validity is evaluated at the timestamp recorded in the event
- rotated-out public verification material is frozen with the anchor and digest-bound
- a retry with a differing journal head fails closed and is surfaced
- competing-identity uniqueness is exercised across separate processes, not only threads

## Validation

- `uv run pytest tests/unit/security/ -q --no-cov` — 371 passed
- `uv run ruff check src/bernstein/core/security/identity_spawn_anchor.py tests/unit/security/test_identity_spawn_anchor.py`
- `uv run pyright src/bernstein/core/security/identity_spawn_anchor.py` — 0 errors
- `uv run mypy src/bernstein/core/security/identity_spawn_anchor.py` — success
- `git diff --check origin/main...HEAD`

Partial implementation of #2931: advances the signed identity-at-spawn acceptance criterion only.
