### PR TITLE
ci: stop the secret-scanning gate failing on ordinary test names

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -48,4 +48,21 @@ jobs:
           # `postgres://user:pass@host` that trufflehog cannot probe but
           # are not real credentials; gating on those forced every push
           # to main red without a real leak.
-          extra_args: --results=verified
+          #
+          # `lob` is excluded because its verifier reports a positive for
+          # any `test_`-prefixed string of exactly 35 further characters,
+          # which is a shape ordinary Python test names land on. Three
+          # randomly generated names of that shape - which cannot be keys -
+          # scanned as `verified_secrets: 3`, so the verdict carries no
+          # information about whether a credential is present. It has twice
+          # turned main red: on `test_public_key_jwk_embedded_and_correct`,
+          # and on `test_required_check_canary_workflow_yaml`, the latter a
+          # test *filename* quoted in `docs/operations/merge-queue.md`.
+          # Since the detector cannot distinguish a key from prose, and
+          # this project has no Lob integration to leak a key for, keeping
+          # it enabled only teaches contributors to disregard the gate.
+          #
+          # This is the whole exclusion list, and
+          # `tests/unit/test_trufflehog_workflow_yaml.py` fails if it grows
+          # - a detector for a service we do use must not be dropped here.
+          extra_args: --results=verified --exclude-detectors=lob

