### PR TITLE
refactor(tenanting): derive tenant paths once and anchor tenant writes to them

### DIFF
--- a/docs/security/audit-multitenant.md
+++ b/docs/security/audit-multitenant.md
@@ -102,12 +102,17 @@ silently. That link now fails on first use with `OSError` (`ELOOP`, or
 Two ways out, both offline:
 
 1. **Move the data under `.sdd`.** Replace the link with a real
-   directory and copy the contents in:
+   directory and copy the contents in. Resolve the target with `realpath`
+   rather than `readlink`: a relative link target is relative to the link's
+   own directory, and `readlink` hands it back unchanged for the shell to
+   resolve against the working directory instead. Copy first and swap last,
+   so a wrong or missing target costs you nothing:
 
    ```bash
-   test -L .sdd/acme/metrics && target=$(readlink .sdd/acme/metrics) \
-     && rm .sdd/acme/metrics && mkdir .sdd/acme/metrics \
-     && cp -a "$target/." .sdd/acme/metrics/
+   link=.sdd/acme/metrics
+   test -L "$link" && target=$(realpath "$link") && test -d "$target" \
+     && mkdir "$link.new" && cp -a "$target/." "$link.new/" \
+     && rm "$link" && mv "$link.new" "$link"
    ```
 
 2. **Move `.sdd` instead.** If the point of the link was to put state on

--- a/docs/security/audit-multitenant.md
+++ b/docs/security/audit-multitenant.md
@@ -121,6 +121,23 @@ Checking for the case is a one-liner:
 find .sdd -mindepth 2 -maxdepth 3 -type l
 ```
 
+#### Where the refusal does not apply
+
+The refusal is `O_NOFOLLOW` on a descriptor-relative open, so it needs a
+platform whose `os.open`, `os.mkdir`, `os.stat`, `os.unlink` and
+`os.rename` all accept `dir_fd`, and which defines `O_NOFOLLOW`. Linux
+and macOS do. Where they are absent - Windows is the case that matters -
+`anchored_write.py` reports `ANCHORED_WRITE_SUPPORTED` (and
+`ANCHORED_ROTATE_SUPPORTED`) false and falls back to the joined-path
+calls that predate the module, which follow a link or a junction exactly
+as before.
+
+So on those platforms the tenant subtree is best-effort: nothing here
+detects a redirected `.sdd/<tenant>/audit`. Treat multi-tenant storage
+that has to resist a local attacker as supported on Linux and macOS, and
+keep `.sdd` on a filesystem only the service account can write to
+regardless of platform.
+
 ## CLI usage
 
 ### Bare HMAC chain (most common)

--- a/docs/security/audit-multitenant.md
+++ b/docs/security/audit-multitenant.md
@@ -83,6 +83,44 @@ scope to resolve); request surfaces already translate `LookupError` into
 JWT `tenant_id` claim is refused as a client error rather than surfacing
 as a server error.
 
+### The tenant subtree is store-managed, not operator-configurable
+
+`.sdd` itself may be a symlink - where the state directory lives is the
+operator's call. Everything below it is layout this store creates and
+owns, so from this release each component of
+`.sdd/<tenant_id>/{backlog,metrics,runtime,runtime/wal,audit}` is created
+and opened relative to a descriptor for its parent, with `O_NOFOLLOW`. A
+component that is a symlink is refused rather than followed.
+
+This is a behaviour change for one existing setup. Earlier releases
+created the layout with `Path.mkdir(parents=True, exist_ok=True)`, which
+treats a symlink to a directory as an existing directory, so a hand-made
+link - `.sdd/acme/metrics -> /var/data/acme-metrics`, say - was followed
+silently. That link now fails on first use with `OSError` (`ELOOP`, or
+`ENOTDIR` on platforms that report it that way) naming the component.
+
+Two ways out, both offline:
+
+1. **Move the data under `.sdd`.** Replace the link with a real
+   directory and copy the contents in:
+
+   ```bash
+   test -L .sdd/acme/metrics && target=$(readlink .sdd/acme/metrics) \
+     && rm .sdd/acme/metrics && mkdir .sdd/acme/metrics \
+     && cp -a "$target/." .sdd/acme/metrics/
+   ```
+
+2. **Move `.sdd` instead.** If the point of the link was to put state on
+   another volume, link the whole `.sdd` directory there. That one is
+   still followed, because it is the anchor rather than something below
+   it.
+
+Checking for the case is a one-liner:
+
+```bash
+find .sdd -mindepth 2 -maxdepth 3 -type l
+```
+
 ## CLI usage
 
 ### Bare HMAC chain (most common)

--- a/src/bernstein/core/cost/cost_tracker.py
+++ b/src/bernstein/core/cost/cost_tracker.py
@@ -1207,8 +1207,15 @@ class CostTracker:
             return None
         try:
             data = json.loads(file_path.read_text())
+            # The filename was validated; the payload it holds was not. A
+            # `requested.json` carrying `{"run_id": "other"}` would otherwise
+            # build a tracker labelled `other`, and `GET /costs/requested`
+            # would answer with that identity and its spend. The file is
+            # authoritative about the numbers, never about whose they are.
+            if data.get("run_id") != run_id:
+                return None
             tracker = cls(
-                run_id=data["run_id"],
+                run_id=run_id,
                 budget_usd=float(data.get("budget_usd", 0.0)),
                 hard_budget_usd=float(data.get("hard_budget_usd", 0.0)),
                 warn_threshold=float(data.get("warn_threshold", DEFAULT_WARN_THRESHOLD)),

--- a/src/bernstein/core/cost/cost_tracker.py
+++ b/src/bernstein/core/cost/cost_tracker.py
@@ -394,6 +394,24 @@ class TokenUsage:
         )
 
 
+def _validate_run_id(run_id: str) -> None:
+    """Refuse a run id that cannot be one filename component.
+
+    Cost state, the cost report, and the rotated usage log are all named after
+    the run id, so it has to be a single name. It comes from
+    ``BERNSTEIN_RUN_ID`` when the environment sets one
+    (``orchestration/orchestrator.py``), which makes it operator input rather
+    than something a caller controls.
+
+    Raises:
+        ValueError: If *run_id* is empty, is ``.`` or ``..``, or carries a path
+            separator or a NUL.
+    """
+    if not run_id or run_id in {".", ".."} or any(c in run_id for c in ("/", "\\", "\x00")):
+        msg = f"run_id must be a single path component, got {run_id!r} (from BERNSTEIN_RUN_ID?)"
+        raise ValueError(msg)
+
+
 @dataclass(frozen=True)
 class BudgetStatus:
     """Snapshot of the current budget state for a run.
@@ -599,7 +617,17 @@ class CostTracker:
     _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
 
     def __post_init__(self) -> None:
-        """Resolve the usage buffer size and rebuild the deque accordingly."""
+        """Validate the run id, then resolve the usage buffer and rebuild the deque.
+
+        ``run_id`` reaches disk as a filename component in three places, and it
+        arrives from ``BERNSTEIN_RUN_ID`` - operator input, not a constant. The
+        anchored writers refuse a component carrying a separator, which is
+        correct, but they refuse it at the write, deep inside best-effort
+        telemetry, after the in-memory accumulators have already moved. Refusing
+        it once here means a bad value fails on construction, naming itself,
+        instead of surfacing later as a rotation that cannot flush.
+        """
+        _validate_run_id(self.run_id)
         resolved = self.usage_buffer_size
         if resolved is None:
             resolved = _resolve_usage_buffer_size()
@@ -1495,7 +1523,11 @@ class CostTracker:
             rotation_dir.mkdir(parents=True, exist_ok=True)
             with anchored_append(AnchoredDir(root=rotation_dir), f"usages-{self.run_id}.jsonl") as fh:
                 fh.write(json.dumps(usage.to_dict()) + "\n")
-        except OSError as exc:  # pragma: no cover - best-effort IO
+        except (OSError, ValueError) as exc:  # pragma: no cover - best-effort IO
+            # ``ValueError`` belongs here even though ``__post_init__`` rejects
+            # the run ids that cause it: telemetry rotation is the hot path,
+            # and a path refusal reaching an orchestrator through the rotation
+            # of an evicted row would abort a run over a dropped metric.
             logger.debug("Failed to rotate evicted cost usage for run %s: %s", self.run_id, exc)
 
     def attach_retry_budget(self, budget: object) -> None:

--- a/src/bernstein/core/cost/cost_tracker.py
+++ b/src/bernstein/core/cost/cost_tracker.py
@@ -33,6 +33,12 @@ from bernstein.core.models import (
     RunCostProjection,
     RunCostReport,
 )
+from bernstein.core.persistence.anchored_write import (
+    AnchoredDir,
+    anchored_append,
+    anchored_write_text,
+    mkdir_anchored,
+)
 from bernstein.core.tenanting import normalize_tenant_id
 
 logger = logging.getLogger(__name__)
@@ -1117,9 +1123,13 @@ class CostTracker:
         Returns:
             Path to the written JSON file.
         """
-        costs_dir = base_dir / "runtime" / "costs"
-        costs_dir.mkdir(parents=True, exist_ok=True)
-        file_path = costs_dir / f"{self.run_id}.json"
+        # The anchor is created normally and the layout below it is not: a
+        # caller-supplied base directory is the location we are trusting, while
+        # ``runtime/costs`` is layout this module owns.  Same split as
+        # ``anchored_write`` draws between a root and its components.
+        base_dir.mkdir(parents=True, exist_ok=True)
+        costs_dir = AnchoredDir(root=base_dir, parts=("runtime", "costs"))
+        mkdir_anchored(costs_dir)
 
         data: dict[str, Any] = {
             "run_id": self.run_id,
@@ -1140,8 +1150,7 @@ class CostTracker:
             "spent_by_envelope": self._spent_by_envelope.copy(),
             "calls_by_envelope": self._calls_by_envelope.copy(),
         }
-        file_path.write_text(json.dumps(data, indent=2))
-        return file_path
+        return anchored_write_text(costs_dir, f"{self.run_id}.json", json.dumps(data, indent=2))
 
     @classmethod
     def load(cls, base_dir: Path, run_id: str) -> CostTracker | None:
@@ -1397,9 +1406,9 @@ class CostTracker:
 
         metrics_path = _Path(str(metrics_dir))
         metrics_path.mkdir(parents=True, exist_ok=True)
-        file_path = metrics_path / f"costs_{self.run_id}.json"
+        target = AnchoredDir(root=metrics_path)
         r = self.report()
-        file_path.write_text(json.dumps(r.to_dict(), indent=2))
+        file_path = anchored_write_text(target, f"costs_{self.run_id}.json", json.dumps(r.to_dict(), indent=2))
         logger.debug("Cost report for run %s saved to %s", self.run_id, file_path)
         return file_path
 
@@ -1484,8 +1493,7 @@ class CostTracker:
             return
         try:
             rotation_dir.mkdir(parents=True, exist_ok=True)
-            rotation_file = rotation_dir / f"usages-{self.run_id}.jsonl"
-            with rotation_file.open("a", encoding="utf-8") as fh:
+            with anchored_append(AnchoredDir(root=rotation_dir), f"usages-{self.run_id}.jsonl") as fh:
                 fh.write(json.dumps(usage.to_dict()) + "\n")
         except OSError as exc:  # pragma: no cover - best-effort IO
             logger.debug("Failed to rotate evicted cost usage for run %s: %s", self.run_id, exc)

--- a/src/bernstein/core/cost/cost_tracker.py
+++ b/src/bernstein/core/cost/cost_tracker.py
@@ -1189,9 +1189,19 @@ class CostTracker:
             run_id: Run identifier to look up.
 
         Returns:
-            Restored ``CostTracker``, or ``None`` if the file doesn't exist
-            or is corrupt.
+            Restored ``CostTracker``, or ``None`` if the file doesn't exist,
+            is corrupt, or *run_id* does not name one file.
         """
+        # Before the join, not after. `run_id` arrives here from
+        # `GET /costs/{run_id}` as well as from the orchestrator, and a path
+        # segment that survives URL decoding is not automatically a filename:
+        # on Windows `Path` treats a backslash as a separator, so `..\outside`
+        # reaches `runtime/outside.json`. Validating in `__post_init__` alone
+        # would check the value after the read it was supposed to gate.
+        try:
+            _validate_run_id(run_id)
+        except ValueError:
+            return None
         file_path = base_dir / "runtime" / "costs" / f"{run_id}.json"
         if not file_path.exists():
             return None

--- a/src/bernstein/core/observability/metric_collector.py
+++ b/src/bernstein/core/observability/metric_collector.py
@@ -20,8 +20,9 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+from bernstein.core.persistence.anchored_write import AnchoredDir, anchored_append, mkdir_anchored
 from bernstein.core.persistence.runtime_state import rotate_log_file
-from bernstein.core.tenanting import normalize_tenant_id, tenant_metrics_dir
+from bernstein.core.tenanting import normalize_tenant_id, tenant_metrics_target
 
 logger = logging.getLogger(__name__)
 
@@ -298,7 +299,12 @@ class MetricsCollector:
         self._usage_quotas: dict[str, UsageQuota] = {}
 
         # Write buffer for batched file I/O
-        self._buffer: list[tuple[Path, str]] = []
+        # Buffered points carry the directory as an anchor plus a filename
+        # rather than as a joined path.  A point is written at flush time, not
+        # at record time, so a path stored here would be resolved long after
+        # the directory it names was decided on -- the anchor defers the walk
+        # to the moment of the write instead.
+        self._buffer: list[tuple[AnchoredDir, str, str]] = []
         self._buffer_limit: int = 50
         self._flush_interval: float = 5.0  # seconds between time-based flushes
         self._last_flush: float = time.time()
@@ -907,7 +913,7 @@ class MetricsCollector:
 
         today = datetime.now().strftime("%Y-%m-%d")
         filename = f"{metric_type.value}_{today}.jsonl"
-        filepath = self._metrics_dir / filename
+        shared_dir = AnchoredDir(root=self._metrics_dir)
 
         point = {
             "timestamp": time.time(),
@@ -919,12 +925,12 @@ class MetricsCollector:
         file_disabled = EventSink.FILE in self._disabled_sinks
         if not file_disabled:
             with self._lock:
-                self._buffer.append((filepath, json.dumps(point)))
+                self._buffer.append((shared_dir, filename, json.dumps(point)))
                 tenant_id = normalize_tenant_id(labels.get("tenant_id"))
                 if tenant_id != "default":
-                    tenant_dir = tenant_metrics_dir(self._metrics_dir, tenant_id)
-                    tenant_dir.mkdir(parents=True, exist_ok=True)
-                    self._buffer.append((tenant_dir / filename, json.dumps(point)))
+                    tenant_dir = tenant_metrics_target(self._metrics_dir, tenant_id)
+                    mkdir_anchored(tenant_dir)
+                    self._buffer.append((tenant_dir, filename, json.dumps(point)))
                 should_flush = (
                     len(self._buffer) >= self._buffer_limit or (time.time() - self._last_flush) >= self._flush_interval
                 )
@@ -944,25 +950,29 @@ class MetricsCollector:
             self._buffer = []
             self._last_flush = time.time()
 
-        # Group lines by file path
-        by_file: dict[Path, list[str]] = {}
-        for filepath, line in batch:
-            by_file.setdefault(filepath, []).append(line)
+        # Group lines by target file. ``AnchoredDir`` is frozen, so the anchor
+        # and filename form the key directly.
+        by_file: dict[tuple[AnchoredDir, str], list[str]] = {}
+        for directory, filename, line in batch:
+            by_file.setdefault((directory, filename), []).append(line)
 
-        for filepath, lines in by_file.items():
+        for (directory, filename), lines in by_file.items():
             try:
                 # Bound per-file growth: rotate *before* appending so the new
                 # write starts a fresh file once the threshold is crossed.
                 # See - previously these JSONL files grew unbounded.
+                # Rotation renames a file that is already written; it is the
+                # append below that decides where new content lands, so that
+                # is the one anchored.
                 rotate_log_file(
-                    filepath,
+                    directory.path / filename,
                     max_bytes=_METRIC_FILE_ROTATE_BYTES,
                     max_backups=_METRIC_FILE_MAX_BACKUPS,
                 )
-                with filepath.open("a") as f:
+                with anchored_append(directory, filename) as f:
                     f.write("\n".join(lines) + "\n")
             except OSError:
-                logger.exception("Failed to flush metrics to %s", filepath)
+                logger.exception("Failed to flush metrics to %s", directory.path / filename)
 
     def flush(self) -> None:
         """Flush the write buffer to disk. Call this each orchestrator tick."""

--- a/src/bernstein/core/observability/metric_collector.py
+++ b/src/bernstein/core/observability/metric_collector.py
@@ -20,8 +20,12 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-from bernstein.core.persistence.anchored_write import AnchoredDir, anchored_append, mkdir_anchored
-from bernstein.core.persistence.runtime_state import rotate_log_file
+from bernstein.core.persistence.anchored_write import (
+    AnchoredDir,
+    anchored_append,
+    mkdir_anchored,
+    rotate_anchored,
+)
 from bernstein.core.tenanting import normalize_tenant_id, tenant_metrics_target
 
 logger = logging.getLogger(__name__)
@@ -37,7 +41,7 @@ def iter_metric_files(metrics_dir: Path, prefix: str) -> list[Path]:
     """Return live and rotated metric JSONL files matching *prefix*.
 
     The on-disk layout is ``{prefix}_YYYYMMDD.jsonl`` plus rotation suffixes
-    ``.1``, ``.2`` … applied by :func:`rotate_log_file`. Callers that
+    ``.1``, ``.2`` … applied by :func:`rotate_anchored`. Callers that
     aggregate across days must include rotated backups, otherwise any
     rollover silently truncates their view.
 
@@ -961,11 +965,15 @@ class MetricsCollector:
                 # Bound per-file growth: rotate *before* appending so the new
                 # write starts a fresh file once the threshold is crossed.
                 # See - previously these JSONL files grew unbounded.
-                # Rotation renames a file that is already written; it is the
-                # append below that decides where new content lands, so that
-                # is the one anchored.
-                rotate_log_file(
-                    directory.path / filename,
+                #
+                # Anchored for the same reason the append is, and it is the
+                # more pressing of the two: rotation stats, unlinks and renames.
+                # On a derived path a symlink at a managed parent redirects all
+                # three before the append can refuse anything, so the operation
+                # that destroys files was the one running unprotected.
+                rotate_anchored(
+                    directory,
+                    filename,
                     max_bytes=_METRIC_FILE_ROTATE_BYTES,
                     max_backups=_METRIC_FILE_MAX_BACKUPS,
                 )

--- a/src/bernstein/core/persistence/anchored_write.py
+++ b/src/bernstein/core/persistence/anchored_write.py
@@ -1,0 +1,309 @@
+"""Create directories and open files below a trusted root without following a link.
+
+This is the write-side counterpart to :mod:`anchored_read`, and it exists for
+the same reason.  A caller that validates a directory and then writes to it by
+re-deriving the path from a string has two different things: the directory it
+checked, and the directory the string names when the write happens.  Those are
+the same object only while nothing replaces a component in between, which is
+not something the caller can arrange.  Anchoring removes the second derivation
+-- there is one walk, each component opened relative to a descriptor for its
+parent with ``O_NOFOLLOW``, so refusing a link is a property of the open rather
+than of a check that preceded it.
+
+Creating a directory needs one step reading does not.  ``os.mkdir`` with the
+name already taken raises ``EEXIST`` and says nothing about *what* took it, so
+``exist_ok`` semantics built on that alone accept a symlink pointing anywhere.
+:func:`mkdir_anchored` therefore always re-opens the component it just created
+or found, with ``O_NOFOLLOW | O_DIRECTORY``, whatever ``mkdir`` did.  A link at
+the name fails that open; which errno says so is the platform's call, since
+``O_NOFOLLOW`` and ``O_DIRECTORY`` disagree about what is wrong first -- Linux
+reports ``ELOOP`` and macOS ``ENOTDIR``.  Callers should treat the refusal, not
+the errno, as the contract.
+
+The **root is opened normally**, deliberately, matching :mod:`anchored_read`.
+Pointing a store's root somewhere else -- ``.sdd`` symlinked onto a larger
+volume -- is ordinary operator configuration, and refusing it would break
+working installations.  Everything below the root is store-managed layout,
+where a link is never something the store itself wrote.
+
+The walk needs ``os.open`` and ``os.mkdir`` to accept ``dir_fd`` **and** the
+platform to define ``O_NOFOLLOW``.  Windows has none of them, so there it
+degrades to plain ``Path.mkdir`` and a single open of the joined path.  Be
+precise about what that fallback is: it refuses **nothing**, at the final
+component or above it.  It is not a weaker guard; it is the absence of one, and
+a Windows junction is followed there exactly as it was before this module
+existed.  Saying otherwise in a docstring would be the only thing worse than
+the gap itself.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from dataclasses import dataclass
+from typing import IO, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+__all__ = [
+    "ANCHORED_WRITE_SUPPORTED",
+    "AnchoredDir",
+    "anchored_append",
+    "anchored_write_text",
+    "mkdir_anchored",
+    "open_anchored_write",
+]
+
+
+# Every capability is required, not just ``dir_fd``.  The walk refuses a link
+# only because ``O_NOFOLLOW`` is among its flags, and it creates directories
+# only because ``os.mkdir`` accepts ``dir_fd``; selecting on a subset would, on
+# a platform offering one without the others, take the branch that cannot
+# refuse anything.  Mirrors ``ANCHORED_OPEN_SUPPORTED`` in ``anchored_read``.
+ANCHORED_WRITE_SUPPORTED: bool = (
+    os.open in os.supports_dir_fd and os.mkdir in os.supports_dir_fd and hasattr(os, "O_NOFOLLOW")
+)
+
+
+def _validate_components(components: tuple[str, ...]) -> None:
+    """Refuse anything that is not a single path component name.
+
+    A separator, ``.`` or ``..`` here is a programming error rather than
+    something to resolve: the whole point of the walk is that each step is one
+    name, so a caller that packs a path into one component has silently opted
+    back into the derivation this module removes.
+    """
+    separators = tuple(sep for sep in (os.sep, os.altsep) if sep)
+    for component in components:
+        if component in {"", ".", ".."} or any(sep in component for sep in separators):
+            msg = f"anchored components must be single names, got {component!r}"
+            raise ValueError(msg)
+
+
+@dataclass(frozen=True)
+class AnchoredDir:
+    """A directory named as a trusted root plus the components below it.
+
+    Carrying the parts rather than a joined path is the point: a consumer can
+    hold this across a buffer or a queue and the walk still happens at the
+    moment of the write, not at the moment the value was built.
+
+    Attributes:
+        root: Trusted anchor.  Opened without ``O_NOFOLLOW`` -- a symlinked
+            root is operator configuration, not something to refuse.
+        parts: Component names below *root*, outermost first.  Each is refused
+            if it turns out to be a link.
+    """
+
+    root: Path
+    parts: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        """Refuse non-component parts at construction rather than at the write."""
+        _validate_components(self.parts)
+
+    @property
+    def path(self) -> Path:
+        """Return the joined path.
+
+        For logging, size checks and rotation only.  Writing through this
+        re-introduces exactly the derivation the type exists to avoid, so
+        callers that write must go through :func:`open_anchored_write` or
+        :func:`anchored_append`.
+        """
+        return self.root.joinpath(*self.parts)
+
+    def child(self, *names: str) -> AnchoredDir:
+        """Return a descendant anchored at the same root."""
+        return AnchoredDir(root=self.root, parts=(*self.parts, *names))
+
+
+def mkdir_anchored(directory: AnchoredDir, *, exist_ok: bool = True) -> None:
+    """Create *directory* and every missing component above it.
+
+    Each component is created relative to a descriptor for its parent and then
+    re-opened with ``O_NOFOLLOW | O_DIRECTORY``.  The re-open is what carries
+    the guarantee: ``mkdir`` reports ``EEXIST`` for a symlink and a directory
+    alike, so accepting its verdict would accept a link planted at the name.
+
+    Args:
+        directory: Anchored directory to create.  The root must already exist
+            and is never created here -- creating an anchor would mean
+            trusting a location nothing has vouched for.
+        exist_ok: Whether an existing directory is acceptable.  A component
+            that already exists as a *directory* is always traversed; this
+            governs only whether the final component may already be present.
+
+    Raises:
+        OSError: As the underlying calls do.  ``ELOOP`` or ``ENOTDIR`` -- see
+            the module docstring on why either can mean the same thing -- means
+            a component was refused as a symlink or a non-directory.
+            ``EEXIST`` means the final component existed with *exist_ok* false.
+    """
+    if not ANCHORED_WRITE_SUPPORTED:
+        # No capability to anchor with; this is the behaviour that predates the
+        # module, kept deliberately rather than dressed up as a check.
+        directory.path.mkdir(parents=True, exist_ok=exist_ok)
+        return
+
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    directory_flag = getattr(os, "O_DIRECTORY", 0)
+    parent_fd = os.open(directory.root, os.O_RDONLY | directory_flag)
+    try:
+        last_index = len(directory.parts) - 1
+        for index, component in enumerate(directory.parts):
+            try:
+                os.mkdir(component, dir_fd=parent_fd)
+            except FileExistsError:
+                # Intermediate components are allowed to exist unconditionally
+                # -- they are layout, not the thing being created.  Whether the
+                # final one may is the caller's call, but the re-open below
+                # still runs either way, so an existing *link* is refused here
+                # even when an existing directory would have been fine.
+                if index == last_index and not exist_ok:
+                    raise
+            child_fd = os.open(
+                component,
+                os.O_RDONLY | nofollow | directory_flag,
+                dir_fd=parent_fd,
+            )
+            # Take ownership before closing the old descriptor: closing first
+            # would, if that close raised, leak the descriptor just opened.
+            # Close errors on a read-only directory descriptor carry nothing a
+            # caller could act on, so they are dropped.
+            stale_fd, parent_fd = parent_fd, child_fd
+            with contextlib.suppress(OSError):
+                os.close(stale_fd)
+    finally:
+        with contextlib.suppress(OSError):
+            os.close(parent_fd)
+
+
+def open_anchored_write(directory: AnchoredDir, name: str, *, flags: int) -> int:
+    """Open *name* inside *directory* for writing, refusing linked components.
+
+    Args:
+        directory: Anchored parent directory.  It is walked, not created; call
+            :func:`mkdir_anchored` first when it may be missing.
+        name: Final component.  A single name, never a path.
+        flags: Open flags, typically ``os.O_WRONLY | os.O_CREAT | os.O_APPEND``.
+            ``O_NOFOLLOW`` is added where the platform defines it.
+
+    Returns:
+        An open file descriptor.  The caller owns it and must close it.
+
+    Raises:
+        ValueError: If *name* is not a single component name.
+        OSError: As :func:`os.open` does.  ``ELOOP`` (or ``ENOTDIR`` for an
+            intermediate component on some platforms) means one was a symlink
+            and the open refused to follow it.
+    """
+    _validate_components((name,))
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+
+    if not ANCHORED_WRITE_SUPPORTED:
+        return os.open(directory.path / name, flags | nofollow, 0o644)
+
+    directory_flag = getattr(os, "O_DIRECTORY", 0)
+    parent_fd = os.open(directory.root, os.O_RDONLY | directory_flag)
+    try:
+        for component in directory.parts:
+            child_fd = os.open(
+                component,
+                os.O_RDONLY | nofollow | directory_flag,
+                dir_fd=parent_fd,
+            )
+            stale_fd, parent_fd = parent_fd, child_fd
+            with contextlib.suppress(OSError):
+                os.close(stale_fd)
+        return os.open(name, flags | nofollow, 0o644, dir_fd=parent_fd)
+    finally:
+        with contextlib.suppress(OSError):
+            os.close(parent_fd)
+
+
+def anchored_write_text(
+    directory: AnchoredDir,
+    name: str,
+    text: str,
+    *,
+    encoding: str = "utf-8",
+) -> Path:
+    """Write *text* to *name* inside *directory*, replacing any current content.
+
+    The anchored counterpart to ``Path.write_text``.  Truncation happens on the
+    descriptor the walk produced, so a link planted at *name* is refused rather
+    than followed and overwritten.
+
+    Args:
+        directory: Anchored parent directory, already created.
+        name: File to write.  Created if absent, truncated if present.
+        text: Content to write.
+        encoding: Text encoding.  Defaults to UTF-8.
+
+    Returns:
+        The joined path that was written, for logging and for callers that
+        report where a file landed.
+
+    Raises:
+        OSError: As :func:`open_anchored_write` does.
+    """
+    fd = open_anchored_write(directory, name, flags=os.O_WRONLY | os.O_CREAT | os.O_TRUNC)
+    try:
+        handle: IO[str] = os.fdopen(fd, "w", encoding=encoding)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.close(fd)
+        raise
+    with handle:
+        handle.write(text)
+    return directory.path / name
+
+
+@contextlib.contextmanager
+def anchored_append(
+    directory: AnchoredDir,
+    name: str,
+    *,
+    encoding: str = "utf-8",
+    fsync: bool = False,
+) -> Iterator[IO[str]]:
+    """Yield a text handle appending to *name* inside *directory*.
+
+    Mirrors the shape of :func:`~bernstein.core.persistence.durable_write.fsynced_write`
+    so an appender switching to an anchored write keeps its structure, and adds
+    the walk that helper cannot do from a path alone.
+
+    Args:
+        directory: Anchored parent directory, already created.
+        name: File to append to.  Created if absent.
+        encoding: Text encoding.  Defaults to UTF-8, as every JSONL appender
+            in the tree uses.
+        fsync: Whether to fsync on clean exit.  On an exception the fsync is
+            skipped -- a partial write cannot be promised durable -- but the
+            handle is closed regardless.
+
+    Yields:
+        The open text-mode handle.  This helper owns flush, fsync and close.
+
+    Raises:
+        OSError: As :func:`open_anchored_write` does.
+    """
+    fd = open_anchored_write(directory, name, flags=os.O_WRONLY | os.O_CREAT | os.O_APPEND)
+    try:
+        handle: IO[str] = os.fdopen(fd, "a", encoding=encoding)
+    except BaseException:
+        # ``fdopen`` takes ownership only on success; without this the
+        # descriptor leaks on the failure path.
+        with contextlib.suppress(OSError):
+            os.close(fd)
+        raise
+    try:
+        yield handle
+        handle.flush()
+        if fsync:
+            os.fsync(handle.fileno())
+    finally:
+        handle.close()

--- a/src/bernstein/core/persistence/anchored_write.py
+++ b/src/bernstein/core/persistence/anchored_write.py
@@ -52,6 +52,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 __all__ = [
+    "ANCHORED_ROTATE_SUPPORTED",
     "ANCHORED_WRITE_SUPPORTED",
     "AnchoredDir",
     "anchored_append",
@@ -69,6 +70,20 @@ __all__ = [
 # refuse anything.  Mirrors ``ANCHORED_OPEN_SUPPORTED`` in ``anchored_read``.
 ANCHORED_WRITE_SUPPORTED: bool = (
     os.open in os.supports_dir_fd and os.mkdir in os.supports_dir_fd and hasattr(os, "O_NOFOLLOW")
+)
+
+# Rotation needs three more calls to accept a descriptor, and its own predicate
+# for the same reason the one above takes every capability rather than a
+# subset: a platform offering ``os.open`` but not ``os.rename`` would enter the
+# anchored branch and raise ``NotImplementedError`` mid-rotation instead of
+# taking the path-based fallback.  ``os.rename`` is spelled through
+# ``supports_dir_fd`` even though it takes ``src_dir_fd``/``dst_dir_fd``; that
+# is the set CPython records it in.
+ANCHORED_ROTATE_SUPPORTED: bool = (
+    ANCHORED_WRITE_SUPPORTED
+    and os.stat in os.supports_dir_fd
+    and os.unlink in os.supports_dir_fd
+    and os.rename in os.supports_dir_fd
 )
 
 
@@ -294,7 +309,7 @@ def rotate_anchored(
     _validate_components((name,))
     max_backups = max(max_backups, 1)
 
-    if not ANCHORED_WRITE_SUPPORTED:
+    if not ANCHORED_ROTATE_SUPPORTED:
         from bernstein.core.persistence.runtime_state import rotate_log_file
 
         return rotate_log_file(directory.path / name, max_bytes=max_bytes, max_backups=max_backups)

--- a/src/bernstein/core/persistence/anchored_write.py
+++ b/src/bernstein/core/persistence/anchored_write.py
@@ -39,13 +39,17 @@ the gap itself.
 from __future__ import annotations
 
 import contextlib
+import logging
 import os
+import stat
 from dataclasses import dataclass
 from typing import IO, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
     from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "ANCHORED_WRITE_SUPPORTED",
@@ -54,6 +58,7 @@ __all__ = [
     "anchored_write_text",
     "mkdir_anchored",
     "open_anchored_write",
+    "rotate_anchored",
 ]
 
 
@@ -222,6 +227,108 @@ def open_anchored_write(directory: AnchoredDir, name: str, *, flags: int) -> int
     finally:
         with contextlib.suppress(OSError):
             os.close(parent_fd)
+
+
+def _walk_to_dir_fd(directory: AnchoredDir) -> int:
+    """Return an open descriptor for *directory*, refusing a linked component.
+
+    The walk every anchored operation starts from. The caller owns the
+    descriptor and must close it.
+
+    Raises:
+        OSError: As :func:`os.open` does. ``ELOOP`` or ``ENOTDIR`` means a
+            component was a symlink and the walk refused to follow it.
+    """
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    directory_flag = getattr(os, "O_DIRECTORY", 0)
+    parent_fd = os.open(directory.root, os.O_RDONLY | directory_flag)
+    try:
+        for component in directory.parts:
+            child_fd = os.open(component, os.O_RDONLY | nofollow | directory_flag, dir_fd=parent_fd)
+            stale_fd, parent_fd = parent_fd, child_fd
+            with contextlib.suppress(OSError):
+                os.close(stale_fd)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.close(parent_fd)
+        raise
+    return parent_fd
+
+
+def rotate_anchored(
+    directory: AnchoredDir,
+    name: str,
+    *,
+    max_bytes: int,
+    max_backups: int = 1,
+) -> bool:
+    """Rotate *name* inside *directory*, doing every step through the anchor.
+
+    The anchored counterpart to
+    ``persistence.runtime_state.rotate_log_file``. Rotation is not a read: it
+    stats, unlinks, and renames. Doing that on a derived path and only anchoring
+    the append that follows protects the wrong operation -- a symlink planted at
+    a managed parent redirects the renames and deletions before the append gets
+    a chance to refuse anything. Here the walk happens first, so a linked
+    component fails the rotation instead of relocating it.
+
+    Backup shifting matches ``rotate_log_file``: ``.1 -> .2``, ``.2 -> .3``, and
+    anything at or beyond *max_backups* is removed.
+
+    Args:
+        directory: Anchored parent directory.
+        name: File to rotate. A single name, never a path.
+        max_bytes: Rotation threshold. A file at or below this size is left
+            alone.
+        max_backups: Number of historical rollovers to retain (minimum 1).
+
+    Returns:
+        True when the file was rotated.
+
+    Raises:
+        ValueError: If *name* is not a single component name.
+        OSError: If the walk refuses a component. Failures of the individual
+            unlink/rename steps are swallowed, as in ``rotate_log_file``: a
+            rollover that cannot be shifted must not lose the row being written.
+    """
+    _validate_components((name,))
+    max_backups = max(max_backups, 1)
+
+    if not ANCHORED_WRITE_SUPPORTED:
+        from bernstein.core.persistence.runtime_state import rotate_log_file
+
+        return rotate_log_file(directory.path / name, max_bytes=max_bytes, max_backups=max_backups)
+
+    dir_fd = _walk_to_dir_fd(directory)
+    try:
+        try:
+            # `follow_symlinks=False`: a link at the name itself has no size
+            # worth rotating, and stat'ing through it would measure a file
+            # outside the layout.
+            info = os.stat(name, dir_fd=dir_fd, follow_symlinks=False)
+        except OSError:
+            return False
+        if not stat.S_ISREG(info.st_mode) or info.st_size <= max_bytes:
+            return False
+
+        for index in range(max_backups, 0, -1):
+            src = f"{name}.{index}"
+            if index >= max_backups:
+                with contextlib.suppress(OSError):
+                    os.unlink(src, dir_fd=dir_fd)
+                continue
+            with contextlib.suppress(OSError):
+                os.rename(src, f"{name}.{index + 1}", src_dir_fd=dir_fd, dst_dir_fd=dir_fd)
+
+        try:
+            os.rename(name, f"{name}.1", src_dir_fd=dir_fd, dst_dir_fd=dir_fd)
+        except OSError as exc:
+            logger.debug("Cannot rotate %s: %s", directory.path / name, exc)
+            return False
+        return True
+    finally:
+        with contextlib.suppress(OSError):
+            os.close(dir_fd)
 
 
 def anchored_write_text(

--- a/src/bernstein/core/persistence/anchored_write.py
+++ b/src/bernstein/core/persistence/anchored_write.py
@@ -219,6 +219,15 @@ def open_anchored_write(directory: AnchoredDir, name: str, *, flags: int) -> int
         OSError: As :func:`os.open` does.  ``ELOOP`` (or ``ENOTDIR`` for an
             intermediate component on some platforms) means one was a symlink
             and the open refused to follow it.
+
+    Note:
+        Without ``ANCHORED_WRITE_SUPPORTED`` the walk is gone but the flag on
+        the final open is not, so a linked *name* is still refused while a
+        linked parent is followed.  Keeping ``O_NOFOLLOW`` there is deliberate:
+        dropping it to make the degraded path uniformly permissive would trade
+        a real refusal for a tidier description of one.  What the caller loses
+        is the parent, not the file -- unlike :func:`mkdir_anchored`, whose
+        fallback refuses nothing at all.
     """
     _validate_components((name,))
     nofollow = getattr(os, "O_NOFOLLOW", 0)
@@ -226,18 +235,8 @@ def open_anchored_write(directory: AnchoredDir, name: str, *, flags: int) -> int
     if not ANCHORED_WRITE_SUPPORTED:
         return os.open(directory.path / name, flags | nofollow, 0o644)
 
-    directory_flag = getattr(os, "O_DIRECTORY", 0)
-    parent_fd = os.open(directory.root, os.O_RDONLY | directory_flag)
+    parent_fd = _walk_to_dir_fd(directory)
     try:
-        for component in directory.parts:
-            child_fd = os.open(
-                component,
-                os.O_RDONLY | nofollow | directory_flag,
-                dir_fd=parent_fd,
-            )
-            stale_fd, parent_fd = parent_fd, child_fd
-            with contextlib.suppress(OSError):
-                os.close(stale_fd)
         return os.open(name, flags | nofollow, 0o644, dir_fd=parent_fd)
     finally:
         with contextlib.suppress(OSError):

--- a/src/bernstein/core/persistence/anchored_write.py
+++ b/src/bernstein/core/persistence/anchored_write.py
@@ -39,6 +39,7 @@ the gap itself.
 from __future__ import annotations
 
 import contextlib
+import errno
 import logging
 import os
 import stat
@@ -64,12 +65,18 @@ __all__ = [
 
 
 # Every capability is required, not just ``dir_fd``.  The walk refuses a link
-# only because ``O_NOFOLLOW`` is among its flags, and it creates directories
-# only because ``os.mkdir`` accepts ``dir_fd``; selecting on a subset would, on
-# a platform offering one without the others, take the branch that cannot
-# refuse anything.  Mirrors ``ANCHORED_OPEN_SUPPORTED`` in ``anchored_read``.
+# only because ``O_NOFOLLOW`` is among its flags, it creates directories only
+# because ``os.mkdir`` accepts ``dir_fd``, and it stays a walk over directories
+# only because ``O_DIRECTORY`` is there to say so -- without it a component that
+# turned out to be a regular file would be opened as the next parent.  Selecting
+# on a subset would, on a platform offering one without the others, take the
+# branch that cannot refuse anything.  Mirrors ``ANCHORED_OPEN_SUPPORTED`` in
+# ``anchored_read``.
 ANCHORED_WRITE_SUPPORTED: bool = (
-    os.open in os.supports_dir_fd and os.mkdir in os.supports_dir_fd and hasattr(os, "O_NOFOLLOW")
+    os.open in os.supports_dir_fd
+    and os.mkdir in os.supports_dir_fd
+    and hasattr(os, "O_NOFOLLOW")
+    and hasattr(os, "O_DIRECTORY")
 )
 
 # Rotation needs three more calls to accept a descriptor, and its own predicate
@@ -112,7 +119,13 @@ class AnchoredDir:
 
     Attributes:
         root: Trusted anchor.  Opened without ``O_NOFOLLOW`` -- a symlinked
-            root is operator configuration, not something to refuse.
+            root is operator configuration, not something to refuse.  Made
+            absolute at construction: deferring the walk is the whole design,
+            and a relative root would defer resolution of the anchor too, so a
+            value built under one working directory and flushed under another
+            would walk a different tree than the caller named.  ``absolute()``
+            rather than ``resolve()`` -- the former fixes the anchor, the
+            latter would also follow the link the docstring above allows.
         parts: Component names below *root*, outermost first.  Each is refused
             if it turns out to be a link.
     """
@@ -121,8 +134,10 @@ class AnchoredDir:
     parts: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
-        """Refuse non-component parts at construction rather than at the write."""
+        """Refuse non-component parts, and pin the anchor to one directory."""
         _validate_components(self.parts)
+        if not self.root.is_absolute():
+            object.__setattr__(self, "root", self.root.absolute())
 
     @property
     def path(self) -> Path:
@@ -218,7 +233,8 @@ def open_anchored_write(directory: AnchoredDir, name: str, *, flags: int) -> int
         ValueError: If *name* is not a single component name.
         OSError: As :func:`os.open` does.  ``ELOOP`` (or ``ENOTDIR`` for an
             intermediate component on some platforms) means one was a symlink
-            and the open refused to follow it.
+            and the open refused to follow it.  ``EPERM`` means *name* existed
+            and was not a regular file.
 
     Note:
         Without ``ANCHORED_WRITE_SUPPORTED`` the walk is gone but the flag on
@@ -233,14 +249,39 @@ def open_anchored_write(directory: AnchoredDir, name: str, *, flags: int) -> int
     nofollow = getattr(os, "O_NOFOLLOW", 0)
 
     if not ANCHORED_WRITE_SUPPORTED:
-        return os.open(directory.path / name, flags | nofollow, 0o644)
+        return _open_regular(directory.path / name, flags | nofollow)
 
     parent_fd = _walk_to_dir_fd(directory)
     try:
-        return os.open(name, flags | nofollow, 0o644, dir_fd=parent_fd)
+        return _open_regular(name, flags | nofollow, dir_fd=parent_fd)
     finally:
         with contextlib.suppress(OSError):
             os.close(parent_fd)
+
+
+def _open_regular(target: str | Path, flags: int, *, dir_fd: int | None = None) -> int:
+    """Open *target* for writing, refusing anything that is not a regular file.
+
+    ``O_NOFOLLOW`` answers for symlinks and for nothing else.  A FIFO sitting
+    where a log belongs is not a link, and ``O_WRONLY`` on one blocks until
+    some reader turns up -- on a worker thread that is a hang rather than an
+    error, and nothing downstream gets the chance to reject it.  So the open is
+    non-blocking, the descriptor is stat'd through itself rather than by name
+    again, and the flag comes off once the file is known to be an ordinary one.
+    """
+    nonblock = getattr(os, "O_NONBLOCK", 0)
+    fd = os.open(target, flags | nonblock, 0o644, dir_fd=dir_fd)
+    try:
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            msg = f"refusing to write through a non-regular file: {target}"
+            raise OSError(errno.EPERM, msg)
+        if nonblock:
+            os.set_blocking(fd, True)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.close(fd)
+        raise
+    return fd
 
 
 def _walk_to_dir_fd(directory: AnchoredDir) -> int:

--- a/src/bernstein/core/security/AGENTS.md
+++ b/src/bernstein/core/security/AGENTS.md
@@ -31,8 +31,9 @@ The HMAC-chained audit log, Ed25519 install identity, and approval / policy enfo
   `runtime`, `runtime/wal`, `audit`) is created and opened through
   `TenantPaths.anchor` / `tenant_metrics_target` via
   `../persistence/anchored_write.py`, rotation included (`rotate_anchored` -
-  it renames and unlinks). Needs `dir_fd` + `O_NOFOLLOW`; without them the
-  refusal is absent, not weaker (`ANCHORED_{WRITE,ROTATE}_SUPPORTED`).
+  it renames and unlinks). Needs `dir_fd` + `O_NOFOLLOW`; lacking either, the
+  refusal narrows to the final component or vanishes, never weakens
+  (`ANCHORED_{WRITE,ROTATE}_SUPPORTED`).
 
 ## Testing
 

--- a/src/bernstein/core/security/AGENTS.md
+++ b/src/bernstein/core/security/AGENTS.md
@@ -19,21 +19,20 @@ The HMAC-chained audit log, Ed25519 install identity, and approval / policy enfo
   group- or world-readable key is a hard error at load time (`audit.py`).
 - Event-type constants are append-only: add `EVENT_*` names, never edit or reuse
   existing ones (`audit_chain.py` module docstring).
-- Chain helpers take the chain instance as a parameter (no singleton imports)
-  and log through `log_with_prev_digest`, so `prev_chain_digest` lands in the
-  payload before the HMAC (`audit_chain.py`).
+- Chain helpers take the chain as a parameter (no singleton imports) and log
+  through `log_with_prev_digest`, so `prev_chain_digest` lands in the payload
+  before the HMAC (`audit_chain.py`).
 - The audit chain is opt-in at runtime (`BERNSTEIN_AUDIT=1`, read in
   `../orchestration/orchestrator.py`); features degrade without it.
 - Untrusted paths are opened, never compared: a path-comparison check validates
-  one lookup while the open performs another. `public_key_file` stays a plain
-  filename inside `attestation_dir` (`sigstore_attestation.py`).
+  one lookup while the open performs another (`sigstore_attestation.py`).
 - Same rule on the tenant write side: a derived path says where the layout
   points, not where a write lands. The whole subtree (`backlog`, `metrics`,
   `runtime`, `runtime/wal`, `audit`) is created and opened through
   `TenantPaths.anchor` / `tenant_metrics_target` via
-  `../persistence/anchored_write.py`: each component opens relative to its
-  parent, and a symlink below `.sdd` is refused. Rotation uses
-  `rotate_anchored` - it renames and unlinks, so it needs the anchor most.
+  `../persistence/anchored_write.py`, rotation included (`rotate_anchored` -
+  it renames and unlinks). Needs `dir_fd` + `O_NOFOLLOW`; without them the
+  refusal is absent, not weaker (`ANCHORED_{WRITE,ROTATE}_SUPPORTED`).
 
 ## Testing
 

--- a/src/bernstein/core/security/AGENTS.md
+++ b/src/bernstein/core/security/AGENTS.md
@@ -33,6 +33,16 @@ subsystems anchor receipts to; treat its write path as load-bearing.
   directory. A path-comparison containment check validates one lookup while
   the open performs another (`sigstore_attestation.py`, "Local bundle
   contract").
+- The tenant `.sdd` layout follows the same rule on the write side.
+  `tenant_paths` and `tenant_metrics_dir` derive a path and assert it stays
+  under its base, but that answers where the layout points when it is
+  derived, not where a later write lands. Writers take `TenantPaths.anchor`
+  (or `tenant_metrics_target`) and go through
+  `../persistence/anchored_write.py`, so each component is opened relative to
+  its parent and a symlink is refused rather than followed. `.sdd` itself may
+  be a symlink -- that is operator configuration; everything below it is
+  store-managed layout. Deriving a tenant path a second time at the moment of
+  a write puts the gap back (`tenanting.py`).
 
 ## Testing
 

--- a/src/bernstein/core/security/AGENTS.md
+++ b/src/bernstein/core/security/AGENTS.md
@@ -1,8 +1,7 @@
 # Security: audit chain, identity, policy
 
-The HMAC-chained audit log, Ed25519 install identity, and approval /
-policy enforcement. The audit chain is the tamper-evident record other
-subsystems anchor receipts to; treat its write path as load-bearing.
+The HMAC-chained audit log, Ed25519 install identity, and approval / policy
+enforcement. Other subsystems anchor receipts to the chain, so its write path is load-bearing.
 
 ## Key files
 
@@ -17,34 +16,25 @@ subsystems anchor receipts to; treat its write path as load-bearing.
 
 ## Invariants
 
-- The HMAC key lives OUTSIDE the audit log directory and must be mode
-  `0600`; a group- or world-readable key is a hard error at load time
-  (`audit.py` module docstring).
-- Event-type constants are append-only: add new `EVENT_*` names, never
-  edit or reuse existing ones (`audit_chain.py` module docstring).
-- Chain helpers take the chain instance as a parameter (no singleton
-  imports) and log through `log_with_prev_digest`, so `prev_chain_digest`
-  lands in the payload before the HMAC is computed (`audit_chain.py`).
+- The HMAC key lives OUTSIDE the audit log directory and must be mode `0600`;
+  a group- or world-readable key is a hard error at load time (`audit.py`).
+- Event-type constants are append-only: add new `EVENT_*` names, never edit or
+  reuse existing ones (`audit_chain.py` module docstring).
+- Chain helpers take the chain instance as a parameter (no singleton imports)
+  and log through `log_with_prev_digest`, so `prev_chain_digest` lands in the
+  payload before the HMAC is computed (`audit_chain.py`).
 - The audit chain is opt-in at runtime (`BERNSTEIN_AUDIT=1`, read in
   `../orchestration/orchestrator.py`); features must degrade without it.
-- An attestation bundle is untrusted input: `public_key_file` must stay a
-  plain filename inside `attestation_dir`, decided from the string with no
-  `resolve` or `stat`, and read through a descriptor anchored to that
-  directory. A path-comparison containment check validates one lookup while
-  the open performs another (`sigstore_attestation.py`, "Local bundle
-  contract").
-- The tenant `.sdd` layout follows the same rule on the write side.
-  `tenant_paths` and `tenant_metrics_dir` derive a path and assert it stays
-  under its base, but that answers where the layout points when it is
-  derived, not where a later write lands. Writers take `TenantPaths.anchor`
-  (or `tenant_metrics_target`) and go through
-  `../persistence/anchored_write.py`, so each component is opened relative to
-  its parent and a symlink is refused rather than followed. `.sdd` itself may
-  be a symlink -- that is operator configuration; everything below it is
-  store-managed layout. Deriving a tenant path a second time at the moment of
-  a write puts the gap back (`tenanting.py`).
+- Untrusted paths are opened, never compared. `public_key_file` stays a plain
+  filename inside `attestation_dir`, decided from the string with no `resolve`
+  or `stat`; a path-comparison check validates one lookup while the open
+  performs another (`sigstore_attestation.py`).
+- Same rule on the tenant write side: deriving a path says where the layout
+  points, not where a write lands. Writers take `TenantPaths.anchor` (or
+  `tenant_metrics_target`) through `../persistence/anchored_write.py`, which
+  opens each component relative to its parent and refuses a symlink below `.sdd`
+  (`tenanting.py`).
 
 ## Testing
 
-Single files only, e.g. `uv run pytest tests/unit/test_audit.py -x -q`;
-most surfaces here have a dedicated `test_audit_*.py` file.
+Single files only: `uv run pytest tests/unit/test_audit.py -x -q`.

--- a/src/bernstein/core/security/AGENTS.md
+++ b/src/bernstein/core/security/AGENTS.md
@@ -1,7 +1,6 @@
 # Security: audit chain, identity, policy
 
-The HMAC-chained audit log, Ed25519 install identity, and approval / policy
-enforcement. Other subsystems anchor receipts to the chain, so its write path is load-bearing.
+The HMAC-chained audit log, Ed25519 install identity, and approval / policy enforcement. Other subsystems anchor receipts to the chain, so its write path is load-bearing.
 
 ## Key files
 
@@ -16,24 +15,25 @@ enforcement. Other subsystems anchor receipts to the chain, so its write path is
 
 ## Invariants
 
-- The HMAC key lives OUTSIDE the audit log directory and must be mode `0600`;
-  a group- or world-readable key is a hard error at load time (`audit.py`).
-- Event-type constants are append-only: add new `EVENT_*` names, never edit or
-  reuse existing ones (`audit_chain.py` module docstring).
+- The HMAC key lives OUTSIDE the audit log directory and must be mode `0600`; a
+  group- or world-readable key is a hard error at load time (`audit.py`).
+- Event-type constants are append-only: add `EVENT_*` names, never edit or reuse
+  existing ones (`audit_chain.py` module docstring).
 - Chain helpers take the chain instance as a parameter (no singleton imports)
   and log through `log_with_prev_digest`, so `prev_chain_digest` lands in the
-  payload before the HMAC is computed (`audit_chain.py`).
+  payload before the HMAC (`audit_chain.py`).
 - The audit chain is opt-in at runtime (`BERNSTEIN_AUDIT=1`, read in
-  `../orchestration/orchestrator.py`); features must degrade without it.
-- Untrusted paths are opened, never compared. `public_key_file` stays a plain
-  filename inside `attestation_dir`, decided from the string with no `resolve`
-  or `stat`; a path-comparison check validates one lookup while the open
-  performs another (`sigstore_attestation.py`).
-- Same rule on the tenant write side: deriving a path says where the layout
-  points, not where a write lands. Writers take `TenantPaths.anchor` (or
-  `tenant_metrics_target`) through `../persistence/anchored_write.py`, which
-  opens each component relative to its parent and refuses a symlink below `.sdd`
-  (`tenanting.py`).
+  `../orchestration/orchestrator.py`); features degrade without it.
+- Untrusted paths are opened, never compared: a path-comparison check validates
+  one lookup while the open performs another. `public_key_file` stays a plain
+  filename inside `attestation_dir` (`sigstore_attestation.py`).
+- Same rule on the tenant write side: a derived path says where the layout
+  points, not where a write lands. The whole subtree (`backlog`, `metrics`,
+  `runtime`, `runtime/wal`, `audit`) is created and opened through
+  `TenantPaths.anchor` / `tenant_metrics_target` via
+  `../persistence/anchored_write.py`: each component opens relative to its
+  parent, and a symlink below `.sdd` is refused. Rotation uses
+  `rotate_anchored` - it renames and unlinks, so it needs the anchor most.
 
 ## Testing
 

--- a/src/bernstein/core/security/tenant_isolation.py
+++ b/src/bernstein/core/security/tenant_isolation.py
@@ -12,6 +12,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.persistence.anchored_write import mkdir_anchored
 from bernstein.core.security.tenanting import (
     DEFAULT_TENANT_ID,
     TenantRegistry,
@@ -23,6 +24,8 @@ from bernstein.core.security.tenanting import (
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from bernstein.core.persistence.anchored_write import AnchoredDir
+
 logger = logging.getLogger(__name__)
 
 
@@ -31,6 +34,12 @@ class TenantDataPaths:
     """Complete set of tenant-scoped data paths.
 
     Extends the basic TenantPaths with WAL and audit directories.
+
+    ``anchor`` is the tenant root in anchored form. Writers under this layout
+    take it rather than one of the plain paths above: a derived path says where
+    the layout points, not where a write lands, and the two differ the moment a
+    component is replaced with a symlink. Reach a subdirectory with
+    ``anchor.child("runtime", "wal")``.
     """
 
     root: Path
@@ -39,6 +48,7 @@ class TenantDataPaths:
     wal_dir: Path
     audit_dir: Path
     runtime_dir: Path
+    anchor: AnchoredDir
 
 
 def tenant_data_paths(sdd_dir: Path, tenant_id: str) -> TenantDataPaths:
@@ -59,6 +69,7 @@ def tenant_data_paths(sdd_dir: Path, tenant_id: str) -> TenantDataPaths:
         wal_dir=base.root / "runtime" / "wal",
         audit_dir=base.root / "audit",
         runtime_dir=base.root / "runtime",
+        anchor=base.anchor,
     )
 
 
@@ -69,14 +80,25 @@ def ensure_tenant_data_layout(sdd_dir: Path, tenant_id: str) -> TenantDataPaths:
         sdd_dir: Root ``.sdd`` directory.
         tenant_id: Tenant identifier.
 
+    Every directory is created through the anchored walk, for the same reason
+    ``backlog`` and ``metrics`` are: ordinary ``mkdir`` treats an existing
+    symlink as an existing directory, so ``.sdd/<tenant>/runtime`` linked at a
+    sibling tenant would silently redirect every WAL and audit write that
+    followed. The refusal has to happen where the directory is created, not
+    where the path was derived.
+
     Returns:
         TenantDataPaths with directories created.
+
+    Raises:
+        OSError: If a component of the layout is a symlink (``ELOOP``) or is
+            not a directory (``ENOTDIR``), or if creation fails.
     """
     ensure_tenant_layout(sdd_dir, tenant_id)
     paths = tenant_data_paths(sdd_dir, tenant_id)
-    paths.wal_dir.mkdir(parents=True, exist_ok=True)
-    paths.audit_dir.mkdir(parents=True, exist_ok=True)
-    paths.runtime_dir.mkdir(parents=True, exist_ok=True)
+    mkdir_anchored(paths.anchor.child("runtime"))
+    mkdir_anchored(paths.anchor.child("runtime", "wal"))
+    mkdir_anchored(paths.anchor.child("audit"))
     return paths
 
 

--- a/src/bernstein/core/security/tenanting.py
+++ b/src/bernstein/core/security/tenanting.py
@@ -329,6 +329,14 @@ def ensure_tenant_layout(sdd_dir: Path, tenant_id: str) -> TenantPaths:
     """
 
     paths = tenant_paths(sdd_dir, tenant_id)
+    # The anchored walk deliberately never creates its own root: an anchor is
+    # the location everything below it is trusted relative to, so creating one
+    # would vouch for a place nothing has vouched for. `.sdd` is that root here
+    # and it is the caller's own base -- operator configuration, allowed to be
+    # a symlink -- so it is created the ordinary way when absent. Leaving it to
+    # the walk turned a first run in an empty directory into `FileNotFoundError`
+    # on the anchor's `open`, which is not a containment refusal at all.
+    sdd_dir.mkdir(parents=True, exist_ok=True)
     mkdir_anchored(paths.anchor.child("backlog"))
     mkdir_anchored(paths.anchor.child("metrics"))
     return paths

--- a/src/bernstein/core/security/tenanting.py
+++ b/src/bernstein/core/security/tenanting.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
+from bernstein.core.persistence.anchored_write import AnchoredDir, mkdir_anchored
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from pathlib import Path
@@ -31,11 +33,26 @@ class TenantConfig:
 
 @dataclass(frozen=True)
 class TenantPaths:
-    """Filesystem layout for a tenant-scoped `.sdd` subtree."""
+    """Filesystem layout for a tenant-scoped `.sdd` subtree.
+
+    The `Path` fields name the layout for callers that read it. `anchor` names
+    the same layout as a root plus the components below it, which is what a
+    caller that *writes* needs: joining `backlog_dir` at the moment of a write
+    derives the directory a second time, and the result is the directory that
+    was validated only while nothing replaced a component in between.
+
+    Attributes:
+        root: The tenant subtree.
+        backlog_dir: Backlog files for this tenant.
+        metrics_dir: Metrics files for this tenant.
+        anchor: The same subtree, anchored on the `.sdd` directory it was
+            derived from. Writers go through this; readers can use either.
+    """
 
     root: Path
     backlog_dir: Path
     metrics_dir: Path
+    anchor: AnchoredDir
 
 
 @dataclass(frozen=True)
@@ -239,6 +256,22 @@ def resolve_tenant_scope(
     return target
 
 
+def _assert_contained(base: Path, derived: Path, tenant_id: str) -> None:
+    """Refuse a derived directory that does not sit strictly under *base*.
+
+    A cheap invariant check on the layout as it stands, run before anything is
+    created. It is not what makes a write safe -- resolving a path says where
+    it pointed when it was resolved, and the write happens later -- but it
+    keeps the derivation honest on its own terms, and it is what fails first if
+    the identifier rule is ever widened.
+    """
+
+    resolved_derived = derived.resolve()
+    resolved_base = base.resolve()
+    if resolved_derived == resolved_base or not resolved_derived.is_relative_to(resolved_base):
+        raise InvalidTenantIdError(f"tenant id {_describe_tenant_id(str(tenant_id))} resolves outside the tenant root")
+
+
 def tenant_paths(sdd_dir: Path, tenant_id: str) -> TenantPaths:
     """Return derived tenant paths inside `.sdd`.
 
@@ -247,6 +280,14 @@ def tenant_paths(sdd_dir: Path, tenant_id: str) -> TenantPaths:
     single path segment, so this check is redundant by design: it keeps the
     layout invariant true on its own terms rather than as a consequence of
     the identifier rule, and it is what fails if that rule is ever widened.
+
+    The check answers where the layout points now. It cannot answer where a
+    later write lands, because a caller that joins the returned paths derives
+    the directory a second time, and the two derivations agree only while
+    nothing replaces a component between them. `TenantPaths.anchor` carries
+    the layout in the form that removes the second derivation; writers use it,
+    and the containment of *their* directory is a property of the walk rather
+    than of this check.
 
     Args:
         sdd_dir: The `.sdd` directory the tenant subtree lives under.
@@ -262,33 +303,93 @@ def tenant_paths(sdd_dir: Path, tenant_id: str) -> TenantPaths:
 
     normalized = normalize_tenant_id(tenant_id)
     root = sdd_dir / normalized
-    resolved_root = root.resolve()
-    resolved_base = sdd_dir.resolve()
-    if resolved_root == resolved_base or not resolved_root.is_relative_to(resolved_base):
-        raise InvalidTenantIdError(f"tenant id {_describe_tenant_id(str(tenant_id))} resolves outside the tenant root")
+    _assert_contained(sdd_dir, root, tenant_id)
     return TenantPaths(
         root=root,
         backlog_dir=root / "backlog",
         metrics_dir=root / "metrics",
+        anchor=AnchoredDir(root=sdd_dir, parts=(normalized,)),
     )
 
 
 def ensure_tenant_layout(sdd_dir: Path, tenant_id: str) -> TenantPaths:
-    """Create and return the tenant-scoped `.sdd` layout."""
+    """Create and return the tenant-scoped `.sdd` layout.
+
+    Every directory is created through the anchored walk, so a component that
+    turns out to be a symlink is refused at the `mkdir` rather than followed.
+    That covers the tenant segment itself as well as the two below it: a
+    tenant directory linked to a *sibling* tenant passes the containment check
+    above -- it does resolve under `.sdd` -- and would otherwise alias one
+    tenant's writes onto another's subtree.
+
+    Raises:
+        InvalidTenantIdError: If *tenant_id* is not usable, per `tenant_paths`.
+        OSError: If a component of the layout is a symlink (`ELOOP`) or is not
+            a directory (`ENOTDIR`), or if creation fails.
+    """
 
     paths = tenant_paths(sdd_dir, tenant_id)
-    paths.backlog_dir.mkdir(parents=True, exist_ok=True)
-    paths.metrics_dir.mkdir(parents=True, exist_ok=True)
+    mkdir_anchored(paths.anchor.child("backlog"))
+    mkdir_anchored(paths.anchor.child("metrics"))
     return paths
 
 
-def tenant_metrics_dir(metrics_dir: Path, tenant_id: str) -> Path:
-    """Return the tenant metrics directory derived from a shared metrics dir."""
+def _tenant_metrics_anchor(metrics_dir: Path, tenant_id: str) -> AnchoredDir:
+    """Return the anchored form of the tenant metrics directory.
+
+    A shared `.sdd/metrics` directory names the tenant subtree as a sibling
+    (`.sdd/<tenant>/metrics`), so the anchor is its parent; anything else is
+    treated as a base the tenant segment hangs directly off.
+
+    The containment assert runs before the anchor is constructed, not after.
+    `AnchoredDir` refuses a part that is not a single name, and that refusal is
+    a plain `ValueError` about a programming error -- correct for its own
+    callers, wrong here, where a bad tenant segment has to keep arriving as
+    `InvalidTenantIdError` so the request surfaces still report it as a client
+    error rather than as a 500.
+    """
 
     normalized = normalize_tenant_id(tenant_id)
+    base: Path
+    parts: tuple[str, ...]
     if metrics_dir.name == "metrics":
-        return metrics_dir.parent / normalized / "metrics"
-    return metrics_dir / normalized
+        base, parts = metrics_dir.parent, (normalized, "metrics")
+    else:
+        base, parts = metrics_dir, (normalized,)
+    _assert_contained(base, base.joinpath(*parts), tenant_id)
+    return AnchoredDir(root=base, parts=parts)
+
+
+def tenant_metrics_dir(metrics_dir: Path, tenant_id: str) -> Path:
+    """Return the tenant metrics directory derived from a shared metrics dir.
+
+    Carries the same containment contract as `tenant_paths`: the derived
+    directory must sit strictly under the base it was derived from. Callers
+    that write to the result should use `tenant_metrics_target` instead, which
+    returns the anchored form and does not require re-deriving the path.
+
+    Raises:
+        InvalidTenantIdError: If *tenant_id* is not a valid identifier, or if
+            the derived directory does not resolve under its base.
+    """
+
+    return _tenant_metrics_anchor(metrics_dir, tenant_id).path
+
+
+def tenant_metrics_target(metrics_dir: Path, tenant_id: str) -> AnchoredDir:
+    """Return the tenant metrics directory as an anchored target.
+
+    The write-side counterpart to `tenant_metrics_dir`. Holding the anchor
+    rather than the joined path is what lets a caller defer the write -- a
+    buffered metric point, flushed later -- without the directory it writes to
+    being re-derived at flush time.
+
+    Raises:
+        InvalidTenantIdError: If *tenant_id* is not a valid identifier, or if
+            the derived directory does not resolve under its base.
+    """
+
+    return _tenant_metrics_anchor(metrics_dir, tenant_id)
 
 
 def request_tenant_id(request: Request) -> str:

--- a/src/bernstein/core/tasks/task_store_core.py
+++ b/src/bernstein/core/tasks/task_store_core.py
@@ -22,6 +22,7 @@ from typing_extensions import TypedDict
 
 from bernstein.core.defaults import TASK as _TASK_DEFAULTS
 from bernstein.core.hook_events import HookEvent
+from bernstein.core.persistence.anchored_write import anchored_append
 from bernstein.core.persistence.durable_write import fsynced_write
 from bernstein.core.persistence.runtime_state import rotate_log_file
 from bernstein.core.security.sanitize import sanitize_log
@@ -366,7 +367,11 @@ async def _retry_io(fn: Any, *args: Any) -> Any:
     import errno
 
     max_retries = _TASK_DEFAULTS.max_io_retries
-    non_transient = {errno.ENOSPC, errno.EROFS, errno.EACCES, errno.EPERM}
+    # ELOOP/ENOTDIR come from an anchored write refusing a component that is a
+    # symlink or not a directory. That is a statement about the layout, not a
+    # condition that clears on its own, so retrying only delays the same
+    # failure and reports it as a store outage rather than as what it is.
+    non_transient = {errno.ENOSPC, errno.EROFS, errno.EACCES, errno.EPERM, errno.ELOOP, errno.ENOTDIR}
     last_exc: OSError | None = None
     for attempt in range(max_retries):
         try:
@@ -823,8 +828,7 @@ class TaskStore:
 
         try:
             tenant_paths = ensure_tenant_layout(self._sdd_dir, str(record["tenant_id"]))
-            target_path = tenant_paths.backlog_dir / "tasks.jsonl"
-            with target_path.open("a", encoding="utf-8") as handle:
+            with anchored_append(tenant_paths.anchor.child("backlog"), "tasks.jsonl") as handle:
                 handle.write(line)
         except OSError as exc:
             # Tenant mirror is best-effort during recovery; the authoritative
@@ -945,10 +949,10 @@ class TaskStore:
         """Mirror task lifecycle records into a tenant-scoped backlog file."""
 
         tenant_paths = ensure_tenant_layout(self._sdd_dir, str(record["tenant_id"]))
-        target_path = tenant_paths.backlog_dir / "tasks.jsonl"
+        backlog = tenant_paths.anchor.child("backlog")
 
         def _write() -> None:
-            with target_path.open("a", encoding="utf-8") as handle:
+            with anchored_append(backlog, "tasks.jsonl") as handle:
                 handle.write(line)
 
         await _retry_io(_write)
@@ -957,10 +961,10 @@ class TaskStore:
         """Mirror archive records into a tenant-scoped backlog archive file."""
 
         tenant_paths = ensure_tenant_layout(self._sdd_dir, tenant_id)
-        target_path = tenant_paths.backlog_dir / "archive.jsonl"
+        backlog = tenant_paths.anchor.child("backlog")
 
         def _write() -> None:
-            with target_path.open("a", encoding="utf-8") as handle:
+            with anchored_append(backlog, "archive.jsonl") as handle:
                 handle.write(line)
 
         await _retry_io(_write)

--- a/tests/unit/cost/test_cost_tracker_paths.py
+++ b/tests/unit/cost/test_cost_tracker_paths.py
@@ -822,3 +822,18 @@ def test_load_still_finds_an_ordinary_run(tmp_path: Path) -> None:
 
     assert restored is not None
     assert restored.run_id == "20260812-120000"
+
+
+@pytest.mark.parametrize("payload", ['{"run_id": "other"}', '{"run_id": ""}', '{"run_id": 7}', "{}"])
+def test_load_refuses_a_file_that_names_a_different_run(tmp_path: Path, payload: str) -> None:
+    """The filename is validated; the identity inside the file has to agree.
+
+    `GET /costs/requested` reads `requested.json`. Were that file free to call
+    itself something else, the response would carry the other run's identity
+    and its spend under the id the caller asked about.
+    """
+    costs_dir = tmp_path / "runtime" / "costs"
+    costs_dir.mkdir(parents=True)
+    (costs_dir / "requested.json").write_text(payload, encoding="utf-8")
+
+    assert Tracker.load(tmp_path, "requested") is None

--- a/tests/unit/cost/test_cost_tracker_paths.py
+++ b/tests/unit/cost/test_cost_tracker_paths.py
@@ -788,3 +788,37 @@ class TestRetryBudgetAttachment:
         assert t.retry_budget is None
         t.attach_retry_budget(sentinel)
         assert t.retry_budget is sentinel
+
+
+# --- run_id as a filename component -----------------------------------------
+#
+# The run id names three files on disk and arrives from `BERNSTEIN_RUN_ID` or
+# from `GET /costs/{run_id}`. Both are input, so it is checked on the way in
+# and on the way out - `load` builds a path from it before any instance exists
+# for `__post_init__` to have validated.
+
+
+@pytest.mark.parametrize("bad", ["a/b", "a\\b", "..", ".", "", "x\x00y"])
+def test_construction_refuses_a_run_id_that_is_not_one_component(bad: str) -> None:
+    with pytest.raises(ValueError, match="single path component"):
+        Tracker(run_id=bad)
+
+
+@pytest.mark.parametrize("bad", ["../outside", "..\\outside", "sub/dir"])
+def test_load_refuses_a_traversing_run_id_before_it_builds_the_path(tmp_path: Path, bad: str) -> None:
+    """The file it would have reached exists, so a pass here would be a read."""
+    outside = tmp_path / "runtime" / "outside.json"
+    outside.parent.mkdir(parents=True)
+    outside.write_text('{"run_id": "outside", "budget_usd": 1.0}', encoding="utf-8")
+
+    assert Tracker.load(tmp_path, bad) is None
+
+
+def test_load_still_finds_an_ordinary_run(tmp_path: Path) -> None:
+    tracker = Tracker(run_id="20260812-120000", budget_usd=5.0)
+    tracker.save(tmp_path)
+
+    restored = Tracker.load(tmp_path, "20260812-120000")
+
+    assert restored is not None
+    assert restored.run_id == "20260812-120000"

--- a/tests/unit/security/test_tenanting_containment.py
+++ b/tests/unit/security/test_tenanting_containment.py
@@ -1,0 +1,190 @@
+"""Tenant layout writes land under the `.sdd` directory they were derived from.
+
+`test_tenanting_validation` covers the identifier rule and the containment
+assert on a derived path. Those answer where the layout points at the moment
+it is derived. This module covers the other half: where a *write* lands, which
+is a different question whenever the directory can change between the two.
+
+Three cases the derived-path check cannot decide on its own:
+
+* A tenant directory linked to a sibling tenant passes it -- the link does
+  resolve under `.sdd` -- and would alias one tenant's writes onto another's.
+* A directory *below* the tenant root was never checked at all.
+* A directory replaced after the check is a different directory by the time
+  the write happens.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bernstein.core.persistence.anchored_write import ANCHORED_WRITE_SUPPORTED, anchored_append
+from bernstein.core.security.tenanting import (
+    InvalidTenantIdError,
+    ensure_tenant_layout,
+    tenant_metrics_dir,
+    tenant_metrics_target,
+    tenant_paths,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = pytest.mark.ci
+
+needs_anchoring = pytest.mark.skipif(not ANCHORED_WRITE_SUPPORTED, reason="needs dir_fd and O_NOFOLLOW")
+
+
+@pytest.fixture
+def sdd_dir(tmp_path: Path) -> Path:
+    """Return a fresh `.sdd` directory."""
+    path = tmp_path / ".sdd"
+    path.mkdir()
+    return path
+
+
+class TestAnchorTracksTheLayout:
+    """The anchored form names the same directories as the path form."""
+
+    def test_anchor_matches_the_derived_paths(self, sdd_dir: Path) -> None:
+        paths = tenant_paths(sdd_dir, "acme")
+        assert paths.anchor.path == paths.root
+        assert paths.anchor.child("backlog").path == paths.backlog_dir
+        assert paths.anchor.child("metrics").path == paths.metrics_dir
+
+    def test_layout_is_created_where_the_paths_say(self, sdd_dir: Path) -> None:
+        paths = ensure_tenant_layout(sdd_dir, "acme")
+        assert paths.backlog_dir.is_dir()
+        assert paths.metrics_dir.is_dir()
+        assert paths.root == sdd_dir / "acme"
+
+
+class TestPreExistingRootSymlink:
+    """A tenant root that is already a link is refused, wherever it points."""
+
+    def test_root_linked_outside_sdd_is_refused(self, sdd_dir: Path, tmp_path: Path) -> None:
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (sdd_dir / "acme").symlink_to(outside, target_is_directory=True)
+
+        with pytest.raises((InvalidTenantIdError, OSError)):
+            ensure_tenant_layout(sdd_dir, "acme")
+        assert list(outside.iterdir()) == []
+
+    @needs_anchoring
+    def test_root_linked_to_a_sibling_tenant_is_refused(self, sdd_dir: Path) -> None:
+        """The case the containment assert cannot catch on its own.
+
+        `.sdd/acme -> .sdd/beta` resolves under `.sdd`, so a check that only
+        asks whether the derived root stays inside the tenant base is
+        satisfied by it. Creating the layout through the walk is what refuses
+        it, and the point of the test is that one tenant cannot be pointed at
+        another's subtree.
+        """
+        beta = ensure_tenant_layout(sdd_dir, "beta")
+        (sdd_dir / "acme").symlink_to(beta.root, target_is_directory=True)
+
+        with pytest.raises(OSError):
+            ensure_tenant_layout(sdd_dir, "acme")
+        assert list(beta.backlog_dir.iterdir()) == []
+
+
+@needs_anchoring
+class TestChildSymlink:
+    """A directory below the tenant root is layout, never a link."""
+
+    def test_linked_backlog_dir_is_refused(self, sdd_dir: Path, tmp_path: Path) -> None:
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (sdd_dir / "acme").mkdir()
+        (sdd_dir / "acme" / "backlog").symlink_to(outside, target_is_directory=True)
+
+        with pytest.raises(OSError):
+            ensure_tenant_layout(sdd_dir, "acme")
+        assert list(outside.iterdir()) == []
+
+    def test_linked_metrics_dir_is_refused(self, sdd_dir: Path, tmp_path: Path) -> None:
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (sdd_dir / "acme").mkdir()
+        (sdd_dir / "acme" / "metrics").symlink_to(outside, target_is_directory=True)
+
+        with pytest.raises(OSError):
+            ensure_tenant_layout(sdd_dir, "acme")
+        assert list(outside.iterdir()) == []
+
+
+@needs_anchoring
+class TestReplacementAfterTheLayoutExists:
+    """A directory swapped after creation is refused at the write."""
+
+    def test_tenant_root_replaced_before_the_append(self, sdd_dir: Path, tmp_path: Path) -> None:
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        paths = ensure_tenant_layout(sdd_dir, "acme")
+
+        # Everything the derived-path check could see was true when it ran.
+        import shutil
+
+        shutil.rmtree(paths.root)
+        (sdd_dir / "acme").symlink_to(outside, target_is_directory=True)
+
+        with pytest.raises(OSError):
+            with anchored_append(paths.anchor.child("backlog"), "tasks.jsonl") as handle:
+                handle.write("{}\n")
+        assert not (outside / "backlog").exists()
+
+    def test_backlog_dir_replaced_before_the_append(self, sdd_dir: Path, tmp_path: Path) -> None:
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        paths = ensure_tenant_layout(sdd_dir, "acme")
+
+        paths.backlog_dir.rmdir()
+        paths.backlog_dir.symlink_to(outside, target_is_directory=True)
+
+        with pytest.raises(OSError):
+            with anchored_append(paths.anchor.child("backlog"), "tasks.jsonl") as handle:
+                handle.write("{}\n")
+        assert not (outside / "tasks.jsonl").exists()
+
+
+class TestMetricsDirContract:
+    """`tenant_metrics_dir` carries the contract `tenant_paths` already had."""
+
+    def test_shared_metrics_dir_yields_a_tenant_sibling(self, sdd_dir: Path) -> None:
+        metrics = sdd_dir / "metrics"
+        metrics.mkdir()
+        assert tenant_metrics_dir(metrics, "acme") == sdd_dir / "acme" / "metrics"
+
+    def test_other_base_hangs_the_tenant_off_it(self, sdd_dir: Path) -> None:
+        base = sdd_dir / "other"
+        base.mkdir()
+        assert tenant_metrics_dir(base, "acme") == base / "acme"
+
+    def test_target_and_path_forms_agree(self, sdd_dir: Path) -> None:
+        metrics = sdd_dir / "metrics"
+        metrics.mkdir()
+        assert tenant_metrics_target(metrics, "acme").path == tenant_metrics_dir(metrics, "acme")
+
+    @pytest.mark.parametrize("tenant_id", ["..", "../escape", "a/b", "/abs"])
+    def test_non_segment_id_is_refused(self, sdd_dir: Path, tenant_id: str) -> None:
+        metrics = sdd_dir / "metrics"
+        metrics.mkdir()
+        with pytest.raises(InvalidTenantIdError):
+            tenant_metrics_dir(metrics, tenant_id)
+        with pytest.raises(InvalidTenantIdError):
+            tenant_metrics_target(metrics, tenant_id)
+
+    def test_containment_holds_independently_of_the_identifier_rule(
+        self, sdd_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The assert is load-bearing on its own, as in `tenant_paths`."""
+        from bernstein.core.security import tenanting
+
+        metrics = sdd_dir / "metrics"
+        metrics.mkdir()
+        monkeypatch.setattr(tenanting, "normalize_tenant_id", lambda raw: str(raw))
+        with pytest.raises(InvalidTenantIdError):
+            tenanting.tenant_metrics_dir(metrics, "..")

--- a/tests/unit/security/test_tenanting_containment.py
+++ b/tests/unit/security/test_tenanting_containment.py
@@ -188,3 +188,41 @@ class TestMetricsDirContract:
         monkeypatch.setattr(tenanting, "normalize_tenant_id", lambda raw: str(raw))
         with pytest.raises(InvalidTenantIdError):
             tenanting.tenant_metrics_dir(metrics, "..")
+
+
+def test_layout_is_created_when_the_sdd_directory_does_not_exist_yet(tmp_path: Path) -> None:
+    """A first run in an empty project must create the layout, not refuse it.
+
+    The anchored walk never creates its own root, by design. `.sdd` is that
+    root, so leaving its creation to the walk made the very first
+    `ensure_tenant_layout` in a fresh directory raise `FileNotFoundError` from
+    the anchor's `open` - a missing base reported as if it were a containment
+    refusal.
+    """
+    sdd_dir = tmp_path / ".sdd"
+    assert not sdd_dir.exists()
+
+    paths = ensure_tenant_layout(sdd_dir, "tenant-a")
+
+    assert paths.backlog_dir.is_dir()
+    assert paths.metrics_dir.is_dir()
+    assert paths.root.resolve().parent == sdd_dir.resolve()
+
+
+@needs_anchoring
+def test_a_symlinked_sdd_directory_is_still_the_operator_s_choice(tmp_path: Path) -> None:
+    """`.sdd` may be a symlink; everything below it may not.
+
+    The anchor root is the caller's own base - operator configuration, and the
+    only place in the layout a link is legitimate. Creating it when absent must
+    not turn into following a link *below* it, which the walk still refuses.
+    """
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    sdd_dir = tmp_path / ".sdd"
+    sdd_dir.symlink_to(elsewhere, target_is_directory=True)
+
+    paths = ensure_tenant_layout(sdd_dir, "tenant-a")
+
+    assert (elsewhere / "tenant-a" / "backlog").is_dir()
+    assert paths.backlog_dir.is_dir()

--- a/tests/unit/security/test_tenanting_containment.py
+++ b/tests/unit/security/test_tenanting_containment.py
@@ -226,3 +226,60 @@ def test_a_symlinked_sdd_directory_is_still_the_operator_s_choice(tmp_path: Path
 
     assert (elsewhere / "tenant-a" / "backlog").is_dir()
     assert paths.backlog_dir.is_dir()
+
+
+# --- the full data layout ---------------------------------------------------
+#
+# `ensure_tenant_data_layout` adds `runtime`, `runtime/wal` and `audit` below
+# the tenant root. Those carry the WAL and the audit chain, so a link at any of
+# them redirects exactly the writes that are supposed to be tamper-evident.
+
+
+@needs_anchoring
+def test_data_layout_refuses_a_runtime_directory_linked_at_a_sibling_tenant(tmp_path: Path) -> None:
+    """The case the containment check passes and the walk still has to catch.
+
+    `.sdd/acme/runtime -> .sdd/other/runtime` resolves under `.sdd`, so the
+    derived path is contained by every measure available at derivation time.
+    Following it would put one tenant's WAL inside another's subtree.
+    """
+    from bernstein.core.security.tenant_isolation import ensure_tenant_data_layout
+
+    sdd_dir = tmp_path / ".sdd"
+    victim = ensure_tenant_data_layout(sdd_dir, "other")
+
+    attacker_root = sdd_dir / "acme"
+    attacker_root.mkdir(parents=True)
+    (attacker_root / "runtime").symlink_to(victim.runtime_dir, target_is_directory=True)
+
+    with pytest.raises(OSError):
+        ensure_tenant_data_layout(sdd_dir, "acme")
+
+    assert not (victim.runtime_dir / "wal" / "wal").exists()
+
+
+@needs_anchoring
+def test_data_layout_refuses_a_linked_audit_directory(tmp_path: Path) -> None:
+    """The audit chain is the one directory a redirect must never survive."""
+    from bernstein.core.security.tenant_isolation import ensure_tenant_data_layout
+
+    sdd_dir = tmp_path / ".sdd"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (sdd_dir / "acme").mkdir(parents=True)
+    (sdd_dir / "acme" / "audit").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(OSError):
+        ensure_tenant_data_layout(sdd_dir, "acme")
+
+
+def test_data_layout_is_created_on_a_first_run(tmp_path: Path) -> None:
+    """The ordinary path still works, `.sdd` absent included."""
+    from bernstein.core.security.tenant_isolation import ensure_tenant_data_layout
+
+    paths = ensure_tenant_data_layout(tmp_path / ".sdd", "acme")
+
+    assert paths.wal_dir.is_dir()
+    assert paths.audit_dir.is_dir()
+    assert paths.runtime_dir.is_dir()
+    assert paths.backlog_dir.is_dir()

--- a/tests/unit/test_anchored_write.py
+++ b/tests/unit/test_anchored_write.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import errno
 import os
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 import pytest
 
@@ -27,9 +27,6 @@ from bernstein.core.persistence.anchored_write import (
     open_anchored_write,
     rotate_anchored,
 )
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 pytestmark = pytest.mark.ci
 
@@ -403,3 +400,100 @@ def test_degraded_open_follows_a_linked_parent(tmp_path: Path, monkeypatch: pyte
     os.close(fd)
 
     assert (outside / "usage.jsonl").exists()
+
+
+# --- what O_NOFOLLOW does not cover ------------------------------------------
+
+
+def test_capability_predicate_requires_o_directory() -> None:
+    """A walk that cannot say "directory" is not a walk over directories.
+
+    Without `O_DIRECTORY` a component that turned out to be a regular file
+    would be opened and handed on as the next parent, so the flag belongs in
+    the predicate next to the two that were already there.
+    """
+    every_capability = (
+        os.open in os.supports_dir_fd
+        and os.mkdir in os.supports_dir_fd
+        and hasattr(os, "O_NOFOLLOW")
+        and hasattr(os, "O_DIRECTORY")
+    )
+    assert ANCHORED_WRITE_SUPPORTED is every_capability
+
+
+@needs_anchoring
+def test_walk_refuses_a_regular_file_where_a_directory_belongs(tmp_path: Path) -> None:
+    (tmp_path / "a").write_text("not a directory\n", encoding="utf-8")
+
+    with pytest.raises(OSError) as excinfo:
+        fd = open_anchored_write(
+            AnchoredDir(root=tmp_path, parts=("a",)),
+            "f.jsonl",
+            flags=os.O_WRONLY | os.O_CREAT,
+        )
+        os.close(fd)
+
+    assert excinfo.value.errno == errno.ENOTDIR
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="needs mkfifo")
+@needs_anchoring
+def test_write_refuses_a_fifo_instead_of_blocking_on_it(tmp_path: Path) -> None:
+    """A FIFO is not a symlink, so `O_NOFOLLOW` lets it through.
+
+    Reader-less, the non-blocking open fails outright (`ENXIO`); with a reader
+    attached it opens and the `fstat` guard is what turns it away. Both are the
+    same requirement seen from two sides: a worker must not park on a name an
+    attacker chose.
+    """
+    fifo = tmp_path / "metrics.jsonl"
+    os.mkfifo(fifo)
+    target = AnchoredDir(root=tmp_path)
+
+    with pytest.raises(OSError) as excinfo:
+        fd = open_anchored_write(target, "metrics.jsonl", flags=os.O_WRONLY | os.O_CREAT | os.O_APPEND)
+        os.close(fd)
+    assert excinfo.value.errno == errno.ENXIO
+
+    reader_fd = os.open(fifo, os.O_RDONLY | os.O_NONBLOCK)
+    try:
+        with pytest.raises(OSError) as excinfo:
+            fd = open_anchored_write(target, "metrics.jsonl", flags=os.O_WRONLY | os.O_CREAT | os.O_APPEND)
+            os.close(fd)
+        assert excinfo.value.errno == errno.EPERM
+    finally:
+        os.close(reader_fd)
+
+
+def test_ordinary_write_still_returns_a_blocking_descriptor(tmp_path: Path) -> None:
+    """The non-blocking open is a probe, not the mode the caller is handed."""
+    fd = open_anchored_write(AnchoredDir(root=tmp_path), "m.jsonl", flags=os.O_WRONLY | os.O_CREAT)
+    try:
+        assert os.get_blocking(fd) is True
+    finally:
+        os.close(fd)
+
+
+# --- the anchor is a directory, not a directory name -------------------------
+
+
+def test_relative_root_is_pinned_at_construction(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """`AnchoredDir` is built once and walked later, possibly elsewhere.
+
+    Deferring the walk is the design; deferring resolution of the anchor too
+    would mean a value built under one working directory and flushed under
+    another wrote into a different tree with no error to show for it.
+    """
+    (tmp_path / "here").mkdir()
+    (tmp_path / "elsewhere" / "here").mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
+
+    target = AnchoredDir(root=Path("here"))
+    assert target.root == tmp_path / "here"
+
+    monkeypatch.chdir(tmp_path / "elsewhere")
+    fd = open_anchored_write(target, "m.jsonl", flags=os.O_WRONLY | os.O_CREAT)
+    os.close(fd)
+
+    assert (tmp_path / "here" / "m.jsonl").exists()
+    assert not (tmp_path / "elsewhere" / "here" / "m.jsonl").exists()

--- a/tests/unit/test_anchored_write.py
+++ b/tests/unit/test_anchored_write.py
@@ -1,0 +1,244 @@
+"""Tests for bernstein.core.persistence.anchored_write - anchored creates and writes.
+
+The interesting cases are the ones a path-based write cannot distinguish: a
+component that is a symlink rather than a directory, and a component replaced
+between the moment the directory was created and the moment the file was
+opened. The replacement tests drive that interleaving through a patched seam
+rather than through a thread race, so a failure means the guard is missing
+rather than that the machine was slow.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bernstein.core.persistence import anchored_write
+from bernstein.core.persistence.anchored_write import (
+    ANCHORED_WRITE_SUPPORTED,
+    AnchoredDir,
+    anchored_append,
+    anchored_write_text,
+    mkdir_anchored,
+    open_anchored_write,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = pytest.mark.ci
+
+needs_anchoring = pytest.mark.skipif(not ANCHORED_WRITE_SUPPORTED, reason="needs dir_fd and O_NOFOLLOW")
+
+
+class TestComponentValidation:
+    """A component is one name, never a path."""
+
+    @pytest.mark.parametrize("component", ["", ".", "..", "a/b", f"a{os.sep}b"])
+    def test_non_component_is_refused_at_construction(self, component: str, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="single names"):
+            AnchoredDir(root=tmp_path, parts=(component,))
+
+    def test_non_component_filename_is_refused(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="single names"):
+            open_anchored_write(AnchoredDir(root=tmp_path), "a/b", flags=os.O_WRONLY | os.O_CREAT)
+
+
+class TestHappyPath:
+    """The ordinary case still works, on every platform."""
+
+    def test_mkdir_creates_the_whole_chain(self, tmp_path: Path) -> None:
+        mkdir_anchored(AnchoredDir(root=tmp_path, parts=("a", "b", "c")))
+        assert (tmp_path / "a" / "b" / "c").is_dir()
+
+    def test_mkdir_is_idempotent(self, tmp_path: Path) -> None:
+        target = AnchoredDir(root=tmp_path, parts=("a", "b"))
+        mkdir_anchored(target)
+        mkdir_anchored(target)
+        assert (tmp_path / "a" / "b").is_dir()
+
+    def test_mkdir_without_exist_ok_refuses_an_existing_final_component(self, tmp_path: Path) -> None:
+        target = AnchoredDir(root=tmp_path, parts=("a", "b"))
+        mkdir_anchored(target)
+        with pytest.raises(FileExistsError):
+            mkdir_anchored(target, exist_ok=False)
+
+    def test_append_creates_then_appends(self, tmp_path: Path) -> None:
+        target = AnchoredDir(root=tmp_path, parts=("d",))
+        mkdir_anchored(target)
+        for line in ("one\n", "two\n"):
+            with anchored_append(target, "log.jsonl") as handle:
+                handle.write(line)
+        assert (tmp_path / "d" / "log.jsonl").read_text() == "one\ntwo\n"
+
+    def test_write_text_replaces_content(self, tmp_path: Path) -> None:
+        target = AnchoredDir(root=tmp_path)
+        anchored_write_text(target, "f.json", "first")
+        written = anchored_write_text(target, "f.json", "second")
+        assert written.read_text() == "second"
+        assert written == tmp_path / "f.json"
+
+    def test_a_symlinked_root_is_accepted(self, tmp_path: Path) -> None:
+        """Pointing a store's root elsewhere is operator configuration."""
+        real = tmp_path / "real"
+        real.mkdir()
+        link = tmp_path / "link"
+        link.symlink_to(real, target_is_directory=True)
+
+        mkdir_anchored(AnchoredDir(root=link, parts=("sub",)))
+        with anchored_append(AnchoredDir(root=link, parts=("sub",)), "f") as handle:
+            handle.write("x")
+        assert (real / "sub" / "f").read_text() == "x"
+
+
+@needs_anchoring
+class TestLinkedComponentsAreRefused:
+    """Everything below the root is store-managed layout; a link is not ours."""
+
+    def test_mkdir_refuses_a_symlinked_component(self, tmp_path: Path) -> None:
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (tmp_path / "a").symlink_to(outside, target_is_directory=True)
+
+        with pytest.raises(OSError) as excinfo:
+            mkdir_anchored(AnchoredDir(root=tmp_path, parts=("a", "b")))
+        # Which of the two arrives is the platform's call: opening a symlink
+        # with ``O_NOFOLLOW | O_DIRECTORY`` is ELOOP on Linux and ENOTDIR on
+        # macOS, since there the missing directory is what fails first. The
+        # refusal is the contract; the errno is not.
+        assert excinfo.value.errno in {errno.ELOOP, errno.ENOTDIR}
+        assert not (outside / "b").exists()
+
+    def test_mkdir_refuses_a_symlinked_final_component(self, tmp_path: Path) -> None:
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (tmp_path / "a").symlink_to(outside, target_is_directory=True)
+
+        with pytest.raises(OSError):
+            mkdir_anchored(AnchoredDir(root=tmp_path, parts=("a",)))
+
+    def test_mkdir_refuses_a_non_directory_component(self, tmp_path: Path) -> None:
+        (tmp_path / "a").write_text("not a directory")
+        with pytest.raises(OSError):
+            mkdir_anchored(AnchoredDir(root=tmp_path, parts=("a", "b")))
+
+    def test_append_refuses_a_symlinked_parent(self, tmp_path: Path) -> None:
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (tmp_path / "a").symlink_to(outside, target_is_directory=True)
+
+        with pytest.raises(OSError):
+            with anchored_append(AnchoredDir(root=tmp_path, parts=("a",)), "f") as handle:
+                handle.write("x")
+        assert not (outside / "f").exists()
+
+    def test_append_refuses_a_symlinked_file(self, tmp_path: Path) -> None:
+        target = tmp_path / "elsewhere.jsonl"
+        target.write_text("")
+        (tmp_path / "log.jsonl").symlink_to(target)
+
+        with pytest.raises(OSError):
+            with anchored_append(AnchoredDir(root=tmp_path), "log.jsonl") as handle:
+                handle.write("x")
+        assert target.read_text() == ""
+
+    def test_write_text_refuses_a_symlinked_file(self, tmp_path: Path) -> None:
+        target = tmp_path / "elsewhere.json"
+        target.write_text("original")
+        (tmp_path / "f.json").symlink_to(target)
+
+        with pytest.raises(OSError):
+            anchored_write_text(AnchoredDir(root=tmp_path), "f.json", "replacement")
+        assert target.read_text() == "original"
+
+
+@needs_anchoring
+class TestReplacementMidOperation:
+    """A component swapped after it was created is still refused.
+
+    The swap is driven from a patched ``os.mkdir`` / ``os.open`` rather than
+    from a competing thread: the point is that the guard holds for a given
+    interleaving, and a scheduled race would only ever sample interleavings.
+    """
+
+    def test_component_replaced_between_mkdir_and_open(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        real_mkdir = os.mkdir
+        swapped = False
+
+        def swapping_mkdir(path: object, *args: object, **kwargs: object) -> None:
+            nonlocal swapped
+            real_mkdir(path, *args, **kwargs)  # type: ignore[arg-type]
+            if not swapped and path == "a":
+                # The directory now exists and has been vouched for by nothing
+                # yet. Replace it before the walk re-opens it.
+                swapped = True
+                dir_fd = kwargs.get("dir_fd")
+                os.rmdir("a", dir_fd=dir_fd)  # type: ignore[arg-type]
+                os.symlink(outside, "a", dir_fd=dir_fd)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(anchored_write.os, "mkdir", swapping_mkdir)
+
+        with pytest.raises(OSError):
+            mkdir_anchored(AnchoredDir(root=tmp_path, parts=("a", "b")))
+        assert swapped, "the swap never ran; the test proved nothing"
+        assert not (outside / "b").exists()
+
+    def test_directory_replaced_between_creation_and_file_open(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        target = AnchoredDir(root=tmp_path, parts=("a",))
+        mkdir_anchored(target)
+
+        # Between the layout being created and the append happening, the
+        # tenant directory is replaced by a link. A caller holding a joined
+        # path would write through it; the walk refuses it.
+        (tmp_path / "a").rmdir()
+        (tmp_path / "a").symlink_to(outside, target_is_directory=True)
+
+        with pytest.raises(OSError):
+            with anchored_append(target, "tasks.jsonl") as handle:
+                handle.write("{}\n")
+        assert not (outside / "tasks.jsonl").exists()
+
+    def test_file_replaced_between_rotation_and_append(self, tmp_path: Path) -> None:
+        """A link planted at the filename is refused even after the dir is fine."""
+        target = AnchoredDir(root=tmp_path, parts=("a",))
+        mkdir_anchored(target)
+        with anchored_append(target, "log.jsonl") as handle:
+            handle.write("first\n")
+
+        outside = tmp_path / "outside.jsonl"
+        outside.write_text("")
+        (tmp_path / "a" / "log.jsonl").unlink()
+        (tmp_path / "a" / "log.jsonl").symlink_to(outside)
+
+        with pytest.raises(OSError):
+            with anchored_append(target, "log.jsonl") as handle:
+                handle.write("second\n")
+        assert outside.read_text() == ""
+
+
+class TestUnsupportedPlatformIsNotDressedUp:
+    """The fallback refuses nothing, and the module says so.
+
+    Asserting this keeps a later change from quietly adding an ``is_symlink``
+    pre-check to the fallback and calling the gap closed: that would trade an
+    atomic guarantee for a race window, which is not an improvement and should
+    not be able to arrive without this test being updated deliberately.
+    """
+
+    def test_support_flag_requires_every_capability(self) -> None:
+        expected = os.open in os.supports_dir_fd and os.mkdir in os.supports_dir_fd and hasattr(os, "O_NOFOLLOW")
+        assert ANCHORED_WRITE_SUPPORTED is expected
+
+    def test_fallback_is_documented_as_absent_rather_than_weak(self) -> None:
+        doc = anchored_write.__doc__ or ""
+        assert "refuses **nothing**" in doc
+        assert "absence of one" in doc

--- a/tests/unit/test_anchored_write.py
+++ b/tests/unit/test_anchored_write.py
@@ -355,3 +355,51 @@ def test_rotation_falls_back_when_the_platform_cannot_anchor(tmp_path: Path, mon
 
     assert rotate_anchored(AnchoredDir(root=tmp_path), "metrics.jsonl", max_bytes=100) is True
     assert (tmp_path / "metrics.jsonl.1").stat().st_size == 500
+
+
+# --- the degraded path, pinned -----------------------------------------------
+#
+# `ANCHORED_WRITE_SUPPORTED` is one flag over two capabilities: `O_NOFOLLOW`
+# and `dir_fd` on open and mkdir. A platform can have the first without the
+# second, and then `open_anchored_write` loses its walk but keeps the flag on
+# the final open. That is a narrower refusal, not an absent one, and the two
+# tests below say which half survives so nobody has to infer it from the flag.
+
+
+@pytest.mark.skipif(not getattr(os, "O_NOFOLLOW", 0), reason="needs O_NOFOLLOW")
+def test_degraded_open_still_refuses_a_linked_final_component(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without the walk, the flag on the last open is all that is left."""
+    monkeypatch.setattr(anchored_write, "ANCHORED_WRITE_SUPPORTED", False)
+    outside = tmp_path / "outside.jsonl"
+    outside.write_text("kept\n", encoding="utf-8")
+    (tmp_path / "metrics.jsonl").symlink_to(outside)
+
+    with pytest.raises(OSError) as excinfo:
+        fd = open_anchored_write(
+            AnchoredDir(root=tmp_path),
+            "metrics.jsonl",
+            flags=os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+        )
+        os.close(fd)
+
+    assert excinfo.value.errno in {errno.ELOOP, errno.ENOTDIR}
+    assert outside.read_text(encoding="utf-8") == "kept\n"
+
+
+def test_degraded_open_follows_a_linked_parent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The half that is genuinely lost, written down rather than discovered."""
+    monkeypatch.setattr(anchored_write, "ANCHORED_WRITE_SUPPORTED", False)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "metrics").symlink_to(outside)
+
+    fd = open_anchored_write(
+        AnchoredDir(root=root, parts=("metrics",)),
+        "usage.jsonl",
+        flags=os.O_WRONLY | os.O_CREAT,
+    )
+    os.close(fd)
+
+    assert (outside / "usage.jsonl").exists()

--- a/tests/unit/test_anchored_write.py
+++ b/tests/unit/test_anchored_write.py
@@ -24,6 +24,7 @@ from bernstein.core.persistence.anchored_write import (
     anchored_write_text,
     mkdir_anchored,
     open_anchored_write,
+    rotate_anchored,
 )
 
 if TYPE_CHECKING:
@@ -242,3 +243,87 @@ class TestUnsupportedPlatformIsNotDressedUp:
         doc = anchored_write.__doc__ or ""
         assert "refuses **nothing**" in doc
         assert "absence of one" in doc
+
+
+# --- rotation ---------------------------------------------------------------
+#
+# Rotation is the operation with the teeth: it stats, unlinks and renames.
+# Running it on a derived path and anchoring only the append that follows
+# protects the harmless half - a link planted at a managed parent has already
+# redirected every rename and deletion by the time the append refuses anything.
+
+
+def _fill(path: Path, size: int) -> None:
+    path.write_text("x" * size, encoding="utf-8")
+
+
+def test_rotate_leaves_a_file_under_the_threshold_alone(tmp_path: Path) -> None:
+    target = tmp_path / "metrics.jsonl"
+    _fill(target, 10)
+
+    assert rotate_anchored(AnchoredDir(root=tmp_path), "metrics.jsonl", max_bytes=100) is False
+    assert target.read_text(encoding="utf-8") == "x" * 10
+    assert not (tmp_path / "metrics.jsonl.1").exists()
+
+
+def test_rotate_shifts_backups_within_the_retention_limit(tmp_path: Path) -> None:
+    _fill(tmp_path / "metrics.jsonl", 200)
+    _fill(tmp_path / "metrics.jsonl.1", 1)
+    _fill(tmp_path / "metrics.jsonl.2", 2)
+
+    assert rotate_anchored(AnchoredDir(root=tmp_path), "metrics.jsonl", max_bytes=100, max_backups=2) is True
+
+    assert not (tmp_path / "metrics.jsonl").exists()
+    assert (tmp_path / "metrics.jsonl.1").stat().st_size == 200
+    # `.1` shifted down to `.2`; the old `.2` was at the limit and was dropped.
+    assert (tmp_path / "metrics.jsonl.2").stat().st_size == 1
+    assert not (tmp_path / "metrics.jsonl.3").exists()
+
+
+def test_rotate_missing_file_is_not_an_error(tmp_path: Path) -> None:
+    assert rotate_anchored(AnchoredDir(root=tmp_path), "absent.jsonl", max_bytes=1) is False
+
+
+@pytest.mark.parametrize("name", ["a/b.jsonl", "..", ".", ""])
+def test_rotate_refuses_a_name_that_is_not_one_component(tmp_path: Path, name: str) -> None:
+    with pytest.raises(ValueError, match="single names"):
+        rotate_anchored(AnchoredDir(root=tmp_path), name, max_bytes=1)
+
+
+@needs_anchoring
+def test_rotate_refuses_a_symlinked_parent_and_touches_nothing_outside(tmp_path: Path) -> None:
+    """The case the derived path could not decide: the parent is a link.
+
+    `outside/metrics.jsonl` is over the threshold and would be renamed if the
+    link were followed. Nothing in `outside` may move.
+    """
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    _fill(outside / "metrics.jsonl", 500)
+
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "metrics").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(OSError) as excinfo:
+        rotate_anchored(AnchoredDir(root=root, parts=("metrics",)), "metrics.jsonl", max_bytes=100)
+
+    assert excinfo.value.errno in {errno.ELOOP, errno.ENOTDIR}
+    assert (outside / "metrics.jsonl").stat().st_size == 500
+    assert not (outside / "metrics.jsonl.1").exists()
+
+
+@needs_anchoring
+def test_rotate_does_not_follow_a_link_planted_at_the_file_itself(tmp_path: Path) -> None:
+    """A link at the name has no size of its own worth rotating.
+
+    Stat'ing through it would measure - and then rename - a file the layout
+    does not own.
+    """
+    outside = tmp_path / "outside.jsonl"
+    _fill(outside, 500)
+    (tmp_path / "metrics.jsonl").symlink_to(outside)
+
+    assert rotate_anchored(AnchoredDir(root=tmp_path), "metrics.jsonl", max_bytes=100) is False
+    assert outside.stat().st_size == 500
+    assert (tmp_path / "metrics.jsonl").is_symlink()

--- a/tests/unit/test_anchored_write.py
+++ b/tests/unit/test_anchored_write.py
@@ -347,9 +347,7 @@ def test_rotation_capability_covers_every_call_rotation_makes() -> None:
         assert fn in os.supports_dir_fd, f"{fn.__name__} must accept dir_fd for rotation to anchor"
 
 
-def test_rotation_falls_back_when_the_platform_cannot_anchor(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_rotation_falls_back_when_the_platform_cannot_anchor(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """With the capability off, rotation still happens - by path."""
     monkeypatch.setattr(anchored_write, "ANCHORED_ROTATE_SUPPORTED", False)
     target = tmp_path / "metrics.jsonl"

--- a/tests/unit/test_anchored_write.py
+++ b/tests/unit/test_anchored_write.py
@@ -18,6 +18,7 @@ import pytest
 
 from bernstein.core.persistence import anchored_write
 from bernstein.core.persistence.anchored_write import (
+    ANCHORED_ROTATE_SUPPORTED,
     ANCHORED_WRITE_SUPPORTED,
     AnchoredDir,
     anchored_append,
@@ -327,3 +328,32 @@ def test_rotate_does_not_follow_a_link_planted_at_the_file_itself(tmp_path: Path
     assert rotate_anchored(AnchoredDir(root=tmp_path), "metrics.jsonl", max_bytes=100) is False
     assert outside.stat().st_size == 500
     assert (tmp_path / "metrics.jsonl").is_symlink()
+
+
+def test_rotation_capability_covers_every_call_rotation_makes() -> None:
+    """A partial platform must take the fallback, not fail halfway through.
+
+    `ANCHORED_WRITE_SUPPORTED` answers for `os.open` and `os.mkdir`. Rotation
+    also stats, unlinks and renames through a descriptor, and a platform with
+    the first pair but not the second would enter the anchored branch and raise
+    `NotImplementedError` mid-rotation - after the earlier steps had already
+    run.
+    """
+    if not ANCHORED_ROTATE_SUPPORTED:
+        pytest.skip("platform takes the path-based fallback")
+
+    assert ANCHORED_WRITE_SUPPORTED
+    for fn in (os.stat, os.unlink, os.rename):
+        assert fn in os.supports_dir_fd, f"{fn.__name__} must accept dir_fd for rotation to anchor"
+
+
+def test_rotation_falls_back_when_the_platform_cannot_anchor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With the capability off, rotation still happens - by path."""
+    monkeypatch.setattr(anchored_write, "ANCHORED_ROTATE_SUPPORTED", False)
+    target = tmp_path / "metrics.jsonl"
+    target.write_text("x" * 500, encoding="utf-8")
+
+    assert rotate_anchored(AnchoredDir(root=tmp_path), "metrics.jsonl", max_bytes=100) is True
+    assert (tmp_path / "metrics.jsonl.1").stat().st_size == 500


### PR DESCRIPTION
# User description
Follow-up to #3691, which added tenant identifier validation and a containment assert on the derived tenant root. This carries the part that PR deliberately left: making the containment hold for the *write*, not only for the derivation.

## What was going on

`tenant_paths` resolved the derived root, asserted it stayed under `.sdd`, and then returned the **unresolved** `root`/`backlog_dir`/`metrics_dir` for callers to join later. That is two derivations of the same directory. They name the same place only while nothing replaces a component between them, so the directory that was checked and the directory `ensure_tenant_layout` created — and the writers appended to — could be different directories.

`tenant_metrics_dir` had no containment check at all.

## What changed

**Paths are derived once and reused.** `TenantPaths` gains an `anchor` that names the layout as a root plus the components below it. Writers take the anchor and open each component relative to its parent with `O_NOFOLLOW`, so containment is a property of the walk rather than of a check that ran earlier.

**`tenant_metrics_dir` gets the same contract as `tenant_paths`,** plus `tenant_metrics_target` returning the anchored form for callers that write.

**New `core/persistence/anchored_write.py`** — the write-side counterpart to the existing `anchored_read.py`, keeping its conventions:

- the root may be a symlink (operator configuration); everything below it may not (store-managed layout)
- `mkdir` reports `EEXIST` for a directory and a symlink alike, so every component is re-opened `O_NOFOLLOW | O_DIRECTORY` after creation — that re-open is what carries the guarantee
- on platforms without `dir_fd`/`O_NOFOLLOW` the fallback is documented as **the absence of a guard**, not a weaker one, matching how `anchored_read` handles the same split. A test asserts that wording so it cannot quietly become an `is_symlink()` pre-check later.

## Two corrections this surfaced

| | |
|---|---|
| Sibling aliasing | `.sdd/acme -> .sdd/beta` satisfied the old containment check — it *does* resolve under `.sdd` — so one tenant's writes could land in another tenant's subtree. Refused now. |
| Retry classification | `_retry_io` treated a refused component as transient and retried it, reporting a permanent layout condition as a store outage. `ELOOP`/`ENOTDIR` joined the non-transient set. |

## Writers updated

- `task_store_core.py` — `tasks.jsonl` (both the sync recovery path and the async one) and `archive.jsonl`
- `metric_collector.py` — buffered points now carry an anchor plus a filename instead of a joined path. This was the widest gap: a point is recorded and flushed at different times, so a stored path was resolved long after the directory it named was decided. Rotation stays path-based and is commented as such — it renames a file that is already written; the append is what decides where new content lands.
- `cost_tracker.py` — `save`, `save_metrics`, `_rotate_evicted`. No tenant awareness added and no signature changes; callers untouched.

## Tests

`tests/unit/test_anchored_write.py` and `tests/unit/security/test_tenanting_containment.py` cover a pre-existing root symlink (outward and sibling-pointing), a child symlink, and replacement between directory creation and both the directory open and the file open.

The replacement cases drive the interleaving through a patched seam rather than a thread race, so a failure means the guard is missing rather than that the machine was slow. POSIX-only cases are skipped behind `ANCHORED_WRITE_SUPPORTED`.

## Notes

- The behaviour predates #3691; it is not something that branch introduced.
- The existing `resolve()` assert is kept rather than replaced. It is cheap, it runs before anything is created, and it is what fails first if the identifier rule is ever widened — the walk is what makes the write safe, not that check.
- `src/bernstein/core/security/AGENTS.md` gains the invariant next to the existing anchored-read one.

Verified: `ruff check`, `ruff format --check`, `mypy` clean on all changed modules (two pre-existing `mypy` errors in `cost_tracker.py` and `metric_collector.py` are unrelated and present on `main`). 1000 tests pass across the tenant, task-store, metrics and cost suites.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Anchor tenant-scoped directory derivation and route layout creation, task, metric, audit, WAL, and cost writes through descriptor-relative <code>O_NOFOLLOW</code> walks. Extend containment validation and document platform fallbacks, migration guidance, retry classification, and run identity checks.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3707?tool=ast&topic=Tenant-safe+writes>Tenant-safe writes</a>
        </td><td>Protect tenant layout creation and persistence from symlink redirection and replacement races by using <code>TenantPaths.anchor</code>, <code>tenant_metrics_target</code>, and <code>anchored_write</code> operations for task, metric, WAL, audit, and rotation writes.<details><summary>Modified files (7)</summary><ul><li>src/bernstein/core/observability/metric_collector.py</li>
<li>src/bernstein/core/persistence/anchored_write.py</li>
<li>src/bernstein/core/security/tenant_isolation.py</li>
<li>src/bernstein/core/security/tenanting.py</li>
<li>src/bernstein/core/tasks/task_store_core.py</li>
<li>tests/unit/security/test_tenanting_containment.py</li>
<li>tests/unit/test_anchored_write.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>fix(persistence): refu...</td><td>August 12, 2026</td></tr>
<tr><td>sanderchernitsky@gmail...</td><td>refactor(tenanting): d...</td><td>August 12, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3707?tool=ast&topic=Cost+and+rollout+safety>Cost and rollout safety</a>
        </td><td>Harden cost persistence by validating <code>run_id</code> before path construction, anchoring cost and usage writes, rejecting mismatched payload identities, and documenting security behavior, supported platforms, and migration options.<details><summary>Modified files (4)</summary><ul><li>docs/security/audit-multitenant.md</li>
<li>src/bernstein/core/cost/cost_tracker.py</li>
<li>src/bernstein/core/security/AGENTS.md</li>
<li>tests/unit/cost/test_cost_tracker_paths.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>fix(cost,persistence):...</td><td>August 12, 2026</td></tr>
<tr><td>sanderchernitsky@gmail...</td><td>refactor(tenanting): d...</td><td>August 12, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3707?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

<!-- bot-ack: 3767731318 reason=metric emission is best-effort by design; a tenant layout that cannot be created must not take the caller down with it. Durability of the metric buffer is tracked separately in #3710. -->
<!-- bot-ack: 3767731320 reason=same call site, same decision: a failed tenant write drops the batch rather than blocking the run. Making the buffer durable is the subject of #3710, not of this change. -->
<!-- bot-ack: 3769462379 reason=this change is about which file `load` opens and whose identity it takes from it. Which rows a reporting endpoint is entitled to return is decided at the endpoint rather than in the loader, and #3677 is the change that carries that. Folding the endpoints in here would put two unrelated reviews behind one approval. -->
