### PR TITLE
fix(cli): name --cli in the no-adapter fatal, not the subprocess's --adapter

### DIFF
--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -162,6 +162,19 @@ from bernstein.evolution.risk import RiskScorer
 
 _BERNSTEIN_YAML = "bernstein.yaml"
 
+#: What an operator is told when no adapter resolves. Every flag it names has to
+#: be a flag of the ``bernstein`` command, because that is what the reader typed
+#: and what they will check against ``bernstein --help``. This module's own
+#: ``--adapter`` argparse flag belongs to the orchestrator subprocess and is not
+#: reachable from there; naming it sent readers looking for an option that does
+#: not exist (#3526). ``tests/unit/test_adapter_fatal_message.py`` resolves each
+#: flag here against the registered CLI, so the text cannot drift back.
+NO_ADAPTER_CONFIGURED = (
+    "FATAL: no adapter configured. Bernstein does not default to Claude - "
+    f"pass --cli (e.g. --cli codex), set BERNSTEIN_ADAPTER, or set 'cli' in {_BERNSTEIN_YAML}. "
+    "Run 'bernstein integrations list --installed' to see which adapters resolve here."
+)
+
 # Preserve underscore-prefixed aliases so existing test imports keep working
 _compute_total_spent = compute_total_spent
 _total_spent_cache = total_spent_cache
@@ -5908,10 +5921,12 @@ if __name__ == "__main__":
             )
 
         if not adapter_name:
-            logger.error(
-                "FATAL: no adapter configured. Bernstein does not default to Claude - "
-                "pass --adapter, set BERNSTEIN_ADAPTER, or configure 'cli' in bernstein.yaml."
-            )
+            # Name --cli, not --adapter. --adapter is this module's own argparse
+            # flag; the operator reaching this message typed `bernstein`, whose
+            # equivalent option is --cli. Naming a flag `bernstein --help` does
+            # not list sends the reader looking for something that is not there
+            # (#3526).
+            logger.error("%s", NO_ADAPTER_CONFIGURED)
             sys.exit(1)
 
         # Run-level model: ``--model`` flag (threaded from ``bernstein run

--- a/tests/unit/test_adapter_fatal_message.py
+++ b/tests/unit/test_adapter_fatal_message.py
@@ -1,0 +1,102 @@
+"""The no-adapter fatal must only name things the operator can actually run.
+
+The message fires inside the orchestrator subprocess, which has its own
+``argparse`` surface, so it is easy to write it against the flags in scope at
+that point in the file. The reader is somewhere else entirely: they typed
+``bernstein``, and every remedy they try will be checked against
+``bernstein --help``. A flag named here that lives only on the subprocess sends
+them looking for an option that does not exist (#3526, reported in #3514).
+
+These tests resolve each flag and command the message names against the
+registered CLI, so the text cannot drift back to naming an internal one.
+"""
+
+from __future__ import annotations
+
+import re
+
+import click
+import pytest
+
+from bernstein.cli.main import cli
+from bernstein.core.orchestration.orchestrator import NO_ADAPTER_CONFIGURED
+
+_FLAG_RE = re.compile(r"(?<![\w-])--[a-z][a-z0-9-]+")
+#: A quoted invocation: the command path, then the flags that belong to it. The
+#: flags are captured with the path so they are checked against the command they
+#: were written for rather than against the top-level group.
+_COMMAND_RE = re.compile(r"bernstein ((?:[a-z][a-z0-9-]* )*[a-z][a-z0-9-]*)((?: --[a-z][a-z0-9-]+)*)")
+
+
+def _group_option_names(group: click.Group) -> set[str]:
+    return {name for param in group.params if isinstance(param, click.Option) for name in param.opts}
+
+
+def _resolve(path: str) -> click.Command | None:
+    """Resolve a space-separated command path against the CLI, or return None."""
+    current: click.Command = cli
+    for token in path.split():
+        if not isinstance(current, click.Group):
+            return None
+        found = current.commands.get(token)
+        if found is None:
+            return None
+        current = found
+    return current
+
+
+def _invocations() -> list[tuple[str, tuple[str, ...]]]:
+    """Return each ``bernstein ...`` invocation as (command path, its flags)."""
+    return [(m.group(1), tuple(_FLAG_RE.findall(m.group(2)))) for m in _COMMAND_RE.finditer(NO_ADAPTER_CONFIGURED)]
+
+
+def _flags_outside_invocations() -> set[str]:
+    """Return flags the message offers on the ``bernstein`` command itself.
+
+    Flags written as part of a quoted invocation belong to that subcommand and
+    are checked against it, so whole invocations are removed here first.
+    """
+    return set(_FLAG_RE.findall(_COMMAND_RE.sub(" ", NO_ADAPTER_CONFIGURED)))
+
+
+def _command_flag_cases() -> list[tuple[str, str]]:
+    return [(path, flag) for path, flags in _invocations() for flag in flags]
+
+
+@pytest.mark.parametrize("flag", sorted(_flags_outside_invocations()))
+def test_every_flag_the_fatal_offers_is_a_flag_of_the_bernstein_command(flag: str) -> None:
+    """The reader checks the remedy against ``bernstein --help``; it has to be there."""
+    assert flag in _group_option_names(cli), (
+        f"the no-adapter fatal tells the operator to pass {flag}, which the bernstein "
+        f"command does not accept; name the user-facing option instead"
+    )
+
+
+@pytest.mark.parametrize("path", [path for path, _ in _invocations()])
+def test_every_command_the_fatal_suggests_resolves(path: str) -> None:
+    """A suggested command that does not resolve is a second dead end."""
+    assert _resolve(path) is not None, f"the no-adapter fatal suggests 'bernstein {path}', which does not resolve"
+
+
+@pytest.mark.parametrize(("path", "flag"), _command_flag_cases())
+def test_every_flag_on_a_suggested_command_belongs_to_that_command(path: str, flag: str) -> None:
+    """A flag quoted with a command has to be accepted by that command."""
+    command = _resolve(path)
+    assert command is not None, f"'bernstein {path}' does not resolve"
+    accepted = {name for param in command.params if isinstance(param, click.Option) for name in param.opts}
+    assert flag in accepted, f"the no-adapter fatal suggests 'bernstein {path} {flag}', which that command rejects"
+
+
+def test_the_fatal_does_not_name_the_orchestrators_own_adapter_flag() -> None:
+    """``--adapter`` is reachable only from the subprocess argparse, never from the CLI."""
+    assert "--adapter" not in NO_ADAPTER_CONFIGURED
+    assert "--adapter" not in _group_option_names(cli), (
+        "the CLI grew an --adapter option; if it is the operator-facing spelling, "
+        "this test and the fatal message should both move to it"
+    )
+
+
+def test_the_fatal_still_offers_the_two_remedies_that_are_not_flags() -> None:
+    """The env var and the config key work and are the fallbacks when no flag fits."""
+    assert "BERNSTEIN_ADAPTER" in NO_ADAPTER_CONFIGURED
+    assert "bernstein.yaml" in NO_ADAPTER_CONFIGURED


