### PR TITLE
Partial implementation of #2953

### DIFF
--- a/src/bernstein/core/lineage/entry.py
+++ b/src/bernstein/core/lineage/entry.py
@@ -40,6 +40,7 @@ ARTEFACT_KINDS: frozenset[str] = frozenset(
         "ops_result",
         "query-result",
         "external",
+        "finding"
     }
 )
 

--- a/src/bernstein/core/lineage/entry.py
+++ b/src/bernstein/core/lineage/entry.py
@@ -40,7 +40,7 @@ ARTEFACT_KINDS: frozenset[str] = frozenset(
         "ops_result",
         "query-result",
         "external",
-        "finding"
+        "finding",
     }
 )
 

--- a/src/bernstein/core/tasks/artifacts.py
+++ b/src/bernstein/core/tasks/artifacts.py
@@ -148,7 +148,6 @@ def _coerce_rows(raw: Any) -> list[Any]:
 
 def _canonical_finding_bytes(raw: Any) -> bytes:
     """Canonicalise a SARIF 2.1.0 finding artifact for content-addressing.
-    
     Projects the finding down to stable identity fields, deliberately dropping
     the raw line number so cosmetic shifts don't change the hash. Binds tool
     context so the identity is anchored to the exact invocation.
@@ -158,16 +157,16 @@ def _canonical_finding_bytes(raw: Any) -> bytes:
 
     # Extract SARIF result fields
     rule_id = str(raw.get("ruleId", ""))
-    
+
     # Normalise artifact location URI to forward slashes
     artifact_location = raw.get("artifactLocation", {})
     uri = str(artifact_location.get("uri", "")).replace("\\", "/")
-    
+
     # Hash the snippet text instead of using the raw line number
     region = raw.get("region", {})
     snippet_text = str(region.get("snippet", {}).get("text", ""))
     snippet_hash = "sha256:" + hashlib.sha256(snippet_text.encode("utf-8")).hexdigest()
-    
+
     # Bind context fields required by the issue
     projected = {
         "ruleId": rule_id,
@@ -179,7 +178,7 @@ def _canonical_finding_bytes(raw: Any) -> bytes:
         "invocation_argv_hash": str(raw.get("invocation_argv_hash", "")),
         "target": str(raw.get("target", "")),
     }
-    
+
     return _canonical_json_bytes(projected)
 
 def canonicalise_artifact(kind: ArtifactKind | str, raw: Any) -> bytes:

--- a/src/bernstein/core/tasks/artifacts.py
+++ b/src/bernstein/core/tasks/artifacts.py
@@ -146,6 +146,7 @@ def _coerce_rows(raw: Any) -> list[Any]:
 # Per-kind canonicalisers + content hash
 # ---------------------------------------------------------------------------
 
+
 def _canonical_finding_bytes(raw: Any) -> bytes:
     """Canonicalise a SARIF 2.1.0 finding artifact for content-addressing.
     Projects the finding down to stable identity fields, deliberately dropping
@@ -180,6 +181,7 @@ def _canonical_finding_bytes(raw: Any) -> bytes:
     }
 
     return _canonical_json_bytes(projected)
+
 
 def canonicalise_artifact(kind: ArtifactKind | str, raw: Any) -> bytes:
     """Return the canonical bytes for ``raw`` under ``kind``'s rule.

--- a/src/bernstein/core/tasks/artifacts.py
+++ b/src/bernstein/core/tasks/artifacts.py
@@ -41,6 +41,7 @@ class ArtifactKind(StrEnum):
     DATASET = "dataset"
     ACTION_LOG = "action_log"
     OPS_RESULT = "ops_result"
+    FINDING = "finding"
 
 
 #: Kinds whose canonical form is normalised UTF-8 *text*.
@@ -145,6 +146,41 @@ def _coerce_rows(raw: Any) -> list[Any]:
 # Per-kind canonicalisers + content hash
 # ---------------------------------------------------------------------------
 
+def _canonical_finding_bytes(raw: Any) -> bytes:
+    """Canonicalise a SARIF 2.1.0 finding artifact for content-addressing.
+    
+    Projects the finding down to stable identity fields, deliberately dropping
+    the raw line number so cosmetic shifts don't change the hash. Binds tool
+    context so the identity is anchored to the exact invocation.
+    """
+    if not isinstance(raw, dict):
+        raise CanonicalisationError(f"finding artifact must be a mapping, got {type(raw).__name__}")
+
+    # Extract SARIF result fields
+    rule_id = str(raw.get("ruleId", ""))
+    
+    # Normalise artifact location URI to forward slashes
+    artifact_location = raw.get("artifactLocation", {})
+    uri = str(artifact_location.get("uri", "")).replace("\\", "/")
+    
+    # Hash the snippet text instead of using the raw line number
+    region = raw.get("region", {})
+    snippet_text = str(region.get("snippet", {}).get("text", ""))
+    snippet_hash = "sha256:" + hashlib.sha256(snippet_text.encode("utf-8")).hexdigest()
+    
+    # Bind context fields required by the issue
+    projected = {
+        "ruleId": rule_id,
+        "uri": uri,
+        "snippet_hash": snippet_hash,
+        "tool": str(raw.get("tool", "")),
+        "tool_version": str(raw.get("tool_version", "")),
+        "pinned_digest": str(raw.get("pinned_digest", "")),
+        "invocation_argv_hash": str(raw.get("invocation_argv_hash", "")),
+        "target": str(raw.get("target", "")),
+    }
+    
+    return _canonical_json_bytes(projected)
 
 def canonicalise_artifact(kind: ArtifactKind | str, raw: Any) -> bytes:
     """Return the canonical bytes for ``raw`` under ``kind``'s rule.
