### PR TITLE
fix(planning): reject scalar and non-string items in depends_on/constraints/context_files

### DIFF
--- a/docs/architecture/plans.md
+++ b/docs/architecture/plans.md
@@ -508,7 +508,7 @@ The plan loader validates fields strictly. This table documents the load-time be
 | Field | Accepted shapes | Rejected shapes | Default | Coercion |
 |-------|-----------------|-----------------|---------|----------|
 | `name` | Non-empty string | Empty string, missing | — | — |
-| `depends_on` | Any list, missing, `null` | — | `[]` (missing or `null`) | Every item via `str()`; a scalar string is iterated character-by-character |
+| `depends_on` | `list[str]`, missing, `null` | Scalar, `list[non-str]` | `[]` (missing or `null`) | — |
 
 ### Plan fields
 
@@ -516,8 +516,8 @@ The plan loader validates fields strictly. This table documents the load-time be
 |-------|-----------------|-----------------|---------|----------|
 | `name` | Non-empty string | Empty string, missing | — | — |
 | `stages` | `list[Stage]` | Missing, non-list | — | — |
-| `constraints` | Any list, missing, `null` | — | `[]` (missing or `null`) | None: non-string items pass through unchanged; a scalar string is iterated character-by-character |
-| `context_files` | Any list, missing, `null` | — | `[]` (missing or `null`) | None: non-string items pass through unchanged; a scalar string is iterated character-by-character |
+| `constraints` | `list[str]`, missing, `null` | Scalar, `list[non-str]` | `[]` (missing or `null`) | — |
+| `context_files` | `list[str]`, missing, `null` | Scalar, `list[non-str]` | `[]` (missing or `null`) | — |
 
 ### Differences between load and validate
 
@@ -526,13 +526,8 @@ The plan loader validates fields strictly. This table documents the load-time be
 | `files: null` | Treated as `[]` | Flagged as error |
 | `files: [1, 2]` | Raises `PlanLoadError` | Flagged as error |
 | `attachments: null` | Treated as `[]` | Not checked (loader-only) |
-| `constraints: "abc"` | Becomes `['a', 'b', 'c']` | Flagged as error |
-
-`files` and `attachments` are the only list fields the loader checks item by
-item. `depends_on`, `constraints`, and `context_files` still carry the lenient
-behaviour the stricter loader replaced elsewhere, so a scalar string is
-iterated rather than rejected there. That gap is tracked in #3639; this table
-documents what the loader does today, not what it should do.
+| `constraints: "abc"` | Raises `PlanLoadError` | Flagged as error |
+| `constraints: [1, 2]` | Raises `PlanLoadError` | Flagged as error |
 
 ### Compatibility window
 

