### PR TITLE
cli(voice): move bernstein listen to optional voice extra (#3145)

### DIFF
--- a/docs/operations/voice-control.md
+++ b/docs/operations/voice-control.md
@@ -39,11 +39,14 @@ strings are passed through verbatim.
 
 ## Setup
 
+The audio and speech-to-text packages ship in the optional `voice`
+extra, not in the base install:
+
 ```
-pip install faster-whisper sounddevice numpy
+pip install 'bernstein[voice]'
 ```
 
-Requirements (`voice_cmd.py:283-296`):
+The extra pulls in (`pyproject.toml`, `[project.optional-dependencies]`):
 
 - `sounddevice` - microphone capture (PortAudio under the hood).
 - `numpy` - audio buffers.
@@ -59,8 +62,10 @@ Platform notes:
 - macOS: `brew install portaudio` is enough.
 - Windows: `pip install sounddevice` ships prebuilt wheels.
 
-The CLI exits with a clear install hint if any of the three deps are
-missing (`voice_cmd.py:271-296`).
+`bernstein listen` stays registered whether or not the extra is
+installed. If any of the three packages is missing it exits with
+status 1 and names `pip install 'bernstein[voice]'`
+(`voice_cmd.py:271-296`) rather than reporting an unknown command.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,6 +224,7 @@ dev = [
     "botocore-stubs>=1.43.14",  # botocore, same publisher
 ]
 grpc = ["grpcio>=1.68", "grpcio-tools>=1.68", "grpcio-reflection>=1.68", "protobuf>=5.29"]
+voice = ["faster-whisper>=1.0.0", "sounddevice>=0.4.0", "numpy>=1.20.0"]
 k8s = ["kubernetes>=35.0.0"]
 # SPIFFE/SPIRE workload-identity integration
 # (src/bernstein/core/identity/spiffe/workload_api.py). The py-spiffe SDK talks

--- a/src/bernstein/cli/commands/voice_cmd.py
+++ b/src/bernstein/cli/commands/voice_cmd.py
@@ -271,8 +271,9 @@ def _load_whisper_model(model_size: str) -> Any:
         from faster_whisper import WhisperModel
     except ImportError as exc:
         console.print(
-            "[red]Error:[/red] 'faster-whisper' is not installed.\n"
-            "Install it with: [bold]pip install faster-whisper[/bold]"
+            r"[red]Error:[/red] Voice dependencies are not installed."
+            "\n"
+            r"Install the voice extra with: [bold]pip install 'bernstein\[voice]'[/bold]"
         )
         raise SystemExit(1) from exc
 
@@ -288,10 +289,10 @@ def _import_audio_deps() -> tuple[Any, Any]:
 
         return np, sd
     except ImportError as exc:
-        missing = "sounddevice" if "sounddevice" in str(exc) else "numpy"
         console.print(
-            f"[red]Error:[/red] '{missing}' is not installed.\n"
-            f"Install it with: [bold]pip install sounddevice numpy[/bold]"
+            r"[red]Error:[/red] Voice dependencies are not installed."
+            "\n"
+            r"Install the voice extra with: [bold]pip install 'bernstein\[voice]'[/bold]"
         )
         raise SystemExit(1) from exc
 

--- a/src/bernstein/cli/commands/voice_cmd.py
+++ b/src/bernstein/cli/commands/voice_cmd.py
@@ -282,7 +282,18 @@ def _load_whisper_model(model_size: str) -> Any:
 
 
 def _import_audio_deps() -> tuple[Any, Any]:
-    """Import numpy and sounddevice or exit with an error message."""
+    """Import numpy and sounddevice, or exit 1 with an actionable message.
+
+    Two distinct failures are possible and they need different instructions.
+    A missing package raises ``ImportError`` and is fixed by installing the
+    ``voice`` extra. ``sounddevice`` also loads the PortAudio shared library
+    at import time, and when the wheel is installed but the system library is
+    not - the documented Linux case - it raises ``OSError`` instead. Installing
+    the extra again does not fix that one.
+
+    Raises:
+        SystemExit: Always, with code 1, when either import fails.
+    """
     try:
         import numpy as np
         import sounddevice as sd
@@ -293,6 +304,14 @@ def _import_audio_deps() -> tuple[Any, Any]:
             r"[red]Error:[/red] Voice dependencies are not installed."
             "\n"
             r"Install the voice extra with: [bold]pip install 'bernstein\[voice]'[/bold]"
+        )
+        raise SystemExit(1) from exc
+    except OSError as exc:
+        console.print(
+            f"[red]Error:[/red] Voice dependencies are installed but failed to load: {exc}\n"
+            "'sounddevice' needs the PortAudio system library at import time.\n"
+            "Install it with: [bold]apt install libportaudio2[/bold] (Debian/Ubuntu), "
+            "[bold]pacman -S portaudio[/bold] (Arch), or [bold]brew install portaudio[/bold] (macOS)."
         )
         raise SystemExit(1) from exc
 

