### PR TITLE
Feat/stall verdict audit chain

### DIFF
--- a/docs/operations/stall-escalation.md
+++ b/docs/operations/stall-escalation.md
@@ -95,3 +95,41 @@ reconstructing a failure window can place "this detector saw these inputs and
 decided" next to "this mechanism delivered the stop" without guessing. Recording
 is best-effort -- a chain failure never blocks the kill -- but never silent: the
 failure surfaces as a warning naming the session.
+
+## Automatic kills emit receipts
+
+The three automatic stall-kill paths in `core.agents.heartbeat`
+(`_escalate_heartbeat`, `_escalate_stall_simple`, `_escalate_stall_profiled`)
+emit a full escalation receipt for every kill they issue, not just the verdict.
+The ordering is:
+
+1. `stall.verdict` is recorded (the decision, before the kill).
+2. The worker is killed (SIGTERM/SIGKILL ladder or `spawner.kill`).
+3. `escalation.receipt` is emitted (the failure window, after the kill).
+
+The receipt assembly runs *after* the kill so the kill path is never delayed or
+blocked, and inside the single-threaded tick loop nothing else appends to the
+journal between the verdict and the receipt, so the receipt binds exactly the
+window the verdict observed. Because the audit chain is read fresh from disk on
+every append, the `escalation.receipt` event chains directly off the
+`stall.verdict` that precedes it.
+
+The automatic path reuses the same assembly and verification machinery as a
+manually issued receipt -- `bernstein escalation verify <receipt-id>` works on
+automatic receipts unchanged, and they appear in `bernstein escalation show`.
+The receipt records the stalled worker's `session_id`, and the mirrored
+`escalation.receipt` audit event carries it too, so the session link is read
+from the record itself rather than reconstructed by matching ids.
+
+The `worktree_id` on an automatic receipt is derived from the worktree the
+orchestrator runs (`sha256` of the resolved workdir, truncated to 16 hex chars
+-- the same convention `worktree_id_for` uses elsewhere), so a receipt stays
+attributable to the worktree that processed the kill without taking a skills
+catalogue dependency.
+
+Emission is best-effort, like the verdict: a missing or empty run journal, a
+failing install identity, or a chain write failure never prevents the kill
+that already happened, and surfaces as a warning naming the session and
+detector. Only when the orchestrator carries no `_run_id` is the skip silent
+(`info`) -- without a run there is no journal to anchor, so there is nothing
+to emit.

--- a/src/bernstein/core/agents/heartbeat.py
+++ b/src/bernstein/core/agents/heartbeat.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import json
 import logging
 import os
@@ -500,6 +501,97 @@ def _emit_stall_verdict(
         )
 
 
