### PR TITLE
fix(ci): stop four e2e workflows requesting conflicting extras

### DIFF
--- a/.github/workflows/a2a-federation-e2e.yml
+++ b/.github/workflows/a2a-federation-e2e.yml
@@ -57,7 +57,7 @@ jobs:
         run: uv python install 3.12
 
       - name: Sync dependencies
-        run: uv sync --frozen --all-extras
+        run: uv sync --frozen --all-extras --no-extra modal
 
       - name: Run A2A federation e2e suite
         run: |

--- a/.github/workflows/cluster-e2e.yml
+++ b/.github/workflows/cluster-e2e.yml
@@ -48,7 +48,7 @@ jobs:
         run: uv python install 3.12
 
       - name: Sync dependencies
-        run: uv sync --frozen --all-extras
+        run: uv sync --frozen --all-extras --no-extra modal
 
       - name: Run cluster e2e suite
         env:

--- a/.github/workflows/cluster-tunnel-e2e.yml
+++ b/.github/workflows/cluster-tunnel-e2e.yml
@@ -67,7 +67,7 @@ jobs:
         run: uv python install 3.12
 
       - name: Sync dependencies
-        run: uv sync --frozen --all-extras
+        run: uv sync --frozen --all-extras --no-extra modal
 
       - name: Verify docker compose available
         run: docker compose version

--- a/.github/workflows/pentest.yml
+++ b/.github/workflows/pentest.yml
@@ -47,7 +47,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install project dependencies
-        run: uv sync --all-extras --no-extra modal
+        run: uv sync --frozen --all-extras --no-extra modal
 
       - name: Run API security tests
         if: ${{ github.event.inputs.suite == 'all' || github.event.inputs.suite == 'api' || github.event_name == 'schedule' }}

--- a/.github/workflows/pentest.yml
+++ b/.github/workflows/pentest.yml
@@ -47,7 +47,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install project dependencies
-        run: uv sync --all-extras
+        run: uv sync --all-extras --no-extra modal
 
       - name: Run API security tests
         if: ${{ github.event.inputs.suite == 'all' || github.event.inputs.suite == 'api' || github.event_name == 'schedule' }}

--- a/tests/unit/test_workflow_extra_conflicts_yaml.py
+++ b/tests/unit/test_workflow_extra_conflicts_yaml.py
@@ -1,0 +1,65 @@
+"""``uv sync --all-extras`` must not request a declared-conflicting extra pair.
+
+``[tool.uv].conflicts`` in ``pyproject.toml`` makes some extras mutually
+exclusive. ``uv sync --all-extras`` asks for every extra at once, so any
+workflow using it plainly fails at resolution time with
+``Extras ... are incompatible with the declared conflicts`` and the job never
+reaches its tests. This test ties the two together: adding a conflict pair
+without excluding one side from an ``--all-extras`` step is a resolution
+failure, and it should be caught here rather than in CI minutes.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+# `uv sync ... --all-extras ...` on a single line, capturing the whole command.
+_ALL_EXTRAS = re.compile(r"uv\s+sync\b[^\n]*--all-extras\b[^\n]*")
+_NO_EXTRA = re.compile(r"--no-extra[= ]([A-Za-z0-9_.-]+)")
+
+
+def _conflict_groups() -> list[set[str]]:
+    """Return each declared conflict group as a set of extra names."""
+    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    raw = data.get("tool", {}).get("uv", {}).get("conflicts", [])
+    groups: list[set[str]] = []
+    for group in raw:
+        extras = {entry["extra"] for entry in group if "extra" in entry}
+        if len(extras) > 1:
+            groups.append(extras)
+    return groups
+
+
+def _all_extras_commands() -> list[tuple[Path, str]]:
+    """Return every ``(workflow, command)`` pair that syncs all extras."""
+    found: list[tuple[Path, str]] = []
+    for path in sorted(WORKFLOW_DIR.glob("*.yml")) + sorted(WORKFLOW_DIR.glob("*.yaml")):
+        text = path.read_text(encoding="utf-8")
+        found.extend((path, match.group(0)) for match in _ALL_EXTRAS.finditer(text))
+    return found
+
+
+def test_conflict_groups_are_declared() -> None:
+    """The guard below is only meaningful while a conflict is declared."""
+    assert _conflict_groups(), "pyproject declares no [tool.uv] conflicts; drop this guard"
+
+
+def test_all_extras_syncs_exclude_one_side_of_every_conflict() -> None:
+    """Each ``--all-extras`` step must exclude all but one extra per conflict group."""
+    groups = _conflict_groups()
+    offenders: list[str] = []
+
+    for path, command in _all_extras_commands():
+        excluded = set(_NO_EXTRA.findall(command))
+        for group in groups:
+            remaining = group - excluded
+            if len(remaining) > 1:
+                offenders.append(f"{path.name}: {command.strip()} -> requests conflicting extras {sorted(remaining)}")
+
+    assert not offenders, "uv sync --all-extras requests a declared-conflicting extra pair:\n" + "\n".join(offenders)

--- a/tests/unit/test_workflow_extra_conflicts_yaml.py
+++ b/tests/unit/test_workflow_extra_conflicts_yaml.py
@@ -8,11 +8,19 @@ reaches its tests. This test ties the two together: adding a conflict pair
 without excluding one side from an ``--all-extras`` step is a resolution
 failure, and it should be caught here rather than in CI minutes.
 
-The scan reads the workflow as YAML and looks only at ``run`` values, then
-tokenizes each command with :mod:`shlex`. Scanning raw file text instead would
-miss a command split across lines with a backslash -- the case a guard exists
-for -- and would flag ``echo "uv sync --all-extras"`` or a commented-out line,
-which are not steps at all.
+The scan reads the workflow as YAML, looks only at ``run`` values, and lexes
+each one with :class:`shlex.shlex` in punctuation mode so that shell operators
+are recognised as tokens rather than matched as text. Splitting on ``&&`` with a
+regex before tokenizing gets this wrong in both directions: an operator inside a
+quoted argument splits a command that should stay whole, and the resulting
+fragments then fail to lex.
+
+A guard that cannot read a command must say so rather than skip it. The one case
+where skipping is provably safe is a line that fails to lex and does not contain
+the literal string ``--all-extras`` anywhere in its raw text -- quoting cannot
+hide a substring from a substring search, so such a line cannot be a command
+this guard is about. Every other unreadable line is a failure naming the
+workflow.
 """
 
 from __future__ import annotations
