### PR TITLE
ci: pin the trufflehog scanner version, not just the action

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -42,6 +42,16 @@ jobs:
       - name: Run trufflehog
         uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11  # v3.96.0
         with:
+          # The `uses:` SHA above pins the action, which is a shell wrapper;
+          # the wrapper runs `ghcr.io/trufflesecurity/trufflehog:${version}`,
+          # and that input defaults to `latest`. Unpinned, a detector added
+          # upstream arrives on whichever pull request is open when it ships,
+          # and reads as that author's fault. Renovate bumps this together
+          # with the `uses:` SHA - see the `trufflehog` group in
+          # `renovate.json` - and `tests/unit/test_trufflehog_workflow_yaml.py`
+          # fails if the two ever name different releases.
+          # renovate: datasource=docker depName=ghcr.io/trufflesecurity/trufflehog
+          version: 3.96.0
           # Only report verified secrets - keeps signal-to-noise high and
           # lets the job act as a hard gate. Unknown / unverified results
           # are dominated by test-fixture connection strings like

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,27 @@
     "config:recommended"
   ],
   "minimumReleaseAge": "7 days",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track the trufflehog scanner image. The github-actions manager only reads 'uses:' lines, but that action is a wrapper that runs 'ghcr.io/trufflesecurity/trufflehog:${version}'; without this the pinned scanner would silently go stale.",
