### PR TITLE
docs: show the terminal and browser operator surfaces on the front page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 <div align="center">
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/logo-dark.svg">
-  <source media="(prefers-color-scheme: light)" srcset="docs/assets/logo-light.svg">
-  <img alt="Bernstein" src="docs/assets/logo-light.svg" width="340">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/sipyourdrink-ltd/bernstein/main/docs/assets/logo-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/sipyourdrink-ltd/bernstein/main/docs/assets/logo-light.svg">
+  <img alt="Bernstein" src="https://raw.githubusercontent.com/sipyourdrink-ltd/bernstein/main/docs/assets/logo-light.svg" width="340">
 </picture>
 
 <br>
 
-<img alt="Bernstein - deterministic multi-agent CLI orchestration" src="docs/assets/banner-readme.png" width="820">
+<img alt="Bernstein - deterministic multi-agent CLI orchestration" src="https://raw.githubusercontent.com/sipyourdrink-ltd/bernstein/main/docs/assets/banner-readme.png" width="820">
 
 <br>
 
@@ -65,6 +65,12 @@ bernstein verify receipt docs/assets/demo-run/run-receipt.json \
 ```
 
 CI re-verifies the committed receipt on every push — and proves a tampered copy fails — so the published evidence cannot rot into a decorative file. `scripts/record_demo.sh` regenerates the recording, receipt, and key from a fresh real run; nothing inside the terminal is synthesised.
+
+A run in flight is watchable from either operator surface. Both read the same task API, so neither is a lagging mirror of the other.
+
+| ![A three-column terminal dashboard: agents with their live logs on the left, the task board on the right, an activity feed and a cost line underneath](https://raw.githubusercontent.com/sipyourdrink-ltd/bernstein/main/docs/assets/tui-agents.png) | ![A browser dashboard listing sixty-two tasks with eleven running, one of them opened to its working-tree diff](https://raw.githubusercontent.com/sipyourdrink-ltd/bernstein/main/docs/assets/webui-agents-diffs.png) |
+|:---:|:---:|
+| `bernstein live` — the terminal dashboard | `bernstein gui serve` — the same run in a browser |
 
 ### prove a run
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,6 +66,12 @@ Then run:
 bernstein -g "Add JWT auth with refresh tokens, tests, and API docs"
 ```
 
+A run in flight is watchable from either operator surface. Both read the same task API, so neither is a lagging mirror of the other.
+
+| ![A three-column terminal dashboard: agents with their live logs on the left, the task board on the right, an activity feed and a cost line underneath](assets/tui-agents.png) | ![A browser dashboard listing sixty-two tasks with eleven running, one of them opened to its working-tree diff](assets/webui-agents-diffs.png) |
+|:---:|:---:|
+| `bernstein live` — the terminal dashboard | `bernstein gui serve` — the same run in a browser |
+
 ## Why Bernstein?
 
 <div class="grid cards" markdown>

--- a/tests/unit/test_packaged_readme_renders_off_repo.py
+++ b/tests/unit/test_packaged_readme_renders_off_repo.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import re
 import tomllib
+from html.parser import HTMLParser
 from pathlib import Path, PurePosixPath
 from urllib.parse import urlsplit
 
@@ -29,12 +30,6 @@ PYPROJECT = REPO_ROOT / "pyproject.toml"
 LINK = re.compile(r"\]\(([^)]+)\)")
 OFF_REPO_SAFE = ("http://", "https://", "#", "mailto:")
 
-#: ``<img src="...">`` - the form the demo GIF uses, because it needs a width.
-HTML_IMG_SRC = re.compile(r"<img\b[^>]*?\bsrc=\"([^\"]+)\"", re.IGNORECASE)
-#: ``<source srcset="...">`` - the theme-switching half of a ``<picture>``.
-#: Easy to miss when rewriting paths, because the ``<img>`` fallback next to it
-#: keeps the page looking correct in whichever theme the author is using.
-HTML_SRCSET = re.compile(r"<source\b[^>]*?\bsrcset=\"([^\"]+)\"", re.IGNORECASE)
 #: ``![alt](target)`` - the form used where the surrounding cell sizes the image.
 MARKDOWN_IMAGE = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 #: Raw-content prefix an absolute image URL has to carry to render off-repo.
@@ -53,6 +48,42 @@ ALLOWED_IMAGE_HOSTS = frozenset(
         "mcptoplist.com",
     }
 )
+
+
+class _ImageSourceCollector(HTMLParser):
+    """Collect every image URL the HTML in a markdown file points at.
+
+    Parsed rather than pattern-matched because ``src='…'`` and bare ``src=…``
+    are as valid as ``src="…"``, and a policy that silently skips the forms it
+    did not anticipate is worse than no policy: it reports success over the
+    markup it could not see.
+
+    ``srcset`` carries a comma-separated candidate list where each entry is a
+    URL followed by an optional descriptor, so entries are split before the URL
+    is taken.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.sources: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        values = dict(attrs)
+        if tag == "img" and values.get("src"):
+            self.sources.append(str(values["src"]).strip())
+        srcset = values.get("srcset") if tag in {"source", "img"} else None
+        if srcset:
+            for candidate in str(srcset).split(","):
+                url = candidate.strip().split(" ", 1)[0]
+                if url:
+                    self.sources.append(url)
+
+
+def _html_image_sources(text: str) -> list[str]:
+    collector = _ImageSourceCollector()
+    collector.feed(text)
+    collector.close()
+    return collector.sources
 
 
 def _links() -> list[str]:
@@ -121,6 +152,13 @@ def test_every_readme_image_resolves_to_an_asset_this_repo_actually_ships() -> N
     and the markdown form (used inside the surface table, where the cell sizes
     the image) are checked, because the README uses both.
 
+    ``<source srcset>`` inside the logo's ``<picture>`` is checked too. PyPI's
+    sanitiser keeps only the ``<img>`` fallback, which is what a fallback is
+    for - the theme switch is a GitHub enhancement, and dropping it there costs
+    the reader nothing. On GitHub it is the element that actually renders in
+    dark mode, so a broken URL in it is invisible to whoever committed it and
+    visible to half the readers.
+
     An image on a host this repository does not ship from cannot be verified
     offline at all, so the rule there is different in kind: the host has to be
     one the front page already depends on deliberately. That does not prove a
@@ -128,9 +166,7 @@ def test_every_readme_image_resolves_to_an_asset_this_repo_actually_ships() -> N
     dependency set from growing silently.
     """
     text = README.read_text(encoding="utf-8")
