### PR TITLE
fix(cli): unwrap the /status task shape in the demo poll and exit on the seeded count

### DIFF
--- a/src/bernstein/cli/commands/quickstart_cmd.py
+++ b/src/bernstein/cli/commands/quickstart_cmd.py
@@ -17,6 +17,7 @@ from bernstein.cli.helpers import (
     is_alive,
     print_banner,
 )
+from bernstein.cli.run_confirm import _lineage_progress, _status_task_rows
 
 _QUICKSTART_PORT = 8056
 _QUICKSTART_GOAL = "Add input validation, error handling, and tests to the TODO API"
@@ -176,23 +177,30 @@ def _poll_until_done(server_url: str, deadline: float) -> None:
         poll_task = progress.add_task("Agents working\u2026", total=None)
 
         while time.monotonic() < deadline:
-            with suppress(Exception):
+            # Suppress only the fetch; row processing runs OUTSIDE it. The
+            # broad suppress ate the shape crash below on every tick and
+            # made the early exit unreachable - the same defect fixed in
+            # the demo poll (issue #3433).
+            payload: Any = None
+            with suppress(httpx.HTTPError, ValueError):
                 resp = httpx.get(f"{server_url}/status", timeout=3.0, headers=auth_headers())
                 if resp.status_code == 200:
                     payload = resp.json()
-                    tasks_list: list[dict[str, Any]] = payload.get("tasks", [])
-                    done_count = sum(1 for t in tasks_list if t.get("status") == "done")
-                    failed_count = sum(1 for t in tasks_list if t.get("status") == "failed")
-                    total_tasks = len(tasks_list)
+            if payload is not None:
+                tasks_list = _status_task_rows(payload)
+                _log_task_transitions(tasks_list, seen_done, seen_failed, progress)
+                done_lineages, failed_lineages, all_lineages = _lineage_progress(tasks_list)
 
-                    _log_task_transitions(tasks_list, seen_done, seen_failed, progress)
-
-                    desc = f"Agents working\u2026 [green]{done_count}[/green]/{total_tasks} tasks done"
-                    if failed_count:
-                        desc += f"  [red]{failed_count} failed[/red]"
-                    progress.update(poll_task, description=desc)
-                    if total_tasks > 0 and done_count + failed_count >= total_tasks:
-                        break
+                desc = f"Agents working\u2026 [green]{len(done_lineages)}[/green]/{len(all_lineages)} tasks done"
+                if failed_lineages:
+                    desc += f"  [red]{len(failed_lineages)} failed[/red]"
+                progress.update(poll_task, description=desc)
+                # Exit early only when every lineage is done. A failed row
+                # is not terminal - its retry spawns as a new row with a
+                # fresh id - so exiting on done+failed would tear the run
+                # down while a fixing retry is still pending.
+                if all_lineages and done_lineages >= all_lineages:
+                    break
             time.sleep(2)
 
 

--- a/src/bernstein/cli/commands/quickstart_cmd.py
+++ b/src/bernstein/cli/commands/quickstart_cmd.py
@@ -159,8 +159,15 @@ def _log_task_transitions(
             progress.console.print(f"  [red]\u2717[/red] [{role}] {title}")
 
 
-def _poll_until_done(server_url: str, deadline: float) -> None:
-    """Poll the task server until all tasks finish or the deadline passes."""
+def _poll_until_done(server_url: str, deadline: float, *, expected_total: int = 0) -> None:
+    """Poll the task server until all tasks finish or the deadline passes.
+
+    ``expected_total`` is the seeded task count. The exit must compare
+    done lineages against it - not against the current snapshot's own
+    lineage set, which can be incomplete while rows are still being
+    registered and would let a partial snapshot tear the run down with
+    work remaining.
+    """
     from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 
     seen_done: set[str] = set()
@@ -190,16 +197,20 @@ def _poll_until_done(server_url: str, deadline: float) -> None:
                 tasks_list = _status_task_rows(payload)
                 _log_task_transitions(tasks_list, seen_done, seen_failed, progress)
                 done_lineages, failed_lineages, all_lineages = _lineage_progress(tasks_list)
+                target = expected_total if expected_total > 0 else len(all_lineages)
 
-                desc = f"Agents working\u2026 [green]{len(done_lineages)}[/green]/{len(all_lineages)} tasks done"
+                desc = f"Agents working\u2026 [green]{len(done_lineages)}[/green]/{target} tasks done"
                 if failed_lineages:
                     desc += f"  [red]{len(failed_lineages)} failed[/red]"
                 progress.update(poll_task, description=desc)
-                # Exit early only when every lineage is done. A failed row
-                # is not terminal - its retry spawns as a new row with a
-                # fresh id - so exiting on done+failed would tear the run
-                # down while a fixing retry is still pending.
-                if all_lineages and done_lineages >= all_lineages:
+                # Exit early only when the seeded count of lineages is
+                # done. A failed row is not terminal - its retry spawns as
+                # a new row with a fresh id - so exiting on done+failed
+                # would tear the run down while a fixing retry is still
+                # pending; and the snapshot's own lineage set is not a
+                # valid target either, since an incomplete snapshot would
+                # satisfy it with work remaining.
+                if target > 0 and len(done_lineages) >= target:
                     break
             time.sleep(2)
 
@@ -362,7 +373,11 @@ def quickstart_cmd(keep: bool, timeout: int, adapter: str | None) -> None:
             cli=detected,
         )
 