### PR DESCRIPTION
# User description
Closes #3526. Reported in #3514 as the point where a first evaluation stopped.

## The defect

When no adapter resolves, the run dies on:

```
FATAL: no adapter configured. Bernstein does not default to Claude -
pass --adapter, set BERNSTEIN_ADAPTER, or configure 'cli' in bernstein.yaml.
```

`--adapter` belongs to the `argparse` parser inside `orchestrator.py`'s
`__main__`, which only the orchestrator subprocess ever parses. The operator who
reads this message typed `bernstein`, whose equivalent option is `--cli`. They
check `bernstein --help`, find no `--adapter`, and are left with two remedies
they have just been implicitly told are the fallbacks.

The other two were accurate: `BERNSTEIN_ADAPTER` is read at `orchestrator.py`
and `preflight.py`, and the seed's `cli` key works — which is what the reporter
eventually found by experiment.

## The change

The message names `--cli` with an example value, keeps the env var and the
config key, and adds `bernstein integrations list --installed` so the reader can
see which adapters actually resolve on their machine instead of guessing a name.
It moves to a module constant, `NO_ADAPTER_CONFIGURED`, so it can be asserted on.

## Why a guard and not just a string edit

The original text was not careless — it was written in a file where `--adapter`
is genuinely in scope. Anything editing that message later is in the same
position, so a fixed string would drift back.

`tests/unit/test_adapter_fatal_message.py` parses the message and checks it
against the live CLI:

- every flag offered on the bare command is an option of the `bernstein` group;
- every `bernstein ...` invocation it suggests resolves against the command tree;
- every flag quoted with an invocation is accepted by that command;
- `--adapter` appears in neither the message nor the CLI, with the assertion
  message saying what to do if the CLI ever grows that spelling;
- the env var and config-key remedies are still offered.

The parser caught a real mistake in my own first draft: it flagged `--installed`
as not being a top-level flag, which was correct — it belongs to `integrations
list`. The check now attributes flags to the command they are written with.

## Verification

```
pytest tests/unit/test_adapter_fatal_message.py \
       tests/unit/test_cli_command_registration.py \
       tests/unit/test_readme_api_coverage.py -q
-> 235 passed
```

Restoring the shipped message fails
`test_every_flag_the_fatal_offers_is_a_flag_of_the_bernstein_command[--adapter]`
and `test_the_fatal_does_not_name_the_orchestrators_own_adapter_flag`.

`ruff check` and `ruff format --check` clean. No other test or doc asserted the
old string.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Correct the no-adapter fatal guidance to use the operator-facing <code>--cli</code> option, preserve environment and configuration remedies, and show how to list installed integrations. Expose the message as <code>NO_ADAPTER_CONFIGURED</code> and validate its flags and commands against the live Click CLI.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3530?tool=ast&topic=CLI+message+guard>CLI message guard</a>
        </td><td>Add automated checks ensuring every suggested command and flag is valid for the user-facing CLI and preventing regression to the internal <code>--adapter</code> option.<details><summary>Modified files (1)</summary><ul><li>tests/unit/test_adapter_fatal_message.py</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>fix(cli): name --cli i...</td><td>August 10, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3530?tool=ast&topic=Adapter+guidance>Adapter guidance</a>
        </td><td>Update the no-adapter guidance to recommend <code>--cli</code>, <code>BERNSTEIN_ADAPTER</code>, the <code>cli</code> configuration key, and <code>bernstein integrations list --installed</code> for diagnosing adapter resolution.<details><summary>Modified files (1)</summary><ul><li>src/bernstein/core/orchestration/orchestrator.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>fix(cli): name --cli i...</td><td>August 10, 2026</td></tr>
<tr><td>chernistry</td><td>fix(types): resolve th...</td><td>August 09, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3530?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>