### PR TITLE
feat(readme-l10n): name the owner when a translation drifts

### DIFF
--- a/docs/playbooks/readme-l10n.md
+++ b/docs/playbooks/readme-l10n.md
@@ -109,3 +109,48 @@ stripped per line, blank lines are dropped, lines are joined with
 blank-line reflow) so the gate does not cry wolf on every formatting
 pass, while still catching any real content change to the English
 source.
+
+## Adding a language
+
+A translation is added by whoever can keep it current, not by whoever
+happens to be merging that week. Two steps, both data:
+
+1. Add `README.<ietf-tag>.md` carrying an `l10n` binding under every
+   translated `###` heading, and append the tag to `languages` in
+   `[tool.bernstein.readme-l10n]`.
+2. Add yourself to `[tool.bernstein.readme-l10n.owners]`:
+
+   ```toml
+   [tool.bernstein.readme-l10n.owners]
+   "zh-Hans" = "@your-handle"
+   ```
+
+`bernstein readme-l10n sync` fills the hashes; `verify` proves the file
+is in sync before the PR merges.
+
+## Ownership
+
+The owner is the person a drift report is addressed to. When `verify`
+fails, it prints the stale section *and* the owner:
+
+```
+DRIFT    README.zh-Hans.md: section "install in 30 seconds" is stale: ...
+OWNER    README.zh-Hans.md is kept current by @your-handle
+```
+
+A language with no entry in the owners table is reported as unowned:
+
+```
+OWNER    README.zh-Hans.md has no owner in [tool.bernstein.readme-l10n.owners]
+```
+
+That is a real state, not a warning to ignore. An unowned translation is
+a removal candidate: it will drift, and the drift will land on whoever
+edited the English source, who by definition cannot check it. The repo
+carried eleven translations once, added in a single change with no gate
+and no owners; seventeen days later they were removed as stale. The gate
+prevents the silent part of that; the owners table prevents the rest.
+
+Handing a language over is a one-line change to the table, made by the
+person taking it on. Nobody is assigned a language they did not
+volunteer for.

--- a/docs/playbooks/readme-l10n.md
+++ b/docs/playbooks/readme-l10n.md
@@ -50,10 +50,40 @@ Adding a language is a data change, not a code change:
 4. Run `uv run bernstein readme-l10n sync` to (re)compute every
    binding hash, then `uv run bernstein readme-l10n verify --workdir .`
    to confirm.
+5. Add yourself to `[tool.bernstein.readme-l10n.owners]`. A translation
+   is added by whoever can keep it current, not by whoever happens to
+   be merging that week:
+
+   ```toml
+   [tool.bernstein.readme-l10n.owners]
+   "zh-Hans" = "@your-handle"
+   ```
 
 A binding line for a section that does not exist in `README.md`
 makes `sync` warn; a translated section without a binding line makes
 `verify` fail with the section name.
+
+## Exit codes
+
+CI has to tell "nothing to verify" apart from "the configuration
+stopped parsing". Those are different situations and only one of them
+is fine, so they get different exit codes.
+
+| Exit | Meaning | Printed |
+|---|---|---|
+| 0 | every configured language is in sync | `OK` |
+| 0 | no `pyproject.toml`, or no configured `languages` | `SKIP` |
+| 1 | drift: stale binding, translated code block, paragraph-count mismatch, or a modified verbatim block | `DRIFT` |
+| 2 | `pyproject.toml` exists but cannot be read or parsed; `languages` malformed; `owners` table or a handle malformed (`verify`) | `CONFIG` |
+
+Both `verify` and `sync` exit 2 on an unreadable or malformed
+`pyproject.toml`. Only `verify` reads the `owners` table, so only
+`verify` can exit 2 because of it.
+
+A CI step written as `verify || exit 1` collapses 1 and 2 into one
+signal. That is fine for blocking a merge and wrong for diagnosing one:
+a stray tab in the TOML would otherwise read as "no languages
+configured", and the translations would rot behind a green check.
 
 ## What CI checks
 
@@ -109,24 +139,6 @@ stripped per line, blank lines are dropped, lines are joined with
 blank-line reflow) so the gate does not cry wolf on every formatting
 pass, while still catching any real content change to the English
 source.
