### PR TITLE
test(adapters): isolate adapter refusal from host PATH

### DIFF
--- a/tests/unit/test_adapter_admission.py
+++ b/tests/unit/test_adapter_admission.py
@@ -786,8 +786,16 @@ def test_adapter_without_a_contract_refuses(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_verify_cli_reports_a_refusal_with_exit_1(receipts_dir: Path, contracts_dir: Path) -> None:
+def test_verify_cli_reports_a_refusal_with_exit_1(
+    receipts_dir: Path,
+    contracts_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from bernstein.cli.commands.adapters_verify_cmd import _execute_verify  # pyright: ignore[reportPrivateUsage]
+
+    # Stub binary lookup so the refusal path is taken by construction on
+    # every host, rather than depending on the absence of a binary.
+    monkeypatch.setattr("shutil.which", lambda _: None)
 
     rc = _execute_verify(
         "kimi",
@@ -802,11 +810,18 @@ def test_verify_cli_reports_a_refusal_with_exit_1(receipts_dir: Path, contracts_
     assert rc == 1
 
 
-def test_verify_cli_seals_a_receipt_the_gate_then_accepts(receipts_dir: Path, contracts_dir: Path) -> None:
+def test_verify_cli_seals_a_receipt_the_gate_then_accepts(
+    receipts_dir: Path,
+    contracts_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from bernstein.cli.commands.adapters_verify_cmd import _execute_verify  # pyright: ignore[reportPrivateUsage]
 
-    # The host has no kimi binary, so the sealed receipt records a refusal -
-    # the negative path, written down rather than left silent.
+    # The adapter binary is stubbed out, so the sealed receipt records a
+    # refusal by construction on every host - the negative path, written
+    # down rather than left silent.
+    monkeypatch.setattr("shutil.which", lambda _: None)
+
     rc = _execute_verify(
         "kimi",
         output_format="text",


### PR DESCRIPTION
## What

Stubs the binary lookup (`shutil.which`) in the adapter verify CLI tests so the refusal path is taken by construction on every machine, rather than depending on the host not having the `kimi` binary installed.

## Why

Closes #3704. The tests at `test_verify_cli_reports_a_refusal_with_exit_1` and `test_verify_cli_seals_a_receipt_the_gate_then_accepts` asserted a refusal path, but got that refusal from an accident of the machine they ran on. On a workstation that does have `kimi` on `PATH`, `_execute_verify` detected the adapter, admitted it, and returned `0`. The tests failed with no defect present. This was hit by an outside contributor on a machine with `kimi.exe` installed.

## How

1. Inject `monkeypatch` into both tests.
2. Patch `shutil.which` to return `None` unconditionally.
3. This forces the conformance probe to skip, which drives the refusal receipt path deterministically.

## Checklist

- [x] `uv run ruff check src/` passes
- [x] `uv run pyright src/` passes
- [x] `uv run python scripts/run_tests.py -x` passes
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)

- [x] User-visible README section updated (or N/A if internal-only)
- [x] `docs/operations/<area>.md` updated (or N/A)
- [x] `docs/api/` schema regenerated if a public surface changed (or N/A)
- [x] `uv run bernstein agents-md sync` run so AGENTS.md, CLAUDE.md, `.goosehints`, `CONVENTIONS.md`, and `.cursor/rules/*.mdc` reflect any new module (or N/A)
- [x] Tests cover the documented behaviour