### PR TITLE
docs: add a naming policy for forks and derivative builds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -274,6 +274,12 @@ Outstanding contributions are featured in our
 [monthly Community Spotlight](https://alexchernysh.com/blog)
 blog posts, which are shared on Twitter/X, LinkedIn, and dev.to.
 
+## Naming
+
+Forks and derivative builds are welcome and ship under their own name.
+The Apache-2.0 code grant does not cover the project name itself — the
+short version of what that means is in [TRADEMARKS.md](TRADEMARKS.md).
+
 ## License
 
 By contributing, you agree that your contributions will be licensed under the [Apache License 2.0](LICENSE).

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,6 @@
+Bernstein
+Copyright 2026 Alex Chernysh
+
+Licensed under the Apache License, Version 2.0 (see LICENSE).
+The Apache-2.0 code grant does not include rights to the project
+name — see TRADEMARKS.md.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 [![Open in Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sipyourdrink-ltd/bernstein?quickstart=1)
 [![MCP Toplist](https://mcptoplist.com/badge/io.github.sipyourdrink-ltd%2Fbernstein.svg)](https://mcptoplist.com/server/io.github.sipyourdrink-ltd%2Fbernstein)
 
-[website](https://bernstein.run) &middot; [docs](https://bernstein.readthedocs.io/) &middot; [install](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/getting-started/install.md) &middot; [first run](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/getting-started/first-run.md) &middot; [glossary](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/GLOSSARY.md) &middot; [limitations](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/KNOWN_LIMITATIONS.md) &middot; [sponsor](https://github.com/sponsors/chernistry)
+[website](https://bernstein.run) &middot; [docs](https://bernstein.readthedocs.io/) &middot; [install](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/getting-started/install.md) &middot; [first run](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/getting-started/first-run.md) &middot; [glossary](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/GLOSSARY.md) &middot; [limitations](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/KNOWN_LIMITATIONS.md) &middot; [name policy](https://github.com/sipyourdrink-ltd/bernstein/blob/main/TRADEMARKS.md) &middot; [sponsor](https://github.com/sponsors/chernistry)
 
 </div>
 
@@ -137,7 +137,7 @@ The full tracked list, including every awesome-list entry, catalog listing, prio
 
 PRs welcome; [CONTRIBUTING.md](https://github.com/sipyourdrink-ltd/bernstein/blob/main/CONTRIBUTING.md) has setup and code style. Security reports go through [SECURITY.md](https://github.com/sipyourdrink-ltd/bernstein/blob/main/SECURITY.md). If Bernstein saves you time: [GitHub Sponsors](https://github.com/sponsors/chernistry). Contact: [forte@bernstein.run](mailto:forte@bernstein.run).
 
-Citation metadata lives in [CITATION.cff](https://github.com/sipyourdrink-ltd/bernstein/blob/main/CITATION.cff). License: [Apache-2.0](https://github.com/sipyourdrink-ltd/bernstein/blob/main/LICENSE).
+Citation metadata lives in [CITATION.cff](https://github.com/sipyourdrink-ltd/bernstein/blob/main/CITATION.cff). License: [Apache-2.0](https://github.com/sipyourdrink-ltd/bernstein/blob/main/LICENSE); the project name is covered separately in [TRADEMARKS.md](https://github.com/sipyourdrink-ltd/bernstein/blob/main/TRADEMARKS.md).
 
 ---
 

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,36 @@
+# Use of the Bernstein name
+
+Bernstein is Apache-2.0: the code is free to use, fork, embed, and ship.
+That is the point of the license. What the license does not grant is the
+project name (Apache License, section 6), and this page explains what that
+means in practice. We want people building on Bernstein — this policy is
+only about readers being able to tell builds apart.
+
+## You can, without asking
+
+- Say your project is **built on Bernstein**, **powered by Bernstein**, or
+  **compatible with Bernstein**.
+- Fork the code and ship it under your own name.
+- Use the name to describe what your project does ("a web UI for
+  Bernstein", "a Bernstein plugin").
+- Mention Bernstein in articles, reviews, talks, benchmarks, and package
+  metadata.
+
+## Please ask first
+
+- Calling a derivative product, UI, or hosted service "Bernstein" — or a
+  name close enough that a reader cannot tell it apart from this project.
+- Using the project logo in a way that presents a product as official.
+- Registering domains or social-media handles that read as official
+  project channels.
+
+## Why
+
+A user who hits a bug needs to know whose build they are running, and a
+derived project deserves recognition under its own name. Nothing here
+limits what you can do with the code — only how the name is presented.
+
+## How to ask
+
+Open an issue on this repository or email alex@alexchernysh.com.
+When confusion is unlikely, the default answer is yes.

--- a/tests/unit/test_naming_policy_docs.py
+++ b/tests/unit/test_naming_policy_docs.py
@@ -1,0 +1,73 @@
+"""Guard: the naming policy stays present and stays reachable.
+
+Apache-2.0 grants every right to the code but explicitly withholds the
+project name (section 6). The repository answered the code half of that
+and left the name half undocumented, so a fork had to guess what it could
+call itself and a user filing a bug had no way to check whose build they
+were running.
+
+`NOTICE` and `TRADEMARKS.md` close that gap, but a policy nobody can find
+is the same as no policy: the failure mode is not the file being edited,
+it is the file being orphaned when `README.md` or `CONTRIBUTING.md` is
+next restructured, and nothing failing until someone goes looking. These
+tests pin the documents and both entry points that lead to them, so
+removing either the policy or a pointer to it fails CI instead of
+surfacing months later.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+NOTICE = REPO_ROOT / "NOTICE"
+TRADEMARKS = REPO_ROOT / "TRADEMARKS.md"
+README = REPO_ROOT / "README.md"
+CONTRIBUTING = REPO_ROOT / "CONTRIBUTING.md"
+
+EMAIL = re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+")
+
+
+def _headings(text: str) -> list[str]:
+    return [line.lstrip("#").strip().lower() for line in text.splitlines() if line.startswith("## ")]
+
+
+def test_notice_names_project_and_license() -> None:
+    """A NOTICE that does not say whose work it covers is decoration."""
+    assert NOTICE.is_file(), "Apache-2.0 projects carry a NOTICE file at the repository root"
+    text = NOTICE.read_text(encoding="utf-8")
+    for token in ("Bernstein", "Copyright", "LICENSE"):
+        assert token in text, (
+            f"NOTICE must state the project, the copyright holder, and point at LICENSE; missing {token!r}"
+        )
+
+
+def test_trademarks_policy_covers_grant_ask_and_contact() -> None:
+    """The policy is only useful if it answers all three questions a fork actually has."""
+    assert TRADEMARKS.is_file(), "the naming policy lives in TRADEMARKS.md at the repository root"
+    text = TRADEMARKS.read_text(encoding="utf-8")
+    headings = _headings(text)
+
+    assert any("without asking" in heading for heading in headings), (
+        f"TRADEMARKS.md must say what derivative works may do without permission; headings are {headings}"
+    )
+    assert any("ask first" in heading for heading in headings), (
+        f"TRADEMARKS.md must say what needs permission first; headings are {headings}"
+    )
+    assert EMAIL.search(text), "TRADEMARKS.md must give a contact for permission requests"
+
+
+def test_readme_points_readers_at_naming_policy() -> None:
+    """The README is where a user checks whether their build is the official one."""
+    assert "TRADEMARKS.md" in README.read_text(encoding="utf-8"), (
+        "README.md must link to TRADEMARKS.md near the license badge, or the policy is unreachable "
+        "from the page most readers land on"
+    )
+
+
+def test_contributing_points_contributors_at_naming_policy() -> None:
+    """A fork author reads CONTRIBUTING before shipping, not the license appendix."""
+    assert "TRADEMARKS.md" in CONTRIBUTING.read_text(encoding="utf-8"), (
+        "CONTRIBUTING.md must link to TRADEMARKS.md so people shipping derivative builds find the policy"
+    )


### PR DESCRIPTION
# User description
Apache-2.0 grants every right to the code but explicitly withholds the project name (section 6), and the repository never said what that means in practice: there was no NOTICE file, no naming policy, and CONTRIBUTING did not mention the topic. The gap ran both ways — a fork had no guidance on what it could call itself, and a user filing a bug report had no documented way to check whose build they were running.

Adds `NOTICE` and a plain-language `TRADEMARKS.md` (what is fine without asking, what needs permission first, why, and how to ask), plus a `Naming` section in `CONTRIBUTING.md` and a pointer in `README.md` next to the license badge. `tests/unit/test_naming_policy_docs.py` pins the two documents and both entry points, so orphaning the policy in a future restructure fails CI instead of going unnoticed. `LICENSE` is unchanged and no dependencies were added; the wheel picks up `NOTICE` through the build backend's default license-file glob, verified against a local build.

Closes #3368

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add a root-level naming policy for Bernstein that explains how forks and derivative builds may use the project name, and surface that guidance from <code>CONTRIBUTING.md</code>, <code>README.md</code>, and <code>NOTICE</code>. Add a guardrail test suite that keeps the policy documents and their entry points from being lost during future doc reshuffles.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3369?tool=ast&topic=Naming+policy>Naming policy</a>
        </td><td>Add <code>NOTICE</code> and <code>TRADEMARKS.md</code> guidance that defines when derivative builds can use the Bernstein name and how to ask for permission.<details><summary>Modified files (4)</summary><ul><li>CONTRIBUTING.md</li>
<li>NOTICE</li>
<li>README.md</li>
<li>TRADEMARKS.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>docs: add a naming pol...</td><td>August 03, 2026</td></tr>
<tr><td>chernistry</td><td>docs: record a new edi...</td><td>August 03, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3369?tool=ast&topic=Doc+coverage>Doc coverage</a>
        </td><td>Add tests that pin the naming policy documents and the links from the main contributor and reader entry points.<details><summary>Modified files (1)</summary><ul><li>tests/unit/test_naming_policy_docs.py</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>docs: add a naming pol...</td><td>August 03, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3369?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>