### PR TITLE
fix(types): resolve the core/orchestration mypy backlog, and fix the cron-trigger defect it surfaced

### DIFF
--- a/docs/substrate/claude-code.md
+++ b/docs/substrate/claude-code.md
@@ -103,3 +103,10 @@ created during install.
   reports an error rather than overwriting it.
 - `bernstein init` may also write `.claude/mcp.json` for orchestration
   auto-discovery; the two mechanisms are independent and can coexist.
+- `.claude/mcp.json` is only edited where its shape is understood. A file
+  whose root is not a JSON object, or whose `mcpServers` is not a map,
+  carries nothing either command can act on: `bernstein init` starts from
+  an empty configuration and writes its own entry, and `bernstein stop`
+  treats the file as having nothing to remove and leaves it byte-for-byte
+  alone. Neither command fails on such a file, and neither discards
+  top-level keys it did not write.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,6 +192,12 @@ dev = [
     # initialised when BERNSTEIN_TELEMETRY_DSN is set. Kept in dev so the
     # test-suite can exercise the no-op + initialised paths.
     "sentry-sdk[fastapi]>=2.20",
+    # Cron expression parser. Optional at runtime - trigger_manager imports it
+    # inside try/except ImportError and yields no events without it - but
+    # required here so the cron-evaluation regression tests execute instead of
+    # being skipped by importorskip. types-croniter below stubs the same
+    # library for mypy.
+    "croniter>=6.0",
     # NOTE: semgrep is intentionally NOT a dev dep. Its transitive pins
     # (click<8.2, opentelemetry-sdk<1.38) collide with our production
     # floors (click>=8.3.3, opentelemetry-sdk>=1.41.1). Install via
@@ -950,6 +956,10 @@ dev = [
     # error sink. Mirror of [project.optional-dependencies].dev; the lazy
     # init in src/bernstein/cli/main.py keeps no-op installs free.
     "sentry-sdk[fastapi]>=2.20",
+    # Cron expression parser. Mirror of [project.optional-dependencies].dev;
+    # optional at runtime, required here so the cron-evaluation tests in
+    # tests/unit/test_trigger_manager.py run rather than importorskip out.
+    "croniter>=6.0",
     # semgrep installed via `uv tool install semgrep` in CI - pins
     # click<8.2 and opentelemetry-sdk<1.38, conflicts with our
     # click>=8.3.3 / opentelemetry-sdk>=1.41.1 floors. Mirror of

--- a/src/bernstein/cli/commands/stop_cmd.py
+++ b/src/bernstein/cli/commands/stop_cmd.py
@@ -92,8 +92,16 @@ def _unregister_mcp_discovery(workdir: Path) -> None:
         data = json.loads(mcp_path.read_text())
     except (ValueError, OSError):
         return
-    servers = data.get("mcpServers", {})
-    if "bernstein" not in servers:
+    # A valid JSON document need not be an object, and mcpServers need not be
+    # a map: null, lists, strings and scalars all decode cleanly and would then
+    # raise from .get(), the membership test, or .pop() - outside the
+    # suppress(OSError) below. Shutdown has nothing to clean up in any of those
+    # shapes, so treat them as a no-op and leave the file untouched rather than
+    # rewriting something this command did not create.
+    if not isinstance(data, dict):
+        return
+    servers = data.get("mcpServers")
+    if not isinstance(servers, dict) or "bernstein" not in servers:
         return
     servers.pop("bernstein")
     data["mcpServers"] = servers

--- a/src/bernstein/core/orchestration/AGENTS.md
+++ b/src/bernstein/core/orchestration/AGENTS.md
@@ -13,6 +13,7 @@ model calls belong to workers, never to coordination decisions.
 | `run_stall.py` | Pure decision function for zero-terminal run quiescence |
 | `deterministic.py` | Seeded-run LLM record/replay via `.sdd/runs/` journals |
 | `escalation.py` | Journal-anchored, Ed25519-signed stall escalation receipts |
+| `trigger_manager.py` | Evaluates `triggers.yaml` rules into `TriggerEvent`s (event and cron sources) |
 | `worker.py` | `bernstein-worker` process wrapper for spawned CLI agents |
 
 Heavy lifting lives in sibling packages: `../tasks/task_lifecycle.py`
@@ -31,6 +32,13 @@ crash detection, reaping).
   (`deterministic.py`).
 - Prefer pure decision functions (`run_stall.py` is the model) so a
   criterion is testable without a tick loop, server, or real clock.
+- Optional third-party imports degrade to a no-op instead of raising;
+  `trigger_manager.py` yields no events when `croniter` is absent.
+- Operator-supplied config is validated per item inside the loop that
+  consumes it, so one malformed entry is logged and skipped rather than
+  aborting the whole pass. Catch the errors the library actually raises:
+  a bad cron schedule reaches `croniter` as `TypeError` or
+  `AttributeError` as readily as `ValueError`.
 
 ## Testing
 

--- a/src/bernstein/core/orchestration/activity_modalities.py
+++ b/src/bernstein/core/orchestration/activity_modalities.py
@@ -629,7 +629,13 @@ class _SignedArtifactActivity(_ObservationCollector):
             signer_public_key_pem=self._public_key_pem,
         )
 