-
-## Adding a language
-
-A translation is added by whoever can keep it current, not by whoever
-happens to be merging that week. Two steps, both data:
-
-1. Add `README.<ietf-tag>.md` carrying an `l10n` binding under every
-   translated `###` heading, and append the tag to `languages` in
-   `[tool.bernstein.readme-l10n]`.
-2. Add yourself to `[tool.bernstein.readme-l10n.owners]`:
-
-   ```toml
-   [tool.bernstein.readme-l10n.owners]
-   "zh-Hans" = "@your-handle"
-   ```
-
-`bernstein readme-l10n sync` fills the hashes; `verify` proves the file
-is in sync before the PR merges.
 
 ## Ownership
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -869,6 +869,16 @@ ignore_missing_imports = true
 # here and add README.<tag>.md carrying l10n bindings.
 languages = ["zh-Hans", "zh-TW"]
 
+# Who keeps each translation current. `verify` names the owner when a
+# language drifts, so the report reaches someone who reads the language
+# rather than defaulting to whoever merged last. A language with no entry
+# here is reported as unowned and is a removal candidate rather than a
+# standing obligation. Handing a language over is a one-line change to
+# this table, made by the person taking it on.
+[tool.bernstein.readme-l10n.owners]
+"zh-Hans" = "@chernistry"
+"zh-TW" = "@chernistry"
+
 [tool.pytest.ini_options]
 minversion = "8.0"
 testpaths = ["tests"]

--- a/src/bernstein/cli/commands/readme_l10n_cmd.py
+++ b/src/bernstein/cli/commands/readme_l10n_cmd.py
@@ -9,10 +9,21 @@ English section and leaves a translation behind turns red in CI.
 
 Non-zero exit codes are operator contract:
 
-- ``0``  - all configured languages are in sync
+- ``0``  - all configured languages are in sync, or there is nothing to
+           verify: no ``pyproject.toml``, or one carrying no
+           ``[tool.bernstein.readme-l10n]`` languages (reported ``SKIP``)
 - ``1``  - drift detected (stale binding, translated code block, or
            modified verbatim block)
-- ``2``  - configuration error (malformed ``languages`` entry)
+- ``2``  - configuration error: ``pyproject.toml`` exists but cannot be
+           read or parsed, ``languages`` is malformed, or - ``verify``
+           only, which is the command that reads it - the ``owners``
+           table or a handle in it is malformed
+
+Exit 2 is deliberately distinct from the exit-0 ``SKIP`` path. A repo
+that never configured the gate is fine; a repo whose configuration
+stopped parsing is not, and CI has to be able to tell those apart -
+otherwise a stray tab in the TOML reads as "nothing to check" and the
+translations rot behind a green check.
 
 Designed for CI gating::
 
