### PR TITLE
chore(ci): ratchet coverage baseline up to 83.19%

### DIFF
--- a/.coverage-baseline.json
+++ b/.coverage-baseline.json
@@ -1,8 +1,8 @@
 {
   "diff_coverage_floor_percent": 85,
-  "head_sha": "1b272130439400b5855ffd0e3737b5250948d959",
-  "line_rate": 0.8312,
-  "run_id": "31081352601",
-  "total_coverage_percent": 83.12,
-  "updated_at": "2026-08-06T08:11:01+00:00"
+  "head_sha": "23c8a5daa41e4e6447db96f77f0b1094e5117bef",
+  "line_rate": 0.8319,
+  "run_id": "31300720016",
+  "total_coverage_percent": 83.19,
+  "updated_at": "2026-08-09T07:55:37+00:00"
 }


### PR DESCRIPTION
# User description
Total line coverage rose on `main`, so the monotonic ratchet
bumped the committed high-water mark in `.coverage-baseline.json`
to **83.19%**.

Measured on `23c8a5daa41e4e6447db96f77f0b1094e5117bef` from the
`coverage-report` artifact of CI run
[31300720016](https://github.com/sipyourdrink-ltd/bernstein/actions/runs/31300720016).
Those, and the raw Cobertura `line-rate` the percentage was
rounded from, are recorded in the baseline, so the number in the
diff can be re-derived from the file itself:

```bash
uv run python scripts/coverage_ratchet.py verify \
    --baseline .coverage-baseline.json --require-provenance
```

From here, any later push whose total coverage falls below this
mark is flagged by the LEVEL 2 ratchet. The gate stays advisory
until promoted; see `docs/operations/coverage-ratchet.md`.

Generated by `.github/workflows/coverage-ratchet.yml`.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Raise the committed coverage high-water mark to 83.19% using the <code>coverage-report</code> artifact from CI run <code>31300720016</code>. Update the baseline provenance consumed by the Level 2 coverage ratchet while keeping the 85% diff coverage floor unchanged.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>chernistry</td><td>chore(ci): ratchet cov...</td><td>August 09, 2026</td></tr>
<tr><td>github-actions[bot]</td><td>chore(ci): ratchet cov...</td><td>July 25, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3496?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>