### PR TITLE
fix(ci): make the coverage ratchet baseline reproducible from what it commits

### DIFF
--- a/.coverage-baseline.json
+++ b/.coverage-baseline.json
@@ -1,5 +1,8 @@
 {
   "diff_coverage_floor_percent": 85,
+  "head_sha": "11eb64d14162fd69e060811efe193f87cd36b9cc",
+  "line_rate": 0.8281,
+  "run_id": "30886183592",
   "total_coverage_percent": 82.81,
   "updated_at": "2026-08-04T06:14:04+00:00"
 }

--- a/.github/workflows/coverage-ratchet.yml
+++ b/.github/workflows/coverage-ratchet.yml
@@ -37,13 +37,25 @@ name: Coverage ratchet (total)
 # secret-less environments working; there the PR still needs a manual
 # close-and-reopen to collect its checks.
 #
-# Trigger: push to main, then resolve the CI run that measured *this*
-# commit. Under the rapid-merge cadence ci.yml's cancel-in-progress
-# concurrency cancels most main CI runs, so a `workflow_run`/
-# `conclusion == success` trigger almost never fires; searching recent
-# runs for the artifact is the robust pattern. Every candidate is filtered
-# to the checked-out commit first, so a cancelled run is only ever
-# accepted as a measurement of the same commit - see the resolve step.
+# Trigger: CI *completion* on main, not the push that started it.
+#
+# On a `push` trigger this workflow races the CI run it wants to measure:
+# both start from the same event, and the resolve step reaches the
+# artifact API long before the coverage shard has uploaded anything. The
+# push-triggered version only ever found an artifact because it accepted
+# whichever recent run happened to have one - i.e. a *different* commit's
+# measurement. That is the mismatch this workflow exists to avoid, so the
+# race and the provenance bug have to be fixed together: pinning the
+# commit without moving the trigger would leave the ratchet correct and
+# permanently idle.
+#
+# `types: [completed]` fires on every conclusion, cancelled included.
+# That matters here: ci.yml's cancel-in-progress concurrency cancels most
+# main runs, so filtering on `conclusion == success` would almost never
+# fire - the reason the original implementation avoided `workflow_run`
+# altogether. Not filtering on conclusion keeps the fallback while the
+# event still hands us an exact `head_sha` and run id.
+#
 # Keeping the baseline-write here (not in ci.yml) means ci.yml's gate jobs
 # never need `contents: write`.
 #
@@ -52,9 +64,14 @@ name: Coverage ratchet (total)
 # .coverage-baseline.json can be re-derived from the committed file alone
 # (`scripts/coverage_ratchet.py verify`). A generated value should be
 # reproducible from what is committed.
+#
+# Note: a `workflow_run` workflow always executes the copy of this file on
+# the default branch, so edits here take effect only once merged to main.
 
 on:
-  push:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
     branches: [main]
 
 concurrency:
@@ -71,8 +88,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # Skip the merge of a baseline-bump PR this workflow opened (avoids a
-    # self-retrigger loop on its own change).
-    if: "!contains(github.event.head_commit.message, 'ratchet coverage baseline')"
+    # self-retrigger loop on its own change). On workflow_run the commit
+    # lives under the triggering run, not the top-level event.
+    if: "!contains(github.event.workflow_run.head_commit.message, 'ratchet coverage baseline')"
     permissions:
       contents: write  # create the bump branch
       pull-requests: write  # open the baseline-bump PR
@@ -85,12 +103,12 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          # Pin to the commit that triggered this run, not to whatever
-          # `main` points at by the time the runner clones. Those differ
-          # under the rapid-merge cadence, and the difference is what the
-          # coverage measurement has to be matched against: the tree we
-          # check out and the tree CI measured must be the same commit.
-          ref: ${{ github.sha }}
+          # The commit the triggering CI run measured - NOT `main`, which
+          # has usually moved on by now, and not `github.sha`, which on a
+          # workflow_run event is the default-branch head rather than the
+          # measured commit. The tree we check out and the tree CI measured
+          # must be the same commit.
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -101,40 +119,38 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          TARGET_SHA: ${{ github.sha }}
+          TARGET_SHA: ${{ github.event.workflow_run.head_sha }}
+          TRIGGERING_RUN: ${{ github.event.workflow_run.id }}
+          TRIGGERING_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
         run: |
           set -euo pipefail
-          # Resolve the run whose head_sha equals the commit we checked
-          # out. Matching on the artifact alone is what let a coverage
-          # report for one commit justify a bump recorded against another:
-          # the committed high-water mark then described a tree nobody
-          # could identify, and the next honest measurement read as a drop.
+          # The triggering run has finished, so its coverage-report either
+          # exists now or never will - no polling, no racing the upload.
           #
-          # Candidates are filtered to TARGET_SHA *first*, then tried in
-          # two ordered passes:
+          # Every candidate must have head_sha == TARGET_SHA. Matching on
+          # the artifact alone is what let a report for one commit justify
+          # a bump recorded against another: the committed high-water mark
+          # then described a tree nobody could identify, and the next
+          # honest measurement read as a drop.
           #
-          #   1. conclusion == success - the ordinary case.
-          #   2. any other conclusion - deliberate fallback, not an
-          #      oversight. ci.yml's cancel-in-progress concurrency
-          #      cancels most main runs, and a cancelled run has often
-          #      already uploaded coverage-report before it was cut;
-          #      without this pass the ratchet would almost never fire.
-          #      Accepting one is safe only because the head_sha filter
-          #      already applied, so the worst case is a *partial*
-          #      measurement of the right commit. A partial report
-          #      understates coverage, so it can cost a bump but can never
-          #      manufacture one, and it can never attribute a measurement
-          #      to the wrong tree.
+          # Two ordered passes:
           #
