### PR TITLE
fix(types): clear the mypy backlog in memory, tokens and routes

### DIFF
--- a/src/bernstein/core/lifecycle/__init__.py
+++ b/src/bernstein/core/lifecycle/__init__.py
@@ -19,6 +19,24 @@ including module-level attribute writes used by their tests.
 from __future__ import annotations
 
 import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # The ``sys.modules`` remap at the bottom of this file is invisible to
+    # static analysis, so type checkers see this package rather than the FSM
+    # module it aliases to and report the FSM's public names as missing.
+    # Re-export them (explicit-alias form) so the checker agrees with what
+    # ``from bernstein.core.lifecycle import ...`` actually resolves to at
+    # runtime. Type-only: nothing here executes.
+    from bernstein.core.tasks.lifecycle import (
+        IllegalTransitionError as IllegalTransitionError,
+    )
+    from bernstein.core.tasks.lifecycle import (
+        transition_agent as transition_agent,
+    )
+    from bernstein.core.tasks.lifecycle import (
+        transition_task as transition_task,
+    )
 
 from bernstein.core.lifecycle.hooks import (
     DEFAULT_TIMEOUT_SECONDS,

--- a/src/bernstein/core/memory/sqlite_store.py
+++ b/src/bernstein/core/memory/sqlite_store.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
+    import builtins
     from collections.abc import Iterable, Iterator, Mapping
     from pathlib import Path
 
@@ -202,6 +203,9 @@ class SQLiteMemoryStore:
                 ids.append(rowid)
         return ids
 
+    # NOTE: this method binds the name ``list`` in the class body, which
+    # shadows the builtin for every annotation that follows it. Signatures
+    # below therefore spell the builtin as ``builtins.list``.
     def list(
         self,
         type: MemoryType | None = None,
@@ -241,10 +245,10 @@ class SQLiteMemoryStore:
     def query(
         self,
         type: MemoryType | None = None,
-        tags: list[str] | None = None,
+        tags: builtins.list[str] | None = None,
         limit: int = 50,
         *,
-        read_only_from_adapters: list[str] | None = None,
+        read_only_from_adapters: builtins.list[str] | None = None,
     ) -> Iterator[MemoryEntry]:
         """Yield memory entries with an optional adapter-allowlist filter.
 
@@ -335,11 +339,11 @@ class SQLiteMemoryStore:
 
     def get_relevant(
         self,
-        tags: list[str],
+        tags: builtins.list[str],
         limit: int = 10,
         *,
-        read_only_from_adapters: list[str] | None = None,
-    ) -> list[MemoryEntry]:
+        read_only_from_adapters: builtins.list[str] | None = None,
+    ) -> builtins.list[MemoryEntry]:
         """Find most relevant memories for a set of tags (e.g. from a task).
 
         ``read_only_from_adapters`` mirrors :meth:`query`'s allow-list: when
@@ -400,7 +404,7 @@ class SQLiteMemoryStore:
         task_id: str,
         agent: str = "",
         model: str = "",
-        tags: list[str] | None = None,
+        tags: builtins.list[str] | None = None,
     ) -> int:
         """Record what happened -- task outcomes, failures, discoveries."""
         return self.add(
@@ -416,7 +420,7 @@ class SQLiteMemoryStore:
     def add_semantic(
         self,
         content: str,
-        tags: list[str] | None = None,
+        tags: builtins.list[str] | None = None,
         importance: float = 1.0,
     ) -> int:
         """Record facts about the codebase -- patterns, conventions, architecture."""
@@ -430,7 +434,7 @@ class SQLiteMemoryStore:
     def add_procedural(
         self,
         content: str,
-        tags: list[str] | None = None,
+        tags: builtins.list[str] | None = None,
     ) -> int:
         """Record how to do things -- test patterns, build steps, deploy procedures."""
         return self.add(
@@ -443,9 +447,9 @@ class SQLiteMemoryStore:
     def query_for_task(
         self,
         role: str,
-        context_files: list[str],
+        context_files: builtins.list[str],
         limit: int = 10,
-    ) -> list[MemoryEntry]:
+    ) -> builtins.list[MemoryEntry]:
         """Get relevant memories for a task based on role and file context.
 
         Builds a tag set from the role name and path prefixes of the

--- a/src/bernstein/core/routes/task_crud.py
+++ b/src/bernstein/core/routes/task_crud.py
@@ -990,7 +990,7 @@ async def create_tasks_batch(body: BatchCreateRequest, request: Request) -> Batc
         prepared.append(effective)
         assessments.append(assessment)
 
-    created_tasks, skipped_titles = await store.create_batch(prepared, dedup_by_title=True)  # pyright: ignore[reportArgumentType]
+    created_tasks, skipped_titles = await store.create_batch(prepared, dedup_by_title=True)
 
     # Build a title->assessment lookup for created tasks (dedup may have dropped some)
     assessment_by_title = dict(zip([t.title for t in prepared], assessments, strict=False))

--- a/src/bernstein/core/routes/well_known.py
+++ b/src/bernstein/core/routes/well_known.py
@@ -48,7 +48,7 @@ import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 from fastapi import APIRouter, Request
 from fastapi.responses import PlainTextResponse, Response
@@ -68,6 +68,9 @@ from bernstein.core.security.agent_card_signer import (
     ed25519_public_jwk,
 )
 from bernstein.core.security.tenanting import DEFAULT_TENANT_ID
+
+if TYPE_CHECKING:
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 router = APIRouter()
 
@@ -440,7 +443,11 @@ def _sign_canonical_body(canonical_body: bytes, private_pem: bytes, *, kid: str)
 
     from cryptography.hazmat.primitives import serialization
 
-    private_key = serialization.load_pem_private_key(private_pem, password=None)
+    # ``load_pem_private_key`` returns the union of every key type cryptography
+    # supports. This helper is documented to take an Ed25519 PKCS#8 key and the
+    # header below hard-codes ``EdDSA``, so the concrete type is known here even
+    # though the loader cannot express it.
+    private_key = cast("Ed25519PrivateKey", serialization.load_pem_private_key(private_pem, password=None))
     header = {"alg": "EdDSA", "typ": "agent-card+jws", "kid": kid}
     header_b64 = base64.urlsafe_b64encode(canonicalize_jcs(header)).rstrip(b"=").decode("ascii")
     body_b64 = base64.urlsafe_b64encode(canonical_body).rstrip(b"=").decode("ascii")

--- a/src/bernstein/core/tasks/task_store_core.py
+++ b/src/bernstein/core/tasks/task_store_core.py
@@ -1610,7 +1610,7 @@ class TaskStore:
 
     async def create_batch(
         self,
-        requests: list[TaskCreateRequest],
+        requests: Sequence[TaskCreateRequest],
         *,
         dedup_by_title: bool = True,
     ) -> tuple[list[Task], list[str]]:

--- a/src/bernstein/core/tokens/compaction_receipt.py
+++ b/src/bernstein/core/tokens/compaction_receipt.py
@@ -279,12 +279,16 @@ def load_receipts(chain: AuditChainStore, *, task_id: str | None = None) -> list
         Receipts in chain order.
     """
     receipts: list[CompactionReceipt] = []
-    for event, parse_error in _iter_receipt_events(chain):
-        if parse_error is not None:
+    # Addressed as a whole rather than unpacked: the pair is a union tagged by
+    # its second member, and that correlation is only visible while the tuple
+    # is still indexed instead of split into two independent names.
+    for entry in _iter_receipt_events(chain):
+        if entry[1] is not None:
             from bernstein.core.security.sanitize import sanitize_log
 
-            logger.warning("Skipping malformed compaction receipt event: %s", sanitize_log(parse_error))
+            logger.warning("Skipping malformed compaction receipt event: %s", sanitize_log(entry[1]))
             continue
+        event = entry[0]
         if task_id is not None and event.task_id != task_id:
             continue
         receipts.append(event)
@@ -400,10 +404,11 @@ def verify_compaction_receipts(
         errors.extend(f"audit chain: {err}" for err in chain_errors)
 
     receipts: dict[str, CompactionReceipt] = {}
-    for receipt, parse_error in _iter_receipt_events(chain):
-        if parse_error is not None:
-            errors.append(f"audit chain: {parse_error}")
+    for entry in _iter_receipt_events(chain):
+        if entry[1] is not None:
+            errors.append(f"audit chain: {entry[1]}")
             continue
+        receipt = entry[0]
         if task_id is not None and receipt.task_id != task_id:
             continue
         receipts[receipt.correlation_id] = receipt
@@ -419,14 +424,14 @@ def verify_compaction_receipts(
                 # tasks are out of scope for this verification pass.
                 continue
             correlation_id = str(call.get("correlation_id", ""))
-            receipt = receipts.get(correlation_id)
-            if receipt is None:
+            pinned = receipts.get(correlation_id)
+            if pinned is None:
                 errors.append(
                     f"compaction step seq={step.seq} (correlation={correlation_id or 'missing'}) "
                     f"has no chain receipt; audit verification fails"
                 )
                 continue
-            if receipt.pre_sha256 != call.get("pre_sha256") or receipt.post_sha256 != call.get("post_sha256"):
+            if pinned.pre_sha256 != call.get("pre_sha256") or pinned.post_sha256 != call.get("post_sha256"):
                 errors.append(
                     f"compaction step seq={step.seq} pre/post hash mismatch against chain receipt {correlation_id}"
                 )

--- a/src/bernstein/core/tokens/context_compression.py
+++ b/src/bernstein/core/tokens/context_compression.py
@@ -15,7 +15,7 @@ import operator
 import re
 from contextlib import suppress
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from bernstein.core.tokens.compression_models import CompressionMetrics, CompressionResult
 
@@ -285,16 +285,17 @@ class BM25Ranker:
 
         # Try to use sklearn TF-IDF for better scoring
         self._use_sklearn = False
-        self._tfidf: object = None
-        self._tfidf_matrix: object = None
+        # sklearn is an optional dependency and ships no type stubs, so the
+        # vectorizer and its matrix stay untyped rather than being declared as
+        # ``object`` (which rejects every attribute access on them below).
+        self._tfidf: Any = None
+        self._tfidf_matrix: Any = None
         if self.filenames:
             try:
                 from sklearn.feature_extraction.text import TfidfVectorizer  # type: ignore[import-untyped]
 
-                self._tfidf = TfidfVectorizer(lowercase=True, stop_words="english")  # type: ignore[assignment]
-                self._tfidf_matrix = self._tfidf.fit_transform(  # type: ignore[union-attr]
-                    [documents[f] for f in self.filenames]
-                )
+                self._tfidf = TfidfVectorizer(lowercase=True, stop_words="english")
+                self._tfidf_matrix = self._tfidf.fit_transform([documents[f] for f in self.filenames])
                 self._use_sklearn = True
             except Exception:
                 logger.debug("sklearn not available, using fallback TF ranking")
@@ -319,11 +320,10 @@ class BM25Ranker:
             return []
 
         if self._use_sklearn:
-            query_vec = self._tfidf.transform([query])  # type: ignore[union-attr]
-            scores = (query_vec @ self._tfidf_matrix.T).toarray()[0]  # type: ignore[union-attr,operator]
+            query_vec = self._tfidf.transform([query])
+            scores = (query_vec @ self._tfidf_matrix.T).toarray()[0]
             results: list[tuple[str, float]] = [
-                (self.filenames[i], float(scores[i]))  # type: ignore[reportUnknownArgumentType]
-                for i in range(len(self.filenames))
+                (self.filenames[i], float(scores[i])) for i in range(len(self.filenames))
             ]
         else:
             query_terms = set(_tokenize(query))

--- a/src/bernstein/core/tokens/sensitive_gate.py
+++ b/src/bernstein/core/tokens/sensitive_gate.py
@@ -499,7 +499,9 @@ def emit_gate_audit(
     from bernstein.core.security.audit_chain import record_sensitive_gate
 
     actor = task_id or session_id or "unknown"
-    records = [(finding, decision.action) for finding in decision.findings]
+    # ``suppressed`` is an audit-only outcome that never appears as a
+    # GateDecision.action, so the recorded action is wider than that Literal.
+    records: list[tuple[GateFinding, str]] = [(finding, decision.action) for finding in decision.findings]
     records.extend((finding, "suppressed") for finding in decision.suppressed)
     for finding, action in records:
         try:

--- a/src/bernstein/core/tokens/template_compression.py
+++ b/src/bernstein/core/tokens/template_compression.py
@@ -360,14 +360,14 @@ def verify_compression_receipts(
         for row in lock_state.compressions:
             if role is not None and row.role != role:
                 continue
-            receipt = receipts.get(row.correlation_id)
-            if receipt is None:
+            pinned = receipts.get(row.correlation_id)
+            if pinned is None:
                 errors.append(
                     f"templates.lock row for role {row.role!r} (correlation={row.correlation_id}) "
                     f"has no chain receipt; verification fails"
                 )
                 continue
-            if receipt.pre_sha256 != row.pre_digest or receipt.post_sha256 != row.post_digest:
+            if pinned.pre_sha256 != row.pre_digest or pinned.post_sha256 != row.post_digest:
                 errors.append(
                     f"templates.lock row for role {row.role!r} pins digests that disagree with "
                     f"chain receipt {row.correlation_id}"


### PR DESCRIPTION
# User description
Clears the advisory mypy backlog in `core/memory`, `core/tokens` and `core/routes`: **38 errors to 0**, and 43 repo-wide (302 to 259) because two of the causes were shared. No suppressions added; five stale ones removed.

## 38 errors, 6 causes

| Cause | Errors |
|---|--:|
| `SQLiteMemoryStore.list` shadows the builtin for every class-scope annotation *after* it -> `builtins.list` | 15 |
| `core/lifecycle/__init__.py` remaps `sys.modules` onto the FSM module, so static analysis cannot follow it and three re-exported names read as missing | 4 (+5 elsewhere) |
| `_iter_receipt_events` returns a tuple union tagged by its second member; unpacking into two names discards the correlation, so indexing the tuple keeps it | 5 |
| `load_pem_private_key` returns a 13-way key union | 8 |
| One name reused for a definite receipt and an optional dict lookup in two loops | 2 |
| Sensitive gate records `"suppressed"`, which is not in `GateDecision.action`'s `Literal` | 1 |
| TF-IDF vectoriser/matrix declared `object`, rejecting every attribute access (sklearn is optional and unstubbed) | 3 |

## Two files changed outside those three packages

Both are annotation-only, and both are the actual root cause rather than a local workaround:

1. **`core/lifecycle/__init__.py`** — a `TYPE_CHECKING` re-export of the three FSM names. Nothing executes; the runtime `sys.modules` shim is untouched. Smoke-checked that `bernstein.core.lifecycle is bernstein.core.tasks.lifecycle` still holds and the hook surface is still merged, since that file is delicate. Fixing it here cleared 4 errors in scope and 5 more elsewhere.
2. **`core/tasks/task_store_core.py:1613`** — `create_batch(requests: list[...])` to `Sequence[...]`. The body only iterates `requests`; single definition, no overrides. Pure widening.

## One thing that looked like a bug and is not

`task_crud.py:993` passes `list[TaskCreate]` where `list[TaskCreateRequest]` is expected, under a `# pyright: ignore`. `TaskCreateRequest` is a `Protocol` and `TaskCreate` satisfies it structurally — mypy's own note identifies the cause as plain `list` invariance. Widening to `Sequence` is the correct fix and let the suppression go.

Separately worth knowing: `context_compression.py` carried `# type: ignore[reportUnknownArgumentType]` — a pyright error code inside a mypy ignore, so it was inert for both checkers. It is gone as part of this change, but the same mistake may exist elsewhere in the tree.

## Verification

New errors introduced: **zero**, verified by set-differencing the before and after error lists rather than comparing counts.

```
uv run pytest tests/unit/test_sqlite_memory_store.py tests/unit/test_memory_store.py \
  tests/unit/test_compaction_receipt.py tests/unit/test_context_compression.py \
  tests/unit/test_sensitive_gate.py tests/unit/test_template_compression.py \
  tests/unit/test_template_compress_validate.py -q                       -> 197 passed

uv run pytest tests/unit/test_well_known.py tests/unit/test_well_known_http_sig_directory.py \
  tests/unit/test_agent_card_signer.py tests/unit/test_route_batch_ops.py \
  tests/unit/test_batch_create_route.py tests/unit/test_lifecycle_transitions.py \
  tests/unit/test_task_lifecycle.py -q                                    -> 426 passed

uv run pytest tests/unit/test_lifecycle_hooks.py tests/unit/test_lifecycle_pluggy_bridge.py \
  tests/unit/lifecycle tests/unit/test_task_crud_claim_conflict_logging.py \
  tests/unit/test_batch_api.py tests/unit/test_batch_router.py -q         -> 85 passed
```

708 passed, 0 failed. Test files named explicitly throughout — the bare suite leaks over 100 GB. `mypy.gate.ini` and `pyproject.toml` untouched.

Part of #2980.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Clear the mypy backlog across memory, tokens, and routes by correcting annotations, narrowing cryptographic key types, and fixing type-checker visibility for lifecycle exports. Remove stale suppressions while preserving runtime behavior and validate the changes with 708 passing targeted tests.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3499?tool=ast&topic=Core+flow+typing>Core flow typing</a>
        </td><td>Fix static typing across memory, routing, and lifecycle flows by qualifying shadowed <code>list</code> annotations, widening <code>create_batch</code> inputs, typing Ed25519 signing keys, and exposing lifecycle symbols to type checkers.<details><summary>Modified files (5)</summary><ul><li>src/bernstein/core/lifecycle/__init__.py</li>
<li>src/bernstein/core/memory/sqlite_store.py</li>
<li>src/bernstein/core/routes/task_crud.py</li>
<li>src/bernstein/core/routes/well_known.py</li>
<li>src/bernstein/core/tasks/task_store_core.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>fix(types): clear mypy...</td><td>August 09, 2026</td></tr>
<tr><td>chernistry</td><td>fix(server,ci): answer...</td><td>July 26, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3499?tool=ast&topic=Token+flow+typing>Token flow typing</a>
        </td><td>Resolve token and compression typing issues by preserving tuple correlation during receipt validation, separating receipt variables, typing optional sklearn state, and allowing audit-only <code>suppressed</code> actions.<details><summary>Modified files (4)</summary><ul><li>src/bernstein/core/tokens/compaction_receipt.py</li>
<li>src/bernstein/core/tokens/context_compression.py</li>
<li>src/bernstein/core/tokens/sensitive_gate.py</li>
<li>src/bernstein/core/tokens/template_compression.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>fix(types): clear mypy...</td><td>August 09, 2026</td></tr>
<tr><td>chernistry</td><td>Proactive context comp...</td><td>July 05, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3499?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

## Review-bot findings

Three findings on `sqlite_store.py` report that `tags` was added ahead of `limit`/`importance` and breaks positional callers. Rejected as false positives: `tags` already sits at that position on `main` and this PR does not move it. Every `-`/`+` pair in that file is the same parameter with `list[...]` requalified to `builtins.list[...]`, which is needed because `SQLiteMemoryStore.list` shadows the builtin for annotations that follow it. Evidence and per-finding replies are in the threads.

<!-- bot-ack: 3743116560 reason=false-positive: `tags` is not introduced or moved by this PR; the diff requalifies its annotation only -->
<!-- bot-ack: 3743116562 reason=false-positive: `tags` is not introduced or moved by this PR; the diff requalifies its annotation only -->
<!-- bot-ack: 3743116563 reason=false-positive: `tags` is not introduced or moved by this PR; the diff requalifies its annotation only -->
