### PR TITLE
docs: consistency and style pass over release notes

### DIFF
--- a/docs/release-notes/v2.0.0.md
+++ b/docs/release-notes/v2.0.0.md
@@ -3,9 +3,7 @@ search:
   exclude: true
 ---
 
-# Bernstein v2.0.0 - Web UI
-
-Hand-curated release notes for the v2.0.0 cut. Overrides the auto-drafter output when the tag is published.
+# v2.0.0
 
 ## Why 2.0.0
 

--- a/docs/release-notes/v2.3.1.md
+++ b/docs/release-notes/v2.3.1.md
@@ -3,7 +3,7 @@ search:
   exclude: true
 ---
 
-# v2.3.1 - Maintenance
+# v2.3.1
 
 4 commits since v2.3.0. No new features, no breaking changes. Patch release covering correctness fixes, CI hardening, and follow-up on review-bot findings deferred during the v2.3.0 cycle.
 

--- a/docs/release-notes/v2.4.0.md
+++ b/docs/release-notes/v2.4.0.md
@@ -3,7 +3,7 @@ search:
   exclude: true
 ---
 
-# v2.4.0 - Observability surfaces, single-writer run state, declarative planning gates
+# v2.4.0
 
 **Release date:** 2026-05-20
 **Commits since v2.3.1:** 33

--- a/docs/release-notes/v2.5.0.md
+++ b/docs/release-notes/v2.5.0.md
@@ -3,13 +3,13 @@ search:
   exclude: true
 ---
 
-## A note on the voice
+# v2.5.0
 
-v2.4.0 was about observability surfaces, running the four backends through one umbrella so a code-scanning regression or a coverage drop surfaces in the same table as a GlitchTip spike. v2.5.0 is the next question over: now that the orchestrator can see itself, can the hosts an operator already runs see it too. And can it stop quietly phoning home to my private infrastructure when it does.
+v2.4.0 was about observability surfaces, running the four backends through one umbrella so a code-scanning regression or a coverage drop surfaces in the same table as a GlitchTip spike. v2.5.0 is the next question over: now that the orchestrator can see itself, can the hosts an operator already runs see it too. And can it stop quietly phoning home to the maintainer's private infrastructure when it does.
 
-## Interop, finally
+## Interop
 