+      "managerFilePatterns": [
+        "/^\\.github/workflows/trufflehog\\.yml$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>\\S+)\\s+version:\\s*(?<currentValue>[^\\s#]+)"
+      ]
+    }
+  ],
   "packageRules": [
+    {
+      "description": "trufflehog releases the action wrapper and the scanner image from one repository, and tests/unit/test_trufflehog_workflow_yaml.py requires the workflow to name the same release for both. Group them so a bump lands as one pull request rather than two that each fail that check.",
+      "groupName": "trufflehog",
+      "matchPackageNames": [
+        "trufflesecurity/trufflehog",
+        "ghcr.io/trufflesecurity/trufflehog"
+      ]
+    },
     {
       "description": "Pin python to 3.13 until aider-chat and other adapters confirm 3.14 compatibility.",
       "matchManagers": [

--- a/tests/unit/test_trufflehog_workflow_yaml.py
+++ b/tests/unit/test_trufflehog_workflow_yaml.py
@@ -1,7 +1,7 @@
 """Structural assertions for the secret-scanning gate.
 
-The gate is only worth having if a red run means something. Two settings
-decide that, and both are the kind of thing that gets widened under time
+The gate is only worth having if a red run means something. Three settings
+decide that, and each is the kind of thing that gets widened under time
 pressure rather than by decision, so they are pinned here:
 
 * it reports verified results only - the unverified stream is dominated by
@@ -12,7 +12,13 @@ pressure rather than by decision, so they are pinned here:
   characters, so it fires on ordinary Python test names and on test
   filenames quoted in prose. A detector that cannot separate a credential
   from a docstring contributes nothing, but the argument stops there - it
-  does not extend to detectors for services this project actually uses.
+  does not extend to detectors for services this project actually uses;
+* it names the scanner version it runs. The ``uses:`` SHA pins the action,
+  which is a shell wrapper; the wrapper then runs
+  ``ghcr.io/trufflesecurity/trufflehog:${version}``, and that input defaults
+  to ``latest``. Left at the default, a detector added upstream reaches this
+  repository on its own schedule and lands on whichever pull request is open
+  at the time.
 
 The second point is why this file exists. ``--exclude-detectors`` takes a
 comma-separated list, so silencing a genuine finding is a one-word edit that
@@ -23,6 +29,7 @@ build green.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any, cast
 
@@ -39,6 +46,13 @@ WORKFLOW = REPO_ROOT / ".github" / "workflows" / "trufflehog.yml"
 #: ordinary test names hit. There is no Lob integration here, so nothing is
 #: lost. Extending this set means a real detector is being turned off.
 ALLOWED_EXCLUDED_DETECTORS = frozenset({"lob"})
+
+#: An exact scanner release, e.g. ``3.96.0``. The image is tagged without a
+#: leading ``v``; ``latest`` and floating prefixes are what this rejects.
+EXACT_RELEASE = re.compile(r"^\d+\.\d+\.\d+$")
+
+#: The ``uses:`` pin and the version comment Renovate maintains beside it.
+ACTION_PIN = re.compile(r"uses:\s*trufflesecurity/trufflehog@[0-9a-f]{40}\s*#\s*v?(?P<version>\d+\.\d+\.\d+)")
 
 
 def _doc() -> dict[str, Any]:
@@ -63,6 +77,21 @@ def _scan_step() -> dict[str, Any]:
 
 def _extra_args() -> str:
     return str(_scan_step().get("with", {}).get("extra_args", ""))
+
+
+def _scanner_version() -> str:
+    """The ``version`` input, i.e. the image tag the wrapper actually runs."""
+    return str(_scan_step().get("with", {}).get("version", "")).strip()
+
+
+def _action_version() -> str:
+    """The wrapper release, read from the comment beside the ``uses:`` SHA."""
+    match = ACTION_PIN.search(WORKFLOW.read_text(encoding="utf-8"))
+    assert match is not None, (
+        "the trufflehog step must pin the action by full SHA with the release "
+        "in a trailing comment, as Renovate writes it"
+    )
+    return match.group("version")
 
 
 def _excluded_detectors() -> frozenset[str]:
@@ -96,6 +125,35 @@ def test_the_known_false_positive_detector_stays_excluded() -> None:
     assert "lob" in _excluded_detectors(), (
         "`lob` verifies any `test_` + 35 characters as a live key; without "
         "this exclusion a test name of that length fails the scan"
+    )
+
+
+def test_the_scanner_binary_is_pinned_to_an_exact_release() -> None:
+    """The ``uses:`` SHA pins the wrapper, not the scanner it downloads."""
+    version = _scanner_version()
+    assert version, (
+        "the trufflehog step must set the `version` input. The `uses:` SHA "
+        "pins the action, but the action is a wrapper that runs "
+        "`ghcr.io/trufflesecurity/trufflehog:${version}`, and that input "
+        "defaults to `latest` - so a detector added upstream reaches this "
+        "repository with no change on this side, on whichever pull request "
+        "happens to be open"
+    )
+    assert EXACT_RELEASE.match(version), (
+        f"`version: {version}` does not name one release. The image tag must "
+        "be an exact `MAJOR.MINOR.PATCH` (no `v` prefix, and not `latest`), "
+        "or the scan is not reproducible from the workflow alone"
+    )
+
+
+def test_the_scanner_binary_and_the_action_wrapper_are_the_same_release() -> None:
+    """Renovate groups the two bumps; a mismatch means one landed alone."""
+    scanner, action = _scanner_version(), _action_version()
+    assert scanner == action, (
+        f"the workflow runs scanner {scanner} through wrapper {action}. "
+        "These ship from one repository and `renovate.json` groups them into "
+        "a single pull request, so a mismatch means half a bump landed - "
+        "reconcile them rather than pinning the test to the drift"
     )
 
 

--- a/tests/unit/test_trufflehog_workflow_yaml.py
+++ b/tests/unit/test_trufflehog_workflow_yaml.py
@@ -51,8 +51,8 @@ ALLOWED_EXCLUDED_DETECTORS = frozenset({"lob"})
 #: leading ``v``; ``latest`` and floating prefixes are what this rejects.
 EXACT_RELEASE = re.compile(r"^\d+\.\d+\.\d+$")
 
-#: The ``uses:`` pin and the version comment Renovate maintains beside it.
-ACTION_PIN = re.compile(r"uses:\s*trufflesecurity/trufflehog@[0-9a-f]{40}\s*#\s*v?(?P<version>\d+\.\d+\.\d+)")
+#: A full-SHA action pin, the only form this repository allows.
+SHA_PIN = re.compile(r"^[\w.-]+/[\w.-]+@[0-9a-f]{40}$")
 
 
 def _doc() -> dict[str, Any]:
@@ -84,14 +84,37 @@ def _scanner_version() -> str:
     return str(_scan_step().get("with", {}).get("version", "")).strip()
 
 
-def _action_version() -> str:
-    """The wrapper release, read from the comment beside the ``uses:`` SHA."""
-    match = ACTION_PIN.search(WORKFLOW.read_text(encoding="utf-8"))
-    assert match is not None, (
-        "the trufflehog step must pin the action by full SHA with the release "
-        "in a trailing comment, as Renovate writes it"
+def _release_comment(text: str, uses: str) -> str:
+    """The release Renovate records beside this exact ``uses:`` pin.
+
+    A SHA is opaque, so the trailing comment is the only readable statement
+    of which release runs - which makes it worth reading carefully. The
+    pattern is anchored to the pin passed in and to the start of its line,
+    so a commented-out predecessor or a second copy of the action cannot
+    answer on behalf of the step that actually runs. Two matches are an
+    error rather than a coin toss: it means the file disagrees with itself.
+    """
+    pattern = re.compile(
+        rf"^[ \t]*uses:[ \t]*{re.escape(uses)}[ \t]*#[ \t]*v?(?P<version>\d+\.\d+\.\d+)[ \t]*$",
+        re.MULTILINE,
     )
-    return match.group("version")
+    found = pattern.findall(text)
+    assert len(found) == 1, (
+        f"expected exactly one `uses: {uses}` line carrying a release comment, "
+        f"found {len(found)}. Renovate writes the release beside the SHA it "
+        "pins; without it there is no readable record of which scanner runs"
+    )
+    return str(found[0])
+
+
+def _action_version() -> str:
+    """The wrapper release, read from the step the workflow actually runs."""
+    uses = str(_scan_step().get("uses", ""))
+    assert SHA_PIN.match(uses), (
+        f"`uses: {uses}` must pin the action to a full 40-character commit "
+        "SHA. A tag or branch is rewritable, so it pins nothing"
+    )
+    return _release_comment(WORKFLOW.read_text(encoding="utf-8"), uses)
 
 
 def _excluded_detectors() -> frozenset[str]:
@@ -155,6 +178,36 @@ def test_the_scanner_binary_and_the_action_wrapper_are_the_same_release() -> Non
         "a single pull request, so a mismatch means half a bump landed - "
         "reconcile them rather than pinning the test to the drift"
     )
+
+
+def _workflow_text(*pin_lines: str) -> str:
+    """A workflow fragment carrying the given ``uses:`` lines verbatim."""
+    body = "\n".join(f"      - name: Run trufflehog\n        {line}" for line in pin_lines)
+    return f"jobs:\n  trufflehog:\n    steps:\n{body}\n"
+
+
+def test_a_commented_out_pin_cannot_answer_for_the_live_one() -> None:
+    """The release must come from the pin that runs, not the first in the file."""
+    text = _workflow_text(
+        f"# uses: trufflesecurity/trufflehog@{'a' * 40}  # v3.90.0",
+        f"uses: trufflesecurity/trufflehog@{'b' * 40}  # v3.96.0",
+    )
+    assert _release_comment(text, f"trufflesecurity/trufflehog@{'b' * 40}") == "3.96.0"
+
+
+def test_a_pin_with_no_release_comment_beside_it_is_rejected() -> None:
+    """Silence is not agreement - an absent comment must not read as a match."""
+    uses = f"trufflesecurity/trufflehog@{'b' * 40}"
+    with pytest.raises(AssertionError):
+        _release_comment(_workflow_text(f"uses: {uses}"), uses)
+
+
+def test_two_pins_of_one_action_are_rejected_rather_than_silently_halved() -> None:
+    """Picking either of two answers hides that the file disagrees with itself."""
+    uses = f"trufflesecurity/trufflehog@{'b' * 40}"
+    text = _workflow_text(f"uses: {uses}  # v3.96.0", f"uses: {uses}  # v3.90.0")
+    with pytest.raises(AssertionError):
+        _release_comment(text, uses)
 
 
 def test_the_scan_still_runs_on_main_and_pull_requests() -> None:

--- a/tests/unit/test_trufflehog_workflow_yaml.py
+++ b/tests/unit/test_trufflehog_workflow_yaml.py
@@ -51,8 +51,18 @@ ALLOWED_EXCLUDED_DETECTORS = frozenset({"lob"})
 #: leading ``v``; ``latest`` and floating prefixes are what this rejects.
 EXACT_RELEASE = re.compile(r"^\d+\.\d+\.\d+$")
 
-#: A full-SHA action pin, the only form this repository allows.
-SHA_PIN = re.compile(r"^[\w.-]+/[\w.-]+@[0-9a-f]{40}$")
+#: The only action this gate may run.
+#:
+#: The step is *discovered* by looking for ``trufflehog`` anywhere in a
+#: ``uses:`` value, which is deliberately generous so that a swapped action
+#: is still found rather than quietly skipped. Identity is then checked
+#: exactly: every other assertion in this file reads the selected step's
+#: inputs, so a fork or a similarly named action would satisfy all of them
+#: while executing somebody else's code.
+SCANNER_ACTION = "trufflesecurity/trufflehog"
+
+#: That action pinned to a full lowercase commit SHA, as Renovate writes it.
+ACTION_PIN = re.compile(rf"^{re.escape(SCANNER_ACTION)}@[0-9a-f]{{40}}\Z")
 
 
 def _doc() -> dict[str, Any]:
@@ -107,14 +117,22 @@ def _release_comment(text: str, uses: str) -> str:
     return str(found[0])
 
 
+def _action_uses() -> str:
+    """The selected step's ``uses:``, checked to be the upstream scanner."""
+    uses = str(_scan_step().get("uses", ""))
+    assert ACTION_PIN.match(uses), (
+        f"`uses: {uses}` must be `{SCANNER_ACTION}@` followed by a full "
+        "40-character lowercase commit SHA. The step is found by matching "
+        "`trufflehog` anywhere in the value, so a fork or a similarly named "
+        "action would pass every other assertion in this file while running "
+        "different code; a tag or branch is rewritable and pins nothing"
+    )
+    return uses
+
+
 def _action_version() -> str:
     """The wrapper release, read from the step the workflow actually runs."""
-    uses = str(_scan_step().get("uses", ""))
-    assert SHA_PIN.match(uses), (
-        f"`uses: {uses}` must pin the action to a full 40-character commit "
-        "SHA. A tag or branch is rewritable, so it pins nothing"
-    )
-    return _release_comment(WORKFLOW.read_text(encoding="utf-8"), uses)
+    return _release_comment(WORKFLOW.read_text(encoding="utf-8"), _action_uses())
 
 
 def _excluded_detectors() -> frozenset[str]:
@@ -184,6 +202,31 @@ def _workflow_text(*pin_lines: str) -> str:
     """A workflow fragment carrying the given ``uses:`` lines verbatim."""
     body = "\n".join(f"      - name: Run trufflehog\n        {line}" for line in pin_lines)
     return f"jobs:\n  trufflehog:\n    steps:\n{body}\n"
+
+
+@pytest.mark.parametrize(
+    "uses",
+    [
+        pytest.param(f"attacker/trufflehog-wrapper@{'a' * 40}", id="unrelated-owner"),
+        pytest.param(f"trufflesecurity/trufflehog-fork@{'a' * 40}", id="suffixed-repo"),
+        pytest.param(f"nottrufflesecurity/trufflehog@{'a' * 40}", id="prefixed-owner"),
+        pytest.param(f"trufflesecurity/trufflehog@{'A' * 40}", id="uppercase-sha"),
+        pytest.param("trufflesecurity/trufflehog@v3", id="tag-not-sha"),
+        pytest.param(f"trufflesecurity/trufflehog@{'a' * 39}", id="truncated-sha"),
+    ],
+)
+def test_an_action_that_merely_resembles_the_scanner_is_refused(uses: str) -> None:
+    """Discovery matches a substring; identity must not be so generous."""
+    assert not ACTION_PIN.match(uses), (
+        f"`{uses}` would be accepted as the scanner. Every other assertion "
+        "in this file reads the selected step's inputs, so a look-alike "
+        "passes them all while running different code"
+    )
+
+
+def test_the_workflow_runs_the_upstream_scanner_action() -> None:
+    """The positive half: the step really is the action it is taken to be."""
+    assert _action_uses().startswith(f"{SCANNER_ACTION}@")
 
 
 def test_a_commented_out_pin_cannot_answer_for_the_live_one() -> None:


### PR DESCRIPTION
# User description
## What

Pins the trufflehog **scanner** version in `.github/workflows/trufflehog.yml`, adds the Renovate wiring to keep that pin current, and adds two tests so it cannot silently revert.

## Why

The `uses:` SHA looks like a full pin, but it is not. That action is a shell wrapper; it runs:

```
docker run --rm -v .:/tmp -w /tmp "${IMAGE}:${VERSION}"
```

`version` is an input that **defaults to `latest`**, and the workflow never set it. So the action was pinned and the scanner was not — every run pulled whatever `ghcr.io/trufflesecurity/trufflehog:latest` resolved to at the time.

The consequence is the failure mode #3488 already dealt with once. A detector added or changed upstream lands on whichever pull request happens to be open when it ships, with no change on this side, and reads as that author's fault. #3488 excluded `lob` because its verifier returns a positive for any `test_` + exactly 35 characters, a shape ordinary Python test names hit by accident. That fixed the detector we had been bitten by; it left the delivery mechanism unpinned, so the next one arrives the same way.

## How

**Pin the scanner.** `version: 3.96.0`, matching the wrapper release already pinned on the `uses:` line. The image is tagged without a leading `v` — checked against the registry rather than assumed:

| Tag | Manifest |
|---|---|
| `3.96.0` | `200` |
| `v3.96.0` | **`404`** |
| `latest` | `200` |

**Keep the pin from going stale.** A pinned scanner that nobody bumps is a scanner that stops finding new classes of secret, which is the opposite of the point. Renovate's `github-actions` manager only reads `uses:` lines, so it would never see this input. Added:

- a `customManagers` entry that tracks the image tag via a `# renovate:` marker comment;
- a `trufflehog` group so the wrapper and the scanner bump in **one** pull request.

The grouping is what makes the consistency test below safe. Without it, two separate bot branches would each carry half a bump and each fail that check.

**Pin the decision.** Two tests added to `tests/unit/test_trufflehog_workflow_yaml.py`, alongside the four from #3488.

## Verification

Tests written first, and confirmed failing for the right reason (`version` absent, not a typo) before the workflow was touched.

Each pin was then mutation-tested, with the tree restored after each:

| Mutation | Result |
|---|---|
| `version: latest` | `..._pinned_to_an_exact_release` **fails** |
| `version: 3.95.0` (scanner drifts from wrapper) | `..._same_release` **fails** |
| `--exclude-detectors=lob,aws` (exclusion widened) | `..._without_a_recorded_reason` **fails** |
| as committed | **6 passed** |

The Renovate regex was validated against the workflow in the same JS engine Renovate uses, not just by eye — one match, extracting `datasource=docker`, `depName=ghcr.io/trufflesecurity/trufflehog`, `currentValue=3.96.0`.

Other checks:

- `uv run ruff check src/` — clean; `ruff format` applied to the changed test file.
- `tests/unit/test_trufflehog_workflow_yaml.py` + the two neighbouring workflow-shape suites — **153 passed**.
- `scripts/gen_workflow_topology.py` re-run — **no diff**, so `docs/operations/ci-topology.md` is not stale (the change is a step input, not a job, trigger, or permission).
- Affected-test selector returns 65 files including this one, so the fail-closed `.github/workflows/` rule in `scripts/run_tests.py` is satisfied.

## Notes for a reviewer

Two things found while working, neither blocking:

- `test_gate_reports_verified_results_only` is 34 characters after `test_` — one character from the trap. Harmless while `lob` stays excluded, which the existing test enforces.
- The workflow file itself now contains two strings that match the Lob pattern, because the #3488 comment quotes both offending names verbatim. The file explaining the false positive would trip the scanner if the exclusion were removed. That is fine, and arguably useful, but it is worth knowing that the exclusion is load-bearing for the workflow's own comments.

## Checklist

- [x] `uv run ruff check src/` passes
- [ ] `uv run pyright src/` passes — **N/A**. No `src/` file is touched by this PR. pyright reports ~22k pre-existing findings on `src/` at this commit (the project type-checks with `uv run mypy src`), so this PR neither improves nor regresses it.
- [x] Tests pass — the affected suites were run rather than the full 2000+ file suite; see Verification for exactly what was executed.
- [x] New code has type hints

### Documentation duty

- [x] User-visible README section updated — **N/A**, internal CI configuration only.
- [x] `docs/operations/<area>.md` updated — **N/A**, and verified: the generator re-runs with no diff.
- [x] `docs/api/` schema regenerated — **N/A**, no public surface change.
- [x] `bernstein agents-md sync` — **N/A**, no new module.
- [x] Tests cover the documented behaviour — the workflow comment and the test module docstring both state the rule the tests enforce.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Pin the TruffleHog scanner image to an exact release alongside its wrapper action, and configure Renovate to update both together. Add workflow tests that enforce reproducible scanner versions, matching wrapper releases, and the intended action identity.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3535?tool=ast&topic=Workflow+safeguards>Workflow safeguards</a>
        </td><td>Enforce the scanner pin, release consistency, upstream action identity, and unambiguous release comments with structural workflow tests.<details><summary>Modified files (1)</summary><ul><li>tests/unit/test_trufflehog_workflow_yaml.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>test: check which acti...</td><td>August 10, 2026</td></tr>
<tr><td>chernistry</td><td>ci: stop the secret-sc...</td><td>August 08, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3535?tool=ast&topic=Scanner+version+pinning>Scanner version pinning</a>
        </td><td>Pin the TruffleHog scanner and keep its image version synchronized with the wrapper action through Renovate grouping and a custom Docker manager.<details><summary>Modified files (2)</summary><ul><li>.github/workflows/trufflehog.yml</li>
<li>renovate.json</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>ci: pin the trufflehog...</td><td>August 10, 2026</td></tr>
<tr><td>chernistry</td><td>ci: stop the secret-sc...</td><td>August 08, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3535?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>