### PR TITLE
Bernsteinのモデル指定とWorkflowルーティングを拡張

### DIFF
--- a/docs/architecture/plans.md
+++ b/docs/architecture/plans.md
@@ -86,7 +86,7 @@ alias).
 | `priority` | int 1-5 | `2` | 1 = highest, 5 = lowest. Affects orchestrator ordering when multiple steps are ready. |
 | `scope` | enum | `medium` | `small` (<30min), `medium` (30-90min), `large` (90min+). Influences cost/model picks. |
 | `complexity` | enum | `medium` | `low`, `medium`, `high`. Drives router/cascade tier choice. |
-| `model` | string | - | Override model with an adapter/provider-specific identifier, such as `gpt-5.3-codex-spark` or `qwen/qwen3-coder`. |
+| `model` | string | - | Override model with an adapter/provider-specific identifier, such as `provider/model-name`. |
 | `effort` | enum | - | Effort knob: `low`, `normal`, `high`, `max`. |
 | `estimated_minutes` | int | `30` | Used by the duration predictor and plan cost estimate. |
 | `mode` | string | - | Execution mode (e.g. `batch`). |

--- a/docs/architecture/plans.md
+++ b/docs/architecture/plans.md
@@ -86,7 +86,7 @@ alias).
 | `priority` | int 1-5 | `2` | 1 = highest, 5 = lowest. Affects orchestrator ordering when multiple steps are ready. |
 | `scope` | enum | `medium` | `small` (<30min), `medium` (30-90min), `large` (90min+). Influences cost/model picks. |
 | `complexity` | enum | `medium` | `low`, `medium`, `high`. Drives router/cascade tier choice. |
-| `model` | enum | - | Override model: `auto`, `opus`, `sonnet`, `haiku`. |
+| `model` | string | - | Override model with an adapter/provider-specific identifier, such as `gpt-5.3-codex-spark` or `qwen/qwen3-coder`. |
 | `effort` | enum | - | Effort knob: `low`, `normal`, `high`, `max`. |
 | `estimated_minutes` | int | `30` | Used by the duration predictor and plan cost estimate. |
 | `mode` | string | - | Execution mode (e.g. `batch`). |
@@ -499,7 +499,7 @@ The plan loader validates fields strictly. This table documents the load-time be
 | `role` | Known role enum | Unknown string | — | — |
 | `scope` | Known scope enum | Unknown string | — | — |
 | `complexity` | Known complexity enum | Unknown string | — | — |
-| `model` | Known model enum | Unknown string | — | — |
+| `model` | Non-empty string | Empty or non-string value | — | — |
 | `effort` | Known effort enum | Unknown string | — | — |
 | `completion_signals` | `list[CompletionSignal]` | — | `[]` (if missing) | — |
 

--- a/docs/workflows/per-step-routing.md
+++ b/docs/workflows/per-step-routing.md
@@ -52,7 +52,7 @@ error rather than silently substituting a different one.
 ### `model`
 
 Pins the provider-specific model identifier for one step, such as
-`gpt-5.3-codex-spark` or `qwen/qwen3-coder`. When set,
+`provider/model-name`. When set,
 the cascade router skips its initial selection logic and uses the
 pinned model as attempt 0.
 

--- a/docs/workflows/per-step-routing.md
+++ b/docs/workflows/per-step-routing.md
@@ -21,15 +21,15 @@ orchestrator actually took.
 | Field | Type | Scope | Wins over |
 |-------|------|-------|-----------|
 | `cli` | string | One step | Top-level plan `cli:` and role policy. |
-| `model` | enum | One step | Cascade router initial pick. |
+| `model` | string | One step | Cascade router initial pick. |
 | `effort` | enum | One step | Cascade router effort default. |
 
 - Set them inside `steps:` in a plan YAML.
 - Leave them off when the step should follow the plan-wide default.
 - `bernstein.yaml` itself takes a top-level `cli:` only; the per-step
   override lives on each plan step.
