### PR TITLE
fix(observability): redact credentials before trace persistence

### DIFF
--- a/docs/observability/trace-store.md
+++ b/docs/observability/trace-store.md
@@ -38,6 +38,21 @@ JSON) without paying for one.
   runs `bernstein trace verify <id>` explicitly. The explicit verify
   command remains for an on-demand check that returns a boolean.
 
+## Credential safety
+
+Both live trace persistence and the content-addressed archive redact PII and
+credential-shaped text before writing. This covers authorization headers,
+known API-key prefixes, private-key blocks, and random-looking values assigned
+to names containing `token`, `secret`, `password`, or `key`. Entropy by itself
+does not trigger redaction, so ordinary content hashes, UUIDs, and base64
+payloads remain intact.
+
+For content-addressed blobs, redaction happens before sha256 calculation. The
+index digest therefore identifies the exact safe bytes on disk, and a redacted
+trace continues to pass `store.verify()`. Debug and ticket bundles copy these
+already-redacted trace bytes; they cannot restore a credential removed at the
+write boundary.
+
 ## CLI
 
 | Command                                | What it does                                      |

--- a/src/bernstein/core/observability/log_redact.py
+++ b/src/bernstein/core/observability/log_redact.py
@@ -1,7 +1,8 @@
-"""PII redaction filter for Python logging.
+"""PII and credential redaction for logging and persisted traces.
 
 Installs a ``logging.Filter`` on the root logger that automatically replaces
-email addresses, phone numbers, SSNs, and credit card numbers with
+email addresses, phone numbers, SSNs, credit card numbers, and credential
+shapes with
 ``[REDACTED]`` before log records are emitted.
 
 Usage::
@@ -19,7 +20,9 @@ text - no PII is ever written to disk or stdout.
 from __future__ import annotations
 
 import logging
+import math
 import re
+from collections import Counter
 from typing import Any
 
 # ---------------------------------------------------------------------------
@@ -47,6 +50,26 @@ _PII_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
 
 _REDACTED = "[REDACTED]"
 
+# Credential matches deliberately require either a known prefix/header/block or
+# a sensitive field name.  Entropy alone is not a signal: content hashes,
+# UUIDs, and base64 payloads are legitimate trace data and must remain stable.
+_AUTHORIZATION_PATTERN = re.compile(
+    r"((?<![A-Za-z0-9_.-])[\"']?authorization[\"']?\s*:\s*[\"']?[A-Za-z][A-Za-z0-9._~-]*\s+)"
+    r"[^\s\"'\\,}]+",
+    re.IGNORECASE,
+)
+_PREFIXED_CREDENTIAL_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9])(?:sk-[A-Za-z0-9_-]{16,}|gh[pousr]_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16})(?![A-Za-z0-9])"
+)
+_PRIVATE_KEY_PATTERN = re.compile(
+    r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----",
+    re.DOTALL,
+)
+_NAMED_VALUE_PATTERN = re.compile(
+    r"(?P<prefix>(?<![A-Za-z0-9_.-])(?P<quote>[\"']?)(?P<name>[A-Za-z_][A-Za-z0-9_.-]*)"
+    r"(?P=quote)\s*(?:=|:)\s*[\"']?)(?P<value>[^\s\"',}\]]{16,})(?P<suffix>[\"']?)"
+)
+
 
 # ---------------------------------------------------------------------------
 # Core redaction
@@ -68,10 +91,55 @@ def redact_pii(text: str) -> str:
     return result
 
 
