### PR TITLE
Fix task identity derivation to prevent evidence misattribution

### DIFF
--- a/src/evaluation/task_matcher.py
+++ b/src/evaluation/task_matcher.py
@@ -1,0 +1,3 @@
+def resolve_task_identity(session: dict) -> str:
+    """Resolve task identity from stable metadata instead of prompt text."""
+    return session.get("task_id") or session.get("lineage_id")


### PR DESCRIPTION
Closes #3629

Previously, task identity was parsed from prompt text, causing evidence to be attributed to the wrong task and inflating completion counts. This change uses the stable `task_id`/`lineage_id` from session metadata to ensure accurate evaluation.