### PR TITLE
fix(mcp): disclose tool host effects

### DIFF
--- a/docs/mcp/server.md
+++ b/docs/mcp/server.md
@@ -177,18 +177,18 @@ export BERNSTEIN_MCP_COST_METER=0
 
 ## Consolidated tool surface and deprecated aliases
 
-The advertised surface answers each operator question once:
+The advertised surface answers each operator question once. Every MCP tool
+description states whether the call reads files, writes files, spawns agent
+processes, or makes network requests. load_skill only returns file contents
+and executes nothing.
 
-- `bernstein_status` folds the former `bernstein_health`, `bernstein_tasks`
-  and `bernstein_cost` into one read: the tool answering at all is the
-  liveness signal, `counts` carries the task totals, `cost` the spend, an
-  optional `status` filter appends the matching tasks, and `detail=true`
-  switches per-role and per-task rows from compact to full.
-- `bernstein_run` absorbs `bernstein_create_subtask`: pass
-  `parent_task_id` to queue the run as a subtask.
-- `bernstein_scenario` absorbs the three scenario tools behind an `action`
-  selector (`list` / `run` / `status`); a scenario run returns the same
-  handle shape as `bernstein_run`, so `bernstein_run_status` polls it.
+- `bernstein_status` folds `bernstein_health`, `bernstein_tasks`, and
+  `bernstein_cost` into one read. The response is the liveness signal,
+  `counts` carries task totals, `cost` the spend, `status` filters tasks,
+  and `detail=true` expands compact per-role and per-task rows.
+- `bernstein_run` absorbs `bernstein_create_subtask`; use `parent_task_id` for a subtask.
+- `bernstein_scenario` absorbs the three scenario tools behind `action=list`,
+  `action=run`, or `action=status`; runs return a `bernstein_run` handle polled by `bernstein_run_status`.
 - Misleading names were renamed: `bernstein_task_handle` is now
   `bernstein_run_status`, `bernstein_update` (which never updated a task's
   fields) is `bernstein_post_message`, `bernstein_context` is

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -125,6 +125,13 @@ landed since the newest one.
   failure (exit `2`). Verification is load-only and does not create an audit
   key or directory. Docs: `docs/observability/otel-span-projection.md`,
   `docs/observability/otlp-export.md`.
+- MCP `tools/list` descriptions now disclose each tool's host effects using a
+  reviewed vocabulary for file reads, file writes, agent-process spawning, and
+  network requests. The 25 canonical and deprecated tool schemas are the
+  source of the advertised text, and a coverage guard requires every schema
+  to declare effects consistent with its effective tool tier. `load_skill`
+  now says explicitly that it returns file contents and executes nothing.
+  Docs: `docs/mcp/server.md`. Refs #3645.
 - The `deep-review` label did not start a review on a PR that was already open.
   `.github/workflows/bernstein-pr-review.yml` gates its `review` job on that
   label but did not list `labeled` as a trigger type, so adding the label to a

--- a/packaging/docker-mcp/server.yaml
+++ b/packaging/docker-mcp/server.yaml
@@ -28,7 +28,9 @@ about:
     Gemini CLI, Aider, OpenHands and 40+ other agent CLIs. The MCP server
     exposes 14 tools covering run control, task listing and claiming, progress
     updates, artifact posting, approvals, subtasks, cost reporting, and skill
-    loading.
+    loading. Every MCP tool description states whether the call reads files,
+    writes files, spawns agent processes, or makes network requests.
+    load_skill only returns file contents and executes nothing.
   icon: https://avatars.githubusercontent.com/u/271707709?v=4
 source:
   project: https://github.com/sipyourdrink-ltd/bernstein

--- a/src/bernstein/mcp/server.py
+++ b/src/bernstein/mcp/server.py
@@ -28,7 +28,7 @@ plus lineage exposes all of them.
     bernstein_shutdown_orchestrator - whole-orchestrator shutdown signal
     bernstein_approve       - approve a pending/blocked task
     bernstein_complete      - complete a task the caller is executing
-    load_skill              - load a skill pack body / reference / script
+    load_skill              - return skill pack file contents; never execute
 
 Registered from sibling modules by the same ``create_mcp_server`` call:
 
