### PR TITLE
fix: assert caller-supplied paths stay under their base directory

### DIFF
--- a/docs/architecture/fast-path-execution.md
+++ b/docs/architecture/fast-path-execution.md
@@ -79,6 +79,12 @@ specific model.
 - `RENAME_SYMBOL` is a word-boundary regex substitution, not an AST-aware
   rename - it does not understand scope, so a common short identifier can
   match unrelated occurrences across `owned_files`.
+- `RENAME_SYMBOL` only edits files it can prove live under the task's
+  working directory. Each `owned_files` entry is joined onto the workdir
+  through `contained_subpath`, and an entry that resolves elsewhere - an
+  absolute path, a `..` component, or a symlinked component leaving the
+  tree - is skipped with a warning rather than edited. The rest of the
+  entries still run.
 - Classification is purely text-pattern-based (task title + description);
   there is no dry-run or confidence threshold exposed to the operator beyond
   the fixed `confidence` field recorded internally.

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -25,6 +25,28 @@ landed since the newest one.
   resolve. An input the filesystem cannot represent, such as an embedded NUL,
   is reported as that error too rather than as a raw filesystem message.
   Refs #3080.
+- Paths built from caller-supplied strings are now asserted to stay under
+  their base directory. One shared helper,
+  `bernstein.core.security.path_containment.contained_subpath`, joins a
+  project-relative candidate onto a base and returns it only when
+  `realpath` keeps the result inside the resolved base; it is the
+  multi-component counterpart to the existing `contained_path`, which takes
+  single opaque identifiers. It is used in the fast-path `rename_symbol`
+  executor (each `owned_files` entry) and in the `/complete` auto-commit
+  hook (the `.sdd/worktrees/<session id>` working directory). A refused
+  entry is skipped and logged, matching how each of those functions already
+  handles an entry it cannot use, so one bad row does not end a run.
+- **Behaviour change:** the same rule is applied at the input boundary, so a
+  bad row does not reach a sink in the first place. `POST /tasks` and
+  `POST /tasks/self-create` now answer `422` when an `owned_files` entry is
+  absolute, carries a `..` or `.` component, or contains a NUL byte;
+  ordinary project-relative paths such as `src/parser.py` are unaffected.
+  The claim boundaries (`POST /tasks/{id}/claim`, `GET /tasks/next/{role}`,
+  `POST /tasks/claim-batch`) answer `422` when `claimed_by_session` is not a
+  single opaque identifier (`[A-Za-z0-9_.-]+`), which is the shape the
+  orchestrator already generates. Both layers are kept: the validator stops
+  new bad rows, the helper protects the sink from rows that already exist or
+  arrive by another route.
 
 ## Added
 

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -39,7 +39,7 @@ landed since the newest one.
 - **Behaviour change:** the same rule is applied at the input boundary, so a
   bad row does not reach a sink in the first place. `POST /tasks` and
   `POST /tasks/self-create` now answer `422` when an `owned_files` entry is
-  absolute, carries a `..` or `.` component, or contains a NUL byte;
+  absolute, carries a `..` component, or contains a NUL byte;
   ordinary project-relative paths such as `src/parser.py` are unaffected.
   The claim boundaries (`POST /tasks/{id}/claim`, `GET /tasks/next/{role}`,
   `POST /tasks/claim-batch`) answer `422` when `claimed_by_session` is not a

--- a/src/bernstein/core/quality/fast_path.py
+++ b/src/bernstein/core/quality/fast_path.py
@@ -29,6 +29,7 @@ import httpx
 from bernstein.core.agents.spawn_errors import ModelNotConfiguredError
 from bernstein.core.metrics import get_collector
 from bernstein.core.models import Complexity, ModelConfig, Scope, Task
+from bernstein.core.security.path_containment import PathContainmentError, contained_subpath
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -362,7 +363,18 @@ def _run_rename(workdir: Path, owned_files: list[str], task: Task | None = None)
 
     modified = 0
     for rel_path in targets:
-        fpath = workdir / rel_path
+        # ``owned_files`` entries are caller-supplied strings, and
+        # ``workdir / rel_path`` is not by itself a path under ``workdir``:
+        # ``Path.__truediv__`` discards the left side when the right side is
+        # absolute and never collapses ``..``.  ``contained_subpath`` returns
+        # the normalised path only when it is proven to stay under the
+        # working directory; an entry that is not is skipped and logged, the
+        # same way an unreadable entry already is.
+        try:
+            fpath = contained_subpath(workdir, rel_path, label="owned file")
+        except PathContainmentError as exc:
+            logger.warning("Rename skipped for %s: %s", rel_path, exc)
+            continue
         if not fpath.is_file():
             continue
         try:

--- a/src/bernstein/core/routes/task_crud.py
+++ b/src/bernstein/core/routes/task_crud.py
@@ -31,6 +31,11 @@ from bernstein.core.role_classifier import classify_role
 from bernstein.core.routes._rate_limit_headers import rate_limit_exception
 from bernstein.core.routes._sse import SSE_RESPONSES
 from bernstein.core.security.auth_middleware import enforce_agent_task_scope_for_ids
+from bernstein.core.security.path_containment import (
+    PathContainmentError,
+    contained_subpath,
+    validate_path_segment,
+)
 from bernstein.core.security.sanitize import sanitize_log
 
 # Import Pydantic models from server - this works because server.py's
@@ -158,6 +163,40 @@ def _record_claim_receipt(request: Request, task: Task, claim_path: str) -> None
 def _get_workdir(request: Request) -> Path:
     """Return the repository root from application state."""
     return request.app.state.workdir  # type: ignore[no-any-return]
