### PR TITLE
chore(auto): nightly mirror + format drift sweep

### DIFF
--- a/tests/unit/cli/test_debug_bundle.py
+++ b/tests/unit/cli/test_debug_bundle.py
@@ -147,9 +147,7 @@ def test_persisted_trace_secret_cannot_reappear_in_debug_bundle(
     canary = "ghp_0123456789abcdefghijklmnopqrstuv"
     store = TraceStore(tmp_path / ".sdd" / "traces")
     trace = new_trace("run-secret", ["task-secret"], "backend", "sonnet", "high")
-    trace.steps.append(
-        TraceStep(type="verify", timestamp=1.0, detail=f"Authorization: Bearer {canary}")
-    )
+    trace.steps.append(TraceStep(type="verify", timestamp=1.0, detail=f"Authorization: Bearer {canary}"))
     store.write(trace)
     (tmp_path / ".sdd" / "runtime").mkdir(parents=True)
     (tmp_path / ".sdd" / "runtime" / "run_id").write_text("task-secret\n", encoding="utf-8")

--- a/tests/unit/observability/test_ticket_bundle.py
+++ b/tests/unit/observability/test_ticket_bundle.py
@@ -129,9 +129,7 @@ def test_persisted_trace_secret_cannot_reappear_in_ticket_bundle(tmp_path: Path)
     canary = "gho_0123456789abcdefghijklmnopqrstuv"
     store = TraceStore(tmp_path / ".sdd" / "traces")
     trace = new_trace("sess-secret", ["ENG-42"], "backend", "sonnet", "high")
-    trace.steps.append(
-        TraceStep(type="verify", timestamp=1.0, detail=f"Authorization: Bearer {canary}")
-    )
+    trace.steps.append(TraceStep(type="verify", timestamp=1.0, detail=f"Authorization: Bearer {canary}"))
     store.write(trace)
     out = tmp_path / "ENG-42.tar.gz"
     bundle = TicketBundle(


### PR DESCRIPTION
# User description
Nightly sweep regenerated AGENTS.md mirrors and ran ruff format on main. Diff is mechanical and may be merged after CI passes.

Source run: https://github.com/sipyourdrink-ltd/bernstein/actions/runs/31781204125

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Confirm that the nightly mirror and <code>ruff format</code> sweep produces no substantive changes in the debug-bundle and ticket-bundle test coverage.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>github-actions[bot]</td><td>chore(auto): nightly m...</td><td>August 14, 2026</td></tr>
<tr><td>Nickgonzales76017</td><td>fix(observability): re...</td><td>August 14, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3736?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>