@@ -34,10 +42,16 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
 PYPROJECT = REPO_ROOT / "pyproject.toml"
 
-#: Shell operators that end one logical command inside a ``run`` block.
-_COMMAND_SPLIT = re.compile(r"&&|\|\||[;\n|]")
 #: A backslash-continued newline: the two lines are one command.
 _CONTINUATION = re.compile(r"\\\s*\n\s*")
+#: Tokens ``shlex`` returns in punctuation mode that end one logical command.
+_OPERATORS = frozenset({"&&", "||", "|", ";", ";;", "&", "(", ")"})
+#: The flag whose presence this guard is about, as a literal substring.
+_ALL_EXTRAS_LITERAL = "--all-extras"
+
+
+class UnreadableCommand(Exception):
+    """A ``run`` line mentioning ``--all-extras`` that could not be lexed."""
 
 
 def _conflict_groups() -> list[set[str]]:
@@ -65,29 +79,46 @@ def _run_values(workflow: object) -> Iterator[str]:
             yield from _run_values(item)
 
 
+def _lex(line: str) -> Iterator[list[str]]:
+    """Yield each logical command in one already-joined line."""
+    lexer = shlex.shlex(line, posix=True, punctuation_chars=True)
+    lexer.whitespace_split = True
+    current: list[str] = []
+    for token in lexer:
+        if token in _OPERATORS:
+            if current:
+                yield current
+                current = []
+        else:
+            current.append(token)
+    if current:
+        yield current
+
+
 def _commands(run_value: str) -> Iterator[list[str]]:
-    """Yield the token list of each logical command in one ``run`` value."""
+    """Yield the token list of each logical command in one ``run`` value.
+
+    Raises:
+        UnreadableCommand: the line could not be lexed and mentions
+            ``--all-extras``, so the guard cannot vouch for it.
+    """
     joined = _CONTINUATION.sub(" ", run_value)
-    for fragment in _COMMAND_SPLIT.split(joined):
-        stripped = fragment.strip()
-        if not stripped:
+    for line in joined.splitlines():
+        if not line.strip():
             continue
         try:
