### PR TITLE
docs: point the demo evidence link at an absolute URL for PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ pip, uv, brew, dnf, npm, Docker, and the air-gapped wheelhouse are covered in th
 
 <img alt="A real bernstein demo run: mock agents fix four seeded bugs in parallel worktrees, ending on the run's signed receipt verifying offline" src="https://raw.githubusercontent.com/sipyourdrink-ltd/bernstein/main/docs/assets/demo-run/demo.gif" width="820">
 
-The recording above is a real run, and it ships with its own proof: the cast, the signed run receipt that exact run produced, and the public key that pins it live together in [`docs/assets/demo-run/`](docs/assets/demo-run/). Verify the run you just watched, offline:
+The recording above is a real run, and it ships with its own proof: the cast, the signed run receipt that exact run produced, and the public key that pins it live together in [`docs/assets/demo-run/`](https://github.com/sipyourdrink-ltd/bernstein/tree/main/docs/assets/demo-run). Verify the run you just watched, offline:
 
 ```bash
 bernstein verify receipt docs/assets/demo-run/run-receipt.json \

--- a/tests/unit/test_packaged_readme_renders_off_repo.py
+++ b/tests/unit/test_packaged_readme_renders_off_repo.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import re
 import tomllib
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 README = REPO_ROOT / "README.md"
@@ -74,7 +74,10 @@ def test_readme_absolute_links_point_at_paths_this_repo_actually_has() -> None:
         if prefix is None:
             continue
         path = link[len(prefix) :].split("#", 1)[0]
-        if not (REPO_ROOT / path).exists():
+        # A traversal component is itself a broken GitHub URL, and letting it
+        # through would validate against whatever happens to exist OUTSIDE the
+        # repository on the machine running the test.
+        if ".." in PurePosixPath(path).parts or not (REPO_ROOT / path).exists():
             broken.append(link)
     assert not broken, f"README links to paths this repository does not contain: {broken}"
 

--- a/tests/unit/test_packaged_readme_renders_off_repo.py
+++ b/tests/unit/test_packaged_readme_renders_off_repo.py
@@ -57,17 +57,23 @@ def test_no_readme_link_depends_on_the_repository_around_it() -> None:
 def test_readme_absolute_links_point_at_paths_this_repo_actually_has() -> None:
     """An absolute link is not automatically a working one.
 
-    Rewriting a relative path to a blob URL is a mechanical edit, and a typo in
-    it fails in exactly the place nobody looks: rendered on PyPI, months later.
-    Checking the path component against the working tree catches that here
-    instead, without needing the network.
+    Rewriting a relative path to a blob or tree URL is a mechanical edit, and a
+    typo in it fails in exactly the place nobody looks: rendered on PyPI,
+    months later. Checking the path component against the working tree catches
+    that here instead, without needing the network. Both GitHub path forms are
+    validated - files (``/blob/main/``) and directories (``/tree/main/``) - so
+    neither form can carry a destination this repository does not contain.
     """
-    blob = "https://github.com/sipyourdrink-ltd/bernstein/blob/main/"
+    prefixes = (
+        "https://github.com/sipyourdrink-ltd/bernstein/blob/main/",
+        "https://github.com/sipyourdrink-ltd/bernstein/tree/main/",
+    )
     broken: list[str] = []
     for link in _links():
-        if not link.startswith(blob):
+        prefix = next((p for p in prefixes if link.startswith(p)), None)
+        if prefix is None:
             continue
-        path = link[len(blob) :].split("#", 1)[0]
+        path = link[len(prefix) :].split("#", 1)[0]
         if not (REPO_ROOT / path).exists():
             broken.append(link)
     assert not broken, f"README links to paths this repository does not contain: {broken}"


### PR DESCRIPTION
# User description
## What

One-line fix for the red `main` round on `3e5664b4f`: the prose link to the demo evidence directory becomes an absolute `github.com` URL.

## Why

`Test (ubuntu-latest, Python 3.12, shard 2)` failed on main with:

```
tests/unit/test_packaged_readme_renders_off_repo.py::test_no_readme_link_depends_on_the_repository_around_it
AssertionError: these README links resolve only inside the repository, so they 404 on PyPI
where this file is the project description: ['docs/assets/demo-run/']
```

The check is right: the README ships as the PyPI long description, and #3438 introduced a repo-relative directory link in the prose — while making the *image* URL absolute for exactly this reason. The link now follows the same convention as the existing install-guide link (full `github.com` URL).

## Verification

| Check | Result |
|---|---|
| `tests/unit/test_packaged_readme_renders_off_repo.py` | 4 passed (the failing test passes; it fails on current `main`, which is the regression pin) |

## Documentation duty

N/A — this is the docs fix itself; no code surface changed.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the README demo evidence link to use an absolute GitHub directory URL so it renders correctly on PyPI. Extend the packaged README link validation to verify both GitHub file and directory URLs, including traversal safety.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3441?tool=ast&topic=README+link+validation>README link validation</a>
        </td><td>Expand <code>test_readme_absolute_links_point_at_paths_this_repo_actually_has</code> to validate <code>blob</code> and <code>tree</code> URLs and reject path traversal.<details><summary>Modified files (1)</summary><ul><li>tests/unit/test_packaged_readme_renders_off_repo.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>Reject traversal compo...</td><td>August 05, 2026</td></tr>
<tr><td>chernistry</td><td>fix(packaging): make t...</td><td>July 27, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3441?tool=ast&topic=Demo+evidence+link>Demo evidence link</a>
        </td><td>Point the demo evidence documentation at the repository’s absolute GitHub directory URL, preserving access when the README is rendered outside the repository.<details><summary>Modified files (1)</summary><ul><li>README.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>docs: point the demo e...</td><td>August 05, 2026</td></tr>
<tr><td>chernistry</td><td>docs: replace the simu...</td><td>August 05, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3441?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>