### PR TITLE
feat(ci): deterministic context-file staleness report derived from git history

### DIFF
--- a/.github/workflows/docs-drift.yml
+++ b/.github/workflows/docs-drift.yml
@@ -12,14 +12,24 @@ name: docs-drift
 # The removed-verb check below is the one hard gate that also fails on pull
 # requests: a doc naming a deleted command surface is a factual error, not
 # staleness, so it must not be allowed to land and be fixed later.
+#
+# The context-file staleness check (scripts/check_context_staleness.py)
+# covers the failure mode the other two gates cannot see: a subtree churns
+# while the curated context file describing it stays byte-identical. It is
+# derived from git history alone, so it needs the full-history checkout
+# below; on pull requests it posts a non-blocking comment when the PR
+# itself pushes a scope over threshold, and the weekly scheduled sweep
+# opens/updates a single tracking issue for accumulated staleness.
 
 on:
   pull_request:
     paths:
       - "docs/**"
       - "src/bernstein/**"
+      - "tests/**"
       - "scripts/check_docs_drift.py"
       - "scripts/check_data_freshness.py"
+      - "scripts/check_context_staleness.py"
       - "scripts/gen_agents_md.py"
       - ".github/workflows/docs-drift.yml"
       - "AGENTS.md"
@@ -33,8 +43,10 @@ on:
     paths:
       - "docs/**"
       - "src/bernstein/**"
+      - "tests/**"
       - "scripts/check_docs_drift.py"
       - "scripts/check_data_freshness.py"
+      - "scripts/check_context_staleness.py"
       - "scripts/gen_agents_md.py"
       - ".github/workflows/docs-drift.yml"
       - "AGENTS.md"
@@ -77,6 +89,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+          # Full history: the context-file staleness check derives churn
+          # numbers from git log; a shallow clone would silently truncate
+          # every one of them, so the checker refuses shallow repos.
+          fetch-depth: 0
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.13"
@@ -103,6 +119,34 @@ jobs:
           cat drift-report.md
         shell: bash
 
+      - name: Run context-file staleness check
+        id: staleness
+        # Deterministic staleness report for curated context files (nested
+        # AGENTS.md, committed .sdd/agents-md overlays): last commit that
+        # touched each file vs the churn under its scope since, derived
+        # from git history alone. On pull requests the PR base sha is the
+        # baseline, so only files this PR itself pushes over threshold
+        # count as new flags. Advisory on every event; the weekly sweep
+        # below tracks accumulated flags in a single issue.
+        env:
+          BASELINE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set +e
+          baseline_args=()
+          if [ -n "${BASELINE_SHA}" ]; then
+            baseline_args=(--baseline "${BASELINE_SHA}")
+          fi
+          python scripts/check_context_staleness.py "${baseline_args[@]}" > staleness-report.md
+          rc=$?
+          echo "report_rc=${rc}" >> "$GITHUB_OUTPUT"
+          python scripts/check_context_staleness.py "${baseline_args[@]}" --json > staleness-report.json
+          clean=$(python -c "import json; print(json.load(open('staleness-report.json')).get('clean', False))" 2>/dev/null || echo "unknown")
+          new_flags=$(python -c "import json; print(len(json.load(open('staleness-report.json')).get('newly_flagged', [])))" 2>/dev/null || echo "0")
+          echo "clean=${clean}" >> "$GITHUB_OUTPUT"
+          echo "new_flags=${new_flags}" >> "$GITHUB_OUTPUT"
+          cat staleness-report.md
+        shell: bash
+
       - name: Upload drift report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -110,6 +154,8 @@ jobs:
           path: |
             drift-report.md
             drift-report.json
+            staleness-report.md
+            staleness-report.json
           retention-days: 14
 
       - name: Add drift report to job summary
@@ -133,6 +179,42 @@ jobs:
             const fs = require('fs');
             const body = fs.readFileSync('drift-report.md', 'utf8');
             const tag = '<!-- docs-drift-report -->';