--- a/tests/unit/test_trufflehog_workflow_yaml.py
+++ b/tests/unit/test_trufflehog_workflow_yaml.py
@@ -1,0 +1,109 @@
+"""Structural assertions for the secret-scanning gate.
+
+The gate is only worth having if a red run means something. Two settings
+decide that, and both are the kind of thing that gets widened under time
+pressure rather than by decision, so they are pinned here:
+
+* it reports verified results only - the unverified stream is dominated by
+  test-fixture connection strings, and gating on it turned main red without
+  a leak;
+* it excludes exactly one detector. ``lob`` is excluded because its verifier
+  returns a positive for any ``test_``-prefixed string of exactly 35 further
+  characters, so it fires on ordinary Python test names and on test
+  filenames quoted in prose. A detector that cannot separate a credential
+  from a docstring contributes nothing, but the argument stops there - it
+  does not extend to detectors for services this project actually uses.
+
+The second point is why this file exists. ``--exclude-detectors`` takes a
+comma-separated list, so silencing a genuine finding is a one-word edit that
+reads exactly like the justified exclusion already present. Adding a name
+here has to be a deliberate act with a reason attached, not a way to get a
+build green.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "trufflehog.yml"
+
+#: The only detector this project may silence, and the reason it may.
+#:
+#: ``lob`` verifies any ``test_`` + 35 characters as a live key, a shape
+#: ordinary test names hit. There is no Lob integration here, so nothing is
+#: lost. Extending this set means a real detector is being turned off.
+ALLOWED_EXCLUDED_DETECTORS = frozenset({"lob"})
+
+
+def _doc() -> dict[str, Any]:
+    data = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    assert isinstance(data, dict), f"{WORKFLOW.name} is not a mapping"
+    return cast("dict[str, Any]", data)
+
+
+def _scan_step() -> dict[str, Any]:
+    jobs = _doc().get("jobs")
+    assert isinstance(jobs, dict), "workflow must declare jobs"
+    steps = [
+        step
+        for job in jobs.values()
+        if isinstance(job, dict)
+        for step in job.get("steps", [])
+        if isinstance(step, dict) and "trufflehog" in str(step.get("uses", ""))
+    ]
+    assert len(steps) == 1, f"expected exactly one trufflehog step, found {len(steps)}"
+    return steps[0]
+
+
+def _extra_args() -> str:
+    return str(_scan_step().get("with", {}).get("extra_args", ""))
+
+
+def _excluded_detectors() -> frozenset[str]:
+    for arg in _extra_args().split():
+        if arg.startswith("--exclude-detectors="):
+            _, _, value = arg.partition("=")
+            return frozenset(part.strip().lower() for part in value.split(",") if part.strip())
+    return frozenset()
+
+
+def test_gate_reports_verified_results_only() -> None:
+    """Unverified results are noise here; gating on them is a red main."""
+    assert "--results=verified" in _extra_args(), "the gate must report verified results only, or it fails on fixtures"
+
+
+def test_no_detector_is_excluded_without_a_recorded_reason() -> None:
+    """Silencing a detector is a one-word edit - it should not be a quiet one."""
+    excluded = _excluded_detectors()
+    unexpected = excluded - ALLOWED_EXCLUDED_DETECTORS
+    assert not unexpected, (
+        f"{sorted(unexpected)} excluded from secret scanning without a reason "
+        "recorded here. If the detector genuinely cannot distinguish a "
+        "credential from this repository's own source, say so in "
+        "ALLOWED_EXCLUDED_DETECTORS and in the workflow comment. If it is "
+        "excluded to make a build green, fix the finding instead."
+    )
+
+
+def test_the_known_false_positive_detector_stays_excluded() -> None:
+    """Removing it turns any 35-character test name into a red main."""
+    assert "lob" in _excluded_detectors(), (
+        "`lob` verifies any `test_` + 35 characters as a live key; without "
+        "this exclusion a test name of that length fails the scan"
+    )
+
+
+def test_the_scan_still_runs_on_main_and_pull_requests() -> None:
+    """An exclusion is only defensible while the gate itself still runs."""
+    doc = _doc()
+    # PyYAML 1.1 parses a bare ``on:`` key as the boolean True.
+    triggers = doc.get(True, doc.get("on"))
+    assert isinstance(triggers, dict), "workflow must declare a mapping of triggers"
+    assert "pull_request" in triggers, "the gate must run before a merge"
+    assert "push" in triggers, "the gate must run on what actually landed"


### PR DESCRIPTION
# User description
## What

`main` is red on `trufflehog (secret scanning)` at `d84cf76a`, reporting two **verified** secrets. Neither is a secret. Both are ordinary identifiers from this repository:

- `test_workflow_rebuilds_from_the_lockfile`
- `test_required_check_canary_workflow_yaml` — not even an identifier at that site, but a test *filename* quoted in `docs/operations/merge-queue.md`

## Why it happens

The `lob` detector matches `test_` followed by exactly 35 characters, and its verifier returns a positive for anything of that shape. Python test names hit it by accident.

The verifier carries no information, which is the part worth being precise about. Three randomly generated names of that shape — which cannot be Lob API keys — scan as:

```
verified_secrets: 3
```

So "verified" here does not mean a credential was probed and found live. It means the string was the right length.

This is the second time it has turned `main` red. The first was `test_public_key_jwk_embedded_and_correct` on #3480, where the false-positive verdict was recorded but not proven; this reproduces it.

## What this changes

`--exclude-detectors=lob`, plus `tests/unit/test_trufflehog_workflow_yaml.py` to keep that from becoming a habit.

There is no Lob integration in this repository, so the detector has no key to protect. Leaving it on has a cost that is easy to underrate: it teaches contributors that a red secret scan is something you disregard, and the next finding may be real.

`--exclude-detectors` is comma-separated, so silencing a genuine finding is a one-word edit that reads exactly like the justified exclusion already in the file. The test pins the list to a single documented entry, keeps the gate reporting verified results only, and keeps it running on both `push` and `pull_request` — an exclusion is only defensible while the gate still runs.

## Verification

Run against trufflehog 3.96.0, the version the workflow pins, over the exact commit range that failed on `main`:

| Scan | `verified_secrets` |
|---|---|
| `99c56c4b..d84cf76a`, as the workflow runs it today | 2 |
| same range, `--exclude-detectors=lob` | **0** |
| three fabricated `test_` + 35-char names, no exclusion | 3 |

And the test itself:

| State | Result |
|---|---|
| before this change | `test_the_known_false_positive_detector_stays_excluded` **fails** |
| after this change | 4 passed |
| exclusion widened to `lob,aws,github` | `test_no_detector_is_excluded_without_a_recorded_reason` **fails** |

## Alternative rejected

Renaming the two offending strings. It gets `main` green with the smallest possible diff and leaves the trap fully armed — the next contributor to write a test name of that length hits it again, and the failure will read as a leaked credential.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Exclude the false-positive <code>lob</code> detector from the TruffleHog secret-scanning gate while retaining verified-only reporting. Add structural tests that pin the exclusion list and ensure the gate continues running on <code>push</code> and <code>pull_request</code>.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3488?tool=ast&topic=Secret+scan+gate>Secret scan gate</a>
        </td><td>Exclude <code>lob</code> from TruffleHog because its verifier flags ordinary test names as verified secrets, while preserving the verified-results gate.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/trufflehog.yml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>ci: stop the secret-sc...</td><td>August 08, 2026</td></tr>
<tr><td>renovate[bot]</td><td>chore(deps): update tr...</td><td>July 31, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3488?tool=ast&topic=Configuration+safeguards>Configuration safeguards</a>
        </td><td>Pin the scanning configuration with tests that require the documented <code>lob</code> exclusion, reject undocumented exclusions, and preserve both workflow triggers.<details><summary>Modified files (1)</summary><ul><li>tests/unit/test_trufflehog_workflow_yaml.py</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>ci: stop the secret-sc...</td><td>August 08, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3488?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>