### PR TITLE
fix(adapters): spawn goose with an inline-prompt flag its CLI accepts

### DIFF
--- a/docs/adapters/capability_profiles.md
+++ b/docs/adapters/capability_profiles.md
@@ -237,4 +237,4 @@ check the profile against every gate above.
 | `droid` | `MODULE` | `droid <prompt>` |
 | `kimi` | `MODULE` | `kimi --yolo -c <prompt>` |
 | `opencode` | `MODULE` | `opencode run -m <model> --format json <prompt>` |
-| `goose` | `MODULE` | `goose run --instruction <prompt>` |
+| `goose` | `MODULE` | `goose run --text <prompt>` |

--- a/src/bernstein/adapters/_contract.py
+++ b/src/bernstein/adapters/_contract.py
@@ -269,19 +269,41 @@ def _strip_ansi(text: str) -> str:
     return _ANSI_RE.sub("", text)
 
 
+#: Characters that can continue a flag name. A required flag only counts as
+#: advertised when neither the character before nor the character after the
+#: match is one of these, so ``-m`` is not found inside ``--model`` and
+#: ``--instruction`` is not found inside ``--instructions``. Trailing ``=``,
+#: ``,``, ``<`` and end-of-line all remain valid terminators.
+_FLAG_NAME_CHARS = r"[A-Za-z0-9_-]"
+
+
+def _flag_pattern(flag: str) -> re.Pattern[str]:
+    """Compile a case-insensitive, token-bounded matcher for one flag."""
+    return re.compile(
+        rf"(?<!{_FLAG_NAME_CHARS}){re.escape(flag)}(?!{_FLAG_NAME_CHARS})",
+        re.IGNORECASE,
+    )
+
+
 def _capability_failures(spec: ContractSpec, help_text: str) -> list[str]:
     """Compute the list of human-readable capability failures.
 
-    Flag match is case-insensitive substring. The leading dashes already
-    make a flag unambiguous. Subcommand match is case-insensitive and
-    requires a token boundary (start/end of line or whitespace) so that
-    ``runs`` does not falsely satisfy ``run``.
+    Flag and subcommand matches are both case-insensitive and both require a
+    token boundary, so that ``runs`` does not falsely satisfy ``run`` and
+    ``--instructions`` does not falsely satisfy ``--instruction``.
+
+    The leading dashes anchor only the *start* of a flag; they say nothing
+    about where it ends. A plain substring match therefore treats a required
+    flag as present whenever upstream renames it to something that merely
+    contains it -- pluralising ``--instruction`` to ``--instructions``, or
+    dropping a ``-m`` alias while keeping ``--model``. That is the exact
+    rename that keeps a probe green against a CLI which rejects the declared
+    flag outright, so both ends are anchored here.
     """
     failures: list[str] = []
     haystack = _strip_ansi(help_text)
-    haystack_lower = haystack.lower()
     for flag in spec.required_flags:
-        if flag.lower() not in haystack_lower:
+        if not re.search(_flag_pattern(flag), haystack):
             failures.append(f"missing required flag {flag!r} in `{spec.binary} --help`")
     for sub in spec.required_subcommands:
         pattern = rf"(?im)(^|\s){re.escape(sub)}(\s|$)"

--- a/src/bernstein/adapters/capability_profile.py
+++ b/src/bernstein/adapters/capability_profile.py
@@ -1152,11 +1152,11 @@ _PROFILE_LIST: tuple[AdapterCapabilityProfile, ...] = (
         invocation=InvocationSpec(
             binary="goose",
             subcommands=("run",),
-            prompt_flag="--instruction",
+            prompt_flag="--text",
         ),
         mcp_client=True,
         event_channel=EventChannel.ACP,
-        notes="Block Goose. Speaks ACP natively; model flag is optional and module-supplied.",
+        notes="Goose (AAIF). Speaks ACP natively; model flag is optional and module-supplied.",
     ),
 )
 

