### PR TITLE
chore(ci): ratchet coverage baseline up to 82.81%

### DIFF
--- a/.coverage-baseline.json
+++ b/.coverage-baseline.json
@@ -1,5 +1,5 @@
 {
   "diff_coverage_floor_percent": 85,
-  "total_coverage_percent": 82.71,
-  "updated_at": "2026-08-01T14:35:09+00:00"
+  "total_coverage_percent": 82.81,
+  "updated_at": "2026-08-04T06:14:04+00:00"
 }


### PR DESCRIPTION
# User description
Total line coverage rose on `main`, so the monotonic ratchet
bumped the committed high-water mark in `.coverage-baseline.json`
to **82.81%**.

From here, any later push whose total coverage falls below this
mark is flagged by the LEVEL 2 ratchet. The gate stays advisory
until promoted; see `docs/operations/coverage-ratchet.md`.

Generated by `.github/workflows/coverage-ratchet.yml`.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Bump the coverage ratchet baseline in <code>.coverage-baseline.json</code> to 82.81% to match the higher total coverage on <code>main</code>. Keep the <code>coverage-ratchet</code> gate aligned with the new high-water mark so later regressions are flagged by the LEVEL 2 check.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>chernistry</td><td>chore(ci): ratchet cov...</td><td>August 04, 2026</td></tr>
<tr><td>github-actions[bot]</td><td>chore(ci): ratchet cov...</td><td>July 25, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3392?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

---

<!-- bot-ack: 3707625660 reason=Baseline provenance is a ratchet-workflow design gap, not a defect in this generated one-line bump. The committed 82.81 was verified directly against the coverage-report artifact of CI run 30886183592 (head_sha 11eb64d1, current main tip): Cobertura root line-rate 0.8281, lines-covered 193411 of lines-valid 233551 = 82.8132%, which rounds to 82.81. Pinning run resolution to a matching head_sha and adding provenance fields to the baseline schema are tracked as a separate change to coverage-ratchet.yml. -->