+            const issue_number = context.payload.pull_request.number;
+            const { owner, repo } = context.repo;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number, per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(tag));
+            const payload = `${tag}\n${body}`;
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: existing.id, body: payload,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number, body: payload,
+              });
+            }
+
+      - name: Add staleness report to job summary
+        # Fork-PR fallback, mirroring the drift report above: the report
+        # stays visible even when the comment step cannot post.
+        if: github.event_name == 'pull_request' && steps.staleness.outputs.new_flags != '0' && steps.staleness.outputs.new_flags != ''
+        run: cat staleness-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment staleness report on the pull request
+        # Non-blocking by design: staleness is a review prompt, not a
+        # merge gate. Posted only when this PR itself pushed a context
+        # file's scope over threshold (new_flags from the baseline
+        # comparison), for same-repo PRs whose token can comment.
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && steps.staleness.outputs.new_flags != '0' && steps.staleness.outputs.new_flags != ''
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('staleness-report.md', 'utf8');
+            const tag = '<!-- context-staleness-report -->';
             const issue_number = context.payload.pull_request.number;
             const { owner, repo } = context.repo;
             const comments = await github.paginate(github.rest.issues.listComments, {
@@ -243,6 +325,43 @@ jobs:
             --jq '.[0].number // ""')"
           if [ -n "${EXISTING}" ]; then
             echo "Refreshing existing tracking issue #${EXISTING}"
+            gh issue edit "${EXISTING}" --repo "${GITHUB_REPOSITORY}" --title "${TITLE}" --body "${BODY}"
+          else
+            gh issue create --repo "${GITHUB_REPOSITORY}" --title "${TITLE}" \
+              --label "docs,bot" --body "${BODY}"
+          fi
+        shell: bash
+
+      # Weekly accumulated-staleness sweep: same single-tracking-issue
+      # pattern as the data-freshness step above. Staleness accrues from
+      # ordinary merges, so it must never redden a main push; the weekly
+      # issue is the durable surface for flags nobody has reconfirmed yet.
+      # The body is assembled with printf (not a heredoc) because the
+      # report legitimately contains backticks, which an unquoted heredoc
+      # would expand as command substitutions.
+      - name: Track accumulated context-file staleness (weekly)
+        if: github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          STALENESS_CLEAN: ${{ steps.staleness.outputs.clean }}
+        run: |
+          set -euo pipefail
+          TITLE="context-file staleness: curated context files lag their subtrees"
+          if [ "${STALENESS_CLEAN}" = "True" ]; then
+            echo "::notice::No stale context files; nothing to track."
+            exit 0
+          fi
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          INTRO="One or more curated context files have accumulated churn under their scope since they were last touched. Review each flagged file per docs/playbooks/docs-drift.md and touch it in a commit to reset its clock; this issue auto-updates on the next weekly sweep."
+          BODY="$(printf '%s\n\n%s\n\nWorkflow run: %s\n' "${INTRO}" "$(cat staleness-report.md)" "${RUN_URL}")"
+          EXISTING="$(gh issue list \
+            --repo "${GITHUB_REPOSITORY}" \
+            --search "in:title ${TITLE}" \
+            --state open \
+            --json number \
+            --jq '.[0].number // ""')"
+          if [ -n "${EXISTING}" ]; then
+            echo "Refreshing existing context-staleness tracking issue #${EXISTING}"
             gh issue edit "${EXISTING}" --repo "${GITHUB_REPOSITORY}" --title "${TITLE}" --body "${BODY}"
           else
             gh issue create --repo "${GITHUB_REPOSITORY}" --title "${TITLE}" \

--- a/docs/playbooks/docs-drift.md
+++ b/docs/playbooks/docs-drift.md
@@ -165,6 +165,62 @@ curl -sS https://pypistats.org/api/packages/bernstein/recent | jq .data
 - The `docs-data-freshness` check is advisory and is not part of the canary
   list of required checks.
 
+## Context-file staleness (curated context files vs their subtrees)
+
+The two gates above check *internal consistency* (`bernstein agents-md
+verify`) and *referential integrity* (source-of-truth paths still exist).
+Neither can notice a subtree churning for weeks while the curated context
+file that describes it stays byte-identical. `scripts/check_context_staleness.py`
+covers that third failure mode with a report derived from git history alone.
+
+What it computes, per curated context file (nested `AGENTS.md` under `src/`
+and `tests/`, plus `.sdd/agents-md/*.md` overlays when committed):
+
+- the last commit that touched the file;
+- the net diff under the file's scope since that commit (files changed,
+  insertions + deletions, `*.py` modules added or removed);
+- the commits in that range ranked by churn, so every flag names the exact
+  commits that aged the file.
+
+Flag rules (named constants at the top of the script):
+
+| Context file kind | Scope | Flags when |
+|-------------------|-------|------------|
+| Nested `AGENTS.md` | its directory subtree | net churn >= 200 lines, or any `*.py` module added/removed |
+| Committed `.sdd/agents-md` overlay | whole repository | net churn >= 2000 lines (module events alone never flag repo-wide prose) |
+
+The computation is a pure function of the repository state: two runs on the
+same repo state produce byte-identical output. Rename detection is disabled
+explicitly (`--no-renames`), so a rename surfaces as one module-removed plus
+one module-added event and the verdict cannot vary with git version or local
+diff configuration. The checker refuses to run on a shallow clone (exit 2)
+rather than emit silently truncated numbers.
+
+Where it surfaces (`.github/workflows/docs-drift.yml`):
+
+- **Pull requests**: a non-blocking comment (marker tag
+  `<!-- context-staleness-report -->`), posted only when the PR itself pushes
+  a scope over threshold — the PR base sha is passed as `--baseline` and only
+  newly flagged files count.
+- **Weekly schedule**: accumulated flags are upserted into a single tracking
+  issue titled `context-file staleness: curated context files lag their
+  subtrees` (updated in place, never duplicated).
+- It never fails a push to `main`: staleness accrues from ordinary merges and
+  is a review prompt, not a merge gate.
+
+To clear a flag, review the context file against its scope and touch it in a
+commit — update the prose, or make a reconfirmation-only edit if everything
+still holds. Either way the "is this still true?" review leaves a commit that
+resets the file's clock.
+
+Run it locally:
+
+```bash
+uv run python scripts/check_context_staleness.py           # markdown report
+uv run python scripts/check_context_staleness.py --json    # machine-readable
+uv run python scripts/check_context_staleness.py --strict  # exit 1 on any flag
+```
+
 ## Cross-repo
 
 The public website mirrors some docs pages.

