### PR TITLE
fix(spiffe): read chain-anchored binding rows through the authenticated path

### DIFF
--- a/src/bernstein/cli/commands/spiffe_cmd.py
+++ b/src/bernstein/cli/commands/spiffe_cmd.py
@@ -105,25 +105,48 @@ def verify_binding_cmd(binding_file: Path, install_key: Path, trust_domain: str,
         raise SystemExit(1)
 
     if audit_dir is not None:
-        matched = _verify_against_chain(binding, audit_dir)
+        matched, chain_reason = _verify_against_chain(binding, audit_dir)
         if not matched:
-            click.echo("invalid: no matching chained spiffe.svid_binding receipt", err=True)
+            click.echo(f"invalid: {chain_reason}", err=True)
             raise SystemExit(1)
         click.echo("valid (chain-anchored)")
         return
     click.echo("valid")
 
 
-def _verify_against_chain(binding: SvidBinding, audit_dir: Path) -> bool:
-    """Return True when *binding* matches a chained ``spiffe.svid_binding`` event."""
+def _verify_against_chain(binding: SvidBinding, audit_dir: Path) -> tuple[bool, str]:
+    """Check *binding* against a verified ``spiffe.svid_binding`` chain event.
+
+    Returns ``(matched, reason)``. Rows are read through
+    :meth:`AuditChainStore.verify_and_query`, so the verdict only ever rests on
+    events whose HMAC linkage held under whole-chain verification -- a
+    ``spiffe.svid_binding`` row inserted by a writer without the audit key
+    fails the chain check instead of anchoring the binding. The key is loaded
+    read-only: a verifier that minted its own key would fail every HMAC check
+    against a chain written under the real key, so a missing key is reported
+    as an operator error rather than papered over with fresh key material.
+    """
+    from bernstein.core.security.audit import (
+        AuditKeyMissingError,
+        AuditKeyPermissionError,
+        load_audit_key,
+    )
     from bernstein.core.security.audit_chain import (
         EVENT_SPIFFE_SVID_BINDING,
         AuditChainStore,
     )
 
-    chain = AuditChainStore(audit_dir)
-    for event in chain.query(event_type=EVENT_SPIFFE_SVID_BINDING):
-        ok, _reason = verify_binding_against_event(binding, event)
-        if ok:
-            return True
-    return False
+    try:
+        key = load_audit_key()
+    except (AuditKeyMissingError, AuditKeyPermissionError) as exc:
+        return False, f"cannot authenticate audit rows: {exc}"
+
+    chain = AuditChainStore(audit_dir, key=key)
+    ok, errors, events = chain.verify_and_query(event_type=EVENT_SPIFFE_SVID_BINDING, include_archived=True)
+    if not ok:
+        return False, "audit chain verification failed: " + "; ".join(errors)
+    for event in events:
+        matched, _reason = verify_binding_against_event(binding, event)
+        if matched:
+            return True, "ok"
+    return False, "no matching chained spiffe.svid_binding receipt"

--- a/tests/unit/identity/spiffe/test_cli.py
+++ b/tests/unit/identity/spiffe/test_cli.py
@@ -37,7 +37,7 @@ def test_id_command_deterministic(tmp_path: Path, install_keypair) -> None:
     assert result.output.strip() == expected
 
 
-def _write_binding(tmp_path: Path, install_keypair, svid_leaf_factory) -> tuple[Path, Path, Path]:
+def _write_binding(tmp_path: Path, install_keypair, svid_leaf_factory) -> tuple[Path, Path, Path, Path]:
     _priv, pub = install_keypair
     key_file = tmp_path / "pub.pem"
     key_file.write_bytes(pub)
@@ -49,17 +49,20 @@ def _write_binding(tmp_path: Path, install_keypair, svid_leaf_factory) -> tuple[
     ref = svid_reference_from_x509(svid)
     card = issue_identity_card("backend-1", "backend", "claude", "opus")
     audit_dir = tmp_path / "audit"
+    audit_key_file = tmp_path / "audit.key"
+    audit_key_file.write_bytes(b"k" * 32)
+    audit_key_file.chmod(0o600)
     chain = AuditChainStore(audit_dir, key=b"k" * 32)
     _updated, binding, _event = bind_svid_to_card(
         card=card, svid_reference=ref, install_public_key_pem=pub, trust_domain="ex.org", chain=chain
     )
     binding_file = tmp_path / "binding.json"
     binding_file.write_text(json.dumps(binding.to_dict()), encoding="utf-8")
-    return binding_file, key_file, audit_dir
+    return binding_file, key_file, audit_dir, audit_key_file
 
 
 def test_verify_binding_ok(tmp_path: Path, install_keypair, svid_leaf_factory) -> None:
-    binding_file, key_file, _audit = _write_binding(tmp_path, install_keypair, svid_leaf_factory)
+    binding_file, key_file, _audit, _audit_key = _write_binding(tmp_path, install_keypair, svid_leaf_factory)
     runner = CliRunner()
     result = runner.invoke(
         spiffe_group,
@@ -70,7 +73,7 @@ def test_verify_binding_ok(tmp_path: Path, install_keypair, svid_leaf_factory) -
 
 
 def test_verify_binding_chain_anchored(tmp_path: Path, install_keypair, svid_leaf_factory) -> None:
-    binding_file, key_file, audit_dir = _write_binding(tmp_path, install_keypair, svid_leaf_factory)
+    binding_file, key_file, audit_dir, audit_key_file = _write_binding(tmp_path, install_keypair, svid_leaf_factory)
     runner = CliRunner()
     result = runner.invoke(
         spiffe_group,
@@ -84,13 +87,85 @@ def test_verify_binding_chain_anchored(tmp_path: Path, install_keypair, svid_lea
             "--audit-dir",
             str(audit_dir),
         ],
+        env={"BERNSTEIN_AUDIT_KEY_PATH": str(audit_key_file)},
     )
     assert result.exit_code == 0, result.output
     assert "chain-anchored" in result.output
 
 
+def test_verify_binding_forged_chain_row_fails_closed(tmp_path: Path, install_keypair, svid_leaf_factory) -> None:
+    """A ``spiffe.svid_binding`` row whose HMAC linkage does not hold must not anchor the binding.
+
+    The row keeps a valid shape and the matching binding details -- only its
+    HMAC is wrong, exactly what a writer without the audit key can produce.
+    The chain-anchored verdict must fail closed instead of trusting the row.
+    """
+    binding_file, key_file, audit_dir, audit_key_file = _write_binding(tmp_path, install_keypair, svid_leaf_factory)
+
+    log_files = sorted(audit_dir.glob("*.jsonl"))
+    assert log_files, "expected at least one live audit segment"
+    tampered = 0
+    for log_file in log_files:
+        rows = []
+        for line in log_file.read_text(encoding="utf-8").splitlines():
+            row = json.loads(line)
+            if row.get("event_type") == "spiffe.svid_binding":
+                row["hmac"] = "0" * 64
+                tampered += 1
+            rows.append(json.dumps(row, sort_keys=True))
+        log_file.write_text("\n".join(rows) + "\n", encoding="utf-8")
+    assert tampered, "expected a spiffe.svid_binding row to tamper"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        spiffe_group,
+        [
+            "verify-binding",
+            str(binding_file),
+            "--install-key",
+            str(key_file),
+            "--trust-domain",
+            "ex.org",
+            "--audit-dir",
+            str(audit_dir),
+        ],
+        env={"BERNSTEIN_AUDIT_KEY_PATH": str(audit_key_file)},
+    )
+    assert result.exit_code == 1, result.output
+    assert "invalid" in result.output
+    assert "chain" in result.output
+
+
+def test_verify_binding_chain_missing_key_fails_closed(tmp_path: Path, install_keypair, svid_leaf_factory) -> None:
+    """Without the audit key the chain rows cannot be authenticated; the verdict must fail closed.
+
+    A read-only verifier must also never mint key material as a side effect.
+    """
+    binding_file, key_file, audit_dir, _audit_key_file = _write_binding(tmp_path, install_keypair, svid_leaf_factory)
+    absent_key = tmp_path / "absent-audit.key"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        spiffe_group,
+        [
+            "verify-binding",
+            str(binding_file),
+            "--install-key",
+            str(key_file),
+            "--trust-domain",
+            "ex.org",
+            "--audit-dir",
+            str(audit_dir),
+        ],
+        env={"BERNSTEIN_AUDIT_KEY_PATH": str(absent_key)},
+    )
+    assert result.exit_code == 1, result.output
+    assert "invalid" in result.output
+    assert not absent_key.exists(), "read-only verification must not create key material"
+
+
 def test_verify_binding_wrong_trust_domain_fails(tmp_path: Path, install_keypair, svid_leaf_factory) -> None:
-    binding_file, key_file, _audit = _write_binding(tmp_path, install_keypair, svid_leaf_factory)
+    binding_file, key_file, _audit, _audit_key = _write_binding(tmp_path, install_keypair, svid_leaf_factory)
     runner = CliRunner()
     result = runner.invoke(
         spiffe_group,


### PR DESCRIPTION
# User description
Closes #3566. Addresses PR #3560 review finding 3750234905.

## Problem
`bernstein spiffe verify-binding --audit-dir` matched `spiffe.svid_binding` events from `AuditChainStore.query()`, which returns rows without HMAC verification. A forged row with valid shape but broken HMAC linkage anchored the binding and the command printed `valid (chain-anchored)`.

## Fix
- `_verify_against_chain` now reads through `AuditChainStore.verify_and_query()`: chain verification and the event projection come from one locked snapshot, so the verdict rests only on rows the verification covered. `include_archived=True` keeps the query scope equal to the verify scope across the retention boundary.
- The audit key is loaded via `load_audit_key()` (read-only). The previous construction went through the load-or-create resolver, so a verifier pointed at a missing key path minted fresh key material as a side effect; now a missing or insecure key fails closed with an operator-facing reason.
- Failure output names the reason (chain verification errors, missing key, or no matching receipt) instead of a generic message.

## Tests
- `test_verify_binding_forged_chain_row_fails_closed` — tampers the stored receipt's HMAC (valid shape, matching details); fails on the previous behaviour (`valid (chain-anchored)`, exit 0), passes now (exit 1, chain verification named).
- `test_verify_binding_chain_missing_key_fails_closed` — absent key: exit 1 and no key material created.
- Existing verify-binding tests updated for explicit key-path wiring and still pass.

## Sibling sweep
Other verification-flavoured callers of the unauthenticated `query()` were checked: `run_service/verify.py` verifies the chain alongside its query, and `computer_use_attestation` cross-checks rows against signed lineage anchors. The attachment worktree access check trusts unverified rows the same way this command did; that needs a design pass on incremental verification and is tracked in #3567.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update <code>verify_binding_cmd</code> and <code>_verify_against_chain</code> to authenticate audit rows through <code>AuditChainStore.verify_and_query</code> using a read-only <code>load_audit_key</code>, preventing forged or unauthenticated receipts from anchoring bindings. Report specific failure reasons and add coverage for tampered chain rows and missing keys.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3569?tool=ast&topic=Binding+Verification>Binding Verification</a>
        </td><td>Ensure chain-anchored binding verification uses authenticated, snapshot-consistent audit events and fails closed for forged rows or missing keys.<details><summary>Modified files (2)</summary><ul><li>src/bernstein/cli/commands/spiffe_cmd.py</li>
<li>tests/unit/identity/spiffe/test_cli.py</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3569?tool=ast&topic=Failure+Coverage>Failure Coverage</a>
        </td><td>Exercise explicit audit-key configuration, tampered receipt rejection, and read-only missing-key behavior.<details><summary>Modified files (1)</summary><ul><li>tests/unit/identity/spiffe/test_cli.py</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3569?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>