+def _emit_escalation_receipt(
+    orch: Any,
+    session: Any,
+    *,
+    stall_reason: StallReason,
+    detector: str,
+) -> None:
+    """Emit a signed, journal-anchored escalation receipt after a stall kill (#3685).
+
+    Called AFTER the automatic stall kill has been issued, mirroring the
+    ``stall.verdict`` that recorded the decision earlier in the same kill
+    path. The receipt binds the trailing journal window by its Merkle hashes,
+    is signed with the install escalation identity, and is mirrored into the
+    HMAC chained audit log as ``escalation.receipt`` -- chained directly off
+    the ``stall.verdict`` it follows.
+
+    Best-effort by design, like ``_emit_stall_verdict``: the receipt must
+    never block, delay, retry, or undo the kill that already happened. A
+    receipt that cannot be produced (missing/empty journal, no identity, a
+    chain write failure) is logged as a warning naming the session -- with
+    one exception: when the orchestrator carries no ``_run_id`` there is no
+    journal to anchor, so the skip is silent info rather than a spurious
+    warning.
+    """
+    workdir = getattr(orch, "_workdir", None)
+    if not isinstance(workdir, Path):
+        return
+    run_id = getattr(orch, "_run_id", None) or ""
+    if not run_id:
+        logger.info(
+            "Skipping escalation receipt for session %s: no run id to anchor a journal",
+            session.id,
+        )
+        return
+    try:
+        from bernstein.core.identity.install_rev import get_install_rev
+        from bernstein.core.orchestration.escalation import (
+            DEFAULT_ESCALATION_WINDOW,
+            assemble_escalation_receipt,
+            load_or_create_escalation_identity,
+        )
+        from bernstein.core.security.audit import load_or_create_audit_key
+        from bernstein.core.security.audit_chain import (
+            AuditChainStore,
+            record_escalation_receipt,
+        )
+
+        identity_dir = workdir / ".sdd" / "escalation"
+        private_key_pem, public_key_pem = load_or_create_escalation_identity(identity_dir)
+        worktree_id = hashlib.sha256(str(workdir.resolve()).encode("utf-8")).hexdigest()[:16]
+        receipt = assemble_escalation_receipt(
+            sdd_dir=workdir / ".sdd",
+            lineage_root=workdir / ".sdd" / "lineage",
+            hmac_key=load_or_create_audit_key(),
+            private_key_pem=private_key_pem,
+            public_key_pem=public_key_pem,
+            run_id=run_id,
+            worker_id=session.id,
+            session_id=session.id,
+            worktree_id=worktree_id,
+            stall_reason=stall_reason,
+            respawn_budget_remaining=0,
+            fork_step=None,
+            window=DEFAULT_ESCALATION_WINDOW,
+            install_rev=get_install_rev(),
+            timestamp=int(time.time()),
+            extra_binding=None,
+        )
+        chain = AuditChainStore(workdir / ".sdd" / "audit")
+        record_escalation_receipt(
+            chain=chain,
+            run_id=receipt.run_id,
+            worker_id=receipt.worker_id,
+            session_id=receipt.session_id,
+            stall_reason=receipt.stall_reason.value,
+            recommended_action=receipt.recommended_action.value,
+            journal_head_at_stall=receipt.journal_head_at_stall,
+            window_size=len(receipt.window_entry_hashes),
+            fork_snapshot_sha=receipt.fork_ref.snapshot_sha if receipt.fork_ref else "",
+            journal_entry_hash=receipt.journal_entry_hash,
+        )
+    except Exception as exc:  # the receipt must never block or undo the kill
+        logger.warning(
+            "Could not emit escalation.receipt for session %s (%s detector): %s: %s",
+            session.id,
+            detector,
+            type(exc).__name__,
+            exc,
+        )
+
+
 def _escalate_heartbeat(
     orch: Any,
     session: Any,
@@ -566,6 +658,12 @@ def _escalate_heartbeat(
             if session.pid is None or not action.action_taken:
                 with contextlib.suppress(Exception):
                     orch._spawner.kill(session)
+            _emit_escalation_receipt(
+                orch,
+                session,
+                stall_reason=StallReason.HEARTBEAT_STALE,
+                detector="heartbeat",
+            )
 
     if age >= shutdown_threshold:
         with contextlib.suppress(OSError):
@@ -727,6 +825,12 @@ def _escalate_stall_simple(
         )
         with contextlib.suppress(Exception):
             orch._spawner.kill(session)
+        _emit_escalation_receipt(
+            orch,
+            session,
+            stall_reason=StallReason.NO_PROGRESS,
+            detector="stall_simple",
+        )
         _reap_session_heartbeat_loop(orch, session, reason="stall_kill")
         orch._stall_counts[task_id] = 0
     elif count >= AGENT.escalation_high_count:
@@ -769,6 +873,12 @@ def _escalate_stall_profiled(
         )
         with contextlib.suppress(Exception):
             orch._spawner.kill(session)
+        _emit_escalation_receipt(
+            orch,
+            session,
+            stall_reason=StallReason.NO_PROGRESS,
+            detector="stall_profiled",
+        )
         _reap_session_heartbeat_loop(orch, session, reason=f"stall_kill:{profile.reason}")
         orch._stall_counts[task_id] = 0
     elif count >= profile.shutdown_threshold:

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -2671,6 +2671,7 @@ def record_escalation_receipt(
     chain: AuditChainStore,
     run_id: str,
     worker_id: str,
+    session_id: str = "",
     stall_reason: str,
     recommended_action: str,
     journal_head_at_stall: str,
@@ -2693,6 +2694,10 @@ def record_escalation_receipt(
         chain: The audit chain store accepting the entry.
         run_id: The run whose journal the receipt anchored.
         worker_id: The stalled worker the receipt covers.
+        session_id: The stalled session id, when known (default: empty). When
+            truthy it is recorded in the details payload so the session link is
+            readable from the record itself rather than reconstructed from
+            matching ids.
         stall_reason: The structured stall reason recorded on the receipt.
         recommended_action: The deterministic recommended action.
         journal_head_at_stall: The run journal Merkle head at stall time.
@@ -2707,21 +2712,24 @@ def record_escalation_receipt(
         The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded in
         its details payload.
     """
+    details: dict[str, object] = {
+        "run_id": run_id,
+        "worker_id": worker_id,
+        "stall_reason": stall_reason,
+        "recommended_action": recommended_action,
+        "journal_head_at_stall": journal_head_at_stall,
+        "window_size": window_size,
+        "fork_snapshot_sha": fork_snapshot_sha,
+        "journal_entry_hash": journal_entry_hash,
+    }
+    if session_id:
+        details["session_id"] = session_id
     return chain.log_with_prev_digest(
         event_type=EVENT_ESCALATION_RECEIPT,
         actor=actor,
         resource_type="escalation_receipt",
         resource_id=journal_entry_hash,
-        details={
-            "run_id": run_id,
-            "worker_id": worker_id,
-            "stall_reason": stall_reason,
-            "recommended_action": recommended_action,
-            "journal_head_at_stall": journal_head_at_stall,
-            "window_size": window_size,
-            "fork_snapshot_sha": fork_snapshot_sha,
-            "journal_entry_hash": journal_entry_hash,
-        },
+        details=details,
     )
 
 

--- a/tests/unit/test_escalation_receipt.py
+++ b/tests/unit/test_escalation_receipt.py
@@ -286,6 +286,7 @@ def test_audit_chain_mirror_records_escalation(tmp_path: Path) -> None:
         chain=chain,
         run_id=receipt.run_id,
         worker_id=receipt.worker_id,
+        session_id=receipt.session_id,
         stall_reason=receipt.stall_reason.value,
         recommended_action=receipt.recommended_action.value,
         journal_head_at_stall=receipt.journal_head_at_stall,
@@ -296,5 +297,7 @@ def test_audit_chain_mirror_records_escalation(tmp_path: Path) -> None:
     assert event.event_type == EVENT_ESCALATION_RECEIPT
     assert "prev_chain_digest" in event.details
     assert event.details["run_id"] == receipt.run_id
+    # The session link is read from the record, not reconstructed by matching.
+    assert event.details["session_id"] == receipt.session_id
     ok, errors = chain.verify()
     assert ok, errors

--- a/tests/unit/test_heartbeat_escalation_receipt.py
+++ b/tests/unit/test_heartbeat_escalation_receipt.py
@@ -1,0 +1,269 @@
+"""Invariant: every automatic stall kill leaves a chained escalation receipt.
+
+Each worker kill decided by the three escalation paths in ``heartbeat``
+(``_escalate_heartbeat``, ``_escalate_stall_simple``, ``_escalate_stall_profiled``)
+emits a signed, journal-anchored escalation receipt after the kill is issued,
+mirrored into the HMAC audit chain as ``escalation.receipt`` -- chained
+directly off the ``stall.verdict`` that recorded the decision first (order:
+verdict -> kill -> receipt).
+
+Like the verdict, emission is best-effort: a missing journal, a failing
+assembly, or a chain write failure must never block or undo the kill, and the
+failure stays observable as a warning naming the session. These tests prove
+the ordering and the best-effort contract by asserting on the chain and the
+on-disk receipt (never that a mock was called) and by driving the real kill
+paths with raising assembly and chain stores.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from bernstein.core.models import AgentHeartbeat, AgentSession, ModelConfig
+
+from bernstein.core.agents.heartbeat import (
+    AGENT,
+    StallProfile,
+    _escalate_heartbeat,
+    _escalate_stall_profiled,
+    _escalate_stall_simple,
+    check_stale_agents,
+)
+from bernstein.core.replay.journal import EventJournal
+from bernstein.core.security.audit_chain import (
+    EVENT_ESCALATION_RECEIPT,
+    EVENT_STALL_VERDICT,
+    AuditChainStore,
+)
+
+RUN_ID = "run-receipt-1"
+
+
+def _session(sid: str = "A-1", task_id: str = "T-1", *, pid: int | None = 4321) -> AgentSession:
+    return AgentSession(
+        id=sid,
+        role="backend",
+        task_ids=[task_id],
+        status="working",
+        spawn_ts=100.0,
+        pid=pid,
+        model_config=ModelConfig("sonnet", "high"),
+    )
+
+
+def _build_journal(workdir: Path, *, n_events: int = 20) -> None:
+    (workdir / ".sdd").mkdir(exist_ok=True)
+    journal = EventJournal(RUN_ID, workdir / ".sdd")
+    for i in range(n_events):
+        journal.record("task.tick", session_id="A-1", seq=i)
+    del journal
+
+
+def _chain_verdicts(workdir: Path) -> list[object]:
+    chain = AuditChainStore(workdir / ".sdd" / "audit")
+    return chain.query(event_type=EVENT_STALL_VERDICT)
+
+
+def _chain_receipts(workdir: Path) -> list[object]:
+    chain = AuditChainStore(workdir / ".sdd" / "audit")
+    return chain.query(event_type=EVENT_ESCALATION_RECEIPT)
+
+
+def _receipt_files(workdir: Path) -> list[Path]:
+    return sorted((workdir / ".sdd" / "escalation" / "receipts").glob("*.json"))
+
+
+def _heartbeat_orch(workdir: Path, session: AgentSession) -> SimpleNamespace:
+    return SimpleNamespace(
+        _agents={session.id: session},
+        _workdir=workdir,
+        _run_id=RUN_ID,
+        _signal_mgr=MagicMock(),
+        _spawner=MagicMock(),
+        _stall_counts={},
+    )
+
+
+def _verify_auto_receipt(workdir: Path, receipt_path: Path) -> tuple[bool, str]:
+    from bernstein.core.orchestration.escalation import verify_escalation_receipt
+    from bernstein.core.security.audit import load_or_create_audit_key
+
+    result = verify_escalation_receipt(
+        sdd_dir=workdir / ".sdd",
+        lineage_root=workdir / ".sdd" / "lineage",
+        hmac_key=load_or_create_audit_key(),
+        receipt_id=receipt_path.stem,
+    )
+    return result.ok, result.reason
+
+
+# ---------------------------------------------------------------------------
+# Ordering: verdict -> kill -> receipt, chained off the verdict
+# ---------------------------------------------------------------------------
+
+
+def test_heartbeat_kill_emits_receipt_chained_off_verdict(tmp_path: Path) -> None:
+    """After a heartbeat kill the receipt event chains directly off the verdict."""
+    _build_journal(tmp_path)
+    orch = _heartbeat_orch(tmp_path, _session())
+    with patch("bernstein.core.platform_compat.kill_process_group"):
+        _escalate_heartbeat(
+            orch,
+            orch._agents["A-1"],
+            age=950.0,
+            elapsed=850.0,
+            shutdown_threshold=60.0,
+            wakeup_threshold=30.0,
+            shutdown_reason="no_heartbeat",
+            kill_threshold=90.0,
+        )
+
+    verdicts = _chain_verdicts(tmp_path)
+    receipts = _chain_receipts(tmp_path)
+    assert len(verdicts) == 1
+    assert len(receipts) == 1
+    # The receipt embeds the verdict's own HMAC as its predecessor.
+    assert receipts[0].details["prev_chain_digest"] == verdicts[0].hmac
+    ok, errors = AuditChainStore(tmp_path / ".sdd" / "audit").verify()
+    assert ok, errors
+    # A signed receipt landed on disk, one per kill.
+    assert len(_receipt_files(tmp_path)) == 1
+
+
+def test_signal_between_verdict_and_receipt(tmp_path: Path) -> None:
+    """At the moment the kill runs the verdict is recorded and no receipt yet."""
+    _build_journal(tmp_path)
+    orch = _heartbeat_orch(tmp_path, _session())
+
+    seen: dict[str, int] = {}
+
+    def fake_kill(session: object) -> None:
+        seen["verdicts_at_kill"] = len(_chain_verdicts(tmp_path))
+        seen["receipts_at_kill"] = len(_chain_receipts(tmp_path))
+
+    orch._spawner.kill.side_effect = fake_kill
+    _escalate_stall_simple(orch, orch._agents["A-1"], "T-1", count=AGENT.escalation_kill_count)
+
+    assert seen["verdicts_at_kill"] == 1
+    assert seen["receipts_at_kill"] == 0
+    assert len(_chain_receipts(tmp_path)) == 1
+    assert orch._spawner.kill.called
+
+
+# ---------------------------------------------------------------------------
+# Session link and the single verifier
+# ---------------------------------------------------------------------------
+
+
+def test_receipt_records_session_link_in_chain_and_on_disk(tmp_path: Path) -> None:
+    """The session link is read from the record, not reconstructed."""
+    _build_journal(tmp_path)
+    orch = _heartbeat_orch(tmp_path, _session(sid="B-7", task_id="T-9"))
+    _escalate_stall_simple(orch, orch._agents["B-7"], "T-9", count=AGENT.escalation_kill_count)
+
+    rows = _chain_receipts(tmp_path)
+    assert len(rows) == 1
+    assert rows[0].details["session_id"] == "B-7"
+    files = _receipt_files(tmp_path)
+    assert len(files) == 1
+    row = json.loads(files[0].read_text(encoding="utf-8"))
+    assert row["session_id"] == "B-7"
+    expected_worktree_id = hashlib.sha256(str(tmp_path.resolve()).encode("utf-8")).hexdigest()[:16]
+    assert row["worktree_id"] == expected_worktree_id
+
+
+def test_auto_receipt_verifies_with_the_same_verifier(tmp_path: Path) -> None:
+    """``verify_escalation_receipt`` accepts an automatic-path receipt unchanged."""
+    _build_journal(tmp_path)
+    orch = _heartbeat_orch(tmp_path, _session())
+    _escalate_stall_profiled(
+        orch,
+        orch._agents["A-1"],
+        "T-1",
+        count=7,
+        profile=StallProfile(wakeup_threshold=3, shutdown_threshold=5, kill_threshold=7, reason="default profile"),
+    )
+
+    files = _receipt_files(tmp_path)
+    assert len(files) == 1
+    ok, reason = _verify_auto_receipt(tmp_path, files[0])
+    assert ok, reason
+
+
+# ---------------------------------------------------------------------------
+# Best-effort contract: failure never blocks the kill
+# ---------------------------------------------------------------------------
+
+
+def test_missing_journal_kills_and_records_verdict_with_no_receipt(tmp_path: Path) -> None:
+    """No journal -> no receipt, but the kill happens, the verdict is recorded,
+    and exactly one warning names the session."""
+    orch = _heartbeat_orch(tmp_path, _session())
+    with patch("bernstein.core.agents.heartbeat.logger") as log:
+        _escalate_stall_simple(orch, orch._agents["A-1"], "T-1", count=AGENT.escalation_kill_count)
+
+    assert orch._spawner.kill.called
+    assert len(_chain_verdicts(tmp_path)) == 1
+    assert len(_chain_receipts(tmp_path)) == 0
+    assert _receipt_files(tmp_path) == []
+    warnings = [c for c in log.warning.call_args_list if "Could not emit escalation.receipt" in str(c.args[0])]
+    assert len(warnings) == 1
+    assert "A-1" in warnings[0].args
+
+
+def test_assembly_failure_never_blocks_the_kill(tmp_path: Path) -> None:
+    """A raising assembly leaves the kill issued and the chain failure loud."""
+    _build_journal(tmp_path)
+    orch = _heartbeat_orch(tmp_path, _session())
+    with (
+        patch("bernstein.core.orchestration.escalation.assemble_escalation_receipt", side_effect=RuntimeError("boom")),
+        patch("bernstein.core.agents.heartbeat.logger") as log,
+    ):
+        _escalate_stall_simple(orch, orch._agents["A-1"], "T-1", count=AGENT.escalation_kill_count)
+
+    assert orch._spawner.kill.called
+    assert _receipt_files(tmp_path) == []
+    warnings = [c for c in log.warning.call_args_list if "Could not emit escalation.receipt" in str(c.args[0])]
+    assert warnings
+    assert "A-1" in warnings[0].args
+
+
+def test_chain_failure_never_blocks_kill_or_signals(tmp_path: Path) -> None:
+    """With the chain store raising, the kill still happens and the SHUTDOWN
+    signal that follows is unchanged; the receipt failure is loud too."""
+    session = _session()
+    _build_journal(tmp_path)
+    from bernstein.core.agents.agent_signals import AgentSignalManager
+
+    orch = SimpleNamespace(
+        _agents={session.id: session},
+        _workdir=tmp_path,
+        _run_id=RUN_ID,
+        _signal_mgr=AgentSignalManager(tmp_path),
+        _spawner=MagicMock(),
+        _config=SimpleNamespace(heartbeat_enabled=True, heartbeat_timeout_s=60.0),
+    )
+    orch._signal_mgr.write_heartbeat("A-1", AgentHeartbeat(timestamp=1000.0, status="starting"))
+
+    with (
+        patch("bernstein.core.agents.heartbeat.time.time", return_value=1100.0),
+        patch("bernstein.core.platform_compat.kill_process_group") as kpg,
+        patch(
+            "bernstein.core.security.audit_chain.AuditChainStore",
+            side_effect=RuntimeError("audit backend down"),
+        ),
+        patch("bernstein.core.agents.heartbeat.logger") as log,
+    ):
+        check_stale_agents(orch)
+
+    assert kpg.called
+    shutdown_file = tmp_path / ".sdd" / "runtime" / "signals" / "A-1" / "SHUTDOWN"
+    assert shutdown_file.exists()
+    assert "no_heartbeat" in shutdown_file.read_text(encoding="utf-8")
+    receipt_warnings = [c for c in log.warning.call_args_list if "Could not emit escalation.receipt" in str(c.args[0])]
+    assert receipt_warnings, "an unrecorded receipt must stay observable via a warning"
+    assert "A-1" in receipt_warnings[0].args


### PR DESCRIPTION
PR body 
## What

Wire the built-in signed escalation receipt into the three automatic stall-kill
paths (heartbeat, simple-stall, profiled-stall) so a kill now leaves both a
`stall.verdict` (the decision, pre-kill) and an `escalation.receipt` (the
evidence, post-kill) on the HMAC audit chain. The operator can finally prove
*what the run saw*, not merely that it decided to kill.

## Why

Closes #3685. `record_escalation_receipt` already existed and mirrors a signed,
spine-anchored receipt (`journal_head_at_stall`, `window_size`,
`fork_snapshot_sha`, `journal_entry_hash`, `recommended_action`) into the chain,
but had no production caller. An automatic kill left a verdict with no
reconstructable failure window: provable adjudication, unprovable evidence.
This wires the existing recorder into the existing kill paths — no new
escalation surface, no notification path, no threshold/decision changes.

## How

- New best-effort `_emit_escalation_receipt` in `heartbeat.py`, shaped exactly
  like `_emit_stall_verdict` (single `except Exception`, warning naming the
  session, never re-raise, never delay/undo the kill). Called from the same
  three kill sites, **after** the kill: ordering is `stall.verdict` → signal →
  `escalation.receipt`, so nothing lengthens deciding-to-kill → killing.
- The receipt assembles the trailing journal window, is signed with the install
  escalation identity (`.sdd/escalation/`), and is mirrored into the audit
  chain chained directly off the preceding verdict (chain head is re-read from
  disk on append).
- `record_escalation_receipt` gains an optional `session_id` carried into the
  payload, so the verdict↔receipt link is explicit in the record, not inferred
  from `worker_id == session.id`.
- Failure semantics match the verdict: missing/empty journal → no receipt + one
  warning naming the session, kill unaffected; injected assembly or chain
  failure → kill + signals unaffected, warning logged. Empty `_run_id` → silent
  info skip (no journal to anchor).

### Worktree identity decision (per the issue's open question)

`worktree_id` is derived inline as `sha256(str(orch._workdir.resolve()))[:16]` —
the same convention `worktree_id_for` uses elsewhere. `AgentSession` has no
worktree field, and importing `worktree_id_for` from the skills catalogue would
couple the stall/audit path to the skills subsystem. Taking the path straight
from the orchestrator keeps the receipt attributable to the worktree that
processed the kill with zero cross-subsystem coupling.

### One ordering nuance worth flagging

In `_escalate_heartbeat`, the escalation ladder's SIGKILL fires just before the
verdict is recorded (pre-existing behavior, unchanged here), so the verdict is
the last non-receipt event before the receipt. The verdict→receipt adjacency
(not signal→receipt) is what the new tests assert and document.

## Checklist

- [x] `uv run ruff check src/` passes
- [ ] `uv run pyright src/` passes
- [ ] `uv run python scripts/run_tests.py -x` passes
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)

- [x] User-visible README section updated (N/A — internal audit/ops path)
- [x] `docs/operations/<area>.md` updated (added "Automatic kills emit
      receipts" to `docs/operations/stall-escalation.md`)
- [x] `docs/api/` schema regenerated if a public surface changed (N/A)
- [x] `uv run bernstein agents-md sync` run (N/A — no new module)
- [x] Tests cover the documented behaviour (`tests/unit/test_heartbeat_escalation_receipt.py`,
      + `session_id` assertions in `test_escalation_receipt.py`)