### PR TITLE
fix(adapters): ship contracts and golden transcripts in the wheel

### DIFF
--- a/docs/adapters/admission-receipts.md
+++ b/docs/adapters/admission-receipts.md
@@ -102,6 +102,23 @@ Sealed receipts live under `.sdd/adapters/admission/` and are
 content-addressed, so a tampered body no longer hashes to its recorded
 identity and is rejected without any key material.
 
+## Where the evidence comes from
+
+The verdict is derived from two trees that live under `tests/` in a source
+checkout — the pinned contract YAMLs in `tests/contract/contracts/` and the
+golden transcripts in `tests/golden/`. Both ship inside the wheel, at
+`bernstein/_default_templates/adapter_contracts/` and
+`bernstein/_default_templates/adapter_golden/`, so a `pip install` derives the
+same replay fingerprint a checkout does and `--seal` goes green on the install
+channel too. A checkout, when present, is read in preference to the bundled
+copy.
+
+To replay against a transcript tree of your own — a vendored fork, or an
+air-gapped mirror — point `BERNSTEIN_ADAPTER_GOLDEN_DIR` at it. It takes
+precedence over both layouts. Note that a different transcript tree changes the
+replay fingerprint, so receipts sealed against it are only comparable with
+other hosts using the same tree.
+
 ## Relationship to the other adapter gates
 
 The admission gate sits alongside two existing spawn-path gates and does not

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -77,6 +77,20 @@ landed since the newest one.
 
 ## Fixed
 
