### PR TITLE
fix(adapters): drive flags the community CLIs actually accept

### DIFF
--- a/src/bernstein/adapters/aider.py
+++ b/src/bernstein/adapters/aider.py
@@ -16,7 +16,7 @@ from bernstein.adapters.env_isolation import build_filtered_env
 # Map Bernstein short model names to aider model identifiers.
 # Aider accepts provider-prefixed names (e.g. "openai/gpt-5.5", "anthropic/claude-opus-4-7").
 # Short names are mapped to the most common aider-compatible IDs; unknown names pass through.
-# Last verified against upstream aider-chat 0.86.2 on 2026-05-19 - install: `pip install aider-chat`.
+# Last verified against upstream aider-chat 0.86.2 on 2026-08-10 - install: `pip install aider-chat`.
 _MODEL_MAP: dict[str, str] = {
     "opus": "anthropic/claude-opus-4-7",
     "opus-4-6": "anthropic/claude-opus-4-6",  # pinned fallback

--- a/src/bernstein/adapters/continue_dev.py
+++ b/src/bernstein/adapters/continue_dev.py
@@ -6,8 +6,12 @@ in headless mode for non-interactive task execution.
 
 Installation: ``npm install -g @continuedev/cli`` (binary is ``cn``).
 Authentication: ``~/.continue/config.yaml`` or provider API keys in the env.
-Model selection is driven by the Continue config; ``cn`` has no CLI flag for
-per-invocation model override, so ``model_config.model`` is logged only.
+Model selection is driven by the Continue config, so ``model_config.model``
+is logged only. Note: ``cn`` 1.5.x does expose a ``--model`` flag, but it
+takes a Continue *hub slug* (``owner/package``) rather than a provider model
+ID, so Bernstein's model identifiers cannot be passed through unmapped.
+
+Last verified against upstream @continuedev/cli 1.5.47 on 2026-08-10.
 """
 
 from __future__ import annotations

--- a/src/bernstein/adapters/gptme.py
+++ b/src/bernstein/adapters/gptme.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 # Map Bernstein short model names to gptme model identifiers.
 # gptme accepts provider-prefixed names (e.g. "anthropic/claude-sonnet-4-6",
 # "openai/gpt-5.5"). Unknown names pass through unchanged.
-# Last verified against upstream gptme 0.27.x on 2026-05-05 - install: `pipx install gptme`.
+# Last verified against upstream gptme 0.32.1 on 2026-08-10 - install: `pipx install gptme`.
 _MODEL_MAP: dict[str, str] = {
     "opus": "anthropic/claude-opus-4-7",
     "opus-4-6": "anthropic/claude-opus-4-6",

--- a/src/bernstein/adapters/ollama.py
+++ b/src/bernstein/adapters/ollama.py
@@ -5,7 +5,8 @@ local server such as vLLM, llama.cpp's HTTP server, LM Studio) as the LLM
 backend.  This enables full code editing capabilities in air-gapped,
 privacy-sensitive, EU-residency, or cost-zero environments.
 
-Last verified against upstream Ollama 0.21.x on 2026-05-05.
+Last verified against upstream Ollama 0.21.x on 2026-08-10 (CLI surface
+verified against aider 0.86.2, which this adapter actually drives).
 
 Prerequisites:
     - Ollama: https://ollama.com  (``brew install ollama`` or
@@ -37,7 +38,7 @@ from typing import TYPE_CHECKING, Any
 
 from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
 from bernstein.adapters.env_isolation import build_filtered_env
-from bernstein.adapters.plugin_sdk import AdapterCapability, AdapterPluginInfo
+from bernstein.adapters.plugin_sdk import AdapterPluginInfo
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -138,22 +139,22 @@ class OllamaAdapter(CLIAdapter):
     def plugin_info(self) -> AdapterPluginInfo:
         """Declare the sampling surface OllamaAdapter genuinely wires.
 
-        This adapter drives Aider (see the module docstring), which
-        accepts a ``--temperature`` flag. Aider has no ``--top-p``,
-        ``--top-k``, or completion ``--max-tokens`` CLI flag (its
-        ``--max-chat-history-tokens`` controls a different thing - chat
-        history truncation, not the completion length), so only the
-        narrow temperature capability is declared -
+        This adapter drives Aider (see the module docstring), which exposes
+        no sampling flags at all: ``--temperature``, ``--top-p``, ``--top-k``
+        and completion ``--max-tokens`` are all absent (``--max-chat-history-
+        tokens`` controls a different thing - chat history truncation, not the
+        completion length). Passing any of them makes Aider exit with
+        "unrecognized arguments", so none are declared -
         :func:`bernstein.adapters.plugin_sdk.ensure_sampling_params_supported`
-        refuses a spawn requesting the others rather than silently
-        dropping them.
+        refuses such a spawn rather than building an argv Aider rejects.
+        Sampling for local models is set on the Ollama model itself.
         """
         return AdapterPluginInfo(
             name="ollama",
             version="0.1.0",
             author="bernstein",
             description="Ollama / OpenAI-compatible local LLM adapter (via Aider)",
-            capabilities=(AdapterCapability.SUPPORTS_TEMPERATURE,),
+            capabilities=(),
         )
 
     def _resolve_model(self, model_name: str) -> str:
@@ -269,11 +270,11 @@ class OllamaAdapter(CLIAdapter):
         ]
 
         if mcp_config:
-            temperature = mcp_config.get("temperature")
-            if isinstance(temperature, (int, float)) and not isinstance(temperature, bool):
-                logger.debug("ollama adapter: wiring --temperature=%s onto aider argv", temperature)
-                cmd.extend(["--temperature", str(float(temperature))])
-            for dropped_key in ("top_p", "top_k", "max_tokens"):
+            # aider exposes no --temperature flag; argparse aborts the run with
+            # "unrecognized arguments: --temperature". Nothing is wired, and
+            # plugin_info() declares no sampling capability so the spawn is
+            # refused before an unusable argv is built.
+            for dropped_key in ("temperature", "top_p", "top_k", "max_tokens"):
                 if mcp_config.get(dropped_key) is not None:
                     logger.warning(
                         "ollama adapter: %s=%r requested but not wired (aider has no matching "

--- a/src/bernstein/adapters/opencode.py
+++ b/src/bernstein/adapters/opencode.py
@@ -1,6 +1,6 @@
 """OpenCode CLI adapter.
 
-Last verified against upstream OpenCode (sst/opencode) 0.x on 2026-05-05.
+Last verified against upstream OpenCode (sst/opencode) 1.14.x on 2026-08-10.
 Install: ``curl -fsSL https://opencode.ai/install | bash`` (fastest),
 ``brew install anomalyco/tap/opencode``, or ``npm i -g opencode-ai@latest``.
 """

--- a/src/bernstein/adapters/qwen.py
+++ b/src/bernstein/adapters/qwen.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
 from bernstein.adapters.env_isolation import build_filtered_env
-from bernstein.adapters.plugin_sdk import AdapterCapability, AdapterPluginInfo
+from bernstein.adapters.plugin_sdk import AdapterPluginInfo
 from bernstein.core.defaults import QWEN_INSTALL_HINT
 from bernstein.core.llm import LLMSettings
 from bernstein.core.models import ApiTier, ApiTierInfo, ModelConfig, ProviderType, RateLimit
@@ -87,23 +87,21 @@ class QwenAdapter(CLIAdapter):
     def plugin_info(self) -> AdapterPluginInfo:
         """Declare the sampling surface QwenAdapter genuinely wires.
 
-        The ``qwen`` CLI accepts ``--temperature``/``--top-p`` pass-through
-        flags for its OpenAI-compatible generation config (see
-        :meth:`_build_command`). It does not expose a ``--top-k`` or
-        ``--max-tokens`` flag, so those are NOT declared here -
+        The ``qwen`` CLI exposes no sampling flags: ``--temperature``,
+        ``--top-p``, ``--top-k`` and ``--max-tokens`` are all rejected by
+        its argument parser (``Unknown argument: temperature``), which is a
+        hard spawn failure rather than a silent drop. None are declared, so
         :func:`bernstein.adapters.plugin_sdk.ensure_sampling_params_supported`
-        would refuse a spawn requesting them rather than silently drop
-        them.
+        refuses such a spawn up front instead of building an argv the CLI
+        will reject. Sampling for ``qwen`` is configured out-of-band via its
+        settings file.
         """
         return AdapterPluginInfo(
             name="qwen",
             version="0.1.0",
             author="bernstein",
             description="Qwen CLI adapter for OpenAI compatible models",
-            capabilities=(
-                AdapterCapability.SUPPORTS_TEMPERATURE,
-                AdapterCapability.SUPPORTS_TOP_P,
-            ),
+            capabilities=(),
         )
 
     def _build_command(
@@ -122,14 +120,17 @@ class QwenAdapter(CLIAdapter):
         :meth:`spawn`.
 
         Args:
-            mcp_config: Per-spawn config that may carry ``temperature``/
-                ``top_p`` overrides - the only two sampling fields this
-                adapter's :meth:`plugin_info` declares support for.
+            mcp_config: Per-spawn config that may carry sampling overrides.
+                None are wired onto argv - the qwen CLI exposes no sampling
+                flags and rejects unknown arguments, so :meth:`plugin_info`
+                declares no sampling capability and such a spawn is refused
+                before it reaches here.
         """
-        # ``--approval-mode yolo`` is the current documented auto-approve flag
-        # in qwen-code (the unified form; the older ``-y`` / ``--yolo`` spellings
-        # are no longer shown in ``qwen --help``). ``--approval-mode`` is the
-        # stable flag the adapter contract verifies against the CLI help.
+        # ``--approval-mode yolo`` is the current auto-approve flag in
+        # qwen-code. Verified accepted on 0.20.0 and 0.21.9 (an invalid value
+        # reports ``Choices: "plan", "default", "auto-edit", "auto", "yolo"``),
+        # but it is absent from ``qwen --help`` in every spelling, so the
+        # adapter contract cannot drift-check it against the help text.
         # ``--output-format stream-json`` makes qwen-code emit line-delimited
         # JSON whose ``stats.models[<route>].tokens`` breakdown and per-call
         # ``usage`` blocks carry the provider's own token accounting. The
@@ -148,15 +149,11 @@ class QwenAdapter(CLIAdapter):
             cmd.extend(["--auth-type", "openai"])
 
         if mcp_config:
-            temperature = mcp_config.get("temperature")
-            if isinstance(temperature, (int, float)) and not isinstance(temperature, bool):
-                logger.debug("qwen adapter: wiring --temperature=%s onto argv", temperature)
-                cmd.extend(["--temperature", str(float(temperature))])
-            top_p = mcp_config.get("top_p")
-            if isinstance(top_p, (int, float)) and not isinstance(top_p, bool):
-                logger.debug("qwen adapter: wiring --top-p=%s onto argv", top_p)
-                cmd.extend(["--top-p", str(float(top_p))])
-            for dropped_key in ("top_k", "max_tokens"):
+            # The qwen CLI parser rejects unknown arguments outright, so a
+            # sampling flag that is not in its surface aborts the run instead
+            # of being ignored. None are wired; plugin_info() declares no
+            # sampling capability so the spawn is refused before reaching here.
+            for dropped_key in ("temperature", "top_p", "top_k", "max_tokens"):
                 if mcp_config.get(dropped_key) is not None:
                     logger.warning(
                         "qwen adapter: %s=%r requested but not wired (qwen CLI has no matching "

--- a/src/bernstein/adapters/qwen.py
+++ b/src/bernstein/adapters/qwen.py
@@ -152,7 +152,10 @@ class QwenAdapter(CLIAdapter):
             # The qwen CLI parser rejects unknown arguments outright, so a
             # sampling flag that is not in its surface aborts the run instead
             # of being ignored. None are wired; plugin_info() declares no
-            # sampling capability so the spawn is refused before reaching here.
+            # sampling capability, so a spawn carrying one of the enforced keys
+            # is refused before reaching here. ``max_tokens`` is the exception:
+            # it is absent from SAMPLING_PARAM_KEYS, so nothing refuses it and
+            # this warning is the only signal the value was dropped (#3586).
             for dropped_key in ("temperature", "top_p", "top_k", "max_tokens"):
                 if mcp_config.get(dropped_key) is not None:
                     logger.warning(

--- a/tests/unit/test_adapter_goose.py
+++ b/tests/unit/test_adapter_goose.py
@@ -1,0 +1,76 @@
+"""Unit tests for GooseAdapter's constructed argv.
+
+No test file previously existed for this adapter (verified via
+``find tests -iname '*goose*'`` before writing this file). Pattern matched
+from ``test_adapter_ollama.py``.
+
+These tests pin the *invocation surface* only, so they run without the
+``goose`` binary present.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.goose import GooseAdapter
+from tests.unit._adapter_test_helpers import inner_cmd, make_popen_mock
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+pytestmark = pytest.mark.usefixtures("no_watchdog_threads")
+
+
+class TestGooseAdapterSpawn:
+    """GooseAdapter.spawn() builds the expected ``goose run`` command."""
+
+    def _spawn(self, tmp_path: Path, *, model: str = "sonnet", pid: int = 900) -> list[str]:
+        adapter = GooseAdapter()
+        proc_mock = make_popen_mock(pid=pid)
+        with patch("bernstein.adapters.goose.subprocess.Popen", return_value=proc_mock) as popen:
+            adapter.spawn(
+                prompt="fix the bug",
+                workdir=tmp_path,
+                model_config=ModelConfig(model=model, effort="high"),
+                session_id="goose-s1",
+            )
+        return inner_cmd(popen.call_args.args[0])
+
+    def test_uses_run_subcommand(self, tmp_path: Path) -> None:
+        inner = self._spawn(tmp_path)
+        assert inner[0] == "goose"
+        assert inner[1] == "run"
+
+    def test_prompt_passed_inline_via_text_flag(self, tmp_path: Path) -> None:
+        """The inline prompt must ride ``--text``.
+
+        ``goose run`` takes the prompt inline only via ``--text/-t``.
+        """
+        inner = self._spawn(tmp_path)
+        assert "--text" in inner
+        assert inner[inner.index("--text") + 1] == "fix the bug"
+
+    def test_never_uses_removed_instruction_flag(self, tmp_path: Path) -> None:
+        """Regression guard: ``--instruction`` is not a goose flag.
+
+        Upstream exposes ``--instructions <FILE>`` (a path, ``-`` for stdin)
+        and ``--text <TEXT>``; the singular ``--instruction`` does not exist,
+        so driving it aborts the run.
+        """
+        inner = self._spawn(tmp_path)
+        assert "--instruction" not in inner
+
+    def test_prompt_is_not_passed_as_a_file_path(self, tmp_path: Path) -> None:
+        """``--instructions`` takes a FILE, so an inline prompt must not use it."""
+        inner = self._spawn(tmp_path)
+        assert "--instructions" not in inner
+
+    def test_model_flag_passthrough(self, tmp_path: Path) -> None:
+        inner = self._spawn(tmp_path, model="sonnet", pid=901)
+        assert "--model" in inner
+        assert inner[inner.index("--model") + 1] == "claude-sonnet-4-6"

--- a/tests/unit/test_adapter_ollama.py
+++ b/tests/unit/test_adapter_ollama.py
@@ -49,22 +49,33 @@ class TestOllamaAdapterSpawn:
 
 
 class TestOllamaAdapterPluginInfo:
-    def test_declares_temperature_only(self) -> None:
+    def test_declares_no_sampling_capability(self) -> None:
+        """Aider exposes no sampling flags, so none may be advertised.
+
+        Declaring one lets ``ensure_sampling_params_supported`` admit a spawn
+        that then builds an argv aider rejects with
+        ``unrecognized arguments``.
+        """
         info = OllamaAdapter().plugin_info()
-        assert set(info.capabilities) == {AdapterCapability.SUPPORTS_TEMPERATURE}
+        assert set(info.capabilities) == set()
 
     def test_does_not_declare_coarse_or_others(self) -> None:
         info = OllamaAdapter().plugin_info()
         assert AdapterCapability.SUPPORTS_SAMPLING_PARAMS not in info.capabilities
+        assert AdapterCapability.SUPPORTS_TEMPERATURE not in info.capabilities
         assert AdapterCapability.SUPPORTS_TOP_P not in info.capabilities
         assert AdapterCapability.SUPPORTS_TOP_K not in info.capabilities
         assert AdapterCapability.SUPPORTS_MAX_TOKENS not in info.capabilities
 
 
 class TestOllamaAdapterSamplingParams:
-    """mcp_config temperature must reach the built aider argv."""
+    """No sampling param may reach the built aider argv.
 
-    def test_temperature_reaches_argv(self, tmp_path: Path) -> None:
+    Aider has no ``--temperature`` flag: passing one makes argparse exit
+    with ``unrecognized arguments: --temperature``, killing the spawn.
+    """
+
+    def test_temperature_never_reaches_argv(self, tmp_path: Path) -> None:
         adapter = OllamaAdapter()
         proc_mock = make_popen_mock(pid=801)
         with patch("bernstein.adapters.ollama.subprocess.Popen", return_value=proc_mock) as popen:
@@ -76,8 +87,7 @@ class TestOllamaAdapterSamplingParams:
                 mcp_config={"temperature": 0.15},
             )
         inner = inner_cmd(popen.call_args.args[0])
-        assert "--temperature" in inner
-        assert inner[inner.index("--temperature") + 1] == "0.15"
+        assert "--temperature" not in inner
 
     def test_no_mcp_config_omits_temperature_flag(self, tmp_path: Path) -> None:
         adapter = OllamaAdapter()

--- a/tests/unit/test_adapter_qwen.py
+++ b/tests/unit/test_adapter_qwen.py
@@ -328,24 +328,34 @@ class TestQwenAdapterSpawn:
 
 
 class TestQwenAdapterPluginInfo:
-    def test_declares_temperature_and_top_p_only(self) -> None:
+    def test_declares_no_sampling_capability(self) -> None:
+        """The qwen CLI exposes no sampling flags, so none may be advertised.
+
+        Declaring one lets ``ensure_sampling_params_supported`` admit a spawn
+        that then builds an argv qwen rejects outright with
+        ``Unknown argument: temperature``.
+        """
         info = QwenAdapter().plugin_info()
-        assert set(info.capabilities) == {
-            AdapterCapability.SUPPORTS_TEMPERATURE,
-            AdapterCapability.SUPPORTS_TOP_P,
-        }
+        assert set(info.capabilities) == set()
 
     def test_does_not_declare_coarse_or_top_k_or_max_tokens(self) -> None:
         info = QwenAdapter().plugin_info()
         assert AdapterCapability.SUPPORTS_SAMPLING_PARAMS not in info.capabilities
+        assert AdapterCapability.SUPPORTS_TEMPERATURE not in info.capabilities
+        assert AdapterCapability.SUPPORTS_TOP_P not in info.capabilities
         assert AdapterCapability.SUPPORTS_TOP_K not in info.capabilities
         assert AdapterCapability.SUPPORTS_MAX_TOKENS not in info.capabilities
 
 
 class TestQwenAdapterSamplingParams:
-    """mcp_config temperature/top_p must reach the built CLI argv."""
+    """No sampling param may reach the built CLI argv.
 
-    def test_temperature_reaches_argv(self, tmp_path: Path) -> None:
+    ``qwen`` rejects unknown arguments rather than ignoring them
+    (``Unknown argument: temperature`` / ``Unknown arguments: top-p, topP``),
+    so a wired sampling flag is a hard spawn failure.
+    """
+
+    def test_temperature_never_reaches_argv(self, tmp_path: Path) -> None:
         adapter = QwenAdapter()
         proc_mock = _make_popen_mock(pid=300)
         settings = _default_settings()
@@ -361,10 +371,9 @@ class TestQwenAdapterSamplingParams:
                 mcp_config={"temperature": 0.3},
             )
         inner = _inner_cmd(popen.call_args.args[0])
-        assert "--temperature" in inner
-        assert inner[inner.index("--temperature") + 1] == "0.3"
+        assert "--temperature" not in inner
 
-    def test_top_p_reaches_argv(self, tmp_path: Path) -> None:
+    def test_top_p_never_reaches_argv(self, tmp_path: Path) -> None:
         adapter = QwenAdapter()
         proc_mock = _make_popen_mock(pid=301)
         settings = _default_settings()
@@ -380,10 +389,9 @@ class TestQwenAdapterSamplingParams:
                 mcp_config={"top_p": 0.85},
             )
         inner = _inner_cmd(popen.call_args.args[0])
-        assert "--top-p" in inner
-        assert inner[inner.index("--top-p") + 1] == "0.85"
+        assert "--top-p" not in inner
 
-    def test_both_reach_argv_together(self, tmp_path: Path) -> None:
+    def test_neither_reaches_argv_together(self, tmp_path: Path) -> None:
         adapter = QwenAdapter()
         proc_mock = _make_popen_mock(pid=302)
         settings = _default_settings()
@@ -399,8 +407,8 @@ class TestQwenAdapterSamplingParams:
                 mcp_config={"temperature": 0.1, "top_p": 0.95},
             )
         inner = _inner_cmd(popen.call_args.args[0])
-        assert inner[inner.index("--temperature") + 1] == "0.1"
-        assert inner[inner.index("--top-p") + 1] == "0.95"
+        assert "--temperature" not in inner
+        assert "--top-p" not in inner
 
     def test_no_mcp_config_omits_sampling_flags(self, tmp_path: Path) -> None:
         adapter = QwenAdapter()


### PR DESCRIPTION
# User description
## What

Swept the community CLI adapters we ship against the vendors' current releases. Three were building argv that upstream rejects outright — the spawn dies before any work happens.

| Adapter | Verdict | Detail |
|---|---|---|
| goose | **fixed** | `--instruction` does not exist. Upstream has `--instructions <FILE>` (a path, `-` for stdin) and `--text <TEXT>`. Inline prompt → `--text`. Contract fixture updated. |
| qwen | **fixed** | CLI exposes no sampling flags and *rejects* unknown args. Adapter declared `SUPPORTS_TEMPERATURE`/`SUPPORTS_TOP_P`, so the gate admitted the spawn and then built an argv qwen refuses. |
| ollama | **fixed** | Drives aider, which has no `--temperature`. argparse exits `unrecognized arguments: --temperature`. |
| aider | pin refresh | 0.86.2 still current on PyPI; all six flags present. |
| gptme | pin refresh | 0.27.x → 0.32.1. `-n` (implies `--no-confirm`), `-m`, positional prompt all intact. |
| opencode | pin refresh | 0.x → 1.14.x. `run`, `-m`, `--format json` all intact. |
| continue_dev | doc fix | Docstring claimed `cn` has no model flag. 1.5.x has one, but it takes a hub slug (`owner/package`), not a provider model ID — passthrough stays unwired. |
| plandex, hermes | verified, no change | `--apply/--auto-exec/--skip-menu/--stop` and `--oneshot PROMPT` all present at HEAD. |

Verified today against goose (`aaif-goose/goose` main), qwen 0.20.0 and 0.21.9, aider 0.86.2, gptme 0.32.1, opencode 1.14.39, `@continuedev/cli` 1.5.47.

Reproduction for the qwen case, since "rejects" vs "ignores" is the whole point:

```
$ qwen --temperature=0.3 -p hi
Unknown argument: temperature
$ qwen --top-p=0.5 -p hi
Unknown arguments: top-p, topP
```

## Why the conformance canary missed this

Three independent reasons, all visible in this PR's own test run:

1. **Binary absent ⇒ `skip`, and a skip is not a failure.** `run_canary_target` returns `verdict="skip"` with `skip_reason="binary not on PATH"` before it ever probes `--help`. `goose.yaml` *did* declare `required_flags: ["--instruction"]` and would have caught this — the probe simply never ran. `tests/contract` on this branch: **94 passed, 405 skipped**.
2. **Contracts declare only a subset of the flags the adapter drives.** `qwen.yaml` lists `--model` and nothing else, so removing `--temperature`/`--top-p` upstream was undetectable even with the binary present.
3. **Some shipped adapters have no contract fixture at all.** There is no `ollama.yaml`, so that adapter has never been drift-checked.

(1) is a policy change rather than a small fix, so it is not in this PR — posted to #3562 with the evidence. (2) and (3) are corrected here for goose only; broadening the fixtures is follow-up work.

## Tests

Every behavioural fix has a test asserting the constructed argv — no vendor binary needed at test time. New `tests/unit/test_adapter_goose.py`; inverted the qwen/ollama sampling assertions that previously pinned the broken behaviour. 9 tests fail on the pre-fix source and pass after.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Align community CLI adapters with the flags accepted by current upstream releases. Update <code>GooseAdapter</code>, <code>QwenAdapter</code>, and <code>OllamaAdapter</code> invocation and capability handling, refresh verification metadata for <code>aider</code>, <code>gptme</code>, and <code>opencode</code>, clarify Continue model passthrough, and add argv regression coverage.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3584?tool=ast&topic=Sampling+flag+safety>Sampling flag safety</a>
        </td><td>Prevent unsupported sampling options from reaching Qwen and Aider-backed Ollama spawns, and update capability declarations and regression tests accordingly.<details><summary>Modified files (4)</summary><ul><li>src/bernstein/adapters/ollama.py</li>
<li>src/bernstein/adapters/qwen.py</li>
<li>tests/unit/test_adapter_ollama.py</li>
<li>tests/unit/test_adapter_qwen.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>docs(adapters): state ...</td><td>August 10, 2026</td></tr>
<tr><td>pollychen.lab@gmail.com</td><td>fix(qwen): use scoped ...</td><td>July 25, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3584?tool=ast&topic=CLI+compatibility>CLI compatibility</a>
        </td><td>Use Goose’s supported <code>--text</code> prompt interface, add invocation tests, and document current CLI verification and model-selection behavior across community adapters.<details><summary>Modified files (6)</summary><ul><li>src/bernstein/adapters/aider.py</li>
<li>src/bernstein/adapters/continue_dev.py</li>
<li>src/bernstein/adapters/gptme.py</li>
<li>src/bernstein/adapters/ollama.py</li>
<li>src/bernstein/adapters/opencode.py</li>
<li>tests/unit/test_adapter_goose.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>fix(adapters): drive f...</td><td>August 10, 2026</td></tr>
<tr><td>chernistry</td><td>fix: multi-provider or...</td><td>July 04, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3584?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>