### PR TITLE
fix(cli): dry-run --plan exits non-zero on plan load failure (#3550)

### DIFF
--- a/src/bernstein/cli/commands/dry_run_cmd.py
+++ b/src/bernstein/cli/commands/dry_run_cmd.py
@@ -17,6 +17,10 @@ import click
 
 from bernstein.cli.helpers import console
 
+# Non-zero exit codes are operator contract (issue #3550): a plan that fails
+# to load must not look like "valid plan, nothing to schedule".
+EXIT_PLAN_ERROR = 1
+
 
 def _route_task_to_dict(
     router: Any,
@@ -82,14 +86,23 @@ def render_dry_run(
 
 
 def _render_dry_run_from_plan(workdir: Path, plan_file: Path) -> list[dict[str, Any]]:
-    """Build dry-run task list from a plan file."""
-    from bernstein.core.plan_loader import PlanLoadError, load_plan
+    """Build dry-run task list from a plan file.
 
-    try:
-        _plan_config, loaded_tasks = load_plan(plan_file)
-    except PlanLoadError as exc:
-        console.print(f"[red]Plan load error:[/red] {exc}")
-        return []
+    Args:
+        workdir: Project root directory.
+        plan_file: Plan file to load tasks from.
+
+    Returns:
+        List of task dicts with routing metadata.
+
+    Raises:
+        PlanLoadError: If the plan file cannot be loaded or parsed. Callers
+            must surface this as a non-zero exit; swallowing it would turn a
+            malformed plan into a convincing empty result.
+    """
+    from bernstein.core.plan_loader import load_plan
+
+    _plan_config, loaded_tasks = load_plan(plan_file)
 
     router = _init_router(workdir)
     result: list[dict[str, Any]] = []
@@ -159,7 +172,18 @@ def print_dry_run_expanded(
     """
     from rich.table import Table
 
-    tasks = render_dry_run(workdir, plan_file, goal)
+    from bernstein.core.plan_loader import PlanLoadError
+
+    try:
+        tasks = render_dry_run(workdir, plan_file, goal)
+    except PlanLoadError as exc:
+        # A malformed plan is a failure, not an empty backlog: exit non-zero
+        # and let the operator see the loader's message in both output modes.
+        if as_json:
+            console.print_json(json.dumps({"error": {"kind": "PlanLoadError", "message": str(exc)}}))
+        else:
+            console.print(f"[red]Plan load error:[/red] {exc}")
+        raise SystemExit(EXIT_PLAN_ERROR) from exc
 
     if as_json:
         console.print_json(json.dumps({"tasks": tasks, "total": len(tasks)}))
@@ -215,6 +239,11 @@ def dry_run_cmd(plan_file: str | None, goal: str | None, as_json: bool) -> None:
     \b
     Reads the backlog or a plan file and displays what would be executed,
     including provider routing decisions for each task.
+
+    \b
+    Exit codes:
+      0  success (including an empty backlog)
+      1  --plan file failed to load
 
     \b
     Examples:

--- a/tests/unit/test_dry_run_cmd.py
+++ b/tests/unit/test_dry_run_cmd.py
@@ -1,8 +1,10 @@
-"""Tests for the ``bernstein dry-run`` failure contract (issue #3550).
+"""Tests for ``bernstein dry-run``: CLI-007 expansion behavior and the #3550 failure contract.
 
-A plan file that fails to load must exit non-zero and surface the loader's
-message in both table and JSON modes -- never a plausible empty result
-(``{"tasks": [], "total": 0}`` with exit 0).
+CLI-007: ``--dry-run`` expansion shows tasks/roles/models without executing.
+
+Issue #3550: a plan file that fails to load must exit non-zero and surface
+the loader's message in both table and JSON modes -- never a plausible
+empty result (``{"tasks": [], "total": 0}`` with exit 0).
 """
 
 from __future__ import annotations
@@ -15,7 +17,54 @@ import pytest
 import yaml
 from click.testing import CliRunner, Result
 
-from bernstein.cli.commands.dry_run_cmd import dry_run_cmd
+from bernstein.cli.commands.dry_run_cmd import dry_run_cmd, render_dry_run
+from bernstein.cli.main import cli
+
+
+class TestDryRunCmd:
+    """Tests for the dry-run command."""
+
+    def test_dry_run_command_exists(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["dry-run", "--help"])
+        assert result.exit_code == 0
+        assert "tasks" in result.output.lower() or "dry" in result.output.lower()
+
+    def test_dry_run_no_backlog(self) -> None:
+        """Without a backlog, should show 'no open tasks'."""
+        import os
+        import tempfile
+
+        old_cwd = os.getcwd()
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                os.chdir(td)
+                runner = CliRunner()
+                result = runner.invoke(dry_run_cmd, [])
+                assert result.exit_code == 0
+                assert "no open tasks" in result.output.lower() or "no" in result.output.lower()
+        finally:
+            os.chdir(old_cwd)
+
+    def test_dry_run_json_flag(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["dry-run", "--help"])
+        assert "--json" in result.output
+
+    def test_dry_run_plan_flag(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["dry-run", "--help"])
+        assert "--plan" in result.output
+
+    def test_render_dry_run_empty(self) -> None:
+        """render_dry_run returns empty list when no backlog."""
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as td:
+            result = render_dry_run(Path(td))
+            assert result == []
+
 
 VALID_PLAN: dict[str, object] = {
     "name": "Dry Run Test Plan",
@@ -70,7 +119,7 @@ def _extract_json(output: str) -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
-# Malformed plan: the failure contract
+# Malformed plan: the #3550 failure contract
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit/test_dry_run_cmd.py
+++ b/tests/unit/test_dry_run_cmd.py
@@ -1,53 +1,127 @@
-"""Tests for CLI-007: --dry-run expansion."""
+"""Tests for the ``bernstein dry-run`` failure contract (issue #3550).
+
+A plan file that fails to load must exit non-zero and surface the loader's
+message in both table and JSON modes -- never a plausible empty result
+(``{"tasks": [], "total": 0}`` with exit 0).
+"""
 
 from __future__ import annotations
 
-from bernstein.cli.dry_run_cmd import dry_run_cmd, render_dry_run
-from click.testing import CliRunner
+import json
+from pathlib import Path
+from typing import Any
 
-from bernstein.cli.main import cli
+import pytest
+import yaml
+from click.testing import CliRunner, Result
+
+from bernstein.cli.commands.dry_run_cmd import dry_run_cmd
+
+VALID_PLAN: dict[str, object] = {
+    "name": "Dry Run Test Plan",
+    "description": "Plan used by the dry-run CLI contract tests",
+    "stages": [
+        {
+            "name": "S1",
+            "steps": [{"title": "Step A", "goal": "Do the thing", "role": "backend"}],
+        }
+    ],
+}
+
+MALFORMED_PLAN_YAML = (
+    "stages:\n"
+    "  - name: S1\n"
+    "    steps:\n"
+    "      - title: [unclosed\n"  # invalid YAML -> PlanLoadError from the loader
+)
 
 
-class TestDryRunCmd:
-    """Tests for the dry-run command."""
+def _write_plan(tmp_path: Path, content: str) -> Path:
+    plan_file = tmp_path / "plan.yaml"
+    plan_file.write_text(content)
+    return plan_file
 
-    def test_dry_run_command_exists(self) -> None:
-        runner = CliRunner()
-        result = runner.invoke(cli, ["dry-run", "--help"])
-        assert result.exit_code == 0
-        assert "tasks" in result.output.lower() or "dry" in result.output.lower()
 
-    def test_dry_run_no_backlog(self) -> None:
-        """Without a backlog, should show 'no open tasks'."""
-        import os
-        import tempfile
+def _valid_plan_yaml() -> str:
+    return yaml.dump(VALID_PLAN)
 
-        old_cwd = os.getcwd()
-        try:
-            with tempfile.TemporaryDirectory() as td:
-                os.chdir(td)
-                runner = CliRunner()
-                result = runner.invoke(dry_run_cmd, [])
-                assert result.exit_code == 0
-                assert "no open tasks" in result.output.lower() or "no" in result.output.lower()
-        finally:
-            os.chdir(old_cwd)
 
-    def test_dry_run_json_flag(self) -> None:
-        runner = CliRunner()
-        result = runner.invoke(cli, ["dry-run", "--help"])
-        assert "--json" in result.output
+def _run_dry_run(plan_file: Path | None, as_json: bool, workdir: Path, monkeypatch: pytest.MonkeyPatch) -> Result:
+    """Invoke ``dry-run`` from ``workdir`` so Path.cwd() resolves there."""
+    monkeypatch.chdir(workdir)
+    args = []
+    if plan_file is not None:
+        args += ["--plan", str(plan_file)]
+    if as_json:
+        args += ["--json"]
+    return CliRunner().invoke(dry_run_cmd, args)
 
-    def test_dry_run_plan_flag(self) -> None:
-        runner = CliRunner()
-        result = runner.invoke(cli, ["dry-run", "--help"])
-        assert "--plan" in result.output
 
-    def test_render_dry_run_empty(self) -> None:
-        """render_dry_run returns empty list when no backlog."""
-        import tempfile
-        from pathlib import Path
+def _extract_json(output: str) -> dict[str, Any]:
+    """Pull the JSON document out of CLI output.
 
-        with tempfile.TemporaryDirectory() as td:
-            result = render_dry_run(Path(td))
-            assert result == []
+    The router can emit ``[SPAWNER-DEBUG]`` log lines to stderr, which
+    CliRunner mixes into ``result.output``; the JSON document itself starts
+    at the first ``{`` and ends at the last ``}``.
+    """
+    start = output.index("{")
+    end = output.rindex("}") + 1
+    return json.loads(output[start:end])
+
+
+# ---------------------------------------------------------------------------
+# Malformed plan: the failure contract
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_plan_table_mode_exits_nonzero(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    plan = _write_plan(tmp_path, MALFORMED_PLAN_YAML)
+    result = _run_dry_run(plan, as_json=False, workdir=tmp_path, monkeypatch=monkeypatch)
+
+    assert result.exit_code == 1, result.output
+    # The loader's message reaches the operator in table mode.
+    assert "Plan load error" in result.output
+
+
+def test_malformed_plan_json_mode_structured_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    plan = _write_plan(tmp_path, MALFORMED_PLAN_YAML)
+    result = _run_dry_run(plan, as_json=True, workdir=tmp_path, monkeypatch=monkeypatch)
+
+    assert result.exit_code == 1, result.output
+    # A structured error payload, never the success shape.
+    assert '"tasks"' not in result.output
+    payload = _extract_json(result.output)
+    assert payload["error"]["kind"] == "PlanLoadError"
+    assert payload["error"]["message"]
+
+
+# ---------------------------------------------------------------------------
+# Valid plan / backlog: unchanged behavior
+# ---------------------------------------------------------------------------
+
+
+def test_valid_plan_table_mode_exits_zero(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    plan = _write_plan(tmp_path, _valid_plan_yaml())
+    result = _run_dry_run(plan, as_json=False, workdir=tmp_path, monkeypatch=monkeypatch)
+
+    assert result.exit_code == 0, result.output
+    assert "Step A" in result.output
+    assert "Plan load error" not in result.output
+
+
+def test_valid_plan_json_mode_exits_zero(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    plan = _write_plan(tmp_path, _valid_plan_yaml())
+    result = _run_dry_run(plan, as_json=True, workdir=tmp_path, monkeypatch=monkeypatch)
+
+    assert result.exit_code == 0, result.output
+    payload = _extract_json(result.output)
+    assert payload["total"] == 1
+    assert payload["tasks"][0]["title"] == "Step A"
+
+
+def test_empty_backlog_remains_legitimate_empty_result(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Backlog path (no --plan) keeps exit 0 for an empty backlog."""
+    result = _run_dry_run(plan_file=None, as_json=False, workdir=tmp_path, monkeypatch=monkeypatch)
+
+    assert result.exit_code == 0, result.output
+    assert "No open tasks found in backlog." in result.output


### PR DESCRIPTION
Closes #3550

## What

The standalone `bernstein dry-run` command's plan path caught `PlanLoadError` in `_render_dry_run_from_plan`, printed a red console line, and returned `[]`. `print_dry_run_expanded` then rendered that empty list as a normal result — `--json` emitted `{"tasks": [], "total": 0}` and table mode printed "No open tasks found in backlog.", both with exit 0. A pipeline gated on `bernstein dry-run --plan plan.yaml --json` would read "valid plan, nothing to schedule" where the truth was "plan does not load". The `bernstein run --dry-run` path already held the strict line (`SystemExit(1)`), so the two dry-run surfaces disagreed on the failure contract.

## Fix

- `_render_dry_run_from_plan` no longer swallows the error: `PlanLoadError` propagates to the caller (docstring documents the `Raises` contract).
- `print_dry_run_expanded` catches it and exits `EXIT_PLAN_ERROR = 1` in both modes:
  - `--json`: a structured `{"error": {"kind": "PlanLoadError", "message": ...}}` payload — never the success shape.
  - table mode: the `Plan load error: <message>` red line reaches the operator.
- Backlog path (no `--plan`) unchanged: an empty backlog remains a legitimate empty result with exit 0.
- `bernstein run --dry-run`'s existing `SystemExit(1)` contract untouched.
- Exit codes documented in the command docstring (named constant per repo convention).

## Tests

New `tests/unit/test_dry_run_cmd.py` (5 tests):
- malformed plan → exit 1 + message in table mode
- malformed plan → exit 1 + structured JSON error payload (and no `"tasks"` success shape)
- valid plan → exit 0 in table mode
- valid plan → exit 0 with tasks in JSON mode
- empty backlog (no --plan) → exit 0 legitimate empty result

All 5 pass; regression `test_cli_command_registration` + `test_plan_loader` 554 passed. Ruff clean.

## Note

Work was done with AI assistance (Claude, via Mike/Hermes automation), consistent with prior contributions. The plan-loading strictness this surfaces was added in #3534/#3539; this fixes the one public boundary that still discarded it.