### PR TITLE
fix(cli): restore issue-to-pr trace command

### DIFF
--- a/docs/orchestration/issue-to-pr.md
+++ b/docs/orchestration/issue-to-pr.md
@@ -84,8 +84,6 @@ last_revise_at: 2026-05-19T12:00:00Z
 
 The command is read-only; it never advances state.
 
-> **Note:** The `issue-to-pr` CLI command group was removed in v4.0.0. The pipeline is driven directly from Python using `bernstein.core.orchestration.issue_to_pr`.
-
 ## State markers
 
 The pipeline stores its progress as HTML comments inside the sticky

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -1122,6 +1122,7 @@ receipt that no longer recomputes fails exactly like a tampered chain entry.
 | `bernstein cache` | Prompt-cache mgmt (group). | `cli/commands/cache_cmd.py:45` |
 | `bernstein notify` | Outbound notification drivers (group). | `cli/commands/notify_cmd.py:63` |
 | `bernstein triggers` | Trigger sources (group). | `cli/commands/triggers_cmd.py:17` |
+| `bernstein issue-to-pr trace --repo OWNER/NAME N` | Print the read-only issue-to-PR pipeline state snapshot. | `cli/commands/issue_to_pr_cmd.py:trace_cmd` |
 
 #### `bernstein doctor`
 

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -77,6 +77,14 @@ landed since the newest one.
 
 ## Fixed
 
