### PR TITLE
fix(security): make the attestation public-key guard a real containment check

### DIFF
--- a/src/bernstein/core/security/AGENTS.md
+++ b/src/bernstein/core/security/AGENTS.md
@@ -13,6 +13,7 @@ subsystems anchor receipts to; treat its write path as load-bearing.
 | `audit_receipt.py` | Offline-verifiable receipt projection (COSE / in-toto) over a chain range |
 | `agent_card_keystore.py` | Ed25519 install-identity keystore |
 | `intent_capsule.py` | Signed task-goal capsules with drift escalation |
+| `sigstore_attestation.py` | Rekor attestation with a local Ed25519 fallback; verifies local bundles |
 
 ## Invariants
 
@@ -28,6 +29,13 @@ subsystems anchor receipts to; treat its write path as load-bearing.
 - The audit chain is opt-in at runtime (`BERNSTEIN_AUDIT=1`, read in
   `../orchestration/orchestrator.py`); features must degrade cleanly
   without it.
+- An attestation bundle is untrusted input. Its `public_key_file` names
+  the key the signature is checked against, so it must stay a single
+  plain filename inside `attestation_dir`, decided from the string with
+  no `resolve` or `stat`, and read through a descriptor anchored to that
+  directory. Never reintroduce a path-comparison containment check: it
+  validates one lookup and the open performs another
+  (`sigstore_attestation.py` module docstring, "Local bundle contract").
 
 ## Testing
 

--- a/src/bernstein/core/security/sigstore_attestation.py
+++ b/src/bernstein/core/security/sigstore_attestation.py
@@ -461,20 +461,19 @@ def verify_local_attestation(bundle_path: Path, attestation_dir: Path) -> bool:
     # ``public_key_file`` comes from the untrusted bundle, so it decides which
     # key the signature is checked against: steer it outside the attestation
     # directory and any payload signed with an attacker-held key verifies.
-    # It must therefore be a relative name that resolves *under* the directory.
-    # An absolute value would drop the directory entirely
-    # (``attestation_dir / "/etc/x"`` is ``/etc/x``), and containment is a
-    # path-component question -- a string prefix test accepts every sibling
-    # whose name starts with the directory's own name.
+    #
+    # Containment is decided from the name alone, with no filesystem lookup.
+    # Resolving a path to prove it is contained and then opening that path are
+    # two separate lookups, and everything between them is a window; a name
+    # that is a single plain component cannot leave the directory it is opened
+    # relative to, so there is no window to begin with. The writer stores
+    # ``pub_path.name``, so nothing legitimate is absolute, descends into a
+    # subdirectory, or walks upwards.
     raw_key_name = bundle["public_key_file"]
-    attestation_root = attestation_dir.resolve()
-    pub_key_file = (attestation_dir / raw_key_name).resolve()
-    if os.path.isabs(raw_key_name) or not pub_key_file.is_relative_to(attestation_root):
+    if _escapes_directory(raw_key_name):
         msg = f"Path traversal detected in public_key_file: {raw_key_name!r}"
         raise ValueError(msg)
-    public_key = serialization.load_pem_public_key(
-        _read_contained_key_bytes(attestation_dir, raw_key_name, pub_key_file)
-    )
+    public_key = serialization.load_pem_public_key(_read_contained_key_bytes(attestation_dir, raw_key_name))
 
     payload_bytes = AttestationPayload(**bundle["payload"]).canonical_json().encode()
     signature = bytes.fromhex(bundle["signature_hex"])
@@ -491,25 +490,50 @@ def verify_local_attestation(bundle_path: Path, attestation_dir: Path) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _read_contained_key_bytes(attestation_dir: Path, raw_key_name: str, resolved: Path) -> bytes:
-    """Read the bundle-named public key without following a link at its name.
+def _escapes_directory(raw_key_name: object) -> bool:
+    """Whether ``raw_key_name`` could name anything but a file in one directory.
 
-    The containment check in :func:`verify_local_attestation` validates a path
-    *string*; this open has to reach the object that string was checked
-    against.  Two lookups are two chances to resolve, so anything able to
-    write into ``attestation_dir`` could drop a symlink at the name between
-    the check and the read and steer the verifier onto a key it owns.
+    Decided from the string alone -- no ``resolve``, no ``stat``, nothing the
+    filesystem can change underneath the answer.  Only a single plain
+    component passes: anything absolute, drive-qualified, separated, or
+    self/parent-referential is rejected, as is a non-string, which a crafted
+    bundle can carry just as easily as a traversing name.
 