-            # ``comments=True`` drops a trailing ``# ...`` outside quotes, so a
-            # commented-out flag is not read as if it were passed.
-            tokens = shlex.split(stripped, comments=True)
-        except ValueError:
-            # Unbalanced quoting -- most often a ``${{ }}`` expression. Skipping
-            # is the safe direction: the guard reports fewer commands, never a
-            # command it misread.
+            # Materialised inside the try: the lexer raises while iterating.
+            commands = list(_lex(line))
+        except ValueError as exc:
+            if _ALL_EXTRAS_LITERAL in line:
+                raise UnreadableCommand(line.strip()) from exc
             continue
-        if tokens:
-            yield tokens
+        yield from commands
 
 
 def _syncs_all_extras(tokens: list[str]) -> bool:
     """Whether this command is a ``uv sync`` requesting every extra."""
-    if "--all-extras" not in tokens:
+    if _ALL_EXTRAS_LITERAL not in tokens:
         return False
     return any(tok == "uv" and tokens[i + 1 : i + 2] == ["sync"] for i, tok in enumerate(tokens))
 
@@ -103,14 +134,20 @@ def _excluded_extras(tokens: list[str]) -> set[str]:
     return excluded
 
 
-def _all_extras_commands() -> list[tuple[Path, list[str]]]:
-    """Return every ``(workflow, tokens)`` pair that syncs all extras."""
+def _all_extras_commands() -> tuple[list[tuple[Path, list[str]]], list[str]]:
+    """Return ``(workflow, tokens)`` pairs that sync all extras, and unreadable lines."""
     found: list[tuple[Path, list[str]]] = []
+    unreadable: list[str] = []
     for path in sorted(WORKFLOW_DIR.glob("*.yml")) + sorted(WORKFLOW_DIR.glob("*.yaml")):
         loaded: object = yaml.safe_load(path.read_text(encoding="utf-8"))
         for run_value in _run_values(loaded):
-            found.extend((path, tokens) for tokens in _commands(run_value) if _syncs_all_extras(tokens))
-    return found
+            try:
+                commands = list(_commands(run_value))
+            except UnreadableCommand as exc:
+                unreadable.append(f"{path.name}: {exc}")
+                continue
+            found.extend((path, tokens) for tokens in commands if _syncs_all_extras(tokens))
+    return found, unreadable
 
 
 def test_conflict_groups_are_declared() -> None:
@@ -118,12 +155,19 @@ def test_conflict_groups_are_declared() -> None:
     assert _conflict_groups(), "pyproject declares no [tool.uv] conflicts; drop this guard"
 
 
+def test_every_all_extras_command_is_readable() -> None:
+    """A command the guard cannot lex is a gap in the guard, not a pass."""
+    _, unreadable = _all_extras_commands()
+    assert not unreadable, "workflow lines mention --all-extras but could not be lexed:\n" + "\n".join(unreadable)
+
+
 def test_all_extras_syncs_exclude_one_side_of_every_conflict() -> None:
     """Each ``--all-extras`` step must exclude all but one extra per conflict group."""
     groups = _conflict_groups()
+    commands, _ = _all_extras_commands()
     offenders: list[str] = []
 
-    for path, tokens in _all_extras_commands():
+    for path, tokens in commands:
         excluded = _excluded_extras(tokens)
         for group in groups:
             remaining = group - excluded
@@ -135,21 +179,52 @@ def test_all_extras_syncs_exclude_one_side_of_every_conflict() -> None:
     assert not offenders, "uv sync --all-extras requests a declared-conflicting extra pair:\n" + "\n".join(offenders)
 
 
+def test_all_extras_syncs_are_frozen() -> None:
+    """A lane requesting every extra must resolve from the checked-in lock."""
+    commands, _ = _all_extras_commands()
+    assert commands, "no --all-extras sync found; this guard has nothing to check"
+    unfrozen = [f"{path.name}: {shlex.join(tokens)}" for path, tokens in commands if "--frozen" not in tokens]
+    assert not unfrozen, "uv sync --all-extras re-resolves instead of using uv.lock:\n" + "\n".join(unfrozen)
+
+
+def test_operators_inside_quotes_do_not_split_a_command() -> None:
+    """A quoted ``&&`` or ``|`` is an argument, not a command boundary."""
+    quoted_amp = 'uv sync --frozen --all-extras --no-extra modal --index-url "https://mirror/?a=1&&b=2"'
+    tokens = [t for t in _commands(quoted_amp) if _syncs_all_extras(t)]
+    assert len(tokens) == 1, "a quoted && split the command"
+    assert _excluded_extras(tokens[0]) == {"modal"}
+
+    quoted_pipe = "uv sync --all-extras --no-extra modal --config-setting 'dir|name'"
+    tokens = [t for t in _commands(quoted_pipe) if _syncs_all_extras(t)]
+    assert len(tokens) == 1, "a quoted | split the command"
+    assert _excluded_extras(tokens[0]) == {"modal"}
+
+
+def test_unreadable_all_extras_line_is_raised_not_skipped() -> None:
+    """An unbalanced quote around an --all-extras sync fails; unrelated lines do not."""
+    with pytest.raises(UnreadableCommand):
+        list(_commands('uv sync --all-extras --index-url "unterminated'))
+
+    # No --all-extras in the raw text, so quoting cannot be hiding one.
+    assert list(_commands('echo "unterminated')) == []
+
+
 def test_scan_reads_continuations_quotes_and_comments() -> None:
