### PR TITLE
fix(trace): authenticate projection audit evidence

### DIFF
--- a/docs/observability/otel-span-projection.md
+++ b/docs/observability/otel-span-projection.md
@@ -29,9 +29,11 @@ semantic-convention attributes while keeping every span id journal-anchored
 
 Every span carries `bernstein.journal.entry_hash` (the exact journal row it
 projects), `bernstein.audit.anchor` (the first-entry projection anchor the
-trace id derives from), and `bernstein.run.id`. Completing the projection
-also appends an `otel.projection` event to the HMAC audit chain, binding the
-trace id, span count, and the SHA-256 of the signed canonical span set.
+trace id derives from), and `bernstein.run.id`. Writing the projection also
+attempts to append an `otel.projection` event to the HMAC audit chain. That
+event binds the run id, journal head, trace id, span count, and SHA-256 of
+the canonical projection payload. `--json` only prints the signed document
+and deliberately records no audit event.
 
 Exit codes: `0` written, `1` no event journal for the run, or bad input.
 
@@ -41,16 +43,28 @@ Exit codes: `0` written, `1` no event journal for the run, or bad input.
 bernstein trace verify-projection RUN_ID [--workdir DIR] [--projection PATH]
 ```
 
-Reloads `RUN_ID`'s journal, recomputes every span id from it, and checks the
-signature against the install identity. `--projection` overrides the
-expected file location (default `.sdd/runs/<run_id>/projection.otel.json`).
-A span whose id was altered, or whose journal entry hash is no longer
-present in the chain, is rejected.
+Reloads `RUN_ID`'s journal, recomputes every span id from it, checks the
+signature against the install identity, and verifies the projection's full
+binding against an authenticated `otel.projection` audit event. The binding
+includes the run id, journal head, trace id, span count, and canonical
+projection digest. Archived audit segments participate in verification.
+`--projection` overrides the expected file location (default
+`.sdd/runs/<run_id>/projection.otel.json`).
 
-Exit codes: `0` OK (span ids recompute from the journal, signature chains to
-the install identity), `1` bad input (no journal, or no projection file at
-the expected/given path), `2` verification failed (recomputed ids diverge,
-or the signature does not chain).
+Verification is read-only with respect to audit evidence: it loads the
+existing audit key and never creates an audit key, audit directory, or event.
+Consequently, output produced only with
+`trace project --json` is unverifiable unless a matching audit event already
+exists.
+
+Exit codes:
+
+- `0` verified: span ids and signature match the journal, and one
+  authenticated audit event matches all five binding fields.
+- `1` could not be evaluated: an input, audit key, audit directory, or
+  matching event is missing or unreadable, or audit-chain integrity fails.
+- `2` verification failed: recomputed ids or the signature diverge, or
+  authenticated evidence for the run contradicts the projection binding.
 
 ## Guarantees
 
@@ -79,6 +93,9 @@ for the live-streaming and per-span verification workflow.
 ## Source
 
 `src/bernstein/cli/commands/advanced_cmd.py` (`trace project` /
-`trace verify-projection`), `src/bernstein/core/observability/otel_projection.py`
-(span projection, signing, verification),
+`trace verify-projection`),
+`src/bernstein/cli/commands/_otel_projection_audit.py` (authenticated audit
+binding verification),
+`src/bernstein/core/observability/otel_projection.py` (span projection,
+signing, verification),
 `src/bernstein/core/replay/journal.py` (the event journal projected from).

--- a/docs/observability/otlp-export.md
+++ b/docs/observability/otlp-export.md
@@ -145,8 +145,12 @@ The offline projection tooling remains available for the whole-run surface:
 
 ```bash
 bernstein trace project <run_id>            # signed projection.otel.json + audit event
