### PR TITLE
fix(cli): journal verifiers load strict=True, corruption fails exit 1 (#3549)

### DIFF
--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -1432,7 +1432,7 @@ def trace_verify_projection_cmd(run_id: str, workdir: str, projection_path: str 
     Rejects a span whose id was altered or whose journal entry hash is absent
     from the chain, and confirms the signature chains to the install identity.
 
-    Exit codes: 0 = OK, 1 = bad input, 2 = verification failed.
+    Exit codes: 0 = OK, 1 = bad input (incl. a corrupted journal), 2 = verification failed.
     """
     from bernstein.cli.commands.credential_cmd import (
         _load_or_create_install_key,
@@ -1443,10 +1443,17 @@ def trace_verify_projection_cmd(run_id: str, workdir: str, projection_path: str 
         projection_from_dict,
         verify_projection,
     )
-    from bernstein.core.replay.journal import load_events
+    from bernstein.core.replay.journal import JournalParseError, load_events
 
     root = Path(workdir).resolve()
-    events = load_events(_journal_path_for_run(root, run_id))
+    try:
+        events = load_events(_journal_path_for_run(root, run_id), strict=True)
+    except JournalParseError as exc:
+        # A verifier attests over the journal on disk, not a filtered
+        # sequence: a malformed row is exactly the corruption a verifier
+        # exists to surface, so refuse rather than verify a partial view.
+        console.print(f"[red]Journal corrupted:[/red] {sanitize_log(str(exc))}; refusing to verify a filtered sequence")
+        raise SystemExit(1) from exc
     if not events:
         console.print(f"[red]No event journal for run[/red] {sanitize_log(run_id)}")
         raise SystemExit(1)

--- a/src/bernstein/cli/commands/telemetry_cmd.py
+++ b/src/bernstein/cli/commands/telemetry_cmd.py
@@ -558,16 +558,21 @@ def telemetry_verify_span(ctx: click.Context, run_id: str, workdir: str, span_so
     whose anchor mismatches, is rejected as a forgery.
 
     Exit codes: 0 = genuine, 1 = could not be evaluated (missing journal,
-    malformed span, bad input), 2 = verification failed (forged). Same
-    convention as ``trace verify-projection``; a rejection is always a hard
-    nonzero exit, never a warning.
+    corrupted journal, malformed span, bad input), 2 = verification failed
+    (forged). Same convention as ``trace verify-projection``; a rejection
+    is always a hard nonzero exit, never a warning.
     """
     from bernstein.core.observability.otel_bridge import (
         SpanParseError,
         parse_exported_span,
         verify_exported_span,
     )
-    from bernstein.core.replay.journal import JournalPathError, load_events, run_journal_path
+    from bernstein.core.replay.journal import (
+        JournalParseError,
+        JournalPathError,
+        load_events,
+        run_journal_path,
+    )
     from bernstein.core.security.audit import load_or_create_audit_key
     from bernstein.core.security.audit_chain import EVENT_OTEL_PROJECTION, AuditChainStore
     from bernstein.core.security.sanitize import sanitize_log
@@ -588,7 +593,15 @@ def telemetry_verify_span(ctx: click.Context, run_id: str, workdir: str, span_so
         journal_path = run_journal_path(root / ".sdd", run_id)
     except JournalPathError as exc:
         raise click.ClickException(sanitize_log(str(exc))) from exc
-    events = load_events(journal_path)
+    try:
+        events = load_events(journal_path, strict=True)
+    except JournalParseError as exc:
+        # A verifier attests over the journal on disk, not a filtered
+        # sequence: a malformed row is exactly the corruption a verifier
+        # exists to surface, so refuse rather than verify a partial view.
+        raise click.ClickException(
+            f"journal is corrupted: {sanitize_log(str(exc))}; refusing to verify a filtered sequence"
+        ) from exc
 
     projections: list[dict[str, Any]] = []
     try:

--- a/tests/unit/test_telemetry_verify_span_cmd.py
+++ b/tests/unit/test_telemetry_verify_span_cmd.py
@@ -363,3 +363,31 @@ def test_verify_exported_span_recompute_uses_shared_derivation(project: Path) ->
     verdict = verify_exported_span(parse_exported_span(forged), events, projections, run_id=_RUN_ID)
     assert verdict.ok is False
     assert verdict.unverifiable is False
+
+
+# --------------------------------------------------------------------------- #
+# #3549: a corrupted journal must fail the verifier, not verify a filtered view #
+# --------------------------------------------------------------------------- #
+
+
+def test_corrupted_journal_is_unverifiable_exit_one(project: Path) -> None:
+    """A journal that does not fully parse must fail the verifier (#3549).
+
+    The tolerant reader is right for ordinary readers (a torn trailing write
+    must not wedge them), but a verifier attests over the journal on disk: a
+    malformed row is exactly the corruption a verifier exists to surface. The
+    failure exits 1 (could not be evaluated) and names the physical line --
+    never a pass over a filtered sequence.
+    """
+    spans = _exported_spans(project)
+    span_file = _write(project, spans[0])
+    genuine = _invoke(["verify-span", "--run", _RUN_ID, "-w", str(project), "--span", str(span_file)])
+    assert genuine.exit_code == 0, genuine.output
+
+    journal_path = run_journal_path(project / ".sdd", _RUN_ID)
+    with journal_path.open("a", encoding="utf-8") as f:
+        f.write("{not json\n")
+    result = _invoke(["verify-span", "--run", _RUN_ID, "-w", str(project), "--span", str(span_file)])
+    assert result.exit_code == 1, result.output
+    assert "corrupted" in result.output.lower()
+    assert "physical line" in result.output.lower()

--- a/tests/unit/test_trace_projection_cmd.py
+++ b/tests/unit/test_trace_projection_cmd.py
@@ -14,7 +14,7 @@ import pytest
 from click.testing import CliRunner
 
 from bernstein.cli.commands.advanced_cmd import trace_cmd
-from bernstein.core.replay.journal import EventJournal
+from bernstein.core.replay.journal import EventJournal, run_journal_path
 
 _RUN_ID = "run-1"
 
@@ -98,3 +98,21 @@ def test_two_projections_byte_identical(project: Path) -> None:
     second = runner.invoke(trace_cmd, ["project", _RUN_ID, "--workdir", str(project), "--json"])
     assert first.exit_code == 0
     assert first.output == second.output
+
+
+def test_verify_projection_corrupted_journal_exits_one(project: Path) -> None:
+    """A journal that does not fully parse must fail the verifier (#3549).
+
+    Same contract as the sibling ``telemetry verify-span`` test: exit 1
+    (bad input) naming the physical line, never a pass over a filtered view.
+    """
+    runner = CliRunner()
+    runner.invoke(trace_cmd, ["project", _RUN_ID, "--workdir", str(project)])
+
+    journal_path = run_journal_path(project / ".sdd", _RUN_ID)
+    with journal_path.open("a", encoding="utf-8") as f:
+        f.write("{not json\n")
+    result = runner.invoke(trace_cmd, ["verify-projection", _RUN_ID, "--workdir", str(project)])
+    assert result.exit_code == 1, result.output
+    assert "corrupted" in result.output.lower()
+    assert "physical line" in result.output.lower()


### PR DESCRIPTION
## What

Both journal verifiers loaded the event journal with the tolerant reader, so malformed JSONL rows were silently dropped before verification ran:

- `bernstein telemetry verify-span` — `src/bernstein/cli/commands/telemetry_cmd.py:591` called `load_events(journal_path)` with no `strict=True`.
- `bernstein trace verify-projection` — `src/bernstein/cli/commands/advanced_cmd.py:1449` called `load_events(_journal_path_for_run(...))` with no `strict=True`.

`load_events` defaults to `strict=False` (`src/bernstein/core/replay/journal.py:447`), which skips any line that does not decode as a JSON object. That policy is right for ordinary readers (a torn trailing write must not wedge them), but a verifier that attests over a filtered view of the journal is attesting over something other than the journal on disk: a journal with valid rows plus one malformed row verifies as if the malformed row never existed, and `trace verify-projection` prints OK and exits 0 over a journal that does not fully parse. Corruption is exactly the condition a verifier exists to surface, and it is the one condition the old load path hid. `bernstein audit diagnose` already holds the `strict=True` line (same reason, see the `load_events` docstring).

## Change

- Both verifier call sites now pass `strict=True`.
- A `JournalParseError` maps to the existing "could not be evaluated" contract:
  - `telemetry verify-span` exits 1 via `click.ClickException`, message carries the physical line index from the error ("unparsable line at physical line N").
  - `trace verify-projection` prints a red "Journal corrupted:" line and exits 1, message carries the physical line index.
- Docstrings updated so the exit-code contract names a corrupted journal under exit 1.

The export path (`telemetry export-otel`) intentionally keeps the tolerant reader: it is a producer path, not a verifier, and must survive a partial trailing write.

## Acceptance criteria mapping (from #3549)

- [x] `telemetry verify-span` and `trace verify-projection` load the journal with `strict=True`.
- [x] A `JournalParseError` maps to the existing "could not be evaluated" contract: failing status, exit 1, with the physical line index in the message.

## Tests

- `tests/unit/test_telemetry_verify_span_cmd.py` — new `test_corrupted_journal_is_unverifiable_exit_one`: genuine span verifies exit 0 first, then appending a malformed line to the journal flips it to exit 1 with "corrupted" + "physical line" in the output.
- `tests/unit/test_trace_projection_cmd.py` — new `test_verify_projection_corrupted_journal_exits_one`: same scenario for `verify-projection` (exit 1, physical line named).
- Local runs:
  - `test_telemetry_verify_span_cmd.py` + `test_trace_projection_cmd.py` + `test_otel_projection.py` + `test_replay_verify_cli.py` + `test_event_journal.py`: **56 passed**
  - Regression batch `test_otel_projection.py test_replay_verify_cli.py test_event_journal.py test_replay_journal_cli.py test_cli/advanced_cmd_paths.py`: **78 passed**
- `ruff check` clean; `ruff format` applied.

## AI assistance disclosure

This PR was implemented with AI assistance (Claude, driven by an automated contributor account), consistent with the disclosure practice on my earlier contributions (#3363, #3371, #3411, #3457, #3602).
