### PR TITLE
docs: complete the contributor register and link it from the docs

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,36 +8,84 @@ We are grateful to everyone who has contributed to Bernstein.
 
 ## Contributors
 
+Everyone below has had at least one pull request merged, most recent first.
+
 | Who | Contribution |
 |-----|-------------|
-| **Coding Dragon** ([@TheCodingDragon0](https://github.com/TheCodingDragon0)) | Feature comparison docs, config diff command, command aliases |
-| **TTClaw** ([@lui62233](https://github.com/lui62233)) | Test data generators for realistic task payloads ([#715](https://github.com/sipyourdrink-ltd/bernstein/pull/715)) |
-| [@Beledarian](https://github.com/Beledarian) | Config path validation ([#583](https://github.com/sipyourdrink-ltd/bernstein/pull/583)) |
-| [@forfreedomforrich-eng](https://github.com/forfreedomforrich-eng) | Fix hardcoded URL in triggers_cmd ([#568](https://github.com/sipyourdrink-ltd/bernstein/pull/568)), dry-run flag for compose ([#274](https://github.com/sipyourdrink-ltd/bernstein/pull/274)) |
-| [@internet-dot](https://github.com/internet-dot) | CI skill-publish validation workflow ([#581](https://github.com/sipyourdrink-ltd/bernstein/pull/581)) |
-| **Pedro Gabriel** ([@pplanel](https://github.com/pplanel)) | Test data generators ([#715](https://github.com/sipyourdrink-ltd/bernstein/pull/715)) |
+| [@Nickgonzales76017](https://github.com/Nickgonzales76017) | Credential redaction before trace persistence, and content-addressed lineage finding records |
+| [@Louis20060723](https://github.com/Louis20060723) | CLI command surface, strict journal verifier loading, and documentation drift gates |
+| [@moto-taka](https://github.com/moto-taka) | Model selection and workflow routing options |
+| [@Krishal743](https://github.com/Krishal743) | Audit-chain records for stall verdicts before automatic worker kills |
+| **Aditya Pathak** ([@Phoenix1504e](https://github.com/Phoenix1504e)) | TUI input fix, typing stubs for generated gRPC modules, and adapter test isolation |
+| **Khoa Nguyen** ([@Purin1410](https://github.com/Purin1410)) | MCP tool host-effect disclosure and authenticated trace projection evidence |
+| **Krzysztof Skomra** ([@KrzysiekSko](https://github.com/KrzysiekSko)) | OpenCode adapter reference refresh and exact canary version comparison |
+| [@mercael91](https://github.com/mercael91) | Plan validation, failed-task dependency blocking, and plan digests in the run journal |
+| **Silent Partner** ([@Silentpartnercoding](https://github.com/Silentpartnercoding)) | Tool-call attestation, signed agent identity binding, and authenticated run closure |
+| [@bymyforge](https://github.com/bymyforge) | Type annotations for the TUI package, CLI command cleanup, and the skill-injection audit trail |
+| **abhinav** ([@erensh27](https://github.com/erensh27)) | SSE record terminator length derivation in the web layer |
+| [@atirna](https://github.com/atirna) | Event-stream authentication and theme resolution before first paint |
+| [@pollychen-lab](https://github.com/pollychen-lab) | Plan file-entry validation and a scoped install hint for the Qwen adapter |
+| **Abhiram V** ([@abhiramvsmg](https://github.com/abhiramvsmg)) | Agents and adapters drift fixes in the getting-started pages |
+| [@floze-the-genius](https://github.com/floze-the-genius) | Restored the issue-to-pr trace command |
+| **Maqbool Ahmed** ([@Maqbool61](https://github.com/Maqbool61)) | Self-hosted OpenAI-compatible endpoint certification, the bernstein-bench harness, and replayable trajectory receipts |
+| [@RawNuke](https://github.com/RawNuke) | Receipt-backed steering from the task drawer |
+| **Eric Gang** ([@ecgang](https://github.com/ecgang)) | microVM sandbox backend with content-addressed snapshots, and CAS blob read hardening |
+| **Mohammed Sufiyan Ahmed** ([@Sufiyan-MSA](https://github.com/Sufiyan-MSA)) | Shipping adapter contracts and golden transcripts in the wheel |
+| **Amir Fathi** ([@AmirF194](https://github.com/AmirF194)) | Heartbeat signal capping, cluster node registration, and parked-session state handling |
+| [@essentialols](https://github.com/essentialols) | Made `evolution_enabled` disable the evolution loop |
+| [@PyaaZz](https://github.com/PyaaZz) | Type annotations for the core routes package |
+| **Tymofii Pidlisnyi** ([@aeoess](https://github.com/aeoess)) | Delegation-chain grading and anchored canonical test vectors |
+| [@MochiGem](https://github.com/MochiGem) | Type-statement conversion for config string constants |
+| **Iqbal Ezedin** ([@Iqbalez](https://github.com/Iqbalez)) | Skipping malformed provider latency records |
+| [@qwenbona](https://github.com/qwenbona) | Separated heartbeat status from task phase |
+| [@octo-patch](https://github.com/octo-patch) | Refreshed the MiniMax price table and added cache tiers |
+| [@sescer](https://github.com/sescer) | Type annotations for the core observability package |
+| [@casbrbr-beep](https://github.com/casbrbr-beep) | A failed required quality gate now skips merge |
+| **Marcos Max** ([@mmaxjr](https://github.com/mmaxjr)) | `bernstein doctor` reports missing uv as a failed check instead of crashing |
+| [@w3lld1](https://github.com/w3lld1) | Adapter cast aliases defined as types |
+| [@0xddneto](https://github.com/0xddneto) | Test coverage for unverifiable foreign attestation |
+| **Chase Naples** ([@cnaples79](https://github.com/cnaples79)) | MCP server reports the Bernstein package version |
+| **Aditya** ([@adity982](https://github.com/adity982)) | Discoverable skill index for the MCP server |
+| **Sanjay Santhanam** ([@Sanjays2402](https://github.com/Sanjays2402)) | Adapter flag and model plumbing, and a loud failure when no trend-scan fetcher is configured |
+| [@AshSgDe29071999](https://github.com/AshSgDe29071999) | Removed a duplicate `--fresh` option on run |
+| **Anay Garodia** ([@AnayGarodia](https://github.com/AnayGarodia)) | Effective server port persistence and centralized artifact constants |
+| **Sai Raj Kasam** ([@sairajkasam](https://github.com/sairajkasam)) | Live OTLP bridge for streaming journal span projection |
+| **Om Rohilla** ([@Om-Rohilla](https://github.com/Om-Rohilla)) | Web UI screenshots, GUI overview docs, and component benchmark results |
+| **Aman** ([@RexxLudwig](https://github.com/RexxLudwig)) | MCP Tasks extension and trace context propagation |
+| **Shane Mattner** ([@shanemmattner](https://github.com/shanemmattner)) | Per-agent run instrumentation, max_turns handling, model plumbing, and spawner hold/release |
+| **Anas Khan** ([@anxkhn](https://github.com/anxkhn)) | Copilot CLI adapter modernized to non-interactive print mode |
+| **Puneet Dixit** ([@puneetdixit200](https://github.com/puneetdixit200)) | Atomic shared backlog claim |
+| [@kite-builds](https://github.com/kite-builds) | The `bernstein analyze` scan and a JWS/JCS Ed25519 signer for agent identity cards |
+| [@gittihub-jpg](https://github.com/gittihub-jpg) | `bernstein export` for shareable HTML run summaries |
+| [@zerone0x](https://github.com/zerone0x) | Run savings summary, enterprise evaluation guide, and use-case workflows page |
+| **Brendan Boyd** ([@0xbboyd](https://github.com/0xbboyd)) | Added opencode and aider to the valid CLI list |
+| **Vedangi Thokal** ([@vedangit](https://github.com/vedangit)) | One-line install script with OS detection |
+| **Sebastian Herrera** ([@sebastian-herrera](https://github.com/sebastian-herrera)) | Project metrics documentation |
+| [@Ai-chan-0411](https://github.com/Ai-chan-0411) | Monthly community spotlight blog post template |
+| **Alex Smith** ([@alexanderxfgl-bit](https://github.com/alexanderxfgl-bit)) | Vulnerability disclosure program, agent credential scope minimization, curated example gallery, and incremental streaming merge |
+| **formatme** ([@oldschoola](https://github.com/oldschoola)) | Port-based task server PID fallback, task filtering with full issue body sync, and title dedup fixes |
+| **TTClaw** ([@lui62233](https://github.com/lui62233)) | Test data generators for realistic task payloads |
+| [@Beledarian](https://github.com/Beledarian) | Config path validation |
+| **Coding Dragon** ([@TheCodingDragon0](https://github.com/TheCodingDragon0)) | Feature comparison table, config diff command, and a glossary of project terms |
+| [@forfreedomforrich-eng](https://github.com/forfreedomforrich-eng) | Hardcoded URL fix in triggers, and a `--dry-run` flag for compose |
+
+## Issue reports, review, and earlier work
+
+| Who | Contribution |
+|-----|-------------|
+| [@internet-dot](https://github.com/internet-dot) | CI skill-publish validation workflow |
+| **Pedro Gabriel** ([@pplanel](https://github.com/pplanel)) | Test data generators |
 | **Vaibhav Singh** ([@vbhavh](https://github.com/vbhavh)) | Adapter contributions (Goose, Cody) |
+| [@chrstphe](https://github.com/chrstphe) | MCP Toplist rank badge |
 | **Luka Stanisljevic** ([@Whatsonyourmind](https://github.com/Whatsonyourmind)) | Issue feedback and testing |
-| **formatme** ([@oldschoola](https://github.com/oldschoola)) | Port-based PID fallback, Windows-safe rmtree, task filter ([#737](https://github.com/sipyourdrink-ltd/bernstein/pull/737)), full GitHub issue body sync, parameter fix ([#738](https://github.com/sipyourdrink-ltd/bernstein/pull/738)), title dedup fix ([#739](https://github.com/sipyourdrink-ltd/bernstein/pull/739)) |
-| **Alex Smith** ([@alexanderxfgl-bit](https://github.com/alexanderxfgl-bit)) | Vulnerability disclosure program ([#740](https://github.com/sipyourdrink-ltd/bernstein/pull/740)), credential scope minimization ([#741](https://github.com/sipyourdrink-ltd/bernstein/pull/741)), example gallery ([#742](https://github.com/sipyourdrink-ltd/bernstein/pull/742)), streaming merge ([#743](https://github.com/sipyourdrink-ltd/bernstein/pull/743)), community spotlight generator ([#783](https://github.com/sipyourdrink-ltd/bernstein/pull/783)) |
-| [@Ai-chan-0411](https://github.com/Ai-chan-0411) | Community Spotlight template ([#782](https://github.com/sipyourdrink-ltd/bernstein/pull/782)) |
-| [@zerone0x](https://github.com/zerone0x) | Use-case workflows guide ([#1048](https://github.com/sipyourdrink-ltd/bernstein/pull/1048)) |
 | **Alokik Singh** ([@alokiksingh676](https://github.com/alokiksingh676)) | Issue feedback |
 | **Ilia** ([@Ilia01](https://github.com/Ilia01)) | Issue feedback |
 | **OyaAI** ([@OyaAIProd](https://github.com/OyaAIProd)) | Security assessment review |
 | **J. Marques** ([@jagmarques](https://github.com/jagmarques)) | Issue feedback |
-| [@0xddneto](https://github.com/0xddneto) | Specify unverifiable foreign attestation ([#3192](https://github.com/sipyourdrink-ltd/bernstein/pull/3192)) |
-| [@adity982](https://github.com/adity982) | Add discoverable skill index ([#3177](https://github.com/sipyourdrink-ltd/bernstein/pull/3177)) |
-| [@aeoess](https://github.com/aeoess) | Supersede seed canonical vectors with anchored set; add nfc-rejection, nano-string and supplementary-plane classes ([#2994](https://github.com/sipyourdrink-ltd/bernstein/pull/2994)) |
-| [@AmirF194](https://github.com/AmirF194) | Cap the log-only heartbeat signal instead of riding it to the hard cap ([#3193](https://github.com/sipyourdrink-ltd/bernstein/pull/3193)) |
-| [@AnayGarodia](https://github.com/AnayGarodia) | Persist effective server port for runtime probes ([#2819](https://github.com/sipyourdrink-ltd/bernstein/pull/2819)); Centralize artifact constants and type wire payloads ([#2838](https://github.com/sipyourdrink-ltd/bernstein/pull/2838)) |
-| [@AshSgDe29071999](https://github.com/AshSgDe29071999) | Remove duplicate --fresh option on run ([#3030](https://github.com/sipyourdrink-ltd/bernstein/pull/3030)) |
-| [@bymyforge](https://github.com/bymyforge) | Annotate the tui package (mypy: 41 -> 15 errors) ([#3236](https://github.com/sipyourdrink-ltd/bernstein/pull/3236)) |
-| [@chrstphe](https://github.com/chrstphe) | Add MCP Toplist rank badge ([#3019](https://github.com/sipyourdrink-ltd/bernstein/pull/3019)) |
-| [@cnaples79](https://github.com/cnaples79) | Report Bernstein package version ([#3153](https://github.com/sipyourdrink-ltd/bernstein/pull/3153)) |
-| [@Maqbool61](https://github.com/Maqbool61) | Document and certify self-hosted OpenAI-compatible endpoint path ([#2913](https://github.com/sipyourdrink-ltd/bernstein/pull/2913)); Ship bernstein-bench — runnable, reproducibility-gated evaluation harness ([#3099](https://github.com/sipyourdrink-ltd/bernstein/pull/3099)), plus 1 more |
-| [@pollychen-lab](https://github.com/pollychen-lab) | Use scoped install hint ([#3011](https://github.com/sipyourdrink-ltd/bernstein/pull/3011)) |
-| [@Sanjays2402](https://github.com/Sanjays2402) | Stop passing removed web search flag ([#2766](https://github.com/sipyourdrink-ltd/bernstein/pull/2766)); Pass model to agy ([#2813](https://github.com/sipyourdrink-ltd/bernstein/pull/2813)), plus 1 more |
+
+Security reporters are credited on the published advisory and in the release
+notes carrying the fix, as described in the
+[bug bounty page](https://bernstein.readthedocs.io/en/latest/security/bug-bounty/).
 
 ## Community
 

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -59,3 +59,6 @@ organized, and the contracts new adapters and hooks must satisfy.
     [Trend scan automation](../devops/trend-scan-automation.md)
 
 </div>
+
+Everyone whose work has been merged is listed in
+[CONTRIBUTORS.md](https://github.com/sipyourdrink-ltd/bernstein/blob/main/CONTRIBUTORS.md).


### PR DESCRIPTION
# User description
## What

Fixes the flag tables in `docs/reference/cli-reference.md` for every command whose documented invocation the parser rejects, and widens the existing per-command flag assertion in `tests/unit/test_cli_command_registration.py` from two hand-picked commands to every command the reference documents.

Fixes #3465.

## Why

A documented flag the parser rejects exits `2` with `No such option` before the command body runs, which reads to a user exactly like the command being missing. Measured against the live `cli` object, 18 commands carried 55 documented flags that do not exist, `bernstein voice` was documented but never registered (the command is `listen`), and four sections (`verify`, `trace`, `evolve`, `eval`/`benchmark`) described a pre-group single-command shape whose flags now live on subcommands.

The counts differ from the issue's table because the issue's probe split sections on command headings only, so tables under combined headings (`bernstein eval` / `bernstein benchmark`) were attributed to the preceding section (e.g. the "chaos" row was really the eval/benchmark table). The issue anticipated this: the list was regenerated from the probe rather than trusted.

## How

**Docs** — every flag table now matches its command's real params:

- Renames to the real spelling: `plan generate --out` → `--output`, `man-pages --out` → `--output-dir`, `mcp --server` → `--server-url`, `worker --labels/--max-agents` → `--label`/`--slots`, `retro -o, --output` reordered to long-form-first.
- Removed flags that do not exist and have no successor: `explain --format`, `slo --reset`, `status --workdir`, `man-pages --section`.
- `run --approval`/`--merge`: removed; the approval gate is `--auto-approve`, the merge strategy is `merge_strategy: pr|direct` in `bernstein.yaml` — the section now says so.
- Full table rewrites from the real params: `init`, `watch`, `test-adapter`, `worker`, `pr`, `listen`.
- Group restructures (flags moved to subcommand tables): `verify`, `trace`, `evolve`; `eval`/`benchmark` split into two sections so the `eval`-only reliability options are no longer attributed to `benchmark`.
- Completed tables that lagged the surface: `stop`, `plan generate`, `status`, `slo`, `doctor`, `cost profile-report`, `mcp`.
- `bernstein voice` dropped; the registered command is `bernstein listen`.
- `dep-impact --package` (called out in the issue): already resolved on main — the table documents the real `--base/--workdir/--strict/--json` surface of the `impact deps` alias, and `--package` never existed on it. Decided side: the docs were wrong, the code is right.

**Gate** — the existing per-command assertion mechanism now covers all documented commands:

- Bidirectional: a doc row for a flag that does not exist fails (`test_documented_flags_exist`), and a real flag without a doc row fails (`test_real_flags_are_documented`). Stated limit: only flag-table rows are asserted; flags in prose, fenced code blocks, and subcommand-purpose tables are out of the gate's reach.
- The section parser splits on any heading and skips fenced code blocks, so combined headings no longer leak their tables into the previous section, and previously invisible headings (`bernstein init` / `bernstein init --wizard`, `bernstein debug-bundle` (deprecated)) are now inside the registration sweep — which is how the unregistered `voice` surfaced.
- `GHOST_FLAG_EXEMPTIONS` ships empty. `PARTIAL_FLAG_TABLES` names the one deliberately abbreviated table (`run`, ~44 flags, table documents the most-used subset) with its reason. A hygiene test fails if either set names a command that no longer exists or no longer has a flag table, so entries cannot rot and growth is visible in review.
- The test file also runs as a step in the Repo hygiene job, so a docs-only change cannot land drift past an affected-tests PR lane.

## Verification

Before (widened gate against the unfixed reference) — both directions fail, plus the registration sweep:

```
FAILED test_documented_commands_are_registered            # voice
FAILED test_documented_flags_exist[run|init|plan generate|status|watch|trace|slo|verify|eval|benchmark|test-adapter|worker|evolve|man-pages|mcp|pr|voice|listen|explain]
FAILED test_real_flags_are_documented[stop|init|plan generate|status|retro|watch|slo|test-adapter|worker|cost profile-report|doctor|man-pages|mcp|pr|voice|listen]
36 failed, 279 passed, 1 skipped
```

Example failures, one per direction:

```
AssertionError: `bernstein explain` documents flags it does not accept: ['--format']
AssertionError: `bernstein listen` accepts flags its reference table does not list: ['--alias-file', '--dry-run', '--min-duration', '--model', '--threshold']
```

After the docs fix:

```
tests/unit/test_cli_command_registration.py  305 passed, 1 skipped
```

(the skip is `run` in `PARTIAL_FLAG_TABLES`, with its reason printed.)

Companion guards that parse the same markdown stay green: `tests/unit/test_readme_api_coverage.py`, `tests/unit/test_regen_contract_drift.py`, `tests/unit/test_fold_benchmark_subcommands.py`, `tests/unit/test_docs_capability_reachability.py` — 347 passed, 1 skipped across the set. `ruff check` and `ruff format --check` clean on the touched Python file.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update <code>CONTRIBUTORS.md</code> with a complete register of merged contributors and separate issue-reporting and review credits. Link the register from the contributing documentation so contributors can find it easily.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3744?tool=ast&topic=Docs+navigation>Docs navigation</a>
        </td><td>Link the contributor register from the contributing documentation.<details><summary>Modified files (1)</summary><ul><li>docs/contributing/index.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>docs: complete the con...</td><td>August 14, 2026</td></tr>
<tr><td>chernistry</td><td>docs: navigation restr...</td><td>July 17, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/sipyourdrink-ltd/bernstein/3744?tool=ast&topic=Contributor+register>Contributor register</a>
        </td><td>Expand the contributor register and organize merged-contribution credits, issue reports, reviews, and security-reporting attribution.<details><summary>Modified files (1)</summary><ul><li>CONTRIBUTORS.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>alex@alexchernysh.com</td><td>docs: complete the con...</td><td>August 14, 2026</td></tr>
<tr><td>chernistry</td><td>chore: scope workflow ...</td><td>July 29, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/sipyourdrink-ltd/bernstein/3744?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>