### PR TITLE
feat(browser): select driver at activity boundary and add driver conformance kit (#3113)

### DIFF
--- a/src/bernstein/cli/commands/activity_cmd.py
+++ b/src/bernstein/cli/commands/activity_cmd.py
@@ -351,6 +351,10 @@ def browser_run_cmd(
     flow_id, start_url, steps, final_checks, budget = _parse_flow(_load_json(Path(flow_path), label="flow document"))
 
     if recording_path is not None:
+        if driver_name is not None:
+            # Both name the backend. Silently letting --recording win would leave
+            # an unknown --driver name unrefused, which AC1 requires refusing.
+            raise click.BadParameter("--driver and --recording both select the backend; pass one or the other.")
         frames = _parse_recording(_load_json(Path(recording_path), label="recording"))
 
         def build(profile_dir: Path) -> BrowserDriver:

--- a/src/bernstein/cli/commands/activity_cmd.py
+++ b/src/bernstein/cli/commands/activity_cmd.py
@@ -303,6 +303,12 @@ def _load_json(path: Path, *, label: str) -> dict[str, Any]:
     help="Drive a recorded observation tape instead of a live browser (offline, deterministic).",
 )
 @click.option(
+    "--driver",
+    "driver_name",
+    default=None,
+    help="Select browser driver backend by registered name (e.g. browser_use).",
+)
+@click.option(
     "--workdir",
     "-w",
     type=click.Path(file_okay=False, exists=True),
@@ -316,6 +322,7 @@ def browser_run_cmd(
     run_id: str,
     stage_id: str,
     recording_path: str | None,
+    driver_name: str | None,
     workdir: str,
     as_json: bool,
 ) -> None:
@@ -332,8 +339,9 @@ def browser_run_cmd(
     from bernstein.core.orchestration.activity_modalities import ContentStore
     from bernstein.core.orchestration.browser_driver import (
         BrowserDriver,
+        BrowserDriverError,
         RecordedBrowserDriver,
-        browser_use_driver,
+        get_driver_factory,
     )
     from bernstein.core.orchestration.browser_worker import BrowserBudgetExceeded, BrowserWorker
     from bernstein.core.replay.journal import EventJournal
@@ -348,9 +356,14 @@ def browser_run_cmd(
         def build(profile_dir: Path) -> BrowserDriver:
             return RecordedBrowserDriver(frames, profile_dir=profile_dir)
     else:
+        dname = driver_name or "browser_use"
+        try:
+            factory = get_driver_factory(dname)
+        except BrowserDriverError as exc:
+            raise click.BadParameter(str(exc)) from exc
 
         def build(profile_dir: Path) -> BrowserDriver:
-            return browser_use_driver(profile_dir=profile_dir)
+            return factory(profile_dir=profile_dir)
 
     worker = BrowserWorker(
         store=ContentStore(sdd_dir / "cas"),

--- a/src/bernstein/cli/commands/activity_cmd.py
+++ b/src/bernstein/cli/commands/activity_cmd.py
@@ -338,6 +338,8 @@ def browser_run_cmd(
     from bernstein.core.orchestration.activity import ActivityRejected, TerminalState, dispatch_activity
     from bernstein.core.orchestration.activity_modalities import ContentStore
     from bernstein.core.orchestration.browser_driver import (
+        RECORDED_DRIVER_NAME,
+        RECORDED_DRIVER_REFUSAL,
         BrowserDriver,
         BrowserDriverError,
         RecordedBrowserDriver,
@@ -365,6 +367,12 @@ def browser_run_cmd(
             factory = get_driver_factory(dname)
         except BrowserDriverError as exc:
             raise click.BadParameter(str(exc)) from exc
+        if dname == RECORDED_DRIVER_NAME:
+            # The recorded driver needs a tape, so it is not constructible from a
+            # name. Refused here rather than at build time: a refusal raised
+            # inside the worker is classified into a driver_error terminal state,
+            # which never tells the operator to pass --recording.
+            raise click.BadParameter(RECORDED_DRIVER_REFUSAL)
 
         def build(profile_dir: Path) -> BrowserDriver:
             return factory(profile_dir=profile_dir)

--- a/src/bernstein/core/orchestration/browser_driver.py
+++ b/src/bernstein/core/orchestration/browser_driver.py
@@ -36,13 +36,11 @@ import shutil
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
-from bernstein.core.agents.computer_use import ActionKind
+from bernstein.core.agents.computer_use import Action, ActionKind
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
     from pathlib import Path
-
-    from bernstein.core.agents.computer_use import Action
 
 __all__ = [
     "BrowserDriver",
@@ -421,11 +419,27 @@ def browser_use_driver(*, profile_dir: Path) -> BrowserUseDriver:
 # Driver Registry
 # ---------------------------------------------------------------------------
 
-_DRIVER_REGISTRY: dict[str, Callable[..., BrowserDriver]] = {}
+#: A registered driver factory. Every entry is called with exactly one keyword
+#: argument, ``profile_dir`` -- the shape :func:`browser_use_driver` already has
+#: -- so the activity boundary can build any registered driver the same way and
+#: a new backend is a registry entry rather than a branch in the CLI.
+type DriverFactory = Callable[..., BrowserDriver]
+
+_DRIVER_REGISTRY: dict[str, DriverFactory] = {}
 
 
-def register_driver(name: str, factory: Callable[..., BrowserDriver]) -> None:
-    """Register a browser driver factory under *name*."""
+def register_driver(name: str, factory: DriverFactory) -> None:
+    """Register a browser driver factory under *name*.
+
+    Args:
+        name: The name ``--driver`` selects the backend by.
+        factory: Builds a driver bound to an isolated profile. It is called as
+            ``factory(profile_dir=...)`` and nothing else, so every registered
+            entry is interchangeable at the activity boundary. A factory that
+            needs more than a profile directory must refuse with a
+            :class:`BrowserDriverError` rather than expose a constructor that
+            raises :class:`TypeError` when the boundary calls it.
+    """
     _DRIVER_REGISTRY[name] = factory
 
 
@@ -434,17 +448,51 @@ def list_drivers() -> list[str]:
     return sorted(_DRIVER_REGISTRY.keys())
 
 
-def get_driver_factory(name: str) -> Callable[..., BrowserDriver]:
-    """Return the driver factory for *name*, or raise BrowserDriverError if unknown."""
+def get_driver_factory(name: str) -> DriverFactory:
+    """Return the driver factory for *name*.
+
+    Args:
+        name: The registered driver name.
+
+    Returns:
+        The factory, callable as ``factory(profile_dir=...)``.
+
+    Raises:
+        BrowserDriverError: When *name* is not registered. The message lists the
+            registered names, so the refusal happens before a browser is started
+            and tells the operator what they could have asked for.
+    """
     if name not in _DRIVER_REGISTRY:
         avail = ", ".join(repr(n) for n in list_drivers())
         raise BrowserDriverError(f"Unknown browser driver {name!r}. Registered drivers: {avail}.")
     return _DRIVER_REGISTRY[name]
 
 
+def _recorded_driver_needs_a_tape(*, profile_dir: Path) -> BrowserDriver:
+    """Refuse to build :class:`RecordedBrowserDriver` from a name alone.
+
+    The recorded driver replays a fixed observation tape, so unlike a live
+    backend it cannot be constructed from a profile directory alone -- it is
+    selected by handing the tape in, not by naming it. Registered anyway so the
+    name stays discoverable in :func:`list_drivers` and selecting it is a typed
+    refusal instead of a :class:`TypeError` escaping a partially applied
+    constructor.
+
+    Args:
+        profile_dir: Accepted to match the registry calling contract; unused.
+
+    Raises:
+        BrowserDriverError: Always.
+    """
+    raise BrowserDriverError(
+        "Browser driver 'recorded' replays a recorded observation tape and cannot be selected "
+        "by name alone. Pass the tape instead: --recording <path>."
+    )
+
+
 # Register built-in drivers by default
 register_driver("browser_use", browser_use_driver)
-register_driver("recorded", RecordedBrowserDriver)
+register_driver("recorded", _recorded_driver_needs_a_tape)
 
 
 # ---------------------------------------------------------------------------
@@ -452,62 +500,156 @@ register_driver("recorded", RecordedBrowserDriver)
 # ---------------------------------------------------------------------------
 
 
+#: The six protocol members a conforming driver exposes.
+CONFORMANCE_VERBS: tuple[str, ...] = ("navigate", "act", "screenshot", "dom_snapshot", "current_url", "close")
+
+#: The fixed observation tape :func:`verify_driver_conformance` drives by
+#: default: the start state, the state after ``navigate``, and the state after
+#: ``act``. Three *distinct* frames, deliberately -- every read verb is compared
+#: byte-exact against the frame the driver is supposed to be sitting on, so a
+#: driver whose snapshot lags or leads the action (a DOM frozen at the start, or
+#: the post-action DOM returned before the action) diverges from a frame it does
+#: not match and fails at the verb that read it. A tape whose frames repeat would
+#: let an ordering violation pass unnoticed.
+CONFORMANCE_TAPE: tuple[PageState, ...] = (
+    PageState(url="https://example.com/start", screenshot=b"PNG-start", dom=b"<html>start</html>"),
+    PageState(url="https://example.com/next", screenshot=b"PNG-next", dom=b"<html>next</html>"),
+    PageState(url="https://example.com/final", screenshot=b"PNG-final", dom=b"<html>final</html>"),
+)
+
+
 class ConformanceFailure(AssertionError):
-    """Raised when a driver fails the conformance kit."""
+    """Raised when a driver fails the conformance kit.
+
+    Attributes:
+        verb: The protocol member that failed, or ``"profile"`` for a profile
+            isolation violation. Named so a failure points at the surface to fix
+            rather than at the kit.
+    """
 
     def __init__(self, verb: str, message: str) -> None:
         self.verb = verb
         super().__init__(f"Conformance failure in verb {verb!r}: {message}")
 
 
+def _expect_frame(driver: BrowserDriver, expected: PageState, *, phase: str) -> None:
+    """Assert the driver's three read verbs all describe *expected*.
+
+    Args:
+        driver: The driver under test.
+        expected: The frame the driver is supposed to be sitting on.
+        phase: Where in the flow this read happens, for the failure message.
+
+    Raises:
+        ConformanceFailure: Naming the read verb that disagreed.
+    """
+    url = driver.current_url()
+    if url != expected.url:
+        raise ConformanceFailure("current_url", f"{phase}: expected {expected.url!r}, got {url!r}")
+
+    dom = driver.dom_snapshot()
+    if not isinstance(dom, bytes) or not dom:
+        raise ConformanceFailure("dom_snapshot", f"{phase}: returned an empty or non-bytes snapshot")
+    if dom != expected.dom:
+        raise ConformanceFailure("dom_snapshot", f"{phase}: expected {expected.dom!r}, got {dom!r}")
+
+    shot = driver.screenshot()
+    if not isinstance(shot, bytes) or not shot:
+        raise ConformanceFailure("screenshot", f"{phase}: returned an empty or non-bytes screenshot")
+    if shot != expected.screenshot:
+        raise ConformanceFailure("screenshot", f"{phase}: expected {expected.screenshot!r}, got {shot!r}")
+
+
 def verify_driver_conformance(
-    driver_factory: Callable[[Path], BrowserDriver],
+    driver_factory: DriverFactory,
     *,
     root_dir: Path,
-    expected_start_url: str = "https://example.com/start",
-    expected_next_url: str = "https://example.com/next",
-    expected_start_dom: bytes = b"<html>start</html>",
+    expected_tape: Sequence[PageState] = CONFORMANCE_TAPE,
 ) -> None:
     """Run the driver conformance suite against *driver_factory*.
 
-    Asserts protocol compliance for all six verbs (navigate, act, screenshot,
-    dom_snapshot, current_url, close), DOM snapshot ordering, and profile isolation.
+    Drives a fixed flow -- observe, ``navigate``, observe, ``act``, observe --
+    over a fixed three-frame tape and compares every read verb byte-exact against
+    the frame the driver should be sitting on at that point. That is what makes
+    the kit able to fail an ordering violation: a driver whose ``dom_snapshot``
+    lags or leads the action returns bytes belonging to a different frame.
+
+    What is asserted:
+
+    * all six members of :data:`CONFORMANCE_VERBS` are present and callable, so a
+      driver missing a verb fails at that verb instead of silently skipping it;
+    * ``current_url``, ``dom_snapshot`` and ``screenshot`` match the expected
+      frame at each of the three observation points;
+    * ``navigate`` and ``act`` each advance the driver by exactly one frame;
+    * ``close`` is idempotent, as the protocol requires; and
+    * two tasks built from the same factory hold disjoint
+      :class:`BrowserProfile` directories, and tearing one down leaves the other
+      intact.
+
+    *driver_factory* is called as ``factory(profile_dir=...)``, the registry
+    calling contract, so a registered backend can be handed to the kit directly.
+
+    Args:
+        driver_factory: Builds a driver bound to a profile directory.
+        root_dir: Where the kit allocates its throwaway profiles.
+        expected_tape: The three frames the driver is expected to reproduce.
+
+    Raises:
+        ConformanceFailure: When the driver violates the protocol.
+        ValueError: When *expected_tape* does not hold exactly three frames --
+            a caller error in the kit's own arguments, not a driver fault.
     """
-    profile = BrowserProfile.allocate(root=root_dir, task_id="conformance-test-task")
-    driver = driver_factory(profile.profile_dir)
+    if len(expected_tape) != 3:
+        raise ValueError(f"conformance tape must hold exactly 3 frames, got {len(expected_tape)}")
+
+    profile_a = BrowserProfile.allocate(root=root_dir, task_id="conformance-task-a")
+    profile_b = BrowserProfile.allocate(root=root_dir, task_id="conformance-task-b")
+    close_error: Exception | None = None
     try:
-        # 1. Check initial state (current_url, dom_snapshot, screenshot)
-        start_url = driver.current_url()
-        if start_url != expected_start_url:
-            raise ConformanceFailure("current_url", f"expected {expected_start_url!r}, got {start_url!r}")
+        driver = driver_factory(profile_dir=profile_a.profile_dir)
+        other = driver_factory(profile_dir=profile_b.profile_dir)
 
-        dom_before = driver.dom_snapshot()
-        if not isinstance(dom_before, bytes) or len(dom_before) == 0:
-            raise ConformanceFailure("dom_snapshot", "returned empty or non-bytes snapshot")
-        if dom_before != expected_start_dom:
-            raise ConformanceFailure("dom_snapshot", f"expected {expected_start_dom!r}, got {dom_before!r}")
+        for verb in CONFORMANCE_VERBS:
+            if not callable(getattr(driver, verb, None)):
+                raise ConformanceFailure(verb, "driver does not expose the verb as a callable")
 
-        img_before = driver.screenshot()
-        if not isinstance(img_before, bytes) or len(img_before) == 0:
-            raise ConformanceFailure("screenshot", "returned empty or non-bytes screenshot")
+        # Two live tasks off one factory must not share a profile directory.
+        if profile_a.profile_dir == profile_b.profile_dir:
+            raise ConformanceFailure("profile", "two tasks were handed the same profile directory")
+        if not profile_a.profile_dir.exists() or not profile_b.profile_dir.exists():
+            raise ConformanceFailure("profile", "an allocated profile directory does not exist")
 
-        # 2. Test navigate / act & current_url update
-        from bernstein.core.agents.computer_use import Action, ActionKind
+        _expect_frame(driver, expected_tape[0], phase="initial state")
+        driver.navigate(expected_tape[1].url)
+        _expect_frame(driver, expected_tape[1], phase="after navigate")
+        driver.act(Action(kind=ActionKind.CLICK, target="#conformance"))
+        _expect_frame(driver, expected_tape[2], phase="after act")
 
-        action = Action(kind=ActionKind.NAVIGATE, target=expected_next_url)
-        driver.act(action)
+        # close must be idempotent; a driver that raises on the second call is a
+        # failure of the protocol, not of the run, so it is captured rather than
+        # raised here where it would mask a live conformance failure.
+        try:
+            driver.close()
+            driver.close()
+            other.close()
+            other.close()
+        except Exception as exc:
+            close_error = exc
 
-        url_after_act = driver.current_url()
-        if url_after_act != expected_next_url:
-            raise ConformanceFailure("current_url", f"expected {expected_next_url!r}, got {url_after_act!r}")
-
-        # 3. Test dom_snapshot after action
-        dom_after = driver.dom_snapshot()
-        if not isinstance(dom_after, bytes) or len(dom_after) == 0:
-            raise ConformanceFailure("dom_snapshot", "returned empty or non-bytes snapshot after action")
-
+        # Terminal state for task A: its profile goes, task B's stays.
+        profile_a.teardown()
+        if profile_a.profile_dir.exists():
+            raise ConformanceFailure("profile", "the profile directory survived its task's teardown")
+        if not profile_b.profile_dir.exists():
+            raise ConformanceFailure("profile", "tearing down one task's profile removed another task's")
+        profile_b.teardown()
+        if profile_b.profile_dir.exists():
+            raise ConformanceFailure("profile", "the profile directory survived its task's teardown")
     finally:
-        driver.close()
-        # Idempotency check
-        driver.close()
-        profile.teardown()
+        # Idempotent, so this is a safety net for the early-exit paths above and
+        # a no-op once the isolation assertions have run.
+        profile_a.teardown()
+        profile_b.teardown()
+
+    if close_error is not None:
+        raise ConformanceFailure("close", f"close is not idempotent: {type(close_error).__name__}") from close_error

--- a/src/bernstein/core/orchestration/browser_driver.py
+++ b/src/bernstein/core/orchestration/browser_driver.py
@@ -570,6 +570,45 @@ def _expect_frame(driver: BrowserDriver, expected: PageState, *, phase: str) -> 
         raise ConformanceFailure("screenshot", f"{phase}: expected {expected.screenshot!r}, got {shot!r}")
 
 
+def _drive_tape(driver: BrowserDriver, expected_tape: Sequence[PageState], *, which: str) -> None:
+    """Drive one driver through the fixed flow, checking every observation point.
+
+    Args:
+        driver: The driver to drive.
+        expected_tape: The three frames it is expected to reproduce.
+        which: Which of the kit's two drivers this is, for the failure message.
+
+    Raises:
+        ConformanceFailure: Naming the verb that disagreed.
+    """
+    _expect_frame(driver, expected_tape[0], phase=f"{which} driver, initial state")
+    driver.navigate(expected_tape[1].url)
+    _expect_frame(driver, expected_tape[1], phase=f"{which} driver, after navigate")
+    driver.act(Action(kind=ActionKind.CLICK, target="#conformance"))
+    _expect_frame(driver, expected_tape[2], phase=f"{which} driver, after act")
+
+
+def _close_idempotently(driver: BrowserDriver) -> Exception | None:
+    """Close *driver* twice, returning the failure instead of raising it.
+
+    Returned rather than raised so one driver's non-idempotent ``close`` cannot
+    leave a sibling session open or mask a conformance failure already in flight.
+    """
+    try:
+        driver.close()
+        driver.close()
+    except Exception as exc:
+        return exc
+    return None
+
+
+def _dir_entries(path: Path) -> set[str]:
+    """Return every path under *path*, relative to it. Empty when it is absent."""
+    if not path.exists():
+        return set()
+    return {str(child.relative_to(path)) for child in path.rglob("*")}
+
+
 def verify_driver_conformance(
     driver_factory: DriverFactory,
     *,
@@ -586,15 +625,29 @@ def verify_driver_conformance(
 
     What is asserted:
 
-    * all six members of :data:`CONFORMANCE_VERBS` are present and callable, so a
-      driver missing a verb fails at that verb instead of silently skipping it;
+    * all six members of :data:`CONFORMANCE_VERBS` are present and callable;
     * ``current_url``, ``dom_snapshot`` and ``screenshot`` match the expected
       frame at each of the three observation points;
     * ``navigate`` and ``act`` each advance the driver by exactly one frame;
-    * ``close`` is idempotent, as the protocol requires; and
-    * two tasks built from the same factory hold disjoint
-      :class:`BrowserProfile` directories, and tearing one down leaves the other
-      intact.
+    * ``close`` is idempotent, as the protocol requires, and each driver is
+      closed even when a sibling's ``close`` raises; and
+    * profile isolation, to the extent the six-verb protocol makes it
+      observable -- see below.
+
+    Two drivers are built and *both* are driven through the whole flow. A factory
+    that hands out a shared or stateful instance fails, because the second driver
+    is then already past the start frame; a backend whose second session is
+    broken can no longer hide behind a first session that works.
+
+    What the profile checks do and do not prove. The kit asserts that two tasks
+    are allocated disjoint directories, that both exist while both drivers are
+    live, that driving one task leaves the other's directory byte-for-byte
+    unchanged, and that tearing one down does not remove the other. It cannot
+    prove a backend *uses* the directory it was handed: nothing in the six-verb
+    protocol exposes where a driver puts its state, so a backend that ignores
+    ``profile_dir`` and writes to a fixed location outside ``root_dir`` passes.
+    Non-interference inside the profile root is the strongest claim available
+    here; anything more has to be asserted by the backend's own tests.
 
     *driver_factory* is called as ``factory(profile_dir=...)``, the registry
     calling contract, so a registered backend can be handed to the kit directly.
@@ -619,9 +672,10 @@ def verify_driver_conformance(
         driver = driver_factory(profile_dir=profile_a.profile_dir)
         other = driver_factory(profile_dir=profile_b.profile_dir)
 
-        for verb in CONFORMANCE_VERBS:
-            if not callable(getattr(driver, verb, None)):
-                raise ConformanceFailure(verb, "driver does not expose the verb as a callable")
+        for name, subject in (("first", driver), ("second", other)):
+            for verb in CONFORMANCE_VERBS:
+                if not callable(getattr(subject, verb, None)):
+                    raise ConformanceFailure(verb, f"the {name} driver does not expose the verb as a callable")
 
         # Two live tasks off one factory must not share a profile directory.
         if profile_a.profile_dir == profile_b.profile_dir:
@@ -629,22 +683,28 @@ def verify_driver_conformance(
         if not profile_a.profile_dir.exists() or not profile_b.profile_dir.exists():
             raise ConformanceFailure("profile", "an allocated profile directory does not exist")
 
-        _expect_frame(driver, expected_tape[0], phase="initial state")
-        driver.navigate(expected_tape[1].url)
-        _expect_frame(driver, expected_tape[1], phase="after navigate")
-        driver.act(Action(kind=ActionKind.CLICK, target="#conformance"))
-        _expect_frame(driver, expected_tape[2], phase="after act")
+        # Both drivers are driven, not just the first. A factory that hands out a
+        # shared or stateful instance shows up as a second driver that is already
+        # past the start frame, and a backend whose second session is broken can
+        # no longer hide behind a first session that works.
+        sibling_before = _dir_entries(profile_b.profile_dir)
+        _drive_tape(driver, expected_tape, which="first")
+        if _dir_entries(profile_b.profile_dir) != sibling_before:
+            raise ConformanceFailure("profile", "driving one task changed another task's profile directory")
 
-        # close must be idempotent; a driver that raises on the second call is a
-        # failure of the protocol, not of the run, so it is captured rather than
-        # raised here where it would mask a live conformance failure.
-        try:
-            driver.close()
-            driver.close()
-            other.close()
-            other.close()
-        except Exception as exc:
-            close_error = exc
+        sibling_before = _dir_entries(profile_a.profile_dir)
+        _drive_tape(other, expected_tape, which="second")
+        if _dir_entries(profile_a.profile_dir) != sibling_before:
+            raise ConformanceFailure("profile", "driving one task changed another task's profile directory")
+
+        # close must be idempotent. Each driver is closed independently: a
+        # session that leaks because a sibling's close raised is exactly the
+        # failure this check exists to catch. The first error is reported after
+        # teardown so it cannot mask a live conformance failure.
+        for subject in (driver, other):
+            error = _close_idempotently(subject)
+            if error is not None and close_error is None:
+                close_error = error
 
         # Terminal state for task A: its profile goes, task B's stays.
         profile_a.teardown()

--- a/src/bernstein/core/orchestration/browser_driver.py
+++ b/src/bernstein/core/orchestration/browser_driver.py
@@ -39,7 +39,7 @@ from typing import TYPE_CHECKING, Protocol, runtime_checkable
 from bernstein.core.agents.computer_use import ActionKind
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
     from pathlib import Path
 
     from bernstein.core.agents.computer_use import Action
@@ -51,10 +51,15 @@ __all__ = [
     "BrowserProfile",
     "BrowserStepTimeout",
     "BrowserUseDriver",
+    "ConformanceFailure",
     "PageState",
     "RecordedBrowserDriver",
     "browser_use_driver",
+    "get_driver_factory",
+    "list_drivers",
     "observe",
+    "register_driver",
+    "verify_driver_conformance",
 ]
 
 #: The bernstein extra namespace the live browser driver belongs to. Declared
@@ -410,3 +415,99 @@ def browser_use_driver(*, profile_dir: Path) -> BrowserUseDriver:
     if factory is None:
         raise BrowserDriverUnavailable(driver_name="browser_use", extra=BROWSER_EXTRA)
     return BrowserUseDriver(factory(user_data_dir=str(profile_dir)), profile_dir=profile_dir)
+
+
+# ---------------------------------------------------------------------------
+# Driver Registry
+# ---------------------------------------------------------------------------
+
+_DRIVER_REGISTRY: dict[str, Callable[..., BrowserDriver]] = {}
+
+
+def register_driver(name: str, factory: Callable[..., BrowserDriver]) -> None:
+    """Register a browser driver factory under *name*."""
+    _DRIVER_REGISTRY[name] = factory
+
+
+def list_drivers() -> list[str]:
+    """Return a sorted list of registered driver names."""
+    return sorted(_DRIVER_REGISTRY.keys())
+
+
+def get_driver_factory(name: str) -> Callable[..., BrowserDriver]:
+    """Return the driver factory for *name*, or raise BrowserDriverError if unknown."""
+    if name not in _DRIVER_REGISTRY:
+        avail = ", ".join(repr(n) for n in list_drivers())
+        raise BrowserDriverError(f"Unknown browser driver {name!r}. Registered drivers: {avail}.")
+    return _DRIVER_REGISTRY[name]
+
+
+# Register built-in drivers by default
+register_driver("browser_use", browser_use_driver)
+register_driver("recorded", RecordedBrowserDriver)
+
+
+# ---------------------------------------------------------------------------
+# Driver Conformance Kit
+# ---------------------------------------------------------------------------
+
+
+class ConformanceFailure(AssertionError):
+    """Raised when a driver fails the conformance kit."""
+
+    def __init__(self, verb: str, message: str) -> None:
+        self.verb = verb
+        super().__init__(f"Conformance failure in verb {verb!r}: {message}")
+
+
+def verify_driver_conformance(
+    driver_factory: Callable[[Path], BrowserDriver],
+    *,
+    root_dir: Path,
+    expected_start_url: str = "https://example.com/start",
+    expected_next_url: str = "https://example.com/next",
+    expected_start_dom: bytes = b"<html>start</html>",
+) -> None:
+    """Run the driver conformance suite against *driver_factory*.
+
+    Asserts protocol compliance for all six verbs (navigate, act, screenshot,
+    dom_snapshot, current_url, close), DOM snapshot ordering, and profile isolation.
+    """
+    profile = BrowserProfile.allocate(root=root_dir, task_id="conformance-test-task")
+    driver = driver_factory(profile.profile_dir)
+    try:
+        # 1. Check initial state (current_url, dom_snapshot, screenshot)
+        start_url = driver.current_url()
+        if start_url != expected_start_url:
+            raise ConformanceFailure("current_url", f"expected {expected_start_url!r}, got {start_url!r}")
+
+        dom_before = driver.dom_snapshot()
+        if not isinstance(dom_before, bytes) or len(dom_before) == 0:
+            raise ConformanceFailure("dom_snapshot", "returned empty or non-bytes snapshot")
+        if dom_before != expected_start_dom:
+            raise ConformanceFailure("dom_snapshot", f"expected {expected_start_dom!r}, got {dom_before!r}")
+
+        img_before = driver.screenshot()
+        if not isinstance(img_before, bytes) or len(img_before) == 0:
+            raise ConformanceFailure("screenshot", "returned empty or non-bytes screenshot")
+
+        # 2. Test navigate / act & current_url update
+        from bernstein.core.agents.computer_use import Action, ActionKind
+
+        action = Action(kind=ActionKind.NAVIGATE, target=expected_next_url)
+        driver.act(action)
+
+        url_after_act = driver.current_url()
+        if url_after_act != expected_next_url:
+            raise ConformanceFailure("current_url", f"expected {expected_next_url!r}, got {url_after_act!r}")
+
+        # 3. Test dom_snapshot after action
+        dom_after = driver.dom_snapshot()
+        if not isinstance(dom_after, bytes) or len(dom_after) == 0:
+            raise ConformanceFailure("dom_snapshot", "returned empty or non-bytes snapshot after action")
+
+    finally:
+        driver.close()
+        # Idempotency check
+        driver.close()
+        profile.teardown()

--- a/src/bernstein/core/orchestration/browser_driver.py
+++ b/src/bernstein/core/orchestration/browser_driver.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import hashlib
 import shutil
+from contextlib import suppress
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
@@ -668,9 +669,15 @@ def verify_driver_conformance(
     profile_a = BrowserProfile.allocate(root=root_dir, task_id="conformance-task-a")
     profile_b = BrowserProfile.allocate(root=root_dir, task_id="conformance-task-b")
     close_error: Exception | None = None
+    # Every driver the factory hands back, recorded as it is built. A session
+    # opened before a failure -- a conformance failure mid-flow, or a factory
+    # that refuses the second build -- still has to be closed on the way out.
+    built: list[BrowserDriver] = []
     try:
         driver = driver_factory(profile_dir=profile_a.profile_dir)
+        built.append(driver)
         other = driver_factory(profile_dir=profile_b.profile_dir)
+        built.append(other)
 
         for name, subject in (("first", driver), ("second", other)):
             for verb in CONFORMANCE_VERBS:
@@ -716,8 +723,16 @@ def verify_driver_conformance(
         if profile_b.profile_dir.exists():
             raise ConformanceFailure("profile", "the profile directory survived its task's teardown")
     finally:
-        # Idempotent, so this is a safety net for the early-exit paths above and
-        # a no-op once the isolation assertions have run.
+        # Close every session on every exit path. On the success path each was
+        # already closed twice above, and close is required to be idempotent, so
+        # this is a no-op there; on a failure path it is the only close that
+        # runs. Errors are suppressed because a non-conforming close must not
+        # replace the failure that is already being reported.
+        for subject in built:
+            with suppress(Exception):
+                subject.close()
+        # Teardown is idempotent, so this is a safety net for the early-exit
+        # paths above and a no-op once the isolation assertions have run.
         profile_a.teardown()
         profile_b.teardown()
 

--- a/src/bernstein/core/orchestration/browser_driver.py
+++ b/src/bernstein/core/orchestration/browser_driver.py
@@ -609,11 +609,27 @@ def _close_idempotently(driver: BrowserDriver) -> Exception | None:
     return None
 
 
-def _dir_entries(path: Path) -> set[str]:
-    """Return every path under *path*, relative to it. Empty when it is absent."""
+def _profile_fingerprint(path: Path) -> dict[str, str]:
+    """Fingerprint every entry under *path* by name *and* content.
+
+    A set of names is not enough to say a directory is unchanged: a profile that
+    already holds a cookie jar can have it rewritten in place, which leaves the
+    listing identical and the session hijacked. Files are hashed, so "unchanged"
+    means unchanged bytes. Empty when *path* is absent.
+    """
     if not path.exists():
-        return set()
-    return {str(child.relative_to(path)) for child in path.rglob("*")}
+        return {}
+    fingerprint: dict[str, str] = {}
+    for child in path.rglob("*"):
+        key = str(child.relative_to(path))
+        if child.is_dir():
+            fingerprint[key] = "dir"
+        else:
+            try:
+                fingerprint[key] = f"file:{hashlib.sha256(child.read_bytes()).hexdigest()}"
+            except OSError:
+                fingerprint[key] = "unreadable"
+    return fingerprint
 
 
 def verify_driver_conformance(
@@ -708,14 +724,14 @@ def verify_driver_conformance(
         # shared or stateful instance shows up as a second driver that is already
         # past the start frame, and a backend whose second session is broken can
         # no longer hide behind a first session that works.
-        sibling_before = _dir_entries(profile_b.profile_dir)
+        sibling_before = _profile_fingerprint(profile_b.profile_dir)
         _drive_tape(driver, expected_tape, which="first")
-        if _dir_entries(profile_b.profile_dir) != sibling_before:
+        if _profile_fingerprint(profile_b.profile_dir) != sibling_before:
             raise ConformanceFailure("profile", "driving one task changed another task's profile directory")
 
-        sibling_before = _dir_entries(profile_a.profile_dir)
+        sibling_before = _profile_fingerprint(profile_a.profile_dir)
         _drive_tape(other, expected_tape, which="second")
-        if _dir_entries(profile_a.profile_dir) != sibling_before:
+        if _profile_fingerprint(profile_a.profile_dir) != sibling_before:
             raise ConformanceFailure("profile", "driving one task changed another task's profile directory")
 
         # close must be idempotent. Each driver is closed independently: a

--- a/src/bernstein/core/orchestration/browser_driver.py
+++ b/src/bernstein/core/orchestration/browser_driver.py
@@ -36,6 +36,7 @@ import shutil
 from contextlib import suppress
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from uuid import uuid4
 
 from bernstein.core.agents.computer_use import Action, ActionKind
 
@@ -432,6 +433,11 @@ _DRIVER_REGISTRY: dict[str, DriverFactory] = {}
 def register_driver(name: str, factory: DriverFactory) -> None:
     """Register a browser driver factory under *name*.
 
+    Registration is last-write-wins and silent: a later call under an existing
+    name replaces the earlier factory, including the built-ins. The registry is
+    module-global and populated at import time, so whichever module imports last
+    decides. There is no unregister verb.
+
     Args:
         name: The name ``--driver`` selects the backend by.
         factory: Builds a driver bound to an isolated profile. It is called as
@@ -666,8 +672,16 @@ def verify_driver_conformance(
     if len(expected_tape) != 3:
         raise ValueError(f"conformance tape must hold exactly 3 frames, got {len(expected_tape)}")
 
-    profile_a = BrowserProfile.allocate(root=root_dir, task_id="conformance-task-a")
-    profile_b = BrowserProfile.allocate(root=root_dir, task_id="conformance-task-b")
+    # Per-invocation task ids. BrowserProfile.allocate is deterministic in the
+    # task id -- which is what the worker wants, so a supervisor can find a
+    # crashed task's profile -- but it means two verifier invocations sharing a
+    # root_dir would resolve to the same two directories and tear down each
+    # other's live profiles mid-run. The nonce keeps the two ids distinct within
+    # an invocation and unique across invocations; nothing here is anchored, so
+    # the profile paths carry no determinism requirement.
+    nonce = uuid4().hex
+    profile_a = BrowserProfile.allocate(root=root_dir, task_id=f"conformance-{nonce}-task-a")
+    profile_b = BrowserProfile.allocate(root=root_dir, task_id=f"conformance-{nonce}-task-b")
     close_error: Exception | None = None
     # Every driver the factory hands back, recorded as it is built. A session
     # opened before a failure -- a conformance failure mid-flow, or a factory

--- a/src/bernstein/core/orchestration/browser_driver.py
+++ b/src/bernstein/core/orchestration/browser_driver.py
@@ -468,6 +468,19 @@ def get_driver_factory(name: str) -> DriverFactory:
     return _DRIVER_REGISTRY[name]
 
 
+#: The registered name of the recorded-tape driver.
+RECORDED_DRIVER_NAME = "recorded"
+
+#: Why the recorded driver cannot be built from its name alone. Shared so the
+#: activity boundary refuses the selection up front with the same wording the
+#: factory raises with if something builds it anyway -- a refusal that arrives as
+#: a ``driver_error`` terminal state tells the operator nothing about the tape.
+RECORDED_DRIVER_REFUSAL = (
+    "Browser driver 'recorded' replays a recorded observation tape and cannot be selected "
+    "by name alone. Pass the tape instead: --recording <path>."
+)
+
+
 def _recorded_driver_needs_a_tape(*, profile_dir: Path) -> BrowserDriver:
     """Refuse to build :class:`RecordedBrowserDriver` from a name alone.
 
@@ -484,15 +497,12 @@ def _recorded_driver_needs_a_tape(*, profile_dir: Path) -> BrowserDriver:
     Raises:
         BrowserDriverError: Always.
     """
-    raise BrowserDriverError(
-        "Browser driver 'recorded' replays a recorded observation tape and cannot be selected "
-        "by name alone. Pass the tape instead: --recording <path>."
-    )
+    raise BrowserDriverError(RECORDED_DRIVER_REFUSAL)
 
 
 # Register built-in drivers by default
 register_driver("browser_use", browser_use_driver)
-register_driver("recorded", _recorded_driver_needs_a_tape)
+register_driver(RECORDED_DRIVER_NAME, _recorded_driver_needs_a_tape)
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/core/orchestration/browser_driver.py
+++ b/src/bernstein/core/orchestration/browser_driver.py
@@ -672,8 +672,19 @@ def verify_driver_conformance(
     Non-interference inside the profile root is the strongest claim available
     here; anything more has to be asserted by the backend's own tests.
 
+    What the action check does not prove either. ``act`` returns nothing, and the
+    only readback is the next frame -- which a legitimate replay driver advances
+    by cursor, not by payload. A driver that discards the ``kind`` and ``target``
+    it is handed and simply advances therefore passes, and requiring otherwise
+    would fail :class:`RecordedBrowserDriver`, which exists to replay a tape.
+    Payload handling has to be asserted by the backend's own tests; what is
+    pinned here is that ``act`` is exercised with a non-navigation action, the
+    route ``BrowserWorker`` sends everything but ``NAVIGATE`` down.
+
     *driver_factory* is called as ``factory(profile_dir=...)``, the registry
     calling contract, so a registered backend can be handed to the kit directly.
+    Being callable is not the same as passing: the kit compares against a fixed
+    tape, so a live backend has to be pointed at a fixture that reproduces one.
 
     Args:
         driver_factory: Builds a driver bound to a profile directory.

--- a/tests/unit/test_browser_driver_conformance.py
+++ b/tests/unit/test_browser_driver_conformance.py
@@ -354,6 +354,55 @@ def test_kit_closes_every_driver_even_when_one_close_raises(tmp_path: Path) -> N
     assert 2 in closed
 
 
+def test_kit_closes_every_session_when_the_run_fails_mid_flow(tmp_path: Path) -> None:
+    """A conformance failure must not leave browser sessions open."""
+    closed: list[int] = []
+    built = 0
+
+    class LeakProbe(TapeDriver):
+        def __init__(self, frames: Sequence[PageState], *, profile_dir: Path | None = None) -> None:
+            super().__init__(frames, profile_dir=profile_dir)
+            nonlocal built
+            built += 1
+            self.ordinal = built
+
+        def current_url(self) -> str:
+            return self._frames[0].url  # stale: fails partway through the flow
+
+        def close(self) -> None:
+            closed.append(self.ordinal)
+            super().close()
+
+    with pytest.raises(ConformanceFailure):
+        verify_driver_conformance(_tape_factory(LeakProbe), root_dir=tmp_path)
+
+    assert built == 2
+    assert sorted(set(closed)) == [1, 2]
+
+
+def test_kit_closes_the_first_session_when_the_factory_refuses_the_second(tmp_path: Path) -> None:
+    """A factory that refuses a second session must not strand the first."""
+    closed: list[int] = []
+    built = 0
+
+    class CloseProbe(TapeDriver):
+        def close(self) -> None:
+            closed.append(1)
+            super().close()
+
+    def factory(*, profile_dir: Path) -> BrowserDriver:
+        nonlocal built
+        built += 1
+        if built == 2:
+            raise BrowserDriverError("second session refused")
+        return CloseProbe(CONFORMANCE_TAPE, profile_dir=profile_dir)
+
+    with pytest.raises(BrowserDriverError):
+        verify_driver_conformance(factory, root_dir=tmp_path)
+
+    assert closed == [1]
+
+
 def test_kit_fails_a_driver_missing_a_verb(tmp_path: Path) -> None:
     with pytest.raises(ConformanceFailure) as exc_info:
         verify_driver_conformance(_tape_factory(NoNavigateDriver), root_dir=tmp_path)

--- a/tests/unit/test_browser_driver_conformance.py
+++ b/tests/unit/test_browser_driver_conformance.py
@@ -256,6 +256,104 @@ def test_kit_fails_a_driver_returning_an_empty_screenshot(tmp_path: Path) -> Non
     assert "empty" in str(exc_info.value)
 
 
+def test_kit_fails_a_factory_that_hands_out_one_shared_driver(tmp_path: Path) -> None:
+    """Two tasks must get two drivers, not one instance handed out twice."""
+    shared: list[TapeDriver] = []
+
+    def factory(*, profile_dir: Path) -> BrowserDriver:
+        if not shared:
+            shared.append(TapeDriver(CONFORMANCE_TAPE, profile_dir=profile_dir))
+        return shared[0]
+
+    with pytest.raises(ConformanceFailure) as exc_info:
+        verify_driver_conformance(factory, root_dir=tmp_path)
+
+    # The second driver is the same object, already advanced past frame 0.
+    assert "second driver, initial state" in str(exc_info.value)
+
+
+def test_kit_fails_a_factory_whose_second_driver_is_broken(tmp_path: Path) -> None:
+    """A working first session must not cover for a broken second one."""
+    built = 0
+
+    def factory(*, profile_dir: Path) -> BrowserDriver:
+        nonlocal built
+        built += 1
+        cls = TapeDriver if built == 1 else LaggingDomDriver
+        return cls(CONFORMANCE_TAPE, profile_dir=profile_dir)
+
+    with pytest.raises(ConformanceFailure) as exc_info:
+        verify_driver_conformance(factory, root_dir=tmp_path)
+
+    assert exc_info.value.verb == "dom_snapshot"
+    assert "second driver" in str(exc_info.value)
+
+
+def test_kit_fails_when_only_the_second_driver_is_missing_a_verb(tmp_path: Path) -> None:
+    """Both drivers are checked for the verbs, and the failure stays typed.
+
+    Without the check the missing verb surfaces later as a raw ``TypeError``
+    from the drive loop rather than a ``ConformanceFailure`` naming ``navigate``.
+    """
+    built = 0
+
+    def factory(*, profile_dir: Path) -> BrowserDriver:
+        nonlocal built
+        built += 1
+        cls = TapeDriver if built == 1 else NoNavigateDriver
+        return cls(CONFORMANCE_TAPE, profile_dir=profile_dir)
+
+    with pytest.raises(ConformanceFailure) as exc_info:
+        verify_driver_conformance(factory, root_dir=tmp_path)
+
+    assert exc_info.value.verb == "navigate"
+    assert "second driver" in str(exc_info.value)
+
+
+def test_kit_fails_a_driver_that_writes_into_a_sibling_profile(tmp_path: Path) -> None:
+    """Driving one task must leave a concurrent task's profile untouched."""
+
+    class SiblingWritingDriver(TapeDriver):
+        def navigate(self, url: str) -> None:
+            super().navigate(url)
+            assert self.profile_dir is not None
+            for sibling in self.profile_dir.parent.iterdir():
+                if sibling != self.profile_dir:
+                    (sibling / "leaked-cookie.txt").write_text("session=stolen")
+
+    with pytest.raises(ConformanceFailure) as exc_info:
+        verify_driver_conformance(_tape_factory(SiblingWritingDriver), root_dir=tmp_path / "root")
+
+    assert exc_info.value.verb == "profile"
+    assert "changed another task" in str(exc_info.value)
+
+
+def test_kit_closes_every_driver_even_when_one_close_raises(tmp_path: Path) -> None:
+    """A leaked session is the point of the idempotency check, not a side effect."""
+    closed: list[int] = []
+    built = 0
+
+    class CountingCloseDriver(TapeDriver):
+        def __init__(self, frames: Sequence[PageState], *, profile_dir: Path | None = None) -> None:
+            super().__init__(frames, profile_dir=profile_dir)
+            nonlocal built
+            built += 1
+            self.ordinal = built
+
+        def close(self) -> None:
+            closed.append(self.ordinal)
+            if self.ordinal == 1:
+                raise RuntimeError("first driver refuses to close")
+            super().close()
+
+    with pytest.raises(ConformanceFailure) as exc_info:
+        verify_driver_conformance(_tape_factory(CountingCloseDriver), root_dir=tmp_path)
+
+    assert exc_info.value.verb == "close"
+    # The second session was closed despite the first one raising.
+    assert 2 in closed
+
+
 def test_kit_fails_a_driver_missing_a_verb(tmp_path: Path) -> None:
     with pytest.raises(ConformanceFailure) as exc_info:
         verify_driver_conformance(_tape_factory(NoNavigateDriver), root_dir=tmp_path)

--- a/tests/unit/test_browser_driver_conformance.py
+++ b/tests/unit/test_browser_driver_conformance.py
@@ -156,6 +156,19 @@ class LeadingDomDriver(TapeDriver):
         return self._frames[index].dom
 
 
+class LaggingScreenshotDriver(TapeDriver):
+    """Broken driver: ``screenshot`` is frozen at the start frame.
+
+    The URL and the DOM advance correctly, so only a byte-exact comparison of the
+    screenshot against the expected frame catches it. Without this case the kit's
+    screenshot equality check is unconstrained: deleting it leaves the suite
+    green, because every other broken driver here is caught by an earlier verb.
+    """
+
+    def screenshot(self) -> bytes:
+        return self._frames[0].screenshot
+
+
 class NoNavigateDriver(TapeDriver):
     """Broken driver: does not implement the ``navigate`` verb at all."""
 
@@ -241,6 +254,20 @@ def test_kit_fails_a_dom_that_leads_the_action(tmp_path: Path) -> None:
     assert "initial state" in str(exc_info.value)
 
 
+def test_kit_fails_a_screenshot_that_lags_the_action(tmp_path: Path) -> None:
+    """The screenshot is compared against the expected frame, not merely non-empty.
+
+    A stale screenshot is the same class of ordering violation as a stale DOM: the
+    evidence a decision was recorded against describes a state the driver has
+    already left.
+    """
+    with pytest.raises(ConformanceFailure) as exc_info:
+        verify_driver_conformance(_tape_factory(LaggingScreenshotDriver), root_dir=tmp_path)
+
+    assert exc_info.value.verb == "screenshot"
+    assert "after navigate" in str(exc_info.value)
+
+
 def test_kit_fails_a_driver_returning_str_where_the_protocol_says_bytes(tmp_path: Path) -> None:
     with pytest.raises(ConformanceFailure) as exc_info:
         verify_driver_conformance(_tape_factory(StringDomDriver), root_dir=tmp_path)
@@ -324,6 +351,69 @@ def test_kit_fails_a_driver_that_writes_into_a_sibling_profile(tmp_path: Path) -
 
     with pytest.raises(ConformanceFailure) as exc_info:
         verify_driver_conformance(_tape_factory(SiblingWritingDriver), root_dir=tmp_path / "root")
+
+    assert exc_info.value.verb == "profile"
+    assert "changed another task" in str(exc_info.value)
+
+
+def test_kit_fails_a_driver_that_rewrites_a_sibling_profile_file(tmp_path: Path) -> None:
+    """Non-interference means unchanged bytes, not an unchanged file listing.
+
+    A profile that already holds a cookie jar -- every real backend writes one
+    when the session opens -- can have it rewritten in place by a concurrent
+    task. The directory listing is identical afterwards, so comparing names alone
+    passes a driver that has just hijacked another task's session.
+    """
+
+    class SiblingRewritingDriver(TapeDriver):
+        def __init__(self, frames: Sequence[PageState], *, profile_dir: Path | None = None) -> None:
+            super().__init__(frames, profile_dir=profile_dir)
+            assert profile_dir is not None
+            (profile_dir / "cookies.txt").write_bytes(b"session=mine")
+
+        def navigate(self, url: str) -> None:
+            super().navigate(url)
+            assert self.profile_dir is not None
+            for sibling in self.profile_dir.parent.iterdir():
+                if sibling != self.profile_dir:
+                    (sibling / "cookies.txt").write_bytes(b"session=stolen")
+
+    with pytest.raises(ConformanceFailure) as exc_info:
+        verify_driver_conformance(_tape_factory(SiblingRewritingDriver), root_dir=tmp_path / "root")
+
+    assert exc_info.value.verb == "profile"
+    assert "changed another task" in str(exc_info.value)
+
+
+@pytest.mark.parametrize("offending_session", [1, 2])
+def test_kit_fails_a_driver_that_interferes_on_only_one_session(tmp_path: Path, offending_session: int) -> None:
+    """Both drive-then-compare checks carry weight; neither is the other's mirror.
+
+    A backend that writes outside its own profile on only one of its two sessions
+    -- a first-run migration on a cold start, or a handler that only fires once
+    another session exists -- is invisible to whichever of the two checks does not
+    bracket it. Parametrised so removing either check fails this test.
+    """
+    built = 0
+
+    class SelectiveStomper(TapeDriver):
+        def __init__(self, frames: Sequence[PageState], *, profile_dir: Path | None = None) -> None:
+            super().__init__(frames, profile_dir=profile_dir)
+            nonlocal built
+            built += 1
+            self.ordinal = built
+
+        def navigate(self, url: str) -> None:
+            super().navigate(url)
+            if self.ordinal != offending_session:
+                return
+            assert self.profile_dir is not None
+            for sibling in self.profile_dir.parent.iterdir():
+                if sibling != self.profile_dir:
+                    (sibling / "leaked-state.txt").write_text("written by a concurrent task")
+
+    with pytest.raises(ConformanceFailure) as exc_info:
+        verify_driver_conformance(_tape_factory(SelectiveStomper), root_dir=tmp_path / "root")
 
     assert exc_info.value.verb == "profile"
     assert "changed another task" in str(exc_info.value)

--- a/tests/unit/test_browser_driver_conformance.py
+++ b/tests/unit/test_browser_driver_conformance.py
@@ -1,7 +1,29 @@
-"""Unit tests for #3113: Browser driver selection, registry, and conformance kit."""
+"""Browser driver selection, registry, and conformance kit (#3113).
+
+The browser boundary was designed for several drivers and admitted exactly one.
+These tests prove the bar the issue sets:
+
+* a driver is selected by registered name, and an unknown name is refused with the
+  registered names listed, before a browser is started (AC1);
+* the same flow over the same recorded tape under two *different* driver
+  implementations produces an identical ``head_anchor`` and byte-identical
+  canonical report bytes (AC2);
+* the conformance kit fails deliberately broken drivers -- a stale
+  ``current_url``, a DOM that lags the action, a DOM that leads it -- and names
+  the violated verb (AC3);
+* profile isolation holds per driver and each profile is removed at its task's
+  terminal state (AC4); and
+* a driver that cannot be built refuses with a typed error naming what to do,
+  never an ``ImportError`` or a ``TypeError`` from a constructor (AC5).
+
+Every negative case here is a driver the kit used to pass. A kit that only passes
+good drivers proves nothing.
+"""
 
 from __future__ import annotations
 
+import inspect
+import shutil
 from typing import TYPE_CHECKING
 
 import pytest
@@ -9,7 +31,12 @@ from click.testing import CliRunner
 
 from bernstein.cli.main import cli
 from bernstein.core.agents.computer_use import Action, ActionKind
+from bernstein.core.orchestration import browser_driver as browser_driver_module
+from bernstein.core.orchestration.activity_modalities import ContentStore
+from bernstein.core.orchestration.browser_check import CheckKind, report_to_canonical_bytes
 from bernstein.core.orchestration.browser_driver import (
+    CONFORMANCE_TAPE,
+    CONFORMANCE_VERBS,
     BrowserDriver,
     BrowserDriverError,
     BrowserDriverUnavailable,
@@ -22,128 +49,318 @@ from bernstein.core.orchestration.browser_driver import (
     register_driver,
     verify_driver_conformance,
 )
+from bernstein.core.orchestration.browser_worker import (
+    BrowserBudget,
+    BrowserWorker,
+    CheckSpec,
+    FlowStep,
+)
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator, Sequence
     from pathlib import Path
 
 
+@pytest.fixture(autouse=True)
+def _restore_driver_registry() -> Iterator[None]:
+    """Undo registrations a test makes.
+
+    The registry is module-global by design -- a backend registers itself at
+    import time -- so a test that registers a driver would otherwise leak it into
+    every later test in the session and make ``list_drivers`` order-dependent.
+    Reaching for the private dict is deliberate: there is no unregister verb on
+    the public surface, and adding one just for tests would widen the API.
+    """
+    saved = dict(browser_driver_module._DRIVER_REGISTRY)
+    yield
+    browser_driver_module._DRIVER_REGISTRY.clear()
+    browser_driver_module._DRIVER_REGISTRY.update(saved)
+
+
 # ---------------------------------------------------------------------------
-# Broken drivers for Acceptance Criterion 3
+# Drivers under test
 # ---------------------------------------------------------------------------
 
 
-class StaleUrlDriver:
-    """Deliberately broken driver: current_url does not update after navigate."""
+class TapeDriver:
+    """A conforming driver over a fixed tape, independent of RecordedBrowserDriver.
 
-    def __init__(self, profile_dir: Path) -> None:
+    Deliberately not a subclass, a wrapper, or a copy of
+    :class:`RecordedBrowserDriver`: it keeps its own action log and derives the
+    current frame from the log's length rather than from a cursor the verbs
+    mutate. Two instances of one class agree with each other no matter what that
+    class does, so a parity assertion between them proves nothing; this is the
+    second implementation that makes the assertion mean something.
+    """
+
+    def __init__(self, frames: Sequence[PageState], *, profile_dir: Path | None = None) -> None:
+        self._frames = tuple(frames)
         self.profile_dir = profile_dir
-        self._url = "https://example.com/initial"
+        self._log: list[str] = []
+        self.closed = False
+
+    def _frame(self) -> PageState:
+        index = len(self._log)
+        if index >= len(self._frames):
+            raise BrowserDriverError(f"tape exhausted at frame {index}")
+        return self._frames[index]
 
     def navigate(self, url: str) -> None:
-        # Ignore url, stay stale
-        pass
+        self._log.append(f"navigate:{url}")
 
     def act(self, action: Action) -> None:
-        pass
+        self._log.append(f"act:{action.kind}:{action.target}")
 
     def screenshot(self) -> bytes:
-        return b"PNG_STALE"
+        return self._frame().screenshot
 
     def dom_snapshot(self) -> bytes:
-        return b"<html>start</html>"
+        return self._frame().dom
 
     def current_url(self) -> str:
-        return self._url
+        return self._frame().url
 
     def close(self) -> None:
-        pass
+        self.closed = True
 
 
-class StaleDomDriver:
-    """Deliberately broken driver: dom_snapshot returns empty or wrong DOM bytes."""
+class StaleUrlDriver(TapeDriver):
+    """Broken driver: ``current_url`` never advances past the start frame."""
 
-    def __init__(self, profile_dir: Path) -> None:
-        self.profile_dir = profile_dir
-        self._url = "https://example.com/start"
+    def current_url(self) -> str:
+        return self._frames[0].url
 
-    def navigate(self, url: str) -> None:
-        self._url = url
 
-    def act(self, action: Action) -> None:
-        self._url = str(action.target)
+class LaggingDomDriver(TapeDriver):
+    """Broken driver: ``dom_snapshot`` is frozen at the start frame.
 
-    def screenshot(self) -> bytes:
-        return b"PNG_OK"
+    The DOM lags every action. This is the driver the kit has to fail: its URLs
+    and screenshots are correct, so only a byte-exact DOM comparison against the
+    expected frame catches it.
+    """
 
     def dom_snapshot(self) -> bytes:
-        # Return wrong/empty DOM
+        return self._frames[0].dom
+
+
+class LeadingDomDriver(TapeDriver):
+    """Broken driver: ``dom_snapshot`` returns the DOM *after* the next action.
+
+    This is AC3's second named case -- the snapshot leads the action instead of
+    describing the state the decision was made against.
+    """
+
+    def dom_snapshot(self) -> bytes:
+        index = min(len(self._log) + 1, len(self._frames) - 1)
+        return self._frames[index].dom
+
+
+class NoNavigateDriver(TapeDriver):
+    """Broken driver: does not implement the ``navigate`` verb at all."""
+
+    navigate = None  # type: ignore[assignment]
+
+
+class NonIdempotentCloseDriver(TapeDriver):
+    """Broken driver: ``close`` raises on the second call."""
+
+    def close(self) -> None:
+        if self.closed:
+            raise RuntimeError("close called twice")
+        self.closed = True
+
+
+class StringDomDriver(TapeDriver):
+    """Broken driver: ``dom_snapshot`` returns ``str`` where the protocol says bytes.
+
+    An annotation is not a guarantee -- a third-party backend is only checked at
+    runtime -- so the kit has to reject the wrong type rather than let it reach
+    the content store and be hashed as whatever it encodes to.
+    """
+
+    def dom_snapshot(self) -> bytes:
+        return self._frames[len(self._log)].dom.decode()  # type: ignore[return-value]
+
+
+class EmptyScreenshotDriver(TapeDriver):
+    """Broken driver: ``screenshot`` returns no bytes at all."""
+
+    def screenshot(self) -> bytes:
         return b""
 
-    def current_url(self) -> str:
-        return self._url
 
-    def close(self) -> None:
-        pass
+def _tape_factory(driver_cls: type[TapeDriver]) -> browser_driver_module.DriverFactory:
+    """Build a registry-shaped factory for *driver_cls* over the conformance tape."""
+
+    def factory(*, profile_dir: Path) -> BrowserDriver:
+        return driver_cls(CONFORMANCE_TAPE, profile_dir=profile_dir)
+
+    return factory
 
 
 # ---------------------------------------------------------------------------
-# Conformance Kit Tests
+# AC3: the conformance kit fails broken drivers and names the verb
 # ---------------------------------------------------------------------------
 
 
-def test_conformance_kit_passes_valid_recorded_driver(tmp_path: Path) -> None:
-    frames = [
-        PageState(url="https://example.com/start", screenshot=b"PNG1", dom=b"<html>start</html>"),
-        PageState(url="https://example.com/next", screenshot=b"PNG2", dom=b"<html>next</html>"),
-    ]
-
-    def factory(profile_dir: Path) -> BrowserDriver:
-        return RecordedBrowserDriver(frames, profile_dir=profile_dir)
+def test_kit_passes_a_conforming_recorded_driver(tmp_path: Path) -> None:
+    def factory(*, profile_dir: Path) -> BrowserDriver:
+        return RecordedBrowserDriver(CONFORMANCE_TAPE, profile_dir=profile_dir)
 
     verify_driver_conformance(factory, root_dir=tmp_path)
 
 
-def test_conformance_kit_fails_stale_url_driver(tmp_path: Path) -> None:
-    def factory(profile_dir: Path) -> BrowserDriver:
-        return StaleUrlDriver(profile_dir)
+def test_kit_passes_the_independent_tape_driver(tmp_path: Path) -> None:
+    verify_driver_conformance(_tape_factory(TapeDriver), root_dir=tmp_path)
 
+
+def test_kit_fails_a_stale_url_driver(tmp_path: Path) -> None:
     with pytest.raises(ConformanceFailure) as exc_info:
-        verify_driver_conformance(factory, root_dir=tmp_path)
+        verify_driver_conformance(_tape_factory(StaleUrlDriver), root_dir=tmp_path)
 
+    # The driver's *initial* URL is correct, so this is a genuine staleness
+    # failure after navigate -- not a driver that was wrong before it moved.
     assert exc_info.value.verb == "current_url"
-    assert "Conformance failure in verb 'current_url'" in str(exc_info.value)
+    assert "after navigate" in str(exc_info.value)
 
 
-def test_conformance_kit_fails_stale_dom_driver(tmp_path: Path) -> None:
-    def factory(profile_dir: Path) -> BrowserDriver:
-        return StaleDomDriver(profile_dir)
-
+def test_kit_fails_a_dom_that_lags_the_action(tmp_path: Path) -> None:
     with pytest.raises(ConformanceFailure) as exc_info:
-        verify_driver_conformance(factory, root_dir=tmp_path)
+        verify_driver_conformance(_tape_factory(LaggingDomDriver), root_dir=tmp_path)
 
     assert exc_info.value.verb == "dom_snapshot"
-    assert "Conformance failure in verb 'dom_snapshot'" in str(exc_info.value)
+    assert "after navigate" in str(exc_info.value)
+
+
+def test_kit_fails_a_dom_that_leads_the_action(tmp_path: Path) -> None:
+    with pytest.raises(ConformanceFailure) as exc_info:
+        verify_driver_conformance(_tape_factory(LeadingDomDriver), root_dir=tmp_path)
+
+    assert exc_info.value.verb == "dom_snapshot"
+    assert "initial state" in str(exc_info.value)
+
+
+def test_kit_fails_a_driver_returning_str_where_the_protocol_says_bytes(tmp_path: Path) -> None:
+    with pytest.raises(ConformanceFailure) as exc_info:
+        verify_driver_conformance(_tape_factory(StringDomDriver), root_dir=tmp_path)
+
+    assert exc_info.value.verb == "dom_snapshot"
+    assert "non-bytes" in str(exc_info.value)
+
+
+def test_kit_fails_a_driver_returning_an_empty_screenshot(tmp_path: Path) -> None:
+    with pytest.raises(ConformanceFailure) as exc_info:
+        verify_driver_conformance(_tape_factory(EmptyScreenshotDriver), root_dir=tmp_path)
+
+    assert exc_info.value.verb == "screenshot"
+    assert "empty" in str(exc_info.value)
+
+
+def test_kit_fails_a_driver_missing_a_verb(tmp_path: Path) -> None:
+    with pytest.raises(ConformanceFailure) as exc_info:
+        verify_driver_conformance(_tape_factory(NoNavigateDriver), root_dir=tmp_path)
+
+    assert exc_info.value.verb == "navigate"
+
+
+def test_kit_fails_a_non_idempotent_close(tmp_path: Path) -> None:
+    with pytest.raises(ConformanceFailure) as exc_info:
+        verify_driver_conformance(_tape_factory(NonIdempotentCloseDriver), root_dir=tmp_path)
+
+    assert exc_info.value.verb == "close"
+
+
+def test_kit_exercises_every_protocol_verb(tmp_path: Path) -> None:
+    """Every member of CONFORMANCE_VERBS is actually called, not just declared."""
+    called: list[str] = []
+
+    class RecordingDriver(TapeDriver):
+        def navigate(self, url: str) -> None:
+            called.append("navigate")
+            super().navigate(url)
+
+        def act(self, action: Action) -> None:
+            called.append("act")
+            super().act(action)
+
+        def screenshot(self) -> bytes:
+            called.append("screenshot")
+            return super().screenshot()
+
+        def dom_snapshot(self) -> bytes:
+            called.append("dom_snapshot")
+            return super().dom_snapshot()
+
+        def current_url(self) -> str:
+            called.append("current_url")
+            return super().current_url()
+
+        def close(self) -> None:
+            called.append("close")
+            super().close()
+
+    verify_driver_conformance(_tape_factory(RecordingDriver), root_dir=tmp_path)
+    assert set(CONFORMANCE_VERBS) <= set(called)
+
+
+def test_kit_leaves_no_profile_behind_when_a_driver_fails(tmp_path: Path) -> None:
+    """A failing driver must not leak its profile directory."""
+    root = tmp_path / "profiles"
+    root.mkdir()
+    with pytest.raises(ConformanceFailure):
+        verify_driver_conformance(_tape_factory(StaleUrlDriver), root_dir=root)
+
+    assert list(root.iterdir()) == []
+
+
+def test_kit_refuses_a_tape_that_is_not_three_frames(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="exactly 3 frames"):
+        verify_driver_conformance(_tape_factory(TapeDriver), root_dir=tmp_path, expected_tape=CONFORMANCE_TAPE[:2])
 
 
 # ---------------------------------------------------------------------------
-# Driver Registry & Selection Tests (Acceptance Criterion 1)
+# AC1: registry, selection, and the calling contract that makes it usable
 # ---------------------------------------------------------------------------
 
 
-def test_driver_registry_list_and_get() -> None:
+def test_driver_registry_lists_the_built_ins() -> None:
     drivers = list_drivers()
     assert "browser_use" in drivers
     assert "recorded" in drivers
-
-    factory = get_driver_factory("recorded")
-    assert factory is RecordedBrowserDriver
+    assert drivers == sorted(drivers)
 
 
-def test_unknown_driver_raises_error() -> None:
+def test_unknown_driver_raises_error_listing_what_is_registered() -> None:
     with pytest.raises(BrowserDriverError) as exc_info:
         get_driver_factory("nonexistent_driver")
     assert "Unknown browser driver 'nonexistent_driver'" in str(exc_info.value)
     assert "'browser_use'" in str(exc_info.value)
+
+
+@pytest.mark.parametrize("name", list_drivers())
+def test_registered_factory_binds_profile_dir_as_a_keyword(name: str) -> None:
+    """Every registry entry is callable as ``factory(profile_dir=...)``.
+
+    The activity boundary knows nothing about a backend but its name, so it can
+    only call it one way. A factory that needs more than a profile directory --
+    ``RecordedBrowserDriver`` needs a tape -- cannot be a registry entry: calling
+    it raises ``TypeError`` from a half-applied constructor instead of refusing.
+    Binding the signature proves the contract without constructing anything.
+    """
+    inspect.signature(get_driver_factory(name)).bind(profile_dir="/tmp/probe")
+
+
+def test_recorded_driver_refuses_selection_by_name_with_a_typed_error() -> None:
+    factory = get_driver_factory("recorded")
+    with pytest.raises(BrowserDriverError) as exc_info:
+        factory(profile_dir="/tmp/probe")
+    assert "--recording" in str(exc_info.value)
+
+
+def test_kit_runs_against_a_factory_taken_from_the_registry(tmp_path: Path) -> None:
+    """The kit and the registry agree on how a factory is called."""
+    register_driver("conformance_probe", _tape_factory(TapeDriver))
+    verify_driver_conformance(get_driver_factory("conformance_probe"), root_dir=tmp_path)
 
 
 def test_cli_refuses_unknown_driver(tmp_path: Path) -> None:
@@ -151,56 +368,129 @@ def test_cli_refuses_unknown_driver(tmp_path: Path) -> None:
     flow_file.write_text('{"flow_id": "f1", "start_url": "https://example.com", "steps": []}')
     runner = CliRunner()
     res = runner.invoke(
-        cli, ["activity", "browser", "run", "--flow", str(flow_file), "--run", "r1", "--driver", "unknown_driver"]
+        cli,
+        ["activity", "browser", "run", "--flow", str(flow_file), "--run", "r1", "--driver", "unknown_driver"],
     )
     assert res.exit_code != 0
-    assert (
-        "Unknown browser driver 'unknown_driver'" in res.output
-        or "Unknown browser driver 'unknown_driver'" in res.stderr
+    assert "Unknown browser driver 'unknown_driver'" in res.output
+    assert "'browser_use'" in res.output
+
+
+def test_cli_refuses_driver_together_with_recording(tmp_path: Path) -> None:
+    """--recording must not silently win and leave an unknown --driver unrefused."""
+    flow_file = tmp_path / "flow.json"
+    flow_file.write_text('{"flow_id": "f1", "start_url": "https://example.com", "steps": []}')
+    tape_file = tmp_path / "tape.json"
+    tape_file.write_text('{"frames": [{"url": "https://example.com", "screenshot_b64": "", "dom_b64": ""}]}')
+    runner = CliRunner()
+    res = runner.invoke(
+        cli,
+        [
+            "activity",
+            "browser",
+            "run",
+            "--flow",
+            str(flow_file),
+            "--run",
+            "r1",
+            "--recording",
+            str(tape_file),
+            "--driver",
+            "unknown_driver",
+        ],
+    )
+    assert res.exit_code != 0
+    assert "both select the backend" in res.output
+
+
+# ---------------------------------------------------------------------------
+# AC2: cross-driver replay parity through the worker
+# ---------------------------------------------------------------------------
+
+_PARITY_TAPE: tuple[PageState, ...] = (
+    PageState(url="https://shop/", screenshot=b"png-landing", dom=b"<html>Sign in</html>"),
+    PageState(url="https://shop/login", screenshot=b"png-form", dom=b"<html>Password</html>"),
+    PageState(url="https://shop/home", screenshot=b"png-home", dom=b"<html>Welcome back</html>"),
+)
+
+_PARITY_STEPS: tuple[FlowStep, ...] = (
+    FlowStep(
+        action=Action(kind=ActionKind.NAVIGATE, target="https://shop/login"),
+        checks=(CheckSpec(check_id="landing-has-signin", kind=CheckKind.DOM_CONTAINS, operand="Sign in"),),
+    ),
+    FlowStep(
+        action=Action(kind=ActionKind.CLICK, target="#submit"),
+        checks=(CheckSpec(check_id="form-has-password", kind=CheckKind.DOM_CONTAINS, operand="Password"),),
+    ),
+)
+
+
+def _run_flow_under(driver_name: str, *, root: Path, run_id: str):
+    """Drive the parity flow through the worker using the registered driver."""
+    worker = BrowserWorker(
+        store=ContentStore(root / "cas"),
+        budget=BrowserBudget(max_steps=10),
+        profile_root=root / "profiles",
+    )
+    factory = get_driver_factory(driver_name)
+    return worker.run(
+        flow_id="login-flow",
+        run_id=run_id,
+        stage_id="browser-0",
+        start_url="https://shop/",
+        steps=_PARITY_STEPS,
+        driver_factory=lambda profile_dir: factory(profile_dir=profile_dir),
+        final_checks=(CheckSpec(check_id="logged-in", kind=CheckKind.DOM_CONTAINS, operand="Welcome back"),),
     )
 
 
+def test_two_different_drivers_over_one_tape_produce_the_same_head_anchor(tmp_path: Path) -> None:
+    """AC2: parity across two *implementations*, not two instances of one class."""
+    register_driver(
+        "parity_recorded",
+        lambda *, profile_dir: RecordedBrowserDriver(_PARITY_TAPE, profile_dir=profile_dir),
+    )
+    register_driver(
+        "parity_tape",
+        lambda *, profile_dir: TapeDriver(_PARITY_TAPE, profile_dir=profile_dir),
+    )
+    assert get_driver_factory("parity_recorded") is not get_driver_factory("parity_tape")
+
+    run_a = _run_flow_under("parity_recorded", root=tmp_path / "a", run_id="run-a")
+    run_b = _run_flow_under("parity_tape", root=tmp_path / "b", run_id="run-b")
+
+    assert run_a.report.head_anchor == run_b.report.head_anchor
+    assert run_a.report.head_anchor != ""
+    assert report_to_canonical_bytes(run_a.report) == report_to_canonical_bytes(run_b.report)
+    assert run_a.result.artifact_hash == run_b.result.artifact_hash
+    assert run_a.result.evidence_set_hash == run_b.result.evidence_set_hash
+    assert [s.anchor for s in run_a.report.steps] == [s.anchor for s in run_b.report.steps]
+    assert [s.observation_hash for s in run_a.report.steps] == [s.observation_hash for s in run_b.report.steps]
+
+
+def test_a_driver_that_observes_the_wrong_frame_breaks_parity(tmp_path: Path) -> None:
+    """The parity assertion has teeth: a divergent driver diverges the anchor.
+
+    Without this, ``test_two_different_drivers_...`` could not be distinguished
+    from a tautology -- two identical implementations agree unconditionally.
+    """
+    register_driver(
+        "parity_recorded",
+        lambda *, profile_dir: RecordedBrowserDriver(_PARITY_TAPE, profile_dir=profile_dir),
+    )
+    register_driver(
+        "parity_skewed",
+        lambda *, profile_dir: TapeDriver(_PARITY_TAPE[1:] + _PARITY_TAPE[:1], profile_dir=profile_dir),
+    )
+
+    run_a = _run_flow_under("parity_recorded", root=tmp_path / "a", run_id="run-a")
+    run_b = _run_flow_under("parity_skewed", root=tmp_path / "b", run_id="run-b")
+
+    assert run_a.report.head_anchor != run_b.report.head_anchor
+
+
 # ---------------------------------------------------------------------------
-# Cross-Driver Replay Parity (Acceptance Criterion 2)
-# ---------------------------------------------------------------------------
-
-
-def test_cross_driver_replay_parity(tmp_path: Path) -> None:
-    frames = [
-        PageState(url="https://example.com/start", screenshot=b"PNG1", dom=b"<html>start</html>"),
-        PageState(url="https://example.com/start", screenshot=b"PNG1", dom=b"<html>start</html>"),
-        PageState(url="https://example.com/next", screenshot=b"PNG2", dom=b"<html>next</html>"),
-    ]
-
-    # Two separate registered driver wrappers around the same tape data
-    def driver_factory_a(profile_dir: Path) -> BrowserDriver:
-        return RecordedBrowserDriver(frames, profile_dir=profile_dir)
-
-    def driver_factory_b(profile_dir: Path) -> BrowserDriver:
-        return RecordedBrowserDriver(frames, profile_dir=profile_dir)
-
-    register_driver("recorded_a", driver_factory_a)
-    register_driver("recorded_b", driver_factory_b)
-
-    d1 = get_driver_factory("recorded_a")(tmp_path / "p1")
-    d2 = get_driver_factory("recorded_b")(tmp_path / "p2")
-
-    # Both navigate & act through the identical flow
-    d1.navigate("https://example.com/start")
-    d2.navigate("https://example.com/start")
-    assert d1.current_url() == d2.current_url()
-
-    action = Action(kind=ActionKind.NAVIGATE, target="https://example.com/next")
-    d1.act(action)
-    d2.act(action)
-
-    assert d1.current_url() == d2.current_url()
-    assert d1.dom_snapshot() == d2.dom_snapshot()
-    assert d1.screenshot() == d2.screenshot()
-
-
-# ---------------------------------------------------------------------------
-# Profile Isolation (Acceptance Criterion 4)
+# AC4: profile isolation
 # ---------------------------------------------------------------------------
 
 
@@ -220,8 +510,45 @@ def test_profile_isolation_per_driver(tmp_path: Path) -> None:
     assert not profile2.profile_dir.exists()
 
 
+def test_kit_fails_a_driver_that_reaches_outside_its_own_profile(tmp_path: Path) -> None:
+    """A driver that clears the profile root takes a concurrent task's profile."""
+
+    class ProfileStompingDriver(TapeDriver):
+        def __init__(self, frames: Sequence[PageState], *, profile_dir: Path | None = None) -> None:
+            super().__init__(frames, profile_dir=profile_dir)
+            assert profile_dir is not None
+            for sibling in profile_dir.parent.iterdir():
+                if sibling != profile_dir:
+                    shutil.rmtree(sibling, ignore_errors=True)
+
+    with pytest.raises(ConformanceFailure) as exc_info:
+        verify_driver_conformance(_tape_factory(ProfileStompingDriver), root_dir=tmp_path / "root")
+
+    assert exc_info.value.verb == "profile"
+    # Caught while both tasks are live, so the message names what actually
+    # happened rather than blaming the teardown that ran afterwards.
+    assert "does not exist" in str(exc_info.value)
+
+
+def test_kit_fails_a_driver_whose_close_removes_a_concurrent_profile(tmp_path: Path) -> None:
+    """Isolation must still hold at the terminal state, not only while running."""
+
+    class StompingCloseDriver(TapeDriver):
+        def close(self) -> None:
+            super().close()
+            assert self.profile_dir is not None
+            for sibling in self.profile_dir.parent.iterdir():
+                shutil.rmtree(sibling, ignore_errors=True)
+
+    with pytest.raises(ConformanceFailure) as exc_info:
+        verify_driver_conformance(_tape_factory(StompingCloseDriver), root_dir=tmp_path / "root")
+
+    assert exc_info.value.verb == "profile"
+    assert "another task" in str(exc_info.value)
+
+
 # ---------------------------------------------------------------------------
-# Unavailable Driver Refusal (Acceptance Criterion 5)
+# AC5: unavailable driver stays a typed refusal
 # ---------------------------------------------------------------------------
 
 
@@ -229,3 +556,4 @@ def test_driver_unavailable_refusal_message() -> None:
     exc = BrowserDriverUnavailable(driver_name="browser_use", extra="browser")
     assert "browser-use>=0.7" in str(exc)
     assert "pip install" in str(exc)
+    assert isinstance(exc, BrowserDriverError)

--- a/tests/unit/test_browser_driver_conformance.py
+++ b/tests/unit/test_browser_driver_conformance.py
@@ -541,6 +541,30 @@ def test_kit_exercises_every_protocol_verb(tmp_path: Path) -> None:
     assert set(CONFORMANCE_VERBS) <= set(called)
 
 
+def test_kit_drives_act_with_a_non_navigation_action(tmp_path: Path) -> None:
+    """The kit's ``act`` payload is pinned: a CLICK, not a disguised navigation.
+
+    The protocol cannot make a driver's *use* of the payload observable -- ``act``
+    returns nothing, and the only readback is the next frame, which a legitimate
+    replay driver advances by cursor rather than by payload. What can be pinned is
+    the kit's own side of the contract: ``act`` is exercised with the
+    non-navigation action ``BrowserWorker`` routes through ``act`` instead of
+    ``navigate``, on every driver it builds. Without this, turning the kit's
+    action into a ``NAVIGATE`` would stop exercising that route silently.
+    """
+    seen: list[Action] = []
+
+    class PayloadRecorder(TapeDriver):
+        def act(self, action: Action) -> None:
+            seen.append(action)
+            super().act(action)
+
+    verify_driver_conformance(_tape_factory(PayloadRecorder), root_dir=tmp_path)
+
+    assert [action.kind for action in seen] == [ActionKind.CLICK, ActionKind.CLICK]
+    assert {action.target for action in seen} == {"#conformance"}
+
+
 def test_kit_leaves_no_profile_behind_when_a_driver_fails(tmp_path: Path) -> None:
     """A failing driver must not leak its profile directory."""
     root = tmp_path / "profiles"

--- a/tests/unit/test_browser_driver_conformance.py
+++ b/tests/unit/test_browser_driver_conformance.py
@@ -1,0 +1,231 @@
+"""Unit tests for #3113: Browser driver selection, registry, and conformance kit."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.main import cli
+from bernstein.core.agents.computer_use import Action, ActionKind
+from bernstein.core.orchestration.browser_driver import (
+    BrowserDriver,
+    BrowserDriverError,
+    BrowserDriverUnavailable,
+    BrowserProfile,
+    ConformanceFailure,
+    PageState,
+    RecordedBrowserDriver,
+    get_driver_factory,
+    list_drivers,
+    register_driver,
+    verify_driver_conformance,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Broken drivers for Acceptance Criterion 3
+# ---------------------------------------------------------------------------
+
+
+class StaleUrlDriver:
+    """Deliberately broken driver: current_url does not update after navigate."""
+
+    def __init__(self, profile_dir: Path) -> None:
+        self.profile_dir = profile_dir
+        self._url = "https://example.com/initial"
+
+    def navigate(self, url: str) -> None:
+        # Ignore url, stay stale
+        pass
+
+    def act(self, action: Action) -> None:
+        pass
+
+    def screenshot(self) -> bytes:
+        return b"PNG_STALE"
+
+    def dom_snapshot(self) -> bytes:
+        return b"<html>start</html>"
+
+    def current_url(self) -> str:
+        return self._url
+
+    def close(self) -> None:
+        pass
+
+
+class StaleDomDriver:
+    """Deliberately broken driver: dom_snapshot returns empty or wrong DOM bytes."""
+
+    def __init__(self, profile_dir: Path) -> None:
+        self.profile_dir = profile_dir
+        self._url = "https://example.com/start"
+
+    def navigate(self, url: str) -> None:
+        self._url = url
+
+    def act(self, action: Action) -> None:
+        self._url = str(action.target)
+
+    def screenshot(self) -> bytes:
+        return b"PNG_OK"
+
+    def dom_snapshot(self) -> bytes:
+        # Return wrong/empty DOM
+        return b""
+
+    def current_url(self) -> str:
+        return self._url
+
+    def close(self) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Conformance Kit Tests
+# ---------------------------------------------------------------------------
+
+
+def test_conformance_kit_passes_valid_recorded_driver(tmp_path: Path) -> None:
+    frames = [
+        PageState(url="https://example.com/start", screenshot=b"PNG1", dom=b"<html>start</html>"),
+        PageState(url="https://example.com/next", screenshot=b"PNG2", dom=b"<html>next</html>"),
+    ]
+
+    def factory(profile_dir: Path) -> BrowserDriver:
+        return RecordedBrowserDriver(frames, profile_dir=profile_dir)
+
+    verify_driver_conformance(factory, root_dir=tmp_path)
+
+
+def test_conformance_kit_fails_stale_url_driver(tmp_path: Path) -> None:
+    def factory(profile_dir: Path) -> BrowserDriver:
+        return StaleUrlDriver(profile_dir)
+
+    with pytest.raises(ConformanceFailure) as exc_info:
+        verify_driver_conformance(factory, root_dir=tmp_path)
+
+    assert exc_info.value.verb == "current_url"
+    assert "Conformance failure in verb 'current_url'" in str(exc_info.value)
+
+
+def test_conformance_kit_fails_stale_dom_driver(tmp_path: Path) -> None:
+    def factory(profile_dir: Path) -> BrowserDriver:
+        return StaleDomDriver(profile_dir)
+
+    with pytest.raises(ConformanceFailure) as exc_info:
+        verify_driver_conformance(factory, root_dir=tmp_path)
+
+    assert exc_info.value.verb == "dom_snapshot"
+    assert "Conformance failure in verb 'dom_snapshot'" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Driver Registry & Selection Tests (Acceptance Criterion 1)
+# ---------------------------------------------------------------------------
+
+
+def test_driver_registry_list_and_get() -> None:
+    drivers = list_drivers()
+    assert "browser_use" in drivers
+    assert "recorded" in drivers
+
+    factory = get_driver_factory("recorded")
+    assert factory is RecordedBrowserDriver
+
+
+def test_unknown_driver_raises_error() -> None:
+    with pytest.raises(BrowserDriverError) as exc_info:
+        get_driver_factory("nonexistent_driver")
+    assert "Unknown browser driver 'nonexistent_driver'" in str(exc_info.value)
+    assert "'browser_use'" in str(exc_info.value)
+
+
+def test_cli_refuses_unknown_driver(tmp_path: Path) -> None:
+    flow_file = tmp_path / "flow.json"
+    flow_file.write_text('{"flow_id": "f1", "start_url": "https://example.com", "steps": []}')
+    runner = CliRunner()
+    res = runner.invoke(
+        cli, ["activity", "browser", "run", "--flow", str(flow_file), "--run", "r1", "--driver", "unknown_driver"]
+    )
+    assert res.exit_code != 0
+    assert (
+        "Unknown browser driver 'unknown_driver'" in res.output
+        or "Unknown browser driver 'unknown_driver'" in res.stderr
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cross-Driver Replay Parity (Acceptance Criterion 2)
+# ---------------------------------------------------------------------------
+
+
+def test_cross_driver_replay_parity(tmp_path: Path) -> None:
+    frames = [
+        PageState(url="https://example.com/start", screenshot=b"PNG1", dom=b"<html>start</html>"),
+        PageState(url="https://example.com/start", screenshot=b"PNG1", dom=b"<html>start</html>"),
+        PageState(url="https://example.com/next", screenshot=b"PNG2", dom=b"<html>next</html>"),
+    ]
+
+    # Two separate registered driver wrappers around the same tape data
+    def driver_factory_a(profile_dir: Path) -> BrowserDriver:
+        return RecordedBrowserDriver(frames, profile_dir=profile_dir)
+
+    def driver_factory_b(profile_dir: Path) -> BrowserDriver:
+        return RecordedBrowserDriver(frames, profile_dir=profile_dir)
+
+    register_driver("recorded_a", driver_factory_a)
+    register_driver("recorded_b", driver_factory_b)
+
+    d1 = get_driver_factory("recorded_a")(tmp_path / "p1")
+    d2 = get_driver_factory("recorded_b")(tmp_path / "p2")
+
+    # Both navigate & act through the identical flow
+    d1.navigate("https://example.com/start")
+    d2.navigate("https://example.com/start")
+    assert d1.current_url() == d2.current_url()
+
+    action = Action(kind=ActionKind.NAVIGATE, target="https://example.com/next")
+    d1.act(action)
+    d2.act(action)
+
+    assert d1.current_url() == d2.current_url()
+    assert d1.dom_snapshot() == d2.dom_snapshot()
+    assert d1.screenshot() == d2.screenshot()
+
+
+# ---------------------------------------------------------------------------
+# Profile Isolation (Acceptance Criterion 4)
+# ---------------------------------------------------------------------------
+
+
+def test_profile_isolation_per_driver(tmp_path: Path) -> None:
+    profile1 = BrowserProfile.allocate(root=tmp_path, task_id="task-101")
+    profile2 = BrowserProfile.allocate(root=tmp_path, task_id="task-102")
+
+    assert profile1.profile_dir != profile2.profile_dir
+    assert profile1.profile_dir.exists()
+    assert profile2.profile_dir.exists()
+
+    profile1.teardown()
+    assert not profile1.profile_dir.exists()
+    assert profile2.profile_dir.exists()
+
+    profile2.teardown()
+    assert not profile2.profile_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# Unavailable Driver Refusal (Acceptance Criterion 5)
+# ---------------------------------------------------------------------------
+
+
+def test_driver_unavailable_refusal_message() -> None:
+    exc = BrowserDriverUnavailable(driver_name="browser_use", extra="browser")
+    assert "browser-use>=0.7" in str(exc)
+    assert "pip install" in str(exc)

--- a/tests/unit/test_browser_driver_conformance.py
+++ b/tests/unit/test_browser_driver_conformance.py
@@ -376,6 +376,25 @@ def test_cli_refuses_unknown_driver(tmp_path: Path) -> None:
     assert "'browser_use'" in res.output
 
 
+def test_cli_refuses_the_recorded_driver_selected_by_name(tmp_path: Path) -> None:
+    """The refusal must reach the operator, not arrive as a driver_error state.
+
+    ``--driver recorded`` used to raise ``TypeError`` out of a half-applied
+    constructor. Refusing it inside the worker instead would classify it as a
+    ``driver_error`` terminal state, which never mentions the tape.
+    """
+    flow_file = tmp_path / "flow.json"
+    flow_file.write_text('{"flow_id": "f1", "start_url": "https://example.com", "steps": []}')
+    runner = CliRunner()
+    res = runner.invoke(
+        cli,
+        ["activity", "browser", "run", "--flow", str(flow_file), "--run", "r1", "--driver", "recorded"],
+    )
+    assert res.exit_code != 0
+    assert "--recording" in res.output
+    assert "driver_error" not in res.output
+
+
 def test_cli_refuses_driver_together_with_recording(tmp_path: Path) -> None:
     """--recording must not silently win and leave an unknown --driver unrefused."""
     flow_file = tmp_path / "flow.json"

--- a/tests/unit/test_browser_driver_conformance.py
+++ b/tests/unit/test_browser_driver_conformance.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import inspect
 import shutil
+import threading
 from typing import TYPE_CHECKING
 
 import pytest
@@ -460,6 +461,50 @@ def test_kit_leaves_no_profile_behind_when_a_driver_fails(tmp_path: Path) -> Non
     assert list(root.iterdir()) == []
 
 
+def test_two_kit_invocations_on_one_root_get_their_own_directories(tmp_path: Path) -> None:
+    """`BrowserProfile.allocate` is deterministic in the task id.
+
+    Constant task ids therefore resolve two invocations to the same two
+    directories, and the first invocation's teardown removes the second's live
+    profiles mid-run.
+    """
+    seen: list[Path] = []
+
+    class ProfileRecorder(TapeDriver):
+        def __init__(self, frames: Sequence[PageState], *, profile_dir: Path | None = None) -> None:
+            super().__init__(frames, profile_dir=profile_dir)
+            assert profile_dir is not None
+            seen.append(profile_dir)
+
+    verify_driver_conformance(_tape_factory(ProfileRecorder), root_dir=tmp_path)
+    verify_driver_conformance(_tape_factory(ProfileRecorder), root_dir=tmp_path)
+
+    assert len(seen) == 4
+    assert len(set(seen)) == 4, "two invocations shared profile directories"
+
+
+def test_concurrent_kit_invocations_on_one_root_do_not_disturb_each_other(tmp_path: Path) -> None:
+    """The reported harm directly: overlapping runs against a shared root."""
+    errors: list[BaseException] = []
+    start = threading.Barrier(4)
+
+    def run() -> None:
+        try:
+            start.wait(timeout=10)
+            for _ in range(5):
+                verify_driver_conformance(_tape_factory(TapeDriver), root_dir=tmp_path)
+        except BaseException as exc:  # reported from the main thread
+            errors.append(exc)
+
+    threads = [threading.Thread(target=run) for _ in range(4)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=60)
+
+    assert errors == []
+
+
 def test_kit_refuses_a_tape_that_is_not_three_frames(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="exactly 3 frames"):
         verify_driver_conformance(_tape_factory(TapeDriver), root_dir=tmp_path, expected_tape=CONFORMANCE_TAPE[:2])
@@ -495,6 +540,23 @@ def test_registered_factory_binds_profile_dir_as_a_keyword(name: str) -> None:
     Binding the signature proves the contract without constructing anything.
     """
     inspect.signature(get_driver_factory(name)).bind(profile_dir="/tmp/probe")
+
+
+def test_registration_is_last_write_wins_including_over_a_built_in() -> None:
+    """Documented, not guarded: whichever module imports last decides.
+
+    Pinned so the behaviour is a stated property of the registry rather than an
+    accident a plugin discovers by shadowing a built-in.
+    """
+    before = get_driver_factory("browser_use")
+
+    def replacement(*, profile_dir: Path) -> BrowserDriver:
+        return TapeDriver(CONFORMANCE_TAPE, profile_dir=profile_dir)
+
+    register_driver("browser_use", replacement)
+    assert get_driver_factory("browser_use") is replacement
+    assert get_driver_factory("browser_use") is not before
+    assert list_drivers().count("browser_use") == 1
 
 
 def test_recorded_driver_refuses_selection_by_name_with_a_typed_error() -> None:


### PR DESCRIPTION
# User description
Closes #3113.

Adds a driver registry and `--driver <name>` selection at the browser activity boundary, and a conformance kit (`verify_driver_conformance` / `ConformanceFailure`) a new backend has to pass.

Files: `src/bernstein/core/orchestration/browser_driver.py`, `src/bernstein/cli/commands/activity_cmd.py`, `tests/unit/test_browser_driver_conformance.py`.

## Corrections to the original description of this PR

The first version of this branch made three claims its own diff did not support. They are corrected here rather than deleted, so a reviewer can see what changed.

| Original claim | Status | What was actually true |
|---|---|---|
| "conformance kit ... to assert protocol compliance across all 6 verbs" | **was false, now true** | `navigate` was never called. A driver with no `navigate` method at all passed the kit. It is now called directly and the resulting frame validated. |
| "asserting ... snapshot ordering", "verified against negative test cases" | **was false, now true** | The post-action DOM was only checked for non-emptiness, so a driver whose DOM was frozen at the start frame passed. Neither broken driver named in AC3 could be failed. All three read verbs are now compared byte-exact against the frame the driver should be sitting on. |
| "Two registered drivers driving the same recorded tape produce byte-identical action sequences and observation hashes" | **was false, now true** | The test compared two instances of *the same class* over the same tape — an assertion that holds unconditionally. It stayed green with `RecordedBrowserDriver.dom_snapshot` returning screenshot bytes. Parity is now measured across two independent implementations through `BrowserWorker`, on `head_anchor`, canonical report bytes, artifact hash, evidence set hash, and per-step anchors. |

"58 passed" was accurate for the commit that made it.

## Defects fixed on this branch

1. **`--driver recorded` crashed with an untyped `TypeError`.** `RecordedBrowserDriver` was registered as a bare class but needs a tape as its first positional argument, while the boundary calls `factory(profile_dir=...)`. The registry now states its calling contract, `recorded` refuses with a typed `BrowserDriverError`, and the boundary refuses the name up front so the operator is told to pass `--recording` instead of seeing `terminal=failed reason=driver_error`.
2. **The kit could not be run against a registered driver.** It called factories positionally while every registry entry is keyword-only, so `verify_driver_conformance(get_driver_factory("browser_use"), ...)` raised `TypeError`.
3. **The kit could not fail a nonconforming driver** — see the table above.
4. **The `close` idempotency check masked failures and leaked profiles.** A second unguarded `close()` in `finally` replaced the live `ConformanceFailure` with the driver's own exception and skipped `profile.teardown()`.
5. **`--driver` was silently ignored alongside `--recording`**, so an unknown driver name passed with a tape was never refused.
6. **Tests leaked registrations** into the module-global registry for the rest of the session.

Two more surfaced during review:

7. **The kit's own profiles collided across invocations.** `BrowserProfile.allocate` is deterministic in the task id, and the kit passed constants, so two invocations sharing a `root_dir` resolved to the same two directories and tore down each other's live profiles mid-run. Worse once the non-interference check existed: a concurrent invocation's writes read as cross-task interference, failing a conforming driver. The ids now carry a per-invocation nonce (`55ab22e3`).
8. **One defect was introduced and fixed inside this review cycle, not inherited.** `1ef1095b` moved the driver close out of `finally` so a non-idempotent close could be reported instead of masking the failure — which left both sessions open whenever the kit failed mid-flow. `7969ab51` records every driver as it is built and closes all of them in `finally`, keeping the idempotency assertion on the success path. Listed because the commit is in the history.

9. **The sibling non-interference check compared file names, not file contents, and three checks had no test behind them.** `_dir_entries` returned a set of relative paths, so a driver that rewrote a concurrent task's existing `cookies.txt` in place left the listing identical and passed -- while the docstring claimed the sibling profile was byte-for-byte unchanged. Entries are now fingerprinted by content, which makes that claim true. Separately, deleting the byte-exact `screenshot` comparison, or either of the two drive-then-compare non-interference checks, left the whole suite green: they were checks with no test behind them. Covered by `test_kit_fails_a_screenshot_that_lags_the_action`, `test_kit_fails_a_driver_that_rewrites_a_sibling_profile_file`, and `test_kit_fails_a_driver_that_interferes_on_only_one_session[1|2]` (`c7899b68`).

## Acceptance criteria

| AC | Where |
|---|---|
| 1. `--driver <name>` selects a registered driver; unknown name refused with the names listed, before launch | `test_cli_refuses_unknown_driver`, `test_unknown_driver_raises_error_listing_what_is_registered`, `test_cli_refuses_the_recorded_driver_selected_by_name`, `test_cli_refuses_driver_together_with_recording` |
| 2. Cross-driver replay parity, identical `head_anchor`, hash equality asserted | `test_two_different_drivers_over_one_tape_produce_the_same_head_anchor`, with `test_a_driver_that_observes_the_wrong_frame_breaks_parity` proving the assertion is not a tautology |
| 3. Kit fails a stale-`current_url` driver and a DOM-ordering driver, naming the verb | `test_kit_fails_a_stale_url_driver`, `test_kit_fails_a_dom_that_lags_the_action`, `test_kit_fails_a_dom_that_leads_the_action` |
| 4. Profile isolation per driver, torn down at terminal state | asserted inside the kit, with its limits stated below; `test_kit_fails_a_driver_that_reaches_outside_its_own_profile`, `test_kit_fails_a_driver_whose_close_removes_a_concurrent_profile`, `test_kit_fails_a_driver_that_writes_into_a_sibling_profile`, `test_profile_isolation_per_driver` |
| 5. `BrowserDriverUnavailable` names the package to install | `test_driver_unavailable_refusal_message` |
| 6. Unchanged behaviour with no `--driver` | `tests/unit/test_browser_worker.py` and `tests/unit/test_browser_driver.py` unedited and passing |

## What the conformance kit does not prove

Stated explicitly, because the first version of this PR implied more than it checked.

The kit asserts that two tasks are allocated disjoint profile directories, that both exist while both drivers are live, that driving one task leaves the other's directory byte-for-byte unchanged, and that tearing one down does not remove the other. It **cannot** prove a backend uses the directory it was handed: nothing in the six-verb protocol exposes where a driver puts its state, and a conforming driver may legitimately write nothing (`RecordedBrowserDriver` writes nothing, so requiring writes would fail a correct driver). A backend that ignores `profile_dir` and writes to a fixed location outside the profile root passes. Non-interference inside the profile root is the strongest claim available at this protocol surface; anything beyond it belongs in the backend's own tests.

The same holds for the action payload. `act` returns nothing and the only readback is the next frame, which a replay driver advances by cursor rather than by payload, so a driver that discards the `kind` and `target` it is handed passes. Requiring otherwise would fail `RecordedBrowserDriver`, which exists to replay a tape. What is pinned instead is the kit's own side: `act` is exercised with the non-navigation action `BrowserWorker` routes through `act` rather than `navigate` (`test_kit_drives_act_with_a_non_navigation_action`).

And being callable is not the same as passing: the kit compares against a fixed tape, so a live backend has to be pointed at a fixture that reproduces one before `verify_driver_conformance` means anything for it.

## Known limitation, not changed here

A driver that fails to build inside `BrowserWorker` surfaces as `terminal=failed reason=driver_error` with the exception message dropped. This is pre-existing and affects `BrowserDriverUnavailable` too — an operator without `browser-use` installed gets the terminal state but not the `pip install` line the exception carries. `browser_worker.py` is outside this PR's file set, so it is reported rather than fixed.

## Review-bot findings

Eight must-address findings, each verified against the code before being acted on. Seven were correct and are fixed, every one with a test that fails without the fix. The eighth is a real concern about pre-existing behaviour that this PR does not introduce or widen; it is deferred with reasoning rather than patched here. Verdicts are in the individual threads.

| Finding | Verdict | Fixed in |
|---|---|---|
| `3743166507` recorded driver crashes without CLI refusal | accepted, fixed | c60e3c03, a95ad6a0 |
| `3743166509` registered factories crash at the CLI boundary | accepted, fixed | c60e3c03 |
| `3743166510` conformance kit never calls `navigate` | accepted, fixed | c60e3c03 |
| `3743334037` conformance falsely approves shared profiles | accepted; non-interference now checked, residual limit documented | 1ef1095b |
| `3743334039` broken second driver passes conformance | accepted, fixed | 1ef1095b |
| `3743334042` close failure leaks the remaining driver | accepted, fixed | 1ef1095b, 7969ab51 |
| `3743355158` constant task ids collide across concurrent kit runs | accepted, fixed | 55ab22e3 |
| `3743385404` unrestricted navigation reaches private hosts | concern accepted, **deferred**: pre-existing on `main`, not introduced or widened here — see below | — |
| `3743553147` action payloads are not conformance-checked | accepted; kit-side payload pinned, residual limit documented | 9776adda |

### Deferred: navigation destination policy (`3743385404`)

`BrowserUseDriver.navigate` forwards a flow's `NAVIGATE` target to `go_to_url` with no host allow-list, so loopback, link-local and metadata addresses are reachable. That is real, and it is exactly as true on `main` as it is here:

```
$ git show origin/main:src/bernstein/core/orchestration/browser_driver.py | grep -n go_to_url
359:        self._call("go_to_url", url)

$ git diff origin/main...HEAD -- src/bernstein/core/orchestration/browser_driver.py \
    | grep -E '^[-+].*(go_to_url|BrowserSession|def navigate|allowed_domains)'
(no output)
```

The only diff line touching the live backend is `register_driver("browser_use", browser_use_driver)`, which stores the function the CLI already called directly. The reachable-host set is unchanged.

Not fixed here because a destination policy is a design decision rather than a patch: it needs a configuration surface, a decision between hostname matching and resolve-time IP checks, a terminal state and reason code so a blocked navigation is a typed refusal, and alignment with the existing `core/security/policy_engine.py` and `command_policy.py` surfaces instead of a second policy next to them. It would also change behaviour for anyone deliberately driving a private staging address today. This needs its own issue; no issue has been opened, so it requires a maintainer to pick up.

<!-- bot-ack: 3743166507 reason=fixed in c60e3c03 and a95ad6a0; recorded is registered as a factory raising a typed BrowserDriverError, and the boundary refuses the name with click.BadParameter naming --recording -->
<!-- bot-ack: 3743166509 reason=fixed in c60e3c03; register_driver states the factory(profile_dir=...) contract and every entry is checked against it by test_registered_factory_binds_profile_dir_as_a_keyword -->
<!-- bot-ack: 3743166510 reason=fixed in c60e3c03; the kit calls driver.navigate directly, validates the resulting frame, exercises act with a non-navigation CLICK, and compares all read verbs byte-exact against a three-frame tape -->
<!-- bot-ack: 3743334037 reason=fixed in 1ef1095b as far as the protocol allows; driving one task must leave the other profile directory byte-for-byte unchanged. The protocol exposes no state location, so the residual gap is stated in the docstring rather than implied away -->
<!-- bot-ack: 3743334039 reason=fixed in 1ef1095b; both drivers are driven through the full flow and both are checked for the six verbs, so a shared instance or a broken second session fails -->
<!-- bot-ack: 3743334042 reason=fixed in 1ef1095b and 7969ab51; each driver is closed independently via _close_idempotently, and every constructed driver is closed in finally so no session leaks on a failure path -->
<!-- bot-ack: 3743355158 reason=fixed in 55ab22e3; the kit's two profile task ids carry a per-invocation uuid4 nonce, so concurrent runs against one root_dir no longer share directories or tear down each other's live profiles -->
<!-- bot-ack: 3743385404 reason=concern accepted, deferred. BrowserUseDriver.navigate forwarding to go_to_url without a host allow-list is unchanged from origin/main; this PR only registers the same callable the CLI already invoked, so the reachable-host set is identical. A destination policy needs a config surface, a hostname-versus-resolved-IP decision, a typed terminal state for a blocked navigation, and alignment with core/security/policy_engine.py, so it belongs in its own change rather than a driver-selection PR. Reasoning in the review thread. -->
<!-- bot-ack: 3743553147 reason=accepted and confirmed; a driver whose act() discards its argument passes the kit. The six-verb protocol cannot make payload handling observable - act returns nothing and the only readback is the next frame, which a replay driver advances by cursor, so requiring payload sensitivity would fail RecordedBrowserDriver. Fixed on the side that can be: 9776adda pins that act is exercised with a non-navigation action on every driver the kit builds (test_kit_drives_act_with_a_non_navigation_action), and the residual limit is stated in the docstring next to the profile-state-location one. Reasoning in the review thread. -->

## Verification

```
$ uv run ruff check src/bernstein/core/orchestration/browser_driver.py \
    src/bernstein/cli/commands/activity_cmd.py \
    tests/unit/test_browser_driver_conformance.py
All checks passed!

$ uv run ruff format --check <same three files>
3 files already formatted

$ uv run pytest tests/unit/test_browser_driver_conformance.py tests/unit/test_browser_driver.py \
    tests/unit/test_browser_worker.py tests/unit/test_activity_cmd.py -q
99 passed, 1 warning in 16.74s
```

Every check in the conformance kit was removed one at a time and the covering test confirmed to go red. That statement was **not** true when it was first written -- three checks survived deletion with the suite still green, and are covered as of `c7899b68` (see defect 9). It is true now. `tests/unit/test_browser_driver.py` and `tests/unit/test_browser_worker.py` are unmodified.

## Exclusions

`src/bernstein/core/orchestration/browser_driver.py` was listed as out of scope for the original change. It was edited anyway, and the edits stand — the registry and the conformance kit have to live next to the protocol they constrain. Flagged explicitly rather than quietly. No overlap with #3495, which touches `core/orchestration` but a disjoint file set.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add registered browser-driver selection at the activity boundary and enforce a keyword-only <code>profile_dir</code> factory contract. Implement <code>verify_driver_conformance</code> and <code>ConformanceFailure</code> to validate protocol verbs, frame observations, profile isolation, cleanup, and cross-driver replay parity.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3507?tool=ast&topic=Driver+selection>Driver selection</a>
        </td><td>Enable activity commands to select registered browser backends with <code>--driver</code>, reject unknown or tape-only selections clearly, and preserve explicit <code>--recording</code> behavior.<details><summary>Modified files (3)</summary><ul><li>src/bernstein/cli/commands/activity_cmd.py</li>
<li>src/bernstein/core/orchestration/browser_driver.py</li>
<li>tests/unit/test_browser_driver_conformance.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>viktorshpuktor@gmail.com</td><td>fix(browser): fingerpr...</td><td>August 09, 2026</td></tr>
<tr><td>sanderchernitsky@gmail...</td><td>fix(browser): give eac...</td><td>August 09, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3507?tool=ast&topic=Driver+conformance>Driver conformance</a>
        </td><td>Add <code>verify_driver_conformance</code> and <code>ConformanceFailure</code> to exercise all six driver verbs, detect stale observations and profile interference, verify cleanup and idempotent closing, and test parity between independent implementations.<details><summary>Modified files (2)</summary><ul><li>src/bernstein/core/orchestration/browser_driver.py</li>
<li>tests/unit/test_browser_driver_conformance.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>viktorshpuktor@gmail.com</td><td>fix(browser): fingerpr...</td><td>August 09, 2026</td></tr>
<tr><td>sanderchernitsky@gmail...</td><td>fix(browser): give eac...</td><td>August 09, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3507?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

