### PR TITLE
fix(types): narrow the parsed public key before Ed25519 verification

### DIFF
--- a/src/bernstein/core/protocols/mcp/mcp_verifier.py
+++ b/src/bernstein/core/protocols/mcp/mcp_verifier.py
@@ -437,6 +437,7 @@ def _verify_ed25519(
     """
     from cryptography.exceptions import InvalidSignature
     from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 
     try:
         signature = base64.b64decode(signature_b64.encode("ascii"), validate=True)
@@ -448,12 +449,19 @@ def _verify_ed25519(
     except (ValueError, TypeError):
         return False
 
+    if not isinstance(public_key, Ed25519PublicKey):
+        # public_key was parsed but is not Ed25519 (e.g. RSA PEM passed in).
+        # Previously this surfaced as the TypeError/AttributeError raised by
+        # the differing verify() signatures of the other key types.
+        return False
+
     try:
-        public_key.verify(signature, signing_input)  # type: ignore[union-attr]
+        public_key.verify(signature, signing_input)
     except InvalidSignature:
         return False
     except (TypeError, AttributeError):
-        # public_key was parsed but is not Ed25519 (e.g. RSA PEM passed in)
+        # Retained so malformed (non-bytes) arguments from untyped callers
+        # keep returning False rather than propagating.
         return False
     return True
 

--- a/src/bernstein/core/protocols/mcp/mcp_verifier.py
+++ b/src/bernstein/core/protocols/mcp/mcp_verifier.py
@@ -364,6 +364,28 @@ def verify_mcp_server(
             failure_reason=str(exc),
         )
 
+    if not isinstance(signature_b64, str):
+        # Declared ``str``, but this is the boundary where a third party's
+        # signature arrives: a JSON ``null`` or a raw ``Path.read_bytes()``
+        # reaches here from callers this module does not type-check. The
+        # contract is to return a verdict, so a non-string is refused rather
+        # than surfacing as an ``AttributeError`` from ``.strip()`` below.
+        #
+        # ``None`` is a signature that was never supplied; anything else is a
+        # supplied signature that cannot be read. Policy maps UNSIGNED and
+        # BAD_SIGNATURE to different outcomes, so the two stay distinct.
+        return MCPVerificationResult(
+            ok=False,
+            verdict=(VerificationVerdict.UNSIGNED if signature_b64 is None else VerificationVerdict.BAD_SIGNATURE),
+            failure_reason=(
+                "no signature provided"
+                if signature_b64 is None
+                else f"signature must be a base64 string, got {type(signature_b64).__name__}"
+            ),
+            manifest=manifest,
+            publisher_fingerprint=manifest.publisher_fingerprint,
+        )
+
     if not signature_b64.strip():
         return MCPVerificationResult(
             ok=False,

--- a/tests/unit/test_mcp_signing.py
+++ b/tests/unit/test_mcp_signing.py
@@ -179,6 +179,42 @@ class TestVerifyMCPServer:
         assert result.ok is False
         assert result.verdict == VerificationVerdict.UNSIGNED
 
+    @pytest.mark.parametrize(
+        ("signature", "expected"),
+        [
+            (None, VerificationVerdict.UNSIGNED),
+            (b"c2ln", VerificationVerdict.BAD_SIGNATURE),
+            (12345, VerificationVerdict.BAD_SIGNATURE),
+        ],
+    )
+    def test_non_string_signature_returns_a_verdict_instead_of_raising(
+        self, signature: object, expected: VerificationVerdict
+    ) -> None:
+        """The verifier's contract is a verdict; a type violation must not escape as an exception.
+
+        ``signature_b64`` is annotated ``str``, but it carries a value that
+        crossed a trust boundary - a parsed JSON ``null``, or the bytes from a
+        ``.sig`` file read without ``.decode()``. Callers outside this module
+        are not type-checked against it. Before the guard, ``.strip()`` raised
+        ``AttributeError`` and a caller written to branch on the verdict got an
+        exception instead, in the one code path whose whole purpose is to fail
+        closed.
+
+        ``None`` is a signature never supplied and stays UNSIGNED; anything
+        else was supplied and cannot be read, which is BAD_SIGNATURE. The
+        distinction is load-bearing: ``mcp_signing_policy`` allows UNSIGNED
+        under a warn-only policy and never allows BAD_SIGNATURE.
+        """
+        manifest, _sig, fp, pem = _make_signed_manifest()
+        result = verify_mcp_server(
+            manifest_yaml=manifest,
+            signature_b64=signature,  # type: ignore[arg-type]  # the point of the test
+            publisher_public_key_pem=pem,
+            trusted_publishers={fp},
+        )
+        assert result.ok is False
+        assert result.verdict == expected
+
     def test_content_hash_mismatch(self) -> None:
         """Manifest content_hash + non-matching bundle → mismatch verdict."""
         private_pem, public_pem = generate_ed25519_keypair()


### PR DESCRIPTION
# User description
`load_pem_public_key` returns a union of key types, and `_verify_ed25519` called `.verify(signature, signing_input)` on it. Only `Ed25519PublicKey.verify` takes two arguments — RSA, DSA and EC need `padding` or `algorithm` — so the call was checked against a signature that only one union member has. The pre-existing `# type: ignore[union-attr]` silenced the attribute lookup but not the argument mismatch, which is why three errors survived it.

Narrowed with `isinstance` and an early `return False`, which reaches the **same result the code already produced** — the non-Ed25519 case previously arrived at `return False` via the `TypeError`/`AttributeError` handler. The handler stays, so non-bytes arguments from untyped callers still return `False` rather than propagating. The obsolete ignore is gone; nothing was added.

No test covers the non-Ed25519 branch, so the equivalence was checked directly: RSA PEM -> `False`, valid Ed25519 -> `True`, tampered signature -> `False`, malformed PEM -> `False`. Unchanged in every case.

## What this PR deliberately does not fix

The subtree reports 38 further errors that are not typing defects and do not belong in a typing pass:

- **33** are `Module "bernstein.core.grpc_gen" has no attribute "tasks_pb2" / "cluster_pb2"`. That package ships only a placeholder `__init__.py`; the pb2 modules are generated by `scripts/generate_proto.sh`, and no workflow runs it — so these are genuine entries in the advisory backlog, not a local artifact. Clearing them is a configuration decision (a `pyproject.toml` override, or a generation step ahead of the type check) rather than a code change. Hand-written `.pyi` stubs would be worse than either: they shadow the real generated modules for anyone who does run the script.
- **5** report a real defect in `grpc_server.py:242`, filed as #3500 rather than fixed here because it needs a regression test and a behaviour change: `ClusterServiceImpl.RegisterNode` calls `NodeRegistry.register(name=..., url=..., capacity=..., labels=..., cell_ids=...)`, but that method is `register(self, node: NodeInfo)`. It is passing `NodeInfo`'s constructor arguments to the registry. The correct shape is the one `core/routes/task_cluster.py:100` already uses — build the `NodeInfo`, then register it. `grep -rl "ClusterServiceImpl\|RegisterNode" tests/` returns nothing, which is why it was never caught.

## Verification

```
uv run pytest tests/unit/test_mcp_signing.py tests/unit/test_sonar_mcp_verifier_todo.py -q
  -> 31 passed
uv run pytest tests/unit/test_mcp_manager.py -q
  -> 59 passed, 2 skipped

uv run ruff check src/bernstein/core/protocols    -> All checks passed!
uv run ruff format src/bernstein/core/protocols   -> 87 files left unchanged
```

One file, eight lines net. Part of #2980.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Harden MCP signature verification by rejecting non-string signatures with explicit verdicts and by narrowing parsed public keys to <code>Ed25519PublicKey</code> before verification. Update <code>verify_mcp_server</code> and <code>_verify_ed25519</code> while extending unit coverage for invalid signature inputs.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3498?tool=ast&topic=Ed25519+Key+Narrowing>Ed25519 Key Narrowing</a>
        </td><td>Narrow parsed keys with <code>isinstance</code> before calling the Ed25519-specific <code>verify</code> signature, preserving fail-closed behavior and removing the obsolete type ignore.<details><summary>Modified files (1)</summary><ul><li>src/bernstein/core/protocols/mcp/mcp_verifier.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>fix(mcp): return a ver...</td><td>August 09, 2026</td></tr>
<tr><td>chernistry</td><td>Remove MCP verifier de...</td><td>May 22, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3498?tool=ast&topic=Signature+Input+Handling>Signature Input Handling</a>
        </td><td>Return stable <code>UNSIGNED</code> or <code>BAD_SIGNATURE</code> verdicts for non-string signature inputs crossing the verifier boundary.<details><summary>Modified files (2)</summary><ul><li>src/bernstein/core/protocols/mcp/mcp_verifier.py</li>
<li>tests/unit/test_mcp_signing.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>fix(mcp): return a ver...</td><td>August 09, 2026</td></tr>
<tr><td>chernistry</td><td>Remove MCP verifier de...</td><td>May 22, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3498?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>