@@ -31,7 +42,7 @@ from bernstein.core.knowledge.readme_l10n import (
     BINDING_RE,
     HEADER_SECTION,
     load_config,
-    load_owners,
+    load_settings,
     section_hash,
     split_sections,
     verify_language,
@@ -49,14 +60,19 @@ def _resolve_workdir(workdir: Path) -> Path:
     return workdir
 
 
-def _load_owners(workdir: Path) -> dict[str, str]:
-    """Load the per-language owner map, mapping config errors to exit 2."""
+def _load_settings(workdir: Path) -> tuple[list[str], dict[str, str]]:
+    """Load languages and owners together, mapping config errors to exit 2.
+
+    Both come from one parse. Loading them separately would let an edit
+    between the two reads report an owner drawn from a different
+    revision than the language list being verified.
+    """
     try:
-        return load_owners(workdir / "pyproject.toml")
+        return load_settings(workdir / "pyproject.toml")
     except ValueError as exc:
         click.echo(f"CONFIG   {exc}", err=True)
         sys.exit(2)
-    return {}
+    return [], {}
 
 
 def _report_owner(lang: str, owners: dict[str, str]) -> None:
@@ -127,8 +143,7 @@ def readme_l10n_verify(workdir: Path) -> None:
         bernstein readme-l10n verify || (echo 'drift; run sync' && exit 1)
     """
     _resolve_workdir(workdir)
-    languages = _load_languages(workdir)
-    owners = _load_owners(workdir)
+    languages, owners = _load_settings(workdir)
     if not languages:
         click.echo("SKIP     no [tool.bernstein.readme-l10n] languages configured; nothing to verify")
         return

--- a/src/bernstein/cli/commands/readme_l10n_cmd.py
+++ b/src/bernstein/cli/commands/readme_l10n_cmd.py
@@ -31,6 +31,7 @@ from bernstein.core.knowledge.readme_l10n import (
     BINDING_RE,
     HEADER_SECTION,
     load_config,
+    load_owners,
     section_hash,
     split_sections,
     verify_language,
@@ -46,6 +47,36 @@ def _resolve_workdir(workdir: Path) -> Path:
     if not (workdir / "README.md").is_file():
         raise click.UsageError(f"{workdir} does not contain a README.md; pass --workdir REPO_ROOT")
     return workdir
+
+
+def _load_owners(workdir: Path) -> dict[str, str]:
+    """Load the per-language owner map, mapping config errors to exit 2."""
+    try:
+        return load_owners(workdir / "pyproject.toml")
+    except ValueError as exc:
+        click.echo(f"CONFIG   {exc}", err=True)
+        sys.exit(2)
+    return {}
+
+
+def _report_owner(lang: str, owners: dict[str, str]) -> None:
+    """Name whoever keeps this translation current, on the failure path.
+
+    A drift report that does not say who to ask lands on the maintainer
+    by default, which is how the previous translation set went stale
+    before anyone noticed. A language with no recorded owner is reported
+    as such: an unowned translation is a removal candidate, not a
+    standing debt.
+    """
+    handle = owners.get(lang)
+    if handle:
+        click.echo(f"OWNER    README.{lang}.md is kept current by {handle}", err=True)
+    else:
+        click.echo(
+            f"OWNER    README.{lang}.md has no owner in [tool.bernstein.readme-l10n.owners]; "
+            "see docs/playbooks/readme-l10n.md",
+            err=True,
+        )
 
 
 def _load_languages(workdir: Path) -> list[str]:
@@ -97,6 +128,7 @@ def readme_l10n_verify(workdir: Path) -> None:
     """
     _resolve_workdir(workdir)
     languages = _load_languages(workdir)
+    owners = _load_owners(workdir)
     if not languages:
         click.echo("SKIP     no [tool.bernstein.readme-l10n] languages configured; nothing to verify")
         return
@@ -109,6 +141,7 @@ def readme_l10n_verify(workdir: Path) -> None:
         tpath = workdir / f"README.{lang}.md"
         if not tpath.is_file():
             click.echo(f"MISSING  README.{lang}.md (configured but not present)", err=True)
+            _report_owner(lang, owners)
             drift_total += 1
             continue
         result = verify_language(sections, lang, tpath.read_text(encoding="utf-8"))
@@ -117,6 +150,7 @@ def readme_l10n_verify(workdir: Path) -> None:
             continue
         for err in result.errors:
             click.echo(f"DRIFT    README.{lang}.md: {err}", err=True)
+        _report_owner(lang, owners)
         drift_total += len(result.errors)
 
     if drift_total:

--- a/src/bernstein/core/knowledge/readme_l10n.py
+++ b/src/bernstein/core/knowledge/readme_l10n.py
@@ -436,3 +436,38 @@ def load_config(pyproject: Path) -> list[str]:
     if not strs or len(strs) != len(langs):
         raise ValueError("[tool.bernstein.readme-l10n] languages must be a non-empty list of IETF tags")
     return strs
+
+
+def load_owners(pyproject: Path) -> dict[str, str]:
+    """Read the per-language owner map from ``[tool.bernstein.readme-l10n.owners]``.
+
+    Maps an IETF tag to the handle of whoever keeps that translation
+    current. Missing config, or a missing ``owners`` table, means no
+    language has a recorded owner - the gate still fails on drift, it
+    just cannot say who to ask. A malformed entry is a hard error for
+    the same reason a malformed ``languages`` entry is: a typo must not
+    quietly turn a language into one nobody is named for.
+    """
+    import tomllib
+
+    try:
+        data: dict[str, object] = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return {}
+
+    section: object = data.get("tool")
+    for key in ("bernstein", "readme-l10n", "owners"):
+        if not isinstance(section, dict):
+            return {}
+        section = cast(dict[str, object], section).get(key)
+    if section is None:
+        return {}
+    if not isinstance(section, dict):
+        raise ValueError('[tool.bernstein.readme-l10n.owners] must be a table of ietf-tag = "handle"')
+    owners = cast(dict[str, object], section)
+    bad = sorted(tag for tag, handle in owners.items() if not isinstance(handle, str) or not handle.strip())
+    if bad:
+        raise ValueError(
+            "[tool.bernstein.readme-l10n.owners] entries must be non-empty strings; bad entries: " + ", ".join(bad)
+        )
+    return {tag: cast(str, handle).strip() for tag, handle in owners.items()}

--- a/src/bernstein/core/knowledge/readme_l10n.py
+++ b/src/bernstein/core/knowledge/readme_l10n.py
@@ -399,6 +399,32 @@ def binding_placement_errors(text: str) -> list[str]:
     return errors
 
 
+_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def _read_pyproject(pyproject: Path) -> dict[str, object] | None:
+    """Parse ``pyproject.toml``; ``None`` means there is no file to read.
+
+    A file that exists but cannot be read or parsed is a configuration
+    error, not an absent configuration. Returning an empty result there
+    would let a stray tab in the TOML disable the drift gate while the
+    run still exits 0 - the gate would report SKIP on a repo whose
+    translations are silently rotting.
+    """
+    import tomllib
+
+    try:
+        text = pyproject.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise ValueError(f"cannot read {pyproject.name}: {exc}") from exc
+    try:
+        return tomllib.loads(text)
+    except tomllib.TOMLDecodeError as exc:
+        raise ValueError(f"{pyproject.name} is not valid TOML: {exc}") from exc
+
+
 def load_config(pyproject: Path) -> list[str]:
     """Read the configured language set from ``[tool.bernstein.readme-l10n]``.
 
@@ -406,11 +432,8 @@ def load_config(pyproject: Path) -> list[str]:
     malformed ``languages`` entry is a hard error so a typo cannot
     silently disable the gate.
     """
-    import tomllib
-
-    try:
-        data: dict[str, object] = tomllib.loads(pyproject.read_text(encoding="utf-8"))
-    except (OSError, tomllib.TOMLDecodeError):
+    data = _read_pyproject(pyproject)
+    if data is None:
         return []
 
     tool_raw: object = data.get("tool")
@@ -448,11 +471,8 @@ def load_owners(pyproject: Path) -> dict[str, str]:
     the same reason a malformed ``languages`` entry is: a typo must not
     quietly turn a language into one nobody is named for.
     """
-    import tomllib
-
-    try:
-        data: dict[str, object] = tomllib.loads(pyproject.read_text(encoding="utf-8"))
-    except (OSError, tomllib.TOMLDecodeError):
+    data = _read_pyproject(pyproject)
+    if data is None:
         return {}
 
     section: object = data.get("tool")
@@ -469,5 +489,15 @@ def load_owners(pyproject: Path) -> dict[str, str]:
     if bad:
         raise ValueError(
             "[tool.bernstein.readme-l10n.owners] entries must be non-empty strings; bad entries: " + ", ".join(bad)
+        )
+    # The handle is echoed into the verify output, which CI logs and
+    # humans read. A newline or an escape sequence in it would let the
+    # config forge lines in that report, so control bytes are refused
+    # rather than stripped: a handle that needs them is a typo.
+    forged = sorted(tag for tag, handle in owners.items() if _CONTROL_CHARS.search(cast(str, handle)))
+    if forged:
+        raise ValueError(
+            "[tool.bernstein.readme-l10n.owners] handles may not contain control characters; bad entries: "
+            + ", ".join(forged)
         )
     return {tag: cast(str, handle).strip() for tag, handle in owners.items()}

--- a/src/bernstein/core/knowledge/readme_l10n.py
+++ b/src/bernstein/core/knowledge/readme_l10n.py
@@ -399,7 +399,7 @@ def binding_placement_errors(text: str) -> list[str]:
     return errors
 
 
-_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f-\x9f]")
 
 
 def _read_pyproject(pyproject: Path) -> dict[str, object] | None:
@@ -432,7 +432,11 @@ def load_config(pyproject: Path) -> list[str]:
     malformed ``languages`` entry is a hard error so a typo cannot
     silently disable the gate.
     """
-    data = _read_pyproject(pyproject)
+    return _languages_from(_read_pyproject(pyproject))
+
+
+def _languages_from(data: dict[str, object] | None) -> list[str]:
+    """Derive the language set from an already-parsed ``pyproject.toml``."""
     if data is None:
         return []
 
@@ -471,7 +475,11 @@ def load_owners(pyproject: Path) -> dict[str, str]:
     the same reason a malformed ``languages`` entry is: a typo must not
     quietly turn a language into one nobody is named for.
     """
-    data = _read_pyproject(pyproject)
+    return _owners_from(_read_pyproject(pyproject))
+
+
+def _owners_from(data: dict[str, object] | None) -> dict[str, str]:
+    """Derive the owner map from an already-parsed ``pyproject.toml``."""
     if data is None:
         return {}
 
@@ -493,7 +501,10 @@ def load_owners(pyproject: Path) -> dict[str, str]:
     # The handle is echoed into the verify output, which CI logs and
     # humans read. A newline or an escape sequence in it would let the
     # config forge lines in that report, so control bytes are refused
-    # rather than stripped: a handle that needs them is a typo.
+    # rather than stripped: a handle that needs them is a typo. The
+    # refused set spans C1 as well as C0, because U+009B is a
+    # single-character CSI that a terminal reading 8-bit controls will
+    # act on exactly as it acts on the two-byte ESC form.
     forged = sorted(tag for tag, handle in owners.items() if _CONTROL_CHARS.search(cast(str, handle)))
     if forged:
         raise ValueError(
@@ -501,3 +512,16 @@ def load_owners(pyproject: Path) -> dict[str, str]:
             + ", ".join(forged)
         )
     return {tag: cast(str, handle).strip() for tag, handle in owners.items()}
+
+
+def load_settings(pyproject: Path) -> tuple[list[str], dict[str, str]]:
+    """Read languages and owners from a single parse of ``pyproject.toml``.
+
+    ``verify`` needs both. Reading the file twice would let an edit
+    landing between the two reads pair the languages of one revision
+    with the owners of another - the report would then name an owner
+    for a language that revision does not configure, or omit one it
+    does. One parse, both values, so the two can never disagree.
+    """
+    data = _read_pyproject(pyproject)
+    return _languages_from(data), _owners_from(data)

--- a/tests/unit/test_readme_l10n_cmd.py
+++ b/tests/unit/test_readme_l10n_cmd.py
@@ -13,12 +13,14 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from click.testing import CliRunner, Result
 
 from bernstein.cli.commands.readme_l10n_cmd import readme_l10n_cmd
 from bernstein.core.knowledge.readme_l10n import (
     HEADER_SECTION,
     Section,
+    load_owners,
     section_hash,
     split_sections,
 )
@@ -306,3 +308,70 @@ class TestCoreSplitting:
         footer = sections[-1].body
         assert "Footer line" in footer
         assert "four stages" not in footer
+
+
+def _stale_repo(tmp_path: Path, *, owners: str = "") -> Path:
+    """A fixture whose English source moved on after the translation bound it."""
+    repo = _write_fixture(tmp_path, zh=_zh_readme(_en_sections()))
+    (repo / "README.md").write_text(
+        EN_README.replace(
+            "pip and uv are covered in the install guide.",
+            "pip, uv, brew and dnf are covered in the install guide.",
+        ),
+        encoding="utf-8",
+    )
+    if owners:
+        (repo / "pyproject.toml").write_text(
+            "[project]\nname = 'demo'\nversion = '0'\n\n"
+            "[tool.bernstein.readme-l10n]\nlanguages = ['zh-Hans']\n\n" + owners,
+            encoding="utf-8",
+        )
+    return repo
+
+
+class TestOwnerReporting:
+    """A drift report has to name someone who reads the language.
+
+    Without it every stale translation lands on whoever merged last,
+    which is how the earlier translation set went stale unnoticed.
+    """
+
+    def test_load_owners_reads_the_table(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text(
+            "[tool.bernstein.readme-l10n]\nlanguages = ['zh-Hans']\n\n"
+            '[tool.bernstein.readme-l10n.owners]\n"zh-Hans" = "@someone"\n',
+            encoding="utf-8",
+        )
+        assert load_owners(tmp_path / "pyproject.toml") == {"zh-Hans": "@someone"}
+
+    def test_absent_owners_table_is_empty_not_an_error(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text(
+            "[tool.bernstein.readme-l10n]\nlanguages = ['zh-Hans']\n", encoding="utf-8"
+        )
+        assert load_owners(tmp_path / "pyproject.toml") == {}
+
+    def test_blank_handle_is_a_config_error(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text(
+            '[tool.bernstein.readme-l10n.owners]\n"zh-Hans" = "  "\n', encoding="utf-8"
+        )
+        with pytest.raises(ValueError, match="zh-Hans"):
+            load_owners(tmp_path / "pyproject.toml")
+
+    def test_verify_names_the_owner_on_drift(self, tmp_path: Path) -> None:
+        repo = _stale_repo(
+            tmp_path,
+            owners='[tool.bernstein.readme-l10n.owners]\n"zh-Hans" = "@translator"\n',
+        )
+        result = _run("verify", "--workdir", str(repo))
+        assert result.exit_code == 1, result.output
+        assert "@translator" in result.output
+
+    def test_verify_says_so_when_nobody_owns_it(self, tmp_path: Path) -> None:
+        result = _run("verify", "--workdir", str(_stale_repo(tmp_path)))
+        assert result.exit_code == 1, result.output
+        assert "no owner" in result.output
+
+    def test_a_blank_handle_exits_two_not_one(self, tmp_path: Path) -> None:
+        repo = _stale_repo(tmp_path, owners='[tool.bernstein.readme-l10n.owners]\n"zh-Hans" = ""\n')
+        result = _run("verify", "--workdir", str(repo))
+        assert result.exit_code == 2, result.output

--- a/tests/unit/test_readme_l10n_cmd.py
+++ b/tests/unit/test_readme_l10n_cmd.py
@@ -22,6 +22,7 @@ from bernstein.core.knowledge.readme_l10n import (
     Section,
     load_config,
     load_owners,
+    load_settings,
     section_hash,
     split_sections,
 )
@@ -423,3 +424,66 @@ class TestConfigFailsClosed:
         )
         with pytest.raises(ValueError, match="control characters"):
             load_owners(tmp_path / "pyproject.toml")
+
+
+class TestHandleControlRange:
+    """The refused control range covers C1, not just C0.
+
+    U+009B is a single-character CSI. A terminal reading 8-bit controls
+    acts on it exactly as it acts on the two-byte ``ESC [`` form, so a
+    handle carrying it can erase the report line it was printed on.
+    """
+
+    def test_handle_with_a_c1_csi_is_refused(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text(
+            '[tool.bernstein.readme-l10n.owners]\n"zh-Hans" = "@ok\\u009b2K"\n', encoding="utf-8"
+        )
+        with pytest.raises(ValueError, match="control characters"):
+            load_owners(tmp_path / "pyproject.toml")
+
+    def test_ordinary_non_ascii_handle_is_accepted(self, tmp_path: Path) -> None:
+        """The rule refuses controls, not non-ASCII: handles carry names."""
+        (tmp_path / "pyproject.toml").write_text(
+            '[tool.bernstein.readme-l10n.owners]\n"ru" = "@\u0410\u043d\u043d\u0430"\n', encoding="utf-8"
+        )
+        assert load_owners(tmp_path / "pyproject.toml") == {"ru": "@\u0410\u043d\u043d\u0430"}
+
+
+class TestSettingsParseOnce:
+    """``verify`` reads the config once, so languages and owners agree.
+
+    Two reads can straddle an edit and pair the languages of one
+    revision with the owners of another - the report would then name an
+    owner for a language that revision does not configure.
+    """
+
+    _CFG = (
+        "[tool.bernstein.readme-l10n]\nlanguages = ['zh-Hans']\n\n"
+        '[tool.bernstein.readme-l10n.owners]\n"zh-Hans" = "@someone"\n'
+    )
+
+    def test_returns_both_values(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text(self._CFG, encoding="utf-8")
+        assert load_settings(tmp_path / "pyproject.toml") == (["zh-Hans"], {"zh-Hans": "@someone"})
+
+    def test_reads_the_file_exactly_once(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        cfg = tmp_path / "pyproject.toml"
+        cfg.write_text(self._CFG, encoding="utf-8")
+        seen: list[Path] = []
+        real = Path.read_text
+
+        def counting(self: Path, *args: object, **kwargs: object) -> str:
+            seen.append(self)
+            return real(self, *args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(Path, "read_text", counting)
+        load_settings(cfg)
+        assert [q for q in seen if q == cfg] == [cfg]
+
+    def test_absent_file_is_empty_not_an_error(self, tmp_path: Path) -> None:
+        assert load_settings(tmp_path / "pyproject.toml") == ([], {})
+
+    def test_malformed_toml_fails_closed(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text("[tool.bernstein\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="not valid TOML"):
+            load_settings(tmp_path / "pyproject.toml")

--- a/tests/unit/test_readme_l10n_cmd.py
+++ b/tests/unit/test_readme_l10n_cmd.py
@@ -20,6 +20,7 @@ from bernstein.cli.commands.readme_l10n_cmd import readme_l10n_cmd
 from bernstein.core.knowledge.readme_l10n import (
     HEADER_SECTION,
     Section,
+    load_config,
     load_owners,
     section_hash,
     split_sections,
@@ -375,3 +376,50 @@ class TestOwnerReporting:
         repo = _stale_repo(tmp_path, owners='[tool.bernstein.readme-l10n.owners]\n"zh-Hans" = ""\n')
         result = _run("verify", "--workdir", str(repo))
         assert result.exit_code == 2, result.output
+
+
+class TestConfigFailsClosed:
+    """A broken pyproject.toml must not read as an absent one.
+
+    Swallowing a parse error would let a stray character disable the
+    drift gate while the run still exits 0, which is the one outcome the
+    gate exists to prevent.
+    """
+
+    def test_malformed_toml_is_a_config_error_not_an_empty_language_set(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text("[tool.bernstein.readme-l10n\nlanguages = [", encoding="utf-8")
+        with pytest.raises(ValueError, match="not valid TOML"):
+            load_config(tmp_path / "pyproject.toml")
+        with pytest.raises(ValueError, match="not valid TOML"):
+            load_owners(tmp_path / "pyproject.toml")
+
+    def test_absent_pyproject_stays_an_empty_config(self, tmp_path: Path) -> None:
+        assert load_config(tmp_path / "pyproject.toml") == []
+        assert load_owners(tmp_path / "pyproject.toml") == {}
+
+    def test_unreadable_pyproject_is_a_config_error(self, tmp_path: Path) -> None:
+        # A directory at the config path: exists, cannot be read as a file.
+        (tmp_path / "pyproject.toml").mkdir()
+        with pytest.raises(ValueError, match="cannot read"):
+            load_config(tmp_path / "pyproject.toml")
+
+    def test_verify_exits_two_on_malformed_toml(self, tmp_path: Path) -> None:
+        (tmp_path / "README.md").write_text(EN_README, encoding="utf-8")
+        (tmp_path / "pyproject.toml").write_text("[tool.bernstein.readme-l10n\n", encoding="utf-8")
+        result = _run("verify", "--workdir", str(tmp_path))
+        assert result.exit_code == 2, result.output
+
+    def test_handle_with_a_newline_cannot_forge_output_lines(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text(
+            '[tool.bernstein.readme-l10n.owners]\n"zh-Hans" = "@ok\\nOK       all translated README(s) in sync"\n',
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="control characters"):
+            load_owners(tmp_path / "pyproject.toml")
+
+    def test_handle_with_an_escape_sequence_is_refused(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text(
+            '[tool.bernstein.readme-l10n.owners]\n"zh-TW" = "@ok\\u001b[2K"\n', encoding="utf-8"
+        )
+        with pytest.raises(ValueError, match="control characters"):
+            load_owners(tmp_path / "pyproject.toml")


### PR DESCRIPTION
# User description
## What

An optional `[tool.bernstein.readme-l10n.owners]` table maps each translated README to the handle of whoever keeps it current. `bernstein readme-l10n verify` prints an `OWNER` line beside every drift and every missing translation, and says so explicitly when a language has no owner recorded.

## Why

The gate names the stale section but not a person, so the report is addressed to whoever edited the English source — who by definition cannot check the translation. That is how the previous translation set went: eleven languages added in one change with no gate and no owners, removed seventeen days later as stale (`8a31e29f`).

Making the owner part of the failure output turns a translation from standing maintainer debt into a surface someone volunteered for. A language with nobody named is reported as unowned, which is the honest signal that it is a removal candidate.

## How

- `load_owners()` mirrors `load_config()`'s defensive parsing. An absent table is `{}` (exit 0 — owners stay optional); a blank or non-string handle is exit 2, matching how a malformed `languages` list is already treated, so a typo cannot quietly unname a language.
- `_report_owner()` runs on the failure path only. A clean verify is unchanged.
- The playbook gains an "Adding a language" and an "Ownership" section: adding a translation and claiming it are two data changes, and handing one over is a one-line edit made by the person taking it on. Nobody is assigned a language they did not volunteer for.

Rejected alternative: deriving the owner from `git blame` on the translated file. After a `sync` run that is the maintainer, and it cannot express a handover.

## Tests

`tests/unit/test_readme_l10n_cmd.py::TestOwnerReporting` — six cases: table read, absent table, blank handle rejected, owner named on drift, unowned reported as unowned, malformed handle exits 2 rather than 1. They fail on `main` (`load_owners` does not exist) and pass here.

```
26 passed
```

## Checklist

- [x] `ruff check` and `ruff format` clean
- [x] `mypy` clean over both changed modules
- [x] Test fails before, passes after
- [x] Docs updated (`docs/playbooks/readme-l10n.md`)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add optional README translation ownership configuration and make <code>bernstein readme-l10n verify</code> report the responsible handle for drift or missing translations. Harden shared TOML settings parsing with distinct configuration errors and document ownership, exit codes, and handover practices.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3591?tool=ast&topic=Translation+Ownership>Translation Ownership</a>
        </td><td>Name translation owners in verification failures and report unowned or missing translations, while documenting how maintainers claim and hand over languages.<details><summary>Modified files (5)</summary><ul><li>docs/playbooks/readme-l10n.md</li>
<li>pyproject.toml</li>
<li>src/bernstein/cli/commands/readme_l10n_cmd.py</li>
<li>src/bernstein/core/knowledge/readme_l10n.py</li>
<li>tests/unit/test_readme_l10n_cmd.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>fix(readme-l10n): refu...</td><td>August 10, 2026</td></tr>
<tr><td>chernistry</td><td>docs: accuracy pass ov...</td><td>August 10, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3591?tool=ast&topic=Config+Validation>Config Validation</a>
        </td><td>Parse <code>pyproject.toml</code> once for languages and owners, reject malformed or unsafe handles, and preserve distinct <code>SKIP</code>, drift, and configuration exit outcomes.<details><summary>Modified files (4)</summary><ul><li>docs/playbooks/readme-l10n.md</li>
<li>src/bernstein/cli/commands/readme_l10n_cmd.py</li>
<li>src/bernstein/core/knowledge/readme_l10n.py</li>
<li>tests/unit/test_readme_l10n_cmd.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>fix(readme-l10n): refu...</td><td>August 10, 2026</td></tr>
<tr><td>chernistry</td><td>docs: accuracy pass ov...</td><td>August 10, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3591?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>