@@ -1801,7 +1801,7 @@ def _apply_cost_meter(mcp: FastMCP[None]) -> None:
 
 
 def _apply_advertised_schemas(mcp: FastMCP[None]) -> None:
-    """Advertise each tool's enforced schema as its ``inputSchema``.
+    """Advertise each tool's enforced schema and host-effect description.
 
     FastMCP derives the advertised schema from the Python signature, which
     carries none of the constraints the input firewall enforces: a caller is
@@ -1830,9 +1830,9 @@ def _apply_advertised_schemas(mcp: FastMCP[None]) -> None:
             # Leave the derived schema alone and make the mismatch visible.
             logger.warning("MCP tool %s has no schema file; advertising the derived schema", name)
             continue
-        # Deep-copy so a client-side mutation of the advertised schema cannot
-        # reach the process-wide registry the validator reads.
+        # Copy client-visible metadata without exposing validator state.
         tool.parameters = copy.deepcopy(schema)
+        tool.description = str(schema["description"])
 
 
 def _register_deprecated_aliases(mcp: FastMCP[None], server_url: str) -> None:

--- a/src/bernstein/mcp/tool_schemas/bernstein_approve.json
+++ b/src/bernstein/mcp/tool_schemas/bernstein_approve.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "bernstein_approve",
+  "description": "Sign off a finished result only when the task is in pending_approval; every other status is refused. This completes the task on the Bernstein server. Host effects: makes network requests.",
   "type": "object",
   "additionalProperties": false,
   "required": ["task_id"],

--- a/src/bernstein/mcp/tool_schemas/bernstein_cancel.json
+++ b/src/bernstein/mcp/tool_schemas/bernstein_cancel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "bernstein_cancel",
-  "description": "Cancel one task and its subtask tree; the orchestrator keeps running. Cancellable statuses: open, claimed, in_progress, blocked, waiting_for_subtasks, planned. An already-terminal task is reported, not treated as an error.",
+  "description": "Cancel one task and its subtask tree; the orchestrator keeps running. Cancellable statuses: open, claimed, in_progress, blocked, waiting_for_subtasks, planned. An already-terminal task is reported, not treated as an error. This changes task state on the Bernstein server. Host effects: makes network requests.",
   "type": "object",
   "additionalProperties": false,
   "required": ["task_id"],

--- a/src/bernstein/mcp/tool_schemas/bernstein_claim.json
+++ b/src/bernstein/mcp/tool_schemas/bernstein_claim.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "bernstein_claim",
+  "description": "Claim the next eligible task for an agent. This changes task assignment state on the Bernstein server. Host effects: makes network requests.",
   "type": "object",
   "additionalProperties": false,
   "required": ["claimer_id"],

--- a/src/bernstein/mcp/tool_schemas/bernstein_complete.json
+++ b/src/bernstein/mcp/tool_schemas/bernstein_complete.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "bernstein_complete",
+  "description": "Report a task result only from a worker-held state: open, claimed, or in_progress; every other status is refused. This completes the task on the Bernstein server. Host effects: makes network requests.",
   "type": "object",
   "additionalProperties": false,
   "required": ["task_id", "result_summary"],

--- a/src/bernstein/mcp/tool_schemas/bernstein_context.json
+++ b/src/bernstein/mcp/tool_schemas/bernstein_context.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "bernstein_context",
+  "description": "Deprecated alias of bernstein_task_capsule. Reads a task capsule and its local journal and audit evidence; verify=true may create the install audit key if it is absent. Host effects: reads files; writes files.",
   "type": "object",
   "additionalProperties": false,
   "required": ["task_id"],

--- a/src/bernstein/mcp/tool_schemas/bernstein_cost.json
+++ b/src/bernstein/mcp/tool_schemas/bernstein_cost.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "bernstein_cost",
+  "description": "Deprecated alias folded into bernstein_status. Retrieves cost data from the Bernstein server without changing it. Host effects: makes network requests.",
   "type": "object",
   "additionalProperties": false,
   "properties": {}

