### PR TITLE
feat(skills): declarative selection rules between role binding and auto-route

### DIFF
--- a/docs/operations/skill-selection-rules.md
+++ b/docs/operations/skill-selection-rules.md
@@ -1,0 +1,105 @@
+# Skill selection rules
+
+A declarative, operator-authored rule layer that selects extra skill
+templates for a spawn based on task facts. It sits between the two
+selection mechanisms that already exist in the injector
+(`src/bernstein/adapters/skills_injector.py`):
+
+- **Role binding** (`ROLE_SKILL_MAP`): deterministic role -> skill
+  mapping, always on.
+- **TF-IDF auto-route** (opt-in via `BERNSTEIN_SKILLS_AUTO_ROUTE=1`):
+  scores every template in the corpus against the task text. Useful,
+  but *corpus-coupled*: adding an unrelated template to
+  `templates/skills/` shifts document frequencies and therefore scores.
+
+Selection rules are corpus-immune. Resolution is a pure function of
+`(tasks, rules)` - no corpus statistics, no environment reads, no
+ordering sensitivity - so the same tasks and the same rule table always
+select the same templates, regardless of what else lives in the skills
+directory. Implemented in
+`src/bernstein/core/skills/selection_rules.py`.
+
+## File location
+
+The rule table is a YAML file named `selection-rules.yaml` living in the
+skills source directory, i.e. sibling of the skill templates it names:
+
+```
+templates/
+  roles/
+  skills/
+    bernstein-completion-protocol.md
+    pytest-helper.md
+    selection-rules.yaml      <- the rule table
+```
+
+Presence is checked with a single cheap stat at injection time. When the
+file is absent, the loader is never invoked and injection behaves
+exactly as if the rule layer did not exist.
+
+## Schema
+
+```yaml
+rules:
+  - owned_files: "src/api/*.py"     # REQUIRED: one glob or a list of globs
+    task_type: fix                   # optional: standard | upgrade_proposal | fix | research
+    skills:                          # skill template names (".md" suffix optional)
+      - api-conventions
+```
+
+Axes:
+
+- `owned_files` (required): fnmatch-style glob(s) matched against each
+  task's `owned_files` entries.
+- `task_type` (optional): one of the `TaskType` values (`standard`,
+  `upgrade_proposal`, `fix`, `research`), case-insensitive. When both
+  axes are present, **both must match on the same task**.
+
+There is deliberately **no `role` axis** - role -> skill binding is
+owned by `ROLE_SKILL_MAP`, and the schema rejects a `role` key at load
+so the two layers cannot drift into conflict.
+
+Multi-task semantics are a union: if any task assigned to the spawn
+matches a rule, the rule's templates are selected. Hits are
+deduplicated and ordered by rule position, then template name within a
+rule.
+
+## Fail-loud validation
+
+The loader (`load_selection_rules`) validates the table at load and
+raises `SelectionRuleError` naming the offending rule and the problem
+for:
+
+- invalid YAML or a top level that is not a `rules:` mapping;
+- unknown keys on a rule (including the rejected `role` axis);
+- a non-string / non-list `owned_files` value, or empty globs;
+- an unknown `task_type` value;
+- a rule naming a skill template that does not exist as
+  `<skills_source_dir>/<name>.md`.
+
+An empty file, `rules:`, or `rules: []` is an empty-but-valid table:
+no rules, no error.
+
+## Precedence
+
+When the same template is selected by more than one layer:
+
+```
+role-binding  >  rule  >  auto-route
+```
+
+- A template selected by both role binding and a rule is injected once
+  and keeps the `role-binding` trigger.
+- Rule-selected templates are passed to the TF-IDF auto-route as
+  excluded, so the auto-route neither re-scores nor duplicates them.
+
+## Activation log
+
+Rule-selected skills flow through the existing activation log
+(`.sdd/skills/activations.jsonl`) with `trigger_source` set to `rule`:
+
+```json
+{"skill":"pytest-helper","role":"backend","task_id":"T-42","trigger_source":"rule","...":"..."}
+```
+
+alongside the existing `role-binding` and `auto-route` trigger sources.

