### PR TITLE
docs: fix the issue templates' broken commands and add a verification-failure form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,73 +1,103 @@
-name: Bug Report
-description: Something isn't working
+name: Bug report
+description: Something does not work the way it is documented
 labels: ["bug"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Every command below is one you can run today. If one of them fails
+        with `No such command`, that is itself a bug worth reporting.
+
   - type: textarea
     id: what-happened
     attributes:
-      label: What happened?
-      description: Describe the bug. What did you expect vs what actually happened?
-      placeholder: "I ran `bernstein conduct --goal '...'` and got..."
+      label: What happened
+      description: >
+        The command you ran and what it did. Paste the command and its output
+        rather than describing them - a summary loses the detail that
+        identifies the cause.
+      placeholder: |
+        $ bernstein -g "fix the failing test in tests/test_foo.py"
+        ...
+      render: shell
     validations:
       required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected instead
+      description: >
+        If a documentation page led you to expect it, link the page. A
+        mismatch between the docs and the behaviour is a bug in one of them,
+        and knowing which one you read tells us which.
+    validations:
+      required: true
+
   - type: textarea
     id: reproduce
     attributes:
       label: Steps to reproduce
-      description: Minimal steps to reproduce the issue
+      description: >
+        The smallest sequence that shows it. If it only happens on your own
+        repository, say so - that is useful, not disqualifying.
       value: |
         1.
         2.
         3.
     validations:
       required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Output of `bernstein --version`
+      placeholder: "bernstein 3.13.0"
+    validations:
+      required: true
+
   - type: textarea
-    id: env
+    id: doctor
     attributes:
       label: Environment
-      description: OS, Python version, bernstein version, which CLI agents you use
-      value: |
-        - OS:
-        - Python:
-        - Bernstein:
-        - Agent CLI: Claude Code / Codex / Gemini CLI / Other
-    validations:
-      required: false
-  - type: textarea
-    id: logs
-    attributes:
-      label: Logs
-      description: Paste relevant logs from `bernstein notes` or `.sdd/runtime/`
+      description: >
+        Output of `bernstein doctor`. It reports the Python version, the
+        installed agent CLIs and their versions, and the workspace state -
+        which is most of what we would otherwise ask you for one item at a
+        time.
       render: shell
     validations:
       required: false
+
   - type: textarea
     id: debug-bundle
     attributes:
       label: Debug bundle
       description: |
-        Run `bernstein debug bundle --last` and attach the generated zip
-        file. The bundle contains a redacted `bernstein.yaml`, a
-        `doctor.json` snapshot, recent traces and metrics, and the tail
-        of `.sdd/runtime/*.log`. Secrets (API keys, tokens, passwords,
-        bearer headers, JWTs, SSH keys) are removed and `$HOME` paths
-        are collapsed to `~` before the zip is written.
+        Run `bernstein debug bundle` and attach the generated zip.
 
-        Quick check before sharing: `unzip -p bernstein-debug-*.zip manifest.json`
-        prints the manifest with version, OS, and file list.
+        It contains a redacted `bernstein.yaml`, a `doctor` snapshot, recent
+        traces and metrics, and the tail of `.sdd/runtime/*.log`. API keys,
+        tokens, passwords, bearer headers, JWTs and SSH keys are removed, and
+        `$HOME` paths are collapsed to `~`, before the zip is written.
 
-        If you cannot run the command, attach any relevant files from
-        `.sdd/runtime/`.
-      placeholder: "Drag and drop the bernstein-debug-*.zip file here"
+        Check what you are about to share:
+        `unzip -p bernstein-debug-*.zip manifest.json`
+
+        If the command will not run, attach whatever is in `.sdd/runtime/`.
+      placeholder: "Drag the bernstein-debug-*.zip here"
     validations:
       required: false
+
   - type: dropdown
     id: severity
     attributes:
-      label: Severity
+      label: Impact
       options:
-        - Crash / data loss
-        - Feature broken
-        - Minor / cosmetic
+        - Data loss, or a wrong result reported as correct
+        - A documented capability does not work
+        - Works, but not as documented
+        - Cosmetic
     validations:
-      required: false
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -15,7 +15,7 @@ body:
     attributes:
       label: Proposed solution
       description: How should it work? CLI examples welcome.
-      placeholder: "`bernstein conduct --parallel 4 --goal '...'`"
+      placeholder: "`bernstein run plan.yaml --max-parallel 4`"
     validations:
       required: false
   - type: dropdown
@@ -32,3 +32,18 @@ body:
         - Other
     validations:
       required: true
+  - type: textarea
+    id: property
+    attributes:
+      label: What must stay true
+      description: >
+        Optional, and the most useful box on this form. Bernstein's value
+        rests on a few properties - a run replays to the same task graph,
+        an artifact stays checkable offline, tasks stay isolated from each
+        other. If your idea touches one of them, say which and how it
+        survives. If it plainly touches none, leave this empty.
+      placeholder: >
+        This adds a new source of input at spawn time, so the run would need
+        to record it for replay to stay honest.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/verification_failure.yml
+++ b/.github/ISSUE_TEMPLATE/verification_failure.yml
@@ -1,0 +1,106 @@
+name: Verification failure
+description: A replay, lineage, audit or receipt check reports a result you did not expect
+labels: ["bug", "verifiability"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this when a verifier disagrees with reality in either direction:
+        it reports a divergence you believe is not real, or it passes a run
+        you know was tampered with. Both are the same severity here. A
+        verifier that says "clean" when it should not is worse than one that
+        crashes, because nothing downstream can tell.
+
+        If a verifier merely crashed, the bug report template is the right
+        one.
+
+  - type: dropdown
+    id: direction
+    attributes:
+      label: Which way is it wrong
+      options:
+        - Reports a failure that is not real (false alarm)
+        - Reports success on something that should have failed (missed detection)
+        - Two runs of the same check disagree with each other
+        - The verdict is right but names the wrong step or artifact
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Which check
+      options:
+        - "bernstein replay latest --verify"
+        - "bernstein lineage verify <run_id>"
+        - "bernstein audit verify"
+        - "bernstein audit diagnose <run_id>"
+        - "bernstein verify run / bernstein verify receipt"
+        - "bernstein bench reliability-verify"
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: command
+    attributes:
+      label: Command and full output
+      description: >
+        The exact invocation and everything it printed, including the exit
+        code. Exit codes carry meaning here - `2` names a divergent step,
+        `3` a missing key - so a truncated paste loses the diagnosis.
+      placeholder: |
+        $ bernstein replay latest --verify
+        ...
+        $ echo $?
+        2
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: why-wrong
+    attributes:
+      label: Why you believe the verdict is wrong
+      description: >
+        What you know about the run that the verdict contradicts. "The two
+        runs were identical" is a claim; "I ran the same plan twice with the
+        same seed and diffed the journals" is evidence. Either is welcome -
+        say which one it is.
+    validations:
+      required: true
+
+  - type: textarea
+    id: artifacts
+    attributes:
+      label: Receipt or journal
+      description: |
+        If the check produced a receipt, attach it - it is designed to be
+        verifiable by someone who does not have your machine, which is
+        exactly this situation.
+
+        `.sdd/runs/<run_id>/run-receipt.json`, plus the public key if you
+        signed with one.
+
+        Do not attach the audit HMAC key. Nothing here needs it, and a
+        verifier that appears to require it is itself the bug.
+      placeholder: "Attach run-receipt.json, or paste the journal head"
+    validations:
+      required: false
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Output of `bernstein --version`
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: reproducible
+    attributes:
+      label: Reproducibility
+      options:
+        - label: The same check gives the same verdict when I run it again
+        - label: I can reproduce this from a fresh clone or a new run
+        - label: This happened once and I still have the artifacts


### PR DESCRIPTION
# User description
## What was wrong

The issue forms told reporters to run commands that do not exist:

| Template | Command named | Reality |
|---|---|---|
| `bug_report.yml` | `bernstein conduct --goal` | not registered |
| `bug_report.yml` | `bernstein notes` | not registered |
| `bug_report.yml` | `bernstein debug bundle --last` | `debug bundle` exists; `--last` does not |
| `feature_request.yml` | `bernstein conduct --parallel 4` | not registered |

These are the first thing an external contributor touches, and each one fails at the moment they are already frustrated enough to file.

## What changed

Every `bernstein ...` string in the templates was walked through the real `cli` object; the eleven that remain all resolve. Environment collection now asks for `bernstein doctor` output instead of four hand-typed fields.

**New: `verification_failure.yml`.** A verifier reporting a divergence that is not real, and one passing a run it should have failed, are the same severity and neither fits a generic bug form — the useful evidence is the exit code, the receipt, and what the reporter knows that the verdict contradicts. The form asks for those, and tells reporters explicitly not to attach the audit HMAC key, since nothing in the flow needs it and a verifier that appears to require one is itself the bug.

`feature_request.yml` gains one optional box: which property the proposal has to preserve.

## Verification

- All five templates parse as YAML.
- Ghost-command sweep over `.github/ISSUE_TEMPLATE/` and `pull_request_template.md` is clean.
- `bernstein replay latest --verify` and `bernstein replay list` were run to confirm the sentinel arguments the README documents do work — they do, so the README needed no change.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Improve the GitHub issue forms to use verified <code>bernstein</code> commands and collect more actionable bug evidence. Add a dedicated verification-failure form covering verdict direction, exit codes, receipts, reproducibility, and safe artifact sharing.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3471?tool=ast&topic=Verification+failures>Verification failures</a>
        </td><td>Add <code>verification_failure.yml</code> for false alarms, missed detections, and inconsistent verification results, capturing commands, exit codes, evidence, receipts, versions, and reproducibility without requesting HMAC keys.<details><summary>Modified files (1)</summary><ul><li>.github/ISSUE_TEMPLATE/verification_failure.yml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>docs: fix the issue te...</td><td>August 07, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3471?tool=ast&topic=Issue+reporting>Issue reporting</a>
        </td><td>Update bug and feature request forms with working commands, structured environment collection, clearer reproduction details, impact classification, and a property-preservation prompt.<details><summary>Modified files (2)</summary><ul><li>.github/ISSUE_TEMPLATE/bug_report.yml</li>
<li>.github/ISSUE_TEMPLATE/feature_request.yml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>docs: fix the issue te...</td><td>August 07, 2026</td></tr>
<tr><td>chernistry</td><td>feat(cli): add bernste...</td><td>May 19, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3471?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>