+
+
+def _checked_claim_session(claimed_by_session: str | None) -> str | None:
+    """Return *claimed_by_session* once it is a usable opaque identifier.
+
+    A claim records this value on the task, and later stages name a
+    directory with it (``.sdd/worktrees/<session id>``).  Checking the
+    shape here means a malformed value is refused at the boundary that
+    accepts it, with the request's own 422, rather than being stored and
+    then declined by a downstream consumer that can only log.
+
+    An absent or empty value means "no owning session" and is passed
+    through unchanged - the consumers already branch on that.
+
+    Args:
+        claimed_by_session: The raw query/body value, if any.
+
+    Returns:
+        The value, unchanged.
+
+    Raises:
+        HTTPException: 422 if the value is not a single safe identifier.
+    """
+    if not claimed_by_session:
+        return claimed_by_session
+    try:
+        return validate_path_segment(claimed_by_session, label="claimed_by_session")
+    except PathContainmentError as exc:
+        logger.warning(
+            "claim rejected: claimed_by_session=%s reason=%s",
+            sanitize_log(str(claimed_by_session)),
+            sanitize_log(str(exc)),
+        )
+        raise HTTPException(status_code=422, detail=str(exc)) from None
 
 
 def _get_gate_report_path(request: Request, task_id: str) -> Path:
