### PR TITLE
docs: roadmap projection, scope boundaries, and an ADR index

### DIFF
--- a/.github/workflows/roadmap-refresh.yml
+++ b/.github/workflows/roadmap-refresh.yml
@@ -13,9 +13,10 @@ on:
     - cron: "17 6 * * 1"
   workflow_dispatch:
 
+# Workflow scope stays read-only; the one job that needs to write
+# re-asserts the elevated set at job scope (Scorecard token-permissions).
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: roadmap-refresh
@@ -23,22 +24,33 @@ concurrency:
 
 jobs:
   refresh:
+    name: Regenerate the milestone projection
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      # Credentials persist because the last step pushes the refresh branch.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7  # zizmor: ignore[artipacked]
+        with:
+          # BOT_PAT when present, so the refresh PR actually runs CI.
+          # A pull request opened under GITHUB_TOKEN never triggers the
+          # required contexts, and reads as green while never having
+          # been checked.
+          token: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.13"
 
-      - name: Regenerate the milestone projection
+      - name: Regenerate ROADMAP.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python scripts/gen_roadmap.py
 
       - name: Open a pull request if the roadmap moved
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           if git diff --quiet -- ROADMAP.md; then
@@ -50,11 +62,12 @@ jobs:
           git checkout -B chore/roadmap-refresh
           git commit -q -m "docs(roadmap): refresh the milestone projection" -- ROADMAP.md
           git push -f origin chore/roadmap-refresh
-          if [ -z "$(gh pr list --head chore/roadmap-refresh --state open --json number --jq '.[].number')" ]; then
+          existing="$(gh pr list --head chore/roadmap-refresh --state open --json number --jq '.[].number')"
+          if [ -z "$existing" ]; then
             gh pr create \
               --head chore/roadmap-refresh \
               --title "docs(roadmap): refresh the milestone projection" \
               --body "Regenerated from the open milestones by \`scripts/gen_roadmap.py\`. Edit the milestone, not the generated block."
           else
-            echo "existing pull request updated by the push"
+            echo "pull request #$existing updated by the push"
           fi

--- a/.github/workflows/roadmap-refresh.yml
+++ b/.github/workflows/roadmap-refresh.yml
@@ -1,0 +1,60 @@
+name: Roadmap refresh
+
+# ROADMAP.md is a projection of the open milestones. This regenerates it
+# and opens a pull request when the projection actually changed.
+#
+# It opens a pull request rather than pushing to main on purpose: main
+# is frozen between a release PR merging and the tag landing, and an
+# unattended weekly push is exactly the kind of thing that would land in
+# that window unnoticed. A pull request is safe to leave sitting.
+
+on:
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: roadmap-refresh
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Regenerate the milestone projection
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python scripts/gen_roadmap.py
+
+      - name: Open a pull request if the roadmap moved
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- ROADMAP.md; then
+            echo "roadmap unchanged; nothing to open"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B chore/roadmap-refresh
+          git commit -q -m "docs(roadmap): refresh the milestone projection" -- ROADMAP.md
+          git push -f origin chore/roadmap-refresh
+          if [ -z "$(gh pr list --head chore/roadmap-refresh --state open --json number --jq '.[].number')" ]; then
+            gh pr create \
+              --head chore/roadmap-refresh \
+              --title "docs(roadmap): refresh the milestone projection" \
+              --body "Regenerated from the open milestones by \`scripts/gen_roadmap.py\`. Edit the milestone, not the generated block."
+          else
+            echo "existing pull request updated by the push"
+          fi

--- a/.github/workflows/roadmap-refresh.yml
+++ b/.github/workflows/roadmap-refresh.yml
@@ -30,14 +30,23 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      # A pull request opened under GITHUB_TOKEN never triggers the required
+      # contexts, so it can never be merged - it would sit open forever
+      # looking green. Failing here makes the missing secret visible once
+      # instead of producing an unmergeable pull request every week.
+      - name: Require BOT_PAT
+        env:
+          BOT_PAT: ${{ secrets.BOT_PAT }}
+        run: |
+          if [ -z "${BOT_PAT}" ]; then
+            echo "::error::BOT_PAT is not configured; a refresh PR opened under GITHUB_TOKEN would never run the required checks"
+            exit 1
+          fi
+
       # Credentials persist because the last step pushes the refresh branch.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7  # zizmor: ignore[artipacked]
         with:
-          # BOT_PAT when present, so the refresh PR actually runs CI.
-          # A pull request opened under GITHUB_TOKEN never triggers the
-          # required contexts, and reads as green while never having
-          # been checked.
-          token: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_PAT }}
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
@@ -50,7 +59,7 @@ jobs:
 
       - name: Open a pull request if the roadmap moved
         env:
-          GH_TOKEN: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.BOT_PAT }}
         run: |
           set -euo pipefail
           if git diff --quiet -- ROADMAP.md; then
@@ -61,7 +70,10 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -B chore/roadmap-refresh
           git commit -q -m "docs(roadmap): refresh the milestone projection" -- ROADMAP.md
