### PR TITLE
fix(cli): journal verifiers load strict=True, corruption fails exit 1 (#3549)

### DIFF
--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -1432,7 +1432,7 @@ def trace_verify_projection_cmd(run_id: str, workdir: str, projection_path: str 
     Rejects a span whose id was altered or whose journal entry hash is absent
     from the chain, and confirms the signature chains to the install identity.
 
-    Exit codes: 0 = OK, 1 = bad input, 2 = verification failed.
+    Exit codes: 0 = OK, 1 = bad input (incl. a corrupted journal), 2 = verification failed.
     """
     from bernstein.cli.commands.credential_cmd import (
         _load_or_create_install_key,
@@ -1443,10 +1443,17 @@ def trace_verify_projection_cmd(run_id: str, workdir: str, projection_path: str 
         projection_from_dict,
         verify_projection,
     )
-    from bernstein.core.replay.journal import load_events
+    from bernstein.core.replay.journal import JournalParseError, load_events
 
     root = Path(workdir).resolve()
-    events = load_events(_journal_path_for_run(root, run_id))
+    try:
+        events = load_events(_journal_path_for_run(root, run_id), strict=True)
+    except JournalParseError as exc:
+        # A verifier attests over the journal on disk, not a filtered
+        # sequence: a malformed row is exactly the corruption a verifier
+        # exists to surface, so refuse rather than verify a partial view.
+        console.print(f"[red]Journal corrupted:[/red] {sanitize_log(str(exc))}; refusing to verify a filtered sequence")
+        raise SystemExit(1) from exc
     if not events:
         console.print(f"[red]No event journal for run[/red] {sanitize_log(run_id)}")
         raise SystemExit(1)

--- a/src/bernstein/cli/commands/dry_run_cmd.py
+++ b/src/bernstein/cli/commands/dry_run_cmd.py
@@ -17,6 +17,10 @@ import click
 
 from bernstein.cli.helpers import console
 
+# Non-zero exit codes are operator contract (issue #3550): a plan that fails
+# to load must not look like "valid plan, nothing to schedule".
+EXIT_PLAN_ERROR = 1
+
 
 def _route_task_to_dict(
     router: Any,
@@ -82,14 +86,23 @@ def render_dry_run(
 
 
 def _render_dry_run_from_plan(workdir: Path, plan_file: Path) -> list[dict[str, Any]]:
-    """Build dry-run task list from a plan file."""
-    from bernstein.core.plan_loader import PlanLoadError, load_plan
+    """Build dry-run task list from a plan file.
 
-    try:
-        _plan_config, loaded_tasks = load_plan(plan_file)
-    except PlanLoadError as exc:
-        console.print(f"[red]Plan load error:[/red] {exc}")
-        return []
+    Args:
+        workdir: Project root directory.
+        plan_file: Plan file to load tasks from.
+
+    Returns:
+        List of task dicts with routing metadata.
+
+    Raises:
+        PlanLoadError: If the plan file cannot be loaded or parsed. Callers
+            must surface this as a non-zero exit; swallowing it would turn a
+            malformed plan into a convincing empty result.
+    """
+    from bernstein.core.plan_loader import load_plan
+
+    _plan_config, loaded_tasks = load_plan(plan_file)
 
     router = _init_router(workdir)
     result: list[dict[str, Any]] = []
@@ -159,7 +172,18 @@ def print_dry_run_expanded(
     """
     from rich.table import Table
 
-    tasks = render_dry_run(workdir, plan_file, goal)
+    from bernstein.core.plan_loader import PlanLoadError
+
+    try:
+        tasks = render_dry_run(workdir, plan_file, goal)
+    except PlanLoadError as exc:
+        # A malformed plan is a failure, not an empty backlog: exit non-zero
+        # and let the operator see the loader's message in both output modes.
+        if as_json:
+            console.print_json(json.dumps({"error": {"kind": "PlanLoadError", "message": str(exc)}}))
+        else:
+            console.print(f"[red]Plan load error:[/red] {exc}")
+        raise SystemExit(EXIT_PLAN_ERROR) from exc
 
     if as_json:
         console.print_json(json.dumps({"tasks": tasks, "total": len(tasks)}))
@@ -215,6 +239,11 @@ def dry_run_cmd(plan_file: str | None, goal: str | None, as_json: bool) -> None:
     \b
     Reads the backlog or a plan file and displays what would be executed,
     including provider routing decisions for each task.
+
+    \b
+    Exit codes:
+      0  success (including an empty backlog)
+      1  --plan file failed to load
 
     \b
     Examples:

--- a/src/bernstein/cli/commands/telemetry_cmd.py
+++ b/src/bernstein/cli/commands/telemetry_cmd.py
@@ -558,16 +558,21 @@ def telemetry_verify_span(ctx: click.Context, run_id: str, workdir: str, span_so
     whose anchor mismatches, is rejected as a forgery.
 
     Exit codes: 0 = genuine, 1 = could not be evaluated (missing journal,
-    malformed span, bad input), 2 = verification failed (forged). Same
-    convention as ``trace verify-projection``; a rejection is always a hard
-    nonzero exit, never a warning.
+    corrupted journal, malformed span, bad input), 2 = verification failed
+    (forged). Same convention as ``trace verify-projection``; a rejection
+    is always a hard nonzero exit, never a warning.
     """
     from bernstein.core.observability.otel_bridge import (
         SpanParseError,
         parse_exported_span,
         verify_exported_span,
     )
-    from bernstein.core.replay.journal import JournalPathError, load_events, run_journal_path
+    from bernstein.core.replay.journal import (
+        JournalParseError,
+        JournalPathError,
+        load_events,
+        run_journal_path,
+    )
     from bernstein.core.security.audit import load_or_create_audit_key
     from bernstein.core.security.audit_chain import EVENT_OTEL_PROJECTION, AuditChainStore
     from bernstein.core.security.sanitize import sanitize_log
@@ -588,7 +593,15 @@ def telemetry_verify_span(ctx: click.Context, run_id: str, workdir: str, span_so
         journal_path = run_journal_path(root / ".sdd", run_id)
     except JournalPathError as exc:
         raise click.ClickException(sanitize_log(str(exc))) from exc
-    events = load_events(journal_path)
+    try:
+        events = load_events(journal_path, strict=True)
+    except JournalParseError as exc:
+        # A verifier attests over the journal on disk, not a filtered
+        # sequence: a malformed row is exactly the corruption a verifier
+        # exists to surface, so refuse rather than verify a partial view.
+        raise click.ClickException(
+            f"journal is corrupted: {sanitize_log(str(exc))}; refusing to verify a filtered sequence"
+        ) from exc
 
     projections: list[dict[str, Any]] = []
     try:

--- a/tests/unit/test_dry_run_cmd.py
+++ b/tests/unit/test_dry_run_cmd.py
@@ -1,8 +1,10 @@
-"""Tests for the ``bernstein dry-run`` failure contract (issue #3550).
+"""Tests for ``bernstein dry-run``: CLI-007 expansion behavior and the #3550 failure contract.
 
-A plan file that fails to load must exit non-zero and surface the loader's
-message in both table and JSON modes -- never a plausible empty result
-(``{"tasks": [], "total": 0}`` with exit 0).
+CLI-007: ``--dry-run`` expansion shows tasks/roles/models without executing.
+
+Issue #3550: a plan file that fails to load must exit non-zero and surface
+the loader's message in both table and JSON modes -- never a plausible
+empty result (``{"tasks": [], "total": 0}`` with exit 0).
 """
 
 from __future__ import annotations
@@ -15,7 +17,54 @@ import pytest
 import yaml
 from click.testing import CliRunner, Result
 
-from bernstein.cli.commands.dry_run_cmd import dry_run_cmd
+from bernstein.cli.commands.dry_run_cmd import dry_run_cmd, render_dry_run
+from bernstein.cli.main import cli
+
+
+class TestDryRunCmd:
+    """Tests for the dry-run command."""
+
+    def test_dry_run_command_exists(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["dry-run", "--help"])
+        assert result.exit_code == 0
+        assert "tasks" in result.output.lower() or "dry" in result.output.lower()
+
+    def test_dry_run_no_backlog(self) -> None:
+        """Without a backlog, should show 'no open tasks'."""
+        import os
+        import tempfile
+
+        old_cwd = os.getcwd()
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                os.chdir(td)
+                runner = CliRunner()
+                result = runner.invoke(dry_run_cmd, [])
+                assert result.exit_code == 0
+                assert "no open tasks" in result.output.lower() or "no" in result.output.lower()
+        finally:
+            os.chdir(old_cwd)
+
+    def test_dry_run_json_flag(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["dry-run", "--help"])
+        assert "--json" in result.output
+
+    def test_dry_run_plan_flag(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["dry-run", "--help"])
+        assert "--plan" in result.output
+
+    def test_render_dry_run_empty(self) -> None:
+        """render_dry_run returns empty list when no backlog."""
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as td:
+            result = render_dry_run(Path(td))
+            assert result == []
+
 
 VALID_PLAN: dict[str, object] = {
     "name": "Dry Run Test Plan",
@@ -70,7 +119,7 @@ def _extract_json(output: str) -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
-# Malformed plan: the failure contract
+# Malformed plan: the #3550 failure contract
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit/test_dry_run_cmd.py
+++ b/tests/unit/test_dry_run_cmd.py
@@ -1,53 +1,127 @@
-"""Tests for CLI-007: --dry-run expansion."""
+"""Tests for the ``bernstein dry-run`` failure contract (issue #3550).
+
+A plan file that fails to load must exit non-zero and surface the loader's
+message in both table and JSON modes -- never a plausible empty result
+(``{"tasks": [], "total": 0}`` with exit 0).
+"""
 
 from __future__ import annotations
 
-from bernstein.cli.dry_run_cmd import dry_run_cmd, render_dry_run
-from click.testing import CliRunner
+import json
+from pathlib import Path
+from typing import Any
 
-from bernstein.cli.main import cli
+import pytest
+import yaml
+from click.testing import CliRunner, Result
+
+from bernstein.cli.commands.dry_run_cmd import dry_run_cmd
+
+VALID_PLAN: dict[str, object] = {
+    "name": "Dry Run Test Plan",
+    "description": "Plan used by the dry-run CLI contract tests",
+    "stages": [
+        {
+            "name": "S1",
+            "steps": [{"title": "Step A", "goal": "Do the thing", "role": "backend"}],
+        }
+    ],
+}
+
+MALFORMED_PLAN_YAML = (
+    "stages:\n"
+    "  - name: S1\n"
+    "    steps:\n"
+    "      - title: [unclosed\n"  # invalid YAML -> PlanLoadError from the loader
+)
 
 
-class TestDryRunCmd:
-    """Tests for the dry-run command."""
+def _write_plan(tmp_path: Path, content: str) -> Path:
+    plan_file = tmp_path / "plan.yaml"
+    plan_file.write_text(content)
+    return plan_file
 
-    def test_dry_run_command_exists(self) -> None:
-        runner = CliRunner()
-        result = runner.invoke(cli, ["dry-run", "--help"])
-        assert result.exit_code == 0
-        assert "tasks" in result.output.lower() or "dry" in result.output.lower()
 
-    def test_dry_run_no_backlog(self) -> None:
-        """Without a backlog, should show 'no open tasks'."""
-        import os
-        import tempfile
+def _valid_plan_yaml() -> str:
+    return yaml.dump(VALID_PLAN)
 
-        old_cwd = os.getcwd()
-        try:
-            with tempfile.TemporaryDirectory() as td:
-                os.chdir(td)
-                runner = CliRunner()
-                result = runner.invoke(dry_run_cmd, [])
-                assert result.exit_code == 0
-                assert "no open tasks" in result.output.lower() or "no" in result.output.lower()
-        finally:
-            os.chdir(old_cwd)
 
-    def test_dry_run_json_flag(self) -> None:
-        runner = CliRunner()
-        result = runner.invoke(cli, ["dry-run", "--help"])
-        assert "--json" in result.output
+def _run_dry_run(plan_file: Path | None, as_json: bool, workdir: Path, monkeypatch: pytest.MonkeyPatch) -> Result:
+    """Invoke ``dry-run`` from ``workdir`` so Path.cwd() resolves there."""
+    monkeypatch.chdir(workdir)
+    args = []
+    if plan_file is not None:
+        args += ["--plan", str(plan_file)]
+    if as_json:
+        args += ["--json"]
+    return CliRunner().invoke(dry_run_cmd, args)
 
-    def test_dry_run_plan_flag(self) -> None:
-        runner = CliRunner()
-        result = runner.invoke(cli, ["dry-run", "--help"])
-        assert "--plan" in result.output
 
-    def test_render_dry_run_empty(self) -> None:
-        """render_dry_run returns empty list when no backlog."""
-        import tempfile
-        from pathlib import Path
+def _extract_json(output: str) -> dict[str, Any]:
+    """Pull the JSON document out of CLI output.
 
-        with tempfile.TemporaryDirectory() as td:
-            result = render_dry_run(Path(td))
-            assert result == []
+    The router can emit ``[SPAWNER-DEBUG]`` log lines to stderr, which
+    CliRunner mixes into ``result.output``; the JSON document itself starts
+    at the first ``{`` and ends at the last ``}``.
+    """
+    start = output.index("{")
+    end = output.rindex("}") + 1
+    return json.loads(output[start:end])
+
+
+# ---------------------------------------------------------------------------
+# Malformed plan: the failure contract
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_plan_table_mode_exits_nonzero(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    plan = _write_plan(tmp_path, MALFORMED_PLAN_YAML)
+    result = _run_dry_run(plan, as_json=False, workdir=tmp_path, monkeypatch=monkeypatch)
+
+    assert result.exit_code == 1, result.output
+    # The loader's message reaches the operator in table mode.
+    assert "Plan load error" in result.output
+
+
+def test_malformed_plan_json_mode_structured_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    plan = _write_plan(tmp_path, MALFORMED_PLAN_YAML)
+    result = _run_dry_run(plan, as_json=True, workdir=tmp_path, monkeypatch=monkeypatch)
+
+    assert result.exit_code == 1, result.output
+    # A structured error payload, never the success shape.
+    assert '"tasks"' not in result.output
+    payload = _extract_json(result.output)
+    assert payload["error"]["kind"] == "PlanLoadError"
+    assert payload["error"]["message"]
+
+
+# ---------------------------------------------------------------------------
+# Valid plan / backlog: unchanged behavior
+# ---------------------------------------------------------------------------
+
+
+def test_valid_plan_table_mode_exits_zero(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    plan = _write_plan(tmp_path, _valid_plan_yaml())
+    result = _run_dry_run(plan, as_json=False, workdir=tmp_path, monkeypatch=monkeypatch)
+
+    assert result.exit_code == 0, result.output
+    assert "Step A" in result.output
+    assert "Plan load error" not in result.output
+
+
+def test_valid_plan_json_mode_exits_zero(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    plan = _write_plan(tmp_path, _valid_plan_yaml())
+    result = _run_dry_run(plan, as_json=True, workdir=tmp_path, monkeypatch=monkeypatch)
+
+    assert result.exit_code == 0, result.output
+    payload = _extract_json(result.output)
+    assert payload["total"] == 1
+    assert payload["tasks"][0]["title"] == "Step A"
+
+
+def test_empty_backlog_remains_legitimate_empty_result(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Backlog path (no --plan) keeps exit 0 for an empty backlog."""
+    result = _run_dry_run(plan_file=None, as_json=False, workdir=tmp_path, monkeypatch=monkeypatch)
+
+    assert result.exit_code == 0, result.output
+    assert "No open tasks found in backlog." in result.output

--- a/tests/unit/test_telemetry_verify_span_cmd.py
+++ b/tests/unit/test_telemetry_verify_span_cmd.py
@@ -363,3 +363,31 @@ def test_verify_exported_span_recompute_uses_shared_derivation(project: Path) ->
     verdict = verify_exported_span(parse_exported_span(forged), events, projections, run_id=_RUN_ID)
     assert verdict.ok is False
     assert verdict.unverifiable is False
+
+
+# --------------------------------------------------------------------------- #
+# #3549: a corrupted journal must fail the verifier, not verify a filtered view #
+# --------------------------------------------------------------------------- #
+
+
+def test_corrupted_journal_is_unverifiable_exit_one(project: Path) -> None:
+    """A journal that does not fully parse must fail the verifier (#3549).
+
+    The tolerant reader is right for ordinary readers (a torn trailing write
+    must not wedge them), but a verifier attests over the journal on disk: a
+    malformed row is exactly the corruption a verifier exists to surface. The
+    failure exits 1 (could not be evaluated) and names the physical line --
+    never a pass over a filtered sequence.
+    """
+    spans = _exported_spans(project)
+    span_file = _write(project, spans[0])
+    genuine = _invoke(["verify-span", "--run", _RUN_ID, "-w", str(project), "--span", str(span_file)])
+    assert genuine.exit_code == 0, genuine.output
+
+    journal_path = run_journal_path(project / ".sdd", _RUN_ID)
+    with journal_path.open("a", encoding="utf-8") as f:
+        f.write("{not json\n")
+    result = _invoke(["verify-span", "--run", _RUN_ID, "-w", str(project), "--span", str(span_file)])
+    assert result.exit_code == 1, result.output
+    assert "corrupted" in result.output.lower()
+    assert "physical line" in result.output.lower()

--- a/tests/unit/test_trace_projection_cmd.py
+++ b/tests/unit/test_trace_projection_cmd.py
@@ -14,7 +14,7 @@ import pytest
 from click.testing import CliRunner
 
 from bernstein.cli.commands.advanced_cmd import trace_cmd
-from bernstein.core.replay.journal import EventJournal
+from bernstein.core.replay.journal import EventJournal, run_journal_path
 
 _RUN_ID = "run-1"
 
@@ -98,3 +98,21 @@ def test_two_projections_byte_identical(project: Path) -> None:
     second = runner.invoke(trace_cmd, ["project", _RUN_ID, "--workdir", str(project), "--json"])
     assert first.exit_code == 0
     assert first.output == second.output
+
+
+def test_verify_projection_corrupted_journal_exits_one(project: Path) -> None:
+    """A journal that does not fully parse must fail the verifier (#3549).
+
+    Same contract as the sibling ``telemetry verify-span`` test: exit 1
+    (bad input) naming the physical line, never a pass over a filtered view.
+    """
+    runner = CliRunner()
+    runner.invoke(trace_cmd, ["project", _RUN_ID, "--workdir", str(project)])
+
+    journal_path = run_journal_path(project / ".sdd", _RUN_ID)
+    with journal_path.open("a", encoding="utf-8") as f:
+        f.write("{not json\n")
+    result = runner.invoke(trace_cmd, ["verify-projection", _RUN_ID, "--workdir", str(project)])
+    assert result.exit_code == 1, result.output
+    assert "corrupted" in result.output.lower()
+    assert "physical line" in result.output.lower()


### PR DESCRIPTION
## What

Both journal verifiers loaded the event journal with the tolerant reader, so malformed JSONL rows were silently dropped before verification ran:

- `bernstein telemetry verify-span` — `src/bernstein/cli/commands/telemetry_cmd.py:591` called `load_events(journal_path)` with no `strict=True`.
- `bernstein trace verify-projection` — `src/bernstein/cli/commands/advanced_cmd.py:1449` called `load_events(_journal_path_for_run(...))` with no `strict=True`.

`load_events` defaults to `strict=False` (`src/bernstein/core/replay/journal.py:447`), which skips any line that does not decode as a JSON object. That policy is right for ordinary readers (a torn trailing write must not wedge them), but a verifier that attests over a filtered view of the journal is attesting over something other than the journal on disk: a journal with valid rows plus one malformed row verifies as if the malformed row never existed, and `trace verify-projection` prints OK and exits 0 over a journal that does not fully parse. Corruption is exactly the condition a verifier exists to surface, and it is the one condition the old load path hid. `bernstein audit diagnose` already holds the `strict=True` line (same reason, see the `load_events` docstring).

## Change

- Both verifier call sites now pass `strict=True`.
- A `JournalParseError` maps to the existing "could not be evaluated" contract:
  - `telemetry verify-span` exits 1 via `click.ClickException`, message carries the physical line index from the error ("unparsable line at physical line N").
  - `trace verify-projection` prints a red "Journal corrupted:" line and exits 1, message carries the physical line index.
- Docstrings updated so the exit-code contract names a corrupted journal under exit 1.

The export path (`telemetry export-otel`) intentionally keeps the tolerant reader: it is a producer path, not a verifier, and must survive a partial trailing write.

## Acceptance criteria mapping (from #3549)

- [x] `telemetry verify-span` and `trace verify-projection` load the journal with `strict=True`.
- [x] A `JournalParseError` maps to the existing "could not be evaluated" contract: failing status, exit 1, with the physical line index in the message.

## Tests

- `tests/unit/test_telemetry_verify_span_cmd.py` — new `test_corrupted_journal_is_unverifiable_exit_one`: genuine span verifies exit 0 first, then appending a malformed line to the journal flips it to exit 1 with "corrupted" + "physical line" in the output.
- `tests/unit/test_trace_projection_cmd.py` — new `test_verify_projection_corrupted_journal_exits_one`: same scenario for `verify-projection` (exit 1, physical line named).
- Local runs:
  - `test_telemetry_verify_span_cmd.py` + `test_trace_projection_cmd.py` + `test_otel_projection.py` + `test_replay_verify_cli.py` + `test_event_journal.py`: **56 passed**
  - Regression batch `test_otel_projection.py test_replay_verify_cli.py test_event_journal.py test_replay_journal_cli.py test_cli/advanced_cmd_paths.py`: **78 passed**
- `ruff check` clean; `ruff format` applied.

## AI assistance disclosure

This PR was implemented with AI assistance (Claude, driven by an automated contributor account), consistent with the disclosure practice on my earlier contributions (#3363, #3371, #3411, #3457, #3602).