--- a/src/bernstein/adapters/goose.py
+++ b/src/bernstein/adapters/goose.py
@@ -1,15 +1,20 @@
 """Goose CLI adapter for Bernstein.
 
-Adapter for Goose (https://github.com/block/goose), now stewarded by the
+Adapter for Goose (https://github.com/aaif-goose/goose), now stewarded by the
 Agentic AI Foundation (Linux Foundation) - the GitHub org has moved from
-``block/goose`` to ``aaif-goose/goose`` while binary releases continue under
-the ``block/goose`` releases page.  Goose is an AI agent that can execute
+``block/goose`` to ``aaif-goose/goose``, and the old paths still resolve
+through GitHub's rename redirect.  Goose is an AI agent that can execute
 tasks autonomously; this adapter allows Bernstein to orchestrate Goose as a
 worker agent.
 
-Last verified against upstream Goose 1.33.x on 2026-05-05.
+``goose run`` takes the prompt either as ``-i/--instructions <FILE>`` or as
+``-t/--text <TEXT>``; there is no singular ``--instruction`` that carries
+prompt text.  Passing one makes the argument parser abort with exit code 2
+before the agent starts, so the worker dies having done no work.
+
+Last verified against upstream Goose 1.45.0 on 2026-08-10.
 Install: ``brew install --cask block-goose`` (macOS), or
-``curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash``.
+``curl -fsSL https://github.com/aaif-goose/goose/releases/download/stable/download_cli.sh | bash``.
 """
 
 from __future__ import annotations
