### PR TITLE
feat(audit): record stall.verdict before automatic worker kills (#3604)

### DIFF
--- a/docs/operations/stall-escalation.md
+++ b/docs/operations/stall-escalation.md
@@ -76,3 +76,22 @@ Each emitted receipt is mirrored into the HMAC-chained audit log as an
 journal head at stall, window size, and resume snapshot sha, so an operator can
 prove from the chain alone that an escalation was emitted, without recording any
 journal payloads.
+
+## Kill-decision verdicts
+
+Before any of this machinery runs, the orchestrator must first decide to kill a
+worker. That decision is mirrored into the audit chain as a `stall.verdict`
+event (`core.security.audit_chain.record_stall_verdict`), written at the moment
+the verdict is reached, before the kill is issued. The event carries the stall
+reason, which detector fired (`heartbeat` / `stall_simple` / `stall_profiled`),
+and the measured inputs that actually drove the decision (heartbeat age,
+identical-snapshot count, the threshold crossed) -- each detector records only
+what it measured.
+
+A verdict attests a decision, never an outcome: the worker may still be alive
+when the record lands. The stop itself is attested by the companion
+`process.reap_receipt` event, and the two join on `session_id`, so an operator
+reconstructing a failure window can place "this detector saw these inputs and
+decided" next to "this mechanism delivered the stop" without guessing. Recording
+is best-effort -- a chain failure never blocks the kill -- but never silent: the
+failure surfaces as a warning naming the session.

--- a/src/bernstein/core/agents/heartbeat.py
+++ b/src/bernstein/core/agents/heartbeat.py
@@ -23,6 +23,7 @@ from bernstein.core.agents.heartbeat_escalation import (
 )
 from bernstein.core.defaults import AGENT
 from bernstein.core.models import AgentHeartbeat, ProgressSnapshot, Task
+from bernstein.core.orchestration.supervisor_receipt import StallReason
 
 logger = logging.getLogger(__name__)
 
@@ -449,6 +450,56 @@ def _agent_has_fresh_liveness_signal(orch: Any, session: Any) -> bool:
     return any(age is not None and age < grace_s for age in (result.get("log_age_s"), result.get("git_age_s")))
 
 
+def _emit_stall_verdict(
+    orch: Any,
+    session: Any,
+    *,
+    reason: str,
+    detector: str,
+    heartbeat_age_s: float | None = None,
+    identical_snapshot_count: int | None = None,
+    threshold: float | None = None,
+) -> None:
+    """Mirror a stall-kill verdict into the audit chain (#3277).
+
+    Best-effort by design: audit mirroring must never block or delay the
+    kill itself (mirrors ``emit_process_reap_receipt`` in the spawner). A
+    kill that cannot be recorded still has to happen -- the record is
+    evidence, not a permission slip. But the failure is never silent: the
+    warning names the session and the reason, so an unrecorded kill stays
+    observable rather than becoming indistinguishable from no kill.
+
+    The record attests the decision, not the outcome -- callers invoke
+    this at the moment the kill verdict is reached, before the kill runs.
+    """
+    workdir = getattr(orch, "_workdir", None)
+    if not isinstance(workdir, Path):
+        return
+    try:
+        from bernstein.core.security.audit_chain import (
+            AuditChainStore,
+            record_stall_verdict,
+        )
+
+        chain = AuditChainStore(workdir / ".sdd" / "audit")
+        record_stall_verdict(
+            chain=chain,
+            session_id=session.id,
+            reason=reason,
+            detector=detector,
+            heartbeat_age_s=heartbeat_age_s,
+            identical_snapshot_count=identical_snapshot_count,
+            threshold=threshold,
+        )
+    except Exception as exc:  # audit must never block the kill path
+        logger.warning(
+            "Could not emit stall.verdict audit event for session %s: %s: %s",
+            session.id,
+            type(exc).__name__,
+            exc,
+        )
+
+
 def _escalate_heartbeat(
     orch: Any,
     session: Any,
@@ -503,6 +554,14 @@ def _escalate_heartbeat(
     else:
         action = ladder.check_and_escalate(session.id, age, pid=session.pid)
         if action is not None and action.tier >= EscalationTier.SIGKILL:
+            _emit_stall_verdict(
+                orch,
+                session,
+                reason=StallReason.HEARTBEAT_STALE,
+                detector="heartbeat",
+                heartbeat_age_s=age,
+                threshold=kill_threshold,
+            )
             _terminate_stuck_agent(orch, session, age)
             if session.pid is None or not action.action_taken:
                 with contextlib.suppress(Exception):
@@ -658,6 +717,14 @@ def _escalate_stall_simple(
     """Apply simple fixed-threshold stall escalation (no workdir mode)."""
     elapsed = time.time() - session.spawn_ts
     if count >= AGENT.escalation_kill_count:
+        _emit_stall_verdict(
+            orch,
+            session,
+            reason=StallReason.NO_PROGRESS,
+            detector="stall_simple",
+            identical_snapshot_count=count,
+            threshold=AGENT.escalation_kill_count,
+        )
         with contextlib.suppress(Exception):
             orch._spawner.kill(session)
         _reap_session_heartbeat_loop(orch, session, reason="stall_kill")
@@ -685,6 +752,14 @@ def _escalate_stall_profiled(
     """Apply profile-aware stall escalation (with workdir / log analysis)."""
     elapsed = time.time() - session.spawn_ts
     if count >= profile.kill_threshold:
+        _emit_stall_verdict(
+            orch,
+            session,
+            reason=StallReason.NO_PROGRESS,
+            detector="stall_profiled",
+            identical_snapshot_count=count,
+            threshold=profile.kill_threshold,
+        )
         logger.warning(
             "Stall-killing agent %s (task %s): %d identical snapshots (%s)",
             session.id,

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -468,6 +468,18 @@ EVENT_ADAPTER_CAPABILITY_REFUSAL = "adapter.capability_refusal"
 #: reap path ran and on which platform semantics it relied.
 EVENT_PROCESS_REAP_RECEIPT = "process.reap_receipt"
 
+#: Issue #3277 -- emitted whenever a supervisor detector decides an agent must
+#: be force-killed. The event records WHY the decision was taken: the stall
+#: reason, which detector fired, and the measured inputs (heartbeat age,
+#: identical-snapshot count, the threshold crossed) that were in scope at the
+#: moment the verdict was reached. It attests a verdict, never an outcome: the
+#: worker may still be alive when this is written. The companion
+#: ``process.reap_receipt`` event (joined on ``session_id``) attests that the
+#: stop was actually delivered, so an operator reconstructing a failure window
+#: can put "this detector saw these inputs and decided" next to "this mechanism
+#: delivered the stop" without guessing.
+EVENT_STALL_VERDICT = "stall.verdict"
+
 #: Issue #2366 -- emitted whenever a scoped dashboard token is issued or
 #: revoked. The event mirrors the signed registry row: the short token id,
 #: the token digest, the principal, the scope, and the grant kind -- never
@@ -4955,6 +4967,73 @@ def record_process_reap_receipt(
     )
 
 
+def record_stall_verdict(
+    *,
+    chain: AuditChainStore,
+    session_id: str,
+    reason: str,
+    detector: str,
+    actor: str = "heartbeat",
+    heartbeat_age_s: float | None = None,
+    identical_snapshot_count: int | None = None,
+    threshold: float | None = None,
+) -> AuditEvent:
+    """Append a ``stall.verdict`` event into *chain* (#3277).
+
+    Mirrors a supervisor decision to force-kill a worker into the audit
+    chain. The record carries the ``StallReason``, which detector fired,
+    and the measured inputs that were in scope when the verdict was
+    reached (heartbeat age, identical-snapshot count, and the threshold
+    that was crossed). Each detector records only the inputs it actually
+    measured; the fields it does not use are left ``None``.
+
+    The event attests a verdict, never an outcome: it is written before
+    the kill is issued, so the worker may still be alive when it lands.
+    The companion :data:`EVENT_PROCESS_REAP_RECEIPT` record -- joined on
+    ``session_id`` -- is what attests that the stop was actually
+    delivered. An operator reconstructing a failure window reads the
+    verdict to learn why a kill was decided and the reap receipt to learn
+    how the stop was delivered.
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        session_id: Agent session whose kill was decided. Matches the
+            ``session_id`` carried by the session's reap receipt, which is
+            the join key between the verdict and the delivered stop.
+        reason: The stall reason, a :class:`StallReason` value (e.g.
+            ``"heartbeat_stale"``, ``"no_progress"``).
+        detector: Identifier of the detector that fired (e.g.
+            ``"heartbeat"``, ``"stall_simple"``, ``"stall_profiled"``).
+        actor: Recorded actor; defaults to ``"heartbeat"``.
+        heartbeat_age_s: Measured heartbeat age in seconds when the
+            verdict was reached, or ``None`` when the detector did not
+            measure it.
+        identical_snapshot_count: Number of identical progress snapshots
+            observed when the verdict was reached, or ``None`` when not
+            measured.
+        threshold: The kill threshold that was crossed (seconds or
+            snapshot count), or ``None`` when not applicable.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded
+        in its details payload.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_STALL_VERDICT,
+        actor=actor,
+        resource_type="stall_verdict",
+        resource_id=session_id,
+        details={
+            "session_id": session_id,
+            "reason": reason,
+            "detector": detector,
+            "heartbeat_age_s": heartbeat_age_s,
+            "identical_snapshot_count": identical_snapshot_count,
+            "threshold": threshold,
+        },
+    )
+
+
 def record_task_suspension(
     *,
     chain: AuditChainStore,
@@ -8198,6 +8277,7 @@ __all__ = [
     "EVENT_SOVEREIGN_DRIFT",
     "EVENT_SPEC_REQUIREMENT_SET",
     "EVENT_SPIFFE_SVID_BINDING",
+    "EVENT_STALL_VERDICT",
     "EVENT_STEERING_RECEIPT",
     "EVENT_SUBAGENT_DELEGATION",
     "EVENT_TASK_CLAIM_RECEIPT",
@@ -8333,6 +8413,7 @@ __all__ = [
     "record_sovereign_drift",
     "record_spec_requirement_set",
     "record_spiffe_svid_binding",
+    "record_stall_verdict",
     "record_steering_receipt",
     "record_subagent_delegation",
     "record_taint_decision",

--- a/tests/unit/test_audit_chain_stall_verdict.py
+++ b/tests/unit/test_audit_chain_stall_verdict.py
@@ -1,0 +1,89 @@
+"""Audit-chain stall verdicts (issue #3277).
+
+Every automatic worker kill decided by the heartbeat/stall supervisors is
+mirrored into the HMAC-chained audit log as a ``stall.verdict`` event before
+the kill is issued: which detector fired, the stall reason, and the measured
+inputs (heartbeat age, identical-snapshot count, threshold crossed) that were
+in scope at decision time. The verdict attests a decision, never an outcome --
+the companion ``process.reap_receipt`` event (joined on ``session_id``)
+attests the delivered stop.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from bernstein.core.security.audit_chain import (
+    EVENT_STALL_VERDICT,
+    AuditChainStore,
+    record_stall_verdict,
+)
+
+
+def test_record_stall_verdict_appends_event(tmp_path: Path) -> None:
+    chain = AuditChainStore(tmp_path / "audit", key=b"0" * 32)
+    event = record_stall_verdict(
+        chain=chain,
+        session_id="agent-1",
+        reason="heartbeat_stale",
+        detector="heartbeat",
+        heartbeat_age_s=100.0,
+        threshold=90.0,
+    )
+    assert event.event_type == EVENT_STALL_VERDICT
+    rows = chain.query(event_type=EVENT_STALL_VERDICT)
+    assert len(rows) == 1
+    details = rows[0].details
+    assert details["session_id"] == "agent-1"
+    assert details["reason"] == "heartbeat_stale"
+    assert details["detector"] == "heartbeat"
+    assert details["heartbeat_age_s"] == 100.0
+    assert details["identical_snapshot_count"] is None
+    assert details["threshold"] == 90.0
+    assert "prev_chain_digest" in details
+
+
+def test_record_stall_verdict_carries_snapshot_detector_inputs(tmp_path: Path) -> None:
+    """The stall detectors record only the inputs they measured."""
+    chain = AuditChainStore(tmp_path / "audit", key=b"0" * 32)
+    record_stall_verdict(
+        chain=chain,
+        session_id="agent-2",
+        reason="no_progress",
+        detector="stall_profiled",
+        identical_snapshot_count=7,
+        threshold=5,
+    )
+    details = chain.query(event_type=EVENT_STALL_VERDICT)[0].details
+    assert details["identical_snapshot_count"] == 7
+    assert details["threshold"] == 5
+    assert details["heartbeat_age_s"] is None
+
+
+def test_record_stall_verdict_honours_actor(tmp_path: Path) -> None:
+    chain = AuditChainStore(tmp_path / "audit", key=b"0" * 32)
+    record_stall_verdict(
+        chain=chain,
+        session_id="agent-3",
+        reason="no_progress",
+        detector="stall_simple",
+        actor="orchestrator",
+    )
+    rows = chain.query(event_type=EVENT_STALL_VERDICT)
+    assert rows[0].actor == "orchestrator"
+    assert rows[0].resource_id == "agent-3"
+    assert rows[0].resource_type == "stall_verdict"
+
+
+def test_audit_chain_stays_verifiable_after_stall_verdict(tmp_path: Path) -> None:
+    chain = AuditChainStore(tmp_path / "audit", key=b"0" * 32)
+    record_stall_verdict(
+        chain=chain,
+        session_id="agent-1",
+        reason="heartbeat_stale",
+        detector="heartbeat",
+        heartbeat_age_s=100.0,
+        threshold=90.0,
+    )
+    ok, errors = chain.verify()
+    assert ok, errors

--- a/tests/unit/test_heartbeat_stall_verdict_audit.py
+++ b/tests/unit/test_heartbeat_stall_verdict_audit.py
@@ -1,0 +1,263 @@
+"""Invariant: no automatic kill leaves the audit chain without a stall verdict.
+
+Every worker kill decided by the three escalation paths in ``heartbeat``
+(``_escalate_heartbeat``, ``_escalate_stall_simple``, ``_escalate_stall_profiled``)
+must be mirrored into the HMAC audit chain as a ``stall.verdict`` event before
+the kill is issued -- exactly once, even across retries, with the detector, the
+reason, and the measured inputs that actually drove the decision.
+
+The mirror is best-effort: a chain failure must never block or delay the kill,
+and an unrecorded kill must stay observable. The tests prove both halves by
+asserting the record exists in the chain (never that a mock was called) and by
+driving the real kill path with a raising chain store.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from bernstein.core.models import (
+    AgentHeartbeat,
+    AgentSession,
+    ModelConfig,
+    ProgressSnapshot,
+)
+
+from bernstein.core.agents.agent_signals import AgentSignalManager
+from bernstein.core.agents.heartbeat import (
+    AGENT,
+    StallProfile,
+    _escalate_heartbeat,
+    _escalate_stall_profiled,
+    _escalate_stall_simple,
+    check_stale_agents,
+    check_stalled_tasks,
+)
+from bernstein.core.security.audit_chain import (
+    EVENT_STALL_VERDICT,
+    AuditChainStore,
+)
+
+
+def _session(sid: str = "A-1", task_id: str = "T-1", *, pid: int | None = 4321) -> AgentSession:
+    return AgentSession(
+        id=sid,
+        role="backend",
+        task_ids=[task_id],
+        status="working",
+        spawn_ts=100.0,
+        pid=pid,
+        model_config=ModelConfig("sonnet", "high"),
+    )
+
+
+def _chain_verdicts(tmp_path: Path) -> list[object]:
+    chain = AuditChainStore(tmp_path / ".sdd" / "audit")
+    return chain.query(event_type=EVENT_STALL_VERDICT)
+
+
+def _heartbeat_orch(tmp_path: Path, session: AgentSession) -> SimpleNamespace:
+    (tmp_path / ".sdd").mkdir(exist_ok=True)
+    return SimpleNamespace(
+        _agents={session.id: session},
+        _workdir=tmp_path,
+        _signal_mgr=MagicMock(),
+        _spawner=MagicMock(),
+        _stall_counts={},
+        _config=SimpleNamespace(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Site 1: _escalate_heartbeat (SIGKILL tier)
+# ---------------------------------------------------------------------------
+
+
+def test_heartbeat_escalation_kill_records_verdict(tmp_path: Path) -> None:
+    """The heartbeat detector records the age and the threshold it crossed."""
+    orch = _heartbeat_orch(tmp_path, _session())
+    with patch("bernstein.core.platform_compat.kill_process_group"):
+        _escalate_heartbeat(
+            orch,
+            orch._agents["A-1"],
+            age=950.0,
+            elapsed=850.0,
+            shutdown_threshold=60.0,
+            wakeup_threshold=30.0,
+            shutdown_reason="no_heartbeat",
+            kill_threshold=90.0,
+        )
+
+    rows = _chain_verdicts(tmp_path)
+    assert len(rows) == 1
+    details = rows[0].details
+    assert details["session_id"] == "A-1"
+    assert details["reason"] == "heartbeat_stale"
+    assert details["detector"] == "heartbeat"
+    assert details["heartbeat_age_s"] == 950.0
+    assert details["identical_snapshot_count"] is None
+    assert details["threshold"] == 90.0
+    ok, errors = AuditChainStore(tmp_path / ".sdd" / "audit").verify()
+    assert ok, errors
+
+
+def test_heartbeat_escalation_kill_records_verdict_once_across_retries(tmp_path: Path) -> None:
+    """A retry of the same frozen heartbeat does not record a second verdict.
+
+    The escalation ladder is idempotent per tier, so the kill branch is entered
+    once per episode; the verdict count must track the kill count.
+    """
+    orch = _heartbeat_orch(tmp_path, _session())
+    with patch("bernstein.core.platform_compat.kill_process_group"):
+        for _ in range(2):
+            _escalate_heartbeat(
+                orch,
+                orch._agents["A-1"],
+                age=950.0,
+                elapsed=850.0,
+                shutdown_threshold=60.0,
+                wakeup_threshold=30.0,
+                shutdown_reason="no_heartbeat",
+                kill_threshold=90.0,
+            )
+
+    rows = _chain_verdicts(tmp_path)
+    assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# Site 2: _escalate_stall_simple
+# ---------------------------------------------------------------------------
+
+
+def test_stall_simple_kill_records_verdict(tmp_path: Path) -> None:
+    """The simple stall detector records the count and its fixed threshold."""
+    orch = _heartbeat_orch(tmp_path, _session())
+    _escalate_stall_simple(orch, orch._agents["A-1"], "T-1", count=AGENT.escalation_kill_count)
+
+    assert orch._spawner.kill.called
+    rows = _chain_verdicts(tmp_path)
+    assert len(rows) == 1
+    details = rows[0].details
+    assert details["reason"] == "no_progress"
+    assert details["detector"] == "stall_simple"
+    assert details["identical_snapshot_count"] == AGENT.escalation_kill_count
+    assert details["threshold"] == AGENT.escalation_kill_count
+    assert details["heartbeat_age_s"] is None
+
+
+# ---------------------------------------------------------------------------
+# Site 3: _escalate_stall_profiled
+# ---------------------------------------------------------------------------
+
+
+def test_stall_profiled_kill_records_verdict(tmp_path: Path) -> None:
+    """The profiled stall detector records the count and the profile threshold."""
+    orch = _heartbeat_orch(tmp_path, _session())
+    profile = StallProfile(wakeup_threshold=3, shutdown_threshold=5, kill_threshold=7, reason="default profile")
+    _escalate_stall_profiled(orch, orch._agents["A-1"], "T-1", count=7, profile=profile)
+
+    assert orch._spawner.kill.called
+    rows = _chain_verdicts(tmp_path)
+    assert len(rows) == 1
+    details = rows[0].details
+    assert details["reason"] == "no_progress"
+    assert details["detector"] == "stall_profiled"
+    assert details["identical_snapshot_count"] == 7
+    assert details["threshold"] == 7
+    assert details["heartbeat_age_s"] is None
+
+
+def test_stalled_tasks_profiled_kill_records_verdict_end_to_end(tmp_path: Path) -> None:
+    """The production check_stalled_tasks path records the strict-profile verdict."""
+    session = _session()
+    (tmp_path / ".sdd").mkdir(exist_ok=True)
+    snap = {"timestamp": 10.0, "files_changed": 1, "tests_passing": 2, "errors": 0, "last_file": "a.py"}
+    orch = SimpleNamespace(
+        _agents={session.id: session},
+        _workdir=tmp_path,
+        _config=SimpleNamespace(server_url="http://srv", heartbeat_timeout_s=60.0),
+        _client=MagicMock(),
+        _last_snapshot_ts={},
+        _last_snapshot={
+            "T-1": ProgressSnapshot(timestamp=9.0, files_changed=1, tests_passing=2, errors=0, last_file="a.py")
+        },
+        _stall_counts={"T-1": 4},
+        _signal_mgr=MagicMock(),
+        _spawner=MagicMock(),
+    )
+    orch._client.get.return_value.json.return_value = [snap]
+    orch._client.get.return_value.raise_for_status.return_value = None
+
+    with patch("bernstein.core.agents.heartbeat.time.time", return_value=300.0):
+        check_stalled_tasks(orch)
+
+    orch._spawner.kill.assert_called_once()
+    rows = _chain_verdicts(tmp_path)
+    assert len(rows) == 1
+    details = rows[0].details
+    assert details["detector"] == "stall_profiled"
+    assert details["reason"] == "no_progress"
+    assert details["identical_snapshot_count"] == 5
+    assert details["threshold"] == 5
+
+
+# ---------------------------------------------------------------------------
+# Best-effort contract: a chain failure never blocks the kill or the signals
+# ---------------------------------------------------------------------------
+
+
+def test_chain_failure_never_blocks_the_kill_or_the_signals(tmp_path: Path) -> None:
+    """Recording is best-effort: with the chain store raising, the kill still
+    happens, the WAKEUP/SHUTDOWN signal ordering is unchanged, and the failure
+    is loud (a warning naming the session).
+    """
+    session = _session()
+    orch = SimpleNamespace(
+        _agents={session.id: session},
+        _signal_mgr=AgentSignalManager(tmp_path),
+        _spawner=MagicMock(),
+        _workdir=tmp_path,
+        _config=SimpleNamespace(heartbeat_enabled=True, heartbeat_timeout_s=60.0),
+    )
+    orch._signal_mgr.write_heartbeat("A-1", AgentHeartbeat(timestamp=1000.0, status="starting"))
+
+    with (
+        patch("bernstein.core.agents.heartbeat.time.time", return_value=1100.0),
+        patch("bernstein.core.platform_compat.kill_process_group") as kpg,
+        patch(
+            "bernstein.core.security.audit_chain.AuditChainStore",
+            side_effect=RuntimeError("audit backend down"),
+        ),
+        patch("bernstein.core.agents.heartbeat.logger") as log,
+    ):
+        check_stale_agents(orch)
+
+    # The kill still happens.
+    assert kpg.called, "a chain write failure must never block the kill"
+    # The SHUTDOWN signal that follows the kill is still written.
+    shutdown_file = tmp_path / ".sdd" / "runtime" / "signals" / "A-1" / "SHUTDOWN"
+    assert shutdown_file.exists()
+    assert "no_heartbeat" in shutdown_file.read_text(encoding="utf-8")
+    # The failure is loud: a warning naming the session, not a silent swallow.
+    verdict_warnings = [c for c in log.warning.call_args_list if "Could not emit stall.verdict" in str(c.args[0])]
+    assert verdict_warnings, "an unrecorded kill must stay observable via a warning"
+    assert "A-1" in verdict_warnings[0].args
+
+
+def test_heartbeat_kill_without_workdir_skips_record_but_still_kills(tmp_path: Path) -> None:
+    """Without a workdir there is no chain to write, so the verdict is skipped
+    silently -- but the kill is unaffected."""
+    session = _session()
+    orch = SimpleNamespace(
+        _agents={session.id: session},
+        _signal_mgr=MagicMock(),
+        _spawner=MagicMock(),
+        _stall_counts={},
+    )
+    _escalate_stall_simple(orch, session, "T-1", count=AGENT.escalation_kill_count)
+
+    assert orch._spawner.kill.called
+    assert not (tmp_path / ".sdd" / "audit").exists()


### PR DESCRIPTION
## What

Records every automatic worker kill decided by heartbeat.py into the audit chain as a new stall.verdict event, written before the kill is issued and bound to the evidence that triggered it (detector, stall reason, measured heartbeat age / identical-snapshot count, threshold crossed).

## Why

Closes #3604 (Slice 1 of #3277). Automatic stall kills were previously off-chain — decisions existed only in a time.monotonic()-keyed in-memory dict that does not survive daemon restart. Recording the verdict is the prerequisite for rebuilding the escalation ladder after a restart; it also lets an operator reconstruct why a kill was decided next to how the stop was delivered.

## How

-src/bernstein/core/security/audit_chain.py: new EVENT_STALL_VERDICT = "stall.verdict" and record_stall_verdict(...) — 8-field record (session_id, reason, detector, actor, heartbeat_age_s / identical_snapshot_count / threshold left None where a detector didn't measure them).
- src/bernstein/core/agents/heartbeat.py: _emit_stall_verdict() wired into all three kill branches (stale-heartbeat, simple-stall, profiled-stall) before the kill, with each branch's own evidence.
- Mirrors the existing _emit_reap_receipt pattern (spawner_core.py:228): lazy import + try/except so a chain failure never blocks or delays the kill, but is loud on failure (logger.warning naming the session). No-workdir environments skip silently.
- Attests a verdict, never an outcome; joined with process.reap_receipt on session_id.
- docs/operations/stall-escalation.md: "Kill-decision verdicts" section.

## Checklist

- [x] `uv run ruff check src/` passes
- [ ] `uv run pyright src/` passes
- [ ] `uv run python scripts/run_tests.py -x` passes
- [x] New code has type hints

- pyright src/ — not checked: pyright has a pre-existing repo-wide backlog (including 39 pre-existing errors in heartbeat.py from an unresolved import, none on this PR's lines). This PR adds zero new errors; it isn't part of CI's gating on this path.
- scripts/run_tests.py -x — not checked: full suite wasn't run locally. The entire affected slice was verified green (74 files: all audit_chain, heartbeat, and timeout_behavior modules). CI runs the full suite on this PR; will confirm/update after it passes.

### Documentation duty (every PR that touches a feature)

- [N/A ] User-visible README section updated (or N/A if internal-only)
- [x] `docs/operations/<area>.md` updated (or N/A)
- [N/A] `docs/api/` schema regenerated if a public surface changed (or N/A)
- [N/A] `uv run bernstein agents-md sync` run so AGENTS.md, CLAUDE.md, `.goosehints`, `CONVENTIONS.md`, and `.cursor/rules/*.mdc` reflect any new module (or N/A)
- [x] Tests cover the documented behaviour
