### PR TITLE
docs: accuracy pass over README, translations, and CLI help text

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -32,8 +32,8 @@ keywords:
   - gemini-cli
   - aider
   - software-engineering
-version: "3.10.0"
-date-released: "2026-07-26"
+version: "3.14.159"
+date-released: "2026-08-10"
 preferred-citation:
   type: software
   title: "Bernstein: a deterministic Python orchestrator for CLI coding agents"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 [![CodeQL](https://github.com/sipyourdrink-ltd/bernstein/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/sipyourdrink-ltd/bernstein/actions/workflows/codeql.yml)
 [![Open in Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sipyourdrink-ltd/bernstein?quickstart=1)
 [![MCP Toplist](https://mcptoplist.com/badge/io.github.sipyourdrink-ltd%2Fbernstein.svg)](https://mcptoplist.com/server/io.github.sipyourdrink-ltd%2Fbernstein)
+<a href="https://deepwiki.com/sipyourdrink-ltd/bernstein"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
 
 [website](https://bernstein.run) &middot; [docs](https://bernstein.readthedocs.io/) &middot; [install](https://bernstein.readthedocs.io/en/latest/getting-started/install/) &middot; [first run](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/getting-started/first-run.md) &middot; [glossary](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/GLOSSARY.md) &middot; [limitations](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/KNOWN_LIMITATIONS.md) &middot; [name policy](https://github.com/sipyourdrink-ltd/bernstein/blob/main/TRADEMARKS.md) &middot; [sponsor](https://github.com/sponsors/chernistry)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 <br>
 
-> *"To achieve great things, two things are needed: a plan and not quite enough time."* - [Sometimes](https://quoteinvestigator.com/2020/08/19/plan-time/) attributed to Leonard Bernstein
+> *"To achieve great things, two things are needed: a plan and not quite enough time."* - [attributed to](https://quoteinvestigator.com/2020/08/19/plan-time/) Leonard Bernstein
 
 ### deterministic multi-agent CLI orchestration
 
@@ -26,7 +26,7 @@
 [![Open in Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sipyourdrink-ltd/bernstein?quickstart=1)
 [![MCP Toplist](https://mcptoplist.com/badge/io.github.sipyourdrink-ltd%2Fbernstein.svg)](https://mcptoplist.com/server/io.github.sipyourdrink-ltd%2Fbernstein)
 
-[website](https://bernstein.run) &middot; [docs](https://bernstein.readthedocs.io/) &middot; [install](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/getting-started/install.md) &middot; [first run](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/getting-started/first-run.md) &middot; [glossary](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/GLOSSARY.md) &middot; [limitations](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/KNOWN_LIMITATIONS.md) &middot; [name policy](https://github.com/sipyourdrink-ltd/bernstein/blob/main/TRADEMARKS.md) &middot; [sponsor](https://github.com/sponsors/chernistry)
+[website](https://bernstein.run) &middot; [docs](https://bernstein.readthedocs.io/) &middot; [install](https://bernstein.readthedocs.io/en/latest/getting-started/install/) &middot; [first run](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/getting-started/first-run.md) &middot; [glossary](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/GLOSSARY.md) &middot; [limitations](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/KNOWN_LIMITATIONS.md) &middot; [name policy](https://github.com/sipyourdrink-ltd/bernstein/blob/main/TRADEMARKS.md) &middot; [sponsor](https://github.com/sponsors/chernistry)
 
 [简体中文](https://github.com/sipyourdrink-ltd/bernstein/blob/main/README.zh-Hans.md) &middot; [繁體中文](https://github.com/sipyourdrink-ltd/bernstein/blob/main/README.zh-TW.md)
 
@@ -43,8 +43,8 @@ Bernstein is a deterministic orchestrator for CLI coding agents (Claude Code, Co
 Four things set it apart; everything after is detail.
 
 - **No LLM in the coordination loop.** Scheduling is plain Python, so a run is reproducible end to end. Replay yesterday's plan and get yesterday's task graph.
-- **Checkable after the fact.** The lineage spine and replay journal record every run; the opt-in audit chain adds receipts you verify offline. Non-determinism surfaces as a hash mismatch at the exact step, not a flaky re-run. Non-code deliverables get the same treatment: a task can declare an artifact contract (report, dataset, action log, ops result) on a plan step, a backlog entry, or the task CLI and complete on a signed lineage receipt instead of a git commit.
-- **Isolated by construction.** Each coding task gets its own git worktree behind merge gates; artifact-mode tasks get working-directory separation under `.sdd/workspaces/`. Under this default isolation there is no shared mutable state between agents; filesystem enforcement beyond that separation is opt-in, from the [sandbox backends](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/architecture/sandbox.md) (disabling worktrees runs every task in the shared checkout).
+- **Checkable after the fact.** The replay journal records every run, and the always-on lineage spine records every lineage-bearing step; the opt-in audit chain adds receipts you verify offline. Non-determinism surfaces as a hash mismatch at the exact step, not a flaky re-run. Non-code deliverables get the same treatment: a task can declare an artifact contract (report, dataset, action log, ops result) on a plan step, a backlog entry, or the task CLI and complete on a signed lineage receipt instead of a git commit.
+- **Isolated by construction.** Each coding task gets its own git worktree behind merge gates; artifact-mode tasks get working-directory separation under `.sdd/workspaces/`. Under this default isolation agents share no mutable workspace; coordination state (the task backlog) is shared and claimed atomically. Filesystem enforcement beyond that separation is opt-in, from the [sandbox backends](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/architecture/sandbox.md) (disabling worktrees runs every task in the shared checkout).
 - **Broad and local.** 40+ CLI agent adapters plus a generic `--prompt` wrapper, file-based state, no SaaS hop, no third-party data plane.
 
 The full list is on the [capabilities page](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/capabilities.md); the [feature matrix](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/FEATURE_MATRIX.md) is the exhaustive index.
@@ -52,29 +52,30 @@ The full list is on the [capabilities page](https://github.com/sipyourdrink-ltd/
 ### install in 30 seconds
 
 ```bash
-pipx install bernstein
+uv tool install bernstein    # or: pipx install bernstein
 bernstein init
+bernstein doctor             # checks a CLI agent is installed and authenticated
 bernstein -g "fix the failing test in tests/test_foo.py"
 ```
 
-pip, uv, brew, dnf, npm, Docker, and the air-gapped wheelhouse are covered in the [install guide](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/getting-started/install.md).
+pipx, pip, brew, dnf, npm, and Docker are covered in the [install guide](https://bernstein.readthedocs.io/en/latest/getting-started/install/); the air-gapped wheelhouse has its own [air-gap guide](https://bernstein.readthedocs.io/en/latest/installation/air-gap/).
 
-<img alt="A real bernstein demo run: mock agents fix four seeded bugs in parallel worktrees, ending on the run's signed receipt verifying offline" src="https://raw.githubusercontent.com/sipyourdrink-ltd/bernstein/main/docs/assets/demo-run/demo.gif" width="820">
+<img alt="A real bernstein demo run: mock agents fix four seeded bugs, ending on the run's signed receipt verifying offline" src="https://raw.githubusercontent.com/sipyourdrink-ltd/bernstein/main/docs/assets/demo-run/demo.gif" width="820">
 
-The recording above is a real run, and it ships with its own proof: the cast, the signed run receipt that exact run produced, and the public key that pins it live together in [`docs/assets/demo-run/`](https://github.com/sipyourdrink-ltd/bernstein/tree/main/docs/assets/demo-run). Verify the run you just watched, offline:
+The recording above is a real run, and it ships with its own proof: the cast, the signed run receipt derived from that run's journal, and the public key that pins it live together in [`docs/assets/demo-run/`](https://github.com/sipyourdrink-ltd/bernstein/tree/main/docs/assets/demo-run). Verify the run you just watched, offline:
 
 ```bash
 bernstein verify receipt docs/assets/demo-run/run-receipt.json \
     --public-key docs/assets/demo-run/run-receipt.pub.pem
 ```
 
-CI re-verifies the committed receipt on every push — and proves a tampered copy fails — so the published evidence cannot rot into a decorative file. `scripts/record_demo.sh` regenerates the recording, receipt, and key from a fresh real run; nothing inside the terminal is synthesised.
+CI re-verifies the committed receipt on every push to main — and proves a tampered copy fails — so the published evidence cannot rot into a decorative file. `scripts/record_demo.sh` regenerates the recording, receipt, and key from a fresh real run; nothing inside the terminal is synthesised.
 
 A run in flight is watchable from either operator surface. Both read the same task API, so neither is a lagging mirror of the other.
 
-| ![A three-column terminal dashboard: agents with their live logs on the left, the task board on the right, an activity feed and a cost line underneath](https://raw.githubusercontent.com/sipyourdrink-ltd/bernstein/main/docs/assets/tui-agents.png) | ![A browser dashboard listing sixty-two tasks with eleven running, one of them opened to its working-tree diff](https://raw.githubusercontent.com/sipyourdrink-ltd/bernstein/main/docs/assets/webui-agents-diffs.png) |
+| ![A two-column terminal dashboard - agents with their live logs on the left, the task board on the right - with a full-width activity feed and a cost line underneath](https://raw.githubusercontent.com/sipyourdrink-ltd/bernstein/main/docs/assets/tui-agents.png) | ![A browser dashboard listing sixty-two tasks with eleven running, one of them opened to its working-tree diff](https://raw.githubusercontent.com/sipyourdrink-ltd/bernstein/main/docs/assets/webui-agents-diffs.png) |
 |:---:|:---:|
-| `bernstein live` — the terminal dashboard | `bernstein gui serve` — the same run in a browser |
+| `bernstein live` — the terminal dashboard | `bernstein gui serve` — the browser dashboard |
 
 ### prove a run
 
@@ -92,9 +93,9 @@ bernstein verify run <run_id> --signing-key-path key.pem   # sign one portable r
 bernstein verify receipt .sdd/runs/<run_id>/run-receipt.json  # verify it offline: file only
 ```
 
-The journal and the lineage spine are written on every run. `bernstein audit verify` only has a chain to check when the run was started with `BERNSTEIN_AUDIT=1`, a compliance preset, or `bernstein run --audit`. The `--audit` flag belongs to `bernstein run`; on the `bernstein -g` form above, set the environment variable.
+The journal is written on every run; the lineage spine is always on and gains an entry for each lineage-bearing step, so a short run can finish with a valid, empty spine. `bernstein audit verify` only has a chain to check when the run was started with `BERNSTEIN_AUDIT=1`, a compliance preset, or `bernstein run --audit`. The `--audit` flag belongs to `bernstein run`; on the `bernstein -g` form above, set the environment variable.
 
-The run receipt binds the journal head and the lineage-spine head (plus, opt-in, an audit-chain range) under one Ed25519-signed subject with the public key embedded, so a reviewer holding the file and the operator's public key can confirm the recorded actions are exactly what executed - no HMAC key, no live `.sdd/`, exit `2` naming the first divergent step on tamper. With the file alone (no `--public-key` pin) the check is integrity-only: it proves the receipt is internally consistent, not who signed it, and the verdict says so. Details in [deterministic replay](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/operations/deterministic-replay.md#signed-run-receipt-one-file-offline-verification).
+The run receipt binds the journal head - and the lineage-spine head when the run wrote spine entries - plus, opt-in, an audit-chain range, under one Ed25519-signed subject with the public key embedded, so a reviewer holding the file and the operator's public key can confirm the recorded actions are exactly what executed - no HMAC key, no live `.sdd/`, exit `2` naming the first divergent step on tamper. With the file alone (no `--public-key` pin) the check is integrity-only: it proves the receipt is internally consistent, not who signed it, and the verdict says so. Details in [deterministic replay](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/operations/deterministic-replay.md#signed-run-receipt-one-file-offline-verification).
 
 The same checkability applies to evaluation numbers: `bernstein bench run <suite> --reliability k` (also spelled `bernstein eval --reliability k`) runs every task `k` times under fixed coordination and reports a `pass^k` floor (all `k` attempts must pass) alongside the `pass@1` ceiling, sealed in a signed receipt that `bernstein bench reliability-verify` recomputes offline — a fabricated floor fails verification. Details: [pass^k reliability floor](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/eval/reliability.md).
 
@@ -113,7 +114,7 @@ Why the scheduler is plain Python, and what that trades away: [why deterministic
 
 ```bash
 cd your-project
-bernstein init                    # creates .sdd/ workspace + bernstein.yaml
+bernstein init                    # creates .sdd/ workspace, bernstein.yaml + templates/
 bernstein -g "Add rate limiting"  # agents spawn, work in parallel, verify, exit
 bernstein live                    # watch progress in the TUI dashboard
 bernstein run plan.yaml           # multi-stage plan: skip LLM planning, execute directly
@@ -126,7 +127,7 @@ Repository hygiene gates: `bernstein readme-l10n verify` fails a PR whose transl
 
 ### supported agents
 
-Claude Code, Codex CLI, Gemini CLI, GitHub Copilot CLI, Cursor, Aider, Goose, Muse Code, OpenAI Agents SDK, Amp, Cody, Continue, Devin Terminal, Junie, Kilo, Kiro, AWS Q Developer, Ollama, OpenCode, OpenHands, Open Interpreter, gptme, Plandex, AIChat, Letta Code, Qwen, and more. The [adapter index](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/adapters/index.md) carries install commands for 30 of them; `bernstein integrations list` enumerates all 51 wired-in adapters from the registry in `src/bernstein/adapters/registry.py`, which is the single source of truth for what resolves; `src/bernstein/adapters/use_cases.py` carries the end-user copy for each one. Anything else with a `--prompt` flag works through the generic wrapper.
+Claude Code, Codex CLI, Gemini CLI, GitHub Copilot CLI, Cursor, Aider, Goose, Muse Code, OpenAI Agents SDK, Amp, Cody, Continue, Devin Terminal, Junie, Kilo, Kiro, AWS Q Developer, Ollama, OpenCode, OpenHands, Open Interpreter, gptme, Plandex, AIChat, Letta Code, Qwen, and more. The [adapter index](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/adapters/index.md) carries install commands for 30 of them; `bernstein integrations list` enumerates all 51 wired-in integrations from the registry in `src/bernstein/adapters/registry.py`, which is the single source of truth for what resolves - 49 of them are selectable agent adapters, the other two rows being the `mock` test stub and the `self-hosted-endpoints` endpoint profile; `src/bernstein/adapters/use_cases.py` carries the end-user copy for each one. Anything else with a `--prompt` flag works through the generic wrapper.
 
 Mix agents in the same run: cheap local models for boilerplate, heavier cloud models for architecture. `bernstein integrations list --installed` shows what is available on your machine.
 
@@ -134,7 +135,7 @@ Mix agents in the same run: cheap local models for boilerplate, heavier cloud mo
 
 Everything deep lives on the [docs site](https://bernstein.readthedocs.io/):
 
-| | |
+| page | what it covers |
 |---|---|
 | [capabilities](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/capabilities.md) | the full capability list: MCP server mode, signed agent cards, sandbox backends, artifact sinks, regulatory mappings |
 | [who this is for](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/use-cases.md) | where the value lands, and where Bernstein is the wrong tool |
@@ -147,13 +148,13 @@ Everything deep lives on the [docs site](https://bernstein.readthedocs.io/):
 
 ### why the name?
 
-Bernstein is named after Leonard Bernstein, the American conductor and composer. The project orchestrates a crew of CLI coding agents the way Bernstein conducted the New York Philharmonic: every player on cue, the score deterministic, the conductor accountable for the result. He is the original orchestrator the project takes its name from.
+Bernstein is named after Leonard Bernstein, the American conductor and composer. The project orchestrates a crew of CLI coding agents the way Bernstein conducted the New York Philharmonic: every player on cue, the score deterministic, the conductor accountable for the result.
 
 i wrote bernstein because i was paying $400/month in claude bills running three coding agents in parallel and getting nondeterministic merges. Apache 2.0, solo maintained. Live stats: [bernstein.run](https://bernstein.run).
 
 ### mentioned in
 
-Listed in [vinta/awesome-python](https://github.com/vinta/awesome-python), covered in Augment Code's [open-source agent orchestrators](https://www.augmentcode.com/tools/open-source-agent-orchestrators) roundup, cited by [awesome-agentic-patterns](https://github.com/nibzard/awesome-agentic-patterns/blob/main/patterns/deterministic-zero-llm-orchestration.md) as the production implementation of deterministic zero-LLM orchestration, featured in [Python Weekly #742](https://www.pythonweekly.com/p/python-weekly-issue-742-april-23-2026), and ranked as the orchestration layer in a ten-repo [Claude Code agent-system breakdown](https://x.com/Granite0x/status/2080665298609328201).
+Listed in [vinta/awesome-python](https://github.com/vinta/awesome-python), covered in Augment Code's [open-source agent orchestrators](https://www.augmentcode.com/tools/open-source-agent-orchestrators) roundup, and listed in [Python Weekly #742](https://www.pythonweekly.com/p/python-weekly-issue-742-april-23-2026). We also wrote up the approach as the [deterministic zero-LLM orchestration](https://github.com/nibzard/awesome-agentic-patterns/blob/main/patterns/deterministic-zero-llm-orchestration.md) pattern in awesome-agentic-patterns.
 
 <details>
 <summary>All coverage: 20+ awesome lists, directories, newsletters, and peer citations</summary>

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -12,10 +12,10 @@
 
 <br>
 
-> *"To achieve great things, two things are needed: a plan and not quite enough time."* - [Sometimes](https://quoteinvestigator.com/2020/08/19/plan-time/) attributed to Leonard Bernstein
+> *"To achieve great things, two things are needed: a plan and not quite enough time."* - [attributed to](https://quoteinvestigator.com/2020/08/19/plan-time/) Leonard Bernstein
 
 ### 确定性多智能体 CLI 编排
-<!-- l10n: en="deterministic multi-agent CLI orchestration" hash="sha256:71266dcc2820" -->
+<!-- l10n: en="deterministic multi-agent CLI orchestration" hash="sha256:b457a1e014b8" -->
 
 [![CI](https://github.com/sipyourdrink-ltd/bernstein/actions/workflows/ci.yml/badge.svg)](https://github.com/sipyourdrink-ltd/bernstein/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/bernstein)](https://pypi.org/project/bernstein/)
@@ -27,7 +27,7 @@
 [![Open in Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sipyourdrink-ltd/bernstein?quickstart=1)
 [![MCP Toplist](https://mcptoplist.com/badge/io.github.sipyourdrink-ltd%2Fbernstein.svg)](https://mcptoplist.com/server/io.github.sipyourdrink-ltd%2Fbernstein)
 
-[website](https://bernstein.run) &middot; [docs](https://bernstein.readthedocs.io/) &middot; [install](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/getting-started/install.md) &middot; [first run](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/getting-started/first-run.md) &middot; [glossary](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/GLOSSARY.md) &middot; [limitations](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/KNOWN_LIMITATIONS.md) &middot; [name policy](https://github.com/sipyourdrink-ltd/bernstein/blob/main/TRADEMARKS.md) &middot; [sponsor](https://github.com/sponsors/chernistry)
+[website](https://bernstein.run) &middot; [docs](https://bernstein.readthedocs.io/) &middot; [install](https://bernstein.readthedocs.io/en/latest/getting-started/install/) &middot; [first run](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/getting-started/first-run.md) &middot; [glossary](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/GLOSSARY.md) &middot; [limitations](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/KNOWN_LIMITATIONS.md) &middot; [name policy](https://github.com/sipyourdrink-ltd/bernstein/blob/main/TRADEMARKS.md) &middot; [sponsor](https://github.com/sponsors/chernistry)
 
 [简体中文](https://github.com/sipyourdrink-ltd/bernstein/blob/main/README.zh-Hans.md) &middot; [繁體中文](https://github.com/sipyourdrink-ltd/bernstein/blob/main/README.zh-TW.md)
 
@@ -40,47 +40,48 @@
 Bernstein 是一个面向 CLI 编码智能体（Claude Code、Codex、Gemini CLI 以及 40 多个其他智能体）的确定性编排器。调度是纯 Python——协调循环中没有 LLM——因此运行可以端到端复现。每个编码任务都在自己的 git worktree 中运行，背后有 lint/type/test 门禁；产物模式（artifact-mode）任务以签署的血统收据（lineage receipt）而非提交来宣告完成，获得一个普通的工作目录。结果事后仍可核查：常驻的血统脊柱（lineage spine）和回放日志（replay journal），外加可选的 HMAC 链式审计日志（`BERNSTEIN_AUDIT=1`），其收据可离线验证。包含离线安装（air-gap）配置。Apache-2.0 许可。
 
 ### 一览
-<!-- l10n: en="at a glance" hash="sha256:bfd131192bf6" -->
+<!-- l10n: en="at a glance" hash="sha256:07445a1bace1" -->
 
 有四件事让它与众不同；其余都是细节。
 
 - **协调循环中没有 LLM。** 调度是纯 Python，因此运行可以端到端复现。重放昨天的计划，得到昨天的任务图。
-- **事后可核查。** 血统脊柱和回放日志记录每一次运行；可选的审计链增加了可离线验证的收据。不确定性会在精确步骤处以哈希失配的形式浮出水面，而不是一次偶发的重跑。非代码交付物也享受同样待遇：任务可以在计划步骤、积压条目或任务 CLI 上声明产物契约（报告、数据集、动作日志、运维结果），并以签署的血统收据而非 git 提交来宣告完成。
-- **构造上即隔离。** 每个编码任务在合并门禁之后获得自己的 git worktree；产物模式任务在 `.sdd/workspaces/` 下获得工作目录隔离。在这种默认隔离下，智能体之间没有共享的可变状态；超出该隔离的文件系统强制是可选的，来自[沙箱后端](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/architecture/sandbox.md)（禁用 worktree 会在共享检出中运行每个任务）。
+- **事后可核查。** 回放日志记录每一次运行，常驻的血统脊柱记录每个产生血统的步骤；可选的审计链增加了可离线验证的收据。不确定性会在精确步骤处以哈希失配的形式浮出水面，而不是一次偶发的重跑。非代码交付物也享受同样待遇：任务可以在计划步骤、积压条目或任务 CLI 上声明产物契约（报告、数据集、动作日志、运维结果），并以签署的血统收据而非 git 提交来宣告完成。
+- **构造上即隔离。** 每个编码任务在合并门禁之后获得自己的 git worktree；产物模式任务在 `.sdd/workspaces/` 下获得工作目录隔离。在这种默认隔离下，智能体之间不共享可变的工作区；协调状态（任务积压）是共享的，并以原子方式认领。超出该隔离的文件系统强制是可选的，来自[沙箱后端](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/architecture/sandbox.md)（禁用 worktree 会在共享检出中运行每个任务）。
 - **广泛且本地。** 40 多个 CLI 智能体适配器，外加通用的 `--prompt` 包装器、基于文件的状态、无 SaaS 跳转、无第三方数据平面。
 
 完整列表见[能力页面](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/capabilities.md)；[功能矩阵](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/FEATURE_MATRIX.md)是详尽的索引。
 
 ### 30 秒安装
-<!-- l10n: en="install in 30 seconds" hash="sha256:30f872dea647" -->
+<!-- l10n: en="install in 30 seconds" hash="sha256:2290842df4d0" -->
 
 ```bash
-pipx install bernstein
+uv tool install bernstein    # or: pipx install bernstein
 bernstein init
+bernstein doctor             # checks a CLI agent is installed and authenticated
 bernstein -g "fix the failing test in tests/test_foo.py"
 ```
 
-pip、uv、brew、dnf、npm、Docker 以及离线 wheelhouse 都涵盖在[安装指南](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/getting-started/install.md)中。
+pipx、pip、brew、dnf、npm 和 Docker 都涵盖在[安装指南](https://bernstein.readthedocs.io/en/latest/getting-started/install/)中；离线 wheelhouse 有单独的 [air-gap 指南](https://bernstein.readthedocs.io/en/latest/installation/air-gap/)。
 
-<img alt="A real bernstein demo run: mock agents fix four seeded bugs in parallel worktrees, ending on the run's signed receipt verifying offline" src="https://raw.githubusercontent.com/sipyourdrink-ltd/bernstein/main/docs/assets/demo-run/demo.gif" width="820">
+<img alt="A real bernstein demo run: mock agents fix four seeded bugs, ending on the run's signed receipt verifying offline" src="https://raw.githubusercontent.com/sipyourdrink-ltd/bernstein/main/docs/assets/demo-run/demo.gif" width="820">
 
-上面的录像是真实运行，并且自带证明：录制文件、那次精确运行产生的签署运行收据，以及将其钉死的公钥，一起存放在 [`docs/assets/demo-run/`](https://github.com/sipyourdrink-ltd/bernstein/tree/main/docs/assets/demo-run) 中。离线验证你刚看到的运行：
+上面的录像是真实运行，并且自带证明：录制文件、从那次运行的日志导出的签署运行收据，以及将其钉死的公钥，一起存放在 [`docs/assets/demo-run/`](https://github.com/sipyourdrink-ltd/bernstein/tree/main/docs/assets/demo-run) 中。离线验证你刚看到的运行：
 
 ```bash
 bernstein verify receipt docs/assets/demo-run/run-receipt.json \
     --public-key docs/assets/demo-run/run-receipt.pub.pem
 ```
 
-CI 在每次推送时重新验证已提交的收据——并证明被篡改的副本会失败——因此已发布的证据不会腐烂成装饰性文件。`scripts/record_demo.sh` 从一次全新的真实运行重新生成录制、收据和密钥；终端里没有任何内容是合成的。
+CI 在每次推送到 main 时重新验证已提交的收据——并证明被篡改的副本会失败——因此已发布的证据不会腐烂成装饰性文件。`scripts/record_demo.sh` 从一次全新的真实运行重新生成录制、收据和密钥；终端里没有任何内容是合成的。
 
 运行中的任务可从任一操作界面观看。两者读取同一个任务 API，因此彼此都不是对方的滞后镜像。
 
-| ![A three-column terminal dashboard: agents with their live logs on the left, the task board on the right, an activity feed and a cost line underneath](https://raw.githubusercontent.com/sipyourdrink-ltd/bernstein/main/docs/assets/tui-agents.png) | ![A browser dashboard listing sixty-two tasks with eleven running, one of them opened to its working-tree diff](https://raw.githubusercontent.com/sipyourdrink-ltd/bernstein/main/docs/assets/webui-agents-diffs.png) |
+| ![A two-column terminal dashboard - agents with their live logs on the left, the task board on the right - with a full-width activity feed and a cost line underneath](https://raw.githubusercontent.com/sipyourdrink-ltd/bernstein/main/docs/assets/tui-agents.png) | ![A browser dashboard listing sixty-two tasks with eleven running, one of them opened to its working-tree diff](https://raw.githubusercontent.com/sipyourdrink-ltd/bernstein/main/docs/assets/webui-agents-diffs.png) |
 |:---:|:---:|
-| `bernstein live` — 终端仪表盘 | `bernstein gui serve` — 浏览器中查看同一运行 |
+| `bernstein live` — 终端仪表盘 | `bernstein gui serve` — 浏览器仪表盘 |
 
 ### 证明一次运行
-<!-- l10n: en="prove a run" hash="sha256:9472ce86e140" -->
+<!-- l10n: en="prove a run" hash="sha256:84a465d512f0" -->
 
 这里的确定性是需要你去核查的东西，而不是凭空相信。启用审计运行一次，然后验证记录的内容：
 
@@ -96,9 +97,9 @@ bernstein verify run <run_id> --signing-key-path key.pem   # sign one portable r
 bernstein verify receipt .sdd/runs/<run_id>/run-receipt.json  # verify it offline: file only
 ```
 
-日志和血统脊柱在每次运行时写入。`bernstein audit verify` 只有在运行以 `BERNSTEIN_AUDIT=1`、合规预设或 `bernstein run --audit` 启动时才有链可查。`--audit` 旗标属于 `bernstein run`；在上面的 `bernstein -g` 形式中，请设置环境变量。
+日志在每次运行时写入；血统脊柱始终开启，在每个产生血统的步骤上增加一条记录，因此一次很短的运行可能以有效但为空的脊柱结束。`bernstein audit verify` 只有在运行以 `BERNSTEIN_AUDIT=1`、合规预设或 `bernstein run --audit` 启动时才有链可查。`--audit` 旗标属于 `bernstein run`；在上面的 `bernstein -g` 形式中，请设置环境变量。
 
-运行收据在一个 Ed25519 签署主体下绑定日志头部和血统脊柱头部（外加可选的审计链范围），并内嵌公钥，因此持有文件与操作者公钥的审查者可以确认记录的动作正是实际执行的动作——无需 HMAC 密钥，无需活跃的 `.sdd/`，篡改时以退出码 `2` 命名第一个分歧步骤。仅凭文件（不钉 `--public-key`）时，检查只是完整性检查：它证明收据内部自洽，而非谁签署的，结论也会如实说明。详见[确定性回放](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/operations/deterministic-replay.md#signed-run-receipt-one-file-offline-verification)。
+运行收据在一个 Ed25519 签署主体下绑定日志头部——当运行写入了脊柱条目时还绑定血统脊柱头部——外加可选的审计链范围，并内嵌公钥，因此持有文件与操作者公钥的审查者可以确认记录的动作正是实际执行的动作——无需 HMAC 密钥，无需活跃的 `.sdd/`，篡改时以退出码 `2` 命名第一个分歧步骤。仅凭文件（不钉 `--public-key`）时，检查只是完整性检查：它证明收据内部自洽，而非谁签署的，结论也会如实说明。详见[确定性回放](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/operations/deterministic-replay.md#signed-run-receipt-one-file-offline-verification)。
 
 同样的可核查性适用于评估数字：`bernstein bench run <suite> --reliability k`（也写作 `bernstein eval --reliability k`）在固定协调下把每个任务运行 `k` 次，并在签署的收据中报告 `pass^k` 下限（所有 `k` 次尝试都必须通过）以及 `pass@1` 上限，`bernstein bench reliability-verify` 可离线重算该收据——伪造的下限会验证失败。详情：[pass^k 可靠性下限](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/eval/reliability.md)。
 
@@ -115,11 +116,11 @@ bernstein verify receipt .sdd/runs/<run_id>/run-receipt.json  # verify it offlin
 调度器为什么是纯 Python，以及这换来什么代价：[为什么确定性](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/architecture/WHY_DETERMINISTIC.md)。
 
 ### 日常命令
-<!-- l10n: en="everyday commands" hash="sha256:097c6c2e0ddf" -->
+<!-- l10n: en="everyday commands" hash="sha256:b3520027ef7d" -->
 
 ```bash
 cd your-project
-bernstein init                    # creates .sdd/ workspace + bernstein.yaml
+bernstein init                    # creates .sdd/ workspace, bernstein.yaml + templates/
 bernstein -g "Add rate limiting"  # agents spawn, work in parallel, verify, exit
 bernstein live                    # watch progress in the TUI dashboard
 bernstein run plan.yaml           # multi-stage plan: skip LLM planning, execute directly
@@ -128,19 +129,21 @@ bernstein stop                    # graceful shutdown with drain
 
 完整的操作界面（PR 自动化、定时任务、聊天桥接、autofix 守护进程）见[操作命令](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/operations/commands.md)。
 
-### 支持的智能体
-<!-- l10n: en="supported agents" hash="sha256:446493547b67" -->
+仓库卫生门禁：`bernstein readme-l10n verify` 会让翻译版 README 偏离英文源的 PR 失败（并指出过期的章节），`bernstein readme-l10n sync` 在英文修改后重新绑定它们。见 [readme-l10n](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/playbooks/readme-l10n.md)。
 
-Claude Code、Codex CLI、Gemini CLI、GitHub Copilot CLI、Cursor、Aider、Goose、Muse Code、OpenAI Agents SDK、Amp、Cody、Continue、Devin Terminal、Junie、Kilo、Kiro、AWS Q Developer、Ollama、OpenCode、OpenHands、Open Interpreter、gptme、Plandex、AIChat、Letta Code、Qwen 等等。[适配器索引](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/adapters/index.md)为其中 30 个提供安装命令；`bernstein integrations list` 从 `src/bernstein/adapters/registry.py` 中的注册表枚举全部 51 个已接线适配器，该文件是"什么能解析"的唯一事实来源；`src/bernstein/adapters/use_cases.py` 为每个适配器提供面向终端用户的文案。任何带 `--prompt` 旗标的其他工具都可以通过通用包装器工作。
+### 支持的智能体
+<!-- l10n: en="supported agents" hash="sha256:aef640e2b705" -->
+
+Claude Code、Codex CLI、Gemini CLI、GitHub Copilot CLI、Cursor、Aider、Goose、Muse Code、OpenAI Agents SDK、Amp、Cody、Continue、Devin Terminal、Junie、Kilo、Kiro、AWS Q Developer、Ollama、OpenCode、OpenHands、Open Interpreter、gptme、Plandex、AIChat、Letta Code、Qwen 等等。[适配器索引](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/adapters/index.md)为其中 30 个提供安装命令；`bernstein integrations list` 从 `src/bernstein/adapters/registry.py` 中的注册表枚举全部 51 个已接线集成，该文件是"什么能解析"的唯一事实来源——其中 49 个是可选择的智能体适配器，另外两行是 `mock` 测试桩和 `self-hosted-endpoints` 端点配置；`src/bernstein/adapters/use_cases.py` 为每个适配器提供面向终端用户的文案。任何带 `--prompt` 旗标的其他工具都可以通过通用包装器工作。
 
 在同一运行中混用智能体：用便宜的本地模型处理样板，用更重的云模型处理架构。`bernstein integrations list --installed` 显示你的机器上可用的内容。
 
 ### 首页之外
-<!-- l10n: en="beyond the front page" hash="sha256:0420eb016a43" -->
+<!-- l10n: en="beyond the front page" hash="sha256:a1aa323fcf03" -->
 
 所有深入内容都在[文档站点](https://bernstein.readthedocs.io/)上：
 
-| | |
+| 页面 | 内容 |
 |---|---|
 | [capabilities](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/capabilities.md) | 完整能力列表：MCP 服务器模式、签署的智能体卡片、沙箱后端、产物存储、监管映射 |
 | [who this is for](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/use-cases.md) | 价值落在哪里，以及 Bernstein 何时是错误工具 |
@@ -152,16 +155,16 @@ Claude Code、Codex CLI、Gemini CLI、GitHub Copilot CLI、Cursor、Aider、Goo
 | [architecture](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/architecture/ARCHITECTURE.md) | 底层工作原理 |
 
 ### 为什么叫这个名字？
-<!-- l10n: en="why the name?" hash="sha256:3c98a35004a1" -->
+<!-- l10n: en="why the name?" hash="sha256:2444448b9e03" -->
 
-Bernstein 得名于美国指挥家、作曲家 Leonard Bernstein。这个项目像 Bernstein 指挥纽约爱乐乐团那样编排一支 CLI 编码智能体队伍：每个乐手准时到位，乐谱确定，指挥对结果负责。他就是这个项目名字所源自的那位原初编排者。
+Bernstein 得名于美国指挥家、作曲家 Leonard Bernstein。这个项目像 Bernstein 指挥纽约爱乐乐团那样编排一支 CLI 编码智能体队伍：每个乐手准时到位，乐谱确定，指挥对结果负责。
 
 我写 bernstein 是因为我每月为并行运行三个编码智能体支付 400 美元的 claude 账单，却得到不确定性的合并。Apache 2.0，单人维护。实时数据：[bernstein.run](https://bernstein.run)。
 
 ### 被提及的地方
-<!-- l10n: en="mentioned in" hash="sha256:e79981346792" -->
+<!-- l10n: en="mentioned in" hash="sha256:e1dfaf62cb5d" -->
 
-收录于 [vinta/awesome-python](https://github.com/vinta/awesome-python)，被 Augment Code 的[开源智能体编排器](https://www.augmentcode.com/tools/open-source-agent-orchestrators)综述提及，被 [awesome-agentic-patterns](https://github.com/nibzard/awesome-agentic-patterns/blob/main/patterns/deterministic-zero-llm-orchestration.md) 引用为确定性零 LLM 编排的生产实现，登上 [Python Weekly #742](https://www.pythonweekly.com/p/python-weekly-issue-742-april-23-2026)，并在一个十仓库的 [Claude Code 智能体系统剖析](https://x.com/Granite0x/status/2080665298609328201)中被列为编排层。
+收录于 [vinta/awesome-python](https://github.com/vinta/awesome-python)，被 Augment Code 的[开源智能体编排器](https://www.augmentcode.com/tools/open-source-agent-orchestrators)综述提及，并收录于 [Python Weekly #742](https://www.pythonweekly.com/p/python-weekly-issue-742-april-23-2026)。我们也把这一方法写成了 awesome-agentic-patterns 中的[确定性零 LLM 编排](https://github.com/nibzard/awesome-agentic-patterns/blob/main/patterns/deterministic-zero-llm-orchestration.md)模式条目。
 
 <details>
 <summary>全部覆盖：20 多个 awesome 列表、目录、通讯和同行引用</summary>

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -15,7 +15,7 @@
 > *"To achieve great things, two things are needed: a plan and not quite enough time."* - [attributed to](https://quoteinvestigator.com/2020/08/19/plan-time/) Leonard Bernstein
 
 ### 确定性多智能体 CLI 编排
-<!-- l10n: en="deterministic multi-agent CLI orchestration" hash="sha256:b457a1e014b8" -->
+<!-- l10n: en="deterministic multi-agent CLI orchestration" hash="sha256:ef82e5bfe3be" -->
 
 [![CI](https://github.com/sipyourdrink-ltd/bernstein/actions/workflows/ci.yml/badge.svg)](https://github.com/sipyourdrink-ltd/bernstein/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/bernstein)](https://pypi.org/project/bernstein/)
@@ -26,6 +26,7 @@
 [![CodeQL](https://github.com/sipyourdrink-ltd/bernstein/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/sipyourdrink-ltd/bernstein/actions/workflows/codeql.yml)
 [![Open in Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sipyourdrink-ltd/bernstein?quickstart=1)
 [![MCP Toplist](https://mcptoplist.com/badge/io.github.sipyourdrink-ltd%2Fbernstein.svg)](https://mcptoplist.com/server/io.github.sipyourdrink-ltd%2Fbernstein)
+<a href="https://deepwiki.com/sipyourdrink-ltd/bernstein"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
 
 [website](https://bernstein.run) &middot; [docs](https://bernstein.readthedocs.io/) &middot; [install](https://bernstein.readthedocs.io/en/latest/getting-started/install/) &middot; [first run](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/getting-started/first-run.md) &middot; [glossary](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/GLOSSARY.md) &middot; [limitations](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/KNOWN_LIMITATIONS.md) &middot; [name policy](https://github.com/sipyourdrink-ltd/bernstein/blob/main/TRADEMARKS.md) &middot; [sponsor](https://github.com/sponsors/chernistry)
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -15,7 +15,7 @@
 > *"To achieve great things, two things are needed: a plan and not quite enough time."* - [attributed to](https://quoteinvestigator.com/2020/08/19/plan-time/) Leonard Bernstein
 
 ### 確定性多代理 CLI 編排
-<!-- l10n: en="deterministic multi-agent CLI orchestration" hash="sha256:b457a1e014b8" -->
+<!-- l10n: en="deterministic multi-agent CLI orchestration" hash="sha256:ef82e5bfe3be" -->
 
 [![CI](https://github.com/sipyourdrink-ltd/bernstein/actions/workflows/ci.yml/badge.svg)](https://github.com/sipyourdrink-ltd/bernstein/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/bernstein)](https://pypi.org/project/bernstein/)
@@ -26,6 +26,7 @@
 [![CodeQL](https://github.com/sipyourdrink-ltd/bernstein/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/sipyourdrink-ltd/bernstein/actions/workflows/codeql.yml)
 [![Open in Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sipyourdrink-ltd/bernstein?quickstart=1)
 [![MCP Toplist](https://mcptoplist.com/badge/io.github.sipyourdrink-ltd%2Fbernstein.svg)](https://mcptoplist.com/server/io.github.sipyourdrink-ltd%2Fbernstein)
+<a href="https://deepwiki.com/sipyourdrink-ltd/bernstein"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
 
 [website](https://bernstein.run) &middot; [docs](https://bernstein.readthedocs.io/) &middot; [install](https://bernstein.readthedocs.io/en/latest/getting-started/install/) &middot; [first run](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/getting-started/first-run.md) &middot; [glossary](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/GLOSSARY.md) &middot; [limitations](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/KNOWN_LIMITATIONS.md) &middot; [name policy](https://github.com/sipyourdrink-ltd/bernstein/blob/main/TRADEMARKS.md) &middot; [sponsor](https://github.com/sponsors/chernistry)
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -12,10 +12,10 @@
 
 <br>
 
-> *"To achieve great things, two things are needed: a plan and not quite enough time."* - [Sometimes](https://quoteinvestigator.com/2020/08/19/plan-time/) attributed to Leonard Bernstein
+> *"To achieve great things, two things are needed: a plan and not quite enough time."* - [attributed to](https://quoteinvestigator.com/2020/08/19/plan-time/) Leonard Bernstein
 
 ### 確定性多代理 CLI 編排
-<!-- l10n: en="deterministic multi-agent CLI orchestration" hash="sha256:71266dcc2820" -->
+<!-- l10n: en="deterministic multi-agent CLI orchestration" hash="sha256:b457a1e014b8" -->
 
 [![CI](https://github.com/sipyourdrink-ltd/bernstein/actions/workflows/ci.yml/badge.svg)](https://github.com/sipyourdrink-ltd/bernstein/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/bernstein)](https://pypi.org/project/bernstein/)
@@ -27,7 +27,7 @@
 [![Open in Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sipyourdrink-ltd/bernstein?quickstart=1)
 [![MCP Toplist](https://mcptoplist.com/badge/io.github.sipyourdrink-ltd%2Fbernstein.svg)](https://mcptoplist.com/server/io.github.sipyourdrink-ltd%2Fbernstein)
 
-[website](https://bernstein.run) &middot; [docs](https://bernstein.readthedocs.io/) &middot; [install](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/getting-started/install.md) &middot; [first run](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/getting-started/first-run.md) &middot; [glossary](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/GLOSSARY.md) &middot; [limitations](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/KNOWN_LIMITATIONS.md) &middot; [name policy](https://github.com/sipyourdrink-ltd/bernstein/blob/main/TRADEMARKS.md) &middot; [sponsor](https://github.com/sponsors/chernistry)
+[website](https://bernstein.run) &middot; [docs](https://bernstein.readthedocs.io/) &middot; [install](https://bernstein.readthedocs.io/en/latest/getting-started/install/) &middot; [first run](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/getting-started/first-run.md) &middot; [glossary](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/GLOSSARY.md) &middot; [limitations](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/KNOWN_LIMITATIONS.md) &middot; [name policy](https://github.com/sipyourdrink-ltd/bernstein/blob/main/TRADEMARKS.md) &middot; [sponsor](https://github.com/sponsors/chernistry)
 
 [简体中文](https://github.com/sipyourdrink-ltd/bernstein/blob/main/README.zh-Hans.md) &middot; [繁體中文](https://github.com/sipyourdrink-ltd/bernstein/blob/main/README.zh-TW.md)
 
@@ -40,47 +40,48 @@
 Bernstein 是面向 CLI 編碼代理（Claude Code、Codex、Gemini CLI 以及 40 多個其他代理）的確定性編排器。排程是純 Python——協調迴圈中沒有 LLM——因此執行可以端到端重現。每個編碼任務都在自己的 git worktree 中執行，背後有 lint/type/test 門禁；產物模式（artifact-mode）任務以簽署的血統收據（lineage receipt）而非提交來宣告完成，獲得一個普通的工作目錄。結果事後仍可核查：常駐的血統脊柱（lineage spine）和重播日誌（replay journal），外加選用的 HMAC 鏈式稽核日誌（`BERNSTEIN_AUDIT=1`），其收據可離線驗證。包含離線安裝（air-gap）設定。Apache-2.0 授權。
 
 ### 一覽
-<!-- l10n: en="at a glance" hash="sha256:bfd131192bf6" -->
+<!-- l10n: en="at a glance" hash="sha256:07445a1bace1" -->
 
 有四件事讓它與眾不同；其餘都是細節。
 
 - **協調迴圈中沒有 LLM。** 排程是純 Python，因此執行可以端到端重現。重播昨天的計畫，得到昨天的任務圖。
-- **事後可核查。** 血統脊柱和重播日誌記錄每一次執行；選用的稽核鏈增加了可離線驗證的收據。不確定性會在精確步驟處以雜湊失配的形式浮出水面，而不是一次偶發的重跑。非程式碼交付物也享有同樣待遇：任務可以在計畫步驟、積壓條目或任務 CLI 上宣告產物契約（報告、資料集、動作日誌、維運結果），並以簽署的血統收據而非 git 提交來宣告完成。
-- **構造上即隔離。** 每個編碼任務在合併門禁之後獲得自己的 git worktree；產物模式任務在 `.sdd/workspaces/` 下獲得工作目錄隔離。在這種預設隔離下，代理之間沒有共享的可變狀態；超出該隔離的檔案系統強制是選用的，來自[沙箱後端](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/architecture/sandbox.md)（停用 worktree 會在共享檢出中執行每個任務）。
+- **事後可核查。** 重播日誌記錄每一次執行，常駐的血統脊柱記錄每個產生血統的步驟；選用的稽核鏈增加了可離線驗證的收據。不確定性會在精確步驟處以雜湊失配的形式浮出水面，而不是一次偶發的重跑。非程式碼交付物也享有同樣待遇：任務可以在計畫步驟、積壓條目或任務 CLI 上宣告產物契約（報告、資料集、動作日誌、維運結果），並以簽署的血統收據而非 git 提交來宣告完成。
+- **構造上即隔離。** 每個編碼任務在合併門禁之後獲得自己的 git worktree；產物模式任務在 `.sdd/workspaces/` 下獲得工作目錄隔離。在這種預設隔離下，代理之間不共享可變的工作區；協調狀態（任務積壓）是共享的，並以原子方式認領。超出該隔離的檔案系統強制是選用的，來自[沙箱後端](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/architecture/sandbox.md)（停用 worktree 會在共享檢出中執行每個任務）。
 - **廣泛且本地。** 40 多個 CLI 代理介面卡，外加通用的 `--prompt` 包裝器、基於檔案的狀態、無 SaaS 跳轉、無第三方資料平面。
 
 完整清單見[能力頁面](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/capabilities.md)；[功能矩陣](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/FEATURE_MATRIX.md)是詳盡的索引。
 
 ### 30 秒安裝
-<!-- l10n: en="install in 30 seconds" hash="sha256:30f872dea647" -->
+<!-- l10n: en="install in 30 seconds" hash="sha256:2290842df4d0" -->
 
 ```bash
-pipx install bernstein
+uv tool install bernstein    # or: pipx install bernstein
 bernstein init
+bernstein doctor             # checks a CLI agent is installed and authenticated
 bernstein -g "fix the failing test in tests/test_foo.py"
 ```
 
-pip、uv、brew、dnf、npm、Docker 以及離線 wheelhouse 都涵蓋在[安裝指南](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/getting-started/install.md)中。
+pipx、pip、brew、dnf、npm 和 Docker 都涵蓋在[安裝指南](https://bernstein.readthedocs.io/en/latest/getting-started/install/)中；離線 wheelhouse 有單獨的 [air-gap 指南](https://bernstein.readthedocs.io/en/latest/installation/air-gap/)。
 
-<img alt="A real bernstein demo run: mock agents fix four seeded bugs in parallel worktrees, ending on the run's signed receipt verifying offline" src="https://raw.githubusercontent.com/sipyourdrink-ltd/bernstein/main/docs/assets/demo-run/demo.gif" width="820">
+<img alt="A real bernstein demo run: mock agents fix four seeded bugs, ending on the run's signed receipt verifying offline" src="https://raw.githubusercontent.com/sipyourdrink-ltd/bernstein/main/docs/assets/demo-run/demo.gif" width="820">
 
-上面的錄影是真實執行，並且自帶證明：錄製檔、那次精確執行產生的簽署執行收據，以及將其釘死的公開金鑰，一起存放在 [`docs/assets/demo-run/`](https://github.com/sipyourdrink-ltd/bernstein/tree/main/docs/assets/demo-run) 中。離線驗證你剛看到的執行：
+上面的錄影是真實執行，並且自帶證明：錄製檔、從那次執行的日誌導出的簽署執行收據，以及將其釘死的公開金鑰，一起存放在 [`docs/assets/demo-run/`](https://github.com/sipyourdrink-ltd/bernstein/tree/main/docs/assets/demo-run) 中。離線驗證你剛看到的執行：
 
 ```bash
 bernstein verify receipt docs/assets/demo-run/run-receipt.json \
     --public-key docs/assets/demo-run/run-receipt.pub.pem
 ```
 
-CI 在每次推送時重新驗證已提交的收據——並證明被竄改的副本會失敗——因此已發布的證據不會腐化成裝飾性檔案。`scripts/record_demo.sh` 從一次全新的真實執行重新產生錄影、收據和金鑰；終端機裡沒有任何內容是合成的。
+CI 在每次推送到 main 時重新驗證已提交的收據——並證明被竄改的副本會失敗——因此已發布的證據不會腐化成裝飾性檔案。`scripts/record_demo.sh` 從一次全新的真實執行重新產生錄影、收據和金鑰；終端機裡沒有任何內容是合成的。
 
 執行中的任務可從任一操作介面觀看。兩者讀取同一個任務 API，因此彼此都不是對方的落後鏡像。
 
-| ![A three-column terminal dashboard: agents with their live logs on the left, the task board on the right, an activity feed and a cost line underneath](https://raw.githubusercontent.com/sipyourdrink-ltd/bernstein/main/docs/assets/tui-agents.png) | ![A browser dashboard listing sixty-two tasks with eleven running, one of them opened to its working-tree diff](https://raw.githubusercontent.com/sipyourdrink-ltd/bernstein/main/docs/assets/webui-agents-diffs.png) |
+| ![A two-column terminal dashboard - agents with their live logs on the left, the task board on the right - with a full-width activity feed and a cost line underneath](https://raw.githubusercontent.com/sipyourdrink-ltd/bernstein/main/docs/assets/tui-agents.png) | ![A browser dashboard listing sixty-two tasks with eleven running, one of them opened to its working-tree diff](https://raw.githubusercontent.com/sipyourdrink-ltd/bernstein/main/docs/assets/webui-agents-diffs.png) |
 |:---:|:---:|
-| `bernstein live` — 終端機儀表板 | `bernstein gui serve` — 在瀏覽器中查看同一執行 |
+| `bernstein live` — 終端機儀表板 | `bernstein gui serve` — 瀏覽器儀表板 |
 
 ### 證明一次執行
-<!-- l10n: en="prove a run" hash="sha256:9472ce86e140" -->
+<!-- l10n: en="prove a run" hash="sha256:84a465d512f0" -->
 
 這裡的確定性是你要去核查的東西，而不是憑空相信。啟用稽核執行一次，然後驗證記錄的內容：
 
@@ -96,9 +97,9 @@ bernstein verify run <run_id> --signing-key-path key.pem   # sign one portable r
 bernstein verify receipt .sdd/runs/<run_id>/run-receipt.json  # verify it offline: file only
 ```
 
-日誌和血統脊柱在每次執行時寫入。`bernstein audit verify` 只有在執行以 `BERNSTEIN_AUDIT=1`、合規預設或 `bernstein run --audit` 啟動時才有鏈可查。`--audit` 旗標屬於 `bernstein run`；在上面的 `bernstein -g` 形式中，請設定環境變數。
+日誌在每次執行時寫入；血統脊柱始終開啟，在每個產生血統的步驟上增加一條記錄，因此一次很短的執行可能以有效但為空的脊柱結束。`bernstein audit verify` 只有在執行以 `BERNSTEIN_AUDIT=1`、合規預設或 `bernstein run --audit` 啟動時才有鏈可查。`--audit` 旗標屬於 `bernstein run`；在上面的 `bernstein -g` 形式中，請設定環境變數。
 
-執行收據在一個 Ed25519 簽署主體下綁定日誌頭部和血統脊柱頭部（外加選用的稽核鏈範圍），並內嵌公開金鑰，因此持有檔案與操作者公開金鑰的審查者可以確認記錄的動作正是實際執行的動作——無需 HMAC 金鑰，無需活躍的 `.sdd/`，竄改時以退出碼 `2` 命名第一個分歧步驟。僅憑檔案（不釘 `--public-key`）時，檢查只是完整性檢查：它證明收據內部自洽，而非誰簽署的，結論也會如實說明。詳見[確定性重播](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/operations/deterministic-replay.md#signed-run-receipt-one-file-offline-verification)。
+執行收據在一個 Ed25519 簽署主體下綁定日誌頭部——當執行寫入了脊柱條目時還綁定血統脊柱頭部——外加選用的稽核鏈範圍，並內嵌公開金鑰，因此持有檔案與操作者公開金鑰的審查者可以確認記錄的動作正是實際執行的動作——無需 HMAC 金鑰，無需活躍的 `.sdd/`，竄改時以退出碼 `2` 命名第一個分歧步驟。僅憑檔案（不釘 `--public-key`）時，檢查只是完整性檢查：它證明收據內部自洽，而非誰簽署的，結論也會如實說明。詳見[確定性重播](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/operations/deterministic-replay.md#signed-run-receipt-one-file-offline-verification)。
 
 同樣的可核查性適用於評估數字：`bernstein bench run <suite> --reliability k`（也寫作 `bernstein eval --reliability k`）在固定協調下把每個任務執行 `k` 次，並在簽署的收據中報告 `pass^k` 下限（所有 `k` 次嘗試都必須通過）以及 `pass@1` 上限，`bernstein bench reliability-verify` 可離線重算該收據——偽造的下限會驗證失敗。詳情：[pass^k 可靠性下限](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/eval/reliability.md)。
 
@@ -115,11 +116,11 @@ bernstein verify receipt .sdd/runs/<run_id>/run-receipt.json  # verify it offlin
 排程器為什麼是純 Python，以及這換來什麼代價：[為什麼確定性](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/architecture/WHY_DETERMINISTIC.md)。
 
 ### 日常命令
-<!-- l10n: en="everyday commands" hash="sha256:097c6c2e0ddf" -->
+<!-- l10n: en="everyday commands" hash="sha256:b3520027ef7d" -->
 
 ```bash
 cd your-project
-bernstein init                    # creates .sdd/ workspace + bernstein.yaml
+bernstein init                    # creates .sdd/ workspace, bernstein.yaml + templates/
 bernstein -g "Add rate limiting"  # agents spawn, work in parallel, verify, exit
 bernstein live                    # watch progress in the TUI dashboard
 bernstein run plan.yaml           # multi-stage plan: skip LLM planning, execute directly
@@ -128,19 +129,21 @@ bernstein stop                    # graceful shutdown with drain
 
 完整的操作介面（PR 自動化、定時任務、聊天橋接、autofix 守護行程）見[操作命令](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/operations/commands.md)。
 
-### 支援的代理
-<!-- l10n: en="supported agents" hash="sha256:446493547b67" -->
+儲存庫衛生門禁：`bernstein readme-l10n verify` 會讓翻譯版 README 偏離英文來源的 PR 失敗（並指出過期的章節），`bernstein readme-l10n sync` 在英文修改後重新綁定它們。見 [readme-l10n](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/playbooks/readme-l10n.md)。
 
-Claude Code、Codex CLI、Gemini CLI、GitHub Copilot CLI、Cursor、Aider、Goose、Muse Code、OpenAI Agents SDK、Amp、Cody、Continue、Devin Terminal、Junie、Kilo、Kiro、AWS Q Developer、Ollama、OpenCode、OpenHands、Open Interpreter、gptme、Plandex、AIChat、Letta Code、Qwen 等等。[介面卡索引](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/adapters/index.md)為其中 30 個提供安裝命令；`bernstein integrations list` 從 `src/bernstein/adapters/registry.py` 中的登錄檔列舉全部 51 個已接線介面卡，該檔案是「什麼能解析」的唯一事實來源；`src/bernstein/adapters/use_cases.py` 為每個介面卡提供面向終端使用者的文案。任何帶 `--prompt` 旗標的其他工具都可以透過通用包裝器運作。
+### 支援的代理
+<!-- l10n: en="supported agents" hash="sha256:aef640e2b705" -->
+
+Claude Code、Codex CLI、Gemini CLI、GitHub Copilot CLI、Cursor、Aider、Goose、Muse Code、OpenAI Agents SDK、Amp、Cody、Continue、Devin Terminal、Junie、Kilo、Kiro、AWS Q Developer、Ollama、OpenCode、OpenHands、Open Interpreter、gptme、Plandex、AIChat、Letta Code、Qwen 等等。[介面卡索引](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/adapters/index.md)為其中 30 個提供安裝命令；`bernstein integrations list` 從 `src/bernstein/adapters/registry.py` 中的登錄檔列舉全部 51 個已接線整合，該檔案是「什麼能解析」的唯一事實來源——其中 49 個是可選擇的代理介面卡，另外兩列是 `mock` 測試樁和 `self-hosted-endpoints` 端點設定檔；`src/bernstein/adapters/use_cases.py` 為每個介面卡提供面向終端使用者的文案。任何帶 `--prompt` 旗標的其他工具都可以透過通用包裝器運作。
 
 在同一執行中混用代理：用便宜的本地模型處理樣板，用更重的雲端模型處理架構。`bernstein integrations list --installed` 顯示你的機器上可用的內容。
 
 ### 首頁之外
-<!-- l10n: en="beyond the front page" hash="sha256:0420eb016a43" -->
+<!-- l10n: en="beyond the front page" hash="sha256:a1aa323fcf03" -->
 
 所有深入內容都在[文件網站](https://bernstein.readthedocs.io/)上：
 
-| | |
+| 頁面 | 內容 |
 |---|---|
 | [capabilities](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/reference/capabilities.md) | 完整能力清單：MCP 伺服器模式、簽署的代理卡片、沙箱後端、產物儲存、監管對映 |
 | [who this is for](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/use-cases.md) | 價值落在哪裡，以及 Bernstein 何時是錯誤工具 |
@@ -152,16 +155,16 @@ Claude Code、Codex CLI、Gemini CLI、GitHub Copilot CLI、Cursor、Aider、Goo
 | [architecture](https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/architecture/ARCHITECTURE.md) | 底層運作原理 |
 
 ### 為什麼叫這個名字？
-<!-- l10n: en="why the name?" hash="sha256:3c98a35004a1" -->
+<!-- l10n: en="why the name?" hash="sha256:2444448b9e03" -->
 
-Bernstein 得名於美國指揮家、作曲家 Leonard Bernstein。這個專案像 Bernstein 指揮紐約愛樂樂團那樣編排一支 CLI 編碼代理隊伍：每個樂手準時到位，樂譜確定，指揮對結果負責。他就是這個專案名字所源自的那位原初編排者。
+Bernstein 得名於美國指揮家、作曲家 Leonard Bernstein。這個專案像 Bernstein 指揮紐約愛樂樂團那樣編排一支 CLI 編碼代理隊伍：每個樂手準時到位，樂譜確定，指揮對結果負責。
 
 我寫 bernstein 是因為我每月為並行執行三個編碼代理支付 400 美元的 claude 帳單，卻得到不確定性的合併。Apache 2.0，單人維護。即時資料：[bernstein.run](https://bernstein.run)。
 
 ### 被提及的地方
-<!-- l10n: en="mentioned in" hash="sha256:e79981346792" -->
+<!-- l10n: en="mentioned in" hash="sha256:e1dfaf62cb5d" -->
 
-收錄於 [vinta/awesome-python](https://github.com/vinta/awesome-python)，被 Augment Code 的[開源代理編排器](https://www.augmentcode.com/tools/open-source-agent-orchestrators)綜述提及，被 [awesome-agentic-patterns](https://github.com/nibzard/awesome-agentic-patterns/blob/main/patterns/deterministic-zero-llm-orchestration.md) 引用為確定性零 LLM 編排的生產實作，登上 [Python Weekly #742](https://www.pythonweekly.com/p/python-weekly-issue-742-april-23-2026)，並在一個十倉庫的 [Claude Code 代理系統剖析](https://x.com/Granite0x/status/2080665298609328201)中被列為編排層。
+收錄於 [vinta/awesome-python](https://github.com/vinta/awesome-python)，被 Augment Code 的[開源代理編排器](https://www.augmentcode.com/tools/open-source-agent-orchestrators)綜述提及，並收錄於 [Python Weekly #742](https://www.pythonweekly.com/p/python-weekly-issue-742-april-23-2026)。我們也把這一方法寫成了 awesome-agentic-patterns 中的[確定性零 LLM 編排](https://github.com/nibzard/awesome-agentic-patterns/blob/main/patterns/deterministic-zero-llm-orchestration.md)模式條目。
 
 <details>
 <summary>全部涵蓋：20 多個 awesome 清單、目錄、通訊和同儕引用</summary>

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,8 @@ search:
 
 **Reproducible multi-agent runs. Verifiable results. Any CLI coding agent.**
 
+<a href="https://deepwiki.com/sipyourdrink-ltd/bernstein"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
+
 <figure markdown>
   ![A real bernstein demo run - mock agents fix four seeded bugs, ending on the run's signed receipt verifying offline](assets/demo-run/demo.gif){ loading=lazy width="820" }
   <figcaption>A real recorded run - its signed receipt and public key ship next to this recording, and CI re-verifies them on every push</figcaption>

--- a/docs/playbooks/readme-l10n.md
+++ b/docs/playbooks/readme-l10n.md
@@ -69,8 +69,37 @@ language it checks:
    section must be byte-identical (normalised) to the English section
    they mirror. A translated command, flag, path or subcommand is a
    failure, not a warning.
-3. **Verbatim header/footer** - logo, badges, the language links
+3. **Binding placement** - each binding sits directly under the
+   translated heading it mirrors. The same English section bound under
+   two headings, or a binding under no heading at all, is a failure:
+   either shape lets a section resolve to the wrong span.
+4. **Paragraph parity** - a translated section carries the same number
+   of paragraph-level blocks as the English section it mirrors.
+5. **Verbatim header/footer** - logo, badges, the language links
    line and the license/footer block must equal the English ones.
+
+## Paragraph parity: translations preserve block structure
+
+Hash bindings pin English *content*, and `sync` re-pins them after an
+English edit without proving the translation followed. A paragraph
+added to the English source could therefore go missing from every
+translation while the gate stayed green. Parity closes that hole by
+comparing block counts per section.
+
+The contract this places on translators is explicit: **a translation
+must preserve the blank-line block structure of the English section it
+mirrors.** Blocks are runs of non-blank lines separated by blank lines;
+a fenced code block counts as one block; binding comments count as
+none.
+
+This is stricter than the hash contract below, deliberately. Hash
+normalisation absorbs blank-line reflow of the *English source* so a
+formatting pass does not invalidate every binding. Parity compares
+English against translation, where a merged pair of paragraphs and a
+dropped paragraph are indistinguishable from the outside - so joining
+two translated paragraphs that are separate in English is an exit-1
+failure, even though no content is missing. Split them back apart to
+match the English layout.
 
 ## Hash stability
 

--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -70,8 +70,8 @@ _STYLE_BOLD_CYAN = "bold cyan"
 def live(interval: float, classic: bool, no_splash: bool) -> None:
     """Live dashboard: active agents, task events, and stats (Ctrl+C to exit).
 
-    Launches the 3-column interactive Textual TUI by default:
-    Agents | Tasks | Activity feed + sparkline + chat input.
+    Launches the two-column interactive Textual TUI by default:
+    Agents | Tasks, with a full-width activity feed + sparkline + chat input below.
     Mouse + keyboard. Pass --classic for the simpler Rich Live display.
     """
     seed_path = find_seed_file()

--- a/src/bernstein/cli/commands/explain_help_cmd.py
+++ b/src/bernstein/cli/commands/explain_help_cmd.py
@@ -85,7 +85,7 @@ _COMMAND_EXAMPLES: dict[str, dict[str, Any]] = {
     "live": {
         "summary": "Launch the interactive TUI dashboard.",
         "examples": [
-            ("bernstein live", "Start the 3-column TUI"),
+            ("bernstein live", "Start the TUI dashboard"),
             ("bernstein live --classic", "Use the simpler Rich Live display"),
             ("bernstein live --interval 5", "Set polling interval to 5 seconds"),
         ],

--- a/src/bernstein/cli/commands/readme_l10n_cmd.py
+++ b/src/bernstein/cli/commands/readme_l10n_cmd.py
@@ -80,9 +80,14 @@ def readme_l10n_verify(workdir: Path) -> None:
       English source (a stale binding names the section),
     - fenced code blocks are verbatim against the English section they
       mirror (a translated command or flag is a failure, not a warning),
+    - every binding sits directly under the translated heading it
+      mirrors (duplicated or orphaned bindings are a failure),
     - every translated section carries the same number of paragraph
-      blocks as the English section it mirrors (a paragraph added to the
-      English source cannot silently go missing from a translation),
+      blocks as the English section it mirrors, so a paragraph added to
+      the English source cannot silently go missing from a translation.
+      A translation must therefore preserve the blank-line block
+      structure of its English section: merging two paragraphs into one
+      is exit 1, even though no content is missing,
     - the header and footer blocks (logo, badges, language links,
       license line) are shared verbatim.
 

--- a/src/bernstein/cli/commands/readme_l10n_cmd.py
+++ b/src/bernstein/cli/commands/readme_l10n_cmd.py
@@ -80,6 +80,9 @@ def readme_l10n_verify(workdir: Path) -> None:
       English source (a stale binding names the section),
     - fenced code blocks are verbatim against the English section they
       mirror (a translated command or flag is a failure, not a warning),
+    - every translated section carries the same number of paragraph
+      blocks as the English section it mirrors (a paragraph added to the
+      English source cannot silently go missing from a translation),
     - the header and footer blocks (logo, badges, language links,
       license line) are shared verbatim.
 

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -439,7 +439,7 @@ def print_rich_help() -> None:
         (
             "monitor",
             [
-                ("live", "interactive TUI dashboard (3 columns)"),
+                ("live", "interactive TUI dashboard (2 columns + activity panel)"),
                 ("dashboard", "open web dashboard in browser"),
                 ("status", "task summary and agent health"),
                 ("ps", "running agent processes"),

--- a/src/bernstein/core/knowledge/readme_l10n.py
+++ b/src/bernstein/core/knowledge/readme_l10n.py
@@ -91,17 +91,7 @@ def split_sections(text: str) -> list[Section]:
     if not heading_idx:
         return [Section(HEADER_SECTION, text)]
 
-    # Footer start: first standalone '---' line after the last heading,
-    # outside any fenced code block.
-    footer_start = len(lines)
-    in_fence = False
-    for i in range(heading_idx[-1] + 1, len(lines)):
-        if _FENCE_RE.match(lines[i]):
-            in_fence = not in_fence
-            continue
-        if not in_fence and lines[i].strip() == "---":
-            footer_start = i
-            break
+    footer_start = _footer_start(lines, heading_idx[-1])
 
     sections: list[Section] = []
 
@@ -121,6 +111,19 @@ def split_sections(text: str) -> list[Section]:
     sections.append(Section(FOOTER_SECTION, footer_text))
 
     return sections
+
+
+def _footer_start(lines: list[str], last_heading_idx: int) -> int:
+    """Index of the footer separator: the first standalone ``---`` line
+    after the last heading, outside any fenced code block."""
+    in_fence = False
+    for i in range(last_heading_idx + 1, len(lines)):
+        if _FENCE_RE.match(lines[i]):
+            in_fence = not in_fence
+            continue
+        if not in_fence and lines[i].strip() == "---":
+            return i
+    return len(lines)
 
 
 def normalize(text: str) -> str:
@@ -162,6 +165,40 @@ def extract_code_blocks(section: Section) -> list[str]:
 def parse_bindings(text: str) -> dict[str, str]:
     """Map English section name -> bound hash from a translated file."""
     return {en: h for en, h in _BINDING_RE.findall(text)}
+
+
+def paragraph_count(body: str) -> int:
+    """Number of paragraph-level blocks in a section body.
+
+    Blocks are runs of non-blank lines separated by blank lines. A fenced
+    code block counts as a single block regardless of internal blank
+    lines. l10n binding comments are gate metadata, not content, and are
+    ignored. Used to compare structure between an English section and the
+    translation that mirrors it: hashes bind content, but a re-synced
+    binding cannot tell whether a paragraph added to the English source
+    ever reached the translation - the block count can.
+    """
+    blocks = 0
+    in_block = False
+    in_fence = False
+    for line in body.splitlines():
+        if _FENCE_RE.match(line):
+            if not in_fence and not in_block:
+                blocks += 1
+                in_block = True
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        if not line.strip():
+            in_block = False
+            continue
+        if _BINDING_RE.search(line):
+            continue
+        if not in_block:
+            blocks += 1
+            in_block = True
+    return blocks
 
 
 # ---------------------------------------------------------------------------
@@ -227,7 +264,27 @@ def verify_language(source_sections: list[Section], lang: str, translated_text: 
                         "and subcommands must stay verbatim"
                     )
 
-    # 3. Header/footer verbatim: logo, badges, language links line and the
+    # 3. Paragraph parity: a translated section must carry the same number
+    #    of paragraph-level blocks as the English section it mirrors. The
+    #    hash binding pins the English content, but `sync` re-binds after
+    #    an English edit without proving the translation followed - a
+    #    paragraph added to the English source can otherwise go missing
+    #    from every translation while the gate stays green.
+    for section in prose:
+        trans_section = _find_translated_section(translated_text, section.heading)
+        if trans_section is None:
+            continue
+        en_blocks_n = paragraph_count(section.body)
+        tr_blocks_n = paragraph_count(trans_section.body)
+        if en_blocks_n != tr_blocks_n:
+            result.errors.append(
+                f'section "{section.heading}" has {tr_blocks_n} paragraph '
+                f"block(s) but the English section has {en_blocks_n}; "
+                "translate the missing or extra paragraph(s) so the "
+                "structures match"
+            )
+
+    # 4. Header/footer verbatim: logo, badges, language links line and the
     #    license/footer block are shared verbatim. The translated file
     #    mirrors the English structure, so its own header (before the
     #    first heading) and footer (after the last '---') map directly.
@@ -259,13 +316,18 @@ def _find_translated_section(text: str, en_heading: str) -> Section | None:
     the section runs to the next ``###`` heading (or l10n binding).
     """
     lines = text.splitlines(keepends=True)
+    heading_idx = [i for i, line in enumerate(lines) if _HEADING_RE.match(line)]
+    # The last section stops where the footer starts, mirroring
+    # ``split_sections`` - otherwise the translated footer is read as part
+    # of the last prose section and its blocks are miscounted.
+    footer_start = _footer_start(lines, heading_idx[-1]) if heading_idx else len(lines)
     # Find the binding line for this English heading.
     for i, line in enumerate(lines):
         m = _BINDING_RE.search(line)
         if m and m.group(1) == en_heading:
             start = i + 1
-            end = len(lines)
-            for j in range(i + 1, len(lines)):
+            end = footer_start
+            for j in range(i + 1, min(len(lines), footer_start)):
                 if _HEADING_RE.match(lines[j]):
                     end = j
                     break

--- a/src/bernstein/core/knowledge/readme_l10n.py
+++ b/src/bernstein/core/knowledge/readme_l10n.py
@@ -381,9 +381,7 @@ def binding_placement_errors(text: str) -> list[str]:
     owned = _owned_sections(text)
     for en, sections in sorted(owned.items()):
         if len(sections) > 1:
-            errors.append(
-                f'section "{en}" is bound by {len(sections)} translated headings; exactly one must mirror it'
-            )
+            errors.append(f'section "{en}" is bound by {len(sections)} translated headings; exactly one must mirror it')
 
     lines = text.splitlines(keepends=True)
     heading_idx = [i for i, line in enumerate(lines) if _HEADING_RE.match(line)]

--- a/src/bernstein/core/knowledge/readme_l10n.py
+++ b/src/bernstein/core/knowledge/readme_l10n.py
@@ -183,10 +183,16 @@ def paragraph_count(body: str) -> int:
     in_fence = False
     for line in body.splitlines():
         if _FENCE_RE.match(line):
-            if not in_fence and not in_block:
+            # A fence always opens a block of its own, even when it
+            # follows prose with no blank line between them, and closing
+            # it ends that block so following prose opens a new one.
+            if not in_fence:
                 blocks += 1
+                in_fence = True
                 in_block = True
-            in_fence = not in_fence
+            else:
+                in_fence = False
+                in_block = False
             continue
         if in_fence:
             continue
@@ -264,7 +270,12 @@ def verify_language(source_sections: list[Section], lang: str, translated_text: 
                         "and subcommands must stay verbatim"
                     )
 
-    # 3. Paragraph parity: a translated section must carry the same number
+    # 3. Binding placement: a duplicated or orphaned binding lets a
+    #    section resolve to the wrong span, so parity below cannot be
+    #    trusted until placement is unambiguous.
+    result.errors.extend(binding_placement_errors(translated_text))
+
+    # 4. Paragraph parity: a translated section must carry the same number
     #    of paragraph-level blocks as the English section it mirrors. The
     #    hash binding pins the English content, but `sync` re-binds after
     #    an English edit without proving the translation followed - a
@@ -284,7 +295,7 @@ def verify_language(source_sections: list[Section], lang: str, translated_text: 
                 "structures match"
             )
 
-    # 4. Header/footer verbatim: logo, badges, language links line and the
+    # 5. Header/footer verbatim: logo, badges, language links line and the
     #    license/footer block are shared verbatim. The translated file
     #    mirrors the English structure, so its own header (before the
     #    first heading) and footer (after the last '---') map directly.
@@ -315,27 +326,79 @@ def _find_translated_section(text: str, en_heading: str) -> Section | None:
     for ``en_heading`` sits directly under the translated heading, and
     the section runs to the next ``###`` heading (or l10n binding).
     """
+    owned = _owned_sections(text)
+    sections = owned.get(en_heading)
+    if sections is None or len(sections) != 1:
+        # Absent, or bound more than once: ambiguous placement is reported
+        # by ``binding_placement_errors`` rather than silently resolved to
+        # whichever copy happens to come first.
+        return None
+    return sections[0]
+
+
+def _owned_sections(text: str) -> dict[str, list[Section]]:
+    """Map English section name -> the translated sections bound to it.
+
+    A binding is owned by the heading it sits under: the *first* binding
+    inside a heading's span, per the documented placement (directly under
+    the translated heading). The section body runs from that binding to
+    the next heading, or to the footer separator for the last one -
+    mirroring ``split_sections`` so the translated footer is never read
+    as part of the last prose section. Resolving by owning heading is
+    what keeps a stray or duplicated binding elsewhere in the file from
+    redefining a section's boundaries.
+    """
     lines = text.splitlines(keepends=True)
     heading_idx = [i for i, line in enumerate(lines) if _HEADING_RE.match(line)]
-    # The last section stops where the footer starts, mirroring
-    # ``split_sections`` - otherwise the translated footer is read as part
-    # of the last prose section and its blocks are miscounted.
+    if not heading_idx:
+        return {}
+    footer_start = _footer_start(lines, heading_idx[-1])
+
+    owned: dict[str, list[Section]] = {}
+    for n, idx in enumerate(heading_idx):
+        end = heading_idx[n + 1] if n + 1 < len(heading_idx) else footer_start
+        for j in range(idx + 1, min(end, len(lines))):
+            m = _BINDING_RE.search(lines[j])
+            if m is None:
+                continue
+            en = m.group(1)
+            owned.setdefault(en, []).append(Section(en, "".join(lines[j + 1 : end])))
+            break  # only the first binding under a heading owns it
+    return owned
+
+
+def binding_placement_errors(text: str) -> list[str]:
+    """Report bindings a reader would misread as pinning a section.
+
+    Two shapes are rejected: the same English section bound under more
+    than one translated heading (which of them mirrors it?), and a
+    binding that sits under no heading at all (before the first heading
+    or below the footer separator), where it pins nothing. Both let a
+    translated paragraph go missing while the hash bindings still
+    reconcile, so they are failures rather than warnings.
+    """
+    errors: list[str] = []
+    owned = _owned_sections(text)
+    for en, sections in sorted(owned.items()):
+        if len(sections) > 1:
+            errors.append(
+                f'section "{en}" is bound by {len(sections)} translated headings; exactly one must mirror it'
+            )
+
+    lines = text.splitlines(keepends=True)
+    heading_idx = [i for i, line in enumerate(lines) if _HEADING_RE.match(line)]
+    first_heading = heading_idx[0] if heading_idx else len(lines)
     footer_start = _footer_start(lines, heading_idx[-1]) if heading_idx else len(lines)
-    # Find the binding line for this English heading.
     for i, line in enumerate(lines):
         m = _BINDING_RE.search(line)
-        if m and m.group(1) == en_heading:
-            start = i + 1
-            end = footer_start
-            for j in range(i + 1, min(len(lines), footer_start)):
-                if _HEADING_RE.match(lines[j]):
-                    end = j
-                    break
-                if _BINDING_RE.search(lines[j]) and j > i:
-                    end = j
-                    break
-            return Section(en_heading, "".join(lines[start:end]))
-    return None
+        if m is None:
+            continue
+        if i < first_heading or i >= footer_start:
+            errors.append(
+                f'binding for section "{m.group(1)}" sits outside every '
+                "translated heading; move it directly under the heading it mirrors"
+            )
+    return errors
 
 
 def load_config(pyproject: Path) -> list[str]:

--- a/tests/unit/test_packaged_readme_renders_off_repo.py
+++ b/tests/unit/test_packaged_readme_renders_off_repo.py
@@ -48,6 +48,7 @@ ALLOWED_IMAGE_HOSTS = frozenset(
         "img.shields.io",
         "api.securityscorecards.dev",
         "mcptoplist.com",
+        "deepwiki.com",
     }
 )
 

--- a/tests/unit/test_readme_adapter_counts.py
+++ b/tests/unit/test_readme_adapter_counts.py
@@ -29,8 +29,10 @@ ADAPTER_INDEX = REPO_ROOT / "docs" / "adapters" / "index.md"
 
 # "carries install commands for 29 of them"
 _MATRIX_CLAIM_RE = re.compile(r"carries install commands for (\d+) of them")
-# "enumerates all 48 wired-in adapters"
-_TOTAL_CLAIM_RE = re.compile(r"enumerates all (\d+) wired-in adapters")
+# "enumerates all 51 wired-in integrations"
+_TOTAL_CLAIM_RE = re.compile(r"enumerates all (\d+) wired-in integrations")
+# "49 of them are selectable agent adapters"
+_SELECTABLE_CLAIM_RE = re.compile(r"(\d+) of them are selectable agent adapters")
 
 
 def _claimed(pattern: re.Pattern[str]) -> int:
@@ -67,6 +69,13 @@ def test_readme_install_matrix_count_matches_the_table() -> None:
 def test_readme_total_adapter_count_matches_the_registry() -> None:
     """The README's wired-in adapter count equals what the CLI enumerates."""
     assert _claimed(_TOTAL_CLAIM_RE) == len(_enumerate_rows())
+
+
+def test_readme_selectable_adapter_count_matches_the_registry() -> None:
+    """The README's selectable-adapter count equals the registry's selectable set."""
+    from bernstein.adapters.registry import selectable_adapter_names
+
+    assert _claimed(_SELECTABLE_CLAIM_RE) == len(selectable_adapter_names())
 
 
 def test_install_matrix_is_a_subset_claim_not_a_full_one() -> None:

--- a/tests/unit/test_readme_l10n_cmd.py
+++ b/tests/unit/test_readme_l10n_cmd.py
@@ -167,6 +167,56 @@ class TestVerify:
         assert "README.md" in result.output
 
 
+class TestParagraphParity:
+    def test_paragraph_added_to_english_fails_even_after_sync(self, tmp_path: Path) -> None:
+        """A paragraph added to the English source must not vanish silently.
+
+        ``sync`` rebinds the hash without proving the translation followed,
+        so the binding check alone goes green; the paragraph-parity check
+        is what turns the missing translated paragraph red.
+        """
+        repo = _write_fixture(tmp_path, zh=_zh_readme(_en_sections()))
+        changed = EN_README.replace(
+            "pip and uv are covered in the install guide.",
+            "pip and uv are covered in the install guide.\n\n"
+            "Hygiene gates: `demo l10n verify` fails a PR whose translations drifted.",
+        )
+        (repo / "README.md").write_text(changed, encoding="utf-8")
+        assert _run("sync", "--workdir", str(repo)).exit_code == 0
+        result = _run("verify", "--workdir", str(repo))
+        assert result.exit_code == 1, result.output
+        assert "paragraph" in result.output
+        assert "install in 30 seconds" in result.output
+
+    def test_translated_paragraph_present_passes(self, tmp_path: Path) -> None:
+        changed_en = EN_README.replace(
+            "pip and uv are covered in the install guide.",
+            "pip and uv are covered in the install guide.\n\n"
+            "Hygiene gates: `demo l10n verify` fails a PR whose translations drifted.",
+        )
+        zh = _zh_readme(_en_sections()).replace(
+            "pip 和 uv 涵盖在安装指南中。",
+            "pip 和 uv 涵盖在安装指南中。\n\n卫生门禁 `demo l10n verify` 会在翻译漂移时让 PR 失败。",
+        )
+        repo = _write_fixture(tmp_path, zh=zh)
+        (repo / "README.md").write_text(changed_en, encoding="utf-8")
+        assert _run("sync", "--workdir", str(repo)).exit_code == 0
+        result = _run("verify", "--workdir", str(repo))
+        assert result.exit_code == 0, result.output
+
+    def test_code_block_counts_as_one_block(self) -> None:
+        from bernstein.core.knowledge.readme_l10n import paragraph_count
+
+        body = "```bash\nfirst\n\nsecond\n```\n\nprose paragraph\n"
+        assert paragraph_count(body) == 2
+
+    def test_binding_comment_is_not_a_block(self) -> None:
+        from bernstein.core.knowledge.readme_l10n import paragraph_count
+
+        body = '<!-- l10n: en="x" hash="sha256:00" -->\n\nprose paragraph\n'
+        assert paragraph_count(body) == 1
+
+
 class TestSync:
     def test_sync_rebinds_stale_sections(self, tmp_path: Path) -> None:
         repo = _write_fixture(tmp_path, zh=_zh_readme(_en_sections()))

--- a/tests/unit/test_readme_l10n_cmd.py
+++ b/tests/unit/test_readme_l10n_cmd.py
@@ -204,6 +204,30 @@ class TestParagraphParity:
         result = _run("verify", "--workdir", str(repo))
         assert result.exit_code == 0, result.output
 
+    def test_fence_adjacent_to_prose_is_its_own_block(self) -> None:
+        """A fence with no blank line before or after it still counts once.
+
+        Counting it as part of the neighbouring prose run would let a
+        translation drop a paragraph next to a code block undetected.
+        """
+        from bernstein.core.knowledge.readme_l10n import paragraph_count
+
+        assert paragraph_count("prose\n```\ncode\n```") == 2
+        assert paragraph_count("```\ncode\n```\nprose") == 2
+        assert paragraph_count("before\n```\ncode\n```\nafter") == 3
+
+    def test_reflowed_translation_is_reported(self) -> None:
+        """Merging two English paragraphs into one translated block fails.
+
+        Documented contract: parity compares English against translation,
+        where a merged pair and a dropped paragraph look identical, so a
+        translation preserves the English block structure.
+        """
+        from bernstein.core.knowledge.readme_l10n import paragraph_count
+
+        assert paragraph_count("A\n\nB\n") == 2
+        assert paragraph_count("译A\n译B\n") == 1
+
     def test_code_block_counts_as_one_block(self) -> None:
         from bernstein.core.knowledge.readme_l10n import paragraph_count
 
@@ -215,6 +239,33 @@ class TestParagraphParity:
 
         body = '<!-- l10n: en="x" hash="sha256:00" -->\n\nprose paragraph\n'
         assert paragraph_count(body) == 1
+
+
+class TestBindingPlacement:
+    def test_duplicate_binding_for_one_section_fails(self, tmp_path: Path) -> None:
+        """Two headings binding one English section is ambiguous, not a pick-first."""
+        en = _en_sections()
+        zh = _zh_readme(en).replace(
+            "### 工作原理\n",
+            f'### 别名\n<!-- l10n: en="install in 30 seconds" hash="{section_hash(en["install in 30 seconds"])}" -->\n\n占位。\n\n### 工作原理\n',
+        )
+        repo = _write_fixture(tmp_path, zh=zh)
+        result = _run("verify", "--workdir", str(repo))
+        assert result.exit_code == 1, result.output
+        assert "bound by 2 translated headings" in result.output
+
+    def test_binding_under_no_heading_fails(self, tmp_path: Path) -> None:
+        """A binding above the first heading pins nothing."""
+        en = _en_sections()
+        h = section_hash(en["install in 30 seconds"])
+        zh = _zh_readme(en).replace(
+            "Intro line.\n",
+            f'Intro line.\n\n<!-- l10n: en="install in 30 seconds" hash="{h}" -->\n',
+        )
+        repo = _write_fixture(tmp_path, zh=zh)
+        result = _run("verify", "--workdir", str(repo))
+        assert result.exit_code == 1, result.output
+        assert "outside every" in result.output
 
 
 class TestSync:


### PR DESCRIPTION
# User description
Accuracy pass over the front page: every claim now matches what a reader can verify by running the advertised commands. Defect classes fixed:

**Links**
- Install links now point at the rendered docs site; the GitHub blob renders mkdocs `=== "tab"` syntax as literal text.
- The air-gapped wheelhouse is covered in its own guide, not the install guide; the sentence now links the right page.

**Claims vs. verifiable behavior**
- The demo receipt is described as *derived from that run's journal* (the recorder rebuilds it post-hoc via `bernstein verify run`).
- The receipt bind claim now says the lineage-spine head is bound *when the run wrote spine entries* - the shipped demo receipt verifies with `spine_entries=0`, and the README's own verify command shows that.
- "CI re-verifies the committed receipt on every push" scoped to pushes to main (the PR lane runs affected tests only).
- Isolation wording: agents share no mutable *workspace*; coordination state (the task backlog) is shared and claimed atomically.
- The TUI/web screenshots are no longer described as the same run; both surfaces read the same task API.

**Counts and surface descriptions**
- `bernstein integrations list` shows 51 wired-in integrations: 49 selectable agent adapters plus the `mock` test stub and the `self-hosted-endpoints` endpoint profile. The README now says exactly that.
- The TUI is 2 columns (Agents | Tasks) with a full-width activity panel below; fixed in the README alt text and the three CLI help strings that said "3 columns".
- Alt text for the demo gif describes what the frames show.

**Quickstart**
- Leads with `uv tool install` (matching the install guide's recommendation), keeps pipx as the alternate.
- Adds a `bernstein doctor` step: the goal line needs a CLI agent installed and authenticated, and the README never said so.
- `bernstein init` comment now includes `templates/`.

**Attribution and mentions**
- The epigraph's attribution now links its provenance research page.
- The mentions line describes each listing accurately (our own pattern write-up is stated as ours; a login-gated listing with no verifiable content was dropped; "featured" corrected to "listed").

**Translations + gate**
- zh-Hans and zh-TW were missing the entire repository-hygiene-gates paragraph while `readme-l10n verify` reported in-sync: the gate binds on the English hash only, so a paragraph added to the English source can vanish from every translation after a re-sync. The paragraph is now translated in both files, the accuracy fixes above are mirrored, and `readme-l10n verify` additionally compares per-section paragraph block counts between the English source and each translation. Tests cover the failing (missing paragraph) and passing (translated paragraph) paths.

**Metadata**
- CITATION.cff: version 3.14.159, date-released 2026-08-10.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Improve Bernstein’s public documentation, installation guidance, verification claims, dashboard descriptions, integration counts, attribution, and release metadata so they match the implemented product behavior. Strengthen translated-README validation with binding-placement and paragraph-structure checks, supported by updated localization, registry-count, and packaging tests.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3568?tool=ast&topic=Documentation+accuracy>Documentation accuracy</a>
        </td><td>Correct README, translated README, site documentation, CLI help, dashboard descriptions, installation instructions, verification claims, integration counts, attribution, external links, and citation metadata to reflect current behavior and release information.<details><summary>Modified files (8)</summary><ul><li>CITATION.cff</li>
<li>README.md</li>
<li>README.zh-Hans.md</li>
<li>README.zh-TW.md</li>
<li>docs/index.md</li>
<li>src/bernstein/cli/commands/advanced_cmd.py</li>
<li>src/bernstein/cli/commands/explain_help_cmd.py</li>
<li>src/bernstein/cli/main.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>chernistry</td><td>docs: re-capture the f...</td><td>August 10, 2026</td></tr>
<tr><td>sanderchernitsky@gmail...</td><td>docs: add DeepWiki bad...</td><td>August 10, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3568?tool=ast&topic=Translation+integrity>Translation integrity</a>
        </td><td>Enforce unambiguous localization bindings and paragraph-block parity so translated README sections cannot silently omit, merge, or misassociate content after English changes; document the strengthened synchronization contract.<details><summary>Modified files (4)</summary><ul><li>docs/playbooks/readme-l10n.md</li>
<li>src/bernstein/cli/commands/readme_l10n_cmd.py</li>
<li>src/bernstein/core/knowledge/readme_l10n.py</li>
<li>tests/unit/test_readme_l10n_cmd.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>style: ruff format rea...</td><td>August 10, 2026</td></tr>
<tr><td>leonbleuciel@gmail.com</td><td>feat(cli): readme-l10n...</td><td>August 06, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3568?tool=ast&topic=Documentation+validation>Documentation validation</a>
        </td><td>Validate the revised documentation surface and claims through tests covering approved external domains and registry-derived integration counts, including the distinction between selectable adapters and non-agent integration profiles.<details><summary>Modified files (2)</summary><ul><li>tests/unit/test_packaged_readme_renders_off_repo.py</li>
<li>tests/unit/test_readme_adapter_counts.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>docs: add DeepWiki bad...</td><td>August 10, 2026</td></tr>
<tr><td>chernistry</td><td>docs: show the termina...</td><td>August 06, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3568?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>