### PR TITLE
Update existing_keys to convert keys to strings

### DIFF
--- a/src/bernstein/tui/task_list.py
+++ b/src/bernstein/tui/task_list.py
@@ -423,7 +423,7 @@ class TaskListWidget(DataTable[Text]):
         """
         # Build a lookup of incoming rows by task_id
         incoming: dict[str, TaskRow] = {r.task_id: r for r in rows}
-        existing_keys: set[str] = set(self.rows)
+        existing_keys: set[str] = {str(key) for key in self.rows}
 
         # Remove rows no longer present
         for key in existing_keys - incoming.keys():


### PR DESCRIPTION
## What

Fixes a pre-existing typing error in `src/bernstein/tui/task_list.py` where `set(self.rows)` yielded `set[RowKey]` but was diffed against a set of plain strings `(incoming.keys())`.

## Why

Part of the typing cleanup tracked in #2980.

The `task_list.py:426` error was flagged by the maintainer as a likely pre-existing bug rather than a pure typing issue. Because RowKey objects were being compared against strings, the stale-row cleanup logic was silently failing to match anything. This PR fixes the typing properly (without `# type: ignore`) and ensures the cleanup logic actually works.

Before: 9 errors in 2 filesAfter: 8 errors in 1 file (remaining 8 are the out-of-scope `Notifications API` mismatch cluster in `app.py`).

## How

Changed line 426 in src/bernstein/tui/task_list.py from:

```python
existing_keys: set[str] = set(self.rows)
```
To:

```
existing_keys: set[str] = {str(key) for key in self.rows}
```

## Checklist

- [x] `uv run ruff check src/` passes
- [ ] `uv run pyright src/` passes (Note: Did not run this specific command, as the issue instructions specified `mypy`, `ruff`, and `pytest`)
- [ ] `uv run python scripts/run_tests.py -x` passes (Note: Ran the specific test files requested in the issue: `uv run pytest tests/unit/test_slo_burndown.py tests/unit/test_tui.py -q`)
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)

- [x] User-visible README section updated (or N/A if internal-only)
- [x] `docs/operations/<area>.md` updated (or N/A)
- [x] `docs/api/` schema regenerated if a public surface changed (or N/A)
- [x] `uv run bernstein agents-md sync` run so AGENTS.md, CLAUDE.md, `.goosehints`, `CONVENTIONS.md`, and `.cursor/rules/*.mdc` reflect any new module (or N/A)
- [x] Tests cover the documented behaviour