-    sources = (
-        HTML_IMG_SRC.findall(text) + HTML_SRCSET.findall(text) + [target for _, target in MARKDOWN_IMAGE.findall(text)]
-    )
+    sources = _html_image_sources(text) + [target for _, target in MARKDOWN_IMAGE.findall(text)]
     assert sources, "expected the README to reference at least one image"
 
     broken: list[str] = []
@@ -157,6 +193,30 @@ def test_every_readme_image_resolves_to_an_asset_this_repo_actually_ships() -> N
         "depend on; add the host to ALLOWED_IMAGE_HOSTS if that dependency is "
         f"intended: {sorted(set(foreign))}"
     )
+
+
+def test_the_image_scan_sees_every_html_attribute_form() -> None:
+    """The scan is only a policy over what it can see.
+
+    ``src='…'`` and bare ``src=…`` render exactly like ``src="…"``, so a scan
+    that reads only the third form passes a README full of images it never
+    looked at - the failure mode where a gate is worse than no gate, because
+    it reports success.
+    """
+    markup = (
+        '<img src="https://one.example/a.png">'
+        "<img src='https://two.example/b.png'>"
+        "<img src=https://three.example/c.png>"
+        "<picture><source srcset='https://four.example/d.png 2x, https://five.example/e.png'></picture>"
+    )
+
+    assert _html_image_sources(markup) == [
+        "https://one.example/a.png",
+        "https://two.example/b.png",
+        "https://three.example/c.png",
+        "https://four.example/d.png",
+        "https://five.example/e.png",
+    ]
 
 
 def test_python_classifiers_match_the_versions_the_project_supports() -> None:

--- a/tests/unit/test_packaged_readme_renders_off_repo.py
+++ b/tests/unit/test_packaged_readme_renders_off_repo.py
@@ -31,6 +31,8 @@ LINK = re.compile(r"\]\(([^)]+)\)")
 OFF_REPO_SAFE = ("http://", "https://", "#", "mailto:")
 
 #: ``![alt](target)`` - the form used where the surrounding cell sizes the image.
+#: The captured group is the whole destination *and* any optional title, which
+#: :func:`markdown_destination` separates.
 MARKDOWN_IMAGE = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 #: Raw-content prefix an absolute image URL has to carry to render off-repo.
 RAW_ASSET_PREFIX = "https://raw.githubusercontent.com/sipyourdrink-ltd/bernstein/main/"
@@ -48,6 +50,25 @@ ALLOWED_IMAGE_HOSTS = frozenset(
         "mcptoplist.com",
     }
 )
+
+
+def markdown_destination(raw: str) -> str:
+    """Return just the URL from a markdown link destination.
+
+    ``![alt](url "title")`` and ``![alt](<url>)`` are both valid and both
+    render; a check that treats the title as part of the path reports a working
+    image as broken. A gate that fails on correct input is worse than a missing
+    one - it gets an exception added, and the exception is where the next real
+    break hides.
+    """
+    stripped = raw.strip()
+    if stripped.startswith("<"):
+        end = stripped.find(">")
+        return stripped[1:end] if end != -1 else stripped[1:]
+    # A destination cannot contain unescaped whitespace unless it is wrapped in
+    # angle brackets, so the first token is the URL and the rest is the title.
+    parts = stripped.split()
+    return parts[0] if parts else ""
 
 
 class _ImageSourceCollector(HTMLParser):
