### PR TITLE
fix(cli): resolve the task server per poll in the TUI instead of pinning 8052

### DIFF
--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -294,6 +294,8 @@ The default is the 3-column Textual TUI: Agents | Tasks | Activity feed. `--clas
 
 Both views resolve the task server the same way as the rest of the CLI: `BERNSTEIN_SERVER_URL`, then the port the running orchestrator persisted in `.sdd/runtime/server.port`, then `http://localhost:8052`. When the poll cannot reach that server the header says `No connection to <url>` rather than drawing empty panels, which would be indistinguishable from an orchestrator with nothing to do.
 
+The run token the orchestrator persists under `.sdd/runtime` is only ever sent to a loopback address: it is a credential this machine minted for its own run, and `BERNSTEIN_SERVER_URL` can name any host. A token you set in `BERNSTEIN_AUTH_TOKEN` yourself goes wherever you point the dashboard.
+
 #### `bernstein dashboard`
 
 | Flag | Default | Meaning |

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -292,6 +292,8 @@ Compact one-screen project view.
 
 The default is the 3-column Textual TUI: Agents | Tasks | Activity feed. `--classic` falls back to a single-pane Rich Live view.
 
+Both views resolve the task server the same way as the rest of the CLI: `BERNSTEIN_SERVER_URL`, then the port the running orchestrator persisted in `.sdd/runtime/server.port`, then `http://localhost:8052`. When the poll cannot reach that server the header says `No connection to <url>` rather than drawing empty panels, which would be indistinguishable from an orchestrator with nothing to do.
+
 #### `bernstein dashboard`
 
 | Flag | Default | Meaning |

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -292,7 +292,7 @@ Compact one-screen project view.
 
 The default is the 3-column Textual TUI: Agents | Tasks | Activity feed. `--classic` falls back to a single-pane Rich Live view.
 
-Both views resolve the task server the same way as the rest of the CLI: `BERNSTEIN_SERVER_URL`, then the port the running orchestrator persisted in `.sdd/runtime/server.port`, then `http://localhost:8052`. When the poll cannot reach that server the header says `No connection to <url>` rather than drawing empty panels, which would be indistinguishable from an orchestrator with nothing to do.
+Both views resolve the task server the same way as the rest of the CLI: `BERNSTEIN_SERVER_URL`, then the port the running orchestrator persisted in `.sdd/runtime/server.port`, then `http://localhost:8052`. When the poll cannot reach that server the header says `No connection to <url>` rather than drawing empty panels, which would be indistinguishable from an orchestrator with nothing to do. That state means *every* read failed: one route erroring while the others answer is a broken route, not a dead server, so the dashboard keeps rendering the panels that did load.
 
 The run token the orchestrator persists under `.sdd/runtime` is only ever sent to a loopback address: it is a credential this machine minted for its own run, and `BERNSTEIN_SERVER_URL` can name any host. A token you set in `BERNSTEIN_AUTH_TOKEN` yourself goes wherever you point the dashboard.
 