+def _is_sensitive_name(name: str) -> bool:
+    """Return whether *name* explicitly denotes credential material."""
+    snake_name = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", name)
+    parts = {part for part in re.split(r"[_.-]+", snake_name.casefold()) if part}
+    return bool(parts & {"token", "secret", "password", "key"}) or {"api", "key"} <= parts
+
+
+def _looks_high_entropy(value: str) -> bool:
+    """Conservatively identify random-looking assigned credential values."""
+    if len(value) < 16 or len(set(value)) < 8:
+        return False
+    counts = Counter(value)
+    entropy = -sum((count / len(value)) * math.log2(count / len(value)) for count in counts.values())
+    return entropy >= 3.5
+
+
+def _redact_named_value(match: re.Match[str]) -> str:
+    name = match.group("name")
+    value = match.group("value")
+    if not _is_sensitive_name(name) or not _looks_high_entropy(value):
+        return match.group(0)
+    return f"{match.group('prefix')}{_REDACTED}{match.group('suffix')}"
+
+
+def redact_sensitive_text(text: str) -> str:
+    """Redact PII and credential-shaped material from arbitrary text.
+
+    Known credential prefixes, authorization headers, and private-key blocks
+    are always removed. Random-looking values are removed only when assigned
+    to an explicitly sensitive name, preventing entropy-only false positives
+    on hashes, UUIDs, and ordinary base64 trace data.
+    """
+    result = redact_pii(text)
+    result = _PRIVATE_KEY_PATTERN.sub(_REDACTED, result)
+    result = _AUTHORIZATION_PATTERN.sub(rf"\1{_REDACTED}", result)
+    result = _PREFIXED_CREDENTIAL_PATTERN.sub(_REDACTED, result)
+    return _NAMED_VALUE_PATTERN.sub(_redact_named_value, result)
+
+
+def redact_sensitive_bytes(data: bytes) -> bytes:
+    """Redact textual credential shapes while preserving non-UTF-8 bytes."""
+    text = data.decode("utf-8", errors="surrogateescape")
+    return redact_sensitive_text(text).encode("utf-8", errors="surrogateescape")
+
+
 def _redact_arg(value: Any) -> Any:
     """Redact a single log-record format argument if it's a string."""
     if isinstance(value, str):
-        return redact_pii(value)
+        return redact_sensitive_text(value)
     return value
 
 
@@ -90,7 +158,7 @@ class PiiRedactingFilter(logging.Filter):
 
     def filter(self, record: logging.LogRecord) -> bool:
         if isinstance(record.msg, str):
-            record.msg = redact_pii(record.msg)
+            record.msg = redact_sensitive_text(record.msg)
 
         if record.args is not None:
             if isinstance(record.args, dict):

--- a/src/bernstein/core/observability/trace_store.py
+++ b/src/bernstein/core/observability/trace_store.py
@@ -49,6 +49,7 @@ import logging
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any, Final
 
+from bernstein.core.observability.log_redact import redact_sensitive_bytes
 from bernstein.core.persistence.cas_store import CASIntegrityError
 
 if TYPE_CHECKING:
@@ -350,8 +351,11 @@ class ContentAddressedTraceStore:
         if not isinstance(trace_bytes, (bytes, bytearray)):
             msg = "trace_bytes must be bytes"
             raise TypeError(msg)
-        # Normalise bytearray to bytes; passthrough for bytes is a no-op.
-        raw = bytes(trace_bytes) if isinstance(trace_bytes, bytearray) else trace_bytes
+        # Redaction precedes content addressing.  The digest identifies the
+        # exact safe bytes stored and later verified; hashing first would make
+        # a redacted blob fail its own receipt.
+        incoming = bytes(trace_bytes) if isinstance(trace_bytes, bytearray) else trace_bytes
+        raw = redact_sensitive_bytes(incoming)
         sha256 = hashlib.sha256(raw).hexdigest()
 
         existing = self._existing_blob_path(sha256)

--- a/src/bernstein/core/observability/traces.py
+++ b/src/bernstein/core/observability/traces.py
@@ -17,6 +17,8 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Literal, cast
 
+from bernstein.core.observability.log_redact import redact_sensitive_text
+
 _JSONL_GLOB = "*.jsonl"
 
 logger = logging.getLogger(__name__)
@@ -384,7 +386,10 @@ class TraceStore:
                 # Single field, top-level, JSON-serialisable.  Doesn't
                 # collide with any existing ``AgentTrace`` field name.
                 payload["_rev"] = header["_rev"]
