### PR TITLE
fix(demo): make mock agents produce real completion evidence and allow demo merges

### DIFF
--- a/src/bernstein/adapters/AGENTS.md
+++ b/src/bernstein/adapters/AGENTS.md
@@ -13,6 +13,7 @@ invocation and streams results back; flat layout, one module per tool.
 | `capability_profile.py` | Declarative adapter capability profiles and profile factory |
 | `skills_injector.py` | Copies sanitized skill markdown into the worktree at dispatch |
 | `canary.py` | Nightly conformance canary matrix over adapter contracts |
+| `mock.py` | Mock agent for zero-API-key demos; produces the same completion evidence real agents do (`Modified:` log lines plus a per-fix commit scoped to the mutated file) |
 
 ## Invariants
 

--- a/src/bernstein/adapters/mock.py
+++ b/src/bernstein/adapters/mock.py
@@ -207,6 +207,43 @@ def write_log(path: Path, message: str) -> None:
         f.write(f"{time.time()} {message}\n")
 
 
+def record_modified(log_path: Path, rel_path: str) -> None:
+    """Write the completion-evidence line the orchestrator parses.
+
+    The log aggregator's ``file_modified`` pattern is ^-anchored
+    (``^(?:Modified|Created|Wrote|Updated): <path>``), so this line must
+    start the log line - the usual timestamp prefix would defeat it.
+    """
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(log_path, "a") as f:
+        f.write(f"Modified: {rel_path}\n")
+
+
+def commit_fix(workdir: Path, log_path: Path, message: str) -> None:
+    """Commit the applied fix on the worktree branch.
+
+    Real agents land their work as commits; the reaper's completion
+    evidence and the merge path both key off them. Degrades to
+    log-evidence only when git is unavailable, the workdir is not a
+    repository, or nothing changed.
+    """
+    import subprocess
+
+    git = [
+        "git",
+        "-c",
+        "user.name=bernstein-mock-agent",
+        "-c",
+        "user.email=mock-agent@bernstein.invalid",
+    ]
+    try:
+        subprocess.run([*git, "add", "-A"], cwd=workdir, check=True, capture_output=True, timeout=30)
+        subprocess.run([*git, "commit", "-m", message], cwd=workdir, check=True, capture_output=True, timeout=30)
+        write_log(log_path, f"Committed fix: {message}")
+    except Exception as exc:
+        write_log(log_path, f"⚠ commit skipped: {exc}")
+
+
 def fix_off_by_one(workdir: Path, log_path: Path) -> None:
     """Fix ITEMS[n] -> ITEMS[n - 1] off-by-one in app.py."""
     app_file = workdir / "app.py"
@@ -225,6 +262,7 @@ def fix_off_by_one(workdir: Path, log_path: Path) -> None:
             ),
         )
         app_file.write_text(content)
+        record_modified(log_path, "app.py")
         write_log(log_path, "✓ Fixed off-by-one: ITEMS[n] → ITEMS[n - 1] + bounds check")
     else:
         write_log(log_path, "⚠ off-by-one pattern not found (already fixed?)")
@@ -247,6 +285,7 @@ def fix_missing_import(workdir: Path, log_path: Path) -> None:
             "    msg = request.args.get(\"msg\", \"\")",
         )
         app_file.write_text(content)
+        record_modified(log_path, "app.py")
         write_log(log_path, "✓ Fixed missing import: added 'request' to flask imports")
     elif "from flask import Flask, jsonify" in content and "request" not in content.split("\n")[1]:
         content = content.replace(
@@ -255,6 +294,7 @@ def fix_missing_import(workdir: Path, log_path: Path) -> None:
             1,
         )
         app_file.write_text(content)
+        record_modified(log_path, "app.py")
         write_log(log_path, "✓ Fixed missing import: added 'request' to flask imports")
     else:
         write_log(log_path, "⚠ missing import pattern not found (already fixed?)")
@@ -272,6 +312,7 @@ def fix_health_status(workdir: Path, log_path: Path) -> None:
     if old_line in content:
         content = content.replace(old_line, new_line)
         app_file.write_text(content)
