### PR TITLE
fix(adapters): drive Hermes through its one-shot flag instead of a bare prompt

### DIFF
--- a/docs/adapters/ADAPTER_GUIDE.md
+++ b/docs/adapters/ADAPTER_GUIDE.md
@@ -516,7 +516,11 @@ for deploy steps, the authentication warning, and the stated limitations.
 
 **Install:** `curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash`
 
-**Env vars:** `HERMES_API_KEY`, `NOUS_API_KEY`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`.
+**Env vars:** `OPENROUTER_API_KEY`, `FIREWORKS_API_KEY`, `NOVITA_API_KEY`, `DEEPINFRA_API_KEY`, `GOOGLE_API_KEY`, `GEMINI_API_KEY`, `GLM_API_KEY`, `KIMI_API_KEY`, `MINIMAX_API_KEY`, `HF_TOKEN`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `HERMES_HOME`. `HOME` is forwarded for every adapter, so a provider configured interactively through the CLI's own setup is picked up from its config file without any of these being set.
+
+**Invocation:** `hermes --oneshot='<prompt>'`. One-shot mode runs a single prompt and exits, printing only the final response. The prompt is passed inside the flag rather than as a following argument for two reasons: this CLI has no top-level positional parameter, so a bare prompt is parsed as a subcommand name and the process exits 2; and a prompt beginning with a dash would otherwise be read as flags. Empty prompts are refused before spawning — one-shot dispatches on the prompt being truthy, so a blank one starts an interactive session — and stdin is closed so no interactive path can block until the task timeout.
+
+**Permissions:** one-shot auto-bypasses approvals and offers no opt-out, which is why the capability contract declares this adapter `always-on` on the permission axis. The worktree boundary is the containment, not a prompt from the agent.
 
 **Best for:** Teams running Nous Research's Hermes open-weight models.
 

--- a/docs/adapters/ADAPTER_GUIDE.md
+++ b/docs/adapters/ADAPTER_GUIDE.md
@@ -516,11 +516,13 @@ for deploy steps, the authentication warning, and the stated limitations.
 
 **Install:** `curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash`
 
-**Env vars:** `OPENROUTER_API_KEY`, `FIREWORKS_API_KEY`, `NOVITA_API_KEY`, `DEEPINFRA_API_KEY`, `GOOGLE_API_KEY`, `GEMINI_API_KEY`, `GLM_API_KEY`, `KIMI_API_KEY`, `MINIMAX_API_KEY`, `HF_TOKEN`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `HERMES_HOME`. `HOME` is forwarded for every adapter, so a provider configured interactively through the CLI's own setup is picked up from its config file without any of these being set.
+**Env vars:** `NOUS_API_KEY` (the `nous-api` provider), `OPENROUTER_API_KEY`, `FIREWORKS_API_KEY`, `NOVITA_API_KEY`, `DEEPINFRA_API_KEY`, `GOOGLE_API_KEY`, `GEMINI_API_KEY`, `GLM_API_KEY`, `KIMI_API_KEY`, `MINIMAX_API_KEY`, `HF_TOKEN`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `HERMES_HOME`. `HOME` is forwarded for every adapter, so a provider configured interactively through the CLI's own setup is picked up from its config file without any of these being set.
 
 **Invocation:** `hermes --oneshot='<prompt>'`. One-shot mode runs a single prompt and exits, printing only the final response. The prompt is passed inside the flag rather than as a following argument for two reasons: this CLI has no top-level positional parameter, so a bare prompt is parsed as a subcommand name and the process exits 2; and a prompt beginning with a dash would otherwise be read as flags. Empty prompts are refused before spawning — one-shot dispatches on the prompt being truthy, so a blank one starts an interactive session — and stdin is closed so no interactive path can block until the task timeout.
 
-**Permissions:** one-shot auto-bypasses approvals and offers no opt-out, which is why the capability contract declares this adapter `always-on` on the permission axis. The worktree boundary is the containment, not a prompt from the agent.
+**Permissions:** one-shot auto-bypasses approvals and offers no opt-out, which is why the capability contract declares this adapter `always-on` on the permission axis.
+
+Note what that means for containment. Bernstein gives each task its own worktree and spawns the agent with that as its working directory, but the direct spawn path mediates no filesystem access — the wrapper it goes through provides process visibility, not a sandbox. Since this agent will not stop to ask, a run can read or write any path the bernstein process itself can reach. Treat the worktree as where the work is expected to happen, not as a boundary that is enforced. Configure a sandbox backend if the boundary needs to hold; see `docs/sandbox/`.
 
 **Best for:** Teams running Nous Research's Hermes open-weight models.
 

--- a/docs/adapters/capability_contract.md
+++ b/docs/adapters/capability_contract.md
@@ -133,7 +133,7 @@ adapters at a glance.
 | `generic` | unsupported | unsupported | text-signals |
 | `goose` | unsupported | unsupported | text-signals |
 | `gptme` | unsupported | unsupported | text-signals |
-| `hermes` | unsupported | unsupported | text-signals |
+| `hermes` | unsupported | always-on | text-signals |
 | `iac` | unsupported | unsupported | text-signals |
 | `junie` | unsupported | unsupported | text-signals |
 | `kilo` | unsupported | unsupported | text-signals |

--- a/src/bernstein/adapters/_contract.py
+++ b/src/bernstein/adapters/_contract.py
@@ -676,7 +676,12 @@ STRATEGY_MATRIX: dict[str, AdapterStrategy] = {
     # so its stdout lifecycle parser is bypassed.
     "goose": AdapterStrategy(event_channel=EventChannel.ACP),
     "gptme": AdapterStrategy(),
-    "hermes": AdapterStrategy(),
+    # Hermes is driven through its one-shot mode, which auto-bypasses approvals
+    # rather than exposing a flag to do so - the CLI is unattended by
+    # construction there, so the axis is always-on, not unsupported. Declaring
+    # it unsupported reads as "cannot be driven unattended", which understates
+    # what an operator is authorising when they select this adapter.
+    "hermes": AdapterStrategy(dangerous_mode=DangerousModeStrategy.ALWAYS_ON),
     "iac": AdapterStrategy(),
     "junie": AdapterStrategy(),
     # Kilo documents native ACP support; it declares the ACP event channel so

--- a/src/bernstein/adapters/hermes.py
+++ b/src/bernstein/adapters/hermes.py
@@ -125,6 +125,7 @@ class HermesAdapter(CLIAdapter):
                 executed.
         """
         self.refuse_multimodal_if_needed(multimodal_context)
+        self.enforce_network_policy()
         if not prompt.strip():
             msg = (
                 "hermes requires a non-empty prompt: one-shot mode dispatches on "

--- a/src/bernstein/adapters/hermes.py
+++ b/src/bernstein/adapters/hermes.py
@@ -13,13 +13,57 @@ if TYPE_CHECKING:
 from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
 from bernstein.adapters.env_isolation import build_filtered_env
 
+#: The prompt travels attached to its flag, never as a separate argument.
+#:
+#: ``hermes`` has no top-level positional parameter - the only positional slot
+#: is the subcommand, so a bare prompt is parsed as a command name and the
+#: process exits 2 before a model is contacted. Using ``--oneshot=<prompt>``
+#: rather than ``-z <prompt>`` additionally keeps a prompt that begins with a
+#: dash from being read as a flag.
+_ONESHOT_FLAG = "--oneshot"
+
+#: Provider credentials forwarded into the spawned environment.
+#:
+#: Taken from the names Hermes documents in its own ``.env.example`` rather
+#: than inferred from the vendor's name. ``HOME`` arrives via the base
+#: allowlist, which is what lets ``~/.hermes/config.yaml`` resolve and carry
+#: whatever the operator configured interactively.
+_PROVIDER_ENV_VARS = (
+    "OPENROUTER_API_KEY",
+    "FIREWORKS_API_KEY",
+    "NOVITA_API_KEY",
+    "DEEPINFRA_API_KEY",
+    "GOOGLE_API_KEY",
+    "GEMINI_API_KEY",
+    "GLM_API_KEY",
+    "KIMI_API_KEY",
+    "MINIMAX_API_KEY",
+    "HF_TOKEN",
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "HERMES_HOME",
+)
+
 
 class HermesAdapter(CLIAdapter):
     """Spawn and monitor Hermes Agent CLI sessions.
 
-    Hermes Agent is Nous Research's CLI coding agent. For non-interactive
-    spawn the prompt is passed positionally; the interactive TUI's
-    keystroke-injection mode is bypassed here.
+    Hermes Agent is Nous Research's agent CLI. It is driven here through its
+    one-shot mode, which runs a single prompt with approvals auto-bypassed,
+    edits files in the process working directory, prints the final response
+    and exits - the shape this orchestrator needs. The interactive TUI is
+    never entered.
+
+    Two properties of that mode decide how the process is spawned:
+
+    * an empty prompt is not treated as an error. Dispatch tests the prompt
+      for truthiness, so a blank one falls through to the interactive path,
+      which then waits on stdin for the whole timeout. Both halves are
+      guarded here - the prompt is rejected before spawning, and stdin is
+      closed so an unforeseen interactive path fails fast instead of hanging.
+    * one-shot suppresses tool previews and progress, so the log this returns
+      holds the final response and little else. Progress is not pollable from
+      it; the diff in the worktree is the outcome to inspect.
     """
 
     def spawn(
@@ -53,14 +97,23 @@ class HermesAdapter(CLIAdapter):
             A :class:`SpawnResult` describing the spawned process.
 
         Raises:
+            ValueError: If *prompt* is empty or only whitespace.
             RuntimeError: If the ``hermes`` binary cannot be found or
                 executed.
         """
         self.refuse_multimodal_if_needed(multimodal_context)
+        if not prompt.strip():
+            msg = (
+                "hermes requires a non-empty prompt: one-shot mode dispatches on "
+                "the prompt being truthy, so a blank one starts an interactive "
+                "session that waits for input until the task times out"
+            )
+            raise ValueError(msg)
+
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
 
-        cmd = ["hermes", prompt]
+        cmd = ["hermes", f"{_ONESHOT_FLAG}={prompt}"]
 
         pid_dir = workdir / ".sdd" / "runtime" / "pids"
         wrapped_cmd = build_worker_cmd(
@@ -73,13 +126,14 @@ class HermesAdapter(CLIAdapter):
             model=model_config.model,
         )
 
-        env = build_filtered_env(["HERMES_API_KEY", "NOUS_API_KEY", "ANTHROPIC_API_KEY", "OPENAI_API_KEY"])
+        env = build_filtered_env(_PROVIDER_ENV_VARS)
         with log_path.open("w") as log_file:
             try:
                 proc = subprocess.Popen(
                     wrapped_cmd,
                     cwd=workdir,
                     env=env,
+                    stdin=subprocess.DEVNULL,
                     stdout=log_file,
                     stderr=subprocess.STDOUT,
                     start_new_session=True,

--- a/src/bernstein/adapters/hermes.py
+++ b/src/bernstein/adapters/hermes.py
@@ -24,11 +24,25 @@ _ONESHOT_FLAG = "--oneshot"
 
 #: Provider credentials forwarded into the spawned environment.
 #:
-#: Taken from the names Hermes documents in its own ``.env.example`` rather
-#: than inferred from the vendor's name. ``HOME`` arrives via the base
-#: allowlist, which is what lets ``~/.hermes/config.yaml`` resolve and carry
-#: whatever the operator configured interactively.
+#: Taken from the variables Hermes documents for its own providers - its
+#: ``.env.example`` and the provider table in ``cli-config.yaml.example`` -
+#: rather than inferred from the vendor's name. A credential missing from this
+#: list is not an error the operator can see: the agent starts, fails to
+#: authenticate, and the run looks like a model problem.
+#:
+#: ``NOUS_API_KEY`` is the documented key for the ``nous-api`` provider and is
+#: forwarded for that reason. ``HERMES_API_KEY`` was previously forwarded and
+#: is not: it appears in neither file, so nothing reads it.
+#:
+#: ``GITHUB_TOKEN`` is deliberately absent although the ``copilot`` provider
+#: reads it. Forwarding a repository-scoped token to an agent whose approvals
+#: are auto-bypassed is a separate decision from forwarding a model
+#: credential, and not one to make implicitly here.
+#:
+#: ``HOME`` arrives via the base allowlist, which is what lets the operator's
+#: own config resolve and carry whatever was configured interactively.
 _PROVIDER_ENV_VARS = (
+    "NOUS_API_KEY",
     "OPENROUTER_API_KEY",
     "FIREWORKS_API_KEY",
     "NOVITA_API_KEY",
@@ -37,8 +51,17 @@ _PROVIDER_ENV_VARS = (
     "GEMINI_API_KEY",
     "GLM_API_KEY",
     "KIMI_API_KEY",
+    "KIMI_CN_API_KEY",
     "MINIMAX_API_KEY",
+    "MINIMAX_CN_API_KEY",
     "HF_TOKEN",
+    "NVIDIA_API_KEY",
+    "ARCEEAI_API_KEY",
+    "XIAOMI_API_KEY",
+    "OLLAMA_API_KEY",
+    "KILOCODE_API_KEY",
+    "AI_GATEWAY_API_KEY",
+    "LM_API_KEY",
     "OPENAI_API_KEY",
     "ANTHROPIC_API_KEY",
     "HERMES_HOME",

--- a/tests/unit/test_adapter_hermes.py
+++ b/tests/unit/test_adapter_hermes.py
@@ -112,18 +112,29 @@ class TestHermesAdapterSpawn:
         popen.assert_not_called()
 
     def test_provider_credentials_reach_the_agent(self, tmp_path: Path) -> None:
-        """Names come from what hermes documents, not from the vendor's name."""
+        """Names come from what the agent documents, not from the vendor's name.
+
+        A credential missing here is invisible to the operator: the agent
+        starts, fails to authenticate, and the run reads as a model problem.
+        """
         with patch("bernstein.adapters.hermes.build_filtered_env", return_value={}) as build_env:
             _spawn(HermesAdapter(), tmp_path, "ship the feature", "hermes-env")
 
         forwarded = set(build_env.call_args.args[0])
-        assert "OPENROUTER_API_KEY" in forwarded, (
-            "the documented API-key path for this agent; without it a configured "
-            "operator credential never reaches the spawned process"
+        assert {"OPENROUTER_API_KEY", "NOUS_API_KEY"} <= forwarded, (
+            "both are documented provider credentials - OPENROUTER_API_KEY in "
+            "the agent's .env.example, NOUS_API_KEY for its `nous-api` provider "
+            "in cli-config.yaml.example. Dropping either silently deauthenticates "
+            "an operator who configured it"
         )
-        assert not {"HERMES_API_KEY", "NOUS_API_KEY"} & forwarded, (
-            "neither name appears in the agent's own .env.example - forwarding "
-            "them suggests a credential path that does not exist"
+        assert "HERMES_API_KEY" not in forwarded, (
+            "this name appears in neither documented config, so nothing reads it; "
+            "forwarding it advertises a credential path that does not exist"
+        )
+        assert "GITHUB_TOKEN" not in forwarded, (
+            "forwarding a repository-scoped token to an agent whose approvals are "
+            "auto-bypassed is a separate decision from forwarding a model "
+            "credential, and is not made implicitly here"
         )
 
     def test_spawn_translates_missing_cli(self, tmp_path: Path) -> None:

--- a/tests/unit/test_adapter_hermes.py
+++ b/tests/unit/test_adapter_hermes.py
@@ -1,4 +1,23 @@
-"""Unit tests for HermesAdapter spawn/name."""
+"""Unit tests for HermesAdapter spawn/name.
+
+``hermes`` exposes no top-level positional parameter. Its only positional slot
+is the subcommand, so a bare prompt is parsed as a command name and the process
+exits 2 before a model is contacted - the agent never runs and the worktree
+diff is empty. The prompt therefore has to arrive attached to the one-shot
+flag, and the tests below are written to catch a command line that is *wrong*
+rather than merely *changed*:
+
+* :meth:`test_no_argument_lands_in_the_subcommand_slot` asserts the property
+  that upstream parser imposes, not the string this implementation happens to
+  emit. A rewrite that reintroduces a bare prompt fails it whatever the
+  wording;
+* the dash-prefixed prompt case pins the reason for ``--oneshot=<prompt>``
+  over ``-z <prompt>``, which is otherwise an invisible detail one refactor
+  away from regressing;
+* stdin and the empty-prompt guard cover the same hazard from both sides -
+  one-shot dispatches on the prompt being truthy, so a blank prompt reaches
+  the interactive path and waits on stdin for the whole timeout.
+"""
 
 from __future__ import annotations
 
@@ -18,19 +37,94 @@ if TYPE_CHECKING:
 pytestmark = pytest.mark.usefixtures("no_watchdog_threads")
 
 
+def _spawn(adapter: HermesAdapter, tmp_path: Path, prompt: str, session_id: str):
+    """Spawn against a mocked ``Popen`` and hand back the mock."""
+    proc_mock = make_popen_mock(pid=900)
+    with patch("bernstein.adapters.hermes.subprocess.Popen", return_value=proc_mock) as popen:
+        adapter.spawn(
+            prompt=prompt,
+            workdir=tmp_path,
+            model_config=ModelConfig(model="sonnet", effort="high"),
+            session_id=session_id,
+        )
+    return popen
+
+
 class TestHermesAdapterSpawn:
-    def test_spawn_builds_run_command(self, tmp_path: Path) -> None:
+    def test_spawn_passes_the_prompt_through_the_oneshot_flag(self, tmp_path: Path) -> None:
+        popen = _spawn(HermesAdapter(), tmp_path, "ship the feature", "hermes-s1")
+        assert inner_cmd(popen.call_args.args[0]) == ["hermes", "--oneshot=ship the feature"]
+
+    def test_the_prompt_is_never_its_own_argument(self, tmp_path: Path) -> None:
+        """Asserted as a property, so a rewrite cannot reintroduce the defect.
+
+        Two distinct failures are ruled out by the same rule. A bare
+        ``["hermes", prompt]`` offers the prompt to the only positional slot
+        there is - the subcommand - and the process exits 2 before reaching a
+        model, which is the form that shipped. And a prompt that begins with a
+        dash is read as flags when it stands alone.
+
+        ``["hermes", "-z", prompt]`` avoids the first failure, because the flag
+        consumes the value before the subparser sees it, but not the second.
+        Keeping the prompt inside a single ``--oneshot=<prompt>`` token avoids
+        both, and that is what this asserts - not the exact spelling above it.
+        """
+        prompt = "ship the feature"
+        popen = _spawn(HermesAdapter(), tmp_path, prompt, "hermes-slot")
+        binary, *arguments = inner_cmd(popen.call_args.args[0])
+
+        assert binary == "hermes"
+        assert prompt not in arguments, (
+            "the prompt is a standalone argument here. On its own it is offered "
+            "to the subcommand slot, and a dash-leading prompt is read as flags. "
+            "It has to stay inside one token with the flag that consumes it."
+        )
+        assert any(prompt in argument for argument in arguments), "the prompt must still be passed"
+
+    def test_a_dash_leading_prompt_stays_attached_to_its_flag(self, tmp_path: Path) -> None:
+        """``-z <prompt>`` would read this prompt as flags; ``--oneshot=`` cannot."""
+        prompt = "--help me remove the -rf guard in scripts/clean.sh"
+        popen = _spawn(HermesAdapter(), tmp_path, prompt, "hermes-dash")
+        arguments = inner_cmd(popen.call_args.args[0])[1:]
+
+        assert arguments == [f"--oneshot={prompt}"]
+        assert len(arguments) == 1, "the prompt must not be split into separate argv entries"
+
+    def test_spawn_closes_stdin(self, tmp_path: Path) -> None:
+        """An inherited stdin lets any interactive path block until timeout."""
+        import subprocess
+
+        popen = _spawn(HermesAdapter(), tmp_path, "ship the feature", "hermes-stdin")
+        assert popen.call_args.kwargs["stdin"] is subprocess.DEVNULL
+
+    def test_empty_prompt_is_refused_before_spawning(self, tmp_path: Path) -> None:
+        """One-shot dispatches on truthiness, so a blank prompt goes interactive."""
         adapter = HermesAdapter()
-        proc_mock = make_popen_mock(pid=900)
-        with patch("bernstein.adapters.hermes.subprocess.Popen", return_value=proc_mock) as popen:
-            adapter.spawn(
-                prompt="ship the feature",
-                workdir=tmp_path,
-                model_config=ModelConfig(model="sonnet", effort="high"),
-                session_id="hermes-s1",
-            )
-        inner = inner_cmd(popen.call_args.args[0])
-        assert inner == ["hermes", "ship the feature"]
+        with patch("bernstein.adapters.hermes.subprocess.Popen") as popen:
+            for blank in ("", "   ", "\n\t"):
+                with pytest.raises(ValueError, match="non-empty prompt"):
+                    adapter.spawn(
+                        prompt=blank,
+                        workdir=tmp_path,
+                        model_config=ModelConfig(model="sonnet", effort="high"),
+                        session_id="hermes-blank",
+                    )
+        popen.assert_not_called()
+
+    def test_provider_credentials_reach_the_agent(self, tmp_path: Path) -> None:
+        """Names come from what hermes documents, not from the vendor's name."""
+        with patch("bernstein.adapters.hermes.build_filtered_env", return_value={}) as build_env:
+            _spawn(HermesAdapter(), tmp_path, "ship the feature", "hermes-env")
+
+        forwarded = set(build_env.call_args.args[0])
+        assert "OPENROUTER_API_KEY" in forwarded, (
+            "the documented API-key path for this agent; without it a configured "
+            "operator credential never reaches the spawned process"
+        )
+        assert not {"HERMES_API_KEY", "NOUS_API_KEY"} & forwarded, (
+            "neither name appears in the agent's own .env.example - forwarding "
+            "them suggests a credential path that does not exist"
+        )
 
     def test_spawn_translates_missing_cli(self, tmp_path: Path) -> None:
         adapter = HermesAdapter()
@@ -52,3 +146,15 @@ class TestHermesAdapterSpawn:
 class TestHermesAdapterName:
     def test_name(self) -> None:
         assert HermesAdapter().name() == "Hermes Agent"
+
+
+class TestHermesDeclaredStrategy:
+    def test_the_declared_permission_axis_matches_the_mode_we_drive(self) -> None:
+        """`unsupported` here reads as "cannot be driven unattended" - it can."""
+        from bernstein.adapters._contract import STRATEGY_MATRIX, DangerousModeStrategy
+
+        assert STRATEGY_MATRIX["hermes"].dangerous_mode is DangerousModeStrategy.ALWAYS_ON, (
+            "one-shot mode auto-bypasses approvals with no flag to opt out, so "
+            "the axis is always-on. Declaring it unsupported understates what an "
+            "operator authorises by selecting this adapter."
+        )

--- a/tests/unit/test_adapter_hermes.py
+++ b/tests/unit/test_adapter_hermes.py
@@ -137,6 +137,26 @@ class TestHermesAdapterSpawn:
             "credential, and is not made implicitly here"
         )
 
+    def test_network_policy_is_enforced_before_spawning(self, tmp_path: Path) -> None:
+        """This adapter forwards provider credentials for a dozen hosted APIs.
+
+        Under a restricted or air-gapped policy that has to be checked before
+        the process starts, not after it has already reached out.
+        """
+        adapter = HermesAdapter()
+        with (
+            patch.object(HermesAdapter, "enforce_network_policy", side_effect=RuntimeError("blocked")),
+            patch("bernstein.adapters.hermes.subprocess.Popen") as popen,
+            pytest.raises(RuntimeError, match="blocked"),
+        ):
+            adapter.spawn(
+                prompt="ship the feature",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="hermes-net",
+            )
+        popen.assert_not_called()
+
     def test_spawn_translates_missing_cli(self, tmp_path: Path) -> None:
         adapter = HermesAdapter()
         with (


### PR DESCRIPTION
# User description
## What was broken

The shipped adapter ran:

```python
cmd = ["hermes", prompt]
```

That CLI has no top-level positional parameter. Its only positional slot is the subcommand, so the prompt was offered as a command name:

```
hermes: error: argument command: invalid choice: 'Fix the bug in foo.py'
```

Exit 2, before a model is contacted. Every task dispatched to this adapter failed identically, and because the failure happened at argument parsing the worktree diff was simply empty — nothing pointed at the cause.

## Why the tests did not catch it

They pinned it:

```python
assert inner == ["hermes", "ship the feature"]
```

The assertion matched the implementation exactly, so the adapter read as covered while never having worked. That is the specific thing this PR tries not to repeat.

## The contract, established from primary sources

Upstream's parser declares a one-shot flag, quoted verbatim from `hermes_cli/_parser.py`:

> One-shot mode: send a single prompt and print ONLY the final response text to stdout. […] approvals are auto-bypassed. Intended for scripts / pipes.

and its only positional slot is `parser.add_subparsers(dest="command", …)`. This was confirmed against the shipped binary (0.19.0), not inferred from documentation: `hermes -z "<prompt>"` exits 0 and creates the file it was asked to create; the bare-prompt form exits 2.

The prompt is passed as one `--oneshot=<prompt>` token rather than `-z` plus a separate argument, so a prompt starting with a dash cannot be read as flags.

## Two hazards in the same path

- One-shot dispatches on the prompt being **truthy**, so a blank prompt falls through to the interactive path. Empty prompts are refused before spawning, and `stdin` is set to `DEVNULL` — otherwise an unforeseen interactive path inherits bernstein's stdin and blocks for the whole task timeout.
- The forwarded credential allowlist was inferred from the vendor's name. Neither `HERMES_API_KEY` nor `NOUS_API_KEY` appears in that project's documented environment; the documented provider variables do, and are forwarded instead. `HOME` already arrives via the base allowlist, which is what lets the operator's own config resolve.

## Declared capability corrected

The permission axis read `unsupported`, which `_contract.py` defines as *"has no non-interactive mode and cannot be driven unattended"*. The mode this adapter drives auto-bypasses approvals with no opt-out, so it is now declared `always-on`. Understating it hides what an operator authorises by selecting this adapter.

## Tests

The replacement asserts a property rather than a string — the prompt is never its own argument — so a rewrite cannot reintroduce the defect under different wording.

| Command form | Result |
|---|---|
| `["hermes", "--oneshot=<prompt>"]` (this PR) | 9 passed |
| `["hermes", prompt]` (what shipped) | 3 failed |
| `["hermes", "-z", prompt]` | 3 failed |

The third row is deliberate. That form works today — the flag consumes the value before the subparser sees it — but breaks on a dash-leading prompt, so it is held to the same rule.

Also covered: `stdin=DEVNULL`, empty/whitespace prompts refused before `Popen`, the forwarded credential set, and the declared permission axis.

## Not addressed here

- **No live conformance run.** The one-shot path was exercised end-to-end, but not a full repo-edit task against a configured provider inside bernstein. Until that runs, this is "the invocation is now correct", not "the integration is proven end-to-end".
- **Cold start.** Every documented route to a working config goes through an interactive wizard; there is no confirmed environment-variable-only path. Relevant to CI use, unchanged by this PR.
- **`mcp_config` is still dropped.** No per-invocation MCP flag was found on that parser.
- One-shot suppresses tool previews, so the log carries the final response and little else. Progress is not pollable from it; the worktree diff is the outcome to inspect.
- The capability table in `docs/adapters/capability_contract.md` is hand-maintained with nothing tying it to `STRATEGY_MATRIX`. Both were updated here, but that gap is worth closing separately.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Drive <code>HermesAdapter</code> through Hermes CLI one-shot mode with safe prompt handling, closed stdin, documented provider credentials, and network-policy enforcement. Correct the adapter’s permission capability to <code>always-on</code> and expand tests and documentation around invocation, credentials, and containment.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3490?tool=ast&topic=Permission+capability>Permission capability</a>
        </td><td>Declare Hermes as <code>always-on</code> because one-shot mode automatically bypasses approvals, and align the capability documentation and contract tests with that behavior.<details><summary>Modified files (3)</summary><ul><li>docs/adapters/capability_contract.md</li>
<li>src/bernstein/adapters/_contract.py</li>
<li>tests/unit/test_adapter_hermes.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>fix(adapters): enforce...</td><td>August 08, 2026</td></tr>
<tr><td>chernistry</td><td>feat(tasks): declare a...</td><td>August 03, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3490?tool=ast&topic=Hermes+one-shot+flow>Hermes one-shot flow</a>
        </td><td>Update <code>HermesAdapter</code> to reject blank prompts, pass prompts as a single <code>--oneshot=&lt;prompt&gt;</code> argument, close stdin, enforce network policy, and forward documented provider credentials. Add regression coverage for argument safety, dash-leading prompts, spawning behavior, credentials, and network restrictions.<details><summary>Modified files (3)</summary><ul><li>docs/adapters/ADAPTER_GUIDE.md</li>
<li>src/bernstein/adapters/hermes.py</li>
<li>tests/unit/test_adapter_hermes.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>fix(adapters): enforce...</td><td>August 08, 2026</td></tr>
<tr><td>chernistry</td><td>feat(adapters): drive ...</td><td>July 24, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3490?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

---

<!-- bot-ack: 3740546168 reason=Pre-existing and shared with 24 other registry adapters; the default admission policy is warn, not enforce; and writing a contract that pins an invocation surface no live conformance run has exercised would assert more than has been verified. Tracked separately rather than fixed here. -->

**Acknowledged, not fixed: no `tests/contract/contracts/hermes.yaml`.**

Verified before deciding. 25 of the 46 registry adapters have no contract file — `cursor`, `cody`, `kilo`, `kiro`, `ollama`, `openai_agents` and `mock` among them — so this is a repo-wide gap, not something this branch introduces or is uniquely missing.

The refusal is also narrower than "permanently refused". `REASON_NO_CONTRACT` produces `VERDICT_REFUSE` only under `POLICY_ENFORCE`; the default resolved by `admission.py` is `POLICY_WARN`, opt-in via `BERNSTEIN_ADAPTER_ADMISSION_POLICY`.

Not fixed here for a specific reason: a contract pins the invocation surface, and the honest input for one is a live conformance run against the installed binary. This PR deliberately does not claim that run has happened — the one-shot path was exercised, a full task through bernstein was not. Writing a contract now would put a stronger claim in a machine-checked file than the PR body is willing to make in prose, which is the wrong way round.
