### PR TITLE
cli(commands): consolidate impact analysis under bernstein impact and register api-check (#3139)

### DIFF
--- a/docs/operations/commands.md
+++ b/docs/operations/commands.md
@@ -76,7 +76,7 @@ bernstein trace <ID> # agent decision trace
 bernstein changelog --hours 48  # changelog from agent-produced diffs
 bernstein explain <cmd>  # detailed help with examples
 bernstein dry-run    # preview tasks without executing
-bernstein dep-impact # API breakage + downstream caller impact
+bernstein impact deps # API breakage + downstream caller impact
 bernstein aliases    # show command shortcuts
 bernstein config-path    # show config file locations
 bernstein init --wizard  # interactive project setup

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -381,8 +381,10 @@ set. (`cli/commands/advanced_cmd.py`, `core/observability/otel_projection.py`.)
 | `bernstein chaos` | Chaos engineering (group). | `cli/commands/chaos_cmd.py:33` |
 | `bernstein eval` | Evaluation pipelines (group). | `cli/commands/eval_benchmark_cmd.py:426` |
 | `bernstein benchmark` | Benchmark pipelines (group). | `cli/commands/eval_benchmark_cmd.py:29` |
-| `bernstein api-check` | Detect breaking-API changes. | `cli/api_check_cmd.py:22` |
-| `bernstein dep-impact` | Dependency change impact. | `cli/dep_impact_cmd.py:25` |
+| `bernstein impact` | Change-impact analysis (group): API compatibility, caller sites, blast radius. | `cli/commands/impact_cmd.py:23` |
+| `bernstein api-check` | Detect breaking-API changes. Second spelling of `bernstein impact api`. | `cli/commands/api_check_cmd.py:22` |
+| `bernstein dep-impact` | Deprecated alias of `bernstein impact deps`; removed in v4.0.0. | `cli/commands/impact_cmd.py:39` |
+| `bernstein blast-radius` | Deprecated alias of `bernstein impact blast`; removed in v4.0.0. | `cli/commands/impact_cmd.py:57` |
 | `bernstein diff` | Task-state diff. | `cli/diff_cmd.py:504` |
 
 #### `bernstein verify`
@@ -458,7 +460,46 @@ The two groups share most flags:
 
 Verification stays on `bernstein bench reliability-verify` / `bernstein bench reliability-check`. (`cli/commands/eval_benchmark_cmd.py:800+`.)
 
+#### `bernstein impact`
+
+Change-impact analysis for a working tree. Three subcommands, each answering a
+different question about the same change.
+
+```bash
+bernstein impact api --base main     # do the changed files break their own signatures?
+bernstein impact deps --base main    # which callers elsewhere in the repo break?
+bernstein impact blast score --file src/db/migrate.py   # how irreversible is it?
+```
+
+#### `bernstein impact api`
+
+Compares Python function signatures between the working tree and a base ref.
+Exits 1 when breaking changes are found.
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--base REF` | `HEAD~1` | Git ref to compare the working tree against. |
+| `--workdir PATH` | current directory | Repository to inspect. |
+
+#### `bernstein impact deps`
+
+Finds every call site in the repository that the changed signatures break.
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--base REF` | `HEAD~1` | Git ref to compare the working tree against. |
+| `--workdir PATH` | current directory | Repository to inspect. |
+| `--strict` | off | Exit 1 on any call-site impact, even without an API break. |
+| `--json` | off | Emit the report as JSON on stdout. |
+
+#### `bernstein impact blast`
+
+Group. `score` scores a change described on the command line; `show TASK_ID`
+pretty-prints a saved report from `.sdd/metrics/blast_radius/`.
+
 #### `bernstein api-check`
+
+Second spelling of `bernstein impact api`. Same flags, same exit codes.
 
 | Flag | Default | Meaning |
 |---|---|---|
@@ -467,11 +508,23 @@ Verification stays on `bernstein bench reliability-verify` / `bernstein bench re
 
 #### `bernstein dep-impact`
 
+Deprecated alias of `bernstein impact deps`, kept registered through the 3.x
+line and removed in v4.0.0. Prints a deprecation notice to stderr, then runs
+`bernstein impact deps` with the arguments it was given, so `--json` output on
+stdout stays parseable.
+
 | Flag | Default | Meaning |
 |---|---|---|
-| `--package NAME` | required | Package whose version change to analyse. |
-| `--from VERSION` | required | Old version. |
-| `--to VERSION` | required | New version. |
+| `--base REF` | `HEAD~1` | Git ref to compare the working tree against. |
+| `--workdir PATH` | current directory | Repository to inspect. |
+| `--strict` | off | Exit 1 on any call-site impact, even without an API break. |
+| `--json` | off | Emit the report as JSON on stdout. |
+
+#### `bernstein blast-radius`
+
+Deprecated alias of `bernstein impact blast`, kept registered through the 3.x
+line and removed in v4.0.0. Exposes the same `score` and `show` subcommands and
+prints a deprecation notice to stderr before running them.
 
 #### `bernstein diff`
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -90,10 +90,10 @@ Good fit when you want issue trackers to stay as the source of truth instead of 
 
 ### API-change safety checks before merge
 
-Breaking a function signature is easy; finding every downstream caller is the annoying part. `dep-impact` compares your branch against a base ref and reports affected call sites before the change merges.
+Breaking a function signature is easy; finding every downstream caller is the annoying part. `impact deps` compares your branch against a base ref and reports affected call sites before the change merges.
 
 ```bash
-bernstein dep-impact --base main
+bernstein impact deps --base main
 ```
 
 Good fit when you are doing refactors in shared libraries or internal platforms and want a fast, concrete answer to "what else does this break?"

--- a/src/bernstein/cli/commands/api_check_cmd.py
+++ b/src/bernstein/cli/commands/api_check_cmd.py
@@ -1,13 +1,13 @@
-"""CLI command: ``bernstein api-check`` - detect breaking API changes via git diff.
+"""CLI command: ``bernstein impact api`` - detect breaking API changes via git diff.
 
 Compares Python function signatures between the current working tree and a
 base git ref (default ``HEAD~1``). Exits with code 1 when breaking changes
-are found.
+are found.  ``bernstein api-check`` stays registered as a second spelling.
 
 Usage::
 
-    bernstein api-check                  # compare against HEAD~1
-    bernstein api-check --base main      # compare against main branch
+    bernstein impact api                 # compare against HEAD~1
+    bernstein impact api --base main     # compare against main branch
 """
 
 from __future__ import annotations
@@ -37,8 +37,8 @@ def api_check_cmd(base: str, workdir: str | None) -> None:
     """Detect breaking API changes in Python files since a git ref.
 
     \b
-      bernstein api-check                 # vs HEAD~1
-      bernstein api-check --base main     # vs main branch
+      bernstein impact api                 # vs HEAD~1
+      bernstein impact api --base main     # vs main branch
     """
     from rich.table import Table
 

--- a/src/bernstein/cli/commands/dep_impact_cmd.py
+++ b/src/bernstein/cli/commands/dep_impact_cmd.py
@@ -1,15 +1,15 @@
-"""CLI command: ``bernstein dep-impact`` - dependency impact analysis.
+"""CLI command: ``bernstein impact deps`` - dependency impact analysis.
 
 Scans the repository for call sites that will break when a function
-signature changes.  Complements ``bernstein api-check`` (which only
+signature changes.  Complements ``bernstein impact api`` (which only
 inspects the changed files themselves) by finding ALL callers across
 the codebase and validating their compatibility with the new signatures.
 
 Usage::
 
-    bernstein dep-impact                 # compare current HEAD vs HEAD~1
-    bernstein dep-impact --base main     # compare against main branch
-    bernstein dep-impact --strict        # exit 1 even for warnings only
+    bernstein impact deps                # compare current HEAD vs HEAD~1
+    bernstein impact deps --base main    # compare against main branch
+    bernstein impact deps --strict       # exit 1 even for warnings only
 """
 
 from __future__ import annotations
@@ -58,9 +58,9 @@ def dep_impact_cmd(
     """Analyse which call sites break when a function signature changes.
 
     \b
-      bernstein dep-impact                 # vs HEAD~1
-      bernstein dep-impact --base main     # vs main branch
-      bernstein dep-impact --strict        # fail on any call-site impact
+      bernstein impact deps                # vs HEAD~1
+      bernstein impact deps --base main    # vs main branch
+      bernstein impact deps --strict       # fail on any call-site impact
 
     Blocks merge (exit code 1) when breaking API changes are found or when
     downstream callers are incompatible with the new signatures.

--- a/src/bernstein/cli/commands/impact_cmd.py
+++ b/src/bernstein/cli/commands/impact_cmd.py
@@ -1,0 +1,67 @@
+"""CLI command group for impact analysis (issue #3139).
+
+Consolidates API compatibility checking, dependency call-site analysis,
+and blast-radius scoring under ``bernstein impact``:
+
+- ``bernstein impact api`` (formerly orphaned ``api-check``)
+- ``bernstein impact deps`` (formerly ``dep-impact``)
+- ``bernstein impact blast`` (formerly ``blast-radius``)
+"""
+
+from __future__ import annotations
+
+import click
+
+from bernstein.cli.commands.api_check_cmd import api_check_cmd
+from bernstein.cli.commands.blast_radius_cmd import blast_radius_group
+from bernstein.cli.commands.dep_impact_cmd import dep_impact_cmd
+
+
+@click.group("impact")
+def impact_group() -> None:
+    """Analyse impact of code changes (API compatibility, caller sites, blast radius)."""
+
+
+# Subcommands under `bernstein impact`
+impact_group.add_command(api_check_cmd, "api")
+impact_group.add_command(dep_impact_cmd, "deps")
+impact_group.add_command(blast_radius_group, "blast")
+
+
+# ---------------------------------------------------------------------------
+# Deprecated top-level aliases for 3.x back-compat
+# ---------------------------------------------------------------------------
+
+
+@click.command("dep-impact", help="[Deprecated] Analyse call-site impacts (use 'bernstein impact deps').")
+@click.option("--base", default="HEAD~1", show_default=True, metavar="REF", help="Git ref to compare against.")
+@click.option(
+    "--workdir", default=None, type=click.Path(exists=True, file_okay=False, resolve_path=True), help="Repository root."
+)
+@click.option("--strict", is_flag=True, default=False, help="Exit 1 when any call-site impact is found.")
+@click.option("--json", "output_json", is_flag=True, default=False, help="Output results as JSON.")
+@click.pass_context
+def dep_impact_alias_cmd(ctx: click.Context, base: str, workdir: str | None, strict: bool, output_json: bool) -> None:
+    """[Deprecated] Use 'bernstein impact deps' instead."""
+    click.echo(
+        "WARNING: 'bernstein dep-impact' is deprecated and will be removed in v4.0.0 (#3139): "
+        "use 'bernstein impact deps' instead.",
+        err=True,
+    )
+    ctx.invoke(dep_impact_cmd, base=base, workdir=workdir, strict=strict, output_json=output_json)
+
+
+@click.group("blast-radius", help="[Deprecated] Inspect blast-radius scores (use 'bernstein impact blast').")
+@click.pass_context
+def blast_radius_alias_group(ctx: click.Context) -> None:
+    """[Deprecated] Use 'bernstein impact blast' instead."""
+    if ctx.invoked_subcommand is not None:
+        click.echo(
+            "WARNING: 'bernstein blast-radius' is deprecated and will be removed in v4.0.0 (#3139): "
+            "use 'bernstein impact blast' instead.",
+            err=True,
+        )
+
+
+for _cmd_name, _cmd_obj in blast_radius_group.commands.items():
+    blast_radius_alias_group.add_command(_cmd_obj, _cmd_name)

--- a/src/bernstein/cli/commands/impact_cmd.py
+++ b/src/bernstein/cli/commands/impact_cmd.py
@@ -3,9 +3,12 @@
 Consolidates API compatibility checking, dependency call-site analysis,
 and blast-radius scoring under ``bernstein impact``:
 
-- ``bernstein impact api`` (formerly orphaned ``api-check``)
-- ``bernstein impact deps`` (formerly ``dep-impact``)
-- ``bernstein impact blast`` (formerly ``blast-radius``)
+- ``bernstein impact api`` -- also reachable as top-level ``api-check``,
+  which an earlier change registered after #3139 measured the module as
+  documented-but-orphaned.  The top-level spelling is left in place and is
+  not deprecated here; this change gives the command a home in the group.
+- ``bernstein impact deps`` (was ``dep-impact``, now a deprecated alias)
+- ``bernstein impact blast`` (was ``blast-radius``, now a deprecated alias)
 """
 
 from __future__ import annotations

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -70,6 +70,11 @@ from bernstein.cli.commands.events_cmd import events_group
 from bernstein.cli.commands.export_cmd import export_cmd
 from bernstein.cli.commands.fleet_cmd import fleet_group
 from bernstein.cli.commands.fork_cmd import fork_cmd
+from bernstein.cli.commands.impact_cmd import (
+    blast_radius_alias_group,
+    dep_impact_alias_cmd,
+    impact_group,
+)
 from bernstein.cli.commands.integrations_cmd import integrations_group
 from bernstein.cli.commands.knowledge_cmd import knowledge_group
 from bernstein.cli.commands.pool_cmd import pool_group
@@ -88,7 +93,6 @@ from bernstein.cli.cost import (
 )
 from bernstein.cli.debug_bundle import debug_group
 from bernstein.cli.debug_cmd import debug_cmd
-from bernstein.cli.dep_impact_cmd import dep_impact_cmd
 from bernstein.cli.diff_cmd import diff_cmd
 from bernstein.cli.disaster_recovery_cmd import dr_group
 from bernstein.cli.dry_run_cmd import dry_run_cmd
@@ -1164,7 +1168,8 @@ cli.add_command(dr_group, "dr")
 cli.add_command(profile_cmd, "profile")
 cli.add_command(templates_group, "templates")
 cli.add_command(validate_alias_cmd, "validate")
-cli.add_command(dep_impact_cmd, "dep-impact")
+cli.add_command(impact_group, "impact")
+cli.add_command(dep_impact_alias_cmd, "dep-impact")
 cli.add_command(fingerprint_group, "fingerprint")
 cli.add_command(fleet_group, "fleet")
 cli.add_command(triggers_group, "triggers")
@@ -1344,9 +1349,7 @@ cli.add_command(delegation_group, "delegation")
 cli.add_command(analyze_cmd, "analyze")  # issue #768
 
 # Blast-radius scorer (issue #1322): inspect + ad-hoc score a change.
-from bernstein.cli.commands.blast_radius_cmd import blast_radius_group  # noqa: E402
-
-cli.add_command(blast_radius_group, "blast-radius")
+cli.add_command(blast_radius_alias_group, "blast-radius")
 
 # Recorded run-session inspection + fork (#1222).
 from bernstein.cli.commands.session_cmd import session_group  # noqa: E402

--- a/tests/unit/sandbox/test_pool_cmd.py
+++ b/tests/unit/sandbox/test_pool_cmd.py
@@ -45,14 +45,31 @@ class TestPoolCli:
 
         res = _run(["list", "--workdir", str(tmp_path), "--json"])
         assert res.exit_code == 0, res.output
-        pools = json.loads(res.output)["pools"]
+        pools = json.loads(res.stdout)["pools"]
         assert "ci-linux" in pools
 
         res = _run(["show", "ci-linux", "--workdir", str(tmp_path)])
         assert res.exit_code == 0, res.output
-        body = json.loads(res.output)
+        body = json.loads(res.stdout)
         assert body["name"] == "ci-linux"
         assert len(body["pool_hash"]) == 64
+
+    def test_json_output_carries_the_document_and_nothing_else(self, tmp_path: Path):
+        """``--json`` output is piped to ``jq``, so stdout must hold only the document.
+
+        Any prose a future change adds - a banner, a notice, a progress line -
+        belongs on stderr. On stdout it lands inside the document and breaks the
+        pipe, which is why the assertions above read ``stdout`` rather than
+        click's ``output`` (stdout and stderr interleaved).
+        """
+        spec = _write_spec(tmp_path)
+        _run(["register", str(spec), "--workdir", str(tmp_path)])
+
+        res = _run(["list", "--workdir", str(tmp_path), "--json"])
+
+        assert res.exit_code == 0, res.output
+        assert set(json.loads(res.stdout)) == {"pools"}
+        assert res.stdout.lstrip().startswith("{")
 
     def test_verify_passes_for_clean_store(self, tmp_path: Path):
         spec = _write_spec(tmp_path)

--- a/tests/unit/test_cli_command_registration.py
+++ b/tests/unit/test_cli_command_registration.py
@@ -214,7 +214,7 @@ def _documented_flags(command_path: str) -> set[str]:
     return set()
 
 
-@pytest.mark.parametrize("name", ["api-check", "ab-test"])
+@pytest.mark.parametrize("name", ["api-check", "ab-test", "impact api", "impact deps", "dep-impact"])
 def test_documented_flags_exist(name: str) -> None:
     """Every flag the reference documents is accepted by the command.
 

--- a/tests/unit/test_impact_consolidation.py
+++ b/tests/unit/test_impact_consolidation.py
@@ -1,0 +1,55 @@
+"""Unit tests for #3139: Consolidating impact analysis under bernstein impact."""
+
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from bernstein.cli.main import cli
+
+
+def test_impact_group_subcommands_registered() -> None:
+    runner = CliRunner()
+    res = runner.invoke(cli, ["impact", "--help"])
+    assert res.exit_code == 0
+    assert "api" in res.output
+    assert "deps" in res.output
+    assert "blast" in res.output
+
+
+def test_impact_api_reachable() -> None:
+    runner = CliRunner()
+    res = runner.invoke(cli, ["impact", "api", "--help"])
+    assert res.exit_code == 0
+    assert "Detect breaking API changes" in res.output
+
+
+def test_impact_deps_reachable() -> None:
+    runner = CliRunner()
+    res = runner.invoke(cli, ["impact", "deps", "--help"])
+    assert res.exit_code == 0
+    assert "Analyse which call sites break" in res.output
+
+
+def test_impact_blast_reachable() -> None:
+    runner = CliRunner()
+    res = runner.invoke(cli, ["impact", "blast", "score", "--help"])
+    assert res.exit_code == 0
+    assert "Score a change described on the command line" in res.output
+
+
+def test_deprecated_top_level_aliases_warning() -> None:
+    runner = CliRunner()
+    res_dep = runner.invoke(cli, ["dep-impact", "--help"])
+    assert res_dep.exit_code == 0
+
+    res_dep_run = runner.invoke(cli, ["dep-impact"])
+    assert (
+        "WARNING: 'bernstein dep-impact' is deprecated" in res_dep_run.output
+        or "WARNING: 'bernstein dep-impact' is deprecated" in res_dep_run.stderr
+    )
+
+    res_blast_run = runner.invoke(cli, ["blast-radius", "score", "--help"])
+    assert (
+        "WARNING: 'bernstein blast-radius' is deprecated" in res_blast_run.output
+        or "WARNING: 'bernstein blast-radius' is deprecated" in res_blast_run.stderr
+    )

--- a/tests/unit/test_impact_consolidation.py
+++ b/tests/unit/test_impact_consolidation.py
@@ -1,55 +1,186 @@
-"""Unit tests for #3139: Consolidating impact analysis under bernstein impact."""
+"""Unit tests for #3139: consolidating impact analysis under ``bernstein impact``.
+
+Every assertion here is written so it can go red.  The first cut of this file
+matched substrings against the whole ``--help`` body, and the group's own
+docstring already contains the words it looked for: deleting
+``impact_group.add_command(blast_radius_group, "blast")`` left
+``test_impact_group_subcommands_registered`` green because "blast radius"
+appears in the group description.  Registration is therefore asserted against
+the group's command table and by object identity, not by substring.
+
+The deprecated top-level aliases are asserted on the two properties the
+migration actually promises: the arguments reach the underlying command, and
+the warning is written to stderr.  Neither was covered before -- deleting the
+``ctx.invoke`` forwarding call, or dropping ``err=True``, left the suite
+green.  The stderr half is not cosmetic: a deprecation banner on stdout ends
+up inside the payload a ``--json`` consumer parses.
+"""
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+from typing import Any
+
+import click
+import pytest
 from click.testing import CliRunner
 
+from bernstein.cli.commands.api_check_cmd import api_check_cmd
+from bernstein.cli.commands.blast_radius_cmd import blast_radius_group
+from bernstein.cli.commands.dep_impact_cmd import dep_impact_cmd
+from bernstein.cli.commands.impact_cmd import blast_radius_alias_group, impact_group
 from bernstein.cli.main import cli
 
-
-def test_impact_group_subcommands_registered() -> None:
-    runner = CliRunner()
-    res = runner.invoke(cli, ["impact", "--help"])
-    assert res.exit_code == 0
-    assert "api" in res.output
-    assert "deps" in res.output
-    assert "blast" in res.output
+_DEP_IMPACT_WARNING = "WARNING: 'bernstein dep-impact' is deprecated"
+_BLAST_RADIUS_WARNING = "WARNING: 'bernstein blast-radius' is deprecated"
 
 
-def test_impact_api_reachable() -> None:
-    runner = CliRunner()
-    res = runner.invoke(cli, ["impact", "api", "--help"])
-    assert res.exit_code == 0
-    assert "Detect breaking API changes" in res.output
+def _resolve(*path: str) -> click.Command:
+    """Walk ``path`` through the real ``cli`` object, failing at the first miss."""
+    node: click.Command = cli
+    for word in path:
+        assert isinstance(node, click.Group), f"`bernstein {' '.join(path)}`: {word!r} has no parent group"
+        found = node.get_command(click.Context(node), word)
+        assert found is not None, f"`bernstein {' '.join(path)}` is not registered"
+        node = found
+    return node
 
 
-def test_impact_deps_reachable() -> None:
-    runner = CliRunner()
-    res = runner.invoke(cli, ["impact", "deps", "--help"])
-    assert res.exit_code == 0
-    assert "Analyse which call sites break" in res.output
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
 
 
-def test_impact_blast_reachable() -> None:
-    runner = CliRunner()
-    res = runner.invoke(cli, ["impact", "blast", "score", "--help"])
-    assert res.exit_code == 0
-    assert "Score a change described on the command line" in res.output
+def test_impact_group_is_registered() -> None:
+    assert isinstance(_resolve("impact"), click.Group)
 
 
-def test_deprecated_top_level_aliases_warning() -> None:
-    runner = CliRunner()
-    res_dep = runner.invoke(cli, ["dep-impact", "--help"])
-    assert res_dep.exit_code == 0
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [("api", api_check_cmd), ("deps", dep_impact_cmd), ("blast", blast_radius_group)],
+)
+def test_impact_subcommand_is_the_existing_command_object(name: str, expected: click.Command) -> None:
+    """``impact <name>`` resolves to the module that already implemented it.
 
-    res_dep_run = runner.invoke(cli, ["dep-impact"])
-    assert (
-        "WARNING: 'bernstein dep-impact' is deprecated" in res_dep_run.output
-        or "WARNING: 'bernstein dep-impact' is deprecated" in res_dep_run.stderr
+    Identity, not a substring of ``--help``: the group description mentions
+    "API", "caller sites" and "blast radius", so a text match passes even
+    when the subcommand is missing.
+    """
+    assert impact_group.commands.get(name) is expected
+    assert _resolve("impact", name) is expected
+
+
+def test_impact_blast_exposes_the_blast_radius_subcommands() -> None:
+    assert set(blast_radius_group.commands) >= {"score", "show"}
+    assert set(_resolve("impact", "blast").commands) == set(blast_radius_group.commands)  # type: ignore[attr-defined]
+
+
+def test_deprecated_blast_alias_mirrors_the_canonical_group() -> None:
+    """The alias copies subcommands at import time; a later addition must not skip it."""
+    assert {name: cmd for name, cmd in blast_radius_alias_group.commands.items()} == dict(blast_radius_group.commands)
+
+
+# ---------------------------------------------------------------------------
+# Canonical commands are reachable and describe themselves
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("path", "expected_summary"),
+    [
+        (("impact", "api"), "Detect breaking API changes"),
+        (("impact", "deps"), "Analyse which call sites break"),
+        (("impact", "blast", "score"), "Score a change described on the command line"),
+    ],
+)
+def test_canonical_command_help_renders(path: tuple[str, ...], expected_summary: str) -> None:
+    res = CliRunner().invoke(cli, [*path, "--help"])
+    assert res.exit_code == 0, res.output
+    assert expected_summary in res.output
+
+
+@pytest.mark.parametrize("path", [("impact", "api"), ("impact", "deps"), ("impact", "blast")])
+def test_canonical_help_does_not_advertise_the_deprecated_spelling(path: tuple[str, ...]) -> None:
+    """The command this PR makes canonical must not tell the reader to use the alias.
+
+    ``impact deps --help`` shipped the ``dep-impact`` examples verbatim, so
+    the help of the replacement pointed at the surface the same change
+    deprecates.
+    """
+    res = CliRunner().invoke(cli, [*path, "--help"])
+    assert res.exit_code == 0, res.output
+    for deprecated in ("bernstein dep-impact", "bernstein api-check", "bernstein blast-radius"):
+        assert deprecated not in res.output, f"`bernstein {' '.join(path)} --help` still points at `{deprecated}`"
+
+
+def test_canonical_path_emits_no_deprecation_warning() -> None:
+    res = CliRunner().invoke(cli, ["impact", "deps", "--help"])
+    assert res.exit_code == 0, res.output
+    assert "deprecated" not in res.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# Deprecated top-level aliases
+# ---------------------------------------------------------------------------
+
+
+def test_dep_impact_alias_forwards_every_option(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The alias runs the real command with the arguments it was given.
+
+    Without this, deleting the ``ctx.invoke`` call in the alias leaves a
+    command that prints a deprecation notice and does nothing, and the suite
+    stays green.
+    """
+    recorded: dict[str, Any] = {}
+    monkeypatch.setattr(dep_impact_cmd, "callback", lambda **kwargs: recorded.update(kwargs))
+
+    res = CliRunner().invoke(
+        cli,
+        ["dep-impact", "--base", "release-3.9", "--workdir", str(tmp_path), "--strict", "--json"],
     )
 
-    res_blast_run = runner.invoke(cli, ["blast-radius", "score", "--help"])
-    assert (
-        "WARNING: 'bernstein blast-radius' is deprecated" in res_blast_run.output
-        or "WARNING: 'bernstein blast-radius' is deprecated" in res_blast_run.stderr
-    )
+    assert res.exit_code == 0, res.output
+    assert recorded == {
+        "base": "release-3.9",
+        "workdir": str(tmp_path),
+        "strict": True,
+        "output_json": True,
+    }
+
+
+def test_dep_impact_alias_warning_goes_to_stderr_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(dep_impact_cmd, "callback", lambda **_kwargs: None)
+
+    res = CliRunner().invoke(cli, ["dep-impact"])
+
+    assert res.exit_code == 0, res.output
+    assert _DEP_IMPACT_WARNING in res.stderr
+    assert _DEP_IMPACT_WARNING not in res.stdout
+
+
+def test_dep_impact_alias_keeps_json_stdout_parseable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--json`` through the alias must still emit a document, not a document with a banner on top."""
+    monkeypatch.setattr(dep_impact_cmd, "callback", lambda **_kwargs: click.echo(json.dumps({"api_breaking": []})))
+
+    res = CliRunner().invoke(cli, ["dep-impact", "--json"])
+
+    assert res.exit_code == 0, res.output
+    assert json.loads(res.stdout) == {"api_breaking": []}
+
+
+def test_blast_radius_alias_warns_on_stderr_and_still_reaches_the_subcommand() -> None:
+    res = CliRunner().invoke(cli, ["blast-radius", "score", "--help"])
+
+    assert res.exit_code == 0, res.output
+    assert _BLAST_RADIUS_WARNING in res.stderr
+    assert _BLAST_RADIUS_WARNING not in res.stdout
+    assert "Score a change described on the command line" in res.stdout
+
+
+def test_blast_radius_alias_without_a_subcommand_shows_help_not_a_bare_warning() -> None:
+    res = CliRunner().invoke(cli, ["blast-radius"])
+
+    assert _BLAST_RADIUS_WARNING not in res.output
+    assert "score" in res.output
+    assert "show" in res.output

--- a/tests/unit/test_readme_api_coverage.py
+++ b/tests/unit/test_readme_api_coverage.py
@@ -314,6 +314,8 @@ DOCUMENTED_COMMANDS: frozenset[str] = frozenset(
         "datasource",
         # Provenance-verified update lifecycle: check, update, pin, rollback (#2942)
         "self",
+        # Bot-added: drift autofix (regen_contract_drift.py)
+        "impact",
     }
 )
 

--- a/tests/unit/test_readme_api_coverage.py
+++ b/tests/unit/test_readme_api_coverage.py
@@ -314,7 +314,10 @@ DOCUMENTED_COMMANDS: frozenset[str] = frozenset(
         "datasource",
         # Provenance-verified update lifecycle: check, update, pin, rollback (#2942)
         "self",
-        # Bot-added: drift autofix (regen_contract_drift.py)
+        # Change-impact analysis group: api / deps / blast (#3139). Documented
+        # in docs/reference/cli-reference.md, with a flag table per subcommand
+        # that tests/unit/test_cli_command_registration.py checks against the
+        # real parser.
         "impact",
     }
 )


### PR DESCRIPTION
# User description
Consolidates impact analysis into a single `bernstein impact` group: `impact api`, `impact deps`, `impact blast`. Top-level `dep-impact` and `blast-radius` stay registered as deprecated aliases through the 3.x line, print a notice to stderr, then run the underlying command with the arguments they were given; both are unregistered in v4.0.0.

### What each subcommand is

| Path | Backed by | Top-level spelling |
|---|---|---|
| `bernstein impact api` | `cli/commands/api_check_cmd.py` | `api-check`, still registered, **not** deprecated by this PR |
| `bernstein impact deps` | `cli/commands/dep_impact_cmd.py` | `dep-impact`, deprecated alias, removed in v4.0.0 |
| `bernstein impact blast` | `cli/commands/blast_radius_cmd.py` | `blast-radius`, deprecated alias, removed in v4.0.0 |

Correction to an earlier version of this description: this PR does **not** register an orphaned `api_check_cmd`. That module was already registered on `main` at `src/bernstein/cli/main.py:1448` (`cli.add_command(api_check_cmd, "api-check")`), by the earlier partial fix for #3139 recorded in `docs/release-notes/unreleased.md`. What this PR adds is a second, grouped path to the same command object. The earlier description also claimed the change "resolved docstring and reference pointers"; it did not touch a docstring or a doc page. That is now done, see below.

The issue made `blast-radius` conditional on #3135 (`run --max-blast-radius` accepted but never enforced). #3135 is closed, so the ordering constraint is satisfied.

### Also in this branch

- The three canonical commands' help shipped the `dep-impact` / `api-check` examples verbatim, so the help of the replacement told the reader to use the spelling this change deprecates. It now names the group path.
- `docs/reference/cli-reference.md` documents `bernstein impact` and a section per subcommand, and `tests/unit/test_cli_command_registration.py` now checks the `impact api` / `impact deps` / `dep-impact` flag tables against the real parser. The `impact` entry had been added to `DOCUMENTED_COMMANDS` by the contract-drift autofix with no documentation behind it, which is the suppression that allow-list exists to prevent. The pre-existing `bernstein dep-impact` flag table documented `--package`, `--from` and `--to`; the command has never had any of them.
- `docs/operations/commands.md` and `docs/use-cases.md` used the deprecated spelling in their examples.
- `tests/unit/sandbox/test_pool_cmd.py` parsed `Result.output` (stdout and stderr interleaved) as JSON, so the deprecation notice `bernstein pool` gained in this stack turned `pool list --json` into a `JSONDecodeError`. That was the `Test (ubuntu-latest, Python 3.13, shard 2)` failure on this branch. It reads `Result.stdout` now, plus a case pinning the notice to stderr.
- The `cost-envelopes` deprecation alias was a `@click.command`, so `bernstein cost-envelopes show` failed at parse time with `Got unexpected extra argument (show)`. It is a group now (`bot-ack: 3743151546`).

### Verification

`tests/unit/test_impact_consolidation.py` failing before, on `origin/main` source with the new test file dropped in:

```
FAILED tests/unit/test_impact_consolidation.py::test_impact_group_subcommands_registered
FAILED tests/unit/test_impact_consolidation.py::test_impact_api_reachable
FAILED tests/unit/test_impact_consolidation.py::test_impact_deps_reachable
FAILED tests/unit/test_impact_consolidation.py::test_impact_blast_reachable
FAILED tests/unit/test_impact_consolidation.py::test_deprecated_top_level_aliases_warning
5 failed in 223.45s
```

That run also measured why the file needed rewriting. It took 223s because `test_deprecated_top_level_aliases_warning` invoked bare `dep-impact`, which runs a real AST analysis of the repository under test against `HEAD~1`; the result therefore depended on how large the previous commit was. The replacements stub the underlying callback and run in milliseconds.

The original five assertions could not fail. Measured by mutation:

| Mutation | Old file | New file |
|---|---|---|
| delete `impact_group.add_command(blast_radius_group, "blast")` | 1 passed | 4 failed |
| delete the `ctx.invoke` forwarding call in `dep_impact_alias_cmd` | 1 passed | 2 failed |
| drop `err=True` from both alias warnings | 5 passed | 3 failed |

The first survived because the group description contains the words "blast radius", so a substring match against `--help` was satisfied with the subcommand missing. Registration is asserted by object identity now. The second and third are the two properties the migration actually promises: that the alias runs the underlying command with the arguments it was given, and that the notice stays off stdout. The stdout half is not cosmetic; it is exactly how `bernstein pool list --json` broke in this stack.

Explicit test files, all passing on the head of this branch:

```
uv run pytest tests/unit/test_impact_consolidation.py tests/unit/test_cli_command_registration.py \
  tests/unit/test_readme_api_coverage.py tests/unit/test_collapse_duplicate_commands.py \
  tests/unit/test_fold_subcommands.py tests/unit/sandbox/test_pool_cmd.py tests/unit/test_dep_impact.py \
  tests/unit/test_blast_radius.py tests/unit/test_blast_radius_run_gate.py tests/unit/test_aliases.py \
  tests/unit/test_cost.py tests/unit/test_artifacts_cmd.py tests/unit/test_artifact_cli_route_parity.py -q
376 passed in 70.46s
```

`ruff check` and `ruff format --check` pass over all 26 Python files this PR touches.

### What breaks if this ships

A pipeline that calls `bernstein dep-impact` or `bernstein blast-radius` keeps working but starts writing a line to stderr; anything asserting on empty stderr fails. `bernstein api-check` now has two spellings with no deprecation notice on either, so operators cannot tell from the CLI which one survives v4.0.0 -- #3147 owns that decision.

### Stacking

This branch sits on `agy/3140-fold-subcommands` (#3502), which sits on `agy/3138-collapse-duplicate-commands` (#3501). Its own change is the last commit plus the four that follow; the rest of the diff belongs to those two PRs. Four open review findings are in their commits, verified and answered in-thread but deliberately not patched here so the fixes land with the change that needs them.

<!-- bot-ack: 3743151537 reason=confirmed defect in commit dbfc4b08 (PR #3501); artifact list TASK --output-json renders Rich text because artifacts_list_cmd has no JSON path at all, so the fix is a new JSON contract for artifact rows rather than a forwarding change; verified and answered in-thread, to be fixed in #3501 -->
<!-- bot-ack: 3743151538 reason=confirmed defect in commit 87c5008e (PR #3502); demo --flask-todo drops --dry-run and --real because quickstart_cmd takes only (keep, timeout, adapter) and decides real mode itself; verified and answered in-thread, to be fixed in #3502 -->
<!-- bot-ack: 3743151543 reason=confirmed defect in commit 87c5008e (PR #3502); init --wizard silently drops --add-badge, --badge-variant and --remote, reproduced with the wizard callback stubbed; the fix is a product choice between forwarding and rejecting, so it belongs to #3502 -->
<!-- bot-ack: 3743151547 reason=confirmed defect in commit 87c5008e (PR #3502); the i shortcut moved from init-wizard to init, so it now writes a plain workspace instead of opening the wizard with no notice; reverting that one line is a decision on #3502 -->

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Consolidate API, dependency, and blast-radius analysis under the <code>impact_group</code> command while retaining <code>api-check</code> and deprecated top-level aliases. Update CLI documentation, help text, parser coverage, and tests to verify command registration, argument forwarding, stderr-only warnings, and JSON-safe stdout.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3503?tool=ast&topic=CLI+docs+and+coverage>CLI docs and coverage</a>
        </td><td>Document the new command paths and align registration and JSON-output tests with the updated CLI behavior, including stderr isolation for deprecation notices.<details><summary>Modified files (6)</summary><ul><li>docs/operations/commands.md</li>
<li>docs/reference/cli-reference.md</li>
<li>docs/use-cases.md</li>
<li>tests/unit/sandbox/test_pool_cmd.py</li>
<li>tests/unit/test_cli_command_registration.py</li>
<li>tests/unit/test_readme_api_coverage.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>chernistry</td><td>cli(commands): fold qu...</td><td>August 09, 2026</td></tr>
<tr><td>sanderchernitsky@gmail...</td><td>docs(cli): document th...</td><td>August 09, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3503?tool=ast&topic=Impact+CLI+flow>Impact CLI flow</a>
        </td><td>Consolidate API, dependency, and blast-radius checks under <code>bernstein impact</code>, while preserving <code>api-check</code> and forwarding deprecated <code>dep-impact</code> and <code>blast-radius</code> aliases with stderr notices.<details><summary>Modified files (5)</summary><ul><li>src/bernstein/cli/commands/api_check_cmd.py</li>
<li>src/bernstein/cli/commands/dep_impact_cmd.py</li>
<li>src/bernstein/cli/commands/impact_cmd.py</li>
<li>src/bernstein/cli/main.py</li>
<li>tests/unit/test_impact_consolidation.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>cli(impact): point the...</td><td>August 09, 2026</td></tr>
<tr><td>chernistry</td><td>chore(voice): anti-ai-...</td><td>May 09, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3503?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

<!-- bot-ack: 3743151546 reason=Confirmed when raised and since fixed on the default branch rather than here. The alias was registered as a click.command, so cost-envelopes show was rejected at parse time before the callback ran. #3501 fixed it in 3e537e17 by keeping the alias a group and attaching the canonical subcommands by reference, and that is merged. This branch was cut from the raw #3138 commit and carried a parallel fix for the same defect, which was dropped during the rebase rather than replayed on top of the merged one. Verified on this head: bernstein cost-envelopes show --help exits 0 with the deprecation notice on stderr, and bare cost-envelopes --help prints the group usage line. The earlier note in this body recorded the id in backticks instead of an HTML comment, so the gate never counted it. -->
