### PR TITLE
fix: validate depends_on, constraints, and context_files as string lists

### DIFF
--- a/docs/architecture/plans.md
+++ b/docs/architecture/plans.md
@@ -493,7 +493,7 @@ The plan loader validates fields strictly. This table documents the load-time be
 |-------|-----------------|-----------------|---------|----------|
 | `title` / `goal` | Non-empty string | Empty string, missing | — | — |
 | `files` | `list[str]`, missing, `null` | Scalar, `list[non-str]` | `[]` (missing or `null`) | — |
-| `attachments` | `list[str]`, missing, `null` | Scalar, `list[non-str]` | `[]` (missing or `null`) | — |
+| `attachments` | Any list, missing, `null` | Scalar | `[]` (missing or `null`) | Every item via `str()` (tracked in #3555) |
 | `priority` | Integer | Float, string, boolean | — | — |
 | `estimated_minutes` | Integer | Float, string, boolean | — | — |
 | `role` | Known role enum | Unknown string | — | — |
@@ -508,7 +508,7 @@ The plan loader validates fields strictly. This table documents the load-time be
 | Field | Accepted shapes | Rejected shapes | Default | Coercion |
 |-------|-----------------|-----------------|---------|----------|
 | `name` | Non-empty string | Empty string, missing | — | — |
-| `depends_on` | Any list, missing, `null` | — | `[]` (missing or `null`) | Every item via `str()`; a scalar string is iterated character-by-character |
+| `depends_on` | `list[str]`, missing, `null` | Scalar, `list[non-str]` | `[]` (missing or `null`) | — |
 
 ### Plan fields
 
@@ -516,8 +516,8 @@ The plan loader validates fields strictly. This table documents the load-time be
 |-------|-----------------|-----------------|---------|----------|
 | `name` | Non-empty string | Empty string, missing | — | — |
 | `stages` | `list[Stage]` | Missing, non-list | — | — |
-| `constraints` | Any list, missing, `null` | — | `[]` (missing or `null`) | None: non-string items pass through unchanged; a scalar string is iterated character-by-character |
-| `context_files` | Any list, missing, `null` | — | `[]` (missing or `null`) | None: non-string items pass through unchanged; a scalar string is iterated character-by-character |
+| `constraints` | `list[str]`, missing, `null` | Scalar, `list[non-str]` | `[]` (missing or `null`) | — |
+| `context_files` | `list[str]`, missing, `null` | Scalar, `list[non-str]` | `[]` (missing or `null`) | — |
 
 ### Differences between load and validate
 
@@ -526,13 +526,26 @@ The plan loader validates fields strictly. This table documents the load-time be
 | `files: null` | Treated as `[]` | Flagged as error |
 | `files: [1, 2]` | Raises `PlanLoadError` | Flagged as error |
 | `attachments: null` | Treated as `[]` | Not checked (loader-only) |
-| `constraints: "abc"` | Becomes `['a', 'b', 'c']` | Flagged as error |
+| `attachments: [1, 2]` | Becomes `['1', '2']` | Not checked (loader-only) |
+| `constraints: null` | Treated as `[]` | Flagged as error |
+| `constraints: "abc"` | Raises `PlanLoadError` | Flagged as error |
 
-`files` and `attachments` are the only list fields the loader checks item by
-item. `depends_on`, `constraints`, and `context_files` still carry the lenient
-behaviour the stricter loader replaced elsewhere, so a scalar string is
-iterated rather than rejected there. That gap is tracked in #3639; this table
-documents what the loader does today, not what it should do.
+`files`, `depends_on`, `constraints`, and `context_files` are checked item by
+item at load, so a scalar string raises rather than being iterated. The
+loader's error names the level of the document the field was found at — `Plan`,
+`Stage 'name'`, or `Step N in stage 'name'` — because the same field names
+appear at more than one level and a reader given the wrong one goes looking for
+a step that does not carry the field.
+
+`attachments` is the one list field still on the lenient path: a scalar raises,
+but non-string items are coerced with `str()` rather than rejected. That gap is
+tracked in #3555.
+
+Explicit `null` is the one shape where load and validate still disagree by
+design: the loader treats it as absent and returns `[]`, while `plan validate`
+sees a present key whose value is not an array and flags it. Existing plans
+rely on the loader's reading, so tightening it is a separate compatibility
+decision, not part of the item-level strictness above.
 
 ### Compatibility window
 

--- a/src/bernstein/core/planning/plan_loader.py
+++ b/src/bernstein/core/planning/plan_loader.py
@@ -208,17 +208,26 @@ def _parse_int_field(
     return raw
 
 
-def _parse_string_list_field(raw: object, field_name: str, stage_name: str, step_idx: int) -> list[str]:
-    """Parse an optional list-of-strings step field.
+def _step_context(stage_name: str, step_idx: int) -> str:
+    """Error-message prefix naming a step by its stage and position."""
+    return f"Step {step_idx} in stage {stage_name!r}"
+
+
+def _parse_string_list_field(raw: object, field_name: str, context: str) -> list[str]:
+    """Parse an optional list-of-strings field.
 
     Args:
-        raw: Raw field value from the YAML step.
-        field_name: Step field name, for error context.
-        stage_name: Stage name for error context.
-        step_idx: Zero-based step index for error context.
+        raw: Raw field value from the YAML document.
+        field_name: Field name, for error context.
+        context: Where in the document the field was found, used verbatim as
+            the error-message prefix -- ``"Plan"``, ``"Stage 'build'"``, or
+            ``_step_context(...)``. The same list fields exist at three levels
+            of a plan file, so the message has to name the level the reader
+            must go and edit; a step-shaped prefix on a plan-level field would
+            send them to a step that does not exist.
 
     Returns:
-        The string items, or an empty list when the field is absent.
+        The string items, or an empty list when the field is absent or ``null``.
 
     Raises:
         PlanLoadError: If the field is present but not a list, or if any list
@@ -227,17 +236,12 @@ def _parse_string_list_field(raw: object, field_name: str, stage_name: str, step
     if raw is None:
         return []
     if not isinstance(raw, list):
-        raise PlanLoadError(
-            f"Step {step_idx} in stage {stage_name!r}: {field_name!r} must be a list of paths, got {type(raw).__name__}"
-        )
+        raise PlanLoadError(f"{context}: {field_name!r} must be a list of strings, got {type(raw).__name__}")
     items = cast(list[object], raw)
     parsed: list[str] = []
     for item_idx, item in enumerate(items):
         if not isinstance(item, str):
-            raise PlanLoadError(
-                f"Step {step_idx} in stage {stage_name!r}: {field_name}[{item_idx}] "
-                f"must be a string, got {type(item).__name__}"
-            )
+            raise PlanLoadError(f"{context}: {field_name}[{item_idx}] must be a string, got {type(item).__name__}")
         parsed.append(item)
     return parsed
 
@@ -398,7 +402,7 @@ def _parse_step(
     # Reject scalar / non-list shapes and non-string items so direct loads
     # match the CLI pre-check (validate_plan) boundary for list[string] fields.
     raw_files: object = step.get("files")
-    owned_files = _parse_string_list_field(raw_files, "files", stage_name, step_index)
+    owned_files = _parse_string_list_field(raw_files, "files", _step_context(stage_name, step_index))
     # Issue #1797: operator-supplied image attachments. The orchestrator
     # builds a MultiModalContext at spawn time from these paths.
     # Reject scalar / non-list shapes so a YAML typo like

--- a/src/bernstein/core/planning/plan_loader.py
+++ b/src/bernstein/core/planning/plan_loader.py
@@ -315,8 +315,8 @@ def load_plan(path: Path) -> tuple[PlanConfig, list[Task]]:
     config = PlanConfig(
         name=str(data.get("name", "")),
         description=str(data.get("description", "")),
-        constraints=list(data.get("constraints") or []),
-        context_files=list(data.get("context_files") or []),
+        constraints=_parse_string_list_field(data.get("constraints"), "constraints", "Plan"),
+        context_files=_parse_string_list_field(data.get("context_files"), "context_files", "Plan"),
         cli=str(data["cli"]) if data.get("cli") else None,
         budget=str(budget_raw) if budget_raw is not None else None,
         max_agents=int(max_agents_raw) if max_agents_raw is not None else None,
@@ -362,7 +362,7 @@ def _parse_stage(
         return
 
     stage_tasks[str(stage_name)] = []
-    stage_deps: list[str] = [str(d) for d in (stage.get("depends_on") or [])]
+    stage_deps: list[str] = _parse_string_list_field(stage.get("depends_on"), "depends_on", f"Stage {stage_name!r}")
     stage_repo: str | None = str(stage["repo"]) if stage.get("repo") else None
 
     for j, step in enumerate(steps):

--- a/tests/unit/test_plan_loader.py
+++ b/tests/unit/test_plan_loader.py
@@ -912,3 +912,135 @@ def test_step_explicit_null_int_field_raises_plan_load_error(tmp_path: Path, fie
     )
     with pytest.raises(PlanLoadError, match=f"'{field}' must be an integer"):
         load_plan_from_yaml(plan_file)
+
+
+# ---------------------------------------------------------------------------
+# Plan- and stage-level list fields, same boundary as `files` (#3639)
+# ---------------------------------------------------------------------------
+#
+# `depends_on`, `constraints`, and `context_files` were left on the lenient
+# path when `files` was tightened, so `constraints: "no network calls"` loaded
+# as 17 single-character constraints and `depends_on: [null]` became the
+# fabricated stage name `'None'`. Both failures are silent: the plan loads and
+# the agents receive nonsense.
+#
+# These fields live at three different levels of the document, so each case
+# also asserts that the error names the level the reader has to go and edit.
+
+
+def _plan_with(**top: object) -> dict[str, object]:
+    return {"name": "P", "stages": [{"name": "S", "steps": [{"title": "T"}]}], **top}
+
+
+@pytest.mark.parametrize("field", ["constraints", "context_files"])
+def test_plan_level_scalar_string_raises_instead_of_being_iterated(tmp_path: Path, field: str) -> None:
+    plan_file = _write_plan(tmp_path, _plan_with(**{field: "no network calls"}))
+
+    with pytest.raises(PlanLoadError) as exc_info:
+        load_plan(plan_file)
+
+    message = str(exc_info.value)
+    assert f"'{field}' must be a list" in message
+    # The field is top-level, so the message must not send the reader hunting
+    # for a step or a stage that does not carry it.
+    assert message.startswith("Plan:"), message
+
+
+@pytest.mark.parametrize("field", ["constraints", "context_files"])
+@pytest.mark.parametrize(
+    ("bad_item", "expected_type"),
+    [(None, "NoneType"), (True, "bool"), (42, "int"), ({"a": "b"}, "dict")],
+)
+def test_plan_level_non_string_item_raises_naming_field_and_index(
+    tmp_path: Path, field: str, bad_item: object, expected_type: str
+) -> None:
+    plan_file = _write_plan(tmp_path, _plan_with(**{field: ["ok", bad_item]}))
+
+    with pytest.raises(PlanLoadError) as exc_info:
+        load_plan(plan_file)
+
+    message = str(exc_info.value)
+    assert f"{field}[1]" in message
+    assert expected_type in message
+
+
+def test_stage_depends_on_scalar_string_raises_instead_of_being_iterated(tmp_path: Path) -> None:
+    plan_file = _write_plan(
+        tmp_path,
+        {
+            "stages": [
+                {"name": "build", "steps": [{"title": "T1"}]},
+                {"name": "test", "depends_on": "build", "steps": [{"title": "T2"}]},
+            ]
+        },
+    )
+
+    with pytest.raises(PlanLoadError) as exc_info:
+        load_plan_from_yaml(plan_file)
+
+    message = str(exc_info.value)
+    assert "'depends_on' must be a list" in message
+    assert message.startswith("Stage 'test':"), message
+
+
+@pytest.mark.parametrize(
+    ("bad_item", "expected_type"),
+    [(None, "NoneType"), (True, "bool"), (42, "int"), ({"a": "b"}, "dict")],
+)
+def test_stage_depends_on_non_string_item_raises(tmp_path: Path, bad_item: object, expected_type: str) -> None:
+    """`depends_on: [null]` used to become the fabricated stage name 'None',
+    which then failed dependency resolution naming a stage nobody wrote."""
+    plan_file = _write_plan(
+        tmp_path,
+        {
+            "stages": [
+                {"name": "build", "steps": [{"title": "T1"}]},
+                {"name": "test", "depends_on": ["build", bad_item], "steps": [{"title": "T2"}]},
+            ]
+        },
+    )
+
+    with pytest.raises(PlanLoadError) as exc_info:
+        load_plan_from_yaml(plan_file)
+
+    message = str(exc_info.value)
+    assert "depends_on[1]" in message
+    assert expected_type in message
+
+
+@pytest.mark.parametrize("field", ["constraints", "context_files"])
+@pytest.mark.parametrize("present", [True, False], ids=["explicit-null", "absent"])
+def test_plan_level_absent_and_null_still_load_as_empty(tmp_path: Path, field: str, present: bool) -> None:
+    """The behaviour most likely to be broken by a strict rewrite: existing
+    plans that omit these fields, or set them to `null`, must keep loading."""
+    top: dict[str, object] = {field: None} if present else {}
+    plan_file = _write_plan(tmp_path, _plan_with(**top))
+
+    config, tasks = load_plan(plan_file)
+
+    assert getattr(config, field) == []
+    assert len(tasks) == 1
+
+
+@pytest.mark.parametrize("present", [True, False], ids=["explicit-null", "absent"])
+def test_stage_depends_on_absent_and_null_still_load_as_empty(tmp_path: Path, present: bool) -> None:
+    stage: dict[str, object] = {"name": "S", "steps": [{"title": "T"}]}
+    if present:
+        stage["depends_on"] = None
+    plan_file = _write_plan(tmp_path, {"stages": [stage]})
+
+    tasks = load_plan_from_yaml(plan_file)
+
+    assert tasks[0].depends_on == []
+
+
+def test_plan_level_valid_string_lists_survive_unchanged(tmp_path: Path) -> None:
+    plan_file = _write_plan(
+        tmp_path,
+        _plan_with(constraints=["no network calls"], context_files=["docs/spec.md"]),
+    )
+
+    config, _ = load_plan(plan_file)
+
+    assert config.constraints == ["no network calls"]
+    assert config.context_files == ["docs/spec.md"]


### PR DESCRIPTION
## Summary

Three list fields (`depends_on`, `constraints`, `context_files`) were still using the lenient path that iterates a scalar string character-by-character, the same bug that was fixed for `files` in #3556.

## Change

Add `_parse_string_list_field()` helper and apply it to:

- Stage `depends_on` (line331)
- Plan `constraints` (line284)
- Plan `context_files` (line285)

The helper validates that all items are strings before returning, matching the behavior of `plan validate`'s `_check_string_items`.

```python
# Before
stage_deps: list[str] = [str(d) for d in (stage.get("depends_on") or [])]
constraints=list(data.get("constraints") or []),
context_files=list(data.get("context_files") or []),

# After
stage_deps: list[str] = _parse_string_list_field(stage.get("depends_on"), "depends_on", f"Stage {stage_name!r}")
constraints=_parse_string_list_field(data.get("constraints"), "constraints", "Plan"),
context_files=_parse_string_list_field(data.get("context_files"), "context_files", "Plan"),
```

Fixes #3639