-    The open is therefore anchored to a descriptor for the attestation
-    directory where the platform offers one, and refuses a symlink at the
-    final component, which closes that window rather than narrowing it.  A
-    non-regular file is rejected too, so a crafted bundle surfaces as the
-    ``ValueError`` callers already handle instead of a stray ``OSError``.
+    Args:
+        raw_key_name: The bundle-supplied ``public_key_file`` value.
+
+    Returns:
+        True when the value must be refused.
+    """
+    if not isinstance(raw_key_name, str) or not raw_key_name:
+        return True
+    drive, _ = os.path.splitdrive(raw_key_name)
+    return bool(
+        drive
+        or os.path.isabs(raw_key_name)
+        or raw_key_name in {os.curdir, os.pardir}
+        or "/" in raw_key_name
+        or "\\" in raw_key_name
+    )
+
+
+def _read_contained_key_bytes(attestation_dir: Path, raw_key_name: str) -> bytes:
+    """Read the bundle-named public key from exactly one directory lookup.
+
+    ``attestation_dir`` is resolved once, into a descriptor, and the key is
+    opened relative to that descriptor.  Nothing re-derives the directory
+    afterwards, so there is no interval in which swapping it could redirect
+    the read; :func:`_escapes_directory` has already established that the name
+    is a single component, which is what makes an anchored open sufficient.
+
+    ``O_NOFOLLOW`` then refuses a symlink at that component, and ``fstat``
+    requires a regular file, so a crafted bundle surfaces as the ``ValueError``
+    callers already handle instead of a stray ``OSError``.
 
     Args:
         attestation_dir: Directory the key must be read from.
-        raw_key_name: Bundle-supplied name, already checked for containment.
-        resolved: The resolved path, used where ``dir_fd`` is unavailable.
+        raw_key_name: Bundle-supplied name, already checked by
+            :func:`_escapes_directory`.
 
     Returns:
         The bytes of the key file.