+        record_modified(log_path, "app.py")
         write_log(log_path, "✓ Fixed health status code: 201 → 200")
     else:
         write_log(log_path, "⚠ health status code pattern not found (already fixed?)")
@@ -295,6 +336,7 @@ def fix_broken_test(workdir: Path, log_path: Path) -> None:
             '\n    ',
         )
         test_file.write_text(content)
+        record_modified(log_path, "tests/test_app.py")
         write_log(log_path, "✓ Fixed broken test: status_code 404 → 200")
     else:
         write_log(log_path, "⚠ broken test pattern not found (already fixed?)")
@@ -390,6 +432,9 @@ def main():
         fix_broken_test(workdir, log_path)
     else:
         write_log(log_path, f"Unknown task type: {task_name} - no-op")
+
+    if task_name in ("off_by_one", "missing_import", "health_status", "broken_test"):
+        commit_fix(workdir, log_path, f"demo: {task_name.replace('_', ' ')}")
 
     time.sleep(0.5)
     write_log(log_path, "Mock agent completed successfully")

--- a/src/bernstein/adapters/mock.py
+++ b/src/bernstein/adapters/mock.py
@@ -219,12 +219,14 @@ def record_modified(log_path: Path, rel_path: str) -> None:
         f.write(f"Modified: {rel_path}\n")
 
 
-def commit_fix(workdir: Path, log_path: Path, message: str) -> None:
-    """Commit the applied fix on the worktree branch.
+def commit_fix(workdir: Path, log_path: Path, message: str, rel_path: str) -> None:
+    """Commit exactly the fixed file on the worktree branch.
 
     Real agents land their work as commits; the reaper's completion
