### PR TITLE
fix(ci): start the labelled PR review when the label is added

### DIFF
--- a/.github/workflows/bernstein-pr-review.yml
+++ b/.github/workflows/bernstein-pr-review.yml
@@ -1,10 +1,13 @@
 name: "Bernstein PR Review"
 
-# Trigger: automatically review every non-draft pull request.
-# Add the label "skip-bernstein" to a PR to opt out.
+# Trigger: non-draft pull requests carrying the "deep-review" label.
+# "labeled" is in the list because the label is often added after the PR is
+# already open and ready; without it the review only ever runs on the next
+# push, and a maintainer adding the label sees nothing happen.
+# Add the label "skip-bernstein" to opt a PR out even when "deep-review" is on.
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review]
+    types: [opened, synchronize, ready_for_review, labeled]
     paths:
       - 'src/**'
       - 'tests/**'

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -77,6 +77,13 @@ landed since the newest one.
 
 ## Fixed
 
+- The `deep-review` label did not start a review on a PR that was already open.
+  `.github/workflows/bernstein-pr-review.yml` gates its `review` job on that
+  label but did not list `labeled` as a trigger type, so adding the label to a
+  ready PR did nothing until the next push -- a switch not wired to anything,
+  and one a contributor cannot work around because label management needs repo
+  write. `labeled` is now a trigger type, and a structural test asserts that a
+  label-gated job keeps a matching trigger.
 - `bernstein issue-to-pr trace --repo OWNER/NAME N` is registered again. The
   orchestration guide continued to advertise this read-only pipeline snapshot
   after the v4 command cleanup, while the formatter that names the command