-        _poll_until_done(server_url, deadline=orchestration_start + timeout)
+        _poll_until_done(
+            server_url,
+            deadline=orchestration_start + timeout,
+            expected_total=len(_QUICKSTART_TASKS),
+        )
         console.print("[green]✓[/green] Orchestration finished")
 
     except KeyboardInterrupt:

--- a/src/bernstein/cli/run_confirm.py
+++ b/src/bernstein/cli/run_confirm.py
@@ -543,11 +543,15 @@ def _fetch_demo_outcome(server_url: str, *, expected_total: int) -> _DemoOutcome
             tasks_data = _status_task_rows(payload)
             total_cost = float(payload.get("total_cost_usd", 0.0) or 0.0)
 
-    # Count done against the seeded set. A failed task spawns a retry task with a
-    # fresh id, so the live list can balloon past the seeded count (banner said
-    # 4, summary said 12). Clamp done to the seeded total and derive "not fixed"
-    # from it so banner, progress and summary never disagree.
-    done = min(sum(1 for t in tasks_data if t.get("status") == "done"), expected_total)
+    # Count done LINEAGES against the seeded set. A failed task spawns a retry
+    # task with a fresh id, so the live list balloons past the seeded count
+    # (banner said 4, summary said 12) and a retried lineage can carry several
+    # done rows - counting rows would let duplicates satisfy the seeded total
+    # while another bug has no successful attempt at all. Clamp to the seeded
+    # total and derive "not fixed" from it so banner, progress and summary
+    # never disagree.
+    done_lineages, _, _ = _lineage_progress(tasks_data)
+    done = min(len(done_lineages), expected_total)
     failed = max(expected_total - done, 0)
     return _DemoOutcome(done=done, failed=failed, total=expected_total, cost_usd=total_cost)
 
@@ -692,6 +696,43 @@ def _status_task_rows(payload: Any) -> list[dict[str, Any]]:
     return [t for t in raw_tasks if isinstance(t, dict)]
 
 
+def _lineage_id(row: dict[str, Any]) -> str:
+    """Return the retry-lineage root for a ``/status`` task row.
+
+    The server exposes ``lineage_id`` (``metadata.original_task_id`` of a
+    retry, or the task's own id). ``title``/``id`` are kept as fallbacks
+    for older payload shapes so counting degrades to at-worst the raw
+    behaviour instead of crashing.
+    """
+    return str(row.get("lineage_id") or row.get("title") or row.get("id") or "")
+
+
+def _lineage_progress(rows: list[dict[str, Any]]) -> tuple[set[str], set[str], set[str]]:
+    """Return ``(done, failed, all)`` lineage-id sets for ``/status`` rows.
+
+    Counting rows double-counts retried work: a failed task's retry is a
+    NEW row with a fresh id, and duplicate ``done`` rows for one lineage
+    were observed live (a "6/8 bugs fixed" frame on a 4-bug demo). A
+    lineage is done when ANY of its rows is done; it is failed only while
+    none is.
+    """
+    done: set[str] = set()
+    failed: set[str] = set()
+    all_ids: set[str] = set()
+    for index, row in enumerate(rows):
+        # A row with no identity at all counts as its own lineage, so
+        # counting degrades to the raw per-row behaviour instead of
+        # silently dropping work from the tally.
+        lid = _lineage_id(row) or f"row-{index}"
+        all_ids.add(lid)
+        status = row.get("status")
+        if status == "done":
+            done.add(lid)
+        elif status == "failed":
+            failed.add(lid)
+    return done, failed - done, all_ids
+
+
 def _poll_demo_completion(server_url: str, deadline: float, *, expected_total: int = 0) -> None:
     """Poll demo server for task completion with live progress output.
 
@@ -700,8 +741,10 @@ def _poll_demo_completion(server_url: str, deadline: float, *, expected_total: i
     as failed tasks spawn retry tasks with fresh ids, and a failed original
     stays ``failed`` forever even after its retry succeeds, so neither
     "all rows done" nor "all rows terminal" can ever hold on a retried
-    run. Done-rows reaching the seeded count is the one exit condition
-    that matches what the summary will report.
+    run. Distinct DONE LINEAGES reaching the seeded count is the one exit
+    condition that matches what the summary will report - done *rows*
+    would double-count a retried lineage and tear the demo down with a
+    seeded bug still unfixed.
     """
     from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 