-        data = json.dumps(payload)
+        # Redact before any bytes reach either live trace location.  Both the
+        # direct lookup file and per-task JSONL therefore persist identical,
+        # credential-safe bytes.
+        data = redact_sensitive_text(json.dumps(payload))
 
         # Write per-trace file (overwrites on update)
         self._path_for_trace(trace.trace_id).write_text(data + "\n")

--- a/tests/unit/cli/test_debug_bundle.py
+++ b/tests/unit/cli/test_debug_bundle.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from bernstein.core.traces import TraceStep, TraceStore, new_trace
 from click.testing import CliRunner
 
 from bernstein.cli.debug_bundle import (
@@ -138,6 +139,29 @@ def test_bernstein_yaml_secrets_are_redacted(tmp_path: Path, monkeypatch: pytest
     assert secret_value not in body
     assert "REDACTED" in body
     assert manifest["redactions_applied"] >= 1
+
+
+def test_persisted_trace_secret_cannot_reappear_in_debug_bundle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    canary = "ghp_0123456789abcdefghijklmnopqrstuv"
+    store = TraceStore(tmp_path / ".sdd" / "traces")
+    trace = new_trace("run-secret", ["task-secret"], "backend", "sonnet", "high")
+    trace.steps.append(
+        TraceStep(type="verify", timestamp=1.0, detail=f"Authorization: Bearer {canary}")
+    )
+    store.write(trace)
+    (tmp_path / ".sdd" / "runtime").mkdir(parents=True)
+    (tmp_path / ".sdd" / "runtime" / "run_id").write_text("task-secret\n", encoding="utf-8")
+    _stub_doctor(monkeypatch)
+
+    result = build_debug_bundle(tmp_path, task="task-secret")
+
+    assert result.output_path is not None
+    with zipfile.ZipFile(result.output_path) as zf:
+        trace_payloads = b"\n".join(zf.read(name) for name in zf.namelist() if name.startswith("traces/"))
+    assert canary.encode() not in trace_payloads
+    assert b"REDACTED" in trace_payloads
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/observability/test_ticket_bundle.py
+++ b/tests/unit/observability/test_ticket_bundle.py
@@ -9,6 +9,7 @@ import tarfile
 from pathlib import Path
 
 import pytest
+from bernstein.core.traces import TraceStep, TraceStore, new_trace
 
 from bernstein.core.lineage.identity import AgentCard, generate_keypair
 from bernstein.core.observability.ticket_bundle import (
@@ -122,6 +123,33 @@ def test_assemble_includes_filename_and_content_matches(workdir: Path) -> None:
     # Noise was excluded
     assert "transcripts/agent-backend-OTHER-1.jsonl" not in arcnames
     assert "audit/unrelated.jsonl" not in arcnames
+
+
+def test_persisted_trace_secret_cannot_reappear_in_ticket_bundle(tmp_path: Path) -> None:
+    canary = "gho_0123456789abcdefghijklmnopqrstuv"
+    store = TraceStore(tmp_path / ".sdd" / "traces")
+    trace = new_trace("sess-secret", ["ENG-42"], "backend", "sonnet", "high")
+    trace.steps.append(
+        TraceStep(type="verify", timestamp=1.0, detail=f"Authorization: Bearer {canary}")
+    )
+    store.write(trace)
+    out = tmp_path / "ENG-42.tar.gz"
+    bundle = TicketBundle(
+        workdir=tmp_path,
+        tracker="github",
+        ticket_id="ENG-42",
+        selector=_selector_without_git(tmp_path),
+    )
+
+    manifest = bundle.assemble(out=out)
+
+    assert any(entry.arcname == "traces/ENG-42.jsonl" for entry in manifest.files)
+    with tarfile.open(out, mode="r:*") as tf:
+        trace_payload = tf.extractfile("traces/ENG-42.jsonl")
+        assert trace_payload is not None
+        persisted = trace_payload.read()
+    assert canary.encode() not in persisted
+    assert b"[REDACTED]" in persisted
 
 
 def test_manifest_schema_and_metadata(workdir: Path) -> None:

--- a/tests/unit/observability/test_trace_store.py
+++ b/tests/unit/observability/test_trace_store.py
@@ -98,6 +98,31 @@ def test_put_returns_sha256_indexed_entry(tmp_path: Path) -> None:
     assert entry.codec in {"gzip", "zstd"}
 
 
+def test_put_redacts_before_content_addressing_and_verification(tmp_path: Path) -> None:
+    store = ContentAddressedTraceStore(tmp_path, prefer_zstd=False)
+    canary = "sk-proj-0123456789abcdefghijklmnop"
+    sha256 = "a3" * 32
+    raw = json.dumps(
+        {
+            "trace_id": "trace-secret",
+            "task_ids": ["T-secret"],
+            "detail": f"Authorization: Bearer {canary}",
+            "content_sha256": sha256,
+        }
+    ).encode()
+
+    entry = store.put(raw)
+    persisted = store.get("trace-secret")
+
+    assert persisted is not None
+    assert canary.encode() not in persisted
+    assert b"[REDACTED]" in persisted
+    assert sha256.encode() in persisted
+    assert entry.sha256 == hashlib.sha256(persisted).hexdigest()
+    assert entry.byte_size == len(persisted)
+    assert store.verify("trace-secret") is True
+
+
 def test_blob_uses_content_addressed_layout(tmp_path: Path) -> None:
     store = ContentAddressedTraceStore(tmp_path, prefer_zstd=False)
     raw = _agent_trace_json()

--- a/tests/unit/test_log_redact.py
+++ b/tests/unit/test_log_redact.py
@@ -17,6 +17,7 @@ from bernstein.core.log_redact import (
     PiiRedactingFilter,
     install_pii_filter,
     redact_pii,
+    redact_sensitive_text,
 )
 
 # ---------------------------------------------------------------------------
@@ -87,6 +88,49 @@ class TestCleanTextUnchanged:
 
     def test_empty(self) -> None:
         assert redact_pii("") == ""
+
+
+class TestCredentialRedaction:
+    def test_explicit_credential_shapes_are_redacted(self) -> None:
+        private_key = (
+            "-----BEGIN PRIVATE KEY-----\n"
+            "VGhpcyBpcyBhIHRlc3QgY2FuYXJ5LCBub3QgYSByZWFsIGtleQ==\n"
+            "-----END PRIVATE KEY-----"
+        )
+        canaries = [
+            "BearerTokenCanary0123456789",
+            "JsonBearerTokenCanary0123456789",
+            "ghp_0123456789abcdefghijklmnopqrstuv",
+            "sk-proj-0123456789abcdefghijklmnop",
+            "A1b2C3d4E5f6G7h8I9j0K1l2",
+            "A1b2!C3d4@E5f6#G7h8$",
+            private_key,
+        ]
+        text = "\n".join(
+            [
+                f"Authorization: Bearer {canaries[0]}",
+                f'{{"Authorization": "Bearer {canaries[1]}"}}',
+                canaries[2],
+                canaries[3],
+                f'api_token="{canaries[4]}"',
+                f'accessToken="{canaries[5]}"',
+                canaries[6],
+            ]
+        )
+
+        redacted = redact_sensitive_text(text)
+
+        for canary in canaries:
+            assert canary not in redacted
+        assert redacted.count("[REDACTED]") == len(canaries)
+
+    def test_entropy_without_sensitive_name_survives(self) -> None:
+        sha256 = "a3" * 32
+        uuid = "123e4567-e89b-12d3-a456-426614174000"
+        base64_payload = "VGhpcyBpcyBhIGxlZ2l0aW1hdGUgcGF5bG9hZA=="
+        text = f"sha256={sha256} request_id={uuid} payload={base64_payload}"
+
+        assert redact_sensitive_text(text) == text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_traces.py
+++ b/tests/unit/test_traces.py
@@ -157,6 +157,37 @@ class TestParseAgentLog:
 
 
 class TestTraceStore:
+    def test_write_redacts_credentials_in_persisted_bytes(self, tmp_path: Path) -> None:
+        traces_dir = tmp_path / "traces"
+        store = TraceStore(traces_dir)
+        trace = new_trace("sess-secret", ["task-secret"], "backend", "sonnet", "high")
+        canary = "gho_0123456789abcdefghijklmnopqrstuv"
+        private_key_body = "U2VjcmV0VHJhY2VDYW5hcnlWYWx1ZQ=="
+        sha256 = "a3" * 32
+        trace.steps.append(
+            TraceStep(
+                type="verify",
+                timestamp=1.0,
+                detail=(
+                    f"Authorization: Bearer {canary}\n"
+                    "-----BEGIN PRIVATE KEY-----\n"
+                    f"{private_key_body}\n"
+                    "-----END PRIVATE KEY-----\n"
+                    f"sha256={sha256}"
+                ),
+            )
+        )
+
+        store.write(trace)
+
+        direct_bytes = (traces_dir / f"trace-{trace.trace_id}.json").read_bytes()
+        task_bytes = (traces_dir / "task-secret.jsonl").read_bytes()
+        for persisted in (direct_bytes, task_bytes):
+            assert canary.encode() not in persisted
+            assert private_key_body.encode() not in persisted
+            assert persisted.count(b"[REDACTED]") == 2
+            assert sha256.encode() in persisted
+
     def test_write_and_read_by_trace_id(self, tmp_path: Path) -> None:
         store = TraceStore(tmp_path / "traces")
         trace = new_trace("sess-1", ["task-abc"], "backend", "sonnet", "high")


### PR DESCRIPTION
Fixes #3700.

## What changed

- Extracted a text/bytes redaction API from the logging-only PII path and added credential shapes for authorization headers (including JSON-serialized headers), `sk-` / GitHub / AWS-prefixed keys, private-key blocks, and high-entropy values assigned to explicitly sensitive names.
- Applied that pass at both persistence writers found in the repository:
  - `TraceStore.write`, which writes the direct trace JSON and per-task JSONL;
  - `ContentAddressedTraceStore.put`, which writes compressed immutable blobs and the index.
- Kept entropy detection gated on a sensitive adjacent name. Standalone sha256 values, UUIDs, and base64 payloads remain byte-identical.
- Documented the storage contract and added export-level regressions for both the CLI debug bundle and ticket bundle.

## Threat model and writer finding

There are two persistence writers rather than one. Protecting only `TraceStore.write` would leave callers of the public content-addressed `put(bytes)` API able to archive a credential directly. Both boundaries therefore redact independently; applying the pass twice is idempotent.

The patch is deliberately a credential-shape filter over free text. It does not attempt the larger typed-event/digest/replay-handle architecture described as future work in the issue.

## Hash order

Redaction happens before content addressing. `ContentAddressedTraceStore.put` computes sha256 and metadata from the redacted bytes, writes those exact bytes, and `verify()` re-hashes those same bytes. Hashing first would create a receipt that the safely stored blob could not satisfy.

## Validation

- `uv run pytest tests/unit/test_log_redact.py tests/unit/test_traces.py tests/unit/observability/test_trace_store.py tests/unit/cli/test_debug_bundle.py tests/unit/observability/test_ticket_bundle.py -q` — 128 passed
- `uv run ruff check .` — passed
- `uv run mypy src/bernstein/core/observability/log_redact.py src/bernstein/core/observability/traces.py src/bernstein/core/observability/trace_store.py` — passed
- `uv run lint-imports` — 3 contracts kept, 0 broken
- `uv run python scripts/run_tests.py -x` — 31 isolated files passed, then an unrelated environment guard stopped the next file because the runner had 0.4 GB free and requires at least 1.0 GB; no test assertion failed before that guard

The persisted-byte tests cover authorization headers, prefixed keys, named high-entropy values, and private-key blocks. Negative controls pin sha256, UUID, and base64 survival. The content-addressed regression also proves the redacted blob's digest and `verify()` result agree.
