### PR TITLE
fix: validate attachments as string list instead of coercing

### DIFF
--- a/docs/architecture/plans.md
+++ b/docs/architecture/plans.md
@@ -493,7 +493,7 @@ The plan loader validates fields strictly. This table documents the load-time be
 |-------|-----------------|-----------------|---------|----------|
 | `title` / `goal` | Non-empty string | Empty string, missing | — | — |
 | `files` | `list[str]`, missing, `null` | Scalar, `list[non-str]` | `[]` (missing or `null`) | — |
-| `attachments` | Any list, missing, `null` | Scalar | `[]` (missing or `null`) | Every item via `str()` (tracked in #3555) |
+| `attachments` | `list[str]`, missing, `null` | Scalar, `list[non-str]` | `[]` (missing or `null`) | — |
 | `priority` | Integer | Float, string, boolean | — | — |
 | `estimated_minutes` | Integer | Float, string, boolean | — | — |
 | `role` | Known role enum | Unknown string | — | — |
@@ -526,20 +526,24 @@ The plan loader validates fields strictly. This table documents the load-time be
 | `files: null` | Treated as `[]` | Flagged as error |
 | `files: [1, 2]` | Raises `PlanLoadError` | Flagged as error |
 | `attachments: null` | Treated as `[]` | Not checked (loader-only) |
-| `attachments: [1, 2]` | Becomes `['1', '2']` | Not checked (loader-only) |
+| `attachments: [1, 2]` | Raises `PlanLoadError` | Not checked (loader-only) |
 | `constraints: null` | Treated as `[]` | Flagged as error |
 | `constraints: "abc"` | Raises `PlanLoadError` | Flagged as error |
+| `constraints: [1, 2]` | Raises `PlanLoadError` | Flagged as error |
 
-`files`, `depends_on`, `constraints`, and `context_files` are checked item by
-item at load, so a scalar string raises rather than being iterated. The
+Every list field is checked item by item at load, so a scalar string raises
+rather than being iterated and a non-string item raises rather than being
+coerced. The
 loader's error names the level of the document the field was found at — `Plan`,
 `Stage 'name'`, or `Step N in stage 'name'` — because the same field names
 appear at more than one level and a reader given the wrong one goes looking for
 a step that does not carry the field.
 
-`attachments` is the one list field still on the lenient path: a scalar raises,
-but non-string items are coerced with `str()` rather than rejected. That gap is
-tracked in #3555.
+Strict loading of `attachments` is not the same as the field working. A plan
+step's `attachments` is loaded and round-trips through `Task`, but no
+production call site forwards it to `MultiModalContext` or an adapter, so it
+never reaches the capability gate, audit event, lineage receipt, or worktree
+pinning that CLI `--attach` goes through. That gap is tracked in #3555.
 
 Explicit `null` is the one shape where load and validate still disagree by
 design: the loader treats it as absent and returns `[]`, while `plan validate`

--- a/src/bernstein/core/planning/plan_loader.py
+++ b/src/bernstein/core/planning/plan_loader.py
@@ -408,8 +408,11 @@ def _parse_step(
     # Reject scalar / non-list shapes so a YAML typo like
     # ``attachments: ./shot.png`` does not silently iterate the string
     # character-by-character. (bot-ack: 3284182784 -- CodeRabbit major.)
+    # Items are checked too: this field becomes a filesystem path at spawn, so
+    # ``str()`` on a mapping produced "{'a': 'b'}" and handed the adapter a
+    # path that cannot exist and never named the plan line that wrote it.
     attachments: list[str] = _parse_string_list_field(
-        step.get("attachments"), "attachments", f"Step {step_index} in stage {stage_name!r}"
+        step.get("attachments"), "attachments", _step_context(stage_name, step_index)
     )
 
     model_raw = step.get("model")

--- a/src/bernstein/core/planning/plan_loader.py
+++ b/src/bernstein/core/planning/plan_loader.py
@@ -408,16 +408,9 @@ def _parse_step(
     # Reject scalar / non-list shapes so a YAML typo like
     # ``attachments: ./shot.png`` does not silently iterate the string
     # character-by-character. (bot-ack: 3284182784 -- CodeRabbit major.)
-    raw_attachments = step.get("attachments")
-    if raw_attachments is None:
-        attachments: list[str] = []
-    elif isinstance(raw_attachments, list):
-        attachments = [str(a) for a in raw_attachments]
-    else:
-        raise PlanLoadError(
-            f"Step {step_index} in stage {stage_name!r}: 'attachments' must be a "
-            f"list of paths, got {type(raw_attachments).__name__}"
-        )
+    attachments: list[str] = _parse_string_list_field(
+        step.get("attachments"), "attachments", f"Step {step_index} in stage {stage_name!r}"
+    )
 
     model_raw = step.get("model")
     effort_raw = step.get("effort")

--- a/tests/unit/test_multimodal_attestation.py
+++ b/tests/unit/test_multimodal_attestation.py
@@ -538,6 +538,59 @@ class TestPlanLoaderAttachments:
         with pytest.raises(PlanLoadError, match="attachments"):
             load_plan_from_yaml(plan_yaml)
 
+    @pytest.mark.parametrize(
+        ("literal", "expected_type"),
+        [("null", "NoneType"), ("true", "bool"), ("42", "int"), ("{a: b}", "dict")],
+        ids=["null", "bool", "number", "mapping"],
+    )
+    def test_yaml_plan_rejects_non_string_attachment_items(
+        self, tmp_path: Path, literal: str, expected_type: str
+    ) -> None:
+        """Every item becomes a filesystem path at spawn, so a non-string one
+        has to fail at load. `str()` turned these into '42' and "{'a': 'b'}" --
+        paths that cannot exist, reported later by whatever tried to open them
+        rather than by the loader that read the plan line."""
+        img = _make_image(tmp_path / "img.png")
+        plan_yaml = tmp_path / "plan.yaml"
+        plan_yaml.write_text(
+            "name: test\n"
+            "stages:\n"
+            "  - name: phase1\n"
+            "    steps:\n"
+            "      - title: With attachment\n"
+            "        role: backend\n"
+            f"        attachments: ['{img}', {literal}]\n"
+        )
+        from bernstein.core.planning.plan_loader import PlanLoadError, load_plan_from_yaml
+
+        with pytest.raises(PlanLoadError) as exc_info:
+            load_plan_from_yaml(plan_yaml)
+
+        message = str(exc_info.value)
+        assert "attachments[1]" in message
+        assert expected_type in message
+        # The plan line is what the reader has to edit, so the message names it.
+        assert message.startswith("Step 0 in stage 'phase1':"), message
+
+    @pytest.mark.parametrize("literal", ["null", ""], ids=["explicit-null", "absent"])
+    def test_yaml_plan_absent_and_null_attachments_still_load(self, tmp_path: Path, literal: str) -> None:
+        """Steps without attachments are the overwhelming majority; a strict
+        rewrite that rejects the absent case would break every existing plan."""
+        plan_yaml = tmp_path / "plan.yaml"
+        field = f"        attachments: {literal}\n" if literal else ""
+        plan_yaml.write_text(
+            "name: test\n"
+            "stages:\n"
+            "  - name: phase1\n"
+            "    steps:\n"
+            "      - title: No attachment\n"
+            "        role: backend\n" + field
+        )
+        from bernstein.core.planning.plan_loader import load_plan_from_yaml
+
+        tasks = load_plan_from_yaml(plan_yaml)
+        assert tasks[0].attachments == []
+
 
 # ---------------------------------------------------------------------------
 # Hash-matches-base64 invariant (bot-ack: 3284182756)


### PR DESCRIPTION
## Summary

The plan loader was coercing non-string attachment items with `str()`, so non-string YAML items (null/bool/number/mapping) slipped past `PlanLoadError` and became fabricated path strings like `'42'` or `"{'a': 'b'}"`.

## Change

Replace the manual coercion with `_parse_string_list_field()` to validate that all items are strings, matching the behavior of `plan validate`'s `_check_string_items`.

```python
# Before
raw_attachments = step.get("attachments")
if raw_attachments is None:
    attachments: list[str] = []
elif isinstance(raw_attachments, list):
    attachments = [str(a) for a in raw_attachments]
else:
    raise PlanLoadError(...)

# After
attachments: list[str] = _parse_string_list_field(
    step.get("attachments"), "attachments", f"Step {step_index} in stage {stage_name!r}"
)
```

## Scope

This PR addresses only the validation part of #3555. The spawn-path forwarding (ensuring plan-declared attachments reach `MultiModalContext` and the adapter) is a separate change.

Partially fixes #3555