--- a/src/bernstein/cli/commands/voice_cmd.py
+++ b/src/bernstein/cli/commands/voice_cmd.py
@@ -501,8 +501,8 @@ def listen_cmd(
       deploy prod: bernstein -g "deploy to production"
 
     \b
-    Requirements (install separately):
-      pip install faster-whisper sounddevice numpy
+    Requirements (optional extra, not installed by default):
+      pip install 'bernstein[voice]'
 
     \b
       bernstein listen                   # start voice session

--- a/tests/unit/test_voice_extra.py
+++ b/tests/unit/test_voice_extra.py
@@ -2,12 +2,51 @@
 
 from __future__ import annotations
 
+import builtins
 import tomllib
+from collections.abc import Iterator
 from pathlib import Path
+from typing import Any
 
+import pytest
 from click.testing import CliRunner
 
+from bernstein.cli.commands.voice_cmd import _import_audio_deps
 from bernstein.cli.main import cli
+
+_INSTALL_HINT = "pip install 'bernstein[voice]'"
+
+
+@pytest.fixture
+def block_imports(monkeypatch: pytest.MonkeyPatch) -> Iterator[Any]:
+    """Force ``ImportError`` for named top-level modules.
+
+    The voice code paths are reached only when the ``voice`` extra is absent.
+    Relying on the ambient environment makes the assertion accidental: on a
+    machine that has ``bernstein[voice]`` installed the same test would build a
+    real ``WhisperModel`` (a ~150 MB download) and then block on a live
+    microphone stream. Blocking the import explicitly keeps the branch under
+    test regardless of what is installed.
+    """
+    real_import = builtins.__import__
+
+    def _block(*names: str) -> None:
+        blocked = frozenset(names)
+
+        def fake_import(
+            name: str,
+            globals: dict[str, Any] | None = None,
+            locals: dict[str, Any] | None = None,
+            fromlist: tuple[str, ...] = (),
+            level: int = 0,
+        ) -> Any:
+            if name.partition(".")[0] in blocked:
+                raise ImportError(f"No module named {name.partition('.')[0]!r}")
+            return real_import(name, globals, locals, fromlist, level)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    yield _block
 
 
 def test_voice_optional_dependency_extra_defined() -> None:
@@ -23,8 +62,33 @@ def test_voice_optional_dependency_extra_defined() -> None:
     assert any("numpy" in dep for dep in voice_deps)
 
 
-def test_listen_without_extra_gives_informative_error() -> None:
-    runner = CliRunner()
-    res = runner.invoke(cli, ["listen"])
+def test_listen_without_extra_gives_informative_error(block_imports: Any) -> None:
+    """``bernstein listen`` names the extra when faster-whisper is missing."""
+    block_imports("faster_whisper")
+
+    res = CliRunner().invoke(cli, ["listen"])
+
     assert res.exit_code != 0
-    assert "pip install 'bernstein[voice]'" in res.output or "pip install 'bernstein[voice]'" in res.stderr
+    assert _INSTALL_HINT in res.output
+    assert "pip install faster-whisper" not in res.output
+
+
+def test_import_audio_deps_without_extra_gives_informative_error(
+    block_imports: Any,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The audio-capture import path names the extra too, not the raw packages.
+
+    ``_import_audio_deps`` is reached only after the whisper model loads, so the
+    ``listen`` end-to-end test never exercises it. Without this test its error
+    message can be reverted to the pre-#3145 wording with the suite still green.
+    """
+    block_imports("numpy", "sounddevice")
+
+    with pytest.raises(SystemExit) as excinfo:
+        _import_audio_deps()
+
+    assert excinfo.value.code == 1
+    out = capsys.readouterr().out
+    assert _INSTALL_HINT in out
+    assert "pip install sounddevice numpy" not in out

--- a/tests/unit/test_voice_extra.py
+++ b/tests/unit/test_voice_extra.py
@@ -92,3 +92,12 @@ def test_import_audio_deps_without_extra_gives_informative_error(
     out = capsys.readouterr().out
     assert _INSTALL_HINT in out
     assert "pip install sounddevice numpy" not in out
+
+
+def test_listen_help_documents_the_voice_extra() -> None:
+    """``bernstein listen --help`` points at the extra, not the raw packages."""
+    res = CliRunner().invoke(cli, ["listen", "--help"])
+
+    assert res.exit_code == 0
+    assert _INSTALL_HINT in res.output
+    assert "pip install faster-whisper sounddevice numpy" not in res.output

--- a/tests/unit/test_voice_extra.py
+++ b/tests/unit/test_voice_extra.py
@@ -1,0 +1,30 @@
+"""Unit tests for #3145: Moving bernstein listen to optional voice extra."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from bernstein.cli.main import cli
+
+
+def test_voice_optional_dependency_extra_defined() -> None:
+    pyproject_path = Path(__file__).resolve().parent.parent.parent / "pyproject.toml"
+    with pyproject_path.open("rb") as f:
+        data = tomllib.load(f)
+
+    extras = data.get("project", {}).get("optional-dependencies", {})
+    assert "voice" in extras, "voice optional dependency extra missing from pyproject.toml"
+    voice_deps = extras["voice"]
+    assert any("faster-whisper" in dep for dep in voice_deps)
+    assert any("sounddevice" in dep for dep in voice_deps)
+    assert any("numpy" in dep for dep in voice_deps)
+
+
+def test_listen_without_extra_gives_informative_error() -> None:
+    runner = CliRunner()
+    res = runner.invoke(cli, ["listen"])
+    assert res.exit_code != 0
+    assert "pip install 'bernstein[voice]'" in res.output or "pip install 'bernstein[voice]'" in res.stderr

--- a/tests/unit/test_voice_extra.py
+++ b/tests/unit/test_voice_extra.py
@@ -30,7 +30,7 @@ def block_imports(monkeypatch: pytest.MonkeyPatch) -> Iterator[Any]:
     """
     real_import = builtins.__import__
 
-    def _block(*names: str) -> None:
+    def _block(*names: str, error: BaseException | None = None) -> None:
         blocked = frozenset(names)
 
         def fake_import(
@@ -40,8 +40,9 @@ def block_imports(monkeypatch: pytest.MonkeyPatch) -> Iterator[Any]:
             fromlist: tuple[str, ...] = (),
             level: int = 0,
         ) -> Any:
-            if name.partition(".")[0] in blocked:
-                raise ImportError(f"No module named {name.partition('.')[0]!r}")
+            root = name.partition(".")[0]
+            if root in blocked:
+                raise error if error is not None else ImportError(f"No module named {root!r}")
             return real_import(name, globals, locals, fromlist, level)
 
         monkeypatch.setattr(builtins, "__import__", fake_import)
@@ -92,6 +93,28 @@ def test_import_audio_deps_without_extra_gives_informative_error(
     out = capsys.readouterr().out
     assert _INSTALL_HINT in out
     assert "pip install sounddevice numpy" not in out
+
+
+def test_missing_portaudio_is_not_reported_as_a_missing_extra(
+    block_imports: Any,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A PortAudio load failure gets its own instruction, not "install the extra".
+
+    ``sounddevice`` dlopens PortAudio at import time. With the wheel installed
+    but the system library absent - the documented Linux case - it raises
+    ``OSError``, which the ImportError handler does not catch, so the operator
+    got a raw traceback after already waiting through a ~150 MB model download.
+    """
+    block_imports("sounddevice", error=OSError("PortAudio library not found"))
+
+    with pytest.raises(SystemExit) as excinfo:
+        _import_audio_deps()
+
+    assert excinfo.value.code == 1
+    out = capsys.readouterr().out
+    assert "PortAudio" in out
+    assert _INSTALL_HINT not in out, "installing the extra does not fix a missing system library"
 
 
 def test_listen_help_documents_the_voice_extra() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -285,6 +285,32 @@ wheels = [
 ]
 
 [[package]]
+name = "av"
+version = "18.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/a4/570a5a35c8638aba01e739925846c35fdd6b0756a15526766d0a4dd3b7df/av-18.0.0.tar.gz", hash = "sha256:4ef7e72c3d3a872584a1215173b16e0226811037f40dcdbf75992631098df1ba", size = 4340222, upload-time = "2026-07-02T06:37:58.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/4a/9e3463df030e063d757fa12f0f39be6541b45b06b5bad48c2ce361b924bf/av-18.0.0-cp311-abi3-macosx_11_0_x86_64.whl", hash = "sha256:149289d40e732a6e49c9530bc245b49d9964cfd1c8c9e06778703b7d5bba6b25", size = 22499354, upload-time = "2026-07-02T06:36:58.751Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b3/2576a44b4f39c7462ced4c17fec04c756f7b0f3c5cb940d124173e417d6a/av-18.0.0-cp311-abi3-macosx_14_0_arm64.whl", hash = "sha256:35274c20d2ad3b4774fe632bcef2e34af79858ddf899352339cc3babbc13a484", size = 18175248, upload-time = "2026-07-02T06:37:01.741Z" },
+    { url = "https://files.pythonhosted.org/packages/84/74/6732f17b96dc23fd23b876b2805435855abdc8a3b397142be4e581165de8/av-18.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4d683b7747a0ba9222b8a5f81e41db5f796e7f64473454ec4fe2548e083c2fa0", size = 33387843, upload-time = "2026-07-02T06:37:05.097Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b9/7708c43fed7ae28b4a1bad060b4221e3334cd827cec24f7165902a6ac1f4/av-18.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ae56b40b6f8b067a8ad2dac664fbfbabac7f7a55b9a7bb031eb99289252bc017", size = 35536910, upload-time = "2026-07-02T06:37:08.806Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/94/eba99691d184f6a395a242d54dc370e2fd2265e95bbc98e2963a0fdbdd6c/av-18.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:ea2e8ebbce521f21b55df9400e00d721623c9020ef158f5a188a96130be0743f", size = 38984619, upload-time = "2026-07-02T06:37:11.861Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/cf/0d7aee07fe16aa9ffdf96043c14bed5485a52c0dea4259de87aa306ecab4/av-18.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef96dabb3e50dac249913145dff5424b302b257fd95dcb64be3c7b7a8aef16d1", size = 34451176, upload-time = "2026-07-02T06:37:15.154Z" },
+    { url = "https://files.pythonhosted.org/packages/76/92/810da80b12680d4c4fe235bd1b4003289be9213ac7f114b77b8ecf0e3b3e/av-18.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:0f65518a184613e41536f29e8758c8e3d8293e46bf5bef108f04f925bbfa3f44", size = 36619869, upload-time = "2026-07-02T06:37:18.495Z" },
+    { url = "https://files.pythonhosted.org/packages/11/85/0f121ff43dc5a70696676c98a8f1674e2fa787614c2abaacb15fa1a9bc99/av-18.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:aaf4d354d2beaa6651e4f92e54409a578bde64f79c0beef9a30b388d06f7c629", size = 27556236, upload-time = "2026-07-02T06:37:21.388Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f6/2509754d4d2356abc6fc0ea3d57c12ade29bac23a1fb7fc215a53ca518fb/av-18.0.0-cp311-abi3-win_arm64.whl", hash = "sha256:adac2b3833b6cb9bd6cb52664a522b94db453615b3675b1dbb26e13fe1c80da6", size = 20221133, upload-time = "2026-07-02T06:37:23.88Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/25/4ee23a7f1609adf9b2f140c7a8ffade64a1449d89ab431d922a809eebf19/av-18.0.0-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:88dd8e35e9242662b409a6a05fd24a6775d949eb05da0ba31cab4f250eacbab5", size = 22740741, upload-time = "2026-07-02T06:37:26.659Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/f0/b9f8363d07aa4521913e483f6a30c7c164973ef01de62769bf9b97049cd8/av-18.0.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:f8f454349c402e2c8d6fa80b54eb2a3f86c00f414d2b399f01ae6dab075c6fd8", size = 18384189, upload-time = "2026-07-02T06:37:29.518Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/e5/69397019aed280a72a43e97a252dee4295df1a9e608848452e5300ec4dab/av-18.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:88ce194c2201c6a6d40336adee8a5ddde46ed743eacb500e3ae9368d1c6d889e", size = 36749881, upload-time = "2026-07-02T06:37:33.096Z" },
+    { url = "https://files.pythonhosted.org/packages/37/3a/1614d74f0d676ea6745eb59553c9ad01ca25db523cba808d522e838f4f5b/av-18.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:aa15e567a018cc94a26b0ab45da676dee70c4146ace6e92e47d30cc9689cbfbe", size = 38645927, upload-time = "2026-07-02T06:37:37.086Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/3c/5f54710d69b0ea93634134f92b49c7a2a7fd27da5486a8a7e6251ac1cfb4/av-18.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:613153e48cefc91700746dde0ad0282d4677b194cba22cc771de14c78411cf8b", size = 40454783, upload-time = "2026-07-02T06:37:40.904Z" },
+    { url = "https://files.pythonhosted.org/packages/26/92/8293e6a267e0591b543abd96ae01e7e8ed228509bdb4e4644a8a8395d90f/av-18.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:30404f53ca1ea7f350ac86ff22a2c04f903014758e9b33f398c5a62de34bd84f", size = 37573117, upload-time = "2026-07-02T06:37:44.856Z" },
+    { url = "https://files.pythonhosted.org/packages/10/0c/38ed7601277ae57dfe857d040be4762530fd728efff45c2fb8f035fef96a/av-18.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6882a48f7aec2863c96cddee3256ff2da98f7fb6cbed83cee9d7e70a8f186a6b", size = 39669026, upload-time = "2026-07-02T06:37:48.761Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/0636ca04d5d89d01c49bd366d2b660cc85d1f8117c476b2be62eb0c70855/av-18.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:55a646e9afce9fdc5de5224205a8a12c7ed1ba9803145dcc876c40bfc03a109b", size = 28448336, upload-time = "2026-07-02T06:37:52.477Z" },
+    { url = "https://files.pythonhosted.org/packages/01/20/1e24450ea981c44ed328691496fd2774dfa9fa3c3b00fd07f72fd5614abe/av-18.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:96f594ff506a09475e5549359352332049a25d37a08f00b4623f7f6e92e45b9c", size = 21377289, upload-time = "2026-07-02T06:37:55.935Z" },
+]
+
+[[package]]
 name = "azure-core"
 version = "1.39.0"
 source = { registry = "https://pypi.org/simple" }