--- a/docs/sdd/skill-selection-rules.md
+++ b/docs/sdd/skill-selection-rules.md
@@ -1,0 +1,65 @@
+# Skill selection rules (issue #3383)
+
+## Where the layer sits
+
+Skill selection has three layers, applied in order inside
+`bernstein.adapters.skills_injector.inject_skills`:
+
+1. **Role binding** (`ROLE_SKILL_MAP`): deterministic baseline, keyed off the
+   agent role. Corpus-immune, coarse.
+2. **Selection rules** (`bernstein.core.skills.selection_rules`, this design):
+   operator-authored `templates/skills/selection-rules.yaml` mapping
+   `owned_files` globs — optionally narrowed by `task_type` — to skill
+   templates. Resolution is a pure function of `(tasks, rules)`.
+3. **TF-IDF auto-route** (opt-in, `BERNSTEIN_SKILLS_AUTO_ROUTE`): corpus-coupled
+   scoring. Rule-selected templates are passed to it as exclusions so it can
+   neither re-score nor duplicate them.
+
+Role binding wins for a template selected by more than one layer; each
+selection records its layer in the activation log (`trigger_source`:
+`role-binding`, `rule`, `auto-route`).
+
+The layer exists because the auto-route's IDF weights depend on corpus
+document frequencies: adding one unrelated template to `templates/skills/`
+can shift which skills a long-stable task receives. Rules give an operator a
+corpus-immune, task-shaped binding whose output replays identically for
+identical inputs.
+
+## Why task types are matched by token, not by enum identity
+
+The import-linter contract "Adapters must not import scheduler internals"
+forbids `bernstein.adapters` from importing `bernstein.core.tasks` — directly
+or transitively. The skill injector (adapters layer) imports this module, so
+this module must not import `bernstein.core.tasks.models.TaskType`; the
+injector's own local `Task` protocol exists for the same reason.
+
+Task types are therefore matched by their lowercase value tokens
+(`standard`, `upgrade_proposal`, `fix`, `research`): rules store the token,
+and the resolver normalizes a task's `task_type` through
+`getattr(value, "value", value)`. The restated token set cannot drift
+silently — `test_known_task_type_tokens_track_the_scheduler_enum` pins it
+against the real enum (tests import the enum freely; the contract binds
+`src/` only).
+
+Normalization fails closed: an *absent* `task_type` defaults to `standard`
+(the injector's protocol does not carry the field), but a present-yet-
+unrecognized value matches no `task_type`-scoped rule at all. Coercing an
+unknown type to `standard` would inject operator-authored skills into tasks
+that are explicitly not standard.
+
+## Containment
+
+A rule's template name is a bare file name resolved inside the skills source
+directory, never a path: absolute entries, `..` traversal, and separator
+components (posix or windows) are rejected at load. Without that, a rule
+table could point the injector at any readable file on the host and have its
+content injected as if it were a vetted template.
+
+## No-table fast path
+
+With no `selection-rules.yaml` present, behaviour is byte-identical to a
+rule-less install: a single existence stat guards the layer and the loader
+is never invoked. This is the merge-deciding property of the feature and is
+pinned by `test_no_rule_table_is_byte_identical_noop`.
+
+Operator-facing schema and examples: `docs/operations/skill-selection-rules.md`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -256,6 +256,7 @@ nav:
           - agents-md sync: agents-md.md
           - Skills catalog: operations/skills-catalog.md
           - Skill lint: operations/skill-lint.md
+          - Skill selection rules: operations/skill-selection-rules.md
           - Layered skill merge: skills/layered-merge.md
           - Agent prompt template: examples/agent-prompt-template.md
       - Memory & context:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -257,6 +257,7 @@ nav:
           - Skills catalog: operations/skills-catalog.md
           - Skill lint: operations/skill-lint.md
           - Skill selection rules: operations/skill-selection-rules.md
+          - Skill selection rules design: sdd/skill-selection-rules.md
           - Layered skill merge: skills/layered-merge.md
           - Agent prompt template: examples/agent-prompt-template.md
       - Memory & context:

--- a/src/bernstein/adapters/skills_injector.py
+++ b/src/bernstein/adapters/skills_injector.py
@@ -42,10 +42,7 @@ from bernstein.core.skills.selection_rules import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-
     from bernstein.core.skills.routing import RoutableTask
-    from bernstein.core.skills.selection_rules import RuleSelectableTask
 
     class Task(RoutableTask, Protocol):
         """Task fields used by the skill injector."""
@@ -273,12 +270,10 @@ def inject_skills(
     # Declarative selection rules (issue #3383): a corpus-immune rule layer
     # between role binding and the opt-in TF-IDF auto-route. Existence is a
     # single cheap stat - when the table is absent the loader is never
-    # invoked and behaviour is byte-identical to a rule-less install. The
-    # cast is safe: the local Task protocol lacks ``task_type``, and the
-    # resolver reads it via ``getattr`` with a ``TaskType.STANDARD`` default.
+    # invoked and behaviour is byte-identical to a rule-less install.
     if (skills_source_dir / SELECTION_RULES_FILENAME).is_file():
         rules = load_selection_rules(skills_source_dir)
-        for rule_template in resolve_rule_templates(rules, cast("Sequence[RuleSelectableTask]", tasks)):
+        for rule_template in resolve_rule_templates(rules, tasks):
             if rule_template in trigger_by_template:
                 # Role binding wins for templates selected by both layers.
                 continue

--- a/src/bernstein/adapters/skills_injector.py
+++ b/src/bernstein/adapters/skills_injector.py
@@ -35,9 +35,17 @@ from bernstein.core.skills.activation_log import (
 )
 from bernstein.core.skills.routing import auto_route_enabled, select_auto_route_templates
 from bernstein.core.skills.sanitizer import sanitize_skill_body
+from bernstein.core.skills.selection_rules import (
+    SELECTION_RULES_FILENAME,
+    load_selection_rules,
+    resolve_rule_templates,
+)
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from bernstein.core.skills.routing import RoutableTask
+    from bernstein.core.skills.selection_rules import RuleSelectableTask
 
     class Task(RoutableTask, Protocol):
         """Task fields used by the skill injector."""
@@ -261,6 +269,22 @@ def inject_skills(
 
     templates_to_inject = list(dict.fromkeys(_ALWAYS_INJECT + ROLE_SKILL_MAP.get(role, [])))
     trigger_by_template = {template_name: "role-binding" for template_name in templates_to_inject}
+
+    # Declarative selection rules (issue #3383): a corpus-immune rule layer
+    # between role binding and the opt-in TF-IDF auto-route. Existence is a
+    # single cheap stat - when the table is absent the loader is never
+    # invoked and behaviour is byte-identical to a rule-less install. The
+    # cast is safe: the local Task protocol lacks ``task_type``, and the
+    # resolver reads it via ``getattr`` with a ``TaskType.STANDARD`` default.
+    if (skills_source_dir / SELECTION_RULES_FILENAME).is_file():
+        rules = load_selection_rules(skills_source_dir)
+        for rule_template in resolve_rule_templates(rules, cast("Sequence[RuleSelectableTask]", tasks)):
+            if rule_template in trigger_by_template:
+                # Role binding wins for templates selected by both layers.
+                continue
+            templates_to_inject.append(rule_template)
+            trigger_by_template[rule_template] = "rule"
+
     if auto_route_enabled():
         for candidate in select_auto_route_templates(
             skills_source_dir,

--- a/src/bernstein/core/skills/selection_rules.py
+++ b/src/bernstein/core/skills/selection_rules.py
@@ -1,0 +1,301 @@
+"""Declarative skill-selection rules (issue #3383).
+
+A rule layer between the role map and the opt-in TF-IDF auto-route in
+:mod:`bernstein.adapters.skills_injector`. Role binding
+(``ROLE_SKILL_MAP``) stays the deterministic baseline; the TF-IDF
+auto-route is corpus-coupled - adding an unrelated template to
+``templates/skills/`` shifts document frequencies and therefore scores.
+Selection rules sit in between: an operator-authored
+``selection-rules.yaml`` maps task facts to skill templates, and
+resolution is a pure function of ``(tasks, rules)`` - no corpus
+statistics, no environment reads, no ordering sensitivity - so the same
+tasks and the same rule table always select the same templates.
+
+A rule has two axes:
+
+- ``owned_files`` (required): one glob or a list of globs, matched
+  fnmatch-style against each task's ``owned_files`` entries.
+- ``task_type`` (optional): one of the :class:`~bernstein.core.tasks.models.TaskType`
+  values (``standard``, ``upgrade_proposal``, ``fix``, ``research``).
+  When present, both axes must match on the same task.
+
+There is deliberately no ``role`` axis - role -> skill binding is owned
+by ``ROLE_SKILL_MAP`` in the injector, and the schema rejects a ``role``
+key at load so the two layers cannot drift into conflict.
+
+The rule table lives at ``<skills_source_dir>/selection-rules.yaml``,
+sibling of the skill templates it names. Validation is loud: unknown
+keys, malformed globs, unknown task types, or a rule naming a template
+that does not exist all raise :class:`SelectionRuleError` naming the
+rule and the problem. An empty-but-valid table means no rules.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fnmatch import fnmatchcase
+from typing import TYPE_CHECKING, Final, Protocol, cast
+
+import yaml
+
+from bernstein.core.tasks.models import TaskType
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+#: File name of the rule table inside the skills source directory.
+SELECTION_RULES_FILENAME: Final[str] = "selection-rules.yaml"
+
+#: Keys a rule mapping may carry. Anything else is rejected at load.
+_ALLOWED_RULE_KEYS: Final[frozenset[str]] = frozenset({"owned_files", "task_type", "skills"})
+
+#: Lowercase task-type token -> enum member, derived from the enum so the
+#: schema can never drift from :class:`TaskType`.
+_TASK_TYPE_BY_TOKEN: Final[dict[str, TaskType]] = {member.value: member for member in TaskType}
+
+
+class SelectionRuleError(ValueError):
+    """Raised when ``selection-rules.yaml`` is malformed or names a missing template."""
+
+
+class RuleSelectableTask(Protocol):
+    """The narrow slice of a task the rule layer matches against.
+
+    Deliberately not a widening of ``RoutableTask`` (which the TF-IDF
+    auto-route owns): rules read only ``owned_files`` and ``task_type``.
+    The resolver reads ``task_type`` via ``getattr`` with a
+    ``TaskType.STANDARD`` default, so callers whose task type lacks the
+    field (e.g. the injector's local ``Task`` protocol) still resolve
+    deterministically.
+    """
+
+    owned_files: list[str]
+    task_type: TaskType
+
+
+@dataclass(frozen=True)
+class SelectionRule:
+    """One validated rule: globs (+ optional task type) -> skill templates."""
+
+    owned_files: tuple[str, ...]
+    task_type: TaskType | None
+    templates: tuple[str, ...]
+
+
+def selection_rules_path(skills_source_dir: Path) -> Path:
+    """Return the rule-table path inside ``skills_source_dir``.
+
+    Callers that only need to know whether a rule table exists should
+    stat this path instead of invoking :func:`load_selection_rules` -
+    with no table present the loader must never run.
+    """
+    return skills_source_dir / SELECTION_RULES_FILENAME
+
+
+def load_selection_rules(skills_source_dir: Path) -> tuple[SelectionRule, ...]:
+    """Load and validate ``selection-rules.yaml`` from ``skills_source_dir``.
+
+    Args:
+        skills_source_dir: Directory holding the skill templates
+            (``templates/skills/``). Rule-named templates must exist here
+            as ``<name>.md``.
+
+    Returns:
+        The validated rules in file order. An empty document, ``rules:``
+        with no entries, or ``rules: []`` all yield an empty tuple.
+
+    Raises:
+        SelectionRuleError: On unreadable files, invalid YAML, wrong
+            shapes, unknown keys (including the rejected ``role`` axis),
+            unknown task types, or rules naming templates that do not
+            exist. The message names the offending rule and the problem.
+    """
+    path = selection_rules_path(skills_source_dir)
+    try:
+        raw_text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise SelectionRuleError(f"cannot read selection rules file {path}: {exc}") from exc
+
+    try:
+        loaded: object = yaml.safe_load(raw_text)
+    except yaml.YAMLError as exc:
+        raise SelectionRuleError(f"invalid YAML in selection rules file {path}: {exc}") from exc
+
+    if loaded is None:
+        return ()
+    if not isinstance(loaded, dict):
+        raise SelectionRuleError(
+            f"selection rules file {path}: top level must be a mapping with a 'rules' list, got {type(loaded).__name__}"
+        )
+
+    mapping = cast("dict[object, object]", loaded)
+    unknown_top = sorted(str(key) for key in mapping if key != "rules")
+    if unknown_top:
+        raise SelectionRuleError(
+            f"selection rules file {path}: unknown top-level key(s) {unknown_top}; only 'rules' is allowed"
+        )
+
+    rules_obj = mapping.get("rules")
+    if rules_obj is None:
+        return ()
+    if not isinstance(rules_obj, list):
+        raise SelectionRuleError(f"selection rules file {path}: 'rules' must be a list, got {type(rules_obj).__name__}")
+
+    entries = cast("list[object]", rules_obj)
+    return tuple(
+        _parse_rule(entry, index=index, path=path, skills_source_dir=skills_source_dir)
+        for index, entry in enumerate(entries, start=1)
+    )
+
+
+def resolve_rule_templates(
+    rules: Sequence[SelectionRule],
+    tasks: Sequence[RuleSelectableTask],
+) -> tuple[str, ...]:
+    """Resolve which skill templates the rules select for ``tasks``.
+
+    A pure function of ``(tasks, rules)``: no filesystem access, no
+    environment reads, no corpus statistics. A rule matches when any
+    single task satisfies every axis the rule declares (``owned_files``
+    always; ``task_type`` when present) - multi-task semantics are a
+    union across tasks. Hits are deduplicated and ordered by rule
+    position, then template name within a rule.
+
+    Returns:
+        Template file names (``<name>.md``) in deterministic order.
+    """
+    selected: list[str] = []
+    seen: set[str] = set()
+    for rule in rules:
+        if not any(_rule_matches_task(rule, task) for task in tasks):
+            continue
+        for template_name in sorted(rule.templates):
+            if template_name not in seen:
+                seen.add(template_name)
+                selected.append(template_name)
+    return tuple(selected)
+
+
+def _rule_matches_task(rule: SelectionRule, task: RuleSelectableTask) -> bool:
+    """Return whether one task satisfies every axis ``rule`` declares."""
+    if rule.task_type is not None and _coerce_task_type(getattr(task, "task_type", None)) != rule.task_type:
+        return False
+    owned = task.owned_files or []
+    return any(fnmatchcase(entry, pattern) for pattern in rule.owned_files for entry in owned)
+
+
+def _coerce_task_type(value: object) -> TaskType:
+    """Normalize a task's ``task_type`` field to a :class:`TaskType`.
+
+    The injector's local ``Task`` protocol does not carry ``task_type``,
+    so missing or unrecognized values deterministically default to
+    ``TaskType.STANDARD``.
+    """
+    if isinstance(value, TaskType):
+        return value
+    if isinstance(value, str):
+        return _TASK_TYPE_BY_TOKEN.get(value.strip().lower(), TaskType.STANDARD)
+    return TaskType.STANDARD
+
+
+def _parse_rule(
+    entry: object,
+    *,
+    index: int,
+    path: Path,
+    skills_source_dir: Path,
+) -> SelectionRule:
+    """Validate one rule mapping, raising :class:`SelectionRuleError` loudly."""
+    label = f"selection rules file {path}: rule {index}"
+    if not isinstance(entry, dict):
+        raise SelectionRuleError(f"{label} must be a mapping, got {type(entry).__name__}")
+
+    mapping = cast("dict[object, object]", entry)
+    keys = {str(key) for key in mapping}
+    if "role" in keys:
+        raise SelectionRuleError(
+            f"{label}: 'role' is not a rule axis - role -> skill binding is owned by "
+            "ROLE_SKILL_MAP in bernstein.adapters.skills_injector; remove the 'role' key"
+        )
+    unknown = sorted(keys - _ALLOWED_RULE_KEYS)
+    if unknown:
+        raise SelectionRuleError(f"{label}: unknown key(s) {unknown}; allowed keys are {sorted(_ALLOWED_RULE_KEYS)}")
+
+    owned_files = _parse_owned_files(mapping.get("owned_files"), label=label)
+    task_type = _parse_task_type(mapping.get("task_type"), label=label)
+    templates = _parse_skills(mapping.get("skills"), label=label, skills_source_dir=skills_source_dir)
+    return SelectionRule(owned_files=owned_files, task_type=task_type, templates=templates)
+
+
+def _parse_owned_files(value: object, *, label: str) -> tuple[str, ...]:
+    """Validate the required ``owned_files`` axis: one glob or a list of globs."""
+    if value is None:
+        raise SelectionRuleError(f"{label}: 'owned_files' is required (a glob or list of globs)")
+    if isinstance(value, str):
+        raw_globs: list[object] = [value]
+    elif isinstance(value, list):
+        raw_globs = cast("list[object]", value)
+    else:
+        raise SelectionRuleError(
+            f"{label}: 'owned_files' must be a string glob or a list of string globs, got {type(value).__name__}"
+        )
+    if not raw_globs:
+        raise SelectionRuleError(f"{label}: 'owned_files' must not be empty")
+
+    globs: list[str] = []
+    for item in raw_globs:
+        if not isinstance(item, str) or not item.strip():
+            raise SelectionRuleError(f"{label}: 'owned_files' entries must be non-empty strings, got {item!r}")
+        globs.append(item)
+    return tuple(globs)
+
+
+def _parse_task_type(value: object, *, label: str) -> TaskType | None:
+    """Validate the optional ``task_type`` axis against :class:`TaskType`."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise SelectionRuleError(f"{label}: 'task_type' must be a string, got {type(value).__name__}")
+    token = value.strip().lower()
+    task_type = _TASK_TYPE_BY_TOKEN.get(token)
+    if task_type is None:
+        raise SelectionRuleError(
+            f"{label}: unknown task_type {value!r}; valid values are {sorted(_TASK_TYPE_BY_TOKEN)}"
+        )
+    return task_type
+
+
+def _parse_skills(value: object, *, label: str, skills_source_dir: Path) -> tuple[str, ...]:
+    """Validate the ``skills`` list and that every named template exists on disk."""
+    if value is None:
+        raise SelectionRuleError(f"{label}: 'skills' is required (a list of skill template names)")
+    if not isinstance(value, list):
+        raise SelectionRuleError(f"{label}: 'skills' must be a list, got {type(value).__name__}")
+    items = cast("list[object]", value)
+    if not items:
+        raise SelectionRuleError(f"{label}: 'skills' must not be empty")
+
+    templates: list[str] = []
+    for item in items:
+        if not isinstance(item, str) or not item.strip():
+            raise SelectionRuleError(f"{label}: 'skills' entries must be non-empty strings, got {item!r}")
+        name = item.strip()
+        template_name = name if name.endswith(".md") else f"{name}.md"
+        if not (skills_source_dir / template_name).is_file():
+            raise SelectionRuleError(
+                f"{label} names skill template {name!r}, but {skills_source_dir / template_name} does not exist"
+            )
+        templates.append(template_name)
+    return tuple(templates)
+
+
+__all__ = [
+    "SELECTION_RULES_FILENAME",
+    "RuleSelectableTask",
+    "SelectionRule",
+    "SelectionRuleError",
+    "load_selection_rules",
+    "resolve_rule_templates",
+    "selection_rules_path",
+]

--- a/src/bernstein/core/skills/selection_rules.py
+++ b/src/bernstein/core/skills/selection_rules.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from fnmatch import fnmatchcase
+from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Final, Protocol, cast
 
 import yaml
@@ -191,22 +192,28 @@ def _rule_matches_task(rule: SelectionRule, task: RuleSelectableTask) -> bool:
     return any(fnmatchcase(entry, pattern) for pattern in rule.owned_files for entry in owned)
 
 
-def _coerce_task_type(value: object) -> str:
+def _coerce_task_type(value: object) -> str | None:
     """Normalize a task's ``task_type`` field to its lowercase token.
 
     An enum member normalizes through its ``value``; a bare string through
     itself. The injector's local ``Task`` protocol does not carry
-    ``task_type``, so missing or unrecognized values deterministically
-    default to ``"standard"``. Matching by token rather than enum identity
-    keeps this module import-free of scheduler internals (see
-    ``_KNOWN_TASK_TYPE_TOKENS``).
+    ``task_type``, so an *absent* field (``None``) deterministically
+    defaults to ``"standard"``. A field that is present but unrecognized -
+    a task type this module does not know, or a non-string value - returns
+    ``None`` and therefore matches no ``task_type``-scoped rule at all:
+    coercing it to ``"standard"`` would inject operator-authored skills
+    into tasks that are explicitly not standard. Matching by token rather
+    than enum identity keeps this module import-free of scheduler
+    internals (see ``_KNOWN_TASK_TYPE_TOKENS``).
     """
+    if value is None:
+        return "standard"
     token = getattr(value, "value", value)
     if isinstance(token, str):
         normalized = token.strip().lower()
         if normalized in _KNOWN_TASK_TYPE_TOKENS:
             return normalized
-    return "standard"
+    return None
 
 
 def _parse_rule(
@@ -291,6 +298,16 @@ def _parse_skills(value: object, *, label: str, skills_source_dir: Path) -> tupl
             raise SelectionRuleError(f"{label}: 'skills' entries must be non-empty strings, got {item!r}")
         name = item.strip()
         template_name = name if name.endswith(".md") else f"{name}.md"
+        # Containment: a template name is a bare file name inside the skills
+        # directory, never a path. Without this, an absolute entry replaces
+        # the base in the join and ``..`` walks out of the corpus, and the
+        # injector would read and inject a file from outside the skills
+        # directory as if it were a vetted template.
+        if PurePosixPath(template_name).name != template_name or "\\" in template_name or template_name == ".md":
+            raise SelectionRuleError(
+                f"{label} names skill template {name!r}, which is not a bare template file name - "
+                "rule templates must live directly in the skills directory, path components are not allowed"
+            )
         if not (skills_source_dir / template_name).is_file():
             raise SelectionRuleError(
                 f"{label} names skill template {name!r}, but {skills_source_dir / template_name} does not exist"

--- a/src/bernstein/core/skills/selection_rules.py
+++ b/src/bernstein/core/skills/selection_rules.py
@@ -15,9 +15,11 @@ A rule has two axes:
 
 - ``owned_files`` (required): one glob or a list of globs, matched
   fnmatch-style against each task's ``owned_files`` entries.
-- ``task_type`` (optional): one of the :class:`~bernstein.core.tasks.models.TaskType`
-  values (``standard``, ``upgrade_proposal``, ``fix``, ``research``).
-  When present, both axes must match on the same task.
+- ``task_type`` (optional): one of the task-type tokens ``standard``,
+  ``upgrade_proposal``, ``fix``, ``research`` (the ``value`` spellings of
+  the scheduler's ``TaskType`` enum, matched by token so this module never
+  imports scheduler internals). When present, both axes must match on the
+  same task.
 
 There is deliberately no ``role`` axis - role -> skill binding is owned
 by ``ROLE_SKILL_MAP`` in the injector, and the schema rejects a ``role``
@@ -38,8 +40,6 @@ from typing import TYPE_CHECKING, Final, Protocol, cast
 
 import yaml
 
-from bernstein.core.tasks.models import TaskType
-
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from pathlib import Path
@@ -50,9 +50,14 @@ SELECTION_RULES_FILENAME: Final[str] = "selection-rules.yaml"
 #: Keys a rule mapping may carry. Anything else is rejected at load.
 _ALLOWED_RULE_KEYS: Final[frozenset[str]] = frozenset({"owned_files", "task_type", "skills"})
 
-#: Lowercase task-type token -> enum member, derived from the enum so the
-#: schema can never drift from :class:`TaskType`.
-_TASK_TYPE_BY_TOKEN: Final[dict[str, TaskType]] = {member.value: member for member in TaskType}
+#: Lowercase task-type tokens the schema accepts - the ``value`` spellings of
+#: ``bernstein.core.tasks.models.TaskType``. Restated here rather than
+#: imported: this module is reached from the adapters layer through the skill
+#: injector, and the import-linter contract forbids adapters importing
+#: scheduler internals, so task types are matched by token, never by enum
+#: identity. ``test_known_task_type_tokens_track_the_scheduler_enum`` pins
+#: this set against the real enum so the two cannot drift silently.
+_KNOWN_TASK_TYPE_TOKENS: Final[frozenset[str]] = frozenset({"standard", "upgrade_proposal", "fix", "research"})
 
 
 class SelectionRuleError(ValueError):
@@ -64,14 +69,15 @@ class RuleSelectableTask(Protocol):
 
     Deliberately not a widening of ``RoutableTask`` (which the TF-IDF
     auto-route owns): rules read only ``owned_files`` and ``task_type``.
-    The resolver reads ``task_type`` via ``getattr`` with a
-    ``TaskType.STANDARD`` default, so callers whose task type lacks the
+    The resolver reads ``task_type`` via ``getattr`` and normalizes it to
+    its lowercase token (an enum member's ``value``, or a bare string),
+    defaulting to ``"standard"``, so callers whose task type lacks the
     field (e.g. the injector's local ``Task`` protocol) still resolve
     deterministically.
     """
 
     owned_files: list[str]
-    task_type: TaskType
+    task_type: object
 
 
 @dataclass(frozen=True)
@@ -79,7 +85,7 @@ class SelectionRule:
     """One validated rule: globs (+ optional task type) -> skill templates."""
 
     owned_files: tuple[str, ...]
-    task_type: TaskType | None
+    task_type: str | None
     templates: tuple[str, ...]
 
 
@@ -185,18 +191,22 @@ def _rule_matches_task(rule: SelectionRule, task: RuleSelectableTask) -> bool:
     return any(fnmatchcase(entry, pattern) for pattern in rule.owned_files for entry in owned)
 
 
-def _coerce_task_type(value: object) -> TaskType:
-    """Normalize a task's ``task_type`` field to a :class:`TaskType`.
+def _coerce_task_type(value: object) -> str:
+    """Normalize a task's ``task_type`` field to its lowercase token.
 
-    The injector's local ``Task`` protocol does not carry ``task_type``,
-    so missing or unrecognized values deterministically default to
-    ``TaskType.STANDARD``.
+    An enum member normalizes through its ``value``; a bare string through
+    itself. The injector's local ``Task`` protocol does not carry
+    ``task_type``, so missing or unrecognized values deterministically
+    default to ``"standard"``. Matching by token rather than enum identity
+    keeps this module import-free of scheduler internals (see
+    ``_KNOWN_TASK_TYPE_TOKENS``).
     """
-    if isinstance(value, TaskType):
-        return value
-    if isinstance(value, str):
-        return _TASK_TYPE_BY_TOKEN.get(value.strip().lower(), TaskType.STANDARD)
-    return TaskType.STANDARD
+    token = getattr(value, "value", value)
+    if isinstance(token, str):
+        normalized = token.strip().lower()
+        if normalized in _KNOWN_TASK_TYPE_TOKENS:
+            return normalized
+    return "standard"
 
 
 def _parse_rule(
@@ -251,19 +261,18 @@ def _parse_owned_files(value: object, *, label: str) -> tuple[str, ...]:
     return tuple(globs)
 
 
-def _parse_task_type(value: object, *, label: str) -> TaskType | None:
-    """Validate the optional ``task_type`` axis against :class:`TaskType`."""
+def _parse_task_type(value: object, *, label: str) -> str | None:
+    """Validate the optional ``task_type`` axis against the known tokens."""
     if value is None:
         return None
     if not isinstance(value, str):
         raise SelectionRuleError(f"{label}: 'task_type' must be a string, got {type(value).__name__}")
     token = value.strip().lower()
-    task_type = _TASK_TYPE_BY_TOKEN.get(token)
-    if task_type is None:
+    if token not in _KNOWN_TASK_TYPE_TOKENS:
         raise SelectionRuleError(
-            f"{label}: unknown task_type {value!r}; valid values are {sorted(_TASK_TYPE_BY_TOKEN)}"
+            f"{label}: unknown task_type {value!r}; valid values are {sorted(_KNOWN_TASK_TYPE_TOKENS)}"
         )
-    return task_type
+    return token
 
 
 def _parse_skills(value: object, *, label: str, skills_source_dir: Path) -> tuple[str, ...]:

--- a/src/bernstein/core/skills/selection_rules.py
+++ b/src/bernstein/core/skills/selection_rules.py
@@ -69,16 +69,18 @@ class RuleSelectableTask(Protocol):
     """The narrow slice of a task the rule layer matches against.
 
     Deliberately not a widening of ``RoutableTask`` (which the TF-IDF
-    auto-route owns): rules read only ``owned_files`` and ``task_type``.
-    The resolver reads ``task_type`` via ``getattr`` and normalizes it to
-    its lowercase token (an enum member's ``value``, or a bare string),
-    defaulting to ``"standard"``, so callers whose task type lacks the
-    field (e.g. the injector's local ``Task`` protocol) still resolve
-    deterministically.
+    auto-route owns), and deliberately requiring only ``owned_files`` —
+    the one field every caller must have. ``task_type`` is read
+    dynamically via ``getattr`` and normalized to its lowercase token (an
+    enum member's ``value``, or a bare string): an absent field defaults
+    to ``"standard"``, a present-but-unrecognized value matches no typed
+    rule. Requiring ``task_type`` here would force callers like the
+    injector (whose local ``Task`` protocol has no such field) into a
+    cast that silences exactly the shape mismatches static checking
+    should catch. Design rationale: ``docs/sdd/skill-selection-rules.md``.
     """
 
     owned_files: list[str]
-    task_type: object
 
 
 @dataclass(frozen=True)

--- a/tests/unit/skills/test_injector_activation_log.py
+++ b/tests/unit/skills/test_injector_activation_log.py
@@ -8,8 +8,11 @@ from pathlib import Path
 import pytest
 from bernstein.core.models import Task
 
-from bernstein.adapters.skills_injector import inject_skills
+from bernstein.adapters import skills_injector
+from bernstein.adapters.skills_injector import inject_skills, render_skill_template
 from bernstein.core.skills.activation_log import ENV_VAR, activation_log_path
+from bernstein.core.skills.sanitizer import sanitize_skill_body
+from bernstein.core.skills.selection_rules import SELECTION_RULES_FILENAME
 
 
 def _make_skill_templates(root: Path) -> Path:
@@ -151,6 +154,208 @@ def test_inject_skills_auto_route_adds_matching_skill_when_enabled(
     auto_rows = [row for row in rows if row["skill"] == "pytest-helper"]
     assert len(auto_rows) == 1
     assert auto_rows[0]["trigger_source"] == "auto-route"
+
+
+def test_no_rule_table_is_byte_identical_noop(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Merge-deciding property of issue #3383: absent table == no rule layer.
+
+    With no ``selection-rules.yaml`` on disk the injector must behave
+    byte-identically to a build without the rule layer: the loader is
+    never invoked (existence is one cheap stat), the injected file set
+    and bytes are exactly what the unchanged sanitize+render pipeline
+    produces for role binding alone, and the activation log carries
+    only ``role-binding`` lines.
+    """
+    monkeypatch.delenv(ENV_VAR, raising=False)
+    monkeypatch.delenv("BERNSTEIN_SKILLS_AUTO_ROUTE", raising=False)
+    loader_calls = {"count": 0}
+    real_loader = skills_injector.load_selection_rules
+
+    def _counting_loader(*args: object, **kwargs: object) -> object:
+        loader_calls["count"] += 1
+        return real_loader(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(skills_injector, "load_selection_rules", _counting_loader)
+
+    templates_dir = _make_skill_templates(tmp_path)
+    skills_source_dir = templates_dir.parent / "skills"
+    assert not (skills_source_dir / SELECTION_RULES_FILENAME).exists()
+    workdir = tmp_path / "workdir"
+    workdir.mkdir()
+    task = _make_task("T-100")
+
+    inject_skills(
+        workdir=workdir,
+        role="security",
+        tasks=[task],
+        session_id="sec-noop",
+        templates_dir=templates_dir,
+    )
+
+    # No rule table on disk -> the loader is never invoked.
+    assert loader_calls["count"] == 0
+
+    # Injected file set is exactly the role-derived pair - no new writes.
+    out_dir = workdir / ".claude" / "skills"
+    expected_names = ["bernstein-completion-protocol.md", "bernstein-signal-check.md"]
+    assert sorted(p.name for p in out_dir.iterdir()) == expected_names
+
+    # Bytes are identical to the pre-rule-layer sanitize+render pipeline.
+    for name in expected_names:
+        source_path = skills_source_dir / name
+        expected_bytes = render_skill_template(
+            sanitize_skill_body(
+                source_path.read_text(encoding="utf-8"),
+                skill_name=name,
+                origin=str(source_path),
+                source_name="templates/skills",
+            ),
+            session_id="sec-noop",
+            tasks=[task],
+        ).encode("utf-8")
+        assert (out_dir / name).read_bytes() == expected_bytes
+
+    # Activation log: one role-binding line per injected skill, nothing else.
+    rows = [json.loads(line) for line in activation_log_path(workdir).read_text(encoding="utf-8").splitlines()]
+    assert len(rows) == 2
+    assert {row["skill"] for row in rows} == {"bernstein-completion-protocol", "bernstein-signal-check"}
+    assert {row["trigger_source"] for row in rows} == {"role-binding"}
+
+
+def test_rule_selected_skill_logs_trigger_source_rule(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A rule-selected template is injected with trigger_source ``rule``."""
+    monkeypatch.delenv(ENV_VAR, raising=False)
+    monkeypatch.delenv("BERNSTEIN_SKILLS_AUTO_ROUTE", raising=False)
+    templates_dir = _make_skill_templates(tmp_path)
+    skills_source_dir = templates_dir.parent / "skills"
+    (skills_source_dir / SELECTION_RULES_FILENAME).write_text(
+        "rules:\n  - owned_files: 'tests/*.py'\n    skills: [pytest-helper]\n",
+        encoding="utf-8",
+    )
+    workdir = tmp_path / "workdir"
+    workdir.mkdir()
+    task = Task(
+        id="T-200",
+        title="Refactor helpers",
+        description="Cleanup",
+        role="security",
+        owned_files=["tests/test_api.py"],
+    )
+
+    inject_skills(
+        workdir=workdir,
+        role="security",
+        tasks=[task],
+        session_id="sec-rule",
+        templates_dir=templates_dir,
+    )
+
+    assert (workdir / ".claude" / "skills" / "pytest-helper.md").is_file()
+    rows = [json.loads(line) for line in activation_log_path(workdir).read_text(encoding="utf-8").splitlines()]
+    rule_rows = [row for row in rows if row["skill"] == "pytest-helper"]
+    assert len(rule_rows) == 1
+    assert rule_rows[0]["trigger_source"] == "rule"
+    assert rule_rows[0]["task_id"] == "T-200"
+
+
+def test_role_binding_wins_for_template_selected_by_both(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A template selected by role map and rules keeps the role-binding trigger."""
+    monkeypatch.delenv(ENV_VAR, raising=False)
+    monkeypatch.delenv("BERNSTEIN_SKILLS_AUTO_ROUTE", raising=False)
+    templates_dir = _make_skill_templates(tmp_path)
+    skills_source_dir = templates_dir.parent / "skills"
+    (skills_source_dir / "bernstein-test-runner.md").write_text(
+        "---\nname: bernstein-test-runner\n"
+        "description: Run the project test suite before completion.\n"
+        "version: 1.0.0\n---\n\n# Test runner\nRun tests with uv.\n",
+        encoding="utf-8",
+    )
+    (skills_source_dir / SELECTION_RULES_FILENAME).write_text(
+        "rules:\n  - owned_files: 'src/*.py'\n    skills: [bernstein-test-runner]\n",
+        encoding="utf-8",
+    )
+    workdir = tmp_path / "workdir"
+    workdir.mkdir()
+    task = Task(
+        id="T-300",
+        title="Implement feature",
+        description="Feature work",
+        role="qa",
+        owned_files=["src/feature.py"],
+    )
+
+    inject_skills(
+        workdir=workdir,
+        role="qa",  # qa role-binds bernstein-test-runner.md
+        tasks=[task],
+        session_id="qa-both",
+        templates_dir=templates_dir,
+    )
+
+    assert (workdir / ".claude" / "skills" / "bernstein-test-runner.md").is_file()
+    rows = [json.loads(line) for line in activation_log_path(workdir).read_text(encoding="utf-8").splitlines()]
+    runner_rows = [row for row in rows if row["skill"] == "bernstein-test-runner"]
+    # Exactly one activation line, and role binding wins the trigger.
+    assert len(runner_rows) == 1
+    assert runner_rows[0]["trigger_source"] == "role-binding"
+
+
+def test_auto_route_excludes_rule_selected_templates(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rule-selected templates are excluded from TF-IDF scoring, trigger stays ``rule``."""
+    monkeypatch.delenv(ENV_VAR, raising=False)
+    monkeypatch.setenv("BERNSTEIN_SKILLS_AUTO_ROUTE", "1")
+    templates_dir = _make_skill_templates(tmp_path)
+    skills_source_dir = templates_dir.parent / "skills"
+    (skills_source_dir / SELECTION_RULES_FILENAME).write_text(
+        "rules:\n  - owned_files: 'tests/*.py'\n    skills: [pytest-helper]\n",
+        encoding="utf-8",
+    )
+    captured: dict[str, list[str]] = {}
+    real_auto_route = skills_injector.select_auto_route_templates
+
+    def _spying_auto_route(*args: object, **kwargs: object) -> object:
+        captured["excluded"] = list(kwargs["excluded_templates"])  # type: ignore[arg-type]
+        return real_auto_route(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(skills_injector, "select_auto_route_templates", _spying_auto_route)
+    workdir = tmp_path / "workdir"
+    workdir.mkdir()
+    task = Task(
+        id="T-400",
+        title="Fix pytest regression",
+        description="The pytest suite is failing.",
+        role="security",
+        owned_files=["tests/test_api.py"],
+    )
+
+    inject_skills(
+        workdir=workdir,
+        role="security",
+        tasks=[task],
+        session_id="sec-excl",
+        templates_dir=templates_dir,
+    )
+
+    # The rule-selected template was passed to the auto-route as excluded,
+    # so TF-IDF neither re-scored nor duplicated it.
+    assert "pytest-helper.md" in captured["excluded"]
+    assert (workdir / ".claude" / "skills" / "pytest-helper.md").is_file()
+    rows = [json.loads(line) for line in activation_log_path(workdir).read_text(encoding="utf-8").splitlines()]
+    helper_rows = [row for row in rows if row["skill"] == "pytest-helper"]
+    assert len(helper_rows) == 1
+    assert helper_rows[0]["trigger_source"] == "rule"
 
 
 def test_inject_skills_auto_route_ignores_malformed_frontmatter(

--- a/tests/unit/skills/test_selection_rules.py
+++ b/tests/unit/skills/test_selection_rules.py
@@ -306,3 +306,17 @@ def test_multi_task_union_semantics(tmp_path: Path) -> None:
     )
     # No task matches -> nothing selected.
     assert resolve_rule_templates(rules, [unrelated]) == ()
+
+
+def test_known_task_type_tokens_track_the_scheduler_enum() -> None:
+    """The restated token set cannot drift from TaskType.
+
+    selection_rules matches task types by token instead of importing the
+    scheduler's enum, because the module is reached from the adapters layer
+    and the import-linter contract forbids adapters importing scheduler
+    internals. This pin is what makes the restatement safe: adding or
+    renaming a TaskType member fails here until the token set follows.
+    """
+    from bernstein.core.skills.selection_rules import _KNOWN_TASK_TYPE_TOKENS
+
+    assert {member.value for member in TaskType} == _KNOWN_TASK_TYPE_TOKENS

--- a/tests/unit/skills/test_selection_rules.py
+++ b/tests/unit/skills/test_selection_rules.py
@@ -1,0 +1,308 @@
+"""Declarative skill-selection rules: loader and resolver units (issue #3383).
+
+The rule layer must be corpus-immune: resolution is a pure function of
+``(tasks, rules)``, unlike the TF-IDF auto-route whose scores move when
+unrelated templates join the corpus. These tests pin the schema (loud
+validation, no ``role`` axis), the matching semantics (fnmatch globs,
+per-task axis conjunction, cross-task union), and the deterministic
+output order (rule position, then template name).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from bernstein.core.models import Task
+
+from bernstein.core.skills.routing import select_auto_route_templates
+from bernstein.core.skills.selection_rules import (
+    SELECTION_RULES_FILENAME,
+    SelectionRuleError,
+    load_selection_rules,
+    resolve_rule_templates,
+)
+from bernstein.core.tasks.models import TaskType
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _make_skills_dir(root: Path, template_names: list[str]) -> Path:
+    """Create a skills source directory holding the named templates."""
+    skills_dir = root / "templates" / "skills"
+    skills_dir.mkdir(parents=True, exist_ok=True)
+    for name in template_names:
+        (skills_dir / f"{name}.md").write_text(
+            f"---\nname: {name}\ndescription: {name} skill\n---\n\n# {name}\nBody of {name}.\n",
+            encoding="utf-8",
+        )
+    return skills_dir
+
+
+def _write_rules(skills_dir: Path, text: str) -> None:
+    (skills_dir / SELECTION_RULES_FILENAME).write_text(text, encoding="utf-8")
+
+
+def _make_task(
+    *,
+    owned_files: list[str],
+    task_type: TaskType = TaskType.STANDARD,
+    task_id: str = "T-001",
+) -> Task:
+    return Task(
+        id=task_id,
+        title="Test task",
+        description="A test task",
+        role="backend",
+        owned_files=owned_files,
+        task_type=task_type,
+    )
+
+
+def test_rule_glob_matches_owned_files(tmp_path: Path) -> None:
+    """A rule whose glob matches a task's owned_files selects its templates."""
+    skills_dir = _make_skills_dir(tmp_path, ["api-conventions"])
+    _write_rules(
+        skills_dir,
+        "rules:\n  - owned_files: 'src/api/*.py'\n    skills: [api-conventions]\n",
+    )
+
+    rules = load_selection_rules(skills_dir)
+    task = _make_task(owned_files=["src/api/users.py"])
+
+    assert resolve_rule_templates(rules, [task]) == ("api-conventions.md",)
+
+
+def test_rule_glob_no_match_selects_nothing(tmp_path: Path) -> None:
+    """A rule whose globs match no owned_files entry selects nothing."""
+    skills_dir = _make_skills_dir(tmp_path, ["api-conventions"])
+    _write_rules(
+        skills_dir,
+        "rules:\n  - owned_files: ['docs/*.md', 'src/api/*.py']\n    skills: [api-conventions]\n",
+    )
+
+    rules = load_selection_rules(skills_dir)
+    task = _make_task(owned_files=["src/core/scheduler.py"])
+
+    assert resolve_rule_templates(rules, [task]) == ()
+
+
+def test_rule_task_type_conjunction_narrows(tmp_path: Path) -> None:
+    """When both axes are present, both must match - on the same task."""
+    skills_dir = _make_skills_dir(tmp_path, ["hotfix-guide"])
+    _write_rules(
+        skills_dir,
+        "rules:\n  - owned_files: 'src/*.py'\n    task_type: fix\n    skills: [hotfix-guide]\n",
+    )
+    rules = load_selection_rules(skills_dir)
+
+    # Glob matches but task_type does not -> not selected.
+    standard = _make_task(owned_files=["src/main.py"], task_type=TaskType.STANDARD)
+    assert resolve_rule_templates(rules, [standard]) == ()
+
+    # Both axes match on the same task -> selected.
+    fix = _make_task(owned_files=["src/main.py"], task_type=TaskType.FIX)
+    assert resolve_rule_templates(rules, [fix]) == ("hotfix-guide.md",)
+
+    # One task matches each axis, but no single task matches both -> not
+    # selected: the conjunction is per-task, not across the task set.
+    glob_only = _make_task(owned_files=["src/main.py"], task_type=TaskType.STANDARD, task_id="T-A")
+    type_only = _make_task(owned_files=["docs/notes.md"], task_type=TaskType.FIX, task_id="T-B")
+    assert resolve_rule_templates(rules, [glob_only, type_only]) == ()
+
+
+def test_rules_have_no_role_axis(tmp_path: Path) -> None:
+    """The schema rejects a ``role`` key at load - ROLE_SKILL_MAP owns roles."""
+    skills_dir = _make_skills_dir(tmp_path, ["api-conventions"])
+    _write_rules(
+        skills_dir,
+        "rules:\n  - owned_files: 'src/*'\n    role: backend\n    skills: [api-conventions]\n",
+    )
+
+    with pytest.raises(SelectionRuleError, match="'role' is not a rule axis"):
+        load_selection_rules(skills_dir)
+
+
+def test_rule_selection_invariant_to_unrelated_corpus(tmp_path: Path) -> None:
+    """The same task and rules select the same templates whatever else the corpus holds."""
+    selections: list[tuple[str, ...]] = []
+    for count, unrelated in enumerate(([], ["extra-a"], [f"extra-{i}" for i in range(12)])):
+        skills_dir = _make_skills_dir(tmp_path / f"corpus-{count}", ["api-conventions", *unrelated])
+        _write_rules(
+            skills_dir,
+            "rules:\n  - owned_files: 'src/api/*.py'\n    skills: [api-conventions]\n",
+        )
+        rules = load_selection_rules(skills_dir)
+        task = _make_task(owned_files=["src/api/users.py"])
+        selections.append(resolve_rule_templates(rules, [task]))
+
+    assert selections[0] == ("api-conventions.md",)
+    assert selections[0] == selections[1] == selections[2]
+
+
+def test_regression_tfidf_shifts_while_rules_hold(tmp_path: Path) -> None:
+    """Adding one unrelated template shifts a TF-IDF score; the rule layer holds.
+
+    This is the determinism motivation for the rule layer in one test:
+    the auto-route's IDF weights depend on corpus document frequencies,
+    so an unrelated template changes an existing template's score for
+    the very same task. Rule resolution never looks at the corpus.
+    """
+    task = Task(
+        id="T-010",
+        title="Fix pytest regression",
+        description="The pytest suite is failing in tests.",
+        role="backend",
+        owned_files=["tests/test_api.py"],
+    )
+    rules_text = "rules:\n  - owned_files: 'tests/*.py'\n    skills: [pytest-helper]\n"
+
+    def _score_and_selection(root: Path, extra: list[str]) -> tuple[float, tuple[str, ...]]:
+        skills_dir = _make_skills_dir(root, ["pytest-helper", "docker-deploy", *extra])
+        # Overwrite with token-bearing bodies so TF-IDF has signal.
+        (skills_dir / "pytest-helper.md").write_text(
+            "---\nname: pytest-helper\ndescription: pytest regression help for tests\n---\n\n"
+            "Run pytest on the failing tests and fix the regression.\n",
+            encoding="utf-8",
+        )
+        for name in extra:
+            (skills_dir / f"{name}.md").write_text(
+                f"---\nname: {name}\ndescription: unrelated helper\n---\n\n"
+                "Terraform plan output review for infrastructure tests.\n",
+                encoding="utf-8",
+            )
+        _write_rules(skills_dir, rules_text)
+        candidates = select_auto_route_templates(skills_dir, [task], excluded_templates=[])
+        by_name = {c.template_name: c.score for c in candidates}
+        selection = resolve_rule_templates(load_selection_rules(skills_dir), [task])
+        return by_name["pytest-helper.md"], selection
+
+    score_small, selection_small = _score_and_selection(tmp_path / "small", extra=[])
+    score_grown, selection_grown = _score_and_selection(tmp_path / "grown", extra=["terraform-notes"])
+
+    assert score_small != score_grown, "TF-IDF score should shift when the corpus grows"
+    assert selection_small == selection_grown == ("pytest-helper.md",)
+
+
+def test_rule_referencing_missing_template_fails_loudly_at_load(tmp_path: Path) -> None:
+    """A rule naming a template with no ``<name>.md`` on disk fails at load."""
+    skills_dir = _make_skills_dir(tmp_path, ["api-conventions"])
+    _write_rules(
+        skills_dir,
+        "rules:\n"
+        "  - owned_files: 'src/*'\n"
+        "    skills: [api-conventions]\n"
+        "  - owned_files: 'docs/*'\n"
+        "    skills: [ghost-template]\n",
+    )
+
+    with pytest.raises(SelectionRuleError, match=r"rule 2.*'ghost-template'"):
+        load_selection_rules(skills_dir)
+
+
+def test_malformed_rule_table_fails_loudly_at_load(tmp_path: Path) -> None:
+    """Bad YAML and wrong shapes raise; an empty-but-valid table means no rules."""
+    skills_dir = _make_skills_dir(tmp_path, ["api-conventions"])
+
+    # Invalid YAML.
+    _write_rules(skills_dir, "rules: [unclosed\n")
+    with pytest.raises(SelectionRuleError, match="invalid YAML"):
+        load_selection_rules(skills_dir)
+
+    # Top level must be a mapping, not a bare list.
+    _write_rules(skills_dir, "- owned_files: 'src/*'\n  skills: [api-conventions]\n")
+    with pytest.raises(SelectionRuleError, match="top level must be a mapping"):
+        load_selection_rules(skills_dir)
+
+    # Unknown top-level key.
+    _write_rules(skills_dir, "rules: []\nextra: true\n")
+    with pytest.raises(SelectionRuleError, match="unknown top-level key"):
+        load_selection_rules(skills_dir)
+
+    # Non-string, non-list glob axis.
+    _write_rules(skills_dir, "rules:\n  - owned_files: 42\n    skills: [api-conventions]\n")
+    with pytest.raises(SelectionRuleError, match="'owned_files' must be a string glob"):
+        load_selection_rules(skills_dir)
+
+    # Non-string entry inside the glob list.
+    _write_rules(skills_dir, "rules:\n  - owned_files: [42]\n    skills: [api-conventions]\n")
+    with pytest.raises(SelectionRuleError, match="'owned_files' entries must be non-empty strings"):
+        load_selection_rules(skills_dir)
+
+    # Missing required owned_files axis.
+    _write_rules(skills_dir, "rules:\n  - skills: [api-conventions]\n")
+    with pytest.raises(SelectionRuleError, match="'owned_files' is required"):
+        load_selection_rules(skills_dir)
+
+    # Unknown task_type value.
+    _write_rules(
+        skills_dir,
+        "rules:\n  - owned_files: 'src/*'\n    task_type: refactor\n    skills: [api-conventions]\n",
+    )
+    with pytest.raises(SelectionRuleError, match="unknown task_type 'refactor'"):
+        load_selection_rules(skills_dir)
+
+    # Unknown rule key.
+    _write_rules(
+        skills_dir,
+        "rules:\n  - owned_files: 'src/*'\n    priority: 3\n    skills: [api-conventions]\n",
+    )
+    with pytest.raises(SelectionRuleError, match=r"unknown key\(s\) \['priority'\]"):
+        load_selection_rules(skills_dir)
+
+    # Empty-but-valid tables mean no rules.
+    _write_rules(skills_dir, "")
+    assert load_selection_rules(skills_dir) == ()
+    _write_rules(skills_dir, "rules: []\n")
+    assert load_selection_rules(skills_dir) == ()
+    _write_rules(skills_dir, "rules:\n")
+    assert load_selection_rules(skills_dir) == ()
+
+
+def test_rule_hits_deduplicated_and_ordered_by_rule_position_then_name(tmp_path: Path) -> None:
+    """Output order is rule position, then template name; duplicates keep first place."""
+    skills_dir = _make_skills_dir(tmp_path, ["alpha", "beta", "zeta"])
+    _write_rules(
+        skills_dir,
+        "rules:\n"
+        "  - owned_files: 'src/*'\n"
+        "    skills: [zeta, alpha]\n"
+        "  - owned_files: 'src/*'\n"
+        "    skills: [alpha, beta]\n",
+    )
+
+    rules = load_selection_rules(skills_dir)
+    task = _make_task(owned_files=["src/main.py"])
+
+    # Rule 1 contributes its hits name-sorted (alpha, zeta); rule 2 adds
+    # only beta - alpha is deduplicated at its first (rule 1) position.
+    assert resolve_rule_templates(rules, [task]) == ("alpha.md", "zeta.md", "beta.md")
+
+
+def test_multi_task_union_semantics(tmp_path: Path) -> None:
+    """A rule matching any one task of the set selects its templates once."""
+    skills_dir = _make_skills_dir(tmp_path, ["api-conventions", "docs-style"])
+    _write_rules(
+        skills_dir,
+        "rules:\n"
+        "  - owned_files: 'src/api/*'\n"
+        "    skills: [api-conventions]\n"
+        "  - owned_files: 'docs/*'\n"
+        "    skills: [docs-style]\n",
+    )
+    rules = load_selection_rules(skills_dir)
+
+    unrelated = _make_task(owned_files=["scripts/build.sh"], task_id="T-A")
+    api = _make_task(owned_files=["src/api/users.py"], task_id="T-B")
+    docs = _make_task(owned_files=["docs/guide.md"], task_id="T-C")
+
+    # Only the second task matches the first rule -> union selects it.
+    assert resolve_rule_templates(rules, [unrelated, api]) == ("api-conventions.md",)
+    # Multiple tasks matching the same rule still yield one hit each.
+    assert resolve_rule_templates(rules, [api, api, docs]) == (
+        "api-conventions.md",
+        "docs-style.md",
+    )
+    # No task matches -> nothing selected.
+    assert resolve_rule_templates(rules, [unrelated]) == ()

--- a/tests/unit/skills/test_selection_rules.py
+++ b/tests/unit/skills/test_selection_rules.py
@@ -320,3 +320,58 @@ def test_known_task_type_tokens_track_the_scheduler_enum() -> None:
     from bernstein.core.skills.selection_rules import _KNOWN_TASK_TYPE_TOKENS
 
     assert {member.value for member in TaskType} == _KNOWN_TASK_TYPE_TOKENS
+
+
+def test_unknown_task_type_matches_no_typed_rule(tmp_path: Path) -> None:
+    """A present-but-unrecognized task_type fails closed on typed rules.
+
+    Coercing an unknown type to "standard" would inject operator-authored
+    skills into tasks that are explicitly not standard; only a genuinely
+    absent field defaults. Glob-only rules still apply - the failure is
+    scoped to the task_type axis.
+    """
+    from types import SimpleNamespace
+
+    skills_dir = _make_skills_dir(tmp_path, ["typed-skill", "glob-skill"])
+    _write_rules(
+        skills_dir,
+        """
+rules:
+  - owned_files: "src/**"
+    task_type: standard
+    skills: [typed-skill]
+  - owned_files: "src/**"
+    skills: [glob-skill]
+""",
+    )
+    rules = load_selection_rules(skills_dir)
+    future_task = SimpleNamespace(owned_files=["src/main.py"], task_type="future_type")
+    assert resolve_rule_templates(rules, [future_task]) == ("glob-skill.md",)
+
+    absent_task = SimpleNamespace(owned_files=["src/main.py"])
+    assert resolve_rule_templates(rules, [absent_task]) == ("typed-skill.md", "glob-skill.md")
+
+
+@pytest.mark.parametrize(
+    "escape_name",
+    ["/outside/secret.md", "../escape.md", "nested/dir-skill.md", "..\\win-escape.md"],
+)
+def test_rule_template_name_cannot_escape_the_skills_directory(tmp_path: Path, escape_name: str) -> None:
+    """Template names are bare file names; paths never leave the corpus.
+
+    An absolute entry replaces the base in a pathlib join and ".." walks
+    out of the skills directory, so without this rejection a rule table
+    could point the injector at any readable file on the host and have its
+    content injected as a vetted skill template.
+    """
+    skills_dir = _make_skills_dir(tmp_path, ["real-skill"])
+    _write_rules(
+        skills_dir,
+        f"""
+rules:
+  - owned_files: "src/**"
+    skills: ['{escape_name}']
+""",
+    )
+    with pytest.raises(SelectionRuleError, match="bare template file name"):
+        load_selection_rules(skills_dir)


### PR DESCRIPTION
# User description
## What

A declarative rule layer for skill selection: `templates/skills/selection-rules.yaml` maps `owned_files` globs (required axis) — optionally narrowed by `task_type` — to skill template names. Resolution is a pure function of the task fields and the rule table: no corpus statistics, no environment reads, no ordering sensitivity. Selected templates log `trigger_source: "rule"` through the existing activation-log mechanism.

Closes #3383.

## Why

The opt-in TF-IDF auto-route couples every candidate's score to the whole template corpus (`routing.py` idf), so adding one unrelated template can silently flip which skills a long-stable task receives — a determinism hole in a substrate whose value is that runs replay identically. The role map is corpus-immune but coarse. Rules give an operator a corpus-immune, task-shaped binding between the two.

Design as settled on the issue thread: no `role` axis (the schema rejects a `role` key at load — `ROLE_SKILL_MAP` already owns that binding, and a second binding creates two places to change one thing); `RoutableTask` untouched (the rule layer declares its own narrow protocol); `activation_log.py` untouched (`"rule"` is a value addition, not a schema change).

## How

- **`src/bernstein/core/skills/selection_rules.py`** (new): `load_selection_rules` (yaml.safe_load, loud validation: unknown keys, non-string globs, unknown `task_type`, `role` key rejected, rule naming a template absent from the skills dir → error naming the rule and the problem; empty table == no rules; names accepted with or without `.md`, both canonicalized) and `resolve_rule_templates` (pure; any-task union; deduplicated; ordered by rule position then name).
- **`skills_injector.py`**: between the role-map selection and the auto-route block — a single `is_file()` stat guards the layer, so an absent table never invokes the loader; role-binding wins for templates selected by both; rule-selected names flow into `select_auto_route_templates(excluded_templates=…)` so auto-route neither re-scores nor duplicates them.
- **Task types matched by token, not by enum identity**: importing `TaskType` from `bernstein.core.tasks` would break the import-linter contract "Adapters must not import scheduler internals" (the injector imports this module). The rule layer restates the four tokens as `_KNOWN_TASK_TYPE_TOKENS`; `test_known_task_type_tokens_track_the_scheduler_enum` pins the set against the enum so drift fails a scheduler-side test, not a user's rule table.
- **Fail-closed hardenings from review**: an absent `task_type` defaults to `"standard"`, but a present-and-unrecognized value matches no typed rule (never coerced to standard); rule template names must be bare file names — absolute paths, `..`, and posix/windows separators are load errors, so a rule table cannot reference files outside the skills directory.
- **`RuleSelectableTask` requires only `owned_files`**: `task_type` is read dynamically via `getattr` with fail-closed normalization, so requiring it in the protocol bought no checking and forced the injector call site into a cast that silenced exactly the shape mismatches mypy should catch. The cast is gone; mypy verifies the call structurally.
- **Merge-deciding property, proven first**: `test_no_rule_table_is_byte_identical_noop` asserts the injected file set and bytes, the activation-log lines, and a loader-invocation counter of zero are identical to a rule-less install.
- 20 tests, each named for the property it protects — corpus-invariance, the TF-IDF-shifts-while-rules-hold regression, fail-loud loading (missing template, malformed table), no-role-axis, conjunction narrowing, unknown-task-type-matches-no-typed-rule, containment (parametrized escapes incl. `..\` windows form), enum drift pin, both-layers precedence, auto-route exclusion, dedup/ordering, multi-task union.
- Fail-before/pass-after proven twice: pre-commit via `git stash -u` (module tests collapse to `ModuleNotFoundError`, integration tests fail) and independently re-verified post-commit by checking out pre-change `src/` (`test_rule_selected_skill_logs_trigger_source_rule` fails without the wiring).
- Docs: `docs/operations/skill-selection-rules.md` (schema, axes, precedence role-binding → rule → auto-route, fail-loud contract) + `docs/sdd/skill-selection-rules.md` (design rationale: layer placement, token matching vs the import contract, containment, no-table fast path), both in mkdocs nav; `bernstein agents-md sync` run (no diff — `core/skills/` is one module-map row).

## Verification

| Check | Result |
|---|---|
| `tests/unit/test_skills_injector.py` + `tests/unit/skills/` | 368 passed |
| `ruff check` / `ruff format --check` (changed files) | clean |
| `mypy` on the new module + injector | no issues |
| `uv run lint-imports` | 3 contracts kept, 0 broken |
| `bernstein agents-md sync` | clean, no drift |

Review findings: all three must-address findings fixed with `bot-ack` trailers in the fixing commits (`a0af575d3`: unknown-task-type coercion 3722348132, path containment 3722348146; `4cd6f1ecf`: unchecked cast 3722407536). The informational SDD-doc finding is resolved by `docs/sdd/skill-selection-rules.md` in `4cd6f1ecf`.

<!-- bot-ack: 3722453359 reason=rejected-false-positive -->
The informational naming finding on `docs/sdd/skill-selection-rules.md` ("restated token set" → "declared token set") is rejected as a false positive: "restated" is deliberate. `_KNOWN_TASK_TYPE_TOKENS` restates the values `TaskType` already states, on the far side of the import-linter boundary — a second statement of an existing original. The next clause ("cannot drift silently — pinned against the real enum") only parses for a restatement; a merely "declared" set has no original to drift from.

## Checklist

- [x] `uv run ruff check src/` passes (changed files)
- [ ] `uv run pyright src/` passes
- [x] `uv run python scripts/run_tests.py -x` passes (targeted: the two touched suites, 368 passed)
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)

- [x] User-visible README section updated (or N/A) — N/A: README does not describe skill selection; the operator surface is documented below
- [x] `docs/operations/.md` updated (or N/A) — new `docs/operations/skill-selection-rules.md`, in nav
- [x] `docs/api/` schema regenerated (or N/A) — N/A
- [x] `uv run bernstein agents-md sync` run (or N/A) — run; no drift
- [x] Tests cover the documented behaviour

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add declarative, corpus-independent skill selection through <code>selection_rules.py</code>, mapping task <code>owned_files</code> and optional <code>task_type</code> values to validated templates. Integrate rule resolution into <code>skills_injector.py</code> between role binding and TF-IDF auto-routing, preserve precedence and activation logging, and document the operator configuration.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3430?tool=ast&amp;topic=Declarative+rule+selection" rel="nofollow noreferrer noopener" target="_blank">Declarative rule selection</a>
        </td><td>Add validated YAML rules that select skill templates by task file globs and optional task types, with deterministic matching, deduplication, corpus invariance, fail-loud schema checks, and path containment.Modified files (4)<ul><li>docs/operations/skill-selection-rules.md</li>
<li>mkdocs.yml</li>
<li>src/bernstein/core/skills/selection_rules.py</li>
<li>tests/unit/skills/test_selection_rules.py</li></ul>Latest Contributors(2)<table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>fix(skills): fail clos...</td><td>August 05, 2026</td></tr>
<tr><td>chernistry</td><td>feat(eval): report a d...</td><td>August 03, 2026</td></tr></table></td></tr>
<tr><td><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3430?tool=ast&amp;topic=Skill+injection+flow" rel="nofollow noreferrer noopener" target="_blank">Skill injection flow</a>
        </td><td>Integrate rule-selected skills into injection with role-binding precedence, auto-route exclusion, <code>trigger_source: "rule"</code> activation entries, and a byte-identical no-op when no rule table exists.Modified files (2)<ul><li>src/bernstein/adapters/skills_injector.py</li>
<li>tests/unit/skills/test_injector_activation_log.py</li></ul>Latest Contributors(2)<table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>Wire selection rules i...</td><td>August 05, 2026</td></tr>
<tr><td>chernistry</td><td>fix(skills): route inj...</td><td>July 25, 2026</td></tr></table></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3430?tool=ast" rel="nofollow noreferrer noopener" target="_blank">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz" rel="nofollow noreferrer noopener" target="_blank">Customize your next review</a></sub>