### PR TITLE
feat(audit): add bernstein audit diagnose - name the first faulty step from the signed per-step journal

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ bernstein replay list                 # run ids recorded on disk
 bernstein replay latest --verify      # recompute the journal head, name the first divergent step
 bernstein lineage verify <run_id>     # recompute the always-on lineage spine
 bernstein audit verify                # HMAC chain + Merkle seal (written because audit was enabled)
+bernstein audit diagnose <run_id> --signal gate --sign-key KEY
+                                      # name the exact step a failure entered the run, as a signed receipt
 ```
 
 The journal and the lineage spine are written on every run. `bernstein audit verify` only has a chain to check when the run was started with `BERNSTEIN_AUDIT=1`, a compliance preset, or `bernstein run --audit`. The `--audit` flag belongs to `bernstein run`; on the `bernstein -g` form above, set the environment variable.

--- a/docs/operations/audit-diagnose.md
+++ b/docs/operations/audit-diagnose.md
@@ -1,0 +1,114 @@
+# Single-run fault localisation: `bernstein audit diagnose` (issue #2928)
+
+Every run's journal (`.sdd/runs/<run_id>/journal.jsonl`) already records
+each tool call, tool result, provider-state mutation, and knob selection as
+a Merkle-chained step. `bernstein audit verify` proves a chain is intact and
+`bernstein replay debug <LEFT> <RIGHT>` localises where two runs diverge --
+but neither can point at the first faulty step of a *single* run that
+recorded cleanly and still went wrong. `audit diagnose` closes that gap: it
+turns a failure signal into a pure predicate over the recorded steps, names
+the minimal step index at which the predicate first holds, and seals the
+finding into a signed receipt any holder of the journal can re-derive
+offline.
+
+## TL;DR
+
+| Verb | What it does |
+|---|---|
+| `bernstein audit diagnose <RUN_ID> --signal <S> --sign-key KEY` | Name the first faulty step (`culprit_index` + `culprit_step_hash`) and write a signed diagnosis receipt under `.sdd/evidence/` |
+| `bernstein audit diagnose verify <RECEIPT> [--public-key PEM]` | Re-derive the culprit offline and assert byte-identity with the receipt |
+
+## Failure signals
+
+`--signal` selects how "this run went wrong" becomes a predicate over the
+recorded steps. Every adapter reads on-disk records only -- no network, no
+live process -- so the resolved predicate is reproducible.
+
+| Signal | Backing record | Culprit criterion |
+|---|---|---|
+| `gate[:RECEIPT_HASH]` | Sealed verdict receipts under `.sdd/eval/gate/` | First step whose payload carries the rejected suite / candidate result-set content hash. Bare `gate` resolves the most recent `significant_regression` receipt deterministically (highest `(timestamp, receipt_hash)`). |
+| `artefact:<path>` | The signed lineage log (`.sdd/lineage/log.jsonl`) | First step whose payload carries the content hash of an untrusted provenance record in the artefact's taint closure. The content-addressed parent chain (culprit record → artefact tip) is attached to the receipt as `lineage_path`. |
+| `incident:<case-id>` | A synthesised incident eval case (`src/bernstein/eval/cases/incidents/`) | First step whose payload carries the case's recorded failure text, byte-exact. |
+| `replay` | The journal itself | First step at which the Merkle chain fails to recompute (`chain_break`). An intact chain reports clean and writes no receipt. |
+
+The culprit is attributed with a `reason_code` from the same machine-readable
+vocabulary `bernstein replay` divergence reporting uses
+(`src/bernstein/core/replay/diff.py`): `bad_input_content_hash`,
+`first_failing_tool_result`, `provider_state_mutation` (when the culprit row
+is a provider-side context mutation), or `chain_break`.
+
+## The diagnosis receipt
+
+The receipt is the deliverable, not the terminal output. It is
+content-addressed (canonical JSON, `receipt_hash` over the body),
+Ed25519-signed with the key you pass via `--sign-key` (the lineage
+customer-signing key machinery), and carries an operator HMAC under the
+audit-chain key plus the current audit-chain head (`chain_head_hmac`) as an
+anchor. Key fields:
+
+| Field | Meaning |
+|---|---|
+| `run_id`, `journal_head` | Run identity; the head is recomputed from the on-disk payloads |
+| `journal_file_sha256` | Exact bytes of the diagnosed journal |
+| `culprit_index`, `culprit_step_hash` | The named step and its exact `event_hash` |
+| `reason_code`, `reason` | Attribution, machine- and human-readable |
+| `predicate_id`, `predicate_hash`, `signal` | What "failed" meant, embedded so a verifier reproduces the predicate without the gate / lineage / incident stores |
+| `lineage_path` | Content-addressed parent chain (artefact signal) |
+| `chain_head_hmac`, `operator_hmac`, `signature` | Anchors: audit chain head, operator HMAC, Ed25519 |
+
+No wall-clock value enters the receipt, so two independent invocations over
+the same journal produce byte-identical receipts -- diff them if you doubt it.
+
+## Worked example
+
+```bash
+# a nightly run went red at the eval gate; name the step that caused it
+bernstein audit diagnose run-2026-08-02-nightly --signal gate \
+  --sign-key /etc/bernstein/lineage-signing.pem
+
+# months later, on another machine, re-check the claim offline
+bernstein audit diagnose verify \
+  .sdd/evidence/diagnosis-run-2026-08-02-nightly-<hash>.json \
+  --public-key lineage-signing-pub.pem
+```
+
+Exit codes -- diagnose: `0` chain intact / nothing to report; `1` culprit
+named and receipt written; `2` fail-closed refusal. verify: `0` the culprit
+re-derives byte-for-byte; `1` verification failed; `2` usage error or
+unreadable receipt.
+
+## Fail-closed contract
+
+The diagnosis is a projection of the signed record, never an inference
+beside it. Each of these refuses with exit `2` and writes **no** receipt:
+
+- the journal is missing or empty ("no signed per-step record for run X");
+- the audit HMAC key is unavailable (`load`-only resolution -- diagnose
+  never creates key material);
+- `--sign-key` is omitted (no unsigned findings);
+- the chain does not recompute and a content signal was requested (use
+  `--signal replay` to localise the break itself);
+- the signal's fingerprint appears in no recorded step -- the command
+  refuses to guess rather than fall back to a heuristic log scan.
+
+`verify` fails on a journal mutated anywhere -- at or after the culprit step
+included -- because the receipt pins both the recomputed head and the exact
+journal bytes.
+
+## Relationship to the replay surface
+
+`bernstein replay` reconstructs and diffs (`--verify`, `--from-step`,
+`debug`, two-run path diff); `audit diagnose` localises a single run's first
+fault and signs the finding. Use `replay debug <RUN> --fork-from N` with the
+receipt's `culprit_index` to reproduce the run from just before the culprit.
+
+## Cross-references
+
+- [HMAC-chained audit log: operator guide](../security/audit-log.md) --
+  "Diagnosing a run" section.
+- [Per-step session replay](replay.md) and
+  [deterministic replay](deterministic-replay.md).
+- [Standard verifiable audit receipts](../security/audit-receipt.md).
+- Source: `src/bernstein/core/replay/diagnose.py`,
+  `diagnose_signals.py`, `diagnosis_receipt.py`;
+  CLI in `src/bernstein/cli/commands/audit_cmd.py`.

--- a/docs/operations/audit-diagnose.md
+++ b/docs/operations/audit-diagnose.md
@@ -27,7 +27,7 @@ live process -- so the resolved predicate is reproducible.
 | Signal | Backing record | Culprit criterion |
 |---|---|---|
 | `gate[:RECEIPT_HASH]` | Sealed verdict receipts under `.sdd/eval/gate/` | First step whose payload carries the rejected suite / candidate result-set content hash. Bare `gate` resolves the most recent `significant_regression` receipt deterministically (highest `(timestamp, receipt_hash)`). |
-| `artefact:<path>` | The signed lineage log (`.sdd/lineage/log.jsonl`) | First step whose payload carries the content hash of an untrusted provenance record in the artefact's taint closure. The content-addressed parent chain (culprit record → artefact tip) is attached to the receipt as `lineage_path`. |
+| `artefact:<path>` | The signed lineage log (`.sdd/lineage/log.jsonl`), **gated first** | The lineage gate (byte-canonical parsing, detached signatures against `.sdd/agents` cards, parent anchoring, operator HMAC when `BERNSTEIN_LINEAGE_OP_SECRET` is set — the same checks `bernstein audit taint` requires) must pass before any predicate is shaped; then the culprit is the first step whose payload carries the content hash of an untrusted provenance record in the artefact's taint closure. The content-addressed parent chain (culprit record → artefact tip) is attached to the receipt as `lineage_path`, and the gate mode used is disclosed in the sealed params as `lineage_gate.operator_hmac_checked`. |
 | `incident:<case-id>` | A synthesised incident eval case (`src/bernstein/eval/cases/incidents/`) | First step whose payload carries the case's recorded failure text, byte-exact. |
 | `replay` | The journal itself | First step at which the Merkle chain fails to recompute (`chain_break`). An intact chain reports clean and writes no receipt. |
 
@@ -90,6 +90,8 @@ beside it. Each of these refuses with exit `2` and writes **no** receipt:
 - the audit HMAC key is unavailable (`load`-only resolution -- diagnose
   never creates key material);
 - `--sign-key` is omitted (no unsigned findings);
+- the lineage gate fails for an `artefact:` signal (an unsigned, malformed,
+  or reparented entry must never shape a sealed predicate);
 - the chain does not recompute and a content signal was requested (use
   `--signal replay` to localise the break itself);
 - the signal's fingerprint appears in no recorded step -- the command

--- a/docs/operations/audit-diagnose.md
+++ b/docs/operations/audit-diagnose.md
@@ -83,6 +83,10 @@ The diagnosis is a projection of the signed record, never an inference
 beside it. Each of these refuses with exit `2` and writes **no** receipt:
 
 - the journal is missing or empty ("no signed per-step record for run X");
+- the journal contains any non-blank line that does not parse as a JSON
+  object (a torn or corrupted write) -- ordinary journal readers tolerate a
+  torn tail, but the diagnostic reader refuses a filtered sequence so every
+  reported index counts physical journal lines;
 - the audit HMAC key is unavailable (`load`-only resolution -- diagnose
   never creates key material);
 - `--sign-key` is omitted (no unsigned findings);

--- a/docs/security/audit-log.md
+++ b/docs/security/audit-log.md
@@ -613,9 +613,42 @@ rare benign causes:
    tighten the key permissions and try again rather than pointing at
    a different key - the existing log was signed with the original.
 
+## Diagnosing a run
+
+`bernstein audit verify` tells you the chain is intact; it does not tell
+you which step of a run first went wrong. `bernstein audit diagnose` does:
+it evaluates a failure signal as a pure predicate over the run's
+Merkle-chained journal (`.sdd/runs/<run_id>/journal.jsonl`) and names the
+first step at which the predicate holds, sealed into an Ed25519-signed,
+content-addressed diagnosis receipt you can re-derive offline.
+
+```bash
+# name the step that introduced the content hash the eval gate rejected
+bernstein audit diagnose <run_id> --signal gate --sign-key KEY
+
+# walk a tainted artefact's lineage back to the recording step
+bernstein audit diagnose <run_id> --signal artefact:out/report.md --sign-key KEY
+
+# localise a chain break (tamper / non-determinism) as a signed finding
+bernstein audit diagnose <run_id> --signal replay --sign-key KEY
+
+# re-derive the culprit offline and assert byte-identity with the receipt
+bernstein audit diagnose verify .sdd/evidence/diagnosis-<run_id>-<hash>.json \
+  --public-key PUB.pem
+```
+
+Fail-closed: a missing or empty journal, an unavailable audit HMAC key
+(load-only -- diagnose never creates key material), a chain-broken journal
+under a content signal, or a signal whose fingerprint appears in no
+recorded step all exit non-zero and write **no** receipt. The diagnosis is
+a projection of the signed record, never a heuristic log scan. Full
+runbook: [audit diagnose](../operations/audit-diagnose.md).
+
 ## Cross-references
 
 - [SOC 2 audit mode quick start](AUDIT.md)
+- [Single-run fault localisation](../operations/audit-diagnose.md) -
+  `bernstein audit diagnose` runbook.
 - [Multi-tenant audit-chain export](audit-multitenant.md)
 - [DSSE / in-toto envelope](audit-dsse-envelope.md) - third-party-verifiable
   wrapper over the Article 12 bundle.

--- a/docs/security/audit-log.md
+++ b/docs/security/audit-log.md
@@ -637,7 +637,8 @@ bernstein audit diagnose verify .sdd/evidence/diagnosis-<run_id>-<hash>.json \
   --public-key PUB.pem
 ```
 
-Fail-closed: a missing or empty journal, an unavailable audit HMAC key
+Fail-closed: a missing or empty journal, a journal with any unparsable
+line (torn or corrupted write), an unavailable audit HMAC key
 (load-only -- diagnose never creates key material), a chain-broken journal
 under a content signal, or a signal whose fingerprint appears in no
 recorded step all exit non-zero and write **no** receipt. The diagnosis is