-    """The scan itself: the three shapes a raw-text scan gets wrong."""
-    # A command split across lines is still one command.
+    """The shapes a raw-text scan gets wrong."""
     continued = "uv sync --frozen \\\n  --all-extras --no-extra modal\n"
     tokens = [t for t in _commands(continued) if _syncs_all_extras(t)]
     assert len(tokens) == 1
     assert _excluded_extras(tokens[0]) == {"modal"}
 
-    # A quoted value is the same exclusion as a bare one.
     assert _excluded_extras(next(_commands('uv sync --all-extras --no-extra "modal"'))) == {"modal"}
     assert _excluded_extras(next(_commands("uv sync --all-extras --no-extra=modal"))) == {"modal"}
 
-    # Text that merely mentions the command is not the command.
     assert not [t for t in _commands('echo "uv sync --all-extras"') if _syncs_all_extras(t)]
     assert not [t for t in _commands("# uv sync --all-extras") if _syncs_all_extras(t)]
+
+    # Genuine operators still separate commands.
+    both = "uv sync --all-extras --no-extra modal && uv run pytest -q"
+    assert len([t for t in _commands(both) if _syncs_all_extras(t)]) == 1
 
 
 def test_scan_ignores_yaml_outside_run_steps() -> None:

--- a/tests/unit/test_workflow_extra_conflicts_yaml.py
+++ b/tests/unit/test_workflow_extra_conflicts_yaml.py
@@ -7,21 +7,37 @@ workflow using it plainly fails at resolution time with
 reaches its tests. This test ties the two together: adding a conflict pair
 without excluding one side from an ``--all-extras`` step is a resolution
 failure, and it should be caught here rather than in CI minutes.
