### PR TITLE
feat(lineage): block writes without verified tool-call evidence

### DIFF
--- a/docs/operations/mcp-gateway.md
+++ b/docs/operations/mcp-gateway.md
@@ -128,6 +128,14 @@ dispatch is paired and identity-verified, the whole-run verdict remains
 launch path yet. The receipt is therefore evidence of the retained interval,
 not evidence that no later call occurred.
 
+For pre-merge enforcement, janitor can receive the authenticated audit-chain
+source and couple it to the signed lineage log. Every
+`LineageEntry.tool_call_id` must then equal the `request_id` of one
+identity-valid, uniquely consumed enforced dispatch. Missing, unsigned,
+duplicated, reordered, mismatched, or audit-tampered evidence blocks the
+janitor verdict. If no audit-chain context is supplied, the legacy lineage
+gate remains available but makes no tool-call attestation claim.
+
 This initial integration seam is programmatic. The CLI does not select a
 provider yet, and an unwired gateway retains its existing observe-only
 behavior. The boundary covers calls that cross the gateway; it cannot contain

--- a/docs/sdd/toolcall-attestation-interlock.md
+++ b/docs/sdd/toolcall-attestation-interlock.md
@@ -88,6 +88,31 @@ This boundary does not contain direct filesystem, process, network, or
 connector effects that bypass the host hook. A completeness statement is valid
 only for the dispatch surfaces wired through the interlock.
 
+## LineageGate coupling
+
+The pre-merge coupling is a separate consumer of the same evidence. The
+janitor authenticates the native audit chain first, then
+`verified_tool_call_ids` projects only request ids that have all of the
+following:
+
+- one spawn-frozen tool-signing identity;
+- an identity envelope valid for that exact run, request, intent, call index,
+  journal head, audit predecessor, and anchor;
+- one immediately following `toolcall.enforced_dispatch` with the same
+  attestation reference and intent digest; and
+- no duplicate request id or attestation consumption.
+
+`LineageEntry.tool_call_id` is matched against that request-id projection.
+When authenticated evidence is explicitly supplied, a missing match is a
+blocking LineageGate failure surfaced in the janitor signal list. The lineage
+gate never opens the audit store and never infers verification mode from a
+payload field; it accepts only the frozen set its security caller derived.
+
+Supplying no audit-chain context preserves the existing lineage-only behavior.
+That compatibility path is not an attestation claim. Legacy HMAC-only
+attestations remain inspectable but are ineligible to authorize a signed
+artefact write through this coupling.
+
 ## Performance measurement
 
 `scripts/bench_toolcall_interlock.py` compares full

--- a/src/bernstein/core/lineage/gate.py
+++ b/src/bernstein/core/lineage/gate.py
@@ -11,6 +11,8 @@ every entry in `log.jsonl` is:
   5. Free of unresolved forks (each open tip is single OR is a merge entry).
   6. (Optional) Authored by a steward-allow-listed agent when the entry is
      a merge (parent_hashes length >= 2).
+  7. (Optional) Coupled to a caller-supplied set of authenticated tool-call
+     attestations.
 
 The check is read-only and does not depend on the LineageStore - it can
 operate on a frozen log + cards directory (e.g. an audit pack).