@@ -483,6 +509,11 @@ teams = [
 telegram = [
     { name = "python-telegram-bot" },
 ]
+voice = [
+    { name = "faster-whisper" },
+    { name = "numpy" },
+    { name = "sounddevice" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -551,6 +582,7 @@ requires-dist = [
     { name = "docker", marker = "extra == 'docker'", specifier = ">=7.1.0" },
     { name = "e2b-code-interpreter", marker = "extra == 'e2b'", specifier = ">=1.0" },
     { name = "fastapi", specifier = ">=0.115" },
+    { name = "faster-whisper", marker = "extra == 'voice'", specifier = ">=1.0.0" },
     { name = "google-cloud-storage", marker = "extra == 'gcs'", specifier = ">=3.10.1" },
     { name = "grpcio", marker = "extra == 'grpc'", specifier = ">=1.68" },
     { name = "grpcio-reflection", marker = "extra == 'grpc'", specifier = ">=1.68" },
@@ -567,6 +599,7 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.28.1,<2" },
     { name = "modal", marker = "extra == 'modal'", specifier = ">=1.4.2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.18.2" },
+    { name = "numpy", marker = "extra == 'voice'", specifier = ">=1.20.0" },
     { name = "openai", specifier = ">=2.36.0" },
     { name = "openai-agents", marker = "extra == 'openai'", specifier = ">=0.4.0" },
     { name = "opentelemetry-api", specifier = ">=1.41.1" },
@@ -607,6 +640,7 @@ requires-dist = [
     { name = "setproctitle", specifier = ">=1.3" },
     { name = "signxml", specifier = ">=4.0" },
     { name = "slack-sdk", marker = "extra == 'slack'", specifier = ">=3.27" },
+    { name = "sounddevice", marker = "extra == 'voice'", specifier = ">=0.4.0" },
     { name = "spiffe", marker = "extra == 'spiffe'", specifier = ">=0.2" },
     { name = "sse-starlette", marker = "extra == 'gui'", specifier = ">=2.1.0" },
     { name = "starlette", specifier = ">=1.0.1" },
@@ -626,7 +660,7 @@ requires-dist = [
     { name = "watchdog", specifier = ">=4.0" },
     { name = "websockets", specifier = ">=14.0" },
 ]
-provides-extras = ["dev", "grpc", "k8s", "spiffe", "ml", "browser", "graphics", "openai", "docker", "e2b", "modal", "s3", "gcs", "azure", "r2", "telegram", "slack", "discord", "teams", "eval", "gui", "otel", "observability"]
+provides-extras = ["dev", "grpc", "voice", "k8s", "spiffe", "ml", "browser", "graphics", "openai", "docker", "e2b", "modal", "s3", "gcs", "azure", "r2", "telegram", "slack", "discord", "teams", "eval", "gui", "otel", "observability"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1221,6 +1255,38 @@ wheels = [
 ]
 
 [[package]]
+name = "ctranslate2"
+version = "4.8.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pyyaml" },
+    { name = "setuptools" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/09/9a50eeab00db68aeac08f6ab7f98b5c36abd26b89cbd707ea39e70656500/ctranslate2-4.8.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9de0dddd91ae68da0a7323441e90708d14b31d31cd443004dda0e1198b5bf11e", size = 1270522, upload-time = "2026-07-03T12:39:13.368Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/97/6c41c4d3ae539ec76b1943c362184677befd7c1d5290d2ec361182cdb1e0/ctranslate2-4.8.1-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:82e0e6eb7d4301fd79a714495c8faf34242e09542cef04c9e9794c3fe90014a1", size = 11930367, upload-time = "2026-07-03T12:39:14.896Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/d4/03428106134a0a58922461074f8942f92c5ed0bb3a8d018677ad64a9c476/ctranslate2-4.8.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5ca144b93035b9f53e6d67b7cdf5802c3fffca9aa0247940eecbd4592c68ce2f", size = 16882768, upload-time = "2026-07-03T12:39:17.425Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c9/976a565398a03fb2973cbe5edd5ca03c4332d86b634799e0ee562420d3bc/ctranslate2-4.8.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dacc408f716ebc73b3b3c6ddd937700e776c4c68b6d9c81862990150ff0f6af6", size = 39529060, upload-time = "2026-07-03T12:39:20.468Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/82/0a5f7f2b03b4e10aacb3146715724e1b96bb993cc7d199be28c9825aa120/ctranslate2-4.8.1-cp312-cp312-win_amd64.whl", hash = "sha256:49f96e861b57301f0b76a082109bde2cac8204a6b4fedc870883008271e82251", size = 19220789, upload-time = "2026-07-03T12:39:23.356Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a7/3101c3a0785253a8ef386f39744ad19c28c75b7f227e7c232aee7a5c416a/ctranslate2-4.8.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ba628835e6ad4ad399261ab6cb51bf152de563e6b122a9e8eb0c61e69f925931", size = 1270478, upload-time = "2026-07-03T12:39:25.401Z" },
+    { url = "https://files.pythonhosted.org/packages/89/b9/e50c7558e96a054d6b1e6a6c5e729dda4a4f05584e065f2902aa5f1bc4c8/ctranslate2-4.8.1-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:85ef15ce0b2172ec471975b8a30d5c5bc71e7cffcd163ad6c07ea32f1943d940", size = 11930241, upload-time = "2026-07-03T12:39:26.927Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/2f/ea7a19c6d7e949b731fb034664633184bbfc7882846d107f4d790693fb76/ctranslate2-4.8.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0030670278a73cae09dff9bca72cdd248af61f9367257f18db9b3b94fbb3a50d", size = 16883512, upload-time = "2026-07-03T12:39:29.302Z" },
+    { url = "https://files.pythonhosted.org/packages/99/4a/21f325a9d0925d8ad24b04249adf29bf9909442967603634f7f6d4acbb79/ctranslate2-4.8.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4242a7f8e285f922525f4cffd5b1fb43cbacc61d0611cf54832e9c447d030840", size = 39529085, upload-time = "2026-07-03T12:39:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e7/37da1a7500b57496a5269318c4f57962ea0c26dcac06b85222d7831acf00/ctranslate2-4.8.1-cp313-cp313-win_amd64.whl", hash = "sha256:d52499f05a60a791aeadee28d609efa130142f376d1ea76b2b1c593bb01f8827", size = 19220784, upload-time = "2026-07-03T12:39:35.74Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/66/39111224e418400d97fd79fbc9e72329c51f91a3e7a9c9a1a182e4f88022/ctranslate2-4.8.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b4c3246aa4a7f309109a841ca743a72cc4abad4f93c0bf7da691023323215621", size = 1271321, upload-time = "2026-07-03T12:39:37.907Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/89/13f827fae226eea51315729c00111f716813d7736ebb827fecb8f361fe0d/ctranslate2-4.8.1-cp314-cp314-macosx_11_0_x86_64.whl", hash = "sha256:c989f747789e8619cbc2e06443b3674c31bc71bad0369652485bd894b627360a", size = 11930735, upload-time = "2026-07-03T12:39:39.534Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/94/4b73f9bbaba29df4227cc65114f11d83fe6d696ef3705cb1ade79eb118fd/ctranslate2-4.8.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c90eb0bd67b6bb183712cc3fd14bf01ec4f622cd625c5b33cc6c56be7d1c9c34", size = 16872460, upload-time = "2026-07-03T12:39:42.272Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/d0/9816494d5ff0745bdf9abe5af04e57a103a416444e604cbe83a6eb0aed7b/ctranslate2-4.8.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e3e3aef4670a6c8dcea367401675f82b49b02c18f5837221bcd7cca90b1707a8", size = 39494736, upload-time = "2026-07-03T12:39:45.733Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/dc/22a2c874ca8bb6caa7018dfefdff92dddd487db31cf169891c4c6d408091/ctranslate2-4.8.1-cp314-cp314-win_amd64.whl", hash = "sha256:a2dcce0a57beee984a691d9daa8fc3fd389f5b6cada2644c34571011833bd5b1", size = 19477164, upload-time = "2026-07-03T12:39:48.952Z" },
+    { url = "https://files.pythonhosted.org/packages/77/39/7b8d47bf49748ba73182742683eef74b46608beb879765d9d4efc46bc345/ctranslate2-4.8.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a28c5889585cd17ee3649dfd46d9002ddf50204173f8bff476b9f76d6585795", size = 1293935, upload-time = "2026-07-03T12:39:50.924Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/20/434e30c752c433eaef5deccd4de54775bc1f205a6fe6c9e756b737018209/ctranslate2-4.8.1-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:911a5cdef8a405c1804330613a1865f616eb9c092a0e932ee4648128eb20b627", size = 11951789, upload-time = "2026-07-03T12:39:52.886Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f2/d716426220b462bbb5bb354b9c6c8d9a41285f067203c860cc79f9f19917/ctranslate2-4.8.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:84723cae6f802551bbf2438e5e4810722631a2183b89a82c31df26566b54821d", size = 16860414, upload-time = "2026-07-03T12:39:55.54Z" },
+    { url = "https://files.pythonhosted.org/packages/69/11/cdab0e7e2ad4e547f15ab227c09207569f1272abae05816900ecebb0797a/ctranslate2-4.8.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1910752ec541980644191fa3b407bc61dee00e88070b0aed29b4cef75010b3ea", size = 39465200, upload-time = "2026-07-03T12:39:59.017Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/03/126e963fc3237a416f3085b8a663ebd8ab449ed6c37195b4e0b49597ba0c/ctranslate2-4.8.1-cp314-cp314t-win_amd64.whl", hash = "sha256:dc9f1abef55579cc02cdc74b3a55df38491ec56d177d6e6039609d61d09ed30e", size = 19499597, upload-time = "2026-07-03T12:40:01.68Z" },
+]
+
+[[package]]
 name = "cyclonedx-python-lib"
 version = "11.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1399,12 +1465,36 @@ wheels = [
 ]
 
 [[package]]
+name = "faster-whisper"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "av" },
+    { name = "ctranslate2" },
+    { name = "huggingface-hub" },
+    { name = "onnxruntime" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/99/49ee85903dee060d9f08297b4a342e5e0bcfca2f027a07b4ee0a38ab13f9/faster_whisper-1.2.1-py3-none-any.whl", hash = "sha256:79a66ad50688c0b794dd501dc340a736992a6342f7f95e5811be60b5224a26a7", size = 1118909, upload-time = "2025-10-31T11:35:47.794Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.29.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+]
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
 ]
 
 [[package]]
@@ -3057,6 +3147,38 @@ wheels = [
 ]
 
 [[package]]
+name = "onnxruntime"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/f8/dcbe7700dca82fa540035abd3c868fe5ad0f86af00b9a3db7c2e27d15c7d/onnxruntime-1.28.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:26ff0fdd06efb6c155bae95387a09db1a2be89c7a03e4d0bffd5a171cc2826da", size = 19141362, upload-time = "2026-07-25T01:22:36.965Z" },
+    { url = "https://files.pythonhosted.org/packages/28/5b/1d77e62097fdbe07e2dc827f389b1c4c0c275f6fab0369a8f46d2461af27/onnxruntime-1.28.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e81a23df16e7acb9d51b06d30cc098e49315ef9180f97bc2221d167b4b04d9c", size = 17050628, upload-time = "2026-07-25T01:21:40.481Z" },
+    { url = "https://files.pythonhosted.org/packages/95/df/5486ab03e9be288d5268867054c8b04bebcf95bfd12e801c05cc67703dab/onnxruntime-1.28.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0a83bdb70d143cede762b677789bf2a7acca54b3fb82565601d5c30695aa933c", size = 19214257, upload-time = "2026-07-25T01:22:01.695Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/3b/986ca67c274932ba9ac5332fb10de56f643dfd433c74e33f8ae8f847cf24/onnxruntime-1.28.0-cp312-cp312-win_amd64.whl", hash = "sha256:c35064f9b3c43c81c5d5d282091401d0f1ff22796d93ccade4ea2ece5e137ab8", size = 13755036, upload-time = "2026-07-25T01:22:26.89Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/46/059dba81d46c6ba88e0c2d1c64321ac8098847d678423300a183d42ecbd6/onnxruntime-1.28.0-cp312-cp312-win_arm64.whl", hash = "sha256:e02feeb0165c5f13b4cc954738078d59b90128516ac12b671ee24a530242bf02", size = 13454462, upload-time = "2026-07-25T01:22:17.38Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/12/3807e2b17d9eb71d3cb78ed2ba76869b05c637c9b9d6112e636098b0c97a/onnxruntime-1.28.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:31410f544674f534c2f27348af52ef81682ca9c8719154bf4d48f0ef23823b1e", size = 19141759, upload-time = "2026-07-25T01:21:53.765Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/23/b46045c3bf67a9cf54c12f5df0f018a422c65fbb9d6072b10071bebfaae2/onnxruntime-1.28.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f649dd6f6452d12a8059888aa489fe519e062e18793dac72b9efa0f9fdb64135", size = 17049339, upload-time = "2026-07-25T01:21:43.005Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b6/8c5396e7894e77c5a7d1e026f3acb9dd39c4b5644e412e37a0055eaa3bc5/onnxruntime-1.28.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:54fa221d669282bd8f582708ce4c96010a7e9fb0661f9006b37fe2fedafb73fe", size = 19214329, upload-time = "2026-07-25T01:22:04.133Z" },
+    { url = "https://files.pythonhosted.org/packages/56/f1/51225c202edba4dfc94e1ea03f3d78f1aaf307da75fd792c0ce1946b2514/onnxruntime-1.28.0-cp313-cp313-win_amd64.whl", hash = "sha256:1a1a19175464665c9b8d50bc916f216cc0b569110045b7bbca8f9f290b186f58", size = 13755033, upload-time = "2026-07-25T01:22:29.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/db/f59f715edfdd96a051f32b5ef0e680a20a8755d4ecd75f63090e960e347a/onnxruntime-1.28.0-cp313-cp313-win_arm64.whl", hash = "sha256:cfab507abe09d6ffeb817eee07944d452fdc0b00fdcef34cab4db10a45e378c7", size = 13454175, upload-time = "2026-07-25T01:22:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/47/28/810314fa88647af9f4cdaf438a30ad1cfebebb53ded55499232d7a0094e6/onnxruntime-1.28.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac301f53b1930402fc46c368e268acfed02f3207272aaff05070d7e09f96f031", size = 17057307, upload-time = "2026-07-25T01:21:45.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/cc/9e9f193cc0f29f263a8f09ec08487aed6c96ee856d5fd77da32a425c1949/onnxruntime-1.28.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f7f022a1103cae591c75fc4565589a515f2ddd14a6ac8e8a05812dfeda142e28", size = 19222954, upload-time = "2026-07-25T01:22:06.952Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/eb/952314c451d9463e5c9aed9978eec76cf32930d407d9ab8700dd0f4ea1ea/onnxruntime-1.28.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:8adff67a3f28257b37cfe945a7e952e4122666aa8c91a0380862e9fd4c2ed19f", size = 19143748, upload-time = "2026-07-25T01:21:56.297Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e9/139180b4dd810329aaa42c238b4e6383c906202d98609ae29d66eb7c32b1/onnxruntime-1.28.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bc2565e487b4896fb988d6383577d875d958e071fc5f6c3550bd5d02ae98264b", size = 17051950, upload-time = "2026-07-25T01:21:48.606Z" },
+    { url = "https://files.pythonhosted.org/packages/03/88/9432428273356ad3c8aa01f52c1b3e7f53c4c0192748f41ad983872b436b/onnxruntime-1.28.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6afdc83f1317c136e92fc29f5ee9f058de59d87c0b22cee3fdbfbaa0ccc2098a", size = 19214924, upload-time = "2026-07-25T01:22:09.727Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/e2/6feb3a43517aaf2b1bf7e46897ba5eb81a29717f7d7901420614d5ee4653/onnxruntime-1.28.0-cp314-cp314-win_amd64.whl", hash = "sha256:f2a3b9e30ce880d4ca54999cb313569e36da4f62eefe25f87be18f43e9a3a4d5", size = 14093738, upload-time = "2026-07-25T01:22:31.629Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/8f/83974a1e201dc2e58e5e7111bcaeb1ca2413e9c41f505d26419ee9e3dddf/onnxruntime-1.28.0-cp314-cp314-win_arm64.whl", hash = "sha256:07fb3cbe990d6bf0ab3c22bfbbfb0e314151266046ea6edb4a07f556b4258c5f", size = 13821117, upload-time = "2026-07-25T01:22:22.387Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/83/00e606bc25c756d76a267370c39b7516ad52f9cf134d7ff2bff8b6108bc4/onnxruntime-1.28.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e562d6e36a749f6764481c0ddb0f2af3d0b5a3c164291361d08803c557f369af", size = 17055518, upload-time = "2026-07-25T01:21:51.08Z" },
+    { url = "https://files.pythonhosted.org/packages/94/a9/68707e1ce345cbdbcd4df65932ebc82a673e917d63eda0007ebcff948691/onnxruntime-1.28.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4f6e92367ddce1e4d33cf295024f40192be6c6171a09208f515ba169ced06c8e", size = 19222976, upload-time = "2026-07-25T01:22:12.474Z" },
+]
+
+[[package]]
 name = "openai"
 version = "2.36.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4473,8 +4595,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -4626,6 +4748,22 @@ wheels = [
 ]
 
 [[package]]
