### PR TITLE
docs: fix agents/adapters drift in getting-started pages (#3619)

### DIFF
--- a/docs/getting-started/first-run.md
+++ b/docs/getting-started/first-run.md
@@ -171,12 +171,12 @@ configuring anything.
 
 ### `No agents available`
 
-`bernstein agents` shows nothing checked. Install at least one CLI agent (Step 1) and run
-its login flow. Then:
+`bernstein doctor` shows every `Adapter:` row red. Install at least one CLI agent
+(Step 1) and run its login flow. Then:
 
 ```bash
-bernstein agents discover    # rescan
-bernstein doctor             # confirm
+bernstein agents discover    # rescan agent-role catalogs
+bernstein doctor             # confirm adapters + auth are green
 ```
 
 ### `Port 8052 already in use`

--- a/docs/getting-started/quickstart-tutorial.md
+++ b/docs/getting-started/quickstart-tutorial.md
@@ -52,20 +52,21 @@ Bernstein does not run models directly - it orchestrates CLI coding agents that 
 separately. Check which ones are available on your system:
 
 ```bash
-bernstein agents
+bernstein doctor
 ```
 
 Example output:
 
 ```
-Available agents:
-  claude    ✓  Claude Code (claude)
-  codex     ✓  Codex CLI (codex)
-  gemini    ✗  Not found - install: npm i -g @google/gemini-cli
-  aider     ✗  Not found - install: pip install aider-chat
+ Check              Status  Detail               Fix
+ Adapter: claude    ✗       not in PATH          Install claude CLI - see docs
+ Adapter: codex     ✗       not in PATH          Install codex CLI - see docs
+ Adapter: gemini    ✗       not in PATH          Install gemini CLI - see docs
 ```
 
-You need at least one `✓`. If none are installed:
+You need at least one adapter row to turn ✓ (`doctor` also checks auth, ports,
+and your `.sdd` workspace - those stay red until later steps). If none are
+installed:
 
 ```bash
 # Claude Code (Anthropic)
@@ -298,7 +299,7 @@ bernstein stop --force   # Hard kill without draining
 
 You have a working Bernstein setup. Here are common next steps:
 
-- **Add more agents**: Run `bernstein agents` to see what else is installable
+- **Add more adapters**: Run `bernstein integrations list` to see what else is installable
 - **Configure model routing**: Set `model_policy` in `bernstein.yaml` to use cheaper models for simple tasks
 - **Write a plan file**: For real project work, a plan file gives you more control than an inline goal
 - **Set up guardrails**: Add `.bernstein/rules.yaml` to control what agents are allowed to do
@@ -318,7 +319,7 @@ Useful references:
 ### "No agents available"
 
 ```bash
-bernstein agents    # See which agents are installed and which are missing
+bernstein doctor    # See which agent CLIs are installed and authenticated
 ```
 
 Install at least one:


### PR DESCRIPTION
Closes part of #3619 (slice 1 of #3527).

## Pages touched

**docs/getting-started/quickstart-tutorial.md**
- Step 2 told readers to run `bernstein agents` to see installed CLI
  agents, with a fabricated "Available agents: claude ✓ ..." example.
  `bernstein agents` (no subcommand) now only prints the agents
  command-group's own help - it doesn't check anything. Replaced with
  `bernstein doctor`, which is the command that actually reports
  adapter install/auth status today, and captured its real output.
- "What next?" pointed to `bernstein agents` to browse installable
  adapters. Replaced with `bernstein integrations list`, the current
  command for that.
- Troubleshooting repeated the same bare `bernstein agents` claim.
  Replaced with `bernstein doctor`.

**docs/getting-started/first-run.md**
- "No agents available" section made the same claim about
  `bernstein agents` showing a checked/unchecked list. Corrected to
  describe `bernstein doctor`'s actual `Adapter:` rows.

All command invocations above were run against a fresh `pip install -e .`
of this branch, not just read.

## Not touched
`docs/index.md`, `docs/guides/index.md`, and `docs/adapters/index.md`
already use "adapters" consistently and their example commands
(`bernstein integrations list`, `bernstein adapters check`) run as
written - no changes needed there.

No changes under `docs/reference/` (that's #3465's territory).