-The piece that kept blocking me on multi-host runs was the lack of a real handshake. Claude Desktop is one process, Claude Code is another, both can spawn agents, neither knew what the other had already decided. I shipped A2A capability cards (#1698): one process mints a signed manifest of what it can do, the other consumes it, verifies the signature against a trusted-issuer set, and refuses to delegate when the advertised policies do not meet the operator's required policies. The lineage chain rides through the same envelope so the audit trail does not break at the organisation boundary.
+The missing piece on multi-host runs was a real handshake. Claude Desktop is one process, Claude Code is another, both can spawn agents, neither knew what the other had already decided. A2A capability cards close that gap (#1698): one process mints a signed manifest of what it can do, the other consumes it, verifies the signature against a trusted-issuer set, and refuses to delegate when the advertised policies do not meet the operator's required policies. The lineage chain rides through the same envelope so the audit trail does not break at the organisation boundary.
 
 The MCP client got the matching upgrade (#1692). Upstream servers will return malformed responses, hang mid-stream, demand re-auth, lie about their capability manifest. The client now treats every upstream as untrusted: capability-card validation before a tool call, retry-with-continuation on dropped streams, in-flight cancellation that preserves partial output, per-server cost metering, schema-violation containment that marks a misbehaving server degraded for the rest of the task. None of this is exotic; it is the brittle-real-world posture that the larger MCP ecosystem will end up needing.
 
@@ -21,11 +21,11 @@ The MCP server side got prompt-catalogue plus OAuth-2 PKCE discovery metadata (#
 
 The honest disclaimer: if a host changes its plugin spec, the per-host adapter breaks. Each adapter is small enough that a host-spec change is a one-day fix, not a re-architecture.
 
-## I removed my private infrastructure from the shipped package
+## Private infrastructure removed from the shipped package
 
 This one was a real silent bug, not a feature. The shipped wheel had two private observability hostnames baked in as defaults for the GlitchTip DSN and the telemetry endpoint. Both backends soft-fail when their env vars are unset, so the package never actually reached out without consent. But the hostnames were sitting there as defaults, which is the kind of thing that turns into a real leak the day someone wires a config they did not read.
 
-#1694 strips those defaults. `tests/unit/observability/test_no_hardcoded_infra.py` asserts zero operator-private host, IP, or DSN matches in `src/` and will fail the build if a future change reintroduces one. Telemetry side-channel is now portable across hosts behind one Sentry-compatible `BERNSTEIN_TELEMETRY_DSN` (#1691) so each operator runs against their own backend, not mine.
+#1694 strips those defaults. `tests/unit/observability/test_no_hardcoded_infra.py` asserts zero operator-private host, IP, or DSN matches in `src/` and will fail the build if a future change reintroduces one. Telemetry side-channel is now portable across hosts behind one Sentry-compatible `BERNSTEIN_TELEMETRY_DSN` (#1691) so each operator runs against their own backend, not the maintainer's.
 
 ## Deterministic replay
 
@@ -35,7 +35,7 @@ Three small things compounded. Session ids are bound deterministically (#1684) s
 
 The `TaskCreate.scope` and `complexity` fields were typed as plain `str` with only a length cap. An empty or out-of-range value passed pydantic and then raised `ValueError` deep in the task store when the enum was constructed, surfacing as an unhandled 500 on `POST /tasks` and `POST /tasks/batch`. Schemathesis kept flagging it intermittently and everyone kept rerunning it as a flake. It was not a flake. #1700 validates at the request boundary and returns 422.
 
-## What I am not claiming
+## What this release does not claim
 
 The two new transports are functional but not load-tested at adversarial scale; the OAuth-2 PKCE discovery surface ships metadata, full token issuance and OIDC federation are deferred to a follow-up. The substrate adapters cover seven hosts; Codex and Gemini CLI are stubbed by design until their respective plugin specs stabilise. The A2A integration honours the protocol as specified at the time of pickup and will need maintenance as the spec evolves.
 
@@ -47,4 +47,4 @@ bernstein interop a2a card --output card.json
 bernstein desktop-register --host cursor
 ```
 
-Full per-PR notes in `docs/release-notes/v2.5.0.md`. Source: https://github.com/sipyourdrink-ltd/bernstein (Apache-2.0). 22 commits since v2.4.0.
+22 commits since v2.4.0.

--- a/docs/release-notes/v2.5.1.md
+++ b/docs/release-notes/v2.5.1.md
@@ -3,9 +3,11 @@ search:
   exclude: true
 ---
 
+# v2.5.1
+
 ## Why this patch exists at all
 
-I noticed something weird about the version cadence: every release since v2.0.1 was a minor bump cut by hand. v2.0.1 was the last automatic patch, four days ago. After that, five separate fix commits landed on main and none of them triggered the patch publish that normally runs on every CI-green push.
+Something was off about the version cadence: every release since v2.0.1 was a minor bump cut by hand. v2.0.1 was the last automatic patch, four days ago. After that, five separate fix commits landed on main and none of them triggered the patch publish that normally runs on every CI-green push.
 
 That is a real outage of the release pipeline, not a stylistic choice. This patch is the catch-up.
 
@@ -31,7 +33,7 @@ Five fix PRs that should have been patch publishes one by one:
 
 - `fix(api)` (#1727) caught what looked like a Schemathesis flake and was actually a real intermittent 500. `TaskCreate.scope` and `complexity` were typed plain `str` with a length cap only. An empty or out-of-range value passed pydantic and then raised `ValueError` deep in the task store when `Scope(value)` / `Complexity(value)` constructed the enum. Schemathesis hit it only on the unlucky inputs, so everyone kept rerunning the job. The fix validates at the request boundary and returns 422. Same PR also caps `GET /tasks` at 500 on the legacy unparameterised path (the unpaginated response had no upper limit) and pushes the `claim_batch` tenant check inside the store lock to close the prior TOCTOU between authz and claim.
 
-## What I am not claiming
+## What this patch does not claim
 
 The dispatcher fix is the minimum to get the chain firing again; the longer term answer is to convert the secrets-block pass into a `vars.*`-gated conditional so an undefined optional secret on the calling side cannot silently break the entire downstream pipeline. That hardening is a separate PR.
 
@@ -47,4 +49,4 @@ If you want Tier-3 OpenRouter shadow mode (#1715) to actually run, define `OPENR
 pipx install --upgrade bernstein
 ```
 
-Source: https://github.com/sipyourdrink-ltd/bernstein (Apache-2.0). Full per-PR notes in `docs/release-notes/v2.5.1.md`. 6 commits on main since v2.5.0.
+6 commits on main since v2.5.0.

--- a/docs/release-notes/v3.0.0.md
+++ b/docs/release-notes/v3.0.0.md
@@ -5,9 +5,8 @@ Released 2026-07-06.
 A verifiability release. Every major surface in this line ships its primary
 artifact as a proof: a signed lineage receipt, an HMAC-chained journal entry, a
 content-addressed record, or a deterministic projection that two operators can
-recompute to the same bytes. The features are not "capability plus an audit
-log" bolted together; the audit substrate is the shape of the capability. Strip
-the chain and the feature loses its meaning, not just its logging.
+recompute to the same bytes. In each case the receipt is the deliverable
+itself, not a log kept beside it.
 
 ## Substrate
 

--- a/docs/release-notes/v3.4.0.md
+++ b/docs/release-notes/v3.4.0.md
@@ -2,13 +2,12 @@
 
 Released 2026-07-12.
 
-A feature release built around one idea: the artefact an operator sees is
-itself the verifiable receipt. Typed activity records, detached runs,
-tournament selection, cost-aware dispatch, in-process gates, a spec-to-graph
-pipeline, workload identity, an MCP Tasks surface, a receipt-backed update
-path, and the run review board all land as signed, replayable records rather
-than logs beside the work. Windows parity coverage and the MCP registry OCI
-packaging fix round out the release.
+A feature release. Typed activity records, detached runs, tournament
+selection, cost-aware dispatch, in-process gates, a spec-to-graph pipeline,
+workload identity, an MCP Tasks surface, a receipt-backed update path, and
+the run review board all land as signed, replayable records that verify
+offline. Windows parity coverage and the MCP registry OCI packaging fix
+round out the release.
 
 A few extra-large items shipped a complete first phase with documented
 follow-ups; each section below says what landed and what is deferred.

--- a/docs/release-notes/v3.7.0.md
+++ b/docs/release-notes/v3.7.0.md
@@ -2,9 +2,7 @@
 
 Released 2026-07-17.
 
-## Theme
-
-v3.7.0 opens the orchestrator beyond coding agents and turns its determinism and audit chain into standard, independently verifiable receipts. The through-line: any agent, any artifact, and every result provable offline.
+v3.7.0 opens the orchestrator beyond coding agents and turns its determinism and audit chain into standard, independently verifiable receipts. Any agent, any artifact, and every result provable offline.
 
 ## Highlights
 


### PR DESCRIPTION
# User description
A style-only pass over the historical release documents under docs/release-notes/.

What changed:
- H1 headings normalized to the bare version tag; the two pages that had no H1 (v2.5.0, v2.5.1) get one.
- One leftover drafting note removed (v2.0.0), and two pointer lines that referenced the page they sit in removed (v2.5.0, v2.5.1).
- Openers, closers, and section headers tightened in eight pages. Every issue/PR reference, number, command name, and behavioural claim is unchanged in meaning.

These are historical documents: claims describe the releases they shipped with and are intentionally unchanged; no behavioural statements were added or removed.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Normalize historical release-note headings and remove redundant drafting or self-referential text across the release-note documents. Tighten introductory and closing prose while preserving all release claims, references, commands, and behavioral meaning.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3557?tool=ast&topic=Heading+consistency>Heading consistency</a>
        </td><td>Normalize H1 headings across release-note documents, adding missing version headings and simplifying existing titles to bare version tags.<details><summary>Modified files (5)</summary><ul><li>docs/release-notes/v2.0.0.md</li>
<li>docs/release-notes/v2.3.1.md</li>
<li>docs/release-notes/v2.4.0.md</li>
<li>docs/release-notes/v2.5.0.md</li>
<li>docs/release-notes/v2.5.1.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>docs: consistency and ...</td><td>August 10, 2026</td></tr>
<tr><td>chernistry</td><td>chore: remove unrefere...</td><td>July 25, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3557?tool=ast&topic=Prose+cleanup>Prose cleanup</a>
        </td><td>Tighten release-note prose by removing drafting and self-referential lines and refining section introductions, claims, and closers without changing their meaning.<details><summary>Modified files (6)</summary><ul><li>docs/release-notes/v2.0.0.md</li>
<li>docs/release-notes/v2.5.0.md</li>
<li>docs/release-notes/v2.5.1.md</li>
<li>docs/release-notes/v3.0.0.md</li>
<li>docs/release-notes/v3.4.0.md</li>
<li>docs/release-notes/v3.7.0.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>docs: consistency and ...</td><td>August 10, 2026</td></tr>
<tr><td>chernistry</td><td>docs: navigation restr...</td><td>July 17, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3557?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>