@@ -526,7 +550,9 @@ def _read_contained_key_bytes(attestation_dir: Path, raw_key_name: str, resolved
             dir_fd = os.open(attestation_dir, os.O_RDONLY)
             fd = os.open(raw_key_name, open_flags, dir_fd=dir_fd)
         else:  # pragma: no cover - Windows has neither dir_fd nor O_NOFOLLOW
-            fd = os.open(resolved, open_flags)
+            # A single component cannot escape the directory it is joined to,
+            # so the join is safe without a containment re-check here.
+            fd = os.open(attestation_dir / raw_key_name, open_flags)
     except OSError as exc:
         # O_NOFOLLOW reports a symlink at the final component as ELOOP.  Every
         # other OSError (a missing or unreadable key) is a genuine local fault

--- a/src/bernstein/core/security/sigstore_attestation.py
+++ b/src/bernstein/core/security/sigstore_attestation.py
@@ -456,10 +456,18 @@ def verify_local_attestation(bundle_path: Path, attestation_dir: Path) -> bool:
         msg = "Not a local Ed25519 attestation bundle"
         raise ValueError(msg)
 
-    # Sanitize public_key_file to prevent path traversal attacks
+    # ``public_key_file`` comes from the untrusted bundle, so it decides which
+    # key the signature is checked against: steer it outside the attestation
+    # directory and any payload signed with an attacker-held key verifies.
+    # It must therefore be a relative name that resolves *under* the directory.
+    # An absolute value would drop the directory entirely
+    # (``attestation_dir / "/etc/x"`` is ``/etc/x``), and containment is a
+    # path-component question -- a string prefix test accepts every sibling
+    # whose name starts with the directory's own name.
     raw_key_name = bundle["public_key_file"]
+    attestation_root = attestation_dir.resolve()
     pub_key_file = (attestation_dir / raw_key_name).resolve()
-    if not str(pub_key_file).startswith(str(attestation_dir.resolve())):
+    if os.path.isabs(raw_key_name) or not pub_key_file.is_relative_to(attestation_root):
         msg = f"Path traversal detected in public_key_file: {raw_key_name!r}"
         raise ValueError(msg)
     public_key = serialization.load_pem_public_key(pub_key_file.read_bytes())

--- a/src/bernstein/core/security/sigstore_attestation.py
+++ b/src/bernstein/core/security/sigstore_attestation.py
@@ -30,11 +30,13 @@ Usage::
 from __future__ import annotations
 
 import contextlib
+import errno
 import hashlib
 import importlib.util
 import json
 import logging
 import os
+import stat
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
@@ -470,7 +472,9 @@ def verify_local_attestation(bundle_path: Path, attestation_dir: Path) -> bool:
     if os.path.isabs(raw_key_name) or not pub_key_file.is_relative_to(attestation_root):
         msg = f"Path traversal detected in public_key_file: {raw_key_name!r}"
         raise ValueError(msg)
-    public_key = serialization.load_pem_public_key(pub_key_file.read_bytes())
+    public_key = serialization.load_pem_public_key(
+        _read_contained_key_bytes(attestation_dir, raw_key_name, pub_key_file)
+    )
 
     payload_bytes = AttestationPayload(**bundle["payload"]).canonical_json().encode()
     signature = bytes.fromhex(bundle["signature_hex"])
@@ -485,6 +489,66 @@ def verify_local_attestation(bundle_path: Path, attestation_dir: Path) -> bool:
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
+
+def _read_contained_key_bytes(attestation_dir: Path, raw_key_name: str, resolved: Path) -> bytes:
+    """Read the bundle-named public key without following a link at its name.
+
+    The containment check in :func:`verify_local_attestation` validates a path
+    *string*; this open has to reach the object that string was checked
+    against.  Two lookups are two chances to resolve, so anything able to
+    write into ``attestation_dir`` could drop a symlink at the name between
+    the check and the read and steer the verifier onto a key it owns.
+
+    The open is therefore anchored to a descriptor for the attestation
+    directory where the platform offers one, and refuses a symlink at the
+    final component, which closes that window rather than narrowing it.  A
+    non-regular file is rejected too, so a crafted bundle surfaces as the
+    ``ValueError`` callers already handle instead of a stray ``OSError``.
+
+    Args:
+        attestation_dir: Directory the key must be read from.
+        raw_key_name: Bundle-supplied name, already checked for containment.
+        resolved: The resolved path, used where ``dir_fd`` is unavailable.
+
+    Returns:
+        The bytes of the key file.
+
+    Raises:
+        ValueError: If the name is a symlink or not a regular file.
+    """
+    # ``O_BINARY`` matters on Windows, where ``os.open`` would otherwise
+    # translate line endings and hand ``load_pem_public_key`` altered bytes.
+    open_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_BINARY", 0)
+    dir_fd: int | None = None
+    try:
+        if os.open in os.supports_dir_fd:
+            dir_fd = os.open(attestation_dir, os.O_RDONLY)
+            fd = os.open(raw_key_name, open_flags, dir_fd=dir_fd)
+        else:  # pragma: no cover - Windows has neither dir_fd nor O_NOFOLLOW
+            fd = os.open(resolved, open_flags)
+    except OSError as exc:
+        # O_NOFOLLOW reports a symlink at the final component as ELOOP.  Every
+        # other OSError (a missing or unreadable key) is a genuine local fault
+        # and keeps propagating as it did before.
+        if exc.errno == errno.ELOOP:
+            msg = f"public_key_file is a symlink, refusing to follow it: {raw_key_name!r}"
+            raise ValueError(msg) from exc
+        raise
+    finally:
+        if dir_fd is not None:
+            os.close(dir_fd)
+
+    try:
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            msg = f"public_key_file is not a regular file: {raw_key_name!r}"
+            raise ValueError(msg)
+        chunks: list[bytes] = []
+        while chunk := os.read(fd, 65536):
+            chunks.append(chunk)
+    finally:
+        os.close(fd)
+    return b"".join(chunks)
 
 
 def _save_record_index(attestation_dir: Path, record: AttestationRecord) -> None:

--- a/src/bernstein/core/security/sigstore_attestation.py
+++ b/src/bernstein/core/security/sigstore_attestation.py
@@ -48,10 +48,10 @@ emit, and consumers may rely on, a narrow shape:
   file, both with ``ValueError``.
 * A missing or unreadable key still raises ``OSError``: that is a local
   fault rather than a hostile bundle, and callers distinguish the two.
-* The symlink refusal is atomic where ``os.open`` supports ``dir_fd`` and
-  ``O_NOFOLLOW``.  On platforms offering neither -- Windows -- it degrades
-  to a best-effort check, since no atomic equivalent exists there.  Name
-  containment is unaffected and holds on every platform.
+* The symlink refusal is atomic only where ``os.open`` supports **both**
+  ``dir_fd`` and ``O_NOFOLLOW``.  Missing either one -- Windows lacks both
+  -- it degrades to a best-effort check, since no atomic equivalent exists
+  there.  Name containment is unaffected and holds on every platform.
 
 None of this depends on ``attestation_dir`` itself being adversary-proof.
 Write access to that directory means control of the stored signing key, at
@@ -576,18 +576,25 @@ def _read_contained_key_bytes(attestation_dir: Path, raw_key_name: str) -> bytes
     # translate line endings and hand ``load_pem_public_key`` altered bytes.
     open_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_BINARY", 0)
     dir_fd: int | None = None
+    # Both capabilities are required, not just ``dir_fd``: the anchored open
+    # refuses a symlink only because ``O_NOFOLLOW`` is among its flags, so
+    # selecting that branch on ``dir_fd`` alone would, on a platform offering
+    # one without the other, take the branch that has no best-effort check
+    # while dropping the flag that would have made it unnecessary.
+    can_anchor = os.open in os.supports_dir_fd and hasattr(os, "O_NOFOLLOW")
     try:
-        if os.open in os.supports_dir_fd:
+        if can_anchor:
             dir_fd = os.open(attestation_dir, os.O_RDONLY)
             fd = os.open(raw_key_name, open_flags, dir_fd=dir_fd)
         else:
-            # Windows reaches this branch: no ``dir_fd``, no ``O_NOFOLLOW``.
-            # A single component still cannot escape the directory it is
-            # joined to, so containment holds; what is missing is an atomic
-            # refusal to follow a link at that component. This check is
-            # therefore best effort by construction -- it catches a symlink
-            # that is present, not one planted between here and the open --
-            # and it is the most the platform offers.
+            # Windows reaches this branch, as does any platform missing
+            # either capability. A single component still cannot escape the
+            # directory it is joined to, so containment holds; what is
+            # missing is an atomic refusal to follow a link at that
+            # component. This check is therefore best effort by construction
+            # -- it catches a symlink that is present, not one planted
+            # between here and the open -- and it is the most such a platform
+            # offers.
             key_path = attestation_dir / raw_key_name
             if key_path.is_symlink():
                 msg = f"public_key_file is a symlink, refusing to follow it: {raw_key_name!r}"

--- a/src/bernstein/core/security/sigstore_attestation.py
+++ b/src/bernstein/core/security/sigstore_attestation.py
@@ -25,6 +25,37 @@ Usage::
         event_hmac="deadbeef...",
     )
     print(record.rekor_log_id or "fallback used")
