### PR TITLE
docs(design): web UI principles and vocabulary inventory

### DIFF
--- a/docs/design/web-ui-inventory.md
+++ b/docs/design/web-ui-inventory.md
@@ -1,0 +1,105 @@
+# Web UI — token and component inventory
+
+What the dashboard already uses, catalogued so a new screen can reuse the
+vocabulary instead of inventing a parallel one. This describes `main` as it
+stands; it is not a proposal.
+
+Sources: `web/tailwind.config.js`, `web/src/index.css`, `web/src/components/`.
+
+## Colour tokens
+
+Declared as HSL triples in `web/src/index.css` and consumed through Tailwind,
+so `bg-surface-raised` and `hsl(var(--surface-raised))` are the same value.
+Light and dark are two sets of the same names — a component never branches on
+theme.
+
+| Group | Tokens |
+|---|---|
+| Base | `--background`, `--foreground` |
+| Surfaces | `--card`, `--card-foreground`, `--popover`, `--popover-foreground`, `--surface-raised` |
+| Emphasis | `--primary`, `--primary-foreground`, `--secondary`, `--secondary-foreground`, `--accent`, `--accent-foreground` |
+| State | `--success`, `--success-foreground`, `--warning`, `--warning-foreground`, `--destructive`, `--destructive-foreground` |
+| Recessive | `--muted`, `--muted-foreground`, `--meta-foreground` |
+| Lines and focus | `--border`, `--border-subtle`, `--border-strong`, `--input`, `--ring` |
+| Geometry | `--radius` (`lg` = the value, `md` = −2px, `sm` = −4px) |
+
+`--meta-foreground`, `--surface-raised`, `--border-subtle`, `--border-strong`
+and the `success` / `warning` pairs are additions on top of the shadcn base
+set. They exist because this UI has three depths of line weight and a
+metadata tier that the base set does not name.
+
+## Type scale
+
+Two vendored variable fonts, no outbound request: `Inter Tight` (300–700) for
+text, `JetBrains Mono` (400–600) for identifiers, hashes, and log output.
+Provenance and hashes in `web/src/fonts/README.md`.
+
+| Name | Size / line-height | Used for |
+|---|---|---|
+| `meta` | 11px / 1.2, tracking 0.12em | uppercase labels, column heads |
+| `log` | 11.5px / 1.55 | log and trace output |
+| `body` | 13px / 1.4 | default text |
+| `body-md` | 14px / 1.35, 500 | emphasised row text |
+| `h3` | 16px / 1.3, 600 | panel titles |
+| `h2` | 20px / 1.2, 600 | section titles |
+| `h1` | 30px / 1.05, 500 | page titles |
+| `stat-md` | 18px / 1.15, 500 | inline figures |
+| `stat-lg` | 24px / 1.1, 500 | headline figures |
+
+Nine steps is already the full budget. A screen needing a tenth is usually a
+screen using the wrong one of the nine.
+
+## Motion
+
+| Name | Definition | Used for |
+|---|---|---|
+| `fade-in` | 90ms `cubic-bezier(0.16, 1, 0.3, 1)` | content appearing in place |
+| `drawer-in` | 250ms, 8px translate + fade | the task drawer |
+
+Shared easing, two durations. `web/src/lib/motion.ts` holds the helpers.
+
+## Component families
+
+| Family | Location | Contents |
+|---|---|---|
+| Shell | `web/src/components/` | `AppShell`, `CommandPalette`, `ThemeProvider`, `SteeringControls`, `PlaceholderScreen` |
+| Artifacts | `components/artifacts/` | `ArtifactCard`, `ProgressStrip`, `TaskArtifactsPanel`, plus its own `types.ts` and data hook |
+| Dependencies | `components/deps/` | `TaskDepsPanel` |
+| Diff | `components/diff/` | `DiffFileList`, `DiffFileView`, `DiffHeader`, `DiffLine`, `DiffStates`, `TaskDiffPanel`, `highlight.ts` |
+| Gates | `components/gates/` | `TaskGatesPanel`, `GateRow`, `GateFilters`, `GateCountsHeader`, `GateStatusIcon`, `TaskLifecyclePill`, `buckets.ts`, `time.ts` |
+| Logs | `components/logs/` | `TaskLogsPanel` plus twelve presentational parts (`LogLine`, `LogList`, `LogToolbar`, filters, follow/pause controls, keyboard help) and `ansi.ts`, `parseLine.ts`, four hooks |
+| Trace | `components/trace/` | `TaskTracePanel`, `TraceEventCard`, `TraceFilters` |
+
+The convention each family follows: a `Panel` component as the entry point,
+narrow presentational children beside it, `types.ts` for the shape it renders,
+and a `use*` hook for fetching. A new drawer tab that follows this shape needs
+no new patterns.
+
+## Shared modules
+
+| Module | Responsibility |
+|---|---|
+| `lib/api.ts` | HTTP client for the orchestrator API |
+| `lib/sse.ts` | server-sent-event stream handling |
+| `lib/states.tsx` | `EmptyState`, `LoadingState`, `ErrorState`, plus `SectionLabel`, `StatusDot`, `Pill` |
+| `lib/format.ts` | value formatting |
+| `lib/motion.ts` | animation helpers |
+| `lib/pwa.ts` | installability |
+| `lib/utils.ts` | class-name merging and small helpers |
+
+`lib/states.tsx` is the one to read before writing an empty state — principle
+P2 in [web-ui-principles.md](web-ui-principles.md) is enforced by using it
+rather than by hand-rolling per screen.
+
+## Known gaps
+
+Recorded here rather than in a comment nobody greps.
+
+- Theme bootstrap: `index.html` has no inline script reading the stored theme
+  before React mounts, so first paint can flash light theme before resolving
+  to dark. Noted in `web/src/index.css` and left out of scope by the file that
+  found it.
+- The token set has no documented contrast measurements. `success` and
+  `warning` on `surface-raised` are the pairs most likely to be short.
+- No route renders a design-system reference page, so the only way to see the
+  vocabulary is to read this file next to the code.

