### PR TITLE
fix(persistence): key symbol memo entries on the extractor source, not just the shim

### DIFF
--- a/docs/concepts/fingerprint-memoization.md
+++ b/docs/concepts/fingerprint-memoization.md
@@ -48,8 +48,37 @@ The decorator is already applied at three call sites:
 | Site | Key |
 |---|---|
 | `quality/cross_model_verifier.py` | `(model_id, prompt, output, verifier_fn_hash)` |
-| `knowledge/knowledge_graph.py` | `(file_sha, extractor_fn_hash)` |
+| `knowledge/knowledge_graph.py` | `(file_sha, extractor_fn_hash, ast_symbol_graph_source_hash)` |
 | `knowledge/rag.py` | `(chunk_sha, embedder_id, chunker_fn_hash)` |
+
+## Declaring code dependencies
+
+The function-body component covers the decorated function's *own*
+source and nothing else. A thin shim that delegates the real work
+elsewhere therefore keeps a byte-identical body when the code it calls
+is rewritten, and its cached entries survive the fix - the exact
+failure this module exists to prevent, reintroduced one level down.
+
+Name the delegated code with `depends_on`:
+
+```python
+from bernstein.core.knowledge import ast_symbol_graph
+
+@memoize_persistent(store, site="knowledge_graph", depends_on=(ast_symbol_graph,))
+def _extract_symbols_for_memo(*, file_sha: str, rel_path: str, abs_path: str):
+    return ast_symbol_graph.parse_file_symbols(Path(abs_path), rel_path)
+```
+
+Prefer passing the **module** over individual callables. A module hashes
+its whole file, so the key also moves when a private helper changes, or
+when a dataclass the cached value is an instance of gains a field -
+neither of which a per-callable hash can see, and the second of which
+would otherwise surface as an `AttributeError` on an unpickled entry.
+The cost is over-invalidation: an unrelated edit anywhere in the module
+rebuilds that site's cache. That is the safe direction.
+
+Omitting `depends_on` leaves keys byte-identical to the previous scheme,
+so adding the parameter did not invalidate existing stores.
 
 ## Configuration
 
@@ -68,8 +97,12 @@ Metrics exposed on `/metrics`:
 
 - Single host. The store is on-disk and not shared across machines.
 - The fingerprint hashes the *immediate* function body only - not the
-  transitive closure of called helpers. If you rely on a helper that
-  changed, decorate that helper too, or invalidate manually.
+  transitive closure of called helpers. Declare the code you delegate
+  to with `depends_on` (above); it is not inferred, so a call site that
+  forgets it silently serves stale entries.
+- `depends_on` covers the declared modules, not *their* imports. A
+  parser that changes behaviour because a library it calls was upgraded
+  still needs manual invalidation (`bernstein cache clear`).
 - Functions with hidden state (env vars read at call time, file IO,
   network calls) are unsafe to memoize. Restrict use to pure
   functions.

--- a/src/bernstein/core/knowledge/knowledge_graph.py
+++ b/src/bernstein/core/knowledge/knowledge_graph.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Literal, cast
 
 from bernstein.core.git_context import ls_files as _git_ls_files
