### PR TITLE
docs: match install and use-cases pages to verified behaviour; fix Docker first-run permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,14 @@ RUN pip install --no-cache-dir /tmp/*.whl && rm /tmp/*.whl && \
     useradd -m -u 1000 bernstein && chown bernstein:bernstein /workspace
 USER bernstein
 
-# Bernstein state directory (mount a volume here for persistence)
-VOLUME ["/workspace/.sdd"]
+# Bernstein state lives in /workspace/.sdd. For persistence, bind-mount your
+# project directory at /workspace (the documented default) or mount an explicit
+# volume at /workspace/.sdd.
+#
+# Deliberately NOT declared as a VOLUME: an anonymous volume at this path is
+# created root-owned (0755) by the daemon while the container runs as uid 1000,
+# so every first run failed with "Permission denied" when creating the
+# worktree under /workspace/.sdd. Do not re-add a VOLUME line here.
 
 # Task server HTTP + gRPC ports
 EXPOSE 8052 50051

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -19,7 +19,10 @@ to follow the [first-run walkthrough](first-run.md).
 - **Git** (any recent version). Bernstein uses git worktrees to isolate agents.
 - **macOS, Linux, or Windows**.
 
-That's it. You do **not** need a CLI coding agent installed yet - that comes in the first-run page.
+That's it for installing. Before your **first run** you will also need at least one
+CLI coding agent (Claude Code, Codex CLI, Gemini CLI, ...) and its API key - the
+[first-run walkthrough](first-run.md) covers that. You do **not** need them to
+complete this page.
 
 ### Supported platforms
 
@@ -75,55 +78,75 @@ irm https://astral.sh/uv/install.ps1 | iex        # Windows PowerShell
 
 === "Homebrew (macOS / Linux)"
 
-    ```bash
-    brew tap chernistry/tap
-    brew install bernstein
-    ```
-
-    Bernstein is **not** in `homebrew-core`. The `tap` step is required.
-    The tap lives at `github.com/chernistry/homebrew-tap`; `brew tap chernistry/tap`
-    is the Homebrew short form.
+    **Temporarily unavailable.** The current formula installs Bernstein without
+    its runtime dependencies, so the installed `bernstein` command fails at
+    startup. Tracked in
+    [#3573](https://github.com/sipyourdrink-ltd/bernstein/issues/3573).
+    Use `uv tool install bernstein` or `pipx install bernstein` instead.
 
 === "Fedora / RHEL (dnf)"
 
-    ```bash
-    sudo dnf copr enable alexchernysh/bernstein
-    sudo dnf install bernstein
-    ```
+    **Not yet available.** The COPR repository exists but does not serve a
+    `bernstein` package yet. Tracked in
+    [#3558](https://github.com/sipyourdrink-ltd/bernstein/issues/3558).
+    Use `uv tool install bernstein` or `pipx install bernstein` in the meantime.
 
-=== "Debian / Ubuntu (apt)"
+=== "Debian / Ubuntu"
 
-    See the [Linux install guide](install-linux.md) for the COPR, Homebrew, pip/uv/pipx, and Docker channels.
-
-=== "npm wrapper"
-
-    ```bash
-    npx bernstein-orchestrator
-    ```
-
-    Wraps the Python package; still requires Python 3.12+ on `$PATH`.
+    There is no APT repository. On Debian/Ubuntu, install with pip/uv/pipx or
+    Docker - see the [Linux install guide](install-linux.md).
 
 === "Docker"
 
     ```bash
-    docker run -v "$(pwd)":/workspace -p 8052:8052 \
-      ghcr.io/sipyourdrink-ltd/bernstein -g "your goal"
+    docker run -v "$(pwd)":/workspace -v "$(pwd)/.sdd":/workspace/.sdd \
+      -p 8052:8052 ghcr.io/sipyourdrink-ltd/bernstein -g "your goal"
     ```
+
+    The explicit `.sdd` mount keeps run state in your project directory. On
+    images up to 3.14.159 it is **required**: without it the container creates
+    a root-owned volume at `/workspace/.sdd` and the run fails with
+    `Permission denied`. Run from a non-default git branch
+    ([first run](first-run.md) explains why).
 
 === "From source"
 
     ```bash
     git clone https://github.com/sipyourdrink-ltd/bernstein
     cd bernstein
-    uv venv && uv pip install -e ".[dev]"
+    uv venv && uv pip install -e .
+    source .venv/bin/activate
+    bernstein --version
     ```
+
+    For a development install (tests, linters, the `.[dev]` extras - which
+    need a C toolchain) see
+    [CONTRIBUTING.md](https://github.com/sipyourdrink-ltd/bernstein/blob/main/CONTRIBUTING.md).
+
+=== "Dev container"
+
+    The repo ships a `.devcontainer/` (Python 3.12, pipx, port 8052 forwarded)
+    for GitHub Codespaces / VS Code Dev Containers. It is aimed at working
+    **on** Bernstein itself; to use Bernstein in your own project, pick one of
+    the other methods.
+
+---
+
+## Run without installing
+
+- `uvx bernstein` - downloads the latest release into a temporary environment
+  and runs it. Needs [`uv`](https://docs.astral.sh/uv/).
+- `npx bernstein-orchestrator` - Node wrapper that delegates to an existing
+  Python setup. It does **not** install Bernstein: it requires Python 3.12+
+  **and** `pipx` or `uv` on `$PATH`, then runs Bernstein through them.
 
 ---
 
 ## One-liner installers
 
-For fresh machines that don't have Python set up yet, the install scripts bootstrap
-Python (via `pyenv` or system package), pipx, and Bernstein in one step.
+On a machine that already has Python 3.12+, the install scripts set up pipx and
+Bernstein in one step. They **check** for Python 3.12+ and stop with an error if
+it is missing - they do not install Python itself.
 
 ```bash
 curl -fsSL https://bernstein.run/install.sh | sh           # macOS / Linux
@@ -173,8 +196,15 @@ You should see the current release version. Then run the pre-flight check:
 bernstein doctor
 ```
 
-`doctor` checks Python version, port availability, your `$PATH`, and any installed CLI agents.
-A clean run prints all green. If something fails, it tells you exactly which step to fix.
+`doctor` checks your setup end to end: installed agent CLIs (adapters), API keys,
+port availability, the `.sdd` workspace, and supporting tools.
+
+Straight after an install - before you have configured an agent CLI or an API
+key - **expect red rows** for adapters, auth, the workspace, and "Ready to run",
+and a non-zero exit code. Those clear as you work through the
+[first run](first-run.md). At this stage you only need `bernstein --version`
+working and the Python and port checks green. Each failing row names the step
+to fix.
 
 > **`command not found: bernstein`**
 > Your tool bin directory is not on `$PATH`. Add it:

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -34,9 +34,14 @@ If you nodded at two of those bullets, this fits.
 - forward-deployed engineering: drop the crew onto a client repo when you arrive, take it with you when you leave.
 - self-evolving projects: point Bernstein at its own repo and let it execute the backlog (the Bernstein codebase is one).
 - CI fleets: run a crew of agents in parallel on PRs, with per-agent credential scoping and an opt-in signed audit trail.
-- air-gapped deployment: install from a signed wheelhouse, run with `--profile airgap` to deny outbound by default. See [air-gap installation](installation/air-gap.md).
+- air-gapped deployment: install from a signed wheelhouse, run with `bernstein run --profile airgap` to deny outbound by default. See [air-gap installation](installation/air-gap.md).
 
 ## Common workflows
+
+The commands below assume the basics from the
+[first run](getting-started/first-run.md): at least one agent CLI with its API
+key configured, and a checked-out **working branch** - `bernstein -g` refuses to
+start on the repository default branch.
 
 ### Parallel test generation with AI agents
 
@@ -53,20 +58,29 @@ Good fit when you want broad coverage quickly, but still need janitor verificati
 Some teams use Bernstein as the repair loop after review has already happened. The autofix daemon watches open PRs, classifies failing checks, and dispatches a scoped fix run when CI turns red.
 
 ```bash
+# One-time: the daemon needs at least one [[repo]] entry in
+# ~/.config/bernstein/autofix.toml before it will do any work:
+#   [[repo]]
+#   name = "your-org/your-repo"
 bernstein autofix start --repo your-org/your-repo --foreground
 ```
 
-Good fit when the painful part is not finding failures, but paying the context-switch tax every time lint, typing, or a focused test failure breaks a PR. See [operations/autofix.md](operations/autofix.md).
+Good fit when the painful part is not finding failures, but paying the context-switch tax every time lint, typing, or a focused test failure breaks a PR. Config format and the full gate list: [operations/autofix.md](operations/autofix.md).
 
 ### PR review follow-up from inline comments
 
 Review comments are often small, mechanical, and easy to lose between pushes. Bernstein's review-responder daemon turns those comments into tracked work so the author can keep moving while the system handles the obvious follow-up.
 
 ```bash
+export BERNSTEIN_REVIEW_WEBHOOK_SECRET=...   # required; shared with the GitHub webhook
 bernstein review-responder start --repo your-org/your-repo --foreground
 ```
 
-Good fit when your team already does human review but wants the "please rename this / add a guard / update the test" loop to close faster. See [operations/review-responder.md](operations/review-responder.md).
+The daemon refuses to start without the webhook secret. To receive comments it
+also needs the repo webhook pointed at it (or it falls back to polling via
+`gh`) - setup steps in [operations/review-responder.md](operations/review-responder.md).
+
+Good fit when your team already does human review but wants the "please rename this / add a guard / update the test" loop to close faster.
 
 ### Large-scale codebase modernization
 
@@ -83,6 +97,7 @@ Good fit when the change is spread across many files and the main risk is merge 
 A lot of teams do not want another planning system; they want their existing tickets to become executable work. Bernstein can import a ticket URL, infer scope, and immediately turn it into a run.
 
 ```bash
+bernstein connect github   # one-time; or export GITHUB_TOKEN=...
 bernstein from-ticket https://github.com/your-org/your-repo/issues/123 --run
 ```
 

--- a/packaging/homebrew/bernstein.rb
+++ b/packaging/homebrew/bernstein.rb
@@ -11,6 +11,12 @@ class Bernstein < Formula
 
   depends_on "python@3.12"
 
+  # BROKEN as-is: `virtualenv_install_with_resources` with no `resource`
+  # blocks installs bernstein via `pip --no-deps`, so the resulting binary
+  # fails at startup (ModuleNotFoundError: no module named 'click').
+  # Do not publish this formula until the runtime closure ships as
+  # resources (or the install strategy changes). Tracked in
+  # https://github.com/sipyourdrink-ltd/bernstein/issues/3573.
   def install
     virtualenv_install_with_resources
   end


### PR DESCRIPTION
# User description
## What

Fixes verified defects in the two most-read onboarding docs (`docs/getting-started/install.md`, `docs/use-cases.md`) plus the shipping defect behind the Docker install path. Install paths were exercised in clean containers; the docs now match observed behaviour.

## Dockerfile: first-run permission failure

`VOLUME ["/workspace/.sdd"]` made the daemon create an anonymous volume owned `root:root 0755` while the container runs as `USER bernstein` (uid 1000), so the documented one-liner always failed. The VOLUME line is removed (persistence still works via the documented bind mounts).

Dockerfile changes are on CI's paths-ignore list (no Docker smoke lane), so verified locally:

Published image (before):
```
$ docker run --rm -v "$PWD":/workspace -p 8053:8052 ghcr.io/sipyourdrink-ltd/bernstein -g "your goal"
Permission denied - Could not create worktree at `/workspace/.sdd/runtime`.
exit=77
```

Image built from this branch (after), fresh dir, non-default branch, container uid 1000:
```
$ docker run --rm -v "$PWD":/workspace --entrypoint sh bernstein-instfix-test -c \
    'echo "uid=$(id -u)"; mkdir -p /workspace/.sdd/runtime && echo MKDIR_OK && touch /workspace/.sdd/runtime/probe && echo WRITE_OK'
uid=1000
MKDIR_OK
WRITE_OK

$ docker run --rm -v "$PWD":/workspace -p 8052:8052 bernstein-instfix-test -g "your goal"
... reaches the EXECUTION PLAN approval screen; grep -ci "permission denied" over full output: 0
```

The doc snippet also gains an explicit `-v "$(pwd)/.sdd":/workspace/.sdd` mount, which is required for already-published images and harmless afterwards.

## install.md

- Homebrew tab marked temporarily unavailable, linking #3573 (formula installs zero runtime deps -> `ModuleNotFoundError: click`; regenerating the 82-package resource closure was not shippable inline, details in the issue). The formula template gets a do-not-publish warning comment.
- COPR tab marked not yet available, linking #3558; apt tab no longer claims an APT channel exists.
- One-liner installer paragraph scoped to reality: the scripts check for Python 3.12+ and exit if missing; they do not bootstrap Python.
- `npx bernstein-orchestrator` moved out of install methods into a "Run without installing" section with its real prerequisites (it only delegates to pipx/uv); `uvx bernstein` documented alongside (verified working).
- From-source: `uv pip install -e .` + venv activation so the verify step can pass; `.[dev]` (needs a C toolchain) deferred to CONTRIBUTING.
- `doctor` section describes what it actually checks and states that red adapter/auth/workspace rows and a non-zero exit are expected before first-run configuration.
- Requirements section points at what the first run will additionally need; devcontainer noted as contributor-oriented.

## use-cases.md

- Shared preamble: snippets need an agent CLI + API key and a working branch (`-g` refuses the default branch).
- `review-responder`: `BERNSTEIN_REVIEW_WEBHOOK_SECRET` shown (daemon refuses to start without it) plus webhook/polling note.
- `from-ticket`: preceded by `bernstein connect github` / `GITHUB_TOKEN`.
- `autofix`: minimal `[[repo]]` config shown (daemon does no work without it).
- Air-gap example written as `bernstein run --profile airgap` (`--profile` is a `run` option, not a root option).

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Align onboarding and use-case documentation with verified installation, configuration, and command behavior, while fixing Docker first-run permissions. Update the install guidance, workflow examples, and Homebrew packaging warnings, and remove the Docker anonymous volume that prevented the non-root daemon from creating workspace state.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3574?tool=ast&topic=Use-case+workflows>Use-case workflows</a>
        </td><td>Correct workflow prerequisites, authentication setup, repository configuration, webhook behavior, GitHub connectivity, and the air-gap command syntax.<details><summary>Modified files (1)</summary><ul><li>docs/use-cases.md</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3574?tool=ast&topic=Installation+onboarding>Installation onboarding</a>
        </td><td>Update installation guidance and packaging behavior for Docker, Python-based installs, unavailable distribution channels, first-run requirements, and diagnostic expectations.<details><summary>Modified files (3)</summary><ul><li>Dockerfile</li>
<li>docs/getting-started/install.md</li>
<li>packaging/homebrew/bernstein.rb</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3574?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>