--- a/tests/unit/eval/test_trajectory_receipt_cli.py
+++ b/tests/unit/eval/test_trajectory_receipt_cli.py
@@ -96,7 +96,9 @@ def _build(workdir: Path, anchors: list[TaskTrajectoryAnchor] | None = None, **k
     """Build a receipt and return its hash."""
     receipt = build_trajectory_receipt(
         run_id=kwargs.pop("run_id", "run-test-001"),
-        task_anchors=anchors if anchors is not None else [
+        task_anchors=anchors
+        if anchors is not None
+        else [
             _anchor("smoke-001", journal_head="sha256:" + "1" * 64),
             _anchor("smoke-002", journal_head="sha256:" + "2" * 64),
         ],
@@ -152,26 +154,20 @@ def _audit_verify_receipts(workdir: Path, monkeypatch: pytest.MonkeyPatch) -> bo
 # ---------------------------------------------------------------------------
 
 
-def test_audit_verify_noop_when_no_receipts_exist(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_audit_verify_noop_when_no_receipts_exist(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """AC7: no trajectory receipts → _verify_trajectory_receipts returns True silently."""
     result = _audit_verify_receipts(tmp_path, monkeypatch)
     assert result is True
 
 
-def test_audit_verify_passes_for_intact_receipt(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_audit_verify_passes_for_intact_receipt(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """AC7: one intact receipt → passes and returns True."""
     _build(tmp_path)
     result = _audit_verify_receipts(tmp_path, monkeypatch)
     assert result is True
 
 
-def test_audit_verify_hard_fails_for_tampered_receipt(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_audit_verify_hard_fails_for_tampered_receipt(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """AC7: a tampered receipt → _verify_trajectory_receipts returns False (hard-fail)."""
     receipt_hash = _build(tmp_path)
 
@@ -185,9 +181,7 @@ def test_audit_verify_hard_fails_for_tampered_receipt(
     assert result is False
 
 
-def test_audit_verify_hard_fails_contaminated_suite(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_audit_verify_hard_fails_contaminated_suite(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """AC7 + AC3: a contaminated golden suite (task_id renamed) hard-fails audit verify."""
     receipt_hash = _build(tmp_path)
     payload = _load_payload(tmp_path, receipt_hash)
@@ -200,14 +194,10 @@ def test_audit_verify_hard_fails_contaminated_suite(
     assert result is False
 
 
-def test_audit_verify_noop_with_multiple_intact_receipts(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_audit_verify_noop_with_multiple_intact_receipts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """AC7: multiple intact receipts all pass; no false failure."""
     _build(tmp_path / "run-a", run_id="run-a")
-    _build(tmp_path / "run-b",
-           anchors=[_anchor("t-X", journal_head="sha256:" + "x" * 64)],
-           run_id="run-b")
+    _build(tmp_path / "run-b", anchors=[_anchor("t-X", journal_head="sha256:" + "x" * 64)], run_id="run-b")
 
     # Both receipts should be under the same workdir for audit verify to find them
     # Build both into the same workdir but different run_ids
@@ -249,9 +239,7 @@ def test_benchmark_receipt_verify_inflated_scalar_fails(tmp_path: Path) -> None:
     payload = _load_payload(tmp_path, receipt_hash)
     payload["published_score"] = 9.99
     # Overwrite without resealing — stale hash caught at step 0/1
-    trajectory_receipt_path(tmp_path, receipt_hash).write_text(
-        _canonical(payload), encoding="utf-8"
-    )
+    trajectory_receipt_path(tmp_path, receipt_hash).write_text(_canonical(payload), encoding="utf-8")
     result = _verify(tmp_path, receipt_hash)
     assert result.ok is False
     assert "tampered" in result.reason.lower() or "hash" in result.reason.lower()
@@ -350,9 +338,7 @@ def test_strip_journal_head_from_anchor_fails_closed(tmp_path: Path) -> None:
     new_hash = _reseal(tmp_path, payload)
 
     result = _verify(tmp_path, new_hash)
-    assert result.ok is False, (
-        "strip-the-substrate must fail closed, not pass as a warning"
-    )
+    assert result.ok is False, "strip-the-substrate must fail closed, not pass as a warning"
     assert result.reason  # must name what failed, not be empty
 
 
@@ -365,9 +351,7 @@ def test_strip_events_hash_from_anchor_fails_closed(tmp_path: Path) -> None:
     new_hash = _reseal(tmp_path, payload)
 
     result = _verify(tmp_path, new_hash)
-    assert result.ok is False, (
-        "absent fixture hash must fail closed, not pass as a warning"
-    )
+    assert result.ok is False, "absent fixture hash must fail closed, not pass as a warning"
 
 
 def test_strip_all_task_anchors_fails_closed(tmp_path: Path) -> None:
@@ -384,9 +368,7 @@ def test_strip_all_task_anchors_fails_closed(tmp_path: Path) -> None:
     new_hash = _reseal(tmp_path, payload)
 
     result = _verify(tmp_path, new_hash)
-    assert result.ok is False, (
-        "stripping all anchors must fail closed (contamination detection)"
-    )
+    assert result.ok is False, "stripping all anchors must fail closed (contamination detection)"
 
 
 def test_strip_substrate_result_is_not_ok_false_is_hard_fail(tmp_path: Path) -> None:
@@ -404,8 +386,6 @@ def test_strip_substrate_result_is_not_ok_false_is_hard_fail(tmp_path: Path) -> 
 
     # ok=False is the hard-fail; reason must not be empty (names the failure)
     assert result.ok is False
-    assert isinstance(result.reason, str) and result.reason.strip(), (
-        "reason must name the failure, not be blank"
-    )
+    assert isinstance(result.reason, str) and result.reason.strip(), "reason must name the failure, not be blank"
     # requested_hash is always retained so the operator can locate the file
     assert result.requested_hash == new_hash

--- a/tests/unit/test_bernstein_pr_review_workflow_yaml.py
+++ b/tests/unit/test_bernstein_pr_review_workflow_yaml.py
@@ -102,3 +102,28 @@ def test_pr_review_runs_local_action_from_base_checkout(review_steps: list[Workf
     task = inputs.get("task", "")
     assert isinstance(task, str)
     assert ".bernstein-pr.diff" in task, "Review task must point the action at the fetched PR diff"
+
+
+def test_label_gated_review_also_triggers_on_labeled(workflow: Workflow) -> None:
+    """A label that gates the job must also be able to start it.
+
+    The ``review`` job runs only when the ``deep-review`` label is present. That
+    label is usually added by a maintainer after the PR is already open and
+    ready for review. Without ``labeled`` in the trigger list, adding it does
+    nothing until the contributor happens to push again -- the label reads as a
+    switch that is not wired to anything.
+    """
+    triggers = cast(dict[str, object], workflow.get("on") or workflow.get(True))
+    pull_request = triggers.get("pull_request")
+    assert isinstance(pull_request, dict), "expected a pull_request trigger"
+    types = pull_request.get("types")
+    assert isinstance(types, list)
+
+    review = cast(dict[str, object], cast(dict[str, object], workflow["jobs"])["review"])
+    condition = str(review.get("if", ""))
+    assert "deep-review" in condition, "this test assumes the job is label-gated"
+
+    assert "labeled" in types, (
+        "the review job is gated on the 'deep-review' label, so 'labeled' must "
+        f"be a trigger type; got {types}"
+    )

--- a/tests/unit/test_bernstein_pr_review_workflow_yaml.py
+++ b/tests/unit/test_bernstein_pr_review_workflow_yaml.py
@@ -124,6 +124,5 @@ def test_label_gated_review_also_triggers_on_labeled(workflow: Workflow) -> None
     assert "deep-review" in condition, "this test assumes the job is label-gated"
 
     assert "labeled" in types, (
-        "the review job is gated on the 'deep-review' label, so 'labeled' must "
-        f"be a trigger type; got {types}"
+        f"the review job is gated on the 'deep-review' label, so 'labeled' must be a trigger type; got {types}"
     )


### PR DESCRIPTION
# User description
## What

`labeled` joins the trigger types of `.github/workflows/bernstein-pr-review.yml`, plus a structural test and a corrected header comment.

## Why

The `review` job is gated on the `deep-review` label:

```
if: contains(github.event.pull_request.labels.*.name, 'deep-review') && ...
```

The trigger list was `[opened, synchronize, ready_for_review]`. So the label could gate the job but could never start it. Adding `deep-review` to a PR that is already open and ready did nothing until the contributor happened to push again.

That is the common path, not an edge case. The label is normally added by a maintainer *after* the contributor flips ready-for-review, and a contributor cannot add it themselves — label management needs repository write. Hit live on #3518: the contributor asked for the label, it was added, and the review workflow stayed skipped.

The header comment was also wrong in the same direction — it described the review as running on every non-draft PR with `skip-bernstein` as an opt-out, while the `if` makes it opt-in. Corrected rather than left to mislead the next reader.

## Test

`test_label_gated_review_also_triggers_on_labeled` reads the workflow, asserts the job is label-gated, then asserts `labeled` is a trigger type. Fails on `origin/main` (`types=['opened', 'synchronize', 'ready_for_review']`), passes here.

The assertion is deliberately conditional on the job still being label-gated, so removing the gate does not leave a test demanding a trigger nothing needs.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enable the label-gated <code>review</code> job to start when <code>deep-review</code> is added to an existing pull request, correcting its workflow documentation and recording the fix in release notes. Preserve fail-closed trajectory verification while simplifying assertion formatting, and add structural coverage to ensure the workflow trigger remains aligned with its label gate.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3600?tool=ast&topic=Labelled+PR+review>Labelled PR review</a>
        </td><td>Trigger the label-gated <code>review</code> job when <code>deep-review</code> is added to an open pull request, update the workflow’s opt-in documentation, and verify the trigger contract structurally.<details><summary>Modified files (3)</summary><ul><li>.github/workflows/bernstein-pr-review.yml</li>
<li>docs/release-notes/unreleased.md</li>
<li>tests/unit/test_bernstein_pr_review_workflow_yaml.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>github-actions[bot]</td><td>chore(auto): regenerat...</td><td>August 11, 2026</td></tr>
<tr><td>sanderchernitsky@gmail...</td><td>fix(ci): start the lab...</td><td>August 11, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3600?tool=ast&topic=Trajectory+test+cleanup>Trajectory test cleanup</a>
        </td><td>Simplify fail-closed trajectory receipt test assertions without changing verification behavior or weakening checks for failure reasons and requested hashes.<details><summary>Modified files (1)</summary><ul><li>tests/unit/eval/test_trajectory_receipt_cli.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>github-actions[bot]</td><td>chore(auto): regenerat...</td><td>August 11, 2026</td></tr>
<tr><td>xmac484@gmail.com</td><td>feat(eval): AC3/AC6/AC...</td><td>August 10, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3600?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>