-- Workflow manifests under `templates/workflows/*.yaml` do **not**
-  carry these fields today; see [Where it works](#where-it-works) below.
+- Workflow manifests under `templates/workflows/*.yaml` accept the same
+  fields on agent nodes; see [Where it works](#where-it-works) below.
 
 ---
 
@@ -51,9 +51,8 @@ error rather than silently substituting a different one.
 
 ### `model`
 
-Pins the model variant for one step: `auto`, `opus`, `sonnet`,
-`haiku`. Only meaningful when the resolved adapter is Claude-compatible
-(other adapters bind their own models and ignore this hint). When set,
+Pins the provider-specific model identifier for one step, such as
+`gpt-5.3-codex-spark` or `qwen/qwen3-coder`. When set,
 the cascade router skips its initial selection logic and uses the
 pinned model as attempt 0.
 
@@ -119,13 +118,13 @@ manager agent needed; the plan is the decomposition.
 | Plan YAML (`bernstein run --from-plan`) | Yes | Read in `plan_loader._parse_step`. Stored on the resulting `Task` row. |
 | `POST /tasks` on the task server | Yes | The HTTP payload accepts the same keys; the planner forwards them when it creates child tasks (`planner.py:86`). |
 | Manager-emitted plans | Yes | When the manager agent decomposes a goal it can stamp `cli` and `model` on individual steps. |
-| Workflow manifests (`templates/workflows/*.yaml`) | No | The declarative manifest schema validates with `extra="forbid"` (`workflow_spec.py`). Per-node routing is tracked separately; use a plan YAML when you need it today. |
+| Workflow manifests (`templates/workflows/*.yaml`) | Yes, on agent nodes | The manifest schema validates the fields and the runner forwards them to the spawned `Task`. |
 | `bernstein.yaml` | Top-level only | The seed file has one global `cli:`. Per-step routing belongs on the plan or task. |
 
-If you write a workflow manifest and need per-step routing, the
-recommended path is to author it as a plan YAML instead. Plans and
-workflows are sibling primitives that target different shapes; the
-plan loader is the one with full routing-hint support today.
+Plans and workflow manifests are sibling primitives: use a plan when the
+stage-oriented plan loader is the better fit, or a workflow manifest when
+you want an explicit node DAG. Both surfaces preserve routing hints on the
+resulting task.
 
 ---
 
@@ -150,13 +149,12 @@ The hint is dropped (silently or with a warning) in these cases:
 
 - The adapter named in `cli:` is not installed. The run aborts with a
   registry-miss error; it does **not** substitute `auto`.
-- `model:` / `effort:` are set on a step whose resolved adapter is not
-  Claude-compatible. The fields are accepted by the schema but the
-  non-Claude adapter ignores them. No warning today; track the actual
-  pick in the trace (next section).
-- Workflow manifest nodes carry `cli:` or `model:`. The manifest
-  loader rejects the file at validation time (`workflow_spec.py`
-  enforces `extra="forbid"`).
+- An adapter does not expose a flag for one of the requested hints. The
+  task still records the requested value; adapter-specific support is
+  visible in the actual spawn event in the trace (next section).
+- Command nodes carry `cli:`, `model:`, or `effort:`. These fields only
+  apply to agent nodes, so the manifest loader rejects them rather than
+  silently ignoring the configuration.
 
 ---
 

--- a/src/bernstein/adapters/pi.py
+++ b/src/bernstein/adapters/pi.py
@@ -43,8 +43,8 @@ class PiAdapter(CLIAdapter):
         Args:
             prompt: Task prompt passed as the single positional argument.
             workdir: Working directory for the agent process.
-            model_config: Model configuration (unused by ``pi`` which
-                selects its own model via its own settings).
+            model_config: Model and effort configuration. The selected model
+                is passed through to Pi when it is not ``auto``.
             session_id: Unique session identifier used for the log file.
             mcp_config: Unused. Pi manages its own integrations.
             timeout_seconds: Watchdog timeout in seconds.
@@ -63,7 +63,10 @@ class PiAdapter(CLIAdapter):
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
 
-        cmd = ["pi", prompt]
+        cmd = ["pi"]
+        if model_config.model and model_config.model.lower() != "auto":
+            cmd.extend(["--model", model_config.model])
+        cmd.append(prompt)
 
         pid_dir = workdir / ".sdd" / "runtime" / "pids"
         wrapped_cmd = build_worker_cmd(

--- a/src/bernstein/cli/commands/plan_validate_cmd.py
+++ b/src/bernstein/cli/commands/plan_validate_cmd.py
@@ -91,7 +91,7 @@ def _check_schema(plan_file: Path, errors: list[str], warnings: list[str]) -> No
 
     ``load_plan`` parses a plan; it does not judge it. It reads ``stages`` and
     ``steps`` and takes whatever it finds, so a plan with no ``name``, a
-    ``priority`` outside 1-5, or a role/model string that is not in the enum
+    ``priority`` outside 1-5, or a role string that is not in the enum
     parses cleanly and reaches every later check intact -- and those checks look
     at the task graph, not at the fields. Without this the command answers
     "Plan is valid." for a plan the scheduler will reject.

--- a/src/bernstein/core/planning/plan_schema.py
+++ b/src/bernstein/core/planning/plan_schema.py
@@ -43,8 +43,6 @@ SCOPE_VALUES: list[str] = ["small", "medium", "large"]
 
 COMPLEXITY_VALUES: list[str] = ["low", "medium", "high"]
 
-MODEL_VALUES: list[str] = ["auto", "opus", "sonnet", "haiku"]
-
 EFFORT_VALUES: list[str] = ["low", "normal", "high", "max"]
 
 PHASE_VALUES: list[str] = ["research", "plan", "implement", "verify"]
@@ -169,7 +167,7 @@ _STEP_SCHEMA: dict[str, Any] = {
         },
         "model": {
             "type": "string",
-            "enum": MODEL_VALUES,
+            "minLength": 1,
             "description": "Model override for this step.",
         },
         "effort": {
@@ -369,7 +367,6 @@ _STEP_ENUM_FIELDS: list[tuple[str, list[str]]] = [
     ("role", KNOWN_ROLES),
     ("scope", SCOPE_VALUES),
     ("complexity", COMPLEXITY_VALUES),
-    ("model", MODEL_VALUES),
     ("effort", EFFORT_VALUES),
 ]
 
@@ -388,6 +385,17 @@ def _validate_step_enums(step: dict[str, Any], path: str, errors: list[str]) -> 
             errors.append(f"{path}.{field_name}: expected type string, got {type(value).__name__}")
             continue
         _validate_enum(value, allowed, f"{path}.{field_name}", errors)
+
+
+def _validate_step_string_fields(step: dict[str, Any], path: str, errors: list[str]) -> None:
+    """Validate free-form string fields whose schema requires a value."""
+    if "model" not in step:
+        return
+    value = step["model"]
+    if not isinstance(value, str):
+        errors.append(f"{path}.model: expected type string, got {type(value).__name__}")
+    elif not value:
+        errors.append(f"{path}.model: must not be empty")
 
 
 def _validate_step_priority(step: dict[str, Any], path: str, errors: list[str]) -> None:
@@ -495,6 +503,7 @@ def _validate_step(step: dict[str, Any], path: str, errors: list[str]) -> None:
         errors.append(f"{path}: step must have a 'title' or 'goal' field")
 
     _validate_step_enums(step, path, errors)
+    _validate_step_string_fields(step, path, errors)
     _validate_step_priority(step, path, errors)
     _validate_step_estimated_minutes(step, path, errors)
 
@@ -646,8 +655,8 @@ def validate_plan(plan_data: dict[str, Any], warnings: list[str] | None = None) 
 
     Performs manual structural checks mirroring :data:`PLAN_JSON_SCHEMA`
     without requiring the ``jsonschema`` package. Enforced as errors: required
-    fields, field and array-item types, enum membership (including the string
-    type of every enum field), and the declared minimums (``max_agents``,
+    fields, field and array-item types, enum membership, string types, and the
+    declared minimums (``max_agents``,
     ``priority``, ``estimated_minutes``). The schema's ``additionalProperties:
     false`` is reported through *warnings* instead, because plans carrying
     extra keys validate today and failing them needs a deprecation window

--- a/src/bernstein/core/workflows/workflow_runner.py
+++ b/src/bernstein/core/workflows/workflow_runner.py
@@ -495,6 +495,9 @@ class WorkflowRunner:
             title=f"workflow:{node.id}",
             description=prompt_body,
             role=node.agent,
+            cli=node.cli,
+            model=node.model,
+            effort=node.effort,
         )
 
         try:

--- a/src/bernstein/core/workflows/workflow_spec.py
+++ b/src/bernstein/core/workflows/workflow_spec.py
@@ -111,6 +111,9 @@ class WorkflowNode(BaseModel):
         prompt: Prompt body for agent-typed nodes.  May contain the
             ``{goal}`` placeholder which the runner substitutes from
             ``WorkflowRunner.run(goal=...)``.
+        cli: Optional adapter override for this node.
+        model: Optional provider-specific model identifier for this node.
+        effort: Optional reasoning-effort override for this node.
         loop: Optional loop predicate.  When set the node re-fires.
         fresh_context: When ``True``, agent-typed nodes get a fresh
             session per iteration (no carryover).  Ignored for command-
@@ -132,6 +135,9 @@ class WorkflowNode(BaseModel):
     command: str | None = None
     agent: str | None = None
     prompt: str | None = None
+    cli: str | None = Field(default=None, min_length=1, max_length=128)
+    model: str | None = Field(default=None, min_length=1, max_length=256)
+    effort: str | None = Field(default=None, min_length=1, max_length=32)
     loop: LoopSpec | None = None
     fresh_context: bool = False
     interactive: bool = False
@@ -169,6 +175,15 @@ class WorkflowNode(BaseModel):
             )
         if has_command and self.prompt is not None:
             raise ValueError(f"node {self.id!r} sets 'command'; 'prompt' is not allowed")
+        if has_command:
+            routing_fields = [
+                name for name, value in (("cli", self.cli), ("model", self.model), ("effort", self.effort)) if value
+            ]
+            if routing_fields:
+                fields = ", ".join(repr(name) for name in routing_fields)
+                raise ValueError(
+                    f"node {self.id!r} sets 'command'; routing fields {fields} require an agent node",
+                )
         if has_agent and (self.prompt is None or self.prompt.strip() == ""):
             raise ValueError(f"node {self.id!r} sets 'agent'; 'prompt' is required")
         if self.id in set(self.depends_on):

--- a/tests/integration/test_workflow_runner.py
+++ b/tests/integration/test_workflow_runner.py
@@ -297,7 +297,7 @@ nodes:
     agent: reviewer
     prompt: "Review {goal}"
     cli: pi
-    model: qwen/qwen3-coder
+    model: provider/model-name
     effort: high
 """
     )
@@ -306,7 +306,7 @@ nodes:
     assert execution.succeeded is True
     assert len(captured) == 1
     assert captured[0].cli == "pi"
-    assert captured[0].model == "qwen/qwen3-coder"
+    assert captured[0].model == "provider/model-name"
     assert captured[0].effort == "high"
 
 

--- a/tests/integration/test_workflow_runner.py
+++ b/tests/integration/test_workflow_runner.py
@@ -276,6 +276,40 @@ nodes:
     assert any("@iter2" in tid for tid in captured)
 
 
+def test_agent_node_forwards_routing_hints_to_task(runner_workdir: Path) -> None:
+    """Workflow routing hints reach the Task handed to the spawner."""
+    captured: list[Any] = []
+
+    class StubSpawner:
+        def spawn_for_tasks(self, tasks: list[Any]) -> Any:
+            captured.append(tasks[0])
+            session = MagicMock()
+            session.id = "sess-routed"
+            return session
+
+    spec = _spec_from(
+        """
+name: routed-agent
+description: "Route one workflow node"
+version: "1.0.0"
+nodes:
+  - id: review
+    agent: reviewer
+    prompt: "Review {goal}"
+    cli: pi
+    model: qwen/qwen3-coder
+    effort: high
+"""
+    )
+    execution = WorkflowRunner(spawner=StubSpawner(), workdir=runner_workdir).run(spec, goal="the patch")
+
+    assert execution.succeeded is True
+    assert len(captured) == 1
+    assert captured[0].cli == "pi"
+    assert captured[0].model == "qwen/qwen3-coder"
+    assert captured[0].effort == "high"
+
+
 # ---------------------------------------------------------------------------
 # Interactive stub for #1110
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_adapter_pi.py
+++ b/tests/unit/test_adapter_pi.py
@@ -28,8 +28,21 @@ class TestPiAdapterSpawn:
             adapter.spawn(
                 prompt="fix the bug",
                 workdir=tmp_path,
-                model_config=ModelConfig(model="sonnet", effort="high"),
+                model_config=ModelConfig(model="qwen/qwen3-coder", effort="high"),
                 session_id="pi-s1",
+            )
+        inner = inner_cmd(popen.call_args.args[0])
+        assert inner == ["pi", "--model", "qwen/qwen3-coder", "fix the bug"]
+
+    def test_spawn_leaves_model_selection_to_pi_for_auto(self, tmp_path: Path) -> None:
+        adapter = PiAdapter()
+        proc_mock = make_popen_mock(pid=801)
+        with patch("bernstein.adapters.pi.subprocess.Popen", return_value=proc_mock) as popen:
+            adapter.spawn(
+                prompt="fix the bug",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="auto", effort="high"),
+                session_id="pi-s2",
             )
         inner = inner_cmd(popen.call_args.args[0])
         assert inner == ["pi", "fix the bug"]

--- a/tests/unit/test_adapter_pi.py
+++ b/tests/unit/test_adapter_pi.py
@@ -28,11 +28,11 @@ class TestPiAdapterSpawn:
             adapter.spawn(
                 prompt="fix the bug",
                 workdir=tmp_path,
-                model_config=ModelConfig(model="qwen/qwen3-coder", effort="high"),
+                model_config=ModelConfig(model="provider/model-name", effort="high"),
                 session_id="pi-s1",
             )
         inner = inner_cmd(popen.call_args.args[0])
-        assert inner == ["pi", "--model", "qwen/qwen3-coder", "fix the bug"]
+        assert inner == ["pi", "--model", "provider/model-name", "fix the bug"]
 
     def test_spawn_leaves_model_selection_to_pi_for_auto(self, tmp_path: Path) -> None:
         adapter = PiAdapter()

--- a/tests/unit/test_plan_schema.py
+++ b/tests/unit/test_plan_schema.py
@@ -12,7 +12,6 @@ from bernstein.core.plan_schema import (
     COMPLEXITY_VALUES,
     EFFORT_VALUES,
     KNOWN_ROLES,
-    MODEL_VALUES,
     PLAN_JSON_SCHEMA,
     SCOPE_VALUES,
     generate_schema_file,
@@ -82,9 +81,10 @@ class TestSchemaStructure:
         step_schema = PLAN_JSON_SCHEMA["properties"]["stages"]["items"]["properties"]["steps"]["items"]
         assert step_schema["properties"]["complexity"]["enum"] == COMPLEXITY_VALUES
 
-    def test_schema_step_model_enum(self) -> None:
+    def test_schema_step_model_is_free_form_string(self) -> None:
         step_schema = PLAN_JSON_SCHEMA["properties"]["stages"]["items"]["properties"]["steps"]["items"]
-        assert step_schema["properties"]["model"]["enum"] == MODEL_VALUES
+        assert step_schema["properties"]["model"]["type"] == "string"
+        assert "enum" not in step_schema["properties"]["model"]
 
     def test_schema_step_effort_enum(self) -> None:
         step_schema = PLAN_JSON_SCHEMA["properties"]["stages"]["items"]["properties"]["steps"]["items"]
@@ -250,11 +250,17 @@ class TestValidatePlanInvalidEnums:
         errors = validate_plan(plan)
         assert any("complexity" in e and "extreme" in e for e in errors)
 
-    def test_invalid_model(self) -> None:
+    def test_arbitrary_model_identifier_is_valid(self) -> None:
         plan = _minimal_plan()
-        plan["stages"][0]["steps"][0]["model"] = "gpt-4"
+        plan["stages"][0]["steps"][0]["model"] = "gpt-5.3-codex-spark"
         errors = validate_plan(plan)
-        assert any("model" in e and "gpt-4" in e for e in errors)
+        assert errors == []
+
+    def test_empty_model_identifier_is_invalid(self) -> None:
+        plan = _minimal_plan()
+        plan["stages"][0]["steps"][0]["model"] = ""
+        errors = validate_plan(plan)
+        assert any("model" in e and "empty" in e for e in errors)
 
     def test_invalid_effort(self) -> None:
         plan = _minimal_plan()

--- a/tests/unit/test_plan_schema.py
+++ b/tests/unit/test_plan_schema.py
@@ -252,7 +252,7 @@ class TestValidatePlanInvalidEnums:
 
     def test_arbitrary_model_identifier_is_valid(self) -> None:
         plan = _minimal_plan()
-        plan["stages"][0]["steps"][0]["model"] = "gpt-5.3-codex-spark"
+        plan["stages"][0]["steps"][0]["model"] = "provider/model-name"
         errors = validate_plan(plan)
         assert errors == []
 

--- a/tests/unit/test_plan_validate.py
+++ b/tests/unit/test_plan_validate.py
@@ -308,7 +308,6 @@ class TestOutOfRangeEnumValues:
         [
             pytest.param("complexity", "epic", id="complexity"),
             pytest.param("scope", "galactic", id="scope"),
-            pytest.param("model", "gpt9000", id="model"),
             pytest.param("effort", "turbo", id="effort"),
         ],
     )
@@ -341,6 +340,39 @@ class TestOutOfRangeEnumValues:
         assert value in result.output
         assert "Traceback" not in result.output
         assert result.exception is None or isinstance(result.exception, SystemExit)
+
+    def test_arbitrary_model_identifier_is_valid_at_command_surface(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        from bernstein.cli.main import cli
+
+        plan_file = _write_plan(
+            tmp_path,
+            {
+                "name": "Arbitrary Model Plan",
+                "stages": [
+                    {
+                        "name": "Stage 1",
+                        "steps": [
+                            {
+                                "title": "Task A",
+                                "role": "backend",
+                                "model": "provider/model-name",
+                            },
+                        ],
+                    },
+                ],
+            },
+        )
+
+        result = runner.invoke(cli, ["plan", "validate", str(plan_file)])
+
+        assert result.exit_code == 0
+        assert "Plan is valid." in result.output
+        assert "Traceback" not in result.output
+        assert result.exception is None
 
 
 class TestSchemaParityAtTheCommand:

--- a/tests/unit/test_workflow_spec.py
+++ b/tests/unit/test_workflow_spec.py
@@ -206,12 +206,12 @@ nodes:
     agent: reviewer
     prompt: "Review the change"
     cli: pi
-    model: qwen/qwen3-coder
+    model: provider/model-name
     effort: high
 """
     node = load_workflow_spec_from_text(text).nodes[0]
     assert node.cli == "pi"
-    assert node.model == "qwen/qwen3-coder"
+    assert node.model == "provider/model-name"
     assert node.effort == "high"
 
 
@@ -224,7 +224,7 @@ version: "1.0.0"
 nodes:
   - id: tests
     command: "pytest"
-    model: qwen/qwen3-coder
+    model: provider/model-name
 """
     with pytest.raises(WorkflowSpecError, match="require an agent node"):
         load_workflow_spec_from_text(text)

--- a/tests/unit/test_workflow_spec.py
+++ b/tests/unit/test_workflow_spec.py
@@ -195,6 +195,41 @@ nodes:
         load_workflow_spec_from_text(text)
 
 
+def test_agent_node_accepts_routing_hints() -> None:
+    """Agent nodes may pin an adapter, model, and effort independently."""
+    text = """
+name: routed
+description: "Agent routing hints"
+version: "1.0.0"
+nodes:
+  - id: review
+    agent: reviewer
+    prompt: "Review the change"
+    cli: pi
+    model: qwen/qwen3-coder
+    effort: high
+"""
+    node = load_workflow_spec_from_text(text).nodes[0]
+    assert node.cli == "pi"
+    assert node.model == "qwen/qwen3-coder"
+    assert node.effort == "high"
+
+
+def test_command_node_rejects_routing_hints() -> None:
+    """Routing hints must not be silently ignored on command nodes."""
+    text = """
+name: invalid-routing
+description: "Command routing hints"
+version: "1.0.0"
+nodes:
+  - id: tests
+    command: "pytest"
+    model: qwen/qwen3-coder
+"""
+    with pytest.raises(WorkflowSpecError, match="require an agent node"):
+        load_workflow_spec_from_text(text)
+
+
 def test_command_node_rejects_prompt() -> None:
     """Command-typed nodes carrying a prompt must be rejected."""
     text = """


### PR DESCRIPTION
## 目的

BernsteinのRuntimeに任意のモデル指定とWorkflow単位のルーティングを任せられるようにする。

## 変更内容

- Pi adapterで `auto` 以外のモデルを `pi --model ...` に渡す
- Planの `model` を固定enumから非空の任意文字列へ変更
- Workflowのagent nodeで `cli` / `model` / `effort` を受け付け、生成するTaskへ引き継ぐ
- command nodeでのルーティング指定はロード時に拒否
- 対応テストとドキュメントを更新

## 検証内容

- 対象テスト: 131 passed
- Ruff check: passed
- 変更対象PythonのRuff format check: passed
- import-linter: passed
- strict Pyright: 0 errors
- `uv build`: passed

## 未検証事項・既知の制約

- 全量pytestは既存の狭いTTY向け起動バナー試験 `tests/unit/cli/test_startup_banner_blockart.py` で失敗（変更対象外）
- 全体のformat checkも既存の `tests/unit/test_cli_demo.py` が未整形のため通過しない（変更対象外）
- Piのeffort指定は今回の対象外で、Workflow Taskへの引き継ぎまでとする