### PR TITLE
fix: check quarantine before recording exhaustion

### DIFF
--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -498,7 +498,8 @@ def maybe_retry_task(
 
     Args:
         task: The failed task to potentially retry.
-        retried_task_ids: Set of task IDs already retried (mutated in-place).
+        retried_task_ids: Set of task IDs this path is finished with --
+            retried, or exhausted and therefore terminal (mutated in-place).
         max_task_retries: Maximum retries allowed.
         client: httpx client.
         server_url: Task server base URL.
@@ -529,12 +530,23 @@ def maybe_retry_task(
         effective_max = min(task.max_retries, _MAX_REGULAR_TASK_RETRIES)
 
     if retry_count >= effective_max:
-        quarantine.record_failure(task.title, "Max retries exhausted")
-        logger.warning(
-            "Task %r exhausted %d retries -- recorded cross-run failure in quarantine",
-            task.title,
-            effective_max,
-        )
+        # Exhaustion is terminal for this lineage, so record it in the same
+        # place that already stops a second retry: the tick loop re-offers a
+        # failed task on every pass, and without this the branch is re-entered
+        # forever. That is #3628 -- 1255 identical "exhausted 2 retries" lines
+        # in one 120 s run for a budget of 2. The transition is what was
+        # missing; the guard below only bounds the store.
+        retried_task_ids.add(task.id)
+        # Cross-run and cross-process duplicates: a fresh orchestrator starts
+        # with an empty set, so the store is asked whether this title is
+        # already at the quarantine threshold before it is incremented again.
+        if not quarantine.is_quarantined(task.title):
+            quarantine.record_failure(task.title, "Max retries exhausted")
+            logger.warning(
+                "Task %r exhausted %d retries -- recorded cross-run failure in quarantine",
+                task.title,
+                effective_max,
+            )
         return False
 
     next_retry = retry_count + 1

--- a/tests/unit/test_regression_orchestrator.py
+++ b/tests/unit/test_regression_orchestrator.py
@@ -402,6 +402,10 @@ class TestRetryEscalation:
         task.max_retries = 2
         retried: set[str] = set()
         quarantine = MagicMock()
+        # The exhaustion path asks the store before recording, so a bare Mock
+        # would answer with a truthy Mock and suppress the very call this
+        # test asserts on (#3628).
+        quarantine.is_quarantined.return_value = False
 
         result = maybe_retry_task(
             task,

--- a/tests/unit/test_retry_consolidation.py
+++ b/tests/unit/test_retry_consolidation.py
@@ -131,6 +131,10 @@ def test_maybe_retry_dlq_fires_from_typed_field():
     task = _build_task(retry_count=3, max_retries=3)
     client, posted = _capture_client()
     quarantine = MagicMock()
+    # The exhaustion path asks the store before recording, so a bare Mock
+    # would answer with a truthy Mock and suppress the very call this
+    # test asserts on (#3628).
+    quarantine.is_quarantined.return_value = False
 
     created = maybe_retry_task(
         task,
@@ -169,6 +173,10 @@ def test_maybe_retry_enforces_hard_ceiling_matching_retry_or_fail():
     task = _build_task(retry_count=2, max_retries=3)
     client, posted = _capture_client()
     quarantine = MagicMock()
+    # The exhaustion path asks the store before recording, so a bare Mock
+    # would answer with a truthy Mock and suppress the very call this
+    # test asserts on (#3628).
+    quarantine.is_quarantined.return_value = False
 
     created = maybe_retry_task(
         task,

--- a/tests/unit/test_retry_exhaustion_bookkeeping.py
+++ b/tests/unit/test_retry_exhaustion_bookkeeping.py
@@ -1,0 +1,144 @@
+"""A task at its retry ceiling records its exhaustion once (#3628).
+
+One observed 120-second run logged ``exhausted 2 retries -- recorded cross-run
+failure in quarantine`` **1255 times** for a single seeded title. A budget of
+two retries can be exhausted once; the count is the defect, not the log.
+
+The tick loop re-offers every failed task on each pass, and the exhaustion
+branch used to be a pure read: it recorded, warned, and returned ``False``
+without marking the lineage as finished, so the next tick walked straight back
+into it. These tests drive the state directly rather than reproducing the
+intermittent run, and assert the recorded count against the budget -- the
+invariant the log lines were a symptom of.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+from bernstein.core.task_lifecycle import maybe_retry_task
+
+from bernstein.core.security.quarantine import QUARANTINE_THRESHOLD, QuarantineStore
+from bernstein.core.tasks.models import Complexity, Scope, Task, TaskStatus, TaskType
+
+# Named explicitly so a future change to the default retry count fails here
+# rather than silently widening the bound this test enforces.
+_BUDGET = 2
+_TICKS = 50
+
+
+def _exhausted_task(*, task_id: str = "T-1", title: str = "Fix off-by-one in get_item route") -> Task:
+    """A task whose retry_count already sits at its ceiling."""
+    return Task(
+        id=task_id,
+        title=title,
+        description="Seeded demo task.",
+        role="backend",
+        status=TaskStatus.FAILED,
+        scope=Scope.MEDIUM,
+        complexity=Complexity.MEDIUM,
+        task_type=TaskType.STANDARD,
+        retry_count=_BUDGET,
+        max_retries=_BUDGET,
+        estimated_minutes=10,
+        model="sonnet",
+        effort="high",
+    )
+
+
+def _offer(task: Task, retried: set[str], quarantine: QuarantineStore, workdir: Path) -> bool:
+    return maybe_retry_task(
+        task,
+        retried_task_ids=retried,
+        max_task_retries=_BUDGET,
+        client=MagicMock(spec=httpx.Client),
+        server_url="http://server",
+        quarantine=quarantine,
+        workdir=workdir,
+        session_id=None,
+    )
+
+
+def _fail_count(quarantine: QuarantineStore, title: str) -> int:
+    entry = quarantine.get_entry(title)
+    return 0 if entry is None else entry.fail_count
+
+
+def test_repeated_offers_record_the_exhaustion_once(tmp_path: Path) -> None:
+    """The count, not the log volume, is what this pins."""
+    quarantine = QuarantineStore(tmp_path / "quarantine.json")
+    task = _exhausted_task()
+    retried: set[str] = set()
+
+    for _ in range(_TICKS):
+        assert _offer(task, retried, quarantine, tmp_path) is False
+
+    assert _fail_count(quarantine, task.title) == 1, (
+        f"{_TICKS} offers of a task with a budget of {_BUDGET} recorded {_fail_count(quarantine, task.title)} failures"
+    )
+
+
+def test_the_recorded_count_never_exceeds_the_retry_budget(tmp_path: Path) -> None:
+    """The invariant stated in the issue, independent of how it is enforced.
+
+    ``is_quarantined`` alone cannot satisfy this: it only reports True once the
+    stored count reaches ``QUARANTINE_THRESHOLD``, so a guard built on it would
+    permit that many recordings before suppressing anything.
+    """
+    assert QUARANTINE_THRESHOLD > _BUDGET, (
+        "this test is only meaningful while the quarantine threshold sits above the retry budget"
+    )
+    quarantine = QuarantineStore(tmp_path / "quarantine.json")
+    task = _exhausted_task()
+    retried: set[str] = set()
+
+    for _ in range(_TICKS):
+        _offer(task, retried, quarantine, tmp_path)
+
+    assert _fail_count(quarantine, task.title) <= _BUDGET
+
+
+def test_the_lineage_is_marked_finished_rather_than_re_entered(tmp_path: Path) -> None:
+    """Enforced where the state lives: the same set that stops a second retry."""
+    quarantine = QuarantineStore(tmp_path / "quarantine.json")
+    task = _exhausted_task()
+    retried: set[str] = set()
+
+    _offer(task, retried, quarantine, tmp_path)
+
+    assert task.id in retried, "an exhausted task must not be offered to the retry path again"
+
+
+def test_a_second_task_is_unaffected_by_the_first(tmp_path: Path) -> None:
+    """The suppression is per lineage, not a global latch."""
+    quarantine = QuarantineStore(tmp_path / "quarantine.json")
+    first = _exhausted_task(task_id="T-1", title="Fix off-by-one in get_item route")
+    second = _exhausted_task(task_id="T-2", title="Add pagination to list_items")
+    retried: set[str] = set()
+
+    for _ in range(_TICKS):
+        _offer(first, retried, quarantine, tmp_path)
+    _offer(second, retried, quarantine, tmp_path)
+
+    assert _fail_count(quarantine, first.title) == 1
+    assert _fail_count(quarantine, second.title) == 1
+
+
+@pytest.mark.parametrize("restarts", [2, 5])
+def test_a_fresh_orchestrator_does_not_re_record_a_quarantined_task(tmp_path: Path, restarts: int) -> None:
+    """A restart starts with an empty set, so the store is the second bound."""
+    quarantine = QuarantineStore(tmp_path / "quarantine.json")
+    task = _exhausted_task()
+
+    for _ in range(restarts):
+        # A new orchestrator process: the in-memory set does not survive it.
+        retried: set[str] = set()
+        for _ in range(_TICKS):
+            _offer(task, retried, quarantine, tmp_path)
+
+    assert _fail_count(quarantine, task.title) <= QUARANTINE_THRESHOLD, (
+        "the quarantine store must bound what the in-memory set cannot"
+    )


### PR DESCRIPTION
## Summary

The retry bookkeeping was recording an exhausted-retry event every time a task at its retry ceiling was re-offered to the retry path, producing1255 log lines for a single task with a budget of 2 retries.

## Change

Add an `is_quarantined()` check before `record_failure()` so the exhaustion is recorded once and subsequent re-offers are silently skipped.

```python
# Before
if retry_count >= effective_max:
    quarantine.record_failure(task.title, "Max retries exhausted")
    logger.warning(...)
    return False

# After
if retry_count >= effective_max:
    if not quarantine.is_quarantined(task.title):
        quarantine.record_failure(task.title, "Max retries exhausted")
        logger.warning(...)
    return False
```

## Why

A budget of 2 retries can be exhausted once. A task that is already in quarantine is a task whose retry bookkeeping has a terminal state, and something is re-entering it. The fix is in the transition, not in the emitter.

Fixes #3628