### PR TITLE
fix: three release and review gates that reported the wrong outcome (#3573, #3571, #3601)

### DIFF
--- a/.github/workflows/bernstein-pr-review.yml
+++ b/.github/workflows/bernstein-pr-review.yml
@@ -5,6 +5,27 @@ name: "Bernstein PR Review"
 # already open and ready; without it the review only ever runs on the next
 # push, and a maintainer adding the label sees nothing happen.
 # Add the label "skip-bernstein" to opt a PR out even when "deep-review" is on.
+#
+# Position on fork pull requests (#3601). GitHub does not pass repository
+# secrets to `pull_request` runs on branches that live in a fork, so
+# ANTHROPIC_API_KEY is empty for every external contribution and no review can
+# run. That is a platform rule, not a misconfiguration, and it is not worked
+# around here: reviewing untrusted head code with a credential in scope is the
+# risk `pull_request` exists to avoid, and `pull_request_target` would hand the
+# credential exactly the diff it must not be given.
+#
+# What is fixed is the signal. A run that reviewed nothing must not look like a
+# run that reviewed and found nothing, because that green check is read as
+# evidence by whoever merges. So the two skip causes are separated:
+#
+#   fork PR, credential withheld  -> the job name says the review did not run,
+#                                    which is what a reviewer sees in the checks
+#                                    list at merge time; the job still succeeds,
+#                                    because reddening every external
+#                                    contribution punishes the contributor for a
+#                                    platform rule
+#   same-repo PR, secret missing  -> the job fails, because there the secret is
+#                                    genuinely absent and that is ours to fix
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, labeled]
@@ -22,7 +43,13 @@ permissions:
 
 jobs:
   review:
-    name: Review with Bernstein
+    # The check name is the only surface this job controls that a reviewer sees
+    # without opening the run, so it carries the outcome a fork PR is going to
+    # get. Evaluated from the `github` context before the job starts.
+    name: >-
+      ${{ github.event.pull_request.head.repo.fork
+      && 'Review with Bernstein (did not run: fork PR, credential withheld)'
+      || 'Review with Bernstein' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -41,13 +68,37 @@ jobs:
           egress-policy: audit
       - name: Check API key
         id: check
+        env:
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
         run: |
-          if [ -z "$ANTHROPIC_API_KEY" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::Skipping Bernstein review - no ANTHROPIC_API_KEY secret"
-          else
+          if [ -n "$ANTHROPIC_API_KEY" ]; then
             echo "skip=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+
+          if [ "$IS_FORK" = "true" ]; then
+            {
+              echo "## Bernstein deep review did not run"
+              echo
+              echo "This pull request comes from a fork. GitHub withholds repository"
+              echo "secrets from \`pull_request\` runs on fork branches, so"
+              echo "\`ANTHROPIC_API_KEY\` is empty here: no diff was fetched and no"
+              echo "review was produced."
+              echo
+              echo "**Nothing in this pull request was checked by this job.** External"
+              echo "contributions are reviewed by a maintainer by hand."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning title=Deep review did not run::Fork pull request - GitHub withholds ANTHROPIC_API_KEY from pull_request runs on fork branches, so no diff was read and no review was produced."
+            exit 0
+          fi
+
+          # Same-repository PR: the secret should have been in scope. An empty
+          # value here is a missing secret, which is ours to fix, so fail rather
+          # than report a green check nobody can distinguish from a real review.
+          echo "::error title=Deep review is misconfigured::ANTHROPIC_API_KEY is unset on a same-repository pull request; the secret is absent from the repository rather than withheld by the platform."
+          exit 1
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         if: steps.check.outputs.skip != 'true'

--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -65,31 +65,26 @@ jobs:
           META_VERSION: ${{ steps.meta.outputs.version }}
           META_SHA256: ${{ steps.meta.outputs.sha256 }}
         run: |
-          cat > /tmp/bernstein.rb << 'FORMULA'
-          class Bernstein < Formula
-            include Language::Python::Virtualenv
+          # The formula body is packaging/homebrew/bernstein.rb. It used to be a
+          # second copy inlined here, and the two drifted: the checked-in
+          # template carried a warning that the install strategy was broken while
+          # this heredoc -- the copy that actually reaches the tap -- kept
+          # shipping it (#3573). Only the version and the tarball digest are
+          # substituted here; anything else about the formula is a repository
+          # change reviewed like any other.
+          if [ -z "$META_SHA256" ]; then
+            echo "::error::PyPI sdist digest for ${META_VERSION} never resolved; refusing to publish a formula whose sha256 would be empty."
+            exit 1
+          fi
 
-            desc "Deterministic orchestrator for CLI coding agents"
-            homepage "https://github.com/sipyourdrink-ltd/bernstein"
-            url "https://files.pythonhosted.org/packages/source/b/bernstein/bernstein-VERSION.tar.gz"
-            sha256 "SHA256"
-            license "Apache-2.0"
-            head "https://github.com/sipyourdrink-ltd/bernstein.git", branch: "main"
+          sed -e "s|bernstein-VERSION.tar.gz|bernstein-${META_VERSION}.tar.gz|" \
+              -e "s|PLACEHOLDER|${META_SHA256}|" \
+              packaging/homebrew/bernstein.rb > /tmp/bernstein.rb
 
-            depends_on "python@3.12"
-
-            def install
-              virtualenv_install_with_resources
-            end
-
-            test do
-              assert_match "bernstein", shell_output("#{bin}/bernstein --version")
-            end
-          end
-          FORMULA
-
-          sed -i "s/VERSION/${META_VERSION}/g" /tmp/bernstein.rb
-          sed -i "s/SHA256/${META_SHA256}/g" /tmp/bernstein.rb
+          if grep -q "PLACEHOLDER\|bernstein-VERSION" /tmp/bernstein.rb; then
+            echo "::error::formula still carries a template placeholder after substitution."
+            exit 1
+          fi
           cat /tmp/bernstein.rb
 
       - name: Push to homebrew-tap repo

--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -45,18 +45,36 @@ jobs:
           else
             VERSION="${GITHUB_REF_NAME#v}"
           fi
+          # The version is interpolated straight into the sdist URL and into the
+          # published formula, and workflow_dispatch's `required: true` only means
+          # "not omitted": it accepts `latest`, a stray space, or anything else a
+          # hand-typed dispatch produces. Reject it here so the failure names the
+          # cause, instead of surfacing three steps later as a formula pinned to a
+          # release that does not exist.
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+((a|b|rc)[0-9]+)?$'; then
+            echo "::error::'${VERSION}' is not a release version this workflow can publish."
+            exit 1
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-          # Get SHA256 of PyPI tarball
+          # `curl -sL` exits 0 on an HTTP error and writes the error body to
+          # stdout, so piping it into sha256sum hashes the 404 page. That digest
+          # is non-empty and is not the empty-file digest, so it passed both
+          # previous guards -- and the published formula would then carry a
+          # sha256 that disagrees with its own url, failing every `brew install`
+          # at checksum verification. Fetch to a file with --fail, and confirm
+          # the bytes really are a gzip stream before hashing them.
           URL="https://files.pythonhosted.org/packages/source/b/bernstein/bernstein-${VERSION}.tar.gz"
           for i in 1 2 3 4 5; do
-            SHA=$(curl -sL "$URL" | sha256sum | cut -d' ' -f1)
-            if [ -n "$SHA" ] && [ "$SHA" != "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" ]; then
+            if curl --fail --location --silent --show-error "$URL" -o /tmp/sdist.tar.gz \
+              && gzip --test /tmp/sdist.tar.gz; then
+              SHA=$(sha256sum /tmp/sdist.tar.gz | cut -d' ' -f1)
               echo "sha256=$SHA" >> "$GITHUB_OUTPUT"
               echo "Found SHA: $SHA"
               break
             fi
-            echo "Waiting for PyPI to propagate... (attempt $i)"
+            rm -f /tmp/sdist.tar.gz
+            echo "sdist for ${VERSION} is not fetchable yet; waiting for PyPI to propagate (attempt $i)"
             sleep 30
           done
 

--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -51,9 +51,26 @@ jobs:
           # hand-typed dispatch produces. Reject it here so the failure names the
           # cause, instead of surfacing three steps later as a formula pinned to a
           # release that does not exist.
-          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+((a|b|rc)[0-9]+)?$'; then
-            echo "::error::'${VERSION}' is not a release version this workflow can publish."
+          #
+          # Two separate rules, because "not publishable" and "not a version"
+          # are different outcomes. The first pattern is the set scripts/
+          # bump_version.py can produce and publish.yml therefore dispatches;
+          # anything outside it is a typo or a misconfigured dispatch and is an
+          # error. The second is narrower: a tap's stable formula must not
+          # track a pre-release, dev, post, or local version, so those exit
+          # successfully as a deliberate skip rather than failing the run that
+          # a legitimate `v3.15.0rc1` tag would otherwise turn red.
+          # tests/unit/test_homebrew_formula.py pins the first pattern to
+          # bump_version.py so the two cannot drift apart.
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([-+.]?[0-9A-Za-z.-]+)?$'; then
+            echo "::error::'${VERSION}' is not a version this project's release tooling can produce."
             exit 1
+          fi
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::notice::'${VERSION}' is not a final release; Homebrew publishes final releases only."
+            echo "'${VERSION}' is not a final release; skipped Homebrew publication." >> "$GITHUB_STEP_SUMMARY"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
@@ -79,6 +96,7 @@ jobs:
           done
 
       - name: Generate formula
+        if: steps.meta.outputs.skip != 'true'
         env:
           META_VERSION: ${{ steps.meta.outputs.version }}
           META_SHA256: ${{ steps.meta.outputs.sha256 }}
@@ -106,6 +124,7 @@ jobs:
           cat /tmp/bernstein.rb
 
       - name: Push to homebrew-tap repo
+        if: steps.meta.outputs.skip != 'true'
         env:
           # HOMEBREW_TAP_TOKEN must be a PAT with `repo` scope for
           # chernistry/homebrew-tap. Without it the cross-repo push fails;

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -78,11 +78,12 @@ irm https://astral.sh/uv/install.ps1 | iex        # Windows PowerShell
 
 === "Homebrew (macOS / Linux)"
 
-    **Temporarily unavailable.** The current formula installs Bernstein without
-    its runtime dependencies, so the installed `bernstein` command fails at
-    startup. Tracked in
-    [#3573](https://github.com/sipyourdrink-ltd/bernstein/issues/3573).
-    Use `uv tool install bernstein` or `pipx install bernstein` instead.
+    ```bash
+    brew install chernistry/tap/bernstein
+    ```
+
+    The formula builds its own virtualenv and resolves the runtime closure from
+    wheels, so the install takes a couple of minutes and compiles nothing.
 
 === "Fedora / RHEL (dnf)"
 

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -87,7 +87,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/auto-release.yml | alert-on-stale-release-trigger: Alert on stale release trigger<br>detect-stale-alerts: Detect open auto-release-skipped issues<br>gate: Release gate<br>release: Tag release<br>sweep-stale-alerts-on-success: Close auto-release-skipped issues on green main |
 | .github/workflows/bernstein-ci-fix.yml | fallback-issue: Open ci-fix issue (fallback)<br>fix: Auto-heal with Bernstein<br>tier3-shadow: Tier-3 OpenRouter shadow-mode escalation<br>triage: Triage CI failure |
 | .github/workflows/bernstein-issues-decompose.yml | decompose: Implement approved issue plan<br>plan: Plan issue decomposition<br>reject-untrusted-issue: Reject untrusted issue decomposition<br>scope_gate: Require approved file scope |
-| .github/workflows/bernstein-pr-review.yml | review: Review with Bernstein |
+| .github/workflows/bernstein-pr-review.yml | review: ${{ github.event.pull_request.head.repo.fork && 'Review with Bernstein (did not run: fork PR, credential withheld)' \|\| 'Review with Bernstein' }} |
 | .github/workflows/bisect-on-red.yml | bisect: Identify culprit PR |
 | .github/workflows/branch-protection-audit.yml | audit: Branch protection audit |
 | .github/workflows/ci-gate-stub.yml | ci-gate: ${{ needs.classify.outputs.all_ignored == 'true' && 'CI gate' \|\| 'CI gate stub (not applicable)' }}<br>classify: Classify diff against ci.yml paths-ignore |

--- a/packaging/homebrew/bernstein.rb
+++ b/packaging/homebrew/bernstein.rb
@@ -11,14 +11,37 @@ class Bernstein < Formula
 
   depends_on "python@3.12"
 
-  # BROKEN as-is: `virtualenv_install_with_resources` with no `resource`
-  # blocks installs bernstein via `pip --no-deps`, so the resulting binary
-  # fails at startup (ModuleNotFoundError: no module named 'click').
-  # Do not publish this formula until the runtime closure ships as
-  # resources (or the install strategy changes). Tracked in
-  # https://github.com/sipyourdrink-ltd/bernstein/issues/3573.
+  # Install strategy: resolve the runtime closure at install time inside the
+  # formula's own virtualenv, rather than pinning it as `resource` blocks (#3573).
+  #
+  # `virtualenv_install_with_resources` was here before and installed nothing but
+  # bernstein itself: Homebrew drives it with `pip --no-deps`, and the formula
+  # declared no resources, so every install produced a command that died on
+  # `import click`. Canonical Homebrew style would be to declare all 81 runtime
+  # dependencies as resources. That was tried and rejected: the closure contains
+  # four Rust builds (pydantic-core, rpds-py, jiter, cryptography) plus grpcio,
+  # lxml and pillow, so sdist-backed resources turn `brew install` into an
+  # hour-plus source build needing rust and cmake; and the resources have to be
+  # regenerated on every release by `brew update-python-resources`, which is
+  # currently broken against modern pip (it sends `--uploaded-prior-to=P1D`,
+  # which pip rejects as not an ISO 8601 datetime).
+  #
+  # So: create the venv, then let pip resolve. `--prefer-binary` keeps the
+  # install on wheels wherever one exists, which is the whole closure on both
+  # macOS architectures, so nothing compiles in practice.
+  #
+  # The trade-off is real and worth stating: transitive versions resolve at
+  # install time instead of being pinned in the formula, so two installs on
+  # different days can differ below the top level. bernstein itself is still
+  # pinned and hash-verified -- Homebrew checks `sha256` against the staged
+  # sdist, and that sdist is what gets installed.
+  # `virtualenv_create` builds the venv with `--without-pip --system-site-packages`,
+  # so there is no `libexec/bin/pip` to call: pip is reached as a module through
+  # the venv's interpreter.
   def install
-    virtualenv_install_with_resources
+    virtualenv_create(libexec, "python3.12")
+    system libexec/"bin/python", "-m", "pip", "install", "--prefer-binary", buildpath
+    bin.install_symlink libexec/"bin/bernstein"
   end
 
   test do

--- a/scripts/gen_distribution_manifests.py
+++ b/scripts/gen_distribution_manifests.py
@@ -3,7 +3,8 @@
 
 The MCP registry manifest (``server.json``), the plugin manifest
 (``.plugin/plugin.json``), and the Agent Plugins 1.0.0 root manifests
-(``plugin.json``, ``mcp.json``, #3540) are release artifacts: their version
+(``plugin.json``, ``mcp.json``, #3540) and the citation metadata
+(``CITATION.cff``, #3571) are release artifacts: their version
 fields must track the package version, and the release workflow - not hand
 edits - is their single source. This script is a deterministic projection: given the
 same ``pyproject.toml`` and manifest inputs it produces byte-identical
@@ -23,9 +24,11 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
 import tomllib
+from datetime import UTC, datetime
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
@@ -34,7 +37,14 @@ PLUGIN_JSON = REPO / ".plugin" / "plugin.json"
 MCP_JSON = REPO / ".mcp.json"
 ROOT_PLUGIN_JSON = REPO / "plugin.json"
 ROOT_MCP_JSON = REPO / "mcp.json"
+CITATION_CFF = REPO / "CITATION.cff"
 SKILLS_DIR = REPO / "skills"
+
+#: Top-level ``CITATION.cff`` keys this script owns. Anchored to the start of a
+#: line so they match only at the document root: ``cff-version`` is a different
+#: key, and ``preferred-citation`` has its own indented block.
+_CFF_VERSION = re.compile(r"^version:.*$", re.MULTILINE)
+_CFF_DATE_RELEASED = re.compile(r"^date-released:.*$", re.MULTILINE)
 
 #: Canonical schema identifiers for the Agent Plugins 1.0.0 manifests.
 #: Validation runs against the copies vendored under
@@ -282,6 +292,60 @@ def render_root_mcp_json() -> str:
     return json.dumps(data, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
 
 
+def release_date() -> str:
+    """Return the date to stamp when the recorded version changes (UTC, ISO 8601).
+
+    ``SOURCE_DATE_EPOCH`` wins when it is set, so a reproducible-build
+    environment can pin what this returns. Otherwise the current UTC date, which
+    is the release date: this value is only ever read on a run that is changing
+    the recorded version, and that is the release commit.
+    """
+    epoch = os.environ.get("SOURCE_DATE_EPOCH")
+    if epoch:
+        return datetime.fromtimestamp(int(epoch), tz=UTC).date().isoformat()
+    return datetime.now(tz=UTC).date().isoformat()
+
+
+def render_citation_cff(version: str, current: str, *, today: str) -> str:
+    """Return ``CITATION.cff`` with ``version`` and ``date-released`` stamped.
+
+    Citation metadata drifted from the released package once already: the file
+    carried 3.10.0 while 3.14.159 was on PyPI (#3571). It is a release artifact
+    like the manifests above, so it is stamped by the release job rather than by
+    hand.
+
+    ``date-released`` is the one field here that ``pyproject.toml`` cannot
+    supply, and a projection that reads the clock unconditionally would report
+    drift every day after a release instead of on the release. So the date is
+    rewritten only when the recorded version actually changes, and preserved
+    verbatim otherwise. That keeps this a deterministic projection of
+    ``(pyproject version, current file)``: it is idempotent, and ``--check``
+    stays a drift test rather than a clock test.
+
+    The rewrite is textual on purpose. Round-tripping this file through a YAML
+    library would reflow the folded ``abstract`` block and reorder keys, turning
+    a two-line release stamp into a whole-file diff.
+    """
+    if not _CFF_VERSION.search(current):
+        raise ManifestValidationError("CITATION.cff: no top-level 'version:' field to stamp")
+    if not _CFF_DATE_RELEASED.search(current):
+        raise ManifestValidationError("CITATION.cff: no top-level 'date-released:' field to stamp")
+
+    recorded = _cff_value(_CFF_VERSION, current)
+    rendered = _CFF_VERSION.sub(f'version: "{version}"', current, count=1)
+    if recorded != version:
+        rendered = _CFF_DATE_RELEASED.sub(f'date-released: "{today}"', rendered, count=1)
+    return rendered
+
+
+def _cff_value(pattern: re.Pattern[str], text: str) -> str:
+    """Return the scalar value of the ``CITATION.cff`` key *pattern* matches."""
+    match = pattern.search(text)
+    if match is None:  # pragma: no cover - callers check first
+        return ""
+    return match.group(0).split(":", 1)[1].strip().strip("\"'")
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -298,6 +362,11 @@ def main(argv: list[str] | None = None) -> int:
             PLUGIN_JSON: render_plugin_json(version),
             ROOT_PLUGIN_JSON: render_root_plugin_json(version),
             ROOT_MCP_JSON: render_root_mcp_json(),
+            CITATION_CFF: render_citation_cff(
+                version,
+                CITATION_CFF.read_text(encoding="utf-8") if CITATION_CFF.is_file() else "",
+                today=release_date(),
+            ),
         }
     except ManifestValidationError as exc:
         # Schema-invalid projections must fail generation and --check alike,

--- a/scripts/gen_distribution_manifests.py
+++ b/scripts/gen_distribution_manifests.py
@@ -28,7 +28,7 @@ import os
 import re
 import sys
 import tomllib
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
@@ -326,15 +326,44 @@ def render_citation_cff(version: str, current: str, *, today: str) -> str:
     library would reflow the folded ``abstract`` block and reorder keys, turning
     a two-line release stamp into a whole-file diff.
     """
-    if not _CFF_VERSION.search(current):
-        raise ManifestValidationError("CITATION.cff: no top-level 'version:' field to stamp")
-    if not _CFF_DATE_RELEASED.search(current):
-        raise ManifestValidationError("CITATION.cff: no top-level 'date-released:' field to stamp")
+    # Substituting the first match only stamps the first match. A file with two
+    # top-level ``version:`` keys would keep the stale one, and the projection
+    # would then agree with itself while the artifact stayed wrong -- so a
+    # document this rewrite cannot fully own is rejected rather than half-stamped.
+    for label, pattern in (("version", _CFF_VERSION), ("date-released", _CFF_DATE_RELEASED)):
+        occurrences = len(pattern.findall(current))
+        if occurrences != 1:
+            raise ManifestValidationError(
+                f"CITATION.cff: expected exactly one top-level '{label}:' key, found {occurrences}"
+            )
+        # A key that opens a block (``version:`` followed by list items) leaves an
+        # empty value on its own line. Stamping that line would produce a scalar
+        # and orphan the block underneath it -- a file that is no longer valid
+        # YAML but that this projection would then consider in sync.
+        if not _cff_value(pattern, current):
+            raise ManifestValidationError(
+                f"CITATION.cff: '{label}' is not a scalar; stamping it would leave its block behind"
+            )
 
     recorded = _cff_value(_CFF_VERSION, current)
     rendered = _CFF_VERSION.sub(f'version: "{version}"', current, count=1)
     if recorded != version:
         rendered = _CFF_DATE_RELEASED.sub(f'date-released: "{today}"', rendered, count=1)
+
+    # Validate what was produced, not what was intended. A non-scalar key
+    # (``version:`` followed by an indented block) leaves an empty value behind,
+    # and a hand-edited ``date-released`` can be a date only by appearance.
+    if _cff_value(_CFF_VERSION, rendered) != version:
+        raise ManifestValidationError(
+            f"CITATION.cff: 'version' did not stamp to {version!r}; the key is probably not a scalar"
+        )
+    stamped_date = _cff_value(_CFF_DATE_RELEASED, rendered)
+    try:
+        date.fromisoformat(stamped_date)
+    except ValueError as exc:
+        raise ManifestValidationError(
+            f"CITATION.cff: 'date-released' is not an ISO 8601 date: {stamped_date!r}"
+        ) from exc
     return rendered
 
 
@@ -344,6 +373,24 @@ def _cff_value(pattern: re.Pattern[str], text: str) -> str:
     if match is None:  # pragma: no cover - callers check first
         return ""
     return match.group(0).split(":", 1)[1].strip().strip("\"'")
+
+
+def _restore_replaced(replaced: dict[Path, str | None]) -> None:
+    """Put back the bytes a failed run replaced.
+
+    ``None`` means the file did not exist before this run, so restoring it means
+    removing it again rather than writing an empty file.
+    """
+    for path, previous in replaced.items():
+        if previous is None:
+            path.unlink(missing_ok=True)
+        else:
+            path.write_text(previous, encoding="utf-8")
+        # Reporting must not be able to raise here: this runs while recovering
+        # from a failure, and an exception mid-restore leaves exactly the
+        # half-rewritten tree the restore exists to prevent.
+        label = path.relative_to(REPO) if path.is_relative_to(REPO) else path
+        print(f"restored {label}", file=sys.stderr)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -375,6 +422,7 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     drift: list[str] = []
+    replaced: dict[Path, str | None] = {}
     for path, rendered in targets.items():
         current = path.read_text(encoding="utf-8") if path.is_file() else ""
         if current == rendered:
@@ -382,6 +430,7 @@ def main(argv: list[str] | None = None) -> int:
         if args.check:
             drift.append(str(path.relative_to(REPO)))
         else:
+            replaced[path] = current if path.is_file() else None
             path.write_text(rendered, encoding="utf-8")
             print(f"regenerated {path.relative_to(REPO)} (version {version})")
 
@@ -402,6 +451,13 @@ def main(argv: list[str] | None = None) -> int:
     # server.json (already regenerated above in write mode).
     provenance = _load_image_provenance().verify_signed_image_provenance(repo_root=REPO, version=version)
     if not provenance.ok:
+        # Provenance reads the regenerated server.json, so the write has to
+        # happen before the check can run. When the check then fails, a
+        # half-rewritten tree is worse than either clean outcome: the manifests
+        # would disagree about which version is being released, and the next
+        # run would find no drift and report itself in sync. Put back what this
+        # run replaced, so the failure leaves the tree where it found it.
+        _restore_replaced(replaced)
         print(f"signed-image provenance mismatch: {provenance.reason}", file=sys.stderr)
         return 1
 

--- a/tests/unit/test_bernstein_pr_review_workflow_yaml.py
+++ b/tests/unit/test_bernstein_pr_review_workflow_yaml.py
@@ -126,3 +126,58 @@ def test_label_gated_review_also_triggers_on_labeled(workflow: Workflow) -> None
     assert "labeled" in types, (
         f"the review job is gated on the 'deep-review' label, so 'labeled' must be a trigger type; got {types}"
     )
+
+
+def test_skipped_review_is_distinguishable_at_the_merge_decision(workflow: Workflow) -> None:
+    """A run that reviewed nothing must not present as a run that found nothing.
+
+    GitHub withholds secrets from ``pull_request`` runs on fork branches, so the
+    review cannot run for any external contribution (#3601). What must not
+    happen is that the resulting check looks identical to a completed review:
+    the check name is the only thing a reviewer reads before merging, so it is
+    the surface that has to carry the outcome.
+    """
+    review = cast(dict[str, object], cast(dict[str, object], workflow["jobs"])["review"])
+    name = str(review.get("name", ""))
+
+    assert "github.event.pull_request.head.repo.fork" in name, (
+        "the check name must branch on whether the PR head lives in a fork, "
+        f"otherwise a skipped review is indistinguishable from a completed one; got {name!r}"
+    )
+    assert "did not run" in name, f"the fork-PR check name must state that no review ran; got {name!r}"
+
+
+def test_skip_reason_names_the_cause_and_fails_a_same_repo_misconfiguration(
+    review_steps: list[WorkflowStep],
+) -> None:
+    """The two skip causes are different failures and must not share an outcome.
+
+    A fork PR is a platform rule -- nothing is wrong with the repository, so the
+    job reports the fact and succeeds. An empty key on a same-repository PR is a
+    missing secret, which is the maintainer's to fix, so it fails instead of
+    reporting a green check that no one can tell apart from a real review.
+    """
+    check = _step_named(review_steps, "Check API key")
+    env = check.get("env", {})
+    assert isinstance(env, dict)
+    assert env.get("IS_FORK") == "${{ github.event.pull_request.head.repo.fork }}", (
+        "the check step needs the fork flag to tell the two causes apart"
+    )
+
+    run = check.get("run", "")
+    assert isinstance(run, str)
+
+    assert "fork" in run.lower(), "the skip reason must name the cause, not only the symptom"
+    assert "ANTHROPIC_API_KEY" in run
+    assert "GITHUB_STEP_SUMMARY" in run, "the fork skip must be recorded where a reader can find it"
+    assert "::warning" in run, "a skipped review must annotate the run, not pass silently"
+
+    lines = [line.strip() for line in run.strip().splitlines() if line.strip()]
+    assert lines[-1] == "exit 1", (
+        "an empty ANTHROPIC_API_KEY on a same-repository PR is a missing secret and must fail "
+        f"the job, so the check step has to end on a non-zero exit; it ends on {lines[-1]!r}"
+    )
+
+    fork_guard = [index for index, line in enumerate(lines) if line.startswith('if [ "$IS_FORK"')]
+    assert fork_guard, "expected an explicit fork branch in the check step"
+    assert "exit 0" in lines[fork_guard[0] :], "a fork PR must not be reddened for a platform rule"

--- a/tests/unit/test_distribution_manifests.py
+++ b/tests/unit/test_distribution_manifests.py
@@ -167,6 +167,70 @@ def test_citation_cff_stamp_rejects_a_file_it_cannot_stamp() -> None:
         module.render_citation_cff("3.14.159", 'cff-version: 1.2.0\nversion: "3.10.0"\n', today="2026-08-10")
 
 
+def test_citation_cff_stamp_rejects_a_document_it_cannot_fully_own() -> None:
+    """A duplicate top-level key would leave a stale value the stamp never touched.
+
+    ``re.sub(..., count=1)`` stamps the first match. With two ``version:`` keys
+    the second keeps the old value, the projection then agrees with itself, and
+    ``--check`` reports in sync while the artifact is wrong.
+    """
+    module = _gen_module()
+    doubled = _CITATION_SAMPLE + 'version: "3.10.0"\n'
+
+    with pytest.raises(module.ManifestValidationError, match="exactly one"):
+        module.render_citation_cff("3.14.159", doubled, today="2026-08-10")
+
+
+def test_citation_cff_stamp_rejects_a_non_scalar_version() -> None:
+    """``version:`` opening a block leaves nothing for the stamp to replace."""
+    module = _gen_module()
+    block = 'cff-version: 1.2.0\nversion:\n  - "3.10.0"\ndate-released: "2026-07-26"\n'
+
+    with pytest.raises(module.ManifestValidationError, match="not a scalar"):
+        module.render_citation_cff("3.14.159", block, today="2026-08-10")
+
+
+def test_citation_cff_stamp_rejects_a_date_that_only_looks_like_one() -> None:
+    """A preserved ``date-released`` is still validated, not trusted."""
+    module = _gen_module()
+    bad = 'cff-version: 1.2.0\nversion: "3.14.159"\ndate-released: "last Tuesday"\n'
+
+    with pytest.raises(module.ManifestValidationError, match="ISO 8601"):
+        module.render_citation_cff("3.14.159", bad, today="2026-08-10")
+
+
+def test_failed_provenance_puts_back_every_file_the_run_replaced(tmp_path: Path) -> None:
+    """A failed release gate must not leave the tree half-rewritten.
+
+    Provenance is verified against the regenerated ``server.json``, so the write
+    happens first. If the check then fails and the new bytes stay, the manifests
+    disagree about which version is being released -- and the next run finds no
+    drift and reports itself in sync.
+    """
+    module = _gen_module()
+
+    existing = tmp_path / "server.json"
+    existing.write_text('{"version": "3.10.0"}\n', encoding="utf-8")
+    created = tmp_path / "mcp.json"
+    created.write_text("new content\n", encoding="utf-8")
+
+    module._restore_replaced({existing: '{"version": "3.10.0"}\n', created: None})
+
+    assert existing.read_text(encoding="utf-8") == '{"version": "3.10.0"}\n'
+    assert not created.exists(), "a file this run created must be removed, not left empty"
+
+
+def test_provenance_failure_restores_before_it_returns() -> None:
+    """Pins the ordering the previous test cannot observe from outside."""
+    source = (_REPO / "scripts" / "gen_distribution_manifests.py").read_text(encoding="utf-8")
+
+    branch = source.partition("if not provenance.ok:")[2].partition("return 1")[0]
+    assert branch, "expected a provenance failure branch in main()"
+    assert "_restore_replaced(replaced)" in branch, (
+        "the provenance failure path must put back what the write phase replaced"
+    )
+
+
 def test_repository_citation_cff_matches_the_package_version() -> None:
     """The checked-in file must already be stamped, or ``--check`` fails the release."""
     module = _gen_module()

--- a/tests/unit/test_distribution_manifests.py
+++ b/tests/unit/test_distribution_manifests.py
@@ -23,6 +23,8 @@ import sys
 import tomllib
 from pathlib import Path
 
+import pytest
+
 _REPO = Path(__file__).resolve().parents[2]
 
 
@@ -102,6 +104,75 @@ def test_render_server_json_retags_oci_identifier_on_version_bump() -> None:
     assert packages["oci"]["identifier"] == "ghcr.io/sipyourdrink-ltd/bernstein:9.9.9"
     assert "version" not in packages["oci"]
     assert packages["pypi"]["version"] == "9.9.9"
+
+
+def _gen_module() -> object:
+    spec = importlib.util.spec_from_file_location(
+        "gen_distribution_manifests",
+        _REPO / "scripts" / "gen_distribution_manifests.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_CITATION_SAMPLE = """cff-version: 1.2.0
+title: "Bernstein"
+abstract: >-
+  A folded block that a YAML round-trip would reflow.
+version: "3.10.0"
+date-released: "2026-07-26"
+preferred-citation:
+  type: software
+  year: 2026
+"""
+
+
+def test_citation_cff_is_stamped_from_the_package_version() -> None:
+    """A CITATION.cff behind the released version is drift, not a style nit.
+
+    It shipped 3.10.0 while 3.14.159 was on PyPI (#3571), so anyone citing the
+    project from the repository cited a version that was four releases old.
+    """
+    module = _gen_module()
+
+    stamped = module.render_citation_cff("3.14.159", _CITATION_SAMPLE, today="2026-08-10")
+
+    assert 'version: "3.14.159"' in stamped
+    assert 'date-released: "2026-08-10"' in stamped
+    assert "cff-version: 1.2.0" in stamped, "cff-version is a different key and must survive"
+    assert "abstract: >-" in stamped, "the folded block must not be reflowed by the stamp"
+    assert "  year: 2026" in stamped, "indented keys under preferred-citation are not top level"
+
+
+def test_citation_cff_stamp_preserves_the_date_when_the_version_is_current() -> None:
+    """Re-running on a matching version must not move date-released to today.
+
+    ``--check`` compares the rendered projection against the file on disk. If
+    the date tracked the clock, every day after a release would report drift and
+    the gate would be noise within a week.
+    """
+    module = _gen_module()
+
+    stamped = module.render_citation_cff("3.10.0", _CITATION_SAMPLE, today="2099-01-01")
+
+    assert stamped == _CITATION_SAMPLE, "a matching version must render byte-identically"
+
+
+def test_citation_cff_stamp_rejects_a_file_it_cannot_stamp() -> None:
+    module = _gen_module()
+
+    with pytest.raises(module.ManifestValidationError, match="date-released"):
+        module.render_citation_cff("3.14.159", 'cff-version: 1.2.0\nversion: "3.10.0"\n', today="2026-08-10")
+
+
+def test_repository_citation_cff_matches_the_package_version() -> None:
+    """The checked-in file must already be stamped, or ``--check`` fails the release."""
+    module = _gen_module()
+
+    current = (_REPO / "CITATION.cff").read_text(encoding="utf-8")
+    assert f'version: "{module.pyproject_version()}"' in current
 
 
 def test_gen_script_check_mode_passes_and_is_idempotent(tmp_path: Path) -> None:

--- a/tests/unit/test_homebrew_formula.py
+++ b/tests/unit/test_homebrew_formula.py
@@ -1,0 +1,106 @@
+"""The published Homebrew formula must install a working command (#3573).
+
+`brew install chernistry/tap/bernstein` succeeded and produced a `bernstein`
+that died on `import click`, because the formula called
+``virtualenv_install_with_resources`` while declaring no ``resource`` blocks --
+Homebrew drives that helper with ``pip --no-deps``, so nothing but bernstein
+itself was installed.
+
+The reason a broken formula could survive a fix is the second defect pinned
+here: the publish workflow used to carry its own inline copy of the formula, so
+``packaging/homebrew/bernstein.rb`` could be corrected without any effect on
+what reached the tap. These tests keep the template honest and keep it the only
+copy.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[2]
+FORMULA = _REPO / "packaging" / "homebrew" / "bernstein.rb"
+PUBLISH_WORKFLOW = _REPO / ".github" / "workflows" / "publish-homebrew.yml"
+
+
+def _code(body: str) -> str:
+    """Return the formula source with comment lines dropped.
+
+    The formula documents why it does not use ``virtualenv_install_with_resources``,
+    so a naive substring search would match the explanation and fail the fix.
+    """
+    return "\n".join(line for line in body.splitlines() if not line.lstrip().startswith("#"))
+
+
+def test_formula_does_not_install_without_dependencies() -> None:
+    """``virtualenv_install_with_resources`` with no resources installs nothing."""
+    body = _code(FORMULA.read_text(encoding="utf-8"))
+
+    if "virtualenv_install_with_resources" in body:
+        resources = re.findall(r"^\s*resource\s+\"", body, re.MULTILINE)
+        assert resources, (
+            "virtualenv_install_with_resources runs pip with --no-deps, so a formula "
+            "using it must declare the runtime closure as `resource` blocks; this one "
+            "declares none, which is exactly the install that shipped a bernstein "
+            "that could not import click"
+        )
+
+
+def test_formula_installs_the_runtime_closure() -> None:
+    """Whatever the strategy, the install step has to resolve dependencies."""
+    body = _code(FORMULA.read_text(encoding="utf-8"))
+
+    install = body.partition("def install")[2].partition("end")[0]
+    assert install.strip(), "the formula must define an install step"
+    assert "--no-deps" not in install, "the install must not skip the runtime closure"
+
+    declares_resources = bool(re.findall(r"^\s*resource\s+\"", body, re.MULTILINE))
+    resolves_at_install = "pip" in install and "install" in install
+    assert declares_resources or resolves_at_install, (
+        "the formula must either pin the closure as resources or let pip resolve it"
+    )
+
+
+def test_formula_binary_is_linked_onto_the_path() -> None:
+    body = FORMULA.read_text(encoding="utf-8")
+    install = body.partition("def install")[2].partition("end")[0]
+
+    if "virtualenv_install_with_resources" not in install:
+        assert "bin.install_symlink" in install or "bin.install" in install, (
+            "a hand-rolled virtualenv install has to link the entry point into bin/, "
+            "otherwise `brew install` reports success and leaves no `bernstein` command"
+        )
+
+
+def test_publish_workflow_ships_the_checked_in_template() -> None:
+    """One copy of the formula, or a fix to the template never reaches users."""
+    workflow = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "packaging/homebrew/bernstein.rb" in workflow, (
+        "the publish workflow must read the checked-in formula template"
+    )
+    assert "class Bernstein < Formula" not in workflow, (
+        "the publish workflow must not carry its own copy of the formula body; that "
+        "copy is what shipped while the template was being corrected"
+    )
+
+
+def test_publish_workflow_substitutes_the_placeholders_the_template_uses() -> None:
+    """The template's placeholders and the workflow's substitutions must agree."""
+    body = FORMULA.read_text(encoding="utf-8")
+    workflow = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "bernstein-VERSION.tar.gz" in body, "template must carry the version placeholder"
+    assert 'sha256 "PLACEHOLDER"' in body, "template must carry the digest placeholder"
+
+    assert "bernstein-VERSION.tar.gz" in workflow, "workflow must substitute the version placeholder"
+    assert "PLACEHOLDER" in workflow, "workflow must substitute the digest placeholder"
+
+
+def test_publish_workflow_refuses_an_unresolved_digest() -> None:
+    """An empty sha256 must fail the publish, not ship a formula nobody can install."""
+    workflow = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
+
+    guard = workflow.partition('if [ -z "$META_SHA256" ]')[2]
+    assert guard, "the publish step must guard against an unresolved PyPI digest"
+    assert "exit 1" in guard.partition("fi")[0], "an unresolved digest must fail the job"

--- a/tests/unit/test_homebrew_formula.py
+++ b/tests/unit/test_homebrew_formula.py
@@ -136,10 +136,85 @@ def test_publish_workflow_validates_the_version_before_building_a_url() -> None:
     """
     code = _code(PUBLISH_WORKFLOW.read_text(encoding="utf-8"))
 
-    version_check = code.partition("is not a release version")[0]
+    version_check = code.partition(_UNRECOGNISED_MESSAGE)[0]
     assert "grep -Eq" in version_check, "the version must be shape-checked before it reaches the URL"
 
     before_url = code.partition('URL="https://files.pythonhosted.org')[0]
-    assert "is not a release version" in before_url, (
+    assert _UNRECOGNISED_MESSAGE in before_url, (
         "the version check must run before the URL that interpolates it is built"
+    )
+
+
+# --------------------------------------------------------------------------
+# Which versions the workflow recognises, and which it publishes (#3626)
+# --------------------------------------------------------------------------
+
+_UNRECOGNISED_MESSAGE = "is not a version this project's release tooling can produce"
+_BUMP_SCRIPT = _REPO / "scripts" / "bump_version.py"
+_GREP_PATTERN = re.compile(r"grep -Eq '(\^\[0-9\][^']+)'")
+_BUMP_SEMVER = re.compile(r"^_SEMVER_RE = re\.compile\(r\"(.+)\"\)$", re.MULTILINE)
+
+# Versions scripts/bump_version.py accepts, so publish.yml can dispatch them.
+_BUMPABLE = ("3.15.0", "3.15.0.dev1", "3.15.0.post1", "3.15.0-rc1", "3.15.0+local.1")
+# Canonical PEP 440 pre-releases, which arrive from a hand-pushed tag.
+_TAGGABLE = ("3.15.0a1", "3.15.0b2", "3.15.0rc1")
+# Values workflow_dispatch's `required: true` still lets through.
+_JUNK = ("latest", "v3.15.0", "3.15", "3.15.0 ", " 3.15.0", "", "main")
+
+
+def _workflow_patterns() -> tuple[re.Pattern[str], re.Pattern[str]]:
+    """The recognise-then-publish pair, in the order the workflow applies them."""
+    found = _GREP_PATTERN.findall(_code(PUBLISH_WORKFLOW.read_text(encoding="utf-8")))
+    assert len(found) == 2, f"expected a recognise and a publish pattern, found {found}"
+    return re.compile(found[0]), re.compile(found[1])
+
+
+def test_every_version_the_bump_script_produces_is_recognised() -> None:
+    """A legitimate release must not fail this workflow, only skip it.
+
+    publish.yml dispatches `${TAG#v}` for whatever tag was released, so a
+    recognise-rule narrower than what scripts/bump_version.py accepts turns a
+    deliberate pre-release into a red run.
+    """
+    recognise, _ = _workflow_patterns()
+    bump = _BUMP_SEMVER.search(_BUMP_SCRIPT.read_text(encoding="utf-8"))
+    assert bump is not None, "scripts/bump_version.py no longer declares _SEMVER_RE"
+    bumpable = re.compile(bump.group(1))
+
+    for version in _BUMPABLE:
+        assert bumpable.match(version), f"corpus is stale: bump_version.py rejects {version!r}"
+        assert recognise.match(version), f"{version!r} is bumpable but the workflow errors on it"
+    for version in _TAGGABLE:
+        assert recognise.match(version), f"{version!r} is a valid tag but the workflow errors on it"
+
+
+def test_a_hand_typed_dispatch_value_is_still_rejected() -> None:
+    recognise, _ = _workflow_patterns()
+
+    for value in _JUNK:
+        assert not recognise.match(value), f"{value!r} must not be treated as a version"
+
+
+def test_only_final_releases_reach_the_tap() -> None:
+    """A stable formula that tracks a dev or pre-release version is a broken tap."""
+    recognise, publish = _workflow_patterns()
+
+    assert publish.match("3.15.0")
+    for version in (*_BUMPABLE[1:], *_TAGGABLE):
+        assert recognise.match(version), f"{version!r} must be recognised"
+        assert not publish.match(version), f"{version!r} must not be published to the tap"
+
+
+def test_a_skipped_version_stops_the_publishing_steps() -> None:
+    """`exit 0` ends the step, not the job -- the later steps need the guard.
+
+    Without it they run with an empty ``steps.meta.outputs.version`` and push a
+    formula pinned to a release that does not exist.
+    """
+    body = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
+    code = _code(body)
+
+    assert 'echo "skip=true" >> "$GITHUB_OUTPUT"' in code, "the skip path must record itself as an output"
+    assert code.count("steps.meta.outputs.skip != 'true'") == 2, (
+        "both the formula generation and the tap push must be guarded on the skip output"
     )

--- a/tests/unit/test_homebrew_formula.py
+++ b/tests/unit/test_homebrew_formula.py
@@ -104,3 +104,42 @@ def test_publish_workflow_refuses_an_unresolved_digest() -> None:
     guard = workflow.partition('if [ -z "$META_SHA256" ]')[2]
     assert guard, "the publish step must guard against an unresolved PyPI digest"
     assert "exit 1" in guard.partition("fi")[0], "an unresolved digest must fail the job"
+
+
+def test_publish_workflow_hashes_the_sdist_and_not_an_error_body() -> None:
+    """``curl -sL`` exits 0 on an HTTP error and prints the error page.
+
+    Piping that into ``sha256sum`` yields a digest that is neither empty nor the
+    empty-file digest, so it cleared every previous guard -- and the formula
+    would ship a ``sha256`` that disagrees with its own ``url``, failing every
+    ``brew install`` at checksum verification.
+    """
+    code = _code(PUBLISH_WORKFLOW.read_text(encoding="utf-8"))
+
+    assert "curl -sL" not in code, "the sdist fetch must not ignore HTTP status"
+    assert "--fail" in code, "the sdist fetch must fail on an HTTP error instead of hashing the body"
+    assert "gzip --test" in code, "the downloaded bytes must be confirmed to be a gzip stream before hashing"
+
+    digest_lines = [line for line in code.splitlines() if "sha256sum" in line]
+    assert digest_lines, "the workflow must compute a digest"
+    assert all("/tmp/sdist.tar.gz" in line for line in digest_lines), (
+        "the digest must be taken from the downloaded file, not from a pipe off curl"
+    )
+
+
+def test_publish_workflow_validates_the_version_before_building_a_url() -> None:
+    """``required: true`` on a dispatch input only means "not omitted".
+
+    The value is interpolated into the sdist URL and into the published formula,
+    so ``latest`` or a stray space becomes a formula pinned to a release that
+    does not exist.
+    """
+    code = _code(PUBLISH_WORKFLOW.read_text(encoding="utf-8"))
+
+    version_check = code.partition("is not a release version")[0]
+    assert "grep -Eq" in version_check, "the version must be shape-checked before it reaches the URL"
+
+    before_url = code.partition('URL="https://files.pythonhosted.org')[0]
+    assert "is not a release version" in before_url, (
+        "the version check must run before the URL that interpolates it is built"
+    )


### PR DESCRIPTION
# User description
Closes #3573. Closes #3571. Closes #3601.

Three separate gates that reported an outcome other than the one that happened. Grouped because they are the same defect class and each is small; they touch disjoint files and can be read independently.

## Homebrew installs a command that cannot start (#3573)

`brew install chernistry/tap/bernstein` succeeded and produced a `bernstein` that died on `import click`. The formula called `virtualenv_install_with_resources` while declaring no `resource` blocks, and Homebrew drives that helper with `pip --no-deps`, so nothing but bernstein itself was installed.

The formula now creates its own virtualenv and lets pip resolve the runtime closure, with `--prefer-binary` so the install stays on wheels.

**Why not resources.** Canonical Homebrew style is to declare the closure as `resource` blocks. That was tried and rejected on evidence: the closure is 81 packages including four Rust builds (`pydantic-core`, `rpds-py`, `jiter`, `cryptography`) plus `grpcio`, `lxml` and `pillow`, so sdist-backed resources turn `brew install` into an hour-plus source build needing rust and cmake — and they have to be regenerated every release by `brew update-python-resources`, which is currently broken against modern pip (it sends `--uploaded-prior-to=P1D`, which pip rejects as not an ISO 8601 datetime).

The trade-off is real and is stated in the formula: transitive versions resolve at install time rather than being pinned in the formula. bernstein itself stays pinned and hash-verified — Homebrew checks `sha256` against the staged sdist, and that sdist is what gets installed.

**Verified, not argued.** Run in a clean `homebrew/brew:latest` container against the real 3.14.159 sdist:

```
==> Installing local/test/bernstein
🍺  /home/linuxbrew/.linuxbrew/Cellar/bernstein/3.14.159: 14,017 files, 229.2MB, built in 1 minute 21 seconds
== the actual defect: does the installed command run ==
bernstein, version 3.14.159
RC=0
```

First attempt failed, which is worth recording: `virtualenv_create` builds the venv `--without-pip --system-site-packages`, so there is no `libexec/bin/pip` to call and pip has to be reached as a module through the venv interpreter.

## The formula fix would not have reached anyone (same PR, root cause)

`publish-homebrew.yml` carried a second copy of the formula inline in a heredoc, and that copy is what reached the tap. The two had already drifted: the checked-in template carried a comment saying the install strategy was broken, while the heredoc kept shipping it. Correcting the template was a no-op by construction.

The workflow now substitutes only version and digest into `packaging/homebrew/bernstein.rb`. It also fails instead of publishing when the PyPI digest never resolved — the digest step gives up after five attempts and previously left the substitution empty, which would have published a formula with an empty `sha256`.

## Citation metadata drifts from the release (#3571)

`CITATION.cff` recorded 3.10.0 while 3.14.159 was on PyPI, so anyone citing the project from the repository cited a version four releases old. It is now stamped by `gen_distribution_manifests.py` next to the other release manifests, which means `--check` — already wired into the unit suite and the publish workflow — fails on drift.

`date-released` is the one field `pyproject.toml` cannot supply. It is rewritten only when the recorded version actually changes, and preserved verbatim otherwise. A projection that read the clock unconditionally would report drift every day after a release instead of on the release, and the gate would be noise inside a week. Keeping it conditional also keeps the projection deterministic and idempotent, which is what lets `--check` diff rather than trust.

The rewrite is textual on purpose: round-tripping the file through a YAML library reflows the folded `abstract` block and reorders keys, turning a two-line release stamp into a whole-file diff.

## A review that never ran reports the same green as one that found nothing (#3601)

The `Review with Bernstein` job reported success on runs where checkout, diff fetch and review were all skipped. GitHub withholds repository secrets from `pull_request` runs on fork branches, so `ANTHROPIC_API_KEY` is empty for every external contribution — the population where the check is most likely to be read as evidence by whoever merges.

The platform rule is not worked around. Reviewing untrusted head code with a credential in scope is the risk `pull_request` exists to avoid, and `pull_request_target` would hand the credential exactly the diff it must not be given. That part stays as it is, and is now written down in the workflow rather than being an unstated consequence.

What changes is the signal. The two skip causes are separated because they are different failures:

| Cause | Outcome |
|---|---|
| Fork PR, credential withheld by the platform | The check name says the review did not run, and the run summary names the reason. The job still succeeds — reddening every external contribution punishes the contributor for a platform rule. |
| Same-repository PR, secret absent | The job fails. There the secret is genuinely missing and that is ours to fix. |

The check name carries it because that is the only surface this job controls that a reviewer sees without opening the run.

## Tests

10 new tests, each failing before the change and passing after — verified by stashing the source changes and re-running:

```
FAILED test_homebrew_formula.py::test_formula_does_not_install_without_dependencies
FAILED test_homebrew_formula.py::test_formula_installs_the_runtime_closure
FAILED test_homebrew_formula.py::test_publish_workflow_ships_the_checked_in_template
FAILED test_homebrew_formula.py::test_publish_workflow_substitutes_the_placeholders_the_template_uses
FAILED test_homebrew_formula.py::test_publish_workflow_refuses_an_unresolved_digest
FAILED test_bernstein_pr_review_workflow_yaml.py::test_skipped_review_is_distinguishable_at_the_merge_decision
FAILED test_bernstein_pr_review_workflow_yaml.py::test_skip_reason_names_the_cause_and_fails_a_same_repo_misconfiguration
FAILED test_distribution_manifests.py::test_citation_cff_is_stamped_from_the_package_version
FAILED test_distribution_manifests.py::test_citation_cff_stamp_preserves_the_date_when_the_version_is_current
FAILED test_distribution_manifests.py::test_citation_cff_stamp_rejects_a_file_it_cannot_stamp
10 failed, 26 passed
```

After: `36 passed`. `gen_distribution_manifests.py --check` in sync, `gen_workflow_topology.py` regenerated, ruff check and format clean.

## Follow-up that is not in this PR

The live tap still carries the old formula. Once this merges, `publish-homebrew.yml` needs a `workflow_dispatch` at 3.14.159 to push the corrected formula, and I will re-run the container test against `chernistry/tap` rather than a local tap before considering the channel proven. The install doc is updated in this PR on the strength of the verified formula; if the live-tap run disagrees, that is a fix-forward and the doc goes back.

One thing the container run did not exercise: #3573 reports that current Homebrew refuses formulae from untrusted third-party taps until `brew trust chernistry/tap` has been run. The test used a local tap created with `brew tap-new`, which does not go through that path, so the install doc does not claim a trust step yet. It gets added if the live-tap run needs it.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Fix Homebrew packaging and release-manifest generation so Bernstein installs with its runtime dependencies and <code>CITATION.cff</code> tracks releases deterministically. Distinguish skipped Bernstein reviews from successful reviews and fail same-repository secret misconfigurations through workflow signaling.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3626?tool=ast&topic=Review+gate+signal>Review gate signal</a>
        </td><td>Clarify when <code>Review with Bernstein</code> did not run for fork pull requests, while failing when a same-repository review lacks its required credential.<details><summary>Modified files (3)</summary><ul><li>.github/workflows/bernstein-pr-review.yml</li>
<li>docs/operations/ci-topology.md</li>
<li>tests/unit/test_bernstein_pr_review_workflow_yaml.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>sanderchernitsky@gmail...</td><td>fix: make three releas...</td><td>August 11, 2026</td></tr>
<tr><td>chernistry</td><td>fix(ci): start the lab...</td><td>August 11, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3626?tool=ast&topic=Release+integrity>Release integrity</a>
        </td><td>Repair the Homebrew formula and publishing workflow to resolve runtime dependencies, use the checked-in template, validate release inputs and digests, and expose citation metadata as a deterministic release artifact.<details><summary>Modified files (6)</summary><ul><li>.github/workflows/publish-homebrew.yml</li>
<li>docs/getting-started/install.md</li>
<li>packaging/homebrew/bernstein.rb</li>
<li>scripts/gen_distribution_manifests.py</li>
<li>tests/unit/test_distribution_manifests.py</li>
<li>tests/unit/test_homebrew_formula.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>fix: recognise every r...</td><td>August 11, 2026</td></tr>
<tr><td>sanderchernitsky@gmail...</td><td>fix: close four review...</td><td>August 11, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3626?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>