--- a/scripts/check_context_staleness.py
+++ b/scripts/check_context_staleness.py
@@ -1,0 +1,487 @@
+#!/usr/bin/env python3
+"""Context-file staleness checker.
+
+The repo's context-file gates check internal consistency (``bernstein
+agents-md verify``) and referential integrity (``check_docs_drift.py``).
+Neither notices the third failure mode: a subtree churns for weeks while
+the curated context file that describes it stays byte-identical. The
+generator keeps module tables fresh mechanically, but curated content
+(nested ``AGENTS.md`` files, committed ``.sdd/agents-md`` overlays)
+asserts invariants the generator cannot derive, and those age silently.
+
+This script derives a staleness report from git history alone. For each
+curated context file it computes:
+
+1. The last commit that touched the file.
+2. The net diff under the file's scope since that commit (files
+   changed, insertions + deletions, ``*.py`` modules added or removed).
+3. The commits in that range, ranked by churn, so every flag names the
+   exact commits that aged the file.
+
+A nested ``AGENTS.md`` is flagged when the net line churn under its
+directory reaches ``SUBTREE_LINE_THRESHOLD``, or when any ``*.py``
+module was added or removed under it (a public-surface event the prose
+almost certainly describes). A committed ``.sdd/agents-md`` overlay is
+repo-scoped prose, so it is flagged on line churn only, at the larger
+``REPO_SCOPE_LINE_THRESHOLD``.
+
+The computation is a pure function of the repository state: two runs on
+the same repo state produce byte-identical output on any machine. Rename
+detection is disabled explicitly (``--no-renames``) so the report cannot
+vary with git version or local diff configuration; a rename therefore
+surfaces as one module-removed plus one module-added event, which is the
+staleness signal we want (the prose likely names the old path). Touching
+a context file in a commit — updating it, or a reconfirmation-only edit
+— resets its clock, so the review of "is this still true?" always
+leaves a commit.
+
+Exits non-zero on flags only with ``--strict`` (the scheduled sweep uses
+it to decide whether to update the tracking issue); without ``--strict``
+the report is advisory and the exit code is always 0. Exit code 2 means
+the repository cannot be assessed (shallow clone: truncated history
+would silently corrupt every number).
+
+Usage:
+
+    uv run python scripts/check_context_staleness.py \
+        [--strict] [--json] [--ref REF] [--baseline REF] [--repo PATH]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Top-level roots searched for nested per-directory ``AGENTS.md`` files.
+# Mirrors ``_DIRECTORY_CONTEXT_ROOTS`` in
+# ``src/bernstein/core/knowledge/agents_md_generator.py``: a fixed
+# allowlist keeps the report byte-stable across environments.
+DIRECTORY_CONTEXT_ROOTS: tuple[str, ...] = ("src", "tests")
+
+# Curated overlay directory (repo-scoped context, when committed).
+OVERLAY_DIR = ".sdd/agents-md"
+
+# Net insertions + deletions under a nested AGENTS.md's directory since
+# the file's last commit at which the file is flagged.
+SUBTREE_LINE_THRESHOLD = 200
+
+# Committed overlays describe the whole repository, so they age slower
+# per line of churn; the flag threshold is correspondingly larger.
+REPO_SCOPE_LINE_THRESHOLD = 2000
+
+# How many top-churn commits each flagged entry names.
+TOP_COMMITS = 5
+
+# Short-sha display length. Fixed here (not ``%h``) because git's
+# abbreviation length varies with object count and ``core.abbrev``.
+SHORT_SHA_LEN = 12
+
+# Explicit config overrides so local git configuration cannot change the
+# output. ``--no-renames`` is passed per diff/log call below; ``log.follow``
+# is forced off because it silently rewrites single-path ``git log`` queries
+# (the last-touch lookup) on machines that enable it.
+_GIT_OVERRIDES = (
+    "-c",
+    "core.quotePath=false",
+    "-c",
+    "log.showSignature=false",
+    "-c",
+    "log.follow=false",
+)
+
+_COMMIT_HEADER_RE = re.compile(r"^[0-9a-f]{40}\t")
+_NUMSTAT_RE = re.compile(r"^(\d+|-)\t(\d+|-)\t(.+)$")
+
+
+class GitError(RuntimeError):
+    """A git invocation failed."""
+
+
+def _git(repo: Path, *args: str) -> str:
+    """Run git in ``repo`` with pinned config overrides; return stdout."""
+    result = subprocess.run(
+        ["git", *_GIT_OVERRIDES, *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    if result.returncode != 0:
+        raise GitError(f"git {' '.join(args)} failed: {result.stderr.strip()}")
+    return result.stdout
+
+
+@dataclass(frozen=True)
+class ContextFile:
+    """A curated context file and the subtree it describes."""
+
+    path: str
+    scope: str  # directory prefix, or "" for repo scope
+    repo_scoped: bool
+
+
+@dataclass(frozen=True)
+class CommitChurn:
+    sha: str
+    subject: str
+    lines: int
+
+
+@dataclass
+class StalenessEntry:
+    context: ContextFile
+    last_commit: str
+    last_commit_date: str
+    last_commit_subject: str
+    commits_since: int = 0
+    files_changed: int = 0
+    insertions: int = 0
+    deletions: int = 0
+    modules_added: list[str] = field(default_factory=list)
+    modules_removed: list[str] = field(default_factory=list)
+    top_commits: list[CommitChurn] = field(default_factory=list)
+    newly_flagged: bool = False
+
+    @property
+    def total_lines(self) -> int:
+        return self.insertions + self.deletions
+
+    @property
+    def line_threshold(self) -> int:
+        return REPO_SCOPE_LINE_THRESHOLD if self.context.repo_scoped else SUBTREE_LINE_THRESHOLD
+
+    @property
+    def flagged(self) -> bool:
+        if self.total_lines >= self.line_threshold:
+            return True
+        if self.context.repo_scoped:
+            # Repo-scoped overlays would flag on every added module
+            # anywhere in the tree; only line churn is meaningful.
+            return False
+        return bool(self.modules_added or self.modules_removed)
+
+
+@dataclass
+class StalenessReport:
+    ref: str
+    baseline: str | None
+    entries: list[StalenessEntry] = field(default_factory=list)
+
+    @property
+    def flagged(self) -> list[StalenessEntry]:
+        return [entry for entry in self.entries if entry.flagged]
+
+    @property
+    def newly_flagged(self) -> list[StalenessEntry]:
+        return [entry for entry in self.flagged if entry.newly_flagged]
+
+    @property
+    def is_clean(self) -> bool:
+        return not self.flagged
+
+
+def _is_excluded(path: str) -> bool:
+    """Context files themselves never count as code churn."""
+    return path.rsplit("/", 1)[-1] == "AGENTS.md" or path.startswith(f"{OVERLAY_DIR}/")
+
+
+def list_context_files(repo: Path, ref: str) -> list[ContextFile]:
+    """Enumerate curated context files tracked at ``ref``.
+
+    Derived from ``git ls-tree`` so untracked scratch files can never
+    enter the report (the same rule the agents-md generator applies).
+    """
+    tracked = _git(repo, "ls-tree", "-r", "--name-only", "-z", ref).split("\0")
+    out: list[ContextFile] = []
+    for path in sorted(p for p in tracked if p):
+        parts = path.split("/")
+        if len(parts) >= 2 and parts[0] in DIRECTORY_CONTEXT_ROOTS and parts[-1] == "AGENTS.md":
+            out.append(ContextFile(path=path, scope="/".join(parts[:-1]), repo_scoped=False))
+        elif path.startswith(f"{OVERLAY_DIR}/") and path.endswith(".md"):
+            out.append(ContextFile(path=path, scope="", repo_scoped=True))
+    return out
+
+
+def _last_touch(repo: Path, ref: str, path: str) -> tuple[str, str, str] | None:
+    """Return (sha, committer-date, subject) of the last commit touching ``path``."""
+    out = _git(repo, "log", "-1", "--no-renames", "--format=%H%x09%cI%x09%s", ref, "--", path)
+    line = out.strip("\n")
+    if not line:
+        return None
+    parts = line.split("\t", 2)
+    sha = parts[0]
+    date = parts[1] if len(parts) > 1 else ""
+    subject = parts[2] if len(parts) > 2 else ""
+    return sha, date, subject
+
+
+def _net_diff(repo: Path, last: str, ref: str, scope: str) -> tuple[int, int, int, list[str], list[str]]:
+    """Net (files, insertions, deletions, modules added, modules removed)."""
+    pathspec = [f"{scope}/"] if scope else []
+    numstat = _git(repo, "diff", "--numstat", "--no-renames", last, ref, "--", *pathspec)
+    files = insertions = deletions = 0
+    for line in numstat.splitlines():
+        match = _NUMSTAT_RE.match(line)
+        if not match or _is_excluded(match.group(3)):
+            continue
+        files += 1
+        if match.group(1) != "-":
+            insertions += int(match.group(1))
+            deletions += int(match.group(2))
+
+    name_status = _git(repo, "diff", "--name-status", "--no-renames", last, ref, "--", *pathspec)
+    added: list[str] = []
+    removed: list[str] = []
+    for line in name_status.splitlines():
+        fields = line.split("\t")
+        if len(fields) < 2:
+            continue
+        status, path = fields[0], fields[1]
+        if _is_excluded(path) or not path.endswith(".py"):
+            continue
+        if status.startswith("A"):
+            added.append(path)
+        elif status.startswith("D"):
+            removed.append(path)
+    return files, insertions, deletions, sorted(added), sorted(removed)
+
+
+def _commit_churn(repo: Path, last: str, ref: str, scope: str) -> tuple[int, list[CommitChurn]]:
+    """Per-commit churn in ``last..ref`` under ``scope``.
+
+    Returns the number of commits with at least one non-excluded change
+    and the top ``TOP_COMMITS`` commits by lines changed (ties broken by
+    sha so the ranking is total and deterministic).
+    """
+    pathspec = [f"{scope}/"] if scope else []
+    out = _git(
+        repo,
+        "log",
+        "--no-renames",
+        "--format=%H%x09%s",
+        "--numstat",
+        f"{last}..{ref}",
+        "--",
+        *pathspec,
+    )
+    commits: list[CommitChurn] = []
+    sha = subject = ""
+    lines = 0
+    touched = False
+
+    def _close() -> None:
+        if sha and touched:
+            commits.append(CommitChurn(sha=sha, subject=subject, lines=lines))
+
+    for raw in out.splitlines():
+        if _COMMIT_HEADER_RE.match(raw):
+            _close()
+            parts = raw.split("\t", 1)
+            sha = parts[0]
+            subject = parts[1] if len(parts) > 1 else ""
+            lines = 0
+            touched = False
+            continue
+        match = _NUMSTAT_RE.match(raw)
+        if not match or _is_excluded(match.group(3)):
+            continue
+        touched = True
+        if match.group(1) != "-":
+            lines += int(match.group(1)) + int(match.group(2))
+    _close()
+
+    top = sorted(
+        (c for c in commits if c.lines > 0),
+        key=lambda c: (-c.lines, c.sha),
+    )[:TOP_COMMITS]
+    return len(commits), top
+
+
+def compute_report(repo: Path, ref: str, baseline: str | None = None) -> StalenessReport:
+    """Compute the staleness report at ``ref``.
+
+    With ``baseline``, each flagged entry is additionally marked
+    ``newly_flagged`` when the same context file was not flagged at the
+    baseline commit — the signal the PR surface keys on.
+    """
+    ref_sha = _git(repo, "rev-parse", "--verify", f"{ref}^{{commit}}").strip()
+    baseline_sha: str | None = None
+    baseline_flagged: set[str] = set()
+    if baseline is not None:
+        baseline_sha = _git(repo, "rev-parse", "--verify", f"{baseline}^{{commit}}").strip()
+        baseline_flagged = {entry.context.path for entry in _compute_entries(repo, baseline_sha) if entry.flagged}
+
+    report = StalenessReport(ref=ref_sha, baseline=baseline_sha)
+    report.entries = _compute_entries(repo, ref_sha)
+    if baseline_sha is not None:
+        for entry in report.entries:
+            entry.newly_flagged = entry.flagged and entry.context.path not in baseline_flagged
+    return report
+
+
+def _compute_entries(repo: Path, ref_sha: str) -> list[StalenessEntry]:
+    entries: list[StalenessEntry] = []
+    for context in list_context_files(repo, ref_sha):
+        last = _last_touch(repo, ref_sha, context.path)
+        if last is None:  # pragma: no cover - tracked files always have a commit
+            continue
+        last_sha, last_date, last_subject = last
+        entry = StalenessEntry(
+            context=context,
+            last_commit=last_sha,
+            last_commit_date=last_date,
+            last_commit_subject=last_subject,
+        )
+        (
+            entry.files_changed,
+            entry.insertions,
+            entry.deletions,
+            entry.modules_added,
+            entry.modules_removed,
+        ) = _net_diff(repo, last_sha, ref_sha, context.scope)
+        entry.commits_since, entry.top_commits = _commit_churn(repo, last_sha, ref_sha, context.scope)
+        entries.append(entry)
+    return entries
+
+
+def _short(sha: str) -> str:
+    return sha[:SHORT_SHA_LEN]
+
+
+def _md_escape(text: str) -> str:
+    return text.replace("|", "\\|")
+
+
+def _fmt_modules(paths: list[str], limit: int = 10) -> str:
+    shown = ", ".join(f"`{p}`" for p in paths[:limit])
+    extra = len(paths) - limit
+    return f"{shown} (+{extra} more)" if extra > 0 else shown
+
+
+def render_markdown(report: StalenessReport) -> str:
+    parts: list[str] = ["# Context-file staleness report\n\n"]
+    parts.append(
+        f"Checked {len(report.entries)} curated context file(s) at `{_short(report.ref)}`. "
+        f"{len(report.flagged)} flagged.\n"
+    )
+    if report.baseline is not None:
+        parts.append(f"Baseline `{_short(report.baseline)}`: {len(report.newly_flagged)} newly flagged since.\n")
+    parts.append("\n")
+
+    if report.is_clean:
+        parts.append("All curated context files are fresh relative to the code they describe.\n")
+        return "".join(parts)
+
+    for entry in report.flagged:
+        scope_label = f"`{entry.context.scope}/`" if entry.context.scope else "the whole repository"
+        marker = " (newly flagged in this range)" if entry.newly_flagged else ""
+        parts.append(f"## `{entry.context.path}`{marker}\n\n")
+        parts.append(f"- Scope: {scope_label}\n")
+        parts.append(
+            f"- Last touched: `{_short(entry.last_commit)}` ({entry.last_commit_date}) — {entry.last_commit_subject}\n"
+        )
+        parts.append(
+            f"- Since then: {entry.commits_since} commit(s) in scope; net diff "
+            f"{entry.files_changed} file(s), +{entry.insertions}/-{entry.deletions} "
+            f"({entry.total_lines} lines, threshold {entry.line_threshold})\n"
+        )
+        if entry.modules_added:
+            parts.append(f"- Modules added: {_fmt_modules(entry.modules_added)}\n")
+        if entry.modules_removed:
+            parts.append(f"- Modules removed: {_fmt_modules(entry.modules_removed)}\n")
+        if entry.top_commits:
+            parts.append("- Top commits by churn:\n\n")
+            parts.append("| Commit | Lines | Subject |\n|--------|-------|---------|\n")
+            for commit in entry.top_commits:
+                parts.append(f"| `{_short(commit.sha)}` | {commit.lines} | {_md_escape(commit.subject)} |\n")
+        parts.append("\n")
+
+    parts.append(
+        "To clear a flag, review the context file against its scope and touch it in a "
+        "commit — update it, or make a reconfirmation-only edit. Either way the "
+        '"is this still true?" review leaves a commit that resets the clock.\n'
+    )
+    return "".join(parts)
+
+
+def render_json(report: StalenessReport) -> str:
+    payload = {
+        "ref": report.ref,
+        "baseline": report.baseline,
+        "files_checked": len(report.entries),
+        "clean": report.is_clean,
+        "flagged": [
+            {
+                "path": entry.context.path,
+                "scope": entry.context.scope,
+                "repo_scoped": entry.context.repo_scoped,
+                "last_commit": entry.last_commit,
+                "last_commit_date": entry.last_commit_date,
+                "commits_since": entry.commits_since,
+                "files_changed": entry.files_changed,
+                "insertions": entry.insertions,
+                "deletions": entry.deletions,
+                "total_lines": entry.total_lines,
+                "line_threshold": entry.line_threshold,
+                "modules_added": entry.modules_added,
+                "modules_removed": entry.modules_removed,
+                "top_commits": [
+                    {"sha": commit.sha, "lines": commit.lines, "subject": commit.subject}
+                    for commit in entry.top_commits
+                ],
+                "newly_flagged": entry.newly_flagged,
+            }
+            for entry in report.flagged
+        ],
+        "newly_flagged": [entry.context.path for entry in report.newly_flagged],
+    }
+    return json.dumps(payload, indent=2)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Deterministic context-file staleness report from git history.")
+    parser.add_argument("--repo", type=Path, default=REPO_ROOT, help="Repository root (default: this repo).")
+    parser.add_argument("--ref", default="HEAD", help="Commit to assess (default: HEAD).")
+    parser.add_argument(
+        "--baseline",
+        default=None,
+        help="Also compute flags at this commit and mark entries newly flagged since (PR surface).",
+    )
+    parser.add_argument("--strict", action="store_true", help="Exit 1 when any context file is flagged.")
+    parser.add_argument("--json", action="store_true", help="Emit a JSON summary instead of the Markdown report.")
+    args = parser.parse_args()
+
+    repo = args.repo.resolve()
+    try:
+        if _git(repo, "rev-parse", "--is-shallow-repository").strip() == "true":
+            print(
+                "ERROR: shallow clone; history-derived churn would be silently wrong. "
+                "Fetch full history (fetch-depth: 0) and re-run.",
+                file=sys.stderr,
+            )
+            return 2
+        report = compute_report(repo, args.ref, args.baseline)
+    except GitError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    print(render_json(report) if args.json else render_markdown(report), end="")
+    if args.json:
+        print()
+
+    if args.strict and not report.is_clean:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -29,6 +29,8 @@ uv run pytest tests/unit/test_foo.py -x -q    # single file (fast)
 - Docs-guard tests (`unit/test_naming_policy_docs.py`,
   `unit/test_nested_agents_context.py`) pin repo-level invariants;
   extend them when adding gated docs.
+- Tests for `scripts/*.py` load the script via importlib; git-derived
+  behaviour runs on synthetic repos (`unit/test_context_staleness.py`).
 
 ## Gotchas
 

--- a/tests/unit/test_context_staleness.py
+++ b/tests/unit/test_context_staleness.py
@@ -1,0 +1,328 @@
+"""Behavioural tests for ``scripts/check_context_staleness.py``.
+
+The staleness report is a pure function of git history, so every test
+builds a real synthetic git repository (``git init`` + commits with
+pinned author/committer identity and dates, isolated from user and
+system git config) and asserts on the script's actual output. The script
+module is loaded via importlib (the ``tests/unit/test_gen_agents_md_split.py``
+pattern) for its named constants; end-to-end runs go through a
+subprocess so exit codes and byte-level determinism are tested for real.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check_context_staleness.py"
+
+
+@pytest.fixture
+def staleness():
+    """Load scripts/check_context_staleness.py without executing main()."""
+    spec = importlib.util.spec_from_file_location("check_context_staleness_under_test", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    yield module
+    sys.modules.pop(spec.name, None)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic-repo helpers
+# ---------------------------------------------------------------------------
+
+
+def _git_env(tmp_path: Path) -> dict[str, str]:
+    """Pinned identity + config isolation so host git config is inert."""
+    import os
+
+    empty_config = tmp_path / "empty-gitconfig"
+    empty_config.touch()
+    return {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "Synthetic",
+        "GIT_AUTHOR_EMAIL": "synthetic@example.invalid",
+        "GIT_COMMITTER_NAME": "Synthetic",
+        "GIT_COMMITTER_EMAIL": "synthetic@example.invalid",
+        "GIT_AUTHOR_DATE": "2026-01-01T00:00:00+00:00",
+        "GIT_COMMITTER_DATE": "2026-01-01T00:00:00+00:00",
+        "GIT_CONFIG_GLOBAL": str(empty_config),
+        "GIT_CONFIG_SYSTEM": str(empty_config),
+    }
+
+
+def _git(repo: Path, env: dict[str, str], *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _write(repo: Path, rel: str, text: str) -> None:
+    path = repo / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8", newline="\n")
+
+
+def _seed_repo(tmp_path: Path) -> tuple[Path, dict[str, str]]:
+    """One commit: a context file plus modules inside and outside its scope."""
+    env = _git_env(tmp_path)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, env, "-c", "init.defaultBranch=main", "init", "--quiet")
+    _write(repo, "src/pkg/AGENTS.md", "# pkg context\n\nInvariant: mod.py stays small.\n")
+    _write(repo, "src/pkg/mod.py", "".join(f"LINE_{i} = {i}\n" for i in range(10)))
+    _write(repo, "src/other/util.py", "UTIL = 1\n")
+    _git(repo, env, "add", "-A")
+    _git(repo, env, "commit", "--quiet", "-m", "seed: context file and modules")
+    return repo, env
+
+
+def _run(repo: Path, env: dict[str, str], *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--repo", str(repo), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+def _run_json(repo: Path, env: dict[str, str], *args: str) -> dict:
+    proc = _run(repo, env, "--json", *args)
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)
+
+
+def _big_rewrite(repo: Path, env: dict[str, str], rel: str = "src/pkg/mod.py", lines: int = 250) -> str:
+    """Rewrite ``rel`` with ``lines`` fresh lines; return the commit sha."""
+    _write(repo, rel, "".join(f"CHURN_{i} = {i}\n" for i in range(lines)))
+    _git(repo, env, "add", "-A")
+    _git(repo, env, "commit", "--quiet", "-m", f"churn: rewrite {rel}")
+    return _git(repo, env, "rev-parse", "HEAD")
+
+
+# ---------------------------------------------------------------------------
+# Flagging behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_churned_subtree_with_untouched_context_file_is_flagged(tmp_path: Path, staleness) -> None:
+    repo, env = _seed_repo(tmp_path)
+    seed_sha = _git(repo, env, "rev-parse", "HEAD")
+    churn_sha = _big_rewrite(repo, env, lines=staleness.SUBTREE_LINE_THRESHOLD + 50)
+
+    payload = _run_json(repo, env)
+    assert payload["clean"] is False
+    (entry,) = payload["flagged"]
+    assert entry["path"] == "src/pkg/AGENTS.md"
+    assert entry["last_commit"] == seed_sha
+    assert entry["total_lines"] >= staleness.SUBTREE_LINE_THRESHOLD
+    # The report names the exact commit that aged the file.
+    assert entry["top_commits"][0]["sha"] == churn_sha
+
+    markdown = _run(repo, env).stdout
+    assert "src/pkg/AGENTS.md" in markdown
+    assert seed_sha[: staleness.SHORT_SHA_LEN] in markdown
+    assert churn_sha[: staleness.SHORT_SHA_LEN] in markdown
+
+
+def test_churn_below_threshold_is_not_flagged(tmp_path: Path) -> None:
+    repo, env = _seed_repo(tmp_path)
+    _write(repo, "src/pkg/mod.py", "".join(f"LINE_{i} = {i + 1}\n" for i in range(10)))
+    _git(repo, env, "add", "-A")
+    _git(repo, env, "commit", "--quiet", "-m", "churn: small tweak")
+
+    payload = _run_json(repo, env)
+    assert payload["clean"] is True
+    assert payload["flagged"] == []
+    assert payload["files_checked"] == 1
+
+
+def test_reconfirmation_only_edit_clears_the_flag(tmp_path: Path) -> None:
+    repo, env = _seed_repo(tmp_path)
+    _big_rewrite(repo, env)
+    assert _run_json(repo, env)["clean"] is False
+
+    # A no-op reconfirmation edit: the content review leaves a commit.
+    agents = repo / "src/pkg/AGENTS.md"
+    _write(repo, "src/pkg/AGENTS.md", agents.read_text(encoding="utf-8") + "\n<!-- reconfirmed -->\n")
+    _git(repo, env, "add", "-A")
+    _git(repo, env, "commit", "--quiet", "-m", "docs: reconfirm pkg context")
+
+    payload = _run_json(repo, env)
+    assert payload["clean"] is True
+    assert payload["flagged"] == []
+
+
+def test_module_add_flags_even_below_line_threshold(tmp_path: Path, staleness) -> None:
+    repo, env = _seed_repo(tmp_path)
+    _write(repo, "src/pkg/new_module.py", "NEW = 1\n")
+    _git(repo, env, "add", "-A")
+    _git(repo, env, "commit", "--quiet", "-m", "feat: add new module")
+
+    payload = _run_json(repo, env)
+    (entry,) = payload["flagged"]
+    assert entry["path"] == "src/pkg/AGENTS.md"
+    assert entry["modules_added"] == ["src/pkg/new_module.py"]
+    assert entry["total_lines"] < staleness.SUBTREE_LINE_THRESHOLD
+
+
+def test_module_removal_flags_even_below_line_threshold(tmp_path: Path, staleness) -> None:
+    repo, env = _seed_repo(tmp_path)
+    _git(repo, env, "rm", "--quiet", "src/pkg/mod.py")
+    _git(repo, env, "commit", "--quiet", "-m", "refactor: drop module")
+
+    payload = _run_json(repo, env)
+    (entry,) = payload["flagged"]
+    assert entry["path"] == "src/pkg/AGENTS.md"
+    assert entry["modules_removed"] == ["src/pkg/mod.py"]
+    assert entry["total_lines"] < staleness.SUBTREE_LINE_THRESHOLD
+
+
+def test_sibling_directory_churn_does_not_age_the_file(tmp_path: Path) -> None:
+    repo, env = _seed_repo(tmp_path)
+    _big_rewrite(repo, env, rel="src/other/util.py", lines=300)
+
+    payload = _run_json(repo, env)
+    assert payload["clean"] is True
+    assert payload["flagged"] == []
+
+
+def test_untracked_context_files_never_enter_the_report(tmp_path: Path) -> None:
+    repo, env = _seed_repo(tmp_path)
+    _write(repo, "src/scratch/AGENTS.md", "# untracked scratch context\n")
+
+    payload = _run_json(repo, env)
+    assert payload["files_checked"] == 1
+    assert "scratch" not in _run(repo, env).stdout
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_report_is_deterministic_for_fixed_history(tmp_path: Path) -> None:
+    repo, env = _seed_repo(tmp_path)
+    _big_rewrite(repo, env)
+
+    md_runs = [_run(repo, env) for _ in range(2)]
+    json_runs = [_run(repo, env, "--json") for _ in range(2)]
+    assert md_runs[0].stdout == md_runs[1].stdout
+    assert json_runs[0].stdout == json_runs[1].stdout
+    assert [p.returncode for p in md_runs + json_runs] == [0, 0, 0, 0]
+
+
+def test_rename_detection_config_cannot_change_the_report(tmp_path: Path) -> None:
+    """A ``git mv`` is one removed + one added surface event, regardless of
+    the repo's ``diff.renames`` setting - the verdict must not vary with
+    git configuration."""
+    repo, env = _seed_repo(tmp_path)
+    _git(repo, env, "mv", "src/pkg/mod.py", "src/pkg/renamed.py")
+    _git(repo, env, "commit", "--quiet", "-m", "refactor: rename module")
+
+    outputs: list[str] = []
+    for value in ("true", "false"):
+        _git(repo, env, "config", "diff.renames", value)
+        outputs.append(_run(repo, env).stdout)
+        payload = _run_json(repo, env)
+        (entry,) = payload["flagged"]
+        assert entry["modules_removed"] == ["src/pkg/mod.py"]
+        assert entry["modules_added"] == ["src/pkg/renamed.py"]
+    assert outputs[0] == outputs[1]
+
+
+# ---------------------------------------------------------------------------
+# Exit codes and surfaces
+# ---------------------------------------------------------------------------
+
+
+def test_strict_flag_gates_exit_code_and_advisory_mode_never_fails(tmp_path: Path) -> None:
+    repo, env = _seed_repo(tmp_path)
+    assert _run(repo, env, "--strict").returncode == 0  # clean + strict
+
+    _big_rewrite(repo, env)
+    assert _run(repo, env).returncode == 0  # flagged + advisory
+    assert _run(repo, env, "--strict").returncode == 1  # flagged + strict
+
+
+def test_baseline_marks_only_newly_flagged(tmp_path: Path, staleness) -> None:
+    env = _git_env(tmp_path)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, env, "-c", "init.defaultBranch=main", "init", "--quiet")
+    for pkg in ("alpha", "beta"):
+        _write(repo, f"src/{pkg}/AGENTS.md", f"# {pkg} context\n")
+        _write(repo, f"src/{pkg}/mod.py", "".join(f"LINE_{i} = {i}\n" for i in range(10)))
+    _git(repo, env, "add", "-A")
+    _git(repo, env, "commit", "--quiet", "-m", "seed: two scoped context files")
+
+    baseline_sha = _big_rewrite(repo, env, rel="src/alpha/mod.py")  # alpha flagged at baseline
+    _big_rewrite(repo, env, rel="src/beta/mod.py")  # beta flagged only at head
+
+    payload = _run_json(repo, env, "--baseline", baseline_sha)
+    assert {e["path"] for e in payload["flagged"]} == {"src/alpha/AGENTS.md", "src/beta/AGENTS.md"}
+    assert payload["newly_flagged"] == ["src/beta/AGENTS.md"]
+
+    # The module API agrees with the CLI surface.
+    report = staleness.compute_report(repo, "HEAD", baseline_sha)
+    assert [e.context.path for e in report.newly_flagged] == ["src/beta/AGENTS.md"]
+
+
+def test_committed_overlay_is_repo_scoped_and_flags_on_lines_only(tmp_path: Path, staleness) -> None:
+    env = _git_env(tmp_path)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, env, "-c", "init.defaultBranch=main", "init", "--quiet")
+    _write(repo, ".sdd/agents-md/conventions.md", "# repo conventions\n")
+    _write(repo, "src/x/code.py", "X = 1\n")
+    _git(repo, env, "add", "-A")
+    _git(repo, env, "commit", "--quiet", "-m", "seed: committed overlay")
+
+    # A module add anywhere must NOT flag a repo-scoped overlay.
+    _write(repo, "src/x/extra.py", "Y = 2\n")
+    _git(repo, env, "add", "-A")
+    _git(repo, env, "commit", "--quiet", "-m", "feat: small module add")
+    assert _run_json(repo, env)["clean"] is True
+
+    # Crossing the repo-scope line threshold does flag it.
+    _big_rewrite(repo, env, rel="src/x/code.py", lines=staleness.REPO_SCOPE_LINE_THRESHOLD + 100)
+    payload = _run_json(repo, env)
+    (entry,) = payload["flagged"]
+    assert entry["path"] == ".sdd/agents-md/conventions.md"
+    assert entry["repo_scoped"] is True
+    assert entry["line_threshold"] == staleness.REPO_SCOPE_LINE_THRESHOLD
+
+
+def test_shallow_clone_is_rejected_instead_of_reporting_wrong_numbers(tmp_path: Path) -> None:
+    repo, env = _seed_repo(tmp_path)
+    _big_rewrite(repo, env)
+    shallow = tmp_path / "shallow"
+    _git(
+        tmp_path,
+        env,
+        "clone",
+        "--quiet",
+        "--depth",
+        "1",
+        f"file://{repo.as_posix()}",
+        str(shallow),
+    )
+
+    proc = _run(shallow, env)
+    assert proc.returncode == 2
+    assert "shallow" in proc.stderr.lower()

