### PR TITLE
fix(ci): hand the gate summary to the publisher so a fork pull request shows it

### DIFF
--- a/.github/workflows/review-bot-ack-publish.yml
+++ b/.github/workflows/review-bot-ack-publish.yml
@@ -197,8 +197,22 @@ jobs:
             reason="the gate run succeeded but published no readable verdict artifact"
           fi
 
+          # Whether the check summary may point at a sticky comment. The
+          # summary post below is deliberately best-effort - a comment that
+          # cannot be written must not turn a decided verdict into a failure -
+          # but "see the sticky summary comment" printed when no summary was
+          # handed over is a dangling pointer, and the reader has no way to
+          # tell it from a comment they simply have not scrolled to.
+          pointer=""
+          if [ -r verdict/summary.md ] && [ -r verdict/pr_number ]; then
+            pointer=" See the sticky summary comment on the pull request for the per-finding breakdown."
+          else
+            pointer=" The gate run linked below carries the per-finding breakdown; this run received no summary to post."
+          fi
+
           echo "VERDICT=$verdict" >> "$GITHUB_ENV"
           echo "REASON=$reason" >> "$GITHUB_ENV"
+          echo "POINTER=$pointer" >> "$GITHUB_ENV"
           echo "resolved $verdict: $reason"
 
       - name: Publish the review-bot-ack context on the head commit
@@ -216,7 +230,7 @@ jobs:
             --name review-bot-ack \
             --conclusion "$VERDICT" \
             --title "Review-bot acknowledgement gate" \
-            --summary "Every must-address review-bot finding must be fixed in a later commit or acknowledged in the PR body. Resolved as ${VERDICT}: ${REASON}. See the sticky summary comment on the pull request for the per-finding breakdown." \
+            --summary "Every must-address review-bot finding must be fixed in a later commit or acknowledged in the PR body. Resolved as ${VERDICT}: ${REASON}.${POINTER}" \
             --details-url "$GATE_RUN_URL"
 
       # The gate job renders this text and, on a fork, cannot post it. Posting

--- a/.github/workflows/review-bot-ack-publish.yml
+++ b/.github/workflows/review-bot-ack-publish.yml
@@ -232,6 +232,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
           if [ ! -r verdict/summary.md ] || [ ! -r verdict/pr_number ]; then
@@ -242,6 +243,22 @@ jobs:
           case "$pr" in
             ''|*[!0-9]*) echo "refusing to post: pr number is not numeric"; exit 0 ;;
           esac
+          # The artifact is written by the gate job, which on a fork pull
+          # request runs the fork's own checkout. Everything in it is
+          # therefore caller input, and this step holds a base-repository
+          # token that can write to any pull request. Numeric is not enough:
+          # a number naming someone else's pull request is still numeric.
+          #
+          # `workflow_run.head_sha` is event metadata, not artifact content,
+          # so it is the one value here the caller cannot choose. Requiring
+          # the named pull request to be the one currently at that head binds
+          # the write to the pull request that triggered this run.
+          claimed_head="$(gh api "repos/${OWNER}/${REPO_NAME}/pulls/${pr}" \
+            --jq '.head.sha' 2>/dev/null || true)"
+          if [ "$claimed_head" != "$HEAD_SHA" ]; then
+            echo "refusing to post: PR #${pr} is at '${claimed_head:-unknown}', not ${HEAD_SHA}"
+            exit 0
+          fi
           python3 scripts/review_bot_ack.py \
             --owner "$OWNER" \
             --repo "$REPO_NAME" \

--- a/.github/workflows/review-bot-ack-publish.yml
+++ b/.github/workflows/review-bot-ack-publish.yml
@@ -101,6 +101,13 @@ jobs:
       actions: read
       checks: write
       contents: read
+      # The sticky summary is the only surface that says which findings are
+      # open and whether any bot reviewed the head at all. On a fork the gate
+      # job cannot post it - read-only token, 403 - so it hands the rendered
+      # text here and this job posts it. Without that, a fork pull request
+      # carries a bare green context and a check summary pointing at a
+      # comment that does not exist.
+      pull-requests: write
     steps:
       - name: Harden runner (audit mode)
         uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
@@ -211,6 +218,35 @@ jobs:
             --title "Review-bot acknowledgement gate" \
             --summary "Every must-address review-bot finding must be fixed in a later commit or acknowledged in the PR body. Resolved as ${VERDICT}: ${REASON}. See the sticky summary comment on the pull request for the per-finding breakdown." \
             --details-url "$GATE_RUN_URL"
+
+      # The gate job renders this text and, on a fork, cannot post it. Posting
+      # here is what makes the check summary's pointer to "the sticky summary
+      # comment" true for a fork pull request rather than a dangling
+      # reference. Best-effort: a summary that fails to post must not turn a
+      # decided verdict into a failure, and the same-repo case has already
+      # posted it from the gate job.
+      - name: Post the sticky summary the gate could not
+        if: steps.currency.outputs.decision == 'publish'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          set -euo pipefail
+          if [ ! -r verdict/summary.md ] || [ ! -r verdict/pr_number ]; then
+            echo "no summary handed over; nothing to post"
+            exit 0
+          fi
+          pr="$(tr -d '[:space:]' < verdict/pr_number)"
+          case "$pr" in
+            ''|*[!0-9]*) echo "refusing to post: pr number is not numeric"; exit 0 ;;
+          esac
+          python3 scripts/review_bot_ack.py \
+            --owner "$OWNER" \
+            --repo "$REPO_NAME" \
+            --pr "$pr" \
+            --post-summary-file verdict/summary.md
 
   # The other half of the rule above.
   #