+name = "sounddevice"
+version = "0.5.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/f9/2592608737553638fca98e21e54bfec40bf577bb98a61b2770c912aab25e/sounddevice-0.5.5.tar.gz", hash = "sha256:22487b65198cb5bf2208755105b524f78ad173e5ab6b445bdab1c989f6698df3", size = 143191, upload-time = "2026-01-23T18:36:43.529Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/0a/478e441fd049002cf308520c0d62dd8333e7c6cc8d997f0dda07b9fbcc46/sounddevice-0.5.5-py3-none-any.whl", hash = "sha256:30ff99f6c107f49d25ad16a45cacd8d91c25a1bcdd3e81a206b921a3a6405b1f", size = 32807, upload-time = "2026-01-23T18:36:35.649Z" },
+    { url = "https://files.pythonhosted.org/packages/56/f9/c037c35f6d0b6bc3bc7bfb314f1d6f1f9a341328ef47cd63fc4f850a7b27/sounddevice-0.5.5-py3-none-macosx_10_6_x86_64.macosx_10_6_universal2.whl", hash = "sha256:05eb9fd6c54c38d67741441c19164c0dae8ce80453af2d8c4ad2e7823d15b722", size = 108557, upload-time = "2026-01-23T18:36:37.41Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a1/d19dd9889cd4bce2e233c4fac007cd8daaf5b9fe6e6a5d432cf17be0b807/sounddevice-0.5.5-py3-none-win32.whl", hash = "sha256:1234cc9b4c9df97b6cbe748146ae0ec64dd7d6e44739e8e42eaa5b595313a103", size = 317765, upload-time = "2026-01-23T18:36:39.047Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/0e/002ed7c4c1c2ab69031f78989d3b789fee3a7fba9e586eb2b81688bf4961/sounddevice-0.5.5-py3-none-win_amd64.whl", hash = "sha256:cfc6b2c49fb7f555591c78cb8ecf48d6a637fd5b6e1db5fec6ed9365d64b3519", size = 365324, upload-time = "2026-01-23T18:36:40.496Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/39/a61d4b83a7746b70d23d9173be688c0c6bfc7173772344b7442c2c155497/sounddevice-0.5.5-py3-none-win_arm64.whl", hash = "sha256:3861901ddd8230d2e0e8ae62ac320cdd4c688d81df89da036dcb812f757bb3e6", size = 317115, upload-time = "2026-01-23T18:36:42.235Z" },
+]
+
+[[package]]
 name = "spiffe"
 version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4757,6 +4895,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/60/21f715d9faba5f5407ff759472ade058ec4a507ad62bcea47cb847239a73/tokenizers-0.23.1.tar.gz", hash = "sha256:1feeeadf865a7915adc25445dea30e9933e593c31bb96c277cee36de227c8bfa", size = 365748, upload-time = "2026-04-27T14:43:25.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/39/b87a87d5bb9470610b80a2d31df42fcffeaf35118b8b97952b2aff598cc7/tokenizers-0.23.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e03d6ffcbe0d56ee9c1ccd070e70a13fa750727c0277e138152acbc0252c2224", size = 3146732, upload-time = "2026-04-27T14:43:15.427Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6a/068ed9f6e444c9d7e9d55ce134181325700f3d7f30410721bdc8f848d727/tokenizers-0.23.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e0948bbb1ac1d7cdfc9fb6d62c596e3b7550036ad60ecd654a66ad273326324e", size = 3054954, upload-time = "2026-04-27T14:43:13.745Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/36/e006edf031154cba92b8416057d92c3abe3635e4c4b0aa0b5b9bb39dde70/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bf13402aff9bc533c89cb849ec3b412dc3fbeacc9744840e423d7bf3f7dc0e3", size = 3374081, upload-time = "2026-04-27T14:43:01.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ef/7735d226f9c7f874a6bee5e3f27fb25ecabdf207d37b8cf45286d0795893/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f836ca703b89ae07919a309f9651f7a88fd5a33d5f718ba5ad0870ec0256bad6", size = 3247641, upload-time = "2026-04-27T14:43:03.856Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d9/24827036f6e21297bfffda0768e58eb6096a4f411e932964a01707857931/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae848657742035523fdf261773630cb819a26995fcd3d9ecae0c1daf6e5a4959", size = 3585624, upload-time = "2026-04-27T14:43:10.664Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/22f3582b3a4f49358293a5206e25317621ee4526bfe9cdaa0f07a12e770e/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:53b09e85775d5187941e7bab30e941b4134ab4a7dd8c68e783d231fb7ca27c51", size = 3844062, upload-time = "2026-04-27T14:43:05.643Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/65/b8f8814eef95800f20721384136d9a1d22241d50b2874357cb70542c392f/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea5a0ce170074329faaa8ea3f6400ecde604b6678192688533af80980daae71a", size = 3460098, upload-time = "2026-04-27T14:43:08.854Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/d5/1353e5f677ec27c2494fb6a6725e82d56c985f53e90ec511369e7e4f02c6/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5075b405006415ea148a992d093699c66eb01952bf59f4d5727089a98bda45a4", size = 3346235, upload-time = "2026-04-27T14:43:12.377Z" },
