### PR TITLE
fix(plan): reject non-string files entries

### DIFF
--- a/src/bernstein/core/planning/plan_loader.py
+++ b/src/bernstein/core/planning/plan_loader.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import yaml
 
@@ -208,6 +208,40 @@ def _parse_int_field(
     return raw
 
 
+def _parse_string_list_field(raw: object, field_name: str, stage_name: str, step_idx: int) -> list[str]:
+    """Parse an optional list-of-strings step field.
+
+    Args:
+        raw: Raw field value from the YAML step.
+        field_name: Step field name, for error context.
+        stage_name: Stage name for error context.
+        step_idx: Zero-based step index for error context.
+
+    Returns:
+        The string items, or an empty list when the field is absent.
+
+    Raises:
+        PlanLoadError: If the field is present but not a list, or if any list
+            item is not a string.
+    """
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        raise PlanLoadError(
+            f"Step {step_idx} in stage {stage_name!r}: {field_name!r} must be a list of paths, got {type(raw).__name__}"
+        )
+    items = cast(list[object], raw)
+    parsed: list[str] = []
+    for item_idx, item in enumerate(items):
+        if not isinstance(item, str):
+            raise PlanLoadError(
+                f"Step {step_idx} in stage {stage_name!r}: {field_name}[{item_idx}] "
+                f"must be a string, got {type(item).__name__}"
+            )
+        parsed.append(item)
+    return parsed
+
+
 def load_plan(path: Path) -> tuple[PlanConfig, list[Task]]:
     """Load a YAML plan file and return plan-level config plus a list of Task objects.
 
@@ -361,19 +395,10 @@ def _parse_step(
 
     raw_signals: list[object] = list(step.get("completion_signals") or [])
     signals = _parse_completion_signals(raw_signals)
-    # Reject scalar / non-list shapes so a YAML typo like ``files: ./mod.py``
-    # does not silently iterate the string character-by-character -- the same
-    # boundary the CLI pre-check (validate_plan) enforces (#3516).
-    raw_files = step.get("files")
-    if raw_files is None:
-        owned_files: list[str] = []
-    elif isinstance(raw_files, list):
-        owned_files = [str(f) for f in raw_files]
-    else:
-        raise PlanLoadError(
-            f"Step {step_index} in stage {stage_name!r}: 'files' must be a "
-            f"list of paths, got {type(raw_files).__name__}"
-        )
+    # Reject scalar / non-list shapes and non-string items so direct loads
+    # match the CLI pre-check (validate_plan) boundary for list[string] fields.
+    raw_files: object = step.get("files")
+    owned_files = _parse_string_list_field(raw_files, "files", stage_name, step_index)
     # Issue #1797: operator-supplied image attachments. The orchestrator
     # builds a MultiModalContext at spawn time from these paths.
     # Reject scalar / non-list shapes so a YAML typo like

--- a/tests/unit/test_plan_loader.py
+++ b/tests/unit/test_plan_loader.py
@@ -401,6 +401,36 @@ def test_step_files_maps_to_owned_files(tmp_path: Path) -> None:
     assert tasks[0].owned_files == ["src/app.py", "tests/test_app.py"]
 
 
+@pytest.mark.parametrize(
+    ("bad_file", "expected_type"),
+    [
+        (None, "NoneType"),
+        (True, "bool"),
+        (42, "int"),
+        ({"path": "src/app.py"}, "dict"),
+    ],
+)
+def test_step_files_rejects_non_string_items(tmp_path: Path, bad_file: object, expected_type: str) -> None:
+    plan_file = _write_plan(
+        tmp_path,
+        {
+            "stages": [
+                {
+                    "name": "S",
+                    "steps": [{"title": "T", "files": ["src/app.py", bad_file]}],
+                }
+            ]
+        },
+    )
+
+    with pytest.raises(PlanLoadError) as exc_info:
+        load_plan_from_yaml(plan_file)
+
+    message = str(exc_info.value)
+    assert "files[1]" in message
+    assert expected_type in message
+
+
 # ---------------------------------------------------------------------------
 # Enum-typed step fields (issue #3515)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Reject non-string entries in plan step `files` lists during direct `load_plan` parsing.

## Why

Closes #3556. `load_plan` previously coerced YAML values such as `42`, `null`, and `true` into fabricated path strings while `plan validate` rejected those same values as non-strings.

## How

Adds a shared list-of-strings parser for step fields and uses it for `files`, preserving the existing scalar/non-list rejection while rejecting invalid list items with `PlanLoadError` before tasks are created. Adds regression coverage for null, bool, number, and mapping entries.

## Validation

- `uv run pytest tests/unit/test_plan_loader.py -x -q` -> 56 passed, 1 existing StarletteDeprecationWarning
- `uv run python scripts/run_tests.py -k plan_loader -x` -> 1 file passed, 56 passed
- `uv run ruff check src/bernstein/core/planning/plan_loader.py tests/unit/test_plan_loader.py` -> passed
- `uv run ruff format --check src/bernstein/core/planning/plan_loader.py tests/unit/test_plan_loader.py` -> passed
- `uv run ruff check src/` -> passed
- `uv run lint-imports` -> passed
- `git diff --check` -> passed

Known baseline: `uv run pyright src/` fails with existing unresolved imports/unknown-type errors across adapters/TUI; `uv run pyright src/bernstein/core/planning/plan_loader.py` also reports the existing unresolved `bernstein.core.models` import and unknown-type baseline in this file.

## Checklist

- [x] `uv run ruff check src/` passes
- [ ] `uv run pyright src/` passes
- [ ] `uv run python scripts/run_tests.py -x` passes
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)

- [x] User-visible README section updated (or N/A if internal-only)
- [x] `docs/operations/<area>.md` updated (or N/A)
- [x] `docs/api/` schema regenerated if a public surface changed (or N/A)
- [x] `uv run bernstein agents-md sync` run so AGENTS.md, CLAUDE.md, `.goosehints`, `CONVENTIONS.md`, and `.cursor/rules/*.mdc` reflect any new module (or N/A)
- [x] Tests cover the documented behaviour