-bernstein trace verify-projection <run_id>  # recompute ids from the journal, check signature
+bernstein trace verify-projection <run_id>  # check journal, signature, and exact audit binding
 ```
+
+Whole-run verification also reads archived audit segments. It exits `1`
+when authenticated audit evidence is unavailable or cannot be trusted, and
+`2` when the signed projection or authenticated binding is contradictory.
 
 ## Relationship to the raw GenAI exporter
 

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -78,6 +78,16 @@ landed since the newest one.
 
 ## Fixed
 
+- `bernstein trace verify-projection` now authenticates the complete
+  `otel.projection` audit binding instead of accepting any projection whose
+  signature and journal-derived span ids verify (#3551). A verified result
+  requires one integrity-checked live or archived event matching the run id,
+  journal head, trace id, span count, and canonical projection digest.
+  Missing or unreadable evidence is `unverifiable` (exit `1`), while a valid
+  same-run audit chain that contradicts the projection is a verification
+  failure (exit `2`). Verification is load-only and does not create an audit
+  key or directory. Docs: `docs/observability/otel-span-projection.md`,
+  `docs/observability/otlp-export.md`.
 - The `deep-review` label did not start a review on a PR that was already open.
   `.github/workflows/bernstein-pr-review.yml` gates its `review` job on that
   label but did not list `labeled` as a trigger type, so adding the label to a

--- a/src/bernstein/cli/commands/_otel_projection_audit.py
+++ b/src/bernstein/cli/commands/_otel_projection_audit.py
@@ -1,0 +1,159 @@
+"""Read-only audit binding checks for ``trace verify-projection``.
+
+The projection's Ed25519 signature proves who signed its canonical bytes;
+the HMAC audit event proves that those exact bytes were anchored for the
+named run.  Keeping the second check here avoids growing ``advanced_cmd``
+and keeps the verifier's fail-closed classification independently testable.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+    from rich.console import Console
+
+from bernstein.core.observability.otel_projection import (
+    SpanProjection,
+    canonical_projection_bytes,
+    verify_projection,
+)
+from bernstein.core.security.audit import (
+    AuditKeyMissingError,
+    AuditKeyPermissionError,
+    load_audit_key,
+)
+from bernstein.core.security.audit_chain import EVENT_OTEL_PROJECTION, AuditChainStore
+from bernstein.core.security.sanitize import sanitize_log
+
+_VERIFY_OK = 0
+_VERIFY_UNVERIFIABLE = 1
+_VERIFY_FAILED = 2
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectionAuditVerification:
+    """Tri-state result of authenticating a projection's audit binding."""
+
+    exit_code: int
+    reason: str
+
+
+def verify_projection_audit_binding(
+    root: Path,
+    *,
+    run_id: str,
+    projection: SpanProjection,
+    journal_events: Sequence[dict[str, Any]],
+) -> ProjectionAuditVerification:
+    """Authenticate the audit row that binds *projection* to *journal_events*.
+
+    Exit 1 is reserved for absent or unreadable evidence: without an
+    authenticated chain snapshot the verifier cannot distinguish deletion
+    from a run that was never projected.  Exit 2 means authenticated evidence
+    exists for the run but contradicts the supplied projection.  The audit
+    key is load-only and archived segments participate in the same snapshot.
+    """
+    if projection.run_id != run_id:
+        return ProjectionAuditVerification(
+            _VERIFY_FAILED,
+            f"projection run_id {projection.run_id!r} does not match requested run {run_id!r}",
+        )
+
+    audit_dir = root / ".sdd" / "audit"
+    if not audit_dir.is_dir():
+        return ProjectionAuditVerification(
+            _VERIFY_UNVERIFIABLE,
+            f"audit directory is unavailable at {audit_dir}",
+        )
+
+    try:
+        key = load_audit_key()
+    except (AuditKeyMissingError, AuditKeyPermissionError, OSError) as exc:
+        return ProjectionAuditVerification(_VERIFY_UNVERIFIABLE, f"could not load audit key: {exc}")
+
+    try:
+        chain = AuditChainStore(audit_dir, key=key)
+        chain_ok, chain_errors, chain_events = chain.verify_and_query(
+            event_type=EVENT_OTEL_PROJECTION,
+            include_archived=True,
+        )
+    except Exception as exc:  # A verifier must fail closed on unreadable evidence.
+        return ProjectionAuditVerification(_VERIFY_UNVERIFIABLE, f"could not read audit chain: {exc}")
+
+    if not chain_ok:
+        detail = "; ".join(chain_errors) if chain_errors else "chain integrity check failed"
+        return ProjectionAuditVerification(_VERIFY_UNVERIFIABLE, f"audit chain failed integrity check: {detail}")
+
+    run_events = [event for event in chain_events if event.details.get("run_id") == run_id]
+    if not run_events:
+        return ProjectionAuditVerification(
+            _VERIFY_UNVERIFIABLE,
+            f"no {EVENT_OTEL_PROJECTION} audit event for run={run_id}",
+        )
+
+    journal_head = str(journal_events[-1].get("event_hash", "")) if journal_events else ""
+    expected = {
+        "run_id": run_id,
+        "journal_head": journal_head,
+        "trace_id": projection.trace_id,
+        "span_count": len(projection.spans),
+        "projection_sha256": hashlib.sha256(canonical_projection_bytes(projection)).hexdigest(),
+    }
+    if any(all(event.details.get(field) == value for field, value in expected.items()) for event in run_events):
+        return ProjectionAuditVerification(_VERIFY_OK, "projection matches an authenticated audit event")
+
+    mismatched_fields = sorted(
+        {field for event in run_events for field, value in expected.items() if event.details.get(field) != value}
+    )
+    return ProjectionAuditVerification(
+        _VERIFY_FAILED,
+        "authenticated audit evidence disagrees on " + ", ".join(mismatched_fields),
+    )
+
+
+def verify_and_render_projection(
+    console: Console,
+    root: Path,
+    *,
+    run_id: str,
+    projection: SpanProjection,
+    journal_events: Sequence[dict[str, Any]],
+    public_key: Ed25519PublicKey,
+) -> int:
+    """Render the combined signature/audit verdict and return its exit code."""
+    signature_result = verify_projection(projection, journal_events, public_key)
+
+    console.print()
+    console.print(
+        f"[bold]OTel projection[/bold] run={sanitize_log(run_id)} "
+        f"trace={projection.trace_id[:16]} spans={len(projection.spans)}"
+    )
+    if not signature_result.ok:
+        console.print(f"[red]VERIFICATION FAILED[/red] -- {len(signature_result.errors)} error(s):")
+        for error in signature_result.errors:
+            console.print(f"  - {sanitize_log(error)}")
+        return _VERIFY_FAILED
+
+    audit_result = verify_projection_audit_binding(
+        root,
+        run_id=run_id,
+        projection=projection,
+        journal_events=journal_events,
+    )
+    if audit_result.exit_code == _VERIFY_UNVERIFIABLE:
+        console.print(f"[yellow]UNVERIFIABLE[/yellow] -- {sanitize_log(audit_result.reason)}")
+    elif audit_result.exit_code == _VERIFY_FAILED:
+        console.print(f"[red]VERIFICATION FAILED[/red] -- {sanitize_log(audit_result.reason)}")
+    else:
+        console.print(
+            "[green]OK[/green] -- span ids and signature verify; "
+            "the canonical projection matches authenticated audit evidence."
+        )
+    return audit_result.exit_code

--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -1427,13 +1427,15 @@ def trace_project_cmd(run_id: str, workdir: str, no_stability: bool, as_json: bo
     help="Projection path (defaults to .sdd/runs/<run>/projection.otel.json).",
 )
 def trace_verify_projection_cmd(run_id: str, workdir: str, projection_path: str | None) -> None:
-    """Recompute span ids from ``RUN_ID``'s journal and verify the signature.
+    """Verify ``RUN_ID``'s signed projection and authenticated audit binding.
 
     Rejects a span whose id was altered or whose journal entry hash is absent
-    from the chain, and confirms the signature chains to the install identity.
+    from the chain, confirms the install signature, and authenticates the full
+    projection digest against the ``otel.projection`` audit event.
 
-    Exit codes: 0 = OK, 1 = bad input (incl. a corrupted journal), 2 = verification failed.
+    Exit codes: 0 = OK, 1 = could not be evaluated, 2 = verification failed.
     """
+    from bernstein.cli.commands._otel_projection_audit import verify_and_render_projection
     from bernstein.cli.commands.credential_cmd import (
         _load_or_create_install_key,
         _signing_key_path,
@@ -1441,7 +1443,6 @@ def trace_verify_projection_cmd(run_id: str, workdir: str, projection_path: str 
     from bernstein.core.observability.otel_projection import (
         ProjectionError,
         projection_from_dict,
-        verify_projection,
     )
     from bernstein.core.replay.journal import JournalParseError, load_events
 
@@ -1471,20 +1472,15 @@ def trace_verify_projection_cmd(run_id: str, workdir: str, projection_path: str 
         raise SystemExit(1) from exc
 
     public_key = _load_or_create_install_key(_signing_key_path(root)).public_key()
-    result = verify_projection(projection, events, public_key)
-
-    console.print()
-    console.print(
-        f"[bold]OTel projection[/bold] run={sanitize_log(run_id)} "
-        f"trace={projection.trace_id[:16]} spans={len(projection.spans)}"
+    exit_code = verify_and_render_projection(
+        console,
+        root,
+        run_id=run_id,
+        projection=projection,
+        journal_events=events,
+        public_key=public_key,
     )
-    if result.ok:
-        console.print("[green]OK[/green] -- span ids recompute from the journal, signature chains to install identity.")
-        raise SystemExit(0)
-    console.print(f"[red]VERIFICATION FAILED[/red] -- {len(result.errors)} error(s):")
-    for err in result.errors:
-        console.print(f"  - {sanitize_log(err)}")
-    raise SystemExit(2)
+    raise SystemExit(exit_code)
 
 
 def _record_otel_projection_event(

--- a/tests/unit/test_telemetry_verify_span_cmd.py
+++ b/tests/unit/test_telemetry_verify_span_cmd.py
@@ -322,7 +322,7 @@ def test_verify_span_and_verify_projection_share_one_exit_code_convention(projec
     assert "2 = verification failed" in span_help
     assert "2 = verification failed" in projection_help
     assert "1 = could not be evaluated" in span_help
-    assert "1 = bad input" in projection_help
+    assert "1 = could not be evaluated" in projection_help
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_trace_projection_cmd.py
+++ b/tests/unit/test_trace_projection_cmd.py
@@ -15,6 +15,12 @@ from click.testing import CliRunner
 
 from bernstein.cli.commands.advanced_cmd import trace_cmd
 from bernstein.core.replay.journal import EventJournal, run_journal_path
+from bernstein.core.security.audit import AuditLog, RetentionPolicy, load_audit_key
+from bernstein.core.security.audit_chain import (
+    EVENT_OTEL_PROJECTION,
+    AuditChainStore,
+    record_otel_projection,
+)
 
 _RUN_ID = "run-1"
 
@@ -33,6 +39,31 @@ def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     journal.record("agent_reaped", agent_id="a1")
     journal.record("run_completed", ok=True)
     return tmp_path
+
+
+def _audit_store(project: Path) -> AuditChainStore:
+    """Open the fixture's audit chain with its existing key."""
+    return AuditChainStore(project / ".sdd" / "audit", key=load_audit_key())
+
+
+def _replace_projection_audit(project: Path, *, field: str, value: object) -> None:
+    """Replace the genuine row with one authenticated mismatched field."""
+    audit_dir = project / ".sdd" / "audit"
+    rows = _audit_store(project).query(event_type=EVENT_OTEL_PROJECTION)
+    assert len(rows) == 1
+    details = dict(rows[0].details)
+    details[field] = value
+
+    for log in audit_dir.glob("*.jsonl"):
+        log.unlink()
+    record_otel_projection(
+        chain=_audit_store(project),
+        run_id=str(details["run_id"]),
+        journal_head=str(details["journal_head"]),
+        trace_id=str(details["trace_id"]),
+        span_count=int(details["span_count"]),
+        projection_sha256=str(details["projection_sha256"]),
+    )
 
 
 def test_project_writes_signed_span_set(project: Path) -> None:
@@ -116,3 +147,130 @@ def test_verify_projection_corrupted_journal_exits_one(project: Path) -> None:
     assert result.exit_code == 1, result.output
     assert "corrupted" in result.output.lower()
     assert "physical line" in result.output.lower()
+
+
+def test_verify_projection_unanchored_is_unverifiable_when_chain_row_missing(project: Path) -> None:
+    """A valid projection that has no otel.projection evidence is unverifiable (exit 1)."""
+    runner = CliRunner()
+    runner.invoke(trace_cmd, ["project", _RUN_ID, "--workdir", str(project)])
+
+    audit_dir = project / ".sdd" / "audit"
+    for log in sorted(audit_dir.glob("*.jsonl")):
+        log.unlink()
+
+    result = runner.invoke(trace_cmd, ["verify-projection", _RUN_ID, "--workdir", str(project)])
+    assert result.exit_code == 1, result.output
+    assert "UNVERIFIABLE" in result.output.upper()
+
+
+def test_verify_projection_missing_audit_key_is_unverifiable_and_read_only(project: Path) -> None:
+    """A verifier never mints a replacement key for evidence it cannot authenticate."""
+    runner = CliRunner()
+    runner.invoke(trace_cmd, ["project", _RUN_ID, "--workdir", str(project)])
+    key_path = project / "audit.key"
+    key_path.unlink()
+
+    result = runner.invoke(trace_cmd, ["verify-projection", _RUN_ID, "--workdir", str(project)])
+    assert result.exit_code == 1, result.output
+    assert "audit key" in result.output.lower()
+    assert not key_path.exists()
+
+
+def test_verify_projection_missing_audit_directory_is_not_recreated(project: Path) -> None:
+    """Missing evidence stays missing after the read-only verification path."""
+    runner = CliRunner()
+    runner.invoke(trace_cmd, ["project", _RUN_ID, "--workdir", str(project)])
+    audit_dir = project / ".sdd" / "audit"
+    for item in audit_dir.iterdir():
+        item.unlink()
+    audit_dir.rmdir()
+
+    result = runner.invoke(trace_cmd, ["verify-projection", _RUN_ID, "--workdir", str(project)])
+    assert result.exit_code == 1, result.output
+    assert "audit directory" in result.output.lower()
+    assert not audit_dir.exists()
+
+
+def test_verify_projection_ignores_projection_event_for_another_run(project: Path) -> None:
+    """An authenticated row for another run is not evidence for the requested run."""
+    runner = CliRunner()
+    runner.invoke(trace_cmd, ["project", _RUN_ID, "--workdir", str(project)])
+    _replace_projection_audit(project, field="run_id", value="another-run")
+
+    result = runner.invoke(trace_cmd, ["verify-projection", _RUN_ID, "--workdir", str(project)])
+    assert result.exit_code == 1, result.output
+    assert "UNVERIFIABLE" in result.output.upper()
+    assert "no otel.projection audit event" in result.output.lower()
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("journal_head", "0" * 64),
+        ("trace_id", "0" * 32),
+        ("span_count", 999),
+        ("projection_sha256", "0" * 64),
+    ],
+)
+def test_verify_projection_rejects_authenticated_audit_binding_mismatch(
+    project: Path,
+    field: str,
+    value: object,
+) -> None:
+    """Authenticated evidence for the run must match every bound field."""
+    runner = CliRunner()
+    runner.invoke(trace_cmd, ["project", _RUN_ID, "--workdir", str(project)])
+    _replace_projection_audit(project, field=field, value=value)
+
+    result = runner.invoke(trace_cmd, ["verify-projection", _RUN_ID, "--workdir", str(project)])
+    assert result.exit_code == 2, result.output
+    assert "VERIFICATION FAILED" in result.output.upper()
+    assert field in result.output
+
+
+def test_verify_projection_accepts_any_exact_event_for_repeated_projection(project: Path) -> None:
+    """A stale sibling row does not mask an exact event for a repeated projection."""
+    runner = CliRunner()
+    runner.invoke(trace_cmd, ["project", _RUN_ID, "--workdir", str(project)])
+    genuine = _audit_store(project).query(event_type=EVENT_OTEL_PROJECTION)[0].details
+    record_otel_projection(
+        chain=_audit_store(project),
+        run_id=_RUN_ID,
+        journal_head=str(genuine["journal_head"]),
+        trace_id=str(genuine["trace_id"]),
+        span_count=int(genuine["span_count"]),
+        projection_sha256="0" * 64,
+    )
+
+    result = runner.invoke(trace_cmd, ["verify-projection", _RUN_ID, "--workdir", str(project)])
+    assert result.exit_code == 0, result.output
+    assert "OK" in result.output
+
+
+def test_verify_projection_accepts_archived_audit_evidence(project: Path) -> None:
+    """Retention must not orphan a projection whose evidence moved to the archive."""
+    runner = CliRunner()
+    runner.invoke(trace_cmd, ["project", _RUN_ID, "--workdir", str(project)])
+    audit_dir = project / ".sdd" / "audit"
+    archived = AuditLog(audit_dir, key=load_audit_key()).archive(RetentionPolicy(retention_days=-1))
+    assert archived.archived
+    assert not list(audit_dir.glob("*.jsonl"))
+
+    result = runner.invoke(trace_cmd, ["verify-projection", _RUN_ID, "--workdir", str(project)])
+    assert result.exit_code == 0, result.output
+    assert "OK" in result.output
+
+
+def test_verify_projection_corrupt_audit_chain_is_unverifiable(project: Path) -> None:
+    """Unauthenticated rows cannot support either a genuine or forged verdict."""
+    runner = CliRunner()
+    runner.invoke(trace_cmd, ["project", _RUN_ID, "--workdir", str(project)])
+    log_path = next((project / ".sdd" / "audit").glob("*.jsonl"))
+    row = json.loads(log_path.read_text(encoding="utf-8"))
+    row["details"]["projection_sha256"] = "0" * 64
+    log_path.write_text(json.dumps(row, sort_keys=True, separators=(",", ":")) + "\n", encoding="utf-8")
+
+    result = runner.invoke(trace_cmd, ["verify-projection", _RUN_ID, "--workdir", str(project)])
+    assert result.exit_code == 1, result.output
+    assert "UNVERIFIABLE" in result.output.upper()
+    assert "integrity" in result.output.lower()


### PR DESCRIPTION
## What

Authenticate the complete `otel.projection` audit binding used by `bernstein trace verify-projection`.

## Why

A signed projection could previously verify after its audit evidence was removed or no longer matched the projected journal state.

Fixes #3551

## How

Load and integrity-check live or archived audit evidence, then match the run ID, journal head, trace ID, span count, and canonical projection digest. Preserve the documented `0`, `1`, and `2` exit contract.

## Review change

A valid signature alone no longer yields success. Exit `0` now also requires an integrity-checked audit event that matches the full projection binding.

## Checklist

- [x] Focused Ruff check and format pass
- [x] Focused strict Pyright passes
- [ ] `uv run python scripts/run_tests.py -x` passes
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)

- [x] User-visible README section updated, N/A because the observability docs are the user-facing surface
- [x] `docs/operations/<area>.md` updated, N/A because the relevant observability docs were updated
- [x] `docs/api/` schema regenerated, N/A because no public schema changed
- [x] `uv run bernstein agents-md sync` run, N/A because no mapped module boundary changed
- [x] Tests cover the documented behaviour

Validation: 42 focused projection, telemetry, and audit tests passed. All import-linter contracts passed.