+- Adapter admission can produce an `ADMIT` verdict on a pip install (#3547).
+  The verdict is a projection of the pinned contract's bytes and the
+  golden-transcript replay, but both trees live under `tests/` and were
+  excluded from the wheel, so off a dev checkout every adapter resolved to a
+  skip-shaped refusal (`no_contract`, then `no_transcript`) and
+  `bernstein adapters verify --seal` could never go green. The contracts and
+  the transcripts now ship in the wheel at
+  `bernstein/_default_templates/adapter_contracts/` and
+  `bernstein/_default_templates/adapter_golden/`; a source checkout still wins
+  when present, and `BERNSTEIN_ADAPTER_GOLDEN_DIR` still overrides both. The
+  trees ship verbatim, so an installed host derives the same replay
+  fingerprint a checkout does. A packaging guard test pins the wheel
+  destinations to the paths the loaders read, so the files cannot silently
+  drop out again. Docs: `docs/adapters/admission-receipts.md`.
 - `ClusterServiceImpl.RegisterNode` no longer raises `TypeError` on every
   gRPC node registration. The handler called `NodeRegistry.register()` with
   `NodeInfo`'s own constructor keywords (`name=`, `url=`, `capacity=`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -511,6 +511,18 @@ artifacts = [
 # the display fallback read by cli/display/splash_v2.py when running from a
 # source checkout.
 
+[tool.hatch.build.targets.sdist.force-include]
+# Wheel force-include sources must also exist inside the sdist: `uv build`
+# (and any pip install from the sdist) builds the wheel FROM the sdist, and
+# hatchling hard-fails on a missing force-include source. Every other wheel
+# force-include source above (templates/, skills, ...) survives into the
+# sdist by default, but these two live under tests/, which the global
+# [tool.hatch.build] exclude drops - so they are re-included here verbatim,
+# at their checkout paths. Guard:
+# tests/unit/test_adapter_verification_data_in_wheel.py.
+"tests/contract/contracts" = "tests/contract/contracts"
+"tests/golden" = "tests/golden"
+
 [tool.ruff]
 target-version = "py312"
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -485,6 +485,17 @@ artifacts = [
 # Built-in team manifests (#2248) so `team_manifest: python` and the
 # `bernstein team` commands resolve right after pip install.
 "templates/teams" = "bernstein/_default_templates/teams"
+# Adapter admission evidence (#3547). The verdict `bernstein adapters
+# verify --seal` derives is a projection of the pinned contract's bytes and
+# the golden-transcript replay, so both have to be resolvable off a pip
+# install or every adapter falls back to a skip-shaped refusal
+# (`no_contract` / `no_transcript`) and the seal can never go green outside
+# a dev checkout. Both trees are shipped verbatim rather than filtered, so
+# an installed host derives the same replay fingerprint a checkout does.
+# Loaders: bernstein.adapters._contract.CONTRACTS_DIR and
+# bernstein.adapters.admission.golden_transcripts_dir.
+"tests/contract/contracts" = "bernstein/_default_templates/adapter_contracts"
+"tests/golden" = "bernstein/_default_templates/adapter_golden"
 # Cross-vendor agent-plugin assets (#2369): the bernstein-run skill plus
 # the plugin command/agent/rule files, so `bernstein skills package
 # install` resolves the bundled tree right after pip install. Loader:

--- a/src/bernstein/adapters/_contract.py
+++ b/src/bernstein/adapters/_contract.py
@@ -39,12 +39,17 @@ from typing import Any, TypedDict
 import yaml
 
 # Repo-root anchor. We compute the repo root from this file's location so
-# the loader works under editable installs and from the wheel-installed
-# package (in which case the contracts simply aren't packaged and the
-# loader raises FileNotFoundError, the expected behaviour off-dev).
+# the loader works under editable installs and from a source checkout.
 _THIS_FILE = Path(__file__).resolve()
 _REPO_ROOT = _THIS_FILE.parents[3]
-CONTRACTS_DIR = _REPO_ROOT / "tests" / "contract" / "contracts"
+_DEV_CONTRACTS_DIR = _REPO_ROOT / "tests" / "contract" / "contracts"
+# Wheel-bundled copy. The contracts are force-included into the package tree
+# at build time (see ``[tool.hatch.build.targets.wheel.force-include]`` in
+# ``pyproject.toml``), so a pip install resolves them without a checkout -
+# without them every adapter's admission verdict is a `no_contract` refusal
+# (issue #3547).
+_PACKAGED_CONTRACTS_DIR = _THIS_FILE.parents[1] / "_default_templates" / "adapter_contracts"
+CONTRACTS_DIR = _DEV_CONTRACTS_DIR if _DEV_CONTRACTS_DIR.is_dir() else _PACKAGED_CONTRACTS_DIR
 
 # Per-subprocess timeouts. Plenty for any well-behaved CLI.
 _HELP_TIMEOUT_SECONDS = 30

--- a/src/bernstein/adapters/admission.py
+++ b/src/bernstein/adapters/admission.py
@@ -272,12 +272,18 @@ _OFF_TOKENS = frozenset({"off", "0", "false", "disabled", "none"})
 #: against ``mock``.
 ADMISSION_EXEMPT: frozenset[str] = frozenset({"generic", "mock"})
 
-#: Env override for the golden-transcript directory (absent from an installed
-#: wheel, present in a dev checkout).
+#: Env override for the golden-transcript directory, for an operator pinning a
+#: tree of their own ahead of both layouts below.
 _GOLDEN_DIR_ENV = "BERNSTEIN_ADAPTER_GOLDEN_DIR"
 
 #: Golden transcripts as laid out in a development checkout.
 _GOLDEN_DIR_DEFAULT = Path(__file__).parents[3] / "tests" / "golden"
+
+#: Golden transcripts as shipped in the wheel. Force-included into the package
+#: tree at build time (see ``[tool.hatch.build.targets.wheel.force-include]``
+#: in ``pyproject.toml``) so a pip install can replay the spawn path instead of
+#: refusing every adapter with :data:`REASON_NO_TRANSCRIPT` (issue #3547).
+_GOLDEN_DIR_PACKAGED = Path(__file__).resolve().parents[1] / "_default_templates" / "adapter_golden"
 
 _RECEIPT_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
 
@@ -334,8 +340,8 @@ def golden_transcripts_dir(explicit: Path | None = None) -> Path | None:
     """Resolve the golden-transcript directory, or ``None`` when absent.
 
     Order: an explicit argument, then :data:`_GOLDEN_DIR_ENV`, then the
-    development-checkout layout. An installed wheel ships no transcripts, so
-    ``None`` there is expected and surfaces as a
+    development-checkout layout, then the copy bundled in the wheel. ``None``
+    means no transcript tree is reachable at all, which surfaces as a
     :data:`REASON_NO_TRANSCRIPT` refusal rather than as silent permission.
     """
     if explicit is not None:
@@ -344,7 +350,9 @@ def golden_transcripts_dir(explicit: Path | None = None) -> Path | None:
     if env_dir:
         candidate = Path(env_dir)
         return candidate if candidate.exists() else None
-    return _GOLDEN_DIR_DEFAULT if _GOLDEN_DIR_DEFAULT.exists() else None
+    if _GOLDEN_DIR_DEFAULT.exists():
+        return _GOLDEN_DIR_DEFAULT
+    return _GOLDEN_DIR_PACKAGED if _GOLDEN_DIR_PACKAGED.exists() else None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_adapter_verification_data_in_wheel.py
+++ b/tests/unit/test_adapter_verification_data_in_wheel.py
@@ -1,0 +1,122 @@
+"""Wheel-packaging regression: adapter admission evidence must ship.
+
+``bernstein adapters verify --seal`` derives its verdict from two trees that
+live outside ``src/`` in the source layout: the pinned contract YAMLs under
+``tests/contract/contracts/`` and the golden transcripts under
+``tests/golden/``. Both were absent from the wheel, so on a pip install every
+adapter resolved to a skip-shaped refusal (``no_contract`` /
+``no_transcript``) and the seal could never go green off a dev checkout
+(issue #3547).
+
+They now reach an installed host through
+``[tool.hatch.build.targets.wheel.force-include]``. These tests pin the two
+halves of that arrangement together: the wheel really declares the trees, and
+the loaders really look where the wheel puts them. Either half drifting on its
+own reproduces the original silent refusal.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+import pytest
+
+import bernstein
+from bernstein.adapters import admission
+from bernstein.adapters._contract import (  # pyright: ignore[reportPrivateUsage]
+    _DEV_CONTRACTS_DIR,
+    _PACKAGED_CONTRACTS_DIR,
+    CONTRACTS_DIR,
+)
+from bernstein.adapters.admission import golden_transcripts_dir
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: Root the force-include destinations are expressed relative to.
+WHEEL_PACKAGE_ROOT = PurePosixPath("bernstein")
+
+#: On-disk root the loaders resolve their packaged copies against.
+PACKAGE_ROOT = Path(bernstein.__file__).resolve().parent
+
+pytestmark = pytest.mark.skipif(
+    not (REPO_ROOT / "pyproject.toml").is_file(),
+    reason="wheel packaging guards only run inside a bernstein source checkout",
+)
+
+
+def _force_include_map() -> dict[str, str]:
+    """Return ``[tool.hatch.build.targets.wheel.force-include]`` as a mapping."""
+    data: Any = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    for key in ("tool", "hatch", "build", "targets", "wheel", "force-include"):
+        data = data.get(key, {})
+    assert isinstance(data, dict), "pyproject.toml has no wheel force-include table"
+    return data
+
+
+@pytest.mark.parametrize(
+    ("source", "packaged_dir", "pattern"),
+    [
+        ("tests/contract/contracts", _PACKAGED_CONTRACTS_DIR, "*.yaml"),
+        ("tests/golden", admission._GOLDEN_DIR_PACKAGED, "*_adapter.yaml"),  # pyright: ignore[reportPrivateUsage]
+    ],
+    ids=["contracts", "golden-transcripts"],
+)
+def test_admission_evidence_is_force_included_into_the_wheel(
+    source: str,
+    packaged_dir: Path,
+    pattern: str,
+) -> None:
+    """The wheel ships each evidence tree where its loader looks for it.
+
+    Drops the force-include entry, renames the destination, or moves the
+    loader's packaged path, and this fails - the three have to agree or a pip
+    install refuses every adapter again.
+    """
+    source_dir = REPO_ROOT / source
+    assert list(source_dir.glob(pattern)), f"no {pattern} files under {source} to package"
+
+    destination = _force_include_map().get(source)
+    assert destination is not None, (
+        f"{source} is not force-included into the wheel; `bernstein adapters verify --seal` "
+        "cannot reach it off a pip install. See [tool.hatch.build.targets.wheel.force-include]."
+    )
+
+    relative = PurePosixPath(destination).relative_to(WHEEL_PACKAGE_ROOT)
+    expected = PurePosixPath(packaged_dir.relative_to(PACKAGE_ROOT).as_posix())
+    assert relative == expected, (
+        f"{source} ships to {destination!r} but the loader reads {packaged_dir}; "
+        "the wheel destination and the packaged-copy path must match."
+    )
+
+
+def test_contracts_dir_resolves_to_a_populated_directory() -> None:
+    """The resolved contracts directory is one of the two known layouts."""
+    assert CONTRACTS_DIR in (_DEV_CONTRACTS_DIR, _PACKAGED_CONTRACTS_DIR)
+    assert CONTRACTS_DIR.is_dir(), f"no contracts directory resolved at {CONTRACTS_DIR}"
+    assert list(CONTRACTS_DIR.glob("*.yaml")), f"no contract YAMLs under {CONTRACTS_DIR}"
+
+
+def test_golden_transcripts_dir_resolves_to_a_populated_directory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The resolved transcript directory holds replayable transcripts."""
+    monkeypatch.delenv("BERNSTEIN_ADAPTER_GOLDEN_DIR", raising=False)
+    resolved = golden_transcripts_dir()
+    assert resolved is not None, "no golden-transcript directory resolved"
+    assert list(resolved.glob("*_adapter.yaml")), f"no golden transcripts under {resolved}"
+
+
+def test_golden_transcripts_dir_falls_back_to_the_packaged_copy(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """With no checkout on disk the wheel-bundled copy is what answers."""
+    monkeypatch.delenv("BERNSTEIN_ADAPTER_GOLDEN_DIR", raising=False)
+    packaged = tmp_path / "adapter_golden"
+    packaged.mkdir()
+    monkeypatch.setattr(admission, "_GOLDEN_DIR_DEFAULT", tmp_path / "absent")
+    monkeypatch.setattr(admission, "_GOLDEN_DIR_PACKAGED", packaged)
+
+    assert golden_transcripts_dir() == packaged

--- a/tests/unit/test_adapter_verification_data_in_wheel.py
+++ b/tests/unit/test_adapter_verification_data_in_wheel.py
@@ -46,12 +46,12 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def _force_include_map() -> dict[str, str]:
-    """Return ``[tool.hatch.build.targets.wheel.force-include]`` as a mapping."""
+def _force_include_map(target: str = "wheel") -> dict[str, str]:
+    """Return ``[tool.hatch.build.targets.<target>.force-include]`` as a mapping."""
     data: Any = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
-    for key in ("tool", "hatch", "build", "targets", "wheel", "force-include"):
+    for key in ("tool", "hatch", "build", "targets", target, "force-include"):
         data = data.get(key, {})
-    assert isinstance(data, dict), "pyproject.toml has no wheel force-include table"
+    assert isinstance(data, dict), f"pyproject.toml has no {target} force-include table"
     return data
 
 
@@ -88,6 +88,30 @@ def test_admission_evidence_is_force_included_into_the_wheel(
     assert relative == expected, (
         f"{source} ships to {destination!r} but the loader reads {packaged_dir}; "
         "the wheel destination and the packaged-copy path must match."
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    ["tests/contract/contracts", "tests/golden"],
+    ids=["contracts", "golden-transcripts"],
+)
+def test_admission_evidence_survives_into_the_sdist(source: str) -> None:
+    """Each wheel force-include source is re-included into the sdist verbatim.
+
+    ``uv build`` (and any pip install from the sdist) builds the wheel FROM
+    the sdist, and hatchling hard-fails on a missing force-include source.
+    These trees live under ``tests/``, which the global
+    ``[tool.hatch.build]`` exclude drops from the sdist - so without a
+    matching sdist force-include entry every sdist-based build of the wheel
+    breaks (this is exactly how CI's "Package size check" job builds).
+    """
+    sdist_destination = _force_include_map("sdist").get(source)
+    assert sdist_destination == source, (
+        f"{source} is force-included into the wheel but does not survive into the sdist; "
+        "building a wheel from the sdist then fails with 'Forced include not found'. "
+        "Re-include it at its checkout path under "
+        "[tool.hatch.build.targets.sdist.force-include]."
     )
 
 


### PR DESCRIPTION
## What

Ships the adapter contract YAMLs and golden transcripts inside the wheel, so
`bernstein adapters verify --seal` can produce a sealed ADMIT on a pip install.

Fixes #3547.

## Why

Admission derives its verdict from the pinned contract's bytes and the
golden-transcript replay. Both trees live under `tests/`, which
`[tool.hatch.build] exclude` drops from the wheel, and neither loader had a
packaged fallback:

- `_contract.CONTRACTS_DIR` anchored at `<repo>/tests/contract/contracts`
- `admission._GOLDEN_DIR_DEFAULT` anchored at `<repo>/tests/golden`

Off a checkout the first resolves to nothing, `_contract_hash` returns `""`,
and `evaluate_admission` refuses with `no_contract`. Fix that alone and the
next refusal is `no_transcript`. Either way the seal cannot go green on the
install channel, which is the channel operators actually use.

### Before

Wheel built from `main`, installed into a clean venv, `claude` 2.1.128 on PATH:

```
$ bernstein adapters verify claude --seal
adapter:             claude
binary:              claude (.../claude.EXE)
installed version:   2.1.128 (Claude Code)
contract hash:       (no contract)
conformance verdict: skip
verdict:             refuse
reason:              no_contract
remediation:         Add tests/contract/contracts/claude.yaml pinning the flags
                     and subcommands the adapter passes, then re-run
                     `bernstein adapters verify claude --seal`.
$ echo $?
1
```

The same command in a dev checkout returned `verdict: admit`, exit 0.

### After

Same clean venv, wheel built from this branch:

```
$ bernstein adapters verify claude --seal
contract hash:       34352fcdfeebad64b9bccd9cae06dc008a723d34d8df3a03114af23c8dbc5da4
replay fingerprint:  sha256:f90f6fc6c1db34f85461a55a56bf860885f9f57016dcbd168bd476b051ec0ab3
conformance verdict: ok
verdict:             admit
allowed:             spawn
$ echo $?
0
```

The replay fingerprint is byte-identical to the one the dev checkout derives, so
an installed host and a checkout agree. Re-running without `--seal` reads the
sealed receipt back and also exits 0.

## How

### Package data, not an override

The issue allows either. Package data is the only shape that satisfies the
second acceptance criterion on its own: an operator on a pip install has no copy
of the files to point an override at, so an override alone leaves the install
channel exactly as broken as it is today. Both trees are force-included into the
package at build time, mirroring how every other non-source asset in this repo
reaches the wheel (`templates/*`, `skills`, `commands`, ...).

The existing `BERNSTEIN_ADAPTER_GOLDEN_DIR` override is untouched and still
takes precedence over both layouts, so the vendored-fork and air-gapped-mirror
cases keep working; it is now documented.

Both trees ship verbatim rather than filtered, so the packaged directory is
byte-identical to the checkout one and the replay fingerprint cannot diverge
between the two layouts. That costs 10 KB of unrelated fixtures under
`tests/golden/`, which the loader already ignores (it reads top-level
`*.yaml` / `*.json` and skips anything without `name` + `adapter_class`).

### Changes

- `pyproject.toml`: force-include `tests/contract/contracts` to
  `bernstein/_default_templates/adapter_contracts` and `tests/golden` to
  `bernstein/_default_templates/adapter_golden`.
- `adapters/_contract.py`: `CONTRACTS_DIR` reads the checkout when present and
  the packaged copy otherwise.
- `adapters/admission.py`: `golden_transcripts_dir()` gains the same fallback,
  after the explicit argument and the env override. Docstrings that asserted a
  wheel ships no transcripts are corrected.
- No change to the admission decision logic, the receipt shape, or any public
  signature.

### Wheel contents

| | before | after |
|---|---|---|
| `adapter_contracts/*.yaml` | 0 | 25 |
| `adapter_golden/*` | 0 | 15 |

## Testing

New guard, `tests/unit/test_adapter_verification_data_in_wheel.py` (5 tests). It
pins the wheel destination and the loader's packaged path to each other, so
dropping the force-include entry, renaming the destination, or moving the
loader all turn it red. It fails on today's packaging and passes on this branch:

```
$ git stash push pyproject.toml
$ pytest tests/unit/test_adapter_verification_data_in_wheel.py -q
FAILED ...::test_admission_evidence_is_force_included_into_the_wheel[contracts]
FAILED ...::test_admission_evidence_is_force_included_into_the_wheel[golden-transcripts]
2 failed, 3 passed

$ git stash pop
$ pytest tests/unit/test_adapter_verification_data_in_wheel.py -q
5 passed
```

Regression run over the admission, contract, conformance and packaging suites
(`test_adapter_admission.py`, `test_adapter_contract.py`,
`test_adapter_contract_check.py`, `test_adapter_contract_security_floor.py`,
`test_adapter_conformance.py`, `test_adapter_conformance_suite.py`,
`test_admission_hardening.py`, `test_spawner_adapter_admission.py`,
`adapters/test_report.py`, `test_packaging_dependency_contract.py`,
`test_gitignore_packaging_guard.py`, `test_distribution_manifests.py`,
`test_eval_smoke_fixtures_in_wheel.py`, `test_agents_md_mirror_guards.py`):

- before: 1110 passed, 12 failed, 8 skipped
- after: 1119 passed, the same 12 failed, 8 skipped

The 12 failures are pre-existing on this Windows host and unrelated: 10 in
`test_adapter_admission.py` refuse `kimi` with `conformance_skip` because that
binary is not installed, and 2 `queue_pause` cases in
`test_admission_hardening.py` are outside the adapter path. No previously
passing test regressed.

Also clean: `ruff check .`, `ruff format --check` on the changed files,
`lint-imports` (3 contracts kept, 0 broken), and `pyright` on the two changed
modules (38 pre-existing errors before and after, no new ones).

## Docs

- `docs/adapters/admission-receipts.md`: new "Where the evidence comes from"
  section covering the resolution order and the `BERNSTEIN_ADAPTER_GOLDEN_DIR`
  override.
- `docs/release-notes/unreleased.md`: entry under `## Fixed`.

No README section covers adapter admission, and no module was added under
`src/`, so no README change and no `agents-md sync` regeneration are needed.
