### PR TITLE
fix: clarify load_skill description — returns file contents, executes nothing

### DIFF
--- a/src/bernstein/mcp/tool_schemas/load_skill.json
+++ b/src/bernstein/mcp/tool_schemas/load_skill.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "load_skill",
-  "description": "List available skills when name is omitted, or load a named skill body, reference, or script.",
+  "description": "List available skills when name is omitted, or load a named skill body, reference, or script file contents. Returns file contents as text; executes nothing.",
   "type": "object",
   "additionalProperties": false,
   "dependencies": {


### PR DESCRIPTION
## Summary

The `load_skill` description could be interpreted as executing a script. Clarify that it returns file contents as text and executes nothing.

## Change

```json
// Before
"description": "List available skills when name is omitted, or load a named skill body, reference, or script."

// After
"description": "List available skills when name is omitted, or load a named skill body, reference, or script file contents. Returns file contents as text; executes nothing."
```

Partially fixes #3645