### PR TITLE
chore(typing): annotate core/routes - fix remaining mypy errors

### DIFF
--- a/src/bernstein/core/routes/graphql_api.py
+++ b/src/bernstein/core/routes/graphql_api.py
@@ -158,7 +158,7 @@ def _resolve_tasks(parsed: ParsedQuery, store: Any) -> list[dict[str, Any]]:
     for t in tasks:
         task = _task_to_dict(t)
         raw_status = task.get("status")
-        task_status_str = raw_status.value if hasattr(raw_status, "value") else raw_status
+        task_status_str = raw_status.value if raw_status is not None and hasattr(raw_status, "value") else raw_status
         if status_filter and task_status_str != status_filter:
             continue
         results.append(_extract_task_fields(task, parsed.fields))

--- a/src/bernstein/core/routes/quality.py
+++ b/src/bernstein/core/routes/quality.py
@@ -206,9 +206,9 @@ def _compute_per_model(
     for rec in usage_records:
         labels = rec.get("labels", {})
         model = labels.get("model") or "unknown"
-        tokens = float(rec.get("value", 0.0))
-        if tokens > 0:
-            by_model_tokens[model].append(tokens)
+        token_val = float(rec.get("value", 0.0))
+        if token_val > 0:
+            by_model_tokens[model].append(token_val)
 
     all_models = set(by_model_durations.keys()) | set(by_model_tokens.keys())
     result: dict[str, Any] = {}

--- a/src/bernstein/core/routes/telemetry_webhooks.py
+++ b/src/bernstein/core/routes/telemetry_webhooks.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import logging
 import os
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
@@ -72,7 +72,7 @@ class TelemetryReceiverState:
 
 def configure_receiver(
     *,
-    app_state: object,
+    app_state: Any,
     settings: TelemetrySettings,
     retriever: GroundingRetriever,
     dispatch_hook: GroundedDispatchHook,

--- a/src/bernstein/core/routes/webhooks.py
+++ b/src/bernstein/core/routes/webhooks.py
@@ -347,7 +347,7 @@ def _with_receipt(response: JSONResponse, admission: TriggerAdmission | None) ->
         return response
     import json as _json
 
-    body: dict[str, Any] = _json.loads(response.body)
+    body: dict[str, Any] = _json.loads(bytes(response.body))
     body["receipt"] = admission.receipt.to_dict()
     return JSONResponse(status_code=response.status_code, content=body)
 


### PR DESCRIPTION
## What

Fix remaining mypy errors in `core/routes/`  continuation of #3267.

## Why

Completing issue #3232. After the first slice (string constants  type aliases), 
18 mypy errors remained. This PR fixes the ones that were addressable.

## How

**Before:** 18 errors | **After:** 12 errors

Fixed:
- `telemetry_webhooks.py`: `app_state: object`  `app_state: Any` `object` 
  doesn't allow dynamic attribute assignment, `Any` does
- `graphql_api.py`: added `raw_status is not None` guard before `hasattr()` check 
  so mypy can narrow the `Any | None` union correctly
- `quality.py`: renamed loop variable `tokens: float` `token_val` to avoid 
  shadowing the `tokens: list[float]` variable below it, fixing 3 errors
- `webhooks.py`: wrapped `response.body` in `bytes()`  Starlette types it as 
  `bytes | memoryview[int]` but `json.loads()` only accepts `str | bytes | bytearray`

Deliberately skipped (per issue instructions):
- `plans.py`, `batch_ops.py`, `task_crud.py:29`  lifecycle meta-path import 
  errors, static checkers can't follow runtime `sys.meta_path` redirects
- `well_known.py:448`  `.sign()` union across 11 key types with incompatible 
  signatures, needs careful per-type handling
- `task_crud.py:993`  `list[TaskCreate]` vs `list[TaskCreateRequest]` mismatch. 
  `TaskCreateRequest` is not exported from `bernstein.core.server` and the Protocol 
  lives in `task_store_core`. This looks like a real type defect worth a separate 
  investigation leaving it rather than silencing it.

## Checklist

- [x] `uv run ruff check src/bernstein/core/routes/` passes
- [x] `uv run mypy src/bernstein/core/routes/` 12 errors (down from 18)
- [x] `uv run pytest tests/unit/test_route_graphql.py tests/unit/test_dashboard.py -q` 52 passed
- [x] New code has type hints
- [x] No `# type: ignore` added
- [x] No runtime behaviour changed annotations only