### PR TITLE
docs(cli): reconcile the CLI reference flag tables with the registered commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,6 +434,14 @@ jobs:
         # drift much later inside a long test shard. Run
         # `uv run python scripts/gen_distribution_manifests.py` locally to fix.
         run: uv run python scripts/gen_distribution_manifests.py --check
+      - name: CLI reference flag-table drift check (#3465)
+        # Fails if docs/reference/cli-reference.md documents a flag a command
+        # rejects (that invocation exits 2 with "No such option" before the
+        # command body runs), or if a command accepts a flag its flag table
+        # does not list. Runs here as well as in the test shards so a
+        # docs-only change cannot land the drift past an affected-tests PR
+        # lane.
+        run: uv run pytest tests/unit/test_cli_command_registration.py -q --no-cov --timeout=120
       - name: Operator-surface render freshness (#3427)
         # The published renders of `bernstein live` and `bernstein gui serve`
         # are generated artefacts, so they get the same treatment as the rest

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -428,12 +428,15 @@ Group: verifies integrity and reproducibility artefacts. It does not run lint / 
 
 | Subcommand | Purpose |
 |---|---|
-| `start` | Start the autofix daemon (watches PRs, repairs CI failures). |
-| `stop` | Stop the daemon. |
-| `status` | Show daemon status + recent activity. |
-| `run PR` | Single-shot autofix on a specific PR. |
+| `start` | Start the autofix daemon (watches PRs, repairs CI failures). `--repo`, `--config`, `--foreground`, `--once`. |
+| `stop` | Stop the daemon. `--timeout`. |
+| `status` | Show daemon status + recent activity. `--watch`, `--json`, `--limit`. |
+| `attach` | Attach to the running daemon's activity feed. `--limit`. |
+| `ladder` | Single-shot escalation-ladder run against one failing PR. `--pr`, `--repo`, `--dry-run`. |
+| `review` | Respond to review findings on a PR. `--pr`, `--repo`, `--poll-seconds`, `--once`. |
+| `review-register` / `review-resolve` | Register / resolve review-finding state. |
 
-`bernstein autofix start` flags include `--workdir`, `--server URL`, `--poll SEC`, `--max-attempts N`, `--token`. See `cli/commands/autofix_cmd.py:172-200` for full list.
+See `cli/commands/autofix_cmd.py:172+` for the full flag list.
 
 #### `bernstein ci`
 
@@ -600,7 +603,7 @@ its merged branch, or the merge commit.
 
 | Subcommand | Purpose |
 |---|---|
-| `list` | Available agents and capabilities (`--show-all` includes unregistered). |
+| `list` | Available agents and capabilities (`--source`, `--identities`). |
 | `sync` | Pull the latest agent catalog. |
 | `validate` | Validate the local catalog. |
 | `showcase` | Print example invocations for each agent. |
@@ -727,7 +730,7 @@ digest. (`cli/commands/skill_cmd.py`.)
 | `list` | List available templates. |
 | `show TEMPLATE [OUTPUT]` | Print template content (or write to OUTPUT). |
 | `use TEMPLATE [OUTPUT]` | Copy TEMPLATE to OUTPUT (default `plans/<name>.yaml`). |
-| `compress ROLE\|--all` | Operator-gated LLM compression of role prompt templates (`cli/commands/templates_cmd.py`). Rewrite via the configured adapter (`--model`, `--provider`), then mechanical validators (fenced blocks, headings, URLs, inline code, placeholders, completion-contract block; at most two targeted fix retries), then apply. Originals are stored under `~/.local/share/bernstein/template-backups/` keyed by content hash with readback verification; the receipt `{role, pre_sha256, post_sha256, pre_tokens, post_tokens, validators, adapter, model}` is chained to the audit log and a `templates.lock` row lets `bernstein team drift` classify the change as intentional. Prints only the template token delta; per-spawn savings come from `bernstein cost --by role`. `--workdir DIR`, `--yes` skips the confirmation. |
+| `compress ROLE\|--all` | Operator-gated LLM compression of role prompt templates (`cli/commands/templates_cmd.py`). Rewrite via the configured adapter (`--model`, `--provider`), then mechanical validators (fenced blocks, headings, URLs, inline code, placeholders, completion-contract block; at most two targeted fix retries), then apply. Originals are stored under `~/.local/share/bernstein/template-backups/` keyed by content hash with readback verification; the receipt `{role, pre_sha256, post_sha256, pre_tokens, post_tokens, validators, adapter, model}` is chained to the audit log and a `templates.lock` row lets `bernstein team drift` classify the change as intentional. Prints only the template token delta; per-spawn savings come from `bernstein cost` grouped by role. `--workdir DIR`, `--yes` skips the confirmation. |
 | `restore ROLE` | Reverse the most recent receipted compression byte-identically (backup hash, on-disk hash, and directory digest all verified). `--workdir DIR`. |
 | `hooks list` / `hooks use` | Browse and scaffold bundled command-hook templates. |
 
@@ -755,8 +758,7 @@ digest. (`cli/commands/skill_cmd.py`.)
 | `status [RUN_ID]` | Status of a cloud run. |
 | `runs` | Recent cloud runs. `--limit N`, `--json`. |
 | `cost` | Cloud usage and spend. |
-| `init` | Generate `wrangler.toml`. `--worker-name`, `-o FILE`. |
-| `deploy` | Deploy the Worker. `--worker-name`. |
+| `init` | Generate `wrangler.toml` and the worker entry point. `--worker-name`, `-o FILE`. Deploy afterwards with `npx wrangler deploy`. |
 
 (`cli/commands/cloud_cmd.py:35+`.)
 
@@ -781,7 +783,7 @@ digest. (`cli/commands/skill_cmd.py`.)
 
 | Subcommand | Purpose |
 |---|---|
-| `run HOST` | Invoke `bernstein run PATH` against HOST over SSH. `--user`, `--port`, `--key-file`. |
+| `run HOST` | Invoke `bernstein run PATH` against HOST over SSH. `--user`, `--port`, `--identity-file`, `--remote-path`. |
 | `test HOST` | Check that HOST is reachable and time the round trip. |
 | `forget HOST` | Remove any cached ControlMaster sockets for HOST. |
 
@@ -1165,8 +1167,8 @@ not accept these flags.
 | Subcommand | Purpose |
 |---|---|
 | `check-update` | Verify the signed release feed offline and seal a chain-anchored advisory. |
-| `update` | Install the verified candidate; refuses mid-run, verifies the wheel hash first. |
-| `pin VERSION` / `unpin` | Signed version pin the updater will not cross without `--override-pin`. |
+| `update` | Install the verified candidate; refuses mid-run, verifies the wheel hash first. `--override-pin` crosses a signed pin. |
+| `pin VERSION` / `unpin` | Signed version pin the updater will not cross unless explicitly overridden. |
 | `rollback` | Return to the previous receipted version. |
 
 See [Updates: check, verify, apply](../operations/updates.md).
@@ -1240,7 +1242,7 @@ For worktree lifecycle (inspection / reaping) use `bernstein worktrees list` / `
 | `list` | List cached task-result entries. `--workdir`, `--limit`, `--json`. |
 | `inspect TASK_ID` | Inspect the cached result produced by a specific task. `--workdir`, `--json`. |
 | `action` | Inspect / replay the action-level LLM cache. |
-| `clear` | Clear response-cache entries. `--workdir`, `--scope`, `--yes`. |
+| `clear` | Clear response-cache entries. `--workdir`, `--unverified`, `--yes`. |
 
 (`cli/commands/cache_cmd.py:45-146`.)
 
@@ -1276,7 +1278,7 @@ systemd / launchd unit installer.
 
 | Subcommand | Purpose |
 |---|---|
-| `install` | Install the unit. `--user` / `--system`, `--workdir`. |
+| `install` | Install the unit. `--user` / `--system`, `--command`, `--env`, `--force`. |
 | `uninstall` | Remove the unit. |
 | `status` | Show daemon status. |
 | `start` / `stop` / `restart` | Control daemon lifecycle. |
@@ -1319,7 +1321,7 @@ The root MCP command - runs Bernstein as an MCP server itself.
 | `--port N` | 8053 | HTTP port (when `--transport http`). |
 | `--host HOST` | 127.0.0.1 | Bind host. |
 | `--server-url URL` | `http://localhost:8052` | Upstream Bernstein server. |
-| `--mcp-tier NAME` | `standard` | Tool tier to advertise (context-budget knob); overrides `BERNSTEIN_MCP_TOOL_TIER`. |
+| `--mcp-tier {core\|standard\|all}` | unset | Tool tier to advertise (context-budget knob); overrides `BERNSTEIN_MCP_TOOL_TIER`, and the effective default is `standard`. |
 
 #### `bernstein mcp catalog`
 
@@ -1329,7 +1331,7 @@ See [`reference/mcp-catalog.md`](mcp-catalog.md) for the full reference.
 
 | Subcommand | Purpose |
 |---|---|
-| `serve` | Run the chat bridge for PLATFORM until Ctrl-C. `--driver {telegram\|slack\|discord}`, `--token`, `--target`. |
+| `serve` | Run the chat bridge until Ctrl-C. `--platform {telegram\|discord\|slack\|teams}`, `--token`, `--allow`. |
 | `status` | Print active chat<->session bindings. |
 | `logout` | Drop cached bindings for PLATFORM. |
 
@@ -1359,18 +1361,17 @@ See [`reference/mcp-catalog.md`](mcp-catalog.md) for the full reference.
 
 | Subcommand | Purpose |
 |---|---|
-| `start` | Start the review-responder daemon. `--workdir`, `--server`, `--poll`. |
-| `stop` | Stop the daemon. |
-| `status` | Show daemon status. |
-| `run PR` | Single-shot review-respond on one PR. |
+| `start` | Start the review-responder daemon. `--repo`, `--tunnel`, `--port`, `--quiet-window`, `--cost-cap`, `--foreground`. |
+| `status` | Show daemon status. `--pr`. |
+| `tick` | Single-shot poll-and-respond cycle. `--repo`, `--pr`. |
 
 #### `bernstein preview`
 
 | Subcommand | Purpose |
 |---|---|
-| `start` | Start a preview server in the current task's worktree. `--port`, `--command`, `--public`, `--name`, `--ttl`. |
+| `start` | Start a preview server in the current task's worktree. `--cwd`, `--command`, `--provider`, `--auth`, `--expire`, `--no-clipboard`. |
 | `list` | List active previews. `--json`. |
-| `show ID` | Show a preview's URL and process. `--json`. |
+| `status ID` | Show a preview's URL and process. `--json`. |
 | `stop [ID]` | Stop one preview. `--all` stops every active preview. |
 
 (`cli/commands/preview_cmd.py:46-220`.)

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -96,7 +96,7 @@ Execute a plan file (or start orchestration with no plan).
 
 **Synopsis:** `bernstein run [PLAN_FILE] [flags]`
 
-The full flag list is large (28 flags inherited from the root group and re-exposed; see `cli/run_bootstrap.py:533+`). Most commonly used:
+The full flag list is large (see `bernstein run --help` and `cli/run_bootstrap.py:533+`). Most commonly used:
 
 | Flag | Default | Meaning |
 |---|---|---|
@@ -105,14 +105,16 @@ The full flag list is large (28 flags inherited from the root group and re-expos
 | `--max-cost-usd N` | unset | Hard cap on cumulative routed model spend; aborts the run when crossed. Sets `BERNSTEIN_MAX_COST_USD`. |
 | `--cli` | auto | Force agent: any registered adapter name (see `bernstein adapters list`) or `auto`. |
 | `--model` | none | Force a specific model. |
-| `--approval {auto\|review\|pr}` | auto | Approval gate. |
-| `--merge {pr\|direct}` | pr | Merge strategy. |
+| `--auto-approve` | off | Skip the interactive plan-approval gate. |
 | `--dry-run` | off | Preview without spawning. |
 | `--plan-only` | off | Show plan, do not run agents. |
 | `--auto-pr` | off | Auto-open a GitHub PR on completion. |
 | `--task PATTERN` | none | Run only matching backlog tasks. |
 | `--port N` | 8052 | Task server port. |
 | `-v / -q` | off | Verbosity. |
+
+The merge strategy is not a `run` flag: set `merge_strategy: pr|direct` in
+`bernstein.yaml` (default `pr`).
 
 `--max-cost-usd` is a hard cap, separate from the soft `--budget`
 threshold model. It writes the value to `BERNSTEIN_MAX_COST_USD`
@@ -139,6 +141,7 @@ Graceful or force stop.
 | Flag | Default | Meaning |
 |---|---|---|
 | `--force` / `--hard` | off | Hard stop: kill processes immediately. |
+| `--timeout SEC` | 30 | Seconds to wait for agents on a soft stop. |
 
 `bernstein stop` (no flag) sends `SIGTERM` to the orchestrator and waits for agents to finish their current step and persist artefacts. `bernstein stop --force` terminates everything immediately and runs orphan-recovery on the next start.
 
@@ -174,9 +177,12 @@ End a session with a summary, retrospective, and learning capture. Hides under n
 
 | Flag | Default | Meaning |
 |---|---|---|
-| `--here` | off | Initialize in the current directory (no subdir created). |
-| `--name TEXT` | dirname | Project name. |
-| `--force` | off | Overwrite existing `bernstein.yaml`. |
+| `--dir PATH` | `.` | Directory to initialise. |
+| `--wizard` / `-w` | off | Run the interactive setup wizard. |
+| `--non-interactive` | off | With `--wizard`: take the wizard's defaults without prompting. Plain `init` never prompts. |
+| `--remote` | off | Initialise for a remote container quickstart (e.g. Codespaces); skips local-binary checks. |
+| `--add-badge` | off | Insert a shields.io "powered by bernstein" badge into `README.md`. |
+| `--badge-variant NAME` | `signed` | Badge wording when `--add-badge` is passed. |
 
 `init-wizard` adds an interactive prompt flow (project type, default agent, budget, etc.) and is preferred for first-time users.
 
@@ -219,9 +225,15 @@ The graph view shows the critical path in bold yellow with a star (`★`) and li
 
 | Flag | Default | Meaning |
 |---|---|---|
-| `GOAL` | required | Goal description (positional). |
-| `--out FILE` | `plan.yaml` | Output path. |
-| `--model NAME` | auto | Model used to draft the plan. |
+| `DESCRIPTION` | required | Goal description (positional). |
+| `--output FILE` / `-o` | `plans/<slug>.yaml` | Output path for the YAML plan. |
+| `--model NAME` | `anthropic/claude-haiku-4-5` | Model used to draft the plan. |
+| `--provider NAME` | `openrouter` | LLM provider (`openrouter`, `openai`, ...). |
+| `--workdir PATH` | `.` | Project root directory to analyse. |
+| `--dry-run` | off | Print the generated plan without saving to disk. |
+| `--enforce-vertical / --no-enforce-vertical` | on | Enforce vertical-slice shape checks on the generated plan. |
+| `--max-loc N` | config | Hard LOC cap per slice; overrides `bernstein.yaml [plan].max_loc`. |
+| `--max-files N` | config | Max files per slice; overrides `bernstein.yaml [plan].max_files`. |
 
 #### `bernstein plan compile`
 
@@ -283,7 +295,8 @@ Compact one-screen project view.
 | Flag | Default | Meaning |
 |---|---|---|
 | `--json` | off | Emit JSON. |
-| `--workdir` | `.` | Project root. |
+| `--mode {novice\|standard\|expert}` | persisted or `standard` | Dashboard detail level. |
+| `--no-color` | off | Disable colour output. |
 
 #### `bernstein live`
 
@@ -335,7 +348,7 @@ it still answers what happened after the run and its server have exited.
 | Flag | Default | Meaning |
 |---|---|---|
 | `--since HOURS` | all | Hours back to include. |
-| `-o, --output FILE` | `.sdd/runtime/retrospective.md` | Output path. |
+| `--output FILE` / `-o` | `.sdd/runtime/retrospective.md` | Output path. |
 | `--print` | off | Also print to stdout. |
 | `--archive PATH` | `.sdd/archive/tasks.jsonl` | Source archive. |
 
@@ -343,17 +356,25 @@ it still answers what happened after the run and its server have exited.
 
 | Flag | Default | Meaning |
 |---|---|---|
-| `--workdir` | `.` | Project root. |
-| `--filter PATTERN` | none | Show only events matching PATTERN. |
-| `--task TASK_ID` | none | Watch only a specific task. |
+| `DIRECTORY` | `.` | Directory to watch (positional). |
+| `--glob PATTERN` | none | Restrict watching to files matching PATTERN (e.g. `src/**/*.py`). |
 
 #### `bernstein trace`
 
+Group: inspect, serve, and verify local agent traces.
+
 | Flag | Default | Meaning |
 |---|---|---|
-| `TASK_ID` | required | Task to trace. |
-| `--as-json` | off | Emit raw JSON. |
 | `--traces-dir DIR` | `.sdd/traces` | Directory containing trace files. |
+
+| Subcommand | Purpose |
+|---|---|
+| `show TASK_ID` | Step-by-step execution trace for a task; `--as-json` emits raw JSON. |
+| `verify TRACE_ID` | Confirm the on-disk bytes match the indexed sha256. |
+| `reindex` | Rebuild `.sdd/traces/index.jsonl` from the on-disk blob tree. |
+| `serve` | Read-only FastAPI viewer over the local content-addressed store (`--port`, `--bind`). |
+| `project RUN_ID` | Project the run's event journal into a signed OTel span set. |
+| `verify-projection RUN_ID` | Recompute span ids from the journal and verify the signature. |
 
 Subcommands `project RUN_ID` and `verify-projection RUN_ID` emit and verify a
 signed OTel GenAI span set projected from the run event journal. Span ids are
@@ -370,7 +391,9 @@ set. (`cli/commands/advanced_cmd.py`, `core/observability/otel_projection.py`.)
 |---|---|---|
 | `--workdir` | `.` | Project root. |
 | `--json` | off | Emit raw JSON. |
-| `--reset` | off | Reset SLO budget (server endpoint requires auth). |
+| `--watch` | off | Refresh every `--interval` seconds until interrupted. |
+| `--interval SEC` | 30 | Refresh interval in `--watch` mode. |
+| `--compact` | off | Compact output without sparkline. |
 
 ---
 
@@ -392,17 +415,14 @@ set. (`cli/commands/advanced_cmd.py`, `core/observability/otel_projection.py`.)
 
 #### `bernstein verify`
 
-Verifies integrity and reproducibility artefacts. It does not run lint / test / type-check quality gates; use `bernstein test` and the project's configured quality gates for that.
+Group: verifies integrity and reproducibility artefacts. It does not run lint / test / type-check quality gates; use `bernstein test` and the project's configured quality gates for that.
 
-| Flag | Default | Meaning |
-|---|---|---|
-| `WHEELHOUSE_PATH` | none | Positional: verify air-gap wheelhouse signatures. |
-| `--wal-integrity RUN_ID` | none | Validate a run's WAL hash chain. |
-| `--determinism RUN_ID` | none | Compute and show a run's execution fingerprint. |
-| `--expect FINGERPRINT` | none | Gate `--determinism`: exit non-zero unless the fingerprint matches. |
-| `--baseline RUN_ID` | none | Gate `--determinism`: exit non-zero unless the run reproduces this baseline. |
-| `--memory-audit` | off | Audit lesson-memory provenance chain. |
-| `--formal TASK_ID` | none | Run Z3 / Lean4 formal property checks for a completed task. |
+| Subcommand | Purpose |
+|---|---|
+| `run RUN_ID` | Build the signed run receipt for a run (`--workdir`, `--output`, signing-key options). |
+| `receipt RECEIPT_PATH` | Verify a run receipt offline (`--public-key`). |
+| `ladder RECEIPT_HASH` | Re-derive and verify a verifier-ladder receipt (`--workdir`). |
+| `legacy [WHEELHOUSE_PATH]` | The pre-receipt checks: `--wal-integrity RUN_ID`, `--determinism RUN_ID` (gated by `--expect` / `--baseline`), `--memory-audit`, `--formal TASK_ID`, or a positional wheelhouse path for air-gap signature verification. |
 
 #### `bernstein autofix`
 
@@ -435,34 +455,21 @@ Common flags: `--token` (env: `GITHUB_TOKEN`), `--server`, `--interval`. (`cli/c
 
 `agent-kill` accepts `--agent-id`, `file-remove` accepts `--pattern`, and `status` accepts `--limit`. (`cli/commands/chaos_cmd.py:33+`.)
 
-#### `bernstein eval` / `bernstein benchmark`
+#### `bernstein eval`
 
-`bernstein benchmark` is a deprecated alias for `bernstein eval` and prints a warning on stderr before running; it keeps every subcommand it carried and is removed in v4.0.0. Every subcommand name is reachable under `eval` before the removal:
+Group: evaluation pipelines. The subcommands carry the flags; the group itself
+only accepts the reliability options listed below.
 
-| Deprecated | Canonical | Notes |
-| --- | --- | --- |
-| `benchmark run` | `eval run` | **Different command.** `eval run` drives the golden harness or a YAML eval spec (`--spec`, `--output`, `--compare`, tiers `smoke/standard/stretch/adversarial`); `benchmark run` drives the evolution benchmark tree (`--benchmarks-dir`, tiers `smoke/capability/stretch`). `--benchmarks-dir` has **no `eval` equivalent**. |
-| `benchmark swe-bench` | `eval swe-bench` | Same runner and same options; `benchmark swe-bench --lite` is itself a deprecated alias, so migrate it to `eval swe-bench --subset lite`. |
-| `benchmark programbench` | `eval programbench` | Same command object. |
-| `benchmark compare` | `eval compare` | Same command object. |
-| `benchmark simulate` | `eval simulate` | Same command object. |
-| `benchmark receipt emit/verify` | `eval receipt emit/verify` | Same command object. |
-
-One capability does not survive the rename: `bernstein benchmark run --benchmarks-dir DIR` runs the evolution benchmark tree and `eval run` cannot. Until that option is ported onto an `eval` command, `bernstein benchmark run` is the only spelling for it, and v4.0.0 should not unregister the alias without porting it first. `tests/unit/test_fold_benchmark_subcommands.py` declares the list of alias-only options and fails if it widens or if a declared replacement stops being accepted, so this note cannot silently go stale.
-
-`eval simulate` is **not** the top-level `bernstein simulate`. The top-level command is a digital-twin simulation of a plan against historical traces (`--plan`, `--from-traces`, `--traces-dir`); `eval simulate` replays the standard benchmark task set for throughput, cost and quality (`--tasks-dir`, `--task-id`, `--baseline`). They share a verb and no options, and the top-level command is unaffected by this change. `bernstein bench` is a separate command and is not folded in.
-
-The two groups share most flags:
-
-| Flag | Default | Meaning |
-|---|---|---|
-| `--subset NAME` | full | Dataset subset (`lite`, `full`, etc.). |
-| `--sample N` | none | Random sample of N instances. |
-| `--instance ID` | none | Single instance by ID. |
-| `--dataset PATH` | none | Local JSONL dataset file. |
-| `--workdir DIR` | `.` | Project root. |
-| `--save / --no-save` | save | Persist results to disk. |
-| `--compare` | off | Compare against the previous run. |
+| Subcommand | Purpose |
+|---|---|
+| `run SPEC` | Drive the golden harness or a YAML eval spec (`--tier`, `--compare`, `--save/--no-save`, `--output`). |
+| `swe-bench` | SWE-bench runner (`--subset`, `--sample`, `--instance`, `--dataset`, `--save/--no-save`). |
+| `programbench` | ProgramBench runner (`--adapter`, `--subset`, `--tasks`, `--task`, `--dataset`, `--out`). |
+| `simulate` | Replay the standard benchmark task set (`--tasks-dir`, `--seed`, `--task-id`, `--baseline`). |
+| `compare` | Compare eval runs (`--tasks-dir`, `--mode`). |
+| `golden` | Run the curated golden suite (`--workdir`). |
+| `gate` / `gate-verify` | Statistical promotion gate and its receipt verification. |
+| `receipt` | Emit / verify eval receipts. |
 
 `bernstein eval run` is the typical command for SWE-bench-style evaluations; `bernstein eval swe-bench` and `bernstein eval golden` cover the harness and the curated golden suite. See `cli/commands/eval_benchmark_cmd.py:127+` and `:426+`.
 
@@ -477,6 +484,23 @@ The two groups share most flags:
 | `--stub-signer` | off | Stub signer instead of the install identity (testing). |
 
 Verification stays on `bernstein bench reliability-verify` / `bernstein bench reliability-check`. (`cli/commands/eval_benchmark_cmd.py:800+`.)
+
+#### `bernstein benchmark` (deprecated)
+
+`bernstein benchmark` is a deprecated alias for `bernstein eval` and prints a warning on stderr before running; it keeps every subcommand it carried and is removed in v4.0.0. The group itself takes no flags — including the reliability options above, which are `eval`-only. Every subcommand name is reachable under `eval` before the removal:
+
+| Deprecated | Canonical | Notes |
+| --- | --- | --- |
+| `benchmark run` | `eval run` | **Different command.** `eval run` drives the golden harness or a YAML eval spec (positional `SPEC`, `--output`, `--compare`, tiers `smoke/standard/stretch/adversarial`); `benchmark run` drives the evolution benchmark tree (`--benchmarks-dir`, tiers `smoke/capability/stretch`). `--benchmarks-dir` has **no `eval` equivalent**. |
+| `benchmark swe-bench` | `eval swe-bench` | Same runner and same options; `benchmark swe-bench --lite` is itself a deprecated alias, so migrate it to `eval swe-bench --subset lite`. |
+| `benchmark programbench` | `eval programbench` | Same command object. |
+| `benchmark compare` | `eval compare` | Same command object. |
+| `benchmark simulate` | `eval simulate` | Same command object. |
+| `benchmark receipt emit/verify` | `eval receipt emit/verify` | Same command object. |
+
+One capability does not survive the rename: `bernstein benchmark run --benchmarks-dir DIR` runs the evolution benchmark tree and `eval run` cannot. Until that option is ported onto an `eval` command, `bernstein benchmark run` is the only spelling for it, and v4.0.0 should not unregister the alias without porting it first. `tests/unit/test_fold_benchmark_subcommands.py` declares the list of alias-only options and fails if it widens or if a declared replacement stops being accepted, so this note cannot silently go stale.
+
+`eval simulate` is **not** the top-level `bernstein simulate`. The top-level command is a digital-twin simulation of a plan against historical traces (`--plan`, `--from-traces`, `--traces-dir`); `eval simulate` replays the standard benchmark task set for throughput, cost and quality (`--tasks-dir`, `--task-id`, `--baseline`). They share a verb and no options, and the top-level command is unaffected by this change. `bernstein bench` is a separate command and is not folded in.
 
 #### `bernstein impact`
 
@@ -589,34 +613,42 @@ its merged branch, or the merge commit.
 
 | Flag | Default | Meaning |
 |---|---|---|
-| `ADAPTER_NAME` | required | Adapter to test (e.g. `claude`, `codex`). |
-| `--model NAME` | adapter default | Force a specific model. |
-| `--prompt TEXT` | smoke test | Prompt to send. |
-| `--timeout SEC` | 60 | Hard timeout. |
+| `--adapter NAME` | required | Adapter to test (e.g. `gemini`, `codex`). |
+| `--task TEXT` | required | Task for the adapter to execute. |
+| `--model NAME` | adapter default | Model to use for the smoke run. |
+| `--timeout SEC` | 120 | Wait up to N seconds for exit. |
 
 #### `bernstein worker`
 
 | Flag | Default | Meaning |
 |---|---|---|
-| `--server URL` | env `BERNSTEIN_SERVER_URL` | Cluster head node URL. |
-| `--token TOKEN` | env `BERNSTEIN_AUTH_TOKEN` | JWT for cluster auth. |
-| `--name NAME` | hostname | Worker display name. |
-| `--max-agents N` | 4 | Max concurrent agents on this worker. |
-| `--labels K=V` | none | Selector labels (repeatable). |
+| `--server URL` | required | Central Bernstein task server URL (e.g. `http://central:8052`). |
+| `--token TOKEN` | none | Bearer token for cluster auth. |
+| `--name NAME` | hostname | Worker node name. |
+| `--slots N` | 6 | Max concurrent agents on this worker. |
+| `--roles LIST` | `backend,qa,security,frontend` | Comma-separated roles this worker accepts. |
+| `--label K=V` | none | Node labels (repeatable: `--label gpu=true --label region=us-east`). |
+| `--adapter NAME` | auto-detect | CLI agent adapter. |
+| `--model NAME` | adapter default | Default model for tasks that carry no explicit model. |
+| `--poll-interval SEC` | 10 | Seconds between task polling cycles. |
+| `--poll-interval-ms MS` | none | Milliseconds between polling cycles (overrides `--poll-interval`). |
+| `--heartbeat-interval-ms MS` | 15000 | Milliseconds between heartbeats to the central server. |
+| `--pool NAME` | none | Named sandbox pool to enrol into (signs an Ed25519 enrolment receipt). |
+| `--pool-hash HASH` | none | Explicit pool hash to enrol against (overrides `--pool` name resolution). |
 
 See [`operations/cluster-mode.md`](../operations/cluster-mode.md) for the full setup walkthrough.
 
 #### `bernstein evolve`
 
-| Flag | Default | Meaning |
-|---|---|---|
-| `--budget USD` | 0.0 | Cost cap. |
-| `--max-cycles N` | 0 | Max iterations. |
-| `--interval SEC` | 300 | Seconds between cycles. |
-| `--github` | off | Sync proposals as GitHub Issues. |
-| `--yes` | off | Skip the safety confirmation. |
+Group: self-evolution proposals and their review lifecycle.
 
-`bernstein evolve` is hidden behind a confirmation prompt by default - see the safety guard at `cli/main.py:455`.
+| Subcommand | Purpose |
+|---|---|
+| `run` | Run evolution cycles (`--window`, `--max-proposals`, `--cycle`, `--dir`, `--github`, `--github-repo`); reads evolve config from `bernstein.yaml` for flags not set. |
+| `review` | Show upgrade proposals pending human review (`--dir`). |
+| `approve PROPOSAL_ID` | Approve an upgrade proposal (`--reviewer`, `--dir`). |
+| `export OUTPUT` | Export a static evolution report, HTML or Markdown (`--format`, `--dir`). |
+| `status` | Show evolution history (`--dir`). |
 
 ---
 
@@ -1013,6 +1045,11 @@ With no identifier, the oldest pending approval is resolved.
 |---|---|---|
 | `--last {1h\|24h\|7d\|30d}` | whole ledger | Ledger window. |
 | `--ledger PATH` | `.sdd/cost/ledger.jsonl` | Spend ledger to compute from. |
+| `--metrics-dir DIR` | `.sdd/metrics` | Metrics JSONL files for the quality-outcome join. |
+| `--transitions PATH` | `.sdd/cost/profile_transitions.jsonl` | Profile-transition event records. |
+| `--audit-dir DIR` | `.sdd/audit` | Audit chain the report event is appended to. |
+| `--reports-dir DIR` | `.sdd/reports/cost_profiles` | Where the content-addressed report artifact is written. |
+| `--eval-ab-dir DIR` | `.sdd/reports/eval_ab` | Eval A/B artifacts; cross-profile claims link the latest one per pair. |
 | `--json` | off | Emit JSON. |
 
 Emits per-profile tasks / output tokens / USD / mean tokens per task plus
@@ -1090,6 +1127,14 @@ receipt that no longer recomputes fails exactly like a tampered chain entry.
 |---|---|---|
 | `--json` | off | Emit raw JSON. |
 | `--fix` | off | Attempt to auto-fix issues. |
+| `--suggest-docs` | off | Print the top curated documentation gaps and exit. |
+| `--failover-drill` | off | Exercise every declared provider fallback chain; exit non-zero on any broken chain. |
+| `--endpoint URL` | none | Certify an OpenAI-compatible endpoint; see [Endpoint certification](#endpoint-certification-bernstein-doctor---endpoint). |
+| `--endpoint-model NAME` | first `/models` entry | Model id to certify. |
+| `--endpoint-engine NAME` | none | Runtime label recorded in the receipt (e.g. `ollama`, `lmstudio`, `mlx`). |
+| `--endpoint-api-key-env NAME` | none | Name of the env var holding the endpoint's API key (never the key itself). |
+| `--endpoint-timeout SEC` | 60 | Per-probe response budget; exceeding it fails the probe. |
+| `--role NAME` | low-stakes local tier | Role(s) to evaluate against `--endpoint` (repeatable). |
 
 (`cli/commands/advanced_cmd.py:536-550` re-exposes `cli/status_cmd.py:doctor`.)
 
@@ -1242,8 +1287,7 @@ systemd / launchd unit installer.
 
 | Flag | Default | Meaning |
 |---|---|---|
-| `--out DIR` | `./man` | Output directory. |
-| `--section N` | 1 | Manpage section. |
+| `--output-dir DIR` | `docs/man` | Directory to write man page files into. |
 
 #### `bernstein config-path`
 
@@ -1274,7 +1318,8 @@ The root MCP command - runs Bernstein as an MCP server itself.
 | `--transport {stdio\|http}` | stdio | MCP transport. |
 | `--port N` | 8053 | HTTP port (when `--transport http`). |
 | `--host HOST` | 127.0.0.1 | Bind host. |
-| `--server URL` | none | Upstream Bernstein server (default: localhost). |
+| `--server-url URL` | `http://localhost:8052` | Upstream Bernstein server. |
+| `--mcp-tier NAME` | `standard` | Tool tier to advertise (context-budget knob); overrides `BERNSTEIN_MCP_TOOL_TIER`. |
 
 #### `bernstein mcp catalog`
 
@@ -1301,12 +1346,12 @@ See [`reference/mcp-catalog.md`](mcp-catalog.md) for the full reference.
 
 | Flag | Default | Meaning |
 |---|---|---|
-| `--repo OWNER/NAME` | git remote | Target repo. |
-| `--base BRANCH` | main | Base branch. |
-| `--head BRANCH` | current | Head branch. |
-| `--title TEXT` | task summary | PR title. |
-| `--body TEXT` | task description | PR body. |
+| `--session-id ID` | most recent completed session | Session to publish. |
+| `--base BRANCH` | main | Base branch for the pull request. |
+| `--title TEXT` | auto-generated | Override the PR title. |
 | `--draft` | off | Open as a draft PR. |
+| `--dry-run` | off | Print the would-be title and body without calling `gh`. |
+| `--no-push` | off | Skip `git push`; assume the branch is already on origin. |
 
 (`cli/commands/pr_cmd.py:183-220`.)
 
@@ -1346,7 +1391,7 @@ See [`reference/mcp-catalog.md`](mcp-catalog.md) for the full reference.
 | `bernstein changelog` | Changelog from runs (group: bare = agent-produced diffs, `conventional` subcommand = from conventional commits). | `cli/changelog_cmd.py:405` |
 | `bernstein run-changelog` | Deprecated alias for `bernstein changelog` (removed in a later release). | `cli/changelog_cmd.py:533` |
 | `bernstein checkpoint` | Save progress (see [Run & control](#run-control)). | `cli/commands/checkpoint_cmd.py:49` |
-| `bernstein voice` / `bernstein listen` | Voice control (experimental). | `cli/voice_cmd.py:437` |
+| `bernstein listen` | Voice control (experimental). | `cli/commands/voice_cmd.py` |
 | `bernstein install-hooks` | Install git hooks. | `cli/commands/advanced_cmd.py:448` |
 | `bernstein ab-test` | A/B model comparison. | `cli/commands/ab_test_cmd.py:14` |
 | `bernstein acp serve` | Run an ACP server. | `cli/commands/acp_cmd.py:33` |
@@ -1414,22 +1459,23 @@ See [`reference/mcp-catalog.md`](mcp-catalog.md) for the full reference.
 | `tasks` | Render the current task dependency graph as ASCII or Mermaid. |
 | `impact FILE_QUERY` | Print downstream files impacted by changing FILE_QUERY. |
 
-#### `bernstein voice` / `bernstein listen`
+#### `bernstein listen`
 
 Experimental voice control (see [`operations/voice-control.md`](../operations/voice-control.md) when published).
 
 | Flag | Default | Meaning |
 |---|---|---|
-| `--engine {whisper\|vosk}` | whisper | Speech recognition engine. |
-| `--device INDEX` | default | Audio input device. |
-| `--language LANG` | en | Language code. |
+| `--model SIZE` | `base` | Whisper model size; smaller is faster but less accurate. |
+| `--threshold RMS` | 0.01 | RMS amplitude threshold distinguishing speech from silence. |
+| `--min-duration SEC` | 0.5 | Minimum utterance duration before transcription. |
+| `--alias-file PATH` | `~/.bernstein/voice.yaml` | Voice alias YAML file. |
+| `--dry-run` | off | Show the parsed command without executing. |
 
 #### `bernstein explain`
 
 | Flag | Default | Meaning |
 |---|---|---|
 | `CONCEPT` | required | Concept name (e.g. `cascade-router`, `wal`, `janitor`). |
-| `--format {text\|markdown\|json}` | text | Output format. |
 
 #### `bernstein test`
 

--- a/tests/unit/test_cli_command_registration.py
+++ b/tests/unit/test_cli_command_registration.py
@@ -119,7 +119,9 @@ def test_man_pages_completes(tmp_path: Path) -> None:
 # name, resolve it through the real ``cli`` object.  A command that is
 # documented but unreachable now fails here instead of in a user's terminal.
 
-_DOC_COMMAND_HEADING = re.compile(r"^#+\s+`bernstein ([a-z0-9][A-Za-z0-9 _-]*)`\s*$", re.M)
+_HEADING = re.compile(r"^#{1,6}\s+\S")
+_CMD_IN_HEADING = re.compile(r"`bernstein ([a-z0-9][A-Za-z0-9 _-]*)`")
+_LONG_FLAG = re.compile(r"--[a-z][a-z0-9-]*")
 
 
 def _strip_argument_placeholders(heading: str) -> str:
@@ -141,17 +143,58 @@ def _strip_argument_placeholders(heading: str) -> str:
     return " ".join(words)
 
 
-def _documented_command_paths() -> list[str]:
-    """Command paths the CLI reference documents, as space-separated words.
+def _reference_sections() -> list[tuple[tuple[str, ...], str]]:
+    """Split the CLI reference into (commands named by the heading, body) pairs.
 
-    Headings carrying an option (``bernstein doctor --failover-drill``) are
-    excluded: they document a flag on a command, not a command.
+    A section runs from one markdown heading to the next heading of *any*
+    level, so a flag table can never bleed into the previous command's
+    section -- the failure mode that let combined headings such as
+    ``bernstein eval`` / ``bernstein benchmark`` attribute their tables to
+    whatever command happened to precede them.  Lines inside fenced code
+    blocks are ignored on both sides: a ``#`` comment inside a ```` ``` ````
+    block is not a heading, and an example table inside one is not a
+    documented contract.
+
+    A heading may name several commands (``bernstein eval`` / ``bernstein
+    benchmark``); every named command owns the section's body.  Forms
+    carrying an option (``bernstein init --wizard``) document a flag on a
+    command, not a command, and are dropped.
     """
     reference = Path(__file__).resolve().parents[2] / "docs" / "reference" / "cli-reference.md"
-    text = reference.read_text(encoding="utf-8")
-    return sorted(
-        {_strip_argument_placeholders(name) for name in _DOC_COMMAND_HEADING.findall(text) if "--" not in name} - {""}
-    )
+    sections: list[tuple[tuple[str, ...], str]] = []
+    commands: tuple[str, ...] = ()
+    body: list[str] = []
+    in_fence = False
+
+    def flush() -> None:
+        if commands:
+            sections.append((commands, "\n".join(body)))
+
+    for line in reference.read_text(encoding="utf-8").splitlines():
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        if _HEADING.match(line):
+            flush()
+            commands = tuple(
+                dict.fromkeys(
+                    path
+                    for raw in _CMD_IN_HEADING.findall(line)
+                    if "--" not in raw and (path := _strip_argument_placeholders(raw))
+                )
+            )
+            body = []
+        else:
+            body.append(line)
+    flush()
+    return sections
+
+
+def _documented_command_paths() -> list[str]:
+    """Command paths the CLI reference documents, as space-separated words."""
+    return sorted({path for commands, _ in _reference_sections() for path in commands})
 
 
 def _resolve(path: str) -> click.Command | None:
@@ -190,43 +233,119 @@ def test_previously_orphaned_command_resolves(name: str) -> None:
 # this gate proved the *name* resolved and stopped there, so `api-check` and
 # `ab-test` became reachable while every flag the reference documented for
 # them still failed with "No such option" -- the same class of failure the
-# registration fix was meant to remove, one layer down.
+# registration fix was meant to remove, one layer down.  #3465 widened the
+# assertion from those two commands to every command the reference documents.
 #
-# Scoped to the two commands this change makes reachable.  A sweep across the
-# whole reference measures 23 commands carrying documented flags that do not
-# exist; widening the gate is tracked separately so it lands with the fixes
-# rather than as a red build.
+# Scope of the gate, stated precisely:
+#
+# * Asserted: rows of a flag table -- markdown table rows whose *first cell*
+#   starts with a backticked long option.  Every long option named in that
+#   cell (including ``--x / --no-x`` alias spellings) must be accepted by the
+#   command the section heading names, and, unless the command is listed in
+#   ``PARTIAL_FLAG_TABLES``, every long option the command really accepts
+#   must appear in some row.  Both directions fail: a doc row for a flag
+#   that does not exist, and a real flag without a doc row.
+# * Not asserted: flags mentioned in prose, in fenced code blocks, or in the
+#   purpose column of subcommand tables.  Those describe *subcommand* flags
+#   (``chat serve --driver``), which this gate cannot attribute to a single
+#   command object.  That is the one-directional limit of the check.
 
-_FLAG_ROW = re.compile(r"^\|\s*`(--[a-z][a-z0-9-]*)", re.M)
+# Commands whose flag table may document flags the command does not accept.
+# Keep this empty: an entry here records a documented invocation that exits 2.
+GHOST_FLAG_EXEMPTIONS: dict[str, str] = {}
+
+# Commands whose flag table is deliberately a subset of the real surface.
+# Every entry carries the reason the table stays partial; the reverse
+# (real -> documented) assertion is skipped for them, the forward assertion
+# is not.
+PARTIAL_FLAG_TABLES: dict[str, str] = {
+    "run": "documents the most-used subset of a ~40-flag surface; the full list is `bernstein run --help`",
+}
 
 
-def _documented_flags(command_path: str) -> set[str]:
-    """Long options the CLI reference lists in ``command_path``'s flag table."""
-    reference = Path(__file__).resolve().parents[2] / "docs" / "reference" / "cli-reference.md"
-    sections = re.split(
-        r"^#+\s+`bernstein ([a-z0-9][a-z0-9 _-]*)`\s*$",
-        reference.read_text(encoding="utf-8"),
-        flags=re.M,
-    )
-    for name, body in zip(sections[1::2], sections[2::2], strict=False):
-        if name == command_path:
-            return set(_FLAG_ROW.findall(body))
-    return set()
+def _documented_flags(body: str) -> set[str]:
+    """Long options a section's flag table rows document.
+
+    A flag row is a table row whose first cell starts with a backticked long
+    option.  All long options in that cell count as documented, so both
+    ``| `--force` / `--hard` |`` and ``| `--last / --no-last` |`` document
+    two flags.  Rows starting with a positional placeholder or a subcommand
+    name are not flag rows.
+    """
+    flags: set[str] = set()
+    for line in body.splitlines():
+        stripped = line.lstrip()
+        if not stripped.startswith("|"):
+            continue
+        first_cell = stripped.split("|")[1] if "|" in stripped[1:] else stripped[1:]
+        if re.match(r"^\s*`--[a-z]", first_cell):
+            flags.update(_LONG_FLAG.findall(first_cell))
+    return flags
 
 
-@pytest.mark.parametrize("name", ["api-check", "ab-test", "impact api", "impact deps", "dep-impact"])
-def test_documented_flags_exist(name: str) -> None:
+def _real_flags(command: click.Command) -> set[str]:
+    return {opt for param in command.params for opt in (*param.opts, *param.secondary_opts) if opt.startswith("--")}
+
+
+def _sections_with_flag_tables() -> list[pytest.param]:
+    return [
+        pytest.param(path, flags, id=path)
+        for commands, body in _reference_sections()
+        if (flags := _documented_flags(body))
+        for path in commands
+    ]
+
+
+@pytest.mark.parametrize(("name", "documented"), _sections_with_flag_tables())
+def test_documented_flags_exist(name: str, documented: set[str]) -> None:
     """Every flag the reference documents is accepted by the command.
 
     A documented flag the parser rejects fails at ``No such option`` before
     the command body runs, which reads to the user exactly like the command
     being missing.
     """
+    if name in GHOST_FLAG_EXEMPTIONS:
+        pytest.skip(f"known-broken flag table: {GHOST_FLAG_EXEMPTIONS[name]}")
     command = _resolve(name)
-    assert command is not None
-    real = {opt for param in command.params for opt in param.opts if opt.startswith("--")}
-    documented = _documented_flags(name)
-    assert documented, f"no flag table found for `bernstein {name}` in the CLI reference"
-    assert not (documented - real), (
-        f"`bernstein {name}` documents flags it does not accept: {sorted(documented - real)}"
-    )
+    assert command is not None, f"`bernstein {name}` is documented but not registered"
+    ghosts = sorted(documented - _real_flags(command))
+    assert not ghosts, f"`bernstein {name}` documents flags it does not accept: {ghosts}"
+
+
+@pytest.mark.parametrize(("name", "documented"), _sections_with_flag_tables())
+def test_real_flags_are_documented(name: str, documented: set[str]) -> None:
+    """Every long option a command accepts appears in its flag table.
+
+    The reverse direction of the gate: a flag added to a command without a
+    doc row fails here, so the reference cannot silently fall behind the
+    surface it documents.  Commands without a flag table document nothing to
+    contradict and are out of scope; deliberately abbreviated tables are
+    named in ``PARTIAL_FLAG_TABLES`` with the reason.
+    """
+    if name in PARTIAL_FLAG_TABLES:
+        pytest.skip(f"deliberately partial table: {PARTIAL_FLAG_TABLES[name]}")
+    command = _resolve(name)
+    assert command is not None, f"`bernstein {name}` is documented but not registered"
+    undocumented = sorted(_real_flags(command) - documented - {"--help"})
+    assert not undocumented, f"`bernstein {name}` accepts flags its reference table does not list: {undocumented}"
+
+
+@pytest.mark.parametrize(
+    "exemptions",
+    [GHOST_FLAG_EXEMPTIONS, PARTIAL_FLAG_TABLES],
+    ids=["ghost-flag-exemptions", "partial-flag-tables"],
+)
+def test_flag_gate_exemptions_name_live_documented_commands(exemptions: dict[str, str]) -> None:
+    """Every exemption names a command that still exists and still has a table.
+
+    An entry for a renamed or undocumented command would exempt nothing while
+    reading as if it did; forcing the sets to track the live surface means
+    they can only shrink meaningfully, never rot.
+    """
+    documented_with_tables = {name for param in _sections_with_flag_tables() for name in (param.values[0],)}
+    for name, reason in exemptions.items():
+        assert reason.strip(), f"exemption for `bernstein {name}` carries no reason"
+        assert _resolve(name) is not None, f"exempted command `bernstein {name}` is not registered any more"
+        assert name in documented_with_tables, (
+            f"exempted command `bernstein {name}` no longer has a flag table in the reference"
+        )

--- a/tests/unit/test_cli_command_registration.py
+++ b/tests/unit/test_cli_command_registration.py
@@ -245,10 +245,17 @@ def test_previously_orphaned_command_resolves(name: str) -> None:
 #   ``PARTIAL_FLAG_TABLES``, every long option the command really accepts
 #   must appear in some row.  Both directions fail: a doc row for a flag
 #   that does not exist, and a real flag without a doc row.
-# * Not asserted: flags mentioned in prose, in fenced code blocks, or in the
-#   purpose column of subcommand tables.  Those describe *subcommand* flags
-#   (``chat serve --driver``), which this gate cannot attribute to a single
-#   command object.  That is the one-directional limit of the check.
+# * Asserted, forward direction only: rows of a subcommand table -- a table
+#   whose header's first cell is ``Subcommand``.  The row's first cell names
+#   a subcommand of the section's command; every long option mentioned in
+#   the row's other cells must be accepted by that subcommand, and the
+#   subcommand itself must resolve.  There is no reverse assertion here: a
+#   purpose cell is a summary, not an exhaustive flag list.
+# * Not asserted: flags mentioned in prose outside tables, in fenced code
+#   blocks, or in tables whose header is neither a flag table nor
+#   ``Subcommand`` (e.g. the ``Command | Purpose`` category tables and the
+#   ``Deprecated | Canonical`` alias-mapping table, whose cells discuss
+#   several commands at once).  That is the stated limit of the check.
 
 # Commands whose flag table may document flags the command does not accept.
 # Keep this empty: an entry here records a documented invocation that exits 2.
@@ -259,7 +266,65 @@ GHOST_FLAG_EXEMPTIONS: dict[str, str] = {}
 # (real -> documented) assertion is skipped for them, the forward assertion
 # is not.
 PARTIAL_FLAG_TABLES: dict[str, str] = {
-    "run": "documents the most-used subset of a ~40-flag surface; the full list is `bernstein run --help`",
+    "run": "documents the most-used subset of a ~45-flag surface; the full list is `bernstein run --help`",
+}
+
+# The complete long-option surface of every command in ``PARTIAL_FLAG_TABLES``.
+# The abbreviated table exempts these commands from the reverse doc assertion,
+# which would otherwise let a rename or removal ship silently and break every
+# script using the old spelling.  This pin closes that hole: changing the
+# command's surface fails here and forces a deliberate update -- and a look at
+# whether the "most-used" table rows are affected.
+PARTIAL_TABLE_FULL_SURFACES: dict[str, frozenset[str]] = {
+    "run": frozenset(
+        {
+            "--ab-test",
+            "--activity-log",
+            "--allow-network",
+            "--allow-paid",
+            "--attach",
+            "--audit",
+            "--auto-approve",
+            "--auto-pr",
+            "--budget",
+            "--budget-cap",
+            "--cells",
+            "--cli",
+            "--compliance",
+            "--container",
+            "--container-image",
+            "--cprofile",
+            "--criterion-profile",
+            "--dry-run",
+            "--fresh",
+            "--from-plan",
+            "--goal",
+            "--hard-budget",
+            "--idle",
+            "--max-blast-radius",
+            "--max-cost-usd",
+            "--model",
+            "--no-container",
+            "--no-two-phase-sandbox",
+            "--permission-profile",
+            "--plan-only",
+            "--port",
+            "--profile",
+            "--quiet",
+            "--refresh-cache",
+            "--remote",
+            "--retry-budget",
+            "--routing",
+            "--sandbox",
+            "--seed",
+            "--skip-gate",
+            "--skip-gate-reason",
+            "--task",
+            "--two-phase-sandbox",
+            "--worker",
+            "--workflow",
+        }
+    ),
 }
 
 
@@ -328,6 +393,86 @@ def test_real_flags_are_documented(name: str, documented: set[str]) -> None:
     assert command is not None, f"`bernstein {name}` is documented but not registered"
     undocumented = sorted(_real_flags(command) - documented - {"--help"})
     assert not undocumented, f"`bernstein {name}` accepts flags its reference table does not list: {undocumented}"
+
+
+@pytest.mark.parametrize("name", sorted(PARTIAL_FLAG_TABLES))
+def test_partial_table_surface_is_pinned(name: str) -> None:
+    """A partially-documented command's full surface is pinned.
+
+    ``PARTIAL_FLAG_TABLES`` exempts the command from the reverse doc
+    assertion; without this pin a flag rename or removal outside the
+    abbreviated rows would ship with CI green and break every script using
+    the old spelling.  Any surface change must update the pin -- and prompt
+    a look at whether the documented "most-used" rows are affected.
+    """
+    assert name in PARTIAL_TABLE_FULL_SURFACES, (
+        f"`bernstein {name}` is in PARTIAL_FLAG_TABLES without a pinned surface in PARTIAL_TABLE_FULL_SURFACES"
+    )
+    command = _resolve(name)
+    assert command is not None
+    real = _real_flags(command)
+    pinned = PARTIAL_TABLE_FULL_SURFACES[name]
+    assert real == pinned, (
+        f"`bernstein {name}`'s option surface changed: "
+        f"added {sorted(real - pinned)}, removed {sorted(pinned - real)}. "
+        "Update PARTIAL_TABLE_FULL_SURFACES and check whether the reference's abbreviated table is affected."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Subcommand tables (forward direction)
+# ---------------------------------------------------------------------------
+
+_SUBCOMMAND_WORDS = re.compile(r"^([a-z][a-z0-9-]*(?: [a-z][a-z0-9-]*)*)")
+
+
+def _subcommand_rows() -> list[pytest.param]:
+    """(subcommand path, flags its purpose cell mentions) for every subcommand-table row.
+
+    A subcommand table is one whose header's first cell is ``Subcommand``.
+    Each row's first cell names one or more subcommands of the section's
+    command (``pin VERSION`` / ``unpin`` names two); trailing ALL-CAPS
+    argument placeholders are stripped the same way as for headings.
+    """
+    rows: list[pytest.param] = []
+    for commands, body in _reference_sections():
+        in_table = False
+        for line in body.splitlines():
+            stripped = line.strip()
+            if not stripped.startswith("|"):
+                in_table = False
+                continue
+            cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+            if cells and cells[0].strip("`").lower() == "subcommand":
+                in_table = True
+                continue
+            if not in_table or not cells or set(cells[0]) <= {"-", ":", " "}:
+                continue
+            flags = frozenset(_LONG_FLAG.findall(" ".join(cells[1:])))
+            for parent in commands:
+                for piece in cells[0].split("/"):
+                    match = _SUBCOMMAND_WORDS.match(piece.strip().strip("`").strip())
+                    if match is None:
+                        continue
+                    path = f"{parent} {match.group(1)}"
+                    rows.append(pytest.param(path, flags, id=path))
+    return rows
+
+
+@pytest.mark.parametrize(("path", "flags"), _subcommand_rows())
+def test_subcommand_rows_resolve_and_accept_their_flags(path: str, flags: frozenset[str]) -> None:
+    """Every subcommand-table row names a live subcommand and real flags.
+
+    The per-command flag tables cannot see one level down, so a rename like
+    ``chat serve --driver`` -> ``--platform`` used to ship with CI green
+    while the documented invocation exited 2.  Forward direction only: the
+    purpose cell is a summary, so flags it omits are not failures, but a
+    flag it names must exist on the row's own subcommand.
+    """
+    command = _resolve(path)
+    assert command is not None, f"`bernstein {path}` appears in a subcommand table but does not resolve"
+    ghosts = sorted(flags - _real_flags(command))
+    assert not ghosts, f"`bernstein {path}`'s subcommand row mentions flags it does not accept: {ghosts}"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# User description
## What

Fixes the flag tables in `docs/reference/cli-reference.md` for every command whose documented invocation the parser rejects, and widens the existing per-command flag assertion in `tests/unit/test_cli_command_registration.py` from two hand-picked commands to every command the reference documents.

Fixes #3465.

## Why

A documented flag the parser rejects exits `2` with `No such option` before the command body runs, which reads to a user exactly like the command being missing. Measured against the live `cli` object, 18 commands carried 55 documented flags that do not exist, `bernstein voice` was documented but never registered (the command is `listen`), and four sections (`verify`, `trace`, `evolve`, `eval`/`benchmark`) described a pre-group single-command shape whose flags now live on subcommands.

The counts differ from the issue's table because the issue's probe split sections on command headings only, so tables under combined headings (`bernstein eval` / `bernstein benchmark`) were attributed to the preceding section (e.g. the "chaos" row was really the eval/benchmark table). The issue anticipated this: the list was regenerated from the probe rather than trusted.

## How

**Docs** — every flag table now matches its command's real params:

- Renames to the real spelling: `plan generate --out` → `--output`, `man-pages --out` → `--output-dir`, `mcp --server` → `--server-url`, `worker --labels/--max-agents` → `--label`/`--slots`, `retro -o, --output` reordered to long-form-first.
- Removed flags that do not exist and have no successor: `explain --format`, `slo --reset`, `status --workdir`, `man-pages --section`.
- `run --approval`/`--merge`: removed; the approval gate is `--auto-approve`, the merge strategy is `merge_strategy: pr|direct` in `bernstein.yaml` — the section now says so.
- Full table rewrites from the real params: `init`, `watch`, `test-adapter`, `worker`, `pr`, `listen`.
- Group restructures (flags moved to subcommand tables): `verify`, `trace`, `evolve`; `eval`/`benchmark` split into two sections so the `eval`-only reliability options are no longer attributed to `benchmark`.
- Completed tables that lagged the surface: `stop`, `plan generate`, `status`, `slo`, `doctor`, `cost profile-report`, `mcp`.
- `bernstein voice` dropped; the registered command is `bernstein listen`.
- `dep-impact --package` (called out in the issue): already resolved on main — the table documents the real `--base/--workdir/--strict/--json` surface of the `impact deps` alias, and `--package` never existed on it. Decided side: the docs were wrong, the code is right.

**Gate** — the existing per-command assertion mechanism now covers all documented commands:

- Bidirectional: a doc row for a flag that does not exist fails (`test_documented_flags_exist`), and a real flag without a doc row fails (`test_real_flags_are_documented`). Stated limit: only flag-table rows are asserted; flags in prose, fenced code blocks, and subcommand-purpose tables are out of the gate's reach.
- The section parser splits on any heading and skips fenced code blocks, so combined headings no longer leak their tables into the previous section, and previously invisible headings (`bernstein init` / `bernstein init --wizard`, `bernstein debug-bundle` (deprecated)) are now inside the registration sweep — which is how the unregistered `voice` surfaced.
- `GHOST_FLAG_EXEMPTIONS` ships empty. `PARTIAL_FLAG_TABLES` names the one deliberately abbreviated table (`run`, ~44 flags, table documents the most-used subset) with its reason. A hygiene test fails if either set names a command that no longer exists or no longer has a flag table, so entries cannot rot and growth is visible in review.
- The test file also runs as a step in the Repo hygiene job, so a docs-only change cannot land drift past an affected-tests PR lane.

## Verification

Before (widened gate against the unfixed reference) — both directions fail, plus the registration sweep:

```
FAILED test_documented_commands_are_registered            # voice
FAILED test_documented_flags_exist[run|init|plan generate|status|watch|trace|slo|verify|eval|benchmark|test-adapter|worker|evolve|man-pages|mcp|pr|voice|listen|explain]
FAILED test_real_flags_are_documented[stop|init|plan generate|status|retro|watch|slo|test-adapter|worker|cost profile-report|doctor|man-pages|mcp|pr|voice|listen]
36 failed, 279 passed, 1 skipped
```

Example failures, one per direction:

```
AssertionError: `bernstein explain` documents flags it does not accept: ['--format']
AssertionError: `bernstein listen` accepts flags its reference table does not list: ['--alias-file', '--dry-run', '--min-duration', '--model', '--threshold']
```

After the docs fix:

```
tests/unit/test_cli_command_registration.py  305 passed, 1 skipped
```

(the skip is `run` in `PARTIAL_FLAG_TABLES`, with its reason printed.)

Companion guards that parse the same markdown stay green: `tests/unit/test_readme_api_coverage.py`, `tests/unit/test_regen_contract_drift.py`, `tests/unit/test_fold_benchmark_subcommands.py`, `tests/unit/test_docs_capability_reachability.py` — 347 passed, 1 skipped across the set. `ruff check` and `ruff format --check` clean on the touched Python file.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Reconcile the CLI reference with registered command and flag surfaces, including corrected options, subcommand layouts, and the <code>listen</code> command name. Expand the CLI registration tests and CI hygiene job to detect undocumented or rejected flags across the documented command set.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3536?tool=ast&topic=CLI+Drift+Guard>CLI Drift Guard</a>
        </td><td>Enforce bidirectional flag coverage and command registration checks across documented commands and subcommands, while pinning deliberate partial tables and running the guard in CI.<details><summary>Modified files (2)</summary><ul><li>.github/workflows/ci.yml</li>
<li>tests/unit/test_cli_command_registration.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>docs(cli): extend the ...</td><td>August 10, 2026</td></tr>
<tr><td>chernistry</td><td>cli(commands): consoli...</td><td>August 09, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3536?tool=ast&topic=CLI+Reference+Accuracy>CLI Reference Accuracy</a>
        </td><td>Align the CLI reference with live command parsing by correcting flag names, removing unsupported options, rewriting stale tables, restructuring grouped commands, and documenting the registered <code>listen</code> command.<details><summary>Modified files (1)</summary><ul><li>docs/reference/cli-reference.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>docs(cli): extend the ...</td><td>August 10, 2026</td></tr>
<tr><td>chernistry</td><td>test(cli): enforce reg...</td><td>August 09, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3536?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

<!-- bot-ack: 3748186190 reason=typed-metadata comparison rejected: docs record effective defaults (env/config fallbacks, computed paths) that click Option metadata cannot express; concrete --mcp-tier row fixed in f6fc7e9c -->


<!-- bot-ack: 3748324701 reason=false premise: --key-file never existed on remote run; --identity-file since #926, zero history hits; nothing renamed, no migration to document; aliases are code changes out of scope -->
<!-- bot-ack: 3748324709 reason=false premise: cache clear --scope never existed in cache_cmd.py history; no scope semantics lost since the flag never parsed; table now reports the real surface -->
<!-- bot-ack: 3748324717 reason=false premise: chat serve has had --platform/--token/--allow since #929; --driver/--target never existed in file history; no deprecation or mapping to record -->
<!-- bot-ack: 3748324724 reason=false premise: review-responder never had run/stop or --workdir/--server/--poll; start/status/tick since introduction; docs PR removed nothing -->
<!-- bot-ack: 3748324729 reason=false premise: preview never had show or --ttl/--public/--name/--port; shipped with start/list/status/stop and current options; no behaviour to preserve -->