--- a/tests/unit/test_context_staleness_workflow_yaml.py
+++ b/tests/unit/test_context_staleness_workflow_yaml.py
@@ -1,0 +1,123 @@
+"""Structural assertions for the context-staleness surfaces in docs-drift.yml.
+
+The staleness numbers are derived purely from git history, so the workflow
+wiring is load-bearing in ways YAML will not enforce by itself: the checkout
+must fetch full history (a shallow clone makes every churn number wrong, and
+the checker refuses to run), the compute step must stay unconditional and
+advisory, the PR comment must use its own marker tag (so it can never
+overwrite the docs-drift report comment), and the weekly sweep must upsert a
+single tracking issue instead of stacking duplicates. These tests pin each of
+those properties.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "docs-drift.yml"
+
+COMPUTE_STEP = "Run context-file staleness check"
+COMMENT_STEP = "Comment staleness report on the pull request"
+SWEEP_STEP = "Track accumulated context-file staleness (weekly)"
+MARKER_TAG = "<!-- context-staleness-report -->"
+
+
+def _workflow() -> dict[str, object]:
+    return cast("dict[str, object]", yaml.safe_load(WORKFLOW.read_text(encoding="utf-8")))
+
+
+def _steps() -> list[dict[str, object]]:
+    jobs = _workflow().get("jobs")
+    assert isinstance(jobs, dict), "docs-drift.yml has no jobs mapping"
+    job = jobs.get("drift-check")
+    assert isinstance(job, dict), "expected a drift-check job"
+    steps = job.get("steps")
+    assert isinstance(steps, list), "drift-check job has no steps"
+    return [step for step in steps if isinstance(step, dict)]
+
+
+def _step(name: str) -> dict[str, object]:
+    for step in _steps():
+        if step.get("name") == name:
+            return step
+    pytest.fail(f"docs-drift.yml has no {name!r} step")
+
+
+def test_checkout_fetches_full_history() -> None:
+    """History-derived churn needs the whole history, not a shallow clone."""
+    for step in _steps():
+        uses = step.get("uses")
+        if isinstance(uses, str) and uses.startswith("actions/checkout@"):
+            with_block = step.get("with")
+            assert isinstance(with_block, dict), "checkout step has no with: block"
+            assert with_block.get("fetch-depth") == 0, (
+                "docs-drift checkout must set fetch-depth: 0 - the staleness "
+                "checker refuses shallow clones rather than emit wrong numbers"
+            )
+            return
+    pytest.fail("docs-drift.yml has no actions/checkout step")
+
+
+def test_staleness_step_runs_the_script_on_every_event() -> None:
+    """The compute step is unconditional and baseline-aware."""
+    step = _step(COMPUTE_STEP)
+    assert "if" not in step, f"{COMPUTE_STEP!r} must run on every event"
+    run = step.get("run")
+    assert isinstance(run, str)
+    assert "scripts/check_context_staleness.py" in run
+    assert "--baseline" in run, "PR runs must pass the base sha as baseline"
+    assert "--strict" not in run, "the compute step is advisory; strictness belongs to the sweep's verdict"
+
+
+def test_pr_comment_upsert_uses_its_own_marker_tag() -> None:
+    """The comment step upserts by a tag distinct from the drift report's."""
+    step = _step(COMMENT_STEP)
+    condition = step.get("if")
+    assert isinstance(condition, str)
+    assert "pull_request" in condition
+    assert "new_flags" in condition, "the comment must key on flags the PR itself introduced"
+    assert step.get("continue-on-error") is True, "a 403 on the comment API must not fail the job"
+
+    with_block = step.get("with")
+    assert isinstance(with_block, dict)
+    script = with_block.get("script")
+    assert isinstance(script, str)
+    assert MARKER_TAG in script
+    assert "<!-- docs-drift-report -->" not in script, "must not upsert into the docs-drift comment"
+    assert "updateComment" in script and "createComment" in script, "expected an upsert, not append-only comments"
+
+
+def test_weekly_sweep_upserts_a_single_tracking_issue() -> None:
+    """Scheduled runs update one tracking issue; they never stack duplicates."""
+    step = _step(SWEEP_STEP)
+    assert step.get("if") == "github.event_name == 'schedule'"
+    run = step.get("run")
+    assert isinstance(run, str)
+    assert "gh issue list" in run, "must look for an existing tracking issue first"
+    assert "gh issue edit" in run and "gh issue create" in run
+    assert "context-file staleness" in run, "the tracking-issue title anchors the upsert search"
+    assert "heredoc" not in run and "<<EOF" not in run, (
+        "the issue body must be assembled with printf - the report contains "
+        "backticks, which an unquoted heredoc expands as command substitutions"
+    )
+
+
+def test_workflow_triggers_cover_the_staleness_inputs() -> None:
+    """Edits to the checker or to covered subtrees must trigger the workflow."""
+    workflow = _workflow()
+    # PyYAML parses the bare `on:` key as boolean True (YAML 1.1).
+    triggers = workflow.get("on", workflow.get(True))
+    assert isinstance(triggers, dict), "docs-drift.yml has no on: mapping"
+    for event in ("pull_request", "push"):
+        block = triggers.get(event)
+        assert isinstance(block, dict), f"expected an on.{event} mapping"
+        paths = block.get("paths")
+        assert isinstance(paths, list), f"expected on.{event}.paths"
+        assert "scripts/check_context_staleness.py" in paths
+        assert "tests/**" in paths, "tests/ holds a covered context file; churn there must trigger the check"
+    assert "schedule" in triggers, "the weekly sweep needs the schedule trigger"