--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -3254,8 +3254,15 @@ def _diagnose_run_cli(
     except LineageSignerError as exc:
         console.print(f"[red]Cannot load signing key:[/red] {exc}")
         return 2
+    # The artefact signal runs the lineage gate; mirror `audit taint`: the
+    # operator HMAC layer is checked when BERNSTEIN_LINEAGE_OP_SECRET is set,
+    # and the mode used is disclosed inside the sealed receipt params.
+    import os as _os
+
+    secret_raw = _os.environ.get("BERNSTEIN_LINEAGE_OP_SECRET")
+    lineage_secret = secret_raw.encode("utf-8") if secret_raw else None
     try:
-        predicate = resolve_signal(signal_spec, sdd_dir=sdd_dir)
+        predicate = resolve_signal(signal_spec, sdd_dir=sdd_dir, lineage_operator_secret=lineage_secret)
         result = diagnose_run(journal_path, predicate, run_id=run_id)
     except DiagnoseError as exc:
         console.print(f"[red]Diagnosis refused (fail closed, no receipt):[/red] {exc}")

--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -25,6 +25,9 @@ Commands:
   bernstein audit slice              Write a deterministic subset.
   bernstein audit query              Query audit log events with filters.
   bernstein audit archive            Safely archive corrupt / pre-rotation jsonl files.
+  bernstein audit diagnose           Name the first faulty step of a run from
+                                     its signed per-step journal (#2928).
+  bernstein audit diagnose verify    Re-derive a diagnosis receipt offline.
 
 Operator guide: docs/security/audit-log.md.
 """
@@ -3081,3 +3084,310 @@ def receipt_verify_cmd(
     if proc.returncode != 0 and proc.stderr:
         console.print(f"[red]{proc.stderr.rstrip()}[/red]")
     raise SystemExit(proc.returncode)
+
+
+# ---------------------------------------------------------------------------
+# audit diagnose - single-run first-fault localisation (#2928)
+# ---------------------------------------------------------------------------
+
+
+@audit_group.command("diagnose")
+@click.argument("args", nargs=-1, required=True)
+@click.option(
+    "--signal",
+    "signal_spec",
+    default=None,
+    help="Failure signal: gate[:RECEIPT_HASH] | artefact:<path> | incident:<case-id> | replay.",
+)
+@click.option(
+    "--sign-key",
+    "sign_key_path",
+    default=None,
+    type=click.Path(dir_okay=False, exists=True, resolve_path=True),
+    help="Ed25519 private key (PEM or raw 32-byte seed) that signs the diagnosis receipt.",
+)
+@click.option(
+    "--public-key",
+    "public_key_path",
+    default=None,
+    type=click.Path(dir_okay=False, exists=True, resolve_path=True),
+    help="Trusted Ed25519 public key to pin when verifying a receipt.",
+)
+@click.option(
+    "--out",
+    "-o",
+    "output_dir",
+    default=None,
+    help="Receipt output directory (default: <sdd-dir>/evidence).",
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Emit the finding as JSON.")
+@click.option("--sdd-dir", "sdd_dir", default=".sdd", show_default=True, help="Project .sdd directory.")
+@click.option(
+    "--audit-key",
+    "audit_key_path",
+    default=None,
+    type=click.Path(dir_okay=False, resolve_path=True),
+    help="Audit HMAC key path override (default: the canonical resolver, load-only).",
+)
+def diagnose_cmd(
+    args: tuple[str, ...],
+    signal_spec: str | None,
+    sign_key_path: str | None,
+    public_key_path: str | None,
+    output_dir: str | None,
+    as_json: bool,
+    sdd_dir: str,
+    audit_key_path: str | None,
+) -> None:
+    """Name the exact first faulty step of a run from its signed journal.
+
+    \b
+    Usage:
+      bernstein audit diagnose <RUN_ID> --signal <SIGNAL> --sign-key KEY
+      bernstein audit diagnose verify <RECEIPT> [--public-key PEM]
+
+    \b
+    The per-run journal (.sdd/runs/<run_id>/journal.jsonl) already records
+    every step as a Merkle-chained row. `verify` (chain integrity) and
+    `replay diff` (two runs) cannot point at the first faulty step of one
+    run - this command can: it resolves --signal into a pure predicate over
+    on-disk records, names the minimal step index at which the predicate
+    first holds, and seals the finding (culprit_index + culprit_step_hash,
+    bound to the recomputed journal head) into an Ed25519-signed,
+    content-addressed diagnosis receipt under <sdd-dir>/evidence.
+    Complementary to `bernstein replay --verify/--from-step/diff`, which
+    reconstructs and diffs; diagnose localises and signs.
+
+    \b
+    Fail-closed: a missing/empty journal, an unavailable audit HMAC key, a
+    chain-broken journal (for content signals), or a signal that resolves
+    to no recorded step all exit non-zero and write no receipt - the
+    diagnosis is a projection of the signed record, never a heuristic scan.
+
+    \b
+    Exit codes (diagnose): 0 chain intact / nothing to report; 1 culprit
+    named and receipt written; 2 fail-closed refusal.
+    Exit codes (verify): 0 receipt re-derives byte-for-byte; 1 verification
+    failed; 2 usage or unreadable receipt.
+
+    Operator runbook: docs/security/audit-log.md (Diagnosing a run).
+    """
+    if args[0] == "verify":
+        raise SystemExit(
+            _diagnose_verify(
+                args[1:],
+                public_key_path=public_key_path,
+                sdd_dir=Path(sdd_dir),
+                audit_key_path=audit_key_path,
+                as_json=as_json,
+            )
+        )
+    raise SystemExit(
+        _diagnose_run_cli(
+            args,
+            signal_spec=signal_spec,
+            sign_key_path=sign_key_path,
+            output_dir=output_dir,
+            sdd_dir=Path(sdd_dir),
+            audit_key_path=audit_key_path,
+            as_json=as_json,
+        )
+    )
+
+
+def _diagnose_load_audit_key(audit_key_path: str | None) -> bytes:
+    """Load the operator audit HMAC key, never creating one (fail closed)."""
+    from bernstein.core.security.audit import load_audit_key
+
+    return load_audit_key(Path(audit_key_path) if audit_key_path else None)
+
+
+def _diagnose_run_cli(
+    args: tuple[str, ...],
+    *,
+    signal_spec: str | None,
+    sign_key_path: str | None,
+    output_dir: str | None,
+    sdd_dir: Path,
+    audit_key_path: str | None,
+    as_json: bool,
+) -> int:
+    """Run the diagnosis flow. Returns the process exit code."""
+    import json as _json
+
+    from bernstein.core.persistence.lineage_signer import Ed25519FileKeySigner, LineageSignerError
+    from bernstein.core.replay.diagnose import DiagnoseError, diagnose_run
+    from bernstein.core.replay.diagnose_signals import resolve_signal
+    from bernstein.core.replay.diagnosis_receipt import DiagnosisReceiptError, build_diagnosis_receipt
+    from bernstein.core.replay.journal import JournalPathError, run_journal_path
+    from bernstein.core.security.audit import AuditKeyMissingError, AuditKeyPermissionError
+
+    if len(args) != 1:
+        console.print("[red]Usage:[/red] bernstein audit diagnose <RUN_ID> --signal <SIGNAL> --sign-key KEY")
+        return 2
+    run_id = args[0]
+    if signal_spec is None:
+        console.print(
+            "[red]--signal is required[/red] (gate[:RECEIPT_HASH] | artefact:<path> | incident:<case-id> | replay)"
+        )
+        return 2
+    if sign_key_path is None:
+        console.print(
+            "[red]--sign-key is required:[/red] the diagnosis receipt is the deliverable and it "
+            "must be Ed25519-signed; refusing to emit an unsigned finding."
+        )
+        return 2
+
+    try:
+        journal_path = run_journal_path(sdd_dir, run_id)
+    except JournalPathError as exc:
+        console.print(f"[red]{exc}[/red]")
+        return 2
+    try:
+        audit_key = _diagnose_load_audit_key(audit_key_path)
+    except (AuditKeyMissingError, AuditKeyPermissionError) as exc:
+        console.print(f"[red]Audit HMAC key unavailable - failing closed, no receipt:[/red] {exc}")
+        return 2
+    try:
+        signer = Ed25519FileKeySigner.from_path(Path(sign_key_path))
+    except LineageSignerError as exc:
+        console.print(f"[red]Cannot load signing key:[/red] {exc}")
+        return 2
+    try:
+        predicate = resolve_signal(signal_spec, sdd_dir=sdd_dir)
+        result = diagnose_run(journal_path, predicate, run_id=run_id)
+    except DiagnoseError as exc:
+        console.print(f"[red]Diagnosis refused (fail closed, no receipt):[/red] {exc}")
+        return 2
+
+    if not result.located:
+        if as_json:
+            click.echo(_json.dumps({"run_id": run_id, "located": False, "reason": result.reason}, sort_keys=True))
+        else:
+            console.print(f"[green]{result.reason}[/green] - nothing to report, no receipt emitted.")
+        return 0
+
+    from bernstein.core.security.audit_chain import AuditChainStore
+
+    chain_head = AuditChainStore(sdd_dir / "audit", key=audit_key).prev_chain_digest
+    try:
+        receipt = build_diagnosis_receipt(
+            result,
+            chain_head_hmac=chain_head,
+            signer=signer,
+            audit_key=audit_key,
+            output_dir=Path(output_dir) if output_dir else sdd_dir / "evidence",
+        )
+    except DiagnosisReceiptError as exc:
+        console.print(f"[red]Receipt build failed:[/red] {exc}")
+        return 2
+
+    if as_json:
+        click.echo(
+            _json.dumps(
+                {
+                    "run_id": run_id,
+                    "located": True,
+                    "culprit_index": result.culprit_index,
+                    "culprit_step_hash": result.culprit_step_hash,
+                    "reason_code": result.reason_code,
+                    "reason": result.reason,
+                    "predicate_id": result.predicate_id,
+                    "predicate_hash": result.predicate_hash,
+                    "journal_head": result.journal_head,
+                    "receipt_hash": receipt.receipt_hash,
+                    "receipt_sha256": receipt.sha256,
+                    "receipt_path": str(receipt.receipt_path),
+                },
+                sort_keys=True,
+            )
+        )
+        return 1
+
+    console.print()
+    console.print(
+        Panel(
+            f"[bold]run {run_id}[/bold]\n"
+            f"culprit step: [bold red]#{result.culprit_index}[/bold red] of {result.event_count}\n"
+            f"step hash:    {result.culprit_step_hash}\n"
+            f"reason:       [bold]{result.reason_code}[/bold] - {result.reason}\n"
+            f"journal head: {result.journal_head}",
+            title="Diagnosis",
+            border_style="red",
+            expand=False,
+        )
+    )
+    console.print(f"[green]Signed diagnosis receipt[/green] -> {receipt.receipt_path}")
+    console.print(f"  receipt_hash: {receipt.receipt_hash}")
+    console.print("[dim]Re-check offline with:[/dim] bernstein audit diagnose verify " + str(receipt.receipt_path))
+    return 1
+
+
+def _diagnose_verify(
+    args: tuple[str, ...],
+    *,
+    public_key_path: str | None,
+    sdd_dir: Path,
+    audit_key_path: str | None,
+    as_json: bool,
+) -> int:
+    """Verify a diagnosis receipt offline. Returns the process exit code."""
+    import json as _json
+
+    from bernstein.core.persistence.lineage_signer import Ed25519PublicKeyVerifier, LineageSignerError
+    from bernstein.core.replay.diagnosis_receipt import verify_diagnosis_receipt
+    from bernstein.core.replay.journal import JournalPathError, run_journal_path
+    from bernstein.core.security.audit import AuditKeyMissingError, AuditKeyPermissionError
+
+    if len(args) != 1:
+        console.print("[red]Usage:[/red] bernstein audit diagnose verify <RECEIPT> [--public-key PEM]")
+        return 2
+    receipt_path = Path(args[0])
+    if not receipt_path.is_file():
+        console.print(f"[red]Receipt not found:[/red] {receipt_path}")
+        return 2
+
+    try:
+        run_id = str(_json.loads(receipt_path.read_text(encoding="utf-8")).get("run_id", ""))
+        journal_path = run_journal_path(sdd_dir, run_id)
+    except (OSError, _json.JSONDecodeError, JournalPathError) as exc:
+        console.print(f"[red]Cannot locate the diagnosed journal:[/red] {exc}")
+        return 2
+
+    verifier = None
+    if public_key_path is not None:
+        try:
+            verifier = Ed25519PublicKeyVerifier.from_path(Path(public_key_path))
+        except LineageSignerError as exc:
+            console.print(f"[red]Cannot load public key:[/red] {exc}")
+            return 2
+
+    audit_key: bytes | None
+    try:
+        audit_key = _diagnose_load_audit_key(audit_key_path)
+    except (AuditKeyMissingError, AuditKeyPermissionError):
+        audit_key = None
+
+    outcome = verify_diagnosis_receipt(
+        receipt_path,
+        journal_path=journal_path,
+        verifier=verifier,
+        audit_key=audit_key,
+    )
+
+    if as_json:
+        click.echo(
+            _json.dumps(
+                {"ok": outcome.ok, "reason": outcome.reason, "hmac_checked": outcome.hmac_checked},
+                sort_keys=True,
+            )
+        )
+        return 0 if outcome.ok else 1
+
+    if outcome.ok:
+        console.print("[green]Diagnosis receipt verified:[/green] the culprit re-derives byte-for-byte.")
+        if not outcome.hmac_checked:
+            console.print("[yellow]Operator HMAC not checked (no audit key available).[/yellow]")
+        return 0
+    console.print(f"[red]Diagnosis receipt FAILED verification:[/red] {outcome.reason}")
+    return 1

--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -3159,10 +3159,11 @@ def diagnose_cmd(
     reconstructs and diffs; diagnose localises and signs.
 
     \b
-    Fail-closed: a missing/empty journal, an unavailable audit HMAC key, a
-    chain-broken journal (for content signals), or a signal that resolves
-    to no recorded step all exit non-zero and write no receipt - the
-    diagnosis is a projection of the signed record, never a heuristic scan.
+    Fail-closed: a missing/empty journal, a journal with any unparsable
+    line, an unavailable audit HMAC key, a chain-broken journal (for
+    content signals), or a signal that resolves to no recorded step all
+    exit non-zero and write no receipt - the diagnosis is a projection of
+    the signed record, never a heuristic scan.
 
     \b
     Exit codes (diagnose): 0 chain intact / nothing to report; 1 culprit

--- a/src/bernstein/core/replay/diagnose.py
+++ b/src/bernstein/core/replay/diagnose.py
@@ -1,0 +1,313 @@
+"""Single-run first-fault locator over the signed per-step journal (#2928).
+
+The per-run event journal (:mod:`bernstein.core.replay.journal`) already
+records every step of a run as a Merkle-chained, hash-addressed row.
+``verify_journal`` proves that chain is intact and ``diff_event_logs``
+(:mod:`bernstein.core.replay.diff`) localises where two runs diverge -- but
+neither can point at the first faulty step of a *single* run that recorded
+cleanly and still went wrong. :func:`diagnose_run` closes that gap: it
+evaluates a pure failure predicate over growing prefixes of the journal and
+names the minimal step index at which the predicate first holds, together
+with that step's exact ``event_hash``.
+
+The finding follows the reporting shape transparency-log verifiers use
+(RFC 6962 style): a 0-based entry index plus the entry's hash, bound to a
+head recomputed over the whole log, so any independent holder of the journal
+re-derives the identical finding offline. No wall-clock value enters the
+result, and the predicate is a pure function of on-disk records, so two
+invocations over the same journal are byte-identical.
+
+Fail-closed contract
+--------------------
+The diagnosis is a projection of the signed record, never an inference
+beside it:
+
+* a missing or empty journal refuses with :class:`DiagnoseError`;
+* a content predicate is only evaluated over a journal whose chain
+  recomputes cleanly -- a chain-broken journal refuses and points the
+  operator at ``--signal replay``, which reports the break itself;
+* a signal whose fingerprint never appears in the journal refuses with
+  :class:`SignalNotLocatedError` rather than guessing a step.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.replay.diff import (
+    REASON_CODE_CHAIN_BREAK,
+    REASON_CODE_NONE,
+    REASON_CODE_PROVIDER_STATE_MUTATION,
+)
+from bernstein.core.replay.journal import (
+    _NON_DETERMINISTIC_FIELDS,  # pyright: ignore[reportPrivateUsage] - shared journal projection
+    load_events,
+    rebuild_state,
+    verify_journal,
+)
+from bernstein.core.replay.provider_state import PROVIDER_STATE_MUTATION_EVENT
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+#: Predicate evaluation modes. ``content`` scans step payloads for the
+#: signal's fingerprint over an intact chain; ``chain`` reports the first
+#: chain-integrity break located by ``verify_journal``.
+SIGNAL_MODE_CONTENT = "content"
+SIGNAL_MODE_CHAIN = "chain"
+
+
+class DiagnoseError(RuntimeError):
+    """Raised when a diagnosis cannot be derived from the signed record.
+
+    Fail-closed by design: callers must emit no receipt on this error.
+    """
+
+
+class SignalNotLocatedError(DiagnoseError):
+    """Raised when the failure signal resolves to no recorded step.
+
+    The signal itself exists (a gate rejected, an artefact is tainted) but
+    the journal never recorded the offending content, so there is no step
+    to name. Refusing is the honest outcome -- a guess would not be a
+    projection of the signed chain.
+    """
+
+
+def _canonical_json(obj: Any) -> str:
+    """Deterministic JSON text (sorted keys, compact separators)."""
+    return json.dumps(obj, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str)
+
+
+@dataclass(frozen=True, slots=True)
+class SignalPredicate:
+    """A failure signal resolved to a pure predicate over journal rows.
+
+    Built by :mod:`bernstein.core.replay.diagnose_signals` from on-disk
+    records only. The ``params`` dict is the predicate's full parameterisation
+    and is embedded verbatim in the diagnosis receipt, so an offline verifier
+    reconstructs exactly the same predicate without re-reading the gate /
+    lineage / incident stores.
+
+    Attributes:
+        predicate_id: Versioned identifier of the predicate semantics
+            (e.g. ``"gate/v1"``).
+        params: JSON-safe parameterisation (kind, needles, anchors).
+        default_reason_code: Attribution class applied when the culprit row
+            is not a provider-state mutation entry.
+        needles: Content fingerprints; a row matches when any needle occurs
+            in its canonical timing-excluded payload text.
+        lineage_path: Optional content-addressed evidence chain
+            (culprit entry -> failing artefact tip), attached unchanged to
+            the result.
+        mode: :data:`SIGNAL_MODE_CONTENT` or :data:`SIGNAL_MODE_CHAIN`.
+    """
+
+    predicate_id: str
+    params: dict[str, Any]
+    default_reason_code: str
+    needles: tuple[str, ...] = ()
+    lineage_path: tuple[str, ...] = ()
+    mode: str = SIGNAL_MODE_CONTENT
+
+    def predicate_hash(self) -> str:
+        """Content hash of the predicate identity and parameterisation.
+
+        A verifier recomputes this from the receipt's embedded ``signal``
+        block, so "what *failed* meant" is pinned by hash rather than prose.
+        """
+        payload = _canonical_json({"predicate_id": self.predicate_id, "params": self.params})
+        return "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class DiagnosisResult:
+    """Outcome of :func:`diagnose_run`, mirroring ``DivergenceResult``.
+
+    Attributes:
+        run_id: The diagnosed run.
+        journal_head: Head hash recomputed over every on-disk row's payload
+            (pure function of the file; equals the stored Merkle head for an
+            intact chain).
+        journal_file_sha256: SHA-256 of the raw journal bytes, binding the
+            finding to the exact file it was derived from.
+        event_count: Number of rows walked.
+        located: ``True`` when a culprit step was named.
+        culprit_index: 0-based index of the first faulty step, or ``None``
+            for a clean chain-mode diagnosis.
+        culprit_step_hash: The stored ``event_hash`` at
+            :attr:`culprit_index` (empty when not located).
+        reason_code: Machine-readable attribution from the shared
+            ``REASON_CODE_*`` vocabulary in
+            :mod:`bernstein.core.replay.diff`.
+        reason: Human-readable explanation.
+        predicate_id: The evaluated predicate's identifier.
+        predicate_hash: The evaluated predicate's content hash.
+        signal_params: The predicate's full parameterisation (JSON-safe).
+        lineage_path: Content-addressed evidence chain when the signal
+            carried one.
+    """
+
+    run_id: str
+    journal_head: str
+    journal_file_sha256: str
+    event_count: int
+    located: bool
+    culprit_index: int | None
+    culprit_step_hash: str
+    reason_code: str
+    reason: str
+    predicate_id: str
+    predicate_hash: str
+    signal_params: dict[str, Any] = field(default_factory=dict[str, Any])
+    lineage_path: tuple[str, ...] = ()
+
+
+def _row_payload_text(row: dict[str, Any]) -> str:
+    """Canonical timing-excluded payload text of one journal row.
+
+    Uses the same field projection the journal's payload hash uses
+    (:data:`~bernstein.core.replay.journal._NON_DETERMINISTIC_FIELDS`
+    excluded), so needle matching sees exactly the bytes the chain covers --
+    never the wall-clock envelope or derived chain fields.
+    """
+    projected = {k: v for k, v in row.items() if k not in _NON_DETERMINISTIC_FIELDS}
+    return _canonical_json(projected)
+
+
+def _reason_code_for_row(row: dict[str, Any], default_code: str) -> str:
+    """Attribute a culprit row, naming provider-state mutations explicitly.
+
+    Mirrors the attribution rule of ``diff_event_logs``: a provider-side
+    context mutation entry is classified as
+    :data:`REASON_CODE_PROVIDER_STATE_MUTATION` regardless of the signal's
+    default, so the two surfaces agree on the same step.
+    """
+    if str(row.get("event", "")) == PROVIDER_STATE_MUTATION_EVENT:
+        return REASON_CODE_PROVIDER_STATE_MUTATION
+    return default_code
+
+
+def diagnose_run(journal_path: Path, predicate: SignalPredicate, *, run_id: str) -> DiagnosisResult:
+    """Name the first step of *run_id*'s journal at which *predicate* holds.
+
+    A linear first-index scan over the prefix is used rather than a binary
+    bisection: it is equally deterministic, costs one pass over a file that
+    is already being read in full, and stays correct for any predicate --
+    bisection is only sound for monotone ones.
+
+    Args:
+        journal_path: Path to the run's ``journal.jsonl`` (derive it via
+            :func:`bernstein.core.replay.journal.run_journal_path`).
+        predicate: The resolved failure signal.
+        run_id: Run identifier recorded in the result.
+
+    Returns:
+        A :class:`DiagnosisResult`. ``located`` is ``False`` only for a
+        chain-mode predicate over an intact chain (nothing to report).
+
+    Raises:
+        DiagnoseError: The journal is missing or empty, or a content
+            predicate was requested over a chain that does not recompute.
+        SignalNotLocatedError: The signal's fingerprint appears in no
+            recorded step.
+    """
+    if not journal_path.exists():
+        raise DiagnoseError(f"no signed per-step record for run {run_id}: {journal_path} does not exist")
+    events = load_events(journal_path)
+    if not events:
+        raise DiagnoseError(f"no signed per-step record for run {run_id}: journal at {journal_path} is empty")
+
+    journal_file_sha256 = hashlib.sha256(journal_path.read_bytes()).hexdigest()
+    journal_head = str(rebuild_state(journal_path, from_step=len(events))["head_hash"])
+    chain = verify_journal(journal_path)
+
+    if predicate.mode == SIGNAL_MODE_CHAIN:
+        if chain.ok:
+            return DiagnosisResult(
+                run_id=run_id,
+                journal_head=journal_head,
+                journal_file_sha256=journal_file_sha256,
+                event_count=len(events),
+                located=False,
+                culprit_index=None,
+                culprit_step_hash="",
+                reason_code=REASON_CODE_NONE,
+                reason=f"chain intact: {len(events)} step(s) recompute cleanly",
+                predicate_id=predicate.predicate_id,
+                predicate_hash=predicate.predicate_hash(),
+                signal_params=predicate.params,
+                lineage_path=predicate.lineage_path,
+            )
+        culprit = chain.divergent_index if chain.divergent_index is not None else 0
+        row = events[culprit]
+        detail = chain.errors[0] if chain.errors else "chain verification failed"
+        return DiagnosisResult(
+            run_id=run_id,
+            journal_head=journal_head,
+            journal_file_sha256=journal_file_sha256,
+            event_count=len(events),
+            located=True,
+            culprit_index=culprit,
+            culprit_step_hash=str(row.get("event_hash", "")),
+            reason_code=REASON_CODE_CHAIN_BREAK,
+            reason=f"step {culprit}: {detail}",
+            predicate_id=predicate.predicate_id,
+            predicate_hash=predicate.predicate_hash(),
+            signal_params=predicate.params,
+            lineage_path=predicate.lineage_path,
+        )
+
+    # Content mode: the predicate is only meaningful over a verified chain.
+    if not chain.ok:
+        detail = chain.errors[0] if chain.errors else "chain verification failed"
+        raise DiagnoseError(
+            f"journal for run {run_id} fails chain verification ({detail}); "
+            "refusing to evaluate a content signal over an unverified record -- "
+            "run `bernstein audit diagnose --signal replay` to localise the break"
+        )
+    if not predicate.needles:
+        raise DiagnoseError(f"signal {predicate.predicate_id} resolved to no content fingerprint; nothing to locate")
+
+    for i, row in enumerate(events):
+        text = _row_payload_text(row)
+        if any(needle in text for needle in predicate.needles):
+            event_type = str(row.get("event", ""))
+            return DiagnosisResult(
+                run_id=run_id,
+                journal_head=journal_head,
+                journal_file_sha256=journal_file_sha256,
+                event_count=len(events),
+                located=True,
+                culprit_index=i,
+                culprit_step_hash=str(row.get("event_hash", "")),
+                reason_code=_reason_code_for_row(row, predicate.default_reason_code),
+                reason=(
+                    f"step {i} ({event_type}): first step whose recorded payload "
+                    f"carries the offending content (signal {predicate.predicate_id})"
+                ),
+                predicate_id=predicate.predicate_id,
+                predicate_hash=predicate.predicate_hash(),
+                signal_params=predicate.params,
+                lineage_path=predicate.lineage_path,
+            )
+
+    raise SignalNotLocatedError(
+        f"signal {predicate.predicate_id} does not resolve to any recorded step of "
+        f"run {run_id} (0 of {len(events)} steps carry the fingerprint); "
+        "refusing to guess -- the diagnosis must be a projection of the signed record"
+    )
+
+
+__all__ = [
+    "SIGNAL_MODE_CHAIN",
+    "SIGNAL_MODE_CONTENT",
+    "DiagnoseError",
+    "DiagnosisResult",
+    "SignalNotLocatedError",
+    "SignalPredicate",
+    "diagnose_run",
+]

--- a/src/bernstein/core/replay/diagnose.py
+++ b/src/bernstein/core/replay/diagnose.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from bernstein.core.replay.diff import (
     REASON_CODE_CHAIN_BREAK,
@@ -48,6 +48,8 @@ from bernstein.core.replay.diff import (
 )
 from bernstein.core.replay.journal import (
     _NON_DETERMINISTIC_FIELDS,  # pyright: ignore[reportPrivateUsage] - shared journal projection
+    JournalParseError,
+    load_events,
     rebuild_state,
     verify_journal,
 )
@@ -172,40 +174,26 @@ class DiagnosisResult:
 def _load_events_strict(journal_path: Path, *, run_id: str) -> list[dict[str, Any]]:
     """Parse every non-blank journal line, refusing any that fails to decode.
 
-    ``journal.load_events`` skips undecodable lines so an ordinary reader
-    survives a torn trailing write. A *diagnostic* reader must not: a
-    silently dropped physical line would let the surviving prefix
+    An ordinary reader survives a torn trailing write; a *diagnostic* reader
+    must not: a silently dropped physical line would let the surviving prefix
     chain-verify cleanly and a signed receipt would then cover a filtered
     sequence, and every reported index would count parsed rows rather than
-    physical journal lines. Any non-blank line that fails to decode as a
-    JSON object refuses the whole diagnosis instead
-    (bot-ack: 3705961185).
+    physical journal lines (bot-ack: 3705961185). The scan itself is
+    single-sourced in :func:`journal.load_events` via its ``strict`` policy,
+    so the diagnostic reader can never drift from the rest of replay
+    (bot-ack: 3706042994).
 
     Raises:
         DiagnoseError: A non-blank line is not a JSON object; the message
             names the 0-based physical line index.
     """
-    events: list[dict[str, Any]] = []
-    with journal_path.open(encoding="utf-8") as f:
-        for lineno, raw in enumerate(f):
-            line = raw.strip()
-            if not line:
-                continue
-            try:
-                row = json.loads(line)
-            except json.JSONDecodeError as exc:
-                raise DiagnoseError(
-                    f"journal for run {run_id} has an unparsable line at physical line {lineno} "
-                    f"({exc.msg}); refusing to diagnose a filtered sequence -- capture the "
-                    "corrupted journal forensically before re-running"
-                ) from exc
-            if not isinstance(row, dict):
-                raise DiagnoseError(
-                    f"journal for run {run_id} has a non-object row at physical line {lineno}; "
-                    "refusing to diagnose a filtered sequence"
-                )
-            events.append(cast("dict[str, Any]", row))
-    return events
+    try:
+        return load_events(journal_path, strict=True)
+    except JournalParseError as exc:
+        raise DiagnoseError(
+            f"journal for run {run_id}: {exc}; refusing to diagnose a filtered sequence -- "
+            "capture the corrupted journal forensically before re-running"
+        ) from exc
 
 
 def _row_payload_text(row: dict[str, Any]) -> str:

--- a/src/bernstein/core/replay/diagnose.py
+++ b/src/bernstein/core/replay/diagnose.py
@@ -23,6 +23,10 @@ The diagnosis is a projection of the signed record, never an inference
 beside it:
 
 * a missing or empty journal refuses with :class:`DiagnoseError`;
+* a journal containing any non-blank line that does not parse as a JSON
+  object refuses -- unlike ordinary journal readers, which tolerate a torn
+  trailing write, the diagnostic reader never operates on a filtered
+  sequence, so every reported index counts physical journal lines;
 * a content predicate is only evaluated over a journal whose chain
   recomputes cleanly -- a chain-broken journal refuses and points the
   operator at ``--signal replay``, which reports the break itself;
@@ -35,7 +39,7 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from bernstein.core.replay.diff import (
     REASON_CODE_CHAIN_BREAK,
@@ -44,7 +48,6 @@ from bernstein.core.replay.diff import (
 )
 from bernstein.core.replay.journal import (
     _NON_DETERMINISTIC_FIELDS,  # pyright: ignore[reportPrivateUsage] - shared journal projection
-    load_events,
     rebuild_state,
     verify_journal,
 )
@@ -166,6 +169,45 @@ class DiagnosisResult:
     lineage_path: tuple[str, ...] = ()
 
 
+def _load_events_strict(journal_path: Path, *, run_id: str) -> list[dict[str, Any]]:
+    """Parse every non-blank journal line, refusing any that fails to decode.
+
+    ``journal.load_events`` skips undecodable lines so an ordinary reader
+    survives a torn trailing write. A *diagnostic* reader must not: a
+    silently dropped physical line would let the surviving prefix
+    chain-verify cleanly and a signed receipt would then cover a filtered
+    sequence, and every reported index would count parsed rows rather than
+    physical journal lines. Any non-blank line that fails to decode as a
+    JSON object refuses the whole diagnosis instead
+    (bot-ack: 3705961185).
+
+    Raises:
+        DiagnoseError: A non-blank line is not a JSON object; the message
+            names the 0-based physical line index.
+    """
+    events: list[dict[str, Any]] = []
+    with journal_path.open(encoding="utf-8") as f:
+        for lineno, raw in enumerate(f):
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise DiagnoseError(
+                    f"journal for run {run_id} has an unparsable line at physical line {lineno} "
+                    f"({exc.msg}); refusing to diagnose a filtered sequence -- capture the "
+                    "corrupted journal forensically before re-running"
+                ) from exc
+            if not isinstance(row, dict):
+                raise DiagnoseError(
+                    f"journal for run {run_id} has a non-object row at physical line {lineno}; "
+                    "refusing to diagnose a filtered sequence"
+                )
+            events.append(cast("dict[str, Any]", row))
+    return events
+
+
 def _row_payload_text(row: dict[str, Any]) -> str:
     """Canonical timing-excluded payload text of one journal row.
 
@@ -217,7 +259,9 @@ def diagnose_run(journal_path: Path, predicate: SignalPredicate, *, run_id: str)
     """
     if not journal_path.exists():
         raise DiagnoseError(f"no signed per-step record for run {run_id}: {journal_path} does not exist")
-    events = load_events(journal_path)
+    # Strict load first: an unparsable line refuses the diagnosis before any
+    # head, count, chain, or culprit computation can observe a filtered view.
+    events = _load_events_strict(journal_path, run_id=run_id)
     if not events:
         raise DiagnoseError(f"no signed per-step record for run {run_id}: journal at {journal_path} is empty")
 

--- a/src/bernstein/core/replay/diagnose_signals.py
+++ b/src/bernstein/core/replay/diagnose_signals.py
@@ -1,0 +1,434 @@
+"""Failure-signal adapters for ``bernstein audit diagnose`` (#2928).
+
+Each adapter turns one operator-facing failure signal into a
+:class:`~bernstein.core.replay.diagnose.SignalPredicate` -- a pure function
+of on-disk records with no network and no live process:
+
+* ``gate[:RECEIPT_HASH]`` -- the rejecting statistical verdict receipt
+  (:mod:`bernstein.eval.gate_receipt`); the fingerprint is the receipt's
+  suite / candidate result-set content hashes.
+* ``artefact:PATH`` -- the lineage taint projection
+  (:mod:`bernstein.core.lineage.provenance`) walked back from the artefact
+  tip; the fingerprint is the content hash of every untrusted provenance
+  record in the closure, and the content-addressed parent chain from the
+  offending record to the tip is attached as evidence.
+* ``incident:CASE_ID`` -- a synthesised incident eval case
+  (:mod:`bernstein.eval.incident_synthesizer`); the fingerprint is the exact
+  recorded failure text carried by the case. When the journal never recorded
+  those bytes the diagnosis refuses rather than guessing.
+* ``replay`` -- chain-integrity mode: the finding is the first step at which
+  ``verify_journal`` reports a break.
+
+The resolved predicate's ``params`` block is embedded verbatim in the
+diagnosis receipt, so :func:`predicate_from_params` reconstructs the
+identical predicate offline without re-reading the gate / lineage / incident
+stores -- re-verification depends only on the receipt and the journal.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import TYPE_CHECKING, Any, cast
+
+from bernstein.core.replay.diagnose import (
+    SIGNAL_MODE_CHAIN,
+    SIGNAL_MODE_CONTENT,
+    DiagnoseError,
+    SignalPredicate,
+)
+from bernstein.core.replay.diff import (
+    REASON_CODE_BAD_INPUT_CONTENT_HASH,
+    REASON_CODE_CHAIN_BREAK,
+    REASON_CODE_FIRST_FAILING_TOOL_RESULT,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from pathlib import Path
+
+    from bernstein.core.lineage.entry import LineageEntry
+
+#: Signal kinds accepted by :func:`resolve_signal`.
+SIGNAL_KIND_GATE = "gate"
+SIGNAL_KIND_ARTEFACT = "artefact"
+SIGNAL_KIND_INCIDENT = "incident"
+SIGNAL_KIND_REPLAY = "replay"
+
+_PREDICATE_IDS: dict[str, str] = {
+    SIGNAL_KIND_GATE: "gate/v1",
+    SIGNAL_KIND_ARTEFACT: "artefact/v1",
+    SIGNAL_KIND_INCIDENT: "incident/v1",
+    SIGNAL_KIND_REPLAY: "replay/v1",
+}
+
+_DEFAULT_REASON_CODES: dict[str, str] = {
+    SIGNAL_KIND_GATE: REASON_CODE_BAD_INPUT_CONTENT_HASH,
+    SIGNAL_KIND_ARTEFACT: REASON_CODE_BAD_INPUT_CONTENT_HASH,
+    SIGNAL_KIND_INCIDENT: REASON_CODE_FIRST_FAILING_TOOL_RESULT,
+    SIGNAL_KIND_REPLAY: REASON_CODE_CHAIN_BREAK,
+}
+
+_RECEIPT_HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_CASE_ID_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
+
+#: Minimum length of an incident fingerprint line. Shorter fragments (a bare
+#: word, a truncation residue) would match almost any payload and turn the
+#: lookup into noise, so they are dropped deterministically.
+_MIN_INCIDENT_NEEDLE_LEN = 12
+
+#: Markers that introduce the recorded failure text inside a synthesised
+#: incident case prompt (see ``incident_synthesizer._build_prompt_from_dlq``
+#: and ``_build_prompt_from_postmortem``).
+_INCIDENT_ERROR_MARKERS = frozenset({"Last error (trimmed):", "Representative error snippets:"})
+
+
+def _bare_digest(content_hash: str) -> str:
+    """Return the hex digest without a ``sha256:`` prefix.
+
+    Journal payloads record content hashes both prefixed and bare; matching
+    on the bare digest covers both spellings deterministically.
+    """
+    return content_hash.split(":", 1)[-1]
+
+
+def _predicate(kind: str, params: dict[str, Any]) -> SignalPredicate:
+    """Assemble a :class:`SignalPredicate` for *kind* from its params block."""
+    needles = tuple(str(n) for n in params.get("needles", []))
+    lineage_path = tuple(str(h) for h in params.get("lineage_path", []))
+    return SignalPredicate(
+        predicate_id=_PREDICATE_IDS[kind],
+        params=params,
+        default_reason_code=_DEFAULT_REASON_CODES[kind],
+        needles=needles,
+        lineage_path=lineage_path,
+        mode=SIGNAL_MODE_CHAIN if kind == SIGNAL_KIND_REPLAY else SIGNAL_MODE_CONTENT,
+    )
+
+
+def predicate_from_params(params: Mapping[str, Any]) -> SignalPredicate:
+    """Reconstruct the predicate a receipt embeds, without any store reads.
+
+    The params block is self-contained (kind, needles, anchors), so offline
+    re-verification reproduces exactly the predicate that was evaluated --
+    including its ``predicate_hash`` -- from the receipt alone.
+
+    Raises:
+        DiagnoseError: The params block names an unknown signal kind.
+    """
+    kind = str(params.get("kind", ""))
+    if kind not in _PREDICATE_IDS:
+        raise DiagnoseError(f"diagnosis receipt names an unknown signal kind: {kind!r}")
+    return _predicate(kind, dict(params))
+
+
+# ---------------------------------------------------------------------------
+# gate
+# ---------------------------------------------------------------------------
+
+
+def _load_gate_receipts(gate_dir: Path) -> list[Any]:
+    """Load every parseable verdict receipt under *gate_dir*."""
+    from bernstein.eval.gate_receipt import VerdictReceipt
+
+    receipts: list[Any] = []
+    if not gate_dir.is_dir():
+        return receipts
+    for path in sorted(gate_dir.glob("*.json")):
+        try:
+            receipts.append(VerdictReceipt.from_dict(json.loads(path.read_text(encoding="utf-8"))))
+        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+            continue
+    return receipts
+
+
+def gate_signal(receipt_hash: str | None, *, gate_dir: Path) -> SignalPredicate:
+    """Resolve the ``gate`` signal from a sealed verdict receipt.
+
+    Args:
+        receipt_hash: Explicit ``sha256:...`` receipt hash, or ``None`` to
+            resolve the most recent rejecting receipt deterministically
+            (highest ``(timestamp, receipt_hash)`` among
+            ``significant_regression`` verdicts).
+        gate_dir: The ``.sdd/eval/gate`` receipt store.
+
+    Raises:
+        DiagnoseError: No matching receipt exists, or the named receipt hash
+            is not canonical.
+    """
+    from bernstein.eval.significance import Verdict
+
+    receipts = _load_gate_receipts(gate_dir)
+    if receipt_hash is not None:
+        if not _RECEIPT_HASH_RE.match(receipt_hash):
+            raise DiagnoseError(f"gate receipt hash is not a canonical sha256 digest: {receipt_hash!r}")
+        matched = [r for r in receipts if r.receipt_hash == receipt_hash]
+        if not matched:
+            raise DiagnoseError(f"no verdict receipt {receipt_hash} under {gate_dir}")
+        receipt = matched[0]
+    else:
+        rejecting = [r for r in receipts if r.verdict is Verdict.SIGNIFICANT_REGRESSION]
+        if not rejecting:
+            raise DiagnoseError(
+                f"no rejecting verdict receipt under {gate_dir}; name one explicitly with --signal gate:<receipt-hash>"
+            )
+        receipt = max(rejecting, key=lambda r: (r.timestamp, r.receipt_hash))
+
+    needles = sorted({_bare_digest(receipt.suite_content_hash), _bare_digest(receipt.candidate_result_set_hash)})
+    params: dict[str, Any] = {
+        "kind": SIGNAL_KIND_GATE,
+        "receipt_hash": receipt.receipt_hash,
+        "verdict": str(receipt.verdict),
+        "needles": needles,
+    }
+    return _predicate(SIGNAL_KIND_GATE, params)
+
+
+# ---------------------------------------------------------------------------
+# artefact
+# ---------------------------------------------------------------------------
+
+
+def _path_tip_to_offender(
+    tip: str,
+    offenders: frozenset[str],
+    index: Mapping[str, LineageEntry],
+) -> tuple[str, ...]:
+    """Deterministic parent-edge path from *tip* down to the first offender.
+
+    Depth-first over ``parent_hashes`` in recorded order, so two verifiers
+    holding the same log derive the identical path. Returned in
+    culprit-to-tip order (the receipt's ``lineage_path`` contract).
+    """
+    stack: list[tuple[str, tuple[str, ...]]] = [(tip, (tip,))]
+    visited: set[str] = set()
+    while stack:
+        current, path = stack.pop()
+        if current in visited:
+            continue
+        visited.add(current)
+        if current in offenders:
+            return tuple(reversed(path))
+        entry = index.get(current)
+        if entry is None:
+            continue
+        # Reversed push keeps pop() order equal to recorded parent order.
+        for parent in reversed(entry.parent_hashes):
+            stack.append((parent, (*path, parent)))
+    return ()
+
+
+def artefact_signal(artefact_path: str, *, lineage_log: Path) -> SignalPredicate:
+    """Resolve the ``artefact:PATH`` signal from the signed lineage log.
+
+    Walks the taint projection back from the artefact tip; the offending
+    fingerprint is the content hash of every untrusted provenance record in
+    the closure.
+
+    Raises:
+        DiagnoseError: The log is missing/empty, the artefact has no lineage
+            tip, the artefact is not tainted, or the closure carries no
+            provenance record to name.
+    """
+    from bernstein.core.lineage.entry import entry_hash
+    from bernstein.core.lineage.provenance import (
+        TrustClass,
+        is_untrusted,
+        load_entries_from_log,
+        resolve_artefact_tip,
+        taint_for_artefact,
+    )
+
+    entries = load_entries_from_log(lineage_log)
+    if not entries:
+        raise DiagnoseError(f"no lineage entries at {lineage_log}; cannot resolve artefact signal")
+    verdict = taint_for_artefact(artefact_path, entries)
+    if not verdict.resolved:
+        raise DiagnoseError(f"artefact {artefact_path!r} has no lineage tip in {lineage_log}")
+    if not verdict.tainted:
+        raise DiagnoseError(
+            f"artefact {artefact_path!r} is not tainted per its lineage closure "
+            f"(effective trust: {verdict.trust.value}); no offending content hash to locate"
+        )
+
+    index = {entry_hash(e): e for e in entries}
+    offenders = frozenset(h for h, tc in verdict.trust_records if h in index and is_untrusted(TrustClass(tc)))
+    if not offenders:
+        raise DiagnoseError(
+            f"artefact {artefact_path!r} is tainted only because its closure carries no "
+            "provenance record (fail-closed default); there is no recorded offending "
+            "content hash to locate"
+        )
+
+    tip = resolve_artefact_tip(artefact_path, entries)
+    lineage_path: tuple[str, ...] = ()
+    if tip is not None:
+        lineage_path = _path_tip_to_offender(tip, offenders, index)
+
+    needles = sorted({_bare_digest(index[h].content_hash) for h in offenders})
+    params: dict[str, Any] = {
+        "kind": SIGNAL_KIND_ARTEFACT,
+        "artefact_path": artefact_path,
+        "tip": tip or "",
+        "needles": needles,
+        "lineage_path": list(lineage_path),
+    }
+    return _predicate(SIGNAL_KIND_ARTEFACT, params)
+
+
+# ---------------------------------------------------------------------------
+# incident
+# ---------------------------------------------------------------------------
+
+
+def _fingerprint_lines(prompt: str) -> tuple[str, ...]:
+    """Extract the recorded failure text from a synthesised case prompt.
+
+    Only the lines following an error marker count as fingerprint; leading
+    ``- `` bullets and trailing truncation ellipses are stripped, and lines
+    shorter than :data:`_MIN_INCIDENT_NEEDLE_LEN` are dropped. Sorted and
+    de-duplicated for determinism.
+    """
+    needles: set[str] = set()
+    in_error = False
+    for raw_line in prompt.splitlines():
+        line = raw_line.strip()
+        if line in _INCIDENT_ERROR_MARKERS:
+            in_error = True
+            continue
+        if not in_error:
+            continue
+        line = line.removeprefix("- ").removesuffix("...").strip()
+        if len(line) >= _MIN_INCIDENT_NEEDLE_LEN:
+            needles.add(line)
+    return tuple(sorted(needles))
+
+
+def incident_signal(case_id: str, *, cases_dir: Path) -> SignalPredicate:
+    """Resolve the ``incident:CASE_ID`` signal from a synthesised eval case.
+
+    The fingerprint is the exact failure text the case recorded. When the
+    case is absent or carries no matchable failure text, the resolution
+    fails closed -- the adapter never widens the match to prose similarity.
+
+    Raises:
+        DiagnoseError: The case id is unsafe, the case file is missing or
+            unparseable, or the case carries no matchable fingerprint.
+    """
+    import yaml
+
+    if not _CASE_ID_RE.match(case_id):
+        raise DiagnoseError(f"unsafe incident case id: {case_id!r}")
+    case_path = cases_dir / f"{case_id}.yaml"
+    if not case_path.is_file():
+        raise DiagnoseError(f"no incident eval case {case_id!r} under {cases_dir}")
+    try:
+        raw = yaml.safe_load(case_path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        raise DiagnoseError(f"cannot read incident case {case_id!r}: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise DiagnoseError(f"incident case {case_id!r} is not a mapping")
+    case = cast("dict[str, Any]", raw)
+
+    needles = _fingerprint_lines(str(case.get("prompt", "")))
+    if not needles:
+        raise DiagnoseError(
+            f"incident case {case_id!r} carries no matchable failure fingerprint "
+            f"(no error line of >= {_MIN_INCIDENT_NEEDLE_LEN} characters); refusing to guess"
+        )
+    params: dict[str, Any] = {
+        "kind": SIGNAL_KIND_INCIDENT,
+        "case_id": case_id,
+        "needles": list(needles),
+    }
+    return _predicate(SIGNAL_KIND_INCIDENT, params)
+
+
+# ---------------------------------------------------------------------------
+# replay
+# ---------------------------------------------------------------------------
+
+
+def replay_signal() -> SignalPredicate:
+    """Resolve the ``replay`` signal: chain-integrity localisation."""
+    return _predicate(SIGNAL_KIND_REPLAY, {"kind": SIGNAL_KIND_REPLAY})
+
+
+# ---------------------------------------------------------------------------
+# spec parsing
+# ---------------------------------------------------------------------------
+
+
+def resolve_signal(
+    spec: str,
+    *,
+    sdd_dir: Path,
+    workdir: Path | None = None,
+    cases_dir: Path | None = None,
+) -> SignalPredicate:
+    """Resolve a ``--signal`` spec string into a :class:`SignalPredicate`.
+
+    Grammar::
+
+        gate                    latest rejecting verdict receipt
+        gate:sha256:<hex>       explicit verdict receipt
+        artefact:<path>         tainted artefact (``artifact:`` accepted)
+        incident:<case-id>      synthesised incident eval case
+        replay                  chain-integrity localisation
+
+    Args:
+        spec: The raw ``--signal`` value.
+        sdd_dir: The project ``.sdd`` directory (gate receipts under
+            ``<sdd>/eval/gate``, lineage log under ``<sdd>/lineage``).
+        workdir: Project root; defaults to ``sdd_dir.parent``. Used for the
+            incident case corpus default location.
+        cases_dir: Override for the incident case corpus (defaults to
+            ``<workdir>/src/bernstein/eval/cases/incidents``).
+
+    Raises:
+        DiagnoseError: The spec is malformed or its backing record is
+            missing (fail closed; never a heuristic fallback).
+    """
+    resolved_workdir = workdir if workdir is not None else sdd_dir.parent
+    kind, _, argument = spec.partition(":")
+    kind = kind.strip().lower()
+    if kind == "artifact":  # common alternate spelling
+        kind = SIGNAL_KIND_ARTEFACT
+
+    if kind == SIGNAL_KIND_REPLAY:
+        if argument:
+            raise DiagnoseError(f"--signal replay takes no argument (got {spec!r})")
+        return replay_signal()
+    if kind == SIGNAL_KIND_GATE:
+        return gate_signal(argument or None, gate_dir=sdd_dir / "eval" / "gate")
+    if kind == SIGNAL_KIND_ARTEFACT:
+        if not argument:
+            raise DiagnoseError("--signal artefact requires a path: artefact:<path>")
+        return artefact_signal(argument, lineage_log=sdd_dir / "lineage" / "log.jsonl")
+    if kind == SIGNAL_KIND_INCIDENT:
+        if not argument:
+            raise DiagnoseError("--signal incident requires a case id: incident:<case-id>")
+        resolved_cases = (
+            cases_dir
+            if cases_dir is not None
+            else resolved_workdir / "src" / "bernstein" / "eval" / "cases" / "incidents"
+        )
+        return incident_signal(argument, cases_dir=resolved_cases)
+
+    raise DiagnoseError(
+        f"unknown --signal {spec!r}; expected gate[:RECEIPT_HASH], artefact:<path>, incident:<case-id>, or replay"
+    )
+
+
+__all__ = [
+    "SIGNAL_KIND_ARTEFACT",
+    "SIGNAL_KIND_GATE",
+    "SIGNAL_KIND_INCIDENT",
+    "SIGNAL_KIND_REPLAY",
+    "artefact_signal",
+    "gate_signal",
+    "incident_signal",
+    "predicate_from_params",
+    "replay_signal",
+    "resolve_signal",
+]

--- a/src/bernstein/core/replay/diagnose_signals.py
+++ b/src/bernstein/core/replay/diagnose_signals.py
@@ -218,19 +218,38 @@ def _path_tip_to_offender(
     return ()
 
 
-def artefact_signal(artefact_path: str, *, lineage_log: Path) -> SignalPredicate:
-    """Resolve the ``artefact:PATH`` signal from the signed lineage log.
+def artefact_signal(
+    artefact_path: str,
+    *,
+    lineage_log: Path,
+    cards_dir: Path,
+    operator_secret: bytes | None = None,
+) -> SignalPredicate:
+    """Resolve the ``artefact:PATH`` signal from the *gated* lineage log.
+
+    The lineage gate runs first -- strict byte-canonical entry parsing,
+    detached-signature verification against the agent cards, parent
+    anchoring, and (when *operator_secret* is supplied) the per-entry
+    operator HMAC -- exactly the checks ``bernstein audit taint`` requires
+    before trusting the log. Only a log that passes shapes the predicate:
+    an unsigned, malformed, or reparented entry refuses the diagnosis
+    instead of being sealed into a signed receipt (bot-ack: 3706042986).
+    Whether the HMAC layer was checked is disclosed in the predicate params
+    (and therefore in the receipt) as ``lineage_gate.operator_hmac_checked``,
+    mirroring how the taint CLI degrades when no operator secret is
+    configured.
 
     Walks the taint projection back from the artefact tip; the offending
     fingerprint is the content hash of every untrusted provenance record in
     the closure.
 
     Raises:
-        DiagnoseError: The log is missing/empty, the artefact has no lineage
-            tip, the artefact is not tainted, or the closure carries no
-            provenance record to name.
+        DiagnoseError: The lineage gate fails, the log is missing/empty, the
+            artefact has no lineage tip, the artefact is not tainted, or the
+            closure carries no provenance record to name.
     """
     from bernstein.core.lineage.entry import entry_hash
+    from bernstein.core.lineage.gate import check
     from bernstein.core.lineage.provenance import (
         TrustClass,
         is_untrusted,
@@ -238,6 +257,14 @@ def artefact_signal(artefact_path: str, *, lineage_log: Path) -> SignalPredicate
         resolve_artefact_tip,
         taint_for_artefact,
     )
+
+    gate_result = check(lineage_log, cards_dir, operator_secret=operator_secret)
+    if not gate_result.ok:
+        shown = "; ".join(gate_result.failures[:5])
+        raise DiagnoseError(
+            f"lineage gate failed for {lineage_log} ({len(gate_result.failures)} failure(s): {shown}); "
+            "refusing to shape a diagnosis from an unverified lineage log"
+        )
 
     entries = load_entries_from_log(lineage_log)
     if not entries:
@@ -272,6 +299,10 @@ def artefact_signal(artefact_path: str, *, lineage_log: Path) -> SignalPredicate
         "tip": tip or "",
         "needles": needles,
         "lineage_path": list(lineage_path),
+        # Honest disclosure of the gate mode the predicate was shaped under:
+        # signatures/anchoring always verified, operator HMAC only when the
+        # secret was configured. Sealed into the receipt via these params.
+        "lineage_gate": {"checked": True, "operator_hmac_checked": operator_secret is not None},
     }
     return _predicate(SIGNAL_KIND_ARTEFACT, params)
 
@@ -365,6 +396,8 @@ def resolve_signal(
     sdd_dir: Path,
     workdir: Path | None = None,
     cases_dir: Path | None = None,
+    lineage_cards_dir: Path | None = None,
+    lineage_operator_secret: bytes | None = None,
 ) -> SignalPredicate:
     """Resolve a ``--signal`` spec string into a :class:`SignalPredicate`.
 
@@ -384,6 +417,11 @@ def resolve_signal(
             incident case corpus default location.
         cases_dir: Override for the incident case corpus (defaults to
             ``<workdir>/src/bernstein/eval/cases/incidents``).
+        lineage_cards_dir: Agent-card directory for the lineage gate the
+            artefact signal runs (defaults to ``<sdd>/agents``, matching
+            ``bernstein audit taint``).
+        lineage_operator_secret: Optional operator HMAC secret; when given
+            the lineage gate also verifies each entry's ``operator_hmac``.
 
     Raises:
         DiagnoseError: The spec is malformed or its backing record is
@@ -404,7 +442,12 @@ def resolve_signal(
     if kind == SIGNAL_KIND_ARTEFACT:
         if not argument:
             raise DiagnoseError("--signal artefact requires a path: artefact:<path>")
-        return artefact_signal(argument, lineage_log=sdd_dir / "lineage" / "log.jsonl")
+        return artefact_signal(
+            argument,
+            lineage_log=sdd_dir / "lineage" / "log.jsonl",
+            cards_dir=lineage_cards_dir if lineage_cards_dir is not None else sdd_dir / "agents",
+            operator_secret=lineage_operator_secret,
+        )
     if kind == SIGNAL_KIND_INCIDENT:
         if not argument:
             raise DiagnoseError("--signal incident requires a case id: incident:<case-id>")

--- a/src/bernstein/core/replay/diagnose_signals.py
+++ b/src/bernstein/core/replay/diagnose_signals.py
@@ -116,9 +116,29 @@ def predicate_from_params(params: Mapping[str, Any]) -> SignalPredicate:
     Raises:
         DiagnoseError: The params block names an unknown signal kind.
     """
-    kind = str(params.get("kind", ""))
-    if kind not in _PREDICATE_IDS:
+    kind = params.get("kind")
+    if not isinstance(kind, str) or kind not in _PREDICATE_IDS:
         raise DiagnoseError(f"diagnosis receipt names an unknown signal kind: {kind!r}")
+    # Receipt params are external input at verify time: reject malformed
+    # shapes instead of coercing them. A plain string here would otherwise
+    # iterate per-character through tuple(str(...) for ...) and silently
+    # rewrite the predicate (and therefore its predicate_hash) into
+    # something that was never evaluated.
+    for list_field in ("needles", "lineage_path"):
+        value = params.get(list_field, [])
+        if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+            raise DiagnoseError(
+                f"diagnosis receipt params field {list_field!r} must be a list of strings; refusing to rebuild "
+                "a predicate from a malformed receipt"
+            )
+    gate_block = params.get("lineage_gate")
+    if gate_block is not None and (
+        not isinstance(gate_block, dict) or any(not isinstance(v, bool) for v in gate_block.values())
+    ):
+        raise DiagnoseError(
+            "diagnosis receipt params field 'lineage_gate' must be a mapping of booleans; refusing to rebuild "
+            "a predicate from a malformed receipt"
+        )
     return _predicate(kind, dict(params))
 
 

--- a/src/bernstein/core/replay/diagnosis_receipt.py
+++ b/src/bernstein/core/replay/diagnosis_receipt.py
@@ -1,0 +1,381 @@
+"""Signed, content-addressed diagnosis receipts for ``audit diagnose`` (#2928).
+
+The primary artefact of a diagnosis is not terminal output; it is a receipt
+that names the culprit step and can be re-checked offline. The receipt reuses
+the machinery the repo's other receipts already trust:
+
+* canonical bytes via the audit-receipt JSON canonicalisation
+  (:func:`bernstein.core.security.audit_receipt._canonical_json_bytes`);
+* a detached Ed25519 signature over those bytes
+  (:mod:`bernstein.core.persistence.lineage_signer`), RFC 8032 deterministic,
+  so identical inputs sign to identical bytes;
+* an operator HMAC-SHA256 under the audit-chain key, plus the current audit
+  chain head embedded as ``chain_head_hmac``, anchoring the finding beside
+  the HMAC audit chain.
+
+Verification contract (:func:`verify_diagnosis_receipt`): the verdict is
+*re-derived, not trusted*. Beyond checking the receipt hash, the Ed25519
+signature, and (when the key is available) the operator HMAC, the verifier
+reconstructs the predicate from the receipt's embedded ``signal`` block,
+re-runs :func:`~bernstein.core.replay.diagnose.diagnose_run` over the
+journal, and asserts the culprit index, step hash, journal head, and reason
+code match byte-for-byte. The receipt also pins the exact journal bytes
+(``journal_file_sha256``), so a journal mutated anywhere -- at or after the
+culprit step included -- fails verification.
+
+Determinism: no wall-clock value enters the receipt, so two independent
+invocations over the same journal and key produce byte-identical receipts.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac as _hmac
+import json
+import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, cast
+
+from bernstein.core.persistence.lineage_signer import (
+    Ed25519FileKeySigner,
+    Ed25519PublicKeyVerifier,
+    LineageSignerError,
+)
+from bernstein.core.replay.diagnose import DiagnoseError, diagnose_run
+from bernstein.core.replay.diagnose_signals import predicate_from_params
+from bernstein.core.security.audit_receipt import (
+    _canonical_json_bytes,  # pyright: ignore[reportPrivateUsage] - shared receipt canonicalisation
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.persistence.lineage_signer import LineageSigner
+    from bernstein.core.replay.diagnose import DiagnosisResult
+
+#: Receipt schema version. Bump only on a wire-format change.
+DIAGNOSIS_RECEIPT_SCHEMA_VERSION: str = "1.0.0"
+
+#: Receipt type URL, versioned so a future v2 can co-exist.
+DIAGNOSIS_RECEIPT_TYPE: str = "https://bernstein.run/attestations/diagnosis-receipt/v1"
+
+#: Ordered body fields covered by ``receipt_hash`` (everything except the
+#: hash itself and the signature envelope).
+_BODY_FIELDS: tuple[str, ...] = (
+    "schema_version",
+    "receipt_type",
+    "run_id",
+    "journal_head",
+    "journal_file_sha256",
+    "event_count",
+    "chain_head_hmac",
+    "culprit_index",
+    "culprit_step_hash",
+    "reason_code",
+    "reason",
+    "predicate_id",
+    "predicate_hash",
+    "signal",
+    "lineage_path",
+)
+
+_RUN_ID_RE = re.compile(r"^[A-Za-z0-9_.-]{1,64}$")
+
+
+class DiagnosisReceiptError(RuntimeError):
+    """Raised for receipt build failures (fail closed: no partial writes)."""
+
+
+@dataclass(frozen=True, slots=True)
+class DiagnosisReceipt:
+    """A built diagnosis receipt.
+
+    Attributes:
+        receipt: The serialisable receipt dict (body + hash + signature).
+        receipt_bytes: Canonical JSON bytes (byte-deterministic).
+        receipt_path: On-disk path when written, else ``None``.
+    """
+
+    receipt: dict[str, Any]
+    receipt_bytes: bytes
+    receipt_path: Path | None = field(default=None)
+
+    @property
+    def sha256(self) -> str:
+        """SHA-256 of the canonical receipt bytes."""
+        return hashlib.sha256(self.receipt_bytes).hexdigest()
+
+    @property
+    def receipt_hash(self) -> str:
+        """The content address of the receipt body."""
+        return str(self.receipt.get("receipt_hash", ""))
+
+    @property
+    def culprit_index(self) -> int:
+        """The named culprit step index."""
+        return int(self.receipt["culprit_index"])
+
+
+@dataclass(frozen=True, slots=True)
+class DiagnosisVerifyResult:
+    """Outcome of an offline diagnosis-receipt verification."""
+
+    ok: bool
+    reason: str
+    hmac_checked: bool = False
+    receipt: dict[str, Any] | None = None
+
+
+def _body_of(result: DiagnosisResult, *, chain_head_hmac: str) -> dict[str, Any]:
+    return {
+        "schema_version": DIAGNOSIS_RECEIPT_SCHEMA_VERSION,
+        "receipt_type": DIAGNOSIS_RECEIPT_TYPE,
+        "run_id": result.run_id,
+        "journal_head": result.journal_head,
+        "journal_file_sha256": result.journal_file_sha256,
+        "event_count": result.event_count,
+        "chain_head_hmac": chain_head_hmac,
+        "culprit_index": result.culprit_index,
+        "culprit_step_hash": result.culprit_step_hash,
+        "reason_code": result.reason_code,
+        "reason": result.reason,
+        "predicate_id": result.predicate_id,
+        "predicate_hash": result.predicate_hash,
+        "signal": dict(result.signal_params),
+        "lineage_path": list(result.lineage_path),
+    }
+
+
+def _receipt_hash_of(body: dict[str, Any]) -> str:
+    return "sha256:" + hashlib.sha256(_canonical_json_bytes(body)).hexdigest()
+
+
+def _signed_payload(body: dict[str, Any], receipt_hash: str) -> bytes:
+    payload = dict(body)
+    payload["receipt_hash"] = receipt_hash
+    return _canonical_json_bytes(payload)
+
+
+def build_diagnosis_receipt(
+    result: DiagnosisResult,
+    *,
+    chain_head_hmac: str,
+    signer: LineageSigner,
+    audit_key: bytes,
+    output_dir: Path | None = None,
+    write: bool = True,
+) -> DiagnosisReceipt:
+    """Seal a located diagnosis into a signed, content-addressed receipt.
+
+    Args:
+        result: A located :class:`DiagnosisResult` (``located`` must be
+            ``True`` -- a clean diagnosis carries no culprit and no receipt
+            is emitted for it).
+        chain_head_hmac: The current HMAC audit-chain head, read (never
+            appended) at build time, anchoring the receipt beside the chain.
+        signer: Ed25519 signer (the lineage customer-signing machinery).
+        audit_key: Operator audit HMAC key; the receipt carries an
+            HMAC-SHA256 over the same canonical bytes the signature covers.
+        output_dir: Where to write the receipt JSON (required when *write*).
+        write: When ``False`` build in-memory only (tests / dry-run).
+
+    Returns:
+        The built :class:`DiagnosisReceipt`.
+
+    Raises:
+        DiagnosisReceiptError: The result carries no culprit, the run id is
+            not a safe path segment, or no output directory was supplied for
+            a write.
+    """
+    if not result.located or result.culprit_index is None:
+        raise DiagnosisReceiptError("a clean diagnosis carries no culprit; no receipt is emitted for it")
+    if not _RUN_ID_RE.match(result.run_id):
+        raise DiagnosisReceiptError(f"unsafe run id for receipt filename: {result.run_id!r}")
+
+    body = _body_of(result, chain_head_hmac=chain_head_hmac)
+    receipt_hash = _receipt_hash_of(body)
+    payload = _signed_payload(body, receipt_hash)
+    signature = signer.sign(payload)
+    operator_hmac = _hmac.new(audit_key, payload, hashlib.sha256).hexdigest()
+
+    signature_block: dict[str, Any] = {
+        "alg": "Ed25519",
+        "signature_b64": base64.b64encode(signature).decode("ascii"),
+    }
+    if isinstance(signer, Ed25519FileKeySigner):
+        signature_block["public_key_b64"] = base64.b64encode(signer.public_key_bytes()).decode("ascii")
+
+    receipt: dict[str, Any] = dict(body)
+    receipt["receipt_hash"] = receipt_hash
+    receipt["signature"] = signature_block
+    receipt["operator_hmac"] = operator_hmac
+    receipt_bytes = _canonical_json_bytes(receipt) + b"\n"
+
+    receipt_path: Path | None = None
+    if write:
+        if output_dir is None:
+            raise DiagnosisReceiptError("output_dir is required to write a diagnosis receipt")
+        output_dir.mkdir(parents=True, exist_ok=True)
+        digest = receipt_hash.split(":", 1)[-1]
+        receipt_path = output_dir / f"diagnosis-{result.run_id}-{digest[:16]}.json"
+        receipt_path.write_bytes(receipt_bytes)
+
+    return DiagnosisReceipt(receipt=receipt, receipt_bytes=receipt_bytes, receipt_path=receipt_path)
+
+
+def _load_verifier(
+    receipt: dict[str, Any],
+    pinned: Ed25519PublicKeyVerifier | None,
+) -> tuple[Ed25519PublicKeyVerifier | None, str]:
+    """Return the verifier to use (pinned wins) or an error reason."""
+    if pinned is not None:
+        return pinned, ""
+    raw_block = receipt.get("signature")
+    if not isinstance(raw_block, dict):
+        return None, "receipt carries no signature block"
+    signature_block = cast("dict[str, Any]", raw_block)
+    embedded = signature_block.get("public_key_b64")
+    if not embedded:
+        return None, "receipt embeds no public key and none was pinned; pass --public-key"
+    try:
+        return Ed25519PublicKeyVerifier.from_raw(base64.b64decode(str(embedded))), ""
+    except (LineageSignerError, ValueError) as exc:
+        return None, f"embedded public key is invalid: {exc}"
+
+
+def verify_diagnosis_receipt(
+    receipt_path: Path,
+    *,
+    journal_path: Path,
+    verifier: Ed25519PublicKeyVerifier | None = None,
+    audit_key: bytes | None = None,
+) -> DiagnosisVerifyResult:
+    """Re-derive a diagnosis receipt offline and assert byte-identity.
+
+    Checks, in order: the receipt hash recomputes from the body; the Ed25519
+    signature verifies (against the pinned key when given, else the embedded
+    one); the operator HMAC verifies when *audit_key* is supplied; the
+    journal bytes match ``journal_file_sha256`` exactly; and the diagnosis
+    re-derived from the embedded ``signal`` block matches the receipt's
+    culprit index, step hash, journal head, event count, reason code, and
+    predicate hash byte-for-byte.
+
+    Args:
+        receipt_path: Path to the receipt JSON.
+        journal_path: Path to the diagnosed run's ``journal.jsonl``.
+        verifier: Optional pinned Ed25519 public key.
+        audit_key: Optional operator audit HMAC key; when omitted the HMAC
+            check is skipped and reported via ``hmac_checked=False``.
+
+    Returns:
+        A :class:`DiagnosisVerifyResult` with the first failing reason.
+    """
+    try:
+        receipt_raw = json.loads(receipt_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return DiagnosisVerifyResult(ok=False, reason=f"malformed diagnosis receipt: {exc}")
+    if not isinstance(receipt_raw, dict):
+        return DiagnosisVerifyResult(ok=False, reason="malformed diagnosis receipt: not a JSON object")
+    receipt = cast("dict[str, Any]", receipt_raw)
+
+    if receipt.get("receipt_type") != DIAGNOSIS_RECEIPT_TYPE:
+        return DiagnosisVerifyResult(
+            ok=False,
+            reason=f"not a diagnosis receipt (receipt_type={receipt.get('receipt_type')!r})",
+            receipt=receipt,
+        )
+    missing = [k for k in _BODY_FIELDS if k not in receipt]
+    if missing:
+        return DiagnosisVerifyResult(ok=False, reason=f"receipt is missing body field(s): {missing}", receipt=receipt)
+
+    body = {k: receipt[k] for k in _BODY_FIELDS}
+    stored_hash = str(receipt.get("receipt_hash", ""))
+    if _receipt_hash_of(body) != stored_hash:
+        return DiagnosisVerifyResult(
+            ok=False,
+            reason="receipt_hash does not recompute from the receipt body (tampered)",
+            receipt=receipt,
+        )
+
+    payload = _signed_payload(body, stored_hash)
+    resolved_verifier, verifier_error = _load_verifier(receipt, verifier)
+    if resolved_verifier is None:
+        return DiagnosisVerifyResult(ok=False, reason=verifier_error, receipt=receipt)
+    sig_raw = receipt.get("signature")
+    sig_block = cast("dict[str, Any]", sig_raw) if isinstance(sig_raw, dict) else {}
+    signature_b64 = str(sig_block.get("signature_b64", ""))
+    try:
+        signature = base64.b64decode(str(signature_b64))
+    except ValueError:
+        return DiagnosisVerifyResult(ok=False, reason="signature is not valid base64", receipt=receipt)
+    if not resolved_verifier.verify(payload, signature):
+        return DiagnosisVerifyResult(
+            ok=False, reason="Ed25519 signature does not verify over the receipt bytes", receipt=receipt
+        )
+
+    hmac_checked = False
+    if audit_key is not None:
+        expected_hmac = _hmac.new(audit_key, payload, hashlib.sha256).hexdigest()
+        if not _hmac.compare_digest(expected_hmac, str(receipt.get("operator_hmac", ""))):
+            return DiagnosisVerifyResult(
+                ok=False, reason="operator HMAC does not verify under the audit key", receipt=receipt
+            )
+        hmac_checked = True
+
+    if not journal_path.exists():
+        return DiagnosisVerifyResult(
+            ok=False,
+            reason=f"journal {journal_path} is absent; cannot re-derive the diagnosis",
+            hmac_checked=hmac_checked,
+            receipt=receipt,
+        )
+    actual_file_sha = hashlib.sha256(journal_path.read_bytes()).hexdigest()
+    if actual_file_sha != str(receipt["journal_file_sha256"]):
+        return DiagnosisVerifyResult(
+            ok=False,
+            reason="journal bytes differ from the diagnosed journal (mutated or different run)",
+            hmac_checked=hmac_checked,
+            receipt=receipt,
+        )
+
+    try:
+        predicate = predicate_from_params(receipt["signal"])
+        rederived = diagnose_run(journal_path, predicate, run_id=str(receipt["run_id"]))
+    except DiagnoseError as exc:
+        return DiagnosisVerifyResult(
+            ok=False, reason=f"re-derivation failed: {exc}", hmac_checked=hmac_checked, receipt=receipt
+        )
+
+    checks: list[tuple[str, Any, Any]] = [
+        ("located", True, rederived.located),
+        ("culprit_index", receipt["culprit_index"], rederived.culprit_index),
+        ("culprit_step_hash", receipt["culprit_step_hash"], rederived.culprit_step_hash),
+        ("journal_head", receipt["journal_head"], rederived.journal_head),
+        ("event_count", receipt["event_count"], rederived.event_count),
+        ("reason_code", receipt["reason_code"], rederived.reason_code),
+        ("reason", receipt["reason"], rederived.reason),
+        ("predicate_id", receipt["predicate_id"], rederived.predicate_id),
+        ("predicate_hash", receipt["predicate_hash"], rederived.predicate_hash),
+    ]
+    for name, stored, derived in checks:
+        if stored != derived:
+            return DiagnosisVerifyResult(
+                ok=False,
+                reason=f"re-derived diagnosis does not match the receipt: {name} {derived!r} != {stored!r}",
+                hmac_checked=hmac_checked,
+                receipt=receipt,
+            )
+
+    return DiagnosisVerifyResult(ok=True, reason="", hmac_checked=hmac_checked, receipt=receipt)
+
+
+__all__ = [
+    "DIAGNOSIS_RECEIPT_SCHEMA_VERSION",
+    "DIAGNOSIS_RECEIPT_TYPE",
+    "DiagnosisReceipt",
+    "DiagnosisReceiptError",
+    "DiagnosisVerifyResult",
+    "build_diagnosis_receipt",
+    "verify_diagnosis_receipt",
+]

--- a/src/bernstein/core/replay/diff.py
+++ b/src/bernstein/core/replay/diff.py
@@ -41,6 +41,24 @@ REASON_CODE_LENGTH_MISMATCH = "length_mismatch"
 #: The first mismatching event is a provider-side context mutation entry.
 REASON_CODE_PROVIDER_STATE_MUTATION = "provider_state_mutation"
 
+# -- Single-run diagnosis attribution (issue #2928) -------------------------
+# ``bernstein audit diagnose`` classifies the first faulty step of a single
+# run with the same machine-readable vocabulary this module already defines
+# for two-run divergence, so the reason-code set stays single-sourced. The
+# additions below are strictly additive: existing codes keep their values.
+
+#: The first faulty step is a chain-integrity break located by
+#: :func:`bernstein.core.replay.journal.verify_journal`.
+REASON_CODE_CHAIN_BREAK = "chain_break"
+
+#: The culprit step is the first recorded step whose payload carries the
+#: failure fingerprint of the diagnosed incident.
+REASON_CODE_FIRST_FAILING_TOOL_RESULT = "first_failing_tool_result"
+
+#: The culprit step first introduced the content hash that a downstream
+#: gate verdict or lineage taint projection rejected.
+REASON_CODE_BAD_INPUT_CONTENT_HASH = "bad_input_content_hash"
+
 
 @dataclass(frozen=True)
 class DivergenceResult:

--- a/src/bernstein/core/replay/journal.py
+++ b/src/bernstein/core/replay/journal.py
@@ -472,10 +472,40 @@ def load_events(path: Path, *, strict: bool = False) -> list[dict[str, Any]]:
                 if strict:
                     raise JournalParseError(f"unparsable line at physical line {lineno} ({exc.msg})") from exc
                 continue
-            if strict and not isinstance(row, dict):
-                raise JournalParseError(f"non-object row at physical line {lineno}")
+            if strict:
+                if not isinstance(row, dict):
+                    raise JournalParseError(f"non-object row at physical line {lineno}")
+                _validate_strict_row(row, lineno)
             events.append(row)
     return events
+
+
+def _validate_strict_row(row: dict[str, Any], lineno: int) -> None:
+    """Shape-check one journal row for the strict (diagnostic) reader.
+
+    ``verify_journal`` recomputes hashes with tolerant ``.get`` defaults, so
+    a row missing or mistyping its chain fields would surface downstream as
+    a *chain break* - a cryptographic verdict - when the honest verdict is
+    "malformed input". The strict reader therefore refuses such a row up
+    front, naming the physical line, before any head or chain computation
+    can be derived from it.
+
+    Raises:
+        JournalParseError: A required field is missing or carries the wrong
+            primitive type.
+    """
+    event = row.get("event")
+    if not isinstance(event, str) or not event:
+        raise JournalParseError(f"row at physical line {lineno} has a missing or non-string 'event'")
+    index = row.get("index")
+    if not isinstance(index, int) or isinstance(index, bool):
+        raise JournalParseError(f"row at physical line {lineno} has a missing or non-integer 'index'")
+    if not isinstance(row.get("prev_hash"), str):
+        raise JournalParseError(f"row at physical line {lineno} has a missing or non-string 'prev_hash'")
+    for hash_field in ("payload_hash", "event_hash"):
+        value = row.get(hash_field)
+        if not isinstance(value, str) or not value:
+            raise JournalParseError(f"row at physical line {lineno} has a missing or empty {hash_field!r}")
 
 
 def verify_journal(path: Path) -> JournalVerifyResult:

--- a/src/bernstein/core/replay/journal.py
+++ b/src/bernstein/core/replay/journal.py
@@ -436,24 +436,45 @@ def _remove_tree(path: Path) -> None:
     path.rmdir()
 
 
-def load_events(path: Path) -> list[dict[str, Any]]:
+class JournalParseError(ValueError):
+    """Raised by ``load_events(strict=True)`` for an untrustworthy row.
+
+    Carries the 0-based physical line index so a diagnostic caller can name
+    the exact on-disk location that refused to parse.
+    """
+
+
+def load_events(path: Path, *, strict: bool = False) -> list[dict[str, Any]]:
     """Load all events from a journal JSONL file in append order.
 
-    Malformed lines are skipped so a partial trailing write cannot wedge
-    a reader.
+    One scan implementation serves both reader policies, so a journal-format
+    change can never make a diagnostic reader drift from the rest of replay:
+
+    * tolerant (default): malformed lines are skipped so a partial trailing
+      write cannot wedge an ordinary reader;
+    * ``strict=True``: any non-blank line that does not decode as a JSON
+      object raises :class:`JournalParseError` naming the 0-based physical
+      line index. Diagnostic readers (``bernstein audit diagnose``) use this
+      so no reported index can ever count parsed rows rather than physical
+      journal lines, and no finding is derived from a filtered sequence.
     """
     events: list[dict[str, Any]] = []
     if not path.exists():
         return events
     with path.open(encoding="utf-8") as f:
-        for raw in f:
+        for lineno, raw in enumerate(f):
             line = raw.strip()
             if not line:
                 continue
             try:
-                events.append(json.loads(line))
-            except json.JSONDecodeError:
+                row = json.loads(line)
+            except json.JSONDecodeError as exc:
+                if strict:
+                    raise JournalParseError(f"unparsable line at physical line {lineno} ({exc.msg})") from exc
                 continue
+            if strict and not isinstance(row, dict):
+                raise JournalParseError(f"non-object row at physical line {lineno}")
+            events.append(row)
     return events
 
 
@@ -646,6 +667,7 @@ __all__ = [
     "JOURNAL_FILENAME",
     "RETENTION_ENV_VAR",
     "EventJournal",
+    "JournalParseError",
     "JournalPathError",
     "JournalVerifyResult",
     "compute_event_hash",

--- a/tests/unit/core/replay/test_diagnose.py
+++ b/tests/unit/core/replay/test_diagnose.py
@@ -611,6 +611,61 @@ def test_predicate_round_trips_through_embedded_params(tmp_path: Path) -> None:
     assert rebuilt.predicate_hash() == original.predicate_hash()
 
 
+def test_mistyped_chain_field_is_refused_as_malformed_not_chain_break(tmp_path: Path) -> None:
+    """A row with a wrong-typed chain field is malformed input, not tamper.
+
+    Pre-fix, strict loading accepted any JSON object, so a mistyped row
+    reached verify_journal and was reported as a cryptographic chain break
+    at that index -- the honest verdict is a refusal naming the physical
+    line (regression for bot-ack: 3707430834).
+    """
+    import json as _json
+
+    from bernstein.core.replay.journal import JournalParseError
+
+    sdd = tmp_path / ".sdd"
+    path = _seed_journal(sdd, "run-mistyped", bad_step=None, steps=3)
+    rows = [_json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    rows[1]["index"] = str(rows[1]["index"])  # right value, wrong type
+    path.write_text("".join(_json.dumps(r) + "\n" for r in rows), encoding="utf-8")
+
+    with pytest.raises(JournalParseError, match="physical line 1 has a missing or non-integer 'index'"):
+        load_events(path, strict=True)
+
+
+def test_row_missing_event_hash_is_refused_before_any_chain_verdict(tmp_path: Path) -> None:
+    import json as _json
+
+    from bernstein.core.replay.journal import JournalParseError
+
+    sdd = tmp_path / ".sdd"
+    path = _seed_journal(sdd, "run-nohash", bad_step=None, steps=3)
+    rows = [_json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    del rows[2]["event_hash"]
+    path.write_text("".join(_json.dumps(r) + "\n" for r in rows), encoding="utf-8")
+
+    with pytest.raises(JournalParseError, match="physical line 2 has a missing or empty 'event_hash'"):
+        load_events(path, strict=True)
+
+
+def test_string_needles_in_receipt_params_are_refused_not_split() -> None:
+    """A plain-string needles value must refuse, never iterate per character.
+
+    Pre-fix, tuple(str(n) for n in "abc") silently rebuilt the predicate as
+    ("a", "b", "c") -- a predicate that was never evaluated -- and its
+    predicate_hash changed with it (regression for bot-ack: 3707430843).
+    """
+    with pytest.raises(DiagnoseError, match="'needles' must be a list of strings"):
+        predicate_from_params({"kind": "gate", "needles": "abc"})
+
+
+def test_malformed_lineage_gate_params_are_refused() -> None:
+    with pytest.raises(DiagnoseError, match="'lineage_gate' must be a mapping of booleans"):
+        predicate_from_params(
+            {"kind": "artefact", "needles": [], "lineage_path": [], "lineage_gate": {"checked": "yes"}}
+        )
+
+
 def test_predicate_from_params_rejects_unknown_kind() -> None:
     with pytest.raises(DiagnoseError, match="unknown signal kind"):
         predicate_from_params({"kind": "mystery"})

--- a/tests/unit/core/replay/test_diagnose.py
+++ b/tests/unit/core/replay/test_diagnose.py
@@ -1,0 +1,459 @@
+"""Unit tests for ``core.replay.diagnose`` and its signal adapters (#2928).
+
+Hermetic throughout: every journal is a synthetic ``EventJournal`` under
+``tmp_path``, every signal is resolved from synthetic on-disk records, and
+no network or live provider is touched.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bernstein.core.lineage.entry import LineageEntry, entry_hash
+from bernstein.core.replay.diagnose import (
+    DiagnoseError,
+    SignalNotLocatedError,
+    SignalPredicate,
+    diagnose_run,
+)
+from bernstein.core.replay.diagnose_signals import (
+    artefact_signal,
+    gate_signal,
+    incident_signal,
+    predicate_from_params,
+    replay_signal,
+    resolve_signal,
+)
+from bernstein.core.replay.diff import (
+    REASON_CODE_BAD_INPUT_CONTENT_HASH,
+    REASON_CODE_CHAIN_BREAK,
+    REASON_CODE_FIRST_FAILING_TOOL_RESULT,
+    REASON_CODE_LENGTH_MISMATCH,
+    REASON_CODE_NONE,
+    REASON_CODE_PROVIDER_STATE_MUTATION,
+    REASON_CODE_RESPONSE_MISMATCH,
+)
+from bernstein.core.replay.journal import EventJournal, load_events
+from bernstein.core.replay.provider_state import PROVIDER_STATE_MUTATION_EVENT
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+BAD_HASH = hashlib.sha256(b"the-offending-content").hexdigest()
+
+
+def _content_predicate(*needles: str) -> SignalPredicate:
+    return SignalPredicate(
+        predicate_id="test/v1",
+        params={"kind": "incident", "needles": sorted(needles)},
+        default_reason_code=REASON_CODE_FIRST_FAILING_TOOL_RESULT,
+        needles=tuple(sorted(needles)),
+    )
+
+
+def _seed_journal(sdd: Path, run_id: str, *, bad_step: int | None, steps: int = 5) -> Path:
+    """Build a journal of *steps* ticks; *bad_step* records the bad hash."""
+    journal = EventJournal(run_id, sdd)
+    for i in range(steps):
+        if i == bad_step:
+            journal.record("tool_result", step=i, content_hash=f"sha256:{BAD_HASH}")
+        else:
+            journal.record("tick", step=i)
+    return journal.path
+
+
+def _tamper_payload(journal_path: Path, index: int) -> None:
+    """Mutate the payload of row *index* without recomputing its hashes."""
+    lines = journal_path.read_text(encoding="utf-8").splitlines()
+    row = json.loads(lines[index])
+    row["step"] = "tampered"
+    lines[index] = json.dumps(row, default=str)
+    journal_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# locator core
+# ---------------------------------------------------------------------------
+
+
+def test_diagnosis_names_first_divergent_step_index(tmp_path: Path) -> None:
+    """The culprit is the exact step that introduced the bad content hash."""
+    sdd = tmp_path / ".sdd"
+    path = _seed_journal(sdd, "run-1", bad_step=3)
+
+    result = diagnose_run(path, _content_predicate(BAD_HASH), run_id="run-1")
+
+    assert result.located is True
+    assert result.culprit_index == 3
+    events = load_events(path)
+    assert result.culprit_step_hash == events[3]["event_hash"]
+    assert result.event_count == 5
+    assert result.reason_code == REASON_CODE_FIRST_FAILING_TOOL_RESULT
+
+
+def test_culprit_is_the_first_of_repeated_appearances(tmp_path: Path) -> None:
+    """When the bad hash recurs, the minimal (first) index is named."""
+    sdd = tmp_path / ".sdd"
+    journal = EventJournal("run-rep", sdd)
+    journal.record("tick", step=0)
+    journal.record("tool_result", step=1, content_hash=f"sha256:{BAD_HASH}")
+    journal.record("tool_result", step=2, content_hash=f"sha256:{BAD_HASH}")
+
+    result = diagnose_run(journal.path, _content_predicate(BAD_HASH), run_id="run-rep")
+
+    assert result.culprit_index == 1
+
+
+def test_untampered_run_diagnoses_clean(tmp_path: Path) -> None:
+    """The replay signal over an intact chain locates nothing (clean)."""
+    sdd = tmp_path / ".sdd"
+    path = _seed_journal(sdd, "run-clean", bad_step=None)
+
+    result = diagnose_run(path, replay_signal(), run_id="run-clean")
+
+    assert result.located is False
+    assert result.culprit_index is None
+    assert result.reason_code == REASON_CODE_NONE
+    assert "chain intact" in result.reason
+
+
+def test_replay_signal_names_chain_break_index(tmp_path: Path) -> None:
+    """A payload mutated at step j surfaces as a chain break at exactly j."""
+    sdd = tmp_path / ".sdd"
+    path = _seed_journal(sdd, "run-tamper", bad_step=None)
+    _tamper_payload(path, 2)
+
+    result = diagnose_run(path, replay_signal(), run_id="run-tamper")
+
+    assert result.located is True
+    assert result.culprit_index == 2
+    assert result.reason_code == REASON_CODE_CHAIN_BREAK
+
+
+def test_broken_chain_fails_closed_for_content_signals(tmp_path: Path) -> None:
+    """Content predicates refuse an unverified record instead of scanning it."""
+    sdd = tmp_path / ".sdd"
+    path = _seed_journal(sdd, "run-broken", bad_step=3)
+    _tamper_payload(path, 1)
+
+    with pytest.raises(DiagnoseError, match="chain verification"):
+        diagnose_run(path, _content_predicate(BAD_HASH), run_id="run-broken")
+
+
+def test_missing_journal_fails_closed(tmp_path: Path) -> None:
+    """No journal file: refuse with the no-signed-record message."""
+    with pytest.raises(DiagnoseError, match="no signed per-step record"):
+        diagnose_run(tmp_path / "absent.jsonl", replay_signal(), run_id="run-x")
+
+
+def test_empty_journal_fails_closed(tmp_path: Path) -> None:
+    """A blanked (zero-event) journal is refused, not reported clean."""
+    empty = tmp_path / "journal.jsonl"
+    empty.write_text("", encoding="utf-8")
+    with pytest.raises(DiagnoseError, match="no signed per-step record"):
+        diagnose_run(empty, replay_signal(), run_id="run-x")
+
+
+def test_unlocatable_signal_refuses_instead_of_guessing(tmp_path: Path) -> None:
+    """A fingerprint absent from every step raises SignalNotLocatedError."""
+    sdd = tmp_path / ".sdd"
+    path = _seed_journal(sdd, "run-nf", bad_step=None)
+
+    with pytest.raises(SignalNotLocatedError, match="does not resolve to any recorded step"):
+        diagnose_run(path, _content_predicate(BAD_HASH), run_id="run-nf")
+
+
+def test_provider_state_mutation_step_is_attributed(tmp_path: Path) -> None:
+    """A mutation-event culprit is attributed with the shared mutation code."""
+    sdd = tmp_path / ".sdd"
+    journal = EventJournal("run-mut", sdd)
+    journal.record("tick", step=0)
+    journal.record(
+        PROVIDER_STATE_MUTATION_EVENT,
+        mutation_kind="context_edit",
+        content_hash=f"sha256:{BAD_HASH}",
+    )
+
+    result = diagnose_run(journal.path, _content_predicate(BAD_HASH), run_id="run-mut")
+
+    assert result.culprit_index == 1
+    assert result.reason_code == REASON_CODE_PROVIDER_STATE_MUTATION
+
+
+# ---------------------------------------------------------------------------
+# shared reason-code vocabulary
+# ---------------------------------------------------------------------------
+
+
+def test_reason_code_vocabulary_stays_backward_compatible() -> None:
+    """Existing two-run diff codes keep their exact values; additions are new.
+
+    Diagnosis and two-run diff share one machine-readable set, so the
+    pre-existing constants must never change value and the diagnosis codes
+    must not collide with them.
+    """
+    assert REASON_CODE_NONE == ""
+    assert REASON_CODE_RESPONSE_MISMATCH == "response_mismatch"
+    assert REASON_CODE_LENGTH_MISMATCH == "length_mismatch"
+    assert REASON_CODE_PROVIDER_STATE_MUTATION == "provider_state_mutation"
+    additions = {
+        REASON_CODE_CHAIN_BREAK,
+        REASON_CODE_FIRST_FAILING_TOOL_RESULT,
+        REASON_CODE_BAD_INPUT_CONTENT_HASH,
+    }
+    existing = {
+        REASON_CODE_NONE,
+        REASON_CODE_RESPONSE_MISMATCH,
+        REASON_CODE_LENGTH_MISMATCH,
+        REASON_CODE_PROVIDER_STATE_MUTATION,
+    }
+    assert len(additions) == 3
+    assert not (additions & existing)
+
+
+# ---------------------------------------------------------------------------
+# gate signal
+# ---------------------------------------------------------------------------
+
+
+def _write_gate_receipt(gate_dir: Path, *, timestamp: int) -> str:
+    """Seal a synthetic rejecting VerdictReceipt to disk; returns its hash."""
+    from bernstein.eval.gate_receipt import VerdictReceipt, recompute_receipt_hash
+    from bernstein.eval.significance import PairedTable, classify, result_set_hash, suite_content_hash
+
+    tasks = {f"t{i}": True for i in range(40)}
+    baseline = dict(tasks)
+    candidate = {k: False for k in tasks}
+    table = PairedTable.from_outcomes(baseline, candidate)
+    evidence = classify(table)
+    assert evidence.verdict.value == "significant_regression"
+
+    unsealed = VerdictReceipt(
+        schema_version=1,
+        suite_content_hash=suite_content_hash(list(tasks)),
+        baseline_result_set_hash=result_set_hash(baseline),
+        candidate_result_set_hash=result_set_hash(candidate),
+        candidate_config_id="cand-1",
+        baseline_config_id="base-1",
+        evidence=evidence,
+        timestamp=timestamp,
+        receipt_hash="",
+    )
+    receipt_hash = recompute_receipt_hash(unsealed.to_dict())
+    sealed = VerdictReceipt(
+        schema_version=1,
+        suite_content_hash=unsealed.suite_content_hash,
+        baseline_result_set_hash=unsealed.baseline_result_set_hash,
+        candidate_result_set_hash=unsealed.candidate_result_set_hash,
+        candidate_config_id="cand-1",
+        baseline_config_id="base-1",
+        evidence=evidence,
+        timestamp=timestamp,
+        receipt_hash=receipt_hash,
+    )
+    gate_dir.mkdir(parents=True, exist_ok=True)
+    (gate_dir / f"{receipt_hash.replace(':', '_')}.json").write_text(
+        json.dumps(sealed.to_dict(), sort_keys=True), encoding="utf-8"
+    )
+    return receipt_hash
+
+
+def test_gate_signal_is_pure_function_of_on_disk_records(tmp_path: Path) -> None:
+    """Two independent resolutions of the same store agree byte-for-byte."""
+    gate_dir = tmp_path / ".sdd" / "eval" / "gate"
+    receipt_hash = _write_gate_receipt(gate_dir, timestamp=100)
+
+    first = gate_signal(None, gate_dir=gate_dir)
+    second = gate_signal(None, gate_dir=gate_dir)
+
+    assert first.params == second.params
+    assert first.predicate_hash() == second.predicate_hash()
+    assert first.params["receipt_hash"] == receipt_hash
+    assert first.default_reason_code == REASON_CODE_BAD_INPUT_CONTENT_HASH
+    assert first.needles  # the receipt's content hashes, bare-hex
+
+
+def test_gate_signal_locates_step_recording_the_rejected_hash(tmp_path: Path) -> None:
+    """The culprit is where the rejected check's content hash first appears."""
+    sdd = tmp_path / ".sdd"
+    gate_dir = sdd / "eval" / "gate"
+    _write_gate_receipt(gate_dir, timestamp=100)
+    predicate = gate_signal(None, gate_dir=gate_dir)
+    suite_hash_hex = next(iter(predicate.needles))
+
+    journal = EventJournal("run-gate", sdd)
+    journal.record("tick", step=0)
+    journal.record("eval_input", suite_content_hash=f"sha256:{suite_hash_hex}")
+    journal.record("tick", step=2)
+
+    result = diagnose_run(journal.path, predicate, run_id="run-gate")
+
+    assert result.culprit_index == 1
+    assert result.reason_code == REASON_CODE_BAD_INPUT_CONTENT_HASH
+
+
+def test_gate_signal_fails_closed_when_no_rejecting_receipt(tmp_path: Path) -> None:
+    with pytest.raises(DiagnoseError, match="no rejecting verdict receipt"):
+        gate_signal(None, gate_dir=tmp_path / "gate")
+
+
+# ---------------------------------------------------------------------------
+# artefact signal
+# ---------------------------------------------------------------------------
+
+
+def _lineage_entry(
+    path: str,
+    *,
+    kind: str,
+    content: bytes,
+    parents: list[str],
+    ts_ns: int,
+    trust_class: str | None = None,
+) -> LineageEntry:
+    return LineageEntry(
+        v=1,
+        artefact_path=path,
+        artefact_kind=kind,
+        content_hash="sha256:" + hashlib.sha256(content).hexdigest(),
+        parent_hashes=parents,
+        agent_id="agent-1",
+        agent_card_kid="kid-1",
+        tool_call_id="tc-1",
+        span_id="span-1",
+        ts_ns=ts_ns,
+        operator_hmac="",
+        trust_class=trust_class,
+    )
+
+
+def test_artefact_signal_locates_first_appearance_of_tainted_hash(tmp_path: Path) -> None:
+    """Lineage walks back from the tip; the culprit step first records the
+    tainted record's content hash, and the parent chain rides as evidence."""
+    sdd = tmp_path / ".sdd"
+    tainted = _lineage_entry(
+        "provenance/web.fetch/aaaa",
+        kind="tool-result",
+        content=b"outsider-bytes",
+        parents=[],
+        ts_ns=1,
+        trust_class="third_party",
+    )
+    tip = _lineage_entry(
+        "out.txt",
+        kind="file",
+        content=b"derived-bytes",
+        parents=[entry_hash(tainted)],
+        ts_ns=2,
+    )
+    log_path = sdd / "lineage" / "log.jsonl"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text("\n".join(json.dumps(asdict(e)) for e in (tainted, tip)) + "\n", encoding="utf-8")
+
+    predicate = artefact_signal("out.txt", lineage_log=log_path)
+    tainted_hex = tainted.content_hash.split(":", 1)[-1]
+    assert predicate.needles == (tainted_hex,)
+    assert predicate.lineage_path == (entry_hash(tainted), entry_hash(tip))
+
+    journal = EventJournal("run-art", sdd)
+    journal.record("tick", step=0)
+    journal.record("tick", step=1)
+    journal.record("tool_result", content_hash=tainted.content_hash)
+    journal.record("tick", step=3)
+
+    result = diagnose_run(journal.path, predicate, run_id="run-art")
+
+    assert result.culprit_index == 2
+    assert result.reason_code == REASON_CODE_BAD_INPUT_CONTENT_HASH
+    assert result.lineage_path == (entry_hash(tainted), entry_hash(tip))
+
+
+def test_artefact_signal_refuses_untainted_artefact(tmp_path: Path) -> None:
+    clean = _lineage_entry("ok.txt", kind="file", content=b"fine", parents=[], ts_ns=1, trust_class="operator")
+    log_path = tmp_path / "log.jsonl"
+    log_path.write_text(json.dumps(asdict(clean)) + "\n", encoding="utf-8")
+
+    with pytest.raises(DiagnoseError, match="not tainted"):
+        artefact_signal("ok.txt", lineage_log=log_path)
+
+
+def test_artefact_signal_fails_closed_without_lineage(tmp_path: Path) -> None:
+    with pytest.raises(DiagnoseError, match="no lineage entries"):
+        artefact_signal("out.txt", lineage_log=tmp_path / "missing.jsonl")
+
+
+# ---------------------------------------------------------------------------
+# incident signal
+# ---------------------------------------------------------------------------
+
+
+def test_incident_signal_matches_exact_recorded_failure_text(tmp_path: Path) -> None:
+    cases = tmp_path / "cases"
+    cases.mkdir()
+    prompt = (
+        "Reproduce and resolve the following terminal failure (role=qa).\n"
+        "Task: flaky pipeline\n"
+        "Failure reason: crash\n"
+        "Last error (trimmed):\n"
+        "ValueError: boom in step seven\n"
+    )
+    (cases / "inc-abc123.yaml").write_text(json.dumps({"id": "inc-abc123", "prompt": prompt}), encoding="utf-8")
+
+    predicate = incident_signal("inc-abc123", cases_dir=cases)
+    assert predicate.needles == ("ValueError: boom in step seven",)
+
+    sdd = tmp_path / ".sdd"
+    journal = EventJournal("run-inc", sdd)
+    journal.record("tick", step=0)
+    journal.record("tool_result", stderr="ValueError: boom in step seven")
+
+    result = diagnose_run(journal.path, predicate, run_id="run-inc")
+
+    assert result.culprit_index == 1
+    assert result.reason_code == REASON_CODE_FIRST_FAILING_TOOL_RESULT
+
+
+def test_incident_signal_fails_closed_on_missing_case(tmp_path: Path) -> None:
+    with pytest.raises(DiagnoseError, match="no incident eval case"):
+        incident_signal("inc-none", cases_dir=tmp_path)
+
+
+def test_incident_signal_refuses_case_without_fingerprint(tmp_path: Path) -> None:
+    (tmp_path / "inc-bare.yaml").write_text(
+        json.dumps({"id": "inc-bare", "prompt": "Reproduce the failure.\n"}), encoding="utf-8"
+    )
+    with pytest.raises(DiagnoseError, match="no matchable failure fingerprint"):
+        incident_signal("inc-bare", cases_dir=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# spec parsing + offline predicate round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_signal_rejects_unknown_kind(tmp_path: Path) -> None:
+    with pytest.raises(DiagnoseError, match="unknown --signal"):
+        resolve_signal("vibes", sdd_dir=tmp_path / ".sdd")
+
+
+def test_predicate_round_trips_through_embedded_params(tmp_path: Path) -> None:
+    """The receipt's embedded signal block rebuilds the identical predicate."""
+    gate_dir = tmp_path / ".sdd" / "eval" / "gate"
+    _write_gate_receipt(gate_dir, timestamp=100)
+    original = gate_signal(None, gate_dir=gate_dir)
+
+    rebuilt = predicate_from_params(json.loads(json.dumps(original.params)))
+
+    assert rebuilt.predicate_id == original.predicate_id
+    assert rebuilt.needles == original.needles
+    assert rebuilt.predicate_hash() == original.predicate_hash()
+
+
+def test_predicate_from_params_rejects_unknown_kind() -> None:
+    with pytest.raises(DiagnoseError, match="unknown signal kind"):
+        predicate_from_params({"kind": "mystery"})

--- a/tests/unit/core/replay/test_diagnose.py
+++ b/tests/unit/core/replay/test_diagnose.py
@@ -188,6 +188,24 @@ def test_malformed_middle_line_fails_closed_for_every_signal_mode(tmp_path: Path
         diagnose_run(path, _content_predicate(BAD_HASH), run_id="run-midtorn")
 
 
+def test_shared_loader_owns_the_malformed_line_policy(tmp_path: Path) -> None:
+    """One scan implementation serves both policies: journal.load_events is
+    tolerant by default and strict on request, and diagnose delegates to it,
+    so the two readers can never drift (regression for bot-ack: 3706042994)."""
+    from bernstein.core.replay.journal import JournalParseError
+
+    sdd = tmp_path / ".sdd"
+    path = _seed_journal(sdd, "run-policy", bad_step=None, steps=3)
+    with path.open("a", encoding="utf-8") as f:
+        f.write("{garbage\n")
+
+    tolerant = load_events(path)
+    assert len(tolerant) == 3  # ordinary readers keep their torn-tail tolerance
+
+    with pytest.raises(JournalParseError, match="unparsable line at physical line 3"):
+        load_events(path, strict=True)
+
+
 def test_non_object_json_row_fails_closed(tmp_path: Path) -> None:
     """A line that decodes to a JSON scalar is refused like garbage."""
     sdd = tmp_path / ".sdd"
@@ -343,11 +361,25 @@ def test_gate_signal_fails_closed_when_no_rejecting_receipt(tmp_path: Path) -> N
 
 
 # ---------------------------------------------------------------------------
-# artefact signal
+# artefact signal (lineage log must pass the gate before shaping a predicate)
 # ---------------------------------------------------------------------------
 
+_LINEAGE_SECRET = b"op-secret-diagnose"
 
-def _lineage_entry(
+
+class _LineageAgent:
+    """A signing identity with an on-disk agent card, as the gate expects."""
+
+    def __init__(self) -> None:
+        from bernstein.core.lineage.identity import generate_keypair
+
+        self.agent_id = "agent:diag"
+        self.kid = "k1"
+        self.priv, self.pub = generate_keypair()
+
+
+def _signed_entry(
+    agent: _LineageAgent,
     path: str,
     *,
     kind: str,
@@ -356,27 +388,65 @@ def _lineage_entry(
     ts_ns: int,
     trust_class: str | None = None,
 ) -> LineageEntry:
-    return LineageEntry(
-        v=1,
-        artefact_path=path,
-        artefact_kind=kind,
-        content_hash="sha256:" + hashlib.sha256(content).hexdigest(),
-        parent_hashes=parents,
-        agent_id="agent-1",
-        agent_card_kid="kid-1",
-        tool_call_id="tc-1",
-        span_id="span-1",
-        ts_ns=ts_ns,
-        operator_hmac="",
-        trust_class=trust_class,
+    def build(op_hmac: str) -> LineageEntry:
+        return LineageEntry(
+            v=1,
+            artefact_path=path,
+            artefact_kind=kind,
+            content_hash="sha256:" + hashlib.sha256(content).hexdigest(),
+            parent_hashes=parents,
+            agent_id=agent.agent_id,
+            agent_card_kid=agent.kid,
+            tool_call_id="tc-1",
+            span_id="span-1",
+            ts_ns=ts_ns,
+            operator_hmac=op_hmac,
+            trust_class=trust_class,
+        )
+
+    from bernstein.core.lineage.entry import compute_operator_hmac
+
+    return build(compute_operator_hmac(build(""), _LINEAGE_SECRET))
+
+
+def _write_gated_log(root: Path, entries: list[LineageEntry], agent: _LineageAgent) -> tuple[Path, Path]:
+    """Write a byte-canonical, JWS-signed lineage log + cards; returns paths."""
+    from bernstein.core.lineage.entry import canonicalise
+    from bernstein.core.lineage.identity import sign_detached
+
+    cards_dir = root / "agents"
+    card_dir = cards_dir / agent.agent_id
+    card_dir.mkdir(parents=True, exist_ok=True)
+    (card_dir / "card.json").write_text(
+        json.dumps(
+            {
+                "protocolVersion": "a2a/1.0",
+                "agent_id": agent.agent_id,
+                "kid": agent.kid,
+                "public_key_pem": agent.pub,
+            }
+        ),
+        encoding="utf-8",
     )
 
+    log_path = root / "lineage" / "log.jsonl"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("wb") as f:
+        for e in entries:
+            f.write(canonicalise(e) + b"\n")
+    sig_root = log_path.parent / "signatures"
+    for e in entries:
+        jws = sign_detached(canonicalise(e), agent.priv, kid=agent.kid)
+        path_hash = hashlib.sha256(e.artefact_path.encode()).hexdigest()
+        dest = sig_root / path_hash[:2] / path_hash
+        dest.mkdir(parents=True, exist_ok=True)
+        (dest / (entry_hash(e).replace("sha256:", "") + ".jws")).write_text(jws, encoding="utf-8")
+    return log_path, cards_dir
 
-def test_artefact_signal_locates_first_appearance_of_tainted_hash(tmp_path: Path) -> None:
-    """Lineage walks back from the tip; the culprit step first records the
-    tainted record's content hash, and the parent chain rides as evidence."""
-    sdd = tmp_path / ".sdd"
-    tainted = _lineage_entry(
+
+def _tainted_pair(agent: _LineageAgent) -> tuple[LineageEntry, LineageEntry]:
+    tainted = _signed_entry(
+        agent,
         "provenance/web.fetch/aaaa",
         kind="tool-result",
         content=b"outsider-bytes",
@@ -384,21 +454,30 @@ def test_artefact_signal_locates_first_appearance_of_tainted_hash(tmp_path: Path
         ts_ns=1,
         trust_class="third_party",
     )
-    tip = _lineage_entry(
+    tip = _signed_entry(
+        agent,
         "out.txt",
         kind="file",
         content=b"derived-bytes",
         parents=[entry_hash(tainted)],
         ts_ns=2,
     )
-    log_path = sdd / "lineage" / "log.jsonl"
-    log_path.parent.mkdir(parents=True, exist_ok=True)
-    log_path.write_text("\n".join(json.dumps(asdict(e)) for e in (tainted, tip)) + "\n", encoding="utf-8")
+    return tainted, tip
 
-    predicate = artefact_signal("out.txt", lineage_log=log_path)
+
+def test_artefact_signal_locates_first_appearance_of_tainted_hash(tmp_path: Path) -> None:
+    """Lineage walks back from the tip; the culprit step first records the
+    tainted record's content hash, and the parent chain rides as evidence."""
+    sdd = tmp_path / ".sdd"
+    agent = _LineageAgent()
+    tainted, tip = _tainted_pair(agent)
+    log_path, cards_dir = _write_gated_log(sdd, [tainted, tip], agent)
+
+    predicate = artefact_signal("out.txt", lineage_log=log_path, cards_dir=cards_dir, operator_secret=_LINEAGE_SECRET)
     tainted_hex = tainted.content_hash.split(":", 1)[-1]
     assert predicate.needles == (tainted_hex,)
     assert predicate.lineage_path == (entry_hash(tainted), entry_hash(tip))
+    assert predicate.params["lineage_gate"] == {"checked": True, "operator_hmac_checked": True}
 
     journal = EventJournal("run-art", sdd)
     journal.record("tick", step=0)
@@ -413,18 +492,56 @@ def test_artefact_signal_locates_first_appearance_of_tainted_hash(tmp_path: Path
     assert result.lineage_path == (entry_hash(tainted), entry_hash(tip))
 
 
+def test_unsigned_lineage_entry_cannot_shape_a_sealed_diagnosis(tmp_path: Path) -> None:
+    """The gate runs before any predicate is shaped: an unsigned log and a
+    tampered signed log both refuse (regression for bot-ack: 3706042986)."""
+    agent = _LineageAgent()
+    tainted, tip = _tainted_pair(agent)
+
+    # Unsigned: entries on disk but no JWS sidecars and no canonical bytes.
+    unsigned_log = tmp_path / "unsigned" / "lineage" / "log.jsonl"
+    unsigned_log.parent.mkdir(parents=True)
+    unsigned_log.write_text("\n".join(json.dumps(asdict(e)) for e in (tainted, tip)) + "\n", encoding="utf-8")
+    with pytest.raises(DiagnoseError, match="lineage gate failed"):
+        artefact_signal(
+            "out.txt",
+            lineage_log=unsigned_log,
+            cards_dir=tmp_path / "unsigned" / "agents",
+            operator_secret=_LINEAGE_SECRET,
+        )
+
+    # Tampered: properly signed log with one byte flipped afterwards.
+    log_path, cards_dir = _write_gated_log(tmp_path / "tampered", [tainted, tip], agent)
+    raw = log_path.read_bytes().replace(b"third_party", b"first_party", 1)
+    log_path.write_bytes(raw)
+    with pytest.raises(DiagnoseError, match="lineage gate failed"):
+        artefact_signal("out.txt", lineage_log=log_path, cards_dir=cards_dir, operator_secret=_LINEAGE_SECRET)
+
+
+def test_artefact_gate_mode_is_disclosed_in_sealed_params(tmp_path: Path) -> None:
+    """Without an operator secret the gate still verifies signatures, and the
+    weaker mode is disclosed in the params the receipt seals."""
+    agent = _LineageAgent()
+    tainted, tip = _tainted_pair(agent)
+    log_path, cards_dir = _write_gated_log(tmp_path, [tainted, tip], agent)
+
+    predicate = artefact_signal("out.txt", lineage_log=log_path, cards_dir=cards_dir, operator_secret=None)
+
+    assert predicate.params["lineage_gate"] == {"checked": True, "operator_hmac_checked": False}
+
+
 def test_artefact_signal_refuses_untainted_artefact(tmp_path: Path) -> None:
-    clean = _lineage_entry("ok.txt", kind="file", content=b"fine", parents=[], ts_ns=1, trust_class="operator")
-    log_path = tmp_path / "log.jsonl"
-    log_path.write_text(json.dumps(asdict(clean)) + "\n", encoding="utf-8")
+    agent = _LineageAgent()
+    clean = _signed_entry(agent, "ok.txt", kind="file", content=b"fine", parents=[], ts_ns=1, trust_class="operator")
+    log_path, cards_dir = _write_gated_log(tmp_path, [clean], agent)
 
     with pytest.raises(DiagnoseError, match="not tainted"):
-        artefact_signal("ok.txt", lineage_log=log_path)
+        artefact_signal("ok.txt", lineage_log=log_path, cards_dir=cards_dir, operator_secret=_LINEAGE_SECRET)
 
 
 def test_artefact_signal_fails_closed_without_lineage(tmp_path: Path) -> None:
     with pytest.raises(DiagnoseError, match="no lineage entries"):
-        artefact_signal("out.txt", lineage_log=tmp_path / "missing.jsonl")
+        artefact_signal("out.txt", lineage_log=tmp_path / "missing.jsonl", cards_dir=tmp_path / "agents")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/core/replay/test_diagnose.py
+++ b/tests/unit/core/replay/test_diagnose.py
@@ -159,6 +159,46 @@ def test_empty_journal_fails_closed(tmp_path: Path) -> None:
         diagnose_run(empty, replay_signal(), run_id="run-x")
 
 
+def test_malformed_tail_line_fails_closed(tmp_path: Path) -> None:
+    """A torn/garbage tail line must refuse, never a receipt over a filtered
+    sequence: the tolerant reader would drop it and the surviving prefix
+    would chain-verify clean (regression for bot-ack: 3705961185)."""
+    sdd = tmp_path / ".sdd"
+    path = _seed_journal(sdd, "run-torn", bad_step=None)
+    with path.open("a", encoding="utf-8") as f:
+        f.write("{this is not json\n")
+
+    with pytest.raises(DiagnoseError, match="unparsable line at physical line 5"):
+        diagnose_run(path, replay_signal(), run_id="run-torn")
+
+
+def test_malformed_middle_line_fails_closed_for_every_signal_mode(tmp_path: Path) -> None:
+    """A malformed middle line refuses both chain and content predicates
+    before any index is computed, so no reported culprit can ever count
+    parsed rows instead of physical journal lines."""
+    sdd = tmp_path / ".sdd"
+    path = _seed_journal(sdd, "run-midtorn", bad_step=3)
+    lines = path.read_text(encoding="utf-8").splitlines()
+    lines.insert(2, "garbage that does not decode")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    with pytest.raises(DiagnoseError, match="unparsable line at physical line 2"):
+        diagnose_run(path, replay_signal(), run_id="run-midtorn")
+    with pytest.raises(DiagnoseError, match="unparsable line at physical line 2"):
+        diagnose_run(path, _content_predicate(BAD_HASH), run_id="run-midtorn")
+
+
+def test_non_object_json_row_fails_closed(tmp_path: Path) -> None:
+    """A line that decodes to a JSON scalar is refused like garbage."""
+    sdd = tmp_path / ".sdd"
+    path = _seed_journal(sdd, "run-scalar", bad_step=None)
+    with path.open("a", encoding="utf-8") as f:
+        f.write("42\n")
+
+    with pytest.raises(DiagnoseError, match="non-object row at physical line 5"):
+        diagnose_run(path, replay_signal(), run_id="run-scalar")
+
+
 def test_unlocatable_signal_refuses_instead_of_guessing(tmp_path: Path) -> None:
     """A fingerprint absent from every step raises SignalNotLocatedError."""
     sdd = tmp_path / ".sdd"

--- a/tests/unit/core/replay/test_diagnose_cli.py
+++ b/tests/unit/core/replay/test_diagnose_cli.py
@@ -121,6 +121,26 @@ def test_missing_audit_key_fails_closed_with_no_receipt(
     assert _receipts_in(sdd) == []
 
 
+def test_malformed_journal_line_fails_closed_with_no_receipt(
+    tmp_path: Path, runner: CliRunner, keys: dict[str, Path]
+) -> None:
+    """A journal with an unparsable line refuses with exit 2 and zero
+    receipts -- diagnose never reads a filtered sequence
+    (regression for bot-ack: 3705961185)."""
+    sdd = tmp_path / ".sdd"
+    journal = EventJournal("run-torn", sdd)
+    for i in range(3):
+        journal.record("tick", step=i)
+    with journal.path.open("a", encoding="utf-8") as f:
+        f.write("{torn trailing write\n")
+
+    result = runner.invoke(audit_group, _diagnose_args(sdd, keys, "run-torn", "replay"))
+
+    assert result.exit_code == 2
+    assert "unparsable line" in result.output
+    assert _receipts_in(sdd) == []
+
+
 def test_unsigned_receipts_are_refused(tmp_path: Path, runner: CliRunner, keys: dict[str, Path]) -> None:
     """Without --sign-key the command refuses rather than emitting unsigned."""
     sdd = tmp_path / ".sdd"

--- a/tests/unit/core/replay/test_diagnose_cli.py
+++ b/tests/unit/core/replay/test_diagnose_cli.py
@@ -1,0 +1,226 @@
+"""CLI tests for ``bernstein audit diagnose`` / ``audit diagnose verify`` (#2928).
+
+Exercises the Click surface end-to-end against synthetic journals under
+``tmp_path``, with an explicit audit HMAC key and Ed25519 signing key so no
+test touches the operator's real key material.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+from click.testing import CliRunner
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from bernstein.cli.commands.audit_cmd import audit_group
+from bernstein.core.replay.journal import EventJournal
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def keys(tmp_path: Path) -> dict[str, Path]:
+    """Audit HMAC key (0600) plus an Ed25519 signing keypair."""
+    audit_key = tmp_path / "audit.key"
+    audit_key.write_bytes(b"cli-test-audit-hmac-key-32-bytes")
+    audit_key.chmod(0o600)
+
+    private = Ed25519PrivateKey.generate()
+    sign_key = tmp_path / "sign.pem"
+    sign_key.write_bytes(
+        private.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        )
+    )
+    public_key = tmp_path / "sign-pub.pem"
+    public_key.write_bytes(
+        private.public_key().public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+    )
+    return {"audit": audit_key, "sign": sign_key, "pub": public_key}
+
+
+def _receipts_in(sdd: Path) -> list[Path]:
+    evidence = sdd / "evidence"
+    return sorted(evidence.glob("*.json")) if evidence.is_dir() else []
+
+
+def _tamper_payload(journal_path: Path, index: int) -> None:
+    lines = journal_path.read_text(encoding="utf-8").splitlines()
+    row = json.loads(lines[index])
+    row["step"] = "tampered"
+    lines[index] = json.dumps(row, default=str)
+    journal_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _diagnose_args(sdd: Path, keys: dict[str, Path], run_id: str, signal: str) -> list[str]:
+    return [
+        "diagnose",
+        run_id,
+        "--signal",
+        signal,
+        "--sign-key",
+        str(keys["sign"]),
+        "--sdd-dir",
+        str(sdd),
+        "--audit-key",
+        str(keys["audit"]),
+    ]
+
+
+def test_missing_journal_fails_closed_with_no_receipt(tmp_path: Path, runner: CliRunner, keys: dict[str, Path]) -> None:
+    """Strip-the-substrate: no journal -> exit non-zero and zero receipts."""
+    sdd = tmp_path / ".sdd"
+    result = runner.invoke(audit_group, _diagnose_args(sdd, keys, "run-none", "replay"))
+
+    assert result.exit_code == 2
+    assert "no signed per-step record" in result.output
+    assert _receipts_in(sdd) == []
+
+
+def test_blanked_journal_fails_closed_with_no_receipt(tmp_path: Path, runner: CliRunner, keys: dict[str, Path]) -> None:
+    """A zero-event journal is refused the same way, with zero receipts."""
+    sdd = tmp_path / ".sdd"
+    journal_path = sdd / "runs" / "run-blank" / "journal.jsonl"
+    journal_path.parent.mkdir(parents=True)
+    journal_path.write_text("", encoding="utf-8")
+
+    result = runner.invoke(audit_group, _diagnose_args(sdd, keys, "run-blank", "replay"))
+
+    assert result.exit_code == 2
+    assert "no signed per-step record" in result.output
+    assert _receipts_in(sdd) == []
+
+
+def test_missing_audit_key_fails_closed_with_no_receipt(
+    tmp_path: Path, runner: CliRunner, keys: dict[str, Path]
+) -> None:
+    """An unavailable audit HMAC key refuses before any receipt is built."""
+    sdd = tmp_path / ".sdd"
+    EventJournal("run-key", sdd).record("tick", step=0)
+
+    args = _diagnose_args(sdd, keys, "run-key", "replay")
+    args[args.index(str(keys["audit"]))] = str(tmp_path / "no-such.key")
+    result = runner.invoke(audit_group, args)
+
+    assert result.exit_code == 2
+    assert "Audit HMAC key unavailable" in result.output
+    assert _receipts_in(sdd) == []
+
+
+def test_unsigned_receipts_are_refused(tmp_path: Path, runner: CliRunner, keys: dict[str, Path]) -> None:
+    """Without --sign-key the command refuses rather than emitting unsigned."""
+    sdd = tmp_path / ".sdd"
+    EventJournal("run-nosig", sdd).record("tick", step=0)
+
+    result = runner.invoke(
+        audit_group,
+        ["diagnose", "run-nosig", "--signal", "replay", "--sdd-dir", str(sdd), "--audit-key", str(keys["audit"])],
+    )
+
+    assert result.exit_code == 2
+    assert "--sign-key is required" in result.output
+    assert _receipts_in(sdd) == []
+
+
+def test_intact_chain_diagnoses_clean_without_receipt(tmp_path: Path, runner: CliRunner, keys: dict[str, Path]) -> None:
+    sdd = tmp_path / ".sdd"
+    journal = EventJournal("run-ok", sdd)
+    for i in range(3):
+        journal.record("tick", step=i)
+
+    result = runner.invoke(audit_group, _diagnose_args(sdd, keys, "run-ok", "replay"))
+
+    assert result.exit_code == 0
+    assert "chain intact" in result.output
+    assert _receipts_in(sdd) == []
+
+
+def test_diagnose_names_culprit_and_receipt_verifies_offline(
+    tmp_path: Path, runner: CliRunner, keys: dict[str, Path]
+) -> None:
+    """Full loop: chain break at step 2 -> receipt written -> verify exit 0."""
+    sdd = tmp_path / ".sdd"
+    journal = EventJournal("run-bad", sdd)
+    for i in range(4):
+        journal.record("tick", step=i)
+    _tamper_payload(journal.path, 2)
+
+    diagnose = runner.invoke(audit_group, [*_diagnose_args(sdd, keys, "run-bad", "replay"), "--json"])
+    assert diagnose.exit_code == 1, diagnose.output
+    payload = json.loads(diagnose.output)
+    assert payload["culprit_index"] == 2
+    assert payload["reason_code"] == "chain_break"
+    receipts = _receipts_in(sdd)
+    assert len(receipts) == 1
+
+    verify = runner.invoke(
+        audit_group,
+        [
+            "diagnose",
+            "verify",
+            str(receipts[0]),
+            "--public-key",
+            str(keys["pub"]),
+            "--sdd-dir",
+            str(sdd),
+            "--audit-key",
+            str(keys["audit"]),
+        ],
+    )
+    assert verify.exit_code == 0, verify.output
+    assert "verified" in verify.output
+
+
+def test_verify_fails_after_journal_mutation(tmp_path: Path, runner: CliRunner, keys: dict[str, Path]) -> None:
+    """A receipt stops verifying once the diagnosed journal is mutated."""
+    sdd = tmp_path / ".sdd"
+    journal = EventJournal("run-mut", sdd)
+    for i in range(4):
+        journal.record("tick", step=i)
+    _tamper_payload(journal.path, 1)
+
+    diagnose = runner.invoke(audit_group, _diagnose_args(sdd, keys, "run-mut", "replay"))
+    assert diagnose.exit_code == 1
+    receipts = _receipts_in(sdd)
+    assert len(receipts) == 1
+
+    _tamper_payload(journal.path, 3)
+
+    verify = runner.invoke(
+        audit_group,
+        ["diagnose", "verify", str(receipts[0]), "--sdd-dir", str(sdd), "--audit-key", str(keys["audit"])],
+    )
+    assert verify.exit_code == 1
+    assert "FAILED" in verify.output
+
+
+def test_signal_is_required(tmp_path: Path, runner: CliRunner, keys: dict[str, Path]) -> None:
+    sdd = tmp_path / ".sdd"
+    result = runner.invoke(
+        audit_group,
+        ["diagnose", "run-x", "--sign-key", str(keys["sign"]), "--sdd-dir", str(sdd)],
+    )
+    assert result.exit_code == 2
+    assert "--signal is required" in result.output
+
+
+def test_verify_missing_receipt_exits_2(tmp_path: Path, runner: CliRunner) -> None:
+    result = runner.invoke(
+        audit_group, ["diagnose", "verify", str(tmp_path / "nope.json"), "--sdd-dir", str(tmp_path / ".sdd")]
+    )
+    assert result.exit_code == 2
+    assert "Receipt not found" in result.output

--- a/tests/unit/core/replay/test_diagnosis_receipt.py
+++ b/tests/unit/core/replay/test_diagnosis_receipt.py
@@ -213,6 +213,27 @@ def test_tampered_journal_after_culprit_fails_verification(tmp_path: Path) -> No
     assert not outcome.ok
 
 
+def test_garbage_line_injected_into_journal_rejected_on_verify(tmp_path: Path) -> None:
+    """A receipt stops verifying once any unparsable line enters the journal:
+    the exact-bytes pin catches it first, and the strict diagnostic loader
+    refuses the filtered sequence regardless (bot-ack: 3705961185)."""
+    journal_path = _seed(tmp_path)
+    priv, _pub = _write_keypair(tmp_path, "signer")
+    receipt = _build(tmp_path, journal_path, priv)
+    assert receipt.receipt_path is not None
+
+    with journal_path.open("a", encoding="utf-8") as f:
+        f.write("{torn trailing write\n")
+
+    outcome = verify_diagnosis_receipt(receipt.receipt_path, journal_path=journal_path, audit_key=AUDIT_KEY)
+    assert not outcome.ok
+
+    from bernstein.core.replay.diagnose import DiagnoseError
+
+    with pytest.raises(DiagnoseError, match="unparsable line"):
+        diagnose_run(journal_path, _predicate(), run_id="run-1")
+
+
 def test_absent_journal_fails_verification(tmp_path: Path) -> None:
     journal_path = _seed(tmp_path)
     priv, _pub = _write_keypair(tmp_path, "signer")

--- a/tests/unit/core/replay/test_diagnosis_receipt.py
+++ b/tests/unit/core/replay/test_diagnosis_receipt.py
@@ -1,0 +1,246 @@
+"""Unit tests for ``core.replay.diagnosis_receipt`` (#2928).
+
+Covers the acceptance criteria of the signed diagnosis receipt: empirical
+byte-identity across independent invocations, offline verification via
+Ed25519 + operator HMAC + full re-derivation, and tamper collapse for both
+the receipt and the underlying journal.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from bernstein.core.persistence.lineage_signer import (
+    Ed25519FileKeySigner,
+    Ed25519PublicKeyVerifier,
+)
+from bernstein.core.replay.diagnose import SignalPredicate, diagnose_run
+from bernstein.core.replay.diagnose_signals import replay_signal
+from bernstein.core.replay.diagnosis_receipt import (
+    DiagnosisReceiptError,
+    build_diagnosis_receipt,
+    verify_diagnosis_receipt,
+)
+from bernstein.core.replay.diff import REASON_CODE_FIRST_FAILING_TOOL_RESULT
+from bernstein.core.replay.journal import EventJournal
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+AUDIT_KEY = b"unit-test-audit-hmac-key-32bytes"
+BAD_HASH = hashlib.sha256(b"the-offending-content").hexdigest()
+
+
+def _write_keypair(tmp_path: Path, name: str) -> tuple[Path, Path]:
+    """Write a fresh Ed25519 keypair; returns (private_pem, public_pem)."""
+    private = Ed25519PrivateKey.generate()
+    priv_path = tmp_path / f"{name}-priv.pem"
+    pub_path = tmp_path / f"{name}-pub.pem"
+    priv_path.write_bytes(
+        private.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        )
+    )
+    pub_path.write_bytes(
+        private.public_key().public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+    )
+    return priv_path, pub_path
+
+
+def _predicate() -> SignalPredicate:
+    return SignalPredicate(
+        predicate_id="incident/v1",
+        params={"kind": "incident", "case_id": "inc-x", "needles": [BAD_HASH]},
+        default_reason_code=REASON_CODE_FIRST_FAILING_TOOL_RESULT,
+        needles=(BAD_HASH,),
+    )
+
+
+def _seed(tmp_path: Path, run_id: str = "run-1", *, bad_step: int = 2) -> Path:
+    sdd = tmp_path / ".sdd"
+    journal = EventJournal(run_id, sdd)
+    for i in range(5):
+        if i == bad_step:
+            journal.record("tool_result", step=i, content_hash=f"sha256:{BAD_HASH}")
+        else:
+            journal.record("tick", step=i)
+    return journal.path
+
+
+def _tamper_payload(journal_path: Path, index: int) -> None:
+    lines = journal_path.read_text(encoding="utf-8").splitlines()
+    row = json.loads(lines[index])
+    row["step"] = "tampered"
+    lines[index] = json.dumps(row, default=str)
+    journal_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _build(tmp_path: Path, journal_path: Path, signer_path: Path, *, write: bool = True):
+    result = diagnose_run(journal_path, _predicate(), run_id="run-1")
+    return build_diagnosis_receipt(
+        result,
+        chain_head_hmac="head-hmac-anchor",
+        signer=Ed25519FileKeySigner.from_path(signer_path),
+        audit_key=AUDIT_KEY,
+        output_dir=tmp_path / "evidence" if write else None,
+        write=write,
+    )
+
+
+def test_diagnosis_is_byte_identical_across_invocations(tmp_path: Path) -> None:
+    """Two independent invocations over the same journal produce identical
+    receipt bytes, culprit fields, predicate hash, and receipt sha256."""
+    journal_path = _seed(tmp_path)
+    priv, _pub = _write_keypair(tmp_path, "signer")
+
+    first = _build(tmp_path, journal_path, priv, write=False)
+    second = _build(tmp_path, journal_path, priv, write=False)
+
+    assert first.receipt_bytes == second.receipt_bytes
+    assert first.sha256 == second.sha256
+    assert first.receipt_hash == second.receipt_hash
+    assert first.receipt["culprit_index"] == second.receipt["culprit_index"] == 2
+    assert first.receipt["culprit_step_hash"] == second.receipt["culprit_step_hash"]
+    assert first.receipt["predicate_hash"] == second.receipt["predicate_hash"]
+
+
+def test_diagnosis_receipt_survives_offline_verification(tmp_path: Path) -> None:
+    """Build -> write -> verify with pinned public key + audit key: ok."""
+    journal_path = _seed(tmp_path)
+    priv, pub = _write_keypair(tmp_path, "signer")
+
+    receipt = _build(tmp_path, journal_path, priv)
+    assert receipt.receipt_path is not None
+    assert receipt.receipt_path.is_file()
+
+    outcome = verify_diagnosis_receipt(
+        receipt.receipt_path,
+        journal_path=journal_path,
+        verifier=Ed25519PublicKeyVerifier.from_path(pub),
+        audit_key=AUDIT_KEY,
+    )
+    assert outcome.ok, outcome.reason
+    assert outcome.hmac_checked is True
+
+
+def test_verification_without_audit_key_reports_hmac_unchecked(tmp_path: Path) -> None:
+    journal_path = _seed(tmp_path)
+    priv, pub = _write_keypair(tmp_path, "signer")
+    receipt = _build(tmp_path, journal_path, priv)
+    assert receipt.receipt_path is not None
+
+    outcome = verify_diagnosis_receipt(
+        receipt.receipt_path,
+        journal_path=journal_path,
+        verifier=Ed25519PublicKeyVerifier.from_path(pub),
+        audit_key=None,
+    )
+    assert outcome.ok
+    assert outcome.hmac_checked is False
+
+
+def test_receipt_signature_round_trips_and_wrong_key_fails(tmp_path: Path) -> None:
+    """The embedded key verifies; a pinned wrong key is rejected."""
+    journal_path = _seed(tmp_path)
+    priv, _pub = _write_keypair(tmp_path, "signer")
+    _wrong_priv, wrong_pub = _write_keypair(tmp_path, "wrong")
+    receipt = _build(tmp_path, journal_path, priv)
+    assert receipt.receipt_path is not None
+
+    embedded = verify_diagnosis_receipt(receipt.receipt_path, journal_path=journal_path, audit_key=AUDIT_KEY)
+    assert embedded.ok, embedded.reason
+
+    wrong = verify_diagnosis_receipt(
+        receipt.receipt_path,
+        journal_path=journal_path,
+        verifier=Ed25519PublicKeyVerifier.from_path(wrong_pub),
+        audit_key=AUDIT_KEY,
+    )
+    assert not wrong.ok
+    assert "signature" in wrong.reason
+
+
+def test_tampered_receipt_rejected(tmp_path: Path) -> None:
+    """Any mutated body field breaks the content address."""
+    journal_path = _seed(tmp_path)
+    priv, _pub = _write_keypair(tmp_path, "signer")
+    receipt = _build(tmp_path, journal_path, priv)
+    assert receipt.receipt_path is not None
+
+    raw = json.loads(receipt.receipt_path.read_text(encoding="utf-8"))
+    raw["culprit_index"] = 0  # point the finger elsewhere
+    receipt.receipt_path.write_text(json.dumps(raw, sort_keys=True), encoding="utf-8")
+
+    outcome = verify_diagnosis_receipt(receipt.receipt_path, journal_path=journal_path, audit_key=AUDIT_KEY)
+    assert not outcome.ok
+    assert "does not recompute" in outcome.reason
+
+
+def test_tampered_journal_at_culprit_fails_verification(tmp_path: Path) -> None:
+    """A journal mutated at the culprit step no longer verifies the receipt."""
+    journal_path = _seed(tmp_path, bad_step=2)
+    priv, _pub = _write_keypair(tmp_path, "signer")
+    receipt = _build(tmp_path, journal_path, priv)
+    assert receipt.receipt_path is not None
+
+    _tamper_payload(journal_path, 2)
+
+    outcome = verify_diagnosis_receipt(receipt.receipt_path, journal_path=journal_path, audit_key=AUDIT_KEY)
+    assert not outcome.ok
+
+
+def test_tampered_journal_after_culprit_fails_verification(tmp_path: Path) -> None:
+    """A journal mutated after the culprit step also fails verification."""
+    journal_path = _seed(tmp_path, bad_step=2)
+    priv, _pub = _write_keypair(tmp_path, "signer")
+    receipt = _build(tmp_path, journal_path, priv)
+    assert receipt.receipt_path is not None
+
+    _tamper_payload(journal_path, 4)
+
+    outcome = verify_diagnosis_receipt(receipt.receipt_path, journal_path=journal_path, audit_key=AUDIT_KEY)
+    assert not outcome.ok
+
+
+def test_absent_journal_fails_verification(tmp_path: Path) -> None:
+    journal_path = _seed(tmp_path)
+    priv, _pub = _write_keypair(tmp_path, "signer")
+    receipt = _build(tmp_path, journal_path, priv)
+    assert receipt.receipt_path is not None
+
+    journal_path.unlink()
+
+    outcome = verify_diagnosis_receipt(receipt.receipt_path, journal_path=journal_path, audit_key=AUDIT_KEY)
+    assert not outcome.ok
+    assert "absent" in outcome.reason
+
+
+def test_clean_diagnosis_refuses_a_receipt(tmp_path: Path) -> None:
+    """A clean (no-culprit) diagnosis emits no receipt, by contract."""
+    sdd = tmp_path / ".sdd"
+    journal = EventJournal("run-clean", sdd)
+    journal.record("tick", step=0)
+    priv, _pub = _write_keypair(tmp_path, "signer")
+
+    result = diagnose_run(journal.path, replay_signal(), run_id="run-clean")
+    assert result.located is False
+
+    with pytest.raises(DiagnosisReceiptError, match="no culprit"):
+        build_diagnosis_receipt(
+            result,
+            chain_head_hmac="head",
+            signer=Ed25519FileKeySigner.from_path(priv),
+            audit_key=AUDIT_KEY,
+            output_dir=tmp_path / "evidence",
+        )


### PR DESCRIPTION
# User description
## What

`bernstein audit diagnose <run_id> --signal <gate[:HASH]|artefact:PATH|incident:ID|replay>` names the exact first faulty step of a single run from its Merkle-chained journal and seals the finding into an Ed25519-signed, content-addressed diagnosis receipt; `bernstein audit diagnose verify <receipt>` re-derives the culprit offline and asserts byte-identity.

Closes #2928

## Why

The per-run journal already records every tool call, tool result, provider-state mutation, and knob selection as a hash-addressed step, but no command reads the culprit out of it. `verify_journal` finds chain breaks (silent on a run that recorded cleanly and still went wrong), `diff_event_logs` needs a known-good twin, and `replay --from-step N` makes the operator bisect by hand. Root-causing a red gate or a tainted artefact should be a lookup with a signed answer over the record we already trust — not log-scrolling.

## How

- **Locator** (`src/bernstein/core/replay/diagnose.py`): `diagnose_run(journal_path, predicate)` scans verified journal rows for the minimal index at which the predicate first holds and reports `culprit_index` + the stored `event_hash` at that step, bound to a head recomputed over the whole file — the index-plus-entry-hash-plus-signed-head shape transparency-log verifiers use, so an independent holder of the journal re-derives the identical finding. Fail-closed: missing/empty journal, chain-broken journal under a content signal, or an unlocatable signal all refuse; no heuristic fallback exists.
- **Signal adapters** (`diagnose_signals.py`): `gate` (rejecting `VerdictReceipt` content hashes from `.sdd/eval/gate`), `artefact:PATH` (taint projection over the signed lineage log via `taint_for_artefact`/`effective_trust`, with the content-addressed parent chain attached as `lineage_path`), `incident:ID` (exact recorded failure text of a synthesised case; refuses when the bytes never appear), `replay` (chain-break localisation via `verify_journal`). Each is a pure function of on-disk records; the resolved params are embedded in the receipt so the verifier reconstructs the identical predicate with no store reads.
- **Receipt** (`diagnosis_receipt.py`): reuses the audit-receipt canonical JSON, the lineage Ed25519 signer (RFC 8032 deterministic), and an operator HMAC under the audit key, plus the current audit-chain head as anchor. No wall-clock value enters the receipt, so independent invocations are byte-identical. `verify_diagnosis_receipt` checks receipt hash, signature, HMAC, exact journal bytes, and re-derives the whole diagnosis — a journal mutated at or after the culprit fails.
- **Vocabulary** (`diff.py`): additive `REASON_CODE_CHAIN_BREAK` / `REASON_CODE_FIRST_FAILING_TOOL_RESULT` / `REASON_CODE_BAD_INPUT_CONTENT_HASH`, so single-run diagnosis and two-run diff stay single-sourced; existing codes untouched (pinned by test).
- **CLI** (`audit_cmd.py`): append-only `diagnose` verb on the existing audit group (run + `verify` dispatch, mirroring the established `replay` pseudo-group pattern); `main.py` untouched.

**Alternative rejected:** the issue sketched a binary bisection over `rebuild_state(path, from_step=N)` prefixes. I implemented a linear first-index scan over chain-verified raw rows instead, for three reasons: `rebuild_state`'s projection carries only `{step_count, head_hash, event types}` — no payload content — so any content predicate must read the raw rows regardless; bisection is only sound for monotone predicates, while a linear scan is correct for arbitrary ones; and both cost one full read of a file that must be chain-verified end-to-end anyway, so the scan is equally deterministic with strictly fewer correctness preconditions. Two smaller honest deviations: the incident adapter defines its fingerprint as the case's exact recorded failure text (no fingerprint API existed in `incident_synthesizer.py`) and refuses when those bytes never appear in the journal; and the operator runbook landed as `docs/operations/audit-diagnose.md` rather than a general `docs/operations/audit.md`, which would have duplicated `docs/security/audit-log.md`.

## Checklist

- [x] `uv run ruff check src/` passes (`ruff check .` and `ruff format --check .` both clean)
- [x] `uv run pyright src/` passes for every file this PR adds or touches (0 errors on the three new modules under the repo config); both gated zones pass (`pyright --project pyrightconfig.strict.json`, `mypy --config-file mypy.gate.ini`); the repo-wide advisory backlog outside this PR is unchanged
- [x] `uv run python scripts/run_tests.py -x` equivalent: every added/touched test file run per-file in isolation (40 new tests pass: 22 + 9 + 9), plus the existing consumers of the touched modules (`test_replay.py`, `test_provider_state_journal.py`, `test_replay_gateway.py`, `core/replay/test_fork.py`, `test_audit.py`, `test_audit_receipt_cmd.py`) — all green; full suite runs in CI shards
- [x] New code has type hints (mypy `--follow-imports=silent` clean on all three new modules)

### Documentation duty (every PR that touches a feature)

- [x] User-visible README section updated ("prove a run" now includes `audit diagnose`)
- [x] `docs/operations/audit-diagnose.md` added (operator runbook: signals, receipt fields, worked example, fail-closed contract); `docs/security/audit-log.md` gained a "Diagnosing a run" section + cross-reference
- [x] `docs/api/` N/A — no HTTP/API schema changed (CLI + core modules only)
- [x] `uv run bernstein agents-md verify --workdir .` passes with all 14 files in sync (the generated maps list `core/replay/` at directory granularity, so the new modules introduce no drift; `scripts/gen_distribution_manifests.py --check` also clean)
- [x] Tests cover the documented behaviour: `tests/unit/core/replay/test_diagnose.py`, `test_diagnosis_receipt.py`, `test_diagnose_cli.py` — culprit naming, first-of-repeated minimality, byte-identity, offline verification, wrong-key rejection, receipt tamper, journal tamper at and after the culprit, strip-the-substrate (missing/blanked journal and missing HMAC key exit non-zero with zero receipts), reason-code backward compatibility

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add <code>bernstein audit diagnose</code> to <code>audit_cmd</code> and the replay diagnostics core so operators can name the first faulty step of a single run from its Merkle-chained journal. Seal the finding into a signed diagnosis receipt in <code>diagnosis_receipt</code> and update the operator docs and README to explain offline verification.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3388?tool=ast&topic=Receipt+verify>Receipt verify</a>
        </td><td>Build signed diagnosis receipts in <code>diagnosis_receipt</code> and wire <code>audit diagnose verify</code> to re-derive the culprit offline with Ed25519, HMAC, and journal-byte checks.<details><summary>Modified files (3)</summary><ul><li>src/bernstein/cli/commands/audit_cmd.py</li>
<li>src/bernstein/core/replay/diagnosis_receipt.py</li>
<li>tests/unit/core/replay/test_diagnosis_receipt.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>noreply@anthropic.com</td><td>fix(replay): gate the ...</td><td>August 03, 2026</td></tr>
<tr><td>alex@alexchernysh.com</td><td>feat(audit): add audit...</td><td>August 03, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3388?tool=ast&topic=Run+diagnosis>Run diagnosis</a>
        </td><td>Add single-run fault localization by teaching <code>diagnose_run</code>, <code>diagnose_signals</code>, and <code>journal.load_events</code> to resolve failure signals, scan verified journal rows, and fail closed on malformed records.<details><summary>Modified files (10)</summary><ul><li>README.md</li>
<li>docs/operations/audit-diagnose.md</li>
<li>docs/security/audit-log.md</li>
<li>src/bernstein/cli/commands/audit_cmd.py</li>
<li>src/bernstein/core/replay/diagnose.py</li>
<li>src/bernstein/core/replay/diagnose_signals.py</li>
<li>src/bernstein/core/replay/diff.py</li>
<li>src/bernstein/core/replay/journal.py</li>
<li>tests/unit/core/replay/test_diagnose.py</li>
<li>tests/unit/core/replay/test_diagnose_cli.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>noreply@anthropic.com</td><td>fix(replay): gate the ...</td><td>August 03, 2026</td></tr>
<tr><td>alex@alexchernysh.com</td><td>feat(audit): add audit...</td><td>August 03, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3388?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>