### PR TITLE
fix(security): absence downgrades the identity verdict, as documented

### DIFF
--- a/docs/sdd/toolcall-attestation-interlock.md
+++ b/docs/sdd/toolcall-attestation-interlock.md
@@ -51,7 +51,14 @@ envelope whose run, agent, scope, request, arguments, intent, monotonic call
 index, frozen journal head, chain predecessor, anchor reference, key id, and
 attestation time verify against the public key frozen at spawn. Missing,
 reordered, duplicated, substituted, or mismatched evidence deterministically
-downgrades to `observed`.
+downgrades to `observed`. Absence fails closed in both shapes: an attestation
+attributed to a run whose anchor binds a tool signing key but carrying no
+envelope downgrades, and an attestation that cannot be attributed to any
+anchored run while a key-bearing identity anchor exists downgrades the same
+way — emptying `run_id` is not an escape from the per-run rule. A run whose
+anchor binds no tool key keeps its HMAC-only semantics: missing envelopes on
+its attestations do not downgrade a verdict that the chain-derived walk would
+otherwise report.
 
 ## Trust boundary
 

--- a/src/bernstein/core/security/toolcall_interlock.py
+++ b/src/bernstein/core/security/toolcall_interlock.py
@@ -217,6 +217,22 @@ def derive_attestation_verdict(events: Sequence[Mapping[str, Any]]) -> Attestati
             intent_digest = str(payload.get("intent_digest", "")).strip()
             run_id = str(payload.get("run_id", "")).strip()
             envelope = payload.get("identity_envelope")
+            if envelope is None:
+                # Absence downgrades: an identity-anchored run must carry a
+                # verified envelope on every attestation, or stripping the
+                # envelope from a retained event would silently upgrade the
+                # run to ``complete``. An attestation that cannot be
+                # attributed to any anchored run while an identity anchor
+                # exists fails closed the same way -- emptying ``run_id``
+                # must not be an escape from the per-run rule. Runs whose
+                # anchor binds no tool key keep their legacy semantics.
+                anchored = anchored_runs.get(run_id)
+                if anchored is not None and anchored.get("tool_signing_kid") is not None:
+                    return AttestationVerdict.OBSERVED
+                if anchored is None and any(
+                    prior.get("tool_signing_kid") is not None for prior in anchored_runs.values()
+                ):
+                    return AttestationVerdict.OBSERVED
             if envelope is not None:
                 if run_id not in anchored_runs or anchored_runs[run_id].get("tool_signing_kid") is None:
                     return AttestationVerdict.OBSERVED