+
+The scan reads the workflow as YAML and looks only at ``run`` values, then
+tokenizes each command with :mod:`shlex`. Scanning raw file text instead would
+miss a command split across lines with a backslash -- the case a guard exists
+for -- and would flag ``echo "uv sync --all-extras"`` or a commented-out line,
+which are not steps at all.
 """
 
 from __future__ import annotations
 
 import re
+import shlex
 import tomllib
+from collections.abc import Iterator, Mapping
 from pathlib import Path
+
+import pytest
+
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - dev env should have pyyaml
+    pytest.skip("pyyaml not installed", allow_module_level=True)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
 PYPROJECT = REPO_ROOT / "pyproject.toml"
 
-# `uv sync ... --all-extras ...` on a single line, capturing the whole command.
-_ALL_EXTRAS = re.compile(r"uv\s+sync\b[^\n]*--all-extras\b[^\n]*")
-_NO_EXTRA = re.compile(r"--no-extra[= ]([A-Za-z0-9_.-]+)")
+#: Shell operators that end one logical command inside a ``run`` block.
+_COMMAND_SPLIT = re.compile(r"&&|\|\||[;\n|]")
+#: A backslash-continued newline: the two lines are one command.
+_CONTINUATION = re.compile(r"\\\s*\n\s*")
 
 
 def _conflict_groups() -> list[set[str]]:
@@ -36,12 +52,64 @@ def _conflict_groups() -> list[set[str]]:
     return groups
 
 
-def _all_extras_commands() -> list[tuple[Path, str]]:
-    """Return every ``(workflow, command)`` pair that syncs all extras."""
-    found: list[tuple[Path, str]] = []
+def _run_values(workflow: object) -> Iterator[str]:
+    """Yield every ``run`` string reachable from a parsed workflow."""
+    if isinstance(workflow, Mapping):
+        for key, value in workflow.items():
+            if key == "run" and isinstance(value, str):
+                yield value
+            else:
+                yield from _run_values(value)
+    elif isinstance(workflow, list):
+        for item in workflow:
+            yield from _run_values(item)
+
+
+def _commands(run_value: str) -> Iterator[list[str]]:
+    """Yield the token list of each logical command in one ``run`` value."""
+    joined = _CONTINUATION.sub(" ", run_value)
+    for fragment in _COMMAND_SPLIT.split(joined):
+        stripped = fragment.strip()
+        if not stripped:
+            continue
+        try:
+            # ``comments=True`` drops a trailing ``# ...`` outside quotes, so a
+            # commented-out flag is not read as if it were passed.
+            tokens = shlex.split(stripped, comments=True)
+        except ValueError:
+            # Unbalanced quoting -- most often a ``${{ }}`` expression. Skipping
+            # is the safe direction: the guard reports fewer commands, never a
+            # command it misread.
+            continue
+        if tokens:
+            yield tokens
+
+
+def _syncs_all_extras(tokens: list[str]) -> bool:
+    """Whether this command is a ``uv sync`` requesting every extra."""
+    if "--all-extras" not in tokens:
+        return False
+    return any(tok == "uv" and tokens[i + 1 : i + 2] == ["sync"] for i, tok in enumerate(tokens))
+
+
+def _excluded_extras(tokens: list[str]) -> set[str]:
+    """Extras removed from the request by ``--no-extra``, in either spelling."""
+    excluded: set[str] = set()
+    for index, token in enumerate(tokens):
+        if token == "--no-extra" and index + 1 < len(tokens):
+            excluded.add(tokens[index + 1])
+        elif token.startswith("--no-extra="):
+            excluded.add(token.partition("=")[2])
+    return excluded
+
+
+def _all_extras_commands() -> list[tuple[Path, list[str]]]:
+    """Return every ``(workflow, tokens)`` pair that syncs all extras."""
+    found: list[tuple[Path, list[str]]] = []
     for path in sorted(WORKFLOW_DIR.glob("*.yml")) + sorted(WORKFLOW_DIR.glob("*.yaml")):
-        text = path.read_text(encoding="utf-8")
-        found.extend((path, match.group(0)) for match in _ALL_EXTRAS.finditer(text))
+        loaded: object = yaml.safe_load(path.read_text(encoding="utf-8"))
+        for run_value in _run_values(loaded):
+            found.extend((path, tokens) for tokens in _commands(run_value) if _syncs_all_extras(tokens))
     return found
 
 
@@ -55,11 +123,36 @@ def test_all_extras_syncs_exclude_one_side_of_every_conflict() -> None:
     groups = _conflict_groups()
     offenders: list[str] = []
 
-    for path, command in _all_extras_commands():
-        excluded = set(_NO_EXTRA.findall(command))
+    for path, tokens in _all_extras_commands():
+        excluded = _excluded_extras(tokens)
         for group in groups:
             remaining = group - excluded
             if len(remaining) > 1:
-                offenders.append(f"{path.name}: {command.strip()} -> requests conflicting extras {sorted(remaining)}")
+                offenders.append(
+                    f"{path.name}: {shlex.join(tokens)} -> requests conflicting extras {sorted(remaining)}"
+                )
 
     assert not offenders, "uv sync --all-extras requests a declared-conflicting extra pair:\n" + "\n".join(offenders)
+
+
+def test_scan_reads_continuations_quotes_and_comments() -> None:
+    """The scan itself: the three shapes a raw-text scan gets wrong."""
+    # A command split across lines is still one command.
+    continued = "uv sync --frozen \\\n  --all-extras --no-extra modal\n"
+    tokens = [t for t in _commands(continued) if _syncs_all_extras(t)]
+    assert len(tokens) == 1
+    assert _excluded_extras(tokens[0]) == {"modal"}
+
+    # A quoted value is the same exclusion as a bare one.
+    assert _excluded_extras(next(_commands('uv sync --all-extras --no-extra "modal"'))) == {"modal"}
+    assert _excluded_extras(next(_commands("uv sync --all-extras --no-extra=modal"))) == {"modal"}
+
+    # Text that merely mentions the command is not the command.
+    assert not [t for t in _commands('echo "uv sync --all-extras"') if _syncs_all_extras(t)]
+    assert not [t for t in _commands("# uv sync --all-extras") if _syncs_all_extras(t)]
+
+
+def test_scan_ignores_yaml_outside_run_steps() -> None:
+    """A ``--all-extras`` string somewhere other than a ``run`` is not a step."""
+    workflow = {"jobs": {"a": {"steps": [{"name": "uv sync --all-extras", "uses": "actions/checkout@v4"}]}}}
+    assert list(_run_values(workflow)) == []


### PR DESCRIPTION
# User description
Four workflows run `uv sync --frozen --all-extras`. `pyproject.toml` declares

```toml
[tool.uv]
conflicts = [[{ extra = "grpc" }, { extra = "modal" }]]
```

so `--all-extras` is unsatisfiable by construction: uv refuses to resolve a set that contains both sides of a declared conflict. The four jobs fail during dependency install, before any test runs, on every PR that touches their paths — the failure looks like a dependency problem rather than a workflow-configuration one, which is why it survived several PRs.

## Change

Each of the four now excludes one side of the conflict:

| Workflow | Before | After |
|---|---|---|
| `a2a-federation-e2e.yml` | `uv sync --frozen --all-extras` | `uv sync --frozen --all-extras --no-extra modal` |
| `cluster-e2e.yml` | same | same |
| `cluster-tunnel-e2e.yml` | same | same |
| `pentest.yml` | `uv sync --all-extras` | `uv sync --frozen --all-extras --no-extra modal` |

`modal` is the side dropped because none of the four exercises the Modal sandbox backend; all four need `grpc`. `pentest.yml` additionally gains `--frozen`, which the other three already had — an unpinned resolve in a security-eval lane is its own reproducibility gap. (An earlier revision of this PR claimed that and did not do it; `test_all_extras_syncs_are_frozen` now asserts it and caught the omission.)

## Why a test and not just the four edits

The same mistake reappears whenever a new workflow is added or a new conflict group is declared, and it only surfaces as a red job in a lane that does not run on most PRs. `tests/unit/test_workflow_extra_conflicts_yaml.py` reads the conflict groups straight out of `pyproject.toml`, scans every `uv sync … --all-extras` line in `.github/workflows/`, and fails naming the offending workflow when a line leaves both sides of a group selected. It stays correct if the conflict groups change.

Verified it actually fails: stashing the `cluster-e2e.yml` hunk alone turns the test red and the message names that workflow.

## Non-goals

No change to `pyproject.toml`, no change to what any of the four jobs asserts, no attempt to make `--all-extras` resolvable.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Prevent CI dependency resolution failures by excluding the conflicting <code>modal</code> extra while retaining <code>grpc</code> in four E2E and pentest workflows, and freeze the pentest installation. Add a YAML workflow guard that reads <code>pyproject.toml</code> conflict groups and validates every <code>uv sync --all-extras</code> command.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3686?tool=ast&topic=Guard+workflow+extras>Guard workflow extras</a>
        </td><td>Add <code>test_workflow_extra_conflicts_yaml.py</code> to parse workflow commands, detect conflicting extras and unreadable sync lines, and require <code>--frozen</code> for all-extras installs.<details><summary>Modified files (1)</summary><ul><li>tests/unit/test_workflow_extra_conflicts_yaml.py</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>test(ci): lex workflow...</td><td>August 12, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3686?tool=ast&topic=Fix+CI+installs>Fix CI installs</a>
        </td><td>Update four CI jobs to run <code>uv sync --frozen --all-extras --no-extra modal</code>, avoiding the declared <code>grpc</code>/<code>modal</code> conflict while preserving their test coverage.<details><summary>Modified files (4)</summary><ul><li>.github/workflows/a2a-federation-e2e.yml</li>
<li>.github/workflows/cluster-e2e.yml</li>
<li>.github/workflows/cluster-tunnel-e2e.yml</li>
<li>.github/workflows/pentest.yml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>fix(ci): stop four e2e...</td><td>August 12, 2026</td></tr>
<tr><td>renovate[bot]</td><td>chore(deps): update as...</td><td>August 05, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3686?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>


<!-- bot-ack: 3765266254 reason=Rejected. The scan reads .github/workflows in its own repository, and GitHub Actions does not execute symlinked workflow files, so a symlink there is not a workflow this guard vouches for. A containment check would have to either skip such a file, reintroducing the fail-open the other four findings were about, or fail on something that is not a workflow. The threat also requires repository write access, at which point editing the workflow is simpler than symlinking it. Reasoned reply in the review thread. -->
