### PR TITLE
chore(ci): ratchet coverage baseline up to 82.89%

### DIFF
--- a/.coverage-baseline.json
+++ b/.coverage-baseline.json
@@ -1,5 +1,5 @@
 {
   "diff_coverage_floor_percent": 85,
-  "total_coverage_percent": 82.81,
-  "updated_at": "2026-08-04T06:14:04+00:00"
+  "total_coverage_percent": 82.89,
+  "updated_at": "2026-08-05T10:07:34+00:00"
 }


### PR DESCRIPTION
**Closed without merging — superseded by regeneration.** This bump was generated at 10:07Z by the pre-#3402 workflow: it carries no provenance fields (`line_rate`, `head_sha`, `run_id`), and its `.coverage-baseline.json` now conflicts with the five merges that landed behind it. Hand-merging the JSON would commit a high-water mark that cannot be re-derived from the committed file — exactly the irreproducibility #3402 removed. The fixed workflow's next scheduled fire regenerates the bump from current `main` with full provenance and re-verifies it before opening the PR; that PR replaces this one.

---

Total line coverage rose on `main`, so the monotonic ratchet
bumped the committed high-water mark in `.coverage-baseline.json`
to **82.89%**.

From here, any later push whose total coverage falls below this
mark is flagged by the LEVEL 2 ratchet. The gate stays advisory
until promoted; see `docs/operations/coverage-ratchet.md`.

Generated by `.github/workflows/coverage-ratchet.yml`.