--- a/tests/unit/security/test_toolcall_identity.py
+++ b/tests/unit/security/test_toolcall_identity.py
@@ -152,6 +152,50 @@ async def test_duplicate_dispatch_and_any_signed_binding_mutation_downgrade(tmp_
         assert derive_attestation_verdict(mutated) is AttestationVerdict.OBSERVED
 
 
+@pytest.mark.asyncio
+async def test_identity_anchored_run_downgrades_when_an_attestation_lacks_its_envelope(tmp_path: Any) -> None:
+    """Absence downgrades: stripping the envelope must never upgrade to complete."""
+    provider = _provider(tmp_path)
+    await provider.prepare_dispatch(_intent())
+    events = _events(provider)
+    assert derive_attestation_verdict(events) is AttestationVerdict.COMPLETE
+
+    stripped = deepcopy(events)
+    del stripped[-2]["details"]["identity_envelope"]
+    assert derive_attestation_verdict(stripped) is AttestationVerdict.OBSERVED
+
+
+@pytest.mark.asyncio
+async def test_unattributable_attestation_downgrades_while_an_identity_anchor_exists(tmp_path: Any) -> None:
+    """Emptying run_id is not an escape from the per-run envelope rule."""
+    provider = _provider(tmp_path)
+    await provider.prepare_dispatch(_intent())
+    events = _events(provider)
+
+    unattributable = deepcopy(events)
+    del unattributable[-2]["details"]["identity_envelope"]
+    unattributable[-2]["details"]["run_id"] = ""
+    assert derive_attestation_verdict(unattributable) is AttestationVerdict.OBSERVED
+
+
+@pytest.mark.asyncio
+async def test_legacy_run_without_envelopes_keeps_its_verdict(tmp_path: Any) -> None:
+    """A run whose anchor binds no tool key keeps HMAC-only semantics."""
+    chain = AuditChainStore(tmp_path / "audit", key=b"k" * 32)
+    private, public = generate_ed25519_keypair()
+    card = AgentIdentityCard(
+        agent_id="agent-1", role="coder", adapter="codex", model="gpt", created_at=100, expires_at=200
+    )
+    signature = sign_agent_card(card, private, kid="spawn-key")
+    IdentitySpawnAnchor(chain, {"spawn-key": public}, clock=lambda: 150).anchor(
+        run_id="run-1", card=card, signature=signature, run_journal_head="journal:fixed"
+    )
+    provider = NativeToolCallEvidenceProvider(chain)
+    await provider.prepare_dispatch(_intent())
+    events = _events(provider)
+    assert derive_attestation_verdict(events) is AttestationVerdict.COMPLETE
+
+
 def test_domain_separation_rejects_a_valid_lineage_signature() -> None:
     private, _ = generate_ed25519_keypair()
     record = ToolCallIdentityAttestation(


### PR DESCRIPTION
# User description
## What

Completes the #3420 slice's verdict-walk contract: for a run whose spawn anchor binds a tool signing key, a `toolcall.attestation` without a verified identity envelope now derives `observed`, never `complete` — and an attestation that cannot be attributed to any anchored run while an identity anchor exists downgrades the same way, so emptying `run_id` is not an escape. Runs whose anchor binds no tool key keep their HMAC-only semantics.

Partial implementation of #2931.

## Why

`derive_attestation_verdict` verified envelopes only when one was present (`if envelope is not None:`), so stripping the envelope from a retained attestation silently upgraded an identity-anchored run to `complete` — the exact evidence-stripping attack the identity slice exists to prevent, and a contradiction of the stated contract in `docs/sdd/toolcall-attestation-interlock.md` ("For an identity-anchored run, every attestation must also carry a valid signed identity envelope"). Found in the merge review of #3420 and reproduced against its head; taken over here rather than bounced back to the contributor.

## How

- `toolcall_interlock.py`: the `envelope is None` path fails closed in both shapes (attributed-to-anchored-run without envelope; unattributable while any identity anchor exists), with the legacy carve-out stated in place.
- Tests, named for the properties: `test_identity_anchored_run_downgrades_when_an_attestation_lacks_its_envelope`, `test_unattributable_attestation_downgrades_while_an_identity_anchor_exists`, `test_legacy_run_without_envelopes_keeps_its_verdict`.
- Fail-before/pass-after proven by stashing the walk change: both downgrade tests fail on the pre-fix tree; the legacy pin passes on both; 24/24 across the identity + interlock suites after.
- `docs/sdd/toolcall-attestation-interlock.md`: the chain-derived-verdict section now states both fail-closed absence paths and the keyless-anchor HMAC-only carve-out alongside the rule they refine.

## Checklist

- [x] `uv run ruff check src/` passes (changed files; format check clean)
- [ ] `uv run pyright src/` passes
- [x] `uv run python scripts/run_tests.py -x` passes (targeted: identity + interlock + native-evidence suites, 33 total)
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)

- [x] User-visible README section updated (or N/A) — N/A: verdict-walk internals
- [x] `docs/operations/<area>.md` updated (or N/A) — N/A: the SDD is the governing doc and is updated in this PR
- [x] `docs/api/` schema regenerated (or N/A) — N/A
- [x] `uv run bernstein agents-md sync` (or N/A) — N/A: no module surface change
- [x] Tests cover the documented behaviour

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Make <code>derive_attestation_verdict</code> fail closed when identity-anchored attestations lack a verified envelope or cannot be attributed to an anchored run, while preserving HMAC-only behavior for legacy runs. Document the contract in the toolcall attestation interlock and add regression tests covering both downgrade paths and the legacy carve-out.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>docs(sdd): state the a...</td><td>August 05, 2026</td></tr>
<tr><td>silentpartnerholdings@...</td><td>feat(security): bind t...</td><td>August 05, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3429?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>