-    evidence and the merge path both key off them. Degrades to
-    log-evidence only when git is unavailable, the workdir is not a
+    evidence and the merge path both key off them. Staging and the
+    commit are both restricted to ``rel_path`` so a resumed worktree's
+    unrelated edits are never swept into this task's output. Degrades
+    to log-evidence only when git is unavailable, the workdir is not a
     repository, or nothing changed.
     """
     import subprocess
@@ -237,109 +239,117 @@ def commit_fix(workdir: Path, log_path: Path, message: str) -> None:
         "user.email=mock-agent@bernstein.invalid",
     ]
     try:
-        subprocess.run([*git, "add", "-A"], cwd=workdir, check=True, capture_output=True, timeout=30)
-        subprocess.run([*git, "commit", "-m", message], cwd=workdir, check=True, capture_output=True, timeout=30)
+        subprocess.run([*git, "add", "--", rel_path], cwd=workdir, check=True, capture_output=True, timeout=30)
+        subprocess.run(
+            [*git, "commit", "-m", message, "--", rel_path],
+            cwd=workdir,
+            check=True,
+            capture_output=True,
+            timeout=30,
+        )
         write_log(log_path, f"Committed fix: {message}")
     except Exception as exc:
         write_log(log_path, f"⚠ commit skipped: {exc}")
 
 
-def fix_off_by_one(workdir: Path, log_path: Path) -> None:
+def fix_off_by_one(workdir: Path, log_path: Path) -> str | None:
     """Fix ITEMS[n] -> ITEMS[n - 1] off-by-one in app.py."""
     app_file = workdir / "app.py"
     if not app_file.exists():
         write_log(log_path, "⚠ app.py not found")
-        return
+        return None
     content = app_file.read_text()
-    if "ITEMS[n]" in content:
-        content = content.replace(
-            "return jsonify({\"id\": n, \"item\": ITEMS[n]})  # off-by-one",
-            (
-                "if n < 1 or n > len(ITEMS):\n"
-                "        from flask import abort\n"
-                "        abort(404)\n"
-                "    return jsonify({\"id\": n, \"item\": ITEMS[n - 1]})"
-            ),
-        )
-        app_file.write_text(content)
-        record_modified(log_path, "app.py")
+    # Mutation ground truth is content inequality, not substring presence:
+    # the fixture's docstring also mentions ITEMS[n], so a rerun in an
+    # already-fixed worktree would otherwise claim work it never did.
+    fixed = content.replace(
+        "return jsonify({\"id\": n, \"item\": ITEMS[n]})  # off-by-one",
+        (
+            "if n < 1 or n > len(ITEMS):\n"
+            "        from flask import abort\n"
+            "        abort(404)\n"
+            "    return jsonify({\"id\": n, \"item\": ITEMS[n - 1]})"
+        ),
+    )
+    if fixed != content:
+        app_file.write_text(fixed)
         write_log(log_path, "✓ Fixed off-by-one: ITEMS[n] → ITEMS[n - 1] + bounds check")
-    else:
-        write_log(log_path, "⚠ off-by-one pattern not found (already fixed?)")
+        return "app.py"
+    write_log(log_path, "⚠ off-by-one pattern not found (already fixed?)")
+    return None
 
 
-def fix_missing_import(workdir: Path, log_path: Path) -> None:
+def fix_missing_import(workdir: Path, log_path: Path) -> str | None:
     """Add 'request' to the flask import line in app.py."""
     app_file = workdir / "app.py"
     if not app_file.exists():
         write_log(log_path, "⚠ app.py not found")
-        return
+        return None
     content = app_file.read_text()
     old_import = "from flask import Flask, jsonify  # BUG 2: 'request' is missing from this import"
     new_import = "from flask import Flask, jsonify, request"
+    fixed = content
     if old_import in content:
-        content = content.replace(old_import, new_import)
+        fixed = fixed.replace(old_import, new_import)
         # Also remove the noqa/type-ignore comment from the echo route
-        content = content.replace(
+        fixed = fixed.replace(
             "    msg = request.args.get(\"msg\", \"\")  # type: ignore[name-defined]  # noqa: F821",
             "    msg = request.args.get(\"msg\", \"\")",
         )
-        app_file.write_text(content)
-        record_modified(log_path, "app.py")
-        write_log(log_path, "✓ Fixed missing import: added 'request' to flask imports")
     elif "from flask import Flask, jsonify" in content and "request" not in content.split("\n")[1]:
-        content = content.replace(
+        fixed = fixed.replace(
             "from flask import Flask, jsonify",
             "from flask import Flask, jsonify, request",
             1,
         )
-        app_file.write_text(content)
-        record_modified(log_path, "app.py")
+    if fixed != content:
+        app_file.write_text(fixed)
         write_log(log_path, "✓ Fixed missing import: added 'request' to flask imports")
-    else:
-        write_log(log_path, "⚠ missing import pattern not found (already fixed?)")
+        return "app.py"
+    write_log(log_path, "⚠ missing import pattern not found (already fixed?)")
+    return None
 
 
-def fix_health_status(workdir: Path, log_path: Path) -> None:
+def fix_health_status(workdir: Path, log_path: Path) -> str | None:
     """Remove incorrect HTTP 201 status from health endpoint in app.py."""
     app_file = workdir / "app.py"
     if not app_file.exists():
         write_log(log_path, "⚠ app.py not found")
-        return
+        return None
     content = app_file.read_text()
     old_line = '    return jsonify({"status": "healthy", "version": "1.0.0"}), 201  # type: ignore[return-value]'
     new_line = '    return jsonify({"status": "healthy", "version": "1.0.0"})'
-    if old_line in content:
-        content = content.replace(old_line, new_line)
-        app_file.write_text(content)
-        record_modified(log_path, "app.py")
+    fixed = content.replace(old_line, new_line)
+    if fixed != content:
+        app_file.write_text(fixed)
         write_log(log_path, "✓ Fixed health status code: 201 → 200")
-    else:
-        write_log(log_path, "⚠ health status code pattern not found (already fixed?)")
+        return "app.py"
+    write_log(log_path, "⚠ health status code pattern not found (already fixed?)")
+    return None
 
 
-def fix_broken_test(workdir: Path, log_path: Path) -> None:
+def fix_broken_test(workdir: Path, log_path: Path) -> str | None:
     """Fix the wrong status_code assertion in tests/test_app.py."""
     test_file = workdir / "tests" / "test_app.py"
     if not test_file.exists():
         write_log(log_path, "⚠ tests/test_app.py not found")
-        return
+        return None
     content = test_file.read_text()
-    if "assert resp.status_code == 404  # wrong - should be 200" in content:
-        content = content.replace(
-            "assert resp.status_code == 404  # wrong - should be 200",
-            "assert resp.status_code == 200",
-        )
-        # Also remove the BUG 4 docstring annotation
-        content = content.replace(
-            '\n    BUG 4: asserts 404 instead of 200.\n    ',
-            '\n    ',
-        )
-        test_file.write_text(content)
-        record_modified(log_path, "tests/test_app.py")
+    fixed = content.replace(
+        "assert resp.status_code == 404  # wrong - should be 200",
+        "assert resp.status_code == 200",
+    )
+    # Also remove the BUG 4 docstring annotation
+    fixed = fixed.replace(
+        '\n    BUG 4: asserts 404 instead of 200.\n    ',
+        '\n    ',
+    )
+    if fixed != content:
+        test_file.write_text(fixed)
         write_log(log_path, "✓ Fixed broken test: status_code 404 → 200")
-    else:
-        write_log(log_path, "⚠ broken test pattern not found (already fixed?)")
+        return "tests/test_app.py"
+    write_log(log_path, "⚠ broken test pattern not found (already fixed?)")
+    return None
 
 
 def _idle_mode(log_path: Path) -> None:
@@ -422,19 +432,25 @@ def main():
     # Simulate realistic agent work time
     time.sleep(1.5)
 
+    modified = None
     if task_name == "off_by_one":
-        fix_off_by_one(workdir, log_path)
+        modified = fix_off_by_one(workdir, log_path)
     elif task_name == "missing_import":
-        fix_missing_import(workdir, log_path)
+        modified = fix_missing_import(workdir, log_path)
     elif task_name == "health_status":
-        fix_health_status(workdir, log_path)
+        modified = fix_health_status(workdir, log_path)
     elif task_name == "broken_test":
-        fix_broken_test(workdir, log_path)
+        modified = fix_broken_test(workdir, log_path)
     else:
         write_log(log_path, f"Unknown task type: {task_name} - no-op")
 
-    if task_name in ("off_by_one", "missing_import", "health_status", "broken_test"):
-        commit_fix(workdir, log_path, f"demo: {task_name.replace('_', ' ')}")
+    # Commit first, evidence second: only a task that actually mutated a
+    # file commits, only the mutated path is staged, and the ``Modified:``
+    # completion-evidence line is emitted once the work is finalized (the
+    # commit landed, or the commit degraded to log-only without git).
+    if modified is not None:
+        commit_fix(workdir, log_path, f"demo: {task_name.replace('_', ' ')}", modified)
+        record_modified(log_path, modified)
 
     time.sleep(0.5)
     write_log(log_path, "Mock agent completed successfully")

--- a/src/bernstein/cli/run_confirm.py
+++ b/src/bernstein/cli/run_confirm.py
@@ -865,6 +865,16 @@ def demo(dry_run: bool, real: bool, adapter: str | None, timeout: int) -> None:
     server_url = f"http://127.0.0.1:{_DEMO_PORT}"
     orchestration_start = time.monotonic()
 
+    # The demo project is a throwaway temp repo whose default branch IS the
+    # intended integration target: without the documented escape hatch every
+    # agent merge is refused with ``target-is-default-branch`` and the summary
+    # can only ever report 0 fixed bugs (issue #3431). Scoped to this run and
+    # restored on exit so an in-process caller does not inherit demo policy.
+    from bernstein.core.agents.spawner_merge import ENV_ALLOW_MERGE_TO_DEFAULT_BRANCH
+
+    prior_allow_merge = os.environ.get(ENV_ALLOW_MERGE_TO_DEFAULT_BRANCH)
+    os.environ[ENV_ALLOW_MERGE_TO_DEFAULT_BRANCH] = "1"
+
     outcome: _DemoOutcome | None = None
     bootstrap_error: Exception | None = None
     try:
@@ -894,6 +904,10 @@ def demo(dry_run: bool, real: bool, adapter: str | None, timeout: int) -> None:
         bootstrap_failed(exc).print()
         bootstrap_error = exc
     finally:
+        if prior_allow_merge is None:
+            os.environ.pop(ENV_ALLOW_MERGE_TO_DEFAULT_BRANCH, None)
+        else:
+            os.environ[ENV_ALLOW_MERGE_TO_DEFAULT_BRANCH] = prior_allow_merge
         _stop_demo_processes(project_dir)
 
     if outcome is not None and outcome.all_fixed:

--- a/tests/unit/test_cli_demo.py
+++ b/tests/unit/test_cli_demo.py
@@ -390,3 +390,67 @@ def test_demo_tasks_content_includes_role():
     """Every demo task must specify a **Role:** field."""
     for task in DEMO_TASKS:
         assert "**Role:**" in task["content"], task["filename"]
+
+
+# ---------------------------------------------------------------------------
+# demo command - default-branch merge escape hatch (issue #3431)
+# ---------------------------------------------------------------------------
+
+
+def test_demo_opts_into_default_branch_merges_for_the_run(tmp_path, monkeypatch):
+    """Demo merges target the throwaway repo's default branch; without the
+    escape hatch every merge is refused as ``target-is-default-branch`` and
+    the summary can only ever report 0 fixed bugs (issue #3431). The opt-in
+    must be live when bootstrap spawns and must not leak past the command.
+    """
+    import os
+
+    from bernstein.core.agents.spawner_merge import ENV_ALLOW_MERGE_TO_DEFAULT_BRANCH
+
+    monkeypatch.delenv(ENV_ALLOW_MERGE_TO_DEFAULT_BRANCH, raising=False)
+    seen: dict[str, str | None] = {}
+
+    def _capture_env(*args, **kwargs):
+        seen["at_bootstrap"] = os.environ.get(ENV_ALLOW_MERGE_TO_DEFAULT_BRANCH)
+
+    outcome = run_confirm._DemoOutcome(done=4, failed=0, total=4, cost_usd=0.0)
+    runner = CliRunner()
+    with (
+        patch.object(run_confirm, "setup_demo_project"),
+        patch.object(run_confirm, "_poll_demo_completion"),
+        patch.object(run_confirm, "_stop_demo_processes"),
+        patch.object(run_confirm, "_fetch_demo_outcome", return_value=outcome),
+        patch("bernstein.core.bootstrap.bootstrap_from_goal", side_effect=_capture_env),
+        patch("tempfile.mkdtemp", return_value=str(tmp_path)),
+    ):
+        result = runner.invoke(cli, ["demo", "--timeout", "1"])
+
+    assert result.exit_code == 0, result.output
+    assert seen["at_bootstrap"] == "1"
+    assert ENV_ALLOW_MERGE_TO_DEFAULT_BRANCH not in os.environ
+
+
+def test_demo_restores_the_operators_prior_merge_policy(tmp_path, monkeypatch):
+    """An operator's explicit merge-policy setting must survive a demo run
+    unchanged - the demo's opt-in is scoped to the run, not a global flip.
+    """
+    import os
+
+    from bernstein.core.agents.spawner_merge import ENV_ALLOW_MERGE_TO_DEFAULT_BRANCH
+
+    monkeypatch.setenv(ENV_ALLOW_MERGE_TO_DEFAULT_BRANCH, "0")
+
+    outcome = run_confirm._DemoOutcome(done=4, failed=0, total=4, cost_usd=0.0)
+    runner = CliRunner()
+    with (
+        patch.object(run_confirm, "setup_demo_project"),
+        patch.object(run_confirm, "_poll_demo_completion"),
+        patch.object(run_confirm, "_stop_demo_processes"),
+        patch.object(run_confirm, "_fetch_demo_outcome", return_value=outcome),
+        patch("bernstein.core.bootstrap.bootstrap_from_goal"),
+        patch("tempfile.mkdtemp", return_value=str(tmp_path)),
+    ):
+        result = runner.invoke(cli, ["demo", "--timeout", "1"])
+
+    assert result.exit_code == 0, result.output
+    assert os.environ[ENV_ALLOW_MERGE_TO_DEFAULT_BRANCH] == "0"

--- a/tests/unit/test_mock_adapter.py
+++ b/tests/unit/test_mock_adapter.py
@@ -7,6 +7,9 @@ and can be used for integration-style tests without real API calls.
 from __future__ import annotations
 
 import asyncio
+import json
+import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -297,3 +300,100 @@ def test_mock_default_model_coerces_claude_tier_instead_of_refusing() -> None:
         adapter_default_model=MockAgentAdapter.default_model,
     )
     assert coerced.model == MockAgentAdapter.default_model
+
+
+# ---------------------------------------------------------------------------
+# Completion evidence - the mock must present what real agents present
+# (issue #3431)
+# ---------------------------------------------------------------------------
+
+
+def _make_demo_workdir(tmp_path: Path) -> Path:
+    """Seed the real demo fixture project (Flask app + git repo with HEAD)."""
+    from bernstein.cli.run_confirm import setup_demo_project
+
+    project = tmp_path / "demo-project"
+    project.mkdir()
+    setup_demo_project(project, "mock")
+    return project
+
+
+def _run_mock_script(workdir: Path, task_name: str, tmp_path: Path) -> Path:
+    """Execute the embedded mock-agent script exactly as ``spawn()`` does."""
+    from bernstein.adapters.mock import MockAgentAdapter
+
+    script = tmp_path / "mock_script.py"
+    script.write_text(MockAgentAdapter._build_mock_script())
+    log_path = workdir / ".sdd" / "runtime" / "agent-mock-test.log"
+    task_info = json.dumps({"workdir": str(workdir), "task_name": task_name, "log_path": str(log_path)})
+    subprocess.run(
+        [sys.executable, str(script), task_info],
+        check=True,
+        timeout=60,
+        capture_output=True,
+    )
+    return log_path
+
+
+def test_mock_fix_evidence_parses_into_files_modified(tmp_path: Path) -> None:
+    """The dead-agent reap path auto-completes only when the log aggregator
+    extracts a non-empty ``files_modified``. Prose-only, timestamp-prefixed
+    lines never match its ^-anchored ``file_modified`` pattern - which is how
+    every demo task ended up failed as unverified (issue #3431). The assertion
+    runs through the real consumer, not a string grep of the log.
+    """
+    from bernstein.core.agents.agent_log_aggregator import AgentLogAggregator
+
+    project = _make_demo_workdir(tmp_path)
+    log_path = _run_mock_script(project, "off_by_one", tmp_path)
+
+    summary = AgentLogAggregator(project).parse_log("agent-mock-test", log_path=log_path)
+    assert "app.py" in summary.files_modified
+
+
+def test_mock_fix_commits_on_the_worktree_branch(tmp_path: Path) -> None:
+    """The reap path's second evidence check and the merge path both key off
+    commits on the branch; an edit left uncommitted can never merge back into
+    the demo project (issue #3431).
+    """
+
+    def _count(project: Path) -> int:
+        out = subprocess.run(
+            ["git", "rev-list", "--count", "HEAD"],
+            cwd=project,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        return int(out.strip())
+
+    project = _make_demo_workdir(tmp_path)
+    before = _count(project)
+    _run_mock_script(project, "health_status", tmp_path)
+
+    assert _count(project) == before + 1
+    porcelain = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=project,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert porcelain.strip() == "", porcelain
+
+
+def test_mock_without_git_repo_degrades_to_log_evidence(tmp_path: Path) -> None:
+    """A workdir that is not a git repository must not crash the agent: the
+    fix is still applied, the ``Modified:`` evidence line still parses, and
+    the skipped commit is recorded instead of raised.
+    """
+    import shutil
+
+    project = _make_demo_workdir(tmp_path)
+    shutil.rmtree(project / ".git")
+
+    log_path = _run_mock_script(project, "off_by_one", tmp_path)
+
+    text = log_path.read_text(encoding="utf-8")
+    assert any(line.startswith("Modified: app.py") for line in text.splitlines())
+    assert "commit skipped" in text

--- a/tests/unit/test_mock_adapter.py
+++ b/tests/unit/test_mock_adapter.py
@@ -397,3 +397,80 @@ def test_mock_without_git_repo_degrades_to_log_evidence(tmp_path: Path) -> None:
     text = log_path.read_text(encoding="utf-8")
     assert any(line.startswith("Modified: app.py") for line in text.splitlines())
     assert "commit skipped" in text
+
+
+def test_noop_task_neither_commits_nor_claims_evidence(tmp_path: Path) -> None:
+    """A task whose fix pattern is absent (already fixed) must not commit
+    anything - especially not unrelated worktree edits swept up by broad
+    staging - and must not emit a ``Modified:`` evidence line for work it
+    did not do (finding 3722894413).
+    """
+
+    def _count(project: Path) -> int:
+        out = subprocess.run(
+            ["git", "rev-list", "--count", "HEAD"],
+            cwd=project,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        return int(out.strip())
+
+    project = _make_demo_workdir(tmp_path)
+    # First run applies the fix and commits it; the rerun sees no pattern.
+    _run_mock_script(project, "off_by_one", tmp_path)
+    after_first = _count(project)
+    # An unrelated edit a resumed worktree might carry.
+    unrelated = project / "requirements.txt"
+    unrelated.write_text(unrelated.read_text() + "\n# unrelated local edit\n")
+
+    log_path = project / ".sdd" / "runtime" / "agent-rerun.log"
+    task_info = json.dumps({"workdir": str(project), "task_name": "off_by_one", "log_path": str(log_path)})
+    script = tmp_path / "mock_script.py"
+    subprocess.run([sys.executable, str(script), task_info], check=True, timeout=60, capture_output=True)
+
+    assert _count(project) == after_first
+    assert "Modified:" not in log_path.read_text(encoding="utf-8")
+    porcelain = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=project,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert " M requirements.txt" in porcelain
+
+
+def test_commit_contains_only_the_fixed_file(tmp_path: Path) -> None:
+    """The task's commit must carry exactly the file the fix mutated; an
+    unrelated dirty file in the worktree stays uncommitted (finding
+    3722894413), and the evidence line lands only after the commit
+    (finding 3722894421 - ordering pinned via the log).
+    """
+    project = _make_demo_workdir(tmp_path)
+    unrelated = project / "requirements.txt"
+    unrelated.write_text(unrelated.read_text() + "\n# unrelated local edit\n")
+
+    log_path = _run_mock_script(project, "health_status", tmp_path)
+
+    committed = subprocess.run(
+        ["git", "show", "--name-only", "--format=", "HEAD"],
+        cwd=project,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.split()
+    assert committed == ["app.py"]
+    porcelain = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=project,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert " M requirements.txt" in porcelain
+
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    committed_at = next(i for i, ln in enumerate(lines) if "Committed fix:" in ln)
+    evidence_at = next(i for i, ln in enumerate(lines) if ln.startswith("Modified: app.py"))
+    assert committed_at < evidence_at


### PR DESCRIPTION
## What

`bernstein demo` — the zero-API-key first contact — has been reporting **0 / 4 bugs fixed** on every run of current `main`, with all four tasks failed as unverified, retried, and quarantined. This PR makes the demo whole again: **4 / 4, exit 0**, with real merge commits in the demo project.

Closes #3431.

## Root causes (three, compounding — none in the hardening itself)

1. **The mock's log lines don't speak the completion-evidence contract.** The dead-agent reap path auto-completes a task only when `AgentLogAggregator` extracts a non-empty `files_modified` — from log lines matching the `^`-anchored pattern `^(?:Modified|Created|Wrote|Updated): <path>` (`agent_log_aggregator.py:60`). The mock's `write_log` prefixes every line with an epoch timestamp and logs prose (`✓ Fixed …`), so the pattern can never match.
2. **The mock never commits**, so the second evidence check (`_has_git_commits_on_branch`) is also always false. With both checks empty and a clean ~3.5 s exit, the fast-exit hardening (issues #2810/#2806) correctly fails the task as unverified. The hardening is doing its job; the mock produced none of the evidence the contract asks for.
3. **Every demo merge was refused** with `target-is-default-branch` (`spawner_merge.py:184`): the throwaway demo repo's only branch is `main`, and `bernstein demo` never set the documented escape hatch, so even completed work could never land and the summary's bug count could never move.

## How

- The embedded mock script writes the aggregator-contract evidence line (`Modified: <path>`, at line start — the usual timestamp prefix would defeat the `^` anchor) after each applied fix.
- Each `fix_*` helper returns the modified relative path, with mutation ground truth being **content inequality** — not substring presence, which the fixture's own docstring defeats on a rerun in an already-fixed worktree.
- The mock commits **exactly the fixed file** on the worktree branch (pathspec-scoped `git add`/`git commit`, explicit demo identity `bernstein-mock-agent <mock-agent@bernstein.invalid>`); a resumed worktree's unrelated edits are never swept into a task's output. Commit first, evidence second; degrades to log-only evidence when git is unavailable or nothing changed.
- `bernstein demo` exports `BERNSTEIN_ALLOW_MERGE_TO_DEFAULT_BRANCH=1` for the run — the demo project is a throwaway temp repo whose default branch *is* the intended integration target, exactly the documented use of the escape hatch — and restores the operator's prior value in `finally`, so nothing leaks past the command.
- No changes to fast-exit thresholds or semantics.
- `src/bernstein/adapters/AGENTS.md` reviewed against its scope per the staleness report on this range; key-files table gains `mock.py`.

## Verification

| Check | Result |
|---|---|
| **End-to-end**: `uv run bernstein demo` on this branch | `✓ Orchestration finished`, **Bugs fixed 4 / 4**, exit 0 — re-proven after the review-round refactor |
| Demo project git log after the run | real `Merge agent/backend-*` commits; `refused_merges.jsonl` absent |
| `tests/unit/test_mock_adapter.py` + `tests/unit/test_cli_demo.py` | 45 passed |
| Fail-before (src stashed) | `test_mock_fix_evidence_parses_into_files_modified`, `test_mock_fix_commits_on_the_worktree_branch`, `test_mock_without_git_repo_degrades_to_log_evidence`, `test_demo_opts_into_default_branch_merges_for_the_run` all FAIL on pre-fix source |
| `ruff check` / `ruff format --check` (changed files) | clean |
| `mypy` on both src files | 14 pre-existing errors, identical on pristine `main` (verified by stash) — zero introduced |
| `uv run lint-imports` | 3 contracts kept, 0 broken |

## Review findings

Both first-round must-address findings are fixed with `bot-ack` trailers in `58e5bd4fd` (no-op commits sweeping unrelated work `3722894413` — real, and the regression test additionally caught the substring/docstring false-success on reruns; evidence-before-commit ordering `3722894421` — the stated race is unreachable since the reap path reads the log only after the agent process exits, but the commit-then-evidence ordering was adopted anyway as part of the same refactor). Baz confirmed both.

<!-- bot-ack: 3722999859 reason=rejected-false-positive -->
The lineage-boundary findings on the second-round head ("Mock fixes bypass mandatory lineage recording", `3722999859`, and its medium sibling on `commit_fix`) are **rejected as false positives**. The mock's subprocess is the simulated CLI agent, and the codebase explicitly documents that spawned CLI-agent file writes do not cross the `record_artifact_write` boundary: `base.py:1029-1032` — "CLI-adapter runs spawn a subprocess (qwen, claude, ...) that writes files directly on disk without crossing this boundary … `LineageSpine.verify` reports … `SEAL_ONLY`" — with the same statement in `record_artifact_write`'s docstring, and the gap tracked globally as issue #2789. The `AGENTS.md` invariant forbids *adapter-side, in-process* artifact write paths; this PR adds none (the in-process adapter code is untouched, and the mock's direct file writes predate this PR entirely). The commits are the completion-evidence contract the orchestrator itself checks (`_has_git_commits_on_branch`) — the core execution model for `code_diff` tasks, identical to every real adapter run. Routing demo edits through `record_artifact_write` would make the demo display a lineage posture (clean pass instead of `SEAL_ONLY`) that **no real adapter run can produce** — faking exactly the kind of evidence the demo-honesty work (#3426) exists to remove. If subprocess writes are ever to be captured, that is issue #2789's scope, for all adapters at once — not a mock-only side channel.

## Documentation duty

- README: N/A — the README's demo description already promises what the demo now actually does; no surface changed.
- `docs/operations/`: N/A — `BERNSTEIN_ALLOW_MERGE_TO_DEFAULT_BRANCH` is already the documented escape hatch (issue #2756 surfacing); the demo's scoped use is internal plumbing.
- `docs/api/`: N/A. `agents-md sync`: N/A — no module purpose changed; `adapters/AGENTS.md` hand-reviewed per the staleness report.
- Tests cover the documented behaviour.