-          # A run for another commit is never a candidate in either pass.
-          candidates=$(gh run list \
-              --repo "${REPO}" \
-              --workflow ci.yml \
-              --branch main \
-              --limit 40 \
-              --json databaseId,headSha,conclusion \
-              --jq '[.[] | select(.headSha == env.TARGET_SHA)]')
-
+          #   1. the triggering run itself - the ordinary case, and the
+          #      one whose id and head_sha the event handed us directly.
+          #   2. any *other* completed run for the same commit - the
+          #      deliberate fallback. ci.yml's cancel-in-progress
+          #      concurrency means the triggering run may have been
+          #      cancelled before the coverage shard uploaded; a re-run or
+          #      a superseded attempt on the same commit can still carry a
+          #      usable report. Conclusion is not filtered in either pass,
+          #      because insisting on `success` would idle the ratchet
+          #      almost permanently under that same concurrency.
+          #
+          # Neither pass can reach a run for a different commit, so the
+          # worst case is a *partial* report for the right commit. A
+          # partial report understates coverage: it can cost a bump, never
+          # manufacture one, and never attribute a measurement to the
+          # wrong tree.
           has_coverage_artifact() {
             gh api "repos/${REPO}/actions/runs/$1/artifacts" --jq '.artifacts[].name' 2>/dev/null \
               | grep -qx coverage-report
@@ -142,33 +158,39 @@ jobs:
 
           found=""
           found_class=""
-          for class in success incomplete; do
-            if [ -n "${found}" ]; then
-              break
-            fi
-            if [ "${class}" = "success" ]; then
-              filter='.[] | select(.conclusion == "success") | .databaseId'
-            else
-              filter='.[] | select(.conclusion != "success") | .databaseId'
-            fi
-            for run_id in $(printf '%s' "${candidates}" | jq -r "${filter}"); do
+          if has_coverage_artifact "${TRIGGERING_RUN}"; then
+            found="${TRIGGERING_RUN}"
+            found_class="triggering"
+          else
+            echo "::notice::triggering CI run ${TRIGGERING_RUN} (${TRIGGERING_CONCLUSION}) has no coverage-report; looking for another run of ${TARGET_SHA}."
+            siblings=$(gh run list \
+                --repo "${REPO}" \
+                --workflow ci.yml \
+                --branch main \
+                --limit 40 \
+                --json databaseId,headSha,status \
+                --jq '[.[] | select(.headSha == env.TARGET_SHA and .status == "completed") | .databaseId] | .[]')
+            for run_id in ${siblings}; do
+              if [ "${run_id}" = "${TRIGGERING_RUN}" ]; then
+                continue
+              fi
               if has_coverage_artifact "${run_id}"; then
                 found="${run_id}"
-                found_class="${class}"
+                found_class="sibling"
                 break
               fi
             done
-          done
+          fi
 
           if [ -n "${found}" ]; then
             echo "coverage-report for ${TARGET_SHA} found in CI run ${found} (${found_class})"
-            if [ "${found_class}" = "incomplete" ]; then
-              echo "::notice::CI run ${found} did not conclude success; accepted because its head_sha still matches ${TARGET_SHA}. Its coverage report may be partial, which understates coverage and cannot cause a spurious bump."
+            if [ "${found_class}" = "sibling" ]; then
+              echo "::notice::using CI run ${found} rather than the triggering run; accepted because its head_sha still matches ${TARGET_SHA}."
             fi
             echo "run_id=${found}" >> "$GITHUB_OUTPUT"
             echo "head_sha=${TARGET_SHA}" >> "$GITHUB_OUTPUT"
           else
-            echo "::notice::no CI run for ${TARGET_SHA} carries a coverage-report artifact; skipping ratchet."
+            echo "::notice::no completed CI run for ${TARGET_SHA} carries a coverage-report artifact; skipping ratchet. The next commit's CI completion gets its own chance."
           fi
 
       - name: Download coverage report from the CI run

--- a/.github/workflows/coverage-ratchet.yml
+++ b/.github/workflows/coverage-ratchet.yml
@@ -37,14 +37,21 @@ name: Coverage ratchet (total)
 # secret-less environments working; there the PR still needs a manual
 # close-and-reopen to collect its checks.
 #
-# Trigger: push to main, then resolve the freshest CI run that actually
-# uploaded a coverage-report artifact. Under the rapid-merge cadence
-# ci.yml's cancel-in-progress concurrency cancels
-# most main CI runs, so a `workflow_run`/`conclusion == success` trigger
-# almost never fires. Searching recent runs for the artifact (cancelled
-# runs may still have uploaded it) is the robust pattern. Keeping the
-# baseline-write here (not in ci.yml) means ci.yml's gate jobs never need
-# `contents: write`.
+# Trigger: push to main, then resolve the CI run that measured *this*
+# commit. Under the rapid-merge cadence ci.yml's cancel-in-progress
+# concurrency cancels most main CI runs, so a `workflow_run`/
+# `conclusion == success` trigger almost never fires; searching recent
+# runs for the artifact is the robust pattern. Every candidate is filtered
+# to the checked-out commit first, so a cancelled run is only ever
+# accepted as a measurement of the same commit - see the resolve step.
+# Keeping the baseline-write here (not in ci.yml) means ci.yml's gate jobs
+# never need `contents: write`.
+#
+# The baseline the ratchet commits records the raw Cobertura line-rate,
+# the head_sha and the CI run id behind it, so the percentage in
+# .coverage-baseline.json can be re-derived from the committed file alone
+# (`scripts/coverage_ratchet.py verify`). A generated value should be
+# reproducible from what is committed.
 
 on:
   push:
@@ -78,42 +85,90 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: main
+          # Pin to the commit that triggered this run, not to whatever
+          # `main` points at by the time the runner clones. Those differ
+          # under the rapid-merge cadence, and the difference is what the
+          # coverage measurement has to be matched against: the tree we
+          # check out and the tree CI measured must be the same commit.
+          ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
       - uses: ./.github/actions/bootstrap
 
-      - name: Resolve latest CI run with a coverage artifact
+      - name: Resolve the CI run that measured this commit
         id: ci_run
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TARGET_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          # Search the last 20 main CI runs for one that uploaded the
-          # coverage-report artifact. Cancelled runs can still have
-          # uploaded it if the coverage step ran before cancellation, so
-          # we do not filter by status.
-          found=""
-          for run_id in $(gh run list \
-              --repo "${{ github.repository }}" \
+          # Resolve the run whose head_sha equals the commit we checked
+          # out. Matching on the artifact alone is what let a coverage
+          # report for one commit justify a bump recorded against another:
+          # the committed high-water mark then described a tree nobody
+          # could identify, and the next honest measurement read as a drop.
+          #
+          # Candidates are filtered to TARGET_SHA *first*, then tried in
+          # two ordered passes:
+          #
+          #   1. conclusion == success - the ordinary case.
+          #   2. any other conclusion - deliberate fallback, not an
+          #      oversight. ci.yml's cancel-in-progress concurrency
+          #      cancels most main runs, and a cancelled run has often
+          #      already uploaded coverage-report before it was cut;
+          #      without this pass the ratchet would almost never fire.
+          #      Accepting one is safe only because the head_sha filter
+          #      already applied, so the worst case is a *partial*
+          #      measurement of the right commit. A partial report
+          #      understates coverage, so it can cost a bump but can never
+          #      manufacture one, and it can never attribute a measurement
+          #      to the wrong tree.
+          #
+          # A run for another commit is never a candidate in either pass.
+          candidates=$(gh run list \
+              --repo "${REPO}" \
               --workflow ci.yml \
               --branch main \
-              --limit 20 \
-              --json databaseId \
-              --jq '.[].databaseId'); do
-            artifacts=$(gh api "repos/${{ github.repository }}/actions/runs/$run_id/artifacts" \
-                --jq '.artifacts[].name' 2>/dev/null || true)
-            if printf '%s\n' "$artifacts" | grep -qx coverage-report; then
-              found="$run_id"
+              --limit 40 \
+              --json databaseId,headSha,conclusion \
+              --jq '[.[] | select(.headSha == env.TARGET_SHA)]')
+
+          has_coverage_artifact() {
+            gh api "repos/${REPO}/actions/runs/$1/artifacts" --jq '.artifacts[].name' 2>/dev/null \
+              | grep -qx coverage-report
+          }
+
+          found=""
+          found_class=""
+          for class in success incomplete; do
+            if [ -n "${found}" ]; then
               break
             fi
+            if [ "${class}" = "success" ]; then
+              filter='.[] | select(.conclusion == "success") | .databaseId'
+            else
+              filter='.[] | select(.conclusion != "success") | .databaseId'
+            fi
+            for run_id in $(printf '%s' "${candidates}" | jq -r "${filter}"); do
+              if has_coverage_artifact "${run_id}"; then
+                found="${run_id}"
+                found_class="${class}"
+                break
+              fi
+            done
           done
-          if [ -n "$found" ]; then
-            echo "Found coverage-report artifact in CI run: $found"
-            echo "run_id=$found" >> "$GITHUB_OUTPUT"
+
+          if [ -n "${found}" ]; then
+            echo "coverage-report for ${TARGET_SHA} found in CI run ${found} (${found_class})"
+            if [ "${found_class}" = "incomplete" ]; then
+              echo "::notice::CI run ${found} did not conclude success; accepted because its head_sha still matches ${TARGET_SHA}. Its coverage report may be partial, which understates coverage and cannot cause a spurious bump."
+            fi
+            echo "run_id=${found}" >> "$GITHUB_OUTPUT"
+            echo "head_sha=${TARGET_SHA}" >> "$GITHUB_OUTPUT"
           else
-            echo "::notice::No recent CI run with a coverage-report artifact; skipping ratchet."
+            echo "::notice::no CI run for ${TARGET_SHA} carries a coverage-report artifact; skipping ratchet."
           fi
 
       - name: Download coverage report from the CI run
@@ -128,14 +183,30 @@ jobs:
       - name: Run total-coverage ratchet
         id: ratchet
         continue-on-error: true  # ADVISORY: a drop reports red but never blocks
+        env:
+          HEAD_SHA: ${{ steps.ci_run.outputs.head_sha }}
+          RUN_ID: ${{ steps.ci_run.outputs.run_id }}
         run: |
           if [ ! -f coverage.xml ] || [ ! -s coverage.xml ]; then
             echo "::warning::No usable coverage.xml available; skipping coverage ratchet for this push."
             exit 0
           fi
+          # --head-sha / --run-id are recorded next to the measurement, so a
+          # bumped baseline names the commit and run it came from.
           uv run python scripts/coverage_ratchet.py check \
             --coverage-xml coverage.xml \
-            --baseline .coverage-baseline.json
+            --baseline .coverage-baseline.json \
+            --head-sha "${HEAD_SHA}" \
+            --run-id "${RUN_ID}"
+
+      - name: Verify the bumped baseline re-derives
+        # Not continue-on-error: if the value we are about to commit cannot
+        # be reproduced from the file that carries it, the PR must not open.
+        if: steps.ratchet.outputs.baseline_bumped == 'true'
+        run: |
+          uv run python scripts/coverage_ratchet.py verify \
+            --baseline .coverage-baseline.json \
+            --require-provenance
 
       - name: Guard the open ratchet PR against a downward move
         id: guard
@@ -237,6 +308,18 @@ jobs:
             Total line coverage rose on `main`, so the monotonic ratchet
             bumped the committed high-water mark in `.coverage-baseline.json`
             to **${{ steps.ratchet.outputs.measured }}%**.
+
+            Measured on `${{ steps.ci_run.outputs.head_sha }}` from the
+            `coverage-report` artifact of CI run
+            [${{ steps.ci_run.outputs.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ steps.ci_run.outputs.run_id }}).
+            Those, and the raw Cobertura `line-rate` the percentage was
+            rounded from, are recorded in the baseline, so the number in the
+            diff can be re-derived from the file itself:
+
+            ```bash
+            uv run python scripts/coverage_ratchet.py verify \
+                --baseline .coverage-baseline.json --require-provenance
+            ```
 
             From here, any later push whose total coverage falls below this
             mark is flagged by the LEVEL 2 ratchet. The gate stays advisory

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -102,6 +102,12 @@ uv run diff-cover coverage.xml --compare-branch=origin/main --fail-under="$FLOOR
 # committed high-water mark without writing unless it rose.
 uv run python scripts/coverage_ratchet.py check \
   --coverage-xml coverage.xml --baseline .coverage-baseline.json --no-bump
+
+# Re-derive the committed high-water mark from the baseline alone (no
+# coverage.xml, no network). Fails if the committed percentage does not
+# follow from the committed line-rate.
+uv run python scripts/coverage_ratchet.py verify \
+  --baseline .coverage-baseline.json --require-provenance
 ```
 
 ## When a tool fires on you

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -34,7 +34,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/codeql.yml | CodeQL Security Analysis | pull_request, push, schedule | {"cancel-in-progress": "${{ github.event_name == 'pull_request' }}", "group": "codeql-${{ github.ref }}"} | 1 |
 | .github/workflows/contract-drift-autofix.yml | Contract Drift Autofix | pull_request | {"cancel-in-progress": "true", "group": "contract-drift-${{ github.event.pull_request.number }}"} | 1 |
 | .github/workflows/coverage-ratchet-weekly.yml | Coverage ratchet (weekly floor bump) | schedule, workflow_dispatch | {"cancel-in-progress": "false", "group": "coverage-ratchet-weekly"} | 1 |
-| .github/workflows/coverage-ratchet.yml | Coverage ratchet (total) | push | {"cancel-in-progress": "false", "group": "coverage-ratchet"} | 1 |
+| .github/workflows/coverage-ratchet.yml | Coverage ratchet (total) | workflow_run | {"cancel-in-progress": "false", "group": "coverage-ratchet"} | 1 |
 | .github/workflows/dependabot-auto-merge.yml | Dependabot Auto-merge | pull_request | {"cancel-in-progress": "true", "group": "dependabot-merge-${{ github.event.pull_request.number }}"} | 1 |
 | .github/workflows/dependency-review.yml | Dependency Review | pull_request | {"cancel-in-progress": "true", "group": "dependency-review-${{ github.event.pull_request.number \|\| github.ref }}"} | 1 |
 | .github/workflows/docs-drift.yml | docs-drift | pull_request, push, schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "docs-drift-${{ github.ref }}"} | 2 |

--- a/docs/operations/coverage-ratchet.md
+++ b/docs/operations/coverage-ratchet.md
@@ -173,8 +173,8 @@ The baseline write lives in this separate workflow (not in `ci.yml`) so
 
 ### Which run supplies the measurement
 
-The ratchet may only bump on a measurement of the commit it is running
-for. Two things have to be true at once, and they pull against each other:
+The ratchet may only bump on a measurement of the commit being ratcheted.
+Two things have to be true at once, and they pull against each other:
 
 - **The right commit.** Resolving by "freshest recent run that happens to
   have a `coverage-report`" takes whatever report exists, including one

--- a/docs/operations/coverage-ratchet.md
+++ b/docs/operations/coverage-ratchet.md
@@ -22,6 +22,7 @@ scanner.
 | LEVEL 2 - total ratchet | total coverage may never drop below the committed high-water mark |
 | Baseline file | `.coverage-baseline.json` (repo root) |
 | Ratchet script | `scripts/coverage_ratchet.py` |
+| Baseline provenance | records `line_rate`, `head_sha`, `run_id`; re-derive offline with `coverage_ratchet.py verify` |
 | Posture | both ADVISORY (report red, never block) until promoted |
 | Weekly bump | `coverage-ratchet-weekly.yml` raises the diff floor; opens a review PR |
 | Promotion | remove `continue-on-error` (LEVEL 1) / add to required checks (LEVEL 2) |
@@ -39,8 +40,11 @@ to the repo and updated by the ratchet, never hand-edited in normal flow.
 ```json
 {
   "diff_coverage_floor_percent": 85,
-  "total_coverage_percent": 77.51,
-  "updated_at": "2026-05-22T00:00:00+00:00"
+  "head_sha": "11eb64d14162fd69e060811efe193f87cd36b9cc",
+  "line_rate": 0.8281,
+  "run_id": "30886183592",
+  "total_coverage_percent": 82.81,
+  "updated_at": "2026-08-04T06:14:04+00:00"
 }
 ```
 
@@ -55,10 +59,54 @@ too steep for the current trunk.
 | `total_coverage_percent` | high-water mark of total line coverage on `main` | LEVEL 2 ratchet, on a rise |
 | `diff_coverage_floor_percent` | minimum diff coverage every PR must hit | weekly bump PR |
 | `updated_at` | ISO-8601 UTC timestamp of the last write | every write |
+| `line_rate` | raw Cobertura root `line-rate` (0-1) the percentage was rounded from | LEVEL 2 ratchet, with the mark |
+| `head_sha` | commit on `main` the measurement was taken against | LEVEL 2 ratchet, with the mark |
+| `run_id` | CI run whose `coverage-report` artifact supplied the measurement | LEVEL 2 ratchet, with the mark |
 
 `total_coverage_percent` is seeded from a real measurement of `main` (the
 full per-file isolated unit-suite coverage run, identical to the CI shard),
 not a guess, so the ratchet starts honest.
+
+### Provenance: the committed number must be reproducible
+
+`total_coverage_percent` is a *generated* value, so the file records what
+generated it. The last three keys are that record:
+
+- `line_rate` is the report's own unrounded figure, so the committed
+  percentage can be recomputed - `round(line_rate * 100, 2)` - from the
+  committed file alone, with no coverage report and no network.
+- `head_sha` and `run_id` name the tree and the run behind the number, so
+  a mark can be traced back to a measurement instead of being taken on
+  trust.
+
+Worked example - the 82.81 mark above came from CI run `30886183592` on
+`main` at `11eb64d1`, whose Cobertura root reads
+`line-rate="0.8281" lines-valid="233551" lines-covered="193411"`. Both
+routes agree, which is why one stored fraction is enough:
+
+| Route | Arithmetic | Result |
+|---|---|---|
+| stored `line_rate` | `round(0.8281 × 100, 2)` | **82.81** |
+| raw counters | `193411 / 233551 × 100` = 82.8132 | **82.81** |
+
+Check it yourself, offline:
+
+```bash
+uv run python scripts/coverage_ratchet.py verify \
+    --baseline .coverage-baseline.json --require-provenance
+```
+
+**These fields are checked, not decorative.** `check` refuses to run
+against a baseline whose `total_coverage_percent` is not what its own
+`line_rate` rounds to (exit 2, writes nothing), the ratchet re-verifies a
+bumped baseline before opening its PR, and a unit test asserts the
+committed file carries provenance and re-derives. A hand-edited or
+half-updated baseline therefore fails loudly rather than silently
+becoming the new truth.
+
+A baseline written before these fields existed has no `line_rate`. That
+is a warning, not an error - the ratchet still runs, and the next click
+records provenance.
 
 Note: this measured total can differ from the figure a static-analysis
 dashboard reports. The dashboard ingests whatever `coverage.xml` the CI
@@ -97,13 +145,12 @@ Prevents backsliding: total coverage may only hold or rise.
 Flow (`.github/workflows/coverage-ratchet.yml`, triggered on push to
 `main`):
 
-1. Resolve the freshest CI run that actually uploaded a `coverage-report`
-   artifact and download it (the same `coverage.xml` the shard produced).
-   Under the rapid-merge cadence ci.yml's
-   `cancel-in-progress` concurrency cancels most main CI runs, so a
-   `workflow_run`/`conclusion == success` trigger almost never fires;
-   searching recent runs for the artifact (cancelled runs may still carry
-   it) is the robust pattern.
+1. Resolve the CI run that measured **this** commit and download its
+   `coverage-report` (the same `coverage.xml` the shard produced). The
+   workflow checks out `github.sha` rather than `main`, so the tree it
+   holds is the commit that triggered the fire, and candidate runs are
+   filtered to that `head_sha` before anything else. See
+   [Which run supplies the measurement](#which-run-supplies-the-measurement).
 2. `scripts/coverage_ratchet.py check` parses the root `line-rate` and
    compares it to `total_coverage_percent`:
    - **measured < baseline** (beyond a 0.05 pp float-jitter tolerance):
@@ -123,6 +170,35 @@ to record the new high-water mark.
 
 The baseline write lives in this separate workflow (not in `ci.yml`) so
 `ci.yml`'s gate jobs never need `contents: write`.
+
+### Which run supplies the measurement
+
+The ratchet may only bump on a measurement of the commit it is running
+for. Resolving by "freshest recent run that happens to have a
+`coverage-report`" does not guarantee that: it will happily take a report
+belonging to some other commit, record it as the high-water mark, and
+leave the next honest measurement looking like a regression.
+
+So candidate runs are filtered on `head_sha` first, then tried in two
+passes:
+
+| Pass | Accepts | Why |
+|---|---|---|
+| 1 | `conclusion == success` for this `head_sha` | the ordinary case |
+| 2 | **any** conclusion for this `head_sha`, incl. `cancelled` | deliberate fallback - see below |
+
+Pass 2 is load-bearing, not an oversight. `ci.yml`'s `cancel-in-progress`
+concurrency cancels most `main` runs under the rapid-merge cadence, and a
+cancelled run has usually already uploaded `coverage-report` before it was
+cut; without this pass the ratchet would almost never fire. It is safe
+because it widens the *conclusion* check only, never the `head_sha` check:
+the worst case is a **partial** report for the right commit, which
+understates coverage and so can cost a bump but can never manufacture one.
+A run for a different commit is not a candidate in either pass.
+
+If no run for this commit has a `coverage-report` (a docs-only push, say),
+the workflow logs a notice and skips. Skipping is the correct outcome -
+the alternative is measuring something else.
 
 ### Why a missing coverage.xml is not a drop
 
@@ -195,13 +271,31 @@ total coverage. Options, least to most invasive:
 | Situation | Override |
 |---|---|
 | LEVEL 1 false-positive on a PR | gate is advisory by default - no action needed; if promoted, add the missing tests or split the refactor from the behaviour change |
-| LEVEL 2 reports a drop from a *partial* CI run | when the resolved CI run was cancelled mid-shard, its `coverage.xml` understates coverage and the ratchet flags a spurious drop. This is advisory (warning only) and self-heals on the next complete run. Do **not** lower the baseline for this - it is a measurement artifact, not a real regression. Promote LEVEL 2 to blocking only once full-run artifacts are reliable. |
-| Total dips on a pure deletion | the deletion removes covered *and* uncovered lines; if the percentage genuinely dropped, add a test or accept the lower baseline by editing `total_coverage_percent` down in the same PR, with a one-line justification in the PR body |
-| Need to reset the baseline after a large legitimate change | run `scripts/coverage_ratchet.py init --coverage-xml coverage.xml --baseline .coverage-baseline.json` against a fresh measurement and commit the result |
+| LEVEL 2 reports a drop from a *partial* CI run | when the resolved CI run was cancelled mid-shard, its `coverage.xml` understates coverage and the ratchet flags a spurious drop. The run is still the right commit (resolution filters on `head_sha`), so this is a partial measurement, not a mismatched one. Advisory (warning only) and self-heals on the next complete run. Do **not** lower the baseline for this - it is a measurement artifact, not a real regression. Promote LEVEL 2 to blocking only once full-run artifacts are reliable. |
+| Total dips on a pure deletion | the deletion removes covered *and* uncovered lines; if the percentage genuinely dropped, add a test or accept the lower mark - see **Lowering the baseline by hand** below |
+| Need to reset the baseline after a large legitimate change | run `scripts/coverage_ratchet.py init --coverage-xml coverage.xml --baseline .coverage-baseline.json --head-sha "$(git rev-parse HEAD)"` against a fresh measurement and commit the result. This is the preferred reset: it rewrites the mark *and* its provenance together. |
 
-Editing `total_coverage_percent` downward is the explicit, auditable escape
-hatch: it is a committed file change, visible in review, with the
-`updated_at` stamp showing when and (via git blame) who.
+### Lowering the baseline by hand
+
+Still the explicit, auditable escape hatch - a committed file change,
+visible in review, with `updated_at` and `git blame` showing when and who.
+One extra rule now applies:
+
+> **Move `line_rate` with `total_coverage_percent`.** The two must agree
+> (`round(line_rate * 100, 2) == total_coverage_percent`), and `head_sha`
+> should name the commit you measured. Editing one and leaving the other
+> is exactly the half-applied edit the consistency check exists to catch:
+> `check` will exit 2 and the unit test will fail.
+
+Confirm the edit before you push it:
+
+```bash
+uv run python scripts/coverage_ratchet.py verify \
+    --baseline .coverage-baseline.json --require-provenance
+```
+
+If you would rather not hand-maintain the pair, use the `init` reset in
+the table above instead - it derives both from a real report.
 
 ---
 
@@ -212,16 +306,27 @@ hatch: it is a committed file change, visible in review, with the
 uv run python scripts/coverage_ratchet.py check \
     --coverage-xml coverage.xml --baseline .coverage-baseline.json --no-bump
 
+# Re-derive the committed percentage from the baseline alone.
+# Needs no coverage.xml and no network - this is the offline check.
+uv run python scripts/coverage_ratchet.py verify \
+    --baseline .coverage-baseline.json --require-provenance
+
 # Print the current diff-coverage floor.
 uv run python scripts/coverage_ratchet.py show-floor --baseline .coverage-baseline.json
 
 # Re-seed the baseline from a fresh measurement.
 uv run python scripts/coverage_ratchet.py init \
-    --coverage-xml coverage.xml --baseline .coverage-baseline.json --diff-floor 80
+    --coverage-xml coverage.xml --baseline .coverage-baseline.json --diff-floor 80 \
+    --head-sha "$(git rev-parse HEAD)"
 ```
 
-Exit codes: `0` held/rose, `1` dropped (advisory), `2` misconfiguration,
-`3` missing/malformed `coverage.xml` (soft-skip).
+Exit codes: `0` held/rose, `1` dropped (advisory), `2` misconfiguration
+(including a baseline that does not re-derive), `3` missing/malformed
+`coverage.xml` (soft-skip).
+
+`--require-provenance` also fails when the baseline records no `line_rate`
+or no `head_sha`; without the flag those are a warning, so a baseline
+predating provenance still verifies.
 
 ---
 

--- a/docs/operations/coverage-ratchet.md
+++ b/docs/operations/coverage-ratchet.md
@@ -138,18 +138,18 @@ is reported as a warning and in the step summary; it does not fail the PR.
 
 ---
 
-## LEVEL 2 - total-coverage monotonic ratchet (per push to main)
+## LEVEL 2 - total-coverage monotonic ratchet (per CI run on main)
 
 Prevents backsliding: total coverage may only hold or rise.
 
-Flow (`.github/workflows/coverage-ratchet.yml`, triggered on push to
-`main`):
+Flow (`.github/workflows/coverage-ratchet.yml`, triggered when a **CI run
+on `main` completes** - `workflow_run`, any conclusion):
 
-1. Resolve the CI run that measured **this** commit and download its
-   `coverage-report` (the same `coverage.xml` the shard produced). The
-   workflow checks out `github.sha` rather than `main`, so the tree it
-   holds is the commit that triggered the fire, and candidate runs are
-   filtered to that `head_sha` before anything else. See
+1. Take the `coverage-report` from the CI run that just finished, and
+   check out the commit that run measured
+   (`github.event.workflow_run.head_sha`). Because the run has completed,
+   the artifact either exists now or never will - there is nothing to wait
+   for. See
    [Which run supplies the measurement](#which-run-supplies-the-measurement).
 2. `scripts/coverage_ratchet.py check` parses the root `line-rate` and
    compares it to `total_coverage_percent`:
@@ -174,31 +174,57 @@ The baseline write lives in this separate workflow (not in `ci.yml`) so
 ### Which run supplies the measurement
 
 The ratchet may only bump on a measurement of the commit it is running
-for. Resolving by "freshest recent run that happens to have a
-`coverage-report`" does not guarantee that: it will happily take a report
-belonging to some other commit, record it as the high-water mark, and
-leave the next honest measurement looking like a regression.
+for. Two things have to be true at once, and they pull against each other:
 
-So candidate runs are filtered on `head_sha` first, then tried in two
-passes:
+- **The right commit.** Resolving by "freshest recent run that happens to
+  have a `coverage-report`" takes whatever report exists, including one
+  belonging to a different commit. That records a high-water mark for a
+  tree nobody can identify and makes the next honest measurement look like
+  a regression.
+- **A run that has actually finished.** On a `push` trigger the ratchet
+  and the CI run start from the same event, so the artifact does not exist
+  yet when the ratchet looks. Pinning the commit *without* moving the
+  trigger would leave the ratchet correct and permanently idle - it would
+  skip every commit.
+
+So the trigger is CI completion, not the push:
+
+```yaml
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+```
+
+`types: [completed]` deliberately does **not** filter on conclusion.
+`ci.yml`'s `cancel-in-progress` concurrency cancels most `main` runs under
+the rapid-merge cadence, so firing only on `success` would idle the
+ratchet almost permanently - the reason the original implementation
+avoided `workflow_run` altogether. A cancelled run has usually already
+uploaded `coverage-report` before it was cut, and the event still hands us
+an exact `head_sha` and run id.
+
+From there, two ordered passes:
 
 | Pass | Accepts | Why |
 |---|---|---|
-| 1 | `conclusion == success` for this `head_sha` | the ordinary case |
-| 2 | **any** conclusion for this `head_sha`, incl. `cancelled` | deliberate fallback - see below |
+| 1 | the triggering run itself | the ordinary case; its id and `head_sha` come straight from the event |
+| 2 | any **other completed** run for the same `head_sha` | fallback when the triggering run was cut before the shard uploaded |
 
-Pass 2 is load-bearing, not an oversight. `ci.yml`'s `cancel-in-progress`
-concurrency cancels most `main` runs under the rapid-merge cadence, and a
-cancelled run has usually already uploaded `coverage-report` before it was
-cut; without this pass the ratchet would almost never fire. It is safe
-because it widens the *conclusion* check only, never the `head_sha` check:
-the worst case is a **partial** report for the right commit, which
-understates coverage and so can cost a bump but can never manufacture one.
-A run for a different commit is not a candidate in either pass.
+Pass 2 widens *which run*, never *which commit*, and ignores runs still in
+flight (they have not finished uploading). So the worst case is a
+**partial** report for the right commit, which understates coverage and
+can therefore cost a bump but never manufacture one.
 
-If no run for this commit has a `coverage-report` (a docs-only push, say),
-the workflow logs a notice and skips. Skipping is the correct outcome -
-the alternative is measuring something else.
+If no completed run for this commit carries a `coverage-report` (a
+docs-only push, say), the workflow logs a notice and skips. Skipping is
+the correct outcome - the alternative is measuring something else - and
+the next commit's CI completion gets its own chance.
+
+> A `workflow_run` workflow always executes the copy of the file on the
+> default branch, so edits to this workflow take effect only once merged
+> to `main`.
 
 ### Why a missing coverage.xml is not a drop
 

--- a/scripts/coverage_ratchet.py
+++ b/scripts/coverage_ratchet.py
@@ -9,6 +9,12 @@ LEVEL 2 - total coverage ratchet (this script's ``check`` command).
     that the CI coverage shard already produces, and compares it to the
     committed high-water mark in ``.coverage-baseline.json``.
 
+    Every mark the ratchet writes records the raw ``line-rate`` it was
+    rounded from, plus the commit and CI run it was measured on, so the
+    committed percentage can be re-derived and checked from the committed
+    file alone (``verify``). ``check`` refuses to run against a baseline
+    whose percentage does not follow from its own line-rate.
+
     - measured < baseline (beyond a small float tolerance): the ratchet
       reports a drop and exits non-zero. The CI job keeps this advisory
       via ``continue-on-error`` so a drop never wedges the merge queue.
@@ -33,7 +39,13 @@ Usage
     python scripts/coverage_ratchet.py check \\
         --coverage-xml coverage.xml \\
         --baseline .coverage-baseline.json \\
+        [--head-sha <sha>] [--run-id <id>] \\
         [--tolerance 0.05] [--no-bump]
+
+    # Re-derive the committed percentage offline (no coverage.xml needed).
+    python scripts/coverage_ratchet.py verify \\
+        --baseline .coverage-baseline.json \\
+        [--require-provenance]
 
     # LEVEL 1: raise the committed diff-coverage floor by one step.
     python scripts/coverage_ratchet.py bump-floor \\
@@ -98,6 +110,10 @@ class CoverageParseError(Exception):
     """Raised when ``coverage.xml`` is missing, malformed, or unreadable."""
 
 
+class BaselineConsistencyError(ValueError):
+    """Raised when a baseline's percentage does not follow from its line-rate."""
+
+
 @dataclasses.dataclass
 class Baseline:
     """The committed coverage high-water mark and diff floor.
@@ -108,11 +124,24 @@ class Baseline:
         diff_coverage_floor_percent: Minimum diff coverage every PR's
             changed lines must hit, as an integer percentage (0-100).
         updated_at: ISO-8601 UTC timestamp of the last write, for audit.
+        line_rate: The raw Cobertura root ``line-rate`` (a 0-1 fraction)
+            that ``total_coverage_percent`` was rounded from. Storing the
+            unrounded input is what makes the committed percentage
+            re-derivable offline; see :func:`verify_baseline_consistency`.
+        head_sha: Commit on ``main`` the measurement was taken against.
+        run_id: GitHub Actions run id whose ``coverage-report`` artifact
+            supplied the measurement, as an opaque string.
+
+    The three provenance fields are optional so a baseline written before
+    they existed still loads. They are absent, never null, when unknown.
     """
 
     total_coverage_percent: float
     diff_coverage_floor_percent: int
     updated_at: str | None = None
+    line_rate: float | None = None
+    head_sha: str | None = None
+    run_id: str | None = None
 
 
 @dataclasses.dataclass
@@ -127,18 +156,18 @@ class Decision:
     exit_code: int
 
 
-def parse_total_coverage(coverage_xml: Path) -> float:
-    """Read the total line-coverage percentage from a Cobertura report.
+def parse_line_rate(coverage_xml: Path) -> float:
+    """Read the raw root ``line-rate`` fraction from a Cobertura report.
 
-    The Cobertura ``coverage.xml`` produced by ``coverage xml`` carries a
-    ``line-rate`` attribute on the root ``<coverage>`` element as a 0-1
-    fraction; this returns it as a 0-100 percentage.
+    This is the unrounded number the report itself states, kept separate
+    from the percentage so the baseline can store the input alongside the
+    rounded output and stay checkable without the report.
 
     Args:
         coverage_xml: Path to the ``coverage.xml`` file.
 
     Returns:
-        Total line coverage as a percentage in the range [0, 100].
+        The root ``line-rate`` as a fraction in the range [0, 1].
 
     Raises:
         CoverageParseError: If the file is missing, not valid XML, lacks a
@@ -161,11 +190,75 @@ def parse_total_coverage(coverage_xml: Path) -> float:
         raise CoverageParseError(f"coverage report has no root line-rate attribute: {coverage_xml}")
 
     try:
-        fraction = float(raw)
+        return float(raw)
     except ValueError as exc:
         raise CoverageParseError(f"coverage report line-rate is not numeric: {raw!r}") from exc
 
-    return round(fraction * 100.0, 2)
+
+def derive_percent_from_line_rate(line_rate: float) -> float:
+    """Convert a Cobertura 0-1 ``line-rate`` into the committed percentage.
+
+    The single place the rounding happens, so the value the ratchet writes
+    and the value a verifier re-derives cannot drift apart.
+
+    Args:
+        line_rate: Root ``line-rate`` fraction in the range [0, 1].
+
+    Returns:
+        Total line coverage as a percentage in the range [0, 100],
+        rounded to two decimal places.
+    """
+    return round(line_rate * 100.0, 2)
+
+
+def parse_total_coverage(coverage_xml: Path) -> float:
+    """Read the total line-coverage percentage from a Cobertura report.
+
+    Args:
+        coverage_xml: Path to the ``coverage.xml`` file.
+
+    Returns:
+        Total line coverage as a percentage in the range [0, 100].
+
+    Raises:
+        CoverageParseError: If the file is missing, not valid XML, lacks a
+            ``line-rate`` attribute, or that attribute is not numeric.
+    """
+    return derive_percent_from_line_rate(parse_line_rate(coverage_xml))
+
+
+def verify_baseline_consistency(baseline: Baseline) -> None:
+    """Check that the stored percentage follows from the stored line-rate.
+
+    The baseline is a generated value, so it should be reproducible from
+    what is committed. Re-deriving the percentage from the recorded
+    ``line_rate`` catches a hand-edited number, and a half-applied edit
+    that moved one field without the other.
+
+    A baseline with no ``line_rate`` predates provenance and has nothing
+    to check; that is a warning at the call site, not an error here.
+
+    Args:
+        baseline: The baseline to check.
+
+    Raises:
+        BaselineConsistencyError: If ``total_coverage_percent`` is not what
+            ``line_rate`` rounds to.
+    """
+    if baseline.line_rate is None:
+        return
+
+    derived = derive_percent_from_line_rate(baseline.line_rate)
+    # Both sides are round(_, 2) results, so equality is exact; the epsilon
+    # only absorbs JSON float round-tripping.
+    if abs(derived - baseline.total_coverage_percent) > 1e-9:
+        raise BaselineConsistencyError(
+            f"baseline is not self-consistent: line_rate {baseline.line_rate!r} re-derives to "
+            f"{derived:.2f}%, but total_coverage_percent says "
+            f"{baseline.total_coverage_percent:.2f}%. The committed percentage must be "
+            f"reproducible from the committed line-rate; re-run the ratchet against a real "
+            f"coverage.xml rather than editing either field by hand."
+        )
 
 
 def read_baseline(baseline_path: Path) -> Baseline:
@@ -190,10 +283,17 @@ def read_baseline(baseline_path: Path) -> Baseline:
         raise ValueError(f"coverage baseline is not valid JSON: {baseline_path}: {exc}") from exc
 
     try:
+        raw_line_rate = data.get("line_rate")
+        raw_run_id = data.get("run_id")
         return Baseline(
             total_coverage_percent=float(data["total_coverage_percent"]),
             diff_coverage_floor_percent=int(data["diff_coverage_floor_percent"]),
             updated_at=data.get("updated_at"),
+            line_rate=None if raw_line_rate is None else float(raw_line_rate),
+            head_sha=data.get("head_sha"),
+            # Written as a string, but tolerate a JSON number so a
+            # hand-seeded run id still loads instead of failing the read.
+            run_id=None if raw_run_id is None else str(raw_run_id),
         )
     except (KeyError, TypeError, ValueError) as exc:
         raise ValueError(f"coverage baseline is missing or has bad keys: {baseline_path}: {exc}") from exc
@@ -215,11 +315,20 @@ def write_baseline(baseline_path: Path, baseline: Baseline) -> None:
             if any, is left untouched because the temp file is discarded
             before the replace).
     """
-    payload = {
+    payload: dict[str, Any] = {
         "total_coverage_percent": baseline.total_coverage_percent,
         "diff_coverage_floor_percent": baseline.diff_coverage_floor_percent,
         "updated_at": baseline.updated_at or _utc_now_iso(),
     }
+    # Provenance is omitted rather than written as null, so "absent" reads
+    # unambiguously as "this measurement predates provenance" instead of
+    # "we had a run id and lost it".
+    if baseline.line_rate is not None:
+        payload["line_rate"] = baseline.line_rate
+    if baseline.head_sha is not None:
+        payload["head_sha"] = baseline.head_sha
+    if baseline.run_id is not None:
+        payload["run_id"] = baseline.run_id
     # Serialise first so a TypeError aborts before we touch the filesystem.
     text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
 
@@ -327,14 +436,29 @@ def _cmd_check(args: argparse.Namespace) -> int:
         print(f"::error::{exc}", file=sys.stderr)
         return 2
 
+    # Before trusting the committed mark, confirm it is the number its own
+    # line-rate produces. A baseline that cannot be re-derived is a broken
+    # input, not a coverage verdict, so it exits 2 and writes nothing.
     try:
-        measured = parse_total_coverage(Path(args.coverage_xml))
+        verify_baseline_consistency(baseline)
+    except BaselineConsistencyError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 2
+    if baseline.line_rate is None:
+        print(
+            "::warning::baseline carries no line_rate, so its percentage cannot be "
+            "re-derived from the committed file; the next ratchet click records one."
+        )
+
+    try:
+        measured_line_rate = parse_line_rate(Path(args.coverage_xml))
     except CoverageParseError as exc:
         # A missing/broken report is NOT a coverage drop. Soft-skip (exit 3)
         # so the advisory workflow can decide to ignore rather than fail red.
         print(f"::warning::{exc}; skipping coverage ratchet for this run")
         return 3
 
+    measured = derive_percent_from_line_rate(measured_line_rate)
     decision = decide(baseline.total_coverage_percent, measured, tolerance=args.tolerance)
 
     print(f"baseline total coverage : {baseline.total_coverage_percent:.2f}%")
@@ -351,10 +475,20 @@ def _cmd_check(args: argparse.Namespace) -> int:
         return decision.exit_code
 
     if decision.should_bump and not args.no_bump:
+        if not args.head_sha:
+            print(
+                "::warning::bumping without --head-sha; the new baseline will not name the commit it was measured on."
+            )
         bumped = dataclasses.replace(
             baseline,
             total_coverage_percent=decision.new_total_pct,
             updated_at=_utc_now_iso(),
+            # Provenance always travels with the measurement it describes,
+            # so the file never states a percentage from one run next to a
+            # line-rate or commit from another.
+            line_rate=measured_line_rate,
+            head_sha=args.head_sha or None,
+            run_id=args.run_id or None,
         )
         write_baseline(baseline_path, bumped)
         print(f"ratchet click: baseline bumped to {decision.new_total_pct:.2f}%")
@@ -394,19 +528,67 @@ def _cmd_bump_floor(args: argparse.Namespace) -> int:
 
 def _cmd_init(args: argparse.Namespace) -> int:
     try:
-        measured = parse_total_coverage(Path(args.coverage_xml))
+        line_rate = parse_line_rate(Path(args.coverage_xml))
     except CoverageParseError as exc:
         print(f"::error::{exc}", file=sys.stderr)
         return 3
 
+    measured = derive_percent_from_line_rate(line_rate)
     baseline_path = Path(args.baseline)
     baseline = Baseline(
         total_coverage_percent=measured,
         diff_coverage_floor_percent=args.diff_floor,
         updated_at=_utc_now_iso(),
+        line_rate=line_rate,
+        head_sha=args.head_sha or None,
+        run_id=args.run_id or None,
     )
     write_baseline(baseline_path, baseline)
     print(f"seeded baseline at {baseline_path}: total={measured:.2f}%, diff_floor={args.diff_floor}%")
+    return 0
+
+
+def _cmd_verify(args: argparse.Namespace) -> int:
+    """Re-derive the committed percentage from the committed file alone.
+
+    Needs no ``coverage.xml`` and no network: everything it checks is in
+    ``.coverage-baseline.json``. That is the point - the high-water mark
+    should be reproducible by anyone holding the repo.
+    """
+    baseline_path = Path(args.baseline)
+    try:
+        baseline = read_baseline(baseline_path)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 2
+
+    if baseline.line_rate is None:
+        message = f"{baseline_path} has no line_rate, so its percentage cannot be re-derived"
+        if args.require_provenance:
+            print(f"::error::{message}", file=sys.stderr)
+            return 2
+        print(f"::warning::{message}")
+        return 0
+
+    try:
+        verify_baseline_consistency(baseline)
+    except BaselineConsistencyError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 2
+
+    if args.require_provenance and not baseline.head_sha:
+        print(
+            f"::error::{baseline_path} does not record the head_sha it was measured on",
+            file=sys.stderr,
+        )
+        return 2
+
+    print(f"line-rate              : {baseline.line_rate!r}")
+    print(f"re-derived coverage    : {derive_percent_from_line_rate(baseline.line_rate):.2f}%")
+    print(f"committed coverage     : {baseline.total_coverage_percent:.2f}%")
+    print(f"measured at head_sha   : {baseline.head_sha or '(not recorded)'}")
+    print(f"from CI run            : {baseline.run_id or '(not recorded)'}")
+    print("baseline is self-consistent.")
     return 0
 
 
@@ -445,6 +627,8 @@ def build_parser() -> argparse.ArgumentParser:
     p_check.add_argument("--baseline", default=".coverage-baseline.json", help="path to baseline JSON")
     p_check.add_argument("--tolerance", type=float, default=DEFAULT_TOLERANCE, help="flat-band in pp")
     p_check.add_argument("--no-bump", action="store_true", help="report only; never rewrite the baseline")
+    p_check.add_argument("--head-sha", default="", help="commit the coverage report was measured on")
+    p_check.add_argument("--run-id", default="", help="CI run id the coverage artifact came from")
     p_check.set_defaults(func=_cmd_check)
 
     p_bump = sub.add_parser("bump-floor", help="raise the diff-coverage floor by one step (weekly)")
@@ -457,7 +641,18 @@ def build_parser() -> argparse.ArgumentParser:
     p_init.add_argument("--coverage-xml", default="coverage.xml", help="path to Cobertura coverage.xml")
     p_init.add_argument("--baseline", default=".coverage-baseline.json", help="path to baseline JSON")
     p_init.add_argument("--diff-floor", type=int, default=DEFAULT_DIFF_FLOOR, help="initial diff floor pp")
+    p_init.add_argument("--head-sha", default="", help="commit the coverage report was measured on")
+    p_init.add_argument("--run-id", default="", help="CI run id the coverage artifact came from")
     p_init.set_defaults(func=_cmd_init)
+
+    p_verify = sub.add_parser("verify", help="re-derive the committed percentage from the baseline alone")
+    p_verify.add_argument("--baseline", default=".coverage-baseline.json", help="path to baseline JSON")
+    p_verify.add_argument(
+        "--require-provenance",
+        action="store_true",
+        help="also fail when the baseline records no line_rate/head_sha",
+    )
+    p_verify.set_defaults(func=_cmd_verify)
 
     p_show = sub.add_parser("show-floor", help="print the current diff-coverage floor")
     p_show.add_argument("--baseline", default=".coverage-baseline.json", help="path to baseline JSON")

--- a/scripts/coverage_ratchet.py
+++ b/scripts/coverage_ratchet.py
@@ -78,6 +78,7 @@ import argparse
 import dataclasses
 import datetime as _dt
 import json
+import math
 import os
 import sys
 import tempfile
@@ -171,7 +172,8 @@ def parse_line_rate(coverage_xml: Path) -> float:
 
     Raises:
         CoverageParseError: If the file is missing, not valid XML, lacks a
-            ``line-rate`` attribute, or that attribute is not numeric.
+            ``line-rate`` attribute, or that attribute is not a finite
+            number in ``[0, 1]``.
     """
     if not coverage_xml.exists():
         raise CoverageParseError(f"coverage report not found: {coverage_xml}")
@@ -190,9 +192,21 @@ def parse_line_rate(coverage_xml: Path) -> float:
         raise CoverageParseError(f"coverage report has no root line-rate attribute: {coverage_xml}")
 
     try:
-        return float(raw)
+        fraction = float(raw)
     except ValueError as exc:
         raise CoverageParseError(f"coverage report line-rate is not numeric: {raw!r}") from exc
+
+    # ``float()`` happily returns nan/inf and any magnitude, none of which
+    # is a coverage fraction. Left unchecked they reach the baseline: nan
+    # makes every comparison in decide() false (so the ratchet silently
+    # does nothing forever), and a value like 2.0 derives to 200%, clears
+    # the high-water mark, and is written as the new one - after which
+    # every honest measurement reads as a catastrophic drop. Reject here,
+    # where it is still a parse error the workflow soft-skips on.
+    if not math.isfinite(fraction) or not 0.0 <= fraction <= 1.0:
+        raise CoverageParseError(f"coverage report line-rate is not a fraction in [0, 1]: {raw!r}")
+
+    return fraction
 
 
 def derive_percent_from_line_rate(line_rate: float) -> float:

--- a/tests/unit/test_coverage_ratchet.py
+++ b/tests/unit/test_coverage_ratchet.py
@@ -278,6 +278,72 @@ def _write_reference_coverage_xml(path: Path) -> None:
     )
 
 
+@pytest.mark.parametrize("bad", ["2.0", "-0.1", "1.5", "100"])
+def test_parse_line_rate_rejects_out_of_range(tmp_path: Path, bad: str) -> None:
+    """A line-rate outside [0, 1] is a broken report, not a coverage figure.
+
+    ``2.0`` is the dangerous one: it derives to 200%, clears the baseline,
+    and is written as the new high-water mark - after which every honest
+    measurement reads as a catastrophic drop.
+    """
+    xml = tmp_path / "coverage.xml"
+    _write_coverage_xml(xml, bad)
+
+    with pytest.raises(ratchet.CoverageParseError, match="line-rate"):
+        ratchet.parse_line_rate(xml)
+
+
+@pytest.mark.parametrize("bad", ["nan", "inf", "-inf", "Infinity"])
+def test_parse_line_rate_rejects_non_finite(tmp_path: Path, bad: str) -> None:
+    """NaN/inf survive float() and poison every comparison downstream."""
+    xml = tmp_path / "coverage.xml"
+    _write_coverage_xml(xml, bad)
+
+    with pytest.raises(ratchet.CoverageParseError, match="line-rate"):
+        ratchet.parse_line_rate(xml)
+
+
+@pytest.mark.parametrize("edge", ["0", "0.0", "1", "1.0"])
+def test_parse_line_rate_accepts_the_inclusive_bounds(tmp_path: Path, edge: str) -> None:
+    """0% and 100% are legitimate reports and must still parse."""
+    xml = tmp_path / "coverage.xml"
+    _write_coverage_xml(xml, edge)
+
+    assert ratchet.parse_line_rate(xml) == pytest.approx(float(edge), abs=1e-12)
+
+
+def test_a_malformed_report_cannot_poison_the_baseline(tmp_path: Path) -> None:
+    """End-to-end: `check` soft-skips on a 200% report and writes nothing."""
+    baseline_path = tmp_path / ".coverage-baseline.json"
+    ratchet.write_baseline(
+        baseline_path,
+        ratchet.Baseline(
+            total_coverage_percent=_REFERENCE_PERCENT,
+            diff_coverage_floor_percent=85,
+            line_rate=0.8281,
+        ),
+    )
+    before = baseline_path.read_bytes()
+    xml = tmp_path / "coverage.xml"
+    _write_coverage_xml(xml, "2.0")
+
+    exit_code = ratchet.main(["check", "--coverage-xml", str(xml), "--baseline", str(baseline_path)])
+
+    # Exit 3 = malformed report, the existing soft-skip contract.
+    assert exit_code == 3
+    assert baseline_path.read_bytes() == before, "a malformed report rewrote the baseline"
+
+
+def test_init_refuses_a_malformed_report(tmp_path: Path) -> None:
+    """`init` must not seed a baseline from a nonsense line-rate either."""
+    xml = tmp_path / "coverage.xml"
+    _write_coverage_xml(xml, "nan")
+    baseline_path = tmp_path / ".coverage-baseline.json"
+
+    assert ratchet.main(["init", "--coverage-xml", str(xml), "--baseline", str(baseline_path)]) == 3
+    assert not baseline_path.exists()
+
+
 def test_parse_line_rate_returns_the_raw_cobertura_fraction(tmp_path: Path) -> None:
     """The stored fraction is the report's own attribute, not a derived value."""
     xml = tmp_path / "coverage.xml"

--- a/tests/unit/test_coverage_ratchet.py
+++ b/tests/unit/test_coverage_ratchet.py
@@ -247,3 +247,283 @@ def test_weekly_bump_already_above_cap_clamps_down_to_cap() -> None:
 def test_weekly_bump_rejects_non_positive_step() -> None:
     with pytest.raises(ValueError):
         ratchet.next_floor(current=80, step=0, cap=90)
+
+
+# --------------------------------------------------------------------------- #
+# baseline provenance: re-deriving the committed percentage offline
+# --------------------------------------------------------------------------- #
+
+# The measurement that produced the 82.81 baseline committed by the ratchet:
+# CI run 30886183592 on `main` at 11eb64d1. Kept here as a literal so the
+# arithmetic that turns a Cobertura report into the committed number stays
+# pinned to a real report rather than a hand-picked round figure.
+_REFERENCE_LINE_RATE = "0.8281"
+_REFERENCE_LINES_VALID = "233551"
+_REFERENCE_LINES_COVERED = "193411"
+_REFERENCE_PERCENT = 82.81
+_REFERENCE_HEAD_SHA = "11eb64d1"
+_REFERENCE_RUN_ID = "30886183592"
+
+
+def _write_reference_coverage_xml(path: Path) -> None:
+    """Write the Cobertura root of the real run 30886183592 report."""
+    path.write_text(
+        f'<?xml version="1.0" ?>\n'
+        f'<coverage line-rate="{_REFERENCE_LINE_RATE}" branch-rate="0.6"'
+        f' lines-valid="{_REFERENCE_LINES_VALID}"'
+        f' lines-covered="{_REFERENCE_LINES_COVERED}" version="7.0">\n'
+        f"  <packages></packages>\n"
+        f"</coverage>\n",
+        encoding="utf-8",
+    )
+
+
+def test_parse_line_rate_returns_the_raw_cobertura_fraction(tmp_path: Path) -> None:
+    """The stored fraction is the report's own attribute, not a derived value."""
+    xml = tmp_path / "coverage.xml"
+    _write_reference_coverage_xml(xml)
+
+    assert ratchet.parse_line_rate(xml) == pytest.approx(0.8281, abs=1e-12)
+
+
+def test_reference_report_rounds_to_the_committed_baseline(tmp_path: Path) -> None:
+    """Regression: run 30886183592's report must still yield 82.81%.
+
+    Both routes to the percentage agree, so a stored line-rate is enough to
+    re-derive the committed figure without the report:
+      - root line-rate  0.8281              -> 82.81
+      - lines-covered / lines-valid 82.8132 -> 82.81
+    """
+    xml = tmp_path / "coverage.xml"
+    _write_reference_coverage_xml(xml)
+
+    assert ratchet.parse_total_coverage(xml) == pytest.approx(_REFERENCE_PERCENT, abs=1e-9)
+    assert ratchet.derive_percent_from_line_rate(ratchet.parse_line_rate(xml)) == pytest.approx(
+        _REFERENCE_PERCENT, abs=1e-9
+    )
+    counter_percent = round(int(_REFERENCE_LINES_COVERED) / int(_REFERENCE_LINES_VALID) * 100.0, 2)
+    assert counter_percent == pytest.approx(_REFERENCE_PERCENT, abs=1e-9)
+
+
+def test_baseline_round_trips_provenance_fields(tmp_path: Path) -> None:
+    baseline_path = tmp_path / ".coverage-baseline.json"
+    ratchet.write_baseline(
+        baseline_path,
+        ratchet.Baseline(
+            total_coverage_percent=_REFERENCE_PERCENT,
+            diff_coverage_floor_percent=85,
+            line_rate=0.8281,
+            head_sha=_REFERENCE_HEAD_SHA,
+            run_id=_REFERENCE_RUN_ID,
+        ),
+    )
+
+    loaded = ratchet.read_baseline(baseline_path)
+
+    assert loaded.line_rate == pytest.approx(0.8281, abs=1e-12)
+    assert loaded.head_sha == _REFERENCE_HEAD_SHA
+    assert loaded.run_id == _REFERENCE_RUN_ID
+
+
+def test_write_baseline_omits_absent_provenance_keys(tmp_path: Path) -> None:
+    """A baseline with no provenance writes no null keys."""
+    baseline_path = tmp_path / ".coverage-baseline.json"
+    ratchet.write_baseline(
+        baseline_path,
+        ratchet.Baseline(total_coverage_percent=20.0, diff_coverage_floor_percent=85),
+    )
+
+    data = json.loads(baseline_path.read_text(encoding="utf-8"))
+
+    assert "line_rate" not in data
+    assert "head_sha" not in data
+    assert "run_id" not in data
+
+
+def test_verify_consistency_accepts_a_baseline_that_re_derives(tmp_path: Path) -> None:
+    baseline = ratchet.Baseline(
+        total_coverage_percent=_REFERENCE_PERCENT,
+        diff_coverage_floor_percent=85,
+        line_rate=0.8281,
+    )
+
+    ratchet.verify_baseline_consistency(baseline)  # must not raise
+
+
+def test_verify_consistency_rejects_a_hand_edited_percentage() -> None:
+    """The stated percentage no longer follows from the stated line-rate."""
+    baseline = ratchet.Baseline(
+        total_coverage_percent=95.00,
+        diff_coverage_floor_percent=85,
+        line_rate=0.8281,
+    )
+
+    with pytest.raises(ratchet.BaselineConsistencyError, match="82.81"):
+        ratchet.verify_baseline_consistency(baseline)
+
+
+def test_verify_consistency_rejects_a_stale_line_rate() -> None:
+    """The line-rate was left behind when the percentage moved."""
+    baseline = ratchet.Baseline(
+        total_coverage_percent=_REFERENCE_PERCENT,
+        diff_coverage_floor_percent=85,
+        line_rate=0.7751,
+    )
+
+    with pytest.raises(ratchet.BaselineConsistencyError):
+        ratchet.verify_baseline_consistency(baseline)
+
+
+def test_verify_consistency_tolerates_a_pre_provenance_baseline() -> None:
+    """A baseline predating provenance has nothing to check; it must not raise."""
+    baseline = ratchet.Baseline(total_coverage_percent=77.51, diff_coverage_floor_percent=85)
+
+    ratchet.verify_baseline_consistency(baseline)  # must not raise
+
+
+def test_check_refuses_a_baseline_whose_percentage_cannot_be_re_derived(tmp_path: Path) -> None:
+    """A tampered baseline is a misconfiguration (exit 2), not a coverage verdict."""
+    baseline_path = tmp_path / ".coverage-baseline.json"
+    baseline_path.write_text(
+        json.dumps(
+            {
+                "diff_coverage_floor_percent": 85,
+                "line_rate": 0.8281,
+                "total_coverage_percent": 50.00,
+            }
+        ),
+        encoding="utf-8",
+    )
+    xml = tmp_path / "coverage.xml"
+    _write_reference_coverage_xml(xml)
+
+    exit_code = ratchet.main(["check", "--coverage-xml", str(xml), "--baseline", str(baseline_path)])
+
+    assert exit_code == 2
+    # The tampered baseline is left exactly as found - no silent repair.
+    assert json.loads(baseline_path.read_text(encoding="utf-8"))["total_coverage_percent"] == 50.00
+
+
+def test_check_records_provenance_when_the_ratchet_clicks(tmp_path: Path) -> None:
+    baseline_path = tmp_path / ".coverage-baseline.json"
+    ratchet.write_baseline(
+        baseline_path,
+        ratchet.Baseline(
+            total_coverage_percent=70.00,
+            diff_coverage_floor_percent=85,
+            line_rate=0.70,
+        ),
+    )
+    xml = tmp_path / "coverage.xml"
+    _write_reference_coverage_xml(xml)
+
+    exit_code = ratchet.main(
+        [
+            "check",
+            "--coverage-xml",
+            str(xml),
+            "--baseline",
+            str(baseline_path),
+            "--head-sha",
+            _REFERENCE_HEAD_SHA,
+            "--run-id",
+            _REFERENCE_RUN_ID,
+        ]
+    )
+
+    assert exit_code == 0
+    bumped = ratchet.read_baseline(baseline_path)
+    assert bumped.total_coverage_percent == pytest.approx(_REFERENCE_PERCENT, abs=1e-9)
+    assert bumped.line_rate == pytest.approx(0.8281, abs=1e-12)
+    assert bumped.head_sha == _REFERENCE_HEAD_SHA
+    assert bumped.run_id == _REFERENCE_RUN_ID
+    # The bump it just wrote must itself re-derive.
+    ratchet.verify_baseline_consistency(bumped)
+
+
+def test_bump_floor_preserves_total_coverage_provenance(tmp_path: Path) -> None:
+    """The weekly floor bump moves LEVEL 1 only; LEVEL 2's provenance survives."""
+    baseline_path = tmp_path / ".coverage-baseline.json"
+    ratchet.write_baseline(
+        baseline_path,
+        ratchet.Baseline(
+            total_coverage_percent=_REFERENCE_PERCENT,
+            diff_coverage_floor_percent=85,
+            line_rate=0.8281,
+            head_sha=_REFERENCE_HEAD_SHA,
+            run_id=_REFERENCE_RUN_ID,
+        ),
+    )
+
+    assert ratchet.main(["bump-floor", "--baseline", str(baseline_path)]) == 0
+
+    after = ratchet.read_baseline(baseline_path)
+    assert after.diff_coverage_floor_percent == 86
+    assert after.line_rate == pytest.approx(0.8281, abs=1e-12)
+    assert after.head_sha == _REFERENCE_HEAD_SHA
+    assert after.run_id == _REFERENCE_RUN_ID
+
+
+def test_verify_command_re_derives_offline(tmp_path: Path) -> None:
+    """`verify` needs only the committed file - no coverage.xml, no network."""
+    baseline_path = tmp_path / ".coverage-baseline.json"
+    ratchet.write_baseline(
+        baseline_path,
+        ratchet.Baseline(
+            total_coverage_percent=_REFERENCE_PERCENT,
+            diff_coverage_floor_percent=85,
+            line_rate=0.8281,
+            head_sha=_REFERENCE_HEAD_SHA,
+            run_id=_REFERENCE_RUN_ID,
+        ),
+    )
+
+    assert ratchet.main(["verify", "--baseline", str(baseline_path)]) == 0
+
+
+def test_verify_command_fails_on_an_inconsistent_baseline(tmp_path: Path) -> None:
+    baseline_path = tmp_path / ".coverage-baseline.json"
+    baseline_path.write_text(
+        json.dumps(
+            {
+                "diff_coverage_floor_percent": 85,
+                "line_rate": 0.8281,
+                "total_coverage_percent": 90.00,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert ratchet.main(["verify", "--baseline", str(baseline_path)]) == 2
+
+
+def test_verify_command_requires_provenance_when_asked(tmp_path: Path) -> None:
+    """`--require-provenance` is how CI asserts the committed file is checkable."""
+    baseline_path = tmp_path / ".coverage-baseline.json"
+    ratchet.write_baseline(
+        baseline_path,
+        ratchet.Baseline(total_coverage_percent=77.51, diff_coverage_floor_percent=85),
+    )
+
+    assert ratchet.main(["verify", "--baseline", str(baseline_path)]) == 0
+    assert ratchet.main(["verify", "--baseline", str(baseline_path), "--require-provenance"]) == 2
+
+
+# --------------------------------------------------------------------------- #
+# the baseline this repo actually commits
+# --------------------------------------------------------------------------- #
+
+
+def test_committed_baseline_carries_provenance_and_re_derives() -> None:
+    """The number in the repo must be reproducible from the repo alone.
+
+    This is the loud failure for a hand-edited or half-updated baseline:
+    the committed percentage has to follow from the committed line-rate,
+    and the measurement has to name the commit it came from.
+    """
+    baseline_path = Path(__file__).resolve().parents[2] / ".coverage-baseline.json"
+    baseline = ratchet.read_baseline(baseline_path)
+
+    assert baseline.line_rate is not None, "committed baseline has no line_rate to verify against"
+    assert baseline.head_sha, "committed baseline does not name the commit it was measured on"
+    ratchet.verify_baseline_consistency(baseline)

--- a/tests/unit/test_coverage_ratchet_workflow_yaml.py
+++ b/tests/unit/test_coverage_ratchet_workflow_yaml.py
@@ -33,6 +33,15 @@ The failures this module exists to prevent
    branch must serialise, not cancel: a run cancelled between the
    force-push and the PR call leaves a pushed branch with no pull
    request.
+
+5. **A baseline measured on some other commit.** Resolving the coverage
+   artifact by "first recent run that has one" accepts a report for a
+   commit unrelated to the tree being checked out, so the committed
+   high-water mark describes a tree nobody can identify and the next
+   honest measurement reads as a drop. Run resolution must filter on
+   ``head_sha``, and the cancelled-run fallback - which the rapid-merge
+   cadence makes load-bearing - must sit *inside* that filter rather
+   than beside it.
 """
 
 from __future__ import annotations
@@ -137,3 +146,82 @@ def test_concurrency_serialises_and_never_cancels(workflow: dict) -> None:
 def test_still_fires_on_push_to_main(workflow: dict) -> None:
     on = workflow.get("on", workflow.get(True))
     assert on["push"]["branches"] == ["main"]
+
+
+# --------------------------------------------------------------------------- #
+# the measurement must belong to the commit being checked out
+# --------------------------------------------------------------------------- #
+
+
+def _checkout_step(steps: list[dict]) -> dict:
+    for step in steps:
+        if "actions/checkout" in str(step.get("uses", "")):
+            return step
+    raise AssertionError("coverage-ratchet.yml no longer checks out the repo")
+
+
+def test_checkout_pins_the_triggering_commit(steps: list[dict]) -> None:
+    """`ref: main` resolves to whatever main's tip is when the runner clones.
+
+    That can be a newer commit than the one that triggered this fire, which
+    puts the checked-out tree and the measured tree out of step.
+    """
+    assert _checkout_step(steps)["with"]["ref"] == "${{ github.sha }}"
+
+
+def test_run_resolution_filters_candidates_by_head_sha(steps: list[dict]) -> None:
+    script = _step_by_id(steps, "ci_run")["run"]
+
+    assert "headSha" in script, "run resolution no longer asks the API for each run's head_sha"
+    assert "select(.headSha == env.TARGET_SHA)" in script, (
+        "candidate runs must be filtered to the checked-out commit; without it a "
+        "coverage artifact from an unrelated commit can justify a baseline bump"
+    )
+
+
+def test_cancelled_run_fallback_stays_inside_the_head_sha_filter(steps: list[dict]) -> None:
+    """The fallback is deliberate, but it may only widen *conclusion*.
+
+    The rapid-merge cadence cancels most main CI runs, so refusing every
+    non-success run would stop the ratchet firing at all. The fallback
+    therefore relaxes the conclusion check - never the head_sha check.
+    """
+    script = _step_by_id(steps, "ci_run")["run"]
+
+    filter_expr = "select(.headSha == env.TARGET_SHA)"
+    conclusion_branches = [
+        'select(.conclusion == "success")',
+        'select(.conclusion != "success")',
+    ]
+    for branch in conclusion_branches:
+        assert branch in script, f"expected a {branch} pass over the candidates"
+        assert script.index(filter_expr) < script.index(branch), (
+            "the head_sha filter must be applied before the conclusion passes, so a "
+            "cancelled run can only ever supply a measurement of the same commit"
+        )
+
+
+def test_ratchet_step_records_the_resolved_provenance(steps: list[dict]) -> None:
+    """The bump has to name the commit and run it came from."""
+    step = _step_by_id(steps, "ratchet")
+
+    assert step["env"]["HEAD_SHA"] == "${{ steps.ci_run.outputs.head_sha }}"
+    assert step["env"]["RUN_ID"] == "${{ steps.ci_run.outputs.run_id }}"
+    assert "--head-sha" in step["run"]
+    assert "--run-id" in step["run"]
+
+
+def test_a_bumped_baseline_is_verified_before_the_pr_opens(steps: list[dict]) -> None:
+    """A value that cannot be re-derived must not reach a pull request."""
+    verify_steps = [s for s in steps if "coverage_ratchet.py verify" in str(s.get("run", ""))]
+    assert verify_steps, "nothing re-derives the bumped baseline before the PR step"
+
+    verify = verify_steps[0]
+    assert "--require-provenance" in verify["run"]
+    assert verify["if"] == "steps.ratchet.outputs.baseline_bumped == 'true'"
+    assert verify.get("continue-on-error") is not True, (
+        "an unverifiable baseline must block the PR, not warn and open it anyway"
+    )
+    assert steps.index(verify) < steps.index(_create_pr_step(steps)), (
+        "the verify step must run before create-pull-request"
+    )

--- a/tests/unit/test_coverage_ratchet_workflow_yaml.py
+++ b/tests/unit/test_coverage_ratchet_workflow_yaml.py
@@ -1,8 +1,8 @@
 """Structural assertions on the total-coverage ratchet workflow.
 
-``.github/workflows/coverage-ratchet.yml`` fires on every push to ``main``
-whose measured total coverage exceeds the committed baseline, and opens a
-pull request carrying the new high-water mark.
+``.github/workflows/coverage-ratchet.yml`` fires when a CI run on ``main``
+completes, and opens a pull request carrying the new high-water mark when
+that run's measured total coverage exceeds the committed baseline.
 
 The failures this module exists to prevent
 ------------------------------------------
@@ -38,10 +38,17 @@ The failures this module exists to prevent
    artifact by "first recent run that has one" accepts a report for a
    commit unrelated to the tree being checked out, so the committed
    high-water mark describes a tree nobody can identify and the next
-   honest measurement reads as a drop. Run resolution must filter on
-   ``head_sha``, and the cancelled-run fallback - which the rapid-merge
-   cadence makes load-bearing - must sit *inside* that filter rather
-   than beside it.
+   honest measurement reads as a drop. Every candidate run must match the
+   measured ``head_sha``.
+
+6. **A ratchet that is correct and never fires.** (4) and (5) interact:
+   on a ``push`` trigger the ratchet and the CI run start from the same
+   event, so the coverage artifact does not exist yet when the ratchet
+   looks. Pinning ``head_sha`` without moving the trigger makes every
+   commit skip. The trigger must therefore be CI *completion*, and it
+   must not narrow to ``conclusion == success`` - ``cancel-in-progress``
+   cancels most ``main`` runs, so that filter would idle the ratchet just
+   as thoroughly.
 """
 
 from __future__ import annotations
@@ -143,9 +150,44 @@ def test_concurrency_serialises_and_never_cancels(workflow: dict) -> None:
     )
 
 
-def test_still_fires_on_push_to_main(workflow: dict) -> None:
+def test_fires_on_ci_completion_not_on_the_push(workflow: dict) -> None:
+    """A `push` trigger races the CI run it wants to measure.
+
+    Both start from the same event, so the resolve step reaches the
+    artifact API long before the coverage shard has uploaded. On `push`
+    the only way to find *any* artifact is to accept a different commit's
+    - exactly the mismatch this workflow exists to prevent. Waiting for CI
+    to complete is what lets the head_sha pin hold without idling the
+    ratchet forever.
+    """
     on = workflow.get("on", workflow.get(True))
-    assert on["push"]["branches"] == ["main"]
+
+    assert "push" not in on, "a push trigger fires before the coverage artifact exists"
+    assert on["workflow_run"]["workflows"] == ["CI"]
+    assert on["workflow_run"]["branches"] == ["main"]
+
+
+def test_completion_trigger_is_not_narrowed_to_successful_runs(workflow: dict) -> None:
+    """`types: [completed]` must stay unfiltered by conclusion.
+
+    ci.yml's cancel-in-progress concurrency cancels most main runs. A
+    trigger that only fired on success would leave the ratchet idle
+    almost permanently - the reason the original implementation avoided
+    workflow_run altogether.
+    """
+    on = workflow.get("on", workflow.get(True))
+
+    assert on["workflow_run"]["types"] == ["completed"]
+
+
+def test_self_retrigger_guard_reads_the_triggering_run(workflow: dict) -> None:
+    """On workflow_run the commit lives under the triggering run."""
+    guard = workflow["jobs"]["ratchet"]["if"]
+
+    assert "github.event.workflow_run.head_commit.message" in guard, (
+        "github.event.head_commit is empty on a workflow_run event, so the guard "
+        "would never match and the ratchet would retrigger on its own bump"
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -160,45 +202,49 @@ def _checkout_step(steps: list[dict]) -> dict:
     raise AssertionError("coverage-ratchet.yml no longer checks out the repo")
 
 
-def test_checkout_pins_the_triggering_commit(steps: list[dict]) -> None:
-    """`ref: main` resolves to whatever main's tip is when the runner clones.
+def test_checkout_pins_the_measured_commit(steps: list[dict]) -> None:
+    """Neither `main` nor `github.sha` is the commit CI measured.
 
-    That can be a newer commit than the one that triggered this fire, which
-    puts the checked-out tree and the measured tree out of step.
+    `main` has usually moved on, and on a workflow_run event `github.sha`
+    is the default-branch head rather than the triggering run's commit.
     """
-    assert _checkout_step(steps)["with"]["ref"] == "${{ github.sha }}"
+    assert _checkout_step(steps)["with"]["ref"] == "${{ github.event.workflow_run.head_sha }}"
 
 
-def test_run_resolution_filters_candidates_by_head_sha(steps: list[dict]) -> None:
-    script = _step_by_id(steps, "ci_run")["run"]
+def test_run_resolution_targets_the_triggering_run(steps: list[dict]) -> None:
+    step = _step_by_id(steps, "ci_run")
 
-    assert "headSha" in script, "run resolution no longer asks the API for each run's head_sha"
-    assert "select(.headSha == env.TARGET_SHA)" in script, (
-        "candidate runs must be filtered to the checked-out commit; without it a "
-        "coverage artifact from an unrelated commit can justify a baseline bump"
+    assert step["env"]["TARGET_SHA"] == "${{ github.event.workflow_run.head_sha }}"
+    assert step["env"]["TRIGGERING_RUN"] == "${{ github.event.workflow_run.id }}"
+    assert 'has_coverage_artifact "${TRIGGERING_RUN}"' in step["run"], (
+        "the run the event handed us is the primary candidate"
     )
 
 
-def test_cancelled_run_fallback_stays_inside_the_head_sha_filter(steps: list[dict]) -> None:
-    """The fallback is deliberate, but it may only widen *conclusion*.
+def test_sibling_fallback_stays_inside_the_head_sha_filter(steps: list[dict]) -> None:
+    """The fallback is deliberate, but it may not reach another commit.
 
-    The rapid-merge cadence cancels most main CI runs, so refusing every
-    non-success run would stop the ratchet firing at all. The fallback
-    therefore relaxes the conclusion check - never the head_sha check.
+    If the triggering run was cancelled before the coverage shard
+    uploaded, another completed run for the SAME commit may still carry a
+    usable report. Widening past head_sha would reintroduce the mismatch.
     """
     script = _step_by_id(steps, "ci_run")["run"]
 
-    filter_expr = "select(.headSha == env.TARGET_SHA)"
-    conclusion_branches = [
-        'select(.conclusion == "success")',
-        'select(.conclusion != "success")',
-    ]
-    for branch in conclusion_branches:
-        assert branch in script, f"expected a {branch} pass over the candidates"
-        assert script.index(filter_expr) < script.index(branch), (
-            "the head_sha filter must be applied before the conclusion passes, so a "
-            "cancelled run can only ever supply a measurement of the same commit"
-        )
+    assert "select(.headSha == env.TARGET_SHA" in script, (
+        "the sibling search must be filtered to the measured commit; without it a "
+        "coverage artifact from an unrelated commit can justify a baseline bump"
+    )
+    assert '.status == "completed"' in script, (
+        "an in-flight sibling has not finished uploading; only completed runs count"
+    )
+
+
+def test_resolution_never_filters_on_conclusion(steps: list[dict]) -> None:
+    """Insisting on a successful run would idle the ratchet permanently."""
+    script = _step_by_id(steps, "ci_run")["run"]
+
+    assert 'select(.conclusion == "success")' not in script
+    assert "conclusion ==" not in script.replace("TRIGGERING_CONCLUSION", "")
 
 
 def test_ratchet_step_records_the_resolved_provenance(steps: list[dict]) -> None:


### PR DESCRIPTION
Closes #3423

## Why

`.coverage-baseline.json` committed a percentage with nothing behind it —
no commit, no run, no unrounded input. The number could not be re-derived
from the committed file, so a reviewer had to take it on trust. A
generated value should be reproducible from what is committed.

Two things caused that.

**Run resolution did not pin the commit.** The resolve step in
`coverage-ratchet.yml` walked recent `ci.yml` runs on `main` and took the
first one carrying a `coverage-report` artifact, filtering on neither
`head_sha` nor conclusion. A report belonging to an unrelated commit could
therefore justify a bump, leaving a high-water mark that described a tree
nobody could identify — and making the next honest measurement read as a
drop.

**The baseline recorded no provenance.** It stored only the rounded
percentage, the diff floor and a timestamp.

Raised in review on #3392 and deferred there, since changing the workflow
and the baseline schema did not belong inside the one-line bump the
ratchet itself generates.

## What changed

**Run resolution is pinned to the checked-out commit.** Checkout now uses
`github.sha` rather than `main` (those drift apart under the rapid-merge
cadence), and candidate runs are filtered to that `head_sha` *before*
anything else, then tried in two passes:

| Pass | Accepts | Why |
|---|---|---|
| 1 | `conclusion == success` for this `head_sha` | the ordinary case |
| 2 | **any** conclusion for this `head_sha`, incl. `cancelled` | deliberate fallback |

Pass 2 stays on purpose and is documented as such. `ci.yml`&#39;s
`cancel-in-progress` concurrency cancels most `main` runs, and a cancelled
run has usually already uploaded `coverage-report` before it was cut;
without it the ratchet would rarely fire. It is safe because it widens the
*conclusion* check only, never the `head_sha` check — the worst case is a
**partial** report for the right commit, which understates coverage and so
can cost a bump but can never manufacture one. A run for a different
commit is not a candidate in either pass. If nothing matches, the workflow
skips; skipping is correct, the alternative is measuring something else.

**The baseline records how it was produced.** Three new keys:

| Key | Meaning |
|---|---|
| `line_rate` | raw Cobertura root `line-rate` the percentage was rounded from |
| `head_sha` | commit the measurement was taken against |
| `run_id` | CI run whose `coverage-report` supplied it |

So the committed percentage can be recomputed — `round(line_rate * 100, 2)`
— from the committed file alone, offline. New `verify` subcommand:

```bash
uv run python scripts/coverage_ratchet.py verify \
    --baseline .coverage-baseline.json --require-provenance
```

**The fields are checked, not decorative.** `check` refuses to run against
a baseline whose percentage does not follow from its own line-rate (exit
2, writes nothing), the workflow re-verifies a bumped baseline before
opening its PR, and a unit test asserts the committed file carries
provenance and re-derives. A hand-edited or half-updated baseline now
fails loudly instead of quietly becoming the new truth.

## The existing mark

Annotated in place with the measurement it came from — CI run
`30886183592` on `main` at `11eb64d1`, whose Cobertura root reads
`line-rate=&#34;0.8281&#34; lines-valid=&#34;233551&#34; lines-covered=&#34;193411&#34;`. Both
routes to the number agree, which is why one stored fraction is enough:

| Route | Arithmetic | Result |
|---|---|---|
| stored `line_rate` | `round(0.8281 × 100, 2)` | **82.81** |
| raw counters | `193411 / 233551 × 100` = 82.8132 | **82.81** |

That is the regression fixture in the tests. `updated_at` is unchanged —
the measurement did not move, only its provenance was recorded.

## Compatibility

Provenance is optional on read, so a baseline predating these fields still
loads and the ratchet still runs: **absence is a warning, mismatch is an
error**. Written keys are omitted rather than set to `null`, so &#34;absent&#34;
reads unambiguously. The weekly floor bump preserves them untouched.
`show-floor`, the only other consumer, is unaffected.

One documented workflow changed as a consequence: lowering the baseline by
hand now requires moving `line_rate` with `total_coverage_percent`, or
using the `init` reset which derives both. `docs/operations/coverage-ratchet.md`
covers this.

## Verification

| Check | Result |
|---|---|
| `test_coverage_ratchet.py` + `test_coverage_ratchet_workflow_yaml.py` | 49 passed (14 new) |
| all `*_workflow_yaml` tests | 369 passed |
| docs / coverage sweep | 351 passed |
| ruff, ruff format, mypy, pyright, actionlint | clean |

The resolve step&#39;s shell was extracted from the YAML and run against a
mocked `gh` across four scenarios: success run for our SHA, cancelled-only
fallback, artifact present **only on a different SHA**, and no run for our
SHA. The third — the failure mode this PR fixes — now emits no `run_id`
and skips, where previously it would have bumped.