### PR TITLE
feat(datasources): add a read-only query driver binding a result to the schema snapshot it was derived against

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -28,7 +28,7 @@ alwaysApply: false
 | `config/`                   | Config: seed parsing, config management, settings, feature gates |
 | `cost/`                     | cost sub-package |
 | `daemon/`                   | Daemon installation helpers for Bernstein |
-| `datasources/`              | Content-addressed query receipts (issue #2887) |
+| `datasources/`              | Content-addressed query receipts (issue #2887) and the schema-bound query driver (issue #3125) |
 | `devops/`                   | devops sub-package |
 | `distribution/`             | Distribution utilities - air-gap wheelhouse build, verify, signing |
 | `endpoints/`                | Local-model worker tier: endpoint conformance and signed certification |

--- a/.goosehints
+++ b/.goosehints
@@ -29,7 +29,7 @@ Bernstein is a deterministic orchestrator for CLI coding agents (Claude Code, Co
 | `config/`                   | Config: seed parsing, config management, settings, feature gates |
 | `cost/`                     | cost sub-package |
 | `daemon/`                   | Daemon installation helpers for Bernstein |
-| `datasources/`              | Content-addressed query receipts (issue #2887) |
+| `datasources/`              | Content-addressed query receipts (issue #2887) and the schema-bound query driver (issue #3125) |
 | `devops/`                   | devops sub-package |
 | `distribution/`             | Distribution utilities - air-gap wheelhouse build, verify, signing |
 | `endpoints/`                | Local-model worker tier: endpoint conformance and signed certification |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ Bernstein is a deterministic orchestrator for CLI coding agents (Claude Code, Co
 | `config/`                   | Config: seed parsing, config management, settings, feature gates |
 | `cost/`                     | cost sub-package |
 | `daemon/`                   | Daemon installation helpers for Bernstein |
-| `datasources/`              | Content-addressed query receipts (issue #2887) |
+| `datasources/`              | Content-addressed query receipts (issue #2887) and the schema-bound query driver (issue #3125) |
 | `devops/`                   | devops sub-package |
 | `distribution/`             | Distribution utilities - air-gap wheelhouse build, verify, signing |
 | `endpoints/`                | Local-model worker tier: endpoint conformance and signed certification |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Bernstein is a deterministic orchestrator for CLI coding agents (Claude Code, Co
 | `config/`                   | Config: seed parsing, config management, settings, feature gates |
 | `cost/`                     | cost sub-package |
 | `daemon/`                   | Daemon installation helpers for Bernstein |
-| `datasources/`              | Content-addressed query receipts (issue #2887) |
+| `datasources/`              | Content-addressed query receipts (issue #2887) and the schema-bound query driver (issue #3125) |
 | `devops/`                   | devops sub-package |
 | `distribution/`             | Distribution utilities - air-gap wheelhouse build, verify, signing |
 | `endpoints/`                | Local-model worker tier: endpoint conformance and signed certification |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -29,7 +29,7 @@ Bernstein is a deterministic orchestrator for CLI coding agents (Claude Code, Co
 | `config/`                   | Config: seed parsing, config management, settings, feature gates |
 | `cost/`                     | cost sub-package |
 | `daemon/`                   | Daemon installation helpers for Bernstein |
-| `datasources/`              | Content-addressed query receipts (issue #2887) |
+| `datasources/`              | Content-addressed query receipts (issue #2887) and the schema-bound query driver (issue #3125) |
 | `devops/`                   | devops sub-package |
 | `distribution/`             | Distribution utilities - air-gap wheelhouse build, verify, signing |
 | `endpoints/`                | Local-model worker tier: endpoint conformance and signed certification |

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Everything deep lives on the [docs site](https://bernstein.readthedocs.io/):
 | [workflows](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/operations/workflow-manifests.md) | declarative YAML DAGs of agent / command / loop nodes |
 | [web UI](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/gui/index.md) | browser dashboard on the same API the TUI uses |
 | [cloud execution](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/cloudflare/cloudflare-overview.md) | experimental: run agents on Cloudflare Workers with R2 workspace sync against your own account. The hosted `api.bernstein.run` service is not yet available |
+| [datasources](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/operations/datasources.md) | read-only query receipts, plus a query driver that binds each result to the schema snapshot it was derived against |
 | [security](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/operations/security.md) | scorecard, fuzzing, hardening |
 | [architecture](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/architecture/ARCHITECTURE.md) | how it works under the hood |
 

--- a/docs/operations/datasources.md
+++ b/docs/operations/datasources.md
@@ -177,6 +177,92 @@ taken from the receipt, so re-execution never trusts a DSN from untrusted data.
 
 ---
 
+## The schema-bound query driver
+
+The receipt above answers "which exact bytes did the model see". It does not
+answer two questions a reviewer holding a number eventually asks. First, **what
+did the statement mean when it ran?** A database logs every statement, but the
+schema state the statement was written against is nowhere in the record — a
+`SELECT` that was correct in March and means something different in July looks
+identical in the log. Second, **are these bytes bound to that statement?** The
+query driver (`bernstein.core.datasources.query_driver`) closes both by
+executing one read-only statement through the `DataActivity` phase machine
+(signed inputs → one deterministic plan → signed outputs, Ed25519 throughout —
+the same machinery the data/ops activity boundary already ships; the driver
+adds no second receipt format):
+
+1. The statement passes the textual read-only guard **before any connection
+   work** — a write is refused with a typed error and provably never reaches
+   the engine. The `mode=ro` open + deny-all-writes authorizer remain behind it
+   as defense in depth.
+2. A **canonical schema snapshot** is taken and recorded as a signed input
+   *before* the plan is derived, together with the query text and bound
+   parameters. The snapshot digest is a content address over the normalised
+   DDL in `sqlite_master` plus each table's column list — not
+   `PRAGMA schema_version`, which is a write counter: two identical schemas
+   can carry different counter values, and equal values attest nothing about
+   content.
+3. The result rows are put into **explicit canonical order** (sorted by their
+   canonical cell bytes) before encoding. An engine's row order without
+   `ORDER BY` is an unspecified plan detail; the driver never lets it into the
+   hash, so the recorded bytes are a pure function of the logical result.
+   (This is a driver-layer step: the `content_hash` of a plain query receipt
+   above still hashes rows in engine order, unchanged.)
+4. The canonical result bytes are recorded as a **signed output bound to the
+   plan hash**. Flipping one byte of the stored result breaks offline
+   verification (`verify_data_ops_receipt`) at evidence reattachment.
+
+```python
+from bernstein.core.datasources.connection import DataSourceConnection
+from bernstein.core.datasources.query_driver import build_sqlite_query_driver
+
+connection = DataSourceConnection(id="sales", driver="sqlite", dsn="/var/data/sales.db")
+driver = build_sqlite_query_driver(sdd_dir, connection)
+
+run = driver.run("SELECT region, SUM(amount) FROM orders GROUP BY region")
+run.schema_digest      # the schema snapshot the result was derived against
+run.result_hash        # sha256 over the canonical (explicitly ordered) bytes
+run.receipt            # the signed DataOpsReceipt; verifies offline
+```
+
+### Schema drift is a typed refusal
+
+Pin the snapshot a statement was recorded against and the driver fails closed
+when the live schema no longer matches — *before* executing the query:
+
+```python
+from bernstein.core.datasources.errors import SchemaDrift
+
+try:
+    driver.run("SELECT region, SUM(amount) FROM orders GROUP BY region",
+               expected_schema=recorded_snapshot)
+except SchemaDrift as drift:
+    drift.changed_object_names   # e.g. ('orders',)
+    drift.drifts[0].describe()   # "changed table 'orders': added columns 'discount'"
+```
+
+The verdict names the changed objects (added / removed / changed, with
+column-level detail for tables) instead of silently returning a number whose
+meaning changed.
+
+### Determinism
+
+The plan hash is a pure function of the signed input hashes; Ed25519 is
+deterministic; the result bytes carry an explicit row order. The same
+statement against the same fixture database with the same signing key
+therefore produces byte-identical canonical result bytes and an identical
+receipt hash — even across two entirely separate `.sdd` directories. The
+driver records only the connection **id** as provenance; a DSN (and any
+secret in it) never enters a signed input, output, or receipt byte.
+
+The reference backend is the stdlib `sqlite3` driver (Python DB-API), so the
+default install gains no dependency and CI needs no service. DuckDB and
+PostgreSQL are planned follow-ups behind the same `QueryDriverBackend`
+protocol (schema snapshot + guarded execution); the receipt path does not
+change.
+
+---
+
 ## On-disk layout
 
 Everything lives under `.sdd/datasources/`:
@@ -188,6 +274,9 @@ lineage/                  append-only log.jsonl + .jws signature sidecars
 receipts/<hash>.json      one receipt per execution
 results/<hash>.bin        optional, size-capped, re-hashable result copies
 receipts-audit.jsonl      additive, secret-free audit mirror
+cas/                      content-addressed store for the query driver's
+                          signed input/output blobs (schema snapshot, query,
+                          canonical result bytes)
 ```
 
 The audit mirror records the connection id, the query/params/content hashes, the

--- a/docs/operations/datasources.md
+++ b/docs/operations/datasources.md
@@ -201,7 +201,15 @@ adds no second receipt format):
    DDL in `sqlite_master` plus each table's column list — not
    `PRAGMA schema_version`, which is a write counter: two identical schemas
    can carry different counter values, and equal values attest nothing about
-   content.
+   content. The query input uses a **type-tagged canonical encoding**: every
+   bound parameter carries its type in the signed bytes, so `1`, `"1"`,
+   `1.0`, `Decimal("1")`, `b"1"` and `True` all sign differently, and an
+   unsupported parameter type is a typed refusal — never a silent
+   stringification.
+   After execution the driver **re-snapshots the schema and compares
+   digests**: if the schema moved between the signed snapshot and the
+   execution, it raises `SchemaDrift` and refuses to sign a result the
+   recorded snapshot may not describe.
 3. The result rows are put into **explicit canonical order** (sorted by their
    canonical cell bytes) before encoding. An engine's row order without
    `ORDER BY` is an unspecified plan detail; the driver never lets it into the

--- a/src/bernstein/core/datasources/__init__.py
+++ b/src/bernstein/core/datasources/__init__.py
@@ -1,9 +1,16 @@
-"""Content-addressed query receipts (issue #2887).
+"""Content-addressed query receipts (issue #2887) and the schema-bound query driver (issue #3125).
 
 Operator-configured, read-only SQL connections whose results are canonicalised
 and bound into a signed lineage receipt: the exact result set that grounded an
 agent's answer is a content-addressed, verifiable record rather than
-unrecorded prompt text.
+unrecorded prompt text. The query driver extends the same posture onto the
+typed activity boundary: it executes one read-only statement through
+``DataActivity``, records the canonical schema snapshot and the query text +
+parameters as signed inputs before the plan, and records the canonicalised
+result bytes (explicit row order) as a signed output -- so a number can be
+traced back to the statement, the parameters, and the schema state it was
+derived against, and schema drift is a typed refusal rather than a silently
+different answer.
 
 Public surface:
 
@@ -13,6 +20,11 @@ Public surface:
   stdlib-sqlite reference engine.
 * :mod:`bernstein.core.datasources.connection` -- connection config + registry.
 * :mod:`bernstein.core.datasources.receipt` -- record / verify / drift.
+* :mod:`bernstein.core.datasources.schema` -- canonical schema snapshot,
+  content digest, per-object drift diff.
+* :mod:`bernstein.core.datasources.query_driver` -- the read-only query driver
+  behind ``DataActivity`` (signed schema/query inputs, canonical result
+  output, fail-closed :class:`~bernstein.core.datasources.errors.SchemaDrift`).
 """
 
 from __future__ import annotations

--- a/src/bernstein/core/datasources/engine.py
+++ b/src/bernstein/core/datasources/engine.py
@@ -357,11 +357,34 @@ class SqliteEngine:
         )
 
 
+def _bind_scalar(value: object) -> object:
+    """Convert one bound parameter into a value ``sqlite3`` can bind.
+
+    stdlib ``sqlite3`` has no registered ``Decimal`` adapter, so a raw
+    ``Decimal`` raises ``ProgrammingError`` only at execute time - after a
+    driver has already recorded the signed query inputs. A finite ``Decimal``
+    is bound as its exact plain-text rendering (``format(value, "f")``), the
+    same rendering the driver's signed input encoding tags it with, so the
+    value that executes is digit-for-digit the value that was signed (column
+    affinity coerces it numerically wherever the column declares a numeric
+    type). A non-finite ``Decimal`` is refused, never silently degraded.
+    """
+    if isinstance(value, Decimal):
+        if not value.is_finite():
+            raise UnsupportedValue(f"non-finite Decimal bound parameter: {value!r}")
+        return format(value, "f")
+    return value
+
+
 def _as_bind(params: Sequence[object] | Mapping[str, object] | None) -> Sequence[Any] | Mapping[str, Any]:
     """Normalise bound parameters into a form ``sqlite3.execute`` accepts."""
+    from collections.abc import Mapping as _RuntimeMapping
+
     if params is None:
         return ()
-    return params
+    if isinstance(params, _RuntimeMapping):
+        return {key: _bind_scalar(value) for key, value in params.items()}
+    return [_bind_scalar(value) for value in params]
 
 
 def _sqlite_columns(conn: sqlite3.Connection, cur: sqlite3.Cursor) -> list[NormalizedColumn]:

--- a/src/bernstein/core/datasources/errors.py
+++ b/src/bernstein/core/datasources/errors.py
@@ -7,6 +7,11 @@ Every failure mode an operator can trip has a named exception so callers
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bernstein.core.datasources.schema import SchemaObjectDrift
+
 
 class DataSourceError(Exception):
     """Base class for every datasource / query-receipt error."""
@@ -55,12 +60,46 @@ class VerificationError(DataSourceError):
     """Offline verification of a receipt failed at a named field."""
 
 
+class SchemaDrift(DataSourceError):
+    """The live schema no longer matches the snapshot a statement was bound to.
+
+    Raised fail-closed by the query driver *before* execution when the live
+    schema digest differs from the recorded one: the statement's meaning is no
+    longer attested, so no result is returned. The error names the changed
+    objects rather than reporting a bare digest mismatch.
+
+    Attributes:
+        recorded_digest: The ``sha256:`` digest the statement was recorded against.
+        live_digest: The ``sha256:`` digest of the schema as it is now.
+        drifts: The per-object differences, in canonical ``(type, name)`` order.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        recorded_digest: str = "",
+        live_digest: str = "",
+        drifts: tuple[SchemaObjectDrift, ...] = (),
+    ) -> None:
+        super().__init__(message)
+        self.recorded_digest = recorded_digest
+        self.live_digest = live_digest
+        self.drifts = drifts
+
+    @property
+    def changed_object_names(self) -> tuple[str, ...]:
+        """The names of the drifted objects, in diff order."""
+        return tuple(d.name for d in self.drifts)
+
+
 __all__ = [
     "ConnectionNotFound",
     "DataSourceError",
     "NonCanonicalText",
     "ReadOnlyViolation",
     "ReceiptNotFound",
+    "SchemaDrift",
     "UnsupportedStatement",
     "UnsupportedValue",
     "VerificationError",

--- a/src/bernstein/core/datasources/query_driver.py
+++ b/src/bernstein/core/datasources/query_driver.py
@@ -48,7 +48,7 @@ import sqlite3
 from collections.abc import Mapping
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, NoReturn, Protocol, runtime_checkable
 
 from bernstein.core.datasources.engine import DEFAULT_ROW_CAP, SqliteEngine, guard_read_only
 from bernstein.core.datasources.errors import DataSourceError, SchemaDrift, UnsupportedValue
@@ -154,6 +154,22 @@ class SqliteQueryBackend:
     ) -> NormalizedResult:
         engine = SqliteEngine(self._db_path, connection=self._conn)
         return engine.execute(sql, params, row_cap=row_cap)
+
+
+def _raise_schema_drift(recorded: SchemaSnapshot, live: SchemaSnapshot, *, message: str) -> NoReturn:
+    """Build and raise the typed drift refusal from one recorded/live pair.
+
+    Both refusal sites (pre-execution pin check, post-execution re-check)
+    share this flow so the drift payload and message shape cannot diverge.
+    """
+    drifts = diff_snapshots(recorded, live)
+    named = "; ".join(d.describe() for d in drifts) or "digests differ but no object-level diff resolved"
+    raise SchemaDrift(
+        f"{message}: {named}",
+        recorded_digest=recorded.digest,
+        live_digest=live.digest,
+        drifts=drifts,
+    )
 
 
 def _row_key(result: NormalizedResult, row: tuple[object, ...]) -> bytes:
@@ -405,14 +421,7 @@ class ReadOnlyQueryDriver:
         # Phase 2: bind to the live schema, fail closed on drift.
         schema = self._backend.schema_snapshot()
         if expected_schema is not None and expected_schema.digest != schema.digest:
-            drifts = diff_snapshots(expected_schema, schema)
-            named = "; ".join(d.describe() for d in drifts) or "digests differ but no object-level diff resolved"
-            raise SchemaDrift(
-                f"schema drift on {self._connection_id!r}: {named}",
-                recorded_digest=expected_schema.digest,
-                live_digest=schema.digest,
-                drifts=drifts,
-            )
+            _raise_schema_drift(expected_schema, schema, message=f"schema drift on {self._connection_id!r}")
 
         # Phase 3: signed inputs, then the deterministic plan (inputs freeze).
         activity = self.new_activity()
@@ -433,13 +442,10 @@ class ReadOnlyQueryDriver:
         # from snapshots alone.)
         post_schema = self._backend.schema_snapshot()
         if post_schema.digest != schema.digest:
-            drifts = diff_snapshots(schema, post_schema)
-            named = "; ".join(d.describe() for d in drifts) or "digests differ but no object-level diff resolved"
-            raise SchemaDrift(
-                f"schema changed during execution on {self._connection_id!r}; refusing to sign the result: {named}",
-                recorded_digest=schema.digest,
-                live_digest=post_schema.digest,
-                drifts=drifts,
+            _raise_schema_drift(
+                schema,
+                post_schema,
+                message=f"schema changed during execution on {self._connection_id!r}; refusing to sign the result",
             )
 
         # Phase 6: explicit row order, signed output.

--- a/src/bernstein/core/datasources/query_driver.py
+++ b/src/bernstein/core/datasources/query_driver.py
@@ -31,7 +31,10 @@ Guarantees:
 * **Fail-closed drift.** When the caller pins the schema snapshot a statement
   was recorded against and the live digest differs, the driver raises a typed
   :class:`~bernstein.core.datasources.errors.SchemaDrift` naming the changed
-  objects instead of returning a number whose meaning changed.
+  objects instead of returning a number whose meaning changed. The same typed
+  refusal fires when the schema changes *between* the signed snapshot and the
+  execution: the driver re-snapshots after executing and refuses to sign a
+  result the recorded snapshot may not describe.
 
 The reference backend is the stdlib ``sqlite3`` driver (Python DB-API); the
 :class:`QueryDriverBackend` protocol is the seam a DuckDB / PostgreSQL backend
@@ -40,13 +43,15 @@ slots in behind later without touching the receipt path.
 
 from __future__ import annotations
 
-import json
+import datetime as _dt
 import sqlite3
+from collections.abc import Mapping
 from dataclasses import dataclass
+from decimal import Decimal
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from bernstein.core.datasources.engine import DEFAULT_ROW_CAP, SqliteEngine, guard_read_only
-from bernstein.core.datasources.errors import DataSourceError, SchemaDrift
+from bernstein.core.datasources.errors import DataSourceError, SchemaDrift, UnsupportedValue
 from bernstein.core.datasources.result import NormalizedResult, canonical_bytes, content_hash
 from bernstein.core.datasources.schema import SchemaSnapshot, diff_snapshots, snapshot_schema
 from bernstein.core.orchestration.activity_modalities import (
@@ -57,14 +62,16 @@ from bernstein.core.orchestration.activity_modalities import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Sequence
     from pathlib import Path
 
     from bernstein.core.datasources.connection import DataSourceConnection
     from bernstein.core.orchestration.activity import ActivityResult
 
-#: Query-input format version, folded into the signed query blob.
-QUERY_INPUT_VERSION = 1
+#: Query-input format version. Version 2 replaced the JSON encoding (whose
+#: ``default=str`` fallback collapsed e.g. ``Decimal("1.5")`` and ``"1.5"``
+#: onto identical bytes) with the type-tagged canonical encoding below.
+QUERY_INPUT_VERSION = 2
 
 #: The declared plan steps. The plan hash covers these plus the signed input
 #: hashes, so the receipt attests both *what* ran and *which* canonicalisation
@@ -181,14 +188,95 @@ def canonicalize_row_order(result: NormalizedResult) -> NormalizedResult:
     )
 
 
+# --- signed query input: type-tagged canonical encoding ----------------------
+
+#: Format magic for the signed query-input blob (bernstein query input, v2).
+_QUERY_INPUT_MAGIC = b"bqi\x02"
+
+# One-byte type tags for bound parameters, aligned with the result encoding's
+# cell tags where the types overlap so the two surfaces read consistently.
+_P_NULL = b"n"
+_P_BOOLEAN = b"o"
+_P_INTEGER = b"i"
+_P_FLOAT = b"f"
+_P_DECIMAL = b"d"
+_P_TEXT = b"t"
+_P_BLOB = b"b"
+_P_DATETIME = b"z"
+_P_DATE = b"y"
+
+
+def _field(payload: bytes) -> bytes:
+    """Length-prefix ``payload`` netstring-style: ``<len>:<payload>``."""
+    return str(len(payload)).encode("ascii") + b":" + payload
+
+
+def _param_scalar_bytes(value: object) -> bytes:
+    """Render one bound parameter to tagged canonical bytes, type-preserving.
+
+    Every supported DB-API parameter type carries its own one-byte tag, so two
+    parameters that differ only in type (``1`` vs ``"1"`` vs ``1.0`` vs
+    ``Decimal("1")`` vs ``b"1"`` vs ``True``) can never render to the same
+    bytes. An unsupported type is refused with a typed error -- never silently
+    stringified, because a lossy fallback is exactly what lets two distinct
+    queries share one signed input hash.
+    """
+    if value is None:
+        return _P_NULL
+    # ``bool`` before ``int`` (subclass); ``datetime`` before ``date`` (subclass).
+    if isinstance(value, bool):
+        return _P_BOOLEAN + (b"1" if value else b"0")
+    if isinstance(value, int):
+        return _P_INTEGER + str(value).encode("ascii")
+    if isinstance(value, float):
+        return _P_FLOAT + repr(value).encode("ascii")
+    if isinstance(value, Decimal):
+        if not value.is_finite():
+            raise UnsupportedValue(f"non-finite Decimal bound parameter: {value!r}")
+        return _P_DECIMAL + format(value, "f").encode("ascii")
+    if isinstance(value, str):
+        return _P_TEXT + value.encode("utf-8")
+    if isinstance(value, (bytes, bytearray)):
+        return _P_BLOB + bytes(value)
+    if isinstance(value, _dt.datetime):
+        return _P_DATETIME + value.isoformat().encode("utf-8")
+    if isinstance(value, _dt.date):
+        return _P_DATE + value.isoformat().encode("utf-8")
+    raise UnsupportedValue(f"cannot canonically encode bound parameter of type {type(value).__name__}: {value!r}")
+
+
 def query_input_bytes(sql: str, params: Sequence[object] | Mapping[str, object] | None) -> bytes:
     """Canonical bytes of the signed query input (statement + bound parameters).
 
-    Canonical JSON over ``{v, sql, params}`` so the same statement with the
-    same parameters signs to the same input hash on every run.
+    The encoding is type-preserving and deterministic: the statement text and
+    every parameter are length-prefixed (netstring-style) and each parameter
+    carries a one-byte type tag, so the same statement with the same
+    parameters signs to the same input hash on every run, and parameters that
+    differ in type or value always sign differently. Positional and named
+    parameter shapes are framed distinctly (``seq`` vs ``map``), and mapping
+    keys are encoded in sorted order so dict iteration order cannot leak into
+    the hash. Unsupported parameter types are refused with a typed error.
     """
-    payload = {"v": QUERY_INPUT_VERSION, "sql": sql, "params": params}
-    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True, default=str).encode("utf-8")
+    parts: list[bytes] = [_QUERY_INPUT_MAGIC]
+    parts.append(_field(b"v=" + str(QUERY_INPUT_VERSION).encode("ascii")))
+    parts.append(_field(sql.encode("utf-8")))
+    if params is None:
+        parts.append(_field(b"params=none"))
+    elif isinstance(params, Mapping):
+        parts.append(_field(b"params=map"))
+        parts.append(_field(str(len(params)).encode("ascii")))
+        # Keys are str by the DB-API named-parameter contract (and by this
+        # function's signature); sorted order keeps dict iteration order out
+        # of the signed bytes.
+        for key in sorted(params):
+            parts.append(_field(key.encode("utf-8")))
+            parts.append(_field(_param_scalar_bytes(params[key])))
+    else:
+        parts.append(_field(b"params=seq"))
+        parts.append(_field(str(len(params)).encode("ascii")))
+        for value in params:
+            parts.append(_field(_param_scalar_bytes(value)))
+    return b"".join(parts)
 
 
 @dataclass(frozen=True, slots=True)
@@ -236,8 +324,12 @@ class ReadOnlyQueryDriver:
        and the query never executes.
     3. Snapshot and query + parameters are recorded as signed inputs; the
        deterministic plan is derived from them (inputs are frozen from here).
-    4. The statement executes on the backend (read-only, authorizer-guarded),
-       the rows are put into explicit canonical order, and the canonical
+    4. The statement executes on the backend (read-only, authorizer-guarded).
+    5. The schema is snapshotted *again* and compared to the signed snapshot:
+       a digest mismatch means the schema moved between snapshot and
+       execution, so the driver raises :class:`SchemaDrift` and refuses to
+       sign a result the recorded snapshot may not describe.
+    6. The rows are put into explicit canonical order and the canonical
        result bytes are recorded as the signed output bound to the plan.
 
     The resulting :class:`DataOpsReceipt` verifies offline through the
@@ -299,7 +391,10 @@ class ReadOnlyQueryDriver:
         Raises:
             UnsupportedStatement: Empty or multi-statement input.
             ReadOnlyViolation: A write statement, refused before execution.
-            SchemaDrift: The live schema diverged from ``expected_schema``.
+            SchemaDrift: The live schema diverged from ``expected_schema``, or
+                the schema changed between the signed snapshot and execution
+                (the driver refuses to sign the result in both cases).
+            UnsupportedValue: A bound parameter of an unencodable type.
         """
         # Phase 1: refuse a write before any connection work. The guard is
         # textual and runs first, so a refused statement provably never
@@ -325,8 +420,29 @@ class ReadOnlyQueryDriver:
         activity.add_input(ref=f"query:{self._connection_id}", content=query_input_bytes(statement, params))
         plan = activity.plan(PLAN_STEPS)
 
-        # Phase 4: guarded execution, explicit row order, signed output.
+        # Phase 4: guarded execution.
         engine_result = self._backend.execute(statement, params, row_cap=row_cap)
+
+        # Phase 5: re-snapshot before signing, fail closed. The snapshot and
+        # the execution may run on separate connections, so a schema change in
+        # the gap could otherwise leave the signed snapshot attesting a schema
+        # the result was not derived against. SQLite blocks a schema change
+        # for the duration of a single executing statement; this check closes
+        # the between-statements window. (A change that is reverted between
+        # the two snapshots -- same digest on both sides -- is not detectable
+        # from snapshots alone.)
+        post_schema = self._backend.schema_snapshot()
+        if post_schema.digest != schema.digest:
+            drifts = diff_snapshots(schema, post_schema)
+            named = "; ".join(d.describe() for d in drifts) or "digests differ but no object-level diff resolved"
+            raise SchemaDrift(
+                f"schema changed during execution on {self._connection_id!r}; refusing to sign the result: {named}",
+                recorded_digest=schema.digest,
+                live_digest=post_schema.digest,
+                drifts=drifts,
+            )
+
+        # Phase 6: explicit row order, signed output.
         result = canonicalize_row_order(engine_result)
         result_bytes = canonical_bytes(result)
         activity.add_output(ref=f"result:{self._connection_id}", content=result_bytes)

--- a/src/bernstein/core/datasources/query_driver.py
+++ b/src/bernstein/core/datasources/query_driver.py
@@ -1,0 +1,385 @@
+"""Read-only query driver binding a result to the schema snapshot behind it.
+
+:class:`~bernstein.core.orchestration.activity_modalities.DataActivity` ships a
+complete phase machine -- signed inputs, one deterministic plan, signed
+outputs, ``DataOpsPhaseError`` on any output before a plan -- but nothing in
+the tree hands it a query to run. This module is that driver.
+
+What it adds, honestly stated: databases already log every statement, and
+re-running a statement is free, so statement logging is not the gap. The gap
+is twofold. First, the schema state a statement was written against is nowhere
+in the record -- a statement that was correct in March and means something
+different in July looks identical in the log. Second, the bytes that actually
+left the system are not bound to the statement that produced them. The driver
+closes both: the canonical schema snapshot and the query text + parameters are
+recorded as signed inputs *before* the plan is derived, and the canonicalised
+result bytes are recorded as a signed output bound to that plan, all through
+``DataActivity``'s existing phase machine and Ed25519 signing (this module is
+a driver, not a second receipt implementation).
+
+Guarantees:
+
+* **Read-only at the boundary.** The submitted statement passes
+  :func:`~bernstein.core.datasources.engine.guard_read_only` before any
+  connection work, so a write is refused before the connection executes
+  anything; the sqlite backend then executes behind ``mode=ro`` and a
+  deny-all-writes authorizer as defense in depth.
+* **Explicit row order.** An engine's row order without ``ORDER BY`` is an
+  unspecified plan detail, so the driver canonicalises it: rows are sorted by
+  their canonical cell bytes (:func:`canonicalize_row_order`) before encoding,
+  making the result bytes a pure function of the logical result.
+* **Fail-closed drift.** When the caller pins the schema snapshot a statement
+  was recorded against and the live digest differs, the driver raises a typed
+  :class:`~bernstein.core.datasources.errors.SchemaDrift` naming the changed
+  objects instead of returning a number whose meaning changed.
+
+The reference backend is the stdlib ``sqlite3`` driver (Python DB-API); the
+:class:`QueryDriverBackend` protocol is the seam a DuckDB / PostgreSQL backend
+slots in behind later without touching the receipt path.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+from bernstein.core.datasources.engine import DEFAULT_ROW_CAP, SqliteEngine, guard_read_only
+from bernstein.core.datasources.errors import DataSourceError, SchemaDrift
+from bernstein.core.datasources.result import NormalizedResult, canonical_bytes, content_hash
+from bernstein.core.datasources.schema import SchemaSnapshot, diff_snapshots, snapshot_schema
+from bernstein.core.orchestration.activity_modalities import (
+    ContentStore,
+    DataActivity,
+    DataOpsPlan,
+    DataOpsReceipt,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+    from pathlib import Path
+
+    from bernstein.core.datasources.connection import DataSourceConnection
+    from bernstein.core.orchestration.activity import ActivityResult
+
+#: Query-input format version, folded into the signed query blob.
+QUERY_INPUT_VERSION = 1
+
+#: The declared plan steps. The plan hash covers these plus the signed input
+#: hashes, so the receipt attests both *what* ran and *which* canonicalisation
+#: produced the output bytes.
+PLAN_STEPS: tuple[str, ...] = ("execute-read-only-query", "canonicalise-row-order")
+
+
+@runtime_checkable
+class QueryDriverBackend(Protocol):
+    """The engine seam behind :class:`ReadOnlyQueryDriver`.
+
+    A backend supplies exactly two things: a canonical snapshot of the live
+    schema and guarded read-only execution onto
+    :class:`~bernstein.core.datasources.result.NormalizedResult`. DuckDB /
+    PostgreSQL backends implement this same protocol later; the driver's
+    receipt path does not change.
+    """
+
+    @property
+    def name(self) -> str:
+        """Engine name recorded as provenance (e.g. ``sqlite``)."""
+        ...
+
+    def schema_snapshot(self) -> SchemaSnapshot:
+        """Return the canonical snapshot of the live schema."""
+        ...
+
+    def execute(
+        self,
+        sql: str,
+        params: Sequence[object] | Mapping[str, object] | None = None,
+        *,
+        row_cap: int = DEFAULT_ROW_CAP,
+    ) -> NormalizedResult:
+        """Run ``sql`` read-only and return the normalised result."""
+        ...
+
+
+class SqliteQueryBackend:
+    """Reference backend: stdlib ``sqlite3`` (Python DB-API), no new dependency.
+
+    File databases are opened read-only (``file:...?mode=ro``); execution goes
+    through :class:`~bernstein.core.datasources.engine.SqliteEngine`, which
+    installs the deny-all-writes authorizer. Tests may inject an open
+    connection (e.g. ``:memory:`` or a traced connection) instead of a path.
+    """
+
+    name = "sqlite"
+
+    def __init__(self, db_path: str | None = None, *, connection: sqlite3.Connection | None = None) -> None:
+        if connection is None and db_path is None:
+            raise ValueError("SqliteQueryBackend requires either db_path or connection")
+        self._db_path = db_path
+        self._conn = connection
+
+    def _connect(self) -> tuple[sqlite3.Connection, bool]:
+        """Return ``(connection, owned)``; owned connections are closed by us."""
+        if self._conn is not None:
+            return self._conn, False
+        try:
+            conn = sqlite3.connect(f"file:{self._db_path}?mode=ro", uri=True)
+        except sqlite3.DatabaseError as exc:
+            raise DataSourceError(f"cannot open database read-only: {exc}") from exc
+        return conn, True
+
+    def schema_snapshot(self) -> SchemaSnapshot:
+        conn, owned = self._connect()
+        try:
+            return snapshot_schema(conn)
+        finally:
+            if owned:
+                conn.close()
+
+    def execute(
+        self,
+        sql: str,
+        params: Sequence[object] | Mapping[str, object] | None = None,
+        *,
+        row_cap: int = DEFAULT_ROW_CAP,
+    ) -> NormalizedResult:
+        engine = SqliteEngine(self._db_path, connection=self._conn)
+        return engine.execute(sql, params, row_cap=row_cap)
+
+
+def _row_key(result: NormalizedResult, row: tuple[object, ...]) -> bytes:
+    """Canonical sort key for one row: its single-row canonical encoding.
+
+    Every single-row projection of the same result shares an identical header
+    (same columns, fixed flags), so ordering by the full encoding is ordering
+    by the row's canonical cell bytes -- a total order that cannot depend on
+    which plan the engine picked.
+    """
+    return canonical_bytes(NormalizedResult(columns=result.columns, rows=(row,), truncated=False, row_cap=0))
+
+
+def canonicalize_row_order(result: NormalizedResult) -> NormalizedResult:
+    """Return *result* with rows in explicit canonical order.
+
+    A SQL engine's row order without ``ORDER BY`` is an unspecified plan
+    detail: it can change with an index, a table rewrite, or a version bump.
+    The driver therefore never leaves row order to the engine -- rows are
+    sorted by their canonical cell bytes, so two runs that produced the same
+    logical row set encode to byte-identical canonical output. (For a
+    truncated result the surviving row *subset* still depends on engine order;
+    the truncation flag is inside the hashed body precisely so a truncated
+    result can never pose as a total one.)
+    """
+    ordered = tuple(sorted(result.rows, key=lambda row: _row_key(result, row)))
+    return NormalizedResult(
+        columns=result.columns,
+        rows=ordered,
+        truncated=result.truncated,
+        row_cap=result.row_cap,
+    )
+
+
+def query_input_bytes(sql: str, params: Sequence[object] | Mapping[str, object] | None) -> bytes:
+    """Canonical bytes of the signed query input (statement + bound parameters).
+
+    Canonical JSON over ``{v, sql, params}`` so the same statement with the
+    same parameters signs to the same input hash on every run.
+    """
+    payload = {"v": QUERY_INPUT_VERSION, "sql": sql, "params": params}
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True, default=str).encode("utf-8")
+
+
+@dataclass(frozen=True, slots=True)
+class QueryRun:
+    """The outcome of one driver execution: result, schema binding, receipt.
+
+    Attributes:
+        result: The normalised result in canonical row order.
+        canonical_result_bytes: The exact bytes recorded as the signed output.
+        result_hash: ``sha256:`` over ``canonical_result_bytes``.
+        schema: The schema snapshot the result was derived against.
+        schema_digest: The snapshot's content digest (a signed input hash).
+        plan: The deterministic plan derived from the signed inputs.
+        receipt: The signed :class:`DataOpsReceipt` (the primary artifact).
+        activity_result: The typed activity result; its ``artifact_hash`` is
+            the receipt hash the journal anchors.
+    """
+
+    result: NormalizedResult
+    canonical_result_bytes: bytes
+    result_hash: str
+    schema: SchemaSnapshot
+    schema_digest: str
+    plan: DataOpsPlan
+    receipt: DataOpsReceipt
+    activity_result: ActivityResult
+
+    @property
+    def receipt_hash(self) -> str:
+        """The ``sha256:`` hash of the receipt's canonical projection."""
+        return self.activity_result.artifact_hash
+
+
+class ReadOnlyQueryDriver:
+    """Execute one read-only query through ``DataActivity``, schema-bound.
+
+    Phase choreography per :meth:`run` (one activity per execution):
+
+    1. The submitted statement passes the textual read-only guard *before any
+       connection work* -- a write is refused with a typed error and nothing
+       ever reaches the engine.
+    2. The live schema snapshot is taken and, when the caller pinned the
+       snapshot a statement was recorded against, compared fail-closed: a
+       digest mismatch raises :class:`SchemaDrift` naming the changed objects
+       and the query never executes.
+    3. Snapshot and query + parameters are recorded as signed inputs; the
+       deterministic plan is derived from them (inputs are frozen from here).
+    4. The statement executes on the backend (read-only, authorizer-guarded),
+       the rows are put into explicit canonical order, and the canonical
+       result bytes are recorded as the signed output bound to the plan.
+
+    The resulting :class:`DataOpsReceipt` verifies offline through the
+    existing :func:`~bernstein.core.orchestration.activity_modalities.verify_data_ops_receipt`.
+    """
+
+    def __init__(
+        self,
+        backend: QueryDriverBackend,
+        *,
+        store: ContentStore,
+        private_key_pem: str,
+        public_key_pem: str,
+        connection_id: str = "",
+    ) -> None:
+        self._backend = backend
+        self._store = store
+        self._private_key_pem = private_key_pem
+        self._public_key_pem = public_key_pem
+        # Provenance label only: refs carry the connection *id*, never a DSN,
+        # so credentials cannot enter the recorded artifact by construction.
+        self._connection_id = connection_id or backend.name
+
+    def new_activity(self) -> DataActivity:
+        """Return the :class:`DataActivity` the driver drives, unstarted.
+
+        Exposed so callers (and tests) can exercise the phase contract
+        directly against the driver's own store and keys: recording an output
+        before a plan raises
+        :class:`~bernstein.core.orchestration.activity_modalities.DataOpsPhaseError`.
+        """
+        return DataActivity(
+            store=self._store,
+            private_key_pem=self._private_key_pem,
+            public_key_pem=self._public_key_pem,
+        )
+
+    def run(
+        self,
+        sql: str,
+        params: Sequence[object] | Mapping[str, object] | None = None,
+        *,
+        row_cap: int = DEFAULT_ROW_CAP,
+        expected_schema: SchemaSnapshot | None = None,
+    ) -> QueryRun:
+        """Execute *sql* read-only and bind the result to the live schema.
+
+        Args:
+            sql: A single read statement. Anything else is refused before the
+                connection executes anything.
+            params: Optional bound parameters (positional or named).
+            row_cap: Per-run row cap; truncation is folded into the hash.
+            expected_schema: When given, the snapshot the statement was
+                recorded against; a live digest mismatch fails closed.
+
+        Returns:
+            The :class:`QueryRun` with the signed receipt.
+
+        Raises:
+            UnsupportedStatement: Empty or multi-statement input.
+            ReadOnlyViolation: A write statement, refused before execution.
+            SchemaDrift: The live schema diverged from ``expected_schema``.
+        """
+        # Phase 1: refuse a write before any connection work. The guard is
+        # textual and runs first, so a refused statement provably never
+        # reached the engine (the backend's authorizer remains as defense in
+        # depth behind it).
+        statement = guard_read_only(sql)
+
+        # Phase 2: bind to the live schema, fail closed on drift.
+        schema = self._backend.schema_snapshot()
+        if expected_schema is not None and expected_schema.digest != schema.digest:
+            drifts = diff_snapshots(expected_schema, schema)
+            named = "; ".join(d.describe() for d in drifts) or "digests differ but no object-level diff resolved"
+            raise SchemaDrift(
+                f"schema drift on {self._connection_id!r}: {named}",
+                recorded_digest=expected_schema.digest,
+                live_digest=schema.digest,
+                drifts=drifts,
+            )
+
+        # Phase 3: signed inputs, then the deterministic plan (inputs freeze).
+        activity = self.new_activity()
+        activity.add_input(ref=f"schema:{self._connection_id}", content=schema.canonical_bytes())
+        activity.add_input(ref=f"query:{self._connection_id}", content=query_input_bytes(statement, params))
+        plan = activity.plan(PLAN_STEPS)
+
+        # Phase 4: guarded execution, explicit row order, signed output.
+        engine_result = self._backend.execute(statement, params, row_cap=row_cap)
+        result = canonicalize_row_order(engine_result)
+        result_bytes = canonical_bytes(result)
+        activity.add_output(ref=f"result:{self._connection_id}", content=result_bytes)
+
+        activity_result = activity.finish()
+        return QueryRun(
+            result=result,
+            canonical_result_bytes=result_bytes,
+            result_hash=content_hash(result),
+            schema=schema,
+            schema_digest=schema.digest,
+            plan=plan,
+            receipt=DataOpsReceipt.from_dict(activity_result.artifact),
+            activity_result=activity_result,
+        )
+
+
+def build_sqlite_query_driver(sdd_dir: Path, connection: DataSourceConnection) -> ReadOnlyQueryDriver:
+    """Return a driver for a registered sqlite connection, keys provisioned.
+
+    Signing identity and content store live under ``<sdd>/datasources`` with
+    the same key files the query-receipt store uses, so the whole datasource
+    subsystem signs under one install identity. The driver records only
+    ``connection.id`` as provenance -- never the DSN.
+    """
+    from bernstein.core.datasources.service import PRIVATE_KEY_NAME, PUBLIC_KEY_NAME, datasources_root
+    from bernstein.core.lineage.identity import load_or_create_signing_identity
+
+    if connection.driver != "sqlite":
+        raise DataSourceError(f"unsupported driver {connection.driver!r} (only 'sqlite' ships today)")
+    root = datasources_root(sdd_dir)
+    private_pem, public_pem = load_or_create_signing_identity(
+        root / "identity",
+        private_name=PRIVATE_KEY_NAME,
+        public_name=PUBLIC_KEY_NAME,
+    )
+    return ReadOnlyQueryDriver(
+        SqliteQueryBackend(connection.dsn),
+        store=ContentStore(root / "cas"),
+        private_key_pem=private_pem,
+        public_key_pem=public_pem,
+        connection_id=connection.id,
+    )
+
+
+__all__ = [
+    "PLAN_STEPS",
+    "QUERY_INPUT_VERSION",
+    "QueryDriverBackend",
+    "QueryRun",
+    "ReadOnlyQueryDriver",
+    "SqliteQueryBackend",
+    "build_sqlite_query_driver",
+    "canonicalize_row_order",
+    "query_input_bytes",
+]

--- a/src/bernstein/core/datasources/schema.py
+++ b/src/bernstein/core/datasources/schema.py
@@ -1,0 +1,352 @@
+"""Canonical SQLite schema snapshots: content digest + per-object drift diff.
+
+A statement's meaning depends on the schema it was written against: the same
+``SELECT`` over a table whose columns changed in between is a different
+question. The query driver (:mod:`bernstein.core.datasources.query_driver`)
+therefore records the schema state a result was derived against as a signed,
+content-addressed input. This module supplies that snapshot: a deterministic
+projection of the live SQLite schema, its ``sha256:`` content digest, and a
+per-object diff that names what changed between two snapshots.
+
+Why a content digest and not ``PRAGMA schema_version``
+------------------------------------------------------
+
+SQLite's ``schema_version`` pragma is a write counter, not a content address:
+it increments on every schema touch, so a table created and dropped again
+leaves the counter changed while the schema is logically identical, and two
+databases holding the same schema (a restore, a copy built from the same DDL)
+carry unrelated counter values. A receipt needs the opposite property -- equal
+content, equal digest -- so the snapshot hashes the schema *content*: the
+normalised DDL text SQLite itself keeps in ``sqlite_master`` plus the
+structural column list per table.
+
+Determinism
+-----------
+
+``sqlite_master`` row order is an engine detail, so objects are ordered
+canonically by ``(type, name)`` before encoding. The DDL text is taken
+verbatim from ``sqlite_master.sql`` (SQLite normalises it and rewrites it on
+``ALTER TABLE``); the snapshot never rewrites DDL, because a lossy rewrite
+could collapse two genuinely different schemas onto one digest. Tables
+additionally carry their ``PRAGMA table_info`` column rows, so a structural
+change is always visible in the diff at column granularity. Internal objects
+(``sqlite_%`` names, e.g. ``sqlite_sequence``) are excluded: they are engine
+bookkeeping, not operator schema.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
+
+from bernstein.core.datasources.errors import DataSourceError
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+#: Snapshot format version, folded into the canonical bytes so a future
+#: format change can never silently re-hash an old snapshot.
+SNAPSHOT_VERSION = 1
+
+#: The object types read from ``sqlite_master``.
+_OBJECT_TYPES = ("table", "index", "view", "trigger")
+
+
+@dataclass(frozen=True, slots=True)
+class SchemaColumn:
+    """One column of a table, as reported by ``PRAGMA table_info``.
+
+    Attributes:
+        name: Column name.
+        declared_type: The declared type text (may be empty for typeless columns).
+        notnull: Whether the column carries a NOT NULL constraint.
+        default: The default-value expression text, or ``None`` when absent.
+        primary_key: 1-based position in the primary key, 0 when not part of it.
+    """
+
+    name: str
+    declared_type: str
+    notnull: bool
+    default: str | None
+    primary_key: int
+
+    def to_dict(self) -> dict[str, object]:
+        """Return the JSON projection folded into the canonical bytes."""
+        return {
+            "name": self.name,
+            "declared_type": self.declared_type,
+            "notnull": self.notnull,
+            "default": self.default,
+            "primary_key": self.primary_key,
+        }
+
+    @classmethod
+    def from_dict(cls, row: Mapping[str, Any]) -> SchemaColumn:
+        """Rebuild a column from its canonical projection."""
+        default = row.get("default")
+        primary_key = row.get("primary_key", 0)
+        return cls(
+            name=str(row.get("name", "")),
+            declared_type=str(row.get("declared_type", "")),
+            notnull=bool(row.get("notnull", False)),
+            default=None if default is None else str(default),
+            primary_key=primary_key if isinstance(primary_key, int) and not isinstance(primary_key, bool) else 0,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SchemaObject:
+    """One schema object: a table, index, view, or trigger.
+
+    Attributes:
+        type: Object type as reported by ``sqlite_master`` (``table`` /
+            ``index`` / ``view`` / ``trigger``).
+        name: Object name.
+        sql: The normalised DDL text from ``sqlite_master.sql`` (empty when
+            SQLite stores none).
+        columns: For tables, the ``PRAGMA table_info`` column rows in declared
+            order; empty for every other object type.
+    """
+
+    type: str
+    name: str
+    sql: str
+    columns: tuple[SchemaColumn, ...] = ()
+
+    def to_dict(self) -> dict[str, object]:
+        """Return the JSON projection folded into the canonical bytes."""
+        return {
+            "type": self.type,
+            "name": self.name,
+            "sql": self.sql,
+            "columns": [c.to_dict() for c in self.columns],
+        }
+
+    @classmethod
+    def from_dict(cls, row: Mapping[str, Any]) -> SchemaObject:
+        """Rebuild an object from its canonical projection."""
+        raw_columns = row.get("columns", [])
+        columns = (
+            tuple(
+                SchemaColumn.from_dict(cast("dict[str, Any]", c))
+                for c in cast("list[Any]", raw_columns)
+                if isinstance(c, dict)
+            )
+            if isinstance(raw_columns, list)
+            else ()
+        )
+        return cls(
+            type=str(row.get("type", "")),
+            name=str(row.get("name", "")),
+            sql=str(row.get("sql", "")),
+            columns=columns,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SchemaSnapshot:
+    """A canonical, content-addressed snapshot of a SQLite schema.
+
+    Attributes:
+        objects: Schema objects in canonical ``(type, name)`` order.
+    """
+
+    objects: tuple[SchemaObject, ...]
+
+    def canonical_bytes(self) -> bytes:
+        """Return the deterministic canonical byte encoding of the snapshot.
+
+        Canonical JSON (sorted keys, minimal separators, UTF-8) over the
+        version tag and the canonically-ordered objects. Two databases holding
+        the same schema encode to byte-identical output regardless of the
+        order ``sqlite_master`` returned rows in.
+        """
+        payload = {
+            "v": SNAPSHOT_VERSION,
+            "objects": [o.to_dict() for o in self.objects],
+        }
+        return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+    @property
+    def digest(self) -> str:
+        """Return ``sha256:<hex>`` over :meth:`canonical_bytes`."""
+        return "sha256:" + hashlib.sha256(self.canonical_bytes()).hexdigest()
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> SchemaSnapshot:
+        """Rebuild a snapshot from its canonical bytes (e.g. a stored input blob).
+
+        Raises:
+            DataSourceError: When the bytes are not a valid snapshot encoding.
+        """
+        try:
+            raw: Any = json.loads(data)
+        except (ValueError, UnicodeDecodeError) as exc:
+            raise DataSourceError(f"schema snapshot bytes are not valid JSON: {exc}") from exc
+        if not isinstance(raw, dict):
+            raise DataSourceError("schema snapshot bytes carry an unknown format version")
+        payload = cast("dict[str, Any]", raw)
+        if payload.get("v") != SNAPSHOT_VERSION:
+            raise DataSourceError("schema snapshot bytes carry an unknown format version")
+        raw_objects = payload.get("objects", [])
+        if not isinstance(raw_objects, list):
+            raise DataSourceError("schema snapshot bytes are malformed (objects is not a list)")
+        objects = tuple(
+            SchemaObject.from_dict(cast("dict[str, Any]", o))
+            for o in cast("list[Any]", raw_objects)
+            if isinstance(o, dict)
+        )
+        return cls(objects=_canonical_order(objects))
+
+
+@dataclass(frozen=True, slots=True)
+class SchemaObjectDrift:
+    """One named schema difference between a recorded and a live snapshot.
+
+    Attributes:
+        change: ``added`` / ``removed`` / ``changed`` (live relative to recorded).
+        object_type: The object's ``sqlite_master`` type.
+        name: The object's name.
+        detail: A short human-readable description of what changed (for tables,
+            the added / removed / redefined column names).
+    """
+
+    change: str
+    object_type: str
+    name: str
+    detail: str = ""
+
+    def describe(self) -> str:
+        """Return a one-line description, e.g. ``changed table 'orders': ...``."""
+        base = f"{self.change} {self.object_type} {self.name!r}"
+        return f"{base}: {self.detail}" if self.detail else base
+
+
+def _quote_ident(ident: str) -> str:
+    """Quote a SQLite identifier for interpolation into a PRAGMA."""
+    return '"' + ident.replace('"', '""') + '"'
+
+
+def _canonical_order(objects: tuple[SchemaObject, ...]) -> tuple[SchemaObject, ...]:
+    """Order objects canonically by ``(type, name)``."""
+    return tuple(sorted(objects, key=lambda o: (o.type, o.name)))
+
+
+def _table_columns(conn: sqlite3.Connection, table: str) -> tuple[SchemaColumn, ...]:
+    """Read the ``PRAGMA table_info`` column rows for *table* in declared order."""
+    columns: list[SchemaColumn] = []
+    for _cid, name, declared, notnull, default, pk in conn.execute(f"PRAGMA table_info({_quote_ident(table)})"):
+        columns.append(
+            SchemaColumn(
+                name=str(name),
+                declared_type=str(declared or ""),
+                notnull=bool(notnull),
+                default=None if default is None else str(default),
+                primary_key=int(pk),
+            )
+        )
+    return tuple(columns)
+
+
+def snapshot_schema(conn: sqlite3.Connection) -> SchemaSnapshot:
+    """Take a canonical schema snapshot over an open SQLite connection.
+
+    Reads every user object from ``sqlite_master`` (internal ``sqlite_%``
+    objects are excluded), attaches the ``PRAGMA table_info`` column rows for
+    tables, and orders everything canonically so the snapshot's digest is a
+    pure function of schema content.
+
+    Args:
+        conn: An open connection (read-only is sufficient).
+
+    Returns:
+        The canonical :class:`SchemaSnapshot`.
+
+    Raises:
+        DataSourceError: When the schema cannot be read.
+    """
+    try:
+        rows = conn.execute(
+            "SELECT type, name, sql FROM sqlite_master WHERE name NOT LIKE 'sqlite_%' ORDER BY type, name"
+        ).fetchall()
+    except sqlite3.DatabaseError as exc:
+        raise DataSourceError(f"cannot read schema: {exc}") from exc
+    objects: list[SchemaObject] = []
+    for obj_type, name, sql in rows:
+        if obj_type not in _OBJECT_TYPES:
+            continue
+        columns = _table_columns(conn, str(name)) if obj_type == "table" else ()
+        objects.append(SchemaObject(type=str(obj_type), name=str(name), sql=str(sql or ""), columns=columns))
+    return SchemaSnapshot(objects=_canonical_order(tuple(objects)))
+
+
+def _column_drift_detail(recorded: SchemaObject, live: SchemaObject) -> str:
+    """Describe a changed table at column granularity."""
+    recorded_cols = {c.name: c for c in recorded.columns}
+    live_cols = {c.name: c for c in live.columns}
+    added = sorted(set(live_cols) - set(recorded_cols))
+    removed = sorted(set(recorded_cols) - set(live_cols))
+    redefined = sorted(name for name in set(recorded_cols) & set(live_cols) if recorded_cols[name] != live_cols[name])
+    parts: list[str] = []
+    if added:
+        parts.append("added columns " + ", ".join(repr(c) for c in added))
+    if removed:
+        parts.append("removed columns " + ", ".join(repr(c) for c in removed))
+    if redefined:
+        parts.append("redefined columns " + ", ".join(repr(c) for c in redefined))
+    if not parts and recorded.sql != live.sql:
+        parts.append("definition changed")
+    return "; ".join(parts) or "definition changed"
+
+
+def diff_snapshots(recorded: SchemaSnapshot, live: SchemaSnapshot) -> tuple[SchemaObjectDrift, ...]:
+    """Name every object that differs between *recorded* and *live*.
+
+    The diff is keyed by ``(type, name)``: an object present only in *live* is
+    ``added``, only in *recorded* is ``removed``, and present in both with a
+    different DDL text or column list is ``changed`` (with column-level detail
+    for tables). An empty result means the snapshots hold the same content
+    (and therefore the same digest).
+
+    Args:
+        recorded: The snapshot a result was recorded against.
+        live: The snapshot of the schema as it is now.
+
+    Returns:
+        The named drifts in canonical ``(type, name)`` order; empty when equal.
+    """
+    recorded_by_key = {(o.type, o.name): o for o in recorded.objects}
+    live_by_key = {(o.type, o.name): o for o in live.objects}
+    drifts: list[SchemaObjectDrift] = []
+    for key in sorted(set(recorded_by_key) | set(live_by_key)):
+        obj_type, name = key
+        rec = recorded_by_key.get(key)
+        cur = live_by_key.get(key)
+        if rec is None and cur is not None:
+            drifts.append(SchemaObjectDrift(change="added", object_type=obj_type, name=name))
+        elif cur is None and rec is not None:
+            drifts.append(SchemaObjectDrift(change="removed", object_type=obj_type, name=name))
+        elif rec is not None and cur is not None and rec != cur:
+            drifts.append(
+                SchemaObjectDrift(
+                    change="changed",
+                    object_type=obj_type,
+                    name=name,
+                    detail=_column_drift_detail(rec, cur),
+                )
+            )
+    return tuple(drifts)
+
+
+__all__ = [
+    "SNAPSHOT_VERSION",
+    "SchemaColumn",
+    "SchemaObject",
+    "SchemaObjectDrift",
+    "SchemaSnapshot",
+    "diff_snapshots",
+    "snapshot_schema",
+]

--- a/src/bernstein/core/datasources/schema.py
+++ b/src/bernstein/core/datasources/schema.py
@@ -85,16 +85,32 @@ class SchemaColumn:
 
     @classmethod
     def from_dict(cls, row: Mapping[str, Any]) -> SchemaColumn:
-        """Rebuild a column from its canonical projection."""
+        """Rebuild a column from its canonical projection, refusing malformed fields.
+
+        Every canonical projection was written by :meth:`to_dict`, which always
+        emits all five keys with these exact types - so a mismatch here is
+        corruption or tampering, never a legitimate legacy blob, and it
+        refuses instead of defaulting a field into the trusted digest.
+
+        Raises:
+            DataSourceError: A required key is missing or carries the wrong type.
+        """
+        name = row.get("name")
+        if not isinstance(name, str) or not name:
+            raise DataSourceError("schema column has a missing or empty name")
+        declared_type = row.get("declared_type")
+        if not isinstance(declared_type, str):
+            raise DataSourceError(f"schema column {name!r} has a non-string declared_type")
+        notnull = row.get("notnull")
+        if not isinstance(notnull, bool):
+            raise DataSourceError(f"schema column {name!r} has a non-boolean notnull")
         default = row.get("default")
-        primary_key = row.get("primary_key", 0)
-        return cls(
-            name=str(row.get("name", "")),
-            declared_type=str(row.get("declared_type", "")),
-            notnull=bool(row.get("notnull", False)),
-            default=None if default is None else str(default),
-            primary_key=primary_key if isinstance(primary_key, int) and not isinstance(primary_key, bool) else 0,
-        )
+        if default is not None and not isinstance(default, str):
+            raise DataSourceError(f"schema column {name!r} has a non-string default")
+        primary_key = row.get("primary_key")
+        if not isinstance(primary_key, int) or isinstance(primary_key, bool):
+            raise DataSourceError(f"schema column {name!r} has a missing or non-integer primary_key")
+        return cls(name=name, declared_type=declared_type, notnull=notnull, default=default, primary_key=primary_key)
 
 
 @dataclass(frozen=True, slots=True)
@@ -129,15 +145,12 @@ class SchemaObject:
     def from_dict(cls, row: Mapping[str, Any]) -> SchemaObject:
         """Rebuild an object from its canonical projection."""
         raw_columns = row.get("columns", [])
-        columns = (
-            tuple(
-                SchemaColumn.from_dict(cast("dict[str, Any]", c))
-                for c in cast("list[Any]", raw_columns)
-                if isinstance(c, dict)
-            )
-            if isinstance(raw_columns, list)
-            else ()
-        )
+        if not isinstance(raw_columns, list):
+            raise DataSourceError("stored schema snapshot: schema object columns must be a list")
+        for entry in cast("list[Any]", raw_columns):
+            if not isinstance(entry, dict):
+                raise DataSourceError("stored schema snapshot: schema object carries a non-object column entry")
+        columns = tuple(SchemaColumn.from_dict(cast("dict[str, Any]", c)) for c in cast("list[Any]", raw_columns))
         valid_type, valid_name, valid_sql = _validated_object_shape(
             row.get("type"), row.get("name"), row.get("sql"), origin="stored schema snapshot"
         )
@@ -192,11 +205,13 @@ class SchemaSnapshot:
         raw_objects = payload.get("objects", [])
         if not isinstance(raw_objects, list):
             raise DataSourceError("schema snapshot bytes are malformed (objects is not a list)")
-        objects = tuple(
-            SchemaObject.from_dict(cast("dict[str, Any]", o))
-            for o in cast("list[Any]", raw_objects)
-            if isinstance(o, dict)
-        )
+        for position, entry in enumerate(cast("list[Any]", raw_objects)):
+            if not isinstance(entry, dict):
+                raise DataSourceError(
+                    f"stored schema snapshot: objects[{position}] is not an object; refusing to "
+                    "rehydrate a snapshot by omission"
+                )
+        objects = tuple(SchemaObject.from_dict(cast("dict[str, Any]", o)) for o in cast("list[Any]", raw_objects))
         return cls(objects=_canonical_order(objects))
 
 

--- a/src/bernstein/core/datasources/schema.py
+++ b/src/bernstein/core/datasources/schema.py
@@ -138,12 +138,10 @@ class SchemaObject:
             if isinstance(raw_columns, list)
             else ()
         )
-        return cls(
-            type=str(row.get("type", "")),
-            name=str(row.get("name", "")),
-            sql=str(row.get("sql", "")),
-            columns=columns,
+        valid_type, valid_name, valid_sql = _validated_object_shape(
+            row.get("type"), row.get("name"), row.get("sql"), origin="stored schema snapshot"
         )
+        return cls(type=valid_type, name=valid_name, sql=valid_sql, columns=columns)
 
 
 @dataclass(frozen=True, slots=True)
@@ -230,6 +228,23 @@ def _quote_ident(ident: str) -> str:
     return '"' + ident.replace('"', '""') + '"'
 
 
+def _validated_object_shape(obj_type: object, name: object, sql: object, *, origin: str) -> tuple[str, str, str]:
+    """One shape rule for every digest-bearing :class:`SchemaObject` producer.
+
+    Both producers (the live ``sqlite_master`` scan and rehydration of a
+    stored snapshot) route through this check, so a malformed field is a
+    typed refusal at either boundary instead of a silent empty-string
+    default entering the trusted digest.
+    """
+    if not isinstance(obj_type, str) or obj_type not in _OBJECT_TYPES:
+        raise DataSourceError(f"{origin}: schema object type must be one of {_OBJECT_TYPES}, got {obj_type!r}")
+    if not isinstance(name, str) or not name:
+        raise DataSourceError(f"{origin}: schema object {obj_type} has a missing or empty name")
+    if sql is not None and not isinstance(sql, str):
+        raise DataSourceError(f"{origin}: schema object {name!r} has a non-string sql field")
+    return obj_type, name, sql or ""
+
+
 def _canonical_order(objects: tuple[SchemaObject, ...]) -> tuple[SchemaObject, ...]:
     """Order objects canonically by ``(type, name)``."""
     return tuple(sorted(objects, key=lambda o: (o.type, o.name)))
@@ -293,8 +308,9 @@ def snapshot_schema(conn: sqlite3.Connection) -> SchemaSnapshot:
         for obj_type, name, sql in rows:
             if obj_type not in _OBJECT_TYPES:
                 continue
-            columns = _table_columns(conn, str(name)) if obj_type == "table" else ()
-            objects.append(SchemaObject(type=str(obj_type), name=str(name), sql=str(sql or ""), columns=columns))
+            valid_type, valid_name, valid_sql = _validated_object_shape(obj_type, name, sql, origin="live schema")
+            columns = _table_columns(conn, valid_name) if valid_type == "table" else ()
+            objects.append(SchemaObject(type=valid_type, name=valid_name, sql=valid_sql, columns=columns))
         return SchemaSnapshot(objects=_canonical_order(tuple(objects)))
     finally:
         if started_txn:

--- a/src/bernstein/core/datasources/schema.py
+++ b/src/bernstein/core/datasources/schema.py
@@ -104,7 +104,12 @@ class SchemaColumn:
         notnull = row.get("notnull")
         if not isinstance(notnull, bool):
             raise DataSourceError(f"schema column {name!r} has a non-boolean notnull")
-        default = row.get("default")
+        if "default" not in row:
+            raise DataSourceError(
+                f"schema column {name!r} is missing its default key; a truncated projection "
+                "must not hash equal to a column with no default"
+            )
+        default = row["default"]
         if default is not None and not isinstance(default, str):
             raise DataSourceError(f"schema column {name!r} has a non-string default")
         primary_key = row.get("primary_key")

--- a/src/bernstein/core/datasources/schema.py
+++ b/src/bernstein/core/datasources/schema.py
@@ -259,6 +259,12 @@ def snapshot_schema(conn: sqlite3.Connection) -> SchemaSnapshot:
     tables, and orders everything canonically so the snapshot's digest is a
     pure function of schema content.
 
+    All reads run inside one read transaction pinned on ``conn`` before the
+    first row is fetched: the ``sqlite_master`` scan and every per-table
+    ``PRAGMA table_info`` see the same schema state, so a concurrent writer
+    (WAL mode) landing an ``ALTER TABLE`` between the reads can never yield a
+    digest describing a schema that existed at no point in time.
+
     Args:
         conn: An open connection (read-only is sufficient).
 
@@ -266,21 +272,33 @@ def snapshot_schema(conn: sqlite3.Connection) -> SchemaSnapshot:
         The canonical :class:`SchemaSnapshot`.
 
     Raises:
-        DataSourceError: When the schema cannot be read.
+        DataSourceError: When the schema cannot be read, or the read
+            transaction cannot be pinned.
     """
+    started_txn = False
+    if not conn.in_transaction:
+        try:
+            conn.execute("BEGIN")
+        except sqlite3.DatabaseError as exc:
+            raise DataSourceError(f"cannot pin a schema read transaction: {exc}") from exc
+        started_txn = True
     try:
-        rows = conn.execute(
-            "SELECT type, name, sql FROM sqlite_master WHERE name NOT LIKE 'sqlite_%' ORDER BY type, name"
-        ).fetchall()
-    except sqlite3.DatabaseError as exc:
-        raise DataSourceError(f"cannot read schema: {exc}") from exc
-    objects: list[SchemaObject] = []
-    for obj_type, name, sql in rows:
-        if obj_type not in _OBJECT_TYPES:
-            continue
-        columns = _table_columns(conn, str(name)) if obj_type == "table" else ()
-        objects.append(SchemaObject(type=str(obj_type), name=str(name), sql=str(sql or ""), columns=columns))
-    return SchemaSnapshot(objects=_canonical_order(tuple(objects)))
+        try:
+            rows = conn.execute(
+                "SELECT type, name, sql FROM sqlite_master WHERE name NOT LIKE 'sqlite_%' ORDER BY type, name"
+            ).fetchall()
+        except sqlite3.DatabaseError as exc:
+            raise DataSourceError(f"cannot read schema: {exc}") from exc
+        objects: list[SchemaObject] = []
+        for obj_type, name, sql in rows:
+            if obj_type not in _OBJECT_TYPES:
+                continue
+            columns = _table_columns(conn, str(name)) if obj_type == "table" else ()
+            objects.append(SchemaObject(type=str(obj_type), name=str(name), sql=str(sql or ""), columns=columns))
+        return SchemaSnapshot(objects=_canonical_order(tuple(objects)))
+    finally:
+        if started_txn:
+            conn.rollback()
 
 
 def _column_drift_detail(recorded: SchemaObject, live: SchemaObject) -> str:

--- a/src/bernstein/core/datasources/service.py
+++ b/src/bernstein/core/datasources/service.py
@@ -25,8 +25,13 @@ if TYPE_CHECKING:
 #: Stable identity for receipt signatures.
 _DS_AGENT_ID = "agent:datasource-receipts"
 _DS_KID = "datasource-receipts-1"
-_PRIVATE_KEY_NAME = "datasource_lineage.pem"
-_PUBLIC_KEY_NAME = "datasource_lineage.pub"
+
+#: Key file names under ``<sdd>/datasources/identity``. Shared by every
+#: datasource signing surface (the receipt store here and the query driver in
+#: :mod:`bernstein.core.datasources.query_driver`), so the whole subsystem
+#: signs under one install identity.
+PRIVATE_KEY_NAME = "datasource_lineage.pem"
+PUBLIC_KEY_NAME = "datasource_lineage.pub"
 
 
 def datasources_root(sdd_dir: Path) -> Path:
@@ -52,8 +57,8 @@ def build_receipt_store(sdd_dir: Path) -> QueryReceiptStore:
     identity_dir = root / "identity"
     _priv, pub = load_or_create_signing_identity(
         identity_dir,
-        private_name=_PRIVATE_KEY_NAME,
-        public_name=_PUBLIC_KEY_NAME,
+        private_name=PRIVATE_KEY_NAME,
+        public_name=PUBLIC_KEY_NAME,
     )
     card = AgentCard(agent_id=_DS_AGENT_ID, kid=_DS_KID, public_key_pem=pub)
     return QueryReceiptStore(
@@ -141,6 +146,8 @@ def resolve_task_datasource_inputs(
 
 
 __all__ = [
+    "PRIVATE_KEY_NAME",
+    "PUBLIC_KEY_NAME",
     "ResolvedDatasourceInput",
     "TaskDatasourceInput",
     "build_connection_registry",

--- a/tests/unit/datasources/test_query_driver.py
+++ b/tests/unit/datasources/test_query_driver.py
@@ -1,0 +1,387 @@
+"""The read-only query driver behind ``DataActivity`` (issue #3125).
+
+Property per test, proven empirically:
+
+* a write statement is refused with a typed error *before the connection
+  executes anything* (trace-callback + nonexistent-file evidence), with the
+  sqlite authorizer as a second, independently-exercised layer;
+* the result is bound to the schema snapshot it was derived against -- the
+  snapshot is a signed input recorded before the plan, and its digest moves
+  when a column is added;
+* the canonical result bytes are a signed output bound to the plan: a one-byte
+  mutation of the stored bytes breaks offline verification;
+* row order is made explicit by the canonicaliser, so two databases holding
+  the same logical rows in different physical order produce byte-identical
+  canonical results and (with the same signing key) identical receipt hashes
+  across separate ``.sdd`` directories;
+* schema drift is a typed, fail-closed refusal naming the changed objects;
+* recording an output before a plan raises ``DataOpsPhaseError``;
+* a connection secret never enters any recorded byte.
+
+All fixture databases are built in-test from SQL statements -- no binary
+fixtures, fully offline.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.datasources.connection import DataSourceConnection
+from bernstein.core.datasources.errors import (
+    ReadOnlyViolation,
+    SchemaDrift,
+    UnsupportedStatement,
+)
+from bernstein.core.datasources.query_driver import (
+    ReadOnlyQueryDriver,
+    SqliteQueryBackend,
+    build_sqlite_query_driver,
+    query_input_bytes,
+)
+from bernstein.core.orchestration.activity_modalities import (
+    ContentStore,
+    DataOpsPhaseError,
+    verify_data_ops_receipt,
+)
+from bernstein.core.skills.catalog.signature import generate_signer_keypair
+
+_FIXTURE_DDL = (
+    "CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT NOT NULL)",
+    "INSERT INTO t (id, name) VALUES (1, 'ada')",
+    "INSERT INTO t (id, name) VALUES (2, 'bob')",
+    "INSERT INTO t (id, name) VALUES (3, 'cyd')",
+)
+
+
+def _build_db(path: Path, statements: tuple[str, ...] = _FIXTURE_DDL) -> None:
+    """Build a fixture database from SQL statements (checked-in, no binary)."""
+    conn = sqlite3.connect(path)
+    try:
+        for stmt in statements:
+            conn.execute(stmt)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _driver(
+    backend: SqliteQueryBackend,
+    store_root: Path,
+    keypair: tuple[str, str] | None = None,
+    connection_id: str = "test",
+) -> ReadOnlyQueryDriver:
+    priv, pub = keypair if keypair is not None else generate_signer_keypair()
+    return ReadOnlyQueryDriver(
+        backend,
+        store=ContentStore(store_root),
+        private_key_pem=priv,
+        public_key_pem=pub,
+        connection_id=connection_id,
+    )
+
+
+def _sha256(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# AC2: read-only enforced at the boundary, before execution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("statement", "expected"),
+    [
+        ("INSERT INTO t (id, name) VALUES (99, 'x')", ReadOnlyViolation),
+        ("UPDATE t SET name = 'x'", ReadOnlyViolation),
+        ("DELETE FROM t", ReadOnlyViolation),
+        ("DROP TABLE t", ReadOnlyViolation),
+        ("CREATE TABLE u (id INTEGER)", ReadOnlyViolation),
+        ("ALTER TABLE t ADD COLUMN extra TEXT", ReadOnlyViolation),
+        # Multi-statement string with the write in second position.
+        ("SELECT id FROM t; DELETE FROM t", UnsupportedStatement),
+        # Write inside a common table expression (read leader, write body).
+        ("WITH doomed AS (SELECT id FROM t) DELETE FROM t WHERE id IN (SELECT id FROM doomed)", ReadOnlyViolation),
+    ],
+)
+def test_write_statement_refused_before_connection_executes(
+    tmp_path: Path, statement: str, expected: type[Exception]
+) -> None:
+    # The trace callback records every statement the connection executes; a
+    # refused write must leave the trace empty -- the refusal precedes any
+    # connection work, it is not a rolled-back execution.
+    conn = sqlite3.connect(":memory:")
+    for stmt in _FIXTURE_DDL:
+        conn.execute(stmt)
+    traced: list[str] = []
+    conn.set_trace_callback(traced.append)
+    store_root = tmp_path / "cas"
+    driver = _driver(SqliteQueryBackend(connection=conn), store_root)
+
+    with pytest.raises(expected):
+        driver.run(statement)
+
+    assert traced == []
+    # Fail closed all the way down: no input, plan, or output was recorded.
+    assert list(store_root.iterdir()) == []
+
+
+def test_write_statement_refused_even_when_no_database_exists(tmp_path: Path) -> None:
+    # With a database path that cannot even be opened, a write still gets the
+    # typed refusal -- proof the guard runs before any connection is opened.
+    driver = _driver(SqliteQueryBackend(str(tmp_path / "does-not-exist.db")), tmp_path / "cas")
+    with pytest.raises(ReadOnlyViolation):
+        driver.run("DELETE FROM t")
+
+
+def test_write_statement_refused_by_authorizer(tmp_path: Path) -> None:
+    # Defense in depth: a value-setting PRAGMA passes the textual guard (read
+    # leader, no write keyword) but is still refused at the connection by the
+    # read-only open + authorizer, surfacing as the same typed error.
+    db = tmp_path / "fixture.db"
+    _build_db(db)
+    store_root = tmp_path / "cas"
+    driver = _driver(SqliteQueryBackend(str(db)), store_root)
+    with pytest.raises(ReadOnlyViolation):
+        driver.run("PRAGMA user_version = 5")
+    # No signed output was recorded for the refused statement.
+    run_ok = driver.run("SELECT id, name FROM t")
+    assert run_ok.result.row_count == 3
+
+
+# ---------------------------------------------------------------------------
+# AC3: the schema snapshot is a signed input recorded before the plan
+# ---------------------------------------------------------------------------
+
+
+def test_result_binds_to_schema_snapshot_digest(tmp_path: Path) -> None:
+    db = tmp_path / "fixture.db"
+    _build_db(db)
+    store = ContentStore(tmp_path / "cas")
+    priv, pub = generate_signer_keypair()
+    driver = ReadOnlyQueryDriver(
+        SqliteQueryBackend(str(db)), store=store, private_key_pem=priv, public_key_pem=pub, connection_id="sales"
+    )
+
+    run = driver.run("SELECT id, name FROM t")
+
+    schema_input_hash = _sha256(run.schema.canonical_bytes())
+    input_hashes = [a.content_hash for a in run.receipt.inputs]
+    # The snapshot is a signed input...
+    assert schema_input_hash in input_hashes
+    # ...recorded before the plan was derived: the plan hash is a function of
+    # the input hashes, so the snapshot is provably inside the plan's preimage.
+    assert schema_input_hash in run.plan.input_hashes
+    assert run.receipt.plan.plan_hash == run.plan.plan_hash
+    # The query text + parameters are the other signed input.
+    assert _sha256(query_input_bytes("SELECT id, name FROM t", None)) in input_hashes
+
+    # Adding a column changes the snapshot digest (and so the signed input).
+    conn = sqlite3.connect(db)
+    try:
+        conn.execute("ALTER TABLE t ADD COLUMN extra TEXT")
+        conn.commit()
+    finally:
+        conn.close()
+    run_after = driver.run("SELECT id, name FROM t")
+    assert run_after.schema_digest != run.schema_digest
+    assert _sha256(run_after.schema.canonical_bytes()) != schema_input_hash
+
+
+def test_bound_parameters_are_inside_the_signed_query_input(tmp_path: Path) -> None:
+    db = tmp_path / "fixture.db"
+    _build_db(db)
+    driver = _driver(SqliteQueryBackend(str(db)), tmp_path / "cas")
+
+    run = driver.run("SELECT id, name FROM t WHERE id >= ?", [2])
+
+    assert run.result.row_count == 2
+    input_hashes = [a.content_hash for a in run.receipt.inputs]
+    assert _sha256(query_input_bytes("SELECT id, name FROM t WHERE id >= ?", [2])) in input_hashes
+    verdict = verify_data_ops_receipt(run.receipt, store=ContentStore(tmp_path / "cas"))
+    assert verdict.ok
+
+
+# ---------------------------------------------------------------------------
+# AC4: the canonical result bytes are a signed output; tamper breaks it
+# ---------------------------------------------------------------------------
+
+
+def test_receipt_verifies_offline_and_tamper_fails(tmp_path: Path) -> None:
+    db = tmp_path / "fixture.db"
+    _build_db(db)
+    store = ContentStore(tmp_path / "cas")
+    priv, pub = generate_signer_keypair()
+    driver = ReadOnlyQueryDriver(
+        SqliteQueryBackend(str(db)), store=store, private_key_pem=priv, public_key_pem=pub, connection_id="sales"
+    )
+
+    run = driver.run("SELECT id, name FROM t")
+    assert verify_data_ops_receipt(run.receipt, store=store).ok
+
+    # Flip one byte of the stored canonical result bytes: the receipt must
+    # stop verifying, and the failure must name evidence reattachment.
+    (output,) = run.receipt.outputs
+    stored = bytearray(store.get(output.content_hash))
+    stored[-1] ^= 0x01
+    store.force_put(output.content_hash, bytes(stored))
+
+    verdict = verify_data_ops_receipt(run.receipt, store=store)
+    assert not verdict.ok
+    assert not verdict.evidence_reattached
+    assert "reattaching" in verdict.reason
+
+
+# ---------------------------------------------------------------------------
+# AC5: determinism -- explicit row order, identical bytes and receipt hash
+# ---------------------------------------------------------------------------
+
+
+def test_row_order_is_canonical_across_runs(tmp_path: Path) -> None:
+    # Two databases holding the same logical rows in different physical
+    # (rowid) order: without ORDER BY the engine returns them differently, and
+    # the driver's canonicaliser must erase that difference. ``id`` must NOT
+    # alias the rowid here (no INTEGER PRIMARY KEY), so rowids -- and the full
+    # scan order -- follow insertion order.
+    ordered_ddl = (
+        "CREATE TABLE t (id INTEGER, name TEXT NOT NULL)",
+        "INSERT INTO t (id, name) VALUES (1, 'ada')",
+        "INSERT INTO t (id, name) VALUES (2, 'bob')",
+        "INSERT INTO t (id, name) VALUES (3, 'cyd')",
+    )
+    scrambled_ddl = (
+        "CREATE TABLE t (id INTEGER, name TEXT NOT NULL)",
+        "INSERT INTO t (id, name) VALUES (3, 'cyd')",
+        "INSERT INTO t (id, name) VALUES (1, 'ada')",
+        "INSERT INTO t (id, name) VALUES (2, 'bob')",
+    )
+    db_a = tmp_path / "a.db"
+    db_b = tmp_path / "b.db"
+    _build_db(db_a, ordered_ddl)
+    _build_db(db_b, scrambled_ddl)
+
+    # Establish that the natural engine order genuinely differs between the
+    # two fixtures -- otherwise this test would prove nothing.
+    def natural_order(path: Path) -> list[tuple[int, str]]:
+        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        try:
+            return list(conn.execute("SELECT id, name FROM t"))
+        finally:
+            conn.close()
+
+    assert natural_order(db_a) != natural_order(db_b)
+
+    keypair = generate_signer_keypair()
+    run_a = _driver(SqliteQueryBackend(str(db_a)), tmp_path / "cas_a", keypair).run("SELECT id, name FROM t")
+    run_b = _driver(SqliteQueryBackend(str(db_b)), tmp_path / "cas_b", keypair).run("SELECT id, name FROM t")
+
+    assert run_a.canonical_result_bytes == run_b.canonical_result_bytes
+    assert run_a.result_hash == run_b.result_hash
+    assert run_a.result.rows == run_b.result.rows
+
+
+def test_result_bytes_and_receipt_hash_identical_across_sdd_dirs(tmp_path: Path) -> None:
+    # Same statement, same fixture DDL, same signing key, two entirely
+    # separate .sdd roots: canonical result bytes must be byte-identical and
+    # the receipt hash identical (deterministic Ed25519, deterministic plan).
+    keypair = generate_signer_keypair()
+    runs = []
+    for name in ("one", "two"):
+        sdd = tmp_path / name / ".sdd"
+        db = tmp_path / name / "fixture.db"
+        db.parent.mkdir(parents=True)
+        _build_db(db)
+        driver = _driver(SqliteQueryBackend(str(db)), sdd / "datasources" / "cas", keypair, connection_id="sales")
+        runs.append(driver.run("SELECT id, name FROM t"))
+
+    first, second = runs
+    assert first.canonical_result_bytes == second.canonical_result_bytes
+    assert first.receipt_hash == second.receipt_hash
+    assert first.receipt_hash.startswith("sha256:")
+    assert first.plan.plan_hash == second.plan.plan_hash
+
+
+# ---------------------------------------------------------------------------
+# AC6: schema drift is a typed, fail-closed verdict naming the objects
+# ---------------------------------------------------------------------------
+
+
+def test_schema_drift_is_typed_and_fail_closed(tmp_path: Path) -> None:
+    conn = sqlite3.connect(":memory:")
+    for stmt in _FIXTURE_DDL:
+        conn.execute(stmt)
+    backend = SqliteQueryBackend(connection=conn)
+    recorded = backend.schema_snapshot()
+
+    # The schema moves under the recorded snapshot.
+    conn.execute("ALTER TABLE t ADD COLUMN discount REAL")
+
+    traced: list[str] = []
+    conn.set_trace_callback(traced.append)
+    store_root = tmp_path / "cas"
+    driver = _driver(backend, store_root)
+
+    with pytest.raises(SchemaDrift) as excinfo:
+        driver.run("SELECT id, name FROM t", expected_schema=recorded)
+
+    drift = excinfo.value
+    assert drift.recorded_digest == recorded.digest
+    assert drift.live_digest != recorded.digest
+    assert "t" in drift.changed_object_names
+    assert any("discount" in d.detail for d in drift.drifts)
+    # Fail closed: the submitted statement never executed (only the driver's
+    # own schema introspection touched the connection) and nothing was signed.
+    assert not any("FROM t" in s for s in traced)
+    assert list(store_root.iterdir()) == []
+
+
+# ---------------------------------------------------------------------------
+# AC7: phase order is enforced by the machine the driver drives
+# ---------------------------------------------------------------------------
+
+
+def test_output_before_plan_raises_phase_error(tmp_path: Path) -> None:
+    driver = _driver(SqliteQueryBackend(":memory:"), tmp_path / "cas")
+    activity = driver.new_activity()
+    activity.add_input(ref="schema:test", content=b"{}")
+    with pytest.raises(DataOpsPhaseError):
+        activity.add_output(ref="result:test", content=b"too early")
+
+
+# ---------------------------------------------------------------------------
+# Credentials never enter the recorded artifact
+# ---------------------------------------------------------------------------
+
+
+def test_connection_secret_never_recorded(tmp_path: Path) -> None:
+    # The DSN (here: a filesystem path carrying a secret-looking component)
+    # must appear in no receipt byte and no stored blob; provenance is the
+    # connection id only.
+    secret = "hunter2-topsecret-dsn-component"
+    db_dir = tmp_path / secret
+    db_dir.mkdir()
+    db = db_dir / "fixture.db"
+    _build_db(db)
+    sdd = tmp_path / ".sdd"
+    connection = DataSourceConnection(id="sales", driver="sqlite", dsn=str(db))
+
+    driver = build_sqlite_query_driver(sdd, connection)
+    run = driver.run("SELECT id, name FROM t")
+
+    receipt_json = json.dumps(run.receipt.to_dict(), sort_keys=True)
+    assert secret not in receipt_json
+    assert "sales" in receipt_json  # provenance is the id, not the DSN
+    cas_root = sdd / "datasources" / "cas"
+    blobs = list(cas_root.iterdir())
+    assert blobs, "expected signed input/output blobs in the content store"
+    for blob in blobs:
+        assert secret.encode("utf-8") not in blob.read_bytes()
+
+    # The receipt still verifies offline from the same store.
+    store = ContentStore(cas_root)
+    assert verify_data_ops_receipt(run.receipt, store=store).ok

--- a/tests/unit/datasources/test_query_driver.py
+++ b/tests/unit/datasources/test_query_driver.py
@@ -272,6 +272,23 @@ def test_param_type_difference_changes_the_receipt_input_hash(tmp_path: Path) ->
     assert run_int.receipt_hash != run_str.receipt_hash
 
 
+def test_decimal_param_never_fails_after_inputs_are_recorded(tmp_path: Path) -> None:
+    # sqlite3 has no registered Decimal adapter: pre-fix, a finite Decimal was
+    # accepted by the signed input encoding and only blew up at execute time
+    # with a raw ProgrammingError - after the input blobs and plan already
+    # existed. The engine now binds a finite Decimal as the exact plain-text
+    # rendering the signed encoding tags it with, so a Decimal-parameterised
+    # run completes all the way to a signed output instead of failing between
+    # input recording and execution.
+    db = tmp_path / "fixture.db"
+    _build_db(db)
+    run = _driver(SqliteQueryBackend(str(db)), tmp_path / "cas_dec").run(
+        "SELECT id, name FROM t WHERE id = ?", [Decimal("1")]
+    )
+    assert run.receipt.inputs
+    assert run.result.rows
+
+
 # ---------------------------------------------------------------------------
 # AC4: the canonical result bytes are a signed output; tamper breaks it
 # ---------------------------------------------------------------------------

--- a/tests/unit/datasources/test_query_driver.py
+++ b/tests/unit/datasources/test_query_driver.py
@@ -24,9 +24,11 @@ fixtures, fully offline.
 
 from __future__ import annotations
 
+import datetime
 import hashlib
 import json
 import sqlite3
+from decimal import Decimal
 from pathlib import Path
 
 import pytest
@@ -36,6 +38,7 @@ from bernstein.core.datasources.errors import (
     ReadOnlyViolation,
     SchemaDrift,
     UnsupportedStatement,
+    UnsupportedValue,
 )
 from bernstein.core.datasources.query_driver import (
     ReadOnlyQueryDriver,
@@ -208,6 +211,68 @@ def test_bound_parameters_are_inside_the_signed_query_input(tmp_path: Path) -> N
 
 
 # ---------------------------------------------------------------------------
+# The signed query input is type-preserving (baz finding 3705959721)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("left", "right"),
+    [
+        ([1], ["1"]),  # int vs str
+        ([1], [1.0]),  # int vs float
+        ([1], [True]),  # int vs bool
+        (["1"], [b"1"]),  # str vs bytes
+        ([Decimal("1")], ["1"]),  # decimal vs its string rendering
+        ([Decimal("1.50")], [Decimal("1.5")]),  # scale is significant
+        ([datetime.datetime(2026, 1, 1)], ["2026-01-01T00:00:00"]),  # datetime vs ISO string
+        ([datetime.date(2026, 1, 1)], [datetime.datetime(2026, 1, 1)]),  # date vs datetime
+        ([None], [""]),  # NULL vs empty string
+    ],
+)
+def test_int_and_str_params_produce_distinct_signed_inputs(left: list[object], right: list[object]) -> None:
+    # The signed input hash must move whenever a parameter's *type* moves,
+    # not only its value -- otherwise two semantically different queries
+    # share one content address.
+    sql = "SELECT id FROM t WHERE id = ?"
+    assert query_input_bytes(sql, left) != query_input_bytes(sql, right)
+
+
+def test_mapping_params_are_order_insensitive_but_shape_sensitive() -> None:
+    sql = "SELECT id FROM t WHERE a = :a AND b = :b"
+    # Dict iteration order must not leak into the signed bytes...
+    assert query_input_bytes(sql, {"a": 1, "b": 2}) == query_input_bytes(sql, {"b": 2, "a": 1})
+    # ...but positional and named parameter shapes are distinct.
+    assert query_input_bytes(sql, [1, 2]) != query_input_bytes(sql, {"a": 1, "b": 2})
+
+
+def test_unsupported_param_type_is_refused_not_stringified() -> None:
+    class Opaque:
+        def __str__(self) -> str:
+            return "1"
+
+    with pytest.raises(UnsupportedValue):
+        query_input_bytes("SELECT 1", [Opaque()])
+
+
+def test_param_type_difference_changes_the_receipt_input_hash(tmp_path: Path) -> None:
+    # Driver-level: the same statement bound with 1 (int) and "1" (str) must
+    # record different signed query inputs on the receipt.
+    db = tmp_path / "fixture.db"
+    _build_db(db)
+    keypair = generate_signer_keypair()
+    run_int = _driver(SqliteQueryBackend(str(db)), tmp_path / "cas_int", keypair).run(
+        "SELECT id, name FROM t WHERE id = ?", [1]
+    )
+    run_str = _driver(SqliteQueryBackend(str(db)), tmp_path / "cas_str", keypair).run(
+        "SELECT id, name FROM t WHERE id = ?", ["1"]
+    )
+    hashes_int = {a.content_hash for a in run_int.receipt.inputs}
+    hashes_str = {a.content_hash for a in run_str.receipt.inputs}
+    assert hashes_int != hashes_str
+    assert run_int.receipt_hash != run_str.receipt_hash
+
+
+# ---------------------------------------------------------------------------
 # AC4: the canonical result bytes are a signed output; tamper breaks it
 # ---------------------------------------------------------------------------
 
@@ -338,6 +403,47 @@ def test_schema_drift_is_typed_and_fail_closed(tmp_path: Path) -> None:
     # own schema introspection touched the connection) and nothing was signed.
     assert not any("FROM t" in s for s in traced)
     assert list(store_root.iterdir()) == []
+
+
+def test_schema_mutation_between_snapshot_and_execute_refuses_to_sign(tmp_path: Path) -> None:
+    # baz finding 3705959714: the snapshot and the execution may run on
+    # separate connections, so the schema can move in the gap. The driver
+    # re-snapshots after executing and must refuse to sign a result the
+    # recorded snapshot no longer describes.
+    conn = sqlite3.connect(":memory:")
+    for stmt in _FIXTURE_DDL:
+        conn.execute(stmt)
+
+    class MutatingBackend:
+        """Delegates to the real sqlite backend, but the schema moves mid-run."""
+
+        name = "sqlite"
+
+        def __init__(self) -> None:
+            self._inner = SqliteQueryBackend(connection=conn)
+
+        def schema_snapshot(self) -> object:
+            return self._inner.schema_snapshot()
+
+        def execute(self, sql: str, params: object = None, *, row_cap: int = 10_000) -> object:
+            result = self._inner.execute(sql, params, row_cap=row_cap)  # type: ignore[arg-type]
+            # The schema changes after the query ran but before the driver signs.
+            conn.execute("ALTER TABLE t ADD COLUMN sneaky TEXT")
+            return result
+
+    store_root = tmp_path / "cas"
+    driver = _driver(MutatingBackend(), store_root)  # type: ignore[arg-type]
+
+    with pytest.raises(SchemaDrift) as excinfo:
+        driver.run("SELECT id, name FROM t")
+
+    drift = excinfo.value
+    assert drift.recorded_digest != drift.live_digest
+    assert "t" in drift.changed_object_names
+    assert any("sneaky" in d.detail for d in drift.drifts)
+    # Refused to sign: the store holds exactly the two signed input blobs
+    # (schema + query) and no output blob, and no receipt was produced.
+    assert len(list(store_root.iterdir())) == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/datasources/test_schema_snapshot.py
+++ b/tests/unit/datasources/test_schema_snapshot.py
@@ -1,0 +1,151 @@
+"""Canonical SQLite schema snapshots: digest identity and per-object drift.
+
+The snapshot's contract is content-addressing: equal schema content yields an
+equal digest regardless of engine row order or object creation order, and any
+structural change (a column added, an index dropped) changes the digest and is
+named by the diff. Fixtures are built in-test from SQL statements -- no binary
+database files -- so CI stays offline and the fixtures stay reviewable.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.datasources.errors import DataSourceError
+from bernstein.core.datasources.schema import (
+    SchemaSnapshot,
+    diff_snapshots,
+    snapshot_schema,
+)
+
+_BASE_DDL = (
+    "CREATE TABLE orders (id INTEGER PRIMARY KEY, amount REAL NOT NULL, note TEXT DEFAULT 'none')",
+    "CREATE INDEX idx_orders_amount ON orders(amount)",
+    "CREATE TABLE customers (id INTEGER PRIMARY KEY, name TEXT)",
+)
+
+
+def _build_db(path: Path, statements: tuple[str, ...]) -> None:
+    """Build a fixture database from SQL statements (checked-in, no binary)."""
+    conn = sqlite3.connect(path)
+    try:
+        for stmt in statements:
+            conn.execute(stmt)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _snapshot(path: Path) -> SchemaSnapshot:
+    conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    try:
+        return snapshot_schema(conn)
+    finally:
+        conn.close()
+
+
+def test_snapshot_digest_is_stable_across_identical_databases(tmp_path: Path) -> None:
+    # Two databases built from the same DDL are the same schema content, so
+    # they must carry the same digest -- the property PRAGMA schema_version
+    # (a write counter) cannot provide.
+    _build_db(tmp_path / "a.db", _BASE_DDL)
+    _build_db(tmp_path / "b.db", _BASE_DDL)
+    snap_a = _snapshot(tmp_path / "a.db")
+    snap_b = _snapshot(tmp_path / "b.db")
+    assert snap_a.digest == snap_b.digest
+    assert snap_a.digest.startswith("sha256:")
+    assert snap_a.canonical_bytes() == snap_b.canonical_bytes()
+
+
+def test_snapshot_digest_is_independent_of_object_creation_order(tmp_path: Path) -> None:
+    # sqlite_master row order is an engine detail; the snapshot orders objects
+    # canonically, so creation order cannot leak into the digest.
+    _build_db(tmp_path / "ab.db", _BASE_DDL)
+    reversed_ddl = (_BASE_DDL[2], _BASE_DDL[0], _BASE_DDL[1])
+    _build_db(tmp_path / "ba.db", reversed_ddl)
+    assert _snapshot(tmp_path / "ab.db").digest == _snapshot(tmp_path / "ba.db").digest
+
+
+def test_snapshot_digest_changes_when_column_added(tmp_path: Path) -> None:
+    db = tmp_path / "orders.db"
+    _build_db(db, _BASE_DDL)
+    before = _snapshot(db).digest
+
+    conn = sqlite3.connect(db)
+    try:
+        conn.execute("ALTER TABLE orders ADD COLUMN discount REAL")
+        conn.commit()
+    finally:
+        conn.close()
+
+    after = _snapshot(db).digest
+    assert before != after
+
+
+def test_snapshot_roundtrips_through_canonical_bytes(tmp_path: Path) -> None:
+    # The signed input blob is the canonical bytes; a verifier must be able to
+    # rebuild the identical snapshot (and digest) from the stored blob alone.
+    db = tmp_path / "orders.db"
+    _build_db(db, _BASE_DDL)
+    snap = _snapshot(db)
+    restored = SchemaSnapshot.from_bytes(snap.canonical_bytes())
+    assert restored == snap
+    assert restored.digest == snap.digest
+
+
+def test_snapshot_from_bytes_rejects_malformed_input() -> None:
+    with pytest.raises(DataSourceError):
+        SchemaSnapshot.from_bytes(b"not json at all")
+    with pytest.raises(DataSourceError):
+        SchemaSnapshot.from_bytes(b'{"v":999,"objects":[]}')
+
+
+def test_internal_sqlite_objects_are_excluded(tmp_path: Path) -> None:
+    # sqlite_sequence (AUTOINCREMENT bookkeeping) is engine state, not operator
+    # schema: it must not appear in the snapshot and must not perturb the digest.
+    db = tmp_path / "auto.db"
+    _build_db(
+        db,
+        (
+            "CREATE TABLE t (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)",
+            "INSERT INTO t (name) VALUES ('a')",
+        ),
+    )
+    snap = _snapshot(db)
+    names = [o.name for o in snap.objects]
+    assert names == ["t"]
+
+
+def test_diff_names_added_removed_and_changed_objects(tmp_path: Path) -> None:
+    recorded_db = tmp_path / "recorded.db"
+    live_db = tmp_path / "live.db"
+    _build_db(recorded_db, _BASE_DDL)
+    _build_db(live_db, _BASE_DDL)
+
+    conn = sqlite3.connect(live_db)
+    try:
+        conn.execute("ALTER TABLE orders ADD COLUMN discount REAL")
+        conn.execute("DROP INDEX idx_orders_amount")
+        conn.execute("CREATE TABLE invoices (id INTEGER PRIMARY KEY)")
+        conn.commit()
+    finally:
+        conn.close()
+
+    drifts = diff_snapshots(_snapshot(recorded_db), _snapshot(live_db))
+    by_name = {d.name: d for d in drifts}
+
+    assert by_name["invoices"].change == "added"
+    assert by_name["idx_orders_amount"].change == "removed"
+    assert by_name["orders"].change == "changed"
+    assert "discount" in by_name["orders"].detail
+    # The untouched table must not be named as drifted.
+    assert "customers" not in by_name
+
+
+def test_diff_is_empty_for_equal_snapshots(tmp_path: Path) -> None:
+    _build_db(tmp_path / "a.db", _BASE_DDL)
+    _build_db(tmp_path / "b.db", _BASE_DDL)
+    assert diff_snapshots(_snapshot(tmp_path / "a.db"), _snapshot(tmp_path / "b.db")) == ()

--- a/tests/unit/datasources/test_schema_snapshot.py
+++ b/tests/unit/datasources/test_schema_snapshot.py
@@ -176,16 +176,6 @@ def test_malformed_stored_snapshot_is_refused_not_defaulted(tmp_path: Path, muta
         SchemaSnapshot.from_bytes(json.dumps(payload).encode("utf-8"))
 
 
-@pytest.mark.parametrize(
-    ("mutate", "match"),
-    [
-        (lambda obj: obj.update(columns="nope"), "columns must be a list"),
-        (lambda obj: obj["columns"].append("not-a-dict"), "non-object column entry"),
-        (lambda obj: obj["columns"][0].update(name=""), "missing or empty name"),
-        (lambda obj: obj["columns"][0].update(primary_key="1"), "non-integer primary_key"),
-    ],
-    ids=["non-list-columns", "non-dict-entry", "empty-column-name", "stringified-primary-key"],
-)
 def test_non_object_snapshot_entry_is_refused_not_dropped(tmp_path: Path) -> None:
     # A snapshot rehydrated with an entry silently omitted re-canonicalises to
     # a digest that can match a live schema missing the same object - the
@@ -201,6 +191,16 @@ def test_non_object_snapshot_entry_is_refused_not_dropped(tmp_path: Path) -> Non
         SchemaSnapshot.from_bytes(json.dumps(payload).encode("utf-8"))
 
 
+@pytest.mark.parametrize(
+    ("mutate", "match"),
+    [
+        (lambda obj: obj.update(columns="nope"), "columns must be a list"),
+        (lambda obj: obj["columns"].append("not-a-dict"), "non-object column entry"),
+        (lambda obj: obj["columns"][0].update(name=""), "missing or empty name"),
+        (lambda obj: obj["columns"][0].update(primary_key="1"), "non-integer primary_key"),
+    ],
+    ids=["non-list-columns", "non-dict-entry", "empty-column-name", "stringified-primary-key"],
+)
 def test_malformed_column_entries_are_refused_not_dropped(tmp_path: Path, mutate, match: str) -> None:
     # Pre-fix, a non-dict column entry was silently filtered and a non-list
     # columns value coerced to () - both let a malformed stored blob rehydrate

--- a/tests/unit/datasources/test_schema_snapshot.py
+++ b/tests/unit/datasources/test_schema_snapshot.py
@@ -151,6 +151,31 @@ def test_diff_is_empty_for_equal_snapshots(tmp_path: Path) -> None:
     assert diff_snapshots(_snapshot(tmp_path / "a.db"), _snapshot(tmp_path / "b.db")) == ()
 
 
+@pytest.mark.parametrize(
+    ("mutate", "match"),
+    [
+        (lambda obj: obj.update(name=""), "missing or empty name"),
+        (lambda obj: obj.update(type="shadow"), "type must be one of"),
+        (lambda obj: obj.update(sql=7), "non-string sql"),
+    ],
+    ids=["empty-name", "unknown-type", "non-string-sql"],
+)
+def test_malformed_stored_snapshot_is_refused_not_defaulted(tmp_path: Path, mutate, match: str) -> None:
+    # A stored snapshot blob is external input at drift-compare time. A field
+    # silently defaulted to "" would enter the trusted digest and turn a
+    # malformed blob into a self-consistent-looking comparison baseline; the
+    # rehydration boundary must refuse instead.
+    import json
+
+    from bernstein.core.datasources.errors import DataSourceError
+
+    _build_db(tmp_path / "a.db", _BASE_DDL)
+    payload = json.loads(_snapshot(tmp_path / "a.db").canonical_bytes())
+    mutate(payload["objects"][0])
+    with pytest.raises(DataSourceError, match=match):
+        SchemaSnapshot.from_bytes(json.dumps(payload).encode("utf-8"))
+
+
 def test_schema_mutation_during_snapshot_never_yields_a_mixed_state(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/datasources/test_schema_snapshot.py
+++ b/tests/unit/datasources/test_schema_snapshot.py
@@ -176,6 +176,47 @@ def test_malformed_stored_snapshot_is_refused_not_defaulted(tmp_path: Path, muta
         SchemaSnapshot.from_bytes(json.dumps(payload).encode("utf-8"))
 
 
+@pytest.mark.parametrize(
+    ("mutate", "match"),
+    [
+        (lambda obj: obj.update(columns="nope"), "columns must be a list"),
+        (lambda obj: obj["columns"].append("not-a-dict"), "non-object column entry"),
+        (lambda obj: obj["columns"][0].update(name=""), "missing or empty name"),
+        (lambda obj: obj["columns"][0].update(primary_key="1"), "non-integer primary_key"),
+    ],
+    ids=["non-list-columns", "non-dict-entry", "empty-column-name", "stringified-primary-key"],
+)
+def test_non_object_snapshot_entry_is_refused_not_dropped(tmp_path: Path) -> None:
+    # A snapshot rehydrated with an entry silently omitted re-canonicalises to
+    # a digest that can match a live schema missing the same object - the
+    # refusal keeps a corrupted blob from becoming a valid comparison baseline.
+    import json
+
+    from bernstein.core.datasources.errors import DataSourceError
+
+    _build_db(tmp_path / "a.db", _BASE_DDL)
+    payload = json.loads(_snapshot(tmp_path / "a.db").canonical_bytes())
+    payload["objects"].insert(1, "not-an-object")
+    with pytest.raises(DataSourceError, match=r"objects\[1\] is not an object"):
+        SchemaSnapshot.from_bytes(json.dumps(payload).encode("utf-8"))
+
+
+def test_malformed_column_entries_are_refused_not_dropped(tmp_path: Path, mutate, match: str) -> None:
+    # Pre-fix, a non-dict column entry was silently filtered and a non-list
+    # columns value coerced to () - both let a malformed stored blob rehydrate
+    # into a snapshot whose digest no longer describes what was stored.
+    import json
+
+    from bernstein.core.datasources.errors import DataSourceError
+
+    _build_db(tmp_path / "a.db", _BASE_DDL)
+    payload = json.loads(_snapshot(tmp_path / "a.db").canonical_bytes())
+    table = next(o for o in payload["objects"] if o["type"] == "table")
+    mutate(table)
+    with pytest.raises(DataSourceError, match=match):
+        SchemaSnapshot.from_bytes(json.dumps(payload).encode("utf-8"))
+
+
 def test_schema_mutation_during_snapshot_never_yields_a_mixed_state(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/datasources/test_schema_snapshot.py
+++ b/tests/unit/datasources/test_schema_snapshot.py
@@ -149,3 +149,63 @@ def test_diff_is_empty_for_equal_snapshots(tmp_path: Path) -> None:
     _build_db(tmp_path / "a.db", _BASE_DDL)
     _build_db(tmp_path / "b.db", _BASE_DDL)
     assert diff_snapshots(_snapshot(tmp_path / "a.db"), _snapshot(tmp_path / "b.db")) == ()
+
+
+def test_schema_mutation_during_snapshot_never_yields_a_mixed_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The snapshot reads sqlite_master and then PRAGMA table_info per table.
+    # A concurrent ALTER TABLE landing between those reads must never produce
+    # a digest describing a schema that never existed (old DDL text + new
+    # column list). All reads run inside one read transaction, so the
+    # snapshot is pinned at its first read: in WAL mode a concurrent writer
+    # commits freely and the snapshot still reflects the pre-ALTER state.
+    import bernstein.core.datasources.schema as schema_module
+
+    db = tmp_path / "wal.db"
+    conn_build = sqlite3.connect(db)
+    conn_build.execute("PRAGMA journal_mode=WAL")
+    for stmt in _BASE_DDL:
+        conn_build.execute(stmt)
+    conn_build.commit()
+    conn_build.close()
+
+    # Reference digests for the two states that really existed.
+    pre_digest = _snapshot(db).digest
+    twin = tmp_path / "twin.db"
+    conn_twin = sqlite3.connect(twin)
+    conn_twin.execute("PRAGMA journal_mode=WAL")
+    for stmt in _BASE_DDL:
+        conn_twin.execute(stmt)
+    conn_twin.execute("ALTER TABLE orders ADD COLUMN discount REAL")
+    conn_twin.commit()
+    conn_twin.close()
+    post_digest = _snapshot(twin).digest
+    assert pre_digest != post_digest
+
+    conn_reader = sqlite3.connect(db)
+    conn_writer = sqlite3.connect(db)
+    real_table_columns = schema_module._table_columns
+    fired = {"done": False}
+
+    def alter_then_read(conn: sqlite3.Connection, table: str) -> object:
+        # A concurrent writer lands an ALTER between the sqlite_master read
+        # and the per-table PRAGMA reads.
+        if not fired["done"]:
+            fired["done"] = True
+            conn_writer.execute("ALTER TABLE orders ADD COLUMN discount REAL")
+            conn_writer.commit()
+        return real_table_columns(conn, table)
+
+    monkeypatch.setattr(schema_module, "_table_columns", alter_then_read)
+    try:
+        snap = snapshot_schema(conn_reader)
+    finally:
+        conn_reader.close()
+        conn_writer.close()
+
+    assert fired["done"], "the concurrent ALTER never fired; the test proved nothing"
+    # The digest must describe a schema state that actually existed -- with
+    # the read transaction pinned before the ALTER, that is the pre state.
+    assert snap.digest in {pre_digest, post_digest}
+    assert snap.digest == pre_digest

--- a/tests/unit/datasources/test_schema_snapshot.py
+++ b/tests/unit/datasources/test_schema_snapshot.py
@@ -198,8 +198,9 @@ def test_non_object_snapshot_entry_is_refused_not_dropped(tmp_path: Path) -> Non
         (lambda obj: obj["columns"].append("not-a-dict"), "non-object column entry"),
         (lambda obj: obj["columns"][0].update(name=""), "missing or empty name"),
         (lambda obj: obj["columns"][0].update(primary_key="1"), "non-integer primary_key"),
+        (lambda obj: obj["columns"][0].pop("default"), "missing its default key"),
     ],
-    ids=["non-list-columns", "non-dict-entry", "empty-column-name", "stringified-primary-key"],
+    ids=["non-list-columns", "non-dict-entry", "empty-column-name", "stringified-primary-key", "omitted-default-key"],
 )
 def test_malformed_column_entries_are_refused_not_dropped(tmp_path: Path, mutate, match: str) -> None:
     # Pre-fix, a non-dict column entry was silently filtered and a non-list


### PR DESCRIPTION
# User description
## What

The first driver behind `DataActivity`: execute one read-only SQL statement through the Python DB-API (stdlib `sqlite3` as the reference implementation, no new dependency) and bind the result to the schema snapshot it was derived against.

- **`src/bernstein/core/datasources/schema.py`** (new): canonical SQLite schema snapshot — normalised `sqlite_master` DDL plus per-table `PRAGMA table_info` column lists, canonically ordered — with a `sha256:` content digest and a per-object drift diff. A content digest rather than `PRAGMA schema_version`, which is a write counter: two identical schemas can carry different counter values, and equal values attest nothing about content.
- **`src/bernstein/core/datasources/query_driver.py`** (new): `ReadOnlyQueryDriver` drives `DataActivity`'s existing phase machine — the textual read-only guard runs **before any connection work**; the schema snapshot and the query text + parameters are recorded as signed inputs before the plan is derived; the statement executes behind the existing `mode=ro` open + deny-all-writes authorizer; rows are put into explicit canonical order (sorted by canonical cell bytes) so the result bytes are a pure function of the logical result; the canonical result bytes are recorded as a signed output bound to the plan hash. The `QueryDriverBackend` protocol is the seam for DuckDB/PostgreSQL follow-ups (deliberately not in this PR, per the issue).
- **`src/bernstein/core/datasources/errors.py`**: typed `SchemaDrift`, raised fail-closed before execution when the live schema digest differs from the pinned one, naming the changed objects (added/removed/changed, with column-level detail).
- **`src/bernstein/core/datasources/service.py`**: the identity key-file names are promoted to public constants so the driver and the receipt store provably share one signing identity (no behaviour change).

Closes #3125.

A note on the issue's "Blocked by #3110" line: every one of the eight acceptance criteria is module-level and exercised via `DataActivity` directly, and none references artifact-mode declaration, so this PR implements the issue standalone. Reachability from a team manifest waits on #3111 exactly as the issue itself states. If you read the #3110 linkage differently, say the word and I will re-label this as a partial.

## Why

`DataActivity` ships a complete phase machine (signed inputs, one deterministic plan, signed outputs, `DataOpsPhaseError`) and is completely unreachable — nothing hands it a query. Being honest about the gap, as the issue insists: databases already log every statement, so statement logging is not the win. What is missing is (1) the schema state a statement was written against — a query that was correct in March and means something different in July looks identical in the log — and (2) a binding from the bytes that left the system back to the statement and schema that produced them. Both are core to bernstein's existing posture (content-addressed query receipts, deterministic replay); this closes them with the machinery already in the tree.

**Rejected alternative:** extending the existing `QueryReceiptStore` (#2887) with a schema field instead of driving `DataActivity`. Rejected for three reasons: the issue explicitly asks for a driver, not a second receipt implementation; the receipt-core binding digest of #2887 is versioned and anchors already-issued receipts, so adding fields to it would invalidate or fork the existing format; and the phase properties the ACs demand (inputs frozen at plan time, output-before-plan refused) already exist in `DataActivity` and would have to be rebuilt in the store. For the same reason, explicit row ordering is implemented as a driver-layer canonicalisation rather than by touching `result.canonical_bytes`, whose `_MAGIC`-versioned encoding anchors existing #2887 receipts — plain #2887 receipts still hash rows in engine order, unchanged, and the doc says so.

## How

Phase choreography in `ReadOnlyQueryDriver.run`: textual guard → live schema snapshot → fail-closed drift check against an optionally pinned snapshot → signed inputs (schema, query+params) → deterministic plan → guarded execution → canonical row order → signed output → `DataOpsReceipt`. Verification is the existing `verify_data_ops_receipt`; determinism across separate `.sdd` directories follows from deterministic Ed25519 plus the plan being a pure function of input hashes.

Tests (26 new, `tests/unit/datasources/test_query_driver.py` + `test_schema_snapshot.py`) map onto the ACs:

- AC2: parametrised refusal suite (insert/update/delete/drop/create/alter, multi-statement with the write second, write inside a CTE) with a **trace-callback on an injected connection proving the connection executed nothing**, plus a refusal against a database file that cannot even be opened; the authorizer layer is exercised independently via a value-setting PRAGMA that passes the textual guard.
- AC3: the snapshot's content hash is asserted among the receipt's signed inputs and inside `plan.input_hashes`; `ALTER TABLE ADD COLUMN` moves the digest.
- AC4: flipping one byte of the stored canonical result bytes fails `verify_data_ops_receipt` at evidence reattachment.
- AC5: byte-identical canonical result bytes and identical receipt hash across two separate temporary `.sdd` directories with the same injected keypair; row order proven canonical against two databases whose natural scan order demonstrably differs (asserted before the canonical comparison).
- AC6: `SchemaDrift` carries both digests and names the changed table and column; the trace callback proves the submitted statement never executed and the content store stays empty.
- AC7: `DataOpsPhaseError` on output-before-plan, exercised directly through the driver's `new_activity()` seam.
- Credentials: a DSN carrying a secret-looking component appears in no receipt byte and no stored blob; provenance is the connection id only.

On AC8 ("CI runs offline against a checked-in fixture database"): no binary DB fixture exists anywhere in `tests/` today, so this PR follows the repo-idiomatic reading — the checked-in artifact is the deterministic fixture-building SQL in the test files, and every database is built in-test from those statements. CI is fully offline either way. Flagging the choice explicitly in case a literal binary fixture was intended.

Fail-before/pass-after was proven empirically: with `git stash push -u -- src/` the new test files fail at collection (`ImportError: cannot import name 'SchemaDrift'`); after `git stash pop` all 26 pass.

## Checklist

- [x] `uv run ruff check src/` passes (`ruff format --check` too)
- [x] `uv run pyright src/` — the four touched modules (`schema.py`, `query_driver.py`, `errors.py`, `service.py`) are pyright-clean at the repo's strict settings (0 errors); the repo-wide run keeps its pre-existing advisory backlog, none of it introduced here
- [x] Tests pass — run per-file with the isolated runner semantics (`tests/unit/datasources/*` 97 passed, `tests/unit/test_activity_data_ops.py` 14 passed); the full `scripts/run_tests.py` sweep is left to the CI shards per the per-file testing policy
- [x] New code has type hints
- [x] `lint-imports` architecture contracts kept

### Documentation duty (every PR that touches a feature)

- [x] README section updated: one pointer row in "beyond the front page" linking the datasources doc
- [x] `docs/operations/datasources.md`: new "The schema-bound query driver" section (guarantees, drift semantics, determinism, on-disk `cas/` layout entry)
- [x] docs/api/ schema regenerated — N/A (no HTTP API surface changed)
- [x] `uv run bernstein agents-md sync` run — AGENTS.md, CLAUDE.md, .goosehints, CONVENTIONS.md, .cursor/rules/*.mdc reflect the updated `datasources/` module purpose; `agents-md verify` clean
- [x] Tests cover the documented behaviour

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add a schema-bound read-only query driver that snapshots SQLite schema content, enforces fail-closed drift checks, and signs canonicalized query inputs and outputs through <code>DataActivity</code>. Update the shared datasource identity wiring and docs so the receipt store, driver, and offline tests all use one install identity and deterministic SQLite behavior.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3386?tool=ast&topic=Schema+snapshot>Schema snapshot</a>
        </td><td>Canonicalize SQLite schema state into a content-addressed snapshot and typed <code>SchemaDrift</code> diff so the driver can fail closed when tables or columns change.<details><summary>Modified files (3)</summary><ul><li>src/bernstein/core/datasources/errors.py</li>
<li>src/bernstein/core/datasources/schema.py</li>
<li>tests/unit/datasources/test_schema_snapshot.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>noreply@anthropic.com</td><td>fix(datasources): requ...</td><td>August 03, 2026</td></tr>
<tr><td>chernistry</td><td>feat(datasources): con...</td><td>July 24, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3386?tool=ast&topic=Query+driver>Query driver</a>
        </td><td>Drive one read-only SQL statement through <code>DataActivity</code>, canonicalize row order, sign query inputs and result bytes, and wire the shared datasource identity and docs around the new flow.<details><summary>Modified files (12)</summary><ul><li>.cursor/rules/module-map.mdc</li>
<li>.goosehints</li>
<li>AGENTS.md</li>
<li>CLAUDE.md</li>
<li>CONVENTIONS.md</li>
<li>README.md</li>
<li>docs/operations/datasources.md</li>
<li>src/bernstein/core/datasources/__init__.py</li>
<li>src/bernstein/core/datasources/engine.py</li>
<li>src/bernstein/core/datasources/query_driver.py</li>
<li>src/bernstein/core/datasources/service.py</li>
<li>tests/unit/datasources/test_query_driver.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>noreply@anthropic.com</td><td>feat(datasources): add...</td><td>August 03, 2026</td></tr>
<tr><td>chernistry</td><td>docs: add per-director...</td><td>August 03, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3386?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>