@@ -189,6 +191,7 @@ def check(
     *,
     operator_secret: bytes | None = None,
     steward_allowlist: frozenset[str] | None = None,
+    verified_tool_call_ids: frozenset[str] | None = None,
 ) -> GateResult:
     """Run all lineage invariants against the log + cards on disk.
 
@@ -200,6 +203,11 @@ def check(
             HMAC field itself). When None, the HMAC check is skipped.
         steward_allowlist: when given, every merge entry's `agent_id` must
             be in this set or the gate fails (privilege escalation guard).
+        verified_tool_call_ids: authenticated tool-call request identifiers
+            supplied by the caller. When provided, every entry's signed
+            ``tool_call_id`` must occur in this set. ``None`` preserves the
+            legacy/audit-disabled gate; an empty set enables the coupling and
+            therefore rejects every referenced tool call.
 
     Returns:
         GateResult with ok=True iff failures is empty.
@@ -269,6 +277,16 @@ def check(
         if steward_allowlist is not None and len(entry.parent_hashes) >= 2 and entry.agent_id not in steward_allowlist:
             failures.append(
                 f"{entry.artefact_path}: merge entry {eh} written by non-steward {entry.agent_id!r} (not in allowlist)"
+            )
+        # The lineage module deliberately does not open or interpret the audit
+        # chain.  The security caller verifies that chain and projects exactly
+        # the request ids supported by identity-bound tool-call evidence.  This
+        # keeps payload contents from selecting their own verification mode and
+        # keeps the frozen lineage gate usable in legacy/audit-disabled packs.
+        if verified_tool_call_ids is not None and entry.tool_call_id not in verified_tool_call_ids:
+            failures.append(
+                f"{entry.artefact_path}: tool_call_id {entry.tool_call_id!r} on entry {eh} "
+                "has no matching verified toolcall.attestation"
             )
 
     # Parent-hash chain integrity.

--- a/src/bernstein/core/quality/janitor.py
+++ b/src/bernstein/core/quality/janitor.py
@@ -40,7 +40,9 @@ from bernstein.core.quality.verifier_ladder import (
 )
 
 if TYPE_CHECKING:
+    from bernstein.core.lineage.gate import GateResult
     from bernstein.core.persistence.lineage import LineageVerificationResult
+    from bernstein.core.security.audit_chain import AuditChainStore
 
 logger = logging.getLogger(__name__)
 
@@ -604,6 +606,63 @@ def verify_lineage_chains(
     return results
 
 
+def verify_lineage_tool_call_gate(
+    workdir: Path,
+    *,
+    audit_chain: AuditChainStore | None = None,
+    operator_secret: bytes | None = None,
+) -> GateResult:
+    """Run the signed-lineage gate with authenticated tool-call evidence.
+
+    The coupling is opt-in at the caller boundary.  Passing no audit chain
+    preserves the legacy/audit-disabled lineage verdict byte-for-byte.  When a
+    chain is supplied, this function authenticates it before projecting
+    identity-bound request ids; an audit verification failure therefore blocks
+    rather than degrading to an unverified payload lookup.
+
+    The function returns :class:`bernstein.core.lineage.gate.GateResult` but
+    keeps the import local so the quality module does not make security-chain
+    construction a mandatory dependency for ordinary janitor runs.
+    """
+    from bernstein.core.lineage.gate import GateResult, check
+
+    sdd = workdir / ".sdd"
+    log_path = sdd / "lineage" / "log.jsonl"
+    cards_dir = sdd / "agents"
+    if audit_chain is None:
+        return check(log_path, cards_dir, operator_secret=operator_secret)
+
+    scan = audit_chain.scan_verified(None)
+    if not scan.ok:
+        errors = scan.errors or ["authenticated audit scan failed"]
+        return GateResult(
+            ok=False,
+            failures=[f"audit chain: {error}" for error in errors],
+        )
+
+    from bernstein.core.security.toolcall_interlock import verified_tool_call_ids
+
+    events = [
+        {
+            "timestamp": event.timestamp,
+            "event_type": event.event_type,
+            "actor": event.actor,
+            "resource_type": event.resource_type,
+            "resource_id": event.resource_id,
+            "details": event.details,
+            "prev_hmac": event.prev_hmac,
+            "hmac": event.hmac,
+        }
+        for event in scan.events
+    ]
+    return check(
+        log_path,
+        cards_dir,
+        operator_secret=operator_secret,
+        verified_tool_call_ids=verified_tool_call_ids(events),
+    )
+
+
 def _surface_tamper(
     run_id: str,
     result: LineageVerificationResult,
@@ -812,6 +871,8 @@ async def run_janitor(
     judge_model: str | None = None,
     judge_provider: str | None = None,
     ladder: VerifierLadderContext | None = None,
+    lineage_audit_chain: AuditChainStore | None = None,
+    lineage_operator_secret: bytes | None = None,
 ) -> list[JanitorResult]:
     """Evaluate tasks and return structured results.
 
