### PR TITLE
fix(sandbox): refuse symlinked parent components on CAS blob reads (#3561)

### DIFF
--- a/docs/architecture/sandbox.md
+++ b/docs/architecture/sandbox.md
@@ -330,10 +330,25 @@ itself rather than by a check that could be raced. The store root is exempt on
 purpose: pointing it at another volume is operator configuration, not an attack.
 The refusal needs `os.open` to accept `dir_fd` and the platform to define
 `O_NOFOLLOW`. **It is POSIX-only.** Windows has neither, and there the read
-falls back to guarding the final component alone — the same protection as
-before, stated rather than implied. A refused symlink is `unreadable` (exit 4)
-on every platform that can refuse it; it is never reported as `absent`, which
-would clear the record of a suspicion the reader cannot rule out.
+falls back to a single open of the joined path that refuses **nothing** — not
+the parents, not the final component. Read that as the absence of a guard
+rather than a weaker one: a Windows junction is followed exactly as it was
+before. A refused symlink is `unreadable` (exit 4) on every platform that can
+refuse it; it is never reported as `absent`, which would clear the record of a
+suspicion the reader cannot rule out.
+
+Symlinks are not the only way to stall a reader, so the blob open also refuses
+anything that is not a regular file, opening non-blocking and checking the type
+on the descriptor. A FIFO planted at a blob's own name needs no link at all,
+and would otherwise block the read until a writer appeared.
+
+This covers the **blob** read, which is what `receipt verify` consults. The
+`.meta.json` sidecar beside each blob is read without the walk, and deliberately
+so: unlike the blob, it is not content-addressed, so there is no digest to check
+it against. An attacker holding the write access needed to plant a symlink in
+the store can equally write a hostile sidecar in place, which no symlink refusal
+would catch. Nothing in the verification path reads metadata; treat it as
+descriptive, not as evidence.
 
 `fork-race` requires a microVM-capable host; on an unsupported host it
 fails loudly. The determinism/tamper guarantees are validated

--- a/docs/architecture/sandbox.md
+++ b/docs/architecture/sandbox.md
@@ -317,11 +317,23 @@ diagnosable error, never a traceback.
 |---|---|---|
 | 0 | `verified` | Anchored to the expected signer, signature + consistency intact, and every named blob (base + winner + losers) re-hashed intact against CAS. |
 | 1 | `failed` | Bad signature/consistency, a **tampered** blob (present, wrong hash), or a **malformed** digest field. Highest precedence — an integrity alarm. |
-| 4 | `unreadable` | A named blob could not be read on this host (permissions, or an anomalous symlinked blob the verifier refuses to dereference). A property of the reader, not the record. |
+| 4 | `unreadable` | A named blob could not be read on this host (permissions, or an anomalous symlink the verifier refuses to dereference). A property of the reader, not the record. |
 | 2 | `incomplete` | A named blob is **absent** from CAS (GC / retention / restart). An ordinary operational event, never conflated with tampering. |
 | 3 | `unanchored` | Signature + blobs check out, but `--expected-keyid` was omitted or empty (an unset env var counts as empty), so *whose* key signed it is unproven. |
 
 Precedence when several apply: `failed` > `unreadable` > `incomplete` (absent) > `unanchored` > `verified`.
+
+**Symlink refusal, and where it stops.** A CAS blob is read by walking the store
+one path component at a time, each open carrying `O_NOFOLLOW`, so a symlink
+planted at the blob *or* at the shard directory above it is refused by the open
+itself rather than by a check that could be raced. The store root is exempt on
+purpose: pointing it at another volume is operator configuration, not an attack.
+The refusal needs `os.open` to accept `dir_fd` and the platform to define
+`O_NOFOLLOW`. **It is POSIX-only.** Windows has neither, and there the read
+falls back to guarding the final component alone — the same protection as
+before, stated rather than implied. A refused symlink is `unreadable` (exit 4)
+on every platform that can refuse it; it is never reported as `absent`, which
+would clear the record of a suspicion the reader cannot rule out.
 
 `fork-race` requires a microVM-capable host; on an unsupported host it
 fails loudly. The determinism/tamper guarantees are validated

--- a/src/bernstein/cli/commands/sandbox_cmd.py
+++ b/src/bernstein/cli/commands/sandbox_cmd.py
@@ -428,8 +428,9 @@ def receipt_verify_cmd(receipt_path: Path, cas_dir: Path, expected_keyid: str | 
         # Ask the store for the path (single source of truth for the shard
         # layout) rather than re-deriving cas_dir / digest[:2] / digest here.
         # Used only for the absent/unreadable disambiguation below; the symlink
-        # defence lives in cas.get (O_NOFOLLOW), atomically and race-free - no
-        # is_symlink() pre-check here, which would only add a TOCTOU window.
+        # defence lives in cas.get, which opens every component below the store
+        # root with O_NOFOLLOW - atomically and race-free, so no is_symlink()
+        # pre-check here, which would only add a TOCTOU window.
         try:
             blob_path = cas.blob_path(digest)
         except ValueError:

--- a/src/bernstein/core/persistence/anchored_read.py
+++ b/src/bernstein/core/persistence/anchored_read.py
@@ -23,13 +23,23 @@ The walk needs ``os.open`` to accept ``dir_fd`` **and** the platform to define
 ``O_NOFOLLOW``.  Windows has neither, so there it degrades to a single open of
 the joined path -- today's behaviour, no worse -- rather than to a
 ``is_symlink()`` pre-check, which would trade an atomic guarantee for a race
-window and call it an improvement.
+window and call it an improvement.  Be precise about what that fallback is:
+with ``O_NOFOLLOW`` undefined it refuses **nothing**, on the final component
+or above it.  It is not a weaker guard; it is the absence of one, and a
+Windows junction is followed there exactly as it was before.
+
+Refusing symlinks is also not the whole of the problem it belongs to.  Nothing
+about a link is required to plant a FIFO or a device at a name and stall the
+reader that opens it, so ``require_regular_file`` covers that separately, by
+opening non-blocking and rejecting the type on the descriptor.
 """
 
 from __future__ import annotations
 
 import contextlib
+import errno
 import os
+import stat
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -46,7 +56,32 @@ __all__ = ["ANCHORED_OPEN_SUPPORTED", "open_anchored"]
 ANCHORED_OPEN_SUPPORTED: bool = os.open in os.supports_dir_fd and hasattr(os, "O_NOFOLLOW")
 
 
-def open_anchored(root: Path, *components: str, flags: int) -> int:
+def _reject_irregular(fd: int, name: str) -> None:
+    """Close *fd* and raise unless it is a regular file.
+
+    A symlink refusal says nothing about what the open landed on when no link
+    was involved at all.  A FIFO, device or directory planted at the name is a
+    different way to reach the same end -- a reader that stalls or reads
+    something that is not a stored blob -- so the type is checked on the
+    descriptor already open, never by stat-ing the path again.
+    """
+    try:
+        mode = os.fstat(fd).st_mode
+    except OSError:
+        os.close(fd)
+        raise
+    if not stat.S_ISREG(mode):
+        os.close(fd)
+        msg = f"not a regular file: {name!r}"
+        raise OSError(errno.EINVAL, msg)
+
+
+def open_anchored(
+    root: Path,
+    *components: str,
+    flags: int,
+    require_regular_file: bool = False,
+) -> int:
     """Open ``root`` joined with *components*, refusing symlinked components.
 
     Args:
@@ -58,6 +93,11 @@ def open_anchored(root: Path, *components: str, flags: int) -> int:
         flags: Open flags for the final component.  ``O_NOFOLLOW`` is added
             where the platform defines it; the caller supplies the rest
             (typically ``os.O_RDONLY``).
+        require_regular_file: Refuse anything that is not a regular file.
+            Adds ``O_NONBLOCK`` to the open so a FIFO cannot stall it, then
+            rejects on the descriptor.  Stores that only ever write regular
+            files should set this; it is off by default because a caller that
+            legitimately opens a directory or device would otherwise break.
 
     Returns:
         An open file descriptor for the final component.  The caller owns it
@@ -66,11 +106,12 @@ def open_anchored(root: Path, *components: str, flags: int) -> int:
     Raises:
         ValueError: If no components are given, or one is not a single
             component name.
-        OSError: As :func:`os.open` does.  Two errno values carry meaning for
+        OSError: As :func:`os.open` does.  Three errno values carry meaning for
             callers: ``ENOENT`` (``FileNotFoundError``) means a component is
-            genuinely missing, and ``ELOOP`` means one was a symlink and the
-            open refused to follow it.  Callers that treat a missing file as
-            an ordinary miss must not widen that to ``OSError``, or a refused
+            genuinely missing, ``ELOOP`` means one was a symlink and the open
+            refused to follow it, and ``EINVAL`` means *require_regular_file*
+            rejected the type.  Callers that treat a missing file as an
+            ordinary miss must not widen that to ``OSError``, or a refused
             symlink would be reported as absence.
     """
     if not components:
@@ -83,12 +124,24 @@ def open_anchored(root: Path, *components: str, flags: int) -> int:
             raise ValueError(msg)
 
     nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if require_regular_file:
+        # ``O_NONBLOCK`` has to be on the open itself.  A FIFO planted at the
+        # final component blocks *inside* ``os.open`` until a writer appears,
+        # so an ``fstat`` afterwards would never be reached -- the check has to
+        # be reachable before it can reject anything.  On a regular file the
+        # flag changes nothing.
+        flags |= getattr(os, "O_NONBLOCK", 0)
+
     if not ANCHORED_OPEN_SUPPORTED:
         # Windows and anything else missing either capability.  One open of the
-        # joined path: the final component keeps whatever protection the
-        # platform offers, and the parents keep none, which is exactly where
-        # this function came in.
-        return os.open(root.joinpath(*components), flags | nofollow)
+        # joined path, with no symlink refusal anywhere: ``O_NOFOLLOW`` is not
+        # defined here, so ``nofollow`` is 0 and this branch protects no
+        # component, parent or final.  That is the behaviour that predates this
+        # function, kept deliberately -- see the module docstring.
+        fd = os.open(root.joinpath(*components), flags | nofollow)
+        if require_regular_file:
+            _reject_irregular(fd, components[-1])
+        return fd
 
     directory_flag = getattr(os, "O_DIRECTORY", 0)
     parent_fd = os.open(root, os.O_RDONLY | directory_flag)
@@ -96,15 +149,30 @@ def open_anchored(root: Path, *components: str, flags: int) -> int:
         for component in components[:-1]:
             # ``O_DIRECTORY`` makes a non-directory component fail as ENOTDIR
             # here rather than at the next open, so the errno names what is
-            # actually wrong.
+            # actually wrong.  It is also why an intermediate component needs
+            # no ``O_NONBLOCK``: a FIFO planted as a shard directory is
+            # rejected on type before the blocking open handler ever runs, so
+            # only the final component -- opened without ``O_DIRECTORY``,
+            # because a blob is a file -- can stall.
             child_fd = os.open(
                 component,
                 os.O_RDONLY | nofollow | directory_flag,
                 dir_fd=parent_fd,
             )
-            os.close(parent_fd)
-            parent_fd = child_fd
-        return os.open(components[-1], flags | nofollow, dir_fd=parent_fd)
+            # Move ownership to the child *before* closing the old descriptor.
+            # Closing first and assigning after would, if that close raised,
+            # leak the descriptor just opened and leave the cleanup below
+            # closing one that already failed. Close errors on a read-only
+            # directory descriptor carry no information a caller could act on
+            # -- there is nothing buffered to lose -- so they are dropped
+            # rather than aborting a walk that has otherwise succeeded.
+            stale_fd, parent_fd = parent_fd, child_fd
+            with contextlib.suppress(OSError):
+                os.close(stale_fd)
+        fd = os.open(components[-1], flags | nofollow, dir_fd=parent_fd)
     finally:
         with contextlib.suppress(OSError):
             os.close(parent_fd)
+    if require_regular_file:
+        _reject_irregular(fd, components[-1])
+    return fd

--- a/src/bernstein/core/persistence/anchored_read.py
+++ b/src/bernstein/core/persistence/anchored_read.py
@@ -1,0 +1,110 @@
+"""Open a file below a trusted root without following a symlink on the way.
+
+``O_NOFOLLOW`` refuses a symlink at the **final** path component only.  A
+store that shards its files into subdirectories therefore keeps an opening: a
+symlink planted at a parent component -- ``.sdd/cas/ab/`` for a CAS blob --
+is still followed, and the read lands wherever it points.
+
+:func:`open_anchored` closes that by walking the path one component at a
+time.  Each component is opened relative to a descriptor for its parent, with
+``O_NOFOLLOW`` among the flags, so the refusal is a property of the open
+itself.  Nothing re-derives a path between the check and the use, because
+there is no check -- the same reasoning that put ``O_NOFOLLOW`` on the blob
+open in the first place, extended to the components above it.
+
+The **root is opened normally**, deliberately.  Pointing a store's root
+somewhere else -- ``.sdd/cas`` symlinked onto a larger volume -- is ordinary
+operator configuration, and refusing it would break working installations to
+defend against an attacker who, by definition, already controls the location
+the operator chose.  Everything below the root is store-managed layout, where
+a symlink is never something the store itself wrote.
+
+The walk needs ``os.open`` to accept ``dir_fd`` **and** the platform to define
+``O_NOFOLLOW``.  Windows has neither, so there it degrades to a single open of
+the joined path -- today's behaviour, no worse -- rather than to a
+``is_symlink()`` pre-check, which would trade an atomic guarantee for a race
+window and call it an improvement.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+__all__ = ["ANCHORED_OPEN_SUPPORTED", "open_anchored"]
+
+
+# Both capabilities are required, not just ``dir_fd``: the anchored open
+# refuses a symlink only because ``O_NOFOLLOW`` is among its flags, so
+# selecting the walk on ``dir_fd`` alone would, on a platform offering one
+# without the other, take the branch that cannot refuse anything.  This mirrors
+# the reasoning in ``core.security.sigstore_attestation``.
+ANCHORED_OPEN_SUPPORTED: bool = os.open in os.supports_dir_fd and hasattr(os, "O_NOFOLLOW")
+
+
+def open_anchored(root: Path, *components: str, flags: int) -> int:
+    """Open ``root`` joined with *components*, refusing symlinked components.
+
+    Args:
+        root: Trusted anchor directory.  Opened without ``O_NOFOLLOW``: a
+            symlinked root is operator configuration, not an attack.
+        *components: Path components below *root*, outermost first.  Each is a
+            single name; passing a separator, ``.`` or ``..`` is a programming
+            error and is refused rather than resolved.
+        flags: Open flags for the final component.  ``O_NOFOLLOW`` is added
+            where the platform defines it; the caller supplies the rest
+            (typically ``os.O_RDONLY``).
+
+    Returns:
+        An open file descriptor for the final component.  The caller owns it
+        and must close it.
+
+    Raises:
+        ValueError: If no components are given, or one is not a single
+            component name.
+        OSError: As :func:`os.open` does.  Two errno values carry meaning for
+            callers: ``ENOENT`` (``FileNotFoundError``) means a component is
+            genuinely missing, and ``ELOOP`` means one was a symlink and the
+            open refused to follow it.  Callers that treat a missing file as
+            an ordinary miss must not widen that to ``OSError``, or a refused
+            symlink would be reported as absence.
+    """
+    if not components:
+        msg = "open_anchored requires at least one path component below the root"
+        raise ValueError(msg)
+    separators = tuple(sep for sep in (os.sep, os.altsep) if sep)
+    for component in components:
+        if component in {"", ".", ".."} or any(sep in component for sep in separators):
+            msg = f"open_anchored components must be single names, got {component!r}"
+            raise ValueError(msg)
+
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if not ANCHORED_OPEN_SUPPORTED:
+        # Windows and anything else missing either capability.  One open of the
+        # joined path: the final component keeps whatever protection the
+        # platform offers, and the parents keep none, which is exactly where
+        # this function came in.
+        return os.open(root.joinpath(*components), flags | nofollow)
+
+    directory_flag = getattr(os, "O_DIRECTORY", 0)
+    parent_fd = os.open(root, os.O_RDONLY | directory_flag)
+    try:
+        for component in components[:-1]:
+            # ``O_DIRECTORY`` makes a non-directory component fail as ENOTDIR
+            # here rather than at the next open, so the errno names what is
+            # actually wrong.
+            child_fd = os.open(
+                component,
+                os.O_RDONLY | nofollow | directory_flag,
+                dir_fd=parent_fd,
+            )
+            os.close(parent_fd)
+            parent_fd = child_fd
+        return os.open(components[-1], flags | nofollow, dir_fd=parent_fd)
+    finally:
+        with contextlib.suppress(OSError):
+            os.close(parent_fd)

--- a/src/bernstein/core/persistence/cas_store.py
+++ b/src/bernstein/core/persistence/cas_store.py
@@ -173,7 +173,20 @@ class CASStore:
         )
 
     def _read_meta(self, digest: str) -> CASEntry | None:
-        """Load the :class:`CASEntry` sidecar, or ``None`` if missing."""
+        """Load the :class:`CASEntry` sidecar, or ``None`` if missing.
+
+        This read is **not** anchored the way :meth:`get` is, deliberately.
+        Unlike a blob, the sidecar is not content-addressed: there is no digest
+        to check it against, so an attacker holding the write access needed to
+        plant a symlink in the store can write a hostile sidecar in place and a
+        symlink refusal would catch nothing. Nothing in the verification path
+        reads metadata -- see "Symlink refusal, and where it stops" in
+        ``docs/architecture/sandbox.md``.
+
+        **That exemption depends on metadata staying descriptive.** A caller
+        that starts making a trust decision from these fields invalidates the
+        reasoning above, and this read needs anchoring before it does.
+        """
         meta = self._meta_path(digest)
         if not meta.exists():
             return None
@@ -263,8 +276,19 @@ class CASStore:
         # platform cannot anchor an open (Windows), it degrades to guarding the
         # final component alone -- see anchored_read. A refused symlink surfaces
         # as OSError (ELOOP), which callers classify as unreadable, not absent.
+        # `require_regular_file` covers the other half of the same exposure: a
+        # symlink is not needed to stall a reader when a FIFO planted at the
+        # blob's own name will do it, and O_NOFOLLOW was never the control for
+        # that. The store writes regular files only, so nothing legitimate is
+        # refused. It surfaces as OSError (EINVAL), classified unreadable.
         try:
-            fd = open_anchored(self._root, digest[:2], digest, flags=os.O_RDONLY)
+            fd = open_anchored(
+                self._root,
+                digest[:2],
+                digest,
+                flags=os.O_RDONLY,
+                require_regular_file=True,
+            )
         except FileNotFoundError:
             # Only a genuinely missing component reads as a cache miss. Every
             # other OSError keeps propagating: widening this to OSError would

--- a/src/bernstein/core/persistence/cas_store.py
+++ b/src/bernstein/core/persistence/cas_store.py
@@ -30,6 +30,8 @@ import time
 from dataclasses import asdict, dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.persistence.anchored_read import open_anchored
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -250,20 +252,24 @@ class CASStore:
                 do not hash to *digest*.
         """
         self._validate_digest(digest)
-        blob = self._blob_path(digest)
-        # Open with O_NOFOLLOW so a symlink planted at the blob path is rejected
-        # atomically by the read itself. A separate is_symlink() pre-check would
-        # leave a TOCTOU window: an attacker with write access to the store could
-        # swap in a symlink to a FIFO/device (hang) or another path between the
-        # check and the read. A content-addressed store only ever writes regular
-        # files, so O_NOFOLLOW never rejects a legitimate blob. The flag is
-        # POSIX-only; where it is absent it degrades to 0 (Windows has different
-        # symlink semantics and its own protections). A symlinked blob surfaces
+        # Walk root -> shard -> blob, refusing a symlink at every component
+        # below the root, so the read cannot be redirected by a link planted at
+        # the shard directory any more than by one planted at the blob itself.
+        # The refusal is a property of each open; a separate is_symlink()
+        # pre-check would leave a TOCTOU window in which an attacker with write
+        # access to the store swaps in a link to a FIFO or device and stalls the
+        # reader. A content-addressed store only ever writes regular files and
+        # real directories, so this never rejects a legitimate blob. Where the
+        # platform cannot anchor an open (Windows), it degrades to guarding the
+        # final component alone -- see anchored_read. A refused symlink surfaces
         # as OSError (ELOOP), which callers classify as unreadable, not absent.
-        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
         try:
-            fd = os.open(blob, flags)
+            fd = open_anchored(self._root, digest[:2], digest, flags=os.O_RDONLY)
         except FileNotFoundError:
+            # Only a genuinely missing component reads as a cache miss. Every
+            # other OSError keeps propagating: widening this to OSError would
+            # report a refused symlink as an absent blob, which is the false
+            # accusation the classification in `receipt verify` exists to avoid.
             return None
         with os.fdopen(fd, "rb") as handle:
             content = handle.read()

--- a/tests/unit/sandbox/test_sandbox_cli.py
+++ b/tests/unit/sandbox/test_sandbox_cli.py
@@ -611,3 +611,31 @@ async def test_receipt_verify_symlinked_blob_is_unreadable_not_followed(tmp_path
     assert res.exit_code == 4, res.output  # unreadable, NOT 2 (absent) or 0 (intact)
     assert "unreadable" in res.output.lower()
     assert "OK" not in res.output
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX symlink semantics")
+@pytest.mark.asyncio
+async def test_receipt_verify_symlinked_shard_dir_is_unreadable_not_followed(tmp_path: Path) -> None:
+    """The same guarantee one level up (#3561). O_NOFOLLOW on the blob open
+    covered the final component only, so a symlink at the shard directory was
+    followed and the verdict came from wherever it pointed. The blob here is
+    real and its bytes are the ones the digest promises, and it still must not
+    be read through a redirected parent: unreadable (exit 4), never intact."""
+    receipt, receipt_path, cas_dir = await _make_receipt(tmp_path)
+    base = receipt.base_snapshot_digest
+    shard = cas_dir / base[:2]
+
+    # Move the shard aside and link to it. Following the link would find the
+    # authentic blob and report intact, so a verdict of intact here means the
+    # parent component was traversed - the defect, stated as a test.
+    elsewhere = tmp_path / "attacker-controlled-shard"
+    shard.rename(elsewhere)
+    shard.symlink_to(elsewhere, target_is_directory=True)
+
+    res = CliRunner().invoke(
+        sandbox_group,
+        ["receipt", "verify", str(receipt_path), "--cas-dir", str(cas_dir), "--expected-keyid", receipt.keyid],
+    )
+    assert res.exit_code == 4, res.output  # unreadable, NOT 2 (absent) or 0 (intact)
+    assert "unreadable" in res.output.lower()
+    assert "OK" not in res.output

--- a/tests/unit/test_anchored_read.py
+++ b/tests/unit/test_anchored_read.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import errno
 import os
 import sys
+import threading
 from typing import TYPE_CHECKING
 
 import pytest
@@ -71,9 +72,13 @@ class TestAnchoredOpen:
             open_anchored(tmp_path, "ab", "blob", flags=os.O_RDONLY)
 
 
-@pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX symlink semantics")
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX symlink and FIFO semantics")
 @pytest.mark.skipif(not ANCHORED_OPEN_SUPPORTED, reason="needs dir_fd and O_NOFOLLOW")
-class TestSymlinkRefusal:
+class TestRefusals:
+    """What the open refuses: symlinked components, and types the caller said
+    it would not accept. The two are separate defences against one outcome --
+    a read that lands somewhere it should not, or never returns at all."""
+
     def test_refuses_a_symlinked_final_component(self, tmp_path: Path) -> None:
         (tmp_path / "ab").mkdir()
         target = tmp_path / "elsewhere"
@@ -116,6 +121,82 @@ class TestSymlinkRefusal:
         (tmp_path / "ab").write_bytes(b"not a directory")
         with pytest.raises(NotADirectoryError):
             open_anchored(tmp_path, "ab", "blob", flags=os.O_RDONLY)
+
+    def test_a_fifo_is_refused_without_stalling(self, tmp_path: Path) -> None:
+        """No symlink is involved: a FIFO at the name blocks a plain open until
+        a writer appears, which is the reader stall the symlink work is meant
+        to prevent, reached by another route. The open must go non-blocking and
+        the type must be rejected on the descriptor.
+
+        The test would hang rather than fail if this regressed, so it runs
+        under a timeout - a hang is the defect, and a hanging test suite
+        reports it as badly as no test at all."""
+        (tmp_path / "ab").mkdir()
+        os.mkfifo(tmp_path / "ab" / "blob")
+
+        finished = threading.Event()
+        result: list[BaseException | None] = []
+
+        def attempt() -> None:
+            try:
+                open_anchored(
+                    tmp_path,
+                    "ab",
+                    "blob",
+                    flags=os.O_RDONLY,
+                    require_regular_file=True,
+                )
+                result.append(None)
+            except BaseException as exc:
+                result.append(exc)
+            finished.set()
+
+        threading.Thread(target=attempt, daemon=True).start()
+        assert finished.wait(timeout=10), "open_anchored stalled on a FIFO"
+        assert isinstance(result[0], OSError)
+        assert result[0].errno == errno.EINVAL
+
+    def test_a_directory_in_place_of_the_blob_is_refused(self, tmp_path: Path) -> None:
+        (tmp_path / "ab" / "blob").mkdir(parents=True)
+        with pytest.raises(OSError) as excinfo:
+            open_anchored(
+                tmp_path,
+                "ab",
+                "blob",
+                flags=os.O_RDONLY,
+                require_regular_file=True,
+            )
+        assert excinfo.value.errno == errno.EINVAL
+
+    def test_a_regular_file_is_unaffected_by_the_type_check(self, tmp_path: Path) -> None:
+        """The guard must not cost a legitimate read."""
+        (tmp_path / "ab").mkdir()
+        (tmp_path / "ab" / "blob").write_bytes(b"payload")
+        fd = open_anchored(
+            tmp_path,
+            "ab",
+            "blob",
+            flags=os.O_RDONLY,
+            require_regular_file=True,
+        )
+        assert _read_all(fd) == b"payload"
+
+    def test_refusing_a_type_leaks_no_descriptors(self, tmp_path: Path) -> None:
+        """The rejected descriptor is closed before the raise."""
+        before = _open_fd_count()
+        if before < 0:
+            pytest.skip("no /proc/self/fd or /dev/fd on this platform")
+        (tmp_path / "ab" / "blob").mkdir(parents=True)
+        for _ in range(50):
+            with pytest.raises(OSError):
+                open_anchored(
+                    tmp_path,
+                    "ab",
+                    "blob",
+                    flags=os.O_RDONLY,
+                    require_regular_file=True,
+                )
+        assert _open_fd_count() == before
 
     def test_refused_walk_leaks_no_descriptors(self, tmp_path: Path) -> None:
         """Every intermediate descriptor is closed on the way out, including the

--- a/tests/unit/test_anchored_read.py
+++ b/tests/unit/test_anchored_read.py
@@ -1,0 +1,133 @@
+"""Tests for bernstein.core.persistence.anchored_read - per-component opens."""
+
+from __future__ import annotations
+
+import errno
+import os
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bernstein.core.persistence.anchored_read import (
+    ANCHORED_OPEN_SUPPORTED,
+    open_anchored,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _read_all(fd: int) -> bytes:
+    with os.fdopen(fd, "rb") as handle:
+        return handle.read()
+
+
+def _open_fd_count() -> int:
+    """Count this process's open descriptors, for leak assertions.
+
+    ``/proc/self/fd`` on Linux, ``/dev/fd`` on macOS and the BSDs; -1 where
+    neither exists, which the caller turns into a skip.
+    """
+    for fd_dir in ("/proc/self/fd", "/dev/fd"):
+        if os.path.isdir(fd_dir):
+            return len(os.listdir(fd_dir))
+    return -1
+
+
+class TestComponentValidation:
+    def test_requires_at_least_one_component(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="at least one path component"):
+            open_anchored(tmp_path, flags=os.O_RDONLY)
+
+    @pytest.mark.parametrize("component", ["", ".", "..", "a/b", "sub/"])
+    def test_rejects_anything_that_is_not_a_single_name(
+        self,
+        tmp_path: Path,
+        component: str,
+    ) -> None:
+        """Traversal is refused as a programming error rather than resolved. A
+        component that could contain a separator would let the caller walk back
+        out of the root the walk exists to anchor on."""
+        with pytest.raises(ValueError, match="single names"):
+            open_anchored(tmp_path, component, flags=os.O_RDONLY)
+
+
+class TestAnchoredOpen:
+    def test_reads_a_file_below_the_root(self, tmp_path: Path) -> None:
+        (tmp_path / "ab").mkdir()
+        (tmp_path / "ab" / "blob").write_bytes(b"payload")
+        assert _read_all(open_anchored(tmp_path, "ab", "blob", flags=os.O_RDONLY)) == b"payload"
+
+    def test_missing_final_component_raises_enoent(self, tmp_path: Path) -> None:
+        (tmp_path / "ab").mkdir()
+        with pytest.raises(FileNotFoundError):
+            open_anchored(tmp_path, "ab", "blob", flags=os.O_RDONLY)
+
+    def test_missing_intermediate_component_raises_enoent(self, tmp_path: Path) -> None:
+        """A caller that treats FileNotFoundError as a miss has to see one from
+        an absent parent too, or a missing shard becomes a hard error."""
+        with pytest.raises(FileNotFoundError):
+            open_anchored(tmp_path, "ab", "blob", flags=os.O_RDONLY)
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX symlink semantics")
+@pytest.mark.skipif(not ANCHORED_OPEN_SUPPORTED, reason="needs dir_fd and O_NOFOLLOW")
+class TestSymlinkRefusal:
+    def test_refuses_a_symlinked_final_component(self, tmp_path: Path) -> None:
+        (tmp_path / "ab").mkdir()
+        target = tmp_path / "elsewhere"
+        target.write_bytes(b"attacker bytes")
+        (tmp_path / "ab" / "blob").symlink_to(target)
+        with pytest.raises(OSError) as excinfo:
+            open_anchored(tmp_path, "ab", "blob", flags=os.O_RDONLY)
+        assert excinfo.value.errno == errno.ELOOP
+
+    def test_refuses_a_symlinked_intermediate_component(self, tmp_path: Path) -> None:
+        """The component O_NOFOLLOW alone never covered.
+
+        The errno is platform-dependent and deliberately not pinned: Linux
+        reports ELOOP for a refused symlink, while macOS and the BSDs report
+        ENOTDIR when O_DIRECTORY is also set. Both mean the link was not
+        traversed - the target here *is* a directory, so ENOTDIR can only come
+        from refusing the link itself. What must hold everywhere is that the
+        failure is not a FileNotFoundError, since callers read that as absence.
+        """
+        decoy = tmp_path / "decoy"
+        decoy.mkdir()
+        (decoy / "blob").write_bytes(b"attacker bytes")
+        (tmp_path / "ab").symlink_to(decoy, target_is_directory=True)
+        with pytest.raises(OSError) as excinfo:
+            open_anchored(tmp_path, "ab", "blob", flags=os.O_RDONLY)
+        assert not isinstance(excinfo.value, FileNotFoundError)
+        assert excinfo.value.errno in {errno.ELOOP, errno.ENOTDIR}
+
+    def test_follows_a_symlinked_root(self, tmp_path: Path) -> None:
+        """The root is the trust anchor and is opened normally - a symlinked
+        root is where the operator chose to put the store."""
+        real = tmp_path / "real"
+        (real / "ab").mkdir(parents=True)
+        (real / "ab" / "blob").write_bytes(b"payload")
+        linked = tmp_path / "linked"
+        linked.symlink_to(real, target_is_directory=True)
+        assert _read_all(open_anchored(linked, "ab", "blob", flags=os.O_RDONLY)) == b"payload"
+
+    def test_a_file_in_place_of_a_directory_is_enotdir(self, tmp_path: Path) -> None:
+        (tmp_path / "ab").write_bytes(b"not a directory")
+        with pytest.raises(NotADirectoryError):
+            open_anchored(tmp_path, "ab", "blob", flags=os.O_RDONLY)
+
+    def test_refused_walk_leaks_no_descriptors(self, tmp_path: Path) -> None:
+        """Every intermediate descriptor is closed on the way out, including the
+        one held when the refusal fires. A walk that leaks here would exhaust
+        the table under exactly the condition it is meant to survive."""
+        before = _open_fd_count()
+        if before < 0:
+            pytest.skip("no /proc/self/fd on this platform")
+        decoy = tmp_path / "decoy"
+        decoy.mkdir()
+        (tmp_path / "ab").symlink_to(decoy, target_is_directory=True)
+        for _ in range(50):
+            with pytest.raises(OSError):
+                open_anchored(tmp_path, "ab", "blob", flags=os.O_RDONLY)
+        assert _open_fd_count() == before

--- a/tests/unit/test_cas_store.py
+++ b/tests/unit/test_cas_store.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import errno
 import hashlib
 import json
+import shutil
 import sys
 from typing import TYPE_CHECKING
 
@@ -433,3 +435,82 @@ class TestCASStoreSymlinkSafety:
         O_NOFOLLOW change does not turn a normal miss into an error."""
         missing = hashlib.sha256(b"never stored").hexdigest()
         assert cas.get(missing) is None
+
+    def test_get_refuses_to_follow_a_symlinked_shard_directory(
+        self,
+        cas: CASStore,
+        tmp_path: Path,
+    ) -> None:
+        """O_NOFOLLOW on the blob open guards the final component only, so the
+        shard directory above it was still followed (#3561). The anchored walk
+        refuses a link at that component too, and the refusal must arrive as an
+        OSError - never as bytes, and never as a miss."""
+        digest = cas.put(b"authentic blob")
+        shard = cas.root / digest[:2]
+        # A shard directory the attacker controls, holding a blob at the same
+        # name whose bytes are not the ones the digest promises.
+        decoy = tmp_path / "attacker-shard"
+        decoy.mkdir()
+        (decoy / digest).write_bytes(b"attacker bytes")
+        shutil.rmtree(shard)
+        shard.symlink_to(decoy, target_is_directory=True)
+
+        # The errno is platform-dependent (ELOOP on Linux, ENOTDIR on macOS and
+        # the BSDs, which check directory-ness before reporting the refusal);
+        # both mean the link was not traversed. What has to hold everywhere is
+        # that no bytes come back and the failure is not FileNotFoundError.
+        with pytest.raises(OSError) as excinfo:
+            cas.get(digest, verify=True)
+        assert not isinstance(excinfo.value, FileNotFoundError)
+        assert excinfo.value.errno in {errno.ELOOP, errno.ENOTDIR}
+
+    def test_symlinked_shard_is_not_reported_as_absent(
+        self,
+        cas: CASStore,
+        tmp_path: Path,
+    ) -> None:
+        """The refusal must not be widened into a cache miss. `receipt verify`
+        splits absent (an operational event) from unreadable (a property of this
+        host); returning None here would file a refused symlink under the wrong
+        one and clear the blob of suspicion it has not earned."""
+        digest = cas.put(b"authentic blob")
+        shard = cas.root / digest[:2]
+        empty = tmp_path / "empty-shard"
+        empty.mkdir()
+        shutil.rmtree(shard)
+        shard.symlink_to(empty, target_is_directory=True)
+
+        # The link resolves to a directory with no blob in it, so following it
+        # would surface ENOENT and read as absent. The refusal must land on the
+        # shard component, before the blob name is ever looked up - which is
+        # what makes this test distinct from the one above: here the wrong
+        # answer is available and quiet.
+        with pytest.raises(OSError) as excinfo:
+            cas.get(digest, verify=True)
+        assert not isinstance(excinfo.value, FileNotFoundError)
+        assert excinfo.value.errno in {errno.ELOOP, errno.ENOTDIR}
+
+    def test_get_returns_none_when_the_shard_directory_is_missing(
+        self,
+        cas: CASStore,
+    ) -> None:
+        """A shard directory that was never created is an ordinary miss, not a
+        reader-side failure - the walk adds a component that can raise ENOENT,
+        and that has to keep reading as absent."""
+        digest = cas.put(b"blob in its own shard")
+        shutil.rmtree(cas.root / digest[:2])
+        assert cas.get(digest) is None
+
+    def test_a_symlinked_store_root_is_still_readable(self, tmp_path: Path) -> None:
+        """Pointing the store root at another volume is operator configuration,
+        not an attack: the walk anchors on the root and only refuses links
+        *below* it. Refusing a symlinked root would break working installs to
+        defend against someone who already controls where the operator put it."""
+        real_root = tmp_path / "real-cas"
+        real_root.mkdir()
+        linked_root = tmp_path / "linked-cas"
+        linked_root.symlink_to(real_root, target_is_directory=True)
+
+        store = CASStore(linked_root)
+        digest = store.put(b"blob under a symlinked root")
+        assert store.get(digest) == b"blob under a symlinked root"

--- a/tests/unit/test_cas_store.py
+++ b/tests/unit/test_cas_store.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import errno
 import hashlib
 import json
+import os
 import shutil
 import sys
+import threading
 from typing import TYPE_CHECKING
 
 import pytest
@@ -500,6 +502,35 @@ class TestCASStoreSymlinkSafety:
         digest = cas.put(b"blob in its own shard")
         shutil.rmtree(cas.root / digest[:2])
         assert cas.get(digest) is None
+
+    def test_get_refuses_a_fifo_at_the_blob_path_without_stalling(self, cas: CASStore) -> None:
+        """The reader stall #3561 is about does not need a symlink: a FIFO at
+        the blob's own name blocks a plain open until a writer appears, and
+        O_NOFOLLOW never had anything to say about it. The read must refuse the
+        type instead of waiting - so this asserts on a worker thread and fails
+        on the timeout, because the regression here is a hang, not an error."""
+        digest = cas.put(b"authentic blob")
+        blob = cas.blob_path(digest)
+        blob.unlink()
+        os.mkfifo(blob)
+
+        finished = threading.Event()
+        result: list[BaseException | None] = []
+
+        def attempt() -> None:
+            try:
+                cas.get(digest, verify=True)
+                result.append(None)
+            except BaseException as exc:
+                result.append(exc)
+            finished.set()
+
+        threading.Thread(target=attempt, daemon=True).start()
+        assert finished.wait(timeout=10), "CASStore.get stalled on a FIFO blob"
+        # OSError, never None: a refused type is a reader-side failure the
+        # verifier reports as unreadable, not a blob that is simply absent.
+        assert isinstance(result[0], OSError)
+        assert not isinstance(result[0], FileNotFoundError)
 
     def test_a_symlinked_store_root_is_still_readable(self, tmp_path: Path) -> None:
         """Pointing the store root at another volume is operator configuration,


### PR DESCRIPTION
## What

Refuses a symlink at **every** path component of a CAS blob read, not just the final one. Closes #3561.

## Why

`O_NOFOLLOW` on the blob open guards the last component. A symlink planted at the shard directory under the CAS root was still followed, so a read could be steered by a parent nobody checked.

Content verification keeps this fail-closed for integrity — bytes that do not hash to the requested digest are reported tampered, never verified — so a redirected parent cannot forge a `verified` verdict. The residual is on the reader: a blob path resolving through a redirected parent can stall the reader on a non-regular file, and setting it up needs write access to the CAS root. Defence in depth, so the refusal means what the docs say it means.

## How

`open_anchored` (new, `core/persistence/anchored_read.py`) walks the path a component at a time, opening each relative to a descriptor for its parent with `O_NOFOLLOW` set. The refusal is a property of the open — nothing is checked and then used. `CASStore.get` routes through it.

Two limits, both deliberate and both documented:

- **The root is opened normally.** A symlinked store root is where the operator chose to put the store; refusing it would break working installs to defend against someone who already controls that choice.
- **The walk needs `dir_fd` and `O_NOFOLLOW`.** Windows has neither and degrades to a single open of the joined path — the protection that was there before, not an `is_symlink()` pre-check that would trade an atomic guarantee for a race window. `docs/architecture/sandbox.md` now says POSIX-only instead of implying otherwise.

`except FileNotFoundError` in `get()` stays narrow on purpose. Widening it to `OSError` would report a refused symlink as an absent blob — the false accusation `receipt verify` splits `unreadable` from `absent` to avoid.

On your note about reusing the attestation pattern: you were right that it exists, and I was wrong to say otherwise — I had searched a checkout ~800 commits behind main. `_read_contained_key_bytes` anchors a single trusted directory and converts refusals to `ValueError` for its callers; the CAS read has to walk a shard level and must keep `OSError` intact so the verifier can tell unreadable from absent. So the helper is new code carrying the same `can_anchor` reasoning, and it cites that module. Migrating the attestation read onto it is a real option, left alone here because changing its error surface is not this issue's business.

## Tests

All three new regression tests were confirmed to **fail against the pre-fix read path** and pass after — a regression test that passes both ways proves nothing.

- Symlinked shard refused by the library read, with the authentic blob behind the decoy so that following the link would return *the right bytes* and report intact.
- A second case where the decoy shard is empty, so following the link would yield ENOENT and read as **absent** — the quiet wrong answer.
- A missing shard directory still reads as an ordinary miss.
- A symlinked store *root* still reads normally, pinning the exemption above.
- `receipt verify` reports exit 4 (unreadable) for a symlinked shard.
- Helper suite: component validation, refusal at leaf and intermediate, that a refused walk closes every descriptor it opened, and the FIFO and directory type refusals.

The FIFO tests assert on a worker thread under a timeout, because the regression there is a hang — and a suite that hangs reports a defect no better than no test at all.

The errno is deliberately not pinned to one value: Linux reports ELOOP, macOS and the BSDs report ENOTDIR when `O_DIRECTORY` is set. Both mean the link was not traversed. What the tests assert is the invariant that matters — the failure is never a `FileNotFoundError`, because callers read that as absence.

## The third commit goes past the acceptance criteria — drop it if you disagree

`9f3cdcf7` is separable on purpose.

The issue names the exposure as a reader that **stalls on a non-regular file**, and the symlink walk does not close it. No link is needed: an attacker with the write access #3561 already assumes can put a FIFO at a blob's own legitimate name, and `os.open` blocks until a writer appears — before any hash check, any type check, or any error the verifier could classify. Measured on a scratch store, the pre-fix open had not returned after 3s; the guarded one fails immediately with EINVAL, which classifies as `unreadable` beside a refused symlink.

The guard is opt-in (`require_regular_file`), off by default, and the store only ever writes regular files. I judged that shipping the symlink half while leaving the stall the issue actually describes would be closing the advertised hole rather than the real one — but it is your call, and dropping that commit leaves the other two coherent.

## Two things I did not do

1. **The `.meta.json` sidecar is not covered.** `_read_meta`, `has` and `list_entries` reach the same shard directory through plain `Path` calls. I left them alone because the sidecar is not content-addressed: there is no digest to check it against, and an attacker holding the write access needed to plant a symlink can write a hostile sidecar in place, which no symlink refusal would catch. Nothing in the verification path reads metadata. The doc now says so rather than letting a reader infer coverage. Happy to extend the walk there if you would rather have it uniform.

2. **A missing or unmounted store root still reads as an absent blob.** The root is opened by pathname on every read, so if it disappears after construction, `receipt verify` reports ordinary absence rather than an unreadable store. This is unchanged by the PR — the pre-fix open of `root/shard/blob` raised the same `FileNotFoundError` — and separating the two would change verdicts for the "CAS directory is gone" case, which felt like yours to decide rather than mine to slip in.

## Review

Two independent passes before this went up, both scoped to these commits. One caught the fd-ownership ordering in the walk (a failing `close` could leak the descriptor just opened) and the sidecar gap above. The other caught the FIFO vector and the overclaiming Windows wording — the fallback was described as guarding the final component when, with `O_NOFOLLOW` undefined, it guards nothing. Both are fixed or documented above.

## Checklist

- [x] `uv run ruff check src/` passes
- [ ] `uv run pyright src/` — not run: pyright is not installed in this environment. `uv run mypy src/bernstein/core/persistence/{anchored_read,cas_store}.py` is clean; leaving the box honest rather than ticked.
- [x] Tests pass: 568 across the CAS consumers (`test_cas_store`, `test_anchored_read`, `tests/unit/sandbox/`, `test_computer_use_lineage`, `test_multimodal_attestation`, `observability/test_trace_store`, `test_sigstore_attestation`), plus `tests/property/test_cas_store_properties.py`
- [x] New code has type hints

### Documentation duty

- [x] `docs/architecture/sandbox.md` updated — the POSIX-only caveat from the issue's acceptance criteria, plus the sidecar scope note
- [x] README — N/A, no user-visible surface change
- [x] `docs/operations/` — N/A
- [x] `docs/api/` — N/A, no public schema change
- [x] `uv run bernstein agents-md sync` run: no drift. The new module sits inside `core/persistence/`, which the generated map lists as a sub-package rather than per file, so nothing regenerated.
- [x] Tests cover the documented behaviour