### PR DESCRIPTION
# User description
## What

A deterministic staleness report for curated context files, derived from git history alone, surfaced in the existing docs-drift cadence.

- New `scripts/check_context_staleness.py`: for each curated context file (nested `AGENTS.md` under `src/`/`tests/`, committed `.sdd/agents-md/*.md` overlays) it computes the last commit that touched the file, the net diff under its scope since (files changed, insertions+deletions, `*.py` modules added/removed), and the commits in that range ranked by churn. A nested `AGENTS.md` flags at >= 200 net lines or any module add/remove under its directory; a repo-scoped overlay flags at >= 2000 net lines only. Advisory by default; `--strict` exits 1 on any flag; `--baseline REF` marks which flags are new since that commit; shallow clones are refused (exit 2) instead of emitting silently truncated numbers.
- `.github/workflows/docs-drift.yml`: checkout now uses `fetch-depth: 0` (history-derived numbers need full history — note this changes the checkout for the whole drift-check job); a new unconditional compute step runs the checker with the PR base sha as `--baseline`; a non-blocking PR comment is upserted under its own marker tag `<!-- context-staleness-report -->` only when the PR itself pushes a scope over threshold; the weekly scheduled sweep upserts a single tracking issue (never duplicates). Trigger paths gain `tests/**` (a covered context file lives there) and the new script.
- `tests/AGENTS.md`: one-line note on the scripts-testing pattern — which also demonstrates the reset rule, since this PR's added test files would otherwise flag `tests/AGENTS.md` itself.