@@ -166,7 +187,7 @@ def test_every_readme_image_resolves_to_an_asset_this_repo_actually_ships() -> N
     dependency set from growing silently.
     """
     text = README.read_text(encoding="utf-8")
-    sources = _html_image_sources(text) + [target for _, target in MARKDOWN_IMAGE.findall(text)]
+    sources = _html_image_sources(text) + [markdown_destination(target) for _, target in MARKDOWN_IMAGE.findall(text)]
     assert sources, "expected the README to reference at least one image"
 
     broken: list[str] = []
@@ -217,6 +238,18 @@ def test_the_image_scan_sees_every_html_attribute_form() -> None:
         "https://four.example/d.png",
         "https://five.example/e.png",
     ]
+
+
+def test_a_markdown_title_is_not_read_as_part_of_the_destination() -> None:
+    """``![alt](url "title")`` is valid markdown that renders.
+
+    Reading the title as part of the path turns a working image into a
+    reported break, which is the failure mode that gets a gate switched off.
+    """
+    assert markdown_destination('docs/a.png "a title"') == "docs/a.png"
+    assert markdown_destination("<https://example.com/a.png>") == "https://example.com/a.png"
+    assert markdown_destination("  https://example.com/a.png  ") == "https://example.com/a.png"
+    assert markdown_destination('<docs/a.png> "titled and bracketed"') == "docs/a.png"
 
 
 def test_python_classifiers_match_the_versions_the_project_supports() -> None:

--- a/tests/unit/test_packaged_readme_renders_off_repo.py
+++ b/tests/unit/test_packaged_readme_renders_off_repo.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import re
 import tomllib
 from pathlib import Path, PurePosixPath
+from urllib.parse import urlsplit
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 README = REPO_ROOT / "README.md"
@@ -38,6 +39,20 @@ HTML_SRCSET = re.compile(r"<source\b[^>]*?\bsrcset=\"([^\"]+)\"", re.IGNORECASE)
 MARKDOWN_IMAGE = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 #: Raw-content prefix an absolute image URL has to carry to render off-repo.
 RAW_ASSET_PREFIX = "https://raw.githubusercontent.com/sipyourdrink-ltd/bernstein/main/"
+#: Hosts the front page is allowed to load an image from. Everything here is a
+#: status badge whose URL cannot be checked offline; the point of the list is
+#: that the set of third parties the front page depends on is a decision, not
+#: something that grows by accident. A new host has to be added here on
+#: purpose, in a diff someone reads.
+ALLOWED_IMAGE_HOSTS = frozenset(
+    {
+        "raw.githubusercontent.com",
+        "github.com",
+        "img.shields.io",
+        "api.securityscorecards.dev",
+        "mcptoplist.com",
+    }
+)
 
 
 def _links() -> list[str]:
@@ -105,6 +120,12 @@ def test_every_readme_image_resolves_to_an_asset_this_repo_actually_ships() -> N
     Both the HTML ``<img>`` form (used for the demo GIF, which needs a width)
     and the markdown form (used inside the surface table, where the cell sizes
     the image) are checked, because the README uses both.
+
+    An image on a host this repository does not ship from cannot be verified
+    offline at all, so the rule there is different in kind: the host has to be
+    one the front page already depends on deliberately. That does not prove a
+    badge URL is spelled correctly - nothing offline can - but it does stop the
+    dependency set from growing silently.
     """
     text = README.read_text(encoding="utf-8")
     sources = (
@@ -113,18 +134,28 @@ def test_every_readme_image_resolves_to_an_asset_this_repo_actually_ships() -> N
     assert sources, "expected the README to reference at least one image"
 
     broken: list[str] = []
+    foreign: list[str] = []
     for src in sources:
         if src.startswith(RAW_ASSET_PREFIX):
             path = src[len(RAW_ASSET_PREFIX) :].split("?", 1)[0]
             if ".." in PurePosixPath(path).parts or not (REPO_ROOT / path).exists():
                 broken.append(src)
-        elif not src.startswith(OFF_REPO_SAFE):
+        elif src.startswith(("http://", "https://")):
+            host = urlsplit(src).hostname or ""
+            if host not in ALLOWED_IMAGE_HOSTS:
+                foreign.append(src)
+        else:
             # Resolves against pypi.org/project/bernstein/ when PyPI renders
             # the long description, so it can only ever be a broken image.
             broken.append(src)
     assert not broken, (
         "these README image sources do not resolve to a committed asset, so they "
         f"render as a broken image on PyPI, on GitHub, or on both: {sorted(set(broken))}"
+    )
+    assert not foreign, (
+        "the front page would load these images from hosts it does not already "
+        "depend on; add the host to ALLOWED_IMAGE_HOSTS if that dependency is "
+        f"intended: {sorted(set(foreign))}"
     )
 
 

--- a/tests/unit/test_packaged_readme_renders_off_repo.py
+++ b/tests/unit/test_packaged_readme_renders_off_repo.py
@@ -194,7 +194,11 @@ def test_every_readme_image_resolves_to_an_asset_this_repo_actually_ships() -> N
     foreign: list[str] = []
     for src in sources:
         if src.startswith(RAW_ASSET_PREFIX):
-            path = src[len(RAW_ASSET_PREFIX) :].split("?", 1)[0]
+            # Take the path component from the parsed URL rather than trimming
+            # suffixes by hand: `?raw=true` and GitHub's `#gh-dark-mode-only`
+            # are both idiomatic on an image URL, and either one left attached
+            # turns a working asset into a reported break.
+            path = urlsplit(src[len(RAW_ASSET_PREFIX) :]).path
             if ".." in PurePosixPath(path).parts or not (REPO_ROOT / path).exists():
                 broken.append(src)
         elif src.startswith(("http://", "https://")):
@@ -238,6 +242,19 @@ def test_the_image_scan_sees_every_html_attribute_form() -> None:
         "https://four.example/d.png",
         "https://five.example/e.png",
     ]
+
+
+def test_a_query_or_fragment_is_not_read_as_part_of_the_asset_path() -> None:
+    """`?raw=true` and `#gh-dark-mode-only` are both idiomatic on an image URL.
+
+    Neither changes which file is fetched, so neither may change whether the
+    gate finds it - a gate that fails on correct input gets switched off.
+    """
+    asset = "docs/assets/tui-agents.png"
+    assert (REPO_ROOT / asset).exists(), "the probe asset has moved"
+    for suffix in ("", "?raw=true", "#gh-dark-mode-only", "?raw=true#gh-dark-mode-only"):
+        path = urlsplit(f"{RAW_ASSET_PREFIX}{asset}{suffix}"[len(RAW_ASSET_PREFIX) :]).path
+        assert (REPO_ROOT / path).exists(), suffix
 
 
 def test_a_markdown_title_is_not_read_as_part_of_the_destination() -> None:

--- a/tests/unit/test_packaged_readme_renders_off_repo.py
+++ b/tests/unit/test_packaged_readme_renders_off_repo.py
@@ -28,6 +28,17 @@ PYPROJECT = REPO_ROOT / "pyproject.toml"
 LINK = re.compile(r"\]\(([^)]+)\)")
 OFF_REPO_SAFE = ("http://", "https://", "#", "mailto:")
 
