### PR TITLE
fix(admission): compare exact canary versions

### DIFF
--- a/src/bernstein/adapters/admission.py
+++ b/src/bernstein/adapters/admission.py
@@ -564,7 +564,11 @@ def _transcripts_for(adapter: str, golden_dir: Path) -> list[Any]:
 
 
 def _canary_verdict_for(adapter: str, installed_version: str | None, last_green_path: Path | None) -> str:
-    """Read the nightly canary's attestation for the installed version."""
+    """Read the nightly canary's attestation for the installed version.
+
+    PEP 440-equivalent spellings such as 1.0 and 1.0.0 intentionally identify
+    the same attested release.
+    """
     from packaging.version import InvalidVersion, Version
 
     from bernstein.adapters.canary import _VERSION_TOKEN_RE, load_last_green  # pyright: ignore[reportPrivateUsage]

--- a/src/bernstein/adapters/admission.py
+++ b/src/bernstein/adapters/admission.py
@@ -565,7 +565,9 @@ def _transcripts_for(adapter: str, golden_dir: Path) -> list[Any]:
 
 def _canary_verdict_for(adapter: str, installed_version: str | None, last_green_path: Path | None) -> str:
     """Read the nightly canary's attestation for the installed version."""
-    from bernstein.adapters.canary import load_last_green
+    from packaging.version import InvalidVersion, Version
+
+    from bernstein.adapters.canary import _VERSION_TOKEN_RE, load_last_green  # pyright: ignore[reportPrivateUsage]
 
     entries = load_last_green(last_green_path)
     entry = entries.get(adapter)
@@ -573,10 +575,17 @@ def _canary_verdict_for(adapter: str, installed_version: str | None, last_green_
         return CANARY_UNKNOWN
     if installed_version is None:
         return CANARY_STALE
-    # ``last_green`` records the parsed dotted-numeric token; the report
-    # captures the full ``--version`` first line. A row attests the installed
-    # binary when its version token appears in that line.
-    return CANARY_GREEN if entry.version and entry.version in installed_version else CANARY_STALE
+
+    match = _VERSION_TOKEN_RE.search(installed_version)
+    if not entry.version or match is None:
+        return CANARY_STALE
+
+    probed_version = match.group(0)
+    try:
+        versions_match = Version(entry.version) == Version(probed_version)
+    except InvalidVersion:
+        versions_match = entry.version == probed_version
+    return CANARY_GREEN if versions_match else CANARY_STALE
 
 
 def gather_admission_evidence(

--- a/tests/unit/test_adapter_admission.py
+++ b/tests/unit/test_adapter_admission.py
@@ -18,6 +18,7 @@ from bernstein.adapters.admission import (
     ADMISSION_EXEMPT,
     CANARY_GREEN,
     CANARY_RED,
+    CANARY_STALE,
     CANARY_UNKNOWN,
     GATE_RECEIPT_KIND,
     POLICY_ENFORCE,
@@ -38,6 +39,7 @@ from bernstein.adapters.admission import (
     AdapterAdmissionRefusal,
     AdmissionEvidence,
     AdmissionGate,
+    _canary_verdict_for,  # pyright: ignore[reportPrivateUsage]
     audit_admission_no_unproven_spawn,
     build_admission_receipt,
     capability_split,
@@ -52,6 +54,7 @@ from bernstein.adapters.admission import (
     verify_admission_receipt,
     write_admission_receipt,
 )
+from bernstein.adapters.canary import LastGreenEntry, save_last_green
 from bernstein.adapters.conformance import StepResult, TranscriptResult
 from bernstein.adapters.registry import get_adapter
 
@@ -153,6 +156,38 @@ def test_replay_fingerprint_changes_when_the_binary_version_changes(contracts_di
     after = _evidence(contracts_dir, version="kimi 1.0.0").replay_fingerprint
 
     assert before != after
+
+
+@pytest.mark.parametrize(
+    ("attested_version", "installed_version", "expected"),
+    [
+        ("0.21.10", "qwen-code 0.21.100", CANARY_STALE),
+        ("0.21.100", "qwen-code 0.21.100", CANARY_GREEN),
+        ("0.21.100", "qwen-code development build", CANARY_STALE),
+    ],
+)
+def test_canary_verdict_compares_extracted_version_tokens(
+    tmp_path: Path,
+    attested_version: str,
+    installed_version: str,
+    expected: str,
+) -> None:
+    """Admission requires the installed binary's exact normalised version."""
+    last_green_path = tmp_path / "last-green.json"
+    save_last_green(
+        last_green_path,
+        {
+            "qwen": LastGreenEntry(
+                adapter="qwen",
+                binary="qwen-code",
+                version=attested_version,
+                receipt_sha256="a" * 64,
+                recorded_at="2026-08-12T00:00:00+00:00",
+            )
+        },
+    )
+
+    assert _canary_verdict_for("qwen", installed_version, last_green_path) == expected
 
 
 def test_replay_fingerprint_ignores_step_messages() -> None:


### PR DESCRIPTION
## Summary

- extract the installed binary''s dotted-numeric version token with the same regex used by the canary
- compare normalized versions with `packaging.version.Version` instead of substring matching
- fall back to exact token equality if either token is not PEP 440 compatible
- return `CANARY_STALE` when the probe line contains no version token

## Design choice

I kept extraction local to `_canary_verdict_for` and reused `canary._VERSION_TOKEN_RE`. This avoids introducing a third regex or widening `canary.py` with a new public helper for a single admission consumer.

## Verification

- `uv run --python 3.12 --managed-python pytest tests/unit/test_adapter_admission.py -k "canary_verdict_compares_extracted_version_tokens" -q` — 3 passed
- `uv run --python 3.12 --managed-python pytest tests/unit/test_adapter_admission.py -k "not test_verify_cli_seals_a_receipt_the_gate_then_accepts" -q` — 64 passed
- `uv run --python 3.12 --managed-python ruff check src/bernstein/adapters/admission.py tests/unit/test_adapter_admission.py` — passed
- `git diff --check` — passed

The excluded existing test assumes the host has no `kimi` binary. This workstation has `kimi.exe` installed, so that test admits the locally detected adapter and returns 0 instead of its host-dependent expected refusal. The failure is unrelated to this diff.

Fixes #3687