## Why

The existing context-file gates check internal consistency (`bernstein agents-md verify`) and referential integrity (`check_docs_drift.py`). Neither can notice a subtree churning for weeks while the curated prose describing it stays byte-identical — the generator keeps module tables fresh mechanically, but curated invariants and gotchas age silently, and the first consumer to find out is an agent acting on a stale invariant inside a worktree. Closes #3373.

## How

Everything is a pure function of the repository state: enumeration comes from `git ls-tree` (untracked files can never enter the report), churn from `git diff --numstat/--name-status` and `git log --numstat` between the file's last-touch commit and the assessed ref, all output sorted, short shas truncated at a fixed length in Python. Rename detection is pinned off (`--no-renames`, plus `log.follow=false` and other `-c` overrides), so a `git mv` deterministically surfaces as one module-removed plus one module-added event and no local git configuration can change the verdict — a unit test flips `diff.renames` both ways and asserts byte-identical output. The flag resets only when the context file itself is touched in a commit, so every "is this still true?" review leaves auditable history. GitHub surfacing (comment, tracking issue) lives entirely in the workflow, keeping the script and its tests network-free. The scheduled issue body is assembled with `printf` rather than the heredoc pattern used by the data-freshness step, because the staleness report legitimately contains backticks, which an unquoted heredoc would expand as command substitutions.