-    def finish(
+    # Deliberately narrower than the base: this modality *derives* its artifact
+    # from the signed receipt rather than accepting one, so it drops the base's
+    # ``artifact`` keyword. That makes it non-substitutable for a bare
+    # _ObservationCollector -- callers must hold the concrete subclass. Widening
+    # it back would change the call contract, so the divergence is suppressed
+    # here rather than papered over.
+    def finish(  # type: ignore[override]
         self,
         *,
         terminal_state: TerminalState = TerminalState.COMPLETED,

--- a/src/bernstein/core/orchestration/bootstrap.py
+++ b/src/bernstein/core/orchestration/bootstrap.py
@@ -181,7 +181,9 @@ def _register_mcp_discovery(workdir: Path) -> None:
         except (ValueError, OSError):
             existing = {}
 
-    servers = dict(existing.get("mcpServers", {}))  # type: ignore[arg-type]
+    # JSON value is `object`; the runtime shape is checked by the isinstance
+    # guards below rather than by the constructor.
+    servers = dict(existing.get("mcpServers", {}))  # type: ignore[call-overload]
     desired_args = ["-m", "bernstein.mcp.server"]
 
     # Self-heal only when the entry is missing or stale. The bernstein entry is

--- a/src/bernstein/core/orchestration/bootstrap.py
+++ b/src/bernstein/core/orchestration/bootstrap.py
@@ -177,13 +177,19 @@ def _register_mcp_discovery(workdir: Path) -> None:
     existing: dict[str, object] = {}
     if mcp_path.exists():
         try:
-            existing = _json.loads(mcp_path.read_text())
+            loaded = _json.loads(mcp_path.read_text())
         except (ValueError, OSError):
-            existing = {}
+            loaded = None
+        # A valid JSON document need not be an object: null, a list, a string,
+        # and scalars all decode cleanly and would then fail on .get() below,
+        # outside the suppress(OSError) both call sites wrap this in.
+        if isinstance(loaded, dict):
+            existing = loaded
 
-    # JSON value is `object`; the runtime shape is checked by the isinstance
-    # guards below rather than by the constructor.
-    servers = dict(existing.get("mcpServers", {}))  # type: ignore[call-overload]
+    raw_servers = existing.get("mcpServers")
+    # dict() also accepts a list of pairs, which would smuggle entries in from
+    # a shape that is not a server map. Require a real object.
+    servers: dict[str, object] = dict(raw_servers) if isinstance(raw_servers, dict) else {}
     desired_args = ["-m", "bernstein.mcp.server"]
 
     # Self-heal only when the entry is missing or stale. The bernstein entry is

--- a/src/bernstein/core/orchestration/commit_completion.py
+++ b/src/bernstein/core/orchestration/commit_completion.py
@@ -85,7 +85,10 @@ class RetryLifecycleEmitter(Protocol):
     CLI scripts, doc generators).
     """
 
-    def __call__(self, payload: dict[str, object]) -> None: ...
+    # Positional-only: every emitter is invoked positionally, and binding the
+    # parameter by name would reject implementations that spell it differently
+    # (the module's own ``_noop_emitter`` names it ``_payload``).
+    def __call__(self, payload: dict[str, object], /) -> None: ...
 
 
 def _noop_emitter(_payload: dict[str, object]) -> None:

--- a/src/bernstein/core/orchestration/drain.py
+++ b/src/bernstein/core/orchestration/drain.py
@@ -424,10 +424,11 @@ class DrainCoordinator:
         while remaining and time.monotonic() < deadline:
             self._poll_agent_statuses(remaining)
             remaining = [a for a in self._agents if a.status == "running"]
-            exited = [a for a in self._agents if a.status == "exited"]
+            exited_agents = [a for a in self._agents if a.status == "exited"]
             elapsed = self._config.wait_timeout_s - (deadline - time.monotonic())
             phase.detail = (
-                f"{len(exited)} exited, {len(remaining)} waiting ({int(elapsed)}s/{self._config.wait_timeout_s}s)"
+                f"{len(exited_agents)} exited, {len(remaining)} waiting "
+                f"({int(elapsed)}s/{self._config.wait_timeout_s}s)"
             )
             if self._callback is not None:
                 self._callback(phase, self._agents)

--- a/src/bernstein/core/orchestration/drain_merge.py
+++ b/src/bernstein/core/orchestration/drain_merge.py
@@ -141,7 +141,9 @@ def _parse_report(stdout: str) -> list[MergeResult]:
                 MergeResult(
                     branch=str(item.get("branch", "")),
                     action=str(item.get("action", "skipped")),
-                    files_changed=int(item.get("files_changed", 0)),  # type: ignore[arg-type]
+                    # JSON value is `object`; a non-numeric one raises here and is
+                    # caught by the enclosing `except (TypeError, ValueError)`.
+                    files_changed=int(item.get("files_changed", 0)),  # type: ignore[call-overload]
                     reason=str(item.get("reason", "")),
                 )
             )

--- a/src/bernstein/core/orchestration/multi_cell.py
+++ b/src/bernstein/core/orchestration/multi_cell.py
@@ -15,7 +15,6 @@ from typing import TYPE_CHECKING
 import httpx
 
 from bernstein.core.bulletin import BulletinBoard, BulletinMessage, SignalActionFailure
-from bernstein.core.lifecycle import transition_agent
 from bernstein.core.models import (
     AgentSession,
     Cell,
@@ -26,6 +25,7 @@ from bernstein.core.models import (
     TaskStatus,
 )
 from bernstein.core.orchestration.orchestrator import TickResult, group_by_role
+from bernstein.core.tasks.lifecycle import transition_agent
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -493,12 +493,13 @@ class Orchestrator:
         init_telemetry(config.telemetry.otlp_endpoint if hasattr(config, "telemetry") else None)
 
         # Self-evolution feedback loop
+        self._evolution: EvolutionCoordinator | None
         if config.evolution_enabled:
             self._evolution = evolution or EvolutionCoordinator(
                 state_dir=workdir / ".sdd",
             )
         else:
-            self._evolution: EvolutionCoordinator | None = None
+            self._evolution = None
 
         # Adaptive governance: adjusts metric weights each evolution cycle.
         # Always initialize the governor - it's lightweight and evolve mode
@@ -721,6 +722,7 @@ class Orchestrator:
         # held for interactive review, or pushed as a GitHub PR.
         # merge_strategy="pr" activates PR mode by default; "direct" forces auto.
         # An explicit approval override ("review" or "pr") takes precedence.
+        self._approval_gate: ApprovalGate | None
         if config.approval == "workflow":
             self._approval_gate = ApprovalGate(
                 mode=ApprovalMode.AUTO,  # base mode, overridden per-task in task_completion.py
@@ -737,7 +739,7 @@ class Orchestrator:
                 # merge_strategy="pr" (default) -> PR mode
                 _effective_approval = "pr"
             _approval_mode = ApprovalMode(_effective_approval)
-            self._approval_gate: ApprovalGate | None = (
+            self._approval_gate = (
                 ApprovalGate(
                     mode=_approval_mode,
                     workdir=workdir,
@@ -890,7 +892,7 @@ class Orchestrator:
         )
         if self._audit_mode:
             from bernstein.core.audit import AuditLog
-            from bernstein.core.lifecycle import set_audit_log
+            from bernstein.core.tasks.lifecycle import set_audit_log
 
             audit_dir = workdir / ".sdd" / "audit"
             self._audit_log = AuditLog(audit_dir)
@@ -3550,7 +3552,7 @@ class Orchestrator:
         """Dispatch an anomaly signal: log, stop spawning, or kill agent."""
         import contextlib
 
-        from bernstein.core import heartbeat as heartbeat_protocol
+        from bernstein.core.agents import heartbeat as heartbeat_protocol
         from bernstein.core.cost_anomaly import AnomalySignal
 
         assert isinstance(signal, AnomalySignal)
@@ -3841,11 +3843,11 @@ class Orchestrator:
         # _reap_session_heartbeat_loop / Defect-10) so the loop does not
         # outlive the agent it was monitoring.
         with contextlib.suppress(Exception):
-            from bernstein.core import heartbeat as heartbeat_protocol
+            from bernstein.core.agents import heartbeat as heartbeat_protocol
 
             heartbeat_protocol._reap_session_heartbeat_loop(self, session, reason="cost_cap_kill")
 
-        from bernstein.core.lifecycle import transition_agent
+        from bernstein.core.tasks.lifecycle import transition_agent
 
         transition_agent(session, "dead", actor="orchestrator", reason="max_cost_per_agent exceeded")
         self._release_file_ownership(session.id)
@@ -3950,7 +3952,7 @@ class Orchestrator:
             elapsed,
             len(pending_kill),
         )
-        from bernstein.core import heartbeat as heartbeat_protocol
+        from bernstein.core.agents import heartbeat as heartbeat_protocol
 
         for session in pending_kill:
             self._budget_stop_killed_agents.add(session.id)

--- a/src/bernstein/core/orchestration/orchestrator_backlog.py
+++ b/src/bernstein/core/orchestration/orchestrator_backlog.py
@@ -63,7 +63,8 @@ def _ensure_ingested_titles(orch: Any) -> set[str]:
         Set of lowered, stripped task titles already on the server.
     """
     if not hasattr(orch, "_ingested_titles"):
-        orch._ingested_titles: set[str] = set()
+        ingested: set[str] = set()
+        orch._ingested_titles = ingested
         with contextlib.suppress(Exception):
             resp = orch._client.get(f"{orch._config.server_url}/tasks")
             resp.raise_for_status()

--- a/src/bernstein/core/orchestration/run_changelog.py
+++ b/src/bernstein/core/orchestration/run_changelog.py
@@ -183,7 +183,8 @@ def _parse_metric_timestamp(ts: object) -> float:
 
         dt = datetime.datetime.fromisoformat(ts.replace("Z", "+00:00"))
         return dt.timestamp()
-    return float(ts)
+    # `ts` is an arbitrary JSON value; a non-numeric one is meant to raise.
+    return float(ts)  # type: ignore[arg-type]
 
 
 def _parse_metric_line(line: str, since_ts: float) -> dict[str, object] | None:

--- a/src/bernstein/core/orchestration/tick_pipeline.py
+++ b/src/bernstein/core/orchestration/tick_pipeline.py
@@ -396,7 +396,7 @@ def prioritize_starving_roles(
 
 def _build_file_affinity_groups(
     role_tasks: list[Task],
-    agent_affinity: dict[str, str] | None,
+    agent_affinity: dict[str, str],
 ) -> list[list[Task]]:
     """Group tasks by transitive file-ownership overlap.
 
@@ -432,7 +432,7 @@ def _build_file_affinity_groups(
 
 def _merge_agent_affinity_groups(
     affinity_groups: list[list[Task]],
-    agent_affinity: dict[str, str] | None,
+    agent_affinity: dict[str, str],
 ) -> None:
     """Merge affinity groups that share a preferred agent (in-place).
 
@@ -464,7 +464,7 @@ def _merge_agent_affinity_groups(
 def _pack_affinity_groups_into_batches(
     affinity_groups: list[list[Task]],
     max_per_batch: int,
-    agent_affinity: dict[str, str] | None,
+    agent_affinity: dict[str, str],
 ) -> list[list[Task]]:
     """Pack affinity groups into batches of up to max_per_batch tasks.
 

--- a/src/bernstein/core/orchestration/trigger_manager.py
+++ b/src/bernstein/core/orchestration/trigger_manager.py
@@ -100,6 +100,10 @@ def load_trigger_configs(path: Path) -> list[TriggerConfig]:
         if not isinstance(raw, dict) or "name" not in raw or "source" not in raw:
             logger.warning("Skipping malformed trigger entry: %r", raw)
             continue
+        # The evaluator skips these on a falsy check every tick, which is silent.
+        # Say so once, at load, so an operator learns the trigger is inert.
+        if raw["source"] == "cron" and not raw.get("schedule"):
+            logger.warning("Cron trigger %r has no usable schedule and will never fire", raw["name"])
         task_raw = raw.get("task", {})
         configs.append(
             TriggerConfig(
@@ -794,9 +798,16 @@ class TriggerManager:
             )
             events.append(event)
 
-            # Mark as fired for this minute
+            # Mark as fired for this minute. The in-memory entry is what
+            # suppresses a re-fire on the next tick; the file only carries that
+            # across a restart, so a failed write must not abort the pass and
+            # strand the triggers after this one. _save_cron_state rewrites the
+            # whole map, so the next tick retries the entries that did not land.
             self._cron_state[trigger.name] = current_minute
-            self._save_cron_state()
+            try:
+                self._save_cron_state()
+            except OSError as exc:
+                logger.error("Could not persist cron state for trigger %s: %s", trigger.name, exc)
 
         return events
 

--- a/src/bernstein/core/orchestration/trigger_manager.py
+++ b/src/bernstein/core/orchestration/trigger_manager.py
@@ -533,10 +533,27 @@ class TriggerManager:
             try:
                 with path.open() as f:
                     data = json.load(f)
-                self._cron_state = {k: v.get("last_fire_minute", "") for k, v in data.items()}
             except (json.JSONDecodeError, OSError):
                 logger.warning("Corrupt cron state, treating as empty")
                 self._cron_state = {}
+                return
+            # Valid JSON of the wrong shape decodes cleanly, so the guard above
+            # does not fire and .items()/.get() would raise out of __init__ -
+            # taking down every command that builds a TriggerManager. Keep the
+            # entries that parse: discarding the whole map re-fires every
+            # trigger already recorded for this minute.
+            if not isinstance(data, dict):
+                logger.warning("Cron state is not an object, treating as empty")
+                self._cron_state = {}
+                return
+            state: dict[str, str] = {}
+            for key, value in data.items():
+                minute = value.get("last_fire_minute", "") if isinstance(value, dict) else None
+                if not isinstance(key, str) or not isinstance(minute, str):
+                    logger.warning("Dropping unreadable cron state entry %r", key)
+                    continue
+                state[key] = minute
+            self._cron_state = state
 
     def _save_cron_state(self) -> None:
         path = self._runtime_dir / "cron_state.json"

--- a/src/bernstein/core/orchestration/trigger_manager.py
+++ b/src/bernstein/core/orchestration/trigger_manager.py
@@ -12,6 +12,7 @@ import fnmatch
 import hashlib
 import json
 import logging
+import os
 import re
 import time
 from dataclasses import asdict
@@ -100,10 +101,24 @@ def load_trigger_configs(path: Path) -> list[TriggerConfig]:
         if not isinstance(raw, dict) or "name" not in raw or "source" not in raw:
             logger.warning("Skipping malformed trigger entry: %r", raw)
             continue
-        # The evaluator skips these on a falsy check every tick, which is silent.
-        # Say so once, at load, so an operator learns the trigger is inert.
-        if raw["source"] == "cron" and not raw.get("schedule"):
-            logger.warning("Cron trigger %r has no usable schedule and will never fire", raw["name"])
+        # TriggerConfig.schedule is str | None, but YAML hands back whatever was
+        # written: `schedule: 30` unquoted arrives as an int and used to be
+        # carried in unchecked, making the declared type a fiction and deferring
+        # the failure to croniter. Drop non-strings here so the dataclass tells
+        # the truth. Syntax is still the evaluator's business - validating it
+        # needs croniter, which is optional.
+        schedule = raw.get("schedule")
+        if raw["source"] == "cron":
+            if schedule is not None and not isinstance(schedule, str):
+                logger.warning(
+                    "Cron trigger %r has a %s schedule, not a string; it will never fire",
+                    raw["name"],
+                    type(schedule).__name__,
+                )
+                schedule = None
+            elif not schedule:
+                # The evaluator skips these on a falsy check every tick, silently.
+                logger.warning("Cron trigger %r has no usable schedule and will never fire", raw["name"])
         task_raw = raw.get("task", {})
         configs.append(
             TriggerConfig(
@@ -113,7 +128,7 @@ def load_trigger_configs(path: Path) -> list[TriggerConfig]:
                 filters=dict(raw.get("filters", {})),
                 conditions=dict(raw.get("conditions", {})),
                 task=_parse_task_template(task_raw),
-                schedule=raw.get("schedule"),
+                schedule=schedule,
             )
         )
     return configs
@@ -514,8 +529,19 @@ class TriggerManager:
     def _save_cron_state(self) -> None:
         path = self._runtime_dir / "cron_state.json"
         data = {k: {"last_fire_minute": v, "last_fired": time.time()} for k, v in self._cron_state.items()}
-        with path.open("w") as f:
-            json.dump(data, f)
+        # Write to a sibling and rename over the target. Opening the real file
+        # "w" truncates it before the content lands, and _load_cron_state reads
+        # a corrupt file as empty state - so an interrupted write did not lose
+        # one entry, it replayed every cron trigger on the next start.
+        tmp = path.with_name(path.name + ".tmp")
+        try:
+            with tmp.open("w") as f:
+                json.dump(data, f)
+                f.flush()
+                os.fsync(f.fileno())
+            tmp.replace(path)
+        finally:
+            tmp.unlink(missing_ok=True)
 
     # -- Fire log -----------------------------------------------------------
 

--- a/src/bernstein/core/orchestration/trigger_manager.py
+++ b/src/bernstein/core/orchestration/trigger_manager.py
@@ -772,14 +772,16 @@ class TriggerManager:
                 continue
 
             try:
-                cron = croniter(trigger.schedule, time.localtime(now))
+                # croniter accepts a Unix timestamp, a datetime, or None - not a
+                # struct_time. ``now`` is already a float epoch, so pass it as-is.
+                cron = croniter(trigger.schedule, now)
                 # Check if the current minute matches the schedule
                 prev_fire = cron.get_prev(float)
                 # If the previous fire time is within this minute, fire
                 prev_minute = time.strftime("%Y-%m-%dT%H:%M", time.localtime(prev_fire))
                 if prev_minute != current_minute:
                     continue
-            except (ValueError, KeyError) as exc:
+            except (ValueError, KeyError, TypeError, AttributeError) as exc:
                 logger.error("Invalid cron expression for trigger %s: %s", trigger.name, exc)
                 continue
 

--- a/src/bernstein/core/orchestration/trigger_manager.py
+++ b/src/bernstein/core/orchestration/trigger_manager.py
@@ -833,6 +833,7 @@ class TriggerManager:
         events: list[TriggerEvent] = []
         now = time.time()
         current_minute = time.strftime("%Y-%m-%dT%H:%M", time.localtime(now))
+        next_minute = now - (now % 60) + 60.0
 
         for trigger in self._configs:
             if not trigger.enabled or trigger.source != "cron" or not trigger.schedule:
@@ -843,10 +844,16 @@ class TriggerManager:
                 continue
 
             try:
-                # croniter accepts a Unix timestamp, a datetime, or None - not a
-                # struct_time. ``now`` is already a float epoch, so pass it as-is.
-                cron = croniter(trigger.schedule, now)
-                # Check if the current minute matches the schedule
+                # croniter accepts a Unix timestamp, a datetime, or None - not
+                # a struct_time; ``now`` is already a float epoch.
+                #
+                # Anchor on the start of the *next* minute, not on ``now``.
+                # get_prev is strictly-before its anchor, so anchoring on now
+                # returns the previous minute whenever a tick lands exactly on
+                # HH:MM:00, silently skipping a trigger due that minute. Cron
+                # fires land on minute boundaries, so the last fire before the
+                # next minute is this minute's if the schedule matches at all.
+                cron = croniter(trigger.schedule, next_minute)
                 prev_fire = cron.get_prev(float)
                 # If the previous fire time is within this minute, fire
                 prev_minute = time.strftime("%Y-%m-%dT%H:%M", time.localtime(prev_fire))

--- a/src/bernstein/core/orchestration/trigger_manager.py
+++ b/src/bernstein/core/orchestration/trigger_manager.py
@@ -8,12 +8,14 @@ limits), and creates tasks on the task server.
 
 from __future__ import annotations
 
+import contextlib
 import fnmatch
 import hashlib
 import json
 import logging
 import os
 import re
+import tempfile
 import time
 from dataclasses import asdict
 from typing import TYPE_CHECKING, Any
@@ -100,6 +102,16 @@ def load_trigger_configs(path: Path) -> list[TriggerConfig]:
     for raw in data["triggers"]:
         if not isinstance(raw, dict) or "name" not in raw or "source" not in raw:
             logger.warning("Skipping malformed trigger entry: %r", raw)
+            continue
+        # Presence is not type. Both fields are load-bearing: name is joined
+        # into the dedup key, where a non-string raises, and source is only
+        # ever compared against string literals, so a non-string one loads
+        # clean and is silently inert.
+        if not isinstance(raw["name"], str) or not raw["name"]:
+            logger.warning("Skipping trigger entry with a non-string or empty name: %r", raw["name"])
+            continue
+        if not isinstance(raw["source"], str) or not raw["source"]:
+            logger.warning("Skipping trigger %r: source must be a non-empty string, got %r", raw["name"], raw["source"])
             continue
         # TriggerConfig.schedule is str | None, but YAML hands back whatever was
         # written: `schedule: 30` unquoted arrives as an int and used to be
@@ -529,19 +541,27 @@ class TriggerManager:
     def _save_cron_state(self) -> None:
         path = self._runtime_dir / "cron_state.json"
         data = {k: {"last_fire_minute": v, "last_fired": time.time()} for k, v in self._cron_state.items()}
-        # Write to a sibling and rename over the target. Opening the real file
-        # "w" truncates it before the content lands, and _load_cron_state reads
-        # a corrupt file as empty state - so an interrupted write did not lose
-        # one entry, it replayed every cron trigger on the next start.
-        tmp = path.with_name(path.name + ".tmp")
+        # Write to a scratch sibling and rename over the target. Opening the
+        # real file "w" truncates it before the content lands, and
+        # _load_cron_state reads a corrupt file as empty state - so an
+        # interrupted write did not lose one entry, it replayed every cron
+        # trigger on the next start.
+        #
+        # mkstemp rather than a fixed ".tmp" name: the name is unique per
+        # writer, so two managers on one runtime dir cannot interleave inside
+        # a single scratch file, and it is created O_EXCL at 0o600, so an
+        # existing path cannot capture the write and the mode carries over to
+        # cron_state.json through the rename.
+        fd, tmp_name = tempfile.mkstemp(dir=self._runtime_dir, prefix="cron_state.", suffix=".tmp")
         try:
-            with tmp.open("w") as f:
+            with os.fdopen(fd, "w") as f:
                 json.dump(data, f)
                 f.flush()
                 os.fsync(f.fileno())
-            tmp.replace(path)
+            os.replace(tmp_name, path)
         finally:
-            tmp.unlink(missing_ok=True)
+            with contextlib.suppress(FileNotFoundError):
+                os.unlink(tmp_name)
 
     # -- Fire log -----------------------------------------------------------
 

--- a/src/bernstein/core/orchestration/trigger_manager.py
+++ b/src/bernstein/core/orchestration/trigger_manager.py
@@ -9,6 +9,7 @@ limits), and creates tasks on the task server.
 from __future__ import annotations
 
 import contextlib
+import datetime
 import fnmatch
 import hashlib
 import json
@@ -833,7 +834,6 @@ class TriggerManager:
         events: list[TriggerEvent] = []
         now = time.time()
         current_minute = time.strftime("%Y-%m-%dT%H:%M", time.localtime(now))
-        next_minute = now - (now % 60) + 60.0
 
         for trigger in self._configs:
             if not trigger.enabled or trigger.source != "cron" or not trigger.schedule:
@@ -846,18 +846,20 @@ class TriggerManager:
             try:
                 # croniter accepts a Unix timestamp, a datetime, or None - not
                 # a struct_time; ``now`` is already a float epoch.
-                #
-                # Anchor on the start of the *next* minute, not on ``now``.
-                # get_prev is strictly-before its anchor, so anchoring on now
-                # returns the previous minute whenever a tick lands exactly on
-                # HH:MM:00, silently skipping a trigger due that minute. Cron
-                # fires land on minute boundaries, so the last fire before the
-                # next minute is this minute's if the schedule matches at all.
-                cron = croniter(trigger.schedule, next_minute)
+                cron = croniter(trigger.schedule, now)
                 prev_fire = cron.get_prev(float)
                 # If the previous fire time is within this minute, fire
                 prev_minute = time.strftime("%Y-%m-%dT%H:%M", time.localtime(prev_fire))
-                if prev_minute != current_minute:
+                # get_prev is strictly-before its anchor, so a tick landing
+                # exactly on a fire instant reports the fire *before* it and the
+                # schedule reads as not due. match() answers that one instant.
+                # It is consulted only after get_prev has already said "not
+                # due", so it can add a fire and never suppress one - and it
+                # leaves a sub-minute schedule's phase alone, which anchoring
+                # the search on the next minute would not.
+                if prev_minute != current_minute and not croniter.match(
+                    trigger.schedule, datetime.datetime.fromtimestamp(now)
+                ):
                     continue
             except (ValueError, KeyError, TypeError, AttributeError) as exc:
                 logger.error("Invalid cron expression for trigger %s: %s", trigger.name, exc)

--- a/src/bernstein/core/orchestration/trigger_manager.py
+++ b/src/bernstein/core/orchestration/trigger_manager.py
@@ -412,6 +412,10 @@ class TriggerManager:
 
         # Cron state: {trigger_name: last_fire_minute}
         self._cron_state: dict[str, str] = {}
+        # Set when _cron_state has changes that are not on disk yet, so a
+        # dropped write is retried on the next pass rather than waiting for
+        # the next fire (the same-minute dedup skips before the write).
+        self._cron_state_dirty = False
 
         # Load persisted state
         self._load_dedup_cache()
@@ -800,16 +804,31 @@ class TriggerManager:
 
             # Mark as fired for this minute. The in-memory entry is what
             # suppresses a re-fire on the next tick; the file only carries that
-            # across a restart, so a failed write must not abort the pass and
-            # strand the triggers after this one. _save_cron_state rewrites the
-            # whole map, so the next tick retries the entries that did not land.
+            # across a restart.
             self._cron_state[trigger.name] = current_minute
-            try:
-                self._save_cron_state()
-            except OSError as exc:
-                logger.error("Could not persist cron state for trigger %s: %s", trigger.name, exc)
+            self._cron_state_dirty = True
 
+        self._flush_cron_state()
         return events
+
+    def _flush_cron_state(self) -> None:
+        """Persist pending cron state, tolerating a failed write.
+
+        Runs once per pass rather than per fire, and unconditionally while
+        state is pending, so a dropped write is retried on the next pass
+        instead of waiting for some trigger to fire again. A write that never
+        lands costs at most a duplicate fire after a restart within the same
+        minute; letting the error escape would strand the whole tick, which is
+        the failure this module already fixed once.
+        """
+        if not self._cron_state_dirty:
+            return
+        try:
+            self._save_cron_state()
+        except OSError as exc:
+            logger.error("Could not persist cron state (will retry next pass): %s", exc)
+            return
+        self._cron_state_dirty = False
 
     # -- Summary for CLI ----------------------------------------------------
 

--- a/tests/unit/test_mcp_discovery.py
+++ b/tests/unit/test_mcp_discovery.py
@@ -168,6 +168,31 @@ def test_unregister_noop_when_bernstein_not_present(tmp_path: Path) -> None:
     assert "other" in data["mcpServers"]
 
 
+@pytest.mark.parametrize("payload", ["null", "[]", '"a string"', "5", "true"])
+def test_unregister_tolerates_non_object_json_root(tmp_path: Path, payload: str) -> None:
+    """Shutdown cleanup must survive the same shapes registration self-heals."""
+    mcp_path = tmp_path / ".claude" / "mcp.json"
+    mcp_path.parent.mkdir(parents=True)
+    mcp_path.write_text(payload)
+
+    _unregister_mcp_discovery(tmp_path)  # must not raise
+
+    assert mcp_path.read_text() == payload, "an unusable file is left untouched"
+
+
+@pytest.mark.parametrize("servers", [None, [], "a string", 5, True, [["bernstein", {}]]])
+def test_unregister_tolerates_malformed_mcpservers(tmp_path: Path, servers: object) -> None:
+    """A non-object ``mcpServers`` is a no-op, not a crash, and is left as-is."""
+    mcp_path = tmp_path / ".claude" / "mcp.json"
+    mcp_path.parent.mkdir(parents=True)
+    original = json.dumps({"otherKey": "keep me", "mcpServers": servers})
+    mcp_path.write_text(original)
+
+    _unregister_mcp_discovery(tmp_path)  # must not raise
+
+    assert mcp_path.read_text() == original
+
+
 def test_register_then_unregister_roundtrip(tmp_path: Path) -> None:
     """register followed by unregister leaves file with no bernstein entry."""
     _register_mcp_discovery(tmp_path)

--- a/tests/unit/test_mcp_discovery.py
+++ b/tests/unit/test_mcp_discovery.py
@@ -6,6 +6,7 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
 from bernstein.cli.stop_cmd import _unregister_mcp_discovery
 from bernstein.core.bootstrap import _register_mcp_discovery
 
@@ -59,6 +60,50 @@ def test_register_tolerates_corrupt_existing_file(tmp_path: Path) -> None:
 
     data = json.loads(mcp_path.read_text())
     assert "bernstein" in data["mcpServers"]
+
+
+@pytest.mark.parametrize("payload", ["null", "[]", '"a string"', "5", "true"])
+def test_register_tolerates_non_object_json_root(tmp_path: Path, payload: str) -> None:
+    """Valid JSON with a non-object root must not abort bootstrap.
+
+    ``json.loads`` succeeds here, so the ``(ValueError, OSError)`` guard above
+    does not fire and the value flows on to ``.get()`` as a non-mapping.
+    """
+    mcp_path = tmp_path / ".claude" / "mcp.json"
+    mcp_path.parent.mkdir(parents=True)
+    mcp_path.write_text(payload)
+
+    _register_mcp_discovery(tmp_path)  # must not raise
+
+    data = json.loads(mcp_path.read_text())
+    assert "bernstein" in data["mcpServers"]
+
+
+@pytest.mark.parametrize("servers", [None, [], "a string", 5, True])
+def test_register_tolerates_malformed_mcpservers(tmp_path: Path, servers: object) -> None:
+    """A non-object ``mcpServers`` is reset without losing the rest of the file."""
+    mcp_path = tmp_path / ".claude" / "mcp.json"
+    mcp_path.parent.mkdir(parents=True)
+    mcp_path.write_text(json.dumps({"otherKey": "keep me", "mcpServers": servers}))
+
+    _register_mcp_discovery(tmp_path)  # must not raise
+
+    data = json.loads(mcp_path.read_text())
+    assert "bernstein" in data["mcpServers"]
+    assert data["otherKey"] == "keep me"
+
+
+def test_register_rejects_pair_list_mcpservers(tmp_path: Path) -> None:
+    """A list of pairs is not a server map, even though ``dict()`` accepts it."""
+    mcp_path = tmp_path / ".claude" / "mcp.json"
+    mcp_path.parent.mkdir(parents=True)
+    mcp_path.write_text(json.dumps({"mcpServers": [["smuggled", {"command": "x"}]]}))
+
+    _register_mcp_discovery(tmp_path)
+
+    data = json.loads(mcp_path.read_text())
+    assert "bernstein" in data["mcpServers"]
+    assert "smuggled" not in data["mcpServers"]
 
 
 def test_register_skips_rewrite_when_command_only_differs(tmp_path: Path) -> None:

--- a/tests/unit/test_trigger_manager.py
+++ b/tests/unit/test_trigger_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -844,6 +845,33 @@ class TestCronEvaluation:
 
         assert len(mgr.evaluate_cron_triggers()) == 1
         assert mgr.evaluate_cron_triggers() == []
+
+    def test_failed_state_write_is_retried_on_a_later_pass(self, sdd_dir: Path) -> None:
+        """A dropped write is retried even when no trigger fires again.
+
+        The same-minute dedup ``continue`` short-circuits before the write, so
+        a pass with nothing new to fire must still flush the pending state or
+        the failure is only repaired by an unrelated trigger firing later.
+        """
+        _write_triggers(sdd_dir, [_cron_trigger("every-minute", "* * * * *")])
+        mgr = TriggerManager(sdd_dir)
+        real_save = mgr._save_cron_state
+        attempts: list[int] = []
+
+        def _flaky() -> None:
+            attempts.append(1)
+            if len(attempts) == 1:
+                raise OSError("read-only filesystem")
+            real_save()
+
+        mgr._save_cron_state = _flaky  # type: ignore[method-assign]
+
+        assert len(mgr.evaluate_cron_triggers()) == 1  # fires; the write fails
+        assert mgr.evaluate_cron_triggers() == []  # nothing new fires
+
+        assert len(attempts) == 2, "the dropped write was never retried"
+        state = json.loads((sdd_dir / "runtime" / "triggers" / "cron_state.json").read_text())
+        assert "every-minute" in state
 
     def test_malformed_schedule_does_not_block_other_triggers(self, sdd_dir: Path) -> None:
         _write_triggers(

--- a/tests/unit/test_trigger_manager.py
+++ b/tests/unit/test_trigger_manager.py
@@ -921,6 +921,29 @@ class TestCronEvaluation:
 
         assert mgr.evaluate_cron_triggers() == []
 
+    @pytest.mark.parametrize(
+        ("offset", "due"), [(0.0, False), (10.0, False), (29.0, False), (30.0, True), (45.0, True)]
+    )
+    def test_sub_minute_schedule_keeps_its_phase(
+        self, sdd_dir: Path, monkeypatch: pytest.MonkeyPatch, offset: float, due: bool
+    ) -> None:
+        """A 6-field schedule fires at the second it names, not at the minute's start.
+
+        croniter's 6-field form puts seconds last, so ``* * * * * 30`` fires at
+        :30 of every minute. Fixing the minute boundary by anchoring the search
+        on the *start of the next minute* would report that fire for any tick in
+        the minute, moving it up to 59s early. The boundary check is a question
+        about ``now`` alone, so it leaves the phase intact.
+        """
+        from bernstein.core.orchestration import trigger_manager as module
+
+        boundary = _FROZEN_NOW - (_FROZEN_NOW % 60)
+        monkeypatch.setattr(module, "time", _FrozenTime(boundary + offset))
+        _write_triggers(sdd_dir, [_cron_trigger("half-past", "* * * * * 30")])
+        mgr = TriggerManager(sdd_dir)
+
+        assert bool(mgr.evaluate_cron_triggers()) is due
+
     def test_trigger_not_due_does_not_fire(self, sdd_dir: Path) -> None:
         off_minute = (time.localtime(_FROZEN_NOW).tm_min + 30) % 60
         _write_triggers(sdd_dir, [_cron_trigger("off-minute", f"{off_minute} * * * *")])

--- a/tests/unit/test_trigger_manager.py
+++ b/tests/unit/test_trigger_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import stat
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -186,6 +187,33 @@ class TestLoadTriggerConfigs:
             yaml.dump({"version": 1}, f)
         with pytest.raises(ValueError, match="triggers"):
             load_trigger_configs(path)
+
+    @pytest.mark.parametrize(("field", "value"), [("name", 42), ("name", ""), ("source", 7), ("source", None)])
+    def test_non_string_name_or_source_is_skipped_at_load(
+        self, sdd_dir: Path, caplog: pytest.LogCaptureFixture, field: str, value: Any
+    ) -> None:
+        """Presence checks are not type checks, and both fields are load-bearing.
+
+        A non-string ``name`` reaches ``compute_dedup_key``, whose ``"|".join``
+        raises TypeError. A non-string ``source`` matches no source string, so
+        the trigger loads clean and is silently inert.
+        """
+        entry: dict[str, Any] = {
+            "name": "ok",
+            "source": "cron",
+            "schedule": "* * * * *",
+            "task": {"title": "t", "role": "qa"},
+        }
+        entry[field] = value
+        path = sdd_dir / "config" / "triggers.yaml"
+        with open(path, "w") as f:
+            yaml.dump({"version": 1, "triggers": [entry]}, f)
+
+        with caplog.at_level("WARNING"):
+            configs = load_trigger_configs(path)
+
+        assert configs == []
+        assert caplog.text
 
     def test_non_string_cron_schedule_is_rejected_at_load(
         self, sdd_dir: Path, caplog: pytest.LogCaptureFixture
@@ -923,6 +951,27 @@ class TestCronEvaluation:
 
         assert state_path.read_text() == good, "the previous state was clobbered"
         assert mgr._cron_state_dirty is True, "a failed write must stay pending"
+        assert self._temp_files(sdd_dir) == [], "a failed write left its scratch file behind"
+
+    @staticmethod
+    def _temp_files(sdd_dir: Path) -> list[str]:
+        runtime = sdd_dir / "runtime" / "triggers"
+        return sorted(p.name for p in runtime.iterdir() if p.name.endswith(".tmp"))
+
+    def test_state_write_is_private_and_leaves_no_scratch_file(self, sdd_dir: Path) -> None:
+        """The scratch file is per-writer and private, and never outlives the write.
+
+        A fixed scratch path is shared by every TriggerManager on the box, so
+        two of them interleave inside one file before either renames it into
+        place.
+        """
+        _write_triggers(sdd_dir, [_cron_trigger("every-minute", "* * * * *")])
+        mgr = TriggerManager(sdd_dir)
+        assert len(mgr.evaluate_cron_triggers()) == 1
+
+        state_path = sdd_dir / "runtime" / "triggers" / "cron_state.json"
+        assert self._temp_files(sdd_dir) == []
+        assert stat.S_IMODE(state_path.stat().st_mode) == 0o600
 
     def test_malformed_schedule_does_not_block_other_triggers(self, sdd_dir: Path) -> None:
         _write_triggers(

--- a/tests/unit/test_trigger_manager.py
+++ b/tests/unit/test_trigger_manager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import stat
 import time
+from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -1005,16 +1006,45 @@ class TestCronEvaluation:
         assert stat.S_IMODE(state_path.stat().st_mode) == 0o600
 
     def test_malformed_schedule_does_not_block_other_triggers(self, sdd_dir: Path) -> None:
+        """A schedule croniter rejects is logged and skipped, not raised."""
         _write_triggers(
             sdd_dir,
             [
                 _cron_trigger("bad-expression", "not a cron expression"),
-                # An unquoted YAML integer reaches croniter as an int, not a str.
+                # Dropped to None by load_trigger_configs, so it is skipped on
+                # the falsy-schedule guard and never reaches croniter. Kept
+                # here because that is the path an operator's YAML takes.
                 _cron_trigger("bad-type", 30),
                 _cron_trigger("every-minute", "* * * * *"),
             ],
         )
         mgr = TriggerManager(sdd_dir)
+
+        events = mgr.evaluate_cron_triggers()
+
+        assert [e.metadata["cron_name"] for e in events] == ["every-minute"]
+
+    def test_non_string_schedule_reaching_croniter_is_skipped_not_raised(self, sdd_dir: Path) -> None:
+        """The evaluator's own guard, exercised on the value croniter chokes on.
+
+        ``load_trigger_configs`` now drops a non-string schedule, so the YAML
+        path no longer reaches croniter with one - but the loader is not the
+        only way ``_configs`` gets populated, and the evaluator documents that
+        it skips a bad entry rather than aborting the pass. croniter answers a
+        non-string with ``AttributeError`` and a struct_time with
+        ``TypeError``; ``except (ValueError, KeyError)`` caught neither, so a
+        single bad entry stranded every trigger behind it.
+        """
+        _write_triggers(sdd_dir, [_cron_trigger("every-minute", "* * * * *")])
+        mgr = TriggerManager(sdd_dir)
+        (good,) = mgr._configs
+        # mtime is unchanged since __init__ loaded it, so _try_reload_config
+        # leaves this in place.
+        mgr._configs = [
+            replace(good, name="int-schedule", schedule=30),  # type: ignore[arg-type]
+            replace(good, name="struct-time-schedule", schedule=time.localtime(_FROZEN_NOW)),  # type: ignore[arg-type]
+            good,
+        ]
 
         events = mgr.evaluate_cron_triggers()
 

--- a/tests/unit/test_trigger_manager.py
+++ b/tests/unit/test_trigger_manager.py
@@ -187,6 +187,26 @@ class TestLoadTriggerConfigs:
         with pytest.raises(ValueError, match="triggers"):
             load_trigger_configs(path)
 
+    def test_non_string_cron_schedule_is_rejected_at_load(
+        self, sdd_dir: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """``TriggerConfig.schedule`` is ``str | None``; YAML must not smuggle an int in.
+
+        ``schedule: 30`` unquoted decodes as an int and was carried into the
+        dataclass unchecked, so the declared type was a fiction and the value
+        only failed much later, inside croniter.
+        """
+        path = sdd_dir / "config" / "triggers.yaml"
+        entry = {"name": "int-schedule", "source": "cron", "schedule": 30, "task": {"title": "t", "role": "qa"}}
+        with open(path, "w") as f:
+            yaml.dump({"version": 1, "triggers": [entry]}, f)
+
+        with caplog.at_level("WARNING"):
+            configs = load_trigger_configs(path)
+
+        assert configs[0].schedule is None
+        assert "int-schedule" in caplog.text
+
     @pytest.mark.parametrize("schedule", [None, "", 0])
     def test_cron_trigger_without_usable_schedule_is_reported(
         self, sdd_dir: Path, caplog: pytest.LogCaptureFixture, schedule: Any
@@ -872,6 +892,37 @@ class TestCronEvaluation:
         assert len(attempts) == 2, "the dropped write was never retried"
         state = json.loads((sdd_dir / "runtime" / "triggers" / "cron_state.json").read_text())
         assert "every-minute" in state
+
+    def test_interrupted_state_write_leaves_the_previous_file_intact(
+        self, sdd_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A half-finished write must not degrade to "no state at all".
+
+        _load_cron_state treats a corrupt file as empty, so a truncating write
+        that dies mid-serialisation would replay every cron fire on restart.
+        """
+        _write_triggers(sdd_dir, [_cron_trigger("every-minute", "* * * * *")])
+        mgr = TriggerManager(sdd_dir)
+        assert len(mgr.evaluate_cron_triggers()) == 1
+
+        state_path = sdd_dir / "runtime" / "triggers" / "cron_state.json"
+        good = state_path.read_text()
+        assert json.loads(good)
+
+        from bernstein.core.orchestration import trigger_manager as module
+
+        def _dump_then_die(obj: Any, fp: Any, *args: Any, **kwargs: Any) -> None:
+            fp.write('{"every-minute": {"last_fire_min')  # truncated on purpose
+            raise OSError("no space left on device")
+
+        monkeypatch.setattr(module.json, "dump", _dump_then_die)
+
+        mgr._cron_state["late-arrival"] = "2023-11-15T00:14"
+        mgr._cron_state_dirty = True
+        mgr._flush_cron_state()
+
+        assert state_path.read_text() == good, "the previous state was clobbered"
+        assert mgr._cron_state_dirty is True, "a failed write must stay pending"
 
     def test_malformed_schedule_does_not_block_other_triggers(self, sdd_dir: Path) -> None:
         _write_triggers(

--- a/tests/unit/test_trigger_manager.py
+++ b/tests/unit/test_trigger_manager.py
@@ -721,6 +721,96 @@ class TestTriggerManager:
 
 
 # ---------------------------------------------------------------------------
+# Cron evaluation tests
+# ---------------------------------------------------------------------------
+
+# A fixed instant 20s into its minute, so the previous fire of an every-minute
+# schedule always lands inside the current minute regardless of local timezone.
+_FROZEN_NOW = 1_700_000_000.0
+
+
+class _FrozenTime:
+    """Stand-in for the ``time`` module with a pinned ``time()``."""
+
+    def __init__(self, now: float) -> None:
+        self._now = now
+
+    def time(self) -> float:
+        return self._now
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(time, name)
+
+
+def _write_triggers(sdd_dir: Path, triggers: list[dict[str, Any]]) -> None:
+    path = sdd_dir / "config" / "triggers.yaml"
+    with open(path, "w") as f:
+        yaml.dump({"version": 1, "triggers": triggers}, f)
+
+
+def _cron_trigger(name: str, schedule: Any) -> dict[str, Any]:
+    return {
+        "name": name,
+        "source": "cron",
+        "enabled": True,
+        "schedule": schedule,
+        "task": {"title": f"{name} ({{date}})", "role": "manager"},
+    }
+
+
+class TestCronEvaluation:
+    """Regression coverage for ``TriggerManager.evaluate_cron_triggers``."""
+
+    @pytest.fixture(autouse=True)
+    def _frozen_clock(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        pytest.importorskip("croniter")
+        from bernstein.core.orchestration import trigger_manager as module
+
+        monkeypatch.setattr(module, "time", _FrozenTime(_FROZEN_NOW))
+
+    def test_due_trigger_fires(self, sdd_dir: Path) -> None:
+        _write_triggers(sdd_dir, [_cron_trigger("every-minute", "* * * * *")])
+        mgr = TriggerManager(sdd_dir)
+
+        events = mgr.evaluate_cron_triggers()
+
+        assert len(events) == 1
+        assert events[0].source == "cron"
+        assert events[0].metadata["cron_name"] == "every-minute"
+        assert events[0].timestamp == _FROZEN_NOW
+
+    def test_trigger_not_due_does_not_fire(self, sdd_dir: Path) -> None:
+        off_minute = (time.localtime(_FROZEN_NOW).tm_min + 30) % 60
+        _write_triggers(sdd_dir, [_cron_trigger("off-minute", f"{off_minute} * * * *")])
+        mgr = TriggerManager(sdd_dir)
+
+        assert mgr.evaluate_cron_triggers() == []
+
+    def test_does_not_refire_within_the_same_minute(self, sdd_dir: Path) -> None:
+        _write_triggers(sdd_dir, [_cron_trigger("every-minute", "* * * * *")])
+        mgr = TriggerManager(sdd_dir)
+
+        assert len(mgr.evaluate_cron_triggers()) == 1
+        assert mgr.evaluate_cron_triggers() == []
+
+    def test_malformed_schedule_does_not_block_other_triggers(self, sdd_dir: Path) -> None:
+        _write_triggers(
+            sdd_dir,
+            [
+                _cron_trigger("bad-expression", "not a cron expression"),
+                # An unquoted YAML integer reaches croniter as an int, not a str.
+                _cron_trigger("bad-type", 30),
+                _cron_trigger("every-minute", "* * * * *"),
+            ],
+        )
+        mgr = TriggerManager(sdd_dir)
+
+        events = mgr.evaluate_cron_triggers()
+
+        assert [e.metadata["cron_name"] for e in events] == ["every-minute"]
+
+
+# ---------------------------------------------------------------------------
 # Trigger source tests
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_trigger_manager.py
+++ b/tests/unit/test_trigger_manager.py
@@ -828,8 +828,9 @@ class TestTriggerManager:
 # Cron evaluation tests
 # ---------------------------------------------------------------------------
 
-# A fixed instant 20s into its minute, so the previous fire of an every-minute
-# schedule always lands inside the current minute regardless of local timezone.
+# A fixed instant 20s into its minute: the ordinary mid-minute tick. The
+# boundary case it used to be chosen to dodge is covered explicitly by
+# test_fires_when_the_tick_lands_exactly_on_the_minute.
 _FROZEN_NOW = 1_700_000_000.0
 
 
@@ -882,6 +883,43 @@ class TestCronEvaluation:
         assert events[0].source == "cron"
         assert events[0].metadata["cron_name"] == "every-minute"
         assert events[0].timestamp == _FROZEN_NOW
+
+    def test_fires_when_the_tick_lands_exactly_on_the_minute(
+        self, sdd_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A tick at HH:MM:00 must still fire a schedule due that minute.
+
+        ``get_prev`` is strictly-before its anchor, so anchoring on ``now`` at
+        an exact boundary returns the *previous* minute and the due trigger is
+        skipped. Nothing guarantees a caller's phase, so this is not only a
+        test-determinism concern.
+        """
+        from bernstein.core.orchestration import trigger_manager as module
+
+        boundary = _FROZEN_NOW - (_FROZEN_NOW % 60)
+        assert boundary % 60 == 0, "the fixture must sit exactly on a minute"
+        monkeypatch.setattr(module, "time", _FrozenTime(boundary))
+
+        _write_triggers(sdd_dir, [_cron_trigger("every-minute", "* * * * *")])
+        mgr = TriggerManager(sdd_dir)
+
+        events = mgr.evaluate_cron_triggers()
+
+        assert [e.metadata["cron_name"] for e in events] == ["every-minute"]
+
+    def test_not_due_trigger_does_not_fire_on_the_minute_either(
+        self, sdd_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The boundary fix must not turn every schedule into an every-minute one."""
+        from bernstein.core.orchestration import trigger_manager as module
+
+        boundary = _FROZEN_NOW - (_FROZEN_NOW % 60)
+        monkeypatch.setattr(module, "time", _FrozenTime(boundary))
+        off_minute = (time.localtime(boundary).tm_min + 30) % 60
+        _write_triggers(sdd_dir, [_cron_trigger("off-minute", f"{off_minute} * * * *")])
+        mgr = TriggerManager(sdd_dir)
+
+        assert mgr.evaluate_cron_triggers() == []
 
     def test_trigger_not_due_does_not_fire(self, sdd_dir: Path) -> None:
         off_minute = (time.localtime(_FROZEN_NOW).tm_min + 30) % 60

--- a/tests/unit/test_trigger_manager.py
+++ b/tests/unit/test_trigger_manager.py
@@ -598,6 +598,37 @@ class TestTriggerManager:
         assert len(mgr.configs) == 4
         assert mgr.configs[0].name == "qa-on-push"
 
+    @pytest.mark.parametrize("payload", ["null", "[]", '"a string"', "5", "true"])
+    def test_corrupt_cron_state_root_does_not_break_construction(self, sdd_dir: Path, payload: str) -> None:
+        """Valid JSON of the wrong shape must not abort __init__.
+
+        json.load succeeds, so the (JSONDecodeError, OSError) guard does not
+        fire and .items() raises out of the constructor - taking down every
+        command that builds a TriggerManager, not just cron evaluation.
+        """
+        (sdd_dir / "runtime" / "triggers" / "cron_state.json").write_text(payload)
+
+        mgr = TriggerManager(sdd_dir)  # must not raise
+
+        assert mgr._cron_state == {}
+
+    def test_corrupt_cron_state_drops_bad_entries_not_the_whole_file(self, sdd_dir: Path) -> None:
+        """One unusable entry must not discard the rest.
+
+        Dropping the whole map re-fires every trigger that was already
+        recorded for this minute, so salvage what parses.
+        """
+        state = {
+            "good": {"last_fire_minute": "2023-11-15T00:13"},
+            "not-a-mapping": 5,
+            "value-wrong-type": {"last_fire_minute": 7},
+        }
+        (sdd_dir / "runtime" / "triggers" / "cron_state.json").write_text(json.dumps(state))
+
+        mgr = TriggerManager(sdd_dir)
+
+        assert mgr._cron_state == {"good": "2023-11-15T00:13"}
+
     def test_evaluate_push_happy_path(self, sdd_dir: Path, triggers_yaml_path: Path, push_event: TriggerEvent) -> None:
         mgr = TriggerManager(sdd_dir)
         payloads, suppressed = mgr.evaluate(push_event)

--- a/tests/unit/test_trigger_manager.py
+++ b/tests/unit/test_trigger_manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import stat
+import sys
 import time
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any
@@ -1003,7 +1004,12 @@ class TestCronEvaluation:
 
         state_path = sdd_dir / "runtime" / "triggers" / "cron_state.json"
         assert self._temp_files(sdd_dir) == []
-        assert stat.S_IMODE(state_path.stat().st_mode) == 0o600
+        if sys.platform != "win32":
+            # st_mode carries no POSIX permission bits on Windows: a regular
+            # file reports 0o666 there (0o444 read-only), whatever mode
+            # mkstemp asked for. The scratch-file assertion above holds on
+            # both.
+            assert stat.S_IMODE(state_path.stat().st_mode) == 0o600
 
     def test_malformed_schedule_does_not_block_other_triggers(self, sdd_dir: Path) -> None:
         """A schedule croniter rejects is logged and skipped, not raised."""

--- a/tests/unit/test_trigger_manager.py
+++ b/tests/unit/test_trigger_manager.py
@@ -186,6 +186,28 @@ class TestLoadTriggerConfigs:
         with pytest.raises(ValueError, match="triggers"):
             load_trigger_configs(path)
 
+    @pytest.mark.parametrize("schedule", [None, "", 0])
+    def test_cron_trigger_without_usable_schedule_is_reported(
+        self, sdd_dir: Path, caplog: pytest.LogCaptureFixture, schedule: Any
+    ) -> None:
+        """A cron trigger that can never fire is surfaced at load, not silently dropped.
+
+        The evaluator skips these on a falsy check every tick, so without a
+        load-time diagnostic an operator gets no signal at all.
+        """
+        path = sdd_dir / "config" / "triggers.yaml"
+        entry: dict[str, Any] = {"name": "ghost", "source": "cron", "task": {"title": "t", "role": "qa"}}
+        if schedule is not None:
+            entry["schedule"] = schedule
+        with open(path, "w") as f:
+            yaml.dump({"version": 1, "triggers": [entry]}, f)
+
+        with caplog.at_level("WARNING"):
+            configs = load_trigger_configs(path)
+
+        assert len(configs) == 1
+        assert "ghost" in caplog.text
+
     def test_model_escalation_parsed(self, triggers_yaml_path: Path) -> None:
         configs = load_trigger_configs(triggers_yaml_path)
         ci_fix = next(c for c in configs if c.name == "ci-fix")
@@ -789,6 +811,36 @@ class TestCronEvaluation:
     def test_does_not_refire_within_the_same_minute(self, sdd_dir: Path) -> None:
         _write_triggers(sdd_dir, [_cron_trigger("every-minute", "* * * * *")])
         mgr = TriggerManager(sdd_dir)
+
+        assert len(mgr.evaluate_cron_triggers()) == 1
+        assert mgr.evaluate_cron_triggers() == []
+
+    def test_state_save_failure_does_not_abort_the_pass(self, sdd_dir: Path) -> None:
+        """A failed state write must not strand the triggers evaluated after it."""
+        _write_triggers(
+            sdd_dir,
+            [_cron_trigger("first", "* * * * *"), _cron_trigger("second", "* * * * *")],
+        )
+        mgr = TriggerManager(sdd_dir)
+
+        def _boom() -> None:
+            raise OSError("read-only filesystem")
+
+        mgr._save_cron_state = _boom  # type: ignore[method-assign]
+
+        events = mgr.evaluate_cron_triggers()
+
+        assert [e.metadata["cron_name"] for e in events] == ["first", "second"]
+
+    def test_state_save_failure_still_suppresses_same_minute_refire(self, sdd_dir: Path) -> None:
+        """In-memory state survives a failed write, so the fire is not duplicated."""
+        _write_triggers(sdd_dir, [_cron_trigger("every-minute", "* * * * *")])
+        mgr = TriggerManager(sdd_dir)
+
+        def _boom() -> None:
+            raise OSError("read-only filesystem")
+
+        mgr._save_cron_state = _boom  # type: ignore[method-assign]
 
         assert len(mgr.evaluate_cron_triggers()) == 1
         assert mgr.evaluate_cron_triggers() == []

--- a/uv.lock
+++ b/uv.lock
@@ -386,6 +386,7 @@ dev = [
     { name = "beartype" },
     { name = "boto3-stubs" },
     { name = "botocore-stubs" },
+    { name = "croniter" },
     { name = "crosshair-tool" },
     { name = "diff-cover" },
     { name = "hypothesis" },
@@ -489,6 +490,7 @@ dev = [
     { name = "beartype" },
     { name = "boto3-stubs" },
     { name = "botocore-stubs" },
+    { name = "croniter" },
     { name = "crosshair-tool" },
     { name = "diff-cover" },
     { name = "hypothesis" },
@@ -539,6 +541,7 @@ requires-dist = [
     { name = "botocore-stubs", marker = "extra == 'dev'", specifier = ">=1.43.14" },
     { name = "cbor2", specifier = ">=5.6" },
     { name = "click", specifier = ">=8.3.3" },
+    { name = "croniter", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "crosshair-tool", marker = "extra == 'dev'", specifier = ">=0.0.95" },
     { name = "cryptography", specifier = ">=50.0.0" },
     { name = "datasets", marker = "extra == 'eval'", specifier = ">=4.8.5" },
@@ -631,6 +634,7 @@ dev = [
     { name = "beartype", specifier = ">=0.21" },
     { name = "boto3-stubs", specifier = ">=1.43.56" },
     { name = "botocore-stubs", specifier = ">=1.43.14" },
+    { name = "croniter", specifier = ">=6.0" },
     { name = "crosshair-tool", specifier = ">=0.0.95" },
     { name = "diff-cover", specifier = ">=9.0" },
     { name = "hypothesis", specifier = ">=6.100" },
@@ -1114,6 +1118,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/db/51/37221f59a111dca5e85be7dbf09696323b5b9f13ff65e0641d535ed06ea8/coverage-7.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:301e3b7dfefecaca37c9f1aa6f0049b7d4ab8dd933742b607765d757aca77d43", size = 224254, upload-time = "2026-03-17T10:33:11.174Z" },
     { url = "https://files.pythonhosted.org/packages/54/83/6acacc889de8987441aa7d5adfbdbf33d288dad28704a67e574f1df9bcbb/coverage-7.13.5-cp314-cp314t-win_arm64.whl", hash = "sha256:9dacc2ad679b292709e0f5fc1ac74a6d4d5562e424058962c7bb0c658ad25e45", size = 222276, upload-time = "2026-03-17T10:33:13.466Z" },
     { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
+]
+
+[[package]]
+name = "croniter"
+version = "6.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/57/2e2a65aee2a70483cb28e2b7e15a072d00a523207593b44400d4717bb100/croniter-6.2.4.tar.gz", hash = "sha256:fc124f751b1b04805c2a04b061898b436b45ab2320b045e1e052ea895de65189", size = 166267, upload-time = "2026-07-10T09:52:59.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/ba/d678e5bd329646ca51d3c92addbc77804e86d21f4b6b6a027218e6abb010/croniter-6.2.4-py3-none-any.whl", hash = "sha256:8ef3d544107a5c05a150a2d78f8bf5a8eb9c5c4d93405a736b824109574e3f4d", size = 46677, upload-time = "2026-07-10T09:52:58.425Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# User description
## What

Two related changes:

1. Clears the advisory mypy backlog for `src/bernstein/core/orchestration`: **19 errors to 0**.
2. Fixes the defect that work surfaced: `TriggerManager.evaluate_cron_triggers()` could not fire a trigger at all, plus the malformed-input and persistence faults found while testing it.

## Why

Refs #2980.

The type work is annotation-only. The cron fix is not — `evaluate_cron_triggers()` built its `croniter` from a `time.struct_time`:

```python
cron = croniter(trigger.schedule, time.localtime(now))
prev_fire = cron.get_prev(float)
# TypeError: argument must be int or float, not time.struct_time
```

`croniter` stores the start value without validating it, so the construction succeeds and the failure surfaces on the next line — confirmed against croniter 6.2.4, not inferred. The enclosing `except (ValueError, KeyError)` does not catch `TypeError`, so it escaped the method entirely. Every enabled cron trigger with a schedule hit this on the first loop iteration.

**Scope of the impact, stated up front:** `evaluate_cron_triggers()` has no in-tree caller. `grep -rn evaluate_cron_triggers src tests` finds its definition and the tests, nothing else — so `source: cron` entries in `triggers.yaml` were not creating tasks before this branch and still are not after it. The method is public on `TriggerManager` and its docstring describes orchestrator-tick usage; this restores it to working order for whoever drives it. Wiring it to a caller is a separate design question, discussed under finding 3743090044 below.

## How

**The cron fix** — `trigger_manager.py`:

```diff
-cron = croniter(trigger.schedule, time.localtime(now))
+cron = croniter(trigger.schedule, now)
...
-except (ValueError, KeyError) as exc:
+except (ValueError, KeyError, TypeError, AttributeError) as exc:
```

`now` is already `time.time()`. `get_prev(float)` returns a Unix timestamp, which the existing `time.strftime(..., time.localtime(prev_fire))` comparison against `current_minute` already expects.

**The widened `except`.** Probing croniter 6.2.4 directly:

| Bad schedule | Raised | Caught by the old `except`? |
|---|---|---|
| `"not a cron expression"` | `CroniterBadCronError` (a `ValueError`) | yes |
| `"99 * * * *"` | `CroniterBadCronError` (a `ValueError`) | yes |
| `30` (unquoted YAML int) | `AttributeError: 'int' object has no attribute 'lower'` | **no** |
| `time.localtime(now)` | `TypeError` | **no** |

The `30` row is what originally justified widening the clause. It no longer describes the YAML path: a later commit on this branch made `load_trigger_configs` drop a non-string `schedule` at load, so an unquoted integer never reaches croniter from a config file any more. The widened clause is kept as the evaluator's own guard — `_configs` is plain state and the loader is not its only writer — and is now covered by `test_non_string_schedule_reaching_croniter_is_skipped_not_raised`, which drives both an `int` and a `struct_time` straight into `_configs`. Narrowing the clause back turns that test red; before it existed, narrowing it back left the whole file green.

**Minute-boundary fire** (review finding 3743466484). `get_prev()` returns the last fire strictly *earlier* than its start, so a tick reading exactly `HH:MM:00.000000` gets the previous minute back and the schedule reads as not due:

```
now=1699999980.0        prev=1699999920.0   -> not due
now=1699999980.000001   prev=1699999980.0   -> due
```

`croniter.match()` now answers that one instant, and is consulted only after `get_prev` has already said "not due", so it can add a fire and never suppress one. The window is a single float instant and the method is documented as safe to call every 3s, so a skipped boundary tick was picked up by the next tick inside the same minute; it was still a branch answering the wrong question.

The first attempt at this (6750bbe8) anchored the search on the start of the *next* minute instead. That fixes the 5-field case but moves croniter's 6-field form: `* * * * * 30` names second 30, and anchored on the next minute it reads as due from `:00`, up to 59s early. `test_sub_minute_schedule_keeps_its_phase` pins `:00`/`:10`/`:29` not-due and `:30`/`:45` due, and is red on that anchor.

**Also in the cron path**, each with its own regression test:

- `load_trigger_configs` type-checks `name`, `source` and (for cron) `schedule` instead of only checking key presence, and reports a cron trigger that can never fire at load rather than skipping it silently every tick.
- `_save_cron_state` writes through a `mkstemp` sibling and `os.replace` rather than truncating the target. `_load_cron_state` reads a corrupt file as empty state, so an interrupted write did not cost one entry — it replayed every cron trigger on the next start.
- `_load_cron_state` validates the decoded shape. Valid JSON of the wrong shape (`null`, a list, a scalar) decoded cleanly past the `(JSONDecodeError, OSError)` guard and raised `AttributeError` out of `TriggerManager.__init__`, taking down every command that constructs one.
- Cron-state persistence is flushed once per pass while dirty, so a dropped write is retried on the next pass instead of waiting for some trigger to fire again.

**MCP discovery** (`bootstrap.py`, `stop_cmd.py`): both the registration and the shutdown path called `.get()` on whatever `json.loads` returned. A valid JSON document need not be an object, so the `(ValueError, OSError)` guard did not fire and the `AttributeError` landed outside the `contextlib.suppress(OSError)` the call sites wrap them in. Both are now `isinstance`-guarded. They diverge deliberately: registration owns its entry and writes one; removal has nothing to remove in any of those shapes and leaves the file byte-for-byte alone.

**The type work:**

- Imports routed through `sys.modules` aliases (`bernstein.core.lifecycle`, `bernstein.core.heartbeat`) now name the real modules. Verified to be the same objects at runtime (`bernstein.core.lifecycle is bernstein.core.tasks.lifecycle` → `True`), and it matches the existing convention in `approval_gate.py`.
- Assorted: attribute types declared on the second branch of an `if`/`else`, dead `| None` on three private `tick_pipeline` helpers whose only caller passes the already-normalised affinity map, a Protocol callback binding its parameter by name, a name collision between a loop-local list and a post-loop count, stale suppression codes written for a different checker.

## Reviewer notes

- **`croniter` is now a dev dependency.** It was declared in no dependency group — only `types-croniter`, its stub package — so `pytest.importorskip("croniter")` skipped `TestCronEvaluation` everywhere, CI included. The last shard log before that change reads `PASS [237/241] test_trigger_manager.py (25.2s) 67 passed, 9 skipped`; all nine were the cron tests. Reverting the croniter fix left CI green. It stays optional at runtime — `trigger_manager` imports it inside `try/except ImportError` and yields no events without it, unchanged — and is in the dev group only so the tests that assert the fixed behaviour execute, the same reason `psutil` and `sentry-sdk` are there.
- **Test determinism.** The default clock is pinned 20s into a minute so `get_prev` never lands on a `:00` boundary by accident; the two boundary tests pin their own clock to the minute start instead. The not-due schedule is derived from `time.localtime()` rather than hardcoded, so it holds under any UTC offset, including the `:30`/`:45` ones. The state-file mode assertion is POSIX-only: `st_mode` carries no permission bits on the Windows shards.
- **Rebased onto `main`.** This branch previously carried a `cast()`-alias commit that was squash-merged separately as #3493; `git rebase origin/main` drops it as already applied. Nothing in the current diff touches `core/security`, `benchmark/`, `plugins/` or the other files that commit changed.

## Verification

Measured against `origin/main` at `c7129f3e`, both sides run in a clean worktree:

```
uv run mypy src/bernstein/core/orchestration   # main: 19 errors in 10 files -> branch: Success, no issues
uv run mypy src                                # main: 202 errors in 79 files -> branch: 186 in 69
```

Diffing the two error sets: 16 error lines removed, **none introduced**.

```
uv run ruff check src/                                        # All checks passed
uv run ruff check <14 changed .py files>                      # All checks passed
uv run ruff format --check <14 changed .py files>             # 14 files already formatted
uv run pytest tests/unit/test_trigger_manager.py -q           # 84 passed
uv run pytest tests/unit/test_mcp_discovery.py tests/unit/test_tick_pipeline.py \
  tests/unit/test_drain.py tests/unit/test_drain_merge.py \
  tests/unit/test_activity_modalities.py tests/unit/test_run_changelog.py \
  tests/unit/test_bootstrap.py tests/unit/test_multi_cell.py \
  tests/unit/test_multi_cell_clearance.py tests/unit/test_events_triggers.py \
  tests/unit/test_routine_trigger.py tests/unit/test_gitlab_trigger.py \
  tests/unit/test_stop_cmd_watchdog_reap.py -q                # all passed
```

Every production change on this branch was reverted one at a time and the suite re-run. Each one turns at least one named test red: the croniter float (8 tests), the widened `except` (1), the minute-boundary check (1), both `mcp.json` root guards, both `mcpServers` guards, the `name`/`source`/`schedule` load checks, the falsy-schedule warning, both `cron_state.json` shape guards, the atomic write, the unique scratch name, and the dirty-flag retry.

## Checklist

- [x] `uv run ruff check src/` passes
- [ ] `uv run pyright src/` passes — **not ticked.** The repo-wide pyright run is not clean on `main` either and this branch does not change that baseline; the gated `Pyright strict (security + cluster)` job is green. The mypy count, which #2980 tracks, is the number reported above.
- [ ] `uv run python scripts/run_tests.py -x` passes — **not run locally.** The full suite is memory-hungry; the affected files were run explicitly (above) and CI runs the sharded suite.
- [x] New code has type hints

### Documentation duty

- [x] User-visible README section updated — N/A, no user-visible surface change
- [x] `docs/operations/<area>.md` updated — `docs/substrate/claude-code.md` records the `.claude/mcp.json` handling on both the init and stop sides
- [x] `docs/api/` schema regenerated — N/A, no public surface changed
- [x] `uv run bernstein agents-md sync` — `src/bernstein/core/orchestration/AGENTS.md` lists `trigger_manager.py` and records the optional-dependency and per-item error-isolation conventions
- [x] Tests cover the documented behaviour

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Fix <code>TriggerManager</code> cron evaluation, configuration validation, persistence, and MCP discovery handling so malformed inputs fail safely and cron triggers fire reliably. Clear the mypy backlog across core orchestration by correcting module imports, annotations, protocol signatures, and helper types.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3495?tool=ast&topic=Orchestration+Robustness>Orchestration Robustness</a>
        </td><td>Harden MCP discovery against non-object JSON shapes and resolve orchestration typing issues through corrected lifecycle and heartbeat imports, attribute initialization, callback contracts, and helper annotations.<details><summary>Modified files (13)</summary><ul><li>docs/substrate/claude-code.md</li>
<li>src/bernstein/cli/commands/stop_cmd.py</li>
<li>src/bernstein/core/orchestration/activity_modalities.py</li>
<li>src/bernstein/core/orchestration/bootstrap.py</li>
<li>src/bernstein/core/orchestration/commit_completion.py</li>
<li>src/bernstein/core/orchestration/drain.py</li>
<li>src/bernstein/core/orchestration/drain_merge.py</li>
<li>src/bernstein/core/orchestration/multi_cell.py</li>
<li>src/bernstein/core/orchestration/orchestrator.py</li>
<li>src/bernstein/core/orchestration/orchestrator_backlog.py</li>
<li>src/bernstein/core/orchestration/run_changelog.py</li>
<li>src/bernstein/core/orchestration/tick_pipeline.py</li>
<li>tests/unit/test_mcp_discovery.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>fix(cli): leave a malf...</td><td>August 09, 2026</td></tr>
<tr><td>chernistry</td><td>fix(stop): reap orphan...</td><td>August 01, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3495?tool=ast&topic=Cron+Trigger+Reliability>Cron Trigger Reliability</a>
        </td><td>Restore <code>evaluate_cron_triggers()</code> functionality with correct epoch-based <code>croniter</code> evaluation, minute-boundary handling, malformed-input isolation, validated configuration, atomic state persistence, and retryable writes.<details><summary>Modified files (5)</summary><ul><li>pyproject.toml</li>
<li>src/bernstein/core/orchestration/AGENTS.md</li>
<li>src/bernstein/core/orchestration/trigger_manager.py</li>
<li>tests/unit/test_trigger_manager.py</li>
<li>uv.lock</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>fix(orchestration): ke...</td><td>August 09, 2026</td></tr>
<tr><td>leonbleuciel@gmail.com</td><td>feat(cli): readme-l10n...</td><td>August 06, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3495?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>