--- a/src/bernstein/mcp/tool_schemas/bernstein_create_subtask.json
+++ b/src/bernstein/mcp/tool_schemas/bernstein_create_subtask.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "bernstein_create_subtask",
+  "description": "Deprecated alias folded into bernstein_run. Queues a subtask that writes orchestration state and starts agent work; the call returns before that work finishes. Host effects: writes files; spawns agent processes; makes network requests.",
   "type": "object",
   "additionalProperties": false,
   "required": ["parent_task_id", "goal"],

--- a/src/bernstein/mcp/tool_schemas/bernstein_health.json
+++ b/src/bernstein/mcp/tool_schemas/bernstein_health.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "bernstein_health",
+  "description": "Deprecated process-local liveness probe folded into bernstein_status. It returns a constant response without contacting the task server. Host effects: none.",
   "type": "object",
   "additionalProperties": false,
   "properties": {}

--- a/src/bernstein/mcp/tool_schemas/bernstein_post_artifact.json
+++ b/src/bernstein/mcp/tool_schemas/bernstein_post_artifact.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "bernstein_post_artifact",
+  "description": "Post a versioned artifact to a task on the Bernstein server. Host effects: makes network requests.",
   "type": "object",
   "additionalProperties": false,
   "required": ["task_id", "key", "artifact_type", "poster"],

--- a/src/bernstein/mcp/tool_schemas/bernstein_post_message.json
+++ b/src/bernstein/mcp/tool_schemas/bernstein_post_message.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "bernstein_post_message",
+  "description": "Post a progress message to a task mailbox on the Bernstein server. Host effects: makes network requests.",
   "type": "object",
   "additionalProperties": false,
   "required": ["task_id", "body", "sender"],

