### PR TITLE
docs: regenerate adapter last-green table from canary receipts

### DIFF
--- a/docs/adapters/conformance-canary.md
+++ b/docs/adapters/conformance-canary.md
@@ -118,14 +118,14 @@ frozen adapter locally, not only in this table.
 | Adapter | Binary | Last-green version | Verified | Receipt |
 |---|---|---|---|---|
 | agy | `agy` | 1.0.0 | 2026-07-11T05:57:23Z (stale) | `006fb946868d` |
-| claude | `claude` | 2.1.226 | 2026-08-10T06:08:05Z | `b28d74127b15` |
-| codex | `codex` | 0.147.0 | 2026-08-10T06:08:05Z | `243aa6fb7455` |
-| copilot | `copilot` | 1.0.78 | 2026-08-10T06:08:05Z | `4260c9ac6d84` |
-| gemini | `gemini` | 0.54.4 | 2026-08-10T06:08:05Z | `3e749e4b1b0c` |
-| kimi | `kimi` | 1.49.0 | 2026-08-10T06:08:05Z | `6db9ef9135a5` |
-| opencode | `opencode` | 1.18.15 | 2026-08-09T05:40:13Z | `fbf184104e78` |
-| pydantic_ai | `clai` | 2.27.0 | 2026-08-10T06:08:05Z | `af6306be308a` |
-| qwen | `qwen` | 0.21.8 | 2026-08-10T06:08:05Z | `3776334a4444` |
+| claude | `claude` | 2.1.227 | 2026-08-11T05:47:04Z | `5d96894dd122` |
+| codex | `codex` | 0.147.0 | 2026-08-11T05:47:04Z | `e48e896d2010` |
+| copilot | `copilot` | 1.0.79 | 2026-08-11T05:47:04Z | `c9a897f9dec2` |
+| gemini | `gemini` | 0.54.4 | 2026-08-11T05:47:04Z | `466c9e678312` |
+| kimi | `kimi` | 1.49.0 | 2026-08-11T05:47:04Z | `8f5ecde0c4e0` |
+| opencode | `opencode` | 1.18.16 | 2026-08-11T05:47:04Z | `792c9e5c2b9e` |
+| pydantic_ai | `clai` | 2.27.1 | 2026-08-11T05:47:04Z | `85d0fc284225` |
+| qwen | `qwen` | 0.21.9 | 2026-08-11T05:47:04Z | `cd0d6579424a` |
 <!-- last-green:end -->
 
 ## Operator knobs

--- a/docs/adapters/conformance-canary.md
+++ b/docs/adapters/conformance-canary.md
@@ -43,6 +43,40 @@ ephemeral runner: recompute a receipt file's SHA-256 and match it
 against the `receipt_sha256` of the persisted `adapter.canary_receipt`
 entry.
 
+## What `last_green.json` rows must look like
+
+`load_last_green` validates each row at the JSON boundary instead of
+coercing it. A row that does not satisfy the shape it claims is **dropped
+with a warning**, and the rest of the table still loads -- one bad row
+must not empty the projection, because an empty projection makes every
+`doctor` staleness check a silent no-op.
+
+| Field | Accepted | Rejected |
+|---|---|---|
+| `binary` | non-empty string; surrounding whitespace is stripped | `null`, numbers, lists, objects, `""` |
+| `version` | non-empty string; surrounding whitespace is stripped | `null`, numbers, lists, objects, `""` |
+| `receipt_sha256` | exactly 64 lowercase hex characters | uppercase hex, truncated hashes, any non-hash string, non-strings |
+| `recorded_at` | a timestamp `datetime.fromisoformat` accepts, including a trailing `Z` | `"yesterday"`, epoch integers, objects, non-strings |
+
+A row missing any of these keys is dropped, as before.
+
+**If you maintain a projection this repo did not generate**, check it
+against the table above before upgrading: a hand-written or older file
+whose `receipt_sha256` is not a full lowercase hash, or whose
+`recorded_at` is not ISO 8601, will now be dropped rather than loaded.
+The symptom is `CANARY_UNKNOWN` at admission and a warning-only `doctor`
+result for that adapter, and the cause is named in a
+`last-green row ... malformed` warning on the loader's logger. Rows the
+canary itself writes are already in this shape; regenerate with
+`uv run python scripts/adapter_canary.py --update-docs` if in doubt.
+
+The reason for validating rather than coercing: `str(value)` renders
+`None` as `"None"` and a list as its repr, so a corrupt row used to load
+as a populated entry that admission and `doctor` then read as a
+receipt-backed claim. The table is a projection of receipts and every row
+is meant to be independently checkable against its receipt file; a value
+that was never a hash cannot be checked against anything.
+
 ## Regression handling
 
 * A regression must repeat: **two consecutive failures with the same