--- a/src/bernstein/core/planning/plan_loader.py
+++ b/src/bernstein/core/planning/plan_loader.py
@@ -242,6 +242,38 @@ def _parse_string_list_field(raw: object, field_name: str, stage_name: str, step
     return parsed
 
 
+def _parse_plan_list_field(raw: object, field_name: str, scope: str = "Plan") -> list[str]:
+    """Parse an optional plan- or stage-level list-of-strings field.
+
+    Mirrors ``_parse_string_list_field`` for step fields: a scalar or a
+    non-string item raises ``PlanLoadError`` instead of being silently
+    coerced or iterated character-by-character (issue #3639).
+
+    Args:
+        raw: Raw field value from the YAML.
+        field_name: Field name, for error context.
+        scope: Human-readable location (e.g. ``"Plan"``, ``"Stage 2"``).
+
+    Returns:
+        The string items, or an empty list when the field is absent or
+        explicitly ``null``.
+
+    Raises:
+        PlanLoadError: If the field is present but not a list, or if any
+            list item is not a string.
+    """
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        raise PlanLoadError(f"{scope}: {field_name!r} must be a list of strings, got {type(raw).__name__}")
+    parsed: list[str] = []
+    for item_idx, item in enumerate(raw):
+        if not isinstance(item, str):
+            raise PlanLoadError(f"{scope}: {field_name}[{item_idx}] must be a string, got {type(item).__name__}")
+        parsed.append(item)
+    return parsed
+
+
 def load_plan(path: Path) -> tuple[PlanConfig, list[Task]]:
     """Load a YAML plan file and return plan-level config plus a list of Task objects.
 
@@ -312,11 +344,14 @@ def load_plan(path: Path) -> tuple[PlanConfig, list[Task]]:
             )
         )
 
+    constraints = _parse_plan_list_field(data.get("constraints"), "constraints")
+    context_files = _parse_plan_list_field(data.get("context_files"), "context_files")
+
     config = PlanConfig(
         name=str(data.get("name", "")),
         description=str(data.get("description", "")),
-        constraints=list(data.get("constraints") or []),
-        context_files=list(data.get("context_files") or []),
+        constraints=constraints,
+        context_files=context_files,
         cli=str(data["cli"]) if data.get("cli") else None,
         budget=str(budget_raw) if budget_raw is not None else None,
         max_agents=int(max_agents_raw) if max_agents_raw is not None else None,
@@ -362,7 +397,7 @@ def _parse_stage(
         return
 
     stage_tasks[str(stage_name)] = []
-    stage_deps: list[str] = [str(d) for d in (stage.get("depends_on") or [])]
+    stage_deps = _parse_plan_list_field(stage.get("depends_on"), "depends_on", f"Stage {stage_index}")
     stage_repo: str | None = str(stage["repo"]) if stage.get("repo") else None
 
     for j, step in enumerate(steps):

--- a/tests/unit/test_plan_loader.py
+++ b/tests/unit/test_plan_loader.py
@@ -866,8 +866,82 @@ def test_step_files_scalar_raises_plan_load_error(tmp_path: Path) -> None:
         tmp_path,
         {"stages": [{"name": "S", "steps": [{"title": "T", "files": "src/app.py"}]}]},
     )
+
     with pytest.raises(PlanLoadError, match="'files' must be a"):
         load_plan_from_yaml(plan_file)
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["depends_on", "constraints", "context_files"],
+)
+def test_plan_list_field_scalar_raises_plan_load_error(tmp_path: Path, field: str) -> None:
+    """A scalar string in a plan-level list field must not be iterated."""
+    data: dict[str, object] = {
+        "stages": [{"name": "S", "steps": [{"title": "T"}]}],
+    }
+    if field == "depends_on":
+        data["stages"] = [{"name": "S", "depends_on": "scalar value", "steps": [{"title": "T"}]}]
+    else:
+        data[field] = "scalar value"
+    plan_file = _write_plan(tmp_path, data)
+
+    with pytest.raises(PlanLoadError, match=f"'{field}' must be a list of strings"):
+        load_plan_from_yaml(plan_file)
+
+
+def test_stage_depends_on_scalar_raises_plan_load_error(tmp_path: Path) -> None:
+    """A scalar string in stage `depends_on` must not be iterated."""
+    plan_file = _write_plan(
+        tmp_path,
+        {"stages": [{"name": "S", "depends_on": "Infrastructure", "steps": [{"title": "T"}]}]},
+    )
+
+    with pytest.raises(PlanLoadError, match="Stage 0: 'depends_on' must be a list of strings"):
+        load_plan_from_yaml(plan_file)
+
+
+@pytest.mark.parametrize(
+    ("field", "bad_item", "expected_type"),
+    [
+        ("depends_on", None, "NoneType"),
+        ("constraints", 42, "int"),
+        ("constraints", None, "NoneType"),
+        ("context_files", {"path": "docs/spec.md"}, "dict"),
+    ],
+)
+def test_plan_list_field_non_string_item_raises_plan_load_error(
+    tmp_path: Path, field: str, bad_item: object, expected_type: str
+) -> None:
+    """A non-string item must be a PlanLoadError naming the field and index."""
+    data: dict[str, object] = {
+        "stages": [{"name": "S", "steps": [{"title": "T"}]}],
+    }
+    if field == "depends_on":
+        data["stages"] = [{"name": "S", "depends_on": ["A", bad_item], "steps": [{"title": "T"}]}]
+    else:
+        data[field] = ["valid", bad_item]
+    plan_file = _write_plan(tmp_path, data)
+
+    with pytest.raises(PlanLoadError) as exc_info:
+        load_plan_from_yaml(plan_file)
+
+    message = str(exc_info.value)
+    assert f"{field}[1]" in message
+    assert expected_type in message
+
+
+@pytest.mark.parametrize("field", ["depends_on", "constraints", "context_files"])
+def test_plan_list_field_absent_and_null_default_to_empty(tmp_path: Path, field: str) -> None:
+    """Missing and explicit-`null` list fields must keep returning `[]`."""
+    base = {"stages": [{"name": "S", "steps": [{"title": "T"}]}]}
+    for data in (base, {**base, field: None}):
+        plan_file = _write_plan(tmp_path, data)
+        config, tasks = load_plan(plan_file)
+        if field == "depends_on":
+            assert tasks[0].depends_on == []
+        else:
+            assert getattr(config, field) == []
 
 
 @pytest.mark.parametrize("value", ["3", True, 2.5], ids=["str", "bool", "float"])


### PR DESCRIPTION
Fixes #3639

**Problem:** a scalar string in `depends_on`, `constraints`, or `context_files` was iterated character-by-character (`constraints: "no network calls"` became 17 one-char entries), and non-string items passed through unchanged or were silently `str()`-coerced (`depends_on: [null]` became the fabricated stage name `None`) — no error, wrong data.

**Fix:** route all three fields through a plan/stage-level variant of the shared `_parse_string_list_field` that `files` already uses:
- scalar value → `PlanLoadError` naming the field
- non-string list item → `PlanLoadError` naming the field and index (same message shape as `files`)
- missing / explicit `null` → still `[]`

**Docs:** `docs/architecture/plans.md` tables updated to the strict behavior; the paragraph documenting the lenient behavior as current is removed.

**Tests:** one per field for the scalar case, one per field for the non-string item case, plus missing/null defaulting pinned by test.

Verified: `pytest tests/unit/test_plan_loader.py` (67 passed) plus dependent suites (context_files attachment, per-step routing, startup task count) all green; `ruff check` and `ruff format --check` clean.