@@ -842,6 +903,12 @@ async def run_janitor(
             ``LadderReceipt`` hash is returned on
             ``JanitorResult.ladder_receipt_hash``. Default ``None``: nothing
             is sealed and janitor behaviour is unchanged.
+        lineage_audit_chain: Optional authenticated audit-chain source for the
+            LineageGate/tool-call coupling. When supplied, a signed lineage
+            entry without matching identity-valid dispatch evidence blocks the
+            janitor verdict. ``None`` preserves legacy/audit-disabled behavior.
+        lineage_operator_secret: Optional HMAC secret for the ordinary signed
+            lineage checks performed by that coupled gate.
 
     Returns:
         List of JanitorResult for each evaluated task.
@@ -852,9 +919,16 @@ async def run_janitor(
     # workdirs (unit tests, dry runs) skip the empty-diff guard entirely --
     # signals-only judgment there is unchanged behavior.
     _attribution_possible = _is_git_repo(workdir)
+    lineage_gate_result = None
+    if lineage_audit_chain is not None:
+        lineage_gate_result = verify_lineage_tool_call_gate(
+            workdir,
+            audit_chain=lineage_audit_chain,
+            operator_secret=lineage_operator_secret,
+        )
     results: list[JanitorResult] = []
     for task in tasks:
-        if not task.completion_signals:
+        if not task.completion_signals and lineage_gate_result is None:
             continue
 
         judge_verdict: JudgeVerdict | None = None
@@ -954,6 +1028,21 @@ async def run_janitor(
                 task.id,
                 [(gr.check, gr.detail) for gr in blocked_guards],
             )
+
+        if lineage_gate_result is not None:
+            if lineage_gate_result.ok:
+                signal_results.append(("lineage:tool_call_attestation", True, ""))
+            else:
+                all_passed = False
+                for failure in lineage_gate_result.failures:
+                    detail = f"lineage:tool_call_attestation: {failure}"
+                    signal_results.append(("lineage:tool_call_attestation", False, failure))
+                    failed_descs.append(detail)
+                logger.warning(
+                    "janitor REJECT (lineage tool-call gate): task=%s failures=%s",
+                    task.id,
+                    lineage_gate_result.failures,
+                )
 
         fix_task_ids = await _create_fix_tasks_if_needed(
             task,

--- a/src/bernstein/core/security/toolcall_interlock.py
+++ b/src/bernstein/core/security/toolcall_interlock.py
@@ -319,6 +319,149 @@ def derive_attestation_verdict(
     return AttestationVerdict.COMPLETE
 
 
+def verified_tool_call_ids(
+    events: Sequence[Mapping[str, Any]],
+    *,
+    witnessed: bool = False,
+) -> frozenset[str]:
+    """Project request ids backed by identity-valid enforced dispatches.
+
+    ``events`` must already have been authenticated and retained in native
+    chain order by the caller.  This function intentionally does not accept a
+    claimed mode and does not inspect an audit path: provenance context comes
+    from the caller, while the payload supplies only evidence to verify.
+
+    A request id is returned only when all of the following hold:
+
+    * exactly one verified run identity anchor binds its tool-signing key;
+    * the attestation's identity envelope verifies against that frozen key;
+    * identity call indices for that run are contiguous in chain order;
+    * the attestation occupies the chain predecessor its signed record names;
+    * exactly one later, adjacent enforced-dispatch marker consumes the same
+      attestation reference and intent digest; and
+    * the request id is unique across the supplied evidence.
+
+    Legacy unsigned attestations remain readable by the ordinary verdict walk
+    but cannot authorize a lineage write.  Any malformed or ambiguous evidence
+    simply omits that request id, so the lineage gate reports the load-bearing
+    failure at the artefact that referenced it.
+    """
+
+    def _payload(event: Mapping[str, Any]) -> Mapping[str, Any]:
+        details = event.get("details")
+        return cast("Mapping[str, Any]", details) if isinstance(details, Mapping) else event
+
+    anchors: dict[str, list[tuple[Mapping[str, Any], str]]] = {}
+    for event in events:
+        if str(event.get("event_type", event.get("event", ""))) != "identity.spawn_attestation":
+            continue
+        payload = _payload(event)
+        run_id = str(payload.get("run_id", event.get("resource_id", ""))).strip()
+        if not run_id:
+            continue
+        anchor_hmac = ""
+        if witnessed:
+            original_hmac = payload.get("_original_hmac")
+            if original_hmac is not None:
+                anchor_hmac = str(original_hmac).strip()
+        if not anchor_hmac:
+            anchor_hmac = str(event.get("hmac", "")).strip()
+        anchors.setdefault(run_id, []).append((payload, "hmac:" + anchor_hmac if anchor_hmac else ""))
+
+    attestations_by_run: dict[str, list[tuple[int, Mapping[str, Any], Mapping[str, Any]]]] = {}
+    dispatches_by_ref: dict[str, list[tuple[int, Mapping[str, Any], Mapping[str, Any]]]] = {}
+    for position, event in enumerate(events):
+        event_type = str(event.get("event_type", event.get("event", "")))
+        payload = _payload(event)
+        if event_type == "toolcall.attestation" and isinstance(payload.get("identity_envelope"), Mapping):
+            run_id = str(payload.get("run_id", "")).strip()
+            if run_id:
+                attestations_by_run.setdefault(run_id, []).append((position, event, payload))
+        elif event_type == "toolcall.enforced_dispatch":
+            reference = str(payload.get("attestation_ref", "")).strip()
+            if reference:
+                dispatches_by_ref.setdefault(reference, []).append((position, event, payload))
+
+    candidates: list[tuple[str, int, Mapping[str, Any], Mapping[str, Any]]] = []
+    invalid_runs: set[str] = set()
+    for run_id, run_attestations in attestations_by_run.items():
+        anchor_rows = anchors.get(run_id, [])
+        if len(anchor_rows) != 1:
+            invalid_runs.add(run_id)
+            continue
+        anchor, anchor_ref = anchor_rows[0]
+        if not anchor_ref or anchor.get("tool_signing_kid") is None:
+            invalid_runs.add(run_id)
+            continue
+        expected_index = 1
+        for position, event, payload in run_attestations:
+            reference = str(payload.get("attestation_ref", "")).strip()
+            intent_digest = str(payload.get("intent_digest", "")).strip()
+            envelope = cast("Mapping[str, Any]", payload["identity_envelope"])
+            try:
+                record = verify_identity_envelope(
+                    envelope,
+                    anchor,
+                    expected_intent_digest=intent_digest,
+                    expected_attestation_ref=reference,
+                )
+            except ToolCallIdentityError:
+                invalid_runs.add(run_id)
+                break
+            bindings = {
+                "run_id": record.run_id,
+                "agent_id": record.agent_id,
+                "scope_id": record.scope_id,
+                "server_name": record.server_name,
+                "method": record.method,
+                "tool_name": record.tool_name,
+                "request_id": record.request_id,
+                "span_id": record.span_id,
+                "args_digest": record.args_digest,
+                "call_index": record.call_index,
+                "identity_anchor_ref": record.identity_anchor_ref,
+            }
+            event_prev = str(event.get("prev_hmac", "")).strip()
+            if (
+                record.call_index != expected_index
+                or record.identity_anchor_ref != anchor_ref
+                or record.prev_chain_digest != payload.get("prev_chain_digest")
+                or (event_prev and record.prev_chain_digest != event_prev)
+                or any(payload.get(key) != value for key, value in bindings.items())
+            ):
+                invalid_runs.add(run_id)
+                break
+            expected_index += 1
+            candidates.append((record.request_id, position, event, payload))
+
+    verified: set[str] = set()
+    duplicate_ids: set[str] = set()
+    for request_id, position, attestation_event, payload in candidates:
+        run_id = str(payload.get("run_id", "")).strip()
+        if run_id in invalid_runs or not request_id:
+            continue
+        reference = str(payload.get("attestation_ref", "")).strip()
+        intent_digest = str(payload.get("intent_digest", "")).strip()
+        dispatches = dispatches_by_ref.get(reference, [])
+        if len(dispatches) != 1:
+            continue
+        dispatch_position, dispatch_event, dispatch = dispatches[0]
+        attestation_hmac = str(attestation_event.get("hmac", "")).strip()
+        if (
+            dispatch_position != position + 1
+            or dispatch.get("intent_digest") != intent_digest
+            or dispatch.get("request_id") != request_id
+            or dispatch.get("run_id") != run_id
+            or (attestation_hmac and str(dispatch_event.get("prev_hmac", "")).strip() != attestation_hmac)
+        ):
+            continue
+        if request_id in verified:
+            duplicate_ids.add(request_id)
+        verified.add(request_id)
+
+    return frozenset(verified - duplicate_ids)
+
+
 def project_attestation_mode(
     events: Sequence[Mapping[str, Any]], *, claimed_mode: str = ""
 ) -> AttestationModeProjection:
@@ -346,4 +489,5 @@ __all__ = [
     "VerifiedDispatchEvidence",
     "derive_attestation_verdict",
     "project_attestation_mode",
+    "verified_tool_call_ids",
 ]

--- a/tests/unit/security/test_lineage_toolcall_gate.py
+++ b/tests/unit/security/test_lineage_toolcall_gate.py
@@ -1,0 +1,194 @@
+"""Adversarial contracts for LineageGate/tool-call evidence coupling."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from bernstein.core.models import Task
+
+from bernstein.core.lineage.identity import AgentCard
+from bernstein.core.lineage.signed_write import SignedLineageLog
+from bernstein.core.lineage.store import LineageStore
+from bernstein.core.quality.janitor import run_janitor, verify_lineage_tool_call_gate
+from bernstein.core.security.agent_card_signer import generate_ed25519_keypair, sign_agent_card
+from bernstein.core.security.agent_identity import AgentIdentityCard
+from bernstein.core.security.audit_chain import AuditChainStore
+from bernstein.core.security.identity_spawn_anchor import IdentitySpawnAnchor
+from bernstein.core.security.native_toolcall_evidence import NativeToolCallEvidenceProvider
+from bernstein.core.security.toolcall_identity import LineageToolCallIdentitySigner
+from bernstein.core.security.toolcall_interlock import ToolCallIntent, verified_tool_call_ids
+
+_AUDIT_KEY = b"a" * 32
+_LINEAGE_KEY = b"lineage-operator-key"
+
+
+def _event_dict(event: Any) -> dict[str, Any]:
+    return {
+        "event_type": event.event_type,
+        "resource_id": event.resource_id,
+        "details": event.details,
+        "prev_hmac": event.prev_hmac,
+        "hmac": event.hmac,
+    }
+
+
+def _seed(
+    tmp_path: Path,
+    *,
+    lineage_tool_call_id: str = "tc-1",
+    attested_ids: tuple[str, ...] = ("tc-1",),
+) -> AuditChainStore:
+    sdd = tmp_path / ".sdd"
+    chain = AuditChainStore(sdd / "audit", key=_AUDIT_KEY)
+    card_private, card_public = generate_ed25519_keypair()
+    tool_private, tool_public = generate_ed25519_keypair()
+    identity_card = AgentIdentityCard(
+        agent_id="agent-1",
+        role="coder",
+        adapter="codex",
+        model="gpt",
+        created_at=100,
+        expires_at=200,
+    )
+    identity = IdentitySpawnAnchor(chain, {"spawn-key": card_public}, clock=lambda: 150).anchor(
+        run_id="run-1",
+        card=identity_card,
+        signature=sign_agent_card(identity_card, card_private, kid="spawn-key"),
+        run_journal_head="journal:fixed",
+        tool_signing_card=AgentCard("agent-1", "tool-key", tool_public.decode()),
+    )
+    provider = NativeToolCallEvidenceProvider(
+        chain,
+        run_identity=identity,
+        signer=LineageToolCallIdentitySigner(tool_private.decode(), "tool-key"),
+        run_journal_head=lambda: "journal:fixed",
+        clock_ns=lambda: 123_000_000_001,
+    )
+    for call_index, request_id in enumerate(attested_ids, start=1):
+        intent = ToolCallIntent.from_request(
+            scope_id="scope:run-1:agent-1",
+            server_name="filesystem",
+            method="tools/call",
+            tool_name="write_file",
+            request_id=request_id,
+            span_id=f"span-{call_index}",
+            arguments={"path": "src/result.py", "content": "secret-free"},
+        )
+        asyncio.run(provider.prepare_dispatch(intent))
+
+    lineage_card = AgentCard("agent-1", "tool-key", tool_public.decode())
+    card_dir = sdd / "agents" / lineage_card.agent_id
+    card_dir.mkdir(parents=True)
+    (card_dir / "card.json").write_text(
+        json.dumps(
+            {
+                "agent_id": lineage_card.agent_id,
+                "kid": lineage_card.kid,
+                "public_key_pem": lineage_card.public_key_pem,
+                "protocolVersion": lineage_card.protocol_version,
+            }
+        )
+    )
+    recorder = SignedLineageLog(LineageStore(sdd / "lineage"), operator_hmac_key=_LINEAGE_KEY)
+    recorder.record_write(
+        artefact_path="src/result.py",
+        new_content=b"result = 1\n",
+        agent_id=lineage_card.agent_id,
+        agent_card=lineage_card,
+        private_key_pem=tool_private.decode(),
+        tool_call_id=lineage_tool_call_id,
+        span_id="span-1",
+        ts_ns=123,
+    )
+    return chain
+
+
+def test_verified_identity_dispatch_authorizes_matching_lineage_write(tmp_path: Path) -> None:
+    chain = _seed(tmp_path)
+
+    result = verify_lineage_tool_call_gate(tmp_path, audit_chain=chain, operator_secret=_LINEAGE_KEY)
+
+    assert result.ok is True, result.failures
+
+
+def test_missing_or_mismatched_request_id_blocks_the_lineage_write(tmp_path: Path) -> None:
+    chain = _seed(tmp_path, lineage_tool_call_id="tc-other")
+
+    result = verify_lineage_tool_call_gate(tmp_path, audit_chain=chain, operator_secret=_LINEAGE_KEY)
+
+    assert result.ok is False
+    assert any("tc-other" in failure and "no matching verified" in failure for failure in result.failures)
+
+
+def test_no_audit_context_preserves_legacy_lineage_behavior(tmp_path: Path) -> None:
+    _seed(tmp_path, lineage_tool_call_id="tc-other")
+
+    result = verify_lineage_tool_call_gate(tmp_path, operator_secret=_LINEAGE_KEY)
+
+    assert result.ok is True, result.failures
+
+
+def test_unsigned_attestation_and_reordered_dispatch_do_not_authorize(tmp_path: Path) -> None:
+    chain = _seed(tmp_path)
+    events = [_event_dict(event) for event in chain.query(include_archived=True)]
+    attestation_index = next(i for i, event in enumerate(events) if event["event_type"] == "toolcall.attestation")
+    dispatch_index = next(i for i, event in enumerate(events) if event["event_type"] == "toolcall.enforced_dispatch")
+
+    unsigned = [dict(event) for event in events]
+    unsigned[attestation_index] = dict(unsigned[attestation_index])
+    unsigned[attestation_index]["details"] = dict(unsigned[attestation_index]["details"])
+    unsigned[attestation_index]["details"].pop("identity_envelope")
+    assert "tc-1" not in verified_tool_call_ids(unsigned)
+
+    reordered = list(events)
+    reordered[attestation_index], reordered[dispatch_index] = reordered[dispatch_index], reordered[attestation_index]
+    assert "tc-1" not in verified_tool_call_ids(reordered)
+
+    mismatched = [dict(event) for event in events]
+    mismatched[dispatch_index] = dict(mismatched[dispatch_index])
+    mismatched[dispatch_index]["details"] = dict(mismatched[dispatch_index]["details"])
+    mismatched[dispatch_index]["details"]["intent_digest"] = "sha256:mismatch"
+    assert "tc-1" not in verified_tool_call_ids(mismatched)
+
+
+def test_duplicate_request_id_is_ambiguous_and_blocks(tmp_path: Path) -> None:
+    chain = _seed(tmp_path, attested_ids=("tc-1", "tc-1"))
+
+    result = verify_lineage_tool_call_gate(tmp_path, audit_chain=chain, operator_secret=_LINEAGE_KEY)
+
+    assert result.ok is False
+    assert any("tc-1" in failure and "no matching verified" in failure for failure in result.failures)
+
+
+def test_tampered_audit_chain_blocks_before_payload_projection(tmp_path: Path) -> None:
+    chain = _seed(tmp_path)
+    segment = next((tmp_path / ".sdd" / "audit").glob("*.jsonl"))
+    raw = segment.read_text()
+    assert '"request_id": "tc-1"' in raw
+    segment.write_text(raw.replace('"request_id": "tc-1"', '"request_id": "tc-X"', 1))
+
+    result = verify_lineage_tool_call_gate(tmp_path, audit_chain=chain, operator_secret=_LINEAGE_KEY)
+
+    assert result.ok is False
+    assert any("audit chain:" in failure for failure in result.failures)
+
+
+@pytest.mark.asyncio
+async def test_janitor_blocks_merge_on_uncoupled_lineage_write(tmp_path: Path) -> None:
+    chain = await asyncio.to_thread(_seed, tmp_path, lineage_tool_call_id="tc-other")
+    task = Task(id="T-gate", title="Gate", description="Gate", role="backend")
+
+    results = await run_janitor(
+        [task],
+        tmp_path,
+        lineage_audit_chain=chain,
+        lineage_operator_secret=_LINEAGE_KEY,
+    )
+
+    assert len(results) == 1
+    assert results[0].passed is False
+    assert any(not passed and desc == "lineage:tool_call_attestation" for desc, passed, _ in results[0].signal_results)


### PR DESCRIPTION
## Summary

Partial implementation of #2931.

This slice couples signed lineage writes to authenticated tool-call evidence at the pre-merge boundary.

When janitor receives an audit-chain context:

- it authenticates the audit chain before reading its events;
- it projects only identity-valid, uniquely dispatched tool-call request IDs;
- `LineageGate.check` requires every signed `LineageEntry.tool_call_id` to match one of those verified request IDs; and
- a missing match becomes a blocking janitor failure.

Without an audit-chain context, the existing lineage-only behavior remains unchanged.

## Trust boundary

`LineageGate` does not open or interpret the audit chain. Its security caller authenticates the chain and supplies a frozen set of verified request IDs.

A request ID qualifies only when:

1. exactly one run identity anchor binds the tool-signing key;
2. the identity envelope verifies against that frozen key;
3. the signed run, request, intent, call index, journal head, audit predecessor, and anchor all match;
4. call indices are contiguous;
5. exactly one immediately following `toolcall.enforced_dispatch` consumes the same attestation reference and intent digest; and
6. the request ID is unique across the supplied evidence.

The signed lineage entry's `tool_call_id` must equal that verified `request_id`.

Verification context comes from the caller. No payload field can select its own provenance or verification mode.

## Adversarial matrix

| Case | Expected result |
|---|---|
| Identity-valid attestation and matching dispatch | Write passes |
| No audit context supplied | Existing lineage behavior is preserved |
| Missing or mismatched request ID | Merge is blocked |
| Identity envelope removed | Request ID cannot authorize the write |
| Dispatch reordered before its attestation | Request ID cannot authorize the write |
| Dispatch intent digest substituted | Request ID cannot authorize the write |
| Duplicate request ID | Treated as ambiguous; merge is blocked |
| Physical byte mutation in the audit chain | Authentication fails before projection |
| Ordinary checks pass but lineage coupling fails | Janitor verdict is blocking |

## Verification

- 207 focused and neighboring tests passed:
  - LineageGate
  - janitor
  - tool-call identity
  - native evidence provider
  - attestation interlock
  - new adversarial coupling tests
- Ruff check passed.
- Ruff formatting check passed.
- Strict Pyright passed with 0 errors.
- All three import architecture contracts passed.
- Generated agent-context files were synchronized.
- `git diff --check` passed.