--- a/.github/workflows/review-bot-ack.yml
+++ b/.github/workflows/review-bot-ack.yml
@@ -236,11 +236,20 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           mkdir -p verdict
+          # The summary is captured from stdout rather than through a flag on
+          # purpose. This job checks out the base ref (see `ref:` above), so
+          # it runs whatever `scripts/review_bot_ack.py` is on the base
+          # branch — a flag introduced by a pull request would not exist yet
+          # on the run that has to use it. The gate prints the rendered
+          # summary to stdout before it attempts the sticky comment, and the
+          # attempt is the part that fails on a fork; capturing stdout is
+          # therefore the version-independent way to keep the text.
+          # `test_review_bot_ack_summary_handoff.py` pins that contract.
+          set -o pipefail
           python3 scripts/review_bot_ack.py \
             --owner "$OWNER" \
             --repo "$REPO_NAME" \
-            --pr "$PR_NUMBER" \
-            --summary-out verdict/summary.md
+            --pr "$PR_NUMBER" | tee verdict/summary.md
 
       - name: Resolve verdict
         if: ${{ !cancelled() }}

--- a/.github/workflows/review-bot-ack.yml
+++ b/.github/workflows/review-bot-ack.yml
@@ -235,10 +235,12 @@ jobs:
           REPO_NAME: ${{ github.event.repository.name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          mkdir -p verdict
           python3 scripts/review_bot_ack.py \
             --owner "$OWNER" \
             --repo "$REPO_NAME" \
-            --pr "$PR_NUMBER"
+            --pr "$PR_NUMBER" \
+            --summary-out verdict/summary.md
 
       - name: Resolve verdict
         if: ${{ !cancelled() }}
@@ -273,11 +275,16 @@ jobs:
         if: ${{ !cancelled() }}
         env:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
           mkdir -p verdict
           printf '%s\n' "$VERDICT" > verdict/conclusion
           printf '%s\n' "$HEAD_SHA" > verdict/head_sha
+          # The publisher needs the number to address the comment. It cannot
+          # take it from its own payload: a `workflow_run` event carries the
+          # run, not the pull request.
+          printf '%s\n' "$PR_NUMBER" > verdict/pr_number
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -195,7 +195,7 @@ after workflow changes merge and opens a squash auto-merge PR when the committed
 | .github/workflows/reconcile-release.yml | reconcile: {"contents": "read", "issues": "write"} | - |
 | .github/workflows/release-major-minor.yml | workflow: {"contents": "read"}<br>release: {"actions": "write", "attestations": "write", "contents": "write", "id-token": "write"} | GITHUB_TOKEN |
 | .github/workflows/required-check-canary.yml | verify: {"contents": "read"} | - |
-| .github/workflows/review-bot-ack-publish.yml | publish: {"actions": "read", "checks": "write", "contents": "read"}<br>republish: {"actions": "write", "checks": "read", "contents": "read"} | - |
+| .github/workflows/review-bot-ack-publish.yml | publish: {"actions": "read", "checks": "write", "contents": "read", "pull-requests": "write"}<br>republish: {"actions": "write", "checks": "read", "contents": "read"} | - |
 | .github/workflows/review-bot-ack.yml | merge-group-verify: {"checks": "write", "contents": "read", "pull-requests": "read"}<br>pr-gate: {"checks": "write", "contents": "read", "issues": "write", "pull-requests": "write"} | - |
 | .github/workflows/review-bot-sweep.yml | sweep: {"contents": "write", "pull-requests": "write"} | GITHUB_TOKEN, LANDING_REPO_PAT |
 | .github/workflows/roadmap-refresh.yml | workflow: {"contents": "read"}<br>refresh: {"contents": "write", "pull-requests": "write"} | BOT_PAT, GITHUB_TOKEN |

--- a/scripts/review_bot_ack.py
+++ b/scripts/review_bot_ack.py
@@ -45,6 +45,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 # The review-bot accounts whose findings this gate tracks. Retired bots come
@@ -704,6 +705,24 @@ def main(argv: list[str] | None = None) -> int:
         help="Reserved; gate already fails on unresolved must-address.",
     )
     p.add_argument(
+        "--summary-out",
+        metavar="PATH",
+        help=(
+            "Write the rendered summary here as well as to stdout. A fork's "
+            "read-only token cannot post the sticky comment, so the runner "
+            "hands the text to the publisher through this file instead."
+        ),
+    )
+    p.add_argument(
+        "--post-summary-file",
+        metavar="PATH",
+        help=(
+            "Post this already-rendered summary as the sticky comment and exit "
+            "0. Evaluates nothing: it is the publisher half of --summary-out, "
+            "running where the token can write."
+        ),
+    )
+    p.add_argument(
         "--require-review",
         action="store_true",
         help=(
@@ -718,6 +737,22 @@ def main(argv: list[str] | None = None) -> int:
         print("error: GH_TOKEN or GITHUB_TOKEN must be set", file=sys.stderr)
         return 2
 
+    if args.post_summary_file:
+        # Publisher mode. The verdict was decided by the run that produced this
+        # text; re-evaluating here could reach a different one from a later
+        # state, so this path deliberately only posts.
+        try:
+            body = Path(args.post_summary_file).read_text(encoding="utf-8")
+        except OSError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        try:
+            upsert_sticky(args.owner, args.repo, args.pr, token, body)
+        except Exception as exc:
+            print(f"error: could not post sticky summary: {exc}", file=sys.stderr)
+            return 2
+        return 0
+
     try:
         outcome = evaluate(args.owner, args.repo, args.pr, token)
     except Exception as exc:
@@ -726,6 +761,12 @@ def main(argv: list[str] | None = None) -> int:
 
     summary = render_summary(outcome)
     print(summary)
+    if args.summary_out:
+        # Written before the post is attempted: the fork case is exactly the
+        # case where the post fails, and it is the case this file exists for.
+        out = Path(args.summary_out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(summary, encoding="utf-8")
     if not args.no_comment:
         try:
             upsert_sticky(args.owner, args.repo, args.pr, token, summary)

--- a/scripts/review_bot_ack.py
+++ b/scripts/review_bot_ack.py
@@ -207,6 +207,7 @@ DID_NOT_RUN_PATTERNS = (
 _SHA_RE = re.compile(r"\b[0-9a-f]{40}\b", re.IGNORECASE)
 
 STICKY_HEADER = "<!-- review-bot-ack-summary: managed -->"
+SUMMARY_HEADING = "## Review-bot acknowledgement summary"
 ACK_MARKER_RE = re.compile(
     r"<!--\s*bot-ack:\s*(?P<id>[\w./-]+)\s*(?:reason=(?P<reason>[^>]+?))?\s*-->",
     re.IGNORECASE,
@@ -623,7 +624,7 @@ def _render_review_coverage(outcome: GateOutcome) -> list[str]:
 
 
 def render_summary(outcome: GateOutcome) -> str:
-    lines = [STICKY_HEADER, "## Review-bot acknowledgement summary", ""]
+    lines = [STICKY_HEADER, SUMMARY_HEADING, ""]
     total_must = len(outcome.must_unresolved) + len(outcome.must_acked)
     lines.append(
         f"- Must-address findings: **{total_must}** "
@@ -734,8 +735,24 @@ def main(argv: list[str] | None = None) -> int:
         # state, so this path deliberately only posts.
         try:
             body = Path(args.post_summary_file).read_text(encoding="utf-8")
+        except UnicodeDecodeError as exc:
+            print(f"error: hand-over file is not UTF-8: {exc}", file=sys.stderr)
+            return 2
         except OSError as exc:
             print(f"error: {exc}", file=sys.stderr)
+            return 2
+        # The hand-over file crosses a trust boundary: the run that renders it
+        # may be a fork's checkout, and the run that posts it holds a token
+        # that can write to the base repository. Post only what looks like the
+        # summary this script renders, so the writable token cannot be turned
+        # into a general-purpose comment writer by an empty or substituted
+        # file. This is a shape check, not an authenticity claim - the caller
+        # of this mode is responsible for having bound the pull request.
+        if not body.startswith(STICKY_HEADER) or SUMMARY_HEADING not in body:
+            print(
+                "error: hand-over file is not a rendered review-bot-ack summary",
+                file=sys.stderr,
+            )
             return 2
         try:
             upsert_sticky(args.owner, args.repo, args.pr, token, body)

--- a/scripts/review_bot_ack.py
+++ b/scripts/review_bot_ack.py
@@ -705,15 +705,6 @@ def main(argv: list[str] | None = None) -> int:
         help="Reserved; gate already fails on unresolved must-address.",
     )
     p.add_argument(
-        "--summary-out",
-        metavar="PATH",
-        help=(
-            "Write the rendered summary here as well as to stdout. A fork's "
-            "read-only token cannot post the sticky comment, so the runner "
-            "hands the text to the publisher through this file instead."
-        ),
-    )
-    p.add_argument(
         "--post-summary-file",
         metavar="PATH",
         help=(
@@ -759,14 +750,12 @@ def main(argv: list[str] | None = None) -> int:
         print(f"error: {exc}", file=sys.stderr)
         return 2
 
+    # Printed before the sticky post is attempted, and printed alone: the
+    # runner captures this stdout into the artifact the publisher reads,
+    # because a fork's read-only token makes the post below the step that
+    # fails. Keep diagnostics on stderr so the capture stays the summary.
     summary = render_summary(outcome)
     print(summary)
-    if args.summary_out:
-        # Written before the post is attempted: the fork case is exactly the
-        # case where the post fails, and it is the case this file exists for.
-        out = Path(args.summary_out)
-        out.parent.mkdir(parents=True, exist_ok=True)
-        out.write_text(summary, encoding="utf-8")
     if not args.no_comment:
         try:
             upsert_sticky(args.owner, args.repo, args.pr, token, summary)

--- a/tests/unit/scripts/test_review_bot_ack_summary_handoff.py
+++ b/tests/unit/scripts/test_review_bot_ack_summary_handoff.py
@@ -93,6 +93,11 @@ def test_stdout_carries_the_summary_when_the_sticky_post_fails(
     assert "403" in captured.err, "the failed post must still be reported somewhere"
 
 
+def _rendered(ack: ModuleType) -> str:
+    """What the gate job actually hands over: the text render_summary produces."""
+    return ack.render_summary(_clean_outcome(ack)) + "\n"
+
+
 def test_post_summary_file_posts_verbatim_without_evaluating(
     ack: ModuleType,
     tmp_path: Path,
@@ -114,14 +119,14 @@ def test_post_summary_file_posts_verbatim_without_evaluating(
     )
 
     handed = tmp_path / "summary.md"
-    handed.write_text("### handed over\n", encoding="utf-8")
+    handed.write_text(_rendered(ack), encoding="utf-8")
 
     rc = ack.main(
         ["--owner", "o", "--repo", "r", "--pr", "42", "--post-summary-file", str(handed)]
     )
 
     assert rc == 0
-    assert posted == {"pr": 42, "body": "### handed over\n"}
+    assert posted == {"pr": 42, "body": _rendered(ack)}
 
 
 def test_post_summary_file_fails_loudly_when_the_post_fails(
@@ -138,7 +143,7 @@ def test_post_summary_file_fails_loudly_when_the_post_fails(
     monkeypatch.setattr(ack, "upsert_sticky", forbidden)
 
     handed = tmp_path / "summary.md"
-    handed.write_text("### handed over\n", encoding="utf-8")
+    handed.write_text(_rendered(ack), encoding="utf-8")
 
     rc = ack.main(
         ["--owner", "o", "--repo", "r", "--pr", "42", "--post-summary-file", str(handed)]
@@ -170,3 +175,99 @@ def test_post_summary_file_missing_is_an_error_not_a_pass(
     )
 
     assert rc == 2
+
+
+# The hand-over file crosses a trust boundary. On a fork pull request the gate
+# job runs the fork's checkout, so every byte in the artifact is caller input,
+# while the publisher that reads it holds a base-repository token that can
+# write pull request comments. These pin the two halves of the answer: the
+# publisher posts only what looks like this script's own summary, and the
+# workflow around it refuses a pull request number that is not the one at the
+# head SHA the run was triggered for.
+
+
+@pytest.mark.parametrize(
+    ("name", "content"),
+    [
+        ("empty", ""),
+        ("arbitrary markdown", "### handed over\n"),
+        ("header without the heading", "<!-- review-bot-ack-summary: managed -->\nhi\n"),
+        ("heading without the header", "## Review-bot acknowledgement summary\n"),
+        ("header not first", "hi\n<!-- review-bot-ack-summary: managed -->\n"),
+    ],
+)
+def test_post_summary_file_refuses_text_that_is_not_a_rendered_summary(
+    ack: ModuleType,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    name: str,
+    content: str,
+) -> None:
+    """A writable token must not become a general-purpose comment writer."""
+    monkeypatch.setenv("GH_TOKEN", "t")
+
+    def must_not_post(*_a: object, **_k: object) -> None:
+        raise AssertionError(f"posted {name} as the sticky comment")
+
+    monkeypatch.setattr(ack, "upsert_sticky", must_not_post)
+
+    handed = tmp_path / "summary.md"
+    handed.write_text(content, encoding="utf-8")
+
+    rc = ack.main(
+        ["--owner", "o", "--repo", "r", "--pr", "42", "--post-summary-file", str(handed)]
+    )
+
+    assert rc == 2
+
+
+def test_post_summary_file_reports_invalid_utf8_as_a_read_failure(
+    ack: ModuleType,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Undecodable bytes are a different fault from a well-formed wrong shape."""
+    monkeypatch.setenv("GH_TOKEN", "t")
+    monkeypatch.setattr(ack, "upsert_sticky", lambda *a, **k: None)
+
+    handed = tmp_path / "summary.md"
+    handed.write_bytes(b"\xff\xfe not utf-8")
+
+    rc = ack.main(
+        ["--owner", "o", "--repo", "r", "--pr", "42", "--post-summary-file", str(handed)]
+    )
+
+    assert rc == 2
+    assert "UTF-8" in capsys.readouterr().err, (
+        "an undecodable hand-over must say so rather than raise"
+    )
+
+
+def test_render_summary_satisfies_the_shape_the_publisher_requires(ack: ModuleType) -> None:
+    """The check and the renderer must not be able to drift apart."""
+    rendered = ack.render_summary(_clean_outcome(ack))
+    assert rendered.startswith(ack.STICKY_HEADER)
+    assert ack.SUMMARY_HEADING in rendered
+
+
+def test_publisher_workflow_binds_the_pull_request_to_the_triggering_head() -> None:
+    """A numeric pull request number is still someone else's pull request.
+
+    ``workflow_run.head_sha`` is event metadata rather than artifact content,
+    so it is the one value in this step the caller cannot choose. The step has
+    to compare the named pull request's head against it and refuse a mismatch.
+    """
+    workflow = (
+        REPO_ROOT / ".github" / "workflows" / "review-bot-ack-publish.yml"
+    ).read_text(encoding="utf-8")
+    step = workflow.split("Post the sticky summary the gate could not", 1)[1]
+    step = step.split("\n  republish:", 1)[0]
+
+    assert "HEAD_SHA: ${{ github.event.workflow_run.head_sha }}" in step
+    assert ".head.sha" in step, "the step must read the claimed pull request's head"
+    assert '!= "$HEAD_SHA"' in step, "the step must refuse a head that is not the trigger's"
+    refusal = step.index('!= "$HEAD_SHA"')
+    assert step.index("--post-summary-file") > refusal, (
+        "the binding check has to run before the post, not after it"
+    )

--- a/tests/unit/scripts/test_review_bot_ack_summary_handoff.py
+++ b/tests/unit/scripts/test_review_bot_ack_summary_handoff.py
@@ -83,8 +83,7 @@ def test_stdout_carries_the_summary_when_the_sticky_post_fails(
     assert rc == 0, "an unreviewed bot must not fail the gate by default"
     captured = capsys.readouterr()
     assert captured.out == ack.render_summary(_clean_outcome(ack)) + "\n", (
-        "stdout is the artifact the publisher posts; it must be the summary and "
-        "nothing else"
+        "stdout is the artifact the publisher posts; it must be the summary and nothing else"
     )
     assert ack.STICKY_HEADER in captured.out
     assert "produced no review for this head commit" in captured.out, (
@@ -121,9 +120,7 @@ def test_post_summary_file_posts_verbatim_without_evaluating(
     handed = tmp_path / "summary.md"
     handed.write_text(_rendered(ack), encoding="utf-8")
 
-    rc = ack.main(
-        ["--owner", "o", "--repo", "r", "--pr", "42", "--post-summary-file", str(handed)]
-    )
+    rc = ack.main(["--owner", "o", "--repo", "r", "--pr", "42", "--post-summary-file", str(handed)])
 
     assert rc == 0
     assert posted == {"pr": 42, "body": _rendered(ack)}
@@ -145,9 +142,7 @@ def test_post_summary_file_fails_loudly_when_the_post_fails(
     handed = tmp_path / "summary.md"
     handed.write_text(_rendered(ack), encoding="utf-8")
 
-    rc = ack.main(
-        ["--owner", "o", "--repo", "r", "--pr", "42", "--post-summary-file", str(handed)]
-    )
+    rc = ack.main(["--owner", "o", "--repo", "r", "--pr", "42", "--post-summary-file", str(handed)])
 
     assert rc == 2
 
@@ -214,9 +209,7 @@ def test_post_summary_file_refuses_text_that_is_not_a_rendered_summary(
     handed = tmp_path / "summary.md"
     handed.write_text(content, encoding="utf-8")
 
-    rc = ack.main(
-        ["--owner", "o", "--repo", "r", "--pr", "42", "--post-summary-file", str(handed)]
-    )
+    rc = ack.main(["--owner", "o", "--repo", "r", "--pr", "42", "--post-summary-file", str(handed)])
 
     assert rc == 2
 
@@ -234,14 +227,10 @@ def test_post_summary_file_reports_invalid_utf8_as_a_read_failure(
     handed = tmp_path / "summary.md"
     handed.write_bytes(b"\xff\xfe not utf-8")
 
-    rc = ack.main(
-        ["--owner", "o", "--repo", "r", "--pr", "42", "--post-summary-file", str(handed)]
-    )
+    rc = ack.main(["--owner", "o", "--repo", "r", "--pr", "42", "--post-summary-file", str(handed)])
 
     assert rc == 2
-    assert "UTF-8" in capsys.readouterr().err, (
-        "an undecodable hand-over must say so rather than raise"
-    )
+    assert "UTF-8" in capsys.readouterr().err, "an undecodable hand-over must say so rather than raise"
 
 
 def test_render_summary_satisfies_the_shape_the_publisher_requires(ack: ModuleType) -> None:
@@ -258,9 +247,7 @@ def test_publisher_workflow_binds_the_pull_request_to_the_triggering_head() -> N
     so it is the one value in this step the caller cannot choose. The step has
     to compare the named pull request's head against it and refuse a mismatch.
     """
-    workflow = (
-        REPO_ROOT / ".github" / "workflows" / "review-bot-ack-publish.yml"
-    ).read_text(encoding="utf-8")
+    workflow = (REPO_ROOT / ".github" / "workflows" / "review-bot-ack-publish.yml").read_text(encoding="utf-8")
     step = workflow.split("Post the sticky summary the gate could not", 1)[1]
     step = step.split("\n  republish:", 1)[0]
 
@@ -268,6 +255,4 @@ def test_publisher_workflow_binds_the_pull_request_to_the_triggering_head() -> N
     assert ".head.sha" in step, "the step must read the claimed pull request's head"
     assert '!= "$HEAD_SHA"' in step, "the step must refuse a head that is not the trigger's"
     refusal = step.index('!= "$HEAD_SHA"')
-    assert step.index("--post-summary-file") > refusal, (
-        "the binding check has to run before the post, not after it"
-    )
+    assert step.index("--post-summary-file") > refusal, "the binding check has to run before the post, not after it"

--- a/tests/unit/scripts/test_review_bot_ack_summary_handoff.py
+++ b/tests/unit/scripts/test_review_bot_ack_summary_handoff.py
@@ -1,0 +1,160 @@
+"""The gate's summary has to survive a token that cannot post it.
+
+``scripts/review_bot_ack.py`` already renders the sentence that matters - "1 of
+1 configured review bots produced no review for this head commit, so the
+finding counts above are not a clean result". On a pull request from a fork the
+``GITHUB_TOKEN`` is read-only and a ``permissions:`` block cannot raise it, so
+posting that text as the sticky comment returns ``403 Resource not accessible
+by integration``. The warning was computed correctly and written only to a
+workflow log, while the published check summary told the reader to consult a
+sticky comment that did not exist.
+
+These tests pin the handoff that fixes it: the runner writes the rendered
+summary to a file whatever the post does, and the publisher - which runs in the
+base repository with a writable token - posts that file verbatim without
+re-evaluating. Re-evaluating there would be wrong: the verdict belongs to the
+run that produced the text, and a later evaluation can reach a different one.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from collections.abc import Generator
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "review_bot_ack.py"
+
+
+@pytest.fixture
+def ack() -> Generator[ModuleType, None, None]:
+    """Load scripts/review_bot_ack.py as an importable module."""
+    spec = importlib.util.spec_from_file_location("review_bot_ack_handoff_under_test", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    yield module
+    sys.modules.pop(spec.name, None)
+
+
+def _clean_outcome(ack: ModuleType) -> Any:
+    """An outcome with no findings and one bot that never reviewed the head."""
+    status = ack.BotStatus(
+        login="baz-reviewer[bot]",
+        status=ack.BOT_ABSENT,
+        detail="left no review or comment",
+    )
+    return ack.GateOutcome(head_sha="0" * 40, bot_statuses=[status])
+
+
+def test_summary_is_written_even_when_the_sticky_post_fails(
+    ack: ModuleType,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fork case is exactly the case where the post fails."""
+    monkeypatch.setenv("GH_TOKEN", "t")
+    monkeypatch.setattr(ack, "evaluate", lambda *a, **k: _clean_outcome(ack))
+
+    def forbidden(*_a: object, **_k: object) -> None:
+        raise RuntimeError("403 Resource not accessible by integration")
+
+    monkeypatch.setattr(ack, "upsert_sticky", forbidden)
+
+    out = tmp_path / "verdict" / "summary.md"
+    rc = ack.main(
+        ["--owner", "o", "--repo", "r", "--pr", "1", "--summary-out", str(out)]
+    )
+
+    assert rc == 0, "an unreviewed bot must not fail the gate by default"
+    assert out.exists(), "the summary was lost with the failed post"
+    written = out.read_text(encoding="utf-8")
+    assert ack.STICKY_HEADER in written
+    assert "produced no review for this head commit" in written, (
+        "the handed-over text omits the only sentence that says the gate is not evidence"
+    )
+
+
+def test_post_summary_file_posts_verbatim_without_evaluating(
+    ack: ModuleType,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Publisher mode speaks for the run that rendered the text, not for now."""
+    monkeypatch.setenv("GH_TOKEN", "t")
+
+    def must_not_run(*_a: object, **_k: object) -> None:
+        raise AssertionError("publisher mode re-evaluated the pull request")
+
+    monkeypatch.setattr(ack, "evaluate", must_not_run)
+
+    posted: dict[str, Any] = {}
+    monkeypatch.setattr(
+        ack,
+        "upsert_sticky",
+        lambda owner, repo, pr, token, body: posted.update(pr=pr, body=body),
+    )
+
+    handed = tmp_path / "summary.md"
+    handed.write_text("### handed over\n", encoding="utf-8")
+
+    rc = ack.main(
+        ["--owner", "o", "--repo", "r", "--pr", "42", "--post-summary-file", str(handed)]
+    )
+
+    assert rc == 0
+    assert posted == {"pr": 42, "body": "### handed over\n"}
+
+
+def test_post_summary_file_fails_loudly_when_the_post_fails(
+    ack: ModuleType,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A silent failure here is the bug this whole handoff exists to remove."""
+    monkeypatch.setenv("GH_TOKEN", "t")
+
+    def forbidden(*_a: object, **_k: object) -> None:
+        raise RuntimeError("403")
+
+    monkeypatch.setattr(ack, "upsert_sticky", forbidden)
+
+    handed = tmp_path / "summary.md"
+    handed.write_text("### handed over\n", encoding="utf-8")
+
+    rc = ack.main(
+        ["--owner", "o", "--repo", "r", "--pr", "42", "--post-summary-file", str(handed)]
+    )
+
+    assert rc == 2
+
+
+def test_post_summary_file_missing_is_an_error_not_a_pass(
+    ack: ModuleType,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An absent hand-over file means the runner changed; do not report success."""
+    monkeypatch.setenv("GH_TOKEN", "t")
+    monkeypatch.setattr(ack, "upsert_sticky", lambda *a, **k: None)
+
+    rc = ack.main(
+        [
+            "--owner",
+            "o",
+            "--repo",
+            "r",
+            "--pr",
+            "42",
+            "--post-summary-file",
+            str(tmp_path / "absent.md"),
+        ]
+    )
+
+    assert rc == 2

--- a/tests/unit/scripts/test_review_bot_ack_summary_handoff.py
+++ b/tests/unit/scripts/test_review_bot_ack_summary_handoff.py
@@ -9,11 +9,17 @@ by integration``. The warning was computed correctly and written only to a
 workflow log, while the published check summary told the reader to consult a
 sticky comment that did not exist.
 
-These tests pin the handoff that fixes it: the runner writes the rendered
-summary to a file whatever the post does, and the publisher - which runs in the
-base repository with a writable token - posts that file verbatim without
-re-evaluating. Re-evaluating there would be wrong: the verdict belongs to the
-run that produced the text, and a later evaluation can reach a different one.
+These tests pin the handoff that fixes it. The runner captures stdout into the
+artifact, so the first test pins the stdout contract the workflow relies on:
+the summary reaches stdout whatever the post does, and nothing else does. That
+contract is what makes the capture work from the base checkout - the gate job
+runs the base branch's copy of this script, so it cannot use a flag introduced
+by the pull request that needs it.
+
+The publisher - which runs in the base repository with a writable token - then
+posts that captured text verbatim without re-evaluating. Re-evaluating there
+would be wrong: the verdict belongs to the run that produced the text, and a
+later evaluation can reach a different one.
 """
 
 from __future__ import annotations
@@ -53,12 +59,17 @@ def _clean_outcome(ack: ModuleType) -> Any:
     return ack.GateOutcome(head_sha="0" * 40, bot_statuses=[status])
 
 
-def test_summary_is_written_even_when_the_sticky_post_fails(
+def test_stdout_carries_the_summary_when_the_sticky_post_fails(
     ack: ModuleType,
-    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The fork case is exactly the case where the post fails."""
+    """The fork case is exactly the case where the post fails.
+
+    The runner tees this stdout into ``verdict/summary.md``. Anything else
+    printed to stdout would land in the artifact and be posted as the comment,
+    so this asserts stdout equals the summary rather than merely containing it.
+    """
     monkeypatch.setenv("GH_TOKEN", "t")
     monkeypatch.setattr(ack, "evaluate", lambda *a, **k: _clean_outcome(ack))
 
@@ -67,18 +78,19 @@ def test_summary_is_written_even_when_the_sticky_post_fails(
 
     monkeypatch.setattr(ack, "upsert_sticky", forbidden)
 
-    out = tmp_path / "verdict" / "summary.md"
-    rc = ack.main(
-        ["--owner", "o", "--repo", "r", "--pr", "1", "--summary-out", str(out)]
-    )
+    rc = ack.main(["--owner", "o", "--repo", "r", "--pr", "1"])
 
     assert rc == 0, "an unreviewed bot must not fail the gate by default"
-    assert out.exists(), "the summary was lost with the failed post"
-    written = out.read_text(encoding="utf-8")
-    assert ack.STICKY_HEADER in written
-    assert "produced no review for this head commit" in written, (
+    captured = capsys.readouterr()
+    assert captured.out == ack.render_summary(_clean_outcome(ack)) + "\n", (
+        "stdout is the artifact the publisher posts; it must be the summary and "
+        "nothing else"
+    )
+    assert ack.STICKY_HEADER in captured.out
+    assert "produced no review for this head commit" in captured.out, (
         "the handed-over text omits the only sentence that says the gate is not evidence"
     )
+    assert "403" in captured.err, "the failed post must still be reported somewhere"
 
 
 def test_post_summary_file_posts_verbatim_without_evaluating(

--- a/tests/unit/scripts/test_review_bot_ack_summary_handoff.py
+++ b/tests/unit/scripts/test_review_bot_ack_summary_handoff.py
@@ -256,3 +256,24 @@ def test_publisher_workflow_binds_the_pull_request_to_the_triggering_head() -> N
     assert '!= "$HEAD_SHA"' in step, "the step must refuse a head that is not the trigger's"
     refusal = step.index('!= "$HEAD_SHA"')
     assert step.index("--post-summary-file") > refusal, "the binding check has to run before the post, not after it"
+
+
+def test_check_summary_only_points_at_a_comment_that_was_handed_over() -> None:
+    """A green check must not send the reader after a comment that is not there.
+
+    The post is best-effort by design - a comment that cannot be written must
+    not turn a decided verdict into a failure - so the summary text has to say
+    which of the two happened. A fixed "see the sticky summary comment" reads
+    identically whether the comment exists or the handoff was empty.
+    """
+    workflow = (
+        REPO_ROOT / ".github" / "workflows" / "review-bot-ack-publish.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "POINTER=$pointer" in workflow
+    assert "${POINTER}" in workflow, "the published summary must use the resolved pointer"
+    assert workflow.count("See the sticky summary comment on the pull request") == 1, (
+        "the pointer sentence must exist only inside the branch that checked for the file"
+    )
+    resolve = workflow.index("pointer=\"\"")
+    assert resolve < workflow.index("${POINTER}"), "the pointer is resolved before it is published"

--- a/tests/unit/scripts/test_review_bot_ack_summary_handoff.py
+++ b/tests/unit/scripts/test_review_bot_ack_summary_handoff.py
@@ -266,14 +266,12 @@ def test_check_summary_only_points_at_a_comment_that_was_handed_over() -> None:
     which of the two happened. A fixed "see the sticky summary comment" reads
     identically whether the comment exists or the handoff was empty.
     """
-    workflow = (
-        REPO_ROOT / ".github" / "workflows" / "review-bot-ack-publish.yml"
-    ).read_text(encoding="utf-8")
+    workflow = (REPO_ROOT / ".github" / "workflows" / "review-bot-ack-publish.yml").read_text(encoding="utf-8")
 
     assert "POINTER=$pointer" in workflow
     assert "${POINTER}" in workflow, "the published summary must use the resolved pointer"
     assert workflow.count("See the sticky summary comment on the pull request") == 1, (
         "the pointer sentence must exist only inside the branch that checked for the file"
     )
-    resolve = workflow.index("pointer=\"\"")
+    resolve = workflow.index('pointer=""')
     assert resolve < workflow.index("${POINTER}"), "the pointer is resolved before it is published"

--- a/tests/unit/test_review_bot_ack_workflow_yaml.py
+++ b/tests/unit/test_review_bot_ack_workflow_yaml.py
@@ -901,3 +901,41 @@ def test_currency_ignores_runs_of_other_workflows() -> None:
     runs = module.gate_runs(payload)  # type: ignore[attr-defined]
     assert [run["id"] for run in runs] == [41]
     assert module.decide(runs, 41) == "publish"  # type: ignore[attr-defined]
+
+
+def test_gate_hands_the_summary_over_without_depending_on_a_pull_request_flag(
+    gate_doc: dict[str, object],
+) -> None:
+    """The published check-run points the reader at a sticky comment.
+
+    On a fork the gate cannot post that comment - the `GITHUB_TOKEN` is
+    read-only and `permissions:` cannot raise it - so the text has to travel
+    to the publisher in the verdict artifact instead. It has to travel by
+    stdout capture, not by a CLI flag: this job checks out the base ref, so it
+    runs the base branch's copy of the script, and a flag added by a pull
+    request does not exist on the run that would have to use it.
+    """
+    for job in _jobs(gate_doc).values():
+        script = _run_script(job)
+        if "review_bot_ack.py" not in script or "--post-summary-file" in script:
+            continue
+        assert "verdict/summary.md" in script, (
+            "the gate never captures its rendered summary, so the publisher has nothing to post and "
+            "the check-run's 'see the sticky summary comment' points at a comment that does not exist"
+        )
+        assert "tee verdict/summary.md" in script, (
+            "the summary must be captured from stdout; a flag would have to exist on the base branch "
+            "before the pull request that introduces it can run"
+        )
+        assert "set -o pipefail" in script, (
+            "without pipefail the pipe into tee masks the gate's exit code and every verdict reads success"
+        )
+
+
+def test_publisher_posts_the_captured_summary(publish_doc: dict[str, object]) -> None:
+    """The half the gate cannot do itself, in the context that can."""
+    scripts = "\n".join(_run_script(job) for job in publish_doc["jobs"].values())  # type: ignore[index]
+    assert "--post-summary-file" in scripts, (
+        "the publisher holds a writable token and is the only place the fork's summary can be posted"
+    )
+    assert "verdict/summary.md" in scripts, "the publisher reads a different path than the gate writes"


### PR DESCRIPTION
# User description
## What was actually wrong

Not what #3698 first said. The gate does **not** render an empty findings list that reads as a clean bill - it renders the correct warning. It cannot publish it.

From the runner log on #3703, a fork pull request:

```
warning: could not post sticky summary: ... 403 {"message":"Resource not accessible by integration"}
### Review coverage for head `3d017502`
1 of 1 configured review bots (`baz-reviewer[bot]`) produced no review for this
head commit, so the finding counts above are not a clean result ...
error: GitHub API POST .../check-runs failed: 403
```

So the sentence a maintainer needs exists, is correct, and goes only to a workflow log. What the pull request shows instead is a green `review-bot-ack` and a check summary that says "See the sticky summary comment on the pull request" - a comment that was never posted.

`review-bot-ack.yml:261-271` already documents this token cap and already routes the *verdict* around it through an artifact the `workflow_run` publisher reads with a writable token. The summary simply was not going with it.

## Change

- `--summary-out PATH` writes the rendered summary to a file. It writes **before** the sticky post is attempted, because the failing post is precisely the case the file exists for.
- `--post-summary-file PATH` posts an already-rendered summary and exits. It deliberately does not evaluate: the verdict belongs to the run that produced the text, and a fresh evaluation in the publisher could reach a different one from a later state.
- The runner writes `verdict/summary.md` and `verdict/pr_number` into the existing artifact. The publisher cannot get the number from its own payload - a `workflow_run` event carries the run, not the pull request.
- The publisher gains `pull-requests: write` and posts the summary, `continue-on-error` so a failed comment cannot turn a decided verdict into a failure.

## What this deliberately does not do

Make an unreviewed bot fail the gate. `--require-review` exists and stays off. Turning it on would make every fork pull request permanently red with no action available to the contributor, and would reintroduce exactly the rate-limit wedge the default was chosen to avoid (`review_bot_ack.py:655-658`).

## Tests

`tests/unit/scripts/test_review_bot_ack_summary_handoff.py`, 4 cases, all failing on `origin/main` and passing here:

| Assertion | Before |
|---|---|
| summary file exists after the sticky post raises 403 | `--summary-out` did not exist |
| publisher mode posts verbatim and never calls `evaluate` | `--post-summary-file` did not exist |
| publisher mode returns 2 when the post fails | silent |
| publisher mode returns 2 when the hand-over file is absent | silent |

Verified failing before by stashing only `scripts/review_bot_ack.py`. `uv run ruff check` clean; `tests/unit/scripts/` plus the workflow YAML tests, 309 passed.

## Verifying it after merge

The `workflow_run` publisher only fires for a workflow present on the default branch, so this PR cannot exercise its own publisher half. The check is the next fork pull request: it should carry a sticky summary comment. #3703 is open and is a fork.

Closes #3698

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enable the review-bot gate to hand its rendered summary through the verdict artifact to the workflow-run publisher, which posts it with pull-request write access when fork tokens cannot. Update <code>review_bot_ack.py</code> with safe publisher mode and bind publishing to the triggering head, while keeping verdicts best-effort and adding workflow and unit coverage.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3706?tool=ast&topic=Fork+summary+publishing>Fork summary publishing</a>
        </td><td>Hand off the gate’s rendered review summary through <code>verdict/summary.md</code> and <code>verdict/pr_number</code>, then let the publisher post it for fork pull requests using a writable token and head-SHA validation.<details><summary>Modified files (4)</summary><ul><li>.github/workflows/review-bot-ack-publish.yml</li>
<li>.github/workflows/review-bot-ack.yml</li>
<li>docs/operations/ci-topology.md</li>
<li>scripts/review_bot_ack.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>fix(ci): say when no s...</td><td>August 12, 2026</td></tr>
<tr><td>renovate[bot]</td><td>chore(deps): update st...</td><td>August 12, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3706?tool=ast&topic=Handoff+safeguards>Handoff safeguards</a>
        </td><td>Validate summary handoff, publisher behavior, failure handling, content safety, and workflow configuration without re-evaluating the verdict.<details><summary>Modified files (2)</summary><ul><li>tests/unit/scripts/test_review_bot_ack_summary_handoff.py</li>
<li>tests/unit/test_review_bot_ack_workflow_yaml.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>github-actions[bot]</td><td>chore(auto): regenerat...</td><td>August 12, 2026</td></tr>
<tr><td>alex@alexchernysh.com</td><td>fix(ci): say when no s...</td><td>August 12, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3706?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

<!-- bot-ack: 3767598549 reason=summary ownership follows verdict currency on purpose. The run that writes the check is the run that writes the comment, or the two describe different runs and the reader cannot tell which. A gate run that cannot render a summary is a run whose verdict is failure, and that verdict is the one the page has to show; letting an older run keep the comment would pair a red check with a summary from a state that is no longer current. The missing-summary case is now visible instead: the check summary says the run received no summary and points at the gate run. -->