+    { url = "https://files.pythonhosted.org/packages/71/89/39b6b8fc073fb6d413d0147aa333dc7eff7be65639ac9d19930a0b21bf33/tokenizers-0.23.1-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:56f3a77de629917652f876294dc9fe6bad4a0c43bc229dc72e59bb23a0f4729a", size = 3426398, upload-time = "2026-04-27T14:43:07.264Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/80/127c854da64827e5b79264ce524993a90dddcb320e5cd42412c5c02f9e8a/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9d10a6d957ef01896dc274e890eee27d41bd0e74ef31e60616f0fc311345184e", size = 9823279, upload-time = "2026-04-27T14:43:17.222Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ba/44c2502feb1a058f096ddfb4e0996ef3225a01a388e1a9b094e91689fe93/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:1974288a609c343774f1b897c8b482c791ab17b75ab5c8c2b1737565c1d82288", size = 9644986, upload-time = "2026-04-27T14:43:19.45Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c1/464019a9fb059870bfe4eebb4ba12208f3042035e258bf5e782906bd3847/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:120468fb4c24faf0543c835a4fabafa4deb3f20a035c9b6e83d0b553a97615d4", size = 9976181, upload-time = "2026-04-27T14:43:21.463Z" },
+    { url = "https://files.pythonhosted.org/packages/79/94/3ac1432bda31626071e9b6a12709b97ae05131c804b94c8f3ac622c5da32/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e3d8f40ea6268047de7046906326abed5134f27d4e8447b23763afe5808c8a96", size = 10113853, upload-time = "2026-04-27T14:43:23.617Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/dd/631b21433c771b1382535326f0eca80b9c9cee2e64961dd993bc9ac4669e/tokenizers-0.23.1-cp310-abi3-win32.whl", hash = "sha256:93120a930b919416da7cd10a2f606ac9919cc69cacae7980fa2140e277660948", size = 2536263, upload-time = "2026-04-27T14:43:29.888Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/2553f72aaf65a2797d4229e37fa7fbe38ffbf3e32912d31bdd78b3323e59/tokenizers-0.23.1-cp310-abi3-win_amd64.whl", hash = "sha256:e7bfaf995c1bdbbd21d13539decb6650967013759318627d85daeb7881af16b7", size = 2798223, upload-time = "2026-04-27T14:43:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2b/2be299bab55fc595e3d38567edb1a87f86e594842968fa9515a07bdcf422/tokenizers-0.23.1-cp310-abi3-win_arm64.whl", hash = "sha256:a26197957d8e4425dfba746315f3c425ea00cfa8367c5fbc4ec73447893dcea9", size = 2664127, upload-time = "2026-04-27T14:43:26.949Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# User description
# Summary

Declares the speech-to-text and audio packages (`faster-whisper`, `sounddevice`, `numpy`) as a `voice` optional-dependency extra so `bernstein listen` has a supported, locked install path: `pip install 'bernstein[voice]'`. The command name and every flag are unchanged; when the extra is absent the command exits 1 naming the extra rather than reporting an unknown command.

Closes #3145.

### Correction to the original description

The first version of this description said the change "moves the heavy audio dependencies into an optional extra ... keeping core orchestration dependency surfaces clean". That is not what the diff does, and #3145's premise ("they are still declared dependencies of the core package") does not hold either. The three packages were never in `[project.dependencies]`; they were undeclared anywhere in `pyproject.toml`. Verified:

```
$ git show origin/main:pyproject.toml | grep -n 'numpy\|faster-whisper\|sounddevice'
816:# toolchains (sounddevice/PortAudio, weasyprint/cairo+pango), multi-
817:# gigabyte ML runtimes (faster-whisper), and import-time-patching APM
826:    "sounddevice.*",  # cli/commands/voice_cmd.py
```

Only comments and a mypy override — no dependency entries. The core dependency list is byte-identical before and after:

```
$ python - <<'PY'
... tomllib.loads(git show <ref>:pyproject.toml)["project"]["dependencies"] ...
PY
origin/main core deps: 34
HEAD core deps       : 34
identical            : True
symmetric difference : []
```

So `pip install bernstein` resolves to exactly the same closure as before this PR. The change is additive: it turns an undocumented "install these three yourself" step into a declared, locked extra. That is the accurate claim, and it is the one the tests assert.

### What changed

| File | Change |
|---|---|
| `pyproject.toml` | New `voice` extra: `faster-whisper>=1.0.0`, `sounddevice>=0.4.0`, `numpy>=1.20.0`. |
| `uv.lock` | Locks the extra and its transitive closure (`av`, `ctranslate2`, `onnxruntime`, `tokenizers`, `flatbuffers`). `numpy` was already locked. |
| `src/bernstein/cli/commands/voice_cmd.py` | Both `ImportError` handlers name `pip install 'bernstein[voice]'`. `listen --help` now names the extra instead of the three raw packages. |
| `docs/operations/voice-control.md` | Setup section points at the extra and states that `listen` stays registered without it. |
| `tests/unit/test_voice_extra.py` | Four tests, described below. |

### Verification

Lock consistent with `pyproject.toml`:

```
$ uv lock --check
Resolved 266 packages in 7ms
```

No module imports `numpy` unconditionally — the only import in `src/` is the guarded one inside `voice_cmd._import_audio_deps`:

```
$ grep -rn --include='*.py' -E '^[[:space:]]*(import numpy|from numpy)' src/
src/bernstein/cli/commands/voice_cmd.py:287:        import numpy as np
```

Tests:

```
$ uv run pytest tests/unit/test_voice_extra.py tests/unit/test_voice_control.py tests/unit/test_readme_api_coverage.py -q
38 passed, 1 warning in 6.76s

$ uv run ruff check src/bernstein/cli/commands/voice_cmd.py tests/unit/test_voice_extra.py
All checks passed!

$ uv run ruff format --check src/bernstein/cli/commands/voice_cmd.py tests/unit/test_voice_extra.py
2 files already formatted
```

Each test was checked against a broken copy of the code it covers:

| Mutation | Test that goes red |
|---|---|
| `_load_whisper_model` message reverted to pre-#3145 wording | `test_listen_without_extra_gives_informative_error` |
| `_import_audio_deps` message reverted to pre-#3145 wording | `test_import_audio_deps_without_extra_gives_informative_error` |
| `listen --help` reverted to `pip install faster-whisper sounddevice numpy` | `test_listen_help_documents_the_voice_extra` |
| `voice` extra removed from `pyproject.toml` | `test_voice_optional_dependency_extra_defined` |

### Defects found and fixed on this branch

1. **`_import_audio_deps` was uncovered.** It is reached only after the whisper model loads, so the end-to-end `listen` invocation never got there. Reverting its message to the pre-#3145 wording left the suite green. Now covered directly.
2. **The `listen` test depended on the ambient environment.** It reached the error branch only because faster-whisper happens to be absent from the dev image. On a machine with `bernstein[voice]` installed the same invocation constructs a real `WhisperModel` (~150 MB download) and then blocks on a live microphone stream. The imports are now blocked explicitly, so the branch is exercised whatever is installed.
3. **`bernstein listen --help` and `docs/operations/voice-control.md` still documented `pip install faster-whisper sounddevice numpy`.** Following either installs the packages without recording the extra, so a later `pip install -e .` drops them again with no diagnostic. Both now name `pip install 'bernstein[voice]'`.

### CI is red on two tests this branch does not introduce

Both failures are present at the commit this branch inherited (`12b6a3ec`) and are green on `origin/main`. Bisected across the stack:

```
$ for c in origin/main dbfc4b08 87c5008e af675a1d ccdfd082; do git checkout -q $c; \
    uv run pytest tests/unit/test_cli_decomposition.py::test_backward_compat_main_imports \
                  tests/unit/sandbox/test_pool_cmd.py::TestPoolCli::test_register_list_show -q; done
origin/main  2 passed
dbfc4b08     1 failed, 1 passed
87c5008e     1 failed, 1 passed
af675a1d     1 failed, 1 passed
ccdfd082     2 failed
```

**`tests/unit/sandbox/test_pool_cmd.py::TestPoolCli::test_register_list_show`** - broken by `dbfc4b08` (#3138, PR #3501). `pool_group` now emits a deprecation warning; it correctly goes to stderr, but the test parses `res.output`, which under Click 8.3 is stdout and stderr combined:

```
--- stdout ---  '{\n  "pools": {}\n}\n'
--- stderr ---  "WARNING: 'bernstein pool' is deprecated ... use 'bernstein limits pool' instead.\n"
--- output ---  the two concatenated, so json.loads() fails on char 0
```

The production stream split is right - a `bernstein pool list --json | jq` pipe stays clean. The assertion should read `res.stdout`. That belongs on #3501, with the warning that provoked it.

**`tests/unit/test_cli_decomposition.py::test_backward_compat_main_imports`** - broken by `ccdfd082` (#3143, PR #3504), which renamed the `bernstein.cli.main` re-export `benchmark_group` to `benchmark_alias_group`. That test exists to hold the backward-compatible import surface of `bernstein.cli.main`, so `from bernstein.cli.main import benchmark_group` is now an ImportError for any existing caller. Editing the test to import the new name would remove the only thing guarding that surface, so the fix is to keep `benchmark_group` exported alongside the new name - a decision for #3504.

Neither file is in this diff and neither fix is applied here: patching them from this branch would mask the regression on the PRs that own it (#3501 is already red on its own shard 2, #3504 on its own shard 3) and would conflict on rebase. `CI gate` stays red on this branch until those two land.

### Stacking note for the reviewer

This branch is stacked on #3501 → #3502 → #3503 → #3504 but targets `main`, so merging it alone would carry those four commits into `main` as well. The five must-address review findings on this PR are all in files owned by #3501 and #3502 — none is in the voice diff. Each has a verified reproduction posted in its thread and is acknowledged below with a pointer to the owning PR. Land those first, or rebase this branch onto the fixed stack.

<!-- bot-ack: 3743168173 reason=Confirmed defect in artifact_cmd.py, introduced by dbfc4b08 (#3138) and owned by PR #3501 where baz raised it as 3743134695. Outside the voice diff; verified reproduction posted in the thread. -->
<!-- bot-ack: 3743168175 reason=Confirmed defect in run_confirm.py demo --flask-todo, introduced by 87c5008e (#3140) and owned by PR #3502 where baz raised the same code path as 3743144057. Outside the voice diff; verified reproduction posted in the thread. -->
<!-- bot-ack: 3743168177 reason=Confirmed gap in init --wizard, introduced by 87c5008e (#3140) and owned by PR #3502. Reproduced (Error: No such option: --non-interactive) in the thread; the deprecated init-wizard alias still works today so nothing is broken before v4.0.0. -->
<!-- bot-ack: 3743168180 reason=Confirmed silent no-op of --add-badge/--badge-variant/--remote under init --wizard, introduced by 87c5008e (#3140) and owned by PR #3502. Outside the voice diff; analysis posted in the thread. -->
<!-- bot-ack: 3743168183 reason=Confirmed break of bernstein cost-envelopes show, introduced by dbfc4b08 (#3138) and owned by PR #3501 where baz raised it as 3743134693. Reproduced (exit 2, No such option: --json) in the thread. -->

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Declare the <code>voice</code> optional dependency extra and lock its speech-to-text and audio packages for <code>bernstein listen</code>. Update <code>voice_cmd</code> error handling, CLI help, documentation, and tests so missing dependencies recommend <code>pip install &#x27;bernstein[voice]&#x27;</code> while missing PortAudio receives system-library guidance.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3505?tool=ast&topic=Listen+diagnostics>Listen diagnostics</a>
        </td><td>Improve <code>bernstein listen</code> guidance by handling missing Python packages and PortAudio separately, preserving command registration, and covering both paths with tests.<details><summary>Modified files (2)</summary><ul><li>src/bernstein/cli/commands/voice_cmd.py</li>
<li>tests/unit/test_voice_extra.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>cli(voice): handle a P...</td><td>August 09, 2026</td></tr>
<tr><td>chernistry</td><td>fix(quality): bulk ref...</td><td>May 19, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3505?tool=ast&topic=Voice+installation>Voice installation</a>
        </td><td>Enable supported voice-command installation by declaring and locking the <code>voice</code> extra, then document its setup and dependency behavior.<details><summary>Modified files (3)</summary><ul><li>docs/operations/voice-control.md</li>
<li>pyproject.toml</li>
<li>uv.lock</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>chernistry</td><td>fix(types): resolve th...</td><td>August 09, 2026</td></tr>
<tr><td>sanderchernitsky@gmail...</td><td>cli(voice): name the v...</td><td>August 09, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3505?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>