+#: ``<img src="...">`` - the form the demo GIF uses, because it needs a width.
+HTML_IMG_SRC = re.compile(r"<img\b[^>]*?\bsrc=\"([^\"]+)\"", re.IGNORECASE)
+#: ``<source srcset="...">`` - the theme-switching half of a ``<picture>``.
+#: Easy to miss when rewriting paths, because the ``<img>`` fallback next to it
+#: keeps the page looking correct in whichever theme the author is using.
+HTML_SRCSET = re.compile(r"<source\b[^>]*?\bsrcset=\"([^\"]+)\"", re.IGNORECASE)
+#: ``![alt](target)`` - the form used where the surrounding cell sizes the image.
+MARKDOWN_IMAGE = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
+#: Raw-content prefix an absolute image URL has to carry to render off-repo.
+RAW_ASSET_PREFIX = "https://raw.githubusercontent.com/sipyourdrink-ltd/bernstein/main/"
+
 
 def _links() -> list[str]:
     return LINK.findall(README.read_text(encoding="utf-8"))
@@ -80,6 +91,41 @@ def test_readme_absolute_links_point_at_paths_this_repo_actually_has() -> None:
         if ".." in PurePosixPath(path).parts or not (REPO_ROOT / path).exists():
             broken.append(link)
     assert not broken, f"README links to paths this repository does not contain: {broken}"
+
+
+def test_every_readme_image_resolves_to_an_asset_this_repo_actually_ships() -> None:
+    """Images have the link problem too, and one renderer further to fall through.
+
+    A repo-relative ``src`` fails on PyPI exactly like a repo-relative link,
+    except it fails silently as a broken-image icon rather than a dead click.
+    An absolute ``raw.githubusercontent.com`` URL survives that render but
+    still 404s when the path is wrong or the asset is later renamed - and the
+    only place that shows is the published page, which nobody re-reads.
+
+    Both the HTML ``<img>`` form (used for the demo GIF, which needs a width)
+    and the markdown form (used inside the surface table, where the cell sizes
+    the image) are checked, because the README uses both.
+    """
+    text = README.read_text(encoding="utf-8")
+    sources = (
+        HTML_IMG_SRC.findall(text) + HTML_SRCSET.findall(text) + [target for _, target in MARKDOWN_IMAGE.findall(text)]
+    )
+    assert sources, "expected the README to reference at least one image"
+
+    broken: list[str] = []
+    for src in sources:
+        if src.startswith(RAW_ASSET_PREFIX):
+            path = src[len(RAW_ASSET_PREFIX) :].split("?", 1)[0]
+            if ".." in PurePosixPath(path).parts or not (REPO_ROOT / path).exists():
+                broken.append(src)
+        elif not src.startswith(OFF_REPO_SAFE):
+            # Resolves against pypi.org/project/bernstein/ when PyPI renders
+            # the long description, so it can only ever be a broken image.
+            broken.append(src)
+    assert not broken, (
+        "these README image sources do not resolve to a committed asset, so they "
+        f"render as a broken image on PyPI, on GitHub, or on both: {sorted(set(broken))}"
+    )
 
 
 def test_python_classifiers_match_the_versions_the_project_supports() -> None:

--- a/tests/unit/test_readme_front_page_surfaces.py
+++ b/tests/unit/test_readme_front_page_surfaces.py
@@ -1,12 +1,18 @@
-"""The front page has to show the two surfaces an operator actually watches.
+"""Both front pages have to show the two surfaces an operator actually watches.
 
 `bernstein live` and `bernstein gui serve` are the two places a run is visible
 while it is running. Before this, the README named them in passing - one line
 inside a code block, one row of a table below the fold - and showed neither,
 while ten renders of exactly those surfaces sat unreferenced in `docs/assets/`.
 