Rejected alternative: summed per-commit churn as the flag metric (activity since last touch) instead of the net endpoint diff. Summed churn looks like the more natural "how much happened here" number, but it flags subtrees whose edits net out to nearly nothing (revert ping-pong, formatting round-trips) even though the code the prose describes is unchanged — and that makes flags unarguable in the wrong direction: a maintainer can be told to reconfirm a file describing code that is provably identical to what it described before. The net diff between the file's last-touch commit and the assessed ref is the honest question ("has the thing the doc describes materially changed?"), while the per-commit view is kept where it is useful — ranking the top offending commits inside the report so every flag names its cause.

Tests were proven red-first: with `scripts/check_context_staleness.py` and the workflow edit stashed, all 18 new tests fail (13 script tests error on the missing script, 5 structural tests fail on the missing workflow wiring); after restoring, all 18 pass. The staleness tests build real synthetic git repos (`git init`, pinned identity/dates, isolated global/system git config) and run the script end-to-end as a subprocess.

## Checklist

- [x] `uv run ruff check src/` passes (run repo-wide: `ruff check .` clean, `ruff format --check .` clean)
- [x] `uv run pyright src/` — no `src/` changes in this PR; the new script is under `scripts/`, outside both strict-zone configs
- [x] `uv run python scripts/run_tests.py -x` — run per-file (repo policy for constrained environments): the 6 touched/affected test files pass (`test_context_staleness.py`, `test_context_staleness_workflow_yaml.py`, `test_docs_drift_workflow_yaml.py`, `test_workflow_topology_report.py`, `test_nested_agents_context.py`, `test_naming_policy_docs.py`)
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)