--- a/docs/design/web-ui-principles.md
+++ b/docs/design/web-ui-principles.md
@@ -1,0 +1,96 @@
+# Web UI — design principles
+
+The browser operator UI has eight screens, a task drawer with six feature
+panels, and no written description of what it is trying to be. Contributors
+are adding screens against it (tracking issue #1262), and the vocabulary they
+match is whatever screen they happened to read first. This file is that
+description. It is short on purpose.
+
+Scope: `web/` only. The TUI is a separate surface with its own constraints.
+
+## What the UI is
+
+A read-mostly view over records the orchestrator already produced. The run
+happened elsewhere; the dashboard reports it. Almost every defect this surface
+can have is a place where the view says something the records do not.
+
+## Principles
+
+Each has an identifier so an issue or a review comment can cite one.
+
+**P1 — Every figure resolves to a record.** A number on screen traces to a
+specific entry the operator can open. Aggregates state what they aggregate
+over. A figure the browser computed from data it does not display is not
+verifiable by the person reading it.
+
+**P2 — Absence renders as absence.** When there is no data, the screen says so
+in the shape of the thing that is missing ("no approvals recorded for this
+run") rather than a zero, a dash, or a skeleton that never resolves. A
+plausible-looking placeholder is worse than an empty state, because it reads
+as a fact.
+
+**P3 — Same records, same view.** Two operators opening the same run see the
+same content. Rendering that depends on the reader — relative timestamps as
+the only form, locale-ordered lists, values that drift with the current clock —
+gets an absolute form alongside it.
+
+**P4 — Verification is reachable from where the claim is shown.** A screen
+displaying attested data shows the command that re-checks it, next to the
+claim rather than in a documentation page. The operator should never have to
+find out elsewhere how to confirm what they are looking at.
+
+**P5 — Quiet by default, dense when asked.** Operators keep this open for
+hours. The type scale already encodes this: 13px body, 11px metadata,
+uppercase tracking reserved for labels. Colour carries emphasis sparingly;
+motion is short (90ms fades, 250ms drawer) and never loops.
+
+**P6 — State is never carried by colour alone.** Every `success` / `warning` /
+`destructive` token appears with a text or icon form of the same information.
+
+**P7 — Nothing leaves the browser at view time.** Fonts are vendored; there
+are no third-party asset hosts, no analytics, no outbound requests to render a
+screen. The project ships an air-gap profile, and an operator opening a
+dashboard should not announce that to anyone.
+
+**P8 — Keyboard reaches everything the mouse reaches.** The command palette is
+the primary route; a control that exists only as a click target is incomplete.
+
+## What this UI will not do
+
+Stated so a proposal can be declined by pointing at a line rather than a
+preference.
+
+- No usage analytics or telemetry from the operator dashboard.
+- No third-party fonts, scripts, or images loaded at view time.
+- No status the source records do not contain, however reasonable the guess.
+- No blocking modal for an action that is not destructive.
+- No infinite spinner: a load either resolves, fails visibly, or is cancelled.
+- No screen whose only content is a chart. Charts sit beside the rows they
+  summarise, so the reader can check one against the other.
+
+## Screens today
+
+| Route | File | Reports |
+|---|---|---|
+| Tasks | `web/src/routes/Tasks.tsx` | task list and the per-task drawer |
+| Approvals | `web/src/routes/Approvals.tsx` | pending and decided approvals |
+| Audit | `web/src/routes/Audit.tsx` | audit chain entries |
+| Costs | `web/src/routes/Costs.tsx` | spend by task, agent, model |
+| Fleet | `web/src/routes/Fleet.tsx` | workers and their liveness |
+| Agents | `web/src/routes/Agents.tsx` | configured adapters |
+| Missions | `web/src/routes/Missions.tsx` | mission-level grouping |
+| Settings | `web/src/routes/Settings.tsx` | local preferences |
+
+Task drawer panels live under `web/src/components/<feature>/`: `artifacts`,
+`deps`, `diff`, `gates`, `logs`, `trace`.
+
+## Using this file
+
+A pull request that adds or changes a screen names the principles it is
+working under and, where it departs from one, says which and why. A reviewer
+who wants a change cites the identifier. If a principle turns out to be wrong,
+change it here first — a rule nobody can amend gets worked around instead.
+
+The vocabulary these principles are written against — tokens, type scale,
+motion, component families — is catalogued in
+[web-ui-inventory.md](web-ui-inventory.md).

--- a/docs/design/web-ui-principles.md
+++ b/docs/design/web-ui-principles.md
@@ -47,10 +47,12 @@ motion is short (90ms fades, 250ms drawer) and never loops.
 **P6 — State is never carried by colour alone.** Every `success` / `warning` /
 `destructive` token appears with a text or icon form of the same information.
 
-**P7 — Nothing leaves the browser at view time.** Fonts are vendored; there
-are no third-party asset hosts, no analytics, no outbound requests to render a
-screen. The project ships an air-gap profile, and an operator opening a
-dashboard should not announce that to anyone.
+**P7 — The orchestrator is the only host the browser talks to.** The
+dashboard fetches records from the API and event stream it was pointed at
+(`web/src/lib/api.ts`, `web/src/lib/sse.ts`) and from nowhere else. Fonts are
+vendored; there are no third-party asset hosts, no analytics, no telemetry.
+The project ships an air-gap profile, and an operator opening a dashboard
+should not announce that outside their own deployment.
 
 **P8 — Keyboard reaches everything the mouse reaches.** The command palette is
 the primary route; a control that exists only as a click target is incomplete.


### PR DESCRIPTION
# User description
## What

Two files under `docs/design/`:

- `web-ui-principles.md` — the rules a dashboard screen is expected to hold to, each with an identifier (P1–P8) so an issue or review comment can cite one, plus an explicit list of what the UI will not do.
- `web-ui-inventory.md` — a catalogue of the colour tokens, type scale, motion definitions, component families and shared modules that already exist.

## Why

The dashboard has eight routes and six drawer panels. Contributors are adding screens against #1262, and with nothing written down the vocabulary a new screen matches is whichever existing screen its author happened to read first. Divergence is cheap to create and expensive to unpick later.

The alternative considered was starting from mockups. Rejected for now: a mockup drawn before the existing vocabulary is named produces a screen that has to be reconciled with eight others afterwards. Naming first makes the mockup step cheaper, not slower.

## How

The inventory is descriptive. Every entry was read out of `web/tailwind.config.js`, `web/src/index.css` and `web/src/components/` — no aspirational tokens, no components that do not exist.

Three gaps found while cataloguing are recorded in the inventory rather than left in a source comment: the missing theme bootstrap in `index.html`, the unmeasured contrast pairs, and the absence of any rendered reference for the vocabulary. Each is filed separately and linked under #1262.

## Checklist

- [x] Docs-only change; no runtime surface touched
- [x] Every claim in the inventory verified against the source it cites
- [x] Cross-links between the two files resolve

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Document the dashboard’s design principles, constraints, and screen vocabulary. Catalog the existing tokens, typography, motion, component families, shared modules, and known gaps to guide future web UI contributions.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3587?tool=ast&topic=UI+Inventory>UI Inventory</a>
        </td><td>Inventory the dashboard’s implemented design vocabulary and shared building blocks, while recording theme, contrast, and reference-page gaps for future work.<details><summary>Modified files (1)</summary><ul><li>docs/design/web-ui-inventory.md</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>docs(design): write do...</td><td>August 10, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3587?tool=ast&topic=UI+Principles>UI Principles</a>
        </td><td>Define eight reviewable principles for the browser operator UI, including verifiable records, explicit empty states, accessible interaction, consistent rendering, and air-gapped operation; also document current routes and non-goals.<details><summary>Modified files (1)</summary><ul><li>docs/design/web-ui-principles.md</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>docs(design): scope P7...</td><td>August 10, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3587?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>