### PR TITLE
feat(lineage): anchor external reference extractor identity (#3697)

### DIFF
--- a/docs/lineage/artifacts.md
+++ b/docs/lineage/artifacts.md
@@ -66,6 +66,22 @@ content_hash = external_reference_content_hash(
 )
 ```
 
+An external reference consumed as *text* (an HTML page, a PDF, a rendered
+doc) reaches the agent through an extractor. Record the extractor identity
+too, so the content address changes when the extraction changes:
+
+```python
+content_hash = external_reference_content_hash(
+    "doc://example.test/lineage",
+    digest="sha256:" + page_sha256,
+    extractor="html-readability@2.4.1",     # stable "id@version", passed deliberately
+)
+```
+
+A reference with no extraction step (a commit SHA, an image digest) must
+omit `extractor`; an empty string is refused, because it would silently
+change the content address of every such reference.
+
 The digest must name its algorithm (`sha1`, `sha256` or `sha512`); a bare hex
 string is ambiguous, and an ambiguous anchor is not an anchor. Entries recorded
 this way carry `artefact_kind="external"`.

--- a/src/bernstein/core/lineage/artifact_uri.py
+++ b/src/bernstein/core/lineage/artifact_uri.py
@@ -539,7 +539,7 @@ def _normalise_digest(digest: str) -> str:
     return f"{alg}:{hexpart}"
 
 
-def external_reference_bytes(uri: str, *, digest: str) -> bytes:
+def external_reference_bytes(uri: str, *, digest: str, extractor: str | None = None) -> bytes:
     """Return the canonical reference document anchoring an external artifact.
 
     An external artifact's bytes do not live in the worktree, so the lineage
@@ -553,18 +553,35 @@ def external_reference_bytes(uri: str, *, digest: str) -> bytes:
     anchoring the same artifact at the same digest derive byte-identical bytes
     and therefore the same content address.
 
+    When an external reference is consumed as extracted text rather than as an
+    opaque digest -- an HTML page rendered by an extractor, a PDF, a fetched
+    document -- the bytes are only half the evidence: the same bytes through a
+    different extractor yield different text in front of the model. Pass
+    ``extractor`` (a stable identity string naming the extractor and its
+    version, e.g. ``"html-readability@2.4.1"``) and it joins the canonical
+    document, so the content address changes when the extraction changes. A
+    reference with no extraction step (a commit SHA, an image digest) must
+    omit it -- an empty-string default would silently change its content
+    address and is refused. The caller passes the version deliberately: a
+    library ``__version__`` read at runtime can differ across install methods,
+    which would give two operators different content addresses for identical
+    evidence, violating the determinism property below.
+
     Args:
         uri: An external artifact URI (``pr``/``pkg``/``deploy``/``doc``).
         digest: The referenced content digest as ``<alg>:<hex>``.
+        extractor: Optional stable extractor identity (``"id@version"``)
+            for references consumed as extracted text. ``None`` when the
+            reference is anchored as an opaque digest.
 
     Returns:
         RFC 8785-style canonical JSON bytes (sorted keys, minimal separators).
 
     Raises:
-        ArtifactURIError: When ``uri`` is a repo key or either input is
-            malformed. A repo artifact is anchored by its own bytes, so
-            referencing it here would create a second, weaker anchor for
-            content the chain can hash directly.
+        ArtifactURIError: When ``uri`` is a repo key, either input is
+            malformed, or ``extractor`` is empty. A repo artifact is anchored
+            by its own bytes, so referencing it here would create a second,
+            weaker anchor for content the chain can hash directly.
     """
     key = parse_artifact_key(uri)
     if key.is_repo:
@@ -572,18 +589,27 @@ def external_reference_bytes(uri: str, *, digest: str) -> bytes:
             f"repo artifacts are anchored by their own bytes, not by reference: {uri!r}",
             reason=REASON_MALFORMED_URI,
         )
-    document = {
+    if extractor is not None and not extractor:
+        raise ArtifactURIError(
+            "extractor identity must be non-empty when provided",
+            reason=REASON_MALFORMED_URI,
+        )
+    document: dict[str, str | int] = {
         "artifact_uri": key.canonical,
         "digest": _normalise_digest(digest),
         "v": _REFERENCE_VERSION,
     }
+    if extractor is not None:
+        document["extractor"] = extractor
     return json.dumps(document, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
 
 
-def external_reference_content_hash(uri: str, *, digest: str) -> str:
+def external_reference_content_hash(uri: str, *, digest: str, extractor: str | None = None) -> str:
     """Return the ``sha256:``-prefixed content address of an external reference.
 
     This is the value a lineage entry records as its ``content_hash`` for an
-    ``external`` artefact kind. Deterministic across hosts.
+    ``external`` artefact kind. Deterministic across hosts. ``extractor`` is
+    forwarded to :func:`external_reference_bytes`; see its docstring for when
+    a reference consumed as extracted text must carry it.
     """
-    return "sha256:" + hashlib.sha256(external_reference_bytes(uri, digest=digest)).hexdigest()
+    return "sha256:" + hashlib.sha256(external_reference_bytes(uri, digest=digest, extractor=extractor)).hexdigest()

--- a/tests/unit/lineage/test_artifact_uri.py
+++ b/tests/unit/lineage/test_artifact_uri.py
@@ -466,3 +466,63 @@ def test_repo_artifacts_are_not_anchored_by_reference() -> None:
     second, weaker identity for content the chain can hash directly."""
     with pytest.raises(ArtifactURIError):
         external_reference_content_hash("src/a.py", digest="sha256:" + "ab" * 32)
+
+
+def test_external_reference_extractor_absent_keeps_legacy_address() -> None:
+    """A reference with no extraction step must serialise the extractor as
+    ABSENT, not as an empty string -- an empty-string default would silently
+    change its content address and is the most likely way to get this wrong."""
+    uri = "pkg://pypi/bernstein/3.9.0"
+    digest = "sha256:" + "ab" * 32
+    assert external_reference_bytes(uri, digest=digest) == (
+        b'{"artifact_uri":"pkg://pypi/bernstein/3.9.0","digest":"sha256:' + b"ab" * 32 + b'","v":1}'
+    )
+    assert external_reference_content_hash(uri, digest=digest) == external_reference_content_hash(
+        uri, digest=digest, extractor=None
+    )
+
+
+def test_external_reference_extractor_is_deterministic() -> None:
+    """Same URI + same digest + same extractor => same content address."""
+    uri = "doc://example.test/lineage"
+    digest = "sha256:" + "cd" * 32
+    a = external_reference_content_hash(uri, digest=digest, extractor="html-readability@2.4.1")
+    b = external_reference_content_hash(uri, digest=digest, extractor="html-readability@2.4.1")
+    assert a == b
+
+
+def test_external_reference_extractor_version_changes_address() -> None:
+    """Changing only the extractor version => different content address."""
+    uri = "doc://example.test/lineage"
+    digest = "sha256:" + "cd" * 32
+    a = external_reference_content_hash(uri, digest=digest, extractor="html-readability@2.4.1")
+    b = external_reference_content_hash(uri, digest=digest, extractor="html-readability@2.5.0")
+    assert a != b
+
+
+def test_external_reference_extractor_changes_address_from_absent() -> None:
+    """Adding an extractor to a reference that had none changes the address."""
+    uri = "doc://example.test/lineage"
+    digest = "sha256:" + "cd" * 32
+    plain = external_reference_content_hash(uri, digest=digest)
+    extracted = external_reference_content_hash(uri, digest=digest, extractor="html-readability@2.4.1")
+    assert plain != extracted
+
+
+def test_external_reference_extractor_joins_canonical_document() -> None:
+    """The extractor identity lands inside the hashed document (sorted keys)."""
+    payload = external_reference_bytes(
+        "pr://github.com/acme/widget/1", digest="sha1:" + "cd" * 20, extractor="git@1.0.0"
+    )
+    assert payload == (
+        b'{"artifact_uri":"pr://github.com/acme/widget/1","digest":"sha1:'
+        + b"cd" * 20
+        + b'","extractor":"git@1.0.0","v":1}'
+    )
+
+
+def test_external_reference_empty_extractor_is_refused() -> None:
+    """An empty-string extractor is refused: absent and empty must not
+    collapse into the same serialised document."""
+    with pytest.raises(ArtifactURIError):
+        external_reference_bytes("pkg://pypi/x/1.0", digest="sha256:" + "ab" * 32, extractor="")


### PR DESCRIPTION
## Summary

Closes #3697. External references consumed as extracted text (HTML, PDF, rendered docs) now anchor the extractor identity inside the canonical reference document, so the content address changes when the extraction changes.

## Decision notes

- **Field placement**: inside the hashed document (per the issue's "Why this shape" — recording it alongside the entry would leave the address unchanged and buy nothing).
- **Persisted-address survey (issue's step 4)**: `external_reference_content_hash`/`external_reference_bytes` have **no in-tree callers** in `src/` (exported via `__init__.py`, referenced only in docstrings), and no fixture/snapshot pins an external-reference content address. In-place field addition is therefore safe — no version discriminator needed. Documented in the docstring.
- **Absent vs empty**: references with no extraction step (commit SHA, image digest) serialise the field as **absent**; an empty-string value is refused with `ArtifactURIError` — the issue's most-likely-way-to-get-this-wrong guard.
- **Determinism**: caller passes a stable `"id@version"` string deliberately; no runtime `__version__` reads (can differ across install methods, violating the docstring's byte-identical-across-operators property). No host path, no timestamp — existing canonical-JSON sorting keeps RFC 8785 shape.

## Scope

- `src/bernstein/core/lineage/artifact_uri.py` — `external_reference_bytes`/`external_reference_content_hash` gain optional `extractor: str | None = None`; `"extractor"` key joins the canonical document only when provided.
- `tests/unit/lineage/test_artifact_uri.py` — 6 new tests: absent keeps legacy address (exact byte assertion), same URI+digest+extractor => same address, extractor version change => different address, absent→present changes address, canonical document byte shape, empty string refused.
- `docs/lineage/artifacts.md` — documents the extractor parameter.

## Verification

- `uv run pytest tests/unit/lineage/test_artifact_uri.py tests/unit/lineage/test_artifact_uri_boundaries.py tests/unit/lineage/test_entry.py tests/unit/lineage/test_store.py` — 204 passed (incl. 6 new)
- `uv run ruff check` / `ruff format --check` — clean
- `uv run mypy src/bernstein/core/lineage/artifact_uri.py` — clean

No callers to update (none exist); AGENTS.md entry-shape doc unchanged (entry shape untouched).

_Generated with AI assistance; reviewed by the author._
