### PR TITLE
fix(ci): give the ratchet PR step the base a detached checkout cannot infer

### DIFF
--- a/.github/workflows/coverage-ratchet.yml
+++ b/.github/workflows/coverage-ratchet.yml
@@ -317,6 +317,12 @@ jobs:
           # publish `CI gate` and `review-bot-ack`, so it can never satisfy
           # branch protection. See the header block.
           token: ${{ secrets.BERNSTEIN_AUTOSYNC_TOKEN || secrets.GITHUB_TOKEN }}
+          # The checkout above is a detached commit (the measured SHA), so
+          # create-pull-request cannot infer the base branch and hard-fails
+          # without an explicit one (issue #3434). The ratchet's base was
+          # always main - the guard step reasons about "the baseline
+          # committed on main".
+          base: main
           # Stable branch so create-pull-request UPDATES the single open
           # ratchet PR in place instead of opening a fresh PR every push.
           branch: coverage-ratchet/baseline

--- a/tests/unit/test_coverage_ratchet_workflow_yaml.py
+++ b/tests/unit/test_coverage_ratchet_workflow_yaml.py
@@ -118,6 +118,19 @@ def test_pr_is_opened_with_a_token_that_triggers_workflows(steps: list[dict]) ->
     )
 
 
+def test_pr_step_supplies_base_for_the_detached_checkout(steps: list[dict]) -> None:
+    """The workflow checks out the measured commit - a detached HEAD - and
+    create-pull-request cannot infer a base from a detached HEAD. Without an
+    explicit ``base`` the step hard-fails exactly and only on the runs that
+    actually bump the baseline: the branch is force-pushed, no PR ever opens,
+    and the main round goes red on every genuine coverage increase
+    (issue #3434)."""
+    assert _create_pr_step(steps)["with"].get("base") == "main", (
+        "the ratchet PR's base was always meant to be main - the downward "
+        "guard explicitly reasons about the baseline committed on main"
+    )
+
+
 def test_downward_guard_exists_and_reads_the_ratchet_branch(steps: list[dict]) -> None:
     guard = _step_by_id(steps, "guard")
     assert RATCHET_BRANCH in yaml.safe_dump(guard), (


### PR DESCRIPTION
## What

Adds `base: main` to the coverage ratchet's `create-pull-request` step, plus a workflow-YAML test that pins it. Closes #3434.

## Why

The ratchet deliberately checks out **the commit the triggering CI run measured** (`ref: ${{ github.event.workflow_run.head_sha }}` — the reproducibility property of #3402: the tree the ratchet reads and the tree CI measured must be the same commit). That is a detached HEAD, and `peter-evans/create-pull-request` cannot infer a base branch from a detached HEAD — it hard-fails with `When the repository is checked out on a commit instead of a branch, the 'base' input must be supplied.`

The failure surfaces exactly and only on runs that actually bump the baseline, so it stayed invisible until the first genuine coverage increase after the rework: run 31033505283 on `654b444eb` force-pushed `coverage-ratchet/baseline` with the new mark, opened no PR, and turned the main round red.

`base: main` encodes existing intent — the workflow's own downward guard reasons about "the baseline committed on main".

## Verification

| Check | Result |
|---|---|
| `tests/unit/test_coverage_ratchet_workflow_yaml.py` | 17 passed |
| Fail-before | `test_pr_step_supplies_base_for_the_detached_checkout` FAILS with the workflow edit stashed |
| `ruff check` / `ruff format --check` (test file) | clean |
| `scripts/gen_workflow_topology.py` | regenerated, no drift |

The measured-commit checkout is untouched (pinned by the existing `test_checkout_pins_the_measured_commit`), so #3402's reproducibility property stays intact. The next coverage bump on `main` — likely the round after #3432 merges — will exercise the fixed step live and open/update the ratchet PR.

## Documentation duty

- README / `docs/operations/`: N/A — no operator-visible surface changed; `docs/operations/ci-topology.md` regenerated with no diff.
- `docs/api/` / `agents-md sync`: N/A — no module changes.
- Tests cover the documented behaviour (workflow-YAML structural pin).