### PR TITLE
chore(ci): ratchet coverage baseline up to 83.25%

### DIFF
--- a/.coverage-baseline.json
+++ b/.coverage-baseline.json
@@ -1,8 +1,8 @@
 {
   "diff_coverage_floor_percent": 85,
-  "head_sha": "23c8a5daa41e4e6447db96f77f0b1094e5117bef",
-  "line_rate": 0.8319,
-  "run_id": "31300720016",
-  "total_coverage_percent": 83.19,
-  "updated_at": "2026-08-09T07:55:37+00:00"
+  "head_sha": "2f00e32226dbdf25daadbb813d1930ff54705099",
+  "line_rate": 0.8325,
+  "run_id": "31321587268",
+  "total_coverage_percent": 83.25,
+  "updated_at": "2026-08-09T16:15:12+00:00"
 }


### PR DESCRIPTION
# User description
Total line coverage rose on `main`, so the monotonic ratchet
bumped the committed high-water mark in `.coverage-baseline.json`
to **83.25%**.

Measured on `2f00e32226dbdf25daadbb813d1930ff54705099` from the
`coverage-report` artifact of CI run
[31321587268](https://github.com/sipyourdrink-ltd/bernstein/actions/runs/31321587268).
Those, and the raw Cobertura `line-rate` the percentage was
rounded from, are recorded in the baseline, so the number in the
diff can be re-derived from the file itself:

```bash
uv run python scripts/coverage_ratchet.py verify \
    --baseline .coverage-baseline.json --require-provenance
```

From here, any later push whose total coverage falls below this
mark is flagged by the LEVEL 2 ratchet. The gate stays advisory
until promoted; see `docs/operations/coverage-ratchet.md`.

Generated by `.github/workflows/coverage-ratchet.yml`.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Raise the committed coverage high-water mark to 83.25% using the latest CI <code>coverage-report</code> artifact. Update the baseline provenance for commit <code>2f00e32226dbdf25daadbb813d1930ff54705099</code> and run <code>31321587268</code> so the coverage ratchet can enforce the new threshold.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>chernistry</td><td>chore(ci): ratchet cov...</td><td>August 09, 2026</td></tr>
<tr><td>github-actions[bot]</td><td>chore(ci): ratchet cov...</td><td>July 25, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3523?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>