+- `bernstein issue-to-pr trace --repo OWNER/NAME N` is registered again. The
+  orchestration guide continued to advertise this read-only pipeline snapshot
+  after the v4 command cleanup, while the formatter that names the command
+  remained in the core API, so following the guide failed with `No such
+  command`. A fixture-backed CLI regression now runs the documented command
+  through the top-level group and pins its rendered summary. Docs:
+  `docs/orchestration/issue-to-pr.md`, `docs/reference/cli-reference.md`. Refs
+  #3595.
 - Adapter admission can produce an `ADMIT` verdict on a pip install (#3547).
   The verdict is a projection of the pinned contract's bytes and the
   golden-transcript replay, but both trees live under `tests/` and were

--- a/src/bernstein/cli/commands/issue_to_pr_cmd.py
+++ b/src/bernstein/cli/commands/issue_to_pr_cmd.py
@@ -1,0 +1,47 @@
+"""``bernstein issue-to-pr`` -- inspect the issue-to-PR pipeline state.
+
+The CLI is intentionally thin: real logic lives in
+:mod:`bernstein.core.orchestration.issue_to_pr`. Only the read-only ``trace``
+subcommand is exposed; advancing the pipeline remains a Python API concern.
+"""
+
+from __future__ import annotations
+
+import click
+
+from bernstein.cli.helpers import console
+from bernstein.core.orchestration.issue_to_pr import (
+    IssuePRClient,
+    IssueToPRConfig,
+    IssueToPRPipeline,
+)
+
+
+@click.group("issue-to-pr")
+def issue_to_pr_group() -> None:
+    """Inspect the issue -> plan-comment -> PR pipeline."""
+
+
+@issue_to_pr_group.command("trace")
+@click.argument("issue_id")
+@click.option(
+    "--repo",
+    required=True,
+    help="GitHub owner/repo slug, e.g. acme/web.",
+)
+def trace_cmd(issue_id: str, repo: str) -> None:
+    """Print the pipeline state for ``<owner>/<repo>#<issue_id>``.
+
+    Reads sticky-comment markers and prints one fact per line. This command is
+    read-only and exits 0 after rendering a snapshot.
+    """
+    try:
+        issue_number = int(issue_id.lstrip("#"))
+    except ValueError as exc:
+        raise click.BadParameter(f"issue_id must be numeric, got {issue_id!r}") from exc
+
+    trace = IssueToPRPipeline(
+        config=IssueToPRConfig(),
+        client=IssuePRClient(),
+    ).trace(repo, issue_number)
+    console.print(trace.render())

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -76,6 +76,7 @@ from bernstein.cli.commands.impact_cmd import (
     impact_group,
 )
 from bernstein.cli.commands.integrations_cmd import integrations_group
+from bernstein.cli.commands.issue_to_pr_cmd import issue_to_pr_group
 from bernstein.cli.commands.knowledge_cmd import knowledge_group
 from bernstein.cli.commands.pool_cmd import pool_group
 from bernstein.cli.commands.resume_cmd import resume_cmd
@@ -1066,6 +1067,7 @@ cli.add_command(connect_cmd, "connect")
 cli.add_command(creds_group, "creds")
 cli.add_command(criterion_profile_group, "criterion-profile")
 cli.add_command(review_responder_group, "review-responder")
+cli.add_command(issue_to_pr_group, "issue-to-pr")
 
 # Already registered elsewhere
 cli.add_command(agents_group)

--- a/tests/unit/test_issue_to_pr_cmd.py
+++ b/tests/unit/test_issue_to_pr_cmd.py
@@ -1,0 +1,62 @@
+"""CLI regressions for the issue-to-PR trace command (issue #3595)."""
+
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.main import cli
+from bernstein.core.orchestration.issue_to_pr import IssueToPRPipeline, PipelineTrace
+
+DOCUMENTED_COMMAND = "bernstein issue-to-pr trace --repo acme/web 42"
+
+
+def test_documented_trace_command_renders_pipeline_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The command advertised in the orchestration guide must stay executable."""
+    docs = Path(__file__).parents[2] / "docs" / "orchestration" / "issue-to-pr.md"
+    assert DOCUMENTED_COMMAND in docs.read_text(encoding="utf-8")
+
+    snapshot = PipelineTrace(
+        repo="acme/web",
+        issue_number=42,
+        plan_posted=True,
+        approved=True,
+        pr_number=4242,
+        last_revise_at="2026-05-19T12:00:00Z",
+    )
+
+    def fake_trace(_self: IssueToPRPipeline, repo: str, issue_number: int) -> PipelineTrace:
+        assert repo == "acme/web"
+        assert issue_number == 42
+        return snapshot
+
+    monkeypatch.setattr(IssueToPRPipeline, "trace", fake_trace)
+
+    result = CliRunner().invoke(cli, shlex.split(DOCUMENTED_COMMAND)[1:])
+
+    assert result.exit_code == 0, result.output
+    assert result.output == f"{snapshot.render()}\n"
+
+
+def test_trace_rejects_non_numeric_issue_without_reading_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invalid input is a Click usage error and never reaches the GitHub client."""
+
+    def fail_trace(_self: IssueToPRPipeline, _repo: str, _issue_number: int) -> PipelineTrace:
+        pytest.fail("trace must not be called for an invalid issue number")
+
+    monkeypatch.setattr(IssueToPRPipeline, "trace", fail_trace)
+
+    result = CliRunner().invoke(
+        cli,
+        ["issue-to-pr", "trace", "--repo", "acme/web", "not-a-number"],
+    )
+
+    assert result.exit_code == 2
+    assert "issue_id must be numeric" in result.output


### PR DESCRIPTION
## What

Restore the read-only `bernstein issue-to-pr trace --repo OWNER/NAME N` command and keep the orchestration guide, CLI reference, and executable surface in sync.

## Why

The pipeline snapshot and its human-readable formatter still ship, while the documented command returned `No such command` after the v4 cleanup.

Closes #3595.

## How

- add a thin Click group that delegates to `IssueToPRPipeline.trace`
- register it on the real top-level CLI
- drive the exact documented argv against a fixture snapshot and assert the rendered summary
- reject invalid issue numbers before any GitHub state read
- update the command docs and unreleased notes

## Validation

- `ruff check src/ tests/unit/test_issue_to_pr_cmd.py`
- `ruff format --check src/ tests/unit/test_issue_to_pr_cmd.py`
- targeted Pyright and Mypy: 0 issues in the new command/test files
- import-linter: 3/3 contracts kept
- post-rebase related suite: 560 passed, 1 skipped
- live read-only smoke against this repository issue printed the six-field snapshot and exited 0
- `bernstein agents-md verify --target all`: 14 files in sync

The full isolated runner completed all 2,178 files: 2,172 passed, 5 failed, and 1 file was fully skipped. The patch-aware runner selected 159 files: 156 passed, 2 were fully skipped, and the unchanged `test_doctor.py` hit the 300-second file timeout while `doctor` waited in commit-attribution `git log` on this partial clone. Known full-run failures also include unchanged narrow-TTY banner and TUI snapshot-freshness checks. No affected assertion failed.

Full `pyright src/` is not green on current main in this environment (22,477 existing errors); the two changed Python files are clean under both Pyright and Mypy.

## Checklist

- [x] `uv run ruff check src/` passes
- [ ] `uv run pyright src/` passes (current-main baseline above; targeted files pass)
- [ ] `uv run python scripts/run_tests.py -x` passes (current-main/environment baseline above; affected assertions pass)
- [x] New code has type hints

### Documentation duty

- [x] User-visible README section updated (N/A: dedicated orchestration guide updated)
- [x] `docs/operations/<area>.md` updated (N/A: existing orchestration guide updated)
- [x] `docs/api/` schema regenerated (N/A: no API schema change)
- [x] `bernstein agents-md verify --target all` confirms generated context is in sync
- [x] Tests cover the documented behaviour