@@ -381,7 +420,25 @@ def _run_auto_commit_pre_complete(
         return
 
     workdir = _get_workdir(request)
-    worktree_path = workdir / ".sdd" / "worktrees" / session_id
+    # The session id is a stored, caller-supplied string and the joined path
+    # becomes a ``subprocess.run`` cwd below, so it is asserted to name a
+    # directory under the worktree root rather than assumed to.  A refusal is
+    # treated like a missing worktree: log and leave, matching this hook's
+    # fail-open contract.
+    try:
+        worktree_path = contained_subpath(
+            workdir / ".sdd" / "worktrees",
+            session_id,
+            label="session id",
+        )
+    except PathContainmentError as exc:
+        logger.info(
+            "auto_commit_pre_complete: task=%s session=%s reason=unsafe_session_path error=%s",
+            sanitize_log(str(task.id)),
+            sanitize_log(str(session_id)),
+            sanitize_log(str(exc)),
+        )
+        return
 
     if not worktree_path.exists() or not worktree_path.is_dir():
         logger.info(
@@ -1101,6 +1158,7 @@ async def next_task(
             status_code=503,
             detail=_DRAINING_DETAIL,
         )
+    claimed_by_session = _checked_claim_session(claimed_by_session)
     store = _get_store(request)
     task = await store.claim_next(
         role,
@@ -1134,6 +1192,7 @@ async def claim_batch(body: BatchClaimRequest, request: Request) -> BatchClaimRe
         # otherwise claim task B here after being denied on
         # ``POST /tasks/B/claim``.
         enforce_agent_task_scope_for_ids(request, body.task_ids)
+        claim_session = _checked_claim_session(body.claimed_by_session)
         store = _get_store(request)
         tenant_id = _resolve_request_tenant_scope(request)
         # Tenant authorization is enforced inside store.claim_batch under
@@ -1142,7 +1201,7 @@ async def claim_batch(body: BatchClaimRequest, request: Request) -> BatchClaimRe
         claimed, failed = await store.claim_batch(
             list(body.task_ids),
             body.agent_id,
-            claimed_by_session=body.claimed_by_session,
+            claimed_by_session=claim_session,
             tenant_id=tenant_id,
         )
         if failed:
@@ -1187,6 +1246,7 @@ async def claim_task(
             status_code=503,
             detail=_DRAINING_DETAIL,
         )
+    claimed_by_session = _checked_claim_session(claimed_by_session)
     with start_span("task.claim", {"task.id": task_id}):
         store = _get_store(request)
         sse_bus = _get_sse_bus(request)

--- a/src/bernstein/core/security/path_containment.py
+++ b/src/bernstein/core/security/path_containment.py
@@ -51,6 +51,16 @@ SAFE_SEGMENT_RE = re.compile(r"^[A-Za-z0-9_.-]+\Z")
 #: Segments that match the alphabet but name the current/parent directory.
 _RESERVED_SEGMENTS = frozenset({".", ".."})
 
+#: Component separator on either platform. A relative path is stored on one
+#: host and consumed on another, so both spellings are split on regardless of
+#: which platform is doing the checking.
+_SEPARATOR_RE = re.compile(r"[\\/]")
+
+#: A leading Windows drive designator (``C:``), absolute or drive-relative.
+#: ``ntpath.isabs`` accepts ``C:x`` as relative, but it is relative to the
+#: drive's working directory, not to any base this module is given.
+_DRIVE_PREFIX_RE = re.compile(r"^[A-Za-z]:")
+
 
 #: Longest single path component, in encoded bytes. ``NAME_MAX`` is 255 on
 #: every filesystem this project supports.
@@ -173,6 +183,123 @@ def contained_path(base: Path | str, *segments: str, label: str = "identifier") 
     return Path(candidate)
 
 
+def validate_relative_path(candidate: str, *, label: str = "path") -> str:
+    """Return *candidate* unchanged when it names a path below a base directory.
+
+    This is the string-only half of the barrier, so request-validation layers
+    can apply the same rule as :func:`contained_subpath` without touching the
+    filesystem. It is deliberately weaker than
+    :func:`validate_path_segment`: a project-relative path is allowed to have
+    several components and to use characters that are illegal in an opaque
+    identifier (spaces, ``+``, non-ASCII names all occur in real repositories).
+    What it must not do is select a location the base does not contain.
+
+    Both separators are examined, not just this platform's. A stored value is
+    written on one host and consumed on another, so ``..\\..\\x`` has to be
+    refused on POSIX as well - it is a parent reference wherever it is read.
+
+    Args:
+        candidate: The externally-influenced relative path to check.
+        label: Noun used in the error message (e.g. ``"owned file"``).
+
+    Returns:
+        The candidate, unchanged, when it is a usable relative path.
+
+    Raises:
+        PathContainmentError: If the candidate is empty, absolute (POSIX
+            root, Windows drive, or UNC share), carries a ``..`` component,
+            or contains a NUL byte.
+        PathTooLongError: If any component exceeds
+            :data:`MAX_SEGMENT_BYTES` once encoded.
+    """
+    if not candidate:
+        msg = f"unsafe {label}: must not be empty"
+        raise PathContainmentError(msg)
+    if "\x00" in candidate:
+        msg = f"unsafe {label}: must not contain a NUL byte"
+        raise PathContainmentError(msg)
+    # A leading separator is a POSIX absolute path or a UNC share; a leading
+    # drive letter is absolute or drive-relative on Windows. Neither is a
+    # path *under* a base, and ``Path.__truediv__`` discards the base for
+    # both, so both are refused before the join happens.
+    if candidate[0] in "/\\" or _DRIVE_PREFIX_RE.match(candidate):
+        msg = f"unsafe {label} {candidate!r}: must be relative to its base directory"
+        raise PathContainmentError(msg)
+    for component in _SEPARATOR_RE.split(candidate):
+        # ``..`` is the escape; ``.`` is refused with it because a lone ``.``
+        # names the base itself rather than something under it, and the
+        # result of this function must always be a strict descendant.
+        # Interior ``.`` components carry no meaning either, so a value
+        # carrying one is malformed rather than merely redundant.
+        if component in _RESERVED_SEGMENTS:
+            msg = f"unsafe {label} {candidate!r}: must not contain a {component!r} component"
+            raise PathContainmentError(msg)
+        encoded = len(component.encode("utf-8", errors="surrogatepass"))
+        if encoded > MAX_SEGMENT_BYTES:
+            msg = (
+                f"{label} component is {encoded} bytes, over the "
+                f"{MAX_SEGMENT_BYTES}-byte filesystem limit for one path component"
+            )
+            raise PathTooLongError(msg)
+    return candidate
+
+
+def contained_subpath(base: Path | str, candidate: str, *, label: str = "path") -> Path:
+    """Join *candidate* under *base* and prove the result stays inside it.
+
+    The multi-component counterpart to :func:`contained_path`, for callers
+    whose input is a project-relative path (``src/pkg/mod.py``) rather than a
+    single opaque identifier. Both halves of the barrier still apply and
+    neither is sufficient alone: :func:`validate_relative_path` rejects the
+    shapes that can be seen in the string, and the realpath comparison
+    catches the one it cannot - an ordinary-looking component that is itself
+    a symlink out of the tree.
+
+    Args:
+        base: The intended containing directory. Trusted by configuration;
+            it need not exist yet.
+        candidate: The relative path to append. Must be a strict descendant
+            of *base*, never *base* itself.
+        label: Noun used in error messages (e.g. ``"owned file"``).
+
+    Returns:
+        The normalised, containment-checked path. Callers must use this
+        return value for filesystem access - it is the only value proven
+        to be inside *base*.
+
+    Raises:
+        PathContainmentError: If the candidate is not a usable relative path,
+            or if it resolves outside the resolved base.
+        PathTooLongError: If a component, or the composed path, exceeds what
+            the filesystem can represent.
+    """
+    validate_relative_path(candidate, label=label)
+    base_real = os.path.realpath(base)
+    # ``os.path.join(x, "")`` appends the separator without doubling it on a
+    # drive root such as ``C:\``, so the prefix test below stays correct for
+    # every base. The trailing separator is what stops a sibling directory
+    # like ``<base>-evil`` from passing a bare prefix comparison.
+    base_prefix = os.path.join(base_real, "")
+    # ``realpath`` resolves symlinks and normalises ``.``/``..`` even for a
+    # path that does not exist yet, so the containment test sees exactly the
+    # location a later open() would reach.
+    resolved = os.path.realpath(os.path.join(base_real, candidate))
+    if not resolved.startswith(base_prefix):
+        # The base is deliberately left out of the message: these errors can
+        # surface to an API caller, and the absolute layout is not theirs.
+        msg = f"{label} {candidate!r} resolves outside its base directory"
+        raise PathContainmentError(msg)
+    # A legal-length component under an already-deep base can still exceed
+    # PATH_MAX, which would surface as OSError(ENAMETOOLONG) at open() -
+    # outside the ValueError hierarchy callers guard on. Checked after
+    # containment so an escape attempt is never reported as a length problem.
+    encoded_path = len(resolved.encode("utf-8", errors="surrogatepass"))
+    if encoded_path > MAX_PATH_BYTES:
+        msg = f"path for {label} is {encoded_path} bytes, over the {MAX_PATH_BYTES}-byte filesystem limit"
+        raise PathTooLongError(msg)
+    return Path(resolved)
+
+
 __all__ = [
     "MAX_PATH_BYTES",
     "MAX_SEGMENT_BYTES",
@@ -180,5 +307,7 @@ __all__ = [
     "PathContainmentError",
     "PathTooLongError",
     "contained_path",
+    "contained_subpath",
     "validate_path_segment",
+    "validate_relative_path",
 ]

--- a/src/bernstein/core/security/path_containment.py
+++ b/src/bernstein/core/security/path_containment.py
@@ -225,15 +225,20 @@ def validate_relative_path(candidate: str, *, label: str = "path") -> str:
     if candidate[0] in "/\\" or _DRIVE_PREFIX_RE.match(candidate):
         msg = f"unsafe {label} {candidate!r}: must be relative to its base directory"
         raise PathContainmentError(msg)
+    named = 0
     for component in _SEPARATOR_RE.split(candidate):
-        # ``..`` is the escape; ``.`` is refused with it because a lone ``.``
-        # names the base itself rather than something under it, and the
-        # result of this function must always be a strict descendant.
-        # Interior ``.`` components carry no meaning either, so a value
-        # carrying one is malformed rather than merely redundant.
-        if component in _RESERVED_SEGMENTS:
-            msg = f"unsafe {label} {candidate!r}: must not contain a {component!r} component"
+        # A ``.`` component, or the empty one a doubled separator produces,
+        # is redundant rather than unsafe: ``./src/x.py`` is an ordinary way
+        # to spell a relative path and normalisation drops it. What it must
+        # not do is be the whole value - see the strict-descendant check
+        # below. ``..`` is the one that changes where the path points, and
+        # is refused wherever it appears.
+        if component == "..":
+            msg = f"unsafe {label} {candidate!r}: must not contain a '..' component"
             raise PathContainmentError(msg)
+        if component in ("", "."):
+            continue
+        named += 1
         encoded = len(component.encode("utf-8", errors="surrogatepass"))
         if encoded > MAX_SEGMENT_BYTES:
             msg = (
@@ -241,6 +246,12 @@ def validate_relative_path(candidate: str, *, label: str = "path") -> str:
                 f"{MAX_SEGMENT_BYTES}-byte filesystem limit for one path component"
             )
             raise PathTooLongError(msg)
+    # The result must be a strict descendant of the base, never the base
+    # itself, so a value that names no component at all ("." , "./", "//")
+    # is refused even though every component in it was individually safe.
+    if named == 0:
+        msg = f"unsafe {label} {candidate!r}: must name a path below its base directory"
+        raise PathContainmentError(msg)
     return candidate
 
 

--- a/src/bernstein/core/server/server_models.py
+++ b/src/bernstein/core/server/server_models.py
@@ -109,6 +109,27 @@ def _ensure_task_enum(value: str, field_name: str) -> str:
     return value
 
 
+def _ensure_relative_owned_files(value: list[str]) -> list[str]:
+    """Reject ``owned_files`` entries that do not name a path under a workdir.
+
+    Every consumer of ``owned_files`` joins the entry onto a working
+    directory before reading or writing it, and ``Path.__truediv__`` neither
+    collapses ``..`` nor keeps the left side when the right side is absolute.
+    Checking the shape as the row is created keeps such an entry out of the
+    store in the first place; the consumers assert containment again on the
+    path they actually open, so a row that predates this rule or arrives by
+    another route is still handled there.
+    """
+    from bernstein.core.security.path_containment import PathContainmentError, validate_relative_path
+
+    for entry in value:
+        try:
+            validate_relative_path(entry, label="owned_files entry")
+        except PathContainmentError as exc:
+            raise ValueError(str(exc)) from None
+    return value
+
+
 class TaskCreate(BaseModel):
     """Body for POST /tasks."""
 
@@ -180,6 +201,11 @@ class TaskCreate(BaseModel):
     def _validate_task_enums(cls, value: str, info: ValidationInfo) -> str:
         return _ensure_task_enum(value, info.field_name or "")
 
+    @field_validator("owned_files")
+    @classmethod
+    def _validate_owned_files(cls, value: list[str]) -> list[str]:
+        return _ensure_relative_owned_files(value)
+
     @field_validator("artifact_spec")
     @classmethod
     def _validate_artifact_spec(cls, value: dict[str, Any] | None) -> dict[str, Any] | None:
@@ -232,6 +258,11 @@ class TaskSelfCreate(BaseModel):
     @classmethod
     def _validate_scope_complexity(cls, value: str, info: ValidationInfo) -> str:
         return _ensure_task_enum(value, info.field_name or "")
+
+    @field_validator("owned_files")
+    @classmethod
+    def _validate_owned_files(cls, value: list[str]) -> list[str]:
+        return _ensure_relative_owned_files(value)
 
 
 class WebhookTaskCreate(TaskCreate):

--- a/tests/unit/test_auto_commit_on_complete.py
+++ b/tests/unit/test_auto_commit_on_complete.py
@@ -466,6 +466,89 @@ def test_auto_commit_skips_when_no_session(tmp_path: Path, caplog: pytest.LogCap
 
 
 # ---------------------------------------------------------------------------
+# (g2) session id that does not name a child of .sdd/worktrees
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "session_id",
+    [
+        "../../../../tmp",
+        "../sibling",
+        "a/../../b",
+        "..",
+        ".",
+        "null\x00byte",
+    ],
+)
+def test_auto_commit_refuses_session_id_outside_worktree_root(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    session_id: str,
+) -> None:
+    """The worktree path is asserted to stay under ``.sdd/worktrees``.
+
+    ``Path.__truediv__`` neither collapses ``..`` nor keeps the left side
+    when the right side is absolute, so a session id of this shape would
+    otherwise select a directory outside the worktree root and hand it to
+    ``subprocess.run(cwd=...)``.  The hook must decline and log instead.
+
+    Shape checking of the id itself belongs to the claim boundary that
+    accepts it; what this hook owns is that the path it actually uses is
+    under the worktree root, whatever is already stored on the task.
+    """
+    caplog.set_level(logging.INFO, logger="bernstein.core.routes.task_crud")
+    workdir = tmp_path / "workdir"
+    _init_git_repo(workdir)
+    # An out-of-tree git repo the traversal would otherwise land in.
+    _init_git_repo(tmp_path / "elsewhere")
+
+    task = _make_task("T-750", session_id)
+    request = _FakeRequest(workdir)
+    _run_auto_commit_pre_complete(request, task)  # type: ignore[arg-type]
+
+    log_lines = [r.message for r in caplog.records if "auto_commit_pre_complete" in r.message]
+    assert any("reason=unsafe_session_path" in m for m in log_lines), log_lines
+
+
+def test_auto_commit_refuses_absolute_session_id(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """An absolute session id must not become the auto-commit ``cwd``."""
+    caplog.set_level(logging.INFO, logger="bernstein.core.routes.task_crud")
+    workdir = tmp_path / "workdir"
+    _init_git_repo(workdir)
+    elsewhere = tmp_path / "elsewhere"
+    _init_git_repo(elsewhere)
+
+    task = _make_task("T-751", str(elsewhere))
+    request = _FakeRequest(workdir)
+    _run_auto_commit_pre_complete(request, task)  # type: ignore[arg-type]
+
+    log_lines = [r.message for r in caplog.records if "auto_commit_pre_complete" in r.message]
+    assert any("reason=unsafe_session_path" in m for m in log_lines), log_lines
+
+
+def test_auto_commit_still_runs_for_ordinary_session_id(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """Containment is a barrier, not a ban: a normal session id still commits."""
+    caplog.set_level(logging.INFO, logger="bernstein.core.routes.task_crud")
+    session_id = "backend-a1b2c3d4"
+    task = _make_task("T-752", session_id)
+    wt = _setup_workdir_with_worktree(tmp_path, session_id)
+    (wt / "deliverable.py").write_text("print('x')\n", encoding="utf-8")
+
+    request = _FakeRequest(tmp_path)
+    _run_auto_commit_pre_complete(request, task)  # type: ignore[arg-type]
+
+    log = subprocess.run(
+        ["git", "log", "-1", "--pretty=%s"],
+        cwd=wt,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert "T-752" in log
+
+
+# ---------------------------------------------------------------------------
 # (h) /complete end-to-end via TestClient - works on a tiny task
 #     (regression: existing /complete path stays green).
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_fast_path.py
+++ b/tests/unit/test_fast_path.py
@@ -282,6 +282,86 @@ class TestExecuteFastPath:
         assert "get_cwd" in src.read_text()
         assert "getCwd" not in src.read_text()
 
+    def test_rename_ignores_absolute_owned_file(self, tmp_path: Path) -> None:
+        """An absolute entry in owned_files never reaches a file outside workdir.
+
+        ``Path.__truediv__`` drops the left operand entirely when the right
+        operand is absolute, so ``workdir / "/x/y"`` is ``/x/y``.  The entry
+        is skipped and the outside file is left byte-for-byte unchanged.
+        """
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+        outside = tmp_path / "outside.py"
+        outside.write_text("def getCwd():\n    return 1\n", encoding="utf-8")
+        original = outside.read_bytes()
+
+        task = _make_task(
+            title="Rename getCwd to get_cwd",
+            complexity=Complexity.LOW,
+            owned_files=[str(outside)],
+        )
+        result = execute_fast_path(
+            FastPathAction.RENAME_SYMBOL,
+            workdir,
+            [str(outside)],
+            task=task,
+        )
+
+        assert outside.read_bytes() == original
+        assert result.files_modified == 0
+
+    def test_rename_ignores_parent_traversal_owned_file(self, tmp_path: Path) -> None:
+        """A ``..`` entry in owned_files never reaches a file outside workdir."""
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+        outside = tmp_path / "outside.py"
+        outside.write_text("def getCwd():\n    return 1\n", encoding="utf-8")
+        original = outside.read_bytes()
+
+        rel = "../outside.py"
+        task = _make_task(
+            title="Rename getCwd to get_cwd",
+            complexity=Complexity.LOW,
+            owned_files=[rel],
+        )
+        result = execute_fast_path(
+            FastPathAction.RENAME_SYMBOL,
+            workdir,
+            [rel],
+            task=task,
+        )
+
+        assert outside.read_bytes() == original
+        assert result.files_modified == 0
+
+    def test_rename_skips_bad_entry_but_still_renames_good_one(self, tmp_path: Path) -> None:
+        """A refused entry is skipped and logged; the run does not crash."""
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+        good = workdir / "main.py"
+        good.write_text("def getCwd():\n    return getCwd()\n", encoding="utf-8")
+        outside = tmp_path / "outside.py"
+        outside.write_text("def getCwd():\n    return 1\n", encoding="utf-8")
+        original = outside.read_bytes()
+
+        targets = ["../outside.py", "main.py"]
+        task = _make_task(
+            title="Rename getCwd to get_cwd",
+            complexity=Complexity.LOW,
+            owned_files=targets,
+        )
+        result = execute_fast_path(
+            FastPathAction.RENAME_SYMBOL,
+            workdir,
+            targets,
+            task=task,
+        )
+
+        assert result.success is True
+        assert result.files_modified == 1
+        assert "get_cwd" in good.read_text(encoding="utf-8")
+        assert outside.read_bytes() == original
+
     def test_rename_no_task_fails(self) -> None:
         result = execute_fast_path(
             FastPathAction.RENAME_SYMBOL,

--- a/tests/unit/test_path_containment.py
+++ b/tests/unit/test_path_containment.py
@@ -39,7 +39,9 @@ from bernstein.core.security.path_containment import (
     PathContainmentError,
     PathTooLongError,
     contained_path,
+    contained_subpath,
     validate_path_segment,
+    validate_relative_path,
 )
 
 #: Identifiers that must never be accepted as a single path segment.
@@ -1177,3 +1179,107 @@ def test_shutdown_signal_path_refuses_a_workdir_that_is_not_textual() -> None:
     for hostile in (123, ["/tmp"], {"workdir": "/tmp"}, None, b"/tmp"):
         with pytest.raises(ShutdownSignalPathError):
             shutdown_signal_path(hostile)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Multi-segment relative candidates (``contained_subpath``)
+# ---------------------------------------------------------------------------
+
+#: Relative-path candidates that must never resolve to a usable path.
+HOSTILE_RELPATHS = [
+    "/etc/passwd",
+    "/",
+    "../x",
+    "../../etc/passwd",
+    "src/../../etc/passwd",
+    "a/../../b",
+    "..",
+    ".",
+    "",
+    "sub/../..",
+    "nul\x00byte.py",
+    "src/nul\x00byte.py",
+    "C:/Windows/system32",
+    "C:\\Windows\\system32",
+    "\\\\server\\share\\x",
+    "..\\..\\windows",
+]
+
+
+@pytest.mark.parametrize("bad", HOSTILE_RELPATHS)
+def test_validate_relative_path_refuses_hostile_candidates(bad: str) -> None:
+    """Absolute paths, parent references, and NUL bytes are refused."""
+    with pytest.raises(PathContainmentError):
+        validate_relative_path(bad, label="owned file")
+
+
+@pytest.mark.parametrize(
+    "good",
+    ["main.py", "src/parser.py", "src/bernstein/core/quality/fast_path.py", "a/b/c/d.txt", "dir/.gitkeep"],
+)
+def test_validate_relative_path_accepts_ordinary_relative_paths(good: str) -> None:
+    """An ordinary project-relative path passes through unchanged."""
+    assert validate_relative_path(good) == good
+
+
+@pytest.mark.parametrize("bad", HOSTILE_RELPATHS)
+def test_contained_subpath_refuses_hostile_candidates(tmp_path: Path, bad: str) -> None:
+    """No hostile candidate ever produces a path outside the base."""
+    with pytest.raises(PathContainmentError):
+        contained_subpath(tmp_path, bad, label="owned file")
+
+
+def test_contained_subpath_joins_multi_segment_under_base(tmp_path: Path) -> None:
+    """A nested relative path resolves under the base and is returned."""
+    target = tmp_path / "src" / "pkg" / "mod.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("x", encoding="utf-8")
+
+    assert contained_subpath(tmp_path, "src/pkg/mod.py") == target.resolve()
+
+
+def test_contained_subpath_refuses_symlink_escape(tmp_path: Path) -> None:
+    """A well-named child that symlinks out of the base is refused.
+
+    ``resolve()``/``realpath`` follows links, so the allowlist alone is not
+    enough here: every segment is an ordinary name, yet following the link
+    leaves the tree.
+    """
+    base = tmp_path / "base"
+    (base / "src").mkdir(parents=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.py").write_text("secret", encoding="utf-8")
+    _symlink_or_skip(base / "src" / "linked", outside, directory=True)
+
+    with pytest.raises(PathContainmentError):
+        contained_subpath(base, "src/linked/secret.py", label="owned file")
+
+
+def test_contained_subpath_allows_symlink_inside_base(tmp_path: Path) -> None:
+    """A symlink that stays inside the base is fine - containment, not a ban."""
+    base = tmp_path / "base"
+    (base / "real").mkdir(parents=True)
+    (base / "real" / "mod.py").write_text("x", encoding="utf-8")
+    _symlink_or_skip(base / "link", base / "real")
+
+    assert contained_subpath(base, "link/mod.py") == (base / "real" / "mod.py").resolve()
+
+
+def test_contained_subpath_refuses_sibling_prefix(tmp_path: Path) -> None:
+    """A sibling sharing the base's name prefix must not pass containment."""
+    base = tmp_path / "base"
+    base.mkdir()
+    sibling = tmp_path / "base-evil"
+    sibling.mkdir()
+    _symlink_or_skip(base / "link", sibling)
+
+    with pytest.raises(PathContainmentError):
+        contained_subpath(base, "link/file.py")
+
+
+def test_contained_subpath_refuses_candidate_over_path_max(tmp_path: Path) -> None:
+    """An over-long composed path is a capacity failure, not a containment one."""
+    deep = "/".join(["a" * 200] * 30)
+    with pytest.raises(PathTooLongError):
+        contained_subpath(tmp_path, deep, label="owned file")

--- a/tests/unit/test_path_containment.py
+++ b/tests/unit/test_path_containment.py
@@ -1197,6 +1197,8 @@ HOSTILE_RELPATHS = [
     ".",
     "",
     "sub/../..",
+    "./",
+    "//",
     "nul\x00byte.py",
     "src/nul\x00byte.py",
     "C:/Windows/system32",
@@ -1215,11 +1217,31 @@ def test_validate_relative_path_refuses_hostile_candidates(bad: str) -> None:
 
 @pytest.mark.parametrize(
     "good",
-    ["main.py", "src/parser.py", "src/bernstein/core/quality/fast_path.py", "a/b/c/d.txt", "dir/.gitkeep"],
+    [
+        "main.py",
+        "src/parser.py",
+        "src/bernstein/core/quality/fast_path.py",
+        "a/b/c/d.txt",
+        "dir/.gitkeep",
+        # A leading "./" is an ordinary spelling of a relative path and
+        # normalisation drops it, so it must not be refused.
+        "./src/parser.py",
+        "src/./parser.py",
+    ],
 )
 def test_validate_relative_path_accepts_ordinary_relative_paths(good: str) -> None:
     """An ordinary project-relative path passes through unchanged."""
     assert validate_relative_path(good) == good
+
+
+def test_contained_subpath_accepts_a_dot_slash_prefix(tmp_path: Path) -> None:
+    """``./src/x.py`` resolves to the same contained path as ``src/x.py``."""
+    target = tmp_path / "src" / "mod.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("x", encoding="utf-8")
+
+    assert contained_subpath(tmp_path, "./src/mod.py") == target.resolve()
+    assert contained_subpath(tmp_path, "./src/mod.py") == contained_subpath(tmp_path, "src/mod.py")
 
 
 @pytest.mark.parametrize("bad", HOSTILE_RELPATHS)

--- a/tests/unit/test_route_input_validation.py
+++ b/tests/unit/test_route_input_validation.py
@@ -190,3 +190,54 @@ def test_login_valid_provider_passes_validation(client: TestClient, provider: st
     """
     resp = client.get("/auth/login", params={"provider": provider})
     assert resp.status_code != 422, resp.text
+
+
+# ---------------------------------------------------------------------------
+# claim routes - ``claimed_by_session`` is a strict opaque identifier
+# ---------------------------------------------------------------------------
+
+#: Session ids that must not be recorded on a task.  The value is later
+#: joined onto ``.sdd/worktrees`` to select a working directory, so it has
+#: to name a single directory entry and nothing else.
+BAD_SESSION_IDS = [
+    "../../etc",
+    "../sibling",
+    "a/../../b",
+    "sub/dir",
+    "/absolute",
+    "with space",
+    "..",
+    ".",
+]
+
+
+@pytest.mark.parametrize("bad_session", BAD_SESSION_IDS)
+def test_claim_task_invalid_session_returns_422(client: TestClient, bad_session: str) -> None:
+    resp = client.post("/tasks/T-does-not-exist/claim", params={"claimed_by_session": bad_session})
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.parametrize("bad_session", BAD_SESSION_IDS)
+def test_next_task_invalid_session_returns_422(client: TestClient, bad_session: str) -> None:
+    resp = client.get("/tasks/next/backend", params={"claimed_by_session": bad_session})
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.parametrize("bad_session", BAD_SESSION_IDS)
+def test_claim_batch_invalid_session_returns_422(client: TestClient, bad_session: str) -> None:
+    resp = client.post(
+        "/tasks/claim-batch",
+        json={"task_ids": ["T-1"], "agent_id": "agent-1", "claimed_by_session": bad_session},
+    )
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.parametrize("good_session", ["backend-a1b2c3d4", "batch-T-1-deadbeef", "A-1", "s.1_2-3"])
+def test_claim_routes_accept_ordinary_session_ids(client: TestClient, good_session: str) -> None:
+    """Validation is a shape check, not a ban: real session ids pass through.
+
+    ``/tasks/next`` answers 404 when the queue is empty - the point is that
+    the session id itself is never what rejects the request.
+    """
+    resp = client.get("/tasks/next/backend", params={"claimed_by_session": good_session})
+    assert resp.status_code != 422, resp.text

--- a/tests/unit/test_task_create_bounds.py
+++ b/tests/unit/test_task_create_bounds.py
@@ -25,7 +25,7 @@ from bernstein.core.server.server_app import (
     ContentLengthMiddleware,
     create_app,
 )
-from bernstein.core.server.server_models import TaskCreate
+from bernstein.core.server.server_models import TaskCreate, TaskSelfCreate
 
 
 class TaskPostPayload(TypedDict, total=False):
@@ -199,6 +199,67 @@ def test_task_create_happy_path_still_works() -> None:
     )
     assert t.title == "Write parser"
     assert t.metadata == {"issue_number": 42}
+
+
+# ---------------------------------------------------------------------------
+# owned_files must name project-relative paths (reject -> 422)
+# ---------------------------------------------------------------------------
+
+#: Entries that must never be stored on a task, because every consumer of
+#: ``owned_files`` joins them onto a working directory.
+BAD_OWNED_FILES = [
+    "/etc/passwd",
+    "/",
+    "../x",
+    "../../etc/passwd",
+    "src/../../etc/passwd",
+    "..",
+    ".",
+    "",
+    "nul\x00byte.py",
+    "src/nul\x00byte.py",
+    "C:/Windows/system32",
+    "..\\..\\windows",
+]
+
+
+@pytest.mark.parametrize("bad", BAD_OWNED_FILES)
+def test_task_create_rejects_non_relative_owned_files(bad: str) -> None:
+    """An entry that does not name a path under the working directory is refused."""
+    with pytest.raises(ValidationError):
+        TaskCreate(title="ok", description="ok", owned_files=[bad])
+
+
+@pytest.mark.parametrize("bad", BAD_OWNED_FILES)
+def test_task_self_create_rejects_non_relative_owned_files(bad: str) -> None:
+    """The self-create copy of ``owned_files`` carries the same rule."""
+    with pytest.raises(ValidationError):
+        TaskSelfCreate(parent_task_id="T-1", title="ok", description="ok", owned_files=[bad])
+
+
+@pytest.mark.parametrize(
+    "good",
+    ["main.py", "src/parser.py", "src/bernstein/core/quality/fast_path.py", "docs/api/schema.json"],
+)
+def test_task_create_accepts_ordinary_owned_files(good: str) -> None:
+    """Ordinary project-relative paths are unaffected."""
+    assert TaskCreate(title="ok", description="ok", owned_files=[good]).owned_files == [good]
+    assert TaskSelfCreate(
+        parent_task_id="T-1",
+        title="ok",
+        description="ok",
+        owned_files=[good],
+    ).owned_files == [good]
+
+
+def test_post_tasks_absolute_owned_file_returns_422(_app_with_auth_disabled) -> None:
+    """The API boundary rejects the row rather than storing it."""
+    with TestClient(_app_with_auth_disabled) as client:
+        resp = client.post(
+            "/tasks",
+            json={"title": "ok", "description": "ok", "owned_files": ["/etc/passwd"]},
+        )
+    assert resp.status_code == 422, resp.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_task_create_bounds.py
+++ b/tests/unit/test_task_create_bounds.py
@@ -239,7 +239,7 @@ def test_task_self_create_rejects_non_relative_owned_files(bad: str) -> None:
 
 @pytest.mark.parametrize(
     "good",
-    ["main.py", "src/parser.py", "src/bernstein/core/quality/fast_path.py", "docs/api/schema.json"],
+    ["main.py", "src/parser.py", "src/bernstein/core/quality/fast_path.py", "docs/api/schema.json", "./src/x.py"],
 )
 def test_task_create_accepts_ordinary_owned_files(good: str) -> None:
     """Ordinary project-relative paths are unaffected."""


### PR DESCRIPTION
# User description
## What

Tenant scope is now derived from authentication state rather than from a request header.

`SSOAuthMiddleware` binds the tenant every accepted credential is issued for onto
`request.state.tenant_id`, and `request_tenant_id()` reports that binding. `X-Tenant-Id`
becomes a *requested* scope that is authorized against the bound one, instead of being
the request's tenant on its own.

## Why

`docs/operations/security-and-identity.md` already documents the intended model:

> When auth is configured, tenant scoping is automatic from JWT claims;
> unauthenticated dev mode falls back to `DEFAULT_TENANT_ID`.

The implementation did not match. Nothing in the authentication layer wrote
`request.state.tenant_id`; the only writer was the access-log middleware, and
`request_tenant_id()` fell back to `X-Tenant-Id` when the attribute was unset. So the
"automatic from JWT claims" half of the documented contract had no implementation behind
it — the request's scope came from request input on every authenticated path, and the
tenant claims that credentials already carry were never read.

This PR makes the code do what the doc says.

## How

**Binding, one per credential path** (`core/security/auth_middleware.py`):

| Credential | Bound tenant | May select another |
|---|---|---|
| SSO user JWT | `tenant_id` claim, else `default` | only with `admin:manage` |
| Agent identity JWT (task-scoped and unrestricted) | the credential's own `tenant_id` | never |
| Legacy static bearer | `default` | never |
| Cluster worker secret | `default` | never |
| Dashboard session / scoped token | `default` | never |
| HMAC webhook secret | `default` | never |

The agent JWT case is pinned rather than trusted: `_validate_jwt_claims` already compares
the stored `credential.tenant_id` against the signed `tenant_id` claim on every
authentication, so the bound value cannot drift from the token presented.

Credentials that are a single process-wide string — the legacy bearer, the cluster
secret, the webhook secrets — bind to `default` and stay there. Administering several
tenants from one credential is the SSO `admin` user's job, where the grant is per-user
and revocable.

**Reading vs establishing** (`core/server/access_log.py`): the log middleware no longer
writes `request.state.tenant_id`. It reports the binding when there is one and the
caller's claimed header otherwise, so log fidelity on unauthenticated paths is unchanged.
Registration order puts the auth middleware outside the access log, so the log observes
an already-bound request.

**The `DEFAULT_TENANT_ID` branch** (`core/security/tenanting.py`): `resolve_tenant_scope`
previously let a `default`-bound caller name any tenant. Since `default` is where every
tenant-less credential lands, that branch is now gated on an explicit flag that callers
derive from the principal, so `default` behaves like any other tenant.

**Dev mode is preserved.** With `BERNSTEIN_AUTH_DISABLED` there is no credential to derive
a scope from, so `X-Tenant-Id` is the bound scope and its absence still means
`DEFAULT_TENANT_ID`. Local multi-tenant work is unaffected.

## Behaviour change to note

Webhook-created tasks (`/webhook`, `/webhooks/*`, `/hooks/*`) now always land in the
default tenant. Those handlers verify `BERNSTEIN_WEBHOOK_SECRET` / `GITHUB_WEBHOOK_SECRET`,
which are process-wide and carry no tenant, so a header on a globally-signed request is
not a sound way to pick one. Routing webhook work to a named tenant wants a per-tenant
secret, which this PR does not add.

## Tests

`tests/unit/test_tenant_scope_http_isolation.py` — 32 cases driving the real
`create_app` middleware chain, real `SSOAuthMiddleware`, real routing, real `TaskStore`.
No mocks stand in for authentication, because the property under test is the composition
of those layers.

One case per credential type across `GET /tasks/{id}`, `PATCH /tasks/{id}`, `POST /tasks`,
plus:

- `request_tenant_id` reports the credential's tenant, not the header's, through a probe
  route on the real app
- a `default`-bound credential cannot reach a named tenant
- naming your own bound tenant explicitly still succeeds
- dev mode still selects by header, and still falls back to `DEFAULT_TENANT_ID`
- the `PATCH` and `POST` cases assert the store, not just the status code — a refusal that
  still wrote the row would pass a status-only assertion

25 of the 32 fail on `main` and pass here. The 7 that pass either way are the
behaviour-preservation controls (own-tenant-explicit, dev-mode), which exist to prove the
change does not over-refuse.

The agent-JWT cases scope the token to *both* task ids on purpose: the pre-existing
task-scope gate would otherwise refuse the write for an unrelated reason, and a case that
passed for that reason would say nothing about tenant scoping.

## Checklist

- [x] `ruff check` / `ruff format` clean on changed files
- [x] `pyright` reports 0 errors in all five changed source files
- [x] Targeted suites green: tenant, auth-middleware, multi-tenant, access-log, webhook, cluster
- [x] New code has type hints
- [x] `docs/operations/security-and-identity.md` updated

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Harden caller-controlled filesystem paths by validating project-relative <code>owned_files</code> entries and opaque session identifiers, then proving resolved paths remain inside their configured worktree roots. Apply the shared containment barrier across task creation, claim APIs, fast-path renaming, and auto-commit execution while preserving valid inputs and fail-open behavior for unsafe legacy records.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3692?tool=ast&topic=Claim+boundary+safety>Claim boundary safety</a>
        </td><td>Reject unsafe <code>claimed_by_session</code> values at task-claim boundaries before they are persisted or converted into worktree directory names, while allowing orchestrator-generated identifiers.<details><summary>Modified files (3)</summary><ul><li>docs/release-notes/unreleased.md</li>
<li>src/bernstein/core/routes/task_crud.py</li>
<li>tests/unit/test_route_input_validation.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>fix: assert caller-sup...</td><td>August 12, 2026</td></tr>
<tr><td>ngminhkhoayj2706@gmail...</td><td>fix(trace): authentica...</td><td>August 12, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3692?tool=ast&topic=Filesystem+containment>Filesystem containment</a>
        </td><td>Add <code>validate_relative_path</code> and <code>contained_subpath</code> to reject absolute paths, traversal, reserved components, NUL bytes, excessive lengths, and symlink escapes, then reuse the checks across task models, fast-path renaming, and auto-commit worktrees.<details><summary>Modified files (10)</summary><ul><li>docs/architecture/fast-path-execution.md</li>
<li>docs/release-notes/unreleased.md</li>
<li>src/bernstein/core/quality/fast_path.py</li>
<li>src/bernstein/core/routes/task_crud.py</li>
<li>src/bernstein/core/security/path_containment.py</li>
<li>src/bernstein/core/server/server_models.py</li>
<li>tests/unit/test_auto_commit_on_complete.py</li>
<li>tests/unit/test_fast_path.py</li>
<li>tests/unit/test_path_containment.py</li>
<li>tests/unit/test_task_create_bounds.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>fix: assert caller-sup...</td><td>August 12, 2026</td></tr>
<tr><td>ngminhkhoayj2706@gmail...</td><td>fix(trace): authentica...</td><td>August 12, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3692?tool=ast&topic=Security+behavior+docs>Security behavior docs</a>
        </td><td>Document the defense-in-depth model: validate new input at API boundaries, re-check existing or alternate-route data at filesystem sinks, skip unsafe entries without aborting unrelated work, and return <code>422</code> for malformed requests.<details><summary>Modified files (5)</summary><ul><li>docs/architecture/fast-path-execution.md</li>
<li>docs/release-notes/unreleased.md</li>
<li>tests/unit/test_auto_commit_on_complete.py</li>
<li>tests/unit/test_route_input_validation.py</li>
<li>tests/unit/test_task_create_bounds.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>fix: assert caller-sup...</td><td>August 12, 2026</td></tr>
<tr><td>ngminhkhoayj2706@gmail...</td><td>fix(trace): authentica...</td><td>August 12, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3692?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>