+from bernstein.core.knowledge import ast_symbol_graph as _ast_symbol_graph
 from bernstein.core.knowledge.ast_symbol_graph import (
     FileSymbols,
     build_semantic_graph,
@@ -88,10 +89,19 @@ _memoized_extract: Any = None
 def _extract_symbols_for_memo(*, file_sha: str, rel_path: str, abs_path: str) -> FileSymbols | None:
     """Memoization shim around :func:`parse_file_symbols`.
 
-    Keyed by (file_sha, rel_path, this-function-body-hash).  The
-    file_sha argument forces invalidation when the source bytes change;
-    a change to *this* function or to ``parse_file_symbols`` is captured
-    by the function-body component of the fingerprint.
+    Keyed by (file_sha, rel_path, this-function-body-hash, hash of the
+    ``ast_symbol_graph`` source).  ``file_sha`` forces invalidation when
+    a file's own bytes change.
+
+    The last component is what makes parser fixes take effect: this shim
+    is one line, so its body is byte-identical before and after any
+    rewrite of the extractor, and the function-body component of the
+    fingerprint cannot see the change.  ``_get_memoized_extract``
+    therefore declares the extractor module as a memo dependency.
+    Hashing the whole module (rather than ``parse_file_symbols`` alone)
+    also covers its private helpers - the import-resolution rules live
+    in one of them - and the :class:`FileSymbols` dataclass itself, so a
+    new field cannot be missing from an unpickled entry.
     """
     return parse_file_symbols(Path(abs_path), rel_path)
 
@@ -101,7 +111,11 @@ def _get_memoized_extract(workdir: Path) -> Any:
     global _kg_memo_store, _memoized_extract
     if _memoized_extract is None:
         _kg_memo_store = default_store(workdir)
-        _memoized_extract = memoize_persistent(_kg_memo_store, site="knowledge_graph")(_extract_symbols_for_memo)
+        _memoized_extract = memoize_persistent(
+            _kg_memo_store,
+            site="knowledge_graph",
+            depends_on=(_ast_symbol_graph,),
+        )(_extract_symbols_for_memo)
     return _memoized_extract
 
 

--- a/src/bernstein/core/persistence/fingerprint.py
+++ b/src/bernstein/core/persistence/fingerprint.py
@@ -53,9 +53,13 @@ _DIGEST_BYTES = 32
 _DEFAULT_MAX_MB = 200
 _AST_CACHE: dict[str, bytes] = {}
 _AST_CACHE_LOCK = threading.Lock()
-#: Per-process source digests for :func:`code_digest` targets, keyed by
-#: ``__name__`` for modules and ``<module>.<qualname>`` for callables.
-_SOURCE_DIGEST_CACHE: dict[str, bytes] = {}
+#: Source digests for :func:`code_digest` targets, keyed by ``__name__``
+#: for modules and ``<module>.<qualname>`` for callables.  The value
+#: carries the ``(mtime_ns, size)`` the digest was computed from, so a
+#: module rewritten under a running interpreter is re-hashed rather than
+#: served from the name alone; ``None`` marks a target with no statable
+#: file.
+_SOURCE_DIGEST_CACHE: dict[str, tuple[tuple[int, int] | None, bytes]] = {}
 
 #: A callable or module whose source participates in a memo key.
 CodeDependency = Callable[..., Any] | ModuleType
@@ -164,6 +168,23 @@ def _module_source_bytes(module: ModuleType) -> bytes:
         return _source_cache_key(module).encode("utf-8")
 
 
+def _module_stat_token(module: ModuleType) -> tuple[int, int] | None:
+    """Return ``(mtime_ns, size)`` for *module*'s file, or ``None``.
+
+    ``None`` means the module has no statable file (namespace package,
+    frozen or zipped import), in which case the digest falls back to
+    being computed once per process.
+    """
+    path = getattr(module, "__file__", None)
+    if not path:
+        return None
+    try:
+        stat = Path(path).stat()
+    except OSError:
+        return None
+    return (stat.st_mtime_ns, stat.st_size)
+
+
 def code_digest(*targets: CodeDependency) -> bytes:
     """Return a 32-byte digest over the source of every target.
 
@@ -175,19 +196,25 @@ def code_digest(*targets: CodeDependency) -> bytes:
     is over-invalidation (an unrelated edit to the module rebuilds the
     cache), which is the safe direction.
 
-    Digests are cached per process; module source cannot change beneath
-    a running interpreter.
+    Module digests are cached against the file's ``(mtime_ns, size)`` and
+    re-derived when that moves, so a module swapped in by
+    ``importlib.reload`` under a long-running process (see
+    ``plugins_core.plugin_hotreload``) does not keep folding its
+    pre-reload source into new keys.  Callable targets inherit
+    :func:`fingerprint`'s per-process source cache; prefer passing the
+    owning module when a target may be reloaded.
     """
     hasher = hashlib.sha256()
     for target in targets:
         key = _source_cache_key(target)
-        digest = _SOURCE_DIGEST_CACHE.get(key)
-        if digest is None:
+        token = _module_stat_token(target) if isinstance(target, ModuleType) else None
+        entry = _SOURCE_DIGEST_CACHE.get(key)
+        if entry is None or entry[0] != token:
             body = _module_source_bytes(target) if isinstance(target, ModuleType) else _function_ast_bytes(target)
-            digest = hashlib.sha256(body).digest()
+            entry = (token, hashlib.sha256(body).digest())
             with _AST_CACHE_LOCK:
-                _SOURCE_DIGEST_CACHE[key] = digest
-        hasher.update(key.encode("utf-8") + b"\0" + digest)
+                _SOURCE_DIGEST_CACHE[key] = entry
+        hasher.update(key.encode("utf-8") + b"\0" + entry[1])
     return hasher.digest()
 
 

--- a/src/bernstein/core/persistence/fingerprint.py
+++ b/src/bernstein/core/persistence/fingerprint.py
@@ -8,6 +8,12 @@ cached entries whenever the function that produced them changes.  Plain
 ``hash(input)`` keys (as used by most of Bernstein's ad-hoc caches)
 silently keep stale outputs after the producer is rewritten.
 
+The body component only covers the memoised function's *own* source.  A
+thin shim that delegates to a helper module keeps a byte-identical body
+when that helper is rewritten, so its cached entries survive the fix.
+Such call sites must name the code they delegate to via
+``memoize_persistent(..., depends_on=...)``; see :func:`code_digest`.
+
 Prior art: ``cocoindex/python/cocoindex/_internal/memo_fingerprint.py``
 (https://github.com/cocoindex-io/cocoindex/blob/main/python/cocoindex/_internal/memo_fingerprint.py).
 That implementation is ~400 LOC of Apache-2.0 Python+Rust tightly
@@ -35,12 +41,11 @@ import pickle
 import textwrap
 import threading
 import uuid
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, cast
-
-if TYPE_CHECKING:
-    from pathlib import Path
+from pathlib import Path
+from types import ModuleType
+from typing import Any, cast
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +53,12 @@ _DIGEST_BYTES = 32
 _DEFAULT_MAX_MB = 200
 _AST_CACHE: dict[str, bytes] = {}
 _AST_CACHE_LOCK = threading.Lock()
+#: Per-process source digests for :func:`code_digest` targets, keyed by
+#: ``__name__`` for modules and ``<module>.<qualname>`` for callables.
+_SOURCE_DIGEST_CACHE: dict[str, bytes] = {}
+
+#: A callable or module whose source participates in a memo key.
+CodeDependency = Callable[..., Any] | ModuleType
 
 
 def _canonicalize(value: Any) -> Any:
@@ -117,6 +128,67 @@ def _function_ast_bytes(fn: Callable[..., Any]) -> bytes:
     with _AST_CACHE_LOCK:
         _AST_CACHE[cache_key] = body
     return body
+
+
+def _source_cache_key(target: CodeDependency) -> str:
+    """Return the stable per-process cache key for *target*.
+
+    Modules key on ``__name__`` rather than ``repr`` so the key does not
+    embed an install path (which differs per machine and would defeat
+    the cache on every process).
+    """
+    if isinstance(target, ModuleType):
+        return getattr(target, "__name__", repr(target))
+    inner = inspect.unwrap(target)
+    module = getattr(inner, "__module__", "?")
+    qualname = getattr(inner, "__qualname__", repr(inner))
+    return f"{module}.{qualname}"
+
+
+def _module_source_bytes(module: ModuleType) -> bytes:
+    """Return the on-disk bytes of *module*, or its name when unreadable.
+
+    Reads the file directly rather than going through ``inspect``: the
+    latter serves from ``linecache``, which can hand back a previous
+    revision of a file rewritten within the same mtime granularity.
+    """
+    path = getattr(module, "__file__", None)
+    if path:
+        try:
+            return Path(path).read_bytes()
+        except OSError:
+            pass
+    try:
+        return inspect.getsource(module).encode("utf-8")
+    except (OSError, TypeError):
+        return _source_cache_key(module).encode("utf-8")
+
+
+def code_digest(*targets: CodeDependency) -> bytes:
+    """Return a 32-byte digest over the source of every target.
+
+    Callables hash via their dedented source; modules hash via their
+    whole on-disk bytes.  Module granularity is deliberate - a memoised
+    value produced by ``mod.f`` is also invalidated by an edit to a
+    private helper ``f`` calls, or to a dataclass the value is an
+    instance of, neither of which a per-callable hash can see.  The cost
+    is over-invalidation (an unrelated edit to the module rebuilds the
+    cache), which is the safe direction.
+
+    Digests are cached per process; module source cannot change beneath
+    a running interpreter.
+    """
+    hasher = hashlib.sha256()
+    for target in targets:
+        key = _source_cache_key(target)
+        digest = _SOURCE_DIGEST_CACHE.get(key)
+        if digest is None:
+            body = _module_source_bytes(target) if isinstance(target, ModuleType) else _function_ast_bytes(target)
+            digest = hashlib.sha256(body).digest()
+            with _AST_CACHE_LOCK:
+                _SOURCE_DIGEST_CACHE[key] = digest
+        hasher.update(key.encode("utf-8") + b"\0" + digest)
+    return hasher.digest()
 
 
 def fingerprint(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> bytes:
@@ -269,20 +341,40 @@ class MemoStore:
             return MemoStats(hits=self._hits, misses=self._misses, bytes_used=self.total_bytes())
 
 
-def memoize_persistent[F: Callable[..., Any]](store: MemoStore, *, site: str = "default") -> Callable[[F], F]:
+def memoize_persistent[F: Callable[..., Any]](
+    store: MemoStore,
+    *,
+    site: str = "default",
+    depends_on: Sequence[CodeDependency] = (),
+) -> Callable[[F], F]:
     """Decorator that caches function results in *store* keyed by fingerprint.
 
     Use *site* as a stable label for metrics (e.g.
     ``"cross_model_verifier"``).  The label ensures Prometheus counters
     can be partitioned per call-site without forcing a global registry.
+
+    Pass *depends_on* whenever the decorated function is a shim over code
+    living elsewhere: the fingerprint sees only the decorated body, so a
+    rewrite of the delegate would otherwise leave every cached entry in
+    place.  Each entry is a callable or - preferably - the module that
+    owns the real work; see :func:`code_digest`.  Leaving it empty keeps
+    keys byte-identical to the pre-``depends_on`` scheme, so existing
+    stores are not invalidated wholesale.
     """
+    dependencies = tuple(depends_on)
+
+    def _key(target: Callable[..., Any], args: tuple[Any, ...], kwargs: dict[str, Any]) -> bytes:
+        base = fingerprint(target, *args, **kwargs)
+        if not dependencies:
+            return base
+        return bytes(a ^ b for a, b in zip(base, code_digest(*dependencies), strict=True))
 
     def decorator(target: F) -> F:
         if inspect.iscoroutinefunction(target):
 
             @functools.wraps(target)
             async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
-                digest = fingerprint(target, *args, **kwargs)
+                digest = _key(target, args, kwargs)
                 cached = store.get(digest)
                 if cached is not None:
                     _record_metric("hit", site)
@@ -294,11 +386,12 @@ def memoize_persistent[F: Callable[..., Any]](store: MemoStore, *, site: str = "
 
             async_wrapper.__memo_store__ = store  # type: ignore[attr-defined]
             async_wrapper.__memo_site__ = site  # type: ignore[attr-defined]
+            async_wrapper.__memo_depends_on__ = dependencies  # type: ignore[attr-defined]
             return cast("F", async_wrapper)
 
         @functools.wraps(target)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
-            digest = fingerprint(target, *args, **kwargs)
+            digest = _key(target, args, kwargs)
             cached = store.get(digest)
             if cached is not None:
                 _record_metric("hit", site)
@@ -310,6 +403,7 @@ def memoize_persistent[F: Callable[..., Any]](store: MemoStore, *, site: str = "
 
         wrapper.__memo_store__ = store  # type: ignore[attr-defined]
         wrapper.__memo_site__ = site  # type: ignore[attr-defined]
+        wrapper.__memo_depends_on__ = dependencies  # type: ignore[attr-defined]
         return cast("F", wrapper)
 
     return decorator
@@ -344,8 +438,10 @@ def default_store(workdir: Path, max_mb: int | None = None) -> MemoStore:
 
 
 __all__ = [
+    "CodeDependency",
     "MemoStats",
     "MemoStore",
+    "code_digest",
     "default_store",
     "fingerprint",
     "memoize_persistent",

--- a/tests/unit/test_fingerprint.py
+++ b/tests/unit/test_fingerprint.py
@@ -7,16 +7,28 @@ bug fix.
 
 from __future__ import annotations
 
+import contextlib
+import importlib
+import sys
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 from bernstein.core.persistence.fingerprint import (
+    _SOURCE_DIGEST_CACHE,
     MemoStore,
+    code_digest,
     default_store,
     fingerprint,
     memoize_persistent,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from types import ModuleType
+
+_PROBE_MODULE = "memo_dependency_probe"
 
 
 def _fn_v1(x: int, y: int) -> int:
@@ -120,6 +132,103 @@ class TestMemoizePersistent:
     def test_default_store_uses_sdd_runtime_memo(self, tmp_path: Path) -> None:
         store = default_store(tmp_path)
         assert store.root == tmp_path / ".sdd" / "runtime" / "memo"
+
+
+class TestDependencyAwareMemoization:
+    """Memo keys must track the code a memoised shim *delegates to*.
+
+    A one-line shim's own body is unchanged by any rewrite of the helper
+    module it calls, so the function-body component of the fingerprint
+    cannot see the edit and the store keeps serving output from the old
+    helper.  ``depends_on`` closes that gap.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _isolate_probe_module(self, tmp_path: Path) -> Generator[None]:
+        sys.path.insert(0, str(tmp_path))
+        preserved = dict(_SOURCE_DIGEST_CACHE)
+        # Two probe revisions can share a byte count and an mtime second, in
+        # which case a written .pyc looks current and ``reload`` serves the
+        # previous bytecode - masking what this class is here to test.
+        bytecode_setting = sys.dont_write_bytecode
+        sys.dont_write_bytecode = True
+        try:
+            yield
+        finally:
+            sys.dont_write_bytecode = bytecode_setting
+            sys.modules.pop(_PROBE_MODULE, None)
+            with contextlib.suppress(ValueError):
+                sys.path.remove(str(tmp_path))
+            _SOURCE_DIGEST_CACHE.clear()
+            _SOURCE_DIGEST_CACHE.update(preserved)
+
+    @staticmethod
+    def _install_probe(tmp_path: Path, body: str) -> ModuleType:
+        """Write *body* to the probe module and (re)import it.
+
+        Clearing the digest cache mirrors what a fresh interpreter does;
+        source cannot change beneath a running process in production, so
+        the cache is only an obstacle here.
+        """
+        (tmp_path / f"{_PROBE_MODULE}.py").write_text(body, encoding="utf-8")
+        _SOURCE_DIGEST_CACHE.clear()
+        existing = sys.modules.get(_PROBE_MODULE)
+        if existing is not None:
+            return importlib.reload(existing)
+        return importlib.import_module(_PROBE_MODULE)
+
+    def test_code_digest_tracks_module_source(self, tmp_path: Path) -> None:
+        first = code_digest(self._install_probe(tmp_path, 'MARKER = "v1"\n'))
+        second = code_digest(self._install_probe(tmp_path, 'MARKER = "v2"\n'))
+        assert first != second
+
+    def test_code_digest_is_stable_for_unchanged_source(self, tmp_path: Path) -> None:
+        module = self._install_probe(tmp_path, 'MARKER = "v1"\n')
+        assert code_digest(module) == code_digest(module)
+
+    def test_code_digest_tracks_callable_body(self) -> None:
+        assert code_digest(_fn_v1) != code_digest(_fn_v2)
+
+    def test_shim_recomputes_when_dependency_module_changes(self, tmp_path: Path) -> None:
+        """The regression: identical args and identical shim, new helper."""
+        store = MemoStore(root=tmp_path / "memo", max_mb=1)
+
+        def build() -> Any:
+            module = sys.modules[_PROBE_MODULE]
+
+            @memoize_persistent(store, site="probe", depends_on=(module,))
+            def shim(*, name: str) -> str:
+                return str(sys.modules[_PROBE_MODULE].extract(name))
+
+            return shim
+
+        self._install_probe(tmp_path, 'def extract(name):\n    return "v1:" + name\n')
+        assert build()(name="a") == "v1:a"
+        # Nothing changed - must be a cache hit, not a recompute.
+        assert build()(name="a") == "v1:a"
+
+        self._install_probe(tmp_path, 'def extract(name):\n    return "v2:" + name\n')
+        assert build()(name="a") == "v2:a"
+
+    def test_absent_depends_on_leaves_existing_keys_untouched(self, tmp_path: Path) -> None:
+        """Existing memo sites must not be invalidated wholesale."""
+        store = MemoStore(root=tmp_path / "memo", max_mb=1)
+
+        @memoize_persistent(store, site="plain")
+        def plain(x: int) -> int:
+            return x * 2
+
+        assert fingerprint(plain, 3) == fingerprint(plain.__wrapped__, 3)
+
+    def test_declared_dependencies_are_introspectable(self, tmp_path: Path) -> None:
+        store = MemoStore(root=tmp_path / "memo", max_mb=1)
+        module = self._install_probe(tmp_path, "MARKER = 1\n")
+
+        @memoize_persistent(store, site="probe", depends_on=(module,))
+        def shim(x: int) -> int:
+            return x
+
+        assert shim.__memo_depends_on__ == (module,)
 
 
 class TestPerfStress:

--- a/tests/unit/test_fingerprint.py
+++ b/tests/unit/test_fingerprint.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import contextlib
 import importlib
+import os
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -29,6 +30,8 @@ if TYPE_CHECKING:
     from types import ModuleType
 
 _PROBE_MODULE = "memo_dependency_probe"
+#: Fixed base mtime so probe revisions get distinct, deterministic stamps.
+_BASE_MTIME = 1_600_000_000
 
 
 def _fn_v1(x: int, y: int) -> int:
@@ -163,24 +166,42 @@ class TestDependencyAwareMemoization:
             _SOURCE_DIGEST_CACHE.update(preserved)
 
     @staticmethod
-    def _install_probe(tmp_path: Path, body: str) -> ModuleType:
+    def _install_probe(tmp_path: Path, body: str, *, revision: int = 1) -> ModuleType:
         """Write *body* to the probe module and (re)import it.
 
-        Clearing the digest cache mirrors what a fresh interpreter does;
-        source cannot change beneath a running process in production, so
-        the cache is only an obstacle here.
+        The digest cache is deliberately *not* cleared: these tests are
+        about an interpreter that keeps running across the rewrite.
+        ``revision`` stamps a distinct mtime so two same-length bodies
+        cannot look unchanged to a stat-based check.
         """
-        (tmp_path / f"{_PROBE_MODULE}.py").write_text(body, encoding="utf-8")
-        _SOURCE_DIGEST_CACHE.clear()
+        path = tmp_path / f"{_PROBE_MODULE}.py"
+        path.write_text(body, encoding="utf-8")
+        stamp = _BASE_MTIME + revision
+        os.utime(path, (stamp, stamp))
         existing = sys.modules.get(_PROBE_MODULE)
         if existing is not None:
             return importlib.reload(existing)
         return importlib.import_module(_PROBE_MODULE)
 
     def test_code_digest_tracks_module_source(self, tmp_path: Path) -> None:
-        first = code_digest(self._install_probe(tmp_path, 'MARKER = "v1"\n'))
-        second = code_digest(self._install_probe(tmp_path, 'MARKER = "v2"\n'))
+        first = code_digest(self._install_probe(tmp_path, 'MARKER = "v1"\n', revision=1))
+        second = code_digest(self._install_probe(tmp_path, 'MARKER = "v2"\n', revision=2))
         assert first != second
+
+    def test_code_digest_recomputes_after_in_process_module_reload(self, tmp_path: Path) -> None:
+        """A long-running process must not pin the digest it first saw.
+
+        ``plugin_hotreload`` swaps module code via ``importlib.reload``
+        without restarting, so a name-keyed digest cache would keep
+        folding the pre-reload source into every subsequent memo key.
+        """
+        module = self._install_probe(tmp_path, 'MARKER = "v1"\n', revision=1)
+        before = code_digest(module)
+
+        reloaded = self._install_probe(tmp_path, 'MARKER = "v2"\n', revision=2)
+
+        assert reloaded.MARKER == "v2", "probe did not actually reload"
+        assert code_digest(reloaded) != before
 
     def test_code_digest_is_stable_for_unchanged_source(self, tmp_path: Path) -> None:
         module = self._install_probe(tmp_path, 'MARKER = "v1"\n')
@@ -202,12 +223,12 @@ class TestDependencyAwareMemoization:
 
             return shim
 
-        self._install_probe(tmp_path, 'def extract(name):\n    return "v1:" + name\n')
+        self._install_probe(tmp_path, 'def extract(name):\n    return "v1:" + name\n', revision=1)
         assert build()(name="a") == "v1:a"
         # Nothing changed - must be a cache hit, not a recompute.
         assert build()(name="a") == "v1:a"
 
-        self._install_probe(tmp_path, 'def extract(name):\n    return "v2:" + name\n')
+        self._install_probe(tmp_path, 'def extract(name):\n    return "v2:" + name\n', revision=2)
         assert build()(name="a") == "v2:a"
 
     def test_absent_depends_on_leaves_existing_keys_untouched(self, tmp_path: Path) -> None:

--- a/tests/unit/test_knowledge_graph.py
+++ b/tests/unit/test_knowledge_graph.py
@@ -138,9 +138,13 @@ class TestSymbolMemoInvalidation:
         assert cached is not None
         assert cached.imports == {"marker": "old"}
 
-        # Simulate an edit to ast_symbol_graph.py.  Shifting its source digest
-        # is what a real edit does on the next interpreter start.
-        fingerprint_mod._SOURCE_DIGEST_CACHE[semantic_graph.__name__] = hashlib.sha256(b"edited").digest()
+        # Simulate an edit to ast_symbol_graph.py by shifting its source
+        # digest, which is what a real edit does.  The cached freshness token
+        # is kept so the substitute digest survives the staleness check
+        # instead of being immediately recomputed from the unedited file.
+        cache = fingerprint_mod._SOURCE_DIGEST_CACHE
+        token = cache[semantic_graph.__name__][0]
+        cache[semantic_graph.__name__] = (token, hashlib.sha256(b"edited").digest())
 
         monkeypatch.setattr(knowledge_graph, "parse_file_symbols", self._fake_parser("new"))
         refreshed = knowledge_graph._parse_file_symbols_memoized(tmp_path, source, rel_path)

--- a/tests/unit/test_knowledge_graph.py
+++ b/tests/unit/test_knowledge_graph.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 import pytest_asyncio
@@ -18,6 +19,7 @@ from bernstein.core.knowledge.knowledge_graph import (
     get_or_build_knowledge_graph,
     query_impact,
 )
+from bernstein.core.persistence import fingerprint as fingerprint_mod
 from bernstein.core.server import create_app
 
 if TYPE_CHECKING:
@@ -88,6 +90,72 @@ class TestKnowledgeGraphBuild:
         monkeypatch.setattr(knowledge_graph, "build_knowledge_graph", _should_not_build)
         reused_path = get_or_build_knowledge_graph(tmp_path)
         assert reused_path == db_path
+
+
+class TestSymbolMemoInvalidation:
+    """A parser fix must not be masked by memoised symbol data.
+
+    ``_extract_symbols_for_memo`` is a one-line shim, so its own body is
+    identical before and after any edit to ``ast_symbol_graph``.  Unless
+    the extractor module is a declared memo dependency, every file whose
+    bytes did not change keeps serving symbols built by the old parser.
+    """
+
+    @staticmethod
+    def _fake_parser(marker: str) -> Any:
+        def _parse(_filepath: Path, rel_path: str) -> semantic_graph.FileSymbols:
+            return semantic_graph.FileSymbols(path=rel_path, imports={"marker": marker})
+
+        return _parse
+
+    def test_extractor_change_invalidates_cached_entry_for_unchanged_file(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Force a fresh memo store rooted under tmp_path; monkeypatch restores
+        # the process-wide extractor afterwards.
+        monkeypatch.setattr(knowledge_graph, "_kg_memo_store", None)
+        monkeypatch.setattr(knowledge_graph, "_memoized_extract", None)
+        monkeypatch.setattr(
+            fingerprint_mod,
+            "_SOURCE_DIGEST_CACHE",
+            dict(fingerprint_mod._SOURCE_DIGEST_CACHE),
+        )
+
+        source = tmp_path / "pkg" / "mod.py"
+        _write(source, "def run() -> int:\n    return 1\n")
+        rel_path = "pkg/mod.py"
+
+        monkeypatch.setattr(knowledge_graph, "parse_file_symbols", self._fake_parser("old"))
+        first = knowledge_graph._parse_file_symbols_memoized(tmp_path, source, rel_path)
+        assert first is not None
+        assert first.imports == {"marker": "old"}
+
+        # Same bytes, same extractor: the second call must be a cache hit.
+        monkeypatch.setattr(knowledge_graph, "parse_file_symbols", self._fake_parser("not-called"))
+        cached = knowledge_graph._parse_file_symbols_memoized(tmp_path, source, rel_path)
+        assert cached is not None
+        assert cached.imports == {"marker": "old"}
+
+        # Simulate an edit to ast_symbol_graph.py.  Shifting its source digest
+        # is what a real edit does on the next interpreter start.
+        fingerprint_mod._SOURCE_DIGEST_CACHE[semantic_graph.__name__] = hashlib.sha256(b"edited").digest()
+
+        monkeypatch.setattr(knowledge_graph, "parse_file_symbols", self._fake_parser("new"))
+        refreshed = knowledge_graph._parse_file_symbols_memoized(tmp_path, source, rel_path)
+        assert refreshed is not None
+        assert refreshed.imports == {"marker": "new"}, "stale symbols served after the extractor changed"
+
+    def test_extractor_module_is_a_declared_memo_dependency(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(knowledge_graph, "_kg_memo_store", None)
+        monkeypatch.setattr(knowledge_graph, "_memoized_extract", None)
+
+        extractor = knowledge_graph._get_memoized_extract(tmp_path)
+
+        assert semantic_graph in extractor.__memo_depends_on__
 
 
 class TestKnowledgeGraphIntegrations:

--- a/tests/unit/test_sonar_final_style_hygiene.py
+++ b/tests/unit/test_sonar_final_style_hygiene.py
@@ -15,7 +15,8 @@ def test_fingerprint_memoize_uses_pep695_generic_syntax() -> None:
     """The memoize decorator should not rely on module-level TypeVar boilerplate."""
     source = _read_source("src/bernstein/core/persistence/fingerprint.py")
 
-    assert 'def memoize_persistent[F: Callable[..., Any]](store: MemoStore, *, site: str = "default")' in source
+    assert "def memoize_persistent[F: Callable[..., Any]](" in source
+    assert 'site: str = "default"' in source
     assert "F = TypeVar" not in source
     assert "def decorator(fn: F)" not in source
 


### PR DESCRIPTION
# User description
## Problem

`_extract_symbols_for_memo` in `src/bernstein/core/knowledge/knowledge_graph.py` is a one-line delegate to `parse_file_symbols`. Its docstring claimed:

> a change to *this* function or to `parse_file_symbols` is captured by the function-body component of the fingerprint

The second half is false. `memoize_persistent` keys entries via `fingerprint(target, *args, **kwargs)`, and `fingerprint` hashes only `_function_ast_bytes(fn)` — the shim's own AST — plus qualname and args. The shim body is byte-identical before and after any rewrite of the extractor, so the disk cache under the memo store keeps serving symbol data produced by the old parser until each file's bytes change.

Two consequences:

1. **Parser corrections do not take effect on already-cached files.** This bit the recent import-resolution change in `ast_symbol_graph.py`: relative imports now resolve against the importing file's package, but cached `FileSymbols` still carried the old, unanchored import map.
2. **Entries are stored with `pickle`.** If `FileSymbols` gains a field, an unpickled stale instance is missing the attribute entirely and raises `AttributeError` at the access site rather than falling back to the default.

Reproduced on `main` before the fix — identical file bytes, changed extractor, stale symbols returned.

## Fix

`memoize_persistent(..., depends_on=(...))` in `src/bernstein/core/persistence/fingerprint.py`. Declared callables and modules contribute a source digest (new public `code_digest()`) that is folded into the memo key, so the key tracks the code that actually runs rather than just the shim.

The knowledge-graph site declares the whole `ast_symbol_graph` **module**, not `parse_file_symbols` alone. That choice matters:

- The import-resolution rules live in `_extract_imports_from_tree`, a private helper. A per-callable hash of `parse_file_symbols` would have missed exactly the change that caused this.
- `FileSymbols` is defined in the same module, so a new field now shifts the key — which closes consequence (2) rather than leaving it as a separate hazard.
- Cost is over-invalidation: an unrelated edit anywhere in `ast_symbol_graph.py` rebuilds that cache. That is the safe direction.

Omitting `depends_on` leaves keys byte-identical to the previous scheme, so `cross_model_verifier` and `rag` keep their existing caches.

The misleading docstring is corrected and now states what the key actually covers.

## Verification

- **Mutation-checked both regression tests.** Removing `depends_on=` → both knowledge-graph tests fail. Neutering the dependency fold in `fingerprint.py` → the knowledge-graph test and the fingerprint probe test fail. Neither test passes for the wrong reason.
- **Real two-process file-edit proof.** Appending a comment to `ast_symbol_graph.py` shifted the actual knowledge-graph memo digest `b109d53b…` → `74e56ee4…`, and reverting restored it exactly — so the key is content-derived and deterministic.
- `uv run ruff check src tests` and `ruff format --check` clean.
- Scoped tests green (112 passed): `test_fingerprint.py`, `test_fingerprint_determinism.py`, `test_knowledge_graph.py`, `test_ast_symbol_graph.py`, `test_sonar_final_style_hygiene.py`, `test_memo_store_concurrency.py`, `test_action_cache.py`, `tests/property/test_fingerprint_properties.py`. Sibling memo sites also re-run green: `test_rag.py`, `test_cross_model_verifier.py`, `test_cli_cache_cmd.py`.

## Tests added

- `TestSymbolMemoInvalidation` in `tests/unit/test_knowledge_graph.py` — the regression asked for: an extractor change invalidates the cached entry for a file whose bytes did not change. Asserts the intermediate cache *hit* too, so it cannot pass by never caching at all.
- `TestDependencyAwareMemoization` in `tests/unit/test_fingerprint.py` — covers the general mechanism against a throwaway module rewritten on disk between calls, plus digest stability, callable targets, and the no-`depends_on` key-compatibility guarantee.

One test-harness trap worth noting for future readers: two module revisions sharing a byte count and an mtime second let a stale `.pyc` defeat `importlib.reload`, which masked the test. The fixture disables bytecode writing and says why.

## Notes

- `tests/unit/test_sonar_final_style_hygiene.py` pinned the exact one-line `memoize_persistent` signature. The assertion is loosened to check the PEP 695 generic syntax and the `site` default, preserving its intent.
- `docs/concepts/fingerprint-memoization.md` gains a "Declaring code dependencies" section. Its Limitations list already named this exact gap; that bullet now points at the remedy.
- Pre-existing and untouched: mypy flags `KnowledgeEdge` `kind` as `str` vs `Literal` in `knowledge_graph.py` (present on `main` before this branch).
- `src/bernstein/core/knowledge/rag.py` has the same defect — `_chunk_for_memo` carries an equivalent false claim about the chunker. Left out of this PR to keep it scoped; tracked separately.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add dependency-aware persistent memoization through <code>code_digest</code> and <code>memoize_persistent</code>, allowing memo keys to track delegated modules or callables. Update knowledge-graph symbol extraction to depend on the <code>ast_symbol_graph</code> module, preventing stale parser results and incompatible pickled <code>FileSymbols</code> entries.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3486?tool=ast&topic=Symbol+cache+invalidation>Symbol cache invalidation</a>
        </td><td>Prevent stale knowledge-graph symbol caches by hashing the complete <code>ast_symbol_graph</code> module, including import helpers and <code>FileSymbols</code> schema changes.<details><summary>Modified files (3)</summary><ul><li>docs/concepts/fingerprint-memoization.md</li>
<li>src/bernstein/core/knowledge/knowledge_graph.py</li>
<li>tests/unit/test_knowledge_graph.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>fix(persistence): re-d...</td><td>August 08, 2026</td></tr>
<tr><td>chernistry</td><td>feat(cache): cache pol...</td><td>July 17, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3486?tool=ast&topic=Dependency-aware+memoization>Dependency-aware memoization</a>
        </td><td>Add <code>code_digest</code> and <code>depends_on</code> support so persistent memo keys incorporate delegated source code while preserving existing keys when no dependency is declared.<details><summary>Modified files (4)</summary><ul><li>docs/concepts/fingerprint-memoization.md</li>
<li>src/bernstein/core/persistence/fingerprint.py</li>
<li>tests/unit/test_fingerprint.py</li>
<li>tests/unit/test_sonar_final_style_hygiene.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>fix(persistence): re-d...</td><td>August 08, 2026</td></tr>
<tr><td>chernistry</td><td>feat(cache): cache pol...</td><td>July 17, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3486?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

## Review-bot findings

**`fingerprint.py` — "Hot-reload changes keep stale memo entries" (id `3740334395`) — fixed in a05848a4.**

Valid and reachable rather than theoretical: `plugins_core/plugin_hotreload.py:153` reloads modules under a running process, so a name-keyed digest cache would keep folding pre-reload source into new keys. Module digests are now cached against the file's `(mtime_ns, size)` and re-derived when that moves, covered by `test_code_digest_recomputes_after_in_process_module_reload`.

**`docs/…/fingerprint-memoization.md` — "Deployments retain stale parser entries" (id `3740334394`) — not applicable as described.**

The stated mechanism does not hold: `git_context` and `lineage` are imported by `ast_symbol_graph` but are not on the memoized code path. `parse_file_symbols` and its helpers (`_extract_imports_from_tree`, `_make_func_symbol`, `_extract_calls`, `_extract_class_symbols`) use only stdlib `ast`.

The residual — stdlib `ast` behaviour shifting across a Python upgrade while a PVC-backed `.sdd/runtime/memo` survives — is real, but pre-existing, unchanged by this PR, and already documented in the Limitations section with `bernstein cache clear`.

Automatic invalidation on dependency or application-version change is a separate design decision, not a docs edit: it would key every memo site on a version hash, including `cross_model_verifier`, whose entries are paid LLM calls.

<!-- bot-ack: 3740334394 reason=Stated mechanism does not apply. The memoized parse path uses only stdlib ast; the cited git_context and lineage imports are not reached from _extract_symbols_for_memo. Residual risk from a stdlib ast change across a Python upgrade with a surviving memo store is pre-existing, unchanged by this PR, and documented in Limitations with bernstein cache clear. Automatic version-based invalidation is a separate design decision with cost implications for the LLM-call memo site. -->