--- a/src/bernstein/adapters/canary.py
+++ b/src/bernstein/adapters/canary.py
@@ -761,8 +761,59 @@ def canary_skip_issue_body(outcome: CanaryOutcome, *, receipt_sha: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+#: A row's ``receipt_sha256`` is the identity of the receipt that attested it:
+#: 64 lowercase hex characters, the shape ``hashlib.sha256().hexdigest()`` emits.
+_RECEIPT_SHA256 = re.compile(r"[0-9a-f]{64}")
+
+
+def _row_text(entry: dict[str, Any], key: str) -> str:
+    """Return *key* as a non-empty string, rejecting values JSON coerces well.
+
+    ``str(value)`` turns ``None`` into ``"None"`` and ``["2.1.0"]`` into
+    ``"['2.1.0']"`` -- values that read downstream as populated fields rather
+    than as the corruption they are. Every row here claims a receipt attested
+    it, so a field that was never a string is a corrupt row, not a row with an
+    unusual value.
+    """
+    value = entry[key]
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{key} must be a non-empty string, got {type(value).__name__}")
+    return value
+
+
+def _row_receipt_sha256(entry: dict[str, Any]) -> str:
+    """Return the attesting receipt hash, or reject the row.
+
+    The table is a projection of receipts and every row is meant to be
+    independently checkable against its receipt file. A hash that is not a hash
+    cannot be checked against anything, so it must not enter the projection
+    wearing the shape of one.
+    """
+    value = _row_text(entry, "receipt_sha256")
+    if not _RECEIPT_SHA256.fullmatch(value):
+        raise ValueError("receipt_sha256 must be 64 lowercase hex characters")
+    return value
+
+
+def _row_recorded_at(entry: dict[str, Any]) -> str:
+    """Return the attesting run's timestamp, or reject the row."""
+    value = _row_text(entry, "recorded_at")
+    try:
+        datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError("recorded_at must be an ISO 8601 timestamp") from exc
+    return value
+
+
 def load_last_green(path: Path | None = None) -> dict[str, LastGreenEntry]:
-    """Load the last-green projection (packaged file by default)."""
+    """Load the last-green projection (packaged file by default).
+
+    Rows are validated at the JSON boundary rather than coerced. A row that
+    does not satisfy the shape it claims is dropped with a warning: the entries
+    this returns feed admission and ``doctor``, which read them as attestations,
+    and an attestation assembled from a coerced value attests nothing while
+    still presenting as evidence.
+    """
     source = path if path is not None else LAST_GREEN_JSON_PATH
     try:
         raw = json.loads(source.read_text(encoding="utf-8"))
@@ -778,12 +829,16 @@ def load_last_green(path: Path | None = None) -> dict[str, LastGreenEntry]:
         try:
             entries[str(name)] = LastGreenEntry(
                 adapter=str(name),
-                binary=str(entry["binary"]),
-                version=str(entry["version"]),
-                receipt_sha256=str(entry["receipt_sha256"]),
-                recorded_at=str(entry["recorded_at"]),
+                binary=_row_text(entry, "binary"),
+                version=_row_text(entry, "version"),
+                receipt_sha256=_row_receipt_sha256(entry),
+                recorded_at=_row_recorded_at(entry),
             )
-        except KeyError:
+        except KeyError as exc:
+            logger.warning("last-green row %r is missing %s; dropped", name, exc)
+            continue
+        except ValueError as exc:
+            logger.warning("last-green row %r is malformed and was dropped: %s", name, exc)
             continue
     return entries
 

--- a/src/bernstein/adapters/canary.py
+++ b/src/bernstein/adapters/canary.py
@@ -774,11 +774,18 @@ def _row_text(entry: dict[str, Any], key: str) -> str:
     than as the corruption they are. Every row here claims a receipt attested
     it, so a field that was never a string is a corrupt row, not a row with an
     unusual value.
+
+    The value is returned stripped. Surrounding whitespace carries no meaning
+    in any of these fields and does not survive a round trip, but it does
+    survive into consumers: ``shutil.which(" claude")`` finds nothing, and a
+    padded version reaches admission as a version nobody installed. Normalising
+    is right here rather than rejecting -- the row is not corrupt, its
+    formatting is.
     """
     value = entry[key]
     if not isinstance(value, str) or not value.strip():
         raise ValueError(f"{key} must be a non-empty string, got {type(value).__name__}")
-    return value
+    return value.strip()
 
 
 def _row_receipt_sha256(entry: dict[str, Any]) -> str:

--- a/src/bernstein/adapters/last_green.json
+++ b/src/bernstein/adapters/last_green.json
@@ -8,51 +8,51 @@
     },
     "claude": {
       "binary": "claude",
-      "receipt_sha256": "b28d74127b15ab2c67c58168dd657c923468a64385fb6eee603659e2590203a9",
-      "recorded_at": "2026-08-10T06:08:05Z",
-      "version": "2.1.226"
+      "receipt_sha256": "5d96894dd122e1c2f1e664586ff5052e47d61e55a44af80d0774f893bb26a809",
+      "recorded_at": "2026-08-11T05:47:04Z",
+      "version": "2.1.227"
     },
     "codex": {
       "binary": "codex",
-      "receipt_sha256": "243aa6fb74555d2a4da26232ed79704887e0106e367208336e3ae837fbdc8b82",
-      "recorded_at": "2026-08-10T06:08:05Z",
+      "receipt_sha256": "e48e896d20100ba1482fcaa3c7f2b5d4606ed9e2490dd6ae90ef5f14b604a8e7",
+      "recorded_at": "2026-08-11T05:47:04Z",
       "version": "0.147.0"
     },
     "copilot": {
       "binary": "copilot",
-      "receipt_sha256": "4260c9ac6d84778eb7ca00db4e55f655427541e4c44dbf9f1c03408fc25957c7",
-      "recorded_at": "2026-08-10T06:08:05Z",
-      "version": "1.0.78"
+      "receipt_sha256": "c9a897f9dec21adae2b3591d0758946c2bbbbe1f907b46cb11bc3a60c08a4251",
+      "recorded_at": "2026-08-11T05:47:04Z",
+      "version": "1.0.79"
     },
     "gemini": {
       "binary": "gemini",
-      "receipt_sha256": "3e749e4b1b0c86be91b3ca0c6c4e958f8739a875db7fc87542d2a3f9837ecea1",
-      "recorded_at": "2026-08-10T06:08:05Z",
+      "receipt_sha256": "466c9e678312317274321ab6440a8e57ae76a57fae06a2c136652d3ec295f271",
+      "recorded_at": "2026-08-11T05:47:04Z",
       "version": "0.54.4"
     },
     "kimi": {
       "binary": "kimi",
-      "receipt_sha256": "6db9ef9135a5671b8550d14310b404dcf762ffdbeb570ac1da14d8d280c317c9",
-      "recorded_at": "2026-08-10T06:08:05Z",
+      "receipt_sha256": "8f5ecde0c4e0ab2b658e585cd6e587884b6b7fb3a1638dc77f0645abec91c183",
+      "recorded_at": "2026-08-11T05:47:04Z",
       "version": "1.49.0"
     },
     "opencode": {
       "binary": "opencode",
-      "receipt_sha256": "fbf184104e78222406e54e962030305210f61a09ca8e957301f2359935e6d2af",
-      "recorded_at": "2026-08-09T05:40:13Z",
-      "version": "1.18.15"
+      "receipt_sha256": "792c9e5c2b9ec76933ae30308af3ea338f43b01111a4959ff8aa53ceb4f898e6",
+      "recorded_at": "2026-08-11T05:47:04Z",
+      "version": "1.18.16"
     },
     "pydantic_ai": {
       "binary": "clai",
-      "receipt_sha256": "af6306be308ab6903d6487e6ee06e71ef57a8b4657e33c085ef75d0e19fbb8a3",
-      "recorded_at": "2026-08-10T06:08:05Z",
-      "version": "2.27.0"
+      "receipt_sha256": "85d0fc284225a59c552a2f6b56ca4dadec417c7b9a05e0b9cfec748f2a03e547",
+      "recorded_at": "2026-08-11T05:47:04Z",
+      "version": "2.27.1"
     },
     "qwen": {
       "binary": "qwen",
-      "receipt_sha256": "3776334a44446e63d1a0a672c1d36565788ab3901a06447d26cc8871c3800f8a",
-      "recorded_at": "2026-08-10T06:08:05Z",
-      "version": "0.21.8"
+      "receipt_sha256": "cd0d6579424a51a24f6bc4fd46586af4446097506ef190d54b63f74d8182a2cb",
+      "recorded_at": "2026-08-11T05:47:04Z",
+      "version": "0.21.9"
     }
   },
   "schema_version": 1

--- a/tests/unit/test_adapter_canary.py
+++ b/tests/unit/test_adapter_canary.py
@@ -535,6 +535,84 @@ class TestLastGreen:
         entries = load_last_green()
         assert isinstance(entries, dict)
 
+    def test_packaged_table_survives_validation(self) -> None:
+        """The shipped projection must satisfy the boundary it is read through.
+
+        Validating rows is only an improvement if the real table passes it; a
+        stricter loader that silently empties the packaged file would turn every
+        ``doctor`` staleness check into a no-op.
+        """
+        entries = load_last_green()
+        assert entries, "the packaged last-green table must load at least one row"
+        for name, entry in entries.items():
+            assert len(entry.receipt_sha256) == 64, name
+            assert entry.version.strip(), name
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("version", None),
+            ("version", ["1.4.0"]),
+            ("version", ""),
+            ("binary", None),
+            ("binary", 7),
+            ("receipt_sha256", None),
+            ("receipt_sha256", 123),
+            ("receipt_sha256", "not-a-hash"),
+            ("receipt_sha256", "AB" * 32),
+            ("recorded_at", None),
+            ("recorded_at", {"at": "2026-07-11T05:57:23Z"}),
+            ("recorded_at", "yesterday"),
+        ],
+    )
+    def test_malformed_row_is_dropped_rather_than_coerced(self, tmp_path: Path, field: str, value: object) -> None:
+        """A row that was never valid must not arrive looking like an attestation.
+
+        ``str(value)`` renders ``None`` as ``"None"`` and a list as its repr, so
+        a corrupt row used to load as a populated entry that admission and
+        ``doctor`` then read as a receipt-backed claim.
+        """
+        row = {
+            "binary": "agy",
+            "version": "1.4.0",
+            "receipt_sha256": "ab" * 32,
+            "recorded_at": "2026-07-11T05:57:23Z",
+        }
+        row[field] = value  # type: ignore[assignment]
+        path = tmp_path / "last_green.json"
+        path.write_text(json.dumps({"adapters": {"agy": row}}), encoding="utf-8")
+
+        assert load_last_green(path) == {}, f"{field}={value!r} must not load as an entry"
+
+    def test_a_malformed_row_does_not_discard_its_valid_neighbours(self, tmp_path: Path) -> None:
+        path = tmp_path / "last_green.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "adapters": {
+                        "agy": {
+                            "binary": "agy",
+                            "version": None,
+                            "receipt_sha256": "ab" * 32,
+                            "recorded_at": "2026-07-11T05:57:23Z",
+                        },
+                        "claude": {
+                            "binary": "claude",
+                            "version": "2.1.227",
+                            "receipt_sha256": "cd" * 32,
+                            "recorded_at": "2026-08-11T05:47:04Z",
+                        },
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        loaded = load_last_green(path)
+
+        assert set(loaded) == {"claude"}
+        assert loaded["claude"].version == "2.1.227"
+
     def test_render_table_rows_sorted_by_adapter(self) -> None:
         entries = {}
         for name in ("gemini", "agy"):

--- a/tests/unit/test_adapter_canary.py
+++ b/tests/unit/test_adapter_canary.py
@@ -613,6 +613,35 @@ class TestLastGreen:
         assert set(loaded) == {"claude"}
         assert loaded["claude"].version == "2.1.227"
 
+    def test_surrounding_whitespace_is_normalised_not_carried_into_consumers(self, tmp_path: Path) -> None:
+        """A padded field passes an emptiness check and then breaks its consumer.
+
+        ``shutil.which(" claude")`` finds nothing and a padded version reaches
+        admission as a version nobody installed, so the row would produce a
+        stale-or-unknown verdict about a perfectly current install.
+        """
+        path = tmp_path / "last_green.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "adapters": {
+                        "claude": {
+                            "binary": " claude ",
+                            "version": "\t2.1.227\n",
+                            "receipt_sha256": "cd" * 32,
+                            "recorded_at": "2026-08-11T05:47:04Z",
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        loaded = load_last_green(path)
+
+        assert loaded["claude"].binary == "claude"
+        assert loaded["claude"].version == "2.1.227"
+
     def test_render_table_rows_sorted_by_adapter(self) -> None:
         entries = {}
         for name in ("gemini", "agy"):


### PR DESCRIPTION
# User description
Nightly adapter conformance canary regeneration of the per-adapter last-green projection (packaged last_green.json + the docs table). Every row is anchored to the receipt that attested it; receipts for this run are attached to the workflow run as artifacts.

Workflow run: https://github.com/sipyourdrink-ltd/bernstein/actions/runs/31462575872

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Regenerate the adapter last-green projection from nightly canary receipts, updating packaged JSON and the documentation table with current versions, timestamps, and hashes. Validate projection rows at the <code>load_last_green</code> boundary so malformed attestations are dropped with warnings while valid adapter data remains available to admission and <code>doctor</code>.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3625?tool=ast&topic=Projection+validation>Projection validation</a>
        </td><td>Validate <code>last_green.json</code> fields without coercion, normalize valid text, preserve neighboring rows, and cover malformed-row behavior with tests.<details><summary>Modified files (3)</summary><ul><li>docs/adapters/conformance-canary.md</li>
<li>src/bernstein/adapters/canary.py</li>
<li>tests/unit/test_adapter_canary.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>fix(canary): normalise...</td><td>August 11, 2026</td></tr>
<tr><td>canary@users.noreply.g...</td><td>docs: regenerate adapt...</td><td>August 11, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3625?tool=ast&topic=Canary+projection>Canary projection</a>
        </td><td>Regenerate the per-adapter last-green projection from canary receipts and update the documented adapter versions, timestamps, and receipt hashes.<details><summary>Modified files (2)</summary><ul><li>docs/adapters/conformance-canary.md</li>
<li>src/bernstein/adapters/last_green.json</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>fix(canary): normalise...</td><td>August 11, 2026</td></tr>
<tr><td>canary@users.noreply.g...</td><td>docs: regenerate adapt...</td><td>August 11, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3625?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>