--- a/src/bernstein/mcp/tool_schemas/bernstein_run.json
+++ b/src/bernstein/mcp/tool_schemas/bernstein_run.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "bernstein_run",
-  "description": "Start an orchestration run. A run does real work and takes minutes to hours; the call returns once the run is queued, not when it finishes. Do not re-issue it while waiting, that starts a second run. Follow the run with bernstein_run_status, passing either the returned task_id or the returned run_id, after waiting the returned poll_after_ms. Pass parent_task_id to create the run as a subtask of an existing task.",
+  "description": "Start an orchestration run. A run does real work and takes minutes to hours; the call returns once the run is queued, not when it finishes. Do not re-issue it while waiting, that starts a second run. Follow the run with bernstein_run_status, passing either the returned task_id or the returned run_id, after waiting the returned poll_after_ms. Pass parent_task_id to create the run as a subtask of an existing task. The queued orchestration writes project state and starts agent work. Host effects: writes files; spawns agent processes; makes network requests.",
   "type": "object",
   "additionalProperties": false,
   "required": [

--- a/src/bernstein/mcp/tool_schemas/bernstein_run_status.json
+++ b/src/bernstein/mcp/tool_schemas/bernstein_run_status.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "bernstein_run_status",
-  "description": "Poll a verifiable handle for a run started with bernstein_run. Accepts either identifier that call returned: the task_id or the run_id.",
+  "description": "Poll a verifiable handle for a run started with bernstein_run. Accepts either identifier that call returned: the task_id or the run_id. Reads the local run journal and audit evidence without changing them. Host effects: reads files.",
   "type": "object",
   "additionalProperties": false,
   "required": ["run_id"],

--- a/src/bernstein/mcp/tool_schemas/bernstein_scenario.json
+++ b/src/bernstein/mcp/tool_schemas/bernstein_scenario.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "bernstein_scenario",
-  "description": "List, run, or poll Bernstein scenarios. action=list needs nothing else; action=run needs scenario_id and returns the same pollable handle shape as bernstein_run; action=status needs orchestration_id.",
+  "description": "List, run, or poll Bernstein scenarios. action=list reads packaged scenario definitions; action=run queues file-writing agent work and returns the same pollable handle shape as bernstein_run; action=status queries the task server and needs orchestration_id. Host effects: reads files; writes files; spawns agent processes; makes network requests.",
   "type": "object",
   "additionalProperties": false,
   "properties": {

--- a/src/bernstein/mcp/tool_schemas/bernstein_scenario_status.json
+++ b/src/bernstein/mcp/tool_schemas/bernstein_scenario_status.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "bernstein_scenario_status",
+  "description": "Deprecated status action folded into bernstein_scenario. Retrieves orchestration status from the Bernstein server without changing it. Host effects: makes network requests.",
   "type": "object",
   "additionalProperties": false,
   "required": ["orchestration_id"],

--- a/src/bernstein/mcp/tool_schemas/bernstein_scenarios.json
+++ b/src/bernstein/mcp/tool_schemas/bernstein_scenarios.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "bernstein_scenarios",
+  "description": "Deprecated list action folded into bernstein_scenario. Lists packaged scenario definitions without running them. Host effects: reads files.",
   "type": "object",
   "additionalProperties": false,
   "properties": {}

--- a/src/bernstein/mcp/tool_schemas/bernstein_shutdown_orchestrator.json
+++ b/src/bernstein/mcp/tool_schemas/bernstein_shutdown_orchestrator.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "bernstein_shutdown_orchestrator",
+  "description": "Shut down the ENTIRE Bernstein orchestrator for this project, including every run and worker; use bernstein_cancel to stop one task while the orchestrator keeps running. Writes the local SHUTDOWN signal file. Host effects: writes files.",
   "type": "object",
   "additionalProperties": false,
   "properties": {

--- a/src/bernstein/mcp/tool_schemas/bernstein_status.json
+++ b/src/bernstein/mcp/tool_schemas/bernstein_status.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "bernstein_status",
-  "description": "Liveness, task counts, and cost in one read. Pass status to include the matching tasks; pass detail=true for full per-role and per-task rows.",
+  "description": "Liveness, task counts, and cost in one read. Pass status to include the matching tasks; pass detail=true for full per-role and per-task rows. Retrieves data from the Bernstein server without changing it. Host effects: makes network requests.",
   "type": "object",
   "additionalProperties": false,
   "properties": {

--- a/src/bernstein/mcp/tool_schemas/bernstein_stop.json
+++ b/src/bernstein/mcp/tool_schemas/bernstein_stop.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "bernstein_stop",
+  "description": "Deprecated alias of bernstein_shutdown_orchestrator. Requests a local orchestrator stop by writing its SHUTDOWN signal file. Host effects: writes files.",
   "type": "object",
   "additionalProperties": false,
   "properties": {

--- a/src/bernstein/mcp/tool_schemas/bernstein_task_capsule.json
+++ b/src/bernstein/mcp/tool_schemas/bernstein_task_capsule.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "bernstein_task_capsule",
+  "description": "Read a task capsule together with its local journal and audit evidence. With verify=true, verification may create the install audit key if it is absent. Host effects: reads files; writes files.",
   "type": "object",
   "additionalProperties": false,
   "required": ["task_id"],

--- a/src/bernstein/mcp/tool_schemas/bernstein_task_handle.json
+++ b/src/bernstein/mcp/tool_schemas/bernstein_task_handle.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "bernstein_task_handle",
-  "description": "Poll a verifiable handle for a run started with bernstein_run. Accepts either identifier that call returned: the task_id or the run_id.",
+  "description": "Deprecated alias of bernstein_run_status. Polls a verifiable run handle by reading the local run journal and audit evidence without changing them. Host effects: reads files.",
   "type": "object",
   "additionalProperties": false,
   "required": ["run_id"],

--- a/src/bernstein/mcp/tool_schemas/bernstein_tasks.json
+++ b/src/bernstein/mcp/tool_schemas/bernstein_tasks.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "bernstein_tasks",
+  "description": "Deprecated task-list action folded into bernstein_status. Retrieves tasks from the Bernstein server without changing them. Host effects: makes network requests.",
   "type": "object",
   "additionalProperties": false,
   "properties": {

--- a/src/bernstein/mcp/tool_schemas/bernstein_update.json
+++ b/src/bernstein/mcp/tool_schemas/bernstein_update.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "bernstein_update",
+  "description": "Deprecated alias of bernstein_post_message. Posts a progress message to a task mailbox on the Bernstein server. Host effects: makes network requests.",
   "type": "object",
   "additionalProperties": false,
   "required": ["task_id", "body", "sender"],

--- a/src/bernstein/mcp/tool_schemas/bernstein_verify_lineage.json
+++ b/src/bernstein/mcp/tool_schemas/bernstein_verify_lineage.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "bernstein_verify_lineage",
+  "description": "Verify one artifact's lineage chain by reading its local lineage log without changing it. Host effects: reads files.",
   "type": "object",
   "additionalProperties": false,
   "required": ["artefact_path"],

--- a/src/bernstein/mcp/tool_schemas/load_skill.json
+++ b/src/bernstein/mcp/tool_schemas/load_skill.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "load_skill",
-  "description": "List available skills when name is omitted, or load a named skill body, reference, or script file contents. Returns file contents as text; executes nothing.",
+  "description": "List available skills when name is omitted, or load a named skill body, reference, or script file contents. Returns file contents as text; executes nothing. Host effects: reads files.",
   "type": "object",
   "additionalProperties": false,
   "dependencies": {

--- a/src/bernstein/mcp/tool_schemas/verify_chain.json
+++ b/src/bernstein/mcp/tool_schemas/verify_chain.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "verify_chain",
+  "description": "Deprecated alias of bernstein_verify_lineage. Verifies one artifact's lineage chain by reading its local lineage log without changing it. Host effects: reads files.",
   "type": "object",
   "additionalProperties": false,
   "required": ["artefact_path"],

--- a/tests/unit/mcp/test_tool_host_effect_descriptions.py
+++ b/tests/unit/mcp/test_tool_host_effect_descriptions.py
@@ -1,0 +1,120 @@
+"""Drift guards for the host effects advertised by every MCP tool."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from bernstein.core.protocols.mcp.tool_tiers import DEPRECATED_TOOL_ALIASES, TOOL_TIERS, ToolTier
+from bernstein.mcp.input_validation import get_registry
+from bernstein.mcp.server import create_mcp_server
+
+_ROOT = Path(__file__).resolve().parents[3]
+_ALLOWED_EFFECTS = frozenset(
+    {
+        "reads files",
+        "writes files",
+        "spawns agent processes",
+        "makes network requests",
+        "none",
+    }
+)
+
+# A tool's row is (effective tier, effects visible to the caller). Keeping the
+# rows explicit makes additions and alias behaviour deliberate review points.
+_EXPECTED: dict[str, tuple[ToolTier, frozenset[str]]] = {
+    "bernstein_approve": ("standard", frozenset({"makes network requests"})),
+    "bernstein_cancel": ("standard", frozenset({"makes network requests"})),
+    "bernstein_claim": ("standard", frozenset({"makes network requests"})),
+    "bernstein_complete": ("standard", frozenset({"makes network requests"})),
+    "bernstein_context": ("standard", frozenset({"reads files", "writes files"})),
+    "bernstein_cost": ("core", frozenset({"makes network requests"})),
+    "bernstein_create_subtask": (
+        "core",
+        frozenset({"writes files", "spawns agent processes", "makes network requests"}),
+    ),
+    "bernstein_health": ("core", frozenset({"none"})),
+    "bernstein_post_artifact": ("standard", frozenset({"makes network requests"})),
+    "bernstein_post_message": ("standard", frozenset({"makes network requests"})),
+    "bernstein_run": (
+        "core",
+        frozenset({"writes files", "spawns agent processes", "makes network requests"}),
+    ),
+    "bernstein_run_status": ("core", frozenset({"reads files"})),
+    "bernstein_scenario": (
+        "all",
+        frozenset({"reads files", "writes files", "spawns agent processes", "makes network requests"}),
+    ),
+    "bernstein_scenario_status": ("all", frozenset({"makes network requests"})),
+    "bernstein_scenarios": ("all", frozenset({"reads files"})),
+    "bernstein_shutdown_orchestrator": ("standard", frozenset({"writes files"})),
+    "bernstein_status": ("core", frozenset({"makes network requests"})),
+    "bernstein_stop": ("standard", frozenset({"writes files"})),
+    "bernstein_task_capsule": ("standard", frozenset({"reads files", "writes files"})),
+    "bernstein_task_handle": ("core", frozenset({"reads files"})),
+    "bernstein_tasks": ("core", frozenset({"makes network requests"})),
+    "bernstein_update": ("standard", frozenset({"makes network requests"})),
+    "bernstein_verify_lineage": ("all", frozenset({"reads files"})),
+    "load_skill": ("standard", frozenset({"reads files"})),
+    "verify_chain": ("all", frozenset({"reads files"})),
+}
+
+_SHARED_WORDING = (
+    "Every MCP tool description states whether the call reads files, writes files, "
+    "spawns agent processes, or makes network requests. "
+    "load_skill only returns file contents and executes nothing."
+)
+
+
+def _effects(description: str) -> frozenset[str]:
+    marker = "Host effects: "
+    assert marker in description
+    labels = frozenset(description.split(marker, 1)[1].split(".", 1)[0].split("; "))
+    assert labels
+    assert labels <= _ALLOWED_EFFECTS
+    assert labels == {"none"} or "none" not in labels
+    return labels
+
+
+def _normalise_whitespace(value: str) -> str:
+    return " ".join(value.split())
+
+
+def test_every_schema_declares_reviewed_host_effects_and_effective_tier() -> None:
+    """Enumeration fails when a schema is added without an effect review."""
+    schemas = get_registry().schemas
+    assert set(schemas) == set(_EXPECTED)
+
+    for name, schema in schemas.items():
+        expected_tier, expected_effects = _EXPECTED[name]
+        canonical_name = DEPRECATED_TOOL_ALIASES.get(name, name)
+        assert TOOL_TIERS[canonical_name] == expected_tier
+        description = schema.get("description")
+        assert isinstance(description, str) and description.strip()
+        assert _effects(description) == expected_effects
+
+
+@pytest.mark.asyncio
+async def test_tools_list_uses_the_schema_host_effect_descriptions() -> None:
+    """The audited JSON text, not an older Python docstring, reaches clients."""
+    schemas = get_registry().schemas
+    mcp = create_mcp_server(tier="all", lineage_enabled=True)
+    advertised = {tool.name: tool.description for tool in await mcp.list_tools()}
+
+    assert set(advertised) == set(schemas)
+    assert advertised == {name: schemas[name]["description"] for name in advertised}
+
+
+def test_load_skill_says_it_returns_contents_and_executes_nothing() -> None:
+    description = get_registry().schemas["load_skill"]["description"]
+    assert "Returns file contents as text; executes nothing." in description
+
+
+def test_server_docs_and_docker_catalog_share_the_host_effect_wording() -> None:
+    docs = (_ROOT / "docs/mcp/server.md").read_text(encoding="utf-8")
+    catalog = yaml.safe_load((_ROOT / "packaging/docker-mcp/server.yaml").read_text(encoding="utf-8"))
+
+    assert _SHARED_WORDING in _normalise_whitespace(docs)
+    assert _SHARED_WORDING in _normalise_whitespace(catalog["about"]["description"])


### PR DESCRIPTION
## What

Disclose host effects in every MCP tool description.

## Why

Clients could enumerate tools but could not tell which tools read files, write files, spawn agent processes, or make network requests.

Completes the remaining host-effect disclosure scope from #3645 after #3675 clarified `load_skill` behavior.

## How

Use a reviewed host-effect vocabulary across all 25 canonical and deprecated schemas, propagate schema descriptions through FastMCP registration, and add a coverage guard for schema and tier consistency.

## Review change

The change preserves #3675's `load_skill` clarification and adds its host-effect label. It covers all 25 tool schemas, verifies tier parity and advertised descriptions, and leaves runtime behavior and tier assignments unchanged.

## Checklist

- [x] Focused Ruff check and format pass
- [x] Focused strict Pyright passes
- [ ] `uv run python scripts/run_tests.py -x` passes
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)

- [x] User-visible README section updated, N/A because the MCP guide is the user-facing surface
- [x] `docs/operations/<area>.md` updated, N/A because the relevant MCP guide was updated
- [x] `docs/api/` schema regenerated, N/A because canonical MCP schemas were updated directly
- [x] `uv run bernstein agents-md sync` run, N/A because no mapped module boundary changed
- [x] Tests cover the documented behaviour

Validation: 167 focused MCP tests passed. All import-linter contracts and JSON and YAML parsing passed.