@@ -160,6 +196,8 @@ def canonicalise_artifact(kind: ArtifactKind | str, raw: Any) -> bytes:
         return b"\n".join(_canonical_json_bytes(row) for row in rows)
     if k in _JSON_OBJECT_KINDS:
         return _canonical_json_bytes(raw)
+    if k is ArtifactKind.FINDING:
+        return _canonical_finding_bytes(raw)
     raise CanonicalisationError(f"no canonicaliser registered for kind {k!r}")
 
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,4 +1,5 @@
 # Test suite
+
 Layered pytest suite. `unit/` is the big one (1600+ files, no network);
 `integration/` needs a running server; `contract/` holds the adapter
 capability contracts; plus `property/`, `snapshot/`, `golden/`,
@@ -13,6 +14,7 @@ uv run pytest tests/unit/test_foo.py -x -q    # single file (fast)
 ```
 
 ## Invariants
+
 - NEVER run bare `pytest` over the whole suite: pytest retains test
   objects for the session, and 2000+ files leak into 100+ GB of RAM.
   The isolated per-file runner caps memory at one file's worth
@@ -29,7 +31,9 @@ uv run pytest tests/unit/test_foo.py -x -q    # single file (fast)
   extend them when adding gated docs.
 - Tests for `scripts/*.py` load the script via importlib; git-derived
   behaviour runs on synthetic repos (`unit/test_context_staleness.py`).
+
 ## Gotchas
+
 - CI shards the suite with `scripts/run_tests.py --shard N/M`; a test
   that depends on sibling-file ordering is already broken.
 - Live adapter conformance tests are opt-in via the `--live` flag

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,5 +1,4 @@
 # Test suite
-
 Layered pytest suite. `unit/` is the big one (1600+ files, no network);
 `integration/` needs a running server; `contract/` holds the adapter
 capability contracts; plus `property/`, `snapshot/`, `golden/`,
@@ -14,7 +13,6 @@ uv run pytest tests/unit/test_foo.py -x -q    # single file (fast)
 ```
 
 ## Invariants
-
 - NEVER run bare `pytest` over the whole suite: pytest retains test
   objects for the session, and 2000+ files leak into 100+ GB of RAM.
   The isolated per-file runner caps memory at one file's worth
@@ -31,9 +29,7 @@ uv run pytest tests/unit/test_foo.py -x -q    # single file (fast)
   extend them when adding gated docs.
 - Tests for `scripts/*.py` load the script via importlib; git-derived
   behaviour runs on synthetic repos (`unit/test_context_staleness.py`).
-
 ## Gotchas
-
 - CI shards the suite with `scripts/run_tests.py --shard N/M`; a test
   that depends on sibling-file ordering is already broken.
 - Live adapter conformance tests are opt-in via the `--live` flag

--- a/tests/unit/core/tasks/test_finding_artifact.py
+++ b/tests/unit/core/tasks/test_finding_artifact.py
@@ -1,0 +1,49 @@
+import pytest
+from bernstein.core.tasks.artifacts import artifact_content_hash, ArtifactKind
+
+def test_finding_identity_stable_across_line_shift():
+    # The exact same finding, but startLine moved from 10 to 11
+    finding_at_line_10 = {
+        "ruleId": "G101",
+        "artifactLocation": {"uri": "src/app.py"},
+        "region": {"startLine": 10, "snippet": {"text": "password = 'hunter2'"}},
+        "tool": "gitleaks",
+        "tool_version": "8.18.0",
+        "pinned_digest": "sha256:abc",
+        "invocation_argv_hash": "sha256:def",
+        "target": "src/app.py"
+    }
+    finding_at_line_11 = {
+        "ruleId": "G101",
+        "artifactLocation": {"uri": "src/app.py"},
+        "region": {"startLine": 11, "snippet": {"text": "password = 'hunter2'"}}, # Line shifted!
+        "tool": "gitleaks",
+        "tool_version": "8.18.0",
+        "pinned_digest": "sha256:abc",
+        "invocation_argv_hash": "sha256:def",
+        "target": "src/app.py"
+    }
+
+    hash_10 = artifact_content_hash(ArtifactKind.FINDING, finding_at_line_10)
+    hash_11 = artifact_content_hash(ArtifactKind.FINDING, finding_at_line_11)
+    
+    # Cosmetic line shift must not change the hash
+    assert hash_10 == hash_11
+
+def test_finding_identity_changes_when_snippet_changes():
+    finding_1 = {
+        "ruleId": "G101",
+        "region": {"startLine": 10, "snippet": {"text": "password = 'hunter2'"}},
+        "tool": "gitleaks", "tool_version": "1", "pinned_digest": "1", "invocation_argv_hash": "1", "target": "a"
+    }
+    finding_2 = {
+        "ruleId": "G101",
+        "region": {"startLine": 10, "snippet": {"text": "password = 'hunter3'"}}, # Snippet changed!
+        "tool": "gitleaks", "tool_version": "1", "pinned_digest": "1", "invocation_argv_hash": "1", "target": "a"
+    }
+
+    hash_1 = artifact_content_hash(ArtifactKind.FINDING, finding_1)
+    hash_2 = artifact_content_hash(ArtifactKind.FINDING, finding_2)
+    
+    # Rule is not just ignoring everything; snippet matters
+    assert hash_1 != hash_2

--- a/tests/unit/tasks/test_artifact_contract.py
+++ b/tests/unit/tasks/test_artifact_contract.py
@@ -43,6 +43,7 @@ def test_artifact_kind_membership() -> None:
         "dataset",
         "action_log",
         "ops_result",
+	"finding",
     }
 
 


### PR DESCRIPTION
## What

Adds the finding artifact kind and its content-addressed canonical form (Step 1 of #2953).

## Why

This is the contract that #2958 (and the rest of the scanner adapter epic) is waiting on. Every scanner adapter will serialise into the identity rule fixed here, so landing this first step is the highest-leverage one in the milestone.

## How

* Added FINDING = `"finding"` to `ArtifactKind in core/tasks/artifacts.py`.
* Added `"finding"` to `ARTEFACT_KINDS` in `core/lineage/entry.py` so `LineageEntry` accepts it.
* Wrote a `_canonical_finding_bytes` normaliser that projects each SARIF 2.1.0 result down to `ruleId` + `normalised artifactLocation.uri` + region + snippet hash, deliberately dropping the raw line number so cosmetic shifts don't change the hash. It binds `{tool, tool_version, pinned digest, invocation_argv_hash, target}` and emits through the existing `_canonical_json_bytes` core.
*Registered it in the `canonicalise_artifact` dispatch.
* Added tests proving:
    * A cosmetic line shift (`startLine` moves while `ruleId`, uri and snippet are untouched) does not change the finding identity (`artifact_content_hash` is byte-identical).
    * Changing the snippet text does change the hash, so the rule is not just ignoring everything.

## Not in this PR (future steps)

The `ScannerAdapter` ABC, the capability declaration mirroring `adapters/_contract.py`, the registry and conformance suite, all three reference adapters, the `enforce_network_policy()` / `rate_limit_meter` reuse from `adapters/base.py`, and the three determinism tiers. As requested, this PR stops at Step 1: the `finding` artifact kind and its content-addressed canonical form.

Part of #2951.

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright src/` passes
- [x] `uv run python scripts/run_tests.py -x` passes (Ran specific test file: `uv run pytest tests/unit/core/tasks/test_finding_artifact.py -q`)
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)

- [x] User-visible README section updated (or N/A if internal-only)
- [x] `docs/operations/<area>.md` updated (or N/A)
- [x] `docs/api/` schema regenerated if a public surface changed (or N/A)
- [x] `uv run bernstein agents-md sync` run so AGENTS.md, CLAUDE.md, `.goosehints`, `CONVENTIONS.md`, and `.cursor/rules/*.mdc` reflect any new module (or N/A)
- [x] Tests cover the documented behaviour