+
+Local bundle contract
+---------------------
+
+A ``bernstein-local-attestation/v1`` bundle is untrusted input: its
+``public_key_file`` field names the key that
+:func:`verify_local_attestation` checks the signature against, so a bundle
+that can steer that name picks its own verdict.  Producers must therefore
+emit, and consumers may rely on, a narrow shape:
+
+* ``public_key_file`` is a **single plain filename** resolved inside
+  ``attestation_dir``.  Absolute paths, drive-qualified paths, anything
+  containing ``/`` or ``\\``, ``.``, ``..``, and non-string values are all
+  rejected with ``ValueError``.  Writers emit ``pub_path.name``, which
+  always satisfies this.
+* Containment is decided from that string alone -- no ``resolve``, no
+  ``stat`` -- so it cannot be raced.  Subdirectories are refused for this
+  reason, not because they are inherently unsafe.
+* The key is read through a descriptor anchored to ``attestation_dir``.  A
+  symlink at the name is refused, as is anything that is not a regular
+  file, both with ``ValueError``.
+* A missing or unreadable key still raises ``OSError``: that is a local
+  fault rather than a hostile bundle, and callers distinguish the two.
+* The symlink refusal is atomic where ``os.open`` supports ``dir_fd`` and
+  ``O_NOFOLLOW``.  On platforms offering neither -- Windows -- it degrades
+  to a best-effort check, since no atomic equivalent exists there.  Name
+  containment is unaffected and holds on every platform.
+
+None of this depends on ``attestation_dir`` itself being adversary-proof.
+Write access to that directory means control of the stored signing key, at
+which point an attacker signs bundles outright rather than steering them.
 """
 
 from __future__ import annotations
@@ -549,10 +580,19 @@ def _read_contained_key_bytes(attestation_dir: Path, raw_key_name: str) -> bytes
         if os.open in os.supports_dir_fd:
             dir_fd = os.open(attestation_dir, os.O_RDONLY)
             fd = os.open(raw_key_name, open_flags, dir_fd=dir_fd)
-        else:  # pragma: no cover - Windows has neither dir_fd nor O_NOFOLLOW
-            # A single component cannot escape the directory it is joined to,
-            # so the join is safe without a containment re-check here.
-            fd = os.open(attestation_dir / raw_key_name, open_flags)
+        else:
+            # Windows reaches this branch: no ``dir_fd``, no ``O_NOFOLLOW``.
+            # A single component still cannot escape the directory it is
+            # joined to, so containment holds; what is missing is an atomic
+            # refusal to follow a link at that component. This check is
+            # therefore best effort by construction -- it catches a symlink
+            # that is present, not one planted between here and the open --
+            # and it is the most the platform offers.
+            key_path = attestation_dir / raw_key_name
+            if key_path.is_symlink():
+                msg = f"public_key_file is a symlink, refusing to follow it: {raw_key_name!r}"
+                raise ValueError(msg)
+            fd = os.open(key_path, open_flags)
     except OSError as exc:
         # O_NOFOLLOW reports a symlink at the final component as ELOOP.  Every
         # other OSError (a missing or unreadable key) is a genuine local fault

--- a/tests/unit/test_sigstore_attestation.py
+++ b/tests/unit/test_sigstore_attestation.py
@@ -256,6 +256,130 @@ class TestFallbackAttestation:
 
 
 # ---------------------------------------------------------------------------
+# Containment of the bundle-supplied public_key_file
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyPublicKeyContainment:
+    """``public_key_file`` is attacker-controlled and must stay inside the dir.
+
+    The bundle is untrusted input: whoever hands us a bundle picks the file
+    the verifier loads its public key from.  If that file can be steered
+    outside ``attestation_dir``, an attacker signs any payload they like with
+    a key they own and the bundle still verifies.  Each rejection case below
+    forges a bundle end-to-end with an attacker keypair, so the containment
+    check is the only thing standing between the forgery and a ``True``
+    verdict.
+    """
+
+    @pytest.fixture
+    def attest_dir(self, tmp_path: Path) -> Path:
+        return tmp_path / "attestations"
+
+    def _forged_bundle(self, attest_dir: Path, key_dir: Path) -> tuple[Path, Path]:
+        """Write a genuine bundle, then re-sign it with an attacker key.
+
+        The attacker public key lands in ``key_dir``; the returned bundle has
+        a tampered payload signed by the matching private key.  Returns the
+        bundle path and the attacker public-key path.
+        """
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+        with patch(
+            "bernstein.core.sigstore_attestation._sigstore_available",
+            return_value=False,
+        ):
+            record = attest_task_completion(
+                task_id="task-traversal",
+                agent_id="a",
+                diff_sha256="d" * 64,
+                event_hmac="e" * 64,
+                attestation_dir=attest_dir,
+            )
+
+        evil_private = Ed25519PrivateKey.generate()
+        key_dir.mkdir(parents=True, exist_ok=True)
+        evil_pub = key_dir / "ed25519-public-key.pem"
+        evil_pub.write_bytes(
+            evil_private.public_key().public_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PublicFormat.SubjectPublicKeyInfo,
+            )
+        )
+
+        bundle_path = Path(record.bundle_path)
+        bundle = json.loads(bundle_path.read_text())
+        bundle["payload"]["task_id"] = "FORGED"
+        payload_bytes = AttestationPayload(**bundle["payload"]).canonical_json().encode()
+        bundle["signature_hex"] = evil_private.sign(payload_bytes).hex()
+        bundle_path.write_text(json.dumps(bundle))
+        return bundle_path, evil_pub
+
+    def test_rejects_sibling_directory_with_shared_name_prefix(self, attest_dir: Path) -> None:
+        """``../attestations-evil/key.pem`` is outside the dir despite the prefix.
+
+        A plain string ``startswith`` on the resolved path accepts any sibling
+        directory whose name begins with the allowed directory's name.
+        """
+        evil_dir = attest_dir.parent / f"{attest_dir.name}-evil"
+        bundle_path, _ = self._forged_bundle(attest_dir, evil_dir)
+
+        bundle = json.loads(bundle_path.read_text())
+        bundle["public_key_file"] = f"../{evil_dir.name}/ed25519-public-key.pem"
+        bundle_path.write_text(json.dumps(bundle))
+
+        with pytest.raises(ValueError, match="Path traversal detected"):
+            verify_local_attestation(bundle_path, attest_dir)
+
+    def test_rejects_absolute_public_key_file_outside_dir(self, attest_dir: Path) -> None:
+        """An absolute path escapes ``attestation_dir / raw`` entirely."""
+        evil_dir = attest_dir.parent / "elsewhere"
+        bundle_path, evil_pub = self._forged_bundle(attest_dir, evil_dir)
+
+        bundle = json.loads(bundle_path.read_text())
+        bundle["public_key_file"] = str(evil_pub)
+        bundle_path.write_text(json.dumps(bundle))
+
+        with pytest.raises(ValueError, match="Path traversal detected"):
+            verify_local_attestation(bundle_path, attest_dir)
+
+    def test_rejects_absolute_public_key_file_inside_dir(self, attest_dir: Path) -> None:
+        """Absolute values are refused even when they land inside the dir.
+
+        Bundles carry a bare filename (``pub_path.name``), so an absolute
+        value never comes from the writer -- it only comes from a crafted
+        bundle probing the guard.
+        """
+        bundle_path, evil_pub = self._forged_bundle(attest_dir, attest_dir)
+
+        bundle = json.loads(bundle_path.read_text())
+        bundle["public_key_file"] = str(evil_pub)
+        bundle_path.write_text(json.dumps(bundle))
+
+        with pytest.raises(ValueError, match="Path traversal detected"):
+            verify_local_attestation(bundle_path, attest_dir)
+
+    def test_accepts_plain_filename_inside_dir(self, attest_dir: Path) -> None:
+        """The legitimate shape -- a bare filename -- still verifies."""
+        with patch(
+            "bernstein.core.sigstore_attestation._sigstore_available",
+            return_value=False,
+        ):
+            record = attest_task_completion(
+                task_id="task-contained",
+                agent_id="a",
+                diff_sha256="d" * 64,
+                event_hmac="e" * 64,
+                attestation_dir=attest_dir,
+            )
+
+        bundle_path = Path(record.bundle_path)
+        assert json.loads(bundle_path.read_text())["public_key_file"] == "ed25519-public-key.pem"
+        assert verify_local_attestation(bundle_path, attest_dir) is True
+
+
+# ---------------------------------------------------------------------------
 # Index and listing
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_sigstore_attestation.py
+++ b/tests/unit/test_sigstore_attestation.py
@@ -8,6 +8,7 @@ the Ed25519 fallback and the data model / persistence layer.
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -377,6 +378,80 @@ class TestVerifyPublicKeyContainment:
         bundle_path = Path(record.bundle_path)
         assert json.loads(bundle_path.read_text())["public_key_file"] == "ed25519-public-key.pem"
         assert verify_local_attestation(bundle_path, attest_dir) is True
+
+
+# ---------------------------------------------------------------------------
+# How the contained key file is opened
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyPublicKeyOpen:
+    """Containment validates a path; the open must reach the same object.
+
+    Checking a path string and later opening that string are two separate
+    lookups, so anything that can write into ``attestation_dir`` could swap a
+    symlink in between them.  The open therefore refuses to follow a link at
+    the named component and insists on a regular file, which removes the
+    window instead of narrowing it.
+    """
+
+    @pytest.fixture
+    def attest_dir(self, tmp_path: Path) -> Path:
+        return tmp_path / "attestations"
+
+    def _bundle_naming(self, attest_dir: Path, key_name: str) -> Path:
+        """Write a genuine bundle whose ``public_key_file`` is ``key_name``."""
+        with patch(
+            "bernstein.core.sigstore_attestation._sigstore_available",
+            return_value=False,
+        ):
+            record = attest_task_completion(
+                task_id="task-open",
+                agent_id="a",
+                diff_sha256="d" * 64,
+                event_hmac="e" * 64,
+                attestation_dir=attest_dir,
+            )
+
+        bundle_path = Path(record.bundle_path)
+        bundle = json.loads(bundle_path.read_text())
+        bundle["public_key_file"] = key_name
+        bundle_path.write_text(json.dumps(bundle))
+        return bundle_path
+
+    @pytest.mark.skipif(not hasattr(os, "O_NOFOLLOW"), reason="O_NOFOLLOW is POSIX-only")
+    def test_refuses_symlink_at_the_named_component(self, attest_dir: Path) -> None:
+        """A symlink is refused even when it points at the real, contained key.
+
+        The link resolves inside the directory, so containment alone is happy
+        with it.  Refusing to follow it is what makes the checked path and the
+        opened file the same object.
+        """
+        bundle_path = self._bundle_naming(attest_dir, "linked-key.pem")
+        (attest_dir / "linked-key.pem").symlink_to(attest_dir / "ed25519-public-key.pem")
+
+        with pytest.raises(ValueError, match="symlink"):
+            verify_local_attestation(bundle_path, attest_dir)
+
+    def test_refuses_non_regular_file(self, attest_dir: Path) -> None:
+        """A directory at the named component is a ValueError, not an OSError.
+
+        Callers already handle ``ValueError`` from this function; letting an
+        ``IsADirectoryError`` escape would make a crafted bundle look like a
+        local I/O fault.
+        """
+        bundle_path = self._bundle_naming(attest_dir, "key-dir")
+        (attest_dir / "key-dir").mkdir()
+
+        with pytest.raises(ValueError, match="not a regular file"):
+            verify_local_attestation(bundle_path, attest_dir)
+
+    def test_missing_key_file_still_raises_oserror(self, attest_dir: Path) -> None:
+        """A genuinely absent key stays an OSError -- that is a local fault."""
+        bundle_path = self._bundle_naming(attest_dir, "no-such-key.pem")
+
+        with pytest.raises(FileNotFoundError):
+            verify_local_attestation(bundle_path, attest_dir)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_sigstore_attestation.py
+++ b/tests/unit/test_sigstore_attestation.py
@@ -464,6 +464,26 @@ class TestVerifyPublicKeyOpen:
         with pytest.raises(ValueError, match="not a regular file"):
             verify_local_attestation(bundle_path, attest_dir)
 
+    @pytest.mark.skipif(not hasattr(os, "O_NOFOLLOW"), reason="needs a POSIX host to emulate from")
+    def test_refuses_symlink_without_dir_fd_or_nofollow(
+        self, attest_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The no-``dir_fd`` branch refuses a symlink too.
+
+        Emulates the platform Windows presents -- no ``dir_fd`` support and no
+        ``O_NOFOLLOW`` -- because a POSIX host would otherwise never reach that
+        branch and it would ship untested.  The check there is best effort: it
+        catches a symlink that is present, not one planted in the instant
+        before the open, which is the most the platform allows.
+        """
+        bundle_path = self._bundle_naming(attest_dir, "linked-key.pem")
+        (attest_dir / "linked-key.pem").symlink_to(attest_dir / "ed25519-public-key.pem")
+        monkeypatch.setattr(os, "supports_dir_fd", set())
+        monkeypatch.delattr(os, "O_NOFOLLOW", raising=False)
+
+        with pytest.raises(ValueError, match="symlink"):
+            verify_local_attestation(bundle_path, attest_dir)
+
     def test_missing_key_file_still_raises_oserror(self, attest_dir: Path) -> None:
         """A genuinely absent key stays an OSError -- that is a local fault."""
         bundle_path = self._bundle_naming(attest_dir, "no-such-key.pem")