@@ -731,26 +774,25 @@ def _poll_demo_completion(server_url: str, deadline: float, *, expected_total: i
                     payload = resp.json()
             if payload is not None:
                 tasks_list = _status_task_rows(payload)
-                done_count, failed_count = _emit_task_events(tasks_list, seen_done, seen_failed, progress)
-                total_tasks = len(tasks_list)
+                _emit_task_events(tasks_list, seen_done, seen_failed, progress)
+                done_lineages, failed_lineages, all_lineages = _lineage_progress(tasks_list)
+                target = expected_total if expected_total > 0 else len(all_lineages)
                 progress.update(
                     poll_task,
                     description=(
                         f"Agents working\u2026 "
-                        f"[green]{done_count}[/green]/{total_tasks} bugs fixed"
-                        + (f"  [red]{failed_count} failed[/red]" if failed_count else "")
+                        f"[green]{len(done_lineages)}[/green]/{target} bugs fixed"
+                        + (f"  [red]{len(failed_lineages)} failed[/red]" if failed_lineages else "")
                     ),
                 )
-                # Leave early only when the seeded count is DONE. A failed
-                # row is not terminal (the lifecycle schedules a retry with
-                # a fresh id after retry_delay_s), so exiting on
-                # done+failed tears the demo down while a retry that would
-                # have fixed the bug is still pending; and a retried run
-                # can never have ALL rows done, because the failed original
-                # keeps its status forever. Runs that never reach the
-                # seeded count wait out the deadline, exactly as before.
-                target = expected_total if expected_total > 0 else total_tasks
-                if total_tasks > 0 and done_count >= target:
+                # Leave early only when the seeded count of LINEAGES is
+                # done. A failed row is not terminal (the lifecycle
+                # schedules a retry with a fresh id after retry_delay_s),
+                # so exiting on done+failed tears the demo down while a
+                # retry that would have fixed the bug is still pending.
+                # Runs that never reach the seeded count wait out the
+                # deadline, exactly as before.
+                if target > 0 and len(done_lineages) >= target:
                     break
             time.sleep(2)
 

--- a/src/bernstein/cli/run_confirm.py
+++ b/src/bernstein/cli/run_confirm.py
@@ -540,15 +540,7 @@ def _fetch_demo_outcome(server_url: str, *, expected_total: int) -> _DemoOutcome
         resp = httpx.get(f"{server_url}/status", timeout=3.0, headers=auth_headers())
         if resp.status_code == 200:
             payload = resp.json()
-            # /status returns tasks as {"count": N, "items": [...]}; tolerate a
-            # bare list too. Iterating the dict form would yield its string keys
-            # and crash on ``t.get`` (the historical AttributeError, #2075), so
-            # unwrap to the items list and keep only dict rows.
-            raw_tasks = payload.get("tasks", [])
-            if isinstance(raw_tasks, dict):
-                raw_tasks = raw_tasks.get("items", [])
-            if isinstance(raw_tasks, list):
-                tasks_data = [t for t in raw_tasks if isinstance(t, dict)]
+            tasks_data = _status_task_rows(payload)
             total_cost = float(payload.get("total_cost_usd", 0.0) or 0.0)
 
     # Count done against the seeded set. A failed task spawns a retry task with a
@@ -678,8 +670,39 @@ def cook(
         console.print("[yellow]Recipe monitor timed out before a final status snapshot was available.[/yellow]")
 
 
-def _poll_demo_completion(server_url: str, deadline: float) -> None:
-    """Poll demo server for task completion with live progress output."""
+def _status_task_rows(payload: Any) -> list[dict[str, Any]]:
+    """Unwrap the ``/status`` payload's task rows.
+
+    ``/status`` returns ``tasks`` as ``{"count": N, "items": [...]}``;
+    tolerate a bare list too. Iterating the dict form yields its string
+    keys and crashes on ``t.get`` - the historical AttributeError
+    (#2075), fixed in ``_fetch_demo_outcome`` but re-grown in the
+    completion poll, where the enclosing ``suppress()`` ate the crash on
+    every tick and the demo always ran to its full timeout (issue
+    #3433). One shared unwrap, so the next ``/status`` shape change
+    breaks one place, loudly, under test.
+    """
+    if not isinstance(payload, dict):
+        return []
+    raw_tasks = payload.get("tasks", [])
+    if isinstance(raw_tasks, dict):
+        raw_tasks = raw_tasks.get("items", [])
+    if not isinstance(raw_tasks, list):
+        return []
+    return [t for t in raw_tasks if isinstance(t, dict)]
+
+
+def _poll_demo_completion(server_url: str, deadline: float, *, expected_total: int = 0) -> None:
+    """Poll demo server for task completion with live progress output.
+
+    ``expected_total`` is the seeded task count - the same denominator
+    ``_fetch_demo_outcome`` clamps against. The live list balloons past it
+    as failed tasks spawn retry tasks with fresh ids, and a failed original
+    stays ``failed`` forever even after its retry succeeds, so neither
+    "all rows done" nor "all rows terminal" can ever hold on a retried
+    run. Done-rows reaching the seeded count is the one exit condition
+    that matches what the summary will report.
+    """
     from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 
     seen_done: set[str] = set()
@@ -696,23 +719,39 @@ def _poll_demo_completion(server_url: str, deadline: float) -> None:
         poll_task = progress.add_task("Agents working\u2026", total=None)
 
         while time.monotonic() < deadline:
-            with suppress(Exception):
+            # Suppress only the fetch (server not up yet, transient HTTP
+            # errors, non-JSON body). Row processing runs OUTSIDE the
+            # suppress: a payload-shape crash here must be loud - eating
+            # it silently is exactly how the early-exit condition below
+            # became unreachable for every demo run (issue #3433).
+            payload: Any = None
+            with suppress(httpx.HTTPError, ValueError):
                 resp = httpx.get(f"{server_url}/status", timeout=3.0, headers=auth_headers())
                 if resp.status_code == 200:
                     payload = resp.json()
-                    tasks_list: list[dict[str, Any]] = payload.get("tasks", [])
-                    done_count, failed_count = _emit_task_events(tasks_list, seen_done, seen_failed, progress)
-                    total_tasks = len(tasks_list)
-                    progress.update(
-                        poll_task,
-                        description=(
-                            f"Agents working\u2026 "
-                            f"[green]{done_count}[/green]/{total_tasks} bugs fixed"
-                            + (f"  [red]{failed_count} failed[/red]" if failed_count else "")
-                        ),
-                    )
-                    if total_tasks > 0 and done_count + failed_count >= total_tasks:
-                        break
+            if payload is not None:
+                tasks_list = _status_task_rows(payload)
+                done_count, failed_count = _emit_task_events(tasks_list, seen_done, seen_failed, progress)
+                total_tasks = len(tasks_list)
+                progress.update(
+                    poll_task,
+                    description=(
+                        f"Agents working\u2026 "
+                        f"[green]{done_count}[/green]/{total_tasks} bugs fixed"
+                        + (f"  [red]{failed_count} failed[/red]" if failed_count else "")
+                    ),
+                )
+                # Leave early only when the seeded count is DONE. A failed
+                # row is not terminal (the lifecycle schedules a retry with
+                # a fresh id after retry_delay_s), so exiting on
+                # done+failed tears the demo down while a retry that would
+                # have fixed the bug is still pending; and a retried run
+                # can never have ALL rows done, because the failed original
+                # keeps its status forever. Runs that never reach the
+                # seeded count wait out the deadline, exactly as before.
+                target = expected_total if expected_total > 0 else total_tasks
+                if total_tasks > 0 and done_count >= target:
+                    break
             time.sleep(2)
 
 
@@ -892,7 +931,7 @@ def demo(dry_run: bool, real: bool, adapter: str | None, timeout: int) -> None:
             cli=detected,
         )
 
-        _poll_demo_completion(server_url, orchestration_start + timeout)
+        _poll_demo_completion(server_url, orchestration_start + timeout, expected_total=len(DEMO_TASKS))
         # Snapshot the outcome while the server is still alive: cleanup below
         # tears it down, so a query after that would read an empty list.
         outcome = _fetch_demo_outcome(server_url, expected_total=len(DEMO_TASKS))

--- a/src/bernstein/cli/run_confirm.py
+++ b/src/bernstein/cli/run_confirm.py
@@ -700,9 +700,15 @@ def _lineage_id(row: dict[str, Any]) -> str:
     """Return the retry-lineage root for a ``/status`` task row.
 
     The server exposes ``lineage_id`` (``metadata.original_task_id`` of a
-    retry, or the task's own id). ``title``/``id`` are kept as fallbacks
-    for older payload shapes so counting degrades to at-worst the raw
-    behaviour instead of crashing.
+    retry, or the task's own id); modern rows always carry it. The
+    fallbacks exist only for older payload shapes, and their order is
+    deliberate: ``title`` BEFORE ``id``. In that regime a retry keeps its
+    title but gets a fresh id, so id-first would re-open the premature
+    green exit this ordering guards against (duplicate done rows
+    satisfying the seeded total while a bug has no successful attempt).
+    Title-first fails safe instead - distinct same-title rows collapse,
+    the count can only be too LOW, and the poll waits out its deadline
+    rather than tearing the run down early.
     """
     return str(row.get("lineage_id") or row.get("title") or row.get("id") or "")
 

--- a/src/bernstein/core/routes/status_dashboard.py
+++ b/src/bernstein/core/routes/status_dashboard.py
@@ -313,6 +313,12 @@ def _status_task_items(tasks: list[Task], now: float) -> list[dict[str, Any]]:
         items.append(
             {
                 "id": task.id,
+                # The retry lineage root: a failed task's retry is a NEW task
+                # with a fresh id carrying metadata.original_task_id, so raw
+                # done-row counts double-count a lineage that was retried.
+                # Consumers that compare progress against a seeded total
+                # (demo, quickstart) must count distinct lineage_ids instead.
+                "lineage_id": str(task.metadata.get("original_task_id") or task.id),
                 "title": task.title,
                 "role": task.role,
                 "status": task.status.value,

--- a/tests/unit/test_cli_demo.py
+++ b/tests/unit/test_cli_demo.py
@@ -454,3 +454,120 @@ def test_demo_restores_the_operators_prior_merge_policy(tmp_path, monkeypatch):
 
     assert result.exit_code == 0, result.output
     assert os.environ[ENV_ALLOW_MERGE_TO_DEFAULT_BRANCH] == "0"
+
+
+# ---------------------------------------------------------------------------
+# _poll_demo_completion - the /status shape and the early exit (issue #3433)
+# ---------------------------------------------------------------------------
+
+
+def test_poll_exits_early_on_the_dict_shaped_status_payload():
+    """``/status`` returns tasks as ``{"count": N, "items": [...]}``. The
+    poll used to iterate that dict, crash on its string keys inside
+    ``_emit_task_events``, and have the crash eaten by ``suppress()`` on
+    every tick - so the early-exit condition was unreachable and every
+    demo run burned the full timeout with a blank spinner (issue #3433).
+    """
+    import time as _time
+
+    payload = {
+        "tasks": {
+            "count": 2,
+            "items": [
+                {"id": "t1", "title": "a", "role": "backend", "status": "done"},
+                {"id": "t2", "title": "b", "role": "qa", "status": "done"},
+            ],
+        },
+    }
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = payload
+    with patch.object(run_confirm.httpx, "get", return_value=resp):
+        start = _time.monotonic()
+        run_confirm._poll_demo_completion("http://127.0.0.1:1", start + 6.0)
+        elapsed = _time.monotonic() - start
+    assert elapsed < 2.0, f"poll must exit on the first tick when all tasks are done; took {elapsed:.1f}s"
+
+
+def test_poll_processing_crashes_are_loud():
+    """The suppress covers only the HTTP fetch. A crash while processing
+    rows must propagate: silently eating it on every tick is exactly how
+    the dead early-exit hid inside a green-looking demo (issue #3433).
+    """
+    import time as _time
+
+    import pytest as _pytest
+
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = {"tasks": {"count": 1, "items": [{"id": "t", "status": "done"}]}}
+    with (
+        patch.object(run_confirm.httpx, "get", return_value=resp),
+        patch.object(run_confirm, "_emit_task_events", side_effect=RuntimeError("boom")),
+        _pytest.raises(RuntimeError, match="boom"),
+    ):
+        run_confirm._poll_demo_completion("http://127.0.0.1:1", _time.monotonic() + 4.0)
+
+
+def test_poll_keeps_waiting_while_a_failed_task_may_still_be_retried():
+    """A failed task is not terminal: the lifecycle schedules a retry with a
+    fresh task id after ``retry_delay_s``. Exiting on ``done + failed``
+    tears the demo down while the retry that would have fixed the bug is
+    still pending (observed live: 3/4 at 21 s instead of 4/4). Only an
+    all-done snapshot may end the poll early.
+    """
+    import time as _time
+
+    payload = {
+        "tasks": {
+            "count": 2,
+            "items": [
+                {"id": "t1", "title": "a", "role": "backend", "status": "done"},
+                {"id": "t2", "title": "b", "role": "qa", "status": "failed"},
+            ],
+        },
+    }
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = payload
+    with patch.object(run_confirm.httpx, "get", return_value=resp):
+        start = _time.monotonic()
+        run_confirm._poll_demo_completion("http://127.0.0.1:1", start + 3.0, expected_total=2)
+        elapsed = _time.monotonic() - start
+    assert elapsed >= 2.9, f"a failed task must keep the poll alive for retries; exited after {elapsed:.1f}s"
+
+
+def test_poll_exits_once_the_seeded_count_is_done_despite_failed_rows():
+    """A retried run can never have all rows done - the failed original
+    keeps its status forever while its retry (fresh id) succeeds - so the
+    exit must compare done rows against the seeded count, the same
+    denominator the summary clamps to. Observed live pre-fix: a retried
+    4/4 run still burned the full deadline.
+    """
+    import time as _time
+
+    payload = {
+        "tasks": {
+            "count": 3,
+            "items": [
+                {"id": "t1", "title": "a", "role": "backend", "status": "done"},
+                {"id": "t2", "title": "b", "role": "qa", "status": "failed"},
+                {"id": "t2r", "title": "b", "role": "qa", "status": "done"},
+            ],
+        },
+    }
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = payload
+    with patch.object(run_confirm.httpx, "get", return_value=resp):
+        start = _time.monotonic()
+        run_confirm._poll_demo_completion("http://127.0.0.1:1", start + 6.0, expected_total=2)
+        elapsed = _time.monotonic() - start
+    assert elapsed < 2.0, f"seeded count reached: poll must exit despite the failed original; took {elapsed:.1f}s"
+
+
+def test_status_rows_unwrap_tolerates_all_known_shapes():
+    """One shared unwrap for both /status consumers: the wrapped dict form,
+    the bare-list form, and garbage all resolve without raising."""
+    rows = [{"id": "t"}]
+    assert run_confirm._status_task_rows({"tasks": {"count": 1, "items": rows}}) == rows
+    assert run_confirm._status_task_rows({"tasks": rows}) == rows
+    assert run_confirm._status_task_rows({"tasks": {"count": 1, "items": "bad"}}) == []
+    assert run_confirm._status_task_rows({"tasks": "bad"}) == []
+    assert run_confirm._status_task_rows(["not-a-dict"]) == []

--- a/tests/unit/test_cli_demo.py
+++ b/tests/unit/test_cli_demo.py
@@ -571,3 +571,58 @@ def test_status_rows_unwrap_tolerates_all_known_shapes():
     assert run_confirm._status_task_rows({"tasks": {"count": 1, "items": "bad"}}) == []
     assert run_confirm._status_task_rows({"tasks": "bad"}) == []
     assert run_confirm._status_task_rows(["not-a-dict"]) == []
+
+
+def test_poll_counts_done_lineages_not_done_rows():
+    """Retry/orphan recovery produces several done rows for one seeded
+    lineage (a "6/8 bugs fixed" frame was observed live on a 4-bug demo).
+    Counting rows lets duplicates satisfy the seeded total while another
+    bug has no successful attempt - the poll must count distinct done
+    lineages (finding 3723321829).
+    """
+    import time as _time
+
+    payload = {
+        "tasks": {
+            "count": 3,
+            "items": [
+                {"id": "a", "lineage_id": "a", "title": "bug a", "role": "backend", "status": "done"},
+                {"id": "a2", "lineage_id": "a", "title": "bug a", "role": "backend", "status": "done"},
+                {"id": "b", "lineage_id": "b", "title": "bug b", "role": "qa", "status": "open"},
+            ],
+        },
+    }
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = payload
+    with patch.object(run_confirm.httpx, "get", return_value=resp):
+        start = _time.monotonic()
+        run_confirm._poll_demo_completion("http://127.0.0.1:1", start + 3.0, expected_total=2)
+        elapsed = _time.monotonic() - start
+    assert elapsed >= 2.9, (
+        f"two done rows of ONE lineage must not satisfy a seeded total of 2; exited after {elapsed:.1f}s"
+    )
+
+
+def test_fetch_outcome_counts_done_lineages_not_done_rows():
+    """The summary's all-fixed verdict must not be reachable by duplicate
+    done rows for one lineage while another seeded bug never succeeded
+    (finding 3723321829).
+    """
+    payload = {
+        "tasks": {
+            "count": 3,
+            "items": [
+                {"id": "a", "lineage_id": "a", "title": "bug a", "status": "done"},
+                {"id": "a2", "lineage_id": "a", "title": "bug a", "status": "done"},
+                {"id": "b", "lineage_id": "b", "title": "bug b", "status": "failed"},
+            ],
+        },
+        "total_cost_usd": 0.0,
+    }
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = payload
+    with patch.object(run_confirm.httpx, "get", return_value=resp):
+        outcome = run_confirm._fetch_demo_outcome("http://127.0.0.1:1", expected_total=2)
+    assert outcome.done == 1
+    assert outcome.failed == 1
+    assert not outcome.all_fixed

--- a/tests/unit/test_quickstart_poll.py
+++ b/tests/unit/test_quickstart_poll.py
@@ -33,7 +33,7 @@ def test_quickstart_poll_exits_early_on_the_dict_shaped_status_payload():
     ]
     with patch.object(quickstart_cmd.httpx, "get", return_value=_resp(items)):
         start = time.monotonic()
-        quickstart_cmd._poll_until_done("http://127.0.0.1:1", start + 6.0)
+        quickstart_cmd._poll_until_done("http://127.0.0.1:1", start + 6.0, expected_total=2)
         elapsed = time.monotonic() - start
     assert elapsed < 2.0, f"poll must exit on the first tick when everything is done; took {elapsed:.1f}s"
 
@@ -47,6 +47,24 @@ def test_quickstart_poll_keeps_waiting_while_a_failed_lineage_may_retry():
     ]
     with patch.object(quickstart_cmd.httpx, "get", return_value=_resp(items)):
         start = time.monotonic()
-        quickstart_cmd._poll_until_done("http://127.0.0.1:1", start + 3.0)
+        quickstart_cmd._poll_until_done("http://127.0.0.1:1", start + 3.0, expected_total=2)
         elapsed = time.monotonic() - start
     assert elapsed >= 2.9, f"a failed lineage must keep the poll alive for its retry; exited after {elapsed:.1f}s"
+
+
+def test_quickstart_poll_ignores_an_incomplete_snapshot():
+    """The current snapshot's own lineage set is not a valid completion
+    target: while rows are still being registered, a partial snapshot
+    whose visible lineages are all done would satisfy it and tear the
+    run down with work remaining (finding 3723410822). The exit must
+    wait for the seeded count of distinct done lineages.
+    """
+    items = [
+        {"id": "t1", "lineage_id": "t1", "title": "a", "role": "backend", "status": "done"},
+        {"id": "t2", "lineage_id": "t2", "title": "b", "role": "qa", "status": "done"},
+    ]
+    with patch.object(quickstart_cmd.httpx, "get", return_value=_resp(items)):
+        start = time.monotonic()
+        quickstart_cmd._poll_until_done("http://127.0.0.1:1", start + 3.0, expected_total=3)
+        elapsed = time.monotonic() - start
+    assert elapsed >= 2.9, f"2 done of 3 seeded must keep the poll alive; exited after {elapsed:.1f}s"

--- a/tests/unit/test_quickstart_poll.py
+++ b/tests/unit/test_quickstart_poll.py
@@ -1,0 +1,52 @@
+"""The quickstart completion poll against the real /status shape.
+
+``bernstein quickstart`` had the same defect the demo poll did (issue
+#3433, finding 3723321824): the wrapped ``tasks: {"count", "items"}``
+payload was iterated raw under a broad ``suppress(Exception)``, so the
+shape crash was eaten on every tick, the early exit was unreachable,
+and every quickstart run burned its full timeout. These tests drive
+``_poll_until_done`` through the shared unwrap and the lineage-aware
+exit.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+from bernstein.cli.commands import quickstart_cmd
+
+
+def _resp(items: list[dict]) -> MagicMock:
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = {"tasks": {"count": len(items), "items": items}}
+    return resp
+
+
+def test_quickstart_poll_exits_early_on_the_dict_shaped_status_payload():
+    """All lineages done on the first tick must end the poll immediately -
+    pre-fix the dict shape crashed row processing and the poll always ran
+    to its deadline behind a blank spinner."""
+    items = [
+        {"id": "t1", "lineage_id": "t1", "title": "a", "role": "backend", "status": "done"},
+        {"id": "t2", "lineage_id": "t2", "title": "b", "role": "qa", "status": "done"},
+    ]
+    with patch.object(quickstart_cmd.httpx, "get", return_value=_resp(items)):
+        start = time.monotonic()
+        quickstart_cmd._poll_until_done("http://127.0.0.1:1", start + 6.0)
+        elapsed = time.monotonic() - start
+    assert elapsed < 2.0, f"poll must exit on the first tick when everything is done; took {elapsed:.1f}s"
+
+
+def test_quickstart_poll_keeps_waiting_while_a_failed_lineage_may_retry():
+    """A failed row is not terminal - its retry spawns later as a new row -
+    so the poll must not tear the run down on done+failed."""
+    items = [
+        {"id": "t1", "lineage_id": "t1", "title": "a", "role": "backend", "status": "done"},
+        {"id": "t2", "lineage_id": "t2", "title": "b", "role": "qa", "status": "failed"},
+    ]
+    with patch.object(quickstart_cmd.httpx, "get", return_value=_resp(items)):
+        start = time.monotonic()
+        quickstart_cmd._poll_until_done("http://127.0.0.1:1", start + 3.0)
+        elapsed = time.monotonic() - start
+    assert elapsed >= 2.9, f"a failed lineage must keep the poll alive for its retry; exited after {elapsed:.1f}s"

--- a/tests/unit/test_status_dashboard_task_rows.py
+++ b/tests/unit/test_status_dashboard_task_rows.py
@@ -1,0 +1,36 @@
+"""The /status task-row contract that progress consumers count on.
+
+The demo and quickstart polls compare progress against a seeded total,
+which only works if each row names its retry-lineage root: a failed
+task's retry is a NEW task with a fresh id, so rows alone double-count
+retried work (issue #3433, finding 3723321829). ``lineage_id`` is that
+root - ``metadata.original_task_id`` for a retry, the task's own id
+otherwise.
+"""
+
+from __future__ import annotations
+
+from bernstein.core.models import Task
+
+from bernstein.core.routes.status_dashboard import _status_task_items
+
+
+def test_status_rows_carry_the_retry_lineage_root() -> None:
+    original = Task(id="orig-1", title="Fix off-by-one", description="d", role="backend")
+    retry = Task(
+        id="retry-1",
+        title="Fix off-by-one",
+        description="d",
+        role="backend",
+        metadata={"original_task_id": "orig-1"},
+    )
+
+    rows = _status_task_items([original, retry], now=0.0)
+
+    assert [row["lineage_id"] for row in rows] == ["orig-1", "orig-1"]
+
+
+def test_a_task_without_retry_metadata_is_its_own_lineage_root() -> None:
+    task = Task(id="solo-1", title="t", description="d", role="qa")
+    (row,) = _status_task_items([task], now=0.0)
+    assert row["lineage_id"] == "solo-1"


### PR DESCRIPTION
## What

Makes the demo and quickstart completion polls actually see task completions, and makes their progress counting immune to retry duplication. A clean `bernstein demo` now finishes in ~21 s and a retried one in ~54 s — both 4/4, exit 0, with an accurate live counter (`4/4 bugs fixed`, previously a raw-row `6/8`) and per-task completion lines. Previously: 125 s flat, blank spinner, no events, always.

Closes #3433.

## Root cause

`/status` returns `tasks` as `{"count": N, "items": [...]}`. `_poll_demo_completion` — and, found in review, quickstart's `_poll_until_done` — iterated that dict directly, so per-row processing crashed on the string keys `"count"`/`"items"` on **every tick**, the enclosing `suppress(Exception)` ate the crash, and the early-exit condition was unreachable. The identical shape crash was fixed once before in `_fetch_demo_outcome` (#2075); neither poll ever received that fix, and the broad suppress kept the regression invisible.

## How

- **`_status_task_rows`**: one shared unwrap (wrapped dict form, bare list, garbage → `[]`) used by all three `/status` consumers — `_fetch_demo_outcome`, the demo poll, and quickstart's poll — so the next shape change breaks one place, loudly, under test.
- **Narrowed suppress** in both polls: only the HTTP fetch (`httpx.HTTPError`, `ValueError` for non-JSON bodies) is tolerated; row processing runs outside it, so a payload-shape crash propagates instead of hiding.
- **Lineage-aware counting** (review finding, corroborated live by a `6/8 bugs fixed` frame on a 4-bug run): a failed task's retry is a *new* row with a fresh id, so raw done-row counts double-count retried lineages and could satisfy the seeded total while a bug still has no successful attempt. `/status` rows now carry `lineage_id` (`metadata.original_task_id` of a retry, the task's own id otherwise — one additive field in `_status_task_items`), and `_lineage_progress` derives done/failed/all lineage sets. A row with no identity counts as its own lineage, so counting degrades to the raw per-row behaviour rather than dropping work.
- **Exit conditions — both keyed to the seeded count, never a snapshot**: the demo poll exits when distinct done lineages reach `expected_total=len(DEMO_TASKS)`; quickstart exits at `expected_total=len(_QUICKSTART_TASKS)`. Three simpler conditions are provably wrong, two observed live and one from review: `done + failed >= rows` tears a run down at 3/4 with the fixing retry still pending; "all rows done" makes a retried 4/4 run burn the deadline; and the snapshot's own lineage set as target lets a partial snapshot (rows still registering) tear the run down with work remaining.

## Verification

| Check | Result |
|---|---|
| `tests/unit/test_cli_demo.py` + `test_quickstart_poll.py` + `test_status_dashboard_task_rows.py` | 41 passed |
| Fail-before (src stashed) | shape/loud-crash/unwrap tests, both lineage-counting tests, the quickstart exits-early test, and both route `lineage_id` tests all FAIL on pre-fix source; the incomplete-snapshot test fails on the intermediate head `b9395566` |
| Live `bernstein demo`, clean run | 4/4, exit 0, ~21 s (was 125 s) |
| Live `bernstein demo`, run with transient failure + retry | 4/4, exit 0, ~54 s, counter shows the true `4/4` denominator |
| `ruff check` / `ruff format --check` | clean |
| `mypy` (`status_dashboard.py`, `quickstart_cmd.py`) | no issues; `run_confirm.py` keeps its 14 pre-existing errors, unchanged from `main` |
| `uv run lint-imports` | 3 contracts kept, 0 broken |

Honest note: `test_quickstart_poll_keeps_waiting_while_a_failed_lineage_may_retry` also passes on the broken code (a poll that never exits trivially "keeps waiting") — it pins the retry semantics of the new exit; the exits-early test is the regression pin.

## Review findings

Round 1, both fixed with `bot-ack` trailers in `b9395566d`: quickstart shape bug `3723321824` (verified real), duplicate-lineage premature exit `3723321829` (verified real — the live `6/8` frame proves duplicate done rows exist).

Round 2: quickstart snapshot-as-target `3723410822` (verified real) fixed with a `bot-ack` trailer in `953959106` — the exit now waits for the seeded count of distinct done lineages, pinned by `test_quickstart_poll_ignores_an_incomplete_snapshot`.

<!-- bot-ack: 3723410817 reason=rejected-false-positive -->
The fallback-order finding (`3723410817`, "Duplicate titles undercount completion" — prefer `id` over `title` when `lineage_id` is absent) is **rejected**: the proposed order is the more dangerous one. The fallback regime only exists for older payload shapes without `lineage_id` (modern rows always carry it — the server and CLI ship together). In that regime a retry keeps its **title** but gets a **fresh id**, so id-first cannot group retries and re-opens exactly the premature-green-exit this PR closes (`3723321829`): duplicate done rows satisfying the seeded total while a bug has no successful attempt — a wrong *success* verdict. Title-first can only collapse distinct same-title rows, i.e. **undercount**, whose worst case is waiting out the deadline — the pre-fix status quo, a slow run but never a false green. Between a failure mode that fabricates success and one that costs time, the ordering chooses time; the rationale is now in `_lineage_id`'s docstring.

Round 3 informational ("Duplicated polling loop will drift"): **acknowledged, deferred**. The premise is correct — this bug existed precisely because the #2075 fix reached one consumer and not the other — which is why the drift-prone logic (the `/status` unwrap, lineage counting, and exit semantics) is now shared by construction through `_status_task_rows` and `_lineage_progress`. What remains duplicated is presentation: command-specific wording, event emitters, and Progress construction. Extracting a callback-parameterized poll engine for that residue is a fair follow-up but exceeds a bug-fix PR three review rounds deep; the shared helpers are the anti-drift mechanism this change commits to.

## Documentation duty

- README / `docs/operations/`: N/A — behaviour now matches what both commands' own UI already promises; no operator surface changed.
- `docs/api/`: the `/status` row gains one additive `lineage_id` field, covered by `test_status_dashboard_task_rows.py`; no published schema file describes `/status` rows.
- `agents-md sync`: N/A — no module added or repurposed.
- Tests cover the documented behaviour.