-These tests pin the three properties that make the rendered result readable
-rather than decorative, each of which fails silently otherwise:
+The project has two front pages: `README.md`, which is also the packaged long
+description on PyPI, and `docs/index.md`, which is the MkDocs Home page. They
+carry the same block and reference the same assets through different URL
+forms, so every check here runs against both - nothing about the second page
+is verified by the docs build, which does not run in CI.
+
+These tests pin the properties that make the rendered result readable rather
+than decorative, each of which fails silently otherwise:
 
 * the page shows one terminal surface and one browser surface, each captioned
   with the command that opens it (a caption naming no command leaves the
@@ -22,12 +28,13 @@ rather than decorative, each of which fails silently otherwise:
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 from pathlib import Path
 
+import pytest
 from PIL import Image
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-README = REPO_ROOT / "README.md"
 RAW_ASSET_PREFIX = "https://raw.githubusercontent.com/sipyourdrink-ltd/bernstein/main/"
 MARKDOWN_IMAGE = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 HTML_IMG = re.compile(r"<img\b[^>]*?\balt=\"([^\"]*)\"[^>]*?\bsrc=\"([^\"]+)\"", re.IGNORECASE)
@@ -41,79 +48,150 @@ SURFACE_COMMANDS = ("bernstein live", "bernstein gui serve")
 IDENTITY_MARKS = frozenset({"logo-light.svg", "logo-dark.svg", "banner-readme.png"})
 
 
+@dataclass(frozen=True)
+class FrontPage:
+    """A front page plus the URL form its images are written in.
+
+    The two pages resolve assets differently and each form is correct where it
+    is used: the README is rendered off-repo by PyPI and needs absolute raw
+    URLs, while MkDocs rewrites site-relative paths and would break on them.
+    Sharing the assertions but not the resolver is what lets one set of
+    properties cover both.
+    """
+
+    name: str
+    path: Path
+    #: Where a resolvable image target starts, relative to the repository root.
+    asset_root: Path
+    #: Prefix an image target must carry on this page, "" for site-relative.
+    required_prefix: str
+
+    def text(self) -> str:
+        return self.path.read_text(encoding="utf-8")
+
+    def images(self) -> list[tuple[str, str]]:
+        """Return (alt, target) for every image on the page, both syntaxes."""
+        body = self.text()
+        return [*MARKDOWN_IMAGE.findall(body), *HTML_IMG.findall(body)]
+
+    def resolve(self, target: str) -> Path | None:
+        """Return the repository file an image target names, or None if foreign.
+
+        Foreign here means an external URL (a status badge), which no offline
+        check can resolve. Whether those are acceptable is settled in
+        ``test_packaged_readme_renders_off_repo``; this resolver only reports
+        that there is no local file behind them.
+        """
+        if self.required_prefix:
+            if not target.startswith(self.required_prefix):
+                return None
+            return self.asset_root / target[len(self.required_prefix) :]
+        if target.startswith(("http://", "https://")):
+            return None
+        return self.asset_root / target
+
+
+FRONT_PAGES = (
+    FrontPage(
+        name="README.md",
+        path=REPO_ROOT / "README.md",
+        asset_root=REPO_ROOT,
+        required_prefix=RAW_ASSET_PREFIX,
+    ),
+    FrontPage(
+        name="docs/index.md",
+        path=REPO_ROOT / "docs" / "index.md",
+        asset_root=REPO_ROOT / "docs",
+        required_prefix="",
+    ),
+)
+PAGE_IDS = [page.name for page in FRONT_PAGES]
+
+
 def _cells(row: str) -> list[str]:
     return [cell.strip() for cell in row.strip().strip("|").split("|")]
 
 
-def _surface_table() -> tuple[list[str], list[str]]:
+def _surface_table(page: FrontPage) -> tuple[list[str], list[str]]:
     """Return the (image row cells, caption row cells) of the surface table.
 
     The table is located by its image row rather than by line number, so
     ordinary edits above it do not turn these tests into a line-count assertion.
     """
-    lines = README.read_text(encoding="utf-8").splitlines()
+    lines = page.text().splitlines()
     for index, line in enumerate(lines):
         if line.startswith("| !["):
             images = _cells(line)
             # index+1 is the alignment row that makes it a table at all.
             captions = _cells(lines[index + 2])
             return images, captions
-    raise AssertionError("no image table found on the front page")
+    raise AssertionError(f"no image table found on {page.name}")
 
 
-def _asset_for(target: str) -> Path:
-    assert target.startswith(RAW_ASSET_PREFIX), (
-        f"front-page image {target!r} must be an absolute raw URL: a repo-relative "
-        "path renders as a broken image on PyPI, where this file is the long description"
-    )
-    return REPO_ROOT / target[len(RAW_ASSET_PREFIX) :]
-
-
-def test_front_page_shows_one_terminal_surface_and_one_browser_surface() -> None:
+@pytest.mark.parametrize("page", FRONT_PAGES, ids=PAGE_IDS)
+def test_front_page_shows_one_terminal_surface_and_one_browser_surface(page: FrontPage) -> None:
     """Two images, side by side, and nothing else in the row."""
-    images, captions = _surface_table()
+    images, captions = _surface_table(page)
 
-    assert len(images) == 2, f"expected exactly two surface renders, found {len(images)}"
-    assert len(captions) == 2, f"expected one caption per render, found {len(captions)}"
+    assert len(images) == 2, f"{page.name}: expected exactly two surface renders, found {len(images)}"
+    assert len(captions) == 2, f"{page.name}: expected one caption per render, found {len(captions)}"
     for cell in images:
-        assert MARKDOWN_IMAGE.fullmatch(cell), f"surface cell is not a bare image: {cell!r}"
+        assert MARKDOWN_IMAGE.fullmatch(cell), f"{page.name}: surface cell is not a bare image: {cell!r}"
 
 
-def test_each_surface_render_is_captioned_with_the_command_that_opens_it() -> None:
+@pytest.mark.parametrize("page", FRONT_PAGES, ids=PAGE_IDS)
+def test_each_surface_render_is_captioned_with_the_command_that_opens_it(page: FrontPage) -> None:
     """A render whose caption names no command is a picture of an unreachable thing."""
-    _, captions = _surface_table()
+    _, captions = _surface_table(page)
 
     for command, caption in zip(SURFACE_COMMANDS, captions, strict=True):
         assert f"`{command}`" in caption, (
-            f"the caption {caption!r} does not name the command that opens that surface (expected `{command}`)"
+            f"{page.name}: the caption {caption!r} does not name the command that opens "
+            f"that surface (expected `{command}`)"
         )
 
 
-def test_alt_text_on_every_front_page_render_is_a_sentence() -> None:
+@pytest.mark.parametrize("page", FRONT_PAGES, ids=PAGE_IDS)
+def test_every_front_page_render_resolves_to_a_committed_asset(page: FrontPage) -> None:
+    """A renamed asset breaks the page in the place nobody re-reads: rendered.
+
+    The README half of this is also covered from the PyPI side in
+    ``test_packaged_readme_renders_off_repo``; the value here is
+    ``docs/index.md``, whose site-relative targets nothing else checks - the
+    docs build does not run in CI.
+    """
+    missing = [
+        target
+        for _, target in page.images()
+        if (resolved := page.resolve(target)) is not None and not resolved.exists()
+    ]
+    assert not missing, f"{page.name} references assets this repository does not contain: {missing}"
+
+
+@pytest.mark.parametrize("page", FRONT_PAGES, ids=PAGE_IDS)
+def test_alt_text_on_every_front_page_render_is_a_sentence(page: FrontPage) -> None:
     """Alt text is read aloud and shown when the image 404s - a filename is neither.
 
     Scoped to the renders this repository ships: an external status badge is
     labelled by convention ("CI", "PyPI") and an identity mark is labelled by
     name, so neither is improved by a sentence.
     """
-    text = README.read_text(encoding="utf-8")
-    pairs = [(alt, target) for alt, target in MARKDOWN_IMAGE.findall(text)]
-    pairs += [(alt, src) for alt, src in HTML_IMG.findall(text)]
     renders = [
         (alt, target)
-        for alt, target in pairs
-        if target.startswith(RAW_ASSET_PREFIX) and Path(target).name not in IDENTITY_MARKS
+        for alt, target in page.images()
+        if (resolved := page.resolve(target)) is not None and resolved.name not in IDENTITY_MARKS
     ]
-    assert renders, "expected the README to reference at least one render of a surface"
+    assert renders, f"{page.name}: expected at least one render of a surface"
 
     for alt, target in renders:
-        assert len(alt.split()) >= 6, f"alt text for {target} is too short to describe it: {alt!r}"
+        assert len(alt.split()) >= 6, f"{page.name}: alt text for {target} is too short: {alt!r}"
         assert not re.search(r"\.(png|gif|svg|jpe?g)\b", alt, re.IGNORECASE), (
-            f"alt text reads as a filename rather than a description: {alt!r}"
+            f"{page.name}: alt text reads as a filename rather than a description: {alt!r}"
         )
 
 
-def test_no_front_page_render_shows_the_page_through_it() -> None:
+@pytest.mark.parametrize("page", FRONT_PAGES, ids=PAGE_IDS)
+def test_no_front_page_render_shows_the_page_through_it(page: FrontPage) -> None:
     """A transparent render inherits the page background and inverts between themes.
 
     Checked on the pixels rather than by eye: whoever commits a render only
@@ -131,18 +209,13 @@ def test_no_front_page_render_shows_the_page_through_it() -> None:
     ``<picture>``/``prefers-color-scheme``, which is the correct mechanism for
     an asset that should follow the theme rather than resist it.
     """
-    text = README.read_text(encoding="utf-8")
-    targets = [target for _, target in MARKDOWN_IMAGE.findall(text)] + [src for _, src in HTML_IMG.findall(text)]
-
     #: Antialiased corners are allowed; a see-through background is not.
     corner_allowance = 0.001
 
     see_through: list[str] = []
-    for target in targets:
-        if not target.startswith(RAW_ASSET_PREFIX):
-            continue
-        asset = _asset_for(target)
-        if asset.name in IDENTITY_MARKS:
+    for _, target in page.images():
+        asset = page.resolve(target)
+        if asset is None or asset.name in IDENTITY_MARKS or not asset.exists():
             continue
         with Image.open(asset) as image:
             # The first frame is the one composited against the page; later
@@ -154,6 +227,6 @@ def test_no_front_page_render_shows_the_page_through_it() -> None:
             see_through.append(f"{asset.name} ({100 * fully_transparent / total:.2f}% transparent)")
 
     assert not see_through, (
-        "these front-page renders show the page through them, so they invert "
+        f"these renders on {page.name} show the page through them, so they invert "
         f"between GitHub's light and dark themes: {see_through}"
     )

--- a/tests/unit/test_readme_front_page_surfaces.py
+++ b/tests/unit/test_readme_front_page_surfaces.py
@@ -1,0 +1,159 @@
+"""The front page has to show the two surfaces an operator actually watches.
+
+`bernstein live` and `bernstein gui serve` are the two places a run is visible
+while it is running. Before this, the README named them in passing - one line
+inside a code block, one row of a table below the fold - and showed neither,
+while ten renders of exactly those surfaces sat unreferenced in `docs/assets/`.
+
+These tests pin the three properties that make the rendered result readable
+rather than decorative, each of which fails silently otherwise:
+
+* the page shows one terminal surface and one browser surface, each captioned
+  with the command that opens it (a caption naming no command leaves the
+  reader with a picture and no way to reach it);
+* the alt text is a sentence (it is what a screen reader announces, and what
+  GitHub shows when the image fails to load);
+* nothing referenced from the page is transparent (a transparent asset takes
+  the page background, so it inverts between GitHub's light and dark themes -
+  legible in one, unreadable in the other, and never noticed by whoever
+  committed it in their own theme).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from PIL import Image
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+README = REPO_ROOT / "README.md"
+RAW_ASSET_PREFIX = "https://raw.githubusercontent.com/sipyourdrink-ltd/bernstein/main/"
+MARKDOWN_IMAGE = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
+HTML_IMG = re.compile(r"<img\b[^>]*?\balt=\"([^\"]*)\"[^>]*?\bsrc=\"([^\"]+)\"", re.IGNORECASE)
+
+#: The commands whose surfaces the front page has to show, in column order.
+SURFACE_COMMANDS = ("bernstein live", "bernstein gui serve")
+
+#: Identity marks, whose correct alt text is the name of the thing they mark.
+#: Describing a logo in a sentence is worse for a screen reader, not better -
+#: the reader wants "Bernstein", not a description of the artwork.
+IDENTITY_MARKS = frozenset({"logo-light.svg", "logo-dark.svg", "banner-readme.png"})
+
+
+def _cells(row: str) -> list[str]:
+    return [cell.strip() for cell in row.strip().strip("|").split("|")]
+
+
+def _surface_table() -> tuple[list[str], list[str]]:
+    """Return the (image row cells, caption row cells) of the surface table.
+
+    The table is located by its image row rather than by line number, so
+    ordinary edits above it do not turn these tests into a line-count assertion.
+    """
+    lines = README.read_text(encoding="utf-8").splitlines()
+    for index, line in enumerate(lines):
+        if line.startswith("| !["):
+            images = _cells(line)
+            # index+1 is the alignment row that makes it a table at all.
+            captions = _cells(lines[index + 2])
+            return images, captions
+    raise AssertionError("no image table found on the front page")
+
+
+def _asset_for(target: str) -> Path:
+    assert target.startswith(RAW_ASSET_PREFIX), (
+        f"front-page image {target!r} must be an absolute raw URL: a repo-relative "
+        "path renders as a broken image on PyPI, where this file is the long description"
+    )
+    return REPO_ROOT / target[len(RAW_ASSET_PREFIX) :]
+
+
+def test_front_page_shows_one_terminal_surface_and_one_browser_surface() -> None:
+    """Two images, side by side, and nothing else in the row."""
+    images, captions = _surface_table()
+
+    assert len(images) == 2, f"expected exactly two surface renders, found {len(images)}"
+    assert len(captions) == 2, f"expected one caption per render, found {len(captions)}"
+    for cell in images:
+        assert MARKDOWN_IMAGE.fullmatch(cell), f"surface cell is not a bare image: {cell!r}"
+
+
+def test_each_surface_render_is_captioned_with_the_command_that_opens_it() -> None:
+    """A render whose caption names no command is a picture of an unreachable thing."""
+    _, captions = _surface_table()
+
+    for command, caption in zip(SURFACE_COMMANDS, captions, strict=True):
+        assert f"`{command}`" in caption, (
+            f"the caption {caption!r} does not name the command that opens that surface (expected `{command}`)"
+        )
+
+
+def test_alt_text_on_every_front_page_render_is_a_sentence() -> None:
+    """Alt text is read aloud and shown when the image 404s - a filename is neither.
+
+    Scoped to the renders this repository ships: an external status badge is
+    labelled by convention ("CI", "PyPI") and an identity mark is labelled by
+    name, so neither is improved by a sentence.
+    """
+    text = README.read_text(encoding="utf-8")
+    pairs = [(alt, target) for alt, target in MARKDOWN_IMAGE.findall(text)]
+    pairs += [(alt, src) for alt, src in HTML_IMG.findall(text)]
+    renders = [
+        (alt, target)
+        for alt, target in pairs
+        if target.startswith(RAW_ASSET_PREFIX) and Path(target).name not in IDENTITY_MARKS
+    ]
+    assert renders, "expected the README to reference at least one render of a surface"
+
+    for alt, target in renders:
+        assert len(alt.split()) >= 6, f"alt text for {target} is too short to describe it: {alt!r}"
+        assert not re.search(r"\.(png|gif|svg|jpe?g)\b", alt, re.IGNORECASE), (
+            f"alt text reads as a filename rather than a description: {alt!r}"
+        )
+
+
+def test_no_front_page_render_shows_the_page_through_it() -> None:
+    """A transparent render inherits the page background and inverts between themes.
+
+    Checked on the pixels rather than by eye: whoever commits a render only
+    ever sees it in their own theme, so "looks fine" is not evidence about the
+    other one.
+
+    Measured as a share of the image rather than as a yes/no on the alpha
+    channel, because the two failure sizes are orders of magnitude apart. The
+    demo GIF is antialiased into rounded corners and spends 8 pixels of 2.08M
+    on them; a render that actually relies on the page background spends tens
+    of thousands. The former is invisible in either theme, the latter is the
+    bug this guards.
+
+    The logo pair is exempt: it is theme-switched deliberately through
+    ``<picture>``/``prefers-color-scheme``, which is the correct mechanism for
+    an asset that should follow the theme rather than resist it.
+    """
+    text = README.read_text(encoding="utf-8")
+    targets = [target for _, target in MARKDOWN_IMAGE.findall(text)] + [src for _, src in HTML_IMG.findall(text)]
+
+    #: Antialiased corners are allowed; a see-through background is not.
+    corner_allowance = 0.001
+
+    see_through: list[str] = []
+    for target in targets:
+        if not target.startswith(RAW_ASSET_PREFIX):
+            continue
+        asset = _asset_for(target)
+        if asset.name in IDENTITY_MARKS:
+            continue
+        with Image.open(asset) as image:
+            # The first frame is the one composited against the page; later
+            # GIF frames are diffs whose transparency means "unchanged".
+            histogram = image.convert("RGBA").getchannel("A").histogram()
+            fully_transparent = histogram[0]
+            total = sum(histogram)
+        if total and fully_transparent / total > corner_allowance:
+            see_through.append(f"{asset.name} ({100 * fully_transparent / total:.2f}% transparent)")
+
+    assert not see_through, (
+        "these front-page renders show the page through them, so they invert "
+        f"between GitHub's light and dark themes: {see_through}"
+    )


### PR DESCRIPTION
# User description
Slice 1 of #3427. Partial implementation of #3427 — slice 2 (the freshness gate) follows separately, so this PR does not close the issue.

## What this does

The README named `bernstein live` in one line inside a code block and linked the web UI from one row of a table below the fold. Ten renders of those two surfaces sit in `docs/assets/` referenced by nothing. This adds one terminal render and one browser render as a two-column table between **install in 30 seconds** and **how it works**, each captioned with the command that opens that surface, and mirrors the same block onto the docs front page (`docs/index.md`).

Chosen renders:

| render | why this one |
|---|---|
| `docs/assets/tui-agents.png` | the three-column layout is the thing worth seeing: agents with live logs, task board, activity feed, cost line |
| `docs/assets/webui-agents-diffs.png` | the only SPA render that is not an empty state — 62 tasks, 11 running, one opened to its working-tree diff. The approvals/agents/tasks renders all show zero rows |

## One deliberate deviation from the issue

The issue sketched a repo-relative markdown image. That form cannot ship: `pyproject.toml` sets `readme = "README.md"`, so the file is the packaged long description, and a repo-relative image resolves against `pypi.org/project/bernstein/`. The renders are referenced by absolute `raw.githubusercontent.com` URLs instead — the same rule #3441 applied to prose links, now extended to images.

## A pre-existing break this turned up

Writing that gate immediately failed on two images that were already repo-relative: the logo `picture` block and the banner. Both have been rendering as broken-image icons on PyPI since the front-page rewrite. Fixed here, including the `srcset` halves — which is where the mistake hides best, because the `img` fallback next to them keeps the page looking correct in whichever theme the author is using.

## Tests

Each is named for the property it protects. The front-page invariants run against **both** front pages — `README.md` and `docs/index.md` — with a per-page resolver, because the MkDocs page uses site-relative targets and the docs build does not run in CI.

| test | property | evidence |
|---|---|---|
| `test_front_page_shows_one_terminal_surface_and_one_browser_surface` | two renders, side by side, nothing else in the row | fails on the pages before this change |
| `test_each_surface_render_is_captioned_with_the_command_that_opens_it` | a render nobody can reach is decoration | fails on the pages before this change |
| `test_every_readme_image_resolves_to_an_asset_this_repo_actually_ships` | no image source 404s on either renderer; no image loads from an unlisted host | fails before this change — it is what caught the logo and banner |
| `test_every_front_page_render_resolves_to_a_committed_asset` | the MkDocs page's assets exist | proven by renaming one asset reference in `docs/index.md` |
| `test_the_image_scan_sees_every_html_attribute_form` | the scan cannot silently skip single-quoted or unquoted attributes | asserts all four forms round-trip |
| `test_a_markdown_title_is_not_read_as_part_of_the_destination` | a titled or angle-bracketed image is not reported as broken | asserts four destination forms |
| `test_alt_text_on_every_front_page_render_is_a_sentence` | alt is what a screen reader announces and what GitHub shows when the image fails | proven by degrading one alt to a filename |
| `test_no_front_page_render_shows_the_page_through_it` | a transparent render takes the page background and inverts between themes | proven with a fully transparent render substituted into the table |

Fail-before / pass-after, run against this branch:

```
######## FAIL-BEFORE: README reverted to origin/main ########
FAILED tests/unit/test_readme_front_page_surfaces.py::test_front_page_shows_one_terminal_surface_and_one_browser_surface
FAILED tests/unit/test_readme_front_page_surfaces.py::test_each_surface_render_is_captioned_with_the_command_that_opens_it
FAILED tests/unit/test_packaged_readme_renders_off_repo.py::test_every_readme_image_resolves_to_an_asset_this_repo_actually_ships
3 failed, 6 passed

######## PASS-AFTER ########
17 passed
```

## On the light/dark acceptance criterion

The criterion asks for both themes to be verified by viewing the rendered README. What is actually being asked is that no image relies on the page background, so it is checked on the pixels instead of by eye — whoever commits a render only ever sees it in their own theme, so "looks fine" is not evidence about the other one. Both renders are opaque: `webui-agents-diffs.png` has no alpha channel at all, `tui-agents.png` has one that is 255 everywhere.

The measurement is a share, not a yes/no, because the two failure sizes are orders of magnitude apart: the demo GIF is antialiased into rounded corners and spends 8 transparent pixels out of 2.08M on them, while a render that genuinely relies on the page background spends tens of thousands. The logo pair is exempt — it is theme-switched on purpose through `prefers-color-scheme`, which is the correct mechanism for an asset that *should* follow the theme.

## Rendered through PyPI's own renderer

Checked with `readme_renderer.markdown.render` (installed ad-hoc, not added as a dependency) against this branch's README. The long description renders (21598 bytes), the two-column table survives, and all three renders survive: `tui-agents.png`, `webui-agents-diffs.png`, `demo.gif`. The `picture` element survives while its `source` children are stripped, so the logo falls back to `logo-light.svg` — which is what the fallback is for.

Wiring that renderer in as a permanent check would be worth doing and needs a dev-dependency decision, so it is a follow-up rather than a quiet addition here.

## Review findings

Every finding has a verdict in the commit trail (the acknowledgements are commit trailers rather than body markers, because this body's HTML-looking spans get sanitised on the way in):

| id | verdict |
|---|---|
| `3726297955` | fixed in `c3c909f3` — host allowlist for images |
| `3726364722` | fixed in `e5e20a24` — HTML parser instead of one quote style |
| `3726408452` | fixed in `03232b62` — markdown destination parsed apart from its title |
| `3726364727` | rejected in `03232b62`, with the renderer output as evidence: the strip is graceful fallback, predates this PR, and the proposed remedy would remove coverage from the element that does render on GitHub in dark mode |
| `3726408457` | rejected in `03232b62`: pinning the image URLs to a commit SHA would freeze the front page's images and require rewriting URLs on every asset change; the URLs say `main` because they mean `main` |

## What this slice does not do

- No freshness gate. Nothing yet fails when the dashboard changes and these renders do not — that is slice 2, and it is the half worth more.
- The committed SPA renders were captured against an older build (their status bars read `v2.7.0` and `v2.0.0`). Slice 2's bundle-hash binding is what makes that visible and fixable rather than a thing someone notices in a year.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add terminal and browser operator-surface renders to the README and documentation front page, captioned with <code>bernstein live</code> and <code>bernstein gui serve</code>. Update image URLs for packaged PyPI rendering and add validation that front-page images resolve, use approved hosts, provide useful alt text, and remain opaque across themes.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3442?tool=ast&topic=Image+rendering+checks>Image rendering checks</a>
        </td><td>Harden front-page image validation for PyPI and MkDocs by resolving Markdown and HTML image forms, enforcing asset and host policies, parsing titles and URL suffixes, and checking rendered assets for transparency.<details><summary>Modified files (3)</summary><ul><li>README.md</li>
<li>tests/unit/test_packaged_readme_renders_off_repo.py</li>
<li>tests/unit/test_readme_front_page_surfaces.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>test(docs): take the a...</td><td>August 06, 2026</td></tr>
<tr><td>chernistry</td><td>docs: point the demo e...</td><td>August 05, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3442?tool=ast&topic=Operator+surfaces>Operator surfaces</a>
        </td><td>Show paired terminal and browser dashboard renders on both front pages, with accessible captions and alt text directing users to the commands that open each operator surface.<details><summary>Modified files (3)</summary><ul><li>README.md</li>
<li>docs/index.md</li>
<li>tests/unit/test_readme_front_page_surfaces.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>test(docs): allowlist ...</td><td>August 06, 2026</td></tr>
<tr><td>chernistry</td><td>docs: point the demo e...</td><td>August 05, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3442?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>