### PR TITLE
docs: state the beta status at the top of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@
 
 ---
 
+> **Status: beta.** Solo-maintained, under active development. The version number counts releases, not maturity - minor versions may change interfaces. Pin the version for anything you depend on; regressions get fixed fast, [file them](https://github.com/sipyourdrink-ltd/bernstein/issues).
+
 Bernstein is a deterministic orchestrator for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40+ more). Scheduling is plain Python - no LLM in the coordination loop - so runs are reproducible end to end. Every coding task runs in its own git worktree behind lint/type/test gates; artifact-mode tasks, which complete on a signed lineage receipt instead of a commit, get a plain working directory instead. Results stay checkable after the fact: an always-on lineage spine and replay journal, plus an opt-in HMAC-chained audit log (`BERNSTEIN_AUDIT=1`) with receipts you can verify offline. Air-gap install profile included. Apache-2.0.
 
 ### at a glance

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -15,7 +15,7 @@
 > *"To achieve great things, two things are needed: a plan and not quite enough time."* - Leonard Bernstein
 
 ### 确定性多智能体 CLI 编排
-<!-- l10n: en="deterministic multi-agent CLI orchestration" hash="sha256:d0cc91d44434" -->
+<!-- l10n: en="deterministic multi-agent CLI orchestration" hash="sha256:71266dcc2820" -->
 
 [![CI](https://github.com/sipyourdrink-ltd/bernstein/actions/workflows/ci.yml/badge.svg)](https://github.com/sipyourdrink-ltd/bernstein/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/bernstein)](https://pypi.org/project/bernstein/)
@@ -34,6 +34,8 @@
 </div>
 
 ---
+
+> **状态：beta。** 由单人维护，正在积极开发中。版本号计的是发布次数，而非成熟度——次版本（minor）可能改变接口。凡有依赖请锁定版本；回归问题会被尽快修复，[欢迎提交](https://github.com/sipyourdrink-ltd/bernstein/issues)。
 
 Bernstein 是一个面向 CLI 编码智能体（Claude Code、Codex、Gemini CLI 以及 40 多个其他智能体）的确定性编排器。调度是纯 Python——协调循环中没有 LLM——因此运行可以端到端复现。每个编码任务都在自己的 git worktree 中运行，背后有 lint/type/test 门禁；产物模式（artifact-mode）任务以签署的血统收据（lineage receipt）而非提交来宣告完成，获得一个普通的工作目录。结果事后仍可核查：常驻的血统脊柱（lineage spine）和回放日志（replay journal），外加可选的 HMAC 链式审计日志（`BERNSTEIN_AUDIT=1`），其收据可离线验证。包含离线安装（air-gap）配置。Apache-2.0 许可。
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -15,7 +15,7 @@
 > *"To achieve great things, two things are needed: a plan and not quite enough time."* - Leonard Bernstein
 
 ### 確定性多代理 CLI 編排
-<!-- l10n: en="deterministic multi-agent CLI orchestration" hash="sha256:d0cc91d44434" -->
+<!-- l10n: en="deterministic multi-agent CLI orchestration" hash="sha256:71266dcc2820" -->
 
 [![CI](https://github.com/sipyourdrink-ltd/bernstein/actions/workflows/ci.yml/badge.svg)](https://github.com/sipyourdrink-ltd/bernstein/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/bernstein)](https://pypi.org/project/bernstein/)
@@ -34,6 +34,8 @@
 </div>
 
 ---
+
+> **狀態：beta。** 由單人維護，正在積極開發中。版本號計的是發布次數，而非成熟度——次版本（minor）可能變更介面。凡有依賴請鎖定版本；回歸問題會被儘快修復，[歡迎回報](https://github.com/sipyourdrink-ltd/bernstein/issues)。
 
 Bernstein 是面向 CLI 編碼代理（Claude Code、Codex、Gemini CLI 以及 40 多個其他代理）的確定性編排器。排程是純 Python——協調迴圈中沒有 LLM——因此執行可以端到端重現。每個編碼任務都在自己的 git worktree 中執行，背後有 lint/type/test 門禁；產物模式（artifact-mode）任務以簽署的血統收據（lineage receipt）而非提交來宣告完成，獲得一個普通的工作目錄。結果事後仍可核查：常駐的血統脊柱（lineage spine）和重播日誌（replay journal），外加選用的 HMAC 鏈式稽核日誌（`BERNSTEIN_AUDIT=1`），其收據可離線驗證。包含離線安裝（air-gap）設定。Apache-2.0 授權。
 


### PR DESCRIPTION
# User description
The README's badge row and release count read as a mature, staffed project. First-use reports (#3514) describe a rougher experience than that framing sets up. One line under the fold states the actual status: beta, solo-maintained, version numbers count releases rather than maturity, pin what you depend on.

The repository About text now carries the same one-word status.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add a prominent beta-status notice to the English and Chinese README introductions, clarifying solo maintenance, release-version semantics, interface-change risk, and dependency pinning. Update localization metadata so the translated notices remain synchronized with the English documentation.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>docs: mirror the beta ...</td><td>August 10, 2026</td></tr>
<tr><td>chernistry</td><td>fix: restore the four ...</td><td>August 09, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3543?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>