--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -26,7 +26,6 @@ import click
 import httpx
 
 from bernstein.cli.helpers import (
-    SERVER_URL,
     ServerAuthError,
     console,
     find_seed_file,
@@ -111,7 +110,8 @@ def live(interval: float, classic: bool, no_splash: bool) -> None:
 
     (
         LiveView(
-            server_url=SERVER_URL,
+            # No explicit URL: the view resolves the server per request, so a
+            # run on a non-default port is followed rather than missed.
             interval=interval,
         )
     ).run()

--- a/src/bernstein/cli/dashboard_app.py
+++ b/src/bernstein/cli/dashboard_app.py
@@ -45,7 +45,6 @@ from bernstein.cli.dashboard_header import (
 )
 from bernstein.cli.dashboard_polling import (
     ROLE_COLORS,
-    SERVER_URL,
     _build_runtime_subtitle,
     _fetch_all,
     _format_activity_line,
@@ -60,6 +59,7 @@ from bernstein.cli.dashboard_polling import (
     _summarize_agent_errors,
     _tail_log,
     _task_retry_count,
+    server_url,
 )
 from bernstein.cli.icons import get_icons
 from bernstein.cli.visual_theme import role_color
@@ -281,6 +281,9 @@ class BernsteinApp(App[None]):
         self._history: deque[float] = deque(maxlen=60)
         self._cost_history: deque[float] = deque(maxlen=10)
         self._evolve = False
+        #: True when the last poll could not reach the task server, so the
+        #: header can say so instead of showing an empty run (issue #3444).
+        self._server_unreachable = False
         self._activity_visible = True
         self._expert_mode = False
         self._task_titles: dict[str, str] = {}
@@ -539,6 +542,7 @@ class BernsteinApp(App[None]):
         status = data.get("status") or {}
         self._log_phase_transitions(status, data.get("agents") or [])
 
+        self._server_unreachable = bool(data.get("server_unreachable"))
         self._update_tasks(data.get("tasks"))
         tasks = data.get("tasks") or []
         costs: dict[str, Any] = data.get("costs") or {}
@@ -816,6 +820,7 @@ class BernsteinApp(App[None]):
             total=bar.total,
             worktrees=bar.active_worktrees,
             restart_count=bar.restart_count,
+            unreachable_url=server_url() if self._server_unreachable else "",
         )
 
         if costs:
@@ -1196,7 +1201,7 @@ class BernsteinApp(App[None]):
             if _shutdown_token:
                 _shutdown_headers["Authorization"] = f"Bearer {_shutdown_token}"
             httpx.post(
-                f"{SERVER_URL}/shutdown",
+                f"{server_url()}/shutdown",
                 json={"reason": "hot restart"},
                 timeout=2.0,
                 headers=_shutdown_headers,
@@ -1410,7 +1415,7 @@ class BernsteinApp(App[None]):
         role = self._detect_role(text)
         try:
             resp = httpx.post(
-                f"{SERVER_URL}/tasks",
+                f"{server_url()}/tasks",
                 json={
                     "title": text,
                     "description": f"User request (P1): {text}",

--- a/src/bernstein/cli/dashboard_polling.py
+++ b/src/bernstein/cli/dashboard_polling.py
@@ -22,8 +22,27 @@ from bernstein.cli.visual_theme import PALETTE, role_color, sample_gradient
 
 logger = logging.getLogger(__name__)
 
+#: Fallback only, and kept because other modules import it. The server the TUI
+#: actually talks to is resolved per call by :func:`server_url` - a run whose
+#: port was taken writes the real one to ``.sdd/runtime/server.port``, and
+#: polling a constant instead renders an empty dashboard that looks like an
+#: idle one (issue #3444).
 SERVER_URL = "http://127.0.0.1:8052"
 _SPARK_CHARS = "▁▂▃▄▅▆▇█"
+
+
+def server_url() -> str:
+    """Resolve the task server the way the rest of the CLI resolves it.
+
+    ``BERNSTEIN_SERVER_URL`` first, then the port the running orchestrator
+    persisted for this workspace, then the default. Resolved per call rather
+    than at import so a dashboard started before the server, or restarted onto
+    a different port, follows it.
+    """
+    from bernstein.cli.helpers import resolve_server_url
+
+    return resolve_server_url()
+
 
 # -- Data fetching (sync -- called via run_worker in a thread) -----
 
@@ -53,7 +72,7 @@ def _get(path: str) -> Any:
 
     try:
         return httpx.get(
-            f"{SERVER_URL}{path}",
+            f"{server_url()}{path}",
             timeout=10.0,
             headers=_auth_headers(),
         ).json()
@@ -67,7 +86,7 @@ def _post(path: str, body: dict[str, Any] | None = None) -> Any:
 
     try:
         return httpx.post(
-            f"{SERVER_URL}{path}",
+            f"{server_url()}{path}",
             json=body or {},
             timeout=2.0,
             headers=_auth_headers(),
@@ -110,6 +129,9 @@ def _fetch_all() -> dict[str, Any]:
         verification_nudge = status.get("verification_nudge", {}) or {}
 
     return {
+        # An unreachable server and an idle one produce the same empty panels,
+        # so the difference is carried explicitly rather than left to the log.
+        "server_unreachable": status is None,
         "tasks": tasks,
         "status": status,
         "agents": agents,
@@ -331,8 +353,19 @@ def _build_runtime_subtitle(
     total: int,
     worktrees: int,
     restart_count: int,
+    unreachable_url: str = "",
 ) -> str:
-    """Build the compact runtime subtitle shown in the TUI header."""
+    """Build the compact runtime subtitle shown in the TUI header.
+
+    Args:
+        unreachable_url: Server the last poll failed against, if it failed. An
+            unreachable server empties every panel, which is indistinguishable
+            on screen from an orchestrator with nothing to do - so when the
+            poll fails the subtitle says so instead of describing a run that
+            may not exist (issue #3444).
+    """
+    if unreachable_url:
+        return f"No connection to {unreachable_url} - showing no data, not an idle run"
     progress_pct = int(done / total * 100) if total > 0 else 0
     parts = [f"Running for {_format_elapsed_label(elapsed_s)}"]
     if git_branch:

--- a/src/bernstein/cli/dashboard_polling.py
+++ b/src/bernstein/cli/dashboard_polling.py
@@ -93,10 +93,16 @@ def _auth_headers(url: str) -> dict[str, str]:
     return {}
 
 
-def _get(path: str) -> Any:
+def _get(path: str, url: str | None = None) -> Any:
+    """GET *path*, from *url* when the caller has already resolved one.
+
+    A batch passes its resolved URL in so every read in one dashboard update
+    comes from the same server: re-resolving per request lets a run that
+    restarts onto another port mid-batch mix two servers into one frame.
+    """
     import httpx
 
-    url = server_url()
+    url = url or server_url()
     try:
         response = httpx.get(f"{url}{path}", timeout=10.0, headers=_auth_headers(url))
         # A 4xx/5xx with a JSON body would otherwise be handed to the widgets
@@ -131,6 +137,9 @@ def _fetch_all() -> dict[str, Any]:
     """
     from typing import cast
 
+    # One resolution for the whole batch: see _get.
+    url = server_url()
+
     # Fast path: local files (instant, no HTTP)
     agents = _load_agents()
     quarantine = _load_quarantine()
@@ -139,12 +148,12 @@ def _fetch_all() -> dict[str, Any]:
     activity_summaries = _load_activity_summaries()
 
     # Slow path: HTTP to task server (may take 1-3s with many tasks)
-    status = _get("/status")
-    costs = _get("/costs")
-    quality = _get("/quality")
-    bandit = _get("/routing/bandit")
+    status = _get("/status", url)
+    costs = _get("/costs", url)
+    quality = _get("/quality", url)
+    bandit = _get("/routing/bandit", url)
     # Use /status for task counts instead of fetching all 400+ task objects
-    tasks = _get("/tasks")
+    tasks = _get("/tasks", url)
     pending_approval = 0
     if isinstance(tasks, list):
         task_dicts = cast("list[dict[str, Any]]", tasks)

--- a/src/bernstein/cli/dashboard_polling.py
+++ b/src/bernstein/cli/dashboard_polling.py
@@ -6,6 +6,7 @@ that are used by the TUI widgets and application.
 
 from __future__ import annotations
 
+import ipaddress
 import json
 import logging
 import os
@@ -13,6 +14,7 @@ import re
 import time
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 from rich.markup import escape
 from rich.text import Text
@@ -47,8 +49,24 @@ def server_url() -> str:
 # -- Data fetching (sync -- called via run_worker in a thread) -----
 
 
-def _auth_headers() -> dict[str, str]:
-    """Return the Authorization header for dashboard polling.
+def is_loopback(url: str) -> bool:
+    """Whether *url* addresses this machine.
+
+    Hostname-based rather than DNS-resolving on purpose: a resolver answer can
+    change between the check and the request, and this decides what a
+    credential is attached to.
+    """
+    host = (urlsplit(url).hostname or "").lower()
+    if host in {"localhost", "::1"}:
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+def _auth_headers(url: str) -> dict[str, str]:
+    """Return the Authorization header for a poll against *url*.
 
     The TUI usually runs inside the main Bernstein process, so it inherits the
     token that ``_resolve_auth_token`` stashes into ``os.environ`` during
@@ -56,9 +74,17 @@ def _auth_headers() -> dict[str, str]:
     it falls back to the persisted run token file under ``.sdd/runtime``
     (issue #2794). Without this header the SSO middleware rejects every
     request with 401, leaving the Tasks panel empty.
+
+    The persisted token is only ever sent to a loopback address. It is a
+    credential this machine minted for its own run, and the destination is now
+    resolvable from ``BERNSTEIN_SERVER_URL``: attaching it to whatever that
+    points at would hand the run credential to any host an operator - or
+    anything that can set an environment variable - names. A token the
+    operator set in the environment themselves is theirs to aim, so it goes
+    where they point it.
     """
     token = os.environ.get("BERNSTEIN_AUTH_TOKEN")
-    if not token:
+    if not token and is_loopback(url):
         from bernstein.core.run_auth_token import read_run_auth_token
 
         token = read_run_auth_token(Path.cwd())
@@ -70,12 +96,14 @@ def _auth_headers() -> dict[str, str]:
 def _get(path: str) -> Any:
     import httpx
 
+    url = server_url()
     try:
-        return httpx.get(
-            f"{server_url()}{path}",
-            timeout=10.0,
-            headers=_auth_headers(),
-        ).json()
+        response = httpx.get(f"{url}{path}", timeout=10.0, headers=_auth_headers(url))
+        # A 4xx/5xx with a JSON body would otherwise be handed to the widgets
+        # as data, and would count as a successful read when deciding whether
+        # the server is reachable at all.
+        response.raise_for_status()
+        return response.json()
     except Exception as exc:
         logger.warning("Dashboard GET %s failed: %s", path, exc)
         return None
@@ -84,13 +112,11 @@ def _get(path: str) -> Any:
 def _post(path: str, body: dict[str, Any] | None = None) -> Any:
     import httpx
 
+    url = server_url()
     try:
-        return httpx.post(
-            f"{server_url()}{path}",
-            json=body or {},
-            timeout=2.0,
-            headers=_auth_headers(),
-        ).json()
+        response = httpx.post(f"{url}{path}", json=body or {}, timeout=2.0, headers=_auth_headers(url))
+        response.raise_for_status()
+        return response.json()
     except Exception as exc:
         logger.warning("Dashboard POST %s failed: %s", path, exc)
         return None

--- a/src/bernstein/cli/dashboard_polling.py
+++ b/src/bernstein/cli/dashboard_polling.py
@@ -128,10 +128,15 @@ def _fetch_all() -> dict[str, Any]:
     if isinstance(status, dict):
         verification_nudge = status.get("verification_nudge", {}) or {}
 
+    # An unreachable server and an idle one produce the same empty panels, so
+    # the difference is carried explicitly rather than left to the log. Every
+    # HTTP read has to have failed before the whole server is called
+    # unreachable: one route erroring is a broken route, and blanking a
+    # working dashboard over it would hide the data that did arrive.
+    server_unreachable = all(result is None for result in (status, costs, quality, bandit, tasks))
+
     return {
-        # An unreachable server and an idle one produce the same empty panels,
-        # so the difference is carried explicitly rather than left to the log.
-        "server_unreachable": status is None,
+        "server_unreachable": server_unreachable,
         "tasks": tasks,
         "status": status,
         "agents": agents,

--- a/src/bernstein/cli/live.py
+++ b/src/bernstein/cli/live.py
@@ -112,6 +112,10 @@ class LiveView:
         self._start_ts = time.time()
         self._cost_history: deque[float] = deque(maxlen=60)
         self._done_history: deque[float] = deque(maxlen=60)
+        #: Set when the last fetch got nothing at all. An empty dashboard and a
+        #: dead server look identical otherwise, in this view as much as in the
+        #: Textual one (issue #3444).
+        self._unreachable_url = ""
 
     # -- Data fetching --
 
@@ -124,7 +128,7 @@ class LiveView:
         """
         return self._server_url or resolve_server_url()
 
-    def _get(self, path: str) -> dict[str, Any] | list[Any] | None:
+    def _get(self, path: str, url: str | None = None) -> dict[str, Any] | list[Any] | None:
         """GET from the task server, returning parsed JSON or None.
 
         Args:
@@ -133,7 +137,7 @@ class LiveView:
         Returns:
             Parsed JSON response, or None on error.
         """
-        url = self._resolved_url()
+        url = url or self._resolved_url()
         try:
             resp = httpx.get(f"{url}{path}", timeout=2.0, headers=poll_auth_headers(url))
             resp.raise_for_status()
@@ -148,14 +152,17 @@ class LiveView:
         Returns:
             Dict with ``status``, ``tasks``, ``agents``, ``costs`` keys.
         """
-        status_resp = self._get("/status")
+        url = self._resolved_url()
+        status_resp = self._get("/status", url)
         status: dict[str, Any] = status_resp if isinstance(status_resp, dict) else {}
 
-        tasks_resp = self._get("/tasks")
+        tasks_resp = self._get("/tasks", url)
         tasks: list[dict[str, Any]] = tasks_resp if isinstance(tasks_resp, list) else []  # type: ignore[assignment]
 
-        costs_resp = self._get("/costs/live")
+        costs_resp = self._get("/costs/live", url)
         costs: dict[str, Any] = costs_resp if isinstance(costs_resp, dict) else {}  # type: ignore[assignment]
+
+        self._unreachable_url = "" if any(x is not None for x in (status_resp, tasks_resp, costs_resp)) else url
 
         return {
             "status": status,
@@ -222,7 +229,7 @@ class LiveView:
         # Stats bar
         stats_bar = _build_stats_text(summary, elapsed, len(agents))
 
-        return Group(
+        panels = [
             agents_table,
             tasks_table,
             Panel(progress_text, title="Progress", border_style="cyan"),
@@ -230,7 +237,19 @@ class LiveView:
             cost_spark_panel,
             spark_panel,
             stats_bar,
-        )
+        ]
+
+        if self._unreachable_url:
+            # Same wording as the Textual header, because it is the same fact:
+            # empty panels here mean nothing arrived, not that nothing is
+            # happening.
+            banner = Text(
+                f"No connection to {self._unreachable_url} - showing no data, not an idle run",
+                style="bold red",
+            )
+            return Group(banner, *panels)
+
+        return Group(*panels)
 
     # -- Public API --
 

--- a/src/bernstein/cli/live.py
+++ b/src/bernstein/cli/live.py
@@ -18,7 +18,8 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
-from bernstein.cli.helpers import auth_headers, resolve_server_url
+from bernstein.cli.dashboard_polling import _auth_headers as poll_auth_headers
+from bernstein.cli.helpers import resolve_server_url
 from bernstein.cli.ui import (
     STATUS_COLORS,
     AgentInfo,
@@ -132,8 +133,10 @@ class LiveView:
         Returns:
             Parsed JSON response, or None on error.
         """
+        url = self._resolved_url()
         try:
-            resp = httpx.get(f"{self._resolved_url()}{path}", timeout=2.0, headers=auth_headers())
+            resp = httpx.get(f"{url}{path}", timeout=2.0, headers=poll_auth_headers(url))
+            resp.raise_for_status()
             result: dict[str, Any] | list[Any] = resp.json()
             return result
         except Exception:

--- a/src/bernstein/cli/live.py
+++ b/src/bernstein/cli/live.py
@@ -6,7 +6,6 @@ from task-server data, plus a simple sparkline renderer for cost over time.
 
 from __future__ import annotations
 
-import os
 import time
 from collections import deque
 from contextlib import suppress
@@ -19,6 +18,7 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
+from bernstein.cli.helpers import auth_headers, resolve_server_url
 from bernstein.cli.ui import (
     STATUS_COLORS,
     AgentInfo,
@@ -72,6 +72,7 @@ def render_sparkline(values: list[float], *, width: int = 40) -> Text:
 # LiveView
 # ---------------------------------------------------------------------------
 
+#: Kept for callers importing it; the view itself resolves per request.
 _DEFAULT_SERVER_URL = "http://127.0.0.1:8052"
 
 
@@ -95,10 +96,15 @@ class LiveView:
 
     def __init__(
         self,
-        server_url: str = _DEFAULT_SERVER_URL,
+        server_url: str | None = None,
         interval: float = 2.0,
         console: Console | None = None,
     ) -> None:
+        #: ``None`` means "resolve per request", which is the default: a
+        #: workspace whose run took another port persists it, and a view
+        #: pinned at construction polls a port with nothing behind it and
+        #: renders an empty dashboard (issue #3444). An explicit URL is still
+        #: honoured, for a caller pointing at a server elsewhere.
         self._server_url = server_url
         self._interval = interval
         self._console = console or make_console()
@@ -107,6 +113,15 @@ class LiveView:
         self._done_history: deque[float] = deque(maxlen=60)
 
     # -- Data fetching --
+
+    def _resolved_url(self) -> str:
+        """Return the server for this request.
+
+        Resolved here rather than at construction so the classic view and the
+        Textual one answer the same question the same way: environment
+        variable, then the port this workspace persisted, then the default.
+        """
+        return self._server_url or resolve_server_url()
 
     def _get(self, path: str) -> dict[str, Any] | list[Any] | None:
         """GET from the task server, returning parsed JSON or None.
@@ -117,12 +132,8 @@ class LiveView:
         Returns:
             Parsed JSON response, or None on error.
         """
-        headers: dict[str, str] = {}
-        token = os.environ.get("BERNSTEIN_AUTH_TOKEN")
-        if token:
-            headers["Authorization"] = f"Bearer {token}"
         try:
-            resp = httpx.get(f"{self._server_url}{path}", timeout=2.0, headers=headers)
+            resp = httpx.get(f"{self._resolved_url()}{path}", timeout=2.0, headers=auth_headers())
             result: dict[str, Any] | list[Any] = resp.json()
             return result
         except Exception:

--- a/tests/unit/test_dashboard_server_resolution.py
+++ b/tests/unit/test_dashboard_server_resolution.py
@@ -1,0 +1,143 @@
+"""The TUI has to poll the server this run is actually on.
+
+`bernstein live` used a module constant pinned to port 8052. A run whose port
+was taken writes the real one to `.sdd/runtime/server.port`, and `bernstein
+demo` runs on 8055, so the dashboard polled a port with nothing behind it,
+swallowed the connection error into a log line, and drew three empty panels -
+identical on screen to an orchestrator with nothing to do (issue #3444).
+
+The tests drive a real HTTP server on a real ephemeral port rather than
+patching `httpx`, because the property under test is "the poll reaches the
+server this workspace recorded", and a recorded call argument cannot fail the
+way a wrong port does.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from collections.abc import Iterator
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+
+from bernstein.cli import dashboard_polling
+from bernstein.cli.helpers import persist_server_port
+
+#: What the fake server answers `/status` with; any value the real route would
+#: not produce by accident, so a passing test cannot be a coincidence.
+STATUS_PAYLOAD = {"total": 7, "done": 3, "agents": [{"id": "backend-fixture", "status": "working"}]}
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler's contract
+        body = json.dumps(STATUS_PAYLOAD if self.path.startswith("/status") else []).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *_args: object) -> None:
+        """Keep the test output readable."""
+
+
+@pytest.fixture
+def live_server() -> Iterator[int]:
+    """Serve JSON on an ephemeral port for the duration of one test."""
+    server = HTTPServer(("127.0.0.1", 0), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server.server_address[1]
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Resolve against a scratch workspace, never the developer's own."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("BERNSTEIN_SERVER_URL", raising=False)
+    monkeypatch.delenv("BERNSTEIN_AUTH_TOKEN", raising=False)
+
+
+def test_the_dashboard_polls_the_port_this_run_persisted(live_server: int) -> None:
+    """The failing case: a run on any port other than the hardcoded default."""
+    persist_server_port(live_server)
+
+    assert dashboard_polling._get("/status") == STATUS_PAYLOAD
+
+
+def test_the_environment_variable_outranks_the_persisted_port(live_server: int, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Same precedence as `resolve_server_url`, so one command cannot disagree.
+
+    The persisted port here is deliberately dead: if it won, the fetch would
+    return None and the assertion would fail rather than pass by luck.
+    """
+    persist_server_port(1)
+    monkeypatch.setenv("BERNSTEIN_SERVER_URL", f"http://127.0.0.1:{live_server}")
+
+    assert dashboard_polling._get("/status") == STATUS_PAYLOAD
+
+
+def test_the_url_is_resolved_per_call_not_at_import(live_server: int, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A dashboard started before the server has to follow it when it appears."""
+    assert dashboard_polling._get("/status") is None  # nothing recorded yet
+
+    monkeypatch.setenv("BERNSTEIN_SERVER_URL", f"http://127.0.0.1:{live_server}")
+
+    assert dashboard_polling._get("/status") == STATUS_PAYLOAD
+
+
+def test_a_full_fetch_against_a_live_server_is_not_reported_unreachable(live_server: int) -> None:
+    persist_server_port(live_server)
+
+    data = dashboard_polling._fetch_all()
+
+    assert data["server_unreachable"] is False
+    assert data["status"] == STATUS_PAYLOAD
+
+
+def test_an_unreachable_server_is_carried_in_the_payload() -> None:
+    """The panels are empty either way; the difference has to be explicit."""
+    persist_server_port(1)
+
+    data = dashboard_polling._fetch_all()
+
+    assert data["server_unreachable"] is True
+    assert data["status"] is None
+    assert data["tasks"] is None
+
+
+def test_the_header_says_no_connection_rather_than_describing_an_idle_run() -> None:
+    """An empty dashboard and a dead server must not read the same."""
+    subtitle = dashboard_polling._build_runtime_subtitle(
+        git_branch="main",
+        elapsed_s=42,
+        done=0,
+        total=0,
+        worktrees=0,
+        restart_count=0,
+        unreachable_url="http://127.0.0.1:8055",
+    )
+
+    assert "No connection to http://127.0.0.1:8055" in subtitle
+    assert "Running for" not in subtitle
+
+
+def test_a_reachable_server_keeps_the_ordinary_subtitle() -> None:
+    subtitle = dashboard_polling._build_runtime_subtitle(
+        git_branch="main",
+        elapsed_s=42,
+        done=3,
+        total=7,
+        worktrees=2,
+        restart_count=0,
+    )
+
+    assert "No connection" not in subtitle
+    assert "3/7 tasks" in subtitle

--- a/tests/unit/test_dashboard_server_resolution.py
+++ b/tests/unit/test_dashboard_server_resolution.py
@@ -34,8 +34,19 @@ class _Handler(BaseHTTPRequestHandler):
     #: When set, `/status` answers 500 while every other route stays healthy -
     #: a broken route on a reachable server, which must not read as offline.
     status_route_broken = False
+    #: When set, every route answers 401 with a JSON body - the shape that
+    #: looks like data to a client that does not check the status code.
+    every_route_rejects = False
 
     def do_GET(self) -> None:
+        if type(self).every_route_rejects:
+            rejection = json.dumps({"detail": "Unauthorized"}).encode()
+            self.send_response(401)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(rejection)))
+            self.end_headers()
+            self.wfile.write(rejection)
+            return
         if self.path.startswith("/status") and type(self).status_route_broken:
             self.send_response(500)
             self.send_header("Content-Length", "0")
@@ -192,3 +203,57 @@ def test_an_explicit_url_still_wins_for_the_classic_view(live_server: int) -> No
     persist_server_port(1)
 
     assert LiveView(server_url=f"http://127.0.0.1:{live_server}")._get("/status") == STATUS_PAYLOAD
+
+
+def test_a_json_error_body_is_not_mistaken_for_data(live_server: int, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 401 carrying JSON is the shape that slips past an unchecked read.
+
+    Without a status check the widgets would render `{"detail": ...}` as
+    dashboard state, and every route answering that way would still count as a
+    reachable server.
+    """
+    persist_server_port(live_server)
+    monkeypatch.setattr(_Handler, "every_route_rejects", True)
+
+    data = dashboard_polling._fetch_all()
+
+    assert data["server_unreachable"] is True
+    assert data["status"] is None
+    assert data["tasks"] is None
+
+
+def test_the_run_token_is_only_sent_to_this_machine(
+    live_server: int, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The persisted token is a credential minted for a local run.
+
+    Now that the destination comes from `BERNSTEIN_SERVER_URL`, attaching it
+    unconditionally would hand that credential to whatever host the variable
+    names - including one set by something other than the operator.
+    """
+    from bernstein.core.run_auth_token import persist_run_auth_token
+
+    persist_run_auth_token(Path.cwd(), "secret-run-token")
+
+    assert dashboard_polling._auth_headers(f"http://127.0.0.1:{live_server}") == {
+        "Authorization": "Bearer secret-run-token"
+    }
+    assert dashboard_polling._auth_headers("https://elsewhere.example/api") == {}
+
+    # A token the operator set themselves is theirs to aim.
+    monkeypatch.setenv("BERNSTEIN_AUTH_TOKEN", "operator-token")
+    assert dashboard_polling._auth_headers("https://elsewhere.example/api") == {
+        "Authorization": "Bearer operator-token"
+    }
+
+
+def test_the_classic_view_also_withholds_the_run_token_from_a_remote_host(tmp_path: Path) -> None:
+    """Both views share one policy, because they now share one resolver."""
+    from bernstein.cli.live import LiveView
+    from bernstein.core.run_auth_token import persist_run_auth_token
+
+    persist_run_auth_token(Path.cwd(), "secret-run-token")
+    view = LiveView(server_url="https://elsewhere.example")
+
+    assert view._get("/status") is None  # nothing there, and nothing sent
+    assert dashboard_polling._auth_headers(view._resolved_url()) == {}

--- a/tests/unit/test_dashboard_server_resolution.py
+++ b/tests/unit/test_dashboard_server_resolution.py
@@ -257,3 +257,42 @@ def test_the_classic_view_also_withholds_the_run_token_from_a_remote_host(tmp_pa
 
     assert view._get("/status") is None  # nothing there, and nothing sent
     assert dashboard_polling._auth_headers(view._resolved_url()) == {}
+
+
+def test_one_dashboard_update_reads_from_one_server(live_server: int, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A run restarting onto another port must not blend two servers into one frame.
+
+    The resolution happens once per batch, so a port file that changes midway
+    lands in the next update rather than half of this one.
+    """
+    persist_server_port(live_server)
+    seen: list[str] = []
+    real_get = dashboard_polling._get
+
+    def recording(path: str, url: str | None = None):  # type: ignore[no-untyped-def]
+        seen.append(url or "<resolved per call>")
+        # Move the target under the batch's feet, the way a restart would.
+        persist_server_port(1)
+        return real_get(path, url)
+
+    monkeypatch.setattr(dashboard_polling, "_get", recording)
+    data = dashboard_polling._fetch_all()
+
+    assert len(set(seen)) == 1, seen
+    assert data["status"] == STATUS_PAYLOAD
+
+
+def test_the_classic_view_says_no_connection_too(live_server: int) -> None:
+    """The empty-panels problem is the same in both views, so is the answer."""
+    from bernstein.cli.live import LiveView
+
+    view = LiveView(server_url=f"http://127.0.0.1:{live_server}")
+    view._render(view._fetch())
+    assert view._unreachable_url == ""
+
+    dead = LiveView(server_url="http://127.0.0.1:1")
+    frame = dead._render(dead._fetch())
+
+    assert dead._unreachable_url == "http://127.0.0.1:1"
+    rendered = "".join(segment.text for segment in frame.renderables[0].render(None))  # type: ignore[attr-defined]
+    assert "No connection to http://127.0.0.1:1" in rendered

--- a/tests/unit/test_dashboard_server_resolution.py
+++ b/tests/unit/test_dashboard_server_resolution.py
@@ -31,7 +31,16 @@ STATUS_PAYLOAD = {"total": 7, "done": 3, "agents": [{"id": "backend-fixture", "s
 
 
 class _Handler(BaseHTTPRequestHandler):
-    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler's contract
+    #: When set, `/status` answers 500 while every other route stays healthy -
+    #: a broken route on a reachable server, which must not read as offline.
+    status_route_broken = False
+
+    def do_GET(self) -> None:
+        if self.path.startswith("/status") and type(self).status_route_broken:
+            self.send_response(500)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
         body = json.dumps(STATUS_PAYLOAD if self.path.startswith("/status") else []).encode()
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
@@ -72,7 +81,9 @@ def test_the_dashboard_polls_the_port_this_run_persisted(live_server: int) -> No
     assert dashboard_polling._get("/status") == STATUS_PAYLOAD
 
 
-def test_the_environment_variable_outranks_the_persisted_port(live_server: int, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_the_environment_variable_outranks_the_persisted_port(
+    live_server: int, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Same precedence as `resolve_server_url`, so one command cannot disagree.
 
     The persisted port here is deliberately dead: if it won, the fetch would
@@ -141,3 +152,43 @@ def test_a_reachable_server_keeps_the_ordinary_subtitle() -> None:
 
     assert "No connection" not in subtitle
     assert "3/7 tasks" in subtitle
+
+
+def test_a_broken_route_on_a_reachable_server_is_not_reported_offline(
+    live_server: int, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One route erroring is a broken route, not a dead server.
+
+    Blanking the header over it would hide the panels that did load, which is
+    the opposite of what the unreachable state is for.
+    """
+    persist_server_port(live_server)
+    monkeypatch.setattr(_Handler, "status_route_broken", True)
+
+    data = dashboard_polling._fetch_all()
+
+    assert data["server_unreachable"] is False
+    assert data["status"] is None  # the broken route still reports nothing
+    assert data["tasks"] == []  # ...while the healthy ones still answer
+
+
+def test_the_classic_view_polls_the_same_server_as_the_textual_one(live_server: int) -> None:
+    """`bernstein live --classic` was pinned to the default port too.
+
+    It resolved through a different import, which is how one command ended up
+    answering the same question two ways.
+    """
+    from bernstein.cli.live import LiveView
+
+    persist_server_port(live_server)
+
+    assert LiveView()._get("/status") == STATUS_PAYLOAD
+
+
+def test_an_explicit_url_still_wins_for_the_classic_view(live_server: int) -> None:
+    """Resolving per request must not take away pointing it somewhere."""
+    from bernstein.cli.live import LiveView
+
+    persist_server_port(1)
+
+    assert LiveView(server_url=f"http://127.0.0.1:{live_server}")._get("/status") == STATUS_PAYLOAD


### PR DESCRIPTION
# User description
Closes #3444.

## The bug

`bernstein live` read its server from a module constant fixed at `127.0.0.1:8052` (`cli/dashboard_polling.py:25`). That constant backs `_get`/`_post`, which back `_fetch_all`, which is the only place the Textual dashboard reads state from.

The port is persisted precisely because it varies — `persist_server_port()` writes `.sdd/runtime/server.port` from three call sites in `run_bootstrap.py` — and `bernstein demo` runs on 8055. Against any of those, every poll returned `None`, `_get` swallowed the connection error into a `logger.warning` the TUI does not surface, and the operator got three empty panels.

That is the part worth fixing twice over: **an unreachable server and an idle orchestrator rendered identically**. Nothing on screen distinguished "showing you nothing" from "there is nothing to show".

Found while driving the dashboard against a live `bernstein demo` run for #3427.

The inconsistency was visible inside one command: `bernstein live --classic` passes `helpers.SERVER_URL` into `LiveView`, so the classic view already followed `BERNSTEIN_SERVER_URL` while the default Textual view ignored it.

## The fix

1. `dashboard_polling.server_url()` resolves through `helpers.resolve_server_url()` — environment variable, then the persisted port, then the default — which is what the rest of the CLI already does. `_get`, `_post` and the two direct uses in `dashboard_app.py` (`/shutdown`, posting a task) go through it.
2. Resolved **per call**, not at import, so a dashboard started before the server, or restarted onto another port, follows it.
3. `_fetch_all` reports `server_unreachable`, and the header renders `No connection to <url> — showing no data, not an idle run` instead of describing a run that may not exist.

The `SERVER_URL` constant stays as the documented fallback, because `cli/dashboard.py` re-exports it.

## Tests

`tests/unit/test_dashboard_server_resolution.py` drives a real HTTP server on a real ephemeral port rather than patching `httpx`. The property under test is "the poll reaches the server this workspace recorded", and a recorded call argument cannot fail the way a wrong port does.

| test | property |
|---|---|
| `test_the_dashboard_polls_the_port_this_run_persisted` | the failing case: a run on any port but the default |
| `test_the_environment_variable_outranks_the_persisted_port` | same precedence as `resolve_server_url`, so one command cannot disagree with another (the persisted port is deliberately dead, so a pass cannot be luck) |
| `test_the_url_is_resolved_per_call_not_at_import` | a dashboard started before the server follows it when it appears |
| `test_a_full_fetch_against_a_live_server_is_not_reported_unreachable` | the healthy path is not mislabelled |
| `test_an_unreachable_server_is_carried_in_the_payload` | the empty-panels case is explicit, not inferred |
| `test_the_header_says_no_connection_rather_than_describing_an_idle_run` | the two states do not read the same |
| `test_a_reachable_server_keeps_the_ordinary_subtitle` | the message does not leak into normal operation |

Fail-before / pass-after, with only `src/` reverted to `origin/main`:

```
######## FAIL-BEFORE ########
FAILED test_the_dashboard_polls_the_port_this_run_persisted
FAILED test_the_environment_variable_outranks_the_persisted_port
FAILED test_the_url_is_resolved_per_call_not_at_import
FAILED test_a_full_fetch_against_a_live_server_is_not_reported_unreachable
FAILED test_an_unreachable_server_is_carried_in_the_payload
FAILED test_the_header_says_no_connection_rather_than_describing_an_idle_run
6 failed, 1 passed

######## PASS-AFTER ########
7 passed
```

The existing dashboard suites still pass (`test_dashboard.py`, `test_dashboard_premium.py`, `test_dashboard_responsive.py`, `test_dashboard_model_label.py` — 58 tests). `mypy` on both changed modules reports the same two pre-existing errors as `origin/main`; the delta is zero.

## Docs

`docs/reference/cli-reference.md` now states the resolution order under `bernstein live` and the no-connection state, since both are operator-visible behaviour.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Resolve the dashboard task server per request through the shared environment, persisted-port, and default fallback logic, updating both Textual and classic views. Surface unreachable-server states distinctly from idle runs while securing persisted tokens and documenting the operator-visible behavior.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3445?tool=ast&topic=Connection+status>Connection status</a>
        </td><td>Report unreachable servers explicitly in Textual and classic dashboards so operators can distinguish connection failures from idle orchestrators, and document the behavior.<details><summary>Modified files (5)</summary><ul><li>docs/reference/cli-reference.md</li>
<li>src/bernstein/cli/dashboard_app.py</li>
<li>src/bernstein/cli/dashboard_polling.py</li>
<li>src/bernstein/cli/live.py</li>
<li>tests/unit/test_dashboard_server_resolution.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>docs(cli): say when th...</td><td>August 06, 2026</td></tr>
<tr><td>chernistry</td><td>docs(cli): fix the run...</td><td>August 05, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3445?tool=ast&topic=Server+resolution>Server resolution</a>
        </td><td>Resolve the task server consistently for both dashboard views, including persisted ports, environment overrides, per-batch URL stability, HTTP error handling, and safe authentication headers.<details><summary>Modified files (5)</summary><ul><li>src/bernstein/cli/commands/advanced_cmd.py</li>
<li>src/bernstein/cli/dashboard_app.py</li>
<li>src/bernstein/cli/dashboard_polling.py</li>
<li>src/bernstein/cli/live.py</li>
<li>tests/unit/test_dashboard_server_resolution.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>fix(cli): one server p...</td><td>August 06, 2026</td></tr>
<tr><td>chernistry</td><td>fix: make 15 capabilit...</td><td>July 25, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3445?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>