--- a/tests/unit/test_sigstore_attestation.py
+++ b/tests/unit/test_sigstore_attestation.py
@@ -484,6 +484,26 @@ class TestVerifyPublicKeyOpen:
         with pytest.raises(ValueError, match="symlink"):
             verify_local_attestation(bundle_path, attest_dir)
 
+    @pytest.mark.skipif(not hasattr(os, "O_NOFOLLOW"), reason="needs a POSIX host to emulate from")
+    def test_refuses_symlink_with_dir_fd_but_no_nofollow(
+        self, attest_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Having ``dir_fd`` is not on its own enough to select the anchored open.
+
+        The anchored branch refuses a symlink only because ``O_NOFOLLOW`` is in
+        its flags, and the best-effort check lives in the other branch.  A
+        platform with one capability and not the other therefore has to reach
+        the best-effort branch, or it gets neither protection.
+        """
+        bundle_path = self._bundle_naming(attest_dir, "linked-key.pem")
+        (attest_dir / "linked-key.pem").symlink_to(attest_dir / "ed25519-public-key.pem")
+        # ``supports_dir_fd`` is deliberately left intact: this is the mixed
+        # capability case, not the no-capability one covered above.
+        monkeypatch.delattr(os, "O_NOFOLLOW", raising=False)
+
+        with pytest.raises(ValueError, match="symlink"):
+            verify_local_attestation(bundle_path, attest_dir)
+
     def test_missing_key_file_still_raises_oserror(self, attest_dir: Path) -> None:
         """A genuinely absent key stays an OSError -- that is a local fault."""
         bundle_path = self._bundle_naming(attest_dir, "no-such-key.pem")

--- a/tests/unit/test_sigstore_attestation.py
+++ b/tests/unit/test_sigstore_attestation.py
@@ -361,6 +361,24 @@ class TestVerifyPublicKeyContainment:
         with pytest.raises(ValueError, match="Path traversal detected"):
             verify_local_attestation(bundle_path, attest_dir)
 
+    def test_rejects_a_contained_subdirectory_path(self, attest_dir: Path) -> None:
+        """Even a name that stays inside the directory is refused if it descends.
+
+        Containment is decided from the name alone, with no filesystem lookup,
+        so it cannot be raced.  That only holds for a single plain component:
+        ``sub/key.pem`` would have to resolve ``sub``, and resolving is the
+        step an attacker gets to interfere with.  The writer emits a bare
+        filename, so nothing legitimate descends.
+        """
+        bundle_path, _ = self._forged_bundle(attest_dir, attest_dir / "sub")
+
+        bundle = json.loads(bundle_path.read_text())
+        bundle["public_key_file"] = "sub/ed25519-public-key.pem"
+        bundle_path.write_text(json.dumps(bundle))
+
+        with pytest.raises(ValueError, match="Path traversal detected"):
+            verify_local_attestation(bundle_path, attest_dir)
+
     def test_accepts_plain_filename_inside_dir(self, attest_dir: Path) -> None:
         """The legitimate shape -- a bare filename -- still verifies."""
         with patch(


### PR DESCRIPTION
# User description
## What

Replace the `str.startswith` guard on the bundle-supplied `public_key_file` in
`verify_local_attestation` with a real path-containment check, and reject
absolute values explicitly.

## Why

`verify_local_attestation` loads the public key it checks the signature against
from a path named inside the attestation bundle. The bundle is untrusted input,
so that field decides which key the verdict is based on.

The guard compared the resolved path to `attestation_dir` with `str.startswith`,
which is a text comparison, not a containment check. With `attestation_dir` at
`/var/lib/bernstein/attest`, a bundle carrying
`public_key_file = "../attest-evil/key.pem"` resolves to
`/var/lib/bernstein/attest-evil/key.pem` and passes the test. Every sibling
directory whose name starts with the allowed directory's name was reachable.

This is a verification bypass, not only an arbitrary key-file read. Confirmed
before fixing: a bundle with a tampered payload, re-signed with an
attacker-generated Ed25519 keypair whose public key sits in the sibling
directory, returned `verify_local_attestation(...) -> True`. After the fix the
same bundle raises `ValueError`.

Separately, an absolute value discards the directory entirely --
`attestation_dir / "/etc/x"` is `/etc/x` -- so absolute paths are now refused on
their own terms rather than relying on where `attestation_dir` happens to live.

## How

```python
attestation_root = attestation_dir.resolve()
pub_key_file = (attestation_dir / raw_key_name).resolve()
if os.path.isabs(raw_key_name) or not pub_key_file.is_relative_to(attestation_root):
    msg = f"Path traversal detected in public_key_file: {raw_key_name!r}"
    raise ValueError(msg)
```

- `Path.is_relative_to()` compares path components instead of characters.
- `os.path.isabs` rejects absolute values; `os` is already imported at module
  scope, while `Path` is imported only under `TYPE_CHECKING` in this module.
- Both sides are resolved, so a symlink inside the directory pointing outside it
  is caught as well.
- The `ValueError` and its message are unchanged, so callers are unaffected.

No behaviour change for legitimate bundles: the writer stores `pub_path.name`, a
bare filename that is neither absolute nor traversing. A test pins that.

### Tests

New `TestVerifyPublicKeyContainment` in `tests/unit/test_sigstore_attestation.py`.
Each rejection case forges a bundle end to end with an attacker keypair, so the
containment check is the only thing between the forgery and a `True` verdict.

| Case | Behaviour before this PR |
|---|---|
| sibling directory `../attestations-evil/...` | accepted -- forged bundle verified `True` |
| absolute path resolving inside the directory | accepted |
| absolute path outside the directory | already rejected; kept as a regression pin |
| plain contained filename still verifies | already passing; pins no regression |

The first two failed against the old guard before the fix was written.

### Note for reviewers

`tests/unit/test_sigstore_attestation_verify.py` covers a different module
(`core/distribution/sigstore_attestation_verify.py`), so nothing was added
there. It was run regardless and passes.

This branch is cut from `main`. `fix/2980-mypy-security` rewrites the
`load_pem_public_key` line immediately below this guard, so expect a small
adjacent-line conflict between the two branches.

## Checklist

- [x] `uv run ruff check src/` passes
- [ ] `uv run pyright src/` passes -- ran on the changed module only:
      23 errors, byte-identical to the `main` baseline for the same file, all on
      the pre-existing `public_key.verify` union-attribute issue that
      `fix/2980-mypy-security` addresses. None in the changed range.
- [ ] `uv run python scripts/run_tests.py -x` passes -- full suite not run
      locally. Ran the affected files instead: `test_sigstore_attestation.py`
      and `test_sigstore_attestation_verify.py` (36 passed), plus the three
      other files importing the module -- `test_lineage_v2_properties.py`,
      `test_self_update_cmd.py`, `test_update_advisory.py` (115 passed).
      Leaving this to CI.
- [x] New code has type hints

### Documentation duty

The `public_key_file` contract did change, so the earlier N/A on docs was
wrong and is corrected here.

- [x] Bundle contract documented -- accepted values, which shapes raise
      `ValueError` against which raise `OSError`, and where the symlink
      guarantee weakens on platforms without an atomic no-follow open.
      Recorded in the `sigstore_attestation.py` module docstring under
      "Local bundle contract".
- [x] `src/bernstein/core/security/AGENTS.md` -- added the module to the key
      files table and the containment rule to Invariants, including why a
      path-comparison check must not be reintroduced.
- [x] User-visible README section updated (N/A -- no user-visible surface
      change; the contract is a producer/consumer detail of the bundle)
- [x] `docs/operations/<area>.md` updated (N/A -- no operator workflow change)
- [x] `docs/api/` schema regenerated if a public surface changed (N/A --
      function signature and raised exception types unchanged)
- [x] `uv run bernstein agents-md sync` run -- produced no drift; the
      generated surfaces already agree.
- [x] Tests cover the documented behaviour

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Harden <code>verify_local_attestation</code> against attacker-controlled <code>public_key_file</code> paths by enforcing single-component containment and safely reading the key relative to <code>attestation_dir</code>. Document the local bundle contract and add forged-bundle, symlink, file-type, and regression tests.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3494?tool=ast&topic=Key+path+containment>Key path containment</a>
        </td><td>Prevent untrusted attestation bundles from redirecting signature verification to sibling, absolute, nested, symlinked, or non-regular key files while preserving legitimate bare-filename verification.<details><summary>Modified files (2)</summary><ul><li>src/bernstein/core/security/sigstore_attestation.py</li>
<li>tests/unit/test_sigstore_attestation.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>fix(security): require...</td><td>August 09, 2026</td></tr>
<tr><td>chernistry</td><td>refactor: bulk refurb ...</td><td>May 20, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3494?tool=ast&topic=Bundle+contract>Bundle contract</a>
        </td><td>Document the local attestation bundle restrictions, anchored key-read guarantees, platform limitations, and security invariant for future maintainers.<details><summary>Modified files (2)</summary><ul><li>src/bernstein/core/security/AGENTS.md</li>
<li>src/bernstein/core/security/sigstore_attestation.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>fix(security): require...</td><td>August 09, 2026</td></tr>
<tr><td>chernistry</td><td>docs: add per-director...</td><td>August 03, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3494?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>