@@ -47,8 +52,8 @@ _MODEL_MAP: dict[str, str] = {
 class GooseAdapter(CLIAdapter):
     """Goose CLI adapter for Bernstein.
 
-    Integrates with Block's Goose CLI agent.
-    GitHub: https://github.com/block/goose
+    Integrates with the Goose CLI agent.
+    GitHub: https://github.com/aaif-goose/goose
     """
 
     def spawn(
@@ -88,7 +93,7 @@ class GooseAdapter(CLIAdapter):
 
         model_id = _MODEL_MAP.get(model_config.model, model_config.model)
 
-        cmd = ["goose", "run", "--instruction", prompt]
+        cmd = ["goose", "run", "--text", prompt]
         if model_id:
             cmd += ["--model", model_id]
 
@@ -121,7 +126,7 @@ class GooseAdapter(CLIAdapter):
                     start_new_session=True,
                 )
             except FileNotFoundError as exc:
-                raise RuntimeError("goose not found in PATH. Install: https://github.com/block/goose") from exc
+                raise RuntimeError("goose not found in PATH. Install: https://github.com/aaif-goose/goose") from exc
             except PermissionError as exc:
                 raise RuntimeError(f"Permission denied executing goose: {exc}") from exc
 

--- a/src/bernstein/core/routing/llm.py
+++ b/src/bernstein/core/routing/llm.py
@@ -107,7 +107,9 @@ _CLI_FLAGS: dict[str, tuple[str, str, list[str]]] = {
     "gemini": ("-p", "-m", []),
     "qwen": ("-y", "--model", []),
     "codex": ("--prompt", "--model", []),
-    "goose": ("--prompt", "--model", []),
+    # goose takes the prompt under its ``run`` subcommand; ``--prompt`` is not
+    # a flag it defines, and without ``run`` there is no subcommand to parse.
+    "goose": ("run --text", "--model", []),
     "aider": ("--message", "--model", []),
     "claude": ("--print -p", "--model", ["--output-format", "text", "--max-turns", "1"]),
 }

--- a/tests/contract/contracts/goose.yaml
+++ b/tests/contract/contracts/goose.yaml
@@ -20,6 +20,13 @@ auth:
   required_for_help: false
   required_for_models: false
   secret_env: "ANTHROPIC_API_KEY"
+#
+# These are flags the CLI must still advertise in ``goose run --help``; the
+# list is not an assertion that every spawn passes each one. ``--model`` is
+# declared even though the adapter appends it only for a non-empty model: a
+# model-less spawn is unaffected, because this list is matched against help
+# text and never against argv, and the profile-contract admission check
+# permits a profile that declares fewer flags than the contract requires.
 required_flags:
   - "--text"
   - "--model"

--- a/tests/contract/contracts/goose.yaml
+++ b/tests/contract/contracts/goose.yaml
@@ -1,18 +1,25 @@
-# Contract for the Block Goose CLI (adapter: goose).
+# Contract for the Goose CLI (adapter: goose).
 #
 # Always-passed surface from src/bernstein/adapters/goose.py:
-# ``goose run --instruction <prompt> [--model <id>]``.
+# ``goose run --text <prompt> [--model <id>]``.
+#
+# ``--text`` is the inline-prompt flag; the file-based sibling is
+# ``--instructions <FILE>``.  A singular ``--instruction`` is NOT accepted and
+# must never be declared here: it is a prefix substring of ``--instructions``,
+# so a substring-matching probe would report it present against a CLI that
+# only offers the plural form.
 adapter: goose
 binary: goose
 install:
   method: curl
-  spec: "https://github.com/block/goose/releases/latest/download/download_cli.sh"
+  spec: "https://github.com/aaif-goose/goose/releases/latest/download/download_cli.sh"
 auth:
   required_for_help: false
   required_for_models: false
   secret_env: "ANTHROPIC_API_KEY"
 required_flags:
-  - "--instruction"
+  - "--text"
+  - "--model"
 required_subcommands:
   - "run"
 # Goose sub-flags live under ``goose run --help``.

--- a/tests/contract/contracts/goose.yaml
+++ b/tests/contract/contracts/goose.yaml
@@ -11,8 +11,11 @@
 adapter: goose
 binary: goose
 install:
+  # ``stable`` matches the install line in src/bernstein/adapters/goose.py.
+  # ``latest`` is not equivalent: it follows the newest release, which can be
+  # a prerelease.
   method: curl
-  spec: "https://github.com/aaif-goose/goose/releases/latest/download/download_cli.sh"
+  spec: "https://github.com/aaif-goose/goose/releases/download/stable/download_cli.sh"
 auth:
   required_for_help: false
   required_for_models: false

--- a/tests/unit/adapters/test_goose_adapter.py
+++ b/tests/unit/adapters/test_goose_adapter.py
@@ -8,6 +8,7 @@ agent starts, so a worker spawned that way dies without doing any work.
 
 from __future__ import annotations
 
+import shlex
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -17,6 +18,7 @@ import yaml
 from bernstein.core.models import ModelConfig
 
 from bernstein.adapters.goose import GooseAdapter
+from bernstein.core.routing.llm import _CLI_FLAGS
 
 CONTRACT_PATH = Path(__file__).resolve().parents[2] / "contract" / "contracts" / "goose.yaml"
 
@@ -91,3 +93,26 @@ def test_contract_fixture_covers_the_flags_the_adapter_spawns(flag: str, tmp_pat
     """Every flag the adapter always passes is guarded by the drift contract."""
     spec = yaml.safe_load(CONTRACT_PATH.read_text(encoding="utf-8"))
     assert flag in spec["required_flags"]
+
+
+def test_spawn_without_a_model_is_still_a_valid_invocation(tmp_path: Path) -> None:
+    """An empty model omits ``--model`` and leaves the rest of argv intact.
+
+    ``required_flags`` pins what ``goose run --help`` advertises, not what the
+    adapter passes on every call, so declaring ``--model`` there must not make
+    a model-less spawn malformed.
+    """
+    argv = _spawn_and_capture(tmp_path, model_config=ModelConfig(model="", effort="normal"))
+    assert argv == ["goose", "run", "--text", "Refactor the auth module"]
+
+
+def test_internal_llm_provider_path_uses_the_run_subcommand() -> None:
+    """``call_llm``'s CLI path builds a goose invocation the binary accepts.
+
+    This path bypasses ``GooseAdapter.spawn`` entirely, so it needs its own
+    guard: it previously built ``goose --prompt <text> --model <id>``, which
+    has neither the ``run`` subcommand nor a flag goose defines.
+    """
+    prompt_flag, model_flag, extra = _CLI_FLAGS["goose"]
+    argv = ["goose", *shlex.split(prompt_flag), "PROMPT", *shlex.split(model_flag), "MODEL", *extra]
+    assert argv == ["goose", "run", "--text", "PROMPT", "--model", "MODEL"]

--- a/tests/unit/adapters/test_goose_adapter.py
+++ b/tests/unit/adapters/test_goose_adapter.py
@@ -1,0 +1,93 @@
+"""Unit tests for the Goose CLI adapter argv contract.
+
+Goose ``run`` accepts the prompt either as ``-i/--instructions <FILE>`` or as
+``-t/--text <TEXT>``.  It has never accepted a singular ``--instruction``
+carrying prompt text; passing one makes clap abort with exit code 2 before the
+agent starts, so a worker spawned that way dies without doing any work.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.goose import GooseAdapter
+
+CONTRACT_PATH = Path(__file__).resolve().parents[2] / "contract" / "contracts" / "goose.yaml"
+
+
+def _inner_argv(cmd: list[str]) -> list[str]:
+    """Return the adapter's own argv from a bernstein-worker wrapped command.
+
+    ``build_worker_cmd`` prefixes the worker invocation, which carries its own
+    ``--model`` flag, and separates it from the wrapped command with ``--``.
+    """
+    return cmd[cmd.index("--") + 1 :]
+
+
+def _spawn_and_capture(tmp_path: Path, **overrides: Any) -> list[str]:
+    """Spawn the adapter with Popen patched; return the inner goose argv."""
+    kwargs: dict[str, Any] = {
+        "prompt": "Refactor the auth module",
+        "workdir": tmp_path,
+        "model_config": ModelConfig(model="sonnet", effort="normal"),
+        "session_id": "backend-goose-task-1",
+        "mcp_config": None,
+        "task_scope": "medium",
+        "budget_multiplier": 1.0,
+        "system_addendum": "",
+        "timeout_seconds": 0,
+    }
+    kwargs.update(overrides)
+    with patch("subprocess.Popen") as mock_popen:
+        mock_proc = MagicMock()
+        mock_proc.pid = 12345
+        mock_popen.return_value = mock_proc
+        result = GooseAdapter().spawn(**kwargs)
+    assert result.pid == 12345
+    return _inner_argv(list(mock_popen.call_args[0][0]))
+
+
+def test_spawn_does_not_pass_singular_instruction_flag(tmp_path: Path) -> None:
+    """``--instruction`` is rejected by goose's parser (exit 2); never emit it."""
+    argv = _spawn_and_capture(tmp_path)
+    assert "--instruction" not in argv
+
+
+def test_spawn_passes_prompt_via_text_flag(tmp_path: Path) -> None:
+    """The prompt rides on ``--text``, immediately followed by the prompt."""
+    argv = _spawn_and_capture(tmp_path, prompt="Refactor the auth module")
+    assert "--text" in argv
+    assert argv[argv.index("--text") + 1] == "Refactor the auth module"
+
+
+def test_spawn_keeps_run_subcommand_and_model_flag(tmp_path: Path) -> None:
+    """``goose run`` and ``--model <id>`` are still part of the invocation."""
+    argv = _spawn_and_capture(tmp_path)
+    assert argv[0] == "goose"
+    assert argv[1] == "run"
+    assert "--model" in argv
+    assert argv[argv.index("--model") + 1] == "claude-sonnet-4-6"
+
+
+def test_contract_fixture_declares_only_flags_goose_accepts() -> None:
+    """The drift contract must not require a flag the CLI rejects.
+
+    A fixture that declares ``--instruction`` keeps the nightly probe green
+    against a CLI that only offers ``--instructions``, because the required
+    token is a prefix substring of the one actually advertised.
+    """
+    spec = yaml.safe_load(CONTRACT_PATH.read_text(encoding="utf-8"))
+    assert "--instruction" not in spec["required_flags"]
+
+
+@pytest.mark.parametrize("flag", ["--text", "--model"])
+def test_contract_fixture_covers_the_flags_the_adapter_spawns(flag: str, tmp_path: Path) -> None:
+    """Every flag the adapter always passes is guarded by the drift contract."""
+    spec = yaml.safe_load(CONTRACT_PATH.read_text(encoding="utf-8"))
+    assert flag in spec["required_flags"]

--- a/tests/unit/test_adapter_contract_check.py
+++ b/tests/unit/test_adapter_contract_check.py
@@ -252,6 +252,67 @@ def test_capability_subcommand_not_substring_match() -> None:
     assert len(failures) == 1
 
 
+def _flag_spec(*flags: str) -> _contract.ContractSpec:
+    """Minimal spec carrying only required flags."""
+    return _contract.ContractSpec(
+        adapter="x",
+        binary="x",
+        install_method="",
+        install_spec="",
+        auth_required_for_help=False,
+        auth_required_for_models=False,
+        auth_secret_env="",
+        required_flags=flags,
+        required_subcommands=(),
+        help_command=(),
+        models_command=(),
+        models_required_present=(),
+    )
+
+
+def test_capability_flag_not_satisfied_by_longer_flag() -> None:
+    """``--instruction`` must not be satisfied by ``--instructions``.
+
+    Upstream Goose renamed its inline-prompt flag to the plural, file-taking
+    ``--instructions``.  A substring match reports the singular flag present,
+    so the nightly probe stays green while every spawned worker aborts at
+    argument parsing.
+    """
+    help_text = "Options:\n  -i, --instructions <FILE>\n  -t, --text <TEXT>\n"
+    failures = _capability_failures_for(help_text, "--instruction")
+    assert len(failures) == 1
+    assert "--instruction" in failures[0]
+
+
+def test_capability_short_flag_not_satisfied_by_long_flag() -> None:
+    """``-m`` must not be satisfied by the ``--model`` that contains it."""
+    failures = _capability_failures_for("Options:\n      --model <MODEL>\n", "-m")
+    assert len(failures) == 1
+
+
+def test_capability_short_flag_matches_its_own_listing() -> None:
+    """``-m`` is present when the CLI lists it as an alias of ``--model``."""
+    assert _capability_failures_for("Options:\n  -m, --model <MODEL>\n", "-m") == []
+
+
+def test_capability_flag_matches_when_followed_by_punctuation() -> None:
+    """A flag stays present when trailed by ``=``, ``,``, ``<`` or end of line."""
+    help_text = "Options:\n  --text=<TEXT>\n  --model, alias\n  --sandbox <MODE>\n  --yolo\n"
+    assert _capability_failures_for(help_text, "--text", "--model", "--sandbox", "--yolo") == []
+
+
+def test_capability_flag_prefix_and_longer_sibling_both_required() -> None:
+    """``--print`` and ``--print-timeout`` are matched independently."""
+    only_long = "Options:\n  --print-timeout <SECS>\n"
+    assert len(_capability_failures_for(only_long, "--print")) == 1
+    both = "Options:\n  --print\n  --print-timeout <SECS>\n"
+    assert _capability_failures_for(both, "--print", "--print-timeout") == []
+
+
+def _capability_failures_for(help_text: str, *flags: str) -> list[str]:
+    return _contract._capability_failures(_flag_spec(*flags), help_text)
+
+
 def test_capability_match_is_case_insensitive() -> None:
     spec = _contract.ContractSpec(
         adapter="x",


### PR DESCRIPTION
# User description
## What

The goose adapter spawned `goose run --instruction <prompt text>`. `goose run` accepts the prompt either as `-i/--instructions <FILE>` or as `-t/--text <TEXT>`; there is no singular `--instruction` that carries prompt text.

The argument parser rejects it before the agent starts:

```
$ goose run --instruction "review the diff"
error: unexpected argument '--instruction' found

  tip: a similar argument exists: '--instructions'

Usage: goose run --instructions <FILE>
$ echo $?
2
```

Every spawned goose worker died at argument parsing having done no work. Verified against goose 1.45.0 (`goose-aarch64-apple-darwin`).

## Changes

| File | Change |
|---|---|
| `adapters/goose.py` | `--instruction` → `--text`; refreshed the verified-against line and the repository URLs |
| `adapters/capability_profile.py` | same flag in the profile registry — a second spawn path |
| `tests/contract/contracts/goose.yaml` | fixture declared the rejected flag; now declares `--text` and `--model` |
| `adapters/_contract.py` | anchor required-flag matching at both ends |
| `docs/adapters/capability_profiles.md` | invocation table row |
| `tests/unit/adapters/test_goose_adapter.py` | new — the adapter had no argv coverage |

## Why the nightly probe did not catch it

Required flags were matched as plain substrings:

```python
if flag.lower() not in haystack_lower:
```

`--instruction` is a prefix of the `--instructions` the CLI advertises, so the required token read as present and the contract check reported no drift. Confirmed by running the real checker against real `goose run --help` output:

```
literal '--instruction' substring present: True
capability_failures: []
-> contract check PASSES
```

The probe-inconclusive path was never involved (`probe_failure_reason` returned `None`): the binary was present and its help output was genuine. This was purely a matching false negative.

Leading dashes anchor only the start of a flag; they say nothing about where it ends. The subcommand check already required a token boundary so that `runs` does not satisfy `run` — required flags now use the same rule. With it, the old fixture produces the correct verdict:

```
OLD fixture (--instruction) -> FAIL (drift)
NEW fixture (--text/--model) -> PASS
```

### Scope note

This tightening is not goose-specific. Short flags were matched the same way — `-m` inside `--model`, `-p` inside `--print-timeout` — across all 25 contract fixtures. The check is now stricter, so previously-green adapters may surface as drift. Those would be genuine findings that the substring match was concealing. `report.py` reuses the same helpers, so the drift workflow and the conformance canary both pick this up.

## Follow-up (not in this PR)

`goose` is absent from `CANARY_MATRIX` in `adapters/canary.py`, so it has no entry in `last_green.json` and no end-to-end conformance coverage — only the help-text contract in `adapter-contract-drift`. Adding a matrix row makes the nightly perform a real model call, so the model choice and cost warrant a separate change; it should also be reconciled with #3562.

## Verification

```
1325 passed, 0 failed     tests/unit/adapters/ + contract suites
ruff check                All checks passed
ruff format --check       clean
mypy                      no new errors in the changed files
```

The six new goose argv tests and three of the new token-boundary tests fail against the pre-fix code.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Correct the Goose adapter and internal LLM routing to invoke <code>goose run --text</code> with inline prompts, updating capability profiles, contracts, documentation, and argv tests. Tighten contract flag detection to require token boundaries so renamed or short flags cannot produce false-positive drift checks.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3580?tool=ast&topic=Contract+flag+matching>Contract flag matching</a>
        </td><td>Strengthen capability contract matching with token-bounded flag detection, preventing substrings such as <code>--instruction</code> within <code>--instructions</code> or <code>-m</code> within <code>--model</code> from masking CLI drift.<details><summary>Modified files (2)</summary><ul><li>src/bernstein/adapters/_contract.py</li>
<li>tests/unit/test_adapter_contract_check.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>fix(adapters): spawn g...</td><td>August 10, 2026</td></tr>
<tr><td>mohammed.sufiyan.msa@g...</td><td>fix(adapters): ship co...</td><td>August 10, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3580?tool=ast&topic=Goose+invocation>Goose invocation</a>
        </td><td>Update Goose spawning and routing to use the CLI-supported <code>--text</code> prompt flag, preserve optional model handling, and align profiles, contracts, documentation, and tests with Goose 1.45.0.<details><summary>Modified files (6)</summary><ul><li>docs/adapters/capability_profiles.md</li>
<li>src/bernstein/adapters/capability_profile.py</li>
<li>src/bernstein/adapters/goose.py</li>
<li>src/bernstein/core/routing/llm.py</li>
<li>tests/contract/contracts/goose.yaml</li>
<li>tests/unit/adapters/test_goose_adapter.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>fix(adapters): spawn g...</td><td>August 10, 2026</td></tr>
<tr><td>chernistry</td><td>fix(adapters): wire ca...</td><td>July 24, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3580?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>