- [x] README section updated — N/A (operator/CI surface; documented in the docs-drift playbook)
- [x] `docs/operations/<area>.md` updated — `docs/operations/ci-topology.md` verified current with `gen_workflow_topology.py --check` (no regeneration needed: the edits add steps and path filters, which the topology report does not track — job count, triggers, permissions, and artifact names are unchanged)
- [x] `docs/api/` schema regenerated — N/A (no API surface)
- [x] `uv run bernstein agents-md sync` — `agents-md verify` passes (all 14 files in sync); `tests/AGENTS.md` edit stays within the 40-line budget pinned by `test_nested_agents_context.py`
- [x] Tests cover the documented behaviour — `docs/playbooks/docs-drift.md` gains a "Context-file staleness" section whose thresholds, determinism claims, and surfaces are each pinned by the new tests

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add a deterministic <code>scripts/check_context_staleness.py</code> report that uses git history to flag stale nested <code>AGENTS.md</code> files and committed <code>.sdd/agents-md</code> overlays when their scoped subtrees churn past threshold. Wire <code>.github/workflows/docs-drift.yml</code> to run the checker with full history, post PR comments, and track weekly staleness in a single issue.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3385?tool=ast&topic=CI+surfacing>CI surfacing</a>
        </td><td>Surface staleness in docs-drift CI by fetching full history, running the checker on every event, and upserting PR comments or a weekly tracking issue.<details><summary>Modified files (2)</summary><ul><li>.github/workflows/docs-drift.yml</li>
<li>tests/unit/test_context_staleness_workflow_yaml.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>feat(eval): report a d...</td><td>August 03, 2026</td></tr>
<tr><td>chernistry</td><td>docs: drop deleted cha...</td><td>August 01, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3385?tool=ast&topic=Staleness+checker>Staleness checker</a>
        </td><td>Compute a deterministic git-history-based staleness report for curated context files, including baseline-aware flags, churn ranking, and shallow-clone rejection.<details><summary>Modified files (4)</summary><ul><li>docs/playbooks/docs-drift.md</li>
<li>scripts/check_context_staleness.py</li>
<li>tests/AGENTS.md</li>
<li>tests/unit/test_context_staleness.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>feat(eval): report a d...</td><td>August 03, 2026</td></tr>
<tr><td>chernistry</td><td>docs: add per-director...</td><td>August 03, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3385?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>