-          git push -f origin chore/roadmap-refresh
+          # --force-with-lease, not -f: if someone else moved the refresh
+          # branch, stop rather than overwrite their work.
+          git fetch -q origin chore/roadmap-refresh || true
+          git push --force-with-lease origin chore/roadmap-refresh
           existing="$(gh pr list --head chore/roadmap-refresh --state open --json number --jq '.[].number')"
           if [ -z "$existing" ]; then
             gh pr create \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,42 @@ git clone https://github.com/sipyourdrink-ltd/bernstein && cd bernstein
 uv venv && uv pip install -e ".[dev]"
 ```
 
+## Picking something to work on
+
+[ROADMAP.md](ROADMAP.md) says what is being built and when. Three
+labelled queues say where to start:
+
+- [good first issue](https://github.com/sipyourdrink-ltd/bernstein/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
+  — self-contained, acceptance criteria written out, no prior context needed.
+- [help wanted](https://github.com/sipyourdrink-ltd/bernstein/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)
+  — larger, still scoped.
+- [adapter](https://github.com/sipyourdrink-ltd/bernstein/issues?q=is%3Aopen+is%3Aissue+label%3Aadapter)
+  — support for another coding CLI: one module, one conformance test,
+  one doc entry.
+
+Every issue in those queues states what "done" looks like before you
+start. If one does not, that is a defect in the issue — say so on it.
+
+Comment to claim an issue. If it is assigned but has been quiet for a
+couple of weeks, ask anyway; stalled is not the same as taken.
+
+Before proposing something large, read [Scope](docs/scope.md). It lists
+the boundaries that are already decided and the reason for each, with
+the [decision records](docs/decisions/index.md) behind them. Arguing
+with a stated reason is a good way to start a discussion. Spending a
+week working against one is not.
+
+### Areas
+
+Land three changes in one area and the area is yours if you want it:
+you are named in [CODEOWNERS](.github/CODEOWNERS) for it, and changes
+there come to you for review. Areas are adapters, the web dashboard,
+the terminal UI, docs, and packaging.
+
+This is not ceremonial. An area with a name against it gets a second
+reader who knows it; an area with nobody against it accumulates
+whatever the last person in a hurry did.
+
 ## Testing
 
 ```bash

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,72 @@
+# Roadmap
+
+What is being built, in what order, and what each milestone commits to.
+
+The section below is projected from the open GitHub milestones. The
+milestone is where the work actually lives; this file is a view of it
+rather than a second copy that can quietly disagree. Issue counts stay
+live on the milestone pages linked here, deliberately — a roadmap that
+changes every time an issue closes is a roadmap nobody reads twice.
+
+<!-- roadmap:generated:start -->
+
+### [v3.15.0](https://github.com/sipyourdrink-ltd/bernstein/milestone/19) — due 24 August 2026
+
+First-run experience and adapter coverage: the defects a new user hits in the first hour, plus the adapter additions already in review.
+
+### [v3.16.0](https://github.com/sipyourdrink-ltd/bernstein/milestone/20) — due 21 September 2026
+
+Verifiability and reliability deepening: receipt coverage, lineage surfaces, scheduler correctness. No breaking changes.
+
+### [v4.0.0](https://github.com/sipyourdrink-ltd/bernstein/milestone/10) — scoped by content, no date
+
+Architectural and breaking work: zero-code adapter onboarding, CLI surface consolidation, web UI maturation. Scoped by content, not by date.
+
+<!-- roadmap:generated:end -->
+
+## What a milestone means here
+
+A milestone **with a date** commits to the date, not to the contents.
+It ships on the date with whatever met the bar; anything that did not
+moves to the next one. That way a slip is visible as a moved issue
+rather than as a quiet delay.
+
+A milestone **without a date** is scoped by content instead. It ships
+when the content is done. Putting a date on it would invent a
+commitment nobody made, which is worse than admitting the work is not
+schedulable yet.
+
+## Where to plug in
+
+- [Good first issues](https://github.com/sipyourdrink-ltd/bernstein/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
+  — self-contained, with acceptance criteria written out, no prior
+  context required.
+- [Help wanted](https://github.com/sipyourdrink-ltd/bernstein/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)
+  — larger, still scoped.
+- [Adapters](https://github.com/sipyourdrink-ltd/bernstein/issues?q=is%3Aopen+is%3Aissue+label%3Aadapter)
+  — support for another coding CLI. The most self-contained kind of
+  change in the repo: one module, one conformance test, one doc entry.
+
+Every issue in those queries states what "done" looks like before you
+start. If one does not, that is a defect in the issue — say so on it.
+
+Comment on an issue to claim it. If it is already assigned and quiet
+for a couple of weeks, ask anyway; stalled is not the same as taken.
+
+## What is not planned
+
+[Scope](docs/scope.md) lists the boundaries that are already decided
+and why. It is the page to read before proposing something large, and
+the page to argue with if you disagree — the reasons are stated so they
+can be attacked. The decisions behind them are in
+[decision records](docs/decisions/index.md).
+
+## How this file stays true
+
+`scripts/gen_roadmap.py` regenerates the block between the markers from
+the milestones API. A scheduled job runs it and opens a pull request
+when the projection changed. The render is deterministic and carries no
+timestamp, so an unchanged roadmap produces no pull request at all.
+
+Editing the generated block by hand is pointless — the next refresh
+overwrites it. Edit the milestone.

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -1,0 +1,43 @@
+# Decision records
+
+Each file here records one decision that shaped the system: what the
+problem was, what was chosen, and what was given up for it. A record is
+written when the decision is made and then left alone. One that gets
+edited to match today's code stops being evidence of anything.
+
+Read one when you want to know *why* something is the way it is. The
+answer is often "the obvious alternative was tried and it lost", and
+that is the part a record preserves and a commit message does not.
+
+| ADR | Decision | Status | Date |
+|---|---|---|---|
+| [001](001-agent-lifecycle.md) | Agent lifecycle model: agents that exhaust their queue exit rather than idle | Accepted | 2026-03-22 |
+| [003](003-self-evolution.md) | Self-evolution feedback loop architecture | Approved | 2026-03-22 |
+| [004](004-file-based-state.md) | Persistent state is plain text under `.sdd/` — no embedded database | Accepted | 2026-03-22 |
+| [005](005-short-lived-agents.md) | Agents spawn with 1–3 tasks, execute, and exit | Accepted | 2026-03-22 |
+| [006](006-no-embedded-llm.md) | Scheduling and lifecycle are deterministic Python; zero tokens on coordination | Accepted | 2026-03-22 |
+| [007](007-pluggy-plugin-system.md) | Pluggy is the plugin surface, so extending does not mean forking | Accepted | 2026-03-22 |
+| [008](008-click-for-cli.md) | Click for the CLI | Accepted | 2026-03-22 |
+| [009](009-lineage-v1.md) | Lineage v1: per-artefact transparency log | Accepted | 2026-05-13 |
+| [010](010-audit-chain-default-cost.md) | What turning the HMAC audit chain on by default costs, and the path to it | Accepted | 2026-07-24 |
+
+## When to write one
+
+Write a record when a decision closes off an alternative someone will
+reasonably propose again later. That is the test — not how large the
+change is. A small decision that will be re-litigated every quarter is
+worth a record; a large one nobody will question is not.
+
+Skip it when the choice is reversible at no cost, or when the code
+already states the reason plainly enough to survive the next reader.
+
+## Format
+
+Follow the existing files: number in sequence, `Status`, `Date`,
+`Context`, then the problem, the decision, and what it costs. State the
+alternatives that lost and why — a record with no rejected alternative
+is a description, not a decision.
+
+The boundaries these records set are collected in
+[Scope](../scope.md), which is the page to link when a proposal runs
+into one of them.

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -62,6 +62,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/review-bot-ack-publish.yml | Review-bot acknowledgement publisher | workflow_run | {"cancel-in-progress": "false", "group": "review-bot-ack-publish-${{ github.event.workflow_run.head_sha }}-${{ github.event.workflow_run.id }}"} | 2 |
 | .github/workflows/review-bot-ack.yml | Review-bot acknowledgement gate | merge_group, pull_request, pull_request_review | {"cancel-in-progress": "true", "group": "review-bot-ack-${{ github.event.pull_request.number \|\| github.ref }}"} | 2 |
 | .github/workflows/review-bot-sweep.yml | Review-bot post-merge sweep | schedule, workflow_dispatch | - | 1 |
+| .github/workflows/roadmap-refresh.yml | Roadmap refresh | schedule, workflow_dispatch | {"cancel-in-progress": "false", "group": "roadmap-refresh"} | 1 |
 | .github/workflows/sbom.yml | SBOM | release, workflow_dispatch | {"cancel-in-progress": "false", "group": "sbom-${{ github.ref }}"} | 1 |
 | .github/workflows/scorecard.yml | OSSF Scorecard | branch_protection_rule, schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "scorecard-${{ github.ref }}"} | 2 |
 | .github/workflows/soc2-evidence-nightly.yml | soc2-evidence-nightly | schedule, workflow_dispatch | {"cancel-in-progress": "false", "group": "soc2-evidence-${{ github.ref }}"} | 2 |
@@ -129,6 +130,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/review-bot-ack-publish.yml | publish: review-bot-ack-publisher<br>republish: review-bot-ack-republisher |
 | .github/workflows/review-bot-ack.yml | merge-group-verify: review-bot-ack-queue-verify<br>pr-gate: review-bot-ack-runner |
 | .github/workflows/review-bot-sweep.yml | sweep: Sweep recently merged PRs for unprocessed bot findings |
+| .github/workflows/roadmap-refresh.yml | refresh: Regenerate the milestone projection |
 | .github/workflows/sbom.yml | sbom: Generate SBOM |
 | .github/workflows/scorecard.yml | analysis: Scorecard analysis<br>upload: Filter suppressions and upload to Code Scanning |
 | .github/workflows/soc2-evidence-nightly.yml | pack: generate evidence pack<br>preflight: preflight (gate) |
@@ -196,6 +198,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/review-bot-ack-publish.yml | publish: {"actions": "read", "checks": "write", "contents": "read"}<br>republish: {"actions": "write", "checks": "read", "contents": "read"} | - |
 | .github/workflows/review-bot-ack.yml | merge-group-verify: {"checks": "write", "contents": "read", "pull-requests": "read"}<br>pr-gate: {"checks": "write", "contents": "read", "issues": "write", "pull-requests": "write"} | - |
 | .github/workflows/review-bot-sweep.yml | sweep: {"contents": "write", "pull-requests": "write"} | GITHUB_TOKEN, LANDING_REPO_PAT |
+| .github/workflows/roadmap-refresh.yml | workflow: {"contents": "read"}<br>refresh: {"contents": "write", "pull-requests": "write"} | BOT_PAT, GITHUB_TOKEN |
 | .github/workflows/sbom.yml | workflow: {"contents": "read"}<br>sbom: {"contents": "write"} | - |
 | .github/workflows/scorecard.yml | workflow: {"contents": "read"}<br>analysis: {"actions": "read", "contents": "read", "id-token": "write", "security-events": "write"}<br>upload: {"contents": "read", "security-events": "write"} | - |
 | .github/workflows/soc2-evidence-nightly.yml | workflow: {"contents": "read"} | SOC2_EVIDENCE_ENABLED |

--- a/docs/scope.md
+++ b/docs/scope.md
@@ -1,0 +1,96 @@
+# Scope: what this project does not do
+
+A project that never says no accumulates surface until nothing in it is
+reliable. This page collects the boundaries that are already decided,
+each pointing at the record that decided it, so a proposal can get an
+answer in one link instead of a paragraph — and so anyone can tell,
+before writing code, whether an idea has a home here.
+
+These are current positions with stated reasons, not permanent law. A
+proposal that addresses the reason is worth reading. A proposal that
+only asserts the feature would be useful is not, because usefulness was
+never the disagreement.
+
+## No model in the coordination loop
+
+Scheduling, task assignment, lifecycle management and retry logic are
+deterministic Python. Zero tokens are spent on coordination.
+
+That is what makes a run replayable: the same inputs produce the same
+task graph, so a divergence between two runs is a bug you can chase
+rather than a sampling artefact you can only shrug at. Anything that
+would put a model between "a task finished" and "what runs next" is out
+of scope, however good the model.
+
+Record: [ADR-006](decisions/006-no-embedded-llm.md).
+
+## No database for run state
+
+All persistent orchestrator state is plain text under `.sdd/` — YAML,
+Markdown, JSONL, JSON. No embedded database, no hidden in-memory state.
+
+A feature that requires run state to move behind a schema is out of
+scope. State you cannot open in an editor is state you cannot read
+during the incident it matters for.
+
+Record: [ADR-004](decisions/004-file-based-state.md).
+
+## No long-lived agents
+
+Agents spawn with a small batch of tasks, execute them, and exit. The
+orchestrator spawns new ones as work appears.
+
+Resident worker pools, persistent agent identities and agent-to-agent
+negotiation are out of scope. The failure they reintroduce — a worker
+that looks alive and produces nothing — is the one this design exists
+to remove, and it is not a failure you notice quickly.
+
+Record: [ADR-005](decisions/005-short-lived-agents.md).
+
+## Extending does not mean forking
+
+Extension happens through the pluggy hook surface. If you need a hook
+that does not exist, the hook is the contribution; a fork that has to
+be rebased forever is not an extension mechanism, it is a maintenance
+sentence.
+
+Record: [ADR-007](decisions/007-pluggy-plugin-system.md).
+
+## Adapters wrap tools, they do not reimplement them
+
+An adapter translates between this orchestrator and a coding CLI's
+actual interface. It does not reimplement the tool's behaviour, work
+around its bugs, or vendor its prompts. When a tool changes its flags,
+the adapter changes. When a tool is wrong, that belongs in the tool's
+own tracker.
+
+A new adapter is welcome. An adapter for a tool that cannot be
+exercised in CI is not, because an adapter nothing runs is a claim
+rather than a feature.
+
+See [adapter contracts](contributing/adapter-contracts.md).
+
+## The dashboard talks to the orchestrator and nothing else
+
+The web UI fetches records from the API and event stream it was pointed
+at, and from nowhere else. Fonts are vendored. There are no third-party
+asset hosts, no analytics, no telemetry.
+
+Record: [web UI principles](design/web-ui-principles.md), P7.
+
+## Not a model provider
+
+This drives coding CLIs you have already installed and authenticated.
+It does not proxy inference and does not resell tokens.
+
+## Not an editor
+
+There is a terminal UI and a web dashboard for watching and steering
+runs. Neither is trying to become the place you write code.
+
+---
+
+If a boundary here is the only thing standing between you and something
+you need, open an issue that argues with the reason rather than around
+it. Several of these records exist because that argument was made and
+won.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -150,6 +150,7 @@ nav:
   - Home:
       - index.md
       - Use cases: use-cases.md
+      - Scope (what this does not do): scope.md
       - What's new: whats-new.md
       - Mentions: mentions.md
       - Benchmarks: benchmarks/BENCHMARKS.md
@@ -629,6 +630,7 @@ nav:
           - Multi-cell orchestration: orchestration/multi-cell.md
           - Bulletin board: orchestration/bulletin-board.md
       - Decisions (ADRs):
+          - Index: decisions/index.md
           - Agent lifecycle: decisions/001-agent-lifecycle.md
           - Self-evolution: decisions/003-self-evolution.md
           - File-based state: decisions/004-file-based-state.md

--- a/scripts/gen_roadmap.py
+++ b/scripts/gen_roadmap.py
@@ -71,7 +71,10 @@ def _due_label(milestone: dict[str, Any]) -> str:
     raw = milestone.get("due_on")
     if not raw:
         return "scoped by content, no date"
-    parsed = datetime.strptime(str(raw), "%Y-%m-%dT%H:%M:%SZ")
+    # GitHub returns the Z spelling today. Pattern-matching that exact
+    # spelling would make the scheduled job die with a stack trace instead
+    # of a roadmap the first time an offset form comes back, so parse both.
+    parsed = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
     return f"due {parsed.day} {parsed.strftime('%B %Y')}"
 
 
@@ -92,7 +95,11 @@ def render(milestones: list[dict[str, Any]]) -> str:
     for milestone in sorted(milestones, key=_sort_key):
         title = str(milestone.get("title", "")).strip()
         url = str(milestone.get("html_url", "")).strip()
-        description = str(milestone.get("description") or "").strip()
+        # A milestone description carrying a generated-block marker would
+        # splice a second marker pair into ROADMAP.md, and every refresh
+        # after that would refuse the file. Strip rather than raise: one
+        # careless description should not permanently stop the roadmap.
+        description = str(milestone.get("description") or "").replace(START, "").replace(END, "").strip()
         heading = f"### [{title}]({url}) — {_due_label(milestone)}"
         body = description or "_No description on the milestone yet._"
         parts.append(f"{heading}\n\n{body}")

--- a/scripts/gen_roadmap.py
+++ b/scripts/gen_roadmap.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Project the open GitHub milestones into the generated block of ROADMAP.md.
+
+The milestone is already the single source of truth for what a release
+contains: its description states the theme, the issues under it are the
+work, its due date is the date. Restating any of that by hand in
+ROADMAP.md would give the repo two answers to the same question and no
+way to tell which one went stale, so this projects the milestones into
+the file instead of asking anyone to keep the two in step.
+
+Two deliberate omissions keep the projection quiet:
+
+- No issue counts. They change with every issue opened or closed, and a
+  roadmap that changes daily is a roadmap nobody reads. The counts are
+  live on the milestone page the file links to.
+- No timestamp. Identical milestones render byte-identical output, so
+  the scheduled refresh opens a pull request when the roadmap actually
+  changed rather than once a week forever.
+
+    python scripts/gen_roadmap.py            # rewrite ROADMAP.md in place
+    python scripts/gen_roadmap.py --check    # exit 1 if it is out of date
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.request
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+START = "<!-- roadmap:generated:start -->"
+END = "<!-- roadmap:generated:end -->"
+DEFAULT_REPO = "sipyourdrink-ltd/bernstein"
+
+
+def fetch_milestones(repo: str, token: str | None) -> list[dict[str, Any]]:
+    """Read the open milestones for ``repo`` from the GitHub REST API."""
+    request = urllib.request.Request(
+        f"https://api.github.com/repos/{repo}/milestones?state=open&per_page=100",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "bernstein-roadmap",
+            **({"Authorization": f"Bearer {token}"} if token else {}),
+        },
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        payload: list[dict[str, Any]] = json.load(response)
+    return payload
+
+
+def _due_label(milestone: dict[str, Any]) -> str:
+    """Render the due date, or say plainly that there is not one.
+
+    A milestone without a date is not a scheduling oversight here: the
+    breaking-change milestone is scoped by content and dating it would
+    invent a commitment nobody made.
+    """
+    raw = milestone.get("due_on")
+    if not raw:
+        return "scoped by content, no date"
+    parsed = datetime.strptime(str(raw), "%Y-%m-%dT%H:%M:%SZ")
+    return f"due {parsed.day} {parsed.strftime('%B %Y')}"
+
+
+def _sort_key(milestone: dict[str, Any]) -> tuple[int, str]:
+    """Dated milestones first, in date order; undated ones last, by title."""
+    raw = milestone.get("due_on")
+    if raw:
+        return (0, str(raw))
+    return (1, str(milestone.get("title", "")))
+
+
+def render(milestones: list[dict[str, Any]]) -> str:
+    """Render the generated block body from milestone records."""
+    if not milestones:
+        return "No open milestones."
+
+    parts: list[str] = []
+    for milestone in sorted(milestones, key=_sort_key):
+        title = str(milestone.get("title", "")).strip()
+        url = str(milestone.get("html_url", "")).strip()
+        description = str(milestone.get("description") or "").strip()
+        heading = f"### [{title}]({url}) — {_due_label(milestone)}"
+        body = description or "_No description on the milestone yet._"
+        parts.append(f"{heading}\n\n{body}")
+    return "\n\n".join(parts)
+
+
+def splice(text: str, block: str) -> str:
+    """Replace the content between the generated markers with ``block``."""
+    start = text.find(START)
+    end = text.find(END)
+    if start == -1 or end == -1 or end < start:
+        raise ValueError(f"ROADMAP.md is missing the {START} / {END} markers")
+    return f"{text[: start + len(START)]}\n\n{block}\n\n{text[end:]}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="exit 1 if ROADMAP.md is out of date")
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", DEFAULT_REPO))
+    parser.add_argument("--path", type=Path, default=Path("ROADMAP.md"))
+    args = parser.parse_args(argv)
+
+    current = args.path.read_text(encoding="utf-8")
+    updated = splice(current, render(fetch_milestones(args.repo, os.environ.get("GITHUB_TOKEN"))))
+
+    if updated == current:
+        print("ROADMAP.md is up to date")
+        return 0
+    if args.check:
+        print("ROADMAP.md is out of date; run python scripts/gen_roadmap.py", file=sys.stderr)
+        return 1
+    args.path.write_text(updated, encoding="utf-8")
+    print(f"rewrote {args.path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/gen_roadmap.py
+++ b/scripts/gen_roadmap.py
@@ -74,15 +74,26 @@ def _due_label(milestone: dict[str, Any]) -> str:
     # GitHub returns the Z spelling today. Pattern-matching that exact
     # spelling would make the scheduled job die with a stack trace instead
     # of a roadmap the first time an offset form comes back, so parse both.
-    parsed = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+    parsed = _parse_due(str(raw))
     return f"due {parsed.day} {parsed.strftime('%B %Y')}"
 
 
-def _sort_key(milestone: dict[str, Any]) -> tuple[int, str]:
-    """Dated milestones first, in date order; undated ones last, by title."""
+def _parse_due(raw: str) -> datetime:
+    """Parse either ISO 8601 spelling GitHub may return for ``due_on``."""
+    return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+
+
+def _sort_key(milestone: dict[str, Any]) -> tuple[int, datetime | str]:
+    """Dated milestones first, in date order; undated ones last, by title.
+
+    Ordering on the parsed instant rather than the raw string: the two
+    ISO spellings sort differently as text, so a mixed set would come out
+    in the wrong chronology while every individual date still rendered
+    correctly - the kind of wrong that looks right.
+    """
     raw = milestone.get("due_on")
     if raw:
-        return (0, str(raw))
+        return (0, _parse_due(str(raw)))
     return (1, str(milestone.get("title", "")))
 
 

--- a/scripts/gen_roadmap.py
+++ b/scripts/gen_roadmap.py
@@ -35,12 +35,13 @@ from typing import Any
 START = "<!-- roadmap:generated:start -->"
 END = "<!-- roadmap:generated:end -->"
 DEFAULT_REPO = "sipyourdrink-ltd/bernstein"
+_PAGE_SIZE = 100
 
 
 def fetch_milestones(repo: str, token: str | None) -> list[dict[str, Any]]:
     """Read the open milestones for ``repo`` from the GitHub REST API."""
     request = urllib.request.Request(
-        f"https://api.github.com/repos/{repo}/milestones?state=open&per_page=100",
+        f"https://api.github.com/repos/{repo}/milestones?state=open&per_page={_PAGE_SIZE}",
         headers={
             "Accept": "application/vnd.github+json",
             "User-Agent": "bernstein-roadmap",
@@ -49,6 +50,14 @@ def fetch_milestones(repo: str, token: str | None) -> list[dict[str, Any]]:
     )
     with urllib.request.urlopen(request, timeout=30) as response:
         payload: list[dict[str, Any]] = json.load(response)
+    if len(payload) >= _PAGE_SIZE:
+        # Refusing beats paginating here. A truncated page would silently
+        # drop milestones from the roadmap, and a repo with 100 open
+        # milestones has a planning problem this script cannot fix.
+        raise ValueError(
+            f"{repo} has at least {_PAGE_SIZE} open milestones; this script reads one page "
+            "and would silently drop the rest"
+        )
     return payload
 
 
@@ -92,10 +101,15 @@ def render(milestones: list[dict[str, Any]]) -> str:
 
 def splice(text: str, block: str) -> str:
     """Replace the content between the generated markers with ``block``."""
+    if text.count(START) != 1 or text.count(END) != 1:
+        # Two marker pairs would splice between mismatched ones and delete
+        # whatever sits in between, which is exactly the failure a
+        # generated block is supposed to make impossible.
+        raise ValueError(f"ROADMAP.md must carry exactly one {START} / {END} marker pair")
     start = text.find(START)
     end = text.find(END)
-    if start == -1 or end == -1 or end < start:
-        raise ValueError(f"ROADMAP.md is missing the {START} / {END} markers")
+    if end < start:
+        raise ValueError(f"ROADMAP.md has the {START} / {END} markers in the wrong order")
     return f"{text[: start + len(START)]}\n\n{block}\n\n{text[end:]}"
 
 

--- a/tests/unit/scripts/test_gen_roadmap.py
+++ b/tests/unit/scripts/test_gen_roadmap.py
@@ -122,3 +122,29 @@ class TestTruncationGuard:
         monkeypatch.setattr(gen_roadmap.urllib.request, "urlopen", lambda *a, **k: _Response())
         with pytest.raises(ValueError, match="at least"):
             gen_roadmap.fetch_milestones("o/r", None)
+
+
+class TestHostileMilestoneData:
+    """Milestone fields are operator-editable text and reach the file verbatim."""
+
+    def test_offset_timestamp_parses_like_the_z_form(self) -> None:
+        z = gen_roadmap.render([_milestone("v1", "2026-08-24T00:00:00Z")])
+        offset = gen_roadmap.render([_milestone("v1", "2026-08-24T00:00:00+00:00")])
+        assert z == offset
+        assert "due 24 August 2026" in offset
+
+    def test_marker_in_a_description_is_stripped(self) -> None:
+        """Otherwise the next refresh sees two pairs and refuses the file forever."""
+        out = gen_roadmap.render(
+            [_milestone("v1", None, description=f"theme {gen_roadmap.START} and {gen_roadmap.END}")]
+        )
+        assert gen_roadmap.START not in out
+        assert gen_roadmap.END not in out
+        assert "theme" in out
+
+    def test_a_stripped_description_still_splices_once(self) -> None:
+        doc = f"a\n\n{gen_roadmap.START}\n\nold\n\n{gen_roadmap.END}\n\nb\n"
+        block = gen_roadmap.render([_milestone("v1", None, description=gen_roadmap.START)])
+        spliced = gen_roadmap.splice(doc, block)
+        assert spliced.count(gen_roadmap.START) == 1
+        assert spliced.count(gen_roadmap.END) == 1

--- a/tests/unit/scripts/test_gen_roadmap.py
+++ b/tests/unit/scripts/test_gen_roadmap.py
@@ -148,3 +148,13 @@ class TestHostileMilestoneData:
         spliced = gen_roadmap.splice(doc, block)
         assert spliced.count(gen_roadmap.START) == 1
         assert spliced.count(gen_roadmap.END) == 1
+
+    def test_mixed_spellings_sort_chronologically(self) -> None:
+        """Text order and time order disagree across the two ISO spellings."""
+        out = gen_roadmap.render(
+            [
+                _milestone("later", "2026-09-21T00:00:00+00:00"),
+                _milestone("earlier", "2026-08-24T00:00:00Z"),
+            ]
+        )
+        assert out.index("earlier") < out.index("later")

--- a/tests/unit/scripts/test_gen_roadmap.py
+++ b/tests/unit/scripts/test_gen_roadmap.py
@@ -85,10 +85,40 @@ class TestSplice:
         assert gen_roadmap.splice(once, "new") == once
 
     def test_missing_markers_raise_rather_than_write_nothing(self) -> None:
-        with pytest.raises(ValueError, match="markers"):
+        with pytest.raises(ValueError, match="marker"):
             gen_roadmap.splice("no markers here\n", "new")
 
     def test_reversed_markers_raise(self) -> None:
         broken = f"{gen_roadmap.END}\n{gen_roadmap.START}\n"
-        with pytest.raises(ValueError, match="markers"):
+        with pytest.raises(ValueError, match="marker"):
             gen_roadmap.splice(broken, "new")
+
+    def test_duplicate_marker_pair_is_refused(self) -> None:
+        """Two pairs would splice between mismatched markers and eat the middle."""
+        doubled = self._DOC + self._DOC
+        with pytest.raises(ValueError, match="exactly one"):
+            gen_roadmap.splice(doubled, "new")
+
+
+class TestTruncationGuard:
+    """A full page means milestones were dropped, and a dropped milestone
+    disappears from the roadmap without anything going red."""
+
+    def test_full_page_is_refused(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        page = [_milestone(f"v{i}", None) for i in range(gen_roadmap._PAGE_SIZE)]
+
+        class _Response:
+            def read(self) -> bytes:
+                import json
+
+                return json.dumps(page).encode()
+
+            def __enter__(self) -> _Response:
+                return self
+
+            def __exit__(self, *args: object) -> None:
+                return None
+
+        monkeypatch.setattr(gen_roadmap.urllib.request, "urlopen", lambda *a, **k: _Response())
+        with pytest.raises(ValueError, match="at least"):
+            gen_roadmap.fetch_milestones("o/r", None)

--- a/tests/unit/scripts/test_gen_roadmap.py
+++ b/tests/unit/scripts/test_gen_roadmap.py
@@ -1,0 +1,94 @@
+"""Tests for ``scripts/gen_roadmap.py``.
+
+The generator runs unattended on a schedule, so the properties worth
+holding are the ones nobody will be watching for: that the render is
+deterministic (otherwise the refresh opens a pull request every week
+whether or not the roadmap moved), that undated milestones sort last
+rather than crashing the date parse, and that splicing refuses a file
+whose markers went missing instead of silently writing nothing.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "gen_roadmap.py"
+_spec = importlib.util.spec_from_file_location("gen_roadmap", _SCRIPT)
+assert _spec and _spec.loader
+gen_roadmap = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gen_roadmap)
+
+
+def _milestone(title: str, due: str | None, description: str = "Theme.") -> dict[str, Any]:
+    return {
+        "title": title,
+        "due_on": due,
+        "description": description,
+        "html_url": f"https://github.com/o/r/milestone/{title}",
+    }
+
+
+class TestRender:
+    def test_dated_milestones_come_first_in_date_order(self) -> None:
+        out = gen_roadmap.render(
+            [
+                _milestone("v4.0.0", None),
+                _milestone("v3.16.0", "2026-09-21T00:00:00Z"),
+                _milestone("v3.15.0", "2026-08-24T00:00:00Z"),
+            ]
+        )
+        assert out.index("v3.15.0") < out.index("v3.16.0") < out.index("v4.0.0")
+
+    def test_undated_milestone_says_so_instead_of_guessing(self) -> None:
+        out = gen_roadmap.render([_milestone("v4.0.0", None)])
+        assert "scoped by content, no date" in out
+
+    def test_due_date_is_rendered_in_full(self) -> None:
+        out = gen_roadmap.render([_milestone("v3.15.0", "2026-08-24T00:00:00Z")])
+        assert "due 24 August 2026" in out
+
+    def test_render_is_deterministic(self) -> None:
+        """Identical input renders identically, so an unchanged roadmap stays unchanged."""
+        milestones = [_milestone("v3.15.0", "2026-08-24T00:00:00Z"), _milestone("v4.0.0", None)]
+        assert gen_roadmap.render(milestones) == gen_roadmap.render(list(reversed(milestones)))
+
+    def test_render_carries_no_timestamp(self) -> None:
+        """A stamped render would differ on every run and defeat the change check."""
+        out = gen_roadmap.render([_milestone("v3.15.0", "2026-08-24T00:00:00Z")])
+        assert "generated on" not in out.lower()
+        assert "2026-08-10" not in out
+
+    def test_missing_description_is_marked_not_blank(self) -> None:
+        out = gen_roadmap.render([_milestone("v9.9.9", None, description="")])
+        assert "_No description on the milestone yet._" in out
+
+    def test_no_open_milestones_renders_a_sentence(self) -> None:
+        assert gen_roadmap.render([]) == "No open milestones."
+
+
+class TestSplice:
+    _DOC = f"intro\n\n{gen_roadmap.START}\n\nold\n\n{gen_roadmap.END}\n\noutro\n"
+
+    def test_replaces_only_between_the_markers(self) -> None:
+        out = gen_roadmap.splice(self._DOC, "new")
+        assert "old" not in out
+        assert out.startswith("intro")
+        assert out.endswith("outro\n")
+        assert "new" in out
+
+    def test_splice_is_idempotent(self) -> None:
+        once = gen_roadmap.splice(self._DOC, "new")
+        assert gen_roadmap.splice(once, "new") == once
+
+    def test_missing_markers_raise_rather_than_write_nothing(self) -> None:
+        with pytest.raises(ValueError, match="markers"):
+            gen_roadmap.splice("no markers here\n", "new")
+
+    def test_reversed_markers_raise(self) -> None:
+        broken = f"{gen_roadmap.END}\n{gen_roadmap.START}\n"
+        with pytest.raises(ValueError, match="markers"):
+            gen_roadmap.splice(broken, "new")

--- a/tests/unit/test_bot_pull_request_tokens_yaml.py
+++ b/tests/unit/test_bot_pull_request_tokens_yaml.py
@@ -523,6 +523,7 @@ def test_discovery_matches_exactly_the_known_pull_request_lanes() -> None:
         "docs-observability-snapshot.yml",
         "nightly-drift-sweep.yml",
         "review-bot-sweep.yml",
+        "roadmap-refresh.yml",
     }
 
 

--- a/tests/unit/test_tui_task_search.py
+++ b/tests/unit/test_tui_task_search.py
@@ -69,6 +69,7 @@ class TestTaskSearchInputPlaceholder:
         """
         widget = TaskSearchInput(placeholder="custom text")
         assert widget.placeholder == "custom text"
+
     def test_positional_placeholder_does_not_raise(self) -> None:
         widget = TaskSearchInput(None, "custom text")
         assert widget.placeholder == "custom text"


### PR DESCRIPTION
# User description
Three documents a reader cannot currently find, plus the machinery to
keep one of them honest.

ROADMAP.md did not exist, but the plan did: three milestones, each with
a written theme and a date. Nobody goes to the milestones page, so the
plan was invisible to anyone not already looking for it. The file
projects the open milestones instead of restating them - two copies of
one plan is one copy and one liability. scripts/gen_roadmap.py renders
the block between the markers; a weekly job regenerates it and opens a
pull request when the projection moved.

The render carries no issue counts and no timestamp, both deliberately.
Counts change with every issue closed, and a roadmap that changes daily
is one nobody reads twice; a timestamp would make every scheduled run
produce a diff whether or not anything actually changed.

docs/scope.md collects the boundaries that are already decided - no
model in the coordination loop, no database for run state, no long-lived
agents, adapters that wrap rather than reimplement - each pointing at
the record that decided it. A proposal that runs into one can now be
answered with a link instead of a paragraph, and anyone can tell before
writing code whether an idea has a home here.

docs/decisions/index.md fronts the nine records that were already
present. They were in the site nav but had no index and no statement of
when a decision is worth recording, so they read as nine files rather
than as a practice.

CONTRIBUTING gains a section on where to start and how an area is
earned: three merged changes in one area and you are named in CODEOWNERS
for it, with changes there coming to you for review.

The refresh opens a pull request rather than pushing to main. Main is
frozen between a release PR merging and the tag landing, and an
unattended weekly push is exactly the thing that would land in that
window unnoticed.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Introduce reader-facing project guidance through a generated milestone roadmap, explicit scope boundaries, an indexed ADR practice, and expanded contributor ownership instructions. Implement deterministic roadmap projection and scheduled pull-request automation with validation tests, protected credentials, CI topology documentation, and related workflow discovery coverage.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3593?tool=ast&topic=Refresh+automation>Refresh automation</a>
        </td><td>Schedule protected weekly or manually triggered roadmap refreshes that open reviewable pull requests instead of modifying the default branch, document the workflow’s permissions and concurrency, and include it in pull-request token discovery coverage.<details><summary>Modified files (4)</summary><ul><li>.github/workflows/roadmap-refresh.yml</li>
<li>docs/operations/ci-topology.md</li>
<li>tests/unit/test_bot_pull_request_tokens_yaml.py</li>
<li>tests/unit/test_tui_task_search.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>test(ci): register the...</td><td>August 10, 2026</td></tr>
<tr><td>chernistry</td><td>fix(rpm): ship the rel...</td><td>August 10, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3593?tool=ast&topic=Roadmap+generator>Roadmap generator</a>
        </td><td>Generate the roadmap from open GitHub milestones using deterministic ordering, date handling, marker-safe splicing, truncation protection, and stale-content checks; verify rendering and hostile-input behavior with focused unit tests.<details><summary>Modified files (2)</summary><ul><li>scripts/gen_roadmap.py</li>
<li>tests/unit/scripts/test_gen_roadmap.py</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>fix(roadmap): order mi...</td><td>August 10, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3593?tool=ast&topic=Project+guidance>Project guidance</a>
        </td><td>Document the project roadmap, architectural boundaries, decision-record conventions, contributor entry points, and area ownership model, then expose the new guidance through the documentation navigation.<details><summary>Modified files (5)</summary><ul><li>CONTRIBUTING.md</li>
<li>ROADMAP.md</li>
<li>docs/decisions/index.md</li>
<li>docs/scope.md</li>
<li>mkdocs.yml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>docs: roadmap projecti...</td><td>August 10, 2026</td></tr>
<tr><td>chernistry</td><td>docs: add a naming pol...</td><td>August 03, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3593?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>